### PR TITLE
fix(core): bump @ag-ui core packages to 0.0.56 and adapt runHttpRequest

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,8 @@
 minimum-release-age=1440
+minimum-release-age-exclude[]=@ag-ui/core
+minimum-release-age-exclude[]=@ag-ui/client
+minimum-release-age-exclude[]=@ag-ui/encoder
+minimum-release-age-exclude[]=@ag-ui/proto
 minimum-release-age-exclude[]=@ag-ui/langgraph
 minimum-release-age-exclude[]=@ag-ui/a2ui-middleware
 minimum-release-age-exclude[]=@ag-ui/a2ui-toolkit

--- a/packages/agentcore-runner/package.json
+++ b/packages/agentcore-runner/package.json
@@ -31,7 +31,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.53",
+    "@ag-ui/client": "0.0.56",
     "@copilotkit/runtime": "workspace:*",
     "rxjs": "7.8.1"
   },

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -33,8 +33,8 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.53",
-    "@ag-ui/core": "0.0.53",
+    "@ag-ui/client": "0.0.56",
+    "@ag-ui/core": "0.0.56",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/shared": "workspace:*",
     "clsx": "^2.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.53",
+    "@ag-ui/client": "0.0.56",
     "@copilotkit/shared": "workspace:*",
     "@tanstack/pacer": "^0.20.1",
     "phoenix": "^1.8.4",

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -370,13 +370,16 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
           agentId: routedId,
         },
       );
-      const httpEvents = runHttpRequest(this.singleEndpointUrl, requestInit);
+      const httpEvents = runHttpRequest(() =>
+        this.fetch(this.singleEndpointUrl!, requestInit),
+      );
       return withAbortErrorHandling(transformHttpEventStream(httpEvents));
     }
 
-    const httpEvents = runHttpRequest(
-      `${this.runtimeUrl}/agent/${routedId}/connect`,
-      this.requestInit(input),
+    const connectUrl = `${this.runtimeUrl}/agent/${routedId}/connect`;
+    const connectRequestInit = this.requestInit(input);
+    const httpEvents = runHttpRequest(() =>
+      this.fetch(connectUrl, connectRequestInit),
     );
     return withAbortErrorHandling(transformHttpEventStream(httpEvents));
   }
@@ -400,7 +403,9 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
           agentId: this.routedAgentId(),
         },
       );
-      const httpEvents = runHttpRequest(this.singleEndpointUrl, requestInit);
+      const httpEvents = runHttpRequest(() =>
+        this.fetch(this.singleEndpointUrl!, requestInit),
+      );
       return withAbortErrorHandling(transformHttpEventStream(httpEvents));
     }
 

--- a/packages/demo-agents/package.json
+++ b/packages/demo-agents/package.json
@@ -24,7 +24,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.53",
+    "@ag-ui/client": "0.0.56",
     "openai": "^4.85.1",
     "rxjs": "^7.8.1"
   },

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -74,8 +74,8 @@
     "attw": "attw --pack . --profile node16 --ignore-rules internal-resolution-error"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.53",
-    "@ag-ui/core": "0.0.53",
+    "@ag-ui/client": "0.0.56",
+    "@ag-ui/core": "0.0.56",
     "@copilotkit/a2ui-renderer": "workspace:*",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/runtime-client-gql": "workspace:*",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -74,7 +74,7 @@
     "unlink:global": "pnpm unlink --global"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.53",
