### PR TITLE
feat(runtime): decouple agent display name from registry key in /info

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
@@ -332,4 +332,168 @@ describe("handleGetRuntimeInfo", () => {
       message: "Failed to get agents",
     });
   });
+
+  describe("agent display name (decoupled from registry key)", () => {
+    /**
+     * Covers the behavior added for issue #4775: an agent that exposes a
+     * public `name` field provides its own human-facing display name in
+     * the /info response, while the registry-key (used for routing) stays
+     * the dictionary key. Agents without a `name` keep today's behavior
+     * (display name = registry key) — backward compatible.
+     */
+    const mockRequest = new Request("https://example.com/info");
+
+    it("falls back to the registry key when the agent does not expose a name (regression guard)", async () => {
+      const mockAgent = {
+        description: "support agent",
+        constructor: { name: "SupportAgent" },
+      };
+      const runtime = new CopilotRuntime({
+        agents: {
+          "support-v1": mockAgent as AbstractAgent,
+        },
+      });
+
+      const response = await handleGetRuntimeInfo({
+        runtime,
+        request: mockRequest,
+      });
+      const data = await response.json();
+
+      expect(data.agents["support-v1"].name).toBe("support-v1");
+    });
+
+    it("uses agent.name as the display name when the agent exposes one", async () => {
+      const mockAgent = {
+        name: "Customer Support Specialist",
+        description: "support agent",
+        constructor: { name: "SupportAgent" },
+      };
+      const runtime = new CopilotRuntime({
+        agents: {
+          "support-v1": mockAgent as unknown as AbstractAgent,
+        },
+      });
+
+      const response = await handleGetRuntimeInfo({
+        runtime,
+        request: mockRequest,
+      });
+      const data = await response.json();
+
+      expect(data.agents["support-v1"].name).toBe(
+        "Customer Support Specialist",
+      );
+    });
+
+    it("trims surrounding whitespace from the agent-provided name", async () => {
+      const mockAgent = {
+        name: "  Friendly Name  ",
+        description: "agent",
+        constructor: { name: "TrimAgent" },
+      };
+      const runtime = new CopilotRuntime({
+        agents: {
+          "trim-key": mockAgent as unknown as AbstractAgent,
+        },
+      });
+
+      const response = await handleGetRuntimeInfo({
+        runtime,
+        request: mockRequest,
+      });
+      const data = await response.json();
+
+      expect(data.agents["trim-key"].name).toBe("Friendly Name");
+    });
+
+    it("falls back to the registry key when agent.name is the empty string", async () => {
+      const mockAgent = {
+        name: "",
+        description: "agent",
+        constructor: { name: "EmptyNameAgent" },
+      };
+      const runtime = new CopilotRuntime({
+        agents: {
+          "empty-key": mockAgent as unknown as AbstractAgent,
+        },
+      });
+
+      const response = await handleGetRuntimeInfo({
+        runtime,
+        request: mockRequest,
+      });
+      const data = await response.json();
+
+      expect(data.agents["empty-key"].name).toBe("empty-key");
+    });
+
+    it("falls back to the registry key when agent.name is whitespace-only", async () => {
+      const mockAgent = {
+        name: "   ",
+        description: "agent",
+        constructor: { name: "WhitespaceAgent" },
+      };
+      const runtime = new CopilotRuntime({
+        agents: {
+          "ws-key": mockAgent as unknown as AbstractAgent,
+        },
+      });
+
+      const response = await handleGetRuntimeInfo({
+        runtime,
+        request: mockRequest,
+      });
+      const data = await response.json();
+
+      expect(data.agents["ws-key"].name).toBe("ws-key");
+    });
+
+    it("falls back to the registry key when agent.name is not a string", async () => {
+      const mockAgent = {
+        name: 42,
+        description: "agent",
+        constructor: { name: "NonStringNameAgent" },
+      };
+      const runtime = new CopilotRuntime({
+        agents: {
+          "nonstring-key": mockAgent as unknown as AbstractAgent,
+        },
+      });
+
+      const response = await handleGetRuntimeInfo({
+        runtime,
+        request: mockRequest,
+      });
+      const data = await response.json();
+
+      expect(data.agents["nonstring-key"].name).toBe("nonstring-key");
+    });
+
+    it("keeps the registry key unchanged in the response map (only display name varies)", async () => {
+      const mockAgent = {
+        name: "Customer Support Specialist",
+        description: "support agent",
+        constructor: { name: "SupportAgent" },
+      };
+      const runtime = new CopilotRuntime({
+        agents: {
+          "customer-support-v1": mockAgent as unknown as AbstractAgent,
+        },
+      });
+
+      const response = await handleGetRuntimeInfo({
+        runtime,
+        request: mockRequest,
+      });
+      const data = await response.json();
+
+      // Registry key (the dictionary key, used for routing) stays the same
+      expect(Object.keys(data.agents)).toEqual(["customer-support-v1"]);
+      // Display name comes from agent.name
+      expect(data.agents["customer-support-v1"].name).toBe(
+        "Customer Support Specialist",
+      );
+    });
+  });
 });

