### PR TITLE
fix(runtime): coalesce consecutive same-role Anthropic messages before dispatch

### DIFF
--- a/.changeset/coalesce-anthropic-same-role-messages.md
+++ b/.changeset/coalesce-anthropic-same-role-messages.md
@@ -1,0 +1,9 @@
+---
+"@copilotkit/runtime": patch
+---
+
+fix(runtime): coalesce consecutive same-role Anthropic messages before dispatch
+
+Fixes multi-turn conversations with Anthropic where a text + tool_use turn produced
+two consecutive assistant messages in the API payload, violating role-alternation and
+causing subsequent assistant responses to appear appended to the previous message.

--- a/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
+++ b/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
@@ -33,6 +33,7 @@ import {
 import {
   convertActionInputToAnthropicTool,
   convertMessageToAnthropicMessage,
+  coalesceConsecutiveSameRoleMessages,
   limitMessagesToTokenCount,
 } from "./utils";
 
@@ -326,9 +327,15 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
         return true;
       }) as Anthropic.Messages.MessageParam[];
 
+    // Coalesce consecutive same-role messages so the Anthropic API receives alternating turns.
+    // A mixed text+tool_use response is stored as separate TextMessage / ActionExecutionMessage
+    // objects; they must be merged into one assistant message before dispatch.
+    const coalescedMessages =
+      coalesceConsecutiveSameRoleMessages(anthropicMessages);
+
     // Apply token limits
     const limitedMessages = limitMessagesToTokenCount(
-      anthropicMessages,
+      coalescedMessages,
       tools,
       model,
       this.maxInputTokens,
@@ -345,7 +352,7 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
     );
 
     // We'll check if we need a fallback response after seeing what Anthropic returns
-    // We skip grouping by role since we've already ensured uniqueness of tool_results
+    // Role alternation is now enforced by coalesceConsecutiveSameRoleMessages above.
 
     let toolChoice: any = forwardedParameters?.toolChoice;
     if (forwardedParameters?.toolChoice === "function") {

--- a/packages/runtime/src/service-adapters/anthropic/utils.ts
+++ b/packages/runtime/src/service-adapters/anthropic/utils.ts
@@ -217,3 +217,35 @@ export function convertMessageToAnthropicMessage(
     };
   }
 }
+
+/**
+ * Anthropic's Messages API requires alternating user/assistant roles.
+ * CopilotKit stores a mixed text+tool_use response as separate TextMessage and
+ * ActionExecutionMessage objects, which map to two consecutive assistant-role entries.
+ * This function merges consecutive same-role messages by concatenating their content
+ * arrays so the payload satisfies Anthropic's role-alternation constraint.
+ */
+export function coalesceConsecutiveSameRoleMessages(
+  messages: Anthropic.Messages.MessageParam[],
+): Anthropic.Messages.MessageParam[] {
+  const result: Anthropic.Messages.MessageParam[] = [];
+  for (const msg of messages) {
+    const prev = result[result.length - 1];
+    if (
+      prev &&
+      prev.role === msg.role &&
+      Array.isArray(prev.content) &&
+      Array.isArray(msg.content)
+    ) {
+      (prev.content as any[]).push(...(msg.content as any[]));
+    } else {
+      result.push({
+        ...msg,
+        content: Array.isArray(msg.content)
+          ? [...(msg.content as any[])]
+          : msg.content,
+      });
+    }
+  }
+  return result;
+}

--- a/packages/runtime/tests/service-adapters/anthropic/anthropic-adapter.test.ts
+++ b/packages/runtime/tests/service-adapters/anthropic/anthropic-adapter.test.ts
@@ -685,3 +685,119 @@ describe("AnthropicAdapter max_tokens default", () => {
     expect(createCallArgs.max_tokens).toBe(8192);
   });
 });
