### PR TITLE
fix(showcase): port-safe image-ref split + decouple promote test fixture from SSOT

### DIFF
--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -1629,7 +1629,7 @@ module Railway
         def image_shape(ref)
             return :missing if ref.nil? || ref.empty?
             return :digest  if ref.include?("@sha256:")
-            return :tag     if ref.include?(":") && ref.split(":", 2).last !~ /\A\s*\z/
+            return :tag     if ref.include?(":") && ref.rsplit_colon.last.to_s !~ /\A\s*\z/
             :other
         end
 
@@ -1772,7 +1772,7 @@ module Railway
             unless image.include?("@sha256:")
                 digest = ghcr.resolve_digest(image)
                 Railway.die!("Could not resolve digest for #{image}.") unless digest
-                base = image.split(":", 2).first
+                base = image.rsplit_colon.first
                 image = "#{base}@#{digest}"
             end
 

--- a/showcase/bin/spec/test_image_ref_colon_split.rb
+++ b/showcase/bin/spec/test_image_ref_colon_split.rb
@@ -54,15 +54,7 @@ class ImageRefColonSplitTest < Minitest::Test
     # port colon, producing the corrupt pin "localhost@sha256:...". RED before
     # the fix, GREEN after.
     def test_pin_preserves_port_base_when_rewriting_to_digest
-        cmd = Railway::PinCommand.new(
-            ["--env", "production", "--service", "shell",
-             "--image", PORT_REF, "--non-interactive", "--yes", "--dry-run"],
-        )
-        cmd.instance_variable_set(:@ghcr, Object.new.tap do |o|
-            def o.resolve_digest(_ref); "sha256:deadbeef"; end
-        end)
-
-        out, _ = capture_io { cmd.run }
+        out = run_pin_dry_run(PORT_REF)
         assert_match(/#{Regexp.escape("#{PORT_REF_BASE}@sha256:deadbeef")}/, out,
             "pin must preserve the full registry:port/org/img base when " \
             "rewriting a tag ref to a digest; got:\n#{out}")
@@ -72,16 +64,36 @@ class ImageRefColonSplitTest < Minitest::Test
 
     # Canonical (no-port) refs must keep working identically through the fix.
     def test_pin_preserves_canonical_base_when_rewriting_to_digest
+        out = run_pin_dry_run(CANONICAL_REF)
+        assert_match(/#{Regexp.escape("#{CANONICAL_BASE}@sha256:deadbeef")}/, out,
+            "canonical ref base must be unchanged by the fix; got:\n#{out}")
+    end
+
+    private
+
+    # Drive PinCommand#run through its tag→digest rewrite under --dry-run while
+    # keeping the test HERMETIC. PinCommand#run resolves the service id via a
+    # fresh `RollbackCommand.new([]).resolve_service_id(...)` BEFORE the dry-run
+    # early-return, which would otherwise issue a real GraphQL call (and `die!`
+    # → exit on a tokenless CI runner, aborting the whole suite). Stub GHCR
+    # digest resolution on the command instance, and stub service-id resolution
+    # at the class level so no network is touched.
+    def run_pin_dry_run(image_ref)
         cmd = Railway::PinCommand.new(
             ["--env", "production", "--service", "shell",
-             "--image", CANONICAL_REF, "--non-interactive", "--yes", "--dry-run"],
+             "--image", image_ref, "--non-interactive", "--yes", "--dry-run"],
         )
         cmd.instance_variable_set(:@ghcr, Object.new.tap do |o|
             def o.resolve_digest(_ref); "sha256:deadbeef"; end
         end)
 
-        out, _ = capture_io { cmd.run }
-        assert_match(/#{Regexp.escape("#{CANONICAL_BASE}@sha256:deadbeef")}/, out,
-            "canonical ref base must be unchanged by the fix; got:\n#{out}")
+        original = Railway::RollbackCommand.instance_method(:resolve_service_id)
+        Railway::RollbackCommand.define_method(:resolve_service_id) { |_env_id, _name| "svc-stub" }
+        begin
+            out, = capture_io { cmd.run }
+            out
+        ensure
+            Railway::RollbackCommand.define_method(:resolve_service_id, original)
+        end
     end
 end

