### PR TITLE
build(core): raise build heap ceiling to 8GB via cross-env

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsdown",
+    "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsdown",
     "size": "size-limit",
     "compat-check": "es-check es2022 --module 'dist/**/!(*.umd).{mjs,cjs,js}' && es-check es2018 'dist/**/*.umd.js'",
     "dev": "tsdown --watch",
@@ -49,6 +49,7 @@
     "@valibot/to-json-schema": "^1.5.0",
     "@vitest/coverage-v8": "^3.2.4",
     "arktype": "^2.1.29",
+    "cross-env": "^10.1.0",
     "tsdown": "^0.20.3",
     "typescript": "5.8.2",
     "valibot": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2581,6 +2581,9 @@ importers:
       arktype:
         specifier: ^2.1.29
         version: 2.1.29
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       tsdown:
         specifier: ^0.20.3
         version: 0.20.3(@arethetypeswrong/core@0.18.2)(publint@0.3.17)(synckit@0.11.12)(typescript@5.8.2)
@@ -6330,6 +6333,9 @@ packages:
   '@envelop/types@5.2.1':
     resolution: {integrity: sha512-CsFmA3u3c2QoLDTfEpGr4t25fjMU31nyvse7IzWTvb0ZycuPjMjb0fjlheh+PbhBYb9YLugnT2uY6Mwcg1o+Zg==}
     engines: {node: '>=18.0.0'}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -15243,6 +15249,11 @@ packages:
   croner@9.1.0:
     resolution: {integrity: sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==}
     engines: {node: '>=18.0'}
+
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
@@ -30635,6 +30646,8 @@ snapshots:
       '@whatwg-node/promise-helpers': 1.3.2
       tslib: 2.8.1
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
@@ -41809,6 +41822,11 @@ snapshots:
   croner@10.0.1: {}
 
   croner@9.1.0: {}
+
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-env@7.0.3:
     dependencies:


### PR DESCRIPTION
## What

Bake a heap ceiling into the `@copilotkit/core` build script:

```diff
-"build": "tsdown",
+"build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsdown",
```

(`cross-env` is already used elsewhere in the repo; added here as a core devDependency.)

## Why

The core build (tsdown + dts generation) has a ~3.45GB working set and OOMs under `nx run-many`, where it competes with sibling builds and GC falls behind.

This mostly bites **local development**. Agents (and humans) routinely have to prefix commits with `NODE_OPTIONS=--max-old-space-size=8192` just to get the build through pre-commit hooks. CI already sets this flag at the workflow level, so baking it into the build script means every invocation path gets the same headroom without anyone remembering to add it: local lefthook hooks, `nx run-many`, a direct `pnpm build`, CI, and Windows (hence `cross-env`).

Scoped to core only, since it's the single package that OOMs.
