### PR TITLE
fix(shell-docs): record location on hero_command_copied for surface attribution

### DIFF
--- a/showcase/shell-docs/src/components/__tests__/hero-start-commands.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/hero-start-commands.test.tsx
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const heroStartCommandsSource = readFileSync(
+  new URL("../hero-start-commands.tsx", import.meta.url),
+  "utf8",
+);
+
+// `hero_command_copied` fires alongside the global <CopyTracker>'s
+// `cli_command_copied` for the same copy. The sibling records
+// `location: window.location.pathname`; this event must carry the same
+// dimension so the two are joinable — and because `location` is the only
+// surface signal that distinguishes the `onboard` card across the home hero
+// and the framework landing heroes (its command is identical everywhere).
+// shell-docs vitest runs in the `node` environment with no jsdom/RTL, so this
+// asserts the capture shape at the source level, matching the suite's
+// convention (see brand-nav.test.tsx).
+describe("hero_command_copied analytics", () => {
+  it("captures the hero_command_copied event", () => {
+    expect(heroStartCommandsSource).toContain(
+      'posthog?.capture("hero_command_copied"',
+    );
+  });
+
+  it("records a location dimension joinable with cli_command_copied", () => {
+    expect(heroStartCommandsSource).toContain("location:");
+    expect(heroStartCommandsSource).toContain("window.location.pathname");
+  });
+
+  it("guards the location read for SSR, mirroring the CopyTracker sibling", () => {
+    expect(heroStartCommandsSource).toContain('typeof window !== "undefined"');
+  });
+});

--- a/showcase/shell-docs/src/components/hero-start-commands.tsx
+++ b/showcase/shell-docs/src/components/hero-start-commands.tsx
@@ -100,12 +100,23 @@ function CommandCard({
     // so this intentionally uses a different event name to avoid
     // double-counting that funnel. `command` is page content (bounded
     // cardinality: bare + one variant per CLI framework), not user input.
+    //
+    // `location` mirrors the pathname `cli_command_copied` records, so the two
+    // paired events join on the same dimension. It's the only surface signal
+    // for the `onboard` card, whose command is byte-identical on the home hero
+    // and every framework landing hero (only `create` embeds the framework in
+    // `command`). Guarded for SSR to match the <CopyTracker> sibling, though
+    // onCopy only runs from a browser click.
     const trackHeroCopy = (clipboardBlocked: boolean) => {
       try {
         posthog?.capture("hero_command_copied", {
           command_id: id,
           command,
           clipboard_blocked: clipboardBlocked,
+          location:
+            typeof window !== "undefined"
+              ? window.location.pathname
+              : undefined,
         });
       } catch {
         // Never let analytics break the copy interaction.


### PR DESCRIPTION
Closes [OSS-299](https://linear.app/copilotkit/issue/OSS-299).

Follow-up to #5248 (already merged).

## Problem

The `hero_command_copied` PostHog event added in #5248 (`showcase/shell-docs/src/components/hero-start-commands.tsx`) carries no surface discriminator. `HeroStartActions` renders on **both** the home hero and **every** framework landing hero:

- The **create** card embeds the framework in `command` (`--framework langgraph-js`), so it's recoverable.
- The **onboard** card's command (`npx copilotkit@latest skills onboard`) is byte-identical on every page — so onboard copies **cannot** be attributed to a surface from the event alone.

Every sibling event in shell-docs already carries a "where" property — `cli_command_copied` → `location: window.location.pathname`, the nav events → `location`, `markdown_copied`/`open_in_llm_clicked` → `path`. `hero_command_copied` was the only one without one.

## Fix

Add `location: window.location.pathname` to the `hero_command_copied` payload, mirroring the `cli_command_copied` event the global `<CopyTracker>` already emits for the same copy (verified: it monkeypatches `navigator.clipboard.writeText`, which the hero calls). The two paired events now join cleanly on the same dimension. Guarded for SSR (`typeof window !== "undefined"`) to match the sibling.

## Test

Adds a colocated source-assertion guard test. shell-docs vitest runs in the `node` environment (no jsdom/RTL), so this follows the suite's existing convention (`readFileSync` + assertions, like `brand-nav.test.tsx`) rather than introducing a behavioral render harness.

```
✓ src/components/__tests__/hero-start-commands.test.tsx (3 tests)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)