### PR TITLE
feat(showcase): XDG state for isolate + --keep persists stack

### DIFF
--- a/showcase/DEBUGGING.md
+++ b/showcase/DEBUGGING.md
@@ -302,8 +302,9 @@ subtly different each run.
 1. **`<name>` and slot/offset**: `<name>` names the isolated compose project and
    must match `[a-z0-9_-]+` (a docker compose project-name constraint; uppercase
    is lowercased with a warning). Use a distinct name per run. The slot and port
-   offset are **auto-assigned** — each run atomically claims a slot via `mkdir
-/tmp/showcase-isolate-slots/N` and derives its offset as `(slot + 1) * 200`
+   offset are **auto-assigned** — each run atomically claims a slot via `mkdir`
+   under `${XDG_STATE_HOME:-$HOME/.local/state}/copilotkit/showcase/slots/N`
+   and derives its offset as `(slot + 1) * 200`
    (slot 0 → +200, slot 1 → +400, ...). Up to 46 concurrent runs are supported.
    Do not assign slots manually.
 
@@ -319,11 +320,14 @@ subtly different each run.
    authenticates with no manual setup. A mismatch here is what previously 400'd
    on pb-auth and left the d6 control-plane enqueuing zero jobs.
 
-4. **Temp overlay + cleanup**: `apply_isolation` writes offset copies of
-   `docker-compose.local.yml` and `shared/local-ports.json` into
-   `$TMPDIR/showcase-isolate-$$/` (originals are never touched).
+4. **Scratch overlay + cleanup**: `apply_isolation` writes offset copies of
+   `docker-compose.local.yml` and `shared/local-ports.json` into a per-run
+   scratch dir at
+   `${XDG_STATE_HOME:-$HOME/.local/state}/copilotkit/showcase/runs/<name>/`
+   (originals are never touched).
    `restore_isolation`, registered via `trap EXIT` before any mutation, tears
-   the stack down and frees the slot on exit — even on crashes or `Ctrl-C`.
+   the stack down and frees the slot on exit — even on crashes or `Ctrl-C` —
+   unless `--keep` is set (see Cleanup below).
 
 ### Interpreting results
 
@@ -334,13 +338,24 @@ production for that pill.
 
 ### Cleanup
 
