### PR TITLE
fix(showcase): green the d5/d6 dashboard — forwarding, routes, LFS, harness

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -354,7 +354,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          lfs: ${{ matrix.service.lfs }}
+          # Always pull LFS. Nearly every integration ships LFS-tracked demo
+          # assets under public/ (public/demo-files/*.png|*.pdf,
+          # public/demo-audio/*.wav per root .gitattributes). With lfs:false
+          # these check out as 130-byte LFS pointer stubs and get COPYed into
+          # the image as text — the deployed image then serves the pointer
+          # with HTTP 200 and the frontend's magic-bytes guard rejects it,
+          # breaking the multimodal test pill. The per-slot matrix.service.lfs
+          # flag was true only for shell/shell-dashboard/shell-docs, leaving
+          # every framework integration shipping pointer stubs. Uniform
+          # lfs:true is the least-error-prone fix: a new integration that adds
+          # demo assets is covered automatically, with no matrix flag to
+          # forget.
+          lfs: true
           persist-credentials: false
 
       - name: Setup Depot

--- a/showcase/harness/config/probes/d6-all-pills-e2e.yml
+++ b/showcase/harness/config/probes/d6-all-pills-e2e.yml
@@ -66,7 +66,11 @@ discovery:
       - showcase-shell-docs
       - showcase-shell-dojo
       # Harness service for .NET integration testing — not a demo service,
-      # deployed: false in manifest, no aimock wiring yet.
+      # deployed: true in manifest, but NOT probe-wired yet: no aimock fixtures
+      # and it shares the ms-agent-dotnet AsyncLocal bug. Excluded from every
+      # probe AND not rendered on the dashboard (see baseline-types.ts) so an
+      # unprobed service never shows stale red. Remove this exclusion only once
+      # it is fully probe-wired (aimock fixtures + the AsyncLocal fix).
       - showcase-ms-agent-harness-dotnet
       # Decommissioned starters
       - showcase-starter-ag2

--- a/showcase/harness/config/probes/e2e-deep.yml
+++ b/showcase/harness/config/probes/e2e-deep.yml
@@ -119,7 +119,11 @@ discovery:
       - showcase-shell-docs
       - showcase-shell-dojo
       # Harness service for .NET integration testing — not a demo service,
-      # deployed: false in manifest, no aimock wiring yet.
+      # deployed: true in manifest, but NOT probe-wired yet: no aimock fixtures
+      # and it shares the ms-agent-dotnet AsyncLocal bug. Excluded from every
+      # probe AND not rendered on the dashboard (see baseline-types.ts) so an
+      # unprobed service never shows stale red. Remove this exclusion only once
+      # it is fully probe-wired (aimock fixtures + the AsyncLocal fix).
       - showcase-ms-agent-harness-dotnet
       # Decommissioned starters — Railway services stopped (PR #4390)
       - showcase-starter-ag2

--- a/showcase/harness/config/probes/e2e-demos.yml
+++ b/showcase/harness/config/probes/e2e-demos.yml
@@ -119,7 +119,11 @@ discovery:
       - showcase-shell-docs
       - showcase-shell-dojo
       # Harness service for .NET integration testing — not a demo service,
-      # deployed: false in manifest, no aimock wiring yet.
+      # deployed: true in manifest, but NOT probe-wired yet: no aimock fixtures
+      # and it shares the ms-agent-dotnet AsyncLocal bug. Excluded from every
+      # probe AND not rendered on the dashboard (see baseline-types.ts) so an
+      # unprobed service never shows stale red. Remove this exclusion only once
+      # it is fully probe-wired (aimock fixtures + the AsyncLocal fix).
       - showcase-ms-agent-harness-dotnet
       # Decommissioned starters — Railway services stopped (PR #4390)
       - showcase-starter-ag2

--- a/showcase/harness/config/probes/e2e-smoke.yml
+++ b/showcase/harness/config/probes/e2e-smoke.yml
@@ -54,7 +54,11 @@ discovery:
       - showcase-shell-docs
       - showcase-shell-dojo
       # Harness service for .NET integration testing — not a demo service,
-      # deployed: false in manifest, no aimock wiring yet.
+      # deployed: true in manifest, but NOT probe-wired yet: no aimock fixtures
+      # and it shares the ms-agent-dotnet AsyncLocal bug. Excluded from every
+      # probe AND not rendered on the dashboard (see baseline-types.ts) so an
+      # unprobed service never shows stale red. Remove this exclusion only once
+      # it is fully probe-wired (aimock fixtures + the AsyncLocal fix).
       - showcase-ms-agent-harness-dotnet
       # Decommissioned starters — Railway services stopped (PR #4390)
       - showcase-starter-ag2

--- a/showcase/harness/config/probes/smoke.yml
+++ b/showcase/harness/config/probes/smoke.yml
@@ -74,7 +74,11 @@ discovery:
       - "showcase-shell-docs"
       - "showcase-shell-dojo"
       # Harness service for .NET integration testing — not a demo service,
-      # deployed: false in manifest, no aimock wiring yet.
+      # deployed: true in manifest, but NOT probe-wired yet: no aimock fixtures
+      # and it shares the ms-agent-dotnet AsyncLocal bug. Excluded from every
+      # probe AND not rendered on the dashboard (see baseline-types.ts) so an
+      # unprobed service never shows stale red. Remove this exclusion only once
+      # it is fully probe-wired (aimock fixtures + the AsyncLocal fix).
       - "showcase-ms-agent-harness-dotnet"
       # Decommissioned starters — Railway services stopped, deployments
       # halted (PR #4390). Excluded so probes don't scan dead endpoints.

--- a/showcase/harness/src/fleet/control-plane/catalog-enumerator.test.ts
+++ b/showcase/harness/src/fleet/control-plane/catalog-enumerator.test.ts
@@ -8,6 +8,8 @@ import {
   D6_DRIVER_KIND,
   D6_DISCOVERY_FILTER,
   E2E_DEMOS_TIMEOUT_MS,
+  D6_E2E_TIMEOUT_MS,
+  D5_E2E_TIMEOUT_MS,
 } from "./catalog-enumerator.js";
 import {
   E2E_SMOKE_DRIVER_KIND,
@@ -195,9 +197,49 @@ describe("createD6ServiceEnumerator", () => {
     // No redundant `publicUrl` key — backendUrl carries the value.
     expect(lg!.driverInputs).not.toHaveProperty("publicUrl");
     expect(lg!.driverInputs?.backendUrl).toBe("http://langgraph-python:10000");
-    // EQUIVALENCE: d6 conveys NO `timeout_ms` (only the demos family does) — the
-    // generic-seam `extraDriverInputs` change must not alter d6's emitted shape.
-    expect(lg!.driverInputs).not.toHaveProperty("timeout_ms");
+    // d6 conveys its YAML outer-cap in `timeout_ms` (so the fleet worker honors
+    // the d6-all-pills-e2e.yml budget); the conveyed cap parses through the
+    // driver's own schema (the worker's gate).
+    expect(lg!.driverInputs?.timeout_ms).toBe(D6_E2E_TIMEOUT_MS);
+  });
+
+  it("conveys the d6 YAML outer-cap in driverInputs.timeout_ms (default = d6-all-pills-e2e.yml value)", async () => {
+    // R-TIMEOUT (Fix B): the d6 enumerator conveys the 20-min outer cap per-job
+    // so the fleet worker's pooled d6 driver reads it from the payload — the
+    // worker never runs the in-process probe-invoker that applies cfg.timeout_ms.
+    // Without it the driver falls back to DEFAULT_TIMEOUT_MS (10 min) and a slow
+    // backend false-aborts.
+    const source = fakeSource([
+      svc({ name: "showcase-langgraph-python" }),
+      svc({ name: "showcase-crewai", publicUrl: "http://crewai:10000" }),
+    ]);
+    const enumerate = createD6ServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+    });
+    const specs = await enumerate(CTX);
+    expect(D6_E2E_TIMEOUT_MS).toBe(1_200_000);
+    for (const s of specs) {
+      expect(s.driverInputs?.timeout_ms).toBe(D6_E2E_TIMEOUT_MS);
+      // The conveyed cap survives the driver's own schema (the worker's gate).
+      const parsed = e2eFullDriver.inputSchema.safeParse(s.driverInputs);
+      expect(parsed.success).toBe(true);
+    }
+  });
+
+  it("honors an explicit timeoutMs override on the conveyed d6 timeout_ms", async () => {
+    const source = fakeSource([svc({ name: "showcase-langgraph-python" })]);
+    const enumerate = createD6ServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+      timeoutMs: 777_000,
+    });
+    const specs = await enumerate(CTX);
+    expect(specs[0]?.driverInputs?.timeout_ms).toBe(777_000);
   });
 
   it("produces a NON-EMPTY spec set for the real-shaped service catalog", async () => {
@@ -427,13 +469,50 @@ describe("createE2eDeepServiceEnumerator", () => {
     // D5-take-one scoping inputs conveyed onto every spec.
     expect(lg?.driverInputs?.representativeOnly).toBe(true);
     expect(lg?.driverInputs?.rowPrefix).toBe("d5");
-    expect(lg?.driverInputs).not.toHaveProperty("timeout_ms");
+    // D5 also conveys its YAML outer-cap (e2e-deep.yml, 10 min) so the fleet
+    // worker's shared d6 driver honors the budget.
+    expect(lg?.driverInputs?.timeout_ms).toBe(D5_E2E_TIMEOUT_MS);
 
     const cr = specs.find((s) => s.serviceSlug === "crewai");
     expect(cr?.probeKey).toBe("d5-single-pill-e2e:crewai");
     expect(cr?.driverKind).toBe(D6_DRIVER_KIND);
     expect(cr?.driverInputs?.representativeOnly).toBe(true);
     expect(cr?.driverInputs?.rowPrefix).toBe("d5");
+  });
+
+  it("conveys the d5 YAML outer-cap in driverInputs.timeout_ms (default = e2e-deep.yml value)", async () => {
+    // R-TIMEOUT (Fix B): D5 runs the shared d6 driver scoped take-one, so it
+    // conveys its own (10-min) YAML cap per-job alongside the scoping inputs.
+    const source = fakeSource([
+      svc({ name: "showcase-langgraph-python" }),
+      svc({ name: "showcase-crewai", publicUrl: "http://crewai:10000" }),
+    ]);
+    const enumerate = createE2eDeepServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+    });
+    const specs = await enumerate(CTX);
+    expect(D5_E2E_TIMEOUT_MS).toBe(600_000);
+    for (const s of specs) {
+      expect(s.driverInputs?.timeout_ms).toBe(D5_E2E_TIMEOUT_MS);
+      const parsed = e2eFullDriver.inputSchema.safeParse(s.driverInputs);
+      expect(parsed.success).toBe(true);
+    }
+  });
+
+  it("honors an explicit timeoutMs override on the conveyed d5 timeout_ms", async () => {
+    const source = fakeSource([svc({ name: "showcase-langgraph-python" })]);
+    const enumerate = createE2eDeepServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+      timeoutMs: 333_000,
+    });
+    const specs = await enumerate(CTX);
+    expect(specs[0]?.driverInputs?.timeout_ms).toBe(333_000);
   });
 
   it("passes the shared d6 discovery filter to the source", async () => {

--- a/showcase/harness/src/fleet/control-plane/catalog-enumerator.ts
+++ b/showcase/harness/src/fleet/control-plane/catalog-enumerator.ts
@@ -72,6 +72,33 @@ export const D6_DRIVER_KIND = "e2e_d6";
 export const E2E_DEMOS_TIMEOUT_MS = 1_200_000;
 
 /**
+ * The d6 (`d6-all-pills-e2e`) full-matrix outer-cap timeout (ms) — the SINGLE
+ * SOURCE OF TRUTH mirroring `config/probes/d6-all-pills-e2e.yml`'s `timeout_ms`
+ * (20 min). Like the demos family, the d6 enumerator CONVEYS this cap per-job in
+ * `driverInputs.timeout_ms` so the fleet WORKER's pooled d6 driver honors the
+ * YAML budget. The legacy in-process path threads the YAML `timeout_ms` into the
+ * driver via `probe-invoker`'s `cfg.timeout_ms` guard; the fleet worker never
+ * runs that boot path, so without this conveyance the d6 driver silently falls
+ * back to its hardcoded `DEFAULT_TIMEOUT_MS` (10 min) and a slow backend
+ * false-aborts at 10 min instead of the YAML's 20. Keep this in lockstep with
+ * the YAML until the in-process and fleet run paths converge on one config.
+ */
+export const D6_E2E_TIMEOUT_MS = 1_200_000;
+
+/**
+ * The d5 (`e2e-deep` / `d5-single-pill-e2e`) take-one outer-cap timeout (ms) —
+ * the SINGLE SOURCE OF TRUTH mirroring `config/probes/e2e-deep.yml`'s
+ * `timeout_ms` (10 min). D5 runs the SAME d6 driver scoped to one representative
+ * pill per feature, so it conveys its own (smaller) YAML cap per-job in
+ * `driverInputs.timeout_ms`. Without it the d5 specs run under the d6 driver's
+ * hardcoded `DEFAULT_TIMEOUT_MS` (10 min) — which happens to coincide today, but
+ * pinning the conveyance to the YAML keeps the two run paths honest and prevents
+ * silent drift if either YAML budget changes. Keep this in lockstep with the
+ * YAML until the in-process and fleet run paths converge on one config.
+ */
+export const D5_E2E_TIMEOUT_MS = 600_000;
+
+/**
  * The d6 service-set filter — the SINGLE SOURCE OF TRUTH mirroring
  * `config/probes/d6-all-pills-e2e.yml`'s `discovery.filter`. Selects the
  * `showcase-*` demo services and excludes infra/shell services and the
@@ -88,7 +115,12 @@ export const D6_DISCOVERY_FILTER = {
     "showcase-shell-dashboard",
     "showcase-shell-docs",
     "showcase-shell-dojo",
-    // Harness service for .NET integration testing — not a demo service.
+    // Harness service for .NET integration testing — deployed: true in its
+    // manifest but NOT probe-wired yet (no aimock fixtures; shares the
+    // ms-agent-dotnet AsyncLocal bug). Excluded from every probe AND not
+    // rendered on the dashboard (see shell-dashboard baseline-types.ts) so an
+    // unprobed service never shows stale red. Re-include only once it is fully
+    // probe-wired.
     "showcase-ms-agent-harness-dotnet",
     // Decommissioned starters.
     "showcase-starter-ag2",
@@ -134,6 +166,15 @@ export interface D6ServiceEnumeratorDeps {
    * (or a future operator config) can narrow the set without editing the SSOT.
    */
   filter?: ServiceSetFilter;
+  /**
+   * The driver-invocation outer-cap timeout (ms), conveyed per-job in
+   * `driverInputs.timeout_ms` so the fleet worker's pooled d6 driver reads the
+   * YAML budget from the payload (the worker never runs the legacy in-process
+   * `probe-invoker` boot path that applies `cfg.timeout_ms`). Each family
+   * defaults to its own YAML value (`D6_E2E_TIMEOUT_MS` for d6,
+   * `D5_E2E_TIMEOUT_MS` for d5). Exposed so a test can override.
+   */
+  timeoutMs?: number;
 }
 
 /**
@@ -340,6 +381,7 @@ export function createD6ServiceEnumerator(
 ): ServiceEnumerator {
   const { source, env, fetchImpl, logger } = deps;
   const filter = deps.filter ?? D6_DISCOVERY_FILTER;
+  const timeoutMs = deps.timeoutMs ?? D6_E2E_TIMEOUT_MS;
 
   return createServiceEnumerator({
     source,
@@ -349,6 +391,9 @@ export function createD6ServiceEnumerator(
     driverKind: D6_DRIVER_KIND,
     probeKeyPrefix: "d6",
     filter,
+    // Convey the YAML outer-cap so the fleet worker's d6 driver honors the
+    // `d6-all-pills-e2e.yml` budget instead of its hardcoded DEFAULT_TIMEOUT_MS.
+    extraDriverInputs: { timeout_ms: timeoutMs },
   });
 }
 
@@ -403,6 +448,7 @@ export function createE2eDeepServiceEnumerator(
 ): ServiceEnumerator {
   const { source, env, fetchImpl, logger } = deps;
   const filter = deps.filter ?? D6_DISCOVERY_FILTER;
+  const timeoutMs = deps.timeoutMs ?? D5_E2E_TIMEOUT_MS;
 
   return createServiceEnumerator({
     source,
@@ -412,7 +458,14 @@ export function createE2eDeepServiceEnumerator(
     driverKind: D6_DRIVER_KIND,
     probeKeyPrefix: "d5-single-pill-e2e",
     filter,
-    extraDriverInputs: { representativeOnly: true, rowPrefix: "d5" },
+    // Convey the YAML outer-cap alongside the D5-take-one scoping so the fleet
+    // worker's d6 driver honors the `e2e-deep.yml` budget rather than its
+    // hardcoded DEFAULT_TIMEOUT_MS.
+    extraDriverInputs: {
+      representativeOnly: true,
+      rowPrefix: "d5",
+      timeout_ms: timeoutMs,
+    },
   });
 }
 

--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -39,6 +39,12 @@ import type {
 interface PageScript {
   throwOnGoto?: Error;
   stallEvaluate?: boolean;
+  /**
+   * When true, `goto` never resolves — used to exercise the driver's
+   * outer-cap timeout (the abort fires while the page is hung) so a test can
+   * assert WHICH timeout value the driver resolved.
+   */
+  stallGoto?: boolean;
 }
 
 function makePage(script: PageScript = {}): E2eFullPage {
@@ -46,6 +52,10 @@ function makePage(script: PageScript = {}): E2eFullPage {
   return {
     async goto() {
       if (script.throwOnGoto) throw script.throwOnGoto;
+      if (script.stallGoto) {
+        // Hang until the run's outer-cap abort tears the page down.
+        await new Promise<void>(() => {});
+      }
     },
     async waitForSelector() {},
     async fill() {},
@@ -1096,5 +1106,80 @@ describe("e2e-full per-feature retry signal isolation", () => {
       const d6Rows = sideEmits.filter((r) => r.key.startsWith("d6:"));
       expect(d6Rows).toEqual([]);
     });
+  });
+
+  // Fix B: the fleet enumerator conveys the YAML outer-cap in
+  // `input.timeout_ms`; the driver must HONOR it over the dep/default. Without
+  // the per-run read the driver falls back to DEFAULT_TIMEOUT_MS (10 min) and a
+  // slow backend false-aborts at 10 min instead of the YAML budget.
+  describe("input.timeout_ms is honored over the construction dep/default", () => {
+    it("aborts at the conveyed input.timeout_ms (queued feature errorDesc names the conveyed value, not the 600000 default)", async () => {
+      // Saturate the semaphore: more features than FEATURE_CONCURRENCY_D6 so at
+      // least one feature is still QUEUED when the outer cap fires. The running
+      // features have a slow goto; the tiny outer `timeout_ms` aborts mid-goto.
+      // When the queued feature then acquires its slot it hits the pre-feature
+      // abort check, which emits `timeout after <resolved-cap>ms` — the exact
+      // value the driver resolved. With the bug (dep/default used) that text
+      // would read 600000ms; with the fix it reads the conveyed 5ms.
+      const featureTypes = [
+        "agentic-chat",
+        "tool-rendering",
+        "shared-state-read",
+        "shared-state-write",
+        "hitl-text-input",
+      ] as const;
+      expect(featureTypes.length).toBeGreaterThan(FEATURE_CONCURRENCY_D6);
+      for (const ft of featureTypes) {
+        registerD5Script(makeScript([ft]));
+      }
+
+      const sideEmits: ProbeResult<unknown>[] = [];
+      const writer: ProbeResultWriter = {
+        write: async (r) => {
+          sideEmits.push(r);
+        },
+      };
+
+      const { launcher } = makeSlowTeardownLauncherFull({
+        gotoDelayMs: 200,
+        closeDelayMs: 5,
+      });
+      const driver = createE2eFullDriver({
+        launcher,
+        scriptLoader: noopScriptLoader(),
+        // Construction-time dep is the 10-min default; the conveyed input cap
+        // must win.
+        timeoutMs: 600_000,
+        // Large enough that the OUTER cap (not the per-feature timer) drives the
+        // abort.
+        featureTimeoutMs: 60_000,
+      });
+      const result = await driver.run(makeCtx({ writer }), {
+        key: "d6-all-pills-e2e:showcase-test-slug",
+        backendUrl: "https://test.example.com",
+        features: [...featureTypes],
+        // The fleet enumerator's conveyed cap — tiny so the test resolves fast.
+        timeout_ms: 5,
+      });
+
+      expect(result.state).toBe("red");
+      // Some feature side-row reports the OUTER-cap timeout with the conveyed
+      // value (the queued feature that hit the pre-feature abort check).
+      const timeoutRows = sideEmits.filter((r) => {
+        const sig = r.signal as E2eFullFeatureSignal;
+        return (
+          typeof sig?.errorDesc === "string" &&
+          sig.errorDesc.startsWith("timeout after ")
+        );
+      });
+      expect(timeoutRows.length).toBeGreaterThan(0);
+      for (const r of timeoutRows) {
+        const sig = r.signal as E2eFullFeatureSignal;
+        // PROOF the driver read input.timeout_ms (5), NOT the dep/default
+        // (600000).
+        expect(sig.errorDesc).toBe("timeout after 5ms");
+        expect(sig.errorDesc).not.toContain("600000");
+      }
+    }, 20_000);
   });
 });

