### PR TITLE
fix(langgraph): honor emit tool call whitelists

### DIFF
--- a/packages/runtime/src/lib/runtime/agent-integrations/langgraph/__tests__/dispatch-event-filtering.test.ts
+++ b/packages/runtime/src/lib/runtime/agent-integrations/langgraph/__tests__/dispatch-event-filtering.test.ts
@@ -35,6 +35,22 @@ function makeTextEvent(
   };
 }
 
+function makeToolEvent(
+  type: EventType,
+  metadata: Record<string, any>,
+  toolCallId = "tc-1",
+  toolCallName?: string,
+) {
+  return {
+    type,
+    toolCallId,
+    ...(toolCallName !== undefined ? { toolCallName } : {}),
+    ...(type === EventType.TOOL_CALL_START ? { parentMessageId: "msg-1" } : {}),
+    ...(type === EventType.TOOL_CALL_ARGS ? { delta: '{"value":true}' } : {}),
+    rawEvent: { metadata },
+  };
+}
+
 function makeCustomEvent(name: string, value: any) {
   return {
     type: EventType.CUSTOM,
@@ -172,6 +188,106 @@ describe("dispatchEvent emit-tool-calls filtering", () => {
 
     expect(result).toBe(true);
     expect(events).toHaveLength(1);
+  });
+
+  it("filters tool event sequences by string whitelist", () => {
+    const { agent, events } = createAgent();
+    const metadata = { "copilotkit:emit-tool-calls": "draft_email_structured" };
+
+    expect(
+      agent.dispatchEvent(
+        makeToolEvent(
+          EventType.TOOL_CALL_START,
+          metadata,
+          "tc-allowed",
+          "draft_email_structured",
+        ) as any,
+      ),
+    ).toBe(true);
+    expect(
+      agent.dispatchEvent(
+        makeToolEvent(EventType.TOOL_CALL_ARGS, metadata, "tc-allowed") as any,
+      ),
+    ).toBe(true);
+    expect(
+      agent.dispatchEvent(
+        makeToolEvent(EventType.TOOL_CALL_END, metadata, "tc-allowed") as any,
+      ),
+    ).toBe(true);
+    expect(events).toHaveLength(3);
+
+    expect(
+      agent.dispatchEvent(
+        makeToolEvent(
+          EventType.TOOL_CALL_START,
+          metadata,
+          "tc-blocked",
+          "list_polish_operations",
+        ) as any,
+      ),
+    ).toBe(false);
+    expect(
+      agent.dispatchEvent(
+        makeToolEvent(EventType.TOOL_CALL_ARGS, metadata, "tc-blocked") as any,
+      ),
+    ).toBe(false);
+    expect(
+      agent.dispatchEvent(
+        makeToolEvent(EventType.TOOL_CALL_END, metadata, "tc-blocked") as any,
+      ),
+    ).toBe(false);
+    expect(events).toHaveLength(3);
+  });
+
+  it("filters tool event sequences by array whitelist", () => {
+    const { agent, events } = createAgent();
+    const metadata = {
+      "copilotkit:emit-tool-calls": ["draft_email_structured", "preview_email"],
+    };
+
+    expect(
+      agent.dispatchEvent(
+        makeToolEvent(
+          EventType.TOOL_CALL_START,
+          metadata,
+          "tc-allowed",
+          "preview_email",
+        ) as any,
+      ),
+    ).toBe(true);
+    expect(
+      agent.dispatchEvent(
+        makeToolEvent(EventType.TOOL_CALL_ARGS, metadata, "tc-allowed") as any,
+      ),
+    ).toBe(true);
+    expect(
+      agent.dispatchEvent(
+        makeToolEvent(EventType.TOOL_CALL_END, metadata, "tc-allowed") as any,
+      ),
+    ).toBe(true);
+    expect(events).toHaveLength(3);
+
+    expect(
+      agent.dispatchEvent(
+        makeToolEvent(
+          EventType.TOOL_CALL_START,
+          metadata,
+          "tc-blocked",
+          "list_polish_operations",
+        ) as any,
+      ),
+    ).toBe(false);
+    expect(
+      agent.dispatchEvent(
+        makeToolEvent(EventType.TOOL_CALL_ARGS, metadata, "tc-blocked") as any,
+      ),
+    ).toBe(false);
+    expect(
+      agent.dispatchEvent(
+        makeToolEvent(EventType.TOOL_CALL_END, metadata, "tc-blocked") as any,
+      ),
+    ).toBe(false);
+    expect(events).toHaveLength(3);
   });
 });
 

