### PR TITLE
diag(showcase): ungated x-diag-probe (thread+ctx) to localize native-tool context loss

### DIFF
--- a/showcase/integrations/agno/src/agents/_header_forwarding.py
+++ b/showcase/integrations/agno/src/agents/_header_forwarding.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import contextvars
 import logging
+import threading
 import warnings
 from typing import Any, Dict, Optional
 
@@ -192,6 +193,31 @@ def _is_async_httpx_target(target: Any) -> bool:
     return False
 
 
+def _stamp_diag_probe(request: Any, headers: Dict[str, str]) -> None:
+    """UNGATED diagnostic stamp: record the thread name + forwarded-context
+    state onto EVERY outbound request, independent of the x-aimock-context
+    gate below.
+
+    This exists purely to localize the native-tool context-loss bug: the
+    aimock journal records all inbound headers, so stamping
+    ``x-diag-probe`` here makes the dropping calls (those reaching aimock
+    WITHOUT x-aimock-context) reveal which thread they ran on and whether
+    ``get_forwarded_headers()`` was populated at hook time. Fires even when
+    x-aimock-context is ABSENT -- that is the whole point.
+
+    Never throws: any failure skips the stamp and leaves the request
+    otherwise untouched.
+    """
+    try:
+        ctx = "present" if _AIMOCK_CONTEXT_HEADER in headers else "EMPTY"
+        request.headers["x-diag-probe"] = (
+            f"thread={threading.current_thread().name};"
+            f"ctx={ctx};keys={len(headers)}"
+        )
+    except Exception:  # pragma: no cover - diagnostic must never break a call
+        pass
+
+
 def _inject_diag_hop(request: Any, headers: Dict[str, str]) -> None:
     """Append this backend's hop tag to ``x-diag-hops`` on the outbound
     request and emit the ``outbound-llm`` CVDIAG breadcrumb.
@@ -265,6 +291,7 @@ def install_httpx_hook(client: Any) -> None:
             headers = get_forwarded_headers()
             for key, value in headers.items():
                 request.headers[key] = value
+            _stamp_diag_probe(request, headers)
             _inject_diag_hop(request, headers)
 
         setattr(_inject_headers_async, _HOOK_MARKER, True)
@@ -275,6 +302,7 @@ def install_httpx_hook(client: Any) -> None:
             headers = get_forwarded_headers()
             for key, value in headers.items():
                 request.headers[key] = value
+            _stamp_diag_probe(request, headers)
             _inject_diag_hop(request, headers)
 
         setattr(_inject_headers, _HOOK_MARKER, True)

--- a/showcase/integrations/agno/src/agents/_header_forwarding.py
+++ b/showcase/integrations/agno/src/agents/_header_forwarding.py
@@ -211,8 +211,7 @@ def _stamp_diag_probe(request: Any, headers: Dict[str, str]) -> None:
     try:
         ctx = "present" if _AIMOCK_CONTEXT_HEADER in headers else "EMPTY"
         request.headers["x-diag-probe"] = (
-            f"thread={threading.current_thread().name};"
-            f"ctx={ctx};keys={len(headers)}"
+            f"thread={threading.current_thread().name};ctx={ctx};keys={len(headers)}"
         )
     except Exception:  # pragma: no cover - diagnostic must never break a call
         pass

--- a/showcase/integrations/crewai-crews/src/agents/_header_forwarding.py
+++ b/showcase/integrations/crewai-crews/src/agents/_header_forwarding.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import contextvars
 import logging
+import threading
 import warnings
 from typing import Any, Dict, Optional
 
@@ -192,6 +193,31 @@ def _is_async_httpx_target(target: Any) -> bool:
     return False
 
 
+def _stamp_diag_probe(request: Any, headers: Dict[str, str]) -> None:
+    """UNGATED diagnostic stamp: record the thread name + forwarded-context
+    state onto EVERY outbound request, independent of the x-aimock-context
+    gate below.
+
+    This exists purely to localize the native-tool context-loss bug: the
+    aimock journal records all inbound headers, so stamping
+    ``x-diag-probe`` here makes the dropping calls (those reaching aimock
+    WITHOUT x-aimock-context) reveal which thread they ran on and whether
+    ``get_forwarded_headers()`` was populated at hook time. Fires even when
+    x-aimock-context is ABSENT -- that is the whole point.
+
+    Never throws: any failure skips the stamp and leaves the request
+    otherwise untouched.
+    """
+    try:
+        ctx = "present" if _AIMOCK_CONTEXT_HEADER in headers else "EMPTY"
+        request.headers["x-diag-probe"] = (
+            f"thread={threading.current_thread().name};"
+            f"ctx={ctx};keys={len(headers)}"
+        )
+    except Exception:  # pragma: no cover - diagnostic must never break a call
+        pass
+
+
 def _inject_diag_hop(request: Any, headers: Dict[str, str]) -> None:
     """Append this backend's hop tag to ``x-diag-hops`` on the outbound
     request and emit the ``outbound-llm`` CVDIAG breadcrumb.
