### PR TITLE
fix(showcase): fail verify-deploy when dashboard config carries an env-unset sentinel

### DIFF
--- a/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
@@ -657,10 +657,16 @@ describe.each(DRIVER_CASES)(
         });
       });
       const healthUrls = seen.filter((u) => !u.includes("/graphql/v2"));
-      expect(healthUrls).toHaveLength(1);
-      expect(healthUrls[0]).toBe(
-        `https://${entry.domains.prod}${expectedHealthPath}`,
-      );
+      // The dashboard driver makes a SECOND GET to `/` after the baseline
+      // healthcheck to fetch + sentinel-check the injected
+      // `__SHOWCASE_CONFIG__` (see verify-deploy.drivers.dashboard.ts). That
+      // extra GET targets the same `/` path, so both non-graphql fetches go
+      // to `https://<host>/`. Every other driver makes exactly one.
+      const expectedHealthCount = label === "dashboard" ? 2 : 1;
+      expect(healthUrls).toHaveLength(expectedHealthCount);
+      for (const u of healthUrls) {
+        expect(u).toBe(`https://${entry.domains.prod}${expectedHealthPath}`);
+      }
     });
 
     it("queries Railway with the SSOT serviceId for the resolved env", async () => {
@@ -723,3 +729,134 @@ describe.each(DRIVER_CASES)(
     });
   },
 );
+
+describe("probeDashboard runtime-config sentinel guard", () => {
+  // Build the dashboard `/` HTML carrying the root-layout injection
+  // `<script id="__showcase_config__">window.__SHOWCASE_CONFIG__={...};</script>`.
+  // The serializer escapes `<` to <; our config URLs never contain `<`,
+  // so the JSON is byte-identical to JSON.stringify.
+  function dashboardHtml(cfg: Record<string, unknown>): string {
+    const json = JSON.stringify(cfg);
+    return `<!doctype html><html><head><script id="__showcase_config__">window.__SHOWCASE_CONFIG__=${json};</script></head><body>ok</body></html>`;
+  }
+
+  const PROD_INVALID_SHELL_URL = "about:blank#shell-url-missing";
+  const PROD_INVALID_POCKETBASE_URL = "http://pocketbase.invalid";
+  const HEALTHY_CFG = {
+    pocketbaseUrl: "https://pb.example.com",
+    shellUrl: "https://shell.example.com",
+    opsBaseUrl: "",
+  };
+
+  // Drive the full driver (baseline GraphQL + healthcheck, then the
+  // config GET) with a single seam that serves SUCCESS for GraphQL, 200
+  // for every page GET, and the provided HTML body.
+  function seamFor(html: string): FetchLike {
+    return makeFetch((url) => {
+      if (url.includes("/graphql/v2")) return gqlDeploymentResponse("SUCCESS");
+      return Promise.resolve(mkResponse({ status: 200, text: html }));
+    });
+  }
+
+  const entry = SERVICES.dashboard;
+  const target: ProbeTarget = {
+    name: "dashboard",
+    host: asHost(entry.domains.prod),
+    driver: "dashboard",
+  };
+
+  it("passes when the injected config is healthy", async () => {
+    await withGlobalSeam(
+      seamFor(dashboardHtml(HEALTHY_CFG)),
+      TOKEN,
+      async () => {
+        const out = await probeDashboard(target);
+        expect(out.ok).toBe(true);
+      },
+    );
+  });
+
+  it("fails loud when shellUrl is the env-unset sentinel", async () => {
+    await withGlobalSeam(
+      seamFor(
+        dashboardHtml({ ...HEALTHY_CFG, shellUrl: PROD_INVALID_SHELL_URL }),
+      ),
+      TOKEN,
+      async () => {
+        const out = await probeDashboard(target);
+        expect(out.ok).toBe(false);
+        if (out.ok === false) {
+          expect(out.error).toMatch(/shellUrl/);
+          expect(out.error).toContain(PROD_INVALID_SHELL_URL);
+          expect(out.error).toMatch(/SHELL_URL/);
+        }
+      },
+    );
+  });
+
+  it("fails loud when pocketbaseUrl is the env-unset sentinel", async () => {
+    await withGlobalSeam(
+      seamFor(
+        dashboardHtml({
+          ...HEALTHY_CFG,
+          pocketbaseUrl: PROD_INVALID_POCKETBASE_URL,
+        }),
+      ),
+      TOKEN,
+      async () => {
+        const out = await probeDashboard(target);
+        expect(out.ok).toBe(false);
+        if (out.ok === false) {
+          expect(out.error).toMatch(/pocketbaseUrl/);
+          expect(out.error).toContain(PROD_INVALID_POCKETBASE_URL);
+        }
+      },
+    );
+  });
+
+  it("does NOT false-fail when the config block is absent from the page", async () => {
+    await withGlobalSeam(
+      seamFor("<html><body>rendered without a config block</body></html>"),
+      TOKEN,
+      async () => {
+        const out = await probeDashboard(target);
+        expect(out.ok).toBe(true);
+      },
+    );
+  });
+
+  it("fails when the config block is present but malformed JSON", async () => {
+    await withGlobalSeam(
+      seamFor(
+        '<html><head><script id="__showcase_config__">window.__SHOWCASE_CONFIG__={broken};</script></head><body>ok</body></html>',
+      ),
+      TOKEN,
+      async () => {
+        const out = await probeDashboard(target);
+        expect(out.ok).toBe(false);
+        if (out.ok === false) expect(out.error).toMatch(/not valid JSON/);
+      },
+    );
+  });
+
+  it("surfaces a config-fetch failure as a probe error (after a green baseline)", async () => {
+    // GraphQL + the baseline healthcheck succeed; the SECOND GET (the
+    // config probe) throws. The dashboard driver must surface it, not
+    // silently pass.
+    let pageGets = 0;
+    const seam = makeFetch((url) => {
+      if (url.includes("/graphql/v2")) return gqlDeploymentResponse("SUCCESS");
+      pageGets += 1;
+      if (pageGets === 1) return Promise.resolve(mkResponse({ status: 200 }));
+      throw new Error("connection refused");
+    });
+    await withGlobalSeam(seam, TOKEN, async () => {
+      const out = await probeDashboard(target);
+      expect(out.ok).toBe(false);
+      if (out.ok === false) {
+        expect(out.error).toMatch(/runtime-config GET/);
+        expect(out.error).toMatch(/connection refused/);
+      }
+    });
+  });
+});