--- a/packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts
+++ b/packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts
@@ -10,9 +10,8 @@ import type {
 import {
   LangGraphAgent as AGUILangGraphAgent,
   LangGraphHttpAgent,
-  type LangGraphAgentConfig,
-  type State,
 } from "@ag-ui/langgraph";
+import type { LangGraphAgentConfig, State } from "@ag-ui/langgraph";
 import type { Message as LangGraphMessage } from "@langchain/langgraph-sdk/dist/types.messages";
 import type { ThreadState } from "@langchain/langgraph-sdk";
 
@@ -35,9 +34,68 @@ import type {
 import { CustomEventNames } from "./consts";
 export { CustomEventNames };
 
+type ToolCallEventLike = Partial<ToolCallEvents> & {
+  toolCallId?: string;
+  toolCallName?: string;
+};
+
 export class LangGraphAgent extends AGUILangGraphAgent {
+  private toolCallNamesById = new Map<string, string>();
+
   constructor(config: LangGraphAgentConfig) {
     super(config);
+  }
+
+  private rememberToolCallName(event: ProcessedEvents): void {
+    if (event.type !== EventType.TOOL_CALL_START) {
+      return;
+    }
+
+    const toolEvent = event as ToolCallEventLike;
+    if (
+      typeof toolEvent.toolCallId === "string" &&
+      typeof toolEvent.toolCallName === "string"
+    ) {
+      this.toolCallNamesById.set(toolEvent.toolCallId, toolEvent.toolCallName);
+    }
+  }
+
+  private forgetToolCallName(event: ProcessedEvents): void {
+    if (event.type !== EventType.TOOL_CALL_END) {
+      return;
+    }
+
+    const toolCallId = (event as ToolCallEventLike).toolCallId;
+    if (typeof toolCallId === "string") {
+      this.toolCallNamesById.delete(toolCallId);
+    }
+  }
+
+  private toolCallNameForEvent(event: ProcessedEvents): string | undefined {
+    const toolEvent = event as ToolCallEventLike;
+    if (typeof toolEvent.toolCallName === "string") {
+      return toolEvent.toolCallName;
+    }
+    if (typeof toolEvent.toolCallId === "string") {
+      return this.toolCallNamesById.get(toolEvent.toolCallId);
+    }
+    return undefined;
+  }
+
+  private shouldEmitToolCall(
+    emitToolCalls: unknown,
+    toolCallName: string | undefined,
+  ): boolean {
+    if (emitToolCalls === false) {
+      return false;
+    }
+    if (typeof emitToolCalls === "string") {
+      return toolCallName === emitToolCalls;
+    }
+    if (Array.isArray(emitToolCalls)) {
+      return toolCallName !== undefined && emitToolCalls.includes(toolCallName);
+    }
+    return true;
   }
 
   dispatchEvent(event: ProcessedEvents) {
@@ -130,11 +188,21 @@ export class LangGraphAgent extends AGUILangGraphAgent {
       event.type === EventType.TOOL_CALL_START ||
       event.type === EventType.TOOL_CALL_ARGS ||
       event.type === EventType.TOOL_CALL_END;
-    if ("copilotkit:emit-tool-calls" in (rawEvent.metadata || {})) {
-      if (
-        rawEvent.metadata["copilotkit:emit-tool-calls"] === false &&
-        isToolEvent
-      ) {
+
+    if (isToolEvent) {
+      this.rememberToolCallName(event);
+
+      let shouldEmitToolCall = true;
+      if ("copilotkit:emit-tool-calls" in (rawEvent.metadata || {})) {
+        shouldEmitToolCall = this.shouldEmitToolCall(
+          rawEvent.metadata["copilotkit:emit-tool-calls"],
+          this.toolCallNameForEvent(event),
+        );
+      }
+
+      this.forgetToolCallName(event);
+
+      if (!shouldEmitToolCall) {
         return false;
       }
     }

--- a/sdk-python/copilotkit/langgraph_agui_agent.py
+++ b/sdk-python/copilotkit/langgraph_agui_agent.py
@@ -68,6 +68,48 @@ class LangGraphAGUIAgent(LangGraphAgent):
     ):
         super().__init__(name=name, graph=graph, description=description, config=config)
         self.constant_schema_keys = self.constant_schema_keys + ["copilotkit"]
+        self._tool_call_names_by_id: Dict[str, str] = {}
+
+    def _remember_tool_call_name(self, event: ToolCallEvents) -> None:
+        if event.type != EventType.TOOL_CALL_START:
+            return
+
+        tool_call_id = getattr(event, "tool_call_id", None)
+        tool_call_name = getattr(event, "tool_call_name", None)
+        if isinstance(tool_call_id, str) and isinstance(tool_call_name, str):
+            self._tool_call_names_by_id[tool_call_id] = tool_call_name
+
+    def _forget_tool_call_name(self, event: ToolCallEvents) -> None:
+        if event.type != EventType.TOOL_CALL_END:
+            return
+
+        tool_call_id = getattr(event, "tool_call_id", None)
+        if isinstance(tool_call_id, str):
+            self._tool_call_names_by_id.pop(tool_call_id, None)
+
+    def _tool_call_name_for_event(self, event: ToolCallEvents) -> Optional[str]:
+        tool_call_name = getattr(event, "tool_call_name", None)
+        if isinstance(tool_call_name, str):
+            return tool_call_name
+
+        tool_call_id = getattr(event, "tool_call_id", None)
+        if isinstance(tool_call_id, str):
+            return self._tool_call_names_by_id.get(tool_call_id)
+
+        return None
+
+    def _should_emit_tool_call(
+        self,
+        emit_tool_calls: Union[bool, str, List[str], Any],
+        tool_call_name: Optional[str],
+    ) -> bool:
+        if emit_tool_calls is False:
+            return False
+        if isinstance(emit_tool_calls, str):
+            return tool_call_name == emit_tool_calls
+        if isinstance(emit_tool_calls, list):
+            return tool_call_name in emit_tool_calls
+        return True
 
     def _dispatch_event(self, event) -> str:
         """Override the dispatch event method to handle custom CopilotKit events and filtering.
@@ -234,8 +276,19 @@ class LangGraphAGUIAgent(LangGraphAgent):
                 else getattr(raw_event, "metadata", {})
             ) or {}
 
-            if "copilotkit:emit-tool-calls" in metadata:
-                if metadata["copilotkit:emit-tool-calls"] is False and is_tool_event:
+            if is_tool_event:
+                self._remember_tool_call_name(event)
+
+                should_emit_tool_call = True
+                if "copilotkit:emit-tool-calls" in metadata:
+                    should_emit_tool_call = self._should_emit_tool_call(
+                        metadata["copilotkit:emit-tool-calls"],
+                        self._tool_call_name_for_event(event),
+                    )
+
+                self._forget_tool_call_name(event)
+
+                if not should_emit_tool_call:
                     return None  # Don't dispatch this event
 
             if "copilotkit:emit-messages" in metadata:

--- a/sdk-python/tests/test_emit_filtering.py
+++ b/sdk-python/tests/test_emit_filtering.py
@@ -13,6 +13,8 @@ from ag_ui.core import (
     TextMessageStartEvent,
     TextMessageContentEvent,
     ToolCallStartEvent,
+    ToolCallArgsEvent,
+    ToolCallEndEvent,
 )
 from copilotkit.langgraph_agui_agent import LangGraphAGUIAgent
 
@@ -45,6 +47,27 @@ def _make_tool_event(metadata: dict) -> ToolCallStartEvent:
     )
 
 
+def _make_tool_args_event(
+    metadata: dict, tool_call_id: str = "tc-1"
+) -> ToolCallArgsEvent:
+    """Create a TOOL_CALL_ARGS event with a dict raw_event carrying metadata."""
+    return ToolCallArgsEvent(
+        toolCallId=tool_call_id,
+        delta='{"value":true}',
+        rawEvent={"metadata": metadata},
+    )
+
+
+def _make_tool_end_event(
+    metadata: dict, tool_call_id: str = "tc-1"
+) -> ToolCallEndEvent:
+    """Create a TOOL_CALL_END event with a dict raw_event carrying metadata."""
+    return ToolCallEndEvent(
+        toolCallId=tool_call_id,
+        rawEvent={"metadata": metadata},
+    )
+
+
 # ---------- Bug 1: dict metadata reading via .get() ----------
 
 
@@ -62,6 +85,75 @@ class TestDictMetadataReading:
         event = _make_tool_event({"copilotkit:emit-tool-calls": False})
         result = agent._dispatch_event(event)
         assert result is None
+
+    def test_emit_tool_calls_string_whitelist_filters_other_tools(self, agent):
+        """A string whitelist should only emit events for the named tool."""
+        metadata = {"copilotkit:emit-tool-calls": "draft_email_structured"}
+
+        matching_start = ToolCallStartEvent(
+            toolCallId="tc-allowed",
+            toolCallName="draft_email_structured",
+            rawEvent={"metadata": metadata},
+        )
+        assert agent._dispatch_event(matching_start) is not None
+        assert (
+            agent._dispatch_event(_make_tool_args_event(metadata, "tc-allowed"))
+            is not None
+        )
+        assert (
+            agent._dispatch_event(_make_tool_end_event(metadata, "tc-allowed"))
+            is not None
+        )
+
+        blocked_start = ToolCallStartEvent(
+            toolCallId="tc-blocked",
+            toolCallName="list_polish_operations",
+            rawEvent={"metadata": metadata},
+        )
+        assert agent._dispatch_event(blocked_start) is None
+        assert (
+            agent._dispatch_event(_make_tool_args_event(metadata, "tc-blocked")) is None
+        )
+        assert (
+            agent._dispatch_event(_make_tool_end_event(metadata, "tc-blocked")) is None
+        )
+
+    def test_emit_tool_calls_list_whitelist_filters_other_tools(self, agent):
+        """A list whitelist should only emit events for tools in the list."""
+        metadata = {
+            "copilotkit:emit-tool-calls": [
+                "draft_email_structured",
+                "preview_email",
+            ]
+        }
+
+        matching_start = ToolCallStartEvent(
+            toolCallId="tc-allowed",
+            toolCallName="preview_email",
+            rawEvent={"metadata": metadata},
+        )
+        assert agent._dispatch_event(matching_start) is not None
+        assert (
+            agent._dispatch_event(_make_tool_args_event(metadata, "tc-allowed"))
+            is not None
+        )
+        assert (
+            agent._dispatch_event(_make_tool_end_event(metadata, "tc-allowed"))
+            is not None
+        )
+
+        blocked_start = ToolCallStartEvent(
+            toolCallId="tc-blocked",
+            toolCallName="list_polish_operations",
+            rawEvent={"metadata": metadata},
+        )
+        assert agent._dispatch_event(blocked_start) is None
+        assert (
+            agent._dispatch_event(_make_tool_args_event(metadata, "tc-blocked")) is None
+        )
+        assert (
+            agent._dispatch_event(_make_tool_end_event(metadata, "tc-blocked")) is None
+        )
 
     def test_emit_messages_true_passes_through(self, agent):
         """emit-messages=True should NOT filter — event passes to super()."""


### PR DESCRIPTION
## What does this PR do?

This PR fixes `copilotkit:emit-tool-calls` filtering when it is configured as a string or string array whitelist.

- Honors string and string[] whitelist values in the TypeScript LangGraph agent integration
- Applies the same whitelist behavior in the Python LangGraph AG-UI agent
- Tracks `toolCallId -> toolCallName` so `TOOL_CALL_ARGS` and `TOOL_CALL_END` follow the `TOOL_CALL_START` whitelist decision
- Adds regression coverage for string and array whitelists in both runtimes

## Related PRs and Issues

- Fixes https://github.com/CopilotKit/CopilotKit/issues/5120

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
  - No documentation update needed: this implements the behavior already documented for `emit_tool_calls` / `emitToolCalls` string and list values.
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)

## Tests

- `corepack pnpm -C packages/runtime exec vitest run src/lib/runtime/agent-integrations/langgraph/__tests__/dispatch-event-filtering.test.ts`
- `sdk-python/.venv/bin/python -m pytest sdk-python/tests/test_emit_filtering.py`

## Notes

The full pre-commit package test hook was not run to completion in this partial local install. It attempted the repository-wide `nx run-many -t test --projects=packages/**` target and failed on unrelated workspace dependency resolution for packages outside this change, including missing `graphql`, `zod`, `@copilotkit/typescript-config`, and `graphql-codegen`.