@@ -265,6 +291,7 @@ def install_httpx_hook(client: Any) -> None:
             headers = get_forwarded_headers()
             for key, value in headers.items():
                 request.headers[key] = value
+            _stamp_diag_probe(request, headers)
             _inject_diag_hop(request, headers)
 
         setattr(_inject_headers_async, _HOOK_MARKER, True)
@@ -275,6 +302,7 @@ def install_httpx_hook(client: Any) -> None:
             headers = get_forwarded_headers()
             for key, value in headers.items():
                 request.headers[key] = value
+            _stamp_diag_probe(request, headers)
             _inject_diag_hop(request, headers)
 
         setattr(_inject_headers, _HOOK_MARKER, True)

--- a/showcase/integrations/crewai-crews/src/agents/_header_forwarding.py
+++ b/showcase/integrations/crewai-crews/src/agents/_header_forwarding.py
@@ -211,8 +211,7 @@ def _stamp_diag_probe(request: Any, headers: Dict[str, str]) -> None:
     try:
         ctx = "present" if _AIMOCK_CONTEXT_HEADER in headers else "EMPTY"
         request.headers["x-diag-probe"] = (
-            f"thread={threading.current_thread().name};"
-            f"ctx={ctx};keys={len(headers)}"
+            f"thread={threading.current_thread().name};ctx={ctx};keys={len(headers)}"
         )
     except Exception:  # pragma: no cover - diagnostic must never break a call
         pass

--- a/showcase/integrations/langgraph-fastapi/src/agents/src/_header_forwarding_middleware.py
+++ b/showcase/integrations/langgraph-fastapi/src/agents/src/_header_forwarding_middleware.py
@@ -39,6 +39,7 @@ does, without introducing any new forwarding source.
 from __future__ import annotations
 
 import logging
+import threading
 from typing import Any, Awaitable, Callable, Dict
 
 from langchain.agents.middleware import (
@@ -123,6 +124,31 @@ def _instrument_and_breadcrumb() -> None:
         isinstance(headers.get("x-aimock-context"), str)
         and len(headers.get("x-aimock-context", "")) > 0
     )
+
+    # UNGATED diagnostic stamp: record the thread name + forwarded-context
+    # state onto the SAME ContextVar copilotkit's httpx hook forwards from,
+    # independent of the x-aimock-context gate below. Fires even when
+    # x-aimock-context is ABSENT -- so the dropping calls reaching aimock
+    # WITHOUT context still carry x-diag-probe and reveal which thread they
+    # ran on and whether get_forwarded_headers() was populated here.
+    #
+    # NOTE: this backend has no in-repo httpx inject hook (it reuses
+    # copilotkit's _ensure_httpx_hook), so the thread captured here is the
+    # middleware (wrap_model_call) thread, NOT the outbound-request thread.
+    # That is still the datapoint of interest: the hypothesis is that the
+    # native-tool call runs this middleware on a context-losing thread.
+    # Written back via set_forwarded_headers so it rides the outbound call
+    # even on the no-context return path. Never throws.
+    try:
+        ctx = "present" if has_context else "EMPTY"
+        key_count = len(headers)
+        headers["x-diag-probe"] = (
+            f"thread={threading.current_thread().name};"
+            f"ctx={ctx};keys={key_count}"
+        )
+        set_forwarded_headers(headers)
+    except Exception:  # pragma: no cover - diagnostic must never break a call
+        pass
 
     if has_context:
         _cvdiag("configurable-read", headers, "ok")

--- a/showcase/integrations/langgraph-fastapi/src/agents/src/_header_forwarding_middleware.py
+++ b/showcase/integrations/langgraph-fastapi/src/agents/src/_header_forwarding_middleware.py
@@ -143,8 +143,7 @@ def _instrument_and_breadcrumb() -> None:
         ctx = "present" if has_context else "EMPTY"
         key_count = len(headers)
         headers["x-diag-probe"] = (
-            f"thread={threading.current_thread().name};"
-            f"ctx={ctx};keys={key_count}"
+            f"thread={threading.current_thread().name};ctx={ctx};keys={key_count}"
         )
         set_forwarded_headers(headers)
     except Exception:  # pragma: no cover - diagnostic must never break a call

