### PR TITLE
ci(release): one-click canary publish orchestrator + release-pipeline lint guards

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,329 @@
+name: canary / publish
+
+# Discoverable, one-click canary publisher. Surfaces in the Actions tab so any
+# maintainer can publish a prerelease of the branch they're working on without
+# learning the manual `canary/*` branch + dispatch dance.
+#
+# IMPORTANT: this workflow does NOT publish to npm itself. It ORCHESTRATES
+# publish-release.yml, which holds the SINGLE npm OIDC trusted-publisher binding
+# (see that file's header). Adding a second npm-publishing entry point would
+# break OIDC for every @copilotkit/* package. The npm trusted publishers for
+# the @copilotkit packages are bound to publish-release.yml + the `npm`
+# environment.
+#
+# Why a separate orchestrator instead of a flag inside publish-release.yml:
+#   The `npm` GitHub Environment's deployment-branch policy is evaluated against
+#   the ref a run is TRIGGERED on — NOT against branches created mid-run. So
+#   publish-release.yml can only publish a canary when its run's ref already
+#   matches the policy (`canary/*`). Creating a branch inside a run triggered on
+#   `feature/*` does not change that run's ref, so it would still be rejected.
+#   This workflow therefore runs on any non-main branch, mirrors it to a
+#   short-lived `canary/<slug>` ref, dispatches publish-release.yml ON that ref
+#   (clearing the env gate), waits for it, then deletes the ref.
+#
+# Token: the branch create/delete and the cross-workflow dispatch use the
+# devops-bot GitHub App token, NOT the default GITHUB_TOKEN. Events authenticated
+# with GITHUB_TOKEN do not start new workflow runs (recursion prevention), so the
+# delegated publish-release run would silently never fire.
+
+on:
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: "Package scope to publish a canary for. Regenerated from release.config.json — do NOT hand-edit (the release-scope-dropdown-sync CI guard enforces parity)."
+        required: true
+        type: choice
+        options:
+          - monorepo
+          - angular
+          - bot
+          - bot-slack
+      suffix:
+        description: "Prerelease suffix (e.g. 'fix-user-issue'); blank = unix timestamp. Allowed: [a-zA-Z0-9._-]+. Reuse a suffix only if the base version moved, else the publish collides."
+        required: false
+        type: string
+      dry_run:
+        # NOTE: this orchestrator exposes `dry_run` (underscore, matching ag-ui's
+        # convention), but publish-release.yml's input is `dry-run` (hyphen).
+        # The dispatch step below maps `dry_run` → `-f dry-run=` accordingly.
+        description: "Dry run: build + detect but do NOT publish to npm. Useful for previewing what would ship."
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  # Serialize repeated dispatches on the same source branch. Cross-branch ref
+  # races are independently prevented by making the canary ref unique per run
+  # (slug + github.run_id, see the slug step below).
+  # Side-effect: repeated dispatches on the same source branch queue behind each
+  # other (cancel-in-progress: false) — even for different scopes.
+  group: canary-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  # The job's own GITHUB_TOKEN does nothing privileged — every write goes through
+  # the App token minted below.
+  contents: read
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    # The delegated publish-release run can take up to ~40 min worst case
+    # (build ~20 + publish ~20); this orchestrator's ceiling must exceed it,
+    # otherwise a timeout-kill triggers ref cleanup mid-publish (yanking the
+    # canary ref out from under a still-running publish). publish-release.yml
+    # also carries a GLOBAL `concurrency: group: publish-release,
+    # cancel-in-progress: false`, so our delegated run can sit QUEUED behind
+    # an unrelated release for a long time before it even starts; the ceiling
+    # must budget that queue time on top of the ~40-min worst case.
+    timeout-minutes: 90
+    steps:
+      - name: Guard ref
+        # Canary publishes are for non-main BRANCHES only. Block main (use the
+        # stable release flow) and block non-branch refs such as tags (a tag
+        # dispatch would otherwise canary-publish from the tagged commit).
+        if: github.ref == 'refs/heads/main' || !startsWith(github.ref, 'refs/heads/')
+        # Pass github.ref via env (matches "Validate suffix" discipline) so the
+        # ref name is never interpolated into the shell — tag/branch names may
+        # contain shell metacharacters and direct ${{ }} interpolation here
+        # would be an expression-injection sink.
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          echo "::error::Canary publishes are for non-main branches only (got '$REF'). To release from main, use the 'release / create-pr' workflow (stable-release.yml) → merge the release PR, or 'release / publish' with mode=stable for retries."
+          exit 1
+
+      - name: Validate suffix
+        if: inputs.suffix != ''
+        env:
+          SUFFIX: ${{ inputs.suffix }}
+        run: |
+          set -euo pipefail
+          # Validate BEFORE any side effect (token mint, ref creation) so a bad
+          # suffix can't leave an orphaned canary ref behind. Bash regex matches
+          # the WHOLE string (grep matches per line and would accept a multi-line
+          # value whose first line is valid).
+          if ! [[ "$SUFFIX" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+            echo "::error::Invalid suffix '$SUFFIX'. Allowed: [a-zA-Z0-9._-]+ (blank = unix timestamp)."
+            exit 1
+          fi
+
+      - name: Mint devops-bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: 1108748
+          private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
+          # Scoped permissions (v3+): contents=write for create/delete of the
+          # canary ref; actions=write to dispatch publish-release.yml and watch
+          # the delegated run. No other scopes are needed.
+          permission-contents: write
+          permission-actions: write
+
+      - name: Compute canary branch name
+        id: slug
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Byte-deterministic (LC_ALL=C) transform collapsing the source ref to a
+          # single path segment under canary/ so it matches the `canary/*`
+          # deployment-branch policy. tr -s collapses same-char runs (so no `..`),
+          # and the sed fully strips any leading/trailing `.`/`-` runs.
+          export LC_ALL=C
+          SLUG=$(printf '%s' "$REF_NAME" | tr '/' '-' | tr -c 'a-zA-Z0-9._-' '-' | tr -s '.-')
+          SLUG=$(printf '%s' "$SLUG" | sed -E 's/^[.-]+//; s/[.-]+$//')
+          if [ -z "$SLUG" ]; then
+            echo "::error::Could not derive a canary slug from ref '$REF_NAME'"
+            exit 1
+          fi
+          # Append run id AND attempt so every dispatch — including a re-run of
+          # this same orchestration — owns a UNIQUE canary ref. This prevents two
+          # dispatches whose source branches slugify to the same value (or a
+          # re-run reusing the run id) from racing one shared ref, and keeps run
+          # discovery below unambiguous (exactly one publish run per ref).
+          REF_SUFFIX="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "branch=canary/${SLUG}-${REF_SUFFIX}" >> "$GITHUB_OUTPUT"
+          echo "Canary branch: canary/${SLUG}-${REF_SUFFIX}"
+
+      - name: Create or update canary ref
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ${{ steps.slug.outputs.branch }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Point canary/<slug> at the dispatched ref's HEAD. The ref is unique
+          # per run AND attempt (slug + run_id + run_attempt — re-runs increment
+          # the attempt), so the "already exists" arm is defense-in-depth and
+          # should be unreachable in practice. Force-update only on that specific
+          # error; any OTHER failure (auth, rate limit, 5xx) must surface, not be
+          # silently retried.
+          ERR=$(mktemp)
+          if gh api --silent -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/heads/${BRANCH}" -f sha="$SHA" 2>"$ERR"; then
+            echo "Created ${BRANCH} at ${SHA}"
+          elif grep -qi "already exists" "$ERR"; then
+            echo "Ref ${BRANCH} already exists; force-updating to ${SHA}"
+            gh api --silent -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH}" \
+              -f sha="$SHA" -F force=true
+          else
+            echo "::error::Failed to create canary ref ${BRANCH}:"
+            cat "$ERR" >&2
+            exit 1
+          fi
+
+      - name: Dispatch publish-release.yml on the canary ref and wait
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ${{ steps.slug.outputs.branch }}
+          SCOPE: ${{ inputs.scope }}
+          SUFFIX: ${{ inputs.suffix }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          # (suffix already validated in the "Validate suffix" step above, before
+          # the canary ref was created)
+          #
+          # Input name mapping: this orchestrator's `dry_run` (underscore) maps
+          # to publish-release.yml's `dry-run` (hyphen). Keep both as-is — the
+          # underscore matches ag-ui's convention; the hyphen matches cpk's
+          # existing publish-release.yml signature.
+          gh workflow run publish-release.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$BRANCH" \
+            -f mode=prerelease \
+            -f scope="$SCOPE" \
+            -f suffix="$SUFFIX" \
+            -f dry-run="$DRY_RUN"
+
+          # The dispatch went through. If anything from here on fails BEFORE a run
+          # is located, the cleanup step keeps the ref (a dispatched-but-unindexed
+          # run may still need it). If the dispatch itself had failed, no run can
+          # exist and the ref is safe to delete.
+          echo "dispatched=true" >> "$GITHUB_OUTPUT"
+          # Residual race: a cancellation landing in the instant between
+          # `gh workflow run` succeeding above and this output write would route
+          # cleanup down the "no run exists" path and delete the ref under a
+          # queued run. Accepted risk — the delegated canary run fails visibly
+          # at checkout and can simply be re-dispatched.
+
+          # The canary ref is unique to this run+attempt, so there is exactly ONE
+          # publish-release dispatch on it — no timestamp watermark needed (which
+          # also sidesteps runner/server clock-skew). Poll until it indexes
+          # (30 x 6s = 3 min tolerance for Actions indexing lag). --limit is
+          # defensive headroom; the branch/workflow/event filters are applied
+          # server-side so the matching run is never crowded out.
+          RUN_ID=""
+          ERR=$(mktemp)
+          for i in $(seq 1 30); do
+            sleep 6
+            RUN_ID=$(gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow=publish-release.yml \
+              --branch "$BRANCH" \
+              --event workflow_dispatch \
+              --limit 100 \
+              --json databaseId \
+              --jq 'sort_by(.databaseId) | last | .databaseId // empty' 2>"$ERR") || {
+                RUN_ID=""
+                echo "::warning::gh run list failed on attempt ${i}; will retry:" >&2
+                cat "$ERR" >&2
+              }
+            if [ -n "$RUN_ID" ]; then
+              break
+            fi
+          done
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::Dispatched publish-release run never appeared on ${BRANCH}. Leaving the ref in place for debugging; delete it manually once resolved."
+            exit 1
+          fi
+
+          # Mark located BEFORE the watch so cleanup runs even if the publish
+          # fails — but is skipped entirely if we never tracked a run (so we
+          # never delete a ref a still-pending run may need).
+          echo "located=true" >> "$GITHUB_OUTPUT"
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+
+          RUN_URL=$(gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" --json url --jq .url)
+          echo "Delegated publish run: ${RUN_URL}"
+          {
+            echo "## Canary publish"
+            echo ""
+            echo "- **Scope:** \`${SCOPE}\`"
+            echo "- **Source branch:** \`${GITHUB_REF_NAME}\`"
+            echo "- **Delegated run:** ${RUN_URL}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # --exit-status propagates the publish run's failure to this job.
+          gh run watch "$RUN_ID" --repo "$GITHUB_REPOSITORY" --exit-status
+
+          # --exit-status catches failures, but a non-failure non-success conclusion
+          # (e.g. skipped) exits 0 with nothing published. Require success explicitly.
+          CONCLUSION=$(gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" --json conclusion --jq .conclusion)
+          if [ "$CONCLUSION" != "success" ]; then
+            echo "::error::Delegated publish run concluded '$CONCLUSION' (expected 'success')."
+            exit 1
+          fi
+
+      - name: Mint cleanup token
+        id: cleanup-token
+        # The job ceiling (90 min) exceeds the 1-hour App-token TTL, so the
+        # token minted at job start can be expired by cleanup time. Mint a
+        # fresh one. Same condition as the delete step below.
+        if: always() && steps.slug.outputs.branch != '' && (steps.dispatch.outputs.located == 'true' || steps.dispatch.outputs.dispatched != 'true')
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: 1108748
+          private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-actions: read
+
+      - name: Delete canary ref
+        # Three cases:
+        #   (a) Run was located (located=true) → delete the ref; the delegated
+        #       publish run has finished (success or fail) and no longer needs it.
+        #       Additionally gated below by a live status check on RUN_ID: on
+        #       cancellation/timeout (always() runs cleanup too) a still-queued
+        #       or running delegated run must keep its branch, since
+        #       checkout-by-SHA can fail once the ref is gone.
+        #   (b) Dispatch succeeded (dispatched=true) but the run was never located
+        #       within the poll window → KEEP the ref; a pending publish run may
+        #       still pick it up and would silently break if the ref vanished.
+        #   (c) The dispatch command itself failed or this step never ran
+        #       (dispatched != 'true') → no publish run can exist, so the ref is
+        #       safe to delete (and almost certainly was never created).
+        # The `steps.slug.outputs.branch != ''` guard skips cleanup entirely when
+        # the slug step never produced a branch name (a guard/suffix failure that
+        # bailed before any ref was created). A DELETE on an empty path would
+        # 404-gracefully anyway, but skipping avoids the spurious API call.
+        if: always() && steps.slug.outputs.branch != '' && (steps.dispatch.outputs.located == 'true' || steps.dispatch.outputs.dispatched != 'true')
+        env:
+          GH_TOKEN: ${{ steps.cleanup-token.outputs.token }}
+          BRANCH: ${{ steps.slug.outputs.branch }}
+          RUN_ID: ${{ steps.dispatch.outputs.run_id }}
+        run: |
+          # Best-effort cleanup: never fail the job on a delete hiccup, but do
+          # surface a real error instead of masking every failure as "gone".
+          set -uo pipefail
+          # If we tracked a delegated run, only delete the ref once that run has
+          # completed. always() brings us here on cancellation/timeout too — a
+          # still-queued run would fail checkout if its branch (and thus the
+          # commit's reachability) disappears from under it.
+          if [ -n "${RUN_ID}" ]; then
+            STATUS=$(gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" --json status --jq .status 2>/dev/null || echo unknown)
+            if [ "$STATUS" != "completed" ]; then
+              echo "::warning::Delegated run $RUN_ID status is '$STATUS' (not completed); keeping ${BRANCH} — delete it manually once the run finishes."
+              exit 0
+            fi
+          fi
+          ERR=$(mktemp)
+          if gh api --silent -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH}" 2>"$ERR"; then
+            echo "Deleted ${BRANCH}"
+          elif grep -qiE "not found|does not exist" "$ERR"; then
+            echo "Branch ${BRANCH} already gone"
+          else
+            echo "::warning::Failed to delete canary ref ${BRANCH} (manual cleanup may be needed):"
+            cat "$ERR" >&2
+          fi

--- a/.github/workflows/lint-release-workflows.yml
+++ b/.github/workflows/lint-release-workflows.yml
@@ -1,0 +1,92 @@
+name: Lint Release Workflows
+
+# Runs actionlint + shellcheck against the release / create-pr, release /
+# publish, and canary / publish pipelines and the scripts they call. Keeps
+# these critical, retry-sensitive files from silently regressing on shell or
+# action-syntax bugs.
+#
+# Scope is intentionally narrow: only the release workflows and
+# scripts/release/*. Expanding later is cheap; starting narrow avoids
+# drowning unrelated changes in pre-existing lint noise.
+#
+# Workflow mapping (cpk):
+#   release / create-pr  -> .github/workflows/stable-release.yml
+#   release / publish    -> .github/workflows/publish-release.yml
+#   canary / publish     -> .github/workflows/canary.yml
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/stable-release.yml"
+      - ".github/workflows/publish-release.yml"
+      - ".github/workflows/canary.yml"
+      - ".github/workflows/lint-release-workflows.yml"
+      - "scripts/release/**"
+      - "release.config.json"
+      - "nx.json"
+  pull_request:
+    paths:
+      - ".github/workflows/stable-release.yml"
+      - ".github/workflows/publish-release.yml"
+      - ".github/workflows/canary.yml"
+      - ".github/workflows/lint-release-workflows.yml"
+      - "scripts/release/**"
+      - "release.config.json"
+      - "nx.json"
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Run actionlint on release workflows
+        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
+        with:
+          reporter: github-check
+          level: error
+          fail_level: error
+          actionlint_flags: >-
+            .github/workflows/stable-release.yml
+            .github/workflows/publish-release.yml
+            .github/workflows/canary.yml
+            .github/workflows/lint-release-workflows.yml
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run shellcheck on release scripts
+        run: |
+          set -euo pipefail
+          shopt -s nullglob globstar
+          files=(scripts/release/**/*.sh)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No shell scripts under scripts/release/"
+            exit 0
+          fi
+          shellcheck --severity=warning "${files[@]}"
+
+  release-scope-dropdown-sync:
+    # Verifies the workflow_dispatch `scope` choice dropdowns in
+    # stable-release.yml, publish-release.yml, and canary.yml match
+    # release.config.json's `.scopes` keys. These option lists are
+    # hand-maintained and drift from the config (newly-enrolled packages
+    # weren't canary-selectable; stale scopes lingered), so this guard fails
+    # CI whenever they diverge again.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Verify release scope dropdowns match release.config.json
+        run: bash scripts/release/verify-release-scope-dropdowns.sh

--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -23,7 +23,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment: npm
+    # NOTE: deliberately NOT in the `npm` environment. pkg-pr-new publishes to
+    # pkg.pr.new (not the npm registry) and uses no environment-scoped secrets,
+    # and this job runs on every push/PR touching packages/** — the npm
+    # environment's deployment-branch policy (main, canary/*,
+    # release/publish/*) would block it.
     permissions:
       contents: read
       # pkg-pr-new posts snapshot comments on the PR using the workflow token

--- a/scripts/release/verify-release-scope-dropdowns.sh
+++ b/scripts/release/verify-release-scope-dropdowns.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# scripts/release/verify-release-scope-dropdowns.sh
+#
+# Verifies that the hand-maintained `workflow_dispatch` `scope` choice
+# dropdowns in the release workflows match the authoritative set of release
+# scopes declared in release.config.json (`.scopes` keys, at the REPO ROOT —
+# the TS side loads the same file via scripts/release/lib/config.ts).
+#
+# Why this matters: the release workflows expose a `scope` input as a
+# `type: choice` with a hard-coded `options:` list. That list is supposed to
+# be "regenerated from release.config.json", but nothing enforced it — so as
+# packages were enrolled/renamed in release.config.json the dropdowns could
+# drift (newly-enrolled packages wouldn't be canary-selectable; stale scopes
+# would linger). This guard fails CI whenever a dropdown diverges from the
+# config.
+#
+# Three files are checked:
+#   .github/workflows/publish-release.yml  — canary/prerelease + stable-retry `scope` input
+#   .github/workflows/stable-release.yml   — create-pr `scope` input (release / create-pr)
+#   .github/workflows/canary.yml           — one-click canary orchestrator `scope` input
+#
+# Sentinel exception: none of the workflows uses a non-scope sentinel option
+# (no `all` / `canary` pseudo-scope — an empty/omitted scope is handled
+# outside the options list). If a sentinel is ever introduced, add it to
+# SENTINELS below so it is excluded from the equality check.
+#
+# Secondary projection guarded here: publish-release.yml's `notify` job has a
+# `Resolve npm URL for scope` step whose `case "$SCOPE"` maps a dispatch
+# scope to a per-scope npm URL. Unlike ag-ui's per-scope ecosystem case
+# (which required full coverage), CopilotKit's case uses a `*)` catch-all,
+# so full per-scope coverage is NOT required. We instead verify the WEAKER
+# but still useful invariant: every EXPLICITLY-named arm (i.e. every arm
+# other than the `*)` catch-all) MUST be a valid scope from
+# release.config.json. This catches stale or renamed scopes lingering as
+# dead arms after a release.config.json rename/removal. See check_notify_case.
+
+set -euo pipefail
+
+# Make sort/comm/diff/string comparison byte-deterministic across environments (macOS vs CI).
+export LC_ALL=C
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CONFIG="$REPO_ROOT/release.config.json"
+PUBLISH_WF="$REPO_ROOT/.github/workflows/publish-release.yml"
+STABLE_WF="$REPO_ROOT/.github/workflows/stable-release.yml"
+CANARY_WF="$REPO_ROOT/.github/workflows/canary.yml"
+
+# Documented non-scope sentinel options to ignore (none today). Space-separated.
+SENTINELS=""
+
+for f in "$CONFIG" "$PUBLISH_WF" "$STABLE_WF" "$CANARY_WF"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: $f not found" >&2
+    exit 1
+  fi
+done
+
+# Authoritative scope set from release.config.json.
+CONFIG_SCOPES=$(jq -r '.scopes | keys[]' "$CONFIG" | sort -u)
+if [ -z "$CONFIG_SCOPES" ]; then
+  echo "ERROR: no scopes found under '.scopes' in $CONFIG — config corrupt or schema changed." >&2
+  exit 1
+fi
+
+# Extract the `options:` list belonging to the `scope:` input from a workflow.
+# Uses yq when available (the CI path on ubuntu-latest), otherwise a robust awk
+# pass (the local-dev fallback):
+#   - find the `scope:` input key (an `inputs:` child, indented 6 spaces),
+#   - within that block find its `options:` line,
+#   - collect the `- value` list items until indentation drops back out.
+#
+# yq path: the `on` key is quoted as .["on"] so it is read as the literal map
+# key and never YAML-1.1-boolean-coerced (`on`/`off`/`yes`/`no` → true/false).
+# The result is emitted on stdout; callers MUST treat zero options as a PARSER
+# failure (loud), distinct from a real drift mismatch — see check_workflow.
+extract_scope_options() {
+  local file="$1"
+  if command -v yq >/dev/null 2>&1; then
+    yq -r '.["on"].workflow_dispatch.inputs.scope.options[]' "$file" | sort -u
+    return
+  fi
+  awk '
+    # Match the scope input key: "      scope:" (6-space indent under inputs:).
+    /^      scope:[[:space:]]*$/ { in_scope = 1; next }
+    # Next sibling input ends the scope block. Match keys with OR without an
+    # inline value (the `      scope:` opener is consumed by the rule above).
+    in_scope && /^      [a-zA-Z0-9_-]+:/ { in_scope = 0 }
+    in_scope && /^        options:[[:space:]]*$/ { in_opts = 1; next }
+    in_opts {
+      # Skip blank lines and full-line YAML comments so readability whitespace
+      # or `# comment` lines between options do not silently terminate the
+      # collection (truncating the option set).
+      if ($0 ~ /^[[:space:]]*(#|$)/) next
+      # An options list item: "          - value"
+      if (match($0, /^[[:space:]]*-[[:space:]]+/)) {
+        val = $0
+        sub(/^[[:space:]]*-[[:space:]]+/, "", val)
+        sub(/[[:space:]]*#.*$/, "", val)   # inline YAML comment
+        gsub(/^["'"'"']|["'"'"']$/, "", val)       # surrounding quotes
+        sub(/[[:space:]]+$/, "", val)
+        if (val != "") print val
+        next
+      }
+      # Any non-list-item line ends the options block.
+      in_opts = 0
+      in_scope = 0
+    }
+  ' "$file" | sort -u
+}
+
+# Strip documented sentinels from an option set before comparing.
+strip_sentinels() {
+  local opts="$1"
+  if [ -z "$SENTINELS" ]; then
+    printf '%s\n' "$opts"
+    return
+  fi
+  local filtered="$opts"
+  for s in $SENTINELS; do
+    # Fixed-string match: sentinels containing regex metacharacters must not over-match.
+    filtered=$(printf '%s\n' "$filtered" | grep -Fvx -- "$s" || true)
+  done
+  printf '%s\n' "$filtered"
+}
+
+check_workflow() {
+  local name="$1" file="$2"
+  local opts
+  opts=$(extract_scope_options "$file")
+  opts=$(strip_sentinels "$opts")
+
+  # Zero options means the PARSER could not locate the scope options block (a
+  # yq/awk extraction failure or a structural change to the workflow), NOT that
+  # the dropdown drifted. Fail LOUD and distinctly so this is never mistaken for
+  # a real drift mismatch (which prints a diff below).
+  if [ -z "$opts" ]; then
+    echo "ERROR: parser could not find scope options in $file ($name)." >&2
+    echo "       Extracted ZERO options via $(command -v yq >/dev/null 2>&1 && echo yq || echo 'awk fallback')." >&2
+    echo "       This is a PARSER failure (not a drift mismatch): the 'scope' input's" >&2
+    echo "       'options:' list could not be located. Check the workflow structure or" >&2
+    echo "       the extractor in this script." >&2
+    return 1
+  fi
+
+  if [ "$opts" = "$CONFIG_SCOPES" ]; then
+    echo "OK: $name scope dropdown matches release.config.json scopes"
+    return 0
+  fi
+
+  echo "ERROR: $name scope dropdown is out of sync with release.config.json." >&2
+  echo "" >&2
+  echo "--- diff (release.config.json scopes  vs  $name options) ---" >&2
+  diff <(printf '%s\n' "$CONFIG_SCOPES") <(printf '%s\n' "$opts") >&2 || true
+  echo "" >&2
+  echo "Fix: update the 'scope' input 'options:' list in $file to exactly match" >&2
+  echo "the keys of '.scopes' in release.config.json" >&2
+  echo "(plus any documented sentinel listed in SENTINELS within this script)." >&2
+  return 1
+}
+
+# Verify the notify-job `Resolve npm URL for scope` step in publish-release.yml.
+# That step's `case "$SCOPE"` maps a dispatch scope to a per-scope npm URL.
+# CopilotKit's case uses a `*)` catch-all (unlike ag-ui's per-scope ecosystem
+# case which required full coverage), so we cannot assert full coverage here.
+# What we CAN — and do — assert is the weaker but still useful invariant:
+# every EXPLICITLY-named arm (every arm whose pattern is not `*`) MUST be a
+# valid scope from release.config.json. This catches stale/renamed scopes
+# lingering as dead arms after a config rename or removal.
+check_notify_case() {
+  local file="$1"
+
+  # Guard against silent parser degradation: this awk only recognizes the
+  # literal form `case "$SCOPE" in` and only the FIRST such block. If the
+  # workflow is refactored to e.g. `case "${SCOPE}" in`, or if a second block
+  # is added, the strict parser would silently validate nothing. Cross-check
+  # a loose grep against the strict form and fail loudly on mismatch.
+  #
+  # Both regexes are anchored to the start of the line (allowing only leading
+  # whitespace) so that prose comments mentioning the words case/SCOPE/in
+  # cannot trip the guard. Comments start with `#`, so `case` is never their
+  # first non-whitespace token.
+  local loose_count strict_count
+  loose_count=$(grep -cE '^[[:space:]]*case[[:space:]].*SCOPE.*[[:space:]]in([[:space:]]|$)' "$file" || true)
+  # Default to 0 on a hard grep failure: `grep -c ... || true` yields "0" on
+  # no-match (grep prints 0, exits 1) but EMPTY if grep itself fails (e.g.
+  # unreadable file), which would make the later integer `-ne` test die
+  # cryptically. Same below.
+  loose_count=${loose_count:-0}
+  # shellcheck disable=SC2016  # literal $SCOPE is intentional — we are matching shell source text, not expanding
+  strict_count=$(grep -cE '^[[:space:]]*case[[:space:]]+"\$SCOPE"[[:space:]]+in' "$file" || true)
+  strict_count=${strict_count:-0}
+  if [ "$loose_count" -ne "$strict_count" ]; then
+    echo "ERROR: $file has $loose_count case-on-SCOPE statement(s) but only $strict_count match the strict 'case \"\$SCOPE\" in' form this parser understands." >&2
+    echo "Update check_notify_case() in $0 to handle the new form." >&2
+    return 1
+  fi
+  if [ "$strict_count" -gt 1 ]; then
+    echo "ERROR: $file has $strict_count 'case \"\$SCOPE\" in' blocks; this parser validates only the first." >&2
+    echo "Update check_notify_case() in $0 to validate every block." >&2
+    return 1
+  fi
+  if [ "$strict_count" -eq 0 ]; then
+    echo "ERROR: no 'case \"\$SCOPE\" in' block found in $file." >&2
+    echo "The notify-job npm-url step was removed or restructured; update or remove check_notify_case() in $0 accordingly." >&2
+    return 1
+  fi
+
+  # Pull the explicit case-arm patterns from the FIRST `case "$SCOPE" in ...
+  # esac` block in the file. The notify job's `Resolve npm URL for scope` step
+  # is the only `case "$SCOPE"` in publish-release.yml; if more are added,
+  # this single-block parser will need updating.
+  local actual_explicit
+  actual_explicit=$(awk '
+    /^[[:space:]]*case[[:space:]]+"\$SCOPE"[[:space:]]+in/ { in_case = 1; next }
+    in_case && /^[[:space:]]*esac[[:space:]]*$/ { in_case = 0; exit }
+    # Comment lines inside the case body are never arms — skip them BEFORE the
+    # arm matcher (a comment like `# maps angular)` ends in ")" and would
+    # otherwise be misparsed as a stale arm).
+    in_case && /^[[:space:]]*#/ { next }
+    # Arm-shaped lines only: the entire line before the closing ")" must be
+    # pattern characters — extended to allow space and surrounding quotes so
+    # we accept legal forms like `"angular")` and `bot | bot-slack)`. We use a
+    # negated class that still excludes `=`, `$`, `(`, `:`, `/` (and `)` since
+    # `)` is the terminator) so body lines like `FOO=$(cmd)` or
+    # `path: /tmp/foo)` cannot match.
+    in_case && /^[[:space:]]*[^=$(:\/)]+\)[[:space:]]*$/ {
+      line = $0
+      sub(/[[:space:]]*\)[[:space:]]*$/, "", line)   # drop trailing ")"
+      sub(/^[[:space:]]+/, "", line)                 # drop leading indent
+      # Skip the catch-all arm.
+      if (line == "*") next
+      # Alternation: a|b|c — split on `|` and emit each pattern. Strip
+      # surrounding whitespace and surrounding quotes (single or double) from
+      # each alternative so `"angular"` and `bot | bot-slack` both yield the
+      # bare scope name. The '"'"' pattern is how a single quote is embedded
+      # inside a single-quoted shell heredoc (see line ~95 above).
+      n = split(line, arr, "|")
+      for (i = 1; i <= n; i++) {
+        p = arr[i]
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", p)
+        gsub(/^["'"'"']|["'"'"']$/, "", p)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", p)
+        if (p != "" && p != "*") print p
+      }
+    }
+  ' "$file" | sort -u)
+
+  # If there are no explicit arms (the case is `*)` only), nothing to check.
+  if [ -z "$actual_explicit" ]; then
+    echo "OK: publish-release.yml notify-job npm-url case has only a catch-all (nothing to validate)"
+    return 0
+  fi
+
+  # Every explicit arm must be a valid config scope.
+  local stale
+  stale=$(comm -23 <(printf '%s\n' "$actual_explicit") <(printf '%s\n' "$CONFIG_SCOPES"))
+
+  if [ -n "$stale" ]; then
+    echo "ERROR: publish-release.yml notify-job npm-url case names scope(s) not in release.config.json:" >&2
+    printf '%s\n' "$stale" | sed 's/^/  /' >&2
+    echo "" >&2
+    echo "Fix: remove or rename the stale arm(s) in the 'Resolve npm URL for scope' step" >&2
+    echo "so every explicitly-named case arm matches a key under '.scopes' in" >&2
+    echo "release.config.json. (The '*)' catch-all handles scopes without a custom URL," >&2
+    echo "so full per-scope coverage is intentionally NOT required.)" >&2
+    return 1
+  fi
+
+  echo "OK: publish-release.yml notify-job npm-url case explicit arms are all valid scopes"
+  return 0
+}
+
+rc=0
+check_workflow "publish-release.yml" "$PUBLISH_WF" || rc=1
+check_workflow "stable-release.yml"  "$STABLE_WF"  || rc=1
+check_workflow "canary.yml"          "$CANARY_WF"  || rc=1
+check_notify_case "$PUBLISH_WF" || rc=1
+
+if [ "$rc" -ne 0 ]; then
+  exit 1
+fi
+
+echo "OK: all release scope dropdowns match release.config.json; notify-job npm-url case explicit arms are all valid scopes"
+exit 0


### PR DESCRIPTION
## Summary

Ports [ag-ui-protocol/ag-ui#1914](https://github.com/ag-ui-protocol/ag-ui/pull/1914) to CopilotKit — plus the two supporting guard files ag-ui already had:

- **`.github/workflows/canary.yml`** — discoverable **`canary / publish`** `workflow_dispatch` orchestrator. Any maintainer can publish a prerelease of the branch they're on straight from the Actions tab. It is a thin orchestrator — it does **not** publish to npm itself:
  1. Guards against `main` and non-branch refs.
  2. Mints the devops-bot App token (app-id `1108748`, `DEVOPS_BOT_PRIVATE_KEY`) with scoped `contents:write` + `actions:write`.
  3. Mirrors the dispatched ref to a unique `canary/<slug>-<run_id>-<attempt>` branch via the GitHub API (no checkout).
  4. Dispatches **`publish-release.yml --ref canary/<slug> -f mode=prerelease …`**, locates the run, and waits (`gh run watch --exit-status` + explicit conclusion check).
  5. Deletes the canary ref — status-gated (never yanks the ref under a still-running delegated run) with a fresh cleanup token (90-min job ceiling exceeds the 1h App-token TTL).
- **`scripts/release/verify-release-scope-dropdowns.sh`** — drift guard: the hand-maintained `scope` dropdowns in `publish-release.yml` / `stable-release.yml` / `canary.yml` must exactly match `release.config.json`'s `.scopes` keys. Parsers fail loud and distinct on structural changes instead of silently passing.
- **`.github/workflows/lint-release-workflows.yml`** — actionlint + shellcheck + the dropdown-sync job over the release pipelines.

### Why a separate orchestrator (and not a flag in publish-release.yml)
- A GitHub Environment's deployment-branch policy is evaluated against the ref a run is **triggered on** — not branches created mid-run. The orchestrator exists to get the publish run *onto* a `canary/*` ref.
- `publish-release.yml` holds the **single npm OIDC trusted-publisher binding**; a second publishing entry point would break OIDC for every `@copilotkit/*` package. The orchestrator never touches npm.
- The cross-workflow dispatch uses the **App token, not `GITHUB_TOKEN`** — `GITHUB_TOKEN`-authenticated events never start new workflow runs.

**Note:** the `npm` environment currently has *no* deployment-branch policy, so the orchestrator is a convenience wrapper today. Tightening the policy to `main` + `canary/*` + `release/publish/*` (matching ag-ui's security posture) is being applied as repo configuration alongside this PR — requires admin. This PR includes the prerequisite: `publish-commit.yml` (pkg-pr-new) is removed from the `npm` environment, since it runs on every PR and would be blocked by the policy (it publishes to pkg.pr.new, not npm, and uses no environment secrets).

## Testing done
- Drift guard: positive run against all three real workflows; negative tests (scope removed → drift FAIL with diff; bogus scope → FAIL; `case "${SCOPE}"` quoting refactor → loud parser-degradation FAIL; whole case block deleted → loud zero-block FAIL; quoted arm `"angular")` → accepted; blank/comment lines inside `options:` → still parsed; prose comments mentioning case/SCOPE/in → no false positive).
- `shellcheck` clean at all severities; `bash -n` on every workflow `run:` block; YAML parses.
- 3 rounds of 7-agent code review converged to zero load-bearing findings.

## ⚠️ Still to verify before first real use
- [ ] devops-bot App (id 1108748) has **Actions: write** — required for the in-workflow `gh workflow run`. Safe first test: dispatch once with `dry_run=true`.
- [ ] First `dry_run=false` run clears the `npm` environment end-to-end via the App token once the deployment-branch policy is tightened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Post-merge follow-ups (maintainer action required)

These need repo **admin** rights and must happen **in this order**:

1. **Merge this PR first.** `main`'s current `publish-commit.yml` (pkg-pr-new) still sits in the `npm` environment and runs on every PR touching `packages/**` — applying the branch policy before this PR lands would block every snapshot publish. This PR removes that environment association.

2. **Tighten the `npm` environment's deployment-branch policy** to `main` + `canary/*` + `release/publish/*` (matching ag-ui). With an admin-scoped token:

   ```bash
   gh api --method PUT repos/CopilotKit/CopilotKit/environments/npm \
     -F "deployment_branch_policy[protected_branches]=false" \
     -F "deployment_branch_policy[custom_branch_policies]=true"
   gh api --method POST repos/CopilotKit/CopilotKit/environments/npm/deployment-branch-policies -f name="main" -f type=branch
   gh api --method POST repos/CopilotKit/CopilotKit/environments/npm/deployment-branch-policies -f name="canary/*" -f type=branch
   gh api --method POST repos/CopilotKit/CopilotKit/environments/npm/deployment-branch-policies -f name="release/publish/*" -f type=branch
   ```

   Or via UI: Settings → Environments → npm → Deployment branches and tags → "Selected branches and tags" → add the three patterns above.

   Why these three: `main` covers stable `workflow_dispatch` retries and `stable-release.yml`; `release/publish/*` covers the merged-release-PR runs (the run's head branch is the release PR branch); `canary/*` covers the orchestrator's delegated prerelease runs. After this, direct `mode=prerelease` dispatches from arbitrary feature branches stop working — the `canary / publish` orchestrator becomes the one-click path (by design).

3. **Verify the devops-bot App (id `1108748`) has `Actions: write`** (org/App settings). The orchestrator's `gh workflow run` dispatch 403s without it. Safe end-to-end test, after step 2: Actions tab → **canary / publish** → pick any feature branch, any scope, **`dry_run=true`** → confirm the delegated `release / publish` run is created, watched, and the `canary/*` ref is deleted afterward.

4. **First real canary** (`dry_run=false`) confirms the npm OIDC publish clears the environment gate end-to-end on a `canary/*` ref.
