### PR TITLE
fix(core): preserve tool result ordering for parallel frontend tool calls

### DIFF
--- a/.changeset/fix-parallel-tool-order.md
+++ b/.changeset/fix-parallel-tool-order.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/core": patch
+---
+
+fix(core): preserve tool result ordering for parallel frontend tool calls

--- a/packages/core/src/__tests__/core-parallel-tool-order.test.ts
+++ b/packages/core/src/__tests__/core-parallel-tool-order.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { CopilotKitCore } from "../core";
+import {
+  MockAgent,
+  createAssistantMessage,
+  createTool,
+  createMultipleToolCallsMessage,
+} from "./test-utils";
+
+describe("CopilotKitCore.runAgent - Parallel Tool Order", () => {
+  let copilotKitCore: CopilotKitCore;
+
+  beforeEach(() => {
+    copilotKitCore = new CopilotKitCore({});
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should preserve tool result ordering for parallel tool calls with followUp: false", async () => {
+    const toolA = createTool({
+      name: "toolA",
+      handler: vi.fn(async () => "Result A"),
+      followUp: false,
+    });
+    const toolB = createTool({
+      name: "toolB",
+      handler: vi.fn(async () => "Result B"),
+      followUp: false,
+    });
+
+    copilotKitCore.addTool(toolA);
+    copilotKitCore.addTool(toolB);
+
+    // Create a message with two parallel tool calls in order: [A, B]
+    const message = createMultipleToolCallsMessage([
+      { name: "toolA" },
+      { name: "toolB" },
+    ]);
+
+    const agent = new MockAgent({ newMessages: [message] });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    // Verify both handlers were called
+    expect(toolA.handler).toHaveBeenCalled();
+    expect(toolB.handler).toHaveBeenCalled();
+
+    // The message structure should be: [assistant, toolResultA, toolResultB, ...]
+    // Find the assistant message
+    const assistantIndex = agent.messages.findIndex(
+      (m) => m.id === message.id,
+    );
+    expect(assistantIndex).toBeGreaterThanOrEqual(0);
+
+    // The next two messages should be tool results in order
+    const firstToolResult = agent.messages[assistantIndex + 1];
+    const secondToolResult = agent.messages[assistantIndex + 2];
+
+    expect(firstToolResult).toBeDefined();
+    expect(secondToolResult).toBeDefined();
+    expect(firstToolResult?.role).toBe("tool");
+    expect(secondToolResult?.role).toBe("tool");
+
+    // Verify the order: first result corresponds to toolA, second to toolB
+    const toolCallIds = message.toolCalls?.map((tc) => tc.id) || [];
+    expect(firstToolResult?.toolCallId).toBe(toolCallIds[0]);
+    expect(secondToolResult?.toolCallId).toBe(toolCallIds[1]);
+  });
+
+  it("should preserve tool result ordering with one tool having followUp: true", async () => {
+    const toolA = createTool({
+      name: "toolA",
+      handler: vi.fn(async () => "Result A"),
+      followUp: false,
+    });
+    const toolB = createTool({
+      name: "toolB",
+      handler: vi.fn(async () => "Result B"),
+      followUp: true, // This will trigger a follow-up
+    });
+
+    copilotKitCore.addTool(toolA);
+    copilotKitCore.addTool(toolB);
+
+    // Create a message with two parallel tool calls in order: [A, B]
+    const message = createMultipleToolCallsMessage([
+      { name: "toolA" },
+      { name: "toolB" },
+    ]);
+
+    const followUpMessage = createAssistantMessage({
+      content: "Follow-up response",
+    });
+
+    const agent = new MockAgent({ newMessages: [message] });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    let callCount = 0;
+    agent.runAgentCallback = () => {
+      callCount++;
+      if (callCount === 2) {
+        agent.setNewMessages([followUpMessage]);
+      }
+    };
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    // Verify both handlers were called
+    expect(toolA.handler).toHaveBeenCalled();
+    expect(toolB.handler).toHaveBeenCalled();
+
+    // Verify the follow-up was triggered
+    expect(agent.runAgentCalls.length).toBeGreaterThan(1);
+
+    // Find the assistant message from the first call
+    const assistantIndex = agent.messages.findIndex(
+      (m) => m.id === message.id,
+    );
+    expect(assistantIndex).toBeGreaterThanOrEqual(0);
+
+    // The next two messages should be tool results in order
+    const firstToolResult = agent.messages[assistantIndex + 1];
+    const secondToolResult = agent.messages[assistantIndex + 2];
+
+    expect(firstToolResult?.role).toBe("tool");
+    expect(secondToolResult?.role).toBe("tool");
+
+    // Verify the order: first result corresponds to toolA, second to toolB
+    const toolCallIds = message.toolCalls?.map((tc) => tc.id) || [];
+    expect(firstToolResult?.toolCallId).toBe(toolCallIds[0]);
+    expect(secondToolResult?.toolCallId).toBe(toolCallIds[1]);
+  });
+
+  it("should preserve tool result ordering with three parallel tool calls", async () => {
+    const tools = [
+      createTool({
+        name: "tool1",
+        handler: vi.fn(async () => "Result 1"),
+        followUp: false,
+      }),
+      createTool({
+        name: "tool2",
+        handler: vi.fn(async () => "Result 2"),
+        followUp: false,
+      }),
+      createTool({
+        name: "tool3",
+        handler: vi.fn(async () => "Result 3"),
+        followUp: false,
+      }),
+    ];
+
+    tools.forEach((tool) => copilotKitCore.addTool(tool));
+
+    // Create a message with three parallel tool calls in order: [1, 2, 3]
+    const message = createMultipleToolCallsMessage([
+      { name: "tool1" },
+      { name: "tool2" },
+      { name: "tool3" },
+    ]);
+
+    const agent = new MockAgent({ newMessages: [message] });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    // Verify all handlers were called
+    tools.forEach((tool) => {
+      expect(tool.handler).toHaveBeenCalled();
+    });
+
+    // Find the assistant message
+    const assistantIndex = agent.messages.findIndex(
+      (m) => m.id === message.id,
+    );
+
+    // The next three messages should be tool results in order
+    const toolResults = [
+      agent.messages[assistantIndex + 1],
+      agent.messages[assistantIndex + 2],
+      agent.messages[assistantIndex + 3],
+    ];
+
+    toolResults.forEach((result) => {
+      expect(result?.role).toBe("tool");
+    });
+
+    // Verify the order
+    const toolCallIds = message.toolCalls?.map((tc) => tc.id) || [];
+    toolResults.forEach((result, index) => {
+      expect(result?.toolCallId).toBe(toolCallIds[index]);
+    });
+  });
+});

