### PR TITLE
fix(sdk-python): emit tool call events for middleware-intercepted SDK Actions

### DIFF
--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -946,30 +946,8 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         state: StateSchema,
         runtime: Runtime[Any],
     ) -> dict[str, Any] | None:
-        # Get the base interception result from the sync implementation
-        result = self.after_model(state, runtime)
-        if result is None:
-            return None
-
-        # Emit custom events for intercepted tool calls so the AG-UI event stream
-        # can pick them up and emit corresponding TOOL_CALL_* events to the frontend.
-        intercepted = (result.get("copilotkit") or {}).get("intercepted_tool_calls", [])
-        if intercepted:
-            from langchain_core.callbacks.manager import adispatch_custom_event
-            from langgraph.config import get_config
-
-            config = get_config()
-            for call in intercepted:
-                await adispatch_custom_event(
-                    "copilotkit_manually_emit_tool_call",
-                    {
-                        "name": call.get("name", ""),
-                        "args": call.get("args", {}),
-                        "id": call.get("id", ""),
-                    },
-                    config=config,
-                )
-        return result
+        # Delegate to sync implementation
+        return self.after_model(state, runtime)
 
     # Restore frontend tool calls to AIMessage before agent exits
     def after_agent(

--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -946,8 +946,30 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         state: StateSchema,
         runtime: Runtime[Any],
     ) -> dict[str, Any] | None:
