### PR TITLE
feat(harness/fleet): generalize enumerator + control-plane for N producer schedules

### DIFF
--- a/showcase/harness/src/fleet/control-plane/catalog-enumerator.test.ts
+++ b/showcase/harness/src/fleet/control-plane/catalog-enumerator.test.ts
@@ -284,4 +284,53 @@ describe("createServiceEnumerator (generic seam)", () => {
     expect(lg?.probeKey).toBe("deep-langgraph-python");
     expect(lg?.driverInputs?.key).toBe("deep-langgraph-python");
   });
+
+  // A5: a filter without a namePrefix would make the discovery source enumerate
+  // ALL services (a documented incident class). Fail loud at construction.
+  it("throws when the filter has no namePrefix (fail loud, never enumerate all)", () => {
+    const source = fakeSource([svc()]);
+    expect(() =>
+      createServiceEnumerator({
+        source,
+        env: {},
+        fetchImpl: globalThis.fetch,
+        logger: SILENT_LOGGER,
+        driverKind: "e2e_smoke",
+        probeKeyPrefix: "smoke",
+        filter: { nameExcludes: ["showcase-harness"] },
+      }),
+    ).toThrow(/namePrefix/);
+  });
+
+  it("throws when the filter namePrefix is an empty string", () => {
+    const source = fakeSource([svc()]);
+    expect(() =>
+      createServiceEnumerator({
+        source,
+        env: {},
+        fetchImpl: globalThis.fetch,
+        logger: SILENT_LOGGER,
+        driverKind: "e2e_smoke",
+        probeKeyPrefix: "smoke",
+        filter: { namePrefix: "" },
+      }),
+    ).toThrow(/namePrefix/);
+  });
+
+  // A6: a function-form probeKeyPrefix returning "" yields an empty
+  // probeKey/driverInputs.key (a bad join key) — fail loud naming the slug.
+  it("throws when a function probeKeyPrefix yields an empty key for a service", async () => {
+    const source = fakeSource([svc({ name: "showcase-langgraph-python" })]);
+    const enumerate = createServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+      driverKind: "e2e_deep",
+      probeKeyPrefix: () => "",
+      filter: { namePrefix: "showcase-" },
+    });
+
+    await expect(enumerate(CTX)).rejects.toThrow(/langgraph-python/);
+  });
 });

--- a/showcase/harness/src/fleet/control-plane/catalog-enumerator.test.ts
+++ b/showcase/harness/src/fleet/control-plane/catalog-enumerator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   createD6ServiceEnumerator,
+  createServiceEnumerator,
   D6_DRIVER_KIND,
   D6_DISCOVERY_FILTER,
 } from "./catalog-enumerator.js";
@@ -205,5 +206,84 @@ describe("createD6ServiceEnumerator", () => {
     const specs = await enumerate(CTX);
     expect(specs.length).toBeGreaterThan(0);
     expect(specs.length).toBe(3);
+  });
+});
+
+describe("createServiceEnumerator (generic seam)", () => {
+  it("stamps the passed driverKind and probeKey prefix (non-d6 params)", async () => {
+    const source = fakeSource([
+      svc({ name: "showcase-langgraph-python" }),
+      svc({ name: "showcase-crewai", publicUrl: "http://crewai:10000" }),
+    ]);
+    const enumerate = createServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+      driverKind: "e2e_smoke",
+      probeKeyPrefix: "smoke",
+      filter: { namePrefix: "showcase-" },
+    });
+
+    const specs = await enumerate(CTX);
+
+    expect(specs).toHaveLength(2);
+    const lg = specs.find((s) => s.serviceSlug === "langgraph-python");
+    expect(lg).toBeDefined();
+    expect(lg?.driverKind).toBe("e2e_smoke");
+    expect(lg?.probeKey).toBe("smoke:langgraph-python");
+    expect(lg?.driverInputs?.key).toBe("smoke:langgraph-python");
+    expect(lg?.driverInputs?.backendUrl).toBe(
+      "http://langgraph-python:10000",
+    );
+
+    const cr = specs.find((s) => s.serviceSlug === "crewai");
+    expect(cr?.probeKey).toBe("smoke:crewai");
+    expect(cr?.driverKind).toBe("e2e_smoke");
+  });
+
+  it("passes the param-supplied filter (namePrefix + nameExcludes) to the source", async () => {
+    const source = fakeSource([svc()]);
+    const filter = {
+      namePrefix: "showcase-",
+      nameExcludes: ["showcase-harness", "showcase-shell"],
+    } as const;
+    const enumerate = createServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+      driverKind: "e2e_smoke",
+      probeKeyPrefix: "smoke",
+      filter,
+    });
+
+    await enumerate(CTX);
+
+    expect(source.configs).toHaveLength(1);
+    const cfg = source.configs[0] as {
+      namePrefix?: string;
+      nameExcludes?: string[];
+    };
+    expect(cfg.namePrefix).toBe("showcase-");
+    expect(cfg.nameExcludes).toEqual([...filter.nameExcludes]);
+  });
+
+  it("accepts a function probeKey prefix builder", async () => {
+    const source = fakeSource([svc({ name: "showcase-langgraph-python" })]);
+    const enumerate = createServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+      driverKind: "e2e_deep",
+      probeKeyPrefix: (slug) => `deep-${slug}`,
+      filter: { namePrefix: "showcase-" },
+    });
+
+    const specs = await enumerate(CTX);
+    const lg = specs.find((s) => s.serviceSlug === "langgraph-python");
+    expect(lg?.probeKey).toBe("deep-langgraph-python");
+    expect(lg?.driverInputs?.key).toBe("deep-langgraph-python");
   });
 });

