### PR TITLE
fix(sdk-python): restore frontend tool history faithfully in LangGraph middleware

### DIFF
--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -59,6 +59,7 @@ _a2ui_tools_by_thread: dict[str, Any] = {}
 # checkpointer). Collisions across concurrent context-less runs are an
 # acceptable edge — the deployed path always carries a thread id.
 _DEFAULT_THREAD_KEY = "__copilotkit_a2ui_default__"
+_FRONTEND_TOOL_RESULT_CONTENT = json.dumps({"status": "forwarded_to_frontend"})
 
 
 def _current_thread_id() -> "str | None":
@@ -446,6 +447,10 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
     ) -> ModelResponse:
         _extract_forwarded_headers_from_config()
         _ensure_httpx_hook(request.model)
+        self._restore_intercepted_tool_call_history(
+            request.messages,
+            request.state.get("copilotkit", {}),
+        )
         request = self._apply_state_note(request)
 
         a2ui_tool = self._maybe_build_a2ui_tool(request)
@@ -641,6 +646,139 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
 
         return messages
 
+    @staticmethod
+    def _frontend_tool_result_message(tool_call: dict[str, Any]) -> ToolMessage | None:
+        tool_call_id = tool_call.get("id")
+        if not tool_call_id:
+            return None
+
+        return ToolMessage(
+            content=_FRONTEND_TOOL_RESULT_CONTENT,
+            tool_call_id=tool_call_id,
+            name=tool_call.get("name"),
+            id=f"copilotkit-fe-tool-result-{tool_call_id}",
+        )
+
+    @staticmethod
+    def _copy_ai_message_with_tool_calls(
+        message: AIMessage,
+        tool_calls: list[dict[str, Any]],
+    ) -> AIMessage:
+        if hasattr(message, "model_copy"):
+            return message.model_copy(update={"tool_calls": tool_calls})
+        return message.copy(update={"tool_calls": tool_calls})
+
+    @classmethod
+    def _restore_intercepted_tool_call_history(
+        cls,
+        messages: list,
+        copilotkit_state: dict[str, Any],
+    ) -> bool:
+        """Rehydrate FE tool calls with synthetic results before model history.
+
+        ``after_model`` strips FE calls so the backend ToolNode only executes
+        backend calls. Once backend ToolMessages have been appended, the next
+        LLM call still needs to see the full assistant turn, including the FE
+        calls it already made. Synthetic ToolMessages make that restored
+        history valid for providers that require every tool call to be
+        answered.
+        """
+        intercepted_tool_calls = copilotkit_state.get("intercepted_tool_calls")
+        original_message_id = copilotkit_state.get("original_ai_message_id")
+        original_tool_calls = copilotkit_state.get("original_tool_calls")
+
+        if not intercepted_tool_calls or not original_message_id:
+            return False
+
+        intercepted_by_id = {
+            call.get("id"): call
+            for call in intercepted_tool_calls
+            if isinstance(call, dict) and call.get("id")
+        }
+        if not intercepted_by_id:
+            return False
+
+        for idx, msg in enumerate(messages):
+            if not isinstance(msg, AIMessage) or msg.id != original_message_id:
+                continue
+
+            changed = False
+            existing_tool_calls = list(getattr(msg, "tool_calls", None) or [])
+            existing_tool_call_ids = {
+                call.get("id")
+                for call in existing_tool_calls
+                if isinstance(call, dict) and call.get("id")
+            }
+            missing_tool_calls = [
+                call
+                for call in intercepted_tool_calls
+                if (
+                    isinstance(call, dict)
+                    and call.get("id") not in existing_tool_call_ids
+                )
+            ]
+
+            if original_tool_calls:
+                full_tool_calls = list(original_tool_calls)
+            else:
+                full_tool_calls = [*existing_tool_calls, *missing_tool_calls]
+
+            if missing_tool_calls or full_tool_calls != existing_tool_calls:
+                messages[idx] = cls._copy_ai_message_with_tool_calls(
+                    msg,
+                    full_tool_calls,
+                )
+                changed = True
+
+            tool_messages_end = idx + 1
+            while (
+                tool_messages_end < len(messages)
+                and isinstance(messages[tool_messages_end], ToolMessage)
+            ):
+                tool_messages_end += 1
+
+            existing_tool_messages = messages[idx + 1 : tool_messages_end]
+            tool_messages_by_id: dict[str, ToolMessage] = {}
+            for tool_message in existing_tool_messages:
+                tool_call_id = getattr(tool_message, "tool_call_id", None)
+                if tool_call_id and tool_call_id not in tool_messages_by_id:
+                    tool_messages_by_id[tool_call_id] = tool_message
+
+            ordered_tool_messages = []
+            used_tool_message_ids = set()
+            for tool_call in full_tool_calls:
+                if not isinstance(tool_call, dict):
+                    continue
+
+                tool_call_id = tool_call.get("id")
+                if not tool_call_id:
+                    continue
+
+                tool_message = tool_messages_by_id.get(tool_call_id)
+                if tool_message is None and tool_call_id in intercepted_by_id:
+                    tool_message = cls._frontend_tool_result_message(tool_call)
+                    if tool_message is not None:
+                        changed = True
+
+                if tool_message is not None:
+                    ordered_tool_messages.append(tool_message)
+                    used_tool_message_ids.add(tool_call_id)
+
+            ordered_tool_messages.extend(
+                tool_message
+                for tool_message in existing_tool_messages
+                if getattr(tool_message, "tool_call_id", None)
+                not in used_tool_message_ids
+            )
+
+            if ordered_tool_messages != existing_tool_messages:
+                messages[idx + 1 : tool_messages_end] = ordered_tool_messages
+                changed = True
+
+            return changed
+
+        return False
+
     async def awrap_model_call(
         self,
         request: ModelRequest,
@@ -648,6 +786,10 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
     ) -> ModelResponse:
         _extract_forwarded_headers_from_config()
         _ensure_httpx_hook(request.model)
