### PR TITLE
fix(react-core): refresh thread headers on provider updates

### DIFF
--- a/packages/react-core/src/v2/context.ts
+++ b/packages/react-core/src/v2/context.ts
@@ -37,6 +37,9 @@ export const useCopilotKit = (): CopilotKitContextValue => {
       onRuntimeConnectionStatusChanged: () => {
         forceUpdate();
       },
+      onHeadersChanged: () => {
+        forceUpdate();
+      },
     });
     return () => {
       subscription.unsubscribe();

--- a/packages/react-core/src/v2/hooks/__tests__/use-threads-provider-headers.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-threads-provider-headers.e2e.test.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { CopilotKitProvider } from "../../providers/CopilotKitProvider";
+import { useThreads } from "../use-threads";
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  });
+}
+
+function ThreadsConsumer() {
+  useThreads({ agentId: "agent-1" });
+  return null;
+}
+
+function threadListCalls() {
+  return fetchMock.mock.calls.filter(
+    ([url]) => typeof url === "string" && url.includes("/threads?"),
+  );
+}
+
+describe("useThreads provider headers", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockImplementation((url: string) => {
+      if (url.endsWith("/info")) {
+        return jsonResponse({ version: "1.0.0", agents: {} });
+      }
+
+      if (url.includes("/threads?")) {
+        return jsonResponse({ threads: [] });
+      }
+
+      return jsonResponse({}, 404);
+    });
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("refreshes thread requests when provider headers change", async () => {
+    const runtimeUrl = "https://runtime.example.com";
+
+    const { rerender } = render(
+      <CopilotKitProvider
+        runtimeUrl={runtimeUrl}
+        useSingleEndpoint={false}
+        headers={{}}
+      >
+        <ThreadsConsumer />
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => {
+      expect(threadListCalls()).toHaveLength(1);
+    });
+
+    rerender(
+      <CopilotKitProvider
+        runtimeUrl={runtimeUrl}
+        useSingleEndpoint={false}
+        headers={{ "X-CSRF": "1" }}
+      >
+        <ThreadsConsumer />
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => {
+      const calls = threadListCalls();
+      expect(calls).toHaveLength(2);
+      expect(calls[1]?.[1]).toMatchObject({
+        headers: expect.objectContaining({ "X-CSRF": "1" }),
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #5282.

Provider header updates already reach the core instance via `setHeaders`, but React consumers of `useCopilotKit()` were only re-rendered for runtime connection status changes. That left `useThreads()` with stale context after the provider `headers` prop changed, so subsequent `/threads` requests could miss headers such as `X-CSRF`.

This subscribes the React context hook to `onHeadersChanged` and adds a provider-level regression test that verifies `/threads` is refetched with the updated header.

## Related PRs and Issues

- Fixes https://github.com/CopilotKit/CopilotKit/issues/5282

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --dir packages/react-core exec vitest run src/v2/hooks/__tests__/use-threads-provider-headers.e2e.test.tsx` (failed before the production change, passed after)
- `pnpm --dir packages/react-core exec vitest run src/v2/hooks/__tests__/use-threads.test.tsx src/v2/hooks/__tests__/use-threads-provider-headers.e2e.test.tsx`
- `pnpm exec oxlint packages/react-core/src/v2/context.ts packages/react-core/src/v2/hooks/__tests__/use-threads-provider-headers.e2e.test.tsx`
- `pnpm exec oxfmt --check packages/react-core/src/v2/context.ts packages/react-core/src/v2/hooks/__tests__/use-threads-provider-headers.e2e.test.tsx`
- `pnpm nx run @copilotkit/react-core:build`
- `pnpm nx run @copilotkit/react-core:test`
- `git commit -m "fix(react-core): refresh thread headers on provider updates"` (pre-commit ran `pnpm run test && pnpm run check:packages`; commit-msg ran `pnpm commitlint --edit`)

Also checked: `pnpm nx run @copilotkit/react-core:check-types` currently fails before checking this package because dependency package type/build errors are reported in `@copilotkit/shared` and `@copilotkit/a2ui-renderer`; I did not change those packages.

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation (not applicable: internal header propagation bug fix)
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly - faster turnaround for everyone)