+
+describe("AnthropicAdapter - same-role coalescing", () => {
+  let adapter: AnthropicAdapter;
+  let mockAnthropicCreate: any;
+  let mockEventSource: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const mockAnthropic = { messages: { create: vi.fn() } };
+    adapter = new AnthropicAdapter({ anthropic: mockAnthropic as any });
+    mockAnthropicCreate = mockAnthropic.messages.create;
+    mockAnthropicCreate.mockResolvedValue({
+      [Symbol.asyncIterator]: async function* () {},
+    });
+    mockEventSource = {
+      stream: vi.fn((cb) => {
+        cb({
+          sendTextMessageStart: vi.fn(),
+          sendTextMessageContent: vi.fn(),
+          sendTextMessageEnd: vi.fn(),
+          sendActionExecutionStart: vi.fn(),
+          sendActionExecutionArgs: vi.fn(),
+          sendActionExecutionEnd: vi.fn(),
+          complete: vi.fn(),
+        });
+        return Promise.resolve();
+      }),
+    };
+  });
+
+  it("merges TextMessage(assistant) + ActionExecutionMessage into a single Anthropic assistant message", async () => {
+    const systemMsg = new TextMessage("system", "You are a helpful assistant.");
+    const userMsg = new TextMessage("user", "Look something up for me.");
+    // A prior assistant turn that had both a text preamble and a tool call.
+    // CopilotKit stores these as separate messages.
+    const assistantText = new TextMessage("assistant", "Let me check that.");
+    const toolExec = new ActionExecutionMessage({
+      id: "tool-abc",
+      name: "lookup",
+      arguments: { query: "example" },
+    });
+    const toolResult = new ResultMessage({
+      actionExecutionId: "tool-abc",
+      result: "Found it.",
+    });
+    const userFollowUp = new TextMessage("user", "Thanks, what did you find?");
+
+    await adapter.process({
+      threadId: "t1",
+      messages: [
+        systemMsg,
+        userMsg,
+        assistantText,
+        toolExec,
+        toolResult,
+        userFollowUp,
+      ],
+      actions: [
+        {
+          name: "lookup",
+          description: "look up",
+          parameters: [],
+          jsonSchema: '{"type":"object","properties":{}}',
+        },
+      ],
+      eventSource: mockEventSource,
+      forwardedParameters: {},
+    });
+
+    const sentMessages: any[] = mockAnthropicCreate.mock.calls[0][0].messages;
+
+    // Find all assistant messages
+    const assistantMessages = sentMessages.filter(
+      (m: any) => m.role === "assistant",
+    );
+
+    // There must be exactly ONE assistant message for the text+tool turn (merged)
+    expect(assistantMessages).toHaveLength(1);
+
+    // That single assistant message must contain both a text block and a tool_use block
+    const blocks = assistantMessages[0].content as any[];
+    const textBlocks = blocks.filter((b: any) => b.type === "text");
+    const toolUseBlocks = blocks.filter((b: any) => b.type === "tool_use");
+    expect(textBlocks).toHaveLength(1);
+    expect(textBlocks[0].text).toBe("Let me check that.");
+    expect(toolUseBlocks).toHaveLength(1);
+    expect(toolUseBlocks[0].id).toBe("tool-abc");
+
+    // Confirm no two consecutive messages share the same role
+    for (let i = 1; i < sentMessages.length; i++) {
+      expect(sentMessages[i].role).not.toBe(sentMessages[i - 1].role);
+    }
+  });
+
+  it("does not merge alternating user/assistant messages (no regression)", async () => {
+    const systemMsg = new TextMessage("system", "You are helpful.");
+    const user1 = new TextMessage("user", "Hi");
+    const asst1 = new TextMessage("assistant", "Hello!");
+    const user2 = new TextMessage("user", "How are you?");
+
+    await adapter.process({
+      threadId: "t2",
+      messages: [systemMsg, user1, asst1, user2],
+      actions: [],
+      eventSource: mockEventSource,
+      forwardedParameters: {},
+    });
+
+    const sentMessages: any[] = mockAnthropicCreate.mock.calls[0][0].messages;
+    // Expect three messages: user, assistant, user — unchanged
+    expect(sentMessages).toHaveLength(3);
+    expect(sentMessages[0].role).toBe("user");
+    expect(sentMessages[1].role).toBe("assistant");
+    expect(sentMessages[2].role).toBe("user");
+  });
+});

