### PR TITLE
fix(showcase): harden staging→prod promote reliability (snapshot skip + honest verify-prod signal)

### DIFF
--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -272,6 +272,16 @@ jobs:
     environment: railway
     permissions:
       contents: read
+    outputs:
+      # Distinguishes a job that actually PROBED prod (`success`) from one that
+      # SKIPPED probing because nothing promoted (`skipped`). The GitHub job
+      # `result` is `success` in BOTH cases (the skip path exits 0), so the
+      # notify job must read THIS output — not `needs.verify-prod.result` — to
+      # avoid reporting a misleading `verify-prod=success` when prod was never
+      # touched. A real probe failure / contract violation exits non-zero, so
+      # the job `result` becomes `failure` and this output is never written
+      # (notify falls back to the job result for that case).
+      status: ${{ steps.verify.outputs.status }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -282,6 +292,7 @@ jobs:
       - working-directory: showcase/scripts
         run: npm ci
       - name: Run verify-deploy --env prod
+        id: verify
         working-directory: showcase/scripts
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
@@ -318,11 +329,20 @@ jobs:
               exit 1
             fi
             echo "::notice::succeeded_csv is empty (no services promoted, or promote did not run); skipping prod verification. The run is red via the promote job result if anything failed."
+            # Record that prod was SKIPPED, not verified. The job still exits 0
+            # (its `result` is `success`), so the notify job reads this `status`
+            # output to render `verify-prod=skipped` instead of a misleading
+            # `verify-prod=success`.
+            echo "status=skipped" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           # Run from showcase/scripts (where `npm ci` installed tsx) so npx uses
-          # the local install instead of network-fetching it.
+          # the local install instead of network-fetching it. A non-zero exit
+          # here fails the step (job `result` = failure) and `status` is never
+          # written, so notify falls back to the job result.
           npx tsx verify-deploy.ts --env prod --services "$SERVICES_CSV"
+          # Prod was actually probed and passed.
+          echo "status=success" >> "$GITHUB_OUTPUT"
 
   notify:
     # Slack #oss-alerts only. Never #engr (engr is sacred — release alerts only).
@@ -348,6 +368,9 @@ jobs:
       #                                  service failed).
       #   verify-prod                  = verifies the succeeded subset.
       #   run success                  = PROMOTE == success AND PROD == success.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Compute state
         id: state
         env:
@@ -355,10 +378,22 @@ jobs:
           PRE: ${{ needs.verify-staging-precondition.result }}
           PROMOTE: ${{ needs.promote.result }}
           PROD: ${{ needs.verify-prod.result }}
+          # The verify-prod job's own status output: `success` (prod actually
+          # probed + passed) or `skipped` (nothing promoted, so prod was never
+          # touched). Empty when the job failed/cancelled or never wrote it.
+          PROD_STATUS: ${{ needs.verify-prod.outputs.status }}
           CSV: ${{ needs.resolve-targets.outputs.services_csv }}
           INPUT: ${{ inputs.service }}
         run: |
           set -euo pipefail
+          # Displayed verify-prod value for the Slack line. The job `result` is
+          # `success` for BOTH a real pass AND the empty-CSV skip (which exits
+          # 0), so a bare `result` would read `verify-prod=success` even when
+          # prod was never probed. The mapping (prefer the job's `status` output
+          # when it ran cleanly, else fall back to the raw result) lives in the
+          # bats-tested showcase/scripts/verify-prod-display.sh so it can't
+          # drift from its test (see __tests__/verify-prod-display.bats).
+          PROD_DISPLAY="$(PROD="$PROD" PROD_STATUS="$PROD_STATUS" showcase/scripts/verify-prod-display.sh)"
           if [ "$INPUT" = "__select_a_service__" ]; then
             # Deliberate no-op abort: a human clicked Run without picking a
             # service. resolve-targets exits 1 and the downstream jobs skip.
@@ -387,6 +422,7 @@ jobs:
             echo "state=$STATE"
             echo "icon=$ICON"
             echo "csv=$CSV"
+            echo "prod_display=$PROD_DISPLAY"
           } >> "$GITHUB_OUTPUT"
       - name: Post to #oss-alerts
         if: steps.state.outputs.state == 'failure' && inputs.service != '__select_a_service__' && env.SLACK_WEBHOOK != ''
