### PR TITLE
docs: fix Copilot Runtime reference links

### DIFF
--- a/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -52,7 +52,7 @@ export interface CopilotKitProps extends Omit<
   };
 
   /**
-   * The endpoint for the Copilot Runtime instance. [Click here for more information](/concepts/copilot-runtime).
+   * The endpoint for the Copilot Runtime instance. [Click here for more information](/backend/copilot-runtime).
    */
   runtimeUrl?: string;
 

--- a/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -1,6 +1,6 @@
 /**
  * <Callout type="info">
- *   This is the reference for the `CopilotRuntime` class. For more information and example code snippets, please see [Concept: Copilot Runtime](/concepts/copilot-runtime).
+ *   This is the reference for the `CopilotRuntime` class. For more information and example code snippets, please see [Concept: Copilot Runtime](/backend/copilot-runtime).
  * </Callout>
  *
  * ## Usage

--- a/showcase/shell-docs/src/content/reference/v1/classes/CopilotRuntime.mdx
+++ b/showcase/shell-docs/src/content/reference/v1/classes/CopilotRuntime.mdx
@@ -11,7 +11,7 @@ description: "Copilot Runtime is the back-end component of CopilotKit, enabling 
   */
 }
 <Callout type="info">
-  This is the reference for the `CopilotRuntime` class. For more information and example code snippets, please see [Concept: Copilot Runtime](/concepts/copilot-runtime).
+  This is the reference for the `CopilotRuntime` class. For more information and example code snippets, please see [Concept: Copilot Runtime](/backend/copilot-runtime).
 </Callout>
  
 ## Usage

--- a/showcase/shell-docs/src/content/reference/v1/components/CopilotKit.mdx
+++ b/showcase/shell-docs/src/content/reference/v1/components/CopilotKit.mdx
@@ -46,7 +46,7 @@ Restrict input to specific topics using guardrails.
 </PropertyReference>
 
 <PropertyReference name="runtimeUrl" type="string"  > 
-The endpoint for the Copilot Runtime instance. [Click here for more information](/concepts/copilot-runtime).
+The endpoint for the Copilot Runtime instance. [Click here for more information](/backend/copilot-runtime).
 </PropertyReference>
 
 <PropertyReference name="transcribeAudioUrl" type="string"  > 


### PR DESCRIPTION
## What does this PR do?

Fixes stale Copilot Runtime documentation links that still point to `/concepts/copilot-runtime` and now route users to the existing `/backend/copilot-runtime` page.

This updates both the source JSDoc and the generated reference MDX so the current docs content and future regenerated reference docs stay aligned.

## Related PRs and Issues

- Closes #2082

## Testing

- `rg -n "concepts/copilot-runtime" packages showcase/shell-docs/src/content` returns no matches
- `rg -n "backend/copilot-runtime" packages/runtime/src/lib/runtime/copilot-runtime.ts packages/react-core/src/components/copilot-provider/copilotkit-props.tsx showcase/shell-docs/src/content/reference/v1/classes/CopilotRuntime.mdx showcase/shell-docs/src/content/reference/v1/components/CopilotKit.mdx`
- `git diff --check`

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)