### PR TITLE
fix(showcase): bump @ag-ui/client to 0.0.48 on reasoning-emitting backends

### DIFF
--- a/showcase/integrations/agno/package-lock.json
+++ b/showcase/integrations/agno/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@copilotkit/showcase-agno",
       "version": "0.1.0",
       "dependencies": {
-        "@ag-ui/client": "^0.0.43",
+        "@ag-ui/client": "0.0.48",
         "@copilotkit/a2ui-renderer": "1.59.4",
         "@copilotkit/react-core": "1.59.4",
         "@copilotkit/runtime": "1.59.4",
@@ -92,13 +92,13 @@
       "integrity": "sha512-9U4DtwJ6rHO4vn4ixYVnRJGrO7u07phT/AjgsHymLf4cvPw57PNZACc4y6eTtayG0IcySNqRGW/wE+qjlXzgzw=="
     },
     "node_modules/@ag-ui/client": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.43.tgz",
-      "integrity": "sha512-150Y3TX+k83qvtmp4bTxmPW0Xu7to2y5vlhD8s5gof5/fxMdxybM1ieZazN7OIWU0nCK/hvhA+bVC7mmyby3gw==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.48.tgz",
+      "integrity": "sha512-JAYH8gScC4JXxfsH8mfhfMzoQ/V0pUK2EapNCDa9TBpma2nraPNWFfxCneClhrk97Kb0wZCxviBKeJbvS++QGQ==",
       "dependencies": {
-        "@ag-ui/core": "0.0.43",
-        "@ag-ui/encoder": "0.0.43",
-        "@ag-ui/proto": "0.0.43",
+        "@ag-ui/core": "0.0.48",
+        "@ag-ui/encoder": "0.0.48",
+        "@ag-ui/proto": "0.0.48",
         "@types/uuid": "^10.0.0",
         "compare-versions": "^6.1.1",
         "fast-json-patch": "^3.1.1",
@@ -109,21 +109,21 @@
       }
     },
     "node_modules/@ag-ui/core": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.43.tgz",
-      "integrity": "sha512-/T7kKwPAhtriFFiv3YxZ0yAzMHoY8a8I5UKzhPzwW934h92c6RJ54N93yb9PAqdX3XjCPId0C5gIBHb6QbeR3Q==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.48.tgz",
+      "integrity": "sha512-HP4wO+0+j8Rkshn0eiV0XAfrh7zeTbvZsQ2URopmMXVK3f6DC2I3jw3IN1ZGaJwSuzPtch5T3NC4jrj/PazVeA==",
       "dependencies": {
         "rxjs": "7.8.1",
         "zod": "^3.22.4"
       }
     },
     "node_modules/@ag-ui/encoder": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.43.tgz",
-      "integrity": "sha512-0b7VXFW5KMctdWsGFQEkbIU2gY/tUv0eWBbMchIvjiIS1aHxdGTB6NXHXJzGvDcXEb3urkIvVIFGvpk0WOUhVw==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.48.tgz",
+      "integrity": "sha512-tqfyZA6SLVibUi+KcBFRSfwLMUXkJ1qgn/FxqaJ0XK/LvfXW8RPREcKwPl1EWYHKJi3K3g7dvKlIFq4srbvn8A==",
       "dependencies": {
-        "@ag-ui/core": "0.0.43",
-        "@ag-ui/proto": "0.0.43"
+        "@ag-ui/core": "0.0.48",
+        "@ag-ui/proto": "0.0.48"
       }
     },
     "node_modules/@ag-ui/langgraph": {
@@ -212,11 +212,11 @@
       }
     },
     "node_modules/@ag-ui/proto": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.43.tgz",
-      "integrity": "sha512-JcGjwMyxd5KiRTVi3158eByPXm9lKDRMIApYgSlzhXpBwyfpub8waGFnEWqjE3U+gA1LaZHiVMIfD5NCVYj4WQ==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.48.tgz",
+      "integrity": "sha512-8kfOLdDRLg9B8I+eAlO/hqZ+iPPTqSYXrh9VN05cvLAEyoyeNE37A6XRDE1VBD+PevsCQmeJQDs2MfqY7UlDWQ==",
       "dependencies": {
-        "@ag-ui/core": "0.0.43",
+        "@ag-ui/core": "0.0.48",
         "@bufbuild/protobuf": "^2.2.5",
         "@protobuf-ts/protoc": "^2.11.1"
       }

