### PR TITLE
feat(shell-docs): gate Slack docs behind early-access password

### DIFF
--- a/showcase/shell-docs/public/images/slack-bot-generative-ui-dark.png
+++ b/showcase/shell-docs/public/images/slack-bot-generative-ui-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3f8baa4728e107358284e22fc47f8dae534005669c5e42743db773f6447e9a1
+size 383708

--- a/showcase/shell-docs/public/images/slack-bot-generative-ui-light.png
+++ b/showcase/shell-docs/public/images/slack-bot-generative-ui-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9939bce6536fbd6c7194ea02b7aba83fc4c9381153d3a26281607c453645f27a
+size 118541

--- a/showcase/shell-docs/src/app/__tests__/public-assets.test.ts
+++ b/showcase/shell-docs/src/app/__tests__/public-assets.test.ts
@@ -27,4 +27,18 @@ describe("public image assets", () => {
       );
     }
   });
+
+  it("serves the slack early-access gate previews as real PNG files", () => {
+    for (const assetPath of [
+      "images/slack-bot-generative-ui-light.png",
+      "images/slack-bot-generative-ui-dark.png",
+    ]) {
+      const bytes = readPublicAsset(assetPath);
+
+      expect(bytes.subarray(0, pngSignature.length)).toEqual(pngSignature);
+      expect(bytes.toString("utf8", 0, 32)).not.toContain(
+        "version https://git-lfs",
+      );
+    }
+  });
 });

--- a/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
+++ b/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
@@ -34,6 +34,8 @@ import {
 } from "fumadocs-ui/page";
 import { ShellDocsLayout } from "@/components/shell-docs-layout";
 import { ReferenceVersionSelector } from "@/components/reference-version-selector";