--- a/showcase/harness/src/probes/drivers/d6-all-pills.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.ts
@@ -108,6 +108,16 @@ const inputSchema = z
      * driver greens.
      */
     rowPrefix: z.enum(["d5", "d6"]).optional(),
+    /**
+     * Driver-invocation outer-cap (ms) conveyed by the fleet enumerator so the
+     * worker's pooled d6 driver honors the YAML `timeout_ms`
+     * (`d6-all-pills-e2e.yml` 20 min / `e2e-deep.yml` 10 min). The fleet worker
+     * never runs the legacy in-process `probe-invoker` boot path that applies
+     * `cfg.timeout_ms`, so without this the driver falls back to its hardcoded
+     * `DEFAULT_TIMEOUT_MS` (10 min) and a slow backend false-aborts. See the
+     * timeout-resolution block in `e2eFullDriver.run`.
+     */
+    timeout_ms: z.number().int().positive().optional(),
   })
   .passthrough()
   .refine((v) => !!(v.backendUrl ?? v.publicUrl), {
@@ -566,7 +576,11 @@ export function createE2eFullDriver(
   deps: E2eFullDriverDeps = {},
 ): ProbeDriver<E2eFullDriverInput, E2eFullAggregateSignal> {
   const launcher = deps.launcher ?? defaultLauncher;
-  const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  // Construction-time fallback cap. The EFFECTIVE per-run cap is resolved inside
+  // `run()` so the fleet enumerator's conveyed `input.timeout_ms` (the YAML
+  // budget) wins over this singleton-registration default. See the resolution
+  // block in `run()`.
+  const depTimeoutMs = deps.timeoutMs;
   const pageTimeoutMs = deps.pageTimeoutMs ?? DEFAULT_PAGE_TIMEOUT_MS;
   const featureTimeoutMs = deps.featureTimeoutMs ?? DEFAULT_FEATURE_TIMEOUT_MS;
   const scriptLoader = deps.scriptLoader ?? defaultScriptLoader;
@@ -583,6 +597,22 @@ export function createE2eFullDriver(
       const observedAt = ctx.now().toISOString();
       const backendUrl = (input.backendUrl ?? input.publicUrl)!;
       const slug = deriveSlug(input.key, input.name);
+
+      // Resolve the outer-cap per `run()`. Fleet path: the enumerator conveys
+      // the YAML cap in `input.timeout_ms` (the worker never runs the in-process
+      // `probe-invoker` boot path that applies `cfg.timeout_ms`). Validated by
+      // the schema (positive int), but guard defensively here too so a bad value
+      // falls through to the dep/default rather than silently disabling the cap.
+      // Resolution order: input cap → construction dep → hardcoded default.
+      const inputTimeoutMs =
+        typeof input.timeout_ms === "number" &&
+        Number.isFinite(input.timeout_ms) &&
+        input.timeout_ms > 0
+          ? input.timeout_ms
+          : NaN;
+      const timeoutMs = Number.isFinite(inputTimeoutMs)
+        ? inputTimeoutMs
+        : (depTimeoutMs ?? DEFAULT_TIMEOUT_MS);
 
       // Dashboard row-key prefix. Defaults to "d6"; the D5 probe passes
       // "d5" so its dashboard column reads the same run conditions.

--- a/showcase/integrations/agno/src/agent_server.py
+++ b/showcase/integrations/agno/src/agent_server.py
@@ -25,10 +25,19 @@ from typing import Any, AsyncIterator, List, Optional, Set, Union
 # import time, so the patch must be in place before those imports run.
 from agents._header_forwarding import (
     HeaderForwardingHTTPMiddleware,
+    install_executor_contextvar_propagation,
     install_global_httpx_hook,
 )
 
 install_global_httpx_hook()
+# Agno dispatches SYNC tools (e.g. the declarative gen-ui `generate_a2ui`
+# tool, which makes a secondary OpenAI call) onto the default
+# ThreadPoolExecutor via loop.run_in_executor(...), which does NOT
+# propagate ContextVars to the worker thread. Without this, the
+# forwarded-header ContextVar set on the inbound request task is empty by
+# the time the secondary call's outbound httpx hook fires, and aimock
+# can't match the right fixture for the request.
+install_executor_contextvar_propagation()
 
 import dotenv
 from ag_ui.core import (

--- a/showcase/integrations/agno/src/agents/_header_forwarding.py
+++ b/showcase/integrations/agno/src/agents/_header_forwarding.py
@@ -369,3 +369,60 @@ def install_global_httpx_hook() -> None:
     httpx.Client.__init__ = _patched_sync_init
     httpx.AsyncClient.__init__ = _patched_async_init
     _GLOBAL_HTTPX_PATCHED = True
+
+
+# Module-scope sentinel preventing repeated executor patching.
+_EXECUTOR_CTXVAR_PATCHED = False
+
+
+def install_executor_contextvar_propagation() -> None:
+    """Patch ``asyncio.events.AbstractEventLoop.run_in_executor`` so the
+    parent task's ContextVars are propagated into the executor thread.
+
+    Why this exists
+    ---------------
+    Frameworks that dispatch a SYNC callable (e.g. agno running a sync
+    tool, or a hand-rolled secondary LLM call) onto the default thread
+    pool via ``loop.run_in_executor(None, functools.partial(...))`` lose
+    the caller's context: the stock ``run_in_executor`` does NOT copy the
+    caller's :pep:`567` context to the worker thread — so the
+    :class:`HeaderForwardingHTTPMiddleware` ContextVar (set on the inbound
+    request task) is empty inside the executor, and our outbound httpx
+    hook sees no headers to forward.
+
+    ``asyncio.to_thread`` (Python 3.9+) does copy context the right way;
+    this patch makes plain ``run_in_executor`` behave the same. It only
+    affects functions submitted via ``run_in_executor`` — coroutines and
+    other constructs are unaffected.
+
+    Safe to call at import time. Idempotent via a module-scope sentinel.
+    Pre-existing event-loop instances inherit the patch because
+    ``run_in_executor`` is defined on ``BaseEventLoop`` and looked up
+    per-call via normal method resolution.
+    """
+    global _EXECUTOR_CTXVAR_PATCHED
+    if _EXECUTOR_CTXVAR_PATCHED:
+        return
+
+    import asyncio.base_events as _base_events
+
+    _orig_run_in_executor = _base_events.BaseEventLoop.run_in_executor
+
+    def _patched_run_in_executor(self, executor, func, *args):
+        # Capture the CURRENT task's context at submit time, then run the
+        # submitted callable inside that context on the worker thread.
+        ctx = contextvars.copy_context()
+
+        def _ctx_wrapper(*a, **kw):
+            return ctx.run(func, *a, **kw)
+
+        # Preserve __name__/__qualname__ for nicer tracebacks where possible.
+        try:
+            _ctx_wrapper.__wrapped__ = func  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover
+            pass
+
+        return _orig_run_in_executor(self, executor, _ctx_wrapper, *args)
+
+    _base_events.BaseEventLoop.run_in_executor = _patched_run_in_executor
+    _EXECUTOR_CTXVAR_PATCHED = True

--- a/showcase/integrations/agno/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -1,0 +1,66 @@
+// Dedicated runtime for the Beautiful Chat flagship showcase cell (Agno).
+//
+// Beautiful Chat exercises A2UI (dynamic + fixed schema) and Open
+// Generative UI. The canonical langgraph-python reference ships MCP Apps
+// on the same runtime as well; the Agno port routes the cell at the shared
+// `main` Agno agent (`/agui`) since there is no dedicated beautiful-chat
+// backend endpoint — the flagship behavior comes from the runtime flags
+// below plus the frontend's per-cell registrations.
+//
+// Isolated on its own endpoint (mirroring beautiful-chat in the canonical)
+// because the `openGenerativeUI` / `a2ui` runtime flags set global state on
+// the probe response that would otherwise leak into the other cells sharing
+// the default `/api/copilotkit` runtime.
+//
+// Mirrors showcase/integrations/pydantic-ai/src/app/api/copilotkit-beautiful-chat/route.ts.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+// The beautiful-chat page resolves <CopilotKit agent="beautiful-chat">
+// here; internal components (headless-chat, example-canvas) also call
+// `useAgent()` with no args, which defaults to agentId "default". Alias
+// default to the same backend so those hooks resolve.
+const agents: Record<string, AbstractAgent> = {
+  "beautiful-chat": new HttpAgent({ url: `${AGENT_URL}/agui` }),
+  default: new HttpAgent({ url: `${AGENT_URL}/agui` }),
+};
+
+const runtime = new CopilotRuntime({
+  // @ts-ignore -- see main route.ts
+  agents,
+  openGenerativeUI: true,
+  a2ui: {
+    // The targeted `main` Agno agent (`/agui`) already registers the
+    // `generate_a2ui` tool itself (src/agents/main.py), so the runtime must
+    // NOT inject a second copy — that would double-bind the render tool.
+    // Matches pydantic-ai's beautiful-chat (this file's mirror source) and
+    // the other Agno a2ui routes, all of which set this false.
+    injectA2UITool: false,
+  },
+});
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-beautiful-chat",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime,
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    console.error(`[copilotkit-beautiful-chat/route] ERROR: ${e.message}`, e.stack);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/integrations/agno/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -57,7 +57,10 @@ export const POST = async (req: NextRequest) => {
     return await handleRequest(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
-    console.error(`[copilotkit-beautiful-chat/route] ERROR: ${e.message}`, e.stack);
+    console.error(
+      `[copilotkit-beautiful-chat/route] ERROR: ${e.message}`,
+      e.stack,
+    );
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 },

--- a/showcase/integrations/agno/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -1,0 +1,60 @@
+// Dedicated runtime for the declarative-hashbrown demo (Agno).
+//
+// The demo folder + route + agent slug were renamed from `byoc-hashbrown`
+// to the canonical `declarative-hashbrown` surface; the underlying Agno
+// agent still mounts at `/byoc-hashbrown/agui` (see src/agent_server.py).
+// The demo page mounts <CopilotKit agent="declarative-hashbrown-demo">.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+console.log(`[copilotkit-declarative-hashbrown/route] AGENT_URL: ${AGENT_URL}`);
+
+function createDeclarativeHashbrownAgent() {
+  return new HttpAgent({
+    url: `${AGENT_URL}/byoc-hashbrown/agui`,
+  });
+}
+
+// Register both the named agent and a default fallback so the runtime
+// can always resolve regardless of which agent name the frontend sends.
+const agents: Record<string, AbstractAgent> = {
+  "declarative-hashbrown-demo": createDeclarativeHashbrownAgent(),
+  default: createDeclarativeHashbrownAgent(),
+};
+
+export const POST = async (req: NextRequest) => {
+  const url = req.url;
+  console.log(`[copilotkit-declarative-hashbrown/route] POST ${url}`);
+
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-declarative-hashbrown",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime: new CopilotRuntime({
+        // @ts-ignore -- see main route.ts
+        agents,
+      }),
+    });
+    const response = await handleRequest(req);
+    console.log(
+      `[copilotkit-declarative-hashbrown/route] Response status: ${response.status}`,
+    );
+    return response;
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    console.error(`[copilotkit-declarative-hashbrown/route] ERROR: ${e.message}`);
+    console.error(`[copilotkit-declarative-hashbrown/route] Stack: ${e.stack}`);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/integrations/agno/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -50,7 +50,9 @@ export const POST = async (req: NextRequest) => {
     return response;
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
-    console.error(`[copilotkit-declarative-hashbrown/route] ERROR: ${e.message}`);
+    console.error(
+      `[copilotkit-declarative-hashbrown/route] ERROR: ${e.message}`,
+    );
     console.error(`[copilotkit-declarative-hashbrown/route] Stack: ${e.stack}`);
     return NextResponse.json(
       { error: "Internal Server Error" },

--- a/showcase/integrations/agno/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -43,7 +43,10 @@ export const POST = async (req: NextRequest) => {
     return await handleRequest(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
-    console.error(`[copilotkit-declarative-json-render/route] ERROR: ${e.message}`, e.stack);
+    console.error(
+      `[copilotkit-declarative-json-render/route] ERROR: ${e.message}`,
+      e.stack,
+    );
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 },

--- a/showcase/integrations/agno/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -1,0 +1,52 @@
+// Dedicated runtime for the declarative-json-render demo (Agno).
+//
+// The demo page renders the agent's JSON output into a frontend-owned
+// component catalog via @json-render/react. The underlying Agno agent mounts
+// at `/byoc-json-render/agui` (see src/agent_server.py). The demo folder +
+// route surface were renamed from `byoc-json-render` to the canonical
+// `declarative-json-render`; the agent ID retains its legacy
+// `byoc_json_render` name.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+const byocJsonRenderAgent = new HttpAgent({
+  url: `${AGENT_URL}/byoc-json-render/agui`,
+});
+
+// Register both the named agent and a `default` fallback so the runtime can
+// resolve regardless of whether the frontend sends an explicit agentId.
+const agents: Record<string, AbstractAgent> = {
+  byoc_json_render: byocJsonRenderAgent,
+  default: byocJsonRenderAgent,
+};
+
+const runtime = new CopilotRuntime({
+  // @ts-ignore -- see main route.ts
+  agents,
+});
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-declarative-json-render",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime,
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    console.error(`[copilotkit-declarative-json-render/route] ERROR: ${e.message}`, e.stack);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/integrations/agno/tests/conftest.py
+++ b/showcase/integrations/agno/tests/conftest.py
@@ -1,0 +1,38 @@
+"""Shared test fixtures for the agno integration test suite.
+
+The executor-ctxvar tests assert order-independent behavior, but
+``install_executor_contextvar_propagation()`` PERMANENTLY monkeypatches
+``asyncio.base_events.BaseEventLoop.run_in_executor`` and flips the
+module-scope ``_EXECUTOR_CTXVAR_PATCHED`` sentinel. Once the GREEN test
+installs the patch, the patched executor (and the True sentinel) leak into
+any subsequent test — so the RED test, which only resets the sentinel to
+False, still runs on the *patched* loop and sees the propagated context
+(observed: ``test_e2e_503_without_fix`` returned 200 instead of 503 when it
+ran after ``test_e2e_200_with_fix``).
+
+This autouse fixture snapshots BOTH the original ``run_in_executor`` method
+and the sentinel before every test and restores them afterward, guaranteeing
+each test starts on the stock executor regardless of execution order.
+"""
+
+import asyncio.base_events as _base_events
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agents import _header_forwarding as hf  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _restore_executor_ctxvar_patch():
+    """Snapshot/restore the executor patch + sentinel around every test."""
+    orig_run_in_executor = _base_events.BaseEventLoop.run_in_executor
+    orig_sentinel = hf._EXECUTOR_CTXVAR_PATCHED
+    try:
+        yield
+    finally:
+        _base_events.BaseEventLoop.run_in_executor = orig_run_in_executor
+        hf._EXECUTOR_CTXVAR_PATCHED = orig_sentinel

--- a/showcase/integrations/agno/tests/test_executor_ctxvar.py
+++ b/showcase/integrations/agno/tests/test_executor_ctxvar.py
@@ -1,0 +1,57 @@
+"""Red-green proof for executor ContextVar propagation.
+
+The gen-ui declarative pill registers a SYNC tool (`generate_a2ui`) on the
+agno Agent. Agno dispatches sync tools onto the default thread-pool via
+``loop.run_in_executor``. Stock ``run_in_executor`` does NOT copy the
+caller's :pep:`567` context to the worker thread, so the
+``_forwarded_headers`` ContextVar set by ``HeaderForwardingHTTPMiddleware``
+on the inbound request task is EMPTY inside the executor. The secondary
+OpenAI call's httpx hook then reads no headers → aimock strict-mode 503.
+
+This test exercises that exact mechanism directly:
+
+* WITHOUT ``install_executor_contextvar_propagation()`` the worker thread
+  sees an empty header set (the bug).
+* WITH it, the worker thread sees the forwarded ``x-aimock-context``
+  header (the fix).
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agents import _header_forwarding as hf  # noqa: E402
+
+
+async def _run_sync_tool_in_executor():
+    """Mimic agno: set the request-scope ContextVar, then dispatch a sync
+    callable onto the default executor and report what it observed."""
+    hf.set_forwarded_headers({"x-aimock-context": "dashboard-red-fixture"})
+
+    def _sync_tool():
+        # This is what the secondary openai.OpenAI() httpx hook reads.
+        return hf.get_forwarded_headers()
+
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, _sync_tool)
+
+
+def test_executor_drops_contextvar_without_fix():
+    """RED: without the patch, the worker thread sees no forwarded headers."""
+    # Ensure no patch is active for this test.
+    hf._EXECUTOR_CTXVAR_PATCHED = False
+    seen = asyncio.run(_run_sync_tool_in_executor())
+    assert seen == {}, (
+        f"expected empty headers in executor thread without fix, got {seen!r}"
+    )
+
+
+def test_executor_propagates_contextvar_with_fix():
+    """GREEN: with the patch, the worker thread sees the forwarded header."""
+    hf.install_executor_contextvar_propagation()
+    seen = asyncio.run(_run_sync_tool_in_executor())
+    assert seen.get("x-aimock-context") == "dashboard-red-fixture", (
+        f"expected forwarded x-aimock-context in executor thread, got {seen!r}"
+    )

--- a/showcase/integrations/agno/tests/test_executor_ctxvar_e2e.py
+++ b/showcase/integrations/agno/tests/test_executor_ctxvar_e2e.py
@@ -1,0 +1,108 @@
+"""End-to-end red-green proof through the REAL httpx event hook + a
+strict-mode mock server, mirroring the secondary gen-ui LLM call path.
+
+This goes beyond the unit test by exercising the actual outbound request
+path agno's `generate_a2ui` tool takes:
+
+1. ``HeaderForwardingHTTPMiddleware`` records ``x-aimock-context`` on the
+   request-scope ContextVar.
+2. A SYNC callable (the tool) is dispatched via ``loop.run_in_executor``.
+3. Inside the executor, an httpx client whose request hook was installed
+   by ``install_httpx_hook`` makes an outbound call.
+4. A strict-mode server returns 503 when ``x-aimock-context`` is absent
+   (the bug) and 200 when present (the fix) — exactly aimock strict mode.
+
+Without ``install_executor_contextvar_propagation()`` the ContextVar is
+empty in the executor thread → hook forwards nothing → 503.
+With it → hook forwards ``x-aimock-context`` → 200.
+"""
+
+import asyncio
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from agents import _header_forwarding as hf  # noqa: E402
+
+AIMOCK_HEADER = "x-aimock-context"
+
+
+class _StrictHandler(BaseHTTPRequestHandler):
+    """Mimic aimock strict mode: 503 unless x-aimock-context present."""
+
+    def do_POST(self):  # noqa: N802
+        # Drain the request body so the client sees a clean response
+        # instead of a connection reset.
+        length = int(self.headers.get("content-length", 0) or 0)
+        if length:
+            self.rfile.read(length)
+        ctx = self.headers.get(AIMOCK_HEADER)
+        if ctx:
+            body = b'{"ok":true}'
+            self.send_response(200)
+        else:
+            body = b'{"error":"ctx empty"}'
+            self.send_response(503)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args):  # silence
+        pass
+
+
+def _start_server():
+    srv = HTTPServer(("127.0.0.1", 0), _StrictHandler)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    return srv
+
+
+async def _drive(url: str) -> int:
+    """Set ctx ContextVar, then make the outbound call from inside an
+    executor thread using a hooked httpx client (the gen-ui tool path)."""
+    hf.set_forwarded_headers({AIMOCK_HEADER: "dashboard-red-fixture"})
+
+    def _sync_outbound_call():
+        # Mirrors the secondary openai.OpenAI() client whose httpx client
+        # carries the install_httpx_hook request hook.
+        client = httpx.Client()
+        hf.install_httpx_hook(client)
+        resp = client.post(url, json={"model": "gpt-4.1"})
+        client.close()
+        return resp.status_code
+
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, _sync_outbound_call)
+
+
+def test_e2e_503_without_fix():
+    """RED: ctx dropped in executor → outbound call hits strict server with
+    no x-aimock-context → 503."""
+    hf._EXECUTOR_CTXVAR_PATCHED = False
+    srv = _start_server()
+    try:
+        url = f"http://127.0.0.1:{srv.server_address[1]}/v1/chat/completions"
+        status = asyncio.run(_drive(url))
+        assert status == 503, f"expected 503 without fix, got {status}"
+    finally:
+        srv.shutdown()
+
+
+def test_e2e_200_with_fix():
+    """GREEN: with executor ctxvar propagation, the hook forwards
+    x-aimock-context → strict server returns 200."""
+    hf.install_executor_contextvar_propagation()
+    srv = _start_server()
+    try:
+        url = f"http://127.0.0.1:{srv.server_address[1]}/v1/chat/completions"
+        status = asyncio.run(_drive(url))
+        assert status == 200, f"expected 200 with fix, got {status}"
+    finally:
+        srv.shutdown()

--- a/showcase/integrations/langroid/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -56,7 +56,10 @@ export const POST = async (req: NextRequest) => {
     return await handleRequest(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
-    console.error(`[copilotkit-beautiful-chat/route] ERROR: ${e.message}`, e.stack);
+    console.error(
+      `[copilotkit-beautiful-chat/route] ERROR: ${e.message}`,
+      e.stack,
+    );
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 },

--- a/showcase/integrations/langroid/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -1,0 +1,65 @@
+// Dedicated runtime for the Beautiful Chat flagship showcase cell (Langroid).
+//
+// Beautiful Chat exercises A2UI (dynamic + fixed schema) and Open
+// Generative UI. The Langroid backend exposes a single unified agent on
+// "/" that handles every request, so the cell routes there; the flagship
+// behavior comes from the runtime flags below plus the frontend's per-cell
+// registrations.
+//
+// Isolated on its own endpoint (mirroring beautiful-chat in the canonical)
+// because the `openGenerativeUI` / `a2ui` runtime flags set global state on
+// the probe response that would otherwise leak into the other cells sharing
+// the default `/api/copilotkit` runtime.
+//
+// Mirrors showcase/integrations/pydantic-ai/src/app/api/copilotkit-beautiful-chat/route.ts.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+// The beautiful-chat page resolves <CopilotKit agent="beautiful-chat">
+// here; internal components (headless-chat, example-canvas) also call
+// `useAgent()` with no args, which defaults to agentId "default". Alias
+// default to the same backend so those hooks resolve.
+const agents: Record<string, AbstractAgent> = {
+  "beautiful-chat": new HttpAgent({ url: `${AGENT_URL}/` }),
+  default: new HttpAgent({ url: `${AGENT_URL}/` }),
+};
+
+const runtime = new CopilotRuntime({
+  // @ts-ignore -- see main route.ts
+  agents,
+  openGenerativeUI: true,
+  a2ui: {
+    // The targeted unified Langroid agent ("/") already registers the
+    // `generate_a2ui` tool itself (GenerateA2UITool in ALL_TOOLS, enabled
+    // via create_agent), so the runtime must NOT inject a second copy —
+    // that would double-bind the render tool. Matches pydantic-ai's
+    // beautiful-chat (this file's mirror source).
+    injectA2UITool: false,
+  },
+});
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-beautiful-chat",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime,
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    console.error(`[copilotkit-beautiful-chat/route] ERROR: ${e.message}`, e.stack);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/integrations/langroid/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -1,0 +1,51 @@
+// Dedicated runtime for the declarative-hashbrown demo (Langroid).
+//
+// The demo page wraps CopilotChat in HashBrownDashboard and overrides the
+// assistant message slot with a renderer that consumes hashbrown-shaped
+// structured output via `@hashbrownai/react`'s `useUiKit` + `useJsonParser`.
+// The agent behind this endpoint is the FastAPI handler at
+// `${AGENT_URL}/byoc-hashbrown` whose system prompt is tuned to emit the
+// hashbrown JSON envelope (see `src/agents/byoc_hashbrown_agent.py`). The
+// demo folder + route + agent slug were renamed from `byoc-hashbrown` to the
+// canonical `declarative-hashbrown` surface; the page mounts
+// <CopilotKit agent="declarative-hashbrown-demo">.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+const declarativeHashbrownAgent = new HttpAgent({
+  url: `${AGENT_URL}/byoc-hashbrown`,
+});
+
+const runtime = new CopilotRuntime({
+  // @ts-ignore -- see main route.ts
+  agents: {
+    "declarative-hashbrown-demo": declarativeHashbrownAgent,
+    default: declarativeHashbrownAgent,
+  },
+});
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-declarative-hashbrown",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime,
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    console.error(`[copilotkit-declarative-hashbrown/route] ERROR: ${e.message}`, e.stack);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/integrations/langroid/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -42,7 +42,10 @@ export const POST = async (req: NextRequest) => {
     return await handleRequest(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
-    console.error(`[copilotkit-declarative-hashbrown/route] ERROR: ${e.message}`, e.stack);
+    console.error(
+      `[copilotkit-declarative-hashbrown/route] ERROR: ${e.message}`,
+      e.stack,
+    );
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 },

--- a/showcase/integrations/langroid/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -40,7 +40,10 @@ export const POST = async (req: NextRequest) => {
     return await handleRequest(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
-    console.error(`[copilotkit-declarative-json-render/route] ERROR: ${e.message}`, e.stack);
+    console.error(
+      `[copilotkit-declarative-json-render/route] ERROR: ${e.message}`,
+      e.stack,
+    );
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 },

--- a/showcase/integrations/langroid/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -1,0 +1,49 @@
+// Dedicated runtime for the declarative-json-render demo (Langroid).
+//
+// The demo page renders the agent's JSON output into a frontend-owned
+// component catalog via @json-render/react. The agent behind this endpoint
+// is the FastAPI handler at `${AGENT_URL}/byoc-json-render` (see
+// `src/agents/byoc_json_render_agent.py`). The demo folder + route surface
+// were renamed from `byoc-json-render` to the canonical
+// `declarative-json-render`; the agent ID retains its legacy
+// `byoc_json_render` name.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+const byocJsonRenderAgent = new HttpAgent({
+  url: `${AGENT_URL}/byoc-json-render`,
+});
+
+const runtime = new CopilotRuntime({
+  // @ts-ignore -- see main route.ts
+  agents: {
+    byoc_json_render: byocJsonRenderAgent,
+    default: byocJsonRenderAgent,
+  },
+});
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-declarative-json-render",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime,
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    console.error(`[copilotkit-declarative-json-render/route] ERROR: ${e.message}`, e.stack);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -57,7 +57,10 @@ export const POST = async (req: NextRequest) => {
     return await handleRequest(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
-    console.error(`[copilotkit-beautiful-chat/route] ERROR: ${e.message}`, e.stack);
+    console.error(
+      `[copilotkit-beautiful-chat/route] ERROR: ${e.message}`,
+      e.stack,
+    );
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 },

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -1,0 +1,66 @@
+// Dedicated runtime for the Beautiful Chat flagship showcase cell (LlamaIndex).
+//
+// Beautiful Chat exercises A2UI (dynamic + fixed schema) and Open
+// Generative UI. The LlamaIndex backend mounts a dedicated beautiful-chat
+// workflow router at `/beautiful-chat` (see src/agent_server.py:
+// `app.include_router(beautiful_chat_router, prefix="/beautiful-chat")`),
+// so the cell routes there; the flagship behavior comes from that backend
+// plus the runtime flags below.
+//
+// Isolated on its own endpoint (mirroring beautiful-chat in the canonical)
+// because the `openGenerativeUI` / `a2ui` runtime flags set global state on
+// the probe response that would otherwise leak into the other cells sharing
+// the default `/api/copilotkit` runtime.
+//
+// Mirrors showcase/integrations/pydantic-ai/src/app/api/copilotkit-beautiful-chat/route.ts.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+// The beautiful-chat page resolves <CopilotKit agent="beautiful-chat">
+// here; internal components (headless-chat, example-canvas) also call
+// `useAgent()` with no args, which defaults to agentId "default". Alias
+// default to the same backend so those hooks resolve.
+const agents: Record<string, AbstractAgent> = {
+  "beautiful-chat": new HttpAgent({ url: `${AGENT_URL}/beautiful-chat/run` }),
+  default: new HttpAgent({ url: `${AGENT_URL}/beautiful-chat/run` }),
+};
+
+const runtime = new CopilotRuntime({
+  // @ts-ignore -- see main route.ts
+  agents,
+  openGenerativeUI: true,
+  a2ui: {
+    // Unlike the other backends' beautiful-chat routes (and pydantic-ai's
+    // mirror source, which set this false), LlamaIndex's dedicated
+    // beautiful-chat workflow (src/agents/beautiful_chat_agent.py) does NOT
+    // register `generate_a2ui` itself — it only owns get_weather. The
+    // runtime must therefore inject the dynamic render tool here.
+    injectA2UITool: true,
+  },
+});
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-beautiful-chat",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime,
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    console.error(`[copilotkit-beautiful-chat/route] ERROR: ${e.message}`, e.stack);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -40,7 +40,10 @@ export const POST = async (req: NextRequest) => {
     return await handleRequest(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
-    console.error(`[copilotkit-declarative-hashbrown/route] ERROR: ${e.message}`, e.stack);
+    console.error(
+      `[copilotkit-declarative-hashbrown/route] ERROR: ${e.message}`,
+      e.stack,
+    );
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 },

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -1,0 +1,49 @@
+// Dedicated runtime for the declarative-hashbrown demo (LlamaIndex).
+//
+// The backend agent emits a `<ui>...</ui>` envelope that `@hashbrownai/react`
+// parses progressively. The runtime just proxies to the LlamaIndex agent at
+// the /byoc-hashbrown subpath. The demo folder + route + agent slug were
+// renamed from `byoc-hashbrown` to the canonical `declarative-hashbrown`
+// surface; the page mounts <CopilotKit agent="declarative-hashbrown-demo">.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+const declarativeHashbrownAgent = new HttpAgent({
+  url: `${AGENT_URL}/byoc-hashbrown/run`,
+});
+
+// Register both the named agent and a `default` fallback so the runtime can
+// resolve regardless of whether the frontend sends an explicit agentId.
+const runtime = new CopilotRuntime({
+  // @ts-ignore -- see main route.ts
+  agents: {
+    "declarative-hashbrown-demo": declarativeHashbrownAgent as AbstractAgent,
+    default: declarativeHashbrownAgent as AbstractAgent,
+  },
+});
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-declarative-hashbrown",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime,
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    console.error(`[copilotkit-declarative-hashbrown/route] ERROR: ${e.message}`, e.stack);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -41,7 +41,10 @@ export const POST = async (req: NextRequest) => {
     return await handleRequest(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
-    console.error(`[copilotkit-declarative-json-render/route] ERROR: ${e.message}`, e.stack);
+    console.error(
+      `[copilotkit-declarative-json-render/route] ERROR: ${e.message}`,
+      e.stack,
+    );
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 },

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -1,0 +1,50 @@
+// Dedicated runtime for the declarative-json-render demo (LlamaIndex).
+//
+// The demo page renders the agent's JSON output into a frontend-owned
+// component catalog via @json-render/react. The runtime proxies to the
+// LlamaIndex agent at the /byoc-json-render subpath. The demo folder + route
+// surface were renamed from `byoc-json-render` to the canonical
+// `declarative-json-render`; the agent ID retains its legacy
+// `byoc_json_render` name.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+const byocJsonRenderAgent = new HttpAgent({
+  url: `${AGENT_URL}/byoc-json-render/run`,
+});
+
+// Register both the named agent and a `default` fallback so the runtime can
+// resolve regardless of whether the frontend sends an explicit agentId.
+const runtime = new CopilotRuntime({
+  // @ts-ignore -- see main route.ts
+  agents: {
+    byoc_json_render: byocJsonRenderAgent as AbstractAgent,
+    default: byocJsonRenderAgent as AbstractAgent,
+  },
+});
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-declarative-json-render",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime,
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    console.error(`[copilotkit-declarative-json-render/route] ERROR: ${e.message}`, e.stack);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/integrations/mastra/package-lock.json
+++ b/showcase/integrations/mastra/package-lock.json
@@ -26,7 +26,7 @@
         "@mastra/memory": "beta",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-separator": "^1.1.8",
-        "ai": "^4.0.0",
+        "ai": "^5.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^0.2.1",
@@ -642,59 +642,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@ai-sdk/react": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
-      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "swr": "^2.2.5",
-        "throttleit": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@ai-sdk/react/node_modules/@ai-sdk/provider": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
-      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@ai-sdk/react/node_modules/@ai-sdk/provider-utils": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
-      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "nanoid": "^3.3.8",
-        "secure-json-parse": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.23.8"
       }
     },
     "node_modules/@ai-sdk/ui-utils": {
@@ -8204,12 +8151,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/diff-match-patch": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
-      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -8719,58 +8660,47 @@
       }
     },
     "node_modules/ai": {
-      "version": "4.3.19",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
-      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
+      "version": "5.0.196",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.196.tgz",
+      "integrity": "sha512-JaljZ1/UagJ1oJp8CcMDxXoE2E2pv4Q/hETkhcD8aE15pbnO7KhEeIqLgsQEizJjc5AquS7matl6GfnDQUDUpA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/react": "1.2.12",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "@opentelemetry/api": "1.9.0",
-        "jsondiffpatch": "0.6.0"
+        "@ai-sdk/gateway": "2.0.97",
+        "@ai-sdk/provider": "2.0.3",
+        "@ai-sdk/provider-utils": "3.0.25",
+        "@opentelemetry/api": "1.9.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/ai/node_modules/@ai-sdk/provider": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
-      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+    "node_modules/ai/node_modules/@ai-sdk/gateway": {
+      "version": "2.0.97",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.97.tgz",
+      "integrity": "sha512-8lM9IuiUcYNw9aYKKsD9Rwr7tfbBxIgsCNlktGBGS7IQHe7bLbK0AZzQKKVWz3JxJn/nhVbGtiFNt3fUnHahvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
-      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "nanoid": "^3.3.8",
-        "secure-json-parse": "^2.7.0"
+        "@ai-sdk/provider": "2.0.3",
+        "@ai-sdk/provider-utils": "3.0.25",
+        "@vercel/oidc": "3.1.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.23.8"
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai/node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/ajv": {
@@ -10444,12 +10374,6 @@
       "engines": {
         "node": ">=0.3.1"
       }
-    },
-    "node_modules/diff-match-patch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
-      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
-      "license": "Apache-2.0"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -12507,35 +12431,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsondiffpatch": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
-      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/diff-match-patch": "^1.0.36",
-        "chalk": "^5.3.0",
-        "diff-match-patch": "^1.0.5"
-      },
-      "bin": {
-        "jsondiffpatch": "bin/jsondiffpatch.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "node_modules/jsondiffpatch/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jsonfile": {
@@ -16928,19 +16823,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/swr": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
-      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
@@ -16979,18 +16861,6 @@
       "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
-      }
-    },
-    "node_modules/throttleit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tiny-invariant": {

--- a/showcase/integrations/mastra/package.json
+++ b/showcase/integrations/mastra/package.json
@@ -30,7 +30,7 @@
     "@mastra/memory": "beta",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-separator": "^1.1.8",
-    "ai": "^4.0.0",
+    "ai": "^5.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^0.2.1",

--- a/showcase/integrations/mastra/src/mastra/tools/index.ts
+++ b/showcase/integrations/mastra/src/mastra/tools/index.ts
@@ -183,7 +183,10 @@ export const generateA2uiTool = createTool({
       tools: {
         render_a2ui: aiTool({
           description: "Render a dynamic A2UI v0.9 surface.",
-          parameters: z.object({
+          // AI SDK v5 renamed the tool schema key from `parameters` to
+          // `inputSchema`; under v5 a `parameters` key is ignored, so the
+          // render_a2ui schema would never reach the model.
+          inputSchema: z.object({
             surfaceId: z.string().describe("Unique surface identifier."),
             catalogId: z.string().describe("The catalog ID."),
             components: z
@@ -204,8 +207,13 @@ export const generateA2uiTool = createTool({
       return JSON.stringify({ error: "LLM did not call render_a2ui" });
     }
 
+    // AI SDK v5 renamed the typed tool-call arguments from `.args` to
+    // `.input` (the `ai` v4 shape was `toolCall.args`). Read `.input` so the
+    // a2ui builder gets the render_a2ui arguments instead of `undefined`.
     return JSON.stringify(
-      buildA2uiOperationsFromToolCall(toolCall.args as Record<string, unknown>),
+      buildA2uiOperationsFromToolCall(
+        toolCall.input as Record<string, unknown>,
+      ),
     );
   },
 });

--- a/showcase/integrations/ms-agent-dotnet/agent/A2uiSecondaryToolCaller.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/A2uiSecondaryToolCaller.cs
@@ -31,7 +31,12 @@ internal static class A2uiSecondaryToolCaller
 
         using var request = new HttpRequestMessage(HttpMethod.Post, "chat/completions");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
-        foreach (var header in AimockHeaderContext.Get())
+        // Forward the inbound x-* headers (incl. x-aimock-context) read off the
+        // current request's HttpContext.Items via the seeded accessor. This
+        // secondary outbound call runs on the SSE-pump ExecutionContext, so it
+        // must read through the accessor (not a middleware-set AsyncLocal) for
+        // the value to be present at call time.
+        foreach (var header in AimockHeaderContext.Get(AimockHeaderPolicy.HttpContextAccessor?.HttpContext))
         {
             request.Headers.TryAddWithoutValidation(header.Key, header.Value);
         }

--- a/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderContext.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderContext.cs
@@ -3,18 +3,48 @@
 // and use the SDK's built-in header propagation.
 // See: https://www.notion.so/copilotkit/3543aa3818528150b6acc5b872ad7fe5
 
+using Microsoft.AspNetCore.Http;
+
 // TODO(copilotkit-sdk-dotnet): migrate to SDK-level header propagation
+//
+// The forwarded x-* headers are stashed in HttpContext.Items rather than an
+// AsyncLocal. HttpContext flows across the AG-UI SSE-pump ExecutionContext
+// boundary (the server seeds IHttpContextAccessor's holder at request entry,
+// before any middleware, and all branches of the request's async tree share
+// that holder), whereas a middleware-set AsyncLocal is captured in a snapshot
+// that the deep outbound-LLM call site does NOT inherit. The previous
+// AsyncLocal approach therefore lost the header at outbound-call time and the
+// mock LLM server (aimock, strict mode) returned 503.
 public static class AimockHeaderContext
 {
-    private static readonly AsyncLocal<Dictionary<string, string>> _headers = new();
+    // Key under which the filtered x-* header map is stored on HttpContext.Items.
+    private const string ItemsKey = "__aimock_forwarded_headers__";
 
-    public static void Set(Dictionary<string, string> headers)
+    /// <summary>
+    /// Stash the inbound x-* headers onto the request's HttpContext.Items so the
+    /// outbound policy can read them at LLM-call time, regardless of which
+    /// ExecutionContext branch the SSE pump is running on.
+    /// </summary>
+    public static void Set(HttpContext context, IDictionary<string, string> headers)
     {
         var filtered = headers
             .Where(h => h.Key.StartsWith("x-", StringComparison.OrdinalIgnoreCase))
             .ToDictionary(h => h.Key.ToLowerInvariant(), h => h.Value);
-        _headers.Value = filtered;
+        context.Items[ItemsKey] = filtered;
     }
 
-    public static Dictionary<string, string> Get() => _headers.Value ?? new();
+    /// <summary>
+    /// Read the forwarded x-* headers for the current request via the supplied
+    /// HttpContext (resolved through IHttpContextAccessor at outbound-call time).
+    /// Returns an empty map when no headers were captured or no request is in scope.
+    /// </summary>
+    public static Dictionary<string, string> Get(HttpContext? context)
+    {
+        if (context?.Items.TryGetValue(ItemsKey, out var value) == true
+            && value is IReadOnlyDictionary<string, string> headers)
+        {
+            return new Dictionary<string, string>(headers);
+        }
+        return new();
+    }
 }

--- a/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderMiddleware.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderMiddleware.cs
@@ -20,18 +20,18 @@ public class AimockHeaderMiddleware
         var headers = context.Request.Headers
             .Where(h => h.Key.StartsWith("x-", StringComparison.OrdinalIgnoreCase))
             .ToDictionary(h => h.Key, h => h.Value.ToString());
-        AimockHeaderContext.Set(headers);
+        // Stash on HttpContext.Items (NOT an AsyncLocal): the value must survive
+        // the AG-UI SSE-pump ExecutionContext boundary so the outbound-LLM policy
+        // can read it via IHttpContextAccessor at call time.
+        AimockHeaderContext.Set(context, headers);
         // CVDIAG inbound breadcrumb: the x-* headers (incl. x-diag-run-id /
-        // x-diag-hops / x-aimock-context) have now been captured into the
-        // AsyncLocal context for this request.
-        CvDiag.LogInbound(_logger, "backend-ms-agent-dotnet", AimockHeaderContext.Get());
-        try
-        {
-            await _next(context);
-        }
-        finally
-        {
-            AimockHeaderContext.Set(new Dictionary<string, string>());
-        }
+        // x-diag-hops / x-aimock-context) have now been captured onto
+        // HttpContext.Items for this request.
+        CvDiag.LogInbound(_logger, "backend-ms-agent-dotnet", AimockHeaderContext.Get(context));
+        // No finally-wipe: the captured headers are request-scoped — they live on
+        // this request's HttpContext and die with it. Wiping them in a finally
+        // raced the still-pumping SSE response and could clear the value before
+        // the outbound LLM call read it.
+        await _next(context);
     }
 }

--- a/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderPolicy.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/AimockHeaderPolicy.cs
@@ -4,11 +4,23 @@
 // See: https://www.notion.so/copilotkit/3543aa3818528150b6acc5b872ad7fe5
 
 using System.ClientModel.Primitives;
+using Microsoft.AspNetCore.Http;
 using OpenAI;
 
 // TODO(copilotkit-sdk-dotnet): migrate to SDK-level header propagation
 public class AimockHeaderPolicy : PipelinePolicy
 {
+    // Seeded once at startup from Program.cs (where the DI container exists).
+    // The policy is created statically via CreateOpenAIClientOptions at
+    // agent-factory construction time and has no DI access, so it reads the
+    // request's HttpContext through this seeded singleton accessor — mirroring
+    // the CvDiag.Logger static-seed pattern. IHttpContextAccessor is a singleton
+    // that resolves the *current* request's HttpContext via a holder the server
+    // seeds at request entry; that holder flows across the AG-UI SSE-pump
+    // ExecutionContext boundary, so the headers the middleware stashed on
+    // HttpContext.Items are visible here at outbound-call time.
+    public static IHttpContextAccessor? HttpContextAccessor { get; set; }
+
     public override void Process(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
     {
         ApplyHeadersAndDiag(message);
@@ -22,12 +34,14 @@ public class AimockHeaderPolicy : PipelinePolicy
     }
 
     // Forwards the captured x-* headers onto the outbound LLM request and emits
-    // the CVDIAG outbound breadcrumb. x-diag-run-id / x-diag-hops rode the
-    // AsyncLocal context the same way as x-aimock-context. This layer appends
-    // its hop tag to x-diag-hops on the outbound call.
+    // the CVDIAG outbound breadcrumb. The headers are read from the current
+    // request's HttpContext.Items via IHttpContextAccessor — HttpContext flows
+    // across the AG-UI SSE-pump ExecutionContext boundary, so the value the
+    // middleware stashed is still visible here at outbound-call time. This layer
+    // appends its hop tag to x-diag-hops on the outbound call.
     private static void ApplyHeadersAndDiag(PipelineMessage message)
     {
-        var headers = AimockHeaderContext.Get();
+        var headers = AimockHeaderContext.Get(HttpContextAccessor?.HttpContext);
         foreach (var header in headers)
         {
             if (string.Equals(header.Key, CvDiag.HeaderDiagHops, StringComparison.OrdinalIgnoreCase))

--- a/showcase/integrations/ms-agent-dotnet/agent/Program.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/Program.cs
@@ -22,10 +22,20 @@ builder.Services.ConfigureHttpJsonOptions(options =>
     options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
 });
 builder.Services.AddAGUI();
+// STOPGAP: IHttpContextAccessor lets AimockHeaderPolicy read the current
+// request's forwarded x-* headers (stashed on HttpContext.Items by
+// AimockHeaderMiddleware) at outbound-LLM-call time. HttpContext flows across
+// the AG-UI SSE-pump ExecutionContext boundary, unlike a middleware-set
+// AsyncLocal. TODO(copilotkit-sdk-dotnet): migrate to SDK-level header propagation.
+builder.Services.AddHttpContextAccessor();
 
 WebApplication app = builder.Build();
 
-// STOPGAP: Extract x-* prefixed headers from incoming AG-UI requests into AsyncLocal
+// STOPGAP: seed the static accessor the outbound header-forwarding policy reads
+// (the policy is created without DI, mirroring CvDiag.Logger).
+AimockHeaderPolicy.HttpContextAccessor = app.Services.GetRequiredService<IHttpContextAccessor>();
+
+// STOPGAP: Extract x-* prefixed headers from incoming AG-UI requests onto HttpContext.Items
 // so AimockHeaderPolicy can forward them to outgoing OpenAI calls.
 // TODO(copilotkit-sdk-dotnet): migrate to SDK-level header propagation
 app.UseMiddleware<AimockHeaderMiddleware>();

--- a/showcase/integrations/ms-agent-dotnet/agent/tests/AimockHeaderPropagationTests.cs
+++ b/showcase/integrations/ms-agent-dotnet/agent/tests/AimockHeaderPropagationTests.cs
@@ -1,0 +1,143 @@
+using System.ClientModel.Primitives;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace MsAgentDotnet.AgentTests;
+
+// Red-green regression test for the .NET header-forwarding root cause.
+//
+// The bug: AimockHeaderMiddleware set the inbound x-aimock-context header into
+// an AsyncLocal, then `await _next(context)` pumped the AG-UI SSE response on an
+// ExecutionContext branch that did NOT inherit that AsyncLocal value. So when
+// the outbound OpenAI call was made (deep inside the SSE pump), the policy read
+// an empty header set -> x-aimock-context was NOT forwarded -> aimock strict
+// mode returned 503 -> hung/aborted turns.
+//
+// The fix: stash the headers on HttpContext.Items and read them via
+// IHttpContextAccessor. HttpContext flows across the SSE-pump ExecutionContext
+// boundary (the server seeds the accessor's holder at request entry, before any
+// middleware, and every branch of the request's async tree shares that holder).
+//
+// These tests reproduce the ExecutionContext boundary the SSE pump crosses:
+// capture an ExecutionContext snapshot at "response start" and run the outbound
+// read inside that captured context via ExecutionContext.Run, exactly as the
+// SSE pump does. The AsyncLocal-set-after-capture value is invisible there; the
+// HttpContext.Items value (read through the accessor singleton) survives.
+public class AimockHeaderPropagationTests
+{
+    private const string AimockHeader = "x-aimock-context";
+    private const string Slug = "gen-ui-chat";
+
+    // Demonstrates the ROOT CAUSE: an AsyncLocal set AFTER an ExecutionContext
+    // snapshot is captured is NOT visible when that snapshot is later run. This
+    // is precisely the AG-UI SSE-pump boundary the old middleware lost the
+    // header across. (RED for the old design.)
+    [Fact]
+    public void AsyncLocalSetAfterSnapshot_IsInvisibleAcrossExecutionContextBoundary()
+    {
+        var asyncLocal = new AsyncLocal<string?>();
+
+        // SSE pump captures the ambient ExecutionContext at response-start,
+        // BEFORE the middleware sets its AsyncLocal for this request.
+        var capturedAtResponseStart = ExecutionContext.Capture()!;
+
+        // Middleware sets the header into the AsyncLocal (old design).
+        asyncLocal.Value = Slug;
+
+        // Outbound LLM call runs inside the captured (pre-set) context.
+        string? observedAtOutbound = "SENTINEL";
+        ExecutionContext.Run(capturedAtResponseStart, _ =>
+        {
+            observedAtOutbound = asyncLocal.Value;
+        }, null);
+
+        // The header is LOST -> this is the 503-causing bug.
+        Assert.Null(observedAtOutbound);
+    }
+
+    // Demonstrates the FIX: HttpContext.Items read via IHttpContextAccessor
+    // survives the same ExecutionContext boundary, because the accessor's holder
+    // (seeded once, ambient) points at the same mutable HttpContext regardless
+    // of which captured ExecutionContext snapshot the outbound read runs on.
+    // (GREEN for the new design.)
+    [Fact]
+    public void HttpContextItems_SurvivesExecutionContextBoundary_ViaAccessor()
+    {
+        var accessor = new HttpContextAccessor();
+        var httpContext = new DefaultHttpContext();
+        accessor.HttpContext = httpContext;
+
+        // SSE pump captures the ambient ExecutionContext at response-start,
+        // BEFORE the middleware stashes the header on HttpContext.Items.
+        var capturedAtResponseStart = ExecutionContext.Capture()!;
+
+        // Middleware stashes the inbound x-* headers on HttpContext.Items (fix).
+        var inbound = new Dictionary<string, string> { [AimockHeader] = Slug };
+        AimockHeaderContext.Set(httpContext, inbound);
+
+        // Outbound LLM call runs inside the captured (pre-set) context, reading
+        // through the accessor exactly as AimockHeaderPolicy.ApplyHeadersAndDiag does.
+        Dictionary<string, string> observedAtOutbound = new();
+        ExecutionContext.Run(capturedAtResponseStart, _ =>
+        {
+            observedAtOutbound = AimockHeaderContext.Get(accessor.HttpContext);
+        }, null);
+
+        // The header is PRESENT at the outbound boundary -> forwarded -> 200.
+        Assert.True(observedAtOutbound.ContainsKey(AimockHeader));
+        Assert.Equal(Slug, observedAtOutbound[AimockHeader]);
+    }
+
+    // End-to-end through the actual policy: the seeded static accessor lets the
+    // production policy forward x-aimock-context onto a real outbound request
+    // message, even when the policy runs inside a pre-captured ExecutionContext.
+    [Fact]
+    public async Task Policy_ForwardsAimockContext_OntoOutboundRequest_AcrossBoundary()
+    {
+        var accessor = new HttpContextAccessor();
+        var httpContext = new DefaultHttpContext();
+        accessor.HttpContext = httpContext;
+        AimockHeaderPolicy.HttpContextAccessor = accessor;
+
+        // SSE pump captures context BEFORE the header is stashed.
+        var capturedAtResponseStart = ExecutionContext.Capture()!;
+
+        AimockHeaderContext.Set(httpContext, new Dictionary<string, string> { [AimockHeader] = Slug });
+
+        // Build a real outbound pipeline message and run it through the policy
+        // inside the captured context (mimicking the SSE-pump outbound call).
+        var policy = new AimockHeaderPolicy();
+        var pipeline = ClientPipeline.Create();
+        using var message = pipeline.CreateMessage();
+        message.Request.Method = "POST";
+        message.Request.Uri = new Uri("http://localhost:1/v1/chat/completions");
+
+        // The header policy at index 0, followed by a terminal no-op so
+        // ProcessNext has a successor to hand off to (and we never make a real
+        // network call).
+        var policies = new PipelinePolicy[] { policy, new TerminalPolicy() };
+
+        var tcs = new TaskCompletionSource();
+        ExecutionContext.Run(capturedAtResponseStart, _ =>
+        {
+            policy.Process(message, policies, 0);
+            tcs.SetResult();
+        }, null);
+        await tcs.Task;
+
+        Assert.True(message.Request.Headers.TryGetValue(AimockHeader, out var forwarded));
+        Assert.Equal(Slug, forwarded);
+    }
+
+    // Terminal pipeline policy: does nothing (does not call ProcessNext), so the
+    // policy chain stops here without making a real network request.
+    private sealed class TerminalPolicy : PipelinePolicy
+    {
+        public override void Process(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+        {
+        }
+
+        public override ValueTask ProcessAsync(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex)
+            => ValueTask.CompletedTask;
+    }
+}

--- a/showcase/integrations/ms-agent-dotnet/agent/tests/SharedStateAgent.Tests.csproj
+++ b/showcase/integrations/ms-agent-dotnet/agent/tests/SharedStateAgent.Tests.csproj
@@ -17,6 +17,14 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 
+  <!-- Needed so the header-propagation tests can use DefaultHttpContext /
+       HttpContextAccessor (Microsoft.AspNetCore.Http types). The production
+       project is a Web SDK app, but a project reference does not flow the
+       ASP.NET shared framework, so reference it explicitly here. -->
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\ProverbsAgent.csproj" />
   </ItemGroup>

--- a/showcase/integrations/ms-agent-python/src/agent_server.py
+++ b/showcase/integrations/ms-agent-python/src/agent_server.py
@@ -16,10 +16,19 @@ import os
 # (line ~79) — so the patch must be in place before that import resolves.
 from agents._header_forwarding import (
     HeaderForwardingHTTPMiddleware,
+    install_executor_contextvar_propagation,
     install_global_httpx_hook,
 )
 
 install_global_httpx_hook()
+# agent_framework dispatches SYNC tools (e.g. the declarative gen-ui
+# `generate_a2ui` tool, which makes a secondary OpenAI call) onto the
+# default ThreadPoolExecutor via loop.run_in_executor(...), which does NOT
+# propagate ContextVars to the worker thread. Without this, the
+# forwarded-header ContextVar set on the inbound request task is empty by
+# the time the secondary call's outbound httpx hook fires, and aimock
+# can't match the right fixture for the request.
+install_executor_contextvar_propagation()
 
 import uvicorn
 from agent_framework import BaseChatClient

--- a/showcase/integrations/ms-agent-python/src/agents/_header_forwarding.py
+++ b/showcase/integrations/ms-agent-python/src/agents/_header_forwarding.py
@@ -369,3 +369,60 @@ def install_global_httpx_hook() -> None:
     httpx.Client.__init__ = _patched_sync_init
     httpx.AsyncClient.__init__ = _patched_async_init
     _GLOBAL_HTTPX_PATCHED = True
+
+
+# Module-scope sentinel preventing repeated executor patching.
+_EXECUTOR_CTXVAR_PATCHED = False
+
+
+def install_executor_contextvar_propagation() -> None:
+    """Patch ``asyncio.events.AbstractEventLoop.run_in_executor`` so the
+    parent task's ContextVars are propagated into the executor thread.
+
+    Why this exists
+    ---------------
+    Frameworks that dispatch a SYNC callable (e.g. agent_framework running
+    a sync tool, or a hand-rolled secondary LLM call) onto the default
+    thread pool via ``loop.run_in_executor(None, functools.partial(...))``
+    lose the caller's context: the stock ``run_in_executor`` does NOT copy
+    the caller's :pep:`567` context to the worker thread — so the
+    :class:`HeaderForwardingHTTPMiddleware` ContextVar (set on the inbound
+    request task) is empty inside the executor, and our outbound httpx
+    hook sees no headers to forward.
+
+    ``asyncio.to_thread`` (Python 3.9+) does copy context the right way;
+    this patch makes plain ``run_in_executor`` behave the same. It only
+    affects functions submitted via ``run_in_executor`` — coroutines and
+    other constructs are unaffected.
+
+    Safe to call at import time. Idempotent via a module-scope sentinel.
+    Pre-existing event-loop instances inherit the patch because
+    ``run_in_executor`` is defined on ``BaseEventLoop`` and looked up
+    per-call via normal method resolution.
+    """
+    global _EXECUTOR_CTXVAR_PATCHED
+    if _EXECUTOR_CTXVAR_PATCHED:
+        return
+
+    import asyncio.base_events as _base_events
+
+    _orig_run_in_executor = _base_events.BaseEventLoop.run_in_executor
+
+    def _patched_run_in_executor(self, executor, func, *args):
+        # Capture the CURRENT task's context at submit time, then run the
+        # submitted callable inside that context on the worker thread.
+        ctx = contextvars.copy_context()
+
+        def _ctx_wrapper(*a, **kw):
+            return ctx.run(func, *a, **kw)
+
+        # Preserve __name__/__qualname__ for nicer tracebacks where possible.
+        try:
+            _ctx_wrapper.__wrapped__ = func  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover
+            pass
+
+        return _orig_run_in_executor(self, executor, _ctx_wrapper, *args)
+
+    _base_events.BaseEventLoop.run_in_executor = _patched_run_in_executor
+    _EXECUTOR_CTXVAR_PATCHED = True

--- a/showcase/integrations/pydantic-ai/src/agent_server.py
+++ b/showcase/integrations/pydantic-ai/src/agent_server.py
@@ -37,10 +37,19 @@ from dotenv import load_dotenv
 # client at agent-module import time.
 from agents._header_forwarding import (
     HeaderForwardingHTTPMiddleware,
+    install_executor_contextvar_propagation,
     install_global_httpx_hook,
 )
 
 install_global_httpx_hook()
+# PydanticAI dispatches SYNC tools (e.g. the declarative gen-ui
+# `generate_a2ui` tool, which makes a secondary OpenAI call) onto the
+# default ThreadPoolExecutor via loop.run_in_executor(...), which does NOT
+# propagate ContextVars to the worker thread. Without this, the
+# forwarded-header ContextVar set on the inbound request task is empty by
+# the time the secondary call's outbound httpx hook fires, and aimock
+# can't match the right fixture for the request.
+install_executor_contextvar_propagation()
 
 from agents.agent import SalesTodosState, StateDeps, agent
 from agents.open_gen_ui_agent import agent as open_gen_ui_agent

--- a/showcase/integrations/pydantic-ai/src/agents/_header_forwarding.py
+++ b/showcase/integrations/pydantic-ai/src/agents/_header_forwarding.py
@@ -369,3 +369,60 @@ def install_global_httpx_hook() -> None:
     httpx.Client.__init__ = _patched_sync_init
     httpx.AsyncClient.__init__ = _patched_async_init
     _GLOBAL_HTTPX_PATCHED = True
+
+
+# Module-scope sentinel preventing repeated executor patching.
+_EXECUTOR_CTXVAR_PATCHED = False
+
+
+def install_executor_contextvar_propagation() -> None:
+    """Patch ``asyncio.events.AbstractEventLoop.run_in_executor`` so the
+    parent task's ContextVars are propagated into the executor thread.
+
+    Why this exists
+    ---------------
+    Frameworks that dispatch a SYNC callable (e.g. pydantic-ai running a
+    sync ``@agent.tool``, or a hand-rolled secondary LLM call) onto the
+    default thread pool via ``loop.run_in_executor(None,
+    functools.partial(...))`` lose the caller's context: the stock
+    ``run_in_executor`` does NOT copy the caller's :pep:`567` context to
+    the worker thread — so the :class:`HeaderForwardingHTTPMiddleware`
+    ContextVar (set on the inbound request task) is empty inside the
+    executor, and our outbound httpx hook sees no headers to forward.
+
+    ``asyncio.to_thread`` (Python 3.9+) does copy context the right way;
+    this patch makes plain ``run_in_executor`` behave the same. It only
+    affects functions submitted via ``run_in_executor`` — coroutines and
+    other constructs are unaffected.
+
+    Safe to call at import time. Idempotent via a module-scope sentinel.
+    Pre-existing event-loop instances inherit the patch because
+    ``run_in_executor`` is defined on ``BaseEventLoop`` and looked up
+    per-call via normal method resolution.
+    """
+    global _EXECUTOR_CTXVAR_PATCHED
+    if _EXECUTOR_CTXVAR_PATCHED:
+        return
+
+    import asyncio.base_events as _base_events
+
+    _orig_run_in_executor = _base_events.BaseEventLoop.run_in_executor
+
+    def _patched_run_in_executor(self, executor, func, *args):
+        # Capture the CURRENT task's context at submit time, then run the
+        # submitted callable inside that context on the worker thread.
+        ctx = contextvars.copy_context()
+
+        def _ctx_wrapper(*a, **kw):
+            return ctx.run(func, *a, **kw)
+
+        # Preserve __name__/__qualname__ for nicer tracebacks where possible.
+        try:
+            _ctx_wrapper.__wrapped__ = func  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover
+            pass
+
+        return _orig_run_in_executor(self, executor, _ctx_wrapper, *args)
+
+    _base_events.BaseEventLoop.run_in_executor = _patched_run_in_executor
+    _EXECUTOR_CTXVAR_PATCHED = True

--- a/showcase/integrations/pydantic-ai/src/agents/a2ui_dynamic.py
+++ b/showcase/integrations/pydantic-ai/src/agents/a2ui_dynamic.py
@@ -16,10 +16,14 @@ Pattern:
   tool).
 
 PydanticAI notes:
-- `agent.to_ag_ui()` exposes StateDeps to tools via `ctx.deps`. The
-  AG-UI adapter populates a `copilotkit` attribute on StateDeps with the
-  forwarded context/messages from the frontend, which we use to feed the
-  secondary LLM's system prompt.
+- `agent.to_ag_ui()` exposes StateDeps to tools via `ctx.deps`, but
+  `StateDeps` carries ONLY a `state` field — it has no `copilotkit`
+  attribute. The real forwarded conversation lives on the pydantic-ai
+  `RunContext` itself, as `ctx.messages` (the `ModelMessage` history the
+  AG-UI adapter built from the frontend run input). We extract the real
+  user/assistant turns from `ctx.messages` and feed the secondary gen-ui
+  LLM a `[system, *real_messages]` prompt — mirroring the langgraph-python
+  north-star (`[SystemMessage(prompt), *real_messages]`).
 """
 
 from __future__ import annotations
@@ -30,6 +34,7 @@ from textwrap import dedent
 from pydantic import BaseModel
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.ag_ui import StateDeps
+from pydantic_ai.messages import ModelRequest, ModelResponse
 from pydantic_ai.models.openai import OpenAIResponsesModel
 
 from tools import build_a2ui_operations_from_tool_call
@@ -64,6 +69,75 @@ SYSTEM_PROMPT = dedent(
 ).strip()
 
 
+# System prompt for the SECONDARY (gen-ui) LLM call. The primary agent
+# decided UI is warranted and called `generate_a2ui`; this prompt instructs
+# the secondary LLM to design the A2UI surface from the real conversation
+# (appended after this message) via the forced `render_a2ui` tool call.
+GEN_UI_SYSTEM_PROMPT = dedent(
+    """
+    You are a UI designer for Declarative Generative UI (A2UI — Dynamic
+    Schema). Given the conversation so far, design a rich, well-structured
+    A2UI v0.9 surface that best presents the answer — a dashboard, status
+    report, KPI summary, card layout, info grid, pie/donut chart for
+    part-of-whole breakdowns, or bar chart for comparisons across
+    categories. Use the registered catalog components (Card, StatusBadge,
+    Metric, InfoRow, PrimaryButton, PieChart, BarChart) plus the basic A2UI
+    primitives. Always emit the surface by calling the `render_a2ui` tool.
+    """
+).strip()
+
+
+def _extract_conversation(ctx: RunContext[StateDeps[EmptyState]]) -> list[dict]:
+    """Extract the real user/assistant turns from the pydantic-ai RunContext.
+
+    The forwarded conversation lives on ``ctx.messages`` (a list of
+    ``ModelRequest`` / ``ModelResponse``), NOT on ``ctx.deps`` — ``StateDeps``
+    has only a ``state`` field. ``ModelRequest`` carries the user input as a
+    ``UserPromptPart`` (``part_kind == "user-prompt"``) and ``ModelResponse``
+    carries the assistant text as ``TextPart`` (``part_kind == "text"``). We
+    flatten those into the OpenAI ``{role, content}`` shape the secondary
+    gen-ui call expects, skipping system/tool/internal parts so the secondary
+    LLM sees only the human-facing conversation.
+    """
+    conversation: list[dict] = []
+    for msg in ctx.messages or []:
+        if isinstance(msg, ModelRequest):
+            role = "user"
+            wanted_kind = "user-prompt"
+        elif isinstance(msg, ModelResponse):
+            role = "assistant"
+            wanted_kind = "text"
+        else:  # pragma: no cover - defensive; only Request/Response exist today
+            continue
+
+        for part in msg.parts:
+            if getattr(part, "part_kind", None) != wanted_kind:
+                continue
+            content = _part_content_to_text(getattr(part, "content", None))
+            if content:
+                conversation.append({"role": role, "content": content})
+    return conversation
+
+
+def _part_content_to_text(content: object) -> str:
+    """Normalize a part's ``content`` (str or multimodal list) to plain text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif hasattr(part, "text"):
+                text = getattr(part, "text", None)
+                if isinstance(text, str):
+                    parts.append(text)
+            elif isinstance(part, dict) and isinstance(part.get("text"), str):
+                parts.append(part["text"])
+        return "".join(parts)
+    return ""
+
+
 agent = Agent(
     model=OpenAIResponsesModel("gpt-4.1"),
     deps_type=StateDeps[EmptyState],
@@ -81,37 +155,12 @@ def generate_a2ui(ctx: RunContext[StateDeps[EmptyState]]) -> str:
     """
     from openai import OpenAI
 
-    # Extract conversation context + catalog schema from the AG-UI payload.
-    copilotkit_state = getattr(ctx.deps, "copilotkit", None)
-    conversation_messages: list[dict] = []
-    context_entries: list[dict] = []
-    if copilotkit_state:
-        if hasattr(copilotkit_state, "messages"):
-            for msg in copilotkit_state.messages or []:
-                role = msg.role.value if hasattr(msg.role, "value") else str(msg.role)
-                if role in ("user", "assistant"):
-                    content = ""
-                    if hasattr(msg, "content"):
-                        if isinstance(msg.content, str):
-                            content = msg.content
-                        elif isinstance(msg.content, list):
-                            parts = []
-                            for part in msg.content:
-                                if hasattr(part, "text"):
-                                    parts.append(part.text)
-                                elif isinstance(part, dict) and "text" in part:
-                                    parts.append(part["text"])
-                            content = "".join(parts)
-                    if content:
-                        conversation_messages.append({"role": role, "content": content})
-        if hasattr(copilotkit_state, "context"):
-            context_entries = copilotkit_state.context or []
-
-    context_text = "\n\n".join(
-        entry.get("value", "")
-        for entry in context_entries
-        if isinstance(entry, dict) and entry.get("value")
-    )
+    # The real forwarded conversation lives on ``ctx.messages`` — NOT on
+    # ``ctx.deps`` (StateDeps has only ``state``, no ``copilotkit``). Mirror
+    # the langgraph-python north-star: build the secondary prompt as
+    # ``[system, *real_messages]`` so the gen-ui LLM designs UI from the
+    # actual conversation rather than an empty/system-only context.
+    conversation_messages = _extract_conversation(ctx)
 
     client = OpenAI()
     tool_schema = {
@@ -132,14 +181,22 @@ def generate_a2ui(ctx: RunContext[StateDeps[EmptyState]]) -> str:
         },
     }
 
+    # North-star shape: [system prompt, *real conversation]. The real
+    # user/assistant turns from ``ctx.messages`` give the secondary LLM the
+    # actual request to design UI for, instead of an empty/system-only prompt.
     llm_messages: list[dict] = [
-        {
-            "role": "system",
-            "content": context_text
-            or "Generate a useful dashboard UI from the conversation so far.",
-        },
+        {"role": "system", "content": GEN_UI_SYSTEM_PROMPT},
     ]
     llm_messages.extend(conversation_messages)
+    if not conversation_messages:
+        # Defensive fallback: never send a bare system-only prompt if the
+        # conversation somehow could not be extracted.
+        llm_messages.append(
+            {
+                "role": "user",
+                "content": "Generate a useful dashboard UI from the conversation so far.",
+            }
+        )
 
     response = client.chat.completions.create(
         model="gpt-4.1",
@@ -152,8 +209,17 @@ def generate_a2ui(ctx: RunContext[StateDeps[EmptyState]]) -> str:
         return json.dumps({"error": "LLM did not call render_a2ui"})
 
     tool_call = response.choices[0].message.tool_calls[0]
-    args = json.loads(tool_call.function.arguments)
+    try:
+        args = json.loads(tool_call.function.arguments)
+    except (json.JSONDecodeError, TypeError):
+        return json.dumps({"error": "render_a2ui returned malformed arguments"})
+    if not isinstance(args, dict):
+        return json.dumps({"error": "render_a2ui returned malformed arguments"})
     # Override catalog id to match the frontend's declarative-gen-ui catalog.
     args.setdefault("catalogId", CUSTOM_CATALOG_ID)
+    # Guard against missing/empty components so the downstream helper never
+    # raises out of the tool; surface a structured error instead.
+    if not args.get("components"):
+        return json.dumps({"error": "render_a2ui returned no components"})
     result = build_a2ui_operations_from_tool_call(args)
     return json.dumps(result)

--- a/showcase/integrations/pydantic-ai/tests/test_a2ui_dynamic_conversation.py
+++ b/showcase/integrations/pydantic-ai/tests/test_a2ui_dynamic_conversation.py
@@ -1,0 +1,188 @@
+"""Red-green proof for the pydantic-ai declarative-gen-ui (a2ui_dynamic) fix.
+
+Defect: `generate_a2ui` read the conversation from
+`getattr(ctx.deps, "copilotkit", None)`, but `StateDeps` has only a
+`state` field, so that attribute is ALWAYS None. The secondary gen-ui LLM
+call therefore received a system-only / empty-context prompt and produced
+the wrong a2ui shape.
+
+Fix: read the REAL forwarded conversation from `ctx.messages` (the
+pydantic-ai RunContext message history) and build the secondary prompt as
+`[system, *real_messages]` — the langgraph-python north-star shape.
+
+This test invokes the real `generate_a2ui` tool with a representative
+RunContext carrying a real user turn, intercepts the secondary OpenAI
+call, and asserts the secondary LLM actually receives that user turn.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make `src/` and `tools/` importable the same way the app entrypoint does.
+_INTEGRATION_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_INTEGRATION_ROOT / "src"))
+sys.path.insert(0, str(_INTEGRATION_ROOT))
+
+from pydantic import BaseModel  # noqa: E402
+from pydantic_ai import RunContext  # noqa: E402
+from pydantic_ai.ag_ui import StateDeps  # noqa: E402
+from pydantic_ai.messages import (  # noqa: E402
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    UserPromptPart,
+)
+from pydantic_ai.models.test import TestModel  # noqa: E402
+from pydantic_ai.usage import RunUsage  # noqa: E402
+
+from agents import a2ui_dynamic  # noqa: E402
+
+
+USER_TURN = "Show me Q3 sales by region as a pie chart"
+
+
+class _FakeMessage:
+    def __init__(self, tool_calls):
+        self.tool_calls = tool_calls
+
+
+class _FakeToolCall:
+    def __init__(self, arguments: str):
+        self.function = type("F", (), {"name": "render_a2ui", "arguments": arguments})()
+
+
+class _FakeChoice:
+    def __init__(self, message):
+        self.message = message
+
+
+class _FakeResponse:
+    def __init__(self, choices):
+        self.choices = choices
+
+
+class _CapturingOpenAI:
+    """Stand-in for openai.OpenAI that records the secondary-call messages."""
+
+    captured_messages: list = []
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    @property
+    def chat(self):
+        return self
+
+    @property
+    def completions(self):
+        return self
+
+    def create(self, *, model, messages, tools, tool_choice, **kwargs):
+        type(self).captured_messages = messages
+        valid_args = json.dumps(
+            {
+                "surfaceId": "declarative-surface",
+                "catalogId": a2ui_dynamic.CUSTOM_CATALOG_ID,
+                "components": [{"id": "root", "component": "Card"}],
+                "data": {},
+            }
+        )
+        return _FakeResponse(
+            [_FakeChoice(_FakeMessage([_FakeToolCall(valid_args)]))]
+        )
+
+
+def _build_ctx() -> RunContext:
+    class _State(BaseModel):
+        pass
+
+    return RunContext(
+        deps=StateDeps[_State](state=_State()),
+        model=TestModel(),
+        usage=RunUsage(),
+        messages=[
+            ModelRequest(parts=[UserPromptPart(content=USER_TURN)]),
+            ModelResponse(parts=[TextPart(content="On it — drawing your dashboard.")]),
+        ],
+    )
+
+
+def _call_tool(ctx: RunContext) -> str:
+    # `@agent.tool` wraps the function; the original is on `.function`.
+    fn = getattr(a2ui_dynamic.generate_a2ui, "function", a2ui_dynamic.generate_a2ui)
+    return fn(ctx)
+
+
+def test_secondary_call_includes_real_conversation(monkeypatch):
+    import openai
+
+    monkeypatch.setattr(openai, "OpenAI", _CapturingOpenAI)
+    _CapturingOpenAI.captured_messages = []
+
+    result = _call_tool(_build_ctx())
+
+    sent = _CapturingOpenAI.captured_messages
+    user_msgs = [m for m in sent if m.get("role") == "user"]
+
+    # BEFORE the fix this list is EMPTY (copilotkit attr is always None) ->
+    # the secondary call is system-only and this assertion fails.
+    assert user_msgs, (
+        "secondary gen-ui call received NO real user message "
+        f"(system-only prompt). messages sent: {sent}"
+    )
+    assert any(USER_TURN in (m.get("content") or "") for m in user_msgs), (
+        f"real user turn not forwarded to secondary call. user msgs: {user_msgs}"
+    )
+
+    # And it still produces a valid a2ui_operations container.
+    parsed = json.loads(result)
+    assert "a2ui_operations" in parsed, parsed
+
+
+def test_part_content_with_none_text_does_not_crash():
+    """A multimodal content part whose `.text` is None must not raise.
+
+    Regression: `_part_content_to_text` unconditionally appended `part.text`,
+    so a part with `text=None` (or a non-str) caused `"".join(...)` to raise
+    TypeError. The guard now skips non-str text values.
+    """
+
+    class _PartWithNoneText:
+        text = None
+
+    class _PartWithRealText:
+        text = "hello"
+
+    out = a2ui_dynamic._part_content_to_text(
+        [_PartWithNoneText(), "world", _PartWithRealText()]
+    )
+    # None is skipped; str parts are concatenated.
+    assert out == "worldhello", out
+
+
+def test_malformed_tool_call_arguments_returns_structured_error(monkeypatch):
+    """Malformed JSON from the secondary render_a2ui call yields a structured
+    error string, not an exception escaping the tool."""
+    import openai
+
+    class _BadArgsOpenAI(_CapturingOpenAI):
+        def create(self, *, model, messages, tools, tool_choice, **kwargs):
+            return _FakeResponse(
+                [_FakeChoice(_FakeMessage([_FakeToolCall("{not valid json")]))]
+            )
+
+    monkeypatch.setattr(openai, "OpenAI", _BadArgsOpenAI)
+
+    result = _call_tool(_build_ctx())
+    parsed = json.loads(result)
+    assert "error" in parsed, parsed
+    assert "a2ui_operations" not in parsed, parsed
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/showcase/integrations/pydantic-ai/tests/test_a2ui_dynamic_conversation.py
+++ b/showcase/integrations/pydantic-ai/tests/test_a2ui_dynamic_conversation.py
@@ -92,9 +92,7 @@ class _CapturingOpenAI:
                 "data": {},
             }
         )
-        return _FakeResponse(
-            [_FakeChoice(_FakeMessage([_FakeToolCall(valid_args)]))]
-        )
+        return _FakeResponse([_FakeChoice(_FakeMessage([_FakeToolCall(valid_args)]))])
 
 
 def _build_ctx() -> RunContext:

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -56,7 +56,10 @@ export const POST = async (req: NextRequest) => {
     return await handleRequest(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
-    console.error(`[copilotkit-beautiful-chat/route] ERROR: ${e.message}`, e.stack);
+    console.error(
+      `[copilotkit-beautiful-chat/route] ERROR: ${e.message}`,
+      e.stack,
+    );
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 },

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -1,0 +1,65 @@
+// Dedicated runtime for the Beautiful Chat flagship showcase cell (Spring AI).
+//
+// Beautiful Chat exercises A2UI (dynamic + fixed schema) and Open
+// Generative UI. The Spring AI backend serves its main agent at "/" (see
+// the `@PostMapping("/")` controller); there is no dedicated beautiful-chat
+// controller, so the cell routes there and the flagship behavior comes from
+// the runtime flags below plus the frontend's per-cell registrations.
+//
+// Isolated on its own endpoint (mirroring beautiful-chat in the canonical)
+// because the `openGenerativeUI` / `a2ui` runtime flags set global state on
+// the probe response that would otherwise leak into the other cells sharing
+// the default `/api/copilotkit` runtime.
+//
+// Mirrors showcase/integrations/pydantic-ai/src/app/api/copilotkit-beautiful-chat/route.ts.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+// The beautiful-chat page resolves <CopilotKit agent="beautiful-chat">
+// here; internal components (headless-chat, example-canvas) also call
+// `useAgent()` with no args, which defaults to agentId "default". Alias
+// default to the same backend so those hooks resolve.
+const agents: Record<string, AbstractAgent> = {
+  "beautiful-chat": new HttpAgent({ url: `${AGENT_URL}/` }),
+  default: new HttpAgent({ url: `${AGENT_URL}/` }),
+};
+
+const runtime = new CopilotRuntime({
+  // @ts-ignore -- see main route.ts
+  agents,
+  openGenerativeUI: true,
+  a2ui: {
+    // The targeted Spring AI agent ("/") already registers the
+    // `generate_a2ui` tool itself (GenerateA2uiTool in AgentConfig), so the
+    // runtime must NOT inject a second copy — that would double-bind the
+    // render tool. Matches pydantic-ai's beautiful-chat (this file's mirror
+    // source).
+    injectA2UITool: false,
+  },
+});
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-beautiful-chat",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime,
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    console.error(`[copilotkit-beautiful-chat/route] ERROR: ${e.message}`, e.stack);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -1,0 +1,49 @@
+// Dedicated runtime for the declarative-hashbrown demo (Spring AI).
+//
+// The demo page wraps CopilotChat in HashBrownDashboard and overrides the
+// assistant message slot with a renderer that consumes hashbrown-shaped
+// structured output via `@hashbrownai/react`'s `useUiKit` + `useJsonParser`.
+// The Spring AI backend has no dedicated hashbrown controller, so this route
+// proxies to the main agent at "/" (see the `@PostMapping("/")` controller);
+// the hashbrown envelope shape is driven by the frontend renderer. The page
+// mounts <CopilotKit agent="declarative-hashbrown-demo">.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+function createAgent() {
+  return new HttpAgent({ url: `${AGENT_URL}/` });
+}
+
+const agents: Record<string, AbstractAgent> = {
+  "declarative-hashbrown-demo": createAgent(),
+  default: createAgent(),
+};
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-declarative-hashbrown",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime: new CopilotRuntime({
+        // @ts-ignore -- see main route.ts
+        agents,
+      }),
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    console.error(`[copilotkit-declarative-hashbrown/route] ERROR: ${e.message}`, e.stack);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -40,7 +40,10 @@ export const POST = async (req: NextRequest) => {
     return await handleRequest(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
-    console.error(`[copilotkit-declarative-hashbrown/route] ERROR: ${e.message}`, e.stack);
+    console.error(
+      `[copilotkit-declarative-hashbrown/route] ERROR: ${e.message}`,
+      e.stack,
+    );
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 },

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -1,0 +1,52 @@
+// Dedicated runtime for the declarative-json-render demo (Spring AI).
+//
+// The demo page renders the agent's JSON output into a frontend-owned
+// component catalog via @json-render/react. The Spring AI backend runs a
+// dedicated controller at /byoc-json-render/run whose system prompt instructs
+// the LLM to emit a flat-spec JSON object matching the catalog's schema. The
+// demo folder + route surface were renamed from `byoc-json-render` to the
+// canonical `declarative-json-render`; the agent ID retains its legacy
+// `byoc_json_render` name.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+function createAgent(): AbstractAgent {
+  return new HttpAgent({ url: `${AGENT_URL}/byoc-json-render/run` });
+}
+
+const byocJsonRenderAgent = createAgent();
+const agents: Record<string, AbstractAgent> = {
+  byoc_json_render: byocJsonRenderAgent,
+  default: byocJsonRenderAgent,
+};
+
+const runtime = new CopilotRuntime({
+  // @ts-ignore -- see main route.ts
+  agents,
+});
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-declarative-json-render",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime,
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    console.error(`[copilotkit-declarative-json-render/route] ERROR: ${e.message}`, e.stack);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -43,7 +43,10 @@ export const POST = async (req: NextRequest) => {
     return await handleRequest(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
-    console.error(`[copilotkit-declarative-json-render/route] ERROR: ${e.message}`, e.stack);
+    console.error(
+      `[copilotkit-declarative-json-render/route] ERROR: ${e.message}`,
+      e.stack,
+    );
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 },

--- a/showcase/integrations/strands/src/agent_server.py
+++ b/showcase/integrations/strands/src/agent_server.py
@@ -96,10 +96,19 @@ _assert_instrumentor_patched()
 # the patch must be in place before the agent imports resolve.
 from agents._header_forwarding import (  # noqa: E402
     HeaderForwardingHTTPMiddleware,
+    install_executor_contextvar_propagation,
     install_global_httpx_hook,
 )
 
 install_global_httpx_hook()
+# Strands dispatches SYNC tools (e.g. the declarative gen-ui
+# `generate_a2ui` tool, which makes a secondary OpenAI call) onto the
+# default ThreadPoolExecutor via loop.run_in_executor(...), which does NOT
+# propagate ContextVars to the worker thread. Without this, the
+# forwarded-header ContextVar set on the inbound request task is empty by
+# the time the secondary call's outbound httpx hook fires, and aimock
+# can't match the right fixture for the request.
+install_executor_contextvar_propagation()
 
 import uvicorn  # noqa: E402  (kept after patch for consistent import-ordering policy)
 from dotenv import load_dotenv  # noqa: E402

--- a/showcase/integrations/strands/src/agents/_header_forwarding.py
+++ b/showcase/integrations/strands/src/agents/_header_forwarding.py
@@ -369,3 +369,60 @@ def install_global_httpx_hook() -> None:
     httpx.Client.__init__ = _patched_sync_init
     httpx.AsyncClient.__init__ = _patched_async_init
     _GLOBAL_HTTPX_PATCHED = True
+
+
+# Module-scope sentinel preventing repeated executor patching.
+_EXECUTOR_CTXVAR_PATCHED = False
+
+
+def install_executor_contextvar_propagation() -> None:
+    """Patch ``asyncio.events.AbstractEventLoop.run_in_executor`` so the
+    parent task's ContextVars are propagated into the executor thread.
+
+    Why this exists
+    ---------------
+    Frameworks that dispatch a SYNC callable (e.g. strands running a sync
+    ``@tool``, or a hand-rolled secondary LLM call) onto the default
+    thread pool via ``loop.run_in_executor(None, functools.partial(...))``
+    lose the caller's context: the stock ``run_in_executor`` does NOT copy
+    the caller's :pep:`567` context to the worker thread — so the
+    :class:`HeaderForwardingHTTPMiddleware` ContextVar (set on the inbound
+    request task) is empty inside the executor, and our outbound httpx
+    hook sees no headers to forward.
+
+    ``asyncio.to_thread`` (Python 3.9+) does copy context the right way;
+    this patch makes plain ``run_in_executor`` behave the same. It only
+    affects functions submitted via ``run_in_executor`` — coroutines and
+    other constructs are unaffected.
+
+    Safe to call at import time. Idempotent via a module-scope sentinel.
+    Pre-existing event-loop instances inherit the patch because
+    ``run_in_executor`` is defined on ``BaseEventLoop`` and looked up
+    per-call via normal method resolution.
+    """
+    global _EXECUTOR_CTXVAR_PATCHED
+    if _EXECUTOR_CTXVAR_PATCHED:
+        return
+
+    import asyncio.base_events as _base_events
+
+    _orig_run_in_executor = _base_events.BaseEventLoop.run_in_executor
+
+    def _patched_run_in_executor(self, executor, func, *args):
+        # Capture the CURRENT task's context at submit time, then run the
+        # submitted callable inside that context on the worker thread.
+        ctx = contextvars.copy_context()
+
+        def _ctx_wrapper(*a, **kw):
+            return ctx.run(func, *a, **kw)
+
+        # Preserve __name__/__qualname__ for nicer tracebacks where possible.
+        try:
+            _ctx_wrapper.__wrapped__ = func  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover
+            pass
+
+        return _orig_run_in_executor(self, executor, _ctx_wrapper, *args)
+
+    _base_events.BaseEventLoop.run_in_executor = _patched_run_in_executor
+    _EXECUTOR_CTXVAR_PATCHED = True

--- a/showcase/integrations/strands/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -61,7 +61,10 @@ export const POST = async (req: NextRequest) => {
     return await handleRequest(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
-    console.error(`[copilotkit-beautiful-chat/route] ERROR: ${e.message}`, e.stack);
+    console.error(
+      `[copilotkit-beautiful-chat/route] ERROR: ${e.message}`,
+      e.stack,
+    );
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 },

--- a/showcase/integrations/strands/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -1,0 +1,70 @@
+// Dedicated runtime for the Beautiful Chat flagship showcase cell (Strands).
+//
+// Beautiful Chat exercises A2UI (dynamic + fixed schema) and Open
+// Generative UI. The shared Strands backend (agent_server.py) hosts a
+// single Strands Agent instance on "/", so the cell routes there; the
+// flagship behavior comes from the runtime flags below plus the frontend's
+// per-cell registrations.
+//
+// Isolated on its own endpoint (mirroring beautiful-chat in the canonical)
+// because the `openGenerativeUI` / `a2ui` runtime flags set global state on
+// the probe response that would otherwise leak into the other cells sharing
+// the default `/api/copilotkit` runtime.
+//
+// Mirrors showcase/integrations/pydantic-ai/src/app/api/copilotkit-beautiful-chat/route.ts.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+function createAgent() {
+  return new HttpAgent({ url: `${AGENT_URL}/` });
+}
+
+// The beautiful-chat page resolves <CopilotKit agent="beautiful-chat">
+// here; internal components (headless-chat, example-canvas) also call
+// `useAgent()` with no args, which defaults to agentId "default". Alias
+// default to the same backend so those hooks resolve.
+const beautifulChatAgent = createAgent();
+const agents = {
+  "beautiful-chat": beautifulChatAgent,
+  default: beautifulChatAgent,
+};
+
+const runtime = new CopilotRuntime({
+  // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
+  agents,
+  openGenerativeUI: true,
+  a2ui: {
+    // The targeted Strands agent ("/") already registers the `generate_a2ui`
+    // tool itself (build_showcase_agent in src/agents/agent.py), so the
+    // runtime must NOT inject a second copy — that would double-bind the
+    // render tool. Matches pydantic-ai's beautiful-chat (this file's mirror
+    // source).
+    injectA2UITool: false,
+  },
+});
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-beautiful-chat",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime,
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    console.error(`[copilotkit-beautiful-chat/route] ERROR: ${e.message}`, e.stack);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/integrations/strands/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -1,0 +1,53 @@
+// Dedicated runtime for the declarative-hashbrown demo (Strands).
+//
+// The shared Strands backend (agent_server.py) hosts a single Strands Agent
+// instance. For the declarative-hashbrown demo we need the LLM to emit a
+// strict hashbrown JSON envelope (see src/agents/byoc_hashbrown.py for the
+// canonical prompt). This route currently proxies to the shared backend
+// agent at "/"; backend prompt specialization for this demo is tracked
+// separately and not wired through this route yet.
+//
+// The demo folder + route + agent slug were renamed from `byoc-hashbrown` to
+// the canonical `declarative-hashbrown` surface; the page mounts
+// <CopilotKit agent="declarative-hashbrown-demo">.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+function createAgent() {
+  return new HttpAgent({ url: `${AGENT_URL}/` });
+}
+
+const declarativeHashbrownAgent = createAgent();
+const agents = {
+  "declarative-hashbrown-demo": declarativeHashbrownAgent,
+  default: declarativeHashbrownAgent,
+};
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-declarative-hashbrown",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime: new CopilotRuntime({
+        // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
+        agents,
+      }),
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    console.error(`[copilotkit-declarative-hashbrown/route] ERROR: ${e.message}`, e.stack);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/integrations/strands/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -44,7 +44,10 @@ export const POST = async (req: NextRequest) => {
     return await handleRequest(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
-    console.error(`[copilotkit-declarative-hashbrown/route] ERROR: ${e.message}`, e.stack);
+    console.error(
+      `[copilotkit-declarative-hashbrown/route] ERROR: ${e.message}`,
+      e.stack,
+    );
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 },

--- a/showcase/integrations/strands/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -41,7 +41,10 @@ export const POST = async (req: NextRequest) => {
     return await handleRequest(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
-    console.error(`[copilotkit-declarative-json-render/route] ERROR: ${e.message}`, e.stack);
+    console.error(
+      `[copilotkit-declarative-json-render/route] ERROR: ${e.message}`,
+      e.stack,
+    );
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 },

--- a/showcase/integrations/strands/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -1,0 +1,50 @@
+// Dedicated runtime for the declarative-json-render demo (Strands).
+//
+// The demo page renders the agent's JSON output into a frontend-owned
+// component catalog via @json-render/react. The shared Strands backend
+// (agent_server.py) hosts a single Strands Agent instance on "/"; the
+// json-render envelope shape is driven by src/agents/byoc_json_render.py. The
+// demo folder + route surface were renamed from `byoc-json-render` to the
+// canonical `declarative-json-render`; the agent ID retains its legacy
+// `byoc_json_render` name.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import { HttpAgent } from "@ag-ui/client";
+
+const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
+
+function createAgent() {
+  return new HttpAgent({ url: `${AGENT_URL}/` });
+}
+
+const byocJsonRenderAgent = createAgent();
+const agents = {
+  byoc_json_render: byocJsonRenderAgent,
+  default: byocJsonRenderAgent,
+};
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      endpoint: "/api/copilotkit-declarative-json-render",
+      serviceAdapter: new ExperimentalEmptyAdapter(),
+      runtime: new CopilotRuntime({
+        // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
+        agents,
+      }),
+    });
+    return await handleRequest(req);
+  } catch (error: unknown) {
+    const e = error as { message?: string; stack?: string };
+    console.error(`[copilotkit-declarative-json-render/route] ERROR: ${e.message}`, e.stack);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 },
+    );
+  }
+};

--- a/showcase/shell-dashboard/src/lib/__tests__/baseline-types.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/baseline-types.test.ts
@@ -148,8 +148,8 @@ describe("FEATURE_CATEGORIES", () => {
 /*  BASELINE_PARTNERS                                                  */
 /* ------------------------------------------------------------------ */
 describe("BASELINE_PARTNERS", () => {
-  it("has exactly 26 partners", () => {
-    expect(BASELINE_PARTNERS).toHaveLength(26);
+  it("has exactly 25 partners", () => {
+    expect(BASELINE_PARTNERS).toHaveLength(25);
   });
 
   it("each partner has name and slug", () => {
@@ -164,6 +164,18 @@ describe("BASELINE_PARTNERS", () => {
   it("slugs are unique", () => {
     const slugs = BASELINE_PARTNERS.map((p) => p.slug);
     expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  // Fix C: ms-agent-harness-dotnet is deployed but NOT probe-wired (excluded
+  // from EVERY probe — d5/d6/e2e-smoke/e2e-demos/smoke/aimock-wiring). Rendering
+  // its column would produce cells with no fresh probe data → perpetual stale
+  // red in both the Baseline and Live-status dimensions. RENDERING must stay
+  // consistent with PROBING: an unprobed service contributes no rendered cells.
+  // Do NOT re-add it here until it is fully probe-wired (deploy + aimock
+  // fixtures + probe inclusion + the ms-agent-dotnet AsyncLocal fix).
+  it("does not render the unprobed ms-agent-harness-dotnet partner column", () => {
+    const slugs = BASELINE_PARTNERS.map((p) => p.slug);
+    expect(slugs).not.toContain("ms-agent-harness-dotnet");
   });
 });
 

--- a/showcase/shell-dashboard/src/lib/baseline-types.ts
+++ b/showcase/shell-dashboard/src/lib/baseline-types.ts
@@ -269,7 +269,14 @@ export const BASELINE_PARTNERS: readonly { name: string; slug: string }[] = [
   { name: "Google ADK", slug: "google-adk" },
   { name: "MS Agent Framework (Python)", slug: "ms-agent-python" },
   { name: "MS Agent Framework (.NET)", slug: "ms-agent-dotnet" },
-  { name: "MS Agent Harness (.NET)", slug: "ms-agent-harness-dotnet" },
+  // ms-agent-harness-dotnet is intentionally NOT rendered. It is deployed but
+  // NOT probe-wired: it is excluded from EVERY harness probe (d5, d6, e2e-smoke,
+  // e2e-demos, smoke, aimock-wiring) because it has no aimock fixtures and shares
+  // the ms-agent-dotnet AsyncLocal bug. Rendering its column would produce cells
+  // with no fresh probe data → perpetual stale red in both the Baseline and
+  // Live-status dimensions. RENDERING must stay consistent with PROBING. Re-add
+  // this entry (and the sort-order.ts slot) only once it is fully probe-wired:
+  // deploy + aimock fixtures + inclusion in the probe configs + the AsyncLocal fix.
   { name: "Strands", slug: "strands" },
   { name: "Mastra", slug: "mastra" },
   { name: "CrewAI", slug: "crewai-crews" },

--- a/showcase/shell-dashboard/src/lib/sort-order.ts
+++ b/showcase/shell-dashboard/src/lib/sort-order.ts
@@ -14,6 +14,10 @@ export const sortOrder: Record<string, number> = {
   "maf-python": 5,
   "ms-agent-dotnet": 6,
   "maf-dotnet": 6,
+  // ms-agent-harness-dotnet is NOT a rendered partner column (deployed but not
+  // probe-wired — see the note in baseline-types.ts BASELINE_PARTNERS). The 6.5
+  // slot is retained so the column sorts correctly if/when it is fully
+  // probe-wired and re-added to BASELINE_PARTNERS.
   "ms-agent-harness-dotnet": 6.5,
   strands: 7,
   mastra: 8,


### PR DESCRIPTION
## Summary
Greens the staging d5/d6 showcase dashboard, which was red across ~450 cells. Root causes were a small set of genuine code/CI bugs (not a single regression — the 06-01/06-06 flap edges were a harness error-banner detector turning on + D5 starting to run the already-broken D6 pill set):

- **ASSET-404 (multimodal):** CI checked out Git LFS files as pointer stubs (`lfs:false` + no `git lfs pull`), so images served 130-byte pointers instead of real assets. Now pulls LFS during build.
- **ROUTE-404 (beautiful-chat / declarative-hashbrown / declarative-json-render):** 5 backends shipped the demo pages but no per-pill API route → 404. Routes added (mirrored from same-language siblings; injectA2UITool set per whether the backend already owns the tool).
- **Gen-UI header forwarding:** the secondary `generate_a2ui` LLM call dropped `x-aimock-context` — in Python because it runs in a thread-pool executor that doesn't propagate the ContextVar (ported ag2's `install_executor_contextvar_propagation` to agno/ms-agent-python/pydantic-ai/strands), and in .NET because the AG-UI SSE pump runs on a non-inheriting ExecutionContext (moved AsyncLocal → HttpContext.Items, removed a racing finally-wipe). pydantic-ai additionally sent a system-only prompt (StateDeps.copilotkit was always None → now reads the real conversation). mastra's gen-a2ui threw AI_UnsupportedModelVersionError (ai v4 vs @ai-sdk/openai v2 → bumped ai to v5).
- **Harness measurement:** the fleet worker ignored the YAML `timeout_ms` (used a hardcoded 10-min default → slow backends false-aborted); now conveyed. Stopped rendering `ms-agent-harness-dotnet`, which was flipped deployed:true but excluded from all probes → perpetual stale red.

Showcase-only; no package releases.

## Test plan
- [ ] CI rebuilds `:latest` images with LFS assets; staging redeploys
- [ ] PB re-pivot: multimodal / beautiful-chat / declarative-* / gen-ui cells green across backends
- [ ] aimock journal: secondary gen-ui calls carry `x-aimock-context` (no ctx-absent 503s on real-pill traffic)
- [ ] ms-agent-dotnet d5 no longer abort-cascades

## Deferred to follow-ups (out of this PR's subject)
- strands + spring-ai declarative-hashbrown/json-render need backend prompt specialization (separate PR)
- pre-existing bucket-(c)/(d): diag-hop labeling (reverts with the temporary x-diag-probe), harness deploy-churn/total-invariant accounting, .NET secondary-caller error-mapping, forwarding-shim hardening, baseline-only stale-render partners