+        self._restore_intercepted_tool_call_history(
+            request.messages,
+            request.state.get("copilotkit", {}),
+        )
         self._fix_messages_for_bedrock(request.messages)
         request = self._apply_state_note(request)
 
@@ -872,11 +1014,12 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         if not frontend_tool_calls:
             return None
 
-        # Create updated AIMessage with only backend tool calls
-        updated_ai_message = AIMessage(
-            content=last_message.content,
-            tool_calls=backend_tool_calls,
-            id=last_message.id,
+        # Keep only backend calls for the ToolNode. The full assistant turn is
+        # restored with synthetic FE ToolMessages before the next model call
+        # and before the agent exits.
+        updated_ai_message = self._copy_ai_message_with_tool_calls(
+            last_message,
+            backend_tool_calls,
         )
 
         return {
@@ -884,6 +1027,7 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
             "copilotkit": {
                 "intercepted_tool_calls": frontend_tool_calls,
                 "original_ai_message_id": last_message.id,
+                "original_tool_calls": tool_calls,
             },
         }
 
@@ -913,26 +1057,18 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
             return None
 
         messages = state.get("messages", [])
-        updated_messages = []
-
-        for msg in messages:
-            if isinstance(msg, AIMessage) and msg.id == original_message_id:
-                existing_tool_calls = getattr(msg, "tool_calls", None) or []
-                updated_messages.append(
-                    AIMessage(
-                        content=msg.content,
-                        tool_calls=[*existing_tool_calls, *intercepted_tool_calls],
-                        id=msg.id,
-                    )
-                )
-            else:
-                updated_messages.append(msg)
+        updated_messages = list(messages)
+        self._restore_intercepted_tool_call_history(
+            updated_messages,
+            copilotkit_state,
+        )
 
         return {
             "messages": updated_messages,
             "copilotkit": {
                 "intercepted_tool_calls": None,
                 "original_ai_message_id": None,
+                "original_tool_calls": None,
             },
         }
 

--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -451,6 +451,7 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
             request.messages,
             request.state.get("copilotkit", {}),
         )
+        self._fix_messages_for_bedrock(request.messages)
         request = self._apply_state_note(request)
 
         a2ui_tool = self._maybe_build_a2ui_tool(request)
@@ -673,15 +674,18 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         cls,
         messages: list,
         copilotkit_state: dict[str, Any],
+        *,
+        synthesize_frontend_tool_results: bool = True,
     ) -> bool:
-        """Rehydrate FE tool calls with synthetic results before model history.
+        """Rehydrate intercepted FE tool calls before model history.
 
         ``after_model`` strips FE calls so the backend ToolNode only executes
         backend calls. Once backend ToolMessages have been appended, the next
         LLM call still needs to see the full assistant turn, including the FE
         calls it already made. Synthetic ToolMessages make that restored
         history valid for providers that require every tool call to be
-        answered.
+        answered. ``after_agent`` disables synthesis so the persisted FE call
+        remains orphaned for the real frontend result.
         """
         intercepted_tool_calls = copilotkit_state.get("intercepted_tool_calls")
         original_message_id = copilotkit_state.get("original_ai_message_id")
@@ -731,9 +735,8 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
                 changed = True
 
             tool_messages_end = idx + 1
-            while (
-                tool_messages_end < len(messages)
-                and isinstance(messages[tool_messages_end], ToolMessage)
+            while tool_messages_end < len(messages) and isinstance(
+                messages[tool_messages_end], ToolMessage
             ):
                 tool_messages_end += 1
 
@@ -755,7 +758,11 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
                     continue
 
                 tool_message = tool_messages_by_id.get(tool_call_id)
-                if tool_message is None and tool_call_id in intercepted_by_id:
+                if (
+                    synthesize_frontend_tool_results
+                    and tool_message is None
+                    and tool_call_id in intercepted_by_id
+                ):
                     tool_message = cls._frontend_tool_result_message(tool_call)
                     if tool_message is not None:
                         changed = True
@@ -1015,8 +1022,8 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
             return None
 
         # Keep only backend calls for the ToolNode. The full assistant turn is
-        # restored with synthetic FE ToolMessages before the next model call
-        # and before the agent exits.
+        # restored with synthetic FE ToolMessages before the next model call,
+        # then as an orphaned FE call before the agent exits.
         updated_ai_message = self._copy_ai_message_with_tool_calls(
             last_message,
             backend_tool_calls,
@@ -1061,7 +1068,18 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         self._restore_intercepted_tool_call_history(
             updated_messages,
             copilotkit_state,
+            synthesize_frontend_tool_results=False,
         )
+        synthetic_result_ids = {
+            f"copilotkit-fe-tool-result-{call.get('id')}"
+            for call in intercepted_tool_calls
+            if isinstance(call, dict) and call.get("id")
+        }
+        updated_messages = [
+            message
+            for message in updated_messages
+            if getattr(message, "id", None) not in synthetic_result_ids
+        ]
 
         return {
             "messages": updated_messages,

--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -447,6 +447,7 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
     ) -> ModelResponse:
         _extract_forwarded_headers_from_config()
         _ensure_httpx_hook(request.model)
+        request = request.override(messages=list(request.messages))
         self._restore_intercepted_tool_call_history(
             request.messages,
             request.state.get("copilotkit", {}),
@@ -674,18 +675,15 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         cls,
         messages: list,
         copilotkit_state: dict[str, Any],
-        *,
-        synthesize_frontend_tool_results: bool = True,
     ) -> bool:
-        """Rehydrate intercepted FE tool calls before model history.
+        """Rehydrate intercepted FE tool calls with synthetic results.
 
         ``after_model`` strips FE calls so the backend ToolNode only executes
         backend calls. Once backend ToolMessages have been appended, the next
         LLM call still needs to see the full assistant turn, including the FE
         calls it already made. Synthetic ToolMessages make that restored
-        history valid for providers that require every tool call to be
-        answered. ``after_agent`` disables synthesis so the persisted FE call
-        remains orphaned for the real frontend result.
+        request history valid for providers that require every tool call to be
+        answered.
         """
         intercepted_tool_calls = copilotkit_state.get("intercepted_tool_calls")
         original_message_id = copilotkit_state.get("original_ai_message_id")
