### PR TITLE
fix(shell-docs): keep docs headings block-level

### DIFF
--- a/showcase/shell-docs/src/app/__tests__/globals-css.test.ts
+++ b/showcase/shell-docs/src/app/__tests__/globals-css.test.ts
@@ -13,3 +13,14 @@ describe("globals.css mobile docs layout", () => {
     );
   });
 });
+
+describe("globals.css docs headings", () => {
+  it("keeps heading anchors in block-level heading rows", () => {
+    expect(globalsCss).toContain(
+      ".reference-content .docs-heading {\n  display: flex;",
+    );
+    expect(globalsCss).not.toContain(
+      ".reference-content .docs-heading {\n  display: inline-flex;",
+    );
+  });
+});

--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -1146,11 +1146,12 @@ samp {
 }
 
 /* Heading anchors — H2/H3 surface a hover-only `#` link aligned to the
- * right of the heading text, matching canonical fumadocs prose. The
- * anchor is part of the heading's normal flow (not absolute) so it
- * never collides with the right-rail TOC at narrow widths. */
+ * right of the heading text, matching canonical fumadocs prose. Keep the
+ * heading itself block-level so adjacent headings never share a line; the
+ * anchor is part of the heading's normal flow (not absolute) so it never
+ * collides with the right-rail TOC at narrow widths. */
 .reference-content .docs-heading {
-  display: inline-flex;
+  display: flex;
   align-items: baseline;
   gap: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- fix shell-docs heading anchors so docs headings remain block-level rows
- prevent adjacent headings, like `## What the runtime provides` followed by `### Authentication & security`, from rendering on the same line
- add a `globals.css` regression guard against bringing back `inline-flex` on `.docs-heading`

## Verification
- `npm run test -- src/app/__tests__/globals-css.test.ts` in `showcase/shell-docs`
- `npm run lint` in `showcase/shell-docs`
- `npm run test` in `showcase/shell-docs`
- `npm run typecheck` in `showcase/shell-docs`
- `npm run build` in `showcase/shell-docs`
- local visual check at `http://localhost:3003/backend/copilot-runtime` with Playwright: the H2 and H3 render as separate full-width rows
- lefthook pre-commit passed `check-binaries`, `lint-fix`, `test-and-check-packages`, and commitlint

## Notes
- `npm run lint` still reports existing warnings unrelated to this change.
- `npm run build` still emits the existing Turbopack/NFT warning from `next.config.ts` / `llms-mdx`, but completes successfully.