--- a/packages/runtime/tests/service-adapters/anthropic/anthropic-adapter.test.ts
+++ b/packages/runtime/tests/service-adapters/anthropic/anthropic-adapter.test.ts
@@ -716,11 +716,20 @@ describe("AnthropicAdapter - same-role coalescing", () => {
   });
 
   it("merges TextMessage(assistant) + ActionExecutionMessage into a single Anthropic assistant message", async () => {
-    const systemMsg = new TextMessage("system", "You are a helpful assistant.");
-    const userMsg = new TextMessage("user", "Look something up for me.");
+    const systemMsg = new TextMessage({
+      role: Role.system,
+      content: "You are a helpful assistant.",
+    });
+    const userMsg = new TextMessage({
+      role: Role.user,
+      content: "Look something up for me.",
+    });
     // A prior assistant turn that had both a text preamble and a tool call.
     // CopilotKit stores these as separate messages.
-    const assistantText = new TextMessage("assistant", "Let me check that.");
+    const assistantText = new TextMessage({
+      role: Role.assistant,
+      content: "Let me check that.",
+    });
     const toolExec = new ActionExecutionMessage({
       id: "tool-abc",
       name: "lookup",
@@ -730,7 +739,10 @@ describe("AnthropicAdapter - same-role coalescing", () => {
       actionExecutionId: "tool-abc",
       result: "Found it.",
     });
-    const userFollowUp = new TextMessage("user", "Thanks, what did you find?");
+    const userFollowUp = new TextMessage({
+      role: Role.user,
+      content: "Thanks, what did you find?",
+    });
 
     await adapter.process({
       threadId: "t1",
@@ -746,7 +758,6 @@ describe("AnthropicAdapter - same-role coalescing", () => {
         {
           name: "lookup",
           description: "look up",
-          parameters: [],
           jsonSchema: '{"type":"object","properties":{}}',
         },
       ],
@@ -780,10 +791,19 @@ describe("AnthropicAdapter - same-role coalescing", () => {
   });
 
   it("does not merge alternating user/assistant messages (no regression)", async () => {
-    const systemMsg = new TextMessage("system", "You are helpful.");
-    const user1 = new TextMessage("user", "Hi");
-    const asst1 = new TextMessage("assistant", "Hello!");
-    const user2 = new TextMessage("user", "How are you?");
+    const systemMsg = new TextMessage({
+      role: Role.system,
+      content: "You are helpful.",
+    });
+    const user1 = new TextMessage({ role: Role.user, content: "Hi" });
+    const asst1 = new TextMessage({
+      role: Role.assistant,
+      content: "Hello!",
+    });
+    const user2 = new TextMessage({
+      role: Role.user,
+      content: "How are you?",
+    });
 
     await adapter.process({
       threadId: "t2",


### PR DESCRIPTION
## Summary

In multi-turn conversations using the Anthropic adapter, a model turn that contains both assistant text and a tool call can be replayed as two consecutive `{role: "assistant"}` entries in the Anthropic payload. Anthropic expects one message object per turn with alternating roles, so that split payload can blur turn boundaries on the next request. This PR coalesces same-role Anthropic messages before dispatch so one assistant turn stays one assistant message.

## Root cause

[`convertMessageToAnthropicMessage`](https://github.com/CopilotKit/CopilotKit/blob/005aebbededbfdd7978b3c1ee221580b74dd088d/packages/runtime/src/service-adapters/anthropic/utils.ts#L142-L219)
maps each CopilotKit message independently. A mixed assistant turn, a `TextMessage(role=assistant)` followed by an `ActionExecutionMessage`, therefore becomes two separate assistant entries. The Anthropic Messages API requires all content blocks for one assistant turn to be sent in a single message object: https://docs.anthropic.com/en/api/messages

[`AnthropicAdapter.process()`](https://github.com/CopilotKit/CopilotKit/blob/005aebbededbfdd7978b3c1ee221580b74dd088d/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts#L282-L366)
already deduplicates `tool_result` blocks on the user side, but it previously forwarded the mapped assistant-side payload without a coalescing pass. Rebasing onto current `main` also exposed test-fixture drift in the two new regression tests, so the final branch updates those fixtures to the current object-form `TextMessage` constructor and removes one stale `ActionInput` field while keeping the production fix unchanged.

## Changes

- `packages/runtime/src/service-adapters/anthropic/utils.ts`: add
  `coalesceConsecutiveSameRoleMessages(messages)` to merge adjacent equal-role
  Anthropic messages by concatenating their `content` arrays.
- `packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts`: call
  `coalesceConsecutiveSameRoleMessages` before `limitMessagesToTokenCount`.
- `packages/runtime/tests/service-adapters/anthropic/anthropic-adapter.test.ts`:
  add same-role regression coverage, align the new fixtures with the current
  object-form `TextMessage` constructor, and remove the stale `parameters` field
  from the action fixture.
- `.changeset/coalesce-anthropic-same-role-messages.md`: patch changeset for
  `@copilotkit/runtime`.

## Scope

The `tool_result` allowlist deduplication stays unchanged. Token trimming and the orphan-removal post-processor still run after coalescing, so `tool_use` and `tool_result` pairing remains intact. The OpenAI, Google, LangChain, and Groq adapters are unaffected.

The reported regression and the explicit regression coverage are assistant-side. The coalescing helper itself is role-agnostic for adjacent equal-role array content, but this PR does not add a separate user-side regression case.

## Related PRs and Issues

Prior attempted fix: #2864, which addressed unrelated message callbacks rather than the adapter payload.

## Test plan

- [x] `pnpm -C packages/runtime exec vitest run tests/service-adapters/anthropic/anthropic-adapter.test.ts`
  10/10 tests pass, including the two same-role coalescing cases.
- [x] `pnpm -C packages/runtime exec vitest run tests/service-adapters/anthropic/utils-token-trimming.test.ts`
  9/9 tests pass.
- [ ] CI green (`static / quality`, `test / unit` on Node 20/22/24)

## Upstream

Closes #2910.
Reported by @alonronin.