@@ -758,11 +756,7 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
                     continue
 
                 tool_message = tool_messages_by_id.get(tool_call_id)
-                if (
-                    synthesize_frontend_tool_results
-                    and tool_message is None
-                    and tool_call_id in intercepted_by_id
-                ):
+                if tool_message is None and tool_call_id in intercepted_by_id:
                     tool_message = cls._frontend_tool_result_message(tool_call)
                     if tool_message is not None:
                         changed = True
@@ -793,6 +787,7 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
     ) -> ModelResponse:
         _extract_forwarded_headers_from_config()
         _ensure_httpx_hook(request.model)
+        request = request.override(messages=list(request.messages))
         self._restore_intercepted_tool_call_history(
             request.messages,
             request.state.get("copilotkit", {}),
@@ -1064,22 +1059,22 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
             return None
 
         messages = state.get("messages", [])
-        updated_messages = list(messages)
-        self._restore_intercepted_tool_call_history(
-            updated_messages,
-            copilotkit_state,
-            synthesize_frontend_tool_results=False,
-        )
-        synthetic_result_ids = {
-            f"copilotkit-fe-tool-result-{call.get('id')}"
-            for call in intercepted_tool_calls
-            if isinstance(call, dict) and call.get("id")
-        }
-        updated_messages = [
-            message
-            for message in updated_messages
-            if getattr(message, "id", None) not in synthetic_result_ids
-        ]
+        updated_messages = []
+
+        for message in messages:
+            if isinstance(message, AIMessage) and message.id == original_message_id:
+                restored_tool_calls = (
+                    copilotkit_state.get("original_tool_calls")
+                    or [*(message.tool_calls or []), *intercepted_tool_calls]
+                )
+                updated_messages.append(
+                    self._copy_ai_message_with_tool_calls(
+                        message,
+                        list(restored_tool_calls),
+                    )
+                )
+            else:
+                updated_messages.append(message)
 
         return {
             "messages": updated_messages,

--- a/sdk-python/copilotkit/langgraph.py
+++ b/sdk-python/copilotkit/langgraph.py
@@ -45,6 +45,7 @@ class CopilotKitProperties(TypedDict):
     # Private state for CopilotKit middleware
     intercepted_tool_calls: Any
     original_ai_message_id: Any
+    original_tool_calls: Any
 
 
 class CopilotKitState(MessagesState):

--- a/sdk-python/tests/test_copilotkit_lg_middleware.py
+++ b/sdk-python/tests/test_copilotkit_lg_middleware.py
@@ -11,8 +11,8 @@ and what state updates the middleware emits):
   becomes a ``SystemMessage`` containing ``"App Context:\\n<json>"``. Empty
   context is a no-op. Re-running ``before_agent`` does not duplicate the note.
 * ``after_model`` peels frontend tool calls off the last AIMessage so the
-  ToolNode does not try to execute them; ``after_agent`` re-attaches them
-  before the run ends.
+  ToolNode does not try to execute them; later model calls and ``after_agent``
+  re-attach them with synthetic ToolMessages so model history remains valid.
 * The ``expose_state`` opt-in surfaces user state into ``request.system_message``
   as a ``"Current agent state:"`` note. Default is off; reserved internal
   keys, underscore-prefixed keys, and empty values are filtered out; an
@@ -583,6 +583,9 @@ def test_after_model_intercepts_frontend_tool_calls_and_leaves_backend_alone():
         content="",
         tool_calls=[backend_call, frontend_call],
         id="ai-1",
+        name="assistant-name",
+        additional_kwargs={"provider": "test-provider"},
+        response_metadata={"finish_reason": "tool_calls"},
     )
     state = {
         "messages": [HumanMessage("hi"), ai],
@@ -596,12 +599,168 @@ def test_after_model_intercepts_frontend_tool_calls_and_leaves_backend_alone():
     last = result["messages"][-1]
     assert isinstance(last, AIMessage)
     assert [tc["name"] for tc in last.tool_calls] == ["backend_search"]
+    assert last.name == "assistant-name"
+    assert last.additional_kwargs == {"provider": "test-provider"}
+    assert last.response_metadata == {"finish_reason": "tool_calls"}
     intercepted = result["copilotkit"]["intercepted_tool_calls"]
     assert len(intercepted) == 1
     assert intercepted[0]["id"] == "2"
     assert intercepted[0]["name"] == "navigate"
     assert intercepted[0]["args"] == {"path": "/x"}
     assert result["copilotkit"]["original_ai_message_id"] == "ai-1"
+    assert [tc["id"] for tc in result["copilotkit"]["original_tool_calls"]] == [
+        "1",
+        "2",
+    ]
+
+
+def test_next_model_call_sees_intercepted_frontend_tool_call_history():
+    middleware = CopilotKitMiddleware()
+    fe_tool = {"function": {"name": "navigate"}}
+    backend_call = {"id": "1", "name": "backend_search", "args": {"q": "hi"}}
+    frontend_call = {"id": "2", "name": "navigate", "args": {"path": "/x"}}
+    initial_state = {
+        "messages": [
+            HumanMessage("hi"),
+            AIMessage(
+                content="",
+                tool_calls=[backend_call, frontend_call],
+                id="ai-1",
+                name="assistant-name",
+                additional_kwargs={"provider": "test-provider"},
+                response_metadata={"finish_reason": "tool_calls"},
+            ),
+        ],
+        "copilotkit": {"actions": [fe_tool]},
+    }
+
+    after_model = middleware.after_model(initial_state, MagicMock(name="runtime"))
+    assert after_model is not None
+
+    messages = [
+        *after_model["messages"],
+        ToolMessage(content='{"hits": 1}', tool_call_id="1"),
+    ]
+    state = {
+        "messages": messages,
+        "copilotkit": {
+            **initial_state["copilotkit"],
+            **after_model["copilotkit"],
+        },
+    }
+    request = _make_request(state=state, messages=messages)
+
+    seen, _ = _run_wrap(middleware, request)
+
+    ai = next(m for m in seen.messages if isinstance(m, AIMessage) and m.id == "ai-1")
+    assert [tc["id"] for tc in ai.tool_calls] == ["1", "2"]
+    assert ai.name == "assistant-name"
+    assert ai.additional_kwargs == {"provider": "test-provider"}
+    assert ai.response_metadata == {"finish_reason": "tool_calls"}
+
+    tool_messages = [m for m in seen.messages if isinstance(m, ToolMessage)]
+    assert [m.tool_call_id for m in tool_messages] == ["1", "2"]
+    assert tool_messages[0].content == '{"hits": 1}'
+    assert json.loads(tool_messages[1].content) == {"status": "forwarded_to_frontend"}
+
+
+def test_next_model_call_preserves_multiple_frontend_tool_calls_in_order():
+    middleware = CopilotKitMiddleware()
+    fe_tools = [{"name": "select_tab"}, {"name": "navigate"}]
+    tool_calls = [
+        {"id": "fe-1", "name": "select_tab", "args": {"tab": "overview"}},
+        {"id": "be-1", "name": "backend_search", "args": {"q": "hi"}},
+        {"id": "be-2", "name": "backend_fetch", "args": {"id": "42"}},
+        {"id": "fe-2", "name": "navigate", "args": {"path": "/x"}},
+    ]
+    initial_state = {
+        "messages": [
+            HumanMessage("hi"),
+            AIMessage(content="", tool_calls=tool_calls, id="ai"),
+        ],
+        "copilotkit": {"actions": fe_tools},
+    }
+
+    after_model = middleware.after_model(initial_state, MagicMock(name="runtime"))
+    assert after_model is not None
+    assert [tc["id"] for tc in after_model["messages"][-1].tool_calls] == [
+        "be-1",
+        "be-2",
+    ]
+
+    messages = [
+        *after_model["messages"],
+        ToolMessage(content="ok", tool_call_id="be-1"),
+        ToolMessage(content="ok", tool_call_id="be-2"),
+    ]
+    state = {
+        "messages": messages,
+        "copilotkit": {
+            **initial_state["copilotkit"],
+            **after_model["copilotkit"],
+        },
+    }
+    request = _make_request(state=state, messages=messages)
+
+    seen, _ = _run_wrap(middleware, request)
+
+    ai = next(m for m in seen.messages if isinstance(m, AIMessage) and m.id == "ai")
+    assert [tc["id"] for tc in ai.tool_calls] == ["fe-1", "be-1", "be-2", "fe-2"]
+
+    tool_messages = [m for m in seen.messages if isinstance(m, ToolMessage)]
+    assert [m.tool_call_id for m in tool_messages] == [
+        "fe-1",
+        "be-1",
+        "be-2",
+        "fe-2",
+    ]
+    assert json.loads(tool_messages[0].content) == {"status": "forwarded_to_frontend"}
+    assert json.loads(tool_messages[-1].content) == {"status": "forwarded_to_frontend"}
+
+
+def test_next_model_call_preserves_frontend_history_when_backend_tool_errors():
+    middleware = CopilotKitMiddleware()
+    fe_tool = {"name": "navigate"}
+    backend_call = {"id": "be-1", "name": "backend_search", "args": {"q": "hi"}}
+    frontend_call = {"id": "fe-1", "name": "navigate", "args": {"path": "/x"}}
+    initial_state = {
+        "messages": [
+            HumanMessage("hi"),
+            AIMessage(
+                content="",
+                tool_calls=[backend_call, frontend_call],
+                id="ai",
+            ),
+        ],
+        "copilotkit": {"actions": [fe_tool]},
+    }
+
+    after_model = middleware.after_model(initial_state, MagicMock(name="runtime"))
+    assert after_model is not None
+
+    messages = [
+        *after_model["messages"],
+        ToolMessage(content="backend failed", tool_call_id="be-1", status="error"),
+    ]
+    state = {
+        "messages": messages,
+        "copilotkit": {
+            **initial_state["copilotkit"],
+            **after_model["copilotkit"],
+        },
+    }
+    request = _make_request(state=state, messages=messages)
+
+    seen, _ = _run_wrap(middleware, request)
+
+    ai = next(m for m in seen.messages if isinstance(m, AIMessage) and m.id == "ai")
+    assert [tc["id"] for tc in ai.tool_calls] == ["be-1", "fe-1"]
+
+    tool_messages = [m for m in seen.messages if isinstance(m, ToolMessage)]
+    assert [m.tool_call_id for m in tool_messages] == ["be-1", "fe-1"]
+    assert tool_messages[0].content == "backend failed"
+    assert getattr(tool_messages[0], "status", None) == "error"
+    assert json.loads(tool_messages[1].content) == {"status": "forwarded_to_frontend"}
 
 
 # ---------------------------------------------------------------------------
@@ -642,8 +801,54 @@ def test_after_agent_restores_intercepted_tool_calls_on_original_message():
         m for m in result["messages"] if isinstance(m, AIMessage) and m.id == "ai-1"
     )
     assert [tc["name"] for tc in restored_ai.tool_calls] == ["navigate"]
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert [m.tool_call_id for m in tool_messages] == ["2"]
+    assert json.loads(tool_messages[0].content) == {"status": "forwarded_to_frontend"}
     assert result["copilotkit"]["intercepted_tool_calls"] is None
     assert result["copilotkit"]["original_ai_message_id"] is None
