### PR TITLE
fix(react-core): detach in-flight runs when switching from non-explicit threads

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -231,13 +231,6 @@ export function CopilotChat({
     // ship the same SDK-generated threadId that the chat UI is rendering.
     agent.threadId = resolvedThreadId;
 
-    // When the caller hasn't picked a specific thread, resolvedThreadId is a
-    // UUID minted locally (either in this CopilotChat or in a wrapping
-    // ThreadsProvider). The backend has never seen it, so /connect would
-    // always 404 — skip the call. A real thread is only created once the
-    // user runs the agent for the first time.
-    if (!hasExplicitThreadId) return;
-
     let detached = false;
 
     // Create a fresh AbortController so we can cancel the HTTP request on cleanup.
@@ -245,41 +238,57 @@ export function CopilotChat({
     // in its fetch config. Unlike runAgent(), connectAgent() does NOT create a new
     // AbortController automatically, so we must set one before connecting.
     const connectAbortController = new AbortController();
-    if (agent instanceof HttpAgent) {
-      agent.abortController = connectAbortController;
+
+    // When the caller hasn't picked a specific thread, resolvedThreadId is a
+    // UUID minted locally (either in this CopilotChat or in a wrapping
+    // ThreadsProvider). The backend has never seen it, so /connect would
+    // always 404 — skip the call. A real thread is only created once the
+    // user runs the agent for the first time.
+    if (hasExplicitThreadId) {
+      if (agent instanceof HttpAgent) {
+        agent.abortController = connectAbortController;
+      }
+
+      const connect = async (agentToConnect: AbstractAgent) => {
+        try {
+          await copilotkit.connectAgent({ agent: agentToConnect });
+        } catch (error) {
+          // Ignore errors from aborted connections (e.g., React StrictMode cleanup)
+          if (detached) return;
+          // connectAgent already emits via the subscriber system, but catch
+          // here to prevent unhandled rejections from unexpected errors.
+          console.error("CopilotChat: connectAgent failed", error);
+        } finally {
+          // Whether the connect succeeded or failed, we're no longer in the
+          // transitional "connecting" state for this thread — unblock the
+          // welcome-screen-suppression so the view can settle.
+          //
+          // Defer one animation frame so any trailing React commits from the
+          // bootstrap replay (final assistant message content) paint before
+          // isConnecting flips off. Without this, suggestions + copy button
+          // can briefly appear against an incompletely-laid-out message tree
+          // and visibly snap once the last text chunk lands.
+          if (!detached) {
+            const raf =
+              typeof requestAnimationFrame === "function"
+                ? requestAnimationFrame
+                : (cb: () => void) => setTimeout(cb, 16);
+            raf(() => {
+              if (!detached) setLastConnectedThreadId(resolvedThreadId);
+            });
+          }
+        }
+      };
+      connect(agent);
     }
 
-    const connect = async (agentToConnect: AbstractAgent) => {
-      try {
-        await copilotkit.connectAgent({ agent: agentToConnect });
-      } catch (error) {
-        // Ignore errors from aborted connections (e.g., React StrictMode cleanup)
-        if (detached) return;
-        // connectAgent already emits via the subscriber system, but catch
-        // here to prevent unhandled rejections from unexpected errors.
-        console.error("CopilotChat: connectAgent failed", error);
-      } finally {
-        // Whether the connect succeeded or failed, we're no longer in the
-        // transitional "connecting" state for this thread — unblock the
-        // welcome-screen-suppression so the view can settle.
-        //
-        // Defer one animation frame so any trailing React commits from the
-        // bootstrap replay (final assistant message content) paint before
-        // isConnecting flips off. Without this, suggestions + copy button
-        // can briefly appear against an incompletely-laid-out message tree
-        // and visibly snap once the last text chunk lands.
-        if (!detached) {
-          const raf =
-            typeof requestAnimationFrame === "function"
-              ? requestAnimationFrame
-              : (cb: () => void) => setTimeout(cb, 16);
-          raf(() => {
-            if (!detached) setLastConnectedThreadId(resolvedThreadId);
-          });
-        }
-      }
-    };
-    connect(agent);
+    // The cleanup is registered even when no connect() was issued above: a
+    // run can be streaming on a non-explicit (locally-minted) thread, and a
+    // thread switch must detach it BEFORE the shared per-agentId agent is
+    // repointed at the new thread. An early return here is what let the old
+    // run keep applying events to the agent and collide with the next
+    // thread's connect replay ("Cannot send 'RUN_STARTED' while a run is
+    // still active").
     return () => {
       // Abort the HTTP request and detach the active run.
       // This is critical for React StrictMode which unmounts+remounts in dev,

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.threadSwitchDetach.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.threadSwitchDetach.test.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { EMPTY } from "rxjs";
+import type { Observable } from "rxjs";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
+import {
+  MockStepwiseAgent,
+  runStartedEvent,
+  textChunkEvent,
+} from "../../../__tests__/utils/test-helpers";
+import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
+import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
+import { CopilotChat } from "../CopilotChat";
+
+/**
+ * Regression tests for the connect effect's cleanup registration.
+ *
+ * The connect effect used to early-return for non-explicit (locally-minted)
+ * threadIds BEFORE registering its cleanup. With no cleanup, a run streaming
+ * on a fresh thread was never detached when the user switched threads — the
+ * old run's events kept applying to the shared per-agentId agent instance
+ * and collided with the next thread's connect replay ("Cannot send
+ * 'RUN_STARTED' while a run is still active").
+ *
+ * The cleanup must be registered unconditionally; only the connect() call
+ * itself is gated on hasExplicitThreadId.
+ */
+describe("CopilotChat detaches in-flight runs on thread switch", () => {
+  function buildTrackingAgent() {
+    // Spies live in the closure, not on the instance: the provider may
+    // clone() registered agents, and MockStepwiseAgent.clone() shares the
+    // event subject but not instance fields.
+    const detachedThreadIds: Array<string | undefined> = [];
+    const runThreadIds: string[] = [];
+    const connectSpy = vi.fn<(input: RunAgentInput) => void>();
+
+    class TrackingAgent extends MockStepwiseAgent {
+      run(input: RunAgentInput): Observable<BaseEvent> {
+        runThreadIds.push(input.threadId);
+        return super.run(input);
+      }
+
+      connect(input: RunAgentInput): Observable<BaseEvent> {
+        connectSpy(input);
+        return EMPTY;
+      }
+
+      // Records the threadId the agent pointed at when the detach arrived,
+      // so tests can tell a cleanup-time detach (still on the outgoing
+      // thread) from one issued after the agent was repointed.
+      async detachActiveRun(): Promise<void> {
+        detachedThreadIds.push(this.threadId);
+      }
+    }
+
+    return {
+      agent: new TrackingAgent(),
+      detachedThreadIds,
+      runThreadIds,
+      connectSpy,
+    };
+  }
+
+  async function startStreamingRun(
+    agent: MockStepwiseAgent,
+    runThreadIds: string[],
+  ) {
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, { target: { value: "stream for a while" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    // Wait for the run pipeline to subscribe before emitting events.
+    await waitFor(() => expect(runThreadIds).toHaveLength(1));
+    agent.emit(runStartedEvent());
+    agent.emit(textChunkEvent("in-flight-msg", "still streaming"));
+  }
+
+  it("detaches the in-flight run before repointing the agent when switching to an explicit thread", async () => {
+    const { agent, detachedThreadIds, runThreadIds, connectSpy } =
+      buildTrackingAgent();
+
+    const view = render(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <CopilotChat welcomeScreen={false} />
+      </CopilotKitProvider>,
+    );
+
+    await startStreamingRun(agent, runThreadIds);
+    const inFlightThreadId = runThreadIds[0];
+    const detachCountBeforeSwitch = detachedThreadIds.length;
+
+    view.rerender(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <CopilotChat welcomeScreen={false} threadId="explicit-thread-b" />
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() =>
+      expect(detachedThreadIds.length).toBeGreaterThan(detachCountBeforeSwitch),
+    );
+    // The first detach after the switch must come from the effect cleanup,
+    // which runs while the agent still points at the outgoing thread. A
+    // detach issued only as a side effect of the new thread's connect would
+    // arrive after agent.threadId was already mutated.
+    expect(detachedThreadIds[detachCountBeforeSwitch]).toBe(inFlightThreadId);
+
+    // The new explicit thread still connects afterwards.
+    await waitFor(() => expect(connectSpy).toHaveBeenCalled());
+    expect(connectSpy.mock.calls[0][0].threadId).toBe("explicit-thread-b");
+  });
+
+  it("detaches the in-flight run when switching between non-explicit threads, without connecting", async () => {
+    const { agent, detachedThreadIds, runThreadIds, connectSpy } =
+      buildTrackingAgent();
+
+    const view = render(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <CopilotChatConfigurationProvider
+          threadId="local-thread-1"
+          hasExplicitThreadId={false}
+        >
+          <CopilotChat welcomeScreen={false} />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    await startStreamingRun(agent, runThreadIds);
+    expect(runThreadIds[0]).toBe("local-thread-1");
+    const detachCountBeforeSwitch = detachedThreadIds.length;
+
+    view.rerender(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <CopilotChatConfigurationProvider
+          threadId="local-thread-2"
+          hasExplicitThreadId={false}
+        >
+          <CopilotChat welcomeScreen={false} />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    // Non-explicit destinations never call connectAgent, so the effect
+    // cleanup is the ONLY thing that can tear the old run down.
+    await waitFor(() =>
+      expect(detachedThreadIds.length).toBeGreaterThan(detachCountBeforeSwitch),
+    );
+    expect(detachedThreadIds[detachCountBeforeSwitch]).toBe("local-thread-1");
+    // Non-explicit threads still skip /connect entirely.
+    expect(connectSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Bug

In the v2 `CopilotChat` connect effect, the non-explicit-thread guard returned early **before** the effect's cleanup was registered:

```tsx
agent.threadId = resolvedThreadId;
if (!hasExplicitThreadId) return; // ← the cleanup below never registers
// ...
return () => {
  detached = true;
  connectAbortController.abort();
  void agent.detachActiveRun().catch(() => {});
};
```

`useAgent` hands every chat the same shared agent instance per `agentId` (`copilotkit.getAgent(agentId)`), with `threadId` mutated in place. So when a run is still streaming on a non-explicit (fresh/auto-minted) thread and the user switches threads (via the `threadId` prop or `CopilotChatConfigurationProvider`), the in-flight run is never detached:

- the old run keeps applying events to the shared agent after `agent.threadId` is repointed at the new thread, and
- its stream collides with the new thread's connect replay, surfacing as repeated `AGUIError: Cannot send 'RUN_STARTED' while a run is still active. The previous run must be finished with 'RUN_FINISHED' before starting a new run.`

Symptoms are timing-dependent: the old stream keeps rendering, the new thread's replay fails, or both.

**Repro** (verified 2026-06-10 against published 1.59.5, Intelligence mode): fresh `CopilotChat` (no explicit `threadId`) → send a message that streams for several seconds → while streaming, set an explicit `threadId` (switch threads) → console fills with the AGUIError above.

## Fix

Register the cleanup unconditionally; gate only the `connect()` call (and its `AbortController` wiring) on `hasExplicitThreadId`. The cleanup now detaches the in-flight run **before** the new effect body repoints the shared agent — and it also covers the two paths where nothing else would ever detach:

- switching to **another non-explicit** thread (new-chat-while-streaming): non-explicit destinations never call `connectAgent`, so the core-side defensive detach never runs;
- **unmount** mid-run.

`CopilotKitCore.connectAgent` already detaches defensively on the core side (`run-handler.ts`, covered by `core-connect-thread-switch.test.ts`), so no core change is needed — but that detach only fires for explicit destinations, and only after `agent.threadId` has already been mutated underneath the in-flight run. The effect cleanup is the only teardown that runs for every outgoing thread.

## Tests

Two regression tests in `CopilotChat.threadSwitchDetach.test.tsx`, written first and verified to fail against the buggy code:

1. **non-explicit → explicit switch mid-run** — the first detach after the switch must arrive while the agent still points at the outgoing thread (cleanup ordering), and the new thread still connects. Failed before the fix with `expected 'explicit-thread-b' to be 'mock-thread-id'`: the only detach came from `connectAgent`'s internal defense, after the agent was repointed.
2. **non-explicit → non-explicit switch mid-run** — the run must be detached even though no connect is issued, and `/connect` stays skipped. Failed before the fix: no detach at all.

Verification:
- `nx run @copilotkit/react-core:test` — 1273/1273 pass
- `nx run @copilotkit/react-core:build` — clean
- `check-types` — fails identically on `main` (pre-existing, 268 errors incl. a2ui-renderer's missing `@a2ui/lit`; not a CI gate). The new test file introduces no new error class — only the same pre-existing `MockStepwiseAgent`/`AbstractAgent` `activeRunCompletionPromise` privacy conflict every sibling test file already exhibits.

## Context

Found while building the control-room demo (#5378). Its `ThreadsPanel.switchThread` detaches in-flight runs before switching as a workaround — that can stay (harmless double-detach), but with this fix other consumers don't need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
