### PR TITLE
feat(react-core): accept threadId in useAgent options

### DIFF
--- a/.changeset/use-agent-thread-id-option.md
+++ b/.changeset/use-agent-thread-id-option.md
@@ -1,0 +1,8 @@
+---
+"@copilotkit/react-core": minor
+---
+
+feat(react-core): accept threadId in useAgent options
+
+Headless callers can now pin the agent to a specific thread without
+manually setting agent.threadId after each render.

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent.e2e.test.tsx
@@ -1,8 +1,14 @@
-import React from "react";
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import React, { useState } from "react";
+import {
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  render,
+} from "@testing-library/react";
 import { describe, it, expect } from "vitest";
-import { type BaseEvent, type RunAgentInput } from "@ag-ui/client";
-import { Observable } from "rxjs";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
+import type { Observable } from "rxjs";
 import {
   MockStepwiseAgent,
   renderWithCopilotKit,
@@ -14,6 +20,8 @@ import {
 import { useAgent } from "../use-agent";
 import { useCopilotKit } from "../../providers/CopilotKitProvider";
 import { CopilotChat } from "../../components/chat/CopilotChat";
+import { CopilotKitProvider } from "../../providers/CopilotKitProvider";
+import { CopilotChatConfigurationProvider } from "../../providers/CopilotChatConfigurationProvider";
 
 /**
  * Mock agent that captures RunAgentInput to verify state is passed correctly
@@ -153,6 +161,77 @@ describe("useAgent e2e", () => {
         expect(
           screen.getByText("Hello! I received your message."),
         ).toBeDefined();
+      });
+    });
+  });
+
+  describe("threadId prop", () => {
+    it("sets agent.threadId from the prop on mount", async () => {
+      const agent = new MockStepwiseAgent();
+      let capturedAgent: typeof agent | undefined;
+
+      function ThreadIdTestComponent() {
+        const { agent: hookAgent } = useAgent({ threadId: "thread-abc" });
+        capturedAgent = hookAgent;
+        return <div data-testid="ready">ready</div>;
+      }
+
+      // Render without providing a config-level threadId to isolate the prop behavior
+      render(
+        <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+          <CopilotChatConfigurationProvider agentId="default">
+            <ThreadIdTestComponent />
+          </CopilotChatConfigurationProvider>
+        </CopilotKitProvider>,
+      );
+      await screen.findByTestId("ready");
+      expect(capturedAgent?.threadId).toBe("thread-abc");
+    });
+
+    it("updates agent.threadId when the prop changes", async () => {
+      const agent = new MockStepwiseAgent();
+      let capturedAgent: typeof agent | undefined;
+
+      function ThreadIdTestComponent() {
+        const [threadId, setThreadId] = useState<string>("thread-initial");
+        const { agent: hookAgent } = useAgent({ threadId });
+        capturedAgent = hookAgent;
+
+        return (
+          <div>
+            <div data-testid="ready">ready</div>
+            <button
+              data-testid="update-thread"
+              onClick={() => setThreadId("thread-updated")}
+            >
+              Update Thread
+            </button>
+            <div data-testid="current-thread">{threadId}</div>
+          </div>
+        );
+      }
+
+      render(
+        <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+          <CopilotChatConfigurationProvider agentId="default">
+            <ThreadIdTestComponent />
+          </CopilotChatConfigurationProvider>
+        </CopilotKitProvider>,
+      );
+      await screen.findByTestId("ready");
+
+      // Check initial threadId
+      expect(capturedAgent?.threadId).toBe("thread-initial");
+
+      // Click button to update threadId
+      const updateBtn = await screen.findByTestId("update-thread");
+      await act(async () => {
+        fireEvent.click(updateBtn);
+      });
+
+      // Wait for the threadId to update on the agent
+      await waitFor(() => {
+        expect(capturedAgent?.threadId).toBe("thread-updated");
       });
     });
   });

--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -48,9 +48,26 @@ export interface UseAgentProps {
    * if that is also unset, the effective value is `0` (no throttle).
    */
   throttleMs?: number;
+  /**
+   * Optional thread ID to associate with this agent instance.
+   * When provided, the agent's `threadId` is set (or updated) to this value
+   * after each render, routing all runs and message persistence to that thread.
+   *
+   * Useful in headless usage where no `CopilotChat` component is mounted to
+   * supply the thread ID automatically via `CopilotChatConfigurationProvider`.
+   *
+   * @example
+   * const { agent } = useAgent({ agentId: "my-agent", threadId: "session-xyz" });
+   */
+  threadId?: string;
 }
 
-export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
+export function useAgent({
+  agentId,
+  updates,
+  throttleMs,
+  threadId,
+}: UseAgentProps = {}) {
   agentId ??= DEFAULT_AGENT_ID;
 
   const { copilotkit } = useCopilotKit();
@@ -222,6 +239,14 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agent, JSON.stringify(copilotkit.headers)]);
+
+  // Apply the caller-supplied threadId to the agent. This is the headless
+  // equivalent of the chat-config sync below: when no CopilotChatConfigurationProvider
+  // is in the tree, this is the only path for a threadId to reach the agent.
+  useEffect(() => {
+    if (!threadId) return;
+    agent.threadId = threadId;
+  }, [agent, threadId]);
 
   // Propagate the caller-supplied threadId from the chat configuration onto
   // the agent. AbstractAgent's constructor auto-mints a UUID when no threadId


