### PR TITLE
fix(react-core): key chat rows by stable renderId to prevent remount flash

### DIFF
--- a/.changeset/stable-message-render-id.md
+++ b/.changeset/stable-message-render-id.md
@@ -1,0 +1,7 @@
+---
+"@copilotkit/react-core": patch
+---
+
+fix: key chat message rows by stable renderId to prevent remount flash
+
+When a message's canonical id changes mid-stream (a transient streaming/run id replaced by a provider's final response id), `CopilotChatMessageView` remounted the row — causing a visible flash, most noticeably the human-in-the-loop tool card flickering / the chat appearing to reset during a tool's `executing → complete` transition. Rows are now keyed by `renderId ?? id` so React reconciles the row in place instead of remounting it. Requires `@ag-ui/client` with the `renderId` field.

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -33,6 +33,19 @@ import type { IntelligenceIndicatorView } from "../intelligence-indicator";
 import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
 
 /**
+ * Stable per-row React key. The AG-UI client sets `renderId` when a message's
+ * canonical `id` changes mid-stream (a transient streaming/run id replaced by a
+ * provider's final id); keying by `renderId ?? id` lets React reconcile the
+ * same row in place instead of remounting it — the remount being what caused
+ * the HITL chat flash. `renderId` is read defensively: it only exists on
+ * `@ag-ui/core` versions that ship the field, and absent it we fall back to
+ * `id` (the keying is then identical to the previous behavior).
+ */
+function getRowRenderKey(message: Message): string {
+  return (message as { renderId?: string }).renderId ?? message.id;
+}
+
+/**
  * Resolves a slot value into a { Component, slotProps } pair, handling the three
  * slot forms: a component type, a className string, or a partial-props object.
  */
