### PR TITLE
fix(showcase): isolated d6 pb-auth + canonical isolate flow

### DIFF
--- a/showcase/DEBUGGING.md
+++ b/showcase/DEBUGGING.md
@@ -276,23 +276,75 @@ showcase diff-logs aimock --since last-test --grep "fixture"
 
 This filters out all log output from before your test started, showing only what happened during the test run itself.
 
-## Isolated Test Runs (`--isolate`)
+## Isolated Verification Runs (`--isolate`)
 
-The `--isolate` flag on `showcase test` lets you run tests without interfering with an already-running local stack (or other isolated runs). It works by creating temporary overlay files rather than mutating originals in place.
+`bin/showcase test <slug> --d6 --isolate <name>` is the canonical, default way
+to verify a slug's D6 state. It brings up a fully isolated stack — its own
+aimock, PocketBase, dashboard, integration, and harness control-plane +
+pool-worker — on offset ports in its own docker compose project, then runs the
+canonical `harness/src/probes/drivers/d6-all-pills.ts` driver: it enqueues
+per-pill jobs, the isolated worker claims them, and asserts per-pill. This is
+**identical to the non-isolate path** — same driver, same per-pill assertions —
+just namespaced so it never disturbs the shared long-lived `showcase-*` stack.
+
+```sh
+showcase test <slug> --d6 --isolate <name>
+```
+
+Verify with this flow rather than hand-driving the browser. The point of the
+isolated driver is the identical-tests invariant: the same assertions run the
+same way for every integration, so a result is comparable across integrations
+and to production. Manual clicking is non-reproducible and tests something
+subtly different each run.
 
 ### How it works
 
-1. **Temp overlay directory**: `apply_isolation` copies `docker-compose.local.yml` and `shared/local-ports.json` to `$TMPDIR/showcase-isolate-$$/`. The originals are never touched. Shell variables (`COMPOSE_FILE`, `COMPOSE_CMD`, `PORTS_FILE`) and the `LOCAL_PORTS_FILE` env var passed to the TS harness all point at the temp copies.
+1. **`<name>` and slot/offset**: `<name>` names the isolated compose project and
+   must match `[a-z0-9_-]+` (a docker compose project-name constraint; uppercase
+   is lowercased with a warning). Use a distinct name per run. The slot and port
+   offset are **auto-assigned** — each run atomically claims a slot via `mkdir
+/tmp/showcase-isolate-slots/N` and derives its offset as `(slot + 1) * 200`
+   (slot 0 → +200, slot 1 → +400, ...). Up to 46 concurrent runs are supported.
+   Do not assign slots manually.
 
-2. **Slot-based port allocation**: Concurrent `--isolate` runs acquire unique port ranges via atomic `mkdir /tmp/showcase-isolate-slots/N`. Slot 0 adds a +200 offset to all ports, slot 1 adds +400, slot 2 adds +600, etc. Up to 46 concurrent isolated runs are supported. Each slot directory contains a `pid` file for stale-slot detection.
+2. **Full isolated stack, shared stack untouched**: every service runs under the
+   `<name>` compose project on the offset ports, so containers, networks, and
+   volumes are fully namespaced. The default/long-lived `showcase-*` project is
+   left completely alone — an isolated run is safe to launch alongside it (or
+   alongside other isolated runs).
 
-3. **Project name scoping**: Each isolated run passes `--project-name <name>` to docker compose, so containers, networks, and volumes are fully namespaced. No collision with the base `showcase` project or other isolated runs.
+3. **PocketBase authenticates out of the box**: the host CLI's default
+   PocketBase superuser (`admin@example.com` / `showcase-local-dev`) matches the
+   `POCKETBASE_SUPERUSER_EMAIL` the compose stack seeds, so a fresh isolated PB
+   authenticates with no manual setup. A mismatch here is what previously 400'd
+   on pb-auth and left the d6 control-plane enqueuing zero jobs.
 
