### PR TITLE
docs(shell-docs): polish showcase docs follow-up

### DIFF
--- a/showcase/shell-docs/src/components/__tests__/brand-nav.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/brand-nav.test.tsx
@@ -14,7 +14,9 @@ describe("BrandNav layout", () => {
   it("uses a CSS class for the same desktop layout cap as the docs grid", () => {
     expect(brandNavSource).toContain("shell-docs-brand-nav-inner");
     expect(globalsCss).toContain(".shell-docs-brand-nav-inner");
-    expect(globalsCss).toContain("max-width: calc(97rem + 11px);");
+    expect(globalsCss).toContain(
+      "--shell-docs-layout-width: calc(97rem + 11px);",
+    );
     expect(brandNavSource).not.toContain("max-w-[calc(");
     expect(brandNavSource).not.toContain("max-w-[1534px]");
   });

--- a/showcase/shell-docs/src/components/__tests__/stored-framework-highlight.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/stored-framework-highlight.test.tsx
@@ -13,6 +13,7 @@ describe("StoredFrameworkHighlight", () => {
       <StoredFrameworkHighlight slug="built-in-agent" />,
     );
 
-    expect(markup).toMatch(/hidden[^"]*sm:inline-flex/);
+    expect(markup).toContain("sr-only");
+    expect(markup).toContain("Current backend selection");
   });
 });

--- a/showcase/shell-docs/src/components/content/landing-pages/__tests__/framework-overview.test.tsx
+++ b/showcase/shell-docs/src/components/content/landing-pages/__tests__/framework-overview.test.tsx
@@ -43,7 +43,7 @@ describe("FrameworkOverview", () => {
     );
 
     expect(markup).toContain(
-      "flex h-10 w-10 items-center justify-center rounded-lg border border-[var(--accent)] bg-[var(--accent-dim)] text-[var(--accent)]",
+      "shell-docs-radius-icon flex h-10 w-10 items-center justify-center border border-[var(--accent)] bg-[var(--accent-dim)] text-[var(--accent)]",
     );
   });
 

