### PR TITLE
docs(packages): scrub Copilot Cloud / client license-key prop from SDK doc references

### DIFF
--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -37,7 +37,6 @@ import { provideCopilotKit } from "@copilotkitnext/angular";
 export const appConfig: ApplicationConfig = {
   providers: [
     provideCopilotKit({
-      licenseKey: "ck_pub_your_license_key",
       runtimeUrl: "http://localhost:3001/api/copilotkit",
       headers: { Authorization: "Bearer ..." },
       properties: { app: "demo" },
@@ -121,7 +120,6 @@ export interface CopilotKitConfig {
 
 - `runtimeUrl`: URL to your CopilotKit runtime.
 - `headers`: Default headers sent to the runtime.
-- `licenseKey`: CopilotKit public license key (`ck_pub_...`), required by `provideCopilotKit`. Get one with `npx copilotkit@latest license`.
 - `properties`: Arbitrary props forwarded to agent runs.
 - `agents`: Local, in-browser agents keyed by `agentId`.
 - `tools`: Tool definitions advertised to the runtime (no handler).
@@ -289,7 +287,6 @@ registerHumanInTheLoop({
 
 ```ts
 provideCopilotKit({
-  licenseKey: "ck_pub_your_license_key",
   frontendTools: [
     /* FrontendToolConfig[] */
   ],

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -37,7 +37,7 @@ import { provideCopilotKit } from "@copilotkitnext/angular";
 export const appConfig: ApplicationConfig = {
   providers: [
     provideCopilotKit({
-      licenseKey: "ck_pub_your_public_api_key",
+      licenseKey: "ck_pub_your_license_key",
       runtimeUrl: "http://localhost:3001/api/copilotkit",
       headers: { Authorization: "Bearer ..." },
       properties: { app: "demo" },
@@ -121,7 +121,7 @@ export interface CopilotKitConfig {
 
 - `runtimeUrl`: URL to your CopilotKit runtime.
 - `headers`: Default headers sent to the runtime.
-- `licenseKey`: Copilot Cloud public API key (`ck_pub_...`), required by `provideCopilotKit`.
+- `licenseKey`: CopilotKit public license key (`ck_pub_...`), required by `provideCopilotKit`. Get one with `npx copilotkit@latest license`.
 - `properties`: Arbitrary props forwarded to agent runs.
 - `agents`: Local, in-browser agents keyed by `agentId`.
 - `tools`: Tool definitions advertised to the runtime (no handler).
@@ -289,7 +289,7 @@ registerHumanInTheLoop({
 
 ```ts
 provideCopilotKit({
-  licenseKey: "ck_pub_your_public_api_key",
+  licenseKey: "ck_pub_your_license_key",
   frontendTools: [
     /* FrontendToolConfig[] */
   ],

--- a/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -18,16 +18,18 @@ export interface CopilotKitProps extends Omit<
   "children"
 > {
   /**
-   * Your Copilot Cloud API key.
+   * Your CopilotKit public license key. Prefer `publicLicenseKey` in new code.
    *
-   * Don't have it yet? Go to https://dashboard.operations.copilotkit.ai and get one for free.
+   * Don't have one yet? Run `npx copilotkit@latest license`, or copy it from the
+   * dashboard at https://dashboard.operations.copilotkit.ai.
    */
   publicApiKey?: string;
 
   /**
    * Your public license key for accessing premium CopilotKit features.
    *
-   * Don't have it yet? Go to https://dashboard.operations.copilotkit.ai and get one for free.
+   * Don't have one yet? Run `npx copilotkit@latest license`, or copy it from the
+   * dashboard at https://dashboard.operations.copilotkit.ai.
    */
   publicLicenseKey?: string;
 
@@ -40,12 +42,7 @@ export interface CopilotKitProps extends Omit<
     invalidTopics?: string[];
   };
 
-  /**
-   * Restrict input to specific topics using guardrails.
-   * @remarks
-   *
-   * This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://dashboard.operations.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
-   */
+  /** @internal Defunct — retained for backward compatibility. */
   guardrails_c?: {
     validTopics?: string[];
     invalidTopics?: string[];
@@ -152,12 +149,7 @@ export interface CopilotKitProps extends Omit<
    */
   forwardedParameters?: Pick<ForwardedParametersInput, "temperature">;
 
-  /**
-   * The auth config to use for the CopilotKit.
-   * @remarks
-   *
-   * This feature is only available when using CopilotKit's hosted cloud service. To use this feature, sign up at https://dashboard.operations.copilotkit.ai to get your publicApiKey. The feature allows restricting chat conversations to specific topics.
-   */
+  /** @internal Defunct — retained for backward compatibility. */
   authConfig_c?: {
     SignInComponent: React.ComponentType<{
       onSignInComplete: (authState: AuthState) => void;
@@ -172,15 +164,15 @@ export interface CopilotKitProps extends Omit<
   /**
    * Optional error handler for comprehensive debugging and observability.
    *
-   * **Requires publicApiKey**: Error handling only works when publicApiKey is provided.
-   * This is a premium Copilot Cloud feature.
+   * **Requires a license key**: Error handling only works when a public license key is provided.
+   * This is a premium feature.
    *
    * @param errorEvent - Structured error event with rich debugging context
    *
    * @example
    * ```typescript
    * <CopilotKit
-   *   publicApiKey="ck_pub_your_key"
+   *   publicLicenseKey="ck_pub_your_key"
    *   onError={(errorEvent) => {
    *     debugDashboard.capture(errorEvent);
    *   }}

--- a/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit-props.tsx
@@ -17,20 +17,10 @@ export interface CopilotKitProps extends Omit<
   CopilotKitProviderProps,
   "children"
 > {
-  /**
-   * Your CopilotKit public license key. Prefer `publicLicenseKey` in new code.
-   *
-   * Don't have one yet? Run `npx copilotkit@latest license`, or copy it from the
-   * dashboard at https://dashboard.operations.copilotkit.ai.
-   */
+  /** Your CopilotKit public license key. */
   publicApiKey?: string;
 
-  /**
-   * Your public license key for accessing premium CopilotKit features.
-   *
-   * Don't have one yet? Run `npx copilotkit@latest license`, or copy it from the
-   * dashboard at https://dashboard.operations.copilotkit.ai.
-   */
+  /** Your public license key for accessing premium CopilotKit features. */
   publicLicenseKey?: string;
 
   /**
@@ -164,15 +154,11 @@ export interface CopilotKitProps extends Omit<
   /**
    * Optional error handler for comprehensive debugging and observability.
    *
-   * **Requires a license key**: Error handling only works when a public license key is provided.
-   * This is a premium feature.
-   *
    * @param errorEvent - Structured error event with rich debugging context
    *
    * @example
    * ```typescript
    * <CopilotKit
-   *   publicLicenseKey="ck_pub_your_key"
    *   onError={(errorEvent) => {
    *     debugDashboard.capture(errorEvent);
    *   }}

--- a/packages/react-core/src/context/copilot-context.tsx
+++ b/packages/react-core/src/context/copilot-context.tsx
@@ -1,30 +1,28 @@
-import {
+import type {
   CopilotCloudConfig,
   FunctionCallHandler,
   CopilotErrorHandler,
   CopilotKitError,
 } from "@copilotkit/shared";
-import {
+import type {
   ActionRenderProps,
   CatchAllActionRenderProps,
   FrontendAction,
 } from "../types/frontend-action";
 import React from "react";
-import { TreeNodeId, Tree } from "../hooks/use-tree";
-import { DocumentPointer } from "../types";
-import { CopilotChatSuggestionConfiguration } from "../types/chat-suggestion-configuration";
-import {
-  CoAgentStateRender,
-  CoAgentStateRenderProps,
-} from "../types/coagent-action";
-import { CoagentState } from "../types/coagent-state";
-import {
-  CopilotRuntimeClient,
+import type { TreeNodeId, Tree } from "../hooks/use-tree";
+import type { DocumentPointer } from "../types";
+import type { CopilotChatSuggestionConfiguration } from "../types/chat-suggestion-configuration";
+import type { CoAgentStateRenderProps } from "../types/coagent-action";
+import { CoAgentStateRender } from "../types/coagent-action";
+import type { CoagentState } from "../types/coagent-state";
+import type {
   ExtensionsInput,
   ForwardedParametersInput,
 } from "@copilotkit/runtime-client-gql";
-import { Agent } from "@copilotkit/runtime-client-gql";
-import {
+import { CopilotRuntimeClient } from "@copilotkit/runtime-client-gql";
+import type { Agent } from "@copilotkit/runtime-client-gql";
+import type {
   LangGraphInterruptRender,
   LangGraphInterruptActionSetter,
   QueuedInterruptEvent,
@@ -35,12 +33,12 @@ import {
  */
 export interface CopilotApiConfig {
   /**
-   * The public API key for Copilot Cloud.
+   * Your CopilotKit public license key (legacy `publicApiKey` alias of `publicLicenseKey`).
    */
   publicApiKey?: string;
 
   /**
-   * The configuration for Copilot Cloud.
+   * The configuration for the CopilotKit hosted runtime.
    */
   cloud?: CopilotCloudConfig;
 

--- a/packages/react-core/src/hooks/use-copilot-authenticated-action.ts
+++ b/packages/react-core/src/hooks/use-copilot-authenticated-action.ts
@@ -11,9 +11,7 @@ import React from "react";
 /**
  * Hook to create an authenticated action that requires user sign-in before execution.
  *
- * @remarks
- * This feature is only available when using CopilotKit's hosted cloud service.
- * To use this feature, sign up at https://dashboard.operations.copilotkit.ai to get your publicApiKey.
+ * @internal Defunct — retained for backward compatibility.
  *
  * @param action - The frontend action to be wrapped with authentication
  * @param dependencies - Optional array of dependencies that will trigger recreation of the action when changed

--- a/packages/react-core/src/hooks/use-copilot-chat-headless_c.ts
+++ b/packages/react-core/src/hooks/use-copilot-chat-headless_c.ts
@@ -2,9 +2,9 @@
  * `useCopilotChatHeadless_c` is for building fully custom UI (headless UI) implementations.
  *
  * <Callout title="This is a premium-only feature">
- * Sign up for free on [Copilot Cloud](https://dashboard.operations.copilotkit.ai) to get your public license key or read more about <a href="/premium/overview">premium features</a>.
+ * Get your public license key with `npx copilotkit@latest license` (or copy it from the [dashboard](https://dashboard.operations.copilotkit.ai)), or read more about <a href="/premium/overview">premium features</a>.
  *
- * Usage is generous, **free** to get started, and works with **either self-hosted or Copilot Cloud** environments.
+ * Usage is generous and **free** to get started.
  * </Callout>
  *
  * ## Key Features
@@ -27,7 +27,7 @@
  *
  * export function App() {
  *   return (
- *     <CopilotKit publicApiKey="your-free-public-license-key">
+ *     <CopilotKit publicLicenseKey="your-public-license-key">
  *       <YourComponent />
  *     </CopilotKit>
  *   );
@@ -205,7 +205,7 @@ const createNonFunctionalReturn = (): UseCopilotChatReturn_c => ({
  * Enterprise React hook that provides complete chat functionality for fully custom UI implementations.
  * Includes all advanced features like direct message access, suggestions array, interrupt handling, and MCP support.
  *
- * **Requires a publicApiKey** - Sign up for free at https://dashboard.operations.copilotkit.ai/
+ * **Requires a public license key** - get one with `npx copilotkit@latest license` (or from https://dashboard.operations.copilotkit.ai/)
  *
  * @param options - Configuration options for the chat
  * @returns Complete chat interface with all enterprise features

--- a/packages/react-core/src/hooks/use-copilot-chat-headless_c.ts
+++ b/packages/react-core/src/hooks/use-copilot-chat-headless_c.ts
@@ -2,7 +2,7 @@
  * `useCopilotChatHeadless_c` is for building fully custom UI (headless UI) implementations.
  *
  * <Callout title="This is a premium-only feature">
- * Get your public license key with `npx copilotkit@latest license` (or copy it from the [dashboard](https://dashboard.operations.copilotkit.ai)), or read more about <a href="/premium/overview">premium features</a>.
+ * Read more about <a href="/premium/overview">premium features</a>.
  *
  * Usage is generous and **free** to get started.
  * </Callout>
@@ -27,7 +27,7 @@
  *
  * export function App() {
  *   return (
- *     <CopilotKit publicLicenseKey="your-public-license-key">
+ *     <CopilotKit runtimeUrl="/api/copilotkit">
  *       <YourComponent />
  *     </CopilotKit>
  *   );
@@ -204,8 +204,6 @@ const createNonFunctionalReturn = (): UseCopilotChatReturn_c => ({
 /**
  * Enterprise React hook that provides complete chat functionality for fully custom UI implementations.
  * Includes all advanced features like direct message access, suggestions array, interrupt handling, and MCP support.
- *
- * **Requires a public license key** - get one with `npx copilotkit@latest license` (or from https://dashboard.operations.copilotkit.ai/)
  *
  * @param options - Configuration options for the chat
  * @returns Complete chat interface with all enterprise features

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -97,11 +97,12 @@ export interface CopilotKitProviderProps {
    */
   credentials?: RequestCredentials;
   /**
-   * The Copilot Cloud public API key.
+   * Your CopilotKit public license key. Prefer `publicLicenseKey` in new code.
    */
   publicApiKey?: string;
   /**
-   * Alias for `publicApiKey`
+   * Your public license key for accessing premium CopilotKit features.
+   * Run `npx copilotkit@latest license`, or copy it from https://dashboard.operations.copilotkit.ai.
    **/
   publicLicenseKey?: string;
   /**

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -96,14 +96,9 @@ export interface CopilotKitProviderProps {
    * Credentials mode for fetch requests (e.g., "include" for HTTP-only cookies in cross-origin requests).
    */
   credentials?: RequestCredentials;
-  /**
-   * Your CopilotKit public license key. Prefer `publicLicenseKey` in new code.
-   */
+  /** Your CopilotKit public license key. */
   publicApiKey?: string;
-  /**
-   * Your public license key for accessing premium CopilotKit features.
-   * Run `npx copilotkit@latest license`, or copy it from https://dashboard.operations.copilotkit.ai.
-   **/
+  /** Your public license key for accessing premium CopilotKit features. */
   publicLicenseKey?: string;
   /**
    * Signed license token for offline verification of premium features.

--- a/packages/react-ui/src/components/chat/Chat.tsx
+++ b/packages/react-ui/src/components/chat/Chat.tsx
@@ -30,10 +30,9 @@
  * ### With Observability Hooks
  *
  * To monitor user interactions, provide the `observabilityHooks` prop.
- * **Note:** This requires a public license key in the `<CopilotKit>` provider.
  *
  * ```tsx
- * <CopilotKit publicLicenseKey="YOUR_PUBLIC_LICENSE_KEY">
+ * <CopilotKit>
  *   <CopilotChat
  *     observabilityHooks={{
  *       onMessageSent: (message) => {
@@ -75,9 +74,11 @@ import type { SystemMessageFunction } from "@copilotkit/react-core";
 import {
   useCopilotContext,
   useCopilotChatInternal,
-  type OnStopGeneration,
-  type OnReloadMessages,
-  type ChatSuggestions,
+} from "@copilotkit/react-core";
+import type {
+  OnStopGeneration,
+  OnReloadMessages,
+  ChatSuggestions,
 } from "@copilotkit/react-core";
 import {
   CopilotKitError,
@@ -87,7 +88,7 @@ import {
   styledConsole,
   randomUUID,
 } from "@copilotkit/shared";
-import {
+import type {
   AssistantMessageProps,
   ChatError,
   ComponentsMap,
@@ -352,7 +353,6 @@ export interface CopilotChatProps {
 
   /**
    * Event hooks for CopilotKit chat events.
-   * These hooks only work when a public license key is provided.
    */
   observabilityHooks?: CopilotObservabilityHooks;
 

--- a/packages/react-ui/src/components/chat/Chat.tsx
+++ b/packages/react-ui/src/components/chat/Chat.tsx
@@ -30,10 +30,10 @@
  * ### With Observability Hooks
  *
  * To monitor user interactions, provide the `observabilityHooks` prop.
- * **Note:** This requires a `publicApiKey` in the `<CopilotKit>` provider.
+ * **Note:** This requires a public license key in the `<CopilotKit>` provider.
  *
  * ```tsx
- * <CopilotKit publicApiKey="YOUR_PUBLIC_API_KEY">
+ * <CopilotKit publicLicenseKey="YOUR_PUBLIC_LICENSE_KEY">
  *   <CopilotChat
  *     observabilityHooks={{
  *       onMessageSent: (message) => {
@@ -62,12 +62,8 @@
  * For more information about how to customize the styles, check out the [Customize Look & Feel](/guides/custom-look-and-feel/customize-built-in-ui-components) guide.
  */
 
-import {
-  ChatContext,
-  ChatContextProvider,
-  CopilotChatIcons,
-  CopilotChatLabels,
-} from "./ChatContext";
+import type { CopilotChatIcons, CopilotChatLabels } from "./ChatContext";
+import { ChatContext, ChatContextProvider } from "./ChatContext";
 import { Messages as DefaultMessages } from "./Messages";
 import { Input as DefaultInput } from "./Input";
 import { RenderMessage as DefaultRenderMessage } from "./messages/RenderMessage";
@@ -75,8 +71,8 @@ import { AssistantMessage as DefaultAssistantMessage } from "./messages/Assistan
 import { UserMessage as DefaultUserMessage } from "./messages/UserMessage";
 import { ImageRenderer as DefaultImageRenderer } from "./messages/ImageRenderer";
 import React, { useEffect, useRef, useState, useCallback } from "react";
+import type { SystemMessageFunction } from "@copilotkit/react-core";
 import {
-  SystemMessageFunction,
   useCopilotContext,
   useCopilotChatInternal,
   type OnStopGeneration,
@@ -86,12 +82,9 @@ import {
 import {
   CopilotKitError,
   CopilotKitErrorCode,
-  CopilotErrorEvent,
-  Message,
   Severity,
   ErrorVisibility,
   styledConsole,
-  CopilotErrorHandler,
   randomUUID,
 } from "@copilotkit/shared";
 import {
@@ -119,7 +112,12 @@ import {
   formatFileSize,
   deprecationWarning,
 } from "./attachment-utils";
-import type { InputContent } from "@copilotkit/shared";
+import type {
+  InputContent,
+  CopilotErrorEvent,
+  Message,
+  CopilotErrorHandler,
+} from "@copilotkit/shared";
 import { Suggestions as DefaultRenderSuggestionsList } from "./Suggestions";
 
 /**
@@ -354,7 +352,7 @@ export interface CopilotChatProps {
 
   /**
    * Event hooks for CopilotKit chat events.
-   * These hooks only work when publicApiKey is provided.
+   * These hooks only work when a public license key is provided.
    */
   observabilityHooks?: CopilotObservabilityHooks;
 

--- a/packages/react-ui/src/components/chat/Popup.tsx
+++ b/packages/react-ui/src/components/chat/Popup.tsx
@@ -31,10 +31,9 @@
  * ### With Observability Hooks
  *
  * To monitor user interactions, provide the `observabilityHooks` prop.
- * **Note:** This requires a public license key in the `<CopilotKit>` provider.
  *
  * ```tsx
- * <CopilotKit publicLicenseKey="YOUR_PUBLIC_LICENSE_KEY">
+ * <CopilotKit>
  *   <CopilotPopup
  *     observabilityHooks={{
  *       onChatExpanded: () => {

--- a/packages/react-ui/src/components/chat/Popup.tsx
+++ b/packages/react-ui/src/components/chat/Popup.tsx
@@ -31,10 +31,10 @@
  * ### With Observability Hooks
  *
  * To monitor user interactions, provide the `observabilityHooks` prop.
- * **Note:** This requires a `publicApiKey` in the `<CopilotKit>` provider.
+ * **Note:** This requires a public license key in the `<CopilotKit>` provider.
  *
  * ```tsx
- * <CopilotKit publicApiKey="YOUR_PUBLIC_API_KEY">
+ * <CopilotKit publicLicenseKey="YOUR_PUBLIC_LICENSE_KEY">
  *   <CopilotPopup
  *     observabilityHooks={{
  *       onChatExpanded: () => {
@@ -66,7 +66,8 @@
  * For more information about how to customize the styles, check out the [Customize Look & Feel](/guides/custom-look-and-feel/customize-built-in-ui-components) guide.
  */
 
-import { CopilotModal, CopilotModalProps } from "./Modal";
+import type { CopilotModalProps } from "./Modal";
+import { CopilotModal } from "./Modal";
 
 export function CopilotPopup(props: CopilotModalProps) {
   props = {

--- a/packages/react-ui/src/components/chat/Sidebar.tsx
+++ b/packages/react-ui/src/components/chat/Sidebar.tsx
@@ -33,10 +33,9 @@
  * ### With Observability Hooks
  *
  * To monitor user interactions, provide the `observabilityHooks` prop.
- * **Note:** This requires a public license key in the `<CopilotKit>` provider.
  *
  * ```tsx
- * <CopilotKit publicLicenseKey="YOUR_PUBLIC_LICENSE_KEY">
+ * <CopilotKit>
  *   <CopilotSidebar
  *     observabilityHooks={{
  *       onChatExpanded: () => {

--- a/packages/react-ui/src/components/chat/Sidebar.tsx
+++ b/packages/react-ui/src/components/chat/Sidebar.tsx
@@ -33,10 +33,10 @@
  * ### With Observability Hooks
  *
  * To monitor user interactions, provide the `observabilityHooks` prop.
- * **Note:** This requires a `publicApiKey` in the `<CopilotKit>` provider.
+ * **Note:** This requires a public license key in the `<CopilotKit>` provider.
  *
  * ```tsx
- * <CopilotKit publicApiKey="YOUR_PUBLIC_API_KEY">
+ * <CopilotKit publicLicenseKey="YOUR_PUBLIC_LICENSE_KEY">
  *   <CopilotSidebar
  *     observabilityHooks={{
  *       onChatExpanded: () => {
@@ -70,7 +70,8 @@
  * For more information about how to customize the styles, check out the [Customize Look & Feel](/guides/custom-look-and-feel/customize-built-in-ui-components) guide.
  */
 import React, { useState } from "react";
-import { CopilotModal, CopilotModalProps } from "./Modal";
+import type { CopilotModalProps } from "./Modal";
+import { CopilotModal } from "./Modal";
 
 export function CopilotSidebar(props: CopilotModalProps) {
   props = {

--- a/packages/react-ui/src/components/chat/props.ts
+++ b/packages/react-ui/src/components/chat/props.ts
@@ -19,7 +19,6 @@ export type { AttachmentsConfig, Attachment, AttachmentModality };
 
 /**
  * Event hooks for CopilotKit chat events.
- * These hooks only work when a public license key is provided.
  */
 export interface CopilotObservabilityHooks {
   /**

--- a/packages/react-ui/src/components/chat/props.ts
+++ b/packages/react-ui/src/components/chat/props.ts
@@ -1,12 +1,12 @@
-import {
+import type {
   AIMessage,
   Message,
   UserMessage,
   CopilotErrorEvent,
 } from "@copilotkit/shared";
-import { CopilotChatSuggestion } from "../../types/suggestions";
-import { ReactNode } from "react";
-import { ImageData } from "@copilotkit/shared";
+import type { CopilotChatSuggestion } from "../../types/suggestions";
+import type { ReactNode } from "react";
+import type { ImageData } from "@copilotkit/shared";
 import type { InputContentSource } from "@copilotkit/shared";
 import type {
   AttachmentsConfig,
@@ -19,7 +19,7 @@ export type { AttachmentsConfig, Attachment, AttachmentModality };
 
 /**
  * Event hooks for CopilotKit chat events.
- * These hooks only work when publicApiKey is provided.
+ * These hooks only work when a public license key is provided.
  */
 export interface CopilotObservabilityHooks {
   /**

--- a/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -13,17 +13,19 @@
  */
 
 import {
-  type Action,
-  type CopilotErrorHandler,
   CopilotKitMisuseError,
-  type MaybePromise,
-  type NonEmptyRecord,
-  type Parameter,
   readBody,
   getZodParameters,
-  type PartialBy,
   isTelemetryDisabled,
-  type DebugConfig,
+} from "@copilotkit/shared";
+import type {
+  Action,
+  CopilotErrorHandler,
+  MaybePromise,
+  NonEmptyRecord,
+  Parameter,
+  PartialBy,
+  DebugConfig,
 } from "@copilotkit/shared";
 import type { RunAgentInput } from "@ag-ui/core";
 import { aguiToGQL } from "../../graphql/message-conversion/agui-to-gql";
@@ -33,13 +35,15 @@ import type {
 } from "../../service-adapters";
 import {
   CopilotRuntime as CopilotRuntimeVNext,
-  type CopilotRuntimeOptions,
-  type CopilotRuntimeOptions as CopilotRuntimeOptionsVNext,
-  type AgentRunner,
-  type AgentsConfig,
-  type AgentsFactory,
-  type AgentFactoryContext,
   InMemoryAgentRunner,
+} from "../../v2/runtime";
+import type {
+  CopilotRuntimeOptions,
+  CopilotRuntimeOptions as CopilotRuntimeOptionsVNext,
+  AgentRunner,
+  AgentsConfig,
+  AgentsFactory,
+  AgentFactoryContext,
 } from "../../v2/runtime";
 
 export type { AgentsConfig, AgentsFactory, AgentFactoryContext };
@@ -50,11 +54,11 @@ import { logRuntimeTelemetryDisclosure } from "../telemetry-disclosure";
 import type { MessageInput } from "../../graphql/inputs/message.input";
 import type { Message } from "../../graphql/types/converted";
 
-import {
-  EndpointType,
-  type EndpointDefinition,
-  type CopilotKitEndpoint,
-  type LangGraphPlatformEndpoint,
+import { EndpointType } from "./types";
+import type {
+  EndpointDefinition,
+  CopilotKitEndpoint,
+  LangGraphPlatformEndpoint,
 } from "./types";
 
 import type {
@@ -65,13 +69,10 @@ import type {
 import type { AbstractAgent } from "@ag-ui/client";
 
 // +++ MCP Imports +++
-import {
-  type MCPClient,
-  type MCPEndpointConfig,
-  type MCPTool,
-  extractParametersFromSchema,
-} from "./mcp-tools-utils";
-import { BuiltInAgent, type BuiltInAgentClassicConfig } from "../../agent";
+import { extractParametersFromSchema } from "./mcp-tools-utils";
+import type { MCPClient, MCPEndpointConfig, MCPTool } from "./mcp-tools-utils";
+import { BuiltInAgent } from "../../agent";
+import type { BuiltInAgentClassicConfig } from "../../agent";
 // Define the function type alias here or import if defined elsewhere
 type CreateMCPClientFunction = (
   config: MCPEndpointConfig,
@@ -217,10 +218,10 @@ export interface CopilotRuntimeConstructorParams_BASE<
 
   /**
    * Configuration for LLM request/response logging.
-   * Requires publicApiKey from CopilotKit component to be set:
+   * Requires a public license key on the CopilotKit component:
    *
    * ```tsx
-   * <CopilotKit publicApiKey="ck_pub_..." />
+   * <CopilotKit publicLicenseKey="ck_pub_..." />
    * ```
    *
    * Example logging config:
@@ -276,8 +277,8 @@ export interface CopilotRuntimeConstructorParams_BASE<
   /**
    * Optional error handler for comprehensive debugging and observability.
    *
-   * **Requires publicApiKey**: Error handling only works when requests include a valid publicApiKey.
-   * This is a premium Copilot Cloud feature.
+   * **Requires a license key**: Error handling only works when requests include a valid public license key.
+   * This is a premium feature.
    *
    * @param errorEvent - Structured error event with rich debugging context
    *

--- a/packages/runtime/src/lib/runtime/copilot-runtime.ts
+++ b/packages/runtime/src/lib/runtime/copilot-runtime.ts
@@ -218,11 +218,6 @@ export interface CopilotRuntimeConstructorParams_BASE<
 
   /**
    * Configuration for LLM request/response logging.
-   * Requires a public license key on the CopilotKit component:
-   *
-   * ```tsx
-   * <CopilotKit publicLicenseKey="ck_pub_..." />
-   * ```
    *
    * Example logging config:
    * ```ts
@@ -276,9 +271,6 @@ export interface CopilotRuntimeConstructorParams_BASE<
 
   /**
    * Optional error handler for comprehensive debugging and observability.
-   *
-   * **Requires a license key**: Error handling only works when requests include a valid public license key.
-   * This is a premium feature.
    *
    * @param errorEvent - Structured error event with rich debugging context
    *

--- a/packages/shared/src/utils/console-styling.ts
+++ b/packages/shared/src/utils/console-styling.ts
@@ -53,11 +53,11 @@ export function logCopilotKitPlatformMessage() {
   console.log(
     `%cCopilotKit Warning%c
 
-useCopilotChatHeadless_c provides full compatibility with CopilotKit's newly released Headless UI feature set. To enable this premium feature, add your public license key, available for free at:
+useCopilotChatHeadless_c provides full compatibility with CopilotKit's newly released Headless UI feature set. To enable this premium feature, add your public license key — run \`npx copilotkit@latest license\`, or copy it from the dashboard:
 
 %chttps://dashboard.operations.copilotkit.ai%c
 
-Alternatively, useCopilotChat is available for basic programmatic control, and does not require an API key.
+Alternatively, useCopilotChat is available for basic programmatic control, and does not require a license key.
 
 To learn more about premium features, read the documentation here:
 
@@ -75,7 +75,7 @@ export function publicApiKeyRequired(feature: string) {
   console.log(
     `
 %cCopilotKit Warning%c \n
-In order to use ${feature}, you need to add your CopilotKit API key, available for free at https://dashboard.operations.copilotkit.ai.
+In order to use ${feature}, you need to add your CopilotKit license key — run \`npx copilotkit@latest license\`, or copy it from https://dashboard.operations.copilotkit.ai.
     `.trim(),
     ConsoleStyles.header,
     ConsoleStyles.body,

--- a/packages/shared/src/utils/console-styling.ts
+++ b/packages/shared/src/utils/console-styling.ts
@@ -53,7 +53,7 @@ export function logCopilotKitPlatformMessage() {
   console.log(
     `%cCopilotKit Warning%c
 
-useCopilotChatHeadless_c provides full compatibility with CopilotKit's newly released Headless UI feature set. To enable this premium feature, add your public license key — run \`npx copilotkit@latest license\`, or copy it from the dashboard:
+useCopilotChatHeadless_c provides full compatibility with CopilotKit's newly released Headless UI feature set. To enable this premium feature, add your public license key, available for free at:
 
 %chttps://dashboard.operations.copilotkit.ai%c
 
@@ -75,7 +75,7 @@ export function publicApiKeyRequired(feature: string) {
   console.log(
     `
 %cCopilotKit Warning%c \n
-In order to use ${feature}, you need to add your CopilotKit license key — run \`npx copilotkit@latest license\`, or copy it from https://dashboard.operations.copilotkit.ai.
+In order to use ${feature}, you need to add your CopilotKit license key, available for free at https://dashboard.operations.copilotkit.ai.
     `.trim(),
     ConsoleStyles.header,
     ConsoleStyles.body,

--- a/packages/vue/src/components/copilot-provider/types.ts
+++ b/packages/vue/src/components/copilot-provider/types.ts
@@ -7,7 +7,7 @@ import type { CopilotKitProviderProps } from "../../v2/providers/CopilotKitProvi
  */
 export interface CopilotKitProps extends CopilotKitProviderProps {
   /**
-   * Your Copilot Cloud API key.
+   * Your CopilotKit public license key.
    * @deprecated Use publicLicenseKey with the v2 CopilotKitProvider instead.
    */
   publicApiKey?: string;


### PR DESCRIPTION
## Why

Copilot Cloud is no longer promoted, but new users still find it through stale links and code references — including the SDK's own JSDoc/console messages. This scrubs the old Copilot Cloud framing **and** the client `publicLicenseKey`/`publicApiKey` prop references from the SDK doc surface.

Important distinction this PR is built around: the **client `publicLicenseKey`/`publicApiKey` prop** is the header→cloud path (being retired) and is **not** what activates the Intelligence runtime. The Intelligence runtime license is the **server-side `COPILOTKIT_LICENSE_TOKEN`** (Ed25519 JWT) → `licenseToken` on `CopilotRuntime`. So the client prop is not documented here as the premium/Intelligence enabler.

Follow-up to the link cleanup in #5258. Example-app + server-side runtime documentation deferred ("Bucket B").

## What changed

Doc-comments / JSDoc / console strings / README prose — **no functional code, no prop renames, no endpoint/header changes.**

- **Copilot Cloud → removed** from JSDoc/console/README across react-core, react-ui, runtime, vue, shared, angular.
- **Client license-key prop references removed**, not reframed:
  - `publicApiKey`/`publicLicenseKey` docstrings (react-core props + v2 provider) reverted to bare one-liners.
  - "Requires a license key" / "premium feature" / `<CopilotKit publicLicenseKey=…>` example notes dropped from the headless hook, react-ui observability docs (`Chat`/`Popup`/`Sidebar`/`props`), and runtime logging/`onError` JSDoc.
  - No `npx copilotkit@latest license` guidance attached to client props (that CLI yields the *server-side* token, not the client prop).
- **Angular**: all `licenseKey` mentions removed from the README — it's no longer a premium feature (the license watermark is disabled) and the key isn't needed to function.
- **Defunct features** (`guardrails_c`, `authConfig_c`, `useCopilotAuthenticatedAction_c`) keep their code but lose their JSDoc (`@internal Defunct`).

### Incidental (pre-commit lint-fix)

The repo's pre-commit hook auto-applied `import type` conversions on the touched files (a pre-existing oxlint warning). Type-only, zero runtime impact.

## Deliberately untouched

`api.cloud.copilotkit.ai` endpoint + `X-CopilotCloud-Public-Api-Key` header (functional), prop names, gating logic, tests, CHANGELOGs, the `#5351` skill files, and `CopilotCloudOptions`/`CopilotCloudConfig` type identifiers.

## Out of scope (deferred — "Bucket B")

- Migrating example apps onto the Intelligence/`COPILOTKIT_LICENSE_TOKEN` runtime model.
- Documenting the server-side `licenseToken` setup.
- Stale `CopilotCloud` watermark strings in `angular/config.ts` (watermark is disabled; flagged for a separate cleanup).

## Verification

- `oxfmt --check` on changed files → pass
- `nx run-many build` (no cache) for `@copilotkit/{shared,react-core,react-ui,runtime,vue}` → success
- `oxlint` on changed files → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)