--- a/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
+++ b/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
@@ -2,9 +2,35 @@ import type { AgentCapabilities } from "@ag-ui/core";
 import type { CopilotRuntimeLike } from "../core/runtime";
 import { isIntelligenceRuntime, resolveAgents } from "../core/runtime";
 import type { AgentDescription, RuntimeInfo } from "@copilotkit/shared";
-import { type RuntimeLicenseStatus } from "@copilotkit/shared";
+import type { RuntimeLicenseStatus } from "@copilotkit/shared";
 import { VERSION } from "../core/runtime";
 import { isTelemetryDisabled } from "../telemetry/telemetry-client";
+
+/**
+ * Resolves the display name for an agent.
+ *
+ * The runtime uses the dictionary key from the `agents` map both as the
+ * agent's routing identity (propagated as `agentId`) and — historically —
+ * as its human-facing display name. To let consumers decouple the two
+ * (e.g. a stable `"customer-support-v1"` routing key with a friendlier
+ * `"Customer Support Specialist"` display name), this preferentially
+ * reads `agent.name` when the implementation exposes one.
+ *
+ * The base `AbstractAgent` from `@ag-ui/client` does not declare a typed
+ * `name` field; subclasses opt in by declaring a public `name: string`,
+ * and we read it at runtime so this works without a coordinated change
+ * to the AG-UI protocol. Falls back to the registry key when `name` is
+ * absent, not a string, or blank.
+ */
+function resolveAgentDisplayName(
+  agent: { name?: unknown },
+  registryKey: string,
+): string {
+  const candidate = agent.name;
+  if (typeof candidate !== "string") return registryKey;
+  const trimmed = candidate.trim();
+  return trimmed.length > 0 ? trimmed : registryKey;
+}
 
 function resolveLicenseStatus(
   runtime: CopilotRuntimeLike,
@@ -49,7 +75,7 @@ export async function handleGetRuntimeInfo({
         }
 
         const description: AgentDescription = {
-          name,
+          name: resolveAgentDisplayName(agent, name),
           description: agent.description,
           className: agent.constructor.name,
           ...(capabilities ? { capabilities } : {}),

--- a/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
@@ -73,6 +73,27 @@ const runtime = new CopilotRuntime({
 
 When you register multiple agents, the `"default"` agent is what powers the chat unless a specific agent is selected. Other agents can still be addressed by passing their `agentId` to `useAgent` or the prebuilt components.
 
+## Display names
+
+By default, each key under `agents:` doubles as the human-facing display name returned by the runtime's `/info` endpoint. Decouple the two — for example, a stable routing key like `"customer-support-v1"` paired with a friendlier display name like `"Customer Support Specialist"` — by declaring a public `name` field on your agent subclass:
+
+```ts title="app/api/copilotkit/route.ts"
+import { BuiltInAgent } from "@copilotkit/runtime/v2";
+
+class CustomerSupportAgent extends BuiltInAgent {
+  name = "Customer Support Specialist";
+}
+
+const runtime = new CopilotRuntime({
+  agents: {
+    // Routing key stays stable even when the friendly name evolves.
+    "customer-support-v1": new CustomerSupportAgent({ model: "openai:gpt-5.4-mini" }),
+  },
+});
+```
+
+Routing still uses `"customer-support-v1"`; the `/info` endpoint reports `"Customer Support Specialist"` as the agent's name. Agents that don't declare a `name` keep today's behavior — display name equals registry key.
+
 ## What the runtime provides
 
 ### Authentication & security

--- a/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
@@ -75,7 +75,9 @@ When you register multiple agents, the `"default"` agent is what powers the chat
 
 ## Display names
 
-By default, each key under `agents:` doubles as the human-facing display name returned by the runtime's `/info` endpoint. Decouple the two — for example, a stable routing key like `"customer-support-v1"` paired with a friendlier display name like `"Customer Support Specialist"` — by declaring a public `name` field on your agent subclass:
+By default, each key under `agents:` doubles as the human-facing display name returned by the runtime's `/info` endpoint. Decouple the two — for example, a stable routing key like `"customer-support-v1"` paired with a friendlier display name like `"Customer Support Specialist"` — by declaring a public `name` field on your agent subclass.
+
+The same pattern works for `BuiltInAgent`, `HttpAgent`, `LangGraphAgent`, `LlamaIndexAgent`, `AgnoAgent`, or any other `AbstractAgent` subclass:
 
 ```ts title="app/api/copilotkit/route.ts"
 import { BuiltInAgent } from "@copilotkit/runtime/v2";


### PR DESCRIPTION
## What does this PR do?

Decouples an agent's human-facing display name from its routing key in the runtime's `/info` endpoint.

Today, the dictionary key passed to `CopilotRuntime({ agents: {...} })` serves two roles: it's the stable routing identifier (`agentId`) *and* the display name returned by `/info`. That forces developers to choose between a clean routing key (e.g. `"customer-support-v1"`) and a friendly UI label (e.g. `"Customer Support Specialist"`) — they can't have both.

This PR adds a small, opt-in mechanism: if an agent subclass declares a public `name` field, `/info` returns that as the display name. If not, behavior is identical to today (the registry key is used). No existing agents need to change.

### Example

```ts
import { BuiltInAgent, CopilotRuntime } from "@copilotkit/runtime/v2";

class CustomerSupportAgent extends BuiltInAgent {
  name = "Customer Support Specialist";
}

const runtime = new CopilotRuntime({
  agents: {
    "customer-support-v1": new CustomerSupportAgent({ model: "openai:gpt-5.4-mini" }),
  },
});
```

The routing key stays `"customer-support-v1"`; `/info` reports `"Customer Support Specialist"` as the agent's name.

## Changes

Four commits:

1. **`feat(runtime)`** — adds a `resolveAgentDisplayName` helper in `get-runtime-info.ts`. Reads `agent.name` when present, non-empty, and a string (trimmed); falls back to the registry key otherwise.
2. **`test(runtime)`** — 7 new test cases in `get-runtime-info.test.ts` covering: regression guard (no `name` → key fallback), happy path (`name` set → returned), whitespace trim, empty-string fallback, whitespace-only fallback, non-string fallback, and registry-key-independent display name.
3. **`docs(runtime)`** — adds a "Display names" section to `copilot-runtime.mdx` with a worked example.
4. **`docs(runtime)`** — notes that the same pattern works for `BuiltInAgent`, `HttpAgent`, `LangGraphAgent`, `LlamaIndexAgent`, `AgnoAgent`, and any other `AbstractAgent` subclass.

## Backward compatibility

Fully backward compatible:

- The `agents:` config shape on `CopilotRuntime` is unchanged.
- Agents without a `name` field behave exactly as before (display name equals registry key).
- The internal routing identity (`agentId`) is unchanged.
- Thread filtering, history lookup, and analytics are unchanged.
- The `AgentDescription` type in the public API is unchanged.

## Related PRs and Issues

Closes #4775.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective and that the feature works
- [x] New and existing unit tests pass locally with my changes
