### PR TITLE
fix(showcase): target-scope promote staging-only set-parity REFUSE

### DIFF
--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -1201,9 +1201,10 @@ module Railway
             #   (1) check_expected_prod_domains diffs the fleet-wide
             #       EXPECTED_DOMAINS against the union of custom_domains
             #       in `prod["services"]`. Narrowed prod carries at most
-            #       one service's domains → the other ~4 fleet hosts look
-            #       "missing" → spurious WARN → run_with_preflight_only
-            #       refuses (workflow doesn't pass --confirm-divergence).
+            #       one service's domains → the remaining fleet hosts (the
+            #       other 4 of the 5 public prod hosts) look "missing" →
+            #       spurious WARN → run_with_preflight_only refuses
+            #       (workflow doesn't pass --confirm-divergence).
             #   (2) check_service_set_parity is a fleet-shape invariant
             #       (no env has services the other lacks); evaluating it
             #       on the narrowed pair makes it tautological when both
@@ -1634,14 +1635,24 @@ module Railway
             s_names = (staging["services"] || []).map { |s| s["name"] }.sort
             p_names = (prod["services"] || []).map { |s| s["name"] }.sort
             staging_only = s_names - p_names
-            # For a single-service promote, the only "staging not in prod" name
-            # that must REFUSE is the TARGET itself (the silent-rc=0 footgun:
-            # narrowed prod would skip the absent target with no mutation).
-            # Unrelated staging-only services (harness-workers, starter-* demos)
-            # are legitimately staging-only and are not this promote's concern.
-            staging_only = staging_only & [target] if target
+            prod_only    = p_names - s_names
+            # For a single-service promote, the ONLY parity violation that must
+            # REFUSE is one involving the TARGET itself — in BOTH directions:
+            #   - target in staging but not prod (the silent-rc=0 footgun:
+            #     narrowed prod would skip the absent target with no mutation);
+            #   - target in prod but not staging (the mirror case).
+            # Unrelated services that exist in only one env (harness-workers,
+            # starter-* demos staging-only; a deprecated prod-only service) are
+            # legitimately single-env and are not this promote's concern, so we
+            # scope BOTH arms to the target. Full-fleet promotes (target nil)
+            # retain full-strictness parity on both arms — there, any env-shape
+            # asymmetry across the whole fleet is a genuine REFUSE.
+            if target
+                staging_only = staging_only & [target]
+                prod_only    = prod_only & [target]
+            end
             findings << "REFUSE: services in staging not in prod: #{staging_only.join(', ')}" unless staging_only.empty?
-            findings << "REFUSE: services in prod not in staging: #{(p_names - s_names).join(', ')}" unless (p_names - s_names).empty?
+            findings << "REFUSE: services in prod not in staging: #{prod_only.join(', ')}" unless prod_only.empty?
             findings
         end
 

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -1313,7 +1313,7 @@ module Railway
             # produce the same verdict regardless of whether this run is
             # full-fleet or restricted to a single service. See `run` for
             # the fleet_* rationale.
-            findings.concat(check_service_set_parity(fleet_staging, fleet_prod))
+            findings.concat(check_service_set_parity(fleet_staging, fleet_prod, target: options[:service]))
             findings.concat(check_critical_env_key_parity(target_staging, target_prod))
             findings.concat(check_expected_prod_domains(fleet_prod))
 
@@ -1629,11 +1629,18 @@ module Railway
             :other
         end
 
-        def check_service_set_parity(staging, prod)
+        def check_service_set_parity(staging, prod, target: nil)
             findings = []
             s_names = (staging["services"] || []).map { |s| s["name"] }.sort
             p_names = (prod["services"] || []).map { |s| s["name"] }.sort
-            findings << "REFUSE: services in staging not in prod: #{(s_names - p_names).join(', ')}" unless (s_names - p_names).empty?
+            staging_only = s_names - p_names
+            # For a single-service promote, the only "staging not in prod" name
+            # that must REFUSE is the TARGET itself (the silent-rc=0 footgun:
+            # narrowed prod would skip the absent target with no mutation).
+            # Unrelated staging-only services (harness-workers, starter-* demos)
+            # are legitimately staging-only and are not this promote's concern.
+            staging_only = staging_only & [target] if target
+            findings << "REFUSE: services in staging not in prod: #{staging_only.join(', ')}" unless staging_only.empty?
             findings << "REFUSE: services in prod not in staging: #{(p_names - s_names).join(', ')}" unless (p_names - s_names).empty?
             findings
         end

