### PR TITLE
docs(showcase): make promote --help banner truthful

### DIFF
--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -1136,13 +1136,16 @@ module Railway
                         digest resolved from staging's :latest tag. Only valid with a
                         positional SERVICE; errors otherwise.
 
-                      MOVES: image digests (resolved to @sha256: at promote time);
-                             autoUpdate=disabled flag.
-                      VERIFY-REFUSE: service-set parity, critical env-key parity,
-                             startCommand parity, PB superuser auth,
-                             PB collection parity, cross-env URL leak scan.
-                      WARN: missing/extra custom domains, sealed-var heuristics.
-                      IGNORE: env-scoped URLs, volumes.
+                      MOVES: pins prod image to the staging digest (resolved to
+                             @sha256: at promote time) and redeploys.
+                      VERIFY-REFUSE: P1 staging digest exists in GHCR, P2 latest
+                             staging deployment succeeded (+ in-flight race),
+                             P3 staging live-green probe, P6 startCommand/
+                             healthcheckPath/image-shape parity, service-set
+                             parity, critical env-key parity.
+                      WARN: P6 region/replicas/restartPolicy/env-key-set
+                             divergence, missing expected prod custom domains.
+                      IGNORE: env var VALUES, env-scoped URLs, volumes.
 
                       Exit 0 on clean promotion, 1 on refuse/findings, 2 on error.
                 BANNER

--- a/showcase/bin/spec/test_snapshot_ivar_lint.rb
+++ b/showcase/bin/spec/test_snapshot_ivar_lint.rb
@@ -54,33 +54,33 @@ class SnapshotIvarLintTest < Minitest::Test
     #                       prose (do not perform a read)
     ALLOWED_LINES = [
         # `run` — capture full-fleet view before optional narrowing.
-        '1221:@full_staging_snapshot = @staging_snapshot',
-        '1222:@full_prod_snapshot    = @prod_snapshot',
+        '1224:@full_staging_snapshot = @staging_snapshot',
+        '1225:@full_prod_snapshot    = @prod_snapshot',
 
         # Doc comment above narrow_snapshots_to_single_service!.
-        '1230:# Narrow @staging_snapshot and @prod_snapshot to only the named',
+        '1233:# Narrow @staging_snapshot and @prod_snapshot to only the named',
 
         # narrow_snapshots_to_single_service! — the WRITE site.
-        '1238:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1243:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
-        '1244:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1245:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
+        '1241:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1246:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
+        '1247:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1248:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
 
         # Doc comment above capture_snapshots.
-        '1249:# @staging_snapshot / @prod_snapshot directly.',
+        '1252:# @staging_snapshot / @prod_snapshot directly.',
 
         # capture_snapshots — single test-seam assignment site.
-        '1251:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
-        '1252:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
+        '1254:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
+        '1255:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
 
         # Doc comment above the accessor block (explains test seam).
-        '1276:# promote tests stub @staging_snapshot/@prod_snapshot directly',
+        '1279:# promote tests stub @staging_snapshot/@prod_snapshot directly',
 
         # The four accessor bodies — the ONLY sanctioned reads.
-        '1288:@full_staging_snapshot || @staging_snapshot',
-        '1292:@full_prod_snapshot || @prod_snapshot',
-        '1296:@staging_snapshot',
-        '1300:@prod_snapshot',
+        '1291:@full_staging_snapshot || @staging_snapshot',
+        '1295:@full_prod_snapshot || @prod_snapshot',
+        '1299:@staging_snapshot',
+        '1303:@prod_snapshot',
     ].freeze
 
     def setup


### PR DESCRIPTION
## Summary

The `bin/railway promote` `--help` banner (in `showcase/bin/railway`) advertised preflight checks and effects that **do not exist in the code**. This PR rewrites the `MOVES` / `VERIFY-REFUSE` / `WARN` / `IGNORE` lines so they list only what `promote` actually does. **Doc-text-only — no logic changed.**

## Audit: each false claim is ASPIRATIONAL (never implemented in any commit)

