### PR TITLE
docs(skills): fix outdated APIs in copilotkit-setup skill

### DIFF
--- a/skills/copilotkit-setup/SKILL.md
+++ b/skills/copilotkit-setup/SKILL.md
@@ -222,7 +222,9 @@ npm install hono @hono/node-server
 
 ### Step 3: Set up the frontend provider
 
-Wrap your application with `CopilotKitProvider` from `@copilotkit/react-core/v2`.
+Wrap your application with `CopilotKit` from `@copilotkit/react-core/v2`.
+
+> **Which provider component?** Always use `CopilotKit` imported from `@copilotkit/react-core/v2`. It is the compatibility bridge across v1 and v2 and a strict superset of the other provider APIs. Do **not** use `CopilotKit` from the package root (`@copilotkit/react-core`, legacy v1) or `CopilotKitProvider` from `/v2` (a subset of the functionality).
 
 **Important:** Import the stylesheet in your root layout:
 
@@ -237,15 +239,15 @@ In `src/app/page.tsx` (or a client component):
 ```tsx
 "use client";
 
-import { CopilotKitProvider, CopilotChat } from "@copilotkit/react-core/v2";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function Home() {
   return (
-    <CopilotKitProvider runtimeUrl="/api/copilotkit">
+    <CopilotKit runtimeUrl="/api/copilotkit">
       <div style={{ height: "100vh" }}>
         <CopilotChat />
       </div>
-    </CopilotKitProvider>
+    </CopilotKit>
   );
 }
 ```
