### PR TITLE
fix(react-core): render intelligence-indicator icon cross-browser

### DIFF
--- a/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/IntelligenceIndicatorView.tsx
@@ -23,40 +23,28 @@ export interface IntelligenceIndicatorViewProps extends React.HTMLAttributes<HTM
  * rendered by the {@link IntelligenceIndicator} brain and the default
  * value for the `intelligenceIndicator` slot.
  *
- * Single-element three-stage design:
- *  1. **In-progress.** Glassmorphism pill chrome around a 270° arc icon
- *     and the label. The arc has a single continuous visible stroke
- *     (one `stroke-dasharray` dash + one gap, summing to the path
- *     length) and the whole SVG rotates — so the viewer sees one
- *     C-shaped arc spinning around the visual center.
- *  2. **Icon morph (~250 ms).** On status flip the single icon path
- *     interpolates from the arc to a checkmark via CSS `d:` while the
- *     dashed stroke transitions to solid (filling in the gap that was
- *     the spinner's open portion). The SVG rotation animation is
- *     removed; the snap back to identity is masked by the simultaneous
- *     shape change. Chrome and text stay at full opacity throughout.
- *  3. **Settle (~400 ms, starts at +250 ms).** Chrome (background,
- *     border, shadow, backdrop-blur) fades to zero opacity. The label
- *     and icon stroke color transitions from saturated purple to a
- *     true-neutral gray at 0.8 alpha — no hue cast, reads as "settled
- *     history metadata." The label simultaneously skews to ~10° (a
- *     transform-based italic feel that interpolates smoothly with the
- *     color, rather than the discrete `font-style: italic` snap that
- *     would cause a layout pop). The label text stays put — only its
- *     color and slant change — so there is no "bump" where the brand
- *     text disappears and reappears.
+ * Layout: a glassmorphism pill (the `__chrome` layer) wrapping an icon
+ * and a label. The icon is two overlaid SVG paths — a spinner arc and a
+ * checkmark — whose geometry lives in each path's `d` ATTRIBUTE so it
+ * renders in every browser (the CSS `d:` property is Chrome-only).
  *
- * Hard sequence: stage 3 has a 250 ms transition-delay so it waits
- * for stage 2 to finish. Total settle time ~650 ms in production.
+ * Two states, driven by the `data-status` attribute (see globals.css
+ * for the exact timing):
+ *  1. **In-progress.** The arc spins (CSS rotation) inside the pill and
+ *     the checkmark is hidden. Label + icon are a saturated purple.
+ *  2. **Finished.** The arc fades out mid-spin while the checkmark draws
+ *     itself in upright (animated `stroke-dashoffset`); the pill chrome
+ *     fades away; and the label + icon settle from purple to a neutral
+ *     gray, with the label slanting slightly (a `transform: skewX`
+ *     faux-italic, so it interpolates with the color instead of snapping
+ *     and never reflows). The result reads as quiet "history metadata"
+ *     rather than an active spinner. The label text itself never changes
+ *     — the static check plus the color/slant shift carry the "done"
+ *     meaning, so no wording change is needed.
  *