+import { EarlyAccessGate } from "@/components/early-access-gate";
+import { getEarlyAccessGate } from "@/lib/early-access";
 import {
   REFERENCE_VERSIONS,
   buildReferencePageTree,
@@ -188,78 +190,99 @@ export default async function ReferenceSlugPage({
         breadcrumb={{ enabled: false }}
         footer={{ enabled: false }}
       >
-        <div className="docs-inner-content max-w-[900px] mx-auto px-4 md:px-6 pt-2 pb-6 md:pt-3 xl:pt-4">
-          <nav className="mb-2 flex flex-wrap items-center gap-1 text-[11px] font-medium leading-none text-[var(--text-muted)]">
-            {breadcrumbs.map((crumb, i) => {
-              const isLast = i === breadcrumbs.length - 1;
-              const labelClass = `truncate ${isLast ? "text-[var(--text)] font-medium" : ""}`;
-              return (
-                <Fragment key={`${crumb.label}-${i}`}>
-                  {i > 0 && (
-                    <ChevronRight
-                      className="size-3 shrink-0"
-                      aria-hidden="true"
-                    />
-                  )}
-                  {crumb.href && !isLast ? (
-                    <Link
-                      href={crumb.href}
-                      className={`${labelClass} transition-opacity hover:opacity-80`}
-                    >
-                      {crumb.label}
-                    </Link>
-                  ) : (
-                    <span className={labelClass}>{crumb.label}</span>
-                  )}
-                </Fragment>
-              );
-            })}
-          </nav>
+        {/* The whole `bot` reference section documents the Slack bot
+            SDK, so it sits behind the same early-access gate as the
+            Slack guide. */}
+        <MaybeEarlyAccessGate gate={version === "bot" ? "slack" : undefined}>
+          <div className="docs-inner-content max-w-[900px] mx-auto px-4 md:px-6 pt-2 pb-6 md:pt-3 xl:pt-4">
+            <nav className="mb-2 flex flex-wrap items-center gap-1 text-[11px] font-medium leading-none text-[var(--text-muted)]">
+              {breadcrumbs.map((crumb, i) => {
+                const isLast = i === breadcrumbs.length - 1;
+                const labelClass = `truncate ${isLast ? "text-[var(--text)] font-medium" : ""}`;
+                return (
+                  <Fragment key={`${crumb.label}-${i}`}>
+                    {i > 0 && (
+                      <ChevronRight
+                        className="size-3 shrink-0"
+                        aria-hidden="true"
+                      />
+                    )}
+                    {crumb.href && !isLast ? (
+                      <Link
+                        href={crumb.href}
+                        className={`${labelClass} transition-opacity hover:opacity-80`}
+                      >
+                        {crumb.label}
+                      </Link>
+                    ) : (
+                      <span className={labelClass}>{crumb.label}</span>
+                    )}
+                  </Fragment>
+                );
+              })}
+            </nav>
 
-          <DocsTitle className="text-[32px] md:text-[40px] font-medium leading-[1.2]">
-            {title}
-          </DocsTitle>
-          {description && (
-            <DocsDescription className="text-lg text-[var(--text-muted)] mt-5 leading-relaxed">
-              {description}
-            </DocsDescription>
-          )}
+            <DocsTitle className="text-[32px] md:text-[40px] font-medium leading-[1.2]">
+              {title}
+            </DocsTitle>
+            {description && (
+              <DocsDescription className="text-lg text-[var(--text-muted)] mt-5 leading-relaxed">
+                {description}
+              </DocsDescription>
+            )}
 
-          <div className="flex min-w-0 flex-row flex-wrap gap-2 items-center my-6">
-            <MarkdownCopyButton markdownUrl={markdownUrl} />
-            <ViewOptionsPopover
-              markdownUrl={markdownUrl}
-              githubUrl={buildGitHubUrl(filePath)}
-            />
-          </div>
+            <div className="flex min-w-0 flex-row flex-wrap gap-2 items-center my-6">
+              <MarkdownCopyButton markdownUrl={markdownUrl} />
+              <ViewOptionsPopover
+                markdownUrl={markdownUrl}
+                githubUrl={buildGitHubUrl(filePath)}
+              />
+            </div>
 
-          <hr className="border-t border-[var(--border)] mt-2 mb-6" />
+            <hr className="border-t border-[var(--border)] mt-2 mb-6" />
 
-          <DocsBody className="reference-content">
-            <MDXRemote
-              source={cleanedContent}
-              components={mdxComponents}
-              options={{
-                mdxOptions: {
-                  remarkPlugins: [remarkGfm],
-                  rehypePlugins: [
-                    [
-                      rehypeCode,
-                      {
-                        fallbackLanguage: "plaintext",
-                        transformers: [
-                          ...(rehypeCodeDefaultOptions.transformers ?? []),
-                          transformerMeta(),
-                        ],
-                      },
+            <DocsBody className="reference-content">
+              <MDXRemote
+                source={cleanedContent}
+                components={mdxComponents}
+                options={{
+                  mdxOptions: {
+                    remarkPlugins: [remarkGfm],
+                    rehypePlugins: [
+                      [
+                        rehypeCode,
+                        {
+                          fallbackLanguage: "plaintext",
+                          transformers: [
+                            ...(rehypeCodeDefaultOptions.transformers ?? []),
+                            transformerMeta(),
+                          ],
+                        },
+                      ],
                     ],
-                  ],
-                },
-              }}
-            />
-          </DocsBody>
-        </div>
+                  },
+                }}
+              />
+            </DocsBody>
+          </div>
+        </MaybeEarlyAccessGate>
       </DocsPage>
     </ShellDocsLayout>
   );
+}
+
+/**
+ * Server-side gate hook-up — mirrors the helper in `docs-page-view.tsx`.
+ * Absent or unknown gate ids render children directly so ungated
+ * reference versions never mount the client-side gate component.
+ */
+function MaybeEarlyAccessGate({
+  gate,
+  children,
+}: {
+  gate?: string;
+  children: React.ReactNode;
+}) {
+  if (!gate || !getEarlyAccessGate(gate)) return <>{children}</>;
+  return <EarlyAccessGate gate={gate}>{children}</EarlyAccessGate>;
 }

--- a/showcase/shell-docs/src/components/__tests__/early-access-gate.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/early-access-gate.test.tsx
@@ -1,0 +1,65 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { EarlyAccessGate } from "../early-access-gate";
+import { EARLY_ACCESS_GATES, getEarlyAccessGate } from "@/lib/early-access";
+
+describe("early-access config", () => {
+  it("registers the slack gate with the shared password", () => {
+    expect(EARLY_ACCESS_GATES.slack.password).toBe("earlyaccess");
+    expect(EARLY_ACCESS_GATES.slack.storageKey).toBe(
+      "shell-docs-early-access:slack",
+    );
+  });
+
+  it("points the request-access CTA at the beyond-the-web form", () => {
+    expect(EARLY_ACCESS_GATES.slack.requestUrl).toBe(
+      "https://go.copilotkit.ai/beyond-the-web-form",
+    );
+  });
+
+  it("resolves known ids and rejects unknown ones", () => {
+    expect(getEarlyAccessGate("slack")).toBe(EARLY_ACCESS_GATES.slack);
+    expect(getEarlyAccessGate("nope")).toBeNull();
+    expect(getEarlyAccessGate(undefined)).toBeNull();
+  });
+});
+
+describe("EarlyAccessGate", () => {
+  it("server-renders gated content blurred, inert, and hidden from AT", () => {
+    const markup = renderToStaticMarkup(
+      <EarlyAccessGate gate="slack">
+        <p>secret slack guide</p>
+      </EarlyAccessGate>,
+    );
+
+    // Content stays in the DOM (it's what gets blurred)…
+    expect(markup).toContain("secret slack guide");
+    // …but is visually blurred and unreachable.
+    expect(markup).toContain("blur-");
+    expect(markup).toContain("inert=");
+    expect(markup).toContain('aria-hidden="true"');
+    expect(markup).toContain("pointer-events-none");
+  });
+
+  it("does not server-render the unlock card (it mounts client-side)", () => {
+    const markup = renderToStaticMarkup(
+      <EarlyAccessGate gate="slack">
+        <p>secret slack guide</p>
+      </EarlyAccessGate>,
+    );
+
+    expect(markup).not.toContain("Enter password");
+    expect(markup).not.toContain("Unlock");
+  });
+
+  it("passes children through untouched for unknown gate ids", () => {
+    const markup = renderToStaticMarkup(
+      <EarlyAccessGate gate="not-a-gate">
+        <p>plain content</p>
+      </EarlyAccessGate>,
+    );
+
+    expect(markup).toBe("<p>plain content</p>");
+  });
+});

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -24,6 +24,8 @@ import {
 } from "fumadocs-ui/page";
 import { ShellDocsLayout } from "@/components/shell-docs-layout";
 import { SidebarFrameworkSelector } from "@/components/sidebar-framework-selector";
+import { EarlyAccessGate } from "@/components/early-access-gate";
+import { getEarlyAccessGate } from "@/lib/early-access";
 import {
   MarkdownCopyButton,
   ViewOptionsPopover,
@@ -218,353 +220,373 @@ export async function DocsPageView({
         footer={{ enabled: false }}
         tableOfContentPopover={{ enabled: false }}
       >
-        <div className="docs-inner-content max-w-[900px] mx-auto px-4 md:px-6 pt-2 pb-6 md:pt-3 xl:pt-4">
-          {/* Breadcrumb styling tracks canonical fumadocs PageBreadcrumb,
-           * but tighter: this should read as quiet page chrome, not a
-           * second title row above the H1. */}
-          <nav className="mb-2 flex flex-wrap items-center gap-1 text-[11px] font-medium leading-none text-[var(--text-muted)]">
-            {breadcrumbs.map((crumb, i) => {
-              const isLast = i === breadcrumbs.length - 1;
-              const labelClass = `truncate ${isLast ? "text-[var(--text)] font-medium" : ""}`;
-              return (
-                <React.Fragment key={i}>
-                  {i > 0 && (
-                    <ChevronRight
-                      className="size-3 shrink-0"
-                      aria-hidden="true"
-                    />
-                  )}
-                  {crumb.href ? (
-                    <Link
-                      href={crumb.href}
-                      className={`${labelClass} transition-opacity hover:opacity-80`}
-                    >
-                      {crumb.label}
-                    </Link>
-                  ) : (
-                    <span className={labelClass}>{crumb.label}</span>
-                  )}
-                </React.Fragment>
-              );
-            })}
-          </nav>
+        <MaybeEarlyAccessGate gate={doc.fm.earlyAccess}>
+          <div className="docs-inner-content max-w-[900px] mx-auto px-4 md:px-6 pt-2 pb-6 md:pt-3 xl:pt-4">
+            {/* Breadcrumb styling tracks canonical fumadocs PageBreadcrumb,
+             * but tighter: this should read as quiet page chrome, not a
+             * second title row above the H1. */}
+            <nav className="mb-2 flex flex-wrap items-center gap-1 text-[11px] font-medium leading-none text-[var(--text-muted)]">
+              {breadcrumbs.map((crumb, i) => {
+                const isLast = i === breadcrumbs.length - 1;
+                const labelClass = `truncate ${isLast ? "text-[var(--text)] font-medium" : ""}`;
+                return (
+                  <React.Fragment key={i}>
+                    {i > 0 && (
+                      <ChevronRight
+                        className="size-3 shrink-0"
+                        aria-hidden="true"
+                      />
+                    )}
+                    {crumb.href ? (
+                      <Link
+                        href={crumb.href}
+                        className={`${labelClass} transition-opacity hover:opacity-80`}
+                      >
+                        {crumb.label}
+                      </Link>
+                    ) : (
+                      <span className={labelClass}>{crumb.label}</span>
+                    )}
+                  </React.Fragment>
+                );
+              })}
+            </nav>
 
-          <DocsTitle className="text-[32px] md:text-[40px] font-medium leading-[1.2]">
-            {doc.fm.title}
-          </DocsTitle>
-          {doc.fm.description && (
-            <DocsDescription className="text-lg text-[var(--text-muted)] mt-5 leading-relaxed">
-              {doc.fm.description}
-            </DocsDescription>
-          )}
+            <DocsTitle className="text-[32px] md:text-[40px] font-medium leading-[1.2]">
+              {doc.fm.title}
+            </DocsTitle>
+            {doc.fm.description && (
+              <DocsDescription className="text-lg text-[var(--text-muted)] mt-5 leading-relaxed">
+                {doc.fm.description}
+              </DocsDescription>
+            )}
 
-          {/* Page actions (Copy Markdown / Open in <LLM>) — fumadocs's
+            {/* Page actions (Copy Markdown / Open in <LLM>) — fumadocs's
               upstream LLM page-actions feature. `markdownUrl` resolves
               through the `/:path*.mdx` rewrite to the route handler at
               `app/llms-mdx/[[...slug]]/route.ts`, which serves the raw
               MDX via the same `loadDoc()` the page uses. The GitHub URL
               is computed from `doc.filePath` (absolute fs path) by
               slicing from the `/showcase/` segment. */}
-          {(() => {
-            // Markdown URL = the canonical page URL with `.mdx` appended.
-            // The Next.js rewrite in `next.config.ts` routes this to
-            // `/llms-mdx/[[...slug]]`, which re-runs the same framework-
-            // aware content resolution the page uses. Using the page URL
-            // (rather than `contentSlugPath`) keeps the "View as Markdown"
-            // link the user opens in a new tab visually aligned with the
-            // page they're reading.
-            const base = `${slugHrefPrefix || ""}/${slugPath}`
-              .replace(/\/+/g, "/")
-              .replace(/^\/+/, "/");
-            const markdownUrl = `${base.replace(/\/$/, "")}.mdx`;
-            return (
-              <div className="flex min-w-0 flex-row flex-wrap gap-2 items-center my-6">
-                <MarkdownCopyButton markdownUrl={markdownUrl} />
-                <ViewOptionsPopover
-                  markdownUrl={markdownUrl}
-                  githubUrl={buildGitHubUrl(doc.filePath)}
-                />
-              </div>
-            );
-          })()}
+            {(() => {
+              // Markdown URL = the canonical page URL with `.mdx` appended.
+              // The Next.js rewrite in `next.config.ts` routes this to
+              // `/llms-mdx/[[...slug]]`, which re-runs the same framework-
+              // aware content resolution the page uses. Using the page URL
+              // (rather than `contentSlugPath`) keeps the "View as Markdown"
+              // link the user opens in a new tab visually aligned with the
+              // page they're reading.
+              const base = `${slugHrefPrefix || ""}/${slugPath}`
+                .replace(/\/+/g, "/")
+                .replace(/^\/+/, "/");
+              const markdownUrl = `${base.replace(/\/$/, "")}.mdx`;
+              return (
+                <div className="flex min-w-0 flex-row flex-wrap gap-2 items-center my-6">
+                  <MarkdownCopyButton markdownUrl={markdownUrl} />
+                  <ViewOptionsPopover
+                    markdownUrl={markdownUrl}
+                    githubUrl={buildGitHubUrl(doc.filePath)}
+                  />
+                </div>
+              );
+            })()}
 
-          {/* Thin divider between the page-actions row and the page body
+            {/* Thin divider between the page-actions row and the page body
               (banner / content). Visually separates the page metadata
               chrome (title + page actions) from the page content
               underneath. Uses the project's `--border` token so it tracks
               the rest of the page chrome in light and dark modes. */}
-          <hr className="border-t border-[var(--border)] mt-2 mb-6" />
+            <hr className="border-t border-[var(--border)] mt-2 mb-6" />
 
-          {bannerSlot}
+            {bannerSlot}
 
-          {!hideBody &&
-            (() => {
-              const body = (
-                <DocsBody className="reference-content">
-                  <MDXRemote
-                    source={content}
-                    components={{
-                      ...docsComponents,
-                      // Wrap MDX-rendered <pre> blocks (triple-fenced code)
-                      // with the same figure chrome <Snippet> uses — copy
-                      // button always visible, file-path caption when the
-                      // fence carries `title="..."`. The `transformerMeta`
-                      // Shiki transformer (wired in `options.mdxOptions.rehypePlugins`
-                      // below) is what puts `data-title` / `data-language`
-                      // on the <pre> for this component to read.
-                      pre: MdxCodeBlock,
-                      Snippet: (props: Record<string, unknown>) => (
-                        <Snippet
-                          {...(props as Record<string, string | undefined>)}
-                          defaultFramework={defaultFramework}
-                          defaultCell={defaultCell}
-                        />
-                      ),
-                      WhenFrameworkHas: (props: Record<string, unknown>) => (
-                        <WhenFrameworkHas
-                          {...(props as {
-                            flag: "a2ui_pattern" | "interrupt_pattern";
-                            equals?: string;
-                            absent?: boolean;
-                            framework?: string;
-                            children?: React.ReactNode;
-                          })}
-                          defaultFramework={defaultFramework}
-                        />
-                      ),
-                      // MDX pages author in-page variant selectors as
-                      // `<Tabs groupId="language_langgraph_agent" default="Python">`.
-                      // When the URL scope is a specific variant (e.g.
-                      // `/langgraph-typescript/*`), pre-select the
-                      // matching tab instead of the author's hardcoded
-                      // default so the code visible on arrival matches
-                      // the URL the user followed. Slugs without a
-                      // mapping (or tabs whose groupId isn't listed in
-                      // TAB_DEFAULTS_BY_SLUG) fall through to the MDX
-                      // `default` and the component's first-label
-                      // fallback unchanged.
-                      Tabs: (props: {
-                        groupId?: string;
-                        default?: string;
-                        items?: string[];
-                        children?: React.ReactNode;
-                        persist?: boolean;
-                      }) => {
-                        const urlDefault = getTabDefault(
-                          frameworkOverride ?? null,
-                          props.groupId,
-                        );
-                        return (
-                          <DocsTabs
-                            {...props}
-                            default={urlDefault ?? props.default}
-                          >
-                            {props.children}
-                          </DocsTabs>
-                        );
-                      },
-                      InlineDemo: (props: Record<string, unknown>) => {
-                        const InlineDemoComp = docsComponents.InlineDemo;
-                        return (
-                          <InlineDemoComp
-                            {...(props as {
-                              integration?: string;
-                              demo?: string;
-                            })}
-                            integration={
-                              defaultFramework ??
-                              (props.integration as string | undefined)
-                            }
+            {!hideBody &&
+              (() => {
+                const body = (
+                  <DocsBody className="reference-content">
+                    <MDXRemote
+                      source={content}
+                      components={{
+                        ...docsComponents,
+                        // Wrap MDX-rendered <pre> blocks (triple-fenced code)
+                        // with the same figure chrome <Snippet> uses — copy
+                        // button always visible, file-path caption when the
+                        // fence carries `title="..."`. The `transformerMeta`
+                        // Shiki transformer (wired in `options.mdxOptions.rehypePlugins`
+                        // below) is what puts `data-title` / `data-language`
+                        // on the <pre> for this component to read.
+                        pre: MdxCodeBlock,
+                        Snippet: (props: Record<string, unknown>) => (
+                          <Snippet
+                            {...(props as Record<string, string | undefined>)}
+                            defaultFramework={defaultFramework}
+                            defaultCell={defaultCell}
                           />
-                        );
-                      },
-                      // Bind the URL framework slug into MdxFrameworkOverview
-                      // so its link rewriter has a target to rewrite TO. The
-                      // shared `integrations/<folder>/index.mdx` files
-                      // (langgraph/, microsoft-agent-framework/, crewai-flows/)
-                      // serve multiple URL variants — without this override the
-                      // adapter's empty-slug fallback would strip the embedded
-                      // framework prefix entirely (e.g. `/langgraph/quickstart`
-                      // → `/quickstart`).
-                      FrameworkOverview: (props: MdxFrameworkOverviewProps) => (
-                        <MdxFrameworkOverview
-                          {...props}
-                          currentFramework={
-                            frameworkOverride ?? props.currentFramework
-                          }
-                        />
-                      ),
-                      // Same closure pattern: thread the URL framework
-                      // slug into <FrameworkSetup concept="..." /> so it
-                      // can resolve the per-framework concept file.
-                      FrameworkSetup: (props: {
-                        concept: string;
-                        heading?: string | null;
-                        headingId?: string;
-                        currentFramework?: string;
-                      }) => (
-                        <FrameworkSetup
-                          {...props}
-                          currentFramework={
-                            frameworkOverride ?? props.currentFramework
-                          }
-                        />
-                      ),
-                      // Inject stable IDs on H2/H3 so the right-rail TOC's
-                      // #anchor links resolve. Slugify the child text with the
-                      // same algorithm used by extractHeadings() so IDs line up
-                      // with the TOC entries.
-                      // H2/H3 carry stable slug IDs (already used by the
-                      // right-rail TOC) and now also surface a hover-only
-                      // `#` anchor link for deep-linking, mirroring the
-                      // canonical fumadocs prose chrome.
-                      h2: ({
-                        children,
-                        ...rest
-                      }: React.HTMLAttributes<HTMLHeadingElement>) => {
-                        const id = slugify(childrenToText(children));
-                        // Spread rest BEFORE id/className so the computed
-                        // slug-id always wins over any MDX-supplied id.
-                        // Otherwise an authored `<h2 id="custom">` would
-                        // override the slugified id, breaking the TOC's
-                        // `href="#${id}"` and any inbound deep-links that
-                        // already rely on the slug.
-                        return (
-                          <h2
-                            {...rest}
-                            id={id}
-                            className={`docs-heading group ${rest.className ?? ""}`}
-                          >
-                            {children}
-                            <a
-                              href={`#${id}`}
-                              aria-label="Link to this section"
-                              className="docs-heading-anchor"
-                            >
-                              #
-                            </a>
-                          </h2>
-                        );
-                      },
-                      h3: ({
-                        children,
-                        ...rest
-                      }: React.HTMLAttributes<HTMLHeadingElement>) => {
-                        const id = slugify(childrenToText(children));
-                        // Spread rest BEFORE id/className — see h2 above for
-                        // rationale.
-                        return (
-                          <h3
-                            {...rest}
-                            id={id}
-                            className={`docs-heading group ${rest.className ?? ""}`}
-                          >
-                            {children}
-                            <a
-                              href={`#${id}`}
-                              aria-label="Link to this section"
-                              className="docs-heading-anchor"
-                            >
-                              #
-                            </a>
-                          </h3>
-                        );
-                      },
-                      // When rendering under a framework-scoped route, rewrite
-                      // root-relative MDX links (/quickstart, /shared-state, …)
-                      // to the framework-scoped equivalent so clicks never land
-                      // on the unscoped page and trigger a RouterPivot redirect.
-                      ...(frameworkOverride && {
-                        a: ({
-                          href,
-                          children,
-                          ...rest
-                        }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
-                          // Rewrite root-relative MDX links into the
-                          // framework scope EXCEPT when the link already
-                          // points at the framework root or its subtree.
-                          // Without the bare-root check, `[…](/built-in-agent)`
-                          // (no trailing slash) would rewrite to
-                          // `/built-in-agent/built-in-agent` and dead-end.
-                          // Also guard protocol-relative URLs (`//host/…`):
-                          // they pass startsWith("/") but must not be
-                          // treated as in-app paths.
-                          const isProtocolRelative =
-                            !!href && href.startsWith("//");
-                          const alreadyScoped =
-                            !!href &&
-                            (href === `/${frameworkOverride}` ||
-                              href.startsWith(`/${frameworkOverride}/`));
-                          // Cross-framework (`/a2a/...`,
-                          // `/langgraph-python/...`) and top-level
-                          // reserved-route (`/reference`, `/ag-ui`,
-                          // `/api`, `/docs`) links must keep their
-                          // absolute path. Without these guards, an
-                          // MDX link like `/a2a/generative-ui/...`
-                          // rendered on a BIA page becomes
-                          // `/built-in-agent/a2a/...` and 404s.
-                          const firstSegment =
-                            href?.startsWith("/") && !isProtocolRelative
-                              ? href.slice(1).split(/[/?#]/, 1)[0]
-                              : undefined;
-                          const targetsAnotherFramework =
-                            firstSegment !== undefined &&
-                            CROSS_FRAMEWORK_SLUGS.has(firstSegment) &&
-                            firstSegment !== frameworkOverride;
-                          const targetsReservedRoute =
-                            firstSegment !== undefined &&
-                            RESERVED_ROUTE_SLUG_SET.has(firstSegment);
-                          const resolved =
-                            href?.startsWith("/") &&
-                            !isProtocolRelative &&
-                            !alreadyScoped &&
-                            !targetsAnotherFramework &&
-                            !targetsReservedRoute
-                              ? `/${frameworkOverride}${href}`
-                              : href;
+                        ),
+                        WhenFrameworkHas: (props: Record<string, unknown>) => (
+                          <WhenFrameworkHas
+                            {...(props as {
+                              flag: "a2ui_pattern" | "interrupt_pattern";
+                              equals?: string;
+                              absent?: boolean;
+                              framework?: string;
+                              children?: React.ReactNode;
+                            })}
+                            defaultFramework={defaultFramework}
+                          />
+                        ),
+                        // MDX pages author in-page variant selectors as
+                        // `<Tabs groupId="language_langgraph_agent" default="Python">`.
+                        // When the URL scope is a specific variant (e.g.
+                        // `/langgraph-typescript/*`), pre-select the
+                        // matching tab instead of the author's hardcoded
+                        // default so the code visible on arrival matches
+                        // the URL the user followed. Slugs without a
+                        // mapping (or tabs whose groupId isn't listed in
+                        // TAB_DEFAULTS_BY_SLUG) fall through to the MDX
+                        // `default` and the component's first-label
+                        // fallback unchanged.
+                        Tabs: (props: {
+                          groupId?: string;
+                          default?: string;
+                          items?: string[];
+                          children?: React.ReactNode;
+                          persist?: boolean;
+                        }) => {
+                          const urlDefault = getTabDefault(
+                            frameworkOverride ?? null,
+                            props.groupId,
+                          );
                           return (
-                            <Link href={resolved ?? "#"} {...rest}>
-                              {children}
-                            </Link>
+                            <DocsTabs
+                              {...props}
+                              default={urlDefault ?? props.default}
+                            >
+                              {props.children}
+                            </DocsTabs>
                           );
                         },
-                      }),
-                    }}
-                    options={{
-                      mdxOptions: {
-                        remarkPlugins: [remarkGfm],
-                        // Use Fumadocs's Shiki-based `rehypeCode` for
-                        // syntax highlighting. Our custom `transformerMeta`
-                        // surfaces the parsed fence `title="..."` and
-                        // resolved language as data-attrs on the <pre>
-                        // so MdxCodeBlock can render Fumadocs's CodeBlock
-                        // chrome with the file-path figcaption + copy
-                        // button.
-                        rehypePlugins: [
-                          [
-                            rehypeCode,
-                            {
-                              fallbackLanguage: "plaintext",
-                              transformers: [
-                                ...(rehypeCodeDefaultOptions.transformers ??
-                                  []),
-                                transformerMeta(),
-                              ],
-                            },
+                        InlineDemo: (props: Record<string, unknown>) => {
+                          const InlineDemoComp = docsComponents.InlineDemo;
+                          return (
+                            <InlineDemoComp
+                              {...(props as {
+                                integration?: string;
+                                demo?: string;
+                              })}
+                              integration={
+                                defaultFramework ??
+                                (props.integration as string | undefined)
+                              }
+                            />
+                          );
+                        },
+                        // Bind the URL framework slug into MdxFrameworkOverview
+                        // so its link rewriter has a target to rewrite TO. The
+                        // shared `integrations/<folder>/index.mdx` files
+                        // (langgraph/, microsoft-agent-framework/, crewai-flows/)
+                        // serve multiple URL variants — without this override the
+                        // adapter's empty-slug fallback would strip the embedded
+                        // framework prefix entirely (e.g. `/langgraph/quickstart`
+                        // → `/quickstart`).
+                        FrameworkOverview: (
+                          props: MdxFrameworkOverviewProps,
+                        ) => (
+                          <MdxFrameworkOverview
+                            {...props}
+                            currentFramework={
+                              frameworkOverride ?? props.currentFramework
+                            }
+                          />
+                        ),
+                        // Same closure pattern: thread the URL framework
+                        // slug into <FrameworkSetup concept="..." /> so it
+                        // can resolve the per-framework concept file.
+                        FrameworkSetup: (props: {
+                          concept: string;
+                          heading?: string | null;
+                          headingId?: string;
+                          currentFramework?: string;
+                        }) => (
+                          <FrameworkSetup
+                            {...props}
+                            currentFramework={
+                              frameworkOverride ?? props.currentFramework
+                            }
+                          />
+                        ),
+                        // Inject stable IDs on H2/H3 so the right-rail TOC's
+                        // #anchor links resolve. Slugify the child text with the
+                        // same algorithm used by extractHeadings() so IDs line up
+                        // with the TOC entries.
+                        // H2/H3 carry stable slug IDs (already used by the
+                        // right-rail TOC) and now also surface a hover-only
+                        // `#` anchor link for deep-linking, mirroring the
+                        // canonical fumadocs prose chrome.
+                        h2: ({
+                          children,
+                          ...rest
+                        }: React.HTMLAttributes<HTMLHeadingElement>) => {
+                          const id = slugify(childrenToText(children));
+                          // Spread rest BEFORE id/className so the computed
+                          // slug-id always wins over any MDX-supplied id.
+                          // Otherwise an authored `<h2 id="custom">` would
+                          // override the slugified id, breaking the TOC's
+                          // `href="#${id}"` and any inbound deep-links that
+                          // already rely on the slug.
+                          return (
+                            <h2
+                              {...rest}
+                              id={id}
+                              className={`docs-heading group ${rest.className ?? ""}`}
+                            >
+                              {children}
+                              <a
+                                href={`#${id}`}
+                                aria-label="Link to this section"
+                                className="docs-heading-anchor"
+                              >
+                                #
+                              </a>
+                            </h2>
+                          );
+                        },
+                        h3: ({
+                          children,
+                          ...rest
+                        }: React.HTMLAttributes<HTMLHeadingElement>) => {
+                          const id = slugify(childrenToText(children));
+                          // Spread rest BEFORE id/className — see h2 above for
+                          // rationale.
+                          return (
+                            <h3
+                              {...rest}
+                              id={id}
+                              className={`docs-heading group ${rest.className ?? ""}`}
+                            >
+                              {children}
+                              <a
+                                href={`#${id}`}
+                                aria-label="Link to this section"
+                                className="docs-heading-anchor"
+                              >
+                                #
+                              </a>
+                            </h3>
+                          );
+                        },
+                        // When rendering under a framework-scoped route, rewrite
+                        // root-relative MDX links (/quickstart, /shared-state, …)
+                        // to the framework-scoped equivalent so clicks never land
+                        // on the unscoped page and trigger a RouterPivot redirect.
+                        ...(frameworkOverride && {
+                          a: ({
+                            href,
+                            children,
+                            ...rest
+                          }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
+                            // Rewrite root-relative MDX links into the
+                            // framework scope EXCEPT when the link already
+                            // points at the framework root or its subtree.
+                            // Without the bare-root check, `[…](/built-in-agent)`
+                            // (no trailing slash) would rewrite to
+                            // `/built-in-agent/built-in-agent` and dead-end.
+                            // Also guard protocol-relative URLs (`//host/…`):
+                            // they pass startsWith("/") but must not be
+                            // treated as in-app paths.
+                            const isProtocolRelative =
+                              !!href && href.startsWith("//");
+                            const alreadyScoped =
+                              !!href &&
+                              (href === `/${frameworkOverride}` ||
+                                href.startsWith(`/${frameworkOverride}/`));
+                            // Cross-framework (`/a2a/...`,
+                            // `/langgraph-python/...`) and top-level
+                            // reserved-route (`/reference`, `/ag-ui`,
+                            // `/api`, `/docs`) links must keep their
+                            // absolute path. Without these guards, an
+                            // MDX link like `/a2a/generative-ui/...`
+                            // rendered on a BIA page becomes
+                            // `/built-in-agent/a2a/...` and 404s.
+                            const firstSegment =
+                              href?.startsWith("/") && !isProtocolRelative
+                                ? href.slice(1).split(/[/?#]/, 1)[0]
+                                : undefined;
+                            const targetsAnotherFramework =
+                              firstSegment !== undefined &&
+                              CROSS_FRAMEWORK_SLUGS.has(firstSegment) &&
+                              firstSegment !== frameworkOverride;
+                            const targetsReservedRoute =
+                              firstSegment !== undefined &&
+                              RESERVED_ROUTE_SLUG_SET.has(firstSegment);
+                            const resolved =
+                              href?.startsWith("/") &&
+                              !isProtocolRelative &&
+                              !alreadyScoped &&
+                              !targetsAnotherFramework &&
+                              !targetsReservedRoute
+                                ? `/${frameworkOverride}${href}`
+                                : href;
+                            return (
+                              <Link href={resolved ?? "#"} {...rest}>
+                                {children}
+                              </Link>
+                            );
+                          },
+                        }),
+                      }}
+                      options={{
+                        mdxOptions: {
+                          remarkPlugins: [remarkGfm],
+                          // Use Fumadocs's Shiki-based `rehypeCode` for
+                          // syntax highlighting. Our custom `transformerMeta`
+                          // surfaces the parsed fence `title="..."` and
+                          // resolved language as data-attrs on the <pre>
+                          // so MdxCodeBlock can render Fumadocs's CodeBlock
+                          // chrome with the file-path figcaption + copy
+                          // button.
+                          rehypePlugins: [
+                            [
+                              rehypeCode,
+                              {
+                                fallbackLanguage: "plaintext",
+                                transformers: [
+                                  ...(rehypeCodeDefaultOptions.transformers ??
+                                    []),
+                                  transformerMeta(),
+                                ],
+                              },
+                            ],
                           ],
-                        ],
-                      },
-                    }}
-                  />
-                </DocsBody>
-              );
-              if (ContentWrapper) {
-                return <ContentWrapper>{body}</ContentWrapper>;
-              }
-              return body;
-            })()}
-        </div>
+                        },
+                      }}
+                    />
+                  </DocsBody>
+                );
+                if (ContentWrapper) {
+                  return <ContentWrapper>{body}</ContentWrapper>;
+                }
+                return body;
+              })()}
+          </div>
+        </MaybeEarlyAccessGate>
       </DocsPage>
     </ShellDocsLayout>
   );
+}
+
+/**
+ * Server-side gate hook-up: pages opt in via `earlyAccess: <gate-id>`
+ * frontmatter. Unknown or absent gate ids render children directly so
+ * ungated pages never mount the client-side gate component.
+ */
+function MaybeEarlyAccessGate({
+  gate,
+  children,
+}: {
+  gate?: string;
+  children: React.ReactNode;
+}) {
+  if (!gate || !getEarlyAccessGate(gate)) return <>{children}</>;
+  return <EarlyAccessGate gate={gate}>{children}</EarlyAccessGate>;
 }

--- a/showcase/shell-docs/src/components/early-access-gate.tsx
+++ b/showcase/shell-docs/src/components/early-access-gate.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+// EarlyAccessGate — client-side soft gate for early-access docs.
+//
+// Renders the gated page content blurred and non-interactive with an
+// unlock card floating above it. The card lives in a sticky,
+// viewport-height frame inside an absolute overlay, so it stays
+// centered in view while the blurred page scrolls underneath — without
+// covering the sidebar or top nav the way a true fixed modal would.
+//
+// Unlock state persists in localStorage (per gate id), so entering the
+// password once unlocks every page behind the same gate.
+
+import React, { useEffect, useId, useState } from "react";
+import Image from "next/image";
+import { Lock, Slack } from "lucide-react";
+import { getEarlyAccessGate } from "@/lib/early-access";
+import type { EarlyAccessGateConfig } from "@/lib/early-access";
+
+// Icon shown in the card header tile, per gate id. Kept here (not in
+// the config module) so the server-importable config stays free of
+// client-only component values.
+const GATE_ICONS: Record<
+  string,
+  React.ComponentType<{ className?: string }>
+> = {
+  slack: Slack,
+};
+
+const UNLOCKED_VALUE = "unlocked";
+
+function readUnlocked(storageKey: string): boolean {
+  try {
+    return window.localStorage.getItem(storageKey) === UNLOCKED_VALUE;
+  } catch {
+    // Storage unavailable (private mode, blocked) — treat as locked;
+    // a correct password still unlocks for the current page view.
+    return false;
+  }
+}
+
+function persistUnlocked(storageKey: string): void {
+  try {
+    window.localStorage.setItem(storageKey, UNLOCKED_VALUE);
+  } catch {
+    // Best effort — the in-memory unlock still applies.
+  }
+}
+
+export function EarlyAccessGate({
+  gate,
+  children,
+}: {
+  gate: string;
+  children: React.ReactNode;
+}) {
+  const config = getEarlyAccessGate(gate);
+  if (!config) return <>{children}</>;
+  return (
+    <GateShell gate={gate} config={config}>
+      {children}
+    </GateShell>
+  );
+}
+
+function GateShell({
+  gate,
+  config,
+  children,
+}: {
+  gate: string;
+  config: EarlyAccessGateConfig;
+  children: React.ReactNode;
+}) {
+  // null = not yet hydrated. The server (and first client render)
+  // always paint the locked state so hydration matches; the effect
+  // then either reveals the content or pops the unlock card in.
+  const [unlocked, setUnlocked] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    setUnlocked(readUnlocked(config.storageKey));
+  }, [config.storageKey]);
+
+  const locked = unlocked !== true;
+
+  return (
+    <div className="relative">
+      <div
+        inert={locked}
+        aria-hidden={locked}
+        className={`transition-[filter,opacity] duration-500 ease-out ${
+          locked
+            ? "pointer-events-none min-h-[75svh] select-none opacity-60 blur-[14px]"
+            : ""
+        }`}
+      >
+        {children}
+      </div>
+      {unlocked === false && (
+        <div className="pointer-events-none absolute inset-0 z-10">
+          {/* Sticky scrollport-height frame: pins to the top of the
+              docs scroll container while the gated region scrolls,
+              keeping the card centered in view the whole way down. The
+              height subtracts the fixed nav + banner so the frame (and
+              the card's max-height) tracks the visible content area. */}
+          <div className="sticky top-0 flex h-[calc(100svh-var(--fd-nav-height,64px)-var(--fd-banner-height,0px))] items-center justify-center px-4 sm:px-6">
+            <UnlockCard
+              gate={gate}
+              config={config}
+              onUnlock={() => {
+                persistUnlocked(config.storageKey);
+                setUnlocked(true);
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UnlockCard({
+  gate,
+  config,
+  onUnlock,
+}: {
+  gate: string;
+  config: EarlyAccessGateConfig;
+  onUnlock: () => void;
+}) {
+  const titleId = useId();
+  const inputId = useId();
+  const errorId = useId();
+  const [value, setValue] = useState("");
+  const [error, setError] = useState(false);
+  const Icon = GATE_ICONS[gate] ?? Lock;
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (value.trim() === config.password) {
+      onUnlock();
+    } else {
+      setError(true);
+    }
+  }
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      className="pointer-events-auto max-h-[calc(100%-2rem)] w-full max-w-[820px] overflow-y-auto rounded-2xl border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-modal)]"
+    >
+      <div className="flex items-center gap-4 p-6">
+        <div
+          className="flex size-[52px] shrink-0 items-center justify-center rounded-xl bg-[var(--accent-dim)] text-[var(--text)]"
+          aria-hidden="true"
+        >
+          <Icon className="size-[26px]" />
+        </div>
+        <div className="min-w-0">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--accent)]">
+            {config.eyebrow}
+          </div>
+          <h2
+            id={titleId}
+            className="mt-1 text-xl font-bold leading-snug tracking-tight text-[var(--text)] md:text-[23px]"
+          >
+            {config.title}
+          </h2>
+        </div>
+      </div>
+
+      <div className="@container border-t border-[var(--border)] p-6">
+        {/* Two columns once the CARD itself is wide enough (container
+            query, not viewport — at tablet widths the sidebar leaves
+            the card too narrow to split). Copy + form on the left,
+            product preview on the right; on narrow cards the preview
+            is hidden so the form needs no internal scrolling. The
+            preview column stretches to exactly the height of the copy
+            column (default align-items, fill + object-cover image). */}
+        <div className="flex flex-col gap-5 @3xl:flex-row @3xl:gap-6">
+          <div className="min-w-0 flex-1">
+            {config.description.map((paragraph, index) => (
+              <p
+                key={paragraph}
+                className={`text-[15px] leading-relaxed text-[var(--text-secondary)] ${
+                  index > 0 ? "mt-3" : ""
+                }`}
+              >
+                {paragraph}
+              </p>
+            ))}
+
+            <p className="mt-3 text-[15px] leading-relaxed text-[var(--text-secondary)]">
+              {config.requestPrompt}{" "}
+              <a
+                href={config.requestUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="font-medium text-[var(--accent)] underline decoration-[color-mix(in_oklch,var(--accent)_40%,transparent)] underline-offset-[3px] transition-colors hover:decoration-[var(--accent)]"
+              >
+                {config.requestLinkLabel}
+              </a>
+              .
+            </p>
+
+            <form onSubmit={handleSubmit} className="mt-5" noValidate>
+              <label
+                htmlFor={inputId}
+                className="block text-sm font-semibold text-[var(--text)]"
+              >
+                Password
+              </label>
+              <div className="mt-2 flex flex-col gap-3 sm:flex-row">
+                <div className="relative min-w-0 flex-1">
+                  <Lock
+                    className="pointer-events-none absolute left-3.5 top-1/2 size-4 -translate-y-1/2 text-[var(--text-muted)]"
+                    aria-hidden="true"
+                  />
+                  <input
+                    id={inputId}
+                    type="password"
+                    value={value}
+                    onChange={(event) => {
+                      setValue(event.target.value);
+                      if (error) setError(false);
+                    }}
+                    placeholder="Enter password"
+                    autoComplete="off"
+                    data-1p-ignore
+                    data-lpignore="true"
+                    aria-invalid={error || undefined}
+                    aria-describedby={error ? errorId : undefined}
+                    className={`h-12 w-full rounded-xl border bg-[var(--bg)] pl-10 pr-3.5 text-[15px] text-[var(--text)] outline-none transition-colors placeholder:text-[var(--text-faint)] focus:ring-2 ${
+                      error
+                        ? "border-[var(--destructive)] focus:border-[var(--destructive)] focus:ring-[color-mix(in_oklch,var(--destructive)_20%,transparent)]"
+                        : "border-[var(--border)] focus:border-[var(--accent)] focus:ring-[var(--accent-dim)]"
+                    }`}
+                  />
+                </div>
+                <button
+                  type="submit"
+                  className="h-12 shrink-0 cursor-pointer rounded-xl bg-[var(--accent)] px-6 text-[15px] font-semibold text-[var(--primary-foreground)] transition-colors hover:bg-[var(--accent-strong)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent)]"
+                >
+                  Unlock
+                </button>
+              </div>
+              {error && (
+                <p
+                  id={errorId}
+                  role="alert"
+                  className="mt-2.5 text-[13px] font-medium text-[var(--destructive)]"
+                >
+                  That password didn&apos;t work — double-check it and try
+                  again.
+                </p>
+              )}
+            </form>
+          </div>
+
+          {config.image && (
+            <div className="relative hidden overflow-hidden rounded-xl border border-[var(--border)] shadow-[var(--shadow-control)] @3xl:block @3xl:w-[300px] @3xl:shrink-0">
+              {/* Theme-paired variants, mirroring the docs' diagram
+                  pattern — the light image renders `dark:hidden`, the
+                  dark one `dark:block`. */}
+              {/* `object-contain` keeps the screenshot uncropped while
+                  the stretched container tracks the copy column's
+                  height; each img's background matches its variant's
+                  own canvas color so the letterboxed area blends in
+                  and the content keeps even padding on every side. */}
+              <Image
+                src={config.image.lightSrc}
+                alt={config.image.alt}
+                fill
+                sizes="300px"
+                className="bg-white object-contain dark:hidden"
+              />
+              <Image
+                src={config.image.darkSrc}
+                alt={config.image.alt}
+                fill
+                sizes="300px"
+                className="hidden bg-[#1c1f24] object-contain dark:block"
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/showcase/shell-docs/src/content/docs/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/slack.mdx
@@ -3,6 +3,7 @@ title: Slack
 description: Build an AI Slack bot with CopilotKit — createBot, the Slack adapter over Socket Mode, agent runs with thread.runAgent, and interactive JSX messages rendered as Block Kit.
 icon: "lucide/Slack"
 hideTOC: true
+earlyAccess: slack
 ---
 This guide takes you from zero to a Slack bot you can @-mention in a channel, then adds an interactive button card. You write handlers in TypeScript, the agent's replies stream into the thread, and rich messages are JSX that the adapter renders to Block Kit (Slack's message-UI format). No public URL needed.
 

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -1508,6 +1508,11 @@ export interface DocFrontmatter {
   defaultFramework?: string;
   defaultCell?: string;
   hideTOC?: boolean;
+  /**
+   * Early-access gate id (see `src/lib/early-access.ts`). When set,
+   * the page renders blurred behind the matching password gate.
+   */
+  earlyAccess?: string;
 }
 
 function slugSegments(slugPath: string): string[] | null {
@@ -1651,6 +1656,8 @@ export function loadDoc(
   const defaultCell =
     typeof data.snippet_cell === "string" ? data.snippet_cell : undefined;
   const hideTOC = data.hideTOC === true;
+  const earlyAccess =
+    typeof data.earlyAccess === "string" ? data.earlyAccess : undefined;
 
   return {
     source,
@@ -1661,6 +1668,7 @@ export function loadDoc(
       defaultFramework,
       defaultCell,
       hideTOC,
+      earlyAccess,
     },
   };
 }

--- a/showcase/shell-docs/src/lib/early-access.ts
+++ b/showcase/shell-docs/src/lib/early-access.ts
@@ -1,0 +1,63 @@
+// Early-access gate registry — shared between server routes (which
+// decide WHETHER a page is gated) and the client-side
+// `EarlyAccessGate` component (which renders the unlock UI).
+//
+// This is a soft gate: the password lives in the client bundle and the
+// gated content is still server-rendered behind the blur (and remains
+// reachable via the raw-MDX / llms.txt routes). It exists to keep
+// early-access docs out of casual view, not to be a security boundary.
+
+export interface EarlyAccessGateConfig {
+  /** localStorage key remembering that this gate was unlocked. */
+  storageKey: string;
+  /** Shared access password compared against the visitor's input. */
+  password: string;
+  /** Small uppercase label above the gate title. */
+  eyebrow: string;
+  /** Gate card heading. */
+  title: string;
+  /** Copy explaining the gate and what the gated feature is, one
+   *  string per paragraph. */
+  description: string[];
+  /** Lead-in before the request-access link, e.g. "Don't have the password?" */
+  requestPrompt: string;
+  /** Link text for the request-access CTA. */
+  requestLinkLabel: string;
+  /** Where the request-access CTA points (early-access form). */
+  requestUrl: string;
+  /** Optional product visual shown in the card body, per theme. The
+   *  card renders it with `fill`, so no intrinsic dimensions needed. */
+  image?: { alt: string; lightSrc: string; darkSrc: string };
+}
+
+export const EARLY_ACCESS_GATES = {
+  slack: {
+    storageKey: "shell-docs-early-access:slack",
+    password: "earlyaccess",
+    eyebrow: "Early access",
+    title: "Slack is in early access",
+    description: [
+      "The Slack docs are behind a password while Slack support is in early access.",
+      "CopilotKit for Slack turns your agent into a Slack bot: streaming replies in threads, calling tools, and rendering interactive messages.",
+    ],
+    requestPrompt: "Don't have the password?",
+    requestLinkLabel: "Reach out to request early access to Slack",
+    requestUrl: "https://go.copilotkit.ai/beyond-the-web-form",
+    image: {
+      alt: "A Slack thread where a user asks the Kite bot for a chart and the bot replies with an interactive generative UI chart.",
+      lightSrc: "/images/slack-bot-generative-ui-light.png",
+      darkSrc: "/images/slack-bot-generative-ui-dark.png",
+    },
+  },
+} as const satisfies Record<string, EarlyAccessGateConfig>;
+
+export type EarlyAccessGateId = keyof typeof EARLY_ACCESS_GATES;
+
+export function getEarlyAccessGate(
+  id: string | undefined,
+): EarlyAccessGateConfig | null {
+  if (!id) return null;
+  return id in EARLY_ACCESS_GATES
+    ? EARLY_ACCESS_GATES[id as EarlyAccessGateId]
+    : null;
+}


### PR DESCRIPTION
## What does this PR do?

Puts the Slack docs behind a shared early-access password. Gated pages render blurred and non-interactive with an unlock card floating above them:

- **`/slack`** — the Slack guide, plus every framework-scoped variant (`/<framework>/slack`), opted in via an `earlyAccess: slack` frontmatter flag
- **`/reference/bot/**`** — the entire bot reference section (`@copilotkit/bot*` packages, the Slack adapter), gated on `version === "bot"`

### The unlock card

- **"Slack is in early access"** headline, a short explanation of the gate and of what CopilotKit for Slack is, and a product screenshot (a Slack thread with a generative-UI bot reply — stored in **git LFS**, rendered via `next/image`).
- **"Don't have the password? Reach out to request early access to Slack"** linking to the [beyond-the-web early-access form](https://go.copilotkit.ai/beyond-the-web-form).
- Password input + Unlock for folks who already have it.

### How it works

- `early-access-gate.tsx` (client) blurs the page content (`inert`, unselectable, pointer-events off) and renders the unlock card in a **sticky scrollport-height frame**, so the card stays centered in view while the blurred page scrolls underneath — sidebar and top nav stay crisp and usable. On very short viewports the card caps its height and scrolls internally.
- `src/lib/early-access.ts` is the gate registry (password, copy, CTA, image, storage key) shared by server routes and the client component. Unlocking persists in `localStorage`, so one unlock covers the guide and all reference pages.
- Ungated pages never mount the client component (server-side conditional wrappers in `docs-page-view.tsx` and the reference route).
- Light/dark theme via existing tokens; responsive down to mobile (input row stacks to a full-width button).

### Reviewer notes

- This is a deliberate **soft gate** (early-access friction, not a security boundary): the password ships in the client bundle, and raw-MDX/`llms.txt`/search-index routes still expose the content.
- Verified in the running app: scroll-following card, wrong-password error state, unlock-in-place, cross-page persistence, mobile/tablet/desktop, dark mode.
- Tests: 6 new vitest cases (config integrity incl. form URL, SSR locked-state markup, unknown-id pass-through). Format/lint/typecheck/test/build all green locally.

## Related PRs and Issues

- Gates the docs introduced in #5368 (`docs(shell-docs): Slack platform quickstart + Bots API reference`)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)