--- a/showcase/bin/spec/test_image_ref_colon_split.rb
+++ b/showcase/bin/spec/test_image_ref_colon_split.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# Port-safe image-ref colon splitting.
+#
+# An image ref may carry a registry PORT (`host:PORT/org/img:tag`). Stripping
+# the tag with a FIRST-colon split (`split(":", 2)`) cuts at the PORT colon and
+# corrupts the ref — `localhost:5000/copilotkit/img:latest` collapses to base
+# `localhost`. The canonical `ghcr.io/...:tag` refs (no port) are unaffected,
+# but the LAST-colon helper (`String#rsplit_colon`, also used by
+# `GHCR#parse_image_ref`) is correct for BOTH shapes. These tests pin that the
+# tag-stripping call sites (`PromoteCommand#image_shape`, `PinCommand#run`'s
+# digest rewrite) use the last-colon semantics consistently.
+
+require_relative "spec_helper"
+
+class ImageRefColonSplitTest < Minitest::Test
+    PORT_REF = "localhost:5000/copilotkit/showcase-shell:latest"
+    PORT_REF_BASE = "localhost:5000/copilotkit/showcase-shell"
+    CANONICAL_REF = "ghcr.io/copilotkit/showcase-shell:latest"
+    CANONICAL_BASE = "ghcr.io/copilotkit/showcase-shell"
+
+    # rsplit_colon is the shared helper — sanity-pin its last-colon semantics
+    # for the port-bearing ref both fixes rely on.
+    def test_rsplit_colon_splits_on_last_colon_for_port_ref
+        base, tag = PORT_REF.rsplit_colon
+        assert_equal PORT_REF_BASE, base
+        assert_equal "latest", tag
+    end
+
+    # ── image_shape: a port-bearing tag ref must classify as :tag AND the tag
+    # detection must read the LAST-colon segment. A first-colon split returns
+    # the port-and-rest segment ("5000/copilotkit/showcase-shell:latest"),
+    # which happens to still classify :tag here, so we additionally assert the
+    # trailing-colon (blank-tag) port ref is NOT misclassified as :tag — that
+    # case is GREEN only with last-colon semantics.
+    def test_image_shape_tags_port_ref
+        c = Railway::PromoteCommand.new(["--non-interactive", "--yes"])
+        assert_equal :tag, c.send(:image_shape, PORT_REF)
+        assert_equal :tag, c.send(:image_shape, CANONICAL_REF)
+    end
+
+    # A port ref with an EMPTY tag (trailing colon) has no real tag. With a
+    # first-colon split the tail is "5000/.../img:" (non-blank) → wrongly :tag.
+    # Last-colon split yields a blank tail → correctly :other. RED before the
+    # fix, GREEN after.
+    def test_image_shape_does_not_tag_port_ref_with_empty_tag
+        c = Railway::PromoteCommand.new(["--non-interactive", "--yes"])
+        assert_equal :other, c.send(:image_shape, "localhost:5000/copilotkit/showcase-shell:")
+    end
+
+    # ── PinCommand#run: when given a tag ref, it resolves the digest then
+    # rewrites the ref as "<base>@<digest>". The <base> MUST retain the full
+    # registry:port/org/img — a first-colon split drops everything after the
+    # port colon, producing the corrupt pin "localhost@sha256:...". RED before
+    # the fix, GREEN after.
+    def test_pin_preserves_port_base_when_rewriting_to_digest
+        cmd = Railway::PinCommand.new(
+            ["--env", "production", "--service", "shell",
+             "--image", PORT_REF, "--non-interactive", "--yes", "--dry-run"],
+        )
+        cmd.instance_variable_set(:@ghcr, Object.new.tap do |o|
+            def o.resolve_digest(_ref); "sha256:deadbeef"; end
+        end)
+
+        out, _ = capture_io { cmd.run }
+        assert_match(/#{Regexp.escape("#{PORT_REF_BASE}@sha256:deadbeef")}/, out,
+            "pin must preserve the full registry:port/org/img base when " \
+            "rewriting a tag ref to a digest; got:\n#{out}")
+        refute_match(/localhost@sha256:/, out,
+            "first-colon split corrupts the base to just the registry host")
+    end
+
+    # Canonical (no-port) refs must keep working identically through the fix.
+    def test_pin_preserves_canonical_base_when_rewriting_to_digest
+        cmd = Railway::PinCommand.new(
+            ["--env", "production", "--service", "shell",
+             "--image", CANONICAL_REF, "--non-interactive", "--yes", "--dry-run"],
+        )
+        cmd.instance_variable_set(:@ghcr, Object.new.tap do |o|
+            def o.resolve_digest(_ref); "sha256:deadbeef"; end
+        end)
+
+        out, _ = capture_io { cmd.run }
+        assert_match(/#{Regexp.escape("#{CANONICAL_BASE}@sha256:deadbeef")}/, out,
+            "canonical ref base must be unchanged by the fix; got:\n#{out}")
+    end
+end

