### PR TITLE
build: exclude root README from oxfmt lint-fix hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -56,6 +56,12 @@ pre-commit:
       # oxfmt exits 2 with "Expected at least one target file" and blocks
       # the commit.
       exclude:
+        # Root README is hand-tuned marketing prose with emoji-aligned tables
+        # that oxfmt re-pads (it miscounts emoji display width) and emphasis
+        # markers it rewrites. main already fails oxfmt here, so any edit to
+        # one section would drag whole-file reformatting into the diff. Keep
+        # the root README out of the formatter so README edits stay surgical.
+        - "README.md"
         - "docs/**"
         - "showcase/aimock/shared/**"
         - "showcase/aimock/d4/**"


### PR DESCRIPTION
Excludes the root `README.md` from the `oxfmt` lint-fix pre-commit hook.

**Why:** The README is hand-tuned marketing prose with emoji-aligned tables. `oxfmt` re-pads those tables (it miscounts emoji width) and rewrites emphasis markers. `main` already fails `oxfmt` on this file, so editing one section reformats the whole file and forces a `--no-verify` commit. Excluding it keeps README edits surgical.

**Verified:** with only `README.md` staged, the lint-fix hook now reports `skip — no files for inspection` and leaves the file untouched.

One line of config (plus a comment):

```yaml
exclude:
  - "README.md"
  - "docs/**"
  ...
```