### PR TITLE
fix(harness): stop staging dashboard flapping (per-run X-Test-Id, graceful drain, worker-row GC)

### DIFF
--- a/showcase/harness/src/fleet/control-plane/control-plane.test.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.test.ts
@@ -115,6 +115,7 @@ function emptyHealthResult(
     commErrors: [],
     reclaimedOverlays: [],
     restartsAttempted: 0,
+    gcDeleted: 0,
     ...over,
   };
 }

--- a/showcase/harness/src/fleet/control-plane/fleet-health.test.ts
+++ b/showcase/harness/src/fleet/control-plane/fleet-health.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
   createFleetHealthMonitor,
   DEFAULT_WORKER_STALE_AFTER_MS,
+  DEFAULT_WORKER_GC_AFTER_MS,
 } from "./fleet-health.js";
 import type {
   PbClient,
@@ -146,6 +147,82 @@ const FRESH = new Date(NOW - 1_000).toISOString();
 const STALE = new Date(
   NOW - DEFAULT_WORKER_STALE_AFTER_MS - 1_000,
 ).toISOString();
+// Older than the 24h GC window — a long-dead row from a prior deploy
+// generation that should be GC-deleted rather than reclaimed.
+const ANCIENT = new Date(
+  NOW - DEFAULT_WORKER_GC_AFTER_MS - 1_000,
+).toISOString();
+
+/**
+ * GC-aware fake PB: like `makeFakePb` but records `delete(collection, id)` calls
+ * (the GC primitive fleet-health uses to evict long-dead roster rows) instead of
+ * throwing. `deleteThrows` makes the delete reject for the given row ids so the
+ * GC-failure-does-not-abort-cycle case can be exercised.
+ */
+function makeGcFakePb(opts: {
+  workers: WorkerRow[];
+  jobs: JobView[];
+  deleteThrows?: Set<string>;
+}): {
+  pb: PbClient;
+  deletes: Array<{ collection: string; id: string }>;
+} {
+  const deletes: Array<{ collection: string; id: string }> = [];
+  const deleteThrows = opts.deleteThrows ?? new Set<string>();
+  const unsupported = (n: string) => () => {
+    throw new Error(`fake-pb: ${n} not implemented`);
+  };
+  const pb = {
+    async list<T>(
+      collection: string,
+      listOpts: ListOpts = {},
+    ): Promise<ListResult<T>> {
+      let items: unknown[];
+      if (collection === "workers") {
+        items = opts.workers;
+      } else {
+        const filter = listOpts.filter ?? "";
+        const statuses = [...filter.matchAll(/status\s*=\s*"(\w+)"/g)].map(
+          (m) => m[1],
+        );
+        const wantStatus = new Set(statuses);
+        const ownerMatch = /claimed_by\s*=\s*"([^"]*)"/.exec(filter);
+        const wantOwner = ownerMatch?.[1];
+        items = opts.jobs.filter((j) => {
+          if (wantStatus.size > 0 && !wantStatus.has(j.status)) return false;
+          if (wantOwner !== undefined && j.claimed_by !== wantOwner) {
+            return false;
+          }
+          return true;
+        });
+      }
+      return {
+        page: 1,
+        perPage: listOpts.perPage ?? items.length,
+        totalPages: 1,
+        totalItems: items.length,
+        items: items as T[],
+      };
+    },
+    async delete(collection: string, id: string): Promise<void> {
+      deletes.push({ collection, id });
+      if (deleteThrows.has(id)) {
+        throw new Error(`fake-pb: delete failed for ${id}`);
+      }
+    },
+    getOne: unsupported("getOne"),
+    getFirst: unsupported("getFirst"),
+    create: unsupported("create"),
+    update: unsupported("update"),
+    upsertByField: unsupported("upsertByField"),
+    deleteByFilter: unsupported("deleteByFilter"),
+    health: unsupported("health"),
+    createBackup: unsupported("createBackup"),
+    downloadBackup: unsupported("downloadBackup"),
+    deleteBackup: unsupported("deleteBackup"),
+  } as unknown as PbClient;
+  return { pb, deletes };
+}
 
 describe("createFleetHealthMonitor.checkOnce", () => {
   it("reclaims a stale worker's in-flight jobs and emits a comm error per job", async () => {
@@ -433,7 +510,231 @@ describe("createFleetHealthMonitor.checkOnce", () => {
       commErrors: [],
       reclaimedOverlays: [],
       restartsAttempted: 0,
+      gcDeleted: 0,
     });
     expect(claim.releases).toEqual([]);
+  });
+
+  it("GCs roster rows older than gcAfterMs (long-dead deploy generations) without reclaiming or restart-attempting them", async () => {
+    // A mix: one fresh (online), one stale-recent (reclaimed at 180s but NOT
+    // GC-old), one ancient (>24h dead — a leftover row from a prior deploy
+    // generation that should be GC-deleted, NOT counted unhealthy/reclaimed).
+    const { pb, deletes } = makeGcFakePb({
+      workers: [
+        { id: "w-fresh", worker_id: "worker-live", last_heartbeat_at: FRESH },
+        { id: "w-stale", worker_id: "worker-stale", last_heartbeat_at: STALE },
+        {
+          id: "w-ancient",
+          worker_id: "worker-ghost",
+          last_heartbeat_at: ANCIENT,
+        },
+      ],
+      jobs: [
+        jobView({ id: "j1", claimed_by: "worker-stale", status: "claimed" }),
+      ],
+    });
+    const claim = makeFakeClaim();
+    const monitor = createFleetHealthMonitor({
+      pb,
+      claim,
+      logger: SILENT_LOGGER,
+      now: () => NOW,
+    });
+
+    const out = await monitor.checkOnce();
+
+    // The ancient row was GC-deleted exactly once, by its row id.
+    expect(deletes).toEqual([{ collection: "workers", id: "w-ancient" }]);
+    expect(out.gcDeleted).toBe(1);
+    // The ancient row is NOT counted unhealthy and NOT reclaimed/restarted —
+    // only the stale-recent worker is.
+    expect(out.online).toBe(1);
+    expect(out.unhealthy).toBe(1);
+    expect(out.reclaimed).toBe(1);
+    // The ancient ghost row never hit the claim CAS.
+    expect(claim.releases).toEqual([
+      { jobId: "j1", workerId: "worker-stale", status: "pending" },
+    ]);
+  });
+
+  it("does not abort the cycle when a GC delete fails — processes the remaining rows", async () => {
+    const { pb, deletes } = makeGcFakePb({
+      workers: [
+        {
+          id: "w-ancient",
+          worker_id: "worker-ghost",
+          last_heartbeat_at: ANCIENT,
+        },
+        { id: "w-stale", worker_id: "worker-stale", last_heartbeat_at: STALE },
+      ],
+      jobs: [
+        jobView({ id: "j1", claimed_by: "worker-stale", status: "claimed" }),
+      ],
+      deleteThrows: new Set(["w-ancient"]),
+    });
+    const claim = makeFakeClaim();
+    const monitor = createFleetHealthMonitor({
+      pb,
+      claim,
+      logger: SILENT_LOGGER,
+      now: () => NOW,
+    });
+
+    // Must not throw despite the GC delete rejecting.
+    const out = await monitor.checkOnce();
+
+    expect(deletes).toEqual([{ collection: "workers", id: "w-ancient" }]);
+    // Failed GC delete is swallowed: not counted gcDeleted, and the row is not
+    // double-processed as unhealthy (it's still GC-class, just couldn't delete).
+    expect(out.gcDeleted).toBe(0);
+    // The stale-recent worker is still processed after the failed GC delete.
+    expect(out.reclaimed).toBe(1);
+    expect(claim.releases).toEqual([
+      { jobId: "j1", workerId: "worker-stale", status: "pending" },
+    ]);
+  });
+
+  it("reclaims a stale-but-not-ancient row rather than GC-deleting it", async () => {
+    const { pb, deletes } = makeGcFakePb({
+      workers: [
+        { id: "w-stale", worker_id: "worker-stale", last_heartbeat_at: STALE },
+      ],
+      jobs: [
+        jobView({ id: "j1", claimed_by: "worker-stale", status: "claimed" }),
+      ],
+    });
+    const claim = makeFakeClaim();
+    const monitor = createFleetHealthMonitor({
+      pb,
+      claim,
+      logger: SILENT_LOGGER,
+      now: () => NOW,
+    });
+
+    const out = await monitor.checkOnce();
+
+    // A row between staleAfterMs and gcAfterMs is reclaimed, never GC-deleted.
+    expect(deletes).toEqual([]);
+    expect(out.gcDeleted).toBe(0);
+    expect(out.unhealthy).toBe(1);
+    expect(out.reclaimed).toBe(1);
+  });
+
+  it("does NOT count restartsAttempted for ghost rows under the default no-op restart hook", async () => {
+    // Post-demotion: with the default no-op restart hook and a stale row that
+    // reclaimed ZERO jobs (a ghost row), restartsAttempted stays 0 — the
+    // metric no longer pretends a restart was attempted when the hook is a
+    // no-op and there was nothing to reclaim.
+    const { pb } = makeGcFakePb({
+      workers: [
+        { id: "w-stale", worker_id: "worker-ghost", last_heartbeat_at: STALE },
+      ],
+      jobs: [], // no in-flight jobs → reclaimed === 0
+    });
+    const claim = makeFakeClaim();
+    const monitor = createFleetHealthMonitor({
+      pb,
+      claim,
+      logger: SILENT_LOGGER,
+      now: () => NOW,
+      // no restartWorker → default no-op hook
+    });
+
+    const out = await monitor.checkOnce();
+
+    expect(out.unhealthy).toBe(1);
+    expect(out.reclaimed).toBe(0);
+    // The no-op hook + zero reclaims => no misleading restart attempt counted.
+    expect(out.restartsAttempted).toBe(0);
+  });
+
+  it("GC-deletes an ancient roster row even when its worker_id is missing/empty (no perpetual warn)", async () => {
+    // The GC delete only needs `row.id` — a malformed row (missing/empty
+    // worker_id) that is ALSO older than gcAfterMs must be GC'd, not warned
+    // about every cycle forever. A malformed row that is NOT GC-old keeps the
+    // existing warn+skip behavior.
+    const warns: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const logger: Logger = {
+      info: () => {},
+      error: () => {},
+      debug: () => {},
+      warn: (msg, meta) => {
+        warns.push({ msg, meta });
+      },
+    };
+    const { pb, deletes } = makeGcFakePb({
+      workers: [
+        // Ancient AND missing worker_id → must be GC-deleted.
+        {
+          id: "w-anc-missing",
+          last_heartbeat_at: ANCIENT,
+        } as unknown as WorkerRow,
+        // Malformed (empty worker_id) but RECENT → today's warn+skip stays.
+        { id: "w-recent-missing", worker_id: "", last_heartbeat_at: FRESH },
+      ],
+      jobs: [],
+    });
+    const claim = makeFakeClaim();
+    const monitor = createFleetHealthMonitor({
+      pb,
+      claim,
+      logger,
+      now: () => NOW,
+    });
+
+    const out = await monitor.checkOnce();
+
+    // The ancient malformed row was GC-deleted by its row id.
+    expect(deletes).toEqual([{ collection: "workers", id: "w-anc-missing" }]);
+    expect(out.gcDeleted).toBe(1);
+    // No missing-worker-id warn for the GC'd row — only the recent malformed
+    // row keeps the warn+skip path.
+    const missingWarns = warns.filter(
+      (w) => w.msg === "fleet.health.row-missing-worker-id",
+    );
+    expect(missingWarns).toHaveLength(1);
+    expect(missingWarns[0]?.meta).toMatchObject({ rowId: "w-recent-missing" });
+    // Neither malformed row ever hits the claim CAS.
+    expect(claim.releases).toEqual([]);
+  });
+
+  it("fails loud at construction when gcAfterMs does not exceed staleAfterMs", () => {
+    // gcAfterMs and staleAfterMs are independently env-overridable
+    // (WORKER_GC_AFTER_MS / WORKER_STALE_AFTER_MS). If gc <= stale, GC runs
+    // FIRST in the cycle and DELETES a merely-stale (recoverable) worker before
+    // its in-flight jobs are reclaimed — jobs wedge until lease expiry and the
+    // crashed-worker overlay never fires. Misconfig must die on boot (mirrors
+    // the worker-loop heartbeatMs/leaseSeconds fail-loud guard).
+    const { pb } = makeFakePb({ workers: [], jobs: [] });
+    const claim = makeFakeClaim();
+    const base = { pb, claim, logger: SILENT_LOGGER, now: () => NOW };
+
+    // gc strictly below stale → throw, naming both values and env vars.
+    expect(() =>
+      createFleetHealthMonitor({ ...base, staleAfterMs: 1000, gcAfterMs: 500 }),
+    ).toThrow(
+      /gcAfterMs \(500\b.*WORKER_GC_AFTER_MS.*staleAfterMs \(1000\b.*WORKER_STALE_AFTER_MS/s,
+    );
+    // gc == stale is equally unsafe (GC fires the moment a row turns stale).
+    expect(() =>
+      createFleetHealthMonitor({
+        ...base,
+        staleAfterMs: 1000,
+        gcAfterMs: 1000,
+      }),
+    ).toThrow(/gcAfterMs/);
+
+    // A valid pair (gc > stale) constructs fine, as do the defaults.
+    expect(() =>
+      createFleetHealthMonitor({
+        ...base,
+        staleAfterMs: 1000,
+        gcAfterMs: 1001,
+      }),
+    ).not.toThrow();
+    expect(() => createFleetHealthMonitor(base)).not.toThrow();
+    expect(DEFAULT_WORKER_GC_AFTER_MS).toBeGreaterThan(
+      DEFAULT_WORKER_STALE_AFTER_MS,
+    );
   });
 });

--- a/showcase/harness/src/fleet/control-plane/fleet-health.ts
+++ b/showcase/harness/src/fleet/control-plane/fleet-health.ts
@@ -69,6 +69,18 @@ import {
  */
 export const DEFAULT_WORKER_STALE_AFTER_MS = 180_000;
 
+/**
+ * Default GC window: a worker whose `last_heartbeat_at` is older than this is a
+ * long-dead row from a prior deploy generation (a crashed/replaced worker that
+ * never deregistered) — fleet-health DELETES it from the roster rather than
+ * counting it unhealthy and pointlessly "reclaiming"/restart-attempting it every
+ * cycle forever. Sized at 24h, vastly larger than `staleAfterMs` (180s) so a
+ * merely-stale (still-recoverable) worker is NEVER GC'd — only generations long
+ * past any plausible recovery. Env-overridable by the wiring slot via
+ * WORKER_GC_AFTER_MS.
+ */
+export const DEFAULT_WORKER_GC_AFTER_MS = 86_400_000;
+
 /** Max worker rows scanned per monitor cycle — bounds the roster read cost. */
 const WORKERS_PAGE = 100;
 
@@ -132,6 +144,13 @@ export interface FleetHealthResult {
   reclaimedOverlays: ReclaimedCommError[];
   /** Restart-hook invocations attempted this cycle. */
   restartsAttempted: number;
+  /**
+   * Long-dead roster rows GC-deleted this cycle (heartbeat older than
+   * `gcAfterMs`). These are NOT counted in `unhealthy` and are NOT
+   * reclaimed/restart-attempted — they are leftover rows from prior deploy
+   * generations being pruned so the roster stops accumulating ghost rows.
+   */
+  gcDeleted: number;
 }
 
 export interface FleetHealthDeps {
@@ -141,6 +160,15 @@ export interface FleetHealthDeps {
   logger: Logger;
   /** Staleness window (ms). Default `DEFAULT_WORKER_STALE_AFTER_MS`. */
   staleAfterMs?: number;
+  /**
+   * GC window (ms): roster rows whose heartbeat is older than this are deleted
+   * (long-dead prior-generation rows) rather than reclaimed. Default
+   * `DEFAULT_WORKER_GC_AFTER_MS` (24h). MUST be >> `staleAfterMs` so a
+   * recoverable worker is never GC'd — ENFORCED at construction:
+   * `createFleetHealthMonitor` throws if the resolved `gcAfterMs` does not
+   * strictly exceed the resolved `staleAfterMs`.
+   */
+  gcAfterMs?: number;
   /** Injectable clock (tests). Returns ms-since-epoch. Defaults to Date.now. */
   now?: () => number;
   /**
@@ -181,7 +209,27 @@ export function createFleetHealthMonitor(
 ): FleetHealthMonitor {
   const { pb, claim, logger } = deps;
   const staleAfterMs = deps.staleAfterMs ?? DEFAULT_WORKER_STALE_AFTER_MS;
+  const gcAfterMs = deps.gcAfterMs ?? DEFAULT_WORKER_GC_AFTER_MS;
+  // Fail-loud at construction: GC runs FIRST in the cycle, so if the GC window
+  // does not strictly exceed the stale window, a merely-stale (recoverable)
+  // worker is GC-DELETED before its in-flight jobs are reclaimed — the jobs
+  // wedge until lease expiry and the crashed-worker overlay never fires. The
+  // two windows are independently env-overridable (WORKER_GC_AFTER_MS /
+  // WORKER_STALE_AFTER_MS via the wiring slot), so an unsafe combo is a
+  // misconfiguration — die immediately (visible in deploy CI / Railway
+  // health-check) rather than silently mis-GC every cycle. Mirrors the
+  // worker-loop heartbeatMs/leaseSeconds fail-loud idiom.
+  if (gcAfterMs <= staleAfterMs) {
+    throw new Error(
+      `Unsafe fleet-health config: gcAfterMs (${gcAfterMs}, env WORKER_GC_AFTER_MS) must be > staleAfterMs (${staleAfterMs}, env WORKER_STALE_AFTER_MS); otherwise GC deletes a merely-stale (recoverable) worker's roster row before its in-flight jobs are reclaimed, wedging those jobs until lease expiry with no crashed-worker overlay.`,
+    );
+  }
   const now = deps.now ?? Date.now;
+  // Whether a REAL restart hook was injected (staging Railway redeploy) vs the
+  // default no-op. Used to demote the misleading `restartsAttempted` metric: a
+  // no-op hook against a ghost row that reclaimed nothing was counting a
+  // "restart attempt" that never did anything, inflating the metric every cycle.
+  const hasRealRestartHook = typeof deps.restartWorker === "function";
   // Default restart is a no-op (local docker handles recovery). The wiring slot
   // injects the Railway serviceInstanceRedeploy hook in staging.
   const restartWorker: RestartWorkerHook = deps.restartWorker ?? (() => {});
@@ -292,6 +340,7 @@ export function createFleetHealthMonitor(
           commErrors: [],
           reclaimedOverlays: [],
           restartsAttempted: 0,
+          gcDeleted: 0,
         };
       }
 
@@ -299,14 +348,53 @@ export function createFleetHealthMonitor(
       let unhealthy = 0;
       let reclaimed = 0;
       let restartsAttempted = 0;
+      let gcDeleted = 0;
       const commErrors: PoolCommError[] = [];
       const reclaimedOverlays: ReclaimedCommError[] = [];
 
       for (const row of page.items) {
+        // GC FIRST — even before the missing-worker-id guard: a row whose
+        // heartbeat is older than `gcAfterMs` is a long-dead prior-generation
+        // row (crashed/replaced worker that never deregistered). DELETE it
+        // best-effort and skip health/reclaim/restart — its jobs, if any, are
+        // long-since lease-expired and handled by the producer's sweepExpired,
+        // so reclaiming/restart-attempting it every cycle was pure noise
+        // (inflating unhealthy/restartsAttempted forever). The delete only
+        // needs `row.id`, so an ancient row with a missing/empty worker_id is
+        // GC'd too — otherwise it would warn every cycle forever, the exact
+        // perpetual noise GC exists to eliminate. A parseable timestamp older
+        // than the GC cutoff is required; an unparseable one falls through to
+        // the existing stale-handling warn.
+        if (
+          typeof row.last_heartbeat_at === "string" &&
+          !Number.isNaN(Date.parse(row.last_heartbeat_at)) &&
+          nowMs - Date.parse(row.last_heartbeat_at) > gcAfterMs
+        ) {
+          try {
+            await pb.delete(WORKERS_COLLECTION, row.id);
+            gcDeleted += 1;
+            logger.info("fleet.health.gc-deleted", {
+              workerId: row.worker_id ?? "<missing>",
+              rowId: row.id,
+              lastHeartbeatAt: row.last_heartbeat_at,
+              gcAfterMs,
+            });
+          } catch (err) {
+            // Best-effort: a failed delete must NOT abort the cycle (same
+            // discipline as reclaim). The row simply survives to the next cycle.
+            logger.warn("fleet.health.gc-failed", {
+              workerId: row.worker_id ?? "<missing>",
+              rowId: row.id,
+              err: err instanceof Error ? err.message : String(err),
+            });
+          }
+          continue;
+        }
         const workerId = row.worker_id;
         if (typeof workerId !== "string" || workerId.length === 0) {
           // A roster row without a usable worker_id can't be joined to claims —
-          // skip it rather than reclaim against an empty owner.
+          // skip it rather than reclaim against an empty owner. (Malformed but
+          // NOT GC-old: the GC branch above already handled ancient rows.)
           logger.warn("fleet.health.row-missing-worker-id", { rowId: row.id });
           continue;
         }
@@ -345,23 +433,43 @@ export function createFleetHealthMonitor(
 
         // RESTART (best-effort): recover the wedged worker. Default no-op
         // locally; staging injects the Railway serviceInstanceRedeploy hook.
-        restartsAttempted += 1;
-        try {
-          await restartWorker(workerId);
-        } catch (err) {
-          logger.warn("fleet.health.restart-failed", {
+        //
+        // DEMOTED METRIC: only count a restart ATTEMPT when it means something —
+        // i.e. a REAL restart hook is wired (staging Railway redeploy) OR this
+        // worker actually had in-flight work we reclaimed. Under the default
+        // no-op hook a ghost row that reclaimed zero jobs was previously counted
+        // as a "restart attempt" every cycle, inflating restartsAttempted with a
+        // number that described nothing. GC now prunes the long-dead rows; for
+        // the remaining recently-stale rows, don't pretend a no-op did a restart.
+        const restartIsMeaningful = hasRealRestartHook || out.reclaimed > 0;
+        if (restartIsMeaningful) {
+          restartsAttempted += 1;
+          try {
+            await restartWorker(workerId);
+          } catch (err) {
+            logger.warn("fleet.health.restart-failed", {
+              workerId,
+              err: err instanceof Error ? err.message : String(err),
+            });
+          }
+        } else {
+          // Intentionally unwired: a recently-stale ghost row with nothing to
+          // reclaim under the no-op hook. Log at debug, not info, so the metric
+          // stops claiming a restart that never happened.
+          logger.debug("fleet.health.restart-skipped", {
             workerId,
-            err: err instanceof Error ? err.message : String(err),
+            msg: "no-op restart hook and nothing reclaimed — not counting a restart attempt",
           });
         }
       }
 
-      if (unhealthy > 0 || reclaimed > 0) {
+      if (unhealthy > 0 || reclaimed > 0 || gcDeleted > 0) {
         logger.info("fleet.health.cycle", {
           online,
           unhealthy,
           reclaimed,
           restartsAttempted,
+          gcDeleted,
         });
       }
 
@@ -372,6 +480,7 @@ export function createFleetHealthMonitor(
         commErrors,
         reclaimedOverlays,
         restartsAttempted,
+        gcDeleted,
       };
     },
   };

--- a/showcase/harness/src/fleet/worker/registration.test.ts
+++ b/showcase/harness/src/fleet/worker/registration.test.ts
@@ -17,6 +17,9 @@ function makeFakePb(): {
     value: string;
     record: Record<string, unknown>;
   }>;
+  deletes: Array<{ collection: string; filter: string }>;
+  /** Ordered log of write KINDS as they SETTLE — proves no re-upsert after delete. */
+  settled: Array<"upsert" | "delete">;
   row: () => Record<string, unknown> | undefined;
 } {
   const upserts: Array<{
@@ -25,6 +28,8 @@ function makeFakePb(): {
     value: string;
     record: Record<string, unknown>;
   }> = [];
+  const deletes: Array<{ collection: string; filter: string }> = [];
+  const settled: Array<"upsert" | "delete"> = [];
   let state: Record<string, unknown> | undefined;
   const pb: RegistrationPbClient = {
     async upsertByField<T>(
@@ -34,12 +39,20 @@ function makeFakePb(): {
       record: Record<string, unknown>,
     ): Promise<T> {
       upserts.push({ collection, field, value, record });
+      settled.push("upsert");
       // Merge over existing state (mirrors PB upsert semantics).
       state = { ...(state ?? {}), [field]: value, ...record };
       return state as T;
     },
+    async deleteByFilter(collection: string, filter: string): Promise<number> {
+      deletes.push({ collection, filter });
+      settled.push("delete");
+      const had = state !== undefined ? 1 : 0;
+      state = undefined;
+      return had;
+    },
   };
-  return { pb, upserts, row: () => state };
+  return { pb, upserts, deletes, settled, row: () => state };
 }
 
 function makeBudget(over: Partial<BrowserPoolBudget> = {}): BrowserPoolBudget {
@@ -57,8 +70,13 @@ function makePool(budget: BrowserPoolBudget): WorkerPoolBudgetSource {
   return { budget: () => budget };
 }
 
-function makeLogger(): RegistrationLogger {
-  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+function makeLogger(): RegistrationLogger & {
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  debug: ReturnType<typeof vi.fn>;
+} {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
 }
 
 describe("registerWorker", () => {
@@ -187,6 +205,9 @@ describe("registerWorker", () => {
       async upsertByField<T>(): Promise<T> {
         throw new Error("pb create failed: 400 missing collection");
       },
+      async deleteByFilter(): Promise<number> {
+        return 0;
+      },
     };
     // Must resolve (not reject) despite the PB error.
     const reg = await registerWorker({
@@ -209,5 +230,247 @@ describe("registerWorker", () => {
       "worker.heartbeat-failed",
       expect.objectContaining({ workerId: "w3" }),
     );
+  });
+
+  // ── deregister (FIX 3: graceful-drain row removal) ───────────────────────
+
+  it("deregister() deletes the worker's registry row by worker_id", async () => {
+    const { pb, deletes } = makeFakePb();
+    const logger = makeLogger();
+    const reg = await registerWorker({
+      pb,
+      pool: makePool(makeBudget()),
+      logger,
+      workerId: "w-drain",
+      endpoint: "host:7",
+      now: () => 0,
+      setIntervalImpl: (() => 0) as unknown as typeof setInterval,
+    });
+    reg.stop();
+    await reg.deregister();
+    // Exactly one delete, scoped to the workers collection by worker_id key.
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0].collection).toBe(WORKERS_COLLECTION);
+    expect(deletes[0].filter).toBe('worker_id = "w-drain"');
+    expect(logger.info).toHaveBeenCalledWith(
+      "worker.deregistered",
+      expect.objectContaining({ workerId: "w-drain" }),
+    );
+  });
+
+  it("deregister() is best-effort: a delete failure does not throw, just warns", async () => {
+    const logger = makeLogger();
+    const failingDeletePb: RegistrationPbClient = {
+      async upsertByField<T>(): Promise<T> {
+        return {} as T;
+      },
+      async deleteByFilter(): Promise<number> {
+        throw new Error("pb delete failed: network blip");
+      },
+    };
+    const reg = await registerWorker({
+      pb: failingDeletePb,
+      pool: makePool(makeBudget()),
+      logger,
+      workerId: "w-drain-fail",
+      endpoint: "host:8",
+      now: () => 0,
+      setIntervalImpl: (() => 0) as unknown as typeof setInterval,
+    });
+    reg.stop();
+    // Must resolve (not reject) despite the PB delete error.
+    await expect(reg.deregister()).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "worker.deregister-failed",
+      expect.objectContaining({ workerId: "w-drain-fail" }),
+    );
+  });
+
+  it("deregister() AWAITS an in-flight heartbeat write BEFORE deleting (no re-upsert after delete)", async () => {
+    // The load-bearing no-re-upsert invariant: the final job-settle heartbeat is
+    // fire-and-forget (`void registration.heartbeat(...)`), so a still-in-flight
+    // upsert could land AFTER deregister's delete and re-create the row. The
+    // handle's lastWrite chain must make deregister await that pending upsert
+    // FIRST, then delete.
+    const settled: Array<"upsert" | "delete"> = [];
+    // A deferred the test controls: it gates the SECOND upsert (the
+    // fire-and-forget heartbeat; n===2), which stays pending until released.
+    // The boot upsert (n===1) settles immediately.
+    let releaseHeartbeatUpsert!: () => void;
+    const heartbeatUpsertGate = new Promise<void>((res) => {
+      releaseHeartbeatUpsert = res;
+    });
+    let upsertCalls = 0;
+    let deleteCalls = 0;
+    const slowPb: RegistrationPbClient = {
+      async upsertByField<T>(): Promise<T> {
+        const n = ++upsertCalls;
+        // The boot upsert (n===1) settles immediately so registerWorker resolves;
+        // the SECOND upsert (the fire-and-forget heartbeat) stays pending until
+        // the test releases it.
+        if (n === 2) {
+          await heartbeatUpsertGate;
+        }
+        settled.push("upsert");
+        return {} as T;
+      },
+      async deleteByFilter(): Promise<number> {
+        deleteCalls++;
+        settled.push("delete");
+        return 1;
+      },
+    };
+    const reg = await registerWorker({
+      pb: slowPb,
+      pool: makePool(makeBudget()),
+      logger: makeLogger(),
+      workerId: "w-race",
+      endpoint: "host:9",
+      now: () => 0,
+      setIntervalImpl: (() => 0) as unknown as typeof setInterval,
+    });
+    // Boot upsert settled.
+    expect(settled).toEqual(["upsert"]);
+
+    // Fire the heartbeat WITHOUT awaiting it (mirrors the fire-and-forget
+    // `void registration.heartbeat(...)` in `runWorker`'s `onCurrentJobChange`
+    // wiring, orchestrator.ts).
+    void reg.heartbeat("job-x");
+    reg.stop();
+    // Kick off deregister; it must NOT delete while the upsert is still pending.
+    const deregisterPromise = reg.deregister();
+
+    // Let microtasks flush — deregister should be parked awaiting the pending upsert.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(deleteCalls).toBe(0);
+    expect(settled).toEqual(["upsert"]); // still only the boot upsert settled
+
+    // Release the pending heartbeat upsert: it settles FIRST, then the delete.
+    releaseHeartbeatUpsert();
+    await deregisterPromise;
+
+    expect(settled).toEqual(["upsert", "upsert", "delete"]);
+    expect(deleteCalls).toBe(1);
+    // No upsert occurs AFTER the delete.
+    expect(settled.lastIndexOf("upsert")).toBeLessThan(
+      settled.indexOf("delete"),
+    );
+  });
+
+  it("a heartbeat fired AFTER deregister does not re-create the row (delete is last)", async () => {
+    const { pb, settled, deletes, upserts, row } = makeFakePb();
+    const logger = makeLogger();
+    const reg = await registerWorker({
+      pb,
+      pool: makePool(makeBudget()),
+      logger,
+      workerId: "w-last",
+      endpoint: "host:10",
+      now: () => 0,
+      setIntervalImpl: (() => 0) as unknown as typeof setInterval,
+    });
+    await reg.heartbeat("job-1");
+    reg.stop();
+    await reg.deregister();
+    expect(deletes).toHaveLength(1);
+    expect(row()).toBeUndefined();
+    const upsertsBeforeLateBeat = upserts.length;
+
+    // THE LOAD-BEARING PART: fire a heartbeat AFTER deregister completed.
+    // Production path: worker-loop stop()'s drain-grace DETACH resolves while
+    // a wedged driver still runs; when that driver finally settles, the
+    // drain-abandon branch fires the fire-and-forget
+    // `void registration.heartbeat(null)` via `runWorker`'s
+    // `onCurrentJobChange` wiring (orchestrator.ts) — AFTER stop ordering
+    // already deregistered. Capture + await the promise to flush the handle's
+    // write chain (production discards it with `void`).
+    const lateBeat = reg.heartbeat("job-x");
+    await expect(lateBeat).resolves.toBeUndefined();
+
+    // The latched handle must NOT have re-created the row: no upsert landed
+    // after the delete, and the delete stays the LAST settled write.
+    expect(row()).toBeUndefined();
+    expect(upserts).toHaveLength(upsertsBeforeLateBeat);
+    expect(settled[settled.length - 1]).toBe("delete");
+    expect(logger.debug).toHaveBeenCalledWith(
+      "worker.heartbeat-after-deregister-skipped",
+      expect.objectContaining({ workerId: "w-last" }),
+    );
+  });
+
+  it("a heartbeat racing deregister cannot land after the delete (delete is the chain's terminal link)", async () => {
+    // The narrow race the latch must also close: a deregister() that merely
+    // awaited a SNAPSHOT of the write chain and then deleted OUTSIDE the chain
+    // lets a heartbeat issued after the snapshot resolved — but before the
+    // delete settled — upsert AFTER the delete and resurrect the row. The
+    // handle must (a) latch synchronously at deregister() entry so the racing
+    // heartbeat is a no-op, and (b) run the delete THROUGH the serialization
+    // chain as its terminal link so no upsert can interleave.
+    const settled: Array<"upsert" | "delete"> = [];
+    let upsertCalls = 0;
+    let releaseDelete!: () => void;
+    const deleteGate = new Promise<void>((res) => {
+      releaseDelete = res;
+    });
+    let releaseLateUpsert!: () => void;
+    const lateUpsertGate = new Promise<void>((res) => {
+      releaseLateUpsert = res;
+    });
+    let state: Record<string, unknown> | undefined;
+    const racePb: RegistrationPbClient = {
+      async upsertByField<T>(
+        _collection: string,
+        field: string,
+        value: string,
+        record: Record<string, unknown>,
+      ): Promise<T> {
+        const n = ++upsertCalls;
+        // Boot upsert (n===1) settles immediately so registerWorker resolves.
+        // Any LATER upsert (the racing heartbeat — only reachable if the
+        // handle wrongly lets it through) is held until the test releases it
+        // AFTER the delete settles, modeling the PB write landing last.
+        if (n > 1) await lateUpsertGate;
+        settled.push("upsert");
+        state = { ...(state ?? {}), [field]: value, ...record };
+        return state as T;
+      },
+      async deleteByFilter(): Promise<number> {
+        await deleteGate;
+        settled.push("delete");
+        const had = state !== undefined ? 1 : 0;
+        state = undefined;
+        return had;
+      },
+    };
+    const reg = await registerWorker({
+      pb: racePb,
+      pool: makePool(makeBudget()),
+      logger: makeLogger(),
+      workerId: "w-race-late",
+      endpoint: "host:11",
+      now: () => 0,
+      setIntervalImpl: (() => 0) as unknown as typeof setInterval,
+    });
+    expect(settled).toEqual(["upsert"]);
+    reg.stop();
+
+    // Start deregister; its delete is parked on the gate (NOT yet settled).
+    const deregPromise = reg.deregister();
+    // While the delete is in flight, the late fire-and-forget heartbeat fires
+    // (the drain-abandon `void registration.heartbeat(...)` path).
+    const lateBeat = reg.heartbeat("job-z");
+
+    // Let the delete settle FIRST, then release the (would-be) late upsert.
+    releaseDelete();
+    await deregPromise;
+    releaseLateUpsert();
+    await lateBeat;
+
+    // Delete is final; the racing heartbeat never upserted, so the row stays
+    // absent instead of being resurrected for fleet-health's 180s red reclaim.
+    expect(settled[settled.length - 1]).toBe("delete");
+    expect(state).toBeUndefined();
+    expect(upsertCalls).toBe(1); // boot only
   });
 });

--- a/showcase/harness/src/fleet/worker/registration.ts
+++ b/showcase/harness/src/fleet/worker/registration.ts
@@ -66,6 +66,15 @@ export interface RegistrationPbClient {
     value: string,
     record: Record<string, unknown>,
   ): Promise<T>;
+  /**
+   * Delete every row matching a PB filter, returning the count deleted. Used by
+   * `deregister()` on graceful drain to remove this worker's own registry row
+   * by its `worker_id` unique key (the handle never holds the PB row `id`, since
+   * registration upserts BY FIELD and never reads the row back). The real
+   * harness `PbClient` already exposes this (pb-client.ts), so production wiring
+   * is unchanged; test fakes add a `deleteByFilter` stub/spy.
+   */
+  deleteByFilter(collection: string, filter: string): Promise<number>;
 }
 
 /** Logger surface — matches the harness optional-method idiom. */
@@ -73,6 +82,7 @@ export interface RegistrationLogger {
   info(msg: string, meta?: Record<string, unknown>): void;
   warn?(msg: string, meta?: Record<string, unknown>): void;
   error?(msg: string, meta?: Record<string, unknown>): void;
+  debug?(msg: string, meta?: Record<string, unknown>): void;
 }
 
 export interface WorkerRegistrationOptions {
@@ -103,11 +113,42 @@ export interface WorkerRegistration {
    * Perform one heartbeat write NOW (best-effort). Exposed so a worker can
    * heartbeat opportunistically (e.g. right after winning/finishing a job) and
    * so tests can drive a beat without the timer. `currentJobId` is the job the
-   * worker is running, or null when idle.
+   * worker is running, or null when idle. Once `deregister()` has been invoked
+   * the handle is LATCHED: any later heartbeat is a logged no-op, so a
+   * straggler beat can never re-create the deleted roster row.
    */
   heartbeat(currentJobId: string | null): Promise<void>;
   /** Cancel the heartbeat loop. Idempotent. */
   stop(): void;
+  /**
+   * Deregister this worker on a GRACEFUL drain: best-effort DELETE this
+   * worker's registry row (by its `worker_id` unique key) so fleet-health never
+   * sees a stale row for a gracefully-drained worker (no row → no 180s reclaim →
+   * no red "crashed/unreachable" overlay), letting the abandoned job reach the
+   * 300s lease expiry where the sweeper re-queues it neutral-gray.
+   *
+   * LATCHES the handle synchronously on entry, then runs the DELETE as the
+   * terminal link of the handle's write-serialization chain. Two hazards both
+   * stem from the final job-settle heartbeat being fire-and-forget (`void
+   * registration.heartbeat(...)` in `runWorker`'s `onCurrentJobChange` wiring,
+   * orchestrator.ts): (1) a still-in-flight upsert could land AFTER the delete
+   * and re-create the row — closed by chaining the delete behind every prior
+   * write; (2) a heartbeat issued AFTER deregister() starts (e.g. the
+   * drain-abandon branch firing `onCurrentJobChange(null)` when a wedged
+   * driver finally settles, after the drain grace already detached) would
+   * upsert the row right back via find-or-create — closed by the latch, which
+   * turns every later `heartbeat()`/write into a logged no-op. Together they
+   * make the no-re-upsert guarantee independent of caller ordering.
+   *
+   * Best-effort: a failed delete (or a rejected prior write) is logged and
+   * swallowed, never thrown into shutdown — the worst case degrades to today's
+   * behavior (the row persists, fleet-health reclaims it red at 180s), not a
+   * regression. Call AFTER `stop()` so the periodic heartbeat timer is cancelled
+   * (the latch also covers a straggler tick). The crash path (process died,
+   * no deregistration) keeps today's red-overlay reclaim — deregistration is the
+   * marker that distinguishes a graceful drain from a crash.
+   */
+  deregister(): Promise<void>;
 }
 
 function resolveHeartbeatMs(explicit: number | undefined): number {
@@ -173,6 +214,14 @@ export async function registerWorker(
   const setIntervalFn = options.setIntervalImpl ?? setInterval;
   const clearIntervalFn = options.clearIntervalImpl ?? clearInterval;
 
+  // DEREGISTERED LATCH: set synchronously at deregister() entry, BEFORE any
+  // await — so a heartbeat arriving after deregister() has merely STARTED is
+  // already a no-op. Without it, any late heartbeat (the drain-abandon branch's
+  // fire-and-forget `onCurrentJobChange(null)` is the concrete production
+  // path) would re-create the just-deleted row via upsertByField's
+  // find-or-create and resurrect the 180s red-reclaim flap FIX 3 removes.
+  let deregistered = false;
+
   /** One best-effort upsert. `isRegister` adds `registered_at` to the patch. */
   async function write(
     currentJobId: string | null,
@@ -210,8 +259,45 @@ export async function registerWorker(
     }
   }
 
+  // IN-FLIGHT-WRITE SERIALIZATION (the no-re-upsert guarantee lives HERE, not in
+  // caller ordering). Every upsert is funneled through `lastWrite`, a promise
+  // chain that resolves only after the prior write SETTLES — so writes never
+  // interleave, and `deregister()` appends its DELETE as the chain's TERMINAL
+  // link, guaranteeing every prior upsert settled before the delete runs. WHY
+  // THIS IS REQUIRED: the final job-settle heartbeat is FIRE-AND-FORGET (`void
+  // registration.heartbeat(...)` in `runWorker`'s `onCurrentJobChange` wiring,
+  // orchestrator.ts; the worker loop only attaches `.catch`, never awaits), so
+  // `await worker.stop()` resolving guarantees the heartbeat was CALLED, NOT
+  // that its PB upsert COMPLETED. A still-in-flight upsert could otherwise land
+  // AFTER the delete and re-create the row. `write()` already swallows its own
+  // errors (never rejects), so the chain never breaks; we still catch
+  // defensively so a future throwing `write` can't poison the chain.
+  let lastWrite: Promise<void> = Promise.resolve();
+  function serializedWrite(
+    currentJobId: string | null,
+    isRegister: boolean,
+  ): Promise<void> {
+    // LATCH CHECK AT ENQUEUE TIME (synchronous): a write requested at or after
+    // deregister() entry must never enqueue — the chain's terminal link is the
+    // row DELETE, and anything queued behind it would re-create the row via
+    // upsertByField's find-or-create. Writes enqueued BEFORE deregister() are
+    // unaffected: the delete is chained behind them, so they settle first.
+    if (deregistered) {
+      logger.debug?.("worker.heartbeat-after-deregister-skipped", {
+        workerId,
+        currentJobId,
+      });
+      return Promise.resolve();
+    }
+    lastWrite = lastWrite.then(
+      () => write(currentJobId, isRegister),
+      () => write(currentJobId, isRegister),
+    );
+    return lastWrite;
+  }
+
   // Boot registration (idle: no job claimed yet).
-  await write(null, true);
+  await serializedWrite(null, true);
 
   let timer: ReturnType<typeof setIntervalFn> | undefined = setIntervalFn(
     () => {
@@ -219,7 +305,7 @@ export async function registerWorker(
       // explicitly via the returned `heartbeat(jobId)` on its run path; the
       // periodic safety beat just refreshes liveness so fleet-health doesn't mark
       // a long-idle worker stale.
-      void write(null, false);
+      void serializedWrite(null, false);
     },
     heartbeatMs,
   );
@@ -232,13 +318,48 @@ export async function registerWorker(
 
   return {
     async heartbeat(currentJobId: string | null): Promise<void> {
-      await write(currentJobId, false);
+      await serializedWrite(currentJobId, false);
     },
     stop(): void {
       if (timer !== undefined) {
         clearIntervalFn(timer);
         timer = undefined;
       }
+    },
+    async deregister(): Promise<void> {
+      // Latch SYNCHRONOUSLY before any await: from this point every
+      // `heartbeat()`/periodic write is a logged no-op, so a beat arriving
+      // while the delete is still in flight (or any time after) can never
+      // re-create the row via upsertByField's find-or-create.
+      deregistered = true;
+      const doDelete = async (): Promise<void> => {
+        try {
+          // JSON.stringify escapes quotes/backslashes in the id — same
+          // defense-in-depth filter idiom as createStatusReader /
+          // verifyWorkerRegistered (orchestrator.ts). workerId is our own
+          // hostname-derived id, but never interpolate raw into a PB filter.
+          await pb.deleteByFilter(
+            WORKERS_COLLECTION,
+            `worker_id = ${JSON.stringify(workerId)}`,
+          );
+          logger.info("worker.deregistered", { workerId, endpoint });
+        } catch (err) {
+          // BEST-EFFORT: a failed delete degrades to today's behavior (the row
+          // persists, fleet-health reclaims it red at the 180s stale window) —
+          // NOT a regression. Swallow + warn; never throw into shutdown.
+          logger.warn?.("worker.deregister-failed", {
+            workerId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      };
+      // Route the DELETE THROUGH the write-serialization chain as its terminal
+      // link: every still-pending (fire-and-forget) heartbeat upsert settles
+      // BEFORE the delete runs, and no upsert can interleave with it. The
+      // rejection arm is defensive only — `write`/`doDelete` swallow their own
+      // errors, so the chain never rejects.
+      lastWrite = lastWrite.then(doDelete, doDelete);
+      await lastWrite;
     },
   };
 }

--- a/showcase/harness/src/fleet/worker/worker-loop.test.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.test.ts
@@ -945,6 +945,225 @@ describe("startWorkerLoop", () => {
     await handle.stop();
     expect(reports[0]!.aggregateState).toBe("green");
   });
+
+  // ── Graceful drain (FIX 3): stop() aborts the in-flight driver run ─────────
+
+  /**
+   * A driver fake that BLOCKS until `ctx.abortSignal` fires (mirroring a
+   * long-lived d6 browser run that observes the external abort). It captures the
+   * ctx it was handed so the test can assert the loop populated `abortSignal` +
+   * `drainReason`. On abort it behaves like the real d6 per-feature abort branch:
+   * it would side-emit a red `errorClass: "abort"` cell — UNLESS
+   * `ctx.drainReason === "shutdown"`, in which case it SUPPRESSES that emit
+   * (the real driver-side suppression this test stands in for).
+   */
+  function makeBlockingDrainDriver(): {
+    driver: ServiceJobDriver;
+    seenCtx: () => ServiceDriverContext | undefined;
+    started: Promise<void>;
+  } {
+    let captured: ServiceDriverContext | undefined;
+    let markStarted!: () => void;
+    const started = new Promise<void>((res) => {
+      markStarted = res;
+    });
+    const driver: ServiceJobDriver = {
+      async run(ctx, _input): Promise<ProbeResult> {
+        captured = ctx;
+        markStarted();
+        // Wait for the external (drain) abort.
+        await new Promise<void>((resolve) => {
+          if (ctx.abortSignal?.aborted) {
+            resolve();
+            return;
+          }
+          ctx.abortSignal?.addEventListener("abort", () => resolve(), {
+            once: true,
+          });
+        });
+        const observedAt = ctx.now().toISOString();
+        // Real-d6-like per-feature abort emit, suppressed on drain.
+        if (ctx.drainReason !== "shutdown") {
+          await ctx.writer.write({
+            key: "d6:langgraph-python/shared-state",
+            state: "red",
+            signal: { featureType: "shared-state", errorClass: "abort" },
+            observedAt,
+          });
+        }
+        return {
+          key: "e2e_d6:langgraph-python",
+          state: "red",
+          signal: { shape: "package", slug: "langgraph-python" },
+          observedAt,
+        };
+      },
+    };
+    return { driver, seenCtx: () => captured, started };
+  }
+
+  it("stop() during an in-flight job aborts the driver (ctx.abortSignal defined+fired) and resolves bounded", async () => {
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const { driver, seenCtx, started } = makeBlockingDrainDriver();
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      driver,
+      payloadToInput: passInput,
+      logger: silentLogger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+
+    // Wait until the driver is actually running (claimed + in run()).
+    await started;
+    const ctx = seenCtx();
+    expect(ctx).toBeDefined();
+    // The loop threads its stopAbort signal into ctx.abortSignal, un-fired
+    // until stop().
+    expect(ctx!.abortSignal).toBeDefined();
+    expect(ctx!.abortSignal!.aborted).toBe(false);
+
+    // stop() must abort the run and resolve promptly (bounded), not hang on the
+    // driver's full timeout. A 1s budget proves it doesn't block.
+    await expect(
+      Promise.race([
+        handle.stop(),
+        new Promise<never>((_res, rej) =>
+          setTimeout(
+            () => rej(new Error("stop() did not resolve bounded")),
+            1000,
+          ),
+        ),
+      ]),
+    ).resolves.toBeUndefined();
+    expect(ctx!.abortSignal!.aborted).toBe(true);
+    expect(ctx!.drainReason).toBe("shutdown");
+  });
+
+  it("drain does NOT emit red cells for not-yet-run pills (drainReason suppresses)", async () => {
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const { driver, started } = makeBlockingDrainDriver();
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      driver,
+      payloadToInput: passInput,
+      logger: silentLogger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+
+    await started;
+    await handle.stop();
+    // No red abort cell was reported (the worker also skips report on drain, so
+    // we assert via the queue: nothing reported, hence no red cell painted).
+    const reportedRedAbort = queue.reports.some((r) =>
+      (r.cells ?? []).some(
+        (c) =>
+          c.state === "red" &&
+          (c.signal as { errorClass?: string })?.errorClass === "abort",
+      ),
+    );
+    expect(reportedRedAbort).toBe(false);
+  });
+
+  it("drain does NOT report the in-flight job (lets the lease expire → sweeper re-queues neutral-gray)", async () => {
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const reportSpy = vi.spyOn(queue, "report");
+    const { driver, started } = makeBlockingDrainDriver();
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      driver,
+      payloadToInput: passInput,
+      logger: silentLogger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+
+    await started;
+    await handle.stop();
+    // The worker abandons the partial: no report for the drained job. The lease
+    // lapses and `sweepExpired` re-queues it neutral-gray (a reported partial
+    // would paint red — terminalJobStatus maps any non-green aggregate to failed).
+    expect(reportSpy).not.toHaveBeenCalled();
+  });
+
+  it("ctx.drainReason is undefined while the drain signal has NOT fired and becomes 'shutdown' after stop()", async () => {
+    // `drainReason` means "the EXTERNAL drain signal FIRED", not "a drain
+    // signal exists". In fleet production every ctx carries the worker's
+    // stopAbort signal, so a statically-stamped "shutdown" would mislabel the
+    // driver's own wall-clock timeout abort as a graceful drain and suppress
+    // its red cells. The ctx must therefore expose drainReason LIVE: undefined
+    // until the signal fires, "shutdown" after.
+    let reasonAtStart: "shutdown" | undefined;
+    let reasonAfterAbort: "shutdown" | undefined;
+    let markStarted!: () => void;
+    const started = new Promise<void>((res) => {
+      markStarted = res;
+    });
+    const driver: ServiceJobDriver = {
+      async run(ctx, _input): Promise<ProbeResult> {
+        reasonAtStart = ctx.drainReason;
+        markStarted();
+        await new Promise<void>((resolve) => {
+          if (ctx.abortSignal?.aborted) {
+            resolve();
+            return;
+          }
+          ctx.abortSignal?.addEventListener("abort", () => resolve(), {
+            once: true,
+          });
+        });
+        reasonAfterAbort = ctx.drainReason;
+        return {
+          key: "e2e_d6:langgraph-python",
+          state: "red",
+          signal: { shape: "package", slug: "langgraph-python" },
+          observedAt: ctx.now().toISOString(),
+        };
+      },
+    };
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      driver,
+      payloadToInput: passInput,
+      logger: silentLogger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+
+    await started;
+    // Before stop(): the drain signal exists but has NOT fired — a timeout
+    // abort at this point is a genuine failure, so drainReason must be unset.
+    expect(reasonAtStart).toBeUndefined();
+    await handle.stop();
+    // After stop(): the drain signal fired — the abort IS a graceful drain.
+    expect(reasonAfterAbort).toBe("shutdown");
+  });
 });
 
 // ── Driver REGISTRY: dispatch by payload.driverKind ────────────────────────

--- a/showcase/harness/src/fleet/worker/worker-loop.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.ts
@@ -87,6 +87,16 @@ export interface ServiceDriverContext {
   env: Readonly<Record<string, string | undefined>>;
   writer: { write(result: ProbeResult): Promise<unknown> };
   abortSignal?: AbortSignal;
+  /**
+   * Reads `"shutdown"` once the worker's drain signal has actually FIRED
+   * (graceful `stop()`), and `undefined` before that — exposed as a live
+   * getter, NOT stamped at ctx construction. This lets the driver distinguish
+   * a drain abort from its own timeout/error abort and SUPPRESS its red
+   * per-cell side-emits only on a true drain (a redeploy must not paint a
+   * mass-red block, but a genuine timeout must stay red). Stays structurally
+   * assignable to `ProbeContext.drainReason`.
+   */
+  drainReason?: "shutdown";
   featureTypes?: string[];
 }
 
@@ -191,9 +201,16 @@ export interface WorkerLoopDeps {
   onCurrentJobChange?: (currentJobId: string | null) => void;
 }
 
-/** Handle returned by `startWorkerLoop` — `stop()` drains and resolves. */
+/** Handle returned by `startWorkerLoop` — `stop()` requests a bounded drain. */
 export interface WorkerLoopHandle {
-  /** Resolves when the loop has stopped (after the in-flight job settles). */
+  /**
+   * Resolves when the loop has stopped OR the drain grace (`drainGraceMs`,
+   * see `DEFAULT_WORKER_DRAIN_GRACE_MS`) expires — whichever comes first. On
+   * expiry stop() DETACHES and resolves anyway, so a wedged driver that
+   * ignores its abort signal may still be running afterwards. Re-entry
+   * caveat: a second stop() call awaits `done` unbounded (no grace race) —
+   * known limitation, tracked in follow-ups.
+   */
   stop(): Promise<void>;
   /** The promise of the loop's run — resolves when the loop exits. */
   done: Promise<void>;
@@ -205,6 +222,21 @@ export const DEFAULT_LEASE_SECONDS = 300;
 export const DEFAULT_HEARTBEAT_MS = 60_000;
 /** Default idle poll interval when there's no work / no budget. */
 export const DEFAULT_POLL_INTERVAL_MS = 5_000;
+/**
+ * Upper bound on how long `stop()` waits for the in-flight run to drain before
+ * detaching and resolving anyway. Comfortably under Railway's SIGTERM grace
+ * window so even a wedged driver (one that ignores its abort signal) can't block
+ * process exit past grace and get SIGKILL'd mid-cleanup. Env-overridable via
+ * `WORKER_DRAIN_GRACE_MS`.
+ */
+export const DEFAULT_WORKER_DRAIN_GRACE_MS = 25_000;
+
+function resolveDrainGraceMs(): number {
+  const raw = process.env.WORKER_DRAIN_GRACE_MS;
+  const parsed = raw ? parseInt(raw, 10) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  return DEFAULT_WORKER_DRAIN_GRACE_MS;
+}
 
 function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise<void>((resolve) => {
@@ -485,16 +517,6 @@ export function buildDriverErrorResult(args: {
 }
 
 /**
- * Run ONE claimed job to completion: install the cell-capturing writer, run the
- * driver with a lease-renewal heartbeat in flight, and return the computed
- * `ServiceJobResult`. On a driver crash/timeout, returns a comm-error terminal
- * result instead of throwing — the loop always has a result to report so a
- * crashed job never silently strands its lease until the sweeper reclaims it.
- *
- * Exported for direct unit testing of the claim→run→report round-trip without
- * driving the full poll loop.
- */
-/**
  * Resolve the `{ driver, payloadToInput }` entry that runs a claimed payload.
  * Dispatch is by `payload.driverKind` against the injected `drivers` registry;
  * when the registry is omitted the loop falls back to the legacy single
@@ -523,6 +545,16 @@ export function resolveDriverEntry(
   return undefined;
 }
 
+/**
+ * Run ONE claimed job to completion: install the cell-capturing writer, run the
+ * driver with a lease-renewal heartbeat in flight, and return the computed
+ * `ServiceJobResult`. On a driver crash/timeout, returns a comm-error terminal
+ * result instead of throwing — the loop always has a result to report so a
+ * crashed job never silently strands its lease until the sweeper reclaims it.
+ *
+ * Exported for direct unit testing of the claim→run→report round-trip without
+ * driving the full poll loop.
+ */
 export async function runClaimedJob(
   deps: Pick<
     WorkerLoopDeps,
@@ -536,6 +568,17 @@ export async function runClaimedJob(
   > & { now: () => Date; sleep: NonNullable<WorkerLoopDeps["sleep"]> },
   lease: JobLease,
   opts: { leaseSeconds: number; heartbeatMs: number },
+  /**
+   * The worker's drain signal (`startWorkerLoop`'s `stopAbort.signal`). Threaded
+   * into `ctx.abortSignal` so a graceful `stop()` cancels the in-flight driver
+   * run promptly (the d6 driver wires `ctx.abortSignal` into its own abort).
+   * Once the signal FIRES, `ctx.drainReason` reads `"shutdown"` (a live getter
+   * — undefined while the signal exists but has not fired) so the driver can
+   * distinguish a drain abort from a timeout/error abort and suppress its red
+   * per-cell side-emits only on a true drain. Optional so the `runClaimedJob`
+   * unit tests that call it directly keep compiling without a signal.
+   */
+  drainSignal?: AbortSignal,
 ): Promise<ServiceJobResult> {
   const { workerId, queue, logger, env, now } = deps;
   const { job, payload } = lease;
@@ -688,6 +731,21 @@ export async function runClaimedJob(
       logger,
       env,
       writer: capture.writer,
+      // Thread the worker's drain signal so a graceful `stop()` aborts the
+      // in-flight run promptly. `drainReason` rides alongside it so the driver
+      // suppresses its red per-cell side-emits on drain (a redeploy must not
+      // paint a mass-red block).
+      abortSignal: drainSignal,
+      // LIVE drain state: "shutdown" only once the drain signal has actually
+      // FIRED — not merely because one exists. Every fleet ctx carries the
+      // signal, so a statically-stamped "shutdown" would mislabel the driver's
+      // OWN wall-clock timeout abort as a graceful drain and suppress the red
+      // cells a genuine timeout must paint. A getter keeps the field a plain
+      // optional property structurally (assignable to ProbeContext.drainReason)
+      // while reading the signal's state at suppression-decision time.
+      get drainReason(): "shutdown" | undefined {
+        return drainSignal?.aborted ? "shutdown" : undefined;
+      },
       featureTypes:
         payload.cellIds && payload.cellIds.length > 0
           ? payload.cellIds
@@ -921,6 +979,8 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
 
       // 3. Run + report. `runClaimedJob` never throws — it returns a comm-error
       //    terminal result on crash/timeout so the loop always reports.
+      //    The drain signal (`stopAbort.signal`) is threaded into the driver ctx
+      //    so a graceful `stop()` cancels the in-flight run.
       const result = await runClaimedJob(
         {
           workerId,
@@ -935,7 +995,30 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
         },
         lease,
         { leaseSeconds, heartbeatMs },
+        stopAbort.signal,
       );
+
+      // DRAIN ABANDON: the check is "stop() was requested" — NOT "the run was
+      // aborted". A result that completed green just before stop() fired is
+      // also abandoned, by design (accepted cost; it re-runs after the lease
+      // lapses). Do NOT report the result —
+      // a reported partial paints RED (terminalJobStatus maps any non-green
+      // aggregate to "failed", and there is no neutral aggregate state the
+      // result-consumer renders). Instead leave the row claimed/running so the
+      // lease lapses and the control-plane sweeper re-queues it neutral-gray
+      // (`worker-reclaimed-pending`). The accepted cost is an up-to-lease-window
+      // re-run delay; the win is ZERO red paint on a routine redeploy. The
+      // worker also deregisters its registry row (orchestrator runWorker stop
+      // path) so fleet-health doesn't reclaim the row red at its 180s stale
+      // window before the 300s lease expiry.
+      if (stopAbort.signal.aborted) {
+        logger.info("fleet.worker.drain-abandon", {
+          workerId,
+          jobId: lease.job.id,
+        });
+        notifyCurrentJob(null);
+        break;
+      }
 
       try {
         await queue.report({ jobId: lease.job.id, workerId, result });
@@ -976,6 +1059,8 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
     logger.info("fleet.worker.loop-stopped", { workerId });
   })();
 
+  const drainGraceMs = resolveDrainGraceMs();
+
   return {
     async stop(): Promise<void> {
       if (stopped) {
@@ -984,7 +1069,34 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
       }
       stopped = true;
       stopAbort.abort();
-      await done;
+      // Bound the drain: the in-flight `driver.run` observes `stopAbort.signal`
+      // (threaded into `ctx.abortSignal`) and returns promptly, so `done`
+      // normally resolves fast. But a wedged driver that ignores the abort must
+      // not block process exit past Railway's grace window → SIGKILL mid-cleanup.
+      // Race `done` against a grace timeout; if the race times out, log and
+      // DETACH (resolve anyway) so the process actually leaves before SIGKILL.
+      let graceTimer: ReturnType<typeof setTimeout> | undefined;
+      const graceExpired = new Promise<"timeout">((resolve) => {
+        graceTimer = setTimeout(() => resolve("timeout"), drainGraceMs);
+        if (
+          graceTimer &&
+          typeof (graceTimer as { unref?: () => void }).unref === "function"
+        ) {
+          (graceTimer as { unref: () => void }).unref();
+        }
+      });
+      const outcome = await Promise.race([
+        done.then(() => "done" as const),
+        graceExpired,
+      ]);
+      if (graceTimer !== undefined) clearTimeout(graceTimer);
+      if (outcome === "timeout") {
+        logger.warn("fleet.worker.drain-timeout", {
+          workerId,
+          drainGraceMs,
+        });
+        // Detach: do NOT await `done` further — let the process exit.
+      }
     },
     done,
   };

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -104,6 +104,7 @@ import { createResultConsumer } from "./fleet/control-plane/result-consumer.js";
 import {
   createFleetHealthMonitor,
   DEFAULT_WORKER_STALE_AFTER_MS,
+  DEFAULT_WORKER_GC_AFTER_MS,
 } from "./fleet/control-plane/fleet-health.js";
 import type { RestartWorkerHook } from "./fleet/control-plane/fleet-health.js";
 import {
@@ -2420,6 +2421,7 @@ export async function runControlPlane(
     claim,
     logger,
     staleAfterMs: resolveWorkerStaleAfterMs(),
+    gcAfterMs: resolveWorkerGcAfterMs(),
     restartWorker: resolveWorkerRestartHook(logger),
   });
 
@@ -3027,6 +3029,22 @@ function resolveWorkerStaleAfterMs(): number {
 }
 
 /**
+ * Resolve the GC window (ms): how long since a worker's last heartbeat before
+ * fleet-health DELETES its roster row outright (a long-dead prior-generation row
+ * that never deregistered) instead of pointlessly reclaiming/restart-attempting
+ * it every cycle. Env-overridable via WORKER_GC_AFTER_MS; defaults to
+ * DEFAULT_WORKER_GC_AFTER_MS (24h). A non-positive / unparseable override falls
+ * back to the default rather than disabling GC. MUST stay >> the stale window so
+ * a recoverable worker is never GC'd.
+ */
+function resolveWorkerGcAfterMs(): number {
+  const raw = process.env.WORKER_GC_AFTER_MS;
+  const parsed = raw ? parseInt(raw, 10) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  return DEFAULT_WORKER_GC_AFTER_MS;
+}
+
+/**
  * Resolve the best-effort worker-restart hook fleet-health fires for a wedged
  * worker. In STAGING a wedged worker is recovered by a Railway
  * `serviceInstanceRedeploy`; the wiring is env-guarded so it only engages when
@@ -3441,11 +3459,33 @@ export async function runWorker(
     port: worker.port,
     bus: worker.bus,
     async stop(): Promise<void> {
-      registration.stop();
-      // We injected BOTH budgetSource and driver, so fleet runWorker did NOT
-      // construct its own pool — its stop() only drains the in-flight job and
-      // stops the loop. WE own the pool, so we shut it down ourselves below.
+      // GRACEFUL-DRAIN STOP ORDERING (FIX 3). The order matters because the
+      // final job-settle heartbeat is FIRE-AND-FORGET (`void
+      // registration.heartbeat(...)` above), so `await worker.stop()` resolving
+      // guarantees that heartbeat was CALLED, not that its PB upsert COMPLETED.
+      //   1. `worker.stop()` — drains/aborts the in-flight run (the loop threads
+      //      its drain signal into the driver ctx, the driver suppresses red
+      //      side-emits, and the loop SKIPS reporting the partial so the lease
+      //      lapses into the sweeper's neutral-gray re-queue). Its settle fires
+      //      the LAST possible (fire-and-forget) `onCurrentJobChange(null)`
+      //      heartbeat upsert.
+      //   2. `registration.stop()` — cancel the periodic heartbeat timer so no
+      //      further periodic upsert can follow the delete.
+      //   3. `registration.deregister()` — AWAIT the handle's tracked in-flight
+      //      write (so the still-in-flight job-settle upsert from step 1 lands
+      //      FIRST), THEN best-effort DELETE this worker's registry row. With no
+      //      row, fleet-health never reclaims a gracefully-drained worker red at
+      //      its 180s stale window; the abandoned job reaches the 300s lease
+      //      expiry where the sweeper re-queues it neutral-gray. The no-re-upsert
+      //      guarantee lives in the HANDLE (the awaited in-flight write), NOT in
+      //      this ordering — the reorder only narrows the race window. Crash path
+      //      (process died, no deregister) keeps today's red reclaim.
+      //   4. `pool.shutdown()` — unchanged (still last). We injected BOTH
+      //      budgetSource and driver, so fleet runWorker did NOT construct its
+      //      own pool — WE own it and shut it down here.
       await worker.stop();
+      registration.stop();
+      await registration.deregister();
       await pool.shutdown().catch((err) => {
         logger.error("showcase-harness.fleet.worker.pool-shutdown-failed", {
           workerId,
@@ -3519,18 +3559,25 @@ export async function bootFleet(
     }
     case "worker": {
       const worker = await runWorker(config, opts);
-      // GRACEFUL-TEARDOWN MARKER (flap-band #70): Railway sends SIGTERM (with a
-      // grace window) on scale-down / redeploy. WITHOUT this handler the worker
-      // process dies mid-job, leaving its claimed/running row to lapse so the
-      // control-plane sweeper reclaims it as a comm error — a FALSE flap on
-      // every routine teardown. Draining here makes the in-flight job report a
-      // TERMINAL result BEFORE the lease can expire, so the sweep never sees the
-      // row at all and no false overlay is synthesized. This is THE distinction
-      // the sweep boundary cannot make on its own (an expired lease looks the
-      // same for a crash and a SIGKILL teardown) — we create the marker by
-      // converting the common SIGTERM teardown into a clean drain. A hard
-      // SIGKILL (no grace) still strands the row, but the sweep now treats that
-      // as the neutral `worker-reclaimed-pending` (re-queued), not a red crash.
+      // GRACEFUL-TEARDOWN MARKER (flap-band #70 / #71-FF3): Railway sends SIGTERM
+      // (with a grace window) on scale-down / redeploy. WITHOUT this handler the
+      // worker process dies mid-job, leaving its claimed/running row to lapse so
+      // the control-plane sweeper reclaims it as a comm error — a FALSE flap on
+      // every routine teardown. The drain (worker.stop() in runWorker's stop
+      // path) does NOT report a terminal result for the in-flight job: a reported
+      // partial would paint RED (terminalJobStatus maps any non-green aggregate
+      // to "failed", and the result-consumer has no neutral aggregate state). So
+      // the drain instead ABANDONS the partial — the driver suppresses its red
+      // per-cell side-emits (ctx.drainReason === "shutdown"), the loop skips
+      // queue.report, and the worker DEREGISTERS its registry row. With no row,
+      // fleet-health can't reclaim a gracefully-drained worker red at its 180s
+      // stale window; the abandoned job's claimed/running row lapses at the 300s
+      // lease expiry where the sweeper re-queues it as the neutral
+      // `worker-reclaimed-pending` (gray), accepting an up-to-lease-window re-run
+      // delay for ZERO red paint on a routine redeploy. Deregistration is THE
+      // distinction the sweep boundary cannot make on its own (an expired lease
+      // looks the same for a crash and a SIGTERM teardown): a CRASH leaves the
+      // row (→ today's red reclaim, unchanged), a graceful drain deletes it.
       let draining = false;
       const drainAndExit = (signal: NodeJS.Signals): void => {
         if (draining) return;

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -582,16 +582,20 @@ describe("createPooledE2eSmokeLauncher context checkout + abort release", () => 
       pool as unknown as BrowserPool,
     );
     const browser = await launcher();
+    // Sample header reflects the real per-run X-Test-Id shape the driver now
+    // emits: `d4-<slug>-<runId>` (the per-run runId suffix is FIX 1). This is a
+    // value-agnostic passthrough test — the launcher forwards whatever headers
+    // it is handed — so the value here is illustrative, not asserted-by-shape.
     await browser.newContext({
       extraHTTPHeaders: {
         "X-AIMock-Context": "slug-d4",
-        "X-Test-Id": "d4-slug-d4",
+        "X-Test-Id": "d4-slug-d4-run1",
       },
     });
     expect(pool._acquireOptions[0]).toEqual({
       extraHTTPHeaders: {
         "X-AIMock-Context": "slug-d4",
-        "X-Test-Id": "d4-slug-d4",
+        "X-Test-Id": "d4-slug-d4-run1",
       },
     });
   });

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -9,6 +9,7 @@ import {
 import type { BrowserPool } from "../helpers/browser-pool.js";
 import type { ProbeDriver } from "../types.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
+import { mintRunId } from "../helpers/cv-diag.js";
 
 /**
  * e2e-smoke driver — L3 (chat round-trip) and L4 (tool rendering) coverage
@@ -202,6 +203,17 @@ export interface E2eSmokeDriverDeps {
    * first token to arrive. Defaults to `pageTimeoutMs`.
    */
   textPollTimeoutMs?: number;
+  /**
+   * Factory for the per-`run()` correlation id (`runId`) folded into the
+   * aimock X-Test-Id (`d4-<slug>-<runId>`). Defaults to `mintRunId`
+   * (`crypto.randomUUID()`). Injectable ONLY so unit tests can supply a
+   * deterministic counter and assert the per-run-unique X-Test-Id without
+   * matching a brittle UUID regex. Production always uses the default. The id
+   * is minted once per `run()`, so both L3/L4 levels of one run share it
+   * (stable within a run) and it is unique across runs — eliminating the
+   * cross-run aimock fixture-match-count desync that flapped the dashboard.
+   */
+  idFactory?: () => string;
 }
 
 const DEFAULT_TIMEOUT_MS = 3 * 60 * 1000;
@@ -430,6 +442,7 @@ export function createE2eSmokeDriver(
   const pageTimeoutMs = deps.pageTimeoutMs ?? DEFAULT_PAGE_TIMEOUT_MS;
   const textPollTimeoutMs = deps.textPollTimeoutMs ?? pageTimeoutMs;
   const demosResolver = deps.demosResolver ?? createDefaultDemosResolver();
+  const idFactory = deps.idFactory ?? mintRunId;
 
   return {
     kind: "e2e_smoke",
@@ -443,6 +456,12 @@ export function createE2eSmokeDriver(
       // Schema already guaranteed at least one is present.
       const backendUrl = (input.backendUrl ?? input.publicUrl)!;
       const slug = deriveSlug(input.key, input.name);
+      // Per-run correlation id folded into the aimock X-Test-Id
+      // (`d4-<slug>-<runId>`). Minted once per `run()` so both L3/L4 levels
+      // share it (stable within a run) yet it is unique across runs, giving
+      // each run a fresh aimock per-test-id fixture-match count and removing
+      // the cross-run sequence/turn-count desync that flapped the dashboard.
+      const runId = idFactory();
       const shape = resolveShape(
         { name: input.name, shape: input.shape },
         { logger: ctx.logger },
@@ -545,6 +564,7 @@ export function createE2eSmokeDriver(
           level: "chat",
           demoPath: "/demos/agentic-chat",
           message: "Hello, please respond with a brief greeting.",
+          testId: `d4-${slug}-${runId}`,
           abortSignal: abort.signal,
           pageTimeoutMs,
           textPollTimeoutMs,
@@ -580,6 +600,7 @@ export function createE2eSmokeDriver(
             level: "tools",
             demoPath: "/demos/tool-rendering",
             message: "What's the weather in San Francisco?",
+            testId: `d4-${slug}-${runId}`,
             abortSignal: abort.signal,
             pageTimeoutMs,
             textPollTimeoutMs,
@@ -707,6 +728,8 @@ async function runLevel(opts: {
   level: "chat" | "tools";
   demoPath: string;
   message: string;
+  /** Per-run aimock X-Test-Id (`d4-<slug>-<runId>`), shared by L3/L4. */
+  testId: string;
   abortSignal: AbortSignal;
   pageTimeoutMs: number;
   textPollTimeoutMs: number;
@@ -720,6 +743,7 @@ async function runLevel(opts: {
     level,
     demoPath,
     message,
+    testId,
     abortSignal,
     pageTimeoutMs,
     textPollTimeoutMs,
@@ -751,7 +775,7 @@ async function runLevel(opts: {
     context = await browser.newContext({
       extraHTTPHeaders: {
         "X-AIMock-Context": slug,
-        "X-Test-Id": `d4-${slug}`,
+        "X-Test-Id": testId,
       },
     });
     page = await context.newPage();

--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -102,6 +102,8 @@ function makeBrowser(opts?: {
 function makeCtx(overrides?: {
   writer?: ProbeResultWriter;
   featureTypes?: string[];
+  abortSignal?: AbortSignal;
+  drainReason?: "shutdown";
 }): ProbeContext {
   return {
     now: () => new Date("2025-01-01T00:00:00Z"),
@@ -109,6 +111,8 @@ function makeCtx(overrides?: {
     env: {},
     writer: overrides?.writer,
     featureTypes: overrides?.featureTypes,
+    abortSignal: overrides?.abortSignal,
+    drainReason: overrides?.drainReason,
   };
 }
 
@@ -267,6 +271,150 @@ describe("e2e-full driver", () => {
       expect(sideRow).toBeDefined();
       expect(sideRow!.state).toBe("green");
     });
+  });
+
+  // FIX 3 (graceful drain): when the run is aborted as part of a worker drain
+  // (`ctx.drainReason === "shutdown"`), the driver must SUPPRESS the red
+  // per-cell `errorClass: "abort"` side-emits it would otherwise write for
+  // not-yet-completed features — a redeploy must not paint a mass-red block.
+  // The worker-loop layer separately skips reporting the partial; the driver's
+  // job here is purely to suppress the per-cell red side-emits.
+  describe("graceful-drain abort suppression", () => {
+    it("suppresses red abort side-emits for unstarted features when drainReason=shutdown", async () => {
+      registerD5Script(makeScript(["agentic-chat"]));
+
+      const sideEmits: ProbeResult<unknown>[] = [];
+      const writer: ProbeResultWriter = {
+        write: async (r) => {
+          sideEmits.push(r);
+        },
+      };
+
+      const driver = createE2eFullDriver({
+        launcher: async () => makeBrowser(),
+        scriptLoader: noopScriptLoader(),
+      });
+
+      // Pre-aborted signal = the worker has already started draining when the
+      // feature loop reaches this pill, so the abort branch fires immediately.
+      const ac = new AbortController();
+      ac.abort();
+
+      await driver.run(
+        makeCtx({ writer, abortSignal: ac.signal, drainReason: "shutdown" }),
+        {
+          key: "e2e_d6:showcase-test-slug",
+          backendUrl: "https://test.example.com",
+          features: ["agentic-chat"],
+        },
+      );
+
+      // NO red per-cell abort side-emit for the unstarted pill.
+      const redAbortCells = sideEmits.filter(
+        (r) =>
+          r.state === "red" &&
+          (r.signal as { errorClass?: string })?.errorClass === "abort",
+      );
+      expect(redAbortCells).toEqual([]);
+    });
+
+    it("STILL emits red abort side-emits when aborted WITHOUT a drain reason (timeout/error abort)", async () => {
+      registerD5Script(makeScript(["agentic-chat"]));
+
+      const sideEmits: ProbeResult<unknown>[] = [];
+      const writer: ProbeResultWriter = {
+        write: async (r) => {
+          sideEmits.push(r);
+        },
+      };
+
+      const driver = createE2eFullDriver({
+        launcher: async () => makeBrowser(),
+        scriptLoader: noopScriptLoader(),
+      });
+
+      // Pre-aborted, but NOT a drain (no drainReason) — a timeout/error abort
+      // still paints red so a genuine failure is visible.
+      const ac = new AbortController();
+      ac.abort();
+
+      await driver.run(makeCtx({ writer, abortSignal: ac.signal }), {
+        key: "e2e_d6:showcase-test-slug",
+        backendUrl: "https://test.example.com",
+        features: ["agentic-chat"],
+      });
+
+      const redAbortCells = sideEmits.filter(
+        (r) =>
+          r.state === "red" &&
+          (r.signal as { errorClass?: string })?.errorClass === "abort",
+      );
+      expect(redAbortCells.length).toBeGreaterThan(0);
+    });
+
+    it("internal timeout abort STILL emits red side-emits even when ctx carries an un-fired drain signal", async () => {
+      // Fleet-shaped ctx: in production the worker threads its drain signal
+      // into EVERY ctx (and stamps drainReason alongside it), but here the
+      // signal never FIRES — the abort is the driver's own wall-clock
+      // `timeoutMs` cap. A timeout is a genuine failure and must paint red;
+      // suppression is only for an abort caused by the external drain signal
+      // actually firing. Saturate the semaphore so the queued feature hits the
+      // pre-start abort branch and the running ones hit the mid-run branch.
+      const featureTypes = [
+        "agentic-chat",
+        "tool-rendering",
+        "shared-state-read",
+        "shared-state-write",
+        "hitl-text-input",
+      ] as const;
+      expect(featureTypes.length).toBeGreaterThan(FEATURE_CONCURRENCY_D6);
+      for (const ft of featureTypes) {
+        registerD5Script(makeScript([ft]));
+      }
+
+      const sideEmits: ProbeResult<unknown>[] = [];
+      const writer: ProbeResultWriter = {
+        write: async (r) => {
+          sideEmits.push(r);
+        },
+      };
+
+      const { launcher } = makeSlowTeardownLauncherFull({
+        gotoDelayMs: 200,
+        closeDelayMs: 5,
+      });
+      const driver = createE2eFullDriver({
+        launcher,
+        scriptLoader: noopScriptLoader(),
+        // Large enough that the OUTER cap (not the per-feature timer) drives
+        // the abort.
+        featureTimeoutMs: 60_000,
+      });
+
+      // The drain signal EXISTS but never fires.
+      const ac = new AbortController();
+
+      const result = await driver.run(
+        makeCtx({ writer, abortSignal: ac.signal, drainReason: "shutdown" }),
+        {
+          key: "e2e_d6:showcase-test-slug",
+          backendUrl: "https://test.example.com",
+          features: [...featureTypes],
+          // Tiny outer cap so the driver's INTERNAL timeout abort fires fast.
+          timeout_ms: 5,
+        },
+      );
+
+      expect(result.state).toBe("red");
+      // The timeout abort must paint red per-cell side-emits — the un-fired
+      // drain signal must NOT suppress them.
+      const redAbortCells = sideEmits.filter(
+        (r) =>
+          r.state === "red" &&
+          (r.signal as { errorClass?: string })?.errorClass === "abort",
+      );
+      expect(redAbortCells.length).toBeGreaterThan(0);
+    }, 20_000);
   });
 
   // Regression guard: the dashboard reads the integration-scoped aggregate

--- a/showcase/harness/src/probes/drivers/d6-all-pills.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.ts
@@ -49,8 +49,11 @@ import type playwright from "playwright";
  *      featureType — unlike D5 which skips with green, D6 treats
  *      missing scripts as a hard failure.
  *   3. Opens a fresh Playwright context with `X-AIMock-Context: <slug>`
- *      and `X-Test-Id: d6-<slug>` headers, navigates to the per-feature
- *      route, and runs the conversation through `runConversation`.
+ *      and `X-Test-Id: d6-<slug>-<runId>` headers (see `buildE2eTestId`;
+ *      the runId suffix gives each run fresh aimock fixture-count state —
+ *      the old per-slug constant id caused the staging flap), navigates to
+ *      the per-feature route, and runs the conversation through
+ *      `runConversation`.
  *   4. Emits one `d6:<slug>/<featureType>` diagnostic side row per
  *      feature (not consumed by dashboard rollup — diagnostic only).
  *   5. Emits an aggregate `d6:<slug>` primary result that is green ONLY
@@ -253,6 +256,28 @@ export interface E2eFullDriverDeps {
    * swallowed by `writeDiagEvent` and can never break a probe.
    */
   diagPb?: DiagSinkClient;
+  /**
+   * Factory for the per-`run()` correlation id (`runId`). Defaults to
+   * `mintRunId` (`crypto.randomUUID()`). Injectable ONLY so unit tests can
+   * supply a deterministic counter and assert the per-run-unique X-Test-Id
+   * (`d6-<slug>-<runId>`) without matching a brittle UUID regex. Production
+   * always uses the default. The id is minted once per `run()` and is stable
+   * across every feature-cell of that run, unique across runs.
+   */
+  idFactory?: () => string;
+}
+
+/**
+ * Build the per-feature aimock X-Test-Id. Folds the per-`run()` correlation
+ * id (`runId`) into the previously per-slug-only id so each run starts from a
+ * fresh aimock per-test-id fixture-match count, eliminating the cross-run
+ * sequence/turn-count desync that flapped the staging dashboard. Stable across
+ * a run's feature-cells (same `runId`), unique across runs. D5 runs THIS driver
+ * (take-one), so it is covered by the same `d6-` value; the D5 dashboard column
+ * is derived from `rowPrefix`, not from this header.
+ */
+export function buildE2eTestId(slug: string, runId: string): string {
+  return `d6-${slug}-${runId}`;
 }
 
 /**
@@ -674,6 +699,7 @@ export function createE2eFullDriver(
   const scriptLoader = deps.scriptLoader ?? defaultScriptLoader;
   const representatives = deps.representatives ?? D5_REPRESENTATIVES;
   const diagPb = deps.diagPb;
+  const idFactory = deps.idFactory ?? mintRunId;
 
   return {
     kind: "e2e_d6",
@@ -713,7 +739,7 @@ export function createE2eFullDriver(
       // component tag distinguishes the D5 take-one path from a full D6 run
       // even though they share THIS driver — that distinction is the whole
       // point of the CV incident (D5/CV red while D6 green).
-      const runId = mintRunId();
+      const runId = idFactory();
       const cvComponent = rowPrefix === "d5" ? "harness-d5" : "harness-d6";
       // The aimock base URL the framework apps are wired to send X-AIMock-*
       // against. Read from env (orchestrator sets AIMOCK_URL; the CLI sets
@@ -1071,29 +1097,48 @@ export function createE2eFullDriver(
           > = [];
           try {
             if (abort.signal.aborted) {
-              await sideEmit(ctx, {
-                key: sideKey,
-                state: "red",
-                signal: {
-                  slug,
-                  featureType: ft,
-                  backendUrl,
-                  url,
-                  fixtureFile: script.fixtureFile,
-                  errorClass: "abort",
-                  errorDesc: timedOut
-                    ? `timeout after ${timeoutMs}ms`
-                    : "aborted",
-                },
-                observedAt: ctx.now().toISOString(),
-              });
+              // GRACEFUL DRAIN (FIX 3): when the abort is a worker drain —
+              // `ctx.drainReason === "shutdown"` AND the EXTERNAL drain signal
+              // actually FIRED — SUPPRESS the red per-cell side-emit for this
+              // not-yet-started pill; a redeploy must not paint a mass-red
+              // block. The pill keeps its prior dashboard colour; the
+              // worker-loop layer separately abandons the partial (skips
+              // `queue.report`) so the lease lapses into the sweeper's
+              // neutral-gray re-queue. The internal `abort` controller ALSO
+              // fires on the driver's own wall-clock `timeoutMs` cap, so the
+              // drain reason alone is not proof of a drain — require
+              // `ctx.abortSignal.aborted` too. A timeout/error abort still
+              // emits red so a genuine failure stays visible.
+              const drainAborted =
+                ctx.drainReason === "shutdown" &&
+                ctx.abortSignal?.aborted === true;
+              if (!drainAborted) {
+                await sideEmit(ctx, {
+                  key: sideKey,
+                  state: "red",
+                  signal: {
+                    slug,
+                    featureType: ft,
+                    backendUrl,
+                    url,
+                    fixtureFile: script.fixtureFile,
+                    errorClass: "abort",
+                    errorDesc: timedOut
+                      ? `timeout after ${timeoutMs}ms`
+                      : "aborted",
+                  },
+                  observedAt: ctx.now().toISOString(),
+                });
+              }
               ctx.logger.info("probe.e2e-full.feature-complete", {
                 slug,
                 featureType: ft,
                 pass: false,
                 errorDesc: timedOut
                   ? `timeout after ${timeoutMs}ms`
-                  : "aborted",
+                  : drainAborted
+                    ? "drain-suppressed"
+                    : "aborted",
                 durationMs: Date.now() - featureStart,
               });
               return {
@@ -1262,31 +1307,48 @@ export function createE2eFullDriver(
                 featureType: ft,
                 rowPrefix,
                 cvComponent,
-                testId: `d6-${slug}`,
+                testId: buildE2eTestId(slug, runId),
                 featureOk: true,
               });
               return { ft, ok: true as const };
             } else {
-              await sideEmit(ctx, {
-                key: sideKey,
-                state: "red",
-                signal: {
-                  slug,
-                  featureType: ft,
-                  backendUrl,
-                  url,
-                  fixtureFile: script.fixtureFile,
-                  turns_completed: featureResult.conversation?.turns_completed,
-                  total_turns: featureResult.conversation?.total_turns,
-                  failure_turn: featureResult.conversation?.failure_turn,
-                  turn_durations_ms:
-                    featureResult.conversation?.turn_durations_ms,
-                  errorDesc: featureResult.errorDesc,
-                  errorClass: featureResult.errorClass,
-                  diagnostics: featureResult.diagnostics,
-                },
-                observedAt: ctx.now().toISOString(),
-              });
+              // GRACEFUL DRAIN (FIX 3): a feature that STARTED then got aborted
+              // MID-RUN by the worker drain (`errorClass: "abort"` while
+              // `ctx.drainReason === "shutdown"` AND the EXTERNAL drain signal
+              // actually fired) is a not-yet-completed pill — suppress its red
+              // side-emit too so a redeploy doesn't paint it red. The internal
+              // abort ALSO fires on the driver's own wall-clock `timeoutMs`
+              // cap, so require `ctx.abortSignal.aborted` to distinguish a true
+              // drain from a timeout — a timeout abort, and a genuine in-driver
+              // failure (any non-abort errorClass), still paint red even within
+              // the drain window.
+              const drainAborted =
+                ctx.drainReason === "shutdown" &&
+                ctx.abortSignal?.aborted === true &&
+                featureResult.errorClass === "abort";
+              if (!drainAborted) {
+                await sideEmit(ctx, {
+                  key: sideKey,
+                  state: "red",
+                  signal: {
+                    slug,
+                    featureType: ft,
+                    backendUrl,
+                    url,
+                    fixtureFile: script.fixtureFile,
+                    turns_completed:
+                      featureResult.conversation?.turns_completed,
+                    total_turns: featureResult.conversation?.total_turns,
+                    failure_turn: featureResult.conversation?.failure_turn,
+                    turn_durations_ms:
+                      featureResult.conversation?.turn_durations_ms,
+                    errorDesc: featureResult.errorDesc,
+                    errorClass: featureResult.errorClass,
+                    diagnostics: featureResult.diagnostics,
+                  },
+                  observedAt: ctx.now().toISOString(),
+                });
+              }
               ctx.logger.info("probe.e2e-full.feature-complete", {
                 slug,
                 featureType: ft,
@@ -1307,7 +1369,7 @@ export function createE2eFullDriver(
                 featureType: ft,
                 rowPrefix,
                 cvComponent,
-                testId: `d6-${slug}`,
+                testId: buildE2eTestId(slug, runId),
                 featureOk: false,
                 featureError: featureResult.errorDesc,
               });
@@ -1492,7 +1554,7 @@ async function runFeature(opts: {
 
   let context: E2eFullBrowserContext | undefined;
   let page: E2eFullPage | undefined;
-  const testId = `d6-${slug}`;
+  const testId = buildE2eTestId(slug, runId);
   try {
     // D6 sets per-feature context headers: X-AIMock-Context and X-Test-Id.
     //

--- a/showcase/harness/src/probes/drivers/d6-test-id-uniqueness.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-test-id-uniqueness.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { buildE2eTestId, createE2eFullDriver } from "./d6-all-pills.js";
+import type {
+  E2eFullBrowser,
+  E2eFullBrowserContext,
+  E2eFullPage,
+} from "./d6-all-pills.js";
+import {
+  __clearD5RegistryForTesting,
+  registerD5Script,
+} from "../helpers/d5-registry.js";
+import type { D5Script } from "../helpers/d5-registry.js";
+import { logger } from "../../logger.js";
+import type { ProbeContext } from "../../types/index.js";
+
+// Per-run-unique X-Test-Id (FIX 1).
+//
+// ROOT CAUSE this guards against: the X-Test-Id was a per-slug CONSTANT
+// (`d6-<slug>`). aimock keys its fixture-match counters by (testId → fixture)
+// (router.ts sequenceIndex/turnIndex gates vs `getFixtureMatchCountsForTest`).
+// A constant per-slug testId meant consecutive runs of the same slug shared one
+// counter, so a second run started mid-sequence and strict-mode 503'd on
+// fixtures the first run had already consumed — the staging dashboard
+// red↔green flap. Folding the per-`run()` `runId` into the testId
+// (`d6-<slug>-<runId>`) gives every run a fresh counter while staying stable
+// across the run's feature-cells (so multi-turn sequenced fixtures within one
+// cell still align). D5 runs THIS driver (take-one), so it is covered too.
+
+// A counter idFactory so the per-run id is deterministic and assertable
+// (mintRunId is crypto.randomUUID — not seedable; the driver exposes
+// `idFactory` exactly so tests can inject a deterministic source).
+function makeCounterIdFactory(): () => string {
+  let n = 0;
+  return () => `run${++n}`;
+}
+
+function makePage(): E2eFullPage {
+  let messageCount = 0;
+  return {
+    async goto() {},
+    async waitForSelector() {},
+    async fill() {},
+    async press() {
+      messageCount++;
+    },
+    async evaluate<R>(fn: () => R): Promise<R> {
+      void fn;
+      return messageCount as unknown as R;
+    },
+    async click() {},
+    async waitForFunction() {},
+    async close() {},
+  };
+}
+
+/**
+ * Launcher whose `newContext` records the `X-Test-Id` value of every context
+ * opened during a run. The header is set at context construction (before any
+ * navigation), so a run need not fully succeed for the assertion to hold.
+ */
+function makeCapturingBrowser(capture: string[]): E2eFullBrowser {
+  return {
+    newContext: async (contextOpts?: {
+      extraHTTPHeaders?: Record<string, string>;
+    }): Promise<E2eFullBrowserContext> => {
+      const testId = contextOpts?.extraHTTPHeaders?.["X-Test-Id"];
+      if (typeof testId === "string") capture.push(testId);
+      return {
+        newPage: async () => makePage(),
+        close: async () => {},
+      };
+    },
+    close: async () => {},
+  };
+}
+
+function makeCtx(): ProbeContext {
+  return {
+    now: () => new Date("2025-01-01T00:00:00Z"),
+    logger,
+    env: {},
+  };
+}
+
+function makeScript(featureTypes: string[]): D5Script {
+  return {
+    featureTypes: featureTypes as D5Script["featureTypes"],
+    fixtureFile: "test-fixture.json",
+    buildTurns: () => [{ input: "hello" }],
+    preNavigateRoute: undefined,
+  };
+}
+
+describe("d6 per-run-unique X-Test-Id", () => {
+  describe("buildE2eTestId (pure helper)", () => {
+    it("is prefixed `d6-<slug>-` and folds in the runId", () => {
+      expect(buildE2eTestId("langgraph-python", "abc123")).toBe(
+        "d6-langgraph-python-abc123",
+      );
+      expect(buildE2eTestId("langgraph-python", "abc123")).toMatch(
+        /^d6-langgraph-python-/,
+      );
+    });
+
+    it("is stable for one runId and distinct across runIds", () => {
+      const a = buildE2eTestId("slug", "run1");
+      const b = buildE2eTestId("slug", "run1");
+      const c = buildE2eTestId("slug", "run2");
+      expect(a).toBe(b);
+      expect(a).not.toBe(c);
+    });
+  });
+
+  describe("driver wiring (injected idFactory)", () => {
+    beforeEach(() => {
+      __clearD5RegistryForTesting();
+    });
+
+    it("emits one stable X-Test-Id across all feature-cells of a run, unique across runs", async () => {
+      registerD5Script(makeScript(["agentic-chat"]));
+      registerD5Script(makeScript(["tool-rendering"]));
+
+      const idFactory = makeCounterIdFactory();
+
+      const run1Ids: string[] = [];
+      const driver1 = createE2eFullDriver({
+        launcher: async () => makeCapturingBrowser(run1Ids),
+        scriptLoader: async () => {},
+        idFactory,
+      });
+      await driver1.run(makeCtx(), {
+        key: "e2e_d6:byoc",
+        backendUrl: "https://byoc.example.com",
+        features: ["agentic-chat", "tool-rendering"],
+      });
+
+      const run2Ids: string[] = [];
+      const driver2 = createE2eFullDriver({
+        launcher: async () => makeCapturingBrowser(run2Ids),
+        scriptLoader: async () => {},
+        idFactory,
+      });
+      await driver2.run(makeCtx(), {
+        key: "e2e_d6:byoc",
+        backendUrl: "https://byoc.example.com",
+        features: ["agentic-chat", "tool-rendering"],
+      });
+
+      // Every cell of a single run shares ONE testId (the run's runId).
+      expect(run1Ids.length).toBeGreaterThanOrEqual(2);
+      expect(new Set(run1Ids).size).toBe(1);
+      expect(run2Ids.length).toBeGreaterThanOrEqual(2);
+      expect(new Set(run2Ids).size).toBe(1);
+
+      const id1 = run1Ids[0];
+      const id2 = run2Ids[0];
+
+      // (a) prefixed `d6-byoc-`
+      expect(id1).toMatch(/^d6-byoc-/);
+      expect(id2).toMatch(/^d6-byoc-/);
+      // (b) DISTINCT across runs (the flap fix)
+      expect(id1).not.toBe(id2);
+      // matches the injected deterministic counter
+      expect(id1).toBe("d6-byoc-run1");
+      expect(id2).toBe("d6-byoc-run2");
+    });
+
+    // Production runs ONE long-lived driver instance (the singleton
+    // `e2eFullDriver`) whose `run()` is invoked repeatedly. The two-driver
+    // test above would still pass if the runId mint regressed to
+    // `createE2eFullDriver()` construction time (each fresh instance would
+    // mint its own id), so this test pins the production shape: the SAME
+    // instance must mint a FRESH runId on every `run()` call.
+    it("mints a fresh X-Test-Id per run() on a single long-lived driver instance", async () => {
+      registerD5Script(makeScript(["agentic-chat"]));
+      registerD5Script(makeScript(["tool-rendering"]));
+
+      const allIds: string[] = [];
+      const driver = createE2eFullDriver({
+        launcher: async () => makeCapturingBrowser(allIds),
+        scriptLoader: async () => {},
+        idFactory: makeCounterIdFactory(),
+      });
+
+      const input = {
+        key: "e2e_d6:byoc",
+        backendUrl: "https://byoc.example.com",
+        features: ["agentic-chat", "tool-rendering"],
+      };
+
+      await driver.run(makeCtx(), input);
+      const run1Count = allIds.length;
+      await driver.run(makeCtx(), input);
+
+      const run1Ids = allIds.slice(0, run1Count);
+      const run2Ids = allIds.slice(run1Count);
+
+      // Internally consistent within each run: every cell shares ONE testId.
+      expect(run1Ids.length).toBeGreaterThanOrEqual(2);
+      expect(new Set(run1Ids).size).toBe(1);
+      expect(run2Ids.length).toBeGreaterThanOrEqual(2);
+      expect(new Set(run2Ids).size).toBe(1);
+
+      // DISTINCT across the two run() calls of the SAME instance (the flap
+      // fix): a construction-time mint would yield "d6-byoc-run1" for BOTH.
+      expect(run1Ids[0]).toBe("d6-byoc-run1");
+      expect(run2Ids[0]).toBe("d6-byoc-run2");
+      expect(run1Ids[0]).not.toBe(run2Ids[0]);
+    });
+  });
+});

--- a/showcase/harness/src/types/index.ts
+++ b/showcase/harness/src/types/index.ts
@@ -152,6 +152,18 @@ export interface ProbeContext {
    */
   abortSignal?: AbortSignal;
   /**
+   * Optional drain reason set by the invoker when `abortSignal` fires as part
+   * of a GRACEFUL worker shutdown (SIGTERM/redeploy), as opposed to a per-run
+   * timeout or an error abort. When `"shutdown"`, drivers SHOULD suppress the
+   * red per-cell side-emits they would otherwise write for not-yet-completed
+   * work — a graceful drain must not paint a mass-red block on the dashboard
+   * (the worker abandons the partial job so the lease lapses into the sweeper's
+   * neutral-gray re-queue instead). Drivers that don't understand this field
+   * ignore it — it's purely advisory. Kept optional so existing ProbeContext
+   * construction sites (tests, legacy drivers) continue to compile.
+   */
+  drainReason?: "shutdown";
+  /**
    * Optional feature-type filter threaded from the trigger layer. When
    * set, drivers that support per-feature-type filtering (e.g. e2e-deep)
    * SHOULD restrict their run to only the listed feature types. Drivers


### PR DESCRIPTION
## Summary

Root-caused and fixed the staging dashboard's red↔green flapping. Empirical investigation separated it into three mechanisms:

1. **PRIMARY (recurring flap): aimock fixture-sequence desync.** Harness drivers sent a stable `d6-<slug>` `X-Test-Id` shared across runs. aimock's stateful strict-mode matching (sequenced fixtures match only when per-test-id matchCount === sequenceIndex) drifts via replay exhaustion and 500-test-id FIFO eviction, so whole integrations 503'd together (~2,200/hr) and recovered — the flap.
2. **SECONDARY (one-off reds): worker restart mid-job.** In-flight `driver.run` was un-cancellable; redeploys SIGKILL'd workers mid-run, leaving partial results that fleet-health painted red (`worker-crashed-mid-job`).
3. **COSMETIC (red floor): dead roster rows.** 22 dead-container registry rows were never GC'd; the restart hook is a no-op stub, so `restartsAttempted` over-counted on rows nothing would ever restart.

## Fixes

- **Per-run-unique X-Test-Id** — fold the existing per-run `mintRunId()` into the test id via exported `buildE2eTestId(slug, runId)` (injectable `idFactory` for tests) in the d6/d5 and d4 drivers, so every run gets a fresh aimock sequence cursor.
- **Graceful worker drain** — on SIGTERM the worker aborts in-flight runs, suppresses red side-emits (`drainReason === "shutdown"` live getter + abort conjunction), **abandons** partial results (skips `queue.report`; the 300s lease sweeper synthesizes neutral `worker-reclaimed-pending`), and deregisters via a latched, `lastWrite`-chained roster delete so late heartbeats cannot resurrect the row. Stop bounded by `WORKER_DRAIN_GRACE_MS` (25s default); order `worker.stop → registration.stop → deregister → pool.shutdown`.
- **Fleet-health GC** — roster rows dead longer than `DEFAULT_WORKER_GC_AFTER_MS` (24h) are deleted (`gcDeleted` counter), malformed rows are GC'd by age before the worker_id guard, `restartsAttempted` is demoted when the restart hook is a no-op, and `createFleetHealthMonitor` fails loud when `gcAfterMs <= staleAfterMs`.

Companion PR: CopilotKit/aimock#259 (strict-mode no-match diagnostics, 1.30.0) makes the PRIMARY mechanism observable instead of a bare 503.

## Review

- 3 unbiased CR rounds (8 reviewer agents each, verbatim non-leading prompt) converged to **zero actionable findings**; round-1 criticals (drain-suppression of genuine timeouts, deregister/heartbeat resurrection race, vacuous tests, GC-skipped malformed rows) were fixed with red-green proofs and confirmed in byte-identical follow-up rounds.
- Bucket-(c) promotion audit: 0 promotions to actionable; 3 trivial consistency items deferred to the follow-up backlog with ~25 pre-existing harness findings.

## Test plan

- [x] Full harness suite: 122 files / 2146 tests green
- [x] `tsc --noEmit` on both tsconfigs; build green
- [x] oxfmt clean on all 14 changed files
- [x] Red-green discipline on every behavioral fix (failures observed before fixes)
- [x] CI green on this PR
- [ ] Staging promotion (explicitly out of scope here; separate step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
