### PR TITLE
feat(react-core): Open Generative UI document assembler, design system, and import maps

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -12,7 +12,6 @@
     "nextjs",
     "nodejs",
     "react",
-    "tanstack-intent",
     "textarea"
   ],
   "homepage": "https://github.com/CopilotKit/CopilotKit",

--- a/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
+++ b/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
@@ -110,6 +110,29 @@ function shouldFlushImmediately(
 }
 
 /**
+ * Builds the preview iframe's `<head>` innerHTML. Shared by the sandbox-creation
+ * resolve (Effect 0) and the content-update effect (Effect 0b) so both assemble
+ * the cascade identically. The overflow guard must be part of the assigned head
+ * content (not a separate append) so it survives the `head.innerHTML` assignment.
+ * Order: overflow guard → kit → extracted preview styles → agent css (css last,
+ * matching the final document's cascade).
+ */
+function buildPreviewHeadHtml(
+  designSystemCss: string | false | undefined,
+  previewStyles: string,
+  css: string | undefined,
+): string {
+  const headParts: string[] = [
+    "<style data-ck-preview-overflow>html, body { overflow: hidden !important; }</style>",
+  ];
+  if (designSystemCss)
+    headParts.push(`<style data-ck-design-system>${designSystemCss}</style>`);
+  if (previewStyles) headParts.push(previewStyles);
+  if (css) headParts.push(`<style>${css}</style>`);
+  return headParts.join("");
+}
+
+/**
  * Outer wrapper — absorbs every parent re-render but only forwards
  * throttled content snapshots to the memoized inner component.
  */
@@ -214,6 +237,20 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
     const hasPreview = cssReady && !!previewBody?.trim();
     const hasVisibleSandbox = !!fullHtml || hasPreview;
 
+    // Latest preview payload, tracked synchronously during render. Effect 0's
+    // sandbox.promise.then resolves AFTER creation, by which point newer chunks
+    // may have streamed in (Effect 0b can't apply them while previewReadyRef is
+    // still false, so it early-returns). Reading from this ref in the resolve
+    // callback applies the CURRENT frame instead of the stale creation-time
+    // snapshot captured in the closure.
+    const latestPreviewRef = useRef<{ headHtml: string; body?: string }>({
+      headHtml: "",
+    });
+    latestPreviewRef.current = {
+      headHtml: buildPreviewHeadHtml(designSystemCss, previewStyles, css),
+      body: previewBody,
+    };
+
     const containerRef = useRef<HTMLDivElement>(null);
     const sandboxRef = useRef<{
       run: (code: string | Function) => Promise<unknown>;
@@ -268,27 +305,18 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
             if (cancelled) return;
             previewReadyRef.current = true;
 
-            // Inject CSS from the dedicated parameter + any inline styles from HTML.
-            // The overflow guard must be part of the assigned head content (not a
-            // separate append) so it survives the head.innerHTML assignment.
-            // Order: overflow guard → kit → extracted preview styles → agent css
-            // (css last, matching the final document's cascade)
-            const headParts: string[] = [
-              "<style data-ck-preview-overflow>html, body { overflow: hidden !important; }</style>",
-            ];
-            if (designSystemCss)
-              headParts.push(
-                `<style data-ck-design-system>${designSystemCss}</style>`,
-              );
-            if (previewStyles) headParts.push(previewStyles);
-            if (css) headParts.push(`<style>${css}</style>`);
+            // Apply the LATEST preview frame, not the snapshot captured when this
+            // effect ran: chunks may have streamed in while the promise was
+            // pending, and Effect 0b early-returns until previewReadyRef flips
+            // true (just above), so it cannot have applied them yet. Reading the
+            // ref here closes that window — the next content change still flows
+            // through Effect 0b normally.
+            const { headHtml, body } = latestPreviewRef.current;
             sandbox.run(
-              `document.head.innerHTML = ${JSON.stringify(headParts.join(""))}`,
+              `document.head.innerHTML = ${JSON.stringify(headHtml)}`,
             );
-            if (previewBody) {
-              sandbox.run(
-                `document.body.innerHTML = ${JSON.stringify(previewBody)}`,
-              );
+            if (body) {
+              sandbox.run(`document.body.innerHTML = ${JSON.stringify(body)}`);
             }
           });
         })
@@ -307,21 +335,13 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
     // Effect 0b — Preview content updates (body + styles)
     useEffect(() => {
       if (!previewSandboxRef.current || !previewReadyRef.current) return;
-      // The overflow guard must be part of the assigned head content (not a
-      // separate append) so it survives the head.innerHTML assignment.
-      // Order: overflow guard → kit → extracted preview styles → agent css
-      // (css last, matching the final document's cascade)
-      const headParts: string[] = [
-        "<style data-ck-preview-overflow>html, body { overflow: hidden !important; }</style>",
-      ];
-      if (designSystemCss)
-        headParts.push(
-          `<style data-ck-design-system>${designSystemCss}</style>`,
-        );
-      if (previewStyles) headParts.push(previewStyles);
-      if (css) headParts.push(`<style>${css}</style>`);
+      const headHtml = buildPreviewHeadHtml(
+        designSystemCss,
+        previewStyles,
+        css,
+      );
       previewSandboxRef.current.run(
-        `document.head.innerHTML = ${JSON.stringify(headParts.join(""))}`,
+        `document.head.innerHTML = ${JSON.stringify(headHtml)}`,
       );
       if (!previewBody) return;
       previewSandboxRef.current.run(

--- a/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
+++ b/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
@@ -27,10 +27,59 @@ export const OpenGenerativeUIContentSchema = z.object({
   html: z.array(z.string()).optional(),
   htmlComplete: z.boolean().optional(),
   jsFunctions: z.string().optional(),
+  // `jsFunctionsComplete` / `jsExpressionsComplete` are streamed by the Open
+  // Generative UI middleware (open-generative-ui-middleware.ts emits them when
+  // the jsFunctions string / jsExpressions array finish parsing). They are not
+  // needed for execution — jsFunctions/jsExpressions run incrementally as they
+  // arrive — but they ARE the per-segment terminal markers the completion
+  // fallback reads (see isGenerationComplete) to recognize a fully-streamed
+  // payload whose `generating: false` delta never arrived.
   jsFunctionsComplete: z.boolean().optional(),
   jsExpressions: z.array(z.string()).optional(),
   jsExpressionsComplete: z.boolean().optional(),
 });
+
+/**
+ * Whether generation has finished. The Open Generative UI middleware emits the
+ * `generating: false` delta ONLY from its TOOL_CALL_END handler
+ * (open-generative-ui-middleware.ts). On a terminal path where the upstream
+ * agent never emits TOOL_CALL_END for the genui tool call — an abort/stop, an
+ * abrupt stream end, or a transport error after the args fully streamed — the
+ * runner's `finalizeRunEvents` synthesizes a TOOL_CALL_END at the runner level,
+ * AFTER the middleware already processed the stream, so it never flows back
+ * through the middleware and `generating: false` is never emitted. The
+ * fully-streamed payload then arrives with `generating` absent.
+ *
+ * Without a fallback, a renderer keying purely on `generating === false` leaves
+ * such a finished, interactive artifact permanently covered by the
+ * pointer-blocking overlay and never measured. The fallback treats a payload as
+ * terminal when every streamed segment that is PRESENT carries its `*Complete`
+ * flag (`htmlComplete`, plus `cssComplete`/`jsFunctionsComplete`/
+ * `jsExpressionsComplete` for whichever of css/jsFunctions/jsExpressions are
+ * present). Those flags are emitted by the producer as each segment finishes
+ * parsing, so this fires only once the WHOLE payload is terminal — never
+ * mid-stream (e.g. html done but jsExpressions still arriving leaves
+ * `jsExpressionsComplete` absent, so this stays false and the overlay stays up,
+ * matching the pre-fallback behavior on every normal path). `htmlComplete` is
+ * required because an interactive artifact only exists once html is complete.
+ * Mirrors the Vue renderer's identical helper.
+ */
+export function isGenerationComplete(
+  content: OpenGenerativeUIContent,
+): boolean {
+  if (content.generating === false) return true;
+  if (!content.htmlComplete) return false;
+  if (content.css !== undefined && !content.cssComplete) return false;
+  if (content.jsFunctions !== undefined && !content.jsFunctionsComplete)
+    return false;
+  if (
+    content.jsExpressions !== undefined &&
+    content.jsExpressions.length > 0 &&
+    !content.jsExpressionsComplete
+  )
+    return false;
+  return true;
+}
 
 export type OpenGenerativeUIContent = z.infer<
   typeof OpenGenerativeUIContentSchema
@@ -417,7 +466,7 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
       // here too would queue it twice). Push the measurement last (functions →
       // expressions → measure); the still-attached __ck_resize listener resolves
       // sandboxRef lazily, so it matches this new sandbox.
-      if (content.generating === false && finalSandboxBuiltRef.current) {
+      if (isGenerationComplete(content) && finalSandboxBuiltRef.current) {
         pendingQueueRef.current.push(MEASURE_ONCE_SCRIPT);
       }
       finalSandboxBuiltRef.current = true;
@@ -532,7 +581,7 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
     }, [content.jsExpressions?.length]);
 
     // Effect 4 — Height measurement listener (attached once generation completes)
-    const generationDone = content.generating === false;
+    const generationDone = isGenerationComplete(content);
     useEffect(() => {
       if (!generationDone) return;
 
@@ -582,7 +631,7 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
 
     const height = autoHeight ?? initialHeight;
 
-    const isGenerating = content.generating !== false;
+    const isGenerating = !isGenerationComplete(content);
 
     return (
       <div

--- a/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
+++ b/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
@@ -320,6 +320,22 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
       sandboxReadyRef.current = false;
       pendingQueueRef.current = [];
 
+      // Re-queue current JS so a rebuilt sandbox is never left without its behavior
+      // (Effects 2/3 won't re-fire when the rebuild trigger isn't a JS change).
+      // Setting the guards here makes Effects 2/3 skip on first mount (they run
+      // after this effect in the same commit), avoiding double-execution.
+      // content.jsFunctions/jsExpressions are read as a rebuild-time snapshot and
+      // are intentionally not in the dep array; the memoized inner component
+      // re-renders on content change so this closure is always current.
+      if (content.jsFunctions) {
+        pendingQueueRef.current.push(content.jsFunctions);
+        jsFunctionsInjectedRef.current = true;
+      }
+      if (content.jsExpressions?.length) {
+        pendingQueueRef.current.push(...content.jsExpressions);
+        executedIndexRef.current = content.jsExpressions.length;
+      }
+
       // Dynamic import to avoid SSR issues (websandbox references `self` at module level)
       const htmlContent = assembleDocument(fullHtml, {
         css,
@@ -388,8 +404,10 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
         sandboxReadyRef.current = false;
         setAutoHeight(null);
       };
-      // designSystemCss and importMap are stable context values (set once at provider mount)
-    }, [fullHtml, css, localApi, designSystemCss, importMap]);
+      // designSystemCss and importMap are stable context values (set once at provider mount).
+      // content.jsFunctions/jsExpressions are read as a rebuild-time snapshot only (see re-queue
+      // block above); including them would re-run the whole sandbox lifecycle on every JS change.
+    }, [fullHtml, css, localApi, designSystemCss, importMap]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // Effect 2 — jsFunctions injection (depends on content.jsFunctions)
     useEffect(() => {

--- a/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
+++ b/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
@@ -240,27 +240,22 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
             if (cancelled) return;
             previewReadyRef.current = true;
 
-            // Prevent scrollbars inside preview iframe
-            sandbox.run(`
-            var s = document.createElement('style');
-            s.textContent = 'html, body { overflow: hidden !important; }';
-            document.head.appendChild(s);
-          `);
-
-            // Inject CSS from the dedicated parameter + any inline styles from HTML
-            // Order: kit → agent css → extracted preview styles
-            const headParts: string[] = [];
+            // Inject CSS from the dedicated parameter + any inline styles from HTML.
+            // The overflow guard must be part of the assigned head content (not a
+            // separate append) so it survives the head.innerHTML assignment.
+            // Order: overflow guard → kit → agent css → extracted preview styles
+            const headParts: string[] = [
+              "<style data-ck-preview-overflow>html, body { overflow: hidden !important; }</style>",
+            ];
             if (designSystemCss)
               headParts.push(
                 `<style data-ck-design-system>${designSystemCss}</style>`,
               );
             if (css) headParts.push(`<style>${css}</style>`);
             if (previewStyles) headParts.push(previewStyles);
-            if (headParts.length) {
-              sandbox.run(
-                `document.head.innerHTML = ${JSON.stringify(headParts.join(""))}`,
-              );
-            }
+            sandbox.run(
+              `document.head.innerHTML = ${JSON.stringify(headParts.join(""))}`,
+            );
             if (previewBody) {
               sandbox.run(
                 `document.body.innerHTML = ${JSON.stringify(previewBody)}`,
@@ -283,19 +278,21 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
     // Effect 0b — Preview content updates (body + styles)
     useEffect(() => {
       if (!previewSandboxRef.current || !previewReadyRef.current) return;
-      // Order: kit → agent css → extracted preview styles
-      const headParts: string[] = [];
+      // The overflow guard must be part of the assigned head content (not a
+      // separate append) so it survives the head.innerHTML assignment.
+      // Order: overflow guard → kit → agent css → extracted preview styles
+      const headParts: string[] = [
+        "<style data-ck-preview-overflow>html, body { overflow: hidden !important; }</style>",
+      ];
       if (designSystemCss)
         headParts.push(
           `<style data-ck-design-system>${designSystemCss}</style>`,
         );
       if (css) headParts.push(`<style>${css}</style>`);
       if (previewStyles) headParts.push(previewStyles);
-      if (headParts.length) {
-        previewSandboxRef.current.run(
-          `document.head.innerHTML = ${JSON.stringify(headParts.join(""))}`,
-        );
-      }
+      previewSandboxRef.current.run(
+        `document.head.innerHTML = ${JSON.stringify(headParts.join(""))}`,
+      );
       if (!previewBody) return;
       previewSandboxRef.current.run(
         `document.body.innerHTML = ${JSON.stringify(previewBody)}`,

--- a/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
+++ b/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
@@ -10,6 +10,8 @@ import React, {
 import { z } from "zod";
 import { ToolCallStatus } from "@copilotkit/core";
 import { useSandboxFunctions } from "../providers/SandboxFunctionsContext";
+import { useOpenGenerativeUIOptions } from "../providers/OpenGenerativeUIOptionsContext";
+import { assembleDocument } from "../lib/assembleDocument";
 import {
   processPartialHtml,
   extractCompleteStyles,
@@ -151,28 +153,12 @@ interface InnerProps {
   content: OpenGenerativeUIContent;
 }
 
-function ensureHead(html: string): string {
-  if (/<head[\s>]/i.test(html)) return html;
-  return `<head></head>${html}`;
-}
-
-function injectCssIntoHtml(html: string, css: string): string {
-  const headCloseIdx = html.indexOf("</head>");
-  if (headCloseIdx !== -1) {
-    return (
-      html.slice(0, headCloseIdx) +
-      `<style>${css}</style>` +
-      html.slice(headCloseIdx)
-    );
-  }
-  return `<head><style>${css}</style></head>${html}`;
-}
-
 const OpenGenerativeUIActivityRendererInner = React.memo(
   function OpenGenerativeUIActivityRendererInner({ content }: InnerProps) {
     const initialHeight = content.initialHeight ?? 200;
     const [autoHeight, setAutoHeight] = useState<number | null>(null);
     const sandboxFunctions = useSandboxFunctions();
+    const { designSystemCss, importMap } = useOpenGenerativeUIOptions();
 
     const localApi = useMemo(() => {
       const api: Record<string, Function> = {};
@@ -262,7 +248,12 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
           `);
 
             // Inject CSS from the dedicated parameter + any inline styles from HTML
+            // Order: kit → agent css → extracted preview styles
             const headParts: string[] = [];
+            if (designSystemCss)
+              headParts.push(
+                `<style data-ck-design-system>${designSystemCss}</style>`,
+              );
             if (css) headParts.push(`<style>${css}</style>`);
             if (previewStyles) headParts.push(previewStyles);
             if (headParts.length) {
@@ -292,7 +283,12 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
     // Effect 0b — Preview content updates (body + styles)
     useEffect(() => {
       if (!previewSandboxRef.current || !previewReadyRef.current) return;
+      // Order: kit → agent css → extracted preview styles
       const headParts: string[] = [];
+      if (designSystemCss)
+        headParts.push(
+          `<style data-ck-design-system>${designSystemCss}</style>`,
+        );
       if (css) headParts.push(`<style>${css}</style>`);
       if (previewStyles) headParts.push(previewStyles);
       if (headParts.length) {
@@ -327,7 +323,11 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
       pendingQueueRef.current = [];
 
       // Dynamic import to avoid SSR issues (websandbox references `self` at module level)
-      const htmlContent = css ? injectCssIntoHtml(fullHtml, css) : fullHtml;
+      const htmlContent = assembleDocument(fullHtml, {
+        css,
+        designSystemCss,
+        importMap,
+      });
       import("@jetbrains/websandbox")
         .then((mod: any) => {
           if (cancelled) return;
@@ -338,7 +338,7 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
           const Websandbox = mod.default?.default ?? mod.default;
           const sandbox = Websandbox.create(localApi, {
             frameContainer: container,
-            frameContent: ensureHead(htmlContent),
+            frameContent: htmlContent,
             allowAdditionalAttributes: "",
           });
           sandboxRef.current = sandbox;
@@ -390,7 +390,8 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
         sandboxReadyRef.current = false;
         setAutoHeight(null);
       };
-    }, [fullHtml, css, localApi]);
+      // designSystemCss and importMap are stable context values (set once at provider mount)
+    }, [fullHtml, css, localApi, designSystemCss, importMap]);
 
     // Effect 2 — jsFunctions injection (depends on content.jsFunctions)
     useEffect(() => {

--- a/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
+++ b/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
@@ -271,7 +271,8 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
             // Inject CSS from the dedicated parameter + any inline styles from HTML.
             // The overflow guard must be part of the assigned head content (not a
             // separate append) so it survives the head.innerHTML assignment.
-            // Order: overflow guard → kit → agent css → extracted preview styles
+            // Order: overflow guard → kit → extracted preview styles → agent css
+            // (css last, matching the final document's cascade)
             const headParts: string[] = [
               "<style data-ck-preview-overflow>html, body { overflow: hidden !important; }</style>",
             ];
@@ -279,8 +280,8 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
               headParts.push(
                 `<style data-ck-design-system>${designSystemCss}</style>`,
               );
-            if (css) headParts.push(`<style>${css}</style>`);
             if (previewStyles) headParts.push(previewStyles);
+            if (css) headParts.push(`<style>${css}</style>`);
             sandbox.run(
               `document.head.innerHTML = ${JSON.stringify(headParts.join(""))}`,
             );
@@ -308,7 +309,8 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
       if (!previewSandboxRef.current || !previewReadyRef.current) return;
       // The overflow guard must be part of the assigned head content (not a
       // separate append) so it survives the head.innerHTML assignment.
-      // Order: overflow guard → kit → agent css → extracted preview styles
+      // Order: overflow guard → kit → extracted preview styles → agent css
+      // (css last, matching the final document's cascade)
       const headParts: string[] = [
         "<style data-ck-preview-overflow>html, body { overflow: hidden !important; }</style>",
       ];
@@ -316,8 +318,8 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
         headParts.push(
           `<style data-ck-design-system>${designSystemCss}</style>`,
         );
-      if (css) headParts.push(`<style>${css}</style>`);
       if (previewStyles) headParts.push(previewStyles);
+      if (css) headParts.push(`<style>${css}</style>`);
       previewSandboxRef.current.run(
         `document.head.innerHTML = ${JSON.stringify(headParts.join(""))}`,
       );

--- a/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
+++ b/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
@@ -350,6 +350,27 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
       // designSystemCss is a stable context value (set once at provider mount)
     }, [previewBody, previewStyles, css, designSystemCss]);
 
+    // Effect 0c — Tear down the preview when it empties mid-stream. The streamed
+    // HTML can transiently reduce to an empty body region (e.g. the only complete
+    // markup so far is a <head> element, which processPartialHtml strips), flipping
+    // hasPreview false while still streaming (no fullHtml yet). Effect 0's cleanup
+    // only sets cancelled = true and Effect 1 only runs once fullHtml is truthy, so
+    // without this the orphaned preview iframe stays mounted behind the placeholder
+    // spinner. Mirrors the Vue renderer's watch([hasPreview, fullHtml]) ->
+    // destroyPreview(). Effect 1 owns the teardown on the transition to the final
+    // document, so skip while fullHtml is truthy to avoid a double destroy. Nulling
+    // previewSandboxRef/previewReadyRef lets Effect 0 build a fresh preview when a
+    // later non-empty chunk arrives; latestPreviewRef still feeds that rebuild its
+    // current frame, so the "applies the latest streamed content" path is intact.
+    useEffect(() => {
+      if (fullHtml || hasPreview) return;
+      if (previewSandboxRef.current) {
+        previewSandboxRef.current.destroy();
+        previewSandboxRef.current = null;
+      }
+      previewReadyRef.current = false;
+    }, [hasPreview, fullHtml]);
+
     // Effect 1 — Final sandbox lifecycle (depends on fullHtml)
     useEffect(() => {
       const container = containerRef.current;

--- a/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
+++ b/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 import { ToolCallStatus } from "@copilotkit/core";
 import { useSandboxFunctions } from "../providers/SandboxFunctionsContext";
 import { useOpenGenerativeUIOptions } from "../providers/OpenGenerativeUIOptionsContext";
-import { assembleDocument } from "../lib/assembleDocument";
+import { assembleDocument, escapeStyleClose } from "../lib/assembleDocument";
 import {
   processPartialHtml,
   extractCompleteStyles,
@@ -165,6 +165,17 @@ function shouldFlushImmediately(
  * content (not a separate append) so it survives the `head.innerHTML` assignment.
  * Order: overflow guard → kit → extracted preview styles → agent css (css last,
  * matching the final document's cascade).
+ *
+ * The kit css and the agent css are spliced RAW into `<style>` elements, so both
+ * pass through {@link escapeStyleClose} — IDENTICALLY to assembleDocument's final
+ * sinks — so a `</style` in either cannot break out of the preview style element
+ * and inject live markup (the preview and final must escape the same way so their
+ * cascade/byte parity holds). `previewStyles` is NOT escaped: it is hoisted by
+ * `extractCompleteStyles` from COMPLETE `<style>…</style>` elements in the agent's
+ * own markup, so by construction it cannot contain a live `</style>` — the
+ * extractor's regex stops AT the first `</style>`, so any earlier close already
+ * terminated the element it came from and nothing after it is carried here. The
+ * overflow guard is a fixed literal with no agent input, so it needs no escaping.
  */
 function buildPreviewHeadHtml(
   designSystemCss: string | false | undefined,
@@ -175,9 +186,11 @@ function buildPreviewHeadHtml(
     "<style data-ck-preview-overflow>html, body { overflow: hidden !important; }</style>",
   ];
   if (designSystemCss)
-    headParts.push(`<style data-ck-design-system>${designSystemCss}</style>`);
+    headParts.push(
+      `<style data-ck-design-system>${escapeStyleClose(designSystemCss)}</style>`,
+    );
   if (previewStyles) headParts.push(previewStyles);
-  if (css) headParts.push(`<style>${css}</style>`);
+  if (css) headParts.push(`<style>${escapeStyleClose(css)}</style>`);
   return headParts.join("");
 }
 

--- a/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
+++ b/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
@@ -63,6 +63,29 @@ interface OpenGenerativeUIActivityRendererProps {
 const THROTTLE_MS = 1000;
 
 /**
+ * One-shot height measurement script. Temporarily forces `body` to auto-size,
+ * reads `body.scrollHeight` (plus vertical margins), then posts the result back
+ * to the parent as a `__ck_resize` message. Static — hoisted so both Effect 4
+ * (initial measurement) and Effect 1 (re-measure on rebuild) reference the same
+ * string. Uses body.scrollHeight (not documentElement.scrollHeight) because the
+ * latter is clamped to the iframe viewport and can never shrink below the
+ * current size.
+ */
+const MEASURE_ONCE_SCRIPT = `
+        (function() {
+          var s = document.createElement('style');
+          s.textContent = 'body { height: auto !important; min-height: 0 !important; }';
+          document.head.appendChild(s);
+          var h = document.body.scrollHeight;
+          var cs = getComputedStyle(document.body);
+          h += parseFloat(cs.marginTop) || 0;
+          h += parseFloat(cs.marginBottom) || 0;
+          s.remove();
+          parent.postMessage({ type: "__ck_resize", height: Math.ceil(h) }, "*");
+        })();
+      `;
+
+/**
  * Returns true when the inner component should re-render immediately
  * (no throttle delay).
  */
@@ -207,6 +230,11 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
     const executedIndexRef = useRef(0);
     const pendingQueueRef = useRef<string[]>([]);
     const jsFunctionsInjectedRef = useRef(false);
+    // Tracks whether Effect 1 has already built a final sandbox. Survives the
+    // effect's cleanup (unlike sandboxRef, which the cleanup nulls), so Effect 1
+    // can tell a first build from a rebuild and only re-measure on rebuilds —
+    // the first measurement is owned by Effect 4.
+    const finalSandboxBuiltRef = useRef(false);
 
     // Effect 0 — Preview sandbox creation
     useEffect(() => {
@@ -327,6 +355,9 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
       // content.jsFunctions/jsExpressions are read as a rebuild-time snapshot and
       // are intentionally not in the dep array; the memoized inner component
       // re-renders on content change so this closure is always current.
+      // Replay semantics: a rebuild intentionally REPLAYS jsFunctions/jsExpressions
+      // (and re-measures below) so the artifact stays alive — expressions with host
+      // side effects therefore re-fire on every rebuild.
       if (content.jsFunctions) {
         pendingQueueRef.current.push(content.jsFunctions);
         jsFunctionsInjectedRef.current = true;
@@ -335,6 +366,18 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
         pendingQueueRef.current.push(...content.jsExpressions);
         executedIndexRef.current = content.jsExpressions.length;
       }
+      // Re-measure when REBUILDING an already-completed artifact. Effect 4 (keyed
+      // on generationDone) measured the first sandbox and won't re-fire for a
+      // rebuild, so the new sandbox would stay clamped at initialHeight and clip
+      // taller content. Guard on finalSandboxBuiltRef so this fires only on a
+      // rebuild — on the first build Effect 4 still owns the measurement (pushing
+      // here too would queue it twice). Push the measurement last (functions →
+      // expressions → measure); the still-attached __ck_resize listener resolves
+      // sandboxRef lazily, so it matches this new sandbox.
+      if (content.generating === false && finalSandboxBuiltRef.current) {
+        pendingQueueRef.current.push(MEASURE_ONCE_SCRIPT);
+      }
+      finalSandboxBuiltRef.current = true;
 
       // Dynamic import to avoid SSR issues (websandbox references `self` at module level)
       const htmlContent = assembleDocument(fullHtml, {
@@ -446,8 +489,6 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
     }, [content.jsExpressions?.length]);
 
     // Effect 4 — One-shot height measurement (fires once when generation completes)
-    // Uses body.scrollHeight (not documentElement.scrollHeight) because the latter
-    // is clamped to the iframe viewport and can never shrink below the current size.
     const generationDone = content.generating === false;
     useEffect(() => {
       if (!generationDone) return;
@@ -457,7 +498,11 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
         if (handled) return;
         // Read sandboxRef lazily — on the fast-completion path the sandbox may
         // still be null when this listener is attached, so capturing it in the
-        // closure would drop the message. Resolve the iframe at message time.
+        // closure would drop the message. Resolving the iframe at message time
+        // also lets this listener serve a sandbox rebuilt by Effect 1 after
+        // completion: sandboxRef.current then points at the NEW iframe, and this
+        // listener survives the rebuild (its cleanup only runs on generationDone
+        // change/unmount, which a rebuild does not trigger).
         if (
           e.source === sandboxRef.current?.iframe?.contentWindow &&
           e.data?.type === "__ck_resize"
@@ -469,20 +514,6 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
       };
       window.addEventListener("message", onMessage);
 
-      const measureOnce = `
-        (function() {
-          var s = document.createElement('style');
-          s.textContent = 'body { height: auto !important; min-height: 0 !important; }';
-          document.head.appendChild(s);
-          var h = document.body.scrollHeight;
-          var cs = getComputedStyle(document.body);
-          h += parseFloat(cs.marginTop) || 0;
-          h += parseFloat(cs.marginBottom) || 0;
-          s.remove();
-          parent.postMessage({ type: "__ck_resize", height: Math.ceil(h) }, "*");
-        })();
-      `;
-
       // When generation completes in the same commit that schedules sandbox
       // creation (reconnect/restore + non-streaming completion), sandboxRef is
       // still null here. Queue the measurement so Effect 1's sandbox.promise.then
@@ -490,11 +521,14 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
       // earlier in the same commit and resets pendingQueueRef before this push,
       // so the queued script survives.
       if (sandboxReadyRef.current && sandboxRef.current) {
-        sandboxRef.current.run(measureOnce);
+        sandboxRef.current.run(MEASURE_ONCE_SCRIPT);
       } else {
-        pendingQueueRef.current.push(measureOnce);
+        pendingQueueRef.current.push(MEASURE_ONCE_SCRIPT);
       }
 
+      // NOTE: this effect handles only the FIRST measurement (keyed on
+      // generationDone). A rebuild after completion does not re-fire it, so
+      // Effect 1's re-queue block re-pushes MEASURE_ONCE_SCRIPT itself.
       return () => {
         window.removeEventListener("message", onMessage);
       };

--- a/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
+++ b/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
@@ -300,7 +300,8 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
       previewSandboxRef.current.run(
         `document.body.innerHTML = ${JSON.stringify(previewBody)}`,
       );
-    }, [previewBody, previewStyles, css]);
+      // designSystemCss is a stable context value (set once at provider mount)
+    }, [previewBody, previewStyles, css, designSystemCss]);
 
     // Effect 1 — Final sandbox lifecycle (depends on fullHtml)
     useEffect(() => {
@@ -434,14 +435,16 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
     // is clamped to the iframe viewport and can never shrink below the current size.
     const generationDone = content.generating === false;
     useEffect(() => {
-      const sandbox = sandboxRef.current;
-      if (!generationDone || !sandbox) return;
+      if (!generationDone) return;
 
       let handled = false;
       const onMessage = (e: MessageEvent) => {
         if (handled) return;
+        // Read sandboxRef lazily — on the fast-completion path the sandbox may
+        // still be null when this listener is attached, so capturing it in the
+        // closure would drop the message. Resolve the iframe at message time.
         if (
-          e.source === sandbox.iframe.contentWindow &&
+          e.source === sandboxRef.current?.iframe?.contentWindow &&
           e.data?.type === "__ck_resize"
         ) {
           handled = true;
@@ -465,8 +468,14 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
         })();
       `;
 
-      if (sandboxReadyRef.current) {
-        sandbox.run(measureOnce);
+      // When generation completes in the same commit that schedules sandbox
+      // creation (reconnect/restore + non-streaming completion), sandboxRef is
+      // still null here. Queue the measurement so Effect 1's sandbox.promise.then
+      // flushes it after jsFunctions/jsExpressions (measure last). Effect 1 runs
+      // earlier in the same commit and resets pendingQueueRef before this push,
+      // so the queued script survives.
+      if (sandboxReadyRef.current && sandboxRef.current) {
+        sandboxRef.current.run(measureOnce);
       } else {
         pendingQueueRef.current.push(measureOnce);
       }
@@ -572,7 +581,7 @@ export const OpenGenerativeUIToolRenderer: React.FC<
       setVisibleMessageIndex(messages.length - 1);
     }
 
-    // Auto-cycle every 3s while still in progress
+    // Auto-cycle every 5s while still in progress
     if (props.status === ToolCallStatus.Complete) return;
     const timer = setInterval(() => {
       setVisibleMessageIndex((i) => (i + 1) % messages.length);

--- a/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
+++ b/packages/react-core/src/v2/components/OpenGenerativeUIRenderer.tsx
@@ -488,28 +488,29 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
       }
     }, [content.jsExpressions?.length]);
 
-    // Effect 4 — One-shot height measurement (fires once when generation completes)
+    // Effect 4 — Height measurement listener (attached once generation completes)
     const generationDone = content.generating === false;
     useEffect(() => {
       if (!generationDone) return;
 
-      let handled = false;
+      // The listener stays armed for the lifetime of this effect — it is NOT
+      // one-shot. Cleanup only runs when generationDone changes or the component
+      // unmounts; a post-completion rebuild (Effect 1) triggers neither, so the
+      // same listener must keep serving the rebuilt sandbox. It applies EVERY
+      // accepted __ck_resize rather than latching after the first.
       const onMessage = (e: MessageEvent) => {
-        if (handled) return;
-        // Read sandboxRef lazily — on the fast-completion path the sandbox may
-        // still be null when this listener is attached, so capturing it in the
-        // closure would drop the message. Resolving the iframe at message time
-        // also lets this listener serve a sandbox rebuilt by Effect 1 after
-        // completion: sandboxRef.current then points at the NEW iframe, and this
-        // listener survives the rebuild (its cleanup only runs on generationDone
-        // change/unmount, which a rebuild does not trigger).
+        // Read sandboxRef lazily so the comparison always targets the CURRENT
+        // sandbox: on the fast-completion path the sandbox may still be null when
+        // this listener is attached (capturing it in the closure would drop the
+        // message), and after a rebuild sandboxRef.current points at the NEW
+        // iframe. A stale iframe's message therefore fails this check and is
+        // ignored. The measurement script posts exactly once per execution, so
+        // each accepted message is one-per-build — applying every one cannot loop.
         if (
           e.source === sandboxRef.current?.iframe?.contentWindow &&
           e.data?.type === "__ck_resize"
         ) {
-          handled = true;
           setAutoHeight(e.data.height);
-          window.removeEventListener("message", onMessage);
         }
       };
       window.addEventListener("message", onMessage);
@@ -526,9 +527,11 @@ const OpenGenerativeUIActivityRendererInner = React.memo(
         pendingQueueRef.current.push(MEASURE_ONCE_SCRIPT);
       }
 
-      // NOTE: this effect handles only the FIRST measurement (keyed on
-      // generationDone). A rebuild after completion does not re-fire it, so
-      // Effect 1's re-queue block re-pushes MEASURE_ONCE_SCRIPT itself.
+      // This effect arms the listener and queues the FIRST measurement. A
+      // rebuild after completion does not re-fire this effect (it is keyed on
+      // generationDone), so Effect 1's re-queue block re-pushes
+      // MEASURE_ONCE_SCRIPT for the rebuilt sandbox — and because the listener
+      // above stays armed across the rebuild, that measurement is applied too.
       return () => {
         window.removeEventListener("message", onMessage);
       };

--- a/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
@@ -776,6 +776,109 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       );
       expect(measureCalls.length).toBeGreaterThanOrEqual(1);
     });
+
+    it("re-measures height when the final sandbox is rebuilt after completion", async () => {
+      // A rebuild AFTER completion (here: a sandbox-functions identity change)
+      // destroys the measured sandbox and resets autoHeight. Effect 4 is keyed on
+      // generationDone and will NOT re-fire, so without Effect 1's re-queue the
+      // new sandbox is never measured: it stays clamped at initialHeight and
+      // taller content is clipped. Effect 1 must re-push the measurement.
+      const completedContent = {
+        html: ["<head></head><body><div>Tall content</div></body>"],
+        htmlComplete: true,
+        css: "body { color: blue; }",
+        cssComplete: true,
+        generating: false,
+      } as const;
+
+      const handler1 = vi.fn();
+      const fns1: SandboxFunction[] = [
+        {
+          name: "fn1",
+          description: "first",
+          parameters: z.object({}),
+          handler: handler1,
+        },
+      ];
+
+      const { rerender } = render(
+        <SandboxFunctionsContext.Provider value={fns1}>
+          <OpenGenerativeUIActivityRenderer
+            activityType="open-generative-ui"
+            content={completedContent}
+            message={{}}
+            agent={{}}
+          />
+        </SandboxFunctionsContext.Provider>,
+      );
+      await flushImport();
+
+      // First sandbox ready — flush its queued measurement
+      await act(async () => {
+        mockPromiseResolve();
+        await mockPromise;
+      });
+      await flushImport();
+
+      // The first sandbox ran the one-shot measurement
+      const measureCallsFirst = mockRun.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" && (c[0] as string).includes("__ck_resize"),
+      );
+      expect(measureCallsFirst.length).toBeGreaterThanOrEqual(1);
+
+      // Rebuild WITHOUT changing content — only the sandbox-functions context
+      // value changes (localApi identity), which re-fires Effect 1 but not
+      // Effect 4. The new sandbox must still be measured.
+      mockRun.mockClear();
+      resetMockPromise();
+      const handler2 = vi.fn();
+      const fns2: SandboxFunction[] = [
+        {
+          name: "fn2",
+          description: "second",
+          parameters: z.object({}),
+          handler: handler2,
+        },
+      ];
+      rerender(
+        <SandboxFunctionsContext.Provider value={fns2}>
+          <OpenGenerativeUIActivityRenderer
+            activityType="open-generative-ui"
+            content={completedContent}
+            message={{}}
+            agent={{}}
+          />
+        </SandboxFunctionsContext.Provider>,
+      );
+      await flushImport();
+
+      // Old sandbox destroyed, new one created
+      expect(mockDestroy).toHaveBeenCalledTimes(1);
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+
+      // New sandbox not ready yet — measurement still queued, nothing flushed
+      const measureBeforeReady = mockRun.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" && (c[0] as string).includes("__ck_resize"),
+      );
+      expect(measureBeforeReady.length).toBe(0);
+
+      // Resolve the second sandbox — the re-queued measurement must replay
+      await act(async () => {
+        mockPromiseResolve();
+        await mockPromise;
+      });
+      await flushImport();
+
+      // RED pre-fix (0 on the rebuilt sandbox), GREEN post-fix: the second
+      // sandbox re-ran the one-shot measurement.
+      const measureCallsSecond = mockRun.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" && (c[0] as string).includes("__ck_resize"),
+      );
+      expect(measureCallsSecond.length).toBeGreaterThanOrEqual(1);
+    });
   });
 
   describe("design-system / importmap injection", () => {

--- a/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { OpenGenerativeUIContent } from "../OpenGenerativeUIRenderer";
 import { OpenGenerativeUIActivityRenderer } from "../OpenGenerativeUIRenderer";
 import { SandboxFunctionsContext } from "../../providers/SandboxFunctionsContext";
+import { OpenGenerativeUIOptionsProvider } from "../../providers/OpenGenerativeUIOptionsContext";
 import type { SandboxFunction } from "../../types/sandbox-function";
 
 // Mock @jetbrains/websandbox
@@ -663,6 +664,117 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       expect(options.frameContent).toContain("Done");
       // Final sandbox uses localApi, not empty object
       expect(options.frameContent).not.toBe("<head></head><body></body>");
+    });
+  });
+
+  describe("design-system / importmap injection", () => {
+    // Test A — defaults (no provider override): design system kit and importmap
+    // are injected before the agent's body content in the final sandbox document.
+    it("injects importmap and design-system kit before agent content (defaults)", async () => {
+      const agentBody = "<body><p>Agent content</p></body>";
+      renderRenderer({
+        html: [`<head></head>${agentBody}`],
+        htmlComplete: true,
+      });
+      await flushImport();
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const [, options] = mockCreate.mock.calls[0];
+      const frameContent: string = options.frameContent;
+
+      // Both kit markers must be present
+      expect(frameContent).toContain("data-ck-design-system");
+      expect(frameContent).toContain('<script type="importmap">');
+
+      // Cascade order: importmap and kit must appear before the agent body content
+      const importmapIdx = frameContent.indexOf('<script type="importmap">');
+      const kitIdx = frameContent.indexOf("data-ck-design-system");
+      const bodyContentIdx = frameContent.indexOf("<p>Agent content</p>");
+
+      expect(importmapIdx).toBeGreaterThan(-1);
+      expect(kitIdx).toBeGreaterThan(-1);
+      expect(bodyContentIdx).toBeGreaterThan(-1);
+
+      expect(importmapIdx).toBeLessThan(bodyContentIdx);
+      expect(kitIdx).toBeLessThan(bodyContentIdx);
+    });
+
+    // Test B — disabled (legacy backward-compat): with designSystemCss: false and
+    // importMap: false the frameContent must be byte-identical to the input html.
+    it("passes frameContent through unchanged when kit and importmap are disabled", async () => {
+      const inputHtml =
+        "<head><title>Legacy</title></head><body><p>Legacy content</p></body>";
+
+      render(
+        <OpenGenerativeUIOptionsProvider
+          value={{ designSystemCss: false, importMap: false }}
+        >
+          <OpenGenerativeUIActivityRenderer
+            activityType="open-generative-ui"
+            content={{ html: [inputHtml], htmlComplete: true }}
+            message={{}}
+            agent={{}}
+          />
+        </OpenGenerativeUIOptionsProvider>,
+      );
+      await flushImport();
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const [, options] = mockCreate.mock.calls[0];
+
+      // Backward-compat invariant: no kit, no importmap, no extra style injected
+      expect(options.frameContent).toBe(inputHtml);
+    });
+
+    // Test C — preview streaming path: the document.head.innerHTML run call must
+    // include data-ck-design-system BEFORE any agent css <style> content.
+    it("injects design-system kit before agent css in preview head update", async () => {
+      const agentCss = "body { color: hotpink; }";
+
+      render(
+        <OpenGenerativeUIActivityRenderer
+          activityType="open-generative-ui"
+          content={{
+            css: agentCss,
+            cssComplete: true,
+            html: ["<body><div>Preview body</div>"],
+            htmlComplete: false,
+            generating: true,
+          }}
+          message={{}}
+          agent={{}}
+        />,
+      );
+      await flushImport();
+
+      // Preview sandbox is created
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      // Resolve the preview sandbox promise so the head/body run calls fire
+      await act(async () => {
+        mockPromiseResolve();
+        await mockPromise;
+      });
+      await flushImport();
+
+      // Find the sandbox.run call that sets document.head.innerHTML
+      const headCalls = mockRun.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("document.head.innerHTML"),
+      );
+      expect(headCalls.length).toBeGreaterThanOrEqual(1);
+
+      const headPayload: string = headCalls[0][0] as string;
+
+      // Both the kit and the agent css must be present
+      expect(headPayload).toContain("data-ck-design-system");
+      expect(headPayload).toContain(agentCss);
+
+      // Cascade order: kit must appear before agent css
+      const kitIdx = headPayload.indexOf("data-ck-design-system");
+      const agentCssIdx = headPayload.indexOf(agentCss);
+      expect(kitIdx).toBeLessThan(agentCssIdx);
     });
   });
 });

--- a/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
@@ -806,5 +806,52 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       const agentCssIdx = headPayload.indexOf(agentCss);
       expect(kitIdx).toBeLessThan(agentCssIdx);
     });
+
+    // Test D — the overflow-hidden guard style must survive the head assignment.
+    // The head innerHTML assignment used to clobber a separately-appended overflow
+    // style; the guard must now be baked into the assigned head content so the
+    // preview iframe never shows scrollbars.
+    it("keeps the overflow guard in the head assignment alongside the kit", async () => {
+      const agentCss = "body { color: hotpink; }";
+
+      render(
+        <OpenGenerativeUIActivityRenderer
+          activityType="open-generative-ui"
+          content={{
+            css: agentCss,
+            cssComplete: true,
+            html: ["<body><div>Preview body</div>"],
+            htmlComplete: false,
+            generating: true,
+          }}
+          message={{}}
+          agent={{}}
+        />,
+      );
+      await flushImport();
+
+      // Preview sandbox is created
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      // Resolve the preview sandbox promise so the head/body run calls fire
+      await act(async () => {
+        mockPromiseResolve();
+        await mockPromise;
+      });
+      await flushImport();
+
+      // Inspect the LAST document.head.innerHTML run call — it must carry BOTH
+      // the overflow guard and the design-system kit (the guard survives).
+      const headCalls = mockRun.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("document.head.innerHTML"),
+      );
+      expect(headCalls.length).toBeGreaterThanOrEqual(1);
+
+      const headPayload: string = headCalls[headCalls.length - 1][0] as string;
+      expect(headPayload).toContain("overflow: hidden");
+      expect(headPayload).toContain("data-ck-design-system");
+    });
   });
 });

--- a/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
@@ -727,6 +727,110 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       expect(options.frameContent).toContain("Hello");
     });
 
+    it("destroys the preview sandbox when the body empties mid-stream, then rebuilds it for a later chunk", async () => {
+      // Mirrors the Vue renderer's watch([hasPreview, fullHtml]) -> destroyPreview()
+      // teardown. While still streaming (htmlComplete:false, no fullHtml), the
+      // accumulated HTML can transiently reduce to an empty body region — e.g. the
+      // only complete markup so far is a <head> element, which processPartialHtml
+      // strips, leaving previewBody empty. hasPreview then flips false and the
+      // container reverts to placeholder styling. The orphaned preview iframe must
+      // be torn down (not left mounted behind the spinner), and a later non-empty
+      // chunk must create a FRESH preview.
+      //
+      // RED pre-fix: only Effect 1 (fullHtml truthy) and unmount destroy the
+      // preview sandbox, so an empty mid-stream body leaves it mounted —
+      // mockDestroy is never called and no second sandbox is created.
+      const { rerender } = render(
+        <OpenGenerativeUIActivityRenderer
+          activityType="open-generative-ui"
+          content={{
+            html: ["<body><div>Hello</div>"],
+            htmlComplete: false,
+            cssComplete: true,
+            generating: true,
+          }}
+          message={{}}
+          agent={{}}
+        />,
+      );
+      await flushImport();
+
+      // Preview sandbox created and painted.
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        mockPromiseResolve();
+        await mockPromise;
+      });
+      await flushImport();
+
+      // A chunk arrives whose only complete markup is a <head> element;
+      // processPartialHtml strips it, so previewBody is empty and hasPreview
+      // flips false. This is a throttled change (htmlComplete stays false, no
+      // immediate-flush trigger), so wait out the 1s throttle window.
+      rerender(
+        <OpenGenerativeUIActivityRenderer
+          activityType="open-generative-ui"
+          content={{
+            html: ["<head><style>.x{color:red}</style></head>"],
+            htmlComplete: false,
+            cssComplete: true,
+            generating: true,
+          }}
+          message={{}}
+          agent={{}}
+        />,
+      );
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 1100));
+      });
+      await flushImport();
+
+      // The orphaned preview sandbox must be destroyed and the container emptied.
+      expect(mockDestroy).toHaveBeenCalledTimes(1);
+
+      // A later non-empty chunk must build a FRESH preview sandbox (the ref was
+      // reset, so Effect 0 re-creates). New promise for the new sandbox.
+      mockRun.mockClear();
+      resetMockPromise();
+      rerender(
+        <OpenGenerativeUIActivityRenderer
+          activityType="open-generative-ui"
+          content={{
+            html: ["<body><div>World</div>"],
+            htmlComplete: false,
+            cssComplete: true,
+            generating: true,
+          }}
+          message={{}}
+          agent={{}}
+        />,
+      );
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 1100));
+      });
+      await flushImport();
+
+      // Second preview sandbox created.
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+      const [, options] = mockCreate.mock.calls[1];
+      expect(options.frameContent).toBe("<head></head><body></body>");
+
+      // Resolve the rebuilt preview and assert the new body is painted.
+      await act(async () => {
+        mockPromiseResolve();
+        await mockPromise;
+      });
+      await flushImport();
+
+      const bodyCalls = mockRun.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("document.body.innerHTML"),
+      );
+      expect(bodyCalls.length).toBeGreaterThanOrEqual(1);
+      expect(bodyCalls[bodyCalls.length - 1]![0]).toContain("World");
+    }, 10000);
+
     it("does not show preview until cssComplete, then starts streaming HTML immediately", async () => {
       // Phase 1: HTML chunks arrive but CSS is not yet complete — no preview
       const { rerender } = render(

--- a/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
@@ -1266,5 +1266,89 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       expect(finalBodyStyleIdx).toBeGreaterThan(-1);
       expect(finalCssIdx).toBeLessThan(finalBodyStyleIdx);
     });
+
+    // Case F — TOP-LEVEL pre-<body> style (no enclosing <head> element): it is
+    // NOT hoisted. assembleDocument leaves a top-level pre-<body> style in the
+    // body region (after the head css in document order), so the preview must
+    // keep it in the body and out of the head — exactly like a body-region
+    // style. This is the parity case for the shared masked-boundary rule: the
+    // hoist decision never depends on <body> detection, only on whether the
+    // style sits inside a complete <head> element (here it does not).
+    //
+    // RED pre-fix: extractCompleteStyles hoisted any style before <body>, so the
+    // top-level style was injected into the preview head and stripped from the
+    // body — the opposite of the final document. GREEN post-fix: left in body.
+    it("keeps a top-level pre-<body> style in the preview body, not the head (matches final document)", async () => {
+      const agentCss = "main { color: rebeccapurple; }";
+      const preBodyStyleContent = ".pre-body-block { color: seagreen; }";
+      // The complete <style> sits at the TOP LEVEL, before <body>, with no
+      // enclosing <head> element — so it is body-region per the final document.
+      const preBodyStyleTag = `<style>${preBodyStyleContent}</style>`;
+      const previewHtml = `${preBodyStyleTag}<body><div class="pre-body-block">Preview body</div>`;
+
+      render(
+        <OpenGenerativeUIActivityRenderer
+          activityType="open-generative-ui"
+          content={{
+            css: agentCss,
+            cssComplete: true,
+            html: [previewHtml],
+            htmlComplete: false,
+            generating: true,
+          }}
+          message={{}}
+          agent={{}}
+        />,
+      );
+      await flushImport();
+
+      // Preview sandbox is created
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      // Resolve the preview sandbox promise so the head/body run calls fire
+      await act(async () => {
+        mockPromiseResolve();
+        await mockPromise;
+      });
+      await flushImport();
+
+      // The body innerHTML run call must contain the top-level pre-<body> style.
+      const bodyCalls = mockRun.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("document.body.innerHTML"),
+      );
+      expect(bodyCalls.length).toBeGreaterThanOrEqual(1);
+      const bodyPayload: string = bodyCalls[bodyCalls.length - 1][0] as string;
+      expect(bodyPayload).toContain(preBodyStyleContent);
+
+      // The head payload must NOT contain the pre-<body> style (not hoisted) —
+      // only the kit and the agent css param.
+      const headCalls = mockRun.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("document.head.innerHTML"),
+      );
+      expect(headCalls.length).toBeGreaterThanOrEqual(1);
+      const headPayload: string = headCalls[headCalls.length - 1][0] as string;
+      expect(headPayload).not.toContain(preBodyStyleContent);
+      expect(headPayload).toContain("data-ck-design-system");
+      expect(headPayload).toContain(agentCss);
+
+      // Final-document parity: the top-level pre-<body> style stays in the BODY,
+      // after the head css in document order (head css index precedes the style
+      // index), so the preview and final cascades agree.
+      const fullHtml = `${preBodyStyleTag}<body><div class="pre-body-block">Preview body</div></body>`;
+      const finalDoc = assembleDocument(fullHtml, {
+        css: agentCss,
+        designSystemCss: DEFAULT_OPEN_GEN_UI_OPTIONS.designSystemCss,
+        importMap: DEFAULT_OPEN_GEN_UI_OPTIONS.importMap,
+      });
+      const finalCssIdx = finalDoc.indexOf(agentCss);
+      const finalPreBodyStyleIdx = finalDoc.indexOf(preBodyStyleContent);
+      expect(finalCssIdx).toBeGreaterThan(-1);
+      expect(finalPreBodyStyleIdx).toBeGreaterThan(-1);
+      expect(finalCssIdx).toBeLessThan(finalPreBodyStyleIdx);
+    });
   });
 });

--- a/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
@@ -782,8 +782,12 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       // destroys the measured sandbox and resets autoHeight. Effect 4 is keyed on
       // generationDone and will NOT re-fire, so without Effect 1's re-queue the
       // new sandbox is never measured: it stays clamped at initialHeight and
-      // taller content is clipped. Effect 1 must re-push the measurement.
+      // taller content is clipped. Effect 1 must re-push the measurement AND the
+      // armed __ck_resize listener must still apply the result to the height.
       const completedContent = {
+        // initialHeight 200 so a stuck height is unmistakably distinct from the
+        // measured 500/700 values below.
+        initialHeight: 200,
         html: ["<head></head><body><div>Tall content</div></body>"],
         htmlComplete: true,
         css: "body { color: blue; }",
@@ -801,7 +805,7 @@ describe("OpenGenerativeUIActivityRenderer", () => {
         },
       ];
 
-      const { rerender } = render(
+      const { container, rerender } = render(
         <SandboxFunctionsContext.Provider value={fns1}>
           <OpenGenerativeUIActivityRenderer
             activityType="open-generative-ui"
@@ -827,9 +831,34 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       );
       expect(measureCallsFirst.length).toBeGreaterThanOrEqual(1);
 
+      const outer = container.firstElementChild as HTMLElement;
+      // Still at initialHeight until the iframe posts back its measurement.
+      expect(outer.style.height).toBe("200px");
+
+      // The mock creates a fresh, DETACHED iframe per sandbox; a detached
+      // iframe's contentWindow is null in jsdom, so stub it with a sentinel
+      // window object and use that same object as the MessageEvent source the
+      // armed listener compares against (sandboxRef.current.iframe.contentWindow).
+      const firstWindow = {} as Window;
+      Object.defineProperty(mockIframe, "contentWindow", {
+        configurable: true,
+        value: firstWindow,
+      });
+
+      // The first sandbox posts its measured height — the listener applies it.
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            data: { type: "__ck_resize", height: 500 },
+            source: firstWindow,
+          }),
+        );
+      });
+      expect(outer.style.height).toBe("500px");
+
       // Rebuild WITHOUT changing content — only the sandbox-functions context
       // value changes (localApi identity), which re-fires Effect 1 but not
-      // Effect 4. The new sandbox must still be measured.
+      // Effect 4. The new sandbox must still be measured and applied.
       mockRun.mockClear();
       resetMockPromise();
       const handler2 = vi.fn();
@@ -856,6 +885,9 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       // Old sandbox destroyed, new one created
       expect(mockDestroy).toHaveBeenCalledTimes(1);
       expect(mockCreate).toHaveBeenCalledTimes(2);
+      // Effect 1's cleanup reset autoHeight, so the height snaps back to
+      // initialHeight until the rebuilt iframe posts its measurement.
+      expect(outer.style.height).toBe("200px");
 
       // New sandbox not ready yet — measurement still queued, nothing flushed
       const measureBeforeReady = mockRun.mock.calls.filter(
@@ -871,13 +903,34 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       });
       await flushImport();
 
-      // RED pre-fix (0 on the rebuilt sandbox), GREEN post-fix: the second
-      // sandbox re-ran the one-shot measurement.
+      // The second sandbox re-ran the one-shot measurement script.
       const measureCallsSecond = mockRun.mock.calls.filter(
         (c: unknown[]) =>
           typeof c[0] === "string" && (c[0] as string).includes("__ck_resize"),
       );
       expect(measureCallsSecond.length).toBeGreaterThanOrEqual(1);
+
+      // Stub the SECOND (now current) iframe's contentWindow with a distinct
+      // sentinel — mockCreate reassigned the module-level mockIframe on rebuild.
+      const secondWindow = {} as Window;
+      Object.defineProperty(mockIframe, "contentWindow", {
+        configurable: true,
+        value: secondWindow,
+      });
+
+      // RED pre-fix: the listener was a one-shot that removed itself after the
+      // first (500px) measurement, so this second post is never received and the
+      // height stays stuck at 200px. GREEN post-fix: the still-armed listener
+      // applies the rebuilt sandbox's measurement.
+      await act(async () => {
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            data: { type: "__ck_resize", height: 700 },
+            source: secondWindow,
+          }),
+        );
+      });
+      expect(outer.style.height).toBe("700px");
     });
   });
 

--- a/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
@@ -1247,6 +1247,85 @@ describe("OpenGenerativeUIActivityRenderer", () => {
     });
   });
 
+  // The Open Generative UI middleware emits `generating: false` ONLY from its
+  // TOOL_CALL_END handler. On a terminal path where the upstream agent never
+  // emits TOOL_CALL_END for the genui tool call — an abort/stop, an abrupt
+  // stream end, or a transport error after the args fully streamed — the
+  // runner's finalizeRunEvents synthesizes a TOOL_CALL_END at the runner level,
+  // AFTER the middleware already processed the stream. So that synthesized end
+  // never flows back through the middleware and `generating: false` is never
+  // emitted. The fully-streamed payload (all *Complete flags true) then arrives
+  // with `generating` absent. A renderer keying purely on `generating === false`
+  // would leave the finished, interactive artifact permanently covered by the
+  // pointer-blocking overlay and (React) never measured. The completion fallback
+  // treats an all-segments-complete payload as terminal, recovering this case.
+  describe("terminal payload with absent generating flag (TOOL_CALL_END never reached the middleware)", () => {
+    const terminalNoFlag: OpenGenerativeUIContent = {
+      initialHeight: 200,
+      html: ["<head></head><body><div>Tall content</div></body>"],
+      htmlComplete: true,
+      css: "body { color: blue; }",
+      cssComplete: true,
+      jsFunctions: "function init(){}",
+      jsFunctionsComplete: true,
+      jsExpressions: ["init()"],
+      jsExpressionsComplete: true,
+      // generating intentionally ABSENT — the synthesized TOOL_CALL_END never
+      // reached the middleware, so no `generating: false` delta was emitted.
+    };
+
+    it("does not cover a fully-streamed artifact with the progress overlay", async () => {
+      const { container } = renderRenderer(terminalNoFlag);
+      await flushImport();
+
+      const outer = container.firstElementChild as HTMLElement;
+      // The pointer-blocking overlay is the absolutely-positioned inset:0 layer
+      // (zIndex 10, pointerEvents all). A finished artifact must not keep it.
+      const overlay = Array.from(outer.children).find(
+        (el) => (el as HTMLElement).style.zIndex === "10",
+      );
+      expect(overlay).toBeUndefined();
+    });
+
+    it("measures height for a fully-streamed artifact", async () => {
+      renderRenderer(terminalNoFlag);
+      await flushUntil(() => createdSandboxes.length === 1, "sandbox created");
+
+      await act(async () => {
+        mockPromiseResolve();
+        await mockPromise;
+      });
+      await flushUntil(() => measureRunCount() >= 1, "measurement flushed");
+
+      // The one-shot measurement script ran — Effect 4 armed via the completion
+      // fallback even though `generating` is absent.
+      expect(measureRunCount()).toBeGreaterThanOrEqual(1);
+    });
+
+    it("still covers an in-flight artifact whose js segments are not yet complete (no premature completion)", async () => {
+      // html finished but jsExpressions are still streaming (jsExpressionsComplete
+      // absent) — this is the NORMAL mid-stream shape, NOT a terminal payload. The
+      // overlay must stay up; the fallback must not lift it early.
+      const { container } = renderRenderer({
+        initialHeight: 200,
+        html: ["<head></head><body><div>partial</div></body>"],
+        htmlComplete: true,
+        css: "body { color: blue; }",
+        cssComplete: true,
+        jsExpressions: ["init()"],
+        // jsExpressionsComplete ABSENT — still streaming.
+        // generating ABSENT too (deltas, no snapshot yet).
+      });
+      await flushImport();
+
+      const outer = container.firstElementChild as HTMLElement;
+      const overlay = Array.from(outer.children).find(
+        (el) => (el as HTMLElement).style.zIndex === "10",
+      );
+      expect(overlay).toBeDefined();
+    });
+  });
+
   describe("design-system / importmap injection", () => {
     // Test A — defaults (no provider override): design system kit and importmap
     // are injected before the agent's body content in the final sandbox document.

--- a/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
@@ -12,6 +12,10 @@ import {
 import { assembleDocument } from "../../lib/assembleDocument";
 import type { SandboxFunction } from "../../types/sandbox-function";
 
+// The renderer's outer wrapper throttles non-immediate content changes with
+// setTimeout(THROTTLE_MS). Keep this in lockstep with THROTTLE_MS in the source.
+const THROTTLE_MS = 1000;
+
 // Mock @jetbrains/websandbox
 const mockRun = vi.fn().mockResolvedValue(undefined);
 const mockDestroy = vi.fn();
@@ -41,11 +45,54 @@ vi.mock("@jetbrains/websandbox", () => ({
   },
 }));
 
-/** Flush the dynamic import() microtask so the sandbox gets created */
+/**
+ * Drain the multi-stage async chain the renderer kicks off when it decides to
+ * build a sandbox: the dynamic `import("@jetbrains/websandbox")` resolves, its
+ * `.then` runs `Websandbox.create` (so `mockCreate` fires) and registers the
+ * `sandbox.promise.then` callback. Each stage is a microtask hop, and a React
+ * commit can interleave another effect between them.
+ *
+ * The previous single `await setTimeout(0)` inside `act` drained "usually
+ * enough" — but a single macrotask tick is margin-based: under CPU load the
+ * commit -> effect -> import-microtask sequence could still be in flight when
+ * assertions ran (the documented `re-measures …` flake). Instead, loop
+ * microtask flushes until the chain settles, detected as `mockCreate`'s call
+ * count going quiet across an iteration (or a hard cap). This is deterministic
+ * rather than time-bounded and uses NO real timer, so it is also safe under
+ * `vi.useFakeTimers()` (a `setTimeout(0)` would otherwise hang there).
+ */
 async function flushImport() {
   await act(async () => {
-    await new Promise((r) => setTimeout(r, 0));
+    let lastCreateCalls = -1;
+    // Cap iterations so a genuinely stuck chain fails loudly instead of hanging.
+    for (let i = 0; i < 50; i++) {
+      const createCalls = mockCreate.mock.calls.length;
+      // Settled: a full iteration passed with no new sandbox created and the
+      // microtask queue drained. Two consecutive quiet reads guard against
+      // stopping in the one-tick gap between import resolve and create.
+      if (createCalls === lastCreateCalls && i > 0) break;
+      lastCreateCalls = createCalls;
+      // eslint-disable-next-line no-await-in-loop
+      await Promise.resolve();
+      // eslint-disable-next-line no-await-in-loop
+      await Promise.resolve();
+    }
   });
+}
+
+/**
+ * Advance the renderer's throttle window deterministically. The outer wrapper
+ * schedules `setTimeout(flush, THROTTLE_MS)` for non-immediate content changes;
+ * under `vi.useFakeTimers()` we step exactly THROTTLE_MS so `flush` fires (no
+ * wall-clock margin a loaded worker can blow through), then drain the microtasks
+ * the resulting re-render queues. Requires `vi.useFakeTimers()` to be active.
+ */
+async function flushThrottle() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(THROTTLE_MS);
+  });
+  // Drain the import/promise microtask chain the re-render may have kicked off.
+  await flushImport();
 }
 
 function renderRenderer(content: OpenGenerativeUIContent) {
@@ -67,6 +114,10 @@ describe("OpenGenerativeUIActivityRenderer", () => {
 
   afterEach(() => {
     cleanup();
+    // Defensive: any test that opted into fake timers must not leak that state
+    // into a sibling running in the same worker (the parallel-load scenario the
+    // flake was reproduced under). A no-op when real timers are already active.
+    vi.useRealTimers();
   });
 
   it("renders placeholder when no html", async () => {
@@ -546,6 +597,10 @@ describe("OpenGenerativeUIActivityRenderer", () => {
     });
 
     it("updates preview on re-render with more chunks (after throttle)", async () => {
+      // Deterministic throttle: step exactly THROTTLE_MS with fake timers
+      // instead of racing a real 1100ms wall-clock wait against the renderer's
+      // 1000ms throttle (the ~100ms margin a loaded worker could blow through).
+      vi.useFakeTimers();
       const { rerender } = render(
         <OpenGenerativeUIActivityRenderer
           activityType="open-generative-ui"
@@ -592,11 +647,8 @@ describe("OpenGenerativeUIActivityRenderer", () => {
         />,
       );
 
-      // Wait for the 1s throttle window to pass
-      await act(async () => {
-        await new Promise((r) => setTimeout(r, 1100));
-      });
-      await flushImport();
+      // Advance exactly the throttle window so the deferred flush fires.
+      await flushThrottle();
 
       // Should have updated innerHTML with new content after throttle
       const updateCalls = mockRun.mock.calls.filter(
@@ -620,6 +672,11 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       // RED pre-fix: Effect 0's promise.then closed over previewBody/previewStyles
       // captured when the effect ran, so the FIRST applied frame was "OLD" only.
       // GREEN post-fix: it reads the latest frame via a ref, so "NEW" is applied.
+      //
+      // Deterministic throttle (fake timers) so the newer chunk is guaranteed to
+      // have been applied to the inner component before the sandbox resolves —
+      // not racing a real wall-clock wait against the 1000ms throttle.
+      vi.useFakeTimers();
       const { rerender } = render(
         <OpenGenerativeUIActivityRenderer
           activityType="open-generative-ui"
@@ -640,8 +697,8 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       expect(mockCreate).toHaveBeenCalledTimes(1);
 
       // A newer chunk streams in before the sandbox is ready. Going 1->2 chunks
-      // (htmlComplete:false) is throttled by the outer wrapper, so wait out the
-      // 1s window to let the inner component re-render with the newer body.
+      // (htmlComplete:false) is throttled by the outer wrapper, so step the
+      // throttle window to let the inner component re-render with the newer body.
       // Effect 0 does not re-fire (the sandbox ref is set); Effect 0b fires but
       // early-returns because previewReadyRef is still false.
       rerender(
@@ -657,10 +714,7 @@ describe("OpenGenerativeUIActivityRenderer", () => {
           agent={{}}
         />,
       );
-      await act(async () => {
-        await new Promise((r) => setTimeout(r, 1100));
-      });
-      await flushImport();
+      await flushThrottle();
 
       // Now the sandbox becomes ready. Its resolve callback applies the preview
       // frame — which must be the latest one, not the creation-time snapshot.
@@ -740,6 +794,10 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       // RED pre-fix: only Effect 1 (fullHtml truthy) and unmount destroy the
       // preview sandbox, so an empty mid-stream body leaves it mounted —
       // mockDestroy is never called and no second sandbox is created.
+      //
+      // Fake timers so the two throttled re-renders below step the throttle
+      // window deterministically instead of racing a real wall-clock wait.
+      vi.useFakeTimers();
       const { rerender } = render(
         <OpenGenerativeUIActivityRenderer
           activityType="open-generative-ui"
@@ -766,7 +824,7 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       // A chunk arrives whose only complete markup is a <head> element;
       // processPartialHtml strips it, so previewBody is empty and hasPreview
       // flips false. This is a throttled change (htmlComplete stays false, no
-      // immediate-flush trigger), so wait out the 1s throttle window.
+      // immediate-flush trigger), so step the throttle window.
       rerender(
         <OpenGenerativeUIActivityRenderer
           activityType="open-generative-ui"
@@ -780,10 +838,7 @@ describe("OpenGenerativeUIActivityRenderer", () => {
           agent={{}}
         />,
       );
-      await act(async () => {
-        await new Promise((r) => setTimeout(r, 1100));
-      });
-      await flushImport();
+      await flushThrottle();
 
       // The orphaned preview sandbox must be destroyed and the container emptied.
       expect(mockDestroy).toHaveBeenCalledTimes(1);
@@ -805,10 +860,7 @@ describe("OpenGenerativeUIActivityRenderer", () => {
           agent={{}}
         />,
       );
-      await act(async () => {
-        await new Promise((r) => setTimeout(r, 1100));
-      });
-      await flushImport();
+      await flushThrottle();
 
       // Second preview sandbox created.
       expect(mockCreate).toHaveBeenCalledTimes(2);

--- a/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
@@ -1090,5 +1090,75 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       expect(headPayload).toContain("overflow: hidden");
       expect(headPayload).toContain("data-ck-design-system");
     });
+
+    // Test E — preview cascade must match the final document's cascade. The
+    // assembled final document (assembleDocument) orders head styles as
+    // kit -> agent's inline <style> blocks (in place) -> agent css param LAST so
+    // the agent css wins equal-specificity ties. The streaming preview must use
+    // the SAME order in its document.head.innerHTML assignment, otherwise an
+    // artifact whose inline style and css param collide at equal specificity
+    // visibly restyles at the preview -> final swap.
+    //
+    // RED pre-fix: the preview pushed the agent css param BEFORE the extracted
+    // inline preview styles, so index(css param) < index(inline style) — the
+    // OPPOSITE of the final document. GREEN post-fix:
+    // index(kit) < index(inline style) < index(css param).
+    it("orders preview head as kit -> inline styles -> agent css (matches final document cascade)", async () => {
+      const agentCss = "main { color: rebeccapurple; }";
+      const inlineStyleContent = ".inline-block { color: seagreen; }";
+
+      render(
+        <OpenGenerativeUIActivityRenderer
+          activityType="open-generative-ui"
+          content={{
+            css: agentCss,
+            cssComplete: true,
+            // A COMPLETE inline <style> block plus body content. The streaming
+            // pipeline extracts the <style> into previewStyles and strips it from
+            // the previewBody.
+            html: [
+              `<style>${inlineStyleContent}</style><body><div class="inline-block">Preview body</div>`,
+            ],
+            htmlComplete: false,
+            generating: true,
+          }}
+          message={{}}
+          agent={{}}
+        />,
+      );
+      await flushImport();
+
+      // Preview sandbox is created
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      // Resolve the preview sandbox promise so the head/body run calls fire
+      await act(async () => {
+        mockPromiseResolve();
+        await mockPromise;
+      });
+      await flushImport();
+
+      // Read the LAST document.head.innerHTML run payload.
+      const headCalls = mockRun.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("document.head.innerHTML"),
+      );
+      expect(headCalls.length).toBeGreaterThanOrEqual(1);
+      const headPayload: string = headCalls[headCalls.length - 1][0] as string;
+
+      // All three must be present in the assigned head content.
+      const kitIdx = headPayload.indexOf("data-ck-design-system");
+      const inlineStyleIdx = headPayload.indexOf(inlineStyleContent);
+      const agentCssIdx = headPayload.indexOf(agentCss);
+      expect(kitIdx).toBeGreaterThan(-1);
+      expect(inlineStyleIdx).toBeGreaterThan(-1);
+      expect(agentCssIdx).toBeGreaterThan(-1);
+
+      // Cascade order: kit first, then the agent's inline <style> block, then the
+      // agent css param LAST — identical to assembleDocument's final cascade.
+      expect(kitIdx).toBeLessThan(inlineStyleIdx);
+      expect(inlineStyleIdx).toBeLessThan(agentCssIdx);
+    });
   });
 });

--- a/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
@@ -662,8 +662,38 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       expect(mockCreate).toHaveBeenCalledTimes(1);
       const [, options] = mockCreate.mock.calls[0];
       expect(options.frameContent).toContain("Done");
-      // Final sandbox uses localApi, not empty object
+      // frameContent is the assembled final document, not the empty preview template
       expect(options.frameContent).not.toBe("<head></head><body></body>");
+    });
+
+    it("measures height on fast completion (htmlComplete + generating:false in one snapshot)", async () => {
+      // Reconnect/restore + non-streaming completion path: a single content
+      // snapshot arrives already complete. The sandbox is only scheduled (async
+      // import) when Effect 4 runs, so the height measurement must be queued and
+      // flushed once the sandbox is ready — otherwise the iframe stays clamped
+      // at initialHeight and taller content is clipped.
+      renderRenderer({
+        html: ["<head></head><body><div>Tall content</div></body>"],
+        htmlComplete: true,
+        css: "body { color: blue; }",
+        cssComplete: true,
+        generating: false,
+      });
+      await flushImport();
+
+      // Resolve the sandbox ready promise so the pending queue is flushed
+      await act(async () => {
+        mockPromiseResolve();
+        await mockPromise;
+      });
+      await flushImport();
+
+      // The one-shot measurement script must have executed via the flushed queue
+      const measureCalls = mockRun.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" && (c[0] as string).includes("__ck_resize"),
+      );
+      expect(measureCalls.length).toBeGreaterThanOrEqual(1);
     });
   });
 

--- a/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
@@ -256,6 +256,87 @@ describe("OpenGenerativeUIActivityRenderer", () => {
     expect(mockRun).toHaveBeenCalledWith("foo()");
   });
 
+  it("re-queues JS into a rebuilt sandbox when html changes (not a JS change)", async () => {
+    const jsFunctions = "function foo(){}";
+    const { rerender } = render(
+      <OpenGenerativeUIActivityRenderer
+        activityType="open-generative-ui"
+        content={{
+          html: ["<head></head><body>v1</body>"],
+          htmlComplete: true,
+          jsFunctions,
+          jsExpressions: ["foo()"],
+        }}
+        message={{}}
+        agent={{}}
+      />,
+    );
+    await flushImport();
+
+    // First sandbox ready — flush its queued JS
+    await act(async () => {
+      mockPromiseResolve();
+      await mockPromise;
+    });
+    await flushImport();
+
+    // First sandbox ran jsFunctions + the expression exactly once each
+    const fnCallsFirst = mockRun.mock.calls.filter(
+      (c: unknown[]) => c[0] === jsFunctions,
+    ).length;
+    const exprCallsFirst = mockRun.mock.calls.filter(
+      (c: unknown[]) => c[0] === "foo()",
+    ).length;
+    expect(fnCallsFirst).toBe(1);
+    expect(exprCallsFirst).toBe(1);
+
+    // Rebuild trigger is the HTML, NOT a JS change: jsFunctions/jsExpressions are
+    // byte-identical so Effects 2/3 will not re-fire. The rebuilt sandbox must
+    // still receive the JS via Effect 1's re-queue.
+    mockRun.mockClear();
+    resetMockPromise();
+    rerender(
+      <OpenGenerativeUIActivityRenderer
+        activityType="open-generative-ui"
+        content={{
+          html: ["<head></head><body>v2</body>"],
+          htmlComplete: true,
+          jsFunctions,
+          jsExpressions: ["foo()"],
+        }}
+        message={{}}
+        agent={{}}
+      />,
+    );
+    await flushImport();
+
+    // Old sandbox destroyed, new one created
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+
+    // New sandbox not ready yet — nothing flushed
+    expect(mockRun).not.toHaveBeenCalledWith(jsFunctions);
+    expect(mockRun).not.toHaveBeenCalledWith("foo()");
+
+    // Resolve the second sandbox — the re-queued JS must replay
+    await act(async () => {
+      mockPromiseResolve();
+      await mockPromise;
+    });
+    await flushImport();
+
+    // The second sandbox received BOTH the jsFunctions string and the expression
+    // again (re-injected), each exactly once — no double-execution.
+    const fnCallsSecond = mockRun.mock.calls.filter(
+      (c: unknown[]) => c[0] === jsFunctions,
+    ).length;
+    const exprCallsSecond = mockRun.mock.calls.filter(
+      (c: unknown[]) => c[0] === "foo()",
+    ).length;
+    expect(fnCallsSecond).toBe(1);
+    expect(exprCallsSecond).toBe(1);
+  });
+
   it("recreates sandbox when html changes", async () => {
     const { rerender } = render(
       <OpenGenerativeUIActivityRenderer

--- a/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
@@ -608,6 +608,79 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       expect(updateCalls[updateCalls.length - 1]![0]).toContain("World");
     }, 10000);
 
+    it("applies the latest streamed content when the preview sandbox becomes ready (no stale snapshot)", async () => {
+      // The preview sandbox is created asynchronously: Effect 0 starts the
+      // dynamic import() and the sandbox's ready promise resolves a tick later.
+      // If newer chunks stream in DURING that window, Effect 0b cannot apply them
+      // (it early-returns until previewReadyRef flips true), so the snapshot that
+      // Effect 0's resolve callback applies must be read live — otherwise the
+      // preview shows the creation-time frame until the next content change, and
+      // if the stream already ended there is no next change.
+      //
+      // RED pre-fix: Effect 0's promise.then closed over previewBody/previewStyles
+      // captured when the effect ran, so the FIRST applied frame was "OLD" only.
+      // GREEN post-fix: it reads the latest frame via a ref, so "NEW" is applied.
+      const { rerender } = render(
+        <OpenGenerativeUIActivityRenderer
+          activityType="open-generative-ui"
+          content={{
+            html: ["<body><div>OLD</div>"],
+            htmlComplete: false,
+            cssComplete: true,
+            generating: true,
+          }}
+          message={{}}
+          agent={{}}
+        />,
+      );
+
+      // Resolve the dynamic import() so Websandbox.create runs and the preview
+      // sandbox ref is populated — but DO NOT resolve the sandbox ready promise.
+      await flushImport();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      // A newer chunk streams in before the sandbox is ready. Going 1->2 chunks
+      // (htmlComplete:false) is throttled by the outer wrapper, so wait out the
+      // 1s window to let the inner component re-render with the newer body.
+      // Effect 0 does not re-fire (the sandbox ref is set); Effect 0b fires but
+      // early-returns because previewReadyRef is still false.
+      rerender(
+        <OpenGenerativeUIActivityRenderer
+          activityType="open-generative-ui"
+          content={{
+            html: ["<body><div>OLD</div>", "<div>NEW</div>"],
+            htmlComplete: false,
+            cssComplete: true,
+            generating: true,
+          }}
+          message={{}}
+          agent={{}}
+        />,
+      );
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 1100));
+      });
+      await flushImport();
+
+      // Now the sandbox becomes ready. Its resolve callback applies the preview
+      // frame — which must be the latest one, not the creation-time snapshot.
+      await act(async () => {
+        mockPromiseResolve();
+        await mockPromise;
+      });
+      await flushImport();
+
+      const bodyCalls = mockRun.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("document.body.innerHTML"),
+      );
+      expect(bodyCalls.length).toBeGreaterThanOrEqual(1);
+      // The body the sandbox first received must already include the newer chunk.
+      const firstBody = bodyCalls[0]![0] as string;
+      expect(firstBody).toContain("NEW");
+    }, 10000);
+
     it("destroys preview and creates final sandbox when htmlComplete arrives", async () => {
       const { rerender } = render(
         <OpenGenerativeUIActivityRenderer

--- a/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
@@ -9,7 +9,7 @@ import {
   OpenGenerativeUIOptionsProvider,
   DEFAULT_OPEN_GEN_UI_OPTIONS,
 } from "../../providers/OpenGenerativeUIOptionsContext";
-import { assembleDocument } from "../../lib/assembleDocument";
+import { assembleDocument, escapeStyleClose } from "../../lib/assembleDocument";
 import type { SandboxFunction } from "../../types/sandbox-function";
 
 // The renderer's outer wrapper throttles non-immediate content changes with
@@ -1434,6 +1434,83 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       const kitIdx = headPayload.indexOf("data-ck-design-system");
       const agentCssIdx = headPayload.indexOf(agentCss);
       expect(kitIdx).toBeLessThan(agentCssIdx);
+    });
+
+    // Test C2 — `</style`-escape parity. The preview's buildPreviewHeadHtml
+    // splices the agent css RAW into a `<style>` element, so it must
+    // `</style`-escape it IDENTICALLY to assembleDocument's final sinks (reusing
+    // the SAME exported escapeStyleClose helper). RED pre-fix: the agent's
+    // `</style>` closed the preview style element early and the trailing
+    // `<script>` became LIVE in the preview iframe. GREEN post-fix: the close is
+    // escaped, so the preview and the final document escape byte-for-byte the
+    // same way (their cascade/byte parity is the whole point of sharing the
+    // helper).
+    it("escapes </style in the agent css in the preview head (same helper as the final document)", async () => {
+      const agentCss = "a{}</style><script>alert(1)</script>";
+
+      render(
+        <OpenGenerativeUIActivityRenderer
+          activityType="open-generative-ui"
+          content={{
+            css: agentCss,
+            cssComplete: true,
+            html: ["<body><div>Preview body</div>"],
+            htmlComplete: false,
+            generating: true,
+          }}
+          message={{}}
+          agent={{}}
+        />,
+      );
+      await flushImport();
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        mockPromiseResolve();
+        await mockPromise;
+      });
+      await flushImport();
+
+      const headCalls = mockRun.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("document.head.innerHTML"),
+      );
+      expect(headCalls.length).toBeGreaterThanOrEqual(1);
+      const headPayload: string = headCalls[headCalls.length - 1][0] as string;
+
+      // The payload is a `document.head.innerHTML = ${JSON.stringify(headHtml)}`
+      // run call, so the head html is JSON-encoded inside it. Decode it back to
+      // the raw head markup the preview iframe will receive.
+      const headHtml: string = JSON.parse(
+        headPayload.replace(/^document\.head\.innerHTML = /, ""),
+      );
+
+      // The preview escapes via the SAME exported helper as the final document.
+      expect(headHtml).toContain(
+        `<style>${escapeStyleClose(agentCss)}</style>`,
+      );
+      // The live-breakout signature is gone (the agent's `</style>` is now an
+      // escaped `<\/style>`, so the `<script>` is inert style text).
+      expect(headHtml).not.toContain("</style><script");
+      expect(headHtml).not.toMatch(/<\/style>\s*<script/i);
+
+      // Parity: assembleDocument escapes the SAME agent css the SAME way for the
+      // final document — the preview style and the final style carry byte-for-byte
+      // identical escaped css.
+      const finalDoc = assembleDocument(
+        "<head></head><body><div>Preview body</div></body>",
+        {
+          css: agentCss,
+          designSystemCss: DEFAULT_OPEN_GEN_UI_OPTIONS.designSystemCss,
+          importMap: DEFAULT_OPEN_GEN_UI_OPTIONS.importMap,
+        },
+      );
+      expect(finalDoc).toContain(
+        `<style>${escapeStyleClose(agentCss)}</style>`,
+      );
+      expect(finalDoc).not.toContain("</style><script");
     });
 
     // Test D — the overflow-hidden guard style must survive the head assignment.

--- a/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
@@ -29,14 +29,55 @@ function resetMockPromise() {
   });
 }
 
+/**
+ * Handle for one sandbox the mock has handed back to the renderer. The renderer
+ * stores this exact object in `sandboxRef.current` (final) or
+ * `previewSandboxRef.current` (preview), so its `contentWindow` sentinel is
+ * precisely what the height listener's
+ * `e.source === sandboxRef.current?.iframe?.contentWindow` guard compares
+ * against. Tests read the sentinel from here rather than re-stubbing the
+ * module-level `mockIframe` after the fact — that decouples the dispatched
+ * MessageEvent source from any timing assumption about which iframe the shared
+ * `mockIframe` variable currently points at.
+ */
+interface CreatedSandbox {
+  iframe: HTMLIFrameElement;
+  /** Stable sentinel installed as iframe.contentWindow at creation time. */
+  contentWindow: Window;
+  run: typeof mockRun;
+  destroy: typeof mockDestroy;
+  promise: Promise<unknown>;
+}
+
+/**
+ * Every sandbox the mock has created, in creation order. `createdSandboxes.at(-1)`
+ * is the object the renderer most recently assigned to its sandbox ref, so the
+ * tests can address "the current sandbox" by identity instead of inferring it
+ * from microtask timing. Reset in beforeEach.
+ */
+let createdSandboxes: CreatedSandbox[] = [];
+
 const mockCreate = vi.fn(() => {
   mockIframe = document.createElement("iframe");
-  return {
+  // Install a stable, known contentWindow sentinel at creation time. A detached
+  // iframe's contentWindow is null in jsdom, so without this the height
+  // listener's source guard could never match; pinning it here (and recording it
+  // on the handle) makes the listener-visible source deterministic and lets
+  // tests dispatch the exact window object the guard will compare against.
+  const contentWindow = {} as Window;
+  Object.defineProperty(mockIframe, "contentWindow", {
+    configurable: true,
+    value: contentWindow,
+  });
+  const sandbox: CreatedSandbox = {
     iframe: mockIframe,
-    promise: mockPromise,
+    contentWindow,
     run: mockRun,
     destroy: mockDestroy,
+    promise: mockPromise,
   };
+  createdSandboxes.push(sandbox);
+  return sandbox;
 });
 
 vi.mock("@jetbrains/websandbox", () => ({
@@ -45,39 +86,81 @@ vi.mock("@jetbrains/websandbox", () => ({
   },
 }));
 
+// How many microtask hops to flush inside a single `act` to drain the renderer's
+// sandbox-build chain. The chain is a fixed, short sequence of microtask hops:
+// the dynamic `import("@jetbrains/websandbox")` resolves -> its `.then` runs
+// `Websandbox.create` (so `mockCreate` fires) and registers the
+// `sandbox.promise.then` callback -> on resolve, that callback runs and flushes
+// the pending queue. React's `act` interleaves a bounded number of effect/commit
+// hops between them. 100 yields is comfortably deeper than any of those chains
+// and — crucially — performs the SAME work on every run regardless of CPU load
+// (microtasks run to completion between awaits; contention delays wall-clock, not
+// ordering). That makes the drain deterministic, not margin-based.
+const MICROTASK_FLUSH_COUNT = 100;
+
 /**
- * Drain the multi-stage async chain the renderer kicks off when it decides to
- * build a sandbox: the dynamic `import("@jetbrains/websandbox")` resolves, its
- * `.then` runs `Websandbox.create` (so `mockCreate` fires) and registers the
- * `sandbox.promise.then` callback. Each stage is a microtask hop, and a React
- * commit can interleave another effect between them.
+ * Flush the renderer's sandbox-build microtask chain deterministically.
  *
- * The previous single `await setTimeout(0)` inside `act` drained "usually
- * enough" — but a single macrotask tick is margin-based: under CPU load the
- * commit -> effect -> import-microtask sequence could still be in flight when
- * assertions ran (the documented `re-measures …` flake). Instead, loop
- * microtask flushes until the chain settles, detected as `mockCreate`'s call
- * count going quiet across an iteration (or a hard cap). This is deterministic
- * rather than time-bounded and uses NO real timer, so it is also safe under
+ * The previous implementation broke when `mockCreate`'s call count went "quiet"
+ * for one iteration — a heuristic proxy for "settled" with a hard cap. Under CPU
+ * contention that proxy could read quiet in the one-tick gap *before* the host's
+ * `sandbox.promise.then` callback had armed `sandboxRef`-visible state, so the
+ * subsequent height MessageEvent was rejected (the documented `re-measures …`
+ * flake). This version drops the heuristic: it flushes a fixed number of
+ * microtask hops, which fully drains the (short, fixed-depth) chain and does
+ * identical work on every run. It uses NO real timer, so it stays safe under
  * `vi.useFakeTimers()` (a `setTimeout(0)` would otherwise hang there).
+ *
+ * For assertions that depend on a *specific* downstream signal (a rebuilt
+ * sandbox having been created, or its measurement having replayed), prefer
+ * {@link flushUntil}, which gates on that concrete condition and fails loud if it
+ * never holds.
  */
 async function flushImport() {
   await act(async () => {
-    let lastCreateCalls = -1;
-    // Cap iterations so a genuinely stuck chain fails loudly instead of hanging.
-    for (let i = 0; i < 50; i++) {
-      const createCalls = mockCreate.mock.calls.length;
-      // Settled: a full iteration passed with no new sandbox created and the
-      // microtask queue drained. Two consecutive quiet reads guard against
-      // stopping in the one-tick gap between import resolve and create.
-      if (createCalls === lastCreateCalls && i > 0) break;
-      lastCreateCalls = createCalls;
-      // eslint-disable-next-line no-await-in-loop
-      await Promise.resolve();
+    for (let i = 0; i < MICROTASK_FLUSH_COUNT; i++) {
       // eslint-disable-next-line no-await-in-loop
       await Promise.resolve();
     }
   });
+}
+
+/**
+ * Flush microtasks inside `act` until `cond()` holds, then stop. Unlike a
+ * fixed-count or call-count-quiet drain, this waits for the EXACT causal signal
+ * the next assertion needs — e.g. "the rebuilt sandbox has been created"
+ * (`createdSandboxes.length === 2`) or "the rebuilt sandbox's measurement has
+ * replayed". If the condition never becomes true within a generous microtask
+ * budget it throws, so a genuinely stuck chain fails loudly instead of letting a
+ * later assertion fail with a misleading value. No wall-clock, no real timer —
+ * safe under fake timers.
+ */
+async function flushUntil(cond: () => boolean, label = "condition") {
+  let settled = false;
+  await act(async () => {
+    for (let i = 0; i < MICROTASK_FLUSH_COUNT; i++) {
+      if (cond()) {
+        settled = true;
+        break;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await Promise.resolve();
+    }
+    if (cond()) settled = true;
+  });
+  if (!settled) {
+    throw new Error(
+      `flushUntil: ${label} never became true within ${MICROTASK_FLUSH_COUNT} microtask flushes`,
+    );
+  }
+}
+
+/** Count of sandbox.run calls carrying the one-shot height measurement script. */
+function measureRunCount(): number {
+  return mockRun.mock.calls.filter(
+    (c: unknown[]) =>
+      typeof c[0] === "string" && (c[0] as string).includes("__ck_resize"),
+  ).length;
 }
 
 /**
@@ -110,6 +193,7 @@ describe("OpenGenerativeUIActivityRenderer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetMockPromise();
+    createdSandboxes = [];
   });
 
   afterEach(() => {
@@ -993,21 +1077,21 @@ describe("OpenGenerativeUIActivityRenderer", () => {
         cssComplete: true,
         generating: false,
       });
-      await flushImport();
+      // Concrete signal: wait until the sandbox has actually been created rather
+      // than guessing the import chain has settled.
+      await flushUntil(() => createdSandboxes.length === 1, "sandbox created");
 
-      // Resolve the sandbox ready promise so the pending queue is flushed
+      // Resolve the sandbox ready promise, then wait on the concrete downstream
+      // signal — the host's sandbox.promise.then callback having flushed the
+      // queued one-shot measurement — instead of a heuristic drain.
       await act(async () => {
         mockPromiseResolve();
         await mockPromise;
       });
-      await flushImport();
+      await flushUntil(() => measureRunCount() >= 1, "measurement flushed");
 
       // The one-shot measurement script must have executed via the flushed queue
-      const measureCalls = mockRun.mock.calls.filter(
-        (c: unknown[]) =>
-          typeof c[0] === "string" && (c[0] as string).includes("__ck_resize"),
-      );
-      expect(measureCalls.length).toBeGreaterThanOrEqual(1);
+      expect(measureRunCount()).toBeGreaterThanOrEqual(1);
     });
 
     it("re-measures height when the final sandbox is rebuilt after completion", async () => {
@@ -1048,42 +1132,38 @@ describe("OpenGenerativeUIActivityRenderer", () => {
           />
         </SandboxFunctionsContext.Provider>,
       );
-      await flushImport();
+      // Concrete signal: the first sandbox has actually been created.
+      await flushUntil(() => createdSandboxes.length === 1, "first sandbox");
 
-      // First sandbox ready — flush its queued measurement
+      // First sandbox ready — wait on the concrete signal that its host
+      // sandbox.promise.then callback has RUN and flushed the queued measurement,
+      // not a heuristic that the chain "looks" settled.
       await act(async () => {
         mockPromiseResolve();
         await mockPromise;
       });
-      await flushImport();
+      await flushUntil(() => measureRunCount() >= 1, "first measurement");
 
       // The first sandbox ran the one-shot measurement
-      const measureCallsFirst = mockRun.mock.calls.filter(
-        (c: unknown[]) =>
-          typeof c[0] === "string" && (c[0] as string).includes("__ck_resize"),
-      );
-      expect(measureCallsFirst.length).toBeGreaterThanOrEqual(1);
+      expect(measureRunCount()).toBeGreaterThanOrEqual(1);
 
       const outer = container.firstElementChild as HTMLElement;
       // Still at initialHeight until the iframe posts back its measurement.
       expect(outer.style.height).toBe("200px");
 
-      // The mock creates a fresh, DETACHED iframe per sandbox; a detached
-      // iframe's contentWindow is null in jsdom, so stub it with a sentinel
-      // window object and use that same object as the MessageEvent source the
-      // armed listener compares against (sandboxRef.current.iframe.contentWindow).
-      const firstWindow = {} as Window;
-      Object.defineProperty(mockIframe, "contentWindow", {
-        configurable: true,
-        value: firstWindow,
-      });
-
-      // The first sandbox posts its measured height — the listener applies it.
+      // Dispatch the first sandbox's measured height. The source is read from the
+      // recorded sandbox handle — the SAME object the renderer stored in
+      // sandboxRef.current — so its stable contentWindow sentinel is exactly what
+      // the listener's `e.source === sandboxRef.current?.iframe?.contentWindow`
+      // guard compares against. No after-the-fact stub on the shared mockIframe,
+      // so there is no window where the dispatched source and the listener-visible
+      // sandbox can disagree.
+      const firstSandbox = createdSandboxes.at(-1)!;
       await act(async () => {
         window.dispatchEvent(
           new MessageEvent("message", {
             data: { type: "__ck_resize", height: 500 },
-            source: firstWindow,
+            source: firstSandbox.contentWindow,
           }),
         );
       });
@@ -1113,7 +1193,11 @@ describe("OpenGenerativeUIActivityRenderer", () => {
           />
         </SandboxFunctionsContext.Provider>,
       );
-      await flushImport();
+      // Concrete signal: the rebuilt sandbox has actually been created (the
+      // rebuild's dynamic import resolved and Websandbox.create ran). flushUntil
+      // throws if it never does, so a stuck rebuild fails loud here instead of
+      // surfacing as a misleading height assertion later.
+      await flushUntil(() => createdSandboxes.length === 2, "rebuilt sandbox");
 
       // Old sandbox destroyed, new one created
       expect(mockDestroy).toHaveBeenCalledTimes(1);
@@ -1123,33 +1207,29 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       expect(outer.style.height).toBe("200px");
 
       // New sandbox not ready yet — measurement still queued, nothing flushed
-      const measureBeforeReady = mockRun.mock.calls.filter(
-        (c: unknown[]) =>
-          typeof c[0] === "string" && (c[0] as string).includes("__ck_resize"),
-      );
-      expect(measureBeforeReady.length).toBe(0);
+      expect(measureRunCount()).toBe(0);
 
-      // Resolve the second sandbox — the re-queued measurement must replay
+      // Resolve the second sandbox, then wait on the concrete signal that the
+      // re-queued measurement has replayed — i.e. the rebuilt sandbox's host
+      // sandbox.promise.then callback has RUN. This is the precise hop the old
+      // call-count heuristic could not observe, so it could let the dispatch below
+      // race a still-pending callback and reject the height MessageEvent.
       await act(async () => {
         mockPromiseResolve();
         await mockPromise;
       });
-      await flushImport();
+      await flushUntil(() => measureRunCount() >= 1, "rebuilt measurement");
 
       // The second sandbox re-ran the one-shot measurement script.
-      const measureCallsSecond = mockRun.mock.calls.filter(
-        (c: unknown[]) =>
-          typeof c[0] === "string" && (c[0] as string).includes("__ck_resize"),
-      );
-      expect(measureCallsSecond.length).toBeGreaterThanOrEqual(1);
+      expect(measureRunCount()).toBeGreaterThanOrEqual(1);
 
-      // Stub the SECOND (now current) iframe's contentWindow with a distinct
-      // sentinel — mockCreate reassigned the module-level mockIframe on rebuild.
-      const secondWindow = {} as Window;
-      Object.defineProperty(mockIframe, "contentWindow", {
-        configurable: true,
-        value: secondWindow,
-      });
+      // Dispatch the rebuilt sandbox's measured height. Again the source is read
+      // from the recorded handle (now createdSandboxes.at(-1), the object in
+      // sandboxRef.current after the rebuild), so it is guaranteed to match the
+      // listener's current-sandbox guard — the height-700 event can no longer be
+      // rejected for pointing at a stale or not-yet-armed contentWindow.
+      const secondSandbox = createdSandboxes.at(-1)!;
+      expect(secondSandbox).not.toBe(firstSandbox);
 
       // RED pre-fix: the listener was a one-shot that removed itself after the
       // first (500px) measurement, so this second post is never received and the
@@ -1159,7 +1239,7 @@ describe("OpenGenerativeUIActivityRenderer", () => {
         window.dispatchEvent(
           new MessageEvent("message", {
             data: { type: "__ck_resize", height: 700 },
-            source: secondWindow,
+            source: secondSandbox.contentWindow,
           }),
         );
       });

--- a/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
@@ -5,7 +5,11 @@ import { z } from "zod";
 import type { OpenGenerativeUIContent } from "../OpenGenerativeUIRenderer";
 import { OpenGenerativeUIActivityRenderer } from "../OpenGenerativeUIRenderer";
 import { SandboxFunctionsContext } from "../../providers/SandboxFunctionsContext";
-import { OpenGenerativeUIOptionsProvider } from "../../providers/OpenGenerativeUIOptionsContext";
+import {
+  OpenGenerativeUIOptionsProvider,
+  DEFAULT_OPEN_GEN_UI_OPTIONS,
+} from "../../providers/OpenGenerativeUIOptionsContext";
+import { assembleDocument } from "../../lib/assembleDocument";
 import type { SandboxFunction } from "../../types/sandbox-function";
 
 // Mock @jetbrains/websandbox
@@ -1091,21 +1095,32 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       expect(headPayload).toContain("data-ck-design-system");
     });
 
-    // Test E — preview cascade must match the final document's cascade. The
-    // assembled final document (assembleDocument) orders head styles as
-    // kit -> agent's inline <style> blocks (in place) -> agent css param LAST so
-    // the agent css wins equal-specificity ties. The streaming preview must use
-    // the SAME order in its document.head.innerHTML assignment, otherwise an
-    // artifact whose inline style and css param collide at equal specificity
-    // visibly restyles at the preview -> final swap.
+    // Test E — preview cascade must match the FINAL document's cascade
+    // (assembleDocument), region by region. Style extraction is region-aware:
     //
-    // RED pre-fix: the preview pushed the agent css param BEFORE the extracted
-    // inline preview styles, so index(css param) < index(inline style) — the
-    // OPPOSITE of the final document. GREEN post-fix:
-    // index(kit) < index(inline style) < index(css param).
-    it("orders preview head as kit -> inline styles -> agent css (matches final document cascade)", async () => {
+    //   * HEAD-region <style> (before the first <body>) is hoisted into the
+    //     preview <head>, exactly as the final document keeps it in the head.
+    //     Order there: kit -> agent's inline <style> -> agent css param LAST.
+    //   * BODY-region <style> (inside <body>) STAYS in the preview body, exactly
+    //     where the final document keeps it (after the head css in document
+    //     order). It is NOT hoisted.
+    //
+    // If a body-region style were hoisted (the old behavior) it would flip
+    // cascade position at the preview -> final swap, visibly restyling artifacts
+    // whose body <style> and the css param collide at equal specificity.
+
+    // Case A — HEAD-region style: the preview head order (kit < inline < css)
+    // matches assembleDocument's final head cascade for the same full html.
+    it("orders preview head as kit -> head-region inline style -> agent css (matches final document)", async () => {
       const agentCss = "main { color: rebeccapurple; }";
       const inlineStyleContent = ".inline-block { color: seagreen; }";
+      // Full html with the inline style in the HEAD (before <body>). The preview
+      // receives the streaming prefix (no closing tags); the final document
+      // receives the complete html. Both must order the inline style before the
+      // css param and after the kit.
+      const headStyle = `<head><style>${inlineStyleContent}</style></head>`;
+      const previewHtml = `${headStyle}<body><div class="inline-block">Preview body</div>`;
+      const fullHtml = `${headStyle}<body><div class="inline-block">Preview body</div></body>`;
 
       render(
         <OpenGenerativeUIActivityRenderer
@@ -1113,12 +1128,7 @@ describe("OpenGenerativeUIActivityRenderer", () => {
           content={{
             css: agentCss,
             cssComplete: true,
-            // A COMPLETE inline <style> block plus body content. The streaming
-            // pipeline extracts the <style> into previewStyles and strips it from
-            // the previewBody.
-            html: [
-              `<style>${inlineStyleContent}</style><body><div class="inline-block">Preview body</div>`,
-            ],
+            html: [previewHtml],
             htmlComplete: false,
             generating: true,
           }}
@@ -1155,10 +1165,106 @@ describe("OpenGenerativeUIActivityRenderer", () => {
       expect(inlineStyleIdx).toBeGreaterThan(-1);
       expect(agentCssIdx).toBeGreaterThan(-1);
 
-      // Cascade order: kit first, then the agent's inline <style> block, then the
-      // agent css param LAST — identical to assembleDocument's final cascade.
+      // Preview cascade: kit first, then the agent's inline <style>, then the
+      // agent css param LAST.
       expect(kitIdx).toBeLessThan(inlineStyleIdx);
       expect(inlineStyleIdx).toBeLessThan(agentCssIdx);
+
+      // The FINAL document must use the SAME relative order for the same input
+      // and options — that is the parity this test asserts.
+      const finalDoc = assembleDocument(fullHtml, {
+        css: agentCss,
+        designSystemCss: DEFAULT_OPEN_GEN_UI_OPTIONS.designSystemCss,
+        importMap: DEFAULT_OPEN_GEN_UI_OPTIONS.importMap,
+      });
+      const finalKitIdx = finalDoc.indexOf("data-ck-design-system");
+      const finalInlineIdx = finalDoc.indexOf(inlineStyleContent);
+      const finalCssIdx = finalDoc.indexOf(agentCss);
+      expect(finalKitIdx).toBeGreaterThan(-1);
+      expect(finalInlineIdx).toBeGreaterThan(-1);
+      expect(finalCssIdx).toBeGreaterThan(-1);
+      expect(finalKitIdx).toBeLessThan(finalInlineIdx);
+      expect(finalInlineIdx).toBeLessThan(finalCssIdx);
+    });
+
+    // Case B — BODY-region style: the style stays in the PREVIEW BODY (the body
+    // innerHTML run call contains it; the head payload does NOT), matching the
+    // final document where a body-region style also sits in the body after the
+    // head css.
+    //
+    // RED pre-fix: extractCompleteStyles hoisted EVERY style, so this body style
+    // was injected into the preview head and stripped from the preview body —
+    // the opposite of the final document. GREEN post-fix: it is left in the body.
+    it("keeps a body-region style in the preview body, not the head (matches final document)", async () => {
+      const agentCss = "main { color: rebeccapurple; }";
+      const bodyStyleContent = ".body-block { color: seagreen; }";
+      // The complete <style> sits INSIDE <body>, so it is body-region.
+      const bodyStyleTag = `<style>${bodyStyleContent}</style>`;
+      const previewHtml = `<body><div class="body-block">Preview body</div>${bodyStyleTag}`;
+
+      render(
+        <OpenGenerativeUIActivityRenderer
+          activityType="open-generative-ui"
+          content={{
+            css: agentCss,
+            cssComplete: true,
+            html: [previewHtml],
+            htmlComplete: false,
+            generating: true,
+          }}
+          message={{}}
+          agent={{}}
+        />,
+      );
+      await flushImport();
+
+      // Preview sandbox is created
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      // Resolve the preview sandbox promise so the head/body run calls fire
+      await act(async () => {
+        mockPromiseResolve();
+        await mockPromise;
+      });
+      await flushImport();
+
+      // The body innerHTML run call must contain the body-region style block.
+      const bodyCalls = mockRun.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("document.body.innerHTML"),
+      );
+      expect(bodyCalls.length).toBeGreaterThanOrEqual(1);
+      const bodyPayload: string = bodyCalls[bodyCalls.length - 1][0] as string;
+      expect(bodyPayload).toContain(bodyStyleContent);
+
+      // The head payload must NOT contain the body-region style (it was not
+      // hoisted) — only the kit and the agent css param.
+      const headCalls = mockRun.mock.calls.filter(
+        (c: unknown[]) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("document.head.innerHTML"),
+      );
+      expect(headCalls.length).toBeGreaterThanOrEqual(1);
+      const headPayload: string = headCalls[headCalls.length - 1][0] as string;
+      expect(headPayload).not.toContain(bodyStyleContent);
+      expect(headPayload).toContain("data-ck-design-system");
+      expect(headPayload).toContain(agentCss);
+
+      // Final-document parity: a body-region style stays in the BODY, after the
+      // head css in document order (the head css index precedes the body style
+      // index), so the preview and final cascades agree.
+      const fullHtml = `<body><div class="body-block">Preview body</div>${bodyStyleTag}</body>`;
+      const finalDoc = assembleDocument(fullHtml, {
+        css: agentCss,
+        designSystemCss: DEFAULT_OPEN_GEN_UI_OPTIONS.designSystemCss,
+        importMap: DEFAULT_OPEN_GEN_UI_OPTIONS.importMap,
+      });
+      const finalCssIdx = finalDoc.indexOf(agentCss);
+      const finalBodyStyleIdx = finalDoc.indexOf(bodyStyleContent);
+      expect(finalCssIdx).toBeGreaterThan(-1);
+      expect(finalBodyStyleIdx).toBeGreaterThan(-1);
+      expect(finalCssIdx).toBeLessThan(finalBodyStyleIdx);
     });
   });
 });

--- a/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.tsx
@@ -2,10 +2,8 @@ import { render, cleanup, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React from "react";
 import { z } from "zod";
-import {
-  OpenGenerativeUIActivityRenderer,
-  OpenGenerativeUIContent,
-} from "../OpenGenerativeUIRenderer";
+import type { OpenGenerativeUIContent } from "../OpenGenerativeUIRenderer";
+import { OpenGenerativeUIActivityRenderer } from "../OpenGenerativeUIRenderer";
 import { SandboxFunctionsContext } from "../../providers/SandboxFunctionsContext";
 import type { SandboxFunction } from "../../types/sandbox-function";
 
@@ -83,7 +81,8 @@ describe("OpenGenerativeUIActivityRenderer", () => {
 
     expect(mockCreate).toHaveBeenCalledTimes(1);
     const [, options] = mockCreate.mock.calls[0];
-    expect(options.frameContent).toBe(html);
+    // assembleDocument injects importmap + design system kit into the head before agent html
+    expect(options.frameContent).toContain("<body><p>Hello</p></body>");
     expect(options.frameContainer).toBeInstanceOf(HTMLElement);
   });
 
@@ -110,7 +109,9 @@ describe("OpenGenerativeUIActivityRenderer", () => {
 
     expect(mockCreate).toHaveBeenCalledTimes(1);
     const [, options] = mockCreate.mock.calls[0];
-    expect(options.frameContent).toContain("<head></head>");
+    // assembleDocument ensures a <head> exists then injects kit into it
+    expect(options.frameContent).toContain("<head>");
+    expect(options.frameContent).toContain("<body><p>No head</p></body>");
   });
 
   it("joins html chunks when complete", async () => {
@@ -122,7 +123,9 @@ describe("OpenGenerativeUIActivityRenderer", () => {
 
     expect(mockCreate).toHaveBeenCalledTimes(1);
     const [, options] = mockCreate.mock.calls[0];
-    expect(options.frameContent).toBe("<head></head><body><p>Hello</p></body>");
+    // assembleDocument injects importmap + design system kit into the head before agent content
+    expect(options.frameContent).toContain("<body><p>Hello</p></body>");
+    expect(options.frameContent).toContain("<head>");
   });
 
   it("destroys sandbox on unmount", async () => {

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx
@@ -627,9 +627,10 @@ describe("CopilotChat activity message rendering", () => {
     await waitFor(() => {
       expect(mockWebsandboxCreate).toHaveBeenCalledTimes(1);
     });
-    expect(mockWebsandboxCreate.mock.calls[0]?.[1]).toMatchObject({
-      frameContent: restoredHtml,
-    });
+    // assembleDocument injects importmap + design system kit into the head before agent html
+    expect(mockWebsandboxCreate.mock.calls[0]?.[1]?.frameContent).toContain(
+      "<body><div>Restored open generative UI</div></body>",
+    );
 
     unmount();
 
@@ -640,9 +641,10 @@ describe("CopilotChat activity message rendering", () => {
     await waitFor(() => {
       expect(mockWebsandboxCreate).toHaveBeenCalledTimes(2);
     });
-    expect(mockWebsandboxCreate.mock.calls[1]?.[1]).toMatchObject({
-      frameContent: restoredHtml,
-    });
+    // assembleDocument injects importmap + design system kit into the head before agent html
+    expect(mockWebsandboxCreate.mock.calls[1]?.[1]?.frameContent).toContain(
+      "<body><div>Restored open generative UI</div></body>",
+    );
 
     expect(mockWebsandboxDestroy).toHaveBeenCalledTimes(1);
   });

--- a/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
@@ -405,6 +405,45 @@ describe("mergeLibraries", () => {
     expect(out["chart.js/"]).toBe(DEFAULTS["chart.js/"]);
   });
 
+  // (6) esm.sh query idioms (?bundle, ?dev, ?target=es2022) are routine. The
+  // subpath slash must be inserted into the PATH, before the `?`, so the
+  // sibling stays a valid URL — not appended after the query.
+  it("inserts the subpath slash before a query string", () => {
+    const out = mergeLibraries(DEFAULTS, {
+      three: "https://esm.sh/three@0.999.0?bundle",
+    });
+    expect(out.three).toBe("https://esm.sh/three@0.999.0?bundle");
+    expect(out["three/"]).toBe("https://esm.sh/three@0.999.0/?bundle");
+  });
+
+  // (7) Same for a fragment: the slash goes before the `#`, not after it.
+  it("inserts the subpath slash before a fragment", () => {
+    const out = mergeLibraries(DEFAULTS, {
+      three: "https://esm.sh/three@0.999.0#frag",
+    });
+    expect(out.three).toBe("https://esm.sh/three@0.999.0#frag");
+    expect(out["three/"]).toBe("https://esm.sh/three@0.999.0/#frag");
+  });
+
+  // (8) When the path already ends with `/` (before the query), no second slash
+  // is inserted — the sibling is left as-is.
+  it("does not double the slash when the path already ends in one before a query", () => {
+    const out = mergeLibraries(DEFAULTS, {
+      three: "https://esm.sh/three@0.999.0/?bundle",
+    });
+    expect(out.three).toBe("https://esm.sh/three@0.999.0/?bundle");
+    expect(out["three/"]).toBe("https://esm.sh/three@0.999.0/?bundle");
+  });
+
+  // (9) A clean URL with no query or fragment still gets a single trailing slash
+  // (existing behavior preserved).
+  it("appends a single trailing slash to a clean URL with no query or fragment", () => {
+    const out = mergeLibraries(DEFAULTS, {
+      three: "https://esm.sh/three@0.999.0",
+    });
+    expect(out["three/"]).toBe("https://esm.sh/three@0.999.0/");
+  });
+
   // Does not mutate its inputs (the defaults map is a shared module constant).
   it("does not mutate its arguments", () => {
     const defaults = { ...DEFAULTS };

--- a/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
@@ -177,6 +177,42 @@ describe("assembleDocument", () => {
     expect(cssIdx).toBeGreaterThan(titleIdx);
   });
 
+  // Literal-`<head>` normalization: an attributed head-open token
+  // (`<head lang="en">`) is rewritten to the exact 6-char literal `<head>` that
+  // real @jetbrains/websandbox requires to mount (`includes('<head>')` gate +
+  // `replace('<head>', …)` bootstrap, websandbox.js:450/462). The `lang`
+  // attribute is intentionally dropped (head attributes have negligible runtime
+  // semantics and CANNOT be preserved). The full cascade still holds:
+  // importmap -> kit -> agent css, with css immediately before the close.
+  it("normalizes an attributed head-open token to the literal <head> and drops its attributes", () => {
+    const out = assembleDocument(
+      '<head lang="en"><title>t</title></head><body>x</body>',
+      {
+        css: ".a{color:red}",
+        designSystemCss: KIT,
+        importMap: { three: "https://esm.sh/three@0.180.0" },
+      },
+    );
+    // The literal token websandbox demands is present.
+    expect(out).toContain("<head>");
+    // The attributes were dropped: no attributed head-OPEN token survives.
+    // Scoped to this input (which contains no `<header>`), so the broad
+    // `/<head[^>]+>/` cannot false-positive on a `<header …>` element.
+    expect(out).not.toMatch(/<head[^>]+>/);
+    // The original attribute string is gone entirely.
+    expect(out).not.toContain('lang="en"');
+    // Cascade order: importmap -> kit -> agent css.
+    const importmapIdx = out.indexOf('<script type="importmap">');
+    const kitIdx = out.indexOf("data-ck-design-system");
+    const cssIdx = out.indexOf(".a{color:red}");
+    const closeIdx = out.indexOf("</head>");
+    expect(importmapIdx).toBeGreaterThan(-1);
+    expect(importmapIdx).toBeLessThan(kitIdx);
+    expect(kitIdx).toBeLessThan(cssIdx);
+    // …and the agent css lands before the head close tag.
+    expect(cssIdx).toBeLessThan(closeIdx);
+  });
+
   // Close-anchor finding: the agent-css close-tag search must target the SAME
   // head the prefix (importmap + kit) was anchored to. When a stray `</head>`
   // precedes the real `<head>`, the open-tag matcher correctly skips the stray
@@ -315,6 +351,14 @@ describe("assembleDocument", () => {
           // importmap precedes the kit.
           expect(importmapIdx).toBeGreaterThan(-1);
           expect(importmapIdx).toBeLessThan(kitIdx);
+          // The structural lever: real @jetbrains/websandbox refuses to mount
+          // any frameContent lacking the exact lowercase literal `<head>` —
+          // `!frameContent.includes('<head>')` throws and its bootstrap injects
+          // via `replace('<head>', …)` (websandbox.js:450/462). So EVERY
+          // non-legacy output must contain that literal token, including the
+          // uppercase/attributed inputs (`<HEAD >…`, `<head data-x="a>b">…`,
+          // `<head data-config=…>`) whose open tags are normalized to `<head>`.
+          expect(out).toContain("<head>");
           // Exactly one head-opening tag — non-legacy mode never duplicates the
           // head, even for the legacy-quirk inputs (stray close, unclosed head).
           expect(out.match(HEAD_OPEN) ?? []).toHaveLength(1);

--- a/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
@@ -64,6 +64,23 @@ describe("assembleDocument", () => {
     expect(json.imports["three/"]).toMatch(/\/$/);
   });
 
+  it("escapes < in library URLs so the importmap script cannot be terminated early", () => {
+    const script = buildImportMapScript({
+      evil: "https://x.example/lib</script><script>alert(1)//",
+    });
+    // No literal close tag inside the importmap payload (only the real one at the end)
+    expect(script.indexOf("</script>")).toBe(
+      script.length - "</script>".length,
+    );
+    // The escaped JSON still parses back to the original URL
+    const json = JSON.parse(
+      script.replace('<script type="importmap">', "").replace("</script>", ""),
+    );
+    expect(json.imports.evil).toBe(
+      "https://x.example/lib</script><script>alert(1)//",
+    );
+  });
+
   it("matches the legacy path byte-for-byte when designSystemCss and importMap are false", () => {
     // legacy reference implementations, copied verbatim from OpenGenerativeUIRenderer.tsx
     const legacyEnsureHead = (html: string) =>

--- a/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
@@ -77,4 +77,76 @@ describe("assembleDocument", () => {
       }
     }
   });
+
+  // Finding 1: a <header> element preceding a real <head> must not capture the
+  // kit/importmap insertion point. The prefix belongs inside the real <head>.
+  it("inserts kit + importmap into the real <head>, not a preceding <header>", () => {
+    const out = assembleDocument(
+      "<header>Title</header><head></head><body>x</body>",
+      {
+        designSystemCss: KIT,
+        importMap: { three: "https://esm.sh/three@0.180.0" },
+      },
+    );
+    const headerOpen = out.indexOf("<header>");
+    const headerClose = out.indexOf("</header>");
+    const importmapIdx = out.indexOf('<script type="importmap">');
+    const kitIdx = out.indexOf("data-ck-design-system");
+    // The prefix must land after the </header> close tag (i.e. inside the
+    // real <head>), never between <header> and </header>.
+    expect(importmapIdx).toBeGreaterThan(headerClose);
+    expect(kitIdx).toBeGreaterThan(headerClose);
+    // Sanity: the <header> element itself is left untouched.
+    expect(headerOpen).toBeGreaterThan(-1);
+    expect(headerClose).toBeGreaterThan(headerOpen);
+    // Order within the head is preserved: importmap before kit.
+    expect(importmapIdx).toBeLessThan(kitIdx);
+  });
+
+  // Finding 2: an open <head> without a </head> must not produce a second head
+  // nor invert the cascade. Order must be importmap -> kit -> agent css.
+  it("handles an unclosed <head> without duplicating it (importmap -> kit -> css)", () => {
+    const out = assembleDocument("<head><body><p>x</p></body>", {
+      css: ".a{color:red}",
+      designSystemCss: KIT,
+      importMap: { three: "https://esm.sh/three@0.180.0" },
+    });
+    // Exactly one <head opening tag — no duplicate head was prepended.
+    const headOpenings = out.match(/<head(\s[^>]*)?>/gi) ?? [];
+    expect(headOpenings).toHaveLength(1);
+    // Cascade order: importmap, then kit, then agent css.
+    const importmapIdx = out.indexOf('<script type="importmap">');
+    const kitIdx = out.indexOf("data-ck-design-system");
+    const cssIdx = out.indexOf(".a{color:red}");
+    expect(importmapIdx).toBeGreaterThan(-1);
+    expect(importmapIdx).toBeLessThan(kitIdx);
+    expect(kitIdx).toBeLessThan(cssIdx);
+  });
+
+  // Finding 2 (constraint): in PURE LEGACY mode the unclosed-<head> quirk must
+  // remain byte-identical to the legacy algorithm (prepend a second head).
+  it("preserves the legacy prepend-second-head quirk for unclosed <head> in pure legacy mode", () => {
+    const html = "<head><body><p>x</p></body>";
+    const css = ".a{color:red}";
+    // Legacy reference: ensureHead is a no-op (a head-opening tag exists), then
+    // injectCssIntoHtml finds no </head> and prepends a fresh head.
+    const legacy = `<head><style>${css}</style></head>${html}`;
+    const next = assembleDocument(html, {
+      css,
+      designSystemCss: false,
+      importMap: false,
+    });
+    expect(next).toBe(legacy);
+  });
+
+  // Finding 3: an empty importMap object must not emit an inert importmap script.
+  it("emits no importmap script when importMap is an empty object", () => {
+    const out = assembleDocument("<head></head><body></body>", {
+      designSystemCss: KIT,
+      importMap: {},
+    });
+    expect(out).not.toContain('<script type="importmap">');
+    // The kit still injects normally.
+    expect(out).toContain("data-ck-design-system");
+  });
 });

--- a/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
@@ -5,6 +5,18 @@ import {
   DEFAULT_OPEN_GEN_UI_LIBRARIES,
 } from "../assembleDocument";
 
+// Legacy reference implementations, copied verbatim from
+// OpenGenerativeUIRenderer.tsx. Hoisted to module scope so the invariant sweep
+// can reuse them without re-declaring on every test invocation.
+const legacyEnsureHeadRef = (html: string) =>
+  /<head[\s>]/i.test(html) ? html : `<head></head>${html}`;
+const legacyInjectRef = (html: string, css: string) => {
+  const i = html.indexOf("</head>");
+  return i !== -1
+    ? html.slice(0, i) + `<style>${css}</style>` + html.slice(i)
+    : `<head><style>${css}</style></head>${html}`;
+};
+
 describe("assembleDocument", () => {
   const KIT = "body{--x:1}";
 
@@ -148,5 +160,92 @@ describe("assembleDocument", () => {
     expect(out).not.toContain('<script type="importmap">');
     // The kit still injects normally.
     expect(out).toContain("data-ck-design-system");
+  });
+
+  // Convergence sweep: a single input matrix that pins the two invariants this
+  // function keeps drifting on — (1) byte-identity to legacy when no prefix is
+  // injected, and (2) no duplicate head / correct cascade order in non-legacy
+  // mode. Adding a degenerate input here is cheaper than discovering the next
+  // off-by-one in production.
+  describe("input-matrix invariant sweep", () => {
+    // Reuse the module-scoped legacy reference implementations (verbatim from
+    // OpenGenerativeUIRenderer.tsx, identical to the byte-equivalence test).
+    const legacyEnsureHead = legacyEnsureHeadRef;
+    const legacyInject = legacyInjectRef;
+
+    const INPUTS = [
+      "<head></head><body>a</body>",
+      "<body>b</body>",
+      "<div>c</div>",
+      "</head><body>x</body>", // stray close before open
+      "foo</head>bar",
+      "<head><body>unclosed</body>", // open without close
+      "<HEAD ><title>t</title></HEAD><body>u</body>", // uppercase + attr-ish
+      '<head data-x="1"><title>t</title></head><body>v</body>', // attributes
+      "<header>h</header><head></head><body>w</body>", // header before head
+      "<header>only</header><div>z</div>", // header, no head
+    ];
+    const CSS = [undefined, ".x{}"];
+    // A real head-opening tag: `<head>` or `<head ...attrs>`, excluding
+    // `<header ...>`. Non-legacy mode must never emit more than one.
+    const HEAD_OPEN = /<head(\s[^>]*)?>/gi;
+
+    // (1) LEGACY MODE — byte-identical to the legacy reference for every input ×
+    // css, under BOTH `importMap: false` and `importMap: {}` (an empty importmap
+    // injects no prefix, so it must behave exactly like pure legacy).
+    for (const importMap of [false, {} as Record<string, string>]) {
+      const label = importMap === false ? "importMap:false" : "importMap:{}";
+      for (const html of INPUTS) {
+        for (const css of CSS) {
+          it(`legacy byte-identity (${label}) — ${JSON.stringify(
+            html,
+          )} / css=${JSON.stringify(css)}`, () => {
+            const legacy = legacyEnsureHead(
+              css ? legacyInject(html, css) : html,
+            );
+            const next = assembleDocument(html, {
+              css,
+              designSystemCss: false,
+              importMap,
+            });
+            expect(next).toBe(legacy);
+          });
+        }
+      }
+    }
+
+    // (2) NON-LEGACY MODE — kit string + one pinned library. Assert the cascade
+    // order invariants and that exactly one head-opening tag exists. Bytes are
+    // not pinned here because the prefix legitimately changes the output.
+    const PINNED = { three: "https://esm.sh/three@0.180.0" };
+    for (const html of INPUTS) {
+      for (const css of CSS) {
+        it(`non-legacy order + single head — ${JSON.stringify(
+          html,
+        )} / css=${JSON.stringify(css)}`, () => {
+          const out = assembleDocument(html, {
+            css,
+            designSystemCss: KIT,
+            importMap: PINNED,
+          });
+          const importmapIdx = out.indexOf('<script type="importmap">');
+          const kitIdx = out.indexOf("data-ck-design-system");
+          // importmap precedes the kit.
+          expect(importmapIdx).toBeGreaterThan(-1);
+          expect(importmapIdx).toBeLessThan(kitIdx);
+          // Exactly one head-opening tag — non-legacy mode never duplicates the
+          // head, even for the legacy-quirk inputs (stray close, unclosed head).
+          expect(out.match(HEAD_OPEN) ?? []).toHaveLength(1);
+          if (css) {
+            const cssMarker = ".x{}";
+            const cssIdx = out.indexOf(cssMarker);
+            // Agent css follows the kit…
+            expect(kitIdx).toBeLessThan(cssIdx);
+            // …and appears exactly once.
+            expect(out.split(cssMarker)).toHaveLength(2);
+          }
+        });
+      }
+    }
   });
 });

--- a/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
@@ -222,6 +222,62 @@ describe("assembleDocument", () => {
     expect(kitIdx).toBeLessThan(cssIdx);
   });
 
+  // Close-anchor finding (unclosed head, implicit body close): when an UNCLOSED
+  // `<head>` carries author in-head content and is implicitly closed by the
+  // first `<body>`, the agent css must land JUST BEFORE that `<body>` — i.e.
+  // AFTER the author's in-head styles — preserving the everywhere-else cascade
+  // (author head content first, agent css last). RED pre-fix: the css spliced
+  // right after the kit/importmap prefix, ahead of the author's in-head styles,
+  // inverting the cascade for an unclosed head (and flipping order at the
+  // streaming-preview→final swap, which hoists author styles before the css).
+  it("anchors agent css to the implicit head close (before <body>) for an unclosed head", () => {
+    const out = assembleDocument("<head><style>.a{}</style><body>x</body>", {
+      css: ".agent{color:red}",
+      designSystemCss: KIT,
+      importMap: { three: "https://esm.sh/three@0.180.0" },
+    });
+    // Exactly one head-open tag — no duplicate head was prepended.
+    const headOpenings =
+      out.match(/<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi) ?? [];
+    expect(headOpenings).toHaveLength(1);
+    const importmapIdx = out.indexOf('<script type="importmap">');
+    const kitIdx = out.indexOf("data-ck-design-system");
+    const authorIdx = out.indexOf(".a{}");
+    const agentIdx = out.indexOf(".agent{color:red}");
+    const bodyIdx = out.search(/<body[\s>]/);
+    expect(importmapIdx).toBeGreaterThan(-1);
+    expect(authorIdx).toBeGreaterThan(-1);
+    expect(agentIdx).toBeGreaterThan(-1);
+    expect(bodyIdx).toBeGreaterThan(-1);
+    // Full cascade: importmap -> kit -> author in-head style -> agent css ->
+    // <body>. The agent css is the LAST thing in the head (just before <body>).
+    expect(importmapIdx).toBeLessThan(kitIdx);
+    expect(kitIdx).toBeLessThan(authorIdx);
+    expect(authorIdx).toBeLessThan(agentIdx);
+    expect(agentIdx).toBeLessThan(bodyIdx);
+  });
+
+  // Close-anchor finding (unclosed head, NO body): with neither a `</head>` nor
+  // a `<body>` to anchor to, the css must fall back to landing right after the
+  // kit/importmap prefix (no duplicate head). This pins the current fallback.
+  it("places agent css right after the prefix for an unclosed head with no body", () => {
+    const out = assembleDocument("<head><p>x</p>", {
+      css: ".agent{color:red}",
+      designSystemCss: KIT,
+      importMap: { three: "https://esm.sh/three@0.180.0" },
+    });
+    const headOpenings =
+      out.match(/<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi) ?? [];
+    expect(headOpenings).toHaveLength(1);
+    const kitIdx = out.indexOf("data-ck-design-system");
+    const agentIdx = out.indexOf(".agent{color:red}");
+    const pIdx = out.indexOf("<p>");
+    // Cascade: kit then agent css, and the css sits right after the prefix —
+    // before the author's `<p>` content (the post-prefix fallback).
+    expect(kitIdx).toBeLessThan(agentIdx);
+    expect(agentIdx).toBeLessThan(pIdx);
+  });
+
   // Finding 2 (constraint): in PURE LEGACY mode the unclosed-<head> quirk must
   // remain byte-identical to the legacy algorithm (prepend a second head).
   it("preserves the legacy prepend-second-head quirk for unclosed <head> in pure legacy mode", () => {

--- a/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  assembleDocument,
+  buildImportMapScript,
+  DEFAULT_OPEN_GEN_UI_LIBRARIES,
+} from "../assembleDocument";
+
+describe("assembleDocument", () => {
+  const KIT = "body{--x:1}";
+
+  it("injects importmap then kit at head start, in order", () => {
+    const out = assembleDocument("<head><title>t</title></head><body></body>", {
+      designSystemCss: KIT,
+      importMap: { three: "https://esm.sh/three@0.180.0" },
+    });
+    const importmapIdx = out.indexOf('<script type="importmap">');
+    const kitIdx = out.indexOf("data-ck-design-system");
+    const titleIdx = out.indexOf("<title>");
+    expect(importmapIdx).toBeGreaterThan(-1);
+    expect(importmapIdx).toBeLessThan(kitIdx);
+    expect(kitIdx).toBeLessThan(titleIdx);
+  });
+
+  it("creates a head when html has none", () => {
+    const out = assembleDocument("<body><p>x</p></body>", {
+      designSystemCss: KIT,
+      importMap: false,
+    });
+    expect(out).toMatch(/^<head>/);
+    expect(out).toContain("data-ck-design-system");
+  });
+
+  it("injects agent css before </head>, after the kit", () => {
+    const out = assembleDocument("<head></head><body></body>", {
+      css: ".a{color:red}",
+      designSystemCss: KIT,
+      importMap: false,
+    });
+    expect(out.indexOf("data-ck-design-system")).toBeLessThan(
+      out.indexOf(".a{color:red}"),
+    );
+    expect(out.indexOf(".a{color:red}")).toBeLessThan(out.indexOf("</head>"));
+  });
+
+  it("emits valid importmap JSON with the pinned defaults", () => {
+    const script = buildImportMapScript(DEFAULT_OPEN_GEN_UI_LIBRARIES);
+    const json = JSON.parse(
+      script.replace('<script type="importmap">', "").replace("</script>", ""),
+    );
+    expect(json.imports.three).toMatch(/^https:\/\/esm\.sh\/three@\d/);
+    expect(json.imports["three/"]).toMatch(/\/$/);
+  });
+
+  it("matches the legacy path byte-for-byte when designSystemCss and importMap are false", () => {
+    // legacy reference implementations, copied verbatim from OpenGenerativeUIRenderer.tsx
+    const legacyEnsureHead = (html: string) =>
+      /<head[\s>]/i.test(html) ? html : `<head></head>${html}`;
+    const legacyInject = (html: string, css: string) => {
+      const i = html.indexOf("</head>");
+      return i !== -1
+        ? html.slice(0, i) + `<style>${css}</style>` + html.slice(i)
+        : `<head><style>${css}</style></head>${html}`;
+    };
+    for (const html of [
+      "<head></head><body>a</body>",
+      "<body>b</body>",
+      "<div>c</div>",
+    ]) {
+      for (const css of [undefined, ".x{}"]) {
+        const legacy = legacyEnsureHead(css ? legacyInject(html, css) : html);
+        const next = assembleDocument(html, {
+          css,
+          designSystemCss: false,
+          importMap: false,
+        });
+        expect(next).toBe(legacy);
+      }
+    }
+  });
+});

--- a/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   assembleDocument,
   buildImportMapScript,
+  escapeStyleClose,
   DEFAULT_OPEN_GEN_UI_LIBRARIES,
   mergeLibraries,
 } from "../assembleDocument";
@@ -9,13 +10,20 @@ import {
 // Legacy reference implementations, copied verbatim from
 // OpenGenerativeUIRenderer.tsx. Hoisted to module scope so the invariant sweep
 // can reuse them without re-declaring on every test invocation.
+//
+// `legacyInjectRef` models the NEW legacy contract: the agent css is
+// `</style`-escaped (escapeStyleClose) before splicing — the second byte-identity
+// carve-out alongside head-token mount normalization. For css WITHOUT `</style`
+// this is byte-identical to the historical injector (the escape is a no-op); for
+// css WITH `</style` it differs ONLY by the inserted backslashes.
 const legacyEnsureHeadRef = (html: string) =>
   /<head[\s>]/i.test(html) ? html : `<head></head>${html}`;
 const legacyInjectRef = (html: string, css: string) => {
+  const safe = escapeStyleClose(css);
   const i = html.indexOf("</head>");
   return i !== -1
-    ? html.slice(0, i) + `<style>${css}</style>` + html.slice(i)
-    : `<head><style>${css}</style></head>${html}`;
+    ? html.slice(0, i) + `<style>${safe}</style>` + html.slice(i)
+    : `<head><style>${safe}</style></head>${html}`;
 };
 
 describe("assembleDocument", () => {
@@ -81,15 +89,151 @@ describe("assembleDocument", () => {
     );
   });
 
+  // -------------------------------------------------------------------------
+  // `</style`-escape — agent css (`css` param) and kit css (`designSystemCss`)
+  // are spliced RAW into `<style>…</style>` elements. A css value containing
+  // `</style` would close the element early and turn whatever follows into LIVE
+  // markup in the sandbox. escapeStyleClose neutralizes it losslessly at every
+  // sink — the analog of the `<`-escape buildImportMapScript applies to the
+  // importmap sink.
+  // -------------------------------------------------------------------------
+
+  // Helper-level semantics the Vue side must mirror byte-for-byte.
+  describe("escapeStyleClose", () => {
+    it("inserts a backslash into the `/` of every </style (case-insensitive, case-preserving)", () => {
+      expect(escapeStyleClose("a{}</style>b")).toBe("a{}<\\/style>b");
+      // Case of `/style` is preserved via $1.
+      expect(escapeStyleClose("</STYLE>")).toBe("<\\/STYLE>");
+      expect(escapeStyleClose("</StYlE >")).toBe("<\\/StYlE >");
+      // Every occurrence is escaped (global flag).
+      expect(escapeStyleClose("</style></style>")).toBe("<\\/style><\\/style>");
+    });
+
+    it("is a no-op for css that does not contain </style", () => {
+      const css = "body { color: red } .a::before { content: '/style' }";
+      // No `</style` sequence anywhere, so the string is returned unchanged.
+      expect(escapeStyleClose(css)).toBe(css);
+    });
+
+    it("does not touch a `</ style>` with whitespace after the slash (the HTML parser would not close on it either)", () => {
+      // The raw-text end-tag scan does not permit whitespace between `/` and the
+      // tag name, so `</ style>` never closes a real <style> element — and the
+      // regex (which matches the parser's close exactly) leaves it untouched.
+      expect(escapeStyleClose("</ style>")).toBe("</ style>");
+    });
+  });
+
+  // Live-script breakout repro at the agent-css sink (non-legacy path). RED
+  // pre-fix: the agent's `</style>` closed the injected style element early and
+  // the trailing `<script>` became LIVE markup in the sandbox. GREEN post-fix:
+  // the close is escaped (`<\/style>`), so the `<script>` stays inert CSS text
+  // inside the style element.
+  it("neutralizes a </style><script> breakout in the agent css (non-legacy)", () => {
+    const css = "a{}</style><script>alert(1)</script>";
+    const out = assembleDocument("<head></head><body></body>", {
+      css,
+      designSystemCss: KIT,
+      importMap: { three: "https://esm.sh/three@0.180.0" },
+    });
+    // The live-breakout signature — a REAL `</style>` immediately followed by a
+    // `<script` open — must be ABSENT (pre-fix it was present).
+    expect(out).not.toContain("</style><script");
+    // No live `<script>alert` survives: every `<script` in the output is
+    // preceded by an ESCAPED close (`<\/style>`), so it is inert style text.
+    // (There is no other real script in this input.)
+    expect(out).not.toMatch(/<\/style>\s*<script/i);
+    // The escaped form is present (the `/` carries a CSS backslash).
+    expect(out).toContain("a{}<\\/style><script>alert(1)</script>");
+    // Style tags stay perfectly balanced (the only real closes are the kit's and
+    // the agent style's own template close — the agent's literal `</style>` no
+    // longer counts as a close).
+    const opens = (out.match(/<style\b/gi) ?? []).length;
+    const closes = (out.match(/<\/style>/gi) ?? []).length;
+    expect(opens).toBe(closes);
+  });
+
+  // Same breakout via the kit css (designSystemCss). The kit string is
+  // operator/designer-supplied via `designSystem: { css }`; escaping it keeps
+  // the breakout protection consistent with the agent-css sink.
+  it("neutralizes a </style><script> breakout in the design-system kit css", () => {
+    const evilKit = "body{}</style><script>alert(2)</script>";
+    const out = assembleDocument("<head></head><body></body>", {
+      designSystemCss: evilKit,
+      importMap: false,
+    });
+    expect(out).not.toContain("</style><script");
+    expect(out).not.toMatch(/<\/style>\s*<script/i);
+    // The kit style element carries the escaped close.
+    expect(out).toContain(
+      "data-ck-design-system>body{}<\\/style><script>alert(2)</script>",
+    );
+    const opens = (out.match(/<style\b/gi) ?? []).length;
+    const closes = (out.match(/<\/style>/gi) ?? []).length;
+    expect(opens).toBe(closes);
+  });
+
+  // Lossless case: a legitimate `content: "</style>"` keeps IDENTICAL computed
+  // CSS semantics — inside a CSS string `\/` unescapes to `/`. Only the bytes
+  // that reach the HTML tokenizer change (the `/` gains a backslash), never the
+  // value the CSS parser sees.
+  it('escapes a legitimate content: "</style>" losslessly (non-legacy)', () => {
+    const css = '.a::before { content: "</style>" }';
+    const out = assembleDocument("<head></head><body></body>", {
+      css,
+      designSystemCss: KIT,
+      importMap: false,
+    });
+    // The escaped form is emitted (the `/` is backslash-escaped inside the
+    // string), so the style element is never terminated early…
+    expect(out).toContain('.a::before { content: "<\\/style>" }');
+    // …and the raw, breakout-capable form (the agent's `</style>` as a REAL
+    // close) is gone. (Note: a kit-close immediately followed by the agent
+    // style-open — `</style><style>` — is a NORMAL, valid sequence and is not
+    // what we guard against; we guard against the agent's content closing the
+    // element.)
+    expect(out).not.toContain('content: "</style>"');
+    // Style tags stay balanced — the escaped `<\/style>` inside the string does
+    // not count as a real close.
+    const opens = (out.match(/<style\b/gi) ?? []).length;
+    const closes = (out.match(/<\/style>/gi) ?? []).length;
+    expect(opens).toBe(closes);
+  });
+
+  // Legacy path (designSystemCss: false, importMap: false): the agent css is
+  // escaped before the legacy injector splices it. RED pre-fix: the legacy path
+  // spliced the css RAW, so a `</style` broke out of the style element.
+  it("escapes </style in the agent css on the legacy path", () => {
+    const css = "a{}</style><script>alert(3)</script>";
+    const out = assembleDocument("<head></head><body>x</body>", {
+      css,
+      designSystemCss: false,
+      importMap: false,
+    });
+    // No prefix on the legacy path…
+    expect(out).not.toContain("data-ck-design-system");
+    expect(out).not.toContain('<script type="importmap">');
+    // …but the agent css is still `</style`-escaped (the breakout is gone).
+    expect(out).not.toContain("</style><script");
+    expect(out).toContain(
+      "<style>a{}<\\/style><script>alert(3)</script></style>",
+    );
+    // And it equals the NEW legacy reference exactly (byte-for-byte, modulo the
+    // escape that the reference now models).
+    expect(out).toBe(legacyInjectRef("<head></head><body>x</body>", css));
+  });
+
   it("matches the legacy path byte-for-byte when designSystemCss and importMap are false (inputs whose legacy output already contains literal <head>)", () => {
-    // legacy reference implementations, copied verbatim from OpenGenerativeUIRenderer.tsx
+    // legacy reference implementations, copied verbatim from OpenGenerativeUIRenderer.tsx.
+    // The injector applies the NEW `</style`-escape carve-out (a no-op for css
+    // without `</style`, so byte-identity holds for these fixtures).
     const legacyEnsureHead = (html: string) =>
       /<head[\s>]/i.test(html) ? html : `<head></head>${html}`;
     const legacyInject = (html: string, css: string) => {
+      const safe = escapeStyleClose(css);
       const i = html.indexOf("</head>");
       return i !== -1
-        ? html.slice(0, i) + `<style>${css}</style>` + html.slice(i)
-        : `<head><style>${css}</style></head>${html}`;
+        ? html.slice(0, i) + `<style>${safe}</style>` + html.slice(i)
+        : `<head><style>${safe}</style></head>${html}`;
     };
     // These inputs all produce a legacy output containing the literal lowercase
     // `<head>` token (the new contract returns L unchanged for exactly those).
@@ -681,7 +825,11 @@ describe("assembleDocument", () => {
       "foo</head><head><title>t</title></head><body>x</body>", // stray close before the real head — agent css must anchor to the real head's close, not the earlier stray
       "</head><head></head><body>z</body>", // leading stray close before the real head — same close-anchor hazard
     ];
-    const CSS = [undefined, ".x{}"];
+    // The third fixture carries a `</style` breakout sequence: every sink must
+    // `</style`-escape it (legacy AND non-legacy). The legacy reference models
+    // the escape via legacyInject; the non-legacy assertion below matches the
+    // ESCAPED marker.
+    const CSS = [undefined, ".x{}", "a{}</style><script>alert(1)</script>"];
     // A real head-opening tag: `<head>` or `<head ...attrs>`, excluding
     // `<header ...>`. The quote-aware attribute span (matching the production
     // insertion regex) bounds the tag so it can never swallow a following
@@ -796,12 +944,18 @@ describe("assembleDocument", () => {
           // separately in the "retains a second authored head" tests below.
           expect(out.match(HEAD_OPEN) ?? []).toHaveLength(1);
           if (css) {
-            const cssMarker = ".x{}";
+            // The css is spliced through escapeStyleClose, so the marker we
+            // search for is the ESCAPED form (a no-op for `.x{}`; for the
+            // `</style`-bearing fixture the `/` gains a backslash).
+            const cssMarker = escapeStyleClose(css);
             const cssIdx = out.indexOf(cssMarker);
             // Agent css follows the kit…
             expect(kitIdx).toBeLessThan(cssIdx);
             // …and appears exactly once.
             expect(out.split(cssMarker)).toHaveLength(2);
+            // The breakout signature is never present — the escape holds for
+            // EVERY input shape in the matrix, not just the well-formed ones.
+            expect(out).not.toContain("</style><script");
           }
         });
       }

--- a/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
@@ -124,7 +124,8 @@ describe("assembleDocument", () => {
       importMap: { three: "https://esm.sh/three@0.180.0" },
     });
     // Exactly one <head opening tag — no duplicate head was prepended.
-    const headOpenings = out.match(/<head(\s[^<>]*)?>/gi) ?? [];
+    const headOpenings =
+      out.match(/<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi) ?? [];
     expect(headOpenings).toHaveLength(1);
     // Cascade order: importmap, then kit, then agent css.
     const importmapIdx = out.indexOf('<script type="importmap">');
@@ -149,6 +150,30 @@ describe("assembleDocument", () => {
       importMap: false,
     });
     expect(next).toBe(legacy);
+  });
+
+  // Quote-aware head tokenization + case-insensitive close lookup: for an
+  // uppercase head with no lowercase `</head>`, the agent css must land
+  // immediately before the (uppercase) close tag — i.e. AFTER the head's
+  // existing content — not right after the kit. A case-sensitive
+  // `indexOf("</head>")` would miss `</HEAD>` and drop the css after the kit,
+  // inverting the css-wins-over-head-content cascade.
+  it("places agent css before the uppercase close tag (after head content)", () => {
+    const out = assembleDocument(
+      "<HEAD ><title>t</title></HEAD><body>u</body>",
+      {
+        css: ".a{color:red}",
+        designSystemCss: KIT,
+        importMap: { three: "https://esm.sh/three@0.180.0" },
+      },
+    );
+    const titleIdx = out.indexOf("<title>");
+    const cssIdx = out.indexOf(".a{color:red}");
+    expect(titleIdx).toBeGreaterThan(-1);
+    expect(cssIdx).toBeGreaterThan(-1);
+    // Agent css lands after the head's content (the <title>), i.e. immediately
+    // before the close tag — not right after the kit.
+    expect(cssIdx).toBeGreaterThan(titleIdx);
   });
 
   // Finding 3: an empty importMap object must not emit an inert importmap script.
@@ -187,13 +212,16 @@ describe("assembleDocument", () => {
       "<head \nclass=x", // unterminated head token (no `>`) — must not drop prefix
       "<head\tfoo", // unterminated head token, tab + bareword — must not drop prefix
       "a<head\t<body>z</body>", // head token whose attr span runs into <body> — prefix must stay out of the body
+      '<head data-x="a>b"><title>t</title></head><body>v</body>', // quoted `>` in attribute — must not splice mid-attribute
+      '<head data-config=\'{"a":">"}\'>x</head><body>y</body>', // quoted `>` in single-quoted attribute — must not splice mid-attribute
     ];
     const CSS = [undefined, ".x{}"];
     // A real head-opening tag: `<head>` or `<head ...attrs>`, excluding
-    // `<header ...>`. `[^<>]*` (matching the production insertion regex) bounds
-    // the attribute span so a tag can never swallow a following `<tag>`.
+    // `<header ...>`. The quote-aware attribute span (matching the production
+    // insertion regex) bounds the tag so it can never swallow a following
+    // `<tag>`, while still tolerating a quoted `>` inside an attribute value.
     // Non-legacy mode must never emit more than one.
-    const HEAD_OPEN = /<head(\s[^<>]*)?>/gi;
+    const HEAD_OPEN = /<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi;
 
     // (1) LEGACY MODE — byte-identical to the legacy reference for every input ×
     // css, under BOTH `importMap: false` and `importMap: {}` (an empty importmap

--- a/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
@@ -400,6 +400,167 @@ describe("assembleDocument", () => {
     expect(cssIdx).toBeLessThan(realHeadCloseIdx);
   });
 
+  // Multi-authored-head retention (NON-LEGACY path). When the author's markup
+  // already contains TWO complete `<head>` elements, `assembleDocument` does not
+  // try to repair it: the prefix (importmap + kit) is spliced into the FIRST
+  // head exactly once, the agent css anchors to the FIRST head's close, and the
+  // SECOND authored head is retained VERBATIM. This is correct behavior — the
+  // final document mounts the author's markup, browsers ignore a duplicate head,
+  // and websandbox only needs the literal `<head>` token to mount. The function
+  // never CREATES a duplicate head (the sweep above pins that for ≤1-head
+  // inputs); it simply doesn't synthesize a second authored head away. These
+  // tests pin the retention so it can't silently regress into a "repair" that
+  // would rewrite author markup.
+  //
+  // GREEN from the start: these pin EXISTING behavior, not a fix.
+  it("retains a second authored head verbatim and injects the prefix into the first (non-legacy)", () => {
+    const html = "<head></head><head></head><body>x</body>";
+    const out = assembleDocument(html, {
+      css: ".a{color:red}",
+      designSystemCss: KIT,
+      importMap: { three: "https://esm.sh/three@0.180.0" },
+    });
+    // Exact shape: prefix + agent css land inside the FIRST head; the second
+    // authored head (`<head></head>`) survives untouched after the first close.
+    expect(out).toBe(
+      '<head><script type="importmap">{"imports":{"three":"https://esm.sh/three@0.180.0"}}</script>' +
+        "<style data-ck-design-system>body{--x:1}</style>" +
+        "<style>.a{color:red}</style></head>" +
+        "<head></head><body>x</body>",
+    );
+    // Exactly ONE prefix instance (importmap + kit) in the whole output — the
+    // second head did NOT get its own copy.
+    expect(out.split('<script type="importmap">')).toHaveLength(2);
+    expect(out.split("data-ck-design-system")).toHaveLength(2);
+    // The agent css also appears exactly once (anchored to the first head only).
+    expect(out.split(".a{color:red}")).toHaveLength(2);
+    // BOTH authored heads are retained — the function did not collapse them.
+    const HEAD_OPEN = /<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi;
+    expect(out.match(HEAD_OPEN) ?? []).toHaveLength(2);
+    // The literal token websandbox demands is present.
+    expect(out).toContain("<head>");
+    // The prefix/css anchor to the FIRST head: every prefix/css marker precedes
+    // the FIRST `</head>` (the first head's close).
+    const firstHeadClose = out.indexOf("</head>");
+    expect(out.indexOf('<script type="importmap">')).toBeLessThan(
+      firstHeadClose,
+    );
+    expect(out.indexOf("data-ck-design-system")).toBeLessThan(firstHeadClose);
+    expect(out.indexOf(".a{color:red}")).toBeLessThan(firstHeadClose);
+    // The second authored head opens AFTER the first head's close (retained as
+    // a distinct, empty head — not merged into the first).
+    expect(out.indexOf("<head>", firstHeadClose)).toBeGreaterThan(
+      firstHeadClose,
+    );
+  });
+
+  it("retains the second authored head with content (non-legacy, two heads each carrying content)", () => {
+    const html =
+      "<head><title>one</title></head><head><meta></head><body>x</body>";
+    const out = assembleDocument(html, {
+      css: ".a{color:red}",
+      designSystemCss: KIT,
+      importMap: { three: "https://esm.sh/three@0.180.0" },
+    });
+    // Cascade INSIDE the first head: importmap -> kit -> author content
+    // (`<title>`) -> agent css -> first close. The SECOND head (`<head><meta>
+    // </head>`) is retained verbatim after the first close.
+    expect(out).toBe(
+      '<head><script type="importmap">{"imports":{"three":"https://esm.sh/three@0.180.0"}}</script>' +
+        "<style data-ck-design-system>body{--x:1}</style>" +
+        "<title>one</title>" +
+        "<style>.a{color:red}</style></head>" +
+        "<head><meta></head><body>x</body>",
+    );
+    // Exactly one prefix/kit/css instance; the second head got none.
+    expect(out.split('<script type="importmap">')).toHaveLength(2);
+    expect(out.split("data-ck-design-system")).toHaveLength(2);
+    expect(out.split(".a{color:red}")).toHaveLength(2);
+    // The second head's content (`<meta>`) is preserved verbatim.
+    expect(out).toContain("<head><meta></head>");
+  });
+
+  it("retains a second lowercase head after normalizing an uppercase <HEAD> first head (non-legacy)", () => {
+    const html = "<HEAD></HEAD><head></head><body>x</body>";
+    const out = assembleDocument(html, {
+      css: ".a{color:red}",
+      designSystemCss: KIT,
+      importMap: { three: "https://esm.sh/three@0.180.0" },
+    });
+    // The FIRST head's uppercase OPEN tag (`<HEAD>`) is normalized to the
+    // literal `<head>` while the prefix is spliced; the agent css anchors to the
+    // first head's (uppercase) close `</HEAD>` (the close lookup is
+    // case-insensitive). The SECOND authored head (`<head></head>`) is retained
+    // verbatim. The first head's uppercase CLOSE tag is NOT rewritten (only the
+    // open token websandbox gates on is normalized).
+    expect(out).toBe(
+      '<head><script type="importmap">{"imports":{"three":"https://esm.sh/three@0.180.0"}}</script>' +
+        "<style data-ck-design-system>body{--x:1}</style>" +
+        "<style>.a{color:red}</style></HEAD>" +
+        "<head></head><body>x</body>",
+    );
+    // Exactly one prefix/kit/css instance.
+    expect(out.split('<script type="importmap">')).toHaveLength(2);
+    expect(out.split("data-ck-design-system")).toHaveLength(2);
+    expect(out.split(".a{color:red}")).toHaveLength(2);
+    // websandbox's literal lowercase token is present (the first open tag was
+    // normalized from `<HEAD>`).
+    expect(out).toContain("<head>");
+    // The second authored head is retained verbatim.
+    expect(out).toContain("<head></head>");
+  });
+
+  // Multi-authored-head retention (LEGACY path). When no prefix is injected and
+  // the legacy output already contains the literal `<head>`, a multi-head input
+  // stays BYTE-IDENTICAL to the historical `injectCssIntoHtml`/`ensureHead`
+  // composition: the legacy css injector splices at the FIRST `</head>` (via
+  // `indexOf("</head>")`), and BOTH authored heads are retained. This mirrors
+  // the byte-identity guarantee the sweep pins for ≤1-head inputs.
+  //
+  // GREEN from the start: pins existing legacy byte-identity.
+  it("keeps a multi-head input byte-identical in the legacy path (no css)", () => {
+    const html = "<head></head><head></head><body>x</body>";
+    // Legacy reference: ensureHead is a no-op (a `<head` exists), no css to
+    // inject — the input is returned verbatim, and it already contains the
+    // literal `<head>`, so the carve-out returns it UNCHANGED.
+    const legacy = legacyEnsureHeadRef(html);
+    const out = assembleDocument(html, {
+      designSystemCss: false,
+      importMap: false,
+    });
+    expect(out).toBe(legacy);
+    expect(out).toBe(html);
+    const HEAD_OPEN = /<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi;
+    expect(out.match(HEAD_OPEN) ?? []).toHaveLength(2);
+    // No kit/importmap on the disabled path.
+    expect(out).not.toContain("data-ck-design-system");
+    expect(out).not.toContain('<script type="importmap">');
+  });
+
+  it("keeps a multi-head input byte-identical in the legacy path (css splices at the first close)", () => {
+    const html = "<head></head><head></head><body>x</body>";
+    const css = ".a{color:red}";
+    // Legacy reference: injectCssIntoHtml finds the FIRST `</head>` and splices
+    // the css there; ensureHead is then a no-op. The result already contains the
+    // literal `<head>`, so the carve-out returns it UNCHANGED.
+    const legacy = legacyEnsureHeadRef(legacyInjectRef(html, css));
+    const out = assembleDocument(html, {
+      css,
+      designSystemCss: false,
+      importMap: false,
+    });
+    expect(out).toBe(legacy);
+    expect(out).toBe(
+      "<head><style>.a{color:red}</style></head><head></head><body>x</body>",
+    );
+    // Both authored heads retained; css appears exactly once at the first close.
+    const HEAD_OPEN = /<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi;
+    expect(out.match(HEAD_OPEN) ?? []).toHaveLength(2);
+    expect(out.split(css)).toHaveLength(2);
+    expect(out).not.toContain("data-ck-design-system");
+    expect(out).not.toContain('<script type="importmap">');
+  });
+
   // Finding 3: an empty importMap object must not emit an inert importmap script.
   it("emits no importmap script when importMap is an empty object", () => {
     const out = assembleDocument("<head></head><body></body>", {
@@ -592,8 +753,11 @@ describe("assembleDocument", () => {
     }
 
     // (2) NON-LEGACY MODE — kit string + one pinned library. Assert the cascade
-    // order invariants and that exactly one head-opening tag exists. Bytes are
-    // not pinned here because the prefix legitimately changes the output.
+    // order invariants and that exactly one head-opening tag exists FOR THIS
+    // MATRIX (every INPUT carries at most one authored head, and the non-legacy
+    // path never CREATES a head it did not author — see the per-assertion note
+    // below; multi-authored-head retention is pinned separately). Bytes are not
+    // pinned here because the prefix legitimately changes the output.
     const PINNED = { three: "https://esm.sh/three@0.180.0" };
     for (const html of INPUTS) {
       for (const css of CSS) {
@@ -618,8 +782,18 @@ describe("assembleDocument", () => {
           // uppercase/attributed inputs (`<HEAD >…`, `<head data-x="a>b">…`,
           // `<head data-config=…>`) whose open tags are normalized to `<head>`.
           expect(out).toContain("<head>");
-          // Exactly one head-opening tag — non-legacy mode never duplicates the
-          // head, even for the legacy-quirk inputs (stray close, unclosed head).
+          // Exactly one head-opening tag for THIS matrix. Every INPUT above
+          // carries AT MOST ONE authored head, and the non-legacy path never
+          // CREATES a head it did not author: it splices the prefix into the
+          // single head (`ensureHead` synthesizes one only when none exists) and
+          // anchors the agent css to that same head's close, so no duplicate is
+          // ever emitted for these inputs — including the legacy-quirk ones
+          // (stray close, unclosed head). It does NOT, however, REPAIR an input
+          // that ALREADY contains two authored heads: that markup is retained
+          // as-authored (prefix into the FIRST head, the second kept verbatim;
+          // browsers ignore a duplicate head and websandbox only needs the
+          // literal `<head>`). That multi-authored-head retention is pinned
+          // separately in the "retains a second authored head" tests below.
           expect(out.match(HEAD_OPEN) ?? []).toHaveLength(1);
           if (css) {
             const cssMarker = ".x{}";

--- a/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
@@ -81,7 +81,7 @@ describe("assembleDocument", () => {
     );
   });
 
-  it("matches the legacy path byte-for-byte when designSystemCss and importMap are false", () => {
+  it("matches the legacy path byte-for-byte when designSystemCss and importMap are false (inputs whose legacy output already contains literal <head>)", () => {
     // legacy reference implementations, copied verbatim from OpenGenerativeUIRenderer.tsx
     const legacyEnsureHead = (html: string) =>
       /<head[\s>]/i.test(html) ? html : `<head></head>${html}`;
@@ -91,6 +91,8 @@ describe("assembleDocument", () => {
         ? html.slice(0, i) + `<style>${css}</style>` + html.slice(i)
         : `<head><style>${css}</style></head>${html}`;
     };
+    // These inputs all produce a legacy output containing the literal lowercase
+    // `<head>` token (the new contract returns L unchanged for exactly those).
     for (const html of [
       "<head></head><body>a</body>",
       "<body>b</body>",
@@ -98,6 +100,8 @@ describe("assembleDocument", () => {
     ]) {
       for (const css of [undefined, ".x{}"]) {
         const legacy = legacyEnsureHead(css ? legacyInject(html, css) : html);
+        // Precondition: this fixture is a byte-identity case.
+        expect(legacy).toContain("<head>");
         const next = assembleDocument(html, {
           css,
           designSystemCss: false,
@@ -106,6 +110,70 @@ describe("assembleDocument", () => {
         expect(next).toBe(legacy);
       }
     }
+  });
+
+  // Finding 1 (legacy mount normalization): the LEGACY path
+  // (`designSystemCss: false`, `importMap: false`, reachable via the documented
+  // public config `openGenerativeUI={{ designSystem: false, libraries: false }}`)
+  // was byte-identity-locked to the pre-branch composition, which for an
+  // uppercase / attributed head-open tag produced an output with NO literal
+  // lowercase `<head>` token — so `@jetbrains/websandbox` threw
+  // `'Websandbox: iFrame content must have "<head>" tag.'` and the artifact never
+  // mounted (stuck behind the spinner). The carve-out now mount-normalizes ONLY
+  // those previously-non-mounting outputs: it rewrites the first head-open token
+  // to the literal `<head>`, leaving css placement otherwise identical to the
+  // legacy composition. (Every input that previously mounted stays byte-identical;
+  // see the byte-identity test above and the sweep below.)
+  it("normalizes an uppercase <HEAD> in the legacy path so the artifact can mount", () => {
+    const html = "<HEAD><title>t</title></HEAD><body>x</body>";
+    const out = assembleDocument(html, {
+      css: undefined,
+      designSystemCss: false,
+      importMap: false,
+    });
+    // The literal token websandbox demands is present (RED pre-fix: the legacy
+    // path returned the input verbatim, with only `<HEAD>` — no literal `<head>`).
+    expect(out).toContain("<head>");
+    // Only the FIRST head-open token was rewritten; the rest of the document
+    // (including the uppercase CLOSE tag) is byte-identical to the legacy output.
+    expect(out).toBe("<head><title>t</title></HEAD><body>x</body>");
+  });
+
+  it("normalizes an attributed <head lang> in the legacy path and keeps css placement", () => {
+    const html = '<head lang="en"><title>t</title></head><body>x</body>';
+    // With css: the legacy injector splices the agent css before `</head>`; the
+    // ONLY change from the legacy output is the head-open token rewrite. The
+    // dropped `lang` attribute has negligible runtime semantics and cannot be
+    // preserved (websandbox demands the exact `<head>` token).
+    const out = assembleDocument(html, {
+      css: ".a{color:red}",
+      designSystemCss: false,
+      importMap: false,
+    });
+    expect(out).toBe(
+      "<head><title>t</title><style>.a{color:red}</style></head><body>x</body>",
+    );
+    expect(out).toContain("<head>");
+    expect(out).not.toContain('lang="en"');
+  });
+
+  it("prepends a minimal <head></head> for an unterminated <head\\t tail in the legacy path", () => {
+    // `ensureHead` sees `/<head[\s>]/` and declines to prepend, but the quote-
+    // aware matcher finds NO complete head-open token (the tag is never closed),
+    // so neither the byte-identity branch nor the token rewrite applies. Fall
+    // back to a minimal websandbox-safe `<head></head>` — WITHOUT kit/importmap
+    // (still the disabled path). RED pre-fix: the legacy path returned `<head\tfoo`
+    // verbatim (no literal `<head>`, never mounted).
+    const out = assembleDocument("<head\tfoo", {
+      css: undefined,
+      designSystemCss: false,
+      importMap: false,
+    });
+    expect(out).toContain("<head>");
+    expect(out).toBe("<head></head><head\tfoo");
+    // The disabled path injects no kit or importmap.
+    expect(out).not.toContain("data-ck-design-system");
+    expect(out).not.toContain('<script type="importmap">');
   });
 
   // Finding 1: a <header> element preceding a real <head> must not capture the
@@ -404,25 +472,64 @@ describe("assembleDocument", () => {
     // Non-legacy mode must never emit more than one.
     const HEAD_OPEN = /<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi;
 
-    // (1) LEGACY MODE — byte-identical to the legacy reference for every input ×
-    // css, under BOTH `importMap: false` and `importMap: {}` (an empty importmap
-    // injects no prefix, so it must behave exactly like pure legacy).
+    // Reference normalizer pinning the NEW legacy contract: given the legacy
+    // output L, return what the legacy path must now produce. If L already
+    // contains the literal `<head>`, L is returned UNCHANGED (byte-identical —
+    // every input that previously mounted). Otherwise the FIRST head-open token
+    // is rewritten to the literal `<head>` (css placement otherwise unchanged),
+    // or — if no head-open token matches at all — a minimal `<head></head>` is
+    // prepended. This mirrors the source exactly so the sweep pins byte-for-byte.
+    const normalizeLegacy = (legacy: string): string => {
+      if (legacy.includes("<head>")) return legacy;
+      const m = legacy.match(/<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i);
+      if (m && m.index !== undefined) {
+        return (
+          legacy.slice(0, m.index) +
+          "<head>" +
+          legacy.slice(m.index + m[0].length)
+        );
+      }
+      return `<head></head>${legacy}`;
+    };
+
+    // (1) LEGACY MODE — pins the NEW contract for every input × css, under BOTH
+    // `importMap: false` and `importMap: {}` (an empty importmap injects no
+    // prefix, so it must behave exactly like pure legacy). For inputs whose
+    // legacy output already contains the literal `<head>` this is byte-identity;
+    // for the previously-non-mounting remainder it is the legacy output with ONLY
+    // its first head-open token normalized to `<head>` (or a minimal head
+    // prepended). EVERY non-mounting output gains the literal token websandbox
+    // requires; the kit/importmap are never injected on this path.
     for (const importMap of [false, {} as Record<string, string>]) {
       const label = importMap === false ? "importMap:false" : "importMap:{}";
       for (const html of INPUTS) {
         for (const css of CSS) {
-          it(`legacy byte-identity (${label}) — ${JSON.stringify(
+          const legacy = legacyEnsureHead(css ? legacyInject(html, css) : html);
+          const identity = legacy.includes("<head>");
+          const tag = identity ? "byte-identity" : "mount-normalized";
+          it(`legacy ${tag} (${label}) — ${JSON.stringify(
             html,
           )} / css=${JSON.stringify(css)}`, () => {
-            const legacy = legacyEnsureHead(
-              css ? legacyInject(html, css) : html,
-            );
             const next = assembleDocument(html, {
               css,
               designSystemCss: false,
               importMap,
             });
-            expect(next).toBe(legacy);
+            // The new contract, pinned byte-for-byte: identity when the legacy
+            // output already mounts; legacy output with only the head token
+            // normalized otherwise.
+            expect(next).toBe(normalizeLegacy(legacy));
+            // EVERY legacy output now carries the literal token websandbox
+            // requires to mount — including the previously-non-mounting inputs.
+            expect(next).toContain("<head>");
+            // The disabled path never injects kit or importmap.
+            expect(next).not.toContain("data-ck-design-system");
+            expect(next).not.toContain('<script type="importmap">');
+            if (identity) {
+              // Inputs that previously mounted stay BYTE-IDENTICAL to the
+              // historical composition (no token rewrite).
+              expect(next).toBe(legacy);
+            }
           });
         }
       }

--- a/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
@@ -124,7 +124,7 @@ describe("assembleDocument", () => {
       importMap: { three: "https://esm.sh/three@0.180.0" },
     });
     // Exactly one <head opening tag — no duplicate head was prepended.
-    const headOpenings = out.match(/<head(\s[^>]*)?>/gi) ?? [];
+    const headOpenings = out.match(/<head(\s[^<>]*)?>/gi) ?? [];
     expect(headOpenings).toHaveLength(1);
     // Cascade order: importmap, then kit, then agent css.
     const importmapIdx = out.indexOf('<script type="importmap">');
@@ -184,11 +184,16 @@ describe("assembleDocument", () => {
       '<head data-x="1"><title>t</title></head><body>v</body>', // attributes
       "<header>h</header><head></head><body>w</body>", // header before head
       "<header>only</header><div>z</div>", // header, no head
+      "<head \nclass=x", // unterminated head token (no `>`) — must not drop prefix
+      "<head\tfoo", // unterminated head token, tab + bareword — must not drop prefix
+      "a<head\t<body>z</body>", // head token whose attr span runs into <body> — prefix must stay out of the body
     ];
     const CSS = [undefined, ".x{}"];
     // A real head-opening tag: `<head>` or `<head ...attrs>`, excluding
-    // `<header ...>`. Non-legacy mode must never emit more than one.
-    const HEAD_OPEN = /<head(\s[^>]*)?>/gi;
+    // `<header ...>`. `[^<>]*` (matching the production insertion regex) bounds
+    // the attribute span so a tag can never swallow a following `<tag>`.
+    // Non-legacy mode must never emit more than one.
+    const HEAD_OPEN = /<head(\s[^<>]*)?>/gi;
 
     // (1) LEGACY MODE — byte-identical to the legacy reference for every input ×
     // css, under BOTH `importMap: false` and `importMap: {}` (an empty importmap

--- a/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
@@ -287,6 +287,85 @@ describe("assembleDocument", () => {
     expect(out).toContain("data-ck-design-system");
   });
 
+  // Mask-before-match finding: a `<head>` token inside an HTML COMMENT before the
+  // real <head> must NOT capture the importmap/kit prefix splice. RED pre-fix:
+  // the head-open match ran on the raw html, so the prefix was spliced INSIDE the
+  // comment (libraries + design tokens silently inert).
+  it("splices the prefix into the real <head>, not a <head> token inside a comment", () => {
+    const html =
+      "<!-- build the <head> here --><head><title>t</title></head><body><p>Hi</p></body>";
+    const out = assembleDocument(html, {
+      css: ".a{color:red}",
+      designSystemCss: KIT,
+      importMap: { three: "https://esm.sh/three@0.180.0" },
+    });
+    const commentClose = out.indexOf("-->");
+    const importmapIdx = out.indexOf('<script type="importmap">');
+    const kitIdx = out.indexOf("data-ck-design-system");
+    const cssIdx = out.indexOf(".a{color:red}");
+    expect(importmapIdx).toBeGreaterThan(-1);
+    // The prefix lands AFTER the comment closes — i.e. inside the real <head>,
+    // not inside the comment.
+    expect(importmapIdx).toBeGreaterThan(commentClose);
+    expect(kitIdx).toBeGreaterThan(commentClose);
+    // The comment text is preserved verbatim (the prefix did not splice into it).
+    expect(out).toContain("<!-- build the <head> here -->");
+    // Cascade order preserved: importmap -> kit -> agent css.
+    expect(importmapIdx).toBeLessThan(kitIdx);
+    expect(kitIdx).toBeLessThan(cssIdx);
+    // websandbox's literal token is present. Exactly one REAL head-open tag
+    // exists after the comment (the `<head>` inside the comment is inert text,
+    // not a structural open tag, so we count only those past the comment close).
+    expect(out).toContain("<head>");
+    expect(
+      out
+        .slice(commentClose)
+        .match(/<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi) ?? [],
+    ).toHaveLength(1);
+  });
+
+  // Same hazard for a `<head>` token inside <style> CONTENT before the real head.
+  it("splices the prefix into the real <head>, not a <head> token inside <style> content", () => {
+    const html =
+      "<style>.x{}/* <head> */</style><head><title>t</title></head><body><p>Hi</p></body>";
+    const out = assembleDocument(html, {
+      css: ".a{color:red}",
+      designSystemCss: KIT,
+      importMap: { three: "https://esm.sh/three@0.180.0" },
+    });
+    const styleClose = out.indexOf("</style>");
+    const importmapIdx = out.indexOf('<script type="importmap">');
+    const kitIdx = out.indexOf("data-ck-design-system");
+    // The prefix lands AFTER the agent's leading <style> block closes — inside
+    // the real <head>, not inside the style content.
+    expect(importmapIdx).toBeGreaterThan(styleClose);
+    expect(kitIdx).toBeGreaterThan(styleClose);
+    // The original style content (with its <head> lookalike) is preserved.
+    expect(out).toContain("<style>.x{}/* <head> */</style>");
+    expect(importmapIdx).toBeLessThan(kitIdx);
+  });
+
+  // A `</head>` token inside a comment AFTER the prefix must not be mistaken for
+  // the real close: the agent css must land before the REAL </head>.
+  it("anchors agent css to the real </head>, not a </head> token inside a comment", () => {
+    const html =
+      "<head><title>t</title><!-- </head> --></head><body><p>Hi</p></body>";
+    const out = assembleDocument(html, {
+      css: ".a{color:red}",
+      designSystemCss: KIT,
+      importMap: { three: "https://esm.sh/three@0.180.0" },
+    });
+    const titleIdx = out.indexOf("<title>");
+    const commentIdx = out.indexOf("<!-- </head> -->");
+    const cssIdx = out.indexOf(".a{color:red}");
+    // The agent css lands after the head content (title) AND after the inert
+    // comment — i.e. immediately before the REAL </head>.
+    expect(cssIdx).toBeGreaterThan(titleIdx);
+    expect(cssIdx).toBeGreaterThan(commentIdx);
+    // The comment with its </head> lookalike is preserved.
+    expect(out).toContain("<!-- </head> -->");
+  });
+
   // Convergence sweep: a single input matrix that pins the two invariants this
   // function keeps drifting on — (1) byte-identity to legacy when no prefix is
   // injected, and (2) no duplicate head / correct cascade order in non-legacy

--- a/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
@@ -176,6 +176,52 @@ describe("assembleDocument", () => {
     expect(cssIdx).toBeGreaterThan(titleIdx);
   });
 
+  // Close-anchor finding: the agent-css close-tag search must target the SAME
+  // head the prefix (importmap + kit) was anchored to. When a stray `</head>`
+  // precedes the real `<head>`, the open-tag matcher correctly skips the stray
+  // and lands on the real head — but a global `</head>` search would resolve to
+  // the earlier stray close, splicing the agent css BEFORE the prefix and
+  // OUTSIDE the real head. That inverts the documented cascade
+  // (importmap -> kit -> agent css). Scoping the close search to the region
+  // at/after the prefix insertion point pins the css inside the real head.
+  it("anchors agent css to the real head's close, not a stray earlier </head>", () => {
+    const html = "foo</head><head><title>t</title></head><body>x</body>";
+    const out = assembleDocument(html, {
+      css: ".a{color:red}",
+      designSystemCss: KIT,
+      importMap: { three: "https://esm.sh/three@0.180.0" },
+    });
+    const importmapIdx = out.indexOf('<script type="importmap">');
+    const kitIdx = out.indexOf("data-ck-design-system");
+    const cssIdx = out.indexOf(".a{color:red}");
+    // The real `<head>` open tag (the stray leading token is `</head>`, which
+    // does not match the slash-free `<head>`). The prefix is spliced just after
+    // this open, so the real head's content (`<title>`) and its close tag both
+    // follow it.
+    const realHeadOpenIdx = out.indexOf("<head>");
+    const titleIdx = out.indexOf("<title>");
+    // The real head's close tag: the first `</head>` at/after the real open
+    // (skipping the stray `</head>` that precedes it).
+    const realHeadCloseIdx = out.indexOf("</head>", realHeadOpenIdx);
+
+    expect(importmapIdx).toBeGreaterThan(-1);
+    expect(realHeadOpenIdx).toBeGreaterThan(-1);
+    expect(titleIdx).toBeGreaterThan(-1);
+    expect(realHeadCloseIdx).toBeGreaterThan(-1);
+
+    // Cascade order: importmap, then kit, then agent css — all present and
+    // strictly ordered (the stray close must not pull css ahead of the prefix).
+    expect(importmapIdx).toBeLessThan(kitIdx);
+    expect(kitIdx).toBeLessThan(cssIdx);
+
+    // The agent css lands INSIDE the real head: after the real `<head>` open
+    // and the head's own content (`<title>`), and before that head's close tag
+    // — not at the stray `</head>` that precedes the real head.
+    expect(cssIdx).toBeGreaterThan(realHeadOpenIdx);
+    expect(cssIdx).toBeGreaterThan(titleIdx);
+    expect(cssIdx).toBeLessThan(realHeadCloseIdx);
+  });
+
   // Finding 3: an empty importMap object must not emit an inert importmap script.
   it("emits no importmap script when importMap is an empty object", () => {
     const out = assembleDocument("<head></head><body></body>", {
@@ -214,6 +260,8 @@ describe("assembleDocument", () => {
       "a<head\t<body>z</body>", // head token whose attr span runs into <body> — prefix must stay out of the body
       '<head data-x="a>b"><title>t</title></head><body>v</body>', // quoted `>` in attribute — must not splice mid-attribute
       '<head data-config=\'{"a":">"}\'>x</head><body>y</body>', // quoted `>` in single-quoted attribute — must not splice mid-attribute
+      "foo</head><head><title>t</title></head><body>x</body>", // stray close before the real head — agent css must anchor to the real head's close, not the earlier stray
+      "</head><head></head><body>z</body>", // leading stray close before the real head — same close-anchor hazard
     ];
     const CSS = [undefined, ".x{}"];
     // A real head-opening tag: `<head>` or `<head ...attrs>`, excluding

--- a/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/assembleDocument.test.ts
@@ -3,6 +3,7 @@ import {
   assembleDocument,
   buildImportMapScript,
   DEFAULT_OPEN_GEN_UI_LIBRARIES,
+  mergeLibraries,
 } from "../assembleDocument";
 
 // Legacy reference implementations, copied verbatim from
@@ -328,5 +329,88 @@ describe("assembleDocument", () => {
         });
       }
     }
+  });
+});
+
+describe("mergeLibraries", () => {
+  // Stand-in defaults shaped like DEFAULT_OPEN_GEN_UI_LIBRARIES: every library
+  // is a PAIR (bare + trailing-slash subpath form) pinned to one version.
+  const DEFAULTS: Record<string, string> = {
+    three: "https://esm.sh/three@0.180.0",
+    "three/": "https://esm.sh/three@0.180.0/",
+    gsap: "https://esm.sh/gsap@3.13.0",
+    "gsap/": "https://esm.sh/gsap@3.13.0/",
+    d3: "https://esm.sh/d3@7.9.0",
+    "d3/": "https://esm.sh/d3@7.9.0/",
+    "chart.js": "https://esm.sh/chart.js@4.5.0",
+    "chart.js/": "https://esm.sh/chart.js@4.5.0/",
+  };
+
+  // (1) Overriding the bare specifier re-pins its trailing-slash sibling to the
+  // SAME version (bare URL + "/"), so a generated scene never loads two copies
+  // of the library. This is the core finding: a flat spread would leave
+  // `three/` on the stale 0.180.0 default.
+  it("re-pins the trailing-slash sibling when only the bare specifier is overridden", () => {
+    const out = mergeLibraries(DEFAULTS, {
+      three: "https://esm.sh/three@0.999.0",
+    });
+    expect(out.three).toBe("https://esm.sh/three@0.999.0");
+    expect(out["three/"]).toBe("https://esm.sh/three@0.999.0/");
+    // Untouched libraries keep their default pins.
+    expect(out.gsap).toBe(DEFAULTS.gsap);
+    expect(out["gsap/"]).toBe(DEFAULTS["gsap/"]);
+  });
+
+  // (2) An explicit user `three/` override always wins — derivation must never
+  // clobber a subpath form the user set on purpose.
+  it("respects an explicit trailing-slash override (not clobbered by derivation)", () => {
+    const out = mergeLibraries(DEFAULTS, {
+      three: "https://esm.sh/three@0.999.0",
+      "three/": "https://cdn.example.com/three-subpath/",
+    });
+    expect(out.three).toBe("https://esm.sh/three@0.999.0");
+    expect(out["three/"]).toBe("https://cdn.example.com/three-subpath/");
+  });
+
+  // (3) A brand-new library with no default sibling gets NO invented `foo/`
+  // entry — we only re-pin subpath forms the defaults actually define.
+  it("does not invent a trailing-slash sibling for a new library without a default sibling", () => {
+    const out = mergeLibraries(DEFAULTS, {
+      foo: "https://esm.sh/foo@1.0.0",
+    });
+    expect(out.foo).toBe("https://esm.sh/foo@1.0.0");
+    expect(out).not.toHaveProperty("foo/");
+  });
+
+  // (4) An override URL that already ends in `/` must not gain a second slash.
+  it("does not double the slash when the override URL already ends in one", () => {
+    const out = mergeLibraries(DEFAULTS, {
+      three: "https://esm.sh/three@0.999.0/",
+    });
+    expect(out.three).toBe("https://esm.sh/three@0.999.0/");
+    expect(out["three/"]).toBe("https://esm.sh/three@0.999.0/");
+  });
+
+  // (5) Untouched defaults (gsap / d3 / chart.js) are left exactly as-is when
+  // only one library is overridden.
+  it("leaves untouched defaults (gsap/d3/chart.js) intact", () => {
+    const out = mergeLibraries(DEFAULTS, {
+      three: "https://esm.sh/three@0.999.0",
+    });
+    expect(out.gsap).toBe(DEFAULTS.gsap);
+    expect(out["gsap/"]).toBe(DEFAULTS["gsap/"]);
+    expect(out.d3).toBe(DEFAULTS.d3);
+    expect(out["d3/"]).toBe(DEFAULTS["d3/"]);
+    expect(out["chart.js"]).toBe(DEFAULTS["chart.js"]);
+    expect(out["chart.js/"]).toBe(DEFAULTS["chart.js/"]);
+  });
+
+  // Does not mutate its inputs (the defaults map is a shared module constant).
+  it("does not mutate its arguments", () => {
+    const defaults = { ...DEFAULTS };
+    const overrides = { three: "https://esm.sh/three@0.999.0" };
+    mergeLibraries(defaults, overrides);
+    expect(defaults).toEqual(DEFAULTS);
+    expect(overrides).toEqual({ three: "https://esm.sh/three@0.999.0" });
   });
 });

--- a/packages/react-core/src/v2/lib/__tests__/designSystemCss.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/designSystemCss.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { OPEN_GEN_UI_DESIGN_SYSTEM_CSS } from "../designSystemCss";
+
+describe("OPEN_GEN_UI_DESIGN_SYSTEM_CSS", () => {
+  it("contains the token, svg, and form layers", () => {
+    expect(OPEN_GEN_UI_DESIGN_SYSTEM_CSS).toContain(
+      "--color-background-primary",
+    );
+    expect(OPEN_GEN_UI_DESIGN_SYSTEM_CSS).toContain(
+      "prefers-color-scheme: dark",
+    );
+    expect(OPEN_GEN_UI_DESIGN_SYSTEM_CSS).toContain(".c-purple");
+    expect(OPEN_GEN_UI_DESIGN_SYSTEM_CSS).toContain('input[type="range"]');
+    expect(OPEN_GEN_UI_DESIGN_SYSTEM_CSS).toContain("prefers-reduced-motion");
+  });
+});

--- a/packages/react-core/src/v2/lib/__tests__/designSystemCss.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/designSystemCss.test.ts
@@ -13,4 +13,10 @@ describe("OPEN_GEN_UI_DESIGN_SYSTEM_CSS", () => {
     expect(OPEN_GEN_UI_DESIGN_SYSTEM_CSS).toContain('input[type="range"]');
     expect(OPEN_GEN_UI_DESIGN_SYSTEM_CSS).toContain("prefers-reduced-motion");
   });
+
+  it("keeps the form focus ring visible in dark mode", () => {
+    expect(OPEN_GEN_UI_DESIGN_SYSTEM_CSS).toContain(
+      "rgba(255, 255, 255, 0.12)",
+    );
+  });
 });

--- a/packages/react-core/src/v2/lib/__tests__/processPartialHtml.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/processPartialHtml.test.ts
@@ -278,4 +278,13 @@ describe("processPartialHtml / extractCompleteStyles — shared boundary parity"
     expect(hoisted).toBe(""); // NOT hoisted
     expect(body).toBe("<style>.head-style{}</style>BODYTEXT"); // kept in body
   });
+
+  // Case G — quote-aware open-tag scan: a quoted `>` inside a <body> attribute
+  // must not truncate the open tag early and leak attribute fragments.
+  it("G: quoted > in a <body> attribute → no attribute fragments leak", () => {
+    const input = '<body data-x="a>b"><p>hi</p></body>';
+    const body = processPartialHtml(input);
+    expect(body).toBe("<p>hi</p>");
+    expect(body).not.toContain('b">');
+  });
 });

--- a/packages/react-core/src/v2/lib/__tests__/processPartialHtml.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/processPartialHtml.test.ts
@@ -531,3 +531,88 @@ describe("processPartialHtml — trailing-entity strip (intended tradeoff)", () 
     expect(processPartialHtml("<p>R&D")).toBe("<p>R");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Content after </body> must be RETAINED in the body (final-document parity).
+// The final document is mounted whole; a browser reparents anything that
+// appears after </body> INTO the body (it is body content, not a wrapper).
+// jsdom (the browser-equivalent parser) confirms:
+//   new JSDOM("<body><p>x</p></body><div>after</div>").window.document
+//     .body.innerHTML === "<p>x</p><div>after</div>"
+//   new JSDOM("<body><p>x</p></body><style>.z{color:green}</style>")…
+//     .body.innerHTML === "<p>x</p><style>.z{color:green}</style>"
+// So the preview must NOT truncate at </body>; it removes the </body> token
+// (mask-located, like the </html> strip) and keeps processing what follows.
+// A complete <style> after </body> is body-region: it must NOT be hoisted and
+// MUST stay in the body (hoist-XOR-keep, never both, never neither).
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — content after </body> retained", () => {
+  // RED pre-fix: step 5 sliced off everything from </body>, so <div>after</div>
+  // vanished from the preview while the final document reparents it into the body.
+  it("R: content after </body> is kept (browser reparents it into the body)", () => {
+    const input = "<body><p>x</p></body><div>after</div>";
+    expect(processPartialHtml(input)).toBe("<p>x</p><div>after</div>");
+  });
+
+  // The </body> token itself is removed (it is not visible content); the body's
+  // inner content and the reparented trailing content are concatenated, exactly
+  // as the browser flattens them in the final document.
+  it("R': the </body> token is removed, not rendered", () => {
+    const body = processPartialHtml("<body><p>x</p></body><div>after</div>");
+    expect(body).not.toContain("</body>");
+  });
+
+  // A complete <style> after </body> is body-region per browser reparenting:
+  // NOT hoisted, KEPT in the body (the hoist-XOR-keep invariant must hold).
+  it("R'': a complete <style> after </body> stays in the body, not hoisted", () => {
+    const input = "<body><p>x</p></body><style>.z{color:green}</style>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe(""); // body-region after </body> → never hoisted
+    expect(body).toBe("<p>x</p><style>.z{color:green}</style>"); // kept in body
+  });
+
+  // Full document: head hoists, body content + post-</body> content both land in
+  // the body; the </html> wrapper is still stripped. Matches jsdom body.innerHTML
+  // ("<p>x</p><div>after</div>") for the same input.
+  it("R''': full document with content after </body></html> keeps the trailing content", () => {
+    const input =
+      "<html><head><title>t</title></head><body><p>x</p></body><div>after</div></html>";
+    expect(processPartialHtml(input)).toBe("<p>x</p><div>after</div>");
+  });
+
+  // A </body> token inside a surviving complete <style> must NOT be treated as
+  // the structural close (masking guards it), so the style — and the content
+  // after it — stay intact.
+  it("R'''': </body> token inside CSS content is not the structural close", () => {
+    const input =
+      '<body><style>.a::after{content:"</body>"}</style><p>p</p></body><div>after</div>';
+    expect(processPartialHtml(input)).toBe(
+      '<style>.a::after{content:"</body>"}</style><p>p</p><div>after</div>',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REFUTED reviewer finding (pinned, no source change): a reviewer claimed that
+// rejecting a self-closing `<script src="x.js"/>` makes the preview "more
+// aggressive than the final document" by dropping the trailing `<p>b</p>`.
+// In HTML5 a `<script>` start tag is NOT self-closing — the `/` before `>` is
+// ignored, the element stays OPEN, and everything up to a real `</script>` is
+// consumed as script content (and never rendered). jsdom confirms:
+//   new JSDOM('<div>a</div><script src="x.js"/><p>b</p>').window.document
+//     .body.innerHTML === '<div>a</div><script src="x.js"><p>b</p></script>'
+//   → script.textContent === "<p>b</p>", 0 rendered <p> elements.
+// So the final document does NOT render <p>b</p> either; the preview's stripping
+// of everything from `<script` onward yields the SAME visible output. Parity
+// holds — the finding is refuted and no source changes.
+// ---------------------------------------------------------------------------
+describe("processPartialHtml — script-with-trailing-slash parity (refuted finding, pinned)", () => {
+  it('S: <script src="x.js"/> swallows the following <p> in both preview and final document', () => {
+    // The trailing `<p>b</p>` is script content in HTML5 (not self-closing), so
+    // it is invisible in the final document. The preview likewise drops it — the
+    // visible result is identical (`<div>a</div>`), so there is no divergence.
+    const input = '<div>a</div><script src="x.js"/><p>b</p>';
+    expect(processPartialHtml(input)).toBe("<div>a</div>");
+  });
+});

--- a/packages/react-core/src/v2/lib/__tests__/processPartialHtml.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/processPartialHtml.test.ts
@@ -288,3 +288,197 @@ describe("processPartialHtml / extractCompleteStyles — shared boundary parity"
     expect(body).not.toContain('b">');
   });
 });
+
+// ---------------------------------------------------------------------------
+// HTML comments must be masked like style/script content: a tag-lookalike
+// inside a complete comment is real comment text (never stripped, never a
+// structural boundary), and an unterminated trailing comment must vanish
+// (the final document's `-->` swallows the remainder). Each case asserts the
+// never-both / never-neither invariant against the FINAL document's rendering.
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — HTML comment masking", () => {
+  // RED pre-fix: maskBlockContent masked only style/script, so the <script>
+  // inside the comment was stripped, gutting the comment.
+  it("H: complete comment containing a <script> is preserved, not gutted", () => {
+    const input =
+      "<body><p>before</p><!-- <script>x</script> --><p>after</p></body>";
+    expect(processPartialHtml(input)).toBe(
+      "<p>before</p><!-- <script>x</script> --><p>after</p>",
+    );
+  });
+
+  // RED pre-fix: the comment's <body> token was taken as the body boundary,
+  // dropping the leading <div>.
+  it("I: complete comment containing a <body> token is not a boundary", () => {
+    const input = "<div>a</div><!-- <body> --><p>b</p>";
+    expect(processPartialHtml(input)).toBe(
+      "<div>a</div><!-- <body> --><p>b</p>",
+    );
+  });
+
+  // A complete comment containing </body> must not fake the close boundary.
+  it("I': complete comment containing </body> is not a close boundary", () => {
+    const input = "<body><p>a</p><!-- </body> --><p>b</p></body>";
+    expect(processPartialHtml(input)).toBe("<p>a</p><!-- </body> --><p>b</p>");
+  });
+
+  // Streaming case: an unterminated trailing comment must not fake structure and
+  // must vanish from the preview body (consistent with the final document, where
+  // the eventual `-->` comments out everything after `<!--`).
+  it("J: unterminated trailing comment is dropped (no fake structure)", () => {
+    expect(processPartialHtml("<div>a</div><!-- partial")).toBe("<div>a</div>");
+    // …even when the partial comment contains a `>` (so step 2's bare
+    // incomplete-tag strip cannot catch it).
+    expect(processPartialHtml("<div>a</div><!-- partial <span> more")).toBe(
+      "<div>a</div>",
+    );
+  });
+
+  // Invariant under an unterminated comment: a COMPLETE style before it is kept
+  // in the body exactly once; a complete-looking style INSIDE the unterminated
+  // comment is neither hoisted nor leaked (the final document comments it out).
+  it("K: complete style before an unterminated comment → kept once, inner style not hoisted/leaked", () => {
+    const input = "<style>.a{}</style><div>x</div><!-- <style>.b{}</style";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(body).toBe("<style>.a{}</style><div>x</div>");
+    expect(hoisted).toBe(""); // .a is top-level (no head); .b is inside the comment
+    expect(body).not.toContain(".b"); // inner style text did not leak
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unclosed <head> with body markup: the preview must agree with the final
+// document's effective rendering (assembleDocument leaves the in-head css in
+// the head and the body content in the body when no </head> is emitted —
+// browsers implicitly close <head> at <body>). Content must never vanish.
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — unclosed <head> implicit body close", () => {
+  // RED pre-fix: extractCompleteStyles hoisted nothing (no complete head
+  // element) AND step 3 stripped the unclosed <head> to end-of-string →
+  // preview rendered empty while the final document renders the content.
+  it("L: unclosed <head> + <body> + content → style hoisted, body content kept (not dropped)", () => {
+    const input = "<head><style>.a{color:red}</style><body><p>hi</p></body>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.a{color:red}</style>"); // hoisted (in-head)
+    expect(body).toBe("<p>hi</p>"); // body content preserved
+    expect(body).not.toContain("<style"); // not double-injected
+  });
+
+  // The implicit close also strips the head region's non-style markup from the
+  // body, keeping only the body content (parity with the final document).
+  it("L': unclosed <head> with title + style before <body> → only body content remains", () => {
+    const input =
+      "<head><title>t</title><style>.a{}</style><body><p>x</p></body>";
+    expect(processPartialHtml(input)).toBe("<p>x</p>");
+    expect(extractCompleteStyles(input)).toBe("<style>.a{}</style>");
+  });
+
+  // Pin: an unclosed <head> with content but NO <body> token is still stripped
+  // (a head genuinely still streaming its own content). Current behavior — kept
+  // stable by the implicit-close rule firing ONLY on a <body> token.
+  it("M: unclosed <head> + content, NO <body> → stripped (pinned)", () => {
+    const input = "<head><style>.a{}</style><p>x</p>";
+    expect(processPartialHtml(input)).toBe("");
+    expect(extractCompleteStyles(input)).toBe("");
+  });
+
+  // A <body> token inside a style/comment within the unclosed head must NOT be
+  // taken as the implicit close (masking guards it).
+  it("M': <body> token inside CSS in an unclosed head is not the implicit close", () => {
+    const input = '<head><style>.a{content:"<body>"}</style><p>x</p>';
+    // No REAL <body> token ⇒ unclosed head with no body ⇒ stripped (pinned).
+    expect(processPartialHtml(input)).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The <html> wrapper open tag must be stripped wherever it appears (not only
+// when leading), mask-aware and quote-aware, so a prefixed wrapper does not
+// leak the tag into the preview body.
+// ---------------------------------------------------------------------------
+describe("processPartialHtml — tolerant <html> wrapper strip", () => {
+  // RED pre-fix: only a LEADING <html> was stripped (`/^<html\b[^>]*>/i`), so a
+  // prefixed wrapper survived into the preview body.
+  it("N: <html> with a text prefix → wrapper stripped, surrounding content kept", () => {
+    const input = "text<html><body><p>x</p></body>";
+    expect(processPartialHtml(input)).toBe("text<p>x</p>");
+  });
+
+  it("N': leading <html> still stripped (existing behavior preserved)", () => {
+    const input = "<html><body><p>x</p></body></html>";
+    expect(processPartialHtml(input)).toBe("<p>x</p>");
+  });
+
+  // Word-bounded: <htmlfoo> is not the html wrapper.
+  it("N'': <htmlfoo> is not <html> → left intact", () => {
+    const input = "<htmlfoo>kept</htmlfoo>";
+    expect(processPartialHtml(input)).toBe("<htmlfoo>kept</htmlfoo>");
+  });
+
+  // Masked search: an <html> token inside a surviving style block cannot fake
+  // the wrapper strip.
+  it("N''': <html> token inside CSS content cannot fake the wrapper strip", () => {
+    const input = '<style>.a{content:"<html>"}</style><div>x</div>';
+    expect(processPartialHtml(input)).toBe(
+      '<style>.a{content:"<html>"}</style><div>x</div>',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// maskBlockContent open-tag end scan must be quote-aware: a quoted `>` in a
+// style/script open tag must not mis-locate the content boundary and leave the
+// real CSS unmasked, where a <body>/<html> token could fake a boundary.
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — quote-aware style open tag", () => {
+  // RED pre-fix: maskBlockContent used full.indexOf(">"), so the quoted `>` in
+  // `data-x="a>b"` mis-located the content start, leaving `b">…` and the CSS
+  // unmasked — the unmasked <body> token then faked a body boundary.
+  it("O: quoted > in a <style> open tag → <body> token in its CSS cannot fake a boundary", () => {
+    const input =
+      '<style data-x="a>b">.foo{content:"<body>"}</style><div>real</div>';
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    // The complete style stays intact in the body; <div>real</div> is kept (the
+    // <body> token inside the CSS did not split anything off as a boundary).
+    expect(body).toBe(
+      '<style data-x="a>b">.foo{content:"<body>"}</style><div>real</div>',
+    );
+    expect(hoisted).toBe("");
+    // Removing the complete style leaves clean markup — no orphan CSS fragment.
+    expect(body.replace(/<style\b[^>]*>[\s\S]*?<\/style>/i, "")).toBe(
+      "<div>real</div>",
+    );
+  });
+
+  // Same hazard with </body> in the CSS and a quoted `>` in the open tag.
+  it("O': quoted > in a <style> open tag → </body> token in its CSS cannot fake a close", () => {
+    const input =
+      '<body><style data-x="a>b">.foo{content:"</body>"}</style><p>p</p></body>';
+    expect(processPartialHtml(input)).toBe(
+      '<style data-x="a>b">.foo{content:"</body>"}</style><p>p</p>',
+    );
+  });
+
+  // RED pre-fix: the unterminated-block strip ran on the UNMASKED string, so a
+  // `<head>` token inside a complete style's ATTRIBUTE value was matched as an
+  // unterminated trailing <head> and the document was truncated to it. The strip
+  // now measures on a masked copy (attribute values blanked), so the complete
+  // style survives intact.
+  it("P: <head> token in a <style> attribute value does not trigger the unterminated-block strip", () => {
+    const input = '<style data-y="<head>">.foo{}</style><div>d</div>';
+    expect(processPartialHtml(input)).toBe(
+      '<style data-y="<head>">.foo{}</style><div>d</div>',
+    );
+  });
+
+  // Same class for a `</body>` token in an attribute value (no fake close).
+  it("P': </body> token in a <style> attribute value does not fake a body close", () => {
+    const input = '<body><style data-y="</body>">.foo{}</style><p>p</p></body>';
+    expect(processPartialHtml(input)).toBe(
+      '<style data-y="</body>">.foo{}</style><p>p</p>',
+    );
+  });
+});

--- a/packages/react-core/src/v2/lib/__tests__/processPartialHtml.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/processPartialHtml.test.ts
@@ -13,13 +13,24 @@ describe("processPartialHtml", () => {
     expect(processPartialHtml('<div>Hello<span class="fo')).toBe("<div>Hello");
   });
 
-  it("strips complete <style> blocks in the head region (before <body>)", () => {
-    // Head-region styles are hoisted into the preview <head> by
-    // extractCompleteStyles, so processPartialHtml strips them here to avoid
-    // duplicating them in the body.
+  it("hoists a complete <head>-element style and strips it from the body", () => {
+    // A <style> inside a complete <head>…</head> element is hoisted into the
+    // preview <head> by extractCompleteStyles, so processPartialHtml removes it
+    // (the whole head element is stripped) — never both, never neither.
+    const input =
+      "<head><style>.foo { color: red; }</style></head><body><div>Hello</div><p>World</p></body>";
+    expect(processPartialHtml(input)).toBe("<div>Hello</div><p>World</p>");
+  });
+
+  it("keeps a top-level pre-<body> style in the body (final-document parity)", () => {
+    // No <head> element wraps this style, so it is NOT hoisted. assembleDocument
+    // leaves a top-level pre-<body> style in the body region (after the head css
+    // in document order), so the preview body must keep it too.
     const input =
       "<style>.foo { color: red; }</style><body><div>Hello</div><p>World</p></body>";
-    expect(processPartialHtml(input)).toBe("<div>Hello</div><p>World</p>");
+    expect(processPartialHtml(input)).toBe(
+      "<style>.foo { color: red; }</style><div>Hello</div><p>World</p>",
+    );
   });
 
   it("keeps a complete <style> block in the body region (cascade parity)", () => {
@@ -37,7 +48,7 @@ describe("processPartialHtml", () => {
   it("keeps a complete <style> block when there is no <body> (whole string is body region)", () => {
     // With no <body> tag the entire string is the body region, so a complete
     // <style> is kept exactly where it appears (and extractCompleteStyles
-    // hoists nothing).
+    // hoists nothing — there is no <head> element).
     const input =
       "<div>Hello</div><style>.foo { color: red; }</style><p>World</p>";
     expect(processPartialHtml(input)).toBe(input);
@@ -106,33 +117,41 @@ describe("extractCompleteStyles", () => {
     expect(extractCompleteStyles("")).toBe("");
   });
 
-  it("extracts a single complete head-region style block", () => {
-    const input =
-      "<style>.foo { color: red; }</style><body><p>World</p></body>";
-    expect(extractCompleteStyles(input)).toBe(
-      "<style>.foo { color: red; }</style>",
-    );
-  });
-
-  it("extracts multiple complete head-region style blocks", () => {
-    const input =
-      "<style>a{}</style><div>X</div><style>b{}</style><body></body>";
-    expect(extractCompleteStyles(input)).toBe(
-      "<style>a{}</style><style>b{}</style>",
-    );
-  });
-
-  it("ignores incomplete style blocks in the head region", () => {
-    const input = "<style>.complete{}</style><style>.incomplete {<body></body>";
-    expect(extractCompleteStyles(input)).toBe("<style>.complete{}</style>");
-  });
-
-  it("extracts styles from head", () => {
+  it("hoists a style inside a complete <head> element", () => {
     const input =
       "<head><style>body { margin: 0; }</style></head><body><p>Hi</p></body>";
     expect(extractCompleteStyles(input)).toBe(
       "<style>body { margin: 0; }</style>",
     );
+  });
+
+  it("hoists multiple styles inside a complete <head> element", () => {
+    const input =
+      "<head><style>a{}</style><style>b{}</style></head><body></body>";
+    expect(extractCompleteStyles(input)).toBe(
+      "<style>a{}</style><style>b{}</style>",
+    );
+  });
+
+  it("does NOT hoist a top-level pre-<body> style (final-document parity)", () => {
+    // No <head> element, so the style is body-region in the final document and
+    // must NOT be hoisted (it stays in the preview body via processPartialHtml).
+    const input =
+      "<style>.foo { color: red; }</style><body><p>World</p></body>";
+    expect(extractCompleteStyles(input)).toBe("");
+  });
+
+  it("does NOT hoist multiple top-level pre-<body> styles", () => {
+    const input =
+      "<style>a{}</style><div>X</div><style>b{}</style><body></body>";
+    expect(extractCompleteStyles(input)).toBe("");
+  });
+
+  it("does NOT hoist when the only complete style is top-level pre-<body>", () => {
+    // An incomplete trailing style is never hoisted; the complete one here is
+    // top-level (no <head> element), so nothing is hoisted.
+    const input = "<style>.complete{}</style><style>.incomplete {<body></body>";
+    expect(extractCompleteStyles(input)).toBe("");
   });
 
   it("does NOT extract styles from the body region (left in place for cascade parity)", () => {
@@ -143,8 +162,8 @@ describe("extractCompleteStyles", () => {
     expect(extractCompleteStyles(input)).toBe("");
   });
 
-  it("extracts only head-region styles, leaving body-region styles behind", () => {
-    // Mixed document: the head style is hoisted, the body style is not.
+  it("hoists only the head-element style, leaving the body-region style behind", () => {
+    // Mixed document: the head-element style is hoisted, the body style is not.
     const input =
       "<head><style>.head { color: red; }</style></head><body><style>.body { color: blue; }</style></body>";
     expect(extractCompleteStyles(input)).toBe(
@@ -155,5 +174,108 @@ describe("extractCompleteStyles", () => {
   it("hoists nothing when there is no <body> tag (whole string is body region)", () => {
     const input = "<style>.foo { color: red; }</style><div>Hi</div>";
     expect(extractCompleteStyles(input)).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Review finding-cluster: the two functions must derive head/body boundaries
+// from ONE shared masked computation. Each case asserts on BOTH functions —
+// every complete <style> is hoisted XOR retained (never both, never neither),
+// no raw CSS text leaks into the body, and the body keeps exactly what the
+// FINAL document (assembleDocument) renders in its body region.
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — shared boundary parity", () => {
+  // Case A — RED pre-fix: a style in a complete <head> element with NO <body>
+  // streamed yet was dropped from BOTH regions (extractCompleteStyles found no
+  // <body> boundary so hoisted nothing; processPartialHtml stripped the whole
+  // head block). NEW rule: hoist the head-element style; keep the trailing
+  // top-level content in the body.
+  it("A: head-element style with no <body> yet → hoisted, not dropped", () => {
+    const input = "<head><style>.h{color:red}</style></head><div>content</div>";
+    const hoisted = extractCompleteStyles(input);
+    const body = processPartialHtml(input);
+    expect(hoisted).toBe("<style>.h{color:red}</style>"); // hoisted
+    expect(body).toBe("<div>content</div>"); // NOT in body
+    expect(body).not.toContain("<style"); // no duplicate / no leak
+  });
+
+  // Case B — RED pre-fix: a chunk ending mid-`<body` tag made
+  // extractCompleteStyles see a phantom boundary (hoist) while processPartialHtml
+  // stripped the incomplete trailing tag and kept the style — DOUBLE-INJECTED.
+  // NEW rule: no <head> element ⇒ never hoist; keep the style in the body only.
+  it("B: chunk ends mid-<body> tag → style kept in body only, not double-injected", () => {
+    const input = '<style>.a{}</style><div>h</div><body class="x';
+    const hoisted = extractCompleteStyles(input);
+    const body = processPartialHtml(input);
+    expect(hoisted).toBe(""); // NOT hoisted (no head element)
+    expect(body).toBe("<style>.a{}</style><div>h</div>"); // kept once in body
+  });
+
+  // Case C — RED pre-fix: a legal CSS token `content:"<body>"` split the style
+  // mid-block in both functions; the raw CSS tail `"}</style>` leaked into the
+  // preview body. NEW rule: masking hides the CSS token, the real <body> is
+  // found, the complete style is kept intact in the body, no leak.
+  it("C: <body> token inside CSS content → style intact in body, no raw CSS leak", () => {
+    const input =
+      '<style>div::before{content:"<body>"}</style><body><p>P</p></body>';
+    const hoisted = extractCompleteStyles(input);
+    const body = processPartialHtml(input);
+    expect(hoisted).toBe(""); // NOT hoisted (no head element)
+    expect(body).toBe('<style>div::before{content:"<body>"}</style><p>P</p>');
+    // No orphan CSS fragment: removing the complete style leaves clean markup.
+    expect(body.replace(/<style\b[^>]*>[\s\S]*?<\/style>/i, "")).toBe(
+      "<p>P</p>",
+    );
+  });
+
+  // Case C (comment variant) — same class: a `<body` token inside a CSS comment.
+  it("C': <body> token inside a CSS comment → style intact in body, no leak", () => {
+    const input =
+      "<style>/* hide <body /> default */ .x{}</style><body><p>P</p></body>";
+    const hoisted = extractCompleteStyles(input);
+    const body = processPartialHtml(input);
+    expect(hoisted).toBe("");
+    expect(body).toBe(
+      "<style>/* hide <body /> default */ .x{}</style><p>P</p>",
+    );
+    expect(body.replace(/<style\b[^>]*>[\s\S]*?<\/style>/i, "")).toBe(
+      "<p>P</p>",
+    );
+  });
+
+  // Case D — RED pre-fix: a <body> token nested inside a complete <head> block
+  // made the two functions classify the trailing top-level `.s{}` differently →
+  // dropped from BOTH. NEW rule: the head element is stripped wholesale (its
+  // nested <body> token cannot fake the real boundary via masking), and the
+  // top-level `.s{}` is body-region — kept in the body, not hoisted.
+  it("D: <body> token nested in a <head> block → top-level style kept in body", () => {
+    const input = "<head>x<body>y</head><style>.s{}</style><body>real</body>";
+    const hoisted = extractCompleteStyles(input);
+    const body = processPartialHtml(input);
+    expect(hoisted).toBe(""); // .s{} is top-level, not in a head element
+    expect(body).toBe("<style>.s{}</style>real"); // kept in body, not dropped
+  });
+
+  // Case E — RED pre-fix: step 5's `/<body[^>]*>/i` (no word boundary) matched
+  // `<bodyguard …>` and dropped the leading <div>. NEW rule: word-bounded
+  // `/<body[\s>]/i` never matches `<bodyguard>`, so the whole input is body.
+  it("E: <bodyguard> is not <body> → leading <div> retained", () => {
+    const input = '<div>hi</div><bodyguard data-x="1">guarded</bodyguard>';
+    const hoisted = extractCompleteStyles(input);
+    const body = processPartialHtml(input);
+    expect(hoisted).toBe("");
+    expect(body).toBe(input); // leading <div> kept; <bodyguard> untouched
+    expect(body).toContain("<div>hi</div>");
+  });
+
+  // Case F — final-document parity: a top-level pre-<body> style stays in the
+  // BODY region of the assembled document (after the head css), so the preview
+  // body must keep it and the head payload must not.
+  it("F: top-level pre-<body> style stays in the body (matches assembleDocument)", () => {
+    const input = "<style>.head-style{}</style><body>BODYTEXT</body>";
+    const hoisted = extractCompleteStyles(input);
+    const body = processPartialHtml(input);
+    expect(hoisted).toBe(""); // NOT hoisted
+    expect(body).toBe("<style>.head-style{}</style>BODYTEXT"); // kept in body
   });
 });

--- a/packages/react-core/src/v2/lib/__tests__/processPartialHtml.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/processPartialHtml.test.ts
@@ -13,10 +13,34 @@ describe("processPartialHtml", () => {
     expect(processPartialHtml('<div>Hello<span class="fo')).toBe("<div>Hello");
   });
 
-  it("strips complete <style> blocks", () => {
+  it("strips complete <style> blocks in the head region (before <body>)", () => {
+    // Head-region styles are hoisted into the preview <head> by
+    // extractCompleteStyles, so processPartialHtml strips them here to avoid
+    // duplicating them in the body.
+    const input =
+      "<style>.foo { color: red; }</style><body><div>Hello</div><p>World</p></body>";
+    expect(processPartialHtml(input)).toBe("<div>Hello</div><p>World</p>");
+  });
+
+  it("keeps a complete <style> block in the body region (cascade parity)", () => {
+    // A complete <style> INSIDE the body stays in place — browsers apply
+    // <style> anywhere and the final document (assembleDocument) likewise keeps
+    // body-region styles in the body (after the head css in document order), so
+    // the preview must not hoist it to the head.
+    const input =
+      "<body><div>Hello</div><style>.foo { color: red; }</style><p>World</p></body>";
+    expect(processPartialHtml(input)).toBe(
+      "<div>Hello</div><style>.foo { color: red; }</style><p>World</p>",
+    );
+  });
+
+  it("keeps a complete <style> block when there is no <body> (whole string is body region)", () => {
+    // With no <body> tag the entire string is the body region, so a complete
+    // <style> is kept exactly where it appears (and extractCompleteStyles
+    // hoists nothing).
     const input =
       "<div>Hello</div><style>.foo { color: red; }</style><p>World</p>";
-    expect(processPartialHtml(input)).toBe("<div>Hello</div><p>World</p>");
+    expect(processPartialHtml(input)).toBe(input);
   });
 
   it("strips complete <script> blocks", () => {
@@ -82,23 +106,24 @@ describe("extractCompleteStyles", () => {
     expect(extractCompleteStyles("")).toBe("");
   });
 
-  it("extracts a single complete style block", () => {
+  it("extracts a single complete head-region style block", () => {
     const input =
-      "<div>Hello</div><style>.foo { color: red; }</style><p>World</p>";
+      "<style>.foo { color: red; }</style><body><p>World</p></body>";
     expect(extractCompleteStyles(input)).toBe(
       "<style>.foo { color: red; }</style>",
     );
   });
 
-  it("extracts multiple complete style blocks", () => {
-    const input = "<style>a{}</style><div>X</div><style>b{}</style>";
+  it("extracts multiple complete head-region style blocks", () => {
+    const input =
+      "<style>a{}</style><div>X</div><style>b{}</style><body></body>";
     expect(extractCompleteStyles(input)).toBe(
       "<style>a{}</style><style>b{}</style>",
     );
   });
 
-  it("ignores incomplete style blocks", () => {
-    const input = "<style>.complete{}</style><style>.incomplete {";
+  it("ignores incomplete style blocks in the head region", () => {
+    const input = "<style>.complete{}</style><style>.incomplete {<body></body>";
     expect(extractCompleteStyles(input)).toBe("<style>.complete{}</style>");
   });
 
@@ -108,5 +133,27 @@ describe("extractCompleteStyles", () => {
     expect(extractCompleteStyles(input)).toBe(
       "<style>body { margin: 0; }</style>",
     );
+  });
+
+  it("does NOT extract styles from the body region (left in place for cascade parity)", () => {
+    // A complete <style> inside the body must stay in the body — hoisting it
+    // would flip its cascade position at the preview→final swap.
+    const input =
+      "<body><div>Hi</div><style>.foo { color: red; }</style></body>";
+    expect(extractCompleteStyles(input)).toBe("");
+  });
+
+  it("extracts only head-region styles, leaving body-region styles behind", () => {
+    // Mixed document: the head style is hoisted, the body style is not.
+    const input =
+      "<head><style>.head { color: red; }</style></head><body><style>.body { color: blue; }</style></body>";
+    expect(extractCompleteStyles(input)).toBe(
+      "<style>.head { color: red; }</style>",
+    );
+  });
+
+  it("hoists nothing when there is no <body> tag (whole string is body region)", () => {
+    const input = "<style>.foo { color: red; }</style><div>Hi</div>";
+    expect(extractCompleteStyles(input)).toBe("");
   });
 });

--- a/packages/react-core/src/v2/lib/__tests__/processPartialHtml.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/processPartialHtml.test.ts
@@ -243,17 +243,25 @@ describe("processPartialHtml / extractCompleteStyles — shared boundary parity"
     );
   });
 
-  // Case D — RED pre-fix: a <body> token nested inside a complete <head> block
-  // made the two functions classify the trailing top-level `.s{}` differently →
-  // dropped from BOTH. NEW rule: the head element is stripped wholesale (its
-  // nested <body> token cannot fake the real boundary via masking), and the
-  // top-level `.s{}` is body-region — kept in the body, not hoisted.
-  it("D: <body> token nested in a <head> block → top-level style kept in body", () => {
+  // Case D — UPDATED to browser parity (the old pin asserted buggy behavior).
+  // Input: `<head>x<body>y</head><style>.s{}</style><body>real</body>`. The old
+  // pin expected `<style>.s{}</style>real` (the whole `<head>x<body>y</head>` was
+  // treated as one head element and dropped, taking `x` and `y` with it — the
+  // very Finding-1 over-greedy `</head>` pairing). jsdom (the oracle) shows the
+  // head closes at the FIRST boundary, the flow TEXT `x`, so `x` (and the later
+  // `y`) are body content and `.s{}` is body-region:
+  //   new JSDOM("<head>x<body>y</head><style>.s{}</style><body>real</body>")
+  //     .window.document.head.innerHTML === ""
+  //     .window.document.body.innerHTML === "xy<style>.s{}</style>real"
+  // The `<body>`/`</body>`/`</head>` tags are consumed as structure; `.s{}` is
+  // never hoisted (no head element survives). The masking intent is unchanged —
+  // a `<body>` inside CSS/a comment still cannot fake a boundary (see C/C'/M').
+  it("D: text + nested body in the head region → head closes at the text, .s{} kept in body", () => {
     const input = "<head>x<body>y</head><style>.s{}</style><body>real</body>";
     const hoisted = extractCompleteStyles(input);
     const body = processPartialHtml(input);
-    expect(hoisted).toBe(""); // .s{} is top-level, not in a head element
-    expect(body).toBe("<style>.s{}</style>real"); // kept in body, not dropped
+    expect(hoisted).toBe(""); // no head element survives ⇒ .s{} is body-region
+    expect(body).toBe("xy<style>.s{}</style>real"); // browser parity (jsdom)
   });
 
   // Case E — RED pre-fix: step 5's `/<body[^>]*>/i` (no word boundary) matched
@@ -348,12 +356,18 @@ describe("processPartialHtml / extractCompleteStyles — HTML comment masking", 
 });
 
 // ---------------------------------------------------------------------------
-// Unclosed <head> with body markup: the preview must agree with the final
-// document's effective rendering (assembleDocument leaves the in-head css in
-// the head and the body content in the body when no </head> is emitted —
-// browsers implicitly close <head> at <body>). Content must never vanish.
+// Unclosed <head> implicit close: the preview must agree with the final
+// document's effective rendering. A browser closes <head> at the FIRST of a
+// <body> token, a flow (non-head-permitted) start tag, or non-whitespace text —
+// leaving the in-head css in the head and everything from the boundary onward in
+// the body. Content must never vanish. jsdom (the browser-equivalent parser) is
+// the oracle for every expectation here:
+//   new JSDOM("<head><style>.a{}</style><body><p>hi</p></body>")…
+//     head.innerHTML === "<style>.a{}</style>", body.innerHTML === "<p>hi</p>"
+//   new JSDOM("<head><style>.a{}</style><p>x</p>")…
+//     head.innerHTML === "<style>.a{}</style>", body.innerHTML === "<p>x</p>"
 // ---------------------------------------------------------------------------
-describe("processPartialHtml / extractCompleteStyles — unclosed <head> implicit body close", () => {
+describe("processPartialHtml / extractCompleteStyles — unclosed <head> implicit close", () => {
   // RED pre-fix: extractCompleteStyles hoisted nothing (no complete head
   // element) AND step 3 stripped the unclosed <head> to end-of-string →
   // preview rendered empty while the final document renders the content.
@@ -367,7 +381,9 @@ describe("processPartialHtml / extractCompleteStyles — unclosed <head> implici
   });
 
   // The implicit close also strips the head region's non-style markup from the
-  // body, keeping only the body content (parity with the final document).
+  // body, keeping only the body content (parity with the final document). Title
+  // text content does NOT trigger the flow/text close — title is head-permitted
+  // RCDATA, so the scan skips its inner text to </title>.
   it("L': unclosed <head> with title + style before <body> → only body content remains", () => {
     const input =
       "<head><title>t</title><style>.a{}</style><body><p>x</p></body>";
@@ -375,21 +391,224 @@ describe("processPartialHtml / extractCompleteStyles — unclosed <head> implici
     expect(extractCompleteStyles(input)).toBe("<style>.a{}</style>");
   });
 
-  // Pin: an unclosed <head> with content but NO <body> token is still stripped
-  // (a head genuinely still streaming its own content). Current behavior — kept
-  // stable by the implicit-close rule firing ONLY on a <body> token.
-  it("M: unclosed <head> + content, NO <body> → stripped (pinned)", () => {
-    const input = "<head><style>.a{}</style><p>x</p>";
+  // Pin (re-scoped): an unclosed <head> whose region so far contains ONLY
+  // head-permitted content and has NO body/flow/text boundary is genuinely still
+  // streaming its own head — it is stripped (preview empty until more streams in,
+  // self-correcting). NOTE: a browser would already hoist `.a` (jsdom body ""),
+  // but mid-stream we defer to "" rather than flash a partial head. This pin is
+  // kept stable by the streaming guard in findHeadContentEnd (no boundary ⇒ null
+  // ⇒ no span ⇒ unterminated-head strip).
+  it("M: unclosed <head>, head-permitted content only, NO body/flow/text → stripped (pinned)", () => {
+    const input = "<head><style>.a{}</style>";
     expect(processPartialHtml(input)).toBe("");
     expect(extractCompleteStyles(input)).toBe("");
   });
 
-  // A <body> token inside a style/comment within the unclosed head must NOT be
-  // taken as the implicit close (masking guards it).
-  it("M': <body> token inside CSS in an unclosed head is not the implicit close", () => {
-    const input = '<head><style>.a{content:"<body>"}</style><p>x</p>';
-    // No REAL <body> token ⇒ unclosed head with no body ⇒ stripped (pinned).
+  // Pin (re-scoped): a <body> token inside a style/comment within an unclosed
+  // head must NOT be taken as the implicit close (masking guards it). With only
+  // head-permitted content and NO real body/flow/text boundary, the head is still
+  // streaming ⇒ stripped. jsdom agrees the body is "" here.
+  it("M': <body> token inside CSS in an unclosed head is not the implicit close (still streaming → stripped)", () => {
+    const input = '<head><style>.a{content:"<body>"}</style>';
+    // No REAL boundary ⇒ unclosed head still streaming ⇒ stripped (pinned).
     expect(processPartialHtml(input)).toBe("");
+    expect(extractCompleteStyles(input)).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FINDING 1 — the </head> pairing must not cross a <body> boundary. The old
+// scan paired a <head> open with the FIRST </head> ANYWHERE after it, even past
+// a <body> token, so body content was swallowed into the "head element" and the
+// preview went BLANK. A browser closes the head at the implicit <body> boundary
+// FIRST; a </head> after <body> is a stray close. jsdom is the oracle:
+//   "<head><style>.a{}</style><body><p>hi</p></head>" → body "<p>hi</p>"
+//   "<head><body><style>.b{}</style></head>"          → body "<style>.b{}</style>"
+//   "<head><style>.a{}</style><body>x</body><head><style>.b{}</style></head>"
+//                              → hoist ".a" only, body "x<style>.b{}</style>"
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — FINDING 1: </head> pairing bounded by <body>", () => {
+  // RED pre-fix: body "" (everything through the trailing </head> read as one
+  // head element). jsdom: head "<style>.a{}</style>", body "<p>hi</p>".
+  it("F1.a: <head>…</head> spanning past <body> → in-head style hoisted, body content kept", () => {
+    const input = "<head><style>.a{}</style><body><p>hi</p></head>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.a{}</style>"); // implicit close at <body>
+    expect(body).toBe("<p>hi</p>"); // not swallowed into the head element
+    expect(body).not.toContain("<style"); // hoisted XOR kept
+    expect(body).not.toContain("</head>"); // stray close not leaked
+  });
+
+  // RED pre-fix: the style after the implicit <body> close was hoisted (head
+  // span crossed <body>). jsdom keeps it in the body: head "", body
+  // "<style>.b{}</style>".
+  it("F1.b: <head><body><style> → style is body-region (not hoisted), kept in body", () => {
+    const input = "<head><body><style>.b{}</style></head>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe(""); // .b is after the implicit <body> close
+    expect(body).toBe("<style>.b{}</style>"); // kept in body, stray head tags dropped
+  });
+
+  // RED pre-fix: BOTH styles hoisted (head span ran to the trailing </head>).
+  // jsdom hoists only .a; .b (in the body-region second head) stays in the body.
+  it("F1.c: head, body, then a second head → only the first in-head style hoisted", () => {
+    const input =
+      "<head><style>.a{}</style><body>x</body><head><style>.b{}</style></head>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.a{}</style>"); // only the pre-<body> head
+    expect(body).toBe("x<style>.b{}</style>"); // body keeps x + the late style; stray head tags dropped
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FINDING 2 — a <head> nested inside the body region is body content, never a
+// head element; its style must NOT be hoisted (a cascade flip at the swap), and
+// the stray <head>/</head> tags are dropped while the content is kept. jsdom:
+//   "<head><style>.h{}</style></head><body><head><style>.b{}</style></head><p>x</p></body>"
+//     → head "<style>.h{}</style>", body "<style>.b{}</style><p>x</p>"
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — FINDING 2: nested <head> in body is body content", () => {
+  // RED pre-fix: both .h and .b hoisted. jsdom hoists only .h; .b stays in body.
+  it("F2.a: <head> inside <body> → only the real head's style hoisted, nested kept in body", () => {
+    const input =
+      "<head><style>.h{}</style></head><body><head><style>.b{}</style></head><p>x</p></body>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.h{}</style>"); // only the pre-<body> head element
+    expect(body).toBe("<style>.b{}</style><p>x</p>"); // nested head tags dropped, content kept
+    expect(body).not.toContain("<head>"); // stray nested head open dropped
+    expect(body).not.toContain("</head>"); // stray nested head close dropped
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FINDING 3 — a stray standalone </head> (unmatched by a counted head element)
+// must be stripped mask-aware, never leaked into the preview body as literal
+// text. jsdom:
+//   "<head>z</head><body><div>real</div></body></head>" → body "z<div>real</div>"
+//   "<head><style>.a{}</style></head><body><div>real</div></body></head>"
+//     → head "<style>.a{}</style>", body "<div>real</div>"
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — FINDING 3: stray </head> stripped, not leaked", () => {
+  // RED pre-fix: body "<div>real</div></head>" (the trailing </head> leaked).
+  // jsdom: body "z<div>real</div>" (z is flow text → head closes before it).
+  it("F3.a: trailing stray </head> after the body is stripped (text in head is body content)", () => {
+    const input = "<head>z</head><body><div>real</div></body></head>";
+    const body = processPartialHtml(input);
+    expect(body).toBe("z<div>real</div>");
+    expect(body).not.toContain("</head>"); // no literal close-tag leak
+  });
+
+  // RED pre-fix: body "<div>real</div></head>". jsdom: head "<style>.a{}</style>",
+  // body "<div>real</div>".
+  it("F3.b: in-head style hoisted, trailing stray </head> stripped from the body", () => {
+    const input =
+      "<head><style>.a{}</style></head><body><div>real</div></body></head>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.a{}</style>");
+    expect(body).toBe("<div>real</div>");
+    expect(body).not.toContain("</head>");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FINDING 4 — a browser opens the body once; a SECOND <body> open token is
+// dropped and its following markup stays in the one body. Step 5 must remove
+// EVERY <body> open, not just the first. jsdom:
+//   "<body><p>a</p><body><p>b</p>" → body "<p>a</p><p>b</p>"
+// ---------------------------------------------------------------------------
+describe("processPartialHtml — FINDING 4: every <body> open removed (duplicate not leaked)", () => {
+  // RED pre-fix: body "<p>a</p><body><p>b</p>" (the second <body> leaked as text).
+  it("F4.a: duplicate <body> open is removed, both contents kept in the body", () => {
+    const input = "<body><p>a</p><body><p>b</p>";
+    const body = processPartialHtml(input);
+    expect(body).toBe("<p>a</p><p>b</p>");
+    expect(body).not.toContain("<body"); // no duplicate open-tag leak
+  });
+
+  // A duplicate <body> with attributes is also dropped (quote-aware open scan).
+  it("F4.b: duplicate <body> with attributes is removed, no attribute fragments leak", () => {
+    const input = '<body class="x"><p>a</p><body data-y="b>c"><p>b</p>';
+    const body = processPartialHtml(input);
+    expect(body).toBe("<p>a</p><p>b</p>");
+    expect(body).not.toContain("<body");
+    expect(body).not.toContain('c">'); // quoted > did not truncate the open tag
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FINDING 5 — the implicit head close fires at the first NON-HEAD content, not
+// only at a <body> token: a flow (non-head-permitted) start tag, or the first
+// non-whitespace text character. Otherwise an unclosed head with flow content
+// and no <body> would strip to end-of-string and render BLANK while the browser
+// renders the flow content. jsdom is the oracle:
+//   "<head><style>.a{}</style><p>x</p>"     → head "<style>.a{}</style>", body "<p>x</p>"
+//   "<head><style>.a{}</style>plaintext"    → head "<style>.a{}</style>", body "plaintext"
+//   "<head><style>.a{}</style><div>flow</div><style>.b{}</style>"
+//                            → head "<style>.a{}</style>", body "<div>flow</div><style>.b{}</style>"
+// The streaming guard (head-permitted-only content with no boundary, or a
+// trailing incomplete tag) is pinned by case M / M' above.
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — FINDING 5: implicit close at flow / text", () => {
+  // RED pre-fix: hoist "" AND body "" (unclosed head stripped to end-of-string).
+  // jsdom hoists .a and renders <p>x</p>.
+  it("F5.a: unclosed <head> + style + flow tag (no <body>) → style hoisted, flow kept", () => {
+    const input = "<head><style>.a{}</style><p>x</p>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.a{}</style>"); // implicit close at <p>
+    expect(body).toBe("<p>x</p>"); // flow content kept, not stripped
+    expect(body).not.toContain("<style");
+  });
+
+  // RED pre-fix: hoist "" AND body "". jsdom: head ".a", body "plaintext"
+  // (non-whitespace text closes the head).
+  it("F5.b: unclosed <head> + style + bare text (no <body>) → style hoisted, text kept", () => {
+    const input = "<head><style>.a{}</style>plaintext";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.a{}</style>"); // implicit close at the text
+    expect(body).toBe("plaintext");
+  });
+
+  // RED pre-fix: hoist "" AND body "". jsdom hoists only the pre-flow .a; the
+  // post-flow .b is body-region.
+  it("F5.c: flow tag splits head/body → only the pre-flow style hoisted, rest in body", () => {
+    const input = "<head><style>.a{}</style><div>flow</div><style>.b{}</style>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.a{}</style>"); // pre-flow, in head
+    expect(body).toBe("<div>flow</div><style>.b{}</style>"); // post-flow, in body
+  });
+
+  // Leading whitespace inside the head does NOT close it; the style after the
+  // whitespace is still in-head. jsdom: head "...<style>.a{}</style>...", body "<p>x</p>".
+  it("F5.d: whitespace in head is not flow content; style stays in head", () => {
+    const input = "<head>   <style>.a{}</style>   <p>x</p>";
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.a{}</style>"); // whitespace did not close the head
+    expect(processPartialHtml(input)).toBe("<p>x</p>");
+  });
+
+  // A trailing INCOMPLETE tag prefix (`<ti`) is indeterminate mid-stream — the
+  // head must NOT close on it. With only head-permitted content + an incomplete
+  // tail, the head is still streaming ⇒ stripped (self-corrects next chunk).
+  it("F5.e: trailing incomplete tag does not trigger the implicit close (still streaming → stripped)", () => {
+    const input = "<head><style>.a{}</style><ti";
+    expect(processPartialHtml(input)).toBe("");
+    expect(extractCompleteStyles(input)).toBe("");
+  });
+
+  // A meta (head-permitted void) followed by flow closes the head at the flow
+  // tag. jsdom: head "<meta charset=...>", body "<h1>title</h1>".
+  it("F5.f: head-permitted void tag then flow → flow content kept in body", () => {
+    const input = "<head><meta charset='utf-8'><h1>title</h1>";
+    expect(processPartialHtml(input)).toBe("<h1>title</h1>");
+    expect(extractCompleteStyles(input)).toBe(""); // no styles
   });
 });
 

--- a/packages/react-core/src/v2/lib/__tests__/processPartialHtml.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/processPartialHtml.test.ts
@@ -425,6 +425,37 @@ describe("processPartialHtml — tolerant <html> wrapper strip", () => {
       '<style>.a{content:"<html>"}</style><div>x</div>',
     );
   });
+
+  // Close-tag analogs of N''' — the trailing </html> strip must also run on a
+  // MASKED string (like every other structural op in the module), so a </html>
+  // token inside SURVIVING body content is never deleted.
+  //
+  // RED pre-fix: the final `result.replace(/<\/html>/gi, "")` ran on the UNMASKED
+  // result, so a </html> token inside CSS content was deleted, emptying it.
+  it("N'''': </html> token inside CSS content cannot fake the wrapper strip", () => {
+    const input =
+      '<div>x</div><style>.a::before{content:"</html>"}</style><div>y</div>';
+    expect(processPartialHtml(input)).toBe(
+      '<div>x</div><style>.a::before{content:"</html>"}</style><div>y</div>',
+    );
+  });
+
+  // RED pre-fix: a </html> token inside a complete comment's text was deleted.
+  it("N''''': </html> token inside a complete comment is preserved", () => {
+    const input = "<div>x</div><!-- ex </html> --><div>y</div>";
+    expect(processPartialHtml(input)).toBe(
+      "<div>x</div><!-- ex </html> --><div>y</div>",
+    );
+  });
+
+  // RED pre-fix: a </html> token inside a <style> open-tag attribute value was
+  // deleted (the attribute is blanked in the mask, so masked search skips it).
+  it("N'''''': </html> token in a <style> attribute value is preserved", () => {
+    const input = '<style data-note="</html>">.a{}</style>';
+    expect(processPartialHtml(input)).toBe(
+      '<style data-note="</html>">.a{}</style>',
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -480,5 +511,23 @@ describe("processPartialHtml / extractCompleteStyles — quote-aware style open 
     expect(processPartialHtml(input)).toBe(
       '<style data-y="</body>">.foo{}</style><p>p</p>',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trailing-entity strip — BY DESIGN, not a bug. At a chunk boundary, a literal
+// `&D` is indistinguishable from a developing entity (`&Dagger;`, `&Delta;`, …),
+// so the conservative choice is to drop the dangling `&…` run. This is GREEN
+// against current source (it pins existing behavior, no source change). It
+// self-corrects: the next chunk re-renders with the full text, and the final
+// document never runs processPartialHtml at all (assembleDocument renders the
+// completed HTML directly), so `R&D` is whole in the delivered result.
+// ---------------------------------------------------------------------------
+describe("processPartialHtml — trailing-entity strip (intended tradeoff)", () => {
+  it("Q: a chunk ending in literal `&D` drops the dangling run mid-stream", () => {
+    // `<p>R&D` → `<p>R`: `&D` could be the start of `&Dagger;`, so the strip is
+    // conservative. Pinned as intended — corrected on the next chunk and at
+    // completion (the final document does not run processPartialHtml).
+    expect(processPartialHtml("<p>R&D")).toBe("<p>R");
   });
 });

--- a/packages/react-core/src/v2/lib/assembleDocument.ts
+++ b/packages/react-core/src/v2/lib/assembleDocument.ts
@@ -34,7 +34,10 @@ export const DEFAULT_OPEN_GEN_UI_LIBRARIES: Record<string, string> = {
  * - For every override key `K` that does NOT end with `/`, where `defaults`
  *   has a `K + "/"` sibling and `overrides` did NOT explicitly provide
  *   `K + "/"`: set `K + "/"` to the override URL with a single trailing slash
- *   appended (appended only if the URL does not already end with one).
+ *   inserted into the PATH — before any `?` query string or `#` fragment
+ *   (appended only if that path part does not already end with one). esm.sh
+ *   query idioms like `?bundle` are routine, so appending the slash after the
+ *   query (`…three@x?bundle/`) would yield a broken subpath URL.
  * - Explicit user `K/` entries always win (never clobbered by derivation).
  * - New libraries with no default sibling get no invented `K/` entry.
  * - Override keys that themselves end in `/` are treated as plain entries.
@@ -57,7 +60,19 @@ export function mergeLibraries(
       !Object.prototype.hasOwnProperty.call(overrides, slashKey)
     ) {
       const url = overrides[key];
-      merged[slashKey] = url.endsWith("/") ? url : url + "/";
+      // Insert the subpath slash into the PATH, before any query (`?`) or
+      // fragment (`#`) — whichever comes first. A pure string split (no URL
+      // constructor) keeps relative-protocol and exotic specifiers unharmed.
+      // Appending the slash after a query (`…?bundle/`) would break the URL,
+      // and esm.sh query idioms (`?bundle`, `?dev`, `?target=es2022`) are
+      // routine.
+      const qIdx = url.indexOf("?");
+      const hIdx = url.indexOf("#");
+      const sepIdx =
+        qIdx === -1 ? hIdx : hIdx === -1 ? qIdx : Math.min(qIdx, hIdx);
+      const path = sepIdx === -1 ? url : url.slice(0, sepIdx);
+      const rest = sepIdx === -1 ? "" : url.slice(sepIdx);
+      merged[slashKey] = path.endsWith("/") ? url : path + "/" + rest;
     }
   }
 

--- a/packages/react-core/src/v2/lib/assembleDocument.ts
+++ b/packages/react-core/src/v2/lib/assembleDocument.ts
@@ -94,9 +94,12 @@ export interface AssembleDocumentOptions {
 /**
  * Builds an HTML `<script type="importmap">` tag from the given library map.
  * The map is serialised as `{ imports: libs }` per the importmap spec.
+ * Every `<` is escaped inside the serialized JSON (a lossless encoding) so a
+ * URL containing `</script>` cannot terminate the importmap tag early.
  */
 export function buildImportMapScript(libs: Record<string, string>): string {
-  return `<script type="importmap">${JSON.stringify({ imports: libs })}</script>`;
+  const json = JSON.stringify({ imports: libs }).replace(/</g, "\\u003c");
+  return `<script type="importmap">${json}</script>`;
 }
 
 /**

--- a/packages/react-core/src/v2/lib/assembleDocument.ts
+++ b/packages/react-core/src/v2/lib/assembleDocument.ts
@@ -125,6 +125,22 @@ export function ensureHead(html: string): string {
  * : html)` path for ALL inputs, by construction (the legacy composition is
  * reproduced verbatim, injecting CSS into the raw html *before* ensuring head).
  *
+ * Literal-`<head>` normalization (NON-LEGACY path only): `@jetbrains/websandbox`
+ * requires the exact 6-character lowercase token `<head>` in `frameContent` — it
+ * throws `'Websandbox: iFrame content must have "<head>" tag.'` when
+ * `!frameContent.includes('<head>')` (case-sensitive) and its bootstrap injects
+ * via an exact `replace('<head>', '<head>\n<script>…')`
+ * (see websandbox.js:450/462). An LLM-emitted document whose head-opening tag is
+ * attributed or uppercase (`<head lang="en">`, `<HEAD>`, `<head >`) would
+ * therefore fail to mount (stuck behind the loading spinner). So when the
+ * quote-aware head-open matcher lands on a token that is NOT exactly `<head>`,
+ * this path REPLACES that token with the literal `<head>` while splicing the
+ * prefix. Head attributes (`lang`, `profile`, …) have negligible runtime
+ * semantics and CANNOT be preserved: websandbox demands the exact `<head>`
+ * token, so the matched token's attributes are intentionally dropped. The legacy
+ * branch is byte-identity-locked and is NOT touched (this failure pre-existed
+ * there).
+ *
  * Pure string function — no DOM, no React.
  */
 export function assembleDocument(
@@ -191,11 +207,27 @@ export function assembleDocument(
   // the first quoted `>` (which would splice the prefix mid-attribute).
   const headOpenMatch = html.match(/<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i);
   if (headOpenMatch && headOpenMatch.index !== undefined) {
-    prefixInsertAt = headOpenMatch.index + headOpenMatch[0].length;
-    html = html.slice(0, prefixInsertAt) + prefix + html.slice(prefixInsertAt);
-    // The inserted prefix shifts the insertion point past its own bytes so
-    // the css fallback lands after the prefix (kit), preserving the cascade.
-    prefixInsertAt += prefix.length;
+    const matchIdx = headOpenMatch.index;
+    const matchedToken = headOpenMatch[0];
+    // websandbox requires the exact 6-char literal `<head>` (see JSDoc above):
+    // it `.includes('<head>')`-gates mounting and `.replace('<head>', …)`s to
+    // inject its bootstrap. If the matched open token is anything else
+    // (`<head lang="en">`, `<HEAD>`, `<head >`), REPLACE it with the literal
+    // `<head>` while splicing the prefix — the token's attributes are dropped
+    // (they have negligible runtime semantics and cannot be preserved). When
+    // the token is already exactly `<head>`, `headOpen.length === 6 ===
+    // matchedToken.length`, so this reduces to a verbatim splice-after-token.
+    const headOpen = "<head>";
+    // Anchor all offsets to the POST-replacement string: the rewritten region
+    // is `headOpen + prefix + <original content after the matched token>`, so
+    // the insertion point sits just past the prefix (start of the original head
+    // content), preserving the cascade for the css fallback below.
+    prefixInsertAt = matchIdx + headOpen.length + prefix.length;
+    html =
+      html.slice(0, matchIdx) +
+      headOpen +
+      prefix +
+      html.slice(matchIdx + matchedToken.length);
   } else {
     // No real head-opening tag exists that we can anchor to (e.g. an
     // unterminated `<head \nclass=x` token that `ensureHead` saw via

--- a/packages/react-core/src/v2/lib/assembleDocument.ts
+++ b/packages/react-core/src/v2/lib/assembleDocument.ts
@@ -16,6 +16,55 @@ export const DEFAULT_OPEN_GEN_UI_LIBRARIES: Record<string, string> = {
 };
 
 /**
+ * Merges user-supplied importmap overrides over a set of defaults, keeping the
+ * bare specifier and its trailing-slash subpath sibling pinned to the SAME
+ * version.
+ *
+ * The defaults register every pre-wired library as a PAIR — a bare specifier
+ * (`three`) and a trailing-slash subpath form (`three/`) — both pinned to one
+ * version, because the tool guidance tells the model to use BOTH forms
+ * (`import * as THREE from "three"` AND `three/examples/jsm/…`). A naive flat
+ * spread (`{ ...defaults, ...overrides }`) re-pins only the bare key the user
+ * passed, leaving its `lib/` sibling on the stale default version — so a
+ * generated scene would load two different copies of the same library in one
+ * sandbox (instanceof failures, duplicate singletons).
+ *
+ * Semantics:
+ * - Start from `{ ...defaults, ...overrides }`.
+ * - For every override key `K` that does NOT end with `/`, where `defaults`
+ *   has a `K + "/"` sibling and `overrides` did NOT explicitly provide
+ *   `K + "/"`: set `K + "/"` to the override URL with a single trailing slash
+ *   appended (appended only if the URL does not already end with one).
+ * - Explicit user `K/` entries always win (never clobbered by derivation).
+ * - New libraries with no default sibling get no invented `K/` entry.
+ * - Override keys that themselves end in `/` are treated as plain entries.
+ *
+ * Pure function — no DOM, no React. Does not mutate its arguments.
+ */
+export function mergeLibraries(
+  defaults: Record<string, string>,
+  overrides: Record<string, string>,
+): Record<string, string> {
+  const merged: Record<string, string> = { ...defaults, ...overrides };
+
+  for (const key of Object.keys(overrides)) {
+    if (key.endsWith("/")) continue;
+    const slashKey = key + "/";
+    // Only re-pin a subpath sibling that the DEFAULTS define; never invent one
+    // for a brand-new library. An explicit override of `slashKey` always wins.
+    if (
+      Object.prototype.hasOwnProperty.call(defaults, slashKey) &&
+      !Object.prototype.hasOwnProperty.call(overrides, slashKey)
+    ) {
+      const url = overrides[key];
+      merged[slashKey] = url.endsWith("/") ? url : url + "/";
+    }
+  }
+
+  return merged;
+}
+
+/**
  * Options for `assembleDocument`.
  */
 export interface AssembleDocumentOptions {

--- a/packages/react-core/src/v2/lib/assembleDocument.ts
+++ b/packages/react-core/src/v2/lib/assembleDocument.ts
@@ -119,13 +119,24 @@ export function assembleDocument(
   // Match only a real head-opening tag: `<head>`, or `<head` followed by
   // whitespace + attributes. This deliberately excludes `<header …>`, which the
   // looser `/<head[^>]*>/i` would have captured (injecting into the body).
-  const headOpenMatch = html.match(/<head(\s[^>]*)?>/i);
+  // `[^<>]*` (not `[^>]*`) bounds the attribute span so the tag can never
+  // greedily swallow a following `<tag>` — e.g. `<head\t<body>` no longer
+  // matches as one "opening tag" and splices the prefix into the body.
+  const headOpenMatch = html.match(/<head(\s[^<>]*)?>/i);
   if (headOpenMatch && headOpenMatch.index !== undefined) {
     prefixInsertAt = headOpenMatch.index + headOpenMatch[0].length;
     html = html.slice(0, prefixInsertAt) + prefix + html.slice(prefixInsertAt);
     // The inserted prefix shifts the insertion point past its own bytes so
     // the css fallback lands after the prefix (kit), preserving the cascade.
     prefixInsertAt += prefix.length;
+  } else {
+    // No real head-opening tag exists that we can anchor to (e.g. an
+    // unterminated `<head \nclass=x` token that `ensureHead` saw via
+    // `/<head[\s>]/` and therefore declined to prepend). Synthesize a head at
+    // position 0 carrying the prefix — and, in cascade order, the agent css —
+    // so the prefix is NEVER dropped. We return immediately: the css here is
+    // already injected, so the css branch below must not run for this path.
+    return `<head>${prefix}${css ? `<style>${css}</style>` : ""}</head>` + html;
   }
 
   // Inject agent CSS immediately before </head> (legacy algorithm).

--- a/packages/react-core/src/v2/lib/assembleDocument.ts
+++ b/packages/react-core/src/v2/lib/assembleDocument.ts
@@ -103,6 +103,41 @@ export function buildImportMapScript(libs: Record<string, string>): string {
 }
 
 /**
+ * Neutralizes any `</style` close-tag sequence inside CSS that is about to be
+ * spliced RAW into a `<style>…</style>` element, so agent-supplied CSS (the
+ * `css` tool parameter, and the custom design-system kit css from
+ * `designSystem: { css }`) cannot break out of the style element and inject live
+ * markup. A css value of `a{}</style><script>alert(1)</script>` would otherwise
+ * produce `…<style>a{}</style><script>alert(1)</script></style>…` — the literal
+ * `</style>` closes the element early and the `<script>` becomes LIVE in the
+ * sandbox. This mirrors the `<`-escape {@link buildImportMapScript} already
+ * applies to the importmap script sink, making the protection consistent across
+ * sinks.
+ *
+ * The escape inserts a CSS backslash into the `/` of every `</style` (matched
+ * case-insensitively): `</style` -> `<\/style` (the original case of `/style` is
+ * preserved via `$1`). It is LOSSLESS by construction:
+ * - Inside a CSS string (`content: "</style>"`), `\/` unescapes to `/`, so the
+ *   computed value is IDENTICAL to the un-escaped form — only the bytes that
+ *   reach the HTML tokenizer change, never the CSS semantics.
+ * - Outside a string the sequence `</style` is invalid CSS either way (a `<` is
+ *   not a valid token start in a stylesheet), so escaping it changes nothing
+ *   that ever parsed as meaningful CSS — but the escaped form can no longer
+ *   terminate the enclosing `<style>` element.
+ *
+ * Defined once and reused at every `<style>` injection sink (the splices in
+ * {@link assembleDocument} and the preview's `buildPreviewHeadHtml` in
+ * OpenGenerativeUIRenderer.tsx) so preview and final escape IDENTICALLY and
+ * their byte/cascade parity holds. The Vue-side agent MUST mirror these exact
+ * semantics byte-for-byte.
+ *
+ * Pure string function — no DOM, no React.
+ */
+export function escapeStyleClose(css: string): string {
+  return css.replace(/<(\/style)/gi, "<\\$1");
+}
+
+/**
  * Ensures the HTML string contains a `<head>` element.
  * If no `<head>` tag is found, prepends `<head></head>` to the string.
  * Ported byte-equivalently from `OpenGenerativeUIRenderer.tsx`.
@@ -201,12 +236,19 @@ function maskInertSpans(html: string): string {
  * Backward-compat invariant (legacy path): when no prefix is injected — i.e.
  * `designSystemCss` is falsy AND `importMap` is falsy or an empty object — the
  * legacy output L is computed verbatim as `ensureHead(css ? injectCssIntoHtml(
- * html, css) : html)` (the CSS injected into the raw html *before* ensuring
- * head). The contract is then:
+ * html, {@link escapeStyleClose}(css)) : html)` (the agent css, `</style`-escaped,
+ * injected into the raw html *before* ensuring head). The contract is then
+ * byte-identical to the historical path EXCEPT for two carve-outs — (a) the
+ * head-token mount normalization described next, and (b) `</style` sequences in
+ * the agent css are escaped (see the `</style`-escape note below; previously they
+ * broke out of the style element — a correctness/security defect, never a working
+ * behavior). With those carve-outs:
  * - If L ALREADY contains the literal 6-character lowercase token `<head>`,
- *   return L UNCHANGED — byte-identical to the historical path. EVERY input that
- *   previously mounted in `@jetbrains/websandbox` lands here, because mounting
- *   itself requires that literal token (see the literal-`<head>` note below).
+ *   return L UNCHANGED (modulo the `</style`-escape, which only ever differs by
+ *   inserted backslashes) — byte-identical to the historical path. EVERY input
+ *   that previously mounted in `@jetbrains/websandbox` lands here, because
+ *   mounting itself requires that literal token (see the literal-`<head>` note
+ *   below).
  * - Otherwise L has only an uppercase/attributed head-open tag (`<HEAD>`,
  *   `<head lang="en">`, `<head >`) and so contains no literal `<head>`. Such an
  *   artifact ALWAYS failed to mount before (no previously-working output reaches
@@ -252,6 +294,22 @@ function maskInertSpans(html: string): string {
  * branch is byte-identity-locked and is NOT touched (this failure pre-existed
  * there).
  *
+ * `</style`-escape (ALL paths — non-legacy AND legacy): the agent css
+ * (`opts.css`) and the design-system kit css (`opts.designSystemCss`) are spliced
+ * RAW into `<style>…</style>` elements. A css value containing `</style` would
+ * otherwise close the element early and turn whatever follows into LIVE markup in
+ * the sandbox (`css: "a{}</style><script>…</script>"`). So BOTH css values pass
+ * through {@link escapeStyleClose} at EVERY `<style>` sink before splicing —
+ * `</style` -> `<\/style`, lossless inside CSS strings, inert outside them. This
+ * mirrors the `<`-escape {@link buildImportMapScript} applies to the importmap
+ * sink, making the breakout protection consistent across every sink. The escape
+ * is the legacy path's SECOND byte-identity carve-out (alongside head-token mount
+ * normalization): legacy outputs whose css lacks `</style` stay byte-identical;
+ * css containing `</style` differs ONLY by the inserted backslashes. The same
+ * helper is reused by the preview's `buildPreviewHeadHtml`
+ * (OpenGenerativeUIRenderer.tsx) so preview and final escape IDENTICALLY and
+ * their cascade/byte parity holds.
+ *
  * Pure string function — no DOM, no React.
  */
 export function assembleDocument(
@@ -265,8 +323,11 @@ export function assembleDocument(
   // otherwise emit an inert `<script type="importmap">{"imports":{}}</script>`.
   const hasImports = !!importMap && Object.keys(importMap).length > 0;
   const importMapPart = hasImports ? buildImportMapScript(importMap) : "";
+  // Escape `</style` in the kit css so it cannot break out of the style element
+  // (lossless — see escapeStyleClose). The importmap sink is already guarded by
+  // buildImportMapScript's `<`-escape.
   const designSystemPart = designSystemCss
-    ? `<style data-ck-design-system>${designSystemCss}</style>`
+    ? `<style data-ck-design-system>${escapeStyleClose(designSystemCss)}</style>`
     : "";
   const prefix = importMapPart + designSystemPart;
 
@@ -287,13 +348,21 @@ export function assembleDocument(
   if (!nonLegacy) {
     let legacy: string;
     if (css) {
+      // Escape `</style` in the agent css before splicing it RAW into a `<style>`
+      // element (lossless — see escapeStyleClose). This is the legacy path's
+      // SECOND byte-identity carve-out (alongside head-token mount
+      // normalization): css lacking `</style` stays byte-identical to the
+      // historical composition; css containing `</style` differs ONLY by the
+      // inserted backslashes (previously it broke out of the style element — a
+      // security defect, never a working behavior).
+      const safeCss = escapeStyleClose(css);
       const headCloseIdx = html.indexOf("</head>");
       const injected =
         headCloseIdx !== -1
           ? html.slice(0, headCloseIdx) +
-            `<style>${css}</style>` +
+            `<style>${safeCss}</style>` +
             html.slice(headCloseIdx)
-          : `<head><style>${css}</style></head>${html}`;
+          : `<head><style>${safeCss}</style></head>${html}`;
       legacy = ensureHead(injected);
     } else {
       legacy = ensureHead(html);
@@ -379,7 +448,12 @@ export function assembleDocument(
     // position 0 carrying the prefix — and, in cascade order, the agent css —
     // so the prefix is NEVER dropped. We return immediately: the css here is
     // already injected, so the css branch below must not run for this path.
-    return `<head>${prefix}${css ? `<style>${css}</style>` : ""}</head>` + html;
+    // Escape `</style` in the agent css so it cannot break out of the style
+    // element (lossless — see escapeStyleClose).
+    return (
+      `<head>${prefix}${css ? `<style>${escapeStyleClose(css)}</style>` : ""}</head>` +
+      html
+    );
   }
 
   // Inject agent CSS immediately before </head> (legacy algorithm), but match
@@ -407,13 +481,18 @@ export function assembleDocument(
   // inert region. The injected prefix's own `<script type="importmap">`/`<style>`
   // content is masked too (it carries no `</head>`), so this is safe.
   if (css) {
+    // Escape `</style` in the agent css before splicing it RAW into a `<style>`
+    // element at any of the sinks below (lossless — see escapeStyleClose). This
+    // mirrors the kit-css escape on the prefix above, so the preview and final
+    // documents escape IDENTICALLY.
+    const safeCss = escapeStyleClose(css);
     const maskedAfter = maskInertSpans(html);
     const closeRel = maskedAfter.slice(prefixInsertAt).search(/<\/head>/i);
     const headCloseIdx = closeRel !== -1 ? closeRel + prefixInsertAt : -1;
     if (headCloseIdx !== -1) {
       return (
         html.slice(0, headCloseIdx) +
-        `<style>${css}</style>` +
+        `<style>${safeCss}</style>` +
         html.slice(headCloseIdx)
       );
     }
@@ -436,7 +515,7 @@ export function assembleDocument(
       const bodyOpenIdx = bodyRel + prefixInsertAt;
       return (
         html.slice(0, bodyOpenIdx) +
-        `<style>${css}</style>` +
+        `<style>${safeCss}</style>` +
         html.slice(bodyOpenIdx)
       );
     }
@@ -448,11 +527,11 @@ export function assembleDocument(
     if (prefixInsertAt !== undefined) {
       return (
         html.slice(0, prefixInsertAt) +
-        `<style>${css}</style>` +
+        `<style>${safeCss}</style>` +
         html.slice(prefixInsertAt)
       );
     }
-    return `<head><style>${css}</style></head>${html}`;
+    return `<head><style>${safeCss}</style></head>${html}`;
   }
 
   return html;

--- a/packages/react-core/src/v2/lib/assembleDocument.ts
+++ b/packages/react-core/src/v2/lib/assembleDocument.ts
@@ -119,10 +119,13 @@ export function assembleDocument(
   // Match only a real head-opening tag: `<head>`, or `<head` followed by
   // whitespace + attributes. This deliberately excludes `<header …>`, which the
   // looser `/<head[^>]*>/i` would have captured (injecting into the body).
-  // `[^<>]*` (not `[^>]*`) bounds the attribute span so the tag can never
-  // greedily swallow a following `<tag>` — e.g. `<head\t<body>` no longer
-  // matches as one "opening tag" and splices the prefix into the body.
-  const headOpenMatch = html.match(/<head(\s[^<>]*)?>/i);
+  // The attribute span is quote-aware: unquoted runs forbid `<`/`>` (so the tag
+  // can never greedily swallow a following `<tag>` — e.g. `<head\t<body>` does
+  // not match as one opening tag and splice the prefix into the body), while
+  // quoted runs (`"…"` / `'…'`) may contain `<`/`>` so a realistic
+  // `<head data-config='{"a":">"}'>` is matched whole rather than truncated at
+  // the first quoted `>` (which would splice the prefix mid-attribute).
+  const headOpenMatch = html.match(/<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i);
   if (headOpenMatch && headOpenMatch.index !== undefined) {
     prefixInsertAt = headOpenMatch.index + headOpenMatch[0].length;
     html = html.slice(0, prefixInsertAt) + prefix + html.slice(prefixInsertAt);
@@ -139,9 +142,15 @@ export function assembleDocument(
     return `<head>${prefix}${css ? `<style>${css}</style>` : ""}</head>` + html;
   }
 
-  // Inject agent CSS immediately before </head> (legacy algorithm).
+  // Inject agent CSS immediately before </head> (legacy algorithm), but match
+  // the close tag case-insensitively here so it pairs with the case-insensitive
+  // open-tag match above. A case-sensitive `indexOf("</head>")` would miss an
+  // uppercase `</HEAD>`, dropping the css after the kit (via the prefixInsertAt
+  // fallback) and inverting the cascade — the agent css must win over existing
+  // head content. (The LEGACY branch keeps the exact `indexOf` for byte
+  // identity; this case-insensitive lookup is non-legacy only.)
   if (css) {
-    const headCloseIdx = html.indexOf("</head>");
+    const headCloseIdx = html.search(/<\/head>/i);
     if (headCloseIdx !== -1) {
       return (
         html.slice(0, headCloseIdx) +

--- a/packages/react-core/src/v2/lib/assembleDocument.ts
+++ b/packages/react-core/src/v2/lib/assembleDocument.ts
@@ -55,9 +55,11 @@ export function ensureHead(html: string): string {
  * 4. `<style>` containing `opts.css` — agent-authored CSS, immediately before
  *    `</head>` so it wins over the kit on specificity ties
  *
- * Backward-compat invariant: when both `designSystemCss` and `importMap` are
- * falsy, the output is byte-identical to the legacy
- * `ensureHead(css ? injectCssIntoHtml(html, css) : html)` path.
+ * Backward-compat invariant: when no prefix is injected — i.e. `designSystemCss`
+ * is falsy AND `importMap` is falsy or an empty object — the output is
+ * byte-identical to the legacy `ensureHead(css ? injectCssIntoHtml(html, css)
+ * : html)` path for ALL inputs, by construction (the legacy composition is
+ * reproduced verbatim, injecting CSS into the raw html *before* ensuring head).
  *
  * Pure string function — no DOM, no React.
  */
@@ -67,25 +69,48 @@ export function assembleDocument(
 ): string {
   const { css, designSystemCss, importMap } = opts;
 
-  // Step 1: ensure a <head> tag exists.
-  html = ensureHead(html);
-
-  // Step 2: build the prefix to insert immediately after the opening <head…> tag.
+  // Build the prefix to insert immediately after the opening <head…> tag.
   // An empty importMap object ({}) is treated as no importmap — it would
   // otherwise emit an inert `<script type="importmap">{"imports":{}}</script>`.
-  const importMapPart =
-    importMap && Object.keys(importMap).length > 0
-      ? buildImportMapScript(importMap)
-      : "";
+  const hasImports = !!importMap && Object.keys(importMap).length > 0;
+  const importMapPart = hasImports ? buildImportMapScript(importMap) : "";
   const designSystemPart = designSystemCss
     ? `<style data-ck-design-system>${designSystemCss}</style>`
     : "";
   const prefix = importMapPart + designSystemPart;
 
-  // Non-legacy mode is active whenever a design-system or importmap injection is
-  // requested. The agent-css fallback below is scoped to this path so the legacy
-  // mode (both falsy) stays byte-identical to the original algorithm.
-  const nonLegacy = Boolean(designSystemCss) || Boolean(importMap);
+  // Non-legacy mode means "a prefix was actually injected". An empty importMap
+  // ({}) with no design-system CSS produces an empty prefix and therefore stays
+  // on the pure-legacy path — `importMap: {}` behaves exactly like `importMap:
+  // false`. (Equivalent to `Boolean(designSystemCss) || hasImports`.)
+  const nonLegacy = prefix !== "";
+
+  // PURE LEGACY PATH — no prefix to inject. Reproduce the legacy composition
+  // verbatim: inject the agent CSS into the RAW html first (the legacy
+  // injectCssIntoHtml algorithm), THEN ensure a <head> exists (legacy
+  // ensureHead). Applying the two helpers in this order makes the output
+  // byte-identical to the legacy path for ALL inputs by construction —
+  // including degenerate inputs where `</head>` appears before/without an
+  // opening `<head>` (ensuring head first would otherwise inject a spurious
+  // earlier `</head>` and the CSS would land in the wrong place).
+  if (!nonLegacy) {
+    if (css) {
+      const headCloseIdx = html.indexOf("</head>");
+      const injected =
+        headCloseIdx !== -1
+          ? html.slice(0, headCloseIdx) +
+            `<style>${css}</style>` +
+            html.slice(headCloseIdx)
+          : `<head><style>${css}</style></head>${html}`;
+      return ensureHead(injected);
+    }
+    return ensureHead(html);
+  }
+
+  // ASSEMBLED (NON-LEGACY) PATH — a prefix exists. Ensure a <head> first so the
+  // prefix has a real head-opening tag to anchor to, then inject prefix +
+  // agent css, preserving the documented cascade: importmap -> kit -> agent css.
+  html = ensureHead(html);
 
   // Track where the prefix's opening <head…> tag ends so the css fallback can
   // inject immediately after the prefix instead of prepending a second head.
@@ -97,16 +122,13 @@ export function assembleDocument(
   const headOpenMatch = html.match(/<head(\s[^>]*)?>/i);
   if (headOpenMatch && headOpenMatch.index !== undefined) {
     prefixInsertAt = headOpenMatch.index + headOpenMatch[0].length;
-    if (prefix) {
-      html =
-        html.slice(0, prefixInsertAt) + prefix + html.slice(prefixInsertAt);
-      // The inserted prefix shifts the insertion point past its own bytes so
-      // the css fallback lands after the prefix (kit), preserving the cascade.
-      prefixInsertAt += prefix.length;
-    }
+    html = html.slice(0, prefixInsertAt) + prefix + html.slice(prefixInsertAt);
+    // The inserted prefix shifts the insertion point past its own bytes so
+    // the css fallback lands after the prefix (kit), preserving the cascade.
+    prefixInsertAt += prefix.length;
   }
 
-  // Step 3: inject agent CSS immediately before </head> (legacy algorithm).
+  // Inject agent CSS immediately before </head> (legacy algorithm).
   if (css) {
     const headCloseIdx = html.indexOf("</head>");
     if (headCloseIdx !== -1) {
@@ -116,12 +138,11 @@ export function assembleDocument(
         html.slice(headCloseIdx)
       );
     }
-    // No </head> exists. In non-legacy mode a real head-opening tag is always
-    // present (ensureHead guarantees it), so inject the agent css right after
-    // the kit/importmap prefix — keeping the documented cascade (kit first,
-    // agent css after) and avoiding a duplicate <head>. In pure legacy mode we
-    // preserve the original prepend-second-head quirk byte-for-byte.
-    if (nonLegacy && prefixInsertAt !== undefined) {
+    // No </head> exists. ensureHead guarantees a real head-opening tag is
+    // present, so inject the agent css right after the kit/importmap prefix —
+    // keeping the documented cascade (kit first, agent css after) and avoiding
+    // a duplicate <head>.
+    if (prefixInsertAt !== undefined) {
       return (
         html.slice(0, prefixInsertAt) +
         `<style>${css}</style>` +

--- a/packages/react-core/src/v2/lib/assembleDocument.ts
+++ b/packages/react-core/src/v2/lib/assembleDocument.ts
@@ -1,0 +1,103 @@
+/**
+ * Pinned ES-module importmap entries for Open Generative UI sandboxes.
+ * Bare specifiers (e.g. "three") and trailing-slash forms (e.g. "three/")
+ * are both registered so sub-path imports (e.g. "three/examples/jsm/…")
+ * resolve correctly against the pinned version.
+ */
+export const DEFAULT_OPEN_GEN_UI_LIBRARIES: Record<string, string> = {
+  three: "https://esm.sh/three@0.180.0",
+  "three/": "https://esm.sh/three@0.180.0/",
+  gsap: "https://esm.sh/gsap@3.13.0",
+  "gsap/": "https://esm.sh/gsap@3.13.0/",
+  d3: "https://esm.sh/d3@7.9.0",
+  "d3/": "https://esm.sh/d3@7.9.0/",
+  "chart.js": "https://esm.sh/chart.js@4.5.0",
+  "chart.js/": "https://esm.sh/chart.js@4.5.0/",
+};
+
+/**
+ * Options for `assembleDocument`.
+ */
+export interface AssembleDocumentOptions {
+  /** The dedicated `css` tool parameter (agent-authored). Injected before </head>, after the kit. */
+  css?: string;
+  /** Resolved design-system CSS, or false to skip injection (legacy behavior). */
+  designSystemCss?: string | false;
+  /** Resolved importmap entries, or false to skip the importmap (legacy behavior). */
+  importMap?: Record<string, string> | false;
+}
+
+/**
+ * Builds an HTML `<script type="importmap">` tag from the given library map.
+ * The map is serialised as `{ imports: libs }` per the importmap spec.
+ */
+export function buildImportMapScript(libs: Record<string, string>): string {
+  return `<script type="importmap">${JSON.stringify({ imports: libs })}</script>`;
+}
+
+/**
+ * Ensures the HTML string contains a `<head>` element.
+ * If no `<head>` tag is found, prepends `<head></head>` to the string.
+ * Ported byte-equivalently from `OpenGenerativeUIRenderer.tsx`.
+ */
+export function ensureHead(html: string): string {
+  if (/<head[\s>]/i.test(html)) return html;
+  return `<head></head>${html}`;
+}
+
+/**
+ * Assembles a complete document string suitable for mounting in a sandbox iframe.
+ *
+ * Injection order (cascade invariant):
+ * 1. `<script type="importmap">` — must precede any module script
+ * 2. `<style data-ck-design-system>` — the design-system token/SVG/form kit
+ * 3. …whatever `<head>` content the agent authored…
+ * 4. `<style>` containing `opts.css` — agent-authored CSS, immediately before
+ *    `</head>` so it wins over the kit on specificity ties
+ *
+ * Backward-compat invariant: when both `designSystemCss` and `importMap` are
+ * falsy, the output is byte-identical to the legacy
+ * `ensureHead(css ? injectCssIntoHtml(html, css) : html)` path.
+ *
+ * Pure string function — no DOM, no React.
+ */
+export function assembleDocument(
+  html: string,
+  opts: AssembleDocumentOptions = {},
+): string {
+  const { css, designSystemCss, importMap } = opts;
+
+  // Step 1: ensure a <head> tag exists.
+  html = ensureHead(html);
+
+  // Step 2: build the prefix to insert immediately after the opening <head…> tag.
+  const importMapPart = importMap ? buildImportMapScript(importMap) : "";
+  const designSystemPart = designSystemCss
+    ? `<style data-ck-design-system>${designSystemCss}</style>`
+    : "";
+  const prefix = importMapPart + designSystemPart;
+
+  if (prefix) {
+    // Insert right after the first <head…> opening tag.
+    const headOpenMatch = html.match(/<head[^>]*>/i);
+    if (headOpenMatch && headOpenMatch.index !== undefined) {
+      const insertAt = headOpenMatch.index + headOpenMatch[0].length;
+      html = html.slice(0, insertAt) + prefix + html.slice(insertAt);
+    }
+  }
+
+  // Step 3: inject agent CSS immediately before </head> (legacy algorithm).
+  if (css) {
+    const headCloseIdx = html.indexOf("</head>");
+    if (headCloseIdx !== -1) {
+      return (
+        html.slice(0, headCloseIdx) +
+        `<style>${css}</style>` +
+        html.slice(headCloseIdx)
+      );
+    }
+    return `<head><style>${css}</style></head>${html}`;
+  }
+
+  return html;
+}

--- a/packages/react-core/src/v2/lib/assembleDocument.ts
+++ b/packages/react-core/src/v2/lib/assembleDocument.ts
@@ -71,18 +71,38 @@ export function assembleDocument(
   html = ensureHead(html);
 
   // Step 2: build the prefix to insert immediately after the opening <head…> tag.
-  const importMapPart = importMap ? buildImportMapScript(importMap) : "";
+  // An empty importMap object ({}) is treated as no importmap — it would
+  // otherwise emit an inert `<script type="importmap">{"imports":{}}</script>`.
+  const importMapPart =
+    importMap && Object.keys(importMap).length > 0
+      ? buildImportMapScript(importMap)
+      : "";
   const designSystemPart = designSystemCss
     ? `<style data-ck-design-system>${designSystemCss}</style>`
     : "";
   const prefix = importMapPart + designSystemPart;
 
-  if (prefix) {
-    // Insert right after the first <head…> opening tag.
-    const headOpenMatch = html.match(/<head[^>]*>/i);
-    if (headOpenMatch && headOpenMatch.index !== undefined) {
-      const insertAt = headOpenMatch.index + headOpenMatch[0].length;
-      html = html.slice(0, insertAt) + prefix + html.slice(insertAt);
+  // Non-legacy mode is active whenever a design-system or importmap injection is
+  // requested. The agent-css fallback below is scoped to this path so the legacy
+  // mode (both falsy) stays byte-identical to the original algorithm.
+  const nonLegacy = Boolean(designSystemCss) || Boolean(importMap);
+
+  // Track where the prefix's opening <head…> tag ends so the css fallback can
+  // inject immediately after the prefix instead of prepending a second head.
+  let prefixInsertAt: number | undefined;
+
+  // Match only a real head-opening tag: `<head>`, or `<head` followed by
+  // whitespace + attributes. This deliberately excludes `<header …>`, which the
+  // looser `/<head[^>]*>/i` would have captured (injecting into the body).
+  const headOpenMatch = html.match(/<head(\s[^>]*)?>/i);
+  if (headOpenMatch && headOpenMatch.index !== undefined) {
+    prefixInsertAt = headOpenMatch.index + headOpenMatch[0].length;
+    if (prefix) {
+      html =
+        html.slice(0, prefixInsertAt) + prefix + html.slice(prefixInsertAt);
+      // The inserted prefix shifts the insertion point past its own bytes so
+      // the css fallback lands after the prefix (kit), preserving the cascade.
+      prefixInsertAt += prefix.length;
     }
   }
 
@@ -94,6 +114,18 @@ export function assembleDocument(
         html.slice(0, headCloseIdx) +
         `<style>${css}</style>` +
         html.slice(headCloseIdx)
+      );
+    }
+    // No </head> exists. In non-legacy mode a real head-opening tag is always
+    // present (ensureHead guarantees it), so inject the agent css right after
+    // the kit/importmap prefix — keeping the documented cascade (kit first,
+    // agent css after) and avoiding a duplicate <head>. In pure legacy mode we
+    // preserve the original prepend-second-head quirk byte-for-byte.
+    if (nonLegacy && prefixInsertAt !== undefined) {
+      return (
+        html.slice(0, prefixInsertAt) +
+        `<style>${css}</style>` +
+        html.slice(prefixInsertAt)
       );
     }
     return `<head><style>${css}</style></head>${html}`;

--- a/packages/react-core/src/v2/lib/assembleDocument.ts
+++ b/packages/react-core/src/v2/lib/assembleDocument.ts
@@ -149,8 +149,20 @@ export function assembleDocument(
   // fallback) and inverting the cascade — the agent css must win over existing
   // head content. (The LEGACY branch keeps the exact `indexOf` for byte
   // identity; this case-insensitive lookup is non-legacy only.)
+  //
+  // Scope the close-tag search to the region AT/AFTER the prefix insertion
+  // point so it pairs with the SAME head the open-tag matcher anchored to. A
+  // global first-match search would resolve to a stray `</head>` that precedes
+  // the real `<head>` (e.g. `foo</head><head>…</head>` or `</head><head></head>`)
+  // — splicing the agent css before the importmap/kit and outside the real
+  // head, inverting the documented cascade. Searching the slice from
+  // `prefixInsertAt` (just past the injected prefix) and adding the offset back
+  // guarantees the css lands inside the anchored head; if no close exists
+  // at/after the anchor we fall through to the post-prefix fallback below
+  // (never to an earlier global match).
   if (css) {
-    const headCloseIdx = html.search(/<\/head>/i);
+    const closeRel = html.slice(prefixInsertAt).search(/<\/head>/i);
+    const headCloseIdx = closeRel !== -1 ? closeRel + prefixInsertAt : -1;
     if (headCloseIdx !== -1) {
       return (
         html.slice(0, headCloseIdx) +

--- a/packages/react-core/src/v2/lib/assembleDocument.ts
+++ b/packages/react-core/src/v2/lib/assembleDocument.ts
@@ -112,6 +112,71 @@ export function ensureHead(html: string): string {
   return `<head></head>${html}`;
 }
 
+/** Quote-aware open-tag end scan: from a `<style`/`<script` start, matches
+ * through the tag's `>`, allowing a `>` inside a quoted attribute value. */
+const ASSEMBLE_OPEN_TAG_END =
+  /^<[a-zA-Z][^\s/>]*(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/;
+
+/**
+ * Length-preserving mask of the CONTENT of every COMPLETE `<style>`/`<script>`
+ * block and `<!-- … -->` comment (and the quoted attribute values inside those
+ * style/script open tags) with spaces. Used by the NON-LEGACY path of
+ * {@link assembleDocument} so a `<head>`/`</head>` token that appears INSIDE a
+ * comment or inside style/script content BEFORE the real `<head>` cannot capture
+ * the importmap/kit prefix splice (which would render the libraries and design
+ * tokens inert). Indices map 1:1 to the original, so the prefix is spliced on the
+ * ORIGINAL string at the masked match positions. A single left-to-right pass
+ * masks whichever construct opens first, so the constructs never interfere.
+ *
+ * NOTE: this is intentionally NOT used by the legacy path, which is
+ * byte-identity-locked to the historical `ensureHead`/`injectCssIntoHtml`
+ * composition (a `</head>` lookalike inside a comment there is a pre-existing
+ * quirk the byte-identity tests pin).
+ */
+function maskInertSpans(html: string): string {
+  const blockRe = /<style\b|<script\b|<!--/gi;
+  let out = "";
+  let last = 0;
+  blockRe.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = blockRe.exec(html)) !== null) {
+    const start = match.index;
+    if (start < last) continue;
+    const token = match[0];
+    if (token === "<!--") {
+      const close = html.indexOf("-->", start + 4);
+      const contentStart = start + 4;
+      const contentEnd = close === -1 ? html.length : close;
+      out += html.slice(last, contentStart);
+      out += " ".repeat(contentEnd - contentStart);
+      last = contentEnd;
+      blockRe.lastIndex = close === -1 ? html.length : close + 3;
+    } else {
+      const tagName = token.slice(1);
+      const openEndMatch = html.slice(start).match(ASSEMBLE_OPEN_TAG_END);
+      const openEnd = openEndMatch
+        ? start + openEndMatch[0].length
+        : html.length;
+      const closeRe = new RegExp(`</${tagName}>`, "i");
+      const closeRel = openEndMatch ? html.slice(openEnd).search(closeRe) : -1;
+      const contentEnd = closeRel === -1 ? html.length : openEnd + closeRel;
+      out += html.slice(last, start);
+      out += html
+        .slice(start, openEnd)
+        .replace(
+          /"[^"]*"|'[^']*'/g,
+          (q) => q[0] + " ".repeat(q.length - 2) + q[0],
+        );
+      out += " ".repeat(contentEnd - openEnd);
+      last = contentEnd;
+      blockRe.lastIndex =
+        closeRel === -1 ? html.length : contentEnd + `</${tagName}>`.length;
+    }
+  }
+  out += html.slice(last);
+  return out;
+}
+
 /**
  * Assembles a complete document string suitable for mounting in a sandbox iframe.
  *
@@ -127,6 +192,16 @@ export function ensureHead(html: string): string {
  * byte-identical to the legacy `ensureHead(css ? injectCssIntoHtml(html, css)
  * : html)` path for ALL inputs, by construction (the legacy composition is
  * reproduced verbatim, injecting CSS into the raw html *before* ensuring head).
+ *
+ * Mask-before-match (NON-LEGACY path only): the head-open match and the agent-css
+ * `</head>` close search both run on a length-preserving MASKED copy
+ * ({@link maskInertSpans}) where the content of complete comments and
+ * style/script blocks is blanked. A `<head>`/`</head>` token that appears inside
+ * a comment (`<!-- build the <head> here -->`) or inside style/script content
+ * BEFORE the real head therefore cannot capture the importmap/kit prefix splice
+ * (which would render the libraries and design tokens inert inside that comment).
+ * The legacy path is intentionally NOT masked — it is byte-identity-locked to the
+ * historical composition, where a `</head>` lookalike is a pinned quirk.
  *
  * Literal-`<head>` normalization (NON-LEGACY path only): `@jetbrains/websandbox`
  * requires the exact 6-character lowercase token `<head>` in `frameContent` — it
@@ -208,7 +283,16 @@ export function assembleDocument(
   // quoted runs (`"…"` / `'…'`) may contain `<`/`>` so a realistic
   // `<head data-config='{"a":">"}'>` is matched whole rather than truncated at
   // the first quoted `>` (which would splice the prefix mid-attribute).
-  const headOpenMatch = html.match(/<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i);
+  //
+  // Run the match on a MASKED copy (comment + style/script content blanked) so a
+  // `<head>` token that appears INSIDE a comment or style/script content BEFORE
+  // the real `<head>` does not capture the prefix splice (which would render the
+  // importmap/kit inert inside that comment). Indices align 1:1, so the prefix is
+  // spliced on the ORIGINAL `html` at the masked match index.
+  const masked = maskInertSpans(html);
+  const headOpenMatch = masked.match(
+    /<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i,
+  );
   if (headOpenMatch && headOpenMatch.index !== undefined) {
     const matchIdx = headOpenMatch.index;
     const matchedToken = headOpenMatch[0];
@@ -259,8 +343,15 @@ export function assembleDocument(
   // guarantees the css lands inside the anchored head; if no close exists
   // at/after the anchor we fall through to the post-prefix fallback below
   // (never to an earlier global match).
+  //
+  // Search on a freshly MASKED copy of the spliced html so a `</head>` token
+  // inside a comment or style/script content (after the prefix) cannot be
+  // mistaken for the real close tag — the css would otherwise land inside that
+  // inert region. The injected prefix's own `<script type="importmap">`/`<style>`
+  // content is masked too (it carries no `</head>`), so this is safe.
   if (css) {
-    const closeRel = html.slice(prefixInsertAt).search(/<\/head>/i);
+    const maskedAfter = maskInertSpans(html);
+    const closeRel = maskedAfter.slice(prefixInsertAt).search(/<\/head>/i);
     const headCloseIdx = closeRel !== -1 ? closeRel + prefixInsertAt : -1;
     if (headCloseIdx !== -1) {
       return (

--- a/packages/react-core/src/v2/lib/assembleDocument.ts
+++ b/packages/react-core/src/v2/lib/assembleDocument.ts
@@ -117,6 +117,14 @@ export function ensureHead(html: string): string {
 const ASSEMBLE_OPEN_TAG_END =
   /^<[a-zA-Z][^\s/>]*(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/;
 
+/** Quote-aware head-open matcher: matches `<head>` or `<head` + a whitespace-led
+ * attribute span ending in `>` (excluding `<header …>`). Unquoted runs forbid
+ * `<`/`>` (so the tag can never greedily swallow a following `<tag>`), while
+ * quoted runs (`"…"` / `'…'`) may contain `<`/`>`. Shared by the legacy
+ * mount-normalization branch and the non-legacy prefix-splice path so both
+ * locate the head-open token identically. */
+const HEAD_OPEN_TAG = /<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i;
+
 /**
  * Length-preserving mask of the CONTENT of every COMPLETE `<style>`/`<script>`
  * block and `<!-- … -->` comment (and the quoted attribute values inside those
@@ -187,11 +195,33 @@ function maskInertSpans(html: string): string {
  * 4. `<style>` containing `opts.css` — agent-authored CSS, immediately before
  *    `</head>` so it wins over the kit on specificity ties
  *
- * Backward-compat invariant: when no prefix is injected — i.e. `designSystemCss`
- * is falsy AND `importMap` is falsy or an empty object — the output is
- * byte-identical to the legacy `ensureHead(css ? injectCssIntoHtml(html, css)
- * : html)` path for ALL inputs, by construction (the legacy composition is
- * reproduced verbatim, injecting CSS into the raw html *before* ensuring head).
+ * Backward-compat invariant (legacy path): when no prefix is injected — i.e.
+ * `designSystemCss` is falsy AND `importMap` is falsy or an empty object — the
+ * legacy output L is computed verbatim as `ensureHead(css ? injectCssIntoHtml(
+ * html, css) : html)` (the CSS injected into the raw html *before* ensuring
+ * head). The contract is then:
+ * - If L ALREADY contains the literal 6-character lowercase token `<head>`,
+ *   return L UNCHANGED — byte-identical to the historical path. EVERY input that
+ *   previously mounted in `@jetbrains/websandbox` lands here, because mounting
+ *   itself requires that literal token (see the literal-`<head>` note below).
+ * - Otherwise L has only an uppercase/attributed head-open tag (`<HEAD>`,
+ *   `<head lang="en">`, `<head >`) and so contains no literal `<head>`. Such an
+ *   artifact ALWAYS failed to mount before (no previously-working output reaches
+ *   this branch). L is MOUNT-NORMALIZED: the first head-open token (located with
+ *   the same quote-aware matcher the non-legacy path uses) is rewritten to the
+ *   literal `<head>` so websandbox's `includes('<head>')` mount gate passes. If
+ *   no head-open token matches at all (e.g. an unterminated `<head\t` tail), a
+ *   minimal `<head></head>` is prepended (mirroring `ensureHead`'s no-head shape).
+ *   The kit/importmap are intentionally NOT injected here — this is still the
+ *   disabled path; only the head token is made mount-safe.
+ *
+ * Remaining legacy quirks are RETAINED BY DESIGN — they fire only on inputs whose
+ * legacy output already contains the literal `<head>`, so those inputs stay
+ * byte-identical: (a) the stray-`</head>` css splice — agent css spliced at a
+ * `</head>` that precedes the real `<head>` (e.g. `foo</head>bar` + css → the css
+ * lands at that stray close); (b) the duplicate-head emission for an unclosed
+ * `<head>` carrying css (`<head><body>…` + css → `<head><style>…</style></head>`
+ * is prepended ahead of the original unclosed `<head>`).
  *
  * Mask-before-match (NON-LEGACY path only): the head-open match and the agent-css
  * `</head>` close search both run on a length-preserving MASKED copy
@@ -246,12 +276,13 @@ export function assembleDocument(
   // PURE LEGACY PATH — no prefix to inject. Reproduce the legacy composition
   // verbatim: inject the agent CSS into the RAW html first (the legacy
   // injectCssIntoHtml algorithm), THEN ensure a <head> exists (legacy
-  // ensureHead). Applying the two helpers in this order makes the output
-  // byte-identical to the legacy path for ALL inputs by construction —
-  // including degenerate inputs where `</head>` appears before/without an
-  // opening `<head>` (ensuring head first would otherwise inject a spurious
-  // earlier `</head>` and the CSS would land in the wrong place).
+  // ensureHead). Applying the two helpers in this order yields the legacy output
+  // L for ALL inputs by construction — including degenerate inputs where
+  // `</head>` appears before/without an opening `<head>` (ensuring head first
+  // would otherwise inject a spurious earlier `</head>` and the CSS would land in
+  // the wrong place).
   if (!nonLegacy) {
+    let legacy: string;
     if (css) {
       const headCloseIdx = html.indexOf("</head>");
       const injected =
@@ -260,9 +291,34 @@ export function assembleDocument(
             `<style>${css}</style>` +
             html.slice(headCloseIdx)
           : `<head><style>${css}</style></head>${html}`;
-      return ensureHead(injected);
+      legacy = ensureHead(injected);
+    } else {
+      legacy = ensureHead(html);
     }
-    return ensureHead(html);
+
+    // Carve-out (mount safety): if L already contains the exact 6-char literal
+    // `<head>`, return it UNCHANGED — every input that previously mounted lands
+    // here and stays byte-identical. Otherwise L has only an uppercase/attributed
+    // head-open tag and so could never mount in `@jetbrains/websandbox`
+    // (`includes('<head>')` gate, websandbox.js:450); normalize that token to the
+    // literal `<head>` so the artifact mounts. The kit/importmap are NOT injected
+    // — this is still the disabled path; only the head token is made mount-safe.
+    if (legacy.includes("<head>")) return legacy;
+    const headOpen = legacy.match(HEAD_OPEN_TAG);
+    if (headOpen && headOpen.index !== undefined) {
+      // Rewrite ONLY the first head-open token to the literal `<head>`; the css
+      // placement (and everything else) is otherwise unchanged from L.
+      return (
+        legacy.slice(0, headOpen.index) +
+        "<head>" +
+        legacy.slice(headOpen.index + headOpen[0].length)
+      );
+    }
+    // No head-open token matched at all (e.g. an unterminated `<head\t` tail that
+    // `ensureHead` saw via `/<head[\s>]/` and declined to prepend). Prepend a
+    // minimal websandbox-safe head, mirroring ensureHead's no-head shape — still
+    // WITHOUT the kit/importmap.
+    return `<head></head>${legacy}`;
   }
 
   // ASSEMBLED (NON-LEGACY) PATH — a prefix exists. Ensure a <head> first so the
@@ -290,9 +346,7 @@ export function assembleDocument(
   // importmap/kit inert inside that comment). Indices align 1:1, so the prefix is
   // spliced on the ORIGINAL `html` at the masked match index.
   const masked = maskInertSpans(html);
-  const headOpenMatch = masked.match(
-    /<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i,
-  );
+  const headOpenMatch = masked.match(HEAD_OPEN_TAG);
   if (headOpenMatch && headOpenMatch.index !== undefined) {
     const matchIdx = headOpenMatch.index;
     const matchedToken = headOpenMatch[0];

--- a/packages/react-core/src/v2/lib/assembleDocument.ts
+++ b/packages/react-core/src/v2/lib/assembleDocument.ts
@@ -193,7 +193,10 @@ function maskInertSpans(html: string): string {
  * 2. `<style data-ck-design-system>` — the design-system token/SVG/form kit
  * 3. …whatever `<head>` content the agent authored…
  * 4. `<style>` containing `opts.css` — agent-authored CSS, immediately before
- *    `</head>` so it wins over the kit on specificity ties
+ *    the head close so it wins over the kit on specificity ties. The close is
+ *    `</head>` when one exists; for an UNCLOSED `<head>` it is the IMPLICIT close
+ *    at the first `<body>` (the body start tag ends the head), so the agent css
+ *    still lands AFTER the author's in-head content rather than ahead of it.
  *
  * Backward-compat invariant (legacy path): when no prefix is injected — i.e.
  * `designSystemCss` is falsy AND `importMap` is falsy or an empty object — the
@@ -414,10 +417,34 @@ export function assembleDocument(
         html.slice(headCloseIdx)
       );
     }
-    // No </head> exists. ensureHead guarantees a real head-opening tag is
-    // present, so inject the agent css right after the kit/importmap prefix —
-    // keeping the documented cascade (kit first, agent css after) and avoiding
-    // a duplicate <head>.
+    // No explicit `</head>` at/after the anchor. The head is implicitly closed
+    // by the first `<body>` (HTML parsing: the body's start tag ends the head).
+    // Anchor the agent css JUST BEFORE that implicit close so it lands AFTER the
+    // author's in-head content — preserving the everywhere-else cascade (author
+    // head content first, agent css last) and keeping the streaming-preview→final
+    // swap stable (the preview hoists the author styles before the css). Without
+    // this, the css would splice right after the prefix, ahead of the author's
+    // in-head styles, inverting the cascade for an unclosed `<head>`.
+    //
+    // Search the SAME masked copy so a `<body>` token inside a comment or
+    // style/script content cannot be mistaken for the structural body-open. The
+    // token must be word-bounded (`<body` then whitespace or `>`) so `<bodyfoo>`
+    // does not match. Scope to the slice at/after `prefixInsertAt` so it pairs
+    // with the head the prefix anchored to.
+    const bodyRel = maskedAfter.slice(prefixInsertAt).search(/<body[\s>]/i);
+    if (bodyRel !== -1) {
+      const bodyOpenIdx = bodyRel + prefixInsertAt;
+      return (
+        html.slice(0, bodyOpenIdx) +
+        `<style>${css}</style>` +
+        html.slice(bodyOpenIdx)
+      );
+    }
+    // Neither a `</head>` nor a `<body>` follows the anchor (e.g. an unclosed
+    // `<head>` with no body at all). ensureHead guarantees a real head-opening
+    // tag is present, so inject the agent css right after the kit/importmap
+    // prefix — keeping the documented cascade (kit first, agent css after) and
+    // avoiding a duplicate <head>.
     if (prefixInsertAt !== undefined) {
       return (
         html.slice(0, prefixInsertAt) +

--- a/packages/react-core/src/v2/lib/designSystemCss.ts
+++ b/packages/react-core/src/v2/lib/designSystemCss.ts
@@ -279,6 +279,12 @@ a:hover { text-decoration: underline; }
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
   }
+}
+
+@media (prefers-color-scheme: dark) {
+  input:focus, textarea:focus, select:focus {
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.12);
+  }
 }`;
 
 export const OPEN_GEN_UI_DESIGN_SYSTEM_CSS = [

--- a/packages/react-core/src/v2/lib/designSystemCss.ts
+++ b/packages/react-core/src/v2/lib/designSystemCss.ts
@@ -1,0 +1,288 @@
+/**
+ * Default design system injected into Open Generative UI sandboxes.
+ * Three layers: design tokens (light/dark via prefers-color-scheme),
+ * SVG helper classes, and themed form-control styles.
+ * Port of the proven kit from CopilotKit/OpenGenerativeUI (widget-renderer).
+ */
+
+export const OPEN_GEN_UI_THEME_CSS = `:root {
+  --color-background-primary: #ffffff;
+  --color-background-secondary: #f7f6f3;
+  --color-background-tertiary: #efeee9;
+  --color-background-info: #E6F1FB;
+  --color-background-danger: #FCEBEB;
+  --color-background-success: #EAF3DE;
+  --color-background-warning: #FAEEDA;
+
+  --color-text-primary: #1a1a1a;
+  --color-text-secondary: #73726c;
+  --color-text-tertiary: #9c9a92;
+  --color-text-info: #185FA5;
+  --color-text-danger: #A32D2D;
+  --color-text-success: #3B6D11;
+  --color-text-warning: #854F0B;
+
+  --color-border-primary: rgba(0, 0, 0, 0.4);
+  --color-border-secondary: rgba(0, 0, 0, 0.3);
+  --color-border-tertiary: rgba(0, 0, 0, 0.15);
+  --color-border-info: #185FA5;
+  --color-border-danger: #A32D2D;
+  --color-border-success: #3B6D11;
+  --color-border-warning: #854F0B;
+
+  --font-sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-serif: Georgia, "Times New Roman", serif;
+  --font-mono: "SF Mono", "Fira Code", "Fira Mono", monospace;
+
+  --border-radius-md: 8px;
+  --border-radius-lg: 12px;
+  --border-radius-xl: 16px;
+
+  --p: var(--color-text-primary);
+  --s: var(--color-text-secondary);
+  --t: var(--color-text-tertiary);
+  --bg2: var(--color-background-secondary);
+  --b: var(--color-border-tertiary);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-background-primary: #1a1a18;
+    --color-background-secondary: #2c2c2a;
+    --color-background-tertiary: #222220;
+    --color-background-info: #0C447C;
+    --color-background-danger: #501313;
+    --color-background-success: #173404;
+    --color-background-warning: #412402;
+
+    --color-text-primary: #e8e6de;
+    --color-text-secondary: #9c9a92;
+    --color-text-tertiary: #73726c;
+    --color-text-info: #85B7EB;
+    --color-text-danger: #F09595;
+    --color-text-success: #97C459;
+    --color-text-warning: #EF9F27;
+
+    --color-border-primary: rgba(255, 255, 255, 0.4);
+    --color-border-secondary: rgba(255, 255, 255, 0.3);
+    --color-border-tertiary: rgba(255, 255, 255, 0.15);
+    --color-border-info: #85B7EB;
+    --color-border-danger: #F09595;
+    --color-border-success: #97C459;
+    --color-border-warning: #EF9F27;
+  }
+}`;
+
+export const OPEN_GEN_UI_SVG_CSS = `svg text.t   { font: 400 14px var(--font-sans); fill: var(--p); }
+svg text.ts  { font: 400 12px var(--font-sans); fill: var(--s); }
+svg text.th  { font: 500 14px var(--font-sans); fill: var(--p); }
+
+svg .box > rect, svg .box > circle, svg .box > ellipse { fill: var(--bg2); stroke: var(--b); }
+svg .node { cursor: pointer; }
+svg .node:hover { opacity: 0.8; }
+svg .arr { stroke: var(--s); stroke-width: 1.5; fill: none; }
+svg .leader { stroke: var(--t); stroke-width: 0.5; stroke-dasharray: 4 4; fill: none; }
+
+/* Purple */
+svg .c-purple > rect, svg .c-purple > circle, svg .c-purple > ellipse,
+svg rect.c-purple, svg circle.c-purple, svg ellipse.c-purple { fill: #EEEDFE; stroke: #534AB7; }
+svg .c-purple text.th, svg .c-purple text.t { fill: #3C3489; }
+svg .c-purple text.ts { fill: #534AB7; }
+
+/* Teal */
+svg .c-teal > rect, svg .c-teal > circle, svg .c-teal > ellipse,
+svg rect.c-teal, svg circle.c-teal, svg ellipse.c-teal { fill: #E1F5EE; stroke: #0F6E56; }
+svg .c-teal text.th, svg .c-teal text.t { fill: #085041; }
+svg .c-teal text.ts { fill: #0F6E56; }
+
+/* Coral */
+svg .c-coral > rect, svg .c-coral > circle, svg .c-coral > ellipse,
+svg rect.c-coral, svg circle.c-coral, svg ellipse.c-coral { fill: #FAECE7; stroke: #993C1D; }
+svg .c-coral text.th, svg .c-coral text.t { fill: #712B13; }
+svg .c-coral text.ts { fill: #993C1D; }
+
+/* Pink */
+svg .c-pink > rect, svg .c-pink > circle, svg .c-pink > ellipse,
+svg rect.c-pink, svg circle.c-pink, svg ellipse.c-pink { fill: #FBEAF0; stroke: #993556; }
+svg .c-pink text.th, svg .c-pink text.t { fill: #72243E; }
+svg .c-pink text.ts { fill: #993556; }
+
+/* Gray */
+svg .c-gray > rect, svg .c-gray > circle, svg .c-gray > ellipse,
+svg rect.c-gray, svg circle.c-gray, svg ellipse.c-gray { fill: #F1EFE8; stroke: #5F5E5A; }
+svg .c-gray text.th, svg .c-gray text.t { fill: #444441; }
+svg .c-gray text.ts { fill: #5F5E5A; }
+
+/* Blue */
+svg .c-blue > rect, svg .c-blue > circle, svg .c-blue > ellipse,
+svg rect.c-blue, svg circle.c-blue, svg ellipse.c-blue { fill: #E6F1FB; stroke: #185FA5; }
+svg .c-blue text.th, svg .c-blue text.t { fill: #0C447C; }
+svg .c-blue text.ts { fill: #185FA5; }
+
+/* Green */
+svg .c-green > rect, svg .c-green > circle, svg .c-green > ellipse,
+svg rect.c-green, svg circle.c-green, svg ellipse.c-green { fill: #EAF3DE; stroke: #3B6D11; }
+svg .c-green text.th, svg .c-green text.t { fill: #27500A; }
+svg .c-green text.ts { fill: #3B6D11; }
+
+/* Amber */
+svg .c-amber > rect, svg .c-amber > circle, svg .c-amber > ellipse,
+svg rect.c-amber, svg circle.c-amber, svg ellipse.c-amber { fill: #FAEEDA; stroke: #854F0B; }
+svg .c-amber text.th, svg .c-amber text.t { fill: #633806; }
+svg .c-amber text.ts { fill: #854F0B; }
+
+/* Red */
+svg .c-red > rect, svg .c-red > circle, svg .c-red > ellipse,
+svg rect.c-red, svg circle.c-red, svg ellipse.c-red { fill: #FCEBEB; stroke: #A32D2D; }
+svg .c-red text.th, svg .c-red text.t { fill: #791F1F; }
+svg .c-red text.ts { fill: #A32D2D; }
+
+@media (prefers-color-scheme: dark) {
+  svg text.t   { fill: #e8e6de; }
+  svg text.ts  { fill: #9c9a92; }
+  svg text.th  { fill: #e8e6de; }
+
+  svg .c-purple > rect, svg .c-purple > circle, svg .c-purple > ellipse,
+  svg rect.c-purple, svg circle.c-purple, svg ellipse.c-purple { fill: #3C3489; stroke: #AFA9EC; }
+  svg .c-purple text.th, svg .c-purple text.t { fill: #CECBF6; }
+  svg .c-purple text.ts { fill: #AFA9EC; }
+
+  svg .c-teal > rect, svg .c-teal > circle, svg .c-teal > ellipse,
+  svg rect.c-teal, svg circle.c-teal, svg ellipse.c-teal { fill: #085041; stroke: #5DCAA5; }
+  svg .c-teal text.th, svg .c-teal text.t { fill: #9FE1CB; }
+  svg .c-teal text.ts { fill: #5DCAA5; }
+
+  svg .c-coral > rect, svg .c-coral > circle, svg .c-coral > ellipse,
+  svg rect.c-coral, svg circle.c-coral, svg ellipse.c-coral { fill: #712B13; stroke: #F0997B; }
+  svg .c-coral text.th, svg .c-coral text.t { fill: #F5C4B3; }
+  svg .c-coral text.ts { fill: #F0997B; }
+
+  svg .c-pink > rect, svg .c-pink > circle, svg .c-pink > ellipse,
+  svg rect.c-pink, svg circle.c-pink, svg ellipse.c-pink { fill: #72243E; stroke: #ED93B1; }
+  svg .c-pink text.th, svg .c-pink text.t { fill: #F4C0D1; }
+  svg .c-pink text.ts { fill: #ED93B1; }
+
+  svg .c-gray > rect, svg .c-gray > circle, svg .c-gray > ellipse,
+  svg rect.c-gray, svg circle.c-gray, svg ellipse.c-gray { fill: #444441; stroke: #B4B2A9; }
+  svg .c-gray text.th, svg .c-gray text.t { fill: #D3D1C7; }
+  svg .c-gray text.ts { fill: #B4B2A9; }
+
+  svg .c-blue > rect, svg .c-blue > circle, svg .c-blue > ellipse,
+  svg rect.c-blue, svg circle.c-blue, svg ellipse.c-blue { fill: #0C447C; stroke: #85B7EB; }
+  svg .c-blue text.th, svg .c-blue text.t { fill: #B5D4F4; }
+  svg .c-blue text.ts { fill: #85B7EB; }
+
+  svg .c-green > rect, svg .c-green > circle, svg .c-green > ellipse,
+  svg rect.c-green, svg circle.c-green, svg ellipse.c-green { fill: #27500A; stroke: #97C459; }
+  svg .c-green text.th, svg .c-green text.t { fill: #C0DD97; }
+  svg .c-green text.ts { fill: #97C459; }
+
+  svg .c-amber > rect, svg .c-amber > circle, svg .c-amber > ellipse,
+  svg rect.c-amber, svg circle.c-amber, svg ellipse.c-amber { fill: #633806; stroke: #EF9F27; }
+  svg .c-amber text.th, svg .c-amber text.t { fill: #FAC775; }
+  svg .c-amber text.ts { fill: #EF9F27; }
+
+  svg .c-red > rect, svg .c-red > circle, svg .c-red > ellipse,
+  svg rect.c-red, svg circle.c-red, svg ellipse.c-red { fill: #791F1F; stroke: #F09595; }
+  svg .c-red text.th, svg .c-red text.t { fill: #F7C1C1; }
+  svg .c-red text.ts { fill: #F09595; }
+}`;
+
+export const OPEN_GEN_UI_FORM_CSS = `* { box-sizing: border-box; margin: 0; }
+
+html { background: transparent; }
+
+body {
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--color-text-primary);
+  background: transparent;
+  -webkit-font-smoothing: antialiased;
+}
+
+button {
+  font-family: inherit;
+  font-size: 14px;
+  padding: 6px 16px;
+  border: 0.5px solid var(--color-border-secondary);
+  border-radius: var(--border-radius-md);
+  background: transparent;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: background 0.15s, transform 0.1s;
+}
+button:hover { background: var(--color-background-secondary); }
+button:active { transform: scale(0.98); }
+
+input[type="text"],
+input[type="number"],
+input[type="email"],
+input[type="search"],
+textarea,
+select {
+  font-family: inherit;
+  font-size: 14px;
+  padding: 6px 12px;
+  height: 36px;
+  border: 0.5px solid var(--color-border-tertiary);
+  border-radius: var(--border-radius-md);
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  transition: border-color 0.15s;
+}
+input:hover, textarea:hover, select:hover { border-color: var(--color-border-secondary); }
+input:focus, textarea:focus, select:focus {
+  outline: none;
+  border-color: var(--color-border-primary);
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.06);
+}
+textarea { height: auto; min-height: 80px; resize: vertical; }
+input::placeholder, textarea::placeholder { color: var(--color-text-tertiary); }
+
+input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  background: var(--color-border-tertiary);
+  border-radius: 2px;
+  border: none;
+  outline: none;
+}
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: var(--color-background-primary);
+  border: 0.5px solid var(--color-border-secondary);
+  cursor: pointer;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+input[type="range"]::-moz-range-thumb {
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: var(--color-background-primary);
+  border: 0.5px solid var(--color-border-secondary);
+  cursor: pointer;
+}
+
+input[type="checkbox"], input[type="radio"] {
+  width: 16px; height: 16px;
+  accent-color: var(--color-text-info);
+}
+
+a { color: var(--color-text-info); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}`;
+
+export const OPEN_GEN_UI_DESIGN_SYSTEM_CSS = [
+  OPEN_GEN_UI_THEME_CSS,
+  OPEN_GEN_UI_SVG_CSS,
+  OPEN_GEN_UI_FORM_CSS,
+].join("\n");

--- a/packages/react-core/src/v2/lib/processPartialHtml.ts
+++ b/packages/react-core/src/v2/lib/processPartialHtml.ts
@@ -50,14 +50,42 @@
  * swallow the rest of the document once `-->` arrives, so the preview drops it
  * to match the final document's effective rendering).
  *
- * An UNCLOSED `<head>` whose region reaches a `<body[\s>]` token (with no
- * `</head>` first) is treated as if the head closed at that implicit `<body>`
- * boundary — exactly how a browser renders the final document (`assembleDocument`
- * leaves the in-head css in the head and the body content in the body when no
- * `</head>` is emitted). So an in-head style there is hoisted and the body
- * content is kept — content never vanishes. An unclosed `<head>` with content
- * but NO `<body>` token is still stripped (a head that is genuinely still
- * streaming its own content).
+ * 3. HEAD/BODY GEOMETRY MATCHES THE BROWSER. The head-element detection in
+ *    `analyzeRegions` partitions the bytes into head vs body exactly where a
+ *    browser does when rendering the final document — never crossing the body
+ *    boundary, never hoisting body-region content:
+ *      • The FIRST masked word-bounded `<body[\s>]` token is the body boundary. A
+ *        `<head>` whose open token starts AT OR AFTER it is body content (a stray
+ *        `<head>` nested in the body), NOT a head element: its tag tokens are
+ *        dropped (step 5) and its content stays in the body, never hoisted.
+ *      • A counted head element's CONTENT ends at the FIRST of an explicit
+ *        `</head>`, the body boundary, a flow (non-head-permitted) START tag, or
+ *        the first non-whitespace TEXT character — the same boundary a browser
+ *        uses (see {@link findHeadContentEnd}). The `</head>` pairing therefore
+ *        NEVER reaches past a `<body>` token: `<head><style>.a{}</style><body>…`
+ *        closes the head at `<body>` (style hoisted, body content kept), it does
+ *        not swallow the body up to a trailing `</head>`. An in-head style before
+ *        the boundary is hoisted; anything from the boundary on stays in the body.
+ *      • A head-permitted element with a text body (`<title>`/`<noscript>`/
+ *        `<template>`, plus the masked `<style>`/`<script>`) is skipped to its
+ *        close so its inner text (`<title>a < b</title>`) is never read as flow.
+ *      • The implicit head close fires at FLOW CONTENT, not only at `<body>`:
+ *        `<head><style>.a{}</style><p>x</p>` (no `<body>` ever) renders `<p>x</p>`
+ *        with `.a` hoisted, NOT a blank preview. Streaming guard: a head whose
+ *        region so far is ONLY head-permitted content with no boundary yet, or a
+ *        trailing incomplete tag (`<ti`, a bare `<`), is genuinely still streaming
+ *        — it yields NO span (stripped, self-correcting next chunk), so the head
+ *        is never closed on an indeterminate tail.
+ *      • STRAY head/body tokens are dropped, not leaked: step 5 removes EVERY
+ *        `<body[\s>]` open (a browser opens the body once — a duplicate `<body>`
+ *        is dropped and its markup stays in the one body), and every stray
+ *        `<head[\s>]`/`</head>` token left in the body (a browser drops the stray
+ *        tag but KEEPS its content) — all mask-aware and quote-aware, the same
+ *        shape as the `</html>` strip.
+ *    All four consumers (style hoist containment, the head-element strip, the
+ *    duplicate-body strip, the stray-head strip) derive from this ONE geometry, so
+ *    the preview body and the hoisted head agree with the final document — a style
+ *    is hoisted XOR kept (never both, never neither) and content never vanishes.
  *
  * Pure functions — no DOM, no React.
  */
@@ -151,6 +179,151 @@ function maskBlockContent(html: string): string {
   return out;
 }
 
+/**
+ * Element names a browser keeps INSIDE `<head>` (HTML "metadata content" plus the
+ * elements the head parser tolerates). Encountering a START tag whose name is NOT
+ * in this set — word-bounded — is flow content and implicitly CLOSES the head, the
+ * same boundary a browser uses when no `</head>` is emitted. Lower-cased; callers
+ * compare against a lower-cased tag name.
+ */
+const HEAD_PERMITTED = new Set([
+  "title",
+  "meta",
+  "link",
+  "style",
+  "script",
+  "base",
+  "noscript",
+  "template",
+]);
+
+/** Head-permitted elements that have NO end tag (void) — their open tag is the
+ * whole element, so the head scan skips just the tag, never hunts a close. */
+const HEAD_VOID = new Set(["meta", "link", "base"]);
+
+/**
+ * Finds where an open `<head>` region's CONTENT ends, scanning the MASKED string
+ * from just after the head open tag (`openEnd`). Mirrors how a browser partitions
+ * the bytes into head vs body when rendering the final document: the head ends at
+ * the FIRST of —
+ *   • an explicit `</head>` close token,
+ *   • a masked word-bounded `<body[\s>]` open token (the implicit body boundary),
+ *   • a START tag whose name is NOT head-permitted (flow content — `<div>`, `<p>`,
+ *     a stray `<html>`, …), or
+ *   • the first non-whitespace TEXT character outside any tag token.
+ * A head-permitted element with a text body (`<title>`, `<noscript>`, `<template>`,
+ * and the already-masked `<style>`/`<script>`) is SKIPPED to its matching close so
+ * its inner text — `<title>a < b</title>` — is never mistaken for flow content
+ * (RCDATA/raw-text parity with the browser). Head-permitted VOID tags
+ * (`<meta>`/`<link>`/`<base>`) skip just the tag.
+ *
+ * Returns the index in the original/masked string where head content ends (the
+ * span is `[openStart, end)`; an explicit `</head>` is NOT included — the stray
+ * `</head>` strip removes it, the same shape as the `</html>` strip). Returns
+ * `null` when the head is GENUINELY STILL STREAMING its own content — content so
+ * far is only head-permitted and the scan runs off the end of the string, OR a
+ * head-permitted text element is unterminated, OR the tail is an incomplete tag
+ * prefix (`<ti`, a bare `<`). A `null` yields NO head span, so the unterminated-
+ * block strip removes the head region (preview empty until more streams in), which
+ * self-corrects on the next chunk — never closing the head on an indeterminate
+ * trailing tag.
+ */
+function findHeadContentEnd(masked: string, openEnd: number): number | null {
+  let i = openEnd;
+  const len = masked.length;
+  while (i < len) {
+    const ch = masked[i]!;
+    if (ch !== "<") {
+      // Whitespace stays in the head; the first non-whitespace text char is flow
+      // content and closes the head. (Masked spans are all spaces, so style/script/
+      // comment content never reads as flow text here.)
+      if (/\s/.test(ch)) {
+        i++;
+        continue;
+      }
+      return i;
+    }
+    // ch === "<": a tag-ish token. Distinguish close tags, comments, the body
+    // boundary, head-permitted elements, and flow start tags.
+    const rest = masked.slice(i);
+    // Explicit </head> close ends the head here.
+    if (/^<\/head[\s>]/i.test(rest) || /^<\/head>/i.test(rest)) {
+      return i;
+    }
+    // The implicit body boundary.
+    if (/^<body[\s>]/i.test(rest)) {
+      return i;
+    }
+    // A complete HTML comment stays in the head (metadata-adjacent); skip it.
+    // (Comment INSIDES are masked to spaces, but the `<!--`/`-->` delimiters are
+    // intact, so we can locate the close.)
+    if (rest.startsWith("<!--")) {
+      const close = masked.indexOf("-->", i + 4);
+      if (close === -1) return null; // unterminated trailing comment → still streaming
+      i = close + 3;
+      continue;
+    }
+    // An incomplete trailing close tag (`</hea`, `</di` with no `>` at end of
+    // string) is indeterminate mid-stream — defer rather than guess.
+    if (/^<\/[a-zA-Z][^>]*$/.test(rest)) {
+      return null;
+    }
+    // Any other COMPLETE close tag (e.g. a stray </p>, </div>) is tolerated inside
+    // the head by the parser without opening the body; skip it.
+    const closeMatch = rest.match(/^<\/([a-zA-Z][^\s/>]*)\s*>/);
+    if (closeMatch) {
+      i += closeMatch[0].length;
+      continue;
+    }
+    // A START tag: read its name (word-bounded). An INCOMPLETE trailing tag prefix
+    // (`<ti`, `<style` / `<div` with no `>`) is indeterminate mid-stream — defer,
+    // never closing the head on it (the trailing-tag handling self-corrects next
+    // chunk). A COMPLETE start tag that is NOT head-permitted is flow content.
+    // A lone trailing `<` (last char) could still grow into a tag next chunk —
+    // indeterminate, defer (the spec's `<` "at end" guard). A `<` followed by a
+    // non-tag-name char (`< b`, `<=x`) can NEVER become a tag, so it is text and
+    // closes the head (browser parity: such a `<` renders as literal text).
+    if (i === len - 1) {
+      return null;
+    }
+    const startMatch = rest.match(/^<([a-zA-Z][^\s/>]*)/);
+    if (!startMatch) {
+      // `<` followed by a non-tag-name char (e.g. `< b`, `<=x`). The browser treats
+      // it as literal text, which closes the head here.
+      return i;
+    }
+    const openTagMatch = rest.match(OPEN_TAG_END);
+    if (!openTagMatch) {
+      // The start tag has no closing `>` yet — incomplete trailing tag → defer.
+      return null;
+    }
+    const name = startMatch[1]!.toLowerCase();
+    if (!HEAD_PERMITTED.has(name)) {
+      // Complete flow start tag → implicit head close at this token.
+      return i;
+    }
+    // Head-permitted start tag, already known to be complete (openTagMatch).
+    const tagEnd = i + openTagMatch[0].length;
+    if (HEAD_VOID.has(name)) {
+      // Void head element (meta/link/base) — no end tag; skip just the open tag.
+      i = tagEnd;
+      continue;
+    }
+    // Non-void head-permitted element (title/noscript/template/style/script): skip
+    // to its matching close so its inner text isn't read as flow. style/script
+    // content is already masked, but title/noscript/template content is not — the
+    // skip-to-close handles all of them uniformly. Unterminated ⇒ still streaming.
+    const closeRe = new RegExp(`</${name}\\s*>`, "i");
+    const closeRel = masked.slice(tagEnd).search(closeRe);
+    if (closeRel === -1) return null;
+    const closeMatchInner = masked.slice(tagEnd + closeRel).match(closeRe)!;
+    i = tagEnd + closeRel + closeMatchInner[0].length;
+  }
+  // Ran off the end with only head-permitted content and no boundary → the head is
+  // still streaming its own content; yield no span (stripped, self-corrects).
+  return null;
+}
+
 interface StyleSpan {
   /** Start index of the complete `<style>` block in the ORIGINAL string. */
   start: number;
@@ -175,40 +348,51 @@ interface Regions {
 function analyzeRegions(html: string): Regions {
   const masked = maskBlockContent(html);
 
+  // The FIRST masked word-bounded `<body[\s>]` open token is the body boundary —
+  // the geometric line a browser draws between head and body. A `<head>` whose
+  // open token starts AT OR AFTER this line is body content (a stray `<head>`
+  // inside the body), not a head element: its tag tokens are dropped from the body
+  // (step 5) and its inner content is kept where it sits, never hoisted. Located
+  // on the masked string so a `<body>` inside CSS/JS or a comment cannot fake it.
+  const firstBodyOpenMatch = masked.match(/<body[\s>]/i);
+  const firstBodyOpen =
+    firstBodyOpenMatch && firstBodyOpenMatch.index !== undefined
+      ? firstBodyOpenMatch.index
+      : Infinity;
+
   // Head ELEMENT spans, `[start, end)`. `<head\b` is word-bounded so it never
   // matches `<header>`; masking ensures a `<head`/`</head>`/`<body>` token inside
   // CSS/JS or a comment cannot open or close a phantom element here.
   //
-  // A head element ends at its `</head>` when one exists. When an opened head has
-  // NO `</head>` but its region reaches a `<body[\s>]` token, the head is treated
-  // as IMPLICITLY closed at that body boundary (span ends just before `<body>`,
-  // which the browser does when rendering the final document) so an in-head style
-  // is still hoisted and the body content is preserved. A head opened with no
-  // `</head>` and no following `<body>` is genuinely still streaming and yields
-  // NO span (the unterminated-block strip step removes it).
+  // GEOMETRY (browser-parity with the final document): a head element counts only
+  // when its OPEN token starts BEFORE the body boundary (`firstBodyOpen`). Its
+  // CONTENT ends — via {@link findHeadContentEnd} — at the FIRST of an explicit
+  // `</head>`, the body boundary, a flow (non-head-permitted) start tag, or
+  // non-whitespace text — exactly where the browser closes the head. The span is
+  // `[openStart, contentEnd)` and EXCLUDES any explicit `</head>` token (the stray
+  // `</head>` strip in step 5 removes it, the same mask-aware shape as `</html>`).
+  // A `null` content end means the head is genuinely still streaming its own
+  // head-permitted content with no boundary yet — NO span (the unterminated-block
+  // strip removes it; the preview self-corrects on the next chunk).
   const headElementSpans: Array<[number, number]> = [];
   // Quote-aware open-tag match (same family as assembleDocument's head matcher)
   // so a quoted `>` in a head attribute does not truncate the tag early and a
   // `<body>` inside the head's own attribute (before openEnd) is not seen by the
-  // implicit-close search below.
+  // content-end search below.
   const headOpenRe = /<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi;
   let headOpen: RegExpExecArray | null;
   while ((headOpen = headOpenRe.exec(masked)) !== null) {
     const openStart = headOpen.index;
+    // A `<head>` at or past the body boundary is body content, not a head element.
+    if (openStart >= firstBodyOpen) break;
     const openEnd = openStart + headOpen[0].length;
-    const closeRel = masked.slice(openEnd).search(/<\/head>/i);
-    if (closeRel !== -1) {
-      const end = openEnd + closeRel + "</head>".length;
-      headElementSpans.push([openStart, end]);
-      headOpenRe.lastIndex = end;
+    const contentEnd = findHeadContentEnd(masked, openEnd);
+    if (contentEnd !== null) {
+      headElementSpans.push([openStart, contentEnd]);
+      headOpenRe.lastIndex = contentEnd;
       continue;
     }
-    // No close — fall back to an implicit `<body>` close.
-    const bodyRel = masked.slice(openEnd).search(/<body[\s>]/i);
-    if (bodyRel !== -1) {
-      headElementSpans.push([openStart, openEnd + bodyRel]);
-    }
-    // Either way there is no further `</head>` to find — stop scanning heads.
+    // Still-streaming head (no boundary yet) — no span; stop scanning heads.
     break;
   }
 
@@ -323,16 +507,19 @@ export function extractCompleteStyles(html: string): string {
  *    `&D` is indistinguishable from a forming `&Dagger;` at the boundary); the
  *    conservative strip self-corrects on the next chunk and at completion (the
  *    FINAL document never runs processPartialHtml).
- * 5. Reduce to the body region: drop the `<body…>` open tag and the `</body…>`
- *    CLOSE TOKEN (but KEEP everything after it), and drop the `<html…>`/`</html>`
+ * 5. Reduce to the body region: drop EVERY `<body…>` open tag and EVERY `</body…>`
+ *    CLOSE TOKEN (but KEEP everything around/after them), drop every stray
+ *    `<head…>`/`</head>` token left in the body, and drop the `<html…>`/`</html>`
  *    structural wrappers — keeping the body's inner content, any surviving
- *    top-level pre-`<body>` content (e.g. a body-region `<style>`), AND any
+ *    top-level pre-`<body>` content (e.g. a body-region `<style>`), the content of
+ *    a stray body-region `<head>` (its tags dropped, content kept), AND any
  *    content after `</body>`. This mirrors how a browser renders the FINAL
  *    document's body region: `<html>`/`<head>`/`<body>`/`</body>`/`</html>` are
- *    tags the parser consumes as structure, while a pre-`<body>` style and any
- *    post-`</body>` markup are real content the browser REPARENTS into the body
- *    (the final document is mounted whole, so the preview must keep them too — a
- *    truncate-at-`</body>` drops content that pops in at the preview→final swap).
+ *    tags the parser consumes as structure (a DUPLICATE `<body>` and a stray
+ *    `<head>`/`</head>` are dropped tags, not visible text), while a pre-`<body>`
+ *    style and any post-`</body>` markup are real content the browser REPARENTS
+ *    into the body (the final document is mounted whole, so the preview must keep
+ *    them too — a truncate-at-`</body>` drops content that pops in at the swap).
  *    The `<body[\s>]`/`</body>`/`<html[\s>]` matches are word-bounded (never
  *    `<bodyguard …>`/`<htmlfoo>`) and run on a freshly masked string so a token
  *    inside a surviving style block or comment cannot fake the boundary. The
@@ -409,19 +596,68 @@ export function processPartialHtml(html: string): string {
     result = removeSpans(result, bodyCloseSpans);
     masked = maskBlockContent(result);
   }
-  const openMatch = masked.match(/<body[\s>]/i);
-  if (openMatch && openMatch.index !== undefined) {
-    // Remove just the `<body…>` open tag, keeping content before and after it.
-    // Quote-aware end-of-tag scan (same shape as assembleDocument's head
-    // matcher) so a quoted `>` in an attribute — `<body data-x="a>b">` — can't
-    // truncate the tag early and leak attribute fragments as visible content.
+  // Remove EVERY `<body…>` open tag, keeping content before and after each. A
+  // browser opens the body only once; a SECOND `<body>` open token is ignored
+  // (its attributes merge, the tag itself is dropped) and the following markup
+  // stays in the one body — `<body><p>a</p><body><p>b</p>` renders `<p>a</p><p>b</p>`.
+  // Removing only the first open would leak the duplicate `<body>` as literal
+  // text, so we loop, locating each open on a freshly masked copy (a `<body>`
+  // inside a surviving style/comment never counts) with the same quote-aware
+  // end-of-tag scan (so a quoted `>` — `<body data-x="a>b">` — can't truncate the
+  // tag early and leak attribute fragments).
+  const bodyOpenSpans: Array<[number, number]> = [];
+  const bodyOpenRe = /<body[\s>]/gi;
+  let bodyOpen: RegExpExecArray | null;
+  while ((bodyOpen = bodyOpenRe.exec(masked)) !== null) {
+    const start = bodyOpen.index;
     const openTag = masked
-      .slice(openMatch.index)
+      .slice(start)
       .match(/^<body(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i);
-    const openTagEnd = openTag
-      ? openMatch.index + openTag[0].length
-      : openMatch.index + masked.slice(openMatch.index).search(/>/) + 1;
-    result = result.slice(0, openMatch.index) + result.slice(openTagEnd);
+    const end = openTag
+      ? start + openTag[0].length
+      : start + masked.slice(start).search(/>/) + 1;
+    bodyOpenSpans.push([start, end]);
+    bodyOpenRe.lastIndex = end;
+  }
+  if (bodyOpenSpans.length > 0) {
+    result = removeSpans(result, bodyOpenSpans);
+    masked = maskBlockContent(result);
+  }
+  // Drop EVERY stray `<head…>` open token and `</head>` close token left in the
+  // body. analyzeRegions already stripped the head ELEMENTS it counted (those
+  // whose open token is before the body boundary), so any `<head>`/`</head>` token
+  // surviving here is body content: a `<head>` nested inside `<body>`, or the
+  // explicit `</head>` of a counted head (whose tag the head span deliberately
+  // excluded). A browser drops these stray tags but KEEPS their inner content —
+  // `<body><head><style>.b{}</style></head><p>x</p>` renders
+  // `<style>.b{}</style><p>x</p>`; a trailing standalone `</head>` after the body
+  // (`<div>real</div></head>`) is dropped, not shown as literal text. Mask-aware +
+  // quote-aware, the same shape as the `</html>` strip. (Done before the `<html>`
+  // strips for symmetry; order is immaterial since all are span-based.)
+  const headTokenSpans: Array<[number, number]> = [];
+  const headOpenStrayRe = /<head[\s>]/gi;
+  let headOpenStray: RegExpExecArray | null;
+  while ((headOpenStray = headOpenStrayRe.exec(masked)) !== null) {
+    const start = headOpenStray.index;
+    const openTag = masked
+      .slice(start)
+      .match(/^<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i);
+    const end = openTag
+      ? start + openTag[0].length
+      : start + masked.slice(start).search(/>/) + 1;
+    headTokenSpans.push([start, end]);
+    headOpenStrayRe.lastIndex = end;
+  }
+  const headCloseStrayRe = /<\/head\s*>/gi;
+  let headCloseStray: RegExpExecArray | null;
+  while ((headCloseStray = headCloseStrayRe.exec(masked)) !== null) {
+    headTokenSpans.push([
+      headCloseStray.index,
+      headCloseStray.index + headCloseStray[0].length,
+    ]);
+  }
+  if (headTokenSpans.length > 0) {
+    result = removeSpans(result, headTokenSpans);
     masked = maskBlockContent(result);
   }
   // Drop the `<html…>` open tag wherever it appears (the browser drops the

--- a/packages/react-core/src/v2/lib/processPartialHtml.ts
+++ b/packages/react-core/src/v2/lib/processPartialHtml.ts
@@ -1,121 +1,251 @@
 /**
- * Returns the HEAD region of `html` — the substring before the first real
- * `<body[\s>]` opening tag (case-insensitive). Returns `""` when no `<body` tag
- * exists, because `processPartialHtml` then treats the WHOLE string as the body
- * region (so there is no head region at all).
+ * Shared region logic for the Open Generative UI streaming preview.
  *
- * Complete `<script>` blocks are stripped FIRST so a `<body` that only appears
- * as text inside a script (e.g. `<script>x="<body>"</script>`) can never be
- * mistaken for the real body boundary. `<head>` blocks are deliberately NOT
- * stripped: a `<style>` wrapped in `<head>…</head>` is still head-region and
- * must be hoisted (and `processPartialHtml` removes that same style as part of
- * its complete-`<head>`-block strip, so the two functions stay in agreement —
- * no style is ever both hoisted and left behind, or dropped from both).
+ * The preview renders accumulated (still-streaming) HTML by hoisting head-region
+ * styles into the preview iframe's `<head>` (via {@link extractCompleteStyles})
+ * and injecting the body markup via `document.body.innerHTML` (via
+ * {@link processPartialHtml}). Those two functions MUST classify every complete
+ * `<style>` block identically — a block is either hoisted to the head XOR left
+ * in the body, never both (double-injected, cascade flip) and never neither
+ * (dropped, unstyled preview).
  *
- * The `<body[\s>]` guard matches `<body>`/`<body …>` but never `<bodysomething>`.
+ * Two principles keep them in lockstep and keep the preview faithful to the
+ * FINAL document produced by `assembleDocument`:
+ *
+ * 1. HOIST ONLY styles inside a COMPLETE `<head>…</head>` ELEMENT. This mirrors
+ *    `assembleDocument` exactly: it injects the kit/importmap/agent-css INTO the
+ *    existing (or `ensureHead`-synthesized) `<head>` and never relocates any
+ *    other markup. So in-head styles stay in the head (before the agent css);
+ *    everything else — including a TOP-LEVEL `<style>` that appears before
+ *    `<body>` with no enclosing `<head>` — stays in the BODY region (after the
+ *    head css in document order). Consequences:
+ *      • A complete `<head>` element hoists correctly even when no `<body>` tag
+ *        has streamed yet (head/css routinely stream before the body).
+ *      • A top-level pre-`<body>` style (no `<head>`) is NEVER hoisted, so the
+ *        preview and final document agree with ZERO dependence on `<body>`
+ *        detection for the hoist decision.
+ *
+ * 2. MASK BEFORE MEASURING. Every structural search (locating `<head>` elements,
+ *    the `<body[\s>]` boundary, the `</body>` close, `<script>`/`<head>` element
+ *    spans) runs on a single shared masked copy of the input where the CONTENT
+ *    of every COMPLETE `<style>`/`<script>` block is replaced with same-length
+ *    placeholders. Indices are preserved 1:1, so spans map straight back to the
+ *    original. A tag-lookalike token inside CSS/JS — `content:"<body>"`,
+ *    `/* hide <body /> default *​/`, `x="</head>"` — therefore can NEVER fake a
+ *    boundary or split a style block. Both exported functions derive their
+ *    classifications from this ONE computation ({@link analyzeRegions}).
+ *
+ * The `<body[\s>]` / `</body>` / `<head\b` guards are all word-bounded so
+ * `<bodyguard …>`, `<header>`, etc. are never mistaken for `<body>`/`<head>`.
+ *
+ * Incomplete trailing `<style>`/`<script>`/`<head>` blocks (an open tag with no
+ * matching close through end of string) are still stripped entirely — an
+ * unterminated block mid-stream must never leak its raw CSS/JS text into the
+ * preview body as visible content.
+ *
+ * Pure functions — no DOM, no React.
  */
-function headRegion(html: string): string {
-  const withoutScripts = html.replace(
-    /<script\b[^>]*>[\s\S]*?<\/script>/gi,
-    "",
-  );
-  const match = withoutScripts.match(/<body[\s>]/i);
-  if (!match || match.index === undefined) return "";
-  return withoutScripts.slice(0, match.index);
+
+/** Matches a COMPLETE `<style>`/`<script>` block, capturing the tag name and its content. */
+const COMPLETE_STYLE_OR_SCRIPT = /<(style|script)\b[^>]*>([\s\S]*?)<\/\1>/gi;
+
+/**
+ * Replaces the CONTENT (between the open tag's `>` and the matching `</tag>`) of
+ * every COMPLETE `<style>`/`<script>` block with same-length space placeholders.
+ * The tags themselves are untouched. Length-preserving, so every index in the
+ * returned string maps 1:1 to the original — callers locate structure on the
+ * masked string and slice the matching text out of the original.
+ */
+function maskBlockContent(html: string): string {
+  let out = "";
+  let last = 0;
+  COMPLETE_STYLE_OR_SCRIPT.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = COMPLETE_STYLE_OR_SCRIPT.exec(html)) !== null) {
+    const full = match[0];
+    const content = match[2]!;
+    // Content starts right after the open tag's first `>`. (Open tags cannot
+    // contain a `>` here — these are `<style …>`/`<script …>` with no `>` in
+    // their attribute values in any realistic streamed document.)
+    const contentStart = match.index + full.indexOf(">") + 1;
+    const contentEnd = contentStart + content.length;
+    out += html.slice(last, contentStart);
+    out += " ".repeat(content.length);
+    last = contentEnd;
+  }
+  out += html.slice(last);
+  return out;
+}
+
+interface StyleSpan {
+  /** Start index of the complete `<style>` block in the ORIGINAL string. */
+  start: number;
+  /** End index (exclusive) of the complete `<style>` block in the ORIGINAL string. */
+  end: number;
+  /** True when the block lies entirely within a complete `<head>…</head>` element. */
+  inHead: boolean;
+}
+
+interface Regions {
+  /** `[start, end)` spans of complete `<script>`/`<head>` ELEMENTS (stripped from the body everywhere). */
+  scriptOrHeadSpans: Array<[number, number]>;
+  /** Every complete `<style>` block, tagged with whether it sits inside a `<head>` element. */
+  styleSpans: StyleSpan[];
 }
 
 /**
- * Extracts complete `<style>…</style>` blocks ONLY from the HEAD region of the
- * raw HTML — everything before the first `<body[\s>]` tag (case-insensitive).
- * When no `<body` tag exists, there is no head region (the whole string is the
- * body region per `processPartialHtml`), so nothing is hoisted. Returns the
- * concatenated head-region style tags, suitable for injection into `<head>`.
- *
- * WHY region-aware: the streaming preview injects the returned styles into the
- * preview iframe's `<head>`, while `processPartialHtml` leaves complete
- * body-region `<style>` blocks in the preview body. This mirrors the final
- * document (`assembleDocument`), which keeps body-region styles in the body
- * (after the head css in document order) and only places head content in the
- * head. Hoisting EVERY style — including body ones — would flip a body style's
- * cascade position at the preview→final swap, visibly restyling artifacts whose
- * body `<style>` and the agent css param collide at equal specificity.
+ * The single shared region computation. Masks complete `<style>`/`<script>`
+ * content (see {@link maskBlockContent}), then derives every structural fact
+ * from that ONE masked string so both exported functions agree by construction.
  */
-export function extractCompleteStyles(html: string): string {
-  const matches = headRegion(html).match(/<style\b[^>]*>[\s\S]*?<\/style>/gi);
-  return matches ? matches.join("") : "";
-}
+function analyzeRegions(html: string): Regions {
+  const masked = maskBlockContent(html);
 
-/**
- * Processes raw accumulated HTML for safe preview via innerHTML injection.
- * Pure function, no DOM dependencies.
- *
- * Pipeline (order matters):
- * 1. Strip incomplete tag at end
- * 2. Strip complete <style> blocks in the HEAD region (before the first
- *    `<body[\s>]`); strip complete <script>/<head> blocks everywhere
- * 3. Strip incomplete <style>/<script>/<head> blocks
- * 4. Strip incomplete HTML entities
- * 5. Extract body content (or use full string if no <body>)
- *
- * Region semantics for `<style>` blocks: complete head-region styles are
- * stripped here because `extractCompleteStyles` hoists them into the preview
- * `<head>`. Complete BODY-region styles are deliberately KEPT in the returned
- * markup — browsers apply `<style>` anywhere, and the final document
- * (`assembleDocument`) likewise leaves body-region styles in the body (after the
- * head css in document order). Keeping them here gives the preview the same
- * cascade as the final document, so styles never shift position at the
- * preview→final swap. Incomplete trailing `<style>` blocks are still stripped
- * entirely in EITHER region: an unterminated `<style>` mid-stream must never
- * leak its raw CSS text into the preview body as visible content.
- */
-export function processPartialHtml(html: string): string {
-  let result = html;
-
-  // 1. Strip incomplete tag at end — e.g. `<div class="fo`
-  result = result.replace(/<[^>]*$/, "");
-
-  // 2a. Strip complete <script> and <head> blocks everywhere.
-  result = result.replace(/<(script|head)\b[^>]*>[\s\S]*?<\/\1>/gi, "");
-
-  // 2b. Strip complete <style> blocks ONLY in the head region (everything
-  // before the first `<body[\s>]`). They are hoisted to the preview <head> by
-  // extractCompleteStyles. Complete body-region <style> blocks stay in place so
-  // the preview cascade matches the final document. When there is no <body>,
-  // the whole string is the body region, so no complete styles are stripped
-  // here. The `<script>`/`<head>` blocks are already gone (step 2a), so this
-  // body-boundary search sees the SAME script/head-stripped text as the shared
-  // `headRegion` helper — the two functions therefore classify every complete
-  // <style> identically (none hoisted-and-kept, none dropped from both).
-  const bodyMatch2b = result.match(/<body[\s>]/i);
-  if (bodyMatch2b && bodyMatch2b.index !== undefined && bodyMatch2b.index > 0) {
-    const bodyStart = bodyMatch2b.index;
-    const head = result
-      .slice(0, bodyStart)
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "");
-    result = head + result.slice(bodyStart);
+  // Complete <head>…</head> element spans. `<head\b` is word-bounded so it never
+  // matches `<header>`; masking ensures a `<head`/`</head>` token inside CSS/JS
+  // cannot open or close a phantom element here.
+  const headElementSpans: Array<[number, number]> = [];
+  const headRe = /<head\b[^>]*>[\s\S]*?<\/head>/gi;
+  let headMatch: RegExpExecArray | null;
+  while ((headMatch = headRe.exec(masked)) !== null) {
+    headElementSpans.push([
+      headMatch.index,
+      headMatch.index + headMatch[0].length,
+    ]);
   }
 
-  // 3. Strip an INCOMPLETE (unterminated) <style>/<script>/<head> block at the
-  // end — an opening tag with no matching close tag through end of string. The
-  // negative-lookahead guard `(?!</\1>)` makes this match ONLY when no closing
-  // tag follows, so complete body-region <style> blocks (kept by step 2b) are
-  // preserved while a truly unterminated trailing block in EITHER region is
-  // removed entirely — raw CSS/JS text must never leak into the preview body.
+  // Every complete <style> block, tagged by containment in a head element. A
+  // block is "in head" only if its whole span sits inside one head element span.
+  const styleSpans: StyleSpan[] = [];
+  const styleRe = /<style\b[^>]*>[\s\S]*?<\/style>/gi;
+  let styleMatch: RegExpExecArray | null;
+  while ((styleMatch = styleRe.exec(masked)) !== null) {
+    const start = styleMatch.index;
+    const end = styleMatch.index + styleMatch[0].length;
+    const inHead = headElementSpans.some(
+      ([hs, he]) => start >= hs && end <= he,
+    );
+    styleSpans.push({ start, end, inHead });
+  }
+
+  // Complete <script> and <head> ELEMENT spans — stripped from the body markup
+  // everywhere. (A head element's in-head <style> blocks are contained within
+  // these spans, so stripping the element removes the hoisted styles too; we
+  // therefore never strip those styles a second time.)
+  const scriptOrHeadSpans: Array<[number, number]> = [];
+  const scriptOrHeadRe = /<(script|head)\b[^>]*>[\s\S]*?<\/\1>/gi;
+  let shMatch: RegExpExecArray | null;
+  while ((shMatch = scriptOrHeadRe.exec(masked)) !== null) {
+    scriptOrHeadSpans.push([shMatch.index, shMatch.index + shMatch[0].length]);
+  }
+
+  return { scriptOrHeadSpans, styleSpans };
+}
+
+/** Removes a set of `[start, end)` spans from `html`, applied right-to-left so
+ * earlier offsets stay valid. */
+function removeSpans(html: string, spans: Array<[number, number]>): string {
+  let out = html;
+  for (const [start, end] of [...spans].sort((a, b) => b[0] - a[0])) {
+    out = out.slice(0, start) + out.slice(end);
+  }
+  return out;
+}
+
+/**
+ * Extracts the complete `<style>` blocks that should be HOISTED into the preview
+ * iframe's `<head>` — i.e. ONLY those inside a complete `<head>…</head>` element
+ * (see the head-element rule in this module's header). Returns the concatenated
+ * style tags, suitable for injection into `<head>`.
+ *
+ * Mirrors `assembleDocument`: it keeps in-head styles in the head (before the
+ * agent css) and leaves every other style — including a top-level pre-`<body>`
+ * style — in the body region. Hoisting a body-region or top-level style would
+ * flip its cascade position at the preview→final swap, visibly restyling
+ * artifacts whose style and the agent css param collide at equal specificity.
+ *
+ * Derived from the shared {@link analyzeRegions} computation, so it classifies
+ * every complete `<style>` exactly as {@link processPartialHtml} does — the
+ * hoisted set here is precisely the set stripped from the body there.
+ */
+export function extractCompleteStyles(html: string): string {
+  const { styleSpans } = analyzeRegions(html);
+  return styleSpans
+    .filter((span) => span.inHead)
+    .map((span) => html.slice(span.start, span.end))
+    .join("");
+}
+
+/**
+ * Processes raw accumulated HTML into the markup injected via the preview's
+ * `document.body.innerHTML`. Pure function, no DOM dependencies.
+ *
+ * Pipeline (all structural detection comes from the shared {@link analyzeRegions}
+ * computation, so it agrees with {@link extractCompleteStyles} by construction):
+ * 1. Remove complete `<script>`/`<head>` ELEMENTS everywhere. Stripping a head
+ *    element also removes its in-head `<style>` blocks — exactly the blocks
+ *    {@link extractCompleteStyles} hoists — so those styles live in the head XOR
+ *    the body, never both. A top-level pre-`<body>` style (no enclosing head) is
+ *    NOT in any head element and is therefore KEPT, matching `assembleDocument`,
+ *    which leaves it in the body region.
+ * 2. Strip an incomplete tag at the very end — e.g. `<div class="fo`.
+ * 3. Strip an incomplete (unterminated) trailing `<style>`/`<script>`/`<head>`
+ *    block. Complete blocks are already removed (head/script) or intentionally
+ *    kept (body/top-level styles), so this only catches a genuinely unterminated
+ *    trailing block — raw CSS/JS text must never leak into the preview body.
+ * 4. Strip an incomplete HTML entity at the end — e.g. `&amp` without `;`.
+ * 5. Reduce to the body region: drop the `<body…>` open tag and the matching
+ *    `</body>` (and everything after it), and drop the `<html…>`/`</html>`
+ *    structural wrappers — keeping the body's inner content AND any surviving
+ *    top-level pre-`<body>` content (e.g. a body-region `<style>`). This mirrors
+ *    how a browser renders the FINAL document's body region: `<html>`/`<head>`
+ *    are wrappers the parser drops, while a pre-`<body>` style is real
+ *    cascade-bearing content that stays with the body. The `<body[\s>]`/`</body>`
+ *    matches are word-bounded (never `<bodyguard …>`) and run on a freshly
+ *    masked string so a `<body>`/`</body>` token inside a surviving style block
+ *    cannot fake the boundary.
+ */
+export function processPartialHtml(html: string): string {
+  const { scriptOrHeadSpans } = analyzeRegions(html);
+
+  // 1. Remove complete <script>/<head> elements (computed on the masked string,
+  // applied to the original by index). In-head styles ride along; body/top-level
+  // styles are preserved.
+  let result = removeSpans(html, scriptOrHeadSpans);
+
+  // 2. Strip an incomplete tag at the very end.
+  result = result.replace(/<[^>]*$/, "");
+
+  // 3. Strip an INCOMPLETE (unterminated) trailing <style>/<script>/<head> block
+  // — an open tag with no matching close through end of string.
   result = result.replace(
     /<(style|script|head)\b[^>]*>(?:(?!<\/\1>)[\s\S])*$/gi,
     "",
   );
 
-  // 4. Strip incomplete HTML entities — e.g. `&amp` without semicolon
+  // 4. Strip an incomplete HTML entity at the end.
   result = result.replace(/&[a-zA-Z0-9#]*$/, "");
 
-  // 5. Extract body content
-  const bodyMatch = result.match(/<body[^>]*>([\s\S]*)/i);
-  if (bodyMatch) {
-    result = bodyMatch[1]!;
-    // Strip </body> and everything after
-    result = result.replace(/<\/body>[\s\S]*/i, "");
+  // 5. Reduce to the body region. Mask first so a <body>/</body> token inside a
+  // surviving complete style block cannot be mistaken for the real boundary.
+  // Strip </body> (+ everything after) BEFORE the open tag so the open-tag
+  // index stays valid for the original string.
+  let masked = maskBlockContent(result);
+  const closeIdx = masked.search(/<\/body>/i);
+  if (closeIdx !== -1) {
+    result = result.slice(0, closeIdx);
+    masked = maskBlockContent(result);
   }
+  const openMatch = masked.match(/<body[\s>]/i);
+  if (openMatch && openMatch.index !== undefined) {
+    // Remove just the `<body…>` open tag, keeping content before and after it.
+    const openTagEnd =
+      openMatch.index + masked.slice(openMatch.index).search(/>/) + 1;
+    result = result.slice(0, openMatch.index) + result.slice(openTagEnd);
+  }
+  // Drop the `<html…>`/`</html>` structural wrappers (the browser drops them in
+  // an innerHTML body context); a pre-`<body>` `<style>` is content and stays.
+  result = result.replace(/^<html\b[^>]*>/i, "").replace(/<\/html>/gi, "");
 
   return result;
 }

--- a/packages/react-core/src/v2/lib/processPartialHtml.ts
+++ b/packages/react-core/src/v2/lib/processPartialHtml.ts
@@ -28,50 +28,124 @@
  * 2. MASK BEFORE MEASURING. Every structural search (locating `<head>` elements,
  *    the `<body[\s>]` boundary, the `</body>` close, `<script>`/`<head>` element
  *    spans) runs on a single shared masked copy of the input where the CONTENT
- *    of every COMPLETE `<style>`/`<script>` block is replaced with same-length
- *    placeholders. Indices are preserved 1:1, so spans map straight back to the
- *    original. A tag-lookalike token inside CSS/JS — `content:"<body>"`,
- *    `/* hide <body /> default *​/`, `x="</head>"` — therefore can NEVER fake a
- *    boundary or split a style block. Both exported functions derive their
- *    classifications from this ONE computation ({@link analyzeRegions}).
+ *    of every COMPLETE `<style>`/`<script>` block AND every COMPLETE `<!-- … -->`
+ *    HTML COMMENT is replaced with same-length placeholders. Indices are
+ *    preserved 1:1, so spans map straight back to the original. A tag-lookalike
+ *    token inside CSS/JS or inside a comment — `content:"<body>"`,
+ *    `/* hide <body /> default *​/`, `x="</head>"`, `<!-- <body> -->`,
+ *    `<!-- <script>x</script> -->` — therefore can NEVER fake a boundary, split
+ *    a style block, or be mistaken for real structure to strip. Both exported
+ *    functions derive their classifications from this ONE computation
+ *    ({@link analyzeRegions}).
  *
- * The `<body[\s>]` / `</body>` / `<head\b` guards are all word-bounded so
- * `<bodyguard …>`, `<header>`, etc. are never mistaken for `<body>`/`<head>`.
+ * The `<body[\s>]` / `</body>` / `<head\b` / `<html[\s>]` guards are all
+ * word-bounded so `<bodyguard …>`, `<header>`, `<htmlfoo>`, etc. are never
+ * mistaken for `<body>`/`<head>`/`<html>`.
  *
- * Incomplete trailing `<style>`/`<script>`/`<head>` blocks (an open tag with no
- * matching close through end of string) are still stripped entirely — an
- * unterminated block mid-stream must never leak its raw CSS/JS text into the
- * preview body as visible content.
+ * Incomplete trailing `<style>`/`<script>`/`<head>` blocks and an incomplete
+ * trailing `<!-- …` comment (an open token with no matching close through end of
+ * string) are still stripped entirely — an unterminated block mid-stream must
+ * never leak its raw CSS/JS/comment text into the preview body as visible
+ * content, and an unterminated comment must never fake structure (it would
+ * swallow the rest of the document once `-->` arrives, so the preview drops it
+ * to match the final document's effective rendering).
+ *
+ * An UNCLOSED `<head>` whose region reaches a `<body[\s>]` token (with no
+ * `</head>` first) is treated as if the head closed at that implicit `<body>`
+ * boundary — exactly how a browser renders the final document (`assembleDocument`
+ * leaves the in-head css in the head and the body content in the body when no
+ * `</head>` is emitted). So an in-head style there is hoisted and the body
+ * content is kept — content never vanishes. An unclosed `<head>` with content
+ * but NO `<body>` token is still stripped (a head that is genuinely still
+ * streaming its own content).
  *
  * Pure functions — no DOM, no React.
  */
 
-/** Matches a COMPLETE `<style>`/`<script>` block, capturing the tag name and its content. */
-const COMPLETE_STYLE_OR_SCRIPT = /<(style|script)\b[^>]*>([\s\S]*?)<\/\1>/gi;
+/**
+ * Quote-aware open-tag end scan: from a `<style`/`<script`/`<head` (etc.) start,
+ * matches through the tag's `>`, allowing a `>` inside a quoted attribute value
+ * (`<style data-x="a>b">`). Used so the masked content boundary is the REAL end
+ * of the open tag, not a quoted `>` mid-attribute.
+ */
+const OPEN_TAG_END = /^<[a-zA-Z][^\s/>]*(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/;
 
 /**
- * Replaces the CONTENT (between the open tag's `>` and the matching `</tag>`) of
- * every COMPLETE `<style>`/`<script>` block with same-length space placeholders.
- * The tags themselves are untouched. Length-preserving, so every index in the
- * returned string maps 1:1 to the original — callers locate structure on the
- * masked string and slice the matching text out of the original.
+ * Blanks the INSIDES of quoted runs (`"…"` / `'…'`) in a tag string with spaces,
+ * length-preserving. A structural-looking token inside an open tag's attribute
+ * value — `<style data-x="<body>">`, `<script src="</head>">` — must not be left
+ * visible to the structural searches (it would fake a boundary), so its bytes are
+ * blanked while the tag skeleton (name + attribute names + delimiters) is kept.
+ */
+function blankQuotedRuns(tag: string): string {
+  return tag.replace(
+    /"[^"]*"|'[^']*'/g,
+    (q) => q[0] + " ".repeat(q.length - 2) + q[0],
+  );
+}
+
+/**
+ * Replaces the CONTENT of every COMPLETE `<style>`/`<script>` block (between the
+ * open tag's real `>` and the matching `</tag>`) and the CONTENT of every
+ * COMPLETE `<!-- … -->` comment (between `<!--` and `-->`) with same-length space
+ * placeholders, and additionally blanks the quoted attribute values inside those
+ * style/script open tags. The delimiting tokens (and attribute skeletons) are
+ * untouched. Length-preserving, so every index in the returned string maps 1:1 to
+ * the original — callers locate structure on the masked string and slice the
+ * matching text out of the original.
+ *
+ * A single left-to-right pass masks whichever construct opens FIRST at each
+ * position, so the three constructs never interfere: a `<style>` mentioned inside
+ * a comment is masked as comment content (not treated as a real style), and a
+ * `-->` inside CSS is masked as style content (not treated as a comment close).
  */
 function maskBlockContent(html: string): string {
+  const blockRe = /<style\b|<script\b|<!--/gi;
   let out = "";
   let last = 0;
-  COMPLETE_STYLE_OR_SCRIPT.lastIndex = 0;
+  blockRe.lastIndex = 0;
   let match: RegExpExecArray | null;
-  while ((match = COMPLETE_STYLE_OR_SCRIPT.exec(html)) !== null) {
-    const full = match[0];
-    const content = match[2]!;
-    // Content starts right after the open tag's first `>`. (Open tags cannot
-    // contain a `>` here — these are `<style …>`/`<script …>` with no `>` in
-    // their attribute values in any realistic streamed document.)
-    const contentStart = match.index + full.indexOf(">") + 1;
-    const contentEnd = contentStart + content.length;
-    out += html.slice(last, contentStart);
-    out += " ".repeat(content.length);
-    last = contentEnd;
+  while ((match = blockRe.exec(html)) !== null) {
+    const start = match.index;
+    if (start < last) continue; // inside a region already masked
+    const token = match[0];
+    if (token === "<!--") {
+      const close = html.indexOf("-->", start + 4);
+      // Content runs from just after `<!--` to just before `-->`. An
+      // UNTERMINATED comment masks to end of string: anything after `<!--`
+      // would be swallowed by the comment once `-->` arrives, so no tag
+      // lookalike inside it (a complete-looking `<style>`, a `<body>`) may be
+      // mistaken for real structure. The trailing `<!-- …` is removed from the
+      // body by the comment-strip step.
+      const contentStart = start + 4;
+      const contentEnd = close === -1 ? html.length : close;
+      out += html.slice(last, contentStart);
+      out += " ".repeat(contentEnd - contentStart);
+      last = contentEnd;
+      blockRe.lastIndex = close === -1 ? html.length : close + 3;
+    } else {
+      // <style …> / <script …>. Find the REAL end of the open tag quote-aware
+      // (a quoted `>` in an attribute — `<style data-x="a>b">` — must not be
+      // mistaken for the end of the open tag), then mask up to the matching
+      // close tag. The open tag's quoted attribute VALUES are blanked too so a
+      // `<body>`/`</head>` inside one cannot fake a boundary. An unterminated
+      // open tag or block masks to end of string and is removed from the body by
+      // the unterminated-block strip step.
+      const tagName = token.slice(1); // "style" | "script"
+      const openEndMatch = html.slice(start).match(OPEN_TAG_END);
+      const openEnd = openEndMatch
+        ? start + openEndMatch[0].length
+        : html.length;
+      const closeRe = new RegExp(`</${tagName}>`, "i");
+      const closeRel = openEndMatch ? html.slice(openEnd).search(closeRe) : -1;
+      const contentEnd = closeRel === -1 ? html.length : openEnd + closeRel;
+      out += html.slice(last, start);
+      out += blankQuotedRuns(html.slice(start, openEnd));
+      out += " ".repeat(contentEnd - openEnd);
+      last = contentEnd;
+      blockRe.lastIndex =
+        closeRel === -1 ? html.length : contentEnd + `</${tagName}>`.length;
+    }
   }
   out += html.slice(last);
   return out;
@@ -101,17 +175,41 @@ interface Regions {
 function analyzeRegions(html: string): Regions {
   const masked = maskBlockContent(html);
 
-  // Complete <head>…</head> element spans. `<head\b` is word-bounded so it never
-  // matches `<header>`; masking ensures a `<head`/`</head>` token inside CSS/JS
-  // cannot open or close a phantom element here.
+  // Head ELEMENT spans, `[start, end)`. `<head\b` is word-bounded so it never
+  // matches `<header>`; masking ensures a `<head`/`</head>`/`<body>` token inside
+  // CSS/JS or a comment cannot open or close a phantom element here.
+  //
+  // A head element ends at its `</head>` when one exists. When an opened head has
+  // NO `</head>` but its region reaches a `<body[\s>]` token, the head is treated
+  // as IMPLICITLY closed at that body boundary (span ends just before `<body>`,
+  // which the browser does when rendering the final document) so an in-head style
+  // is still hoisted and the body content is preserved. A head opened with no
+  // `</head>` and no following `<body>` is genuinely still streaming and yields
+  // NO span (the unterminated-block strip step removes it).
   const headElementSpans: Array<[number, number]> = [];
-  const headRe = /<head\b[^>]*>[\s\S]*?<\/head>/gi;
-  let headMatch: RegExpExecArray | null;
-  while ((headMatch = headRe.exec(masked)) !== null) {
-    headElementSpans.push([
-      headMatch.index,
-      headMatch.index + headMatch[0].length,
-    ]);
+  // Quote-aware open-tag match (same family as assembleDocument's head matcher)
+  // so a quoted `>` in a head attribute does not truncate the tag early and a
+  // `<body>` inside the head's own attribute (before openEnd) is not seen by the
+  // implicit-close search below.
+  const headOpenRe = /<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi;
+  let headOpen: RegExpExecArray | null;
+  while ((headOpen = headOpenRe.exec(masked)) !== null) {
+    const openStart = headOpen.index;
+    const openEnd = openStart + headOpen[0].length;
+    const closeRel = masked.slice(openEnd).search(/<\/head>/i);
+    if (closeRel !== -1) {
+      const end = openEnd + closeRel + "</head>".length;
+      headElementSpans.push([openStart, end]);
+      headOpenRe.lastIndex = end;
+      continue;
+    }
+    // No close — fall back to an implicit `<body>` close.
+    const bodyRel = masked.slice(openEnd).search(/<body[\s>]/i);
+    if (bodyRel !== -1) {
+      headElementSpans.push([openStart, openEnd + bodyRel]);
+    }
+    // Either way there is no further `</head>` to find — stop scanning heads.
+    break;
   }
 
   // Every complete <style> block, tagged by containment in a head element. A
@@ -128,25 +226,48 @@ function analyzeRegions(html: string): Regions {
     styleSpans.push({ start, end, inHead });
   }
 
-  // Complete <script> and <head> ELEMENT spans — stripped from the body markup
-  // everywhere. (A head element's in-head <style> blocks are contained within
-  // these spans, so stripping the element removes the hoisted styles too; we
-  // therefore never strip those styles a second time.)
-  const scriptOrHeadSpans: Array<[number, number]> = [];
-  const scriptOrHeadRe = /<(script|head)\b[^>]*>[\s\S]*?<\/\1>/gi;
-  let shMatch: RegExpExecArray | null;
-  while ((shMatch = scriptOrHeadRe.exec(masked)) !== null) {
-    scriptOrHeadSpans.push([shMatch.index, shMatch.index + shMatch[0].length]);
+  // Complete <script> ELEMENT spans — stripped from the body markup everywhere.
+  const scriptSpans: Array<[number, number]> = [];
+  const scriptRe = /<script\b[^>]*>[\s\S]*?<\/script>/gi;
+  let scriptMatch: RegExpExecArray | null;
+  while ((scriptMatch = scriptRe.exec(masked)) !== null) {
+    scriptSpans.push([
+      scriptMatch.index,
+      scriptMatch.index + scriptMatch[0].length,
+    ]);
   }
+
+  // <script> AND <head> ELEMENT spans are both stripped from the body markup.
+  // (A head element's in-head <style> blocks are contained within its span, so
+  // stripping the element removes the hoisted styles too; we therefore never
+  // strip those styles a second time. The implicit-close head span is included
+  // here as well, so an unclosed-head-with-body strips its head region — keeping
+  // the in-head style hoisted XOR present, never both.)
+  const scriptOrHeadSpans = [...scriptSpans, ...headElementSpans];
 
   return { scriptOrHeadSpans, styleSpans };
 }
 
-/** Removes a set of `[start, end)` spans from `html`, applied right-to-left so
+/** Removes a set of `[start, end)` spans from `html`. Spans are coalesced first
+ * (a `<script>` nested inside a `<head>` element yields a script span contained
+ * in the head span — overlapping/contained ranges must be merged or a
+ * right-to-left splice would use a stale offset), then applied right-to-left so
  * earlier offsets stay valid. */
 function removeSpans(html: string, spans: Array<[number, number]>): string {
+  if (spans.length === 0) return html;
+  const sorted = [...spans].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const merged: Array<[number, number]> = [];
+  for (const [start, end] of sorted) {
+    const lastMerged = merged[merged.length - 1];
+    if (lastMerged && start <= lastMerged[1]) {
+      lastMerged[1] = Math.max(lastMerged[1], end);
+    } else {
+      merged.push([start, end]);
+    }
+  }
   let out = html;
-  for (const [start, end] of [...spans].sort((a, b) => b[0] - a[0])) {
+  for (let i = merged.length - 1; i >= 0; i--) {
+    const [start, end] = merged[i]!;
     out = out.slice(0, start) + out.slice(end);
   }
   return out;
@@ -190,9 +311,12 @@ export function extractCompleteStyles(html: string): string {
  *    which leaves it in the body region.
  * 2. Strip an incomplete tag at the very end — e.g. `<div class="fo`.
  * 3. Strip an incomplete (unterminated) trailing `<style>`/`<script>`/`<head>`
- *    block. Complete blocks are already removed (head/script) or intentionally
- *    kept (body/top-level styles), so this only catches a genuinely unterminated
- *    trailing block — raw CSS/JS text must never leak into the preview body.
+ *    block AND an incomplete trailing `<!-- …` comment. Complete blocks/comments
+ *    are already removed (head/script) or masked/intentionally kept (body styles,
+ *    complete comments), so this only catches a genuinely unterminated trailing
+ *    construct — raw CSS/JS text must never leak into the preview body, and an
+ *    unterminated comment must vanish (the final document's `-->` would swallow
+ *    the remainder, so the preview shows nothing for it).
  * 4. Strip an incomplete HTML entity at the end — e.g. `&amp` without `;`.
  * 5. Reduce to the body region: drop the `<body…>` open tag and the matching
  *    `</body>` (and everything after it), and drop the `<html…>`/`</html>`
@@ -201,9 +325,11 @@ export function extractCompleteStyles(html: string): string {
  *    how a browser renders the FINAL document's body region: `<html>`/`<head>`
  *    are wrappers the parser drops, while a pre-`<body>` style is real
  *    cascade-bearing content that stays with the body. The `<body[\s>]`/`</body>`
- *    matches are word-bounded (never `<bodyguard …>`) and run on a freshly
- *    masked string so a `<body>`/`</body>` token inside a surviving style block
- *    cannot fake the boundary.
+ *    /`<html[\s>]` matches are word-bounded (never `<bodyguard …>`/`<htmlfoo>`)
+ *    and run on a freshly masked string so a token inside a surviving style block
+ *    or comment cannot fake the boundary. The `<html…>` open tag is stripped
+ *    wherever it appears (not only when leading), so a prefixed wrapper —
+ *    `text<html>…` — does not leak the tag into the preview body.
  */
 export function processPartialHtml(html: string): string {
   const { scriptOrHeadSpans } = analyzeRegions(html);
@@ -213,23 +339,43 @@ export function processPartialHtml(html: string): string {
   // styles are preserved.
   let result = removeSpans(html, scriptOrHeadSpans);
 
-  // 2. Strip an incomplete tag at the very end.
-  result = result.replace(/<[^>]*$/, "");
+  // Steps 2–3 locate the trailing-incomplete cut point on a MASKED copy so a
+  // `<`, `<style`/`<head`/`<!--` token inside a COMPLETE style block's content or
+  // a quoted attribute value cannot be mistaken for a genuinely unterminated
+  // trailing construct; the cut is then applied to the original by index.
+  let trimMask = maskBlockContent(result);
 
-  // 3. Strip an INCOMPLETE (unterminated) trailing <style>/<script>/<head> block
-  // — an open tag with no matching close through end of string.
-  result = result.replace(
-    /<(style|script|head)\b[^>]*>(?:(?!<\/\1>)[\s\S])*$/gi,
-    "",
+  // 2. Strip an incomplete tag at the very end (e.g. `<div class="fo`).
+  const incompleteTag = trimMask.search(/<[^>]*$/);
+  if (incompleteTag !== -1) {
+    result = result.slice(0, incompleteTag);
+    trimMask = maskBlockContent(result);
+  }
+
+  // 3. Strip an INCOMPLETE (unterminated) trailing <!-- … comment, then an
+  // unterminated trailing <style>/<script>/<head> block. The unterminated
+  // construct masks to end-of-string in maskBlockContent, so its open token
+  // remains the only structural marker on the masked copy at the tail; complete
+  // blocks (with their close tags) never match here.
+  const incompleteComment = trimMask.search(/<!--(?:(?!-->)[\s\S])*$/);
+  if (incompleteComment !== -1) {
+    result = result.slice(0, incompleteComment);
+    trimMask = maskBlockContent(result);
+  }
+  const incompleteBlock = trimMask.search(
+    /<(style|script|head)\b[^>]*>(?:(?!<\/\1>)[\s\S])*$/i,
   );
+  if (incompleteBlock !== -1) {
+    result = result.slice(0, incompleteBlock);
+  }
 
   // 4. Strip an incomplete HTML entity at the end.
   result = result.replace(/&[a-zA-Z0-9#]*$/, "");
 
-  // 5. Reduce to the body region. Mask first so a <body>/</body> token inside a
-  // surviving complete style block cannot be mistaken for the real boundary.
-  // Strip </body> (+ everything after) BEFORE the open tag so the open-tag
-  // index stays valid for the original string.
+  // 5. Reduce to the body region. Mask first so a <body>/</body>/<html> token
+  // inside a surviving complete style block or comment cannot be mistaken for the
+  // real boundary. Strip </body> (+ everything after) BEFORE the open tag so the
+  // open-tag index stays valid for the original string.
   let masked = maskBlockContent(result);
   const closeIdx = masked.search(/<\/body>/i);
   if (closeIdx !== -1) {
@@ -249,10 +395,24 @@ export function processPartialHtml(html: string): string {
       ? openMatch.index + openTag[0].length
       : openMatch.index + masked.slice(openMatch.index).search(/>/) + 1;
     result = result.slice(0, openMatch.index) + result.slice(openTagEnd);
+    masked = maskBlockContent(result);
   }
-  // Drop the `<html…>`/`</html>` structural wrappers (the browser drops them in
-  // an innerHTML body context); a pre-`<body>` `<style>` is content and stays.
-  result = result.replace(/^<html\b[^>]*>/i, "").replace(/<\/html>/gi, "");
+  // Drop the `<html…>` open tag wherever it appears (the browser drops the
+  // wrapper in an innerHTML body context); a pre-`<body>` `<style>` is content
+  // and stays. Quote-aware end-of-tag scan + masked search so an `<html>` token
+  // inside a surviving style/comment cannot fake it, and a prefixed wrapper
+  // (`text<html>…`) is handled, not just a leading one.
+  const htmlOpen = masked.match(/<html[\s>]/i);
+  if (htmlOpen && htmlOpen.index !== undefined) {
+    const openTag = masked
+      .slice(htmlOpen.index)
+      .match(/^<html(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i);
+    const openTagEnd = openTag
+      ? htmlOpen.index + openTag[0].length
+      : htmlOpen.index + masked.slice(htmlOpen.index).search(/>/) + 1;
+    result = result.slice(0, htmlOpen.index) + result.slice(openTagEnd);
+  }
+  result = result.replace(/<\/html>/gi, "");
 
   return result;
 }

--- a/packages/react-core/src/v2/lib/processPartialHtml.ts
+++ b/packages/react-core/src/v2/lib/processPartialHtml.ts
@@ -239,8 +239,15 @@ export function processPartialHtml(html: string): string {
   const openMatch = masked.match(/<body[\s>]/i);
   if (openMatch && openMatch.index !== undefined) {
     // Remove just the `<body…>` open tag, keeping content before and after it.
-    const openTagEnd =
-      openMatch.index + masked.slice(openMatch.index).search(/>/) + 1;
+    // Quote-aware end-of-tag scan (same shape as assembleDocument's head
+    // matcher) so a quoted `>` in an attribute — `<body data-x="a>b">` — can't
+    // truncate the tag early and leak attribute fragments as visible content.
+    const openTag = masked
+      .slice(openMatch.index)
+      .match(/^<body(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i);
+    const openTagEnd = openTag
+      ? openMatch.index + openTag[0].length
+      : openMatch.index + masked.slice(openMatch.index).search(/>/) + 1;
     result = result.slice(0, openMatch.index) + result.slice(openTagEnd);
   }
   // Drop the `<html…>`/`</html>` structural wrappers (the browser drops them in

--- a/packages/react-core/src/v2/lib/processPartialHtml.ts
+++ b/packages/react-core/src/v2/lib/processPartialHtml.ts
@@ -323,18 +323,22 @@ export function extractCompleteStyles(html: string): string {
  *    `&D` is indistinguishable from a forming `&Dagger;` at the boundary); the
  *    conservative strip self-corrects on the next chunk and at completion (the
  *    FINAL document never runs processPartialHtml).
- * 5. Reduce to the body region: drop the `<body…>` open tag and the matching
- *    `</body>` (and everything after it), and drop the `<html…>`/`</html>`
- *    structural wrappers — keeping the body's inner content AND any surviving
- *    top-level pre-`<body>` content (e.g. a body-region `<style>`). This mirrors
- *    how a browser renders the FINAL document's body region: `<html>`/`<head>`
- *    are wrappers the parser drops, while a pre-`<body>` style is real
- *    cascade-bearing content that stays with the body. The `<body[\s>]`/`</body>`
- *    /`<html[\s>]` matches are word-bounded (never `<bodyguard …>`/`<htmlfoo>`)
- *    and run on a freshly masked string so a token inside a surviving style block
- *    or comment cannot fake the boundary. The `<html…>` open tag is stripped
- *    wherever it appears (not only when leading), so a prefixed wrapper —
- *    `text<html>…` — does not leak the tag into the preview body.
+ * 5. Reduce to the body region: drop the `<body…>` open tag and the `</body…>`
+ *    CLOSE TOKEN (but KEEP everything after it), and drop the `<html…>`/`</html>`
+ *    structural wrappers — keeping the body's inner content, any surviving
+ *    top-level pre-`<body>` content (e.g. a body-region `<style>`), AND any
+ *    content after `</body>`. This mirrors how a browser renders the FINAL
+ *    document's body region: `<html>`/`<head>`/`<body>`/`</body>`/`</html>` are
+ *    tags the parser consumes as structure, while a pre-`<body>` style and any
+ *    post-`</body>` markup are real content the browser REPARENTS into the body
+ *    (the final document is mounted whole, so the preview must keep them too — a
+ *    truncate-at-`</body>` drops content that pops in at the preview→final swap).
+ *    The `<body[\s>]`/`</body>`/`<html[\s>]` matches are word-bounded (never
+ *    `<bodyguard …>`/`<htmlfoo>`) and run on a freshly masked string so a token
+ *    inside a surviving style block or comment cannot fake the boundary. The
+ *    `</body>` and `<html…>` tokens are stripped wherever they appear (not only
+ *    when leading/trailing), so a prefixed wrapper — `text<html>…` — does not
+ *    leak the tag into the preview body, and post-`</body>` content is retained.
  */
 export function processPartialHtml(html: string): string {
   const { scriptOrHeadSpans } = analyzeRegions(html);
@@ -379,12 +383,30 @@ export function processPartialHtml(html: string): string {
 
   // 5. Reduce to the body region. Mask first so a <body>/</body>/<html> token
   // inside a surviving complete style block or comment cannot be mistaken for the
-  // real boundary. Strip </body> (+ everything after) BEFORE the open tag so the
-  // open-tag index stays valid for the original string.
+  // real boundary. Remove the </body> CLOSE TOKEN(S) but KEEP the content after
+  // them — a browser reparents any markup that appears after </body> back INTO
+  // the body when it renders the final (whole-document) mount, so truncating at
+  // </body> would drop content the final document still shows (a preview↔final
+  // divergence where post-</body> content pops in at the swap). A complete
+  // <style> after </body> is body-region too (it sits in no <head> element), so
+  // analyzeRegions does not hoist it and it stays here in the body — preserving
+  // the hoist-XOR-keep invariant. Locate each </body> on the MASKED copy (so a
+  // </body> token inside a surviving style/comment is never taken as the
+  // structural close) and splice those spans out of the ORIGINAL by index — the
+  // same mask-aware shape as the </html> strip below. Done before the <body>
+  // open-tag step so its offsets stay valid for the post-removal string.
   let masked = maskBlockContent(result);
-  const closeIdx = masked.search(/<\/body>/i);
-  if (closeIdx !== -1) {
-    result = result.slice(0, closeIdx);
+  const bodyCloseSpans: Array<[number, number]> = [];
+  const bodyCloseRe = /<\/body>/gi;
+  let bodyClose: RegExpExecArray | null;
+  while ((bodyClose = bodyCloseRe.exec(masked)) !== null) {
+    bodyCloseSpans.push([
+      bodyClose.index,
+      bodyClose.index + bodyClose[0].length,
+    ]);
+  }
+  if (bodyCloseSpans.length > 0) {
+    result = removeSpans(result, bodyCloseSpans);
     masked = maskBlockContent(result);
   }
   const openMatch = masked.match(/<body[\s>]/i);

--- a/packages/react-core/src/v2/lib/processPartialHtml.ts
+++ b/packages/react-core/src/v2/lib/processPartialHtml.ts
@@ -1,9 +1,47 @@
 /**
- * Extracts all complete `<style>` blocks from the raw HTML.
- * Returns the concatenated style tags, suitable for injection into `<head>`.
+ * Returns the HEAD region of `html` — the substring before the first real
+ * `<body[\s>]` opening tag (case-insensitive). Returns `""` when no `<body` tag
+ * exists, because `processPartialHtml` then treats the WHOLE string as the body
+ * region (so there is no head region at all).
+ *
+ * Complete `<script>` blocks are stripped FIRST so a `<body` that only appears
+ * as text inside a script (e.g. `<script>x="<body>"</script>`) can never be
+ * mistaken for the real body boundary. `<head>` blocks are deliberately NOT
+ * stripped: a `<style>` wrapped in `<head>…</head>` is still head-region and
+ * must be hoisted (and `processPartialHtml` removes that same style as part of
+ * its complete-`<head>`-block strip, so the two functions stay in agreement —
+ * no style is ever both hoisted and left behind, or dropped from both).
+ *
+ * The `<body[\s>]` guard matches `<body>`/`<body …>` but never `<bodysomething>`.
+ */
+function headRegion(html: string): string {
+  const withoutScripts = html.replace(
+    /<script\b[^>]*>[\s\S]*?<\/script>/gi,
+    "",
+  );
+  const match = withoutScripts.match(/<body[\s>]/i);
+  if (!match || match.index === undefined) return "";
+  return withoutScripts.slice(0, match.index);
+}
+
+/**
+ * Extracts complete `<style>…</style>` blocks ONLY from the HEAD region of the
+ * raw HTML — everything before the first `<body[\s>]` tag (case-insensitive).
+ * When no `<body` tag exists, there is no head region (the whole string is the
+ * body region per `processPartialHtml`), so nothing is hoisted. Returns the
+ * concatenated head-region style tags, suitable for injection into `<head>`.
+ *
+ * WHY region-aware: the streaming preview injects the returned styles into the
+ * preview iframe's `<head>`, while `processPartialHtml` leaves complete
+ * body-region `<style>` blocks in the preview body. This mirrors the final
+ * document (`assembleDocument`), which keeps body-region styles in the body
+ * (after the head css in document order) and only places head content in the
+ * head. Hoisting EVERY style — including body ones — would flip a body style's
+ * cascade position at the preview→final swap, visibly restyling artifacts whose
+ * body `<style>` and the agent css param collide at equal specificity.
  */
 export function extractCompleteStyles(html: string): string {
-  const matches = html.match(/<style\b[^>]*>[\s\S]*?<\/style>/gi);
+  const matches = headRegion(html).match(/<style\b[^>]*>[\s\S]*?<\/style>/gi);
   return matches ? matches.join("") : "";
 }
 
@@ -13,10 +51,22 @@ export function extractCompleteStyles(html: string): string {
  *
  * Pipeline (order matters):
  * 1. Strip incomplete tag at end
- * 2. Strip complete <style>, <script>, and <head> blocks
+ * 2. Strip complete <style> blocks in the HEAD region (before the first
+ *    `<body[\s>]`); strip complete <script>/<head> blocks everywhere
  * 3. Strip incomplete <style>/<script>/<head> blocks
  * 4. Strip incomplete HTML entities
  * 5. Extract body content (or use full string if no <body>)
+ *
+ * Region semantics for `<style>` blocks: complete head-region styles are
+ * stripped here because `extractCompleteStyles` hoists them into the preview
+ * `<head>`. Complete BODY-region styles are deliberately KEPT in the returned
+ * markup — browsers apply `<style>` anywhere, and the final document
+ * (`assembleDocument`) likewise leaves body-region styles in the body (after the
+ * head css in document order). Keeping them here gives the preview the same
+ * cascade as the final document, so styles never shift position at the
+ * preview→final swap. Incomplete trailing `<style>` blocks are still stripped
+ * entirely in EITHER region: an unterminated `<style>` mid-stream must never
+ * leak its raw CSS text into the preview body as visible content.
  */
 export function processPartialHtml(html: string): string {
   let result = html;
@@ -24,11 +74,37 @@ export function processPartialHtml(html: string): string {
   // 1. Strip incomplete tag at end — e.g. `<div class="fo`
   result = result.replace(/<[^>]*$/, "");
 
-  // 2. Strip complete <style>, <script>, and <head> blocks
-  result = result.replace(/<(style|script|head)\b[^>]*>[\s\S]*?<\/\1>/gi, "");
+  // 2a. Strip complete <script> and <head> blocks everywhere.
+  result = result.replace(/<(script|head)\b[^>]*>[\s\S]*?<\/\1>/gi, "");
 
-  // 3. Strip incomplete <style>/<script>/<head> blocks (opening tag, no close)
-  result = result.replace(/<(style|script|head)\b[^>]*>[\s\S]*$/gi, "");
+  // 2b. Strip complete <style> blocks ONLY in the head region (everything
+  // before the first `<body[\s>]`). They are hoisted to the preview <head> by
+  // extractCompleteStyles. Complete body-region <style> blocks stay in place so
+  // the preview cascade matches the final document. When there is no <body>,
+  // the whole string is the body region, so no complete styles are stripped
+  // here. The `<script>`/`<head>` blocks are already gone (step 2a), so this
+  // body-boundary search sees the SAME script/head-stripped text as the shared
+  // `headRegion` helper — the two functions therefore classify every complete
+  // <style> identically (none hoisted-and-kept, none dropped from both).
+  const bodyMatch2b = result.match(/<body[\s>]/i);
+  if (bodyMatch2b && bodyMatch2b.index !== undefined && bodyMatch2b.index > 0) {
+    const bodyStart = bodyMatch2b.index;
+    const head = result
+      .slice(0, bodyStart)
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "");
+    result = head + result.slice(bodyStart);
+  }
+
+  // 3. Strip an INCOMPLETE (unterminated) <style>/<script>/<head> block at the
+  // end — an opening tag with no matching close tag through end of string. The
+  // negative-lookahead guard `(?!</\1>)` makes this match ONLY when no closing
+  // tag follows, so complete body-region <style> blocks (kept by step 2b) are
+  // preserved while a truly unterminated trailing block in EITHER region is
+  // removed entirely — raw CSS/JS text must never leak into the preview body.
+  result = result.replace(
+    /<(style|script|head)\b[^>]*>(?:(?!<\/\1>)[\s\S])*$/gi,
+    "",
+  );
 
   // 4. Strip incomplete HTML entities — e.g. `&amp` without semicolon
   result = result.replace(/&[a-zA-Z0-9#]*$/, "");

--- a/packages/react-core/src/v2/lib/processPartialHtml.ts
+++ b/packages/react-core/src/v2/lib/processPartialHtml.ts
@@ -317,7 +317,12 @@ export function extractCompleteStyles(html: string): string {
  *    construct — raw CSS/JS text must never leak into the preview body, and an
  *    unterminated comment must vanish (the final document's `-->` would swallow
  *    the remainder, so the preview shows nothing for it).
- * 4. Strip an incomplete HTML entity at the end — e.g. `&amp` without `;`.
+ * 4. Strip an incomplete HTML entity at the end — e.g. `&amp` without `;`. BY
+ *    DESIGN this also drops a trailing run of LITERAL text that merely looks
+ *    like a developing entity (a chunk ending `<p>R&D` renders as `<p>R`, since
+ *    `&D` is indistinguishable from a forming `&Dagger;` at the boundary); the
+ *    conservative strip self-corrects on the next chunk and at completion (the
+ *    FINAL document never runs processPartialHtml).
  * 5. Reduce to the body region: drop the `<body…>` open tag and the matching
  *    `</body>` (and everything after it), and drop the `<html…>`/`</html>`
  *    structural wrappers — keeping the body's inner content AND any surviving
@@ -411,8 +416,25 @@ export function processPartialHtml(html: string): string {
       ? htmlOpen.index + openTag[0].length
       : htmlOpen.index + masked.slice(htmlOpen.index).search(/>/) + 1;
     result = result.slice(0, htmlOpen.index) + result.slice(openTagEnd);
+    masked = maskBlockContent(result);
   }
-  result = result.replace(/<\/html>/gi, "");
+  // Drop the `</html…>` close tag wherever it appears, mask-aware like every
+  // other structural op here. Locate each `</html>` on the MASKED copy (so a
+  // `</html>` token inside a SURVIVING complete style/comment block or a quoted
+  // attribute value is never seen as the wrapper close) and slice those spans
+  // out of the ORIGINAL by index. A plain `result.replace(/<\/html>/gi, "")`
+  // would run on the UNMASKED string and wrongly delete such a token from
+  // content the final document keeps (e.g. `content:"</html>"`).
+  const htmlCloseSpans: Array<[number, number]> = [];
+  const htmlCloseRe = /<\/html>/gi;
+  let htmlClose: RegExpExecArray | null;
+  while ((htmlClose = htmlCloseRe.exec(masked)) !== null) {
+    htmlCloseSpans.push([
+      htmlClose.index,
+      htmlClose.index + htmlClose[0].length,
+    ]);
+  }
+  result = removeSpans(result, htmlCloseSpans);
 
   return result;
 }

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -52,6 +52,10 @@ import type { ReactHumanInTheLoop } from "../types/human-in-the-loop";
 import type { ReactCustomMessageRenderer } from "../types/react-custom-message-renderer";
 import type { SandboxFunction } from "../types/sandbox-function";
 import { SandboxFunctionsContext } from "./SandboxFunctionsContext";
+import { OPEN_GEN_UI_DESIGN_SYSTEM_CSS } from "../lib/designSystemCss";
+import { DEFAULT_OPEN_GEN_UI_LIBRARIES } from "../lib/assembleDocument";
+import { OpenGenerativeUIOptionsProvider } from "./OpenGenerativeUIOptionsContext";
+import type { OpenGenerativeUIResolvedOptions } from "./OpenGenerativeUIOptionsContext";
 import { schemaToJsonSchema } from "@copilotkit/shared";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
@@ -63,7 +67,10 @@ const EMPTY_HEADERS: Readonly<Record<string, string>> = Object.freeze({});
 const EMPTY_PROPERTIES: Readonly<Record<string, unknown>> = Object.freeze({});
 const EMPTY_AGENTS: Readonly<Record<string, AbstractAgent>> = Object.freeze({});
 
-const DEFAULT_DESIGN_SKILL = `When generating UI with generateSandboxedUi, follow these design principles inspired by shadcn/ui:
+// Legacy design skill (hardcoded palette). Used when the design system is
+// disabled (`openGenerativeUI.designSystem === false`) so the model still
+// receives concrete color/border guidance instead of token references.
+const LEGACY_DEFAULT_DESIGN_SKILL = `When generating UI with generateSandboxedUi, follow these design principles inspired by shadcn/ui:
 
 - Use a minimal, flat aesthetic. Avoid drop shadows and gradients — rely on subtle borders (1px solid, light gray like #e5e7eb) to define surfaces.
 - Neutral base palette: white backgrounds, zinc/slate gray text (#09090b for headings, #71717a for secondary text). One accent color for interactive elements.
@@ -74,19 +81,57 @@ const DEFAULT_DESIGN_SKILL = `When generating UI with generateSandboxedUi, follo
 - Minimal transitions (150ms) for hover/focus states only. No decorative animations.
 - Keep the UI focused and dense — avoid excessive padding. Use compact spacing (8–12px gaps, 10–14px padding in controls).`;
 
-const GENERATE_SANDBOXED_UI_DESCRIPTION =
-  "Generate sandboxed UI. " +
-  "IMPORTANT: The generated code runs in a sandboxed iframe WITHOUT same-origin access. " +
-  "Do NOT use localStorage, sessionStorage, document.cookie, IndexedDB, or fetch/XMLHttpRequest to same-origin URLs. " +
-  "To communicate with the host application, use Websandbox.connection.remote.<functionName>(args) which returns a Promise.\n\n" +
-  "You CAN use external libraries from CDNs by including <script> or <link> tags in the HTML <head> (e.g., Chart.js, D3, Three.js, x-data-spreadsheet, etc.). " +
-  "CDN resources load normally inside the sandbox.\n\n" +
-  "PARAMETER ORDER IS CRITICAL — generate parameters in exactly this order:\n" +
-  "1. initialHeight + placeholderMessages (shown to user while generating)\n" +
-  "2. css (all styles FIRST — the user sees a placeholder until CSS is complete)\n" +
-  "3. html (streams in live — the user watches the UI build as HTML is generated)\n" +
-  "4. jsFunctions (reusable helper functions)\n" +
-  "5. jsExpressions (applied one-by-one — the user sees each expression take effect)";
+// Default design skill (token-based). Used when the design system is injected
+// so the model styles against the pre-injected design tokens.
+const DEFAULT_DESIGN_SKILL = `When generating UI with generateSandboxedUi, follow these design principles inspired by shadcn/ui:
+
+- Use the injected design tokens for all colors and radii (var(--color-*), var(--border-radius-*)); never hardcode grays. One accent color for interactive elements.
+- Surfaces separate with 1px var(--color-border-tertiary) borders, not shadows.
+- Use system font stacks (system-ui, -apple-system, sans-serif) at readable sizes (14px body, 600 weight for headings). Tight line-heights.
+- Small, consistent border-radius (6–8px). Cards and containers use border, not shadow, for separation.
+- Buttons: solid fill for primary (dark bg, white text), outline for secondary (border + transparent bg). Subtle hover state (slight opacity or background shift).
+- Use CSS Grid or Flexbox for layout. Ensure the UI looks good at any width.
+- Minimal transitions (150ms) for hover/focus states only. No decorative animations.
+- Keep the UI focused and dense — avoid excessive padding. Use compact spacing (8–12px gaps, 10–14px padding in controls).`;
+
+// Base generateSandboxedUi tool description. When the design system / library
+// importmap are injected into the document, append guidance so the model knows
+// the kit and pre-wired ES-module libraries exist. With both disabled this
+// returns the original (legacy) description text verbatim.
+function buildGenerateSandboxedUiDescription(opts: {
+  designSystem: boolean;
+  libraries: string[];
+}): string {
+  let description =
+    "Generate sandboxed UI. " +
+    "IMPORTANT: The generated code runs in a sandboxed iframe WITHOUT same-origin access. " +
+    "Do NOT use localStorage, sessionStorage, document.cookie, IndexedDB, or fetch/XMLHttpRequest to same-origin URLs. " +
+    "To communicate with the host application, use Websandbox.connection.remote.<functionName>(args) which returns a Promise.\n\n" +
+    "You CAN use external libraries from CDNs by including <script> or <link> tags in the HTML <head> (e.g., Chart.js, D3, Three.js, x-data-spreadsheet, etc.). " +
+    "CDN resources load normally inside the sandbox.\n\n" +
+    "PARAMETER ORDER IS CRITICAL — generate parameters in exactly this order:\n" +
+    "1. initialHeight + placeholderMessages (shown to user while generating)\n" +
+    "2. css (all styles FIRST — the user sees a placeholder until CSS is complete)\n" +
+    "3. html (streams in live — the user watches the UI build as HTML is generated)\n" +
+    "4. jsFunctions (reusable helper functions)\n" +
+    "5. jsExpressions (applied one-by-one — the user sees each expression take effect)";
+
+  if (opts.designSystem) {
+    description +=
+      "\n\nA design system is PRE-INJECTED into the document. Prefer it over hand-rolled styles:\n" +
+      "- CSS variables: var(--color-background-primary|secondary|tertiary), var(--color-text-primary|secondary|tertiary), var(--color-border-*), semantic info/danger/success/warning variants, var(--font-sans|serif|mono), var(--border-radius-md|lg|xl). Light/dark is automatic — do NOT hardcode colors for things the tokens cover.\n" +
+      "- Form controls (button, input, textarea, select, range, checkbox, radio) are pre-styled; write semantic HTML and skip restyling basics.\n" +
+      "- SVG helper classes: text.t/.ts/.th for typography; .box, .node, .arr, .leader; color ramps .c-purple/.c-teal/.c-coral/.c-pink/.c-gray/.c-blue/.c-green/.c-amber/.c-red for fills+strokes with dark-mode handled.";
+  }
+
+  if (opts.libraries.length > 0) {
+    description += `\n\nPre-wired ES-module libraries (importmap is already in the document): ${opts.libraries.join(
+      ", ",
+    )}. Import them with bare specifiers inside <script type="module"> (e.g. import * as THREE from "three"; OrbitControls from "three/examples/jsm/controls/OrbitControls.js"). Do NOT add <script src> CDN tags for these libraries.`;
+  }
+
+  return description;
+}
 // Provider props interface
 export interface CopilotKitProviderProps {
   children: ReactNode;
@@ -150,6 +195,18 @@ export interface CopilotKitProviderProps {
      * A sensible default is provided if omitted.
      */
     designSkill?: string;
+    /**
+     * Design-system CSS injected into every generated document.
+     * `true` (default) injects the built-in token/SVG/form kit; `false` disables;
+     * `{ css }` replaces the kit with a custom one.
+     */
+    designSystem?: boolean | { css: string };
+    /**
+     * ES-module importmap entries injected into every generated document.
+     * Defaults to pinned three/gsap/d3/chart.js. Merged over the defaults;
+     * `false` disables the importmap entirely.
+     */
+    libraries?: Record<string, string> | false;
   };
   showDevConsole?: boolean | "auto";
   /**
@@ -278,6 +335,23 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   const [runtimeA2UIEnabled, setRuntimeA2UIEnabled] = useState(false);
   const [runtimeOpenGenUIEnabled, setRuntimeOpenGenUIEnabled] = useState(false);
   const openGenUIActive = runtimeOpenGenUIEnabled || !!openGenerativeUI;
+  // Resolve the design-system CSS + library importmap once. Defaults inject the
+  // built-in kit and pinned libraries; `designSystem: false` / `libraries: false`
+  // restore legacy (no-injection) behavior.
+  const openGenUIOptions = useMemo<OpenGenerativeUIResolvedOptions>(() => {
+    const ds = openGenerativeUI?.designSystem;
+    const libs = openGenerativeUI?.libraries;
+    return {
+      designSystemCss:
+        ds === false
+          ? false
+          : typeof ds === "object"
+            ? ds.css
+            : OPEN_GEN_UI_DESIGN_SYSTEM_CSS,
+      importMap:
+        libs === false ? false : { ...DEFAULT_OPEN_GEN_UI_LIBRARIES, ...libs },
+    };
+  }, [openGenerativeUI?.designSystem, openGenerativeUI?.libraries]);
   const [runtimeLicenseStatus, setRuntimeLicenseStatus] = useState<
     string | undefined
   >(undefined);
@@ -475,14 +549,21 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
     return [
       {
         name: "generateSandboxedUi",
-        description: GENERATE_SANDBOXED_UI_DESCRIPTION,
+        description: buildGenerateSandboxedUiDescription({
+          designSystem: openGenUIOptions.designSystemCss !== false,
+          libraries: openGenUIOptions.importMap
+            ? Object.keys(openGenUIOptions.importMap).filter(
+                (k) => !k.endsWith("/"),
+              )
+            : [],
+        }),
         parameters: GenerateSandboxedUiArgsSchema,
         handler: async () => "UI generated",
         followUp: true,
         render: OpenGenerativeUIToolRenderer,
       },
     ];
-  }, [openGenUIActive]);
+  }, [openGenUIActive, openGenUIOptions]);
 
   // Combine all tools for CopilotKitCore
   const allTools = useMemo(() => {
@@ -718,8 +799,14 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
     copilotkit.setDefaultThrottleMs(defaultThrottleMs);
   }, [copilotkit, defaultThrottleMs]);
 
-  // Register design skill as agent context for the generateSandboxedUi tool
-  const designSkill = openGenerativeUI?.designSkill ?? DEFAULT_DESIGN_SKILL;
+  // Register design skill as agent context for the generateSandboxedUi tool.
+  // When the design system is disabled, fall back to the legacy (hardcoded
+  // palette) skill so the model still gets concrete color/border guidance.
+  const designSkill =
+    openGenerativeUI?.designSkill ??
+    (openGenUIOptions.designSystemCss === false
+      ? LEGACY_DEFAULT_DESIGN_SKILL
+      : DEFAULT_DESIGN_SKILL);
 
   useLayoutEffect(() => {
     if (!copilotkit || !openGenUIActive) return;
@@ -771,39 +858,41 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   );
 
   return (
-    <SandboxFunctionsContext.Provider value={sandboxFunctionsList}>
-      <CopilotKitContext.Provider value={contextValue}>
-        <LicenseContext.Provider value={licenseContextValue}>
-          {runtimeA2UIEnabled && <A2UIBuiltInToolCallRenderer />}
-          {runtimeA2UIEnabled && (
-            <A2UICatalogContext
-              catalog={a2ui?.catalog}
-              includeSchema={a2ui?.includeSchema}
-            />
-          )}
-          {children}
-          {shouldRenderInspector ? (
-            <CopilotKitInspector
-              core={copilotkit}
-              defaultAnchor={inspectorDefaultAnchor}
-            />
-          ) : null}
-          {/* License warnings — driven by server-reported status */}
-          {runtimeLicenseStatus === "none" && !resolvedPublicKey && (
-            <LicenseWarningBanner type="no_license" />
-          )}
-          {runtimeLicenseStatus === "expired" && (
-            <LicenseWarningBanner type="expired" />
-          )}
-          {runtimeLicenseStatus === "invalid" && (
-            <LicenseWarningBanner type="invalid" />
-          )}
-          {runtimeLicenseStatus === "expiring" && (
-            <LicenseWarningBanner type="expiring" />
-          )}
-        </LicenseContext.Provider>
-      </CopilotKitContext.Provider>
-    </SandboxFunctionsContext.Provider>
+    <OpenGenerativeUIOptionsProvider value={openGenUIOptions}>
+      <SandboxFunctionsContext.Provider value={sandboxFunctionsList}>
+        <CopilotKitContext.Provider value={contextValue}>
+          <LicenseContext.Provider value={licenseContextValue}>
+            {runtimeA2UIEnabled && <A2UIBuiltInToolCallRenderer />}
+            {runtimeA2UIEnabled && (
+              <A2UICatalogContext
+                catalog={a2ui?.catalog}
+                includeSchema={a2ui?.includeSchema}
+              />
+            )}
+            {children}
+            {shouldRenderInspector ? (
+              <CopilotKitInspector
+                core={copilotkit}
+                defaultAnchor={inspectorDefaultAnchor}
+              />
+            ) : null}
+            {/* License warnings — driven by server-reported status */}
+            {runtimeLicenseStatus === "none" && !resolvedPublicKey && (
+              <LicenseWarningBanner type="no_license" />
+            )}
+            {runtimeLicenseStatus === "expired" && (
+              <LicenseWarningBanner type="expired" />
+            )}
+            {runtimeLicenseStatus === "invalid" && (
+              <LicenseWarningBanner type="invalid" />
+            )}
+            {runtimeLicenseStatus === "expiring" && (
+              <LicenseWarningBanner type="expiring" />
+            )}
+          </LicenseContext.Provider>
+        </CopilotKitContext.Provider>
+      </SandboxFunctionsContext.Provider>
+    </OpenGenerativeUIOptionsProvider>
   );
 };
 

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -724,8 +724,12 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
 
   // Sync runtime feature flags from the core once runtime info is fetched
   useEffect(() => {
-    // Check current value immediately (may already be set before subscription)
+    // Read all current values immediately: runtime /info may have already
+    // resolved before this effect subscribed, and no further
+    // onRuntimeConnectionStatusChanged event would fire to deliver them.
     setRuntimeA2UIEnabled(copilotkit.a2uiEnabled);
+    setRuntimeOpenGenUIEnabled(copilotkit.openGenerativeUIEnabled);
+    setRuntimeLicenseStatus(copilotkit.licenseStatus);
     const subscription = copilotkit.subscribe({
       onRuntimeConnectionStatusChanged: () => {
         setRuntimeA2UIEnabled(copilotkit.a2uiEnabled);

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -136,7 +136,7 @@ function buildGenerateSandboxedUiDescription(opts: {
   if (opts.libraries.length > 0) {
     description += `\n\nPre-wired ES-module libraries (importmap is already in the document): ${opts.libraries.join(
       ", ",
-    )}. Import them with bare specifiers inside <script type="module"> (e.g. import * as THREE from "three"; OrbitControls from "three/examples/jsm/controls/OrbitControls.js"). Do NOT add <script src> CDN tags for these libraries.`;
+    )}. Import them with bare specifiers inside <script type="module"> (e.g. import * as THREE from "three"; import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js"). Do NOT add <script src> CDN tags for these libraries.`;
   }
 
   return description;

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -134,6 +134,15 @@ function buildGenerateSandboxedUiDescription(opts: {
   }
 
   if (opts.libraries.length > 0) {
+    // The appended block below tells the model NOT to add <script src> CDN tags
+    // for the pre-wired libraries. The base text's CDN example previously named
+    // some of those same libraries (Chart.js, D3, Three.js), directly
+    // contradicting that instruction — so when the block is appended, drop the
+    // pre-wired names from the example and keep only a non-pre-wired one.
+    description = description.replace(
+      "(e.g., Chart.js, D3, Three.js, x-data-spreadsheet, etc.)",
+      "(e.g., x-data-spreadsheet, etc.)",
+    );
     description += `\n\nPre-wired ES-module libraries (importmap is already in the document): ${opts.libraries.join(
       ", ",
     )}. Import them with bare specifiers inside <script type="module"> (e.g. import * as THREE from "three"; import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js"). Do NOT add <script src> CDN tags for these libraries.`;
@@ -177,12 +186,10 @@ export interface CopilotKitProviderProps {
    *
    * @example
    * ```tsx
-   * <CopilotKit
-   *   runtimeUrl="/api/copilotkit"
-   *   openGenerativeUI={{
-   *     sandboxFunctions: [{ name: "addToCart", description: "…", parameters: schema, handler: fn }],
-   *   }}
-   * >
+   * // define outside the component (or useMemo) — a stable identity avoids sandbox rebuilds
+   * const sandboxFunctions = [{ name: "addToCart", description: "…", parameters: schema, handler: fn }];
+   *
+   * <CopilotKit runtimeUrl="/api/copilotkit" openGenerativeUI={{ sandboxFunctions }}>
    * ```
    */
   openGenerativeUI?: {
@@ -370,12 +377,26 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   const designSystemOff = designSystem === false;
 
   // Value-stable key for the library importmap. The inline idiom
-  // (`libraries={{ … }}`) passes a fresh object every render; JSON.stringify of
-  // a small literal yields a stable string whenever the VALUE is unchanged
-  // (key order from an inline literal is stable across renders), so the memo
-  // below recomputes only on genuine value changes — not object-identity churn.
+  // (`libraries={{ … }}`) passes a fresh object every render, and a dynamically
+  // built object (spread merges, Object.fromEntries) can also reorder keys
+  // between renders while carrying the same entries. JSON.stringify is
+  // insertion-order-sensitive, so we serialize from sorted entries — the key
+  // changes only on a genuine VALUE change, never on key-order or
+  // object-identity churn. The memo below therefore recomputes only when the
+  // resolved importmap would actually differ.
   const libs = openGenerativeUI?.libraries;
-  const librariesKey = libs === false ? "false" : JSON.stringify(libs ?? null);
+  const librariesKey =
+    libs === false
+      ? "false"
+      : libs == null
+        ? "null"
+        : JSON.stringify(
+            Object.fromEntries(
+              Object.entries(libs).sort(([a], [b]) =>
+                a < b ? -1 : a > b ? 1 : 0,
+              ),
+            ),
+          );
 
   // Resolve the design-system CSS + library importmap once. Defaults inject the
   // built-in kit and pinned libraries; `designSystem: false` / `libraries: false`

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -204,7 +204,8 @@ export interface CopilotKitProviderProps {
     /**
      * Design-system CSS injected into every generated document.
      * `true` (default) injects the built-in token/SVG/form kit; `false` disables;
-     * `{ css }` replaces the kit with a custom one.
+     * `{ css }` replaces the kit with a custom one (a degenerate object such as
+     * `{}` or `{ css: "" }` falls back to the built-in kit).
      */
     designSystem?: boolean | { css: string };
     /**
@@ -341,38 +342,47 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   const [runtimeA2UIEnabled, setRuntimeA2UIEnabled] = useState(false);
   const [runtimeOpenGenUIEnabled, setRuntimeOpenGenUIEnabled] = useState(false);
   const openGenUIActive = runtimeOpenGenUIEnabled || !!openGenerativeUI;
+  // Single source of truth for the custom design-system stylesheet. A custom kit
+  // is only present when `designSystem` is an object carrying a non-empty `css`
+  // string; `{}`, `{ css: "" }`, whitespace-only css, `null` and `undefined` all
+  // resolve to `undefined` here and therefore behave like the built-in kit.
+  // Both the injection decision (`openGenUIOptions.designSystemCss`) and the
+  // guidance decision (`usingBuiltInKit`) derive from this so they can never
+  // disagree about what actually landed in the document.
+  const customKitCss = useMemo(() => {
+    const ds = openGenerativeUI?.designSystem;
+    return ds &&
+      typeof ds === "object" &&
+      typeof ds.css === "string" &&
+      ds.css.trim().length > 0
+      ? ds.css
+      : undefined;
+  }, [openGenerativeUI?.designSystem]);
+
   // Resolve the design-system CSS + library importmap once. Defaults inject the
   // built-in kit and pinned libraries; `designSystem: false` / `libraries: false`
   // restore legacy (no-injection) behavior.
   const openGenUIOptions = useMemo<OpenGenerativeUIResolvedOptions>(() => {
     const ds = openGenerativeUI?.designSystem;
     const libs = openGenerativeUI?.libraries;
-    // `null` behaves like `undefined` (built-in kit), consistent with the
-    // lenient `libraries` resolver below. Guard the object branch so a stray
-    // `null` doesn't crash render via `ds.css` (typeof null === "object").
-    const customKitCss = ds && typeof ds === "object" ? ds.css : undefined;
     return {
       designSystemCss:
-        ds === false
-          ? false
-          : customKitCss !== undefined
-            ? customKitCss
-            : OPEN_GEN_UI_DESIGN_SYSTEM_CSS,
+        ds === false ? false : (customKitCss ?? OPEN_GEN_UI_DESIGN_SYSTEM_CSS),
       importMap:
         libs === false ? false : { ...DEFAULT_OPEN_GEN_UI_LIBRARIES, ...libs },
     };
-  }, [openGenerativeUI?.designSystem, openGenerativeUI?.libraries]);
+  }, [
+    openGenerativeUI?.designSystem,
+    openGenerativeUI?.libraries,
+    customKitCss,
+  ]);
 
   // Distinguish the built-in kit from a custom one so downstream guidance
   // (tool description + design skill) advertises only what's actually injected.
-  // Built-in kit = `true` / `undefined` / `null` (not `false`, not a custom
-  // `{ css }` object). A custom kit may not define the built-in token/SVG names.
-  const usingBuiltInKit = useMemo(() => {
-    const ds = openGenerativeUI?.designSystem;
-    if (ds === false) return false;
-    if (ds && typeof ds === "object") return false;
-    return true;
-  }, [openGenerativeUI?.designSystem]);
+  // Built-in kit = anything except `false` (disabled) or a non-empty custom
+  // `{ css }`. A custom kit may not define the built-in token/SVG names.
+  const usingBuiltInKit =
+    openGenerativeUI?.designSystem !== false && customKitCss === undefined;
   const [runtimeLicenseStatus, setRuntimeLicenseStatus] = useState<
     string | undefined
   >(undefined);

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -53,7 +53,10 @@ import type { ReactCustomMessageRenderer } from "../types/react-custom-message-r
 import type { SandboxFunction } from "../types/sandbox-function";
 import { SandboxFunctionsContext } from "./SandboxFunctionsContext";
 import { OPEN_GEN_UI_DESIGN_SYSTEM_CSS } from "../lib/designSystemCss";
-import { DEFAULT_OPEN_GEN_UI_LIBRARIES } from "../lib/assembleDocument";
+import {
+  DEFAULT_OPEN_GEN_UI_LIBRARIES,
+  mergeLibraries,
+} from "../lib/assembleDocument";
 import { OpenGenerativeUIOptionsProvider } from "./OpenGenerativeUIOptionsContext";
 import type { OpenGenerativeUIResolvedOptions } from "./OpenGenerativeUIOptionsContext";
 import { schemaToJsonSchema } from "@copilotkit/shared";
@@ -390,7 +393,9 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
         ? false
         : (customKitCss ?? OPEN_GEN_UI_DESIGN_SYSTEM_CSS),
       importMap:
-        libs === false ? false : { ...DEFAULT_OPEN_GEN_UI_LIBRARIES, ...libs },
+        libs === false
+          ? false
+          : mergeLibraries(DEFAULT_OPEN_GEN_UI_LIBRARIES, libs ?? {}),
     }),
     // identity-stable: deps are value keys, not object identities. `libs` is
     // intentionally read from the latest closure (gated by `librariesKey`).

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -349,40 +349,60 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   // Both the injection decision (`openGenUIOptions.designSystemCss`) and the
   // guidance decision (`usingBuiltInKit`) derive from this so they can never
   // disagree about what actually landed in the document.
-  const customKitCss = useMemo(() => {
-    const ds = openGenerativeUI?.designSystem;
-    return ds &&
-      typeof ds === "object" &&
-      typeof ds.css === "string" &&
-      ds.css.trim().length > 0
-      ? ds.css
+  //
+  // Computed as a plain const (cheap string ops; output is the primitive
+  // `string | undefined`) rather than a memo keyed on the `designSystem` object
+  // identity — the documented inline idiom (`designSystem={{ css }}`) passes a
+  // fresh object every render, so an identity-keyed memo would recompute (and
+  // break referential stability of the resolved options) on every parent
+  // re-render even when the value is unchanged.
+  const designSystem = openGenerativeUI?.designSystem;
+  const customKitCss =
+    designSystem &&
+    typeof designSystem === "object" &&
+    typeof designSystem.css === "string" &&
+    designSystem.css.trim().length > 0
+      ? designSystem.css
       : undefined;
-  }, [openGenerativeUI?.designSystem]);
+  const designSystemOff = designSystem === false;
+
+  // Value-stable key for the library importmap. The inline idiom
+  // (`libraries={{ … }}`) passes a fresh object every render; JSON.stringify of
+  // a small literal yields a stable string whenever the VALUE is unchanged
+  // (key order from an inline literal is stable across renders), so the memo
+  // below recomputes only on genuine value changes — not object-identity churn.
+  const libs = openGenerativeUI?.libraries;
+  const librariesKey = libs === false ? "false" : JSON.stringify(libs ?? null);
 
   // Resolve the design-system CSS + library importmap once. Defaults inject the
   // built-in kit and pinned libraries; `designSystem: false` / `libraries: false`
   // restore legacy (no-injection) behavior.
-  const openGenUIOptions = useMemo<OpenGenerativeUIResolvedOptions>(() => {
-    const ds = openGenerativeUI?.designSystem;
-    const libs = openGenerativeUI?.libraries;
-    return {
-      designSystemCss:
-        ds === false ? false : (customKitCss ?? OPEN_GEN_UI_DESIGN_SYSTEM_CSS),
+  //
+  // Deps are VALUE keys (primitives), not object identities, so inline-but-
+  // unchanged configs keep a referentially stable result. This matters because
+  // the resolved options flow into the live sandbox iframe: a new identity on an
+  // unrelated parent re-render would destroy and rebuild the iframe (flicker +
+  // full JS-state wipe). The memo body may read the latest `libs` closure since
+  // `librariesKey` changes whenever the VALUE changes.
+  const openGenUIOptions = useMemo<OpenGenerativeUIResolvedOptions>(
+    () => ({
+      designSystemCss: designSystemOff
+        ? false
+        : (customKitCss ?? OPEN_GEN_UI_DESIGN_SYSTEM_CSS),
       importMap:
         libs === false ? false : { ...DEFAULT_OPEN_GEN_UI_LIBRARIES, ...libs },
-    };
-  }, [
-    openGenerativeUI?.designSystem,
-    openGenerativeUI?.libraries,
-    customKitCss,
-  ]);
+    }),
+    // identity-stable: deps are value keys, not object identities. `libs` is
+    // intentionally read from the latest closure (gated by `librariesKey`).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [designSystemOff, customKitCss, librariesKey],
+  );
 
   // Distinguish the built-in kit from a custom one so downstream guidance
   // (tool description + design skill) advertises only what's actually injected.
   // Built-in kit = anything except `false` (disabled) or a non-empty custom
   // `{ css }`. A custom kit may not define the built-in token/SVG names.
-  const usingBuiltInKit =
-    openGenerativeUI?.designSystem !== false && customKitCss === undefined;
+  const usingBuiltInKit = !designSystemOff && customKitCss === undefined;
   const [runtimeLicenseStatus, setRuntimeLicenseStatus] = useState<
     string | undefined
   >(undefined);

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -96,10 +96,13 @@ const DEFAULT_DESIGN_SKILL = `When generating UI with generateSandboxedUi, follo
 
 // Base generateSandboxedUi tool description. When the design system / library
 // importmap are injected into the document, append guidance so the model knows
-// the kit and pre-wired ES-module libraries exist. With both disabled this
+// the kit and pre-wired ES-module libraries exist.
+// `designSystem` is three-state: "builtin" advertises the built-in token/SVG
+// kit; "custom" appends a short neutral line (the custom CSS may not define the
+// built-in token names); "off" appends nothing. With "off" + no libraries this
 // returns the original (legacy) description text verbatim.
 function buildGenerateSandboxedUiDescription(opts: {
-  designSystem: boolean;
+  designSystem: "builtin" | "custom" | "off";
   libraries: string[];
 }): string {
   let description =
@@ -116,12 +119,15 @@ function buildGenerateSandboxedUiDescription(opts: {
     "4. jsFunctions (reusable helper functions)\n" +
     "5. jsExpressions (applied one-by-one — the user sees each expression take effect)";
 
-  if (opts.designSystem) {
+  if (opts.designSystem === "builtin") {
     description +=
       "\n\nA design system is PRE-INJECTED into the document. Prefer it over hand-rolled styles:\n" +
       "- CSS variables: var(--color-background-primary|secondary|tertiary), var(--color-text-primary|secondary|tertiary), var(--color-border-*), semantic info/danger/success/warning variants, var(--font-sans|serif|mono), var(--border-radius-md|lg|xl). Light/dark is automatic — do NOT hardcode colors for things the tokens cover.\n" +
       "- Form controls (button, input, textarea, select, range, checkbox, radio) are pre-styled; write semantic HTML and skip restyling basics.\n" +
       "- SVG helper classes: text.t/.ts/.th for typography; .box, .node, .arr, .leader; color ramps .c-purple/.c-teal/.c-coral/.c-pink/.c-gray/.c-blue/.c-green/.c-amber/.c-red for fills+strokes with dark-mode handled.";
+  } else if (opts.designSystem === "custom") {
+    description +=
+      "\n\nA custom design system stylesheet is PRE-INJECTED into the document. Prefer its existing styles over hand-rolled CSS.";
   }
 
   if (opts.libraries.length > 0) {
@@ -341,17 +347,32 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   const openGenUIOptions = useMemo<OpenGenerativeUIResolvedOptions>(() => {
     const ds = openGenerativeUI?.designSystem;
     const libs = openGenerativeUI?.libraries;
+    // `null` behaves like `undefined` (built-in kit), consistent with the
+    // lenient `libraries` resolver below. Guard the object branch so a stray
+    // `null` doesn't crash render via `ds.css` (typeof null === "object").
+    const customKitCss = ds && typeof ds === "object" ? ds.css : undefined;
     return {
       designSystemCss:
         ds === false
           ? false
-          : typeof ds === "object"
-            ? ds.css
+          : customKitCss !== undefined
+            ? customKitCss
             : OPEN_GEN_UI_DESIGN_SYSTEM_CSS,
       importMap:
         libs === false ? false : { ...DEFAULT_OPEN_GEN_UI_LIBRARIES, ...libs },
     };
   }, [openGenerativeUI?.designSystem, openGenerativeUI?.libraries]);
+
+  // Distinguish the built-in kit from a custom one so downstream guidance
+  // (tool description + design skill) advertises only what's actually injected.
+  // Built-in kit = `true` / `undefined` / `null` (not `false`, not a custom
+  // `{ css }` object). A custom kit may not define the built-in token/SVG names.
+  const usingBuiltInKit = useMemo(() => {
+    const ds = openGenerativeUI?.designSystem;
+    if (ds === false) return false;
+    if (ds && typeof ds === "object") return false;
+    return true;
+  }, [openGenerativeUI?.designSystem]);
   const [runtimeLicenseStatus, setRuntimeLicenseStatus] = useState<
     string | undefined
   >(undefined);
@@ -550,7 +571,12 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
       {
         name: "generateSandboxedUi",
         description: buildGenerateSandboxedUiDescription({
-          designSystem: openGenUIOptions.designSystemCss !== false,
+          designSystem:
+            openGenUIOptions.designSystemCss === false
+              ? "off"
+              : usingBuiltInKit
+                ? "builtin"
+                : "custom",
           libraries: openGenUIOptions.importMap
             ? Object.keys(openGenUIOptions.importMap).filter(
                 (k) => !k.endsWith("/"),
@@ -563,7 +589,7 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
         render: OpenGenerativeUIToolRenderer,
       },
     ];
-  }, [openGenUIActive, openGenUIOptions]);
+  }, [openGenUIActive, openGenUIOptions, usingBuiltInKit]);
 
   // Combine all tools for CopilotKitCore
   const allTools = useMemo(() => {
@@ -800,13 +826,13 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   }, [copilotkit, defaultThrottleMs]);
 
   // Register design skill as agent context for the generateSandboxedUi tool.
-  // When the design system is disabled, fall back to the legacy (hardcoded
-  // palette) skill so the model still gets concrete color/border guidance.
+  // The token-based skill (which references built-in var(--color-*) names) is
+  // only safe when the built-in kit is injected. For a custom kit or a disabled
+  // design system, fall back to the generic legacy skill so the model gets
+  // concrete color/border guidance instead of token names it may not have.
   const designSkill =
     openGenerativeUI?.designSkill ??
-    (openGenUIOptions.designSystemCss === false
-      ? LEGACY_DEFAULT_DESIGN_SKILL
-      : DEFAULT_DESIGN_SKILL);
+    (usingBuiltInKit ? DEFAULT_DESIGN_SKILL : LEGACY_DEFAULT_DESIGN_SKILL);
 
   useLayoutEffect(() => {
     if (!copilotkit || !openGenUIActive) return;

--- a/packages/react-core/src/v2/providers/OpenGenerativeUIOptionsContext.tsx
+++ b/packages/react-core/src/v2/providers/OpenGenerativeUIOptionsContext.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext } from "react";
+import { OPEN_GEN_UI_DESIGN_SYSTEM_CSS } from "../lib/designSystemCss";
+import { DEFAULT_OPEN_GEN_UI_LIBRARIES } from "../lib/assembleDocument";
+
+export interface OpenGenerativeUIResolvedOptions {
+  /** CSS kit to inject, or false when disabled. */
+  designSystemCss: string | false;
+  /** Importmap entries to inject, or false when disabled. */
+  importMap: Record<string, string> | false;
+}
+
+export const DEFAULT_OPEN_GEN_UI_OPTIONS: OpenGenerativeUIResolvedOptions = {
+  designSystemCss: OPEN_GEN_UI_DESIGN_SYSTEM_CSS,
+  importMap: DEFAULT_OPEN_GEN_UI_LIBRARIES,
+};
+
+const OpenGenerativeUIOptionsContext =
+  createContext<OpenGenerativeUIResolvedOptions>(DEFAULT_OPEN_GEN_UI_OPTIONS);
+
+export const OpenGenerativeUIOptionsProvider =
+  OpenGenerativeUIOptionsContext.Provider;
+
+export function useOpenGenerativeUIOptions(): OpenGenerativeUIResolvedOptions {
+  return useContext(OpenGenerativeUIOptionsContext);
+}

--- a/packages/react-core/src/v2/providers/__tests__/CopilotChatDefaultLabels.barrel.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotChatDefaultLabels.barrel.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { CopilotChatDefaultLabels as DefaultLabelsFromProvider } from "../CopilotChatConfigurationProvider";
+import { CopilotChatDefaultLabels as DefaultLabelsFromBarrel } from "../../index";
+
+// Regression guard: the public web barrel (`@copilotkit/react-core/v2`,
+// `src/v2/index.ts`) re-exports `./providers`, so the runtime value
+// `CopilotChatDefaultLabels` must flow through `providers/index.ts` for web
+// consumers to spread/override the default labels. The headless entrypoint
+// (`src/v2/headless.ts`) already exports it for react-native; this asserts the
+// web barrel exposes the same value.
+describe("CopilotChatDefaultLabels barrel re-export", () => {
+  it("is exposed from the v2 web barrel", () => {
+    expect(DefaultLabelsFromBarrel).toBeDefined();
+  });
+
+  it("is the same value re-exported by CopilotChatConfigurationProvider", () => {
+    expect(DefaultLabelsFromBarrel).toBe(DefaultLabelsFromProvider);
+  });
+});

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.openGenerativeUI.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.openGenerativeUI.test.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { vi } from "vitest";
 import { CopilotKitProvider, useCopilotKit } from "../CopilotKitProvider";
+import { CopilotKitCoreReact } from "../../lib/react-core";
 import { useOpenGenerativeUIOptions } from "../OpenGenerativeUIOptionsContext";
 import { OPEN_GEN_UI_DESIGN_SYSTEM_CSS } from "../../lib/designSystemCss";
 import { DEFAULT_OPEN_GEN_UI_LIBRARIES } from "../../lib/assembleDocument";
@@ -517,6 +518,34 @@ describe("CopilotKitProvider — openGenerativeUI option-resolution wiring", () 
       );
       // No pre-wired libraries block on the legacy path.
       expect(description).not.toContain("Do NOT add <script src>");
+    });
+  });
+
+  describe("(q) runtime-flag-only activation when /info resolved before subscription", () => {
+    it("openGenerativeUIEnabled getter already true at mount, no status callback → generateSandboxedUi is registered", () => {
+      // Simulate the runtime /info handshake resolving BEFORE the provider's
+      // connection-status effect subscribes: the core's synchronous getter is
+      // already `true` at construction, and no onRuntimeConnectionStatusChanged
+      // event ever fires to deliver the flag later. Without the immediate read
+      // in that effect, runtimeOpenGenUIEnabled stays false and the built-in
+      // tool is never registered (RED). With the immediate read it activates
+      // purely from the runtime flag (GREEN) — no `openGenerativeUI` prop given.
+      vi.spyOn(
+        CopilotKitCoreReact.prototype,
+        "openGenerativeUIEnabled",
+        "get",
+      ).mockReturnValue(true);
+
+      const { result } = renderHook(() => useCopilotKit(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider>{children}</CopilotKitProvider>
+        ),
+      });
+
+      const tool = result.current.copilotkit.getTool({
+        toolName: "generateSandboxedUi",
+      });
+      expect(tool).toBeDefined();
     });
   });
 });

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.openGenerativeUI.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.openGenerativeUI.test.tsx
@@ -432,4 +432,91 @@ describe("CopilotKitProvider — openGenerativeUI option-resolution wiring", () 
       expect(nextImportMap).not.toHaveProperty("foo");
     });
   });
+
+  describe("(o) reordered libraries keys keep the importmap referentially stable", () => {
+    it("rerender with the SAME entries in reversed key order → importMap is referentially equal", () => {
+      // A dynamically built `libraries` object (spread merges, Object.fromEntries)
+      // can emit the same entries with a different key order between renders.
+      // The memo key must be VALUE-stable (sorted), not insertion-order-stable —
+      // otherwise key churn rebuilds the live sandbox iframe. Drive the key order
+      // from a closure variable the wrapper reads on every render.
+      let reversed = false;
+      const { result, rerender } = renderHook(
+        () => useOpenGenerativeUIOptions(),
+        {
+          wrapper: ({ children }) => (
+            <CopilotKitProvider
+              openGenerativeUI={{
+                libraries: reversed
+                  ? { gsap: "https://y", three: "https://x" }
+                  : { three: "https://x", gsap: "https://y" },
+              }}
+            >
+              {children}
+            </CopilotKitProvider>
+          ),
+        },
+      );
+
+      const firstImportMap = result.current.importMap;
+
+      // Same entries, reversed key order. RED pre-fix: key-order-sensitive
+      // stringify churns the key → new importMap identity → iframe rebuild.
+      reversed = true;
+      rerender();
+
+      expect(result.current.importMap).toBe(firstImportMap);
+    });
+  });
+
+  describe("(p) the tool description does not contradict itself about CDN script tags", () => {
+    it("default options → no Chart.js/D3/Three.js CDN example, but keeps the 'Do NOT add <script src>' clause and the x-data-spreadsheet example", () => {
+      const { result } = renderHook(() => useCopilotKit(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider openGenerativeUI={{}}>
+            {children}
+          </CopilotKitProvider>
+        ),
+      });
+
+      const tool = result.current.copilotkit.getTool({
+        toolName: "generateSandboxedUi",
+      });
+      expect(tool).toBeDefined();
+      const description = tool!.description!;
+
+      // The pre-wired libraries block forbids CDN script tags for these
+      // libraries; the base CDN example must no longer name them.
+      expect(description).not.toContain("Chart.js, D3, Three.js");
+      // But the non-pre-wired example and the forbidding clause must remain.
+      expect(description).toContain("x-data-spreadsheet");
+      expect(description).toContain("Do NOT add <script src>");
+    });
+
+    it("legacy path ({ designSystem: false, libraries: false }) → original CDN example list is preserved byte-for-byte", () => {
+      const { result } = renderHook(() => useCopilotKit(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider
+            openGenerativeUI={{ designSystem: false, libraries: false }}
+          >
+            {children}
+          </CopilotKitProvider>
+        ),
+      });
+
+      const tool = result.current.copilotkit.getTool({
+        toolName: "generateSandboxedUi",
+      });
+      expect(tool).toBeDefined();
+      const description = tool!.description!;
+
+      // With the libraries block absent, the base text is untouched: the
+      // original example list (naming Chart.js/D3/Three.js) stays verbatim.
+      expect(description).toContain(
+        "You CAN use external libraries from CDNs by including <script> or <link> tags in the HTML <head> (e.g., Chart.js, D3, Three.js, x-data-spreadsheet, etc.).",
+      );
+      // No pre-wired libraries block on the legacy path.
+      expect(description).not.toContain("Do NOT add <script src>");
+    });
+  });
 });

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.openGenerativeUI.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.openGenerativeUI.test.tsx
@@ -138,4 +138,100 @@ describe("CopilotKitProvider — openGenerativeUI option-resolution wiring", () 
       expect(designContext!.value).toContain("var(--color-");
     });
   });
+
+  describe("(g) custom kit pairs with neutral guidance, not built-in tokens", () => {
+    it("custom kit → design-skill context has no built-in token names and tool description advertises the custom-kit line, not built-in tokens/SVG classes", () => {
+      const { result } = renderHook(() => useCopilotKit(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider
+            openGenerativeUI={{ designSystem: { css: ".my-kit{color:red}" } }}
+          >
+            {children}
+          </CopilotKitProvider>
+        ),
+      });
+
+      // Design-skill context must be the generic legacy skill (no built-in
+      // token names a custom kit may not define).
+      const designContext = findDesignSkillContext(
+        result.current.copilotkit.context,
+      );
+      expect(designContext).toBeDefined();
+      expect(designContext!.value).not.toContain("var(--color-");
+      expect(designContext!.value).not.toContain("var(--border-radius-");
+
+      // The generateSandboxedUi tool description must NOT advertise the
+      // built-in token/SVG block, but MUST include the neutral custom-kit line.
+      const tool = result.current.copilotkit.getTool({
+        toolName: "generateSandboxedUi",
+      });
+      expect(tool).toBeDefined();
+      const description = tool!.description!;
+      expect(description).not.toContain(".c-purple");
+      expect(description).not.toContain("--color-background-primary");
+      expect(description).toContain(
+        "A custom design system stylesheet is PRE-INJECTED",
+      );
+    });
+  });
+
+  describe("(h) built-in kit advertises the token block in the tool description", () => {
+    it("openGenerativeUI={{}} → tool description contains built-in tokens and SVG color ramp classes", () => {
+      const { result } = renderHook(() => useCopilotKit(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider openGenerativeUI={{}}>
+            {children}
+          </CopilotKitProvider>
+        ),
+      });
+
+      const tool = result.current.copilotkit.getTool({
+        toolName: "generateSandboxedUi",
+      });
+      expect(tool).toBeDefined();
+      const description = tool!.description!;
+      expect(description).toContain("--color-background-primary");
+      expect(description).toContain(".c-purple");
+    });
+  });
+
+  describe("(i) designSystem: null resolves to built-in kit without crashing", () => {
+    it("null designSystem → no crash, options resolve to the built-in kit, token-based guidance applied", () => {
+      const { result } = renderHook(
+        () => ({
+          options: useOpenGenerativeUIOptions(),
+          ck: useCopilotKit(),
+        }),
+        {
+          wrapper: ({ children }) => (
+            <CopilotKitProvider
+              openGenerativeUI={{ designSystem: null as any }}
+            >
+              {children}
+            </CopilotKitProvider>
+          ),
+        },
+      );
+
+      // Resolves to the built-in kit, exactly like `undefined`.
+      expect(result.current.options.designSystemCss).toBe(
+        OPEN_GEN_UI_DESIGN_SYSTEM_CSS,
+      );
+
+      // And is treated as the built-in kit downstream: token-based design skill
+      // and the built-in token/SVG block in the tool description.
+      const designContext = findDesignSkillContext(
+        result.current.ck.copilotkit.context,
+      );
+      expect(designContext).toBeDefined();
+      expect(designContext!.value).toContain("var(--color-");
+
+      const tool = result.current.ck.copilotkit.getTool({
+        toolName: "generateSandboxedUi",
+      });
+      expect(tool).toBeDefined();
+      expect(tool!.description!).toContain("--color-background-primary");
+      expect(tool!.description!).toContain(".c-purple");
+    });
+  });
 });

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.openGenerativeUI.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.openGenerativeUI.test.tsx
@@ -96,6 +96,30 @@ describe("CopilotKitProvider — openGenerativeUI option-resolution wiring", () 
       expect(importMap).toHaveProperty("foo", "https://x");
       expect(importMap).toHaveProperty("three");
     });
+
+    it("(e2) overriding the bare 'three' specifier re-pins the 'three/' subpath form to the SAME version", () => {
+      // Finding: the documented idiom `libraries: { three: <url> }` upgrades
+      // only the bare key under a flat spread, leaving `three/` on the stale
+      // default version — so a generated scene loads two copies of three.js.
+      // The resolved importmap must re-pin the subpath sibling to the override.
+      const { result } = renderHook(() => useOpenGenerativeUIOptions(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider
+            openGenerativeUI={{
+              libraries: { three: "https://esm.sh/three@0.999.0" },
+            }}
+          >
+            {children}
+          </CopilotKitProvider>
+        ),
+      });
+
+      expect(result.current.importMap).not.toBe(false);
+      const importMap = result.current.importMap as Record<string, string>;
+      expect(importMap["three"]).toBe("https://esm.sh/three@0.999.0");
+      // RED pre-fix: this equals the default 0.180.0 URL (stale sibling).
+      expect(importMap["three/"]).toBe("https://esm.sh/three@0.999.0/");
+    });
   });
 
   describe("(f) legacy design-skill guard — agent context registration", () => {

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.openGenerativeUI.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.openGenerativeUI.test.tsx
@@ -234,4 +234,111 @@ describe("CopilotKitProvider — openGenerativeUI option-resolution wiring", () 
       expect(tool!.description!).toContain(".c-purple");
     });
   });
+
+  describe("(j) degenerate empty object designSystem behaves like the built-in kit", () => {
+    it("designSystem: {} → designSystemCss is the built-in kit, description advertises built-in tokens, design skill is token-based", () => {
+      const { result } = renderHook(
+        () => ({
+          options: useOpenGenerativeUIOptions(),
+          ck: useCopilotKit(),
+        }),
+        {
+          wrapper: ({ children }) => (
+            <CopilotKitProvider openGenerativeUI={{ designSystem: {} as any }}>
+              {children}
+            </CopilotKitProvider>
+          ),
+        },
+      );
+
+      // A `{}` (no `css` key) carries no custom stylesheet, so the built-in kit
+      // is what actually lands in the document.
+      expect(result.current.options.designSystemCss).toBe(
+        OPEN_GEN_UI_DESIGN_SYSTEM_CSS,
+      );
+
+      // Guidance must match the injected kit: built-in token block in the tool
+      // description, token-based design skill.
+      const tool = result.current.ck.copilotkit.getTool({
+        toolName: "generateSandboxedUi",
+      });
+      expect(tool).toBeDefined();
+      expect(tool!.description!).toContain("--color-background-primary");
+
+      const designContext = findDesignSkillContext(
+        result.current.ck.copilotkit.context,
+      );
+      expect(designContext).toBeDefined();
+      expect(designContext!.value).toContain("var(--color-");
+    });
+  });
+
+  describe("(k) whitespace/empty custom css behaves like the built-in kit", () => {
+    it('designSystem: { css: "" } → designSystemCss is the built-in kit, description advertises built-in tokens, design skill is token-based', () => {
+      const { result } = renderHook(
+        () => ({
+          options: useOpenGenerativeUIOptions(),
+          ck: useCopilotKit(),
+        }),
+        {
+          wrapper: ({ children }) => (
+            <CopilotKitProvider
+              openGenerativeUI={{ designSystem: { css: "" } }}
+            >
+              {children}
+            </CopilotKitProvider>
+          ),
+        },
+      );
+
+      // An empty custom stylesheet injects nothing, so the built-in kit is the
+      // only thing that can land — guidance must reflect that, not a phantom
+      // custom stylesheet.
+      expect(result.current.options.designSystemCss).toBe(
+        OPEN_GEN_UI_DESIGN_SYSTEM_CSS,
+      );
+
+      const tool = result.current.ck.copilotkit.getTool({
+        toolName: "generateSandboxedUi",
+      });
+      expect(tool).toBeDefined();
+      expect(tool!.description!).toContain("--color-background-primary");
+
+      const designContext = findDesignSkillContext(
+        result.current.ck.copilotkit.context,
+      );
+      expect(designContext).toBeDefined();
+      expect(designContext!.value).toContain("var(--color-");
+    });
+  });
+
+  describe("(l) non-empty custom css is preserved and advertised as custom", () => {
+    it('designSystem: { css: "X{}" } → designSystemCss === "X{}" and the description advertises the custom-kit line', () => {
+      const { result } = renderHook(
+        () => ({
+          options: useOpenGenerativeUIOptions(),
+          ck: useCopilotKit(),
+        }),
+        {
+          wrapper: ({ children }) => (
+            <CopilotKitProvider
+              openGenerativeUI={{ designSystem: { css: "X{}" } }}
+            >
+              {children}
+            </CopilotKitProvider>
+          ),
+        },
+      );
+
+      expect(result.current.options.designSystemCss).toBe("X{}");
+
+      const tool = result.current.ck.copilotkit.getTool({
+        toolName: "generateSandboxedUi",
+      });
+      expect(tool).toBeDefined();
+      expect(tool!.description!).toContain(
+        "A custom design system stylesheet is PRE-INJECTED",
+      );
+    });
+  });
 });

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.openGenerativeUI.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.openGenerativeUI.test.tsx
@@ -1,0 +1,141 @@
+import { renderHook } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { vi } from "vitest";
+import { CopilotKitProvider, useCopilotKit } from "../CopilotKitProvider";
+import { useOpenGenerativeUIOptions } from "../OpenGenerativeUIOptionsContext";
+import { OPEN_GEN_UI_DESIGN_SYSTEM_CSS } from "../../lib/designSystemCss";
+import { DEFAULT_OPEN_GEN_UI_LIBRARIES } from "../../lib/assembleDocument";
+
+describe("CopilotKitProvider — openGenerativeUI option-resolution wiring", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** Helper: find the design-skill context entry from the context record */
+  function findDesignSkillContext(
+    ctx: Record<string, { description: string; value: string }>,
+  ) {
+    return Object.values(ctx).find((c) =>
+      c.description.includes("Design guidelines"),
+    );
+  }
+
+  describe("OpenGenerativeUIOptionsContext resolution", () => {
+    it("(a) openGenerativeUI={{}} → designSystemCss equals built-in kit, importMap deep-equals defaults", () => {
+      const { result } = renderHook(() => useOpenGenerativeUIOptions(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider openGenerativeUI={{}}>
+            {children}
+          </CopilotKitProvider>
+        ),
+      });
+
+      expect(result.current.designSystemCss).toBe(
+        OPEN_GEN_UI_DESIGN_SYSTEM_CSS,
+      );
+      expect(result.current.importMap).toEqual(DEFAULT_OPEN_GEN_UI_LIBRARIES);
+    });
+
+    it("(b) openGenerativeUI={{ designSystem: false }} → designSystemCss === false", () => {
+      const { result } = renderHook(() => useOpenGenerativeUIOptions(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider openGenerativeUI={{ designSystem: false }}>
+            {children}
+          </CopilotKitProvider>
+        ),
+      });
+
+      expect(result.current.designSystemCss).toBe(false);
+    });
+
+    it("(c) openGenerativeUI={{ designSystem: { css: 'X{}' } }} → designSystemCss === 'X{}'", () => {
+      const { result } = renderHook(() => useOpenGenerativeUIOptions(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider
+            openGenerativeUI={{ designSystem: { css: "X{}" } }}
+          >
+            {children}
+          </CopilotKitProvider>
+        ),
+      });
+
+      expect(result.current.designSystemCss).toBe("X{}");
+    });
+
+    it("(d) openGenerativeUI={{ libraries: false }} → importMap === false", () => {
+      const { result } = renderHook(() => useOpenGenerativeUIOptions(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider openGenerativeUI={{ libraries: false }}>
+            {children}
+          </CopilotKitProvider>
+        ),
+      });
+
+      expect(result.current.importMap).toBe(false);
+    });
+
+    it("(e) openGenerativeUI={{ libraries: { foo: 'https://x' } }} → importMap contains 'foo' AND default key 'three' (merge, not replace)", () => {
+      const { result } = renderHook(() => useOpenGenerativeUIOptions(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider
+            openGenerativeUI={{ libraries: { foo: "https://x" } }}
+          >
+            {children}
+          </CopilotKitProvider>
+        ),
+      });
+
+      expect(result.current.importMap).not.toBe(false);
+      const importMap = result.current.importMap as Record<string, string>;
+      expect(importMap).toHaveProperty("foo", "https://x");
+      expect(importMap).toHaveProperty("three");
+    });
+  });
+
+  describe("(f) legacy design-skill guard — agent context registration", () => {
+    it("with designSystem: false → design-skill context contains hardcoded palette text", () => {
+      const { result } = renderHook(() => useCopilotKit(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider openGenerativeUI={{ designSystem: false }}>
+            {children}
+          </CopilotKitProvider>
+        ),
+      });
+
+      const designContext = findDesignSkillContext(
+        result.current.copilotkit.context,
+      );
+      expect(designContext).toBeDefined();
+
+      // The legacy skill contains hardcoded hex palette and/or "Neutral base palette" text
+      const value = designContext!.value;
+      const hasHardcodedColor = value.includes("#e5e7eb");
+      const hasNeutralText = value.includes("Neutral base palette");
+      expect(hasHardcodedColor || hasNeutralText).toBe(true);
+    });
+
+    it("with openGenerativeUI={{}} → design-skill context contains token-based var(--color-) references", () => {
+      const { result } = renderHook(() => useCopilotKit(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider openGenerativeUI={{}}>
+            {children}
+          </CopilotKitProvider>
+        ),
+      });
+
+      const designContext = findDesignSkillContext(
+        result.current.copilotkit.context,
+      );
+      expect(designContext).toBeDefined();
+
+      // The token-based skill uses CSS custom properties instead of hardcoded colors
+      expect(designContext!.value).toContain("var(--color-");
+    });
+  });
+});

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.openGenerativeUI.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.openGenerativeUI.test.tsx
@@ -341,4 +341,71 @@ describe("CopilotKitProvider — openGenerativeUI option-resolution wiring", () 
       );
     });
   });
+
+  describe("(m) resolved options stay referentially stable across re-renders with inline props", () => {
+    it("a fresh inline openGenerativeUI object each render → useOpenGenerativeUIOptions() result (and importMap) is referentially equal across renders", () => {
+      // The documented inline idiom creates new `openGenerativeUI`,
+      // `libraries`, and `designSystem` objects on every render. The resolved
+      // options must stay referentially stable so downstream consumers (the
+      // live sandbox iframe) are not destroyed and rebuilt on unrelated parent
+      // re-renders.
+      const { result, rerender } = renderHook(
+        () => useOpenGenerativeUIOptions(),
+        {
+          wrapper: ({ children }) => (
+            <CopilotKitProvider
+              openGenerativeUI={{
+                libraries: { foo: "https://x" },
+                designSystem: { css: "X{}" },
+              }}
+            >
+              {children}
+            </CopilotKitProvider>
+          ),
+        },
+      );
+
+      const first = result.current;
+      const firstImportMap = result.current.importMap;
+
+      // Re-render the wrapper, which builds a brand-new inline object literal.
+      rerender();
+
+      expect(result.current).toBe(first);
+      expect(result.current.importMap).toBe(firstImportMap);
+    });
+  });
+
+  describe("(n) genuine value changes are still detected", () => {
+    it("rerender with a different inline libraries value → importMap identity changes and contains the new entry", () => {
+      // Drive the inline value from a closure variable the wrapper reads on
+      // every render, so we can change the VALUE (foo → bar) between renders
+      // while still passing a fresh inline object literal each time.
+      let libKey = "foo";
+      const { result, rerender } = renderHook(
+        () => useOpenGenerativeUIOptions(),
+        {
+          wrapper: ({ children }) => (
+            <CopilotKitProvider
+              openGenerativeUI={{ libraries: { [libKey]: "https://x" } }}
+            >
+              {children}
+            </CopilotKitProvider>
+          ),
+        },
+      );
+
+      const firstImportMap = result.current.importMap as Record<string, string>;
+      expect(firstImportMap).toHaveProperty("foo", "https://x");
+
+      // Change the actual value (foo → bar); identity must change.
+      libKey = "bar";
+      rerender();
+
+      expect(result.current.importMap).not.toBe(firstImportMap);
+      const nextImportMap = result.current.importMap as Record<string, string>;
+      expect(nextImportMap).toHaveProperty("bar", "https://x");
+      expect(nextImportMap).not.toHaveProperty("foo");
+    });
+  });
 });

--- a/packages/react-core/src/v2/providers/__tests__/OpenGenerativeUIOptionsContext.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/OpenGenerativeUIOptionsContext.test.tsx
@@ -1,0 +1,31 @@
+import { renderHook } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_OPEN_GEN_UI_OPTIONS,
+  OpenGenerativeUIOptionsProvider,
+  useOpenGenerativeUIOptions,
+} from "../OpenGenerativeUIOptionsContext";
+
+describe("OpenGenerativeUIOptionsContext", () => {
+  it("returns DEFAULT_OPEN_GEN_UI_OPTIONS when no provider is present", () => {
+    const { result } = renderHook(() => useOpenGenerativeUIOptions());
+
+    expect(result.current).toEqual(DEFAULT_OPEN_GEN_UI_OPTIONS);
+  });
+
+  it("returns the provided value when wrapped in OpenGenerativeUIOptionsProvider", () => {
+    const { result } = renderHook(() => useOpenGenerativeUIOptions(), {
+      wrapper: ({ children }) => (
+        <OpenGenerativeUIOptionsProvider
+          value={{ designSystemCss: false, importMap: false }}
+        >
+          {children}
+        </OpenGenerativeUIOptionsProvider>
+      ),
+    });
+
+    expect(result.current.designSystemCss).toBe(false);
+    expect(result.current.importMap).toBe(false);
+  });
+});

--- a/packages/react-core/src/v2/providers/index.ts
+++ b/packages/react-core/src/v2/providers/index.ts
@@ -1,6 +1,7 @@
 export {
   CopilotChatConfigurationProvider,
   useCopilotChatConfiguration,
+  CopilotChatDefaultLabels,
   type CopilotChatLabels,
   type CopilotChatConfigurationValue,
   type CopilotChatConfigurationProviderProps,

--- a/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
+++ b/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
@@ -616,9 +616,16 @@ export const OpenGenerativeUIToolRenderer = defineComponent({
   setup(props) {
     const visibleMessageIndex = ref(0);
 
+    // Watch status alongside placeholderMessages so a transition to Complete
+    // re-runs this watcher: the onCleanup below clears the in-flight interval
+    // and the Complete guard prevents re-arming. Without status in the source,
+    // a stable placeholderMessages reference would leave the 5s interval firing
+    // until unmount even after the call completes (the render returns null, so
+    // it would be an invisible lingering timer). Mirrors react-core, which keys
+    // its placeholder effect on props.status.
     watch(
-      () => props.args.placeholderMessages,
-      (messages, _, onCleanup) => {
+      () => [props.args.placeholderMessages, props.status] as const,
+      ([messages], _, onCleanup) => {
         if (!messages?.length || props.status === ToolCallStatus.Complete)
           return;
         visibleMessageIndex.value = Math.max(messages.length - 1, 0);

--- a/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
+++ b/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
@@ -66,6 +66,11 @@ function shouldFlushImmediately(
 // react-core's assembleDocument head-open matcher.
 const HEAD_OPEN = /<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i;
 
+// Word-bounded `<body` open token (`<body>` or `<body …>`), used as the implicit
+// head close when no `</head>` follows the head-open. `[\s>]` forbids `<bodyfoo>`
+// from being mistaken for `<body>`. Matched on the masked copy (see below).
+const BODY_OPEN = /<body[\s>]/i;
+
 /**
  * Locates the real head-opening tag on a length-preserving MASKED copy of the
  * raw html — the content of complete `<style>`/`<script>` blocks and `<!-- … -->`
@@ -135,22 +140,29 @@ function ensureHead(html: string): string {
  * and comments are preserved byte-for-byte.
  *
  * Always called after `ensureHead`, so a real head-opening tag exists by
- * construction. Two edge shapes are guarded on the masked copy:
- *  - A stray `</head>` BEFORE the real head: the close search is anchored
- *    at/after the matched head-open so the css lands inside the REAL head (e.g.
- *    `foo</head><head>…</head>`), not at the earlier stray close (which would
- *    put it outside and before the real head — cascade inversion).
- *  - A head-open with NO matching close: the css is inserted immediately AFTER
- *    the (normalized) head-open rather than prepending a fresh `<head>`, which
- *    would otherwise create two head elements with the agent css before the
- *    author's head content.
+ * construction. The anchor is chosen on the masked copy:
+ *  - `</head>` AT/AFTER the matched head-open wins — the css lands inside the
+ *    REAL head (before that close), not at a stray `</head>` PRECEDING it (e.g.
+ *    `foo</head><head>…</head>`), which would put the css outside and before the
+ *    real head (cascade inversion). The close search is anchored at/after the
+ *    head-open to pair it with the SAME head.
+ *  - else the first word-bounded `<body[\s>]` token after the head-open is the
+ *    IMPLICIT head close (the browser closes an unclosed head at `<body>`): the
+ *    css is inserted JUST BEFORE it, so it sits after the author's in-head styles
+ *    (cascade parity) rather than before them.
+ *  - else (no close, no body) insert the css immediately AFTER the (normalized)
+ *    head-open rather than prepending a fresh `<head>`, which would produce two
+ *    head elements with the agent css before the author's head content.
  *
  * Mirrors the masked-matching + real-head/stray-`</head>` anchoring of
  * react-core's assembleDocument NON-legacy path (Vue injects no kit/importmap, so
- * only the agent css is anchored; the no-`</head>` fallback inserts right after
- * the head-open, as react-core's non-legacy path does). react-core's LEGACY path
- * deliberately diverges — raw, unmasked `indexOf("</head>")`, a pinned
- * byte-identity quirk.
+ * only the agent css is anchored). Two intentional differences: the IMPLICIT
+ * `<body>` close fallback matches THIS package's own preview region logic
+ * (`analyzeRegions` in processPartialHtml — an unclosed head closes at `<body>`),
+ * keeping the preview and final document in parity, whereas react-core's
+ * non-legacy no-`</head>` fallback inserts right after the head-open; and
+ * react-core's LEGACY path diverges entirely (raw, unmasked `indexOf("</head>")`,
+ * a pinned byte-identity quirk).
  */
 function injectCssIntoHtml(html: string, css: string): string {
   const masked = maskBlockContent(html);
@@ -170,8 +182,18 @@ function injectCssIntoHtml(html: string, css: string): string {
       html.slice(headCloseIdx)
     );
   }
-  // No `</head>` at/after the head-open. ensureHead guaranteed a real head-open,
-  // so insert the agent css immediately AFTER that (normalized) head-open rather
+  // No `</head>` at/after the head-open. An unclosed head closes IMPLICITLY at
+  // the first `<body>` after it (browser behavior): insert the css JUST BEFORE
+  // that `<body>` so it follows the author's in-head styles (cascade parity).
+  const bodyRel = masked.slice(searchFrom).match(BODY_OPEN);
+  if (bodyRel && bodyRel.index !== undefined) {
+    const bodyIdx = searchFrom + bodyRel.index;
+    return (
+      html.slice(0, bodyIdx) + `<style>${css}</style>` + html.slice(bodyIdx)
+    );
+  }
+  // No `</head>` and no `<body>`. ensureHead guaranteed a real head-open, so
+  // insert the agent css immediately AFTER that (normalized) head-open rather
   // than prepending a fresh `<head>` — which would produce two head elements
   // with the agent css before the author's head content (cascade inversion).
   if (head) {

--- a/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
+++ b/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
@@ -19,6 +19,13 @@ export const OpenGenerativeUIContentSchema = z.object({
   html: z.array(z.string()).optional(),
   htmlComplete: z.boolean().optional(),
   jsFunctions: z.string().optional(),
+  // `jsFunctionsComplete` / `jsExpressionsComplete` are streamed by the Open
+  // Generative UI middleware (open-generative-ui-middleware.ts emits them when
+  // the jsFunctions string / jsExpressions array finish parsing). They are not
+  // needed for execution — jsFunctions/jsExpressions run incrementally as they
+  // arrive — but they ARE the per-segment terminal markers the completion
+  // fallback reads (see isGenerationComplete) to recognize a fully-streamed
+  // payload whose `generating: false` delta never arrived.
   jsFunctionsComplete: z.boolean().optional(),
   jsExpressions: z.array(z.string()).optional(),
   jsExpressionsComplete: z.boolean().optional(),
@@ -55,6 +62,48 @@ function shouldFlushImmediately(
     return true;
   if (next.html?.length && (!previous || !previous.html?.length)) return true;
   return false;
+}
+
+/**
+ * Whether generation has finished. The Open Generative UI middleware emits the
+ * `generating: false` delta ONLY from its TOOL_CALL_END handler
+ * (open-generative-ui-middleware.ts). On a terminal path where the upstream
+ * agent never emits TOOL_CALL_END for the genui tool call — an abort/stop, an
+ * abrupt stream end, or a transport error after the args fully streamed — the
+ * runner's `finalizeRunEvents` synthesizes a TOOL_CALL_END at the runner level,
+ * AFTER the middleware already processed the stream, so it never flows back
+ * through the middleware and `generating: false` is never emitted. The
+ * fully-streamed payload then arrives with `generating` absent.
+ *
+ * Without a fallback, a renderer keying purely on `generating === false` leaves
+ * such a finished, interactive artifact permanently covered by the
+ * pointer-blocking overlay. The fallback treats a payload as terminal when
+ * every streamed segment that is PRESENT carries its `*Complete` flag
+ * (`htmlComplete`, plus `cssComplete`/`jsFunctionsComplete`/
+ * `jsExpressionsComplete` for whichever of css/jsFunctions/jsExpressions are
+ * present). Those flags are emitted by the producer as each segment finishes
+ * parsing, so this fires only once the WHOLE payload is terminal — never
+ * mid-stream (e.g. html done but jsExpressions still arriving leaves
+ * `jsExpressionsComplete` absent, so this stays false and the overlay stays up,
+ * matching the pre-fallback behavior on every normal path). `htmlComplete` is
+ * required because an interactive artifact only exists once html is complete.
+ * Mirrors the react-core renderer's identical helper.
+ */
+export function isGenerationComplete(
+  content: OpenGenerativeUIContent,
+): boolean {
+  if (content.generating === false) return true;
+  if (!content.htmlComplete) return false;
+  if (content.css !== undefined && !content.cssComplete) return false;
+  if (content.jsFunctions !== undefined && !content.jsFunctionsComplete)
+    return false;
+  if (
+    content.jsExpressions !== undefined &&
+    content.jsExpressions.length > 0 &&
+    !content.jsExpressionsComplete
+  )
+    return false;
+  return true;
 }
 
 // Match only a real head-opening tag: `<head>`, or `<head` followed by
@@ -489,6 +538,16 @@ export const OpenGenerativeUIRenderer = defineComponent({
             const functionsCode = throttledContent.value.jsFunctions;
             if (functionsCode && !jsFunctionsInjected.value) {
               jsFunctionsInjected.value = true;
+              // unshift (NOT push): during the rebuild window the jsExpressions
+              // watcher can already have pushed an expression onto pendingQueue
+              // before this ready callback runs. jsFunctions must be DEFINED
+              // before any expression executes (expressions call them), so they
+              // go to the FRONT, ahead of that queued expression. A push would
+              // append them after it and the expression would run against
+              // undefined functions. Matches react-core's effective order
+              // (Effect 1 clears the queue then requeues functions first, then
+              // expressions). Pinned by the "runs jsFunctions before a
+              // jsExpression queued during the rebuild window" test.
               pendingQueue.value.unshift(functionsCode);
             }
             const expressions = throttledContent.value.jsExpressions;
@@ -552,7 +611,7 @@ export const OpenGenerativeUIRenderer = defineComponent({
     );
 
     const isGenerating = computed(
-      () => throttledContent.value.generating !== false,
+      () => !isGenerationComplete(throttledContent.value),
     );
     watch(
       [hasPreview, fullHtml],

--- a/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
+++ b/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
@@ -1,12 +1,5 @@
-import {
-  computed,
-  defineComponent,
-  h,
-  onBeforeUnmount,
-  ref,
-  watch,
-  type PropType,
-} from "vue";
+import { computed, defineComponent, h, onBeforeUnmount, ref, watch } from "vue";
+import type { PropType } from "vue";
 import { z } from "zod";
 import { ToolCallStatus } from "@copilotkit/core";
 import {
@@ -275,9 +268,16 @@ export const OpenGenerativeUIRenderer = defineComponent({
       [previewBody, previewStyles, css, previewReady],
       ([body, styles, cssText, ready]) => {
         if (!previewSandboxRef.value || !ready) return;
+        // Cascade parity: extracted head styles first, agent css LAST — mirroring
+        // the final document, where injectCssIntoHtml inserts the agent css
+        // immediately before </head> (after the existing head content). Ordering
+        // the agent css first would flip its cascade position at the preview→final
+        // swap, visibly restyling artifacts that collide with it at equal
+        // specificity. Vue has no kit/design-system injection, so the only two
+        // head payloads are: extracted styles → agent css.
         const headParts: string[] = [];
-        if (cssText) headParts.push(`<style>${cssText}</style>`);
         if (styles) headParts.push(styles);
+        if (cssText) headParts.push(`<style>${cssText}</style>`);
         if (headParts.length) {
           void previewSandboxRef.value.run(
             `document.head.innerHTML = ${JSON.stringify(headParts.join(""))}`,

--- a/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
+++ b/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
@@ -56,13 +56,56 @@ function shouldFlushImmediately(
   return false;
 }
 
+// Match only a real head-opening tag: `<head>`, or `<head` followed by
+// whitespace + attributes. This deliberately excludes `<header …>` (which a
+// looser `/<head[^>]*>/i` would capture). The attribute span is quote-aware:
+// unquoted runs forbid `<`/`>` (so the tag can never greedily swallow a
+// following `<tag>`), while quoted runs (`"…"` / `'…'`) may contain `<`/`>` so
+// a realistic `<head data-config='{"a":">"}'>` is matched whole. Mirrors
+// react-core's assembleDocument head-open matcher.
+const HEAD_OPEN = /<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i;
+
+/**
+ * Ensures the final frameContent contains the EXACT literal lowercase token
+ * `<head>`. @jetbrains/websandbox hard-requires it: validateOptions throws
+ * `'Websandbox: iFrame content must have "<head>" tag.'` when
+ * `!frameContent.includes('<head>')`, and it injects its bootstrap via
+ * `frameContent.replace('<head>', …)` — both case-sensitive on the 6-char
+ * token. An agent-emitted `<HEAD>` or `<head lang="en">` would otherwise fail
+ * mounting (stuck spinner) and never receive the bootstrap.
+ *
+ * If a real head-opening tag exists, its token is NORMALIZED to `<head>` (head
+ * attributes have negligible runtime semantics inside the sandbox iframe and
+ * cannot be preserved given websandbox's exact-token demand). If none exists,
+ * `<head></head>` is prepended. Mirrors react-core's normalization.
+ */
 function ensureHead(html: string): string {
-  if (/<head[\s>]/i.test(html)) return html;
+  const match = html.match(HEAD_OPEN);
+  if (match && match.index !== undefined) {
+    if (match[0] === "<head>") return html;
+    return (
+      html.slice(0, match.index) +
+      "<head>" +
+      html.slice(match.index + match[0].length)
+    );
+  }
   return `<head></head>${html}`;
 }
 
+/**
+ * Injects the agent css immediately before `</head>` — i.e. AFTER the author's
+ * existing head content — so the documented cascade holds (author head styles
+ * first, agent css last; matching react-core). The close lookup is
+ * case-insensitive so it pairs with `ensureHead`'s case-insensitive open match:
+ * a case-sensitive `indexOf("</head>")` would miss an uppercase `</HEAD>` and
+ * PREPEND a second `<head>`, producing two head elements and flipping the
+ * cascade so the agent css wins over the author's head styles.
+ *
+ * Always called after `ensureHead`, so a real `<head>` exists by construction;
+ * the no-close fallback synthesizes a websandbox-safe literal `<head>`.
+ */
 function injectCssIntoHtml(html: string, css: string): string {
-  const headCloseIdx = html.indexOf("</head>");
+  const headCloseIdx = html.search(/<\/head>/i);
   if (headCloseIdx !== -1) {
     return (
       html.slice(0, headCloseIdx) +

--- a/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
+++ b/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
@@ -5,6 +5,7 @@ import { ToolCallStatus } from "@copilotkit/core";
 import {
   processPartialHtml,
   extractCompleteStyles,
+  maskBlockContent,
 } from "../lib/processPartialHtml";
 import { useSandboxFunctions } from "../providers/SandboxFunctionsContext";
 
@@ -66,6 +67,23 @@ function shouldFlushImmediately(
 const HEAD_OPEN = /<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i;
 
 /**
+ * Locates the real head-opening tag on a length-preserving MASKED copy of the
+ * raw html — the content of complete `<style>`/`<script>` blocks and `<!-- … -->`
+ * comments is blanked (and quoted attribute runs inside style/script open tags),
+ * so a `<head>` token inside a comment or inside style/script content can never
+ * be mistaken for the real head-open. Indices map 1:1 to the original, so callers
+ * splice on the ORIGINAL string at the returned index. Mirrors react-core's
+ * assembleDocument, which masks inert spans before its head-open match.
+ */
+function matchHeadOpen(
+  masked: string,
+): { index: number; token: string } | null {
+  const match = masked.match(HEAD_OPEN);
+  if (!match || match.index === undefined) return null;
+  return { index: match.index, token: match[0] };
+}
+
+/**
  * Ensures the final frameContent contains the EXACT literal lowercase token
  * `<head>`. @jetbrains/websandbox hard-requires it: validateOptions throws
  * `'Websandbox: iFrame content must have "<head>" tag.'` when
@@ -77,55 +95,75 @@ const HEAD_OPEN = /<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i;
  * If a real head-opening tag exists, its token is NORMALIZED to `<head>` (head
  * attributes have negligible runtime semantics inside the sandbox iframe and
  * cannot be preserved given websandbox's exact-token demand). If none exists,
- * `<head></head>` is prepended. Mirrors react-core's normalization.
+ * `<head></head>` is prepended.
+ *
+ * The head-open is matched on a MASKED copy (complete comments + style/script
+ * content blanked) and the token is replaced on the ORIGINAL at the masked
+ * index, so a `<head>` token inside a comment is never matched (it would
+ * short-circuit on the comment's literal `<head>`, leaving the real attributed
+ * head un-normalized — websandbox would then `.replace('<head>', …)` its
+ * bootstrap INTO THE COMMENT and never initialize) and a comment containing a
+ * head token is preserved byte-for-byte.
+ *
+ * Mirrors the masked-matching + literal-`<head>` normalization of react-core's
+ * assembleDocument NON-legacy path (which masks inert spans before its head-open
+ * match). Two intentional differences: Vue injects no kit/importmap, so the head
+ * is only normalized, never prefixed; and react-core's LEGACY path deliberately
+ * diverges — it matches on the raw html (a `<head>` inside a comment is a pinned
+ * byte-identity quirk there).
  */
 function ensureHead(html: string): string {
-  const match = html.match(HEAD_OPEN);
-  if (match && match.index !== undefined) {
-    if (match[0] === "<head>") return html;
+  const head = matchHeadOpen(maskBlockContent(html));
+  if (head) {
+    if (head.token === "<head>") return html;
     return (
-      html.slice(0, match.index) +
+      html.slice(0, head.index) +
       "<head>" +
-      html.slice(match.index + match[0].length)
+      html.slice(head.index + head.token.length)
     );
   }
   return `<head></head>${html}`;
 }
 
 /**
- * Injects the agent css immediately before `</head>` — i.e. AFTER the author's
- * existing head content — so the documented cascade holds (author head styles
- * first, agent css last; matching react-core). The close lookup is
- * case-insensitive so it pairs with `ensureHead`'s case-insensitive open match:
- * a case-sensitive `indexOf("</head>")` would miss an uppercase `</HEAD>` and
- * flip the cascade so the agent css wins over the author's head styles.
+ * Injects the agent css into the real head so the documented cascade holds
+ * (author head content first, agent css last). Every structural search runs on a
+ * length-preserving MASKED copy (complete comments + style/script content
+ * blanked) and the css is spliced on the ORIGINAL at the masked index, so a
+ * `</head>`/`<body>` token inside a comment or style/script content cannot
+ * capture the splice (it would otherwise land the css inside that inert region)
+ * and comments are preserved byte-for-byte.
  *
  * Always called after `ensureHead`, so a real head-opening tag exists by
- * construction. Two edge shapes are guarded:
+ * construction. Two edge shapes are guarded on the masked copy:
  *  - A stray `</head>` BEFORE the real head: the close search is anchored
- *    at/after the matched head-open so the css lands inside the REAL head, not
- *    at the earlier stray close (which would put it outside and before the real
- *    head — cascade inversion).
+ *    at/after the matched head-open so the css lands inside the REAL head (e.g.
+ *    `foo</head><head>…</head>`), not at the earlier stray close (which would
+ *    put it outside and before the real head — cascade inversion).
  *  - A head-open with NO matching close: the css is inserted immediately AFTER
  *    the (normalized) head-open rather than prepending a fresh `<head>`, which
  *    would otherwise create two head elements with the agent css before the
- *    author's head content. Only the no-head-at-all path (which `ensureHead`
- *    prevents here) would synthesize a brand-new head.
+ *    author's head content.
+ *
+ * Mirrors the masked-matching + real-head/stray-`</head>` anchoring of
+ * react-core's assembleDocument NON-legacy path (Vue injects no kit/importmap, so
+ * only the agent css is anchored; the no-`</head>` fallback inserts right after
+ * the head-open, as react-core's non-legacy path does). react-core's LEGACY path
+ * deliberately diverges — raw, unmasked `indexOf("</head>")`, a pinned
+ * byte-identity quirk.
  */
 function injectCssIntoHtml(html: string, css: string): string {
-  const match = html.match(HEAD_OPEN);
+  const masked = maskBlockContent(html);
+  const head = matchHeadOpen(masked);
   // ensureHead runs first, so a real head-opening tag exists by construction.
   // Anchor the close-tag search at/after the matched head-open so it pairs with
-  // the SAME head: a global first-match `search(/<\/head>/i)` would resolve to a
-  // stray `</head>` that PRECEDES the real head (e.g.
-  // `foo</head><head>…</head>`), splicing the agent css outside and before the
-  // real head and inverting the documented cascade. Mirrors react-core's
-  // assembleDocument, which scopes the close search to after the head-open.
-  const searchFrom =
-    match && match.index !== undefined ? match.index + match[0].length : 0;
-  const closeRel = html.slice(searchFrom).search(/<\/head>/i);
-  const headCloseIdx = closeRel !== -1 ? closeRel + searchFrom : -1;
-  if (headCloseIdx !== -1) {
+  // the SAME head: a global first-match would resolve to a stray `</head>` that
+  // PRECEDES the real head, splicing the agent css outside and before the real
+  // head and inverting the documented cascade.
+  const searchFrom = head ? head.index + head.token.length : 0;
+  const closeRel = masked.slice(searchFrom).search(/<\/head>/i);
+  if (closeRel !== -1) {
+    const headCloseIdx = closeRel + searchFrom;
     return (
       html.slice(0, headCloseIdx) +
       `<style>${css}</style>` +
@@ -136,9 +174,8 @@ function injectCssIntoHtml(html: string, css: string): string {
   // so insert the agent css immediately AFTER that (normalized) head-open rather
   // than prepending a fresh `<head>` — which would produce two head elements
   // with the agent css before the author's head content (cascade inversion).
-  // Matches react-core's post-head-open fallback.
-  if (match && match.index !== undefined) {
-    const insertAt = match.index + match[0].length;
+  if (head) {
+    const insertAt = head.index + head.token.length;
     return (
       html.slice(0, insertAt) + `<style>${css}</style>` + html.slice(insertAt)
     );

--- a/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
+++ b/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
@@ -98,19 +98,49 @@ function ensureHead(html: string): string {
  * first, agent css last; matching react-core). The close lookup is
  * case-insensitive so it pairs with `ensureHead`'s case-insensitive open match:
  * a case-sensitive `indexOf("</head>")` would miss an uppercase `</HEAD>` and
- * PREPEND a second `<head>`, producing two head elements and flipping the
- * cascade so the agent css wins over the author's head styles.
+ * flip the cascade so the agent css wins over the author's head styles.
  *
- * Always called after `ensureHead`, so a real `<head>` exists by construction;
- * the no-close fallback synthesizes a websandbox-safe literal `<head>`.
+ * Always called after `ensureHead`, so a real head-opening tag exists by
+ * construction. Two edge shapes are guarded:
+ *  - A stray `</head>` BEFORE the real head: the close search is anchored
+ *    at/after the matched head-open so the css lands inside the REAL head, not
+ *    at the earlier stray close (which would put it outside and before the real
+ *    head — cascade inversion).
+ *  - A head-open with NO matching close: the css is inserted immediately AFTER
+ *    the (normalized) head-open rather than prepending a fresh `<head>`, which
+ *    would otherwise create two head elements with the agent css before the
+ *    author's head content. Only the no-head-at-all path (which `ensureHead`
+ *    prevents here) would synthesize a brand-new head.
  */
 function injectCssIntoHtml(html: string, css: string): string {
-  const headCloseIdx = html.search(/<\/head>/i);
+  const match = html.match(HEAD_OPEN);
+  // ensureHead runs first, so a real head-opening tag exists by construction.
+  // Anchor the close-tag search at/after the matched head-open so it pairs with
+  // the SAME head: a global first-match `search(/<\/head>/i)` would resolve to a
+  // stray `</head>` that PRECEDES the real head (e.g.
+  // `foo</head><head>…</head>`), splicing the agent css outside and before the
+  // real head and inverting the documented cascade. Mirrors react-core's
+  // assembleDocument, which scopes the close search to after the head-open.
+  const searchFrom =
+    match && match.index !== undefined ? match.index + match[0].length : 0;
+  const closeRel = html.slice(searchFrom).search(/<\/head>/i);
+  const headCloseIdx = closeRel !== -1 ? closeRel + searchFrom : -1;
   if (headCloseIdx !== -1) {
     return (
       html.slice(0, headCloseIdx) +
       `<style>${css}</style>` +
       html.slice(headCloseIdx)
+    );
+  }
+  // No `</head>` at/after the head-open. ensureHead guaranteed a real head-open,
+  // so insert the agent css immediately AFTER that (normalized) head-open rather
+  // than prepending a fresh `<head>` — which would produce two head elements
+  // with the agent css before the author's head content (cascade inversion).
+  // Matches react-core's post-head-open fallback.
+  if (match && match.index !== undefined) {
+    const insertAt = match.index + match[0].length;
+    return (
+      html.slice(0, insertAt) + `<style>${css}</style>` + html.slice(insertAt)
     );
   }
   return `<head><style>${css}</style></head>${html}`;

--- a/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
+++ b/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
@@ -146,6 +146,30 @@ function injectCssIntoHtml(html: string, css: string): string {
   return `<head><style>${css}</style></head>${html}`;
 }
 
+/**
+ * Overflow guard for the preview iframe: `html, body { overflow: hidden }`. It
+ * must be baked into the head innerHTML so it survives every
+ * `document.head.innerHTML = …` reassignment built from head parts — a one-time
+ * `head.appendChild` on ready would be clobbered by the first reassignment and
+ * the preview iframe could then show scrollbars. Mirrors react-core's
+ * `buildPreviewHeadHtml` (overflow guard first, then preview styles, then agent
+ * css last so the cascade matches the final document). Vue has no
+ * kit/design-system injection, so the only head parts are: guard → extracted
+ * styles → agent css.
+ */
+const PREVIEW_OVERFLOW_GUARD =
+  "<style data-ck-preview-overflow>html, body { overflow: hidden !important; }</style>";
+
+function buildPreviewHeadHtml(
+  previewStyles: string,
+  css: string | undefined,
+): string {
+  const headParts: string[] = [PREVIEW_OVERFLOW_GUARD];
+  if (previewStyles) headParts.push(previewStyles);
+  if (css) headParts.push(`<style>${css}</style>`);
+  return headParts.join("");
+}
+
 type SandboxInstance = {
   iframe: HTMLIFrameElement;
   promise: Promise<unknown>;
@@ -320,10 +344,12 @@ export const OpenGenerativeUIRenderer = defineComponent({
 
           sandbox.promise.then(() => {
             if (cancelled || !previewSandboxRef.value) return;
+            // Flip ready — the content-update watcher (which lists previewReady
+            // in its source) then assigns the head/body. The overflow guard is
+            // baked into that head payload (buildPreviewHeadHtml), so it survives
+            // every reassignment; a separate appendChild here would be clobbered
+            // by the first head.innerHTML assignment. Mirrors react-core.
             previewReady.value = true;
-            void sandbox.run(
-              "var s=document.createElement('style');s.textContent='html, body { overflow: hidden !important; }';document.head.appendChild(s);",
-            );
           });
         } catch (error) {
           console.error(
@@ -343,21 +369,19 @@ export const OpenGenerativeUIRenderer = defineComponent({
       [previewBody, previewStyles, css, previewReady],
       ([body, styles, cssText, ready]) => {
         if (!previewSandboxRef.value || !ready) return;
-        // Cascade parity: extracted head styles first, agent css LAST — mirroring
-        // the final document, where injectCssIntoHtml inserts the agent css
-        // immediately before </head> (after the existing head content). Ordering
-        // the agent css first would flip its cascade position at the preview→final
-        // swap, visibly restyling artifacts that collide with it at equal
-        // specificity. Vue has no kit/design-system injection, so the only two
-        // head payloads are: extracted styles → agent css.
-        const headParts: string[] = [];
-        if (styles) headParts.push(styles);
-        if (cssText) headParts.push(`<style>${cssText}</style>`);
-        if (headParts.length) {
-          void previewSandboxRef.value.run(
-            `document.head.innerHTML = ${JSON.stringify(headParts.join(""))}`,
-          );
-        }
+        // Cascade parity: overflow guard first, then extracted head styles, then
+        // agent css LAST — mirroring the final document, where injectCssIntoHtml
+        // inserts the agent css immediately before </head> (after the existing
+        // head content). Ordering the agent css first would flip its cascade
+        // position at the preview→final swap, visibly restyling artifacts that
+        // collide with it at equal specificity. The guard is ALWAYS present (so
+        // the head is assigned even with no styles/css), which also keeps the
+        // overflow guard from being lost when css/head styles arrive — the head
+        // payload is fully rebuilt on every assignment. Mirrors react-core's
+        // buildPreviewHeadHtml.
+        void previewSandboxRef.value.run(
+          `document.head.innerHTML = ${JSON.stringify(buildPreviewHeadHtml(styles, cssText))}`,
+        );
         if (body) {
           void previewSandboxRef.value.run(
             `document.body.innerHTML = ${JSON.stringify(body)}`,

--- a/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
+++ b/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
@@ -180,6 +180,31 @@ function ensureHead(html: string): string {
 }
 
 /**
+ * Neutralizes the `<style>`-element-closing sequence inside agent css before it
+ * is spliced into a `<style>` element. The agent css is injected RAW into every
+ * `<style>${css}</style>` sink in this file (the final document via
+ * `injectCssIntoHtml`, and the streaming preview head via
+ * `buildPreviewHeadHtml`); a css value containing `</style>` would otherwise
+ * close the element early and let the markup after it become LIVE content in the
+ * sandbox iframe (e.g. `css: "a{}</style><script>alert(1)</script>"` → live
+ * script).
+ *
+ * The escape inserts a CSS backslash into the `/` of the close token
+ * (`</style` → `<\/style`), case-preservingly via `$1`. This is LOSSLESS inside
+ * a CSS string (a CSS parser reads `"\/"` back as `/`) and a dead, non-closing
+ * token in any other CSS position, so it changes nothing about how the css
+ * renders while making the element-close impossible.
+ *
+ * Mirrors react-core's exported helper (which guards its own assembleDocument /
+ * buildPreviewHeadHtml css sinks) and MUST stay lockstep with it — the escape is
+ * byte-for-byte identical so the final document and preview are produced the same
+ * way on both packages.
+ */
+function escapeStyleClose(css: string): string {
+  return css.replace(/<(\/style)/gi, "<\\$1");
+}
+
+/**
  * Injects the agent css into the real head so the documented cascade holds
  * (author head content first, agent css last). Every structural search runs on a
  * length-preserving MASKED copy (complete comments + style/script content
@@ -222,12 +247,17 @@ function injectCssIntoHtml(html: string, css: string): string {
   // PRECEDES the real head, splicing the agent css outside and before the real
   // head and inverting the documented cascade.
   const searchFrom = head ? head.index + head.token.length : 0;
+  // Escape any `</style>` in the agent css (escapeStyleClose) at EVERY sink
+  // below so a css value cannot close the injected `<style>` element early and
+  // smuggle live markup into the sandbox iframe. Lossless inside CSS, dead token
+  // otherwise. Mirrors react-core's css sinks.
+  const safeCss = escapeStyleClose(css);
   const closeRel = masked.slice(searchFrom).search(/<\/head>/i);
   if (closeRel !== -1) {
     const headCloseIdx = closeRel + searchFrom;
     return (
       html.slice(0, headCloseIdx) +
-      `<style>${css}</style>` +
+      `<style>${safeCss}</style>` +
       html.slice(headCloseIdx)
     );
   }
@@ -238,7 +268,7 @@ function injectCssIntoHtml(html: string, css: string): string {
   if (bodyRel && bodyRel.index !== undefined) {
     const bodyIdx = searchFrom + bodyRel.index;
     return (
-      html.slice(0, bodyIdx) + `<style>${css}</style>` + html.slice(bodyIdx)
+      html.slice(0, bodyIdx) + `<style>${safeCss}</style>` + html.slice(bodyIdx)
     );
   }
   // No `</head>` and no `<body>`. ensureHead guaranteed a real head-open, so
@@ -248,10 +278,12 @@ function injectCssIntoHtml(html: string, css: string): string {
   if (head) {
     const insertAt = head.index + head.token.length;
     return (
-      html.slice(0, insertAt) + `<style>${css}</style>` + html.slice(insertAt)
+      html.slice(0, insertAt) +
+      `<style>${safeCss}</style>` +
+      html.slice(insertAt)
     );
   }
-  return `<head><style>${css}</style></head>${html}`;
+  return `<head><style>${safeCss}</style></head>${html}`;
 }
 
 /**
@@ -273,8 +305,15 @@ function buildPreviewHeadHtml(
   css: string | undefined,
 ): string {
   const headParts: string[] = [PREVIEW_OVERFLOW_GUARD];
+  // previewStyles are hoisted from the agent's OWN complete `<style>` elements
+  // (extractCompleteStyles). They are spliced verbatim and NOT escaped: by
+  // construction a complete `<style>` element cannot contain a live `</style>`
+  // (that token already terminated it), so re-emitting it cannot break out.
+  // Mirrors react-core (only the agent css param is escaped here).
   if (previewStyles) headParts.push(previewStyles);
-  if (css) headParts.push(`<style>${css}</style>`);
+  // Escape any `</style>` in the agent css so the css value cannot close this
+  // `<style>` element early and inject live markup into the preview iframe.
+  if (css) headParts.push(`<style>${escapeStyleClose(css)}</style>`);
   return headParts.join("");
 }
 

--- a/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
+++ b/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
@@ -772,23 +772,41 @@ export const OpenGenerativeUIToolRenderer = defineComponent({
   },
   setup(props) {
     const visibleMessageIndex = ref(0);
+    const prevMessageCount = ref(0);
 
-    // Watch status alongside placeholderMessages so a transition to Complete
-    // re-runs this watcher: the onCleanup below clears the in-flight interval
-    // and the Complete guard prevents re-arming. Without status in the source,
-    // a stable placeholderMessages reference would leave the 5s interval firing
-    // until unmount even after the call completes (the render returns null, so
-    // it would be an invisible lingering timer). Mirrors react-core, which keys
-    // its placeholder effect on props.status.
+    // Key the placeholder cycle on the message COUNT and the status — both as
+    // stable SCALAR sources. A `() => [placeholderMessages, status]` getter
+    // returns a FRESH array literal each tick, which Vue compares by reference,
+    // so the watcher would fire on essentially every reactive tick (every
+    // placeholderMessages identity change during streaming): the index would be
+    // forced to length-1 and the 5s interval torn down/re-armed each time. Vue
+    // compares the elements of a MULTI-SOURCE array by value for scalars, so
+    // `[() => length, () => status]` fires only when the count or the status
+    // actually changes. Mirrors react-core's placeholder effect, whose deps are
+    // `[messages?.length, props.status]`.
     watch(
-      () => [props.args.placeholderMessages, props.status] as const,
-      ([messages], _, onCleanup) => {
-        if (!messages?.length || props.status === ToolCallStatus.Complete)
-          return;
-        visibleMessageIndex.value = Math.max(messages.length - 1, 0);
+      [
+        () => props.args.placeholderMessages?.length,
+        () => props.status,
+      ] as const,
+      ([count, status], _previous, onCleanup) => {
+        if (!count) return;
+        // Jump to the newest message ONLY when the count changes (a new message
+        // streamed in) — never on a status-only re-run. Tracked against a
+        // previous-count ref, mirroring react-core's prevMessageCountRef.
+        if (count !== prevMessageCount.value) {
+          prevMessageCount.value = count;
+          visibleMessageIndex.value = count - 1;
+        }
+        // Auto-cycle only while in progress. The interval is cleared (onCleanup)
+        // and re-armed only when this watcher re-runs, i.e. only on a count or
+        // status change — not on every tick. On Complete it is cleared and NOT
+        // re-armed (the render returns null, so a lingering timer would be an
+        // invisible leak firing until unmount). Mirrors react-core's
+        // clear-on-complete + status-keyed re-arm.
+        if (status === ToolCallStatus.Complete) return;
         const timer = window.setInterval(() => {
-          visibleMessageIndex.value =
-            (visibleMessageIndex.value + 1) % Math.max(messages.length, 1);
+          visibleMessageIndex.value = (visibleMessageIndex.value + 1) % count;
         }, 5000);
         onCleanup(() => window.clearInterval(timer));
       },

--- a/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
+++ b/packages/vue/src/v2/components/OpenGenerativeUIRenderer.ts
@@ -119,7 +119,7 @@ function injectCssIntoHtml(html: string, css: string): string {
 type SandboxInstance = {
   iframe: HTMLIFrameElement;
   promise: Promise<unknown>;
-  run: (code: string | Function) => Promise<unknown>;
+  run: (code: string | ((...args: unknown[]) => unknown)) => Promise<unknown>;
   destroy: () => void;
 };
 
@@ -135,7 +135,9 @@ type WebsandboxModule = {
 };
 
 async function loadWebsandbox(): Promise<WebsandboxModule> {
-  const mod = (await import("@jetbrains/websandbox")) as any;
+  const mod = (await import("@jetbrains/websandbox")) as {
+    default?: { default?: unknown } & unknown;
+  };
   return (mod.default?.default ?? mod.default) as WebsandboxModule;
 }
 

--- a/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
+++ b/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
@@ -729,5 +729,77 @@ describe("OpenGenerativeUIRenderer", () => {
       expect(agentIdx).toBeGreaterThan(-1);
       expect(authorIdx).toBeLessThan(agentIdx);
     });
+
+    // Case 4 — stray </head> BEFORE the real head, WITH css. A global
+    // `search(/<\/head>/i)` resolves to the FIRST close anywhere — here the
+    // stray one before the real `<head>` — so the agent css splices outside and
+    // before the real head (cascade inversion). React's assembleDocument scopes
+    // the close search to at/after the matched head-open. GREEN post-fix: the
+    // css lands INSIDE the real head, after the author's head content, before
+    // the real `</head>`.
+    it("anchors the css to the real head when a stray </head> precedes it", async () => {
+      const agentCss = ".agent{color:red}";
+      renderRenderer({
+        html: ["foo</head><head><title>t</title></head><body>x</body>"],
+        htmlComplete: true,
+        css: agentCss,
+        cssComplete: true,
+      });
+      await flushImport();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const frameContent = finalFrameContent();
+
+      // The css must sit inside the REAL head: after the head-open, after the
+      // author's <title>, and before the real (last) </head>.
+      const headOpenIdx = frameContent.indexOf("<head>");
+      const titleIdx = frameContent.indexOf("<title>t</title>");
+      const cssIdx = frameContent.indexOf(agentCss);
+      const realHeadCloseIdx = frameContent
+        .toLowerCase()
+        .lastIndexOf("</head>");
+      expect(headOpenIdx).toBeGreaterThan(-1);
+      expect(titleIdx).toBeGreaterThan(-1);
+      expect(cssIdx).toBeGreaterThan(-1);
+      // Inside the real head, after the author content, before the real close.
+      expect(cssIdx).toBeGreaterThan(headOpenIdx);
+      expect(cssIdx).toBeGreaterThan(titleIdx);
+      expect(cssIdx).toBeLessThan(realHeadCloseIdx);
+    });
+
+    // Case 5 — head-open with NO close, WITH css. ensureHead normalizes the open
+    // token; injectCssIntoHtml then finds no `</head>` and (pre-fix) PREPENDS a
+    // fresh `<head><style>…</style></head>`, producing TWO head elements with the
+    // agent css before the author's head content. React's assembleDocument for
+    // the same input yields exactly ONE head with the css right after the
+    // head-open. GREEN post-fix: one `<head` token, css after the open and
+    // before the author's <title>.
+    it("inserts css after the head-open (one head) when no close exists", async () => {
+      const agentCss = ".agent{color:red}";
+      renderRenderer({
+        html: ["<HEAD><title>t</title><body>x</body>"],
+        htmlComplete: true,
+        css: agentCss,
+        cssComplete: true,
+      });
+      await flushImport();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const frameContent = finalFrameContent();
+
+      // Exactly one head-open token — no duplicate head was prepended. Match is
+      // quote-aware, mirroring the renderer's normalization regex.
+      const headOpenings =
+        frameContent.match(/<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi) ?? [];
+      expect(headOpenings).toHaveLength(1);
+      // The css sits after the (normalized) head-open and before the author's
+      // <title>, i.e. immediately after the open rather than in a prepended head.
+      const headOpenIdx = frameContent.indexOf("<head>");
+      const cssIdx = frameContent.indexOf(agentCss);
+      const titleIdx = frameContent.indexOf("<title>t</title>");
+      expect(headOpenIdx).toBeGreaterThan(-1);
+      expect(cssIdx).toBeGreaterThan(-1);
+      expect(titleIdx).toBeGreaterThan(-1);
+      expect(cssIdx).toBeGreaterThan(headOpenIdx);
+      expect(cssIdx).toBeLessThan(titleIdx);
+    });
   });
 });

--- a/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
+++ b/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
@@ -815,17 +815,19 @@ describe("OpenGenerativeUIRenderer", () => {
       expect(cssIdx).toBeLessThan(realHeadCloseIdx);
     });
 
-    // Case 5 — head-open with NO close, WITH css. ensureHead normalizes the open
-    // token; injectCssIntoHtml then finds no `</head>` and (pre-fix) PREPENDS a
-    // fresh `<head><style>…</style></head>`, producing TWO head elements with the
-    // agent css before the author's head content. React's assembleDocument for
-    // the same input yields exactly ONE head with the css right after the
-    // head-open. GREEN post-fix: one `<head` token, css after the open and
-    // before the author's <title>.
-    it("inserts css after the head-open (one head) when no close exists", async () => {
+    // Case 5 — head-open with NO close AND NO `<body>`, WITH css (the final
+    // fallback). ensureHead normalizes the open token; injectCssIntoHtml then
+    // finds no `</head>` and no `<body>` and (pre-fix) PREPENDED a fresh
+    // `<head><style>…</style></head>`, producing TWO head elements with the agent
+    // css before the author's head content. GREEN post-fix: exactly ONE `<head`
+    // token, css inserted immediately after the open (no `<body>` exists to
+    // anchor the implicit-close branch — see the unclosed-head-with-body test
+    // below for that path). React's assembleDocument non-legacy fallback inserts
+    // after the head-open here too.
+    it("inserts css after the head-open (one head) when no close and no body exist", async () => {
       const agentCss = ".agent{color:red}";
       renderRenderer({
-        html: ["<HEAD><title>t</title><body>x</body>"],
+        html: ["<HEAD><title>t</title>"],
         htmlComplete: true,
         css: agentCss,
         cssComplete: true,
@@ -958,6 +960,44 @@ describe("OpenGenerativeUIRenderer", () => {
       expect(frameContent).not.toContain('lang="fr"');
       // The author's head content survives.
       expect(frameContent).toContain("<title>t</title>");
+    });
+
+    // Finding 2 — an UNCLOSED head WITH css and an in-head author style. RED
+    // pre-fix: with no `</head>`, injectCssIntoHtml inserted the agent css
+    // immediately after the head-open — BEFORE the author's in-head `<style>`,
+    // inverting the author-first/css-last cascade (and flipping order against the
+    // streaming preview, whose analyzeRegions implicitly closes the head at
+    // `<body>`). GREEN post-fix: the first `<body>` after the head-open is the
+    // implicit head close, so the css is inserted JUST BEFORE `<body>` — after
+    // the author style, before the body.
+    it("anchors css to the implicit <body> close for an unclosed head (author style before agent css)", async () => {
+      const authorStyle = ".a{color:blue}";
+      const agentCss = ".agent{color:red}";
+      renderRenderer({
+        html: [`<head><style>${authorStyle}</style><body>x</body>`],
+        htmlComplete: true,
+        css: agentCss,
+        cssComplete: true,
+      });
+      await flushImport();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const frameContent = finalFrameContent();
+
+      // Exactly one head-open token — no duplicate head was synthesized.
+      const headOpenings =
+        frameContent.match(/<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi) ?? [];
+      expect(headOpenings).toHaveLength(1);
+
+      const authorIdx = frameContent.indexOf(authorStyle);
+      const agentIdx = frameContent.indexOf(agentCss);
+      const bodyIdx = frameContent.search(/<body[\s>]/i);
+      expect(authorIdx).toBeGreaterThan(-1);
+      expect(agentIdx).toBeGreaterThan(-1);
+      expect(bodyIdx).toBeGreaterThan(-1);
+      // Cascade parity: author in-head style FIRST, then the agent css, and the
+      // agent css sits before the implicit `<body>` close.
+      expect(authorIdx).toBeLessThan(agentIdx);
+      expect(agentIdx).toBeLessThan(bodyIdx);
     });
   });
 });

--- a/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
+++ b/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
@@ -295,6 +295,67 @@ describe("OpenGenerativeUIRenderer", () => {
     expect(mockRun).toHaveBeenCalledWith("foo()");
   });
 
+  // Ordering invariant on a final-sandbox rebuild: jsFunctions must be DEFINED
+  // before any jsExpression runs (expressions call the functions). During the
+  // rebuild window the jsExpressions watcher can push an expression into the
+  // pending queue BEFORE the sandbox's ready callback runs. The ready callback
+  // therefore `unshift`es jsFunctions to the FRONT of the queue so they execute
+  // ahead of that already-queued expression. A plain `push` would append the
+  // functions AFTER the queued expression and the expression would run against
+  // undefined functions. This pins functions-before-expressions through that
+  // exact race (and discriminates unshift from push — flip it and this fails).
+  it("runs jsFunctions before a jsExpression queued during the rebuild window", async () => {
+    // 1. Mount with html + jsFunctions, NO jsExpressions. The final-sandbox
+    //    watch fires, creates the sandbox and registers its ready callback, but
+    //    the promise stays UNRESOLVED (we don't resolve it yet). The
+    //    jsFunctions/jsExpressions watchers do not fire on mount (no immediate),
+    //    so the queue is empty and jsFunctions are NOT yet injected.
+    const mounted = renderRenderer({
+      html: ["<head></head><body></body>"],
+      htmlComplete: true,
+      jsFunctions: "function defineThings() {}",
+      generating: true,
+    });
+    await flushImport();
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    // Nothing has run yet — the sandbox is not ready.
+    expect(mockRun).not.toHaveBeenCalled();
+
+    // 2. While the sandbox promise is still unresolved, a jsExpression streams
+    //    in. The jsExpressions watcher fires, sees the sandbox not ready, and
+    //    pushes the expression onto the pending queue — so the queue holds the
+    //    EXPRESSION before the functions are ever queued.
+    mounted.rerender({
+      activityType: "open-generative-ui",
+      content: {
+        html: ["<head></head><body></body>"],
+        htmlComplete: true,
+        jsFunctions: "function defineThings() {}",
+        jsExpressions: ["defineThings()"],
+        generating: true,
+      },
+      message: {},
+      agent: {},
+    });
+    await flushImport();
+    // Still nothing executed — promise not resolved; both are queued.
+    expect(mockRun).not.toHaveBeenCalled();
+
+    // 3. Resolve the sandbox. The ready callback unshifts jsFunctions ahead of
+    //    the already-queued expression, then flushes the queue in order.
+    mockPromiseResolve();
+    await mockPromise;
+    await flushImport();
+
+    const jsCalls = mockRun.mock.calls
+      .map((c) => c[0])
+      .filter(
+        (c) => c === "function defineThings() {}" || c === "defineThings()",
+      );
+    // Functions MUST come before the expression.
+    expect(jsCalls).toEqual(["function defineThings() {}", "defineThings()"]);
+  });
+
   it("passes localApi built from sandbox functions to websandbox", async () => {
     const handler = vi.fn().mockResolvedValue(42);
     const sandboxFunctions: SandboxFunction[] = [
@@ -562,6 +623,57 @@ describe("OpenGenerativeUIRenderer", () => {
       const [, options] = mockCreate.mock.calls[0];
       expect(options.frameContent).toContain("Done");
       expect(options.frameContent).not.toBe("<head></head><body></body>");
+    });
+  });
+
+  // The Open Generative UI middleware emits `generating: false` ONLY from its
+  // TOOL_CALL_END handler. On a terminal path where the upstream agent never
+  // emits TOOL_CALL_END for the genui tool call — an abort/stop, an abrupt
+  // stream end, or a transport error after the args fully streamed — the
+  // runner's finalizeRunEvents synthesizes a TOOL_CALL_END at the runner level,
+  // AFTER the middleware already processed the stream, so it never flows back
+  // through the middleware and `generating: false` is never emitted. The
+  // fully-streamed payload then arrives with `generating` absent. Without a
+  // fallback the renderer would keep the pointer-blocking overlay over a
+  // finished, interactive artifact forever. The completion fallback treats an
+  // all-segments-complete payload as terminal.
+  describe("terminal payload with absent generating flag (TOOL_CALL_END never reached the middleware)", () => {
+    it("does not cover a fully-streamed artifact with the progress overlay", async () => {
+      const { queryByTestId } = renderRenderer({
+        initialHeight: 200,
+        html: ["<head></head><body><div>Tall content</div></body>"],
+        htmlComplete: true,
+        css: "body { color: blue; }",
+        cssComplete: true,
+        jsFunctions: "function init(){}",
+        jsFunctionsComplete: true,
+        jsExpressions: ["init()"],
+        jsExpressionsComplete: true,
+        // generating intentionally ABSENT — no `generating: false` delta arrived.
+      });
+      await flushImport();
+
+      expect(queryByTestId("open-generative-ui-progress-overlay")).toBeNull();
+    });
+
+    it("still covers an in-flight artifact whose js segments are not yet complete (no premature completion)", async () => {
+      // html finished but jsExpressions are still streaming
+      // (jsExpressionsComplete absent) — the NORMAL mid-stream shape, NOT a
+      // terminal payload. The overlay must stay up.
+      const { queryByTestId } = renderRenderer({
+        initialHeight: 200,
+        html: ["<head></head><body><div>partial</div></body>"],
+        htmlComplete: true,
+        css: "body { color: blue; }",
+        cssComplete: true,
+        jsExpressions: ["init()"],
+        // jsExpressionsComplete ABSENT — still streaming. generating ABSENT too.
+      });
+      await flushImport();
+
+      expect(
+        queryByTestId("open-generative-ui-progress-overlay"),
+      ).not.toBeNull();
     });
   });
 

--- a/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
+++ b/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
@@ -850,6 +850,115 @@ describe("OpenGenerativeUIRenderer", () => {
       expect(cssIdx).toBeGreaterThan(headOpenIdx);
       expect(cssIdx).toBeLessThan(titleIdx);
     });
+
+    // ---------------------------------------------------------------------
+    // Mask-before-match (Finding 1): the head helpers run their head-open
+    // match and `</head>` close search on a length-preserving MASKED copy
+    // (complete comments + style/script content blanked) and splice on the
+    // ORIGINAL at the masked indices — mirroring react-core's assembleDocument
+    // non-legacy anchoring. A `<head>`/`</head>` token inside a comment or
+    // style/script content therefore can never capture the splice or
+    // short-circuit normalization, and comments are preserved byte-for-byte.
+    // ---------------------------------------------------------------------
+
+    // Finding 1a — a `</head>` lookalike inside a comment BEFORE the real
+    // close. RED pre-fix: injectCssIntoHtml searched the RAW html, so the
+    // comment's `</head>` captured the close search and the agent css spliced
+    // INSIDE the comment (inert — never applied). GREEN post-fix: the masked
+    // search skips the comment's lookalike and the css lands inside the REAL
+    // head, after the comment, before the real `</head>`.
+    it("anchors css to the real </head>, not a </head> inside a comment (masked)", async () => {
+      const agentCss = ".agent{color:red}";
+      renderRenderer({
+        html: ["<head><title>t</title><!-- </head> --></head><body>x</body>"],
+        htmlComplete: true,
+        css: agentCss,
+        cssComplete: true,
+      });
+      await flushImport();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const frameContent = finalFrameContent();
+
+      const titleIdx = frameContent.indexOf("<title>t</title>");
+      const commentIdx = frameContent.indexOf("<!-- </head> -->");
+      const cssIdx = frameContent.indexOf(agentCss);
+      const realCloseIdx = frameContent.toLowerCase().lastIndexOf("</head>");
+      expect(titleIdx).toBeGreaterThan(-1);
+      expect(commentIdx).toBeGreaterThan(-1);
+      expect(cssIdx).toBeGreaterThan(-1);
+      // The css lands AFTER the author content and AFTER the inert comment, and
+      // BEFORE the real (last) </head> — i.e. inside the real head, not in the
+      // comment.
+      expect(cssIdx).toBeGreaterThan(titleIdx);
+      expect(cssIdx).toBeGreaterThan(commentIdx);
+      expect(cssIdx).toBeLessThan(realCloseIdx);
+      // The comment (with its </head> lookalike) is preserved byte-for-byte.
+      expect(frameContent).toContain("<!-- </head> -->");
+    });
+
+    // Finding 1b — a literal `<head>` inside a comment BEFORE the real
+    // attributed head. RED pre-fix: ensureHead's RAW match found the comment's
+    // `<head>` first and (token === "<head>") short-circuited, leaving the real
+    // `<head lang="en">` un-normalized — so the only normalization websandbox's
+    // `.replace('<head>', bootstrap)` could anchor on was the inert comment
+    // token, and the real head never received the bootstrap (permanent spinner).
+    // GREEN post-fix: the masked match skips the comment and normalizes the REAL
+    // head to the literal `<head>`; the comment is preserved byte-for-byte.
+    it("normalizes the real head, not a <head> inside a comment, keeping the comment intact (masked)", async () => {
+      renderRenderer({
+        html: [
+          '<!-- <head> --><head lang="en"><title>t</title></head><body>x</body>',
+        ],
+        htmlComplete: true,
+      });
+      await flushImport();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const frameContent = finalFrameContent();
+
+      // websandbox's literal-head gate is satisfied.
+      expect(frameContent).toContain("<head>");
+      // The comment is preserved byte-for-byte (its inner <head> lookalike was
+      // never rewritten).
+      expect(frameContent).toContain("<!-- <head> -->");
+      // The REAL head (past the comment close) was normalized: no attributed
+      // head-open token survives there. Scoped past the comment so the
+      // comment's own literal `<head>` is not counted, and this input has no
+      // `<header>` to false-positive the broad attributed-head match.
+      const commentClose = frameContent.indexOf("-->");
+      expect(commentClose).toBeGreaterThan(-1);
+      expect(frameContent.slice(commentClose)).not.toMatch(/<head[^>]+>/);
+      expect(frameContent).not.toContain('lang="en"');
+      // The author's head content survives.
+      expect(frameContent).toContain("<title>t</title>");
+    });
+
+    // Finding 1c — a comment containing an attributed head lookalike BEFORE the
+    // real attributed head. RED pre-fix: ensureHead's RAW match landed on the
+    // comment's `<head lang="en">` and REWROTE that token to `<head>` (corrupting
+    // the comment), while the real `<head lang="fr">` was left untouched. GREEN
+    // post-fix: the masked match skips the comment (preserved byte-for-byte) and
+    // normalizes the REAL head.
+    it("rewrites the real head, not an attributed <head> inside a comment (masked)", async () => {
+      renderRenderer({
+        html: [
+          '<!-- example: <head lang="en"> --><head lang="fr"><title>t</title></head><body>x</body>',
+        ],
+        htmlComplete: true,
+      });
+      await flushImport();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const frameContent = finalFrameContent();
+
+      // The comment is preserved byte-for-byte (its attributed head lookalike was
+      // never rewritten).
+      expect(frameContent).toContain('<!-- example: <head lang="en"> -->');
+      // websandbox's literal token is present and the real head was normalized:
+      // neither attribute string survives.
+      expect(frameContent).toContain("<head>");
+      expect(frameContent).not.toContain('lang="fr"');
+      // The author's head content survives.
+      expect(frameContent).toContain("<title>t</title>");
+    });
   });
 });
 

--- a/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
+++ b/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
@@ -622,4 +622,112 @@ describe("OpenGenerativeUIRenderer", () => {
       expect(headPayload!).toContain(agentCss);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // FINAL document head normalization for websandbox mounting.
+  //
+  // @jetbrains/websandbox@1.1.3 hard-requires the EXACT literal lowercase token
+  // `<head>` in frameContent: validateOptions throws when
+  // `!frameContent.includes('<head>')`, and it injects its bootstrap via
+  // `frameContent.replace('<head>', …)` (both case-sensitive on the 6-char
+  // token). An agent-emitted `<HEAD>` or `<head lang="en">` therefore both fails
+  // mounting (stuck spinner) and, even if it slipped past, never receives the
+  // bootstrap. The final-document helpers must normalize the head-open token to
+  // the literal `<head>` and inject the agent css INSIDE the existing head
+  // (after author content, before the close) so the documented cascade holds:
+  // author head styles first, agent css last — matching react-core.
+  // -------------------------------------------------------------------------
+  describe("final document head normalization (websandbox)", () => {
+    function finalFrameContent(): string {
+      const finalCall = mockCreate.mock.calls.find(
+        ([, options]) =>
+          typeof options.frameContent === "string" &&
+          options.frameContent !== "<head></head><body></body>",
+      );
+      return (finalCall?.[1].frameContent as string) ?? "";
+    }
+
+    // Case 1 — uppercase <HEAD>…</HEAD>, NO css. ensureHead matched the head
+    // case-insensitively and left the uppercase token verbatim, so frameContent
+    // had no literal `<head>` → websandbox.validateOptions throws → never mounts.
+    // GREEN post-fix: the open token is normalized to the literal `<head>`.
+    it("normalizes an uppercase head with no css so frameContent has the literal <head>", async () => {
+      renderRenderer({
+        html: ["<HEAD><title>t</title></HEAD><body>x</body>"],
+        htmlComplete: true,
+      });
+      await flushImport();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const frameContent = finalFrameContent();
+      // websandbox's literal-head gate is satisfied.
+      expect(frameContent).toContain("<head>");
+      // The author's head content survives the normalization.
+      expect(frameContent).toContain("<title>t</title>");
+    });
+
+    // Case 2 — attributed <head lang="en">…</head> WITH css. injectCssIntoHtml
+    // found </head> and injected before it, but the only head-open token was the
+    // attributed `<head lang="en">` → no literal `<head>` → websandbox throws.
+    // GREEN post-fix: the literal `<head>` is present AND the agent css <style>
+    // sits INSIDE the real head — after the author's title, before the close.
+    it("normalizes an attributed head with css so the literal <head> is present and css lands inside the real head", async () => {
+      const agentCss = ".a{color:red}";
+      renderRenderer({
+        html: ['<head lang="en"><title>t</title></head><body>x</body>'],
+        htmlComplete: true,
+        css: agentCss,
+        cssComplete: true,
+      });
+      await flushImport();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const frameContent = finalFrameContent();
+      // websandbox's literal-head gate is satisfied.
+      expect(frameContent).toContain("<head>");
+      // The agent css must sit INSIDE the real head element.
+      const headOpenIdx = frameContent.indexOf("<head>");
+      const headCloseIdx = frameContent.toLowerCase().indexOf("</head>");
+      const titleIdx = frameContent.indexOf("<title>t</title>");
+      const cssIdx = frameContent.indexOf(agentCss);
+      expect(headOpenIdx).toBeGreaterThan(-1);
+      expect(headCloseIdx).toBeGreaterThan(-1);
+      expect(cssIdx).toBeGreaterThan(-1);
+      // css is between the head-open and head-close (inside the real head).
+      expect(cssIdx).toBeGreaterThan(headOpenIdx);
+      expect(cssIdx).toBeLessThan(headCloseIdx);
+      // Cascade: author head content (title) precedes the agent css.
+      expect(titleIdx).toBeGreaterThan(-1);
+      expect(titleIdx).toBeLessThan(cssIdx);
+    });
+
+    // Case 3 (cascade) — uppercase head WITH css. injectCssIntoHtml's
+    // case-sensitive indexOf("</head>") missed the uppercase `</HEAD>`, so it
+    // PREPENDED a fresh `<head><style>…</style></head>` before the author's
+    // uppercase head — two head elements, agent css cascading BEFORE the author's
+    // head styles. GREEN post-fix: exactly one head element, author styles before
+    // agent css.
+    it("produces exactly one head element with author styles before agent css (uppercase head with css)", async () => {
+      const authorStyle = ".author{color:blue}";
+      const agentCss = ".agent{color:red}";
+      renderRenderer({
+        html: [`<HEAD><style>${authorStyle}</style></HEAD><body>x</body>`],
+        htmlComplete: true,
+        css: agentCss,
+        cssComplete: true,
+      });
+      await flushImport();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const frameContent = finalFrameContent();
+      // Exactly one head-open token (no duplicate head was prepended). Match is
+      // quote-aware, mirroring the renderer's normalization regex.
+      const headOpenings =
+        frameContent.match(/<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi) ?? [];
+      expect(headOpenings).toHaveLength(1);
+      // Cascade: author head style precedes the agent css.
+      const authorIdx = frameContent.indexOf(authorStyle);
+      const agentIdx = frameContent.indexOf(agentCss);
+      expect(authorIdx).toBeGreaterThan(-1);
+      expect(agentIdx).toBeGreaterThan(-1);
+      expect(authorIdx).toBeLessThan(agentIdx);
+    });
+  });
 });

--- a/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
+++ b/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "@testing-library/vue";
-import { ref } from "vue";
+import { nextTick, ref } from "vue";
 import type { Ref } from "vue";
 import { ToolCallStatus } from "@copilotkit/core";
 import {
@@ -50,6 +50,40 @@ vi.mock("@jetbrains/websandbox", () => ({
 
 async function flushImport() {
   await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// The renderer's content watcher throttles non-immediate changes with
+// window.setTimeout(flush, THROTTLE_MS). Keep this in lockstep with the 1000ms
+// throttle window in the source.
+const THROTTLE_MS = 1000;
+
+/**
+ * Fake-timer-safe drain of the Vue scheduler + the dynamic-import / sandbox-ready
+ * microtask chain the renderer kicks off (the `import("@jetbrains/websandbox")`
+ * resolve, its `.then` running `create`, and the `sandbox.promise.then` ready
+ * callback are each a microtask hop, interleaved with Vue reactive re-renders).
+ * Uses ONLY microtask hops (`Promise.resolve()`) and `nextTick` — NO real timer
+ * — so, unlike `flushImport`'s `setTimeout(0)`, it does not hang under
+ * `vi.useFakeTimers()`. Mirrors react-core's fake-timer-safe `flushImport` loop.
+ */
+async function flushMicrotasks() {
+  for (let i = 0; i < 8; i++) {
+    await Promise.resolve();
+    await nextTick();
+  }
+}
+
+/**
+ * Advance the renderer's throttle window deterministically. Under
+ * `vi.useFakeTimers()` we step exactly THROTTLE_MS so the deferred flush fires
+ * (no wall-clock margin a loaded parallel worker can blow through), then drain
+ * the scheduler + microtask chain the resulting reactive update queues (the
+ * preview head/body `run` calls). Requires `vi.useFakeTimers()` to be active —
+ * it uses NO real timer. Mirrors react-core's `flushThrottle`.
+ */
+async function flushThrottle() {
+  await vi.advanceTimersByTimeAsync(THROTTLE_MS);
+  await flushMicrotasks();
 }
 
 function renderRenderer(
@@ -397,17 +431,29 @@ describe("OpenGenerativeUIRenderer", () => {
     });
 
     it("updates preview after throttled rerender", async () => {
+      // Deterministic throttle: drive the whole test with fake timers and step
+      // exactly THROTTLE_MS for the deferred flush, instead of racing a real
+      // 1100ms wall-clock wait against the renderer's 1000ms throttle (the
+      // ~100ms margin a loaded parallel worker could blow through). Fake timers
+      // are enabled from the START so the sandbox-setup chain and the rerender's
+      // throttle timer share one fake clock; flushMicrotasks drains the
+      // import/promise chain without a real timer. vi.useRealTimers() in
+      // afterEach restores real timers.
+      vi.useFakeTimers();
       const mounted = renderRenderer({
         html: ["<body><div>Hello</div>"],
         htmlComplete: false,
         cssComplete: true,
         generating: true,
       });
-      await flushImport();
+      // Drain the dynamic import + Websandbox.create chain (fake-timer-safe).
+      await flushMicrotasks();
 
+      // Resolve the preview sandbox's ready promise, then drain the resulting
+      // head/body assignment (the initial content is an immediate flush, so no
+      // throttle timer is pending after this).
       mockPromiseResolve();
-      await mockPromise;
-      await flushImport();
+      await flushMicrotasks();
       mockRun.mockClear();
 
       mounted.rerender({
@@ -422,8 +468,9 @@ describe("OpenGenerativeUIRenderer", () => {
         agent: {},
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 1100));
-      await flushImport();
+      // Advance exactly the throttle window so the deferred flush fires, then
+      // drain the reactive update it queues.
+      await flushThrottle();
 
       const bodyCalls = mockRun.mock.calls.filter(
         (call) =>

--- a/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
+++ b/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "@testing-library/vue";
 import { ref } from "vue";
 import type { Ref } from "vue";
-import { OpenGenerativeUIActivityRenderer } from "../OpenGenerativeUIRenderer";
+import { ToolCallStatus } from "@copilotkit/core";
+import {
+  OpenGenerativeUIActivityRenderer,
+  OpenGenerativeUIToolRenderer,
+} from "../OpenGenerativeUIRenderer";
 import type { OpenGenerativeUIContent } from "../OpenGenerativeUIRenderer";
 import { SandboxFunctionsKey } from "../../providers/keys";
 import type { SandboxFunction } from "../../types";
@@ -846,5 +850,98 @@ describe("OpenGenerativeUIRenderer", () => {
       expect(cssIdx).toBeGreaterThan(headOpenIdx);
       expect(cssIdx).toBeLessThan(titleIdx);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool renderer placeholder-message timer lifecycle.
+//
+// While the call is in progress and placeholderMessages exist, a 5s interval
+// cycles the visible message. When the call completes the renderer returns
+// null, but the interval keeps firing until unmount unless it is cleared on
+// completion. React's equivalent keys its effect on props.status and clears
+// the interval when status === Complete. The Vue watcher must do the same:
+// include status in the watch source and clear the interval on completion.
+// ---------------------------------------------------------------------------
+describe("OpenGenerativeUIToolRenderer placeholder timer", () => {
+  function renderTool(props: {
+    status: ToolCallStatus;
+    placeholderMessages?: string[];
+    result?: string;
+  }) {
+    return render(OpenGenerativeUIToolRenderer, {
+      props: {
+        name: "generateSandboxedUi",
+        args: { placeholderMessages: props.placeholderMessages },
+        status: props.status,
+        result: props.result,
+      },
+    });
+  }
+
+  // The placeholderMessages array is referentially STABLE across rerenders, so
+  // the only thing that changes between in-progress and complete is `status`.
+  // Pre-fix the watch source is `() => props.args.placeholderMessages` only, so
+  // flipping status (same array ref) does NOT re-run the watcher and the
+  // interval is never cleared — it keeps ticking until unmount. Post-fix the
+  // watch source includes status, so completion re-runs the watcher, clears the
+  // interval, and (being complete) does not re-arm.
+  //
+  // RED pre-fix: the captured interval callback still fires after completion
+  // (the timer was never cleared). GREEN post-fix: it is cleared, so it never
+  // fires again.
+  it("clears the placeholder interval when the call completes", async () => {
+    vi.useFakeTimers();
+    let ticks = 0;
+    const realSetInterval = window.setInterval.bind(window);
+    const setSpy = vi.spyOn(window, "setInterval").mockImplementation(((
+      cb: TimerHandler,
+      ms?: number,
+    ) => {
+      // Wrap the renderer's callback so we can count actual ticks while still
+      // arming a real fake-timers interval that advanceTimersByTime drives.
+      const wrapped = () => {
+        ticks += 1;
+        if (typeof cb === "function") (cb as () => void)();
+      };
+      return realSetInterval(wrapped, ms);
+    }) as typeof window.setInterval);
+
+    const messages = ["First", "Second", "Third"];
+    const mounted = renderTool({
+      status: ToolCallStatus.Executing,
+      placeholderMessages: messages,
+    });
+
+    // A 5s interval is armed while in progress.
+    expect(setSpy).toHaveBeenCalledTimes(1);
+
+    // While in progress, the interval fires on each 5s tick.
+    vi.advanceTimersByTime(5000);
+    expect(ticks).toBe(1);
+    vi.advanceTimersByTime(5000);
+    expect(ticks).toBe(2);
+
+    // The call completes — SAME placeholderMessages reference, only status
+    // changes. The renderer returns null AND the interval must be cleared.
+    const clearSpy = vi.spyOn(window, "clearInterval");
+    await mounted.rerender({
+      name: "generateSandboxedUi",
+      args: { placeholderMessages: messages },
+      status: ToolCallStatus.Complete,
+      result: "done",
+    });
+    // The interval was cleared on completion (without unmounting).
+    expect(clearSpy).toHaveBeenCalled();
+    // No new interval was armed for the completed call.
+    expect(setSpy).toHaveBeenCalledTimes(1);
+
+    // Advancing well past several tick windows must produce NO further ticks —
+    // proving the timer is gone rather than merely producing no visible output.
+    const ticksAtCompletion = ticks;
+    vi.advanceTimersByTime(20000);
+    expect(ticks).toBe(ticksAtCompletion);
+
+    mounted.unmount();
   });
 });

--- a/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
+++ b/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
@@ -1159,6 +1159,136 @@ describe("OpenGenerativeUIRenderer", () => {
       expect(agentIdx).toBeLessThan(bodyIdx);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Finding 1 — agent css is injected RAW into `<style>` elements (the final
+  // document via injectCssIntoHtml, and the streaming preview head via
+  // buildPreviewHeadHtml). A css value containing `</style>` closes the style
+  // element early, and any markup after it becomes LIVE content in the sandbox
+  // iframe. The renderer must neutralize the element-close sequence with the
+  // SAME escape semantics react-core ships: `css.replace(/<(\/style)/gi,
+  // "<\\$1")` — a CSS backslash is inserted into the `/`, which is lossless
+  // inside a CSS string (`"\/"` unescapes to `/`) and a dead token otherwise.
+  // The previewStyles HOISTED from the agent's real `<style>` elements are NOT
+  // escaped: they were extracted from already-terminated style elements, so by
+  // construction they cannot contain a live `</style>`.
+  // -------------------------------------------------------------------------
+  describe("agent css style-close escaping (Finding 1)", () => {
+    function finalFrameContent(): string {
+      const finalCall = mockCreate.mock.calls.find(
+        ([, options]) =>
+          typeof options.frameContent === "string" &&
+          options.frameContent !== "<head></head><body></body>",
+      );
+      return (finalCall?.[1].frameContent as string) ?? "";
+    }
+    function lastHeadPayload(): string | undefined {
+      const headCalls = mockRun.mock.calls.filter(
+        (c) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("document.head.innerHTML"),
+      );
+      return headCalls.length
+        ? (headCalls[headCalls.length - 1]![0] as string)
+        : undefined;
+    }
+
+    // The reviewer's repro: a css value that closes the style element early and
+    // injects a live <script>. RED pre-fix: the raw `</style>` terminates the
+    // injected `<style>` and the `<script>alert(1)</script>` lands as live markup
+    // in the frameContent (unbalanced style tags). GREEN post-fix: the close
+    // sequence is escaped, the style tags stay balanced, and no live
+    // `<script>alert` exists outside a style element.
+    it("escapes a </style> breakout in the final document so no live script is injected", async () => {
+      renderRenderer({
+        html: ["<head></head><body><div>x</div></body>"],
+        htmlComplete: true,
+        css: "a{}</style><script>alert(1)</script>",
+        cssComplete: true,
+      });
+      await flushImport();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const frameContent = finalFrameContent();
+
+      // No LIVE <script>alert lands outside a <style> element. Strip every
+      // <style>…</style> region, then assert the malicious tag is not in what
+      // remains (it survives only as inert text inside the escaped style block).
+      const outsideStyles = frameContent.replace(
+        /<style[^>]*>[\s\S]*?<\/style>/gi,
+        "",
+      );
+      expect(outsideStyles).not.toContain("<script>alert");
+
+      // Style tags are balanced: every `<style…>` has a matching `</style>`.
+      const openCount = (frameContent.match(/<style[^>]*>/gi) ?? []).length;
+      const closeCount = (frameContent.match(/<\/style>/gi) ?? []).length;
+      expect(openCount).toBe(closeCount);
+
+      // The escape is exactly react-core's: the `/` of the close gains a CSS
+      // backslash, so the literal `<\/style` token is present.
+      expect(frameContent).toContain("<\\/style");
+    });
+
+    // Lossless inside a CSS string: `content: "</style>"` is a legitimate value.
+    // The escape inserts a backslash before the `/` — `"</style>"` becomes
+    // `"<\/style>"`, which a CSS parser reads back as the original `</style>`
+    // (the backslash is an identity escape on `/`). The injected style element
+    // stays balanced (the close is neutralized) and the escaped token is present.
+    it("losslessly escapes a CSS string value of </style>", async () => {
+      const css = '.x::before{content:"</style>"}';
+      renderRenderer({
+        html: ["<head></head><body><div>x</div></body>"],
+        htmlComplete: true,
+        css,
+        cssComplete: true,
+      });
+      await flushImport();
+      const frameContent = finalFrameContent();
+
+      // The raw, element-closing `</style>` from the css does NOT appear as-is
+      // inside the value (it was escaped); the escaped form does.
+      expect(frameContent).toContain('content:"<\\/style>"');
+      // Style tags stay balanced — the value's `</style>` did not close the tag.
+      const openCount = (frameContent.match(/<style[^>]*>/gi) ?? []).length;
+      const closeCount = (frameContent.match(/<\/style>/gi) ?? []).length;
+      expect(openCount).toBe(closeCount);
+    });
+
+    // The preview head payload (buildPreviewHeadHtml) injects the agent css into
+    // a `<style>` too, so it must escape the close sequence with identical
+    // semantics. RED pre-fix: the raw `</style>` from the css closes the agent
+    // style element inside the head innerHTML payload. GREEN post-fix: the
+    // payload carries the escaped `<\/style` token and no bare element-closing
+    // `</style>` from the css value.
+    it("escapes a </style> breakout in the preview head payload", async () => {
+      renderRenderer({
+        css: "a{}</style><script>alert(1)</script>",
+        cssComplete: true,
+        html: ["<body><div>Preview body</div>"],
+        htmlComplete: false,
+        generating: true,
+      });
+      await flushImport();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      mockPromiseResolve();
+      await mockPromise;
+      await flushImport();
+
+      const headPayload = lastHeadPayload();
+      expect(headPayload).toBeDefined();
+      // The payload is `document.head.innerHTML = ${JSON.stringify(headHtml)}`,
+      // so the single CSS backslash from the escape is doubled by JSON.stringify
+      // → the runtime payload carries `<\\/style` (two literal backslashes).
+      expect(headPayload!).toContain("<\\\\/style");
+      // The breakout signature — a bare element-closing `</style>` immediately
+      // followed by the `<script>` — must be gone. Pre-fix the raw css produced
+      // exactly `</style><script>`; post-fix the close is escaped so that exact
+      // sequence never appears (the only real `</style>` is the agent block's own
+      // terminator, preceded by `</script>`).
+      expect(headPayload!).not.toContain("</style><script>");
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
+++ b/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
@@ -621,6 +621,51 @@ describe("OpenGenerativeUIRenderer", () => {
       expect(headPayload).toBeDefined();
       expect(headPayload!).toContain(agentCss);
     });
+
+    // Case C — the overflow guard must survive every `document.head.innerHTML`
+    // assignment. The preview sandbox shows scrollbars unless `html, body {
+    // overflow: hidden }` is part of the assigned head content: a one-time
+    // appendChild on ready is clobbered by the first head reassignment built
+    // from headParts (extracted styles + agent css). Mirroring react-core's
+    // buildPreviewHeadHtml, the guard must be the FIRST part of the head payload
+    // on EVERY assignment.
+    //
+    // RED pre-fix: the head payload contained only the extracted styles + agent
+    // css, no guard. GREEN post-fix: the guard leads the payload, then extracted
+    // styles, then agent css.
+    it("keeps the overflow guard first in the head assignment, then extracted styles, then agent css", async () => {
+      const agentCss = "main { color: rebeccapurple; }";
+      const inlineStyleContent = ".inline-block { color: seagreen; }";
+      const previewHtml = `<head><style>${inlineStyleContent}</style></head><body><div class="inline-block">Preview body</div>`;
+
+      renderRenderer({
+        css: agentCss,
+        cssComplete: true,
+        html: [previewHtml],
+        htmlComplete: false,
+        generating: true,
+      });
+      await flushImport();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      mockPromiseResolve();
+      await mockPromise;
+      await flushImport();
+
+      const headPayload = lastHeadPayload();
+      expect(headPayload).toBeDefined();
+      const guardIdx = headPayload!.indexOf(
+        "html, body { overflow: hidden !important; }",
+      );
+      const inlineStyleIdx = headPayload!.indexOf(inlineStyleContent);
+      const agentCssIdx = headPayload!.indexOf(agentCss);
+      expect(guardIdx).toBeGreaterThan(-1);
+      expect(inlineStyleIdx).toBeGreaterThan(-1);
+      expect(agentCssIdx).toBeGreaterThan(-1);
+      // Guard FIRST, then extracted styles, then agent css.
+      expect(guardIdx).toBeLessThan(inlineStyleIdx);
+      expect(inlineStyleIdx).toBeLessThan(agentCssIdx);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
+++ b/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
@@ -1297,9 +1297,14 @@ describe("OpenGenerativeUIRenderer", () => {
 // While the call is in progress and placeholderMessages exist, a 5s interval
 // cycles the visible message. When the call completes the renderer returns
 // null, but the interval keeps firing until unmount unless it is cleared on
-// completion. React's equivalent keys its effect on props.status and clears
-// the interval when status === Complete. The Vue watcher must do the same:
-// include status in the watch source and clear the interval on completion.
+// completion. React's equivalent keys its effect on `[messages?.length,
+// props.status]`: it clears the interval when status === Complete, jumps the
+// index to the newest message only when the COUNT changes, and re-arms only on
+// a count/status change. The Vue watcher must do the same — its sources are the
+// stable scalars `[() => placeholderMessages?.length, () => props.status]`, NOT
+// a fresh `[messages, status]` array literal (which Vue compares by reference,
+// firing every tick: forcing the index to length-1 and re-arming the interval
+// on every placeholderMessages identity change during streaming).
 // ---------------------------------------------------------------------------
 describe("OpenGenerativeUIToolRenderer placeholder timer", () => {
   function renderTool(props: {
@@ -1379,6 +1384,80 @@ describe("OpenGenerativeUIToolRenderer placeholder timer", () => {
     const ticksAtCompletion = ticks;
     vi.advanceTimersByTime(20000);
     expect(ticks).toBe(ticksAtCompletion);
+
+    mounted.unmount();
+  });
+
+  // Pin (Finding 2b): a NEW placeholderMessages array with the SAME length must
+  // NOT reset visibleMessageIndex and must NOT tear down / re-arm the interval.
+  // A fresh-array-literal watch source (or jumping the index on every re-run)
+  // would, on each streaming tick that re-creates the array at the same length,
+  // snap the visible message back to the newest and restart the 5s timer. With
+  // the scalar `[length, status]` sources and the count-keyed jump, an identity
+  // change at constant length is a no-op: the watcher does not even re-run.
+  //
+  // RED (fresh-array-literal source): the same-length rerender re-runs the
+  // watcher, clears+re-arms the interval, and resets the index to length-1.
+  // GREEN (scalar sources): no re-run, so no clear, no re-arm, and the cycled
+  // index is preserved.
+  it("does not reset the index or restart the interval on a same-length placeholderMessages change", async () => {
+    vi.useFakeTimers();
+    const setSpy = vi.spyOn(window, "setInterval");
+    const clearSpy = vi.spyOn(window, "clearInterval");
+
+    // Distinct strings per array so the rendered text reveals the exact index:
+    // index 0 → "A0"/"B0", index 2 (length-1) → "A2"/"B2".
+    const first = ["A0", "A1", "A2"];
+    const mounted = renderTool({
+      status: ToolCallStatus.Executing,
+      placeholderMessages: first,
+    });
+
+    // Armed once; index jumped to the newest (length-1 = 2) → shows "A2".
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    await nextTick();
+    expect(
+      mounted.getByTestId("open-generative-ui-tool-placeholder").textContent,
+    ).toBe("A2");
+
+    // One 5s tick cycles the index to (2 + 1) % 3 = 0 → shows "A0". The interval
+    // callback mutates a ref; flush the Vue scheduler (microtask-based, so it
+    // runs under fake timers) so the DOM reflects the new index.
+    vi.advanceTimersByTime(5000);
+    await nextTick();
+    expect(
+      mounted.getByTestId("open-generative-ui-tool-placeholder").textContent,
+    ).toBe("A0");
+
+    setSpy.mockClear();
+    clearSpy.mockClear();
+
+    // A NEW array of the SAME length (3) streams in — identity changed, count
+    // and status unchanged.
+    const second = ["B0", "B1", "B2"];
+    await mounted.rerender({
+      name: "generateSandboxedUi",
+      args: { placeholderMessages: second },
+      status: ToolCallStatus.Executing,
+      result: undefined,
+    });
+
+    // The interval was neither cleared nor re-armed (the watcher did not re-run).
+    expect(clearSpy).not.toHaveBeenCalled();
+    expect(setSpy).not.toHaveBeenCalled();
+    // The index was NOT reset to length-1: it stayed at 0, now showing the new
+    // array's first element "B0" (a reset would show "B2").
+    await nextTick();
+    expect(
+      mounted.getByTestId("open-generative-ui-tool-placeholder").textContent,
+    ).toBe("B0");
+
+    // The original interval is still live: a further 5s tick advances 0 → 1.
+    vi.advanceTimersByTime(5000);
+    await nextTick();
+    expect(
+      mounted.getByTestId("open-generative-ui-tool-placeholder").textContent,
+    ).toBe("B1");
 
     mounted.unmount();
   });

--- a/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
+++ b/packages/vue/src/v2/components/__tests__/OpenGenerativeUIRenderer.test.ts
@@ -513,4 +513,113 @@ describe("OpenGenerativeUIRenderer", () => {
       expect(options.frameContent).not.toBe("<head></head><body></body>");
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Preview cascade must match the FINAL document's cascade, region by region.
+  // The final document (ensureHead + injectCssIntoHtml) injects the agent css
+  // immediately before </head>, i.e. AFTER any existing head content. So the
+  // preview head must order extracted head styles BEFORE the agent css. A
+  // body-region style stays in the preview BODY, matching the final document
+  // where it sits in the body after the head css.
+  // -------------------------------------------------------------------------
+  describe("preview cascade parity", () => {
+    function lastHeadPayload(): string | undefined {
+      const headCalls = mockRun.mock.calls.filter(
+        (c) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("document.head.innerHTML"),
+      );
+      return headCalls.length
+        ? (headCalls[headCalls.length - 1]![0] as string)
+        : undefined;
+    }
+    function lastBodyPayload(): string | undefined {
+      const bodyCalls = mockRun.mock.calls.filter(
+        (c) =>
+          typeof c[0] === "string" &&
+          (c[0] as string).includes("document.body.innerHTML"),
+      );
+      return bodyCalls.length
+        ? (bodyCalls[bodyCalls.length - 1]![0] as string)
+        : undefined;
+    }
+
+    // Case A — HEAD-region style: the preview head order (extracted head style
+    // < agent css) matches the final document, where injectCssIntoHtml puts the
+    // agent css after the existing head content (immediately before </head>).
+    //
+    // RED pre-fix: the renderer pushed the agent css BEFORE the extracted style,
+    // flipping the cascade relative to the final document. GREEN post-fix: the
+    // extracted style precedes the agent css.
+    it("orders preview head as head-region style -> agent css (matches final document)", async () => {
+      const agentCss = "main { color: rebeccapurple; }";
+      const inlineStyleContent = ".inline-block { color: seagreen; }";
+      // Inline style in the HEAD element (before <body>). The preview receives
+      // the streaming prefix (no closing tags); both must order the inline style
+      // before the agent css param.
+      const previewHtml = `<head><style>${inlineStyleContent}</style></head><body><div class="inline-block">Preview body</div>`;
+
+      renderRenderer({
+        css: agentCss,
+        cssComplete: true,
+        html: [previewHtml],
+        htmlComplete: false,
+        generating: true,
+      });
+      await flushImport();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      mockPromiseResolve();
+      await mockPromise;
+      await flushImport();
+
+      const headPayload = lastHeadPayload();
+      expect(headPayload).toBeDefined();
+      const inlineStyleIdx = headPayload!.indexOf(inlineStyleContent);
+      const agentCssIdx = headPayload!.indexOf(agentCss);
+      expect(inlineStyleIdx).toBeGreaterThan(-1);
+      expect(agentCssIdx).toBeGreaterThan(-1);
+      // Preview cascade: extracted head style first, agent css param LAST.
+      expect(inlineStyleIdx).toBeLessThan(agentCssIdx);
+    });
+
+    // Case B — BODY-region style: the style stays in the PREVIEW BODY (the body
+    // innerHTML run call contains it; the head payload does NOT), matching the
+    // final document where a body-region style also sits in the body after the
+    // head css.
+    //
+    // RED pre-fix: extractCompleteStyles hoisted EVERY style, so this body style
+    // was injected into the preview head and stripped from the preview body —
+    // the opposite of the final document. GREEN post-fix: it is left in the body.
+    it("keeps a body-region style in the preview body, not the head (matches final document)", async () => {
+      const agentCss = "main { color: rebeccapurple; }";
+      const bodyStyleContent = ".body-block { color: seagreen; }";
+      // The complete <style> sits INSIDE <body>, so it is body-region.
+      const previewHtml = `<body><div class="body-block">Preview body</div><style>${bodyStyleContent}</style>`;
+
+      renderRenderer({
+        css: agentCss,
+        cssComplete: true,
+        html: [previewHtml],
+        htmlComplete: false,
+        generating: true,
+      });
+      await flushImport();
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+
+      mockPromiseResolve();
+      await mockPromise;
+      await flushImport();
+
+      const headPayload = lastHeadPayload();
+      const bodyPayload = lastBodyPayload();
+      // Body-region style lives in the body payload, never hoisted to the head.
+      expect(bodyPayload).toBeDefined();
+      expect(bodyPayload!).toContain(bodyStyleContent);
+      if (headPayload) expect(headPayload).not.toContain(bodyStyleContent);
+      // The agent css is still applied to the head.
+      expect(headPayload).toBeDefined();
+      expect(headPayload!).toContain(agentCss);
+    });
+  });
 });

--- a/packages/vue/src/v2/lib/__tests__/processPartialHtml.test.ts
+++ b/packages/vue/src/v2/lib/__tests__/processPartialHtml.test.ts
@@ -533,3 +533,88 @@ describe("processPartialHtml — trailing-entity strip (intended tradeoff)", () 
     expect(processPartialHtml("<p>R&D")).toBe("<p>R");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Content after </body> must be RETAINED in the body (final-document parity).
+// The final document is mounted whole; a browser reparents anything that
+// appears after </body> INTO the body (it is body content, not a wrapper).
+// jsdom (the browser-equivalent parser) confirms:
+//   new JSDOM("<body><p>x</p></body><div>after</div>").window.document
+//     .body.innerHTML === "<p>x</p><div>after</div>"
+//   new JSDOM("<body><p>x</p></body><style>.z{color:green}</style>")…
+//     .body.innerHTML === "<p>x</p><style>.z{color:green}</style>"
+// So the preview must NOT truncate at </body>; it removes the </body> token
+// (mask-located, like the </html> strip) and keeps processing what follows.
+// A complete <style> after </body> is body-region: it must NOT be hoisted and
+// MUST stay in the body (hoist-XOR-keep, never both, never neither).
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — content after </body> retained", () => {
+  // RED pre-fix: step 5 sliced off everything from </body>, so <div>after</div>
+  // vanished from the preview while the final document reparents it into the body.
+  it("R: content after </body> is kept (browser reparents it into the body)", () => {
+    const input = "<body><p>x</p></body><div>after</div>";
+    expect(processPartialHtml(input)).toBe("<p>x</p><div>after</div>");
+  });
+
+  // The </body> token itself is removed (it is not visible content); the body's
+  // inner content and the reparented trailing content are concatenated, exactly
+  // as the browser flattens them in the final document.
+  it("R': the </body> token is removed, not rendered", () => {
+    const body = processPartialHtml("<body><p>x</p></body><div>after</div>");
+    expect(body).not.toContain("</body>");
+  });
+
+  // A complete <style> after </body> is body-region per browser reparenting:
+  // NOT hoisted, KEPT in the body (the hoist-XOR-keep invariant must hold).
+  it("R'': a complete <style> after </body> stays in the body, not hoisted", () => {
+    const input = "<body><p>x</p></body><style>.z{color:green}</style>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe(""); // body-region after </body> → never hoisted
+    expect(body).toBe("<p>x</p><style>.z{color:green}</style>"); // kept in body
+  });
+
+  // Full document: head hoists, body content + post-</body> content both land in
+  // the body; the </html> wrapper is still stripped. Matches jsdom body.innerHTML
+  // ("<p>x</p><div>after</div>") for the same input.
+  it("R''': full document with content after </body></html> keeps the trailing content", () => {
+    const input =
+      "<html><head><title>t</title></head><body><p>x</p></body><div>after</div></html>";
+    expect(processPartialHtml(input)).toBe("<p>x</p><div>after</div>");
+  });
+
+  // A </body> token inside a surviving complete <style> must NOT be treated as
+  // the structural close (masking guards it), so the style — and the content
+  // after it — stay intact.
+  it("R'''': </body> token inside CSS content is not the structural close", () => {
+    const input =
+      '<body><style>.a::after{content:"</body>"}</style><p>p</p></body><div>after</div>';
+    expect(processPartialHtml(input)).toBe(
+      '<style>.a::after{content:"</body>"}</style><p>p</p><div>after</div>',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REFUTED reviewer finding (pinned, no source change): a reviewer claimed that
+// rejecting a self-closing `<script src="x.js"/>` makes the preview "more
+// aggressive than the final document" by dropping the trailing `<p>b</p>`.
+// In HTML5 a `<script>` start tag is NOT self-closing — the `/` before `>` is
+// ignored, the element stays OPEN, and everything up to a real `</script>` is
+// consumed as script content (and never rendered). jsdom confirms:
+//   new JSDOM('<div>a</div><script src="x.js"/><p>b</p>').window.document
+//     .body.innerHTML === '<div>a</div><script src="x.js"><p>b</p></script>'
+//   → script.textContent === "<p>b</p>", 0 rendered <p> elements.
+// So the final document does NOT render <p>b</p> either; the preview's stripping
+// of everything from `<script` onward yields the SAME visible output. Parity
+// holds — the finding is refuted and no source changes.
+// ---------------------------------------------------------------------------
+describe("processPartialHtml — script-with-trailing-slash parity (refuted finding, pinned)", () => {
+  it('S: <script src="x.js"/> swallows the following <p> in both preview and final document', () => {
+    // The trailing `<p>b</p>` is script content in HTML5 (not self-closing), so
+    // it is invisible in the final document. The preview likewise drops it — the
+    // visible result is identical (`<div>a</div>`), so there is no divergence.
+    const input = '<div>a</div><script src="x.js"/><p>b</p>';
+    expect(processPartialHtml(input)).toBe("<div>a</div>");
+  });
+});

--- a/packages/vue/src/v2/lib/__tests__/processPartialHtml.test.ts
+++ b/packages/vue/src/v2/lib/__tests__/processPartialHtml.test.ts
@@ -244,17 +244,25 @@ describe("processPartialHtml / extractCompleteStyles — shared boundary parity"
     );
   });
 
-  // Case D — RED pre-fix: a <body> token nested inside a complete <head> block
-  // made the two functions classify the trailing top-level `.s{}` differently →
-  // dropped from BOTH. NEW rule: the head element is stripped wholesale (its
-  // nested <body> token cannot fake the real boundary via masking), and the
-  // top-level `.s{}` is body-region — kept in the body, not hoisted.
-  it("D: <body> token nested in a <head> block → top-level style kept in body", () => {
+  // Case D — UPDATED to browser parity (the old pin asserted buggy behavior).
+  // Input: `<head>x<body>y</head><style>.s{}</style><body>real</body>`. The old
+  // pin expected `<style>.s{}</style>real` (the whole `<head>x<body>y</head>` was
+  // treated as one head element and dropped, taking `x` and `y` with it — the
+  // very Finding-1 over-greedy `</head>` pairing). jsdom (the oracle) shows the
+  // head closes at the FIRST boundary, the flow TEXT `x`, so `x` (and the later
+  // `y`) are body content and `.s{}` is body-region:
+  //   new JSDOM("<head>x<body>y</head><style>.s{}</style><body>real</body>")
+  //     .window.document.head.innerHTML === ""
+  //     .window.document.body.innerHTML === "xy<style>.s{}</style>real"
+  // The `<body>`/`</body>`/`</head>` tags are consumed as structure; `.s{}` is
+  // never hoisted (no head element survives). The masking intent is unchanged —
+  // a `<body>` inside CSS/a comment still cannot fake a boundary (see C/C'/M').
+  it("D: text + nested body in the head region → head closes at the text, .s{} kept in body", () => {
     const input = "<head>x<body>y</head><style>.s{}</style><body>real</body>";
     const hoisted = extractCompleteStyles(input);
     const body = processPartialHtml(input);
-    expect(hoisted).toBe(""); // .s{} is top-level, not in a head element
-    expect(body).toBe("<style>.s{}</style>real"); // kept in body, not dropped
+    expect(hoisted).toBe(""); // no head element survives ⇒ .s{} is body-region
+    expect(body).toBe("xy<style>.s{}</style>real"); // browser parity (jsdom)
   });
 
   // Case E — RED pre-fix: step 5's `/<body[^>]*>/i` (no word boundary) matched
@@ -349,13 +357,18 @@ describe("processPartialHtml / extractCompleteStyles — HTML comment masking", 
 });
 
 // ---------------------------------------------------------------------------
-// Unclosed <head> with body markup: the preview must agree with the final
-// document's effective rendering (ensureHead + injectCssIntoHtml leave the
-// in-head css in the head and the body content in the body when no </head> is
-// emitted —
-// browsers implicitly close <head> at <body>). Content must never vanish.
+// Unclosed <head> implicit close: the preview must agree with the final
+// document's effective rendering. A browser closes <head> at the FIRST of a
+// <body> token, a flow (non-head-permitted) start tag, or non-whitespace text —
+// leaving the in-head css in the head and everything from the boundary onward in
+// the body. Content must never vanish. jsdom (the browser-equivalent parser) is
+// the oracle for every expectation here:
+//   new JSDOM("<head><style>.a{}</style><body><p>hi</p></body>")…
+//     head.innerHTML === "<style>.a{}</style>", body.innerHTML === "<p>hi</p>"
+//   new JSDOM("<head><style>.a{}</style><p>x</p>")…
+//     head.innerHTML === "<style>.a{}</style>", body.innerHTML === "<p>x</p>"
 // ---------------------------------------------------------------------------
-describe("processPartialHtml / extractCompleteStyles — unclosed <head> implicit body close", () => {
+describe("processPartialHtml / extractCompleteStyles — unclosed <head> implicit close", () => {
   // RED pre-fix: extractCompleteStyles hoisted nothing (no complete head
   // element) AND step 3 stripped the unclosed <head> to end-of-string →
   // preview rendered empty while the final document renders the content.
@@ -369,7 +382,9 @@ describe("processPartialHtml / extractCompleteStyles — unclosed <head> implici
   });
 
   // The implicit close also strips the head region's non-style markup from the
-  // body, keeping only the body content (parity with the final document).
+  // body, keeping only the body content (parity with the final document). Title
+  // text content does NOT trigger the flow/text close — title is head-permitted
+  // RCDATA, so the scan skips its inner text to </title>.
   it("L': unclosed <head> with title + style before <body> → only body content remains", () => {
     const input =
       "<head><title>t</title><style>.a{}</style><body><p>x</p></body>";
@@ -377,21 +392,224 @@ describe("processPartialHtml / extractCompleteStyles — unclosed <head> implici
     expect(extractCompleteStyles(input)).toBe("<style>.a{}</style>");
   });
 
-  // Pin: an unclosed <head> with content but NO <body> token is still stripped
-  // (a head genuinely still streaming its own content). Current behavior — kept
-  // stable by the implicit-close rule firing ONLY on a <body> token.
-  it("M: unclosed <head> + content, NO <body> → stripped (pinned)", () => {
-    const input = "<head><style>.a{}</style><p>x</p>";
+  // Pin (re-scoped): an unclosed <head> whose region so far contains ONLY
+  // head-permitted content and has NO body/flow/text boundary is genuinely still
+  // streaming its own head — it is stripped (preview empty until more streams in,
+  // self-correcting). NOTE: a browser would already hoist `.a` (jsdom body ""),
+  // but mid-stream we defer to "" rather than flash a partial head. This pin is
+  // kept stable by the streaming guard in findHeadContentEnd (no boundary ⇒ null
+  // ⇒ no span ⇒ unterminated-head strip).
+  it("M: unclosed <head>, head-permitted content only, NO body/flow/text → stripped (pinned)", () => {
+    const input = "<head><style>.a{}</style>";
     expect(processPartialHtml(input)).toBe("");
     expect(extractCompleteStyles(input)).toBe("");
   });
 
-  // A <body> token inside a style/comment within the unclosed head must NOT be
-  // taken as the implicit close (masking guards it).
-  it("M': <body> token inside CSS in an unclosed head is not the implicit close", () => {
-    const input = '<head><style>.a{content:"<body>"}</style><p>x</p>';
-    // No REAL <body> token ⇒ unclosed head with no body ⇒ stripped (pinned).
+  // Pin (re-scoped): a <body> token inside a style/comment within an unclosed
+  // head must NOT be taken as the implicit close (masking guards it). With only
+  // head-permitted content and NO real body/flow/text boundary, the head is still
+  // streaming ⇒ stripped. jsdom agrees the body is "" here.
+  it("M': <body> token inside CSS in an unclosed head is not the implicit close (still streaming → stripped)", () => {
+    const input = '<head><style>.a{content:"<body>"}</style>';
+    // No REAL boundary ⇒ unclosed head still streaming ⇒ stripped (pinned).
     expect(processPartialHtml(input)).toBe("");
+    expect(extractCompleteStyles(input)).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FINDING 1 — the </head> pairing must not cross a <body> boundary. The old
+// scan paired a <head> open with the FIRST </head> ANYWHERE after it, even past
+// a <body> token, so body content was swallowed into the "head element" and the
+// preview went BLANK. A browser closes the head at the implicit <body> boundary
+// FIRST; a </head> after <body> is a stray close. jsdom is the oracle:
+//   "<head><style>.a{}</style><body><p>hi</p></head>" → body "<p>hi</p>"
+//   "<head><body><style>.b{}</style></head>"          → body "<style>.b{}</style>"
+//   "<head><style>.a{}</style><body>x</body><head><style>.b{}</style></head>"
+//                              → hoist ".a" only, body "x<style>.b{}</style>"
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — FINDING 1: </head> pairing bounded by <body>", () => {
+  // RED pre-fix: body "" (everything through the trailing </head> read as one
+  // head element). jsdom: head "<style>.a{}</style>", body "<p>hi</p>".
+  it("F1.a: <head>…</head> spanning past <body> → in-head style hoisted, body content kept", () => {
+    const input = "<head><style>.a{}</style><body><p>hi</p></head>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.a{}</style>"); // implicit close at <body>
+    expect(body).toBe("<p>hi</p>"); // not swallowed into the head element
+    expect(body).not.toContain("<style"); // hoisted XOR kept
+    expect(body).not.toContain("</head>"); // stray close not leaked
+  });
+
+  // RED pre-fix: the style after the implicit <body> close was hoisted (head
+  // span crossed <body>). jsdom keeps it in the body: head "", body
+  // "<style>.b{}</style>".
+  it("F1.b: <head><body><style> → style is body-region (not hoisted), kept in body", () => {
+    const input = "<head><body><style>.b{}</style></head>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe(""); // .b is after the implicit <body> close
+    expect(body).toBe("<style>.b{}</style>"); // kept in body, stray head tags dropped
+  });
+
+  // RED pre-fix: BOTH styles hoisted (head span ran to the trailing </head>).
+  // jsdom hoists only .a; .b (in the body-region second head) stays in the body.
+  it("F1.c: head, body, then a second head → only the first in-head style hoisted", () => {
+    const input =
+      "<head><style>.a{}</style><body>x</body><head><style>.b{}</style></head>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.a{}</style>"); // only the pre-<body> head
+    expect(body).toBe("x<style>.b{}</style>"); // body keeps x + the late style; stray head tags dropped
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FINDING 2 — a <head> nested inside the body region is body content, never a
+// head element; its style must NOT be hoisted (a cascade flip at the swap), and
+// the stray <head>/</head> tags are dropped while the content is kept. jsdom:
+//   "<head><style>.h{}</style></head><body><head><style>.b{}</style></head><p>x</p></body>"
+//     → head "<style>.h{}</style>", body "<style>.b{}</style><p>x</p>"
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — FINDING 2: nested <head> in body is body content", () => {
+  // RED pre-fix: both .h and .b hoisted. jsdom hoists only .h; .b stays in body.
+  it("F2.a: <head> inside <body> → only the real head's style hoisted, nested kept in body", () => {
+    const input =
+      "<head><style>.h{}</style></head><body><head><style>.b{}</style></head><p>x</p></body>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.h{}</style>"); // only the pre-<body> head element
+    expect(body).toBe("<style>.b{}</style><p>x</p>"); // nested head tags dropped, content kept
+    expect(body).not.toContain("<head>"); // stray nested head open dropped
+    expect(body).not.toContain("</head>"); // stray nested head close dropped
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FINDING 3 — a stray standalone </head> (unmatched by a counted head element)
+// must be stripped mask-aware, never leaked into the preview body as literal
+// text. jsdom:
+//   "<head>z</head><body><div>real</div></body></head>" → body "z<div>real</div>"
+//   "<head><style>.a{}</style></head><body><div>real</div></body></head>"
+//     → head "<style>.a{}</style>", body "<div>real</div>"
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — FINDING 3: stray </head> stripped, not leaked", () => {
+  // RED pre-fix: body "<div>real</div></head>" (the trailing </head> leaked).
+  // jsdom: body "z<div>real</div>" (z is flow text → head closes before it).
+  it("F3.a: trailing stray </head> after the body is stripped (text in head is body content)", () => {
+    const input = "<head>z</head><body><div>real</div></body></head>";
+    const body = processPartialHtml(input);
+    expect(body).toBe("z<div>real</div>");
+    expect(body).not.toContain("</head>"); // no literal close-tag leak
+  });
+
+  // RED pre-fix: body "<div>real</div></head>". jsdom: head "<style>.a{}</style>",
+  // body "<div>real</div>".
+  it("F3.b: in-head style hoisted, trailing stray </head> stripped from the body", () => {
+    const input =
+      "<head><style>.a{}</style></head><body><div>real</div></body></head>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.a{}</style>");
+    expect(body).toBe("<div>real</div>");
+    expect(body).not.toContain("</head>");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FINDING 4 — a browser opens the body once; a SECOND <body> open token is
+// dropped and its following markup stays in the one body. Step 5 must remove
+// EVERY <body> open, not just the first. jsdom:
+//   "<body><p>a</p><body><p>b</p>" → body "<p>a</p><p>b</p>"
+// ---------------------------------------------------------------------------
+describe("processPartialHtml — FINDING 4: every <body> open removed (duplicate not leaked)", () => {
+  // RED pre-fix: body "<p>a</p><body><p>b</p>" (the second <body> leaked as text).
+  it("F4.a: duplicate <body> open is removed, both contents kept in the body", () => {
+    const input = "<body><p>a</p><body><p>b</p>";
+    const body = processPartialHtml(input);
+    expect(body).toBe("<p>a</p><p>b</p>");
+    expect(body).not.toContain("<body"); // no duplicate open-tag leak
+  });
+
+  // A duplicate <body> with attributes is also dropped (quote-aware open scan).
+  it("F4.b: duplicate <body> with attributes is removed, no attribute fragments leak", () => {
+    const input = '<body class="x"><p>a</p><body data-y="b>c"><p>b</p>';
+    const body = processPartialHtml(input);
+    expect(body).toBe("<p>a</p><p>b</p>");
+    expect(body).not.toContain("<body");
+    expect(body).not.toContain('c">'); // quoted > did not truncate the open tag
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FINDING 5 — the implicit head close fires at the first NON-HEAD content, not
+// only at a <body> token: a flow (non-head-permitted) start tag, or the first
+// non-whitespace text character. Otherwise an unclosed head with flow content
+// and no <body> would strip to end-of-string and render BLANK while the browser
+// renders the flow content. jsdom is the oracle:
+//   "<head><style>.a{}</style><p>x</p>"     → head "<style>.a{}</style>", body "<p>x</p>"
+//   "<head><style>.a{}</style>plaintext"    → head "<style>.a{}</style>", body "plaintext"
+//   "<head><style>.a{}</style><div>flow</div><style>.b{}</style>"
+//                            → head "<style>.a{}</style>", body "<div>flow</div><style>.b{}</style>"
+// The streaming guard (head-permitted-only content with no boundary, or a
+// trailing incomplete tag) is pinned by case M / M' above.
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — FINDING 5: implicit close at flow / text", () => {
+  // RED pre-fix: hoist "" AND body "" (unclosed head stripped to end-of-string).
+  // jsdom hoists .a and renders <p>x</p>.
+  it("F5.a: unclosed <head> + style + flow tag (no <body>) → style hoisted, flow kept", () => {
+    const input = "<head><style>.a{}</style><p>x</p>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.a{}</style>"); // implicit close at <p>
+    expect(body).toBe("<p>x</p>"); // flow content kept, not stripped
+    expect(body).not.toContain("<style");
+  });
+
+  // RED pre-fix: hoist "" AND body "". jsdom: head ".a", body "plaintext"
+  // (non-whitespace text closes the head).
+  it("F5.b: unclosed <head> + style + bare text (no <body>) → style hoisted, text kept", () => {
+    const input = "<head><style>.a{}</style>plaintext";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.a{}</style>"); // implicit close at the text
+    expect(body).toBe("plaintext");
+  });
+
+  // RED pre-fix: hoist "" AND body "". jsdom hoists only the pre-flow .a; the
+  // post-flow .b is body-region.
+  it("F5.c: flow tag splits head/body → only the pre-flow style hoisted, rest in body", () => {
+    const input = "<head><style>.a{}</style><div>flow</div><style>.b{}</style>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.a{}</style>"); // pre-flow, in head
+    expect(body).toBe("<div>flow</div><style>.b{}</style>"); // post-flow, in body
+  });
+
+  // Leading whitespace inside the head does NOT close it; the style after the
+  // whitespace is still in-head. jsdom: head "...<style>.a{}</style>...", body "<p>x</p>".
+  it("F5.d: whitespace in head is not flow content; style stays in head", () => {
+    const input = "<head>   <style>.a{}</style>   <p>x</p>";
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.a{}</style>"); // whitespace did not close the head
+    expect(processPartialHtml(input)).toBe("<p>x</p>");
+  });
+
+  // A trailing INCOMPLETE tag prefix (`<ti`) is indeterminate mid-stream — the
+  // head must NOT close on it. With only head-permitted content + an incomplete
+  // tail, the head is still streaming ⇒ stripped (self-corrects next chunk).
+  it("F5.e: trailing incomplete tag does not trigger the implicit close (still streaming → stripped)", () => {
+    const input = "<head><style>.a{}</style><ti";
+    expect(processPartialHtml(input)).toBe("");
+    expect(extractCompleteStyles(input)).toBe("");
+  });
+
+  // A meta (head-permitted void) followed by flow closes the head at the flow
+  // tag. jsdom: head "<meta charset=...>", body "<h1>title</h1>".
+  it("F5.f: head-permitted void tag then flow → flow content kept in body", () => {
+    const input = "<head><meta charset='utf-8'><h1>title</h1>";
+    expect(processPartialHtml(input)).toBe("<h1>title</h1>");
+    expect(extractCompleteStyles(input)).toBe(""); // no styles
   });
 });
 

--- a/packages/vue/src/v2/lib/__tests__/processPartialHtml.test.ts
+++ b/packages/vue/src/v2/lib/__tests__/processPartialHtml.test.ts
@@ -427,6 +427,37 @@ describe("processPartialHtml — tolerant <html> wrapper strip", () => {
       '<style>.a{content:"<html>"}</style><div>x</div>',
     );
   });
+
+  // Close-tag analogs of N''' — the trailing </html> strip must also run on a
+  // MASKED string (like every other structural op in the module), so a </html>
+  // token inside SURVIVING body content is never deleted.
+  //
+  // RED pre-fix: the final `result.replace(/<\/html>/gi, "")` ran on the UNMASKED
+  // result, so a </html> token inside CSS content was deleted, emptying it.
+  it("N'''': </html> token inside CSS content cannot fake the wrapper strip", () => {
+    const input =
+      '<div>x</div><style>.a::before{content:"</html>"}</style><div>y</div>';
+    expect(processPartialHtml(input)).toBe(
+      '<div>x</div><style>.a::before{content:"</html>"}</style><div>y</div>',
+    );
+  });
+
+  // RED pre-fix: a </html> token inside a complete comment's text was deleted.
+  it("N''''': </html> token inside a complete comment is preserved", () => {
+    const input = "<div>x</div><!-- ex </html> --><div>y</div>";
+    expect(processPartialHtml(input)).toBe(
+      "<div>x</div><!-- ex </html> --><div>y</div>",
+    );
+  });
+
+  // RED pre-fix: a </html> token inside a <style> open-tag attribute value was
+  // deleted (the attribute is blanked in the mask, so masked search skips it).
+  it("N'''''': </html> token in a <style> attribute value is preserved", () => {
+    const input = '<style data-note="</html>">.a{}</style>';
+    expect(processPartialHtml(input)).toBe(
+      '<style data-note="</html>">.a{}</style>',
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -482,5 +513,23 @@ describe("processPartialHtml / extractCompleteStyles — quote-aware style open 
     expect(processPartialHtml(input)).toBe(
       '<style data-y="</body>">.foo{}</style><p>p</p>',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trailing-entity strip — BY DESIGN, not a bug. At a chunk boundary, a literal
+// `&D` is indistinguishable from a developing entity (`&Dagger;`, `&Delta;`, …),
+// so the conservative choice is to drop the dangling `&…` run. This is GREEN
+// against current source (it pins existing behavior, no source change). It
+// self-corrects: the next chunk re-renders with the full text, and the final
+// document never runs processPartialHtml at all (the renderer renders the
+// completed HTML directly), so `R&D` is whole in the delivered result.
+// ---------------------------------------------------------------------------
+describe("processPartialHtml — trailing-entity strip (intended tradeoff)", () => {
+  it("Q: a chunk ending in literal `&D` drops the dangling run mid-stream", () => {
+    // `<p>R&D` → `<p>R`: `&D` could be the start of `&Dagger;`, so the strip is
+    // conservative. Pinned as intended — corrected on the next chunk and at
+    // completion (the final document does not run processPartialHtml).
+    expect(processPartialHtml("<p>R&D")).toBe("<p>R");
   });
 });

--- a/packages/vue/src/v2/lib/__tests__/processPartialHtml.test.ts
+++ b/packages/vue/src/v2/lib/__tests__/processPartialHtml.test.ts
@@ -279,4 +279,208 @@ describe("processPartialHtml / extractCompleteStyles — shared boundary parity"
     expect(hoisted).toBe(""); // NOT hoisted
     expect(body).toBe("<style>.head-style{}</style>BODYTEXT"); // kept in body
   });
+
+  // Case G — quote-aware open-tag scan: a quoted `>` inside a <body> attribute
+  // must not truncate the open tag early and leak attribute fragments.
+  it("G: quoted > in a <body> attribute → no attribute fragments leak", () => {
+    const input = '<body data-x="a>b"><p>hi</p></body>';
+    const body = processPartialHtml(input);
+    expect(body).toBe("<p>hi</p>");
+    expect(body).not.toContain('b">');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTML comments must be masked like style/script content: a tag-lookalike
+// inside a complete comment is real comment text (never stripped, never a
+// structural boundary), and an unterminated trailing comment must vanish
+// (the final document's `-->` swallows the remainder). Each case asserts the
+// never-both / never-neither invariant against the FINAL document's rendering.
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — HTML comment masking", () => {
+  // RED pre-fix: maskBlockContent masked only style/script, so the <script>
+  // inside the comment was stripped, gutting the comment.
+  it("H: complete comment containing a <script> is preserved, not gutted", () => {
+    const input =
+      "<body><p>before</p><!-- <script>x</script> --><p>after</p></body>";
+    expect(processPartialHtml(input)).toBe(
+      "<p>before</p><!-- <script>x</script> --><p>after</p>",
+    );
+  });
+
+  // RED pre-fix: the comment's <body> token was taken as the body boundary,
+  // dropping the leading <div>.
+  it("I: complete comment containing a <body> token is not a boundary", () => {
+    const input = "<div>a</div><!-- <body> --><p>b</p>";
+    expect(processPartialHtml(input)).toBe(
+      "<div>a</div><!-- <body> --><p>b</p>",
+    );
+  });
+
+  // A complete comment containing </body> must not fake the close boundary.
+  it("I': complete comment containing </body> is not a close boundary", () => {
+    const input = "<body><p>a</p><!-- </body> --><p>b</p></body>";
+    expect(processPartialHtml(input)).toBe("<p>a</p><!-- </body> --><p>b</p>");
+  });
+
+  // Streaming case: an unterminated trailing comment must not fake structure and
+  // must vanish from the preview body (consistent with the final document, where
+  // the eventual `-->` comments out everything after `<!--`).
+  it("J: unterminated trailing comment is dropped (no fake structure)", () => {
+    expect(processPartialHtml("<div>a</div><!-- partial")).toBe("<div>a</div>");
+    // …even when the partial comment contains a `>` (so step 2's bare
+    // incomplete-tag strip cannot catch it).
+    expect(processPartialHtml("<div>a</div><!-- partial <span> more")).toBe(
+      "<div>a</div>",
+    );
+  });
+
+  // Invariant under an unterminated comment: a COMPLETE style before it is kept
+  // in the body exactly once; a complete-looking style INSIDE the unterminated
+  // comment is neither hoisted nor leaked (the final document comments it out).
+  it("K: complete style before an unterminated comment → kept once, inner style not hoisted/leaked", () => {
+    const input = "<style>.a{}</style><div>x</div><!-- <style>.b{}</style";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(body).toBe("<style>.a{}</style><div>x</div>");
+    expect(hoisted).toBe(""); // .a is top-level (no head); .b is inside the comment
+    expect(body).not.toContain(".b"); // inner style text did not leak
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unclosed <head> with body markup: the preview must agree with the final
+// document's effective rendering (ensureHead + injectCssIntoHtml leave the
+// in-head css in the head and the body content in the body when no </head> is
+// emitted —
+// browsers implicitly close <head> at <body>). Content must never vanish.
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — unclosed <head> implicit body close", () => {
+  // RED pre-fix: extractCompleteStyles hoisted nothing (no complete head
+  // element) AND step 3 stripped the unclosed <head> to end-of-string →
+  // preview rendered empty while the final document renders the content.
+  it("L: unclosed <head> + <body> + content → style hoisted, body content kept (not dropped)", () => {
+    const input = "<head><style>.a{color:red}</style><body><p>hi</p></body>";
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    expect(hoisted).toBe("<style>.a{color:red}</style>"); // hoisted (in-head)
+    expect(body).toBe("<p>hi</p>"); // body content preserved
+    expect(body).not.toContain("<style"); // not double-injected
+  });
+
+  // The implicit close also strips the head region's non-style markup from the
+  // body, keeping only the body content (parity with the final document).
+  it("L': unclosed <head> with title + style before <body> → only body content remains", () => {
+    const input =
+      "<head><title>t</title><style>.a{}</style><body><p>x</p></body>";
+    expect(processPartialHtml(input)).toBe("<p>x</p>");
+    expect(extractCompleteStyles(input)).toBe("<style>.a{}</style>");
+  });
+
+  // Pin: an unclosed <head> with content but NO <body> token is still stripped
+  // (a head genuinely still streaming its own content). Current behavior — kept
+  // stable by the implicit-close rule firing ONLY on a <body> token.
+  it("M: unclosed <head> + content, NO <body> → stripped (pinned)", () => {
+    const input = "<head><style>.a{}</style><p>x</p>";
+    expect(processPartialHtml(input)).toBe("");
+    expect(extractCompleteStyles(input)).toBe("");
+  });
+
+  // A <body> token inside a style/comment within the unclosed head must NOT be
+  // taken as the implicit close (masking guards it).
+  it("M': <body> token inside CSS in an unclosed head is not the implicit close", () => {
+    const input = '<head><style>.a{content:"<body>"}</style><p>x</p>';
+    // No REAL <body> token ⇒ unclosed head with no body ⇒ stripped (pinned).
+    expect(processPartialHtml(input)).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The <html> wrapper open tag must be stripped wherever it appears (not only
+// when leading), mask-aware and quote-aware, so a prefixed wrapper does not
+// leak the tag into the preview body.
+// ---------------------------------------------------------------------------
+describe("processPartialHtml — tolerant <html> wrapper strip", () => {
+  // RED pre-fix: only a LEADING <html> was stripped (`/^<html\b[^>]*>/i`), so a
+  // prefixed wrapper survived into the preview body.
+  it("N: <html> with a text prefix → wrapper stripped, surrounding content kept", () => {
+    const input = "text<html><body><p>x</p></body>";
+    expect(processPartialHtml(input)).toBe("text<p>x</p>");
+  });
+
+  it("N': leading <html> still stripped (existing behavior preserved)", () => {
+    const input = "<html><body><p>x</p></body></html>";
+    expect(processPartialHtml(input)).toBe("<p>x</p>");
+  });
+
+  // Word-bounded: <htmlfoo> is not the html wrapper.
+  it("N'': <htmlfoo> is not <html> → left intact", () => {
+    const input = "<htmlfoo>kept</htmlfoo>";
+    expect(processPartialHtml(input)).toBe("<htmlfoo>kept</htmlfoo>");
+  });
+
+  // Masked search: an <html> token inside a surviving style block cannot fake
+  // the wrapper strip.
+  it("N''': <html> token inside CSS content cannot fake the wrapper strip", () => {
+    const input = '<style>.a{content:"<html>"}</style><div>x</div>';
+    expect(processPartialHtml(input)).toBe(
+      '<style>.a{content:"<html>"}</style><div>x</div>',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// maskBlockContent open-tag end scan must be quote-aware: a quoted `>` in a
+// style/script open tag must not mis-locate the content boundary and leave the
+// real CSS unmasked, where a <body>/<html> token could fake a boundary.
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — quote-aware style open tag", () => {
+  // RED pre-fix: maskBlockContent used full.indexOf(">"), so the quoted `>` in
+  // `data-x="a>b"` mis-located the content start, leaving `b">…` and the CSS
+  // unmasked — the unmasked <body> token then faked a body boundary.
+  it("O: quoted > in a <style> open tag → <body> token in its CSS cannot fake a boundary", () => {
+    const input =
+      '<style data-x="a>b">.foo{content:"<body>"}</style><div>real</div>';
+    const body = processPartialHtml(input);
+    const hoisted = extractCompleteStyles(input);
+    // The complete style stays intact in the body; <div>real</div> is kept (the
+    // <body> token inside the CSS did not split anything off as a boundary).
+    expect(body).toBe(
+      '<style data-x="a>b">.foo{content:"<body>"}</style><div>real</div>',
+    );
+    expect(hoisted).toBe("");
+    // Removing the complete style leaves clean markup — no orphan CSS fragment.
+    expect(body.replace(/<style\b[^>]*>[\s\S]*?<\/style>/i, "")).toBe(
+      "<div>real</div>",
+    );
+  });
+
+  // Same hazard with </body> in the CSS and a quoted `>` in the open tag.
+  it("O': quoted > in a <style> open tag → </body> token in its CSS cannot fake a close", () => {
+    const input =
+      '<body><style data-x="a>b">.foo{content:"</body>"}</style><p>p</p></body>';
+    expect(processPartialHtml(input)).toBe(
+      '<style data-x="a>b">.foo{content:"</body>"}</style><p>p</p>',
+    );
+  });
+
+  // RED pre-fix: the unterminated-block strip ran on the UNMASKED string, so a
+  // `<head>` token inside a complete style's ATTRIBUTE value was matched as an
+  // unterminated trailing <head> and the document was truncated to it. The strip
+  // now measures on a masked copy (attribute values blanked), so the complete
+  // style survives intact.
+  it("P: <head> token in a <style> attribute value does not trigger the unterminated-block strip", () => {
+    const input = '<style data-y="<head>">.foo{}</style><div>d</div>';
+    expect(processPartialHtml(input)).toBe(
+      '<style data-y="<head>">.foo{}</style><div>d</div>',
+    );
+  });
+
+  // Same class for a `</body>` token in an attribute value (no fake close).
+  it("P': </body> token in a <style> attribute value does not fake a body close", () => {
+    const input = '<body><style data-y="</body>">.foo{}</style><p>p</p></body>';
+    expect(processPartialHtml(input)).toBe(
+      '<style data-y="</body>">.foo{}</style><p>p</p>',
+    );
+  });
 });

--- a/packages/vue/src/v2/lib/__tests__/processPartialHtml.test.ts
+++ b/packages/vue/src/v2/lib/__tests__/processPartialHtml.test.ts
@@ -13,10 +13,46 @@ describe("processPartialHtml", () => {
     expect(processPartialHtml('<div>Hello<span class="fo')).toBe("<div>Hello");
   });
 
-  it("strips complete <style> blocks", () => {
+  it("hoists a complete <head>-element style and strips it from the body", () => {
+    // A <style> inside a complete <head>…</head> element is hoisted into the
+    // preview <head> by extractCompleteStyles, so processPartialHtml removes it
+    // (the whole head element is stripped) — never both, never neither.
+    const input =
+      "<head><style>.foo { color: red; }</style></head><body><div>Hello</div><p>World</p></body>";
+    expect(processPartialHtml(input)).toBe("<div>Hello</div><p>World</p>");
+  });
+
+  it("keeps a top-level pre-<body> style in the body (final-document parity)", () => {
+    // No <head> element wraps this style, so it is NOT hoisted. The final
+    // document (ensureHead + injectCssIntoHtml) leaves a top-level pre-<body>
+    // style in the body region (after the head css in document order), so the
+    // preview body must keep it too.
+    const input =
+      "<style>.foo { color: red; }</style><body><div>Hello</div><p>World</p></body>";
+    expect(processPartialHtml(input)).toBe(
+      "<style>.foo { color: red; }</style><div>Hello</div><p>World</p>",
+    );
+  });
+
+  it("keeps a complete <style> block in the body region (cascade parity)", () => {
+    // A complete <style> INSIDE the body stays in place — browsers apply
+    // <style> anywhere and the final document likewise keeps body-region styles
+    // in the body (after the head css in document order), so the preview must
+    // not hoist it to the head.
+    const input =
+      "<body><div>Hello</div><style>.foo { color: red; }</style><p>World</p></body>";
+    expect(processPartialHtml(input)).toBe(
+      "<div>Hello</div><style>.foo { color: red; }</style><p>World</p>",
+    );
+  });
+
+  it("keeps a complete <style> block when there is no <body> (whole string is body region)", () => {
+    // With no <body> tag the entire string is the body region, so a complete
+    // <style> is kept exactly where it appears (and extractCompleteStyles
+    // hoists nothing — there is no <head> element).
     const input =
       "<div>Hello</div><style>.foo { color: red; }</style><p>World</p>";
-    expect(processPartialHtml(input)).toBe("<div>Hello</div><p>World</p>");
+    expect(processPartialHtml(input)).toBe(input);
   });
 
   it("strips complete <script> blocks", () => {
@@ -56,9 +92,20 @@ describe("processPartialHtml", () => {
     expect(processPartialHtml(input)).toBe("<p>Content</p>");
   });
 
-  it("handles no <body> tag", () => {
+  it("handles no <body> tag — returns full processed string", () => {
     const input = "<div><p>Just content</p></div>";
     expect(processPartialHtml(input)).toBe("<div><p>Just content</p></div>");
+  });
+
+  it("handles combined edge cases: full document with styles, scripts, and incomplete tag", () => {
+    const input =
+      '<html><head><style>body { margin: 0; }</style></head><body><div>Hello</div><script>console.log("x")</script><p>World</p><span class="in';
+    expect(processPartialHtml(input)).toBe("<div>Hello</div><p>World</p>");
+  });
+
+  it("handles body content with incomplete style at end", () => {
+    const input = "<body><div>Content</div><style>.partial {";
+    expect(processPartialHtml(input)).toBe("<div>Content</div>");
   });
 });
 
@@ -67,18 +114,169 @@ describe("extractCompleteStyles", () => {
     expect(extractCompleteStyles("<div>Hello</div>")).toBe("");
   });
 
-  it("extracts a single complete style block", () => {
+  it("returns empty string for empty input", () => {
+    expect(extractCompleteStyles("")).toBe("");
+  });
+
+  it("hoists a style inside a complete <head> element", () => {
     const input =
-      "<div>Hello</div><style>.foo { color: red; }</style><p>World</p>";
+      "<head><style>body { margin: 0; }</style></head><body><p>Hi</p></body>";
     expect(extractCompleteStyles(input)).toBe(
-      "<style>.foo { color: red; }</style>",
+      "<style>body { margin: 0; }</style>",
     );
   });
 
-  it("extracts multiple complete style blocks", () => {
-    const input = "<style>a{}</style><div>X</div><style>b{}</style>";
+  it("hoists multiple styles inside a complete <head> element", () => {
+    const input =
+      "<head><style>a{}</style><style>b{}</style></head><body></body>";
     expect(extractCompleteStyles(input)).toBe(
       "<style>a{}</style><style>b{}</style>",
     );
+  });
+
+  it("does NOT hoist a top-level pre-<body> style (final-document parity)", () => {
+    // No <head> element, so the style is body-region in the final document and
+    // must NOT be hoisted (it stays in the preview body via processPartialHtml).
+    const input =
+      "<style>.foo { color: red; }</style><body><p>World</p></body>";
+    expect(extractCompleteStyles(input)).toBe("");
+  });
+
+  it("does NOT hoist multiple top-level pre-<body> styles", () => {
+    const input =
+      "<style>a{}</style><div>X</div><style>b{}</style><body></body>";
+    expect(extractCompleteStyles(input)).toBe("");
+  });
+
+  it("does NOT hoist when the only complete style is top-level pre-<body>", () => {
+    // An incomplete trailing style is never hoisted; the complete one here is
+    // top-level (no <head> element), so nothing is hoisted.
+    const input = "<style>.complete{}</style><style>.incomplete {<body></body>";
+    expect(extractCompleteStyles(input)).toBe("");
+  });
+
+  it("does NOT extract styles from the body region (left in place for cascade parity)", () => {
+    // A complete <style> inside the body must stay in the body — hoisting it
+    // would flip its cascade position at the preview→final swap.
+    const input =
+      "<body><div>Hi</div><style>.foo { color: red; }</style></body>";
+    expect(extractCompleteStyles(input)).toBe("");
+  });
+
+  it("hoists only the head-element style, leaving the body-region style behind", () => {
+    // Mixed document: the head-element style is hoisted, the body style is not.
+    const input =
+      "<head><style>.head { color: red; }</style></head><body><style>.body { color: blue; }</style></body>";
+    expect(extractCompleteStyles(input)).toBe(
+      "<style>.head { color: red; }</style>",
+    );
+  });
+
+  it("hoists nothing when there is no <body> tag (whole string is body region)", () => {
+    const input = "<style>.foo { color: red; }</style><div>Hi</div>";
+    expect(extractCompleteStyles(input)).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Review finding-cluster: the two functions must derive head/body boundaries
+// from ONE shared masked computation. Each case asserts on BOTH functions —
+// every complete <style> is hoisted XOR retained (never both, never neither),
+// no raw CSS text leaks into the body, and the body keeps exactly what the
+// FINAL document (ensureHead + injectCssIntoHtml) renders in its body region.
+// ---------------------------------------------------------------------------
+describe("processPartialHtml / extractCompleteStyles — shared boundary parity", () => {
+  // Case A — RED pre-fix: a style in a complete <head> element with NO <body>
+  // streamed yet was dropped from BOTH regions (extractCompleteStyles found no
+  // <body> boundary so hoisted nothing; processPartialHtml stripped the whole
+  // head block). NEW rule: hoist the head-element style; keep the trailing
+  // top-level content in the body.
+  it("A: head-element style with no <body> yet → hoisted, not dropped", () => {
+    const input = "<head><style>.h{color:red}</style></head><div>content</div>";
+    const hoisted = extractCompleteStyles(input);
+    const body = processPartialHtml(input);
+    expect(hoisted).toBe("<style>.h{color:red}</style>"); // hoisted
+    expect(body).toBe("<div>content</div>"); // NOT in body
+    expect(body).not.toContain("<style"); // no duplicate / no leak
+  });
+
+  // Case B — RED pre-fix: a chunk ending mid-`<body` tag made
+  // extractCompleteStyles see a phantom boundary (hoist) while processPartialHtml
+  // stripped the incomplete trailing tag and kept the style — DOUBLE-INJECTED.
+  // NEW rule: no <head> element ⇒ never hoist; keep the style in the body only.
+  it("B: chunk ends mid-<body> tag → style kept in body only, not double-injected", () => {
+    const input = '<style>.a{}</style><div>h</div><body class="x';
+    const hoisted = extractCompleteStyles(input);
+    const body = processPartialHtml(input);
+    expect(hoisted).toBe(""); // NOT hoisted (no head element)
+    expect(body).toBe("<style>.a{}</style><div>h</div>"); // kept once in body
+  });
+
+  // Case C — RED pre-fix: a legal CSS token `content:"<body>"` split the style
+  // mid-block in both functions; the raw CSS tail `"}</style>` leaked into the
+  // preview body. NEW rule: masking hides the CSS token, the real <body> is
+  // found, the complete style is kept intact in the body, no leak.
+  it("C: <body> token inside CSS content → style intact in body, no raw CSS leak", () => {
+    const input =
+      '<style>div::before{content:"<body>"}</style><body><p>P</p></body>';
+    const hoisted = extractCompleteStyles(input);
+    const body = processPartialHtml(input);
+    expect(hoisted).toBe(""); // NOT hoisted (no head element)
+    expect(body).toBe('<style>div::before{content:"<body>"}</style><p>P</p>');
+    // No orphan CSS fragment: removing the complete style leaves clean markup.
+    expect(body.replace(/<style\b[^>]*>[\s\S]*?<\/style>/i, "")).toBe(
+      "<p>P</p>",
+    );
+  });
+
+  // Case C (comment variant) — same class: a `<body` token inside a CSS comment.
+  it("C': <body> token inside a CSS comment → style intact in body, no leak", () => {
+    const input =
+      "<style>/* hide <body /> default */ .x{}</style><body><p>P</p></body>";
+    const hoisted = extractCompleteStyles(input);
+    const body = processPartialHtml(input);
+    expect(hoisted).toBe("");
+    expect(body).toBe(
+      "<style>/* hide <body /> default */ .x{}</style><p>P</p>",
+    );
+    expect(body.replace(/<style\b[^>]*>[\s\S]*?<\/style>/i, "")).toBe(
+      "<p>P</p>",
+    );
+  });
+
+  // Case D — RED pre-fix: a <body> token nested inside a complete <head> block
+  // made the two functions classify the trailing top-level `.s{}` differently →
+  // dropped from BOTH. NEW rule: the head element is stripped wholesale (its
+  // nested <body> token cannot fake the real boundary via masking), and the
+  // top-level `.s{}` is body-region — kept in the body, not hoisted.
+  it("D: <body> token nested in a <head> block → top-level style kept in body", () => {
+    const input = "<head>x<body>y</head><style>.s{}</style><body>real</body>";
+    const hoisted = extractCompleteStyles(input);
+    const body = processPartialHtml(input);
+    expect(hoisted).toBe(""); // .s{} is top-level, not in a head element
+    expect(body).toBe("<style>.s{}</style>real"); // kept in body, not dropped
+  });
+
+  // Case E — RED pre-fix: step 5's `/<body[^>]*>/i` (no word boundary) matched
+  // `<bodyguard …>` and dropped the leading <div>. NEW rule: word-bounded
+  // `/<body[\s>]/i` never matches `<bodyguard>`, so the whole input is body.
+  it("E: <bodyguard> is not <body> → leading <div> retained", () => {
+    const input = '<div>hi</div><bodyguard data-x="1">guarded</bodyguard>';
+    const hoisted = extractCompleteStyles(input);
+    const body = processPartialHtml(input);
+    expect(hoisted).toBe("");
+    expect(body).toBe(input); // leading <div> kept; <bodyguard> untouched
+    expect(body).toContain("<div>hi</div>");
+  });
+
+  // Case F — final-document parity: a top-level pre-<body> style stays in the
+  // BODY region of the assembled document (after the head css), so the preview
+  // body must keep it and the head payload must not.
+  it("F: top-level pre-<body> style stays in the body (matches final document)", () => {
+    const input = "<style>.head-style{}</style><body>BODYTEXT</body>";
+    const hoisted = extractCompleteStyles(input);
+    const body = processPartialHtml(input);
+    expect(hoisted).toBe(""); // NOT hoisted
+    expect(body).toBe("<style>.head-style{}</style>BODYTEXT"); // kept in body
   });
 });

--- a/packages/vue/src/v2/lib/processPartialHtml.ts
+++ b/packages/vue/src/v2/lib/processPartialHtml.ts
@@ -52,14 +52,42 @@
  * swallow the rest of the document once `-->` arrives, so the preview drops it
  * to match the final document's effective rendering).
  *
- * An UNCLOSED `<head>` whose region reaches a `<body[\s>]` token (with no
- * `</head>` first) is treated as if the head closed at that implicit `<body>`
- * boundary — exactly how a browser renders the final document (`ensureHead` +
- * `injectCssIntoHtml` leave the in-head css in the head and the body content in
- * the body when no `</head>` is emitted). So an in-head style there is hoisted
- * and the body content is kept — content never vanishes. An unclosed `<head>`
- * with content but NO `<body>` token is still stripped (a head that is genuinely
- * still streaming its own content).
+ * 3. HEAD/BODY GEOMETRY MATCHES THE BROWSER. The head-element detection in
+ *    `analyzeRegions` partitions the bytes into head vs body exactly where a
+ *    browser does when rendering the final document — never crossing the body
+ *    boundary, never hoisting body-region content:
+ *      • The FIRST masked word-bounded `<body[\s>]` token is the body boundary. A
+ *        `<head>` whose open token starts AT OR AFTER it is body content (a stray
+ *        `<head>` nested in the body), NOT a head element: its tag tokens are
+ *        dropped (step 5) and its content stays in the body, never hoisted.
+ *      • A counted head element's CONTENT ends at the FIRST of an explicit
+ *        `</head>`, the body boundary, a flow (non-head-permitted) START tag, or
+ *        the first non-whitespace TEXT character — the same boundary a browser
+ *        uses (see {@link findHeadContentEnd}). The `</head>` pairing therefore
+ *        NEVER reaches past a `<body>` token: `<head><style>.a{}</style><body>…`
+ *        closes the head at `<body>` (style hoisted, body content kept), it does
+ *        not swallow the body up to a trailing `</head>`. An in-head style before
+ *        the boundary is hoisted; anything from the boundary on stays in the body.
+ *      • A head-permitted element with a text body (`<title>`/`<noscript>`/
+ *        `<template>`, plus the masked `<style>`/`<script>`) is skipped to its
+ *        close so its inner text (`<title>a < b</title>`) is never read as flow.
+ *      • The implicit head close fires at FLOW CONTENT, not only at `<body>`:
+ *        `<head><style>.a{}</style><p>x</p>` (no `<body>` ever) renders `<p>x</p>`
+ *        with `.a` hoisted, NOT a blank preview. Streaming guard: a head whose
+ *        region so far is ONLY head-permitted content with no boundary yet, or a
+ *        trailing incomplete tag (`<ti`, a bare `<`), is genuinely still streaming
+ *        — it yields NO span (stripped, self-correcting next chunk), so the head
+ *        is never closed on an indeterminate tail.
+ *      • STRAY head/body tokens are dropped, not leaked: step 5 removes EVERY
+ *        `<body[\s>]` open (a browser opens the body once — a duplicate `<body>`
+ *        is dropped and its markup stays in the one body), and every stray
+ *        `<head[\s>]`/`</head>` token left in the body (a browser drops the stray
+ *        tag but KEEPS its content) — all mask-aware and quote-aware, the same
+ *        shape as the `</html>` strip.
+ *    All four consumers (style hoist containment, the head-element strip, the
+ *    duplicate-body strip, the stray-head strip) derive from this ONE geometry, so
+ *    the preview body and the hoisted head agree with the final document — a style
+ *    is hoisted XOR kept (never both, never neither) and content never vanishes.
  *
  * Pure functions — no DOM, no Vue.
  */
@@ -158,6 +186,151 @@ export function maskBlockContent(html: string): string {
   return out;
 }
 
+/**
+ * Element names a browser keeps INSIDE `<head>` (HTML "metadata content" plus the
+ * elements the head parser tolerates). Encountering a START tag whose name is NOT
+ * in this set — word-bounded — is flow content and implicitly CLOSES the head, the
+ * same boundary a browser uses when no `</head>` is emitted. Lower-cased; callers
+ * compare against a lower-cased tag name.
+ */
+const HEAD_PERMITTED = new Set([
+  "title",
+  "meta",
+  "link",
+  "style",
+  "script",
+  "base",
+  "noscript",
+  "template",
+]);
+
+/** Head-permitted elements that have NO end tag (void) — their open tag is the
+ * whole element, so the head scan skips just the tag, never hunts a close. */
+const HEAD_VOID = new Set(["meta", "link", "base"]);
+
+/**
+ * Finds where an open `<head>` region's CONTENT ends, scanning the MASKED string
+ * from just after the head open tag (`openEnd`). Mirrors how a browser partitions
+ * the bytes into head vs body when rendering the final document: the head ends at
+ * the FIRST of —
+ *   • an explicit `</head>` close token,
+ *   • a masked word-bounded `<body[\s>]` open token (the implicit body boundary),
+ *   • a START tag whose name is NOT head-permitted (flow content — `<div>`, `<p>`,
+ *     a stray `<html>`, …), or
+ *   • the first non-whitespace TEXT character outside any tag token.
+ * A head-permitted element with a text body (`<title>`, `<noscript>`, `<template>`,
+ * and the already-masked `<style>`/`<script>`) is SKIPPED to its matching close so
+ * its inner text — `<title>a < b</title>` — is never mistaken for flow content
+ * (RCDATA/raw-text parity with the browser). Head-permitted VOID tags
+ * (`<meta>`/`<link>`/`<base>`) skip just the tag.
+ *
+ * Returns the index in the original/masked string where head content ends (the
+ * span is `[openStart, end)`; an explicit `</head>` is NOT included — the stray
+ * `</head>` strip removes it, the same shape as the `</html>` strip). Returns
+ * `null` when the head is GENUINELY STILL STREAMING its own content — content so
+ * far is only head-permitted and the scan runs off the end of the string, OR a
+ * head-permitted text element is unterminated, OR the tail is an incomplete tag
+ * prefix (`<ti`, a bare `<`). A `null` yields NO head span, so the unterminated-
+ * block strip removes the head region (preview empty until more streams in), which
+ * self-corrects on the next chunk — never closing the head on an indeterminate
+ * trailing tag.
+ */
+function findHeadContentEnd(masked: string, openEnd: number): number | null {
+  let i = openEnd;
+  const len = masked.length;
+  while (i < len) {
+    const ch = masked[i]!;
+    if (ch !== "<") {
+      // Whitespace stays in the head; the first non-whitespace text char is flow
+      // content and closes the head. (Masked spans are all spaces, so style/script/
+      // comment content never reads as flow text here.)
+      if (/\s/.test(ch)) {
+        i++;
+        continue;
+      }
+      return i;
+    }
+    // ch === "<": a tag-ish token. Distinguish close tags, comments, the body
+    // boundary, head-permitted elements, and flow start tags.
+    const rest = masked.slice(i);
+    // Explicit </head> close ends the head here.
+    if (/^<\/head[\s>]/i.test(rest) || /^<\/head>/i.test(rest)) {
+      return i;
+    }
+    // The implicit body boundary.
+    if (/^<body[\s>]/i.test(rest)) {
+      return i;
+    }
+    // A complete HTML comment stays in the head (metadata-adjacent); skip it.
+    // (Comment INSIDES are masked to spaces, but the `<!--`/`-->` delimiters are
+    // intact, so we can locate the close.)
+    if (rest.startsWith("<!--")) {
+      const close = masked.indexOf("-->", i + 4);
+      if (close === -1) return null; // unterminated trailing comment → still streaming
+      i = close + 3;
+      continue;
+    }
+    // An incomplete trailing close tag (`</hea`, `</di` with no `>` at end of
+    // string) is indeterminate mid-stream — defer rather than guess.
+    if (/^<\/[a-zA-Z][^>]*$/.test(rest)) {
+      return null;
+    }
+    // Any other COMPLETE close tag (e.g. a stray </p>, </div>) is tolerated inside
+    // the head by the parser without opening the body; skip it.
+    const closeMatch = rest.match(/^<\/([a-zA-Z][^\s/>]*)\s*>/);
+    if (closeMatch) {
+      i += closeMatch[0].length;
+      continue;
+    }
+    // A START tag: read its name (word-bounded). An INCOMPLETE trailing tag prefix
+    // (`<ti`, `<style` / `<div` with no `>`) is indeterminate mid-stream — defer,
+    // never closing the head on it (the trailing-tag handling self-corrects next
+    // chunk). A COMPLETE start tag that is NOT head-permitted is flow content.
+    // A lone trailing `<` (last char) could still grow into a tag next chunk —
+    // indeterminate, defer (the spec's `<` "at end" guard). A `<` followed by a
+    // non-tag-name char (`< b`, `<=x`) can NEVER become a tag, so it is text and
+    // closes the head (browser parity: such a `<` renders as literal text).
+    if (i === len - 1) {
+      return null;
+    }
+    const startMatch = rest.match(/^<([a-zA-Z][^\s/>]*)/);
+    if (!startMatch) {
+      // `<` followed by a non-tag-name char (e.g. `< b`, `<=x`). The browser treats
+      // it as literal text, which closes the head here.
+      return i;
+    }
+    const openTagMatch = rest.match(OPEN_TAG_END);
+    if (!openTagMatch) {
+      // The start tag has no closing `>` yet — incomplete trailing tag → defer.
+      return null;
+    }
+    const name = startMatch[1]!.toLowerCase();
+    if (!HEAD_PERMITTED.has(name)) {
+      // Complete flow start tag → implicit head close at this token.
+      return i;
+    }
+    // Head-permitted start tag, already known to be complete (openTagMatch).
+    const tagEnd = i + openTagMatch[0].length;
+    if (HEAD_VOID.has(name)) {
+      // Void head element (meta/link/base) — no end tag; skip just the open tag.
+      i = tagEnd;
+      continue;
+    }
+    // Non-void head-permitted element (title/noscript/template/style/script): skip
+    // to its matching close so its inner text isn't read as flow. style/script
+    // content is already masked, but title/noscript/template content is not — the
+    // skip-to-close handles all of them uniformly. Unterminated ⇒ still streaming.
+    const closeRe = new RegExp(`</${name}\\s*>`, "i");
+    const closeRel = masked.slice(tagEnd).search(closeRe);
+    if (closeRel === -1) return null;
+    const closeMatchInner = masked.slice(tagEnd + closeRel).match(closeRe)!;
+    i = tagEnd + closeRel + closeMatchInner[0].length;
+  }
+  // Ran off the end with only head-permitted content and no boundary → the head is
+  // still streaming its own content; yield no span (stripped, self-corrects).
+  return null;
+}
+
 interface StyleSpan {
   /** Start index of the complete `<style>` block in the ORIGINAL string. */
   start: number;
@@ -182,40 +355,51 @@ interface Regions {
 function analyzeRegions(html: string): Regions {
   const masked = maskBlockContent(html);
 
+  // The FIRST masked word-bounded `<body[\s>]` open token is the body boundary —
+  // the geometric line a browser draws between head and body. A `<head>` whose
+  // open token starts AT OR AFTER this line is body content (a stray `<head>`
+  // inside the body), not a head element: its tag tokens are dropped from the body
+  // (step 5) and its inner content is kept where it sits, never hoisted. Located
+  // on the masked string so a `<body>` inside CSS/JS or a comment cannot fake it.
+  const firstBodyOpenMatch = masked.match(/<body[\s>]/i);
+  const firstBodyOpen =
+    firstBodyOpenMatch && firstBodyOpenMatch.index !== undefined
+      ? firstBodyOpenMatch.index
+      : Infinity;
+
   // Head ELEMENT spans, `[start, end)`. `<head\b` is word-bounded so it never
   // matches `<header>`; masking ensures a `<head`/`</head>`/`<body>` token inside
   // CSS/JS or a comment cannot open or close a phantom element here.
   //
-  // A head element ends at its `</head>` when one exists. When an opened head has
-  // NO `</head>` but its region reaches a `<body[\s>]` token, the head is treated
-  // as IMPLICITLY closed at that body boundary (span ends just before `<body>`,
-  // which the browser does when rendering the final document) so an in-head style
-  // is still hoisted and the body content is preserved. A head opened with no
-  // `</head>` and no following `<body>` is genuinely still streaming and yields
-  // NO span (the unterminated-block strip step removes it).
+  // GEOMETRY (browser-parity with the final document): a head element counts only
+  // when its OPEN token starts BEFORE the body boundary (`firstBodyOpen`). Its
+  // CONTENT ends — via {@link findHeadContentEnd} — at the FIRST of an explicit
+  // `</head>`, the body boundary, a flow (non-head-permitted) start tag, or
+  // non-whitespace text — exactly where the browser closes the head. The span is
+  // `[openStart, contentEnd)` and EXCLUDES any explicit `</head>` token (the stray
+  // `</head>` strip in step 5 removes it, the same mask-aware shape as `</html>`).
+  // A `null` content end means the head is genuinely still streaming its own
+  // head-permitted content with no boundary yet — NO span (the unterminated-block
+  // strip removes it; the preview self-corrects on the next chunk).
   const headElementSpans: Array<[number, number]> = [];
   // Quote-aware open-tag match (same family as the final document's head matcher)
   // so a quoted `>` in a head attribute does not truncate the tag early and a
   // `<body>` inside the head's own attribute (before openEnd) is not seen by the
-  // implicit-close search below.
+  // content-end search below.
   const headOpenRe = /<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi;
   let headOpen: RegExpExecArray | null;
   while ((headOpen = headOpenRe.exec(masked)) !== null) {
     const openStart = headOpen.index;
+    // A `<head>` at or past the body boundary is body content, not a head element.
+    if (openStart >= firstBodyOpen) break;
     const openEnd = openStart + headOpen[0].length;
-    const closeRel = masked.slice(openEnd).search(/<\/head>/i);
-    if (closeRel !== -1) {
-      const end = openEnd + closeRel + "</head>".length;
-      headElementSpans.push([openStart, end]);
-      headOpenRe.lastIndex = end;
+    const contentEnd = findHeadContentEnd(masked, openEnd);
+    if (contentEnd !== null) {
+      headElementSpans.push([openStart, contentEnd]);
+      headOpenRe.lastIndex = contentEnd;
       continue;
     }
-    // No close — fall back to an implicit `<body>` close.
-    const bodyRel = masked.slice(openEnd).search(/<body[\s>]/i);
-    if (bodyRel !== -1) {
-      headElementSpans.push([openStart, openEnd + bodyRel]);
-    }
-    // Either way there is no further `</head>` to find — stop scanning heads.
+    // Still-streaming head (no boundary yet) — no span; stop scanning heads.
     break;
   }
 
@@ -331,16 +515,19 @@ export function extractCompleteStyles(html: string): string {
  *    `&D` is indistinguishable from a forming `&Dagger;` at the boundary); the
  *    conservative strip self-corrects on the next chunk and at completion (the
  *    FINAL document never runs processPartialHtml).
- * 5. Reduce to the body region: drop the `<body…>` open tag and the `</body…>`
- *    CLOSE TOKEN (but KEEP everything after it), and drop the `<html…>`/`</html>`
+ * 5. Reduce to the body region: drop EVERY `<body…>` open tag and EVERY `</body…>`
+ *    CLOSE TOKEN (but KEEP everything around/after them), drop every stray
+ *    `<head…>`/`</head>` token left in the body, and drop the `<html…>`/`</html>`
  *    structural wrappers — keeping the body's inner content, any surviving
- *    top-level pre-`<body>` content (e.g. a body-region `<style>`), AND any
+ *    top-level pre-`<body>` content (e.g. a body-region `<style>`), the content of
+ *    a stray body-region `<head>` (its tags dropped, content kept), AND any
  *    content after `</body>`. This mirrors how a browser renders the FINAL
  *    document's body region: `<html>`/`<head>`/`<body>`/`</body>`/`</html>` are
- *    tags the parser consumes as structure, while a pre-`<body>` style and any
- *    post-`</body>` markup are real content the browser REPARENTS into the body
- *    (the final document is mounted whole, so the preview must keep them too — a
- *    truncate-at-`</body>` drops content that pops in at the preview→final swap).
+ *    tags the parser consumes as structure (a DUPLICATE `<body>` and a stray
+ *    `<head>`/`</head>` are dropped tags, not visible text), while a pre-`<body>`
+ *    style and any post-`</body>` markup are real content the browser REPARENTS
+ *    into the body (the final document is mounted whole, so the preview must keep
+ *    them too — a truncate-at-`</body>` drops content that pops in at the swap).
  *    The `<body[\s>]`/`</body>`/`<html[\s>]` matches are word-bounded (never
  *    `<bodyguard …>`/`<htmlfoo>`) and run on a freshly masked string so a token
  *    inside a surviving style block or comment cannot fake the boundary. The
@@ -417,19 +604,68 @@ export function processPartialHtml(html: string): string {
     result = removeSpans(result, bodyCloseSpans);
     masked = maskBlockContent(result);
   }
-  const openMatch = masked.match(/<body[\s>]/i);
-  if (openMatch && openMatch.index !== undefined) {
-    // Remove just the `<body…>` open tag, keeping content before and after it.
-    // Quote-aware end-of-tag scan (same shape as the final document's head
-    // matcher) so a quoted `>` in an attribute — `<body data-x="a>b">` — can't
-    // truncate the tag early and leak attribute fragments as visible content.
+  // Remove EVERY `<body…>` open tag, keeping content before and after each. A
+  // browser opens the body only once; a SECOND `<body>` open token is ignored
+  // (its attributes merge, the tag itself is dropped) and the following markup
+  // stays in the one body — `<body><p>a</p><body><p>b</p>` renders `<p>a</p><p>b</p>`.
+  // Removing only the first open would leak the duplicate `<body>` as literal
+  // text, so we loop, locating each open on a freshly masked copy (a `<body>`
+  // inside a surviving style/comment never counts) with the same quote-aware
+  // end-of-tag scan (so a quoted `>` — `<body data-x="a>b">` — can't truncate the
+  // tag early and leak attribute fragments).
+  const bodyOpenSpans: Array<[number, number]> = [];
+  const bodyOpenRe = /<body[\s>]/gi;
+  let bodyOpen: RegExpExecArray | null;
+  while ((bodyOpen = bodyOpenRe.exec(masked)) !== null) {
+    const start = bodyOpen.index;
     const openTag = masked
-      .slice(openMatch.index)
+      .slice(start)
       .match(/^<body(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i);
-    const openTagEnd = openTag
-      ? openMatch.index + openTag[0].length
-      : openMatch.index + masked.slice(openMatch.index).search(/>/) + 1;
-    result = result.slice(0, openMatch.index) + result.slice(openTagEnd);
+    const end = openTag
+      ? start + openTag[0].length
+      : start + masked.slice(start).search(/>/) + 1;
+    bodyOpenSpans.push([start, end]);
+    bodyOpenRe.lastIndex = end;
+  }
+  if (bodyOpenSpans.length > 0) {
+    result = removeSpans(result, bodyOpenSpans);
+    masked = maskBlockContent(result);
+  }
+  // Drop EVERY stray `<head…>` open token and `</head>` close token left in the
+  // body. analyzeRegions already stripped the head ELEMENTS it counted (those
+  // whose open token is before the body boundary), so any `<head>`/`</head>` token
+  // surviving here is body content: a `<head>` nested inside `<body>`, or the
+  // explicit `</head>` of a counted head (whose tag the head span deliberately
+  // excluded). A browser drops these stray tags but KEEPS their inner content —
+  // `<body><head><style>.b{}</style></head><p>x</p>` renders
+  // `<style>.b{}</style><p>x</p>`; a trailing standalone `</head>` after the body
+  // (`<div>real</div></head>`) is dropped, not shown as literal text. Mask-aware +
+  // quote-aware, the same shape as the `</html>` strip. (Done before the `<html>`
+  // strips for symmetry; order is immaterial since all are span-based.)
+  const headTokenSpans: Array<[number, number]> = [];
+  const headOpenStrayRe = /<head[\s>]/gi;
+  let headOpenStray: RegExpExecArray | null;
+  while ((headOpenStray = headOpenStrayRe.exec(masked)) !== null) {
+    const start = headOpenStray.index;
+    const openTag = masked
+      .slice(start)
+      .match(/^<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i);
+    const end = openTag
+      ? start + openTag[0].length
+      : start + masked.slice(start).search(/>/) + 1;
+    headTokenSpans.push([start, end]);
+    headOpenStrayRe.lastIndex = end;
+  }
+  const headCloseStrayRe = /<\/head\s*>/gi;
+  let headCloseStray: RegExpExecArray | null;
+  while ((headCloseStray = headCloseStrayRe.exec(masked)) !== null) {
+    headTokenSpans.push([
+      headCloseStray.index,
+      headCloseStray.index + headCloseStray[0].length,
+    ]);
+  }
+  if (headTokenSpans.length > 0) {
+    result = removeSpans(result, headTokenSpans);
     masked = maskBlockContent(result);
   }
   // Drop the `<html…>` open tag wherever it appears (the browser drops the

--- a/packages/vue/src/v2/lib/processPartialHtml.ts
+++ b/packages/vue/src/v2/lib/processPartialHtml.ts
@@ -30,51 +30,124 @@
  * 2. MASK BEFORE MEASURING. Every structural search (locating `<head>` elements,
  *    the `<body[\s>]` boundary, the `</body>` close, `<script>`/`<head>` element
  *    spans) runs on a single shared masked copy of the input where the CONTENT
- *    of every COMPLETE `<style>`/`<script>` block is replaced with same-length
- *    placeholders. Indices are preserved 1:1, so spans map straight back to the
- *    original. A tag-lookalike token inside CSS/JS — `content:"<body>"`, a
- *    `<body` mention inside a CSS comment, or `x="</head>"` in a script string —
- *    therefore can NEVER fake a boundary or split a style block. Both exported
+ *    of every COMPLETE `<style>`/`<script>` block AND every COMPLETE `<!-- … -->`
+ *    HTML COMMENT is replaced with same-length placeholders. Indices are
+ *    preserved 1:1, so spans map straight back to the original. A tag-lookalike
+ *    token inside CSS/JS or inside a comment — `content:"<body>"`,
+ *    `/* hide <body /> default *​/`, `x="</head>"`, `<!-- <body> -->`,
+ *    `<!-- <script>x</script> -->` — therefore can NEVER fake a boundary, split
+ *    a style block, or be mistaken for real structure to strip. Both exported
  *    functions derive their classifications from this ONE computation
  *    ({@link analyzeRegions}).
  *
- * The `<body[\s>]` / `</body>` / `<head\b` guards are all word-bounded so
- * `<bodyguard …>`, `<header>`, etc. are never mistaken for `<body>`/`<head>`.
+ * The `<body[\s>]` / `</body>` / `<head\b` / `<html[\s>]` guards are all
+ * word-bounded so `<bodyguard …>`, `<header>`, `<htmlfoo>`, etc. are never
+ * mistaken for `<body>`/`<head>`/`<html>`.
  *
- * Incomplete trailing `<style>`/`<script>`/`<head>` blocks (an open tag with no
- * matching close through end of string) are still stripped entirely — an
- * unterminated block mid-stream must never leak its raw CSS/JS text into the
- * preview body as visible content.
+ * Incomplete trailing `<style>`/`<script>`/`<head>` blocks and an incomplete
+ * trailing `<!-- …` comment (an open token with no matching close through end of
+ * string) are still stripped entirely — an unterminated block mid-stream must
+ * never leak its raw CSS/JS/comment text into the preview body as visible
+ * content, and an unterminated comment must never fake structure (it would
+ * swallow the rest of the document once `-->` arrives, so the preview drops it
+ * to match the final document's effective rendering).
+ *
+ * An UNCLOSED `<head>` whose region reaches a `<body[\s>]` token (with no
+ * `</head>` first) is treated as if the head closed at that implicit `<body>`
+ * boundary — exactly how a browser renders the final document (`ensureHead` +
+ * `injectCssIntoHtml` leave the in-head css in the head and the body content in
+ * the body when no `</head>` is emitted). So an in-head style there is hoisted
+ * and the body content is kept — content never vanishes. An unclosed `<head>`
+ * with content but NO `<body>` token is still stripped (a head that is genuinely
+ * still streaming its own content).
  *
  * Pure functions — no DOM, no Vue.
  */
 
-/** Matches a COMPLETE `<style>`/`<script>` block, capturing the tag name and its content. */
-const COMPLETE_STYLE_OR_SCRIPT = /<(style|script)\b[^>]*>([\s\S]*?)<\/\1>/gi;
+/**
+ * Quote-aware open-tag end scan: from a `<style`/`<script`/`<head` (etc.) start,
+ * matches through the tag's `>`, allowing a `>` inside a quoted attribute value
+ * (`<style data-x="a>b">`). Used so the masked content boundary is the REAL end
+ * of the open tag, not a quoted `>` mid-attribute.
+ */
+const OPEN_TAG_END = /^<[a-zA-Z][^\s/>]*(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/;
 
 /**
- * Replaces the CONTENT (between the open tag's `>` and the matching `</tag>`) of
- * every COMPLETE `<style>`/`<script>` block with same-length space placeholders.
- * The tags themselves are untouched. Length-preserving, so every index in the
- * returned string maps 1:1 to the original — callers locate structure on the
- * masked string and slice the matching text out of the original.
+ * Blanks the INSIDES of quoted runs (`"…"` / `'…'`) in a tag string with spaces,
+ * length-preserving. A structural-looking token inside an open tag's attribute
+ * value — `<style data-x="<body>">`, `<script src="</head>">` — must not be left
+ * visible to the structural searches (it would fake a boundary), so its bytes are
+ * blanked while the tag skeleton (name + attribute names + delimiters) is kept.
+ */
+function blankQuotedRuns(tag: string): string {
+  return tag.replace(
+    /"[^"]*"|'[^']*'/g,
+    (q) => q[0] + " ".repeat(q.length - 2) + q[0],
+  );
+}
+
+/**
+ * Replaces the CONTENT of every COMPLETE `<style>`/`<script>` block (between the
+ * open tag's real `>` and the matching `</tag>`) and the CONTENT of every
+ * COMPLETE `<!-- … -->` comment (between `<!--` and `-->`) with same-length space
+ * placeholders, and additionally blanks the quoted attribute values inside those
+ * style/script open tags. The delimiting tokens (and attribute skeletons) are
+ * untouched. Length-preserving, so every index in the returned string maps 1:1 to
+ * the original — callers locate structure on the masked string and slice the
+ * matching text out of the original.
+ *
+ * A single left-to-right pass masks whichever construct opens FIRST at each
+ * position, so the three constructs never interfere: a `<style>` mentioned inside
+ * a comment is masked as comment content (not treated as a real style), and a
+ * `-->` inside CSS is masked as style content (not treated as a comment close).
  */
 function maskBlockContent(html: string): string {
+  const blockRe = /<style\b|<script\b|<!--/gi;
   let out = "";
   let last = 0;
-  COMPLETE_STYLE_OR_SCRIPT.lastIndex = 0;
+  blockRe.lastIndex = 0;
   let match: RegExpExecArray | null;
-  while ((match = COMPLETE_STYLE_OR_SCRIPT.exec(html)) !== null) {
-    const full = match[0];
-    const content = match[2]!;
-    // Content starts right after the open tag's first `>`. (Open tags cannot
-    // contain a `>` here — these are `<style …>`/`<script …>` with no `>` in
-    // their attribute values in any realistic streamed document.)
-    const contentStart = match.index + full.indexOf(">") + 1;
-    const contentEnd = contentStart + content.length;
-    out += html.slice(last, contentStart);
-    out += " ".repeat(content.length);
-    last = contentEnd;
+  while ((match = blockRe.exec(html)) !== null) {
+    const start = match.index;
+    if (start < last) continue; // inside a region already masked
+    const token = match[0];
+    if (token === "<!--") {
+      const close = html.indexOf("-->", start + 4);
+      // Content runs from just after `<!--` to just before `-->`. An
+      // UNTERMINATED comment masks to end of string: anything after `<!--`
+      // would be swallowed by the comment once `-->` arrives, so no tag
+      // lookalike inside it (a complete-looking `<style>`, a `<body>`) may be
+      // mistaken for real structure. The trailing `<!-- …` is removed from the
+      // body by the comment-strip step.
+      const contentStart = start + 4;
+      const contentEnd = close === -1 ? html.length : close;
+      out += html.slice(last, contentStart);
+      out += " ".repeat(contentEnd - contentStart);
+      last = contentEnd;
+      blockRe.lastIndex = close === -1 ? html.length : close + 3;
+    } else {
+      // <style …> / <script …>. Find the REAL end of the open tag quote-aware
+      // (a quoted `>` in an attribute — `<style data-x="a>b">` — must not be
+      // mistaken for the end of the open tag), then mask up to the matching
+      // close tag. The open tag's quoted attribute VALUES are blanked too so a
+      // `<body>`/`</head>` inside one cannot fake a boundary. An unterminated
+      // open tag or block masks to end of string and is removed from the body by
+      // the unterminated-block strip step.
+      const tagName = token.slice(1); // "style" | "script"
+      const openEndMatch = html.slice(start).match(OPEN_TAG_END);
+      const openEnd = openEndMatch
+        ? start + openEndMatch[0].length
+        : html.length;
+      const closeRe = new RegExp(`</${tagName}>`, "i");
+      const closeRel = openEndMatch ? html.slice(openEnd).search(closeRe) : -1;
+      const contentEnd = closeRel === -1 ? html.length : openEnd + closeRel;
+      out += html.slice(last, start);
+      out += blankQuotedRuns(html.slice(start, openEnd));
+      out += " ".repeat(contentEnd - openEnd);
+      last = contentEnd;
+      blockRe.lastIndex =
+        closeRel === -1 ? html.length : contentEnd + `</${tagName}>`.length;
+    }
   }
   out += html.slice(last);
   return out;
@@ -104,17 +177,41 @@ interface Regions {
 function analyzeRegions(html: string): Regions {
   const masked = maskBlockContent(html);
 
-  // Complete <head>…</head> element spans. `<head\b` is word-bounded so it never
-  // matches `<header>`; masking ensures a `<head`/`</head>` token inside CSS/JS
-  // cannot open or close a phantom element here.
+  // Head ELEMENT spans, `[start, end)`. `<head\b` is word-bounded so it never
+  // matches `<header>`; masking ensures a `<head`/`</head>`/`<body>` token inside
+  // CSS/JS or a comment cannot open or close a phantom element here.
+  //
+  // A head element ends at its `</head>` when one exists. When an opened head has
+  // NO `</head>` but its region reaches a `<body[\s>]` token, the head is treated
+  // as IMPLICITLY closed at that body boundary (span ends just before `<body>`,
+  // which the browser does when rendering the final document) so an in-head style
+  // is still hoisted and the body content is preserved. A head opened with no
+  // `</head>` and no following `<body>` is genuinely still streaming and yields
+  // NO span (the unterminated-block strip step removes it).
   const headElementSpans: Array<[number, number]> = [];
-  const headRe = /<head\b[^>]*>[\s\S]*?<\/head>/gi;
-  let headMatch: RegExpExecArray | null;
-  while ((headMatch = headRe.exec(masked)) !== null) {
-    headElementSpans.push([
-      headMatch.index,
-      headMatch.index + headMatch[0].length,
-    ]);
+  // Quote-aware open-tag match (same family as the final document's head matcher)
+  // so a quoted `>` in a head attribute does not truncate the tag early and a
+  // `<body>` inside the head's own attribute (before openEnd) is not seen by the
+  // implicit-close search below.
+  const headOpenRe = /<head(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/gi;
+  let headOpen: RegExpExecArray | null;
+  while ((headOpen = headOpenRe.exec(masked)) !== null) {
+    const openStart = headOpen.index;
+    const openEnd = openStart + headOpen[0].length;
+    const closeRel = masked.slice(openEnd).search(/<\/head>/i);
+    if (closeRel !== -1) {
+      const end = openEnd + closeRel + "</head>".length;
+      headElementSpans.push([openStart, end]);
+      headOpenRe.lastIndex = end;
+      continue;
+    }
+    // No close — fall back to an implicit `<body>` close.
+    const bodyRel = masked.slice(openEnd).search(/<body[\s>]/i);
+    if (bodyRel !== -1) {
+      headElementSpans.push([openStart, openEnd + bodyRel]);
+    }
+    // Either way there is no further `</head>` to find — stop scanning heads.
+    break;
   }
 
   // Every complete <style> block, tagged by containment in a head element. A
@@ -131,25 +228,48 @@ function analyzeRegions(html: string): Regions {
     styleSpans.push({ start, end, inHead });
   }
 
-  // Complete <script> and <head> ELEMENT spans — stripped from the body markup
-  // everywhere. (A head element's in-head <style> blocks are contained within
-  // these spans, so stripping the element removes the hoisted styles too; we
-  // therefore never strip those styles a second time.)
-  const scriptOrHeadSpans: Array<[number, number]> = [];
-  const scriptOrHeadRe = /<(script|head)\b[^>]*>[\s\S]*?<\/\1>/gi;
-  let shMatch: RegExpExecArray | null;
-  while ((shMatch = scriptOrHeadRe.exec(masked)) !== null) {
-    scriptOrHeadSpans.push([shMatch.index, shMatch.index + shMatch[0].length]);
+  // Complete <script> ELEMENT spans — stripped from the body markup everywhere.
+  const scriptSpans: Array<[number, number]> = [];
+  const scriptRe = /<script\b[^>]*>[\s\S]*?<\/script>/gi;
+  let scriptMatch: RegExpExecArray | null;
+  while ((scriptMatch = scriptRe.exec(masked)) !== null) {
+    scriptSpans.push([
+      scriptMatch.index,
+      scriptMatch.index + scriptMatch[0].length,
+    ]);
   }
+
+  // <script> AND <head> ELEMENT spans are both stripped from the body markup.
+  // (A head element's in-head <style> blocks are contained within its span, so
+  // stripping the element removes the hoisted styles too; we therefore never
+  // strip those styles a second time. The implicit-close head span is included
+  // here as well, so an unclosed-head-with-body strips its head region — keeping
+  // the in-head style hoisted XOR present, never both.)
+  const scriptOrHeadSpans = [...scriptSpans, ...headElementSpans];
 
   return { scriptOrHeadSpans, styleSpans };
 }
 
-/** Removes a set of `[start, end)` spans from `html`, applied right-to-left so
+/** Removes a set of `[start, end)` spans from `html`. Spans are coalesced first
+ * (a `<script>` nested inside a `<head>` element yields a script span contained
+ * in the head span — overlapping/contained ranges must be merged or a
+ * right-to-left splice would use a stale offset), then applied right-to-left so
  * earlier offsets stay valid. */
 function removeSpans(html: string, spans: Array<[number, number]>): string {
+  if (spans.length === 0) return html;
+  const sorted = [...spans].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const merged: Array<[number, number]> = [];
+  for (const [start, end] of sorted) {
+    const lastMerged = merged[merged.length - 1];
+    if (lastMerged && start <= lastMerged[1]) {
+      lastMerged[1] = Math.max(lastMerged[1], end);
+    } else {
+      merged.push([start, end]);
+    }
+  }
   let out = html;
-  for (const [start, end] of [...spans].sort((a, b) => b[0] - a[0])) {
+  for (let i = merged.length - 1; i >= 0; i--) {
+    const [start, end] = merged[i]!;
     out = out.slice(0, start) + out.slice(end);
   }
   return out;
@@ -194,9 +314,12 @@ export function extractCompleteStyles(html: string): string {
  *    which leaves it in the body region.
  * 2. Strip an incomplete tag at the very end — e.g. `<div class="fo`.
  * 3. Strip an incomplete (unterminated) trailing `<style>`/`<script>`/`<head>`
- *    block. Complete blocks are already removed (head/script) or intentionally
- *    kept (body/top-level styles), so this only catches a genuinely unterminated
- *    trailing block — raw CSS/JS text must never leak into the preview body.
+ *    block AND an incomplete trailing `<!-- …` comment. Complete blocks/comments
+ *    are already removed (head/script) or masked/intentionally kept (body styles,
+ *    complete comments), so this only catches a genuinely unterminated trailing
+ *    construct — raw CSS/JS text must never leak into the preview body, and an
+ *    unterminated comment must vanish (the final document's `-->` would swallow
+ *    the remainder, so the preview shows nothing for it).
  * 4. Strip an incomplete HTML entity at the end — e.g. `&amp` without `;`.
  * 5. Reduce to the body region: drop the `<body…>` open tag and the matching
  *    `</body>` (and everything after it), and drop the `<html…>`/`</html>`
@@ -205,9 +328,11 @@ export function extractCompleteStyles(html: string): string {
  *    how a browser renders the FINAL document's body region: `<html>`/`<head>`
  *    are wrappers the parser drops, while a pre-`<body>` style is real
  *    cascade-bearing content that stays with the body. The `<body[\s>]`/`</body>`
- *    matches are word-bounded (never `<bodyguard …>`) and run on a freshly
- *    masked string so a `<body>`/`</body>` token inside a surviving style block
- *    cannot fake the boundary.
+ *    /`<html[\s>]` matches are word-bounded (never `<bodyguard …>`/`<htmlfoo>`)
+ *    and run on a freshly masked string so a token inside a surviving style block
+ *    or comment cannot fake the boundary. The `<html…>` open tag is stripped
+ *    wherever it appears (not only when leading), so a prefixed wrapper —
+ *    `text<html>…` — does not leak the tag into the preview body.
  */
 export function processPartialHtml(html: string): string {
   const { scriptOrHeadSpans } = analyzeRegions(html);
@@ -217,23 +342,43 @@ export function processPartialHtml(html: string): string {
   // styles are preserved.
   let result = removeSpans(html, scriptOrHeadSpans);
 
-  // 2. Strip an incomplete tag at the very end.
-  result = result.replace(/<[^>]*$/, "");
+  // Steps 2–3 locate the trailing-incomplete cut point on a MASKED copy so a
+  // `<`, `<style`/`<head`/`<!--` token inside a COMPLETE style block's content or
+  // a quoted attribute value cannot be mistaken for a genuinely unterminated
+  // trailing construct; the cut is then applied to the original by index.
+  let trimMask = maskBlockContent(result);
 
-  // 3. Strip an INCOMPLETE (unterminated) trailing <style>/<script>/<head> block
-  // — an open tag with no matching close through end of string.
-  result = result.replace(
-    /<(style|script|head)\b[^>]*>(?:(?!<\/\1>)[\s\S])*$/gi,
-    "",
+  // 2. Strip an incomplete tag at the very end (e.g. `<div class="fo`).
+  const incompleteTag = trimMask.search(/<[^>]*$/);
+  if (incompleteTag !== -1) {
+    result = result.slice(0, incompleteTag);
+    trimMask = maskBlockContent(result);
+  }
+
+  // 3. Strip an INCOMPLETE (unterminated) trailing <!-- … comment, then an
+  // unterminated trailing <style>/<script>/<head> block. The unterminated
+  // construct masks to end-of-string in maskBlockContent, so its open token
+  // remains the only structural marker on the masked copy at the tail; complete
+  // blocks (with their close tags) never match here.
+  const incompleteComment = trimMask.search(/<!--(?:(?!-->)[\s\S])*$/);
+  if (incompleteComment !== -1) {
+    result = result.slice(0, incompleteComment);
+    trimMask = maskBlockContent(result);
+  }
+  const incompleteBlock = trimMask.search(
+    /<(style|script|head)\b[^>]*>(?:(?!<\/\1>)[\s\S])*$/i,
   );
+  if (incompleteBlock !== -1) {
+    result = result.slice(0, incompleteBlock);
+  }
 
   // 4. Strip an incomplete HTML entity at the end.
   result = result.replace(/&[a-zA-Z0-9#]*$/, "");
 
-  // 5. Reduce to the body region. Mask first so a <body>/</body> token inside a
-  // surviving complete style block cannot be mistaken for the real boundary.
-  // Strip </body> (+ everything after) BEFORE the open tag so the open-tag
-  // index stays valid for the original string.
+  // 5. Reduce to the body region. Mask first so a <body>/</body>/<html> token
+  // inside a surviving complete style block or comment cannot be mistaken for the
+  // real boundary. Strip </body> (+ everything after) BEFORE the open tag so the
+  // open-tag index stays valid for the original string.
   let masked = maskBlockContent(result);
   const closeIdx = masked.search(/<\/body>/i);
   if (closeIdx !== -1) {
@@ -243,13 +388,34 @@ export function processPartialHtml(html: string): string {
   const openMatch = masked.match(/<body[\s>]/i);
   if (openMatch && openMatch.index !== undefined) {
     // Remove just the `<body…>` open tag, keeping content before and after it.
-    const openTagEnd =
-      openMatch.index + masked.slice(openMatch.index).search(/>/) + 1;
+    // Quote-aware end-of-tag scan (same shape as the final document's head
+    // matcher) so a quoted `>` in an attribute — `<body data-x="a>b">` — can't
+    // truncate the tag early and leak attribute fragments as visible content.
+    const openTag = masked
+      .slice(openMatch.index)
+      .match(/^<body(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i);
+    const openTagEnd = openTag
+      ? openMatch.index + openTag[0].length
+      : openMatch.index + masked.slice(openMatch.index).search(/>/) + 1;
     result = result.slice(0, openMatch.index) + result.slice(openTagEnd);
+    masked = maskBlockContent(result);
   }
-  // Drop the `<html…>`/`</html>` structural wrappers (the browser drops them in
-  // an innerHTML body context); a pre-`<body>` `<style>` is content and stays.
-  result = result.replace(/^<html\b[^>]*>/i, "").replace(/<\/html>/gi, "");
+  // Drop the `<html…>` open tag wherever it appears (the browser drops the
+  // wrapper in an innerHTML body context); a pre-`<body>` `<style>` is content
+  // and stays. Quote-aware end-of-tag scan + masked search so an `<html>` token
+  // inside a surviving style/comment cannot fake it, and a prefixed wrapper
+  // (`text<html>…`) is handled, not just a leading one.
+  const htmlOpen = masked.match(/<html[\s>]/i);
+  if (htmlOpen && htmlOpen.index !== undefined) {
+    const openTag = masked
+      .slice(htmlOpen.index)
+      .match(/^<html(\s(?:[^<>"']|"[^"]*"|'[^']*')*)?>/i);
+    const openTagEnd = openTag
+      ? htmlOpen.index + openTag[0].length
+      : htmlOpen.index + masked.slice(htmlOpen.index).search(/>/) + 1;
+    result = result.slice(0, htmlOpen.index) + result.slice(openTagEnd);
+  }
+  result = result.replace(/<\/html>/gi, "");
 
   return result;
 }

--- a/packages/vue/src/v2/lib/processPartialHtml.ts
+++ b/packages/vue/src/v2/lib/processPartialHtml.ts
@@ -1,21 +1,255 @@
-export function extractCompleteStyles(html: string): string {
-  const matches = html.match(/<style\b[^>]*>[\s\S]*?<\/style>/gi);
-  return matches ? matches.join("") : "";
+/**
+ * Shared region logic for the Open Generative UI streaming preview.
+ *
+ * The preview renders accumulated (still-streaming) HTML by hoisting head-region
+ * styles into the preview iframe's `<head>` (via {@link extractCompleteStyles})
+ * and injecting the body markup via `document.body.innerHTML` (via
+ * {@link processPartialHtml}). Those two functions MUST classify every complete
+ * `<style>` block identically — a block is either hoisted to the head XOR left
+ * in the body, never both (double-injected, cascade flip) and never neither
+ * (dropped, unstyled preview).
+ *
+ * Two principles keep them in lockstep and keep the preview faithful to the
+ * FINAL document the Vue renderer assembles (`ensureHead` + `injectCssIntoHtml`
+ * in `OpenGenerativeUIRenderer`):
+ *
+ * 1. HOIST ONLY styles inside a COMPLETE `<head>…</head>` ELEMENT. This mirrors
+ *    the final document exactly: `ensureHead` keeps (or synthesizes) the
+ *    `<head>` and `injectCssIntoHtml` injects the agent css INTO that head,
+ *    immediately before `</head>` — it never relocates any other markup. So
+ *    in-head styles stay in the head (before the agent css); everything else —
+ *    including a TOP-LEVEL `<style>` that appears before `<body>` with no
+ *    enclosing `<head>` — stays in the BODY region (after the head css in
+ *    document order). Consequences:
+ *      • A complete `<head>` element hoists correctly even when no `<body>` tag
+ *        has streamed yet (head/css routinely stream before the body).
+ *      • A top-level pre-`<body>` style (no `<head>`) is NEVER hoisted, so the
+ *        preview and final document agree with ZERO dependence on `<body>`
+ *        detection for the hoist decision.
+ *
+ * 2. MASK BEFORE MEASURING. Every structural search (locating `<head>` elements,
+ *    the `<body[\s>]` boundary, the `</body>` close, `<script>`/`<head>` element
+ *    spans) runs on a single shared masked copy of the input where the CONTENT
+ *    of every COMPLETE `<style>`/`<script>` block is replaced with same-length
+ *    placeholders. Indices are preserved 1:1, so spans map straight back to the
+ *    original. A tag-lookalike token inside CSS/JS — `content:"<body>"`, a
+ *    `<body` mention inside a CSS comment, or `x="</head>"` in a script string —
+ *    therefore can NEVER fake a boundary or split a style block. Both exported
+ *    functions derive their classifications from this ONE computation
+ *    ({@link analyzeRegions}).
+ *
+ * The `<body[\s>]` / `</body>` / `<head\b` guards are all word-bounded so
+ * `<bodyguard …>`, `<header>`, etc. are never mistaken for `<body>`/`<head>`.
+ *
+ * Incomplete trailing `<style>`/`<script>`/`<head>` blocks (an open tag with no
+ * matching close through end of string) are still stripped entirely — an
+ * unterminated block mid-stream must never leak its raw CSS/JS text into the
+ * preview body as visible content.
+ *
+ * Pure functions — no DOM, no Vue.
+ */
+
+/** Matches a COMPLETE `<style>`/`<script>` block, capturing the tag name and its content. */
+const COMPLETE_STYLE_OR_SCRIPT = /<(style|script)\b[^>]*>([\s\S]*?)<\/\1>/gi;
+
+/**
+ * Replaces the CONTENT (between the open tag's `>` and the matching `</tag>`) of
+ * every COMPLETE `<style>`/`<script>` block with same-length space placeholders.
+ * The tags themselves are untouched. Length-preserving, so every index in the
+ * returned string maps 1:1 to the original — callers locate structure on the
+ * masked string and slice the matching text out of the original.
+ */
+function maskBlockContent(html: string): string {
+  let out = "";
+  let last = 0;
+  COMPLETE_STYLE_OR_SCRIPT.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = COMPLETE_STYLE_OR_SCRIPT.exec(html)) !== null) {
+    const full = match[0];
+    const content = match[2]!;
+    // Content starts right after the open tag's first `>`. (Open tags cannot
+    // contain a `>` here — these are `<style …>`/`<script …>` with no `>` in
+    // their attribute values in any realistic streamed document.)
+    const contentStart = match.index + full.indexOf(">") + 1;
+    const contentEnd = contentStart + content.length;
+    out += html.slice(last, contentStart);
+    out += " ".repeat(content.length);
+    last = contentEnd;
+  }
+  out += html.slice(last);
+  return out;
 }
 
-export function processPartialHtml(html: string): string {
-  let result = html;
+interface StyleSpan {
+  /** Start index of the complete `<style>` block in the ORIGINAL string. */
+  start: number;
+  /** End index (exclusive) of the complete `<style>` block in the ORIGINAL string. */
+  end: number;
+  /** True when the block lies entirely within a complete `<head>…</head>` element. */
+  inHead: boolean;
+}
 
+interface Regions {
+  /** `[start, end)` spans of complete `<script>`/`<head>` ELEMENTS (stripped from the body everywhere). */
+  scriptOrHeadSpans: Array<[number, number]>;
+  /** Every complete `<style>` block, tagged with whether it sits inside a `<head>` element. */
+  styleSpans: StyleSpan[];
+}
+
+/**
+ * The single shared region computation. Masks complete `<style>`/`<script>`
+ * content (see {@link maskBlockContent}), then derives every structural fact
+ * from that ONE masked string so both exported functions agree by construction.
+ */
+function analyzeRegions(html: string): Regions {
+  const masked = maskBlockContent(html);
+
+  // Complete <head>…</head> element spans. `<head\b` is word-bounded so it never
+  // matches `<header>`; masking ensures a `<head`/`</head>` token inside CSS/JS
+  // cannot open or close a phantom element here.
+  const headElementSpans: Array<[number, number]> = [];
+  const headRe = /<head\b[^>]*>[\s\S]*?<\/head>/gi;
+  let headMatch: RegExpExecArray | null;
+  while ((headMatch = headRe.exec(masked)) !== null) {
+    headElementSpans.push([
+      headMatch.index,
+      headMatch.index + headMatch[0].length,
+    ]);
+  }
+
+  // Every complete <style> block, tagged by containment in a head element. A
+  // block is "in head" only if its whole span sits inside one head element span.
+  const styleSpans: StyleSpan[] = [];
+  const styleRe = /<style\b[^>]*>[\s\S]*?<\/style>/gi;
+  let styleMatch: RegExpExecArray | null;
+  while ((styleMatch = styleRe.exec(masked)) !== null) {
+    const start = styleMatch.index;
+    const end = styleMatch.index + styleMatch[0].length;
+    const inHead = headElementSpans.some(
+      ([hs, he]) => start >= hs && end <= he,
+    );
+    styleSpans.push({ start, end, inHead });
+  }
+
+  // Complete <script> and <head> ELEMENT spans — stripped from the body markup
+  // everywhere. (A head element's in-head <style> blocks are contained within
+  // these spans, so stripping the element removes the hoisted styles too; we
+  // therefore never strip those styles a second time.)
+  const scriptOrHeadSpans: Array<[number, number]> = [];
+  const scriptOrHeadRe = /<(script|head)\b[^>]*>[\s\S]*?<\/\1>/gi;
+  let shMatch: RegExpExecArray | null;
+  while ((shMatch = scriptOrHeadRe.exec(masked)) !== null) {
+    scriptOrHeadSpans.push([shMatch.index, shMatch.index + shMatch[0].length]);
+  }
+
+  return { scriptOrHeadSpans, styleSpans };
+}
+
+/** Removes a set of `[start, end)` spans from `html`, applied right-to-left so
+ * earlier offsets stay valid. */
+function removeSpans(html: string, spans: Array<[number, number]>): string {
+  let out = html;
+  for (const [start, end] of [...spans].sort((a, b) => b[0] - a[0])) {
+    out = out.slice(0, start) + out.slice(end);
+  }
+  return out;
+}
+
+/**
+ * Extracts the complete `<style>` blocks that should be HOISTED into the preview
+ * iframe's `<head>` — i.e. ONLY those inside a complete `<head>…</head>` element
+ * (see the head-element rule in this module's header). Returns the concatenated
+ * style tags, suitable for injection into `<head>`.
+ *
+ * Mirrors the final document (`ensureHead` + `injectCssIntoHtml`): it keeps
+ * in-head styles in the head (before the agent css) and leaves every other style
+ * — including a top-level pre-`<body>` style — in the body region. Hoisting a
+ * body-region or top-level style would flip its cascade position at the
+ * preview→final swap, visibly restyling artifacts whose style and the agent css
+ * param collide at equal specificity.
+ *
+ * Derived from the shared {@link analyzeRegions} computation, so it classifies
+ * every complete `<style>` exactly as {@link processPartialHtml} does — the
+ * hoisted set here is precisely the set stripped from the body there.
+ */
+export function extractCompleteStyles(html: string): string {
+  const { styleSpans } = analyzeRegions(html);
+  return styleSpans
+    .filter((span) => span.inHead)
+    .map((span) => html.slice(span.start, span.end))
+    .join("");
+}
+
+/**
+ * Processes raw accumulated HTML into the markup injected via the preview's
+ * `document.body.innerHTML`. Pure function, no DOM dependencies.
+ *
+ * Pipeline (all structural detection comes from the shared {@link analyzeRegions}
+ * computation, so it agrees with {@link extractCompleteStyles} by construction):
+ * 1. Remove complete `<script>`/`<head>` ELEMENTS everywhere. Stripping a head
+ *    element also removes its in-head `<style>` blocks — exactly the blocks
+ *    {@link extractCompleteStyles} hoists — so those styles live in the head XOR
+ *    the body, never both. A top-level pre-`<body>` style (no enclosing head) is
+ *    NOT in any head element and is therefore KEPT, matching the final document,
+ *    which leaves it in the body region.
+ * 2. Strip an incomplete tag at the very end — e.g. `<div class="fo`.
+ * 3. Strip an incomplete (unterminated) trailing `<style>`/`<script>`/`<head>`
+ *    block. Complete blocks are already removed (head/script) or intentionally
+ *    kept (body/top-level styles), so this only catches a genuinely unterminated
+ *    trailing block — raw CSS/JS text must never leak into the preview body.
+ * 4. Strip an incomplete HTML entity at the end — e.g. `&amp` without `;`.
+ * 5. Reduce to the body region: drop the `<body…>` open tag and the matching
+ *    `</body>` (and everything after it), and drop the `<html…>`/`</html>`
+ *    structural wrappers — keeping the body's inner content AND any surviving
+ *    top-level pre-`<body>` content (e.g. a body-region `<style>`). This mirrors
+ *    how a browser renders the FINAL document's body region: `<html>`/`<head>`
+ *    are wrappers the parser drops, while a pre-`<body>` style is real
+ *    cascade-bearing content that stays with the body. The `<body[\s>]`/`</body>`
+ *    matches are word-bounded (never `<bodyguard …>`) and run on a freshly
+ *    masked string so a `<body>`/`</body>` token inside a surviving style block
+ *    cannot fake the boundary.
+ */
+export function processPartialHtml(html: string): string {
+  const { scriptOrHeadSpans } = analyzeRegions(html);
+
+  // 1. Remove complete <script>/<head> elements (computed on the masked string,
+  // applied to the original by index). In-head styles ride along; body/top-level
+  // styles are preserved.
+  let result = removeSpans(html, scriptOrHeadSpans);
+
+  // 2. Strip an incomplete tag at the very end.
   result = result.replace(/<[^>]*$/, "");
-  result = result.replace(/<(style|script|head)\b[^>]*>[\s\S]*?<\/\1>/gi, "");
-  result = result.replace(/<(style|script|head)\b[^>]*>[\s\S]*$/gi, "");
+
+  // 3. Strip an INCOMPLETE (unterminated) trailing <style>/<script>/<head> block
+  // — an open tag with no matching close through end of string.
+  result = result.replace(
+    /<(style|script|head)\b[^>]*>(?:(?!<\/\1>)[\s\S])*$/gi,
+    "",
+  );
+
+  // 4. Strip an incomplete HTML entity at the end.
   result = result.replace(/&[a-zA-Z0-9#]*$/, "");
 
-  const bodyMatch = result.match(/<body[^>]*>([\s\S]*)/i);
-  if (bodyMatch) {
-    result = bodyMatch[1]!;
-    result = result.replace(/<\/body>[\s\S]*/i, "");
+  // 5. Reduce to the body region. Mask first so a <body>/</body> token inside a
+  // surviving complete style block cannot be mistaken for the real boundary.
+  // Strip </body> (+ everything after) BEFORE the open tag so the open-tag
+  // index stays valid for the original string.
+  let masked = maskBlockContent(result);
+  const closeIdx = masked.search(/<\/body>/i);
+  if (closeIdx !== -1) {
+    result = result.slice(0, closeIdx);
+    masked = maskBlockContent(result);
   }
+  const openMatch = masked.match(/<body[\s>]/i);
+  if (openMatch && openMatch.index !== undefined) {
+    // Remove just the `<body…>` open tag, keeping content before and after it.
+    const openTagEnd =
+      openMatch.index + masked.slice(openMatch.index).search(/>/) + 1;
+    result = result.slice(0, openMatch.index) + result.slice(openTagEnd);
+  }
+  // Drop the `<html…>`/`</html>` structural wrappers (the browser drops them in
+  // an innerHTML body context); a pre-`<body>` `<style>` is content and stays.
+  result = result.replace(/^<html\b[^>]*>/i, "").replace(/<\/html>/gi, "");
 
   return result;
 }

--- a/packages/vue/src/v2/lib/processPartialHtml.ts
+++ b/packages/vue/src/v2/lib/processPartialHtml.ts
@@ -331,18 +331,22 @@ export function extractCompleteStyles(html: string): string {
  *    `&D` is indistinguishable from a forming `&Dagger;` at the boundary); the
  *    conservative strip self-corrects on the next chunk and at completion (the
  *    FINAL document never runs processPartialHtml).
- * 5. Reduce to the body region: drop the `<body…>` open tag and the matching
- *    `</body>` (and everything after it), and drop the `<html…>`/`</html>`
- *    structural wrappers — keeping the body's inner content AND any surviving
- *    top-level pre-`<body>` content (e.g. a body-region `<style>`). This mirrors
- *    how a browser renders the FINAL document's body region: `<html>`/`<head>`
- *    are wrappers the parser drops, while a pre-`<body>` style is real
- *    cascade-bearing content that stays with the body. The `<body[\s>]`/`</body>`
- *    /`<html[\s>]` matches are word-bounded (never `<bodyguard …>`/`<htmlfoo>`)
- *    and run on a freshly masked string so a token inside a surviving style block
- *    or comment cannot fake the boundary. The `<html…>` open tag is stripped
- *    wherever it appears (not only when leading), so a prefixed wrapper —
- *    `text<html>…` — does not leak the tag into the preview body.
+ * 5. Reduce to the body region: drop the `<body…>` open tag and the `</body…>`
+ *    CLOSE TOKEN (but KEEP everything after it), and drop the `<html…>`/`</html>`
+ *    structural wrappers — keeping the body's inner content, any surviving
+ *    top-level pre-`<body>` content (e.g. a body-region `<style>`), AND any
+ *    content after `</body>`. This mirrors how a browser renders the FINAL
+ *    document's body region: `<html>`/`<head>`/`<body>`/`</body>`/`</html>` are
+ *    tags the parser consumes as structure, while a pre-`<body>` style and any
+ *    post-`</body>` markup are real content the browser REPARENTS into the body
+ *    (the final document is mounted whole, so the preview must keep them too — a
+ *    truncate-at-`</body>` drops content that pops in at the preview→final swap).
+ *    The `<body[\s>]`/`</body>`/`<html[\s>]` matches are word-bounded (never
+ *    `<bodyguard …>`/`<htmlfoo>`) and run on a freshly masked string so a token
+ *    inside a surviving style block or comment cannot fake the boundary. The
+ *    `</body>` and `<html…>` tokens are stripped wherever they appear (not only
+ *    when leading/trailing), so a prefixed wrapper — `text<html>…` — does not
+ *    leak the tag into the preview body, and post-`</body>` content is retained.
  */
 export function processPartialHtml(html: string): string {
   const { scriptOrHeadSpans } = analyzeRegions(html);
@@ -387,12 +391,30 @@ export function processPartialHtml(html: string): string {
 
   // 5. Reduce to the body region. Mask first so a <body>/</body>/<html> token
   // inside a surviving complete style block or comment cannot be mistaken for the
-  // real boundary. Strip </body> (+ everything after) BEFORE the open tag so the
-  // open-tag index stays valid for the original string.
+  // real boundary. Remove the </body> CLOSE TOKEN(S) but KEEP the content after
+  // them — a browser reparents any markup that appears after </body> back INTO
+  // the body when it renders the final (whole-document) mount, so truncating at
+  // </body> would drop content the final document still shows (a preview↔final
+  // divergence where post-</body> content pops in at the swap). A complete
+  // <style> after </body> is body-region too (it sits in no <head> element), so
+  // analyzeRegions does not hoist it and it stays here in the body — preserving
+  // the hoist-XOR-keep invariant. Locate each </body> on the MASKED copy (so a
+  // </body> token inside a surviving style/comment is never taken as the
+  // structural close) and splice those spans out of the ORIGINAL by index — the
+  // same mask-aware shape as the </html> strip below. Done before the <body>
+  // open-tag step so its offsets stay valid for the post-removal string.
   let masked = maskBlockContent(result);
-  const closeIdx = masked.search(/<\/body>/i);
-  if (closeIdx !== -1) {
-    result = result.slice(0, closeIdx);
+  const bodyCloseSpans: Array<[number, number]> = [];
+  const bodyCloseRe = /<\/body>/gi;
+  let bodyClose: RegExpExecArray | null;
+  while ((bodyClose = bodyCloseRe.exec(masked)) !== null) {
+    bodyCloseSpans.push([
+      bodyClose.index,
+      bodyClose.index + bodyClose[0].length,
+    ]);
+  }
+  if (bodyCloseSpans.length > 0) {
+    result = removeSpans(result, bodyCloseSpans);
     masked = maskBlockContent(result);
   }
   const openMatch = masked.match(/<body[\s>]/i);

--- a/packages/vue/src/v2/lib/processPartialHtml.ts
+++ b/packages/vue/src/v2/lib/processPartialHtml.ts
@@ -100,8 +100,13 @@ function blankQuotedRuns(tag: string): string {
  * position, so the three constructs never interfere: a `<style>` mentioned inside
  * a comment is masked as comment content (not treated as a real style), and a
  * `-->` inside CSS is masked as style content (not treated as a comment close).
+ *
+ * Exported so the final-document head helpers in `OpenGenerativeUIRenderer` can
+ * mask-before-matching on the SAME length-preserving algorithm (rather than
+ * duplicating it), mirroring react-core's assembleDocument, which masks inert
+ * spans before its head-open/`</head>` searches.
  */
-function maskBlockContent(html: string): string {
+export function maskBlockContent(html: string): string {
   const blockRe = /<style\b|<script\b|<!--/gi;
   let out = "";
   let last = 0;

--- a/packages/vue/src/v2/lib/processPartialHtml.ts
+++ b/packages/vue/src/v2/lib/processPartialHtml.ts
@@ -320,7 +320,12 @@ export function extractCompleteStyles(html: string): string {
  *    construct — raw CSS/JS text must never leak into the preview body, and an
  *    unterminated comment must vanish (the final document's `-->` would swallow
  *    the remainder, so the preview shows nothing for it).
- * 4. Strip an incomplete HTML entity at the end — e.g. `&amp` without `;`.
+ * 4. Strip an incomplete HTML entity at the end — e.g. `&amp` without `;`. BY
+ *    DESIGN this also drops a trailing run of LITERAL text that merely looks
+ *    like a developing entity (a chunk ending `<p>R&D` renders as `<p>R`, since
+ *    `&D` is indistinguishable from a forming `&Dagger;` at the boundary); the
+ *    conservative strip self-corrects on the next chunk and at completion (the
+ *    FINAL document never runs processPartialHtml).
  * 5. Reduce to the body region: drop the `<body…>` open tag and the matching
  *    `</body>` (and everything after it), and drop the `<html…>`/`</html>`
  *    structural wrappers — keeping the body's inner content AND any surviving
@@ -414,8 +419,25 @@ export function processPartialHtml(html: string): string {
       ? htmlOpen.index + openTag[0].length
       : htmlOpen.index + masked.slice(htmlOpen.index).search(/>/) + 1;
     result = result.slice(0, htmlOpen.index) + result.slice(openTagEnd);
+    masked = maskBlockContent(result);
   }
-  result = result.replace(/<\/html>/gi, "");
+  // Drop the `</html…>` close tag wherever it appears, mask-aware like every
+  // other structural op here. Locate each `</html>` on the MASKED copy (so a
+  // `</html>` token inside a SURVIVING complete style/comment block or a quoted
+  // attribute value is never seen as the wrapper close) and slice those spans
+  // out of the ORIGINAL by index. A plain `result.replace(/<\/html>/gi, "")`
+  // would run on the UNMASKED string and wrongly delete such a token from
+  // content the final document keeps (e.g. `content:"</html>"`).
+  const htmlCloseSpans: Array<[number, number]> = [];
+  const htmlCloseRe = /<\/html>/gi;
+  let htmlClose: RegExpExecArray | null;
+  while ((htmlClose = htmlCloseRe.exec(masked)) !== null) {
+    htmlCloseSpans.push([
+      htmlClose.index,
+      htmlClose.index + htmlClose[0].length,
+    ]);
+  }
+  result = removeSpans(result, htmlCloseSpans);
 
   return result;
 }

--- a/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
@@ -33,7 +33,9 @@ Key benefits:
   `@copilotkit/react-core` only. The Vue package supports the secure sandbox,
   live streaming preview, `sandboxFunctions`, and `designSkill`, but injects no
   design-system kit and no importmap — generated documents in Vue are not
-  augmented with either.
+  augmented with either. Vue also has no height auto-measurement: the artifact
+  iframe stays at `initialHeight` (200px by default), so taller content is
+  clipped — have the agent pass a generous `initialHeight` for tall UIs.
 </Callout>
 
 ## Minimal setup

--- a/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
@@ -21,11 +21,20 @@ progressively, and finally JavaScript expressions execute one by one.
 Key benefits:
 
 - **No predefined components** — the agent creates any UI it needs, on demand
-- **Design system built in** — a token-based CSS kit (light/dark, styled form controls, SVG helpers) is pre-injected into every generated document
-- **Pre-wired libraries** — Three.js, GSAP, D3, and Chart.js are import-ready via a pinned importmap; other CDN libraries can still be loaded via `<script>`/`<link>` tags
+- **Design system built in** (React) — a token-based CSS kit (light/dark, styled form controls, SVG helpers) is pre-injected into every generated document
+- **Pre-wired libraries** (React) — Three.js, GSAP, D3, and Chart.js are import-ready via a pinned importmap; other CDN libraries can still be loaded via `<script>`/`<link>` tags
 - **Live streaming** — HTML streams into a preview as it's generated
 - **Secure sandboxing** — content runs in an isolated iframe without same-origin access
 - **Sandbox functions** — optionally expose host functions to the generated UI for two-way communication
+
+<Callout type="info" title="React-only features">
+  The built-in design system, the pre-wired libraries importmap, and the
+  `designSystem` / `libraries` provider options are currently available in
+  `@copilotkit/react-core` only. The Vue package supports the secure sandbox,
+  live streaming preview, `sandboxFunctions`, and `designSkill`, but injects no
+  design-system kit and no importmap — generated documents in Vue are not
+  augmented with either.
+</Callout>
 
 ## Minimal setup
 
@@ -114,8 +123,15 @@ progressively.
 
 ## Using libraries
 
-Three.js, GSAP, D3, and Chart.js are **pre-wired**: every generated document
-ships with a pinned importmap, so the agent imports them as bare module
+<Callout type="info" title="React only">
+  The pre-wired importmap and the `libraries` provider option below are
+  available in `@copilotkit/react-core` only. In Vue, no importmap is injected,
+  so the agent must load every library — including Three.js, GSAP, D3, and
+  Chart.js — via classic CDN `<script>`/`<link>` tags.
+</Callout>
+
+In React, Three.js, GSAP, D3, and Chart.js are **pre-wired**: every generated
+document ships with a pinned importmap, so the agent imports them as bare module
 specifiers inside `<script type="module">` — no CDN `<script src>` tags needed
 for these four (the built-in tool description steers the agent accordingly).
 
@@ -133,7 +149,7 @@ for these four (the built-in tool description steers the agent accordingly).
 Any **other** CDN-hosted library still works the classic way — include its
 `<script>` or `<link>` tag in the generated HTML `<head>`.
 
-Override or disable the importmap via the provider:
+Override or disable the importmap via the React provider:
 
 ```tsx
 <CopilotKit
@@ -150,8 +166,15 @@ Override or disable the importmap via the provider:
 
 ## The built-in design system
 
-Every generated document is assembled with a default design system: CSS
-design tokens with automatic light/dark (`--color-*`, `--font-*`,
+<Callout type="info" title="React only">
+  The built-in design system and the `designSystem` provider option are
+  available in `@copilotkit/react-core` only. Vue injects no design-system kit;
+  generated documents carry only the styles the agent writes (optionally guided
+  by a custom `designSkill`).
+</Callout>
+
+In React, every generated document is assembled with a default design system:
+CSS design tokens with automatic light/dark (`--color-*`, `--font-*`,
 `--border-radius-*`), pre-styled form controls, and SVG helper classes
 (`.c-purple`…`.c-red`, `.box`, `.arr`). The agent is instructed to build on
 these tokens instead of hand-rolling palettes, so generated UIs stay

--- a/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
@@ -48,7 +48,9 @@ sandboxed iframe.
 
 ### Drop `<CopilotChat />` into the page
 
-Wrap your app in `CopilotKit` and render `<CopilotChat>` — no extra props needed:
+Wrap your app in `CopilotKit` and render `<CopilotChat>` — the activity
+renderer registers automatically (the sample also opts into a custom
+`designSkill`):
 
 <Snippet region="minimal-provider-setup" />
 

--- a/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
@@ -102,7 +102,7 @@ knows which bridges are available when generating HTML/JS.
 The agent generates the tool call's parameters in an order optimized for the
 user experience:
 
-1. **`placeholderMessages`** — shown immediately while generating
+1. **`initialHeight` + `placeholderMessages`** — sizing hint and status lines, shown immediately while generating
 2. **`css`** — all styles first; the preview starts once CSS is complete
 3. **`html`** — streams live into the preview as it's generated
 4. **`jsFunctions`** — reusable helpers injected before expressions
@@ -139,7 +139,10 @@ Override or disable the importmap via the provider:
 <CopilotKit
   runtimeUrl="/api/copilotkit"
   openGenerativeUI={{
-    libraries: { lodash: "https://esm.sh/lodash-es@4.17.21" }, // merged over the defaults; overriding a bare specifier re-pins its "lib/" subpath form too
+    libraries: {
+      lodash: "https://esm.sh/lodash-es@4.17.21", // new entries merge over the defaults
+      three: "https://esm.sh/three@0.181.0", // overriding a pre-wired library re-pins its "three/" subpath form too
+    },
     // libraries: false  — disable the importmap entirely
   }}
 >

--- a/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
@@ -21,8 +21,9 @@ progressively, and finally JavaScript expressions execute one by one.
 Key benefits:
 
 - **No predefined components** — the agent creates any UI it needs, on demand
+- **Design system built in** — a token-based CSS kit (light/dark, styled form controls, SVG helpers) is pre-injected into every generated document
+- **Pre-wired libraries** — Three.js, GSAP, D3, and Chart.js are import-ready via a pinned importmap; other CDN libraries can still be loaded via `<script>`/`<link>` tags
 - **Live streaming** — HTML streams into a preview as it's generated
-- **CDN libraries** — the generated UI can load Chart.js, D3, Three.js, etc. via `<script>` tags
 - **Secure sandboxing** — content runs in an isolated iframe without same-origin access
 - **Sandbox functions** — optionally expose host functions to the generated UI for two-way communication
 
@@ -109,19 +110,58 @@ The middleware parses the tool-call arguments incrementally and emits
 activity events as each parameter completes, so the preview updates
 progressively.
 
-## Using CDN libraries
+## Using libraries
 
-The sandboxed iframe can load external libraries from CDNs; just include
-`<script>` or `<link>` tags in the generated HTML `<head>`. Chart.js, D3,
-Three.js, and any other CDN-hosted library work out of the box.
+Three.js, GSAP, D3, and Chart.js are **pre-wired**: every generated document
+ships with a pinned importmap, so the agent imports them as bare module
+specifiers inside `<script type="module">` — no CDN `<script src>` tags needed
+for these four (the built-in tool description steers the agent accordingly).
 
 ```html
-<head>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-</head>
 <body>
-  <canvas id="myChart"></canvas>
+  <canvas id="scene"></canvas>
+  <script type="module">
+    import * as THREE from "three";
+    import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+    // …
+  </script>
 </body>
+```
+
+Any **other** CDN-hosted library still works the classic way — include its
+`<script>` or `<link>` tag in the generated HTML `<head>`.
+
+Override or disable the importmap via the provider:
+
+```tsx
+<CopilotKit
+  runtimeUrl="/api/copilotkit"
+  openGenerativeUI={{
+    libraries: { lodash: "https://esm.sh/lodash-es@4.17.21" }, // merged over the defaults
+    // libraries: false  — disable the importmap entirely
+  }}
+>
+```
+
+## The built-in design system
+
+Every generated document is assembled with a default design system: CSS
+design tokens with automatic light/dark (`--color-*`, `--font-*`,
+`--border-radius-*`), pre-styled form controls, and SVG helper classes
+(`.c-purple`…`.c-red`, `.box`, `.arr`). The agent is instructed to build on
+these tokens instead of hand-rolling palettes, so generated UIs stay
+consistent and theme-aware.
+
+Supply your own kit — or opt out for the legacy blank-document behavior:
+
+```tsx
+<CopilotKit
+  runtimeUrl="/api/copilotkit"
+  openGenerativeUI={{
+    designSystem: { css: myDesignSystemCss }, // custom kit (pair with a designSkill)
+    // designSystem: false  — no injected styles (legacy behavior)
+  }}
+>
 ```
 
 <IntegrationGrid path="generative-ui/open-generative-ui" />

--- a/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
@@ -139,7 +139,7 @@ Override or disable the importmap via the provider:
 <CopilotKit
   runtimeUrl="/api/copilotkit"
   openGenerativeUI={{
-    libraries: { lodash: "https://esm.sh/lodash-es@4.17.21" }, // merged over the defaults
+    libraries: { lodash: "https://esm.sh/lodash-es@4.17.21" }, // merged over the defaults; overriding a bare specifier re-pins its "lib/" subpath form too
     // libraries: false  — disable the importmap entirely
   }}
 >

--- a/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
@@ -154,14 +154,15 @@ design tokens with automatic light/dark (`--color-*`, `--font-*`,
 these tokens instead of hand-rolling palettes, so generated UIs stay
 consistent and theme-aware.
 
-Supply your own kit — or opt out for the legacy blank-document behavior:
+Supply your own kit — or opt out of the injected styles:
 
 ```tsx
 <CopilotKit
   runtimeUrl="/api/copilotkit"
   openGenerativeUI={{
     designSystem: { css: myDesignSystemCss }, // custom kit (pair with a designSkill)
-    // designSystem: false  — no injected styles (legacy behavior)
+    // designSystem: false — no design-system styles; importmap still injects
+    // (set libraries: false too for a fully un-augmented legacy document)
   }}
 >
 ```


### PR DESCRIPTION
## What

Phase 1 of the Open Generative UI improvement plan: generated artifacts are assembled into a full document with a curated import map and a built-in design system, configurable per app.

- **`assembleDocument()`** (`packages/react-core/src/v2/lib/assembleDocument.ts`) — composes importmap → design-system kit → agent head content → agent CSS into the sandboxed document; normalizes the head tag to the literal `<head>` websandbox requires; quote-aware and comment-masked head tokenization; byte-identical legacy output when both features are disabled (fuzz-verified).
- **Built-in design system** (`designSystemCss.ts`) — tokens, light/dark, SVG + form styling, dark-mode focus ring; override with `openGenerativeUI={{ designSystem: { css } }}` or disable with `designSystem: false`.
- **Curated import maps** — three / gsap / d3 / chart.js pre-wired via esm.sh (bare + subpath specifiers); extend/override/disable via `openGenerativeUI.libraries`; overriding a bare specifier re-pins its subpath sibling (`mergeLibraries`).
- **Provider options** — `OpenGenerativeUIOptionsContext` + three-state tool-description builder (builtin / custom / off) with referentially stable option resolution (no sandbox-destroying identity churn).
- **Region-aware streaming preview** (`processPartialHtml.ts`, React + Vue) — length-preserving masking of style/script/comment content so tag-lookalikes can't fake structure; only head-element styles hoist, for cascade parity with the final document.
- **Vue parity** — streaming-preview cascade order fixed; final-document head normalized so websandbox can always mount (literal-`<head>` requirement).
- **Docs** — `showcase/shell-docs` Open Generative UI page: libraries, design system, streaming behavior.

## Status

🚧 Draft for early visibility. A 7-agent review-fix loop is converging on this branch: 13 review rounds complete and all Round-13 fixes landed; the final confirmation round is running. Both package suites (react-core, vue) are green at every commit.

Known follow-up backlog (will be filed as issues at merge): preview spinner for the generating-omitted state, preview sandbox unmount-leak hardening, `</style>` breakout hardening, ResizeObserver-based post-measurement growth, e2e assertion hygiene, V1-compat packaging type hygiene, Vue feature-port of the assembler/design-system/import maps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)