### PR TITLE
refactor(runtime): Update Intelligence API handlers to pass along user IDs as route params

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/handle-run.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-run.test.ts
@@ -408,6 +408,7 @@ describe("handleRunAgent", () => {
       });
       expect(platform.getThreadMessages).toHaveBeenCalledWith({
         threadId: "thread-1",
+        userId: "user-1",
       });
     });
 

--- a/packages/runtime/src/v2/runtime/__tests__/handle-threads.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-threads.test.ts
@@ -514,6 +514,7 @@ describe("thread handlers", () => {
       expect(body.messages).toEqual([{ id: "m1" }]);
       expect(intelligence.getThreadMessages).toHaveBeenCalledWith({
         threadId: "thread-1",
+        userId: "user-1",
       });
       expect(identifyUser).toHaveBeenCalledTimes(1);
       expect(identifyUser).toHaveBeenCalledWith(

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/run.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/run.ts
@@ -172,6 +172,7 @@ export async function handleIntelligenceRun({
     try {
       const history = await runtime.intelligence.getThreadMessages({
         threadId: canonicalThreadId,
+        userId,
       });
       const historicMessageIds = new Set(
         history.messages.map((message) => message.id),

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/threads.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/threads.ts
@@ -1,8 +1,8 @@
-import {
+import type {
   CopilotIntelligenceRuntimeLike,
   CopilotRuntimeLike,
-  isIntelligenceRuntime,
 } from "../../core/runtime";
+import { isIntelligenceRuntime } from "../../core/runtime";
 import { logger } from "@copilotkit/shared";
 import { errorResponse, isHandlerResponse } from "../shared/json-response";
 import { isValidIdentifier } from "../shared/intelligence-utils";
@@ -274,7 +274,10 @@ export async function handleGetThreadMessages({
       const user = await resolveIntelligenceUser({ runtime, request });
       if (isHandlerResponse(user)) return user;
 
-      const data = await runtime.intelligence.getThreadMessages({ threadId });
+      const data = await runtime.intelligence.getThreadMessages({
+        threadId,
+        userId: user.id,
+      });
       return Response.json(data);
     } catch (error) {
       logger.error({ err: error, threadId }, "Error fetching thread messages");

--- a/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
@@ -245,11 +245,14 @@ describe("CopilotKitIntelligence", () => {
       };
       fetchMock.mockReturnValue(jsonResponse({ thread }));
 
-      const result = await client.getThread({ threadId: "t-1" });
+      const result = await client.getThread({
+        threadId: "t-1",
+        userId: "user-1",
+      });
 
       expect(result).toEqual(thread);
       const [url, opts] = fetchMock.mock.calls[0];
-      expect(url).toBe("https://api.example.com/api/threads/t-1");
+      expect(url).toBe("https://api.example.com/api/threads/t-1?userId=user-1");
       expect(opts.method).toBe("GET");
     });
   });
@@ -267,11 +270,16 @@ describe("CopilotKitIntelligence", () => {
       };
       fetchMock.mockReturnValue(jsonResponse(payload));
 
-      const result = await client.getThreadMessages({ threadId: "t-1" });
+      const result = await client.getThreadMessages({
+        threadId: "t-1",
+        userId: "user-1",
+      });
 
       expect(result).toEqual(payload);
       const [url, opts] = fetchMock.mock.calls[0];
-      expect(url).toBe("https://api.example.com/api/threads/t-1/messages");
+      expect(url).toBe(
+        "https://api.example.com/api/threads/t-1/messages?userId=user-1",
+      );
       expect(opts.method).toBe("GET");
     });
   });
@@ -335,6 +343,8 @@ describe("CopilotKitIntelligence", () => {
       expect(url).toBe("https://api.example.com/api/threads/t-1");
       expect(opts.method).toBe("DELETE");
       expect(JSON.parse(opts.body)).toEqual({
+        userId: "user-1",
+        agentId: "agent-1",
         reason:
           "Deleted via CopilotKit runtime (userId=user-1, agentId=agent-1)",
       });

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -22,7 +22,7 @@ export const INTELLIGENCE_USER_ID_HEADER = "x-cpki-user-id";
  * @example
  * ```ts
  * try {
- *   await intelligence.getThread({ threadId });
+ *   await intelligence.getThread({ threadId, userId });
  * } catch (error) {
  *   if (error instanceof PlatformRequestError && error.status === 404) {
  *     // thread does not exist yet
@@ -612,10 +612,14 @@ export class CopilotKitIntelligence {
    * @throws {@link PlatformRequestError} with status 404 if the thread does
    *   not exist.
    */
-  async getThread(params: { threadId: string }): Promise<ThreadSummary> {
+  async getThread(params: {
+    threadId: string;
+    userId: string;
+  }): Promise<ThreadSummary> {
+    const qs = new URLSearchParams({ userId: params.userId }).toString();
     const response = await this.#request<ThreadEnvelope>(
       "GET",
-      `/api/threads/${encodeURIComponent(params.threadId)}`,
+      `/api/threads/${encodeURIComponent(params.threadId)}?${qs}`,
     );
     return response.thread;
   }
@@ -639,7 +643,10 @@ export class CopilotKitIntelligence {
     params: CreateThreadRequest,
   ): Promise<{ thread: ThreadSummary; created: boolean }> {
     try {
-      const thread = await this.getThread({ threadId: params.threadId });
+      const thread = await this.getThread({
+        threadId: params.threadId,
+        userId: params.userId,
+      });
       return { thread, created: false };
     } catch (error) {
       if (!(error instanceof PlatformRequestError && error.status === 404)) {
@@ -653,7 +660,10 @@ export class CopilotKitIntelligence {
     } catch (error) {
       // Another request created the thread between our get and create — retry get.
       if (error instanceof PlatformRequestError && error.status === 409) {
-        const thread = await this.getThread({ threadId: params.threadId });
+        const thread = await this.getThread({
+          threadId: params.threadId,
+          userId: params.userId,
+        });
         return { thread, created: false };
       }
       throw error;
@@ -668,10 +678,12 @@ export class CopilotKitIntelligence {
    */
   async getThreadMessages(params: {
     threadId: string;
+    userId: string;
   }): Promise<ThreadMessagesResponse> {
+    const qs = new URLSearchParams({ userId: params.userId }).toString();
     return this.#request<ThreadMessagesResponse>(
       "GET",
-      `/api/threads/${encodeURIComponent(params.threadId)}/messages`,
+      `/api/threads/${encodeURIComponent(params.threadId)}/messages?${qs}`,
     );
   }
 
@@ -755,6 +767,8 @@ export class CopilotKitIntelligence {
       "DELETE",
       `/api/threads/${encodeURIComponent(params.threadId)}`,
       {
+        userId: params.userId,
+        agentId: params.agentId,
         reason: `Deleted via CopilotKit runtime (userId=${params.userId}, agentId=${params.agentId})`,
       },
     );


### PR DESCRIPTION
## Summary

- Pass the resolved runtime `userId` through Intelligence thread reads and message-history lookups.
- Include `userId` and `agentId` in Intelligence thread delete requests.
- Update Runtime tests to assert the new REST wire contract.

## Why

The Intelligence REST API now requires explicit app-user ownership for direct thread reads, message reads, and destructive thread mutations. Older Runtime code still omitted `userId` on those calls, which breaks against the updated API even though create/list/connect/lock already send `userId`.

## Validation

- `pnpm nx run @copilotkit/runtime:test -- --run src/v2/runtime/intelligence-platform/__tests__/client.test.ts src/v2/runtime/__tests__/handle-threads.test.ts src/v2/runtime/__tests__/handle-run.test.ts`
- `git diff --check`

Skipped local package typecheck; it is known to be unreliable locally and hit Node heap/long-running behavior in this worktree. CI should provide the final signal.
