### PR TITLE
fix(showcase): track interim harness-legacy service in railway-envs SSOT (unblock harness builds)

### DIFF
--- a/showcase/scripts/__tests__/emit-railway-envs-json.test.ts
+++ b/showcase/scripts/__tests__/emit-railway-envs-json.test.ts
@@ -25,7 +25,7 @@ describe("emit-railway-envs-json", () => {
     expect(json.projectId).toBe("6f8c6bff-a80d-4f8f-b78d-50b32bcf4479");
     expect(json.envIds.staging).toBe("8edfef02-ea09-4a20-8689-261f21cc2849");
     expect(json.envIds.prod).toBe("b14919f4-6417-429f-848d-c6ae2201e04f");
-    expect(json.services.length).toBe(28);
+    expect(json.services.length).toBe(29);
     const docs = json.services.find((s: { name: string }) => s.name === "docs");
     expect(docs.domains.staging).toBe("docs.staging.copilotkit.ai");
     expect(docs.domains.prod).toBe("docs.copilotkit.ai");

--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -22,11 +22,13 @@ import type { ServiceEntry } from "../railway-envs";
 describe("ServiceEntry gateIgnore field", () => {
   it("is optional on the type and defaults to falsy when unset", () => {
     // Every real SSOT entry has gateIgnore unset (undefined / falsy),
-    // EXCEPT the staging-only `showcase-harness-worker` pool-fleet worker,
-    // which is deliberately gateIgnore:true (no prod instance, no public
-    // domain — it does not fit the symmetric dual-env shape the gate
-    // validates). See its SSOT entry in railway-envs.ts for the rationale.
-    const GATE_IGNORED = new Set(["showcase-harness-worker"]);
+    // EXCEPT two deliberately gateIgnore:true entries: the staging-only
+    // `showcase-harness-worker` pool-fleet worker (no public domain, does not
+    // fit the symmetric dual-env shape the gate validates) and the interim
+    // `harness-legacy` fleet-migration bridge (runs a pinned out-of-band
+    // digest, not the canonical :latest/@sha256 shape). See their SSOT
+    // entries in railway-envs.ts for the rationale.
+    const GATE_IGNORED = new Set(["showcase-harness-worker", "harness-legacy"]);
     for (const [name, entry] of Object.entries(SERVICES)) {
       const gi = (entry as ServiceEntry).gateIgnore;
       if (GATE_IGNORED.has(name)) {
@@ -232,15 +234,17 @@ describe("WS-C: all gate-managed services gateValidated, with correct overrides"
     ["harness", "showcase-harness"],
   ] as const;
 
-  it("has 28 services in the SSOT", () => {
-    expect(Object.keys(SERVICES)).toHaveLength(28);
+  it("has 29 services in the SSOT", () => {
+    expect(Object.keys(SERVICES)).toHaveLength(29);
   });
 
   it("marks every gate-managed service gateValidated (no Phase-2 holdouts)", () => {
-    // The staging-only `showcase-harness-worker` is the sole intentional
-    // gateValidated:false entry (it is gateIgnore:true — no prod instance,
-    // no public domain). Every OTHER service must be gateValidated:true.
-    const GATE_IGNORED = new Set(["showcase-harness-worker"]);
+    // Two intentional gateValidated:false entries: the staging-only
+    // `showcase-harness-worker` (gateIgnore:true — no public domain) and the
+    // interim `harness-legacy` fleet-migration bridge (gateIgnore:true — runs
+    // a pinned out-of-band digest). Every OTHER service must be
+    // gateValidated:true.
+    const GATE_IGNORED = new Set(["showcase-harness-worker", "harness-legacy"]);
     const unvalidated = Object.entries(SERVICES)
       .filter(
         ([name, entry]) => !entry.gateValidated && !GATE_IGNORED.has(name),

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -116,6 +116,27 @@
       }
     },
     {
+      "name": "harness-legacy",
+      "serviceId": "11279eba-97eb-417e-82a5-7cb4254eb147",
+      "prodInstanceId": "3d125700-a08d-4a7f-904b-c13f3f7cc0fc",
+      "stagingInstanceId": "ed184024-fdfa-4b6f-bb51-37d6648e0beb",
+      "ciBuilt": false,
+      "gateValidated": false,
+      "repoNameOverride": {
+        "prod": "showcase-harness",
+        "staging": "showcase-harness"
+      },
+      "domains": {
+        "staging": "harness-staging-2ee4.up.railway.app",
+        "prod": "showcase-harness-production.up.railway.app"
+      },
+      "probe": {
+        "staging": false,
+        "prod": false,
+        "driver": "harness"
+      }
+    },
+    {
       "name": "pocketbase",
       "serviceId": "ba11e854-d695-4738-9a45-2b0776788824",
       "prodInstanceId": "1ee376e2-13f2-4464-801e-d0aa0bf76532",

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -54,9 +54,9 @@ describe("railway-envs SSOT", () => {
     expect(ENV_IDS.staging).toBe(STAGING_ENV_ID);
   });
 
-  it("contains exactly 28 services", () => {
+  it("contains exactly 29 services", () => {
     const names = listServiceNames();
-    expect(names.length).toBe(28);
+    expect(names.length).toBe(29);
   });
 
   it("contains the expected canonical services", () => {

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -332,6 +332,55 @@ export const SERVICES: Record<
     // probe and the Railway-internal /health healthcheck.
     probe: { staging: false, prod: false, driver: "harness" },
   },
+  "harness-legacy": {
+    serviceId: "11279eba-97eb-417e-82a5-7cb4254eb147",
+    // INTERIM service (fleet-migration bridge). This is the legacy all-probe
+    // harness (HARNESS_ROLE unset) stood up to keep the non-d6 probe coverage
+    // live while the pool-fleet migration proceeds. It runs a PINNED pre-fleet
+    // `showcase-harness` image digest set out-of-band — it is NOT CI-built —
+    // and will be torn down (removed from this SSOT and from Railway) at
+    // migration end. Real serviceInstance IDs exist for BOTH envs on Railway
+    // (resolved 2026-06-05 via GraphQL); we record both. gateIgnore keeps the
+    // image-ref gate from validating either instance's (out-of-band) ref, and
+    // ciBuilt:false keeps it out of the default CI_BUILT_SERVICES redeploy
+    // scope. The build only failed because the Railway→SSOT untracked-services
+    // check saw this service name with no SSOT entry; listing it here clears
+    // that without subjecting its pinned digest to the gate's shape check.
+    prodInstanceId: "3d125700-a08d-4a7f-904b-c13f3f7cc0fc",
+    stagingInstanceId: "ed184024-fdfa-4b6f-bb51-37d6648e0beb",
+    // Runs a pinned pre-fleet `showcase-harness` image digest, set
+    // out-of-band rather than tracked by showcase_build.yml. ciBuilt:false
+    // (no dedicated build slot — there is no `harness-legacy` build slot)
+    // and a repoNameOverride to `showcase-harness` so the image-ref shape
+    // resolves correctly if the gate ever validates it.
+    ciBuilt: false,
+    // gateIgnore: deliberately-untracked for the image-ref gate. This
+    // interim service runs a pinned digest (not the canonical :latest /
+    // @sha256 shape the gate enforces) and is short-lived. Listing it here
+    // (with gateIgnore) is what clears the "untracked Railway service"
+    // failure — findUntrackedServices treats any SSOT entry as known —
+    // WITHOUT triggering a false "missing from prod" failure from
+    // findMissingServices (which only checks gateValidated:true entries).
+    // Mirrors showcase-harness-worker exactly.
+    gateValidated: false,
+    gateIgnore: true,
+    repoNameOverride: {
+      prod: "showcase-harness",
+      staging: "showcase-harness",
+    },
+    // The schema requires both domains be set; point both at the
+    // control-plane harness staging/prod hosts purely to satisfy the
+    // no-scheme domain invariant. domainFor() is never called for this
+    // service because its probe is disabled in both envs (below) and
+    // verify-deploy skips probe:false services.
+    domains: {
+      staging: "harness-staging-2ee4.up.railway.app",
+      prod: "showcase-harness-production.up.railway.app",
+    },
+    // probe disabled in BOTH envs: this interim service's coverage is
+    // exercised out-of-band during the migration, not by verify-deploy.
+    probe: { staging: false, prod: false, driver: "harness" },
+  },
   pocketbase: {
     serviceId: "ba11e854-d695-4738-9a45-2b0776788824",
     prodInstanceId: "1ee376e2-13f2-4464-801e-d0aa0bf76532",


### PR DESCRIPTION
## Summary

The `showcase_build` workflow's pre-build `verify-image-refs` gate (SSOT = `showcase/scripts/railway-envs.ts`) was **failing all staging deploys** with `1 untracked Railway services`. The interim `harness-legacy` staging service (id `11279eba-97eb-417e-82a5-7cb4254eb147`, project `showcase`, env `staging`) exists on Railway but had no SSOT entry, so the Railway→SSOT drift check failed → build skipped → nothing deployed (this blocked PR #5283's merge build).

`harness-legacy` is the **interim legacy all-probe harness** (`HARNESS_ROLE` unset) stood up to keep non-d6 coverage live during the fleet migration. It is **not CI-built** (runs a pinned pre-fleet image digest set out-of-band) and will be torn down at migration end.

## Change

- Adds a `harness-legacy` entry to `SERVICES` mirroring the `showcase-harness-worker` precedent (PR #5280):
  - `ciBuilt: false` — not built by `showcase_build`; no dedicated build slot.
  - `gateIgnore: true` — deliberately-untracked for the image-ref gate. `findUntrackedServices` treats any SSOT entry as known, so this clears the "untracked" failure; `gateValidated: false` keeps `findMissingServices` from flagging it.
  - `repoNameOverride` → `showcase-harness` for both envs (same image-ref shape as the control-plane harness).
  - Real serviceInstance IDs recorded for both envs (resolved via Railway GraphQL); probe disabled in both envs.
- Regenerates `railway-envs.generated.json`.
- Updates service-count and gate-ignored carve-out assertions across the three affected test files (28 → 29 services; `harness-legacy` added to the two `GATE_IGNORED` sets).

## Verification

- **Live gate (red→green):** without the entry, `verify-railway-image-refs.ts` exits **1** with `harness-legacy is not in the SSOT`; with the entry it exits **0** — `✓ 54 env-scoped instances verified (2 skipped)`.
- **Full scripts test suite green:** 1771 passed (49 files), including `railway-envs.test.ts`, `verify-railway-image-refs.test.ts`, and `emit-railway-envs-json.test.ts`.
- **`emit --check`** confirms `railway-envs.generated.json` is in sync.
- **tsc** clean (`tsc --noEmit -p showcase/scripts/tsconfig.json`).

## Test plan

- [x] `npx tsx showcase/scripts/verify-railway-image-refs.ts` exits 0 against live Railway
- [x] `vitest run` in `showcase/scripts` fully green
- [x] `npx tsx showcase/scripts/emit-railway-envs-json.ts --check` passes
- [x] `tsc --noEmit -p showcase/scripts/tsconfig.json` clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)