### PR TITLE
fix(release): emit version/scope to GITHUB_OUTPUT from prerelease publishes

### DIFF
--- a/scripts/release/lib/github-output.test.ts
+++ b/scripts/release/lib/github-output.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { emitGithubOutputs } from "./github-output.js";
+
+let tmpDir: string;
+let outputFile: string;
+const originalGithubOutput = process.env.GITHUB_OUTPUT;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gh-output-"));
+  outputFile = path.join(tmpDir, "output");
+  fs.writeFileSync(outputFile, "");
+  process.env.GITHUB_OUTPUT = outputFile;
+});
+
+afterEach(() => {
+  if (originalGithubOutput === undefined) {
+    delete process.env.GITHUB_OUTPUT;
+  } else {
+    process.env.GITHUB_OUTPUT = originalGithubOutput;
+  }
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("emitGithubOutputs", () => {
+  it("appends key=value lines to the GITHUB_OUTPUT file", () => {
+    emitGithubOutputs({ version: "1.2.3-canary.42", scope: "monorepo" });
+
+    expect(fs.readFileSync(outputFile, "utf8")).toBe(
+      "version=1.2.3-canary.42\nscope=monorepo\n",
+    );
+  });
+
+  it("appends without truncating prior outputs", () => {
+    fs.writeFileSync(outputFile, "earlier=value\n");
+
+    emitGithubOutputs({ version: "1.2.3" });
+
+    expect(fs.readFileSync(outputFile, "utf8")).toBe(
+      "earlier=value\nversion=1.2.3\n",
+    );
+  });
+
+  it("is a no-op when GITHUB_OUTPUT is unset", () => {
+    delete process.env.GITHUB_OUTPUT;
+
+    expect(() => emitGithubOutputs({ version: "1.2.3" })).not.toThrow();
+    expect(fs.readFileSync(outputFile, "utf8")).toBe("");
+  });
+});

--- a/scripts/release/lib/github-output.test.ts
+++ b/scripts/release/lib/github-output.test.ts
@@ -16,13 +16,14 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Restore spies first so they cannot leak into the env/fs cleanup below.
+  vi.restoreAllMocks();
   if (originalGithubOutput === undefined) {
     delete process.env.GITHUB_OUTPUT;
   } else {
     process.env.GITHUB_OUTPUT = originalGithubOutput;
   }
   fs.rmSync(tmpDir, { recursive: true, force: true });
-  vi.restoreAllMocks();
 });
 
 describe("emitGithubOutputs", () => {
@@ -64,7 +65,29 @@ describe("emitGithubOutputs", () => {
 
   it("throws when a key contains a newline", () => {
     expect(() => emitGithubOutputs({ "bad\nkey": "value" })).toThrow(
-      /bad\\nkey/,
+      /alphanumeric/,
     );
+  });
+
+  it("throws when a key contains '='", () => {
+    expect(() => emitGithubOutputs({ "bad=key": "value" })).toThrow(
+      /alphanumeric/,
+    );
+  });
+
+  it("throws when a key contains a space", () => {
+    expect(() => emitGithubOutputs({ "bad key": "value" })).toThrow(
+      /alphanumeric/,
+    );
+  });
+
+  it("throws when a key is empty", () => {
+    expect(() => emitGithubOutputs({ "": "value" })).toThrow(/alphanumeric/);
+  });
+
+  it("accepts a value containing '=' and writes it verbatim", () => {
+    emitGithubOutputs({ note: "a=b" });
+
+    expect(fs.readFileSync(outputFile, "utf8")).toBe("note=a=b\n");
   });
 });

--- a/scripts/release/lib/github-output.test.ts
+++ b/scripts/release/lib/github-output.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs";
 import path from "path";
 import os from "os";
@@ -22,6 +22,7 @@ afterEach(() => {
     process.env.GITHUB_OUTPUT = originalGithubOutput;
   }
   fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
 });
 
 describe("emitGithubOutputs", () => {
@@ -45,8 +46,25 @@ describe("emitGithubOutputs", () => {
 
   it("is a no-op when GITHUB_OUTPUT is unset", () => {
     delete process.env.GITHUB_OUTPUT;
+    const appendSpy = vi.spyOn(fs, "appendFileSync");
 
     expect(() => emitGithubOutputs({ version: "1.2.3" })).not.toThrow();
-    expect(fs.readFileSync(outputFile, "utf8")).toBe("");
+    expect(appendSpy).not.toHaveBeenCalled();
+  });
+
+  it("throws when a value contains a newline, naming the offending key", () => {
+    expect(() =>
+      emitGithubOutputs({ version: "1.2.3\nmalicious=evil" }),
+    ).toThrow(/version/);
+  });
+
+  it("throws when a value contains a carriage return", () => {
+    expect(() => emitGithubOutputs({ version: "1.2.3\r" })).toThrow(/version/);
+  });
+
+  it("throws when a key contains a newline", () => {
+    expect(() => emitGithubOutputs({ "bad\nkey": "value" })).toThrow(
+      /bad\\nkey/,
+    );
   });
 });

--- a/scripts/release/lib/github-output.ts
+++ b/scripts/release/lib/github-output.ts
@@ -7,8 +7,25 @@ import fs from "fs";
  * and the downstream summary/tag steps read `steps.publish.outputs.version`
  * (and `scope`), so every publish script must emit these after publishing.
  * No-op outside CI (GITHUB_OUTPUT unset), e.g. when running locally.
+ *
+ * Keys and values must be single-line: the helper throws if any contains a
+ * newline or carriage return, since GITHUB_OUTPUT's `key=value` form cannot
+ * carry newlines (multi-line values would need the heredoc form, which this
+ * helper deliberately does not support).
  */
 export function emitGithubOutputs(outputs: Record<string, string>): void {
+  for (const [key, value] of Object.entries(outputs)) {
+    if (/[\n\r]/.test(key)) {
+      throw new Error(
+        `emitGithubOutputs: key ${JSON.stringify(key)} contains a newline or carriage return; GITHUB_OUTPUT's key=value form cannot carry newlines (multi-line values would need the heredoc form, which this helper deliberately does not support).`,
+      );
+    }
+    if (/[\n\r]/.test(value)) {
+      throw new Error(
+        `emitGithubOutputs: value for key ${JSON.stringify(key)} contains a newline or carriage return; GITHUB_OUTPUT's key=value form cannot carry newlines (multi-line values would need the heredoc form, which this helper deliberately does not support).`,
+      );
+    }
+  }
   const outputPath = process.env.GITHUB_OUTPUT;
   if (!outputPath) return;
   const lines = Object.entries(outputs)

--- a/scripts/release/lib/github-output.ts
+++ b/scripts/release/lib/github-output.ts
@@ -8,16 +8,17 @@ import fs from "fs";
  * (and `scope`), so every publish script must emit these after publishing.
  * No-op outside CI (GITHUB_OUTPUT unset), e.g. when running locally.
  *
- * Keys and values must be single-line: the helper throws if any contains a
- * newline or carriage return, since GITHUB_OUTPUT's `key=value` form cannot
- * carry newlines (multi-line values would need the heredoc form, which this
- * helper deliberately does not support).
+ * Keys must match GitHub Actions' safe output-name shape
+ * (`/^[A-Za-z_][A-Za-z0-9_-]*$/`); values must be single-line (no newline or
+ * carriage return), since GITHUB_OUTPUT's `key=value` form splits on the first
+ * `=` and cannot carry newlines (multi-line values would need the heredoc
+ * form, which this helper deliberately does not support).
  */
 export function emitGithubOutputs(outputs: Record<string, string>): void {
   for (const [key, value] of Object.entries(outputs)) {
-    if (/[\n\r]/.test(key)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_-]*$/.test(key)) {
       throw new Error(
-        `emitGithubOutputs: key ${JSON.stringify(key)} contains a newline or carriage return; GITHUB_OUTPUT's key=value form cannot carry newlines (multi-line values would need the heredoc form, which this helper deliberately does not support).`,
+        `emitGithubOutputs: key ${JSON.stringify(key)} is not a valid GitHub Actions output name; keys must be alphanumeric/underscore/dash and start with a letter or underscore.`,
       );
     }
     if (/[\n\r]/.test(value)) {

--- a/scripts/release/lib/github-output.ts
+++ b/scripts/release/lib/github-output.ts
@@ -1,0 +1,18 @@
+import fs from "fs";
+
+/**
+ * Append step outputs to the file GitHub Actions exposes via GITHUB_OUTPUT.
+ *
+ * The publish-release workflow's "Verify publish step emitted version" guard
+ * and the downstream summary/tag steps read `steps.publish.outputs.version`
+ * (and `scope`), so every publish script must emit these after publishing.
+ * No-op outside CI (GITHUB_OUTPUT unset), e.g. when running locally.
+ */
+export function emitGithubOutputs(outputs: Record<string, string>): void {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  const lines = Object.entries(outputs)
+    .map(([key, value]) => `${key}=${value}\n`)
+    .join("");
+  fs.appendFileSync(outputPath, lines);
+}

--- a/scripts/release/prerelease.ts
+++ b/scripts/release/prerelease.ts
@@ -41,7 +41,7 @@ function main() {
 
   if (!scope || !VALID_SCOPES.includes(scope)) {
     console.error(
-      `Usage: prerelease.ts --scope <${VALID_SCOPES.join("|")}> [--suffix <label>] [--dry-run]`,
+      `Usage: prerelease.ts --scope <${VALID_SCOPES.join("|")}> [--dry-run]`,
     );
     process.exit(1);
   }
@@ -52,6 +52,12 @@ function main() {
   // Read the version from package.json — already bumped by bump-prerelease.ts
   // in the CI build job.
   const packages = getPackagesForScope(scope);
+  if (packages.length === 0) {
+    console.error(
+      `No packages found for scope "${scope}" — refusing to emit a version for a publish that did nothing.`,
+    );
+    process.exit(1);
+  }
   const publishVersion = packages[0]?.pkg.version ?? getCurrentVersion(scope);
   console.log(`Scope: ${scope}`);
   console.log(`Publishing version: ${publishVersion}`);

--- a/scripts/release/prerelease.ts
+++ b/scripts/release/prerelease.ts
@@ -12,7 +12,9 @@
 
 import { spawnSync } from "child_process";
 import { getCurrentVersion, getPackagesForScope } from "./lib/versions.js";
-import { ROOT, loadConfig, type ReleaseScope } from "./lib/config.js";
+import { ROOT, loadConfig } from "./lib/config.js";
+import type { ReleaseScope } from "./lib/config.js";
+import { emitGithubOutputs } from "./lib/github-output.js";
 
 function run(cmd: string, args: string[], opts?: { cwd?: string }) {
   const result = spawnSync(cmd, args, {
@@ -60,6 +62,7 @@ function main() {
     for (const p of packages) {
       console.log(`  ${p.name}@${p.pkg.version}`);
     }
+    emitGithubOutputs({ version: publishVersion, scope });
     console.log("\n[DRY RUN] Exiting.");
     return;
   }
@@ -93,6 +96,10 @@ function main() {
       { cwd: p.dir },
     );
   }
+
+  // The workflow's "Verify publish step emitted version" guard and the
+  // prerelease summary read these from steps.publish.outputs.
+  emitGithubOutputs({ version: publishVersion, scope });
 
   console.log(`\nPrerelease published: ${publishVersion} (tag: ${distTag})`);
 }

--- a/scripts/release/prerelease.ts
+++ b/scripts/release/prerelease.ts
@@ -11,7 +11,7 @@
  */
 
 import { spawnSync } from "child_process";
-import { getCurrentVersion, getPackagesForScope } from "./lib/versions.js";
+import { getPackagesForScope } from "./lib/versions.js";
 import { ROOT, loadConfig } from "./lib/config.js";
 import type { ReleaseScope } from "./lib/config.js";
 import { emitGithubOutputs } from "./lib/github-output.js";
@@ -58,7 +58,13 @@ function main() {
     );
     process.exit(1);
   }
-  const publishVersion = packages[0]?.pkg.version ?? getCurrentVersion(scope);
+  const publishVersion = packages[0].pkg.version;
+  if (!publishVersion) {
+    console.error(
+      `Package ${packages[0].name} has no version field; refusing to publish.`,
+    );
+    process.exit(1);
+  }
   console.log(`Scope: ${scope}`);
   console.log(`Publishing version: ${publishVersion}`);
   console.log(`Dist tag: ${distTag}`);
@@ -68,6 +74,9 @@ function main() {
     for (const p of packages) {
       console.log(`  ${p.name}@${p.pkg.version}`);
     }
+    // Emitting in dry-run is safe — the publish workflow gates both the
+    // publish step and the verify guard on `inputs.dry-run != true`, so this
+    // only serves local/e2e verification of the output contract.
     emitGithubOutputs({ version: publishVersion, scope });
     console.log("\n[DRY RUN] Exiting.");
     return;

--- a/scripts/release/publish-release.ts
+++ b/scripts/release/publish-release.ts
@@ -161,9 +161,16 @@ async function main() {
   // npm 11 uses GitHub Actions OIDC tokens for auth when id-token: write
   // is granted, eliminating the need for long-lived NPM_TOKEN secrets.
   // Skips packages already published at this version (idempotent retries).
+  const packages = getPackagesForScope(scope);
+  if (packages.length === 0) {
+    console.error(
+      `No packages found for scope "${scope}" — refusing to emit a version for a publish that did nothing.`,
+    );
+    process.exit(1);
+  }
   console.log("\nPublishing packages...");
   let skipped = 0;
-  for (const p of getPackagesForScope(scope)) {
+  for (const p of packages) {
     const pubVersion = getPublishedVersion(p.name);
     if (pubVersion === version) {
       console.log(`  Skipping ${p.name}@${version} (already published)`);

--- a/scripts/release/publish-release.ts
+++ b/scripts/release/publish-release.ts
@@ -34,6 +34,7 @@ import {
   loadConfig,
   type ReleaseScope,
 } from "./lib/config.js";
+import { emitGithubOutputs } from "./lib/github-output.js";
 
 function run(cmd: string, args: string[], opts?: { cwd?: string }) {
   const result = spawnSync(cmd, args, {
@@ -192,11 +193,7 @@ async function main() {
   }
 
   // Output version for downstream steps
-  const outputPath = process.env.GITHUB_OUTPUT;
-  if (outputPath) {
-    fs.appendFileSync(outputPath, `version=${version}\n`);
-    fs.appendFileSync(outputPath, `scope=${scope}\n`);
-  }
+  emitGithubOutputs({ version, scope });
 
   console.log(`\nRelease published: ${version} (${scope})`);
 }

--- a/scripts/release/publish-release.ts
+++ b/scripts/release/publish-release.ts
@@ -96,6 +96,18 @@ async function main() {
 
   const version = getCurrentVersion(scope);
   const scopeConfig = getScopeConfig(scope);
+
+  // Resolve packages before any version/registry safety checks so that a
+  // misconfigured scope fails with a clear "no packages" error instead of a
+  // misleading "not greater than published" one.
+  const packages = getPackagesForScope(scope);
+  if (packages.length === 0) {
+    console.error(
+      `No packages found for scope "${scope}" — refusing to emit a version for a publish that did nothing.`,
+    );
+    process.exit(1);
+  }
+
   console.log(`Scope: ${scope}`);
   console.log(`Publishing version: ${version}`);
 
@@ -161,13 +173,6 @@ async function main() {
   // npm 11 uses GitHub Actions OIDC tokens for auth when id-token: write
   // is granted, eliminating the need for long-lived NPM_TOKEN secrets.
   // Skips packages already published at this version (idempotent retries).
-  const packages = getPackagesForScope(scope);
-  if (packages.length === 0) {
-    console.error(
-      `No packages found for scope "${scope}" — refusing to emit a version for a publish that did nothing.`,
-    );
-    process.exit(1);
-  }
   console.log("\nPublishing packages...");
   let skipped = 0;
   for (const p of packages) {


### PR DESCRIPTION
## Summary

Canary dispatches of `release / publish` always ended **red after a successful npm publish**: `prerelease.ts` published every package but never wrote `version` to `$GITHUB_OUTPUT`, so the workflow's "Verify publish step emitted version" guard aborted (see [run 27286564989](https://github.com/CopilotKit/CopilotKit/actions/runs/27286564989) — all packages live at `1.59.5-canary.1781104893`, run concluded failure).

- Extract the `GITHUB_OUTPUT` append (previously inline in `publish-release.ts`) into a shared `scripts/release/lib/github-output.ts` helper; both publish scripts now emit `version`/`scope`.
- The helper validates its inputs structurally: GHA-safe key charset (`/^[A-Za-z_][A-Za-z0-9_-]*$/` — a key with `=`/spaces would silently corrupt the `key=value` line) and single-line values (newline/CR throws; `=` in values is legal). Validation runs before the no-`GITHUB_OUTPUT` early return so caller bugs fail loudly even locally.
- Fail-loud guards: both scripts now refuse to proceed on an **empty package list** (previously `prerelease.ts` would have emitted a version for a publish that did nothing — the new emission would otherwise have *weakened* the guard for that case); `prerelease.ts` errors on a missing `version` field instead of silently falling back; `publish-release.ts`'s guard sits above the registry checks so a misconfigured scope reports "no packages" instead of a misleading version error.
- Removed the advertised-but-unparsed `[--suffix]` from `prerelease.ts`'s usage string (suffix handling lives in `bump-prerelease.ts`).

## Validation

- 95/95 release-script tests green (`vitest --config scripts/release/vitest.config.mts`); new helper covered incl. red-green-verified throw paths for newline values and malformed keys.
- E2E: `GITHUB_OUTPUT=$(mktemp) pnpm release:prerelease:dry` → file contains `version=1.59.5` / `scope=monorepo`.
- 3-round 7-agent CR loop converged (final round zero in-scope findings).

## Follow-ups surfaced during review (pre-existing, separate PR: "release scripts hardening")

`prerelease.ts` lacks already-published skip logic (retries die on E409 after partial publish); `isGreaterVersion` ignores prerelease ordering (a canary on `latest` blocks the same-triplet stable); the versionSource "not greater" guard contradicts per-package idempotent retries; `getPublishedVersion` E404 string-matching, unpinned host npm, ignored `result.error`, empty-stdout-as-unpublished; tarball names reconstructed instead of read from `pnpm pack --json` (and `publish-release.ts` uses scope version where `prerelease.ts` uses per-package); Notion catch conflates config vs API failures and silent-skips; no per-package version-skew assertion before emitting a single version; `VALID_SCOPES` not derived from `ReleaseScope`; `--scope=value` form unsupported; `run()` drops `result.error` detail.

## Test plan

- [ ] CI green
- [ ] Next canary dispatch ends green with the version visible in the run summary