### PR TITLE
feat(showcase): run e2e_smoke/e2e_demos/e2e_deep browser families on the fleet

### DIFF
--- a/showcase/harness/src/fleet/control-plane/catalog-enumerator.test.ts
+++ b/showcase/harness/src/fleet/control-plane/catalog-enumerator.test.ts
@@ -1,10 +1,19 @@
 import { describe, it, expect } from "vitest";
 import {
   createD6ServiceEnumerator,
+  createE2eSmokeServiceEnumerator,
+  createE2eDemosServiceEnumerator,
+  createE2eDeepServiceEnumerator,
   createServiceEnumerator,
   D6_DRIVER_KIND,
   D6_DISCOVERY_FILTER,
+  E2E_DEMOS_TIMEOUT_MS,
 } from "./catalog-enumerator.js";
+import {
+  E2E_SMOKE_DRIVER_KIND,
+  E2E_DEMOS_DRIVER_KIND,
+  E2E_DEEP_DRIVER_KIND,
+} from "../worker/payload-mapper.js";
 import type { DiscoverySource } from "../../probes/types.js";
 import type { RailwayServiceInfo } from "../../probes/discovery/railway-services.js";
 import type { EnumerateContext } from "./job-producer.js";
@@ -187,6 +196,9 @@ describe("createD6ServiceEnumerator", () => {
     // No redundant `publicUrl` key — backendUrl carries the value.
     expect(lg!.driverInputs).not.toHaveProperty("publicUrl");
     expect(lg!.driverInputs?.backendUrl).toBe("http://langgraph-python:10000");
+    // EQUIVALENCE: d6 conveys NO `timeout_ms` (only the demos family does) — the
+    // generic-seam `extraDriverInputs` change must not alter d6's emitted shape.
+    expect(lg!.driverInputs).not.toHaveProperty("timeout_ms");
   });
 
   it("produces a NON-EMPTY spec set for the real-shaped service catalog", async () => {
@@ -332,5 +344,169 @@ describe("createServiceEnumerator (generic seam)", () => {
     });
 
     await expect(enumerate(CTX)).rejects.toThrow(/langgraph-python/);
+  });
+});
+
+describe("createE2eSmokeServiceEnumerator", () => {
+  it("stamps the e2e_smoke kind + d4:<slug> probeKey and carries driver inputs", async () => {
+    const source = fakeSource([
+      svc({ name: "showcase-langgraph-python" }),
+      svc({ name: "showcase-crewai", publicUrl: "http://crewai:10000" }),
+    ]);
+    const enumerate = createE2eSmokeServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+    });
+
+    const specs = await enumerate(CTX);
+
+    expect(specs).toHaveLength(2);
+    const lg = specs.find((s) => s.serviceSlug === "langgraph-python");
+    expect(lg?.driverKind).toBe(E2E_SMOKE_DRIVER_KIND);
+    expect(lg?.probeKey).toBe("d4:langgraph-python");
+    expect(lg?.driverInputs?.key).toBe("d4:langgraph-python");
+    expect(lg?.driverInputs?.name).toBe("showcase-langgraph-python");
+    expect(lg?.driverInputs?.backendUrl).toBe("http://langgraph-python:10000");
+    expect(lg?.driverInputs?.demos).toEqual(["agentic_chat", "shared_state"]);
+    expect(lg?.driverInputs?.notSupportedFeatures).toEqual([]);
+    // Smoke conveys no outer-cap timeout.
+    expect(lg?.driverInputs).not.toHaveProperty("timeout_ms");
+
+    const cr = specs.find((s) => s.serviceSlug === "crewai");
+    expect(cr?.probeKey).toBe("d4:crewai");
+  });
+
+  it("passes the shared d6 discovery filter to the source", async () => {
+    const source = fakeSource([svc()]);
+    const enumerate = createE2eSmokeServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+    });
+    await enumerate(CTX);
+    const cfg = source.configs[0] as {
+      namePrefix?: string;
+      nameExcludes?: string[];
+    };
+    expect(cfg.namePrefix).toBe(D6_DISCOVERY_FILTER.namePrefix);
+    expect(cfg.nameExcludes).toEqual([...D6_DISCOVERY_FILTER.nameExcludes]);
+  });
+});
+
+describe("createE2eDeepServiceEnumerator", () => {
+  it("stamps the e2e_deep kind + d5-single-pill-e2e:<slug> probeKey and carries driver inputs", async () => {
+    const source = fakeSource([
+      svc({ name: "showcase-langgraph-python" }),
+      svc({ name: "showcase-crewai", publicUrl: "http://crewai:10000" }),
+    ]);
+    const enumerate = createE2eDeepServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+    });
+
+    const specs = await enumerate(CTX);
+
+    expect(specs).toHaveLength(2);
+    const lg = specs.find((s) => s.serviceSlug === "langgraph-python");
+    expect(lg?.driverKind).toBe(E2E_DEEP_DRIVER_KIND);
+    expect(lg?.probeKey).toBe("d5-single-pill-e2e:langgraph-python");
+    expect(lg?.driverInputs?.key).toBe("d5-single-pill-e2e:langgraph-python");
+    expect(lg?.driverInputs?.name).toBe("showcase-langgraph-python");
+    expect(lg?.driverInputs?.backendUrl).toBe("http://langgraph-python:10000");
+    expect(lg?.driverInputs?.demos).toEqual(["agentic_chat", "shared_state"]);
+    expect(lg?.driverInputs?.notSupportedFeatures).toEqual([]);
+    expect(lg?.driverInputs).not.toHaveProperty("timeout_ms");
+
+    const cr = specs.find((s) => s.serviceSlug === "crewai");
+    expect(cr?.probeKey).toBe("d5-single-pill-e2e:crewai");
+  });
+
+  it("passes the shared d6 discovery filter to the source", async () => {
+    const source = fakeSource([svc()]);
+    const enumerate = createE2eDeepServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+    });
+    await enumerate(CTX);
+    const cfg = source.configs[0] as {
+      namePrefix?: string;
+      nameExcludes?: string[];
+    };
+    expect(cfg.namePrefix).toBe(D6_DISCOVERY_FILTER.namePrefix);
+    expect(cfg.nameExcludes).toEqual([...D6_DISCOVERY_FILTER.nameExcludes]);
+  });
+});
+
+describe("createE2eDemosServiceEnumerator", () => {
+  it("stamps the e2e_demos kind + e2e-demos:<slug> probeKey and conveys the YAML timeout_ms", async () => {
+    const source = fakeSource([
+      svc({ name: "showcase-langgraph-python" }),
+      svc({ name: "showcase-crewai", publicUrl: "http://crewai:10000" }),
+    ]);
+    const enumerate = createE2eDemosServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+    });
+
+    const specs = await enumerate(CTX);
+
+    expect(specs).toHaveLength(2);
+    const lg = specs.find((s) => s.serviceSlug === "langgraph-python");
+    expect(lg?.driverKind).toBe(E2E_DEMOS_DRIVER_KIND);
+    expect(lg?.probeKey).toBe("e2e-demos:langgraph-python");
+    expect(lg?.driverInputs?.key).toBe("e2e-demos:langgraph-python");
+    expect(lg?.driverInputs?.name).toBe("showcase-langgraph-python");
+    expect(lg?.driverInputs?.backendUrl).toBe("http://langgraph-python:10000");
+    expect(lg?.driverInputs?.demos).toEqual(["agentic_chat", "shared_state"]);
+    // R-TIMEOUT: the demos family conveys the 20-min outer cap per-job so the
+    // fleet worker's pooled demos driver reads it from the payload (it never
+    // sees the legacy E2E_DEMOS_TIMEOUT_MS env). Default = YAML value.
+    expect(lg?.driverInputs?.timeout_ms).toBe(E2E_DEMOS_TIMEOUT_MS);
+    expect(E2E_DEMOS_TIMEOUT_MS).toBe(1_200_000);
+
+    const cr = specs.find((s) => s.serviceSlug === "crewai");
+    expect(cr?.probeKey).toBe("e2e-demos:crewai");
+    expect(cr?.driverInputs?.timeout_ms).toBe(E2E_DEMOS_TIMEOUT_MS);
+  });
+
+  it("honors an explicit timeoutMs override on the conveyed timeout_ms", async () => {
+    const source = fakeSource([svc({ name: "showcase-langgraph-python" })]);
+    const enumerate = createE2eDemosServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+      timeoutMs: 999_000,
+    });
+
+    const specs = await enumerate(CTX);
+    const lg = specs.find((s) => s.serviceSlug === "langgraph-python");
+    expect(lg?.driverInputs?.timeout_ms).toBe(999_000);
+  });
+
+  it("passes the shared d6 discovery filter to the source", async () => {
+    const source = fakeSource([svc()]);
+    const enumerate = createE2eDemosServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+    });
+    await enumerate(CTX);
+    const cfg = source.configs[0] as {
+      namePrefix?: string;
+      nameExcludes?: string[];
+    };
+    expect(cfg.namePrefix).toBe(D6_DISCOVERY_FILTER.namePrefix);
+    expect(cfg.nameExcludes).toEqual([...D6_DISCOVERY_FILTER.nameExcludes]);
   });
 });

