### PR TITLE
docs: simplify README agent-skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,19 +80,19 @@ https://github.com/user-attachments/assets/72b7b4f3-b6e7-460c-a932-5746fe3c8db3
 - **Generative UI** – Allows agents to generate and update UI components dynamically at runtime based on user intent and agent state.
 - **Shared State** – A synchronized state layer that both agents and UI components can read from and write to in real time.
 - **Human-in-the-Loop** – Lets agents pause execution to request user input, confirmation, or edits before continuing.
-- **Self-Learning** *(early access)* – Agents that continuously improve from user feedback via in-context reinforcement learning (CLHF).
+- **Self-Learning** _(early access)_ – Agents that continuously improve from user feedback via in-context reinforcement learning (CLHF).
 
 ## 🧩 Works With Your Stack
 
 One agent backend. Every frontend.
 
-| Platform           | Status       | Get Started                                                 |
-| ------------------ | ------------ | ----------------------------------------------------------- |
-| ⚛️ React / Next.js | ✅ GA        | [Quickstart](https://docs.copilotkit.ai/built-in-agent/quickstart) |
-| 🅰️ Angular         | ✅ Supported | [Source Code - Quickstart coming soon](https://github.com/CopilotKit/CopilotKit/tree/main/packages/angular) |
-| 💚 Vue             | ✅ Supported | [Source Code - Quickstart coming soon](https://github.com/CopilotKit/CopilotKit/tree/main/packages/vue) |
-| 📱 React Native    | ✅ Supported | [Quickstart](https://docs.copilotkit.ai/react-native) |
-| 💬 Slack / MS Teams / Discord / Google Chat | 🟡 Beta  | [Request early access](https://go.copilotkit.ai/beyond-the-web-form) |
+| Platform                                    | Status       | Get Started                                                                                                 |
+| ------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------- |
+| ⚛️ React / Next.js                          | ✅ GA        | [Quickstart](https://docs.copilotkit.ai/built-in-agent/quickstart)                                          |
+| 🅰️ Angular                                  | ✅ Supported | [Source Code - Quickstart coming soon](https://github.com/CopilotKit/CopilotKit/tree/main/packages/angular) |
+| 💚 Vue                                      | ✅ Supported | [Source Code - Quickstart coming soon](https://github.com/CopilotKit/CopilotKit/tree/main/packages/vue)     |
+| 📱 React Native                             | ✅ Supported | [Quickstart](https://docs.copilotkit.ai/react-native)                                                       |
+| 💬 Slack / MS Teams / Discord / Google Chat | 🟡 Beta      | [Request early access](https://go.copilotkit.ai/beyond-the-web-form)                                        |
 
 Your agent logic stays the same — AG-UI handles the wire protocol, CopilotKit handles the UI layer for each framework.
 
@@ -125,7 +125,6 @@ Available via CopilotKit Cloud or self-hosted.
 🔒 **Early access:** We're onboarding teams now.
 
 👉 **[Request early access →](https://go.copilotkit.ai/beyond-the-web-form)**
-
 
 https://github.com/user-attachments/assets/7372b27b-8def-40fb-a11d-1f6585f556ad
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ Up and running in under five minutes. All you need is an LLM key (OpenAI, Anthro
 npx copilotkit@latest create
 ```
 
+## Agent Skills
+
+CopilotKit ships [agent skills](https://docs.copilotkit.ai) that teach your coding agent (Claude Code, Codex, Cursor, Gemini, and others) how to set up, build with, integrate, debug, and upgrade CopilotKit.
+
+Install them into any project directory:
+
+```bash
+npx copilotkit@latest skills install
+```
+
+Run it again any time to refresh to the latest skills.
+
 ## Bring Your App to Life
 
 https://github.com/user-attachments/assets/72b7b4f3-b6e7-460c-a932-5746fe3c8db3
@@ -238,39 +250,6 @@ Here are a few useful resources to help you get started:
 - For documentation-related contributions, [check out the documentation contributions guide](https://docs.copilotkit.ai/contributing/docs-contributions?ref=github_readme).
 
 - Want to contribute but not sure how? [Join our Discord](https://discord.gg/6dffbvGU3D) and we'll help you out!
-
-## Install as a Claude Code plugin
-
-The CopilotKit monorepo doubles as a Claude Code plugin — all 9 skills (3 package meta-skills + 6 lifecycle journey skills) are available once installed.
-
-Add the repo as a Claude Code marketplace:
-
-```bash
-claude plugin marketplace add https://github.com/CopilotKit/CopilotKit
-claude plugin install copilotkit
-```
-
-Skills are discovered from `skills/<slug>/SKILL.md` at the repo root. The three package meta-skills (`runtime`, `react-core`, `a2ui-renderer`) are **generated mirrors** of the source-of-truth files at `packages/<pkg>/skills/<pkg>/` — do not edit the mirror directly. To update content, edit the source under `packages/*/skills/` and run:
-
-```bash
-pnpm sync:plugin-skills
-```
-
-A lefthook pre-commit check (`pnpm check:plugin-skills`) rejects commits that drift the mirror. The plugin version is pinned to `packages/runtime/package.json` and is also kept in sync by the same script.
-
-### Skill inventory
-
-| Slug                     | Type      | Source                                         |
-| ------------------------ | --------- | ---------------------------------------------- |
-| `runtime`                | core      | `packages/runtime/skills/runtime/`             |
-| `react-core`             | framework | `packages/react-core/skills/react-core/`       |
-| `a2ui-renderer`          | framework | `packages/a2ui-renderer/skills/a2ui-renderer/` |
-| `0-to-working-chat`      | lifecycle | `skills/0-to-working-chat/`                    |
-| `spa-without-runtime`    | lifecycle | `skills/spa-without-runtime/`                  |
-| `go-to-production`       | lifecycle | `skills/go-to-production/`                     |
-| `scale-to-multi-agent`   | lifecycle | `skills/scale-to-multi-agent/`                 |
-| `v1-to-v2-migration`     | lifecycle | `skills/v1-to-v2-migration/`                   |
-| `debug-and-troubleshoot` | lifecycle | `skills/debug-and-troubleshoot/`               |
 
 ## 📄 License
 


### PR DESCRIPTION
Replaces the "Install as a Claude Code plugin" section and its skill-inventory table with our recommended one-line install:

```bash
npx copilotkit@latest skills install
```

**Why:**

- The hand-maintained skill table goes stale fast. It already listed 9 skills and 6 lifecycle slugs that no longer exist (there are 11 skills now).
- `npx copilotkit@latest skills install` is our new recommended way to install the skills. It works across Claude Code, Codex, Cursor, Gemini, and others, and always pulls the latest.

**Two commits, reviewed separately:**

1. `style: format README with oxfmt`. README has failed `oxfmt` on main since 1e70dae97 widened the lint-fix glob to cover markdown but never backfilled existing files. This runs the formatter once so the file conforms, which also keeps the content change below from being buried under whole-file reformat noise. Render-neutral: only emphasis markers and table column padding, which GitHub renders identically.
2. `docs: simplify README agent-skills section`. The actual content change. Surgical, one section.