### PR TITLE
feat(examples/slack): Dockerfiles for the runtime and bot services

### DIFF
--- a/examples/slack/.dockerignore
+++ b/examples/slack/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+.env.*
+e2e

--- a/examples/slack/Dockerfile.bot
+++ b/examples/slack/Dockerfile.bot
@@ -1,0 +1,22 @@
+# Slack ingress bot (app/index.ts): Socket Mode, JSX -> Block Kit, and the
+# chart/diagram renderer, which drives Playwright Chromium. The browser is
+# installed INSIDE node_modules (PLAYWRIGHT_BROWSERS_PATH=0) so it ships with
+# the app layer, and `install --with-deps` bakes Chromium's system libraries
+# into this image — the two failure modes of platform builders, eliminated.
+FROM node:22.16.0-slim@sha256:048ed02c5fd52e86fda6fbd2f6a76cf0d4492fd6c6fee9e2c463ed5108da0e34
+
+WORKDIR /app
+ENV CI=true \
+    PLAYWRIGHT_BROWSERS_PATH=0
+RUN corepack enable && corepack prepare pnpm@10.13.1 --activate
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+# Uses the lockfile-resolved playwright version — no version drift possible.
+RUN npx playwright install --with-deps chromium
+
+COPY . .
+
+# Socket Mode is outbound-only: no ports exposed. Needs SLACK_BOT_TOKEN,
+# SLACK_APP_TOKEN, AGENT_URL in the environment.
+CMD ["pnpm", "start"]

--- a/examples/slack/Dockerfile.runtime
+++ b/examples/slack/Dockerfile.runtime
@@ -1,0 +1,17 @@
+# Agent backend (runtime.ts): LLM + MCP served over AG-UI.
+# No browser — chart/diagram rendering happens in the bot image.
+FROM node:22.16.0-slim@sha256:048ed02c5fd52e86fda6fbd2f6a76cf0d4492fd6c6fee9e2c463ed5108da0e34
+
+WORKDIR /app
+ENV CI=true
+RUN corepack enable && corepack prepare pnpm@10.13.1 --activate
+
+# Layer-cache the install: manifests first, source after.
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+# Reads PORT (default 8200). Slack/LLM/MCP credentials come from the environment.
+EXPOSE 8200
+CMD ["pnpm", "runtime"]

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -313,6 +313,31 @@ set the same env vars, and (for Notion) run the
 `@notionhq/notion-mcp-server` sidecar alongside the runtime with
 `NOTION_MCP_URL` pointed at it.
 
+## Deploying
+
+The example is two processes, each with its own image — everything they need is encoded in the Dockerfiles (no platform build magic required):
+
+| Process                          | Dockerfile           | Env vars                                                                                                 | Network                                |
+| -------------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `runtime` (agent backend)        | `Dockerfile.runtime` | `OPENAI_API_KEY`, `LINEAR_API_KEY` (optional), `LINEAR_TEAM_KEY` (optional), `PORT` (default 8200)       | Listens on `PORT`; keep it private     |
+| `bot` (Slack ingress + renderer) | `Dockerfile.bot`     | `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `AGENT_URL` (the runtime's `/api/copilotkit/agent/triage/run` URL) | Outbound-only (Socket Mode) — no ports |
+
+```bash
+docker build -f Dockerfile.runtime -t slack-example-runtime .
+docker build -f Dockerfile.bot -t slack-example-bot .
+```
+
+The bot image bakes in Playwright Chromium and its system libraries (for the
+`render_chart` / `render_diagram` tools): browsers install inside
+`node_modules` (`PLAYWRIGHT_BROWSERS_PATH=0`) so they ship with the app layer.
+
+On Railway: one project, two services pointed at this directory with the
+respective `dockerfilePath`, secrets set per the table, and
+`AGENT_URL=http://<runtime-private-domain>:8200/api/copilotkit/agent/triage/run`
+over the private network. Scope deploy triggers with a watch path of
+`/examples/slack/**`. Note: a bot restart drops in-flight button handlers
+(in-memory `ActionStore`) — clicks on older messages degrade to "expired".
+
 ## Tests
 
 ```bash

--- a/examples/slack/package.json
+++ b/examples/slack/package.json
@@ -37,5 +37,6 @@
     "overrides": {
       "@ai-sdk/mcp": "1.0.21"
     }
-  }
+  },
+  "packageManager": "pnpm@10.13.1"
 }


### PR DESCRIPTION
Makes the hosted-deployment recipe **permanent and portable** — everything currently living as Railway service config becomes reviewable code in the example.

## What

- **`Dockerfile.runtime`** — the agent backend: digest-pinned `node:22.16.0-slim`, pinned pnpm (`packageManager` field added), frozen-lockfile install, `pnpm runtime`. No browser.
- **`Dockerfile.bot`** — the Slack ingress + chart/diagram renderer: same base, plus Playwright Chromium installed **inside `node_modules`** (`PLAYWRIGHT_BROWSERS_PATH=0`, so the browser ships with the app layer) and its system libraries via `playwright install --with-deps`. These were exactly the two gaps that broke `render_chart` on Railpack-style platform builders: build-stage browser caches don't ship, and deploy images lack Chromium's shared libraries.
- **`.dockerignore`**, README **Deploying** section (process/env table, Railway notes incl. the watch-path and ActionStore-restart caveats).

## Verification (per docker-ci-safety: local builds before any platform sees them)

- Both images build clean locally
- `chromium.launch()` inside the built bot image → **LAUNCH OK**
- Runtime image boots to `[slack-runtime] listening` / `agent ready`
- The equivalent env-var configuration is already live on Railway and rendering charts in our workspace; after this merges, the services switch to `dockerfilePath` and the scaffolding env vars get deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)