### PR TITLE
fix(plugin): re-pin plugin version to 1.60.2 and close the silent-drift gap

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "AI agent skills for CopilotKit — setup, develop, integrate, debug, upgrade, and contribute",
-    "version": "1.57.3"
+    "version": "1.60.2"
   },
   "plugins": [
     {
       "name": "copilotkit",
       "source": "./",
       "description": "AI agent skills for CopilotKit — setup, develop, integrate, debug, upgrade, and contribute to CopilotKit projects",
-      "version": "1.60.0",
+      "version": "1.60.2",
       "author": {
         "name": "CopilotKit",
         "url": "https://copilotkit.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "copilotkit",
   "description": "AI agent skills for CopilotKit — setup, develop, integrate, debug, upgrade, and contribute to CopilotKit projects",
-  "version": "1.60.0",
+  "version": "1.60.2",
   "author": {
     "name": "CopilotKit",
     "url": "https://copilotkit.ai"

--- a/.github/workflows/plugin-skills-check.yml
+++ b/.github/workflows/plugin-skills-check.yml
@@ -12,6 +12,9 @@ on:
       - "scripts/__tests__/sync-plugin-skills.test.ts"
       - ".claude-plugin/**"
       - ".github/workflows/plugin-skills-check.yml"
+      # The plugin version pins to packages/runtime/package.json, so a release
+      # bump there must re-trigger the drift check or the pin silently rots.
+      - "packages/runtime/package.json"
   pull_request:
     paths:
       - "packages/*/skills/**"
@@ -22,6 +25,7 @@ on:
       - "scripts/__tests__/sync-plugin-skills.test.ts"
       - ".claude-plugin/**"
       - ".github/workflows/plugin-skills-check.yml"
+      - "packages/runtime/package.json"
 
 permissions:
   contents: read

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -99,7 +99,7 @@ pre-commit:
 
     check-plugin-skills:
       tags: plugin-skills
-      glob: "{packages/*/skills/**,skills/runtime/**,skills/react-core/**,skills/a2ui-renderer/**,scripts/sync-plugin-skills.ts,.claude-plugin/**}"
+      glob: "{packages/*/skills/**,skills/runtime/**,skills/react-core/**,skills/a2ui-renderer/**,scripts/sync-plugin-skills.ts,.claude-plugin/**,packages/runtime/package.json}"
       run: pnpm check:plugin-skills
       fail_text: |
         Plugin skill mirror is out of sync with the Intent source.

--- a/scripts/__tests__/sync-plugin-skills.test.ts
+++ b/scripts/__tests__/sync-plugin-skills.test.ts
@@ -164,6 +164,7 @@ describe("syncPluginSkills", () => {
       JSON.stringify(
         {
           name: "copilotkit",
+          metadata: { version: initialPluginVersion },
           plugins: [
             { name: "copilotkit", source: "./", version: initialPluginVersion },
           ],
@@ -186,6 +187,30 @@ describe("syncPluginSkills", () => {
     );
     expect(plugin.version).toBe("1.56.2");
     expect(market.plugins[0].version).toBe("1.56.2");
+    // metadata.version tracks the runtime package too — both marketplace fields
+    // must move together so neither rots independently.
+    expect(market.metadata.version).toBe("1.56.2");
+  });
+
+  it("write mode re-syncs marketplace.json metadata.version when it lags plugins[0].version", async () => {
+    await makeRepo(repo);
+    await addVersionFixtures(repo, "1.56.2", "1.56.2");
+    // Simulate the historical drift: plugins[0] was bumped by an earlier sync
+    // but metadata.version was left behind because it was unmanaged.
+    const marketPath = join(repo, ".claude-plugin/marketplace.json");
+    const market = JSON.parse(await readFile(marketPath, "utf8"));
+    market.metadata.version = "1.55.0";
+    await writeFile(marketPath, JSON.stringify(market, null, 2) + "\n");
+
+    const drift = await syncPluginSkills({ cwd: repo, mode: "check" });
+    expect(drift.exitCode).toBe(1);
+    expect(drift.message).toMatch(/metadata\.version/i);
+    expect(drift.message).toContain("1.55.0");
+
+    await syncPluginSkills({ cwd: repo, mode: "write" });
+    const fixed = JSON.parse(await readFile(marketPath, "utf8"));
+    expect(fixed.metadata.version).toBe("1.56.2");
+    expect(fixed.plugins[0].version).toBe("1.56.2");
   });
 
   it("check mode detects plugin.json version drift", async () => {

--- a/scripts/sync-plugin-skills.ts
+++ b/scripts/sync-plugin-skills.ts
@@ -222,12 +222,31 @@ async function handleVersionSync(opts: SyncOptions): Promise<string> {
   if (existsSync(marketPath)) {
     const market = JSON.parse(await readFile(marketPath, "utf8"));
     const marketVersion = market.plugins?.[0]?.version;
+    const metadataVersion = market.metadata?.version;
+    // Both version fields in marketplace.json track the runtime package. They
+    // are checked together so neither rots independently — metadata.version was
+    // historically unmanaged and drifted behind plugins[0].version.
     if (marketVersion !== srcVersion) {
       if (opts.mode === "check") {
         return `marketplace.json plugins[0].version is "${marketVersion}", expected "${srcVersion}" (from ${VERSION_SOURCE_PACKAGE_JSON})`;
       }
-      if (market.plugins?.[0]) {
+    }
+    if (metadataVersion !== undefined && metadataVersion !== srcVersion) {
+      if (opts.mode === "check") {
+        return `marketplace.json metadata.version is "${metadataVersion}", expected "${srcVersion}" (from ${VERSION_SOURCE_PACKAGE_JSON})`;
+      }
+    }
+    if (opts.mode === "write") {
+      let mutated = false;
+      if (market.plugins?.[0] && marketVersion !== srcVersion) {
         market.plugins[0].version = srcVersion;
+        mutated = true;
+      }
+      if (market.metadata && metadataVersion !== srcVersion) {
+        market.metadata.version = srcVersion;
+        mutated = true;
+      }
+      if (mutated) {
         await writeFile(marketPath, JSON.stringify(market, null, 2) + "\n");
       }
     }


### PR DESCRIPTION
Re-pins the plugin version to match `packages/runtime/package.json` (the pin source), and closes the gap that let it drift. `pnpm check:plugin-skills` is currently **failing on `main`** because of this drift.

### The drift (before, after)

| Field | Before | After |
|---|---|---|
| `packages/runtime/package.json` (pin source) | 1.60.2 | 1.60.2 |
| `.claude-plugin/plugin.json` | 1.60.0 | **1.60.2** |
| `marketplace.json` > `plugins[0].version` | 1.60.0 | **1.60.2** |
| `marketplace.json` > `metadata.version` | 1.57.3 | **1.60.2** |

### Changes (2 commits)

- **`fix(plugin)`**: re-pin via `pnpm sync:plugin-skills`, and teach `handleVersionSync` to also manage `marketplace.json metadata.version` (it was unmanaged, which is why it drifted furthest). +2 unit tests.
- **`ci(plugin-skills)`**: watch `packages/runtime/package.json` in the lefthook glob and both workflow path filters. A release bump there matched no trigger before, so the pin rotted silently between releases. That was the root cause.

### Verify

- `vitest run scripts/__tests__/sync-plugin-skills.test.ts`, 10 passed
- `pnpm check:plugin-skills`, `plugin skill mirror in sync` (was failing)
