### PR TITLE
docs(skills): complete v2 API migration across CopilotKit skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "copilotkit",
       "source": "./",
       "description": "AI agent skills for CopilotKit — setup, develop, integrate, debug, upgrade, and contribute to CopilotKit projects",
-      "version": "1.59.5",
+      "version": "1.60.0",
       "author": {
         "name": "CopilotKit",
         "url": "https://copilotkit.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "copilotkit",
   "description": "AI agent skills for CopilotKit — setup, develop, integrate, debug, upgrade, and contribute to CopilotKit projects",
-  "version": "1.59.5",
+  "version": "1.60.0",
   "author": {
     "name": "CopilotKit",
     "url": "https://copilotkit.ai"

--- a/packages/react-core/skills/react-core/references/chat-components.md
+++ b/packages/react-core/skills/react-core/references/chat-components.md
@@ -31,7 +31,7 @@ suggestions internally via `useAgent`. You do not pass `messages` or
 ```tsx
 import { CopilotPopup } from "@copilotkit/react-core/v2";
 
-<CopilotPopup agentId="default" isModalDefaultOpen={false} />;
+<CopilotPopup agentId="default" defaultOpen={false} />;
 ```
 
 ### Persistent sidebar
@@ -53,8 +53,6 @@ want to manage `messages`/`isRunning` yourself.
 ```tsx
 import {
   CopilotChatView,
-  CopilotChatInput,
-  CopilotChatMessageView,
   useAgent,
   useCopilotKit,
 } from "@copilotkit/react-core/v2";
@@ -67,7 +65,7 @@ export function HeadlessChat() {
     <CopilotChatView
       messages={agent.messages}
       isRunning={agent.isRunning}
-      onSubmitInput={async (text) => {
+      onSubmitMessage={async (text) => {
         agent.addMessage({
           id: crypto.randomUUID(),
           role: "user",
@@ -76,8 +74,12 @@ export function HeadlessChat() {
         await copilotkit.runAgent({ agent });
       }}
     >
-      <CopilotChatMessageView />
-      <CopilotChatInput />
+      {({ messageView, input }) => (
+        <>
+          {messageView}
+          {input}
+        </>
+      )}
     </CopilotChatView>
   );
 }
@@ -90,7 +92,7 @@ export function HeadlessChat() {
   agentId="default"
   labels={{
     chatInputPlaceholder: "Ask about the data…",
-    thinking: "Analyzing…",
+    welcomeMessageText: "What would you like to analyze?",
   }}
 />
 ```
@@ -158,14 +160,19 @@ Correct:
 // CopilotChat manages messages and isRunning internally.
 <CopilotChat agentId="default" />
 
-// For manual control, drop down to headless CopilotChatView:
+// For manual control, drop down to headless CopilotChatView. Its `children`
+// is a render prop that receives the bound slot elements:
 <CopilotChatView
   messages={myMessages}
   isRunning={busy}
-  onSubmitInput={handleSubmit}
+  onSubmitMessage={handleSubmit}
 >
-  <CopilotChatMessageView />
-  <CopilotChatInput />
+  {({ messageView, input }) => (
+    <>
+      {messageView}
+      {input}
+    </>
+  )}
 </CopilotChatView>
 ```
 

--- a/packages/runtime/skills/runtime/references/wiring-agno.md
+++ b/packages/runtime/skills/runtime/references/wiring-agno.md
@@ -1,9 +1,10 @@
-Agno — wired via `@ag-ui/agno`. Requires an `/agui` URL suffix.
+Agno — wired via the generic `HttpAgent` from `@ag-ui/client`. Requires an `/agui` URL
+suffix.
 
 ## Install
 
 ```bash
-pnpm add @ag-ui/agno
+pnpm add @ag-ui/client
 ```
 
 ## Minimal wire-up
@@ -13,11 +14,11 @@ import {
   CopilotRuntime,
   createCopilotRuntimeHandler,
 } from "@copilotkit/runtime/v2";
-import { AgnoAgent } from "@ag-ui/agno";
+import { HttpAgent } from "@ag-ui/client";
 
 const runtime = new CopilotRuntime({
   agents: {
-    default: new AgnoAgent({
+    default: new HttpAgent({
       url: process.env.AGNO_URL ?? "http://localhost:8000/agui",
     }),
   },

--- a/packages/runtime/skills/runtime/references/wiring-external-agents.md
+++ b/packages/runtime/skills/runtime/references/wiring-external-agents.md
@@ -3,20 +3,20 @@
 `CopilotRuntime` takes any `AbstractAgent` subclass. Every framework below ships a
 ready-made subclass you construct and hand to `agents: { ... }`.
 
-| Framework                 | Package                     | Construct                                                                                                                    |
-| ------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| Mastra                    | `@ag-ui/mastra`             | `MastraAgent.getLocalAgents({ mastra, resourceId? })` (record; `resourceId` required only when the agent has Memory enabled) |
-| LangGraph                 | `@ag-ui/langgraph`          | `new LangGraphAgent({ deploymentUrl, graphId })`                                                                             |
-| CrewAI Crews              | `@ag-ui/crewai`             | `new CrewAIAgent({ url })`                                                                                                   |
-| CrewAI Flows              | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
-| PydanticAI                | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
-| Google ADK                | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
-| LlamaIndex                | `@ag-ui/llamaindex`         | `new LlamaIndexAgent({ url: ".../run" })` (`/run` suffix)                                                                    |
-| Agno                      | `@ag-ui/agno`               | `new AgnoAgent({ url: ".../agui" })` (`/agui` suffix)                                                                        |
-| AWS Strands               | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
-| Microsoft Agent Framework | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
-| AG2                       | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
-| A2A                       | `@ag-ui/a2a`                | `new A2AAgent({ a2aClient })` (pre-built `A2AClient`, not a URL)                                                             |
+| Framework                 | Package                         | Construct                                                                                                                    |
+| ------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Mastra                    | `@ag-ui/mastra`                 | `MastraAgent.getLocalAgents({ mastra, resourceId? })` (record; `resourceId` required only when the agent has Memory enabled) |
+| LangGraph                 | `@copilotkit/runtime/langgraph` | `new LangGraphAgent({ deploymentUrl, graphId })`                                                                             |
+| CrewAI Crews              | `@ag-ui/crewai`                 | `new CrewAIAgent({ url })`                                                                                                   |
+| CrewAI Flows              | `@ag-ui/client` (HttpAgent)     | `new HttpAgent({ url })`                                                                                                     |
+| PydanticAI                | `@ag-ui/client` (HttpAgent)     | `new HttpAgent({ url })`                                                                                                     |
+| Google ADK                | `@ag-ui/client` (HttpAgent)     | `new HttpAgent({ url })`                                                                                                     |
+| LlamaIndex                | `@ag-ui/llamaindex`             | `new LlamaIndexAgent({ url: ".../run" })` (`/run` suffix)                                                                    |
+| Agno                      | `@ag-ui/client` (HttpAgent)     | `new HttpAgent({ url: ".../agui" })` (`/agui` suffix)                                                                        |
+| AWS Strands               | `@ag-ui/client` (HttpAgent)     | `new HttpAgent({ url })`                                                                                                     |
+| Microsoft Agent Framework | `@ag-ui/client` (HttpAgent)     | `new HttpAgent({ url })`                                                                                                     |
+| AG2                       | `@ag-ui/client` (HttpAgent)     | `new HttpAgent({ url })`                                                                                                     |
+| A2A                       | `@ag-ui/a2a`                    | `new A2AAgent({ a2aClient })` (pre-built `A2AClient`, not a URL)                                                             |
 
 MCP Apps is NOT a framework — it's a runtime middleware:
 `new CopilotRuntime({ agents, mcpApps: { servers: [...] } })`. See
@@ -85,7 +85,7 @@ import {
   CopilotRuntime,
   createCopilotRuntimeHandler,
 } from "@copilotkit/runtime/v2";
-import { LangGraphAgent } from "@ag-ui/langgraph";
+import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const runtime = new CopilotRuntime({
   agents: {
@@ -114,7 +114,7 @@ import {
   CopilotRuntime,
   createCopilotRuntimeHandler,
 } from "@copilotkit/runtime/v2";
-import { LangGraphAgent } from "@ag-ui/langgraph";
+import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 import { CrewAIAgent } from "@ag-ui/crewai";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -170,7 +170,7 @@ export default { fetch: handler };
 Wrong:
 
 ```typescript
-import { LangGraphAgent } from "@ag-ui/langgraph";
+import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 new LangGraphAgent({ deploymentUrl: "/api/copilotkit", graphId: "agent" });
 ```
@@ -221,17 +221,17 @@ Wrong:
 
 ```typescript
 import { LlamaIndexAgent } from "@ag-ui/llamaindex";
-import { AgnoAgent } from "@ag-ui/agno";
+import { HttpAgent } from "@ag-ui/client";
 
 new LlamaIndexAgent({ url: "http://localhost:8000" });
-new AgnoAgent({ url: "http://localhost:8000" });
+new HttpAgent({ url: "http://localhost:8000" });
 ```
 
 Correct:
 
 ```typescript
 new LlamaIndexAgent({ url: "http://localhost:8000/run" });
-new AgnoAgent({ url: "http://localhost:8000/agui" });
+new HttpAgent({ url: "http://localhost:8000/agui" });
 ```
 
 LlamaIndex requires a `/run` suffix, Agno requires `/agui`. The generic HttpAgent fallback

--- a/packages/runtime/skills/runtime/references/wiring-langgraph.md
+++ b/packages/runtime/skills/runtime/references/wiring-langgraph.md
@@ -1,11 +1,10 @@
-LangGraph — wired via `@ag-ui/langgraph`. Supports LangGraph Platform deployments and
-self-hosted LangGraph servers.
+LangGraph — wired via `@copilotkit/runtime/langgraph`. Supports LangGraph Platform
+deployments and self-hosted LangGraph servers.
 
 ## Install
 
-```bash
-pnpm add @ag-ui/langgraph
-```
+`LangGraphAgent` (and `LangGraphHttpAgent` for self-hosted AG-UI LangGraph servers)
+ship with `@copilotkit/runtime` — no separate install needed.
 
 ## Minimal wire-up
 
@@ -14,7 +13,7 @@ import {
   CopilotRuntime,
   createCopilotRuntimeHandler,
 } from "@copilotkit/runtime/v2";
-import { LangGraphAgent } from "@ag-ui/langgraph";
+import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const runtime = new CopilotRuntime({
   agents: {

--- a/skills/copilotkit-develop/SKILL.md
+++ b/skills/copilotkit-develop/SKILL.md
@@ -17,19 +17,23 @@ This plugin includes an MCP server (`copilotkit-docs`) that provides `search-doc
 
 CopilotKit v2 is built on the AG-UI protocol (`@ag-ui/client` / `@ag-ui/core`). The stack has three layers:
 
-1. **Runtime** (`@copilotkit/runtime`) -- Server-side. Hosts agents, handles SSE/Intelligence transport, middleware, transcription.
+1. **Runtime** (`@copilotkit/runtime`, v2 symbols under `@copilotkit/runtime/v2`) -- Server-side. Hosts agents, handles SSE/Intelligence transport, middleware, transcription.
 2. **Core** (`@copilotkit/core`) -- Shared state management, tool registry, suggestion engine. Not imported directly by apps.
-3. **React** (`@copilotkit/react`) -- Provider, chat components, hooks. Re-exports everything from `@ag-ui/client` so apps need only one import.
+3. **React** (`@copilotkit/react-core`, v2 symbols under `@copilotkit/react-core/v2`) -- Provider, chat components, hooks. Re-exports everything from `@ag-ui/client` so apps need only one import.
 
 ## Workflow
 
 ### 1. Set Up the Runtime (Server)
 
-Create a `CopilotRuntime` (or the explicit `CopilotSseRuntime` / `CopilotIntelligenceRuntime`) and expose it via `createCopilotEndpoint` (Hono) or `createCopilotEndpointExpress` (Express).
+Create a `CopilotRuntime` (or the explicit `CopilotSseRuntime` / `CopilotIntelligenceRuntime`) and expose it via `createCopilotHonoHandler` (Hono) or `createCopilotExpressHandler` (Express).
 
 ```ts
-import { CopilotRuntime, createCopilotEndpoint } from "@copilotkit/runtime";
-import { LangGraphAgent } from "@ag-ui/langgraph";
+import {
+  CopilotRuntime,
+  createCopilotHonoHandler,
+} from "@copilotkit/runtime/v2";
+import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
+import { handle } from "hono/vercel";
 
 const runtime = new CopilotRuntime({
   agents: {
@@ -39,10 +43,18 @@ const runtime = new CopilotRuntime({
   },
 });
 
-const app = createCopilotEndpoint({
+const app = createCopilotHonoHandler({
   runtime,
   basePath: "/api/copilotkit",
 });
+
+// Multi-route (the default): export every method the runtime serves.
+// useThreads needs them all — rename via PATCH, delete via DELETE; archive
+// uses the already-exported POST.
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
 
 ### 2. Wrap Your App with the Provider (Client)
@@ -54,7 +66,10 @@ import { CopilotKit } from "@copilotkit/react-core/v2";
 
 function App() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit">
+    // useSingleEndpoint={false} matches the multi-route backend above. The
+    // v1-compat CopilotKit bridge defaults it to true (single transport),
+    // which would 404 against a multi-route handler.
+    <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
       <YourApp />
     </CopilotKit>
   );
@@ -66,7 +81,7 @@ function App() {
 Use `<CopilotChat>`, `<CopilotPopup>`, or `<CopilotSidebar>`:
 
 ```tsx
-import { CopilotChat } from "@copilotkit/react";
+import { CopilotChat } from "@copilotkit/react-core/v2";
 
 function ChatPage() {
   return <CopilotChat agentId="myAgent" />;
@@ -78,7 +93,7 @@ function ChatPage() {
 Let the agent call functions in the browser:
 
 ```tsx
-import { useFrontendTool } from "@copilotkit/react";
+import { useFrontendTool } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
 useFrontendTool({
@@ -97,7 +112,7 @@ useFrontendTool({
 Provide runtime data to the agent:
 
 ```tsx
-import { useAgentContext } from "@copilotkit/react";
+import { useAgentContext } from "@copilotkit/react-core/v2";
 
 useAgentContext({
   description: "The user's current shopping cart",
@@ -110,7 +125,7 @@ useAgentContext({
 When an agent pauses for human input:
 
 ```tsx
-import { useInterrupt } from "@copilotkit/react";
+import { useInterrupt } from "@copilotkit/react-core/v2";
 
 useInterrupt({
   render: ({ event, resolve }) => (
@@ -127,7 +142,7 @@ useInterrupt({
 Show custom UI when tools execute:
 
 ```tsx
-import { useRenderTool } from "@copilotkit/react";
+import { useRenderTool } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
 useRenderTool(
@@ -153,7 +168,7 @@ useRenderTool(
 | `useComponent`             | Register a React component as a chat-rendered tool (convenience wrapper around `useFrontendTool`) |
 | `useAgentContext`          | Share JSON-serializable application state with the agent                                          |
 | `useAgent`                 | Get the `AbstractAgent` instance for an agent ID; subscribe to message/state/run-status changes   |
-| `useInterrupt`             | Handle `on_interrupt` events from agents with render + optional handler/filter                    |
+| `useInterrupt`             | Handle `on_interrupt` events from agents with render + optional handler/`enabled` predicate       |
 | `useHumanInTheLoop`        | Register a tool that pauses execution until the user responds via a rendered UI                   |
 | `useRenderTool`            | Register a renderer for tool calls (by name or wildcard `"*"`)                                    |
 | `useDefaultRenderTool`     | Register a wildcard `"*"` renderer using the built-in expandable card UI                          |
@@ -179,11 +194,13 @@ useRenderTool(
 
 ## Quick Reference: Runtime
 
-| Export                         | Purpose                                                   |
-| ------------------------------ | --------------------------------------------------------- |
-| `CopilotRuntime`               | Auto-detecting runtime (delegates to SSE or Intelligence) |
-| `CopilotSseRuntime`            | Explicit SSE-mode runtime                                 |
-| `CopilotIntelligenceRuntime`   | Intelligence-mode runtime with durable threads            |
-| `createCopilotEndpoint`        | Create a Hono app with all CopilotKit routes              |
-| `createCopilotEndpointExpress` | Create an Express router with all CopilotKit routes       |
-| `CopilotKitIntelligence`       | Intelligence platform client configuration                |
+All v2 runtime symbols import from `@copilotkit/runtime/v2` (`createCopilotExpressHandler` from `@copilotkit/runtime/v2/express`).
+
+| Export                        | Purpose                                                   |
+| ----------------------------- | --------------------------------------------------------- |
+| `CopilotRuntime`              | Auto-detecting runtime (delegates to SSE or Intelligence) |
+| `CopilotSseRuntime`           | Explicit SSE-mode runtime                                 |
+| `CopilotIntelligenceRuntime`  | Intelligence-mode runtime with durable threads            |
+| `createCopilotHonoHandler`    | Create a Hono app with all CopilotKit routes              |
+| `createCopilotExpressHandler` | Create an Express router with all CopilotKit routes       |
+| `CopilotKitIntelligence`      | Intelligence platform client configuration                |

--- a/skills/copilotkit-develop/references/api-surface.md
+++ b/skills/copilotkit-develop/references/api-surface.md
@@ -1,12 +1,12 @@
 # CopilotKit v2 Public API Reference
 
-Package imports: `@copilotkit/react`, `@copilotkit/runtime`, `@copilotkit/core`.
+Package imports: `@copilotkit/react-core/v2`, `@copilotkit/runtime/v2`, `@copilotkit/core`.
 
-Note: `@copilotkit/react` re-exports everything from `@ag-ui/client` (which itself re-exports `@ag-ui/core`), so applications typically only need `@copilotkit/react` and `@copilotkit/runtime`.
+Note: `@copilotkit/react-core/v2` re-exports everything from `@ag-ui/client` (which itself re-exports `@ag-ui/core`), so applications typically only need `@copilotkit/react-core/v2` and `@copilotkit/runtime/v2`.
 
 ---
 
-## Hooks (`@copilotkit/react`)
+## Hooks (`@copilotkit/react-core/v2`)
 
 ### useFrontendTool
 
@@ -281,14 +281,18 @@ Registers a suggestion configuration. Two modes:
 function useThreads(input: UseThreadsInput): UseThreadsResult;
 
 interface UseThreadsInput {
-  userId: string;
   agentId: string;
+  includeArchived?: boolean; // default: false
+  limit?: number; // enables cursor-based pagination when set
 }
 
 interface UseThreadsResult {
   threads: Thread[];
   isLoading: boolean;
   error: Error | null;
+  hasMoreThreads: boolean;
+  isFetchingMoreThreads: boolean;
+  fetchMoreThreads: () => void;
   renameThread: (threadId: string, name: string) => Promise<void>;
   archiveThread: (threadId: string) => Promise<void>;
   deleteThread: (threadId: string) => Promise<void>;
@@ -296,13 +300,16 @@ interface UseThreadsResult {
 
 interface Thread {
   id: string;
-  name?: string;
+  agentId: string;
+  name: string | null;
+  archived: boolean;
   createdAt: string;
   updatedAt: string;
+  lastRunAt?: string; // last agent run; prefer over updatedAt for "last activity"
 }
 ```
 
-Lists and manages Intelligence platform threads. Uses a realtime WebSocket subscription when available.
+Lists and manages Intelligence platform threads. Thread operations are scoped to the runtime-authenticated user (no `userId` input) and the given `agentId`. Uses a realtime WebSocket subscription when available.
 
 ---
 
@@ -340,7 +347,7 @@ Returns a function to render custom message decorators at `"before"` or `"after"
 
 ---
 
-## Components (`@copilotkit/react`)
+## Components (`@copilotkit/react-core/v2`)
 
 ### CopilotKit (provider)
 
@@ -450,7 +457,7 @@ Headless chat view with a slot-based architecture. Accepts slots for `messageVie
 
 ---
 
-## Types (`@copilotkit/react`)
+## Types (`@copilotkit/react-core/v2`)
 
 ### ReactFrontendTool
 
@@ -521,6 +528,6 @@ type FrontendToolHandlerContext = {
 
 ---
 
-## Runtime (`@copilotkit/runtime`)
+## Runtime (`@copilotkit/runtime/v2`)
 
 See [runtime-api.md](./runtime-api.md) for full runtime reference.

--- a/skills/copilotkit-develop/references/runtime-api.md
+++ b/skills/copilotkit-develop/references/runtime-api.md
@@ -1,6 +1,6 @@
 # CopilotKit v2 Runtime API Reference
 
-Package: `@copilotkit/runtime`
+Package: `@copilotkit/runtime/v2` (`createCopilotExpressHandler` from `@copilotkit/runtime/v2/express`)
 
 ---
 
@@ -11,7 +11,7 @@ Package: `@copilotkit/runtime`
 Compatibility shim that auto-detects the mode based on whether `intelligence` is provided. Delegates to `CopilotSseRuntime` or `CopilotIntelligenceRuntime`.
 
 ```ts
-import { CopilotRuntime } from "@copilotkit/runtime";
+import { CopilotRuntime } from "@copilotkit/runtime/v2";
 
 const runtime = new CopilotRuntime({
   agents: { myAgent: new LangGraphAgent({ ... }) },
@@ -24,7 +24,7 @@ const runtime = new CopilotRuntime({
 Explicit SSE-mode runtime. Agents run in-memory via `InMemoryAgentRunner`.
 
 ```ts
-import { CopilotSseRuntime } from "@copilotkit/runtime";
+import { CopilotSseRuntime } from "@copilotkit/runtime/v2";
 
 const runtime = new CopilotSseRuntime({
   agents: { myAgent: agent },
@@ -40,12 +40,15 @@ Intelligence-mode runtime with durable threads, realtime events, and persistent 
 import {
   CopilotIntelligenceRuntime,
   CopilotKitIntelligence,
-} from "@copilotkit/runtime";
+} from "@copilotkit/runtime/v2";
 
 const runtime = new CopilotIntelligenceRuntime({
   agents: { myAgent: agent },
   intelligence: new CopilotKitIntelligence({ ... }),
-  identifyUser: async (request) => ({ id: getUserIdFromRequest(request) }),
+  identifyUser: async (request) => ({
+    id: getUserIdFromRequest(request),
+    name: getUserNameFromRequest(request),
+  }),
   generateThreadNames?: boolean,  // default: true
 });
 ```
@@ -93,14 +96,15 @@ type McpAppsServerConfig = MCPClientConfig & {
 
 ## Endpoint Factories
 
-### createCopilotEndpoint (Hono)
+### createCopilotHonoHandler (Hono)
 
 ```ts
-import { createCopilotEndpoint } from "@copilotkit/runtime";
+import { createCopilotHonoHandler } from "@copilotkit/runtime/v2";
 
-const app = createCopilotEndpoint({
+const app = createCopilotHonoHandler({
   runtime: CopilotRuntimeLike,
   basePath: string,
+  mode?: "multi-route" | "single-route", // default: "multi-route"
   cors?: {
     origin: string | string[] | ((origin: string) => string | null);
     credentials?: boolean;
@@ -108,16 +112,17 @@ const app = createCopilotEndpoint({
 });
 ```
 
-Returns a Hono app instance with all CopilotKit routes mounted under `basePath`.
+Returns a Hono app instance with all CopilotKit routes mounted under `basePath`. Defaults to multi-route mode; pass `mode: "single-route"` to expose a single combined route.
 
-### createCopilotEndpointExpress (Express)
+### createCopilotExpressHandler (Express)
 
 ```ts
-import { createCopilotEndpointExpress } from "@copilotkit/runtime";
+import { createCopilotExpressHandler } from "@copilotkit/runtime/v2/express";
 
-const router = createCopilotEndpointExpress({
+const router = createCopilotExpressHandler({
   runtime: CopilotRuntimeLike,
   basePath: string,
+  mode?: "multi-route" | "single-route", // default: "multi-route"
 });
 
 // Use in Express app:
@@ -204,7 +209,7 @@ const runtime = new CopilotRuntime({
 Client for the CopilotKit Intelligence platform (durable threads, realtime WebSocket).
 
 ```ts
-import { CopilotKitIntelligence } from "@copilotkit/runtime";
+import { CopilotKitIntelligence } from "@copilotkit/runtime/v2";
 
 const intelligence = new CopilotKitIntelligence({
   // Configuration for the Intelligence platform
@@ -217,7 +222,9 @@ const intelligence = new CopilotKitIntelligence({
 Required for Intelligence mode. Resolves the authenticated user from the incoming request.
 
 ```ts
-type IdentifyUserCallback = (request: Request) => MaybePromise<{ id: string }>;
+type IdentifyUserCallback = (
+  request: Request,
+) => MaybePromise<{ id: string; name: string }>;
 ```
 
 ### Thread Management Types
@@ -286,7 +293,7 @@ Implement this class to provide audio-to-text transcription. The runtime exposes
 The Hono endpoint factory accepts explicit CORS configuration:
 
 ```ts
-createCopilotEndpoint({
+createCopilotHonoHandler({
   runtime,
   basePath: "/api/copilotkit",
   cors: {
@@ -306,38 +313,40 @@ The Express endpoint factory uses `cors({ origin: "*" })` by default. Override b
 
 ```ts
 // app/api/copilotkit/[[...path]]/route.ts
-import { CopilotRuntime, createCopilotEndpoint } from "@copilotkit/runtime";
-import { LangGraphAgent } from "@ag-ui/langgraph";
+import {
+  CopilotRuntime,
+  createCopilotHonoHandler,
+} from "@copilotkit/runtime/v2";
+import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
+import { handle } from "hono/vercel";
 
 const runtime = new CopilotRuntime({
   agents: {
     researcher: new LangGraphAgent({
       graphId: "researcher",
-      url: process.env.LANGGRAPH_URL!,
+      deploymentUrl: process.env.LANGGRAPH_URL!,
     }),
   },
 });
 
-const app = createCopilotEndpoint({
+const app = createCopilotHonoHandler({
   runtime,
   basePath: "/api/copilotkit",
 });
 
-export const GET = app.fetch;
-export const POST = app.fetch;
-export const PATCH = app.fetch;
-export const DELETE = app.fetch;
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
 
 ## Complete Example: Express
 
 ```ts
 import express from "express";
-import {
-  CopilotRuntime,
-  createCopilotEndpointExpress,
-} from "@copilotkit/runtime";
-import { LangGraphAgent } from "@ag-ui/langgraph";
+import { CopilotRuntime } from "@copilotkit/runtime/v2";
+import { createCopilotExpressHandler } from "@copilotkit/runtime/v2/express";
+import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const app = express();
 
@@ -345,13 +354,13 @@ const runtime = new CopilotRuntime({
   agents: {
     researcher: new LangGraphAgent({
       graphId: "researcher",
-      url: process.env.LANGGRAPH_URL!,
+      deploymentUrl: process.env.LANGGRAPH_URL!,
     }),
   },
 });
 
 app.use(
-  createCopilotEndpointExpress({
+  createCopilotExpressHandler({
     runtime,
     basePath: "/api/copilotkit",
   }),

--- a/skills/copilotkit-integrations/SKILL.md
+++ b/skills/copilotkit-integrations/SKILL.md
@@ -19,8 +19,8 @@ CopilotKit connects to external agent frameworks through the **AG-UI (Agent-UI) 
 
 1. **Agent server** -- your agent framework runs as an HTTP server (usually FastAPI/uvicorn for Python, or an Express/Next.js route for JS/TS)
 2. **AG-UI adapter** -- a framework-specific adapter translates between the agent's native interface and the AG-UI wire protocol
-3. **CopilotKit runtime** -- the Next.js API route creates a `CopilotRuntime` that connects to the agent via an AG-UI client class
-4. **Frontend** -- React components use `useAgent`, `useFrontendTool`, `useRenderToolCall`, and `useHumanInTheLoop` to interact with the agent
+3. **CopilotKit runtime** -- the Next.js catch-all API route creates a `CopilotRuntime` that connects to the agent via an AG-UI client class, mounted with the V2 multi-route Hono handler
+4. **Frontend** -- React components use `useAgent`, `useFrontendTool`, `useRenderTool`, and `useHumanInTheLoop` to interact with the agent
 
 ## Supported Integrations
 
@@ -78,76 +78,87 @@ import "@copilotkit/react-core/v2/styles.css";
 
 export default function RootLayout({ children }) {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent_name">
+    <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
       {children}
     </CopilotKit>
   );
 }
 ```
 
-The `agent` prop must match the key used in `CopilotRuntime({ agents: { my_agent_name: ... } })`.
+The provider component is `CopilotKit` (imported from `@copilotkit/react-core/v2`). There is no `agent` prop -- agents are selected per-hook via `agentId` (matching a key from `CopilotRuntime({ agents: { ... } })`). Set `useSingleEndpoint={false}` so the v1-compat bridge uses multi-route transport against the catch-all backend route below; omitting it defaults to single-route, which a multi-route backend 404s.
 
 ### API Route Pattern (route.ts)
 
-All integrations create a Next.js API route at `src/app/api/copilotkit/route.ts`:
+All integrations create a Next.js catch-all API route at `src/app/api/copilotkit/[[...slug]]/route.ts` using the V2 multi-route Hono handler:
 
 ```tsx
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { NextRequest } from "next/server";
+  createCopilotHonoHandler,
+  InMemoryAgentRunner,
+} from "@copilotkit/runtime/v2";
+import { handle } from "hono/vercel";
 // Import the appropriate agent class for your framework
 
 const runtime = new CopilotRuntime({
   agents: {
-    my_agent: new SomeAgentClass({ url: "http://localhost:8000/" }),
+    default: new SomeAgentClass({ url: "http://localhost:8000/" }),
   },
+  runner: new InMemoryAgentRunner(),
 });
 
-export const POST = async (req: NextRequest) => {
-  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-    runtime,
-    serviceAdapter: new ExperimentalEmptyAdapter(),
-    endpoint: "/api/copilotkit",
-  });
-  return handleRequest(req);
-};
+const app = createCopilotHonoHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
+
+Use `createCopilotHonoHandler` (the non-deprecated factory; `createCopilotEndpoint` is an alias). The frontend selects this agent via `agentId: "default"`.
 
 ### Shared State (useAgent)
 
+`useAgent` returns `{ agent }` only. Read state via `agent.state` and write via `agent.setState`:
+
 ```tsx
-const { state, setState } = useAgent<{ proverbs: string[] }>({
-  name: "my_agent",
-  initialState: { proverbs: [] },
-});
+const { agent } = useAgent({ agentId: "default" });
+const state = (agent.state as { proverbs: string[] } | undefined) ?? {
+  proverbs: [],
+};
+const setState = (next: { proverbs: string[] }) => agent.setState(next);
 ```
 
 ### Frontend Tools (useFrontendTool)
 
 ```tsx
+import { z } from "zod";
+
 useFrontendTool({
   name: "setThemeColor",
-  parameters: [
-    { name: "themeColor", description: "Hex color value", required: true },
-  ],
-  handler({ themeColor }) {
+  parameters: z.object({
+    themeColor: z.string().describe("The theme color to set."),
+  }),
+  handler: async ({ themeColor }) => {
     setThemeColor(themeColor);
+    return `Set theme color to ${themeColor}`;
   },
 });
 ```
 
-### Generative UI (useRenderToolCall)
+### Generative UI (useRenderTool)
 
 ```tsx
-useRenderToolCall(
+import { z } from "zod";
+
+useRenderTool(
   {
     name: "get_weather",
-    description: "Get weather for a location.",
-    parameters: [{ name: "location", type: "string", required: true }],
-    render: ({ args }) => <WeatherCard location={args.location} />,
+    parameters: z.object({ location: z.string() }),
+    render: ({ parameters }) => <WeatherCard location={parameters.location} />,
   },
   [],
 );
@@ -176,8 +187,8 @@ On the agent side, shared state is managed differently per framework, but the pr
 
 Frontend (all integrations):
 
-- `@copilotkit/react` -- hooks (`useAgent`, `useFrontendTool`, `useRenderToolCall`, `useHumanInTheLoop`) and UI components (`CopilotSidebar`, `CopilotPopup`)
-- `@copilotkit/runtime` -- server runtime (`CopilotRuntime`, `ExperimentalEmptyAdapter`)
+- `@copilotkit/react-core/v2` -- provider (`CopilotKit`), hooks (`useAgent`, `useFrontendTool`, `useRenderTool`, `useHumanInTheLoop`), and chat components (`CopilotChat`, `CopilotSidebar`, `CopilotPopup`). Styles: `import "@copilotkit/react-core/v2/styles.css"`.
+- `@copilotkit/runtime/v2` -- server runtime (`CopilotRuntime`, `createCopilotHonoHandler`, `InMemoryAgentRunner`)
 
 AG-UI client classes (choose one per integration):
 

--- a/skills/copilotkit-integrations/references/integrations/a2a.md
+++ b/skills/copilotkit-integrations/references/integrations/a2a.md
@@ -26,59 +26,60 @@ Orchestrator (ADK, port 9000)
 - Python 3.10+
 - Google API key + OpenAI API key
 
-### Next.js Route (app/api/copilotkit/route.ts)
+### Next.js Route (app/api/copilotkit/[[...slug]]/route.ts)
 
 ```typescript
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotHonoHandler,
+  InMemoryAgentRunner,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import { A2AMiddlewareAgent } from "@ag-ui/a2a-middleware";
-import { NextRequest } from "next/server";
+import { handle } from "hono/vercel";
 
-export async function POST(request: NextRequest) {
-  const researchAgentUrl =
-    process.env.RESEARCH_AGENT_URL || "http://localhost:9001";
-  const analysisAgentUrl =
-    process.env.ANALYSIS_AGENT_URL || "http://localhost:9002";
-  const orchestratorUrl =
-    process.env.ORCHESTRATOR_URL || "http://localhost:9000";
+const researchAgentUrl =
+  process.env.RESEARCH_AGENT_URL || "http://localhost:9001";
+const analysisAgentUrl =
+  process.env.ANALYSIS_AGENT_URL || "http://localhost:9002";
+const orchestratorUrl = process.env.ORCHESTRATOR_URL || "http://localhost:9000";
 
-  // Connect to orchestrator via AG-UI Protocol
-  const orchestrationAgent = new HttpAgent({ url: orchestratorUrl });
+// Connect to orchestrator via AG-UI Protocol
+const orchestrationAgent = new HttpAgent({ url: orchestratorUrl });
 
-  // A2A Middleware wraps orchestrator and injects send_message_to_a2a_agent tool
-  const a2aMiddlewareAgent = new A2AMiddlewareAgent({
-    description: "Research assistant with 2 specialized agents",
-    agentUrls: [researchAgentUrl, analysisAgentUrl],
-    orchestrationAgent,
-    instructions: `
-      You are a research assistant that orchestrates between 2 specialized agents.
-      - Research Agent (LangGraph): Gathers and summarizes information
-      - Analysis Agent (ADK): Analyzes research findings
+// A2A Middleware wraps orchestrator and injects send_message_to_a2a_agent tool
+const a2aMiddlewareAgent = new A2AMiddlewareAgent({
+  description: "Research assistant with 2 specialized agents",
+  agentUrls: [researchAgentUrl, analysisAgentUrl],
+  orchestrationAgent,
+  instructions: `
+    You are a research assistant that orchestrates between 2 specialized agents.
+    - Research Agent (LangGraph): Gathers and summarizes information
+    - Analysis Agent (ADK): Analyzes research findings
 
-      When the user asks to research a topic:
-      1. Research Agent - gather information
-      2. Analysis Agent - analyze the findings
-      3. Present the complete research and analysis
-    `,
-  });
+    When the user asks to research a topic:
+    1. Research Agent - gather information
+    2. Analysis Agent - analyze the findings
+    3. Present the complete research and analysis
+  `,
+});
 
-  const runtime = new CopilotRuntime({
-    agents: {
-      a2a_chat: a2aMiddlewareAgent,
-    },
-  });
+const runtime = new CopilotRuntime({
+  agents: {
+    a2a_chat: a2aMiddlewareAgent,
+  },
+  runner: new InMemoryAgentRunner(),
+});
 
-  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-    runtime,
-    serviceAdapter: new ExperimentalEmptyAdapter(),
-    endpoint: "/api/copilotkit",
-  });
-  return handleRequest(request);
-}
+const app = createCopilotHonoHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
 
 Key patterns:
@@ -88,6 +89,10 @@ Key patterns:
 - `orchestrationAgent` is the main agent that receives requests from the UI
 - `instructions` guide the orchestrator on how to use the specialized agents
 - The middleware automatically injects the `send_message_to_a2a_agent` tool
+
+> The shipped `a2a-middleware` example subclasses `A2AMiddlewareAgent` to recreate an isolated middleware agent per run (overriding `runAgent`/`clone`) so concurrent threads don't share orchestrator state. The flat construction above is the pedagogical baseline; reach for the per-run subclass pattern when serving multiple concurrent users.
+>
+> Cross-reference: the `runtime` skill documents an alternate single-agent A2A path using `A2AAgent` from `@ag-ui/a2a` (connecting directly to one A2A server). Use `A2AMiddlewareAgent` from `@ag-ui/a2a-middleware` (shown here) when orchestrating multiple A2A agents from one chat.
 
 ### Adding New Agents
 
@@ -135,8 +140,14 @@ The main `page.tsx` is minimal -- the agent drives the UI:
 MCP Apps integrate Model Context Protocol servers as middleware on a `BuiltInAgent`:
 
 ```typescript
-import { BuiltInAgent } from "@copilotkit/runtime/v2";
+import {
+  CopilotRuntime,
+  BuiltInAgent,
+  createCopilotHonoHandler,
+  InMemoryAgentRunner,
+} from "@copilotkit/runtime/v2";
 import { MCPAppsMiddleware } from "@ag-ui/mcp-apps-middleware";
+import { handle } from "hono/vercel";
 
 const middlewares = [
   new MCPAppsMiddleware({
@@ -161,7 +172,18 @@ for (const middleware of middlewares) {
 
 const runtime = new CopilotRuntime({
   agents: { default: agent },
+  runner: new InMemoryAgentRunner(),
 });
+
+const app = createCopilotHonoHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
 
 Key patterns:

--- a/skills/copilotkit-integrations/references/integrations/adk.md
+++ b/skills/copilotkit-integrations/references/integrations/adk.md
@@ -121,31 +121,35 @@ Key patterns:
 - Wrap the ADK agent with `ADKAgent` from `ag-ui-adk`, then use `add_adk_fastapi_endpoint` to mount it
 - ADK uses Gemini models by default (`gemini-2.5-flash`)
 
-## Next.js Route (src/app/api/copilotkit/route.ts)
+## Next.js Route (src/app/api/copilotkit/[[...slug]]/route.ts)
 
 ```typescript
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotHonoHandler,
+  InMemoryAgentRunner,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
-import { NextRequest } from "next/server";
+import { handle } from "hono/vercel";
 
 const runtime = new CopilotRuntime({
   agents: {
-    my_agent: new HttpAgent({ url: "http://localhost:8000/" }),
+    default: new HttpAgent({
+      url: process.env.AGENT_URL || "http://localhost:8000/",
+    }),
   },
+  runner: new InMemoryAgentRunner(),
 });
 
-export const POST = async (req: NextRequest) => {
-  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-    runtime,
-    serviceAdapter: new ExperimentalEmptyAdapter(),
-    endpoint: "/api/copilotkit",
-  });
-  return handleRequest(req);
-};
+const app = createCopilotHonoHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
 
 ADK uses the generic `HttpAgent` from `@ag-ui/client`.

--- a/skills/copilotkit-integrations/references/integrations/agno.md
+++ b/skills/copilotkit-integrations/references/integrations/agno.md
@@ -77,31 +77,37 @@ Key patterns:
 - `agent_os.get_app()` returns a FastAPI/ASGI app
 - The AG-UI endpoint is served at `/agui` by default
 
-## Next.js Route (src/app/api/copilotkit/route.ts)
+## Next.js Route (src/app/api/copilotkit/[[...slug]]/route.ts)
 
 ```typescript
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotHonoHandler,
+  InMemoryAgentRunner,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
-import { NextRequest } from "next/server";
+import { handle } from "hono/vercel";
 
 const runtime = new CopilotRuntime({
   agents: {
-    agno_agent: new HttpAgent({ url: "http://localhost:8000/agui" }),
+    default: new HttpAgent({
+      url:
+        (process.env.AGENT_URL || "http://localhost:8000").replace(/\/$/, "") +
+        "/agui",
+    }),
   },
+  runner: new InMemoryAgentRunner(),
 });
 
-export const POST = async (req: NextRequest) => {
-  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-    runtime,
-    serviceAdapter: new ExperimentalEmptyAdapter(),
-    endpoint: "/api/copilotkit",
-  });
-  return handleRequest(req);
-};
+const app = createCopilotHonoHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
 
 Note the URL path is `/agui` -- this is where Agno's `AGUI` interface mounts.

--- a/skills/copilotkit-integrations/references/integrations/crewai.md
+++ b/skills/copilotkit-integrations/references/integrations/crewai.md
@@ -118,31 +118,38 @@ app = FastAPI()
 add_crewai_flow_fastapi_endpoint(app, SampleAgentFlow(), "/")
 ```
 
-### Next.js Route (src/app/api/copilotkit/route.ts)
+### Next.js Route (src/app/api/copilotkit/[[...slug]]/route.ts)
 
 ```typescript
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotHonoHandler,
+  InMemoryAgentRunner,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
-import { NextRequest } from "next/server";
+import { handle } from "hono/vercel";
 
 const runtime = new CopilotRuntime({
   agents: {
-    sample_agent: new HttpAgent({ url: "http://localhost:8000/" }),
+    default: new HttpAgent({
+      url: (process.env.AGENT_URL || "http://localhost:8000").replace(
+        /\/$/,
+        "",
+      ),
+    }),
   },
+  runner: new InMemoryAgentRunner(),
 });
 
-export const POST = async (req: NextRequest) => {
-  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-    runtime,
-    serviceAdapter: new ExperimentalEmptyAdapter(),
-    endpoint: "/api/copilotkit",
-  });
-  return handleRequest(req);
-};
+const app = createCopilotHonoHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
 
 CrewAI Flows use the generic `HttpAgent` from `@ag-ui/client`.
@@ -207,16 +214,35 @@ add_crewai_crew_fastapi_endpoint(app, LatestAiDevelopment(), "/")
 
 Note the different function: `add_crewai_crew_fastapi_endpoint` vs `add_crewai_flow_fastapi_endpoint`.
 
-### Next.js Route
+### Next.js Route (src/app/api/copilotkit/[[...slug]]/route.ts)
 
 ```typescript
+import {
+  CopilotRuntime,
+  createCopilotHonoHandler,
+  InMemoryAgentRunner,
+} from "@copilotkit/runtime/v2";
 import { CrewAIAgent } from "@ag-ui/crewai";
+import { handle } from "hono/vercel";
 
 const runtime = new CopilotRuntime({
   agents: {
-    starterAgent: new CrewAIAgent({ url: "http://localhost:8000/" }),
+    default: new CrewAIAgent({
+      url: process.env.AGENT_URL || "http://localhost:8000/",
+    }),
   },
+  runner: new InMemoryAgentRunner(),
 });
+
+const app = createCopilotHonoHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
 
 CrewAI Crews use `CrewAIAgent` from `@ag-ui/crewai` (not `HttpAgent`).

--- a/skills/copilotkit-integrations/references/integrations/langgraph.md
+++ b/skills/copilotkit-integrations/references/integrations/langgraph.md
@@ -110,36 +110,38 @@ add_langgraph_fastapi_endpoint(
 )
 ```
 
-### Next.js Route (src/app/api/copilotkit/route.ts)
+### Next.js Route (src/app/api/copilotkit/[[...slug]]/route.ts)
 
 ```typescript
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotHonoHandler,
+  InMemoryAgentRunner,
+} from "@copilotkit/runtime/v2";
 import { LangGraphHttpAgent } from "@copilotkit/runtime/langgraph";
-import { NextRequest } from "next/server";
+import { handle } from "hono/vercel";
 
 const runtime = new CopilotRuntime({
   agents: {
-    sample_agent: new LangGraphHttpAgent({
-      url: process.env.AGENT_URL || "http://localhost:8123",
+    default: new LangGraphHttpAgent({
+      url: `${process.env.AGENT_URL || "http://localhost:8123"}/`,
     }),
   },
+  runner: new InMemoryAgentRunner(),
 });
 
-export const POST = async (req: NextRequest) => {
-  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-    runtime,
-    serviceAdapter: new ExperimentalEmptyAdapter(),
-    endpoint: "/api/copilotkit",
-  });
-  return handleRequest(req);
-};
+const app = createCopilotHonoHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
 
-Use `LangGraphHttpAgent` (from `@copilotkit/runtime/langgraph`) for self-hosted agents. The default port is 8123.
+Use `LangGraphHttpAgent` (from `@copilotkit/runtime/langgraph`) for self-hosted agents -- the FastAPI server runs under `ag-ui-langgraph`, which speaks AG-UI directly. The default port is 8123 (note the trailing slash on the URL).
 
 ---
 
@@ -147,10 +149,16 @@ Use `LangGraphHttpAgent` (from `@copilotkit/runtime/langgraph`) for self-hosted 
 
 This is the `langgraph-python` example pattern. Uses `LangGraphAgent` which connects to a LangGraph deployment (local or cloud).
 
-### Next.js Route
+### Next.js Route (src/app/api/copilotkit/[[...slug]]/route.ts)
 
 ```typescript
+import {
+  CopilotRuntime,
+  createCopilotHonoHandler,
+  InMemoryAgentRunner,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
+import { handle } from "hono/vercel";
 
 const defaultAgent = new LangGraphAgent({
   deploymentUrl:
@@ -161,20 +169,21 @@ const defaultAgent = new LangGraphAgent({
 
 const runtime = new CopilotRuntime({
   agents: { default: defaultAgent },
-  a2ui: { injectA2UITool: true },
-  mcpApps: {
-    servers: [
-      {
-        type: "http",
-        url: process.env.MCP_SERVER_URL || "https://mcp.excalidraw.com",
-        serverId: "example_mcp_app",
-      },
-    ],
-  },
+  runner: new InMemoryAgentRunner(),
 });
+
+const app = createCopilotHonoHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
 
-Key difference from self-hosted: `LangGraphAgent` uses `deploymentUrl` and `graphId` (and optionally `langsmithApiKey`), while `LangGraphHttpAgent` uses a plain `url`.
+Key difference from self-hosted: `LangGraphAgent` uses `deploymentUrl` and `graphId` (and optionally `langsmithApiKey`) to target the LangGraph Platform / `langgraph-cli dev` surface, while `LangGraphHttpAgent` uses a plain `url` for a self-hosted AG-UI server.
 
 ---
 
@@ -260,9 +269,26 @@ Key JS-specific patterns:
 - Use `convertActionsToDynamicStructuredTools()` to convert frontend actions to LangChain tools
 - Check `copilotkit.actions` to determine whether a tool call should route to `tool_node` (backend) or `__end__` (frontend)
 
+### Serving the JS graph
+
+`LangGraphAgent` with `deploymentUrl`/`graphId` targets the LangGraph **server** surface, not the bare compiled `graph` export. Serve the graph with the LangGraph JS CLI (`@langchain/langgraph-cli`) so that surface exists. Add a `langgraph.json` next to the agent:
+
+```json
+{
+  "node_version": "20",
+  "dependencies": ["."],
+  "graphs": {
+    "sample_agent": "./src/agent.ts:graph"
+  },
+  "env": "../.env"
+}
+```
+
+Run it with `langgraphjs dev --port 8123` (the agent app's `dev` script). The `graphId` you pass to `LangGraphAgent` must match a key under `graphs` (here `"sample_agent"`), and `deploymentUrl` points at the CLI server (`http://localhost:8123`).
+
 ### Next.js Route
 
-Same as the Platform pattern -- uses `LangGraphAgent` with `deploymentUrl` and `graphId`.
+The catch-all `src/app/api/copilotkit/[[...slug]]/route.ts` uses `LangGraphAgent` (from `@copilotkit/runtime/langgraph`) with `deploymentUrl` (the `langgraphjs dev` URL, e.g. `http://localhost:8123`) and `graphId` (`"sample_agent"`), mounted via `createCopilotHonoHandler`.
 
 ## Monorepo Structure (JS)
 
@@ -271,9 +297,9 @@ The JS variant uses a Turborepo monorepo:
 ```
 apps/
   web/          # Next.js frontend
-  agent/        # LangGraph agent (Node.js)
+  agent/        # LangGraph agent, served via `langgraphjs dev` (langgraph.json)
 pnpm-workspace.yaml
 turbo.json
 ```
 
-Run `pnpm dev` to start both apps via Turborepo.
+Run `pnpm dev` to start both apps via Turborepo (the agent app runs `langgraphjs dev --port 8123`).

--- a/skills/copilotkit-integrations/references/integrations/llamaindex.md
+++ b/skills/copilotkit-integrations/references/integrations/llamaindex.md
@@ -91,33 +91,37 @@ if __name__ == "__main__":
 
 Note: LlamaIndex defaults to port **9000** (not 8000).
 
-## Next.js Route (src/app/api/copilotkit/route.ts)
+## Next.js Route (src/app/api/copilotkit/[[...slug]]/route.ts)
 
 ```typescript
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotHonoHandler,
+  InMemoryAgentRunner,
+} from "@copilotkit/runtime/v2";
 import { LlamaIndexAgent } from "@ag-ui/llamaindex";
-import { NextRequest } from "next/server";
+import { handle } from "hono/vercel";
 
-export async function POST(request: NextRequest) {
-  const runtime = new CopilotRuntime({
-    agents: {
-      sample_agent: new LlamaIndexAgent({
-        url: "http://127.0.0.1:9000/run",
-      }),
-    },
-  });
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new LlamaIndexAgent({
+      url:
+        (process.env.AGENT_URL || "http://127.0.0.1:9000").replace(/\/$/, "") +
+        "/run",
+    }),
+  },
+  runner: new InMemoryAgentRunner(),
+});
 
-  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-    runtime,
-    serviceAdapter: new ExperimentalEmptyAdapter(),
-    endpoint: `/api/copilotkit`,
-  });
-  return handleRequest(request);
-}
+const app = createCopilotHonoHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
 
 LlamaIndex uses `LlamaIndexAgent` from `@ag-ui/llamaindex`. Note the URL path is `/run` (appended to the base URL).

--- a/skills/copilotkit-integrations/references/integrations/mastra.md
+++ b/skills/copilotkit-integrations/references/integrations/mastra.md
@@ -16,10 +16,15 @@ Mastra is a TypeScript-native agent framework. The CopilotKit integration runs e
   "@mastra/memory": "beta",
   "@mastra/libsql": "beta",
   "mastra": "beta",
-  "@copilotkit/react": "latest",
+  "@copilotkit/react-core": "latest",
   "@copilotkit/runtime": "latest"
 }
 ```
+
+> **Note:** `@ag-ui/mastra@beta` currently declares a peer dependency on a
+> pre-release `@copilotkit/runtime`, which conflicts with the published
+> `@copilotkit/runtime@latest`. Install with `--legacy-peer-deps` (npm) or
+> the equivalent until the beta peer range is updated.
 
 ## Agent Definition (src/mastra/agents/index.ts)
 
@@ -104,31 +109,33 @@ export const mastra = new Mastra({
 });
 ```
 
-## Next.js Route (src/app/api/copilotkit/route.ts)
+## Next.js Route (src/app/api/copilotkit/[[...slug]]/route.ts)
 
 ```typescript
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotHonoHandler,
+  InMemoryAgentRunner,
+} from "@copilotkit/runtime/v2";
 import { MastraAgent } from "@ag-ui/mastra";
-import { NextRequest } from "next/server";
 import { mastra } from "@/mastra";
+import { handle } from "hono/vercel";
 
-export const POST = async (req: NextRequest) => {
-  const runtime = new CopilotRuntime({
-    // @ts-expect-error - typing issue in current beta
-    agents: MastraAgent.getLocalAgents({ mastra }),
-  });
+const runtime = new CopilotRuntime({
+  // @ts-expect-error - typing issue in current beta
+  agents: MastraAgent.getLocalAgents({ mastra }),
+  runner: new InMemoryAgentRunner(),
+});
 
-  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-    runtime,
-    serviceAdapter: new ExperimentalEmptyAdapter(),
-    endpoint: "/api/copilotkit",
-  });
-  return handleRequest(req);
-};
+const app = createCopilotHonoHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
 
 Key difference from other integrations: `MastraAgent.getLocalAgents({ mastra })` automatically discovers all agents registered in the Mastra instance. No need to manually specify URLs or create agent instances -- the agents run in-process.

--- a/skills/copilotkit-integrations/references/integrations/ms-agent-framework.md
+++ b/skills/copilotkit-integrations/references/integrations/ms-agent-framework.md
@@ -219,31 +219,35 @@ dotnet user-secrets set GitHubToken "$(gh auth token)"
 
 ---
 
-## Next.js Route (both Python and .NET)
+## Next.js Route (both Python and .NET) -- src/app/api/copilotkit/[[...slug]]/route.ts
 
 ```typescript
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotHonoHandler,
+  InMemoryAgentRunner,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
-import { NextRequest } from "next/server";
+import { handle } from "hono/vercel";
 
 const runtime = new CopilotRuntime({
   agents: {
-    my_agent: new HttpAgent({ url: "http://localhost:8000/" }),
+    default: new HttpAgent({
+      url: process.env.AGENT_URL || "http://localhost:8000/",
+    }),
   },
+  runner: new InMemoryAgentRunner(),
 });
 
-export const POST = async (req: NextRequest) => {
-  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-    runtime,
-    serviceAdapter: new ExperimentalEmptyAdapter(),
-    endpoint: "/api/copilotkit",
-  });
-  return handleRequest(req);
-};
+const app = createCopilotHonoHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
 
-Both Python and .NET variants use `HttpAgent` from `@ag-ui/client`.
+Both Python and .NET variants use `HttpAgent` from `@ag-ui/client` -- both speak AG-UI directly.

--- a/skills/copilotkit-integrations/references/integrations/pydantic-ai.md
+++ b/skills/copilotkit-integrations/references/integrations/pydantic-ai.md
@@ -105,35 +105,39 @@ if __name__ == "__main__":
 
 The `agent.to_ag_ui()` call creates a full ASGI application. Pass initial `deps` with default state.
 
-## Next.js Route (src/app/api/copilotkit/route.ts)
+## Next.js Route (src/app/api/copilotkit/[[...slug]]/route.ts)
 
 ```typescript
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotHonoHandler,
+  InMemoryAgentRunner,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
-import { NextRequest } from "next/server";
+import { handle } from "hono/vercel";
 
 const runtime = new CopilotRuntime({
   agents: {
-    sample_agent: new HttpAgent({ url: "http://localhost:8000/" }),
+    default: new HttpAgent({
+      url: process.env.AGENT_URL || "http://localhost:8000/",
+    }),
   },
+  runner: new InMemoryAgentRunner(),
 });
 
-export const POST = async (req: NextRequest) => {
-  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-    runtime,
-    serviceAdapter: new ExperimentalEmptyAdapter(),
-    endpoint: "/api/copilotkit",
-  });
-  return handleRequest(req);
-};
+const app = createCopilotHonoHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
 
 PydanticAI uses the generic `HttpAgent` from `@ag-ui/client`.
 
 ## Frontend Usage
 
-The frontend is standard CopilotKit -- `useAgent` for shared state, `useRenderToolCall` for generative UI, `useHumanInTheLoop` for approval flows. See the main SKILL.md for common patterns.
+The frontend is standard CopilotKit -- `useAgent` for shared state (read `agent.state`, write `agent.setState`), `useRenderTool` for generative UI, `useHumanInTheLoop` for approval flows. See the main SKILL.md for common patterns.

--- a/skills/copilotkit-integrations/references/integrations/strands.md
+++ b/skills/copilotkit-integrations/references/integrations/strands.md
@@ -126,33 +126,35 @@ Key patterns:
 - Frontend tools return `None` -- actual execution happens on the client
 - `create_strands_app()` builds a complete FastAPI application
 
-## Next.js Route (src/app/api/copilotkit/route.ts)
+## Next.js Route (src/app/api/copilotkit/[[...slug]]/route.ts)
 
 ```typescript
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotHonoHandler,
+  InMemoryAgentRunner,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
-import { NextRequest } from "next/server";
+import { handle } from "hono/vercel";
 
 const runtime = new CopilotRuntime({
   agents: {
-    strands_agent: new HttpAgent({
-      url: process.env.STRANDS_AGENT_URL || "http://localhost:8000",
+    default: new HttpAgent({
+      url: `${process.env.AGENT_URL || process.env.STRANDS_AGENT_URL || "http://localhost:8000"}/`,
     }),
   },
+  runner: new InMemoryAgentRunner(),
 });
 
-export const POST = async (req: NextRequest) => {
-  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-    runtime,
-    serviceAdapter: new ExperimentalEmptyAdapter(),
-    endpoint: "/api/copilotkit",
-  });
-  return handleRequest(req);
-};
+const app = createCopilotHonoHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
 
-Strands uses the generic `HttpAgent` from `@ag-ui/client`.
+Strands uses the generic `HttpAgent` from `@ag-ui/client` -- the agent runs under `ag_ui_strands`, which speaks AG-UI directly.

--- a/skills/copilotkit-setup/SKILL.md
+++ b/skills/copilotkit-setup/SKILL.md
@@ -67,9 +67,12 @@ npm install @copilotkit/runtime hono
 For standalone Express backends, install Express adapter dependencies instead of `hono`:
 
 ```bash
-npm install @copilotkit/runtime express cors
-npm install -D @types/express @types/cors
+npm install @copilotkit/runtime express dotenv zod
+npm install -D @types/express tsx typescript
 ```
+
+(`createCopilotExpressHandler` enables CORS internally, so you do not need to
+install `cors` yourself. `dotenv` and `zod` are used by the example asset.)
 
 ### Step 2: Configure the runtime
 
@@ -112,6 +115,10 @@ const app = createCopilotHonoHandler({
 
 export const GET = handle(app);
 export const POST = handle(app);
+// PATCH/DELETE are used by thread operations (useThreads); export them too
+// so the multi-route handler can serve them when you enable Intelligence/threads.
+export const PATCH = handle(app);
+export const DELETE = handle(app);
 ```
 
 #### Next.js App Router (alternative: single-route)
@@ -243,7 +250,10 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function Home() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit">
+    // useSingleEndpoint={false} matches the multi-route backend above.
+    // The v1-compat CopilotKit bridge defaults useSingleEndpoint to true,
+    // which would 404 against multi-route endpoints.
+    <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
       <div style={{ height: "100vh" }}>
         <CopilotChat />
       </div>
@@ -273,7 +283,7 @@ Set `useSingleEndpoint` when the backend uses single-route endpoints (`createCop
 | `headers`           | `Record<string, string> \| (() => Record<string, string>)` | Custom headers sent with every request. The function form is evaluated per-request (useful for dynamic auth tokens). |
 | `credentials`       | `RequestCredentials`                                       | Fetch credentials mode (e.g., `"include"` for cookies)                                                               |
 | `publicLicenseKey`  | `string`                                                   | CopilotKit Intelligence public license key (`publicApiKey` is a deprecated alias)                                    |
-| `showDevConsole`    | `boolean \| "auto"`                                        | Show the dev inspector (`"auto"` = development only)                                                                 |
+| `showDevConsole`    | `boolean`                                                  | Show the dev console. Omit it to get the default behavior (shown on `localhost` only)                                |
 | `renderToolCalls`   | `ReactToolCallRenderer[]`                                  | Custom renderers for tool call UI                                                                                    |
 | `frontendTools`     | `ReactFrontendTool[]`                                      | Frontend-defined tools (declarative alternative to `useFrontendTool`)                                                |
 | `onError`           | `(event) => void`                                          | Global error handler                                                                                                 |
@@ -293,7 +303,7 @@ Example with sidebar:
 ```tsx
 import { CopilotKit, CopilotSidebar } from "@copilotkit/react-core/v2";
 
-<CopilotKit runtimeUrl="/api/copilotkit" showDevConsole="auto">
+<CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
   <YourApp />
   <CopilotSidebar
     defaultOpen
@@ -356,7 +366,7 @@ See `references/telemetry-setup.md` for full details on what the license key ena
 2. Open the app in a browser
 3. The chat UI should render and connect to the runtime
 4. Send a test message -- you should receive an AI response
-5. Check the runtime's `/info` endpoint (GET) to confirm it reports available agents
+5. Check the runtime's info endpoint to confirm it reports available agents. For multi-route handlers this is `GET /api/copilotkit/info`; for single-route handlers (`mode: "single-route"`, e.g. the Express example) it is a `POST` to the base path with body `{ "method": "info" }` (a plain `GET` will not return agent info — the Hono single-route handler answers `405`, and the Express single-route router has no `GET` route so it falls through to a `404`)
 
 ## Security notes
 
@@ -364,7 +374,7 @@ Keep these in mind as you wire up a real deployment:
 
 - **Secrets stay server-side and in env vars.** Provider API keys (`OPENAI_API_KEY`, etc.) are read by the runtime/agent on the server. Never expose them to the browser, hardcode them, or commit them -- store them in environment variables or a secret manager (see Step 5). The CopilotKit license key is the one client-side value, and it is a public project identifier, not a secret.
 - **Treat all chat input as untrusted.** Chat messages flow from the frontend through the `CopilotRuntime` endpoint into the agent's LLM context. They are user-controlled and can attempt prompt injection -- including indirect injection via content the agent fetches (web pages, documents, tool results). Do not assume the model will only do what your system prompt intends.
-- **Give server-side tools least privilege.** A `defineTool` handler runs with your server's authority. Validate every argument (the `zod` `parameters` schema is your first gate), scope each tool to the narrowest action it needs, and enforce your own authorization inside the `execute` function for anything sensitive (database writes, payments, file access) rather than trusting that the model called it correctly.
+- **Give server-side tools least privilege.** A `defineTool`'s `execute` function runs with your server's authority. Validate every argument (the `zod` `parameters` schema is your first gate), scope each tool to the narrowest action it needs, and enforce your own authorization inside the `execute` function for anything sensitive (database writes, payments, file access) rather than trusting that the model called it correctly.
 - **Authenticate the runtime endpoint.** The runtime route is a public HTTP endpoint by default. Put your app's auth in front of it so only authorized users can drive the agent and consume provider credits.
 
 ## Quick Reference

--- a/skills/copilotkit-setup/assets/express-runtime.ts
+++ b/skills/copilotkit-setup/assets/express-runtime.ts
@@ -1,8 +1,15 @@
 // File: src/index.ts
 // Standalone Express server with CopilotKit runtime (single-route)
 //
+// Frontend pairing: because this server is single-route AND cross-origin,
+// the provider must use useSingleEndpoint (true) and an absolute runtimeUrl,
+// e.g. <CopilotKit runtimeUrl="http://localhost:4000/api/copilotkit"
+// useSingleEndpoint>. The nextjs-app-router-page.tsx asset is for the
+// same-origin multi-route Hono route (useSingleEndpoint={false}) and does
+// NOT pair with this server.
+//
 // Prerequisites:
-//   npm install @copilotkit/runtime @copilotkit/agent express dotenv zod
+//   npm install @copilotkit/runtime express dotenv zod
 //   npm install -D @types/express tsx typescript
 //
 // Environment variables (store secrets in env, never hardcode them):
@@ -15,10 +22,12 @@
 import express from "express";
 import dotenv from "dotenv";
 import { z } from "zod";
-import { CopilotRuntime } from "@copilotkit/runtime";
-import { createCopilotEndpointSingleRouteExpress } from "@copilotkit/runtime/express";
-import { BuiltInAgent, defineTool } from "@copilotkit/agent";
-import type { ToolDefinition } from "@copilotkit/agent";
+import {
+  CopilotRuntime,
+  BuiltInAgent,
+  defineTool,
+} from "@copilotkit/runtime/v2";
+import { createCopilotExpressHandler } from "@copilotkit/runtime/v2/express";
 
 dotenv.config();
 
@@ -33,12 +42,17 @@ const weatherTool = defineTool({
     // Replace with real weather API call
     return { city, temperature: 72, condition: "sunny" };
   },
-}) as unknown as ToolDefinition;
+});
 
 const agent = new BuiltInAgent({
   model: "openai/gpt-4o",
   prompt: "You are a helpful AI assistant.",
   tools: [weatherTool],
+  // Allow multiple steps so the agent can call the tool and then use the
+  // result to answer. Without maxSteps the agent stops after a single step
+  // (the underlying AI SDK default), emitting the tool call but never
+  // producing a final reply.
+  maxSteps: 5,
 });
 
 const runtime = new CopilotRuntime({
@@ -51,9 +65,10 @@ const app = express();
 
 app.use(
   "/api/copilotkit",
-  createCopilotEndpointSingleRouteExpress({
+  createCopilotExpressHandler({
     runtime,
     basePath: "/",
+    mode: "single-route",
   }),
 );
 

--- a/skills/copilotkit-setup/assets/nextjs-app-router-page.tsx
+++ b/skills/copilotkit-setup/assets/nextjs-app-router-page.tsx
@@ -13,7 +13,10 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function Home() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" showDevConsole="auto">
+    // useSingleEndpoint={false} pairs with the multi-route runtime handler.
+    // The v1-compat CopilotKit bridge defaults this to true (single-route
+    // transport), which would 404 against the multi-route backend — keep it.
+    <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
       <div
         style={{ height: "100vh", margin: 0, padding: 0, overflow: "hidden" }}
       >

--- a/skills/copilotkit-setup/assets/nextjs-app-router-route.ts
+++ b/skills/copilotkit-setup/assets/nextjs-app-router-route.ts
@@ -2,17 +2,17 @@
 // Next.js App Router + Hono multi-route endpoint
 //
 // Prerequisites:
-//   npm install @copilotkit/runtime @copilotkit/agent hono
+//   npm install @copilotkit/runtime hono
 //
 // Environment variables (store secrets in env, never hardcode them):
 //   OPENAI_API_KEY=<your-api-key>  (or ANTHROPIC_API_KEY / GOOGLE_API_KEY)
 
 import {
   CopilotRuntime,
-  createCopilotEndpoint,
+  createCopilotHonoHandler,
   InMemoryAgentRunner,
-} from "@copilotkit/runtime";
-import { BuiltInAgent } from "@copilotkit/agent";
+  BuiltInAgent,
+} from "@copilotkit/runtime/v2";
 import { handle } from "hono/vercel";
 
 const agent = new BuiltInAgent({
@@ -27,10 +27,14 @@ const runtime = new CopilotRuntime({
   runner: new InMemoryAgentRunner(),
 });
 
-const app = createCopilotEndpoint({
+const app = createCopilotHonoHandler({
   runtime,
   basePath: "/api/copilotkit",
 });
 
 export const GET = handle(app);
 export const POST = handle(app);
+// PATCH/DELETE back thread operations (useThreads); harmless for the
+// BuiltInAgent demo, required once you enable Intelligence/threads.
+export const PATCH = handle(app);
+export const DELETE = handle(app);

--- a/skills/copilotkit-setup/references/framework-detection.md
+++ b/skills/copilotkit-setup/references/framework-detection.md
@@ -31,7 +31,7 @@ Detect the project's framework before generating any setup code. The detection o
 - **Runtime location:** `src/app/api/copilotkit/[[...slug]]/route.ts` (multi-route) or `src/app/api/copilotkit/route.ts` (single-route)
 - **Provider placement:** In a `"use client"` page or layout component
 - **Route handler style:** Named exports `GET` and `POST` using `handle(app)` from `hono/vercel`
-- **Stylesheet import:** In `layout.tsx`: `import "@copilotkit/react/styles.css"`
+- **Stylesheet import:** In `layout.tsx`: `import "@copilotkit/react-core/v2/styles.css"`
 - **Env file:** `.env.local`
 - **Extra deps:** `hono` (for Hono adapter)
 
@@ -40,7 +40,7 @@ Detect the project's framework before generating any setup code. The detection o
 - **Runtime location:** Typically runs as a separate Express server (not in API routes). The Pages Router examples in the CopilotKit repo use an external Express runtime.
 - **Provider placement:** In `pages/_app.tsx` or a page component. Must be a client component (default in Pages Router).
 - **Frontend connects to external URL:** `runtimeUrl` points to the Express server (e.g., `http://localhost:4000/api/copilotkit`)
-- **Stylesheet import:** In `pages/_app.tsx` or `styles/globals.css`: `import "@copilotkit/react/styles.css"`
+- **Stylesheet import:** In `pages/_app.tsx` or `styles/globals.css`: `import "@copilotkit/react-core/v2/styles.css"`
 - **Env file:** `.env.local`
 - **Key prop:** `useSingleEndpoint` must be set on the provider when using single-route Express endpoints
 
@@ -50,28 +50,28 @@ Detect the project's framework before generating any setup code. The detection o
 - **Provider placement:** Uses Angular-specific components from `@copilotkit/angular` (separate package)
 - **Not React-based:** Does NOT use the `CopilotKit` provider or React hooks
 - **Stylesheet import:** Via Angular styles configuration in `angular.json`
-- **Package:** `@copilotkit/angular` instead of `@copilotkit/react`
+- **Package:** `@copilotkit/angular` instead of `@copilotkit/react-core`
 
 ### Vite + React
 
 - **Runtime location:** Separate backend server (Express or Hono standalone). Vite dev server only serves the frontend.
 - **Provider placement:** In the root `App.tsx` component
 - **Frontend connects to external URL:** `runtimeUrl` points to the backend server
-- **Stylesheet import:** In `main.tsx` or `App.tsx`: `import "@copilotkit/react/styles.css"`
+- **Stylesheet import:** In `main.tsx` or `App.tsx`: `import "@copilotkit/react-core/v2/styles.css"`
 - **Env file:** `.env` (Vite exposes vars prefixed with `VITE_`)
 - **Note:** API keys should NOT be prefixed with `VITE_` -- they belong on the backend server, not exposed to the browser
 
 ### Standalone Backend (Express)
 
 - **No framework detection needed** -- this is a backend-only setup
-- **Uses:** `@copilotkit/runtime` and `@copilotkit/agent`
-- **Does NOT need:** `@copilotkit/react` or `@copilotkit/core`
-- **Endpoint factories:** `createCopilotEndpointExpress` (multi-route) or `createCopilotEndpointSingleRouteExpress` (single-route), both from `@copilotkit/runtime/express`
+- **Uses:** `@copilotkit/runtime/v2` (and `@copilotkit/runtime/v2/express` for the Express handler)
+- **Does NOT need:** `@copilotkit/react-core`
+- **Endpoint factory:** `createCopilotExpressHandler` from `@copilotkit/runtime/v2/express` (multi-route by default; pass `mode: "single-route"` for single-route)
 - **Env file:** `.env` (loaded via `dotenv`)
 
 ### Standalone Backend (Hono)
 
-- **Same as Express** but uses `createCopilotEndpoint` or `createCopilotEndpointSingleRoute` from `@copilotkit/runtime`
+- **Same as Express** but uses `createCopilotHonoHandler` from `@copilotkit/runtime/v2` (pass `mode: "single-route"` for single-route)
 - **Served via:** `@hono/node-server` with `serve({ fetch: app.fetch, port })`
 
 ## File-Level Detection Commands

--- a/skills/copilotkit-setup/references/runtime-architecture.md
+++ b/skills/copilotkit-setup/references/runtime-architecture.md
@@ -1,6 +1,6 @@
 # Runtime Architecture
 
-The CopilotKit v2 runtime (`@copilotkit/runtime`) is the server-side component that manages agent execution, thread state, and communication with the frontend via the AG-UI protocol (SSE-based events).
+The CopilotKit v2 runtime (`@copilotkit/runtime/v2`) is the server-side component that manages agent execution, thread state, and communication with the frontend via the AG-UI protocol (SSE-based events).
 
 ## Core Concepts
 
@@ -9,7 +9,7 @@ The CopilotKit v2 runtime (`@copilotkit/runtime`) is the server-side component t
 `CopilotRuntime` is the main entry point. It is a compatibility shim that delegates to either `CopilotSseRuntime` (default) or `CopilotIntelligenceRuntime` depending on configuration.
 
 ```typescript
-import { CopilotRuntime } from "@copilotkit/runtime";
+import { CopilotRuntime } from "@copilotkit/runtime/v2";
 
 // SSE mode (default) -- in-memory thread state
 const runtime = new CopilotRuntime({
@@ -21,7 +21,7 @@ const runtime = new CopilotRuntime({
 const runtime = new CopilotRuntime({
   agents: { default: myAgent },
   intelligence: new CopilotKitIntelligence({ ... }),
-  identifyUser: (request) => ({ id: "user-123" }),
+  identifyUser: (request) => ({ id: "user-123", name: "Ada Lovelace" }),
 });
 ```
 
@@ -34,7 +34,7 @@ const runtime = new CopilotRuntime({
 | `intelligence`            | `CopilotKitIntelligence`                       | Enables Intelligence mode with durable threads.                       |
 | `identifyUser`            | `(request: Request) => CopilotRuntimeUser`     | Required with Intelligence mode. Resolves authenticated user.         |
 | `generateThreadNames`     | `boolean`                                      | Auto-generate thread names (Intelligence mode only, default: `true`). |
-| `transcriptionService`    | `TranscriptionService`                         | Optional audio transcription (e.g., `TranscriptionServiceOpenAI`).    |
+| `transcriptionService`    | `TranscriptionService`                         | Optional audio transcription (a `TranscriptionService` subclass).     |
 | `beforeRequestMiddleware` | `BeforeRequestMiddleware`                      | Callback or webhook URL invoked before each request.                  |
 | `afterRequestMiddleware`  | `AfterRequestMiddleware`                       | Callback or webhook URL invoked after each request.                   |
 | `a2ui`                    | `{ agents?: string[] } & A2UIMiddlewareConfig` | Auto-apply A2UI (Agent-to-UI) middleware to agents.                   |
@@ -42,10 +42,10 @@ const runtime = new CopilotRuntime({
 
 ### Agents
 
-Agents implement the `AbstractAgent` interface from `@ag-ui/client`. CopilotKit provides `BuiltInAgent` (from `@copilotkit/agent`) as a ready-to-use implementation backed by the Vercel AI SDK.
+Agents implement the `AbstractAgent` interface from `@ag-ui/client`. CopilotKit provides `BuiltInAgent` (from `@copilotkit/runtime/v2`) as a ready-to-use implementation backed by the Vercel AI SDK.
 
 ```typescript
-import { BuiltInAgent, defineTool } from "@copilotkit/agent";
+import { BuiltInAgent, defineTool } from "@copilotkit/runtime/v2";
 import { z } from "zod";
 
 const agent = new BuiltInAgent({
@@ -69,7 +69,7 @@ const agent = new BuiltInAgent({
 });
 ```
 
-`BasicAgent` is an alias for `BuiltInAgent` (same class, exported for convenience).
+`BasicAgent` is a **deprecated** subclass of `BuiltInAgent` (it logs a deprecation warning at construction). Use `BuiltInAgent` directly.
 
 **BuiltInAgent configuration:**
 
@@ -109,7 +109,7 @@ abstract class AgentRunner {
 
 ## Endpoint Factories
 
-Endpoint factories create HTTP handlers that expose the runtime's functionality. There are four variants across two HTTP frameworks (Hono, Express) and two routing styles (multi-route, single-route).
+Endpoint factories create HTTP handlers that expose the runtime's functionality. There are two factories -- one per HTTP framework (`createCopilotHonoHandler` from `@copilotkit/runtime/v2`, `createCopilotExpressHandler` from `@copilotkit/runtime/v2/express`) -- and each supports two routing styles (multi-route by default, single-route via `mode: "single-route"`).
 
 ### Multi-Route Endpoints
 
@@ -128,12 +128,15 @@ Each operation gets its own HTTP path under the base path:
 | POST   | `/threads/:threadId/archive`     | Archive a thread                         |
 | DELETE | `/threads/:threadId`             | Delete a thread                          |
 
-**Hono (`createCopilotEndpoint`):**
+**Hono (`createCopilotHonoHandler`):**
 
 ```typescript
-import { CopilotRuntime, createCopilotEndpoint } from "@copilotkit/runtime";
+import {
+  CopilotRuntime,
+  createCopilotHonoHandler,
+} from "@copilotkit/runtime/v2";
 
-const app = createCopilotEndpoint({
+const app = createCopilotHonoHandler({
   runtime,
   basePath: "/api/copilotkit",
   cors: {
@@ -144,12 +147,12 @@ const app = createCopilotEndpoint({
 });
 ```
 
-**Express (`createCopilotEndpointExpress`):**
+**Express (`createCopilotExpressHandler`):**
 
 ```typescript
-import { createCopilotEndpointExpress } from "@copilotkit/runtime/express";
+import { createCopilotExpressHandler } from "@copilotkit/runtime/v2/express";
 
-const router = createCopilotEndpointExpress({
+const router = createCopilotExpressHandler({
   runtime,
   basePath: "/api/copilotkit",
 });
@@ -158,43 +161,45 @@ app.use(router);
 
 ### Single-Route Endpoints
 
-All operations go through a single POST endpoint. The operation is identified by a `method` field in the JSON body. This is simpler to deploy (one route, no catch-all needed).
+All operations go through a single POST endpoint. The operation is identified by a `method` field in the JSON body. This is simpler to deploy (one route, no catch-all needed). Use the same factories with `mode: "single-route"`.
 
-**Hono (`createCopilotEndpointSingleRoute`):**
+**Hono (`createCopilotHonoHandler` with `mode: "single-route"`):**
 
 ```typescript
 import {
   CopilotRuntime,
-  createCopilotEndpointSingleRoute,
-} from "@copilotkit/runtime";
+  createCopilotHonoHandler,
+} from "@copilotkit/runtime/v2";
 
-const app = createCopilotEndpointSingleRoute({
+const app = createCopilotHonoHandler({
   runtime,
   basePath: "/api/copilotkit",
+  mode: "single-route",
 });
 ```
 
-**Express (`createCopilotEndpointSingleRouteExpress`):**
+**Express (`createCopilotExpressHandler` with `mode: "single-route"`):**
 
 ```typescript
-import { createCopilotEndpointSingleRouteExpress } from "@copilotkit/runtime/express";
+import { createCopilotExpressHandler } from "@copilotkit/runtime/v2/express";
 
-const router = createCopilotEndpointSingleRouteExpress({
+const router = createCopilotExpressHandler({
   runtime,
   basePath: "/", // relative to where it's mounted
+  mode: "single-route",
 });
 app.use("/api/copilotkit", router);
 ```
 
 ### When to Use Which
 
-| Scenario                                   | Recommended                                                            |
-| ------------------------------------------ | ---------------------------------------------------------------------- |
-| Next.js App Router                         | Multi-route Hono (`createCopilotEndpoint`) via `[[...slug]]` catch-all |
-| Next.js App Router (no catch-all desired)  | Single-route Hono (`createCopilotEndpointSingleRoute`)                 |
-| Standalone Express server                  | Single-route Express (`createCopilotEndpointSingleRouteExpress`)       |
-| Standalone Hono/Node server                | Multi-route Hono (`createCopilotEndpoint`)                             |
-| Need thread management (Intelligence mode) | Multi-route only (thread endpoints not available in single-route)      |
+| Scenario                                   | Recommended                                                                   |
+| ------------------------------------------ | ----------------------------------------------------------------------------- |
+| Next.js App Router                         | Multi-route Hono (`createCopilotHonoHandler`) via `[[...slug]]` catch-all     |
+| Next.js App Router (no catch-all desired)  | Single-route Hono (`createCopilotHonoHandler` + `mode: "single-route"`)       |
+| Standalone Express server                  | Single-route Express (`createCopilotExpressHandler` + `mode: "single-route"`) |
+| Standalone Hono/Node server                | Multi-route Hono (`createCopilotHonoHandler`)                                 |
+| Need thread management (Intelligence mode) | Multi-route only (thread endpoints not available in single-route)             |
 
 ## Middleware
 
@@ -229,7 +234,7 @@ All endpoint factories enable CORS by default with `origin: "*"`. For production
 **Hono endpoints:**
 
 ```typescript
-createCopilotEndpoint({
+createCopilotHonoHandler({
   runtime,
   basePath: "/api/copilotkit",
   cors: {
@@ -244,5 +249,9 @@ createCopilotEndpoint({
 **Frontend side:** Set `credentials: "include"` on the `CopilotKit` provider to send cookies:
 
 ```tsx
-<CopilotKit runtimeUrl="/api/copilotkit" credentials="include">
+<CopilotKit
+  runtimeUrl="/api/copilotkit"
+  useSingleEndpoint={false}
+  credentials="include"
+>
 ```

--- a/skills/react-core/references/chat-components.md
+++ b/skills/react-core/references/chat-components.md
@@ -31,7 +31,7 @@ suggestions internally via `useAgent`. You do not pass `messages` or
 ```tsx
 import { CopilotPopup } from "@copilotkit/react-core/v2";
 
-<CopilotPopup agentId="default" isModalDefaultOpen={false} />;
+<CopilotPopup agentId="default" defaultOpen={false} />;
 ```
 
 ### Persistent sidebar
@@ -53,8 +53,6 @@ want to manage `messages`/`isRunning` yourself.
 ```tsx
 import {
   CopilotChatView,
-  CopilotChatInput,
-  CopilotChatMessageView,
   useAgent,
   useCopilotKit,
 } from "@copilotkit/react-core/v2";
@@ -67,7 +65,7 @@ export function HeadlessChat() {
     <CopilotChatView
       messages={agent.messages}
       isRunning={agent.isRunning}
-      onSubmitInput={async (text) => {
+      onSubmitMessage={async (text) => {
         agent.addMessage({
           id: crypto.randomUUID(),
           role: "user",
@@ -76,8 +74,12 @@ export function HeadlessChat() {
         await copilotkit.runAgent({ agent });
       }}
     >
-      <CopilotChatMessageView />
-      <CopilotChatInput />
+      {({ messageView, input }) => (
+        <>
+          {messageView}
+          {input}
+        </>
+      )}
     </CopilotChatView>
   );
 }
@@ -90,7 +92,7 @@ export function HeadlessChat() {
   agentId="default"
   labels={{
     chatInputPlaceholder: "Ask about the data…",
-    thinking: "Analyzing…",
+    welcomeMessageText: "What would you like to analyze?",
   }}
 />
 ```
@@ -158,14 +160,19 @@ Correct:
 // CopilotChat manages messages and isRunning internally.
 <CopilotChat agentId="default" />
 
-// For manual control, drop down to headless CopilotChatView:
+// For manual control, drop down to headless CopilotChatView. Its `children`
+// is a render prop that receives the bound slot elements:
 <CopilotChatView
   messages={myMessages}
   isRunning={busy}
-  onSubmitInput={handleSubmit}
+  onSubmitMessage={handleSubmit}
 >
-  <CopilotChatMessageView />
-  <CopilotChatInput />
+  {({ messageView, input }) => (
+    <>
+      {messageView}
+      {input}
+    </>
+  )}
 </CopilotChatView>
 ```
 

--- a/skills/runtime/references/wiring-agno.md
+++ b/skills/runtime/references/wiring-agno.md
@@ -1,9 +1,10 @@
-Agno — wired via `@ag-ui/agno`. Requires an `/agui` URL suffix.
+Agno — wired via the generic `HttpAgent` from `@ag-ui/client`. Requires an `/agui` URL
+suffix.
 
 ## Install
 
 ```bash
-pnpm add @ag-ui/agno
+pnpm add @ag-ui/client
 ```
 
 ## Minimal wire-up
@@ -13,11 +14,11 @@ import {
   CopilotRuntime,
   createCopilotRuntimeHandler,
 } from "@copilotkit/runtime/v2";
-import { AgnoAgent } from "@ag-ui/agno";
+import { HttpAgent } from "@ag-ui/client";
 
 const runtime = new CopilotRuntime({
   agents: {
-    default: new AgnoAgent({
+    default: new HttpAgent({
       url: process.env.AGNO_URL ?? "http://localhost:8000/agui",
     }),
   },

--- a/skills/runtime/references/wiring-external-agents.md
+++ b/skills/runtime/references/wiring-external-agents.md
@@ -3,20 +3,20 @@
 `CopilotRuntime` takes any `AbstractAgent` subclass. Every framework below ships a
 ready-made subclass you construct and hand to `agents: { ... }`.
 
-| Framework                 | Package                     | Construct                                                                                                                    |
-| ------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| Mastra                    | `@ag-ui/mastra`             | `MastraAgent.getLocalAgents({ mastra, resourceId? })` (record; `resourceId` required only when the agent has Memory enabled) |
-| LangGraph                 | `@ag-ui/langgraph`          | `new LangGraphAgent({ deploymentUrl, graphId })`                                                                             |
-| CrewAI Crews              | `@ag-ui/crewai`             | `new CrewAIAgent({ url })`                                                                                                   |
-| CrewAI Flows              | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
-| PydanticAI                | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
-| Google ADK                | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
-| LlamaIndex                | `@ag-ui/llamaindex`         | `new LlamaIndexAgent({ url: ".../run" })` (`/run` suffix)                                                                    |
-| Agno                      | `@ag-ui/agno`               | `new AgnoAgent({ url: ".../agui" })` (`/agui` suffix)                                                                        |
-| AWS Strands               | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
-| Microsoft Agent Framework | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
-| AG2                       | `@ag-ui/client` (HttpAgent) | `new HttpAgent({ url })`                                                                                                     |
-| A2A                       | `@ag-ui/a2a`                | `new A2AAgent({ a2aClient })` (pre-built `A2AClient`, not a URL)                                                             |
+| Framework                 | Package                         | Construct                                                                                                                    |
+| ------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Mastra                    | `@ag-ui/mastra`                 | `MastraAgent.getLocalAgents({ mastra, resourceId? })` (record; `resourceId` required only when the agent has Memory enabled) |
+| LangGraph                 | `@copilotkit/runtime/langgraph` | `new LangGraphAgent({ deploymentUrl, graphId })`                                                                             |
+| CrewAI Crews              | `@ag-ui/crewai`                 | `new CrewAIAgent({ url })`                                                                                                   |
+| CrewAI Flows              | `@ag-ui/client` (HttpAgent)     | `new HttpAgent({ url })`                                                                                                     |
+| PydanticAI                | `@ag-ui/client` (HttpAgent)     | `new HttpAgent({ url })`                                                                                                     |
+| Google ADK                | `@ag-ui/client` (HttpAgent)     | `new HttpAgent({ url })`                                                                                                     |
+| LlamaIndex                | `@ag-ui/llamaindex`             | `new LlamaIndexAgent({ url: ".../run" })` (`/run` suffix)                                                                    |
+| Agno                      | `@ag-ui/client` (HttpAgent)     | `new HttpAgent({ url: ".../agui" })` (`/agui` suffix)                                                                        |
+| AWS Strands               | `@ag-ui/client` (HttpAgent)     | `new HttpAgent({ url })`                                                                                                     |
+| Microsoft Agent Framework | `@ag-ui/client` (HttpAgent)     | `new HttpAgent({ url })`                                                                                                     |
+| AG2                       | `@ag-ui/client` (HttpAgent)     | `new HttpAgent({ url })`                                                                                                     |
+| A2A                       | `@ag-ui/a2a`                    | `new A2AAgent({ a2aClient })` (pre-built `A2AClient`, not a URL)                                                             |
 
 MCP Apps is NOT a framework — it's a runtime middleware:
 `new CopilotRuntime({ agents, mcpApps: { servers: [...] } })`. See
@@ -85,7 +85,7 @@ import {
   CopilotRuntime,
   createCopilotRuntimeHandler,
 } from "@copilotkit/runtime/v2";
-import { LangGraphAgent } from "@ag-ui/langgraph";
+import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const runtime = new CopilotRuntime({
   agents: {
@@ -114,7 +114,7 @@ import {
   CopilotRuntime,
   createCopilotRuntimeHandler,
 } from "@copilotkit/runtime/v2";
-import { LangGraphAgent } from "@ag-ui/langgraph";
+import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 import { CrewAIAgent } from "@ag-ui/crewai";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -170,7 +170,7 @@ export default { fetch: handler };
 Wrong:
 
 ```typescript
-import { LangGraphAgent } from "@ag-ui/langgraph";
+import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 new LangGraphAgent({ deploymentUrl: "/api/copilotkit", graphId: "agent" });
 ```
@@ -221,17 +221,17 @@ Wrong:
 
 ```typescript
 import { LlamaIndexAgent } from "@ag-ui/llamaindex";
-import { AgnoAgent } from "@ag-ui/agno";
+import { HttpAgent } from "@ag-ui/client";
 
 new LlamaIndexAgent({ url: "http://localhost:8000" });
-new AgnoAgent({ url: "http://localhost:8000" });
+new HttpAgent({ url: "http://localhost:8000" });
 ```
 
 Correct:
 
 ```typescript
 new LlamaIndexAgent({ url: "http://localhost:8000/run" });
-new AgnoAgent({ url: "http://localhost:8000/agui" });
+new HttpAgent({ url: "http://localhost:8000/agui" });
 ```
 
 LlamaIndex requires a `/run` suffix, Agno requires `/agui`. The generic HttpAgent fallback

--- a/skills/runtime/references/wiring-langgraph.md
+++ b/skills/runtime/references/wiring-langgraph.md
@@ -1,11 +1,10 @@
-LangGraph — wired via `@ag-ui/langgraph`. Supports LangGraph Platform deployments and
-self-hosted LangGraph servers.
+LangGraph — wired via `@copilotkit/runtime/langgraph`. Supports LangGraph Platform
+deployments and self-hosted LangGraph servers.
 
 ## Install
 
-```bash
-pnpm add @ag-ui/langgraph
-```
+`LangGraphAgent` (and `LangGraphHttpAgent` for self-hosted AG-UI LangGraph servers)
+ship with `@copilotkit/runtime` — no separate install needed.
 
 ## Minimal wire-up
 
@@ -14,7 +13,7 @@ import {
   CopilotRuntime,
   createCopilotRuntimeHandler,
 } from "@copilotkit/runtime/v2";
-import { LangGraphAgent } from "@ag-ui/langgraph";
+import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const runtime = new CopilotRuntime({
   agents: {


### PR DESCRIPTION
## What

Completes the v2 API migration across the CopilotKit agent skills, extending #5345 (which started it for `copilotkit-setup`). Docs only, no runtime code changed.

## Why

The journey skills a new user reaches for were still teaching pre-v2 APIs, so copy-pasting their examples failed before anything ran:

- `copilotkit-develop` and `copilotkit-integrations` imported from `@copilotkit/react`, which does not exist (the package is `@copilotkit/react-core`, v2 surface at `/v2`).
- `copilotkit-setup` assets imported the phantom `@copilotkit/agent` package and a non-existent `@copilotkit/runtime/express` subpath.
- `copilotkit-integrations` used the v1 route and an uncompilable `useAgent` shape.
- The recommended multi-route provider snippet omitted `useSingleEndpoint={false}`, so the chat rendered but never connected (404).

## Changes

| Skill | Migration |
|-------|-----------|
| `copilotkit-setup` | assets + refs to `@copilotkit/runtime/v2` (and `/v2/express`), `createCopilotHonoHandler` / `createCopilotExpressHandler`, `@copilotkit/react-core/v2`; transport fix (`useSingleEndpoint={false}`); PATCH/DELETE route exports |
| `copilotkit-develop` | hooks and components to `react-core/v2`, runtime to `/v2`, `useThreads` signature, complete route example |
| `copilotkit-integrations` | `CopilotKit` provider, v2 catch-all Hono route, per-framework agent classes matched to the shipped `examples/integrations/*` |
| `runtime` skill | LangGraph to `@copilotkit/runtime/langgraph`, Agno to `HttpAgent` from `@ag-ui/client` |
| `react-core` skill | `defaultOpen`, `onSubmitMessage`, headless `CopilotChatView` render prop |

Standardized on the non-deprecated `createCopilotHonoHandler` / `createCopilotExpressHandler` factories (matching #5345).

## Validation

- Reviewed across 5 unbiased review rounds (7 agents per round); the final round found zero actionable findings in the changed code.
- Functional build test against the published `@copilotkit/*@1.60.0` packages: `npm install` plus `tsc --noEmit` pass with zero errors, and every `/v2` subpath and imported symbol resolves.

## Out of scope (tracked separately)

Pre-existing issues in files this PR did not change: integration example Python bodies, `runtime`-skill citation paths into the retired `docs/` tree, reference completeness gaps, `showDevConsole` doc accuracy, the `copilotkit-upgrade` skill, the `publicApiKey` vs `publicLicenseKey` source-of-truth decision, and skill eval modernization.