--- a/showcase/harness/src/fleet/control-plane/catalog-enumerator.ts
+++ b/showcase/harness/src/fleet/control-plane/catalog-enumerator.ts
@@ -50,8 +50,27 @@ import type {
   EnumerateContext,
 } from "./job-producer.js";
 
+import {
+  E2E_SMOKE_DRIVER_KIND,
+  E2E_DEMOS_DRIVER_KIND,
+  E2E_DEEP_DRIVER_KIND,
+} from "../worker/payload-mapper.js";
+
 /** The d6 driver kind every enumerated spec runs under. */
 export const D6_DRIVER_KIND = "e2e_d6";
+
+/**
+ * The demos family's outer-cap timeout (ms) — the SINGLE SOURCE OF TRUTH
+ * mirroring `config/probes/e2e-demos.yml`'s `timeout_ms` (20 min). On the legacy
+ * in-process path the orchestrator threads this YAML value into the demos driver
+ * via the `E2E_DEMOS_TIMEOUT_MS` env (see `orchestrator.ts` `envForCfg`). The
+ * fleet WORKER does not run that boot path and never sets that env, so the demos
+ * enumerator instead CONVEYS the cap per-job in `driverInputs.timeout_ms` (the
+ * driver reads `input.timeout_ms`). Without it the 38-demo service would blow the
+ * driver's 5-min `DEFAULT_TIMEOUT_MS` and go all-red. Keep this in lockstep with
+ * the YAML until the in-process and fleet run paths converge on one config.
+ */
+export const E2E_DEMOS_TIMEOUT_MS = 1_200_000;
 
 /**
  * The d6 service-set filter — the SINGLE SOURCE OF TRUTH mirroring
@@ -146,6 +165,16 @@ export interface ServiceEnumeratorParams {
    * Carries the discovery source's `namePrefix` / `nameExcludes` block.
    */
   filter: ServiceSetFilter;