@@ -255,17 +257,14 @@ export default function Home() {
 When the runtime runs on a separate server (e.g., Express on port 4000):
 
 ```tsx
-<CopilotKitProvider
-  runtimeUrl="http://localhost:4000/api/copilotkit"
-  useSingleEndpoint
->
+<CopilotKit runtimeUrl="http://localhost:4000/api/copilotkit" useSingleEndpoint>
   {children}
-</CopilotKitProvider>
+</CopilotKit>
 ```
 
 Set `useSingleEndpoint` when the backend uses single-route endpoints (`createCopilotHonoHandler` or `createCopilotExpressHandler` with `mode: "single-route"`).
 
-#### CopilotKitProvider key props
+#### CopilotKit key props
 
 | Prop                | Type                                                       | Description                                                                                                          |
 | ------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
@@ -273,7 +272,7 @@ Set `useSingleEndpoint` when the backend uses single-route endpoints (`createCop
 | `useSingleEndpoint` | `boolean`                                                  | Set to `true` when using single-route endpoints                                                                      |
 | `headers`           | `Record<string, string> \| (() => Record<string, string>)` | Custom headers sent with every request. The function form is evaluated per-request (useful for dynamic auth tokens). |
 | `credentials`       | `RequestCredentials`                                       | Fetch credentials mode (e.g., `"include"` for cookies)                                                               |
-| `publicApiKey`      | `string`                                                   | Copilot Cloud public API key (if using hosted runtime)                                                               |
+| `publicLicenseKey`  | `string`                                                   | Copilot Cloud public license key (`publicApiKey` is a deprecated alias)                                              |
 | `showDevConsole`    | `boolean \| "auto"`                                        | Show the dev inspector (`"auto"` = development only)                                                                 |
 | `renderToolCalls`   | `ReactToolCallRenderer[]`                                  | Custom renderers for tool call UI                                                                                    |
 | `frontendTools`     | `ReactFrontendTool[]`                                      | Frontend-defined tools (declarative alternative to `useFrontendTool`)                                                |
@@ -292,9 +291,9 @@ CopilotKit provides three pre-built chat layouts (all imported from `@copilotkit
 Example with sidebar:
 
 ```tsx
-import { CopilotKitProvider, CopilotSidebar } from "@copilotkit/react-core/v2";
+import { CopilotKit, CopilotSidebar } from "@copilotkit/react-core/v2";
 
-<CopilotKitProvider runtimeUrl="/api/copilotkit" showDevConsole="auto">
+<CopilotKit runtimeUrl="/api/copilotkit" showDevConsole="auto">
   <YourApp />
   <CopilotSidebar
     defaultOpen
@@ -304,7 +303,7 @@ import { CopilotKitProvider, CopilotSidebar } from "@copilotkit/react-core/v2";
       chatInputPlaceholder: "Ask me anything...",
     }}
   />
-</CopilotKitProvider>;
+</CopilotKit>;
 ```
 
 ### Step 5: Set environment variables
@@ -336,13 +335,13 @@ CopilotKit uses telemetry to understand adoption, improve the product, and provi
    ```
 3. Guide the user through the browser-based authentication that opens.
 4. Once authentication completes, the CLI outputs a license key (a public, client-side project identifier -- not a secret).
-5. Store the license key in an environment variable and reference it from the `CopilotKitProvider` -- this keeps it out of source and easy to rotate per environment:
+5. Store the license key in an environment variable and reference it from the `CopilotKit` provider -- this keeps it out of source and easy to rotate per environment:
    ```
    # .env.local (Next.js)
    NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY=<your-license-key>
    ```
    ```tsx
-   <CopilotKitProvider
+   <CopilotKit
      runtimeUrl="/api/copilotkit"
      publicLicenseKey={process.env.NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY}
    >

--- a/skills/copilotkit-setup/SKILL.md
+++ b/skills/copilotkit-setup/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use when adding CopilotKit to an existing project or bootstrapping a new CopilotKit
   project from scratch. Covers framework detection, package installation, runtime wiring,
   provider setup, and first working chat integration.
-version: 1.1.1
+version: 1.1.2
 ---
 
 # CopilotKit Setup
@@ -77,8 +77,8 @@ The runtime is the server-side component that manages agent execution. See `refe
 
 There are two endpoint styles:
 
-1. **Multi-route (Hono)** -- uses `createCopilotEndpoint`. Requires a catch-all route (`[[...slug]]` in Next.js). Each operation (run, connect, stop, info, transcribe, threads) gets its own HTTP path.
-2. **Single-route (Hono or Express)** -- uses `createCopilotEndpointSingleRoute` or `createCopilotEndpointSingleRouteExpress`. All operations go through a single POST endpoint with method multiplexing.
+1. **Multi-route (Hono)** -- uses `createCopilotHonoHandler`. Requires a catch-all route (`[[...slug]]` in Next.js). Each operation (run, connect, stop, info, transcribe, threads) gets its own HTTP path.
+2. **Single-route (Hono or Express)** -- uses `createCopilotHonoHandler({ ..., mode: "single-route" })` or `createCopilotExpressHandler({ ..., mode: "single-route" })`. All operations go through a single POST endpoint with method multiplexing.
 
 #### Next.js App Router (recommended: multi-route with Hono)
 
@@ -87,7 +87,7 @@ Create `src/app/api/copilotkit/[[...slug]]/route.ts`:
 ```typescript
 import {
   CopilotRuntime,
-  createCopilotEndpoint,
+  createCopilotHonoHandler,
   InMemoryAgentRunner,
   BuiltInAgent,
 } from "@copilotkit/runtime/v2";
@@ -105,7 +105,7 @@ const runtime = new CopilotRuntime({
   runner: new InMemoryAgentRunner(),
 });
 
-const app = createCopilotEndpoint({
+const app = createCopilotHonoHandler({
   runtime,
   basePath: "/api/copilotkit",
 });
@@ -121,7 +121,7 @@ Create `src/app/api/copilotkit/route.ts`:
 ```typescript
 import {
   CopilotRuntime,
-  createCopilotEndpointSingleRoute,
+  createCopilotHonoHandler,
   InMemoryAgentRunner,
   BuiltInAgent,
 } from "@copilotkit/runtime/v2";
@@ -139,9 +139,10 @@ const runtime = new CopilotRuntime({
   runner: new InMemoryAgentRunner(),
 });
 
-const app = createCopilotEndpointSingleRoute({
+const app = createCopilotHonoHandler({
   runtime,
   basePath: "/api/copilotkit",
+  mode: "single-route",
 });
 
 export const POST = handle(app);
@@ -156,7 +157,7 @@ Create `src/index.ts`:
 ```typescript
 import express from "express";
 import { CopilotRuntime, BuiltInAgent } from "@copilotkit/runtime/v2";
-import { createCopilotEndpointSingleRouteExpress } from "@copilotkit/runtime/v2/express";
+import { createCopilotExpressHandler } from "@copilotkit/runtime/v2/express";
 
 const agent = new BuiltInAgent({
   model: "openai/gpt-4o",
@@ -172,9 +173,10 @@ const app = express();
 
 app.use(
   "/api/copilotkit",
-  createCopilotEndpointSingleRouteExpress({
+  createCopilotExpressHandler({
     runtime,
     basePath: "/",
+    mode: "single-route",
   }),
 );
 
@@ -186,14 +188,14 @@ app.listen(port, () => {
 });
 ```
 
-For multi-route Express, use `createCopilotEndpointExpress` instead (imported from `@copilotkit/runtime/v2/express`).
+For multi-route Express, omit the `mode` option (multi-route is the default) -- `createCopilotExpressHandler` is the same factory for both styles (imported from `@copilotkit/runtime/v2/express`).
 
 #### Standalone Hono Server (non-Vercel)
 
 ```typescript
 import {
   CopilotRuntime,
-  createCopilotEndpoint,
+  createCopilotHonoHandler,
   BuiltInAgent,
 } from "@copilotkit/runtime/v2";
 import { serve } from "@hono/node-server";
@@ -204,7 +206,7 @@ const runtime = new CopilotRuntime({
   },
 });
 
-const app = createCopilotEndpoint({
+const app = createCopilotHonoHandler({
   runtime,
   basePath: "/api/copilotkit",
 });
@@ -261,21 +263,21 @@ When the runtime runs on a separate server (e.g., Express on port 4000):
 </CopilotKitProvider>
 ```
 
-Set `useSingleEndpoint` when the backend uses single-route endpoints (`createCopilotEndpointSingleRoute` or `createCopilotEndpointSingleRouteExpress`).
+Set `useSingleEndpoint` when the backend uses single-route endpoints (`createCopilotHonoHandler` or `createCopilotExpressHandler` with `mode: "single-route"`).
 
 #### CopilotKitProvider key props
 
-| Prop                | Type                      | Description                                                           |
-| ------------------- | ------------------------- | --------------------------------------------------------------------- |
-| `runtimeUrl`        | `string`                  | URL of the CopilotKit runtime endpoint                                |
-| `useSingleEndpoint` | `boolean`                 | Set to `true` when using single-route endpoints                       |
-| `headers`           | `Record<string, string>`  | Custom headers sent with every request                                |
-| `credentials`       | `RequestCredentials`      | Fetch credentials mode (e.g., `"include"` for cookies)                |
-| `publicApiKey`      | `string`                  | Copilot Cloud public API key (if using hosted runtime)                |
-| `showDevConsole`    | `boolean \| "auto"`       | Show the dev inspector (`"auto"` = development only)                  |
-| `renderToolCalls`   | `ReactToolCallRenderer[]` | Custom renderers for tool call UI                                     |
-| `frontendTools`     | `ReactFrontendTool[]`     | Frontend-defined tools (declarative alternative to `useFrontendTool`) |
-| `onError`           | `(event) => void`         | Global error handler                                                  |
+| Prop                | Type                                                       | Description                                                                                                          |
+| ------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `runtimeUrl`        | `string`                                                   | URL of the CopilotKit runtime endpoint                                                                               |
+| `useSingleEndpoint` | `boolean`                                                  | Set to `true` when using single-route endpoints                                                                      |
+| `headers`           | `Record<string, string> \| (() => Record<string, string>)` | Custom headers sent with every request. The function form is evaluated per-request (useful for dynamic auth tokens). |
+| `credentials`       | `RequestCredentials`                                       | Fetch credentials mode (e.g., `"include"` for cookies)                                                               |
+| `publicApiKey`      | `string`                                                   | Copilot Cloud public API key (if using hosted runtime)                                                               |
+| `showDevConsole`    | `boolean \| "auto"`                                        | Show the dev inspector (`"auto"` = development only)                                                                 |
+| `renderToolCalls`   | `ReactToolCallRenderer[]`                                  | Custom renderers for tool call UI                                                                                    |
+| `frontendTools`     | `ReactFrontendTool[]`                                      | Frontend-defined tools (declarative alternative to `useFrontendTool`)                                                |
+| `onError`           | `(event) => void`                                          | Global error handler                                                                                                 |
 
 ### Step 4: Add a chat UI component
 
@@ -342,7 +344,7 @@ CopilotKit uses telemetry to understand adoption, improve the product, and provi
    ```tsx
    <CopilotKitProvider
      runtimeUrl="/api/copilotkit"
-     licenseKey={process.env.NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY}
+     publicLicenseKey={process.env.NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY}
    >
    ```
    The `NEXT_PUBLIC_`/`VITE_` prefix is required because the key is read on the client.
@@ -378,12 +380,12 @@ Keep these in mind as you wire up a real deployment:
 
 ### Endpoint factory functions
 
-| Function                                  | Import                           | Protocol               | Framework                           |
-| ----------------------------------------- | -------------------------------- | ---------------------- | ----------------------------------- |
-| `createCopilotEndpoint`                   | `@copilotkit/runtime/v2`         | Multi-route (Hono)     | Next.js App Router, Hono standalone |
-| `createCopilotEndpointSingleRoute`        | `@copilotkit/runtime/v2`         | Single-route (Hono)    | Next.js App Router                  |
-| `createCopilotEndpointExpress`            | `@copilotkit/runtime/v2/express` | Multi-route (Express)  | Express standalone                  |
-| `createCopilotEndpointSingleRouteExpress` | `@copilotkit/runtime/v2/express` | Single-route (Express) | Express standalone                  |
+| Function                      | Import                           | Framework                           | Mode                                                |
+| ----------------------------- | -------------------------------- | ----------------------------------- | --------------------------------------------------- |
+| `createCopilotHonoHandler`    | `@copilotkit/runtime/v2`         | Next.js App Router, Hono standalone | `"multi-route"` (default) or `mode: "single-route"` |
+| `createCopilotExpressHandler` | `@copilotkit/runtime/v2/express` | Express standalone                  | `"multi-route"` (default) or `mode: "single-route"` |
+
+> The `createCopilotEndpoint`, `createCopilotEndpointSingleRoute`, `createCopilotEndpointExpress`, and `createCopilotEndpointSingleRouteExpress` names are deprecated aliases of the two factories above. Prefer the handler factories with the `mode` option.
 
 ### Runtime classes
 

--- a/skills/copilotkit-setup/assets/nextjs-app-router-page.tsx
+++ b/skills/copilotkit-setup/assets/nextjs-app-router-page.tsx
@@ -2,23 +2,23 @@
 // Next.js App Router frontend with CopilotKit provider and chat UI
 //
 // Prerequisites:
-//   npm install @copilotkit/react @copilotkit/core
+//   npm install @copilotkit/react-core
 //
 // Also add to layout.tsx:
-//   import "@copilotkit/react/styles.css";
+//   import "@copilotkit/react-core/v2/styles.css";
 
 "use client";
 
-import { CopilotKitProvider, CopilotChat } from "@copilotkit/react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function Home() {
   return (
-    <CopilotKitProvider runtimeUrl="/api/copilotkit" showDevConsole="auto">
+    <CopilotKit runtimeUrl="/api/copilotkit" showDevConsole="auto">
       <div
         style={{ height: "100vh", margin: 0, padding: 0, overflow: "hidden" }}
       >
         <CopilotChat />
       </div>
-    </CopilotKitProvider>
+    </CopilotKit>
   );
 }

--- a/skills/copilotkit-setup/eval.yaml
+++ b/skills/copilotkit-setup/eval.yaml
@@ -20,7 +20,7 @@ tasks:
       - CopilotKit runtime packages (@copilotkit/runtime, @copilotkit/agent)
       - A runtime API route at src/app/api/copilotkit/[[...slug]]/route.ts using
         createCopilotEndpoint with a BuiltInAgent
-      - A page component with CopilotKitProvider wrapping CopilotChat
+      - A page component with the CopilotKit provider wrapping CopilotChat
       - The @copilotkit/react stylesheet imported
     graders:
       - type: deterministic
@@ -72,11 +72,11 @@ tasks:
             add_check "Runtime route file exists" false "No copilotkit API route found"
           fi
 
-          # Check for CopilotKitProvider usage
-          if grep -r "CopilotKitProvider" --include='*.tsx' --include='*.ts' --include='*.jsx' . > /dev/null 2>&1; then
-            add_check "CopilotKitProvider used" true "Found in source files"
+          # Check for CopilotKit provider usage (matches <CopilotKit and legacy <CopilotKitProvider)
+          if grep -r "<CopilotKit" --include='*.tsx' --include='*.ts' --include='*.jsx' . > /dev/null 2>&1; then
+            add_check "CopilotKit provider used" true "Found in source files"
           else
-            add_check "CopilotKitProvider used" false "CopilotKitProvider not found in any source file"
+            add_check "CopilotKit provider used" false "CopilotKit provider not found in any source file"
           fi
 
           # Check for CopilotChat usage
@@ -95,7 +95,7 @@ tasks:
       - type: llm_rubric
         rubric: |
           Evaluate whether this project has a complete, working CopilotKit setup:
-          1. Does it have a CopilotKitProvider wrapping a CopilotChat (or CopilotSidebar/CopilotPopup) component?
+          1. Does it have a CopilotKit provider (the `CopilotKit` component from @copilotkit/react-core/v2) wrapping a CopilotChat (or CopilotSidebar/CopilotPopup) component?
           2. Does the runtime route use createCopilotEndpoint or createCopilotEndpointSingleRoute with a BuiltInAgent?
           3. Is the @copilotkit/react stylesheet imported (styles.css)?
           4. Does the provider's runtimeUrl point to the correct API route?
@@ -109,7 +109,7 @@ tasks:
       - CopilotKit frontend packages (@copilotkit/react, @copilotkit/core)
       - CopilotKit runtime packages (@copilotkit/runtime, @copilotkit/agent)
       - A backend server (Express or Hono) running the CopilotRuntime with a BuiltInAgent
-      - CopilotKitProvider in the React app pointing to the backend URL
+      - The CopilotKit provider in the React app pointing to the backend URL
       - A CopilotSidebar component for the chat UI
       - The @copilotkit/react stylesheet imported
     workspace:
@@ -146,11 +146,11 @@ tasks:
             add_check "@copilotkit/runtime installed" false "Not found in any package.json"
           fi
 
-          # Check for CopilotKitProvider
-          if grep -r "CopilotKitProvider" --include='*.tsx' --include='*.ts' --include='*.jsx' . > /dev/null 2>&1; then
-            add_check "CopilotKitProvider used" true "Found in source files"
+          # Check for CopilotKit provider (matches <CopilotKit and legacy <CopilotKitProvider)
+          if grep -r "<CopilotKit" --include='*.tsx' --include='*.ts' --include='*.jsx' . > /dev/null 2>&1; then
+            add_check "CopilotKit provider used" true "Found in source files"
           else
-            add_check "CopilotKitProvider used" false "CopilotKitProvider not found"
+            add_check "CopilotKit provider used" false "CopilotKit provider not found"
           fi
 
           # Check for CopilotSidebar or other chat component
@@ -183,7 +183,7 @@ tasks:
       - type: llm_rubric
         rubric: |
           Evaluate whether CopilotKit is properly integrated into this Vite+React project:
-          1. Is CopilotKitProvider set up with a runtimeUrl pointing to the backend server?
+          1. Is the CopilotKit provider set up with a runtimeUrl pointing to the backend server?
           2. Is there a CopilotSidebar (or equivalent chat component) rendered in the app?
           3. Does the backend use CopilotRuntime with a BuiltInAgent and an appropriate endpoint factory?
           4. Is the @copilotkit/react stylesheet imported?

--- a/skills/copilotkit-setup/references/framework-detection.md
+++ b/skills/copilotkit-setup/references/framework-detection.md
@@ -48,7 +48,7 @@ Detect the project's framework before generating any setup code. The detection o
 
 - **Runtime location:** Separate backend server (Express or Hono standalone)
 - **Provider placement:** Uses Angular-specific components from `@copilotkit/angular` (separate package)
-- **Not React-based:** Does NOT use `CopilotKitProvider` or React hooks
+- **Not React-based:** Does NOT use the `CopilotKit` provider or React hooks
 - **Stylesheet import:** Via Angular styles configuration in `angular.json`
 - **Package:** `@copilotkit/angular` instead of `@copilotkit/react`
 

--- a/skills/copilotkit-setup/references/runtime-architecture.md
+++ b/skills/copilotkit-setup/references/runtime-architecture.md
@@ -241,8 +241,8 @@ createCopilotEndpoint({
 
 **Express endpoints:** CORS is handled internally via the `cors` middleware with permissive defaults. Customize by wrapping the router or adding your own CORS middleware upstream.
 
-**Frontend side:** Set `credentials: "include"` on `CopilotKitProvider` to send cookies:
+**Frontend side:** Set `credentials: "include"` on the `CopilotKit` provider to send cookies:
 
 ```tsx
-<CopilotKitProvider runtimeUrl="/api/copilotkit" credentials="include">
+<CopilotKit runtimeUrl="/api/copilotkit" credentials="include">
 ```

--- a/skills/copilotkit-setup/references/telemetry-setup.md
+++ b/skills/copilotkit-setup/references/telemetry-setup.md
@@ -49,15 +49,15 @@ Then reference it in the provider:
 
 ```tsx
 // Next.js
-<CopilotKitProvider
+<CopilotKit
   runtimeUrl="/api/copilotkit"
-  licenseKey={process.env.NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY}
+  publicLicenseKey={process.env.NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY}
 >
 
 // Vite
-<CopilotKitProvider
+<CopilotKit
   runtimeUrl="/api/copilotkit"
-  licenseKey={import.meta.env.VITE_COPILOTKIT_LICENSE_KEY}
+  publicLicenseKey={import.meta.env.VITE_COPILOTKIT_LICENSE_KEY}
 >
 ```
 
@@ -65,4 +65,4 @@ The `NEXT_PUBLIC_` or `VITE_` prefix is required because the license key is used
 
 ## Opting out
 
-To disconnect from CopilotCloud, simply remove the `licenseKey` prop from `CopilotKitProvider` (and delete the environment variable if you set one). No other changes are needed -- CopilotKit will continue to function normally without it.
+To disconnect from CopilotCloud, simply remove the `publicLicenseKey` prop from the `CopilotKit` provider (and delete the environment variable if you set one). No other changes are needed -- CopilotKit will continue to function normally without it.


### PR DESCRIPTION
Fixes 4 accuracy issues surfaced by a docs gardener agent reviewing the `copilotkit-setup` skill. Docs-only; no runtime code touched.

| # | Issue | Fix | Proof (source) |
|---|-------|-----|----------------|
| 1 | `licenseKey` is not a valid `CopilotKitProvider` prop | Use `publicLicenseKey` (alias of `publicApiKey`) | [`publicApiKey` L102](https://github.com/CopilotKit/CopilotKit/blob/01f89396a494cd44437979730ded6d9dcbbc02ab/packages/react-core/src/v2/providers/CopilotKitProvider.tsx#L102), [`publicLicenseKey` L106](https://github.com/CopilotKit/CopilotKit/blob/01f89396a494cd44437979730ded6d9dcbbc02ab/packages/react-core/src/v2/providers/CopilotKitProvider.tsx#L106) |
| 2 | `createCopilotEndpoint` / `createCopilotEndpointSingleRoute` are `@deprecated` | Use `createCopilotHonoHandler` with `mode: "single-route"` | [`createCopilotEndpoint` deprecated alias, hono.ts L52-55](https://github.com/CopilotKit/CopilotKit/blob/01f89396a494cd44437979730ded6d9dcbbc02ab/packages/runtime/src/v2/runtime/endpoints/hono.ts#L52-L55), [single-route deprecated, hono-single.ts L24](https://github.com/CopilotKit/CopilotKit/blob/01f89396a494cd44437979730ded6d9dcbbc02ab/packages/runtime/src/v2/runtime/endpoints/hono-single.ts#L24) |
| 3 | `createCopilotEndpointExpress` / `...SingleRouteExpress` are `@deprecated` | Use `createCopilotExpressHandler` with `mode: "single-route"` | [`createCopilotEndpointExpress` deprecated alias, express.ts L88-91](https://github.com/CopilotKit/CopilotKit/blob/01f89396a494cd44437979730ded6d9dcbbc02ab/packages/runtime/src/v2/runtime/endpoints/express.ts#L88-L91), [single-route deprecated, express-single.ts L41](https://github.com/CopilotKit/CopilotKit/blob/01f89396a494cd44437979730ded6d9dcbbc02ab/packages/runtime/src/v2/runtime/endpoints/express-single.ts#L41) |
| 4 | `headers` prop type incomplete | Document `Record<string, string> \| (() => Record<string, string>)`, evaluated per-request | [headers union type, CopilotKitProvider.tsx L94](https://github.com/CopilotKit/CopilotKit/blob/01f89396a494cd44437979730ded6d9dcbbc02ab/packages/react-core/src/v2/providers/CopilotKitProvider.tsx#L94) |

### Notes for review
- Both deprecated factory families collapse into a single factory each (`createCopilotHonoHandler` / `createCopilotExpressHandler`), differentiated by `mode` (`"multi-route"` is the default). The deprecated names still work, so existing user code is unaffected; only the recommended docs path changed.
- `createCopilotExpressHandler` defaults to `cors: true` ([express.ts L91](https://github.com/CopilotKit/CopilotKit/blob/01f89396a494cd44437979730ded6d9dcbbc02ab/packages/runtime/src/v2/runtime/endpoints/express.ts#L91)), matching the old `...SingleRouteExpress` wrapper, so the single-route example keeps identical CORS behavior without an extra option.
- Quick Reference table rewritten with a `Mode` column; a one-line note keeps the deprecated names discoverable.
- Skill `version` bumped from 1.1.1 to 1.1.2.