--- a/packages/core/src/__tests__/core-parallel-tool-order.test.ts
+++ b/packages/core/src/__tests__/core-parallel-tool-order.test.ts
@@ -1,3 +1,4 @@
+import type { Message } from "@ag-ui/client";
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { CopilotKitCore } from "../core";
 import {
@@ -6,6 +7,24 @@ import {
   createTool,
   createMultipleToolCallsMessage,
 } from "./test-utils";
+
+function getToolCallIds(message: Message): string[] {
+  if (message.role !== "assistant") {
+    throw new Error("Expected assistant message");
+  }
+
+  return message.toolCalls?.map((tc) => tc.id) ?? [];
+}
+
+function getToolResultMessage(
+  message: Message | undefined,
+): Extract<Message, { role: "tool" }> {
+  if (!message || message.role !== "tool") {
+    throw new Error("Expected tool message");
+  }
+
+  return message;
+}
 
 describe("CopilotKitCore.runAgent - Parallel Tool Order", () => {
   let copilotKitCore: CopilotKitCore;
@@ -54,24 +73,21 @@ describe("CopilotKitCore.runAgent - Parallel Tool Order", () => {
 
     // The message structure should be: [assistant, toolResultA, toolResultB, ...]
     // Find the assistant message
-    const assistantIndex = agent.messages.findIndex(
-      (m) => m.id === message.id,
-    );
+    const assistantIndex = agent.messages.findIndex((m) => m.id === message.id);
     expect(assistantIndex).toBeGreaterThanOrEqual(0);
 
     // The next two messages should be tool results in order
-    const firstToolResult = agent.messages[assistantIndex + 1];
-    const secondToolResult = agent.messages[assistantIndex + 2];
-
-    expect(firstToolResult).toBeDefined();
-    expect(secondToolResult).toBeDefined();
-    expect(firstToolResult?.role).toBe("tool");
-    expect(secondToolResult?.role).toBe("tool");
+    const firstToolResult = getToolResultMessage(
+      agent.messages[assistantIndex + 1],
+    );
+    const secondToolResult = getToolResultMessage(
+      agent.messages[assistantIndex + 2],
+    );
 
     // Verify the order: first result corresponds to toolA, second to toolB
-    const toolCallIds = message.toolCalls?.map((tc) => tc.id) || [];
-    expect(firstToolResult?.toolCallId).toBe(toolCallIds[0]);
-    expect(secondToolResult?.toolCallId).toBe(toolCallIds[1]);
+    const toolCallIds = getToolCallIds(message);
+    expect(firstToolResult.toolCallId).toBe(toolCallIds[0]);
+    expect(secondToolResult.toolCallId).toBe(toolCallIds[1]);
   });
 
   it("should preserve tool result ordering with one tool having followUp: true", async () => {
@@ -123,22 +139,21 @@ describe("CopilotKitCore.runAgent - Parallel Tool Order", () => {
     expect(agent.runAgentCalls.length).toBeGreaterThan(1);
 
     // Find the assistant message from the first call
-    const assistantIndex = agent.messages.findIndex(
-      (m) => m.id === message.id,
-    );
+    const assistantIndex = agent.messages.findIndex((m) => m.id === message.id);
     expect(assistantIndex).toBeGreaterThanOrEqual(0);
 
     // The next two messages should be tool results in order
-    const firstToolResult = agent.messages[assistantIndex + 1];
-    const secondToolResult = agent.messages[assistantIndex + 2];
-
-    expect(firstToolResult?.role).toBe("tool");
-    expect(secondToolResult?.role).toBe("tool");
+    const firstToolResult = getToolResultMessage(
+      agent.messages[assistantIndex + 1],
+    );
+    const secondToolResult = getToolResultMessage(
+      agent.messages[assistantIndex + 2],
+    );
 
     // Verify the order: first result corresponds to toolA, second to toolB
-    const toolCallIds = message.toolCalls?.map((tc) => tc.id) || [];
-    expect(firstToolResult?.toolCallId).toBe(toolCallIds[0]);
-    expect(secondToolResult?.toolCallId).toBe(toolCallIds[1]);
+    const toolCallIds = getToolCallIds(message);
+    expect(firstToolResult.toolCallId).toBe(toolCallIds[0]);
+    expect(secondToolResult.toolCallId).toBe(toolCallIds[1]);
   });
 
   it("should preserve tool result ordering with three parallel tool calls", async () => {
@@ -183,25 +198,19 @@ describe("CopilotKitCore.runAgent - Parallel Tool Order", () => {
     });
 
     // Find the assistant message
-    const assistantIndex = agent.messages.findIndex(
-      (m) => m.id === message.id,
-    );
+    const assistantIndex = agent.messages.findIndex((m) => m.id === message.id);
 
     // The next three messages should be tool results in order
     const toolResults = [
-      agent.messages[assistantIndex + 1],
-      agent.messages[assistantIndex + 2],
-      agent.messages[assistantIndex + 3],
+      getToolResultMessage(agent.messages[assistantIndex + 1]),
+      getToolResultMessage(agent.messages[assistantIndex + 2]),
+      getToolResultMessage(agent.messages[assistantIndex + 3]),
     ];
 
-    toolResults.forEach((result) => {
-      expect(result?.role).toBe("tool");
-    });
-
     // Verify the order
-    const toolCallIds = message.toolCalls?.map((tc) => tc.id) || [];
+    const toolCallIds = getToolCallIds(message);
     toolResults.forEach((result, index) => {
-      expect(result?.toolCallId).toBe(toolCallIds[index]);
+      expect(result.toolCallId).toBe(toolCallIds[index]);
     });
   });
 });

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -719,7 +719,7 @@ export class RunHandler {
       let insertAt = messageIndex + 1;
       while (
         insertAt < agent.messages.length &&
-        agent.messages[insertAt].role === "tool"
+        agent.messages[insertAt]?.role === "tool"
       ) {
         insertAt++;
       }
@@ -868,7 +868,7 @@ export class RunHandler {
       let insertAt = messageIndex + 1;
       while (
         insertAt < agent.messages.length &&
-        agent.messages[insertAt].role === "tool"
+        agent.messages[insertAt]?.role === "tool"
       ) {
         insertAt++;
       }

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -712,13 +712,24 @@ export class RunHandler {
         // do not request a follow-up to avoid mutating the wrong thread.
         return false;
       }
+      // Find the correct insertion point: after the parent assistant message
+      // and any tool-result messages already inserted for earlier tool calls
+      // in the same batch. This preserves tool-result ordering relative to
+      // the toolCalls array, which some providers (OpenAI) require.
+      let insertAt = messageIndex + 1;
+      while (
+        insertAt < agent.messages.length &&
+        agent.messages[insertAt].role === "tool"
+      ) {
+        insertAt++;
+      }
       const toolMessage = {
         id: randomUUID(),
         role: "tool" as const,
         toolCallId: toolCall.id,
         content: handlerResult.result,
       };
-      agent.messages.splice(messageIndex + 1, 0, toolMessage);
+      agent.messages.splice(insertAt, 0, toolMessage);
 
       if (!handlerResult.error && tool?.followUp !== false) {
         return true; // Needs follow-up
@@ -850,13 +861,24 @@ export class RunHandler {
         // do not request a follow-up to avoid mutating the wrong thread.
         return false;
       }
+      // Find the correct insertion point: after the parent assistant message
+      // and any tool-result messages already inserted for earlier tool calls
+      // in the same batch. This preserves tool-result ordering relative to
+      // the toolCalls array, which some providers (OpenAI) require.
+      let insertAt = messageIndex + 1;
+      while (
+        insertAt < agent.messages.length &&
+        agent.messages[insertAt].role === "tool"
+      ) {
+        insertAt++;
+      }
       const toolMessage = {
         id: randomUUID(),
         role: "tool" as const,
         toolCallId: toolCall.id,
         content: toolCallResult,
       };
-      agent.messages.splice(messageIndex + 1, 0, toolMessage);
+      agent.messages.splice(insertAt, 0, toolMessage);
 
       if (!errorMessage && wildcardTool?.followUp !== false) {
         return true; // Needs follow-up


### PR DESCRIPTION
## Summary
When an assistant message contains multiple parallel tool calls targeting frontend tools (`useFrontendTool`), the tool result messages are spliced into `agent.messages` in reverse order. This violates the ordering contract that some LLM providers (OpenAI via ADK + LiteLLM) enforce: tool results must appear in the same order as their corresponding `tool_call_id`s. The mismatch causes the provider to silently discard unmatched results during the follow-up run, making it appear as though only the first frontend tool executed.

## Root cause
`executeSpecificTool` and `executeWildcardTool` both used the fixed insertion point `messageIndex + 1`, where `messageIndex` is the assistant message's position. Because the assistant message's index doesn't shift when a tool result is inserted after it, each successive splice pushed previously inserted results to the right, reversing the final order.

## Changes
- `packages/core/src/core/run-handler.ts`: In both `executeSpecificTool` and `executeWildcardTool`, advance the insertion index past any tool-result messages already present after the parent assistant message before splicing.
- `packages/core/src/__tests__/core-parallel-tool-order.test.ts`: New regression coverage for parallel tool-call ordering, including the follow-up path, with type-safe assistant and tool-message assertions on current `main`.
- `.changeset/fix-parallel-tool-order.md`: Patch changeset for `@copilotkit/core`.

## What is NOT changed
- Sequential execution of tool handlers is preserved; only the splice insertion position changes.
- `runTool()` (programmatic API) is unaffected; it creates a single tool call per invocation.
- The `newMessages.findIndex` guard that skips already-answered tool calls is unchanged.
- Follow-up recursion logic is unchanged.

## Related PRs and Issues
Closes #2809.

## Test plan
- [x] `npx nx run @copilotkit/core:build`
- [x] `pnpm -C packages/core exec vitest run src/__tests__/core-parallel-tool-order.test.ts` — 3/3 pass
- [x] `pnpm -C packages/core exec vitest run` — 586/586 pass
- [x] `pnpm -C packages/core exec tsc --noEmit`
- [ ] CI green
