### PR TITLE
fix(sdk-python): bridge copilotkit context into LangGraph subgraphs

### DIFF
--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -274,6 +274,25 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
     def name(self) -> str:
         return "CopilotKitMiddleware"
 
+    @staticmethod
+    def _get_copilotkit_context(state: dict) -> dict:
+        """Read copilotkit context from state, falling back to LangGraph config.
+
+        When the agent runs as a subgraph, the parent may not propagate the
+        copilotkit state key. LangGraph always propagates config.configurable
+        to subgraph nodes, so we fall back to reading from there.
+        """
+        ck = state.get("copilotkit") or {}
+        if ck.get("actions") or ck.get("context"):
+            return ck
+        try:
+            from langgraph.config import get_config
+
+            cfg = get_config() or {}
+            return (cfg.get("configurable") or {}).get("copilotkit") or ck
+        except Exception:  # noqa: BLE001 - no active context / older langgraph
+            return ck
+
     # ------------------------------------------------------------------
     # State-to-prompt surfacing
     # ------------------------------------------------------------------
@@ -539,7 +558,9 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         request = self._apply_app_context_note(request)
 
         a2ui_tool = self._maybe_build_a2ui_tool(request)
-        frontend_tools = request.state.get("copilotkit", {}).get("actions", [])
+        frontend_tools = self._get_copilotkit_context(request.state or {}).get(
+            "actions", []
+        )
         if a2ui_tool is not None:
             # Our generate_a2ui replaces the runtime's render tool — don't
             # advertise both. Drop the render tool the A2UI middleware injected.
@@ -743,7 +764,9 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         request = self._apply_app_context_note(request)
 
         a2ui_tool = self._maybe_build_a2ui_tool(request)
-        frontend_tools = request.state.get("copilotkit", {}).get("actions", [])
+        frontend_tools = self._get_copilotkit_context(request.state or {}).get(
+            "actions", []
+        )
         if a2ui_tool is not None:
             # Our generate_a2ui replaces the runtime's render tool — don't
             # advertise both. Drop the render tool the A2UI middleware injected.
@@ -820,7 +843,7 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         state: StateSchema,
         runtime: Runtime[Any],
     ) -> dict[str, Any] | None:
-        frontend_tools = state.get("copilotkit", {}).get("actions", [])
+        frontend_tools = self._get_copilotkit_context(state).get("actions", [])
         if not frontend_tools:
             return None
 

--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -275,21 +275,54 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         return "CopilotKitMiddleware"
 
     @staticmethod
-    def _get_copilotkit_context(state: dict) -> dict:
-        """Read copilotkit context from state, falling back to LangGraph config.
+    def _has_copilotkit_payload(candidate: Any) -> bool:
+        return isinstance(candidate, dict) and (
+            bool(candidate.get("actions")) or bool(candidate.get("context"))
+        )
+
+    @staticmethod
+    def _copilotkit_from_runtime_context(runtime_context: Any) -> dict[str, Any]:
+        if not isinstance(runtime_context, dict):
+            return {}
+        nested = runtime_context.get("copilotkit")
+        if CopilotKitMiddleware._has_copilotkit_payload(nested):
+            return nested
+        if CopilotKitMiddleware._has_copilotkit_payload(runtime_context):
+            return runtime_context
+        return {}
+
+    @staticmethod
+    def _get_copilotkit_context(
+        state: dict,
+        runtime_context: Any = None,
+    ) -> dict:
+        """Read copilotkit context from state, runtime context, then config carriers.
 
         When the agent runs as a subgraph, the parent may not propagate the