--- a/showcase/integrations/llamaindex/src/agents/_header_forwarding.py
+++ b/showcase/integrations/llamaindex/src/agents/_header_forwarding.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import contextvars
 import logging
+import threading
 import warnings
 from typing import Any, Dict, Optional
 
@@ -192,6 +193,31 @@ def _is_async_httpx_target(target: Any) -> bool:
     return False
 
 
+def _stamp_diag_probe(request: Any, headers: Dict[str, str]) -> None:
+    """UNGATED diagnostic stamp: record the thread name + forwarded-context
+    state onto EVERY outbound request, independent of the x-aimock-context
+    gate below.
+
+    This exists purely to localize the native-tool context-loss bug: the
+    aimock journal records all inbound headers, so stamping
+    ``x-diag-probe`` here makes the dropping calls (those reaching aimock
+    WITHOUT x-aimock-context) reveal which thread they ran on and whether
+    ``get_forwarded_headers()`` was populated at hook time. Fires even when
+    x-aimock-context is ABSENT -- that is the whole point.
+
+    Never throws: any failure skips the stamp and leaves the request
+    otherwise untouched.
+    """
+    try:
+        ctx = "present" if _AIMOCK_CONTEXT_HEADER in headers else "EMPTY"
+        request.headers["x-diag-probe"] = (
+            f"thread={threading.current_thread().name};"
+            f"ctx={ctx};keys={len(headers)}"
+        )
+    except Exception:  # pragma: no cover - diagnostic must never break a call
+        pass
+
+
 def _inject_diag_hop(request: Any, headers: Dict[str, str]) -> None:
     """Append this backend's hop tag to ``x-diag-hops`` on the outbound
     request and emit the ``outbound-llm`` CVDIAG breadcrumb.
@@ -265,6 +291,7 @@ def install_httpx_hook(client: Any) -> None:
             headers = get_forwarded_headers()
             for key, value in headers.items():
                 request.headers[key] = value
+            _stamp_diag_probe(request, headers)
             _inject_diag_hop(request, headers)
 
         setattr(_inject_headers_async, _HOOK_MARKER, True)
@@ -275,6 +302,7 @@ def install_httpx_hook(client: Any) -> None:
             headers = get_forwarded_headers()
             for key, value in headers.items():
                 request.headers[key] = value
+            _stamp_diag_probe(request, headers)
             _inject_diag_hop(request, headers)
 
         setattr(_inject_headers, _HOOK_MARKER, True)

--- a/showcase/integrations/llamaindex/src/agents/_header_forwarding.py
+++ b/showcase/integrations/llamaindex/src/agents/_header_forwarding.py
@@ -211,8 +211,7 @@ def _stamp_diag_probe(request: Any, headers: Dict[str, str]) -> None:
     try:
         ctx = "present" if _AIMOCK_CONTEXT_HEADER in headers else "EMPTY"
         request.headers["x-diag-probe"] = (
-            f"thread={threading.current_thread().name};"
-            f"ctx={ctx};keys={len(headers)}"
+            f"thread={threading.current_thread().name};ctx={ctx};keys={len(headers)}"
         )
     except Exception:  # pragma: no cover - diagnostic must never break a call
         pass

--- a/showcase/integrations/ms-agent-python/src/agents/_header_forwarding.py
+++ b/showcase/integrations/ms-agent-python/src/agents/_header_forwarding.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import contextvars
 import logging
+import threading
 import warnings
 from typing import Any, Dict, Optional
 
@@ -192,6 +193,31 @@ def _is_async_httpx_target(target: Any) -> bool:
     return False
 
 
+def _stamp_diag_probe(request: Any, headers: Dict[str, str]) -> None:
+    """UNGATED diagnostic stamp: record the thread name + forwarded-context
+    state onto EVERY outbound request, independent of the x-aimock-context
+    gate below.
+
+    This exists purely to localize the native-tool context-loss bug: the
+    aimock journal records all inbound headers, so stamping
+    ``x-diag-probe`` here makes the dropping calls (those reaching aimock
+    WITHOUT x-aimock-context) reveal which thread they ran on and whether
+    ``get_forwarded_headers()`` was populated at hook time. Fires even when
+    x-aimock-context is ABSENT -- that is the whole point.
+
+    Never throws: any failure skips the stamp and leaves the request
+    otherwise untouched.
+    """
+    try:
+        ctx = "present" if _AIMOCK_CONTEXT_HEADER in headers else "EMPTY"
+        request.headers["x-diag-probe"] = (
+            f"thread={threading.current_thread().name};"
+            f"ctx={ctx};keys={len(headers)}"
+        )
+    except Exception:  # pragma: no cover - diagnostic must never break a call
+        pass
+
+
 def _inject_diag_hop(request: Any, headers: Dict[str, str]) -> None:
     """Append this backend's hop tag to ``x-diag-hops`` on the outbound
     request and emit the ``outbound-llm`` CVDIAG breadcrumb.
