### PR TITLE
fix(showcase-harness): pnpm-packages discovery must skip out-of-prefix deep-glob patterns instead of throwing (version_drift enumerate failure)

### DIFF
--- a/showcase/harness/src/probes/discovery/pnpm-packages.test.ts
+++ b/showcase/harness/src/probes/discovery/pnpm-packages.test.ts
@@ -388,6 +388,57 @@ describe("pnpmPackagesDiscoverySource", () => {
     ).rejects.toBeInstanceOf(DiscoverySourceSchemaError);
   });
 
+  it("skips out-of-prefix deep-glob patterns instead of throwing when pathPrefix is set", async () => {
+    // Regression: the fleet pnpm-workspace.yaml carries a multi-segment
+    // glob (`examples/v2/*/apps/*`) that the strict matcher rejects. The
+    // version_drift probe only wants `packages/`, so an unsupported
+    // pattern that can't possibly match the requested prefix must be
+    // skipped BEFORE its glob shape is validated — otherwise enumeration
+    // aborts with discoveryFailed:true and writes 0 rows.
+    await writeFile(
+      "pnpm-workspace.yaml",
+      `packages:\n  - "packages/*"\n  - "examples/v2/*/apps/*"\n`,
+    );
+    await writeFile(
+      "packages/runtime/package.json",
+      JSON.stringify({ name: "@copilotkit/runtime", version: "1.2.0" }),
+    );
+    await writeFile(
+      "packages/core/package.json",
+      JSON.stringify({ name: "@copilotkit/core", version: "0.9.5" }),
+    );
+    // A real example app under the deep-glob path — proves we don't crash
+    // on it and don't (wrongly) include it given the packages/ prefix.
+    await writeFile(
+      "examples/v2/react/apps/demo/package.json",
+      JSON.stringify({ name: "demo-app", version: "0.0.0" }),
+    );
+    const records = await pnpmPackagesDiscoverySource.enumerate(BASE_CTX, {
+      rootDir: tmpDir,
+      pathPrefix: "packages/",
+    });
+    expect(records.map((r) => r.name).sort()).toEqual([
+      "@copilotkit/core",
+      "@copilotkit/runtime",
+    ]);
+  });
+
+  it("still throws on an unsupported deep-glob pattern that DOES match the requested prefix", async () => {
+    // The skip is scoped to patterns that can't match the prefix. A
+    // deep-glob whose own prefix overlaps the requested pathPrefix is
+    // still a genuine unsupported-shape error and must surface loudly.
+    await writeFile(
+      "pnpm-workspace.yaml",
+      `packages:\n  - "packages/*/apps/*"\n`,
+    );
+    await expect(
+      pnpmPackagesDiscoverySource.enumerate(BASE_CTX, {
+        rootDir: tmpDir,
+        pathPrefix: "packages/",
+      }),
+    ).rejects.toBeInstanceOf(DiscoverySourceSchemaError);
+  });
+
   it("skips non-directory entries inside a globbed prefix", async () => {
     await writeFile("pnpm-workspace.yaml", `packages:\n  - "packages/*"\n`);
     await writeFile(

--- a/showcase/harness/src/probes/discovery/pnpm-packages.ts
+++ b/showcase/harness/src/probes/discovery/pnpm-packages.ts
@@ -77,7 +77,7 @@ export const pnpmPackagesDiscoverySource: DiscoverySource<PnpmPackageRecord> = {
     const workspacePath = path.join(rootDir, "pnpm-workspace.yaml");
 
     const patterns = await readWorkspacePatterns(workspacePath);
-    const matchedDirs = await expandPatterns(rootDir, patterns);
+    const matchedDirs = await expandPatterns(rootDir, patterns, filter.pathPrefix);
 
     const records: PnpmPackageRecord[] = [];
     for (const relDir of matchedDirs) {
@@ -165,19 +165,60 @@ async function readWorkspacePatterns(workspacePath: string): Promise<string[]> {
 }
 
 /**
+ * The static (wildcard-free) leading portion of a pattern — everything
+ * before the first `*`. Every directory a pattern can possibly match
+ * begins with this prefix, so it's the cheapest sound test for "could
+ * this pattern ever produce a path under the requested pathPrefix?".
+ * For a literal pattern the whole pattern is its static prefix.
+ */
+function staticPrefix(pattern: string): string {
+  const starIdx = pattern.indexOf("*");
+  return starIdx === -1 ? pattern : pattern.slice(0, starIdx);
+}
+
+/**
+ * True iff a pattern could match at least one directory under
+ * `pathPrefix`. Two ranges of paths overlap iff one's static prefix is a
+ * prefix of the other's: e.g. pathPrefix "packages/" overlaps pattern
+ * "packages/*" and "packages/*\/apps/*" (static "packages/"), but NOT
+ * "examples/v2/*\/apps/*" (static "examples/v2/"). When no pathPrefix is
+ * requested every pattern is in scope.
+ */
+function patternIntersectsPrefix(
+  pattern: string,
+  pathPrefix: string | undefined,
+): boolean {
+  if (!pathPrefix) return true;
+  const sp = staticPrefix(pattern);
+  return sp.startsWith(pathPrefix) || pathPrefix.startsWith(sp);
+}
+
+/**
  * Expand a list of pnpm-workspace patterns into workspace-relative dirs.
  * Supports: literal paths, `<prefix>/*`, and leading-`!` negation.
  * Does NOT support `**` or brace expansion (see class-level JSDoc).
+ *
+ * When `pathPrefix` is set, patterns whose static prefix cannot intersect
+ * it are skipped BEFORE their glob shape is validated. This keeps a
+ * deep-glob the workspace uses for an unrelated subtree (e.g.
+ * `examples/v2/*\/apps/*`) from aborting enumeration for a probe that only
+ * wants `packages/` — the strict-shape SchemaError still fires for an
+ * unsupported pattern that DOES overlap the requested prefix.
  */
 async function expandPatterns(
   rootDir: string,
   patterns: string[],
+  pathPrefix?: string,
 ): Promise<string[]> {
   const include: string[] = [];
   const exclude: string[] = [];
   for (const p of patterns) {
-    if (p.startsWith("!")) exclude.push(p.slice(1));
-    else include.push(p);
+    const bare = p.startsWith("!") ? p.slice(1) : p;
+    // Out-of-prefix patterns can neither add nor remove an in-prefix dir,
+    // so skip both includes and excludes before shape validation.
+    if (!patternIntersectsPrefix(bare, pathPrefix)) continue;
+    if (p.startsWith("!")) exclude.push(bare);
+    else include.push(bare);
   }
   const dirs = new Set<string>();
   for (const pattern of include) {

--- a/showcase/harness/src/probes/discovery/pnpm-packages.ts
+++ b/showcase/harness/src/probes/discovery/pnpm-packages.ts
@@ -77,7 +77,11 @@ export const pnpmPackagesDiscoverySource: DiscoverySource<PnpmPackageRecord> = {
     const workspacePath = path.join(rootDir, "pnpm-workspace.yaml");
 
     const patterns = await readWorkspacePatterns(workspacePath);
-    const matchedDirs = await expandPatterns(rootDir, patterns, filter.pathPrefix);
+    const matchedDirs = await expandPatterns(
+      rootDir,
+      patterns,
+      filter.pathPrefix,
+    );
 
     const records: PnpmPackageRecord[] = [];
     for (const relDir of matchedDirs) {


### PR DESCRIPTION
## Summary

The `version_drift` probe fails on the fleet control-plane with `probe.discovery-enumerate-failed` / `discoveryFailed:true` and writes 0 PB rows.

**Root cause:** the fleet `pnpm-workspace.yaml` carries a multi-segment glob `examples/v2/*/apps/*`. The `pnpm-packages` discovery source's `matchPattern` only supports literals and trailing `/*`, and throws `DiscoverySourceSchemaError("unsupported pnpm-workspace glob pattern")` for any pattern whose segment after the first `*` is not `""`/`"/"`. That throw happens inside `expandPatterns` during enumeration — **before** the probe's `pathPrefix: "packages/"` filter is applied — so it aborts the entire enumeration. `version_drift` never gets to filter to `packages/`; it just fails.

**Fix (option a):** thread `pathPrefix` into `expandPatterns` and skip any pattern whose static (wildcard-free) leading prefix cannot intersect the requested `pathPrefix`, **before** validating its glob shape. `examples/v2/*/apps/*` (static prefix `examples/v2/`) is skipped when the probe only wants `packages/`, so enumeration completes and returns the `packages/` set.

Preserved behavior:
- An unsupported deep-glob that DOES overlap the requested prefix (e.g. `packages/*/apps/*` with `pathPrefix: packages/`) still throws the strict-shape SchemaError.
- With no `pathPrefix`, every pattern is in scope and the existing strict-throw behavior is unchanged.

## Changes
- `showcase/harness/src/probes/discovery/pnpm-packages.ts` — `staticPrefix` + `patternIntersectsPrefix` helpers; `expandPatterns` now takes `pathPrefix` and skips out-of-prefix include/exclude patterns before shape validation.
- `showcase/harness/src/probes/discovery/pnpm-packages.test.ts` — red→green regression tests.

## Test plan
- [x] Red: new "skips out-of-prefix deep-glob" test fails against unfixed source (throws SchemaError in `expandPatterns`)
- [x] Green: same test passes after the fix; out-of-prefix deep-glob skipped, `packages/` packages still enumerated
- [x] Preserved: unsupported deep-glob overlapping the prefix still throws; existing "non-trailing `*` throws" test (no pathPrefix) unchanged
- [x] Full harness suite: 2137 passed (120 files)
- [x] `tsc -p tsconfig.build.json` clean