I traced every phrase through the full git history of `showcase/bin/railway` (`git log -S`). Every one resolves to the original add `56e85dfd80` — and even there it existed **only as banner text**, never as working logic. None is STALE (none was ever implemented and later removed). I also confirmed repo-wide that none is currently wired into the promote path:

| Banner claim | Verdict | Evidence |
|---|---|---|
| `MOVES: autoUpdate=disabled flag` | **ASPIRATIONAL** | `execute_promotion` only pins the prod image digest + redeploys. The image-pin mutation sets `input: { source: { image: $image } }` only. `auto_updates_disabled` is a vestigial snapshot field **hardcoded to `nil`** and never mutated anywhere. |
| `VERIFY-REFUSE: PB superuser auth` | **ASPIRATIONAL** | No PocketBase authentication happens in promote. `POCKETBASE_SUPERUSER_EMAIL/PASSWORD` are merely two entries in `CRITICAL_ENV_KEYS` — checked for **key-presence parity only**. All real PB auth lives in `showcase/harness/**`, never reached by `bin/railway`. |
| `VERIFY-REFUSE: PB collection parity` | **ASPIRATIONAL** | No collection-schema comparison exists in the promote path. (PB collection access is harness-only.) |
| `VERIFY-REFUSE: cross-env URL leak scan` | **ASPIRATIONAL** | Snapshots capture env-var **NAMES only** (values are explicitly never compared — the code even prints a NOTE saying so), making a value-level leak scan impossible by construction. The original commit's own comment acknowledged "URL leak in env-key NAMES is impossible (we have names only)". |
| `WARN: sealed-var heuristics` | **ASPIRATIONAL** | `isSealed` is fetched in the env-vars GraphQL query but **never read** — only `serviceId` and `name` are consumed. No heuristic exists. |

**Confirmed: none of the five claims is currently wired anywhere** (only the banner text mentioned them).

## The real promote behavior (what the new banner says)

- **MOVES:** pin prod image to the staging digest (resolved to `@sha256:` at promote time) + redeploy.
- **VERIFY-REFUSE:** P1 staging digest exists in GHCR; P2 latest staging deployment succeeded (+ in-flight race); P3 staging live-green probe; P6 startCommand / healthcheckPath / image-shape parity; service-set parity; critical env-key parity.
- **WARN:** P6 region/replicas/restartPolicy/env-key-set divergence; missing expected prod custom domains.
- **IGNORE:** env var VALUES, env-scoped URLs, volumes.

## Banner before → after

**Before:**
```
MOVES: image digests (resolved to @sha256: at promote time);
       autoUpdate=disabled flag.
VERIFY-REFUSE: service-set parity, critical env-key parity,
       startCommand parity, PB superuser auth,
       PB collection parity, cross-env URL leak scan.
WARN: missing/extra custom domains, sealed-var heuristics.
IGNORE: env-scoped URLs, volumes.
```

**After:**
```
MOVES: pins prod image to the staging digest (resolved to
       @sha256: at promote time) and redeploys.
VERIFY-REFUSE: P1 staging digest exists in GHCR, P2 latest
       staging deployment succeeded (+ in-flight race),
       P3 staging live-green probe, P6 startCommand/
       healthcheckPath/image-shape parity, service-set
       parity, critical env-key parity.
WARN: P6 region/replicas/restartPolicy/env-key-set
       divergence, missing expected prod custom domains.
IGNORE: env var VALUES, env-scoped URLs, volumes.
```

## Test change (mechanical, not logic)

`test_snapshot_ivar_lint.rb` pins sanctioned ivar-read sites by **line number** by design (it documents that any line shift above its region requires hand-renumbering). The longer banner shifted those lines by +3, so the `ALLOWED_LINES` entries were renumbered +3. The full Ruby suite (`ruby showcase/bin/spec/all_tests.rb`, the same invocation CI runs) is green: `131 runs, 450 assertions, 0 failures`.

## Test plan
- [x] `ruby -c showcase/bin/railway` — Syntax OK
- [x] `ruby showcase/bin/railway promote --help` renders the corrected banner without error
- [x] `ruby showcase/bin/spec/all_tests.rb` — 131 runs, 0 failures (matches CI's `showcase_lint_prod.yml` invocation)
- [ ] CI green