--- a/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
+++ b/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
@@ -17,9 +17,11 @@
 #   (1) check_expected_prod_domains compares the FLEET-WIDE public-host set
 #       (EXPECTED_DOMAINS[PRODUCTION_ENV_ID]) against the union of
 #       custom_domains across the FULL prod snapshot. The fixture's full
-#       prod fleet carries all 5 public hosts; a narrowed single-service
-#       view of the target owns 0 of them, so reading the narrowed view
-#       would make all 5 look "missing" → spurious WARN → and because the
+#       prod fleet carries the full public-host set (every host in
+#       EXPECTED_DOMAINS[PRODUCTION_ENV_ID], currently 5); a narrowed
+#       single-service view of the target owns 0 of them, so reading the
+#       narrowed view would make the entire set look "missing" → spurious
+#       WARN → and because the
 #       real workflow (.github/workflows/showcase_promote.yml) does NOT
 #       pass --confirm-divergence, promote would refuse. Reading the FULL
 #       fleet avoids that.
@@ -238,19 +240,47 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
         Railway::PromoteCommand.new(argv + ["--non-interactive", "--yes"])
     end
 
+    # Zero the promote retry back-off for the duration of the block so the 3x
+    # eventual-consistency retry loop in pin_and_verify doesn't add real wall
+    # time. RETRY_DELAY_SEC is a process-global constant, so this is a global
+    # mutation; the clean seam would be pin_and_verify(sleeper:), but the
+    # cmd.run → pin loop constructs that call internally with no injection
+    # point we can reach without changing bin/railway production logic. So we
+    # keep the swap but make it BULLETPROOF against run-order state leakage:
+    #
+    #   - capture `original` BEFORE any mutation;
+    #   - track whether the swap actually happened (`swapped`) so a failure
+    #     between capture and set never leaves the const removed/zeroed;
+    #   - restore in `ensure` (runs even if the block raises);
+    #   - swap via const_set with warnings silenced (no remove_const churn /
+    #     "already initialized constant" warning), and restore the EXACT prior
+    #     value so no perturbed state can leak into a later test in the
+    #     randomized run order.
     def with_fast_sleeper
         original = Railway::PromoteCommand.const_get(:RETRY_DELAY_SEC)
-        Railway::PromoteCommand.send(:remove_const, :RETRY_DELAY_SEC)
-        Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, 0)
+        swapped  = false
+        silence_const_redefinition { Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, 0) }
+        swapped = true
         yield
     ensure
-        Railway::PromoteCommand.send(:remove_const, :RETRY_DELAY_SEC)
-        Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, original)
+        silence_const_redefinition { Railway::PromoteCommand.const_set(:RETRY_DELAY_SEC, original) } if swapped
+    end
+
+    # const_set over an existing constant emits a Ruby "already initialized
+    # constant" warning; suppress it locally so the suite output stays clean
+    # without touching the process-global $VERBOSE beyond this block.
+    def silence_const_redefinition
+        prev = $VERBOSE
+        $VERBOSE = nil
+        yield
+    ensure
+        $VERBOSE = prev
     end
 
     # ── #5322 regression guard: healthy fleet, single-service promote, NO
     # --confirm-divergence must succeed. check_expected_prod_domains reads the
-    # FULL prod snapshot (all 5 public hosts present), so no phantom domain
+    # FULL prod snapshot (the full EXPECTED_DOMAINS[PRODUCTION_ENV_ID]
+    # public-host set present), so no phantom domain
     # WARN is synthesized and the promote proceeds: rc=0, target pinned,
     # siblings untouched. (This pins that fleet-scoped checks read the full
     # snapshot; it is a guard, not red-green for the current parity change.)

--- a/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
+++ b/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
@@ -175,7 +175,18 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
             "fixture target #{target.inspect} must be a real SSOT staging service"
         # Plus the targeted service (no public domain of its own — e.g. an
         # internal aimock). Optionally OMIT it from prod to exercise BUG #2.