--- a/showcase/integrations/agno/package.json
+++ b/showcase/integrations/agno/package.json
@@ -10,7 +10,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@ag-ui/client": "^0.0.43",
+    "@ag-ui/client": "0.0.48",
     "@copilotkit/a2ui-renderer": "1.59.4",
     "@copilotkit/react-core": "1.59.4",
     "@copilotkit/runtime": "1.59.4",

--- a/showcase/integrations/claude-sdk-python/package-lock.json
+++ b/showcase/integrations/claude-sdk-python/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@copilotkit/showcase-claude-sdk-python",
       "version": "0.1.0",
       "dependencies": {
-        "@ag-ui/client": "^0.0.43",
+        "@ag-ui/client": "0.0.48",
         "@copilotkit/a2ui-renderer": "1.59.4",
         "@copilotkit/react-core": "1.59.4",
         "@copilotkit/runtime": "1.59.4",
@@ -92,13 +92,13 @@
       "integrity": "sha512-9U4DtwJ6rHO4vn4ixYVnRJGrO7u07phT/AjgsHymLf4cvPw57PNZACc4y6eTtayG0IcySNqRGW/wE+qjlXzgzw=="
     },
     "node_modules/@ag-ui/client": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.43.tgz",
-      "integrity": "sha512-150Y3TX+k83qvtmp4bTxmPW0Xu7to2y5vlhD8s5gof5/fxMdxybM1ieZazN7OIWU0nCK/hvhA+bVC7mmyby3gw==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.48.tgz",
+      "integrity": "sha512-JAYH8gScC4JXxfsH8mfhfMzoQ/V0pUK2EapNCDa9TBpma2nraPNWFfxCneClhrk97Kb0wZCxviBKeJbvS++QGQ==",
       "dependencies": {
-        "@ag-ui/core": "0.0.43",
-        "@ag-ui/encoder": "0.0.43",
-        "@ag-ui/proto": "0.0.43",
+        "@ag-ui/core": "0.0.48",
+        "@ag-ui/encoder": "0.0.48",
+        "@ag-ui/proto": "0.0.48",
         "@types/uuid": "^10.0.0",
         "compare-versions": "^6.1.1",
         "fast-json-patch": "^3.1.1",
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@ag-ui/core": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.43.tgz",
-      "integrity": "sha512-/T7kKwPAhtriFFiv3YxZ0yAzMHoY8a8I5UKzhPzwW934h92c6RJ54N93yb9PAqdX3XjCPId0C5gIBHb6QbeR3Q==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.48.tgz",
+      "integrity": "sha512-HP4wO+0+j8Rkshn0eiV0XAfrh7zeTbvZsQ2URopmMXVK3f6DC2I3jw3IN1ZGaJwSuzPtch5T3NC4jrj/PazVeA==",
       "dependencies": {
         "rxjs": "7.8.1",
         "zod": "^3.22.4"
@@ -136,12 +136,12 @@
       }
     },
     "node_modules/@ag-ui/encoder": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.43.tgz",
-      "integrity": "sha512-0b7VXFW5KMctdWsGFQEkbIU2gY/tUv0eWBbMchIvjiIS1aHxdGTB6NXHXJzGvDcXEb3urkIvVIFGvpk0WOUhVw==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.48.tgz",
+      "integrity": "sha512-tqfyZA6SLVibUi+KcBFRSfwLMUXkJ1qgn/FxqaJ0XK/LvfXW8RPREcKwPl1EWYHKJi3K3g7dvKlIFq4srbvn8A==",
       "dependencies": {
-        "@ag-ui/core": "0.0.43",
-        "@ag-ui/proto": "0.0.43"
+        "@ag-ui/core": "0.0.48",
+        "@ag-ui/proto": "0.0.48"
       }
     },
     "node_modules/@ag-ui/langgraph": {
@@ -239,11 +239,11 @@
       }
     },
     "node_modules/@ag-ui/proto": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.43.tgz",
-      "integrity": "sha512-JcGjwMyxd5KiRTVi3158eByPXm9lKDRMIApYgSlzhXpBwyfpub8waGFnEWqjE3U+gA1LaZHiVMIfD5NCVYj4WQ==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.48.tgz",
+      "integrity": "sha512-8kfOLdDRLg9B8I+eAlO/hqZ+iPPTqSYXrh9VN05cvLAEyoyeNE37A6XRDE1VBD+PevsCQmeJQDs2MfqY7UlDWQ==",
       "dependencies": {
-        "@ag-ui/core": "0.0.43",
+        "@ag-ui/core": "0.0.48",
         "@bufbuild/protobuf": "^2.2.5",
         "@protobuf-ts/protoc": "^2.11.1"
       }