-        copilotkit state key. LangGraph always propagates config.configurable
-        to subgraph nodes, so we fall back to reading from there.
+        copilotkit state key onto child state, but it may still be present on
+        the model request/runtime context. Current LangGraph prefers
+        ``config["context"]`` for run-scoped context and older paths still rely on
+        ``config["configurable"]``, so we check both.
         """
         ck = state.get("copilotkit") or {}
-        if ck.get("actions") or ck.get("context"):
+        if CopilotKitMiddleware._has_copilotkit_payload(ck):
             return ck
+        runtime_ck = CopilotKitMiddleware._copilotkit_from_runtime_context(
+            runtime_context
+        )
+        if runtime_ck:
+            return runtime_ck
         try:
             from langgraph.config import get_config
 
             cfg = get_config() or {}
-            return (cfg.get("configurable") or {}).get("copilotkit") or ck
+            for carrier in (cfg.get("context"), cfg.get("configurable")):
+                candidate = CopilotKitMiddleware._copilotkit_from_runtime_context(
+                    carrier or {}
+                )
+                if candidate:
+                    return candidate
+            return ck
         except Exception:  # noqa: BLE001 - no active context / older langgraph
             return ck
 
@@ -362,8 +395,18 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         state: dict[str, Any],
         runtime_context: Any = None,
     ) -> str | None:
-        copilotkit_state = state.get("copilotkit", {})
-        app_context = copilotkit_state.get("context") or runtime_context
+        copilotkit_state = self._get_copilotkit_context(state, runtime_context)
+        app_context = copilotkit_state.get("context")
+
+        if not app_context:
+            if isinstance(runtime_context, dict):
+                app_context = {
+                    k: v
+                    for k, v in runtime_context.items()
+                    if k != "copilotkit_forwarded_headers"
+                }
+            else:
+                app_context = runtime_context
 
         if isinstance(app_context, dict):
             app_context = {
@@ -455,7 +498,9 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
             return None, catalog_id
 
         # CopilotKit runtime-proxy path: the catalog arrives as a context entry.
-        context = (state.get("copilotkit") or {}).get("context") or []
+        context = (
+            CopilotKitMiddleware._get_copilotkit_context(state).get("context") or []
+        )
         for entry in context:
             if not isinstance(entry, dict):
                 continue
@@ -558,9 +603,10 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         request = self._apply_app_context_note(request)
 
         a2ui_tool = self._maybe_build_a2ui_tool(request)
-        frontend_tools = self._get_copilotkit_context(request.state or {}).get(
-            "actions", []
-        )
+        frontend_tools = self._get_copilotkit_context(
+            request.state or {},
+            getattr(request.runtime, "context", None),
+        ).get("actions", [])
         if a2ui_tool is not None:
             # Our generate_a2ui replaces the runtime's render tool — don't
             # advertise both. Drop the render tool the A2UI middleware injected.
@@ -764,9 +810,10 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         request = self._apply_app_context_note(request)
 
         a2ui_tool = self._maybe_build_a2ui_tool(request)
-        frontend_tools = self._get_copilotkit_context(request.state or {}).get(
-            "actions", []
-        )
+        frontend_tools = self._get_copilotkit_context(
+            request.state or {},
+            getattr(request.runtime, "context", None),
+        ).get("actions", [])
         if a2ui_tool is not None:
             # Our generate_a2ui replaces the runtime's render tool — don't
             # advertise both. Drop the render tool the A2UI middleware injected.
@@ -843,7 +890,10 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         state: StateSchema,
         runtime: Runtime[Any],
     ) -> dict[str, Any] | None:
-        frontend_tools = self._get_copilotkit_context(state).get("actions", [])
+        frontend_tools = self._get_copilotkit_context(
+            state,
+            getattr(runtime, "context", None),
+        ).get("actions", [])
         if not frontend_tools:
             return None
 

--- a/sdk-python/copilotkit/langgraph_agui_agent.py
+++ b/sdk-python/copilotkit/langgraph_agui_agent.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import logging
 from enum import Enum
@@ -70,6 +71,7 @@ class LangGraphAGUIAgent(LangGraphAgent):
     ):
         super().__init__(name=name, graph=graph, description=description, config=config)
         self.constant_schema_keys = self.constant_schema_keys + ["copilotkit"]
+        self._copilotkit_runtime_payload: dict[str, Any] | None = None
 
     def _dispatch_event(self, event) -> str:
         """Override the dispatch event method to handle custom CopilotKit events and filtering.
@@ -248,9 +250,15 @@ class LangGraphAGUIAgent(LangGraphAgent):
 
     async def run(self, input):
         """Override run to filter out None events from _dispatch_event filtering."""