+    assert result["copilotkit"]["original_tool_calls"] is None
+
+
+def test_after_agent_does_not_duplicate_rehydrated_frontend_tool_history():
+    middleware = CopilotKitMiddleware()
+    backend_call = {"id": "1", "name": "backend_search", "args": {"q": "hi"}}
+    frontend_call = {"id": "2", "name": "navigate", "args": {"path": "/x"}}
+    state = {
+        "messages": [
+            HumanMessage("hi"),
+            AIMessage(
+                content="",
+                tool_calls=[backend_call, frontend_call],
+                id="ai-1",
+            ),
+            ToolMessage(content="ok", tool_call_id="1"),
+            ToolMessage(
+                content=json.dumps({"status": "forwarded_to_frontend"}),
+                tool_call_id="2",
+            ),
+        ],
+        "copilotkit": {
+            "intercepted_tool_calls": [frontend_call],
+            "original_ai_message_id": "ai-1",
+            "original_tool_calls": [backend_call, frontend_call],
+        },
+    }
+    runtime = MagicMock(name="runtime")
+
+    result = middleware.after_agent(state, runtime)
+
+    assert result is not None
+    restored_ai = next(
+        m for m in result["messages"] if isinstance(m, AIMessage) and m.id == "ai-1"
+    )
+    assert [tc["id"] for tc in restored_ai.tool_calls] == ["1", "2"]
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert [m.tool_call_id for m in tool_messages] == ["1", "2"]
+    assert result["copilotkit"]["intercepted_tool_calls"] is None
+    assert result["copilotkit"]["original_ai_message_id"] is None
+    assert result["copilotkit"]["original_tool_calls"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/sdk-python/tests/test_copilotkit_lg_middleware.py
+++ b/sdk-python/tests/test_copilotkit_lg_middleware.py
@@ -895,6 +895,158 @@ def test_bedrock_fix_repairs_string_args_to_dicts():
 
 
 # ---------------------------------------------------------------------------
+# Checkpoint roundtrip — orphan-handoff contract
+# ---------------------------------------------------------------------------
+# These tests exercise the full checkpoint roundtrip path:
+# 1. after_agent leaves FE tool call as orphan (no ToolMessage)
+# 2. Checkpoint saved with orphan state
+# 3. Checkpoint loaded; patch_orphan_tool_calls adds _INTERRUPTED_PAT placeholder
+# 4. Real frontend result arrives (appended to messages)
+# 5. _fix_messages_for_bedrock dedupes: real result replaces placeholder
+#
+# The key invariant is that after_agent MUST NOT persist synthetic
+# ToolMessages — only the tool_calls are restored to the AIMessage.
+
+
+def test_checkpoint_roundtrip_placeholder_replaced_by_real_result():
+    """Simulates checkpoint restore with patch_orphan_tool_calls placeholder,
+    then real FE result arriving — the Bedrock fix should replace the
+    placeholder with the real result, keeping the result adjacent to the
+    AIMessage.
+    """
+    # State after checkpoint restore: patch_orphan_tool_calls added a
+    # placeholder for the orphan FE tool call. The real result is appended
+    # at the end (e.g. by the AG-UI adapter or add_messages).
+    ai = AIMessage(
+        content="",
+        tool_calls=[
+            {"id": "be-1", "name": "backend_search", "args": {}},
+            {"id": "fe-1", "name": "navigate", "args": {"path": "/x"}},
+        ],
+        id="ai-1",
+    )
+    backend_result = ToolMessage(content='{"hits": 3}', tool_call_id="be-1")
+    # patch_orphan_tool_calls injects this pattern for orphan tool calls
+    placeholder = ToolMessage(
+        content="Tool call 'navigate' with id 'fe-1' was interrupted before completion.",
+        tool_call_id="fe-1",
+    )
+    # Real FE result arrives later, appended at end
+    real_fe_result = ToolMessage(
+        content='{"navigated_to": "/x"}',
+        tool_call_id="fe-1",
+    )
+    messages: list[Any] = [
+        HumanMessage("hi"),
+        ai,
+        backend_result,
+        placeholder,
+        real_fe_result,
+    ]
+
+    CopilotKitMiddleware._fix_messages_for_bedrock(messages)
+
+    # The real result should replace the placeholder at the adjacent position
+    tool_messages = [m for m in messages if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 2, "Should have backend + FE results only"
+    assert tool_messages[0].tool_call_id == "be-1"
+    assert tool_messages[0].content == '{"hits": 3}'
+    assert tool_messages[1].tool_call_id == "fe-1"
+    assert tool_messages[1].content == '{"navigated_to": "/x"}'
+
+
+def test_checkpoint_roundtrip_multiple_fe_calls_with_placeholders():
+    """Multiple FE tool calls, all orphaned after turn 1, each gets a
+    placeholder from patch_orphan_tool_calls. Real results arrive for all.
+    """
+    ai = AIMessage(
+        content="",
+        tool_calls=[
+            {"id": "fe-1", "name": "select_tab", "args": {"tab": "overview"}},
+            {"id": "be-1", "name": "search", "args": {"q": "hi"}},
+            {"id": "fe-2", "name": "navigate", "args": {"path": "/x"}},
+        ],
+        id="ai-1",
+    )
+    placeholder_fe1 = ToolMessage(
+        content="Tool call 'select_tab' with id 'fe-1' was interrupted before completion.",
+        tool_call_id="fe-1",
+    )
+    backend_result = ToolMessage(content='{"hits": 5}', tool_call_id="be-1")
+    placeholder_fe2 = ToolMessage(
+        content="Tool call 'navigate' with id 'fe-2' was interrupted before completion.",
+        tool_call_id="fe-2",
+    )
+    real_fe1 = ToolMessage(content='{"tab": "overview"}', tool_call_id="fe-1")
+    real_fe2 = ToolMessage(content='{"path": "/x"}', tool_call_id="fe-2")
+    messages: list[Any] = [
+        HumanMessage("hi"),
+        ai,
+        placeholder_fe1,
+        backend_result,
+        placeholder_fe2,
+        real_fe1,  # appended later
+        real_fe2,  # appended later
+    ]
+
+    CopilotKitMiddleware._fix_messages_for_bedrock(messages)
+
+    tool_messages = [m for m in messages if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 3, "Should have 3 results: fe-1, be-1, fe-2"
+    # The dedup replaces placeholders with real results
+    assert all(
+        "was interrupted before completion" not in m.content for m in tool_messages
+    ), "All placeholders should be replaced"
+    ids = [m.tool_call_id for m in tool_messages]
+    assert set(ids) == {"fe-1", "be-1", "fe-2"}
+
+
+def test_after_agent_leaves_fe_call_orphaned_for_checkpoint():
+    """Verify that after_agent does not add any ToolMessage for FE calls —
+    the FE tool call is left orphaned so the checkpoint can receive the real
+    frontend result later via add_messages merge.
+    """
+    middleware = CopilotKitMiddleware()
+    backend_call = {"id": "be-1", "name": "search", "args": {"q": "hi"}}
+    frontend_call = {"id": "fe-1", "name": "navigate", "args": {"path": "/x"}}
+    # State after backend execution + mid-loop model calls complete
+    state = {
+        "messages": [
+            HumanMessage("hi"),
+            AIMessage(content="", tool_calls=[backend_call], id="ai-1"),
+            ToolMessage(content="ok", tool_call_id="be-1"),
+        ],
+        "copilotkit": {
+            "intercepted_tool_calls": [frontend_call],
+            "original_ai_message_id": "ai-1",
+            "original_tool_calls": [backend_call, frontend_call],
+        },
+    }
+    runtime = MagicMock(name="runtime")
+
+    result = middleware.after_agent(state, runtime)
+
+    assert result is not None
+    # AIMessage should have both tool_calls restored
+    restored_ai = next(
+        m for m in result["messages"] if isinstance(m, AIMessage) and m.id == "ai-1"
+    )
+    assert [tc["id"] for tc in restored_ai.tool_calls] == ["be-1", "fe-1"]
+
+    # Critical: only the backend ToolMessage should exist — the FE call is
+    # left as an orphan for the real frontend result to fill.
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1, "Only backend ToolMessage should exist"
+    assert tool_messages[0].tool_call_id == "be-1"
+    # No synthetic FE ToolMessage should be present
+    assert not any(
+        "forwarded_to_frontend" in str(m.content)
+        for m in result["messages"]
+        if isinstance(m, ToolMessage)
+    ), "No synthetic FE ToolMessage should be in after_agent output"
+
+
+# ---------------------------------------------------------------------------
 # _extract_forwarded_headers_from_config — raw x-* header extraction
 # ---------------------------------------------------------------------------
 

--- a/sdk-python/tests/test_copilotkit_lg_middleware.py
+++ b/sdk-python/tests/test_copilotkit_lg_middleware.py
@@ -615,7 +615,8 @@ def test_after_model_intercepts_frontend_tool_calls_and_leaves_backend_alone():
     ]
 
 
-def test_next_model_call_sees_intercepted_frontend_tool_call_history():
+@pytest.mark.parametrize("use_async", [False, True])
+def test_next_model_call_sees_request_scoped_frontend_tool_history(use_async):
     middleware = CopilotKitMiddleware()
     fe_tool = {"function": {"name": "navigate"}}
     backend_call = {"id": "1", "name": "backend_search", "args": {"q": "hi"}}
@@ -651,7 +652,17 @@ def test_next_model_call_sees_intercepted_frontend_tool_call_history():
     }
     request = _make_request(state=state, messages=messages)
 
-    seen, _ = _run_wrap(middleware, request)
+    if use_async:
+        received: dict[str, ModelRequest] = {}
+
+        async def handler(req: ModelRequest):
+            received["req"] = req
+            return "ok"
+
+        asyncio.run(middleware.awrap_model_call(request, handler))
+        seen = received["req"]
+    else:
+        seen, _ = _run_wrap(middleware, request)
 
     ai = next(m for m in seen.messages if isinstance(m, AIMessage) and m.id == "ai-1")
     assert [tc["id"] for tc in ai.tool_calls] == ["1", "2"]
@@ -663,6 +674,13 @@ def test_next_model_call_sees_intercepted_frontend_tool_call_history():
     assert [m.tool_call_id for m in tool_messages] == ["1", "2"]
     assert tool_messages[0].content == '{"hits": 1}'
     assert json.loads(tool_messages[1].content) == {"status": "forwarded_to_frontend"}
+
+    persisted_ai = next(
+        m for m in messages if isinstance(m, AIMessage) and m.id == "ai-1"
+    )
+    assert [tc["id"] for tc in persisted_ai.tool_calls] == ["1"]
+    persisted_tool_messages = [m for m in messages if isinstance(m, ToolMessage)]
+    assert [m.tool_call_id for m in persisted_tool_messages] == ["1"]
 
 
 def test_next_model_call_preserves_multiple_frontend_tool_calls_in_order():
@@ -782,52 +800,13 @@ def test_after_agent_no_intercepted_returns_no_update():
 
 def test_after_agent_restores_intercepted_tool_calls_on_original_message():
     middleware = CopilotKitMiddleware()
-    intercepted = [{"id": "2", "name": "navigate", "args": {"path": "/x"}}]
-    state = {
-        "messages": [
-            HumanMessage("hi"),
-            AIMessage(content="", id="ai-1"),
-        ],
-        "copilotkit": {
-            "intercepted_tool_calls": intercepted,
-            "original_ai_message_id": "ai-1",
-        },
-    }
-    runtime = MagicMock(name="runtime")
-
-    result = middleware.after_agent(state, runtime)
-
-    assert result is not None
-    restored_ai = next(
-        m for m in result["messages"] if isinstance(m, AIMessage) and m.id == "ai-1"
-    )
-    assert [tc["name"] for tc in restored_ai.tool_calls] == ["navigate"]
-
-    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
-    assert tool_messages == []
-    assert result["copilotkit"]["intercepted_tool_calls"] is None
-    assert result["copilotkit"]["original_ai_message_id"] is None
-    assert result["copilotkit"]["original_tool_calls"] is None
-
-
-def test_after_agent_removes_rehydrated_frontend_tool_result():
-    middleware = CopilotKitMiddleware()
     backend_call = {"id": "1", "name": "backend_search", "args": {"q": "hi"}}
     frontend_call = {"id": "2", "name": "navigate", "args": {"path": "/x"}}
     state = {
         "messages": [
             HumanMessage("hi"),
-            AIMessage(
-                content="",
-                tool_calls=[backend_call, frontend_call],
-                id="ai-1",
-            ),
+            AIMessage(content="", tool_calls=[backend_call], id="ai-1"),
             ToolMessage(content="ok", tool_call_id="1"),
-            ToolMessage(
-                content=json.dumps({"status": "forwarded_to_frontend"}),
-                tool_call_id="2",
-                id="copilotkit-fe-tool-result-2",
-            ),
         ],
         "copilotkit": {
             "intercepted_tool_calls": [frontend_call],

--- a/sdk-python/tests/test_copilotkit_lg_middleware.py
+++ b/sdk-python/tests/test_copilotkit_lg_middleware.py
@@ -11,8 +11,9 @@ and what state updates the middleware emits):
   becomes a ``SystemMessage`` containing ``"App Context:\\n<json>"``. Empty
   context is a no-op. Re-running ``before_agent`` does not duplicate the note.
 * ``after_model`` peels frontend tool calls off the last AIMessage so the
-  ToolNode does not try to execute them; later model calls and ``after_agent``
-  re-attach them with synthetic ToolMessages so model history remains valid.
+  ToolNode does not try to execute them; later model calls re-attach them with
+  synthetic ToolMessages, while ``after_agent`` persists them as orphans for
+  the real frontend result.
 * The ``expose_state`` opt-in surfaces user state into ``request.system_message``
   as a ``"Current agent state:"`` note. Default is off; reserved internal
   keys, underscore-prefixed keys, and empty values are filtered out; an
@@ -803,14 +804,13 @@ def test_after_agent_restores_intercepted_tool_calls_on_original_message():
     assert [tc["name"] for tc in restored_ai.tool_calls] == ["navigate"]
 
     tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
-    assert [m.tool_call_id for m in tool_messages] == ["2"]
-    assert json.loads(tool_messages[0].content) == {"status": "forwarded_to_frontend"}
+    assert tool_messages == []
     assert result["copilotkit"]["intercepted_tool_calls"] is None
     assert result["copilotkit"]["original_ai_message_id"] is None
     assert result["copilotkit"]["original_tool_calls"] is None
 
 
-def test_after_agent_does_not_duplicate_rehydrated_frontend_tool_history():
+def test_after_agent_removes_rehydrated_frontend_tool_result():
     middleware = CopilotKitMiddleware()
     backend_call = {"id": "1", "name": "backend_search", "args": {"q": "hi"}}
     frontend_call = {"id": "2", "name": "navigate", "args": {"path": "/x"}}
@@ -826,6 +826,7 @@ def test_after_agent_does_not_duplicate_rehydrated_frontend_tool_history():
             ToolMessage(
                 content=json.dumps({"status": "forwarded_to_frontend"}),
                 tool_call_id="2",
+                id="copilotkit-fe-tool-result-2",
             ),
         ],
         "copilotkit": {
@@ -845,7 +846,7 @@ def test_after_agent_does_not_duplicate_rehydrated_frontend_tool_history():
     assert [tc["id"] for tc in restored_ai.tool_calls] == ["1", "2"]
 
     tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
-    assert [m.tool_call_id for m in tool_messages] == ["1", "2"]
+    assert [m.tool_call_id for m in tool_messages] == ["1"]
     assert result["copilotkit"]["intercepted_tool_calls"] is None
     assert result["copilotkit"]["original_ai_message_id"] is None
     assert result["copilotkit"]["original_tool_calls"] is None
@@ -874,7 +875,7 @@ def test_bedrock_fix_strips_unanswered_tool_calls_from_ai_message():
     assert [tc["id"] for tc in repaired_ai.tool_calls] == ["answered"]
 
 
-def test_bedrock_fix_dedupes_tool_messages_with_shared_id():
+def test_sync_wrap_dedupes_tool_messages_with_shared_id():
     """Real result wins over an interrupted placeholder for the same id."""
     ai = AIMessage(
         content="",
@@ -888,9 +889,10 @@ def test_bedrock_fix_dedupes_tool_messages_with_shared_id():
     real = ToolMessage(content='{"hits": 3}', tool_call_id="tc-1")
     messages: list[Any] = [HumanMessage("hi"), ai, placeholder, real]
 
-    CopilotKitMiddleware._fix_messages_for_bedrock(messages)
+    request = _make_request(state={"messages": messages}, messages=messages)
+    seen, _ = _run_wrap(CopilotKitMiddleware(), request)
 
-    tool_messages = [m for m in messages if isinstance(m, ToolMessage)]
+    tool_messages = [m for m in seen.messages if isinstance(m, ToolMessage)]
     assert len(tool_messages) == 1
     assert tool_messages[0].content == '{"hits": 3}'
 


### PR DESCRIPTION
## Description

Fixes the LangGraph middleware "lying" to the agent about frontend tool execution (#4759). When a model turn calls a `useFrontendTool` handler, the middleware strips the FE tool calls so the backend `ToolNode` only runs calls it actually made, then rehydrates them afterward. Previously the rehydration could leave the restored AI message and its tool history inconsistent, so providers that require every tool call to have a matching result would break, and the agent saw an incorrect picture of what executed.

## Changes

- `_restore_intercepted_tool_call_history` rebuilds the intercepted FE tool calls with synthetic `ToolMessage` results only for the restored model history (so providers that require every `tool_call` to have a result stay valid), and preserves the original AI message's `name`, `additional_kwargs`, and `response_metadata` on restore.
- Tracks `original_tool_calls` in the CopilotKit private state so the original call set is restored exactly.

## Testing

`uv run pytest tests/test_copilotkit_lg_middleware.py` — 68 passed, including new cases asserting the restored AI message keeps its tool-call ids, name, `additional_kwargs`, and `response_metadata`, and that tool results line up with their calls.

Closes #4759

AI was used for assistance.
