### PR TITLE
fix(security): harden MCP Apps iframe sandbox

### DIFF
--- a/packages/react-core/src/v2/components/MCPAppsActivityRenderer.tsx
+++ b/packages/react-core/src/v2/components/MCPAppsActivityRenderer.tsx
@@ -29,13 +29,29 @@ function buildSandboxHTML(extraCspDomains?: string[]): string {
 if(window.self===window.top){throw new Error("This file must be used in an iframe.")}
 const inner=document.createElement("iframe");
 inner.style="width:100%;height:100%;border:none;";
-inner.setAttribute("sandbox","allow-scripts allow-same-origin allow-forms");
+// Default sandbox intentionally omits allow-same-origin: combining it with
+// allow-scripts neuters the sandbox per HTML spec. The MCP-app HTML loaded
+// into srcdoc below is server-supplied (third-party MCP), so it must run in
+// an opaque-origin context to prevent access to the host page's cookies,
+// localStorage, DOM, and authenticated fetches.
+inner.setAttribute("sandbox","allow-scripts allow-forms");
 document.body.appendChild(inner);
+// Sandbox tokens an MCP server may request via ui/notifications/sandbox-resource-ready.
+// allow-same-origin is forbidden because together with allow-scripts it
+// removes sandboxing entirely.
+const ALLOWED_SANDBOX_TOKENS=["allow-scripts","allow-forms","allow-popups","allow-modals","allow-downloads","allow-pointer-lock","allow-popups-to-escape-sandbox","allow-presentation"];
+function sanitizeSandbox(s){
+if(typeof s!=="string")return null;
+const tokens=s.split(/\\s+/).filter(Boolean);
+const safe=tokens.filter(t=>ALLOWED_SANDBOX_TOKENS.indexOf(t)!==-1);
+return safe.length?safe.join(" "):null;
+}
 window.addEventListener("message",async(event)=>{
 if(event.source===window.parent){
 if(event.data&&event.data.method==="ui/notifications/sandbox-resource-ready"){
 const{html,sandbox}=event.data.params;
-if(typeof sandbox==="string")inner.setAttribute("sandbox",sandbox);
+const safeSandbox=sanitizeSandbox(sandbox);
+if(safeSandbox)inner.setAttribute("sandbox",safeSandbox);
 if(typeof html==="string")inner.srcdoc=html;
 }else if(inner&&inner.contentWindow){
 inner.contentWindow.postMessage(event.data,"*");
@@ -446,10 +462,12 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
           iframe.style.border = "none";
           iframe.style.backgroundColor = "transparent";
           iframe.style.display = "block";
-          iframe.setAttribute(
-            "sandbox",
-            "allow-scripts allow-same-origin allow-forms",
-          );
+          // Sandbox the proxy iframe with allow-scripts only. The proxy
+          // only runs the inline relay script from buildSandboxHTML — it does
+          // not need same-origin access, form submission, or any other
+          // capability. Keeping it minimal limits blast radius if a future
+          // change introduces an XSS in the proxy HTML itself.
+          iframe.setAttribute("sandbox", "allow-scripts");
 
           // Wait for sandbox proxy to be ready
           const sandboxReady = new Promise<void>((resolve) => {

--- a/packages/vue/src/v2/components/MCPAppsActivityRenderer.ts
+++ b/packages/vue/src/v2/components/MCPAppsActivityRenderer.ts
@@ -28,13 +28,29 @@ function buildSandboxHTML(extraCspDomains?: string[]): string {
 if(window.self===window.top){throw new Error("This file must be used in an iframe.")}
 const inner=document.createElement("iframe");
 inner.style="width:100%;height:100%;border:none;";
-inner.setAttribute("sandbox","allow-scripts allow-same-origin allow-forms");
+// Default sandbox intentionally omits allow-same-origin: combining it with
+// allow-scripts neuters the sandbox per HTML spec. The MCP-app HTML loaded
+// into srcdoc below is server-supplied (third-party MCP), so it must run in
+// an opaque-origin context to prevent access to the host page's cookies,
+// localStorage, DOM, and authenticated fetches.
+inner.setAttribute("sandbox","allow-scripts allow-forms");
 document.body.appendChild(inner);
+// Sandbox tokens an MCP server may request via ui/notifications/sandbox-resource-ready.
+// allow-same-origin is forbidden because together with allow-scripts it
+// removes sandboxing entirely.
+const ALLOWED_SANDBOX_TOKENS=["allow-scripts","allow-forms","allow-popups","allow-modals","allow-downloads","allow-pointer-lock","allow-popups-to-escape-sandbox","allow-presentation"];
+function sanitizeSandbox(s){
+if(typeof s!=="string")return null;
+const tokens=s.split(/\\s+/).filter(Boolean);
+const safe=tokens.filter(t=>ALLOWED_SANDBOX_TOKENS.indexOf(t)!==-1);
+return safe.length?safe.join(" "):null;
+}
 window.addEventListener("message",async(event)=>{
 if(event.source===window.parent){
 if(event.data&&event.data.method==="ui/notifications/sandbox-resource-ready"){
 const{html,sandbox}=event.data.params;
-if(typeof sandbox==="string")inner.setAttribute("sandbox",sandbox);
+const safeSandbox=sanitizeSandbox(sandbox);
+if(safeSandbox)inner.setAttribute("sandbox",safeSandbox);
 if(typeof html==="string")inner.srcdoc=html;
 }else if(inner&&inner.contentWindow){
 inner.contentWindow.postMessage(event.data,"*");
@@ -423,10 +439,12 @@ export const MCPAppsActivityRenderer = defineComponent({
             iframe.style.border = "none";
             iframe.style.backgroundColor = "transparent";
             iframe.style.display = "block";
-            iframe.setAttribute(
-              "sandbox",
-              "allow-scripts allow-same-origin allow-forms",
-            );
+            // Sandbox the proxy iframe with allow-scripts only. The proxy
+            // only runs the inline relay script from buildSandboxHTML — it
+            // does not need same-origin access, form submission, or any other
+            // capability. Keeping it minimal limits blast radius if a future
+            // change introduces an XSS in the proxy HTML itself.
+            iframe.setAttribute("sandbox", "allow-scripts");
 
             const sandboxReady = new Promise<void>((resolve) => {
               initialListener = (event: MessageEvent) => {


### PR DESCRIPTION
## Summary

The MCP Apps iframe sandbox in `MCPAppsActivityRenderer` (both `react-core` and `vue`) sets `sandbox="allow-scripts allow-same-origin allow-forms"` for the inner iframe that renders server-supplied HTML from third-party MCP servers, and the same flag set on the outer proxy iframe. Per the HTML Living Standard ([MDN: iframe sandbox](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox)):

> When the embedded document has the same origin as the embedding page, it is strongly discouraged to use both `allow-scripts` and `allow-same-origin`, as that lets the embedded document remove the sandbox attribute — making it no more secure than not using the sandbox attribute at all.

The MCP-app HTML in the inner iframe is third-party content (returned by whatever MCP server the user has configured), so it should run in an opaque-origin context.

CopilotKit's own published guidance for `open-generative-ui` already mandates this boundary — `showcase/integrations/google-adk/qa/open-gen-ui-advanced.md:61` and the e2e specs in `showcase/integrations/*/tests/e2e/open-gen-ui.spec.ts:16` both pin `sandbox="allow-scripts"` only for that surface. This PR brings the new MCP Apps renderer in line with that same policy.

## Impact

Without this change, scripts in the MCP-app's HTML run as same-origin as the host page that embeds CopilotKit, defeating the sandbox isolation that the protocol design implies.

## Location

- `packages/react-core/src/v2/components/MCPAppsActivityRenderer.tsx` (default inner sandbox at L32, outer proxy sandbox at L451)
- `packages/vue/src/v2/components/MCPAppsActivityRenderer.ts` (same two sites: L31 and L428)

## Fix

Three changes per file:

1. **Outer proxy iframe**: `sandbox="allow-scripts"` only. The proxy iframe runs the inline message-relay script from `buildSandboxHTML` and needs no other capabilities.
2. **Inner iframe default**: `sandbox="allow-scripts allow-forms"` (drops `allow-same-origin`). Forms are kept so legitimate MCP-app UIs with inputs still work; the origin sharing is what removes the sandbox.
3. **`ui/notifications/sandbox-resource-ready` override**: the server-supplied `sandbox` string is now sanitized against an allowlist of safe tokens (`allow-scripts`, `allow-forms`, `allow-popups`, `allow-modals`, `allow-downloads`, `allow-pointer-lock`, `allow-popups-to-escape-sandbox`, `allow-presentation`). `allow-same-origin` is filtered out so a server cannot smuggle it back in via the protocol override path.

Each fix is local to `buildSandboxHTML` (~15 lines added) or the outer iframe creation block (1 line changed). No protocol changes, no breaking changes for the documented host capabilities.

## Verification

- `git -C . diff --stat` → 2 files changed, 48 insertions(+), 12 deletions(-).
- No test in `packages/react-core/src/v2/components/__tests__/` or `packages/vue/src/v2/components/__tests__/` pins the sandbox attribute value, so existing tests are unaffected.
- Manually walked the React component's `event.source === iframe.contentWindow` checks and the proxy iframe's `event.source === window.parent` checks — both work against cross-origin sandboxed iframes (Window reference equality still holds; postMessage is allowed across opaque origins; CSP `'unsafe-inline'` covers the inline relay script in opaque-origin context).
- The default sandbox is now stricter than before for any MCP-app that relied on same-origin access. That reliance is precisely what makes the host vulnerable; MCP apps should not have access to the host's storage or DOM.

## Detected by

[Aeon](https://github.com/aaronjmars/aeon-aaron) + Semgrep p/security-audit (`javascript.browser.security.wildcard-postmessage-configuration`, surfaced the iframe pair; the sandbox-bypass underneath is the upstream cause).

- Severity: high
- CWE-1021 (Improper Restriction of Rendered UI Layers or Frames)
- CWE-693 (Protection Mechanism Failure)

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron). Happy to iterate on the sanitization allowlist or split the three fixes into separate commits if you'd prefer.
