### PR TITLE
fix(showcase): flap-band — cold-start retry + honest fleet/dashboard surface-state

### DIFF
--- a/showcase/harness/src/fleet/contracts.test.ts
+++ b/showcase/harness/src/fleet/contracts.test.ts
@@ -15,10 +15,12 @@ import {
   terminalJobStatus,
   FLEET_COMM_ERROR_SIGNAL_KEY,
   WORKERS_COLLECTION,
-  type PoolCommError,
-  type ServiceJobResult,
-  type WorkerCapacity,
-  type FleetStatusRow,
+} from "./contracts.js";
+import type {
+  PoolCommError,
+  ServiceJobResult,
+  WorkerCapacity,
+  FleetStatusRow,
 } from "./contracts.js";
 
 /**
@@ -64,13 +66,14 @@ const SAMPLE_COMM_ERROR: PoolCommError = {
 };
 
 describe("PoolCommError taxonomy (REQ-B)", () => {
-  it("enumerates the five comm-error kinds", () => {
+  it("enumerates the six comm-error kinds", () => {
     expect(POOL_COMM_ERROR_KINDS).toEqual([
       "worker-unreachable",
       "claim-comm-failure",
       "worker-protocol-timeout",
       "worker-crashed-mid-job",
       "worker-protocol-violation",
+      "worker-reclaimed-pending",
     ]);
   });
 

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -244,6 +244,21 @@ export const POOL_COMM_ERROR_KINDS = [
   "worker-crashed-mid-job",
   /** A report arrived but failed schema/shape validation (protocol mismatch). */
   "worker-protocol-violation",
+  /**
+   * A lease lapsed on a claimed/running row and the sweeper RE-QUEUED the job
+   * (flipped it back to `pending`). The sweep boundary CANNOT tell a real
+   * worker crash apart from an expected platform teardown (Railway scale-down /
+   * redeploy SIGKILL with no graceful drain) — both leave an identical expired
+   * lease. But either way the job is now BACK IN FLIGHT (re-queued to pending),
+   * so this is NOT a terminal failure: the dashboard renders it as a neutral
+   * "re-queued / pending" surface (gray), never the red "crashed/unreachable"
+   * overlay. A genuine pool outage where no worker can pick the job up keeps
+   * re-surfacing this kind and the cell stays gray (no green) — the honest
+   * signal — instead of flapping red. The worker's OWN self-monitor still emits
+   * `worker-crashed-mid-job` for an in-driver pool-infra crash it observed
+   * directly (that one IS a known crash and stays red).
+   */
+  "worker-reclaimed-pending",
 ] as const;
 
 /** A single pool communication-failure kind. */

--- a/showcase/harness/src/fleet/control-plane/control-plane.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.ts
@@ -212,6 +212,13 @@ export function buildJobProducer(deps: {
    * Omit to keep the legacy log-only behaviour.
    */
   onSweepCommErrors?: SweepCommErrorSink;
+  /**
+   * Pre-dispatch health warm-up (flap-band #72). When supplied, each tick fires
+   * a fire-and-forget `GET <backendUrl>/health` per enumerated spec before
+   * enqueueing, waking cold containers ahead of the pills that probe them. Omit
+   * to keep the legacy no-warm behaviour.
+   */
+  warmHealth?: Parameters<typeof createJobProducer>[0]["warmHealth"];
 }): JobProducer {
   return createJobProducer({
     queue: deps.queue,
@@ -220,6 +227,7 @@ export function buildJobProducer(deps: {
     ...(deps.onSweepCommErrors
       ? { onSweepCommErrors: deps.onSweepCommErrors }
       : {}),
+    ...(deps.warmHealth ? { warmHealth: deps.warmHealth } : {}),
   });
 }
 

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -2,9 +2,8 @@ import { describe, it, expect, vi } from "vitest";
 import {
   createJobProducer,
   DEFAULT_SWEEP_INTERVAL_MS,
-  type JobProducer,
-  type ServiceJobSpec,
 } from "./job-producer.js";
+import type { JobProducer, ServiceJobSpec } from "./job-producer.js";
 import type {
   EnqueueJobInput,
   FleetQueueClient,
@@ -468,6 +467,122 @@ describe("job-producer — sweep cadence", () => {
     t = DEFAULT_SWEEP_INTERVAL_MS; // window reached
     await producer.tick(); // sweep
     expect(queue.sweepCalls).toEqual([0, DEFAULT_SWEEP_INTERVAL_MS]);
+  });
+});
+
+describe("job-producer — #72 pre-dispatch health warm-up", () => {
+  /** A fetch spy that records each warm URL and resolves a 200. */
+  function makeFetchSpy(): {
+    fetchImpl: typeof fetch;
+    calls: { url: string; method: string | undefined }[];
+  } {
+    const calls: { url: string; method: string | undefined }[] = [];
+    const fetchImpl = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      calls.push({ url: String(input), method: init?.method });
+      return new Response(null, { status: 200 });
+    }) as typeof fetch;
+    return { fetchImpl, calls };
+  }
+
+  it("fires a health GET for every enumerated spec BEFORE dispatch", async () => {
+    const { fetchImpl, calls } = makeFetchSpy();
+    // Track enqueue ordering: the warm must fire before any enqueue. We assert
+    // this by capturing the warm-call count observed at first enqueue time.
+    let warmCountAtFirstEnqueue = -1;
+    const queue = makeFakeQueue({
+      enqueueImpl: async (input) => {
+        if (warmCountAtFirstEnqueue === -1) {
+          warmCountAtFirstEnqueue = calls.length;
+        }
+        return {
+          id: `job-${input.payload.serviceSlug}`,
+          probe_key: input.payload.probeKey,
+          status: "pending",
+          claimed_by: "",
+          lease_expires_at: null,
+          version: 1,
+        };
+      },
+    });
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["alpha", "beta"]),
+      logger: SILENT_LOGGER,
+      warmHealth: { fetchImpl },
+    });
+    producer.start();
+    await producer.tick();
+
+    // One warm GET per enumerated spec.
+    expect(calls).toHaveLength(2);
+    for (const call of calls) {
+      expect(call.method).toBe("GET");
+    }
+    // deriveHealthUrl appends /health to the spec's backendUrl base.
+    const urls = calls.map((c) => c.url).sort();
+    expect(urls).toEqual([
+      "https://alpha.example.com/health",
+      "https://beta.example.com/health",
+    ]);
+    // Both warm GETs fired BEFORE the first job was enqueued.
+    expect(warmCountAtFirstEnqueue).toBe(2);
+  });
+
+  it("does NOT warm when no warmHealth config is supplied (legacy behavior)", async () => {
+    const { fetchImpl, calls } = makeFetchSpy();
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["alpha"]),
+      logger: SILENT_LOGGER,
+      // no warmHealth
+    });
+    producer.start();
+    await producer.tick();
+    // fetchImpl was never wired, so nothing was warmed.
+    expect(calls).toHaveLength(0);
+    void fetchImpl;
+  });
+
+  it("a rejecting warm fetch never aborts job production (best-effort)", async () => {
+    const failingFetch = (async (): Promise<Response> => {
+      throw new Error("ECONNREFUSED (cold container still booting)");
+    }) as typeof fetch;
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["alpha", "beta"]),
+      logger: SILENT_LOGGER,
+      warmHealth: { fetchImpl: failingFetch },
+    });
+    producer.start();
+    const result = await producer.tick();
+    // Production proceeded despite every warm GET rejecting.
+    expect(result.enqueued).toBe(2);
+  });
+
+  it("skips specs with no backendUrl (no bogus warm GET)", async () => {
+    const { fetchImpl, calls } = makeFetchSpy();
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => [
+        {
+          probeKey: "d6:nourl",
+          serviceSlug: "nourl",
+          driverKind: "e2e_d6",
+          // no driverInputs.backendUrl
+        },
+      ],
+      logger: SILENT_LOGGER,
+      warmHealth: { fetchImpl },
+    });
+    producer.start();
+    await producer.tick();
+    expect(calls).toHaveLength(0);
   });
 });
 

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -47,6 +47,7 @@ import type {
   ServiceJobMeta,
   ServiceJobPayload,
 } from "../contracts.js";
+import { deriveHealthUrl } from "../../probes/liveness.js";
 
 /**
  * Sink the producer hands its lease-sweep comm errors to (REQ-B). `sweepExpired`
@@ -63,6 +64,33 @@ import type {
 export type SweepCommErrorSink = (
   commErrors: PoolCommError[],
 ) => void | Promise<void>;
+
+/**
+ * Pre-dispatch HEALTH WARM-UP config (flap-band #72). Before a run's jobs are
+ * enqueued, the producer fires a fire-and-forget `GET <backendUrl>/health`
+ * against every enumerated backend so a cold (scaled-to-zero) container starts
+ * waking BEFORE a pill actually probes it — removing most `current=0`
+ * zero-output timeouts where the first pill paid the cold-start latency.
+ *
+ * This is NOT an LLM call and NOT an agent turn — it is a cheap unauthenticated
+ * liveness GET with a short timeout, fully best-effort: a warm failure (cold
+ * container still booting, network blip) is logged at debug and never blocks or
+ * fails job production. Injected so the producer stays dependency-free and the
+ * warm loop is unit-testable with a fake `fetch`.
+ */
+export interface WarmHealthConfig {
+  /**
+   * The `fetch` impl used for the warm GETs. Injected (production wires
+   * `globalThis.fetch`); tests pass a spy. When omitted, warm-up is disabled.
+   */
+  fetchImpl: typeof fetch;
+  /**
+   * Per-request timeout in ms for each warm GET. The warm must never hang the
+   * tick, so each GET is aborted after this window. Default
+   * `DEFAULT_WARM_TIMEOUT_MS`.
+   */
+  timeoutMs?: number;
+}
 
 /**
  * The per-service unit the enumerator yields for a run. This is the
@@ -171,6 +199,31 @@ export interface JobProducerOptions {
    * abort job production.
    */
   onSweepCommErrors?: SweepCommErrorSink;