--- a/showcase/integrations/claude-sdk-python/package.json
+++ b/showcase/integrations/claude-sdk-python/package.json
@@ -10,7 +10,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@ag-ui/client": "^0.0.43",
+    "@ag-ui/client": "0.0.48",
     "@copilotkit/a2ui-renderer": "1.59.4",
     "@copilotkit/react-core": "1.59.4",
     "@copilotkit/runtime": "1.59.4",

--- a/showcase/integrations/llamaindex/package-lock.json
+++ b/showcase/integrations/llamaindex/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@copilotkit/showcase-llamaindex",
       "version": "0.1.0",
       "dependencies": {
-        "@ag-ui/client": "^0.0.43",
+        "@ag-ui/client": "0.0.48",
         "@copilotkit/a2ui-renderer": "1.59.4",
         "@copilotkit/react-core": "1.59.4",
         "@copilotkit/runtime": "1.59.4",
@@ -92,13 +92,13 @@
       "integrity": "sha512-9U4DtwJ6rHO4vn4ixYVnRJGrO7u07phT/AjgsHymLf4cvPw57PNZACc4y6eTtayG0IcySNqRGW/wE+qjlXzgzw=="
     },
     "node_modules/@ag-ui/client": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.43.tgz",
-      "integrity": "sha512-150Y3TX+k83qvtmp4bTxmPW0Xu7to2y5vlhD8s5gof5/fxMdxybM1ieZazN7OIWU0nCK/hvhA+bVC7mmyby3gw==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.48.tgz",
+      "integrity": "sha512-JAYH8gScC4JXxfsH8mfhfMzoQ/V0pUK2EapNCDa9TBpma2nraPNWFfxCneClhrk97Kb0wZCxviBKeJbvS++QGQ==",
       "dependencies": {
-        "@ag-ui/core": "0.0.43",
-        "@ag-ui/encoder": "0.0.43",
-        "@ag-ui/proto": "0.0.43",
+        "@ag-ui/core": "0.0.48",
+        "@ag-ui/encoder": "0.0.48",
+        "@ag-ui/proto": "0.0.48",
         "@types/uuid": "^10.0.0",
         "compare-versions": "^6.1.1",
         "fast-json-patch": "^3.1.1",
@@ -109,21 +109,21 @@
       }
     },
     "node_modules/@ag-ui/core": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.43.tgz",
-      "integrity": "sha512-/T7kKwPAhtriFFiv3YxZ0yAzMHoY8a8I5UKzhPzwW934h92c6RJ54N93yb9PAqdX3XjCPId0C5gIBHb6QbeR3Q==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.48.tgz",
+      "integrity": "sha512-HP4wO+0+j8Rkshn0eiV0XAfrh7zeTbvZsQ2URopmMXVK3f6DC2I3jw3IN1ZGaJwSuzPtch5T3NC4jrj/PazVeA==",
       "dependencies": {
         "rxjs": "7.8.1",
         "zod": "^3.22.4"
       }
     },
     "node_modules/@ag-ui/encoder": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.43.tgz",
-      "integrity": "sha512-0b7VXFW5KMctdWsGFQEkbIU2gY/tUv0eWBbMchIvjiIS1aHxdGTB6NXHXJzGvDcXEb3urkIvVIFGvpk0WOUhVw==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.48.tgz",
+      "integrity": "sha512-tqfyZA6SLVibUi+KcBFRSfwLMUXkJ1qgn/FxqaJ0XK/LvfXW8RPREcKwPl1EWYHKJi3K3g7dvKlIFq4srbvn8A==",
       "dependencies": {
-        "@ag-ui/core": "0.0.43",
-        "@ag-ui/proto": "0.0.43"
+        "@ag-ui/core": "0.0.48",
+        "@ag-ui/proto": "0.0.48"
       }
     },
     "node_modules/@ag-ui/langgraph": {
@@ -212,11 +212,11 @@
       }
     },
     "node_modules/@ag-ui/proto": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.43.tgz",