-        async for event in super().run(input):
-            if event is not None:
-                yield event
+        self._copilotkit_runtime_payload = self._serialize_copilotkit_runtime_payload(
+            input
+        )
+        try:
+            async for event in super().run(input):
+                if event is not None:
+                    yield event
+        finally:
+            self._copilotkit_runtime_payload = None
 
     async def _handle_single_event(
         self, event: Any, state: State
@@ -295,13 +303,29 @@ class LangGraphAGUIAgent(LangGraphAgent):
         fork: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """Thread CopilotKit payload through LangGraph runtime context for subgraphs."""
+        supports_context = (
+            "context" in inspect.signature(self.graph.astream_events).parameters
+        )
         merged_context = dict(context or {})
-        existing_copilotkit = merged_context.get("copilotkit") or {}
-        merged_context["copilotkit"] = {
-            **existing_copilotkit,
-            **self._serialize_copilotkit_runtime_payload(input),
-        }
-        return super().get_stream_kwargs(
+        captured_payload = self._copilotkit_runtime_payload
+        if captured_payload is not None:
+            if supports_context:
+                existing_copilotkit = merged_context.get("copilotkit") or {}
+                merged_context["copilotkit"] = {
+                    **existing_copilotkit,
+                    **captured_payload,
+                }
+            else:
+                next_config = dict(config or {})
+                configurable = dict(next_config.get("configurable") or {})
+                existing_copilotkit = configurable.get("copilotkit") or {}
+                configurable["copilotkit"] = {
+                    **existing_copilotkit,
+                    **captured_payload,
+                }
+                next_config["configurable"] = configurable
+                config = next_config
+        stream_kwargs = super().get_stream_kwargs(
             input=input,
             subgraphs=subgraphs,
             version=version,
@@ -309,6 +333,7 @@ class LangGraphAGUIAgent(LangGraphAgent):
             context=merged_context,
             fork=fork,
         )
+        return stream_kwargs
 
     def langgraph_default_merge_state(
         self, state: State, messages: List[BaseMessage], input: Any

--- a/sdk-python/copilotkit/langgraph_agui_agent.py
+++ b/sdk-python/copilotkit/langgraph_agui_agent.py
@@ -1,24 +1,26 @@
 import json
 import logging
-from typing import Dict, Any, List, Optional, Union, AsyncGenerator
 from enum import Enum
+from typing import Any, AsyncGenerator, Dict, List, Optional, Union
+
+from ag_ui.core import (
+    CustomEvent,
+    EventType,
+    StateSnapshotEvent,
+    TextMessageContentEvent,
+    TextMessageEndEvent,
+    TextMessageStartEvent,
+    ToolCallArgsEvent,
+    ToolCallEndEvent,
+    ToolCallStartEvent,
+)
+from ag_ui_langgraph import LangGraphAgent
+from langchain_core.runnables import RunnableConfig
+from langgraph.graph.state import CompiledStateGraph
+
 from .exc import CopilotKitMisuseError
 
 logger = logging.getLogger(__name__)
-from ag_ui_langgraph import LangGraphAgent
-from ag_ui.core import (
-    EventType,
-    CustomEvent,
-    TextMessageStartEvent,
-    TextMessageContentEvent,
-    TextMessageEndEvent,
-    ToolCallStartEvent,
-    ToolCallArgsEvent,
-    ToolCallEndEvent,
-    StateSnapshotEvent,
-)
-from langgraph.graph.state import CompiledStateGraph
-from langchain_core.runnables import RunnableConfig
 
 try:
     from langchain.schema import BaseMessage
@@ -266,6 +268,47 @@ class LangGraphAGUIAgent(LangGraphAgent):
         # Call the parent method to handle all other events
         async for event_str in super()._handle_single_event(event, state):
             yield event_str
+
+    @staticmethod
+    def _serialize_copilotkit_runtime_payload(input: Any) -> dict[str, Any]:
+        """Build the CopilotKit payload that subgraphs need in runtime context."""
+        tools = [
+            tool.model_dump() if hasattr(tool, "model_dump") else tool
+            for tool in (getattr(input, "tools", None) or [])
+        ]
+        context = [
+            item.model_dump() if hasattr(item, "model_dump") else item
+            for item in (getattr(input, "context", None) or [])
+        ]
+        return {
+            "actions": tools,
+            "context": context,
+        }
+
+    def get_stream_kwargs(
+        self,
+        input: Any,
+        subgraphs: bool = False,
+        version: str = "v2",
+        config: Union[Optional[RunnableConfig], dict] = None,
+        context: Optional[Dict[str, Any]] = None,
+        fork: Optional[Any] = None,
+    ) -> Dict[str, Any]:
+        """Thread CopilotKit payload through LangGraph runtime context for subgraphs."""
+        merged_context = dict(context or {})
+        existing_copilotkit = merged_context.get("copilotkit") or {}
+        merged_context["copilotkit"] = {
+            **existing_copilotkit,
+            **self._serialize_copilotkit_runtime_payload(input),
+        }
+        return super().get_stream_kwargs(
+            input=input,
+            subgraphs=subgraphs,
+            version=version,
+            config=config,
+            context=merged_context,
+            fork=fork,
+        )
 
     def langgraph_default_merge_state(
         self, state: State, messages: List[BaseMessage], input: Any

--- a/sdk-python/tests/test_agui_agent.py
+++ b/sdk-python/tests/test_agui_agent.py
@@ -457,8 +457,8 @@ class TestLanggraphDefaultMergeState:
         assert action_names == ["first", "second", "third"]
 
 
-class TestGetStreamKwargs:
-    """get_stream_kwargs threads CopilotKit payload into LangGraph context."""
+class TestRunRuntimeContextBridge:
+    """run captures the request before the base agent derives stream input."""
 
     class _GraphWithContext:
         nodes = {}
@@ -478,7 +478,24 @@ class TestGetStreamKwargs:
             if False:
                 yield input, subgraphs, version, config, context
 
-    def test_copilotkit_payload_added_to_runtime_context(self):
+    class _GraphWithoutContext:
+        nodes = {}
+
+        def get_state(self):
+            return None
+
+        async def astream_events(
+            self,
+            *,
+            input=None,
+            subgraphs=False,
+            version="v2",
+            config=None,
+        ):
+            if False:
+                yield input, subgraphs, version, config
+
+    def test_run_captures_payload_for_derived_stream_input(self):
         agent = LangGraphAGUIAgent(name="test", graph=self._GraphWithContext())
         run_input = RunAgentInput(
             thread_id="t-1",
@@ -500,28 +517,88 @@ class TestGetStreamKwargs:
             forwarded_props={},
         )
 
-        kwargs = agent.get_stream_kwargs(
-            input=run_input,
-            subgraphs=True,
-            version="v2",
-            config={"configurable": {"thread_id": "t-1", "x-trace": "abc"}},
+        captured = {}
+
+        async def fake_base_run(_self, _input):
+            captured.update(
+                _self.get_stream_kwargs(
+                    input={"messages": []},
+                    subgraphs=True,
+                    version="v2",
+                    config={"configurable": {"thread_id": "t-1", "x-trace": "abc"}},
+                )
+            )
+            if False:
+                yield None
+
+        with patch.object(AGUIBase, "run", new=fake_base_run):
+            import asyncio
+
+            asyncio.run(self._consume(agent.run(run_input)))
+
+        assert captured["context"]["thread_id"] == "t-1"
+        assert captured["context"]["x-trace"] == "abc"
+        assert captured["context"]["copilotkit"]["actions"][0]["name"] == (
+            "frontend_lookup"
+        )
+        assert captured["context"]["copilotkit"]["context"] == [
+            {"description": "viewer role", "value": "admin"}
+        ]
+
+    def test_run_does_not_force_context_for_graphs_without_context_support(self):
+        agent = LangGraphAGUIAgent(name="test", graph=self._GraphWithoutContext())
+        run_input = RunAgentInput(
+            thread_id="t-1",
+            run_id="r-1",
+            state={},
+            messages=[],
+            tools=[
+                {
+                    "name": "frontend_lookup",
+                    "description": "frontend tool",
+                }
+            ],
+            context=[
+                {
+                    "description": "viewer role",
+                    "value": "admin",
+                }
+            ],
+            forwarded_props={},
         )
 
-        assert kwargs["context"]["thread_id"] == "t-1"
-        assert kwargs["context"]["x-trace"] == "abc"
-        assert kwargs["context"]["copilotkit"]["actions"] == [
-            {
-                "name": "frontend_lookup",
-                "description": "frontend tool",
-                "parameters": None,
-            }
+        captured = {}
+
+        async def fake_base_run(_self, _input):
+            captured.update(
+                _self.get_stream_kwargs(
+                    input={"messages": []},
+                    subgraphs=True,
+                    version="v2",
+                    config={"configurable": {"thread_id": "t-1", "x-trace": "abc"}},
+                )
+            )
+            if False:
+                yield None
+
+        with patch.object(AGUIBase, "run", new=fake_base_run):
+            import asyncio
+
+            asyncio.run(self._consume(agent.run(run_input)))
+
+        assert "context" not in captured
+        assert captured["config"]["configurable"]["thread_id"] == "t-1"
+        assert captured["config"]["configurable"]["x-trace"] == "abc"
+        assert captured["config"]["configurable"]["copilotkit"]["actions"][0][
+            "name"
+        ] == ("frontend_lookup")
+        assert captured["config"]["configurable"]["copilotkit"]["context"] == [
+            {"description": "viewer role", "value": "admin"}
         ]
-        assert kwargs["context"]["copilotkit"]["context"] == [
-            {
-                "description": "viewer role",
-                "value": "admin",
-            }
-        ]
+
+    @staticmethod
+    async def _consume(events):
+        return [event async for event in events]
 
 
 # ---------- Reasoning content preservation ----------

--- a/sdk-python/tests/test_agui_agent.py
+++ b/sdk-python/tests/test_agui_agent.py
@@ -7,25 +7,22 @@ Covers:
 """
 
 import json
-import pytest
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
+
+import pytest
 from ag_ui.core import (
-    EventType,
     CustomEvent,
-    TextMessageStartEvent,
+    EventType,
+    RunAgentInput,
     TextMessageContentEvent,
-    TextMessageEndEvent,
     ToolCallStartEvent,
-    ToolCallArgsEvent,
-    ToolCallEndEvent,
-    StateSnapshotEvent,
 )
 from ag_ui_langgraph import LangGraphAgent as AGUIBase
 from copilotkit import CopilotKitRemoteEndpoint
 from copilotkit.langgraph_agui_agent import (
-    LangGraphAGUIAgent,
     CustomEventNames,
+    LangGraphAGUIAgent,
 )
 
 
@@ -458,6 +455,73 @@ class TestLanggraphDefaultMergeState:
 
         action_names = [a.get("name") for a in result["copilotkit"]["actions"]]
         assert action_names == ["first", "second", "third"]
+
+
+class TestGetStreamKwargs:
+    """get_stream_kwargs threads CopilotKit payload into LangGraph context."""
+
+    class _GraphWithContext:
+        nodes = {}
+
+        def get_state(self):
+            return None
+
+        async def astream_events(
+            self,
+            *,
+            input=None,
+            subgraphs=False,
+            version="v2",
+            config=None,
+            context=None,
+        ):
+            if False:
+                yield input, subgraphs, version, config, context
+
+    def test_copilotkit_payload_added_to_runtime_context(self):
+        agent = LangGraphAGUIAgent(name="test", graph=self._GraphWithContext())
+        run_input = RunAgentInput(
+            thread_id="t-1",
+            run_id="r-1",
+            state={},
+            messages=[],
+            tools=[
+                {
+                    "name": "frontend_lookup",
+                    "description": "frontend tool",
+                }
+            ],
+            context=[
+                {
+                    "description": "viewer role",
+                    "value": "admin",
+                }
+            ],
+            forwarded_props={},
+        )
+
+        kwargs = agent.get_stream_kwargs(
+            input=run_input,
+            subgraphs=True,
+            version="v2",
+            config={"configurable": {"thread_id": "t-1", "x-trace": "abc"}},
+        )
+
+        assert kwargs["context"]["thread_id"] == "t-1"
+        assert kwargs["context"]["x-trace"] == "abc"
+        assert kwargs["context"]["copilotkit"]["actions"] == [
+            {
+                "name": "frontend_lookup",
+                "description": "frontend tool",
+                "parameters": None,
+            }
+        ]
+        assert kwargs["context"]["copilotkit"]["context"] == [
+            {
+                "description": "viewer role",
+                "value": "admin",
+            }
+        ]
 
 
 # ---------- Reasoning content preservation ----------

--- a/sdk-python/tests/test_copilotkit_lg_middleware.py
+++ b/sdk-python/tests/test_copilotkit_lg_middleware.py
@@ -134,6 +134,136 @@ def test_frontend_tools_merge_does_not_mutate_input_request():
 
 
 # ---------------------------------------------------------------------------
+# _get_copilotkit_context — fallback to config.configurable
+# ---------------------------------------------------------------------------
+
+
+def test_get_copilotkit_context_returns_state_level_when_present(monkeypatch):
+    """When state["copilotkit"] has actions, return it unchanged."""
+    middleware = CopilotKitMiddleware()
+    state = {
+        "copilotkit": {
+            "actions": [{"name": "fe_one"}],
+            "context": "some context",
+        }
+    }
+
+    result = middleware._get_copilotkit_context(state)
+
+    assert result == state["copilotkit"]
+
+
+def test_get_copilotkit_context_falls_back_to_config_when_state_empty(monkeypatch):
+    """When state["copilotkit"] is empty, read from config.configurable.copilotkit."""
+    middleware = CopilotKitMiddleware()
+    config_copilotkit = {
+        "actions": [{"name": "fe_from_config"}],
+        "context": "config context",
+    }
+
+    def mock_get_config():
+        return {"configurable": {"copilotkit": config_copilotkit}}
+
+    monkeypatch.setattr(
+        "langgraph.config.get_config",
+        mock_get_config,
+    )
+
+    state = {}
+    result = middleware._get_copilotkit_context(state)
+
+    assert result == config_copilotkit
+
+
+def test_get_copilotkit_context_prefers_state_over_config(monkeypatch):
+    """State-level copilotkit takes precedence over config."""
+    middleware = CopilotKitMiddleware()
+    state = {
+        "copilotkit": {
+            "actions": [{"name": "fe_state"}],
+        }
+    }
+
+    def mock_get_config():
+        return {
+            "configurable": {
+                "copilotkit": {
+                    "actions": [{"name": "fe_config"}],
+                }
+            }
+        }
+
+    monkeypatch.setattr(
+        "langgraph.config.get_config",
+        mock_get_config,
+    )
+
+    result = middleware._get_copilotkit_context(state)
+
+    assert result["actions"][0]["name"] == "fe_state"
+
+
+def test_get_copilotkit_context_returns_empty_dict_when_not_found(monkeypatch):
+    """When copilotkit is not in state or config, return empty dict."""
+    middleware = CopilotKitMiddleware()
+
+    def mock_get_config():
+        return {"configurable": {}}
+
+    monkeypatch.setattr(
+        "langgraph.config.get_config",
+        mock_get_config,
+    )
+
+    state = {}
+    result = middleware._get_copilotkit_context(state)
+
+    assert result == {}
+
+
+def test_get_copilotkit_context_handles_missing_config(monkeypatch):
+    """When get_config raises, return empty state copilotkit."""
+    middleware = CopilotKitMiddleware()
+
+    def mock_get_config():
+        raise RuntimeError("No active context")
+
+    monkeypatch.setattr(
+        "langgraph.config.get_config",
+        mock_get_config,
+    )
+
+    state = {}
+    result = middleware._get_copilotkit_context(state)
+
+    assert result == {}
+
+
+def test_wrap_model_call_injects_frontend_tools_from_config_fallback(monkeypatch):
+    """wrap_model_call uses config fallback when state lacks copilotkit."""
+    middleware = CopilotKitMiddleware()
+    backend_tool = {"name": "backend_tool"}
+    fe_tools = [{"name": "fe_from_config"}]
+
+    def mock_get_config():
+        return {"configurable": {"copilotkit": {"actions": fe_tools}}}
+
+    monkeypatch.setattr(
+        "langgraph.config.get_config",
+        mock_get_config,
+    )
+
+    # State has no copilotkit key, but config does.
+    request = _make_request(state={"messages": []}, tools=[backend_tool])
+
+    seen, _ = _run_wrap(middleware, request)
+
+    seen_names = [t["name"] for t in seen.tools]
+    assert "backend_tool" in seen_names
+    assert "fe_from_config" in seen_names
+
+
+# ---------------------------------------------------------------------------
 # expose_state — opt-in state surfacing
 # ---------------------------------------------------------------------------
 

--- a/sdk-python/tests/test_copilotkit_lg_middleware.py
+++ b/sdk-python/tests/test_copilotkit_lg_middleware.py
@@ -30,13 +30,21 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import Field
+from typing_extensions import TypedDict
+from langchain.agents import create_agent
+from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import (
     AIMessage,
+    BaseMessage,
     HumanMessage,
     SystemMessage,
     ToolMessage,
 )
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langgraph.constants import END, START
 from langchain.agents.middleware import ModelRequest
+from langgraph.graph import StateGraph
 
 from copilotkit.copilotkit_lg_middleware import (
     CopilotKitMiddleware,
@@ -58,13 +66,15 @@ def _make_request(
     messages: list[Any] | None = None,
 ) -> ModelRequest:
     """Build a ModelRequest with sensible defaults for testing."""
+    runtime = MagicMock(name="runtime")
+    runtime.context = None
     return ModelRequest(
         model=MagicMock(name="model"),
         messages=messages if messages is not None else [],
         system_message=system_message,
         tools=tools if tools is not None else [],
         state=state if state is not None else {"messages": []},
-        runtime=MagicMock(name="runtime", context=None),
+        runtime=runtime,
     )
 
 
@@ -85,6 +95,39 @@ def _run_wrap(middleware: CopilotKitMiddleware, request: ModelRequest):
     result = middleware.wrap_model_call(request, handler)
     assert handler.received is not None, "handler must be called"
     return handler.received, result
+
+
+class _RecordingToolAwareChatModel(BaseChatModel):
+    """Minimal model that records the messages/tools LangChain bound to it."""
+
+    bound_tools: list[Any] = Field(default_factory=list)
+    last_messages: list[BaseMessage] = Field(default_factory=list)
+
+    @property
+    def _llm_type(self) -> str:
+        return "recording-tool-aware-chat-model"
+
+    def bind_tools(self, tools, *, tool_choice=None, **kwargs):
+        self.bound_tools = list(tools)
+        return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager=None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        self.last_messages = list(messages)
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content="ok"))])
+
+
+class _ParentState(TypedDict):
+    messages: list[Any]
+
+
+class _ParentContext(TypedDict, total=False):
+    copilotkit: dict[str, Any]
 
 
 # ---------------------------------------------------------------------------
@@ -134,7 +177,7 @@ def test_frontend_tools_merge_does_not_mutate_input_request():
 
 
 # ---------------------------------------------------------------------------
-# _get_copilotkit_context — fallback to config.configurable
+# _get_copilotkit_context — fallback to LangGraph runtime carriers
 # ---------------------------------------------------------------------------
 
 
@@ -153,16 +196,16 @@ def test_get_copilotkit_context_returns_state_level_when_present(monkeypatch):
     assert result == state["copilotkit"]
 
 
-def test_get_copilotkit_context_falls_back_to_config_when_state_empty(monkeypatch):
-    """When state["copilotkit"] is empty, read from config.configurable.copilotkit."""
+def test_get_copilotkit_context_falls_back_to_langgraph_context(monkeypatch):
+    """When state lacks copilotkit, prefer config.context.copilotkit."""
     middleware = CopilotKitMiddleware()
     config_copilotkit = {
-        "actions": [{"name": "fe_from_config"}],
-        "context": "config context",
+        "actions": [{"name": "fe_from_context"}],
+        "context": [{"description": "viewer role", "value": "admin"}],
     }
 
     def mock_get_config():
-        return {"configurable": {"copilotkit": config_copilotkit}}
+        return {"context": {"copilotkit": config_copilotkit}}
 
     monkeypatch.setattr(
         "langgraph.config.get_config",
@@ -175,8 +218,31 @@ def test_get_copilotkit_context_falls_back_to_config_when_state_empty(monkeypatc
     assert result == config_copilotkit
 
 
-def test_get_copilotkit_context_prefers_state_over_config(monkeypatch):
-    """State-level copilotkit takes precedence over config."""
+def test_get_copilotkit_context_falls_back_to_configurable_when_context_missing(
+    monkeypatch,
+):
+    """Older configurable-only carriers still work as a fallback."""
+    middleware = CopilotKitMiddleware()
+    config_copilotkit = {
+        "actions": [{"name": "fe_from_configurable"}],
+        "context": [{"description": "workspace", "value": "prod"}],
+    }
+
+    def mock_get_config():
+        return {"configurable": {"copilotkit": config_copilotkit}}
+
+    monkeypatch.setattr(
+        "langgraph.config.get_config",
+        mock_get_config,
+    )
+
+    result = middleware._get_copilotkit_context({})
+
+    assert result == config_copilotkit
+
+
+def test_get_copilotkit_context_prefers_state_over_runtime_carriers(monkeypatch):
+    """State-level copilotkit takes precedence over config/context fallbacks."""
     middleware = CopilotKitMiddleware()
     state = {
         "copilotkit": {
@@ -239,14 +305,14 @@ def test_get_copilotkit_context_handles_missing_config(monkeypatch):
     assert result == {}
 
 
-def test_wrap_model_call_injects_frontend_tools_from_config_fallback(monkeypatch):
-    """wrap_model_call uses config fallback when state lacks copilotkit."""
+def test_wrap_model_call_injects_frontend_tools_from_context_bridge(monkeypatch):
+    """wrap_model_call uses the runtime context bridge when state lacks copilotkit."""
     middleware = CopilotKitMiddleware()
     backend_tool = {"name": "backend_tool"}
-    fe_tools = [{"name": "fe_from_config"}]
+    fe_tools = [{"name": "fe_from_context"}]
 
     def mock_get_config():
-        return {"configurable": {"copilotkit": {"actions": fe_tools}}}
+        return {"context": {"copilotkit": {"actions": fe_tools}}}
 
     monkeypatch.setattr(
         "langgraph.config.get_config",
@@ -260,7 +326,51 @@ def test_wrap_model_call_injects_frontend_tools_from_config_fallback(monkeypatch
 
     seen_names = [t["name"] for t in seen.tools]
     assert "backend_tool" in seen_names
-    assert "fe_from_config" in seen_names
+    assert "fe_from_context" in seen_names
+
+
+def test_real_subgraph_context_bridge_reaches_child_agent():
+    """A real create_agent subgraph sees frontend tools and app context via runtime context."""
+    model = _RecordingToolAwareChatModel()
+    child_agent = create_agent(
+        model=model,
+        tools=[],
+        middleware=[CopilotKitMiddleware()],
+    )
+    parent = StateGraph(_ParentState, context_schema=_ParentContext)
+    parent.add_node("child", child_agent)
+    parent.add_edge(START, "child")
+    parent.add_edge("child", END)
+    compiled = parent.compile()
+
+    result = compiled.invoke(
+        {"messages": [HumanMessage("hi")]},
+        context={
+            "copilotkit": {
+                "actions": [
+                    {
+                        "name": "frontend_lookup",
+                        "description": "frontend tool",
+                    }
+                ],
+                "context": [
+                    {
+                        "description": "viewer role",
+                        "value": "admin",
+                    }
+                ],
+            }
+        },
+    )
+
+    assert result["messages"][-1].content == "ok"
+    assert [tool.get("name") for tool in model.bound_tools] == ["frontend_lookup"]
+    system_messages = [
+        msg for msg in model.last_messages if isinstance(msg, SystemMessage)
+    ]
+    assert system_messages, "middleware should inject an app-context system message"
+    assert any("App Context:" in msg.content for msg in system_messages)
+    assert any("admin" in msg.content for msg in system_messages)
 
 
 # ---------------------------------------------------------------------------

--- a/sdk-python/tests/test_copilotkit_lg_middleware.py
+++ b/sdk-python/tests/test_copilotkit_lg_middleware.py
@@ -30,6 +30,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from ag_ui.core import RunAgentInput, UserMessage
 from pydantic import Field
 from typing_extensions import TypedDict
 from langchain.agents import create_agent
@@ -43,6 +44,7 @@ from langchain_core.messages import (
 )
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langgraph.constants import END, START
+from langgraph.checkpoint.memory import MemorySaver
 from langchain.agents.middleware import ModelRequest
 from langgraph.graph import StateGraph
 
@@ -51,6 +53,7 @@ from copilotkit.copilotkit_lg_middleware import (
     _extract_forwarded_headers_from_config,
 )
 from copilotkit.header_propagation import get_forwarded_headers, set_forwarded_headers
+from copilotkit.langgraph_agui_agent import LangGraphAGUIAgent
 
 
 # ---------------------------------------------------------------------------
@@ -330,40 +333,52 @@ def test_wrap_model_call_injects_frontend_tools_from_context_bridge(monkeypatch)
 
 
 def test_real_subgraph_context_bridge_reaches_child_agent():
-    """A real create_agent subgraph sees frontend tools and app context via runtime context."""
+    """A real AG-UI run carries tools and app context into a child agent."""
     model = _RecordingToolAwareChatModel()
+    middleware = CopilotKitMiddleware()
     child_agent = create_agent(
         model=model,
         tools=[],
-        middleware=[CopilotKitMiddleware()],
+        middleware=[middleware],
+        context_schema=_ParentContext,
     )
     parent = StateGraph(_ParentState, context_schema=_ParentContext)
     parent.add_node("child", child_agent)
     parent.add_edge(START, "child")
     parent.add_edge("child", END)
-    compiled = parent.compile()
-
-    result = compiled.invoke(
-        {"messages": [HumanMessage("hi")]},
-        context={
-            "copilotkit": {
-                "actions": [
-                    {
-                        "name": "frontend_lookup",
-                        "description": "frontend tool",
-                    }
-                ],
-                "context": [
-                    {
-                        "description": "viewer role",
-                        "value": "admin",
-                    }
-                ],
-            }
-        },
+    agent = LangGraphAGUIAgent(
+        name="parent", graph=parent.compile(checkpointer=MemorySaver())
     )
 
-    assert result["messages"][-1].content == "ok"
+    async def consume_run():
+        return [
+            event
+            async for event in agent.run(
+                RunAgentInput(
+                    thread_id="t-1",
+                    run_id="r-1",
+                    state={},
+                    messages=[UserMessage(id="m-1", content="hi")],
+                    tools=[
+                        {
+                            "name": "frontend_lookup",
+                            "description": "frontend tool",
+                        }
+                    ],
+                    context=[
+                        {
+                            "description": "viewer role",
+                            "value": "admin",
+                        }
+                    ],
+                    forwarded_props={},
+                )
+            )
+        ]
+
+    asyncio.run(consume_run())
+
+    assert model.last_messages, "child model should receive the parent run"
     assert [tool.get("name") for tool in model.bound_tools] == ["frontend_lookup"]
     system_messages = [
         msg for msg in model.last_messages if isinstance(msg, SystemMessage)


### PR DESCRIPTION
## Summary

`CopilotKitMiddleware` loses frontend actions and app context when a middleware-wrapped agent runs as a LangGraph subgraph. Parent graphs propagate run context to child nodes, but `state["copilotkit"]` stays empty there, so the child misses both frontend-tool injection and the `App Context:` note.

## Root cause

`LangGraphAGUIAgent.langgraph_default_merge_state(...)` materializes CopilotKit data into state for top-level runs, but child LangGraph nodes inherit runtime context rather than arbitrary parent state. The missing piece was earlier in the write path: by the time the base agent calls `get_stream_kwargs(...)`, it has already replaced the original AG-UI request with merged graph state, so serializing from that argument drops the frontend tools and app context on the real subgraph path.

The fix moves ownership to the run entry: `LangGraphAGUIAgent.run(...)` now captures the frontend tools and app context from the real `RunAgentInput`, and `get_stream_kwargs(...)` forwards that captured payload into LangGraph using `context["copilotkit"]` when the graph supports runtime context, or `config["configurable"]["copilotkit"]` on older graph shapes. `CopilotKitMiddleware` still uses one shared lookup order everywhere it reads CopilotKit data: `state["copilotkit"]`, then `runtime.context["copilotkit"]`, then LangGraph config fallbacks. That same carrier now drives the app-context-note helper path too.

## Changes

- `sdk-python/copilotkit/langgraph_agui_agent.py`: capture frontend actions and app context from the original `RunAgentInput` in `run(...)`, then write the captured payload into the LangGraph runtime carrier that the current graph shape supports before the subgraph starts.
- `sdk-python/copilotkit/copilotkit_lg_middleware.py`: unify frontend-tool, app-context, and interception lookups around the same carrier order, and cover the current-`main` app-context helper path.
- `sdk-python/tests/test_agui_agent.py`: add focused coverage for both the runtime-context path and the configurable fallback path on graphs without `context` support.
- `sdk-python/tests/test_copilotkit_lg_middleware.py`: replace the manually seeded subgraph proof with a real `LangGraphAGUIAgent.run(...)` regression that reaches the child middleware through the production path.

## What is NOT changed

- Top-level agents still prefer `state["copilotkit"]`; the runtime bridge only fills the subgraph gap.
- Header propagation behavior is unchanged.
- No JS LangGraph executor changes are part of this PR.

## Related PRs and Issues

Closes #3886.

## Test plan

- [x] `cd sdk-python && pytest tests/test_agui_agent.py tests/test_copilotkit_lg_middleware.py -q` - 108/108 pass. Covers the AGUI run-entry bridge, the configurable fallback for graphs without `context` support, frontend-tool injection, app-context note injection, and a real `create_agent` subgraph invocation through `LangGraphAGUIAgent.run(...)`.
- [x] `ruff check sdk-python/copilotkit/copilotkit_lg_middleware.py sdk-python/copilotkit/langgraph_agui_agent.py sdk-python/tests/test_agui_agent.py sdk-python/tests/test_copilotkit_lg_middleware.py` - pass. Covers Python lint on every touched file.
- [x] `ruff format --check sdk-python/copilotkit/copilotkit_lg_middleware.py sdk-python/copilotkit/langgraph_agui_agent.py sdk-python/tests/test_agui_agent.py sdk-python/tests/test_copilotkit_lg_middleware.py` - pass. Covers repo formatting on every touched file.
- [ ] CI green (`static / quality`, `test / unit` on Node 20/22/24)
