### PR TITLE
fix(harness): deregister before best-effort teardown on drain

### DIFF
--- a/showcase/harness/src/fleet/orchestrator.test.ts
+++ b/showcase/harness/src/fleet/orchestrator.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import net from "node:net";
 import type { Browser } from "playwright";
 import { runWorker } from "./orchestrator.js";
 import type { FleetRoleConfig } from "./role-config.js";
@@ -11,6 +12,7 @@ import type {
   ServiceJobResult,
 } from "./contracts.js";
 import type { Logger } from "../types/index.js";
+import { BrowserPool } from "../probes/helpers/browser-pool.js";
 import type {
   LaunchBrowser,
   CgroupPidsReader,
@@ -167,5 +169,118 @@ describe("runWorker default (self-contained) boot", () => {
     expect(result.commError).toBeUndefined();
     expect(result.aggregateState).toBe("green");
     expect(result.aggregateKey).toBe("e2e_d6:langgraph-python");
+  });
+});
+
+/** Bind-then-release an ephemeral port for the worker /health server. */
+async function pickPort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address() as net.AddressInfo;
+      srv.close(() => resolve(addr.port));
+    });
+  });
+}
+
+describe("runWorker loop-crash surfacing", () => {
+  it("logs fleet.worker.loop-crashed (with stack), flips /health to 503, and a throwing stop-path logger still tears everything down", async () => {
+    // B4: `loop.done` rejecting is a CRASHED worker loop. Pre-fix the handle
+    // wiring was `void loop.done.finally(...)` — the rejection propagated
+    // through the derived chain as an UNHANDLED rejection and nothing logged
+    // why the loop died; /health flipped silently. The crash must be logged
+    // loud (message + stack) and /health must report loop:"stopped" (503).
+    //
+    // Rejection vector: with every IIFE log guarded (`safeLog`), a throwing
+    // logger no longer crashes the loop — the residual seam is a
+    // structurally POISON queue result whose `.claimed` getter throws
+    // outside the loop's claimNext try/catch.
+    //
+    // STOP-PATH GUARD (extends the teardown contract below): the logger ALSO
+    // throws on `fleet.worker.stopping`/`fleet.worker.stopped`. Pre-guard,
+    // `fleet.worker.stopping` sat unguarded BEFORE stop()'s try/finally, so
+    // the logger throw escaped stop() FIRST — loop.stop was never awaited,
+    // the /health server stayed bound, and the pool's chromium processes
+    // stranded. Post-guard, stop() surfaces the loop-crash error and both
+    // teardown arms still run.
+    const queueBase = makeQueue([]);
+    const queue: FleetQueueClient = {
+      ...queueBase,
+      async claimNext(): Promise<ClaimedJob> {
+        return {
+          get claimed(): boolean {
+            throw new Error("poison claim");
+          },
+        } as ClaimedJob;
+      },
+    };
+    const errors: Array<[string, Record<string, unknown> | undefined]> = [];
+    const logger: Logger = {
+      ...silentLogger,
+      info: (msg) => {
+        if (msg === "fleet.worker.stopping" || msg === "fleet.worker.stopped") {
+          throw new Error("logger exploded on stop path");
+        }
+      },
+      error: (msg, meta) => {
+        errors.push([msg, meta]);
+      },
+    };
+    const port = await pickPort();
+    // Spy on the pool the DEFAULT (self-contained) boot path constructs so the
+    // stop() teardown contract below is observable: a rejecting loop.stop()
+    // must still shut the pool down (PID-ceiling compounding otherwise).
+    const shutdownSpy = vi.spyOn(BrowserPool.prototype, "shutdown");
+    try {
+      const worker = await runWorker(config, {
+        queue,
+        workerId: "worker-crash",
+        logger,
+        env: {},
+        port,
+        // Default-boot seams (no injected budgetSource/driver) so runWorker
+        // constructs its OWN pool — the one stop() must shut down. The crash
+        // fires on the poison claim, before the d6 driver ever runs.
+        launchBrowser: makeNoopLauncher(),
+        cgroupPidsReader: headroomPidsReader,
+        pollIntervalMs: 1,
+        leaseSeconds: 2000,
+        heartbeatMs: 1_000_000,
+      });
+
+      // The crash is LOGGED — message and stack both carried.
+      await vi.waitFor(() =>
+        expect(errors.map((e) => e[0])).toContain("fleet.worker.loop-crashed"),
+      );
+      const crash = errors.find((e) => e[0] === "fleet.worker.loop-crashed")!;
+      expect(crash[1]).toMatchObject({
+        workerId: "worker-crash",
+        err: "poison claim",
+      });
+      expect(String((crash[1] as { stack?: string }).stack)).toContain(
+        "poison claim",
+      );
+
+      // …and /health reflects the dead loop (503, loop:"stopped").
+      const res = await fetch(`http://127.0.0.1:${port}/health`);
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as { loop: string };
+      expect(body.loop).toBe("stopped");
+
+      // stop() re-awaits the rejected done: the rejection SURFACES to the
+      // caller — but the /health server is closed and the pool is shut down
+      // anyway. Pre-fix the rejection escaped BEFORE either teardown arm,
+      // leaking the bound port and stranding the pool's chromium processes.
+      // The LOOP-CRASH error surfaces — NOT "logger exploded on stop path":
+      // the guarded `fleet.worker.stopping` log cannot preempt the teardown.
+      await expect(worker.stop()).rejects.toThrow("poison claim");
+      expect(shutdownSpy).toHaveBeenCalledTimes(1);
+      // The port no longer accepts connections — the health server really
+      // closed (a still-bound server would answer this fetch).
+      await expect(fetch(`http://127.0.0.1:${port}/health`)).rejects.toThrow();
+    } finally {
+      shutdownSpy.mockRestore();
+    }
   });
 });

