### PR TITLE
fix(react-core): stabilize pin-to-send scrolling

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
@@ -668,7 +668,7 @@ export namespace CopilotChatView {
     useEffect(() => {
       if (mode === "pin-to-bottom") return; // Skip for autoscroll mode
 
-      const scrollElement = scrollRef.current;
+      const scrollElement = nonAutoScrollEl;
       if (!scrollElement) return;
 
       const checkScroll = () => {
@@ -691,7 +691,7 @@ export namespace CopilotChatView {
         scrollElement.removeEventListener("scroll", checkScroll);
         resizeObserver.disconnect();
       };
-    }, [scrollRef, mode]);
+    }, [nonAutoScrollEl, mode]);
 
     if (!hasMounted) {
       return (

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatView.pinToSend.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatView.pinToSend.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import React from "react";
 import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
 import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
@@ -8,7 +8,41 @@ import { LastUserMessageContext } from "../last-user-message-context";
 
 beforeEach(() => {
   HTMLElement.prototype.scrollTo = vi.fn();
+  vi.stubGlobal(
+    "ResizeObserver",
+    vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    })),
+  );
 });
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function setScrollMetrics(
+  el: HTMLElement,
+  {
+    clientHeight,
+    scrollHeight,
+    scrollTop,
+  }: { clientHeight: number; scrollHeight: number; scrollTop: number },
+) {
+  Object.defineProperty(el, "clientHeight", {
+    configurable: true,
+    value: clientHeight,
+  });
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    value: scrollHeight,
+  });
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    value: scrollTop,
+  });
+}
 
 // Wrapper to provide required context (same pattern as CopilotChatView.slots.e2e.test.tsx)
 const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
@@ -46,6 +80,40 @@ describe("CopilotChatView pin-to-send mode", () => {
     await waitForMount(screen);
     const spacer = screen.container.querySelector("[data-pin-to-send-spacer]");
     expect(spacer).not.toBeNull();
+  });
+
+  it("shows the scroll-to-bottom button after the pin-to-send scroll element mounts and scrolls away from bottom", async () => {
+    const ScrollButton = (
+      props: React.ButtonHTMLAttributes<HTMLButtonElement>,
+    ) => <button data-testid="scroll-to-bottom" {...props} />;
+
+    const screen = render(
+      <TestWrapper>
+        <LastUserMessageContext.Provider value={{ id: null, sendNonce: 0 }}>
+          <CopilotChatView
+            autoScroll="pin-to-send"
+            messages={sampleMessages}
+            scrollView={{ scrollToBottomButton: ScrollButton }}
+          />
+        </LastUserMessageContext.Provider>
+      </TestWrapper>,
+    );
+
+    await waitForMount(screen);
+
+    const spacer = screen.container.querySelector("[data-pin-to-send-spacer]");
+    const scrollElement = spacer?.parentElement as HTMLElement | null;
+    expect(scrollElement).not.toBeNull();
+
+    setScrollMetrics(scrollElement!, {
+      clientHeight: 300,
+      scrollHeight: 1000,
+      scrollTop: 100,
+    });
+    await waitFor(() => {
+      fireEvent.scroll(scrollElement!);
+      expect(screen.getByTestId("scroll-to-bottom")).toBeTruthy();
+    });
   });
 
   it("does not render the spacer when autoScroll='pin-to-bottom'", async () => {

--- a/packages/react-core/src/v2/hooks/__tests__/use-pin-to-send.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-pin-to-send.test.tsx
@@ -146,7 +146,7 @@ describe("usePinToSend", () => {
     });
   });
 