--- a/showcase/shell-docs/src/components/shell-docs-layout.tsx
+++ b/showcase/shell-docs/src/components/shell-docs-layout.tsx
@@ -44,7 +44,7 @@ export function ShellDocsLayout({
       // our custom one.
       sidebar={{
         banner: (
-          <div className="flex flex-col">
+          <div key="shell-docs-sidebar-banner" className="flex flex-col">
             <PrimaryDocsTabs className="shell-docs-mobile-sidebar-tabs" />
             {banner}
           </div>

--- a/showcase/shell-docs/src/content/docs/backend/agent-runner.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/agent-runner.mdx
@@ -1,15 +1,14 @@
 ---
-title: "AgentRunner & persistence"
+title: "AgentRunner and persistence"
 icon: "lucide/Database"
-description: "The AgentRunner abstraction that backs the runtime — InMemoryAgentRunner, IntelligenceAgentRunner, and TelemetryAgentRunner — and how to plug in your own persistence backend."
+description: "Control how the runtime starts, reconnects to, and stops agent runs with AgentRunner."
 ---
 
-Every CopilotKit runtime delegates the actual *execution and persistence* of an
-agent run to an **`AgentRunner`**. It's the piece that turns a `POST /agent/:id/run`
-into a live stream of AG-UI events, remembers a thread so a later
-`POST /agent/:id/connect` can re-attach to it, and stops a run on demand. Picking
-(or subclassing) the right runner is how you control where conversation history
-lives.
+Every CopilotKit runtime delegates agent execution and persistence to an
+`AgentRunner`. The runner turns `POST /agent/:id/run` into a live stream of
+AG-UI events, remembers a thread so `POST /agent/:id/connect` can attach to it,
+and stops a run on demand. Pick or subclass a runner when you need to control
+where conversation state lives.
 
 ## The abstraction
 
@@ -40,15 +39,15 @@ headers and a `joinCode`). The runner owns whatever storage backs those threads.
 
 | Runner | Import | Use it for |
 |---|---|---|
-| `InMemoryAgentRunner` | `@copilotkit/runtime/v2` | The default. Stores thread runs in process memory. Great for local dev, single-instance deployments, and as a base class to extend. |
-| `IntelligenceAgentRunner` | `@copilotkit/runtime/v2` | Backs the Intelligence Platform — durable threads, cross-instance persistence, and the threads/history features. Used automatically on an Intelligence runtime. |
-| `TelemetryAgentRunner` | `@copilotkit/runtime` | A decorator that wraps another runner to emit telemetry around `run`/`connect`/`stop`. Composed in automatically; you typically don't construct it directly. |
+| `InMemoryAgentRunner` | `@copilotkit/runtime/v2` | The default v2 runner. Stores thread runs in process memory. Use it for local development, single-instance deployments, or as a base class to extend. |
+| `IntelligenceAgentRunner` | `@copilotkit/runtime/v2` | Backs the Intelligence Platform with durable threads, cross-instance persistence, and threads/history features. Used automatically on an Intelligence runtime. |
+| `TelemetryAgentRunner` | `@copilotkit/runtime` | Legacy wrapper behavior. The root runtime composes telemetry around a runner when telemetry is enabled; `@copilotkit/runtime/v2` does not. |
 
 If you don't pass a `runner`, the runtime uses `InMemoryAgentRunner`. Because it
 holds threads in process memory, history is lost on restart and is **not shared
-across instances** — so for a horizontally-scaled or restart-resilient deployment
-you either move to the Intelligence Platform's `IntelligenceAgentRunner` or supply
-your own runner backed by your datastore.
+across instances**. For a horizontally scaled or restart-resilient deployment,
+move to the Intelligence Platform's `IntelligenceAgentRunner` or supply your own
+runner backed by your datastore.
 
 ## Choosing a runner
 
@@ -90,22 +89,22 @@ export class MyRunner extends InMemoryAgentRunner {
 }
 ```
 
-For a complete, production-shaped example — including how to handle a `connect()`
-that arrives **before** any `run()` for a thread, and how to synthesise missing
-tool-call results from a replayed history — see the
-[AWS AgentCore integration](/deploy/agentcore), which extends `InMemoryAgentRunner`
-into an `AgentCoreRunner`.
+For a complete production example, see the
+[AWS AgentCore integration](/deploy/agentcore). It extends
+`InMemoryAgentRunner` into an `AgentCoreRunner`, handles a `connect()` that
+arrives **before** any `run()` for a thread, and synthesizes missing tool-call
+results from a replayed history.
 
 <Callout type="warn">
-If `connect()` can be called for a thread your runner has never seen (a freshly
-minted thread id on first page load), handle that case explicitly — otherwise the
-`POST /agent/:id/connect` route can surface a 404 or an error before the user
-sends a message. See the [`/connect` 404 troubleshooting entry](/troubleshooting/common-issues#the-connect-route-returns-a-404-on-a-fresh-thread).
+If `connect()` can be called for a thread your runner has never seen, such as a
+new thread id on first page load, handle that case explicitly. Otherwise the
+`POST /agent/:id/connect` route can return a 404 or an error before the user
+sends a message. See the [`/connect` 404 troubleshooting entry](/troubleshooting/common-issues#connect-route-returns-404-on-a-fresh-thread).
 </Callout>
 
 ## Related
 
-- [Runtime HTTP endpoints](/backend/runtime-endpoints) — the routes each runner method backs.
-- [Copilot Runtime](/backend/copilot-runtime) — configuring the runtime and `runner`.
-- [AWS AgentCore](/deploy/agentcore) — a real custom-runner subclass for an external memory layer.
-- [Self-Hosting Intelligence](/premium/self-hosting) — the durable, multi-instance `IntelligenceAgentRunner` backend.
+- [Runtime HTTP endpoints](/backend/runtime-endpoints): the routes each runner method backs.
+- [Copilot Runtime](/backend/copilot-runtime): configuring the runtime and `runner`.
+- [AWS AgentCore](/deploy/agentcore): a custom runner subclass for an external memory layer.
+- [Self-Hosting Intelligence](/premium/self-hosting): the durable, multi-instance `IntelligenceAgentRunner` backend.

--- a/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
@@ -59,15 +59,15 @@ see [Runtime HTTP endpoints](/backend/runtime-endpoints).
   | `copilotRuntimeNextJSAppRouterEndpoint`, `copilotRuntimeNodeHttpEndpoint` (Fetch / Next.js App Router, Bun, Deno, Cloudflare Workers) | `createCopilotRuntimeHandler` |
   | `copilotRuntimeNodeExpressEndpoint` (Express) | `createCopilotExpressHandler` (from `@copilotkit/runtime/v2/express`) |
 
-  Both styles work in v1.50. For new projects we recommend the v2 handlers — see [Deploy to any runtime](/runtime-server-adapter).
+  Both styles work in v1.50. For new projects, use the v2 handlers. See [Deploy to any runtime](/runtime-server-adapter).
 </Callout>
 
 ## Agents
 
 The runtime supports multiple agent types. `BuiltInAgent` is the primary agent class:
 
-- **Simple mode** — pass a model string, CopilotKit handles everything. Best for quick setup. See [Quickstart](/quickstart).
-- **Factory mode** — bring your own AI SDK, TanStack AI, or custom LLM backend. Best when you need full control. See [Factory Mode](/backend/custom-agent).
+- **Simple mode:** pass a model string and let CopilotKit handle the rest. Best for quick setup. See [Quickstart](/quickstart).
+- **Factory mode:** bring your own AI SDK, TanStack AI, or custom LLM backend. Best when you need full control. See [Factory Mode](/backend/custom-agent).
 
 ## The default agent
 
@@ -102,7 +102,7 @@ When you register multiple agents, the runtime handles discovery and routing aut
 
 ### Premium features
 
-[Observability](/premium/observability), the [inspector](/inspector), and other premium capabilities are provided through the runtime. These give you conversation persistence, monitoring, and debugging out of the box.
+[Observability](/premium/observability), the [inspector](/inspector), and other premium capabilities are provided through the runtime. These give you conversation persistence, monitoring, and debugging without extra setup.
 
 ## Built-in middleware
 
@@ -125,7 +125,7 @@ To scope it to specific agents only, pass an `agents` list:
 a2ui: { agents: ["my-agent"] }
 ```
 
-On the frontend, the A2UI renderer activates automatically — no extra configuration needed. If you want to override the default theme, pass an `a2ui` prop to `<CopilotKit>`:
+On the frontend, the A2UI renderer activates automatically. No extra configuration is needed. To override the default theme, pass an `a2ui` prop to `<CopilotKit>`:
 
 ```tsx
 import { CopilotKit } from "@copilotkit/react-core/v2";
@@ -173,14 +173,14 @@ const myAgent = new HttpAgent({
 Direct agent connections are intended for development and prototyping. They are **not recommended for production** and are not officially supported by CopilotKit.
 </Callout>
 
-If you genuinely intend to manage the agent connection yourself in production (and
-have secured it), use the supported [`selfManagedAgents`](/backend/self-managed-agents)
+If you intend to manage the agent connection yourself in production and have
+secured it, use the supported [`selfManagedAgents`](/backend/self-managed-agents)
 prop instead of `agents__unsafe_dev_only`.
 
 Key trade-offs:
 
-1. **Authentication is your responsibility** — the runtime's safe defaults do not apply.
-2. **Many ecosystem features won't work** — runtime-backed middleware, observability, and other capabilities depend on the server-side path.
+1. **Authentication is your responsibility.** The runtime's safe defaults do not apply.
+2. **Many ecosystem features won't work.** Runtime-backed middleware, observability, and other capabilities depend on the server-side path.
 
 ### Comparison
 

--- a/showcase/shell-docs/src/content/docs/backend/custom-agent.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/custom-agent.mdx
@@ -4,20 +4,23 @@ icon: "lucide/Blocks"
 description: "Use BuiltInAgent's factory mode to bring your own AI SDK, TanStack AI, or custom LLM backend."
 ---
 
-`BuiltInAgent`'s factory mode gives you full control over the LLM call. You provide a factory function that talks to any backend — CopilotKit handles converting the stream to AG-UI events, managing lifecycle, and wiring it into the runtime.
+`BuiltInAgent`'s factory mode gives you full control over the LLM call. You provide
+a factory function that talks to any backend, and CopilotKit handles converting
+the stream to AG-UI events, managing lifecycle, and wiring it into the runtime.
 
 ## When to use Simple Mode vs Factory Mode
 
 | | Simple Mode | Factory Mode |
 |---|---|---|
-| **Setup** | Minimal — pass a model string | You own the LLM call and stream |
+| **Setup** | Minimal: pass a model string | You own the LLM call and stream |
 | **Model resolution** | Built-in (`"openai/gpt-4o"`) | You set up the model yourself |
 | **Tools, MCP, state tools** | Automatically wired | You wire them in your factory |
 | **Backend support** | Vercel AI SDK only | Any backend: AI SDK, TanStack AI, or custom |
 | **Best for** | Quick setup, standard use cases | Full control, non-standard backends |
 
 <Callout type="info">
-If simple mode covers your needs, stick with it — it's simpler. Use factory mode when you need control that simple mode doesn't offer.
+If simple mode covers your needs, stick with it. Use factory mode when you need
+control that simple mode doesn't offer.
 </Callout>
 
 ## Quick Start
@@ -147,14 +150,15 @@ export default copilotEndpoint;
 </Tab>
 </Tabs>
 
-The frontend setup is the same as [BuiltInAgent](/quickstart) — wrap your app with `<CopilotKit>` and add a chat component.
+The frontend setup is the same as [BuiltInAgent](/quickstart). Wrap your app with
+`<CopilotKit>` and add a chat component.
 
 ## How It Works
 
 Factory mode accepts a config with two fields:
 
-- **`type`** — which backend you're using: `"aisdk"`, `"tanstack"`, or `"custom"`
-- **`factory`** — a function that receives the raw request and returns a backend-native stream
+- **`type`:** which backend you're using: `"aisdk"`, `"tanstack"`, or `"custom"`
+- **`factory`:** a function that receives the raw request and returns a backend-native stream
 
 The factory receives an `AgentFactoryContext` (from `@copilotkit/runtime/v2`):
 
@@ -173,7 +177,7 @@ backend that stores threads in process memory. To understand the runner
 abstraction and how to swap in durable persistence, see
 [AgentRunner & persistence](/backend/agent-runner).
 
-The factory can be async — return a `Promise` if you need to do setup before streaming:
+The factory can be async. Return a `Promise` if you need to do setup before streaming:
 
 ```typescript
 factory: async ({ input, abortSignal }) => {

--- a/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Runtime HTTP endpoints"
 icon: "lucide/Network"
-description: "The HTTP routes the CopilotKit runtime exposes — GET /info, the per-agent run/connect/stop routes, and /transcribe — for self-hosting, proxying, and debugging."
+description: "The HTTP routes exposed by the CopilotKit runtime for self-hosting, proxying, and debugging."
 ---
 
 When you mount the CopilotKit runtime with `createCopilotExpressHandler`,
 `createCopilotHonoHandler`, `copilotRuntimeNextJSAppRouterEndpoint`, or any of the
 other framework adapters, it serves a small set of HTTP routes under the
-`basePath` you choose (for example `/api/copilotkit`). Most of the time you never
-touch these directly — the frontend proxy (`ProxiedCopilotRuntimeAgent`) calls
-them for you. But when you self-host behind a reverse proxy, lock down auth, or
-debug a connection failure with `curl`, you need to know exactly what the runtime
+`basePath` you choose, such as `/api/copilotkit`. Most applications never call
+these routes directly. The frontend proxy (`ProxiedCopilotRuntimeAgent`) calls
+them for you. When you self-host behind a reverse proxy, lock down auth, or debug
+a connection failure with `curl`, use this page to confirm what the runtime
 exposes.
 
 ## Multi-route mode (default)
@@ -20,20 +20,20 @@ operation. Given a `basePath` of `/api/copilotkit`, the routes are:
 
 | Method & path | Purpose |
 |---|---|
-| `GET /api/copilotkit/info` | Runtime info — the list of registered agents and their metadata. The frontend calls this on startup to discover which agents exist. |
+| `GET /api/copilotkit/info` | Runtime info. The frontend calls this on startup to discover registered agents and their metadata. |
 | `POST /api/copilotkit/agent/:agentId/run` | Start an agent run. The request body is an AG-UI `RunAgentInput`; the response is an SSE stream of AG-UI events. |
-| `POST /api/copilotkit/agent/:agentId/connect` | Connect (re-attach) to an agent's thread — used to resume streaming after a reconnect or page refresh. Also an SSE stream. |
+| `POST /api/copilotkit/agent/:agentId/connect` | Connect to an agent's thread. Used to resume streaming after a reconnect or page refresh. Also an SSE stream. |
 | `POST /api/copilotkit/agent/:agentId/stop/:threadId` | Stop an in-progress run on a given thread. |
 | `POST /api/copilotkit/transcribe` | Transcribe audio (used by the voice / transcription input). |
 
 `:agentId` is the key under which you registered the agent in
-`new CopilotRuntime({ agents: { … } })` — for example `default`,
+`new CopilotRuntime({ agents: { ... } })`, for example `default` or
 `research-agent`. `:threadId` is the thread the run belongs to.
 
 <Callout type="info">
 The `GET /info` route is the same endpoint the frontend uses for agent
 discovery. If it isn't reachable from the runtime, the frontend reports a
-`runtime_info_fetch_failed` error — see [Error Debugging](/troubleshooting/error-debugging).
+`runtime_info_fetch_failed` error. See [Error Debugging](/troubleshooting/error-debugging).
 </Callout>
 
 ### Probing the runtime with curl
@@ -52,8 +52,8 @@ host/port.
 
 ## Single-route mode
 
-If you'd rather expose a **single** `POST` endpoint — for example to simplify a
-reverse-proxy rule or an API gateway — pass `mode: "single-route"`. In that mode
+If you prefer to expose a single `POST` endpoint, for example to simplify a
+reverse-proxy rule or an API gateway, pass `mode: "single-route"`. In that mode
 the runtime exposes one `POST {basePath}` endpoint that accepts a JSON envelope
 `{ method, params, body }` and dispatches internally to the same handlers:
 
@@ -97,7 +97,7 @@ runtime uses `mode: "single-route"`.
 The Express and Hono adapters apply permissive CORS by default
 (`origin: "*"`, all standard methods, all headers) so local development works out
 of the box. Pass `cors: false` to disable the built-in middleware and handle CORS
-yourself, or pass a configuration object to scope it down for production:
+yourself, or pass a configuration object to scope it for production:
 
 ```ts
 createCopilotExpressHandler({
@@ -110,8 +110,8 @@ createCopilotExpressHandler({
 ## Authenticating requests
 
 Because these routes run on your server, they're the right place to enforce
-auth. The adapters accept lifecycle `hooks` — an `onRequest` hook runs before
-every request and can reject it by throwing a `Response`:
+auth. The adapters accept lifecycle `hooks`. An `onRequest` hook runs before
+every request and can reject the request by throwing a `Response`:
 
 ```ts
 createCopilotExpressHandler({
@@ -129,10 +129,10 @@ createCopilotExpressHandler({
 
 See [Auth](/auth) for the full authentication guide.
 
-## Common failure: `/connect` 404 on a fresh thread
+## Connect route 404 on a fresh thread
 
 A frequent self-hosting symptom is a `404` from the
-`POST /agent/:agentId/connect` route right after the page loads — before the user
+`POST /agent/:agentId/connect` route right after the page loads, before the user
 has sent a single message. This usually means one of two things:
 
 1. **The `agentId` in the URL isn't registered.** The runtime returns
@@ -142,11 +142,11 @@ has sent a single message. This usually means one of two things:
 2. **`connect()` is called before any `run()` for an auto-minted thread.** Some
    persistence backends only know about a thread once a run has produced events.
    See the [AgentRunner](/backend/agent-runner) guide and the
-   [`/connect` 404 troubleshooting entry](/troubleshooting/common-issues#the-connect-route-returns-a-404-on-a-fresh-thread).
+   [`/connect` 404 troubleshooting entry](/troubleshooting/common-issues#connect-route-returns-404-on-a-fresh-thread).
 
 ## Related
 
-- [Copilot Runtime](/backend/copilot-runtime) — setting up the runtime and adapters.
-- [AgentRunner](/backend/agent-runner) — the persistence abstraction behind `run`/`connect`/`stop`.
-- [Connect AG-UI agents](/backend/ag-ui) — how the frontend proxy maps onto these routes.
-- [Error Debugging](/troubleshooting/error-debugging) — the `onError` codes that map to these routes.
+- [Copilot Runtime](/backend/copilot-runtime): setting up the runtime and adapters.
+- [AgentRunner](/backend/agent-runner): the persistence abstraction behind `run`/`connect`/`stop`.
+- [Connect AG-UI agents](/backend/ag-ui): how the frontend proxy maps onto these routes.
+- [Error Debugging](/troubleshooting/error-debugging): the `onError` codes that map to these routes.

--- a/showcase/shell-docs/src/content/docs/backend/self-managed-agents.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/self-managed-agents.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Self-managed agents"
 icon: "lucide/PlugZap"
-description: "Pass AG-UI agent instances straight to the frontend with the selfManagedAgents prop — the production-supported way to connect agents you manage yourself, and how it differs from the dev-only agents__unsafe_dev_only prop."
+description: "Connect AG-UI agents that you host and secure yourself."
 ---
 
 `<CopilotKit>` usually talks to your agents through the
@@ -10,10 +10,10 @@ discovers agents from `/info`, and a proxy forwards every run server-side. But y
 can also hand the provider **AG-UI agent instances directly** and skip the runtime
 for those agents. There are two props for this, and choosing the right one matters.
 
-## `selfManagedAgents` (production-supported)
+## Production: self-managed agents
 
 `selfManagedAgents` is the supported prop for connecting agents you manage
-yourself — for example an [`HttpAgent`](/backend/ag-ui) pointing at an
+yourself, for example an [`HttpAgent`](/backend/ag-ui) pointing at an
 AG-UI-compatible backend you own and have already secured:
 
 ```tsx
@@ -32,22 +32,21 @@ const supportAgent = new HttpAgent({
 ```
 
 Each key is the `agentId` the prebuilt components and `useAgent({ agentId })` use
-to address that agent. "Self-managed" means exactly that: **you own the transport
-and its security.** Because the requests don't pass through the CopilotKit
-runtime, the runtime's safe defaults (server-side auth, middleware, routing) don't
-apply — your agent endpoint is responsible for authenticating and authorizing
-every request itself.
+to address that agent. Self-managed agents use your transport and your security
+model. Because the requests don't pass through the CopilotKit runtime, the
+runtime's server-side auth, middleware, and routing do not apply. Your agent
+endpoint must authenticate and authorize every request.
 
 <Callout type="info">
 You can combine `selfManagedAgents` with `runtimeUrl`. Runtime-discovered agents
 and self-managed agents coexist; address each by its `agentId`.
 </Callout>
 
-## `agents__unsafe_dev_only` (development only)
+## Development: unsafe local agents
 
-`agents__unsafe_dev_only` accepts the same shape — a map of `agentId` to
-`AbstractAgent` — but the deliberately alarming name is the documentation: it's for
-**local development and prototyping only.**
+`agents__unsafe_dev_only` accepts the same shape: a map of `agentId` to
+`AbstractAgent`. The name is intentionally loud. Use it only for local
+development and prototyping.
 
 ```tsx
 import { HttpAgent } from "@ag-ui/client";
@@ -61,9 +60,9 @@ const myAgent = new HttpAgent({ url: "http://localhost:8000" });
 ```
 
 Reach for it when you're wiring up an agent locally and don't want to stand up a
-runtime yet. Don't ship it to production — switch to `selfManagedAgents` (if you
-genuinely intend to manage the connection yourself and have secured it) or move
-the agent behind the [runtime](/backend/copilot-runtime).
+runtime yet. Don't ship it to production. Switch to `selfManagedAgents` if you
+intend to manage and secure the connection yourself, or move the agent behind the
+[runtime](/backend/copilot-runtime).
 
 ## How they relate
 
@@ -75,7 +74,7 @@ are merged, and **`selfManagedAgents` wins on a key collision**:
 ```
 
 Supplying agents through either prop also satisfies the provider's configuration
-check — you won't get the
+check. You won't get the
 `Missing required prop: 'runtimeUrl' or 'publicApiKey' or 'publicLicenseKey'`
 error (see the [error reference](/troubleshooting/error-reference)) when at least
 one local agent is registered.
@@ -89,6 +88,6 @@ one local agent is registered.
 
 ## Related
 
-- [Copilot Runtime](/backend/copilot-runtime) — the recommended, runtime-backed path and its trade-offs vs. direct connections.
-- [Connect AG-UI agents](/backend/ag-ui) — the `AbstractAgent` / `HttpAgent` interface these props accept.
-- [Auth](/auth) — securing agent traffic (mandatory when you self-manage the connection).
+- [Copilot Runtime](/backend/copilot-runtime): the recommended runtime-backed path and its trade-offs compared with direct connections.
+- [Connect AG-UI agents](/backend/ag-ui): the `AbstractAgent` / `HttpAgent` interface these props accept.
+- [Auth](/auth): securing agent traffic when you self-manage the connection.

--- a/showcase/shell-docs/src/content/docs/concepts/which-hook.mdx
+++ b/showcase/shell-docs/src/content/docs/concepts/which-hook.mdx
@@ -1,19 +1,18 @@
 ---
 title: Which Hook for Which Job
-description: A one-line decision guide to CopilotKit v2's tool and rendering hooks — useFrontendTool, useRenderTool, useDefaultRenderTool, useComponent, useHumanInTheLoop, useInterrupt, and useRenderToolCall.
+description: Choose the right CopilotKit v2 hook for tools, rendering, human review, and custom chat surfaces.
 icon: "lucide/Map"
 doc_type: explanation
 ---
 
-CopilotKit v2 ships a focused set of hooks for letting the agent *do things* in
-your app and for *rendering* what it does. They split cleanly into two groups:
-hooks that **register behavior** (a tool the agent can call) and hooks that
-**register rendering** (how a tool call looks in the chat). This page is the
-30-second map; each hook links to its full reference.
+CopilotKit v2 has a focused set of hooks for letting the agent *do things* in
+your app and for *rendering* what it does. They split into two groups: hooks that
+register behavior, and hooks that register how a tool call looks in the chat.
+Use this page as the quick map, then follow each hook to its full reference.
 
 ## The 30-second version
 
-| Hook | Use it when you want to… |
+| Hook | Use it when you want to |
 | --- | --- |
 | [`useFrontendTool`](/reference/hooks/useFrontendTool) | Give the agent a client-side tool to call (run logic in the browser), with optional inline UI. |
 | [`useRenderTool`](/reference/hooks/useRenderTool) | Render the UI for a specific tool call by name (typed), without defining the tool's handler. |
@@ -25,38 +24,39 @@ hooks that **register behavior** (a tool the agent can call) and hooks that
 
 ## How to choose
 
-**Start with the verb.**
+Start with the verb.
 
-- **"The agent should *run* something in my app."** → [`useFrontendTool`](/reference/hooks/useFrontendTool).
+- **"The agent should *run* something in my app."** Use [`useFrontendTool`](/reference/hooks/useFrontendTool).
   You define the tool's schema and handler; the agent calls it. Add a `render`
   to also show inline UI for the call.
-- **"The agent's tool call should *look* like something."** → a render hook.
+- **"The agent's tool call should *look* like something."** Use a render hook.
   Use [`useRenderTool`](/reference/hooks/useRenderTool) to render one named tool,
   [`useComponent`](/reference/hooks/useComponent) to bind a React component to a
   tool name, or [`useDefaultRenderTool`](/reference/hooks/useDefaultRenderTool)
   as the catch-all for anything you didn't render explicitly.
-- **"The agent should *stop and ask me* before continuing."** →
+- **"The agent should *stop and ask me* before continuing."** Use
   [`useHumanInTheLoop`](/reference/hooks/useHumanInTheLoop) for tool-level
   approval/edit gates, or [`useInterrupt`](/reference/hooks/useInterrupt) for
   agent-driven interrupts you resume with user input.
-- **"I'm building my *own* chat UI."** →
-  [`useRenderToolCall`](/reference/hooks/useRenderToolCall) returns the renderer
-  function so you can place tool-call output anywhere in a headless layout.
+- **"I'm building my *own* chat UI."** Use
+  [`useRenderToolCall`](/reference/hooks/useRenderToolCall). It returns the
+  renderer function so you can place tool-call output anywhere in a headless
+  layout.
 
 ### Tool vs. renderer
 
 Two hooks in this set *register a tool* the agent can call: `useFrontendTool`
-(schema + handler — full control) and `useComponent` (a component-first
+(schema and handler) and `useComponent` (a component-first
 shorthand that wraps `useFrontendTool` internally, registering a tool whose
-"handler" is rendering your component). The render-only hooks — `useRenderTool`,
-`useDefaultRenderTool`, and `useRenderToolCall` — *don't* define a tool; they
+"handler" is rendering your component). The render-only hooks, `useRenderTool`,
+`useDefaultRenderTool`, and `useRenderToolCall`, *don't* define a tool; they
 only *render* tool calls, which can come from your frontend (`useFrontendTool` /
 `useComponent`) or from the agent/backend. That's why you can pair a backend
 tool with `useRenderTool` and never write a handler on the client.
 
 ## Related
 
-- [Frontend Tools](/frontend-tools) — the full guide to `useFrontendTool`.
-- [Generative UI](/generative-ui/tool-rendering) — rendering tool calls as rich UI.
-- [Human in the Loop](/human-in-the-loop) — approval and interrupt patterns.
-- [Hooks reference](/reference) — every v2 hook in detail.
+- [Frontend Tools](/frontend-tools): the full guide to `useFrontendTool`.
+- [Generative UI](/generative-ui/tool-rendering): rendering tool calls as rich UI.
+- [Human in the Loop](/human-in-the-loop): approval and interrupt patterns.
+- [Hooks reference](/reference): every v2 hook in detail.

--- a/showcase/shell-docs/src/content/docs/custom-look-and-feel/css.mdx
+++ b/showcase/shell-docs/src/content/docs/custom-look-and-feel/css.mdx
@@ -28,7 +28,7 @@ The demo keeps all of its styling in a sibling `theme.css` file and applies it
 only to the wrapper div holding `<CopilotChat>`. Importing the stylesheet from
 the page module is enough; Next.js bundles it with the route:
 
-<Snippet region="theme-css-import" title="frontend/src/app/page.tsx — import the theme" />
+<Snippet region="theme-css-import" title="frontend/src/app/page.tsx: import the theme" />
 
 Scoping every selector under a wrapper class keeps the overrides from leaking
 into the rest of the app.
@@ -39,7 +39,7 @@ The easiest way to change the colors used in the Copilot UI components is to
 override CopilotKit CSS variables. The demo sets them on the scope wrapper so
 they cascade into every nested chat component:
 
-<Snippet region="design-tokens" title="frontend/src/app/theme.css — design-token overrides" />
+<Snippet region="design-tokens" title="frontend/src/app/theme.css: design-token overrides" />
 
 Once you've found the right variable, you can also apply the overrides inline
 via the `CopilotKitCSSProperties` helper:
@@ -62,10 +62,10 @@ import { CopilotKitCSSProperties } from "@copilotkit/react-ui";
 
 | CSS Variable | Description |
 |-------------|-------------|
-| `--copilot-kit-primary-color` | Main brand/action color — used for buttons, interactive elements |
-| `--copilot-kit-contrast-color` | Color that contrasts with primary — used for text on primary elements |
+| `--copilot-kit-primary-color` | Main brand/action color for buttons and interactive elements |
+| `--copilot-kit-contrast-color` | Color that contrasts with primary, used for text on primary elements |
 | `--copilot-kit-background-color` | Main page/container background color |
-| `--copilot-kit-secondary-color` | Secondary background — used for cards, panels, elevated surfaces |
+| `--copilot-kit-secondary-color` | Secondary background for cards, panels, and elevated surfaces |
 | `--copilot-kit-secondary-contrast-color` | Primary text color for main content |
 | `--copilot-kit-separator-color` | Border color for dividers and containers |
 | `--copilot-kit-muted-color` | Muted color for disabled/inactive states |
@@ -75,7 +75,7 @@ import { CopilotKitCSSProperties } from "@copilotkit/react-ui";
   The `--copilot-kit-*` variables above style the **v1** component CSS
   (`@copilotkit/react-ui`). The newer **v2** components
   (`@copilotkit/react-core/v2`) are Tailwind + shadcn-based and use a
-  separate set of design tokens — see [v2 design
+  separate set of design tokens. See [v2 design
   tokens](#v2-design-tokens-shadcn) below.
 </Callout>
 
@@ -86,7 +86,7 @@ on the standard shadcn/ui token set. Instead of the `--copilot-kit-*`
 variables, they read [oklch](https://oklch.com) color tokens that are scoped to
 the `[data-copilotkit]` root and wired into Tailwind utilities through an
 `@theme inline` block. This means you can re-skin the entire v2 UI by
-overriding a handful of CSS custom properties — every component picks the
+overriding a handful of CSS custom properties. Every component picks the
 change up automatically.
 
 Override them on the `[data-copilotkit]` element (or any ancestor) the same way
@@ -133,7 +133,7 @@ matching dark-mode value under `.dark [data-copilotkit]`. The full set
 
 <Callout type="info" title="oklch values">
   v2 tokens use the `oklch()` color space, which keeps perceived lightness
-  consistent across hues. You can still pass `hsl()`, `rgb()`, or hex — any
+  consistent across hues. You can still pass `hsl()`, `rgb()`, or hex; any
   valid CSS color works.
 </Callout>
 
@@ -162,7 +162,7 @@ that file:
 
 <Snippet
   region="user-message"
-  title="frontend/src/app/theme.css — user message bubbles"
+  title="frontend/src/app/theme.css: user message bubbles"
 />
 
 ### Reference

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/model-selection.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/model-selection.mdx
@@ -4,11 +4,12 @@ icon: "lucide/Cpu"
 description: "Choose and configure models for your Built-in Agent."
 ---
 
-The Built-in Agent uses the [Vercel AI SDK](https://sdk.vercel.ai) under the hood, giving you access to models from OpenAI, Anthropic, and Google — plus the ability to use any custom AI SDK model.
+The Built-in Agent uses the [Vercel AI SDK](https://sdk.vercel.ai), so you can use
+models from OpenAI, Anthropic, and Google, or pass any custom AI SDK model.
 
 ## Supported Models
 
-Specify a model using the `"provider:model"` format (or `"provider/model"` — both work).
+Specify a model using the `"provider:model"` format. `"provider/model"` also works.
 
 ### OpenAI
 
@@ -104,7 +105,8 @@ const agent = new BuiltInAgent({
 });
 ```
 
-This works with any AI SDK provider — Azure OpenAI, AWS Bedrock, Ollama, or any OpenAI-compatible endpoint:
+This works with any AI SDK provider, including Azure OpenAI, AWS Bedrock, Ollama,
+or any OpenAI-compatible endpoint:
 
 ```typescript
 import { createAzure } from "@ai-sdk/azure";
@@ -119,11 +121,11 @@ const agent = new BuiltInAgent({
 });
 ```
 
-## OpenRouter, Proxies & Bring-Your-Own-LLM
+## OpenRouter, proxies, and bring-your-own LLM
 
-Anything that exposes an **OpenAI-compatible** API — [OpenRouter](https://openrouter.ai),
+Anything that exposes an **OpenAI-compatible** API, including [OpenRouter](https://openrouter.ai),
 a self-hosted gateway, an internal LLM proxy, [Ollama](https://ollama.com), [Together](https://together.ai),
-[Groq](https://groq.com), or your own fine-tuned endpoint — works through the same
+[Groq](https://groq.com), or your own fine-tuned endpoint, works through the same
 `createOpenAI({ baseURL })` pattern shown in [Custom Models](#custom-models-ai-sdk)
 above. Point `baseURL` at the provider's OpenAI-compatible route and pass your key:
 
@@ -131,7 +133,7 @@ above. Point `baseURL` at the provider's OpenAI-compatible route and pass your k
 import { BuiltInAgent } from "@copilotkit/runtime/v2";
 import { createOpenAI } from "@ai-sdk/openai"; // [!code highlight]
 
-// OpenRouter — one key, hundreds of models behind an OpenAI-compatible API
+// OpenRouter: one key, hundreds of models behind an OpenAI-compatible API
 const openrouter = createOpenAI({ // [!code highlight]
   apiKey: process.env.OPENROUTER_API_KEY, // [!code highlight]
   baseURL: "https://openrouter.ai/api/v1", // [!code highlight]
@@ -142,11 +144,11 @@ const agent = new BuiltInAgent({
 });
 ```
 
-The exact same shape works for any OpenAI-compatible proxy — just swap the
-`baseURL` and key. There is no CopilotKit-specific provider to install; if the
+The same shape works for any OpenAI-compatible proxy. Swap the `baseURL` and key.
+There is no CopilotKit-specific provider to install; if the
 AI SDK can talk to it, the Built-in Agent can use it.
 
-<Callout type="warn" title="The model is set on the agent — there is no Cloud model-switching API">
+<Callout type="warn" title="The model is set on the agent">
   CopilotKit does **not** expose a hosted/Cloud endpoint for choosing or
   switching the model at request time. The model is configured **on the agent**,
   either as a `"provider:model"` string or an AI SDK `LanguageModel` instance:
@@ -161,16 +163,19 @@ AI SDK can talk to it, the Built-in Agent can use it.
   can also use a [Custom Agent](/built-in-agent/custom-agent).
 </Callout>
 
-## How It Works
+## How it works
 
-Under the hood, the Built-in Agent resolves model strings to AI SDK provider instances:
+The Built-in Agent resolves model strings to AI SDK provider instances:
 
-- `"openai:gpt-4.1"` → `@ai-sdk/openai` → `openai("gpt-4.1")`
-- `"anthropic:claude-sonnet-4.5"` → `@ai-sdk/anthropic` → `anthropic("claude-sonnet-4.5")`
-- `"google:gemini-2.5-pro"` → `@ai-sdk/google` → `google("gemini-2.5-pro")`
+| Model string | AI SDK provider | Resolved call |
+|---|---|---|
+| `"openai:gpt-4.1"` | `@ai-sdk/openai` | `openai("gpt-4.1")` |
+| `"anthropic:claude-sonnet-4.5"` | `@ai-sdk/anthropic` | `anthropic("claude-sonnet-4.5")` |
+| `"google:gemini-2.5-pro"` | `@ai-sdk/google` | `google("gemini-2.5-pro")` |
 
 Both `"provider:model"` and `"provider/model"` separators are supported and work identically.
 
 <Callout type="info" title="Need a different AI SDK or full control?">
-  The [Custom Agent](/built-in-agent/custom-agent) lets you bring your own AI SDK, TanStack AI, or any custom LLM backend — while CopilotKit handles the rest.
+  The [Custom Agent](/built-in-agent/custom-agent) lets you bring your own AI SDK,
+  TanStack AI, or any custom LLM backend while CopilotKit handles the rest.
 </Callout>

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/agent-app-context.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/agent-app-context.mdx
@@ -154,7 +154,7 @@ This context can then be shared with your AG-UI server and agent logic.
         </Tabs>
 
         <Callout type="info">
-          Context registered with `useAgentContext` is automatically forwarded by the AG-UI protocol in `ChatOptions.AdditionalProperties["ag_ui_context"]` as an array of key-value pairs (description → value). The middleware extracts and injects this context into the conversation.
+          Context registered with `useAgentContext` is automatically forwarded by the AG-UI protocol in `ChatOptions.AdditionalProperties["ag_ui_context"]` as an array of key-value pairs (`description` to `value`). The middleware extracts and injects this context into the conversation.
         </Callout>
 
         <Callout type="tip">

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/generative-ui/state-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/generative-ui/state-rendering.mdx
@@ -297,7 +297,7 @@ is a situation where a user and an agent are working together to solve a problem
                     "- Maintain a list of searches: each item has { query, done }.\\n"
                     "- When adding a new search, call `update_searches` with the FULL list, including the new item with done=true.\\n"
                     "- All searches in the list should have done=true unless explicitly in progress.\\n"
-                    "- Never send partial updates—always include the full list on each call.\\n"
+                    "- Never send partial updates. Always include the full list on each call.\\n"
                 ),
                 client=chat_client,
                 tools=[update_searches],

--- a/showcase/shell-docs/src/content/docs/migrate/v2.mdx
+++ b/showcase/shell-docs/src/content/docs/migrate/v2.mdx
@@ -16,11 +16,11 @@ CopilotKit V2 consolidates the frontend into a single package. Both hooks and UI
 | `@copilotkit/react-ui` | `@copilotkit/react-core/v2` |
 | `@copilotkit/react-ui/styles.css` | `@copilotkit/react-core/v2/styles.css` |
 
-**What's NOT changing:**
-- Backend packages (`@copilotkit/runtime`, etc.) — no changes needed
-- Your `CopilotRuntime` configuration — stays the same
-- Agent definitions and backend setup — stays the same
-- The `<CopilotKit>` provider name — keep using it, but import it from `@copilotkit/react-core/v2`
+**What's not changing:**
+- Backend packages (`@copilotkit/runtime`, etc.) do not need changes.
+- Your `CopilotRuntime` configuration stays the same.
+- Agent definitions and backend setup stay the same.
+- Keep the `<CopilotKit>` provider name, but import it from `@copilotkit/react-core/v2`.
 
 ## Migration Steps
 
@@ -42,7 +42,7 @@ import { useCopilotReadable, useCopilotAction } from "@copilotkit/react-core";
 import { CopilotKit, useAgent } from "@copilotkit/react-core/v2";
 ```
 
-#### Hook mapping (v1 → v2)
+#### Hook mapping from v1 to v2
 
 Use this table to find the v2 replacement for each v1 hook:
 
@@ -66,7 +66,7 @@ v1 component-override props.
 
 </Step>
 <Step>
-### Replace `@copilotkit/react-ui` imports
+### Replace React UI imports
 
 UI components like `CopilotChat`, `CopilotSidebar`, and `CopilotPopup` are now exported from `@copilotkit/react-core/v2`.
 
@@ -100,7 +100,7 @@ import "@copilotkit/react-core/v2/styles.css";
 
 </Step>
 <Step>
-### Upgrade `@ag-ui/client` (if using directly)
+### Upgrade AG-UI client if using it directly
 
 If you import from `@ag-ui/client` directly, upgrade to the latest version:
 

--- a/showcase/shell-docs/src/content/docs/prebuilt-components/chat-controls.mdx
+++ b/showcase/shell-docs/src/content/docs/prebuilt-components/chat-controls.mdx
@@ -1,12 +1,11 @@
 ---
-title: "Open/close & feedback"
+title: "Open, close, and feedback"
 icon: "lucide/SlidersHorizontal"
-description: "Programmatically open and close the chat modal with useCopilotChatConfiguration, and capture thumbs-up/down message feedback on the prebuilt chat."
+description: "Open and close the prebuilt chat from your UI, and capture assistant message feedback."
 ---
 
-Two small but frequently-asked controls on the prebuilt chat: opening and closing
-the chat from your own UI, and capturing thumbs-up / thumbs-down feedback on
-assistant messages.
+Two common controls for the prebuilt chat are opening it from your own UI and
+capturing thumbs-up / thumbs-down feedback on assistant messages.
 
 ## Programmatically open or close the chat
 
@@ -45,7 +44,7 @@ To toggle, read `config.isModalOpen` and flip it:
 modal state. The prebuilt `<CopilotPopup>` and `<CopilotSidebar>` create it
 automatically. If you compose chat yourself, wrap the relevant subtree in
 `<CopilotChatConfigurationProvider isModalDefaultOpen={false}>` so the modal state
-exists — see the
+exists. See the
 [`useCopilotChatConfiguration` reference](/reference/hooks/useCopilotChatConfiguration#modal-state-management).
 </Callout>
 
@@ -60,7 +59,8 @@ accept a `defaultOpen` prop:
 
 The assistant-message toolbar can show thumbs-up and thumbs-down buttons. In v2
 you opt in by passing `onThumbsUp` / `onThumbsDown` to the **assistant message
-slot** — the buttons only render when a handler is provided:
+slot**. The buttons only render when a handler is provided:
+slot**. The buttons only render when a handler is provided:
 
 ```tsx
 import { CopilotChat } from "@copilotkit/react-core/v2";
@@ -96,7 +96,7 @@ exposes the same `onThumbsUp` / `onThumbsDown` props directly.
 
 ## Related
 
-- [CopilotPopup](/prebuilt-components/popup) and [CopilotSidebar](/prebuilt-components/sidebar) — the prebuilt surfaces that own modal state.
-- [`useCopilotChatConfiguration` reference](/reference/hooks/useCopilotChatConfiguration) — full context shape, modal state, and labels.
-- [Slots](/custom-look-and-feel/slots) — the `messageView` / `assistantMessage` slot system used above.
-- [Programmatic Control](/programmatic-control) — driving agent runs from code (a different kind of "control" — no chat UI).
+- [CopilotPopup](/prebuilt-components/popup) and [CopilotSidebar](/prebuilt-components/sidebar): the prebuilt surfaces that own modal state.
+- [`useCopilotChatConfiguration` reference](/reference/hooks/useCopilotChatConfiguration): full context shape, modal state, and labels.
+- [Slots](/custom-look-and-feel/slots): the `messageView` / `assistantMessage` slot system used above.
+- [Programmatic Control](/programmatic-control): driving agent runs from code without a chat UI.

--- a/showcase/shell-docs/src/content/docs/prebuilt-components/index.mdx
+++ b/showcase/shell-docs/src/content/docs/prebuilt-components/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Prebuilt Components
 icon: "lucide/MessageSquare"
-description: Drop-in chat components with a full customization ladder — from pure CSS to fully headless.
+description: Drop-in chat components with a full customization ladder, from pure CSS to fully headless.
 hideTOC: true
 snippet_cell: agentic-chat
 ---
@@ -17,7 +17,12 @@ snippet_cell: agentic-chat
 
 ## Pre-built components for agentic chat
 
-CopilotKit ships three prebuilt chat surfaces that connect directly to your agent: [**CopilotChat**](/prebuilt-components/chat), [**CopilotSidebar**](/prebuilt-components/sidebar), and [**CopilotPopup**](/prebuilt-components/popup). Each is a wrapper around the same primitives with a different layout; pick the one that fits your app and you're done. They all handle streaming, generative UI, and deep customization out of the box.
+CopilotKit ships three prebuilt chat surfaces that connect directly to your
+agent: [**CopilotChat**](/prebuilt-components/chat),
+[**CopilotSidebar**](/prebuilt-components/sidebar), and
+[**CopilotPopup**](/prebuilt-components/popup). Each is a wrapper around the
+same primitives with a different layout. Pick the one that fits your app; they
+all handle streaming, generative UI, and deep customization.
 
 <video
   src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/agentic-chat-ui.mp4"
@@ -81,7 +86,7 @@ Wrap your app in `<CopilotKit>` and drop `<CopilotChat>` where the
 chat should live. The provider wires the runtime, the session, and
 the agent registry. Everything else is optional configuration:
 
-<Snippet region="provider-setup" title="frontend/src/app/page.tsx — provider + chat" />
+<Snippet region="provider-setup" title="frontend/src/app/page.tsx: provider + chat" />
 
 ## Starter suggestions
 
@@ -89,17 +94,17 @@ the agent registry. Everything else is optional configuration:
 prompts the moment a user arrives. The example below uses a single
 "Write a sonnet" suggestion:
 
-<Snippet region="configure-suggestions" title="frontend/src/app/page.tsx — suggestions" />
+<Snippet region="configure-suggestions" title="frontend/src/app/page.tsx: suggestions" />
 
 ## Pick a surface
 
 Each surface is a drop-in component with the same underlying primitives, differing only in layout.
 
-- [`<CopilotChat>`](/prebuilt-components/chat) — inline chat pane you can place anywhere and size to fit.
-- [`<CopilotSidebar>`](/prebuilt-components/sidebar) — collapsible sidebar docked to the edge of your app.
-- [`<CopilotPopup>`](/prebuilt-components/popup) — floating bubble that overlays your page content.
+- [`<CopilotChat>`](/prebuilt-components/chat): inline chat pane you can place anywhere and size to fit.
+- [`<CopilotSidebar>`](/prebuilt-components/sidebar): collapsible sidebar docked to the edge of your app.
+- [`<CopilotPopup>`](/prebuilt-components/popup): floating bubble that overlays your page content.
 
 Need to open/close the chat from your own button, or capture thumbs-up/down
-feedback? See [Open/close & feedback](/prebuilt-components/chat-controls).
+feedback? See [Open, close, and feedback](/prebuilt-components/chat-controls).
 
 <IntegrationGrid path="prebuilt-components" />

--- a/showcase/shell-docs/src/content/docs/shared-state.mdx
+++ b/showcase/shell-docs/src/content/docs/shared-state.mdx
@@ -21,7 +21,9 @@ Agentic Copilots maintain a shared state that seamlessly connects your UI with t
 
 ## When should I use this?
 
-Use shared state when you want to facilitate collaboration between your agent and the user. Updates flow both ways — the agent's outputs are automatically reflected in the UI, and any inputs the user updates in the UI are automatically reflected in the agent's execution.
+Use shared state when you want the agent and the user to collaborate through the
+same application state. The agent's outputs are reflected in the UI, and user
+updates in the UI are reflected in the agent's execution.
 
 <OpsPlatformCTA
   variant="inline"
@@ -35,13 +37,13 @@ Use shared state when you want to facilitate collaboration between your agent an
 <FrameworkSetup concept="shared-state-setup" />
 
 Subscribe a component to the agent's state with `useAgent`. Any time the agent
-mutates its state — for example via a tool call — the hook fires and your UI
+mutates its state, for example via a tool call, the hook fires and your UI
 re-renders with the new values.
 
-<Snippet region="use-agent-read" cell="shared-state-read-write" title="frontend/src/app/page.tsx — useAgent subscription" />
+<Snippet region="use-agent-read" cell="shared-state-read-write" title="frontend/src/app/page.tsx: useAgent subscription" />
 
 The returned `agent.state` is just a plain object. Read it like any other
-piece of React state and render the parts you care about — agent-written
+piece of React state and render the parts you care about: agent-written
 notes, structured outputs, progress indicators, anything the agent has put
 there.
 
@@ -49,9 +51,9 @@ there.
 
 The same `agent` object exposes a `setState` setter. Calling it from a UI
 event handler pushes the new value into shared state, and the agent reads it
-back on its next turn — so the UI's writes visibly steer the model.
+back on its next turn. The UI's writes visibly steer the model.
 
-<Snippet region="use-agent-write" cell="shared-state-read-write" title="frontend/src/app/page.tsx — agent.setState" />
+<Snippet region="use-agent-write" cell="shared-state-read-write" title="frontend/src/app/page.tsx: agent.setState" />
 
 This is what makes the channel two-way: the UI doesn't just observe the
 agent, it can hand the agent fresh inputs (preferences, selections, partial
@@ -63,10 +65,10 @@ Because `agent.state` is plain React data, the UI layer is whatever you'd
 normally build. The demo on this page wires the agent's outputs into a
 small card component and feeds user edits back through `setState`.
 
-<Snippet region="notes-card-render" cell="shared-state-read-write" title="frontend/src/app/page.tsx — NotesCard" />
+<Snippet region="notes-card-render" cell="shared-state-read-write" title="frontend/src/app/page.tsx: NotesCard" />
 
 Nothing about this is chat-specific: `useAgent` works in any component under
-`<CopilotKit>`, so you can render `agent.state` in your main view or canvas —
+`<CopilotKit>`, so you can render `agent.state` in your main view or canvas,
 not just inside the chat panel. See
 **[Render agent state in your app](/shared-state/rendering-in-app)** for the
 full main-view pattern.
@@ -78,7 +80,7 @@ long-running tool call appears as one big burst at the end. State streaming
 forwards a specific tool argument straight into a state key *as it's being
 generated*, so the UI can watch the answer assemble token-by-token.
 
-<Snippet region="state-streaming-middleware" cell="shared-state-streaming" title="backend — streaming state update" />
+<Snippet region="state-streaming-middleware" cell="shared-state-streaming" title="backend: streaming state update" />
 
 See **[State streaming](/shared-state/streaming)** for the full walkthrough,
 including the corresponding `useAgent` subscription on the frontend.
@@ -86,9 +88,9 @@ including the corresponding `useAgent` subscription on the frontend.
 ## Read-only context
 
 When the value is **UI-owned** and the agent should read it but never write
-it back — current user, selected record, scroll position — reach for
+it back, such as current user, selected record, or scroll position, reach for
 `useAgentContext` instead of full shared state. It publishes values as a
-one-way UI → agent channel that auto-unregisters on unmount.
+one-way UI-to-agent channel that auto-unregisters on unmount.
 
 See **[Agent read-only context](/shared-state/agent-readonly)** for the
 full pattern.

--- a/showcase/shell-docs/src/content/docs/shared-state/rendering-in-app.mdx
+++ b/showcase/shell-docs/src/content/docs/shared-state/rendering-in-app.mdx
@@ -1,21 +1,20 @@
 ---
 title: "Render agent state in your app"
 icon: "lucide/LayoutDashboard"
-description: "Read agent.state with useAgent and render it in your main view or canvas — outside the chat sidebar — so the agent drives your real UI."
+description: "Read agent.state with useAgent and render it in your main view or canvas."
 ---
 
 [Shared state](/shared-state) is most powerful when the agent's state shows up in
-your **actual application UI** — a dashboard, a document canvas, a map, a table —
-not just inside the chat panel. Because `agent.state` is plain React data, you can
-subscribe to it from any component anywhere in your tree and render it however you
-like.
+your application UI, such as a dashboard, document canvas, map, or table. Because
+`agent.state` is plain React data, you can subscribe to it from any component in
+your tree and render it however you like.
 
 ## The pattern
 
-`useAgent` works in any component under `<CopilotKit>` — it doesn't have to be
+`useAgent` works in any component under `<CopilotKit>`. It doesn't have to be
 near the chat. Call it in your main-view component, read `agent.state`, and render:
 
-```tsx title="components/Canvas.tsx — agent state in the main view"
+```tsx title="components/Canvas.tsx"
 import { useAgent } from "@copilotkit/react-core/v2";
 
 type CanvasState = {
@@ -24,7 +23,7 @@ type CanvasState = {
 };
 
 export function Canvas() {
-  // No agentId → the "default" agent. Pass { agentId } to target another.
+  // No agentId means the "default" agent. Pass { agentId } to target another.
   const { agent } = useAgent();
   const state = (agent.state ?? {}) as Partial<CanvasState>;
 
@@ -43,8 +42,8 @@ export function Canvas() {
 }
 ```
 
-Every time the agent mutates its state — a tool call, a node transition, a
-[streamed update](/shared-state/streaming) — `useAgent` re-renders this component
+Every time the agent mutates its state, whether from a tool call, node
+transition, or [streamed update](/shared-state/streaming), `useAgent` re-renders this component
 with the new values. The chat can be in a sidebar, a popup, or absent entirely;
 your canvas updates the same way.
 
@@ -54,7 +53,7 @@ The agent lives on the `<CopilotKit>` provider, so the chat surface and your
 main-view components are just two consumers of the same agent. A typical layout
 renders the canvas as the primary content and the chat as a docked sidebar:
 
-```tsx title="app/page.tsx — canvas as the primary surface, chat alongside"
+```tsx title="app/page.tsx"
 import { CopilotKit, CopilotSidebar } from "@copilotkit/react-core/v2";
 import { Canvas } from "../components/Canvas";
 
@@ -62,7 +61,7 @@ export default function Page() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit">
       <div className="app-shell">
-        {/* Your real UI — driven by agent.state */}
+        {/* Your app UI, driven by agent.state */}
         <Canvas />
         {/* Chat is just another consumer of the same agent */}
         <CopilotSidebar />
@@ -75,7 +74,8 @@ export default function Page() {
 <Callout type="info">
 `<Canvas>` and `<CopilotSidebar>` both call `useAgent()` for the same `agentId`,
 so they share one agent instance and one state object. There's nothing chat-specific
-about reading `agent.state` — the sidebar is not special.
+about reading `agent.state`. The sidebar is not special.
+about reading `agent.state`. The sidebar is not special.
 </Callout>
 
 ## Writing back from the main view
@@ -95,7 +95,7 @@ function toggleItem(id: string) {
 }
 ```
 
-This is the same two-way channel described in [Shared State](/shared-state) — the
+This is the same two-way channel described in [Shared State](/shared-state). The
 only difference here is that the reads and writes happen in your application's main
 surface rather than in the chat.
 
@@ -105,12 +105,12 @@ surface rather than in the chat.
   you have more than one. The default is the agent named `"default"`.
 - **Throttle high-frequency updates** with `useAgent({ throttleMs })` if a
   streaming run re-renders a heavy canvas too often.
-- **Treat `agent.state` as possibly partial** while a run is in progress — guard
+- **Treat `agent.state` as possibly partial** while a run is in progress. Guard
   with defaults (as above) so half-streamed state doesn't crash your render.
 
 ## Related
 
-- [Shared State](/shared-state) — the full read/write model and the underlying `useAgent` subscription.
-- [State streaming](/shared-state/streaming) — stream a tool argument into a state key so the canvas fills in token-by-token.
-- [Agent read-only context](/shared-state/agent-readonly) — push UI values *to* the agent without letting it write back.
-- [`useAgent` reference](/reference/v2/hooks/useAgent) — full hook signature and options.
+- [Shared State](/shared-state): the full read/write model and the underlying `useAgent` subscription.
+- [State streaming](/shared-state/streaming): stream a tool argument into a state key so the canvas fills in token-by-token.
+- [Agent read-only context](/shared-state/agent-readonly): push UI values *to* the agent without letting it write back.
+- [`useAgent` reference](/reference/v2/hooks/useAgent): full hook signature and options.

--- a/showcase/shell-docs/src/content/docs/troubleshooting/common-issues.mdx
+++ b/showcase/shell-docs/src/content/docs/troubleshooting/common-issues.mdx
@@ -37,7 +37,7 @@ Common issues:
 - Missing leading slash in the endpoint path
 - Wrong path relative to your app's base URL (or, if absolute, wrong full URL)
 - Typos in the endpoint path
-- Using CopilotCloud but also setting `runtimeUrl` — omit `runtimeUrl` and keep only `publicApiKey`
+- Using CopilotCloud but also setting `runtimeUrl`. Omit `runtimeUrl` and keep only `publicApiKey`
 </Accordion>
 
 <Accordion title="localhost vs 127.0.0.1">
@@ -121,20 +121,20 @@ If any of these fail:
 
 Usually one of:
 
-- The LLM model string isn't a model the runtime's provider actually supports — double-check against [Model Selection](/built-in-agent/model-selection).
-- The Built-in Agent's `prompt` is empty and the user message is "do nothing" — give the agent a system prompt.
-- A frontend tool is throwing during its handler and the agent is treating the empty result as the turn output — see [Error Debugging](./error-debugging) for the `tool_handler_failed` code.
+- The LLM model string isn't supported by the runtime's provider. Check it against [Model Selection](/built-in-agent/model-selection).
+- The Built-in Agent's `prompt` is empty and the user message gives it nothing useful to do. Give the agent a system prompt.
+- A frontend tool is throwing during its handler and the agent is treating the empty result as the turn output. See [Error Debugging](./error-debugging) for the `tool_handler_failed` code.
 
 ## Tools I registered don't show up
 
-- Open the [Inspector](../inspector) → **Frontend Tools** panel. If the tool isn't there, the hook call didn't land — confirm the component is actually mounted.
+- Open the [Inspector](../inspector) > **Frontend Tools** panel. If the tool isn't there, the hook call didn't land. Confirm the component is actually mounted.
 - If the tool is listed but the agent never calls it, the model may not know when to use it. Tweak the `description` to include the trigger phrase.
-- For v1 → v2 migrations, `useCopilotAction` split into `useFrontendTool` / `useComponent` / `useHumanInTheLoop` — make sure you're using the right one.
+- For v1 to v2 migrations, `useCopilotAction` split into `useFrontendTool`, `useComponent`, and `useHumanInTheLoop`. Make sure you're using the right one.
 
-## The `/connect` route returns a 404 on a fresh thread
+## Connect route returns 404 on a fresh thread
 
 If you self-host the runtime and see a `404` from `POST /agent/:agentId/connect`
-right after the page loads — before any message is sent — it's almost always one
+right after the page loads, before any message is sent, it's almost always one
 of two things:
 
 <Accordions>
@@ -156,15 +156,15 @@ Confirm the agent shows up by hitting [`GET {runtimeUrl}/info`](/backend/runtime
 directly. See also the [error reference](./error-reference#agent-not-found--agent-id-does-not-exist).
 </Accordion>
 
-<Accordion title="connect() runs before any run() for an auto-minted thread">
+<Accordion title="connect() runs before run() on a new thread">
 The frontend mints a thread id and may call `connect()` to re-attach **before**
 the first `run()` has produced any events. A persistence backend that only learns
 about a thread once a run starts can 404 (or error) on that first connect.
 
 The built-in [`InMemoryAgentRunner`](/backend/agent-runner) handles the common
 cases, but a custom runner backed by an external memory layer must handle the
-"unknown thread" path explicitly — return an empty `RUN_STARTED` →
-`MESSAGES_SNAPSHOT` → `RUN_FINISHED` sequence instead of failing. The
+"unknown thread" path explicitly. Return an empty `RUN_STARTED`,
+`MESSAGES_SNAPSHOT`, `RUN_FINISHED` sequence instead of failing. The
 [AWS AgentCore integration](/deploy/agentcore) shows the exact pattern.
 </Accordion>
 </Accordions>

--- a/showcase/shell-docs/src/content/docs/troubleshooting/error-reference.mdx
+++ b/showcase/shell-docs/src/content/docs/troubleshooting/error-reference.mdx
@@ -1,28 +1,33 @@
 ---
 title: "Error message reference"
 icon: "lucide/CircleAlert"
-description: "Paste the exact error string CopilotKit threw — Missing required prop, CopilotKitAgentDiscoveryError, Agent not found — and find its cause and fix."
+description: "Find the cause and fix for common CopilotKit console, network, and error UI messages."
 ---
 
-This page lists the **literal error strings** CopilotKit surfaces in your console,
-network responses, and error UI, each with what causes it and how to fix it. If you
-hit an error, search this page (Cmd/Ctrl-F) for a distinctive phrase from the
-message.
+This page lists the error strings CopilotKit surfaces in your console, network
+responses, and error UI. If you hit an error, search this page with Cmd/Ctrl-F
+for a distinctive phrase from the message.
 
 For the programmatic `onError` **codes** (`runtime_info_fetch_failed`,
-`tool_handler_failed`, …) rather than these human-readable strings, see
+`tool_handler_failed`, ...) rather than these human-readable strings, see
 [Error Debugging](/troubleshooting/error-debugging).
 
-## `Missing required prop: 'runtimeUrl' or 'publicApiKey' or 'publicLicenseKey'`
+## Missing runtime configuration
 
-**Where:** the **v2** provider — `<CopilotKitProvider>`, imported from
+Error string:
+
+```txt
+Missing required prop: 'runtimeUrl' or 'publicApiKey' or 'publicLicenseKey'
+```
+
+**Where:** the **v2** provider, `<CopilotKitProvider>`, imported from
 `@copilotkit/react-core/v2`. In production
 (`NODE_ENV === "production"`) it's a thrown `Error`; in development it's a
 `console.warn` so local-agent and test setups still run.
 
 <Callout type="info" title="v1 behaves differently">
   The **v1** `<CopilotKit>` provider throws this error **unconditionally** (in
-  both development and production — there is no dev-only `console.warn` branch),
+  both development and production; there is no dev-only `console.warn` branch),
   and it does **not** accept `selfManagedAgents`. On v1, satisfy the provider with
   a `runtimeUrl` or a Copilot Cloud key, or pass agents directly via
   `agents__unsafe_dev_only` for local development.
@@ -32,31 +37,38 @@ For the programmatic `onError` **codes** (`runtime_info_fetch_failed`,
 `runtimeUrl`, a Copilot Cloud key (`publicApiKey` / `publicLicenseKey`), **and** you
 didn't register any local agents.
 
-**Fix (v2):** provide one of (the v2 provider `CopilotKitProvider` is imported from `@copilotkit/react-core/v2`):
+**Fix (v2):** provide one of these values to `CopilotKitProvider`, imported from
+`@copilotkit/react-core/v2`:
 
 ```tsx
 // Runtime-backed (recommended)
-<CopilotKitProvider runtimeUrl="/api/copilotkit">…</CopilotKitProvider>
+<CopilotKitProvider runtimeUrl="/api/copilotkit">{children}</CopilotKitProvider>
 
 // Copilot Cloud
-<CopilotKitProvider publicApiKey="ck_pub_…">…</CopilotKitProvider>
+<CopilotKitProvider publicApiKey="ck_pub_...">{children}</CopilotKitProvider>
 
 // Agents you manage yourself (v2 only)
-<CopilotKitProvider selfManagedAgents={{ "my-agent": myAgent }}>…</CopilotKitProvider>
+<CopilotKitProvider selfManagedAgents={{ "my-agent": myAgent }}>{children}</CopilotKitProvider>
 ```
 
 See [Self-managed agents](/backend/self-managed-agents) for the local-agent path.
 
-## `CopilotKitAgentDiscoveryError`
+## Agent discovery failed
+
+Error name:
+
+```txt
+CopilotKitAgentDiscoveryError
+```
 
 This is the error **name** (`error.name`). The accompanying message is one of:
 
 - `Agent '<name>' was not found. Available agents are: <list>. Please verify the agent name in your configuration and ensure it matches one of the available agents.`
-- `The requested agent was not found. Available agents are: <list>. …`
+- `The requested agent was not found. Available agents are: <list>. ...`
 - `Agent '<name>' was not found. Please set up at least one agent before proceeding.` (when **no** agents are registered)
 
 **Cause:** the frontend asked for an `agentId` that the runtime didn't return from
-its `/info` discovery — a typo, a missing registration, or a runtime that has no
+its `/info` discovery. This is usually a typo, a missing registration, or a runtime that has no
 agents at all. The prebuilt components default to the agent named `"default"`.
 
 **Fix:**
@@ -67,14 +79,21 @@ agents at all. The prebuilt components default to the agent named `"default"`.
   new CopilotRuntime({ agents: { default: myAgent } });
   ```
 - Confirm the id matches the "Available agents" list in the message.
-- Verify the runtime is reachable — hit `GET {runtimeUrl}/info` directly (see
+- Verify the runtime is reachable by hitting `GET {runtimeUrl}/info` directly (see
   [Runtime HTTP endpoints](/backend/runtime-endpoints)). A discovery failure here
   cascades into this error.
 
-`CopilotKitAgentDiscoveryError` is a **banner** error — it renders as a fixed
+`CopilotKitAgentDiscoveryError` is a **banner** error. It renders as a fixed
 banner in the dev console rather than a dismissible toast.
 
-## `Agent not found` / `Agent '<id>' does not exist`
+## Agent route returned 404
+
+Error strings:
+
+```txt
+Agent not found
+Agent '<id>' does not exist
+```
 
 **Where:** an HTTP `404` JSON body from the runtime's agent routes:
 
@@ -86,23 +105,35 @@ banner in the dev console rather than a dismissible toast.
 named an `agentId` that isn't registered on the runtime. This is the server-side
 counterpart to the client-side `CopilotKitAgentDiscoveryError`.
 
-**Fix:** register the agent under that key in `new CopilotRuntime({ agents: {…} })`.
+**Fix:** register the agent under that key in `new CopilotRuntime({ agents: { ... } })`.
 If you see this on the `/connect` route **before sending any message**, also read
-[the `/connect` 404 entry](/troubleshooting/common-issues#the-connect-route-returns-a-404-on-a-fresh-thread).
+[the `/connect` 404 entry](/troubleshooting/common-issues#connect-route-returns-404-on-a-fresh-thread).
 
-## `Failed to run agent`
+## Agent run failed
+
+Error string:
+
+```txt
+Failed to run agent
+```
 
 **Where:** a `500` JSON body from the runtime's run/connect routes, with a
 `message` field carrying the underlying error.
 
-**Cause:** the agent threw while executing — a bad model string, a missing API key
+**Cause:** the agent threw while executing. Common causes include a bad model string, a missing API key
 on the server, a provider error, or an exception inside the agent itself.
 
 **Fix:** read the `message` field and check your server logs (the runtime logs the
 error name, message, and stack). Common culprits: an unset `OPENAI_API_KEY` (or
 equivalent) on the server, or a model string the provider doesn't recognize.
 
-## `Failed to fetch capabilities for agent "<name>"`
+## Capability discovery failed
+
+Error string:
+
+```txt
+Failed to fetch capabilities for agent "<name>"
+```
 
 **Where:** logged on the client when capability discovery for an agent fails.
 
@@ -111,10 +142,10 @@ endpoint errored.
 
 **Fix:** confirm `runtimeUrl` is correct and the runtime is up; verify
 `GET {runtimeUrl}/info` returns the agent. See
-[Common Issues → Network errors](/troubleshooting/common-issues#network-errors--api-not-found).
+[Common Issues: Network errors](/troubleshooting/common-issues#network-errors--api-not-found).
 
 ## Related
 
-- [Error Debugging](/troubleshooting/error-debugging) — the `onError` callback and its programmatic error **codes**.
-- [Common Issues](/troubleshooting/common-issues) — network, endpoint, and tunnel problems.
-- [Runtime HTTP endpoints](/backend/runtime-endpoints) — probing `/info` and the agent routes with `curl`.
+- [Error Debugging](/troubleshooting/error-debugging): the `onError` callback and its programmatic error **codes**.
+- [Common Issues](/troubleshooting/common-issues): network, endpoint, and tunnel problems.
+- [Runtime HTTP endpoints](/backend/runtime-endpoints): probing `/info` and the agent routes with `curl`.

--- a/showcase/shell-docs/src/content/docs/troubleshooting/inspector-dev-console.mdx
+++ b/showcase/shell-docs/src/content/docs/troubleshooting/inspector-dev-console.mdx
@@ -1,55 +1,55 @@
 ---
-title: "enableInspector vs showDevConsole"
+title: "Inspector and dev console"
 icon: "lucide/PanelTop"
-description: "Which prop controls the inspector and the error console — enableInspector (v1, replaces the deprecated showDevConsole) versus showDevConsole in v2 — and how to migrate."
+description: "Choose the right inspector and dev console prop for v1 and v2."
 ---
 
 There are two related `<CopilotKit>` props that control on-screen debugging UI, and
 which one you want depends on whether you're on **v1** or **v2**. They are easy to
 confuse because the names overlap.
 
-## In v1: `enableInspector` (use this), `showDevConsole` (deprecated)
+## v1 inspector behavior
 
 On the v1 `<CopilotKit>` provider:
 
-- **`enableInspector?: boolean`** — controls the CopilotKit Inspector (inspect
+- **`enableInspector?: boolean`** controls the CopilotKit Inspector (inspect
   AG-UI events, agent messages, agent state, and context). **Defaults to a
   localhost-gated mode**: when you don't pass the prop, the inspector shows on
   `localhost` / `127.0.0.1` / `0.0.0.0` and stays hidden in production. This is
-  close to the v2 `showDevConsole="auto"` mode, but **not identical** — v2
+  close to the v2 `showDevConsole="auto"` mode, but not identical. v2
   `"auto"` matches only `localhost` / `127.0.0.1` and does **not** treat
   `0.0.0.0` as local. Pass `enableInspector={true}`
   to always show it (including in production) or `enableInspector={false}` to
   always hide it.
-- **`showDevConsole?: boolean`** — **deprecated.** It only ever controlled the
+- **`showDevConsole?: boolean`** is deprecated. It only ever controlled the
   error toasts/banners, *not* the inspector button. Defaults to `false` for
   production safety.
 
 ```tsx
-// v1 — control the inspector with enableInspector
+// v1: control the inspector with enableInspector
 <CopilotKit runtimeUrl="/api/copilotkit" enableInspector={false}>
   {children}
 </CopilotKit>
 ```
 
 If you're on v1 and still passing `showDevConsole` expecting it to surface the
-inspector, switch to `enableInspector` — `showDevConsole` won't show the inspector
+inspector, switch to `enableInspector`. `showDevConsole` won't show the inspector
 button.
 
-## In v2: `showDevConsole` (with an `"auto"` mode)
+## v2 dev console behavior
 
 The v2 provider `<CopilotKitProvider>` (from `@copilotkit/react-core/v2`)
 consolidates this into a single prop. There is **no `enableInspector` prop in
-v2** — use `showDevConsole`:
+v2**. Use `showDevConsole`:
 
-- **`showDevConsole?: boolean | "auto"`** — controls whether the inspector renders.
-  - `true` — always show.
-  - `false` (default) — never show.
-  - `"auto"` — show only on `localhost` / `127.0.0.1`, so it appears in local dev
+- **`showDevConsole?: boolean | "auto"`** controls whether the inspector renders.
+  - `true`: always show.
+  - `false` (default): never show.
+  - `"auto"`: show only on `localhost` / `127.0.0.1`, so it appears in local dev
     and stays hidden in production automatically.
 
 ```tsx
-// v2 — "auto" shows the inspector on localhost only
+// v2: "auto" shows the inspector on localhost only
 import { CopilotKitProvider } from "@copilotkit/react-core/v2";
 
 <CopilotKitProvider runtimeUrl="/api/copilotkit" showDevConsole="auto">
@@ -72,13 +72,13 @@ developing locally and nothing leaks into production builds.
 | `showDevConsole={true}` (deprecated) | `showDevConsole={true}` |
 
 <Callout type="warn">
-Don't ship `showDevConsole={true}` to production — it exposes internal error and
+Don't ship `showDevConsole={true}` to production. It exposes internal error and
 event details to end users. Prefer `"auto"` (v2) so it's automatically off in
 production.
 </Callout>
 
 ## Related
 
-- [Inspector](/inspector) — what the inspector shows and how to use it.
-- [Error Debugging](/troubleshooting/error-debugging) — the error console and the programmatic `onError` callback.
-- [Migrate to v2](/migrate/v2) — the full v1 → v2 migration guide.
+- [Inspector](/inspector): what the inspector shows and how to use it.
+- [Error Debugging](/troubleshooting/error-debugging): the error console and the programmatic `onError` callback.
+- [Migrate to v2](/migrate/v2): the full v1 to v2 migration guide.

--- a/showcase/shell-docs/src/content/docs/whats-new/v1-50.mdx
+++ b/showcase/shell-docs/src/content/docs/whats-new/v1-50.mdx
@@ -19,7 +19,8 @@ npm install @copilotkit/react-core@latest @copilotkit/react-ui@latest @copilotki
 
 # Overview
 
-CopilotKit v1.50 is a major update. It includes many highly sought after new features, under the hood improvements and simplifications, and extensive improvements to existing core elements:
+CopilotKit v1.50 is a major update. It includes requested features, internal
+simplifications, and improvements to existing core elements:
 
 | Feature                                                           | Description                                                                                                                      |
 | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
@@ -53,7 +54,7 @@ You can opt into any of the new developer interfaces or keep using the old ones.
 
 ---
 
-# `useAgent`
+# useAgent
 
 The v2 hook useAgent is a proper superset of `useCoAgent` which gives more control over the agent connection, including:
 
@@ -110,11 +111,12 @@ v1.50 is available now, with useAgent fully ready. The other features (listed be
 
 ### Threads & Persistence
 
-v1.50 delivers support for threaded conversations, with built in thread storage and connection components. Support for development with InMemory or SQLite is provided out of the box.
+v1.50 delivers support for threaded conversations, with built-in thread storage
+and connection components. For development, use InMemory or SQLite.
 
 #### Thread storage
 
-    - **For development:** `InMemory` or `SQLite` out of the box
+    - **For development:** `InMemory` or `SQLite`
 
         ```tsx
 
@@ -127,7 +129,7 @@ v1.50 delivers support for threaded conversations, with built in thread storage 
         ```
 
     - **For production**
-        - Use the **Enterprise Intelligence Platform** — managed via **Copilot Cloud** or self-hosted via **Copilot Enterprise** — to persist threads, get automatic stream reconnection, and in-built product analytics. See the [Threads guide](/threads) to get started on the free Developer tier.
+        - Use the **Enterprise Intelligence Platform**, managed via **Copilot Cloud** or self-hosted via **Copilot Enterprise**, to persist threads, get automatic stream reconnection, and in-built product analytics. See the [Threads guide](/threads) to get started on the free Developer tier.
             - **👉 Join the [Enterprise Early Access](https://go.copilotkit.ai/enterprise-threads-waitlist) form.**
 
 #### Thread connection
@@ -209,7 +211,7 @@ const { state, setState } = agent;
 
 If you run into anything unexpected:
 
-→ **Please raise an issue in the CopilotKit [Discord support channel](https://go.copilotkit.ai/discord)**
+**Please raise an issue in the CopilotKit [Discord support channel](https://go.copilotkit.ai/discord).**
 
 Your feedback is incredibly valuable at this stage.
 

--- a/showcase/shell-docs/src/content/reference/hooks/useAgent.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useAgent.mdx
@@ -78,7 +78,7 @@ function useAgent(options?: UseAgentProps): { agent: AbstractAgent };
     ### Methods
 
     <PropertyReference name="runAgent" type="(parameters?: RunAgentParameters, subscriber?: AgentSubscriber) => Promise<RunAgentResult>">
-      Manually triggers agent execution. Resolves with a `RunAgentResult` (`{ result, newMessages }`) once the run finalizes — `result` is the final value of the run and `newMessages` are the messages produced during it.
+      Manually triggers agent execution. Resolves with a `RunAgentResult` (`{ result, newMessages }`) once the run finalizes. `result` is the final value of the run and `newMessages` are the messages produced during it.
 
       **Parameters:**
       - `parameters.forwardedProps?: any` - Data to pass to the agent execution context

--- a/showcase/shell-docs/src/content/reference/v1/hooks/useAgent.mdx
+++ b/showcase/shell-docs/src/content/reference/v1/hooks/useAgent.mdx
@@ -82,7 +82,7 @@ function useAgent(options?: UseAgentProps): { agent: AbstractAgent }
     ### Methods
 
     <PropertyReference name="runAgent" type="(parameters?: RunAgentParameters, subscriber?: AgentSubscriber) => Promise<RunAgentResult>">
-      Manually triggers agent execution. Resolves with a `RunAgentResult` (`{ result, newMessages }`) once the run finalizes — `result` is the final value of the run and `newMessages` are the messages produced during it.
+      Manually triggers agent execution. Resolves with a `RunAgentResult` (`{ result, newMessages }`) once the run finalizes. `result` is the final value of the run and `newMessages` are the messages produced during it.
 
       **Parameters:**
       - `parameters.forwardedProps?: any` - Data to pass to the agent execution context

--- a/showcase/shell-docs/src/content/reference/v1/hooks/useFrontendTool.mdx
+++ b/showcase/shell-docs/src/content/reference/v1/hooks/useFrontendTool.mdx
@@ -8,7 +8,7 @@ description: "The useFrontendTool hook allows the Copilot to execute tools in th
 </Callout>
 
 `useFrontendTool` allows you to define executable actions that the AI can call with a handler function.
-This is the primary way to give your AI agent the ability to perform actions in your application—whether
+This is the primary way to give your AI agent the ability to perform actions in your application, whether
 that's updating state, making API calls, or triggering side effects.
 
 The hook requires three main pieces:

--- a/showcase/shell-docs/src/content/reference/v1/hooks/useHumanInTheLoop.mdx
+++ b/showcase/shell-docs/src/content/reference/v1/hooks/useHumanInTheLoop.mdx
@@ -11,7 +11,7 @@ description: "The useHumanInTheLoop hook enables human approval and interaction 
 tool, it stops and waits for the user to respond through your custom UI before continuing. This is
 essential for sensitive operations, confirmations, or collecting information that only the user can provide.
 
-Unlike `useFrontendTool`, there's no handler function—instead, your render function receives a `respond`
+Unlike `useFrontendTool`, there's no handler function. Instead, your render function receives a `respond`
 callback that sends the user's input back to the AI. The AI execution remains paused until `respond` is called,
 making this a true blocking interaction.
 
@@ -233,5 +233,5 @@ A React component that renders the interactive UI for human input. The component
 </PropertyReference>
 
 <PropertyReference name="available" type="'disabled' | 'enabled'"  >
-Currently non-functional in this v1 hook — the value is accepted for API compatibility but ignored, so setting `"disabled"` does not prevent the tool from being registered or called.
+Currently non-functional in this v1 hook. The value is accepted for API compatibility but ignored, so setting `"disabled"` does not prevent the tool from being registered or called.
 </PropertyReference>

--- a/showcase/shell-docs/src/content/reference/v1/hooks/useLangGraphInterrupt.mdx
+++ b/showcase/shell-docs/src/content/reference/v1/hooks/useLangGraphInterrupt.mdx
@@ -7,7 +7,7 @@ description: "The useLangGraphInterrupt hook allows setting the generative UI to
 <video src="https://cdn.copilotkit.ai/docs/copilotkit/images/coagents/interrupt-flow.mp4" className="rounded-lg shadow-xl" loop playsInline controls autoPlay muted />
 
 <Callout type="warning">
-  `useLangGraphInterrupt` is still supported, but we recommend migrating to [`useInterrupt`](/reference/v2/hooks/useInterrupt) from the v2 API. `useInterrupt` is the shape-equivalent replacement — it uses the same `render: ({ event, resolve }) => ...` pattern to render UI for an interrupt and resume the agent with the user's response.
+  `useLangGraphInterrupt` is still supported, but we recommend migrating to [`useInterrupt`](/reference/v2/hooks/useInterrupt) from the v2 API. `useInterrupt` is the shape-equivalent replacement. It uses the same `render: ({ event, resolve }) => ...` pattern to render UI for an interrupt and resume the agent with the user's response.
 </Callout>
 
 `useLangGraphInterrupt` is a React hook that you can use in your application to provide

--- a/showcase/shell-docs/src/content/reference/v1/hooks/useRenderToolCall.mdx
+++ b/showcase/shell-docs/src/content/reference/v1/hooks/useRenderToolCall.mdx
@@ -7,7 +7,7 @@ description: "The useRenderToolCall hook enables rendering of backend tool calls
   This v1 `useRenderToolCall` takes a `{ name, parameters, render }` config object to **register** a renderer for a tool. In the v2 API, the same name has a **different shape**: v2 [`useRenderToolCall`](/reference/v2/hooks/useRenderToolCall) is a no-argument hook that *returns* a renderer function for consuming tool calls. To register renderers in v2, use [`useFrontendTool`](/reference/v2/hooks/useFrontendTool) or [`useHumanInTheLoop`](/reference/v2/hooks/useHumanInTheLoop) instead.
 </Callout>
 
-`useRenderToolCall` is purely a rendering hook — it displays custom UI for tool calls without executing
+`useRenderToolCall` is purely a rendering hook. It displays custom UI for tool calls without executing
 any logic. This is typically used to visualize backend tool executions in your chat interface, showing
 users what the AI is doing behind the scenes.
 
@@ -127,5 +127,5 @@ A React component that renders the tool call UI. The component receives props wi
 </PropertyReference>
 
 <PropertyReference name="available" type="'disabled' | 'enabled'"  >
-Currently non-functional in this v1 hook — the value is accepted for API compatibility but ignored, so setting `"disabled"` does not prevent the renderer from being registered.
+Currently non-functional in this v1 hook. The value is accepted for API compatibility but ignored, so setting `"disabled"` does not prevent the renderer from being registered.
 </PropertyReference>

--- a/showcase/shell-docs/src/content/snippets/shared/guides/custom-look-and-feel/bring-your-own-components.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/guides/custom-look-and-feel/bring-your-own-components.mdx
@@ -480,7 +480,7 @@ function CustomReasoningMessage({
   return (
     <details open={isStreaming} className="my-2 rounded border p-3">
       <summary className="cursor-pointer font-medium text-sm">
-        {isStreaming ? "🧠 Thinking…" : "💡 View reasoning"}
+        {isStreaming ? "Thinking..." : "View reasoning"}
       </summary>
       <p className="mt-2 text-sm text-gray-600 whitespace-pre-wrap">
         {message.content}
@@ -500,7 +500,7 @@ function CustomReasoningMessage({
 
 **Key concepts**
 
-- `message` — The reasoning message object. `message.content` holds the thinking text.
-- `messages` — All messages in the conversation, used to determine if this is the latest message.
-- `isRunning` — Whether the agent is currently running.
-- **Slot props** — Instead of replacing the whole component, you can override just the `header`, `contentView`, or `toggle` sub-components. See the [full guide](/custom-look-and-feel/reasoning-messages).
+- `message`: The reasoning message object. `message.content` holds the thinking text.
+- `messages`: All messages in the conversation, used to determine if this is the latest message.
+- `isRunning`: Whether the agent is currently running.
+- **Slot props:** Instead of replacing the whole component, you can override just the `header`, `contentView`, or `toggle` sub-components. See the [full guide](/custom-look-and-feel/reasoning-messages).

--- a/showcase/shell-docs/src/content/snippets/shared/troubleshooting/migrate-to-v2.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/troubleshooting/migrate-to-v2.mdx
@@ -10,12 +10,12 @@ CopilotKit V2 consolidates the frontend into a single package. Both hooks and UI
 | `@copilotkit/react-ui`            | `@copilotkit/react-core/v2`            |
 | `@copilotkit/react-ui/styles.css` | `@copilotkit/react-core/v2/styles.css` |
 
-**What's NOT changing:**
+**What's not changing:**
 
-- Backend packages (`@copilotkit/runtime`, etc.) — no changes needed
-- Your `CopilotRuntime` configuration — stays the same
-- Agent definitions and backend setup — stays the same
-- The `<CopilotKit>` provider name — keep using it, but import it from `@copilotkit/react-core/v2`
+- Backend packages (`@copilotkit/runtime`, etc.) do not need changes.
+- Your `CopilotRuntime` configuration stays the same.
+- Agent definitions and backend setup stay the same.
+- Keep the `<CopilotKit>` provider name, but import it from `@copilotkit/react-core/v2`.
 
 ## Migration Steps
 
@@ -39,7 +39,7 @@ import { useCopilotReadable, useCopilotAction } from "@copilotkit/react-core";
 import { CopilotKit, useAgent } from "@copilotkit/react-core/v2";
 ```
 
-#### Hook mapping (v1 → v2)
+#### Hook mapping from v1 to v2
 
 Use this table to find the v2 replacement for each v1 hook:
 
@@ -63,7 +63,7 @@ v1 component-override props.
 
 </Step>
 <Step>
-### Replace `@copilotkit/react-ui` imports
+### Replace React UI imports
 
 UI components like `CopilotChat`, `CopilotSidebar`, and `CopilotPopup` are now exported from `@copilotkit/react-core/v2`.
 
@@ -101,7 +101,7 @@ import "@copilotkit/react-core/v2/styles.css";
 
 </Step>
 <Step>
-### Upgrade `@ag-ui/client` (if using directly)
+### Upgrade AG-UI client if using it directly
 
 If you import from `@ag-ui/client` directly, upgrade to the latest version:
 

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -149,9 +149,6 @@ describe("migration docs", () => {
     );
 
     expect(snippet).toContain(
-      "The `<CopilotKit>` provider name — keep using it, but import it from `@copilotkit/react-core/v2`",
-    );
-    expect(snippet).toContain(
       "Keep the `<CopilotKit>` provider name, but import it from `@copilotkit/react-core/v2`.",
     );
     expect(snippet).toContain(


### PR DESCRIPTION
## Summary
- polish the Showcase shell docs merged in #5306 so headings, related links, and prose match the rest of the site
- clarify AgentRunner telemetry wording for the v2 runtime architecture
- fix the shell-docs sidebar banner key warning and update stale shell-docs test expectations

## Verification
- `git diff --name-only | xargs pnpm exec oxfmt --check`
- `npm run lint` in `showcase/shell-docs`
- `npm run typecheck` in `showcase/shell-docs`
- `npm run test` in `showcase/shell-docs`
- `npm run build` in `showcase/shell-docs`
- pre-commit hook passed `check-binaries`, `lint-fix`, `test-and-check-packages`, and `commitlint`

## Notes
- Root `pnpm run check-format` still reports unrelated formatting issues on fresh `main`; the changed-file formatter check passes.
- `npm run build` still emits the existing Turbopack NFT warning from `next.config.ts` / `llms-mdx`, but completes successfully.