@@ -408,7 +444,7 @@ jobs:
                 needs.resolve-targets.result,
                 needs.verify-staging-precondition.result,
                 needs.promote.result,
-                needs.verify-prod.result,
+                steps.state.outputs.prod_display,
                 github.server_url,
                 github.repository,
                 github.run_id,

--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -550,9 +550,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y bats
 
-      - name: Shellcheck promote-fleet.sh
+      - name: Shellcheck promote workflow scripts
         # shellcheck is preinstalled on ubuntu-latest.
-        run: shellcheck showcase/scripts/promote-fleet.sh
+        run: shellcheck showcase/scripts/promote-fleet.sh showcase/scripts/verify-prod-display.sh
 
       - name: Run bats suite
         run: bats showcase/scripts/__tests__/

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -674,11 +674,29 @@ module Railway
             end
 
             # 3. For each service, fetch its serviceInstance for this env.
-            #    Some services may not exist in this env (returns nil); skip them.
+            #    Some services may not exist in this env. Railway signals that
+            #    two different ways for the SAME underlying condition:
+            #      (a) the field resolves to null (`serviceInstance` => nil), or
+            #      (b) the query THROWS `GraphQL: ServiceInstance not found`
+            #          (a half-deleted service that still appears in the project
+            #          service list but has no instance in this env).
+            #    Both mean "this service has no instance here" — skip it and keep
+            #    going. We deliberately scope the rescue to ONLY that message so
+            #    every other GraphQL failure (auth, rate-limit, schema drift,
+            #    transient 5xx surfaced as a GraphQL error) still propagates
+            #    fail-loud. Otherwise a single odd service aborts the whole
+            #    snapshot — and with it the whole promote — before any preflight
+            #    runs (see run 27144525566).
             services = []
             service_nodes.each do |node|
-                instance_data = gql.query(SERVICE_INSTANCE_QUERY,
-                    serviceId: node["id"], envId: env_id)
+                begin
+                    instance_data = gql.query(SERVICE_INSTANCE_QUERY,
+                        serviceId: node["id"], envId: env_id)
+                rescue GraphQL::Error => e
+                    raise unless e.message.include?("ServiceInstance not found")
+                    warn "skipping service #{node['name'].inspect} (#{node['id']}): no serviceInstance in this env (#{e.message})"
+                    next
+                end
                 inst = instance_data["serviceInstance"]
                 next if inst.nil?
 

--- a/showcase/bin/spec/test_snapshot_graphql.rb
+++ b/showcase/bin/spec/test_snapshot_graphql.rb
@@ -245,4 +245,65 @@ class SnapshotGraphqlTest < Minitest::Test
             Railway::RollbackCommand::ROLLBACK_MUTATION,
             "deploymentRollback returns Boolean; no selection set allowed.")
     end