--- a/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
+++ b/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
@@ -1,30 +1,44 @@
 # frozen_string_literal: true
 
-# bin/railway promote — fleet-scoped invariants must evaluate against the
-# FULL un-narrowed snapshots, not the single-service narrowed view.
+# bin/railway promote — fleet-scoped invariants must read the FULL
+# un-narrowed snapshots, while set-parity is target-scoped for a
+# single-service promote.
 #
-# Background: the per-service `promote <svc>` feature narrows BOTH
-# @staging_snapshot and @prod_snapshot to one service before preflight. Two
-# fleet-scoped checks were incorrectly co-narrowed:
+# Background: the per-service `promote <svc>` feature narrows the
+# target_*/per-service views to one service for the P1..P3/P6 and
+# critical-env-key checks, but the FLEET-SHAPE checks
+# (check_expected_prod_domains, check_service_set_parity) read the FULL
+# un-narrowed fleet_* snapshots — they describe the env, not the promote
+# target. (#5322 removed the earlier co-narrowing of these checks; do NOT
+# reintroduce snapshot narrowing for fleet-scoped checks.)
+#
+# Mechanism under test:
 #
 #   (1) check_expected_prod_domains compares the FLEET-WIDE public-host set
 #       (EXPECTED_DOMAINS[PRODUCTION_ENV_ID]) against the union of
-#       custom_domains across `prod["services"]`. Narrowed prod has ~1
-#       service → ~4 fleet hosts look "missing" → spurious WARN. The real
-#       workflow (.github/workflows/showcase_promote.yml) does NOT pass
-#       --confirm-divergence, so promote refuses on its first iteration and
-#       `set -e` aborts the loop. Healthy fleet, no real divergence,
-#       blocked.
+#       custom_domains across the FULL prod snapshot. The fixture's full
+#       prod fleet carries all 5 public hosts; a narrowed single-service
+#       view of the target owns 0 of them, so reading the narrowed view
+#       would make all 5 look "missing" → spurious WARN → and because the
+#       real workflow (.github/workflows/showcase_promote.yml) does NOT
+#       pass --confirm-divergence, promote would refuse. Reading the FULL
+#       fleet avoids that.
 #
-#   (2) check_service_set_parity diffs staging vs prod service names. After
-#       narrowing both to the same single name, the diff is always empty —
-#       the invariant is dead. Worse: if the target is in staging but
-#       ABSENT from prod, execute_promotion's `next unless find_service`
-#       silently skips and returns rc=0. Operator sees "success" while
-#       prod was untouched.
+#   (2) check_service_set_parity reads the FULL un-narrowed fleet_staging /
+#       fleet_prod snapshots and applies `& [target]` scoping to BOTH the
+#       staging-only and prod-only arms when a single service is targeted.
+#       So a single-service promote REFUSEs only on parity violations
+#       involving the TARGET itself, and tolerates unrelated single-env
+#       services (staging-only harness-workers / starter-* demos, or a
+#       deprecated prod-only service). Full-fleet promotes (target nil)
+#       keep both arms at full fleet strictness.
 #
-# These tests pin the fix contract: fleet-scoped checks read the FULL
-# snapshots; per-service mutation reads the narrowed snapshots.
+# Red-green coverage for THIS PR is provided by the two tolerance tests:
+#   - test_single_service_promote_tolerates_unrelated_staging_only_services
+#   - test_single_service_promote_tolerates_unrelated_prod_only_service
+# The test_healthy_* and test_target_absent_* tests are #5322 regression
+# guards (they pin that fleet-scoped checks read the FULL snapshots and
+# that an absent target still fails loud), not red-green for this change.
 
 require_relative "spec_helper"
 require "stringio"
@@ -96,17 +110,6 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
         def parse_image_ref(ref); Railway::GHCR.allocate.parse_image_ref(ref); end
     end
 