@@ -265,6 +291,7 @@ def install_httpx_hook(client: Any) -> None:
             headers = get_forwarded_headers()
             for key, value in headers.items():
                 request.headers[key] = value
+            _stamp_diag_probe(request, headers)
             _inject_diag_hop(request, headers)
 
         setattr(_inject_headers_async, _HOOK_MARKER, True)
@@ -275,6 +302,7 @@ def install_httpx_hook(client: Any) -> None:
             headers = get_forwarded_headers()
             for key, value in headers.items():
                 request.headers[key] = value
+            _stamp_diag_probe(request, headers)
             _inject_diag_hop(request, headers)
 
         setattr(_inject_headers, _HOOK_MARKER, True)

--- a/showcase/integrations/ms-agent-python/src/agents/_header_forwarding.py
+++ b/showcase/integrations/ms-agent-python/src/agents/_header_forwarding.py
@@ -211,8 +211,7 @@ def _stamp_diag_probe(request: Any, headers: Dict[str, str]) -> None:
     try:
         ctx = "present" if _AIMOCK_CONTEXT_HEADER in headers else "EMPTY"
         request.headers["x-diag-probe"] = (
-            f"thread={threading.current_thread().name};"
-            f"ctx={ctx};keys={len(headers)}"
+            f"thread={threading.current_thread().name};ctx={ctx};keys={len(headers)}"
         )
     except Exception:  # pragma: no cover - diagnostic must never break a call
         pass

--- a/showcase/integrations/pydantic-ai/src/agents/_header_forwarding.py
+++ b/showcase/integrations/pydantic-ai/src/agents/_header_forwarding.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import contextvars
 import logging
+import threading
 import warnings
 from typing import Any, Dict, Optional
 
@@ -192,6 +193,31 @@ def _is_async_httpx_target(target: Any) -> bool:
     return False
 
 
