### PR TITLE
fix(react-core): preserve markdown code block newlines

### DIFF
--- a/packages/react-core/src/v2/styles/__tests__/globals-css.test.ts
+++ b/packages/react-core/src/v2/styles/__tests__/globals-css.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const globalsCss = readFileSync(join(currentDir, "../globals.css"), "utf8");
+
+describe("v2 globals.css", () => {
+  it("preserves newlines inside streamdown code blocks", () => {
+    const codeBlockPreRule = globalsCss.match(
+      /\[data-copilotkit\]\s+div\[data-streamdown="code-block"\]\s+>\s+pre\s*\{[^}]*\}/,
+    );
+
+    expect(codeBlockPreRule?.[0]).toContain("cpk:whitespace-pre");
+  });
+});

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -177,7 +177,7 @@
 }
 
 [data-copilotkit] div[data-streamdown="code-block"] > pre {
-  @apply cpk:mt-0 cpk:mb-0;
+  @apply cpk:mt-0 cpk:mb-0 cpk:whitespace-pre;
 }
 
 /* Minimal scrollbar for WebKit browsers (Chrome, Safari, Edge) */


### PR DESCRIPTION
## What does this PR do?

Fixes markdown code blocks in the v2 React chat UI so newlines are preserved when Streamdown renders fenced code blocks.

This adds `cpk:whitespace-pre` to the existing `[data-streamdown="code-block"] > pre` rule and includes a small regression test that keeps the CSS rule from dropping the whitespace preservation utility again.

I also checked for existing open and closed PRs by issue number and root-cause terms (`#3330`, code block, newlines, `whitespace-pre`, Streamdown) before opening this PR and did not find an overlapping PR.

Testing:

- `corepack pnpm -C packages/react-core exec vitest run src/v2/styles/__tests__/globals-css.test.ts`
- `corepack pnpm -C packages/react-core run build:css`
- `corepack pnpm exec oxfmt --check packages/react-core/src/v2/styles/__tests__/globals-css.test.ts packages/react-core/src/v2/styles/globals.css`
- `git diff --check`

## Related PRs and Issues

Fixes #3330

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation (not applicable: scoped visual bug fix)
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)
