### PR TITLE
fix(shared): keep telemetry lambdaClient.send intact through bundling

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/telemetry.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/telemetry.test.ts
@@ -310,4 +310,24 @@ describe("TelemetryClient", () => {
 
     expect(lambdaSpy).toHaveBeenCalledTimes(2);
   });
+
+  it("never rejects when the telemetry sink throws", async () => {
+    // Telemetry must never break the application. Callers fire capture()
+    // without awaiting/catching (e.g. the intelligence run handler), so a
+    // rejection here becomes an unhandled rejection that crashes the run.
+    lambdaSpy.mockRejectedValue(new Error("sink unavailable"));
+    const client = new TelemetryClient({
+      telemetryDisabled: false,
+      sampleRate: 1,
+    });
+
+    await expect(
+      client.capture("oss.runtime.instance_created", {
+        actionsAmount: 0,
+        endpointTypes: [],
+        endpointsAmount: 0,
+        "cloud.api_key_provided": false,
+      }),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/packages/runtime/src/v2/runtime/telemetry/telemetry-client.ts
+++ b/packages/runtime/src/v2/runtime/telemetry/telemetry-client.ts
@@ -57,18 +57,25 @@ export class TelemetryClient {
     event: K,
     properties: AnalyticsEvents[K],
   ) {
-    if (this.telemetryDisabled) return;
-    // Anonymous callers are gated by sampleRate; identified callers
-    // (telemetry_id present) bypass the gate and always send.
-    if (!this.telemetryId && !this.shouldSendEvent()) return;
+    // Telemetry must never break the application. Callers fire capture()
+    // without awaiting/catching it, so any throw here surfaces as an
+    // unhandled rejection that crashes the process. Swallow everything.
+    try {
+      if (this.telemetryDisabled) return;
+      // Anonymous callers are gated by sampleRate; identified callers
+      // (telemetry_id present) bypass the gate and always send.
+      if (!this.telemetryId && !this.shouldSendEvent()) return;
 
-    await lambdaClient.send({
-      event,
-      properties: properties as Record<string, unknown>,
-      packageName: packageJson.name,
-      packageVersion: packageJson.version,
-      licenseToken: this.licenseToken ?? undefined,
-    });
+      await lambdaClient.send({
+        event,
+        properties: properties as Record<string, unknown>,
+        packageName: packageJson.name,
+        packageVersion: packageJson.version,
+        licenseToken: this.licenseToken ?? undefined,
+      });
+    } catch {
+      // Silent failure — telemetry must not break the application.
+    }
   }
 
   private setSampleRate(sampleRate: number | undefined) {

--- a/packages/shared/src/telemetry/index.ts
+++ b/packages/shared/src/telemetry/index.ts
@@ -1,5 +1,14 @@
+// Bind `lambdaClient` as a local const in this entry module rather than
+// re-exporting it across the module boundary. `tsdown` mis-compiles a
+// cross-module `export { ... } from "./lambda-client"` of the client into
+// an assignment of the whole module namespace (so `lambdaClient.send` is
+// undefined and the real client ends up under `.default`), which crashes
+// every caller. Importing the default here and re-exporting a fresh local
+// binding compiles to a plain property reference that survives bundling.
+import lambdaClientDefault from "./lambda-client";
+
 export * from "./telemetry-client";
-export { default as lambdaClient } from "./lambda-client";
+export const lambdaClient = lambdaClientDefault;
 export {
   parseTelemetryIdFromLicense,
   parseAndWarnTelemetryId,

--- a/packages/shared/src/telemetry/lambda-client.ts
+++ b/packages/shared/src/telemetry/lambda-client.ts
@@ -150,4 +150,11 @@ export async function send(opts: LambdaSendOptions): Promise<void> {
   }
 }
 
-export default { send };
+/**
+ * The telemetry lambda client. Exposed as the module default and
+ * re-bound to a named `lambdaClient` in `./index.ts` (see the note there
+ * on why it is re-bound locally rather than re-exported directly).
+ */
+const lambdaClient = { send };
+
+export default lambdaClient;


### PR DESCRIPTION
## Problem

`@copilotkit/runtime`'s `TelemetryClient.capture()` calls `lambdaClient.send(...)`, but in the **published** `@copilotkit/shared` package `lambdaClient.send` is `undefined` — the real client ends up under `lambdaClient.default`. So `capture()` throws `TypeError: ...send is not a function`. Because `capture()` is fire-and-forget (e.g. the intelligence run handler), that throw becomes an **unhandled rejection that crashes the process** / surfaces as an HTTP 500 and aborts the agent run.

### Root cause: a bundling mis-compile, not a logic bug

`packages/shared/src/telemetry/index.ts` re-exported the client with `export { default as lambdaClient } from "./lambda-client"`. `tsdown` compiles that cross-module *re-export of a default* into an assignment of the **whole module namespace** (`exports.lambdaClient = require_lambda_client`) rather than the module's default export. The published artifact therefore exposes `lambdaClient` with **no top-level `.send`**. (Verified against a fresh `npm install @copilotkit/shared@1.59.5`.)

## Fix

1. **Bind `lambdaClient` as a local const in the telemetry entry module** (from the default import) instead of re-exporting it across the module boundary — compiles to a plain property reference that survives bundling (verified in the rebuilt `dist`).
2. **Harden `TelemetryClient.capture()`** to swallow all errors. Telemetry must never break the application.

## Tests

New regression test: `capture()` never rejects when the sink throws (written test-first). `nx test runtime`/`shared` telemetry suites green; `publint`/`attw` pass for all packages.

---

## Part of a two-PR combination (branch `lukasmoschitz/fix-recall-pill-ci`)

This fixes one of **two independent causes** of a red recall e2e in the CopilotKit Intelligence repo:

1. **This PR (`@copilotkit`)** — the `lambdaClient.send` telemetry crash (an *intermittent* ~25% failure that crashes the consuming BFF and cascades HTTP 500s).
2. **Intelligence test-selector fix** (same branch name `lukasmoschitz/fix-recall-pill-ci`) — fixes a *deterministic* stale e2e selector (`cpk-intelligence-pill-` → `cpk-intelligence-indicator-`).

Verified in Intelligence CI: with **both** applied, the recall e2e is green across all 3 browsers; either alone still fails on the other cause. This telemetry fix reaches Intelligence via a `@copilotkit` release bump.

_(Supersedes #5320, which auto-closed during a branch rename.)_