-        # Delegate to sync implementation
-        return self.after_model(state, runtime)
+        # Get the base interception result from the sync implementation
+        result = self.after_model(state, runtime)
+        if result is None:
+            return None
+
+        # Emit custom events for intercepted tool calls so the AG-UI event stream
+        # can pick them up and emit corresponding TOOL_CALL_* events to the frontend.
+        intercepted = (result.get("copilotkit") or {}).get("intercepted_tool_calls", [])
+        if intercepted:
+            from langchain_core.callbacks.manager import adispatch_custom_event
+            from langgraph.config import get_config
+
+            config = get_config()
+            for call in intercepted:
+                await adispatch_custom_event(
+                    "copilotkit_manually_emit_tool_call",
+                    {
+                        "name": call.get("name", ""),
+                        "args": call.get("args", {}),
+                        "id": call.get("id", ""),
+                    },
+                    config=config,
+                )
+        return result
 
     # Restore frontend tool calls to AIMessage before agent exits
     def after_agent(

--- a/sdk-python/copilotkit/langgraph_agui_agent.py
+++ b/sdk-python/copilotkit/langgraph_agui_agent.py
@@ -44,6 +44,7 @@ class LangGraphEventTypes(Enum):
     """LangGraph event types"""
 
     OnChatModelStream = "on_chat_model_stream"
+    OnChatModelEnd = "on_chat_model_end"
     OnCustomEvent = "on_custom_event"
 
 
@@ -283,7 +284,9 @@ class LangGraphAGUIAgent(LangGraphAgent):
             for emitted_event in self._intercepted_frontend_tool_call_events(event):
                 yield self._dispatch_event(emitted_event)
 
-    def _intercepted_frontend_tool_call_events(self, event: Any) -> list[ToolCallEvents]:
+    def _intercepted_frontend_tool_call_events(
+        self, event: Any
+    ) -> list[ToolCallEvents]:
         frontend_tool_names = self._frontend_tool_names()
         if not frontend_tool_names:
             return []

--- a/sdk-python/copilotkit/langgraph_agui_agent.py
+++ b/sdk-python/copilotkit/langgraph_agui_agent.py
@@ -29,8 +29,6 @@ except ImportError:
     # Langchain >= 1.0.0
     from langchain_core.messages import BaseMessage
 
-logger = logging.getLogger(__name__)
-
 
 class CustomEventNames(Enum):
     """Custom event names for CopilotKit"""
@@ -44,7 +42,6 @@ class LangGraphEventTypes(Enum):
     """LangGraph event types"""
 
     OnChatModelStream = "on_chat_model_stream"
-    OnChatModelEnd = "on_chat_model_end"
     OnCustomEvent = "on_custom_event"
 
 
@@ -115,86 +112,11 @@ class LangGraphAGUIAgent(LangGraphAgent):
                 return super()._dispatch_event(event)
 
             if custom_event.name == CustomEventNames.ManuallyEmitToolCall.value:
-                value = custom_event.value
-                if not isinstance(value, dict):
-                    raise CopilotKitMisuseError(
-                        f"ManuallyEmitToolCall event 'value' must be a dict, got {type(value).__name__}"
-                    )
-
-                tool_call_id = value.get("id")
-                tool_call_name = value.get("name")
-                tool_call_args = value.get("args")
-
-                if not isinstance(tool_call_id, str) or not tool_call_id.strip():
-                    raise CopilotKitMisuseError(
-                        f"ManuallyEmitToolCall event missing valid 'id': got {type(tool_call_id).__name__}"
-                    )
-                if not isinstance(tool_call_name, str) or not tool_call_name.strip():
-                    raise CopilotKitMisuseError(
-                        f"ManuallyEmitToolCall event missing valid 'name': got {type(tool_call_name).__name__}"
-                    )
-                if tool_call_args is None:
-                    raise CopilotKitMisuseError(
-                        f"ManuallyEmitToolCall event missing 'args' for tool_call_id={tool_call_id}"
-                    )
-
-                try:
-                    delta = (
-                        tool_call_args
-                        if isinstance(tool_call_args, str)
-                        else json.dumps(tool_call_args)
-                    )
-                except (TypeError, ValueError) as e:
-                    raise CopilotKitMisuseError(
-                        f"ManuallyEmitToolCall 'args' is not JSON-serializable for tool_call_id={tool_call_id}: {e}"
-                    ) from e
-
-                dispatched_start = False
-                end_dispatched = False
-                try:
-                    super()._dispatch_event(
-                        ToolCallStartEvent(
-                            type=EventType.TOOL_CALL_START,
-                            tool_call_id=tool_call_id,
-                            tool_call_name=tool_call_name,
-                            parent_message_id=tool_call_id,
-                            raw_event=event,
-                        )
-                    )
-                    dispatched_start = True
-                    super()._dispatch_event(
-                        ToolCallArgsEvent(
-                            type=EventType.TOOL_CALL_ARGS,
-                            tool_call_id=tool_call_id,
-                            delta=delta,
-                            raw_event=event,
-                        )
-                    )
-                    super()._dispatch_event(
-                        ToolCallEndEvent(
-                            type=EventType.TOOL_CALL_END,
-                            tool_call_id=tool_call_id,
-                            raw_event=event,
-                        )
-                    )
-                    end_dispatched = True
-                except Exception:
-                    if dispatched_start and not end_dispatched:
-                        try:
-                            super()._dispatch_event(
-                                ToolCallEndEvent(
-                                    type=EventType.TOOL_CALL_END,
-                                    tool_call_id=tool_call_id,
-                                    raw_event=event,
-                                )
-                            )
-                        except Exception:
-                            logger.error(
-                                "Failed to emit compensating TOOL_CALL_END for %s",
-                                tool_call_id,
-                                exc_info=True,
-                            )
-                    raise
+                self._materialize_tool_call_events(
+                    custom_event.value,
+                    event,
+                    parent_message_id=None,
+                )
                 return super()._dispatch_event(event)
 
             if custom_event.name == CustomEventNames.ManuallyEmitState.value:
@@ -280,91 +202,159 @@ class LangGraphAGUIAgent(LangGraphAgent):
         async for event_str in super()._handle_single_event(event, state):
             yield event_str
 
-        if event.get("event") == LangGraphEventTypes.OnChatModelEnd.value:
-            for emitted_event in self._intercepted_frontend_tool_call_events(event):
-                yield self._dispatch_event(emitted_event)
+        if event.get("event") != "on_chain_end":
+            return
 
-    def _intercepted_frontend_tool_call_events(
-        self, event: Any
-    ) -> list[ToolCallEvents]:
-        frontend_tool_names = self._frontend_tool_names()
-        if not frontend_tool_names:
-            return []
-
-        streamed_tool_call_ids = (getattr(self, "active_run", None) or {}).setdefault(
-            "streamed_tool_call_ids",
-            set(),
-        )
         output = (event.get("data") or {}).get("output")
-        tool_calls = getattr(output, "tool_calls", None) or []
-        parent_message_id = getattr(output, "id", None)
+        copilotkit_state = (
+            output.get("copilotkit") if isinstance(output, dict) else None
+        )
+        if not isinstance(copilotkit_state, dict):
+            return
 
-        emitted_events: list[ToolCallEvents] = []
-        for tool_call in tool_calls:
-            if not isinstance(tool_call, dict):
-                continue
+        intercepted_tool_calls = copilotkit_state.get("intercepted_tool_calls")
+        parent_message_id = copilotkit_state.get("original_ai_message_id")
+        if not isinstance(intercepted_tool_calls, list) or not isinstance(
+            parent_message_id, str
+        ):
+            return
 
-            tool_call_id = tool_call.get("id")
-            tool_call_name = tool_call.get("name")
-            tool_call_args = tool_call.get("args")
-
-            if (
-                tool_call_name not in frontend_tool_names
-                or not isinstance(tool_call_id, str)
-                or not tool_call_id.strip()
-                or tool_call_id in streamed_tool_call_ids
-            ):
-                continue
-
-            try:
-                delta = (
-                    tool_call_args
-                    if isinstance(tool_call_args, str)
-                    else json.dumps(tool_call_args)
-                )
-            except (TypeError, ValueError):
-                logger.warning(
-                    "Skipping frontend tool call %s because args are not JSON-serializable",
-                    tool_call_id,
-                    exc_info=True,
-                )
-                continue
-
-            streamed_tool_call_ids.add(tool_call_id)
-            emitted_events.extend(
-                [
-                    ToolCallStartEvent(
-                        type=EventType.TOOL_CALL_START,
-                        tool_call_id=tool_call_id,
-                        tool_call_name=tool_call_name,
-                        parent_message_id=parent_message_id or tool_call_id,
-                        raw_event=event,
-                    ),
-                    ToolCallArgsEvent(
-                        type=EventType.TOOL_CALL_ARGS,
-                        tool_call_id=tool_call_id,
-                        delta=delta,
-                        raw_event=event,
-                    ),
-                    ToolCallEndEvent(
-                        type=EventType.TOOL_CALL_END,
-                        tool_call_id=tool_call_id,
-                        raw_event=event,
-                    ),
-                ]
+        valid_calls = [
+            call
+            for call in intercepted_tool_calls
+            if self._materialize_tool_call_events(
+                call, event, parent_message_id=parent_message_id, dispatch=False
             )
-
-        return emitted_events
-
-    def _frontend_tool_names(self) -> set[str]:
-        names: set[str] = set()
-        for tool in (self._copilotkit_runtime_payload or {}).get("actions") or []:
-            if not isinstance(tool, dict):
+        ]
+        streamed_tool_call_ids = (getattr(self, "active_run", None) or {}).setdefault(
+            "streamed_tool_call_ids", set()
+        )
+        for call in valid_calls:
+            tool_call_id = call["id"]
+            # The parent adapter records streamed IDs even when lifecycle emission is suppressed.
+            if tool_call_id in streamed_tool_call_ids:
                 continue
-            name = tool.get("function", {}).get("name") or tool.get("name")
-            if isinstance(name, str) and name.strip():
-                names.add(name)
-        return names
+            if self._materialize_tool_call_events(
+                call,
+                event,
+                parent_message_id=parent_message_id,
+                dispatch_via_adapter=True,
+            ):
+                streamed_tool_call_ids.add(tool_call_id)
+
+    def _materialize_tool_call_events(
+        self,
+        value: Any,
+        event: Any,
+        *,
+        parent_message_id: Optional[str],
+        dispatch: bool = True,
+        dispatch_via_adapter: bool = False,
+    ) -> bool:
+        if not isinstance(value, dict):
+            if dispatch:
+                raise CopilotKitMisuseError(
+                    f"ManuallyEmitToolCall event 'value' must be a dict, got {type(value).__name__}"
+                )
+            return False
+
+        tool_call_id = value.get("id")
+        tool_call_name = value.get("name")
+        tool_call_args = value.get("args")
+        if not isinstance(tool_call_id, str) or not tool_call_id.strip():
+            if dispatch:
+                raise CopilotKitMisuseError(
+                    f"ManuallyEmitToolCall event missing valid 'id': got {type(tool_call_id).__name__}"
+                )
+            logger.warning("Skipping intercepted tool call with invalid id")
+            return False
+        if not isinstance(tool_call_name, str) or not tool_call_name.strip():
+            if dispatch:
+                raise CopilotKitMisuseError(
+                    f"ManuallyEmitToolCall event missing valid 'name': got {type(tool_call_name).__name__}"
+                )
+            logger.warning(
+                "Skipping intercepted tool call %s with invalid name", tool_call_id
+            )
+            return False
+        if tool_call_args is None:
+            if dispatch:
+                raise CopilotKitMisuseError(
+                    f"ManuallyEmitToolCall event missing 'args' for tool_call_id={tool_call_id}"
+                )
+            logger.warning(
+                "Skipping intercepted tool call %s without args", tool_call_id
+            )
+            return False
+        try:
+            delta = (
+                tool_call_args
+                if isinstance(tool_call_args, str)
+                else json.dumps(tool_call_args)
+            )
+        except (TypeError, ValueError) as error:
+            if dispatch:
+                raise CopilotKitMisuseError(
+                    f"ManuallyEmitToolCall 'args' is not JSON-serializable for tool_call_id={tool_call_id}: {error}"
+                ) from error
+            logger.warning(
+                "Skipping intercepted tool call %s with non-serializable args",
+                tool_call_id,
+            )
+            return False
+        if not dispatch:
+            return True
+
+        dispatched_start = False
+        end_dispatched = False
+        dispatch_event = (
+            self._dispatch_event if dispatch_via_adapter else super()._dispatch_event
+        )
+        try:
+            dispatch_event(
+                ToolCallStartEvent(
+                    type=EventType.TOOL_CALL_START,
+                    tool_call_id=tool_call_id,
+                    tool_call_name=tool_call_name,
+                    parent_message_id=parent_message_id or tool_call_id,
+                    raw_event=event,
+                )
+            )
+            dispatched_start = True
+            dispatch_event(
+                ToolCallArgsEvent(
+                    type=EventType.TOOL_CALL_ARGS,
+                    tool_call_id=tool_call_id,
+                    delta=delta,
+                    raw_event=event,
+                )
+            )
+            dispatch_event(
+                ToolCallEndEvent(
+                    type=EventType.TOOL_CALL_END,
+                    tool_call_id=tool_call_id,
+                    raw_event=event,
+                )
+            )
+            end_dispatched = True
+        except Exception:
+            if dispatched_start and not end_dispatched:
+                try:
+                    dispatch_event(
+                        ToolCallEndEvent(
+                            type=EventType.TOOL_CALL_END,
+                            tool_call_id=tool_call_id,
+                            raw_event=event,
+                        )
+                    )
+                except Exception:
+                    logger.error(
+                        "Failed to emit compensating TOOL_CALL_END for %s",
+                        tool_call_id,
+                        exc_info=True,
+                    )
+            raise
+        return True
 
     @staticmethod
     def _serialize_copilotkit_runtime_payload(input: Any) -> dict[str, Any]:

--- a/sdk-python/copilotkit/langgraph_agui_agent.py
+++ b/sdk-python/copilotkit/langgraph_agui_agent.py
@@ -234,13 +234,18 @@ class LangGraphAGUIAgent(LangGraphAgent):
             # The parent adapter records streamed IDs even when lifecycle emission is suppressed.
             if tool_call_id in streamed_tool_call_ids:
                 continue
+            transformed_events: List[Any] = []
             if self._materialize_tool_call_events(
                 call,
                 event,
                 parent_message_id=parent_message_id,
                 dispatch_via_adapter=True,
+                dispatched_events=transformed_events,
             ):
                 streamed_tool_call_ids.add(tool_call_id)
+            for transformed_event in transformed_events:
+                if transformed_event is not None:
+                    yield transformed_event
 
     def _materialize_tool_call_events(
         self,
@@ -250,6 +255,7 @@ class LangGraphAGUIAgent(LangGraphAgent):
         parent_message_id: Optional[str],
         dispatch: bool = True,
         dispatch_via_adapter: bool = False,
+        dispatched_events: Optional[List[Any]] = None,
     ) -> bool:
         if not isinstance(value, dict):
             if dispatch:
@@ -311,7 +317,7 @@ class LangGraphAGUIAgent(LangGraphAgent):
             self._dispatch_event if dispatch_via_adapter else super()._dispatch_event
         )
         try:
-            dispatch_event(
+            start_event = dispatch_event(
                 ToolCallStartEvent(
                     type=EventType.TOOL_CALL_START,
                     tool_call_id=tool_call_id,
@@ -320,8 +326,10 @@ class LangGraphAGUIAgent(LangGraphAgent):
                     raw_event=event,
                 )
             )
+            if dispatched_events is not None:
+                dispatched_events.append(start_event)
             dispatched_start = True
-            dispatch_event(
+            args_event = dispatch_event(
                 ToolCallArgsEvent(
                     type=EventType.TOOL_CALL_ARGS,
                     tool_call_id=tool_call_id,
@@ -329,24 +337,30 @@ class LangGraphAGUIAgent(LangGraphAgent):
                     raw_event=event,
                 )
             )
-            dispatch_event(
+            if dispatched_events is not None:
+                dispatched_events.append(args_event)
+            end_event = dispatch_event(
                 ToolCallEndEvent(
                     type=EventType.TOOL_CALL_END,
                     tool_call_id=tool_call_id,
                     raw_event=event,
                 )
             )
+            if dispatched_events is not None:
+                dispatched_events.append(end_event)
             end_dispatched = True
         except Exception:
             if dispatched_start and not end_dispatched:
                 try:
-                    dispatch_event(
+                    end_event = dispatch_event(
                         ToolCallEndEvent(
                             type=EventType.TOOL_CALL_END,
                             tool_call_id=tool_call_id,
                             raw_event=event,
                         )
                     )
+                    if dispatched_events is not None:
+                        dispatched_events.append(end_event)
                 except Exception:
                     logger.error(
                         "Failed to emit compensating TOOL_CALL_END for %s",

--- a/sdk-python/copilotkit/langgraph_agui_agent.py
+++ b/sdk-python/copilotkit/langgraph_agui_agent.py
@@ -29,6 +29,8 @@ except ImportError:
     # Langchain >= 1.0.0
     from langchain_core.messages import BaseMessage
 
+logger = logging.getLogger(__name__)
+
 
 class CustomEventNames(Enum):
     """Custom event names for CopilotKit"""
@@ -276,6 +278,90 @@ class LangGraphAGUIAgent(LangGraphAgent):
         # Call the parent method to handle all other events
         async for event_str in super()._handle_single_event(event, state):
             yield event_str
+
+        if event.get("event") == LangGraphEventTypes.OnChatModelEnd.value:
+            for emitted_event in self._intercepted_frontend_tool_call_events(event):
+                yield self._dispatch_event(emitted_event)
+
+    def _intercepted_frontend_tool_call_events(self, event: Any) -> list[ToolCallEvents]:
+        frontend_tool_names = self._frontend_tool_names()
+        if not frontend_tool_names:
+            return []
+
+        streamed_tool_call_ids = (getattr(self, "active_run", None) or {}).setdefault(
+            "streamed_tool_call_ids",
+            set(),
+        )
+        output = (event.get("data") or {}).get("output")
+        tool_calls = getattr(output, "tool_calls", None) or []
+        parent_message_id = getattr(output, "id", None)
+
+        emitted_events: list[ToolCallEvents] = []
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+
+            tool_call_id = tool_call.get("id")
+            tool_call_name = tool_call.get("name")
+            tool_call_args = tool_call.get("args")
+
+            if (
+                tool_call_name not in frontend_tool_names
+                or not isinstance(tool_call_id, str)
+                or not tool_call_id.strip()
+                or tool_call_id in streamed_tool_call_ids
+            ):
+                continue
+
+            try:
+                delta = (
+                    tool_call_args
+                    if isinstance(tool_call_args, str)
+                    else json.dumps(tool_call_args)
+                )
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Skipping frontend tool call %s because args are not JSON-serializable",
+                    tool_call_id,
+                    exc_info=True,
+                )
+                continue
+
+            streamed_tool_call_ids.add(tool_call_id)
+            emitted_events.extend(
+                [
+                    ToolCallStartEvent(
+                        type=EventType.TOOL_CALL_START,
+                        tool_call_id=tool_call_id,
+                        tool_call_name=tool_call_name,
+                        parent_message_id=parent_message_id or tool_call_id,
+                        raw_event=event,
+                    ),
+                    ToolCallArgsEvent(
+                        type=EventType.TOOL_CALL_ARGS,
+                        tool_call_id=tool_call_id,
+                        delta=delta,
+                        raw_event=event,
+                    ),
+                    ToolCallEndEvent(
+                        type=EventType.TOOL_CALL_END,
+                        tool_call_id=tool_call_id,
+                        raw_event=event,
+                    ),
+                ]
+            )
+
+        return emitted_events
+
+    def _frontend_tool_names(self) -> set[str]:
+        names: set[str] = set()
+        for tool in (self._copilotkit_runtime_payload or {}).get("actions") or []:
+            if not isinstance(tool, dict):
+                continue
+            name = tool.get("function", {}).get("name") or tool.get("name")
+            if isinstance(name, str) and name.strip():
+                names.add(name)
+        return names
 
     @staticmethod
     def _serialize_copilotkit_runtime_payload(input: Any) -> dict[str, Any]:

--- a/sdk-python/tests/test_intercepted_tool_call_events.py
+++ b/sdk-python/tests/test_intercepted_tool_call_events.py
@@ -1,365 +1,174 @@
-"""Tests for middleware emission of AG-UI tool call events for intercepted SDK Actions.
+"""End-to-end coverage for intercepted SDK Action tool-call emission.
 
-Covers:
-  - When aafter_model intercepts SDK Action tool calls, copilotkit_manually_emit_tool_call
-    custom events are dispatched for each intercepted call
-  - When no tool calls are intercepted, no custom events are dispatched
-  - Multiple intercepted tool calls each produce their own custom event
-  - The custom event payload matches the format expected by LangGraphAGUIAgent._dispatch_event()
-  - Sync after_model path works unchanged (no event emission from sync path)
+Covers the real LangChain `create_agent(..., tools=[])` path the regression
+was reported against:
+
+  - current main emits no AG-UI TOOL_CALL_* events for intercepted SDK Actions
+  - this branch emits exactly one TOOL_CALL_START/ARGS/END triple
+  - `after_agent` still restores the tool call into the final snapshot without
+    causing a duplicate stream emission
 """
 
-from __future__ import annotations
-
 import asyncio
-from unittest.mock import MagicMock, AsyncMock, patch
+from typing import Any
+from unittest.mock import patch
 
-import pytest
-from langchain_core.messages import AIMessage, HumanMessage
+from ag_ui.core import EventType, MessagesSnapshotEvent, Tool, UserMessage
+from ag_ui_langgraph import LangGraphAgent as AGUIBase
+from ag_ui.core.types import RunAgentInput
+from langchain.agents import create_agent
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langgraph.checkpoint.memory import InMemorySaver
+from pydantic import Field
 
-from copilotkit.copilotkit_lg_middleware import CopilotKitMiddleware
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def middleware():
-    """Create a fresh middleware instance for each test."""
-    return CopilotKitMiddleware()
+from copilotkit import CopilotKitMiddleware
+from copilotkit.langgraph_agui_agent import LangGraphAGUIAgent
 
 
-def _make_tool_call(
-    name: str,
-    args: dict | None = None,
-    tool_call_id: str | None = None,
-) -> dict:
-    """Create a proper tool call dict for langchain AIMessage."""
-    return {
-        "type": "tool_call",
-        "name": name,
-        "args": args or {},
-        "id": tool_call_id or f"call_{name}",
-    }
+class BoundFakeToolModel(BaseChatModel):
+    """Minimal fake chat model that supports `bind_tools()` for `create_agent()`."""
+
+    responses: list[AIMessage]
+    i: int = 0
+    bound_tools: list[Any] = Field(default_factory=list)
+
+    def bind_tools(self, tools, **kwargs):
+        return self.__class__(
+            responses=self.responses,
+            i=self.i,
+            bound_tools=list(tools),
+        )
+
+    @property
+    def _llm_type(self) -> str:
+        return "bound-fake-tool-model"
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        response = self.responses[self.i]
+        if self.i < len(self.responses) - 1:
+            self.i += 1
+        return ChatResult(generations=[ChatGeneration(message=response)])
 
 
-def _make_state(
-    *,
-    ai_message: AIMessage | None = None,
-    actions: list[dict] | None = None,
-) -> dict:
-    """Build a state dict for testing."""
-    messages = [HumanMessage("hi")]
-    if ai_message:
-        messages.append(ai_message)
-
-    return {
-        "messages": messages,
-        "copilotkit": {
-            "actions": actions or [],
+def _frontend_tool() -> Tool:
+    return Tool(
+        name="ask_user_name",
+        description="Frontend SDK Action",
+        parameters={
+            "type": "object",
+            "properties": {"prompt": {"type": "string"}},
+            "required": ["prompt"],
         },
-    }
-
-
-# ---------------------------------------------------------------------------
-# Tests: no interception
-# ---------------------------------------------------------------------------
-
-
-def test_aafter_model_no_frontend_tools_is_noop(middleware):
-    """When no frontend tools exist, aafter_model returns None."""
-
-    async def _run():
-        state = _make_state(
-            ai_message=AIMessage(
-                content="",
-                tool_calls=[_make_tool_call("backend_only", tool_call_id="1")],
-            ),
-            actions=[],
-        )
-        runtime = MagicMock(name="runtime")
-
-        with patch("langgraph.config.get_config", return_value=MagicMock()):
-            result = await middleware.aafter_model(state, runtime)
-
-        assert result is None
-
-    asyncio.run(_run())
-
-
-def test_aafter_model_no_tool_calls_is_noop(middleware):
-    """When the AIMessage has no tool calls, aafter_model returns None."""
-
-    async def _run():
-        state = _make_state(
-            ai_message=AIMessage(content="Just a response, no tools"),
-            actions=[{"function": {"name": "navigate"}}],
-        )
-        runtime = MagicMock(name="runtime")
-
-        with patch("langgraph.config.get_config", return_value=MagicMock()):
-            result = await middleware.aafter_model(state, runtime)
-
-        assert result is None
-
-    asyncio.run(_run())
-
-
-def test_aafter_model_only_backend_tools_is_noop(middleware):
-    """When all tool calls are backend tools (not frontend actions), no dispatch occurs."""
-
-    async def _run():
-        state = _make_state(
-            ai_message=AIMessage(
-                content="",
-                tool_calls=[
-                    _make_tool_call("backend_search", {"q": "hi"}, tool_call_id="1")
-                ],
-            ),
-            actions=[{"function": {"name": "navigate"}}],
-        )
-        runtime = MagicMock(name="runtime")
-
-        with patch("langgraph.config.get_config", return_value=MagicMock()):
-            with patch(
-                "langchain_core.callbacks.manager.adispatch_custom_event",
-                new_callable=AsyncMock,
-            ) as mock_dispatch:
-                result = await middleware.aafter_model(state, runtime)
-
-        assert result is None
-        mock_dispatch.assert_not_called()
-
-    asyncio.run(_run())
-
-
-# ---------------------------------------------------------------------------
-# Tests: interception with event dispatch
-# ---------------------------------------------------------------------------
-
-
-def test_aafter_model_emits_event_for_single_intercepted_tool_call(middleware):
-    """When a single tool call matches a frontend action, emit a custom event."""
-
-    async def _run():
-        frontend_call = _make_tool_call("navigate", {"path": "/x"}, tool_call_id="2")
-        state = _make_state(
-            ai_message=AIMessage(
-                content="",
-                tool_calls=[frontend_call],
-                id="ai-1",
-            ),
-            actions=[{"function": {"name": "navigate"}}],
-        )
-        runtime = MagicMock(name="runtime")
-        mock_config = MagicMock()
-
-        with patch("langgraph.config.get_config", return_value=mock_config):
-            with patch(
-                "langchain_core.callbacks.manager.adispatch_custom_event",
-                new_callable=AsyncMock,
-            ) as mock_dispatch:
-                result = await middleware.aafter_model(state, runtime)
-
-        # Verify the result has the intercepted call stored
-        assert result is not None
-        intercepted = result["copilotkit"]["intercepted_tool_calls"]
-        assert len(intercepted) == 1
-        assert intercepted[0]["name"] == "navigate"
-        assert intercepted[0]["id"] == "2"
-
-        # Verify the custom event was dispatched
-        mock_dispatch.assert_called_once()
-        args, kwargs = mock_dispatch.call_args
-        assert len(args) == 2
-        assert args[0] == "copilotkit_manually_emit_tool_call"
-        assert args[1] == {
-            "name": "navigate",
-            "args": {"path": "/x"},
-            "id": "2",
-        }
-        assert kwargs.get("config") is mock_config
-
-    asyncio.run(_run())
-
-
-def test_aafter_model_emits_events_for_multiple_intercepted_tool_calls(middleware):
-    """When multiple tool calls match frontend actions, emit a custom event for each."""
-
-    async def _run():
-        backend_call = _make_tool_call("backend_search", {"q": "hi"}, tool_call_id="1")
-        frontend_call_1 = _make_tool_call("navigate", {"path": "/x"}, tool_call_id="2")
-        frontend_call_2 = _make_tool_call(
-            "update_context", {"ctx": "val"}, tool_call_id="3"
-        )
-
-        state = _make_state(
-            ai_message=AIMessage(
-                content="",
-                tool_calls=[backend_call, frontend_call_1, frontend_call_2],
-                id="ai-1",
-            ),
-            actions=[
-                {"function": {"name": "navigate"}},
-                {"function": {"name": "update_context"}},
-            ],
-        )
-        runtime = MagicMock(name="runtime")
-        mock_config = MagicMock()
-
-        with patch("langgraph.config.get_config", return_value=mock_config):
-            with patch(
-                "langchain_core.callbacks.manager.adispatch_custom_event",
-                new_callable=AsyncMock,
-            ) as mock_dispatch:
-                result = await middleware.aafter_model(state, runtime)
-
-        # Verify the result has both intercepted calls stored
-        assert result is not None
-        intercepted = result["copilotkit"]["intercepted_tool_calls"]
-        assert len(intercepted) == 2
-        assert intercepted[0]["id"] == "2"
-        assert intercepted[1]["id"] == "3"
-
-        # Verify two custom events were dispatched
-        assert mock_dispatch.call_count == 2
-
-        # First event payload
-        first_args, first_kwargs = mock_dispatch.call_args_list[0]
-        assert first_args[0] == "copilotkit_manually_emit_tool_call"
-        assert first_args[1] == {
-            "name": "navigate",
-            "args": {"path": "/x"},
-            "id": "2",
-        }
-
-        # Second event payload
-        second_args, second_kwargs = mock_dispatch.call_args_list[1]
-        assert second_args[0] == "copilotkit_manually_emit_tool_call"
-        assert second_args[1] == {
-            "name": "update_context",
-            "args": {"ctx": "val"},
-            "id": "3",
-        }
-
-    asyncio.run(_run())
-
-
-def test_aafter_model_event_payload_format_matches_agui_handler(middleware):
-    """Verify the custom event payload format matches LangGraphAGUIAgent expectation."""
-
-    async def _run():
-        # The AG-UI handler expects: {"name": str, "args": dict, "id": str}
-        # This test ensures we emit exactly that format.
-        frontend_call = _make_tool_call(
-            "my_action", {"key1": "value1", "key2": 42}, tool_call_id="tool-123"
-        )
-        state = _make_state(
-            ai_message=AIMessage(
-                content="",
-                tool_calls=[frontend_call],
-                id="ai-1",
-            ),
-            actions=[{"function": {"name": "my_action"}}],
-        )
-        runtime = MagicMock(name="runtime")
-        mock_config = MagicMock()
-
-        with patch("langgraph.config.get_config", return_value=mock_config):
-            with patch(
-                "langchain_core.callbacks.manager.adispatch_custom_event",
-                new_callable=AsyncMock,
-            ) as mock_dispatch:
-                await middleware.aafter_model(state, runtime)
-
-        mock_dispatch.assert_called_once()
-        args, kwargs = mock_dispatch.call_args
-        payload = args[1]
-
-        # Verify all required fields are present
-        assert "name" in payload
-        assert "args" in payload
-        assert "id" in payload
-
-        # Verify the types
-        assert isinstance(payload["name"], str)
-        assert isinstance(payload["args"], dict)
-        assert isinstance(payload["id"], str)
-
-        # Verify the values are correct
-        assert payload["name"] == "my_action"
-        assert payload["args"] == {"key1": "value1", "key2": 42}
-        assert payload["id"] == "tool-123"
-
-    asyncio.run(_run())
-
-
-def test_aafter_model_handles_missing_optional_fields_in_call(middleware):
-    """When a tool call is missing optional fields, use sensible defaults."""
-
-    async def _run():
-        # Tool calls may not always have all fields populated during construction
-        # Here we'll test with a minimal dict structure
-        frontend_call = {"name": "action_no_id", "id": "", "args": {}}
-        state = _make_state(
-            ai_message=AIMessage(
-                content="",
-                tool_calls=[frontend_call],
-                id="ai-1",
-            ),
-            actions=[{"function": {"name": "action_no_id"}}],
-        )
-        runtime = MagicMock(name="runtime")
-        mock_config = MagicMock()
-
-        with patch("langgraph.config.get_config", return_value=mock_config):
-            with patch(
-                "langchain_core.callbacks.manager.adispatch_custom_event",
-                new_callable=AsyncMock,
-            ) as mock_dispatch:
-                await middleware.aafter_model(state, runtime)
-
-        # Should succeed and dispatch with defaults for missing fields
-        mock_dispatch.assert_called_once()
-        args, kwargs = mock_dispatch.call_args
-        payload = args[1]
-        assert payload["name"] == "action_no_id"
-        assert payload["args"] == {}
-        assert payload["id"] == ""
-
-    asyncio.run(_run())
-
-
-# ---------------------------------------------------------------------------
-# Tests: Backward compatibility — sync after_model unchanged
-# ---------------------------------------------------------------------------
-
-
-def test_after_model_sync_unchanged(middleware):
-    """The sync after_model path should work unchanged (no custom events)."""
-    frontend_call = _make_tool_call("navigate", {"path": "/x"}, tool_call_id="2")
-    state = _make_state(
-        ai_message=AIMessage(
-            content="",
-            tool_calls=[frontend_call],
-            id="ai-1",
-        ),
-        actions=[{"function": {"name": "navigate"}}],
     )
-    runtime = MagicMock(name="runtime")
 
-    # Call the sync method directly
-    result = middleware.after_model(state, runtime)
 
-    # Verify it works as before: returns the intercepted state
-    assert result is not None
-    intercepted = result["copilotkit"]["intercepted_tool_calls"]
-    assert len(intercepted) == 1
-    assert intercepted[0]["name"] == "navigate"
-    assert intercepted[0]["id"] == "2"
-    # And the AIMessage now has no tool calls
-    last_msg = result["messages"][-1]
-    assert isinstance(last_msg, AIMessage)
-    assert len(last_msg.tool_calls) == 0
+def _collect_intercepted_tool_run():
+    model = BoundFakeToolModel(
+        responses=[
+            AIMessage(
+                content="",
+                id="ai-1",
+                tool_calls=[
+                    {
+                        "id": "tc-1",
+                        "name": "ask_user_name",
+                        "args": {"prompt": "what is your name?"},
+                    }
+                ],
+            )
+        ]
+    )
+    graph = create_agent(
+        model=model,
+        tools=[],
+        middleware=[CopilotKitMiddleware()],
+        checkpointer=InMemorySaver(),
+    )
+    agent = LangGraphAGUIAgent(name="test", graph=graph)
+    run_input = RunAgentInput(
+        threadId="t1",
+        runId="r1",
+        state={},
+        messages=[UserMessage(id="u1", content="hi")],
+        tools=[_frontend_tool()],
+        context=[],
+        forwardedProps={},
+    )
+
+    async def _run():
+        dispatched = []
+        yielded = []
+        original = AGUIBase._dispatch_event
+
+        def _track(self_inner, event):
+            dispatched.append(event)
+            return original(self_inner, event)
+
+        with patch.object(AGUIBase, "_dispatch_event", new=_track):
+            async for event in agent.run(run_input):
+                yielded.append(event)
+
+        return dispatched, yielded
+
+    return asyncio.run(_run())
+
+
+def test_intercepted_sdk_action_emits_single_tool_call_triple_end_to_end():
+    dispatched, _ = _collect_intercepted_tool_run()
+
+    tool_call_starts = [
+        event for event in dispatched if getattr(event, "type", None) == EventType.TOOL_CALL_START
+    ]
+    tool_call_args = [
+        event for event in dispatched if getattr(event, "type", None) == EventType.TOOL_CALL_ARGS
+    ]
+    tool_call_ends = [
+        event for event in dispatched if getattr(event, "type", None) == EventType.TOOL_CALL_END
+    ]
+    manual_emit_events = [
+        event
+        for event in dispatched
+        if getattr(event, "type", None) == EventType.CUSTOM
+        and getattr(event, "name", None) == "copilotkit_manually_emit_tool_call"
+    ]
+
+    assert len(manual_emit_events) == 1
+    assert len(tool_call_starts) == 1
+    assert len(tool_call_args) == 1
+    assert len(tool_call_ends) == 1
+
+    assert tool_call_starts[0].tool_call_id == "tc-1"
+    assert tool_call_args[0].tool_call_id == "tc-1"
+    assert tool_call_args[0].delta == '{"prompt": "what is your name?"}'
+    assert tool_call_ends[0].tool_call_id == "tc-1"
+
+
+def test_after_agent_restores_tool_call_without_duplicate_stream_events():
+    dispatched, yielded = _collect_intercepted_tool_run()
+
+    final_snapshot = next(
+        event
+        for event in reversed(yielded)
+        if isinstance(event, MessagesSnapshotEvent)
+    )
+    assistant_message = final_snapshot.messages[-1]
+
+    tool_call_ids = [
+        event.tool_call_id
+        for event in dispatched
+        if getattr(event, "type", None) in {
+            EventType.TOOL_CALL_START,
+            EventType.TOOL_CALL_ARGS,
+            EventType.TOOL_CALL_END,
+        }
+    ]
+
+    assert len(tool_call_ids) == 3
+    assert tool_call_ids == ["tc-1", "tc-1", "tc-1"]
+
+    assert len(assistant_message.tool_calls) == 1
+    assert assistant_message.tool_calls[0].id == "tc-1"
+    assert assistant_message.tool_calls[0].function.name == "ask_user_name"
+    assert assistant_message.tool_calls[0].function.arguments == '{"prompt": "what is your name?"}'

--- a/sdk-python/tests/test_intercepted_tool_call_events.py
+++ b/sdk-python/tests/test_intercepted_tool_call_events.py
@@ -1,0 +1,365 @@
+"""Tests for middleware emission of AG-UI tool call events for intercepted SDK Actions.
+
+Covers:
+  - When aafter_model intercepts SDK Action tool calls, copilotkit_manually_emit_tool_call
+    custom events are dispatched for each intercepted call
+  - When no tool calls are intercepted, no custom events are dispatched
+  - Multiple intercepted tool calls each produce their own custom event
+  - The custom event payload matches the format expected by LangGraphAGUIAgent._dispatch_event()
+  - Sync after_model path works unchanged (no event emission from sync path)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, AsyncMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from copilotkit.copilotkit_lg_middleware import CopilotKitMiddleware
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def middleware():
+    """Create a fresh middleware instance for each test."""
+    return CopilotKitMiddleware()
+
+
+def _make_tool_call(
+    name: str,
+    args: dict | None = None,
+    tool_call_id: str | None = None,
+) -> dict:
+    """Create a proper tool call dict for langchain AIMessage."""
+    return {
+        "type": "tool_call",
+        "name": name,
+        "args": args or {},
+        "id": tool_call_id or f"call_{name}",
+    }
+
+
+def _make_state(
+    *,
+    ai_message: AIMessage | None = None,
+    actions: list[dict] | None = None,
+) -> dict:
+    """Build a state dict for testing."""
+    messages = [HumanMessage("hi")]
+    if ai_message:
+        messages.append(ai_message)
+
+    return {
+        "messages": messages,
+        "copilotkit": {
+            "actions": actions or [],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: no interception
+# ---------------------------------------------------------------------------
+
+
+def test_aafter_model_no_frontend_tools_is_noop(middleware):
+    """When no frontend tools exist, aafter_model returns None."""
+
+    async def _run():
+        state = _make_state(
+            ai_message=AIMessage(
+                content="",
+                tool_calls=[_make_tool_call("backend_only", tool_call_id="1")],
+            ),
+            actions=[],
+        )
+        runtime = MagicMock(name="runtime")
+
+        with patch("langgraph.config.get_config", return_value=MagicMock()):
+            result = await middleware.aafter_model(state, runtime)
+
+        assert result is None
+
+    asyncio.run(_run())
+
+
+def test_aafter_model_no_tool_calls_is_noop(middleware):
+    """When the AIMessage has no tool calls, aafter_model returns None."""
+
+    async def _run():
+        state = _make_state(
+            ai_message=AIMessage(content="Just a response, no tools"),
+            actions=[{"function": {"name": "navigate"}}],
+        )
+        runtime = MagicMock(name="runtime")
+
+        with patch("langgraph.config.get_config", return_value=MagicMock()):
+            result = await middleware.aafter_model(state, runtime)
+
+        assert result is None
+
+    asyncio.run(_run())
+
+
+def test_aafter_model_only_backend_tools_is_noop(middleware):
+    """When all tool calls are backend tools (not frontend actions), no dispatch occurs."""
+
+    async def _run():
+        state = _make_state(
+            ai_message=AIMessage(
+                content="",
+                tool_calls=[
+                    _make_tool_call("backend_search", {"q": "hi"}, tool_call_id="1")
+                ],
+            ),
+            actions=[{"function": {"name": "navigate"}}],
+        )
+        runtime = MagicMock(name="runtime")
+
+        with patch("langgraph.config.get_config", return_value=MagicMock()):
+            with patch(
+                "langchain_core.callbacks.manager.adispatch_custom_event",
+                new_callable=AsyncMock,
+            ) as mock_dispatch:
+                result = await middleware.aafter_model(state, runtime)
+
+        assert result is None
+        mock_dispatch.assert_not_called()
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Tests: interception with event dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_aafter_model_emits_event_for_single_intercepted_tool_call(middleware):
+    """When a single tool call matches a frontend action, emit a custom event."""
+
+    async def _run():
+        frontend_call = _make_tool_call("navigate", {"path": "/x"}, tool_call_id="2")
+        state = _make_state(
+            ai_message=AIMessage(
+                content="",
+                tool_calls=[frontend_call],
+                id="ai-1",
+            ),
+            actions=[{"function": {"name": "navigate"}}],
+        )
+        runtime = MagicMock(name="runtime")
+        mock_config = MagicMock()
+
+        with patch("langgraph.config.get_config", return_value=mock_config):
+            with patch(
+                "langchain_core.callbacks.manager.adispatch_custom_event",
+                new_callable=AsyncMock,
+            ) as mock_dispatch:
+                result = await middleware.aafter_model(state, runtime)
+
+        # Verify the result has the intercepted call stored
+        assert result is not None
+        intercepted = result["copilotkit"]["intercepted_tool_calls"]
+        assert len(intercepted) == 1
+        assert intercepted[0]["name"] == "navigate"
+        assert intercepted[0]["id"] == "2"
+
+        # Verify the custom event was dispatched
+        mock_dispatch.assert_called_once()
+        args, kwargs = mock_dispatch.call_args
+        assert len(args) == 2
+        assert args[0] == "copilotkit_manually_emit_tool_call"
+        assert args[1] == {
+            "name": "navigate",
+            "args": {"path": "/x"},
+            "id": "2",
+        }
+        assert kwargs.get("config") is mock_config
+
+    asyncio.run(_run())
+
+
+def test_aafter_model_emits_events_for_multiple_intercepted_tool_calls(middleware):
+    """When multiple tool calls match frontend actions, emit a custom event for each."""
+
+    async def _run():
+        backend_call = _make_tool_call("backend_search", {"q": "hi"}, tool_call_id="1")
+        frontend_call_1 = _make_tool_call("navigate", {"path": "/x"}, tool_call_id="2")
+        frontend_call_2 = _make_tool_call(
+            "update_context", {"ctx": "val"}, tool_call_id="3"
+        )
+
+        state = _make_state(
+            ai_message=AIMessage(
+                content="",
+                tool_calls=[backend_call, frontend_call_1, frontend_call_2],
+                id="ai-1",
+            ),
+            actions=[
+                {"function": {"name": "navigate"}},
+                {"function": {"name": "update_context"}},
+            ],
+        )
+        runtime = MagicMock(name="runtime")
+        mock_config = MagicMock()
+
+        with patch("langgraph.config.get_config", return_value=mock_config):
+            with patch(
+                "langchain_core.callbacks.manager.adispatch_custom_event",
+                new_callable=AsyncMock,
+            ) as mock_dispatch:
+                result = await middleware.aafter_model(state, runtime)
+
+        # Verify the result has both intercepted calls stored
+        assert result is not None
+        intercepted = result["copilotkit"]["intercepted_tool_calls"]
+        assert len(intercepted) == 2
+        assert intercepted[0]["id"] == "2"
+        assert intercepted[1]["id"] == "3"
+
+        # Verify two custom events were dispatched
+        assert mock_dispatch.call_count == 2
+
+        # First event payload
+        first_args, first_kwargs = mock_dispatch.call_args_list[0]
+        assert first_args[0] == "copilotkit_manually_emit_tool_call"
+        assert first_args[1] == {
+            "name": "navigate",
+            "args": {"path": "/x"},
+            "id": "2",
+        }
+
+        # Second event payload
+        second_args, second_kwargs = mock_dispatch.call_args_list[1]
+        assert second_args[0] == "copilotkit_manually_emit_tool_call"
+        assert second_args[1] == {
+            "name": "update_context",
+            "args": {"ctx": "val"},
+            "id": "3",
+        }
+
+    asyncio.run(_run())
+
+
+def test_aafter_model_event_payload_format_matches_agui_handler(middleware):
+    """Verify the custom event payload format matches LangGraphAGUIAgent expectation."""
+
+    async def _run():
+        # The AG-UI handler expects: {"name": str, "args": dict, "id": str}
+        # This test ensures we emit exactly that format.
+        frontend_call = _make_tool_call(
+            "my_action", {"key1": "value1", "key2": 42}, tool_call_id="tool-123"
+        )
+        state = _make_state(
+            ai_message=AIMessage(
+                content="",
+                tool_calls=[frontend_call],
+                id="ai-1",
+            ),
+            actions=[{"function": {"name": "my_action"}}],
+        )
+        runtime = MagicMock(name="runtime")
+        mock_config = MagicMock()
+
+        with patch("langgraph.config.get_config", return_value=mock_config):
+            with patch(
+                "langchain_core.callbacks.manager.adispatch_custom_event",
+                new_callable=AsyncMock,
+            ) as mock_dispatch:
+                await middleware.aafter_model(state, runtime)
+
+        mock_dispatch.assert_called_once()
+        args, kwargs = mock_dispatch.call_args
+        payload = args[1]
+
+        # Verify all required fields are present
+        assert "name" in payload
+        assert "args" in payload
+        assert "id" in payload
+
+        # Verify the types
+        assert isinstance(payload["name"], str)
+        assert isinstance(payload["args"], dict)
+        assert isinstance(payload["id"], str)
+
+        # Verify the values are correct
+        assert payload["name"] == "my_action"
+        assert payload["args"] == {"key1": "value1", "key2": 42}
+        assert payload["id"] == "tool-123"
+
+    asyncio.run(_run())
+
+
+def test_aafter_model_handles_missing_optional_fields_in_call(middleware):
+    """When a tool call is missing optional fields, use sensible defaults."""
+
+    async def _run():
+        # Tool calls may not always have all fields populated during construction
+        # Here we'll test with a minimal dict structure
+        frontend_call = {"name": "action_no_id", "id": "", "args": {}}
+        state = _make_state(
+            ai_message=AIMessage(
+                content="",
+                tool_calls=[frontend_call],
+                id="ai-1",
+            ),
+            actions=[{"function": {"name": "action_no_id"}}],
+        )
+        runtime = MagicMock(name="runtime")
+        mock_config = MagicMock()
+
+        with patch("langgraph.config.get_config", return_value=mock_config):
+            with patch(
+                "langchain_core.callbacks.manager.adispatch_custom_event",
+                new_callable=AsyncMock,
+            ) as mock_dispatch:
+                await middleware.aafter_model(state, runtime)
+
+        # Should succeed and dispatch with defaults for missing fields
+        mock_dispatch.assert_called_once()
+        args, kwargs = mock_dispatch.call_args
+        payload = args[1]
+        assert payload["name"] == "action_no_id"
+        assert payload["args"] == {}
+        assert payload["id"] == ""
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Tests: Backward compatibility — sync after_model unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_after_model_sync_unchanged(middleware):
+    """The sync after_model path should work unchanged (no custom events)."""
+    frontend_call = _make_tool_call("navigate", {"path": "/x"}, tool_call_id="2")
+    state = _make_state(
+        ai_message=AIMessage(
+            content="",
+            tool_calls=[frontend_call],
+            id="ai-1",
+        ),
+        actions=[{"function": {"name": "navigate"}}],
+    )
+    runtime = MagicMock(name="runtime")
+
+    # Call the sync method directly
+    result = middleware.after_model(state, runtime)
+
+    # Verify it works as before: returns the intercepted state
+    assert result is not None
+    intercepted = result["copilotkit"]["intercepted_tool_calls"]
+    assert len(intercepted) == 1
+    assert intercepted[0]["name"] == "navigate"
+    assert intercepted[0]["id"] == "2"
+    # And the AIMessage now has no tool calls
+    last_msg = result["messages"][-1]
+    assert isinstance(last_msg, AIMessage)
+    assert len(last_msg.tool_calls) == 0

--- a/sdk-python/tests/test_intercepted_tool_call_events.py
+++ b/sdk-python/tests/test_intercepted_tool_call_events.py
@@ -161,15 +161,17 @@ def _assert_single_tool_call_triple(dispatched, tool_call_id="tc-1"):
 
 
 def test_intercepted_sdk_action_non_streaming_reproduces_issue_and_emits_once():
-    dispatched, _, model = _collect_intercepted_tool_run(streaming=False)
+    dispatched, yielded, model = _collect_intercepted_tool_run(streaming=False)
     _assert_single_tool_call_triple(dispatched)
+    _assert_single_tool_call_triple(yielded)
     assert BoundFakeToolModel.generate_calls == 1
     assert BoundFakeToolModel.astream_calls == 0
 
 
 def test_intercepted_sdk_action_streaming_emits_once():
-    dispatched, _, model = _collect_intercepted_tool_run(streaming=True)
+    dispatched, yielded, model = _collect_intercepted_tool_run(streaming=True)
     _assert_single_tool_call_triple(dispatched)
+    _assert_single_tool_call_triple(yielded)
     assert BoundFakeToolModel.astream_calls == 1
     assert BoundFakeToolModel.generate_calls == 0
 
@@ -205,8 +207,7 @@ async def _state_event(agent, state, *, calls, parent_message_id="ai-1", metadat
             }
         },
     }
-    async for _ in agent._handle_single_event(event, state):
-        pass
+    return [result async for result in agent._handle_single_event(event, state)]
 
 
 def _bridge_agent():
@@ -230,20 +231,19 @@ def _run_state_event(calls, streamed=None, metadata=None):
 
     async def _parent(self_inner, event, state):
         parent_events.append((event, state))
-        if False:
-            yield ""
+        yield "parent-event"
 
     async def _run():
         with patch.object(AGUIBase, "_handle_single_event", new=_parent):
             with patch.object(AGUIBase, "_dispatch_event", new=_track):
-                await _state_event(agent, {}, calls=calls, metadata=metadata)
+                return await _state_event(agent, {}, calls=calls, metadata=metadata)
 
-    asyncio.run(_run())
-    return dispatched, agent, parent_events
+    parent_results = asyncio.run(_run())
+    return dispatched, agent, parent_events, parent_results
 
 
 def test_multiple_intercepted_calls_dedupe_per_id():
-    dispatched, agent, _ = _run_state_event(
+    dispatched, agent, _, _ = _run_state_event(
         [
             {"id": "streamed", "name": "one", "args": {}},
             {"id": "fresh", "name": "two", "args": {"x": 1}},
@@ -280,21 +280,24 @@ def test_backend_call_is_not_published_by_intercepted_state_bridge():
     ]
     assert [call["id"] for call in result["messages"][-1].tool_calls] == ["backend"]
 
-    dispatched, _, _ = _run_state_event(result["copilotkit"]["intercepted_tool_calls"])
+    dispatched, _, _, _ = _run_state_event(
+        result["copilotkit"]["intercepted_tool_calls"]
+    )
     assert {event.tool_call_id for event in _tool_events(dispatched)} == {"frontend"}
 
 
 def test_intercepted_state_metadata_opt_out_is_not_recreated_by_bridge():
-    dispatched, _, parent_events = _run_state_event(
+    dispatched, _, parent_events, parent_results = _run_state_event(
         [{"id": "fresh", "name": "ask_user_name", "args": {}}],
         metadata={"copilotkit:emit-tool-calls": False},
     )
     assert _tool_events(dispatched) == []
     assert len(parent_events) == 1
+    assert parent_results[0] == "parent-event"
 
 
 def test_bridge_ignores_runtime_action_catalog_shapes():
-    dispatched, _, _ = _run_state_event(
+    dispatched, _, _, _ = _run_state_event(
         [{"id": "safe", "name": "ask_user_name", "args": {}}]
     )
     assert [event.tool_call_id for event in _tool_events(dispatched)] == [
@@ -305,7 +308,7 @@ def test_bridge_ignores_runtime_action_catalog_shapes():
 
 
 def test_malformed_intercepted_entries_emit_no_partial_lifecycle():
-    dispatched, _, parent_events = _run_state_event(
+    dispatched, _, parent_events, parent_results = _run_state_event(
         [
             {"id": "bad", "name": "bad", "args": object()},
             {"id": "", "name": "ignored", "args": {}},
@@ -319,3 +322,9 @@ def test_malformed_intercepted_entries_emit_no_partial_lifecycle():
     ]
     assert len(parent_events) == 1
     assert parent_events[0][0]["event"] == "on_chain_end"
+    assert parent_results[0] == "parent-event"
+    assert [event.tool_call_id for event in _tool_events(parent_results)] == [
+        "good",
+        "good",
+        "good",
+    ]

--- a/sdk-python/tests/test_intercepted_tool_call_events.py
+++ b/sdk-python/tests/test_intercepted_tool_call_events.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+from contextlib import nullcontext
 from typing import Any, ClassVar
 from unittest.mock import patch
 
@@ -83,7 +84,14 @@ def _frontend_tool(name="ask_user_name") -> Tool:
     )
 
 
-def _collect_intercepted_tool_run(*, streaming=False, tools=None, forwarded_props=None):
+def _collect_intercepted_tool_run(
+    *,
+    streaming=False,
+    tools=None,
+    forwarded_props=None,
+    config_metadata=None,
+    observed_events=None,
+):
     BoundFakeToolModel.generate_calls = 0
     BoundFakeToolModel.astream_calls = 0
     model = BoundFakeToolModel(
@@ -108,7 +116,11 @@ def _collect_intercepted_tool_run(*, streaming=False, tools=None, forwarded_prop
         middleware=[CopilotKitMiddleware()],
         checkpointer=InMemorySaver(),
     )
-    agent = LangGraphAGUIAgent(name="test", graph=graph)
+    agent = LangGraphAGUIAgent(
+        name="test",
+        graph=graph,
+        config={"metadata": config_metadata} if config_metadata else None,
+    )
     run_input = RunAgentInput(
         threadId="t1",
         runId="r1",
@@ -128,9 +140,22 @@ def _collect_intercepted_tool_run(*, streaming=False, tools=None, forwarded_prop
             dispatched.append(event)
             return original(self_inner, event)
 
-        with patch.object(AGUIBase, "_dispatch_event", new=_track):
-            async for event in agent.run(run_input):
-                yielded.append(event)
+        original_adapter = LangGraphAGUIAgent._dispatch_event
+
+        def _track_adapter(self_inner, event):
+            if observed_events is not None:
+                observed_events.append(event)
+            return original_adapter(self_inner, event)
+
+        adapter_patch = (
+            patch.object(LangGraphAGUIAgent, "_dispatch_event", new=_track_adapter)
+            if observed_events is not None
+            else nullcontext()
+        )
+        with adapter_patch:
+            with patch.object(AGUIBase, "_dispatch_event", new=_track):
+                async for event in agent.run(run_input):
+                    yielded.append(event)
         return dispatched, yielded, model
 
     return asyncio.run(_run())
@@ -287,13 +312,27 @@ def test_backend_call_is_not_published_by_intercepted_state_bridge():
 
 
 def test_intercepted_state_metadata_opt_out_is_not_recreated_by_bridge():
-    dispatched, _, parent_events, parent_results = _run_state_event(
-        [{"id": "fresh", "name": "ask_user_name", "args": {}}],
-        metadata={"copilotkit:emit-tool-calls": False},
+    observed = []
+    _, yielded, _ = _collect_intercepted_tool_run(
+        config_metadata={"copilotkit:emit-tool-calls": False},
+        observed_events=observed,
     )
-    assert _tool_events(dispatched) == []
-    assert len(parent_events) == 1
-    assert parent_results[0] == "parent-event"
+    observed_tool_events = [
+        event
+        for event in observed
+        if event.type
+        in {
+            EventType.TOOL_CALL_START,
+            EventType.TOOL_CALL_ARGS,
+            EventType.TOOL_CALL_END,
+        }
+    ]
+    assert observed_tool_events
+    assert all(
+        event.raw_event["metadata"]["copilotkit:emit-tool-calls"] is False
+        for event in observed_tool_events
+    )
+    assert _tool_events(yielded) == []
 
 
 def test_bridge_ignores_runtime_action_catalog_shapes():
@@ -310,8 +349,10 @@ def test_bridge_ignores_runtime_action_catalog_shapes():
 def test_malformed_intercepted_entries_emit_no_partial_lifecycle():
     dispatched, _, parent_events, parent_results = _run_state_event(
         [
+            None,
             {"id": "bad", "name": "bad", "args": object()},
-            {"id": "", "name": "ignored", "args": {}},
+            {"id": "missing-name", "name": "", "args": {}},
+            {"id": "missing-args", "name": "ignored"},
             {"id": "good", "name": "good", "args": {}},
         ]
     )

--- a/sdk-python/tests/test_intercepted_tool_call_events.py
+++ b/sdk-python/tests/test_intercepted_tool_call_events.py
@@ -1,16 +1,8 @@
-"""End-to-end coverage for intercepted SDK Action tool-call emission.
-
-Covers the real LangChain `create_agent(..., tools=[])` path the regression
-was reported against:
-
-  - current main emits no AG-UI TOOL_CALL_* events for intercepted SDK Actions
-  - this branch emits exactly one TOOL_CALL_START/ARGS/END triple
-  - `after_agent` still restores the tool call into the final snapshot without
-    causing a duplicate stream emission
-"""
+"""Production-path regressions for middleware-intercepted SDK Action calls."""
 
 import asyncio
-from typing import Any
+import json
+from typing import Any, ClassVar
 from unittest.mock import patch
 
 from ag_ui.core import EventType, MessagesSnapshotEvent, Tool, UserMessage
@@ -28,12 +20,14 @@ from copilotkit.langgraph_agui_agent import LangGraphAGUIAgent
 
 
 class BoundFakeToolModel(BaseChatModel):
-    """Minimal fake chat model that supports `bind_tools()` for `create_agent()`."""
+    """Small model that proves create_agent selects its streaming path."""
 
     responses: list[AIMessage]
     i: int = 0
     bound_tools: list[Any] = Field(default_factory=list)
     streaming: bool = False
+    generate_calls: ClassVar[int] = 0
+    astream_calls: ClassVar[int] = 0
 
     def bind_tools(self, tools, **kwargs):
         return self.__class__(
@@ -48,23 +42,20 @@ class BoundFakeToolModel(BaseChatModel):
         return "bound-fake-tool-model"
 
     def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        type(self).generate_calls += 1
         response = self.responses[self.i]
         if self.i < len(self.responses) - 1:
             self.i += 1
         return ChatResult(generations=[ChatGeneration(message=response)])
 
     async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
+        type(self).astream_calls += 1
         yield ChatGenerationChunk(
             message=AIMessageChunk(
                 content="",
                 id="ai-1",
                 tool_call_chunks=[
-                    {
-                        "id": "tc-1",
-                        "name": "ask_user_name",
-                        "args": "",
-                        "index": 0,
-                    }
+                    {"id": "tc-1", "name": "ask_user_name", "args": "", "index": 0}
                 ],
             )
         )
@@ -77,14 +68,12 @@ class BoundFakeToolModel(BaseChatModel):
                 ],
             )
         )
-        yield ChatGenerationChunk(
-            message=AIMessageChunk(content="", id="ai-1", tool_call_chunks=[])
-        )
+        yield ChatGenerationChunk(message=AIMessageChunk(content="", id="ai-1"))
 
 
-def _frontend_tool() -> Tool:
+def _frontend_tool(name="ask_user_name") -> Tool:
     return Tool(
-        name="ask_user_name",
+        name=name,
         description="Frontend SDK Action",
         parameters={
             "type": "object",
@@ -94,7 +83,9 @@ def _frontend_tool() -> Tool:
     )
 
 
-def _collect_intercepted_tool_run(*, streaming=False):
+def _collect_intercepted_tool_run(*, streaming=False, tools=None, forwarded_props=None):
+    BoundFakeToolModel.generate_calls = 0
+    BoundFakeToolModel.astream_calls = 0
     model = BoundFakeToolModel(
         responses=[
             AIMessage(
@@ -123,9 +114,9 @@ def _collect_intercepted_tool_run(*, streaming=False):
         runId="r1",
         state={},
         messages=[UserMessage(id="u1", content="hi")],
-        tools=[_frontend_tool()],
+        tools=tools or [_frontend_tool()],
         context=[],
-        forwardedProps={},
+        forwardedProps=forwarded_props or {},
     )
 
     async def _run():
@@ -140,82 +131,191 @@ def _collect_intercepted_tool_run(*, streaming=False):
         with patch.object(AGUIBase, "_dispatch_event", new=_track):
             async for event in agent.run(run_input):
                 yielded.append(event)
-
-        return dispatched, yielded
+        return dispatched, yielded, model
 
     return asyncio.run(_run())
 
 
-def _assert_single_tool_call_triple(dispatched):
-
-    tool_call_starts = [
+def _tool_events(dispatched):
+    return [
         event
         for event in dispatched
-        if getattr(event, "type", None) == EventType.TOOL_CALL_START
-    ]
-    tool_call_args = [
-        event
-        for event in dispatched
-        if getattr(event, "type", None) == EventType.TOOL_CALL_ARGS
-    ]
-    tool_call_ends = [
-        event
-        for event in dispatched
-        if getattr(event, "type", None) == EventType.TOOL_CALL_END
-    ]
-    manual_emit_events = [
-        event
-        for event in dispatched
-        if getattr(event, "type", None) == EventType.CUSTOM
-        and getattr(event, "name", None) == "copilotkit_manually_emit_tool_call"
+        if getattr(event, "type", None)
+        in {
+            EventType.TOOL_CALL_START,
+            EventType.TOOL_CALL_ARGS,
+            EventType.TOOL_CALL_END,
+        }
     ]
 
-    assert len(manual_emit_events) == 0
-    assert len(tool_call_starts) == 1
-    assert len(tool_call_args) == 1
-    assert len(tool_call_ends) == 1
 
-    assert tool_call_starts[0].tool_call_id == "tc-1"
-    assert tool_call_args[0].tool_call_id == "tc-1"
-    assert tool_call_args[0].delta == '{"prompt": "what is your name?"}'
-    assert tool_call_ends[0].tool_call_id == "tc-1"
+def _assert_single_tool_call_triple(dispatched, tool_call_id="tc-1"):
+    events = _tool_events(dispatched)
+    assert [event.type for event in events] == [
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_END,
+    ]
+    assert [event.tool_call_id for event in events] == [tool_call_id] * 3
+    assert events[1].delta == '{"prompt": "what is your name?"}'
 
 
-def test_intercepted_sdk_action_emits_single_tool_call_triple_in_both_modes():
-    for streaming in (False, True):
-        dispatched, _ = _collect_intercepted_tool_run(streaming=streaming)
-        _assert_single_tool_call_triple(dispatched)
+def test_intercepted_sdk_action_non_streaming_reproduces_issue_and_emits_once():
+    dispatched, _, model = _collect_intercepted_tool_run(streaming=False)
+    _assert_single_tool_call_triple(dispatched)
+    assert BoundFakeToolModel.generate_calls == 1
+    assert BoundFakeToolModel.astream_calls == 0
+
+
+def test_intercepted_sdk_action_streaming_emits_once():
+    dispatched, _, model = _collect_intercepted_tool_run(streaming=True)
+    _assert_single_tool_call_triple(dispatched)
+    assert BoundFakeToolModel.astream_calls == 1
+    assert BoundFakeToolModel.generate_calls == 0
 
 
 def test_after_agent_restores_tool_call_in_both_modes():
     for streaming in (False, True):
-        dispatched, yielded = _collect_intercepted_tool_run(streaming=streaming)
-
+        dispatched, yielded, _ = _collect_intercepted_tool_run(streaming=streaming)
         final_snapshot = next(
             event
             for event in reversed(yielded)
             if isinstance(event, MessagesSnapshotEvent)
         )
         assistant_message = final_snapshot.messages[-1]
-
-        tool_call_ids = [
-            event.tool_call_id
-            for event in dispatched
-            if getattr(event, "type", None)
-            in {
-                EventType.TOOL_CALL_START,
-                EventType.TOOL_CALL_ARGS,
-                EventType.TOOL_CALL_END,
-            }
-        ]
-
-        assert len(tool_call_ids) == 3
-        assert tool_call_ids == ["tc-1", "tc-1", "tc-1"]
-
+        _assert_single_tool_call_triple(dispatched)
         assert len(assistant_message.tool_calls) == 1
         assert assistant_message.tool_calls[0].id == "tc-1"
         assert assistant_message.tool_calls[0].function.name == "ask_user_name"
-        assert (
-            assistant_message.tool_calls[0].function.arguments
-            == '{"prompt": "what is your name?"}'
+        assert assistant_message.tool_calls[0].function.arguments == json.dumps(
+            {"prompt": "what is your name?"}
         )
+
+
+async def _state_event(agent, state, *, calls, parent_message_id="ai-1", metadata=None):
+    event = {
+        "event": "on_chain_end",
+        "metadata": metadata or {},
+        "data": {
+            "output": {
+                "copilotkit": {
+                    "intercepted_tool_calls": calls,
+                    "original_ai_message_id": parent_message_id,
+                }
+            }
+        },
+    }
+    async for _ in agent._handle_single_event(event, state):
+        pass
+
+
+def _bridge_agent():
+    agent = object.__new__(LangGraphAGUIAgent)
+    agent.active_run = {"streamed_tool_call_ids": {"streamed"}}
+    agent._copilotkit_runtime_payload = {"actions": [{"function": None}]}
+    return agent
+
+
+def _run_state_event(calls, streamed=None, metadata=None):
+    agent = _bridge_agent()
+    if streamed is not None:
+        agent.active_run["streamed_tool_call_ids"] = set(streamed)
+    dispatched = []
+    parent_events = []
+    original = AGUIBase._dispatch_event
+
+    def _track(self_inner, event):
+        dispatched.append(event)
+        return original(self_inner, event)
+
+    async def _parent(self_inner, event, state):
+        parent_events.append((event, state))
+        if False:
+            yield ""
+
+    async def _run():
+        with patch.object(AGUIBase, "_handle_single_event", new=_parent):
+            with patch.object(AGUIBase, "_dispatch_event", new=_track):
+                await _state_event(agent, {}, calls=calls, metadata=metadata)
+
+    asyncio.run(_run())
+    return dispatched, agent, parent_events
+
+
+def test_multiple_intercepted_calls_dedupe_per_id():
+    dispatched, agent, _ = _run_state_event(
+        [
+            {"id": "streamed", "name": "one", "args": {}},
+            {"id": "fresh", "name": "two", "args": {"x": 1}},
+        ]
+    )
+    assert [event.tool_call_id for event in _tool_events(dispatched)] == [
+        "fresh",
+        "fresh",
+        "fresh",
+    ]
+    assert agent.active_run["streamed_tool_call_ids"] == {"streamed", "fresh"}
+
+
+def test_backend_call_is_not_published_by_intercepted_state_bridge():
+    backend_and_frontend = AIMessage(
+        content="",
+        id="ai-1",
+        tool_calls=[
+            {"id": "frontend", "name": "frontend", "args": {}},
+            {"id": "backend", "name": "backend", "args": {"x": 1}},
+        ],
+    )
+    middleware = CopilotKitMiddleware()
+    result = middleware.after_model(
+        {
+            "messages": [backend_and_frontend],
+            "copilotkit": {"actions": [{"name": "frontend"}]},
+        },
+        None,
+    )
+    assert result is not None
+    assert [call["id"] for call in result["copilotkit"]["intercepted_tool_calls"]] == [
+        "frontend"
+    ]
+    assert [call["id"] for call in result["messages"][-1].tool_calls] == ["backend"]
+
+    dispatched, _, _ = _run_state_event(result["copilotkit"]["intercepted_tool_calls"])
+    assert {event.tool_call_id for event in _tool_events(dispatched)} == {"frontend"}
+
+
+def test_intercepted_state_metadata_opt_out_is_not_recreated_by_bridge():
+    dispatched, _, parent_events = _run_state_event(
+        [{"id": "fresh", "name": "ask_user_name", "args": {}}],
+        metadata={"copilotkit:emit-tool-calls": False},
+    )
+    assert _tool_events(dispatched) == []
+    assert len(parent_events) == 1
+
+
+def test_bridge_ignores_runtime_action_catalog_shapes():
+    dispatched, _, _ = _run_state_event(
+        [{"id": "safe", "name": "ask_user_name", "args": {}}]
+    )
+    assert [event.tool_call_id for event in _tool_events(dispatched)] == [
+        "safe",
+        "safe",
+        "safe",
+    ]
+
+
+def test_malformed_intercepted_entries_emit_no_partial_lifecycle():
+    dispatched, _, parent_events = _run_state_event(
+        [
+            {"id": "bad", "name": "bad", "args": object()},
+            {"id": "", "name": "ignored", "args": {}},
+            {"id": "good", "name": "good", "args": {}},
+        ]
+    )
+    assert [event.tool_call_id for event in _tool_events(dispatched)] == [
+        "good",
+        "good",
+        "good",
+    ]
+    assert len(parent_events) == 1
+    assert parent_events[0][0]["event"] == "on_chain_end"

--- a/sdk-python/tests/test_intercepted_tool_call_events.py
+++ b/sdk-python/tests/test_intercepted_tool_call_events.py
@@ -18,8 +18,8 @@ from ag_ui_langgraph import LangGraphAgent as AGUIBase
 from ag_ui.core.types import RunAgentInput
 from langchain.agents import create_agent
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage
-from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.messages import AIMessage, AIMessageChunk
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langgraph.checkpoint.memory import InMemorySaver
 from pydantic import Field
 
@@ -33,12 +33,14 @@ class BoundFakeToolModel(BaseChatModel):
     responses: list[AIMessage]
     i: int = 0
     bound_tools: list[Any] = Field(default_factory=list)
+    streaming: bool = False
 
     def bind_tools(self, tools, **kwargs):
         return self.__class__(
             responses=self.responses,
             i=self.i,
             bound_tools=list(tools),
+            streaming=self.streaming,
         )
 
     @property
@@ -50,6 +52,34 @@ class BoundFakeToolModel(BaseChatModel):
         if self.i < len(self.responses) - 1:
             self.i += 1
         return ChatResult(generations=[ChatGeneration(message=response)])
+
+    async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
+        yield ChatGenerationChunk(
+            message=AIMessageChunk(
+                content="",
+                id="ai-1",
+                tool_call_chunks=[
+                    {
+                        "id": "tc-1",
+                        "name": "ask_user_name",
+                        "args": "",
+                        "index": 0,
+                    }
+                ],
+            )
+        )
+        yield ChatGenerationChunk(
+            message=AIMessageChunk(
+                content="",
+                id="ai-1",
+                tool_call_chunks=[
+                    {"args": '{"prompt": "what is your name?"}', "index": 0}
+                ],
+            )
+        )
+        yield ChatGenerationChunk(
+            message=AIMessageChunk(content="", id="ai-1", tool_call_chunks=[])
+        )
 
 
 def _frontend_tool() -> Tool:
@@ -64,7 +94,7 @@ def _frontend_tool() -> Tool:
     )
 
 
-def _collect_intercepted_tool_run():
+def _collect_intercepted_tool_run(*, streaming=False):
     model = BoundFakeToolModel(
         responses=[
             AIMessage(
@@ -78,7 +108,8 @@ def _collect_intercepted_tool_run():
                     }
                 ],
             )
-        ]
+        ],
+        streaming=streaming,
     )
     graph = create_agent(
         model=model,
@@ -115,17 +146,22 @@ def _collect_intercepted_tool_run():
     return asyncio.run(_run())
 
 
-def test_intercepted_sdk_action_emits_single_tool_call_triple_end_to_end():
-    dispatched, _ = _collect_intercepted_tool_run()
+def _assert_single_tool_call_triple(dispatched):
 
     tool_call_starts = [
-        event for event in dispatched if getattr(event, "type", None) == EventType.TOOL_CALL_START
+        event
+        for event in dispatched
+        if getattr(event, "type", None) == EventType.TOOL_CALL_START
     ]
     tool_call_args = [
-        event for event in dispatched if getattr(event, "type", None) == EventType.TOOL_CALL_ARGS
+        event
+        for event in dispatched
+        if getattr(event, "type", None) == EventType.TOOL_CALL_ARGS
     ]
     tool_call_ends = [
-        event for event in dispatched if getattr(event, "type", None) == EventType.TOOL_CALL_END
+        event
+        for event in dispatched
+        if getattr(event, "type", None) == EventType.TOOL_CALL_END
     ]
     manual_emit_events = [
         event
@@ -134,7 +170,7 @@ def test_intercepted_sdk_action_emits_single_tool_call_triple_end_to_end():
         and getattr(event, "name", None) == "copilotkit_manually_emit_tool_call"
     ]
 
-    assert len(manual_emit_events) == 1
+    assert len(manual_emit_events) == 0
     assert len(tool_call_starts) == 1
     assert len(tool_call_args) == 1
     assert len(tool_call_ends) == 1
@@ -145,30 +181,41 @@ def test_intercepted_sdk_action_emits_single_tool_call_triple_end_to_end():
     assert tool_call_ends[0].tool_call_id == "tc-1"
 
 
-def test_after_agent_restores_tool_call_without_duplicate_stream_events():
-    dispatched, yielded = _collect_intercepted_tool_run()
+def test_intercepted_sdk_action_emits_single_tool_call_triple_in_both_modes():
+    for streaming in (False, True):
+        dispatched, _ = _collect_intercepted_tool_run(streaming=streaming)
+        _assert_single_tool_call_triple(dispatched)
 
-    final_snapshot = next(
-        event
-        for event in reversed(yielded)
-        if isinstance(event, MessagesSnapshotEvent)
-    )
-    assistant_message = final_snapshot.messages[-1]
 
-    tool_call_ids = [
-        event.tool_call_id
-        for event in dispatched
-        if getattr(event, "type", None) in {
-            EventType.TOOL_CALL_START,
-            EventType.TOOL_CALL_ARGS,
-            EventType.TOOL_CALL_END,
-        }
-    ]
+def test_after_agent_restores_tool_call_in_both_modes():
+    for streaming in (False, True):
+        dispatched, yielded = _collect_intercepted_tool_run(streaming=streaming)
 
-    assert len(tool_call_ids) == 3
-    assert tool_call_ids == ["tc-1", "tc-1", "tc-1"]
+        final_snapshot = next(
+            event
+            for event in reversed(yielded)
+            if isinstance(event, MessagesSnapshotEvent)
+        )
+        assistant_message = final_snapshot.messages[-1]
 
-    assert len(assistant_message.tool_calls) == 1
-    assert assistant_message.tool_calls[0].id == "tc-1"
-    assert assistant_message.tool_calls[0].function.name == "ask_user_name"
-    assert assistant_message.tool_calls[0].function.arguments == '{"prompt": "what is your name?"}'
+        tool_call_ids = [
+            event.tool_call_id
+            for event in dispatched
+            if getattr(event, "type", None)
+            in {
+                EventType.TOOL_CALL_START,
+                EventType.TOOL_CALL_ARGS,
+                EventType.TOOL_CALL_END,
+            }
+        ]
+
+        assert len(tool_call_ids) == 3
+        assert tool_call_ids == ["tc-1", "tc-1", "tc-1"]
+
+        assert len(assistant_message.tool_calls) == 1
+        assert assistant_message.tool_calls[0].id == "tc-1"
+        assert assistant_message.tool_calls[0].function.name == "ask_user_name"
+        assert (
+            assistant_message.tool_calls[0].function.arguments
+            == '{"prompt": "what is your name?"}'
+        )


### PR DESCRIPTION
## Summary

Frontend SDK Actions intercepted by `CopilotKitMiddleware` could disappear before the client received a tool-call lifecycle, leaving the handler uncalled and the conversation without a tool result or follow-up answer. The bridge now consumes the middleware's authoritative intercepted-call state and publishes each call through the AG-UI adapter at most once. The focused intercepted file has 8 tests and the manual AG-UI file has 30 tests; the combined run is 38 tests, with the supported-version matrix remaining CI-owned.

## Root cause

`CopilotKitMiddleware.after_model()` removes frontend calls before LangChain's backend tool node and records those exact calls for final-message restoration. The previous adapter fallback ignored that state and reconstructed frontend ownership from `on_chat_model_end` plus the run's action catalog. That duplicated classification, failed when an action carried `function: None`, and never ran on Python 3.10 because the async LangChain path emitted no model callbacks there.

## Changes

- `sdk-python/copilotkit/langgraph_agui_agent.py`
  - publish middleware-classified calls from the existing chain-state event path
  - reuse one lifecycle materializer and the parent adapter's per-run ID ledger
  - remove raw model-end/action-schema reconstruction and the duplicate logger assignment
- `sdk-python/tests/test_intercepted_tool_call_events.py`
  - exercise the real `create_agent(..., tools=[])` middleware and AG-UI path in streaming and non-streaming modes
  - cover exactly-once identity, Python 3.10 restoration, multiple IDs, metadata opt-out, backend negative space, and malformed action/state shapes

## What is not changed

- backend tools still use LangChain's normal tool node
- `after_agent` still restores intercepted calls into the final assistant snapshot
- tool-call emission metadata still controls streamed lifecycle visibility
- explicit `copilotkit_emit_tool_call()` calls keep their existing caller-controlled semantics

## Related PRs and Issues

Closes #4342.

## Test plan

- [x] Focused intercepted SDK Action regression file, 8 passed on Python 3.12. Covers the real `create_agent(..., tools=[])` path, streaming, restoration, mixed ownership, chain metadata suppression, malformed state, and action-shape isolation.
- [x] Existing manual tool-call materialization file, 30 passed on Python 3.12.
- [x] Combined focused selection, 38 passed on Python 3.12, counted once rather than adding a second 38-test total.
- [x] Ruff check and format check on both changed files, both passed.
- [ ] Python SDK CI matrix green on Python 3.10, 3.11, 3.12, 3.13, and 3.14