-The isolated stack tears down on exit and frees its slot automatically — the
-normal case needs no cleanup, and each fresh run gets a clean PocketBase volume
-(which is what keeps pb-auth deterministic). The `--keep` flag governs
-harness-started packages on the non-isolate path; it does not override the
-isolated teardown trap. To leave a stack up for inspection, start it explicitly
-with `bin/showcase up` under your own project name. Tear that down by project
-name when done:
+By default the isolated stack tears down on exit and frees its slot
+automatically — the normal case needs no cleanup, and each fresh run gets a
+clean PocketBase volume (which is what keeps pb-auth deterministic).
+
+With `--keep`, the isolated stack survives the run (success or failure): the
+stack is left standing, and the per-run scratch dir and slot are preserved
+(live containers keep the slot from being reaped). That protection applies
+only while the containers are RUNNING — if they stop (manual `docker stop`,
+daemon restart, host reboot), the next isolate run's sweep reclaims the slot,
+composing the stopped containers and named volumes down and removing the
+scratch dir. Inspect a kept stack before stopping it; it does not survive a
+reboot. At exit a survival notice
+prints the stack's host ports (aimock, dashboard, PocketBase) plus the manual
+teardown command
+(`docker compose -p <name> down --remove-orphans && rm -rf <run-dir> <slot-dir>`).
+Note that `down --remove-orphans` does not remove named volumes (e.g.
+`<name>_showcase-pb-data`); for a fully clean slate, tear down by project name
+with volumes (or `docker volume rm` the leftovers):
 
 ```sh
 docker compose --project-name <name> down --volumes
@@ -357,9 +372,9 @@ docker compose --project-name <name> down --volumes
 
   The current isolate behavior auto-detects and cleans up these stale backups on startup, but a manual restore is the safest fix if things look wrong.
 
-- **Temp files**: Overlay directories live at `$TMPDIR/showcase-isolate-*/`. They are cleaned up on normal exit; if a run was killed with `SIGKILL`, the directory may linger. Safe to remove manually.
+- **Scratch files**: Per-run overlay directories live at `${XDG_STATE_HOME:-$HOME/.local/state}/copilotkit/showcase/runs/<name>/`. They are cleaned up on normal exit; if a run was killed with `SIGKILL`, the directory may linger. Safe to remove manually.
 
-- **Slot directories**: Located at `/tmp/showcase-isolate-slots/`. Each numbered subdirectory is a claimed slot. If slots accumulate from killed processes, clean them with `rm -rf /tmp/showcase-isolate-slots/*`.
+- **Slot directories**: Located at `${XDG_STATE_HOME:-$HOME/.local/state}/copilotkit/showcase/slots/`. Each numbered subdirectory is a claimed slot. Slots from killed processes are auto-reaped on the next isolate run (a slot whose compose project has no live containers is reclaimed); to clean them manually, run `rm -rf "${XDG_STATE_HOME:-$HOME/.local/state}/copilotkit/showcase/slots"/*`.
 
 ## Environment Variables
 

--- a/showcase/DEBUGGING.md
+++ b/showcase/DEBUGGING.md
@@ -300,8 +300,11 @@ subtly different each run.
 ### How it works
 
 1. **`<name>` and slot/offset**: `<name>` names the isolated compose project and
-   must match `[a-z0-9_-]+` (a docker compose project-name constraint; uppercase
-   is lowercased with a warning). Use a distinct name per run. The slot and port
+   must start with a lowercase letter or digit, then lowercase letters, digits,
+   `-` or `_` (`[a-z0-9][a-z0-9_-]*`, a docker compose project-name constraint;
+   uppercase is normalized to lowercase with a warning). The name `showcase` is
+   reserved — it is the default stack's own compose project name, so the CLI
+   refuses it. Use a distinct name per run. The slot and port
    offset are **auto-assigned** — each run atomically claims a slot via `mkdir`
    under `${XDG_STATE_HOME:-$HOME/.local/state}/copilotkit/showcase/slots/N`
    and derives its offset as `(slot + 1) * 200`
@@ -352,14 +355,13 @@ scratch dir. Inspect a kept stack before stopping it; it does not survive a
 reboot. At exit a survival notice
 prints the stack's host ports (aimock, dashboard, PocketBase) plus the manual
 teardown command
-(`docker compose -p <name> down --remove-orphans && rm -rf <run-dir> <slot-dir>`).
-Note that `down --remove-orphans` does not remove named volumes (e.g.
-`<name>_showcase-pb-data`); for a fully clean slate, tear down by project name
-with volumes (or `docker volume rm` the leftovers):
-
-```sh
-docker compose --project-name <name> down --volumes
-```
+(`docker compose -p <name> down --remove-orphans --volumes && rm -rf <run-dir> <slot-dir>`).
+The teardown includes `--volumes`: isolated stacks are ephemeral, so the
+project-scoped named volumes (e.g. `<name>_showcase-pb-data`) are removed along
+with the containers and networks — the same flags the automatic (non-`--keep`)
+teardown uses, so a kept stack leaves nothing behind once torn down. The
+`rm -rf` clears the per-run scratch dir and the slot reservation (the notice
+prints the real paths).
 
 ### Troubleshooting
 

--- a/showcase/RUNBOOK.md
+++ b/showcase/RUNBOOK.md
@@ -163,9 +163,12 @@ bin/showcase test <slug> --d6 --isolate <name>
 
 ### How it works
 
-- **`<name>`**: names the isolated compose project. It must match `[a-z0-9_-]+`
-  (a docker compose project-name constraint; uppercase is lowercased with a
-  warning). Use a distinct name per run so concurrent runs never collide.
+- **`<name>`**: names the isolated compose project. It must start with a
+  lowercase letter or digit, followed by lowercase letters, digits, `-` or `_`
+  (`[a-z0-9][a-z0-9_-]*`, a docker compose project-name constraint); uppercase
+  is normalized to lowercase with a warning. The name `showcase` is reserved —
+  it is the default stack's own compose project name, so the CLI refuses it.
+  Use a distinct name per run so concurrent runs never collide.
 - **Auto-assigned slot and port offset**: each run atomically claims a slot
   (0–45) and derives its port offset as `(slot + 1) * 200` — slot 0 → +200,
   slot 1 → +400, and so on. **Do not assign slots or offsets manually**; the
@@ -213,16 +216,15 @@ stack's host ports (aimock, dashboard, PocketBase) and the manual teardown
 command:
 
 ```sh
-docker compose -p <name> down --remove-orphans && rm -rf <run-dir> <slot-dir>
+docker compose -p <name> down --remove-orphans --volumes && rm -rf <run-dir> <slot-dir>
 ```
 
-Note that `down --remove-orphans` removes containers and networks but NOT named
-volumes (e.g. `<name>_showcase-pb-data`). For a fully clean slate, tear down by
-project name with volumes (or `docker volume rm` the leftovers):
-
-```sh
-docker compose --project-name <name> down --volumes
-```
+The teardown includes `--volumes`: isolated stacks are ephemeral, so the
+project-scoped named volumes (e.g. `<name>_showcase-pb-data`) are removed along
+with the containers and networks — the same flags the automatic (non-`--keep`)
+teardown uses, so a kept stack leaves nothing behind once torn down. The
+`rm -rf` clears the per-run scratch dir and the slot reservation (the notice
+prints the real paths).
 
 If a run was killed with `SIGKILL` (so the trap never fired), the next isolate
 run auto-reaps the dead slot (a slot whose compose project has no live

--- a/showcase/RUNBOOK.md
+++ b/showcase/RUNBOOK.md
@@ -183,9 +183,10 @@ bin/showcase test <slug> --d6 --isolate <name>
   authenticates with no manual setup. (A mismatch here is what previously 400'd
   on pb-auth and left the control-plane enqueuing zero jobs.)
 - **Originals are never modified**: the flag writes offset copies of
-  `docker-compose.local.yml` and `shared/local-ports.json` into
-  `$TMPDIR/showcase-isolate-$$/`. If the process crashes, the originals are
-  untouched.
+  `docker-compose.local.yml` and `shared/local-ports.json` into a per-run
+  scratch dir at
+  `${XDG_STATE_HOME:-$HOME/.local/state}/copilotkit/showcase/runs/<name>/`.
+  If the process crashes, the originals are untouched.
 
 ### Interpreting results
 
@@ -196,28 +197,39 @@ from the shared stack or production for that pill.
 
 ### Cleanup
 
-An isolated run tears its stack down on exit (via `trap EXIT`) and frees its
-slot automatically — the normal, no-cleanup-needed case. Each fresh run gets a
-clean PocketBase volume, which is what makes pb-auth deterministic.
+By default an isolated run tears its stack down on exit (via `trap EXIT`) and
+frees its slot automatically — the normal, no-cleanup-needed case. Each fresh
+run gets a clean PocketBase volume, which is what makes pb-auth deterministic.
 
-To leave the stack up for inspection after the run, start it explicitly with
-`bin/showcase up` under your own compose project name instead of relying on a
-test run's transient stack (the test path always tears its own stack down). The
-`--keep` flag governs harness-started packages on the non-isolate path; it does
-not override the isolated teardown trap.
+To leave the stack up for inspection after the run, pass `--keep`: the isolated
+stack survives the run (success or failure), and the run dir and slot are
+preserved — the live containers keep the slot from being reaped. That
+protection lasts only while the containers are RUNNING: if they stop (manual
+`docker stop`, a daemon restart, a host reboot), the next isolate run's sweep
+reclaims the slot — composing the stopped containers and named volumes down and
+removing the run dir. Inspect a kept stack before stopping it, and don't expect
+it to survive a reboot. At exit the CLI prints a survival notice with the
+stack's host ports (aimock, dashboard, PocketBase) and the manual teardown
+command:
 
-When you're done inspecting a manually-kept stack, tear down its containers and
-volumes by project name:
+```sh
+docker compose -p <name> down --remove-orphans && rm -rf <run-dir> <slot-dir>
+```
+
+Note that `down --remove-orphans` removes containers and networks but NOT named
+volumes (e.g. `<name>_showcase-pb-data`). For a fully clean slate, tear down by
+project name with volumes (or `docker volume rm` the leftovers):
 
 ```sh
 docker compose --project-name <name> down --volumes
 ```
 
-If a run was killed with `SIGKILL` (so the trap never fired), clean up the slot
-reservations manually:
+If a run was killed with `SIGKILL` (so the trap never fired), the next isolate
+run auto-reaps the dead slot (a slot whose compose project has no live
+containers is reclaimed). To clean up the slot reservations manually:
 
 ```sh
-rm -rf /tmp/showcase-isolate-slots/*
+rm -rf "${XDG_STATE_HOME:-$HOME/.local/state}/copilotkit/showcase/slots"/*
 ```
 
 - **Stale `.iso-bak` files**: if you see `docker-compose.local.yml.iso-bak` or

--- a/showcase/scripts/__tests__/isolate.bats
+++ b/showcase/scripts/__tests__/isolate.bats
@@ -10,22 +10,59 @@
 #   2. Stale slots are reaped by compose-project liveness: a slot whose recorded
 #      project has no live containers is reclaimed; one with a live container is
 #      left alone (so a --keep'd stack is never stolen out from under).
-#   3. restore_isolation honors --keep: when keep is set it does NOT compose-down,
-#      does NOT remove the run dir, does NOT release the slot, and prints a
-#      survival notice (project, slot, the three +offset host ports, and the exact
-#      teardown command).
+#   3. restore_isolation honors --keep: when ISOLATE_KEEP is set it does NOT
+#      compose-down, does NOT remove the run dir, does NOT release the slot, and
+#      prints a survival notice (project, slot, the three +offset host ports, and
+#      the exact teardown command). ISOLATE_KEEP must be a GLOBAL that survives
+#      cmd_test returning — the EXIT trap fires at top-level exit, where a
+#      function-local flag has already unwound.
 #
-# NB on assertion gating: bats does NOT run test bodies under `set -e` (errexit).
-# Only the FINAL command's exit status decides pass/fail — a non-zero command on
-# an earlier line does NOT abort the test. So a bare `[[ ... ]]` on a non-final
-# line is a silent no-op. Every substantive / non-final assertion MUST be written
-# `[[ ... ]] || fail "message"` so the check actually forces a hard failure (and
-# supplies a diagnostic). Dropping the `|| fail` turns it into a false-green.
+# NB on assertion style: bats-core runs test bodies with errexit semantics
+# (`set -eET` plus an ERR trap), so a bare `[[ ... ]]` that fails DOES fail the
+# test — even on a non-final line. We still write assertions as
+# `[[ ... ]] || fail "message"` for the diagnostic message on failure, and for
+# robustness in contexts where errexit is suppressed (e.g. inside && / ||
+# chains or condition positions).
 
-# fail <msg> — print the message to the bats failure stream and abort the test.
+# fail <msg> — print the message and abort the test. The message goes to
+# STDOUT: bats reliably displays a failed test's stdout, but not its stderr.
 fail() {
-  echo "$1" >&2
+  echo "$1"
   return 1
+}
+
+# require_python3 — skip tests that drive apply_isolation through its real
+# python3 ports/compose rewriters; without this, a python3-less machine fails
+# those tests with a bare "command not found" instead of a clear skip.
+require_python3() {
+  command -v python3 >/dev/null 2>&1 || skip "python3 required (apply_isolation rewrites ports/compose files with it)"
+}
+
+# _touch_age <seconds-ago> <path> — backdate a path's mtime portably. BSD
+# touch has no GNU-style `-d '-N seconds'`; compute the absolute `-t` stamp
+# with python3 instead (callers must require_python3). DST-safe: the stamp is
+# computed in UTC (time.gmtime) and interpreted in UTC (TZ=UTC for touch) —
+# a localtime stamp straddling a DST transition would be off by an hour (or
+# land in a nonexistent/ambiguous wall-clock time).
+_touch_age() {
+  local stamp
+  stamp="$(python3 -c "import time; print(time.strftime('%Y%m%d%H%M.%S', time.gmtime(time.time() - $1)))")"
+  TZ=UTC touch -t "$stamp" "$2"
+}
+
+# _assert_stub_sentinel_logged — prove the docker-stub→DOCKER_LOG pipeline is
+# alive before drawing any conclusion from the log's contents. Several tests
+# assert the ABSENCE of compose-down lines; without this sentinel, a silently
+# broken pipeline (DOCKER_LOG unset/unwritable in the child, an export
+# regression, the stub falling off PATH) makes those absence checks pass
+# vacuously — "no evidence of wrongdoing" instead of "verified right-doing".
+# Each caller runs `docker version` before the code under test (and after any
+# log truncation); this asserts that invocation actually landed in the log.
+_assert_stub_sentinel_logged() {
+  [ -f "$DOCKER_LOG" ] \
+    || fail "docker stub log missing — stub/DOCKER_LOG pipeline broken, absence assertions would be vacuous"
+  grep -qx "version" "$DOCKER_LOG" \
+    || fail "sentinel 'docker version' invocation not logged — stub/DOCKER_LOG pipeline broken: $(cat "$DOCKER_LOG")"
 }
 
 setup() {
@@ -35,20 +72,50 @@ setup() {
   # apply_isolation runs `$COMPOSE_CMD down` and the reaper runs
   # `docker ps -q --filter ...`. Both must be stubbed so no real docker is hit.
   # The `ps` behavior is driven by $DOCKER_PS_OUTPUT so individual tests can make
-  # a project look live (non-empty) or dead (empty).
+  # a project look live (non-empty) or dead (empty), and by $DOCKER_PS_EXIT so
+  # tests can simulate a docker daemon failure (non-zero exit, no output).
+  # `compose ... down` failure is driven by $DOCKER_COMPOSE_DOWN_EXIT so tests
+  # can simulate a teardown that leaves the stack standing.
   STUB_DIR="$BATS_TEST_TMPDIR/stub"
   mkdir -p "$STUB_DIR"
   cat > "$STUB_DIR/docker" <<'STUB'
 #!/usr/bin/env bash
+# Record every invocation so tests can assert on WHICH compose commands ran
+# (e.g. that a failed --isolate never composes down the default stack).
+printf '%s\n' "$*" >> "${DOCKER_LOG:-/dev/null}"
 case "$1" in
-  ps)      printf '%s' "${DOCKER_PS_OUTPUT:-}"; [ -z "${DOCKER_PS_OUTPUT:-}" ] || echo ;;
-  compose) : ;;  # swallow `docker compose ... down` etc.
+  ps)
+    [ "${DOCKER_PS_EXIT:-0}" -eq 0 ] || exit "${DOCKER_PS_EXIT}"
+    printf '%s' "${DOCKER_PS_OUTPUT:-}"; [ -z "${DOCKER_PS_OUTPUT:-}" ] || echo ;;
+  compose)
+    # Ordering probe: when REAP_ORDER_CHECK_DIR is set, snapshot whether that
+    # dir still exists at the moment a compose-down is invoked. Lets tests pin
+    # "compose-down runs BEFORE state deletion" (the reap's split-brain
+    # guarantee) instead of only "compose-down ran at some point".
+    if [[ " $* " == *" down "* ]] && [ -n "${REAP_ORDER_CHECK_DIR:-}" ]; then
+      if [ -d "$REAP_ORDER_CHECK_DIR" ]; then
+        echo "REAP_ORDER_CHECK dir-present" >> "${DOCKER_LOG:-/dev/null}"
+      else
+        echo "REAP_ORDER_CHECK dir-absent" >> "${DOCKER_LOG:-/dev/null}"
+      fi
+    fi
+    # Match `down` as a discrete word: a bare *" down"* substring also matches
+    # the PROJECT NAME in `--project-name downfail`, silently failing commands
+    # that never ran `down` at all. Space-padding "$*" makes the word check
+    # exact whether `down` is interior or the final argument.
+    if [[ " $* " == *" down "* ]] && [ "${DOCKER_COMPOSE_DOWN_EXIT:-0}" -ne 0 ]; then
+      echo "stub: compose down failed" >&2
+      exit "${DOCKER_COMPOSE_DOWN_EXIT}"
+    fi ;;  # otherwise swallow `docker compose ...` quietly
   *)       : ;;
 esac
 exit 0
 STUB
   chmod +x "$STUB_DIR/docker"
   PATH="$STUB_DIR:$PATH"
+
+  # Invocation log for the docker stub (one line per call, "$*"-joined args).
+  export DOCKER_LOG="$BATS_TEST_TMPDIR/docker-invocations.log"
 
   # ── Fake SHOWCASE_ROOT with the two files apply_isolation rewrites ──────────
   export SHOWCASE_ROOT_OVERRIDE="$BATS_TEST_TMPDIR/root"
@@ -69,8 +136,11 @@ YML
   # ── XDG state base ─────────────────────────────────────────────────────────
   export XDG_STATE_HOME="$BATS_TEST_TMPDIR/xdg"
 
-  # Default: dead project (no live containers) unless a test overrides it.
+  # Default: dead project (no live containers), healthy docker daemon, compose
+  # down succeeds, unless a test overrides them.
   export DOCKER_PS_OUTPUT=""
+  export DOCKER_PS_EXIT=0
+  export DOCKER_COMPOSE_DOWN_EXIT=0
 }
 
 # load_common — source _common.sh, then repoint the path vars at the fake root.
@@ -91,10 +161,8 @@ load_common() {
   load_common
   [[ "$ISOLATE_SLOT_DIR" == "$XDG_STATE_HOME/copilotkit/showcase/slots" ]] \
     || fail "ISOLATE_SLOT_DIR not under XDG_STATE_HOME: $ISOLATE_SLOT_DIR"
-  # Must NOT be the old hardcoded /tmp registry path (XDG_STATE_HOME itself may
-  # live under /tmp in the bats sandbox, so we pin the exact retired path).
-  [[ "$ISOLATE_SLOT_DIR" != "/tmp/showcase-isolate-slots" ]] \
-    || fail "ISOLATE_SLOT_DIR still the old /tmp registry: $ISOLATE_SLOT_DIR"
+  # (Regression note: the pre-XDG registry lived at /tmp/showcase-isolate-slots;
+  # the exact-path equality above already rules that out.)
 }
 
 @test "state base falls back to \$HOME/.local/state when XDG_STATE_HOME unset" {
@@ -108,21 +176,25 @@ load_common() {
 }
 
 @test "per-run dir lives under XDG state runs/<name>, not /tmp" {
+  require_python3
   load_common
   apply_isolation foo
   [[ "$ISOLATE_TMPDIR" == "$XDG_STATE_HOME/copilotkit/showcase/runs/foo" ]] \
     || fail "run dir not under XDG state runs/<name>: $ISOLATE_TMPDIR"
-  # Must NOT be the old PID-keyed /tmp scratch dir.
-  [[ "$ISOLATE_TMPDIR" != "${TMPDIR:-/tmp}/showcase-isolate-"* ]] \
-    || fail "run dir still the old /tmp PID scratch dir: $ISOLATE_TMPDIR"
+  # (Regression note: the pre-XDG scratch dir was the PID-keyed
+  # ${TMPDIR:-/tmp}/showcase-isolate-<pid>; the exact-path equality above
+  # already rules that out.)
   [ -d "$ISOLATE_TMPDIR" ] || fail "run dir not created: $ISOLATE_TMPDIR"
 }
 
 # ── Change 2: stale-slot reaping by compose-project liveness ─────────────────
 
-@test "claim reaps a slot whose project has no live containers" {
+@test "claim reaps a slot whose project has no live containers and no live owning PID" {
   load_common
-  # Pre-seed slot 0 for a project with NO live containers (DOCKER_PS_OUTPUT="").
+  # Pre-seed slot 0 for a project with NO live containers (DOCKER_PS_OUTPUT="")
+  # and NO pid file (so there is no live owning PID to protect it either —
+  # under the three-signal order, the ABSENCE of live containers alone is not
+  # enough to reap while the owning process is still alive).
   mkdir -p "$XDG_STATE_HOME/copilotkit/showcase/slots/0"
   echo "ghost-proj" > "$XDG_STATE_HOME/copilotkit/showcase/slots/0/project"
 
@@ -130,9 +202,12 @@ load_common() {
   _claim_isolate_slot
   # The dead slot 0 is reaped and reclaimed by this run.
   [ "$ISOLATE_SLOT" = "0" ] || fail "expected to reclaim reaped slot 0, got: $ISOLATE_SLOT"
-  # The new claim recorded ITS own project, not the ghost.
-  run cat "$XDG_STATE_HOME/copilotkit/showcase/slots/0/project"
-  [[ "$output" != "ghost-proj" ]] || fail "ghost project not overwritten on reclaim"
+  # The reap rm -rf'd the ghost slot dir: only apply_isolation (not the claim)
+  # writes a project file, so after a genuine reap+reclaim the ghost project
+  # file must be GONE. (A `run cat`+`!= ghost-proj` check here would pass
+  # vacuously on empty output even if the reap never happened.)
+  [ ! -f "$XDG_STATE_HOME/copilotkit/showcase/slots/0/project" ] \
+    || fail "ghost project file survived the reap"
 }
 
 @test "claim does NOT reap a slot whose project has a live container" {
@@ -147,22 +222,462 @@ load_common() {
   # Slot 0 and its project file survive untouched.
   [ -d "$XDG_STATE_HOME/copilotkit/showcase/slots/0" ] || fail "live slot 0 was wrongly reaped"
   run cat "$XDG_STATE_HOME/copilotkit/showcase/slots/0/project"
+  [ "$status" -eq 0 ] || fail "live slot 0 project file missing"
   [[ "$output" == "live-proj" ]] || fail "live slot 0 project mangled: $output"
 }
 
 @test "slot claim persists the project name alongside the pid file" {
+  require_python3
   load_common
   apply_isolation myproj
   local slotdir="$ISOLATE_SLOT_DIR/$ISOLATE_SLOT"
   [ -f "$slotdir/project" ] || fail "no project file written for claimed slot"
   run cat "$slotdir/project"
+  [ "$status" -eq 0 ] || fail "project file unreadable"
   [[ "$output" == "myproj" ]] || fail "wrong project recorded: $output"
   [ -f "$slotdir/pid" ] || fail "pid file no longer written"
+}
+
+@test "claim does NOT reap a project-recorded slot with zero containers but a LIVE owning PID" {
+  # The claim/start race: apply_isolation writes the project file minutes before
+  # any container exists (image builds happen later). Zero live containers must
+  # NOT be authoritative while the owning process is still alive.
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "racer-proj" > "$slots/0/project"
+  echo "$$" > "$slots/0/pid"   # this bats process — definitely alive
+
+  export DOCKER_PS_OUTPUT=""   # no containers yet (still building)
+  _claim_isolate_slot
+  [ "$ISOLATE_SLOT" = "1" ] || fail "live-owner slot 0 was stolen; claimed: $ISOLATE_SLOT"
+  [ -d "$slots/0" ] || fail "live-owner slot 0 was reaped"
+  run cat "$slots/0/project"
+  [ "$status" -eq 0 ] || fail "slot 0 project file missing after sweep"
+  [[ "$output" == "racer-proj" ]] || fail "slot 0 project mangled: $output"
+}
+
+@test "claim leaves a project-recorded slot alone when docker ps fails" {
+  # A docker daemon failure must read as "cannot verify", never as "no
+  # containers" — otherwise a daemon hiccup mass-reaps live slots.
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "unknowable-proj" > "$slots/0/project"
+
+  export DOCKER_PS_EXIT=1
+  _claim_isolate_slot
+  [ "$ISOLATE_SLOT" = "1" ] || fail "unverifiable slot 0 was claimed: $ISOLATE_SLOT"
+  [ -d "$slots/0" ] || fail "slot 0 reaped despite docker ps failure"
+  run cat "$slots/0/project"
+  [ "$status" -eq 0 ] || fail "slot 0 project file missing after sweep"
+  [[ "$output" == "unknowable-proj" ]] || fail "slot 0 project mangled: $output"
+}
+
+@test "legacy slot without project file survives set -e and is reaped via dead-PID fallback" {
+  # bin/showcase runs `set -euo pipefail` and sources _common.sh; a slot dir
+  # with no project file must not kill the script (cat exits 1), and the
+  # documented PID fallback must actually reap it.
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"   # legacy: NO project file
+  bash -c 'exit 0' &
+  local dead_pid=$!
+  wait "$dead_pid" || true
+  # PID-reuse guard: the fixture's premise is a DEAD owning pid; if the OS
+  # recycled it to a live process between wait and the sweep, skip rather than
+  # flake.
+  if kill -0 "$dead_pid" 2>/dev/null; then
+    skip "PID $dead_pid was recycled to a live process — dead-PID fixture invalid"
+  fi
+  echo "$dead_pid" > "$slots/0/pid"
+
+  run bash -euo pipefail -c "source '$COMMON'; _claim_isolate_slot; echo \"CLAIMED=\$ISOLATE_SLOT\""
+  [ "$status" -eq 0 ] || fail "script died under set -euo pipefail on legacy slot: $output"
+  [[ "$output" == *"CLAIMED=0"* ]] || fail "dead legacy slot 0 not reaped/reclaimed: $output"
+}
+
+@test "claim does NOT reap a kept-stack slot (owner dead, containers live)" {
+  # --keep leaves the stack standing after the owning process exits; container
+  # liveness alone must keep protecting the slot.
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "keeper-proj" > "$slots/0/project"
+  bash -c 'exit 0' &
+  local dead_pid=$!
+  wait "$dead_pid" || true
+  # PID-reuse guard (see the legacy-slot test above): a recycled live pid
+  # would invalidate the dead-owner premise.
+  if kill -0 "$dead_pid" 2>/dev/null; then
+    skip "PID $dead_pid was recycled to a live process — dead-PID fixture invalid"
+  fi
+  echo "$dead_pid" > "$slots/0/pid"
+
+  export DOCKER_PS_OUTPUT="abc123def456"   # containers still up
+  _claim_isolate_slot
+  [ "$ISOLATE_SLOT" = "1" ] || fail "kept-stack slot 0 was stolen: $ISOLATE_SLOT"
+  [ -d "$slots/0" ] || fail "kept-stack slot 0 was reaped"
+  run cat "$slots/0/project"
+  [ "$status" -eq 0 ] || fail "kept-stack project file missing after sweep"
+  [[ "$output" == "keeper-proj" ]] || fail "kept-stack project mangled: $output"
+}
+
+@test "claim reaps an over-age legacy slot whose pid file is empty (inconclusive)" {
+  # An empty/garbage pid file used to dodge BOTH the pid check and the
+  # `[ ! -f pid ]`-gated age fallback, leaking the slot forever.
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"   # legacy: no project file
+  : > "$slots/0/pid"    # empty pid file → pid check inconclusive
+  touch -t 202001010000 "$slots/0"   # mtime far beyond the 2h threshold
+
+  _claim_isolate_slot
+  [ "$ISOLATE_SLOT" = "0" ] || fail "empty-pid over-age slot 0 leaked; claimed: $ISOLATE_SLOT"
+}
+
+@test "claim does NOT reap a RECENT project-recorded slot whose pid file is garbage (inconclusive)" {
+  # Truncated-pid-write race: a live owner mid-build (project recorded, zero
+  # containers yet) whose pid file write was truncated/corrupted must NOT lose
+  # its slot — "no live owner" was never actually verified. An unreadable/
+  # empty/non-numeric pid is INCONCLUSIVE and must fall through to the age
+  # fallback; a RECENT slot therefore survives the sweep.
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "truncated-proj" > "$slots/0/project"
+  echo "not-a-pid" > "$slots/0/pid"   # garbage contents — pid check inconclusive
+
+  export DOCKER_PS_OUTPUT=""   # zero containers (still building)
+  _claim_isolate_slot
+  [ "$ISOLATE_SLOT" = "1" ] || fail "inconclusive-pid slot 0 was stolen; claimed: $ISOLATE_SLOT"
+  [ -d "$slots/0" ] || fail "inconclusive-pid slot 0 was reaped"
+  run cat "$slots/0/project"
+  [ "$status" -eq 0 ] || fail "slot 0 project file missing after sweep"
+  [[ "$output" == "truncated-proj" ]] || fail "slot 0 project mangled: $output"
+}
+
+@test "claim reaps an OVER-AGE project-recorded slot whose pid file is garbage via the age fallback" {
+  # Companion to the test above: inconclusive-pid slots are not protected
+  # FOREVER — the age fallback still reclaims them (and their runs/<project>
+  # scratch dir) once they exceed ISOLATE_STALE_THRESHOLD.
+  load_common
+  local base="$XDG_STATE_HOME/copilotkit/showcase"
+  local slots="$base/slots"
+  mkdir -p "$slots/0"
+  echo "truncated-proj" > "$slots/0/project"
+  echo "not-a-pid" > "$slots/0/pid"
+  mkdir -p "$base/runs/truncated-proj"
+  touch -t 202001010000 "$slots/0"   # mtime far beyond the 2h threshold
+
+  export DOCKER_PS_OUTPUT=""
+  _claim_isolate_slot
+  [ "$ISOLATE_SLOT" = "0" ] || fail "over-age inconclusive-pid slot 0 leaked; claimed: $ISOLATE_SLOT"
+  [ ! -f "$slots/0/project" ] || fail "ghost project record survived the age-fallback reap"
+  [ ! -d "$base/runs/truncated-proj" ] || fail "orphan run dir leaked: $base/runs/truncated-proj"
+}
+
+@test "reaping a dead slot also removes its runs/<project> scratch dir" {
+  # Orphan-leak regression: the sweep used to remove only the slot dir; the
+  # crashed run's runs/<project> scratch dir was cleaned by NOTHING (the owner
+  # is dead, and restore_isolation only removes the CURRENT run's dir), so
+  # orphans accumulated under XDG state forever.
+  load_common
+  local base="$XDG_STATE_HOME/copilotkit/showcase"
+  mkdir -p "$base/slots/0"
+  echo "ghost-proj" > "$base/slots/0/project"   # dead project, no pid file
+  mkdir -p "$base/runs/ghost-proj"
+  touch "$base/runs/ghost-proj/docker-compose.local.yml"
+
+  export DOCKER_PS_OUTPUT=""   # no live containers → project-stale reap
+  _claim_isolate_slot
+  [ "$ISOLATE_SLOT" = "0" ] || fail "expected to reclaim reaped slot 0, got: $ISOLATE_SLOT"
+  [ ! -f "$base/slots/0/project" ] || fail "ghost slot 0 was not reaped"
+  [ ! -d "$base/runs/ghost-proj" ] || fail "orphan run dir leaked: $base/runs/ghost-proj"
+  # The sweep released its own lock on the way out.
+  [ ! -d "$base/slots/.sweep.lock" ] || fail "sweep lock left behind after a normal sweep"
+}
+
+@test "reaping a dead slot composes the project down before deleting its state" {
+  # Stopped-but-present remnants: container-liveness protection is RUNNING
+  # containers only (docker ps -q). A --keep'd stack whose containers were
+  # stopped (manual docker stop, daemon restart, host reboot) reaches the reap
+  # with stopped containers and named volumes still present — deleting the run
+  # dir + slot while those remain would strand them with no compose state
+  # (split-brain). The reap must therefore attempt a best-effort, project-
+  # labeled compose-down FIRST.
+  load_common
+  local base="$XDG_STATE_HOME/copilotkit/showcase"
+  mkdir -p "$base/slots/0"
+  echo "stopped-keeper" > "$base/slots/0/project"   # validated record, no pid file
+  mkdir -p "$base/runs/stopped-keeper"
+
+  export DOCKER_PS_OUTPUT=""   # containers stopped → no RUNNING ones → reap path
+  # Ordering probe (see the stub): snapshot the runs dir's existence at
+  # compose-down time, so "down BEFORE state deletion" is pinned directly.
+  export REAP_ORDER_CHECK_DIR="$base/runs/stopped-keeper"
+  : > "$DOCKER_LOG"
+  docker version
+  _claim_isolate_slot
+  [ "$ISOLATE_SLOT" = "0" ] || fail "expected to reclaim reaped slot 0, got: $ISOLATE_SLOT"
+  [ ! -f "$base/slots/0/project" ] || fail "ghost project record survived the reap"
+  [ ! -d "$base/runs/stopped-keeper" ] || fail "runs dir survived the reap"
+  # The remnant cleanup ran: a project-labeled compose down carrying --volumes.
+  _assert_stub_sentinel_logged
+  run grep -E -- "compose -p stopped-keeper down --remove-orphans --volumes" "$DOCKER_LOG"
+  [ "$status" -eq 0 ] \
+    || fail "reap did not compose the dead project down: $(cat "$DOCKER_LOG")"
+  # …and it ran BEFORE the state deletion: the runs dir still existed when the
+  # down was invoked (deleting state first would strand stopped containers /
+  # named volumes with no compose state — the split-brain the order prevents).
+  run grep -qx -- "REAP_ORDER_CHECK dir-present" "$DOCKER_LOG"
+  [ "$status" -eq 0 ] \
+    || fail "compose-down ran AFTER the runs dir was deleted (reap order regression): $(cat "$DOCKER_LOG")"
+}
+
+@test "a slot whose project record fails the traversal guard is left intact for inspection" {
+  # Path-traversal guard vs. orphaning: a corrupted/tampered project record
+  # (e.g. "../..") must never be interpolated into rm -rf — but the OLD code
+  # still rm -rf'd the SLOT dir, destroying the only pointer to whatever runs
+  # dir the record names. The guard now leaves the whole slot in place for
+  # manual inspection instead of half-destroying the evidence.
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  printf '%s\n' '../evil' > "$slots/0/project"   # fails [a-z0-9][a-z0-9_-]*
+
+  export DOCKER_PS_OUTPUT=""   # no live containers, no pid file → reap path
+  _claim_isolate_slot
+  # The suspicious slot survives — with its record — and the claim moves on.
+  [ "$ISOLATE_SLOT" = "1" ] || fail "expected slot 1 (suspicious slot 0 preserved), got: $ISOLATE_SLOT"
+  [ -d "$slots/0" ] || fail "suspicious slot 0 was reaped (record/evidence destroyed)"
+  run cat "$slots/0/project"
+  [ "$status" -eq 0 ] || fail "suspicious slot 0 record removed"
+  [[ "$output" == "../evil" ]] || fail "suspicious record mangled: $output"
+}
+
+@test "a fresh pre-existing .sweep.lock skips the sweep; claiming still succeeds" {
+  # TOCTOU sweep/claim race: two concurrent claimants could both observe slot 0
+  # stale — A reaps + re-claims it, then B reaps A's FRESH claim and claims the
+  # same slot (two owners, identical port offsets). The sweep is serialized by
+  # a .sweep.lock dir; a held (fresh) lock means another process is already
+  # sweeping, so this claimant must SKIP the sweep — the stale-looking slot
+  # survives — and proceed straight to claiming a free slot.
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "ghost-proj" > "$slots/0/project"   # stale-looking: dead project, no pid
+  mkdir -p "$slots/.sweep.lock"            # fresh lock — sweeper "active"
+
+  export DOCKER_PS_OUTPUT=""
+  _claim_isolate_slot
+  # Sweep skipped: the stale-looking slot 0 survives untouched…
+  [ -d "$slots/0" ] || fail "sweep ran despite a held .sweep.lock"
+  run cat "$slots/0/project"
+  [ "$status" -eq 0 ] || fail "slot 0 project file missing after skipped sweep"
+  [[ "$output" == "ghost-proj" ]] || fail "slot 0 project mangled: $output"
+  # …and the claim proceeds to the next free slot (lock name never collides
+  # with the numeric claim loop).
+  [ "$ISOLATE_SLOT" = "1" ] || fail "expected slot 1 with sweep skipped, got: $ISOLATE_SLOT"
+  # The foreign sweeper's fresh lock is not ours to remove.
+  [ -d "$slots/.sweep.lock" ] || fail "foreign (fresh) sweep lock was removed"
+}
+
+@test "an over-age .sweep.lock is taken over and the sweep proceeds" {
+  # Crashed-sweeper recovery, with the DEDICATED lock threshold: the lock is
+  # held for seconds, so a leftover lock aged ~10 minutes must be taken over —
+  # under the old code the lock reused the 2-hour SLOT threshold
+  # (ISOLATE_STALE_THRESHOLD), so a crashed sweeper disabled stale reaping for
+  # 2 hours. The takeover is an atomic mv-to-tombstone (only one of two racing
+  # observers can win the rename), so no tombstone may leak either. The
+  # companion guarantee — a FRESH lock is NOT taken over — is pinned by the
+  # "fresh pre-existing .sweep.lock skips the sweep" test above.
+  require_python3   # _touch_age computes the backdated stamp with python3
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "ghost-proj" > "$slots/0/project"   # dead project, no pid file
+  mkdir -p "$slots/.sweep.lock"
+  _touch_age 600 "$slots/.sweep.lock"      # >60s lock threshold, <<2h slot threshold
+
+  export DOCKER_PS_OUTPUT=""
+  _claim_isolate_slot
+  # Takeover happened → the sweep ran → the dead slot 0 was reaped + reclaimed.
+  [ "$ISOLATE_SLOT" = "0" ] \
+    || fail "over-age sweep lock not taken over (sweep skipped); claimed: $ISOLATE_SLOT"
+  [ ! -f "$slots/0/project" ] \
+    || fail "ghost project record survived — sweep did not run after the takeover"
+  # The winner's fresh lock was released on the way out, and no tombstone leaked.
+  [ ! -d "$slots/.sweep.lock" ] || fail "sweep lock left behind after takeover sweep"
+  run bash -c "ls -A '$slots' | grep -F '.sweep.lock.tomb'"
+  [ "$status" -ne 0 ] || fail "takeover tombstone leaked: $output"
+}
+
+@test "sweep-lock release is own-lock-aware: a taken-over lock is left in place" {
+  # Takeover/release race: if a slow sweeper's lock is taken over (heartbeat
+  # stalled — e.g. a wedged docker daemon pushed it over-age), the ORIGINAL
+  # holder's release must not remove the TAKEOVER's fresh lock — that would
+  # open the door to a THIRD concurrent sweeper. Ownership is the pid file
+  # written into the lock dir at acquisition; release only removes a lock
+  # that still carries OUR pid. Tested via direct invocation of the release
+  # helper (pausing a real sweep mid-flight is not deterministic in bats).
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  local lock="$slots/.sweep.lock"
+
+  # Simulate the takeover: the lock exists but carries a DIFFERENT holder's
+  # pid (the takeover rewrote it). PID 1 is never this test process.
+  mkdir -p "$lock"
+  echo "1" > "$lock/pid"
+  run _release_sweep_lock "$lock"
+  [ "$status" -eq 0 ] || fail "_release_sweep_lock failed on a foreign lock: $output"
+  [ -d "$lock" ] || fail "release removed a lock owned by ANOTHER holder (takeover's lock destroyed)"
+  [[ "$output" == *"taken over"* ]] || fail "no takeover warning printed: $output"
+
+  # Control: a lock carrying OUR pid IS removed on release.
+  echo "$$" > "$lock/pid"
+  run _release_sweep_lock "$lock"
+  [ "$status" -eq 0 ] || fail "_release_sweep_lock failed on our own lock: $output"
+  [ ! -d "$lock" ] || fail "release left our own lock behind"
+}
+
+@test "an over-age takeover tombstone is reclaimed on the next claim; a fresh one survives" {
+  # Crashed-takeover recovery: a sweeper that died between the takeover mv and
+  # its rm -rf leaves .sweep.lock.tomb.<pid> behind — dot-named, invisible to
+  # every glob, cleaned by nothing. The claim path must reclaim tombstones
+  # older than the LOCK threshold, while leaving a FRESH tombstone alone (it
+  # may belong to a takeover in flight: mv done, rm pending).
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/.sweep.lock.tomb.11111"
+  touch -t 202001010000 "$slots/.sweep.lock.tomb.11111"   # far over the 60s lock threshold
+  mkdir -p "$slots/.sweep.lock.tomb.22222"                # fresh — takeover may be in flight
+
+  _claim_isolate_slot
+  [ ! -d "$slots/.sweep.lock.tomb.11111" ] || fail "over-age tombstone leaked"
+  [ -d "$slots/.sweep.lock.tomb.22222" ] || fail "fresh (possibly in-flight) tombstone was removed"
+}
+
+@test "sweep heartbeat never recreates a removed sweep lock (no plain-file resurrection)" {
+  # Takeover/heartbeat race: the lock can be mv'd away (taken over) between
+  # heartbeats. The OLD heartbeat (bare `touch "$sweep_lock"`) then RECREATED
+  # the lock as a plain FILE — the takeover's `mkdir` failed against it and
+  # sweeping wedged until the 60s over-age self-heal. The heartbeat must
+  # refresh-only (touch -c behind a -d guard), never create. Direct
+  # invocation: run the sweep with the lock already gone — exactly the
+  # post-takeover view inside an iteration — and pin that no lock (file OR
+  # dir) materializes.
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"                      # one slot so the loop body (heartbeat) runs
+  echo "ghost-proj" > "$slots/0/project"
+  export DOCKER_PS_OUTPUT=""
+  _sweep_isolate_slots
+  [ ! -e "$slots/.sweep.lock" ] \
+    || fail "heartbeat recreated the removed sweep lock: $(ls -ld "$slots/.sweep.lock")"
+}
+
+@test "an over-age PLAIN-FILE .sweep.lock (old heartbeat artifact) is taken over; claiming proceeds" {
+  # Forward-compat with the old bug's residue: a pre-fix heartbeat could leave
+  # the lock behind as a plain FILE. mkdir fails against it just like against
+  # a dir, so it must flow through the same over-age takeover (mv works on
+  # files too) instead of wedging the sweep/claim forever.
+  require_python3   # _touch_age computes the backdated stamp with python3
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "ghost-proj" > "$slots/0/project"   # dead project, no pid file
+  : > "$slots/.sweep.lock"                 # plain FILE, not a dir
+  _touch_age 600 "$slots/.sweep.lock"      # over the 60s lock threshold
+  export DOCKER_PS_OUTPUT=""
+  _claim_isolate_slot
+  # Takeover + sweep ran: the dead slot 0 was reaped and reclaimed.
+  [ "$ISOLATE_SLOT" = "0" ] || fail "plain-file lock wedged the sweep; claimed: $ISOLATE_SLOT"
+  # And nothing lock-shaped was left behind (takeover's own lock released).
+  [ ! -e "$slots/.sweep.lock" ] || fail "stale plain-file lock (or its takeover) left behind"
+  # No takeover tombstone leaked either (same guarantee the dir-lock variant
+  # pins: the winner disposes of the mv'd-aside tombstone).
+  run bash -c "ls -A '$slots' | grep -F '.sweep.lock.tomb'"
+  [ "$status" -ne 0 ] || fail "takeover tombstone leaked: $output"
+}
+
+@test "claim survives an over-age tombstone whose removal fails (set -e safety)" {
+  # The tombstone reclamation runs OUTSIDE the sweep lock by design, so two
+  # claimants can race the same rm: both observe the tombstone over-age, one
+  # wins, and the loser's mid-traversal ENOENT makes its rm exit nonzero —
+  # under bin/showcase's `set -euo pipefail` that used to kill the whole CLI.
+  # The race itself isn't deterministically reproducible in bats; an
+  # unremovable tombstone (non-writable dir with contents) forces the same
+  # nonzero rm exit deterministically.
+  #
+  # Root caveat: as root, `chmod a-w` does not block rm — the tombstone is
+  # removed anyway, the failure can't be forced, and the cleanup chmod below
+  # would then ERROR on the vanished path under bats errexit. Skip as root.
+  [ "$(id -u)" -ne 0 ] || skip "rm -rf succeeds as root — cannot force the tombstone rm failure"
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/.sweep.lock.tomb.99999/inner"
+  touch -t 202001010000 "$slots/.sweep.lock.tomb.99999"   # far over the 60s threshold
+  chmod a-w "$slots/.sweep.lock.tomb.99999"               # rm -rf cannot unlink 'inner'
+  run bash -euo pipefail -c "source '$COMMON'; _claim_isolate_slot; echo \"CLAIMED=\$ISOLATE_SLOT\""
+  # Let bats teardown clean up; guarded — the tombstone may be gone if rm
+  # unexpectedly succeeded, and a chmod error here must not mask the real
+  # assertions below.
+  chmod u+w "$slots/.sweep.lock.tomb.99999" 2>/dev/null || true
+  [ "$status" -eq 0 ] || fail "claim died under set -e on a failed tombstone rm: $output"
+  [[ "$output" == *"CLAIMED=0"* ]] \
+    || fail "claim did not proceed past the failed tombstone rm: $output"
+}
+
+@test "takeover survives a failed tombstone disposal (set -e safety) and still sweeps" {
+  # The takeover winner's `rm -rf $lock_tombstone` is ACTIVELY raced: mv
+  # preserves the (already over-age) lock mtime, so the fresh tombstone is
+  # immediately over-age and concurrent claimants' tombstone-reclamation
+  # loops legitimately race its removal — the loser's nonzero rm must not
+  # kill the CLI under bin/showcase's `set -euo pipefail`. As in the
+  # tombstone-reclamation test above, the race itself isn't deterministic in
+  # bats; an unremovable tombstone (non-writable dir with contents, preserved
+  # verbatim by the takeover mv) forces the same nonzero rm exit.
+  require_python3   # _touch_age computes the backdated stamp with python3
+  [ "$(id -u)" -ne 0 ] || skip "rm -rf succeeds as root — cannot force the tombstone rm failure"
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "ghost-proj" > "$slots/0/project"   # dead project, no pid file
+  mkdir -p "$slots/.sweep.lock/inner"      # over-age lock the takeover will mv aside
+  _touch_age 600 "$slots/.sweep.lock"      # >60s lock threshold
+  chmod a-w "$slots/.sweep.lock"           # rm -rf of the mv'd tombstone cannot unlink 'inner'
+  export DOCKER_PS_OUTPUT=""
+  run bash -euo pipefail -c "source '$COMMON'; _claim_isolate_slot; echo \"CLAIMED=\$ISOLATE_SLOT\""
+  # Let bats teardown clean up the unremovable tombstone (pid-suffixed by the
+  # child, hence the glob); guarded — must not mask the assertions below.
+  chmod u+w "$slots"/.sweep.lock.tomb.* 2>/dev/null || true
+  [ "$status" -eq 0 ] || fail "takeover died under set -e on a failed tombstone rm: $output"
+  # The takeover completed despite the failed disposal: fresh lock acquired,
+  # sweep ran, dead slot 0 reaped + reclaimed.
+  [[ "$output" == *"CLAIMED=0"* ]] \
+    || fail "sweep did not run after the failed tombstone disposal: $output"
+}
+
+@test "_release_sweep_lock distinguishes a vanished lock from a takeover" {
+  # When the lock (or its pid ownership marker) is GONE entirely, the release
+  # used to mis-report "taken over (current holder pid: unknown)" — there is
+  # no holder to report. A vanished lock gets its own message; the takeover
+  # warn (pinned by the own-lock-aware test above) stays reserved for a lock
+  # that actually carries a DIFFERENT holder's pid.
+  load_common
+  local lock="$XDG_STATE_HOME/copilotkit/showcase/slots/.sweep.lock"
+  [ ! -e "$lock" ] || fail "precondition: lock unexpectedly exists"
+  run _release_sweep_lock "$lock"
+  [ "$status" -eq 0 ] || fail "_release_sweep_lock failed on a missing lock: $output"
+  [[ "$output" == *"vanished"* ]] || fail "missing lock not reported as vanished: $output"
+  [[ "$output" != *"taken over"* ]] || fail "missing lock mis-reported as a takeover: $output"
 }
 
 # ── Change 3: restore_isolation honors --keep ────────────────────────────────
 
 @test "restore_isolation with keep set preserves slot + run dir and prints survival notice" {
+  require_python3
   load_common
   apply_isolation keepme
   local slotdir="$ISOLATE_SLOT_DIR/$ISOLATE_SLOT"
@@ -170,7 +685,15 @@ load_common() {
   [ -d "$slotdir" ] || fail "precondition: slot dir missing after apply"
   [ -d "$rundir" ]  || fail "precondition: run dir missing after apply"
 
-  keep=true
+  # Truncate the stub log: apply_isolation's idempotent pre-down already
+  # logged a `--project-name keepme down ...` line, which would poison the
+  # does-NOT-compose-down assertion below. The `docker version` sentinel then
+  # proves the stub→DOCKER_LOG pipeline is still live AFTER the truncation,
+  # so the absence check cannot pass vacuously.
+  : > "$DOCKER_LOG"
+  docker version
+
+  ISOLATE_KEEP=true
   run restore_isolation
   [ "$status" -eq 0 ] || fail "restore_isolation failed under keep: $output"
 
@@ -179,16 +702,177 @@ load_common() {
   [ -d "$rundir" ]  || fail "kept run dir was removed"
 
   # Survival notice content: project name, the 3 +offset host ports, teardown cmd.
-  # slot 0 default name -> offset 200: aimock 4210, dashboard 3400, pocketbase 8290.
+  # Explicit name 'keepme' on slot 0 -> offset 200: aimock 4210, dashboard 3400,
+  # pocketbase 8290.
   [[ "$output" == *"keepme"* ]] || fail "notice missing project name: $output"
   [[ "$output" == *"4210"* ]] || fail "notice missing aimock host port: $output"
   [[ "$output" == *"3400"* ]] || fail "notice missing dashboard host port: $output"
   [[ "$output" == *"8290"* ]] || fail "notice missing pocketbase host port: $output"
   [[ "$output" == *"docker compose -p keepme down"* ]] \
     || fail "notice missing literal teardown command: $output"
+
+  # The keep path's central promise: it does NOT compose-down the kept stack.
+  # (Last, because `run grep` clobbers the $output the notice checks read.)
+  _assert_stub_sentinel_logged
+  run grep -E -- "--project-name keepme down" "$DOCKER_LOG"
+  [ "$status" -ne 0 ] || fail "keep path composed the kept stack down: $output"
+}
+
+# ── Change 4: a FAILED apply_isolation must never down the default stack ─────
+#
+# cmd-test.sh registers `trap restore_isolation EXIT` BEFORE calling
+# apply_isolation, so a die() inside apply_isolation (invalid name, slot
+# exhaustion, ...) fires the trap with half-initialized isolation state. If
+# ISOLATE_ACTIVE was already true while COMPOSE_CMD still pointed at the
+# ORIGINAL docker-compose.local.yml (no project name), restore_isolation would
+# silently `compose down` the user's live DEFAULT stack. This pins that a
+# failed apply_isolation results in NO compose-down against the default project.
+
+@test "failed apply_isolation (invalid name) does not compose-down the default stack via the EXIT trap" {
+  load_common
+  # Mirror cmd-test.sh's real registration order in a child bash process run
+  # under bin/showcase's real shell options (-euo pipefail): a sentinel docker
+  # call proves the stub+log pipeline, the EXIT trap is armed, then
+  # apply_isolation dies on the invalid name ('MyName!' lowercases to
+  # 'myname!', which still fails [a-z0-9][a-z0-9_-]*).
+  run bash -euo pipefail -c "
+    source '$COMMON'
+    SHOWCASE_ROOT='$SHOWCASE_ROOT_OVERRIDE'
+    COMPOSE_FILE=\"\$SHOWCASE_ROOT/docker-compose.local.yml\"
+    PORTS_FILE=\"\$SHOWCASE_ROOT/shared/local-ports.json\"
+    COMPOSE_CMD=\"docker compose -f \$COMPOSE_FILE\"
+    docker version   # sentinel: prove stub+DOCKER_LOG wiring BEFORE the trap
+    trap restore_isolation EXIT
+    apply_isolation 'MyName!'
+  "
+  [ "$status" -ne 0 ] || fail "apply_isolation unexpectedly succeeded with invalid name 'MyName!'"
+
+  # Stub pipeline verified live — now absence of compose-down is meaningful.
+  _assert_stub_sentinel_logged
+
+  # The EXIT trap must NOT have run any `compose ... down` (word-matched, so a
+  # project name merely CONTAINING "down" can't satisfy/poison the check, and
+  # the bare minimal `compose down` — no args in between — is matched too) —
+  # neither against the original compose file nor the (never-created)
+  # isolated project.
+  local default_compose="$SHOWCASE_ROOT_OVERRIDE/docker-compose.local.yml"
+  run grep -E "(^|[[:space:]])compose([[:space:]].*)?[[:space:]]down([[:space:]]|\$)" "$DOCKER_LOG"
+  [ "$status" -ne 0 ] \
+    || fail "EXIT trap composed down after failed apply_isolation: $output"
+  run grep -F "$default_compose" "$DOCKER_LOG"
+  [ "$status" -ne 0 ] \
+    || fail "EXIT trap touched the default compose file after failed apply_isolation: $output"
+}
+
+@test "apply_isolation dying AFTER the slot claim (python3 failure) does not compose-down the default stack via the EXIT trap" {
+  load_common
+  # The dangerous window is wider than the pre-claim die above: apply_isolation
+  # can also die AFTER the slot claim but BEFORE ISOLATE_ACTIVE=true — e.g. the
+  # python3 ports/compose rewriters failing. COMPOSE_CMD still points at the
+  # ORIGINAL compose file in that window, so the armed EXIT trap must not run
+  # any compose-down against the default stack. Poison python3 via a PATH stub
+  # in the child to force the post-claim die.
+  #
+  # NB: this test pins ONLY the no-default-stack-compose-down invariant; what
+  # happens to the slot/run dirs in this window is pinned elsewhere.
+  local pybad="$BATS_TEST_TMPDIR/pybad"
+  mkdir -p "$pybad"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$pybad/python3"
+  chmod +x "$pybad/python3"
+
+  run bash -euo pipefail -c "
+    PATH='$pybad':\"\$PATH\"   # poison python3; docker stub stays on PATH
+    source '$COMMON'
+    SHOWCASE_ROOT='$SHOWCASE_ROOT_OVERRIDE'
+    COMPOSE_FILE=\"\$SHOWCASE_ROOT/docker-compose.local.yml\"
+    PORTS_FILE=\"\$SHOWCASE_ROOT/shared/local-ports.json\"
+    COMPOSE_CMD=\"docker compose -f \$COMPOSE_FILE\"
+    docker version   # sentinel: prove stub+DOCKER_LOG wiring BEFORE the trap
+    trap restore_isolation EXIT
+    apply_isolation 'pyfail'
+  "
+  [ "$status" -ne 0 ] || fail "apply_isolation unexpectedly succeeded with a poisoned python3"
+
+  # Stub pipeline verified live — now absence of compose-down is meaningful.
+  _assert_stub_sentinel_logged
+
+  # No compose-down of ANY kind may have run in this window: the idempotent
+  # pre-down comes only after ISOLATE_ACTIVE=true (never reached here), and
+  # the trap's half-init cleanup is state-only. The pattern also matches the
+  # bare minimal `compose down` (no args between the two words), which a
+  # `compose .*[[:space:]]down` regex would miss.
+  run grep -E "(^|[[:space:]])compose([[:space:]].*)?[[:space:]]down([[:space:]]|\$)" "$DOCKER_LOG"
+  [ "$status" -ne 0 ] \
+    || fail "EXIT trap composed down after post-claim die: $output"
+}
+
+# ── Leading-character rule: compose project names must START with [a-z0-9] ───
+#
+# docker compose accepts [a-z0-9][a-z0-9_-]* — '_' and '-' are valid only in
+# the INTERIOR of a project name. Names like '_foo' or '-foo' used to slip
+# through the CLI check (which only looked for chars outside [a-z0-9_-]) and
+# then failed deep inside compose with exactly the opaque error this
+# validation exists to prevent.
+
+@test "apply_isolation rejects names with an invalid leading character" {
+  load_common
+  run apply_isolation '_foo'
+  [ "$status" -ne 0 ] || fail "apply_isolation unexpectedly accepted '_foo'"
+  [[ "$output" == *"must start with a lowercase letter or digit"* ]] \
+    || fail "die message does not describe the leading-character rule: $output"
+
+  run apply_isolation '-foo'
+  [ "$status" -ne 0 ] || fail "apply_isolation unexpectedly accepted '-foo'"
+  [[ "$output" == *"must start with a lowercase letter or digit"* ]] \
+    || fail "die message does not describe the leading-character rule: $output"
+}
+
+@test "apply_isolation accepts a normal name with interior '_' and '-'" {
+  require_python3
+  load_common
+  apply_isolation 'foo_bar-9'
+  [[ "$ISOLATE_TMPDIR" == "$XDG_STATE_HOME/copilotkit/showcase/runs/foo_bar-9" ]] \
+    || fail "valid name 'foo_bar-9' was not accepted: $ISOLATE_TMPDIR"
+}
+
+# ── Reserved name: 'showcase' IS the default stack's compose project ─────────
+#
+# docker compose defaults the project name to the directory name, so the
+# DEFAULT stack's project is literally "showcase". An accidental
+# `--isolate showcase` used to sail through the charset validation (the
+# container-name rewrite showcase- → showcase- is a no-op), and the idempotent
+# pre-down then ran `--project-name showcase down --remove-orphans --volumes`
+# — tearing down the user's live default stack, bypassing every guard this
+# code has.
+
+@test "apply_isolation rejects the reserved name 'showcase' before any compose command" {
+  load_common
+  docker version   # sentinel: prove stub+DOCKER_LOG wiring BEFORE the call
+  run apply_isolation showcase
+  [ "$status" -ne 0 ] || fail "apply_isolation accepted the reserved name 'showcase'"
+  [[ "$output" == *"reserved"* ]] \
+    || fail "die message does not say the name is reserved: $output"
+
+  # The uppercase variant must be caught too: the check runs AFTER the
+  # lowercase normalization, so 'Showcase' lowercases into the reserved name.
+  run apply_isolation Showcase
+  [ "$status" -ne 0 ] || fail "apply_isolation accepted 'Showcase' (lowercases to the reserved name)"
+  [[ "$output" == *"reserved"* ]] \
+    || fail "die message for 'Showcase' does not say the name is reserved: $output"
+
+  # No compose command of ANY kind may have run — the rejection must land
+  # BEFORE the idempotent pre-down that would hit the default stack. Word-
+  # matched so the sweep's `ps -q --filter label=com.docker.compose.project=…`
+  # line can't satisfy/poison the check. The sentinel proves the stub→log
+  # pipeline is live first, so this absence check cannot pass vacuously.
+  _assert_stub_sentinel_logged
+  run grep -E "(^|[[:space:]])compose([[:space:]]|\$)" "$DOCKER_LOG"
+  [ "$status" -ne 0 ] \
+    || fail "reserved-name rejection ran a compose command: $output"
 }
 
 @test "restore_isolation without keep removes run dir and releases slot" {
+  require_python3
   load_common
   apply_isolation dropme
   local slotdir="$ISOLATE_SLOT_DIR/$ISOLATE_SLOT"
@@ -196,7 +880,15 @@ load_common() {
   [ -d "$slotdir" ] || fail "precondition: slot dir missing after apply"
   [ -d "$rundir" ]  || fail "precondition: run dir missing after apply"
 
-  keep=false
+  # Truncate the stub log NOW: apply_isolation's idempotent pre-down logs a
+  # BYTE-IDENTICAL `--project-name dropme down --remove-orphans --volumes`
+  # line, so without the truncation the teardown assertion below would pass
+  # vacuously even if restore_isolation dropped --volumes or never composed
+  # down at all. After the truncation, any matching line can only have come
+  # from the teardown itself.
+  : > "$DOCKER_LOG"
+
+  ISOLATE_KEEP=false
   run restore_isolation
   [ "$status" -eq 0 ] || fail "restore_isolation failed: $output"
 
@@ -204,4 +896,363 @@ load_common() {
   # assert on the filesystem effects, which DO persist across the subshell.
   [ ! -d "$rundir" ] || fail "run dir not removed on teardown: $rundir"
   [ ! -d "$slotdir" ] || fail "slot not released on teardown: $slotdir"
+
+  # Volumes consistency: isolated stacks are ephemeral, and both printed
+  # manual teardown commands (keep notice + failed-down recovery) include
+  # --volumes. The AUTOMATIC teardown must agree, or project-scoped named
+  # volumes leak (unbounded for explicit names). The log was truncated after
+  # apply_isolation returned (see above), so this match is necessarily the
+  # teardown's own project-named down carrying --volumes.
+  run grep -E -- "--project-name dropme down --remove-orphans --volumes" "$DOCKER_LOG"
+  [ "$status" -eq 0 ] \
+    || fail "automatic teardown down did not include --volumes: $(cat "$DOCKER_LOG")"
+}
+
+# ── Duplicate explicit --isolate name must not destroy a live run ────────────
+#
+# apply_isolation's idempotent pre-down keys on the compose project NAME, but
+# the slot registry only enforces SLOT uniqueness. A second concurrent run
+# passing the same explicit --isolate <name> used to get a different slot but
+# the same compose project — its pre-down silently tore down the first run's
+# containers mid-test (or a --keep-parked stack), and two slots then recorded
+# the same project name, corrupting the liveness-reaping signal.
+
+@test "apply_isolation dies on a duplicate explicit name without composing it down" {
+  load_common
+  # Seed slot 0 as another LIVE run already using "dupename": project recorded,
+  # owning PID alive (this bats process), so the stale-sweep must not reap it.
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "dupename" > "$slots/0/project"
+  echo "$$" > "$slots/0/pid"
+
+  export DOCKER_PS_OUTPUT=""   # zero containers (still building) — PID protects
+  run apply_isolation dupename
+  [ "$status" -ne 0 ] || fail "apply_isolation accepted a duplicate name"
+  [[ "$output" == *"already in use by slot 0"* ]] \
+    || fail "die message does not name the conflicting slot: $output"
+
+  # The live run's stack must be untouched: NO compose-down of any kind may
+  # have run (the pre-down comes only after the duplicate guard). The sweep is
+  # expected to have called `docker ps` for the recorded project — assert that
+  # exact invocation actually landed in the log (the stub logs one
+  # "$*"-joined line per call), not merely that the log file exists: a
+  # silently broken stub/DOCKER_LOG pipeline would make the absence check
+  # below pass vacuously.
+  [ -f "$DOCKER_LOG" ] \
+    || fail "docker stub log missing — the sweep should have called docker ps; absence check would be vacuous"
+  grep -qxF -- "ps -q --filter label=com.docker.compose.project=dupename" "$DOCKER_LOG" \
+    || fail "sweep's docker ps invocation not logged — stub/DOCKER_LOG pipeline broken, absence check would be vacuous: $(cat "$DOCKER_LOG")"
+  run grep -E "(^|[[:space:]])compose([[:space:]].*)?[[:space:]]down([[:space:]]|\$)" "$DOCKER_LOG"
+  [ "$status" -ne 0 ] \
+    || fail "duplicate-name run composed down the live project: $output"
+
+  # Slot 0's record survives intact for the live owner.
+  [ -d "$slots/0" ] || fail "live slot 0 was reaped during the duplicate claim"
+  run cat "$slots/0/project"
+  [ "$status" -eq 0 ] || fail "live slot 0 project file missing after duplicate claim"
+  [[ "$output" == "dupename" ]] || fail "live slot 0 project mangled: $output"
+}
+
+@test "duplicate-name guard is claim-then-verify: loser backs off without touching the winner" {
+  # TOCTOU regression: the guard used to SCAN the other slots and only then
+  # write its own project record. Two concurrent same-name claims could both
+  # pass the scan and both record the name — one run's pre-down then tore the
+  # other's stack down mid-test, and reaping either slot deleted the SHARED
+  # runs/<name> dir. The fix writes our record FIRST, then scans: the later
+  # writer of any concurrent pair is guaranteed to see the earlier record and
+  # back off (die) before runs/<name> is ever created or touched.
+  load_common
+  local base="$XDG_STATE_HOME/copilotkit/showcase"
+  local slots="$base/slots"
+  # Winner: slot 0 already holds 'dup' (live owning PID) plus its run dir.
+  mkdir -p "$slots/0"
+  echo "dup" > "$slots/0/project"
+  echo "$$" > "$slots/0/pid"
+  mkdir -p "$base/runs/dup"
+  touch "$base/runs/dup/docker-compose.local.yml"
+  export DOCKER_PS_OUTPUT=""   # zero containers (still building) — PID protects
+
+  # Ordering pin (claim BEFORE verify): `run` dies in a subshell with no trap,
+  # so the loser's slot dir survives for inspection — and it must already
+  # contain our own 'dup' record, written BEFORE the conflict scan. Under the
+  # old scan-then-write order this record never exists (that unrecorded window
+  # is exactly the TOCTOU hole).
+  run apply_isolation dup
+  [ "$status" -ne 0 ] || fail "apply_isolation accepted duplicate name 'dup'"
+  [[ "$output" == *"already in use by slot 0"* ]] \
+    || fail "die message does not name the conflicting slot: $output"
+  run cat "$slots/1/project"
+  [ "$status" -eq 0 ] \
+    || fail "loser did not record its claim BEFORE verifying (scan-then-write TOCTOU order)"
+  [[ "$output" == "dup" ]] || fail "loser recorded the wrong project: $output"
+  rm -rf "$slots/1"   # clear the no-trap leftovers; trap cleanup is pinned next
+
+  # Real wiring (trap armed first, bin/showcase's shell options): the loser's
+  # die must clean up its OWN slot — including the just-written record — via
+  # the EXIT trap, and the winner's slot record AND runs/dup dir must be
+  # untouched (ISOLATE_TMPDIR is set only after the verify passes, so the
+  # loser's cleanup cannot reach the shared run dir).
+  run bash -euo pipefail -c "
+    source '$COMMON'
+    SHOWCASE_ROOT='$SHOWCASE_ROOT_OVERRIDE'
+    COMPOSE_FILE=\"\$SHOWCASE_ROOT/docker-compose.local.yml\"
+    PORTS_FILE=\"\$SHOWCASE_ROOT/shared/local-ports.json\"
+    COMPOSE_CMD=\"docker compose -f \$COMPOSE_FILE\"
+    trap restore_isolation EXIT
+    apply_isolation dup
+  "
+  [ "$status" -ne 0 ] || fail "apply_isolation accepted duplicate name 'dup' (trap run)"
+  [ ! -d "$slots/1" ] || fail "loser's slot/record leaked after the EXIT trap: $slots/1"
+  # Winner untouched: record intact, run dir (and its contents) intact.
+  [ -d "$slots/0" ] || fail "winner's slot was reaped by the losing claim"
+  run cat "$slots/0/project"
+  [ "$status" -eq 0 ] || fail "winner's project record missing"
+  [[ "$output" == "dup" ]] || fail "winner's project record mangled: $output"
+  [ -f "$base/runs/dup/docker-compose.local.yml" ] \
+    || fail "winner's run dir was damaged by the losing claim"
+}
+
+@test "duplicate-name guard treats an EQUAL-mtime conflicting record as a conflict (tie = back off)" {
+  # Tie semantics pin: the backoff comparison is `-le` — a conflicting record
+  # that does NOT strictly postdate ours (older OR EQUAL epoch mtime) means we
+  # lose. A regression to `-lt` would make two same-second claimants BOTH
+  # treat the other's record as "strictly newer → the other backs off" and
+  # BOTH proceed as dual owners of one compose project. The other duplicate
+  # tests seed their conflicting record by wall clock, so whether they hit
+  # the equal or the older branch depends on second-boundary timing; force
+  # the tie DETERMINISTICALLY by stubbing _file_mtime to one fixed epoch for
+  # every path (safe here: slot 0 is pid-protected, so the sweep never
+  # consults mtimes, and no tombstones/locks exist).
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "tiename" > "$slots/0/project"
+  echo "$$" > "$slots/0/pid"           # live owner — sweep must not reap it
+  export DOCKER_PS_OUTPUT=""
+
+  _file_mtime() { echo 1700000000; }   # our record and theirs: EQUAL mtimes
+
+  run apply_isolation tiename
+  [ "$status" -ne 0 ] \
+    || fail "equal-mtime conflicting record did not back the claimant off (tie regression: -le became -lt?)"
+  [[ "$output" == *"already in use by slot 0"* ]] \
+    || fail "die message does not name the conflicting slot: $output"
+}
+
+@test "re-using a name after clean teardown still works" {
+  require_python3
+  load_common
+  apply_isolation reusable
+  ISOLATE_KEEP=false
+  restore_isolation
+  # The old slot was released and its record removed — the name is free again.
+  # (In production restore_isolation only runs at EXIT; it does not repoint
+  # COMPOSE_FILE/PORTS_FILE/COMPOSE_CMD at the originals. Re-point them here
+  # the way a fresh process sourcing _common.sh would see them.)
+  COMPOSE_FILE="$SHOWCASE_ROOT/docker-compose.local.yml"
+  PORTS_FILE="$SHOWCASE_ROOT/shared/local-ports.json"
+  COMPOSE_CMD="docker compose -f $COMPOSE_FILE"
+  apply_isolation reusable
+  [[ "$ISOLATE_NAME" == "reusable" ]] || fail "name not reusable after teardown"
+}
+
+# ── Half-initialized apply_isolation must clean its state via the EXIT trap ──
+#
+# If apply_isolation dies AFTER _claim_isolate_slot but BEFORE
+# ISOLATE_ACTIVE=true (python3 failure, mkdir failure), the EXIT trap's
+# restore_isolation must not compose-down anything (that guard protects the
+# user's default stack) — but it used to ALSO leak the claimed slot dir and
+# the runs/<name> dir silently. The slot self-healed via the stale-sweep; the
+# runs dir never did. Pin that the trap now cleans both, with NO compose
+# command at all.
+
+@test "half-initialized apply_isolation cleans slot and run dir via EXIT trap without any compose" {
+  # Poison python3 so apply_isolation dies after the slot claim, project-file
+  # write, and run-dir mkdir — i.e. genuinely half-initialized.
+  local poison="$BATS_TEST_TMPDIR/poison"
+  mkdir -p "$poison"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$poison/python3"
+  chmod +x "$poison/python3"
+
+  # Mirror cmd-test.sh's real wiring in a child bash: trap armed first, then
+  # apply_isolation fails partway through under set -euo pipefail.
+  run bash -euo pipefail -c "
+    PATH='$poison':\"\$PATH\"
+    source '$COMMON'
+    SHOWCASE_ROOT='$SHOWCASE_ROOT_OVERRIDE'
+    COMPOSE_FILE=\"\$SHOWCASE_ROOT/docker-compose.local.yml\"
+    PORTS_FILE=\"\$SHOWCASE_ROOT/shared/local-ports.json\"
+    COMPOSE_CMD=\"docker compose -f \$COMPOSE_FILE\"
+    docker version   # sentinel: prove stub+DOCKER_LOG wiring BEFORE the trap
+    trap restore_isolation EXIT
+    apply_isolation halfinit
+  "
+  [ "$status" -ne 0 ] || fail "apply_isolation unexpectedly survived poisoned python3"
+
+  # State cleaned: the claimed slot AND the runs/<name> dir are gone.
+  [ ! -d "$XDG_STATE_HOME/copilotkit/showcase/slots/0" ] \
+    || fail "half-initialized slot dir leaked"
+  [ ! -d "$XDG_STATE_HOME/copilotkit/showcase/runs/halfinit" ] \
+    || fail "half-initialized run dir leaked"
+
+  # And the cleanup was STATE-ONLY: no compose command of any kind ran (the
+  # compose-down hazard against the default stack is exactly what the
+  # ISOLATE_ACTIVE guard prevents — cleanup must not reintroduce it). The
+  # sentinel proves the stub→log pipeline is live first, so this absence
+  # check cannot pass vacuously. Word-matched so the sweep's
+  # `ps -q --filter label=com.docker.compose.project=…` line can't
+  # satisfy/poison the check.
+  _assert_stub_sentinel_logged
+  run grep -E "(^|[[:space:]])compose([[:space:]]|\$)" "$DOCKER_LOG"
+  [ "$status" -ne 0 ] \
+    || fail "half-init cleanup ran a compose command: $output"
+}
+
+@test "restore_isolation without keep preserves run dir and slot when compose down FAILS" {
+  require_python3
+  # Split-brain regression: a silently failed `compose down` (stderr to
+  # /dev/null, `|| true`) used to leave the stack RUNNING while the run dir
+  # (the only copy of the rewritten compose file) and the slot were deleted —
+  # live containers with no state and a re-claimable slot (port collisions).
+  # On compose-down failure the evidence must survive and a loud warning with
+  # the project name + manual teardown command must print.
+  load_common
+  apply_isolation downfail
+  local slotdir="$ISOLATE_SLOT_DIR/$ISOLATE_SLOT"
+  local rundir="$ISOLATE_TMPDIR"
+  [ -d "$slotdir" ] || fail "precondition: slot dir missing after apply"
+  [ -d "$rundir" ]  || fail "precondition: run dir missing after apply"
+
+  # Set AFTER apply_isolation so its idempotent pre-down is unaffected.
+  export DOCKER_COMPOSE_DOWN_EXIT=1
+  ISOLATE_KEEP=false
+  run restore_isolation
+  [ "$status" -eq 0 ] || fail "restore_isolation must not propagate the failure: $output"
+
+  # Evidence preserved: run dir kept, slot NOT released.
+  [ -d "$rundir" ]  || fail "run dir deleted despite failed compose down"
+  [ -d "$slotdir" ] || fail "slot released despite failed compose down"
+
+  # Loud warning: project name + manual teardown command for recovery.
+  [[ "$output" == *"downfail"* ]] || fail "warning missing project name: $output"
+  [[ "$output" == *"docker compose -p downfail down"* ]] \
+    || fail "warning missing manual teardown command: $output"
+}
+
+@test "restore_isolation guard mismatch warns and preserves run dir + slot (no fall-through deletion)" {
+  # Belt-and-suspenders divergence: ISOLATE_ACTIVE=true but COMPOSE_CMD is NOT
+  # repointed at the isolated project. The old code skipped the compose-down
+  # (correct — never down an unknown target) but then FELL THROUGH to deleting
+  # the run dir and releasing the slot, manufacturing the exact split-brain
+  # the adjacent comment documents: a possibly-running stack whose only
+  # compose state is deleted and whose slot is reclaimable. Unreachable
+  # through today's call paths (apply_isolation sets ISOLATE_ACTIVE only
+  # after the repoint), but the defensive path must be SAFE, not destructive:
+  # warn loudly and preserve everything, mirroring the failed-down branch.
+  load_common
+  local base="$XDG_STATE_HOME/copilotkit/showcase"
+  mkdir -p "$base/slots/3" "$base/runs/mismatched"
+  echo "$$" > "$base/slots/3/pid"
+  ISOLATE_ACTIVE=true
+  ISOLATE_NAME="mismatched"
+  ISOLATE_SLOT=3
+  ISOLATE_TMPDIR="$base/runs/mismatched"
+  ISOLATE_KEEP=false
+  # COMPOSE_CMD (from load_common) carries NO --project-name — the mismatch.
+  : > "$DOCKER_LOG"
+  docker version
+  run restore_isolation
+  [ "$status" -eq 0 ] || fail "restore_isolation failed on the mismatch path: $output"
+  [ -d "$base/runs/mismatched" ] \
+    || fail "run dir deleted on the guard-mismatch path (split-brain)"
+  [ -d "$base/slots/3" ] \
+    || fail "slot released on the guard-mismatch path (split-brain)"
+  [[ "$output" == *"mismatch"* ]] \
+    || fail "no loud warning on the guard-mismatch path: $output"
+  [[ "$output" == *"docker compose -p mismatched down"* ]] \
+    || fail "warning missing manual teardown command: $output"
+  # No compose command of any kind ran — COMPOSE_CMD's target is unknown.
+  _assert_stub_sentinel_logged
+  run grep -E "(^|[[:space:]])compose([[:space:]].*)?[[:space:]]down([[:space:]]|\$)" "$DOCKER_LOG"
+  [ "$status" -ne 0 ] || fail "guard-mismatch path ran a compose down: $output"
+}
+
+@test "apply_isolation warns (but does not die) when the idempotent pre-down fails" {
+  require_python3
+  # The pre-down exists to clear a prior crashed run's containers/volumes. Its
+  # failure must stay non-fatal (the common case is "nothing to tear down"),
+  # but it must not be SILENT either — leftover state is exactly what the
+  # pre-clean is for, so the user gets a warning that it may remain.
+  load_common
+  export DOCKER_COMPOSE_DOWN_EXIT=1   # set BEFORE apply: poison the pre-down
+  run apply_isolation predownfail
+  [ "$status" -eq 0 ] || fail "apply_isolation died on a failed pre-down: $output"
+  [[ "$output" == *"pre-clean of project predownfail failed"* ]] \
+    || fail "no warning printed for the failed pre-down: $output"
+  [[ "$output" == *"Isolation active"* ]] \
+    || fail "apply_isolation did not complete after the failed pre-down: $output"
+}
+
+@test "EXIT trap honors keep flag set inside a function that has returned (real cmd_test wiring)" {
+  require_python3
+  # Regression test for the --keep teardown bug: cmd_test used to hold the keep
+  # flag in a `local keep`. On the NORMAL path cmd_test returns, its locals
+  # unwind, and the EXIT trap fires later at top-level script exit — where the
+  # local no longer exists — so restore_isolation read `${keep:-false}` as
+  # false and tore the kept stack down anyway. (The earlier tests above call
+  # restore_isolation directly with the flag set at test scope, which is
+  # exactly the pattern that masked this.)
+  #
+  # This test exercises the REAL wiring: a child bash sources _common.sh,
+  # registers `trap restore_isolation EXIT`, then a function sets the keep flag
+  # the same way cmd_test's --keep handler does, applies isolation, RETURNS,
+  # and the script exits normally. The run dir and slot must survive the trap
+  # and the survival notice must print.
+  cat > "$BATS_TEST_TMPDIR/keep-wiring.sh" <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail   # bin/showcase's real shell options — fixture fidelity
+# shellcheck disable=SC1090
+source "$COMMON_SH"
+# Repoint the derived paths at the per-test fake root (same as load_common).
+SHOWCASE_ROOT="$SHOWCASE_ROOT_OVERRIDE"
+COMPOSE_FILE="$SHOWCASE_ROOT/docker-compose.local.yml"
+PORTS_FILE="$SHOWCASE_ROOT/shared/local-ports.json"
+COMPOSE_CMD="docker compose -f $COMPOSE_FILE"
+
+fake_cmd_test() {
+  ISOLATE_KEEP=true   # what cmd_test's --keep arg handler does
+  trap restore_isolation EXIT
+  apply_isolation trapkeep
+  return 0
+}
+fake_cmd_test
+# Truncate the stub log: apply_isolation's idempotent pre-down already logged
+# a `--project-name trapkeep down ...` line that would poison the parent
+# test's does-NOT-compose-down assertion. The `docker version` sentinel then
+# proves the stub→DOCKER_LOG pipeline is still live after the truncation.
+: > "$DOCKER_LOG"
+docker version
+exit 0   # locals (if any) are long gone; the EXIT trap fires HERE
+FIXTURE
+
+  export COMMON_SH="$COMMON"
+  run bash "$BATS_TEST_TMPDIR/keep-wiring.sh"
+  [ "$status" -eq 0 ] || fail "fixture script failed: $output"
+
+  # Survival: the run dir and slot must still exist after the trap ran.
+  local slotdir="$XDG_STATE_HOME/copilotkit/showcase/slots/0"
+  local rundir="$XDG_STATE_HOME/copilotkit/showcase/runs/trapkeep"
+  [ -d "$rundir" ]  || fail "kept run dir was torn down by the EXIT trap: $output"
+  [ -d "$slotdir" ] || fail "kept slot was released by the EXIT trap: $output"
+  [[ "$output" == *"Kept isolated group standing"* ]] \
+    || fail "survival notice not printed at exit: $output"
+
+  # The keep path's central promise, under the REAL trap wiring: the EXIT trap
+  # did NOT compose-down the kept stack. The log was truncated inside the
+  # fixture after apply_isolation's pre-down, and the sentinel proves the
+  # stub→log pipeline stayed live, so this absence check is not vacuous.
+  _assert_stub_sentinel_logged
+  run grep -E -- "--project-name trapkeep down" "$DOCKER_LOG"
+  [ "$status" -ne 0 ] || fail "EXIT trap composed the kept stack down: $output"
 }

--- a/showcase/scripts/__tests__/isolate.bats
+++ b/showcase/scripts/__tests__/isolate.bats
@@ -159,3 +159,49 @@ load_common() {
   [[ "$output" == "myproj" ]] || fail "wrong project recorded: $output"
   [ -f "$slotdir/pid" ] || fail "pid file no longer written"
 }
+
+# ── Change 3: restore_isolation honors --keep ────────────────────────────────
+
+@test "restore_isolation with keep set preserves slot + run dir and prints survival notice" {
+  load_common
+  apply_isolation keepme
+  local slotdir="$ISOLATE_SLOT_DIR/$ISOLATE_SLOT"
+  local rundir="$ISOLATE_TMPDIR"
+  [ -d "$slotdir" ] || fail "precondition: slot dir missing after apply"
+  [ -d "$rundir" ]  || fail "precondition: run dir missing after apply"
+
+  keep=true
+  run restore_isolation
+  [ "$status" -eq 0 ] || fail "restore_isolation failed under keep: $output"
+
+  # Nothing torn down: slot + run dir survive, slot NOT released.
+  [ -d "$slotdir" ] || fail "kept slot dir was removed"
+  [ -d "$rundir" ]  || fail "kept run dir was removed"
+
+  # Survival notice content: project name, the 3 +offset host ports, teardown cmd.
+  # slot 0 default name -> offset 200: aimock 4210, dashboard 3400, pocketbase 8290.
+  [[ "$output" == *"keepme"* ]] || fail "notice missing project name: $output"
+  [[ "$output" == *"4210"* ]] || fail "notice missing aimock host port: $output"
+  [[ "$output" == *"3400"* ]] || fail "notice missing dashboard host port: $output"
+  [[ "$output" == *"8290"* ]] || fail "notice missing pocketbase host port: $output"
+  [[ "$output" == *"docker compose -p keepme down"* ]] \
+    || fail "notice missing literal teardown command: $output"
+}
+
+@test "restore_isolation without keep removes run dir and releases slot" {
+  load_common
+  apply_isolation dropme
+  local slotdir="$ISOLATE_SLOT_DIR/$ISOLATE_SLOT"
+  local rundir="$ISOLATE_TMPDIR"
+  [ -d "$slotdir" ] || fail "precondition: slot dir missing after apply"
+  [ -d "$rundir" ]  || fail "precondition: run dir missing after apply"
+
+  keep=false
+  run restore_isolation
+  [ "$status" -eq 0 ] || fail "restore_isolation failed: $output"
+
+  # NB `run` executes in a subshell, so the parent's ISOLATE_* are unchanged; we
+  # assert on the filesystem effects, which DO persist across the subshell.
+  [ ! -d "$rundir" ] || fail "run dir not removed on teardown: $rundir"
+  [ ! -d "$slotdir" ] || fail "slot not released on teardown: $slotdir"
+}

--- a/showcase/scripts/__tests__/isolate.bats
+++ b/showcase/scripts/__tests__/isolate.bats
@@ -456,6 +456,54 @@ load_common() {
   [[ "$output" == "../evil" ]] || fail "suspicious record mangled: $output"
 }
 
+@test "a slot whose project record reads the RESERVED 'showcase' is left intact — reap never composes the default stack down" {
+  # Reserved-name guard in the REAPER: 'showcase' IS the default stack's
+  # compose project name, and it PASSES the charset regex — so a slot record
+  # reading 'showcase' (a corrupt record, or one written by an older CLI
+  # version before apply_isolation reserved the name) used to make the reap
+  # run `compose -p showcase down --remove-orphans --volumes` against the
+  # user's LIVE DEFAULT stack, destroying the PocketBase named volume.
+  # apply_isolation reserves the name at claim time, but the reaper must not
+  # trust records: the reserved name gets the same treatment as the
+  # path-traversal guard — warn and leave the whole slot in place for manual
+  # inspection (no compose-down, no state removal).
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+  echo "showcase" > "$slots/0/project"   # passes [a-z0-9][a-z0-9_-]*
+
+  export DOCKER_PS_OUTPUT=""   # no live containers, no pid file → reap path
+  : > "$DOCKER_LOG"
+  docker version   # sentinel: prove stub+DOCKER_LOG wiring before the claim
+  run _claim_isolate_slot
+  [ "$status" -eq 0 ] || fail "_claim_isolate_slot failed: $output"
+
+  # A loud warning names the offending record and why it is dangerous.
+  # (Checked before any `run grep` clobbers $output.)
+  [[ "$output" == *"RESERVED"* ]] \
+    || fail "no reserved-name warning printed: $output"
+  [[ "$output" == *"$slots/0"* ]] \
+    || fail "warning does not name the slot record: $output"
+
+  # The reserved-name slot survives — with its record — for inspection, and
+  # the claim moves on to the next free slot (the subshell's mkdir persists
+  # on the filesystem even though `run` ran the claim in a subshell).
+  [ -d "$slots/0" ] || fail "reserved-name slot 0 was reaped (default stack endangered)"
+  run cat "$slots/0/project"
+  [ "$status" -eq 0 ] || fail "reserved-name slot 0 record removed"
+  [[ "$output" == "showcase" ]] || fail "reserved-name record mangled: $output"
+  [ -d "$slots/1" ] || fail "claim did not proceed past the preserved slot 0"
+
+  # NO compose-down of the 'showcase' project may have run — match BOTH
+  # compose project-flag spellings (the reaper uses -p; other paths use
+  # --project-name). The sentinel proves the stub→log pipeline is live, so
+  # this absence check cannot pass vacuously.
+  _assert_stub_sentinel_logged
+  run grep -E -- "(--project-name|-p) showcase down" "$DOCKER_LOG"
+  [ "$status" -ne 0 ] \
+    || fail "reap composed the RESERVED 'showcase' project down (live default stack): $output"
+}
+
 @test "a fresh pre-existing .sweep.lock skips the sweep; claiming still succeeds" {
   # TOCTOU sweep/claim race: two concurrent claimants could both observe slot 0
   # stale — A reaps + re-claims it, then B reaps A's FRESH claim and claims the
@@ -712,9 +760,12 @@ load_common() {
     || fail "notice missing literal teardown command: $output"
 
   # The keep path's central promise: it does NOT compose-down the kept stack.
+  # Match BOTH compose project-flag spellings — restore_isolation's own down
+  # uses --project-name, but the reaper (and any keep-branch regression)
+  # spells it -p, which a --project-name-only grep would let slip through.
   # (Last, because `run grep` clobbers the $output the notice checks read.)
   _assert_stub_sentinel_logged
-  run grep -E -- "--project-name keepme down" "$DOCKER_LOG"
+  run grep -E -- "(--project-name|-p) keepme down" "$DOCKER_LOG"
   [ "$status" -ne 0 ] || fail "keep path composed the kept stack down: $output"
 }
 
@@ -1249,10 +1300,13 @@ FIXTURE
     || fail "survival notice not printed at exit: $output"
 
   # The keep path's central promise, under the REAL trap wiring: the EXIT trap
-  # did NOT compose-down the kept stack. The log was truncated inside the
-  # fixture after apply_isolation's pre-down, and the sentinel proves the
-  # stub→log pipeline stayed live, so this absence check is not vacuous.
+  # did NOT compose-down the kept stack. Match BOTH compose project-flag
+  # spellings (--project-name and -p) — a keep-branch regression via the -p
+  # form would pass a --project-name-only grep undetected. The log was
+  # truncated inside the fixture after apply_isolation's pre-down, and the
+  # sentinel proves the stub→log pipeline stayed live, so this absence check
+  # is not vacuous.
   _assert_stub_sentinel_logged
-  run grep -E -- "--project-name trapkeep down" "$DOCKER_LOG"
+  run grep -E -- "(--project-name|-p) trapkeep down" "$DOCKER_LOG"
   [ "$status" -ne 0 ] || fail "EXIT trap composed the kept stack down: $output"
 }

--- a/showcase/scripts/__tests__/isolate.bats
+++ b/showcase/scripts/__tests__/isolate.bats
@@ -117,3 +117,45 @@ load_common() {
     || fail "run dir still the old /tmp PID scratch dir: $ISOLATE_TMPDIR"
   [ -d "$ISOLATE_TMPDIR" ] || fail "run dir not created: $ISOLATE_TMPDIR"
 }
+
+# ── Change 2: stale-slot reaping by compose-project liveness ─────────────────
+
+@test "claim reaps a slot whose project has no live containers" {
+  load_common
+  # Pre-seed slot 0 for a project with NO live containers (DOCKER_PS_OUTPUT="").
+  mkdir -p "$XDG_STATE_HOME/copilotkit/showcase/slots/0"
+  echo "ghost-proj" > "$XDG_STATE_HOME/copilotkit/showcase/slots/0/project"
+
+  export DOCKER_PS_OUTPUT=""
+  _claim_isolate_slot
+  # The dead slot 0 is reaped and reclaimed by this run.
+  [ "$ISOLATE_SLOT" = "0" ] || fail "expected to reclaim reaped slot 0, got: $ISOLATE_SLOT"
+  # The new claim recorded ITS own project, not the ghost.
+  run cat "$XDG_STATE_HOME/copilotkit/showcase/slots/0/project"
+  [[ "$output" != "ghost-proj" ]] || fail "ghost project not overwritten on reclaim"
+}
+
+@test "claim does NOT reap a slot whose project has a live container" {
+  load_common
+  mkdir -p "$XDG_STATE_HOME/copilotkit/showcase/slots/0"
+  echo "live-proj" > "$XDG_STATE_HOME/copilotkit/showcase/slots/0/project"
+
+  # Make docker ps report a live container id -> slot 0 must be preserved.
+  export DOCKER_PS_OUTPUT="abc123def456"
+  _claim_isolate_slot
+  [ "$ISOLATE_SLOT" = "1" ] || fail "expected to skip live slot 0 and claim 1, got: $ISOLATE_SLOT"
+  # Slot 0 and its project file survive untouched.
+  [ -d "$XDG_STATE_HOME/copilotkit/showcase/slots/0" ] || fail "live slot 0 was wrongly reaped"
+  run cat "$XDG_STATE_HOME/copilotkit/showcase/slots/0/project"
+  [[ "$output" == "live-proj" ]] || fail "live slot 0 project mangled: $output"
+}
+
+@test "slot claim persists the project name alongside the pid file" {
+  load_common
+  apply_isolation myproj
+  local slotdir="$ISOLATE_SLOT_DIR/$ISOLATE_SLOT"
+  [ -f "$slotdir/project" ] || fail "no project file written for claimed slot"
+  run cat "$slotdir/project"
+  [[ "$output" == "myproj" ]] || fail "wrong project recorded: $output"
+  [ -f "$slotdir/pid" ] || fail "pid file no longer written"
+}

--- a/showcase/scripts/__tests__/isolate.bats
+++ b/showcase/scripts/__tests__/isolate.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# Tests for the isolation helpers in scripts/cli/_common.sh — the --isolate
+# runtime-state plumbing that lets multiple `showcase test --isolate` runs share
+# one host without colliding on ports, compose project names, or scratch dirs.
+#
+# Three behaviors are pinned here:
+#   1. Runtime state lives under XDG_STATE_HOME (NOT /tmp). The slot registry and
+#      per-run scratch dir are rooted at $XDG_STATE_HOME/copilotkit/showcase, with
+#      the documented $HOME/.local/state fallback when XDG_STATE_HOME is unset.
+#   2. Stale slots are reaped by compose-project liveness: a slot whose recorded
+#      project has no live containers is reclaimed; one with a live container is
+#      left alone (so a --keep'd stack is never stolen out from under).
+#   3. restore_isolation honors --keep: when keep is set it does NOT compose-down,
+#      does NOT remove the run dir, does NOT release the slot, and prints a
+#      survival notice (project, slot, the three +offset host ports, and the exact
+#      teardown command).
+#
+# NB on assertion gating: bats does NOT run test bodies under `set -e` (errexit).
+# Only the FINAL command's exit status decides pass/fail — a non-zero command on
+# an earlier line does NOT abort the test. So a bare `[[ ... ]]` on a non-final
+# line is a silent no-op. Every substantive / non-final assertion MUST be written
+# `[[ ... ]] || fail "message"` so the check actually forces a hard failure (and
+# supplies a diagnostic). Dropping the `|| fail` turns it into a false-green.
+
+# fail <msg> — print the message to the bats failure stream and abort the test.
+fail() {
+  echo "$1" >&2
+  return 1
+}
+
+setup() {
+  COMMON="$BATS_TEST_DIRNAME/../cli/_common.sh"
+
+  # ── Fake docker on PATH ────────────────────────────────────────────────────
+  # apply_isolation runs `$COMPOSE_CMD down` and the reaper runs
+  # `docker ps -q --filter ...`. Both must be stubbed so no real docker is hit.
+  # The `ps` behavior is driven by $DOCKER_PS_OUTPUT so individual tests can make
+  # a project look live (non-empty) or dead (empty).
+  STUB_DIR="$BATS_TEST_TMPDIR/stub"
+  mkdir -p "$STUB_DIR"
+  cat > "$STUB_DIR/docker" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  ps)      printf '%s' "${DOCKER_PS_OUTPUT:-}"; [ -z "${DOCKER_PS_OUTPUT:-}" ] || echo ;;
+  compose) : ;;  # swallow `docker compose ... down` etc.
+  *)       : ;;
+esac
+exit 0
+STUB
+  chmod +x "$STUB_DIR/docker"
+  PATH="$STUB_DIR:$PATH"
+
+  # ── Fake SHOWCASE_ROOT with the two files apply_isolation rewrites ──────────
+  export SHOWCASE_ROOT_OVERRIDE="$BATS_TEST_TMPDIR/root"
+  mkdir -p "$SHOWCASE_ROOT_OVERRIDE/shared"
+  cat > "$SHOWCASE_ROOT_OVERRIDE/shared/local-ports.json" <<'JSON'
+{
+  "mastra": 3104
+}
+JSON
+  cat > "$SHOWCASE_ROOT_OVERRIDE/docker-compose.local.yml" <<'YML'
+services:
+  aimock:
+    container_name: showcase-aimock
+    ports:
+      - "4010:4010"
+YML
+
+  # ── XDG state base ─────────────────────────────────────────────────────────
+  export XDG_STATE_HOME="$BATS_TEST_TMPDIR/xdg"
+
+  # Default: dead project (no live containers) unless a test overrides it.
+  export DOCKER_PS_OUTPUT=""
+}
+
+# load_common — source _common.sh, then repoint the path vars at the fake root.
+# _common.sh computes SHOWCASE_ROOT from its own location at source time, so we
+# override the derived paths afterward to point at the per-test scratch root.
+load_common() {
+  # shellcheck disable=SC1090
+  source "$COMMON"
+  SHOWCASE_ROOT="$SHOWCASE_ROOT_OVERRIDE"
+  COMPOSE_FILE="$SHOWCASE_ROOT/docker-compose.local.yml"
+  PORTS_FILE="$SHOWCASE_ROOT/shared/local-ports.json"
+  COMPOSE_CMD="docker compose -f $COMPOSE_FILE"
+}
+
+# ── Change 1: runtime state under XDG_STATE_HOME ─────────────────────────────
+
+@test "ISOLATE_SLOT_DIR is rooted under XDG_STATE_HOME, not /tmp" {
+  load_common
+  [[ "$ISOLATE_SLOT_DIR" == "$XDG_STATE_HOME/copilotkit/showcase/slots" ]] \
+    || fail "ISOLATE_SLOT_DIR not under XDG_STATE_HOME: $ISOLATE_SLOT_DIR"
+  # Must NOT be the old hardcoded /tmp registry path (XDG_STATE_HOME itself may
+  # live under /tmp in the bats sandbox, so we pin the exact retired path).
+  [[ "$ISOLATE_SLOT_DIR" != "/tmp/showcase-isolate-slots" ]] \
+    || fail "ISOLATE_SLOT_DIR still the old /tmp registry: $ISOLATE_SLOT_DIR"
+}
+
+@test "state base falls back to \$HOME/.local/state when XDG_STATE_HOME unset" {
+  unset XDG_STATE_HOME
+  export HOME="$BATS_TEST_TMPDIR/home"
+  load_common
+  run _showcase_state_base
+  [ "$status" -eq 0 ] || fail "_showcase_state_base failed: $output"
+  [[ "$output" == "$HOME/.local/state/copilotkit/showcase" ]] \
+    || fail "wrong fallback base: $output"
+}
+
+@test "per-run dir lives under XDG state runs/<name>, not /tmp" {
+  load_common
+  apply_isolation foo
+  [[ "$ISOLATE_TMPDIR" == "$XDG_STATE_HOME/copilotkit/showcase/runs/foo" ]] \
+    || fail "run dir not under XDG state runs/<name>: $ISOLATE_TMPDIR"
+  # Must NOT be the old PID-keyed /tmp scratch dir.
+  [[ "$ISOLATE_TMPDIR" != "${TMPDIR:-/tmp}/showcase-isolate-"* ]] \
+    || fail "run dir still the old /tmp PID scratch dir: $ISOLATE_TMPDIR"
+  [ -d "$ISOLATE_TMPDIR" ] || fail "run dir not created: $ISOLATE_TMPDIR"
+}

--- a/showcase/scripts/cli/_common.sh
+++ b/showcase/scripts/cli/_common.sh
@@ -115,14 +115,129 @@ ISOLATE_PORT_OFFSET=0
 ISOLATE_SLOT=""
 ISOLATE_ACTIVE=false
 ISOLATE_TMPDIR=""
+# Set true by cmd-test.sh when --keep is parsed; read by restore_isolation.
+# Deliberately a namespaced GLOBAL (not a `local` in cmd_test): the EXIT trap
+# fires at top-level script exit, after cmd_test has returned and its locals
+# have unwound. Initializing it here also shields against a stray `keep`-like
+# env var exported by the user flipping teardown behavior.
+ISOLATE_KEEP=false
 
 # Runtime state (slot registry + per-run scratch dirs) lives under
-# XDG_STATE_HOME, NOT /tmp — /tmp gets wiped on reboot and is world-writable,
-# which made stale-slot reaping racy and lost --keep'd run dirs across reboots.
+# XDG_STATE_HOME, NOT /tmp — /tmp is world-writable (which made stale-slot
+# reaping racy) and gets wiped on reboot (which destroyed the registry/run-dir
+# state out from under any surviving docker resources). NB this does NOT make
+# --keep reboot-proof: container-liveness protection counts only RUNNING
+# containers, so after a reboot (or daemon restart / manual docker stop) the
+# kept stack's stopped containers no longer protect its slot — the next
+# claim's sweep reclaims it, composing the remnants down (see
+# _reap_isolate_slot).
 _showcase_state_base() { printf '%s/copilotkit/showcase' "${XDG_STATE_HOME:-$HOME/.local/state}"; }
 
+# Single-user assumption: the slot registry is PER-USER (XDG state), while
+# docker compose project names and host ports are HOST-global. Two different
+# UNIX users running --isolate concurrently on one host each get their own
+# registry, so neither the slot claim nor the duplicate-name guard can see
+# the other user's claims — identical port offsets or same-name projects can
+# collide across users. Accepted: dev hosts are effectively single-user.
+# Note the pid-liveness checks share this assumption: `kill -0` on another
+# user's live pid returns EPERM (read here as "dead"), so cross-user slot
+# protection via pid is also unreliable.
 ISOLATE_SLOT_DIR="$(_showcase_state_base)/slots"
-ISOLATE_STALE_THRESHOLD=7200  # 2 hours in seconds
+ISOLATE_STALE_THRESHOLD=7200  # 2 hours in seconds — slot-age fallback
+# The sweep lock is held only for the duration of one sweep pass (seconds, even
+# with all 46 slots populated). A crashed sweeper's leftover lock must not
+# disable stale reaping for the full 2-hour SLOT threshold — give the lock its
+# own, much shorter staleness threshold.
+ISOLATE_SWEEP_LOCK_STALE_THRESHOLD=60  # seconds
+
+# _file_mtime <path> — epoch mtime of a path, or empty when it cannot be
+# stat'ed (vanished concurrently, permissions). Callers must treat a
+# non-numeric result as "unknown", never as zero.
+_file_mtime() {
+  if [[ "$OSTYPE" == darwin* ]]; then
+    stat -f %m "$1" 2>/dev/null || true
+  else
+    stat -c %Y "$1" 2>/dev/null || true
+  fi
+}
+
+# Reap one stale slot: compose any docker remnants of the recorded project
+# down (best-effort), then remove the slot's runs/<project> scratch dir AND
+# the slot dir itself. Without the runs-dir removal, crashed runs leak orphan
+# run dirs under XDG state forever (nothing else cleans them —
+# restore_isolation only removes the CURRENT run's dir).
+#
+# Kept stacks: container-liveness protection applies only while containers
+# are RUNNING (the sweep's probe is `docker ps -q`, deliberately — `-aq`
+# would let crashed runs' exited containers protect dead slots forever). A
+# --keep'd stack whose containers are stopped-but-present (manual `docker
+# stop`, daemon restart, host reboot) therefore DOES reach this function:
+# its owner pid is dead by design, so the slot is reclaimed. The compose-down
+# below keeps that safe — stopped containers and named volumes are removed
+# along with the state dirs instead of being stranded with no compose state.
+#
+# Order matters: runs/<project> FIRST, slot dir LAST. The slot's project
+# record is the ONLY pointer to the runs dir — a crash between the two
+# removals with the old order (slot first) orphaned the runs dir forever,
+# while with this order a surviving slot record simply makes the next sweep
+# retry the reap.
+_reap_isolate_slot() {
+  local slot_entry="${1:?slot entry required}"
+  local slot_proj="${2:-}"
+  if [ -n "$slot_proj" ]; then
+    # The record comes from a user-writable state file — never interpolate it
+    # into rm -rf unvalidated (a corrupted record like "../.." would traverse
+    # out of the runs dir). Compose project names are [a-z0-9][a-z0-9_-]*; on
+    # mismatch, warn and leave the SLOT intact too: the record is the ONLY
+    # pointer to the runs dir (see the header above), so reaping the slot
+    # anyway would orphan whatever runs dir the record actually points at.
+    # A corrupted record is a bug or tampering — leave the evidence in place
+    # for manual inspection rather than half-destroy it.
+    if [[ "$slot_proj" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+      # Best-effort remnant cleanup BEFORE deleting any state: a stopped kept
+      # stack (see the header) still has containers + named volumes; deleting
+      # the run dir + slot first would strand them with no compose state
+      # (split-brain). `compose -p` resolves resources via project labels, so
+      # no -f compose file is needed; failure (daemon down, nothing to remove)
+      # is non-fatal — the rm below still reclaims the state dirs.
+      docker compose -p "$slot_proj" down --remove-orphans --volumes >/dev/null 2>&1 || true
+      # State-removal rms are guarded throughout this file: a concurrent
+      # claimant/release can race the same path, and the loser's mid-traversal
+      # ENOENT makes rm exit nonzero — which must not kill the CLI under
+      # bin/showcase's `set -e` (the state is gone either way).
+      rm -rf "$(_showcase_state_base)/runs/$slot_proj" 2>/dev/null || true
+    else
+      warn "Slot record at $slot_entry names suspicious project '$slot_proj' (path-traversal guard) — leaving the slot intact for manual inspection; its runs dir would be $(_showcase_state_base)/runs/$slot_proj"
+      return 0
+    fi
+  fi
+  rm -rf "$slot_entry" 2>/dev/null || true
+}
+
+# Release the sweep lock — but ONLY if it is still ours. The takeover path
+# below can legitimately move an over-age lock out from under a slow-but-live
+# holder and install a fresh lock of its own; if the original holder then
+# blindly removed "$sweep_lock" on its way out, it would destroy the
+# TAKEOVER's lock and open the door to a THIRD concurrent sweeper. Ownership
+# is the pid file written into the lock dir at acquisition.
+_release_sweep_lock() {
+  local sweep_lock="${1:?sweep lock path required}"
+  # Lock (or its pid ownership marker) gone entirely: nothing to release and
+  # no holder to report — a takeover mv'd it away, or something external
+  # cleaned it up. Distinct from the takeover case below, which has an actual
+  # current holder's lock that must be left in place.
+  if [ ! -d "$sweep_lock" ] || [ ! -f "$sweep_lock/pid" ]; then
+    warn "Sweep lock $sweep_lock vanished while we held it (takeover or external cleanup) — leaving as-is"
+    return 0
+  fi
+  local lock_pid
+  lock_pid="$(cat "$sweep_lock/pid" 2>/dev/null || true)"
+  if [ "$lock_pid" = "$$" ]; then
+    rm -rf "$sweep_lock"
+  else
+    warn "Sweep lock $sweep_lock was taken over while we held it (current holder pid: ${lock_pid:-unknown}) — leaving it in place"
+  fi
+}
 
 # Claim an isolation slot using atomic mkdir. Slots start at 0 and increment.
 # Each slot dir contains a "pid" file for stale-detection. The port offset is
@@ -130,49 +245,84 @@ ISOLATE_STALE_THRESHOLD=7200  # 2 hours in seconds
 _claim_isolate_slot() {
   mkdir -p "$ISOLATE_SLOT_DIR"
 
-  # Clean up stale slots first. Preferred signal: compose-project liveness — a
-  # slot whose recorded project has NO live containers is dead, regardless of
-  # PID/age (this correctly LEAVES a --keep'd stack's slot alone, since its
-  # containers are still up). PID/age heuristics remain as a fallback for slots
-  # predating the "project" file.
-  local slot_entry
-  for slot_entry in "$ISOLATE_SLOT_DIR"/[0-9]*; do
-    [ -d "$slot_entry" ] || continue
-    local slot_proj
-    slot_proj="$(cat "$slot_entry/project" 2>/dev/null)"
-    if [ -n "$slot_proj" ]; then
-      if [ -z "$(docker ps -q --filter "label=com.docker.compose.project=$slot_proj" 2>/dev/null)" ]; then
-        info "Reclaiming stale slot $(basename "$slot_entry") (project $slot_proj has no live containers)"
-        rm -rf "$slot_entry"
-      fi
-      # Project recorded → liveness is authoritative; skip PID/age fallback.
-      continue
-    fi
-    local slot_pid_file="$slot_entry/pid"
-    if [ -f "$slot_pid_file" ]; then
-      local slot_pid
-      slot_pid="$(cat "$slot_pid_file" 2>/dev/null)"
-      # If the PID is dead, remove the stale slot
-      if [ -n "$slot_pid" ] && ! kill -0 "$slot_pid" 2>/dev/null; then
-        info "Reclaiming stale slot $(basename "$slot_entry") (PID $slot_pid dead)"
-        rm -rf "$slot_entry"
-        continue
-      fi
-    fi
-    # Fallback: age-based cleanup if no pid file or pid check inconclusive
-    if [ ! -f "$slot_pid_file" ]; then
-      local slot_age
-      if [[ "$OSTYPE" == darwin* ]]; then
-        slot_age=$(( $(date +%s) - $(stat -f %m "$slot_entry") ))
-      else
-        slot_age=$(( $(date +%s) - $(stat -c %Y "$slot_entry") ))
-      fi
-      if [ "$slot_age" -gt "$ISOLATE_STALE_THRESHOLD" ]; then
-        info "Reclaiming stale slot $(basename "$slot_entry") (age ${slot_age}s > ${ISOLATE_STALE_THRESHOLD}s)"
-        rm -rf "$slot_entry"
-      fi
+  # Reclaim crashed-takeover tombstones: a sweeper that died between the
+  # takeover mv and its rm -rf (below) leaves .sweep.lock.tomb.<pid> behind
+  # forever — dot-named, so neither the sweep glob nor the claim loop ever
+  # sees it, and nothing else cleans it. Age them by the LOCK threshold: a
+  # fresh tombstone may belong to a takeover in flight (mv done, rm pending),
+  # so only over-age ones are removed.
+  local tomb
+  for tomb in "$ISOLATE_SLOT_DIR"/.sweep.lock.tomb.*; do
+    [ -e "$tomb" ] || continue
+    local tomb_mtime
+    tomb_mtime="$(_file_mtime "$tomb")"
+    [[ "$tomb_mtime" =~ ^[0-9]+$ ]] || continue
+    if [ $(( $(date +%s) - tomb_mtime )) -gt "$ISOLATE_SWEEP_LOCK_STALE_THRESHOLD" ]; then
+      # This cleanup runs OUTSIDE the sweep lock by design: two claimants can
+      # both observe the same over-age tombstone and race the removal, and the
+      # loser's mid-traversal ENOENT makes rm exit nonzero — which must not
+      # kill the CLI under `set -e` (losing the race is fine; the tombstone is
+      # gone either way).
+      rm -rf "$tomb" 2>/dev/null || true
     fi
   done
+
+  # Serialize the stale sweep with a lock dir. Without it, two concurrent
+  # claimants can both observe slot N stale: A reaps + re-claims it (writing a
+  # live pid), then B reaps A's FRESH claim based on its stale observation and
+  # claims the same slot — two owners, identical port offsets. The lock is
+  # advisory and non-blocking: if another process holds it, we SKIP the sweep
+  # entirely (that process is already sweeping) and go straight to the claim
+  # loop. The dot-name keeps the lock out of the sweep's [0-9]* glob and the
+  # claim loop's numeric slot names.
+  local sweep_lock="$ISOLATE_SLOT_DIR/.sweep.lock"
+  local have_sweep_lock=false
+  if mkdir "$sweep_lock" 2>/dev/null; then
+    echo "$$" > "$sweep_lock/pid"   # ownership marker for _release_sweep_lock
+    have_sweep_lock=true
+  else
+    # Lock held — but a sweeper that crashed mid-sweep would leave it behind
+    # forever, permanently disabling stale reaping. Take over an over-age lock
+    # (dedicated short threshold: the lock is held for seconds, not hours);
+    # otherwise (fresh lock, or lock vanished between our mkdir and the stat)
+    # skip the sweep this round. A LIVE sweeper refreshes the lock mtime every
+    # slot iteration (heartbeat in _sweep_isolate_slots), so an over-age lock
+    # really does mean a crashed/wedged holder.
+    local lock_mtime
+    lock_mtime="$(_file_mtime "$sweep_lock")"
+    if [[ "$lock_mtime" =~ ^[0-9]+$ ]] \
+      && [ $(( $(date +%s) - lock_mtime )) -gt "$ISOLATE_SWEEP_LOCK_STALE_THRESHOLD" ]; then
+      # Atomic takeover: rename the stale lock aside to a unique tombstone
+      # first. Two claimants can BOTH observe the lock over-age; with a plain
+      # rm+mkdir the slower one could rm the faster one's FRESH replacement
+      # lock and retake it — two concurrent sweepers. rename(2) is atomic:
+      # exactly one mv wins, the loser's mv fails and it simply skips the
+      # sweep this round (it must NOT remove a lock the winner may already
+      # have refreshed). The winner disposes of the tombstone and takes a
+      # brand-new lock. A crash between mv and rm leaves only a dot-named
+      # tombstone, invisible to both the sweep glob and the claim loop —
+      # reclaimed once over-age by the tombstone cleanup at the top of this
+      # function.
+      local lock_tombstone="$ISOLATE_SLOT_DIR/.sweep.lock.tomb.$$"
+      if mv "$sweep_lock" "$lock_tombstone" 2>/dev/null; then
+        warn "Removing stale sweep lock (crashed sweeper?): $sweep_lock"
+        # Guarded: mv preserves the lock's (already over-age) mtime, so this
+        # fresh tombstone is immediately over-age too — concurrent claimants'
+        # tombstone-reclamation loops (top of this function) legitimately race
+        # this removal, and the loser's nonzero rm must not kill the CLI.
+        rm -rf "$lock_tombstone" 2>/dev/null || true
+        if mkdir "$sweep_lock" 2>/dev/null; then
+          echo "$$" > "$sweep_lock/pid"   # ownership marker for _release_sweep_lock
+          have_sweep_lock=true
+        fi
+      fi
+    fi
+  fi
+
+  if [ "$have_sweep_lock" = true ]; then
+    _sweep_isolate_slots
+    _release_sweep_lock "$sweep_lock"
+  fi
 
   # Claim the first available slot (mkdir is atomic — if it succeeds, we own it)
   local n=0
@@ -190,32 +340,167 @@ _claim_isolate_slot() {
   done
 }
 
-# Release the claimed isolation slot
+# Sweep stale slots. Caller (_claim_isolate_slot) MUST hold .sweep.lock.
+_sweep_isolate_slots() {
+  # Staleness signals, in order:
+  #   1. Compose-project liveness: RUNNING containers always protect the slot
+  #      (this is what keeps a --keep'd stack — owning process gone, containers
+  #      still up — from being stolen). RUNNING only, deliberately (`docker ps
+  #      -q`, not `-aq`): exited containers from crashed runs must not protect
+  #      dead slots forever, so a kept stack whose containers were STOPPED
+  #      (docker stop, daemon restart, reboot) is reclaimed — with its
+  #      remnants composed down by _reap_isolate_slot. A docker failure is NOT
+  #      "no containers": if we cannot ask, we leave the slot alone.
+  #   2. Owning-PID liveness: a live owning PID always protects the slot. This
+  #      matters because apply_isolation records the project BEFORE any
+  #      container starts (image builds can take minutes), so "project recorded
+  #      + zero containers" alone is NOT proof of staleness.
+  #   3. Age: fallback when the pid check is inconclusive — the pid file is
+  #      missing on a slot with no recorded project (legacy slots predating
+  #      the "project" file), or the pid file EXISTS but its contents are
+  #      empty/non-numeric on ANY slot (possibly a live owner whose pid write
+  #      was truncated — inconclusive, so it defers to the age fallback
+  #      rather than being reaped immediately; once the slot is older than
+  #      ISOLATE_STALE_THRESHOLD it IS reaped, inconclusive pid and all,
+  #      so such slots don't leak forever). A project-recorded slot
+  #      with NO pid file at all is reaped directly: the claim writes the pid
+  #      file before the project record, so its absence means the owner state
+  #      is genuinely gone.
+  local sweep_lock="$ISOLATE_SLOT_DIR/.sweep.lock"
+  local slot_entry
+  for slot_entry in "$ISOLATE_SLOT_DIR"/[0-9]*; do
+    [ -d "$slot_entry" ] || continue
+    # Heartbeat: refresh the lock mtime at the top of every iteration so a
+    # LIVE sweep never looks over-age to a concurrent claimant. A full sweep
+    # makes up to 46 `docker ps` calls; a wedged daemon can stretch that past
+    # ISOLATE_SWEEP_LOCK_STALE_THRESHOLD, and without the heartbeat the
+    # claimant would "take over" the lock from a sweeper that is still
+    # running. Refresh-only, NEVER create: -c behind the -d guard. A bare
+    # `touch` here used to RECREATE the lock as a plain FILE when a takeover
+    # mv'd the dir away mid-iteration — the takeover's mkdir then failed
+    # against the file and sweeping wedged until the 60s over-age self-heal.
+    # Failure/vanished lock is non-fatal (_release_sweep_lock handles the
+    # taken-over/vanished cases on the way out).
+    [ -d "$sweep_lock" ] && touch -c "$sweep_lock" 2>/dev/null || true
+    local slot_name
+    slot_name="$(basename "$slot_entry")"
+    local slot_proj has_proj=false
+    slot_proj="$(cat "$slot_entry/project" 2>/dev/null || true)"
+    if [ -n "$slot_proj" ]; then
+      has_proj=true
+      local live_containers
+      if ! live_containers="$(docker ps -q --filter "label=com.docker.compose.project=$slot_proj" 2>/dev/null)"; then
+        warn "Cannot verify liveness of slot $slot_name (docker ps failed) — leaving it alone"
+        continue
+      fi
+      if [ -n "$live_containers" ]; then
+        # Live containers → in use (covers --keep'd stacks whose owner exited).
+        continue
+      fi
+      # Zero live containers is inconclusive (project file is written before
+      # the containers start) — fall through to the owning-PID check.
+    fi
+    local slot_pid_file="$slot_entry/pid"
+    local slot_pid="" pid_file_present=false
+    if [ -f "$slot_pid_file" ]; then
+      pid_file_present=true
+      slot_pid="$(cat "$slot_pid_file" 2>/dev/null || true)"
+    fi
+    if [[ "$slot_pid" =~ ^[0-9]+$ ]]; then
+      if kill -0 "$slot_pid" 2>/dev/null; then
+        # Live owning PID always protects the slot.
+        continue
+      fi
+      info "Attempting to reclaim stale slot $slot_name (PID $slot_pid dead)"
+      _reap_isolate_slot "$slot_entry" "$slot_proj"
+      continue
+    fi
+    if [ "$has_proj" = true ] && [ "$pid_file_present" = false ]; then
+      # Project recorded, no live containers, and no pid file at all — the
+      # claim writes the pid file BEFORE the project record, so a missing pid
+      # file means the owner state is genuinely gone. A pid file that EXISTS
+      # but is empty/non-numeric is NOT the same thing: it may be a live owner
+      # mid-build whose pid write was truncated — that case is INCONCLUSIVE
+      # and falls through to the age fallback below instead of being reaped.
+      info "Attempting to reclaim stale slot $slot_name (project $slot_proj has no live containers and no recorded owner)"
+      _reap_isolate_slot "$slot_entry" "$slot_proj"
+      continue
+    fi
+    # Fallback: age-based cleanup when the pid check is inconclusive (pid file
+    # missing on a project-less legacy slot, or present-but-empty/non-numeric
+    # contents on any slot). Capture the mtime with a
+    # failure guard: a concurrent release can rm -rf the slot between our glob
+    # and this stat, and an empty substitution inside $(( )) is a syntax error
+    # that would kill the whole CLI under `set -e`. A vanished slot needs no
+    # reaping — skip it.
+    local slot_mtime
+    slot_mtime="$(_file_mtime "$slot_entry")"
+    [[ "$slot_mtime" =~ ^[0-9]+$ ]] || continue
+    local slot_age
+    slot_age=$(( $(date +%s) - slot_mtime ))
+    if [ "$slot_age" -gt "$ISOLATE_STALE_THRESHOLD" ]; then
+      # Surface WHY the pid check was inconclusive — it's the evidence that
+      # routed this slot to the age fallback in the first place.
+      local pid_evidence="no pid file"
+      if [ "$pid_file_present" = true ]; then
+        pid_evidence="pid file present but empty/non-numeric"
+      fi
+      info "Attempting to reclaim stale slot $slot_name (age ${slot_age}s > ${ISOLATE_STALE_THRESHOLD}s; owner-pid check inconclusive: $pid_evidence)"
+      _reap_isolate_slot "$slot_entry" "$slot_proj"
+    fi
+  done
+}
+
+# Release the claimed isolation slot. The parent slots dir is deliberately
+# LEFT IN PLACE: removing it here raced a concurrent claimer between its
+# `mkdir -p` of the parent and its per-slot mkdir — every slot mkdir then
+# failed ENOENT and the claimer died "No isolation slots available". An empty
+# slots dir under XDG state is harmless.
 _release_isolate_slot() {
   if [ -n "$ISOLATE_SLOT" ] && [ -d "$ISOLATE_SLOT_DIR/$ISOLATE_SLOT" ]; then
-    rm -rf "$ISOLATE_SLOT_DIR/$ISOLATE_SLOT"
+    rm -rf "$ISOLATE_SLOT_DIR/$ISOLATE_SLOT" 2>/dev/null || true
   fi
-  # Remove the parent dir if now empty
-  rmdir "$ISOLATE_SLOT_DIR" 2>/dev/null || true
   ISOLATE_SLOT=""
 }
 
+# Contract: callers MUST arm `trap restore_isolation EXIT` BEFORE calling this
+# function (cmd-test.sh does). Every die() below — invalid name, slot
+# exhaustion, duplicate-name conflict, rewriter failure — relies on that trap
+# for cleanup of the claimed slot (and, once created, the runs/<name> dir).
 apply_isolation() {
   local name="${1:-}"
-  ISOLATE_ACTIVE=true
+  # NB: ISOLATE_ACTIVE is deliberately NOT set here. cmd-test.sh arms
+  # `trap restore_isolation EXIT` BEFORE calling this function, so if we
+  # flipped it true before COMPOSE_CMD is repointed at the isolated project,
+  # any die() below (invalid name, slot exhaustion) would make the trap run
+  # `$COMPOSE_CMD down` against the ORIGINAL compose file — silently tearing
+  # down the user's live DEFAULT stack. It is set only after the repoint.
 
-  # docker compose project names must be lowercase ([a-z0-9_-]). Reject (or
-  # normalize) uppercase so the user gets a clear error instead of an opaque
-  # compose failure. We normalize-with-warn for ergonomic CLI use.
-  if [ -n "$name" ] && [[ "$name" =~ [^a-z0-9_-] ]]; then
+  # docker compose project names must start with a lowercase letter or digit,
+  # followed by lowercase letters, digits, '-' or '_' ([a-z0-9][a-z0-9_-]*).
+  # Reject (or normalize) anything else so the user gets a clear error instead
+  # of an opaque compose failure. We normalize-with-warn for ergonomic CLI use.
+  if [ -n "$name" ] && ! [[ "$name" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
     local lowered
     lowered="$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')"
-    if [[ "$lowered" =~ ^[a-z0-9_-]+$ ]]; then
+    if [[ "$lowered" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
       warn "Isolation name '$name' has uppercase chars; lowercasing to '$lowered' (docker compose project-name constraint)"
       name="$lowered"
     else
-      die "Invalid --isolate name '$name': must match [a-z0-9_-]+ (docker compose project-name constraint)"
+      die "Invalid --isolate name '$name': must start with a lowercase letter or digit, then lowercase letters, digits, '-' or '_' (docker compose project-name constraint)"
     fi
+  fi
+
+  # Reserved name: 'showcase' IS the default stack's compose project name
+  # (docker compose defaults the project name to the directory name). It
+  # passes the charset check, the container-name rewrite showcase- →
+  # showcase- is a no-op, and the idempotent pre-down below would then run
+  # `--project-name showcase down --remove-orphans --volumes` against the
+  # user's LIVE DEFAULT stack — bypassing every other guard in this file.
+  # Checked AFTER the lowercase normalization (so 'Showcase' is caught too)
+  # and BEFORE any compose command or state write.
+  if [ "$name" = "showcase" ]; then
+    die "Isolation name 'showcase' is reserved: it collides with the default stack's compose project name (compose defaults the project to the directory name), so --isolate showcase would tear down the live default stack — pick another name"
   fi
 
   # Guard: clean up stale .iso-bak files from a prior botched run that
@@ -233,15 +518,71 @@ apply_isolation() {
   if [ -z "$name" ]; then
     name="showcase-iso${ISOLATE_SLOT}"
   fi
+
   ISOLATE_NAME="$name"
   export COMPOSE_PROJECT_NAME="$name"
 
-  # Record the compose project alongside the slot's pid file so the next claim's
-  # stale-sweep can reap this slot by container liveness (project file written
-  # here, AFTER the name is finalized; the slot was claimed PID-first above).
-  if [ -n "$ISOLATE_SLOT" ] && [ -d "$ISOLATE_SLOT_DIR/$ISOLATE_SLOT" ]; then
-    echo "$name" > "$ISOLATE_SLOT_DIR/$ISOLATE_SLOT/project"
+  # Duplicate-name guard, claim-then-verify. The slot registry only enforces
+  # SLOT uniqueness, but the idempotent pre-down below keys on the compose
+  # project NAME: a second run reusing a live explicit name would get a
+  # different slot yet the same compose project — its pre-down would silently
+  # tear down the first run's containers mid-test (or a --keep-parked stack),
+  # and two slots recording the same project would corrupt the liveness-reaping
+  # signal. Re-running a name after clean teardown still works: the old slot
+  # was released, so no record remains.
+  #
+  # We record our project on our own slot FIRST, and only THEN scan the other
+  # slots. (Scan-then-write was a TOCTOU hole: two concurrent same-name claims
+  # could both pass the scan and both record the name.) With write-then-scan,
+  # the later writer of any concurrent pair is guaranteed to see the earlier
+  # writer's record. Backoff is deterministic: we lose against any conflicting
+  # record that does NOT strictly postdate ours (older or equal mtime — a
+  # strictly NEWER record means the other claimant wrote after us, so its own
+  # scan sees our record and IT backs off). Established runs always have older
+  # records and therefore always win; two same-second claimants may BOTH back
+  # off, which is safe (the names were colliding anyway — nobody tears down a
+  # stack they don't own).
+  #
+  # The verify runs BEFORE the runs/<name> dir is created, so on the
+  # conflict-die path ISOLATE_TMPDIR is still unset and the loser's EXIT-trap
+  # cleanup removes ONLY its own slot dir — it can never touch the winner's
+  # run dir.
+  local our_record="$ISOLATE_SLOT_DIR/$ISOLATE_SLOT/project"
+  echo "$name" > "$our_record"
+  local our_mtime
+  our_mtime="$(_file_mtime "$our_record")"
+  local other_slot conflict_slot=""
+  for other_slot in "$ISOLATE_SLOT_DIR"/[0-9]*; do
+    [ -d "$other_slot" ] || continue
+    local other_num
+    other_num="$(basename "$other_slot")"
+    [[ "$other_num" =~ ^[0-9]+$ ]] || continue
+    if [ "$other_num" = "$ISOLATE_SLOT" ]; then
+      continue
+    fi
+    local other_proj
+    other_proj="$(cat "$other_slot/project" 2>/dev/null || true)"
+    [ "$other_proj" = "$name" ] || continue
+    local other_mtime
+    other_mtime="$(_file_mtime "$other_slot/project")"
+    # Record vanished between the read and the stat (a concurrent loser
+    # backing off, or a sweep) — no conflict.
+    [[ "$other_mtime" =~ ^[0-9]+$ ]] || continue
+    if ! [[ "$our_mtime" =~ ^[0-9]+$ ]] || [ "$other_mtime" -le "$our_mtime" ]; then
+      conflict_slot="$other_num"
+      break
+    fi
+    # Other record strictly postdates ours → the other claimant is the loser
+    # of this pair (its post-write scan sees our older record); keep scanning.
+  done
+  if [ -n "$conflict_slot" ]; then
+    die "isolate name '$name' is already in use by slot $conflict_slot — pick another name, or tear the existing stack down first: docker compose -p $name down --remove-orphans --volumes (if no such run exists, the record may be stale — the sweep is skipped while another run holds the lock; re-running usually resolves it)"
   fi
+
+  # The rewriters below need python3 — check now, with a clear message, while
+  # the runs/<name> dir does not exist yet (a die here leaves only our slot
+  # for the EXIT trap to clean).
+  command -v python3 >/dev/null 2>&1 || die "python3 is required for --isolate"
 
   # Create per-run scratch dir for overlay copies (originals stay untouched).
   # Keyed by the finalized project name (not the PID) so a --keep'd run is
@@ -315,6 +656,10 @@ with open('$tmp_compose', 'w') as f:
   COMPOSE_CMD="docker compose -f $COMPOSE_FILE --project-name $name"
   PORTS_FILE="$tmp_ports"
 
+  # Only NOW is it safe for restore_isolation to compose-down: COMPOSE_CMD
+  # points at the isolated project (see the note at the top of this function).
+  ISOLATE_ACTIVE=true
+
   # Export for the TS harness CLI (config.ts / lifecycle.ts honor these).
   # Without SHOWCASE_COMPOSE_FILE the harness hardcodes the default compose
   # path, causing container-name collisions on a second concurrent --isolate.
@@ -336,19 +681,45 @@ with open('$tmp_compose', 'w') as f:
   export DASHBOARD_PORT_LOCAL="$dashboard_host_port"
   export POCKETBASE_URL_LOCAL="http://localhost:${pocketbase_host_port}"
 
-  # Idempotent: tear down any prior run with this name
-  $COMPOSE_CMD down --remove-orphans 2>/dev/null || true
+  # Idempotent: tear down any prior run with this name. --volumes matches
+  # every other teardown path (automatic, --keep notice, failed-down
+  # recovery) — without it a reused name inherits the prior crashed run's
+  # named volumes, i.e. stale DB state. A failure here is non-fatal (the
+  # common case is simply "nothing to tear down"), but it must not be SILENT:
+  # leftover containers/volumes from a prior crashed run are exactly the state
+  # this pre-clean exists to remove, so at least warn that they may remain.
+  local pre_down_err=""
+  if ! pre_down_err="$($COMPOSE_CMD down --remove-orphans --volumes 2>&1 >/dev/null)"; then
+    warn "pre-clean of project $name failed — stale containers/volumes may remain${pre_down_err:+: ${pre_down_err}}"
+  fi
 
   info "Isolation active: project=$name slot=$ISOLATE_SLOT ports=+$ISOLATE_PORT_OFFSET tmpdir=$ISOLATE_TMPDIR"
 }
 
 restore_isolation() {
+  if ! $ISOLATE_ACTIVE; then
+    # Half-initialized: apply_isolation died AFTER _claim_isolate_slot but
+    # BEFORE ISOLATE_ACTIVE=true (duplicate name, python3 failure, ...). The
+    # not-active guard exists to protect the user's DEFAULT stack from a
+    # compose-down, and that protection stays absolute — clean up ONLY our own
+    # state (the claimed slot dir and the runs/<name> scratch dir), with no
+    # compose command of any kind. With no slot claimed this remains a pure
+    # no-op.
+    if [ -n "$ISOLATE_SLOT" ]; then
+      if [ -n "$ISOLATE_TMPDIR" ] && [ -d "$ISOLATE_TMPDIR" ]; then
+        rm -rf "$ISOLATE_TMPDIR" 2>/dev/null || true
+      fi
+      _release_isolate_slot
+    fi
+    return 0
+  fi
   if $ISOLATE_ACTIVE; then
     # --keep: leave the stack standing. Do NOT compose-down, do NOT remove the
     # run dir, do NOT release the slot — the live containers keep the slot from
-    # being reaped (Change 2). Print a survival notice with everything needed to
-    # reach and later tear down the stack by hand.
-    if [ "${keep:-false}" = true ]; then
+    # being reaped (the stale-sweep in _claim_isolate_slot treats a slot whose
+    # project has live containers as in use). Print a survival notice with
+    # everything needed to reach and later tear down the stack by hand.
+    if [ "${ISOLATE_KEEP:-false}" = true ]; then
       local aimock_host_port=$(( 4010 + ISOLATE_PORT_OFFSET ))
       local dashboard_host_port=$(( 3200 + ISOLATE_PORT_OFFSET ))
       local pocketbase_host_port=$(( 8090 + ISOLATE_PORT_OFFSET ))
@@ -356,16 +727,75 @@ restore_isolation() {
       info "  aimock:     http://localhost:${aimock_host_port}"
       info "  dashboard:  http://localhost:${dashboard_host_port}"
       info "  pocketbase: http://localhost:${pocketbase_host_port}"
-      info "  tear down:  docker compose -p $ISOLATE_NAME down --remove-orphans && rm -rf $ISOLATE_TMPDIR $ISOLATE_SLOT_DIR/$ISOLATE_SLOT"
+      info "  tear down:  docker compose -p $ISOLATE_NAME down --remove-orphans --volumes && rm -rf \"$ISOLATE_TMPDIR\" \"$ISOLATE_SLOT_DIR/$ISOLATE_SLOT\""
       ISOLATE_ACTIVE=false
+      # Disown the surviving state: with ISOLATE_ACTIVE back to false, a
+      # repeated restore_isolation would otherwise hit the half-initialized
+      # cleanup above and silently destroy the kept slot + run dir.
+      ISOLATE_SLOT=""
+      ISOLATE_TMPDIR=""
       return 0
     fi
 
     info "Tearing down isolated group: $ISOLATE_NAME (slot $ISOLATE_SLOT)"
-    $COMPOSE_CMD down --remove-orphans 2>/dev/null || true
+    # Belt-and-suspenders: only compose-down when the isolated state is fully
+    # initialized — a non-empty isolated project name AND COMPOSE_CMD actually
+    # repointed at that project. A half-initialized state (e.g. die() partway
+    # through apply_isolation) must never down the user's default stack.
+    # Unreachable today (apply_isolation sets ISOLATE_ACTIVE only after the
+    # repoint), but if state ever diverges, the mismatch branch below must be
+    # SAFE: skipping the down while still deleting the run dir and releasing
+    # the slot would manufacture the exact split-brain documented at the
+    # failed-down branch — a possibly-running stack whose only compose state
+    # is gone and whose slot is reclaimable.
+    # End-anchored (no trailing *): the project name is the FINAL token of
+    # COMPOSE_CMD as built by apply_isolation, and a substring match would let
+    # '--project-name foo2' satisfy the guard for ISOLATE_NAME=foo (prefix
+    # collision) — pointing the compose-down at the wrong project.
+    if [ -z "$ISOLATE_NAME" ] || [[ "$COMPOSE_CMD" != *"--project-name $ISOLATE_NAME" ]]; then
+      warn "Isolation state mismatch: ISOLATE_ACTIVE=true but COMPOSE_CMD is not pointed at project '${ISOLATE_NAME:-<unset>}' — skipping compose-down (unknown target)"
+      warn "Preserving run dir and slot $ISOLATE_SLOT for manual recovery:"
+      # With an EMPTY ISOLATE_NAME there is no compose project to name — a
+      # 'docker compose -p  down' hint would be malformed; print only the
+      # state-cleanup half in that case.
+      if [ -n "$ISOLATE_NAME" ]; then
+        warn "  tear down:  docker compose -p $ISOLATE_NAME down --remove-orphans --volumes && rm -rf \"$ISOLATE_TMPDIR\" \"$ISOLATE_SLOT_DIR/$ISOLATE_SLOT\""
+      else
+        warn "  clean up:   rm -rf \"$ISOLATE_TMPDIR\" \"$ISOLATE_SLOT_DIR/$ISOLATE_SLOT\""
+      fi
+      ISOLATE_ACTIVE=false
+      # Disown the kept-for-recovery state (see the --keep branch above): a
+      # repeated restore_isolation must not destroy it via the
+      # half-initialized cleanup.
+      ISOLATE_SLOT=""
+      ISOLATE_TMPDIR=""
+      return 0
+    fi
+    # Fail-loud: a silently failed compose-down (stderr to /dev/null,
+    # `|| true`) once left the stack RUNNING while the run dir — the only
+    # copy of the rewritten compose file — and the slot were deleted out
+    # from under it: live containers with no state and a re-claimable slot
+    # (port collisions). On failure, keep the run dir AND the slot (same as
+    # --keep) and print the manual teardown command so recovery is possible.
+    # --volumes keeps the automatic teardown consistent with both printed
+    # manual teardown commands (keep notice + failed-down recovery above and
+    # below): isolated test stacks are ephemeral, and without it every run
+    # leaks project-scoped named volumes (unbounded for explicit names).
+    if ! $COMPOSE_CMD down --remove-orphans --volumes; then
+      warn "compose down FAILED for isolated project $ISOLATE_NAME — stack may still be running"
+      warn "Keeping run dir and slot $ISOLATE_SLOT for manual recovery:"
+      warn "  tear down:  docker compose -p $ISOLATE_NAME down --remove-orphans --volumes && rm -rf \"$ISOLATE_TMPDIR\" \"$ISOLATE_SLOT_DIR/$ISOLATE_SLOT\""
+      ISOLATE_ACTIVE=false
+      # Disown the kept-for-recovery state (see the --keep branch above):
+      # a repeated restore_isolation must not destroy it via the
+      # half-initialized cleanup.
+      ISOLATE_SLOT=""
+      ISOLATE_TMPDIR=""
+      return 0
+    fi
     # Just remove the temp dir — originals were never touched
     if [ -n "$ISOLATE_TMPDIR" ] && [ -d "$ISOLATE_TMPDIR" ]; then
-      rm -rf "$ISOLATE_TMPDIR"
+      rm -rf "$ISOLATE_TMPDIR" 2>/dev/null || true
     fi
     # Release the isolation slot so other runs can claim it
     _release_isolate_slot

--- a/showcase/scripts/cli/_common.sh
+++ b/showcase/scripts/cli/_common.sh
@@ -130,10 +130,24 @@ ISOLATE_STALE_THRESHOLD=7200  # 2 hours in seconds
 _claim_isolate_slot() {
   mkdir -p "$ISOLATE_SLOT_DIR"
 
-  # Clean up stale slots first (crashed runs older than 2 hours, or dead PIDs)
+  # Clean up stale slots first. Preferred signal: compose-project liveness — a
+  # slot whose recorded project has NO live containers is dead, regardless of
+  # PID/age (this correctly LEAVES a --keep'd stack's slot alone, since its
+  # containers are still up). PID/age heuristics remain as a fallback for slots
+  # predating the "project" file.
   local slot_entry
   for slot_entry in "$ISOLATE_SLOT_DIR"/[0-9]*; do
     [ -d "$slot_entry" ] || continue
+    local slot_proj
+    slot_proj="$(cat "$slot_entry/project" 2>/dev/null)"
+    if [ -n "$slot_proj" ]; then
+      if [ -z "$(docker ps -q --filter "label=com.docker.compose.project=$slot_proj" 2>/dev/null)" ]; then
+        info "Reclaiming stale slot $(basename "$slot_entry") (project $slot_proj has no live containers)"
+        rm -rf "$slot_entry"
+      fi
+      # Project recorded → liveness is authoritative; skip PID/age fallback.
+      continue
+    fi
     local slot_pid_file="$slot_entry/pid"
     if [ -f "$slot_pid_file" ]; then
       local slot_pid
@@ -221,6 +235,13 @@ apply_isolation() {
   fi
   ISOLATE_NAME="$name"
   export COMPOSE_PROJECT_NAME="$name"
+
+  # Record the compose project alongside the slot's pid file so the next claim's
+  # stale-sweep can reap this slot by container liveness (project file written
+  # here, AFTER the name is finalized; the slot was claimed PID-first above).
+  if [ -n "$ISOLATE_SLOT" ] && [ -d "$ISOLATE_SLOT_DIR/$ISOLATE_SLOT" ]; then
+    echo "$name" > "$ISOLATE_SLOT_DIR/$ISOLATE_SLOT/project"
+  fi
 
   # Create per-run scratch dir for overlay copies (originals stay untouched).
   # Keyed by the finalized project name (not the PID) so a --keep'd run is

--- a/showcase/scripts/cli/_common.sh
+++ b/showcase/scripts/cli/_common.sh
@@ -344,6 +344,23 @@ with open('$tmp_compose', 'w') as f:
 
 restore_isolation() {
   if $ISOLATE_ACTIVE; then
+    # --keep: leave the stack standing. Do NOT compose-down, do NOT remove the
+    # run dir, do NOT release the slot — the live containers keep the slot from
+    # being reaped (Change 2). Print a survival notice with everything needed to
+    # reach and later tear down the stack by hand.
+    if [ "${keep:-false}" = true ]; then
+      local aimock_host_port=$(( 4010 + ISOLATE_PORT_OFFSET ))
+      local dashboard_host_port=$(( 3200 + ISOLATE_PORT_OFFSET ))
+      local pocketbase_host_port=$(( 8090 + ISOLATE_PORT_OFFSET ))
+      info "Kept isolated group standing: project=$ISOLATE_NAME slot=$ISOLATE_SLOT"
+      info "  aimock:     http://localhost:${aimock_host_port}"
+      info "  dashboard:  http://localhost:${dashboard_host_port}"
+      info "  pocketbase: http://localhost:${pocketbase_host_port}"
+      info "  tear down:  docker compose -p $ISOLATE_NAME down --remove-orphans && rm -rf $ISOLATE_TMPDIR $ISOLATE_SLOT_DIR/$ISOLATE_SLOT"
+      ISOLATE_ACTIVE=false
+      return 0
+    fi
+
     info "Tearing down isolated group: $ISOLATE_NAME (slot $ISOLATE_SLOT)"
     $COMPOSE_CMD down --remove-orphans 2>/dev/null || true
     # Just remove the temp dir — originals were never touched

--- a/showcase/scripts/cli/_common.sh
+++ b/showcase/scripts/cli/_common.sh
@@ -193,6 +193,19 @@ _reap_isolate_slot() {
     # anyway would orphan whatever runs dir the record actually points at.
     # A corrupted record is a bug or tampering — leave the evidence in place
     # for manual inspection rather than half-destroy it.
+    #
+    # Reserved name, same treatment: 'showcase' IS the default stack's compose
+    # project name and PASSES the charset check below, so a record reading
+    # 'showcase' (a corrupt record, or one written by an older CLI version
+    # before apply_isolation reserved the name) would aim the compose-down at
+    # the user's LIVE DEFAULT stack — and --volumes would destroy its
+    # PocketBase data. apply_isolation refuses the name at claim time, but the
+    # reaper must not trust records: warn and leave the whole slot intact for
+    # manual inspection (no compose-down, no state removal).
+    if [ "$slot_proj" = "showcase" ]; then
+      warn "Slot record at $slot_entry names the RESERVED project 'showcase' — that is the LIVE default stack's compose project, so reaping it would compose the default stack down (--volumes included: PocketBase data destroyed). Leaving the slot intact for manual inspection; its runs dir would be $(_showcase_state_base)/runs/$slot_proj"
+      return 0
+    fi
     if [[ "$slot_proj" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
       # Best-effort remnant cleanup BEFORE deleting any state: a stopped kept
       # stack (see the header) still has containers + named volumes; deleting
@@ -505,10 +518,15 @@ apply_isolation() {
 
   # Guard: clean up stale .iso-bak files from a prior botched run that
   # mutated originals in-place (the old approach). This makes migration safe.
+  # The mv's are race-guarded: two concurrent runs can both see the same stale
+  # backup, and the loser's mv (the FINAL command of its AND-list — final-
+  # command failures DO trip set -e) would otherwise die pre-claim with a raw
+  # error. The survivor's restore wins; the loser proceeds with the restored
+  # originals.
   if [ -f "${PORTS_FILE}.iso-bak" ] || [ -f "${COMPOSE_FILE}.iso-bak" ]; then
     warn "Stale .iso-bak files found from a prior crash — restoring originals"
-    [ -f "${PORTS_FILE}.iso-bak" ] && mv "${PORTS_FILE}.iso-bak" "$PORTS_FILE"
-    [ -f "${COMPOSE_FILE}.iso-bak" ] && mv "${COMPOSE_FILE}.iso-bak" "$COMPOSE_FILE"
+    [ -f "${PORTS_FILE}.iso-bak" ] && mv "${PORTS_FILE}.iso-bak" "$PORTS_FILE" 2>/dev/null || true
+    [ -f "${COMPOSE_FILE}.iso-bak" ] && mv "${COMPOSE_FILE}.iso-bak" "$COMPOSE_FILE" 2>/dev/null || true
   fi
 
   # Claim a slot for unique port offsets

--- a/showcase/scripts/cli/_common.sh
+++ b/showcase/scripts/cli/_common.sh
@@ -116,7 +116,12 @@ ISOLATE_SLOT=""
 ISOLATE_ACTIVE=false
 ISOLATE_TMPDIR=""
 
-ISOLATE_SLOT_DIR="/tmp/showcase-isolate-slots"
+# Runtime state (slot registry + per-run scratch dirs) lives under
+# XDG_STATE_HOME, NOT /tmp — /tmp gets wiped on reboot and is world-writable,
+# which made stale-slot reaping racy and lost --keep'd run dirs across reboots.
+_showcase_state_base() { printf '%s/copilotkit/showcase' "${XDG_STATE_HOME:-$HOME/.local/state}"; }
+
+ISOLATE_SLOT_DIR="$(_showcase_state_base)/slots"
 ISOLATE_STALE_THRESHOLD=7200  # 2 hours in seconds
 
 # Claim an isolation slot using atomic mkdir. Slots start at 0 and increment.
@@ -166,7 +171,7 @@ _claim_isolate_slot() {
     fi
     n=$((n + 1))
     if [ "$n" -gt 45 ]; then
-      die "No isolation slots available (0-45 exhausted). Check /tmp/showcase-isolate-slots/"
+      die "No isolation slots available (0-45 exhausted). Check $ISOLATE_SLOT_DIR/"
     fi
   done
 }
@@ -217,8 +222,10 @@ apply_isolation() {
   ISOLATE_NAME="$name"
   export COMPOSE_PROJECT_NAME="$name"
 
-  # Create temp directory for overlay copies (originals stay untouched)
-  ISOLATE_TMPDIR="${TMPDIR:-/tmp}/showcase-isolate-$$"
+  # Create per-run scratch dir for overlay copies (originals stay untouched).
+  # Keyed by the finalized project name (not the PID) so a --keep'd run is
+  # locatable for manual teardown, and lives under XDG state, not /tmp.
+  ISOLATE_TMPDIR="$(_showcase_state_base)/runs/$name"
   mkdir -p "$ISOLATE_TMPDIR"
 
   # Generate offset ports file in the temp dir

--- a/showcase/scripts/cli/cmd-test.sh
+++ b/showcase/scripts/cli/cmd-test.sh
@@ -43,6 +43,7 @@ cmd_test() {
   local cycle=""
   local isolate_name=""
   local use_isolate=false
+  local keep=false
   local harness_args=()
 
   # Parse arguments — pass most through to the harness CLI
@@ -54,7 +55,7 @@ cmd_test() {
       --smoke)   harness_args+=(--smoke);   shift ;;
       --verbose) harness_args+=(--verbose); shift ;;
       --headed)  harness_args+=(--headed);  shift ;;
-      --keep)    harness_args+=(--keep);    shift ;;
+      --keep)    keep=true; harness_args+=(--keep); shift ;;
       --live)    harness_args+=(--live);    shift ;;
       --rebuild) harness_args+=(--rebuild); shift ;;
       --direct)  harness_args+=(--direct);  shift ;;
@@ -109,10 +110,14 @@ cmd_test() {
 
   # Apply isolation if requested (must happen before any compose commands).
   # Register the trap BEFORE apply_isolation so cleanup runs even if the
-  # function itself crashes partway through.
+  # function itself crashes partway through. restore_isolation reads the local
+  # `keep` (visible because the EXIT trap fires in this same shell): under --keep
+  # it leaves the stack standing and prints a survival notice instead of tearing
+  # down, so the slot's live containers keep it from being reaped.
   if $use_isolate; then
     trap restore_isolation EXIT
     apply_isolation "${isolate_name:-}"
+    $keep && info "--keep set: isolated stack will be left standing after the run (teardown command printed at exit)"
   fi
 
   # Build the filter description for the info line

--- a/showcase/scripts/cli/cmd-test.sh
+++ b/showcase/scripts/cli/cmd-test.sh
@@ -20,12 +20,14 @@ Options:
   --verbose        Verbose test output
   --headed         Run Playwright in headed (visible) mode
   --repeat <n>     Run N times
-  --keep           Don't stop auto-started packages after test
+  --keep           Don't stop auto-started packages after test; with --isolate,
+                   also leaves the isolated stack standing (teardown command
+                   printed at exit)
   --live           Write results to PocketBase for dashboard
   --rebuild        Force Docker rebuild before running
   --cycle          On failure, auto-dump aimock logs from the test window
   --isolate [name] Run in an isolated compose project with offset ports
-                   (default name: isolate-<PID>). Allows parallel test runs.
+                   (default name: showcase-iso<slot>). Allows parallel test runs.
 
 Examples:
   showcase test mastra --d6 --verbose         # D6 probes (full matrix) with verbose output
@@ -43,7 +45,6 @@ cmd_test() {
   local cycle=""
   local isolate_name=""
   local use_isolate=false
-  local keep=false
   local harness_args=()
 
   # Parse arguments — pass most through to the harness CLI
@@ -55,7 +56,7 @@ cmd_test() {
       --smoke)   harness_args+=(--smoke);   shift ;;
       --verbose) harness_args+=(--verbose); shift ;;
       --headed)  harness_args+=(--headed);  shift ;;
-      --keep)    keep=true; harness_args+=(--keep); shift ;;
+      --keep)    ISOLATE_KEEP=true; harness_args+=(--keep); shift ;;
       --live)    harness_args+=(--live);    shift ;;
       --rebuild) harness_args+=(--rebuild); shift ;;
       --direct)  harness_args+=(--direct);  shift ;;
@@ -110,14 +111,21 @@ cmd_test() {
 
   # Apply isolation if requested (must happen before any compose commands).
   # Register the trap BEFORE apply_isolation so cleanup runs even if the
-  # function itself crashes partway through. restore_isolation reads the local
-  # `keep` (visible because the EXIT trap fires in this same shell): under --keep
-  # it leaves the stack standing and prints a survival notice instead of tearing
-  # down, so the slot's live containers keep it from being reaped.
+  # function itself crashes partway through. restore_isolation reads the
+  # ISOLATE_KEEP global (set above when --keep is parsed). It MUST be a global,
+  # not a local: on the normal path cmd_test returns and its locals unwind
+  # before the EXIT trap fires at top-level script exit, so a function-local
+  # flag would silently read as false there (a local is only visible to the
+  # trap when `die` exits from inside cmd_test itself). Under --keep,
+  # restore_isolation leaves the stack standing and prints a survival notice
+  # instead of tearing down, so the slot's live containers keep it from being
+  # reaped.
   if $use_isolate; then
     trap restore_isolation EXIT
     apply_isolation "${isolate_name:-}"
-    $keep && info "--keep set: isolated stack will be left standing after the run (teardown command printed at exit)"
+    if $ISOLATE_KEEP; then
+      info "--keep set: isolated stack will be left standing after the run (teardown command printed at exit)"
+    fi
   fi
 
   # Build the filter description for the info line


### PR DESCRIPTION
## Summary

Hardens the `--isolate` showcase verification flow across three areas:

**1. XDG state migration.** Isolate slot registry and per-run rewritten-compose scratch dirs move off `/tmp` (wiped on reboot, world-writable) to `${XDG_STATE_HOME:-$HOME/.local/state}/copilotkit/showcase/` (`slots/` + `runs/<name>/`). `/tmp` clearing silently destroyed a kept stack's compose file and slot, making `--keep` unreliable. Run dirs are keyed by the finalized project name (not PID) so a kept run is locatable for manual teardown.

**2. Slot reaping + registry concurrency.** Since the state dir is now persistent, slots are reaped by compose-project liveness (`docker ps --filter label=com.docker.compose.project=<name>`), with PID/age heuristics as fallback. The registry is made safe under concurrent claimers: a sweep lock with heartbeat updates, own-pid lock release, and tombstones; a claim-then-verify duplicate-name guard closing the TOCTOU window; crash-safe reap ordering with compose-down of reap remnants and a path-traversal guard. Failed `--isolate` setup no longer tears down the default stack; half-initialized state is cleaned up on the way out. Teardown uses `--volumes` everywhere, and a failed compose-down preserves state for diagnosis. `--isolate` names are validated (must start with lowercase letter/digit; `showcase` is reserved — it aliases the default stack), and a fail-loud warning precedes pre-down of an existing stack.

**3. `--keep` now actually persists an isolated stack.** Previously the unconditional `trap restore_isolation EXIT` tore the stack down regardless of `--keep`. Teardown is now gated on the keep flag (`ISOLATE_KEEP` promoted to a global so it survives `cmd_test` return into the trap scope): the slot + run dir are retained and a survival notice prints the project name, the three offset host ports, and the exact `docker compose -p <name> down` command — no silent port/slot leak. A kept stack's live containers keep its slot from being reaped.

Shell-only — confined to `showcase/scripts/cli/_common.sh` + `cmd-test.sh`; the harness TS only reads the env vars the shell exports (unchanged). Follows up the `--keep` caveat documented in #5346.

## Review hardening

The branch went through an 8-round, 7-agent code-review loop with red-green-verified fixes — that loop produced the state-machine hardening commit (trap-scope fix, default-stack guards, registry concurrency/teardown robustness, name validation) and grew the test suite to pin every fix. A live end-to-end `--keep` verification run is what surfaced the trap-scope bug (`--keep` silently not honored), driving the `ISOLATE_KEEP` global fix.

## Test plan
- [x] `showcase/scripts/__tests__/isolate.bats` — 41 isolate tests (red→green): XDG path resolution (+`XDG_STATE_HOME` override, `~/.local/state` fallback, `runs/<name>`), liveness-based reaping (dead project reaped/reclaimed, live project preserved), real-trap-path `--keep` tests (no simulated-trap shortcuts), sweep/lock/tombstone race pins (heartbeat resurrection, lock takeover, duplicate-name TOCTOU), reap-order probe pinning live-slot protection, root/PID-reuse/DST guards, and sentinel anti-vacuity discipline so trap tests cannot pass vacuously.
- [x] Full `bats showcase/scripts/__tests__/` green, matching CI's Shell script tests invocation.
- [x] shellcheck: no new warnings.
- [x] Live end-to-end: `bin/showcase test <slug> --d6 --isolate <name> --keep` persists the stack under `~/.local/state/copilotkit/showcase`, survival notice + manual teardown work, follow-up run reaps the stale slot.