-        domain_services_prod << make_prod_service(target) if prod_includes_target
+        #
+        # GUARD: if `target` already owns a public prod host it is ALREADY in
+        # `domain_services_prod` above. Appending make_prod_service(target)
+        # again would produce a malformed fleet with the SAME prod service
+        # (service_id "prod-#{target}") listed twice — once domain-bearing,
+        # once with custom_domains:[] — contradicting this helper's own
+        # "no public domain of its own" contract. So only append the bare
+        # target when it is NOT already a derived domain owner.
+        derived_owner_names = domain_services_prod.map { |s| s["name"] }
+        if prod_includes_target && !derived_owner_names.include?(target)
+            domain_services_prod << make_prod_service(target)
+        end
         # And a non-targeted sibling that exists in both staging and prod —
         # picked from STAGING_SERVICES as a real service that owns no public
         # prod host, so it stays distinct from the domain-bearing set above.
@@ -416,5 +427,43 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
         sid, image = pinned.first
         assert_equal "prod-docs", sid
         assert_equal "ghcr.io/copilotkit/docs@sha256:NEW_DOCS", image
+    end
+
+    # ── Fixture well-formedness: the derived prod snapshot must NEVER list the
+    # same prod service twice. When the promote target already owns a public
+    # prod host (e.g. "docs" owns docs.copilotkit.ai), the SSOT-derivation
+    # already includes it among the domain-bearing services; the helper must
+    # not ALSO append a bare make_prod_service(target), which would yield two
+    # services with the same name + service_id ("prod-docs") — one
+    # domain-bearing, one with custom_domains:[] — a malformed fleet shape that
+    # contradicts the helper's "no public domain of its own" contract and is
+    # only masked downstream by find_service first-match + .uniq. We assert the
+    # invariant directly against the snapshot the fixture installs.
+    def test_install_fleet_fixture_produces_no_duplicate_prod_services
+        gql  = FakeGQLBenign.new
+        ghcr = FakeGHCR.new
+        cmd  = build_cmd(["docs"])
+        # "docs" owns a public prod host, so it is the case that previously
+        # produced a duplicate prod-docs entry.
+        install_fleet_fixture(cmd, gql, ghcr, prod_includes_target: true, target: "docs")
+
+        prod = cmd.instance_variable_get(:@prod_snapshot)
+        names = (prod["services"] || []).map { |s| s["name"] }
+        dups  = names.tally.select { |_, count| count > 1 }.keys
+        assert_empty dups,
+            "derived prod snapshot must not list any service name twice; " \
+            "duplicates=#{dups.inspect} in #{names.inspect}"
+
+        ids = (prod["services"] || []).map { |s| s["service_id"] }
+        id_dups = ids.tally.select { |_, count| count > 1 }.keys
+        assert_empty id_dups,
+            "derived prod snapshot must not list any service_id twice; " \
+            "duplicate ids=#{id_dups.inspect} in #{ids.inspect}"
+
+        # The target must still be present in prod exactly once (a healthy
+        # single-service promote target), so the tolerance tests above keep
+        # genuinely exercising a present-in-both target.
+        assert_equal 1, names.count("docs"),
+            "the promote target must appear in the prod fleet exactly once"
     end
 end

--- a/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
+++ b/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
@@ -151,21 +151,39 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
     # legitimately prod-only and a single-service promote must tolerate them.
     def install_fleet_fixture(cmd, gql, ghcr, prod_includes_target: true, target: "aimock",
                               staging_only_extras: [], prod_only_extras: [])
-        # Five "domain-bearing" services so the prod fleet legitimately
-        # carries all 5 public prod hosts, even when promote is narrowed to
-        # a service that doesn't itself own any public host.
-        domain_services_prod = [
-            make_prod_service("dashboard", custom_domains: ["dashboard.showcase.copilotkit.ai"]),
-            make_prod_service("docs",      custom_domains: ["docs.copilotkit.ai"]),
-            make_prod_service("dojo",      custom_domains: ["dojo.showcase.copilotkit.ai"]),
-            make_prod_service("webhooks",  custom_domains: ["hooks.showcase.copilotkit.ai"]),
-            make_prod_service("shell",     custom_domains: ["showcase.copilotkit.ai"]),
-        ]
-        # Plus the targeted service (no public domain of its own — it's an
+        # DERIVE-FROM-SSOT INVARIANT: the "domain-bearing" prod services and
+        # their public hosts are derived from the SAME constant the prod code
+        # reads — Railway::EXPECTED_DOMAINS[PRODUCTION_ENV_ID] — rather than
+        # re-hardcoding host literals here. This keeps the fixture coupled to
+        # the SSOT (showcase/scripts/railway-envs.generated.json): when the
+        # SSOT public-host set changes, this fixture moves with it instead of
+        # synthesizing phantom-domain WARNs or breaking the parity die!.
+        #
+        # Each public host is mapped back to its owning SSOT service name so
+        # the fixture's prod fleet legitimately carries all public prod hosts,
+        # even when promote is narrowed to a service that owns no public host.
+        public_hosts = Railway::EXPECTED_DOMAINS[Railway::PRODUCTION_ENV_ID]
+        ssot_services = Railway::SSOT_DATA.fetch("services")
+        domain_services_prod = public_hosts.map do |host|
+            owner = ssot_services.find { |s| s.dig("domains", "prod") == host }
+            make_prod_service(owner.fetch("name"), custom_domains: [host])
+        end
+        # The promote target must be a real SSOT staging service (this is what
+        # the prod code validates against), so assert it rather than trusting a
+        # bare literal that could silently drift from the SSOT.
+        assert_includes Railway::STAGING_SERVICES, target,
+            "fixture target #{target.inspect} must be a real SSOT staging service"
+        # Plus the targeted service (no public domain of its own — e.g. an
         # internal aimock). Optionally OMIT it from prod to exercise BUG #2.
         domain_services_prod << make_prod_service(target) if prod_includes_target