+  /**
+   * Extra family-wide `driverInputs` fields spread onto every enumerated spec's
+   * `driverInputs` AFTER the per-service `toDriverInputs` projection, so a family
+   * can convey a YAML-derived knob the worker can't otherwise reach (e.g. the
+   * demos `timeout_ms` outer cap — the fleet worker never sets the legacy
+   * `E2E_DEMOS_TIMEOUT_MS` env). The per-service fields win on key collision; the
+   * conveyed knobs (e.g. `timeout_ms`) never collide with the per-service shape.
+   * Omitted by d6/smoke/deep (their specs are unchanged).
+   */
+  extraDriverInputs?: Readonly<Record<string, unknown>>;
 }
 
 /**
@@ -214,8 +243,16 @@ function toDriverInputs(
 export function createServiceEnumerator(
   params: ServiceEnumeratorParams,
 ): ServiceEnumerator {
-  const { source, env, fetchImpl, logger, driverKind, probeKeyPrefix, filter } =
-    params;
+  const {
+    source,
+    env,
+    fetchImpl,
+    logger,
+    driverKind,
+    probeKeyPrefix,
+    filter,
+    extraDriverInputs,
+  } = params;
 
   // Fail loud on a filter with no `namePrefix`: the discovery source treats an
   // absent/empty prefix as "match everything", which would enumerate ALL
@@ -262,7 +299,13 @@ export function createServiceEnumerator(
         probeKey,
         serviceSlug: slug,
         driverKind,
-        driverInputs: toDriverInputs(svc, slug, probeKey),
+        // Family-wide conveyed knobs (e.g. demos `timeout_ms`) spread FIRST so
+        // the per-service `toDriverInputs` projection always wins on a key
+        // collision — the conveyed knobs never overlap the per-service shape.
+        driverInputs: {
+          ...extraDriverInputs,
+          ...toDriverInputs(svc, slug, probeKey),
+        },
       };
       // Forward the operator feature-type scoping to the worker as a cell
       // narrowing (the d6 driver filters by ctx.featureTypes); per-service is
@@ -307,5 +350,96 @@ export function createD6ServiceEnumerator(
     driverKind: D6_DRIVER_KIND,
     probeKeyPrefix: "d6",
     filter,
+  });
+}
+
+/**
+ * Build the real e2e-smoke (`d4`) `ServiceEnumerator` — a thin specialization of
+ * `createServiceEnumerator` with the shared showcase filter, the `e2e_smoke`
+ * driver kind, and the `d4:<slug>` probeKey prefix (matching `src/cli/targets.ts`
+ * `d4:<slug>` and `config/probes/e2e-smoke.yml`). The fleet WORKER routes
+ * `e2e_smoke` jobs to its pooled smoke driver, which sets the per-slug
+ * `X-AIMock-Context` header itself via the pooled launcher.
+ */
+export function createE2eSmokeServiceEnumerator(
+  deps: D6ServiceEnumeratorDeps,
+): ServiceEnumerator {
+  const { source, env, fetchImpl, logger } = deps;
+  const filter = deps.filter ?? D6_DISCOVERY_FILTER;
+
+  return createServiceEnumerator({
+    source,
+    env,
+    fetchImpl,
+    logger,
+    driverKind: E2E_SMOKE_DRIVER_KIND,
+    probeKeyPrefix: "d4",
+    filter,
+  });
+}
+
+/**
+ * Build the real e2e-deep (`d5-single-pill-e2e`) `ServiceEnumerator` — a thin
+ * specialization of `createServiceEnumerator` with the shared showcase filter,
+ * the `e2e_deep` driver kind, and the `d5-single-pill-e2e:<slug>` probeKey prefix
+ * (matching `src/cli/targets.ts` `d5-single-pill-e2e:<slug>` and
+ * `config/probes/e2e-deep.yml`).
+ */
+export function createE2eDeepServiceEnumerator(
+  deps: D6ServiceEnumeratorDeps,
+): ServiceEnumerator {
+  const { source, env, fetchImpl, logger } = deps;
+  const filter = deps.filter ?? D6_DISCOVERY_FILTER;
+
+  return createServiceEnumerator({
+    source,
+    env,
+    fetchImpl,
+    logger,
+    driverKind: E2E_DEEP_DRIVER_KIND,
+    probeKeyPrefix: "d5-single-pill-e2e",
+    filter,
+  });
+}
+
+/** Deps for the demos enumerator — `D6ServiceEnumeratorDeps` plus the outer-cap. */
+export interface E2eDemosServiceEnumeratorDeps extends D6ServiceEnumeratorDeps {
+  /**
+   * The demos driver's outer-cap timeout (ms), conveyed per-job in
+   * `driverInputs.timeout_ms` so the fleet worker's pooled demos driver reads it
+   * (the worker never sets the legacy `E2E_DEMOS_TIMEOUT_MS` env). Defaults to
+   * {@link E2E_DEMOS_TIMEOUT_MS} (the `config/probes/e2e-demos.yml` value).
+   */
+  timeoutMs?: number;
+}
+
+/**
+ * Build the real e2e-demos (`e2e-demos`) `ServiceEnumerator` — a thin
+ * specialization of `createServiceEnumerator` with the shared showcase filter,
+ * the `e2e_demos` driver kind, and the `e2e-demos:<slug>` probeKey prefix
+ * (matching `config/probes/e2e-demos.yml` `id: e2e-demos`).
+ *
+ * Unlike the other families, demos CONVEYS its YAML `timeout_ms` outer cap into
+ * each spec's `driverInputs.timeout_ms` (see {@link E2E_DEMOS_TIMEOUT_MS}): the
+ * fleet worker re-hydrates the payload but never sets the legacy
+ * `E2E_DEMOS_TIMEOUT_MS` env, so without this the 38-demo service would blow the
+ * demos driver's 5-min `DEFAULT_TIMEOUT_MS` and go all-red.
+ */
+export function createE2eDemosServiceEnumerator(
+  deps: E2eDemosServiceEnumeratorDeps,
+): ServiceEnumerator {
+  const { source, env, fetchImpl, logger } = deps;
+  const filter = deps.filter ?? D6_DISCOVERY_FILTER;
+  const timeoutMs = deps.timeoutMs ?? E2E_DEMOS_TIMEOUT_MS;
+
+  return createServiceEnumerator({
+    source,
+    env,
+    fetchImpl,
+    logger,
+    driverKind: E2E_DEMOS_DRIVER_KIND,
+    probeKeyPrefix: "e2e-demos",
+    filter,
+    extraDriverInputs: { timeout_ms: timeoutMs },
   });
 }

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -16,10 +16,22 @@ import {
   createRailwayAdapter,
   registerAllProbeDrivers,
   buildPooledBrowserDrivers,
+  buildProducerSchedules,
+  FLEET_PRODUCER_SMOKE_CRON,
+  FLEET_PRODUCER_DEMOS_CRON,
+  FLEET_PRODUCER_DEEP_CRON,
+  FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
+  FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
+  FLEET_PRODUCER_DEEP_SCHEDULE_ID,
   hydrateProbeLastRuns,
   surfaceReclaimedCommErrors,
   verifyWorkerRegistered,
 } from "./orchestrator.js";
+import {
+  DEFAULT_PRODUCER_CRON,
+  FLEET_PRODUCER_SCHEDULE_ID,
+} from "./fleet/control-plane/control-plane.js";
+import type { JobProducer } from "./fleet/control-plane/job-producer.js";
 import { createE2eFullDriver } from "./probes/drivers/d6-all-pills.js";
 import { createE2eDeepDriver } from "./probes/drivers/d5-single-pill.js";
 import { createE2eDemosDriver } from "./probes/drivers/e2e-readiness.js";
@@ -2891,7 +2903,14 @@ describe("orchestrator runControlPlane async bind error cleanup (CR-FIX #1)", ()
     // Critical: the scheduler must have been stopped as part of teardown.
     // Pre-fix the async bind error was unobserved and runControlPlane resolved
     // with the scheduler (and fleet-health interval) still running.
-    expect(stopSpy).toHaveBeenCalled();
+    //
+    // `teardownAfterBindFailure` is fire-and-forget on the error path (operators
+    // see the original bind error, not a stop-failure shadow), and it awaits
+    // `controlPlane.stop()` — which now unregisters FOUR producer schedules —
+    // BEFORE `scheduler.stop()`. So the rejection above can resolve a few
+    // microtasks ahead of `scheduler.stop()`; poll until teardown settles
+    // rather than asserting synchronously (avoids a timing-dependent flake).
+    await vi.waitFor(() => expect(stopSpy).toHaveBeenCalled());
   });
 });
 
@@ -3046,7 +3065,13 @@ describe("orchestrator runControlPlane REQ-B sweep wiring (control-plane integra
               cron: string;
               handler: () => Promise<unknown>;
             }) => {
-              producerHandler = entry.handler;
+              // The d6 producer (`fleet-job-producer`) is the ONLY one wired
+              // with the REQ-B `onSweepCommErrors` sweep leg, so capture ITS
+              // handler specifically — the other three browser-family producer
+              // schedules + the `probe:*` HTTP entries also register here.
+              if (entry.id === FLEET_PRODUCER_SCHEDULE_ID) {
+                producerHandler = entry.handler;
+              }
               return (real.register as (...a: unknown[]) => unknown)(entry);
             },
           };
