### PR TITLE
feat(showcase): mount /api/probes trigger endpoint on the fleet control-plane

### DIFF
--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -3901,6 +3901,227 @@ describe("orchestrator runControlPlane in-process HTTP probes", () => {
     // After stop() the watcher's unsubscribe ran → no reload fires anymore.
     expect(unwatched).toBe(true);
   });
+
+  // ── /api/probes trigger endpoint on the control-plane ──────────────────
+  //
+  // The control-plane runs the 8 in-process HTTP probe families on its own
+  // scheduler under `probe:<id>` entries. The on-demand trigger endpoint
+  // (`POST /api/probes/:id/trigger`, bearer-auth gated) lets operators fire a
+  // family immediately instead of waiting on the slow cron. It is mounted via
+  // the SAME `registerProbesRoutes` boot() uses, wired from the control-plane's
+  // own `httpProbeRegistry`/`httpProbeConfigs`/`scheduler`/`httpRunWriter` and
+  // `OPS_TRIGGER_TOKEN`. The router id namespace is the prefixed scheduler id
+  // (`probe:<cfg.id>`), matching boot() and the in-process registration.
+  describe("on-demand trigger endpoint (/api/probes)", () => {
+    const TOKEN = "cp-trigger-token";
+    let prevToken: string | undefined;
+
+    beforeEach(() => {
+      prevToken = process.env.OPS_TRIGGER_TOKEN;
+      process.env.OPS_TRIGGER_TOKEN = TOKEN;
+    });
+
+    afterEach(() => {
+      if (prevToken === undefined) delete process.env.OPS_TRIGGER_TOKEN;
+      else process.env.OPS_TRIGGER_TOKEN = prevToken;
+    });
+
+    function pbMock() {
+      vi.doMock("@hono/node-server", async () => {
+        const actual =
+          await vi.importActual<typeof import("@hono/node-server")>(
+            "@hono/node-server",
+          );
+        return { ...actual };
+      });
+      vi.doMock("./storage/pb-client.js", async () => {
+        const actual = await vi.importActual<
+          typeof import("./storage/pb-client.js")
+        >("./storage/pb-client.js");
+        return {
+          ...actual,
+          createPbClient: () => ({
+            health: async () => true,
+            getOne: async () => null,
+            getFirst: async () => null,
+            getList: async () => ({ items: [] }),
+          }),
+        };
+      });
+    }
+
+    it("GET /api/probes lists the in-process HTTP families (and not the browser kind)", async () => {
+      vi.resetModules();
+      pbMock();
+      const orchMod = await import("./orchestrator.js");
+      const handle = await orchMod.runControlPlane(
+        { role: "control-plane", poolCount: 1 },
+        { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+      );
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}/api/probes`);
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { probes: Array<{ id: string }> };
+        const ids = body.probes.map((p) => p.id).sort();
+        // The 3 HTTP families written to the temp probes dir, under their
+        // prefixed scheduler ids.
+        expect(ids).toEqual(
+          ["probe:image_drift", "probe:qa", "probe:smoke"].sort(),
+        );
+        // Browser kind is worker-routed, never in-process → not listed.
+        expect(ids).not.toContain("probe:e2e_smoke");
+      } finally {
+        await handle.stop();
+      }
+    });
+
+    it("POST /api/probes/probe:smoke/trigger with the bearer token runs the in-process probe", async () => {
+      vi.resetModules();
+      pbMock();
+
+      // Capture trigger() calls on the real scheduler so we can assert the
+      // route routed the request to the control-plane's scheduler entry.
+      const triggered: string[] = [];
+      vi.doMock("./scheduler/scheduler.js", async () => {
+        const actual = await vi.importActual<
+          typeof import("./scheduler/scheduler.js")
+        >("./scheduler/scheduler.js");
+        return {
+          ...actual,
+          createScheduler: (
+            deps: Parameters<typeof actual.createScheduler>[0],
+          ) => {
+            const real = actual.createScheduler(deps);
+            return {
+              ...real,
+              trigger: async (id: string, opts?: unknown) => {
+                triggered.push(id);
+                return { runId: "run_cp", status: "queued", probe: id };
+              },
+            };
+          },
+        };
+      });
+
+      const orchMod = await import("./orchestrator.js");
+      const handle = await orchMod.runControlPlane(
+        { role: "control-plane", poolCount: 1 },
+        { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+      );
+      try {
+        const res = await fetch(
+          `http://127.0.0.1:${port}/api/probes/probe:smoke/trigger`,
+          {
+            method: "POST",
+            headers: { Authorization: `Bearer ${TOKEN}` },
+          },
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { runId: string; probe: string };
+        expect(body.runId).toBe("run_cp");
+        expect(body.probe).toBe("probe:smoke");
+        // The route invoked the control-plane scheduler's entry for the probe.
+        expect(triggered).toContain("probe:smoke");
+      } finally {
+        await handle.stop();
+      }
+    });
+
+    it("POST /api/probes/probe:smoke/trigger WITHOUT the bearer token 401s", async () => {
+      vi.resetModules();
+      pbMock();
+      const orchMod = await import("./orchestrator.js");
+      const handle = await orchMod.runControlPlane(
+        { role: "control-plane", poolCount: 1 },
+        { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+      );
+      try {
+        const res = await fetch(
+          `http://127.0.0.1:${port}/api/probes/probe:smoke/trigger`,
+          { method: "POST" },
+        );
+        expect(res.status).toBe(401);
+      } finally {
+        await handle.stop();
+      }
+    });
+
+    it("POST /api/probes/probe:e2e_smoke/trigger 404s — browser families are not in-process", async () => {
+      vi.resetModules();
+      pbMock();
+      const orchMod = await import("./orchestrator.js");
+      const handle = await orchMod.runControlPlane(
+        { role: "control-plane", poolCount: 1 },
+        { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+      );
+      try {
+        const res = await fetch(
+          `http://127.0.0.1:${port}/api/probes/probe:e2e_smoke/trigger`,
+          {
+            method: "POST",
+            headers: { Authorization: `Bearer ${TOKEN}` },
+          },
+        );
+        // browser-only id is not a registered in-process probe → 404
+        expect(res.status).toBe(404);
+      } finally {
+        await handle.stop();
+      }
+    });
+
+    it("POST /api/probes/probe:nope/trigger 404s for an unknown id", async () => {
+      vi.resetModules();
+      pbMock();
+      const orchMod = await import("./orchestrator.js");
+      const handle = await orchMod.runControlPlane(
+        { role: "control-plane", poolCount: 1 },
+        { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+      );
+      try {
+        const res = await fetch(
+          `http://127.0.0.1:${port}/api/probes/probe:nope/trigger`,
+          {
+            method: "POST",
+            headers: { Authorization: `Bearer ${TOKEN}` },
+          },
+        );
+        expect(res.status).toBe(404);
+      } finally {
+        await handle.stop();
+      }
+    });
+
+    it("does NOT mount the trigger endpoint when OPS_TRIGGER_TOKEN is unset (fail-safe)", async () => {
+      delete process.env.OPS_TRIGGER_TOKEN;
+      vi.resetModules();
+      pbMock();
+      const orchMod = await import("./orchestrator.js");
+      const handle = await orchMod.runControlPlane(
+        { role: "control-plane", poolCount: 1 },
+        { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+      );
+      try {
+        // Router not mounted → /api/probes returns Hono's default 404.
+        const res = await fetch(`http://127.0.0.1:${port}/api/probes`);
+        expect(res.status).toBe(404);
+      } finally {
+        await handle.stop();
+      }
+    });
+
+    it("throws fail-loud when OPS_TRIGGER_TOKEN is set-but-empty", async () => {
+      process.env.OPS_TRIGGER_TOKEN = "   ";
+      vi.resetModules();
+      pbMock();
+      const orchMod = await import("./orchestrator.js");
+      await expect(
+        orchMod.runControlPlane(
+          { role: "control-plane", poolCount: 1 },
+          { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+        ),
+      ).rejects.toThrow(/OPS_TRIGGER_TOKEN.*empty/i);
+    });
+  });
 });
 
 // A4 drift-lock: the HTTP-only driver set registered by

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -2661,6 +2661,44 @@ export async function runControlPlane(
     );
   }
 
+  // On-demand /api/probes trigger surface. The control-plane now runs the
+  // in-process HTTP probe families, so operators need the same manual-trigger
+  // endpoint boot() exposes (fire a family immediately instead of waiting on
+  // its slow cron). Mounted via the SAME `registerProbesRoutes` boot() uses —
+  // wired from the control-plane's own `httpProbeRegistry`/`httpProbeConfigs`/
+  // `scheduler`/`httpRunWriter`. The router id namespace is the prefixed
+  // scheduler id (`probe:<cfg.id>`), matching both `httpProbeConfigs`'s keying
+  // and the `scheduler.register({ id: "probe:<id>" })` entries — so the
+  // `isProbeId` guard inside the router admits exactly the in-process HTTP
+  // families and 404s everything else (browser-only `probe:e2e_*` ids, the
+  // producer's own entries, and unknown ids).
+  //
+  // Token handling mirrors boot() exactly (fail-safe): unset → router omitted;
+  // set-but-empty (incl. whitespace-only) → fail-loud at boot so a mistyped
+  // `OPS_TRIGGER_TOKEN=` can't silently ship an insecure/always-reject route.
+  const rawTriggerToken = process.env.OPS_TRIGGER_TOKEN;
+  if (rawTriggerToken !== undefined && rawTriggerToken.trim() === "") {
+    throw new Error(
+      "OPS_TRIGGER_TOKEN is set but empty — refusing to mount probes router with insecure auth",
+    );
+  }
+  const triggerToken = rawTriggerToken?.trim(); // undefined or non-empty
+  const probesDeps = triggerToken
+    ? {
+        scheduler,
+        writer: httpRunWriter,
+        getProbeConfig: (id: string): ProbeConfig | undefined =>
+          httpProbeConfigs.get(id),
+        triggerToken,
+        now: () => Date.now(),
+      }
+    : undefined;
+  if (!triggerToken) {
+    logger.info("fleet.control-plane.probes-router-disabled", {
+      reason: "OPS_TRIGGER_TOKEN unset — /api/probes routes not mounted",
+    });
+  }
+
   // Minimal HTTP surface for the role's liveness `port` (fleet-health probes
   // hit this). /health reports OK once the producer's scheduler entry is live.
   const app = buildServer({
@@ -2686,6 +2724,7 @@ export async function runControlPlane(
     schedulerJobCount: () => scheduler.list().length,
     schedulerIsStopped: () => scheduler.isStopped(),
     bus,
+    probes: probesDeps,
   });
 
   scheduler.start();


### PR DESCRIPTION
## Summary

The fleet **control-plane** runs the 8 in-process HTTP probe families (smoke, starter_smoke, image_drift, qa, aimock_wiring, version_drift, pin_drift, redirect_decommission) on its scheduler, but the on-demand trigger endpoint `POST /api/probes/:id/trigger` was only mounted on the legacy `boot()` path. There was no way to fire a family immediately on the control-plane — operators had to wait on the slow cron.

This wires the **same** `registerProbesRoutes` onto the control-plane's `buildServer` call in `runControlPlane`, using the control-plane's already-built `httpProbeRegistry` / `httpProbeConfigs` / `scheduler` / `httpRunWriter` and `OPS_TRIGGER_TOKEN`. Enables instant verification instead of waiting on crons.

- **Triggerable ids** (control-plane): the prefixed in-process HTTP probe scheduler ids — `probe:smoke`, `probe:image_drift`, `probe:qa`, etc. (whatever HTTP families are loaded). The router's `isProbeId` guard resolves against `httpProbeConfigs` (keyed `probe:<cfg.id>`).
- **404'd**: browser-only families (`probe:e2e_smoke`, `probe:e2e_demos`, `probe:e2e_deep`, `probe:e2e_d6`) — they are worker-routed, never run in-process — plus unknown ids and the producer's own scheduler entries.
- **Fail-safe token handling mirrors `boot()` exactly**: `OPS_TRIGGER_TOKEN` unset → router omitted (route 404s); set-but-empty / whitespace-only → fail-loud at boot (refuses to mount an insecure route); missing bearer token → 401.

## Scope

Minimal: only the `buildServer({ ..., probes })` wiring + the boot()-equivalent token resolution in `runControlPlane`. No changes to `probes.ts`, the in-process runner, or the worker/boot paths.

## Test plan

- [x] RED→GREEN: with the impl reverted, the GET-list / trigger-runs / no-token-401 / empty-token-fail-loud tests fail (route absent → 404); with the impl they pass.
- [x] New tests in `orchestrator.test.ts` (real `runControlPlane` boot on a live port): GET `/api/probes` lists the 3 HTTP families (not the browser kind); POST `probe:smoke/trigger` with bearer runs it; 401 without token; 404 for `probe:e2e_smoke` and unknown ids; router omitted when token unset; fail-loud on empty token.
- [x] Full harness suite green: 120 files / 2135 tests.
- [x] `tsc -p tsconfig.build.json` clean.
- [x] oxlint / oxfmt clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)