+  /**
+   * Pre-dispatch health warm-up (flap-band #72). When supplied, each tick fires
+   * a fire-and-forget `GET <backendUrl>/health` per enumerated spec right after
+   * enumeration and BEFORE enqueueing, so cold containers start waking before
+   * pills probe them. When omitted, no warm-up runs (the legacy behavior).
+   */
+  warmHealth?: WarmHealthConfig;
+}
+
+/** Default per-request timeout for a #72 health warm-up GET. */
+export const DEFAULT_WARM_TIMEOUT_MS = 3_000;
+
+/**
+ * Read a spec's backend base URL from its serialized `driverInputs.backendUrl`
+ * (the catalog enumerator sets this to the service's reachable base). Returns
+ * undefined when absent / not a string so the warm loop skips that spec rather
+ * than firing at a bogus URL.
+ */
+function backendUrlFromSpec(spec: ServiceJobSpec): string | undefined {
+  const inputs = spec.driverInputs;
+  if (inputs === undefined || inputs === null || typeof inputs !== "object") {
+    return undefined;
+  }
+  const url = (inputs as Record<string, unknown>).backendUrl;
+  return typeof url === "string" && url.length > 0 ? url : undefined;
 }
 
 /**
@@ -202,6 +255,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
   const sweepIntervalMs = opts.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS;
   const runIdFactory = opts.runIdFactory ?? defaultRunIdFactory();
   const onSweepCommErrors = opts.onSweepCommErrors;
+  const warmHealth = opts.warmHealth;
 
   let running = false;
   let stopped = false;
@@ -284,6 +338,58 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     }
   }
 
+  /**
+   * Fire-and-forget pre-dispatch health warm-up (flap-band #72). For each
+   * enumerated spec with a backend URL, fire a `GET <backendUrl>/health` so a
+   * cold container starts waking before its pill probes it. Best-effort: every
+   * GET has a short abort timeout and its rejection is swallowed (logged at
+   * debug) — a warm failure must NEVER block or fail job production. Returns the
+   * count of warm GETs fired (for the tick log / tests). The GETs are NOT
+   * awaited to completion (we await the dispatch, not the responses) so a slow
+   * cold container never delays enqueueing the run.
+   */
+  function warmEnumeratedBackends(specs: ServiceJobSpec[]): number {
+    if (!warmHealth) return 0;
+    const { fetchImpl } = warmHealth;
+    const timeoutMs = warmHealth.timeoutMs ?? DEFAULT_WARM_TIMEOUT_MS;
+    let fired = 0;
+    for (const spec of specs) {
+      const backendUrl = backendUrlFromSpec(spec);
+      if (backendUrl === undefined) continue;
+      const healthUrl = deriveHealthUrl(backendUrl);
+      if (healthUrl === "") continue;
+      fired += 1;
+      // Fire-and-forget: an AbortController bounds each GET so a hung cold
+      // container can't leak a pending request across ticks. The whole chain is
+      // swallowed — warm-up is a latency optimization, never a correctness gate.
+      const ac = new AbortController();
+      const timer = setTimeout(() => ac.abort(), timeoutMs);
+      void fetchImpl(healthUrl, { method: "GET", signal: ac.signal })
+        .then(
+          () => {
+            logger.debug("fleet.producer.warm-ok", {
+              serviceSlug: spec.serviceSlug,
+              healthUrl,
+            });
+          },
+          (err: unknown) => {
+            // A cold container still booting / a network blip is EXPECTED here —
+            // the warm is precisely for the not-yet-ready case. Debug-level only.
+            logger.debug("fleet.producer.warm-failed", {
+              serviceSlug: spec.serviceSlug,
+              healthUrl,
+              err: err instanceof Error ? err.message : String(err),
+            });
+          },
+        )
+        .finally(() => clearTimeout(timer));
+    }
+    if (fired > 0) {
+      logger.info("fleet.producer.warmed", { warmed: fired });
+    }
+    return fired;
+  }
+
   return {
     start() {
       if (stopped) {
@@ -359,6 +465,13 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
         triggered,
         services: specs.length,
       });
+
+      // #72 PRE-DISPATCH WARM-UP: fire fire-and-forget health GETs at every
+      // enumerated backend BEFORE enqueueing, so cold containers start waking
+      // ahead of the pills that probe them. Best-effort and non-blocking — the
+      // GETs are dispatched (not awaited), so a slow cold container never delays
+      // the run's enqueue.
+      warmEnumeratedBackends(specs);
 
       let enqueued = 0;
       let enqueueFailures = 0;

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -827,7 +827,7 @@ describe("FleetQueueClient.report", () => {
 });
 
 describe("FleetQueueClient.sweepExpired", () => {
-  it("reclaims expired leases and emits worker-crashed-mid-job comm errors", async () => {
+  it("reclaims expired leases and emits worker-reclaimed-pending comm errors (flap-band #70)", async () => {
     const now = Date.parse("2026-06-04T00:05:00.000Z");
     // One running row with an EXPIRED lease (crashed worker), one with a live
     // lease that must NOT be swept.
@@ -871,7 +871,12 @@ describe("FleetQueueClient.sweepExpired", () => {
 
     expect(sweep.reclaimed).toBe(1);
     expect(sweep.commErrors).toHaveLength(1);
-    expect(sweep.commErrors[0].kind).toBe("worker-crashed-mid-job");
+    // flap-band #70: the sweep boundary cannot tell a real crash from an
+    // expected platform teardown (both leave an identical expired lease), and
+    // the job is RE-QUEUED to pending (back in flight), so the sweep emits the
+    // NEUTRAL `worker-reclaimed-pending` kind — NOT `worker-crashed-mid-job`,
+    // which would flap the service red on every routine teardown.
+    expect(sweep.commErrors[0].kind).toBe("worker-reclaimed-pending");
     expect(sweep.commErrors[0].jobId).toBe("j1");
     expect(sweep.commErrors[0].workerId).toBe("worker-dead");
     expect(releaseJob).toHaveBeenCalledWith("j1", "worker-dead", "pending");

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -45,17 +45,17 @@
 import type { Logger } from "../types/index.js";
 import type { PbClient } from "../storage/pb-client.js";
 import type { JobClaimClient, JobView } from "./job-claim.js";
-import {
-  terminalJobStatus,
-  type ClaimedJob,
-  type EnqueueJobInput,
-  type FleetQueueClient,
-  type JobLease,
-  type PoolCommError,
-  type ReportJobInput,
-  type ServiceJobMeta,
-  type ServiceJobPayload,
-  type SweepResult,
+import { terminalJobStatus } from "./contracts.js";
+import type {
+  ClaimedJob,
+  EnqueueJobInput,
+  FleetQueueClient,
+  JobLease,
+  PoolCommError,
+  ReportJobInput,
+  ServiceJobMeta,
+  ServiceJobPayload,
+  SweepResult,
 } from "./contracts.js";
 
 /**
@@ -510,9 +510,22 @@ export function createFleetQueueClient(
           continue;
         }
         reclaimed += 1;
+        // The sweep boundary CANNOT distinguish a real worker crash from an
+        // expected platform teardown (Railway scale-down / redeploy SIGKILL with
+        // no graceful drain) — both leave an identical expired lease on a
+        // claimed/running row. So we do NOT synthesize `worker-crashed-mid-job`
+        // here (that would flap the whole service red on every routine
+        // teardown). The job has been RE-QUEUED to pending by the releaseJob
+        // above, so it is back in flight; emit the neutral
+        // `worker-reclaimed-pending` kind, which the dashboard renders as a gray
+        // "re-queued" surface, NOT a red unreachable overlay. A genuine pool
+        // outage keeps re-surfacing this and the cell stays gray (no green) — the
+        // honest signal. (A graceful worker shutdown drains the in-flight job to
+        // a terminal report BEFORE the lease expires, so the sweep never sees it
+        // at all — see the SIGTERM drain handler in orchestrator.bootFleet.)
         commErrors.push({
-          kind: "worker-crashed-mid-job",
-          message: `lease for job ${row.id} expired (worker ${row.claimed_by || "unknown"} crashed mid-job); re-queued`,
+          kind: "worker-reclaimed-pending",
+          message: `lease for job ${row.id} expired (worker ${row.claimed_by || "unknown"} reclaimed); re-queued to pending`,
           workerId: row.claimed_by || undefined,
           jobId: row.id,
           observedAt,

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -2466,7 +2466,10 @@ export async function runControlPlane(
     logger,
   });
   // REQ-B producer-sweep leg: the producer's lease-driven `sweepExpired`
-  // synthesizes a `worker-crashed-mid-job` comm error per reclaimed job, but a
+  // synthesizes a `worker-reclaimed-pending` comm error per reclaimed job (the
+  // sweep boundary cannot tell a real crash from a routine platform teardown,
+  // so it emits the neutral re-queued kind rather than `worker-crashed-mid-job`
+  // — see queue-client.ts sweepExpired), but a
   // bare swept error carries only the `jobId`, not the `d6:<slug>` dashboard
   // key. This resolver maps each error to its aggregate key via the SAME
   // `probe_jobs` row lookup `surfaceReclaimedCommErrors` used (the job row's
@@ -2522,6 +2525,13 @@ export async function runControlPlane(
     onSweepCommErrors: async (commErrors) => {
       await controlPlaneRef?.surfaceSweepCommErrors(commErrors);
     },
+    // #72 PRE-DISPATCH WARM-UP: fire a fire-and-forget GET <backendUrl>/health
+    // at every enumerated d6 backend before its pills run, so a cold
+    // (scaled-to-zero) container starts waking ahead of the probe — removing
+    // most `current=0` zero-output cold-start timeouts. Best-effort, short
+    // timeout, no LLM cost. Only the d6 producer warms (it drives the heaviest
+    // per-pill runs); the lighter smoke/demos/deep families do not.
+    warmHealth: { fetchImpl: globalThis.fetch },
   });
   // The three non-d6 browser families each get their own producer over their
   // family enumerator. They intentionally do NOT wire `onSweepCommErrors`: the
@@ -3474,10 +3484,73 @@ export async function bootFleet(
 ): Promise<Awaited<ReturnType<typeof boot>>> {
   const config = resolveFleetRoleConfig();
   switch (config.role) {
-    case "control-plane":
-      return runControlPlane(config, opts);
-    case "worker":
-      return runWorker(config, opts);
+    case "control-plane": {
+      const controlPlane = await runControlPlane(config, opts);
+      // GRACEFUL-TEARDOWN MARKER (flap-band #70/#71-FF3): Railway sends SIGTERM
+      // (with a grace window) on redeploy / scale-down. The worker arm below
+      // already drains on signal (#70); the control-plane — which owns the
+      // producers, the result consumer, and the fleet-health timers — had NO
+      // handler, so a redeploy killed it mid-cycle: interval timers stranded,
+      // the HTTP server left open, and an in-flight aggregation abandoned.
+      // Mirror the worker arm: drain via the handle's stop() (which clears the
+      // controlPlane + scheduler intervals and closes the server) before
+      // exiting, guarded against a double-drain.
+      let cpDraining = false;
+      const drainControlPlaneAndExit = (signal: NodeJS.Signals): void => {
+        if (cpDraining) return;
+        cpDraining = true;
+        logger.info("showcase-harness.fleet.control-plane.signal-drain", {
+          signal,
+        });
+        controlPlane
+          .stop()
+          .catch((err) =>
+            logErrorWithStack(
+              logger,
+              "showcase-harness.fleet.control-plane.signal-drain-failed",
+              err,
+            ),
+          )
+          .finally(() => process.exit(0));
+      };
+      process.once("SIGTERM", () => drainControlPlaneAndExit("SIGTERM"));
+      process.once("SIGINT", () => drainControlPlaneAndExit("SIGINT"));
+      return controlPlane;
+    }
+    case "worker": {
+      const worker = await runWorker(config, opts);
+      // GRACEFUL-TEARDOWN MARKER (flap-band #70): Railway sends SIGTERM (with a
+      // grace window) on scale-down / redeploy. WITHOUT this handler the worker
+      // process dies mid-job, leaving its claimed/running row to lapse so the
+      // control-plane sweeper reclaims it as a comm error — a FALSE flap on
+      // every routine teardown. Draining here makes the in-flight job report a
+      // TERMINAL result BEFORE the lease can expire, so the sweep never sees the
+      // row at all and no false overlay is synthesized. This is THE distinction
+      // the sweep boundary cannot make on its own (an expired lease looks the
+      // same for a crash and a SIGKILL teardown) — we create the marker by
+      // converting the common SIGTERM teardown into a clean drain. A hard
+      // SIGKILL (no grace) still strands the row, but the sweep now treats that
+      // as the neutral `worker-reclaimed-pending` (re-queued), not a red crash.
+      let draining = false;
+      const drainAndExit = (signal: NodeJS.Signals): void => {
+        if (draining) return;
+        draining = true;
+        logger.info("showcase-harness.fleet.worker.signal-drain", { signal });
+        worker
+          .stop()
+          .catch((err) =>
+            logErrorWithStack(
+              logger,
+              "showcase-harness.fleet.worker.signal-drain-failed",
+              err,
+            ),
+          )
+          .finally(() => process.exit(0));
+      };
+      process.once("SIGTERM", () => drainAndExit("SIGTERM"));
+      process.once("SIGINT", () => drainAndExit("SIGINT"));
+      return worker;
+    }
     default: {
       // Exhaustiveness guard: a new HarnessRole added without a dispatch arm
       // is a compile error here, not a silent fall-through.

--- a/showcase/harness/src/probes/helpers/conversation-runner.test.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.test.ts
@@ -63,6 +63,14 @@ interface PageScript {
   // banner whose TEXT changes across polls (a re-armed new/changed error)
   // — not just its visibility.
   errorBannerValues?: Array<boolean | { visible: boolean; text?: string }>;
+  // When true, the fake exposes a `page.reload()` that RE-SEEDS the
+  // assistant-message and error-banner queues from their original scripted
+  // values — modelling a real Playwright reload tearing down and re-painting
+  // the DOM. Used by turn-1 fast-fail tests to verify a SUSTAINED real banner
+  // still fast-fails on the bounded cold-start retry's 2nd attempt (the banner
+  // re-paints fresh after the reload, so the 2nd settle re-snapshots a clean
+  // baseline and fast-fails again — #5142 stays intact across the retry).
+  reloadReplaysQueues?: boolean;
 }
 
 /**
@@ -192,6 +200,22 @@ function makePage(script: PageScript = {}): Page {
             if (inputQueue.length === 0) return "";
             if (inputQueue.length === 1) return inputQueue[0]!;
             return inputQueue.shift()!;
+          },
+        }
+      : {}),
+    // reload is only provided when the script opts in. It re-seeds the
+    // assistant-message and error-banner queues from their original scripted
+    // values so the post-reload settle replays the same scripted sequence —
+    // modelling a real DOM teardown + re-paint. Auto-user-message growth is
+    // reset too so the re-send's fillAndVerifySend sees a fresh user bubble.
+    ...(script.reloadReplaysQueues
+      ? {
+          async reload(): Promise<void> {
+            queue.length = 0;
+            queue.push(...(script.evaluateValues ?? []));
+            errorBannerQueue.length = 0;
+            errorBannerQueue.push(...(script.errorBannerValues ?? []));
+            autoUserCalls = 0;
           },
         }
       : {}),
@@ -376,6 +400,11 @@ describe("runConversation", () => {
       // (last value `true` repeats forever) → 2+ consecutive
       // differs-from-baseline polls → fast-fail under the unified debounce.
       errorBannerValues: [false, false, true],
+      // This is turn 1, so the bounded cold-start retry fires once on the
+      // fast-fail. The banner SURVIVES the reload (re-seeded queues re-paint
+      // the same fresh banner) → the 2nd attempt fast-fails again and the
+      // distinguished AssistantErroredError is re-thrown. #5142 stays intact.
+      reloadReplaysQueues: true,
       recorded,
     });
 
@@ -411,8 +440,11 @@ describe("runConversation", () => {
     expect(expected).toBeInstanceOf(AssistantErroredError);
     expect(expected).toBeInstanceOf(Error);
     expect(result.error).toBe(expected.message);
-    // The whole point: bail well before the 5000ms responseTimeout.
-    expect(elapsed).toBeLessThan(2000);
+    // The whole point: bail well before the 5000ms responseTimeout. The
+    // bounded turn-1 cold-start retry adds a SECOND fast-fail cycle, so the
+    // bound is 3000ms (two fast-fail cycles) — still far under the 5000ms
+    // settle timeout, proving we never burned the full wall-clock.
+    expect(elapsed).toBeLessThan(3000);
     // Failed turn's duration is not recorded.
     expect(result.turn_durations_ms).toHaveLength(0);
     // Real multi-poll settle loop; explicit timeout for CI headroom.
@@ -472,6 +504,11 @@ describe("runConversation", () => {
         { visible: true, text: "Old error" },
         { visible: true, text: "New error" },
       ],
+      // Turn 1 → the bounded cold-start retry fires on the fast-fail. The
+      // re-seeded queues replay the same baseline-stale-then-changed sequence,
+      // so the 2nd attempt re-arms and fast-fails on "New error" again. #5142
+      // (and the baseline-text re-arm fix) stay intact across the retry.
+      reloadReplaysQueues: true,
       recorded,
     });
 
@@ -492,8 +529,10 @@ describe("runConversation", () => {
     expect(result.error).toContain("copilot-error-banner visible");
     expect(result.error).toContain("New error");
     expect(result.error!.toLowerCase()).not.toContain("timeout");
-    // Bailed well before the 5000ms responseTimeout — the whole point.
-    expect(elapsed).toBeLessThan(2000);
+    // Bailed well before the 5000ms responseTimeout — the whole point. The
+    // bounded cold-start retry adds a 2nd fast-fail cycle, so the bound is
+    // 3000ms (two cycles), still far under the 5000ms settle timeout.
+    expect(elapsed).toBeLessThan(3000);
     expect(result.turn_durations_ms).toHaveLength(0);
     // Real multi-poll settle loop; explicit timeout for CI headroom.
   }, 20_000);
@@ -573,6 +612,9 @@ describe("runConversation", () => {
         { visible: true, text: "New" },
         { visible: true, text: "New" },
       ],
+      // Turn 1 → the bounded cold-start retry fires; re-seeded queues replay
+      // the same stable-new-error sequence so the 2nd attempt fast-fails again.
+      reloadReplaysQueues: true,
       recorded,
     });
 
@@ -591,9 +633,9 @@ describe("runConversation", () => {
     expect(result.error).toContain("copilot-error-banner visible");
     expect(result.error).toContain("New");
     expect(result.error!.toLowerCase()).not.toContain("timeout");
-    // Debounce adds ~1 poll of latency at most — still far under the 5000ms
-    // responseTimeout.
-    expect(elapsed).toBeLessThan(2000);
+    // Debounce adds ~1 poll of latency; the bounded cold-start retry adds a
+    // 2nd fast-fail cycle — still far under the 5000ms responseTimeout.
+    expect(elapsed).toBeLessThan(3000);
     expect(result.turn_durations_ms).toHaveLength(0);
     // Real multi-poll settle loop; explicit timeout for CI headroom.
   }, 20_000);
@@ -754,6 +796,285 @@ describe("runConversation", () => {
     // Real multi-poll settle loop; explicit timeout for CI headroom.
   }, 20_000);
 
+  it("cold-start retry: a turn-1 banner that clears after page.reload() RECOVERS (turn succeeds)", async () => {
+    // Flap-band fix #71. A showcase cold-start can paint a transient error
+    // banner on the FIRST turn (the agent backend / runtime is still warming
+    // up) that clears on its own a beat later. PR #5142's fast-fail correctly
+    // bails on a sustained banner, but on turn 1 a single bounded retry —
+    // reload the page, re-send the same message — recovers the would-be flap
+    // without masking a real failure. This test models attempt 1 fast-failing
+    // on a fresh sustained banner, then `page.reload()` flips the page into a
+    // clean state where the assistant responds and the turn SETTLES.
+    let reloaded = false;
+    const recorded = { fills: [] as string[], presses: [] as string[] };
+    let userCalls = 0;
+    let bannerReadsBeforeReload = 0;
+    let assistantCallsAfterReload = 0;
+    const page: Page & { reload: () => Promise<void> } = {
+      async waitForSelector() {},
+      async fill(_selector, value) {
+        recorded.fills.push(value);
+      },
+      async press(_selector, key) {
+        recorded.presses.push(key);
+      },
+      async reload() {
+        reloaded = true;
+        // Reset send-verification baseline so the re-send's fillAndVerifySend
+        // observes fresh user-message growth.
+        userCalls = 0;
+      },
+      async evaluate<R>(fn: () => R): Promise<R> {
+        const body = fn.toString();
+        if (body.includes("copilot-error-banner")) {
+          // After reload: banner gone → attempt 2 settles cleanly.
+          if (reloaded) return { visible: false } as never;
+          // Before reload: NOT visible on the baseline snapshot (first read),
+          // then a FRESH banner appears and STAYS (differs-from-baseline on 2+
+          // consecutive polls) → AssistantErroredError fast-fail on attempt 1.
+          bannerReadsBeforeReload++;
+          if (bannerReadsBeforeReload <= 1) return { visible: false } as never;
+          return {
+            visible: true,
+            text: "cold start: backend warming up",
+          } as never;
+        }
+        if (body.includes("copilot-user-message")) {
+          // Monotonic growth so fillAndVerifySend sees the user bubble.
+          return userCalls++ as never;
+        }
+        // Assistant-message count. Before reload: pinned at baseline 0 (no
+        // response) so attempt 1 cannot settle and the fresh banner fast-fails.
+        // After reload: grows to 1 and freezes → settles.
+        if (!reloaded) return 0 as never;
+        assistantCallsAfterReload++;
+        return (assistantCallsAfterReload > 1 ? 1 : 0) as never;
+      },
+    };
+
+    const result = await runConversation(
+      page,
+      [{ input: "hello cold start", responseTimeoutMs: 5000 }],
+      { assistantSettleMs: 50 },
+    );
+
+    // The retry recovered the flap: the turn SUCCEEDED.
+    expect(reloaded).toBe(true);
+    expect(result.turns_completed).toBe(1);
+    expect(result.total_turns).toBe(1);
+    expect(result.failure_turn).toBeUndefined();
+    expect(result.error).toBeUndefined();
+    // Message was re-sent after the reload (filled twice: original + retry).
+    expect(recorded.fills).toEqual(["hello cold start", "hello cold start"]);
+    // Real multi-poll settle loop; explicit timeout for CI headroom.
+  }, 20_000);
+
+  it("cold-start retry does NOT mask a real failure: a banner that SURVIVES the reload still fast-fails", async () => {
+    // The bound that keeps #5142 intact: the cold-start retry fires AT MOST
+    // ONCE, only on turn 1, only for an AssistantErroredError. If the error
+    // banner is a REAL sustained failure that survives the page.reload() and
+    // re-send, the second waitForAssistantSettled fast-fails again and the
+    // runner re-throws — the turn fails with the distinguished
+    // AssistantErroredError, NOT a generic timeout, and NOT a false success.
+    let reloadCount = 0;
+    const recorded = { fills: [] as string[], presses: [] as string[] };
+    let userCalls = 0;
+    // Per-attempt banner-read counter, reset on each reload. Each
+    // waitForAssistantSettled invocation snapshots the banner ONCE at its
+    // baseline (first read) — that must be NOT visible so the subsequent
+    // sustained banner reads as a differs-from-baseline NEW error and
+    // fast-fails. A genuine failure does this on BOTH attempts.
+    let bannerReadsThisAttempt = 0;
+    const page: Page & { reload: () => Promise<void> } = {
+      async waitForSelector() {},
+      async fill(_selector, value) {
+        recorded.fills.push(value);
+      },
+      async press(_selector, key) {
+        recorded.presses.push(key);
+      },
+      async reload() {
+        reloadCount++;
+        userCalls = 0;
+        bannerReadsThisAttempt = 0;
+      },
+      async evaluate<R>(fn: () => R): Promise<R> {
+        const body = fn.toString();
+        if (body.includes("copilot-error-banner")) {
+          // NOT visible on each attempt's baseline snapshot (first read),
+          // then a SUSTAINED banner that the reload does NOT clear — a REAL
+          // failure. Differs-from-baseline across 2+ consecutive polls →
+          // fast-fails on BOTH attempts.
+          bannerReadsThisAttempt++;
+          if (bannerReadsThisAttempt <= 1) return { visible: false } as never;
+          return { visible: true, text: "real backend failure" } as never;
+        }
+        if (body.includes("copilot-user-message")) {
+          return userCalls++ as never;
+        }
+        // Assistant never produces a response on either attempt.
+        return 0 as never;
+      },
+    };
+
+    const start = Date.now();
+    const result = await runConversation(
+      page,
+      [{ input: "still broken", responseTimeoutMs: 5000 }],
+      { assistantSettleMs: 50 },
+    );
+    const elapsed = Date.now() - start;
+
+    // The retry happened AT MOST ONCE (bounded) — and did not mask the error.
+    expect(reloadCount).toBe(1);
+    expect(result.turns_completed).toBe(0);
+    expect(result.total_turns).toBe(1);
+    expect(result.failure_turn).toBe(1);
+    // Distinguished AssistantErroredError survives the retry — NOT a timeout,
+    // NOT a false success.
+    expect(result.error).toBe(
+      new AssistantErroredError("real backend failure").message,
+    );
+    expect(result.error).toContain("copilot-error-banner visible");
+    expect(result.error!.toLowerCase()).not.toContain("timeout");
+    // Re-sent exactly once (original + one retry), proving the retry is bounded.
+    expect(recorded.fills).toEqual(["still broken", "still broken"]);
+    // Bailed via fast-fail on BOTH attempts; well under the 5000ms timeout.
+    expect(elapsed).toBeLessThan(3000);
+    expect(result.turn_durations_ms).toHaveLength(0);
+    // Real multi-poll settle loop; explicit timeout for CI headroom.
+  }, 20_000);
+
+  it("cold-start retry: a skipSend turn-1 banner FAST-FAILS without retry (the retry only fires for plain-fill turns)", async () => {
+    // Flap-band #71. The cold-start retry can ONLY recover a turn it can
+    // RE-ISSUE: a plain-fill turn (reload + re-fill + re-send). A `skipSend`
+    // turn's submission is issued entirely by `preFill` (e.g. a
+    // sample-attachment button auto-sends via the agent surface — the textarea
+    // is never touched), which a reload would wipe and the skipSend path never
+    // re-issues. Skipping the reload (the earlier fix) left a no-op retry that
+    // re-submitted nothing, could not recover, and risked false-settling
+    // against attempt 1's stale DOM. So the retry is GATED to plain-fill turns:
+    // a skipSend cold-start banner now fast-fails with `AssistantErroredError`
+    // (no retry, no reload, no false-settle) — PR #5142's fast-fail, the
+    // pre-retry behavior for skipSend, NOT a regression.
+    let reloaded = false;
+    let preFillCalls = 0;
+    let bannerReads = 0;
+    const page: Page & { reload: () => Promise<void> } = {
+      async waitForSelector() {},
+      async fill() {},
+      async press() {},
+      async reload() {
+        // Must NEVER be reached for a skipSend turn — the retry is gated off.
+        reloaded = true;
+      },
+      async evaluate<R>(fn: () => R): Promise<R> {
+        const body = fn.toString();
+        if (body.includes("copilot-error-banner")) {
+          bannerReads++;
+          // NOT visible on the baseline snapshot, then a fresh banner appears
+          // and STAYS across ≥2 consecutive polls → AssistantErroredError
+          // fast-fail. No retry follows for a skipSend turn.
+          if (bannerReads <= 1) return { visible: false } as never;
+          return {
+            visible: true,
+            text: "cold start: backend warming up",
+          } as never;
+        }
+        // Assistant never produces a response — the only exit is the fast-fail.
+        return 0 as never;
+      },
+    };
+
+    const start = Date.now();
+    const result = await runConversation(
+      page,
+      [
+        {
+          input: "skip-send sample",
+          skipSend: true,
+          responseTimeoutMs: 5000,
+          preFill: async () => {
+            preFillCalls++;
+          },
+        },
+      ],
+      { assistantSettleMs: 50 },
+    );
+    const elapsed = Date.now() - start;
+
+    // No retry: the page was never reloaded and the turn failed via fast-fail.
+    expect(reloaded).toBe(false);
+    expect(preFillCalls).toBe(1);
+    expect(result.turns_completed).toBe(0);
+    expect(result.failure_turn).toBe(1);
+    // The distinguished banner fast-fail error propagated (NOT a settle
+    // timeout, NOT a false-settle).
+    expect(result.error).toContain("copilot-error-banner visible");
+    expect(result.error).toContain("cold start: backend warming up");
+    expect(result.error!.toLowerCase()).not.toContain("timeout");
+    // A SINGLE fast-fail cycle (no second attempt) — well under the timeout.
+    expect(elapsed).toBeLessThan(3000);
+    expect(result.turn_durations_ms).toHaveLength(0);
+  }, 20_000);
+
+  it("cold-start retry shares a single turn deadline — a retried turn does NOT run ~2× the budget (FF20)", async () => {
+    // Flap-band #71/FF20. The first settle wait and the retry settle wait must
+    // share ONE turn deadline. Without it the retry gets a fresh full
+    // `turnTimeoutMs`, so a turn that fast-fails then settle-times-out on retry
+    // burns ~2× the budget. Here the banner fast-fails attempt 1, the reload
+    // succeeds, then the assistant NEVER responds so the retry settle-times-out.
+    // With the shared deadline the total stays close to ONE turnTimeoutMs.
+    const TURN_TIMEOUT = 1000;
+    let reloaded = false;
+    let bannerReads = 0;
+    let userCalls = 0;
+    const page: Page & { reload: () => Promise<void> } = {
+      async waitForSelector() {},
+      async fill() {},
+      async press() {},
+      async reload() {
+        reloaded = true;
+        bannerReads = 0;
+        userCalls = 0;
+      },
+      async evaluate<R>(fn: () => R): Promise<R> {
+        const body = fn.toString();
+        if (body.includes("copilot-error-banner")) {
+          bannerReads++;
+          // Fresh sustained banner on attempt 1 → fast-fail. After the reload
+          // the banner is gone (so the retry does NOT fast-fail; it instead
+          // burns the remaining budget waiting for a response that never comes).
+          if (reloaded) return { visible: false } as never;
+          if (bannerReads <= 1) return { visible: false } as never;
+          return { visible: true, text: "cold start" } as never;
+        }
+        if (body.includes("copilot-user-message")) {
+          return userCalls++ as never;
+        }
+        // Assistant never responds → the retry settle-times-out.
+        return 0 as never;
+      },
+    };
+
+    const start = Date.now();
+    const result = await runConversation(
+      page,
+      [{ input: "deadline test", responseTimeoutMs: TURN_TIMEOUT }],
+      { assistantSettleMs: 50 },
+    );
+    const elapsed = Date.now() - start;
+
+    expect(reloaded).toBe(true);
+    // Turn failed (assistant never settled), but the KEY assertion: the retry
+    // shared the turn deadline, so total elapsed is ~1× the budget, not ~2×.
+    expect(result.failure_turn).toBe(1);
+    // Shared deadline: total ≈ 1× budget + the small retry floor + send-verify
+    // overhead, comfortably under the OLD ~2× (two fresh full budgets would be
+    // ≥ 2000ms here).
+    expect(elapsed).toBeLessThan(TURN_TIMEOUT * 1.8);
+  }, 20_000);
+
   it("empty turns array: returns zeroes immediately", async () => {
     const page = makePage();
     const result = await runConversation(page, []);
@@ -793,6 +1114,11 @@ describe("runConversation", () => {
         { visible: true, text: baselineText },
         { visible: true, text: newErrorText },
       ],
+      // Turn 1 → the bounded cold-start retry fires; re-seeded queues replay
+      // the same prefix-collision sequence so the 2nd attempt re-arms on the
+      // full-text comparison and fast-fails again. The truncation-false-negative
+      // fix stays intact across the retry.
+      reloadReplaysQueues: true,
       recorded,
     });
 
@@ -815,8 +1141,10 @@ describe("runConversation", () => {
     // shared prefix; the distinguishing suffix may be elided. What matters is
     // that we fast-failed at all (timeout would mean the bug reproduced).
     expect(result.error).toContain(prefix300.slice(0, 50));
-    // Bailed well before the 5000ms responseTimeout — the whole point.
-    expect(elapsed).toBeLessThan(2000);
+    // Bailed well before the 5000ms responseTimeout — the whole point. The
+    // bounded cold-start retry adds a 2nd fast-fail cycle, so the bound is
+    // 3000ms (two cycles), still far under the 5000ms settle timeout.
+    expect(elapsed).toBeLessThan(3000);
     expect(result.turn_durations_ms).toHaveLength(0);
     // Real multi-poll settle loop; explicit timeout for CI headroom.
   }, 20_000);

--- a/showcase/harness/src/probes/helpers/conversation-runner.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.ts
@@ -161,6 +161,37 @@ const SELECTOR_PROBE_TIMEOUT_MS = 5_000;
 const POLL_INTERVAL_MS = 100;
 
 /**
+ * Bounded cold-start retry budget. A showcase can paint a TRANSIENT error
+ * banner on the FIRST turn while its agent backend / runtime is still warming
+ * up; that banner then clears on its own a beat later. PR #5142's fast-fail
+ * (`AssistantErroredError`) correctly bails on a SUSTAINED banner, but on
+ * turn 1 a single bounded retry — reload the page, re-send the same message —
+ * recovers the would-be flap WITHOUT masking a real failure: a banner that
+ * SURVIVES the reload+re-send fast-fails again on the 2nd attempt and is
+ * re-thrown.
+ *
+ * Strictly bounded so #5142 stays intact: the retry fires AT MOST ONCE
+ * (`coldStartRetries` counter), ONLY on turn 1 (the cold-start window — reload
+ * is safe there because no conversation state exists yet), and ONLY for an
+ * `AssistantErroredError` (NOT a settle `timeout`, which is a different
+ * failure mode). A sustained real banner still fast-fails on the 2nd attempt.
+ */
+const COLD_START_RETRY_MAX = 1;
+
+/**
+ * Floor for the cold-start retry's settle budget (#71/FF20). The retry shares
+ * the turn's single deadline so a retried turn cannot run ~2× the budget, but
+ * if the first attempt consumed nearly all of it the remaining window can drop
+ * below the fast-fail debounce (2 consecutive polls). A zero-or-near-zero retry
+ * window would convert a SUSTAINED real banner — which #5142 requires to
+ * fast-fail again on the 2nd attempt — into a generic settle timeout, silently
+ * weakening that guarantee. Flooring the retry window at a few poll intervals
+ * keeps wall-clock close to 1× (never the old ~2×) while preserving the
+ * fast-fail debounce so a real banner still re-throws `AssistantErroredError`.
+ */
+const COLD_START_RETRY_MIN_SETTLE_MS = 3 * POLL_INTERVAL_MS;
+
+/**
  * Minimal Page surface the runner depends on. Real `playwright.Page`
  * satisfies this structurally; tests inject scripted fakes. We
  * intentionally do NOT import `playwright`'s Page type — pulling DOM
@@ -199,6 +230,16 @@ export interface Page {
    * implementation.
    */
   inputValue?(selector: string): Promise<string>;
+  /**
+   * Reload the page. Used ONLY by the bounded turn-1 cold-start retry: a
+   * showcase that paints a transient error banner while its backend is
+   * still warming up can be recovered by reloading and re-sending the
+   * first message (safe on turn 1 — there is no conversation state to
+   * lose). Optional — when absent, the cold-start retry re-sends without a
+   * reload. The real Playwright Page provides it natively; test fakes
+   * supply a scripted implementation.
+   */
+  reload?(): Promise<unknown>;
 }
 
 export interface ConversationTurn {
@@ -390,6 +431,17 @@ export async function runConversation(
     const turnNum = idx + 1;
     const turnTimeoutMs = turn.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS;
     const startedAt = Date.now();
+    // A SINGLE deadline shared across the first settle wait AND the cold-start
+    // retry's settle wait (#71/FF20). Without this the retry would get a fresh
+    // full `turnTimeoutMs`, letting a cold-start turn run ~2× its budget. The
+    // first wait uses the full `turnTimeoutMs`; the retry wait uses only the
+    // time remaining against this deadline.
+    const turnDeadline = startedAt + turnTimeoutMs;
+    // Bounded once-per-turn cold-start retry counter. Only ever consulted on
+    // turn 1 (the cold-start window); declaring it per-iteration scopes it to
+    // the turn it protects. The fast-fail retry fires while this is below
+    // `COLD_START_RETRY_MAX` (1), so at most one reload+re-send per turn.
+    let coldStartRetries = 0;
 
     console.debug(
       `[conversation-runner] turn ${turnNum}/${total} — sending message`,
@@ -441,18 +493,29 @@ export async function runConversation(
         }
       }
 
-      if (turn.skipSend) {
-        console.debug(
-          `[conversation-runner] turn ${turnNum}/${total} — skipSend=true, preFill handled submission; not touching textarea`,
-        );
-      } else if (turn.skipFill) {
-        console.debug(
-          `[conversation-runner] turn ${turnNum}/${total} — skipFill=true, waiting for textarea content then pressing Enter`,
-        );
-        await waitForContentAndSend(page, chatInputSelector, turnTimeoutMs);
-      } else {
-        await fillAndVerifySend(page, chatInputSelector, turn.input);
-      }
+      // Send (or, for skipSend/skipFill turns, confirm) the user message.
+      // Extracted into a closure so the bounded turn-1 cold-start retry can
+      // re-send the same message after a `page.reload()` without duplicating
+      // the skipSend/skipFill/normal branch logic. `chatInputSelector` is
+      // non-null here (resolved above or it returned), so the cast-free
+      // local capture is safe.
+      const selector = chatInputSelector;
+      const sendTurnMessage = async (): Promise<void> => {
+        if (turn.skipSend) {
+          console.debug(
+            `[conversation-runner] turn ${turnNum}/${total} — skipSend=true, preFill handled submission; not touching textarea`,
+          );
+        } else if (turn.skipFill) {
+          console.debug(
+            `[conversation-runner] turn ${turnNum}/${total} — skipFill=true, waiting for textarea content then pressing Enter`,
+          );
+          await waitForContentAndSend(page, selector, turnTimeoutMs);
+        } else {
+          await fillAndVerifySend(page, selector, turn.input);
+        }
+      };
+
+      await sendTurnMessage();
 
       console.debug(
         `[conversation-runner] turn ${turnNum}/${total} — waiting for assistant settle`,
@@ -467,12 +530,89 @@ export async function runConversation(
       // Wait for the assistant-message count to grow past the baseline
       // and then stay stable for `settleMs`. If the deadline passes
       // before we see growth, fail the turn with a timeout error.
-      const newCount = await waitForAssistantSettled({
-        page,
-        baselineCount,
-        settleMs,
-        timeoutMs: turnTimeoutMs,
-      });
+      //
+      // Bounded turn-1 cold-start retry: if the FIRST turn fast-fails with an
+      // `AssistantErroredError` (a banner appeared with no response produced —
+      // see #5142), the showcase backend may simply have been cold. Retry
+      // ONCE: reload the page (safe on turn 1 — no conversation state to lose)
+      // and re-send the same message, then re-enter the settle wait. A banner
+      // that SURVIVES the retry re-throws (a real failure). Strictly bounded —
+      // only turn 1, only once (`coldStartRetries` < `COLD_START_RETRY_MAX`),
+      // only a PLAIN-FILL turn (the retry must re-issue the submission; a
+      // skipSend/skipFill turn's submission came from `preFill` and a reload
+      // would wipe it, so those fast-fail without retry), and only
+      // `AssistantErroredError` (NOT a settle timeout). This does NOT widen the
+      // catch to generic timeouts and does NOT defeat #5142: a sustained real
+      // banner still fast-fails on the 2nd attempt.
+      let newCount: number;
+      try {
+        newCount = await waitForAssistantSettled({
+          page,
+          baselineCount,
+          settleMs,
+          timeoutMs: turnTimeoutMs,
+        });
+      } catch (settleErr) {
+        // The cold-start retry can ONLY meaningfully recover a turn it can
+        // RE-ISSUE: a plain-fill turn (reload the page + re-fill the textarea +
+        // re-send). skipSend/skipFill submissions are issued by `turn.preFill`
+        // (skipSend → preFill auto-sent via the agent surface; skipFill →
+        // preFill populated the textarea), which a reload would wipe — so for
+        // those turns there is nothing to re-issue and the retry could only
+        // false-settle against the first attempt's stale DOM, run on an
+        // unbounded budget, or no-op. Gate the retry to plain-fill turns; for
+        // skipSend/skipFill turns let the original `AssistantErroredError`
+        // propagate (PR #5142 fast-fail — the pre-retry behavior for those
+        // turns, not a regression).
+        const isPlainFillTurn = !turn.skipSend && !turn.skipFill;
+        const isColdStartWindow =
+          turnNum === 1 &&
+          coldStartRetries < COLD_START_RETRY_MAX &&
+          isPlainFillTurn;
+        if (settleErr instanceof AssistantErroredError && isColdStartWindow) {
+          coldStartRetries++;
+          console.warn(
+            `[conversation-runner] turn ${turnNum}/${total} — cold-start banner fast-fail; reloading + re-sending ONCE before fast-fail`,
+            { error: errorMessage(settleErr) },
+          );
+          // Reload to clear the transient cold-start banner. Safe on turn 1 —
+          // no conversation state exists yet — and the plain-fill re-send below
+          // re-issues the message the reload cleared. Optional on the structural
+          // Page surface — skip cleanly if a caller's page can't reload.
+          if (page.reload) {
+            await page.reload();
+            // Re-resolve the chat input after reload — the DOM was torn down, so
+            // the previously-cached selector may no longer be attached.
+            chatInputSelector = await resolveChatInputSelector(
+              page,
+              opts.chatInputSelector,
+            );
+            // Re-read the baseline so growth is measured against the post-reload
+            // message count, then re-send the same message.
+            baselineCount = await readMessageCount(page);
+          }
+          await fillAndVerifySend(page, chatInputSelector, turn.input);
+          // Re-enter the settle wait, sharing the turn deadline (#71/FF20) so
+          // the retry only ever consumes the time remaining in the turn budget
+          // rather than a fresh full `turnTimeoutMs`. A banner that survives
+          // this attempt throws again (AssistantErroredError) and the outer
+          // catch records the turn failure — #5142 stays intact.
+          newCount = await waitForAssistantSettled({
+            page,
+            baselineCount,
+            settleMs,
+            timeoutMs: Math.max(
+              COLD_START_RETRY_MIN_SETTLE_MS,
+              turnDeadline - Date.now(),
+            ),
+          });
+        } else {
+          // Not the cold-start case (later turn, already retried, a
+          // skipSend/skipFill turn, or a settle timeout) — propagate to the
+          // per-turn catch unchanged.
+          throw settleErr;
+        }
+      }
 
       console.debug(
         `[conversation-runner] turn ${turnNum}/${total} — assistant settled`,

--- a/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-chip.test.tsx
@@ -249,6 +249,53 @@ describe("DepthChip", () => {
     expect(chip.getAttribute("data-status")).not.toBe("unreachable");
     expect(chip.className).toContain("emerald");
   });
+
+  // ── flap-band #70: pending (reclaimed) treatment ────────────────────
+
+  it("renders a NEUTRAL pending treatment when pending=true (not red, not the indigo unreachable overlay)", () => {
+    const { getByTestId } = render(
+      <DepthChip
+        depth={5}
+        status="wired"
+        chipColor="green"
+        pending
+        commTooltip="re-queued (pending): worker-reclaimed-pending — worker w-9"
+      />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.getAttribute("data-status")).toBe("pending");
+    expect(chip.getAttribute("data-surface-state")).toBe("pending");
+    expect(chip.getAttribute("title")).toContain("worker-reclaimed-pending");
+    // NEUTRAL — never the red danger class, never the indigo "unreachable"
+    // overlay. A routine teardown must not read as a failure.
+    expect(chip.className).not.toContain("danger");
+    expect(chip.className).not.toContain("indigo");
+    expect(chip.className).not.toContain("emerald");
+  });
+
+  it("unreachable takes precedence over pending (a known crash outranks an ambiguous reclaim)", () => {
+    const { getByTestId } = render(
+      <DepthChip
+        depth={3}
+        status="wired"
+        chipColor="green"
+        unreachable
+        pending
+      />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.getAttribute("data-status")).toBe("unreachable");
+    expect(chip.className).toContain("indigo");
+  });
+
+  it("renders normally (no pending) when pending=false", () => {
+    const { getByTestId } = render(
+      <DepthChip depth={5} status="wired" chipColor="green" pending={false} />,
+    );
+    const chip = getByTestId("depth-chip");
+    expect(chip.getAttribute("data-status")).not.toBe("pending");
+    expect(chip.className).toContain("emerald");
+  });
 });
 
 describe("depthColorClass (direct)", () => {

--- a/showcase/shell-dashboard/src/components/depth-chip.tsx
+++ b/showcase/shell-dashboard/src/components/depth-chip.tsx
@@ -42,7 +42,16 @@ export interface DepthChipProps {
    * comm-error overlay; the descriptive tooltip is supplied via `commTooltip`.
    */
   unreachable?: boolean;
-  /** Tooltip text for the unreachable treatment (names the comm-error kind). */
+  /**
+   * Pool RECLAIM-PENDING state (flap-band #70). When set, the job's lease
+   * lapsed and the control-plane RE-QUEUED it (back in flight). The sweep
+   * boundary cannot tell a real crash from an expected platform teardown, so
+   * this is NEUTRAL — a gray "⟳ pending" treatment, distinct from both the red
+   * `unreachable` overlay and a real probe colour, so a routine teardown never
+   * reads as a failure. `unreachable` takes precedence when both are set.
+   */
+  pending?: boolean;
+  /** Tooltip text for the unreachable / pending treatment (names the kind). */
   commTooltip?: string;
 }
 
@@ -103,6 +112,7 @@ export function DepthChip({
   maxDepth,
   chipColor,
   unreachable,
+  pending,
   commTooltip,
 }: DepthChipProps) {
   // Pool comm-error overlay (REQ-B) takes precedence over every probe colour:
@@ -119,6 +129,25 @@ export function DepthChip({
         title={commTooltip ?? "pool unreachable — comm error"}
       >
         ⚡
+      </span>
+    );
+  }
+
+  // Reclaim-pending overlay (flap-band #70): the job's lease lapsed and was
+  // re-queued (back in flight). NEUTRAL — a gray fill + ⟳ glyph, distinct from
+  // the red `unreachable` overlay above, so an expected platform teardown never
+  // flaps the service red. Resolved before unshipped/unsupported so it always
+  // shows, but AFTER `unreachable` (a known crash outranks an ambiguous reclaim).
+  if (pending) {
+    return (
+      <span
+        data-testid="depth-chip"
+        data-status="pending"
+        data-surface-state="pending"
+        className="inline-flex items-center justify-center min-w-[32px] h-5 px-1.5 rounded text-[10px] font-semibold tabular-nums border border-[var(--text-muted)]/40 bg-[var(--text-muted)]/20 text-[var(--text-muted)]"
+        title={commTooltip ?? "re-queued — pending re-run"}
+      >
+        ⟳
       </span>
     );
   }

--- a/showcase/shell-dashboard/src/components/unified-cell.tsx
+++ b/showcase/shell-dashboard/src/components/unified-cell.tsx
@@ -110,7 +110,15 @@ function TestBadge({
  */
 export function commErrorTooltip(err: PoolCommError): string {
   const worker = err.workerId ? ` — worker ${err.workerId}` : "";
-  return `pool unreachable: ${err.kind}${worker} — ${err.message}`;
+  // A re-queued (reclaimed-pending) job is NOT an outage — the lease lapsed and
+  // the control-plane re-queued it (back in flight), which the sweep boundary
+  // cannot tell apart from an expected platform teardown. Phrase it neutrally
+  // (flap-band #70) so the tooltip doesn't read as "unreachable".
+  const lead =
+    err.kind === "worker-reclaimed-pending"
+      ? "re-queued (pending)"
+      : "pool unreachable";
+  return `${lead}: ${err.kind}${worker} — ${err.message}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -190,6 +198,7 @@ function DepthLayer({ ctx, model }: { ctx: CellContext; model: CellModel }) {
           depth={model.achievedDepth}
           status="wired"
           unreachable={model.surfaceState === "unreachable"}
+          pending={model.surfaceState === "pending"}
           commTooltip={
             model.commError ? commErrorTooltip(model.commError) : undefined
           }

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -1613,6 +1613,64 @@ describe("buildCellModel", () => {
       expect(unsupported.commError).toBeUndefined();
     });
 
+    // ── flap-band #70: worker-reclaimed-pending → NEUTRAL "pending" surface ──
+    // A lease lapsed and the sweeper re-queued the job (back in flight). The
+    // sweep boundary cannot tell a real crash from an expected platform
+    // teardown, so this kind renders a NEUTRAL "pending" surface (gray) — NOT
+    // the red "unreachable" overlay — so a routine teardown never flaps red.
+    describe("worker-reclaimed-pending → pending surface (flap-band #70)", () => {
+      const reclaimSignal = {
+        __fleetCommError: {
+          kind: "worker-reclaimed-pending",
+          message: "lease for job j-7 expired; re-queued to pending",
+          workerId: "fleet-worker-9",
+          observedAt: FRESH_OBSERVED_AT,
+        },
+      };
+
+      it("a reclaimed-pending comm error surfaces as 'pending', NOT 'unreachable' and NOT red", () => {
+        const live = mapOf([
+          row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+          row(keyFor("chat", "agno"), "chat", "green"),
+          row(keyFor("tools", "agno"), "tools", "green"),
+          row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+          row(keyFor("d6", "agno", "agentic-chat"), "d6", "green", {
+            signal: reclaimSignal,
+          }),
+        ]);
+        const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+        // The neutral surface — the key flap-band #70 assertion.
+        expect(model.surfaceState).toBe("pending");
+        expect(model.surfaceState).not.toBe("unreachable");
+        expect(model.surfaceState).not.toBe("red");
+        // The comm error is still decoded (for the tooltip), it just maps to a
+        // different, neutral surface.
+        expect(model.commError?.kind).toBe("worker-reclaimed-pending");
+        expect(model.commError?.workerId).toBe("fleet-worker-9");
+        // The last-known probe colour stays visible underneath the overlay.
+        expect(model.chipColor).toBe("green");
+      });
+
+      it("a crash (worker-crashed-mid-job) still surfaces red 'unreachable' — only reclaim is neutralized", () => {
+        const live = mapOf([
+          row(keyFor("d6", "agno", "agentic-chat"), "d6", "green", {
+            signal: {
+              __fleetCommError: {
+                kind: "worker-crashed-mid-job",
+                message: "worker crashed running job j-7",
+                observedAt: FRESH_OBSERVED_AT,
+              },
+            },
+          }),
+        ]);
+        const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+        // A KNOWN crash the worker observed directly stays the loud red overlay.
+        expect(model.surfaceState).toBe("unreachable");
+        expect(model.surfaceState).not.toBe("pending");
+        expect(model.commError?.kind).toBe("worker-crashed-mid-job");
+      });
+    });
+
     it("the MOST RECENT comm error wins — a newer aggregate (worker-death) beats a stale per-cell one", () => {
       // A STALE per-cell comm error (older `observedAt`) lingers on the per-cell
       // d6 row, scanned BEFORE the aggregate. A NEWER worker-death comm error

--- a/showcase/shell-dashboard/src/lib/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.test.ts
@@ -1,0 +1,149 @@
+/**
+ * cell-model — comm-error overlay precedence (flap-band FF3/FF4/FF5/FF7).
+ *
+ * These cases pin the load-bearing invariant: a NEUTRAL
+ * `worker-reclaimed-pending` overlay must never mask a GENUINE red, and a
+ * newer reclaim must never out-rank an older directly-observed crash. They
+ * also pin the staleness fail-safe for an unparseable `observedAt`.
+ */
+import { describe, it, expect } from "vitest";
+import { buildCellModel } from "./cell-model";
+import { keyFor, FLEET_COMM_ERROR_SIGNAL_KEY } from "./live-status";
+import type {
+  LiveStatusMap,
+  StatusRow,
+  State,
+  PoolCommError,
+} from "./live-status";
+
+const SLUG = "acme";
+const FEATURE = "beautiful-chat";
+const NOW = Date.parse("2026-06-04T12:00:00.000Z");
+
+function commErrorSignal(err: Partial<PoolCommError>): Record<string, unknown> {
+  return {
+    [FLEET_COMM_ERROR_SIGNAL_KEY]: {
+      kind: "worker-unreachable",
+      message: "x",
+      observedAt: "2026-06-04T11:59:00.000Z",
+      ...err,
+    },
+  };
+}
+
+function row(
+  key: string,
+  state: State,
+  opts: { signal?: unknown; observedAt?: string } = {},
+): StatusRow {
+  const observed = opts.observedAt ?? "2026-06-04T11:59:30.000Z";
+  return {
+    id: key,
+    key,
+    dimension: key.split(":")[0],
+    state,
+    signal: opts.signal ?? null,
+    observed_at: observed,
+    transitioned_at: observed,
+    fail_count: state === "red" ? 1 : 0,
+    first_failure_at: state === "red" ? observed : null,
+  };
+}
+
+const WIRED = {
+  slug: SLUG,
+  featureId: FEATURE,
+  isSupported: true,
+  isWired: true,
+} as const;
+
+describe("buildCellModel — comm-error overlay precedence", () => {
+  it("FF4: a present red is NOT masked by a reclaimed-pending overlay", () => {
+    // A red e2e (D3) row → chipColor red, AND it carries a reclaimed-pending
+    // comm-error overlay. The neutral "pending" surface must NOT hide the red.
+    const live: LiveStatusMap = new Map();
+    live.set(
+      keyFor("e2e", SLUG, FEATURE),
+      row(keyFor("e2e", SLUG, FEATURE), "red", {
+        signal: commErrorSignal({
+          kind: "worker-reclaimed-pending",
+          observedAt: "2026-06-04T11:59:50.000Z",
+        }),
+      }),
+    );
+
+    const model = buildCellModel(live, WIRED, NOW);
+
+    expect(model.chipColor).toBe("red");
+    expect(model.commError?.kind).toBe("worker-reclaimed-pending");
+    // Pre-fix this resolved to "pending"; the genuine red must win.
+    expect(model.surfaceState).toBe("red");
+  });
+
+  it("routine teardown (non-red probe) still shows the neutral pending surface", () => {
+    // A green e2e row carrying a reclaimed-pending overlay → no red, no
+    // regression → the neutral gray "pending" surface is correct.
+    const live: LiveStatusMap = new Map();
+    live.set(
+      keyFor("e2e", SLUG, FEATURE),
+      row(keyFor("e2e", SLUG, FEATURE), "green", {
+        signal: commErrorSignal({
+          kind: "worker-reclaimed-pending",
+          observedAt: "2026-06-04T11:59:50.000Z",
+        }),
+      }),
+    );
+
+    const model = buildCellModel(live, WIRED, NOW);
+
+    expect(model.chipColor).not.toBe("red");
+    expect(model.surfaceState).toBe("pending");
+  });
+
+  it("FF5: an older real crash out-ranks a newer reclaimed-pending", () => {
+    // The e2e row carries an OLDER directly-observed crash; the d6 aggregate
+    // carries a NEWER reclaim. The crash must win (severity over recency).
+    const live: LiveStatusMap = new Map();
+    live.set(
+      keyFor("e2e", SLUG, FEATURE),
+      row(keyFor("e2e", SLUG, FEATURE), "green", {
+        signal: commErrorSignal({
+          kind: "worker-crashed-mid-job",
+          observedAt: "2026-06-04T11:58:00.000Z",
+        }),
+      }),
+    );
+    live.set(
+      keyFor("d6", SLUG),
+      row(keyFor("d6", SLUG), "green", {
+        signal: commErrorSignal({
+          kind: "worker-reclaimed-pending",
+          observedAt: "2026-06-04T11:59:50.000Z",
+        }),
+      }),
+    );
+
+    const model = buildCellModel(live, WIRED, NOW);
+
+    expect(model.commError?.kind).toBe("worker-crashed-mid-job");
+    expect(model.surfaceState).toBe("unreachable");
+  });
+
+  it("FF7: an unparseable observedAt is treated as stale (no phantom overlay)", () => {
+    const live: LiveStatusMap = new Map();
+    live.set(
+      keyFor("e2e", SLUG, FEATURE),
+      row(keyFor("e2e", SLUG, FEATURE), "green", {
+        signal: commErrorSignal({
+          kind: "worker-unreachable",
+          observedAt: "not-a-real-timestamp",
+        }),
+      }),
+    );
+
+    const model = buildCellModel(live, WIRED, NOW);
+
+    expect(model.commError).toBeUndefined();
+    expect(model.surfaceState).not.toBe("unreachable");
+  });
+});

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -97,10 +97,18 @@ export interface CellModel {
    */
   commError?: PoolCommError;
   /**
-   * The dashboard's presentation state: `"unreachable"` when a `commError` is
-   * present, otherwise the cell's underlying probe colour (mapped from
-   * `chipColor`). Lets the renderer branch on ONE value instead of re-deriving
-   * the comm-error precedence. A presentation field only — never persisted.
+   * The dashboard's presentation state. Lets the renderer branch on ONE value
+   * instead of re-deriving the comm-error precedence. A presentation field
+   * only — never persisted. The derivation produces THREE outcomes:
+   *   - `"unreachable"` — a `commError` of a directly-observed crash kind
+   *     (`worker-crashed-mid-job`, `worker-unreachable`, …) is present: paint
+   *     the red comm-error overlay.
+   *   - `"pending"` — a NON-RED `worker-reclaimed-pending` commError is present:
+   *     a lease lapsed and the job was re-queued (routine teardown, not a known
+   *     crash), so render the neutral gray "pending" surface.
+   *   - the cell's underlying probe colour (mapped from `chipColor`) — no
+   *     commError, OR a `worker-reclaimed-pending` commError that must NOT mask
+   *     a red/regressed probe result (the genuine failure passes through).
    */
   surfaceState: FleetSurfaceState;
 }
@@ -454,14 +462,20 @@ function chipColorToSurface(color: ChipColor): FleetSurfaceState {
  * `PoolCommError` into the row signal under `FLEET_COMM_ERROR_SIGNAL_KEY` (see
  * `commErrorFromStatusSignal`).
  *
- * RECENCY, not key order, decides the winner. Multiple rows can each carry a
- * comm error simultaneously (e.g. a STALE per-cell comm error left over from an
- * earlier attempt, plus a NEWER worker-death error that landed solely on the
- * aggregate row). A fixed key-order scan would let the stale per-cell error mask
- * the newer aggregate one, painting the wrong cause. So we decode EVERY
- * candidate row and return the one with the most recent `observedAt`, falling
- * back to scan order only as a stable tie-break when timestamps are equal/absent.
- * Returns `undefined` when no candidate row carries a comm error (pool reachable).
+ * KIND SEVERITY — not key order, and NOT recency — decides the winner; recency
+ * is only a within-tier tie-break (flap-band #70/FF5). Multiple rows can each
+ * carry a comm error simultaneously (e.g. a STALE per-cell comm error left over
+ * from an earlier attempt, plus an error that landed solely on the aggregate
+ * row). A directly-observed crash kind (`worker-crashed-mid-job`,
+ * `worker-unreachable`, every non-reclaim kind) is a HARD failure the
+ * worker/control-plane saw first-hand and OUT-RANKS the sweep-inferred
+ * `worker-reclaimed-pending` (a lease lapsed / job re-queued — which cannot tell
+ * a real crash from a routine teardown). A NEWER reclaim must therefore NOT mask
+ * an OLDER real crash. So we decode EVERY candidate row and return the
+ * highest-SEVERITY comm error, using the most recent `observedAt` only to break
+ * ties WITHIN a severity tier and falling back to scan order when timestamps are
+ * equal/absent (stable tie-break). Returns `undefined` when no candidate row
+ * carries a comm error (pool reachable).
  *
  * STALENESS WINDOW: a comm error is only surfaced while it is RECENT. The
  * control-plane mirrors a `PoolCommError` onto the `d6:<slug>` aggregate row but
@@ -512,11 +526,19 @@ function decodeCellCommError(
   candidateKeys.push(keyFor("tools", slug));
   candidateKeys.push(keyFor("health", slug));
 
-  // Decode every candidate and keep the MOST RECENT comm error. A later
-  // candidate only wins if its `observedAt` is strictly newer, so for equal
-  // (or unparseable) timestamps the first-in-scan-order error is retained —
-  // a stable tie-break preserving the prior authority ordering.
+  // Decode every candidate and keep the WORST comm error, ranking by KIND
+  // SEVERITY first and using recency only as a same-severity tie-break. A
+  // directly-observed crash (`worker-crashed-mid-job`, `worker-unreachable`,
+  // every non-reclaim kind) is a HARD failure the worker/control-plane saw
+  // first-hand; `worker-reclaimed-pending` is only the sweep boundary's
+  // inference (a lease lapsed, job re-queued) and cannot tell a real crash from
+  // a routine teardown. So a NEWER reclaim must NOT out-rank an OLDER real
+  // crash — severity is the primary winner key, recency only the tie-break
+  // WITHIN a tier. Within the same tier a later candidate wins only when its
+  // `observedAt` is strictly newer, so for equal/absent timestamps the
+  // first-in-scan-order error is retained (stable tie-break).
   let winner: PoolCommError | undefined;
+  let winnerSeverity = Number.NEGATIVE_INFINITY;
   let winnerTs = Number.NEGATIVE_INFINITY;
   for (const key of candidateKeys) {
     const row = live.get(key);
@@ -524,23 +546,28 @@ function decodeCellCommError(
     const commError = commErrorFromStatusSignal(row.signal);
     if (!commError) continue;
     // `observedAt` is an ISO string; `Date.parse` yields NaN for a malformed
-    // value. Treat NaN as the oldest possible time so a well-timestamped error
-    // always outranks an untimestamped one, and so the first untimestamped
-    // error still wins over later untimestamped ones (stable scan-order).
+    // value.
     const parsed = Date.parse(commError.observedAt);
     // STALENESS GATE: a comm error older than the staleness window is treated
     // as recovered and skipped — nothing clears the mirrored blob on recovery,
     // so without this the cell would render "unreachable" forever. Mirrors the
-    // resolveDx stale-green downgrade and `isStale`'s fail-safe: a malformed /
-    // unparseable `observedAt` (NaN) is NOT treated as stale, so such an error
-    // is still surfaced rather than silently dropped.
-    if (!Number.isNaN(parsed) && now - parsed > E2E_STALE_AFTER_MS) {
+    // resolveDx stale-green downgrade. An UNPARSEABLE `observedAt` (NaN) is
+    // treated as stale too: it can never be cleared on recovery (its age is
+    // undefined), so surfacing it would strand a permanent phantom overlay.
+    if (Number.isNaN(parsed) || now - parsed > E2E_STALE_AFTER_MS) {
       continue;
     }
-    const ts = Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed;
-    if (winner === undefined || ts > winnerTs) {
+    // Severity tier: directly-observed crash kinds (everything except the
+    // sweep-inferred reclaim) outrank `worker-reclaimed-pending`.
+    const severity = commError.kind === "worker-reclaimed-pending" ? 0 : 1;
+    if (
+      winner === undefined ||
+      severity > winnerSeverity ||
+      (severity === winnerSeverity && parsed > winnerTs)
+    ) {
       winner = commError;
-      winnerTs = ts;
+      winnerSeverity = severity;
+      winnerTs = parsed;
     }
   }
   return winner;
@@ -746,14 +773,34 @@ export function buildCellModel(
     nextRung.exists &&
     nextRung.status !== null;
 
-  // ── Pool comm-error overlay (REQ-B) ───────────────────────────────
+  // ── Pool comm-error overlay (REQ-B + flap-band #70) ───────────────
   // Decode "couldn't reach the pool" off the rows this cell reads. When
   // present it does NOT overwrite chipColor — the cell keeps showing its
-  // last-known probe result; surfaceState flips to "unreachable" so the
-  // renderer paints the distinct comm-error treatment on top.
+  // last-known probe result; surfaceState flips to an overlay so the renderer
+  // paints the distinct comm-error treatment on top.
+  //
+  // The overlay surface depends on the comm-error KIND:
+  //   - `worker-reclaimed-pending`: a lease lapsed and the sweeper re-queued the
+  //     job (back in flight). The sweep boundary cannot tell a real crash from an
+  //     expected platform teardown, so this is NEUTRAL — render "pending" (gray),
+  //     never red. This is the flap-band #70 fix: a routine Railway teardown no
+  //     longer flaps the whole service red.
+  //   - every other kind (worker-crashed-mid-job, worker-unreachable, …): a
+  //     KNOWN comm failure the worker/control-plane observed directly — render
+  //     the red "unreachable" overlay as before.
   const commError = decodeCellCommError(live, slug, featureId, now);
   const surfaceState: FleetSurfaceState = commError
-    ? "unreachable"
+    ? commError.kind === "worker-reclaimed-pending"
+      ? // A reclaimed-pending overlay is NEUTRAL (gray "pending") ONLY when the
+        // cell's real probe result isn't itself red/regressed. A present red
+        // (or a regression below the ceiling) is a GENUINE failure that the
+        // neutral pending overlay must NOT mask — otherwise DepthChip's
+        // "pending" early-return would hide a real red. The red probe result
+        // wins; routine teardown (non-red) still shows gray.
+        chipColor === "red" || isRegression
+        ? chipColorToSurface(chipColor)
+        : "pending"
+      : "unreachable"
     : chipColorToSurface(chipColor);
 
   return {

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -59,6 +59,15 @@ export const POOL_COMM_ERROR_KINDS = [
   "worker-crashed-mid-job",
   /** A report arrived but failed schema/shape validation (protocol mismatch). */
   "worker-protocol-violation",
+  /**
+   * A lease lapsed and the control-plane sweeper RE-QUEUED the job to pending.
+   * The sweep boundary cannot tell a real crash from an expected platform
+   * teardown, but either way the job is back in flight — so the dashboard
+   * renders this as a NEUTRAL "re-queued / pending" surface (gray), NOT the red
+   * "unreachable" overlay. Mirror of the harness `worker-reclaimed-pending`
+   * kind; the cross-package drift test pins the two lists equal.
+   */
+  "worker-reclaimed-pending",
 ] as const;
 
 /** A single pool communication-failure kind. */
@@ -110,7 +119,13 @@ export type FleetSurfaceState =
   | "amber"
   | "red"
   | "gray"
-  | "unreachable";
+  | "unreachable"
+  // A `worker-reclaimed-pending` comm error: the job's lease lapsed and the
+  // control-plane re-queued it (back in flight). A NEUTRAL surface — the
+  // renderer paints it gray, distinct from both the red `"unreachable"` crash
+  // overlay and the cell's last-known probe colour — so a routine teardown
+  // never flaps the service red.
+  | "pending";
 
 /**
  * Extract a `PoolCommError` from a status-row signal blob, or `undefined` when


### PR DESCRIPTION
## Summary

- **Cold-start retry before fast-fail (#71), gated to plain-fill turns** — `conversation-runner` now performs a bounded turn-1 `page.reload()` retry when an error banner appears on a cold start, recovering transient boot flaps. The retry shares the single turn deadline (no ~2× budget blowup, FF20) and is gated to plain-fill turns so it never masks a real failure: a banner that survives the reload still fast-fails.
- **Fleet teardown surface-state honesty** — adds a `worker-reclaimed-pending` comm-error kind, a control-plane SIGTERM drain path that distinguishes graceful teardown from a crash (#70), and pre-dispatch warm-up health pings (#72). Graceful Railway teardown is now reported as pending, not as a red.
- **Dashboard pending-surface never masks a real red** — `cell-model` decodes comm-errors severity-first, guards against stale `observedAt`, and renders a dedicated pending chip. A pending surface can never override a genuine red, while transient teardown noise resolves to pending instead of flapping.

**Dashboard-green impact:** kills false flaps on Railway teardown WITHOUT masking real reds, and bounds the cold-start retry so a genuinely-broken cold start still surfaces.

## Test plan

- [x] harness `tsc --noEmit` (clean)
- [x] harness vitest — conversation-runner (46), fleet contracts + control-plane/job-producer + queue-client (123 tests across 4 touched suites, all passing)
- [x] shell-dashboard `tsc --noEmit` (clean)
- [x] shell-dashboard vitest — cell-model + depth-chip (148 tests, all passing)
- [x] oxfmt `--check` clean on all changed files

## Known follow-ups

All pre-existing, tracked for a separate PR (not introduced by this change):

- `priority` / `leaseSeconds` dead knobs in the fleet contracts
- `modelsEqual` does not compare `jobId`
- `DepthChip` switch is not exhaustiveness-checked
- unknown-state should map to a gray cell in `cell-model`
- `createRailwayAdapter` stale JSDoc
- no-reload-retry test-fake edge case

🤖 Generated with [Claude Code](https://claude.com/claude-code)