### PR TITLE
fix(examples): correct Threads locked-state license command to `copilotkit license`

### DIFF
--- a/examples/integrations/a2a-a2ui/app/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/a2a-a2ui/app/components/threads-drawer/locked-state.tsx
@@ -46,9 +46,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>
-              copilotkit add-intelligence
-            </code>
+            <code className={styles.lockedCommandCode}>copilotkit license</code>
           </div>
           <button
             type="button"

--- a/examples/integrations/a2a-a2ui/app/components/threads-drawer/threads-drawer.module.css
+++ b/examples/integrations/a2a-a2ui/app/components/threads-drawer/threads-drawer.module.css
@@ -554,7 +554,7 @@
 /* Locked state — same panel chrome (white surface, hairline right border,
    header rhythm) as the unlocked drawer, with a single clean card that speaks
    the V2 card vocabulary: rounded-lg, hairline border, muted icon chip, the
-   add-intelligence command in a muted code well, and a near-black primary CTA
+   license command in a muted code well, and a near-black primary CTA
    pill matching the sidebar's send button. */
 .lockedPanel {
   display: flex;

--- a/examples/integrations/a2a-middleware/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/a2a-middleware/components/threads-drawer/locked-state.tsx
@@ -46,9 +46,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>
-              copilotkit add-intelligence
-            </code>
+            <code className={styles.lockedCommandCode}>copilotkit license</code>
           </div>
           <button
             type="button"

--- a/examples/integrations/a2a-middleware/components/threads-drawer/threads-drawer.module.css
+++ b/examples/integrations/a2a-middleware/components/threads-drawer/threads-drawer.module.css
@@ -554,7 +554,7 @@
 /* Locked state — same panel chrome (white surface, hairline right border,
    header rhythm) as the unlocked drawer, with a single clean card that speaks
    the V2 card vocabulary: rounded-lg, hairline border, muted icon chip, the
-   add-intelligence command in a muted code well, and a near-black primary CTA
+   license command in a muted code well, and a near-black primary CTA
    pill matching the sidebar's send button. */
 .lockedPanel {
   display: flex;

--- a/examples/integrations/adk/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/adk/src/components/threads-drawer/locked-state.tsx
@@ -67,7 +67,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
         <CardFooter className="flex-col items-start gap-3">
           <div className="w-full rounded-[var(--radius)] border border-[var(--border)] bg-[var(--secondary)] px-3 py-2">
             <code className="text-xs whitespace-nowrap text-[var(--secondary-foreground)]">
-              copilotkit add-intelligence
+              copilotkit license
             </code>
           </div>
           <Button

--- a/examples/integrations/agent-spec/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/agent-spec/src/components/threads-drawer/locked-state.tsx
@@ -46,9 +46,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>
-              copilotkit add-intelligence
-            </code>
+            <code className={styles.lockedCommandCode}>copilotkit license</code>
           </div>
           <button
             type="button"

--- a/examples/integrations/agent-spec/src/components/threads-drawer/threads-drawer.module.css
+++ b/examples/integrations/agent-spec/src/components/threads-drawer/threads-drawer.module.css
@@ -554,7 +554,7 @@
 /* Locked state — same panel chrome (white surface, hairline right border,
    header rhythm) as the unlocked drawer, with a single clean card that speaks
    the V2 card vocabulary: rounded-lg, hairline border, muted icon chip, the
-   add-intelligence command in a muted code well, and a near-black primary CTA
+   license command in a muted code well, and a near-black primary CTA
    pill matching the sidebar's send button. */
 .lockedPanel {
   display: flex;

--- a/examples/integrations/agentcore/frontend/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/agentcore/frontend/src/components/threads-drawer/locked-state.tsx
@@ -67,7 +67,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
         <CardFooter className="flex-col items-start gap-3">
           <div className="w-full rounded-[var(--radius)] border border-[var(--border)] bg-[var(--secondary)] px-3 py-2">
             <code className="text-xs whitespace-nowrap text-[var(--secondary-foreground)]">
-              copilotkit add-intelligence
+              copilotkit license
             </code>
           </div>
           <Button

--- a/examples/integrations/agno/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/agno/src/components/threads-drawer/locked-state.tsx
@@ -67,7 +67,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
         <CardFooter className="flex-col items-start gap-3">
           <div className="w-full rounded-[var(--radius)] border border-[var(--border)] bg-[var(--secondary)] px-3 py-2">
             <code className="text-xs whitespace-nowrap text-[var(--secondary-foreground)]">
-              copilotkit add-intelligence
+              copilotkit license
             </code>
           </div>
           <Button

--- a/examples/integrations/crewai-crews/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/crewai-crews/src/components/threads-drawer/locked-state.tsx
@@ -46,9 +46,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>
-              copilotkit add-intelligence
-            </code>
+            <code className={styles.lockedCommandCode}>copilotkit license</code>
           </div>
           <button
             type="button"

--- a/examples/integrations/crewai-crews/src/components/threads-drawer/threads-drawer.module.css
+++ b/examples/integrations/crewai-crews/src/components/threads-drawer/threads-drawer.module.css
@@ -554,7 +554,7 @@
 /* Locked state — same panel chrome (white surface, hairline right border,
    header rhythm) as the unlocked drawer, with a single clean card that speaks
    the V2 card vocabulary: rounded-lg, hairline border, muted icon chip, the
-   add-intelligence command in a muted code well, and a near-black primary CTA
+   license command in a muted code well, and a near-black primary CTA
    pill matching the sidebar's send button. */
 .lockedPanel {
   display: flex;

--- a/examples/integrations/crewai-flows/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/crewai-flows/src/components/threads-drawer/locked-state.tsx
@@ -46,9 +46,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>
-              copilotkit add-intelligence
-            </code>
+            <code className={styles.lockedCommandCode}>copilotkit license</code>
           </div>
           <button
             type="button"

--- a/examples/integrations/crewai-flows/src/components/threads-drawer/threads-drawer.module.css
+++ b/examples/integrations/crewai-flows/src/components/threads-drawer/threads-drawer.module.css
@@ -554,7 +554,7 @@
 /* Locked state — same panel chrome (white surface, hairline right border,
    header rhythm) as the unlocked drawer, with a single clean card that speaks
    the V2 card vocabulary: rounded-lg, hairline border, muted icon chip, the
-   add-intelligence command in a muted code well, and a near-black primary CTA
+   license command in a muted code well, and a near-black primary CTA
    pill matching the sidebar's send button. */
 .lockedPanel {
   display: flex;

--- a/examples/integrations/langgraph-fastapi/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/langgraph-fastapi/src/components/threads-drawer/locked-state.tsx
@@ -67,7 +67,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
         <CardFooter className="flex-col items-start gap-3">
           <div className="w-full rounded-[var(--radius)] border border-[var(--border)] bg-[var(--secondary)] px-3 py-2">
             <code className="text-xs whitespace-nowrap text-[var(--secondary-foreground)]">
-              copilotkit add-intelligence
+              copilotkit license
             </code>
           </div>
           <Button

--- a/examples/integrations/langgraph-js/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/langgraph-js/src/components/threads-drawer/locked-state.tsx
@@ -67,7 +67,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
         <CardFooter className="flex-col items-start gap-3">
           <div className="w-full rounded-[var(--radius)] border border-[var(--border)] bg-[var(--secondary)] px-3 py-2">
             <code className="text-xs whitespace-nowrap text-[var(--secondary-foreground)]">
-              copilotkit add-intelligence
+              copilotkit license
             </code>
           </div>
           <Button

--- a/examples/integrations/langgraph-python/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/langgraph-python/src/components/threads-drawer/locked-state.tsx
@@ -67,7 +67,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
         <CardFooter className="flex-col items-start gap-3">
           <div className="w-full rounded-[var(--radius)] border border-[var(--border)] bg-[var(--secondary)] px-3 py-2">
             <code className="text-xs whitespace-nowrap text-[var(--secondary-foreground)]">
-              copilotkit add-intelligence
+              copilotkit license
             </code>
           </div>
           <Button

--- a/examples/integrations/llamaindex/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/llamaindex/src/components/threads-drawer/locked-state.tsx
@@ -46,9 +46,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>
-              copilotkit add-intelligence
-            </code>
+            <code className={styles.lockedCommandCode}>copilotkit license</code>
           </div>
           <button
             type="button"

--- a/examples/integrations/llamaindex/src/components/threads-drawer/threads-drawer.module.css
+++ b/examples/integrations/llamaindex/src/components/threads-drawer/threads-drawer.module.css
@@ -554,7 +554,7 @@
 /* Locked state — same panel chrome (white surface, hairline right border,
    header rhythm) as the unlocked drawer, with a single clean card that speaks
    the V2 card vocabulary: rounded-lg, hairline border, muted icon chip, the
-   add-intelligence command in a muted code well, and a near-black primary CTA
+   license command in a muted code well, and a near-black primary CTA
    pill matching the sidebar's send button. */
 .lockedPanel {
   display: flex;

--- a/examples/integrations/mastra/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/mastra/src/components/threads-drawer/locked-state.tsx
@@ -46,9 +46,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>
-              copilotkit add-intelligence
-            </code>
+            <code className={styles.lockedCommandCode}>copilotkit license</code>
           </div>
           <button
             type="button"

--- a/examples/integrations/mastra/src/components/threads-drawer/threads-drawer.module.css
+++ b/examples/integrations/mastra/src/components/threads-drawer/threads-drawer.module.css
@@ -554,7 +554,7 @@
 /* Locked state — same panel chrome (white surface, hairline right border,
    header rhythm) as the unlocked drawer, with a single clean card that speaks
    the V2 card vocabulary: rounded-lg, hairline border, muted icon chip, the
-   add-intelligence command in a muted code well, and a near-black primary CTA
+   license command in a muted code well, and a near-black primary CTA
    pill matching the sidebar's send button. */
 .lockedPanel {
   display: flex;

--- a/examples/integrations/mcp-apps/app/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/mcp-apps/app/components/threads-drawer/locked-state.tsx
@@ -46,9 +46,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>
-              copilotkit add-intelligence
-            </code>
+            <code className={styles.lockedCommandCode}>copilotkit license</code>
           </div>
           <button
             type="button"

--- a/examples/integrations/mcp-apps/app/components/threads-drawer/threads-drawer.module.css
+++ b/examples/integrations/mcp-apps/app/components/threads-drawer/threads-drawer.module.css
@@ -554,7 +554,7 @@
 /* Locked state — same panel chrome (white surface, hairline right border,
    header rhythm) as the unlocked drawer, with a single clean card that speaks
    the V2 card vocabulary: rounded-lg, hairline border, muted icon chip, the
-   add-intelligence command in a muted code well, and a near-black primary CTA
+   license command in a muted code well, and a near-black primary CTA
    pill matching the sidebar's send button. */
 .lockedPanel {
   display: flex;

--- a/examples/integrations/ms-agent-framework-dotnet/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/ms-agent-framework-dotnet/src/components/threads-drawer/locked-state.tsx
@@ -46,9 +46,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>
-              copilotkit add-intelligence
-            </code>
+            <code className={styles.lockedCommandCode}>copilotkit license</code>
           </div>
           <button
             type="button"

--- a/examples/integrations/ms-agent-framework-dotnet/src/components/threads-drawer/threads-drawer.module.css
+++ b/examples/integrations/ms-agent-framework-dotnet/src/components/threads-drawer/threads-drawer.module.css
@@ -552,7 +552,7 @@
 /* Locked state — same panel chrome (white surface, hairline right border,
    header rhythm) as the unlocked drawer, with a single clean card that speaks
    the V2 card vocabulary: rounded-lg, hairline border, muted icon chip, the
-   add-intelligence command in a muted code well, and a near-black primary CTA
+   license command in a muted code well, and a near-black primary CTA
    pill matching the sidebar's send button. */
 .lockedPanel {
   display: flex;

--- a/examples/integrations/ms-agent-framework-python/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/ms-agent-framework-python/src/components/threads-drawer/locked-state.tsx
@@ -46,9 +46,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>
-              copilotkit add-intelligence
-            </code>
+            <code className={styles.lockedCommandCode}>copilotkit license</code>
           </div>
           <button
             type="button"

--- a/examples/integrations/ms-agent-framework-python/src/components/threads-drawer/threads-drawer.module.css
+++ b/examples/integrations/ms-agent-framework-python/src/components/threads-drawer/threads-drawer.module.css
@@ -552,7 +552,7 @@
 /* Locked state — same panel chrome (white surface, hairline right border,
    header rhythm) as the unlocked drawer, with a single clean card that speaks
    the V2 card vocabulary: rounded-lg, hairline border, muted icon chip, the
-   add-intelligence command in a muted code well, and a near-black primary CTA
+   license command in a muted code well, and a near-black primary CTA
    pill matching the sidebar's send button. */
 .lockedPanel {
   display: flex;

--- a/examples/integrations/pydantic-ai/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/pydantic-ai/src/components/threads-drawer/locked-state.tsx
@@ -46,9 +46,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>
-              copilotkit add-intelligence
-            </code>
+            <code className={styles.lockedCommandCode}>copilotkit license</code>
           </div>
           <button
             type="button"

--- a/examples/integrations/pydantic-ai/src/components/threads-drawer/threads-drawer.module.css
+++ b/examples/integrations/pydantic-ai/src/components/threads-drawer/threads-drawer.module.css
@@ -554,7 +554,7 @@
 /* Locked state — same panel chrome (white surface, hairline right border,
    header rhythm) as the unlocked drawer, with a single clean card that speaks
    the V2 card vocabulary: rounded-lg, hairline border, muted icon chip, the
-   add-intelligence command in a muted code well, and a near-black primary CTA
+   license command in a muted code well, and a near-black primary CTA
    pill matching the sidebar's send button. */
 .lockedPanel {
   display: flex;

--- a/examples/integrations/strands-python/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/strands-python/src/components/threads-drawer/locked-state.tsx
@@ -67,7 +67,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
         <CardFooter className="flex-col items-start gap-3">
           <div className="w-full rounded-[var(--radius)] border border-[var(--border)] bg-[var(--secondary)] px-3 py-2">
             <code className="text-xs whitespace-nowrap text-[var(--secondary-foreground)]">
-              copilotkit add-intelligence
+              copilotkit license
             </code>
           </div>
           <Button


### PR DESCRIPTION
## Summary

The Threads locked-state card in every integration example tells users to add a CopilotKit Intelligence license with `copilotkit add-intelligence`. That's the wrong command:

1. `add-intelligence` is intentionally not wired into the CLI dispatch yet.
2. Even when implemented, it only drops the Intelligence overlay — it does not issue a license (licensed behavior is deferred to ENT-725).

The command that actually issues a license key and writes it to `.env` is **`copilotkit license`**.

## Changes

- `locked-state.tsx` in all 18 examples: `copilotkit add-intelligence` → `copilotkit license` (oxfmt collapsed the now-shorter `<code>` element onto one line)
- `threads-drawer.module.css` descriptive comments (11 examples): "add-intelligence command" → "license command"
- `examples/integrations/_intelligence/` references to `copilotkit add-intelligence` are untouched — those describe the overlay scaffold command, not licensing.

## Verification

- `git grep add-intelligence -- 'examples/**'` only matches `_intelligence/` scaffold docs
- `pnpm parity:check` — no new findings (threads-drawer/** is allowedDivergence; only pre-existing next-env.d.ts warns)

Closes ENT-804

🤖 Generated with [Claude Code](https://claude.com/claude-code)