-    # Public hosts as published by EXPECTED_DOMAINS for the production env.
-    # These are the SSOT-derived fleet-wide hosts; pulled here verbatim so
-    # the fixture's full prod snapshot legitimately satisfies the check.
-    FLEET_PUBLIC_PROD_HOSTS = [
-        "dashboard.showcase.copilotkit.ai",
-        "docs.copilotkit.ai",
-        "dojo.showcase.copilotkit.ai",
-        "hooks.showcase.copilotkit.ai",
-        "showcase.copilotkit.ai",
-    ].freeze
-
     def make_staging_service(name)
         {
             "name" => name, "service_id" => "svc-#{name}",
@@ -140,10 +143,17 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
     # (pre-narrow) staging snapshot, exactly where the fleet-scoped
     # set-parity check reads. They are legitimately staging-only and a
     # single-service promote must tolerate them.
-    def install_fleet_fixture(cmd, gql, ghcr, prod_includes_target: true, target: "aimock", staging_only_extras: [])
+    #
+    # `prod_only_extras:` is the mirror: it injects services into the FULL
+    # prod snapshot that have NO staging counterpart — modeling a
+    # deprecated/prod-only service. They land in the full (pre-narrow) prod
+    # snapshot where the prod-only arm of set-parity reads. They are
+    # legitimately prod-only and a single-service promote must tolerate them.
+    def install_fleet_fixture(cmd, gql, ghcr, prod_includes_target: true, target: "aimock",
+                              staging_only_extras: [], prod_only_extras: [])
         # Five "domain-bearing" services so the prod fleet legitimately
-        # carries all FLEET_PUBLIC_PROD_HOSTS, even when promote is
-        # narrowed to a service that doesn't itself own any public host.
+        # carries all 5 public prod hosts, even when promote is narrowed to
+        # a service that doesn't itself own any public host.
         domain_services_prod = [
             make_prod_service("dashboard", custom_domains: ["dashboard.showcase.copilotkit.ai"]),
             make_prod_service("docs",      custom_domains: ["docs.copilotkit.ai"]),
@@ -160,9 +170,15 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
 
         # Staging mirrors prod's service NAMES (set parity) — every prod
         # service has a corresponding staging entry. (For BUG #2, target is
-        # in staging but absent from prod by design.)
+        # in staging but absent from prod by design.) `prod_only_extras` are
+        # deliberately NOT mirrored into staging, so they land in the full
+        # prod snapshot with no staging counterpart.
         staging_names = (domain_services_prod.map { |s| s["name"] } + [target] + staging_only_extras).uniq
         staging_services = staging_names.map { |n| make_staging_service(n) }
+
+        # Inject prod-only extras into the FULL prod snapshot AFTER deriving
+        # staging_names, so they have no staging counterpart.
+        prod_only_extras.each { |n| domain_services_prod << make_prod_service(n) }
 
         cmd.instance_variable_set(:@staging_snapshot, { "services" => staging_services })
         cmd.instance_variable_set(:@prod_snapshot,    { "services" => domain_services_prod })
@@ -203,11 +219,12 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
         Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, original)
     end
 
-    # ── BUG #1: healthy fleet, single-service promote, NO --confirm-divergence.
-    # Today (red): narrowed prod has 1 service whose custom_domains do not
-    # include the 5 fleet public hosts → WARN → run_with_preflight_only
-    # refuses (rc=1) because options[:confirm_divergence] is false.
-    # After fix (green): rc=0, target pinned, siblings untouched.
+    # ── #5322 regression guard: healthy fleet, single-service promote, NO
+    # --confirm-divergence must succeed. check_expected_prod_domains reads the
+    # FULL prod snapshot (all 5 public hosts present), so no phantom domain
+    # WARN is synthesized and the promote proceeds: rc=0, target pinned,
+    # siblings untouched. (This pins that fleet-scoped checks read the full
+    # snapshot; it is a guard, not red-green for the current parity change.)
     def test_healthy_fleet_single_service_promote_without_confirm_divergence_succeeds
         gql  = FakeGQLBenign.new
         ghcr = FakeGHCR.new(resolve_map: {
@@ -244,20 +261,15 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
             "dashboard must not be pinned when only aimock was promoted"
     end
 
-    # ── BUG #2: target exists in staging but is ABSENT from prod.
-    # Today (red): both snapshots get narrowed; service_set_parity (narrowed)
-    # diffs [target] vs [] but the test fixture wouldn't have a prod entry
-    # at all after narrowing... wait — narrowing prod yields an EMPTY
-    # services list (no match). check_service_set_parity then diffs
-    # ["aimock"] vs [] → finds REFUSE "services in staging not in prod".
-    # BUT: the per-service feature's narrowing also narrows staging to
-    # [target], so the diff against an empty prod *should* surface the
-    # REFUSE. Verify the failure mode is the silent-skip path:
-    # execute_promotion's `next unless find_service` for absent prod.
-    #
-    # Either way, the contract is: if the targeted service is in staging
-    # but ABSENT from prod, promote must FAIL LOUD (nonzero rc + clear
-    # message), never silently rc=0 with no pin mutations.
+    # ── #5322 regression guard: target in staging but ABSENT from prod must
+    # FAIL LOUD. check_service_set_parity reads the FULL un-narrowed
+    # fleet_staging / fleet_prod and applies `& [target]` scoping: the target
+    # is in the staging-only set, so the staging-not-in-prod REFUSE survives
+    # scoping and surfaces (never a silent rc=0 with no pin). To prove the
+    # check truly reads the FULL fleet AND applies target-scoping (not merely
+    # a trivially-narrowed pair), the fixture also carries an UNRELATED
+    # staging-only sibling: it must be IGNORED while the target REFUSE fires —
+    # the REFUSE names ONLY the target.
     def test_target_absent_from_prod_fails_loud
         gql  = FakeGQLBenign.new
         ghcr = FakeGHCR.new(resolve_map: {
@@ -265,10 +277,14 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
         })
         cmd = build_cmd(["aimock"])
         # prod_includes_target=false → "aimock" exists in staging but NOT
-        # in the full prod snapshot. The fleet otherwise mirrors itself
-        # (no spurious set-parity issues), so the REFUSE we observe is
-        # specifically the staging-only-target case.
-        install_fleet_fixture(cmd, gql, ghcr, prod_includes_target: false, target: "aimock")
+        # in the full prod snapshot. An unrelated staging-only sibling
+        # ("harness-workers") is injected too: the full fleet thus has TWO
+        # staging-only names, but target-scoping must REFUSE on ONLY the
+        # target. This distinguishes the fix from the buggy full-vs-narrowed
+        # behavior — a check that ignored target-scoping would also name the
+        # sibling.
+        install_fleet_fixture(cmd, gql, ghcr, prod_includes_target: false, target: "aimock",
+                              staging_only_extras: %w[harness-workers])
 
         rc = nil
         out, _ = with_fast_sleeper { capture_io { rc = cmd.run } }
@@ -279,9 +295,16 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
             "Got rc=#{rc.inspect}; out=\n#{out}"
 
         # The error message must be informative — surface the parity
-        # violation rather than a generic / opaque failure.
-        assert_match(/REFUSE: services in staging not in prod/, out,
-            "must surface a clear REFUSE explaining target is missing from prod")
+        # violation rather than a generic / opaque failure. AND it must name
+        # ONLY the target: target-scoping means the unrelated staging-only
+        # sibling is excluded from the REFUSE even though it is in the FULL
+        # fleet's staging-only set. (A check that read the full fleet without
+        # target-scoping would also list "harness-workers" here.)
+        assert_match(/REFUSE: services in staging not in prod: aimock\b/, out,
+            "must surface a clear REFUSE naming the target missing from prod")
+        refute_match(/harness-workers/, out,
+            "target-scoping must exclude unrelated staging-only siblings from " \
+            "the REFUSE — only the target should be named")
 
         assert_empty gql.pinned_services,
             "no pin mutations may be issued when target is absent from prod"
@@ -293,11 +316,12 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
     # starter-* demos (not in SSOT). For a single-service promote of a
     # healthy target (present in both staging and prod) these are irrelevant.
     #
-    # Today (red): check_service_set_parity diffs the FULL staging fleet vs
+    # Red-green for the STAGING-only arm of the target-scoping fix (#5324):
+    # before scoping, check_service_set_parity diffs the FULL staging fleet vs
     # the FULL prod fleet and REFUSEs because the extras are "in staging not
-    # in prod" — blocking an otherwise-clean single-service promote.
-    # After fix (green): the staging-only REFUSE is target-scoped, so the
-    # unrelated extras are ignored; rc=0, target pinned, no REFUSE.
+    # in prod" — blocking an otherwise-clean single-service promote. After
+    # the fix, the staging-only REFUSE is target-scoped, so the unrelated
+    # extras are ignored; rc=0, target pinned, no REFUSE.
     def test_single_service_promote_tolerates_unrelated_staging_only_services
         gql  = FakeGQLBenign.new
         ghcr = FakeGHCR.new(resolve_map: {
@@ -321,6 +345,51 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
 
         refute_match(/REFUSE: services in staging not in prod/, out,
             "staging-only services unrelated to the promote target must not " \
+            "trigger the set-parity REFUSE on a single-service promote")
+
+        pinned = gql.pinned_services
+        assert_equal 1, pinned.size,
+            "exactly one service should be promoted (target only); got #{pinned.inspect}"
+        sid, image = pinned.first
+        assert_equal "prod-docs", sid
+        assert_equal "ghcr.io/copilotkit/docs@sha256:NEW_DOCS", image
+    end
+
+    # ── Single-service promote must TOLERATE unrelated prod-only services.
+    # This is the MIRROR of the staging-only tolerance test and the red-green
+    # for the PROD-only arm of the target-scoping fix (#5324). A prod-only
+    # service (e.g. a deprecated "harness-legacy" still present in prod but
+    # removed from staging) has no bearing on a single-service promote of an
+    # unrelated healthy target.
+    #
+    # Red (before this PR's source change): the prod-only arm of
+    # check_service_set_parity was computed over the FULL fleet
+    # (`(p_names - s_names)`) with NO target scoping, so ANY prod-only service
+    # REFUSEs EVERY single-service promote — "services in prod not in staging"
+    # fires and rc=1. Green (after): the prod-only arm is target-scoped too,
+    # so the unrelated prod-only service is ignored; rc=0, target pinned, no
+    # "in prod not in staging" REFUSE.
+    def test_single_service_promote_tolerates_unrelated_prod_only_service
+        gql  = FakeGQLBenign.new
+        ghcr = FakeGHCR.new(resolve_map: {
+            "ghcr.io/copilotkit/docs:latest" => "sha256:NEW_DOCS",
+        })
+        cmd = build_cmd(["docs"])
+        # Target "docs" is present in BOTH staging and prod. Inject an
+        # unrelated prod-only sibling (no staging counterpart).
+        install_fleet_fixture(cmd, gql, ghcr, prod_includes_target: true, target: "docs",
+                              prod_only_extras: %w[harness-legacy])
+
+        rc = nil
+        out, _ = with_fast_sleeper { capture_io { rc = cmd.run } }
+
+        assert_equal 0, rc,
+            "a single-service promote of a healthy target must NOT be refused " \
+            "because an UNRELATED prod-only service (harness-legacy) exists in " \
+            "prod but not staging. Got rc=#{rc.inspect}; out=\n#{out}"
+
+        refute_match(/REFUSE: services in prod not in staging/, out,
+            "prod-only services unrelated to the promote target must not " \
             "trigger the set-parity REFUSE on a single-service promote")
 
         pinned = gql.pinned_services

--- a/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
+++ b/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
@@ -133,7 +133,14 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
     # EXPECTED_DOMAINS[PRODUCTION_ENV_ID] set, so a healthy fleet must NOT
     # produce a domain WARN. Two of those services ("aimock", "harness")
     # also exist in staging — promote will target one of them.
-    def install_fleet_fixture(cmd, gql, ghcr, prod_includes_target: true, target: "aimock")
+    #
+    # `staging_only_extras:` injects services into the STAGING fleet that
+    # have NO prod counterpart — modeling the live staging-only services
+    # (harness-workers + the 12 starter-* demos). They land in the full
+    # (pre-narrow) staging snapshot, exactly where the fleet-scoped
+    # set-parity check reads. They are legitimately staging-only and a
+    # single-service promote must tolerate them.
+    def install_fleet_fixture(cmd, gql, ghcr, prod_includes_target: true, target: "aimock", staging_only_extras: [])
         # Five "domain-bearing" services so the prod fleet legitimately
         # carries all FLEET_PUBLIC_PROD_HOSTS, even when promote is
         # narrowed to a service that doesn't itself own any public host.
@@ -154,7 +161,8 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
         # Staging mirrors prod's service NAMES (set parity) — every prod
         # service has a corresponding staging entry. (For BUG #2, target is
         # in staging but absent from prod by design.)
-        staging_services = (domain_services_prod.map { |s| s["name"] } + [target]).uniq.map { |n| make_staging_service(n) }
+        staging_names = (domain_services_prod.map { |s| s["name"] } + [target] + staging_only_extras).uniq
+        staging_services = staging_names.map { |n| make_staging_service(n) }
 
         cmd.instance_variable_set(:@staging_snapshot, { "services" => staging_services })
         cmd.instance_variable_set(:@prod_snapshot,    { "services" => domain_services_prod })
@@ -277,5 +285,49 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
 
         assert_empty gql.pinned_services,
             "no pin mutations may be issued when target is absent from prod"
+    end
+
+    # ── Single-service promote must TOLERATE unrelated staging-only services.
+    # The live staging fleet legitimately carries services with no prod
+    # counterpart — harness-workers (SSOT-modeled staging-only) and the 12
+    # starter-* demos (not in SSOT). For a single-service promote of a
+    # healthy target (present in both staging and prod) these are irrelevant.
+    #
+    # Today (red): check_service_set_parity diffs the FULL staging fleet vs
+    # the FULL prod fleet and REFUSEs because the extras are "in staging not
+    # in prod" — blocking an otherwise-clean single-service promote.
+    # After fix (green): the staging-only REFUSE is target-scoped, so the
+    # unrelated extras are ignored; rc=0, target pinned, no REFUSE.
+    def test_single_service_promote_tolerates_unrelated_staging_only_services
+        gql  = FakeGQLBenign.new
+        ghcr = FakeGHCR.new(resolve_map: {
+            "ghcr.io/copilotkit/docs:latest" => "sha256:NEW_DOCS",
+        })
+        cmd = build_cmd(["docs"])
+        # Target "docs" is present in BOTH staging and prod (the domain-
+        # bearing prod fixture already includes a "docs" service, mirrored
+        # into staging). Inject unrelated staging-only siblings.
+        install_fleet_fixture(cmd, gql, ghcr, prod_includes_target: true, target: "docs",
+                              staging_only_extras: %w[harness-workers starter-adk starter-langgraph-python])
+
+        rc = nil
+        out, _ = with_fast_sleeper { capture_io { rc = cmd.run } }
+
+        assert_equal 0, rc,
+            "a single-service promote of a healthy target must NOT be refused " \
+            "because UNRELATED staging-only services (harness-workers, " \
+            "starter-* demos) exist in staging but not prod. " \
+            "Got rc=#{rc.inspect}; out=\n#{out}"
+
+        refute_match(/REFUSE: services in staging not in prod/, out,
+            "staging-only services unrelated to the promote target must not " \
+            "trigger the set-parity REFUSE on a single-service promote")
+
+        pinned = gql.pinned_services
+        assert_equal 1, pinned.size,
+            "exactly one service should be promoted (target only); got #{pinned.inspect}"
+        sid, image = pinned.first
+        assert_equal "prod-docs", sid
+        assert_equal "ghcr.io/copilotkit/docs@sha256:NEW_DOCS", image
     end
 end

--- a/showcase/bin/spec/test_snapshot_ivar_lint.rb
+++ b/showcase/bin/spec/test_snapshot_ivar_lint.rb
@@ -54,33 +54,33 @@ class SnapshotIvarLintTest < Minitest::Test
     #                       prose (do not perform a read)
     ALLOWED_LINES = [
         # `run` — capture full-fleet view before optional narrowing.
-        '1220:@full_staging_snapshot = @staging_snapshot',
-        '1221:@full_prod_snapshot    = @prod_snapshot',
+        '1221:@full_staging_snapshot = @staging_snapshot',
+        '1222:@full_prod_snapshot    = @prod_snapshot',
 
         # Doc comment above narrow_snapshots_to_single_service!.
-        '1229:# Narrow @staging_snapshot and @prod_snapshot to only the named',
+        '1230:# Narrow @staging_snapshot and @prod_snapshot to only the named',
 
         # narrow_snapshots_to_single_service! — the WRITE site.
-        '1237:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1242:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
-        '1243:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1244:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
+        '1238:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1243:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
+        '1244:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1245:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
 
         # Doc comment above capture_snapshots.
-        '1248:# @staging_snapshot / @prod_snapshot directly.',
+        '1249:# @staging_snapshot / @prod_snapshot directly.',
 
         # capture_snapshots — single test-seam assignment site.
-        '1250:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
-        '1251:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
+        '1251:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
+        '1252:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
 
         # Doc comment above the accessor block (explains test seam).
-        '1275:# promote tests stub @staging_snapshot/@prod_snapshot directly',
+        '1276:# promote tests stub @staging_snapshot/@prod_snapshot directly',
 
         # The four accessor bodies — the ONLY sanctioned reads.
-        '1287:@full_staging_snapshot || @staging_snapshot',
-        '1291:@full_prod_snapshot || @prod_snapshot',
-        '1295:@staging_snapshot',
-        '1299:@prod_snapshot',
+        '1288:@full_staging_snapshot || @staging_snapshot',
+        '1292:@full_prod_snapshot || @prod_snapshot',
+        '1296:@staging_snapshot',
+        '1300:@prod_snapshot',
     ].freeze
 
     def setup


### PR DESCRIPTION
## Summary

`showcase/bin/railway`'s `check_service_set_parity` compares the **full** live staging fleet against the **full** prod fleet and emits `REFUSE: services in staging not in prod: <names>` / `REFUSE: services in prod not in staging: <names>` whenever one env carries a service the other lacks. The live staging fleet legitimately contains 13 services with **no prod counterpart**:

- `harness-workers` (SSOT-modeled staging-only)
- 12 `starter-*` demo services (not in SSOT)

For a **single-service** promote (e.g. `docs`) these are irrelevant, but the full-fleet check REFUSEs the whole promote (exit 1). This blocked the prod `docs` promote — see [run 27156146035](https://github.com/CopilotKit/CopilotKit/actions/runs/27156146035). The mirror is equally broken: any **prod-only** service (e.g. a deprecated service still in prod but removed from staging) would REFUSE every unrelated single-service promote via the "prod not in staging" arm.

## The fix

Target-scope **both** arms of the set-parity REFUSE for single-service promotes: intersect the staging-only set AND the prod-only set with the promote target when `--service` is in effect. Unrelated single-env services in either direction are no longer this promote's concern. Full-fleet promotes (`--service` absent, `target` nil) keep both arms at full strictness.

```ruby
staging_only = s_names - p_names
prod_only    = p_names - s_names
if target
    staging_only = staging_only & [target]
    prod_only    = prod_only & [target]
end
```

**Safety invariants preserved (all green in CI tests):**
- A single-service promote whose **target** is in staging but absent from prod **still REFUSEs** (target ∈ staging_only → intersection is `[target]`). The silent-rc=0 footgun is intact.
- The mirror also holds: a single-service promote whose target is in prod but absent from staging still REFUSEs via the prod-only arm.
- **Full-fleet** promotes (`--service` absent, `target` nil) retain full strictness on **both** arms — no intersection applied.
- No change to P6 image/start-command/healthcheck divergence or critical-env-key parity.

## Test plan

- [x] RED→GREEN test `test_single_service_promote_tolerates_unrelated_staging_only_services` (staging-only arm): extends the fleet fixture with a `staging_only_extras:` keyword modeling `harness-workers` + `starter-*` siblings. RED before scoping, GREEN after.
- [x] **New** RED→GREEN test `test_single_service_promote_tolerates_unrelated_prod_only_service` (prod-only arm, the mirror): adds a `prod_only_extras:` keyword injecting a service into the full prod snapshot with no staging counterpart. Confirmed RED against branch HEAD before the source change (`REFUSE: services in prod not in staging: harness-legacy`, rc=1), GREEN after.
- [x] **Strengthened** `test_target_absent_from_prod_fails_loud`: now injects an unrelated staging-only sibling and asserts the REFUSE names **only** the target (`aimock`), proving the check reads the full fleet **and** applies target-scoping (a check ignoring scoping would also name the sibling).
- [x] Rewrote the stale snapshot-narrowing comments (header block + per-test "Today (red)" prose) to describe the real `fleet_*` + `& [target]` contract; the genuine red-green for this PR is the staging-only and prod-only tolerance tests, while `test_healthy_*` / `test_target_absent_*` are #5322 regression guards.
- [x] Removed the dead `FLEET_PUBLIC_PROD_HOSTS` constant (never referenced; fixture hardcodes hosts inline) and corrected the stale "~4 fleet hosts" count.
- [x] Full Ruby spec suite green: `ruby showcase/bin/spec/all_tests.rb` → 131 runs, 450 assertions, 0 failures, 0 errors.
- [x] `test_snapshot_ivar_lint.rb` allowlist renumbered (+1 line shift from a one-line comment edit in `bin/railway`); both ivar-lint self-checks pass.

Complements #5322.