-  it("shrinks spacer as content height grows (does not grow it)", async () => {
+  it("adjusts spacer as content height changes to keep the user message pinned", async () => {
     let observed: (() => void) | null = null;
     const ROStub = vi.fn().mockImplementation((cb: () => void) => {
       observed = cb;
@@ -182,11 +182,14 @@ describe("usePinToSend", () => {
       act(() => observed?.());
       expect(parseInt(spacer.style.height, 10)).toBeLessThan(744);
 
-      // Simulate content shrinking — spacer should NOT grow back
+      // Simulate content shrinking — spacer should grow back to preserve the
+      // original anchor instead of leaving the user message shifted.
       setHeight(content, 100);
       const shrunkHeight = spacer.style.height;
       act(() => observed?.());
-      expect(spacer.style.height).toBe(shrunkHeight);
+      expect(parseInt(spacer.style.height, 10)).toBeGreaterThan(
+        parseInt(shrunkHeight, 10),
+      );
     } finally {
       global.ResizeObserver = prevRO;
     }

--- a/packages/react-core/src/v2/hooks/use-pin-to-send.ts
+++ b/packages/react-core/src/v2/hooks/use-pin-to-send.ts
@@ -16,7 +16,6 @@ export function usePinToSend({
 }: UsePinToSendOptions): void {
   const { id, sendNonce } = useContext(LastUserMessageContext);
   const lastNonceRef = useRef<number>(-1);
-  const currentSpacerHeightRef = useRef<number>(0);
 
   useEffect(() => {
     if (sendNonce === lastNonceRef.current) return;
@@ -50,7 +49,6 @@ export function usePinToSend({
     const spacerHeight = Math.max(0, viewportHeight - bubbleHeight - topOffset);
 
     spacerEl.style.height = `${spacerHeight}px`;
-    currentSpacerHeightRef.current = spacerHeight;
 
     const raf = requestAnimationFrame(() => {
       // Scroll so the BUBBLE is `topOffset` from the viewport top — the
@@ -60,10 +58,9 @@ export function usePinToSend({
       scrollEl.scrollTo({ top: Math.max(0, targetTop), behavior: "smooth" });
     });
 
-    // Shrink-only ResizeObserver: as the assistant response grows below the
-    // anchored user message, collapse the spacer by the same amount so total
-    // scrollable space below the bubble stays constant (and the bubble stays
-    // pinned). Never grow the spacer after initial sizing.
+    // As content below the anchored user message changes, adjust the spacer by
+    // the same amount so total scrollable space below the bubble stays
+    // constant and the bubble stays pinned.
     const ro = new ResizeObserver(() => {
       if (!contentEl || !spacerEl || !scrollEl) return;
       const contentHeight = contentEl.getBoundingClientRect().height;
@@ -71,10 +68,7 @@ export function usePinToSend({
       const consumedBelow =
         contentHeight - targetOffsetWithinContent - userMessageHeight;
       const remaining = Math.max(0, spacerHeight - consumedBelow);
-      if (remaining < currentSpacerHeightRef.current) {
-        spacerEl.style.height = `${remaining}px`;
-        currentSpacerHeightRef.current = remaining;
-      }
+      spacerEl.style.height = `${remaining}px`;
     });
     ro.observe(contentEl);
 


### PR DESCRIPTION
## What does this PR do?

Fixes `pin-to-send` scrolling in the v2 chat view.

- Re-attaches the non-autoscroll scroll listener after the real scroll element mounts by depending on `nonAutoScrollEl`, not the stable `scrollRef` object.
- Lets the `usePinToSend` spacer adjust in both directions as content below the pinned user message changes, so the user message stays anchored after streaming finishes and layout height changes.
- Adds regression coverage for the scroll-to-bottom button and spacer adjustment behavior.

## Related PRs and Issues

Fixes #5355

## Tests

- `corepack pnpm -C packages/react-core exec vitest run src/v2/hooks/__tests__/use-pin-to-send.test.tsx src/v2/components/chat/__tests__/CopilotChatView.pinToSend.test.tsx`
- `corepack pnpm exec oxfmt --check packages/react-core/src/v2/components/chat/CopilotChatView.tsx packages/react-core/src/v2/hooks/use-pin-to-send.ts packages/react-core/src/v2/hooks/__tests__/use-pin-to-send.test.tsx packages/react-core/src/v2/components/chat/__tests__/CopilotChatView.pinToSend.test.tsx`
- `git diff --check`

Attempted:

- `corepack pnpm -C packages/react-core run check-types`
  - This failed in the local workspace on existing/type-resolution issues outside this diff, including `react-markdown` JSX namespace errors, missing `@copilotkit/runtime-client-gql` declarations, and existing e2e mock `AbstractAgent` private member mismatches.

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation (N/A: bug fix only, no API/docs change)
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)