--- a/showcase/scripts/verify-deploy.drivers.dashboard.ts
+++ b/showcase/scripts/verify-deploy.drivers.dashboard.ts
@@ -1,19 +1,165 @@
 import type { ProbeTarget } from "./verify-deploy";
 import type { ProbeOutcome } from "./verify-deploy.drivers";
+import type { FetchLike } from "./verify-deploy.drivers.baseline";
 import { probeBaseline } from "./verify-deploy.drivers.baseline";
+
+const DRIVER_LABEL = "dashboard";
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Production sentinels the dashboard's runtime-config reader emits when a
+ * required env var is unset on the Railway service. When either of these
+ * lands in the injected `window.__SHOWCASE_CONFIG__`, the dashboard renders
+ * with dead Demo/Code/hover-preview links (shellUrl) or dead Status-tab
+ * live-readers (pocketbaseUrl) — a 200 that is NOT healthy.
+ *
+ * These MUST stay in sync with the SSOT in
+ * `showcase/shell-dashboard/src/lib/runtime-config.ts:39-40`
+ * (`PROD_INVALID_POCKETBASE_URL` / `PROD_INVALID_SHELL_URL`). That module
+ * imports `next/cache`, so it cannot be cleanly imported into the scripts
+ * tsconfig (the scripts typecheck has no Next types and `include` is scoped
+ * to this directory); we mirror the literals here with this pointer instead
+ * of pulling Next into the verify-deploy toolchain.
+ */
+const PROD_INVALID_SHELL_URL = "about:blank#shell-url-missing";
+const PROD_INVALID_POCKETBASE_URL = "http://pocketbase.invalid";
+
+function isAbortError(e: unknown): boolean {
+  if (!e || typeof e !== "object") return false;
+  return (e as { name?: unknown }).name === "AbortError";
+}
+
+/**
+ * Extract the inlined runtime config from the dashboard's HTML. The root
+ * layout (`shell-dashboard/src/app/layout.tsx`) injects an inline
+ * `<script id="__showcase_config__">` whose body is
+ * `window.__SHOWCASE_CONFIG__={...};`. The serializer
+ * (`runtime-config-serialize.ts`) escapes `<` to `<`, so the JSON
+ * payload never contains a raw `<` — the `[^<]*?` body match is safe.
+ *
+ * Returns the parsed config object, or `undefined` when the block is not
+ * present on the page (some renders may omit it) — in that case the probe
+ * must NOT false-fail.
+ */
+function extractInjectedConfig(
+  html: string,
+): Record<string, unknown> | undefined {
+  const match = html.match(/window\.__SHOWCASE_CONFIG__\s*=\s*(\{[^<]*?\});/);
+  if (!match) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(match[1]);
+  } catch {
+    // A malformed config block is itself a wiring bug; treat it as "present
+    // but unusable" so we don't silently pass. Surface via the caller's
+    // sentinel-check path by returning an empty object — the caller fails
+    // only on a recognized sentinel, so we instead throw to be explicit.
+    throw new Error("__SHOWCASE_CONFIG__ present but not valid JSON");
+  }
+  if (parsed === null || typeof parsed !== "object") return undefined;
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * After a green baseline, fetch `/` and assert the injected runtime config
+ * is not carrying a production "env unset" sentinel. Returns an error
+ * string on a sentinel hit (or on a malformed config block); `undefined`
+ * when the config is healthy OR the block is simply absent.
+ */
+async function checkRuntimeConfigSentinels(
+  host: string,
+  fetchImpl: FetchLike,
+  timeoutMs: number,
+): Promise<string | undefined> {
+  const url = `https://${host}/`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  let res: Awaited<ReturnType<FetchLike>>;
+  try {
+    res = await fetchImpl(url, {
+      method: "GET",
+      headers: { "User-Agent": "verify-deploy" },
+      signal: controller.signal,
+    });
+  } catch (e: unknown) {
+    const msg = isAbortError(e)
+      ? `timed out after ${timeoutMs}ms`
+      : e instanceof Error
+        ? e.message
+        : String(e);
+    return `${DRIVER_LABEL}: runtime-config GET ${url} failed: ${msg}`;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  let html: string;
+  try {
+    html = await res.text();
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return `${DRIVER_LABEL}: runtime-config GET ${url} body read failed: ${msg}`;
+  }
+
+  let cfg: Record<string, unknown> | undefined;
+  try {
+    cfg = extractInjectedConfig(html);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return `${DRIVER_LABEL}: ${msg} at ${url}`;
+  }
+  // Block absent — do not false-fail (some renders omit it).
+  if (!cfg) return undefined;
+
+  if (cfg.shellUrl === PROD_INVALID_SHELL_URL) {
+    return (
+      `${DRIVER_LABEL}: injected __SHOWCASE_CONFIG__.shellUrl is the ` +
+      `"env unset" sentinel "${PROD_INVALID_SHELL_URL}" at ${url} — ` +
+      `Demo/Code/preview links are dead. Set SHELL_URL on the Railway service.`
+    );
+  }
+  if (cfg.pocketbaseUrl === PROD_INVALID_POCKETBASE_URL) {
+    return (
+      `${DRIVER_LABEL}: injected __SHOWCASE_CONFIG__.pocketbaseUrl is the ` +
+      `"env unset" sentinel "${PROD_INVALID_POCKETBASE_URL}" at ${url} — ` +
+      `Status-tab live-readers are dead. Set POCKETBASE_URL on the Railway service.`
+    );
+  }
+  return undefined;
+}
 
 /**
  * Feature-level verifier for the `shell-dashboard` Next.js service.
  *
- * Baseline (this commit): Railway deployment-SUCCESS + HTTP 200 on `/`.
- * Future driver-specific layer: dashboard-DOM assertion (catches the
- * "rendered the 404 chrome with 200" case Next.js dev quirks produce).
+ * Baseline: Railway deployment-SUCCESS + HTTP 200 on `/`.
+ *
+ * Driver-specific layer: after a green baseline, fetch `/`, parse the
+ * injected `window.__SHOWCASE_CONFIG__`, and FAIL if it carries a
+ * production "env unset" sentinel (`shellUrl === about:blank#shell-url-missing`
+ * or `pocketbaseUrl === http://pocketbase.invalid`). This catches the
+ * "200 but every Demo/Code/preview link is dead" case that a naked HTTP
+ * probe misses — the exact failure that shipped to staging when SHELL_URL
+ * was unset on the Railway service.
  */
 export async function probeDashboard(
   target: ProbeTarget,
 ): Promise<ProbeOutcome> {
-  return probeBaseline(target, {
-    driverLabel: "dashboard",
+  const baseline = await probeBaseline(target, {
+    driverLabel: DRIVER_LABEL,
     healthcheckPath: "/",
   });
+  if (!baseline.ok) return baseline;
+
+  // Reuse the same fetch impl/timeout policy as the baseline. Production
+  // callers use the real `globalThis.fetch`; tests inject a seam by passing
+  // a custom `globalThis.fetch` stub (the baseline's `fetchImpl` opt is not
+  // threaded here since `probeDashboard`'s public signature takes only a
+  // target — mirror that for the config check).
+  const sentinelErr = await checkRuntimeConfigSentinels(
+    target.host,
+    globalThis.fetch as unknown as FetchLike,
+    DEFAULT_TIMEOUT_MS,
+  );
+  if (sentinelErr) return { ok: false, error: sentinelErr };
+
+  return { ok: true };
 }


### PR DESCRIPTION
## Summary

The dashboard deploy probe previously only asserted HTTP 200, so a deploy with an unset `SHELL_URL` (or `POCKETBASE_URL`) on the Railway service shipped green even though the injected runtime config fell back to a sentinel — leaving every Demo/Code/hover-preview link (`shellUrl`) or Status-tab live-reader (`pocketbaseUrl`) dead. This exact failure hit staging.

After a green baseline, `probeDashboard` now fetches `/`, parses the injected `window.__SHOWCASE_CONFIG__`, and fails loud when `shellUrl` is `about:blank#shell-url-missing` or `pocketbaseUrl` is `http://pocketbase.invalid` (the `PROD_INVALID_*` sentinels in shell-dashboard runtime-config). When the config block is absent from a render it does not false-fail; a present-but-malformed block fails explicitly.

## Verification

Proven in a prior session.