-      "integrity": "sha512-JcGjwMyxd5KiRTVi3158eByPXm9lKDRMIApYgSlzhXpBwyfpub8waGFnEWqjE3U+gA1LaZHiVMIfD5NCVYj4WQ==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.48.tgz",
+      "integrity": "sha512-8kfOLdDRLg9B8I+eAlO/hqZ+iPPTqSYXrh9VN05cvLAEyoyeNE37A6XRDE1VBD+PevsCQmeJQDs2MfqY7UlDWQ==",
       "dependencies": {
-        "@ag-ui/core": "0.0.43",
+        "@ag-ui/core": "0.0.48",
         "@bufbuild/protobuf": "^2.2.5",
         "@protobuf-ts/protoc": "^2.11.1"
       }

--- a/showcase/integrations/llamaindex/package.json
+++ b/showcase/integrations/llamaindex/package.json
@@ -10,7 +10,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@ag-ui/client": "^0.0.43",
+    "@ag-ui/client": "0.0.48",
     "@copilotkit/a2ui-renderer": "1.59.4",
     "@copilotkit/react-core": "1.59.4",
     "@copilotkit/runtime": "1.59.4",

--- a/showcase/scripts/fail-baseline.json
+++ b/showcase/scripts/fail-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Drift ratchet baseline for showcase_validate.yml. `validatePinsFailCount` holds the last-known FAIL count; `validatePinsFailHash` is a SHA-256 of the sorted, deduplicated `[FAIL] ...` lines from validate-pins.ts. CI compares BOTH: if the count changes, it tells you to ratchet (up rejected, down instructed). If the count is equal but the hash differs, the FAIL *set* has drifted (one item fixed, another regressed) and CI fails with a diff. Never raise the count without an explicit review + sign-off. `baselineDemoCount` is the per-package e2e-spec-count floor (single source of truth consumed by both the workflow and validate-parity.ts). NOTE: validate-parity.ts `BASELINE_DEMO_COUNT` default must match `baselineDemoCount` here; keep them in sync. See .github/workflows/showcase_validate.yml 'Run validate-pins (ratchet)' step.",
-  "validatePinsFailCount": 60,
-  "validatePinsFailHash": "7db1cd422ee5a3394044e9aedc1ce8fc8fabca0107b2df47f7167bdf3c7556ce",
+  "validatePinsFailCount": 57,
+  "validatePinsFailHash": "e5b9fb5081edcd3dc9d279e9dc32bb5850ba7abd9b367140e54f6b44247f9ce0",
   "baselineDemoCount": 9
 }


### PR DESCRIPTION
## Summary
Follow-up to #5323. That PR made **llamaindex, agno, claude-sdk-python** emit AG-UI `REASONING_MESSAGE_*`, but only bumped **claude-sdk-typescript**'s `@ag-ui/client` to `0.0.48` — leaving the other three on `^0.0.43`, whose `@ag-ui/core` discriminated-union lacks `REASONING_MESSAGE_*`. On staging the frontend threw `invalid_union_discriminator` on the new event and the reasoning demos broke (assistant never responded). This bumps `@ag-ui/client` (+ transitive `@ag-ui/core`/`@ag-ui/encoder`) to exact `0.0.48` on those three, matching claude-sdk-typescript.

## Verification (local-first, staging-equivalent)
Proven GREEN on the local built-image rig (real Docker image + HTTP entrypoint + d5/d6 aimock fixtures + Playwright browser — not a dev server): for llamaindex, agno, claude-sdk-python — D5 reasoning 2/2, D6 `reasoning-display` pass, `[data-testid="reasoning-block"]` mounts, `invalid_union_discriminator = 0`.

## validate-pins
The 3 caret `@ag-ui/client` pins become exact → FAIL count ratcheted down accordingly in `fail-baseline.json`.

## Follow-ups (separate, not in this PR)
- Isolate-rig PocketBase pb-auth seeding mismatch (`admin@localhost.dev` vs `admin@example.com`).
- agno reasoning demo uses `gpt-4o-mini` (no native `reasoning_content`) — fine under aimock, non-deterministic on a real model; route to a reasoning model or harden the `<reasoning>`-tag fallback.
- Staging sweep probe-config still references old route names (`agentic-chat-reasoning`/`reasoning-default-render` → 404); the reasoning-custom/reasoning-default cells won't be probed until that propagates.

## Test plan
- [ ] CI green
- [ ] Post-merge: rebuild `:latest` + confirm staging d5/d6 reasoning-display green for the 3 backends