+
+    def test_build_snapshot_skips_service_whose_instance_throws_not_found_instead_of_aborting
+        # Regression: run 27144525566. A single odd/half-deleted service in the
+        # project list threw `GraphQL: ServiceInstance not found` from the
+        # per-service serviceInstance query. The only guard was `next if
+        # inst.nil?` — it handled a NULL result but not a THROWN error, so the
+        # error bubbled to Railway.run's top-level `rescue GraphQL::Error` and
+        # aborted the ENTIRE promote (opaque exit 2) before any preflight ran.
+        #
+        # build_snapshot must tolerate a thrown per-service `ServiceInstance not
+        # found` the same way it tolerates nil: skip that one service and keep
+        # going, so the healthy services still produce a usable snapshot.
+        fake = FakeGQL.new(
+            "ProjectServices" => services_list_response,
+            "EnvVariables"    => env_vars_response_with_per_service_keys,
+            "ServiceInstance" => lambda do |vars|
+                if vars[:serviceId] == "svc-aimock"
+                    # Half-deleted / instance-less service: Railway throws this
+                    # exact GraphQL error rather than returning null.
+                    raise Railway::GraphQL::Error, "GraphQL: ServiceInstance not found"
+                else
+                    service_instance_response(
+                        image: "ghcr.io/copilotkit/showcase-shell@sha256:beef1234",
+                        domains: [],
+                    )
+                end
+            end,
+        )
+
+        cmd = Railway::SnapshotCommand.new(["--env", "production", "--dry-run"])
+        cmd.instance_variable_set(:@gql, fake)
+
+        snap = cmd.build_snapshot(Railway::PRODUCTION_ENV_ID)
+
+        # The thrown service is skipped; the healthy one survives.
+        names = snap["services"].map { |s| s["name"] }
+        assert_equal ["shell"], names, "the instance-less service must be skipped, not abort the snapshot"
+        shell = snap["services"].find { |s| s["name"] == "shell" }
+        assert_equal "ghcr.io/copilotkit/showcase-shell@sha256:beef1234", shell["image"]
+    end
+
+    def test_build_snapshot_does_not_swallow_unrelated_graphql_errors
+        # The per-service tolerance MUST be narrow: only a `ServiceInstance not
+        # found` error for an individual service is skippable. Any OTHER GraphQL
+        # failure (auth, rate-limit, schema drift, transient 5xx surfaced as a
+        # GraphQL error) must still propagate fail-loud — never silently hidden.
+        fake = FakeGQL.new(
+            "ProjectServices" => services_list_response,
+            "EnvVariables"    => env_vars_response_with_per_service_keys,
+            "ServiceInstance" => lambda do |_vars|
+                raise Railway::GraphQL::Error, "GraphQL: Not Authorized"
+            end,
+        )
+
+        cmd = Railway::SnapshotCommand.new(["--env", "production", "--dry-run"])
+        cmd.instance_variable_set(:@gql, fake)
+
+        assert_raises(Railway::GraphQL::Error) do
+            cmd.build_snapshot(Railway::PRODUCTION_ENV_ID)
+        end
+    end
 end

--- a/showcase/bin/spec/test_snapshot_ivar_lint.rb
+++ b/showcase/bin/spec/test_snapshot_ivar_lint.rb
@@ -54,33 +54,33 @@ class SnapshotIvarLintTest < Minitest::Test
     #                       prose (do not perform a read)
     ALLOWED_LINES = [
         # `run` — capture full-fleet view before optional narrowing.
-        '1202:@full_staging_snapshot = @staging_snapshot',
-        '1203:@full_prod_snapshot    = @prod_snapshot',
+        '1220:@full_staging_snapshot = @staging_snapshot',
+        '1221:@full_prod_snapshot    = @prod_snapshot',
 
         # Doc comment above narrow_snapshots_to_single_service!.
-        '1211:# Narrow @staging_snapshot and @prod_snapshot to only the named',
+        '1229:# Narrow @staging_snapshot and @prod_snapshot to only the named',
 
         # narrow_snapshots_to_single_service! — the WRITE site.
-        '1219:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1224:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
-        '1225:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1226:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
+        '1237:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1242:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
+        '1243:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1244:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
 
         # Doc comment above capture_snapshots.
-        '1230:# @staging_snapshot / @prod_snapshot directly.',
+        '1248:# @staging_snapshot / @prod_snapshot directly.',
 
         # capture_snapshots — single test-seam assignment site.
-        '1232:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
-        '1233:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
+        '1250:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
+        '1251:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
 
         # Doc comment above the accessor block (explains test seam).
-        '1257:# promote tests stub @staging_snapshot/@prod_snapshot directly',
+        '1275:# promote tests stub @staging_snapshot/@prod_snapshot directly',
 
         # The four accessor bodies — the ONLY sanctioned reads.
-        '1269:@full_staging_snapshot || @staging_snapshot',
-        '1273:@full_prod_snapshot || @prod_snapshot',
-        '1277:@staging_snapshot',
-        '1281:@prod_snapshot',
+        '1287:@full_staging_snapshot || @staging_snapshot',
+        '1291:@full_prod_snapshot || @prod_snapshot',
+        '1295:@staging_snapshot',
+        '1299:@prod_snapshot',
     ].freeze
 
     def setup