@@ -557,11 +570,7 @@ export function CopilotChatMessageView({
   const renderMessageBlock = (message: Message): React.ReactElement[] => {
     const elements: (React.ReactElement | null | undefined)[] = [];
     const stateSnapshot = getStateSnapshotForMessage(message.id);
-    // Key rows by the stable render identity (set by the AG-UI client when a
-    // message's canonical `id` changes mid-stream), falling back to `id`.
-    // Keeps React reconciling the same row instead of remounting it — which is
-    // what caused the HITL chat flash. `id` is still used everywhere else.
-    const rowKey = message.renderId ?? message.id;
+    const rowKey = getRowRenderKey(message);
 
     if (renderCustomMessage) {
       elements.push(
@@ -690,7 +699,7 @@ export function CopilotChatMessageView({
             const message = deduplicatedMessages[virtualItem.index]!;
             return (
               <div
-                key={message.renderId ?? message.id}
+                key={getRowRenderKey(message)}
                 data-index={virtualItem.index}
                 ref={virtualizer.measureElement}
                 style={{

--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -557,11 +557,16 @@ export function CopilotChatMessageView({
   const renderMessageBlock = (message: Message): React.ReactElement[] => {
     const elements: (React.ReactElement | null | undefined)[] = [];
     const stateSnapshot = getStateSnapshotForMessage(message.id);
+    // Key rows by the stable render identity (set by the AG-UI client when a
+    // message's canonical `id` changes mid-stream), falling back to `id`.
+    // Keeps React reconciling the same row instead of remounting it — which is
+    // what caused the HITL chat flash. `id` is still used everywhere else.
+    const rowKey = message.renderId ?? message.id;
 
     if (renderCustomMessage) {
       elements.push(
         <MemoizedCustomMessage
-          key={`${message.id}-custom-before`}
+          key={`${rowKey}-custom-before`}
           message={message}
           position="before"
           renderCustomMessage={renderCustomMessage}
@@ -573,7 +578,7 @@ export function CopilotChatMessageView({
     if (message.role === "assistant") {
       elements.push(
         <MemoizedAssistantMessage
-          key={message.id}
+          key={rowKey}
           message={message as AssistantMessage}
           messages={messages}
           isRunning={isRunning}
@@ -584,7 +589,7 @@ export function CopilotChatMessageView({
     } else if (message.role === "user") {
       elements.push(
         <MemoizedUserMessage
-          key={message.id}
+          key={rowKey}
           message={message as UserMessage}
           UserMessageComponent={UserComponent}
           slotProps={userSlotProps}
@@ -593,7 +598,7 @@ export function CopilotChatMessageView({
     } else if (message.role === "activity") {
       elements.push(
         <MemoizedActivityMessage
-          key={message.id}
+          key={rowKey}
           message={message as ActivityMessage}
           renderActivityMessage={renderActivityMessage}
         />,
@@ -601,7 +606,7 @@ export function CopilotChatMessageView({
     } else if (message.role === "reasoning") {
       elements.push(
         <MemoizedReasoningMessage
-          key={message.id}
+          key={rowKey}
           message={message as ReasoningMessage}
           messages={messages}
           isRunning={isRunning}
@@ -614,7 +619,7 @@ export function CopilotChatMessageView({
     if (renderCustomMessage) {
       elements.push(
         <MemoizedCustomMessage
-          key={`${message.id}-custom-after`}
+          key={`${rowKey}-custom-after`}
           message={message}
           position="after"
           renderCustomMessage={renderCustomMessage}
@@ -685,7 +690,7 @@ export function CopilotChatMessageView({
             const message = deduplicatedMessages[virtualItem.index]!;
             return (
               <div
-                key={message.id}
+                key={message.renderId ?? message.id}
                 data-index={virtualItem.index}
                 ref={virtualizer.measureElement}
                 style={{

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatMessageView.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatMessageView.test.tsx
@@ -52,6 +52,16 @@ function toolCall(id: string, name: string, args = "{}") {
 }
 
 /**
+ * Attaches a `renderId` to a message. `renderId` is emitted by newer
+ * `@ag-ui/core` versions; the cast keeps this test compiling against versions
+ * whose `Message` type does not yet declare the field (the value is still read
+ * at runtime, which is what the keying logic relies on).
+ */
+function withRenderId<T extends Message>(message: T, renderId: string): T {
+  return { ...message, renderId } as T;
+}
+
+/**
  * Renders CopilotChatMessageView wrapped in the required providers.
  * Unified helper used by all describe blocks in this file.
  */
@@ -183,6 +193,50 @@ describe("CopilotChatMessageView duplicate message deduplication", () => {
     );
     expect(userMessages).toHaveLength(2);
     expect(assistantMessages).toHaveLength(2);
+  });
+});
+
+describe("CopilotChatMessageView stable renderId keying", () => {
+  function tree(messages: Message[]) {
+    return (
+      <CopilotKitProvider>
+        <CopilotChatConfigurationProvider
+          agentId={AGENT_ID}
+          threadId={THREAD_ID}
+        >
+          <CopilotChatMessageView messages={messages} />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>
+    );
+  }
+
+  it("reconciles the row in place when id changes but renderId is stable", () => {
+    const { rerender } = render(
+      tree([withRenderId(assistantMsg("stream-1", "Thinking..."), "render-1")]),
+    );
+    const before = screen.getByTestId("copilot-assistant-message");
+
+    // Canonical id flips mid-stream; renderId stays stable.
+    rerender(
+      tree([withRenderId(assistantMsg("final-1", "Thinking..."), "render-1")]),
+    );
+    const after = screen.getByTestId("copilot-assistant-message");
+
+    // Same DOM node => React reconciled in place instead of remounting.
+    expect(after).toBe(before);
+  });
+
+  it("remounts the row when id changes and no renderId is present (fallback to id)", () => {
+    const { rerender } = render(
+      tree([assistantMsg("stream-1", "Thinking...")]),
+    );
+    const before = screen.getByTestId("copilot-assistant-message");
+
+    rerender(tree([assistantMsg("final-1", "Thinking...")]));
+    const after = screen.getByTestId("copilot-assistant-message");
+
+    // Different DOM node => the row remounted (the pre-fix behavior).
+    expect(after).not.toBe(before);
   });
 });
 


### PR DESCRIPTION
## Summary

`CopilotChatMessageView` keyed each message row by `message.id`. When a message's canonical id legitimately changes mid-stream — a transient streaming/run id (`lc_run--…`) replaced by a provider's final response id (`resp_…`) — keying by `id` made React **unmount and remount the row**, causing a visible flash. The most visible symptom: the **human-in-the-loop tool card flickering / the chat appearing to reset** during a tool's `executing → complete` transition.

Root cause is the message **re-key**, not provider re-render churn. A single `getRowRenderKey(message)` helper now derives the row key as `renderId ?? id` and is used at both the flat and virtualized paths (plus custom-before/after), so React reconciles the row in place. All other `id` usages are unchanged. `renderId` is read defensively, so the change compiles and is a safe no-op against `@ag-ui` versions that don't yet ship the field. Adds covering tests (reconciles in place on an id-swap when `renderId` is stable; remounts via the `id` fallback when `renderId` is absent).

## Depends on (to activate, not to merge)

- ag-ui-protocol/ag-ui#1908 — adds the `renderId` field and preserves it across the snapshot re-key.
- This PR merges independently: with the currently-pinned `@ag-ui` (no `renderId`), the helper falls back to `id` and behavior is identical to before (the flash fix is simply inert). The fix **activates** once `@ag-ui` ships `renderId` (#1908) and `@copilotkit/react-core` bumps its `@ag-ui/*` pin to that release. Until then there is no regression and no hard build dependency.

## How it was validated

Reproduced in a HITL sandbox with mount-sentinel instrumentation: before, the tool-call row logged a remount on every `executing → complete`; with `renderId` keying (+ the ag-ui change) the row no longer remounts despite the canonical id changing. Also confirmed the customer's originally-proposed `executingToolCallIds` provider-store patch did **not** fix it (the flash is a remount from re-keying, not a re-render).

## Notes / follow-up

- A plain assistant **text** message (no tool-call anchor) can still re-key on the snapshot — a sub-frame blip. Cleaner long-term fix is stable ids upstream; tracked separately.
- **Coordination:** bump the `@ag-ui/*` pin in `@copilotkit/react-core` once #1908 publishes (this is what activates the fix).
- **Out-of-scope follow-ups surfaced during review (separate PRs — pre-existing, not this subject):**
  - `CopilotChatMessageView` internals debt: `MemoizedAssistantMessage` `isLatest` asymmetry vs the reasoning memo; `JSON.stringify` deep-equality in memo comparators (throws on circular/BigInt agent state); `MemoizedCustomMessage` declares `stateSnapshot` but never forwards it to the renderer; `deduplicateMessages` content uses `||` not `??` and silently overwrites mismatched-role id collisions; dev duplicate-merge `console.warn` fires every render; `lastMessage`/isLatest read the raw (non-deduped) `messages`; `measureElement` returns `0` for a null element; `firstMessageId`-driven scroll-to-bottom can fire on an id-swap; `getStateSnapshotForMessage` looks up by `id`.
  - Test hardening for `CopilotChatMessageView.slots.e2e.test.tsx`: no-op `expect(querySelector(...)).toBeDefined()`, `expect(x || true).toBeTruthy()` tautologies, and `vi.fn()` spies that are never asserted.

## Test plan

- [ ] HITL flow: approval card no longer flashes on `executing → complete` (with an `@ag-ui` build containing `renderId`)
- [ ] Long/virtualized thread: no row remount on tool-state transitions
- [ ] Regression check on current `@ag-ui` pin: behavior unchanged (helper falls back to `id`)
- [ ] After ag-ui#1908 publishes: bump `@ag-ui/*` pin and re-verify the fix is active