### PR DESCRIPTION
## Summary

Adds optional `threadId` support to the `useAgent` hook, enabling headless callers to associate an agent with a specific thread without manually patching `agent.threadId` after each render. When a caller provides a `threadId` prop to `useAgent`, the agent's thread is pinned to that value, routing all runs and message persistence to the specified thread.

## Root cause

`useAgent({ agentId })` in headless mode (without a wrapping `CopilotChat`/`CopilotSidebar` component) ignores any desired thread ID. The agent's `AbstractAgent.threadId` is auto-minted as a random UUID at construction and never synced to a caller-supplied value. Users must manually set `agent.threadId = desiredId` before each `copilotkit.runAgent()` call — a pattern the docs do not describe and UI components handle automatically via `CopilotChatConfigurationProvider`.

## Changes

### 1. Add `threadId` prop to `UseAgentProps` (packages/react-core/src/v2/hooks/use-agent.tsx)

- Added optional `threadId?: string` field to the props interface with JSDoc explaining headless usage.
- Updated the function signature to destructure `threadId`.

### 2. Apply caller-supplied threadId in a new useEffect

- Inserted a new effect after the headers-sync effect that sets `agent.threadId = threadId` when the prop is provided.
- Placed before the existing chat-config sync so the provider value can override if both are present (design intent: explicit provider config wins).

### 3. Add test coverage (packages/react-core/src/v2/hooks/__tests__/use-agent.e2e.test.tsx)

New test suite "threadId prop" with two tests:
- **"sets agent.threadId from the prop on mount"**: Verifies that when `useAgent({ threadId: "thread-abc" })` is called, `agent.threadId` equals the supplied value after render.
- **"updates agent.threadId when the prop changes"**: Verifies that when the threadId prop is updated via state change, `agent.threadId` reflects the new value.

Tests use a custom render setup without a config-provided threadId to isolate the prop's behavior.

### 4. Write changeset (`.changeset/use-agent-thread-id-option.md`)

Changesets entry for `@copilotkit/react-core` as a minor version bump (new optional public API).

## What is NOT changed

- The existing chat-config threadId sync (lines 234–240) is unchanged.
- When both a prop threadId and a `CopilotChatConfigurationProvider`-sourced thread ID are present, the provider value wins (it runs last in effect order).
- `CopilotChat`, `CopilotSidebar`, `CopilotChatConfigurationProvider`, and `ThreadsProvider` are untouched.
- No behavior changes to existing components or v1 bridges.
- Python SDK and LangGraph parity are not in scope.

## Test plan

- [x] **use-agent.e2e.test.tsx**: 4/4 tests pass. Tests verify that the `threadId` prop is applied to the agent on mount and updated when the prop changes (no `runAgent` calls needed; direct inspection of `agent.threadId` is sufficient).
- [x] **use-agent-stability.test.tsx**: 4/4 tests pass. Existing stability tests remain unaffected.
- [x] Code formatted with oxfmt and linted with oxlint (zero errors, zero warnings in modified test file).
- [ ] CI green (`static / quality`, `test / unit` on Node 20/22/24)

## Notes

- The implementation mirrors the existing chat-config threadId sync pattern but at the hook's prop level, providing the headless equivalent.
- Effect order ensures provider-level config takes precedence when both paths are active (e.g., nested `useAgent` inside a `CopilotChat` subtree).