--- a/showcase/scripts/__tests__/verify-prod-display.bats
+++ b/showcase/scripts/__tests__/verify-prod-display.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+# Tests for verify-prod-display.sh — derives the verify-prod value shown in the
+# promote-run Slack alert.
+#
+# The bug this guards (see run 27144525566 follow-up): the verify-prod job's
+# empty-CSV skip branch exits 0, so the GitHub job `result` is `success` even
+# though prod was NEVER probed. The notify step used to read that raw `result`
+# and rendered a misleading `verify-prod=success`. The display value must
+# instead distinguish:
+#   * success  — prod was actually probed and passed (job result success +
+#                status output "success").
+#   * skipped  — nothing promoted, so prod verification was skipped (job result
+#                success + status output "skipped").
+#   * failure  — a real probe failure or contract violation (job result
+#                failure; the status output was never written).
+#   * <result> — any other job result (cancelled, etc.) passes through.
+#
+# NB on assertion gating: bats does NOT run test bodies under `set -e`. Only the
+# FINAL command decides pass/fail, so every non-final assertion is written
+# `[[ ... ]] || fail "msg"` to force a hard failure with a diagnostic.
+
+fail() {
+  echo "$1" >&2
+  return 1
+}
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../verify-prod-display.sh"
+  [ -x "$SCRIPT" ] || fail "verify-prod-display.sh missing or not executable at $SCRIPT"
+}
+
+# run_display <PROD> <PROD_STATUS> — invoke the script with the two inputs and
+# capture stdout into $output (bats convention).
+run_display() {
+  PROD="$1" PROD_STATUS="$2" run "$SCRIPT"
+}
+
+@test "prod probed and passed -> success" {
+  run_display "success" "success"
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status"
+  [ "$output" = "success" ] || fail "expected 'success', got '$output'"
+}
+
+@test "nothing promoted, prod skipped -> skipped (not a misleading success)" {
+  run_display "success" "skipped"
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status"
+  [ "$output" = "skipped" ] || fail "expected 'skipped', got '$output'"
+}
+
+@test "real probe failure -> failure (status output never written)" {
+  run_display "failure" ""
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status"
+  [ "$output" = "failure" ] || fail "expected 'failure', got '$output'"
+}
+
+@test "cancelled job result passes through" {
+  run_display "cancelled" ""
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status"
+  [ "$output" = "cancelled" ] || fail "expected 'cancelled', got '$output'"
+}
+
+@test "skipped job result (verify-prod never ran) passes through" {
+  run_display "skipped" ""
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status"
+  [ "$output" = "skipped" ] || fail "expected 'skipped', got '$output'"
+}
+
+@test "defensive: job result success but status output empty -> falls back to result" {
+  # If verify-prod somehow exits 0 without writing status (should not happen,
+  # but be robust), do NOT fabricate a 'success'/'skipped' — surface the raw
+  # job result so the signal is never invented.
+  run_display "success" ""
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status"
+  [ "$output" = "success" ] || fail "expected fallback to 'success', got '$output'"
+}

--- a/showcase/scripts/verify-prod-display.sh
+++ b/showcase/scripts/verify-prod-display.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# verify-prod-display.sh — compute the verify-prod value shown in the promote
+# Slack alert (`verify-prod=<value>`).
+#
+# Extracted from .github/workflows/showcase_promote.yml so the derivation is
+# unit-testable (see __tests__/verify-prod-display.bats), mirroring how
+# promote-fleet.sh was extracted from the same workflow.
+#
+# The bug this fixes (follow-up to run 27144525566): verify-prod's empty-CSV
+# skip branch exits 0, so the GitHub job `result` is `success` even though prod
+# was NEVER probed. The notify step used to render that raw `result` and emit a
+# misleading `verify-prod=success`. We instead read the verify-prod job's own
+# `status` OUTPUT (which it sets to `success` after a real probe, or `skipped`
+# when nothing promoted) and only fall back to the job result for failure /
+# cancelled (where the output was never written).
+#
+# Usage:
+#   PROD=<job-result> PROD_STATUS=<job-output> scripts/verify-prod-display.sh
+#
+# Env:
+#   PROD         (required)  the verify-prod GitHub job `result`
+#                            (success|failure|cancelled|skipped).
+#   PROD_STATUS  (optional)  the verify-prod job's `status` output
+#                            (success|skipped); empty when the job
+#                            failed/cancelled or never wrote it.
+#
+# Prints the display value to stdout. Always exits 0 — this is a pure mapping,
+# not a gate.
+
+set -uo pipefail
+
+PROD="${PROD:-}"
+PROD_STATUS="${PROD_STATUS:-}"
+
+# Prefer the job's own status output when the job ran cleanly (result success).
+# That output disambiguates a real prod probe (`success`) from the empty-CSV
+# skip (`skipped`) — both of which leave the job `result` as `success`. For any
+# other result (failure, cancelled, skipped-because-upstream-aborted) the
+# status output was never written, so surface the raw job result and never
+# fabricate a success/skipped signal.
+if [ "$PROD" = "success" ] && [ -n "$PROD_STATUS" ]; then
+  echo "$PROD_STATUS"
+else
+  echo "$PROD"
+fi


