### PR TITLE
fix(angular): support Angular 19–21 install and fix README package name

### DIFF
--- a/.changeset/angular-21-install-and-types.md
+++ b/.changeset/angular-21-install-and-types.md
@@ -1,0 +1,15 @@
+---
+"@copilotkitnext/angular": patch
+---
+
+fix(angular): support Angular 19–21 install and fix README package name
+
+Two fixes hit on a fresh Angular 21 setup:
+
+- Widen the `@angular/*` peer dependency range from `^19.0.0` to
+  `^19.0.0 || ^20.0.0 || ^21.0.0` so a clean install on Angular 20/21 no longer
+  throws `ERESOLVE` (previously required `--legacy-peer-deps`).
+- Correct the README: the package name is `@copilotkitnext/angular` (the old
+  `@copilotkit/angular` import path does not exist on npm), the install command
+  is `npm install @copilotkitnext/angular`, and document the current `TS7016`
+  TypeScript workaround until the `exports` map ships a `types` condition.

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -6,12 +6,23 @@ Angular bindings for CopilotKit core and AG-UI agents. This package provides ser
 
 ```bash
 # npm
-npm install @copilotkit/{core,angular}
+npm install @copilotkitnext/angular
 ```
 
-- `@angular/core` and `@angular/common` (19+)
+Peer dependencies you provide in your app:
+
+- `@angular/core` and `@angular/common` (19, 20, or 21)
 - `@angular/cdk` (match your Angular major)
 - `rxjs`
+
+> **TypeScript note:** if your build reports `TS7016: Could not find a declaration file for module '@copilotkitnext/angular'`, add a `paths` entry pointing at the bundled types until the package's `exports` map ships a `types` condition:
+>
+> ```jsonc
+> // tsconfig.json → compilerOptions
+> "paths": {
+>   "@copilotkitnext/angular": ["./node_modules/@copilotkitnext/angular/dist/index.d.ts"]
+> }
+> ```
 
 ## Quick start
 
@@ -21,7 +32,7 @@ Configure runtime and tools in your app config:
 
 ```ts
 import { ApplicationConfig } from "@angular/core";
-import { provideCopilotKit } from "@copilotkit/angular";
+import { provideCopilotKit } from "@copilotkitnext/angular";
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -40,7 +51,7 @@ export const appConfig: ApplicationConfig = {
 ```ts
 import { Component, inject, signal } from "@angular/core";
 import { Message } from "@ag-ui/client";
-import { CopilotKit, injectAgentStore } from "@copilotkit/angular";
+import { CopilotKit, injectAgentStore } from "@copilotkitnext/angular";
 import { randomUUID } from "@copilotkit/shared";
 
 @Component({
@@ -178,7 +189,7 @@ Advanced factory for creating `AgentStore` signals. Most apps should use `inject
 Connect AG-UI context to the runtime (auto-cleanup when the effect is destroyed):
 
 ```ts
-import { connectAgentContext } from "@copilotkit/angular";
+import { connectAgentContext } from "@copilotkitnext/angular";
 
 connectAgentContext({
   description: "User preferences",
@@ -250,7 +261,7 @@ import {
   registerFrontendTool,
   registerRenderToolCall,
   registerHumanInTheLoop,
-} from "@copilotkit/angular";
+} from "@copilotkitnext/angular";
 import { z } from "zod";
 
 registerFrontendTool({

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -82,9 +82,9 @@
     "zone.js": "^0.14.0"
   },
   "peerDependencies": {
-    "@angular/cdk": "^19.0.0",
-    "@angular/common": "^19.0.0",
-    "@angular/core": "^19.0.0",
+    "@angular/cdk": "^19.0.0 || ^20.0.0 || ^21.0.0",
+    "@angular/common": "^19.0.0 || ^20.0.0 || ^21.0.0",
+    "@angular/core": "^19.0.0 || ^20.0.0 || ^21.0.0",
     "rxjs": "^7.8.0"
   }
 }


### PR DESCRIPTION
## What & why

A fresh **Angular 21** + CopilotKit setup (validated this week against an enterprise eval that was blocked on it) hits avoidable friction. This PR fixes the two issues that are unambiguously correct, and documents a third for follow-up.

### Fixed here
- **Peer-dep `ERESOLVE`** — `@angular/*` peer range was `^19.0.0`, so a clean install on Angular 20/21 failed and required `--legacy-peer-deps`. Widened to `^19.0.0 || ^20.0.0 || ^21.0.0`. (The library is built with ng-packagr 19 but runs fine on 20/21.)
- **README points at a package that 404s** — install/import examples referenced `@copilotkit/angular`, which does not exist on npm. The package is `@copilotkitnext/angular`. Corrected the install command and all import examples.

### Documented, not fixed (needs a maintainer call)
- **`TS7016` missing types** — the published `exports` map has no `types` condition, so TS (`moduleResolution: bundler`/`node16`) can't find declarations. Adding `"types": "./dist/index.d.ts"` to `exports` makes **bundler** resolution green (what Angular apps use), but trips the `attw` **node16** gate by exposing a pre-existing internal-resolution issue in the generated `.d.ts` files (on `main`, attw passes only because `untyped-resolution` is in its ignore list). Properly fixing this means addressing the ng-packagr exports/`.d.ts` output, so it's left out of this PR. The README now documents the `tsconfig paths` workaround so users aren't blocked in the meantime.

## Testing
- Lefthook green (format, `check:packages` incl. `publint`/`attw`, commitlint).
- Empirically verified: bare-minimum app on Angular 21.2.16 builds, dev server boots, and `<copilot-chat>` renders.

Originating real-world report: https://copilotkit.slack.com/archives/C08LNPSE5CM/p1781015696972179

🤖 Generated with [Claude Code](https://claude.com/claude-code)