### PR TITLE
test(core): cover thread request headers

### DIFF
--- a/packages/core/src/__tests__/threads.test.ts
+++ b/packages/core/src/__tests__/threads.test.ts
@@ -359,6 +359,63 @@ describe("thread store", () => {
     });
   });
 
+  it("forwards configured headers to all thread REST requests", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          threads: sampleThreads,
+          joinCode: "jc-1",
+          nextCursor: "cursor-abc",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          joinToken: "jt-1",
+        }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          threads: [],
+          nextCursor: null,
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const store = ɵcreateThreadStore(
+      createEnvironment(fetchMock as typeof fetch),
+    );
+    stores.push(store);
+    store.start();
+    store.setContext({
+      runtimeUrl: "https://runtime.example.com",
+      headers: { "X-CSRF": "1" },
+      wsUrl: "ws://localhost:4000/client",
+      agentId: "agent-1",
+      limit: 2,
+    });
+
+    await flushEffects();
+
+    store.fetchNextPage();
+    await store.renameThread("thread-1", "Renamed");
+    await store.archiveThread("thread-2");
+    await store.deleteThread("thread-2");
+    await flushEffects();
+
+    const threadCalls = fetchMock.mock.calls.filter(
+      ([url]) => typeof url === "string" && url.includes("/threads"),
+    );
+
+    expect(threadCalls).toHaveLength(6);
+    for (const [, options] of threadCalls) {
+      expect(options.headers).toMatchObject({ "X-CSRF": "1" });
+    }
+  });
+
   it("stores fetch failures in error state", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,

--- a/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
@@ -190,12 +190,15 @@ function getMockSockets(): MockSocketLike[] {
   return phoenix.sockets;
 }
 
-function setupCopilotKit(runtimeUrl = "http://localhost:4000") {
+function setupCopilotKit(
+  runtimeUrl = "http://localhost:4000",
+  headers: Record<string, string> = { Authorization: "Bearer test-token" },
+) {
   mockUseCopilotKit.mockReturnValue({
     copilotkit: {
       runtimeUrl,
       runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Connected,
-      headers: { Authorization: "Bearer test-token" },
+      headers,
       intelligence: {
         wsUrl: "ws://localhost:4000/client",
       },
@@ -289,6 +292,40 @@ describe("useThreads", () => {
     const socket = getMockSockets()[0];
     expect(socket.connected).toBe(true);
     expect(socket.channels[0].topic).toBe("user_meta:jc-1");
+  });
+
+  it("forwards configured headers to thread list and subscribe requests", async () => {
+    setupCopilotKit("http://localhost:4000", { "X-CSRF": "1" });
+    fetchMock
+      .mockReturnValueOnce(
+        jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
+      )
+      .mockReturnValueOnce(jsonResponse({ joinToken: "jt-1" }));
+
+    const { result } = renderHook(() => useThreads(defaultInput));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const listCall = fetchMock.mock.calls.find(
+      ([url]) => typeof url === "string" && url.includes("/threads?"),
+    );
+    const subscribeCall = fetchMock.mock.calls.find(
+      ([url]) => typeof url === "string" && url.includes("/threads/subscribe"),
+    );
+
+    expect(listCall?.[1]).toMatchObject({
+      method: "GET",
+      headers: { "X-CSRF": "1" },
+    });
+    expect(subscribeCall?.[1]).toMatchObject({
+      method: "POST",
+      headers: expect.objectContaining({
+        "X-CSRF": "1",
+        "Content-Type": "application/json",
+      }),
+    });
   });
 
   it("stores fetch failures in error state", async () => {


### PR DESCRIPTION
## Summary

Add regression coverage for configured CopilotKit headers on `/threads` requests.

Issue #5282 reported that headers like `X-CSRF` were not being sent on `/threads` requests when using multi-endpoint transport (`useSingleEndpoint={false}`), causing backend proxy CSRF/auth checks to reject the requests. Current main already forwards thread headers through the core thread store, so this PR locks that behavior down with focused tests.

## Changes

- Add a core thread-store regression test asserting configured headers are forwarded to all thread REST calls:
  - list threads
  - subscribe credentials
  - next page
  - rename
  - archive
  - delete
- Add a React `useThreads` regression test asserting provider headers reach thread list and subscribe requests.

## Testing

- `pnpm nx run @copilotkit/core:test --run src/__tests__/threads.test.ts`
- `pnpm -C packages/react-core exec vitest run src/v2/hooks/__tests__/use-threads.test.tsx`