@@ -3526,8 +3551,10 @@ describe("orchestrator runControlPlane in-process HTTP probes", () => {
       // `rules>0` gate, so `status` does NOT flip to degraded on a zero load
       // (visibility is for dashboards/alerting, not container liveness).
       expect(body.rules).toBe(3);
-      // schedulerJobs = the producer entry + the 3 in-process probe entries.
-      expect(body.schedulerJobs).toBe(4);
+      // schedulerJobs = the 4 browser-family producer entries (d6 + smoke +
+      // demos + deep, registered via the multi-schedule manifest) + the 3
+      // in-process HTTP probe entries.
+      expect(body.schedulerJobs).toBe(7);
       // The role-drop keeps status ok regardless of the rule count.
       expect(body.status).toBe("ok");
     } finally {
@@ -3953,3 +3980,234 @@ function makeCronRule(id: string, cron: string): CompiledRule {
     actions: [],
   };
 }
+
+/**
+ * Phase 2 — fleet producer multi-schedule wiring.
+ *
+ * `runControlPlane` now builds FOUR browser-family producers (d6 + smoke +
+ * demos + deep) and passes a `schedules` array to `createControlPlane`, each on
+ * its own cron. `buildProducerSchedules` is the pure manifest assembler; these
+ * tests pin the EXACT schedule ids + crons (the deliberate offsets that stagger
+ * the families' Playwright fan-outs on the shared BrowserPool) and the d6
+ * env-override behavior, then prove the schedules actually register on the live
+ * scheduler when `runControlPlane` boots.
+ */
+describe("buildProducerSchedules (fleet multi-schedule manifest)", () => {
+  function fakeProducer(): JobProducer {
+    return {
+      start: () => {},
+      stop: async () => {},
+      tick: async () => ({ enqueued: 0, runId: "r" }) as never,
+      maybeSweep: async () => undefined,
+    } as unknown as JobProducer;
+  }
+
+  it("emits 4 schedules with the exact ids + crons read from the YAMLs", () => {
+    const d6 = fakeProducer();
+    const smoke = fakeProducer();
+    const demos = fakeProducer();
+    const deep = fakeProducer();
+
+    const schedules = buildProducerSchedules({ d6, smoke, demos, deep });
+
+    expect(schedules).toHaveLength(4);
+
+    const byId = new Map(schedules.map((s) => [s.scheduleId, s]));
+
+    // d6: historic scheduleId + cron (degenerate-path equivalence).
+    expect(byId.get(FLEET_PRODUCER_SCHEDULE_ID)?.cron).toBe("40 * * * *");
+    expect(byId.get(FLEET_PRODUCER_SCHEDULE_ID)?.cron).toBe(
+      DEFAULT_PRODUCER_CRON,
+    );
+    expect(byId.get(FLEET_PRODUCER_SCHEDULE_ID)?.producer).toBe(d6);
+
+    // smoke: every 15 min (e2e-smoke.yml).
+    expect(FLEET_PRODUCER_SMOKE_SCHEDULE_ID).toBe("fleet-producer-e2e-smoke");
+    expect(byId.get(FLEET_PRODUCER_SMOKE_SCHEDULE_ID)?.cron).toBe(
+      "*/15 * * * *",
+    );
+    expect(byId.get(FLEET_PRODUCER_SMOKE_SCHEDULE_ID)?.cron).toBe(
+      FLEET_PRODUCER_SMOKE_CRON,
+    );
+    expect(byId.get(FLEET_PRODUCER_SMOKE_SCHEDULE_ID)?.producer).toBe(smoke);
+
+    // demos: hourly at :10 (e2e-demos.yml).
+    expect(FLEET_PRODUCER_DEMOS_SCHEDULE_ID).toBe("fleet-producer-e2e-demos");
+    expect(byId.get(FLEET_PRODUCER_DEMOS_SCHEDULE_ID)?.cron).toBe("10 * * * *");
+    expect(byId.get(FLEET_PRODUCER_DEMOS_SCHEDULE_ID)?.cron).toBe(
+      FLEET_PRODUCER_DEMOS_CRON,
+    );
+    expect(byId.get(FLEET_PRODUCER_DEMOS_SCHEDULE_ID)?.producer).toBe(demos);
+
+    // deep: :05/:20/:35/:50 (e2e-deep.yml).
+    expect(FLEET_PRODUCER_DEEP_SCHEDULE_ID).toBe("fleet-producer-e2e-deep");
+    expect(byId.get(FLEET_PRODUCER_DEEP_SCHEDULE_ID)?.cron).toBe(
+      "5,20,35,50 * * * *",
+    );
+    expect(byId.get(FLEET_PRODUCER_DEEP_SCHEDULE_ID)?.cron).toBe(
+      FLEET_PRODUCER_DEEP_CRON,
+    );
+    expect(byId.get(FLEET_PRODUCER_DEEP_SCHEDULE_ID)?.producer).toBe(deep);
+
+    // All four schedule ids are distinct (createControlPlane throws on dups).
+    expect(new Set(schedules.map((s) => s.scheduleId)).size).toBe(4);
+  });
+
+  it("threads the FLEET_PRODUCER_CRON override onto the d6 schedule only", () => {
+    const d6 = fakeProducer();
+    const smoke = fakeProducer();
+    const demos = fakeProducer();
+    const deep = fakeProducer();
+
+    const schedules = buildProducerSchedules({
+      d6,
+      smoke,
+      demos,
+      deep,
+      d6Cron: "* * * * *",
+    });
+    const byId = new Map(schedules.map((s) => [s.scheduleId, s]));
+
+    // d6 honors the override; the 3 browser families keep their YAML crons.
+    expect(byId.get(FLEET_PRODUCER_SCHEDULE_ID)?.cron).toBe("* * * * *");
+    expect(byId.get(FLEET_PRODUCER_SMOKE_SCHEDULE_ID)?.cron).toBe(
+      "*/15 * * * *",
+    );
+    expect(byId.get(FLEET_PRODUCER_DEMOS_SCHEDULE_ID)?.cron).toBe("10 * * * *");
+    expect(byId.get(FLEET_PRODUCER_DEEP_SCHEDULE_ID)?.cron).toBe(
+      "5,20,35,50 * * * *",
+    );
+  });
+});
+
+describe("runControlPlane registers 4 producer schedules on the scheduler", () => {
+  let port = 0;
+
+  beforeEach(async () => {
+    port = await pickPort();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("registers d6 + smoke + demos + deep producer schedules with exact crons, alongside the in-process HTTP probes", async () => {
+    vi.resetModules();
+
+    // Real serve() (immunize against a sibling test's leaked doMock).
+    vi.doMock("@hono/node-server", async () => {
+      const actual =
+        await vi.importActual<typeof import("@hono/node-server")>(
+          "@hono/node-server",
+        );
+      return { ...actual };
+    });
+
+    // Minimal queue fake — no enqueue/sweep churn; the producers never tick here.
+    vi.doMock("./fleet/queue-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./fleet/queue-client.js")
+      >("./fleet/queue-client.js");
+      return {
+        ...actual,
+        createFleetQueueClient: () => ({
+          enqueue: async () => ({}) as never,
+          claimNext: async () => ({ claimed: false }) as never,
+          renewLease: async () => null,
+          report: async () => undefined,
+          sweepExpired: async () => ({ reclaimed: 0, commErrors: [] }),
+        }),
+      };
+    });
+
+    vi.doMock("./storage/pb-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./storage/pb-client.js")
+      >("./storage/pb-client.js");
+      return {
+        ...actual,
+        createPbClient: () => ({
+          health: async () => true,
+          getOne: async () => null,
+          getFirst: async () => null,
+        }),
+      };
+    });
+
+    vi.doMock("./writers/status-writer.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./writers/status-writer.js")
+      >("./writers/status-writer.js");
+      return {
+        ...actual,
+        createStatusWriter: () => ({ write: async () => undefined }),
+      };
+    });
+
+    vi.doMock("./probes/run-history.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./probes/run-history.js")
+      >("./probes/run-history.js");
+      return {
+        ...actual,
+        createProbeRunWriter: () => ({
+          findByJobId: async () => null,
+          start: async () => ({}) as never,
+          finishTerminal: async () => undefined,
+        }),
+      };
+    });
+
+    // Record EVERY scheduler register call (id + cron) so we can assert the
+    // producer schedules landed alongside the in-process `probe:*` HTTP entries.
+    const registered: Array<{ id: string; cron: string }> = [];
+    vi.doMock("./scheduler/scheduler.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./scheduler/scheduler.js")
+      >("./scheduler/scheduler.js");
+      return {
+        ...actual,
+        createScheduler: (
+          deps: Parameters<typeof actual.createScheduler>[0],
+        ) => {
+          const real = actual.createScheduler(deps);
+          return {
+            ...real,
+            register: (entry: {
+              id: string;
+              cron: string;
+              handler: () => Promise<unknown>;
+            }) => {
+              registered.push({ id: entry.id, cron: entry.cron });
+              return (real.register as (...a: unknown[]) => unknown)(entry);
+            },
+          };
+        },
+      };
+    });
+
+    const orchMod = await import("./orchestrator.js");
+    const handle = await orchMod.runControlPlane(
+      { role: "control-plane", poolCount: 1 },
+      // Empty d6 enumerator → no enqueue churn; schedule registration still runs.
+      { port, fleetEnumerate: async () => [] },
+    );
+
+    try {
+      const byId = new Map(registered.map((r) => [r.id, r.cron]));
+
+      // All four producer schedules registered with their exact crons.
+      expect(byId.get("fleet-job-producer")).toBe("40 * * * *");
+      expect(byId.get("fleet-producer-e2e-smoke")).toBe("*/15 * * * *");
+      expect(byId.get("fleet-producer-e2e-demos")).toBe("10 * * * *");
+      expect(byId.get("fleet-producer-e2e-deep")).toBe("5,20,35,50 * * * *");
+
+      // The in-process HTTP probe families still register alongside (additive).
+      const probeEntries = registered.filter((r) => r.id.startsWith("probe:"));
+      expect(probeEntries.length).toBeGreaterThan(0);
+    } finally {
+      await handle.stop();
+    }
+  });
+});

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -109,17 +109,28 @@ import {
   DEFAULT_WORKER_STALE_AFTER_MS,
   type RestartWorkerHook,
 } from "./fleet/control-plane/fleet-health.js";