--- a/showcase/harness/src/fleet/control-plane/catalog-enumerator.test.ts
+++ b/showcase/harness/src/fleet/control-plane/catalog-enumerator.test.ts
@@ -233,9 +233,7 @@ describe("createServiceEnumerator (generic seam)", () => {
     expect(lg?.driverKind).toBe("e2e_smoke");
     expect(lg?.probeKey).toBe("smoke:langgraph-python");
     expect(lg?.driverInputs?.key).toBe("smoke:langgraph-python");
-    expect(lg?.driverInputs?.backendUrl).toBe(
-      "http://langgraph-python:10000",
-    );
+    expect(lg?.driverInputs?.backendUrl).toBe("http://langgraph-python:10000");
 
     const cr = specs.find((s) => s.serviceSlug === "crewai");
     expect(cr?.probeKey).toBe("smoke:crewai");

--- a/showcase/harness/src/fleet/control-plane/catalog-enumerator.ts
+++ b/showcase/harness/src/fleet/control-plane/catalog-enumerator.ts
@@ -93,6 +93,16 @@ export const D6_DISCOVERY_FILTER = {
   ],
 } as const;
 
+/**
+ * A discovery service-set filter — the `namePrefix` / `nameExcludes` block the
+ * discovery source narrows on. Shared by the d6 wrapper deps and the generic
+ * enumerator params so the shape stays in one place.
+ */
+export interface ServiceSetFilter {
+  namePrefix?: string;
+  nameExcludes?: readonly string[];
+}
+
 export interface D6ServiceEnumeratorDeps {
   /** The discovery source to enumerate (production: `railwayServicesSource`). */
   source: DiscoverySource<RailwayServiceInfo>;
@@ -105,7 +115,7 @@ export interface D6ServiceEnumeratorDeps {
    * Service-set filter. Defaults to `D6_DISCOVERY_FILTER`. Exposed so a test
    * (or a future operator config) can narrow the set without editing the SSOT.
    */
-  filter?: { namePrefix?: string; nameExcludes?: readonly string[] };
+  filter?: ServiceSetFilter;
 }
 
 /**
@@ -135,10 +145,16 @@ export interface ServiceEnumeratorParams {
    * Service-set filter selecting which discovered services this family runs.
    * Carries the discovery source's `namePrefix` / `nameExcludes` block.
    */
-  filter: { namePrefix?: string; nameExcludes?: readonly string[] };
+  filter: ServiceSetFilter;
 }
 
-/** Resolve a `ProbeKeyPrefix` into the concrete dashboard key for a slug. */
+/**
+ * Resolve a `ProbeKeyPrefix` into the concrete dashboard key for a slug. The
+ * string arm OWNS the `:` separator (`<prefix>:<slug>`), so a string-form caller
+ * passes the bare prefix WITHOUT a trailing `:` (e.g. `"d6"`, not `"d6:"`). The
+ * function arm gives a family full control over the key shape (and is
+ * responsible for its own separators).
+ */
 function buildProbeKey(prefix: ProbeKeyPrefix, slug: string): string {
   return typeof prefix === "function" ? prefix(slug) : `${prefix}:${slug}`;
 }
@@ -192,14 +208,27 @@ function toDriverInputs(
  * in-process invoker's slug filter.
  *
  * `createD6ServiceEnumerator` is the d6 specialization of this seam; other
- * browser families (Phase 2) re-express their enumerators the same way, each
- * passing its own filter / kind / prefix.
+ * browser families re-express their enumerators the same way, each passing its
+ * own filter / kind / prefix.
  */
 export function createServiceEnumerator(
   params: ServiceEnumeratorParams,
 ): ServiceEnumerator {
   const { source, env, fetchImpl, logger, driverKind, probeKeyPrefix, filter } =
     params;
+
+  // Fail loud on a filter with no `namePrefix`: the discovery source treats an
+  // absent/empty prefix as "match everything", which would enumerate ALL
+  // services (the railway-services source documents this incident class). The
+  // d6 wrapper always passes a concrete filter, so it is unaffected. A future
+  // family that legitimately needs "match all" can revisit this; default to
+  // fail-loud now.
+  if (typeof filter.namePrefix !== "string" || filter.namePrefix === "") {
+    throw new Error(
+      `createServiceEnumerator: filter.namePrefix must be a non-empty string ` +
+        `(driverKind ${driverKind}); an absent/empty prefix would enumerate ALL services.`,
+    );
+  }
 
   return async (ctx: EnumerateContext): Promise<ServiceJobSpec[]> => {
     const discoveryCtx: DiscoveryContext = { fetchImpl, env, logger };
@@ -220,6 +249,15 @@ export function createServiceEnumerator(
       const slug = deriveSlug(svc.name);
       if (slugSet && !slugSet.has(slug) && !slugSet.has(svc.name)) continue;
       const probeKey = buildProbeKey(probeKeyPrefix, slug);
+      // A function-form prefix returning "" yields an empty probeKey (and
+      // `driverInputs.key`) — a bad dashboard/claim join key. Fail loud naming
+      // the offending slug rather than emitting a spec keyed "".
+      if (probeKey === "") {
+        throw new Error(
+          `createServiceEnumerator: probeKeyPrefix produced an empty probeKey ` +
+            `for service "${svc.name}" (slug "${slug}", driverKind ${driverKind}).`,
+        );
+      }
       const spec: ServiceJobSpec = {
         probeKey,
         serviceSlug: slug,
@@ -249,8 +287,11 @@ export function createServiceEnumerator(
 /**
  * Build the real d6 `ServiceEnumerator` — a thin specialization of
  * `createServiceEnumerator` with the d6 filter, the `e2e_d6` driver kind, and
- * the `d6:<slug>` probeKey prefix. d6 behavior is BYTE-IDENTICAL to the prior
- * hardwired implementation (same services, same filter, same kind, same keys).
+ * the `d6:<slug>` probeKey prefix. The produced SPECS are identical to the prior
+ * hardwired implementation (same services, same filter, same kind, same keys);
+ * the only observable change is the diagnostic log line — the generic
+ * enumerator's `fleet.control-plane.catalog-enumerated` log additionally carries
+ * a `driverKind` field (the specs themselves are unchanged).
  */
 export function createD6ServiceEnumerator(
   deps: D6ServiceEnumeratorDeps,

--- a/showcase/harness/src/fleet/control-plane/catalog-enumerator.ts
+++ b/showcase/harness/src/fleet/control-plane/catalog-enumerator.ts
@@ -109,6 +109,41 @@ export interface D6ServiceEnumeratorDeps {
 }
 
 /**
+ * Build the dashboard `probeKey` for a given service slug. A bare string is
+ * treated as a prefix (`<prefix>:<slug>` — the d6 `d6:<slug>` convention); a
+ * function gives a family full control over the key shape. The same value is
+ * stamped onto `driverInputs.key` so the driver emits the exact dashboard keys.
+ */
+export type ProbeKeyPrefix = string | ((slug: string) => string);
+
+export interface ServiceEnumeratorParams {
+  /** The discovery source to enumerate (production: `railwayServicesSource`). */
+  source: DiscoverySource<RailwayServiceInfo>;
+  /** Frozen env snapshot threaded to the discovery context. */
+  env: Readonly<Record<string, string | undefined>>;
+  /** Fetch impl threaded to the discovery context (tests stub network). */
+  fetchImpl: typeof fetch;
+  logger: Logger;
+  /** The driver kind every enumerated spec runs under (e.g. `e2e_d6`). */
+  driverKind: string;
+  /**
+   * Builds the dashboard `probeKey` (and `driverInputs.key`) per service. A
+   * string is used as a `<prefix>:<slug>` prefix; a function gives full control.
+   */
+  probeKeyPrefix: ProbeKeyPrefix;
+  /**
+   * Service-set filter selecting which discovered services this family runs.
+   * Carries the discovery source's `namePrefix` / `nameExcludes` block.
+   */
+  filter: { namePrefix?: string; nameExcludes?: readonly string[] };
+}
+
+/** Resolve a `ProbeKeyPrefix` into the concrete dashboard key for a slug. */
+function buildProbeKey(prefix: ProbeKeyPrefix, slug: string): string {
+  return typeof prefix === "function" ? prefix(slug) : `${prefix}:${slug}`;
+}
+
+/**
  * Strip the `showcase-` prefix to derive the slug — mirrors the d6 driver's
  * `deriveSlug` and discovery's `deriveSlugFromServiceName` so the enumerated
  * `serviceSlug` / `probeKey` match the keys the dashboard already reads.
@@ -148,17 +183,23 @@ function toDriverInputs(
 }
 
 /**
- * Build the real d6 `ServiceEnumerator`. Each call enumerates the discovery
- * source under the d6 filter and maps every service to one `ServiceJobSpec`.
- * The `EnumerateContext.filter` (operator slug scoping on a triggered run) is
- * applied AFTER discovery so an operator can scope a manual run to a subset of
- * services without re-querying — mirroring the in-process invoker's slug filter.
+ * Build a generic per-service `ServiceEnumerator` parameterized by the
+ * service-set filter, the `driverKind`, and the `probeKey` prefix builder. Each
+ * call enumerates the discovery source under the filter and maps every service
+ * to one `ServiceJobSpec`. The `EnumerateContext.filter` (operator slug scoping
+ * on a triggered run) is applied AFTER discovery so an operator can scope a
+ * manual run to a subset of services without re-querying — mirroring the
+ * in-process invoker's slug filter.
+ *
+ * `createD6ServiceEnumerator` is the d6 specialization of this seam; other
+ * browser families (Phase 2) re-express their enumerators the same way, each
+ * passing its own filter / kind / prefix.
  */
-export function createD6ServiceEnumerator(
-  deps: D6ServiceEnumeratorDeps,
+export function createServiceEnumerator(
+  params: ServiceEnumeratorParams,
 ): ServiceEnumerator {
-  const { source, env, fetchImpl, logger } = deps;
-  const filter = deps.filter ?? D6_DISCOVERY_FILTER;
+  const { source, env, fetchImpl, logger, driverKind, probeKeyPrefix, filter } =
+    params;
 
   return async (ctx: EnumerateContext): Promise<ServiceJobSpec[]> => {
     const discoveryCtx: DiscoveryContext = { fetchImpl, env, logger };
@@ -178,11 +219,11 @@ export function createD6ServiceEnumerator(
     for (const svc of services) {
       const slug = deriveSlug(svc.name);
       if (slugSet && !slugSet.has(slug) && !slugSet.has(svc.name)) continue;
-      const probeKey = `d6:${slug}`;
+      const probeKey = buildProbeKey(probeKeyPrefix, slug);
       const spec: ServiceJobSpec = {
         probeKey,
         serviceSlug: slug,
-        driverKind: D6_DRIVER_KIND,
+        driverKind,
         driverInputs: toDriverInputs(svc, slug, probeKey),
       };
       // Forward the operator feature-type scoping to the worker as a cell
@@ -197,9 +238,33 @@ export function createD6ServiceEnumerator(
     logger.info("fleet.control-plane.catalog-enumerated", {
       runId: ctx.runId,
       triggered: ctx.triggered,
+      driverKind,
       discovered: services.length,
       enqueueable: specs.length,
     });
     return specs;
   };
+}
+
+/**
+ * Build the real d6 `ServiceEnumerator` — a thin specialization of
+ * `createServiceEnumerator` with the d6 filter, the `e2e_d6` driver kind, and
+ * the `d6:<slug>` probeKey prefix. d6 behavior is BYTE-IDENTICAL to the prior
+ * hardwired implementation (same services, same filter, same kind, same keys).
+ */
+export function createD6ServiceEnumerator(
+  deps: D6ServiceEnumeratorDeps,
+): ServiceEnumerator {
+  const { source, env, fetchImpl, logger } = deps;
+  const filter = deps.filter ?? D6_DISCOVERY_FILTER;
+
+  return createServiceEnumerator({
+    source,
+    env,
+    fetchImpl,
+    logger,
+    driverKind: D6_DRIVER_KIND,
+    probeKeyPrefix: "d6",
+    filter,
+  });
 }

--- a/showcase/harness/src/fleet/control-plane/control-plane.test.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.test.ts
@@ -254,6 +254,67 @@ describe("createControlPlane.start", () => {
   });
 });
 
+describe("createControlPlane — multiple producer schedules", () => {
+  it("registers one scheduler entry per schedule with its own cron + producer", async () => {
+    const producerA = makeFakeProducer();
+    const producerB = makeFakeProducer();
+    const scheduler = makeFakeScheduler();
+    const cp = createControlPlane({
+      producer: producerA,
+      consumer: makeFakeConsumer(),
+      scheduler,
+      logger: SILENT_LOGGER,
+      schedules: [
+        { scheduleId: "fleet-d6-producer", cron: "40 * * * *", producer: producerA },
+        { scheduleId: "fleet-smoke-producer", cron: "*/15 * * * *", producer: producerB },
+      ],
+      setIntervalImpl: makeFakeTimers().setIntervalImpl,
+    });
+    cp.start();
+
+    expect(scheduler.entries.size).toBe(2);
+    const a = scheduler.entries.get("fleet-d6-producer");
+    const b = scheduler.entries.get("fleet-smoke-producer");
+    expect(a?.cron).toBe("40 * * * *");
+    expect(b?.cron).toBe("*/15 * * * *");
+
+    // Each handler drives ITS producer's tick.
+    await a?.handler();
+    expect(producerA.ticks).toBe(1);
+    expect(producerB.ticks).toBe(0);
+    await b?.handler();
+    expect(producerB.ticks).toBe(1);
+
+    // Both producers were started.
+    expect(producerA.started).toBe(true);
+    expect(producerB.started).toBe(true);
+  });
+
+  it("stop() unregisters every schedule and stops every producer", async () => {
+    const producerA = makeFakeProducer();
+    const producerB = makeFakeProducer();
+    const scheduler = makeFakeScheduler();
+    const cp = createControlPlane({
+      producer: producerA,
+      consumer: makeFakeConsumer(),
+      scheduler,
+      logger: SILENT_LOGGER,
+      schedules: [
+        { scheduleId: "fleet-d6-producer", cron: "40 * * * *", producer: producerA },
+        { scheduleId: "fleet-smoke-producer", cron: "*/15 * * * *", producer: producerB },
+      ],
+      setIntervalImpl: makeFakeTimers().setIntervalImpl,
+    });
+    cp.start();
+    await cp.stop();
+
+    expect(scheduler.entries.has("fleet-d6-producer")).toBe(false);
+    expect(scheduler.entries.has("fleet-smoke-producer")).toBe(false);
+    expect(producerA.stopped).toBe(true);
+    expect(producerB.stopped).toBe(true);
+  });
+});
+
 describe("createControlPlane.stop", () => {
   it("unregisters the producer tick, stops the producer, and clears the consumer timer", async () => {
     const producer = makeFakeProducer();

--- a/showcase/harness/src/fleet/control-plane/control-plane.test.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.test.ts
@@ -265,8 +265,16 @@ describe("createControlPlane — multiple producer schedules", () => {
       scheduler,
       logger: SILENT_LOGGER,
       schedules: [
-        { scheduleId: "fleet-d6-producer", cron: "40 * * * *", producer: producerA },
-        { scheduleId: "fleet-smoke-producer", cron: "*/15 * * * *", producer: producerB },
+        {
+          scheduleId: "fleet-d6-producer",
+          cron: "40 * * * *",
+          producer: producerA,
+        },
+        {
+          scheduleId: "fleet-smoke-producer",
+          cron: "*/15 * * * *",
+          producer: producerB,
+        },
       ],
       setIntervalImpl: makeFakeTimers().setIntervalImpl,
     });
@@ -300,8 +308,16 @@ describe("createControlPlane — multiple producer schedules", () => {
       scheduler,
       logger: SILENT_LOGGER,
       schedules: [
-        { scheduleId: "fleet-d6-producer", cron: "40 * * * *", producer: producerA },
-        { scheduleId: "fleet-smoke-producer", cron: "*/15 * * * *", producer: producerB },
+        {
+          scheduleId: "fleet-d6-producer",
+          cron: "40 * * * *",
+          producer: producerA,
+        },
+        {
+          scheduleId: "fleet-smoke-producer",
+          cron: "*/15 * * * *",
+          producer: producerB,
+        },
       ],
       setIntervalImpl: makeFakeTimers().setIntervalImpl,
     });

--- a/showcase/harness/src/fleet/control-plane/control-plane.test.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.test.ts
@@ -331,6 +331,174 @@ describe("createControlPlane — multiple producer schedules", () => {
   });
 });
 
+// ── Multi-schedule seam hardening (best-effort / fail-loud bar) ─────────────
+describe("createControlPlane — multi-schedule hardening", () => {
+  // A1: one producer's stop() (or unregister) rejecting must NOT abort teardown
+  // of later schedules — best-effort teardown completes all entries.
+  it("stop() still tears down later schedules when an earlier unregister rejects", async () => {
+    const producerA = makeFakeProducer();
+    const producerB = makeFakeProducer();
+    const scheduler = makeFakeScheduler();
+    // Make the FIRST schedule's unregister reject.
+    const realUnregister = scheduler.unregister.bind(scheduler);
+    scheduler.unregister = (async (id: string) => {
+      if (id === "fleet-d6-producer") throw new Error("unregister boom");
+      return realUnregister(id);
+    }) as typeof scheduler.unregister;
+
+    const cp = createControlPlane({
+      producer: producerA,
+      consumer: makeFakeConsumer(),
+      scheduler,
+      logger: SILENT_LOGGER,
+      schedules: [
+        {
+          scheduleId: "fleet-d6-producer",
+          cron: "40 * * * *",
+          producer: producerA,
+        },
+        {
+          scheduleId: "fleet-smoke-producer",
+          cron: "*/15 * * * *",
+          producer: producerB,
+        },
+      ],
+      setIntervalImpl: makeFakeTimers().setIntervalImpl,
+    });
+    cp.start();
+    await cp.stop();
+
+    // The second schedule is still unregistered AND its producer still stopped,
+    // and the first producer's stop() still ran despite its unregister rejecting.
+    expect(scheduler.entries.has("fleet-smoke-producer")).toBe(false);
+    expect(producerB.stopped).toBe(true);
+    expect(producerA.stopped).toBe(true);
+  });
+
+  it("stop() still stops later producers when an earlier producer.stop() rejects", async () => {
+    const producerA = makeFakeProducer();
+    const producerB = makeFakeProducer();
+    // Make the FIRST producer's stop() reject.
+    producerA.stop = async () => {
+      throw new Error("producer stop boom");
+    };
+    const scheduler = makeFakeScheduler();
+    const cp = createControlPlane({
+      producer: producerA,
+      consumer: makeFakeConsumer(),
+      scheduler,
+      logger: SILENT_LOGGER,
+      schedules: [
+        {
+          scheduleId: "fleet-d6-producer",
+          cron: "40 * * * *",
+          producer: producerA,
+        },
+        {
+          scheduleId: "fleet-smoke-producer",
+          cron: "*/15 * * * *",
+          producer: producerB,
+        },
+      ],
+      setIntervalImpl: makeFakeTimers().setIntervalImpl,
+    });
+    cp.start();
+    await cp.stop();
+
+    expect(scheduler.entries.has("fleet-smoke-producer")).toBe(false);
+    expect(producerB.stopped).toBe(true);
+  });
+
+  // A2: an invalid cron must fail BEFORE any producer is started, and must not
+  // leave `started` latched true (a retry must be able to start cleanly).
+  it("start() throws on an invalid cron BEFORE starting any producer", () => {
+    const producerA = makeFakeProducer();
+    const producerB = makeFakeProducer();
+    const scheduler = makeFakeScheduler();
+    const cp = createControlPlane({
+      producer: producerA,
+      consumer: makeFakeConsumer(),
+      scheduler,
+      logger: SILENT_LOGGER,
+      schedules: [
+        { scheduleId: "fleet-ok", cron: "40 * * * *", producer: producerA },
+        { scheduleId: "fleet-bad", cron: "not a cron", producer: producerB },
+      ],
+      setIntervalImpl: makeFakeTimers().setIntervalImpl,
+    });
+
+    expect(() => cp.start()).toThrow(/fleet-bad/);
+    // No producer was started — validation happens up-front.
+    expect(producerA.started).toBe(false);
+    expect(producerB.started).toBe(false);
+    // Nothing registered.
+    expect(scheduler.entries.size).toBe(0);
+
+    // `started` is not latched true: a subsequent start() with valid crons works.
+    const cpOk = createControlPlane({
+      producer: producerA,
+      consumer: makeFakeConsumer(),
+      scheduler: makeFakeScheduler(),
+      logger: SILENT_LOGGER,
+      schedules: [
+        { scheduleId: "fleet-ok", cron: "40 * * * *", producer: producerA },
+      ],
+      setIntervalImpl: makeFakeTimers().setIntervalImpl,
+    });
+    expect(() => cpOk.start()).not.toThrow();
+    expect(producerA.started).toBe(true);
+  });
+
+  // A3: duplicate scheduleId must throw loudly (replace-semantics would silently
+  // collapse two producers onto one scheduler entry).
+  it("throws on a duplicate scheduleId", () => {
+    const producerA = makeFakeProducer();
+    const producerB = makeFakeProducer();
+    expect(() =>
+      createControlPlane({
+        producer: producerA,
+        consumer: makeFakeConsumer(),
+        scheduler: makeFakeScheduler(),
+        logger: SILENT_LOGGER,
+        schedules: [
+          { scheduleId: "dup", cron: "40 * * * *", producer: producerA },
+          { scheduleId: "dup", cron: "*/15 * * * *", producer: producerB },
+        ],
+        setIntervalImpl: makeFakeTimers().setIntervalImpl,
+      }),
+    ).toThrow(/dup/);
+  });
+
+  // A4: distinguish undefined (→ d6 default) from an explicit [] (caller error).
+  it("throws when schedules is an explicit empty array", () => {
+    expect(() =>
+      createControlPlane({
+        producer: makeFakeProducer(),
+        consumer: makeFakeConsumer(),
+        scheduler: makeFakeScheduler(),
+        logger: SILENT_LOGGER,
+        schedules: [],
+        setIntervalImpl: makeFakeTimers().setIntervalImpl,
+      }),
+    ).toThrow(/empty/i);
+  });
+
+  it("omitting schedules still yields the single d6 schedule (unchanged)", () => {
+    const producer = makeFakeProducer();
+    const scheduler = makeFakeScheduler();
+    const cp = createControlPlane({
+      producer,
+      consumer: makeFakeConsumer(),
+      scheduler,
+      logger: SILENT_LOGGER,
+      setIntervalImpl: makeFakeTimers().setIntervalImpl,
+    });
+    cp.start();
+    expect(scheduler.entries.size).toBe(1);
+    expect(scheduler.entries.has(FLEET_PRODUCER_SCHEDULE_ID)).toBe(true);
+  });
+});
+
 describe("createControlPlane.stop", () => {
   it("unregisters the producer tick, stops the producer, and clears the consumer timer", async () => {
     const producer = makeFakeProducer();

--- a/showcase/harness/src/fleet/control-plane/control-plane.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.ts
@@ -96,8 +96,26 @@ export type PriorStateResolver = (
   aggregateKey: string,
 ) => Promise<State | null | undefined> | State | null | undefined;
 
+/**
+ * One producer schedule entry: a `producer` registered on the scheduler under
+ * `scheduleId` at `cron`. The control-plane registers each entry as its own
+ * scheduler handler so N producers can tick on N distinct cadences (the d6
+ * producer at `40 * * * *`, future browser families on their own crons).
+ */
+export interface ProducerSchedule {
+  /** Scheduler entry id this producer registers under (must be unique). */
+  scheduleId: string;
+  /** Cron cadence this producer ticks on. */
+  cron: string;
+  /** The producer whose `tick` the scheduler handler drives. */
+  producer: JobProducer;
+}
+
 export interface ControlPlaneDeps {
-  /** Job producer (S4). Injected pre-built so tests pass a fake. */
+  /**
+   * Job producer (S4) for the degenerate single-schedule (d6) case. Injected
+   * pre-built so tests pass a fake. Ignored when `schedules` is provided.
+   */
   producer: JobProducer;
   /** Result consumer (worker->aggregator bridge). Injected pre-built. */
   consumer: ResultConsumer;
@@ -106,6 +124,15 @@ export interface ControlPlaneDeps {
   logger: Logger;
   /** Producer cron cadence. Default `DEFAULT_PRODUCER_CRON`. */
   producerCron?: string;
+  /**
+   * The producer schedules to register. When provided, the control-plane
+   * registers each entry as its own scheduler handler on its own cron — N
+   * producers on N cadences. When omitted, it degenerates to the single d6
+   * schedule built from `producer` / `producerCron` (scheduleId
+   * `FLEET_PRODUCER_SCHEDULE_ID`), preserving the historic single-producer
+   * behavior byte-for-byte.
+   */
+  schedules?: readonly ProducerSchedule[];
   /** Result-consumer poll interval (ms). Default `DEFAULT_CONSUMER_INTERVAL_MS`. */
   consumerIntervalMs?: number;
   /**
@@ -197,6 +224,19 @@ export function buildJobProducer(deps: {
 export function createControlPlane(deps: ControlPlaneDeps): ControlPlane {
   const { producer, consumer, scheduler, logger } = deps;
   const producerCron = deps.producerCron ?? DEFAULT_PRODUCER_CRON;
+  // Normalize to an array of schedules. The degenerate single-d6 case (no
+  // `schedules` passed) becomes a one-element array on FLEET_PRODUCER_SCHEDULE_ID
+  // at `producerCron`, so the historic single-producer behavior is identical.
+  const schedules: readonly ProducerSchedule[] =
+    deps.schedules && deps.schedules.length > 0
+      ? deps.schedules
+      : [
+          {
+            scheduleId: FLEET_PRODUCER_SCHEDULE_ID,
+            cron: producerCron,
+            producer,
+          },
+        ];
   const consumerIntervalMs =
     deps.consumerIntervalMs ?? DEFAULT_CONSUMER_INTERVAL_MS;
   const fleetHealthIntervalMs =
@@ -365,20 +405,24 @@ export function createControlPlane(deps: ControlPlaneDeps): ControlPlane {
     start() {
       if (started) return;
       started = true;
-      producer.start();
-      // The producer's tick is the scheduler handler — cron cadence drives
-      // runs; the tick also gates sweepExpired internally.
-      scheduler.register({
-        id: FLEET_PRODUCER_SCHEDULE_ID,
-        cron: producerCron,
-        // The scheduler handler returns void|RunSummary; the producer's tick
-        // returns a richer TickResult, so adapt by awaiting + discarding it
-        // (the producer logs its own per-tick outcome). Errors are swallowed
-        // by the scheduler's per-tick isolation, same as legacy handlers.
-        handler: async () => {
-          await producer.tick();
-        },
-      });
+      // Start each producer and register its tick as a scheduler handler — cron
+      // cadence drives runs; each producer's tick also gates sweepExpired
+      // internally. N schedules => N producers on N cadences (the degenerate
+      // single-d6 case is a one-element array).
+      for (const sched of schedules) {
+        sched.producer.start();
+        scheduler.register({
+          id: sched.scheduleId,
+          cron: sched.cron,
+          // The scheduler handler returns void|RunSummary; the producer's tick
+          // returns a richer TickResult, so adapt by awaiting + discarding it
+          // (the producer logs its own per-tick outcome). Errors are swallowed
+          // by the scheduler's per-tick isolation, same as legacy handlers.
+          handler: async () => {
+            await sched.producer.tick();
+          },
+        });
+      }
       // The consumer runs on its own finer interval so result latency isn't
       // bounded by the producer's cron cadence.
       consumerTimer = setIntervalFn(() => {
@@ -393,7 +437,10 @@ export function createControlPlane(deps: ControlPlaneDeps): ControlPlane {
         }, fleetHealthIntervalMs);
       }
       logger.info("fleet.control-plane.started", {
-        producerCron,
+        schedules: schedules.map((s) => ({
+          scheduleId: s.scheduleId,
+          cron: s.cron,
+        })),
         consumerIntervalMs,
         fleetHealth: fleetHealth !== undefined,
       });
@@ -410,12 +457,16 @@ export function createControlPlane(deps: ControlPlaneDeps): ControlPlane {
         clearIntervalFn(fleetHealthTimer);
         fleetHealthTimer = undefined;
       }
-      await scheduler.unregister(FLEET_PRODUCER_SCHEDULE_ID).catch((err) =>
-        logger.warn("fleet.control-plane.unregister-failed", {
-          err: err instanceof Error ? err.message : String(err),
-        }),
-      );
-      await producer.stop();
+      // Unregister every schedule and stop every producer (mirrors start()).
+      for (const sched of schedules) {
+        await scheduler.unregister(sched.scheduleId).catch((err) =>
+          logger.warn("fleet.control-plane.unregister-failed", {
+            scheduleId: sched.scheduleId,
+            err: err instanceof Error ? err.message : String(err),
+          }),
+        );
+        await sched.producer.stop();
+      }
       logger.info("fleet.control-plane.stopped");
     },
 

--- a/showcase/harness/src/fleet/control-plane/control-plane.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.ts
@@ -15,7 +15,8 @@
  *   3. AGGREGATE — `createResultAggregator` (S5), the ONLY writer of the
  *      authoritative dashboard status + run-history. The consumer runs on its
  *      OWN interval (sub-minute, finer than cron) since result latency should
- *      not be bounded by the producer's cron cadence.
+ *      not be bounded by any producer's cron cadence (one or more producers may
+ *      tick on distinct cadences).
  *
  * ── REQ-B: SURFACING DEAD-WORKER COMM ERRORS ───────────────────────────────
  * Two legs reclaim a crashed / lease-expired worker's job and synthesize a
@@ -42,6 +43,7 @@
  * Chromium of its own — `runControlPlane` constructs the real deps.
  */
 
+import { Cron } from "croner";
 import type { Logger, State } from "../../types/index.js";
 import type { Scheduler } from "../../scheduler/scheduler.js";
 import type { PoolCommError } from "../contracts.js";
@@ -171,9 +173,9 @@ export interface ControlPlaneDeps {
 
 /** A running control-plane: producer registered + consumer loop ticking. */
 export interface ControlPlane {
-  /** Start the producer + register its scheduler tick + start the consumer loop. */
+  /** Start each producer + register every schedule's scheduler tick + start the consumer loop. */
   start(): void;
-  /** Stop the consumer loop, unregister the producer tick, stop the producer. */
+  /** Stop the consumer loop, unregister every schedule's tick, stop each producer. */
   stop(): Promise<void>;
   /** Run one consumer cycle NOW (exposed for tests + opportunistic drains). */
   consumeOnce(): Promise<void>;
@@ -224,11 +226,20 @@ export function buildJobProducer(deps: {
 export function createControlPlane(deps: ControlPlaneDeps): ControlPlane {
   const { producer, consumer, scheduler, logger } = deps;
   const producerCron = deps.producerCron ?? DEFAULT_PRODUCER_CRON;
-  // Normalize to an array of schedules. The degenerate single-d6 case (no
-  // `schedules` passed) becomes a one-element array on FLEET_PRODUCER_SCHEDULE_ID
-  // at `producerCron`, so the historic single-producer behavior is identical.
+  // Normalize to an array of schedules. An OMITTED `schedules` (undefined)
+  // degenerates to the single-d6 case — a one-element array on
+  // FLEET_PRODUCER_SCHEDULE_ID at `producerCron`, so the historic
+  // single-producer behavior is identical. An EXPLICIT empty array is a caller
+  // error (intent erased), distinct from omission — fail loud rather than
+  // silently coercing it to the d6 fallback.
+  if (deps.schedules !== undefined && deps.schedules.length === 0) {
+    throw new Error(
+      "createControlPlane: `schedules` provided but empty — pass at least one " +
+        "schedule, or omit `schedules` for the default single-d6 schedule.",
+    );
+  }
   const schedules: readonly ProducerSchedule[] =
-    deps.schedules && deps.schedules.length > 0
+    deps.schedules !== undefined
       ? deps.schedules
       : [
           {
@@ -237,6 +248,23 @@ export function createControlPlane(deps: ControlPlaneDeps): ControlPlane {
             producer,
           },
         ];
+  // `ProducerSchedule.scheduleId` is documented "must be unique"; the scheduler
+  // registers by id with replace-semantics, so two entries sharing an id would
+  // silently collapse (one family's producer runs but never ticks). Enforce
+  // uniqueness loudly at construction, naming the offending id(s).
+  const seenScheduleIds = new Set<string>();
+  const duplicateScheduleIds = new Set<string>();
+  for (const sched of schedules) {
+    if (seenScheduleIds.has(sched.scheduleId)) {
+      duplicateScheduleIds.add(sched.scheduleId);
+    }
+    seenScheduleIds.add(sched.scheduleId);
+  }
+  if (duplicateScheduleIds.size > 0) {
+    throw new Error(
+      `createControlPlane: duplicate scheduleId(s) — ${[...duplicateScheduleIds].join(", ")}; each ProducerSchedule.scheduleId must be unique.`,
+    );
+  }
   const consumerIntervalMs =
     deps.consumerIntervalMs ?? DEFAULT_CONSUMER_INTERVAL_MS;
   const fleetHealthIntervalMs =
@@ -404,11 +432,39 @@ export function createControlPlane(deps: ControlPlaneDeps): ControlPlane {
   return {
     start() {
       if (started) return;
+      // Pre-validate EVERY schedule's cron BEFORE starting any producer. A bad
+      // cron would otherwise throw mid-loop (after `scheduler.register`'s own
+      // validateCron), leaving earlier producers started+registered, the timers
+      // unset, and `started` latched true — an unrecoverable half-started state.
+      // Croner throws synchronously on bad syntax; instantiate a paused job per
+      // schedule and aggregate the offending ids into one clear error. This is
+      // the same validation the scheduler applies, run up-front so start() is
+      // all-or-nothing.
+      const invalidCrons: string[] = [];
+      for (const sched of schedules) {
+        try {
+          new Cron(sched.cron, { paused: true });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          logger.error("fleet.control-plane.invalid-cron", {
+            scheduleId: sched.scheduleId,
+            cron: sched.cron,
+            err: msg,
+          });
+          invalidCrons.push(`${sched.scheduleId} (${sched.cron}: ${msg})`);
+        }
+      }
+      if (invalidCrons.length > 0) {
+        throw new Error(
+          `createControlPlane.start: invalid cron(s) — ${invalidCrons.join("; ")}`,
+        );
+      }
       started = true;
       // Start each producer and register its tick as a scheduler handler — cron
       // cadence drives runs; each producer's tick also gates sweepExpired
       // internally. N schedules => N producers on N cadences (the degenerate
-      // single-d6 case is a one-element array).
+      // single-d6 case is a one-element array). All crons are pre-validated
+      // above, so this loop can't throw partway and leave a half-started plane.
       for (const sched of schedules) {
         sched.producer.start();
         scheduler.register({
@@ -458,6 +514,11 @@ export function createControlPlane(deps: ControlPlaneDeps): ControlPlane {
         fleetHealthTimer = undefined;
       }
       // Unregister every schedule and stop every producer (mirrors start()).
+      // Teardown is BEST-EFFORT: one schedule's unregister OR producer.stop()
+      // rejecting must not abort teardown of the later schedules (that would
+      // leak live cron handlers + running producers). Guard each leg per entry
+      // — mirror the unregister guard onto producer.stop() — so every entry is
+      // torn down even if an earlier one throws.
       for (const sched of schedules) {
         await scheduler.unregister(sched.scheduleId).catch((err) =>
           logger.warn("fleet.control-plane.unregister-failed", {
@@ -465,7 +526,14 @@ export function createControlPlane(deps: ControlPlaneDeps): ControlPlane {
             err: err instanceof Error ? err.message : String(err),
           }),
         );
-        await sched.producer.stop();
+        try {
+          await sched.producer.stop();
+        } catch (err) {
+          logger.error("fleet.control-plane.producer-stop-failed", {
+            scheduleId: sched.scheduleId,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
       }
       logger.info("fleet.control-plane.stopped");
     },


### PR DESCRIPTION
## Summary

Producer-side foundation for fleet framework item 3b. Two **behavior-preserving** generalizations that make the seam capable of multiple browser families and multiple producer cadences, while keeping the d6 case **byte-identical**. No wiring is flipped on yet (see Out of Scope).

### 1. Parameterized service enumerator
`showcase/harness/src/fleet/control-plane/catalog-enumerator.ts`
- New generic `createServiceEnumerator(params)` (catalog-enumerator.ts:215) takes the service-set `filter`, the `driverKind`, and a `probeKeyPrefix` (string prefix → `<prefix>:<slug>`, or a builder fn).
- `createD6ServiceEnumerator` (catalog-enumerator.ts:280) is re-expressed as a thin call passing the d6 params: `D6_DRIVER_KIND` (`e2e_d6`), prefix `"d6"` (→ `d6:<slug>`), and `D6_DISCOVERY_FILTER`. d6 output is unchanged — same services, same filter, same kind, same keys.

### 2. Control-plane accepts an array of producer schedules
`showcase/harness/src/fleet/control-plane/control-plane.ts`
- New `ProducerSchedule` type (`{ scheduleId, cron, producer }`) + a `schedules?` dep on `ControlPlaneDeps`.
- `createControlPlane` normalizes to an array (control-plane.ts:~232); omitting `schedules` degenerates to the single d6 schedule on `FLEET_PRODUCER_SCHEDULE_ID` (`fleet-job-producer`) @ `40 * * * *` — current behavior preserved exactly.
- `start()` / `stop()` iterate the array, registering/unregistering each scheduler entry and starting/stopping each producer.

## Out of scope (deferred — gated on other in-flight PRs)
- **No `runControlPlane` wiring** to actually PASS multiple schedules — that edit conflicts with in-flight **#5284** (which edits `runControlPlane`) and is deferred. This PR only makes `control-plane.ts` *capable* of N schedules + generalizes the enumerator seam; the wiring lands later.
- No `e2e_smoke` / `e2e_demos` / `e2e_deep` enumerators or producers (Phase 2).
- No changes to `worker-loop.ts` / `payload-mapper.ts` / `probe-loader.ts` (other PRs own those).
- No driverKind constant / contract changes.

## Test plan
- [x] Red→green TDD: 3 new enumerator tests (generic kind/keys/filter/fn-prefix) + 2 new control-plane tests (N entries registered with distinct crons; stop tears all down) failed before impl, pass after.
- [x] Equivalence: all pre-existing d6-enumerator + single-schedule control-plane tests pass unchanged.
- [x] Full harness suite green: **2078 passed** (119 files).
- [x] `tsc -p tsconfig.build.json` clean (exit 0).
- [x] Only the 4 intended files changed; no lockfile drift.

Do not merge — producer-side foundation only; wiring follows after #5284 lands.