- * Both shapes are 3-segment cubic Bézier paths with matched command
- * structure (one `M` plus three `C`s), which is what makes the d
- * morph interpolate as a continuous shape change rather than snapping.
- *
- * The label is identical in both states (default "CopilotKit
- * Intelligence"). The static check icon carries the "done" semantic;
- * the color + slant transition does the "settle" work without needing
- * any wording change.
+ * All motion is gated behind `prefers-reduced-motion` (globals.css):
+ * when reduced motion is requested the arc does not spin and the two
+ * states swap instantly, without transitions.
  *
  * Customize via the `intelligenceIndicator` slot on `CopilotChat`:
  * a className string restyles the wrapper, a props object tweaks
@@ -95,14 +83,25 @@ export function IntelligenceIndicatorView({
           height="14"
           aria-hidden="true"
         >
-          {/* Single path element whose `d` attribute morphs from the
-              arc to the checkmark via CSS `d:` interpolation. Both
-              shapes are 3-segment cubic Béziers; the arc is a 270°
-              quarter-by-quarter approximation of a circle, the
-              checkmark is a 2-stroke polyline split into 3 cubics
-              with collinear controls (so the segments render as
-              straight lines). */}
-          <path className="cpk-intelligence-indicator__icon-path" />
+          {/* Two overlaid paths whose geometry lives in the `d`
+              ATTRIBUTE (works in every browser — the CSS `d:` property
+              is Blink-only, so a stylesheet-driven `d` renders nothing
+              in Safari/Firefox). Both paths set `pathLength={1}` so the
+              stylesheet can express dashes as plain fractions of the
+              shape. The arc is a full circle shown as a partial ring by
+              its dash pattern; it spins while in-progress (CSS) and on
+              the status flip fades out mid-spin while the checkmark
+              draws itself in (see globals.css). */}
+          <path
+            className="cpk-intelligence-indicator__icon-arc"
+            pathLength={1}
+            d="M 12 3 C 17 3 21 7 21 12 C 21 17 17 21 12 21 C 7 21 3 17 3 12 C 3 7 7 3 12 3"
+          />
+          <path
+            className="cpk-intelligence-indicator__icon-check"
+            pathLength={1}
+            d="M 5 12.5 L 9 16.5 L 19 6.5"
+          />
         </svg>
         <span className="cpk-intelligence-indicator__label">{label}</span>
       </span>

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -230,43 +230,43 @@
   background-size: 100% 100%;
 }
 /*
- * IntelligenceIndicator — single-element, three-stage design.
+ * IntelligenceIndicator — the default "CopilotKit Intelligence" face.
  *
- * Layers (always in the DOM, always at full opacity for layout
- * purposes — only individual properties animate):
+ * Layers (all always in the DOM; individual properties animate as the
+ * `data-status` attribute flips in-progress → finished):
  *
- *   • `__chrome`   — the glassmorphism pill (bg, border, shadow,
- *                    backdrop-blur). Absolute-positioned behind the
- *                    content. Visible while in-progress; fades to 0
- *                    once the icon morph completes.
- *   • `__content`  — icon + label flex row. Stays in place across
- *                    the whole transition. Only its `color` alpha
- *                    drops on settle (0.92 → 0.55).
- *   • `__icon-path` — single SVG path whose `d` morphs between a
- *                    270° arc and a checkmark. Both shapes share the
- *                    same 3-segment cubic Bézier topology, which is
- *                    what makes the d interpolate cleanly. The "spin"
- *                    is a marching-dash animation on the stroke, not
- *                    an SVG rotation — so there is no rotation state
- *                    to snap back to identity when the animation is
- *                    removed at status flip.
+ *   • `__chrome`     — the glassmorphism pill (bg, border, shadow,
+ *                      backdrop-blur), absolute-positioned behind the
+ *                      content. Visible while in-progress; fades to 0
+ *                      on settle.
+ *   • `__content`    — icon + label flex row. Stays in place across the
+ *                      whole transition; on settle its `color` shifts
+ *                      from saturated purple to neutral gray and the
+ *                      label slants (faux-italic via `transform: skewX`).
+ *   • `__icon-arc`   — a full-circle SVG path shown as a partial ring by
+ *                      its dash pattern; spins (CSS rotation) while
+ *                      in-progress and fades out mid-spin on finish.
+ *   • `__icon-check` — a checkmark path that draws itself in upright
+ *                      (animated `stroke-dashoffset`) on finish.
  *
- * Stage timing (hard sequence — stage 2 waits for stage 1):
- *   • Stage 1, icon morph: 0 → 250 ms.
- *       - d interpolates arc → check
- *       - stroke-dasharray transitions dashed → solid
- *       - marching-dash animation is removed (`animation: none`)
- *   • Stage 2, settle:     250 → 650 ms (transition-delay 250 ms).
- *       - chrome opacity 1 → 0
- *       - content color alpha 0.92 → 0.55
+ * Icon geometry lives in each path's `d` ATTRIBUTE, not the CSS `d:`
+ * property (which is Chrome-only), so it renders in every browser; the
+ * arc spins via `transform-box: fill-box` so it stays centered in Safari
+ * too. See the per-rule comments below for the cross-browser details.
  *
- * Total ~650 ms in production. No moment exists where the icon or
+ * Timing on finish: the arc fades and the checkmark draws in over
+ * ~360 ms, then the chrome + color/slant settle (400 ms, after a 250 ms
+ * delay so it waits for the icon). No moment exists where the icon or
  * label is invisible, so the eye never sees a "bump."
  *
- * Mount-already-finished is handled implicitly: CSS transitions
- * don't fire when the target value is the computed value at first
- * paint, so a historical-replay turn renders directly in its
- * settled state with no animation — which is the desired behavior.
+ * Reduced motion: all of the above is gated behind
+ * `prefers-reduced-motion` — the arc does not spin and the states swap
+ * instantly (see the media query at the end of this section).
+ *
+ * Mount-already-finished is handled implicitly: CSS transitions don't
+ * fire when the target value is the computed value at first paint, so a
+ * historical-replay turn renders directly in its settled state with no
+ * animation — which is the desired behavior.
  */
 .cpk-intelligence-indicator {
   position: relative;
@@ -370,58 +370,74 @@
 .cpk-intelligence-indicator__icon {
   display: block;
   flex-shrink: 0;
-  /* The whole SVG rotates while in-progress; the dash pattern on the
-     path inside is static, so what the viewer sees is one continuous
-     arc rotating around the SVG's visual center. Rotation is removed
-     on status flip — the snap back to identity is masked by the
-     simultaneous d-morph (the shape is changing so rapidly the eye
-     does not register the angle reset). */
-  transform-origin: 7px 7px;
-  animation: cpk-intelligence-spin 0.9s linear infinite;
+  /* The icon holds two overlaid paths: a spinning arc (in-progress)
+     and a checkmark (done). The spin lives on the ARC PATH itself
+     (below), NOT on this SVG — so the checkmark sibling always renders
+     upright instead of inheriting whatever angle the arc was spinning
+     through, and the arc can keep spinning as it fades out (no abrupt
+     stop, no snap back to a fixed angle). */
 }
 
-.cpk-intelligence-indicator[data-status="finished"]
-  .cpk-intelligence-indicator__icon {
-  animation: none;
-}
+/* ─── Icon paths — arc (spinner) → checkmark (done) ─────────────────── */
+/* Geometry lives in each path's `d` ATTRIBUTE (set in the view), not the
+   CSS `d:` property, so the icon renders in every browser. The arc eases
+   out while the checkmark draws itself in (stroke-dashoffset) — a smooth,
+   cross-browser stand-in for the old Blink-only `d:` morph. */
 
-/* ─── Icon path — d-morph + dashed-to-solid stroke ──────────────────── */
-
-.cpk-intelligence-indicator__icon-path {
+.cpk-intelligence-indicator__icon-arc,
+.cpk-intelligence-indicator__icon-check {
   fill: none;
   stroke: currentColor;
   stroke-width: 2.5;
   stroke-linecap: round;
   stroke-linejoin: round;
-  /* In-progress shape: a 270° arc (3 cubic Béziers approximating three
-     quarter-circles, top → right → bottom → left). The fourth quarter
-     is the visible "gap" in the loader. */
-  d: path("M 12 3 C 17 3 21 7 21 12 C 21 17 17 21 12 21 C 7 21 3 17 3 12");
-  /* One continuous arc + one gap, summing to roughly the path length
-     (~42 units). The static dash pattern shows as a single C-shape
-     stroke; the rotation on the SVG above makes that C appear to
-     spin around the center. */
-  stroke-dasharray: 30 14;
-  /* Stage 1 — d and stroke-dasharray both interpolate over 250 ms with
-     the same eased curve so the morph reads as one motion. */
+}
+
+/* In-progress: the arc is a full circle (in the view) shown as a partial ring
+   by this dash pattern — `0.53` visible + `0.47` gap of the `pathLength="1"`
+   normalized circle reads as a C-shape — and the whole ring spins. Expressing
+   the dash as fractions (rather than raw path-length units) matches how the
+   checkmark below is normalized, so both shapes use one consistent idiom.
+   The spin lives here on the arc (not the parent SVG) so the checkmark stays
+   upright. `transform-box: fill-box` + `transform-origin: center` rotates around
+   the arc's geometry-box center — exactly the icon center (12,12) — and is the
+   Safari-safe combo (`transform-box: view-box` is mis-resolved by WebKit and
+   spins off-center; a SMIL `<animateTransform>` stalls for a beat on first paint
+   in Chrome). The animation is `infinite` and is left running in the finished
+   state, so the arc keeps rotating while its opacity fades to 0 (fades out
+   mid-spin rather than stopping dead). */
+.cpk-intelligence-indicator__icon-arc {
+  stroke-dasharray: 0.53 0.47;
+  opacity: 1;
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: cpk-intelligence-spin 0.9s linear infinite;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* `pathLength="1"` (set in the view) normalizes the path's length to 1, so the
+   checkmark starts fully offset (undrawn) and, on finish, draws itself in by
+   animating stroke-dashoffset 1 → 0 — slightly delayed and overlapping the
+   arc's fade so the spinner resolves into the tick rather than hard-cutting. */
+.cpk-intelligence-indicator__icon-check {
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+  opacity: 0;
   transition:
-    d 250ms cubic-bezier(0.4, 0, 0.2, 1),
-    stroke-dasharray 250ms cubic-bezier(0.4, 0, 0.2, 1);
+    stroke-dashoffset 360ms cubic-bezier(0.22, 0.61, 0.36, 1) 90ms,
+    opacity 140ms linear 90ms;
 }
 
 .cpk-intelligence-indicator[data-status="finished"]
-  .cpk-intelligence-indicator__icon-path {
-  /* Finished shape: a checkmark expressed as 3 cubic Béziers with
-     collinear control points (so each segment renders as a straight
-     line). Three segments instead of the natural two so the topology
-     matches the 270° arc above and the d morph interpolates cleanly. */
-  d: path(
-    "M 5 12.5 C 6.33 13.83 7.67 15.17 9 16.5 C 10.67 14.83 12.33 13.17 14 11.5 C 15.67 9.83 17.33 8.17 19 6.5"
-  );
-  /* Large first value, zero gap = solid stroke. Interpolates from
-     `30 14` over 250 ms in lock-step with the d morph, filling in
-     the gap that was the spinner's "open" portion. */
-  stroke-dasharray: 100 0;
+  .cpk-intelligence-indicator__icon-arc {
+  /* Spin is intentionally left running here (now invisible): stopping it
+     would snap the arc back to 0° mid-fade. The cost is negligible. */
+  opacity: 0;
+}
+.cpk-intelligence-indicator[data-status="finished"]
+  .cpk-intelligence-indicator__icon-check {
+  stroke-dashoffset: 0;
+  opacity: 1;
 }
 
 /* ─── Keyframes ─────────────────────────────────────────────────────── */
@@ -429,5 +445,23 @@
 @keyframes cpk-intelligence-spin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+/* ─── Reduced motion ────────────────────────────────────────────────── */
+/* Honor the OS "reduce motion" preference: the arc does not spin and the
+   in-progress → finished states swap instantly instead of animating. The
+   pill + label still convey "working", and the static check still conveys
+   "done" — the information is intact, just without movement. */
+@media (prefers-reduced-motion: reduce) {
+  .cpk-intelligence-indicator__icon-arc {
+    animation: none;
+  }
+  .cpk-intelligence-indicator__chrome,
+  .cpk-intelligence-indicator__content,
+  .cpk-intelligence-indicator__label,
+  .cpk-intelligence-indicator__icon-arc,
+  .cpk-intelligence-indicator__icon-check {
+    transition: none;
   }
 }


### PR DESCRIPTION
## Problem

The "CopilotKit Intelligence" indicator's icon (spinner → checkmark) rendered **blank in Safari and Firefox**. Its geometry was defined through the CSS `d:` property, which is Blink-only (Chrome/Edge) — so in any other engine the stylesheet-driven path drew nothing.

## Fix

- **Geometry in the `d` attribute, not CSS `d:`** — renders in every browser.
- **Two overlaid paths instead of one morphing path.** A spinning **arc** that fades out, and a **checkmark** that draws itself in via `stroke-dashoffset`, upright. Cross-fading two static shapes is more robust than path-morphing (the old `d:` morph was Chrome-only anyway).
- **Arc spins via `transform-box: fill-box; transform-origin: center`** — the Safari-safe way to rotate an SVG sub-element about its center. (`transform-box: view-box` is mis-resolved by WebKit and spins off-center; a SMIL `<animateTransform>` fixes Safari but stalls for a beat on first paint in Chrome — `fill-box` + `center` is correct and instant in both.)
- **Spin isolated to the arc**, so the checkmark always renders upright regardless of where the spin was when the turn finished, and the arc keeps spinning as it fades (no abrupt stop / snap-back).
- **`pathLength="1"` on both paths** so dashes are expressed as plain fractions — one consistent, self-documenting idiom for both shapes.
- **`prefers-reduced-motion` support** added: the arc doesn't spin and the in-progress → finished states swap instantly.
- Both stale design docblocks rewritten to describe the actual implementation.

## Scope

Two files — `IntelligenceIndicatorView.tsx` and `globals.css`. No behavior/runtime changes; purely the indicator's presentation. The settle choreography (glass chrome, hue shift, faux-italic label) is unchanged.

## Testing

- `nx test react-core` — 24 intelligence-indicator tests pass (the suite asserts DOM structure/behavior; cross-browser rendering itself isn't observable in jsdom and was verified manually in Chrome + Safari).
- oxlint / oxfmt clean; type-check clean for the changed files.
- Manually verified in **Chrome and Safari**: icon renders, spins centered, fades out mid-spin, checkmark draws in upright; no Chrome startup stall, no Safari wobble.