-import { createD6ServiceEnumerator } from "./fleet/control-plane/catalog-enumerator.js";
+import {
+  createD6ServiceEnumerator,
+  createE2eSmokeServiceEnumerator,
+  createE2eDemosServiceEnumerator,
+  createE2eDeepServiceEnumerator,
+} from "./fleet/control-plane/catalog-enumerator.js";
 import {
   buildJobProducer,
   createControlPlane,
+  DEFAULT_PRODUCER_CRON,
+  FLEET_PRODUCER_SCHEDULE_ID,
 } from "./fleet/control-plane/control-plane.js";
 import type {
   ControlPlane,
+  ProducerSchedule,
   PriorStateResolver,
   SweepAggregateKeyResolver,
 } from "./fleet/control-plane/control-plane.js";
-import type { ServiceEnumerator } from "./fleet/control-plane/job-producer.js";
+import type {
+  ServiceEnumerator,
+  JobProducer,
+} from "./fleet/control-plane/job-producer.js";
 
 export interface BootOptions {
   configDir?: string;
@@ -1167,6 +1178,71 @@ export function assertHttpBrowserKindPartition(httpKinds: string[]): void {
         `HTTP driver set and BROWSER_KINDS must be DISJOINT.`,
     );
   }
+}
+
+/**
+ * The scheduler entry id + cron for each BROWSER probe family's fleet producer.
+ *
+ * The crons are LITERAL from `config/probes/*.yml` `schedule:` and the OFFSETS
+ * ARE DELIBERATE — the four browser families share ONE BrowserPool (capped at
+ * `BROWSER_POOL_MAX_CONTEXTS`, 24) on the pooled worker(s), so co-firing all
+ * four Playwright fan-outs at the same minute would starve the pool. Staggering
+ * their producer ticks (smoke every :15, demos at :10, deep at :05/:20/:35/:50,
+ * d6 at :40) keeps the families from claiming the pool simultaneously. Do NOT
+ * "tidy" these to a uniform cadence — keep each in lockstep with its YAML.
+ *
+ * The d6 entry keeps the historic `FLEET_PRODUCER_SCHEDULE_ID`
+ * (`fleet-job-producer`) so the degenerate single-schedule behavior is
+ * preserved exactly for d6 (and a `FLEET_PRODUCER_CRON` env override still wins
+ * for d6 — see `buildProducerSchedules`).
+ */
+export const FLEET_PRODUCER_SMOKE_CRON = "*/15 * * * *";
+export const FLEET_PRODUCER_DEMOS_CRON = "10 * * * *";
+export const FLEET_PRODUCER_DEEP_CRON = "5,20,35,50 * * * *";
+
+/** Scheduler entry ids for the three non-d6 browser-family producers. */
+export const FLEET_PRODUCER_SMOKE_SCHEDULE_ID = "fleet-producer-e2e-smoke";
+export const FLEET_PRODUCER_DEMOS_SCHEDULE_ID = "fleet-producer-e2e-demos";
+export const FLEET_PRODUCER_DEEP_SCHEDULE_ID = "fleet-producer-e2e-deep";
+
+/**
+ * Assemble the multi-schedule producer manifest `runControlPlane` passes to
+ * `createControlPlane`. Pure (no I/O) so the schedule ids + crons are
+ * unit-testable without booting the control-plane. Each browser family ticks on
+ * its own cron from the YAML (see the cron constants above for the offset
+ * rationale); the d6 entry keeps `fleet-job-producer` and honors the
+ * `FLEET_PRODUCER_CRON` env override (`d6Cron`) for the local fast-cadence seam.
+ */
+export function buildProducerSchedules(producers: {
+  d6: JobProducer;
+  smoke: JobProducer;
+  demos: JobProducer;
+  deep: JobProducer;
+  /** d6 cron — `FLEET_PRODUCER_CRON` override or `DEFAULT_PRODUCER_CRON`. */
+  d6Cron?: string;
+}): ProducerSchedule[] {
+  return [
+    {
+      scheduleId: FLEET_PRODUCER_SCHEDULE_ID,
+      cron: producers.d6Cron ?? DEFAULT_PRODUCER_CRON,
+      producer: producers.d6,
+    },
+    {
+      scheduleId: FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
+      cron: FLEET_PRODUCER_SMOKE_CRON,
+      producer: producers.smoke,
+    },
+    {
+      scheduleId: FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
+      cron: FLEET_PRODUCER_DEMOS_CRON,
+      producer: producers.demos,
+    },
+    {
+      scheduleId: FLEET_PRODUCER_DEEP_SCHEDULE_ID,
+      cron: FLEET_PRODUCER_DEEP_CRON,
+      producer: producers.deep,
+    },
+  ];
 }
 
 /**
@@ -2229,6 +2305,31 @@ export async function runControlPlane(
       fetchImpl: globalThis.fetch,
       logger,
     });
+  // The three non-d6 BROWSER families (smoke/demos/deep) each get their own
+  // catalog enumerator over the SAME `railway-services` source + shared showcase
+  // filter, differing only in driverKind + dashboard probeKey prefix (and, for
+  // demos, the conveyed `timeout_ms` outer cap). `opts.fleetEnumerate` is a
+  // d6-ONLY test seam (it overrides the d6 enumerate above) — the new families
+  // always use their real enumerators so a d6-focused test override never
+  // accidentally re-points them. Each becomes its own fleet producer below.
+  const enumerateSmoke = createE2eSmokeServiceEnumerator({
+    source: railwayServicesSource,
+    env: process.env,
+    fetchImpl: globalThis.fetch,
+    logger,
+  });
+  const enumerateDemos = createE2eDemosServiceEnumerator({
+    source: railwayServicesSource,
+    env: process.env,
+    fetchImpl: globalThis.fetch,
+    logger,
+  });
+  const enumerateDeep = createE2eDeepServiceEnumerator({
+    source: railwayServicesSource,
+    env: process.env,
+    fetchImpl: globalThis.fetch,
+    logger,
+  });
   // REQ-B producer-sweep leg: the producer's lease-driven `sweepExpired`
   // synthesizes a `worker-crashed-mid-job` comm error per reclaimed job, but a
   // bare swept error carries only the `jobId`, not the `d6:<slug>` dashboard
@@ -2269,10 +2370,31 @@ export async function runControlPlane(
     logger,
     // REQ-B: forward swept comm errors into the control-plane's surfacing sink,
     // which resolves each `d6:<slug>` key and writes the overlay through the
-    // aggregator. Best-effort; never aborts production.
+    // aggregator. Best-effort; never aborts production. Only the d6 producer
+    // wires this sweep leg — it's the historic REQ-B path and stays unchanged;
+    // the three new browser-family producers below do not forward sweep errors.
     onSweepCommErrors: async (commErrors) => {
       await controlPlaneRef?.surfaceSweepCommErrors(commErrors);
     },
+  });
+  // The three non-d6 browser families each get their own producer over their
+  // family enumerator. They intentionally do NOT wire `onSweepCommErrors`: the
+  // single REQ-B sweep-surfacing leg stays on the d6 producer (preserving the
+  // current behavior); adding parallel sweep legs is out of scope for Phase 2.
+  const smokeProducer = buildJobProducer({
+    queue,
+    enumerate: enumerateSmoke,
+    logger,
+  });
+  const demosProducer = buildJobProducer({
+    queue,
+    enumerate: enumerateDemos,
+    logger,
+  });
+  const deepProducer = buildJobProducer({
+    queue,
+    enumerate: enumerateDeep,
+    logger,
   });
 
   // Producer cron cadence. Defaults to the hourly-at-:40 rhythm
@@ -2280,8 +2402,22 @@ export async function runControlPlane(
   // Env-overridable via FLEET_PRODUCER_CRON so a local N=1 run can drive the
   // SAME enqueue path on a fast cadence (e.g. `* * * * *`) instead of waiting
   // up to an hour for the top-of-:40 tick — local exercises the identical
-  // producer→queue→worker→consumer chain prod runs, just more often.
+  // producer→queue→worker→consumer chain prod runs, just more often. The env
+  // override applies to the d6 producer only; the three new browser families
+  // keep their literal YAML crons (the deliberate offsets that stagger the
+  // shared BrowserPool — see buildProducerSchedules).
   const producerCron = process.env.FLEET_PRODUCER_CRON?.trim() || undefined;
+
+  // Multi-schedule manifest: one producer per browser family, each on its own
+  // cron. d6 keeps `fleet-job-producer` @ its (optionally env-overridden) cron;
+  // smoke/demos/deep tick on their staggered YAML crons.
+  const schedules: ProducerSchedule[] = buildProducerSchedules({
+    d6: producer,
+    smoke: smokeProducer,
+    demos: demosProducer,
+    deep: deepProducer,
+    ...(producerCron ? { d6Cron: producerCron } : {}),
+  });
 
   // REQ-B: wire the real aggregator + fleet-health monitor + sweep-key resolver
   // into the control-plane assembly so BOTH crash-path legs surface onto the
@@ -2289,7 +2425,13 @@ export async function runControlPlane(
   // fleet-health monitor on its own interval and feeds each reclaimedOverlays
   // entry — and each swept error via surfaceSweepCommErrors — to the aggregator).
   const controlPlane = createControlPlane({
+    // `producer` is still required by the API (the degenerate single-d6 case),
+    // but it's IGNORED when `schedules` is provided — the d6 producer is already
+    // the first entry in `schedules`. The `FLEET_PRODUCER_CRON` env override is
+    // threaded into the d6 schedule's cron via `buildProducerSchedules`, so the
+    // degenerate `producerCron` knob is intentionally not passed here.
     producer,
+    schedules,
     consumer,
     scheduler,
     logger,
@@ -2297,7 +2439,6 @@ export async function runControlPlane(
     fleetHealth,
     resolveSweepAggregateKey,
     resolvePriorState,
-    ...(producerCron ? { producerCron } : {}),
   });
   controlPlaneRef = controlPlane;
 

--- a/showcase/harness/src/probes/drivers/e2e-readiness.test.ts
+++ b/showcase/harness/src/probes/drivers/e2e-readiness.test.ts
@@ -798,6 +798,128 @@ describe("e2e-demos driver", () => {
     expect(aborts.length).toBeGreaterThan(0);
   });
 
+  // --- Fleet path: per-job cap conveyed via input.timeout_ms ------------
+  //
+  // On the fleet the worker re-hydrates the driver input from the job payload
+  // and NEVER sets the legacy E2E_DEMOS_TIMEOUT_MS env. The demos enumerator
+  // (createE2eDemosServiceEnumerator) conveys the YAML 20-min cap in
+  // `driverInputs.timeout_ms`; the driver must read it so the 38-demo service
+  // doesn't blow the 5-min DEFAULT_TIMEOUT_MS and go all-red.
+
+  it("input.timeout_ms (fleet payload) wins over the deps default when env is absent", async () => {
+    // A goto that resolves quickly; the assertion is about WHICH cap fired.
+    // deps.timeoutMs is a tiny 10ms — if input.timeout_ms (5000ms) is honored,
+    // the per-demo work completes with no abort rows. If the deps default
+    // wins, the 10ms cap fires an abort.
+    let gotoStarted = false;
+    const slowPage: E2eDemosPage = {
+      async goto() {
+        gotoStarted = true;
+        await new Promise((r) => setTimeout(r, 20));
+      },
+      async waitForSelector() {
+        /* match immediately */
+      },
+      async close() {
+        /* no-op */
+      },
+    };
+    const slowBrowser: E2eDemosBrowser = {
+      async newContext() {
+        return {
+          async newPage() {
+            return slowPage;
+          },
+          async close() {
+            /* no-op */
+          },
+        };
+      },
+      async close() {
+        /* no-op */
+      },
+    };
+
+    const driver = createE2eDemosDriver({
+      launcher: async () => slowBrowser,
+      timeoutMs: 10,
+    });
+    const { writer, writes } = mkWriter();
+
+    // No E2E_DEMOS_TIMEOUT_MS env (fleet worker reality); cap comes from payload.
+    const result = await driver.run(mkCtx(writer, {}), {
+      key: "e2e-demos:input-timeout",
+      name: "showcase-input-timeout",
+      publicUrl: "https://showcase-input-timeout.example.com",
+      demos: ["d1"],
+      shape: "package",
+      timeout_ms: 5000,
+    });
+
+    expect(gotoStarted).toBe(true);
+    expect(result.state).toBe("green");
+    const aborts = writes.filter(
+      (w) => (w.signal as { errorClass?: string })?.errorClass === "abort",
+    );
+    expect(aborts).toHaveLength(0);
+  });
+
+  it("env override still wins over input.timeout_ms (precedence: env > input > deps)", async () => {
+    // env caps at 50ms, input.timeout_ms is a generous 60_000ms, goto sleeps
+    // 200ms. If env wins (correct), the 50ms cap fires abort rows. If input
+    // wrongly won, the run would complete green.
+    const slowPage: E2eDemosPage = {
+      async goto() {
+        await new Promise((r) => setTimeout(r, 200));
+      },
+      async waitForSelector() {
+        /* never gets here */
+      },
+      async close() {
+        /* no-op */
+      },
+    };
+    const slowBrowser: E2eDemosBrowser = {
+      async newContext() {
+        return {
+          async newPage() {
+            return slowPage;
+          },
+          async close() {
+            /* no-op */
+          },
+        };
+      },
+      async close() {
+        /* no-op */
+      },
+    };
+
+    const driver = createE2eDemosDriver({
+      launcher: async () => slowBrowser,
+      timeoutMs: 5 * 60 * 1000,
+    });
+    const { writer, writes } = mkWriter();
+
+    const result = await driver.run(
+      mkCtx(writer, { E2E_DEMOS_TIMEOUT_MS: "50" }),
+      {
+        key: "e2e-demos:env-beats-input",
+        name: "showcase-env-beats-input",
+        publicUrl: "https://showcase-env-beats-input.example.com",
+        demos: ["d1", "d2", "d3"],
+        shape: "package",
+        timeout_ms: 60_000,
+      },
+    );
+
+    expect(result.state).toBe("red");
+    const aborts = writes.filter(
+      (w) => (w.signal as { errorClass?: string })?.errorClass === "abort",
+    );
+    expect(aborts.length).toBeGreaterThan(0);
+  });
+
   // --- L: Driver fires internal cap mid-fan-out, side-emits abort rows ---
 
   it("driver fires the internal cap mid-fan-out and side-emits errorClass: 'abort' rows for remaining demos", async () => {

--- a/showcase/harness/src/probes/drivers/e2e-readiness.ts
+++ b/showcase/harness/src/probes/drivers/e2e-readiness.ts
@@ -50,6 +50,11 @@ const inputSchema = z
     name: z.string().optional(),
     demos: z.array(z.string()).optional(),
     shape: showcaseShapeSchema.optional(),
+    // Optional outer-cap (ms) conveyed by the fleet enumerator so the worker's
+    // pooled demos driver reads the YAML `timeout_ms` from the payload (the
+    // worker never sets the legacy `E2E_DEMOS_TIMEOUT_MS` env). See the
+    // `TIMEOUT_ENV_VAR` resolution-order block.
+    timeout_ms: z.number().int().positive().optional(),
   })
   .passthrough()
   .refine((v) => !!(v.backendUrl ?? v.publicUrl), {
@@ -197,9 +202,13 @@ const DEFAULT_PAGE_TIMEOUT_MS = 30 * 1000;
  * invoker's outer race (1_200_000ms in production today).
  *
  * Resolution order (highest precedence first):
- *   1. `ctx.env.E2E_DEMOS_TIMEOUT_MS` — orchestrator-threaded YAML value.
- *   2. `deps.timeoutMs` — explicit per-driver override (used by tests).
- *   3. `DEFAULT_TIMEOUT_MS` — fallback (5 min).
+ *   1. `ctx.env.E2E_DEMOS_TIMEOUT_MS` — orchestrator-threaded YAML value
+ *      (legacy in-process path).
+ *   2. `input.timeout_ms` — per-job cap conveyed by the fleet enumerator
+ *      (`createE2eDemosServiceEnumerator`), since the fleet worker never sets
+ *      the env var.
+ *   3. `deps.timeoutMs` — explicit per-driver override (used by tests).
+ *   4. `DEFAULT_TIMEOUT_MS` — fallback (5 min).
  *
  * Env values that don't parse as positive integers fall through to the
  * dep / default — a typo'd env var must NOT silently disable the cap.
@@ -543,10 +552,22 @@ export function createE2eDemosDriver(
         typeof envRaw === "string" && /^\d+$/.test(envRaw.trim())
           ? Number.parseInt(envRaw.trim(), 10)
           : NaN;
+      // Fleet path: the enumerator conveys the YAML cap in `input.timeout_ms`
+      // (the worker never sets `E2E_DEMOS_TIMEOUT_MS`). Validated by the schema
+      // (positive int), but guard defensively here too so a bad value falls
+      // through to the dep/default rather than silently disabling the cap.
+      const inputTimeoutMs =
+        typeof input.timeout_ms === "number" &&
+        Number.isFinite(input.timeout_ms) &&
+        input.timeout_ms > 0
+          ? input.timeout_ms
+          : NaN;
       const timeoutMs =
         Number.isFinite(envParsed) && envParsed > 0
           ? envParsed
-          : (depTimeoutMs ?? DEFAULT_TIMEOUT_MS);
+          : Number.isFinite(inputTimeoutMs)
+            ? inputTimeoutMs
+            : (depTimeoutMs ?? DEFAULT_TIMEOUT_MS);
 
       // Per-run side-emit closure. Captures ctx + a warnedNoWriter flag
       // so the writer-missing warn fires once per run instead of per


### PR DESCRIPTION
## Summary

Phase 2 of the harness pool-fleet migration: make the three remaining BROWSER probe families (`e2e_smoke`, `e2e_demos`, `e2e_deep`) actually run on the fleet by wiring producers into the control-plane. The worker `DriverRegistry` for all four browser kinds already landed in #5283; this PR is purely the PRODUCER side. Builds on #5283/#5284/#5285/#5286 (all merged).

### Unit A — three catalog-enumerator factories
`createE2eSmokeServiceEnumerator` / `createE2eDemosServiceEnumerator` / `createE2eDeepServiceEnumerator`, each a thin specialization of the generic `createServiceEnumerator` (the #5285 seam) with its own `driverKind` + dashboard `probeKey` prefix and the shared `D6_DISCOVERY_FILTER`:

| family | driverKind | probeKey prefix | verified against |
|---|---|---|---|
| smoke | `e2e_smoke` | `d4:<slug>` | `src/cli/targets.ts` `d4:${slug}` |
| demos | `e2e_demos` | `e2e-demos:<slug>` | `config/probes/e2e-demos.yml` `id: e2e-demos` |
| deep | `e2e_deep` | `d5-single-pill-e2e:<slug>` | `src/cli/targets.ts` `d5-single-pill-e2e:${slug}` |

### Unit B — multi-schedule wiring in `runControlPlane`
`runControlPlane` now builds four producers and passes a `schedules` array to `createControlPlane` (the #5285 multi-schedule API) via a new pure `buildProducerSchedules` helper. Crons are read **literally from the config YAMLs** — the deliberate offsets stagger the four families' Playwright fan-outs on the shared `BrowserPool`:

| scheduleId | cron | source |
|---|---|---|
| `fleet-job-producer` | `40 * * * *` | d6 (unchanged; still honors `FLEET_PRODUCER_CRON`) |
| `fleet-producer-e2e-smoke` | `*/15 * * * *` | `e2e-smoke.yml` |
| `fleet-producer-e2e-demos` | `10 * * * *` | `e2e-demos.yml` |
| `fleet-producer-e2e-deep` | `5,20,35,50 * * * *` | `e2e-deep.yml` |

The in-process HTTP probe runner (#5284) and the d6 producer's REQ-B sweep leg are left intact (additive). The worker registry is **not** touched.

### R-timeout (demos) — addressed
The demos driver's 20-min outer cap is threaded in-process via the legacy `E2E_DEMOS_TIMEOUT_MS` env, which the **fleet worker never sets** — so without a fix the 38-demo service would blow the driver's 5-min `DEFAULT_TIMEOUT_MS` and go all-red. Fix:
- New `E2E_DEMOS_TIMEOUT_MS` SSOT const (mirrors `e2e-demos.yml` `timeout_ms`) in the enumerator module.
- `createE2eDemosServiceEnumerator` conveys the cap per-job in `driverInputs.timeout_ms` (smoke/deep convey nothing — verified no `timeout_ms` on their specs, and d6's spec shape is unchanged).
- The demos driver now reads `input.timeout_ms` as a resolution source: `ctx.env.E2E_DEMOS_TIMEOUT_MS` (legacy) > `input.timeout_ms` (fleet) > `deps.timeoutMs` > `DEFAULT_TIMEOUT_MS`. Schema gains `timeout_ms: z.number().int().positive().optional()`.

### Risks honored
- **R3 pool-contention (deploy-time):** all four families' jobs are claimed by the same pooled worker(s) drawing from ONE `BrowserPool` under `BROWSER_POOL_MAX_CONTEXTS` (24). Per-family `max_concurrency` governs producer ENQUEUE width, not worker execution. The guard is the offset crons + the 24-cap — preserved faithfully here. **Verify at deploy time by triggering each family's producer and confirming the BrowserPool does not starve.**
- **R1 context-headers (verified, no change):** both `createPooledE2eSmokeLauncher` and `createPooledE2eDeepLauncher` thread `contextOpts.extraHTTPHeaders`, so smoke + deep set their per-slug `X-AIMock-Context` themselves.

## Test plan
- [x] Unit A: `createE2eSmoke/Demos/Deep` factories stamp the right driverKind + probeKey shape and carry driverInputs; demos conveys `timeout_ms` (default + override); d6 equivalence (no `timeout_ms`) asserted — red→green verified.
- [x] Demos driver reads `input.timeout_ms` when the env is absent (fleet path), env still wins over input (precedence) — red→green verified.
- [x] Unit B: `buildProducerSchedules` emits 4 schedules with exact ids + crons; `FLEET_PRODUCER_CRON` override applies to d6 only; `runControlPlane` registers all 4 producer schedules on the live scheduler alongside the `probe:*` HTTP entries — red→green verified.
- [x] Full harness suite green: **120 files / 2128 tests passed**.
- [x] `tsc --noEmit` clean except the lone pre-existing `toReversed` error.
- [ ] Deploy-time: trigger each family's producer and verify BrowserPool does not starve under co-firing (R3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)