--- a/showcase/harness/src/fleet/orchestrator.ts
+++ b/showcase/harness/src/fleet/orchestrator.ts
@@ -43,6 +43,7 @@ import type { FleetQueueClient } from "./contracts.js";
 import { buildWorkerHealthServer } from "./worker/worker-health.js";
 import {
   startWorkerLoop,
+  safeLog,
   type PayloadToDriverInput,
   type ServiceJobDriver,
   type DriverRegistry,
@@ -55,7 +56,22 @@ import {
 
 /** The worker boot handle — symmetric with the control-plane `boot()` shape. */
 export interface WorkerHandle {
-  /** Stops the loop, drains the in-flight job, and shuts down the pool. */
+  /**
+   * SYNCHRONOUSLY request the drain (forwards `WorkerLoopHandle.drain()`):
+   * fires the loop's abort/abandon signal WITHOUT awaiting teardown, so a
+   * caller can deregister the worker's roster row BEFORE the platform kill
+   * grace expires and only then spend the drain budget in `stop()`.
+   * Idempotent; `stop()` implies it.
+   */
+  drain: () => void;
+  /**
+   * Stops the loop, drains the in-flight job, and shuts down the pool. The
+   * pool shutdown applies only when THIS entrypoint constructed the pool
+   * (the self-contained boot path) — callers that inject their own
+   * `budgetSource` + run path own their pool's lifecycle and shut it down
+   * themselves. A rejecting loop stop still closes the /health server and
+   * shuts the pool down before the rejection re-surfaces to the caller.
+   */
   stop: () => Promise<void>;
   /** The port the worker's liveness endpoint binds (for fleet-health probes). */
   port: number;
@@ -271,7 +287,24 @@ export async function runWorker(
   } catch (err) {
     // Loop construction is synchronous and shouldn't throw, but if it does,
     // never strand the pool's chromium processes (PID-ceiling compounding).
-    if (pool) await pool.shutdown().catch(() => {});
+    // The shutdown is best-effort but LOGGED (consistent with the stop path's
+    // pool-shutdown logging below) — an empty catch would hide why chromium
+    // processes were left stranded behind the construction failure. The
+    // original construction error still rethrows.
+    if (pool) {
+      // Guarded: a throwing logger inside this .catch handler would reject
+      // the awaited chain and mask the construction error being rethrown.
+      await pool.shutdown().catch((shutdownErr) =>
+        safeLog(logger, "error", "fleet.worker.pool-shutdown-failed", {
+          workerId,
+          phase: "loop-construction-failed",
+          err:
+            shutdownErr instanceof Error
+              ? shutdownErr.message
+              : String(shutdownErr),
+        }),
+      );
+    }
     throw err;
   }
 
@@ -279,10 +312,28 @@ export async function runWorker(
   // the loop exits (clean stop OR an unexpected crash). Until then the loop is
   // alive. A loop that exits WITHOUT a stop() (crash) flips /health to 503 so
   // the healthcheck reflects a dead worker rather than reporting healthy.
+  // A REJECTED `done` is a crashed loop: log it loud (message + stack) before
+  // flipping /health — a bare `.finally()` chain would re-propagate the
+  // rejection as an UNHANDLED rejection with no record of WHY the loop died.
+  // DEFENSE-IN-DEPTH: with every log inside the loop's done-IIFE guarded
+  // (`safeLog`), a throwing logger can no longer reject `done` — the residual
+  // crash vectors are structural (e.g. a poison queue result throwing outside
+  // the loop's try/catch blocks), so this catch is kept but nearly
+  // unreachable. The crash log itself is guarded too: a throwing logger
+  // inside this handler would turn the HANDLED rejection back into an
+  // unhandled one on the derived chain.
   let loopAlive = true;
-  void loop.done.finally(() => {
-    loopAlive = false;
-  });
+  void loop.done
+    .catch((err) => {
+      safeLog(logger, "error", "fleet.worker.loop-crashed", {
+        workerId,
+        err: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+      });
+    })
+    .finally(() => {
+      loopAlive = false;
+    });
 
   // Bind the worker's /health server on the resolved port. The docker/Railway
   // healthcheck GETs this; without it the container is restart-looped. Bind
@@ -301,9 +352,33 @@ export async function runWorker(
       logger.info("fleet.worker.health-listening", { workerId, port });
     } catch (err) {
       // A bind failure (EADDRINUSE) must not strand the pool's chromium
-      // processes or the loop; tear both down before rethrowing.
-      await loop.stop().catch(() => {});
-      if (pool) await pool.shutdown().catch(() => {});
+      // processes or the loop; tear both down before rethrowing. Both
+      // teardown arms are best-effort but LOGGED (consistent with the stop
+      // path's pool-shutdown logging below) — empty catches would hide why a
+      // bind-failure teardown also failed. The original bind error still
+      // rethrows.
+      // Both .catch handlers log GUARDED: a throwing logger inside either
+      // would reject the awaited chain, skip the teardown arm behind it, and
+      // mask the bind error being rethrown.
+      await loop.stop().catch((stopErr) =>
+        safeLog(logger, "error", "fleet.worker.loop-stop-failed", {
+          workerId,
+          phase: "health-bind-failed",
+          err: stopErr instanceof Error ? stopErr.message : String(stopErr),
+        }),
+      );
+      if (pool) {
+        await pool.shutdown().catch((shutdownErr) =>
+          safeLog(logger, "error", "fleet.worker.pool-shutdown-failed", {
+            workerId,
+            phase: "health-bind-failed",
+            err:
+              shutdownErr instanceof Error
+                ? shutdownErr.message
+                : String(shutdownErr),
+          }),
+        );
+      }
       throw err;
     }
   }
@@ -311,27 +386,48 @@ export async function runWorker(
   return {
     port,
     bus,
+    drain(): void {
+      loop.drain();
+    },
     async stop(): Promise<void> {
-      logger.info("fleet.worker.stopping", { workerId });
-      await loop.stop();
-      if (server) {
-        await new Promise<void>((resolve) => {
-          const srv = server as unknown as {
-            close?: (cb?: () => void) => void;
-          };
-          if (typeof srv.close === "function") srv.close(() => resolve());
-          else resolve();
-        });
+      // GUARDED (sits BEFORE the try/finally): in the self-contained path a
+      // throwing logger here would skip loop.stop, the /health server close,
+      // AND the pool shutdown — the entire teardown — for a forensic line.
+      safeLog(logger, "info", "fleet.worker.stopping", { workerId });
+      // A REJECTING loop.stop() (the loop's done-promise crashed) must not
+      // leak the bound /health server (the port would stay taken and the
+      // container healthcheck would keep answering for a dead worker) or
+      // strand the pool's chromium processes (PID-ceiling compounding) — both
+      // teardown arms ALWAYS run, then the stop rejection re-surfaces to the
+      // caller. Neither arm throws in practice (the server-close promise only
+      // resolves, and the pool shutdown carries its own .catch) — the one
+      // residual is a SYNCHRONOUSLY-throwing `srv.close`, which would reject
+      // inside this finally and mask the stop error; vanishingly unlikely for
+      // a node server handle, and accepted.
+      try {
+        await loop.stop();
+      } finally {
+        if (server) {
+          await new Promise<void>((resolve) => {
+            const srv = server as unknown as {
+              close?: (cb?: () => void) => void;
+            };
+            if (typeof srv.close === "function") srv.close(() => resolve());
+            else resolve();
+          });
+        }
+        if (pool) {
+          // Guarded: a throwing logger inside this .catch would reject the
+          // finally chain and mask the stop error being re-surfaced.
+          await pool.shutdown().catch((err) =>
+            safeLog(logger, "error", "fleet.worker.pool-shutdown-failed", {
+              workerId,
+              err: err instanceof Error ? err.message : String(err),
+            }),
+          );
+        }
       }
-      if (pool) {
-        await pool.shutdown().catch((err) =>
-          logger.error("fleet.worker.pool-shutdown-failed", {
-            workerId,
-            err: err instanceof Error ? err.message : String(err),
-          }),
-        );
-      }
-      logger.info("fleet.worker.stopped", { workerId });
+      safeLog(logger, "info", "fleet.worker.stopped", { workerId });
     },
   };
 }

--- a/showcase/harness/src/fleet/worker/worker-loop.test.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   startWorkerLoop,
   runClaimedJob,
   computeRollup,
   buildServiceJobResult,
   buildCommErrorResult,
+  DEFAULT_WORKER_DRAIN_GRACE_MS,
+  // The deregister cap that precedes the drain grace in `drainFleetWorker`'s
+  // SERIAL budget — used by the composed-budget pin below.
+  DRAIN_DEREGISTER_TIMEOUT_MS,
 } from "./worker-loop.js";
 import type {
   ServiceJobDriver,
@@ -607,6 +611,163 @@ describe("runClaimedJob", () => {
     expect(queue.renewCalls).toBeGreaterThanOrEqual(1);
     expect(renewedDuringRun).toBeGreaterThanOrEqual(1);
   });
+
+  it("a rejecting injected sleep breaks the heartbeat but never rejects runClaimedJob (never-throws contract)", async () => {
+    // The heartbeat IIFE awaits `deps.sleep` — if that await sits OUTSIDE the
+    // heartbeat's try/catch, a rejecting sleep rejects the heartbeat promise,
+    // which escapes runClaimedJob's `await heartbeat` finally and rejects the
+    // LOOP's done-promise (silent worker death). A sleep rejection must break
+    // the heartbeat like a renew failure instead; the run's own result is
+    // still computed and returned.
+    const queue = makeQueue([]);
+    const driver = makeDriver({
+      slug: "langgraph-python",
+      cells: [{ featureId: "shared-state", state: "green" }],
+      aggregateState: "green",
+    });
+    const result = await runClaimedJob(
+      {
+        workerId: "worker-test",
+        queue,
+        driver,
+        payloadToInput: passInput,
+        logger: silentLogger,
+        env: {},
+        now: () => new Date("2026-06-04T00:04:00.000Z"),
+        sleep: async () => {
+          throw new Error("timer subsystem down");
+        },
+      },
+      makeLease(),
+      // A tiny heartbeatMs so the (rejecting) sleep is exercised immediately.
+      { leaseSeconds: 300, heartbeatMs: 1 },
+    );
+    expect(result.aggregateState).toBe("green");
+    expect(result.commError).toBeUndefined();
+  });
+
+  it("stops renewing the lease as soon as the drain signal fires (abandoned lease must lapse for the sweeper)", async () => {
+    // A2: once drain() fires the in-flight job is ABANDONED — the loop will
+    // never report it, and the whole abandon design relies on the lease
+    // LAPSING so the sweeper re-queues the job neutral-gray. A heartbeat that
+    // keeps renewing while a wedged run ignores its abort would keep the
+    // abandoned lease alive indefinitely. The heartbeat must observe the
+    // drain signal and stop renewing the moment it fires.
+    const queue = makeQueue([]);
+    let markStarted!: () => void;
+    const started = new Promise<void>((res) => {
+      markStarted = res;
+    });
+    let releaseFn!: () => void;
+    const released = new Promise<void>((res) => {
+      releaseFn = res;
+    });
+    // Wedged driver: IGNORES the abort signal, never settles until released.
+    const driver: ServiceJobDriver = {
+      async run(ctx): Promise<ProbeResult> {
+        markStarted();
+        await released;
+        return {
+          key: "e2e_d6:langgraph-python",
+          state: "green",
+          signal: { shape: "package", slug: "langgraph-python" },
+          observedAt: ctx.now().toISOString(),
+        };
+      },
+    };
+    const drain = new AbortController();
+    const resultPromise = runClaimedJob(
+      {
+        workerId: "worker-test",
+        queue,
+        driver,
+        payloadToInput: passInput,
+        logger: silentLogger,
+        env: {},
+        now: () => new Date("2026-06-04T00:04:00.000Z"),
+        sleep: yieldingSleep(),
+      },
+      makeLease(),
+      // Short heartbeat so renews fire on every macrotask tick.
+      { leaseSeconds: 300, heartbeatMs: 1 },
+      drain.signal,
+    );
+
+    await started;
+    // The heartbeat is live: at least one renew lands while the run is wedged.
+    await vi.waitFor(() => expect(queue.renewCalls).toBeGreaterThanOrEqual(1));
+
+    // DRAIN: fire the signal mid-run. Let any already-in-flight heartbeat
+    // iteration settle, then snapshot the renew count.
+    drain.abort();
+    await new Promise((r) => setTimeout(r, 0));
+    const renewsAtDrain = queue.renewCalls;
+
+    // Advance time (several macrotask ticks — each would have renewed before
+    // the fix): ZERO further renewLease calls may land after the drain.
+    for (let i = 0; i < 10; i++) {
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    expect(queue.renewCalls).toBe(renewsAtDrain);
+
+    // Un-wedge the driver so the run settles and the job-runner returns.
+    releaseFn();
+    const result = await resultPromise;
+    expect(result.aggregateState).toBe("green");
+  });
+
+  it("entered with an ALREADY-aborted drain signal: never renews the lease and hands the run aborted drain semantics", async () => {
+    // The drain can fire between the loop winning a claim and runClaimedJob
+    // entry. `addEventListener("abort", ...)` on an ALREADY-aborted signal
+    // never fires, so the heartbeat must be aborted AT ENTRY: zero renewLease
+    // round-trips may land (the abandoned lease must lapse for the sweeper),
+    // and the driver sees `abortSignal.aborted` + drainReason "shutdown" (the
+    // loop's report-skip then drops whatever the run returns).
+    const queue = makeQueue([]);
+    const drain = new AbortController();
+    drain.abort();
+    let seen: { aborted: boolean; drainReason: string | undefined } | undefined;
+    const driver: ServiceJobDriver = {
+      async run(ctx): Promise<ProbeResult> {
+        seen = {
+          aborted: ctx.abortSignal?.aborted ?? false,
+          drainReason: ctx.drainReason,
+        };
+        // Spin several macrotasks: absent the at-entry heartbeat abort, the
+        // tiny heartbeatMs below would land renews during this window.
+        for (let i = 0; i < 5; i++) {
+          await new Promise((r) => setTimeout(r, 0));
+        }
+        return {
+          key: "e2e_d6:langgraph-python",
+          state: "green",
+          signal: { shape: "package", slug: "langgraph-python" },
+          observedAt: ctx.now().toISOString(),
+        };
+      },
+    };
+    const result = await runClaimedJob(
+      {
+        workerId: "worker-test",
+        queue,
+        driver,
+        payloadToInput: passInput,
+        logger: silentLogger,
+        env: {},
+        now: () => new Date("2026-06-04T00:04:00.000Z"),
+        sleep: yieldingSleep(),
+      },
+      makeLease(),
+      { leaseSeconds: 300, heartbeatMs: 1 },
+      drain.signal,
+    );
+
+    expect(queue.renewCalls).toBe(0);
+    expect(seen).toEqual({ aborted: true, drainReason: "shutdown" });
+    // runClaimedJob still returns the settled result — the LOOP's
+    // signal-keyed report-skip is what abandons it, not the job runner.
+    expect(result.aggregateState).toBe("green");
+  });
 });
 
 // ── startWorkerLoop: full poll loop ────────────────────────────────────────
@@ -946,6 +1107,222 @@ describe("startWorkerLoop", () => {
     expect(reports[0]!.aggregateState).toBe("green");
   });
 
+  it("survives a rejecting idle-poll sleep: logs fleet.worker.sleep-failed and continues claiming (done does not reject)", async () => {
+    // The heartbeat's sleep already has rejecting-sleep hardening — the
+    // loop's OWN idle/poll points must too: a bare `await sleep(...)` there
+    // rejects the loop's done-promise (silent worker death). A sleep
+    // rejection is logged and treated as the interval having elapsed; the
+    // drain/stop signal still governs exit.
+    const queue = makeQueue([
+      // Nothing claimable first → forces an idle-poll sleep (the one that
+      // rejects), then a real claim proves the loop kept pulling.
+      { claimed: false },
+      { claimed: true, lease: makeLease() },
+    ]);
+    const warn = vi.fn();
+    const base = yieldingSleep();
+    let rejectedOnce = false;
+    const sleep = async (ms: number, signal?: AbortSignal): Promise<void> => {
+      if (!rejectedOnce) {
+        rejectedOnce = true;
+        throw new Error("timer subsystem down");
+      }
+      return base(ms, signal);
+    };
+    const driver = makeDriver({
+      slug: "langgraph-python",
+      cells: [{ featureId: "shared-state", state: "green" }],
+      aggregateState: "green",
+    });
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      driver,
+      payloadToInput: passInput,
+      logger: { ...silentLogger, warn },
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep,
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+
+    // The loop survived the rejecting sleep and claimed + reported the job.
+    await vi.waitFor(() => expect(queue.reports).toHaveLength(1));
+    expect(warn).toHaveBeenCalledWith(
+      "fleet.worker.sleep-failed",
+      expect.objectContaining({
+        workerId: "worker-test",
+        err: "timer subsystem down",
+      }),
+    );
+    await handle.stop();
+    await expect(handle.done).resolves.toBeUndefined();
+  });
+
+  it("PERSISTENT sleep rejections degrade to interval pacing, not a microtask busy loop (claims bounded by the poll interval)", async () => {
+    // Treating a rejected sleep as "interval elapsed" is right for a one-off —
+    // but a PERSISTENTLY rejecting injected/platform sleep would degrade the
+    // idle loop into a microtask-speed busy loop hammering pool.budget() /
+    // claimNext. After logging, the loop must fall back to a raw timer wait
+    // (which cannot reject), keeping claim attempts paced at ~1 per interval.
+    vi.useFakeTimers();
+    try {
+      let claims = 0;
+      let handle: WorkerLoopHandle | undefined;
+      const queueBase = makeQueue([]);
+      const queue: FleetQueueClient = {
+        ...queueBase,
+        async claimNext(): Promise<ClaimedJob> {
+          claims++;
+          // SPIN GUARD: the busy-loop regression never touches the timer
+          // queue, so the fake-timer advances below would starve forever —
+          // bound it by draining the loop at 50 claims so the regression
+          // FAILS on the pacing assertion instead of hanging the test.
+          if (claims >= 50) handle?.drain();
+          return { claimed: false };
+        },
+      };
+      const warn = vi.fn();
+      handle = startWorkerLoop({
+        workerId: "worker-test",
+        queue,
+        pool: budgetWith(5),
+        driver: makeDriver({ slug: "x", cells: [], aggregateState: "green" }),
+        payloadToInput: passInput,
+        logger: { ...silentLogger, warn },
+        env: {},
+        now: () => new Date("2026-06-04T00:04:00.000Z"),
+        sleep: async () => {
+          throw new Error("timer subsystem down");
+        },
+        pollIntervalMs: 1_000,
+        leaseSeconds: 2000,
+        heartbeatMs: 1_000_000,
+      });
+
+      // Boot microtasks: one claim attempt lands, then the loop parks in the
+      // raw fallback wait until the interval timer fires.
+      await vi.advanceTimersByTimeAsync(0);
+      const bootClaims = claims;
+      expect(bootClaims).toBeGreaterThanOrEqual(1);
+      expect(bootClaims).toBeLessThanOrEqual(2);
+
+      // 10 poll intervals → ~10 more claims, NOT hundreds (the busy-loop
+      // regression blows through the 50-claim spin guard immediately).
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(claims).toBeGreaterThanOrEqual(bootClaims + 9);
+      expect(claims).toBeLessThanOrEqual(bootClaims + 11);
+      expect(warn).toHaveBeenCalledWith(
+        "fleet.worker.sleep-failed",
+        expect.objectContaining({ err: "timer subsystem down" }),
+      );
+
+      // The raw fallback wait stays abort-responsive: drain exits the loop
+      // without waiting out the pending interval.
+      handle.drain();
+      await vi.advanceTimersByTimeAsync(0);
+      await handle.done;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears the grace timer even when the loop's done-promise REJECTS (the rejection still propagates from stop())", async () => {
+    // stop()'s grace race awaits `done` — a crashed loop makes that a
+    // REJECTED promise, so the race throws. The `clearTimeout(graceTimer)`
+    // must sit in a finally: on the reject path a trailing clearTimeout is
+    // skipped and the grace timer leaks. The rejection itself still
+    // propagates to the caller (the fleet wrapper closes the health server /
+    // pool around it).
+    //
+    // CRASH VECTOR: with every IIFE log guarded (`safeLog`), a throwing
+    // logger no longer rejects done — the residual seam is a structurally
+    // POISON queue result whose `.claimed` getter throws outside the
+    // claimNext try/catch.
+    const queueBase = makeQueue([]);
+    const queue: FleetQueueClient = {
+      ...queueBase,
+      async claimNext(): Promise<ClaimedJob> {
+        return {
+          get claimed(): boolean {
+            throw new Error("poison claim");
+          },
+        } as ClaimedJob;
+      },
+    };
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      driver: makeDriver({ slug: "x", cells: [], aggregateState: "green" }),
+      payloadToInput: passInput,
+      logger: silentLogger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+    // The first claim crashes the loop before any sleep is ever taken.
+    await expect(handle.done).rejects.toThrow("poison claim");
+
+    // Fake timers AFTER the loop has crashed: the only timer stop() can set
+    // is its own grace timer, so a zero pending-timer count proves it was
+    // cleared on the reject path (pre-fix: 1 leaked timer).
+    vi.useFakeTimers();
+    try {
+      await expect(handle.stop()).rejects.toThrow("poison claim");
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a throwing logger on an IIFE log (fleet.worker.claimed) neither rejects done nor skips the report (guarded logs)", async () => {
+    // CLASS-LEVEL GUARD (`safeLog`): on this path the failing component IS
+    // the logger. Pre-guard, this exact vector crashed the loop — done
+    // rejected and the claimed job was never reported, a silent worker death
+    // caused by FORENSICS. The log lines are best-effort; the loop is
+    // load-bearing: the job must still run and report, and stop() must
+    // resolve cleanly (done never rejected).
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const logger: Logger = {
+      ...silentLogger,
+      info: (msg) => {
+        if (msg === "fleet.worker.claimed") {
+          throw new Error("logger exploded mid-claim");
+        }
+      },
+    };
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      driver: makeDriver({
+        slug: "langgraph-python",
+        cells: [{ featureId: "shared-state", state: "green" }],
+        aggregateState: "green",
+      }),
+      payloadToInput: passInput,
+      logger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+    // The job still ran and was REPORTED despite the throwing claim log…
+    await vi.waitFor(() => expect(queue.reports).toHaveLength(1));
+    expect(queue.reports[0]!.aggregateState).toBe("green");
+    // …and done never rejected: stop() resolves cleanly.
+    await handle.stop();
+  });
+
   // ── Graceful drain (FIX 3): stop() aborts the in-flight driver run ─────────
 
   /**
@@ -961,12 +1338,15 @@ describe("startWorkerLoop", () => {
     driver: ServiceJobDriver;
     seenCtx: () => ServiceDriverContext | undefined;
     started: Promise<void>;
+    /** Every cell the driver actually WROTE through `ctx.writer.write`. */
+    written: ProbeResult[];
   } {
     let captured: ServiceDriverContext | undefined;
     let markStarted!: () => void;
     const started = new Promise<void>((res) => {
       markStarted = res;
     });
+    const written: ProbeResult[] = [];
     const driver: ServiceJobDriver = {
       async run(ctx, _input): Promise<ProbeResult> {
         captured = ctx;
@@ -984,12 +1364,14 @@ describe("startWorkerLoop", () => {
         const observedAt = ctx.now().toISOString();
         // Real-d6-like per-feature abort emit, suppressed on drain.
         if (ctx.drainReason !== "shutdown") {
-          await ctx.writer.write({
+          const redAbortCell: ProbeResult = {
             key: "d6:langgraph-python/shared-state",
             state: "red",
             signal: { featureType: "shared-state", errorClass: "abort" },
             observedAt,
-          });
+          };
+          written.push(redAbortCell);
+          await ctx.writer.write(redAbortCell);
         }
         return {
           key: "e2e_d6:langgraph-python",
@@ -999,7 +1381,7 @@ describe("startWorkerLoop", () => {
         };
       },
     };
-    return { driver, seenCtx: () => captured, started };
+    return { driver, seenCtx: () => captured, started, written };
   }
 
   it("stop() during an in-flight job aborts the driver (ctx.abortSignal defined+fired) and resolves bounded", async () => {
@@ -1048,7 +1430,7 @@ describe("startWorkerLoop", () => {
 
   it("drain does NOT emit red cells for not-yet-run pills (drainReason suppresses)", async () => {
     const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
-    const { driver, started } = makeBlockingDrainDriver();
+    const { driver, started, written } = makeBlockingDrainDriver();
     const handle = startWorkerLoop({
       workerId: "worker-test",
       queue,
@@ -1066,16 +1448,19 @@ describe("startWorkerLoop", () => {
 
     await started;
     await handle.stop();
-    // No red abort cell was reported (the worker also skips report on drain, so
-    // we assert via the queue: nothing reported, hence no red cell painted).
-    const reportedRedAbort = queue.reports.some((r) =>
-      (r.cells ?? []).some(
-        (c) =>
-          c.state === "red" &&
-          (c.signal as { errorClass?: string })?.errorClass === "abort",
-      ),
+    // The suppression's REAL surface is the WRITE side: on a drain the driver
+    // must never WRITE a red `errorClass: "abort"` cell at all. (Asserting on
+    // `queue.reports` alone is vacuous here — drain skips the report entirely,
+    // so reports stay empty whether or not the red cell was written.)
+    const writtenRedAbort = written.filter(
+      (c) =>
+        c.state === "red" &&
+        (c.signal as { errorClass?: string })?.errorClass === "abort",
     );
-    expect(reportedRedAbort).toBe(false);
+    expect(writtenRedAbort).toEqual([]);
+    // The report-skip leg stays pinned alongside (see the next test for the
+    // dedicated assertion): nothing was reported either.
+    expect(queue.reports).toEqual([]);
   });
 
   it("drain does NOT report the in-flight job (lets the lease expire → sweeper re-queues neutral-gray)", async () => {
@@ -1163,6 +1548,477 @@ describe("startWorkerLoop", () => {
     await handle.stop();
     // After stop(): the drain signal fired — the abort IS a graceful drain.
     expect(reasonAfterAbort).toBe("shutdown");
+  });
+});
+
+// ── drain(): deregister-FIRST drain request (platform-kill hardening) ───────
+//
+// Railway SIGKILLs ~10s after SIGTERM (live-verified) — a drain whose roster
+// deregister waits behind slow browser-context teardown gets HARD-KILLED
+// before the delete ever runs, stranding a stale roster row that fleet-health
+// reclaims red at its 180s stale mark. The handle therefore exposes a SYNCHRONOUS
+// `drain()` that fires the abort + records the abandon decision WITHOUT
+// awaiting the run, so the caller can deregister immediately and spend the
+// grace budget on best-effort teardown afterwards (`stop()`).
+describe("WorkerLoopHandle.drain() — deregister-first drain request", () => {
+  /**
+   * A driver fake whose run HANGS until `release()` is called and IGNORES the
+   * drain abort entirely — the stand-in for a wedged browser-context teardown
+   * that outlives the drain signal. Resolves GREEN on release so the
+   * never-report assertion covers the worst case (a run that "completes"
+   * successfully after the abandon decision).
+   */
+  function makeWedgedDriver(): {
+    driver: ServiceJobDriver;
+    seenCtx: () => ServiceDriverContext | undefined;
+    started: Promise<void>;
+    release: () => void;
+    runSettled: () => boolean;
+  } {
+    let captured: ServiceDriverContext | undefined;
+    let markStarted!: () => void;
+    const started = new Promise<void>((res) => {
+      markStarted = res;
+    });
+    let releaseFn!: () => void;
+    const released = new Promise<void>((res) => {
+      releaseFn = res;
+    });
+    let settled = false;
+    const driver: ServiceJobDriver = {
+      async run(ctx, _input): Promise<ProbeResult> {
+        captured = ctx;
+        markStarted();
+        // Deliberately IGNORE ctx.abortSignal — a wedged teardown.
+        await released;
+        settled = true;
+        return {
+          key: "e2e_d6:langgraph-python",
+          state: "green",
+          signal: { shape: "package", slug: "langgraph-python" },
+          observedAt: ctx.now().toISOString(),
+        };
+      },
+    };
+    return {
+      driver,
+      seenCtx: () => captured,
+      started,
+      release: () => releaseFn(),
+      runSettled: () => settled,
+    };
+  }
+
+  function startWedgedLoop(args: {
+    queue: RecordingQueue;
+    driver: ServiceJobDriver;
+    logger?: Logger;
+  }): WorkerLoopHandle {
+    return startWorkerLoop({
+      workerId: "worker-test",
+      queue: args.queue,
+      pool: budgetWith(5),
+      driver: args.driver,
+      payloadToInput: passInput,
+      logger: args.logger ?? silentLogger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+  }
+
+  it("drain() synchronously fires the in-flight run's abort signal WITHOUT awaiting teardown", async () => {
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const { driver, seenCtx, started, release } = makeWedgedDriver();
+    const handle = startWedgedLoop({ queue, driver });
+
+    await started;
+    expect(seenCtx()!.abortSignal!.aborted).toBe(false);
+
+    // SYNCHRONOUS: drain() returns void having already fired the signal — it
+    // must not await the (wedged) run.
+    handle.drain();
+    expect(seenCtx()!.abortSignal!.aborted).toBe(true);
+    expect(seenCtx()!.drainReason).toBe("shutdown");
+
+    // The loop has NOT exited (the run is wedged) — done is still pending, so
+    // a caller can deregister NOW instead of behind teardown. Observe BOTH
+    // arms: a rejected done would otherwise surface as an orphan unhandled
+    // rejection in the test output instead of failing the assertion below.
+    let doneSettled = false;
+    void handle.done.then(
+      () => {
+        doneSettled = true;
+      },
+      () => {
+        doneSettled = true;
+      },
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(doneSettled).toBe(false);
+
+    release();
+    await handle.stop();
+  });
+
+  it("drain() records the abandon decision (in-flight jobId) BEFORE the run settles", async () => {
+    const info = vi.fn();
+    const logger: Logger = { ...silentLogger, info };
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const { driver, started, release, runSettled } = makeWedgedDriver();
+    const handle = startWedgedLoop({ queue, driver, logger });
+
+    await started;
+    handle.drain();
+    // The abandon decision is on the record while the run is STILL in flight —
+    // a caller's deregister therefore always follows a recorded decision.
+    expect(runSettled()).toBe(false);
+    expect(info).toHaveBeenCalledWith("fleet.worker.drain-requested", {
+      workerId: "worker-test",
+      abandoningJobId: "job-1",
+    });
+
+    release();
+    await handle.stop();
+  });
+
+  it("drain() fires the abort even when the drain-requested log THROWS (the throw never escapes)", async () => {
+    // drain() is the FIRST step of drainFleetWorker's SIGTERM critical path.
+    // The abort is the load-bearing half (report-skip, heartbeat stop, driver
+    // cancel key on the SIGNAL); the log line is forensics. A throwing logger
+    // must neither skip the abort nor propagate out of drain() — pre-fix the
+    // log preceded the abort unguarded, so a logger throw escaped
+    // drainFleetWorker BEFORE the roster delete ever ran.
+    const logger: Logger = {
+      ...silentLogger,
+      info: (msg) => {
+        if (msg === "fleet.worker.drain-requested") {
+          throw new Error("logger exploded on drain");
+        }
+      },
+    };
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const { driver, seenCtx, started, release } = makeWedgedDriver();
+    const handle = startWedgedLoop({ queue, driver, logger });
+
+    await started;
+    expect(seenCtx()!.abortSignal!.aborted).toBe(false);
+    expect(() => handle.drain()).not.toThrow();
+    expect(seenCtx()!.abortSignal!.aborted).toBe(true);
+
+    release();
+    await handle.stop();
+  });
+
+  it("an abandoned job is NEVER reported even when the wedged run later settles GREEN", async () => {
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const reportSpy = vi.spyOn(queue, "report");
+    const { driver, started, release } = makeWedgedDriver();
+    const handle = startWedgedLoop({ queue, driver });
+
+    await started;
+    handle.drain();
+    // Teardown later "completes" the run (green!) — the report-skip is keyed
+    // on the drain SIGNAL, not on stop() completion, so it is still abandoned.
+    release();
+    await handle.done;
+    expect(reportSpy).not.toHaveBeenCalled();
+  });
+
+  it("drain() is idempotent and stop() keeps its bounded/second-caller contract", async () => {
+    const info = vi.fn();
+    const logger: Logger = { ...silentLogger, info };
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const { driver, started, release } = makeWedgedDriver();
+    const handle = startWedgedLoop({ queue, driver, logger });
+
+    await started;
+    handle.drain();
+    handle.drain(); // second drain: no-op, no double log
+    expect(
+      info.mock.calls.filter((c) => c[0] === "fleet.worker.drain-requested"),
+    ).toHaveLength(1);
+
+    release();
+    // First stop() after drain(): still resolves bounded.
+    await expect(
+      Promise.race([
+        handle.stop(),
+        new Promise<never>((_res, rej) =>
+          setTimeout(
+            () => rej(new Error("stop() did not resolve bounded")),
+            1000,
+          ),
+        ),
+      ]),
+    ).resolves.toBeUndefined();
+    // Second stop(): awaits the (now settled) done — resolves immediately.
+    await handle.stop();
+  });
+
+  it("skips running a job whose claim resolves AFTER drain() fires (driver never invoked)", async () => {
+    // B3: the drain signal can fire while a `claimNext` round-trip is in
+    // flight. The won claim must NOT be run — running it would start a doomed
+    // driver run on a process that is exiting. Skip it entirely and leave the
+    // claim to lease expiry (the same abandon path as an in-flight drain).
+    let resolveClaim!: (c: ClaimedJob) => void;
+    const pendingClaim = new Promise<ClaimedJob>((res) => {
+      resolveClaim = res;
+    });
+    let claimCalls = 0;
+    const queueBase = makeQueue([]);
+    const queue: FleetQueueClient = {
+      ...queueBase,
+      async claimNext(): Promise<ClaimedJob> {
+        claimCalls++;
+        if (claimCalls === 1) return pendingClaim;
+        return { claimed: false };
+      },
+    };
+    const run = vi.fn(
+      async (
+        ctx: ServiceDriverContext,
+        _input: unknown,
+      ): Promise<ProbeResult> => ({
+        key: "e2e_d6:langgraph-python",
+        state: "green",
+        signal: { shape: "package", slug: "langgraph-python" },
+        observedAt: ctx.now().toISOString(),
+      }),
+    );
+    const info = vi.fn();
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      driver: { run },
+      payloadToInput: passInput,
+      logger: { ...silentLogger, info },
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+
+    // Wait until the loop is parked inside the pending claimNext…
+    await vi.waitFor(() => expect(claimCalls).toBe(1));
+    // …drain while the claim round-trip is in flight, THEN let the claim win.
+    handle.drain();
+    resolveClaim({ claimed: true, lease: makeLease() });
+    await handle.done;
+
+    expect(run).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith("fleet.worker.drain-claim-skipped", {
+      workerId: "worker-test",
+      jobId: "job-1",
+    });
+    await handle.stop();
+  });
+
+  it("a drain during an in-flight report logs abandoningJobId null (the run already began reporting)", async () => {
+    // B5: once the run has settled and the loop has INITIATED queue.report,
+    // the job is past the abandon point — a drain() racing the in-flight
+    // report must not record it as `abandoningJobId` (the report is landing;
+    // logging it as abandoned would be a forensic lie).
+    let releaseReport!: () => void;
+    const reportGate = new Promise<void>((res) => {
+      releaseReport = res;
+    });
+    let markReportStarted!: () => void;
+    const reportInFlight = new Promise<void>((res) => {
+      markReportStarted = res;
+    });
+    const queueBase = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const queue: RecordingQueue = {
+      ...queueBase,
+      reports: queueBase.reports,
+      async report({ result }): Promise<void> {
+        markReportStarted();
+        await reportGate;
+        queueBase.reports.push(result);
+      },
+    };
+    const driver = makeDriver({
+      slug: "langgraph-python",
+      cells: [{ featureId: "shared-state", state: "green" }],
+      aggregateState: "green",
+    });
+    const info = vi.fn();
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      driver,
+      payloadToInput: passInput,
+      logger: { ...silentLogger, info },
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+
+    // Park the loop inside the in-flight report, then drain.
+    await reportInFlight;
+    handle.drain();
+    expect(info).toHaveBeenCalledWith("fleet.worker.drain-requested", {
+      workerId: "worker-test",
+      abandoningJobId: null,
+    });
+
+    releaseReport();
+    await handle.stop();
+    // The in-flight report still landed — it was never the abandoned one.
+    expect(queue.reports).toHaveLength(1);
+  });
+});
+
+// ── Drain grace resolution (WORKER_DRAIN_GRACE_MS) ─────────────────────────
+
+describe("drain grace (WORKER_DRAIN_GRACE_MS)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("defaults UNDER Railway's ~10s SIGTERM→SIGKILL window (6s) — COMPOSED with the deregister cap", () => {
+    // Railway hard-kills ~10s after SIGTERM (live-verified 2026-06-10), and
+    // the drain sequence spends its phases SERIALLY inside that window:
+    // DRAIN_DEREGISTER_TIMEOUT_MS (3s cap on a hung-PB roster delete) is
+    // consumed BEFORE this grace even starts. Pinning the bare constant under
+    // 10s is therefore not enough — the COMPOSED worst case (hung PB AND a
+    // wedged driver) must fit. Grace history: 25s at the 2026-06-10 live
+    // incident → an 8s interim (whose composed 3s + 8s still overshot the
+    // window) → the composed 6s default pinned here.
+    expect(DEFAULT_WORKER_DRAIN_GRACE_MS).toBe(6_000);
+    expect(
+      DRAIN_DEREGISTER_TIMEOUT_MS + DEFAULT_WORKER_DRAIN_GRACE_MS,
+    ).toBeLessThan(10_000);
+  });
+
+  it("warns and falls back to the default when WORKER_DRAIN_GRACE_MS is not a positive integer", async () => {
+    vi.stubEnv("WORKER_DRAIN_GRACE_MS", "soon");
+    const warn = vi.fn();
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue: makeQueue([]),
+      pool: budgetWith(5),
+      driver: makeDriver({ slug: "x", cells: [], aggregateState: "green" }),
+      payloadToInput: passInput,
+      logger: { ...silentLogger, warn },
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+    await handle.stop();
+    expect(warn).toHaveBeenCalledWith(
+      "fleet.worker.drain-grace-invalid",
+      expect.objectContaining({
+        raw: "soon",
+        fallbackMs: DEFAULT_WORKER_DRAIN_GRACE_MS,
+      }),
+    );
+  });
+
+  it("an invalid WORKER_DRAIN_GRACE_MS bounds stop() at the DEFAULT grace against a wedged driver (no NaN→0 instant detach, no hang)", async () => {
+    // The fallback's BEHAVIOR, not just its warn: with a garbage override and
+    // a wedged driver (ignores its abort, never settles), stop() must detach
+    // at DEFAULT_WORKER_DRAIN_GRACE_MS semantics — a NaN→0 grace would detach
+    // instantly (no drain at all) and a dropped timer would hang stop() past
+    // Railway's kill window. Fake timers pin both edges deterministically.
+    vi.stubEnv("WORKER_DRAIN_GRACE_MS", "soon");
+    vi.useFakeTimers();
+    try {
+      const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+      let release!: () => void;
+      const released = new Promise<void>((res) => {
+        release = res;
+      });
+      let markStarted!: () => void;
+      const started = new Promise<void>((res) => {
+        markStarted = res;
+      });
+      const driver: ServiceJobDriver = {
+        async run(ctx): Promise<ProbeResult> {
+          markStarted();
+          // Deliberately IGNORE ctx.abortSignal — a wedged teardown.
+          await released;
+          return {
+            key: "e2e_d6:langgraph-python",
+            state: "green",
+            signal: { shape: "package", slug: "langgraph-python" },
+            observedAt: ctx.now().toISOString(),
+          };
+        },
+      };
+      const handle = startWorkerLoop({
+        workerId: "worker-test",
+        queue,
+        pool: budgetWith(5),
+        driver,
+        payloadToInput: passInput,
+        logger: silentLogger,
+        env: {},
+        now: () => new Date("2026-06-04T00:04:00.000Z"),
+        sleep: yieldingSleep(),
+        pollIntervalMs: 1,
+        leaseSeconds: 2000,
+        heartbeatMs: 1_000_000,
+      });
+      await started;
+
+      let stopSettled = false;
+      const stopPromise = handle.stop().then(() => {
+        stopSettled = true;
+      });
+      // NOT instantaneous: one tick short of the default grace, the wedged
+      // drain is still being waited on (a NaN→0 grace would already have
+      // detached).
+      await vi.advanceTimersByTimeAsync(DEFAULT_WORKER_DRAIN_GRACE_MS - 1);
+      expect(stopSettled).toBe(false);
+      // …and NOT a hang: crossing the default grace detaches stop().
+      await vi.advanceTimersByTimeAsync(1);
+      await stopPromise;
+      expect(stopSettled).toBe(true);
+
+      // Cleanup: un-wedge the run so the loop exits via the abandon path.
+      release();
+      await handle.done;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does NOT warn for a valid positive-integer override", async () => {
+    vi.stubEnv("WORKER_DRAIN_GRACE_MS", "200");
+    const warn = vi.fn();
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue: makeQueue([]),
+      pool: budgetWith(5),
+      driver: makeDriver({ slug: "x", cells: [], aggregateState: "green" }),
+      payloadToInput: passInput,
+      logger: { ...silentLogger, warn },
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+    await handle.stop();
+    expect(warn).not.toHaveBeenCalledWith(
+      "fleet.worker.drain-grace-invalid",
+      expect.anything(),
+    );
   });
 });
 
@@ -1329,6 +2185,70 @@ describe("driver registry (driverKind → driver)", () => {
     expect(result.cells).toHaveLength(1);
     expect(result.cells[0]!.cellKey).toBe("custom:langgraph-python/feat-1");
     expect(result.commError).toBeUndefined();
+  });
+
+  it("classifies a THROWING custom aggregateSlugKey builder as worker-protocol-violation and the loop continues", async () => {
+    // B4: `buildAggregateSlugKey(payload.serviceSlug)` runs BEFORE the
+    // try/catch around the driver run — a throwing custom builder must not
+    // escape runClaimedJob (it would reject the loop's done-promise = silent
+    // worker death). It is a registry-entry misconfiguration the worker owns,
+    // classified like the other payload/protocol failures.
+    const drivers = new Map<DriverKind, DriverRegistryEntry>([
+      [
+        "e2e_d6",
+        {
+          driver: makeTaggingDriver("e2e_d6"),
+          payloadToInput: passInput,
+          aggregateSlugKey: () => {
+            throw new Error("bad aggregate key builder");
+          },
+        },
+      ],
+      ["e2e_smoke", entry("e2e_smoke")],
+    ]);
+    const queue = makeQueue([
+      {
+        claimed: true,
+        lease: makeLease({ payload: { driverKind: "e2e_d6" } }),
+      },
+      {
+        claimed: true,
+        lease: makeLease({
+          job: { id: "job-2" },
+          payload: { driverKind: "e2e_smoke" },
+        }),
+      },
+    ]);
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      drivers,
+      logger: silentLogger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+    let doneRejected = false;
+    handle.done.catch(() => {
+      doneRejected = true;
+    });
+
+    // BOTH jobs report: the poisoned one as a protocol violation, the next one
+    // normally — proof the loop survived the throwing builder.
+    await vi.waitFor(() => expect(queue.reports).toHaveLength(2));
+    await handle.stop();
+    expect(doneRejected).toBe(false);
+    expect(queue.reports[0]!.aggregateState).toBe("error");
+    expect(queue.reports[0]!.commError?.kind).toBe("worker-protocol-violation");
+    expect(queue.reports[0]!.commError?.message).toContain(
+      "bad aggregate key builder",
+    );
+    expect(queue.reports[1]!.aggregateState).toBe("green");
+    expect(queue.reports[1]!.commError).toBeUndefined();
   });
 
   it("honors driverInputs.rowPrefix=d5 over the entry's d6 aggregate filter (D5 take-one)", async () => {

--- a/showcase/harness/src/fleet/worker/worker-loop.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.ts
@@ -171,8 +171,10 @@ export interface WorkerLoopDeps {
    * LEGACY single-driver pair. When `drivers` is omitted, the loop runs EVERY
    * claimed job through this one driver (the pre-registry behavior). Retained so
    * existing call sites / tests that inject one driver keep working; the
-   * registry path is preferred. Exactly one of `drivers` or this pair must be
-   * supplied.
+   * registry path is preferred and TAKES PRECEDENCE — when both are supplied
+   * the loop dispatches through `drivers` and this pair is ignored (matching
+   * the fleet entrypoint's precedence doc). At least one run path must be
+   * supplied; the construction guard throws otherwise.
    */
   driver?: ServiceJobDriver;
   /** Maps a claimed payload to the legacy driver's per-service input. */
@@ -204,6 +206,20 @@ export interface WorkerLoopDeps {
 /** Handle returned by `startWorkerLoop` — `stop()` requests a bounded drain. */
 export interface WorkerLoopHandle {
   /**
+   * SYNCHRONOUSLY request the drain: fire the loop's stop/abort signal and
+   * record the abandon decision for any in-flight job — WITHOUT awaiting the
+   * run's teardown. The loop's report-skip is keyed on this SIGNAL (not on
+   * `stop()` completing), so once `drain()` returns, a run that has not
+   * begun reporting can never be reported — even if a wedged teardown later
+   * "completes" the run. (A report the loop already INITIATED before the
+   * signal fired is past the abandon point: it is in flight and may land.)
+   * Idempotent; `stop()` calls it implicitly. Callers that must beat a
+   * platform kill grace (Railway SIGKILLs ~10s after SIGTERM) call `drain()`
+   * first, run their fast deregister work, and only then spend the drain
+   * grace budget in `stop()`.
+   */
+  drain(): void;
+  /**
    * Resolves when the loop has stopped OR the drain grace (`drainGraceMs`,
    * see `DEFAULT_WORKER_DRAIN_GRACE_MS`) expires — whichever comes first. On
    * expiry stop() DETACHES and resolves anyway, so a wedged driver that
@@ -223,18 +239,100 @@ export const DEFAULT_HEARTBEAT_MS = 60_000;
 /** Default idle poll interval when there's no work / no budget. */
 export const DEFAULT_POLL_INTERVAL_MS = 5_000;
 /**
- * Upper bound on how long `stop()` waits for the in-flight run to drain before
- * detaching and resolving anyway. Comfortably under Railway's SIGTERM grace
- * window so even a wedged driver (one that ignores its abort signal) can't block
- * process exit past grace and get SIGKILL'd mid-cleanup. Env-overridable via
- * `WORKER_DRAIN_GRACE_MS`.
+ * Bound on the roster-row deregister await inside the orchestrator's
+ * `drainFleetWorker` (which re-exports this constant).
+ *
+ * The deregister is the only step that must beat the platform kill grace
+ * (Railway SIGKILLs ~10s after SIGTERM) — but a HUNG (not failing) PocketBase
+ * must not consume that whole window and starve the best-effort teardown +
+ * pool shutdown queued behind it. NOTE the race bounds the WHOLE
+ * write-serialization chain of the registration handle, not just the delete:
+ * `deregister()` is the chain's terminal link, so an already-enqueued slow
+ * heartbeat upsert consumes part of this budget BEFORE the delete is even
+ * issued. On timeout the drain logs
+ * `fleet.worker.deregister-timeout` and PROCEEDS to teardown: the roster row
+ * strands, degrading to the documented crash-path reclaim (fleet-health
+ * reclaims the stale row red at its 180s mark) — strictly better than being
+ * SIGKILL'd mid-deregister with the pool's chromium processes stranded.
+ *
+ * Lives in this LEAF module (not orchestrator.ts) next to
+ * `DEFAULT_WORKER_DRAIN_GRACE_MS`, whose doc owns the composed drain budget
+ * the two constants share.
  */
-export const DEFAULT_WORKER_DRAIN_GRACE_MS = 25_000;
+export const DRAIN_DEREGISTER_TIMEOUT_MS = 3_000;
+/**
+ * Upper bound on how long `stop()` waits for the in-flight run to drain before
+ * detaching and resolving anyway.
+ *
+ * SERIAL BUDGET vs the platform kill: Railway SIGKILLs ~10s after SIGTERM
+ * (live-verified 2026-06-10), and the drain sequence (`drainFleetWorker`)
+ * spends its phases SERIALLY inside that window:
+ *
+ *     DRAIN_DEREGISTER_TIMEOUT_MS (cap; <1s normally)   — roster delete
+ *   + DEFAULT_WORKER_DRAIN_GRACE_MS (this grace)        — best-effort teardown
+ *   + health-server close + pool shutdown               — small remainder
+ *   ≈ Railway's ~10s SIGTERM→SIGKILL window
+ *
+ * The COMPOSED worst case — a hung PocketBase consuming the full
+ * `DRAIN_DEREGISTER_TIMEOUT_MS` cap AND a wedged driver consuming this full
+ * grace — must fit under that window. The composed-budget test in
+ * worker-loop.test.ts pins `DRAIN_DEREGISTER_TIMEOUT_MS +
+ * DEFAULT_WORKER_DRAIN_GRACE_MS` against it and is the source of truth when
+ * retuning either constant (both live in this file). Deregister-first
+ * ordering makes the trade safe: only the roster delete is GUARANTEED to
+ * beat the kill; the pool shutdown and clean `process.exit` behind this
+ * grace are best-effort (a SIGKILL mid-teardown is harmless once the roster
+ * row is gone). Env-overridable via `WORKER_DRAIN_GRACE_MS` for platforms
+ * with longer stop-grace windows — but an override above ~7s forfeits the
+ * composed <10s budget on Railway (the 3s deregister cap plus the override
+ * would exceed the SIGTERM→SIGKILL window).
+ */
+export const DEFAULT_WORKER_DRAIN_GRACE_MS = 6_000;
 
-function resolveDrainGraceMs(): number {
+/**
+ * Guarded log: invoke `logger[level]` and SWALLOW any throw.
+ *
+ * WHY: on the worker's loop and drain/stop paths the failing component may BE
+ * the logger. A throwing logger inside the loop's done-IIFE would reject the
+ * loop's done-promise (silent worker death + restart loop), and one on the
+ * stop/drain path would skip the teardown behind it (health server left
+ * bound, the pool's chromium processes stranded, the roster delete never
+ * reached). Forensics are best-effort; the loop and its teardown are
+ * load-bearing — so EVERY log on those paths routes through this guard. A
+ * throwing logger must neither reject the loop's done-promise nor skip the
+ * drain/stop teardown.
+ *
+ * Exported so the fleet entrypoint (`fleet/orchestrator.ts`) and the drain
+ * sequence (`drainFleetWorker` in orchestrator.ts) apply the same discipline
+ * through ONE implementation.
+ */
+export function safeLog(
+  logger: Logger,
+  level: "debug" | "info" | "warn" | "error",
+  msg: string,
+  meta?: Record<string, unknown>,
+): void {
+  try {
+    logger[level](msg, meta);
+  } catch {
+    // Swallow: the logger is the failing component; nothing load-bearing may
+    // sit behind a forensic log line.
+  }
+}
+
+function resolveDrainGraceMs(logger: Logger): number {
   const raw = process.env.WORKER_DRAIN_GRACE_MS;
-  const parsed = raw ? parseInt(raw, 10) : NaN;
-  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  if (raw === undefined || raw.trim() === "") {
+    return DEFAULT_WORKER_DRAIN_GRACE_MS;
+  }
+  const parsed = Number(raw);
+  if (Number.isInteger(parsed) && parsed > 0) return parsed;
+  // Fail loud-ish: a present-but-garbage override silently falling back would
+  // leave an operator believing their grace tuning took effect.
+  logger.warn("fleet.worker.drain-grace-invalid", {
+    raw,
+    fallbackMs: DEFAULT_WORKER_DRAIN_GRACE_MS,
+  });
   return DEFAULT_WORKER_DRAIN_GRACE_MS;
 }
 
@@ -475,6 +573,11 @@ export function buildCommErrorResult(args: {
     aggregateState: errorState,
     aggregateKey: payload.probeKey,
     aggregateSignal: { error: commError.message },
+    // cells: [] is DELIBERATE here and in `buildDriverErrorResult` below: any
+    // per-cell rows captured before the run THREW are untrusted partial state
+    // on an error result, so both builders drop them. Whether trustworthy
+    // partial cells could be salvaged instead is a behavioral question
+    // tracked in the backlog, not an accident of these builders.
     cells: [],
     rollup: { total: 0, passed: 0, failed: 0 },
     finishedAt,
@@ -591,7 +694,7 @@ export async function runClaimedJob(
   // kind. This mirrors the unmappable-payload failure shape below.
   const entry = resolveDriverEntry(deps, payload.driverKind);
   if (!entry) {
-    logger.error("fleet.worker.unknown-driver-kind", {
+    safeLog(logger, "error", "fleet.worker.unknown-driver-kind", {
       workerId,
       jobId: job.id,
       probeKey: payload.probeKey,
@@ -631,7 +734,7 @@ export async function runClaimedJob(
     input = payloadToInput(payload);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    logger.error("fleet.worker.payload-decode-error", {
+    safeLog(logger, "error", "fleet.worker.payload-decode-error", {
       workerId,
       jobId: job.id,
       probeKey: payload.probeKey,
@@ -651,7 +754,7 @@ export async function runClaimedJob(
     });
   }
   if (input === undefined) {
-    logger.warn("fleet.worker.payload-unmappable", {
+    safeLog(logger, "warn", "fleet.worker.payload-unmappable", {
       workerId,
       jobId: job.id,
       probeKey: payload.probeKey,
@@ -682,40 +785,94 @@ export async function runClaimedJob(
   // `rowPrefix` carried on the payload's driver inputs here — otherwise the
   // `d5:<slug>` aggregate would leak into the captured per-cell set.
   const rowPrefixOverride = readRowPrefix(payload.driverInputs);
-  const aggregateSlugKey =
-    rowPrefixOverride !== undefined
-      ? `${rowPrefixOverride}:${payload.serviceSlug}`
-      : buildAggregateSlugKey(payload.serviceSlug);
+  // A CUSTOM `aggregateSlugKey` builder is registry-supplied code running
+  // BEFORE the driver-run try/catch below — a throwing builder would escape
+  // runClaimedJob and reject the loop's done-promise (silent worker death),
+  // breaking the never-throws contract. It is a registry-entry
+  // misconfiguration the worker owns (it won the claim), so classify it via
+  // the protocol-violation path like the other payload/decode failures.
+  let aggregateSlugKey: string;
+  try {
+    aggregateSlugKey =
+      rowPrefixOverride !== undefined
+        ? `${rowPrefixOverride}:${payload.serviceSlug}`
+        : buildAggregateSlugKey(payload.serviceSlug);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    safeLog(logger, "error", "fleet.worker.aggregate-key-error", {
+      workerId,
+      jobId: job.id,
+      probeKey: payload.probeKey,
+      driverKind: payload.driverKind,
+      err: msg,
+    });
+    return buildCommErrorResult({
+      lease,
+      workerId,
+      commError: {
+        kind: "worker-protocol-violation",
+        message: `worker could not build the aggregate slug key for probeKey "${payload.probeKey}" (driverKind "${payload.driverKind}"): ${msg}`,
+        workerId,
+        jobId: job.id,
+        observedAt: now().toISOString(),
+      },
+      finishedAt: now().toISOString(),
+    });
+  }
   const capture = createCellCapture(aggregateSlugKey);
 
   // Heartbeat-renew the lease while the (long) driver run is in flight. A renew
   // that returns null (lease lost/stolen) stops the heartbeat but does not
   // abort the run — `report` is the final CAS arbiter.
   const heartbeatAbort = new AbortController();
+  // DRAIN STOPS RENEWAL: once the drain signal fires the in-flight job is
+  // ABANDONED — the loop will never report it, and the abandon design relies
+  // on the lease LAPSING so the sweeper re-queues the job neutral-gray. A
+  // wedged driver that ignores its abort would otherwise keep this heartbeat
+  // renewing indefinitely, holding the abandoned lease alive past every
+  // reclaim window. Abort the heartbeat the moment the drain fires (the
+  // listener is removed in the finally below so a long-lived drain signal
+  // doesn't accumulate listeners across jobs). A renewLease round-trip that
+  // was ALREADY dispatched when the drain fired may still land post-drain and
+  // extend the abandoned lease once — accepted (it only delays the sweeper's
+  // reclaim by one lease window) and untested by design.
+  const stopHeartbeatOnDrain = (): void => heartbeatAbort.abort();
+  if (drainSignal?.aborted) {
+    heartbeatAbort.abort();
+  } else {
+    drainSignal?.addEventListener("abort", stopHeartbeatOnDrain, {
+      once: true,
+    });
+  }
   const heartbeat = (async (): Promise<void> => {
     while (!heartbeatAbort.signal.aborted) {
-      await deps.sleep(opts.heartbeatMs, heartbeatAbort.signal);
-      if (heartbeatAbort.signal.aborted) break;
+      // The sleep await sits INSIDE the try so a rejecting injected sleep
+      // breaks the heartbeat like a renew failure — outside it, the rejection
+      // would escape through the `await heartbeat` in the finally below and
+      // reject runClaimedJob (breaking its never-throws contract = silent
+      // worker death via a rejected loop done-promise).
       try {
+        await deps.sleep(opts.heartbeatMs, heartbeatAbort.signal);
+        if (heartbeatAbort.signal.aborted) break;
         const renewed = await queue.renewLease(
           job.id,
           workerId,
           opts.leaseSeconds,
         );
         if (renewed === null) {
-          logger.warn("fleet.worker.lease-lost", {
+          safeLog(logger, "warn", "fleet.worker.lease-lost", {
             workerId,
             jobId: job.id,
           });
           break;
         }
-        logger.debug("fleet.worker.lease-renewed", {
+        safeLog(logger, "debug", "fleet.worker.lease-renewed", {
           workerId,
           jobId: job.id,
           leaseExpiresAt: renewed.leaseExpiresAt,
         });
       } catch (err) {
-        logger.warn("fleet.worker.lease-renew-error", {
+        safeLog(logger, "warn", "fleet.worker.lease-renew-error", {
           workerId,
           jobId: job.id,
           err: err instanceof Error ? err.message : String(err),
@@ -767,7 +924,7 @@ export async function runClaimedJob(
     // A schema/input-validation throw is a protocol violation, not a crash —
     // the payload could not be trusted (same class as an unmappable payload).
     if (cls === "protocol-violation") {
-      logger.error("fleet.worker.job-protocol-violation", {
+      safeLog(logger, "error", "fleet.worker.job-protocol-violation", {
         workerId,
         jobId: job.id,
         probeKey: payload.probeKey,
@@ -791,7 +948,7 @@ export async function runClaimedJob(
     // A true infra/pool-unreachable failure stays `worker-crashed-mid-job` so
     // the dashboard renders the "couldn't reach the pool" overlay (REQ-B).
     if (cls === "pool-infra") {
-      logger.error("fleet.worker.job-crashed", {
+      safeLog(logger, "error", "fleet.worker.job-crashed", {
         workerId,
         jobId: job.id,
         probeKey: payload.probeKey,
@@ -816,7 +973,7 @@ export async function runClaimedJob(
     // not a pool-comm failure — surface it as an `error`-state result with NO
     // commError so the dashboard shows a probe error, not a pool-unreachable
     // overlay (REQ-B inversion fix).
-    logger.error("fleet.worker.job-driver-error", {
+    safeLog(logger, "error", "fleet.worker.job-driver-error", {
       workerId,
       jobId: job.id,
       probeKey: payload.probeKey,
@@ -830,6 +987,7 @@ export async function runClaimedJob(
       finishedAt: now().toISOString(),
     });
   } finally {
+    drainSignal?.removeEventListener("abort", stopHeartbeatOnDrain);
     heartbeatAbort.abort();
     await heartbeat;
   }
@@ -896,14 +1054,14 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
       const maybe = deps.onCurrentJobChange(currentJobId) as unknown;
       if (maybe && typeof (maybe as Promise<unknown>).catch === "function") {
         (maybe as Promise<unknown>).catch((err) =>
-          logger.warn("fleet.worker.current-job-hook-error", {
+          safeLog(logger, "warn", "fleet.worker.current-job-hook-error", {
             workerId,
             err: err instanceof Error ? err.message : String(err),
           }),
         );
       }
     } catch (err) {
-      logger.warn("fleet.worker.current-job-hook-error", {
+      safeLog(logger, "warn", "fleet.worker.current-job-hook-error", {
         workerId,
         err: err instanceof Error ? err.message : String(err),
       });
@@ -912,9 +1070,76 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
 
   const stopAbort = new AbortController();
   let stopped = false;
+  let drainRequested = false;
+  /**
+   * The jobId of the run currently in flight (null when idle) — tracked so the
+   * drain request can record WHICH job is being abandoned at signal time,
+   * BEFORE the (possibly wedged) run settles and the loop's own
+   * `drain-abandon` line fires.
+   */
+  let inFlightJobId: string | null = null;
+
+  /**
+   * Fire the drain signal exactly once: ABORT FIRST, then record the abandon
+   * decision. The abort is the load-bearing half — the loop's report-skip,
+   * the heartbeat stop, and the driver cancel all key on `stopAbort.signal`,
+   * NOT on `stop()` completing — so a hung run that "completes" after this
+   * point is still abandoned, never reported. The log line is forensics, and
+   * `requestDrain()` sits at the head of `drainFleetWorker`'s SIGTERM
+   * critical path: a throwing logger ahead of the abort would skip the abort
+   * AND propagate out before the roster delete ever ran, so the log fires
+   * after the abort and is guarded. (The abort dispatches its listeners
+   * synchronously but the loop reacts asynchronously, so `inFlightJobId` is
+   * still the pre-drain value when logged.)
+   */
+  function requestDrain(): void {
+    if (drainRequested) return;
+    drainRequested = true;
+    stopAbort.abort();
+    // Best-effort forensics only (guarded): the abort already fired, and
+    // nothing on the drain critical path may throw past this point.
+    safeLog(logger, "info", "fleet.worker.drain-requested", {
+      workerId,
+      abandoningJobId: inFlightJobId,
+    });
+  }
+
+  /**
+   * Idle/poll sleep that NEVER rejects: a rejecting injected/platform sleep
+   * at a poll point would reject the loop's done-promise (silent worker
+   * death) — the same hardening the in-job heartbeat applies to ITS sleep.
+   * Log the failure, then fall back to the module's RAW timer sleep
+   * (`defaultSleep` — a bare setTimeout race that cannot reject and stays
+   * abort-responsive via the stop signal): treating the interval as merely
+   * "elapsed" would let a PERSISTENTLY rejecting sleep degrade the idle loop
+   * into a microtask-speed busy loop hammering `pool.budget()`/`claimNext`.
+   * The `while` condition still observes the drain/stop signal, which
+   * governs exit.
+   */
+  async function safeSleep(ms: number): Promise<void> {
+    try {
+      await sleep(ms, stopAbort.signal);
+    } catch (err) {
+      safeLog(logger, "warn", "fleet.worker.sleep-failed", {
+        workerId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      await defaultSleep(ms, stopAbort.signal);
+    }
+  }
+
+  // CONSTRUCTION-TIME grace resolution, BEFORE the claiming loop starts. The
+  // invalid-override warn in resolveDrainGraceMs is the one log call on this
+  // module's runtime paths deliberately left UNGUARDED (a fail-loud misconfig
+  // surface, like the construction guards above). Resolving it after the
+  // done-IIFE had started meant a throwing warn escaped startWorkerLoop with
+  // a LIVE claiming loop already running and no handle returned to stop it —
+  // an orphaned worker. Above the IIFE, the same throw fires before the
+  // first claim is ever attempted.
+  const drainGraceMs = resolveDrainGraceMs(logger);
 
   const done = (async (): Promise<void> => {
-    logger.info("fleet.worker.loop-start", { workerId });
+    safeLog(logger, "info", "fleet.worker.loop-start", { workerId });
     while (!stopAbort.signal.aborted) {
       // 1. Budget gate — only claim when we have free context capacity. This
       //    is what keeps the worker under its cgroup pids ceiling. Reading the
@@ -927,22 +1152,22 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
       try {
         budget = pool.budget();
       } catch (err) {
-        logger.error("fleet.worker.budget-error", {
+        safeLog(logger, "error", "fleet.worker.budget-error", {
           workerId,
           err: err instanceof Error ? err.message : String(err),
         });
-        await sleep(pollIntervalMs, stopAbort.signal);
+        await safeSleep(pollIntervalMs);
         continue;
       }
       if (budget.available <= 0) {
-        logger.debug("fleet.worker.no-budget", {
+        safeLog(logger, "debug", "fleet.worker.no-budget", {
           workerId,
           inUse: budget.inUse,
           max: budget.max,
           pidsCurrent: budget.pidsCurrent,
           pidsMax: budget.pidsMax,
         });
-        await sleep(pollIntervalMs, stopAbort.signal);
+        await safeSleep(pollIntervalMs);
         continue;
       }
 
@@ -951,21 +1176,36 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
       try {
         claimed = await queue.claimNext(workerId, leaseSeconds);
       } catch (err) {
-        logger.warn("fleet.worker.claim-error", {
+        safeLog(logger, "warn", "fleet.worker.claim-error", {
           workerId,
           err: err instanceof Error ? err.message : String(err),
         });
-        await sleep(pollIntervalMs, stopAbort.signal);
+        await safeSleep(pollIntervalMs);
         continue;
       }
 
       if (!claimed.claimed || !claimed.lease) {
-        await sleep(pollIntervalMs, stopAbort.signal);
+        await safeSleep(pollIntervalMs);
         continue;
       }
 
       const lease = claimed.lease;
-      logger.info("fleet.worker.claimed", {
+
+      // DRAIN CLAIM SKIP: the drain signal can fire while the claimNext
+      // round-trip is in flight. A claim won AFTER the drain decision must
+      // NOT be run — the process is exiting, so starting the driver would
+      // only spin up a doomed run. Skip it entirely and leave the claimed
+      // row to lease expiry, the same abandon path an in-flight drain uses
+      // (the sweeper re-queues it neutral-gray).
+      if (stopAbort.signal.aborted) {
+        safeLog(logger, "info", "fleet.worker.drain-claim-skipped", {
+          workerId,
+          jobId: lease.job.id,
+        });
+        break;
+      }
+
+      safeLog(logger, "info", "fleet.worker.claimed", {
         workerId,
         jobId: lease.job.id,
         probeKey: lease.payload.probeKey,
@@ -975,6 +1215,7 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
       // Reflect the now-running job on the registration row so fleet-health
       // sees a non-null current_job_id while the (long) run is in flight.
       // Best-effort — a throwing hook must never break the loop.
+      inFlightJobId = lease.job.id;
       notifyCurrentJob(lease.job.id);
 
       // 3. Run + report. `runClaimedJob` never throws — it returns a comm-error
@@ -1012,17 +1253,23 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
       // path) so fleet-health doesn't reclaim the row red at its 180s stale
       // window before the 300s lease expiry.
       if (stopAbort.signal.aborted) {
-        logger.info("fleet.worker.drain-abandon", {
+        safeLog(logger, "info", "fleet.worker.drain-abandon", {
           workerId,
           jobId: lease.job.id,
         });
+        inFlightJobId = null;
         notifyCurrentJob(null);
         break;
       }
 
+      // The run has settled and is about to be reported — clear the abandon
+      // marker BEFORE initiating the report so a drain() racing the in-flight
+      // report never records this job as `abandoningJobId` (a run that has
+      // begun reporting is past the abandon point; the report may land).
+      inFlightJobId = null;
       try {
         await queue.report({ jobId: lease.job.id, workerId, result });
-        logger.info("fleet.worker.reported", {
+        safeLog(logger, "info", "fleet.worker.reported", {
           workerId,
           jobId: lease.job.id,
           aggregateState: result.aggregateState,
@@ -1045,30 +1292,32 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
         //     is what synthesizes the comm error for this case (NOT the sweeper).
         // Either way the dashboard ends up showing "unreachable"; log and keep
         // pulling.
-        logger.error("fleet.worker.report-error", {
+        safeLog(logger, "error", "fleet.worker.report-error", {
           workerId,
           jobId: lease.job.id,
           err: err instanceof Error ? err.message : String(err),
         });
       } finally {
-        // The job has settled — clear the current-job marker so the worker
-        // shows idle again on the next heartbeat.
+        // The job has settled (and `inFlightJobId` was already cleared above,
+        // pre-report) — clear the current-job marker so the worker shows idle
+        // again on the next registration heartbeat.
         notifyCurrentJob(null);
       }
     }
-    logger.info("fleet.worker.loop-stopped", { workerId });
+    safeLog(logger, "info", "fleet.worker.loop-stopped", { workerId });
   })();
 
-  const drainGraceMs = resolveDrainGraceMs();
-
   return {
+    drain(): void {
+      requestDrain();
+    },
     async stop(): Promise<void> {
       if (stopped) {
         await done;
         return;
       }
       stopped = true;
-      stopAbort.abort();
+      requestDrain();
       // Bound the drain: the in-flight `driver.run` observes `stopAbort.signal`
       // (threaded into `ctx.abortSignal`) and returns promptly, so `done`
       // normally resolves fast. But a wedged driver that ignores the abort must
@@ -1085,13 +1334,22 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
           (graceTimer as { unref: () => void }).unref();
         }
       });
-      const outcome = await Promise.race([
-        done.then(() => "done" as const),
-        graceExpired,
-      ]);
-      if (graceTimer !== undefined) clearTimeout(graceTimer);
+      let outcome: "done" | "timeout";
+      try {
+        outcome = await Promise.race([
+          done.then(() => "done" as const),
+          graceExpired,
+        ]);
+      } finally {
+        // ALWAYS clear the grace timer: a CRASHED loop makes `done` a
+        // rejected promise, so the race THROWS — a trailing clearTimeout
+        // would be skipped on that path and leak the timer. The rejection
+        // itself still propagates to the caller (the fleet wrapper's stop()
+        // closes the health server / pool around it).
+        if (graceTimer !== undefined) clearTimeout(graceTimer);
+      }
       if (outcome === "timeout") {
-        logger.warn("fleet.worker.drain-timeout", {
+        safeLog(logger, "warn", "fleet.worker.drain-timeout", {
           workerId,
           drainGraceMs,
         });

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -26,7 +26,22 @@ import {
   hydrateProbeLastRuns,
   surfaceReclaimedCommErrors,
   verifyWorkerRegistered,
+  drainFleetWorker,
+  DRAIN_DEREGISTER_TIMEOUT_MS,
 } from "./orchestrator.js";
+import { runWorker as runFleetWorker } from "./fleet/orchestrator.js";
+import { registerWorker } from "./fleet/worker/registration.js";
+import type { RegistrationPbClient } from "./fleet/worker/registration.js";
+import type { FleetRoleConfig } from "./fleet/role-config.js";
+import type {
+  FleetQueueClient,
+  ClaimedJob,
+  JobLease,
+} from "./fleet/contracts.js";
+import type {
+  ServiceJobDriver,
+  ServiceDriverContext,
+} from "./fleet/worker/worker-loop.js";
 import {
   DEFAULT_PRODUCER_CRON,
   FLEET_PRODUCER_SCHEDULE_ID,
@@ -2792,6 +2807,612 @@ describe("orchestrator.verifyWorkerRegistered (CR-FIX #4)", () => {
     const body = (await res.json()) as { registered: boolean };
     expect(res.status).toBe(503);
     expect(body.registered).toBe(false);
+  });
+});
+
+/**
+ * Deregister-FIRST drain ordering (platform-kill hardening).
+ *
+ * Live Railway redeploys proved the platform's stop grace (~10s after
+ * SIGTERM) is SHORT — shorter than the 25s drain grace the worker shipped
+ * with (WORKER_DRAIN_GRACE_MS, since lowered to a 6s default so the SERIAL
+ * deregister-cap + grace budget fits UNDER the platform window): workers stuck in slow browser-context teardown were HARD-KILLED
+ * before the old `await worker.stop()` → deregister sequence ever reached the
+ * roster delete, stranding stale rows that fleet-health reclaimed red at its
+ * 180s stale mark (the residual deploy red-splash). `drainFleetWorker` is the
+ * reordered critical path: signal the drain synchronously, deregister
+ * IMMEDIATELY (<1s), and only THEN spend the grace budget on best-effort
+ * teardown. These tests compose the REAL fleet `runWorker` handle with the
+ * REAL `registerWorker` handle (fake PB/queue/driver) so the ordering under
+ * test is the production wiring, not a re-implementation.
+ */
+describe("drainFleetWorker — deregister-FIRST drain ordering", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  const silentFleetLogger = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+
+  const fleetConfig: FleetRoleConfig = { role: "worker", poolCount: 1 };
+
+  const budgetSource = {
+    budget: () => ({
+      inUse: 0,
+      available: 5,
+      max: 24,
+      pidsCurrent: 10,
+      pidsMax: 1000,
+    }),
+  };
+
+  function makeDrainLease(): JobLease {
+    return {
+      job: {
+        id: "job-drain-1",
+        probe_key: "d6:langgraph-python",
+        status: "claimed",
+        claimed_by: "worker-drain",
+        lease_expires_at: "2026-06-04T00:05:00.000Z",
+        version: 1,
+      },
+      payload: {
+        probeKey: "d6:langgraph-python",
+        serviceSlug: "langgraph-python",
+        driverKind: "e2e_d6",
+        meta: {
+          runId: "run-drain",
+          triggered: false,
+          enqueuedAt: "2026-06-04T00:00:00.000Z",
+        },
+      },
+      leaseExpiresAt: "2026-06-04T00:05:00.000Z",
+    };
+  }
+
+  /** A queue fake that hands out ONE claim then reports nothing claimable. */
+  function makeDrainQueue(): FleetQueueClient {
+    let claimed = false;
+    return {
+      async enqueue() {
+        throw new Error("enqueue not used by worker");
+      },
+      async claimNext(): Promise<ClaimedJob> {
+        if (claimed) return { claimed: false };
+        claimed = true;
+        return { claimed: true, lease: makeDrainLease() };
+      },
+      async renewLease() {
+        return makeDrainLease();
+      },
+      async report() {},
+      async sweepExpired() {
+        return { reclaimed: 0, commErrors: [] };
+      },
+    };
+  }
+
+  /**
+   * Registration fake PB mirroring registration.test.ts's: records upserts and
+   * deletes, plus an ordered `settled` log proving no upsert lands after the
+   * delete. `onDelete` lets a test thread the delete into a shared event log.
+   */
+  function makeRegPb(onDelete?: () => void): {
+    pb: RegistrationPbClient;
+    deletes: Array<{ collection: string; filter: string }>;
+    settled: Array<"upsert" | "delete">;
+  } {
+    const deletes: Array<{ collection: string; filter: string }> = [];
+    const settled: Array<"upsert" | "delete"> = [];
+    const pb: RegistrationPbClient = {
+      async upsertByField<T>(): Promise<T> {
+        settled.push("upsert");
+        return {} as T;
+      },
+      async deleteByFilter(
+        collection: string,
+        filter: string,
+      ): Promise<number> {
+        deletes.push({ collection, filter });
+        settled.push("delete");
+        onDelete?.();
+        return 1;
+      },
+    };
+    return { pb, deletes, settled };
+  }
+
+  /**
+   * A driver whose run HANGS until `release()` and IGNORES the drain abort —
+   * the stand-in for the slow browser-context teardown that outlives the
+   * platform kill grace. Resolves GREEN on release (worst case for the
+   * never-report guarantee).
+   */
+  function makeWedgedDriver(onSettle?: () => void): {
+    driver: ServiceJobDriver;
+    started: Promise<void>;
+    release: () => void;
+    runSettled: () => boolean;
+  } {
+    let markStarted!: () => void;
+    const started = new Promise<void>((res) => {
+      markStarted = res;
+    });
+    let releaseFn!: () => void;
+    const released = new Promise<void>((res) => {
+      releaseFn = res;
+    });
+    let settled = false;
+    const driver: ServiceJobDriver = {
+      async run(ctx: ServiceDriverContext): Promise<ProbeResult> {
+        markStarted();
+        await released; // deliberately ignores ctx.abortSignal
+        settled = true;
+        onSettle?.();
+        return {
+          key: "e2e_d6:langgraph-python",
+          state: "green",
+          signal: { shape: "package", slug: "langgraph-python" },
+          observedAt: ctx.now().toISOString(),
+        };
+      },
+    };
+    return {
+      driver,
+      started,
+      release: () => releaseFn(),
+      runSettled: () => settled,
+    };
+  }
+
+  it("reaches the roster delete while a wedged teardown NEVER resolves within the drain (deregister does not gate on teardown)", async () => {
+    // Shrink the loop's drain grace so the best-effort teardown phase detaches
+    // fast under test (read from env at startWorkerLoop construction).
+    vi.stubEnv("WORKER_DRAIN_GRACE_MS", "200");
+    const events: string[] = [];
+    const { pb, deletes } = makeRegPb(() => events.push("roster-delete"));
+    const queue = makeDrainQueue();
+    const reportSpy = vi.spyOn(queue, "report");
+    const { driver, started, release, runSettled } = makeWedgedDriver(() =>
+      events.push("teardown-complete"),
+    );
+
+    const worker = await runFleetWorker(fleetConfig, {
+      queue,
+      workerId: "worker-drain-a",
+      skipHealthServer: true,
+      budgetSource,
+      driver,
+      payloadToInput: () => ({ key: "d6:langgraph-python" }),
+      logger: silentFleetLogger,
+      env: {},
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+    const registration = await registerWorker({
+      pb,
+      pool: budgetSource,
+      logger: silentFleetLogger,
+      workerId: "worker-drain-a",
+      endpoint: "http://worker-drain-a:8080",
+      setIntervalImpl: (() => 0) as unknown as typeof setInterval,
+    });
+
+    await started;
+    const drainPromise = drainFleetWorker({
+      worker,
+      registration,
+      shutdownPool: async () => {
+        events.push("pool-shutdown");
+      },
+    });
+
+    // THE FIX: the roster delete lands while the wedged run is STILL hung —
+    // under the old ordering (await worker.stop() first) this waitFor would
+    // time out because deregister sat behind the teardown grace (200ms here;
+    // 25s in prod at the time of the live Railway hard-kills).
+    await vi.waitFor(() => expect(deletes).toHaveLength(1));
+    expect(runSettled()).toBe(false);
+    expect(deletes[0]!.filter).toContain("worker-drain-a");
+
+    // The full drain still completes (grace detach), teardown never finished,
+    // pool shutdown stays last, and the abandoned job was never reported.
+    await drainPromise;
+    expect(runSettled()).toBe(false);
+    expect(events).toEqual(["roster-delete", "pool-shutdown"]);
+    expect(reportSpy).not.toHaveBeenCalled();
+
+    // Cleanup: un-wedge the driver so the loop (and its heartbeat timer) wind
+    // down; the second stop() awaits the settled loop.
+    release();
+    await worker.stop();
+  });
+
+  it("deregisters BEFORE teardown completes, never reports the abandoned job, and latches out the post-deregister job-settle heartbeat", async () => {
+    // Shrink the drain grace (like test A) so the assertion is insensitive to
+    // the default's value and the grace detach stays fast under test.
+    vi.stubEnv("WORKER_DRAIN_GRACE_MS", "200");
+    const events: string[] = [];
+    const { pb, settled } = makeRegPb(() => events.push("roster-delete"));
+    const queue = makeDrainQueue();
+    const reportSpy = vi.spyOn(queue, "report");
+    const { driver, started, release } = makeWedgedDriver(() =>
+      events.push("teardown-complete"),
+    );
+
+    const registration = await registerWorker({
+      pb,
+      pool: budgetSource,
+      logger: silentFleetLogger,
+      workerId: "worker-drain-b",
+      endpoint: "http://worker-drain-b:8080",
+      setIntervalImpl: (() => 0) as unknown as typeof setInterval,
+    });
+    const worker = await runFleetWorker(fleetConfig, {
+      queue,
+      workerId: "worker-drain-b",
+      skipHealthServer: true,
+      budgetSource,
+      driver,
+      payloadToInput: () => ({ key: "d6:langgraph-python" }),
+      logger: silentFleetLogger,
+      env: {},
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+      // PRODUCTION WIRING: the job-settle beat is fire-and-forget into the
+      // registration handle — after deregister it MUST be latched out or it
+      // would re-create the just-deleted roster row.
+      onCurrentJobChange: (currentJobId) => {
+        void registration.heartbeat(currentJobId);
+      },
+    });
+
+    await started;
+    const drainPromise = drainFleetWorker({
+      worker,
+      registration,
+      shutdownPool: async () => {
+        events.push("pool-shutdown");
+      },
+    });
+
+    // Deregister lands FIRST, while teardown is still hung…
+    await vi.waitFor(() => expect(events).toContain("roster-delete"));
+    expect(events).not.toContain("teardown-complete");
+
+    // …then the wedged teardown "completes" the run GREEN. The drain signal
+    // (not stop() completion) keys the report-skip, so it is still abandoned.
+    //
+    // GRACE-RACE NOTE: with the 200ms grace stubbed above, stop() either (a)
+    // observes the released run settle first, or (b) detaches at grace expiry
+    // while the release's microtasks land moments later. BOTH outcomes are
+    // safe for the assertions below: the roster delete already happened (so
+    // the roster-delete < teardown-complete ordering holds either way), the
+    // report-skip keys on the drain SIGNAL (so the green settle is never
+    // reported in either branch), and `teardown-complete` is pushed by the
+    // driver's own settle, not by stop() resolving.
+    release();
+    await drainPromise;
+
+    // FINAL QUIESCENCE (vacuous-pass guard): in the grace-DETACH branch of
+    // the race note above, drainPromise can resolve while the released run's
+    // microtasks — including the fire-and-forget job-settle heartbeat — are
+    // still landing. Asserting the `settled` latch immediately could then
+    // pass VACUOUSLY, with a late resurrection upsert arriving only after
+    // the assertion ran. The second stop() awaits the (released, settling)
+    // loop to completion, so every job-settle beat has fired through the
+    // latched registration handle before the assertions below.
+    await worker.stop();
+
+    expect(events.indexOf("roster-delete")).toBeLessThan(
+      events.indexOf("teardown-complete"),
+    );
+    expect(reportSpy).not.toHaveBeenCalled();
+    // The run-settle heartbeat fired AFTER deregister was latched out: the
+    // delete is the LAST roster write — no resurrection upsert follows it.
+    expect(settled[settled.length - 1]).toBe("delete");
+  });
+
+  it("always runs shutdownPool even when worker.stop() rejects (the rejection still surfaces)", async () => {
+    // A1: `stop()` is the BEST-EFFORT teardown phase — a rejecting stop must
+    // not strand the pool's chromium processes (PID-ceiling compounding). The
+    // pool shutdown ALWAYS runs; the stop rejection is surfaced to the caller
+    // (the signal handler logs it via signal-drain-failed), never swallowed.
+    const shutdownPool = vi.fn(async () => {});
+    const registration = {
+      stop: vi.fn(),
+      deregister: vi.fn(async () => {}),
+    };
+    const worker = {
+      drain: vi.fn(),
+      stop: vi.fn(async () => {
+        throw new Error("teardown exploded");
+      }),
+    };
+
+    await expect(
+      drainFleetWorker({ worker, registration, shutdownPool }),
+    ).rejects.toThrow("teardown exploded");
+    // Deregister (unconditional) ran before the failed teardown…
+    expect(registration.deregister).toHaveBeenCalledTimes(1);
+    // …and the pool shutdown still ran despite the stop rejection.
+    expect(shutdownPool).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the stop() error — not the pool error — when BOTH stop and shutdownPool reject", async () => {
+    // A bare `finally { await shutdownPool() }` MASKS the stop rejection with
+    // the pool one when both reject (the later throw wins), contra the
+    // surfacing contract above. The stop error is the primary failure: the
+    // pool failure is logged best-effort and the stop error is the one thrown.
+    const shutdownPool = vi.fn(async () => {
+      throw new Error("pool exploded");
+    });
+    const registration = {
+      stop: vi.fn(),
+      deregister: vi.fn(async () => {}),
+    };
+    const worker = {
+      drain: vi.fn(),
+      stop: vi.fn(async () => {
+        throw new Error("teardown exploded");
+      }),
+    };
+
+    await expect(
+      drainFleetWorker({ worker, registration, shutdownPool }),
+    ).rejects.toThrow("teardown exploded");
+    expect(shutdownPool).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds a HUNG deregister: teardown and pool shutdown are still reached at DRAIN_DEREGISTER_TIMEOUT_MS", async () => {
+    // A HUNG — not failing — PocketBase must not consume Railway's ~10s kill
+    // window: the deregister await is raced against a bound; on timeout the
+    // drain logs `fleet.worker.deregister-timeout` and PROCEEDS to teardown
+    // (the roster row strands, degrading to the documented crash-path
+    // reclaim). Pre-fix this drain hung forever on the unresolved deregister.
+    vi.useFakeTimers();
+    try {
+      const shutdownPool = vi.fn(async () => {});
+      const stop = vi.fn(async () => {});
+      const registration = {
+        stop: vi.fn(),
+        // Never settles — the wedged-PB stand-in.
+        deregister: vi.fn(() => new Promise<void>(() => {})),
+      };
+
+      const drainPromise = drainFleetWorker({
+        worker: { drain: vi.fn(), stop },
+        registration,
+        shutdownPool,
+      });
+      await vi.advanceTimersByTimeAsync(DRAIN_DEREGISTER_TIMEOUT_MS);
+      await expect(drainPromise).resolves.toBeUndefined();
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(shutdownPool).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a deregister that rejects AFTER the timeout wins never surfaces as an unhandled rejection (race losers stay subscribed)", async () => {
+    // EMPIRICAL PIN of the ECMAScript Promise.race semantics this drain (and
+    // the loop's stop() grace race) relies on — repeatedly re-flagged in
+    // review, so this test is the standing refutation: `Promise.race`
+    // SUBSCRIBES to every input when it is constructed, so a LOSER that
+    // rejects after the winner settled is a HANDLED rejection (consumed by
+    // the race's own subscription), never an unhandled one. vitest surfaces
+    // unhandled rejections as failures, so the pin is non-vacuous: the test
+    // deliberately attaches NO handler of its own to the losing deregister —
+    // if the race did not keep it subscribed, the late rejection below would
+    // fail this run.
+    vi.useFakeTimers();
+    let rejectDeregister!: (err: Error) => void;
+    try {
+      const shutdownPool = vi.fn(async () => {});
+      const registration = {
+        stop: vi.fn(),
+        // Hangs past the cap, then REJECTS only after the timeout arm won.
+        deregister: vi.fn(
+          () =>
+            new Promise<void>((_resolve, reject) => {
+              rejectDeregister = reject;
+            }),
+        ),
+      };
+
+      const drainPromise = drainFleetWorker({
+        worker: { drain: vi.fn(), stop: vi.fn(async () => {}) },
+        registration,
+        shutdownPool,
+      });
+      // The deregister cap elapses → the timeout arm wins and the drain runs
+      // through teardown to completion.
+      await vi.advanceTimersByTimeAsync(DRAIN_DEREGISTER_TIMEOUT_MS);
+      await expect(drainPromise).resolves.toBeUndefined();
+      expect(shutdownPool).toHaveBeenCalledTimes(1);
+      // NOW the losing deregister rejects, 50ms after the race settled.
+      await vi.advanceTimersByTimeAsync(50);
+      rejectDeregister(new Error("post-timeout deregister rejection"));
+    } finally {
+      vi.useRealTimers();
+    }
+    // Give the would-be unhandledRejection a real macrotask turn to surface —
+    // an unsubscribed loser would fail the run here, not pass silently.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  });
+
+  it("a THROWING structural drain()/registration.stop() never skips the roster delete (log-and-proceed)", async () => {
+    // `worker.drain()` and `registration.stop()` are structural handles — the
+    // REAL ones never throw, but drainFleetWorker sits on the SIGTERM
+    // critical path, so a throwing caller-supplied handle gets the same
+    // log-and-proceed discipline as deregister: the roster delete is the ONLY
+    // step that must beat the platform kill, and a throw upstream of it must
+    // not abort the drain sequence. Pre-fix both calls were unguarded — a
+    // throw here escaped drainFleetWorker before deregister ever ran.
+    const shutdownPool = vi.fn(async () => {});
+    const stop = vi.fn(async () => {});
+    const registration = {
+      stop: vi.fn(() => {
+        throw new Error("registration.stop exploded");
+      }),
+      deregister: vi.fn(async () => {}),
+    };
+    const worker = {
+      drain: vi.fn(() => {
+        throw new Error("drain exploded");
+      }),
+      stop,
+    };
+
+    await expect(
+      drainFleetWorker({ worker, registration, shutdownPool }),
+    ).resolves.toBeUndefined();
+    // The roster delete still landed despite BOTH structural steps throwing…
+    expect(registration.deregister).toHaveBeenCalledTimes(1);
+    // …and the best-effort teardown phases still ran, in order.
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(shutdownPool).toHaveBeenCalledTimes(1);
+  });
+
+  it("a THROWING logger.warn inside the drain's catch blocks never skips the roster delete or teardown", async () => {
+    // The failing component may BE the logger: the structural-throw catches
+    // above LOG before proceeding, so an unguarded logger.warn inside either
+    // pre-deregister catch would escape drainFleetWorker before the roster
+    // delete ever ran — the exact failure class requestDrain() already
+    // guards with its abort-before-log discipline. The post-deregister warns
+    // are guarded the same way so the teardown phases stay reachable too.
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {
+      throw new Error("logger exploded");
+    });
+    try {
+      const shutdownPool = vi.fn(async () => {});
+      const stop = vi.fn(async () => {});
+      const registration = {
+        stop: vi.fn(() => {
+          throw new Error("registration.stop exploded");
+        }),
+        deregister: vi.fn(async () => {}),
+      };
+      const worker = {
+        drain: vi.fn(() => {
+          throw new Error("drain exploded");
+        }),
+        stop,
+      };
+
+      await expect(
+        drainFleetWorker({ worker, registration, shutdownPool }),
+      ).resolves.toBeUndefined();
+      // The roster delete still landed despite BOTH structural steps throwing
+      // AND the logger throwing inside both catch blocks…
+      expect(registration.deregister).toHaveBeenCalledTimes(1);
+      // …and the best-effort teardown phases still ran, in order.
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(shutdownPool).toHaveBeenCalledTimes(1);
+      // The warns were ATTEMPTED (forensics stay best-effort, not skipped).
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("a REJECTING deregister (structural-contract caller) degrades like the timeout: teardown still runs", async () => {
+    // registration.ts's deregister() contract is never-reject (failed deletes
+    // are swallowed + warned there) — but drainFleetWorker takes a structural
+    // `{ deregister(): Promise<void> }`, so a caller-supplied handle that DOES
+    // reject must degrade the same way the hang does: proceed to teardown.
+    const shutdownPool = vi.fn(async () => {});
+    const stop = vi.fn(async () => {});
+    const registration = {
+      stop: vi.fn(),
+      deregister: vi.fn(async () => {
+        throw new Error("pb exploded");
+      }),
+    };
+
+    await expect(
+      drainFleetWorker({
+        worker: { drain: vi.fn(), stop },
+        registration,
+        shutdownPool,
+      }),
+    ).resolves.toBeUndefined();
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(shutdownPool).toHaveBeenCalledTimes(1);
+  });
+
+  it("idle drain (no in-flight job): deregister still precedes teardown, abandons nothing, completes promptly", async () => {
+    vi.stubEnv("WORKER_DRAIN_GRACE_MS", "200");
+    const events: string[] = [];
+    const { pb, deletes } = makeRegPb(() => events.push("roster-delete"));
+    // A queue that never has work — the worker stays idle the whole time.
+    const queue: FleetQueueClient = {
+      ...makeDrainQueue(),
+      claimNext: async () => ({ claimed: false }),
+    };
+    const run = vi.fn(async (): Promise<ProbeResult> => {
+      throw new Error("driver must never run on an idle drain");
+    });
+    const info = vi.fn();
+    const recordingLogger = { ...silentFleetLogger, info };
+
+    const worker = await runFleetWorker(fleetConfig, {
+      queue,
+      workerId: "worker-drain-idle",
+      skipHealthServer: true,
+      budgetSource,
+      driver: { run },
+      payloadToInput: () => ({ key: "d6:langgraph-python" }),
+      logger: recordingLogger,
+      env: {},
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+    const registration = await registerWorker({
+      pb,
+      pool: budgetSource,
+      logger: silentFleetLogger,
+      workerId: "worker-drain-idle",
+      endpoint: "http://worker-drain-idle:8080",
+      setIntervalImpl: (() => 0) as unknown as typeof setInterval,
+    });
+
+    // An idle drain has nothing to wait on: it must complete promptly (well
+    // under the grace), with the same deregister-before-teardown ordering.
+    await expect(
+      Promise.race([
+        drainFleetWorker({
+          worker,
+          registration,
+          shutdownPool: async () => {
+            events.push("pool-shutdown");
+          },
+        }),
+        new Promise<never>((_res, rej) =>
+          setTimeout(
+            () => rej(new Error("idle drain did not complete promptly")),
+            1000,
+          ),
+        ),
+      ]),
+    ).resolves.toBeUndefined();
+
+    expect(run).not.toHaveBeenCalled();
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0]!.filter).toContain("worker-drain-idle");
+    expect(events).toEqual(["roster-delete", "pool-shutdown"]);
+    // The abandon decision records NO job — the worker was idle.
+    expect(info).toHaveBeenCalledWith("fleet.worker.drain-requested", {
+      workerId: "worker-drain-idle",
+      abandoningJobId: null,
+    });
   });
 });
 

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -94,6 +94,10 @@ import {
   E2E_DEMOS_DRIVER_KIND,
   E2E_SMOKE_DRIVER_KIND,
 } from "./fleet/worker/payload-mapper.js";
+import {
+  DRAIN_DEREGISTER_TIMEOUT_MS,
+  safeLog,
+} from "./fleet/worker/worker-loop.js";
 import type { DriverRegistry } from "./fleet/worker/worker-loop.js";
 import { registerWorker } from "./fleet/worker/registration.js";
 import {
@@ -3185,6 +3189,175 @@ export async function verifyWorkerRegistered(deps: {
 }
 
 /**
+ * GRACEFUL-DRAIN STOP SEQUENCE for the fleet worker role — deregister FIRST,
+ * teardown best-effort AFTER (the platform-kill hardening).
+ *
+ * WHY THIS ORDER: live Railway redeploys showed the platform's stop grace
+ * (~10s after SIGTERM) is SHORTER than the drain grace the worker shipped
+ * with (WORKER_DRAIN_GRACE_MS — grace history: 25s at the 2026-06-10 live
+ * incident → an 8s interim → the composed 6s default, so the SERIAL
+ * deregister-cap + grace budget fits UNDER the platform window). The
+ * previous sequence
+ * (`await worker.stop()`
+ * → deregister) gated the <1s roster delete on slow browser-context teardown:
+ * workers stuck in teardown were HARD-KILLED before deregistering, stranding
+ * stale roster rows that fleet-health reclaimed red at its 180s stale mark —
+ * the exact deploy red-splash the drain was built to remove. Abandon +
+ * deregister take <1s; teardown is best-effort on a process that is dying
+ * anyway (a SIGKILL mid-teardown is harmless once the roster row is gone).
+ *
+ *   1. `worker.drain()` — SYNCHRONOUS: fires the loop's drain signal, aborting
+ *      the in-flight run and recording the abandon decision
+ *      (`fleet.worker.drain-requested` with the abandoned jobId). The loop's
+ *      report-skip keys on the SIGNAL — not on `stop()` completing — so a run
+ *      that has not begun reporting can never be reported, even if a wedged
+ *      teardown later "completes" the run; its lease lapses and the sweeper
+ *      re-queues it neutral-gray (unchanged abandon semantics). (A report the
+ *      loop already initiated before the signal is past the abandon point and
+ *      may land — it is not recorded as abandoned.)
+ *   2. `registration.stop()` — cancel the periodic heartbeat timer so no
+ *      further periodic upsert can follow the delete.
+ *   3. `await registration.deregister()` — latch the handle (every later
+ *      heartbeat, including the abandoned run's eventual fire-and-forget
+ *      job-settle beat, becomes a logged no-op) and DELETE the roster row as
+ *      the terminal link of the handle's write-serialization chain (any
+ *      already-enqueued upsert settles first). This await is the ONLY step
+ *      that must beat the platform kill — and it no longer gates on teardown.
+ *      It is BOUNDED at `DRAIN_DEREGISTER_TIMEOUT_MS`: the real
+ *      registration.ts `deregister()` NEVER REJECTS (failed deletes are
+ *      swallowed + warned there), but it can HANG on a wedged PocketBase —
+ *      and a hang must not consume the platform's ~10s kill window. On
+ *      timeout (or a rejecting deregister from a structural-contract caller)
+ *      the drain logs and proceeds to teardown; the row strands, degrading to
+ *      the documented crash-path reclaim.
+ *   4. `await worker.stop()` — BEST-EFFORT teardown, bounded by the loop's
+ *      drain grace (WORKER_DRAIN_GRACE_MS now bounds this phase only): waits
+ *      for the in-flight run/loop to wind down (a wedged driver detaches at
+ *      grace expiry), then the fleet wrapper closes its health server. A
+ *      rejecting stop() still surfaces to the caller — but only AFTER step 5.
+ *   5. `shutdownPool()` — still last, and ALWAYS runs even when stop()
+ *      rejects (a stop failure must never strand the pool's chromium
+ *      processes); the caller owns the pool. The stop error is captured and
+ *      re-thrown AFTER the shutdown, and a shutdown failure is logged rather
+ *      than thrown so it can never mask the stop error.
+ *
+ * Crash path (process died, no deregister) keeps today's red reclaim —
+ * deregistration remains the marker distinguishing a graceful drain from a
+ * crash. Exported because the ORDERING is the fix — orchestrator.test.ts pins
+ * it against the real fleet worker + registration handles.
+ */
+// DRAIN_DEREGISTER_TIMEOUT_MS lives in the LEAF module
+// (fleet/worker/worker-loop.ts, next to DEFAULT_WORKER_DRAIN_GRACE_MS and the
+// composed-budget doc) so worker-loop.test.ts can pin the composed drain
+// budget without importing this module's whole graph; re-exported here for
+// existing importers (orchestrator.test.ts pins the drain ordering with it).
+export { DRAIN_DEREGISTER_TIMEOUT_MS };
+
+export async function drainFleetWorker(args: {
+  worker: { drain(): void; stop(): Promise<void> };
+  registration: { stop(): void; deregister(): Promise<void> };
+  shutdownPool: () => Promise<void>;
+}): Promise<void> {
+  // EVERY log on this path is guarded: when a catch block here is logging,
+  // the failing component may BE the logger — an unguarded warn inside a
+  // pre-deregister catch would escape drainFleetWorker before the roster
+  // delete ever ran (the exact failure class requestDrain() already guards
+  // with its abort-before-log discipline), and one inside a post-deregister
+  // catch would strand the teardown phases behind it. Forensics are
+  // best-effort; the drain sequence is load-bearing. Delegates to the shared
+  // guarded-log helper (`safeLog`, fleet/worker/worker-loop.ts) — one
+  // implementation of the discipline, bound to this module's logger.
+  const safeWarn = (
+    msg: string,
+    meta: Record<string, unknown>,
+    level: "warn" | "error" = "warn",
+  ): void => safeLog(logger, level, msg, meta);
+  // Steps 1–2 are STRUCTURAL handles (the real ones never throw), but this is
+  // the SIGTERM critical path: a throwing caller-supplied handle upstream of
+  // the roster delete must NOT skip it — same log-and-proceed discipline as
+  // the deregister below.
+  try {
+    args.worker.drain();
+  } catch (err) {
+    safeWarn("fleet.worker.drain-failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+  try {
+    args.registration.stop();
+  } catch (err) {
+    safeWarn("fleet.worker.registration-stop-failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+  // BOUNDED deregister: a HUNG — not failing — PocketBase must not consume
+  // Railway's ~10s kill window (the teardown + pool shutdown behind this
+  // await would never run before the SIGKILL). registration.ts's
+  // `deregister()` contract is never-reject (failed deletes are swallowed +
+  // warned there), so the catch is for STRUCTURAL callers that supply their
+  // own `{ deregister(): Promise<void> }` handle; both degradations proceed
+  // to teardown — the roster row strands into the documented crash-path
+  // reclaim (fleet-health reclaims the stale row at its 180s mark).
+  let deregisterTimer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const outcome = await Promise.race([
+      args.registration.deregister().then(() => "deregistered" as const),
+      new Promise<"timeout">((resolve) => {
+        deregisterTimer = setTimeout(
+          () => resolve("timeout"),
+          DRAIN_DEREGISTER_TIMEOUT_MS,
+        );
+        if (
+          typeof (deregisterTimer as { unref?: () => void }).unref ===
+          "function"
+        ) {
+          (deregisterTimer as { unref: () => void }).unref();
+        }
+      }),
+    ]);
+    if (outcome === "timeout") {
+      safeWarn("fleet.worker.deregister-timeout", {
+        timeoutMs: DRAIN_DEREGISTER_TIMEOUT_MS,
+      });
+    }
+  } catch (err) {
+    safeWarn("fleet.worker.deregister-failed", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  } finally {
+    if (deregisterTimer !== undefined) clearTimeout(deregisterTimer);
+  }
+  // stop() is BEST-EFFORT teardown — its rejection must not strand the pool's
+  // chromium processes (PID-ceiling compounding), so the pool shutdown ALWAYS
+  // runs. The stop error is CAPTURED rather than left to a bare
+  // `finally { await shutdownPool() }`: if the shutdown ALSO rejected, the
+  // finally's throw would MASK the stop error. The shutdown failure is logged
+  // best-effort; the stop error is the one re-surfaced to the caller (the
+  // signal handler logs it via signal-drain-failed) rather than being
+  // swallowed here.
+  let stopFailed = false;
+  let stopError: unknown;
+  try {
+    await args.worker.stop();
+  } catch (err) {
+    stopFailed = true;
+    stopError = err;
+  }
+  await args.shutdownPool().catch((err) => {
+    // Guarded at error level: a throwing logger inside this catch handler
+    // would reject the awaited chain and mask the captured stop error.
+    safeWarn(
+      "fleet.worker.pool-shutdown-failed-after-stop",
+      {
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "error",
+    );
+  });
+  if (stopFailed) throw stopError;
+}
+
+/**
  * Worker role entrypoint: runs the BrowserPool and pulls per-service jobs from
  * the control-plane queue.
  *
@@ -3449,9 +3622,21 @@ export async function runWorker(
     });
   } catch (err) {
     // Never strand the registration heartbeat or the pool's chromium processes
-    // if the loop fails to start.
+    // if the loop fails to start. The shutdown is best-effort but LOGGED
+    // (consistent with the drain path's pool-shutdown logging) — an empty
+    // catch would hide WHY chromium processes were left stranded behind the
+    // boot failure. The original boot error still rethrows below.
     registration.stop();
-    await pool.shutdown().catch(() => {});
+    await pool.shutdown().catch((shutdownErr) => {
+      logger.error("showcase-harness.fleet.worker.pool-shutdown-failed", {
+        workerId,
+        phase: "worker-boot-failed",
+        err:
+          shutdownErr instanceof Error
+            ? shutdownErr.message
+            : String(shutdownErr),
+      });
+    });
     throw err;
   }
 
@@ -3459,48 +3644,36 @@ export async function runWorker(
     port: worker.port,
     bus: worker.bus,
     async stop(): Promise<void> {
-      // GRACEFUL-DRAIN STOP ORDERING (FIX 3). The order matters because the
-      // final job-settle heartbeat is FIRE-AND-FORGET (`void
-      // registration.heartbeat(...)` above), so `await worker.stop()` resolving
-      // guarantees that heartbeat was CALLED, not that its PB upsert COMPLETED.
-      //   1. `worker.stop()` — drains/aborts the in-flight run (the loop threads
-      //      its drain signal into the driver ctx, the driver suppresses red
-      //      side-emits, and the loop SKIPS reporting the partial so the lease
-      //      lapses into the sweeper's neutral-gray re-queue). Its settle fires
-      //      the LAST possible (fire-and-forget) `onCurrentJobChange(null)`
-      //      heartbeat upsert.
-      //   2. `registration.stop()` — cancel the periodic heartbeat timer so no
-      //      further periodic upsert can follow the delete.
-      //   3. `registration.deregister()` — AWAIT the handle's tracked in-flight
-      //      write (so the still-in-flight job-settle upsert from step 1 lands
-      //      FIRST), THEN best-effort DELETE this worker's registry row. With no
-      //      row, fleet-health never reclaims a gracefully-drained worker red at
-      //      its 180s stale window; the abandoned job reaches the 300s lease
-      //      expiry where the sweeper re-queues it neutral-gray. The no-re-upsert
-      //      guarantee lives in the HANDLE (the awaited in-flight write), NOT in
-      //      this ordering — the reorder only narrows the race window. Crash path
-      //      (process died, no deregister) keeps today's red reclaim.
-      //   4. `pool.shutdown()` — unchanged (still last). We injected BOTH
-      //      budgetSource and driver, so fleet runWorker did NOT construct its
-      //      own pool — WE own it and shut it down here.
-      await worker.stop();
-      registration.stop();
-      await registration.deregister();
-      await pool.shutdown().catch((err) => {
-        logger.error("showcase-harness.fleet.worker.pool-shutdown-failed", {
-          workerId,
-          err: err instanceof Error ? err.message : String(err),
-        });
-        // CVDIAG: the worker's pool shutdown threw — chromium processes may be
-        // stranded. Surface the swallowed error with the worker_id.
-        console.log(
-          formatCvdiag({
-            component: "harness-orchestrator:worker-pool-shutdown-failed",
-            boundary: "als-snapshot",
-            status: "error",
-            error: `workerId=${workerId} ${err instanceof Error ? err.message : String(err)}`,
+      // DEREGISTER-FIRST GRACEFUL DRAIN — see `drainFleetWorker` for the full
+      // ordering rationale (the platform kill grace is shorter than the drain
+      // grace, so the <1s abandon + roster delete must NOT gate on slow
+      // browser-context teardown). The no-re-upsert guarantee lives in the
+      // registration HANDLE (deregister latches synchronously, and the delete
+      // is the terminal link of its write-serialization chain), so the
+      // abandoned run's eventual fire-and-forget job-settle heartbeat —
+      // which now fires AFTER the delete — is latched into a logged no-op.
+      // We injected BOTH budgetSource and drivers, so fleet runWorker did NOT
+      // construct its own pool — WE own it and shut it down here (last).
+      await drainFleetWorker({
+        worker,
+        registration,
+        shutdownPool: () =>
+          pool.shutdown().catch((err) => {
+            logger.error("showcase-harness.fleet.worker.pool-shutdown-failed", {
+              workerId,
+              err: err instanceof Error ? err.message : String(err),
+            });
+            // CVDIAG: the worker's pool shutdown threw — chromium processes may
+            // be stranded. Surface the swallowed error with the worker_id.
+            console.log(
+              formatCvdiag({
+                component: "harness-orchestrator:worker-pool-shutdown-failed",
+                boundary: "als-snapshot",
+                status: "error",
+                error: `workerId=${workerId} ${err instanceof Error ? err.message : String(err)}`,
+              }),
+            );
           }),
-        );
       });
     },
   };


### PR DESCRIPTION
## Summary

- Live staging redeploy evidence (2026-06-10 16:37Z): 2/6 workers completed the full SIGTERM → abandon → deregister sequence in **under 1 second**, while 4/6 were SIGKILLed mid-browser-teardown because Railway's ~10s stop grace is shorter than the old 25s drain budget — leaving 4 stale roster rows and a reclaim splash on every deploy.
- This PR makes abandon + deregister the **guarded, sub-second critical path** and demotes teardown to best-effort within a composed <10s budget, so a platform kill mid-teardown is harmless.

## Design

- `drainFleetWorker` ordering: drain → `registration.stop` → bounded deregister → graced `worker.stop` → always-run pool shutdown, with stop-error precedence (a pool-shutdown failure can never mask the stop error).
- `DRAIN_DEREGISTER_TIMEOUT_MS` (3s) bounds the **whole registration write chain**, so a hung—not failing—PocketBase cannot consume the kill window; timeout degrades to the documented crash-path reclaim.
- `safeLog` guards every loop/stop/drain-path log: a throwing logger can neither reject the worker loop's done-promise nor skip the roster delete or teardown (abort-before-log in `requestDrain`; structural-caller guards in `drainFleetWorker`).
- Drain-aware lease renewal (an abandoned job's lease lapses instead of being re-extended), mid-drain claim skip (a claim won after the drain decision is never run), and mid-report precision (a run that began reporting is never logged as abandoned).
- Never-throws loop closure: loop-crash logging via `done.catch` + `/health` 503, heartbeat and idle-poll sleep hardening with a non-busy pacing floor, aggregate-key protocol-violation wrap.
- `WORKER_DRAIN_GRACE_MS` default 25s → 6s; the composed 3+6 < 10s budget is **pinned by a test**; present-but-invalid overrides warn; overrides at/above ~7s are documented as forfeiting the composed budget.
- Boot-failure teardown catches now log (no silent chromium stranding).

## Review

- 6 unbiased 7-agent CR rounds + 5 fix rounds; every behavioral change red-green or mutation-proven; `Promise.race` loser semantics empirically pinned by test.
- ~30 pre-existing harness findings deferred to the flap-fix follow-up backlog (top of the next fleet-robustness PR: lease-renew retry-on-throw, empty-registry guard/dispatch mismatch, `registered`-flag refresh, worker `/health` async bind race, queue fetch timeouts).

## Test plan

- [x] 2176/2176 vitest (32 new tests)
- [x] `tsc --noEmit` both configs
- [x] oxfmt clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)