### PR TITLE
docs(shell-docs): early-access callout + CTA on Slack quickstart and Bots reference

### DIFF
--- a/showcase/shell-docs/src/content/docs/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/slack.mdx
@@ -4,6 +4,10 @@ description: Build an AI Slack bot with CopilotKit — createBot, the Slack adap
 icon: "lucide/Slack"
 hideTOC: true
 ---
+<Callout type="info" title="Early access">
+  The bot stack is in **early access** — APIs may change before general availability. We're onboarding teams now: [request early access →](https://go.copilotkit.ai/beyond-the-web-form)
+</Callout>
+
 This guide takes you from zero to a Slack bot you can @-mention in a channel, then adds an interactive button card. You write handlers in TypeScript, the agent's replies stream into the thread, and rich messages are JSX that the adapter renders to Block Kit (Slack's message-UI format). No public URL needed.
 
 ## Prerequisites

--- a/showcase/shell-docs/src/content/reference/bot/index.mdx
+++ b/showcase/shell-docs/src/content/reference/bot/index.mdx
@@ -3,6 +3,10 @@ title: "Bots"
 description: "API reference for the CopilotKit bot stack — @copilotkit/bot, @copilotkit/bot-ui, and @copilotkit/bot-slack."
 ---
 
+<Callout type="info" title="Early access">
+  The bot stack is in **early access** — APIs may change before general availability. We're onboarding teams now: [request early access →](https://go.copilotkit.ai/beyond-the-web-form)
+</Callout>
+
 The bot stack turns any [AG-UI](https://docs.ag-ui.com) agent into a chat-platform bot. Three packages, three jobs:
 
 | Package | Role |


### PR DESCRIPTION
## What

PM feedback on #5368: the Slack/bot platform docs shipped without signaling that the bot stack is **early access**. This adds an `Early access` callout — *subject to change before GA* plus a **request early access** CTA — to both surfaces:

- `/slack` quickstart (top of page, above the intro)
- `/reference/bot` landing page (top of page)

The CTA links to [go.copilotkit.ai/beyond-the-web-form](https://go.copilotkit.ai/beyond-the-web-form) — the Slack/Teams ("beyond the web") early-access form confirmed in the README-refresh draft in Notion (302 → live Google Form, verified).

Copy follows the existing `ThreadsEarlyAccess` callout convention ("APIs may change before general availability").

## Verification

- `npm run build` (production, compiles all MDX) ✅
- `npm run typecheck` (incl. registry/search-index generation over content) ✅ · `npm run lint` ✅ (pre-existing warnings only, none in touched files)
- `npm test`: 93/94 — the 1 failure (`framework-overview.test.tsx` CTA copy) reproduced with this change stashed; pre-dates the branch (hero copy changed in #5248), same failure documented in #5368
- Both pages rendered on the dev server: callout title, bolded phrase, and form link present at the top of `/slack` and `/reference/bot` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)