-        # And a non-targeted sibling that exists in both staging and prod.
-        sibling = "harness"
+        # And a non-targeted sibling that exists in both staging and prod —
+        # picked from STAGING_SERVICES as a real service that owns no public
+        # prod host, so it stays distinct from the domain-bearing set above.
+        domain_owner_names = domain_services_prod.map { |s| s["name"] }
+        sibling = Railway::STAGING_SERVICES.find do |n|
+            !domain_owner_names.include?(n) && n != target &&
+                ssot_services.find { |s| s["name"] == n }&.dig("domains", "prod")&.end_with?(".up.railway.app")
+        end
         domain_services_prod << make_prod_service(sibling)
 
         # Staging mirrors prod's service NAMES (set parity) — every prod


### PR DESCRIPTION
## Summary

Two related hardening fixes to the showcase promote tooling (`showcase/bin/railway` + its specs). No version bump, no behavior change for canonical inputs.

### Fix A — port-safe image-ref colon splitting (latent / port-ref-only)
`PinCommand#run` and `PromoteCommand#image_shape` stripped the image tag with a first-colon `split(":", 2)`. For a `host:PORT/org/img:tag` ref this cuts at the **registry port colon** and corrupts the ref (`localhost:5000/copilotkit/img:latest` → base `localhost`). Both call sites now use the existing last-colon `String#rsplit_colon` helper — the same one `GHCR#parse_image_ref` already uses — so tag stripping is consistent and port-safe.

Canonical `ghcr.io/...:tag` refs (no port) are **unaffected today**, so this is a latent correctness fix, not a live bug. Red-green unit coverage added in `test_image_ref_colon_split.rb`:
- `host:PORT/img:tag` pins to the full base `+@sha256` (RED → GREEN)
- empty-tag port ref (`host:PORT/img:`) no longer misclassified as `:tag` (RED → GREEN)
- canonical refs and `rsplit_colon` semantics pinned as guards

### Fix B — decouple promote test fixture from the live SSOT
`test_promote_single_service_fleet_invariants.rb`'s `install_fleet_fixture` hardcoded the 5 public prod hosts and the tests hardcoded service names. An SSOT change (`railway-envs.generated.json`) would break these tests with confusing phantom-domain `WARN` / parity `die!` failures — a brittle gate around the promote logic.

The fixture now derives its domain-bearing prod services from the **same constant the prod code reads** — `Railway::EXPECTED_DOMAINS[PRODUCTION_ENV_ID]` — mapping each public host back to its owning SSOT service, and selects the target/sibling from `Railway::STAGING_SERVICES` instead of bare strings. The derive-from-SSOT invariant is documented inline. Behavior is identical for the current SSOT — all four existing tests stay green.

## Scope guardrails
- Touches ONLY these two concerns. Does not touch the promote banner or `check_service_set_parity` logic.
- `bin/railway` edits are line-count-neutral and below the ivar-lint allowlist region, so `test_snapshot_ivar_lint.rb` needed **no** renumbering.

## Test plan
- [x] Fix A red-green: tests FAIL on unmodified source, PASS after the helper swap
- [x] Fix B: all 4 existing fleet-invariant tests stay green
- [x] Full Ruby suite green: `ruby showcase/bin/spec/all_tests.rb` → 136 runs, 469 assertions, 0 failures
- [ ] CI green (`showcase_lint_prod` runs the same suite)