-4. **Cleanup**: `restore_isolation` removes the temp directory and releases the slot. It is registered via `trap EXIT` before any mutation occurs, so cleanup runs even on crashes or `Ctrl-C`.
+4. **Temp overlay + cleanup**: `apply_isolation` writes offset copies of
+   `docker-compose.local.yml` and `shared/local-ports.json` into
+   `$TMPDIR/showcase-isolate-$$/` (originals are never touched).
+   `restore_isolation`, registered via `trap EXIT` before any mutation, tears
+   the stack down and frees the slot on exit — even on crashes or `Ctrl-C`.
 
-### Parallel runs are safe
+### Interpreting results
 
-Multiple agents or terminal sessions can each run `showcase test <slug> --isolate` simultaneously. Each gets its own port range and project namespace. No coordination is needed beyond the atomic slot allocation.
+Per-pill FAILs reflect real demo/feature issues for that integration, not
+artifacts of isolation. Because the driver asserts per-pill identically across
+integrations, a FAIL is the same signal you'd get from the shared stack or
+production for that pill.
+
+### Cleanup
+
+The isolated stack tears down on exit and frees its slot automatically — the
+normal case needs no cleanup, and each fresh run gets a clean PocketBase volume
+(which is what keeps pb-auth deterministic). The `--keep` flag governs
+harness-started packages on the non-isolate path; it does not override the
+isolated teardown trap. To leave a stack up for inspection, start it explicitly
+with `bin/showcase up` under your own project name. Tear that down by project
+name when done:
+
+```sh
+docker compose --project-name <name> down --volumes
+```
 
 ### Troubleshooting
 
@@ -303,7 +355,7 @@ Multiple agents or terminal sessions can each run `showcase test <slug> --isolat
   rm -f showcase/docker-compose.local.yml.iso-bak showcase/shared/local-ports.json.iso-bak
   ```
 
-  The new isolate behavior auto-detects and cleans up these stale backups on startup, but a manual restore is the safest fix if things look wrong.
+  The current isolate behavior auto-detects and cleans up these stale backups on startup, but a manual restore is the safest fix if things look wrong.
 
 - **Temp files**: Overlay directories live at `$TMPDIR/showcase-isolate-*/`. They are cleaned up on normal exit; if a run was killed with `SIGKILL`, the directory may linger. Safe to remove manually.
 

--- a/showcase/RUNBOOK.md
+++ b/showcase/RUNBOOK.md
@@ -8,14 +8,41 @@ Intended audience: engineers and AI agents working on showcase integrations.
 ALWAYS use `bin/showcase` for all operations. Never raw `docker compose` or `docker build`.
 
 ```
-bin/showcase up <slug>          # start container
-bin/showcase rebuild <slug>     # code changes (new image)
-bin/showcase test <slug> --d5   # run D5 probe
+bin/showcase up <slug>                      # start container
+bin/showcase rebuild <slug>                 # code changes (new image)
+bin/showcase test <slug> --d5               # run D5 probe
+bin/showcase test <slug> --d6 --isolate <name>   # canonical d6 verification
 ```
 
 - **`rebuild`** handles symlink dereferencing that raw `docker build` cannot (`tools/` and `shared-tools/` are symlinks to `../../shared/`).
 - **`recreate`** for env/config changes (same image, new container).
 - **`rebuild`** for code changes (new image).