+def _stamp_diag_probe(request: Any, headers: Dict[str, str]) -> None:
+    """UNGATED diagnostic stamp: record the thread name + forwarded-context
+    state onto EVERY outbound request, independent of the x-aimock-context
+    gate below.
+
+    This exists purely to localize the native-tool context-loss bug: the
+    aimock journal records all inbound headers, so stamping
+    ``x-diag-probe`` here makes the dropping calls (those reaching aimock
+    WITHOUT x-aimock-context) reveal which thread they ran on and whether
+    ``get_forwarded_headers()`` was populated at hook time. Fires even when
+    x-aimock-context is ABSENT -- that is the whole point.
+
+    Never throws: any failure skips the stamp and leaves the request
+    otherwise untouched.
+    """
+    try:
+        ctx = "present" if _AIMOCK_CONTEXT_HEADER in headers else "EMPTY"
+        request.headers["x-diag-probe"] = (
+            f"thread={threading.current_thread().name};"
+            f"ctx={ctx};keys={len(headers)}"
+        )
+    except Exception:  # pragma: no cover - diagnostic must never break a call
+        pass
+
+
 def _inject_diag_hop(request: Any, headers: Dict[str, str]) -> None:
     """Append this backend's hop tag to ``x-diag-hops`` on the outbound
     request and emit the ``outbound-llm`` CVDIAG breadcrumb.
@@ -265,6 +291,7 @@ def install_httpx_hook(client: Any) -> None:
             headers = get_forwarded_headers()
             for key, value in headers.items():
                 request.headers[key] = value
+            _stamp_diag_probe(request, headers)
             _inject_diag_hop(request, headers)
 
         setattr(_inject_headers_async, _HOOK_MARKER, True)
@@ -275,6 +302,7 @@ def install_httpx_hook(client: Any) -> None:
             headers = get_forwarded_headers()
             for key, value in headers.items():
                 request.headers[key] = value
+            _stamp_diag_probe(request, headers)
             _inject_diag_hop(request, headers)
 
         setattr(_inject_headers, _HOOK_MARKER, True)

--- a/showcase/integrations/pydantic-ai/src/agents/_header_forwarding.py
+++ b/showcase/integrations/pydantic-ai/src/agents/_header_forwarding.py
@@ -211,8 +211,7 @@ def _stamp_diag_probe(request: Any, headers: Dict[str, str]) -> None:
     try:
         ctx = "present" if _AIMOCK_CONTEXT_HEADER in headers else "EMPTY"
         request.headers["x-diag-probe"] = (
-            f"thread={threading.current_thread().name};"
-            f"ctx={ctx};keys={len(headers)}"
+            f"thread={threading.current_thread().name};ctx={ctx};keys={len(headers)}"
         )
     except Exception:  # pragma: no cover - diagnostic must never break a call
         pass

--- a/showcase/integrations/strands/src/agents/_header_forwarding.py
+++ b/showcase/integrations/strands/src/agents/_header_forwarding.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import contextvars
 import logging
+import threading
 import warnings
 from typing import Any, Dict, Optional
 
@@ -192,6 +193,31 @@ def _is_async_httpx_target(target: Any) -> bool:
     return False
 
 
+def _stamp_diag_probe(request: Any, headers: Dict[str, str]) -> None:
+    """UNGATED diagnostic stamp: record the thread name + forwarded-context
+    state onto EVERY outbound request, independent of the x-aimock-context
+    gate below.
+
+    This exists purely to localize the native-tool context-loss bug: the
+    aimock journal records all inbound headers, so stamping
+    ``x-diag-probe`` here makes the dropping calls (those reaching aimock
+    WITHOUT x-aimock-context) reveal which thread they ran on and whether
+    ``get_forwarded_headers()`` was populated at hook time. Fires even when
+    x-aimock-context is ABSENT -- that is the whole point.
+
+    Never throws: any failure skips the stamp and leaves the request
+    otherwise untouched.
+    """
+    try:
+        ctx = "present" if _AIMOCK_CONTEXT_HEADER in headers else "EMPTY"
+        request.headers["x-diag-probe"] = (
+            f"thread={threading.current_thread().name};"
+            f"ctx={ctx};keys={len(headers)}"
+        )
+    except Exception:  # pragma: no cover - diagnostic must never break a call
+        pass
+
+
 def _inject_diag_hop(request: Any, headers: Dict[str, str]) -> None:
     """Append this backend's hop tag to ``x-diag-hops`` on the outbound
     request and emit the ``outbound-llm`` CVDIAG breadcrumb.
@@ -265,6 +291,7 @@ def install_httpx_hook(client: Any) -> None:
             headers = get_forwarded_headers()
             for key, value in headers.items():
                 request.headers[key] = value
+            _stamp_diag_probe(request, headers)
             _inject_diag_hop(request, headers)
 
         setattr(_inject_headers_async, _HOOK_MARKER, True)
@@ -275,6 +302,7 @@ def install_httpx_hook(client: Any) -> None:
             headers = get_forwarded_headers()
             for key, value in headers.items():
                 request.headers[key] = value
+            _stamp_diag_probe(request, headers)
             _inject_diag_hop(request, headers)
 
         setattr(_inject_headers, _HOOK_MARKER, True)

--- a/showcase/integrations/strands/src/agents/_header_forwarding.py
+++ b/showcase/integrations/strands/src/agents/_header_forwarding.py
@@ -211,8 +211,7 @@ def _stamp_diag_probe(request: Any, headers: Dict[str, str]) -> None:
     try:
         ctx = "present" if _AIMOCK_CONTEXT_HEADER in headers else "EMPTY"
         request.headers["x-diag-probe"] = (
-            f"thread={threading.current_thread().name};"
-            f"ctx={ctx};keys={len(headers)}"
+            f"thread={threading.current_thread().name};ctx={ctx};keys={len(headers)}"
         )
     except Exception:  # pragma: no cover - diagnostic must never break a call
         pass


### PR DESCRIPTION
TEMPORARY DIAGNOSTIC (to be reverted after reading). Adds one ungated header `x-diag-probe: thread=<name>;ctx=<present|EMPTY>;keys=<n>` on every outbound LLM call (before the context gate) across the 7 backends whose native tool calls drop x-aimock-context. The aimock journal (HTTP-readable) will then show, per dropping call, which thread it ran on and whether the forwarded-headers contextvar was empty — pinning the context-losing run-path. Additive, try/except-wrapped (never throws), no change to existing forwarding/injection/gating. py_compile clean.