### PR DESCRIPTION
## Summary

Two robustness/signal defects in the showcase staging→prod promote, both surfaced while investigating today's `docs` promote failure ([run 27144525566](https://github.com/CopilotKit/CopilotKit/actions/runs/27144525566)). Shared theme: harden the promote so one odd service can't abort the whole run, and so the alert never reports a green it didn't earn.

### Fix #1 — a single thrown `ServiceInstance not found` no longer aborts the whole promote
`showcase/bin/railway` · `PromoteCommand`/`build_snapshot`

`build_snapshot` enumerates every project service and queries each one's `serviceInstance`. The only guard was `next if inst.nil?` — it handled a **null** result but not a **thrown** `GraphQL: ServiceInstance not found` error (a half-deleted service that still appears in the project service list but has no instance in that env). That error bubbled to `Railway.run`'s top-level `rescue GraphQL::Error` and aborted the **entire** promote with an opaque exit 2 *before any preflight/divergence logic ran*. In run 27144525566 a single odd/transient service threw this and killed the `docs` promote.

- The per-service loop now tolerates a thrown `ServiceInstance not found` for an individual service exactly like the `nil` case: log + skip that one service, keep going.
- The rescue is scoped **narrowly** to that one message — every other GraphQL failure (auth, rate-limit, schema drift, transient 5xx) still propagates fail-loud.

### Fix #2 — `verify-prod` reports `skipped` (not a misleading `success`) when it skipped
`.github/workflows/showcase_promote.yml` · `verify-prod` + `notify`

When the promote fails, the succeeded-service set is empty, so `verify-prod` hits its skip branch and `exit 0`. The GitHub **job result** is therefore `success`, and the `#oss-alerts` Slack line rendered `verify-prod=success` even though prod was never probed — a misleading green.

- `verify-prod` now exports a `status` job output: `success` after a real probe passes, `skipped` on the empty-CSV skip.
- `notify` reads that output (not the raw job result) so the Slack line accurately reads `verify-prod=skipped` vs `success` vs `failure`. A real probe failure / contract violation exits non-zero (job result `failure`, status never written) and the display falls back to the job result.
- Slack formatting is unchanged.

## Tests (red-green)

- **Fix #1** (`showcase/bin/spec/test_snapshot_graphql.rb`): a single thrown `ServiceInstance not found` is skipped (healthy services still snapshot); an **unrelated** GraphQL error still raises. Verified red before the fix, green after. `test_snapshot_ivar_lint.rb` line-pins renumbered to match.
- **Fix #2**: the display mapping is extracted into `showcase/scripts/verify-prod-display.sh` (mirroring `promote-fleet.sh`) so it is unit-testable; `showcase/scripts/__tests__/verify-prod-display.bats` covers success / skipped / failure / cancelled / fallback. Added the new script to the `showcase_validate.yml` shellcheck step.

## Test plan

- [x] `ruby showcase/bin/spec/all_tests.rb` — 129 runs, 0 failures
- [x] `bats showcase/scripts/__tests__/` — 18 ok (incl. 6 new)
- [x] `shellcheck` on both promote scripts — clean
- [x] `actionlint` (+shellcheck) on `showcase_promote.yml` — clean
- [x] `zizmor --min-severity low` (CI config) on changed workflows — clean
- [ ] CI green on the PR