### PR TITLE
docs: fix typo recieve → receive in LangGraph ai-travel-app tutorial

### DIFF
--- a/.auto-pr/target-repo.txt
+++ b/.auto-pr/target-repo.txt
@@ -1,0 +1,1 @@
+CopilotKit/CopilotKit

--- a/docs/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-5-stream-progress.mdx
+++ b/docs/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-5-stream-progress.mdx
@@ -165,9 +165,9 @@ async def search_node(state: AgentState, config: RunnableConfig):
 </Step>
 </Steps>
 
-## Recieving and rendering the manaully emitted state
+## Receiving and rendering the manually emitted state
 
-Now that we are manually emitting the state of our search, we can recieve and render that state in the UI. To do this,
+Now that we are manually emitting the state of our search, we can receive and render that state in the UI. To do this,
 we'll be using the [useCoAgentStateRender](/reference/v1/hooks/useCoAgentStateRender) function in our `use-trips.tsx` hook.
 
 

--- a/docs/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-6-human-in-the-loop.mdx
+++ b/docs/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-6-human-in-the-loop.mdx
@@ -50,7 +50,7 @@ This will force the agent to pause execution at the `trips_node` and wait for th
 <Step>
 ## Update the perform_trips_node node to properly handle the user's decision
 
-Prior to this step, entrance to the `perform_trips_node` was standard. We would recieve the requested tool call, call the appropriate
+Prior to this step, entrance to the `perform_trips_node` was standard. We would receive the requested tool call, call the appropriate
 tool, edit the message state to reflect the tool call results, and then move on to the next node.
 
 However, this will no longer work since we've added a breakpoint to the `trips_node`. In a future step, we'll be utilizing this
@@ -101,7 +101,7 @@ other decision returned will result in the requested actions being performed.
 </Step>
 <Step>
 ## Emitting the tool calls
-In order for the front-end to recieve the breakpoint and take the user's decision, we'll need to emit the tool calls that the agent is requesting.
+In order for the front-end to receive the breakpoint and take the user's decision, we'll need to emit the tool calls that the agent is requesting.
 To do this, we'll be editing the `chat_node` in the `chat.py` file.
 ```python title="agent/travel/chat.py"
 # ...
@@ -272,7 +272,7 @@ export const ActionButtons = ({ status, handler, approve, reject }: ActionButton
 
 The important piece here is that the `onClick` handlers emit the user's decision back to the agent. If the user clicks the `Delete` button
 then the `handler?.("SEND")` is called. If the user clicks the `Cancel` button then the `handler?.("CANCEL")` is called. This is how the 
-agent recieves the user's decision. 
+agent receives the user's decision. 
 
 <Callout>
 If you wanted to implement a more complex UI that allows for the human to edit the tool call arguments before sending them back to the agent,


### PR DESCRIPTION
## Summary

Fix 4 spelling typos (`recieve`/`recieves` → `receive`/`receives`) in the LangGraph AI Travel App tutorial docs:

- `step-5-stream-progress.mdx`: heading "Recieving" → "Receiving", body "recieve" → "receive"
- `step-6-human-in-the-loop.mdx`: 3 occurrences of `recieve`/`recieves` → `receive`/`receives`

Closes no issue — straightforward doc spelling correction.

## Test plan
- [ ] No code changed, docs-only edit
- [ ] Verified no remaining `recieve`/`recieves` in the affected files