+    "@ag-ui/client": "0.0.56",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/react-core": "workspace:*",
     "@copilotkit/shared": "workspace:*",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -78,9 +78,9 @@
   },
   "dependencies": {
     "@ag-ui/a2ui-middleware": "0.0.8",
-    "@ag-ui/client": "0.0.53",
-    "@ag-ui/core": "0.0.53",
-    "@ag-ui/encoder": "0.0.53",
+    "@ag-ui/client": "0.0.56",
+    "@ag-ui/core": "0.0.56",
+    "@ag-ui/encoder": "0.0.56",
     "@ag-ui/langgraph": "0.0.39",
     "@ag-ui/mcp-apps-middleware": "0.0.3",
     "@ag-ui/mcp-middleware": "0.0.1",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -50,7 +50,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.53",
+    "@ag-ui/client": "0.0.56",
     "@copilotkit/license-verifier": "~0.4.2",
     "@segment/analytics-node": "^2.1.2",
     "@standard-schema/spec": "^1.0.0",

--- a/packages/sqlite-runner/package.json
+++ b/packages/sqlite-runner/package.json
@@ -31,7 +31,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.53",
+    "@ag-ui/client": "0.0.56",
     "@copilotkit/runtime": "workspace:*",
     "rxjs": "7.8.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -78,8 +78,8 @@
   },
   "dependencies": {
     "@a2ui/web_core": "0.9.0",
-    "@ag-ui/client": "0.0.53",
-    "@ag-ui/core": "0.0.53",
+    "@ag-ui/client": "0.0.56",
+    "@ag-ui/core": "0.0.56",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/shared": "workspace:*",
     "@copilotkit/web-inspector": "workspace:*",

--- a/packages/web-inspector/package.json
+++ b/packages/web-inspector/package.json
@@ -34,7 +34,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.53",
+    "@ag-ui/client": "0.0.56",
     "@copilotkit/core": "workspace:*",
     "lit": "^3.2.0",
     "lucide": "^0.525.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,7 +312,7 @@ importers:
         version: 0.8.3(signal-polyfill@0.2.2)
       '@ag-ui/a2a':
         specifier: ^0.0.6
-        version: 0.0.6(@ag-ui/client@0.0.42)(@ag-ui/core@0.0.54)
+        version: 0.0.6(@ag-ui/client@0.0.42)(@ag-ui/core@0.0.56)
       '@ag-ui/a2a-middleware':
         specifier: ^0.0.2
         version: 0.0.2(rxjs@7.8.1)
@@ -1874,7 +1874,7 @@ importers:
         version: 0.0.52
       '@ag-ui/mcp-apps-middleware':
         specifier: 0.0.2
-        version: 0.0.2(@ag-ui/client@0.0.53)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
+        version: 0.0.2(@ag-ui/client@0.0.56)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../../../../packages/core
@@ -2032,8 +2032,8 @@ importers:
   packages/agentcore-runner:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.56
+        version: 0.0.56
       '@copilotkit/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -2060,11 +2060,11 @@ importers:
   packages/angular:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.56
+        version: 0.0.56
       '@ag-ui/core':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.56
+        version: 0.0.56
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -2193,8 +2193,8 @@ importers:
   packages/core:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.56
+        version: 0.0.56
       '@copilotkit/shared':
         specifier: workspace:*
         version: link:../shared
@@ -2245,8 +2245,8 @@ importers:
   packages/demo-agents:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.56
+        version: 0.0.56
       openai:
         specifier: ^4.85.1
         version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
@@ -2273,11 +2273,11 @@ importers:
   packages/react-core:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.56
+        version: 0.0.56
       '@ag-ui/core':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.56
+        version: 0.0.56
       '@copilotkit/a2ui-renderer':
         specifier: workspace:*
         version: link:../a2ui-renderer
@@ -2439,8 +2439,8 @@ importers:
   packages/react-native:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.56
+        version: 0.0.56
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -2689,22 +2689,22 @@ importers:
     dependencies:
       '@ag-ui/a2ui-middleware':
         specifier: 0.0.8
-        version: 0.0.8(@ag-ui/client@0.0.53)(rxjs@7.8.1)
+        version: 0.0.8(@ag-ui/client@0.0.56)(rxjs@7.8.1)
       '@ag-ui/client':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.56
+        version: 0.0.56
       '@ag-ui/core':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.56
+        version: 0.0.56
       '@ag-ui/encoder':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.56
+        version: 0.0.56
       '@ag-ui/langgraph':
         specifier: 0.0.39
-        version: 0.0.39(@ag-ui/client@0.0.53)(@ag-ui/core@0.0.53)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+        version: 0.0.39(@ag-ui/client@0.0.56)(@ag-ui/core@0.0.56)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@ag-ui/mcp-apps-middleware':
         specifier: 0.0.3
-        version: 0.0.3(@ag-ui/client@0.0.53)(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+        version: 0.0.3(@ag-ui/client@0.0.56)(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@ag-ui/mcp-middleware':
         specifier: 0.0.1
         version: 0.0.1(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
@@ -2976,7 +2976,7 @@ importers:
     dependencies:
       '@ag-ui/langgraph':
         specifier: 0.0.39
-        version: 0.0.39(@ag-ui/client@0.0.53)(@ag-ui/core@0.0.54)(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+        version: 0.0.39(@ag-ui/client@0.0.56)(@ag-ui/core@0.0.56)(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@copilotkit/shared':
         specifier: workspace:*
         version: link:../shared
@@ -3030,8 +3030,8 @@ importers:
   packages/shared:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.56
+        version: 0.0.56
       '@ag-ui/core':
         specifier: '>=0.0.48'
         version: 0.0.51
@@ -3094,8 +3094,8 @@ importers:
   packages/sqlite-runner:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.56
+        version: 0.0.56
       '@copilotkit/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -3166,11 +3166,11 @@ importers:
         specifier: 0.9.0
         version: 0.9.0
       '@ag-ui/client':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.56
+        version: 0.0.56
       '@ag-ui/core':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.56
+        version: 0.0.56
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -3290,8 +3290,8 @@ importers:
   packages/web-inspector:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.56
+        version: 0.0.56
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -3517,6 +3517,9 @@ packages:
   '@ag-ui/client@0.0.53':
     resolution: {integrity: sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==}
 
+  '@ag-ui/client@0.0.56':
+    resolution: {integrity: sha512-dxen4qVnDQB1xC9x1nND9W/plidoy0qwDarUPuasHCrtlkMl1EUlc+rNJM7Lr1NtnRmGHHX8gHrSeUXP3vPVHA==}
+
   '@ag-ui/core@0.0.36':
     resolution: {integrity: sha512-uYUrzw6uxuw4qVQ61mdSeiG0mFh2n/VAWmWsWzwETDuhqJZT7rFmd07IajcFWcyItMr1wjqxFDdlklucAyEYNA==}
 
@@ -3535,8 +3538,8 @@ packages:
   '@ag-ui/core@0.0.53':
     resolution: {integrity: sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ==}
 
-  '@ag-ui/core@0.0.54':
-    resolution: {integrity: sha512-Ilx31OvRQaZfU7jSArGqz06JZKOsAt8zWiCPJljyp9zR6Tzl18oyfx8o6FsuGfAktGRe50GI9SCCxNXXysZwtA==}
+  '@ag-ui/core@0.0.56':
+    resolution: {integrity: sha512-PD26s7qk8dG6/TOGmOv23ByTaGwJs2Wzm53OwsM40jSjio3xmswGZzDaFpjMNP6FsASNGovCPB8xICAyWhYx8A==}
 
   '@ag-ui/encoder@0.0.36':
     resolution: {integrity: sha512-p8UNh6a77G/oe/4EZmwkTeYCN/5SnqSY2Cz8f8psZpk4LKzzrPkRNykrUAIBsi1wMp50/VQiM27oTRaade/Qkw==}
@@ -3549,6 +3552,9 @@ packages:
 
   '@ag-ui/encoder@0.0.53':
     resolution: {integrity: sha512-bAOcfVdm6U4H6G6tW+DZfwPEQm1w/snVBTwaFn9nJcEMW69M7/HZuwvEc/7Zo0rK1jRL32N/j60PwTAeky19fw==}
+
+  '@ag-ui/encoder@0.0.56':
+    resolution: {integrity: sha512-JkR7OGby8hBUOOlrvli0bArM5qvfCoavj3ajUp8324n20wYMrfN+/TR3GUm7wW1japrV+2dS7JEVX5dylrPF1A==}
 
   '@ag-ui/langgraph@0.0.11':
     resolution: {integrity: sha512-3xUkaOelnpQ5tbsbuoOTin71tTgWEN0GDZBjGs/7xAwly2Dn4fahbBAoscXullO/pH9kTGGgbuJ0rWDUgo6fKQ==}
@@ -3592,6 +3598,9 @@ packages:
 
   '@ag-ui/proto@0.0.53':
     resolution: {integrity: sha512-swjz22xWT8YUZt5OhmUwkARDQdwt8XM1hmGZbQrhRnNPXKwrKJX9ELlbnQ4iFUQIKkMWpphzE3vA3yNKs2bbKw==}
+
+  '@ag-ui/proto@0.0.56':
+    resolution: {integrity: sha512-D72l/Xa3vHRBJtlxa+gG3VcycrEwDCHwCTh8BGkyrnRdraYPFl92eeWSV0tnF9+i7xLyNqCdww+NgCoPlrdhZQ==}
 
   '@ai-sdk/anthropic@2.0.71':
     resolution: {integrity: sha512-JXTtAwlyxGzzRtpiAXk/O93aOTgdfoVX28EoUuRNVqZRgtkoniLQTtqeb8uZ4oXljNJlXzaJLNasS/U90w/wjw==}
@@ -23586,8 +23595,8 @@ packages:
   vue-component-type-helpers@3.3.1:
     resolution: {integrity: sha512-pu58kqxmVyEH6VfNYW1UyEfR3XAnJ27ZXT3yzXxxpjLxVzAbyC35Zk/nm/RMs7ijWnJNSd9fWkeex2OhUsx3MA==}
 
-  vue-component-type-helpers@3.3.3:
-    resolution: {integrity: sha512-x4nsFpy5Pe8fqPzp/5vkTPeTTDBpAx4WVtV47Ejt0+2FQrq4pRRsJs7JmYRqMFzTu/LW+pCWEjQ3YVCkPV7f9g==}
+  vue-component-type-helpers@3.3.4:
+    resolution: {integrity: sha512-joip1uZTaQR0nD23N400gIdJ7xY+WiiiMA/BCKz842gvGBknqDQAzklUvDEhqFvvrhQY8S2ZANBMu4X70VMFGw==}
 
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
@@ -24223,19 +24232,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ag-ui/a2a@0.0.6(@ag-ui/client@0.0.42)(@ag-ui/core@0.0.54)':
+  '@ag-ui/a2a@0.0.6(@ag-ui/client@0.0.42)(@ag-ui/core@0.0.56)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
       '@ag-ui/client': 0.0.42
-      '@ag-ui/core': 0.0.54
+      '@ag-ui/core': 0.0.56
       rxjs: 7.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ag-ui/a2ui-middleware@0.0.8(@ag-ui/client@0.0.53)(rxjs@7.8.1)':
+  '@ag-ui/a2ui-middleware@0.0.8(@ag-ui/client@0.0.56)(rxjs@7.8.1)':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.2
-      '@ag-ui/client': 0.0.53
+      '@ag-ui/client': 0.0.56
       clarinet: 0.12.6
       rxjs: 7.8.1
 
@@ -24292,6 +24301,19 @@ snapshots:
       uuid: 11.1.0
       zod: 3.25.76
 
+  '@ag-ui/client@0.0.56':
+    dependencies:
+      '@ag-ui/core': 0.0.56
+      '@ag-ui/encoder': 0.0.56
+      '@ag-ui/proto': 0.0.56
+      '@types/uuid': 10.0.0
+      compare-versions: 6.1.1
+      fast-json-patch: 3.1.1
+      rxjs: 7.8.1
+      untruncate-json: 0.0.1
+      uuid: 11.1.0
+      zod: 3.25.76
+
   '@ag-ui/core@0.0.36':
     dependencies:
       rxjs: 7.8.1
@@ -24318,7 +24340,7 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  '@ag-ui/core@0.0.54':
+  '@ag-ui/core@0.0.56':
     dependencies:
       zod: 3.25.76
 
@@ -24342,6 +24364,11 @@ snapshots:
       '@ag-ui/core': 0.0.53
       '@ag-ui/proto': 0.0.53
 
+  '@ag-ui/encoder@0.0.56':
+    dependencies:
+      '@ag-ui/core': 0.0.56
+      '@ag-ui/proto': 0.0.56
+
   '@ag-ui/langgraph@0.0.11(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.19.0)':
     dependencies:
       '@ag-ui/client': 0.0.36
@@ -24358,11 +24385,11 @@ snapshots:
       - react-dom
       - ws
 
-  '@ag-ui/langgraph@0.0.39(@ag-ui/client@0.0.53)(@ag-ui/core@0.0.53)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@ag-ui/langgraph@0.0.39(@ag-ui/client@0.0.56)(@ag-ui/core@0.0.56)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.2
-      '@ag-ui/client': 0.0.53
-      '@ag-ui/core': 0.0.53
+      '@ag-ui/client': 0.0.56
+      '@ag-ui/core': 0.0.56
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))
       langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
@@ -24380,11 +24407,11 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  '@ag-ui/langgraph@0.0.39(@ag-ui/client@0.0.53)(@ag-ui/core@0.0.54)(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@ag-ui/langgraph@0.0.39(@ag-ui/client@0.0.56)(@ag-ui/core@0.0.56)(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.2
-      '@ag-ui/client': 0.0.53
-      '@ag-ui/core': 0.0.54
+      '@ag-ui/client': 0.0.56
+      '@ag-ui/core': 0.0.56
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))
       langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
@@ -24422,9 +24449,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@ag-ui/mcp-apps-middleware@0.0.2(@ag-ui/client@0.0.53)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
+  '@ag-ui/mcp-apps-middleware@0.0.2(@ag-ui/client@0.0.56)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
     dependencies:
-      '@ag-ui/client': 0.0.53
+      '@ag-ui/client': 0.0.56
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       rxjs: 7.8.1
     transitivePeerDependencies:
@@ -24432,9 +24459,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@ag-ui/mcp-apps-middleware@0.0.3(@ag-ui/client@0.0.53)(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+  '@ag-ui/mcp-apps-middleware@0.0.3(@ag-ui/client@0.0.56)(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@ag-ui/client': 0.0.53
+      '@ag-ui/client': 0.0.56
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       rxjs: 7.8.1
     transitivePeerDependencies:
@@ -24473,6 +24500,12 @@ snapshots:
   '@ag-ui/proto@0.0.53':
     dependencies:
       '@ag-ui/core': 0.0.53
+      '@bufbuild/protobuf': 2.11.0
+      '@protobuf-ts/protoc': 2.11.1
+
+  '@ag-ui/proto@0.0.56':
+    dependencies:
+      '@ag-ui/core': 0.0.56
       '@bufbuild/protobuf': 2.11.0
       '@protobuf-ts/protoc': 2.11.1
 
@@ -35167,7 +35200,7 @@ snapshots:
       storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.34(typescript@5.8.2)
-      vue-component-type-helpers: 3.3.3
+      vue-component-type-helpers: 3.3.4
 
   '@swc/core-darwin-arm64@1.15.8':
     optional: true
@@ -52265,7 +52298,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.1: {}
 
-  vue-component-type-helpers@3.3.3: {}
+  vue-component-type-helpers@3.3.4: {}
 
   vue-devtools-stub@0.1.0: {}
 


### PR DESCRIPTION
## What

Bump `@ag-ui/core`, `@ag-ui/client`, `@ag-ui/encoder` from `0.0.53` → `0.0.56` across all packages, and fix the breakage that bump introduces.

## Blowups fixed

1. **pnpm `minimum-release-age` gate** — `.npmrc` enforces a 1440min (24h) release-age floor. `0.0.56` was published ~9h ago, so install was rejected in CI. Added `@ag-ui/core`, `client`, `encoder`, and `proto` (transitive dep of client) to `minimum-release-age-exclude[]`, matching the existing `@ag-ui/langgraph` / a2ui pattern.

2. **`runHttpRequest` signature change** — `@ag-ui/client@0.0.56` changed `runHttpRequest` from `(url, requestInit)` to a fetch-thunk signature `(() => Promise<Response>)`. This broke the single-route and connect transport paths in `ProxiedCopilotRuntimeAgent` with `TypeError: e is not a function` (8 failing core tests). Fixed the 3 callsites in `packages/core/src/agent.ts` to wrap the request in `() => this.fetch(url, init)`, which also respects the agent's configurable `fetch`.

## Validation (CI mirror — all green)

- `pnpm install --frozen-lockfile`
- lint (oxlint) — 0 errors
- `check:packages` (publint + attw)
- build (17 projects)
- test — 17 projects, all unit tests pass
- compat-check (es-check)
- release-script tests (85)