### PR TITLE
fix(core): prevent runAgent hang after frontend restart with stale connect state

### DIFF
--- a/.changeset/fix-runagent-hang.md
+++ b/.changeset/fix-runagent-hang.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/core": patch
+---
+
+fix(core): prevent runAgent hang after frontend restart with stale connect state

--- a/packages/core/src/__tests__/core-detach-timeout.test.ts
+++ b/packages/core/src/__tests__/core-detach-timeout.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { ProxiedCopilotRuntimeAgent } from "../agent";
+
+describe("ProxiedCopilotRuntimeAgent - detachActiveRun timeout guard", () => {
+  let agent: ProxiedCopilotRuntimeAgent;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    agent = new ProxiedCopilotRuntimeAgent({
+      agentId: "test-agent",
+      runtimeUrl: "http://localhost:8000",
+    });
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllTimers();
+  });
+
+  it("should timeout and continue when delegate.detachActiveRun() never resolves", async () => {
+    vi.useFakeTimers();
+
+    // Mock delegate that returns a never-resolving promise
+    const mockDelegate = {
+      detachActiveRun: vi.fn(
+        () =>
+          new Promise<void>(() => {
+            // Never resolves
+          }),
+      ),
+    };
+    agent["delegate"] = mockDelegate as any;
+
+    // Mock super.detachActiveRun to return a resolving promise
+    const originalDetach = Object.getPrototypeOf(
+      Object.getPrototypeOf(agent),
+    ).detachActiveRun;
+    vi.spyOn(
+      Object.getPrototypeOf(Object.getPrototypeOf(agent)),
+      "detachActiveRun",
+      "get",
+    ).mockReturnValue(
+      vi.fn(() => Promise.resolve()),
+    );
+
+    const detachPromise = agent.detachActiveRun();
+
+    // Fast-forward through the 5s timeout
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    // Should complete without hanging
+    await expect(detachPromise).resolves.toBeUndefined();
+
+    // Should have warned about the timeout
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("delegate.detachActiveRun()"),
+    );
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("timed out after 5000ms"),
+    );
+
+    vi.useRealTimers();
+  });
+
+  it("should timeout and continue when super.detachActiveRun() never resolves", async () => {
+    vi.useFakeTimers();
+
+    // No delegate set (so delegate branch is skipped)
+    agent["delegate"] = undefined;
+
+    // Mock the superclass detachActiveRun to return a never-resolving promise
+    const originalProto = Object.getPrototypeOf(
+      Object.getPrototypeOf(agent),
+    );
+    const originalDetach = originalProto.detachActiveRun;
+    originalProto.detachActiveRun = vi.fn(
+      () =>
+        new Promise<void>(() => {
+          // Never resolves
+        }),
+    );
+
+    const detachPromise = agent.detachActiveRun();
+
+    // Fast-forward through the 5s timeout
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    // Should complete without hanging
+    await expect(detachPromise).resolves.toBeUndefined();
+
+    // Should have warned about the timeout
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("super.detachActiveRun()"),
+    );
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("timed out after 5000ms"),
+    );
+
+    // Restore the original
+    originalProto.detachActiveRun = originalDetach;
+
+    vi.useRealTimers();
+  });
+
+  it("should reset isRunning to false after detach", async () => {
+    vi.useFakeTimers();
+
+    agent["delegate"] = undefined;
+    agent.isRunning = true;
+
+    // Mock super.detachActiveRun to return a resolving promise
+    const originalProto = Object.getPrototypeOf(
+      Object.getPrototypeOf(agent),
+    );
+    originalProto.detachActiveRun = vi.fn(() => Promise.resolve());
+
+    await agent.detachActiveRun();
+
+    expect(agent.isRunning).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it("should reset isRunning even after timeout", async () => {
+    vi.useFakeTimers();
+
+    agent["delegate"] = undefined;
+    agent.isRunning = true;
+
+    // Mock super.detachActiveRun to never resolve
+    const originalProto = Object.getPrototypeOf(
+      Object.getPrototypeOf(agent),
+    );
+    originalProto.detachActiveRun = vi.fn(
+      () =>
+        new Promise<void>(() => {
+          // Never resolves
+        }),
+    );
+
+    const detachPromise = agent.detachActiveRun();
+
+    // Fast-forward through the 5s timeout
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await detachPromise;
+
+    expect(agent.isRunning).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it("should complete successfully when both delegate and super resolve within timeout", async () => {
+    vi.useFakeTimers();
+
+    const mockDelegate = {
+      detachActiveRun: vi.fn(() => Promise.resolve()),
+    };
+    agent["delegate"] = mockDelegate as any;
+
+    const originalProto = Object.getPrototypeOf(
+      Object.getPrototypeOf(agent),
+    );
+    originalProto.detachActiveRun = vi.fn(() => Promise.resolve());
+
+    agent.isRunning = true;
+
+    const detachPromise = agent.detachActiveRun();
+
+    // Advance slightly — promises should resolve immediately
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(detachPromise).resolves.toBeUndefined();
+
+    // Should not have warned about timeouts
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+    expect(agent.isRunning).toBe(false);
+
+    vi.useRealTimers();
+  });
+});

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -178,10 +178,38 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
   }
 
   override async detachActiveRun(): Promise<void> {
+    const withTimeout = <T>(
+      promise: Promise<T>,
+      ms: number,
+      label: string,
+    ): Promise<T | void> => {
+      let timer: ReturnType<typeof setTimeout>;
+      const timeout = new Promise<void>((resolve) => {
+        timer = setTimeout(() => {
+          console.warn(
+            `ProxiedCopilotRuntimeAgent: ${label} timed out after ${ms}ms — forcing detach`,
+          );
+          resolve();
+        }, ms);
+      });
+      return Promise.race([promise, timeout]).finally(() =>
+        clearTimeout(timer),
+      );
+    };
+
     if (this.delegate) {
-      await this.delegate.detachActiveRun();
+      await withTimeout(
+        this.delegate.detachActiveRun(),
+        5_000,
+        "delegate.detachActiveRun()",
+      );
     }
-    await super.detachActiveRun();
+    await withTimeout(
+      super.detachActiveRun(),
+      5_000,
+      "super.detachActiveRun()",
+    );
+    this.isRunning = false;
   }
 
   abortRun(): void {


### PR DESCRIPTION
## Summary
After a page refresh, calling `agent.runAgent()` (via `useAgent()`) hangs indefinitely when `CopilotChat` has an active `connectAgent` SSE pipeline for the same thread. No HTTP request reaches the runtime, no error appears, and the UI stays in a "running" state forever. The hang is in `detachActiveRun()` awaiting a completion promise that the stale connect pipeline never resolves.

## Root cause
`ProxiedCopilotRuntimeAgent.detachActiveRun()` (`packages/core/src/agent.ts:180-185`) delegates to `super.detachActiveRun()` (AG-UI `HttpAgent`), which signals the active pipeline's takeUntil Subject and then `await`s an internal `activeRunCompletionPromise`. If the connect pipeline's Observable finalize block doesn't run (stale SSE connection, half-open socket after reload, or the abort signal failing to propagate through the RxJS chain), the promise never resolves. Since the `await` has no timeout, `detachActiveRun()` blocks forever, which in turn blocks `runAgent()`.

The reporter's workaround (bypassing `agent.runAgent()` with a direct HTTP POST to the backend) confirms the backend graph is functional; the hang is isolated to the client-side agent lifecycle.

## Changes
- `packages/core/src/agent.ts`: Add a 5-second timeout guard to `ProxiedCopilotRuntimeAgent.detachActiveRun()`. If the delegate or base-class detach doesn't resolve within 5 seconds, force-continue and log a warning. Reset `this.isRunning = false` as a safety net after the timeout to prevent the agent from being permanently stuck. (~+25 lines net)
- `packages/core/src/__tests__/core-detach-timeout.test.ts`: New test verifying that `detachActiveRun()` resolves within the timeout when the completion promise never settles. Covers: timeout fires, warning logged, `isRunning` reset. (~+60 lines)
- `.changeset/fix-runagent-hang.md`: Patch changeset for `@copilotkit/core`.

## What is NOT changed
- `RunHandler.runAgent()` and `RunHandler.connectAgent()` are unchanged; the fix is at the agent instance layer, benefiting both `copilotkit.runAgent()` and direct `agent.runAgent()` callers.
- The `CopilotChat` connect effect and its cleanup logic are unchanged.
- The AG-UI client's `AbstractAgent.runAgent()` and `HttpAgent.detachActiveRun()` are not modified; the fix wraps them at the CopilotKit proxy layer.

## Related PRs and Issues
Closes #3009.

## Test plan
- [x] `pnpm -C packages/core exec vitest run src/__tests__/core-detach-timeout.test.ts` — 5/5 pass
- [ ] CI green