+
+## Verifying a Slug's D6 State (canonical flow)
+
+To verify an integration's D6 state, run:
+
+```
+bin/showcase test <slug> --d6 --isolate <name>
+```
+
+This is THE default way to verify a slug. `--isolate <name>` brings up a fully
+isolated stack — its own aimock + PocketBase + dashboard + integration +
+harness control-plane and pool-worker — on offset ports in its own docker
+compose project, then runs the canonical `harness/src/probes/drivers/d6-all-pills.ts`
+driver: it enqueues per-pill jobs, the isolated worker claims them, and asserts
+per-pill. This is **identical to the non-isolate path** — the same driver, the
+same per-pill assertions — just on isolated ports/project so it doesn't disturb
+the shared long-lived `showcase-*` stack.
+
+Verifiers use THIS flow rather than hand-driving the browser. Hand-driving
+breaks the identical-tests invariant: the whole point is that the same driver
+runs and asserts per-pill the same way across every integration, so a result is
+comparable to every other integration and to production. Manual clicking is
+non-reproducible and tests something subtly different per run.
+
+See [Isolated Verification Runs (`--isolate`)](#isolated-verification-runs---isolate)
+below for the full mechanics and cleanup.
 
 ## Fixture Matching
 
@@ -122,30 +149,81 @@ Rate limit: 5 minutes per probe ID.
 
 When `package.json` changes (new deps, version bumps), volume mounts don't cover `node_modules`. You MUST rebuild the Docker image: `bin/showcase rebuild <slug>`, then re-test. A passing `bin/showcase test` against a volume-mounted container does NOT validate the build.
 
-## Isolated Test Runs (`--isolate`)
+## Isolated Verification Runs (`--isolate`)
 
-Use `--isolate` when another agent or terminal session is already running showcase locally. It prevents port collisions and container name conflicts by scoping everything into a temporary overlay.
+`--isolate <name>` is the default way to verify a slug (see [Verifying a Slug's
+D6 State](#verifying-a-slugs-d6-state-canonical-flow)). It brings up a fully
+isolated stack on offset ports in its own docker compose project and runs the
+canonical `d6-all-pills` driver against it — identical to the non-isolate path,
+just namespaced so it never touches the shared `showcase-*` stack.
 
 ```
-bin/showcase test <slug> --d5 --isolate
+bin/showcase test <slug> --d6 --isolate <name>
 ```
 
-### Operational notes
+### How it works
 
-- **Required when sharing a machine**: If any other session has `showcase up` running, use `--isolate` to avoid stomping on its containers and ports.
-- **Parallel runs supported**: Up to 46 concurrent `--isolate` runs. Each gets a unique port range (slot 0 = +200, slot 1 = +400, ...) and a scoped docker compose project name.
-- **Originals are never modified**: The flag writes temp copies of `docker-compose.local.yml` and `shared/local-ports.json` to `$TMPDIR/showcase-isolate-$$/`. If the process crashes, originals are untouched.
-- **Cleanup is automatic**: The temp directory and slot are released on exit (via `trap EXIT`). If a run was killed with `SIGKILL`, clean up manually:
+- **`<name>`**: names the isolated compose project. It must match `[a-z0-9_-]+`
+  (a docker compose project-name constraint; uppercase is lowercased with a
+  warning). Use a distinct name per run so concurrent runs never collide.
+- **Auto-assigned slot and port offset**: each run atomically claims a slot
+  (0–45) and derives its port offset as `(slot + 1) * 200` — slot 0 → +200,
+  slot 1 → +400, and so on. **Do not assign slots or offsets manually**; the
+  CLI claims and frees them for you. Up to 46 concurrent isolated runs are
+  supported.
+- **Full isolated stack**: its own aimock, PocketBase, dashboard, integration,
+  and harness control-plane + pool-worker, all on the offset ports under the
+  `<name>` compose project.
+- **Does NOT touch the shared stack**: the default/long-lived `showcase-*`
+  project is left completely alone, so an isolated run is safe to launch
+  alongside it (or alongside other isolated runs).
+- **PocketBase authenticates out of the box**: the host CLI's default PocketBase
+  superuser (`admin@example.com` / `showcase-local-dev`) matches the
+  `POCKETBASE_SUPERUSER_EMAIL` the compose stack seeds, so a fresh isolated PB
+  authenticates with no manual setup. (A mismatch here is what previously 400'd
+  on pb-auth and left the control-plane enqueuing zero jobs.)
+- **Originals are never modified**: the flag writes offset copies of
+  `docker-compose.local.yml` and `shared/local-ports.json` into
+  `$TMPDIR/showcase-isolate-$$/`. If the process crashes, the originals are
+  untouched.
 
-  ```sh
-  # Remove orphaned containers from a specific isolated run:
-  docker compose --project-name <name> down
+### Interpreting results
 
-  # Clear all stale slot reservations:
-  rm -rf /tmp/showcase-isolate-slots/*
-  ```
+Per-pill FAILs in an isolated run reflect real demo/feature issues for that
+integration — not artifacts of isolation. The driver runs and asserts per-pill
+identically across every integration, so a FAIL is the same signal you'd get
+from the shared stack or production for that pill.
 
-- **Stale `.iso-bak` files**: If you see `docker-compose.local.yml.iso-bak` or `local-ports.json.iso-bak`, those are leftovers from the old (pre-PR#4570) isolate behavior. The new code auto-restores them on startup, but you can also clean up manually with `git checkout` on the affected files.
+### Cleanup
+
+An isolated run tears its stack down on exit (via `trap EXIT`) and frees its
+slot automatically — the normal, no-cleanup-needed case. Each fresh run gets a
+clean PocketBase volume, which is what makes pb-auth deterministic.
+
+To leave the stack up for inspection after the run, start it explicitly with
+`bin/showcase up` under your own compose project name instead of relying on a
+test run's transient stack (the test path always tears its own stack down). The
+`--keep` flag governs harness-started packages on the non-isolate path; it does
+not override the isolated teardown trap.
+
+When you're done inspecting a manually-kept stack, tear down its containers and
+volumes by project name:
+
+```sh
+docker compose --project-name <name> down --volumes
+```
+
+If a run was killed with `SIGKILL` (so the trap never fired), clean up the slot
+reservations manually:
+
+```sh
+rm -rf /tmp/showcase-isolate-slots/*
+```
+
+- **Stale `.iso-bak` files**: if you see `docker-compose.local.yml.iso-bak` or
+  `local-ports.json.iso-bak`, those are leftovers from an old isolate behavior
+  that mutated files in place. The current code auto-restores them on startup,
+  but you can also clean up manually with `git checkout` on the affected files.
 
 ## Anti-Patterns
 

--- a/showcase/harness/src/cli/config.test.ts
+++ b/showcase/harness/src/cli/config.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
+
+import { loadConfig } from "./config.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// showcase/harness/src/cli -> showcase
+const SHOWCASE_DIR = path.resolve(__dirname, "../../..");
+const COMPOSE_FILE = path.join(SHOWCASE_DIR, "docker-compose.local.yml");
+
+/**
+ * Read the superuser email the PocketBase service is seeded with in
+ * docker-compose.local.yml. The PB `entrypoint.sh` creates exactly this
+ * superuser, so it is the single source of truth for the credential the
+ * host CLI must authenticate as. A fresh isolated PB volume ONLY has this
+ * account — if the host default disagrees the pb-auth login 400s and the
+ * d6 control plane enqueues 0 jobs.
+ */
+function composeSeededSuperuserEmail(): string {
+  const doc = yaml.load(fs.readFileSync(COMPOSE_FILE, "utf-8")) as {
+    services: Record<string, { environment?: string[] }>;
+  };
+  const env = doc.services.pocketbase.environment ?? [];
+  const entry = env.find((e) => e.startsWith("POCKETBASE_SUPERUSER_EMAIL="));
+  if (!entry) {
+    throw new Error(
+      "POCKETBASE_SUPERUSER_EMAIL not set on the pocketbase service in docker-compose.local.yml",
+    );
+  }
+  return entry.slice("POCKETBASE_SUPERUSER_EMAIL=".length);
+}
+
+describe("loadConfig() — PocketBase superuser default", () => {
+  const SUPERUSER_ENV_KEYS = [
+    "POCKETBASE_SUPERUSER_EMAIL",
+    "POCKETBASE_SUPERUSER_PASSWORD",
+    "POCKETBASE_URL_LOCAL",
+  ] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    // Clear superuser env so we exercise the hardcoded config default — the
+    // host shell does NOT load showcase/.env (compose passes it to containers
+    // only), so an isolated `bin/showcase` run falls through to this default.
+    for (const key of SUPERUSER_ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of SUPERUSER_ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it("defaults the superuser email to the value docker-compose.local.yml seeds", () => {
+    // Single source of truth: docker-compose.local.yml:130
+    // POCKETBASE_SUPERUSER_EMAIL. The host CLI default MUST match the
+    // compose-seeded superuser or isolated PB volumes 400 on pb-auth.
+    const expected = composeSeededSuperuserEmail();
+    expect(loadConfig().pocketbase.email).toBe(expected);
+  });
+});

--- a/showcase/harness/src/cli/config.ts
+++ b/showcase/harness/src/cli/config.ts
@@ -38,12 +38,16 @@ export function loadConfig(): LocalConfig {
     localPorts,
     pocketbase: {
       url: process.env.POCKETBASE_URL_LOCAL || "http://localhost:8090",
-      // PB 0.22+ rejects `admin@localhost` (single-label TLD) as an invalid
-      // email. Use a valid format that the PB validator accepts. The
-      // matching admin account is created in the entrypoint / migrations
-      // path; the docker-compose env vars and `bin/showcase` superuser
-      // bootstrap must agree on this value.
-      email: "admin@localhost.dev",
+      // The host CLI loads no env file (showcase/.env is passed to containers
+      // via compose `env_file`, never into the host process), so an isolated
+      // `bin/showcase` run falls through to this default. It MUST equal the
+      // superuser the PB `entrypoint.sh` actually seeds — i.e. the value of
+      // POCKETBASE_SUPERUSER_EMAIL in docker-compose.local.yml:130. A fresh
+      // isolated PB volume ONLY has that account; any mismatch 400s on
+      // pb-auth and the d6 control plane enqueues 0 jobs. (PB 0.22+ also
+      // rejects single-label hosts like `admin@localhost`, so the value must
+      // carry a TLD regardless.)
+      email: "admin@example.com",
       password: "showcase-local-dev",
     },
     // When --isolate offsets the aimock host port, honor env overrides so the


### PR DESCRIPTION
## Summary

`bin/showcase test <slug> --d6 --isolate <name>` brought up a healthy isolated stack but the d6 control plane failed `pb-auth: 400 Failed to authenticate`, enqueued **0 jobs**, and the `d6-all-pills` driver no-op'd — forcing verifiers to hand-drive the browser instead of the shared driver (violating the identical-tests invariant).

**Root cause:** the host-side `bin/showcase` CLI never loads `showcase/.env` into its own process (the env file is only passed to containers via compose `env_file`), so an isolated run falls through to the default PocketBase superuser creds in `config.ts`. That default email was `admin@localhost.dev`, but the PB `entrypoint.sh` seeds `admin@example.com` (`POCKETBASE_SUPERUSER_EMAIL` in `docker-compose.local.yml`). A **fresh isolated PB volume** only has `admin@example.com`, so the CLI's login 400'd → 0 enqueued → driver no-op. The non-isolate path only worked by accident: the long-lived default volume carried a hand-created `admin@localhost.dev` superuser.

## Changes
- **`harness/src/cli/config.ts`**: default superuser email `admin@localhost.dev` → `admin@example.com`, matching the compose-seeded account (password default already matched). Fixes the isolated path and removes the latent default-path mismatch.
- **`harness/src/cli/config.test.ts`** (new): derives the expected email by parsing `docker-compose.local.yml` (single source of truth) and asserts the CLI default equals the seeded `POCKETBASE_SUPERUSER_EMAIL` — so host CLI and container seed cannot drift again.
- **`RUNBOOK.md` / `DEBUGGING.md`**: establish `bin/showcase test <slug> --d6 --isolate <name>` as the canonical default verification flow, with accurate mechanics (offset ports, auto-assigned slot, isolated compose project, doesn't touch the shared stack, pb-auth works out of the box).

## Proof
Verified locally on **llamaindex** and **agno** with `--isolate`: all services healthy, **no pb-auth 400**, **Enqueued 1 job(s)** (was 0), and the isolated pool-worker claims the job and runs the real `d6-all-pills` driver emitting per-pill pass/fail rows (e.g. `feature-complete frontend-tools-async pass:false`, `tool-rendering-reasoning-chain pass:false`). Per-pill FAILs are integration demo/fixture issues, not the isolate/auth bug.

## Test plan
- [x] `harness` unit suite green (2124 passed; 1 known pre-existing timing flake, verified on baseline)
- [x] `tsc --noEmit` + build clean
- [x] `oxfmt@0.36 --check` (CI-pinned) clean on all changed files
- [x] Live `--isolate` runs for llamaindex + agno enqueue >0 and run d6-all-pills per-pill