### PR TITLE
fix(sdk-python): sanitize raw_event to prevent deepcopy crash on non-copyable objects

### DIFF
--- a/sdk-python/copilotkit/langgraph_agui_agent.py
+++ b/sdk-python/copilotkit/langgraph_agui_agent.py
@@ -1,3 +1,4 @@
+import dataclasses
 import json
 import logging
 from typing import Dict, Any, List, Optional, Union, AsyncGenerator
@@ -57,6 +58,41 @@ TextMessageEvents = Union[
 ToolCallEvents = Union[ToolCallStartEvent, ToolCallArgsEvent, ToolCallEndEvent]
 
 
+def _make_safe(obj, _seen=None):
+    """Recursively convert obj to a JSON-safe structure.
+
+    Replaces non-serializable values with placeholder strings like
+    "<non-serializable: ClassName>". Handles circular references by
+    returning "<circular: ClassName>" to prevent infinite loops.
+    """
+    if _seen is None:
+        _seen = set()
+    obj_id = id(obj)
+    if obj_id in _seen:
+        return f"<circular: {type(obj).__name__}>"
+    if obj is None or isinstance(obj, (bool, int, float, str)):
+        return obj
+    _seen.add(obj_id)
+    try:
+        if isinstance(obj, dict):
+            return {str(k): _make_safe(v, _seen) for k, v in obj.items()}
+        if isinstance(obj, (list, tuple)):
+            return [_make_safe(v, _seen) for v in obj]
+        if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+            return {k: _make_safe(v, _seen) for k, v in obj.__dict__.items()}
+        if hasattr(obj, "model_dump"):
+            try:
+                return _make_safe(obj.model_dump(), _seen)
+            except Exception:
+                return f"<non-serializable: {type(obj).__name__}>"
+        json.dumps(obj)
+        return obj
+    except (TypeError, ValueError, OverflowError):
+        return f"<non-serializable: {type(obj).__name__}>"
+    finally:
+        _seen.discard(obj_id)
+
+
 class LangGraphAGUIAgent(LangGraphAgent):
     def __init__(
         self,
@@ -69,6 +105,13 @@ class LangGraphAGUIAgent(LangGraphAgent):
         super().__init__(name=name, graph=graph, description=description, config=config)
         self.constant_schema_keys = self.constant_schema_keys + ["copilotkit"]
 
+    @staticmethod
+    def _safe_raw_event(raw_event):
+        """Produce a JSON-safe copy of raw_event, replacing non-serializable values."""
+        if raw_event is None:
+            return None
+        return _make_safe(raw_event)
+
     def _dispatch_event(self, event) -> str:
         """Override the dispatch event method to handle custom CopilotKit events and filtering.
 
@@ -76,6 +119,12 @@ class LangGraphAGUIAgent(LangGraphAgent):
         but the base class also violates it by returning event objects). The None values are
         filtered out in run() before reaching the encoder.
         """
+        # Sanitize raw_event to prevent deepcopy crashes on non-copyable objects (MCP tools, DB connections)
+        if hasattr(event, "raw_event") and event.raw_event is not None:
+            try:
+                event.raw_event = self._safe_raw_event(event.raw_event)
+            except Exception:
+                event.raw_event = None
 
         if event.type == EventType.CUSTOM:
             custom_event = event

--- a/sdk-python/tests/test_raw_event_sanitization.py
+++ b/sdk-python/tests/test_raw_event_sanitization.py
@@ -1,0 +1,267 @@
+"""Tests for raw_event sanitization to prevent deepcopy crashes on non-copyable objects."""
+
+import dataclasses
+import json
+from unittest.mock import Mock, patch, MagicMock
+
+import pytest
+
+from copilotkit.langgraph_agui_agent import _make_safe, LangGraphAGUIAgent
+from ag_ui_langgraph import LangGraphAgent
+
+
+class NonCopyableObject:
+    """Simulates a non-copyable object like a Cython extension or HTTP client."""
+
+    def __init__(self, name: str = "NonCopyable"):
+        self.name = name
+
+    def __reduce__(self):
+        raise TypeError("no default __reduce__ due to non-trivial __cinit__")
+
+
+@dataclasses.dataclass
+class SampleDataclass:
+    """Sample dataclass for testing."""
+
+    field1: str
+    field2: int
+
+
+class TestMakeSafe:
+    """Test the _make_safe() helper function."""
+
+    def test_make_safe_with_plain_dict(self):
+        """Plain dict with JSON-serializable values should pass through."""
+        obj = {"key": "value", "number": 42}
+        result = _make_safe(obj)
+        assert result == obj
+        assert json.dumps(result)  # Should be JSON-serializable
+
+    def test_make_safe_with_non_copyable_object(self):
+        """Dict containing non-copyable object should replace with placeholder."""
+        non_copyable = NonCopyableObject("test_object")
+        obj = {"safe": "value", "unsafe": non_copyable}
+        result = _make_safe(obj)
+
+        assert isinstance(result, dict)
+        assert result["safe"] == "value"
+        assert result["unsafe"] == "<non-serializable: NonCopyableObject>"
+        assert json.dumps(result)  # Should be JSON-serializable
+
+    def test_make_safe_with_dataclass_containing_non_serializable(self):
+        """Dataclass with non-serializable fields should sanitize recursively."""
+        non_copyable = NonCopyableObject()
+        dc = SampleDataclass(field1="text", field2=123)
+        dc.field3 = non_copyable  # Add non-serializable field
+
+        obj = {"dataclass": dc}
+        result = _make_safe(obj)
+
+        assert isinstance(result, dict)
+        assert isinstance(result["dataclass"], dict)
+        assert result["dataclass"]["field1"] == "text"
+        assert result["dataclass"]["field2"] == 123
+        assert result["dataclass"]["field3"] == "<non-serializable: NonCopyableObject>"
+        assert json.dumps(result)
+
+    def test_make_safe_with_circular_references(self):
+        """Circular references should not cause infinite loops."""
+        obj = {"key": "value"}
+        obj["self"] = obj  # Create circular reference
+
+        result = _make_safe(obj)
+
+        assert isinstance(result, dict)
+        assert result["key"] == "value"
+        assert result["self"] == "<circular: dict>"
+        assert json.dumps(result)  # Should be JSON-serializable
+
+    def test_make_safe_with_nested_structures(self):
+        """Nested dicts/lists with mixed safe and unsafe values."""
+        non_copyable = NonCopyableObject("nested")
+        obj = {
+            "level1": {
+                "level2": [1, 2, {"unsafe": non_copyable}, "safe"],
+                "number": 42,
+            },
+            "list": [True, False, non_copyable],
+        }
+        result = _make_safe(obj)
+
+        assert (
+            result["level1"]["level2"][2]["unsafe"]
+            == "<non-serializable: NonCopyableObject>"
+        )
+        assert result["list"][2] == "<non-serializable: NonCopyableObject>"
+        assert json.dumps(result)
+
+    def test_make_safe_with_none_values(self):
+        """None values should pass through."""
+        obj = {"key": None, "another": "value"}
+        result = _make_safe(obj)
+        assert result == obj
+
+    def test_make_safe_with_bool_int_float_str(self):
+        """Primitive types should pass through."""
+        obj = {"bool": True, "int": 42, "float": 3.14, "str": "text"}
+        result = _make_safe(obj)
+        assert result == obj
+
+    def test_make_safe_with_list_containing_non_copyable(self):
+        """Lists should be sanitized recursively."""
+        non_copyable = NonCopyableObject()
+        obj = [1, "text", non_copyable, {"nested": non_copyable}]
+        result = _make_safe(obj)
+
+        assert result[0] == 1
+        assert result[1] == "text"
+        assert result[2] == "<non-serializable: NonCopyableObject>"
+        assert result[3]["nested"] == "<non-serializable: NonCopyableObject>"
+        assert json.dumps(result)
+
+    def test_make_safe_with_pydantic_model(self):
+        """Pydantic models with model_dump should be handled."""
+        try:
+            from pydantic import BaseModel
+
+            class PydanticModel(BaseModel):
+                field1: str
+                field2: int
+
+            model = PydanticModel(field1="test", field2=42)
+            obj = {"model": model}
+            result = _make_safe(obj)
+
+            assert isinstance(result["model"], dict)
+            assert result["model"]["field1"] == "test"
+            assert result["model"]["field2"] == 42
+            assert json.dumps(result)
+        except ImportError:
+            pytest.skip("pydantic not installed")
+
+    def test_make_safe_with_dataclass_nested(self):
+        """Nested dataclasses should be recursively sanitized."""
+        dc1 = SampleDataclass(field1="inner", field2=10)
+        dc2 = SampleDataclass(field1="outer", field2=20)
+        dc2.nested = dc1  # Add nested dataclass
+
+        result = _make_safe(dc2)
+
+        assert isinstance(result, dict)
+        assert result["field1"] == "outer"
+        assert result["nested"]["field1"] == "inner"
+        assert json.dumps(result)
+
+
+class TestLangGraphAGUIAgentSafeRawEvent:
+    """Test LangGraphAGUIAgent._safe_raw_event() method."""
+
+    def test_safe_raw_event_with_none(self):
+        """None input should return None."""
+        assert LangGraphAGUIAgent._safe_raw_event(None) is None
+
+    def test_safe_raw_event_with_dict(self):
+        """Dict input should be sanitized."""
+        obj = {"key": "value", "unsafe": NonCopyableObject()}
+        result = LangGraphAGUIAgent._safe_raw_event(obj)
+
+        assert isinstance(result, dict)
+        assert result["key"] == "value"
+        assert result["unsafe"] == "<non-serializable: NonCopyableObject>"
+
+
+class TestLangGraphAGUIAgentDispatchEvent:
+    """Test LangGraphAGUIAgent._dispatch_event() sanitization."""
+
+    @pytest.fixture
+    def mock_agent(self):
+        """Create a mock LangGraphAGUIAgent for testing."""
+        with patch(
+            "copilotkit.langgraph_agui_agent.LangGraphAgent.__init__"
+        ) as mock_init:
+            mock_init.return_value = None
+            agent = MagicMock(spec=LangGraphAGUIAgent)
+            agent.constant_schema_keys = []
+            agent.active_run = {}
+            # Use the real _safe_raw_event and _dispatch_event methods
+            agent._safe_raw_event = LangGraphAGUIAgent._safe_raw_event
+            agent._dispatch_event = LangGraphAGUIAgent._dispatch_event.__get__(
+                agent, LangGraphAGUIAgent
+            )
+            return agent
+
+    def test_dispatch_event_sanitizes_raw_event(self, mock_agent):
+        """_dispatch_event should sanitize raw_event before passing to parent."""
+        non_copyable = NonCopyableObject()
+        event = Mock()
+        event.type = "CUSTOM"
+        event.name = "unknown_event"
+        event.raw_event = {"data": "test", "unsafe": non_copyable}
+
+        # Mock the parent _dispatch_event
+        with patch(
+            "copilotkit.langgraph_agui_agent.LangGraphAgent._dispatch_event",
+            return_value=None,
+        ):
+            try:
+                mock_agent._dispatch_event(event)
+            except AttributeError:
+                # Expected if parent method is not fully mocked; we just care about sanitization
+                pass
+
+        # raw_event should be sanitized
+        assert isinstance(event.raw_event, dict)
+        assert event.raw_event["data"] == "test"
+        assert event.raw_event["unsafe"] == "<non-serializable: NonCopyableObject>"
+
+    def test_dispatch_event_handles_none_raw_event(self, mock_agent):
+        """_dispatch_event should handle None raw_event gracefully."""
+        event = Mock()
+        event.type = "TEXT_MESSAGE_START"
+        event.raw_event = None
+
+        with patch.object(LangGraphAgent, "_dispatch_event", return_value="dispatched"):
+            mock_agent._dispatch_event(event)
+
+        # Should not raise an exception
+        assert event.raw_event is None
+
+    def test_dispatch_event_handles_missing_raw_event_attribute(self, mock_agent):
+        """_dispatch_event should handle events without raw_event attribute."""
+        event = Mock()
+        del event.raw_event  # Remove the raw_event attribute
+        event.type = "CUSTOM"
+        event.name = "unknown_event"
+
+        with patch(
+            "copilotkit.langgraph_agui_agent.LangGraphAgent._dispatch_event",
+            return_value=None,
+        ):
+            try:
+                mock_agent._dispatch_event(event)
+            except (AttributeError, TypeError):
+                # Expected if event structure is incomplete; we just care that it doesn't crash on missing raw_event
+                pass
+
+        # Should not raise an exception about raw_event
+        # (any AttributeError would be about other event attributes, not raw_event)
+        assert True
+
+    def test_dispatch_event_exception_handling(self, mock_agent):
+        """_dispatch_event should set raw_event to None on unexpected errors during sanitization."""
+        event = Mock()
+        event.type = "TEXT_MESSAGE_START"
+        event.raw_event = {"key": "value"}
+
+        # Patch _safe_raw_event to raise an exception
+        with patch.object(
+            mock_agent, "_safe_raw_event", side_effect=RuntimeError("Unexpected error")
+        ):
+            with patch.object(
+                LangGraphAgent, "_dispatch_event", return_value="dispatched"
+            ):
+                mock_agent._dispatch_event(event)
+
+        # raw_event should be set to None on exception
+        assert event.raw_event is None


### PR DESCRIPTION
## Summary
LangGraph agents using MCP tools (`langchain-mcp-adapters`) or holding DB connections crash during event streaming with `TypeError: no default __reduce__ due to non-trivial __cinit__`. The crash occurs when `ag_ui_langgraph`'s `make_json_safe()` calls `dataclasses.asdict()`, which internally uses `copy.deepcopy()` on objects that cannot be pickled.

## Root cause
`LangGraphAGUIAgent._dispatch_event()` delegates to `super()._dispatch_event(event)` at multiple points (`langgraph_agui_agent.py:85-108, 191, 206, 245`). The parent class (`ag_ui_langgraph.LangGraphAgent`) runs `make_json_safe(event.raw_event)`, which calls `asdict()` on dataclass values inside `raw_event`. `asdict()` uses `copy.deepcopy()`, which fails on Cython extensions (MCP tool handles), httpx clients, and DB connections with `TypeError: no default __reduce__ due to non-trivial __cinit__`.

## Changes
- `sdk-python/copilotkit/langgraph_agui_agent.py`: add `_make_safe()` helper that recursively walks `raw_event` and replaces non-serializable values with `"<non-serializable: ClassName>"` placeholders, using `__dict__` instead of `asdict()` to avoid `deepcopy`. Sanitize `event.raw_event` at the top of `_dispatch_event()` before any `super()` call. (~40 lines)
- `sdk-python/tests/test_raw_event_sanitization.py`: new test file covering plain dicts, non-copyable objects, dataclass fields, circular references, nested mixed values, and end-to-end `_dispatch_event` safety. (~80 lines)

## What is NOT changed
- `ag_ui_langgraph`'s `make_json_safe()` is an external dependency and is not modified; it still runs but now receives pre-sanitized input.
- JSON-serializable fields in `raw_event` pass through unchanged; only non-serializable leaves are replaced with placeholder strings.
- CrewAI's `deepcopy` usage (copies crew/flow objects, not event payloads) is unrelated and untouched.
- The middleware (`copilotkit_lg_middleware.py`) is not changed.

## Related PRs and Issues
Closes #3051.

## Test plan
- [x] `cd sdk-python && pytest tests/test_raw_event_sanitization.py -v` -- 16/16 pass
- [ ] CI green