### PR TITLE
feat(showcase): run HTTP-only probe families in-process on the fleet control-plane

### DIFF
--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -3469,8 +3469,7 @@ describe("orchestrator runControlPlane in-process HTTP probes", () => {
       expect(ids).not.toContain("probe:e2e_smoke");
 
       // Crons are driven FROM the YAML `schedule`, never hardcoded.
-      const cronFor = (id: string) =>
-        registered.find((r) => r.id === id)?.cron;
+      const cronFor = (id: string) => registered.find((r) => r.id === id)?.cron;
       expect(cronFor("probe:smoke")).toBe("*/5 * * * *");
       expect(cronFor("probe:image_drift")).toBe("*/15 * * * *");
       expect(cronFor("probe:qa")).toBe("0 * * * *");
@@ -3813,7 +3812,9 @@ describe("orchestrator runControlPlane in-process HTTP probes", () => {
 
     // Drive the probe loader's watch callback manually so the reload path is
     // deterministic (no chokidar timing). `unwatch` records teardown.
-    let watchCb: ((next: import("./probes/loader/schema.js").ProbeConfig[]) => void) | undefined;
+    let watchCb:
+      | ((next: import("./probes/loader/schema.js").ProbeConfig[]) => void)
+      | undefined;
     let unwatched = false;
     const smokeCfg = {
       kind: "smoke",

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -3284,25 +3284,29 @@ describe("orchestrator runControlPlane REQ-B worker-self-report wiring (aggregat
 /**
  * In-process HTTP-only probe families on the fleet control-plane.
  *
- * The control-plane today only runs the d6 producer; the 8 HTTP-only probe
- * families (smoke, starter_smoke, image_drift, qa, aimock_wiring,
- * version_drift, pin_drift, redirect_decommission) are dark on the fleet.
- * These tests pin the desired end-state:
+ * The control-plane runs the 8 HTTP-only probe families (smoke, starter_smoke,
+ * image_drift, qa, aimock_wiring, version_drift, pin_drift,
+ * redirect_decommission) IN-PROCESS, alongside the d6 producer. These tests
+ * pin that behavior:
  *
  *   1. `runControlPlane` loads `config/probes/*.yml`, partitions by
  *      `BROWSER_KINDS`, and registers ONLY the HTTP-kind families on its own
- *      scheduler under `probe:<id>` entries. Browser kinds (e2e_*) are NOT
- *      scheduled in-process — they route through the worker producer path.
- *   2. /health's `rules` count reflects the in-process HTTP probe count (so
- *      the control-plane role-drop on the rules>0 gate doesn't mask a real
- *      loader failure), and `schedulerJobs` includes the probe entries.
+ *      scheduler under `probe:<id>` entries, with crons taken FROM the YAML
+ *      `schedule`. Browser kinds (e2e_*) are NOT scheduled in-process — they
+ *      route through the worker producer path.
+ *   2. /health's `rules` count reflects the REAL in-process HTTP probe count
+ *      so a zero-probe load is OBSERVABLE in the /health JSON body. The role
+ *      still DROPS the `rules>0` gate, so `status` stays ok regardless (the
+ *      count is for dashboards/alerting visibility, not container liveness);
+ *      `schedulerJobs` includes the probe entries.
  *
  * The probe config dir is the sibling `../probes` of `opts.configDir` (same
  * resolution boot() uses), so the test writes a temp alerts dir + sibling
- * probes dir containing one HTTP family (smoke), one more HTTP family
- * (image_drift), and one BROWSER family (e2e_smoke) to prove the partition.
+ * probes dir containing HTTP families (smoke, image_drift, qa — the last a
+ * discovery-backed family) plus one BROWSER family (e2e_smoke) to prove the
+ * partition.
  */
-describe("orchestrator runControlPlane in-process HTTP probes (Phase-1 3c)", () => {
+describe("orchestrator runControlPlane in-process HTTP probes", () => {
   let port = 0;
   let probesDir = "";
   let alertsDir = "";
@@ -3343,6 +3347,23 @@ describe("orchestrator runControlPlane in-process HTTP probes (Phase-1 3c)", () 
       ].join("\n"),
       "utf-8",
     );
+    // A discovery-backed family (qa → railway-services discovery) so the test
+    // exercises the discovery-registry wiring, not just the single-target
+    // smoke path. The discovery source resolves against the mocked PB/railway
+    // env; we only assert it SCHEDULES, not that it ticks.
+    await fs.writeFile(
+      path.join(probesDir, "qa.yml"),
+      [
+        "kind: qa",
+        "id: qa",
+        'schedule: "0 * * * *"',
+        "discovery:",
+        "  source: railway-services",
+        '  key_template: "qa:${name}"',
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
     await fs.writeFile(
       path.join(probesDir, "e2e-smoke.yml"),
       [
@@ -3361,9 +3382,20 @@ describe("orchestrator runControlPlane in-process HTTP probes (Phase-1 3c)", () 
   afterEach(() => {
     vi.resetModules();
     vi.restoreAllMocks();
+    // doMock factories persist across the file (resetModules clears the module
+    // CACHE, not the mock REGISTRY). Explicitly unmock every module these tests
+    // doMock so a stale factory (e.g. a probe-loader that always throws, or an
+    // event-bus that pre-hooks a subscriber) never bleeds into a sibling test
+    // that doesn't re-mock it.
+    vi.doUnmock("@hono/node-server");
+    vi.doUnmock("./storage/pb-client.js");
+    vi.doUnmock("./scheduler/scheduler.js");
+    vi.doUnmock("./probes/run-history.js");
+    vi.doUnmock("./probes/loader/probe-loader.js");
+    vi.doUnmock("./events/event-bus.js");
   });
 
-  it("schedules the HTTP families (smoke, image_drift) in-process but NOT the browser kind", async () => {
+  it("schedules the HTTP families (smoke, image_drift, qa) in-process with their YAML crons but NOT the browser kind", async () => {
     vi.resetModules();
 
     // Pin the REAL serve() so this role binds cleanly (immunize against a
@@ -3392,9 +3424,11 @@ describe("orchestrator runControlPlane in-process HTTP probes (Phase-1 3c)", () 
       };
     });
 
-    // Capture every scheduler.register id so we can assert which probe
-    // families landed as in-process scheduler entries.
-    const registeredIds: string[] = [];
+    // Capture every scheduler.register id AND cron so we can assert which
+    // probe families landed as in-process scheduler entries AND that their
+    // crons come FROM the YAML `schedule` (a hardcoded-cron regression must
+    // fail this).
+    const registered: { id: string; cron?: string }[] = [];
     vi.doMock("./scheduler/scheduler.js", async () => {
       const actual = await vi.importActual<
         typeof import("./scheduler/scheduler.js")
@@ -3407,8 +3441,8 @@ describe("orchestrator runControlPlane in-process HTTP probes (Phase-1 3c)", () 
           const real = actual.createScheduler(deps);
           return {
             ...real,
-            register: (entry: { id: string }) => {
-              registeredIds.push(entry.id);
+            register: (entry: { id: string; cron?: string }) => {
+              registered.push({ id: entry.id, cron: entry.cron });
               return (real.register as (...a: unknown[]) => unknown)(entry);
             },
           };
@@ -3424,11 +3458,22 @@ describe("orchestrator runControlPlane in-process HTTP probes (Phase-1 3c)", () 
     );
 
     try {
+      const ids = registered.map((r) => r.id);
       // HTTP families register as in-process probe entries.
-      expect(registeredIds).toContain("probe:smoke");
-      expect(registeredIds).toContain("probe:image_drift");
+      expect(ids).toContain("probe:smoke");
+      expect(ids).toContain("probe:image_drift");
+      // Discovery-backed family (qa → railway-services) also schedules,
+      // exercising the discovery-registry wiring, not just single-target.
+      expect(ids).toContain("probe:qa");
       // Browser kind is NOT scheduled in-process — it routes to the producer.
-      expect(registeredIds).not.toContain("probe:e2e_smoke");
+      expect(ids).not.toContain("probe:e2e_smoke");
+
+      // Crons are driven FROM the YAML `schedule`, never hardcoded.
+      const cronFor = (id: string) =>
+        registered.find((r) => r.id === id)?.cron;
+      expect(cronFor("probe:smoke")).toBe("*/5 * * * *");
+      expect(cronFor("probe:image_drift")).toBe("*/15 * * * *");
+      expect(cronFor("probe:qa")).toBe("0 * * * *");
     } finally {
       await handle.stop();
     }
@@ -3474,11 +3519,18 @@ describe("orchestrator runControlPlane in-process HTTP probes (Phase-1 3c)", () 
         rules: number;
         schedulerJobs: number;
       };
-      // Two HTTP families loaded → rules must be >= 2 (the control-plane now
-      // has in-process rules; the role-drop no longer masks a loader failure).
-      expect(body.rules).toBeGreaterThanOrEqual(2);
-      // schedulerJobs includes the producer + the in-process probe entries.
-      expect(body.schedulerJobs).toBeGreaterThanOrEqual(3);
+      // Three HTTP families loaded (smoke, image_drift, qa) → `rules` reports
+      // the REAL in-process probe count. EXACT (not >=) so a browser kind
+      // leaking into the in-process scheduler is caught. `ruleCount` reporting
+      // the real count means a zero-probe load is OBSERVABLE in /health rather
+      // than hidden behind the hardcoded-0 — but note the role still DROPS the
+      // `rules>0` gate, so `status` does NOT flip to degraded on a zero load
+      // (visibility is for dashboards/alerting, not container liveness).
+      expect(body.rules).toBe(3);
+      // schedulerJobs = the producer entry + the 3 in-process probe entries.
+      expect(body.schedulerJobs).toBe(4);
+      // The role-drop keeps status ok regardless of the rule count.
+      expect(body.status).toBe("ok");
     } finally {
       await handle.stop();
     }
@@ -3489,6 +3541,398 @@ describe("orchestrator runControlPlane in-process HTTP probes (Phase-1 3c)", () 
     expect([...orchMod.BROWSER_KINDS].sort()).toEqual(
       ["e2e_d6", "e2e_deep", "e2e_demos", "e2e_smoke"].sort(),
     );
+  });
+
+  // A1: the control-plane must sweep orphaned `running` probe_runs rows at
+  // boot, mirroring boot()'s `sweepStaleRuns(pb)` — boot() never runs in fleet
+  // mode, so without this the control-plane (which now writes probe_runs via
+  // the in-process HTTP probes) leaks orphaned `running` rows forever after a
+  // crash.
+  it("sweeps stale probe_runs at control-plane boot (and a sweep failure does not abort boot)", async () => {
+    vi.resetModules();
+
+    vi.doMock("@hono/node-server", async () => {
+      const actual =
+        await vi.importActual<typeof import("@hono/node-server")>(
+          "@hono/node-server",
+        );
+      return { ...actual };
+    });
+
+    vi.doMock("./storage/pb-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./storage/pb-client.js")
+      >("./storage/pb-client.js");
+      return {
+        ...actual,
+        createPbClient: () => ({
+          health: async () => true,
+          getOne: async () => null,
+          getFirst: async () => null,
+          getList: async () => ({ items: [] }),
+        }),
+      };
+    });
+
+    // sweepStaleRuns: first throws (a sweep failure must NOT abort boot),
+    // and we record that it was invoked at all.
+    const sweepCalls: number[] = [];
+    vi.doMock("./probes/run-history.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./probes/run-history.js")
+      >("./probes/run-history.js");
+      return {
+        ...actual,
+        sweepStaleRuns: async () => {
+          sweepCalls.push(Date.now());
+          throw new Error("simulated sweep failure");
+        },
+      };
+    });
+
+    const orchMod = await import("./orchestrator.js");
+
+    // A sweep that throws must not reject runControlPlane — boot continues.
+    const handle = await orchMod.runControlPlane(
+      { role: "control-plane", poolCount: 1 },
+      { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+    );
+
+    try {
+      expect(sweepCalls.length).toBe(1);
+      // Boot still completed despite the sweep failure: /health is reachable.
+      const res = await fetch(`http://127.0.0.1:${port}/health`);
+      expect(res.status).toBeGreaterThanOrEqual(200);
+      expect(res.status).toBeLessThan(600);
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  // A2: a probe-loader failure at INITIAL load must NOT take down the
+  // control-plane. The producer stays alive (status ok), `rules` reads 0
+  // (observable), and `probes.reload.failed` is emitted.
+  it("control-plane still boots (status ok, rules 0) and emits probes.reload.failed when the probe loader throws at initial load", async () => {
+    vi.resetModules();
+
+    vi.doMock("@hono/node-server", async () => {
+      const actual =
+        await vi.importActual<typeof import("@hono/node-server")>(
+          "@hono/node-server",
+        );
+      return { ...actual };
+    });
+
+    vi.doMock("./storage/pb-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./storage/pb-client.js")
+      >("./storage/pb-client.js");
+      return {
+        ...actual,
+        createPbClient: () => ({
+          health: async () => true,
+          getOne: async () => null,
+          getFirst: async () => null,
+          getList: async () => ({ items: [] }),
+        }),
+      };
+    });
+
+    // Force the probe loader's initial load() to throw (e.g. probes dir
+    // missing / unreadable on disk).
+    vi.doMock("./probes/loader/probe-loader.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./probes/loader/probe-loader.js")
+      >("./probes/loader/probe-loader.js");
+      return {
+        ...actual,
+        createProbeLoader: () => ({
+          load: async () => {
+            throw new Error("simulated probes dir missing");
+          },
+          watch: () => () => {},
+        }),
+      };
+    });
+
+    const orchMod = await import("./orchestrator.js");
+
+    const handle = await orchMod.runControlPlane(
+      { role: "control-plane", poolCount: 1 },
+      { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+    );
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/health`);
+      const body = (await res.json()) as { status: string; rules: number };
+      // Producer alive: status stays ok (the role drops the rules>0 gate).
+      expect(body.status).toBe("ok");
+      // Zero probes loaded → rules reads 0, visible on /health (observable,
+      // not a hard gate). The dedicated bus-subscription test below proves
+      // `probes.reload.failed` is emitted.
+      expect(body.rules).toBe(0);
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  // A2: prove `probes.reload.failed` is emitted by subscribing to the bus the
+  // control-plane uses BEFORE the failing load runs. We swap createEventBus so
+  // the test owns the bus instance the orchestrator constructs internally.
+  it("emits probes.reload.failed on the control-plane bus when initial probe load throws", async () => {
+    vi.resetModules();
+
+    vi.doMock("@hono/node-server", async () => {
+      const actual =
+        await vi.importActual<typeof import("@hono/node-server")>(
+          "@hono/node-server",
+        );
+      return { ...actual };
+    });
+
+    vi.doMock("./storage/pb-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./storage/pb-client.js")
+      >("./storage/pb-client.js");
+      return {
+        ...actual,
+        createPbClient: () => ({
+          health: async () => true,
+          getOne: async () => null,
+          getFirst: async () => null,
+          getList: async () => ({ items: [] }),
+        }),
+      };
+    });
+
+    vi.doMock("./probes/loader/probe-loader.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./probes/loader/probe-loader.js")
+      >("./probes/loader/probe-loader.js");
+      return {
+        ...actual,
+        createProbeLoader: () => ({
+          load: async () => {
+            throw new Error("simulated probes dir missing");
+          },
+          watch: () => () => {},
+        }),
+      };
+    });
+
+    // Own the bus the orchestrator constructs so we can subscribe BEFORE the
+    // synchronous emit during runControlPlane.
+    const reloadFailures: unknown[] = [];
+    vi.doMock("./events/event-bus.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./events/event-bus.js")
+      >("./events/event-bus.js");
+      return {
+        ...actual,
+        createEventBus: () => {
+          const realBus = actual.createEventBus();
+          realBus.on("probes.reload.failed", (payload: unknown) => {
+            reloadFailures.push(payload);
+          });
+          return realBus;
+        },
+      };
+    });
+
+    const orchMod = await import("./orchestrator.js");
+
+    const handle = await orchMod.runControlPlane(
+      { role: "control-plane", poolCount: 1 },
+      { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+    );
+
+    try {
+      expect(reloadFailures.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  // A2: hot-reload + watcher teardown. A YAML added on reload registers a new
+  // probe:<id>; a YAML deleted unregisters it AND drops it from
+  // httpProbeConfigs (so /health no longer counts it); after stop() the
+  // watcher is torn down and no further reload fires.
+  it("hot-reloads added/removed YAMLs and tears down the watcher on stop()", async () => {
+    vi.resetModules();
+
+    vi.doMock("@hono/node-server", async () => {
+      const actual =
+        await vi.importActual<typeof import("@hono/node-server")>(
+          "@hono/node-server",
+        );
+      return { ...actual };
+    });
+
+    vi.doMock("./storage/pb-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./storage/pb-client.js")
+      >("./storage/pb-client.js");
+      return {
+        ...actual,
+        createPbClient: () => ({
+          health: async () => true,
+          getOne: async () => null,
+          getFirst: async () => null,
+          getList: async () => ({ items: [] }),
+        }),
+      };
+    });
+
+    // Capture register/unregister calls on the scheduler.
+    const registeredIds: string[] = [];
+    const unregisteredIds: string[] = [];
+    vi.doMock("./scheduler/scheduler.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./scheduler/scheduler.js")
+      >("./scheduler/scheduler.js");
+      return {
+        ...actual,
+        createScheduler: (
+          deps: Parameters<typeof actual.createScheduler>[0],
+        ) => {
+          const real = actual.createScheduler(deps);
+          return {
+            ...real,
+            register: (entry: { id: string }) => {
+              registeredIds.push(entry.id);
+              return (real.register as (...a: unknown[]) => unknown)(entry);
+            },
+            unregister: (id: string) => {
+              unregisteredIds.push(id);
+              return (real.unregister as (...a: unknown[]) => unknown)(id);
+            },
+          };
+        },
+      };
+    });
+
+    // Drive the probe loader's watch callback manually so the reload path is
+    // deterministic (no chokidar timing). `unwatch` records teardown.
+    let watchCb: ((next: import("./probes/loader/schema.js").ProbeConfig[]) => void) | undefined;
+    let unwatched = false;
+    const smokeCfg = {
+      kind: "smoke",
+      id: "smoke",
+      schedule: "*/5 * * * *",
+      target: { key: "smoke:test", url: "https://example.com" },
+    } as unknown as import("./probes/loader/schema.js").ProbeConfig;
+    const extraCfg = {
+      kind: "pin_drift",
+      id: "pin_drift",
+      schedule: "0 9 * * 1",
+      target: { key: "pin_drift:test" },
+    } as unknown as import("./probes/loader/schema.js").ProbeConfig;
+    vi.doMock("./probes/loader/probe-loader.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./probes/loader/probe-loader.js")
+      >("./probes/loader/probe-loader.js");
+      return {
+        ...actual,
+        createProbeLoader: () => ({
+          // Initial load: just smoke.
+          load: async () => [smokeCfg],
+          watch: (cb: typeof watchCb) => {
+            watchCb = cb;
+            return () => {
+              unwatched = true;
+            };
+          },
+        }),
+      };
+    });
+
+    const orchMod = await import("./orchestrator.js");
+
+    const handle = await orchMod.runControlPlane(
+      { role: "control-plane", poolCount: 1 },
+      { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+    );
+
+    try {
+      expect(registeredIds).toContain("probe:smoke");
+      expect(watchCb).toBeDefined();
+
+      // Reload with an ADDED YAML (pin_drift) → new probe:<id> registered.
+      watchCb!([smokeCfg, extraCfg]);
+      await new Promise((r) => setTimeout(r, 0));
+      expect(registeredIds).toContain("probe:pin_drift");
+
+      // Reload with smoke DELETED → unregister probe:smoke fires.
+      watchCb!([extraCfg]);
+      await new Promise((r) => setTimeout(r, 0));
+      expect(unregisteredIds).toContain("probe:smoke");
+    } finally {
+      await handle.stop();
+    }
+
+    // After stop() the watcher's unsubscribe ran → no reload fires anymore.
+    expect(unwatched).toBe(true);
+  });
+});
+
+// A4 drift-lock: the HTTP-only driver set registered by
+// `registerHttpProbeDrivers` must be DISJOINT from BROWSER_KINDS, and together
+// they must cover the full registered driver universe. Mirrors the
+// `registerAllProbeDrivers` drift-guard above. A future kind mis-added to
+// BROWSER_KINDS — or an HTTP driver whose kind overlaps a browser kind — would
+// silently drop a family from the in-process schedule.
+describe("orchestrator.registerHttpProbeDrivers / BROWSER_KINDS partition (drift-lock)", () => {
+  it("registers exactly the 8 HTTP-only kinds (no browser kinds)", async () => {
+    const orchMod = await import("./orchestrator.js");
+    const registry = createProbeRegistry();
+    orchMod.registerHttpProbeDrivers(registry);
+    const kinds = registry.list();
+    expect(kinds.sort()).toEqual(
+      [
+        "aimock_wiring",
+        "image_drift",
+        "pin_drift",
+        "qa",
+        "redirect_decommission",
+        "smoke",
+        "starter_smoke",
+        "version_drift",
+      ].sort(),
+    );
+  });
+
+  it("the HTTP driver kinds and BROWSER_KINDS are DISJOINT and jointly cover the full driver universe", async () => {
+    const orchMod = await import("./orchestrator.js");
+    const httpRegistry = createProbeRegistry();
+    orchMod.registerHttpProbeDrivers(httpRegistry);
+    const httpKinds = new Set(httpRegistry.list());
+    const browserKinds = new Set<string>([...orchMod.BROWSER_KINDS]);
+
+    // Disjoint: no kind is in both sets.
+    for (const k of httpKinds) {
+      expect(browserKinds.has(k)).toBe(false);
+    }
+
+    // Jointly cover the FULL registered universe (registerAllProbeDrivers).
+    const allRegistry = createProbeRegistry();
+    registerAllProbeDrivers(allRegistry);
+    const allKinds = new Set(allRegistry.list());
+    const union = new Set<string>([...httpKinds, ...browserKinds]);
+    expect([...union].sort()).toEqual([...allKinds].sort());
+  });
+
+  it("assertHttpBrowserKindPartition throws if a browser kind is in the HTTP set", async () => {
+    const orchMod = await import("./orchestrator.js");
+    // Clean partition passes.
+    const registry = createProbeRegistry();
+    orchMod.registerHttpProbeDrivers(registry);
+    expect(() =>
+      orchMod.assertHttpBrowserKindPartition(registry.list()),
+    ).not.toThrow();
+    // A browser kind sneaking into the HTTP set fails loud.
+    expect(() =>
+      orchMod.assertHttpBrowserKindPartition([...registry.list(), "e2e_smoke"]),
+    ).toThrow(/DISJOINT/);
   });
 });
 

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -3281,6 +3281,217 @@ describe("orchestrator runControlPlane REQ-B worker-self-report wiring (aggregat
   });
 });
 
+/**
+ * In-process HTTP-only probe families on the fleet control-plane.
+ *
+ * The control-plane today only runs the d6 producer; the 8 HTTP-only probe
+ * families (smoke, starter_smoke, image_drift, qa, aimock_wiring,
+ * version_drift, pin_drift, redirect_decommission) are dark on the fleet.
+ * These tests pin the desired end-state:
+ *
+ *   1. `runControlPlane` loads `config/probes/*.yml`, partitions by
+ *      `BROWSER_KINDS`, and registers ONLY the HTTP-kind families on its own
+ *      scheduler under `probe:<id>` entries. Browser kinds (e2e_*) are NOT
+ *      scheduled in-process — they route through the worker producer path.
+ *   2. /health's `rules` count reflects the in-process HTTP probe count (so
+ *      the control-plane role-drop on the rules>0 gate doesn't mask a real
+ *      loader failure), and `schedulerJobs` includes the probe entries.
+ *
+ * The probe config dir is the sibling `../probes` of `opts.configDir` (same
+ * resolution boot() uses), so the test writes a temp alerts dir + sibling
+ * probes dir containing one HTTP family (smoke), one more HTTP family
+ * (image_drift), and one BROWSER family (e2e_smoke) to prove the partition.
+ */
+describe("orchestrator runControlPlane in-process HTTP probes (Phase-1 3c)", () => {
+  let port = 0;
+  let probesDir = "";
+  let alertsDir = "";
+
+  beforeEach(async () => {
+    port = await pickPort();
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "harness-cp-http-probes-"),
+    );
+    alertsDir = path.join(root, "alerts");
+    probesDir = path.join(root, "probes");
+    await fs.mkdir(alertsDir, { recursive: true });
+    await fs.mkdir(probesDir, { recursive: true });
+    // Two HTTP families (single-target shapes keep the YAML minimal) + one
+    // browser family. The browser family must be SKIPPED in-process.
+    await fs.writeFile(
+      path.join(probesDir, "smoke.yml"),
+      [
+        "kind: smoke",
+        "id: smoke",
+        'schedule: "*/5 * * * *"',
+        "target:",
+        "  key: smoke:test",
+        '  url: "https://example.com"',
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(probesDir, "image-drift.yml"),
+      [
+        "kind: image_drift",
+        "id: image_drift",
+        'schedule: "*/15 * * * *"',
+        "target:",
+        "  key: image_drift:test",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(probesDir, "e2e-smoke.yml"),
+      [
+        "kind: e2e_smoke",
+        "id: e2e_smoke",
+        'schedule: "*/5 * * * *"',
+        "target:",
+        "  key: e2e_smoke:test",
+        '  url: "https://example.com"',
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("schedules the HTTP families (smoke, image_drift) in-process but NOT the browser kind", async () => {
+    vi.resetModules();
+
+    // Pin the REAL serve() so this role binds cleanly (immunize against a
+    // sibling test's leaked @hono/node-server doMock).
+    vi.doMock("@hono/node-server", async () => {
+      const actual =
+        await vi.importActual<typeof import("@hono/node-server")>(
+          "@hono/node-server",
+        );
+      return { ...actual };
+    });
+
+    // pb fake: health() true so the role boots clean; lookups return null.
+    vi.doMock("./storage/pb-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./storage/pb-client.js")
+      >("./storage/pb-client.js");
+      return {
+        ...actual,
+        createPbClient: () => ({
+          health: async () => true,
+          getOne: async () => null,
+          getFirst: async () => null,
+          getList: async () => ({ items: [] }),
+        }),
+      };
+    });
+
+    // Capture every scheduler.register id so we can assert which probe
+    // families landed as in-process scheduler entries.
+    const registeredIds: string[] = [];
+    vi.doMock("./scheduler/scheduler.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./scheduler/scheduler.js")
+      >("./scheduler/scheduler.js");
+      return {
+        ...actual,
+        createScheduler: (
+          deps: Parameters<typeof actual.createScheduler>[0],
+        ) => {
+          const real = actual.createScheduler(deps);
+          return {
+            ...real,
+            register: (entry: { id: string }) => {
+              registeredIds.push(entry.id);
+              return (real.register as (...a: unknown[]) => unknown)(entry);
+            },
+          };
+        },
+      };
+    });
+
+    const orchMod = await import("./orchestrator.js");
+
+    const handle = await orchMod.runControlPlane(
+      { role: "control-plane", poolCount: 1 },
+      { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+    );
+
+    try {
+      // HTTP families register as in-process probe entries.
+      expect(registeredIds).toContain("probe:smoke");
+      expect(registeredIds).toContain("probe:image_drift");
+      // Browser kind is NOT scheduled in-process — it routes to the producer.
+      expect(registeredIds).not.toContain("probe:e2e_smoke");
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  it("/health reflects the in-process HTTP rule count (not a hardcoded 0)", async () => {
+    vi.resetModules();
+
+    vi.doMock("@hono/node-server", async () => {
+      const actual =
+        await vi.importActual<typeof import("@hono/node-server")>(
+          "@hono/node-server",
+        );
+      return { ...actual };
+    });
+
+    vi.doMock("./storage/pb-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./storage/pb-client.js")
+      >("./storage/pb-client.js");
+      return {
+        ...actual,
+        createPbClient: () => ({
+          health: async () => true,
+          getOne: async () => null,
+          getFirst: async () => null,
+          getList: async () => ({ items: [] }),
+        }),
+      };
+    });
+
+    const orchMod = await import("./orchestrator.js");
+
+    const handle = await orchMod.runControlPlane(
+      { role: "control-plane", poolCount: 1 },
+      { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+    );
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/health`);
+      const body = (await res.json()) as {
+        status: string;
+        rules: number;
+        schedulerJobs: number;
+      };
+      // Two HTTP families loaded → rules must be >= 2 (the control-plane now
+      // has in-process rules; the role-drop no longer masks a loader failure).
+      expect(body.rules).toBeGreaterThanOrEqual(2);
+      // schedulerJobs includes the producer + the in-process probe entries.
+      expect(body.schedulerJobs).toBeGreaterThanOrEqual(3);
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  it("BROWSER_KINDS is the e2e partition (the in-process exclusion set)", async () => {
+    const orchMod = await import("./orchestrator.js");
+    expect([...orchMod.BROWSER_KINDS].sort()).toEqual(
+      ["e2e_d6", "e2e_deep", "e2e_demos", "e2e_smoke"].sort(),
+    );
+  });
+});
+
 // Shared helper used by both the R25 and R28 describe blocks.
 function makeCronRule(id: string, cron: string): CompiledRule {
   return {

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -1125,12 +1125,48 @@ export function registerHttpProbeDrivers(
 ): void {
   probeRegistry.register(aimockWiringDriver);
   probeRegistry.register(pinDriftDriver);
+  // The `smoke` family is served by `livenessDriver` (whose `kind` is
+  // `"smoke"`) — there is no separate "smoke" driver export.
   probeRegistry.register(livenessDriver);
   probeRegistry.register(imageDriftDriver);
   probeRegistry.register(versionDriftDriver);
   probeRegistry.register(redirectDecommissionDriver);
   probeRegistry.register(qaDriver);
   probeRegistry.register(starterSmokeDriver);
+}
+
+/**
+ * Fail-loud invariant for the HTTP/browser kind partition. Given the list of
+ * driver kinds the control-plane registered in-process (via
+ * `registerHttpProbeDrivers`), assert that NONE of them is in `BROWSER_KINDS` —
+ * the two sets must be DISJOINT, so an HTTP driver kind can never collide with a
+ * browser kind.
+ *
+ * Today both sets are hand-maintained from a single 12-kind list, so this can
+ * only trip on a future edit. But a kind mis-added to BROWSER_KINDS that ALSO
+ * has an HTTP driver would go dark on the fleet — `includeKind` would skip the
+ * YAML in-process while the browser path wouldn't pick up an HTTP family — so we
+ * throw at control-plane boot rather than let a probe family vanish unnoticed.
+ *
+ * (The complementary JOINT-COVERAGE check — that the HTTP kinds + BROWSER_KINDS
+ * together equal the full `registerAllProbeDrivers` universe — lives in the
+ * drift-lock test, which can see the whole universe; this runtime guard only has
+ * the HTTP set in hand.)
+ *
+ * Exported so the drift-lock test can assert the partition without booting the
+ * full control-plane.
+ */
+export function assertHttpBrowserKindPartition(httpKinds: string[]): void {
+  const overlap = httpKinds.filter((kind) =>
+    BROWSER_KINDS.has(kind as ProbeConfig["kind"]),
+  );
+  if (overlap.length > 0) {
+    throw new Error(
+      `registerHttpProbeDrivers registered browser kind(s) that must NOT run ` +
+        `in-process on the control-plane: ${overlap.sort().join(", ")}. The ` +
+        `HTTP driver set and BROWSER_KINDS must be DISJOINT.`,
+    );
+  }
 }
 
 /**
@@ -2265,7 +2301,7 @@ export async function runControlPlane(
   });
   controlPlaneRef = controlPlane;
 
-  // ---- In-process HTTP-only probe families (Phase-1 3c) ----
+  // ---- In-process HTTP-only probe families ----
   //
   // The control-plane runs the 8 HTTP-only probe families IN-PROCESS by
   // lifting the legacy boot() probe-loader machinery: an HTTP-only
@@ -2281,14 +2317,44 @@ export async function runControlPlane(
   // The browser families (e2e_d6 / e2e_smoke / e2e_demos / e2e_deep) are NOT
   // run here — d6 goes via the producer; the rest need a BrowserPool the
   // control-plane deliberately does not own.
+
+  // Crash-recovery parity with boot(): finalize any `running` probe_runs rows
+  // orphaned by a prior crash BEFORE registering the in-process HTTP probes.
+  // boot() does this at startup, but boot() never runs in fleet mode — so
+  // without this the control-plane (which now writes probe_runs via the HTTP
+  // probes) would leak orphaned `running` rows forever. Best-effort: a sweep
+  // failure must NOT abort control-plane boot (mirrors boot's
+  // `boot.sweep-stale-runs-failed`).
+  try {
+    const swept = await sweepStaleRuns(pb);
+    if (swept > 0) {
+      logger.info("fleet.control-plane.swept-stale-runs", { swept });
+    }
+  } catch (err) {
+    logger.error("fleet.control-plane.sweep-stale-runs-failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
   const httpProbeRegistry = createProbeRegistry();
   registerHttpProbeDrivers(httpProbeRegistry);
+
+  // Drift-guard: the registered HTTP driver kinds and BROWSER_KINDS must be
+  // DISJOINT and together cover the full registered driver-kind universe. This
+  // is theoretical today (the two sets are hand-maintained from one list), but
+  // a future kind mis-added to BROWSER_KINDS — or an HTTP driver whose kind
+  // overlaps a browser kind — would silently drop a family from the in-process
+  // schedule (it'd be skipped by includeKind yet never run anywhere). Fail loud
+  // at boot rather than let a probe go dark unnoticed.
+  assertHttpBrowserKindPartition(httpProbeRegistry.list());
+
   const httpDiscoveryRegistry = createDiscoveryRegistry();
-  // `qa` is a per-service discovery probe (railway-services); `image_drift`
-  // and the pnpm-pinned drift probes use pnpm-packages discovery. Register the
-  // SAME discovery sources boot() wires so the HTTP families fan out to the
-  // identical target set. railway-services is cached (24h TTL) with an
-  // auth-failure tracker, mirroring boot().
+  // `qa` and `image_drift` are per-service discovery probes (railway-services);
+  // `version_drift` uses pnpm-packages discovery. (`pin_drift` is single-target
+  // — it has NO discovery source.) Register the SAME discovery sources boot()
+  // wires so the HTTP families fan out to the identical target set.
+  // railway-services is cached (24h TTL) with an auth-failure tracker,
+  // mirroring boot().
   const httpAuthTracker = new DiscoveryAuthTracker({
     threshold: 3,
     writer: statusWriter,
@@ -2341,6 +2407,15 @@ export async function runControlPlane(
       desired.set(`probe:${cfg.id}`, cfg);
     }
     // Unregister probe ids no longer desired (YAML deleted on a reload).
+    // Unregister-failure post-state (mirrors boot()'s diffProbeSchedules
+    // intent): await the unregister and only drop the config from
+    // `httpProbeConfigs` on SUCCESS. If unregister REJECTS, the scheduler still
+    // holds the old entry, so we deliberately KEEP the config in
+    // `httpProbeConfigs` — the orphaned entry stays VISIBLE on /health (its
+    // `rules` count still includes it) and a future surface could report its
+    // real kind/config rather than an "unknown" orphan. We log the drift; the
+    // next successful diff sweep cleans it up once the YAML is restored or the
+    // service restarts.
     for (const entry of scheduler.list()) {
       if (!entry.id.startsWith("probe:")) continue;
       if (!desired.has(entry.id)) {
@@ -2354,6 +2429,8 @@ export async function runControlPlane(
             err,
             { id: entry.id },
           );
+          // Intentionally do NOT delete from httpProbeConfigs — keep the
+          // orphan observable with proper metadata (see comment above).
         }
       }
     }
@@ -2403,8 +2480,12 @@ export async function runControlPlane(
     bus.emit("probes.reloaded", { count: httpConfigs.length });
   } catch (err) {
     // A probe-load failure must NOT take down the control-plane — the d6
-    // producer + fleet-health legs still function. Surface on the bus so
-    // operators can alert on `probes.reload.failed` without blocking boot.
+    // producer + fleet-health legs still function. The failure surface is the
+    // structured error log below PLUS the /health `rules` count dropping to 0
+    // (see ruleCount wiring), which dashboards/alerting can observe. We also
+    // emit `probes.reload.failed` on the bus for any future subscriber, but the
+    // control-plane wires NO bus subscriber for it today (unlike boot(), it has
+    // no metrics registry) — so the log + ruleCount are the live surface.
     logErrorWithStack(
       logger,
       "fleet.control-plane.initial-probe-load-failed",
@@ -2451,11 +2532,15 @@ export async function runControlPlane(
     // count is the number of in-process HTTP probe configs. We keep
     // `role: "control-plane"` (its liveness is still governed by the scheduler
     // signals folded into loopOk — schedulerJobCount>0 covers BOTH the
-    // producer entry AND the probe entries), but `ruleCount` now reflects the
-    // real in-process rule count so the role-drop on the rules>0 gate does not
-    // MASK a probe-loader failure: if the loader silently produced zero HTTP
-    // probes, `rules` reads 0 and the gap is visible on /health rather than
-    // hidden behind the role short-circuit.
+    // producer entry AND the probe entries). `ruleCount` now reports the REAL
+    // in-process probe count instead of a hardcoded 0, so a zero-probe load is
+    // OBSERVABLE in the /health JSON `rules` field (for dashboards / alerting).
+    // NOTE: the role still DROPS the `rules > 0` gate (server.ts forces
+    // `rulesOk = true` for the control-plane role), so a zero-probe load does
+    // NOT flip `status` to degraded — the visibility is for dashboards/alerts,
+    // not container liveness. Keeping the gate dropped is deliberate: the
+    // control-plane's liveness is its scheduler/producer signals, not its probe
+    // count.
     role: "control-plane",
     ruleCount: () => httpProbeConfigs.size,
     schedulerStarted: () => scheduler.isStarted(),

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -1092,6 +1092,48 @@ export function buildPooledBrowserDrivers(
 }
 
 /**
+ * The probe kinds that REQUIRE a browser (Playwright via the BrowserPool /
+ * worker) and therefore must NOT run in-process on the fleet control-plane.
+ * They route through the worker producer path instead. Everything else is an
+ * HTTP-only family that the control-plane runs in-process (lifting the legacy
+ * `boot()` probe-loader machinery). Used to partition `config/probes/*.yml`:
+ * HTTP = every kind NOT in this set.
+ *
+ * Exported so unit tests can lock the partition without reaching into the
+ * control-plane's private wiring, and so a future kind addition flows through
+ * one source of truth rather than a drifting inline literal.
+ */
+export const BROWSER_KINDS: ReadonlySet<ProbeConfig["kind"]> = new Set<
+  ProbeConfig["kind"]
+>(["e2e_d6", "e2e_smoke", "e2e_demos", "e2e_deep"]);
+
+/**
+ * Register ONLY the HTTP-only probe drivers (no browser/BrowserPool drivers)
+ * onto the given registry. This is the control-plane's in-process driver set:
+ * the 8 families that need nothing but `fetch` + registry/API calls
+ * (smoke, starter_smoke, image_drift, qa, aimock_wiring, version_drift,
+ * pin_drift, redirect_decommission). The browser `e2e_*` kinds are
+ * deliberately omitted — they run via the worker producer path, not in-process.
+ *
+ * Kept SEPARATE from `registerAllProbeDrivers` (which also registers the e2e
+ * drivers) so the control-plane's `probeRegistry` contains only the HTTP
+ * drivers; paired with the probe-loader's `includeKind` scoping this means a
+ * browser YAML on disk is skipped at load, never rejected.
+ */
+export function registerHttpProbeDrivers(
+  probeRegistry: Pick<ProbeRegistry, "register">,
+): void {
+  probeRegistry.register(aimockWiringDriver);
+  probeRegistry.register(pinDriftDriver);
+  probeRegistry.register(livenessDriver);
+  probeRegistry.register(imageDriftDriver);
+  probeRegistry.register(versionDriftDriver);
+  probeRegistry.register(redirectDecommissionDriver);
+  probeRegistry.register(qaDriver);
+  probeRegistry.register(starterSmokeDriver);
+}
+
+/**
  * Register every probe driver this orchestrator knows about onto the
  * given registry. Single source of truth for the registered probe-kind
  * set so YAML probe configs (`config/probes/*.yml`) and orchestrator
@@ -2223,19 +2265,199 @@ export async function runControlPlane(
   });
   controlPlaneRef = controlPlane;
 
+  // ---- In-process HTTP-only probe families (Phase-1 3c) ----
+  //
+  // The control-plane runs the 8 HTTP-only probe families IN-PROCESS by
+  // lifting the legacy boot() probe-loader machinery: an HTTP-only
+  // `probeRegistry` (no browser drivers), a `createProbeLoader` scoped to the
+  // HTTP `kind`s via `includeKind` (browser `e2e_*` YAMLs are SKIPPED, not
+  // rejected — they route through the worker producer path), and the same
+  // `buildProbeInvoker` loop boot() uses to register one `probe:<id>` entry per
+  // config on THIS control-plane's scheduler. Crons are driven FROM the YAML
+  // (`cfg.schedule`), never hardcoded. Each tick flows through the SAME
+  // status-writer pipeline (`statusWriter`) the worker-result aggregator uses,
+  // so a smoke/qa/image_drift result lands on the dashboard identically.
+  //
+  // The browser families (e2e_d6 / e2e_smoke / e2e_demos / e2e_deep) are NOT
+  // run here — d6 goes via the producer; the rest need a BrowserPool the
+  // control-plane deliberately does not own.
+  const httpProbeRegistry = createProbeRegistry();
+  registerHttpProbeDrivers(httpProbeRegistry);
+  const httpDiscoveryRegistry = createDiscoveryRegistry();
+  // `qa` is a per-service discovery probe (railway-services); `image_drift`
+  // and the pnpm-pinned drift probes use pnpm-packages discovery. Register the
+  // SAME discovery sources boot() wires so the HTTP families fan out to the
+  // identical target set. railway-services is cached (24h TTL) with an
+  // auth-failure tracker, mirroring boot().
+  const httpAuthTracker = new DiscoveryAuthTracker({
+    threshold: 3,
+    writer: statusWriter,
+    logger,
+    now: () => Date.now(),
+  });
+  httpDiscoveryRegistry.register(
+    withCache(railwayServicesSource, {
+      ttlMs: 86_400_000,
+      logger,
+      authTracker: httpAuthTracker,
+    }),
+  );
+  httpDiscoveryRegistry.register(pnpmPackagesDiscoverySource);
+
+  const httpProbeConfigDir =
+    opts.configDir !== undefined
+      ? path.resolve(opts.configDir, "../probes")
+      : path.resolve(process.cwd(), "config/probes");
+  const httpProbeLoader = createProbeLoader(httpProbeConfigDir, {
+    probeRegistry: httpProbeRegistry,
+    discoveryRegistry: httpDiscoveryRegistry,
+    // Scope to HTTP-only kinds — browser YAMLs are skipped at load (see
+    // BROWSER_KINDS). Without this, a browser YAML on disk would fail the
+    // driver-resolution check against the HTTP-only registry and surface a
+    // spurious `probes.reload.failed`.
+    includeKind: (kind) => !BROWSER_KINDS.has(kind),
+    bus: {
+      emit(event, payload) {
+        bus.emit(event, payload);
+      },
+    },
+    logger,
+  });
+
+  // probe_runs writer reused by every per-probe invoker (start/finish a
+  // `running` row per tick), constructed once so its PB client is shared.
+  const httpRunWriter = createProbeRunWriter(pb);
+
+  // Per-cfg map of scheduler-id → config so /health can count the in-process
+  // HTTP rules (and a future /api/probes surface could read it). Keyed by the
+  // prefixed scheduler id (`probe:<cfg.id>`).
+  const httpProbeConfigs = new Map<string, ProbeConfig>();
+
+  async function diffHttpProbeSchedules(
+    configs: ProbeConfig[],
+  ): Promise<void> {
+    const desired = new Map<string, ProbeConfig>();
+    for (const cfg of configs) {
+      desired.set(`probe:${cfg.id}`, cfg);
+    }
+    // Unregister probe ids no longer desired (YAML deleted on a reload).
+    for (const entry of scheduler.list()) {
+      if (!entry.id.startsWith("probe:")) continue;
+      if (!desired.has(entry.id)) {
+        try {
+          await scheduler.unregister(entry.id);
+          httpProbeConfigs.delete(entry.id);
+        } catch (err) {
+          logErrorWithStack(
+            logger,
+            "fleet.control-plane.probe-unregister-failed",
+            err,
+            { id: entry.id },
+          );
+        }
+      }
+    }
+    const baseEnv: Readonly<Record<string, string | undefined>> = {
+      ...process.env,
+    };
+    for (const [id, cfg] of desired) {
+      const driver = httpProbeRegistry.get(cfg.kind);
+      if (!driver) {
+        // Unreachable: the loader already validates kind→driver at load time
+        // (and skips browser kinds via includeKind). Cheap guard.
+        logger.error("fleet.control-plane.probe-driver-missing", {
+          id: cfg.id,
+          kind: cfg.kind,
+        });
+        continue;
+      }
+      const invoker = buildProbeInvoker(cfg, {
+        driver,
+        discoveryRegistry: httpDiscoveryRegistry,
+        writer: statusWriter,
+        logger,
+        fetchImpl: globalThis.fetch,
+        env: envForCfg(cfg, baseEnv),
+        now: () => new Date(),
+        scheduler,
+        schedulerId: id,
+        runWriter: httpRunWriter,
+      });
+      try {
+        scheduler.register({ id, cron: cfg.schedule, handler: invoker });
+        httpProbeConfigs.set(id, cfg);
+      } catch (err) {
+        logErrorWithStack(
+          logger,
+          "fleet.control-plane.probe-register-failed",
+          err,
+          { id, kind: cfg.kind, schedule: cfg.schedule },
+        );
+      }
+    }
+  }
+
+  try {
+    const httpConfigs = await httpProbeLoader.load();
+    await diffHttpProbeSchedules(httpConfigs);
+    bus.emit("probes.reloaded", { count: httpConfigs.length });
+  } catch (err) {
+    // A probe-load failure must NOT take down the control-plane — the d6
+    // producer + fleet-health legs still function. Surface on the bus so
+    // operators can alert on `probes.reload.failed` without blocking boot.
+    logErrorWithStack(
+      logger,
+      "fleet.control-plane.initial-probe-load-failed",
+      err,
+    );
+    bus.emit("probes.reload.failed", {
+      errors: [{ file: "(initial-load)", error: String(err) }],
+    });
+  }
+
+  // Hot-reload: re-diff on YAML edits, mirroring boot()'s fire-and-forget
+  // watch callback (the chokidar callback is sync/void-returning).
+  let unwatchHttpProbes: () => void = () => {};
+  try {
+    unwatchHttpProbes = httpProbeLoader.watch((next) => {
+      diffHttpProbeSchedules(next)
+        .then(() => bus.emit("probes.reloaded", { count: next.length }))
+        .catch((err) => {
+          logErrorWithStack(
+            logger,
+            "fleet.control-plane.probe-watch-reload-failed",
+            err,
+          );
+          bus.emit("probes.reload.failed", {
+            errors: [{ file: "(watch-reload)", error: String(err) }],
+          });
+        });
+    });
+  } catch (err) {
+    logErrorWithStack(
+      logger,
+      "fleet.control-plane.probe-watch-init-failed",
+      err,
+    );
+  }
+
   // Minimal HTTP surface for the role's liveness `port` (fleet-health probes
   // hit this). /health reports OK once the producer's scheduler entry is live.
   const app = buildServer({
     pb,
     logger,
-    // The control-plane is a scheduler/queue/aggregator with NO probe rules —
-    // only the single fleet-job-producer scheduler entry. The role flag drops
-    // /health's `rules > 0` gate so the container reports HEALTHY on its real
-    // liveness signals (pb ok, scheduler started + alive, schedulerJobs>0);
-    // without it /health is degraded forever (rules always 0) and Railway
-    // restart-loops the service.
+    // The control-plane is a scheduler/queue/aggregator. It now ALSO runs the
+    // HTTP-only probe families in-process, so it DOES own probe rules — the
+    // count is the number of in-process HTTP probe configs. We keep
+    // `role: "control-plane"` (its liveness is still governed by the scheduler
+    // signals folded into loopOk — schedulerJobCount>0 covers BOTH the
+    // producer entry AND the probe entries), but `ruleCount` now reflects the
+    // real in-process rule count so the role-drop on the rules>0 gate does not
+    // MASK a probe-loader failure: if the loader silently produced zero HTTP
+    // probes, `rules` reads 0 and the gap is visible on /health rather than
+    // hidden behind the role short-circuit.
     role: "control-plane",
-    ruleCount: () => 0,
+    ruleCount: () => httpProbeConfigs.size,
     schedulerStarted: () => scheduler.isStarted(),
     schedulerJobCount: () => scheduler.list().length,
     schedulerIsStopped: () => scheduler.isStopped(),
@@ -2260,6 +2482,18 @@ export async function runControlPlane(
   // internal intervals. Best-effort: operators see the original bind error, not
   // a teardown-failure shadow.
   async function teardownAfterBindFailure(): Promise<void> {
+    // Tear down the HTTP-probe file watcher so a failed bind never leaks a
+    // chokidar watcher (best-effort; the watcher's own unsubscribe is sync).
+    try {
+      unwatchHttpProbes();
+    } catch (unwatchErr) {
+      logger.error("fleet.control-plane.probe-unwatch-after-bind-failure", {
+        err:
+          unwatchErr instanceof Error
+            ? unwatchErr.message
+            : String(unwatchErr),
+      });
+    }
     await controlPlane.stop().catch((stopErr) =>
       logger.error("fleet.control-plane.stop-after-bind-failure", {
         err: stopErr instanceof Error ? stopErr.message : String(stopErr),
@@ -2326,6 +2560,14 @@ export async function runControlPlane(
     port,
     bus,
     async stop(): Promise<void> {
+      // Tear down the HTTP-probe file watcher first so no reload fires mid-stop.
+      try {
+        unwatchHttpProbes();
+      } catch (err) {
+        logger.error("fleet.control-plane.probe-unwatch-on-stop-failed", {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
       // controlPlane.stop() clears its own internal fleet-health + consumer
       // intervals (REQ-B seams now own that lifecycle).
       await controlPlane.stop();

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -2399,9 +2399,7 @@ export async function runControlPlane(
   // prefixed scheduler id (`probe:<cfg.id>`).
   const httpProbeConfigs = new Map<string, ProbeConfig>();
 
-  async function diffHttpProbeSchedules(
-    configs: ProbeConfig[],
-  ): Promise<void> {
+  async function diffHttpProbeSchedules(configs: ProbeConfig[]): Promise<void> {
     const desired = new Map<string, ProbeConfig>();
     for (const cfg of configs) {
       desired.set(`probe:${cfg.id}`, cfg);
@@ -2574,9 +2572,7 @@ export async function runControlPlane(
     } catch (unwatchErr) {
       logger.error("fleet.control-plane.probe-unwatch-after-bind-failure", {
         err:
-          unwatchErr instanceof Error
-            ? unwatchErr.message
-            : String(unwatchErr),
+          unwatchErr instanceof Error ? unwatchErr.message : String(unwatchErr),
       });
     }
     await controlPlane.stop().catch((stopErr) =>

--- a/showcase/harness/src/probes/loader/probe-loader.test.ts
+++ b/showcase/harness/src/probes/loader/probe-loader.test.ts
@@ -185,6 +185,52 @@ describe("createProbeLoader", () => {
     );
   });
 
+  it("includeKind SKIPS (not rejects) a config whose kind the predicate excludes", async () => {
+    // An HTTP family (smoke) + a browser family (e2e_smoke). The HTTP-only
+    // caller registers ONLY the smoke driver and scopes the loader to exclude
+    // browser kinds — the e2e_smoke YAML must be SKIPPED (loaded out), NOT
+    // surfaced as a `probes.reload.failed` (it would otherwise fail the
+    // no-driver-registered check against the HTTP-only registry).
+    await fs.writeFile(
+      path.join(dir, "smoke.yml"),
+      [
+        "kind: smoke",
+        "id: smoke-http",
+        'schedule: "*/5 * * * *"',
+        "targets: [{ key: 'smoke:http', url: 'https://x.example' }]",
+      ].join("\n"),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(dir, "e2e-smoke.yml"),
+      [
+        "kind: e2e_smoke",
+        "id: e2e-smoke-browser",
+        'schedule: "*/5 * * * *"',
+        "target: { key: 'e2e_smoke:browser', url: 'https://x.example' }",
+      ].join("\n"),
+      "utf-8",
+    );
+    const probeRegistry = createProbeRegistry();
+    probeRegistry.register(mkDriver("smoke"));
+    // NOTE: deliberately do NOT register an e2e_smoke driver — proving the
+    // skip happens BEFORE the driver-resolution check.
+    const bus = mkBus();
+    const loader = createProbeLoader(dir, {
+      probeRegistry,
+      discoveryRegistry: createDiscoveryRegistry(),
+      bus,
+      logger,
+      includeKind: (kind) => kind !== "e2e_smoke",
+    });
+    const configs = await loader.load();
+    expect(configs.map((c) => c.id)).toEqual(["smoke-http"]);
+    // Skipping must NOT produce a reload-failed event.
+    expect(bus.events.some((e) => e.event === "probes.reload.failed")).toBe(
+      false,
+    );
+  });
+
   it("rejects a config whose kind has no registered driver", async () => {
     await fs.writeFile(
       path.join(dir, "unregistered.yml"),

--- a/showcase/harness/src/probes/loader/probe-loader.ts
+++ b/showcase/harness/src/probes/loader/probe-loader.ts
@@ -119,7 +119,10 @@ export function createProbeLoader(
         // browser YAML never tries to resolve against an HTTP-only registry
         // (which would surface a spurious `no driver registered` failure).
         if (includeKind && !includeKind(cfg.kind)) {
-          logger.debug("probe-loader.kind-skipped", {
+          // logger.info (not debug) so a skipped config is visible at normal
+          // verbosity — operators can confirm WHICH on-disk YAMLs the
+          // HTTP-only control-plane is deliberately not scheduling.
+          logger.info("probe-loader.kind-skipped", {
             file: f,
             kind: cfg.kind,
           });

--- a/showcase/harness/src/probes/loader/probe-loader.ts
+++ b/showcase/harness/src/probes/loader/probe-loader.ts
@@ -25,6 +25,20 @@ export interface ProbeLoaderDeps {
   bus?: ProbeLoadErrorEmitter;
   logger: Logger;
   /**
+   * Optional kind predicate. When supplied, a probe config whose `kind` the
+   * predicate REJECTS is silently SKIPPED (not error-listed) before the
+   * driver-resolution check. This lets a caller scope the loader to a SUBSET
+   * of kinds — e.g. the fleet control-plane runs only the HTTP-only families
+   * in-process and excludes the browser (`e2e_*`) kinds, which route through
+   * the worker producer path. Skipping (rather than rejecting) keeps an
+   * HTTP-only `probeRegistry` clean: the loader never tries to resolve a
+   * browser kind against a registry that deliberately omits its driver, so a
+   * browser YAML present on disk does not surface as a spurious
+   * `probes.reload.failed`. When undefined, every kind is included (legacy
+   * boot behaviour).
+   */
+  includeKind?: (kind: ProbeConfig["kind"]) => boolean;
+  /**
    * Test-only escape hatch for chokidar's options. Production callers leave
    * this undefined; the loader picks FSEvents on macOS / inotify on Linux.
    * Tests pass `{ usePolling: true, interval: 50 }` because chokidar's
@@ -72,6 +86,7 @@ export function createProbeLoader(
     discoveryRegistry,
     bus,
     logger,
+    includeKind,
     watcherOptionsOverride,
   } = deps;
   let watcher: FSWatcher | null = null;
@@ -97,6 +112,19 @@ export function createProbeLoader(
       try {
         const doc = await readYaml(filePath);
         const cfg = ProbeConfigSchema.parse(doc);
+        // Kind scoping: a caller may run only a SUBSET of kinds (the fleet
+        // control-plane loads only the HTTP-only families in-process and
+        // excludes browser `e2e_*` kinds). Skip — do NOT error — a config the
+        // predicate rejects, BEFORE the driver-resolution check below, so a
+        // browser YAML never tries to resolve against an HTTP-only registry
+        // (which would surface a spurious `no driver registered` failure).
+        if (includeKind && !includeKind(cfg.kind)) {
+          logger.debug("probe-loader.kind-skipped", {
+            file: f,
+            kind: cfg.kind,
+          });
+          continue;
+        }
         // Resolve driver — unknown kind means no scheduler wiring is
         // possible, so fail the file at load time rather than at first
         // tick. Mirrors rule-loader's enum check on dimension.


### PR DESCRIPTION
## Summary

Make the fleet control-plane ALSO run the 8 HTTP-only probe families in-process (they don't need the BrowserPool/worker), by lifting the legacy `boot()` probe-loader machinery into `runControlPlane`. Before this, the control-plane only ran the d6 producer and the 8 HTTP families were dark on the fleet.

HTTP-only families now run in-process: `smoke`, `starter_smoke`, `image_drift`, `qa`, `aimock_wiring`, `version_drift`, `pin_drift`, `redirect_decommission`. The browser families (`e2e_d6` / `e2e_smoke` / `e2e_demos` / `e2e_deep`) are deliberately NOT run in-process — d6 goes via the worker producer path; the rest need a BrowserPool the control-plane does not own. This is independent of the worker-registry / worker-loop work.

## Design

- **`BROWSER_KINDS`** (exported) = `{e2e_d6, e2e_smoke, e2e_demos, e2e_deep}`. HTTP = every kind NOT in this set. Single source of truth for the partition.
- **`registerHttpProbeDrivers`** (exported) registers only the 8 HTTP drivers (no BrowserPool drivers) — kept separate from `registerAllProbeDrivers` so the control-plane's `probeRegistry` is HTTP-only.
- In **`runControlPlane`**: build an HTTP-only `probeRegistry` + a discovery registry wiring the SAME sources `boot()` uses (`railway-services` cached 24h with an auth tracker, `pnpm-packages`), a `createProbeLoader` scoped to HTTP kinds, and the same `diffProbeSchedules`/`buildProbeInvoker` loop `boot()` runs — registering one `probe:<id>` scheduler entry per YAML config on the control-plane's scheduler. **Crons are driven FROM the YAML** (`cfg.schedule`), never hardcoded. Each tick flows through the same `statusWriter` pipeline as the worker-result aggregator. Hot-reload via `probeLoader.watch` mirrors `boot()`.
- **`includeKind` predicate** added to `createProbeLoader`: a browser YAML on disk is SKIPPED (not rejected) against the HTTP-only registry, so a present `e2e_*` YAML never surfaces a spurious `probes.reload.failed`.

## /health handling

The control-plane now owns in-process probe rules, so `ruleCount` reflects the real in-process HTTP probe count (was a hardcoded `0`). The `role: "control-plane"` rules>0 gate-drop is retained (liveness is governed by the scheduler signals already folded into `loopOk`), but the real count means a silent probe-loader failure (zero HTTP probes loaded) is now VISIBLE on `/health` rather than masked behind the role short-circuit. `schedulerJobCount` already counts the new `probe:` entries (covers BOTH the producer entry and the probe entries).

Teardown: the HTTP-probe file watcher is torn down on `stop()` and on bind failure.

## Red→Green evidence

Wrote failing tests first, confirmed RED against baseline (stashed the impl):
- scheduling test: `probe:smoke` / `probe:image_drift` not registered (FAIL)
- /health test: `rules` < 2 (FAIL)
- `BROWSER_KINDS is not iterable` (FAIL)
- loader `includeKind` skip behavior

After implementing, all GREEN.

## Test plan

- [x] New `runControlPlane` in-process HTTP probe tests (scheduling partition + /health rule count + BROWSER_KINDS) — green, RED-verified
- [x] New `createProbeLoader` `includeKind` skip-not-reject test — green
- [x] Full harness vitest suite: 119 files / 2076 tests passed
- [x] Production build `tsc -p tsconfig.build.json`: clean (the only `--noEmit` error is the pre-existing `toReversed` lib-target issue in an unrelated test file, excluded from the build config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)