### PR TITLE
fix(cf+dashboard): fleet claim-fairness, supplemental-merge freshness, dashboard drilldown D4 parity

### DIFF
--- a/showcase/harness/src/fleet/contracts.test.ts
+++ b/showcase/harness/src/fleet/contracts.test.ts
@@ -21,6 +21,7 @@ import type {
   ServiceJobResult,
   WorkerCapacity,
   FleetStatusRow,
+  FleetSurfaceState,
 } from "./contracts.js";
 
 /**
@@ -138,14 +139,67 @@ describe("fleetSurfaceState", () => {
     observedAt: "2026-06-04T00:00:00.000Z",
   };
 
+  const RECLAIM_COMM_ERROR: PoolCommError = {
+    kind: "worker-reclaimed-pending",
+    message: "lease expired; job re-queued to pending",
+    jobId: "j1",
+    observedAt: "2026-06-04T00:00:00.000Z",
+  };
+
   it("returns the probe colour when there is no comm error", () => {
     expect(fleetSurfaceState(row)).toBe("green");
   });
 
-  it("returns 'unreachable' when a comm error overlays the row", () => {
+  it("returns 'unreachable' when a crash-kind comm error overlays the row", () => {
     expect(fleetSurfaceState({ ...row, commError: SAMPLE_COMM_ERROR })).toBe(
       "unreachable",
     );
+  });
+
+  it("routes every non-reclaim comm-error kind to 'unreachable'", () => {
+    for (const kind of POOL_COMM_ERROR_KINDS) {
+      if (kind === "worker-reclaimed-pending") continue;
+      expect(
+        fleetSurfaceState({
+          ...row,
+          commError: { ...SAMPLE_COMM_ERROR, kind },
+        }),
+      ).toBe("unreachable");
+    }
+  });
+
+  it("routes worker-reclaimed-pending on a non-red row to the NEUTRAL 'pending' surface", () => {
+    // The sweep boundary cannot tell a real crash from a routine platform
+    // teardown — either way the job is re-queued (back in flight), so the
+    // surface is the neutral gray "pending", NEVER the red "unreachable"
+    // overlay (see POOL_COMM_ERROR_KINDS; mirrors the dashboard derivation).
+    expect(fleetSurfaceState({ ...row, commError: RECLAIM_COMM_ERROR })).toBe(
+      "pending",
+    );
+    expect(
+      fleetSurfaceState({
+        ...row,
+        state: "degraded",
+        commError: RECLAIM_COMM_ERROR,
+      }),
+    ).toBe("pending");
+  });
+
+  it("worker-reclaimed-pending must NOT mask a red probe result (red passes through)", () => {
+    // Mirrors the dashboard's cell-model derivation: a present red is a
+    // GENUINE failure the neutral pending overlay must not hide.
+    expect(
+      fleetSurfaceState({
+        ...row,
+        state: "red",
+        commError: RECLAIM_COMM_ERROR,
+      }),
+    ).toBe("red");
+  });
+
+  it("type-level: the union carries the 'pending' member alongside 'unreachable'", () => {
+    expectTypeOf<"pending">().toMatchTypeOf<FleetSurfaceState>();
+    expectTypeOf<"unreachable">().toMatchTypeOf<FleetSurfaceState>();
   });
 });
 

--- a/showcase/harness/src/fleet/contracts.test.ts
+++ b/showcase/harness/src/fleet/contracts.test.ts
@@ -113,6 +113,22 @@ describe("comm-error ↔ status-row signal round-trip", () => {
     expect(commErrorFromStatusSignal("nope")).toBeUndefined();
   });
 
+  it("rejects an ARRAY embedded under the signal key (arrays are typeof object)", () => {
+    // A plain array decodes to undefined already (no .kind property), but an
+    // array carrying comm-error fields as EXPANDO properties passes the bare
+    // `typeof raw === "object"` check and would decode as if it were a
+    // well-formed PoolCommError — an array is never a valid wire shape, so
+    // Array.isArray must reject it explicitly.
+    expect(
+      commErrorFromStatusSignal({ [FLEET_COMM_ERROR_SIGNAL_KEY]: [] }),
+    ).toBeUndefined();
+    expect(
+      commErrorFromStatusSignal({
+        [FLEET_COMM_ERROR_SIGNAL_KEY]: Object.assign([], SAMPLE_COMM_ERROR),
+      }),
+    ).toBeUndefined();
+  });
+
   it("rejects a malformed embedded comm error (bad kind / missing fields)", () => {
     expect(
       commErrorFromStatusSignal({

--- a/showcase/harness/src/fleet/contracts.test.ts
+++ b/showcase/harness/src/fleet/contracts.test.ts
@@ -129,6 +129,20 @@ describe("comm-error ↔ status-row signal round-trip", () => {
     ).toBeUndefined();
   });
 
+  it("rejects an ARRAY at the TOP LEVEL (the signal blob itself an array)", () => {
+    // Same rationale one level up: a top-level array is typeof "object" and
+    // non-null, so it passes the bare first guard — and an array carrying the
+    // signal key as an EXPANDO property would then decode a comm error out of
+    // a blob that is never a valid wire shape. Array.isArray must reject the
+    // signal blob itself, not only the nested value.
+    expect(commErrorFromStatusSignal([])).toBeUndefined();
+    expect(
+      commErrorFromStatusSignal(
+        Object.assign([], { [FLEET_COMM_ERROR_SIGNAL_KEY]: SAMPLE_COMM_ERROR }),
+      ),
+    ).toBeUndefined();
+  });
+
   it("rejects a malformed embedded comm error (bad kind / missing fields)", () => {
     expect(
       commErrorFromStatusSignal({

--- a/showcase/harness/src/fleet/contracts.test.ts
+++ b/showcase/harness/src/fleet/contracts.test.ts
@@ -273,6 +273,21 @@ describe("worker capacity + staleness", () => {
     expect(workerCapacityFromBudget(budget)).toEqual(budget);
   });
 
+  it("clamps a negative budget.available to 0 (WorkerCapacity.available is documented never-negative)", () => {
+    // A pool budget computed mid-teardown (or from a racy snapshot) can
+    // transiently report available < 0; the capacity CONTRACT documents
+    // `available` as "never negative", so the mapper must enforce it rather
+    // than leak the racy value to the registry/heartbeat consumers.
+    const budget: BrowserPoolBudget = {
+      inUse: 9,
+      available: -1,
+      max: 8,
+      pidsCurrent: 120,
+      pidsMax: 1000,
+    };
+    expect(workerCapacityFromBudget(budget).available).toBe(0);
+  });
+
   it("isWorkerStale flags a heartbeat older than the window", () => {
     const now = Date.parse("2026-06-04T00:01:00.000Z");
     expect(isWorkerStale("2026-06-04T00:00:00.000Z", now, 30_000)).toBe(true);

--- a/showcase/harness/src/fleet/contracts.test.ts
+++ b/showcase/harness/src/fleet/contracts.test.ts
@@ -13,6 +13,7 @@ import {
   isWorkerStale,
   workerCapacityFromBudget,
   terminalJobStatus,
+  probeKeyFamily,
   FLEET_COMM_ERROR_SIGNAL_KEY,
   WORKERS_COLLECTION,
 } from "./contracts.js";
@@ -270,6 +271,26 @@ describe("terminalJobStatus", () => {
     expect(
       terminalJobStatus(makeResult({ commError: SAMPLE_COMM_ERROR })),
     ).toBe("failed");
+  });
+});
+
+describe("probeKeyFamily", () => {
+  it("extracts the prefix before the first ':'", () => {
+    expect(probeKeyFamily("d6:langgraph-python")).toBe("d6");
+    expect(probeKeyFamily("e2e-demos:agno")).toBe("e2e-demos");
+    expect(probeKeyFamily("d6:agno:extra")).toBe("d6");
+  });
+
+  it("returns the whole key when no ':' is present", () => {
+    expect(probeKeyFamily("standalone")).toBe("standalone");
+  });
+
+  it("treats a leading-colon key as having NO family prefix (whole key, never '')", () => {
+    // A key beginning with ':' would otherwise yield the EMPTY-STRING family,
+    // which flows into countPendingForFamily and the claimNext fairness
+    // partition as a phantom real bucket.
+    expect(probeKeyFamily(":weird")).toBe(":weird");
+    expect(probeKeyFamily(":")).toBe(":");
   });
 });
 

--- a/showcase/harness/src/fleet/contracts.test.ts
+++ b/showcase/harness/src/fleet/contracts.test.ts
@@ -11,6 +11,7 @@ import {
   probeResultsForServiceJobResult,
   runSummaryForServiceJobResult,
   isWorkerStale,
+  heartbeatParseable,
   workerCapacityFromBudget,
   terminalJobStatus,
   probeKeyFamily,
@@ -310,6 +311,36 @@ describe("worker capacity + staleness", () => {
 
   it("isWorkerStale treats an unparseable timestamp as not-yet-stale", () => {
     expect(isWorkerStale("not-a-date", Date.now(), 1_000)).toBe(false);
+  });
+
+  it("isWorkerStale parses the PB space-separated date form (normalized to ISO 'T')", () => {
+    // PB stores datetimes as `YYYY-MM-DD HH:MM:SS.sssZ` (space separator). A
+    // heartbeat read back in that form must be parsed via the SAME anchored
+    // space→'T' normalization the queue-client applies to lease timestamps —
+    // not left to engine-specific Date.parse leniency.
+    const now = Date.parse("2026-06-04T00:01:00.000Z");
+    expect(isWorkerStale("2026-06-04 00:00:00.000Z", now, 30_000)).toBe(true);
+    expect(isWorkerStale("2026-06-04 00:00:45.000Z", now, 30_000)).toBe(false);
+  });
+
+  it("isWorkerStale ISO boundaries: exactly-at-window is NOT stale, one ms past is", () => {
+    const now = Date.parse("2026-06-04T00:01:00.000Z");
+    // age === staleAfterMs → not stale (strict >)
+    expect(isWorkerStale("2026-06-04T00:00:30.000Z", now, 30_000)).toBe(false);
+    // age === staleAfterMs + 1 → stale
+    expect(isWorkerStale("2026-06-04T00:00:29.999Z", now, 30_000)).toBe(true);
+  });
+
+  it("heartbeatParseable distinguishes a corrupt heartbeat from a fresh one (fleet-health observability)", () => {
+    // `isWorkerStale` deliberately returns false for an unparseable timestamp
+    // (never flap the fleet offline on one bad row) — but that makes a corrupt
+    // heartbeat INDISTINGUISHABLE from a fresh one ("never stale forever").
+    // The companion lets fleet-health (S10) count/warn on unparseable rows.
+    expect(heartbeatParseable("not-a-date")).toBe(false);
+    expect(heartbeatParseable("")).toBe(false);
+    expect(heartbeatParseable("2026-06-04T00:00:00.000Z")).toBe(true);
+    // The PB space form is parseable AFTER the anchored normalization.
+    expect(heartbeatParseable("2026-06-04 00:00:00.000Z")).toBe(true);
   });
 });
 

--- a/showcase/harness/src/fleet/contracts.test.ts
+++ b/showcase/harness/src/fleet/contracts.test.ts
@@ -169,33 +169,45 @@ describe("fleetSurfaceState", () => {
     }
   });
 
-  it("routes worker-reclaimed-pending on a non-red row to the NEUTRAL 'pending' surface", () => {
+  it("routes worker-reclaimed-pending on a GREEN row to the NEUTRAL 'pending' surface", () => {
     // The sweep boundary cannot tell a real crash from a routine platform
-    // teardown — either way the job is re-queued (back in flight), so the
-    // surface is the neutral gray "pending", NEVER the red "unreachable"
-    // overlay (see POOL_COMM_ERROR_KINDS; mirrors the dashboard derivation).
+    // teardown — either way the job is re-queued (back in flight), so on a
+    // healthy (green) row the surface is the neutral gray "pending", NEVER
+    // the red "unreachable" overlay (see POOL_COMM_ERROR_KINDS; mirrors the
+    // dashboard derivation).
     expect(fleetSurfaceState({ ...row, commError: RECLAIM_COMM_ERROR })).toBe(
       "pending",
     );
-    expect(
-      fleetSurfaceState({
-        ...row,
-        state: "degraded",
-        commError: RECLAIM_COMM_ERROR,
-      }),
-    ).toBe("pending");
   });
 
-  it("worker-reclaimed-pending must NOT mask a red probe result (red passes through)", () => {
-    // Mirrors the dashboard's cell-model derivation: a present red is a
-    // GENUINE failure the neutral pending overlay must not hide.
+  it("worker-reclaimed-pending must NOT mask ANY non-green failure state (red/degraded/error pass through)", () => {
+    // Mirrors the dashboard's cell-model derivation and the A2 rank
+    // principle (an unrecognized/error state ranks ABOVE red): every
+    // non-green last-known state is a GENUINE failure the neutral pending
+    // overlay must not hide — only green becomes "pending".
+    for (const state of ["red", "degraded", "error"] as const) {
+      expect(
+        fleetSurfaceState({
+          ...row,
+          state,
+          commError: RECLAIM_COMM_ERROR,
+        }),
+      ).toBe(state);
+    }
+  });
+
+  it("worker-reclaimed-pending passes an OUT-OF-VOCABULARY runtime state through (never masks)", () => {
+    // `FleetStatusRow.state` is typed ProbeState, but a runtime row can carry
+    // an out-of-vocabulary value; the A2 never-swallow rule ranks it above
+    // red, so the neutral overlay must pass it through, not mask it.
+    const outOfVocab = "flapping" as unknown as FleetStatusRow["state"];
     expect(
       fleetSurfaceState({
         ...row,
-        state: "red",
+        state: outOfVocab,
         commError: RECLAIM_COMM_ERROR,
       }),
-    ).toBe("red");
+    ).toBe(outOfVocab);
   });
 
   it("type-level: the union carries the 'pending' member alongside 'unreachable'", () => {

--- a/showcase/harness/src/fleet/contracts.test.ts
+++ b/showcase/harness/src/fleet/contracts.test.ts
@@ -7,6 +7,7 @@ import {
   isPoolCommErrorKind,
   commErrorToStatusSignal,
   commErrorFromStatusSignal,
+  statusSignalHasCommErrorKey,
   fleetSurfaceState,
   probeResultsForServiceJobResult,
   runSummaryForServiceJobResult,
@@ -159,6 +160,56 @@ describe("comm-error ↔ status-row signal round-trip", () => {
         [FLEET_COMM_ERROR_SIGNAL_KEY]: { kind: "worker-unreachable" },
       }),
     ).toBeUndefined();
+  });
+
+  it("statusSignalHasCommErrorKey distinguishes 'key present but undecodable' from 'absent' (version-skew hazard)", () => {
+    // The decode returns undefined for BOTH a signal that carries no comm
+    // error AND one whose embedded value is malformed/unknown — so a REQ-B
+    // overlay written by a NEWER producer (e.g. a new kind rolled out
+    // write-side first) silently drops on an older reader. The companion lets
+    // consumers count/log those drops without changing the decode contract.
+    //
+    // Key present, kind unknown to this reader (the version-skew case):
+    const unknownKind = {
+      [FLEET_COMM_ERROR_SIGNAL_KEY]: {
+        kind: "some-future-kind",
+        message: "x",
+        observedAt: "2026-06-04T00:00:00.000Z",
+      },
+    };
+    expect(commErrorFromStatusSignal(unknownKind)).toBeUndefined();
+    expect(statusSignalHasCommErrorKey(unknownKind)).toBe(true);
+    //
+    // Key present, required field RENAMED (message -> msg):
+    const renamedField = {
+      [FLEET_COMM_ERROR_SIGNAL_KEY]: {
+        kind: "worker-unreachable",
+        msg: "connect ECONNREFUSED",
+        observedAt: "2026-06-04T00:00:00.000Z",
+      },
+    };
+    expect(commErrorFromStatusSignal(renamedField)).toBeUndefined();
+    expect(statusSignalHasCommErrorKey(renamedField)).toBe(true);
+    //
+    // Key present and well-formed: both sides agree.
+    const wellFormed = commErrorToStatusSignal(SAMPLE_COMM_ERROR);
+    expect(commErrorFromStatusSignal(wellFormed)).toEqual(SAMPLE_COMM_ERROR);
+    expect(statusSignalHasCommErrorKey(wellFormed)).toBe(true);
+  });
+
+  it("statusSignalHasCommErrorKey is false when the key is genuinely absent (or the blob is no wire shape)", () => {
+    expect(statusSignalHasCommErrorKey({ failedCount: 0 })).toBe(false);
+    expect(statusSignalHasCommErrorKey(null)).toBe(false);
+    expect(statusSignalHasCommErrorKey(undefined)).toBe(false);
+    expect(statusSignalHasCommErrorKey("nope")).toBe(false);
+    // Arrays are never a valid wire shape — even with the key as an expando
+    // property (mirrors the decoder's top-level Array.isArray rejection).
+    expect(statusSignalHasCommErrorKey([])).toBe(false);
+    expect(
+      statusSignalHasCommErrorKey(
+        Object.assign([], { [FLEET_COMM_ERROR_SIGNAL_KEY]: SAMPLE_COMM_ERROR }),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/showcase/harness/src/fleet/contracts.test.ts
+++ b/showcase/harness/src/fleet/contracts.test.ts
@@ -320,6 +320,17 @@ describe("probeKeyFamily", () => {
     expect(probeKeyFamily(":weird")).toBe(":weird");
     expect(probeKeyFamily(":")).toBe(":");
   });
+
+  it("a leading-colon key with FURTHER colons is still its own whole-key family", () => {
+    // Pins the equality-only invariant documented on probeKeyFamily: the
+    // family of ':foo:bar' is the whole ':foo:bar', NOT ':foo' — so a
+    // consumer expanding family ':foo' with a prefix-LIKE '<family>:%'
+    // pattern (queue-client familyInclusionClause/familyExclusionClause)
+    // would wrongly fold ':foo:bar' under ':foo'. Whole-key (colon-bearing)
+    // families must be matched by equality only.
+    expect(probeKeyFamily(":foo:bar")).toBe(":foo:bar");
+    expect(probeKeyFamily(probeKeyFamily(":foo:bar"))).toBe(":foo:bar");
+  });
 });
 
 describe("type-level: contract assignability", () => {

--- a/showcase/harness/src/fleet/contracts.test.ts
+++ b/showcase/harness/src/fleet/contracts.test.ts
@@ -39,12 +39,12 @@ function makeResult(
 ): ServiceJobResult {
   return {
     jobId: "j1",
-    probeKey: "e2e_d6:langgraph-python",
+    probeKey: "d6:langgraph-python",
     serviceSlug: "langgraph-python",
     runId: "run-1",
     workerId: "worker-7",
     aggregateState: "green",
-    aggregateKey: "e2e_d6:langgraph-python",
+    aggregateKey: "d6:langgraph-python",
     aggregateSignal: { failedCount: 0 },
     cells: [
       {
@@ -215,8 +215,8 @@ describe("comm-error ↔ status-row signal round-trip", () => {
 
 describe("fleetSurfaceState", () => {
   const row: FleetStatusRow = {
-    key: "e2e_d6:langgraph-python",
-    dimension: "e2e_d6",
+    key: "d6:langgraph-python",
+    dimension: "d6",
     state: "green",
     signal: {},
     observedAt: "2026-06-04T00:00:00.000Z",
@@ -303,7 +303,7 @@ describe("result ↔ storage mappers (preserve dashboard row shape)", () => {
     const results = probeResultsForServiceJobResult(makeResult());
     expect(results).toHaveLength(2);
     expect(results[0]).toEqual({
-      key: "e2e_d6:langgraph-python",
+      key: "d6:langgraph-python",
       state: "green",
       signal: { failedCount: 0 },
       observedAt: "2026-06-04T00:00:02.000Z",

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -659,3 +659,19 @@ export function terminalJobStatus(
   if (result.commError) return "failed";
   return result.aggregateState === "green" ? "done" : "failed";
 }
+
+/**
+ * Extract a probe_key's FAMILY — the prefix before the first ":" (the whole
+ * key when no ":" is present). The family is the probe-family partition the
+ * producers enqueue per schedule (`d6:<slug>` → `d6`, `d4:<slug>` → `d4`,
+ * `e2e-demos:<slug>` → `e2e-demos`, ...). It is the FAIRNESS unit of the
+ * queue: `claimNext` round-robins claims across the distinct families present
+ * in pending so a high-frequency family's backlog can never starve a
+ * low-frequency family's jobs out of the candidate page, and the producer's
+ * backlog dedupe gates each tick on its own family's pending count. Pure;
+ * unit-tested via the queue-client + producer suites.
+ */
+export function probeKeyFamily(probeKey: string): string {
+  const idx = probeKey.indexOf(":");
+  return idx === -1 ? probeKey : probeKey.slice(0, idx);
+}

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -429,6 +429,22 @@ export function commErrorToStatusSignal(
  * status-row signal blob, or `undefined` when none is present / the embedded
  * value is malformed. Pure; unit-tested. The dashboard slot (REQ-B) uses this
  * to decide whether to render the "unreachable" overlay.
+ *
+ * VERSION-SKEW HAZARD: `undefined` conflates "no comm error was written" with
+ * "the key IS present but the embedded value did not decode" — e.g. a NEW
+ * `PoolCommErrorKind` rolled out write-side first, or a renamed required
+ * field. A reader on the older vocabulary silently DROPS that REQ-B overlay
+ * and renders the row's last-known probe colour as if the fleet were healthy.
+ * The decode return type deliberately stays `PoolCommError | undefined`
+ * (every render path branches on presence); consumers that need to SEE the
+ * drop pair this with the `statusSignalHasCommErrorKey` companion below and
+ * count/log when the key is present but the decode returned `undefined`.
+ *
+ * NOTE: the function source below is pinned BYTE-IDENTICAL against the
+ * dashboard's structural copy (`shell-dashboard`'s `live-status.ts`) by
+ * `commError-contract-drift.test.ts` — any edit to the function body must
+ * land on both sides; this doc comment and the companion live OUTSIDE the
+ * mirrored region.
  */
 export function commErrorFromStatusSignal(
   signal: unknown,
@@ -460,6 +476,23 @@ export function commErrorFromStatusSignal(
   if (typeof candidate.workerId === "string") out.workerId = candidate.workerId;
   if (typeof candidate.jobId === "string") out.jobId = candidate.jobId;
   return out;
+}
+
+/**
+ * Companion to `commErrorFromStatusSignal`: does the signal blob CARRY the
+ * well-known comm-error key at all, regardless of whether the embedded value
+ * decodes? Lets consumers distinguish "key present but undecodable" (the
+ * version-skew drop documented on the decode above — count/log it) from
+ * "genuinely absent" (nothing to report) without changing the decode's return
+ * contract. Mirrors the decoder's wire-shape guards: a null / non-object /
+ * array blob is never a valid signal, so the key cannot be "present" on one.
+ * Pure; unit-tested.
+ */
+export function statusSignalHasCommErrorKey(signal: unknown): boolean {
+  if (signal === null || typeof signal !== "object" || Array.isArray(signal)) {
+    return false;
+  }
+  return FLEET_COMM_ERROR_SIGNAL_KEY in signal;
 }
 
 // ───────────────────────────────────────────────────────────────────────

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -240,7 +240,12 @@ export const POOL_COMM_ERROR_KINDS = [
   "claim-comm-failure",
   /** The worker exceeded the protocol response deadline (hung, no crash). */
   "worker-protocol-timeout",
-  /** The worker died mid-job: lease expired with no terminal report. */
+  /**
+   * The worker's OWN self-monitor observed an in-driver pool-infra crash
+   * mid-job and reported it directly (a known crash — stays red). A lease
+   * that merely expired with no terminal report is NOT this kind; the sweep
+   * emits `worker-reclaimed-pending` for that.
+   */
   "worker-crashed-mid-job",
   /** A report arrived but failed schema/shape validation (protocol mismatch). */
   "worker-protocol-violation",
@@ -491,8 +496,9 @@ export interface WorkerRegistration {
 /**
  * The periodic heartbeat a worker writes to refresh its liveness + capacity.
  * fleet-health (S10) reads `lastHeartbeatAt` against a staleness window to
- * derive `WorkerHealthState`; a worker whose heartbeat lapses is what the
- * control-plane treats as `worker-crashed-mid-job` (see PoolCommErrorKind).
+ * derive `WorkerHealthState`; a worker whose heartbeat lapses leaves its
+ * leases to expire, which the sweep reclaims and surfaces as the neutral
+ * `worker-reclaimed-pending` kind (see PoolCommErrorKind).
  */
 export interface WorkerHeartbeat {
   workerId: string;
@@ -601,7 +607,7 @@ export interface ReportJobInput {
 export interface SweepResult {
   /** Number of expired leases reclaimed (jobs re-queued to pending). */
   reclaimed: number;
-  /** The comm errors synthesized for each reclaimed (crashed) worker job. */
+  /** The `worker-reclaimed-pending` comm errors synthesized per reclaimed job. */
   commErrors: PoolCommError[];
   /**
    * Number of STALE PENDING jobs expired (claimed-then-deleted) because they
@@ -622,8 +628,9 @@ export interface SweepResult {
  *     a `JobLease` to the worker on a win (the exactly-one-winner guarantee
  *     comes from S0).
  *   - `renewLease` / `report` delegate to S0's `renewLease` / `releaseJob`.
- *   - `sweepExpired` reclaims leases from crashed workers and emits the
- *     `worker-crashed-mid-job` comm errors (REQ-B) the dashboard renders.
+ *   - `sweepExpired` reclaims expired leases (re-queues the jobs to pending)
+ *     and emits the neutral `worker-reclaimed-pending` comm errors (REQ-B)
+ *     the dashboard renders as a gray "re-queued" surface.
  *
  * Producers (control-plane S4) use `enqueue` + `sweepExpired`; consumers
  * (worker loop S7) use `claimNext` + `renewLease` + `report`.

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -117,7 +117,7 @@ export interface ServiceJobMeta {
   triggered: boolean;
   /** ISO timestamp the control-plane enqueued the job. */
   enqueuedAt: string;
-  /** Optional priority hint; higher pulls first when a worker has a choice. */
+  /** Optional priority hint. Reserved; not currently consulted by claimNext. */
   priority?: number;
 }
 

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -601,18 +601,53 @@ export interface WorkerDescriptor {
 }
 
 /**
- * Pure staleness check used by fleet-health (S10): a worker is stale when its
- * last heartbeat is older than `staleAfterMs`. Returns false when the
- * timestamp is unparseable (treat unknown as not-yet-stale; the next heartbeat
- * resolves it) so a malformed row can't flap the whole fleet to offline. Pure;
+ * Anchor the PB space→"T" date-separator rewrite to the canonical PB shape
+ * (`YYYY-MM-DD ` then time) so we ONLY convert the date/time boundary, never
+ * an arbitrary first space. LOCAL REPLICA of the queue-client's exported
+ * `PB_DATE_SEP_RE` (queue-client.ts) — replicated rather than imported because
+ * the dependency points the other way (queue-client imports contracts), and
+ * the anchoring contract is the same one the JSVM hook pins: a bare
+ * `String.replace(" ", "T")` would coerce a malformed value into something
+ * that parses instead of letting it fall through to NaN.
+ */
+const PB_DATE_SEP_RE = /^(\d{4}-\d{2}-\d{2}) /;
+
+/** Parse a heartbeat timestamp, normalizing the PB space-separated date form. */
+function parseHeartbeatMs(lastHeartbeatAt: string): number {
+  return Date.parse(String(lastHeartbeatAt).replace(PB_DATE_SEP_RE, "$1T"));
+}
+
+/**
+ * Companion to `isWorkerStale`: is `lastHeartbeatAt` a parseable timestamp
+ * (after the PB space→"T" normalization)? `isWorkerStale` deliberately maps an
+ * unparseable heartbeat to `false` (never flap the fleet offline on one
+ * malformed row), but that alone makes a CORRUPT heartbeat indistinguishable
+ * from a FRESH one — "never stale forever" is silent fleet-health blindness.
+ * fleet-health (S10) uses this to count/warn on unparseable heartbeat rows
+ * while keeping the conservative not-yet-stale staleness answer. Pure;
  * unit-tested.
+ */
+export function heartbeatParseable(lastHeartbeatAt: string): boolean {
+  return !Number.isNaN(parseHeartbeatMs(lastHeartbeatAt));
+}
+
+/**
+ * Pure staleness check used by fleet-health (S10): a worker is stale when its
+ * last heartbeat is older than `staleAfterMs`. The PB date form uses a space
+ * separator; normalize ONLY the canonical date/time boundary to ISO "T"
+ * before parsing (anchored exactly as the queue-client's lease parse) so the
+ * answer doesn't ride on engine-specific `Date.parse` leniency. Returns false
+ * when the timestamp is unparseable (treat unknown as not-yet-stale; the next
+ * heartbeat resolves it) so a malformed row can't flap the whole fleet to
+ * offline — callers that need to SEE the corruption use the
+ * `heartbeatParseable` companion. Pure; unit-tested.
  */
 export function isWorkerStale(
   lastHeartbeatAt: string,
   nowMs: number,
   staleAfterMs: number,
 ): boolean {
-  const beatMs = Date.parse(lastHeartbeatAt);
+  const beatMs = parseHeartbeatMs(lastHeartbeatAt);
   if (Number.isNaN(beatMs)) return false;
   return nowMs - beatMs > staleAfterMs;
 }

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -571,8 +571,6 @@ export function workerCapacityFromBudget(
 export interface EnqueueJobInput {
   /** The per-service payload to run. */
   payload: ServiceJobPayload;
-  /** Optional explicit lease seconds for the eventual claim; default per impl. */
-  leaseSeconds?: number;
 }
 
 /** A lease handle a worker holds while running a claimed job. */

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -696,12 +696,14 @@ export interface FleetQueueClient {
   /** Producer: reclaim expired leases from crashed/unreachable workers. */
   sweepExpired(nowMs: number): Promise<SweepResult>;
   /**
-   * Producer: how many of `family`'s jobs are pending (unclaimed). The
-   * producer's per-tick backlog gate: a scheduled tick must NOT enqueue a
-   * fresh batch for a family whose previous batch is still sitting unclaimed
-   * (the compounding-backlog half of the e2e-demos starvation — see
-   * `probeKeyFamily`). Claimed/running/terminal rows do NOT count: a batch
-   * being actively worked is not a backlog.
+   * Producer: how many of `family`'s jobs are NON-TERMINAL (pending, claimed,
+   * or running). The producer's per-tick backlog gate: a scheduled tick must
+   * NOT enqueue a fresh batch for a family whose previous batch is still in
+   * flight — either sitting unclaimed (the compounding-backlog half of the
+   * e2e-demos starvation — see `probeKeyFamily`) or claimed/running (where a
+   * fresh batch would double the family's concurrent runs). Only terminal
+   * rows (done/failed) stop gating. (Name kept for history: "pending" here
+   * means "not yet finished", not the `pending` status.)
    */
   countPendingForFamily(family: string): Promise<number>;
 }

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -766,9 +766,13 @@ export interface SweepResult {
   reclaimed: number;
   /**
    * The `worker-reclaimed-pending` comm errors synthesized by the sweep —
-   * one per reclaimed job AND one per thrown-release indeterminate row
-   * (`commErrors.length === reclaimed + reclaimedIndeterminate`; the
-   * queue-client pairs them 1:1 with the rows those counters document).
+   * one per reclaimed job AND one per thrown-release indeterminate row.
+   * FOR IMPLEMENTATIONS THAT REPORT THE SPLIT (the real queue-client always
+   * does), `commErrors.length === reclaimed + reclaimedIndeterminate` and
+   * the queue-client pairs them 1:1 with the rows those counters document.
+   * A fake that synthesizes comm errors without reporting
+   * `reclaimedIndeterminate` (the field is optional below) is not bound by
+   * the pairing — assert it against the concrete client, not the shared type.
    */
   commErrors: PoolCommError[];
   /**

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -697,6 +697,15 @@ export interface SweepResult {
   /** The `worker-reclaimed-pending` comm errors synthesized per reclaimed job. */
   commErrors: PoolCommError[];
   /**
+   * Of the sweep's reclaim attempts, the thrown-release conservative maybes
+   * (release transport failed AFTER the CAS may have committed — the
+   * at-least-once over-report slice; see queue-client
+   * `SweepResultWithIndeterminate`). Optional so sweep fakes keyed on the
+   * reclamation contract stay valid; the real queue-client always reports it
+   * (required there).
+   */
+  reclaimedIndeterminate?: number;
+  /**
    * Number of STALE PENDING jobs expired (claimed-then-deleted) because they
    * sat unclaimed longer than their family's expiry window — the structural
    * backlog drain (see queue-client `stalePending`). Optional so the many

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -731,6 +731,19 @@ export function terminalJobStatus(
  * low-frequency family's jobs out of the candidate page, and the producer's
  * backlog dedupe gates each tick on its own family's pending count. Pure;
  * unit-tested via the queue-client + producer suites.
+ *
+ * INVARIANT — WHOLE-KEY FAMILIES MATCH BY EQUALITY ONLY. A leading-colon key
+ * (`":foo:bar"`, the `idx <= 0` branch below) is its OWN family: the WHOLE
+ * key. Such a family value itself contains colons, so expanding it with a
+ * prefix-LIKE pattern of the shape `<family>:%` is WRONG: family `":foo"`
+ * (from key `":foo"`) would prefix-match the unrelated key `":foo:bar"`,
+ * whose own family is the whole `":foo:bar"` — the inclusion/exclusion and
+ * pending-count legs would then disagree with this function's partition.
+ * Consumers that build key-matching filters from a family (the queue-client's
+ * `familyInclusionClause` / `familyExclusionClause`) MUST special-case any
+ * family containing a colon (equivalently: starting with `:`) to the equality
+ * leg only — never the `<family>:%` LIKE leg, which is reserved for normal
+ * prefix families that cannot contain a colon by construction.
  */
 export function probeKeyFamily(probeKey: string): string {
   const idx = probeKey.indexOf(":");

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -433,11 +433,14 @@ export function commErrorToStatusSignal(
 export function commErrorFromStatusSignal(
   signal: unknown,
 ): PoolCommError | undefined {
-  if (signal === null || typeof signal !== "object") return undefined;
+  // Array.isArray (BOTH levels): arrays are typeof "object", and an array
+  // carrying the signal key (here) or comm-error fields (below) as expando
+  // properties would otherwise decode as a well-formed PoolCommError — an
+  // array is never a valid wire shape at either level.
+  if (signal === null || typeof signal !== "object" || Array.isArray(signal)) {
+    return undefined;
+  }
   const raw = (signal as Record<string, unknown>)[FLEET_COMM_ERROR_SIGNAL_KEY];
-  // Array.isArray: arrays are typeof "object", and an array carrying
-  // comm-error fields as expando properties would otherwise decode as a
-  // well-formed PoolCommError — never a valid wire shape.
   if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
     return undefined;
   }

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -241,10 +241,17 @@ export const POOL_COMM_ERROR_KINDS = [
   /** The worker exceeded the protocol response deadline (hung, no crash). */
   "worker-protocol-timeout",
   /**
-   * The worker's OWN self-monitor observed an in-driver pool-infra crash
-   * mid-job and reported it directly (a known crash — stays red). A lease
-   * that merely expired with no terminal report is NOT this kind; the sweep
-   * emits `worker-reclaimed-pending` for that.
+   * A known crash/loss on a specific job (stays red), reported by either of
+   * two sources:
+   *   1. the worker's OWN self-monitor observed an in-driver pool-infra
+   *      crash mid-job and reported it directly, or
+   *   2. the control-plane RESULT CONSUMER synthesized it for a row that
+   *      went terminal but whose SEPARATE result write never landed
+   *      (terminal-but-resultless past the consumer's grace window — the
+   *      queue-client's bounded result-write retry was exhausted, so the
+   *      result is lost; see queue-client `RESULT_WRITE_MAX_ATTEMPTS`).
+   * A lease that merely expired with no terminal report is NEITHER source;
+   * the sweep emits `worker-reclaimed-pending` for that.
    */
   "worker-crashed-mid-job",
   /** A report arrived but failed schema/shape validation (protocol mismatch). */

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -398,7 +398,12 @@ export function commErrorFromStatusSignal(
 ): PoolCommError | undefined {
   if (signal === null || typeof signal !== "object") return undefined;
   const raw = (signal as Record<string, unknown>)[FLEET_COMM_ERROR_SIGNAL_KEY];
-  if (raw === null || typeof raw !== "object") return undefined;
+  // Array.isArray: arrays are typeof "object", and an array carrying
+  // comm-error fields as expando properties would otherwise decode as a
+  // well-formed PoolCommError — never a valid wire shape.
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return undefined;
+  }
   const candidate = raw as Partial<PoolCommError>;
   if (
     !isPoolCommErrorKind(candidate.kind) ||

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -603,6 +603,14 @@ export interface SweepResult {
   reclaimed: number;
   /** The comm errors synthesized for each reclaimed (crashed) worker job. */
   commErrors: PoolCommError[];
+  /**
+   * Number of STALE PENDING jobs expired (claimed-then-deleted) because they
+   * sat unclaimed longer than their family's expiry window — the structural
+   * backlog drain (see queue-client `stalePending`). Optional so the many
+   * sweep fakes keyed on the reclamation contract stay valid; the real
+   * queue-client always reports it.
+   */
+  expiredPending?: number;
 }
 
 /**

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -643,6 +643,15 @@ export interface FleetQueueClient {
   report(input: ReportJobInput): Promise<void>;
   /** Producer: reclaim expired leases from crashed/unreachable workers. */
   sweepExpired(nowMs: number): Promise<SweepResult>;
+  /**
+   * Producer: how many of `family`'s jobs are pending (unclaimed). The
+   * producer's per-tick backlog gate: a scheduled tick must NOT enqueue a
+   * fresh batch for a family whose previous batch is still sitting unclaimed
+   * (the compounding-backlog half of the e2e-demos starvation — see
+   * `probeKeyFamily`). Claimed/running/terminal rows do NOT count: a batch
+   * being actively worked is not a backlog.
+   */
+  countPendingForFamily(family: string): Promise<number>;
 }
 
 /**

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -718,5 +718,8 @@ export function terminalJobStatus(
  */
 export function probeKeyFamily(probeKey: string): string {
   const idx = probeKey.indexOf(":");
-  return idx === -1 ? probeKey : probeKey.slice(0, idx);
+  // idx <= 0: a leading-colon key has NO family prefix — treat the whole key
+  // as its own family rather than letting the empty string flow into
+  // countPendingForFamily / the fairness partition as a phantom bucket.
+  return idx <= 0 ? probeKey : probeKey.slice(0, idx);
 }

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -697,7 +697,12 @@ export interface ReportJobInput {
 export interface SweepResult {
   /** Number of expired leases reclaimed (jobs re-queued to pending). */
   reclaimed: number;
-  /** The `worker-reclaimed-pending` comm errors synthesized per reclaimed job. */
+  /**
+   * The `worker-reclaimed-pending` comm errors synthesized by the sweep —
+   * one per reclaimed job AND one per thrown-release indeterminate row
+   * (`commErrors.length === reclaimed + reclaimedIndeterminate`; the
+   * queue-client pairs them 1:1 with the rows those counters document).
+   */
   commErrors: PoolCommError[];
   /**
    * Of the sweep's reclaim attempts, the thrown-release conservative maybes

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -677,12 +677,11 @@ export interface ClaimedJob {
  * duplication is deliberate (release and aggregation read different halves
  * of this input) but the values MUST be equal.
  *
- * INTEGRATOR NOTE: the queue-client's `report()` does NOT currently validate
- * this equality — it releases on the top-level `jobId`/`workerId` and
- * persists `result` verbatim, so a mismatched caller would release one row
- * while filing the result under another job's/worker's ids. Callers are the
- * enforcement point today; a queue-client-side validation would belong in
- * `report()` (sibling-owned file — not changed here).
+ * INTEGRATOR NOTE: the queue-client's `report()` ENFORCES this equality — it
+ * rejects (throws) on a mismatched input before touching the queue, so a
+ * mismatched caller can no longer release one row while filing the result
+ * under another job's/worker's ids. Callers should still construct the input
+ * correctly, but the queue-client is the enforcement point.
  */
 export interface ReportJobInput {
   /** The claim row id being terminated (S0 `JobView.id`). Must equal `result.jobId`. */

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -334,6 +334,16 @@ export interface PoolCommError {
  *     red, degraded, error, or an out-of-vocabulary runtime state — passes
  *     through — the neutral overlay must never mask a genuine failure.
  *   - otherwise the row's last-known probe colour (`state`).
+ *
+ * DELIBERATE ASYMMETRY in the pending gate: this HARNESS derivation is
+ * green-ONLY because `ProbeState` has no no-data colour to route. The
+ * dashboard's derivation runs over its `ChipColor` vocabulary, whose `gray`
+ * is a dashboard-only no-data colour this side cannot represent — there, a
+ * reclaim on a green OR gray (non-regressed) cell becomes `"pending"`. The
+ * shared invariant both sides pin is the NEVER-MASK rule: red / degraded
+ * (amber) / error / out-of-vocabulary states — and, dashboard-side, a
+ * regression — always pass through; only healthy-or-no-data becomes pending.
+ * The dashboard's commError-contract-drift.test.ts pins both derivations.
  */
 export type FleetSurfaceState = ProbeState | "unreachable" | "pending";
 
@@ -361,8 +371,7 @@ export interface FleetStatusRow {
 
 /**
  * Compute the dashboard's surface state from a row's colour + comm error.
- * Mirrors the dashboard's `cell-model.ts` derivation exactly: the
- * sweep-inferred `worker-reclaimed-pending` kind renders the NEUTRAL
+ * The sweep-inferred `worker-reclaimed-pending` kind renders the NEUTRAL
  * `"pending"` surface (the job is re-queued / back in flight, not a known
  * crash) ONLY when the row's last-known probe colour is green (healthy).
  * ANY non-green state — red, degraded, error, or an out-of-vocabulary
@@ -372,6 +381,12 @@ export interface FleetStatusRow {
  * kind is a directly-observed pool failure and renders the red
  * `"unreachable"` overlay; absent any comm error the row's last-known probe
  * colour passes through unchanged.
+ *
+ * The dashboard's `cell-model.ts` mirrors this derivation over its
+ * `ChipColor` vocabulary with ONE deliberate difference (see the
+ * `FleetSurfaceState` doc above): its dashboard-only no-data `gray` ALSO
+ * becomes `"pending"` — green-only here purely because `ProbeState` has no
+ * no-data colour. The never-mask rule is identical on both sides.
  */
 export function fleetSurfaceState(row: FleetStatusRow): FleetSurfaceState {
   if (!row.commError) return row.state;

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -783,7 +783,12 @@ export interface SweepResult {
   /**
    * Number of STALE PENDING jobs expired (claimed-then-deleted) because they
    * sat unclaimed longer than their family's expiry window — the structural
-   * backlog drain (see queue-client `stalePending`). Optional so the many
+   * backlog drain (see queue-client `stalePending`). Despite the name, the
+   * LEASE phase's long-expired carve-out ALSO counts here: a CLAIMED/RUNNING
+   * row whose created-age exceeds the same family stale window and whose
+   * lease is long-expired (or unparseable) is claim-DELETED — not re-queued,
+   * no comm error, no `reclaimed` increment — into this count. See the
+   * queue-client's sweep-lease-stale-deleted path. Optional so the many
    * sweep fakes keyed on the reclamation contract stay valid; the real
    * queue-client always reports it.
    */

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -320,10 +320,11 @@ export interface PoolCommError {
  * derivation) produces THREE outcomes:
  *   - `"unreachable"` — a directly-observed crash kind (worker-crashed-mid-job,
  *     worker-unreachable, ...) overlays the row: the red comm-error treatment.
- *   - `"pending"` — a `worker-reclaimed-pending` comm error on a NON-red row:
+ *   - `"pending"` — a `worker-reclaimed-pending` comm error on a GREEN row:
  *     the lease lapsed and the sweeper re-queued the job (routine teardown,
  *     not a known crash), so the surface is the NEUTRAL gray "re-queued /
- *     pending" treatment (see POOL_COMM_ERROR_KINDS). A red row passes
+ *     pending" treatment (see POOL_COMM_ERROR_KINDS). ANY non-green row —
+ *     red, degraded, error, or an out-of-vocabulary runtime state — passes
  *     through — the neutral overlay must never mask a genuine failure.
  *   - otherwise the row's last-known probe colour (`state`).
  */
@@ -356,16 +357,19 @@ export interface FleetStatusRow {
  * Mirrors the dashboard's `cell-model.ts` derivation exactly: the
  * sweep-inferred `worker-reclaimed-pending` kind renders the NEUTRAL
  * `"pending"` surface (the job is re-queued / back in flight, not a known
- * crash) UNLESS the row's own probe colour is red — a present red is a
- * genuine failure the neutral overlay must NOT mask, so it passes through.
- * Every other comm-error kind is a directly-observed pool failure and
- * renders the red `"unreachable"` overlay; no comm error passes the row's
- * last-known probe colour through unchanged.
+ * crash) ONLY when the row's last-known probe colour is green (healthy).
+ * ANY non-green state — red, degraded, error, or an out-of-vocabulary
+ * runtime value — is a genuine failure the neutral overlay must NOT mask
+ * (the A2 rank principle: an unrecognized state ranks ABOVE red, so it
+ * passes through too), and passes through unchanged. Every other comm-error
+ * kind is a directly-observed pool failure and renders the red
+ * `"unreachable"` overlay; absent any comm error the row's last-known probe
+ * colour passes through unchanged.
  */
 export function fleetSurfaceState(row: FleetStatusRow): FleetSurfaceState {
   if (!row.commError) return row.state;
   if (row.commError.kind === "worker-reclaimed-pending") {
-    return row.state === "red" ? row.state : "pending";
+    return row.state === "green" ? "pending" : row.state;
   }
   return "unreachable";
 }

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -315,10 +315,19 @@ export interface PoolCommError {
  *     the pool" treatment.
  *
  * `FleetSurfaceState` is the UNION the DASHBOARD computes for rendering — it is
- * a presentation type, NOT a persisted column. The dashboard derives it:
- * `commError ? "unreachable" : state`.
+ * a presentation type, NOT a persisted column. The derivation (see
+ * `fleetSurfaceState`, mirrored by the dashboard's `cell-model.ts` surface
+ * derivation) produces THREE outcomes:
+ *   - `"unreachable"` — a directly-observed crash kind (worker-crashed-mid-job,
+ *     worker-unreachable, ...) overlays the row: the red comm-error treatment.
+ *   - `"pending"` — a `worker-reclaimed-pending` comm error on a NON-red row:
+ *     the lease lapsed and the sweeper re-queued the job (routine teardown,
+ *     not a known crash), so the surface is the NEUTRAL gray "re-queued /
+ *     pending" treatment (see POOL_COMM_ERROR_KINDS). A red row passes
+ *     through — the neutral overlay must never mask a genuine failure.
+ *   - otherwise the row's last-known probe colour (`state`).
  */
-export type FleetSurfaceState = ProbeState | "unreachable";
+export type FleetSurfaceState = ProbeState | "unreachable" | "pending";
 
 /** Signal-blob key under which a comm error is mirrored onto a status row. */
 export const FLEET_COMM_ERROR_SIGNAL_KEY = "__fleetCommError" as const;
@@ -342,9 +351,23 @@ export interface FleetStatusRow {
   commError?: PoolCommError;
 }
 
-/** Compute the dashboard's surface state from a row's colour + comm error. */
+/**
+ * Compute the dashboard's surface state from a row's colour + comm error.
+ * Mirrors the dashboard's `cell-model.ts` derivation exactly: the
+ * sweep-inferred `worker-reclaimed-pending` kind renders the NEUTRAL
+ * `"pending"` surface (the job is re-queued / back in flight, not a known
+ * crash) UNLESS the row's own probe colour is red — a present red is a
+ * genuine failure the neutral overlay must NOT mask, so it passes through.
+ * Every other comm-error kind is a directly-observed pool failure and
+ * renders the red `"unreachable"` overlay; no comm error passes the row's
+ * last-known probe colour through unchanged.
+ */
 export function fleetSurfaceState(row: FleetStatusRow): FleetSurfaceState {
-  return row.commError ? "unreachable" : row.state;
+  if (!row.commError) return row.state;
+  if (row.commError.kind === "worker-reclaimed-pending") {
+    return row.state === "red" ? row.state : "pending";
+  }
+  return "unreachable";
 }
 
 /**

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -335,12 +335,24 @@ export interface PoolCommError {
  *     through — the neutral overlay must never mask a genuine failure.
  *   - otherwise the row's last-known probe colour (`state`).
  *
- * DELIBERATE ASYMMETRY in the pending gate: this HARNESS derivation is
- * green-ONLY because `ProbeState` has no no-data colour to route. The
- * dashboard's derivation runs over its `ChipColor` vocabulary, whose `gray`
- * is a dashboard-only no-data colour this side cannot represent — there, a
- * reclaim on a green OR gray (non-regressed) cell becomes `"pending"`. The
- * shared invariant both sides pin is the NEVER-MASK rule: red / degraded
+ * TWO DELIBERATE DIVERGENCES from the dashboard mirror (`cell-model.ts`):
+ *
+ *   1. PENDING-GATE VOCABULARY: this HARNESS derivation is green-ONLY
+ *      because `ProbeState` has no no-data colour to route. The dashboard's
+ *      derivation runs over its `ChipColor` vocabulary, whose `gray` is a
+ *      dashboard-only no-data colour this side cannot represent — there, a
+ *      reclaim on a green OR gray (non-regressed) cell becomes `"pending"`.
+ *   2. RECENCY: this derivation has NO recency gate — a present `commError`
+ *      always overlays, regardless of its `observedAt` age. The dashboard
+ *      mirror staleness-gates comm errors (see `decodeCellCommError`'s
+ *      per-row-family window) because nothing clears the mirrored signal
+ *      blob on recovery and a stale overlay would pin cells "unreachable"
+ *      forever. Harness-side that gate is deliberately ABSENT: consumers
+ *      here receive rows the aggregator just wrote (the comm error is fresh
+ *      by construction at the write site) — recency is the CALLER's concern
+ *      when this is ever applied to read-back rows.
+ *
+ * The shared invariant both sides pin is the NEVER-MASK rule: red / degraded
  * (amber) / error / out-of-vocabulary states — and, dashboard-side, a
  * regression — always pass through; only healthy-or-no-data becomes pending.
  * The dashboard's commError-contract-drift.test.ts pins both derivations.
@@ -383,10 +395,13 @@ export interface FleetStatusRow {
  * colour passes through unchanged.
  *
  * The dashboard's `cell-model.ts` mirrors this derivation over its
- * `ChipColor` vocabulary with ONE deliberate difference (see the
- * `FleetSurfaceState` doc above): its dashboard-only no-data `gray` ALSO
+ * `ChipColor` vocabulary with TWO deliberate differences (enumerated in the
+ * `FleetSurfaceState` doc above): (1) its dashboard-only no-data `gray` ALSO
  * becomes `"pending"` — green-only here purely because `ProbeState` has no
- * no-data colour. The never-mask rule is identical on both sides.
+ * no-data colour; and (2) the dashboard staleness-gates comm errors before
+ * deriving, while this derivation has no recency gate (the aggregator-side
+ * callers see freshly-written rows; recency is the caller's concern). The
+ * never-mask rule is identical on both sides.
  */
 export function fleetSurfaceState(row: FleetStatusRow): FleetSurfaceState {
   if (!row.commError) return row.state;
@@ -602,14 +617,18 @@ export function isWorkerStale(
 /**
  * Build a `WorkerCapacity` from a `BrowserPoolBudget` (S6). Thin, explicit
  * field copy so the registration/heartbeat path never accidentally widens with
- * pool-internal fields. Pure; unit-tested.
+ * pool-internal fields. `available` is CLAMPED at 0: the capacity contract
+ * documents it "never negative", and a racy/mid-teardown pool snapshot can
+ * transiently compute a negative remainder — the mapper enforces the
+ * invariant rather than leak the racy value to registry/heartbeat consumers.
+ * Pure; unit-tested.
  */
 export function workerCapacityFromBudget(
   budget: BrowserPoolBudget,
 ): WorkerCapacity {
   return {
     inUse: budget.inUse,
-    available: budget.available,
+    available: Math.max(0, budget.available),
     max: budget.max,
     pidsCurrent: budget.pidsCurrent,
     pidsMax: budget.pidsMax,
@@ -645,11 +664,27 @@ export interface ClaimedJob {
   lease?: JobLease;
 }
 
-/** Input a worker passes to report a finished job back to the control-plane. */
+/**
+ * Input a worker passes to report a finished job back to the control-plane.
+ *
+ * EQUALITY INVARIANT: `jobId === result.jobId` and
+ * `workerId === result.workerId`. The top-level fields are the claim-row
+ * coordinates the queue's release path keys on; `result` echoes them so the
+ * aggregator can group results without re-joining the claim row. The
+ * duplication is deliberate (release and aggregation read different halves
+ * of this input) but the values MUST be equal.
+ *
+ * INTEGRATOR NOTE: the queue-client's `report()` does NOT currently validate
+ * this equality — it releases on the top-level `jobId`/`workerId` and
+ * persists `result` verbatim, so a mismatched caller would release one row
+ * while filing the result under another job's/worker's ids. Callers are the
+ * enforcement point today; a queue-client-side validation would belong in
+ * `report()` (sibling-owned file — not changed here).
+ */
 export interface ReportJobInput {
-  /** The claim row id being terminated (S0 `JobView.id`). */
+  /** The claim row id being terminated (S0 `JobView.id`). Must equal `result.jobId`. */
   jobId: string;
-  /** The reporting worker (S0 `JobView.claimed_by`). */
+  /** The reporting worker (S0 `JobView.claimed_by`). Must equal `result.workerId`. */
   workerId: string;
   /** The per-service result, OR a comm-error-only terminal report. */
   result: ServiceJobResult;

--- a/showcase/harness/src/fleet/control-plane/control-plane.test.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.test.ts
@@ -437,6 +437,14 @@ describe("createControlPlane — multi-schedule hardening", () => {
     // Nothing registered.
     expect(scheduler.entries.size).toBe(0);
 
+    // `started` is not latched true on the FAILED instance: a retry on the
+    // SAME control-plane re-validates and throws again (a latched-true latch
+    // would make the second start() a silent no-op).
+    expect(() => cp.start()).toThrow(/fleet-bad/);
+    expect(producerA.started).toBe(false);
+    expect(producerB.started).toBe(false);
+    expect(scheduler.entries.size).toBe(0);
+
     // `started` is not latched true: a subsequent start() with valid crons works.
     const cpOk = createControlPlane({
       producer: producerA,

--- a/showcase/harness/src/fleet/control-plane/control-plane.test.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.test.ts
@@ -49,6 +49,7 @@ function makeFakeProducer(): JobProducer & {
         runId: "r",
         enqueued: 0,
         enqueueFailures: 0,
+        skippedForBacklog: 0,
         sweptExpired: false,
         reclaimed: 0,
       };

--- a/showcase/harness/src/fleet/control-plane/control-plane.test.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.test.ts
@@ -53,6 +53,7 @@ function makeFakeProducer(): JobProducer & {
         sweptExpired: false,
         sweepFailed: false,
         reclaimed: 0,
+        enumerateFailed: false,
       };
     },
     isRunning() {

--- a/showcase/harness/src/fleet/control-plane/control-plane.test.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.test.ts
@@ -162,20 +162,35 @@ function makeFakeScheduler(): Scheduler & {
   };
 }
 
-/** A controllable fake setInterval/clearInterval pair. */
+/**
+ * A controllable fake setInterval/clearInterval pair. PER-HANDLE like the
+ * real timers: the control-plane registers up to TWO intervals (consumer
+ * poll + fleet-health), and the old single-callback-slot fake let the
+ * second registration silently overwrite the first — any test "driving" the
+ * consumer loop with fleet-health injected was vacuous, and a leaked
+ * (never-cleared) interval was invisible to the `cleared` flag.
+ */
 class FakeTimers {
-  private cb: (() => void) | undefined;
-  cleared = false;
+  private handles = new Map<number, () => void>();
+  private nextHandle = 1;
+  /** Total intervals ever registered (cleared or not). */
+  registered = 0;
   setIntervalImpl = ((fn: () => void) => {
-    this.cb = fn;
-    return 1 as unknown as ReturnType<typeof setInterval>;
+    const handle = this.nextHandle++;
+    this.registered += 1;
+    this.handles.set(handle, fn);
+    return handle as unknown as ReturnType<typeof setInterval>;
   }) as unknown as typeof setInterval;
-  clearIntervalImpl = (() => {
-    this.cleared = true;
-    this.cb = undefined;
+  clearIntervalImpl = ((handle: unknown) => {
+    this.handles.delete(handle as number);
   }) as unknown as typeof clearInterval;
+  /** True when at least one interval was registered and ALL were cleared. */
+  get cleared(): boolean {
+    return this.registered > 0 && this.handles.size === 0;
+  }
+  /** Fire every ACTIVE (uncleared) interval callback once. */
   async fire(): Promise<void> {
-    this.cb?.();
+    for (const cb of [...this.handles.values()]) cb();
     // Let the void-returned async cycle settle.
     await Promise.resolve();
     await Promise.resolve();
@@ -605,14 +620,49 @@ describe("createControlPlane — REQ-B comm-error surfacing", () => {
       logger: SILENT_LOGGER,
       aggregator,
       fleetHealth,
-      // Use the SAME fake timer for both consumer + fleet-health; fire() drives
-      // whichever callback was registered last (fleet-health), proving the loop
-      // is attached. We assert the monitor was invoked.
+      // The SAME fake timer pair carries both the consumer and fleet-health
+      // intervals (per-handle, like the real setInterval); fire() drives
+      // every active callback. We assert the monitor was invoked.
       setIntervalImpl: timers.setIntervalImpl,
       clearIntervalImpl: timers.clearIntervalImpl,
     });
     cp.start();
     await timers.fire();
+    expect(fleetHealth.calls).toBe(1);
+  });
+
+  it("with fleetHealth injected, the consumer AND fleet-health intervals BOTH fire — and stop() clears BOTH", async () => {
+    // The old FakeTimers held a SINGLE callback slot, so the second
+    // registration (fleet-health) silently overwrote the consumer's — a
+    // control-plane that never started the consumer loop when fleet-health
+    // was injected would have passed every test in this file. Per-handle
+    // timers pin both loops, and per-handle clears pin that stop() tears
+    // down BOTH (a leaked interval would survive shutdown).
+    const consumer = makeFakeConsumer();
+    const fleetHealth = makeFakeFleetHealth(emptyHealthResult());
+    const timers = makeFakeTimers();
+    const cp = createControlPlane({
+      producer: makeFakeProducer(),
+      consumer,
+      scheduler: makeFakeScheduler(),
+      logger: SILENT_LOGGER,
+      aggregator: makeFakeAggregator(),
+      fleetHealth,
+      setIntervalImpl: timers.setIntervalImpl,
+      clearIntervalImpl: timers.clearIntervalImpl,
+    });
+    cp.start();
+    expect(timers.registered).toBe(2);
+
+    await timers.fire();
+    expect(consumer.calls).toBe(1);
+    expect(fleetHealth.calls).toBe(1);
+
+    await cp.stop();
+    // ALL registered handles cleared — not just the last one.
+    expect(timers.cleared).toBe(true);
+    await timers.fire();
+    expect(consumer.calls).toBe(1);
     expect(fleetHealth.calls).toBe(1);
   });
 

--- a/showcase/harness/src/fleet/control-plane/control-plane.test.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.test.ts
@@ -50,6 +50,7 @@ function makeFakeProducer(): JobProducer & {
         enqueued: 0,
         enqueueFailures: 0,
         skippedForBacklog: 0,
+        backlogGateFailedOpen: 0,
         truncatedByStop: 0,
         sweptExpired: false,
         sweepFailed: false,

--- a/showcase/harness/src/fleet/control-plane/control-plane.test.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.test.ts
@@ -50,6 +50,7 @@ function makeFakeProducer(): JobProducer & {
         enqueued: 0,
         enqueueFailures: 0,
         skippedForBacklog: 0,
+        truncatedByStop: 0,
         sweptExpired: false,
         sweepFailed: false,
         reclaimed: 0,

--- a/showcase/harness/src/fleet/control-plane/control-plane.test.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.test.ts
@@ -51,6 +51,7 @@ function makeFakeProducer(): JobProducer & {
         enqueueFailures: 0,
         skippedForBacklog: 0,
         sweptExpired: false,
+        sweepFailed: false,
         reclaimed: 0,
       };
     },

--- a/showcase/harness/src/fleet/control-plane/fleet-health.test.ts
+++ b/showcase/harness/src/fleet/control-plane/fleet-health.test.ts
@@ -336,6 +336,48 @@ describe("createFleetHealthMonitor.checkOnce", () => {
     expect(claim.releases).toEqual([]);
   });
 
+  it("warns AND counts an unparseable heartbeat per cycle (heartbeatParseable wiring — the blind-but-online row is surfaced)", async () => {
+    const { pb } = makeFakePb({
+      workers: [
+        {
+          id: "w1",
+          worker_id: "worker-corrupt",
+          last_heartbeat_at: "not-a-date",
+        },
+        { id: "w2", worker_id: "worker-live", last_heartbeat_at: FRESH },
+      ],
+      jobs: [],
+    });
+    const claim = makeFakeClaim();
+    const warn = vi.fn();
+    const info = vi.fn();
+    const logger: Logger = { ...SILENT_LOGGER, warn, info };
+    const monitor = createFleetHealthMonitor({
+      pb,
+      claim,
+      logger,
+      now: () => NOW,
+    });
+
+    const out = await monitor.checkOnce();
+
+    // isWorkerStale is deliberately blind to an unparseable heartbeat (never
+    // flap the fleet offline on one malformed row), so the corrupt row still
+    // derives "online" — the per-worker warn + per-cycle count are the ONLY
+    // operator visibility into the orphaned row.
+    expect(out.online).toBe(2);
+    expect(out.unhealthy).toBe(0);
+    expect(warn).toHaveBeenCalledWith("fleet.health.unparseable-heartbeat", {
+      workerId: "worker-corrupt",
+      lastHeartbeatAt: "not-a-date",
+    });
+    expect(info).toHaveBeenCalledWith(
+      "fleet.health.cycle",
+      expect.objectContaining({ unparseableHeartbeats: 1 }),
+    );
+    expect(claim.releases).toEqual([]);
+  });
+
   it("fires the best-effort restart hook once per stale worker after reclaiming", async () => {
     const { pb } = makeFakePb({
       workers: [

--- a/showcase/harness/src/fleet/control-plane/fleet-health.ts
+++ b/showcase/harness/src/fleet/control-plane/fleet-health.ts
@@ -54,6 +54,7 @@ import type { JobClaimClient, JobView } from "../job-claim.js";
 import { PROBE_JOBS_COLLECTION } from "../queue-client.js";
 import {
   WORKERS_COLLECTION,
+  heartbeatParseable,
   isWorkerStale,
   type PoolCommError,
   type WorkerHealthState,
@@ -349,6 +350,11 @@ export function createFleetHealthMonitor(
       let reclaimed = 0;
       let restartsAttempted = 0;
       let gcDeleted = 0;
+      // Per-cycle count of roster rows whose heartbeat the contract parser
+      // can't read (see the unparseable-heartbeat warn below) — surfaced on
+      // the cycle log so a persistently corrupt row shows up as a number, not
+      // just warn-stream noise.
+      let unparseableHeartbeats = 0;
       const commErrors: PoolCommError[] = [];
       const reclaimedOverlays: ReclaimedCommError[] = [];
 
@@ -402,11 +408,16 @@ export function createFleetHealthMonitor(
         // false (treat-unknown-as-not-yet-stale) so a malformed row can't flap
         // the whole fleet to offline — but a PERSISTENTLY bad timestamp means
         // this worker silently never gets reclaimed. Warn so the orphaned row is
-        // visible to an operator (the next valid heartbeat clears it).
+        // visible to an operator (the next valid heartbeat clears it). The
+        // predicate is the contract's `heartbeatParseable` companion — the
+        // EXACT complement of what `isWorkerStale` can see (same PB space-form
+        // normalization) — not a raw engine-lenient `Date.parse`, so the warn
+        // fires precisely when the staleness check is blind.
         if (
           typeof row.last_heartbeat_at !== "string" ||
-          Number.isNaN(Date.parse(row.last_heartbeat_at))
+          !heartbeatParseable(row.last_heartbeat_at)
         ) {
+          unparseableHeartbeats += 1;
           logger.warn("fleet.health.unparseable-heartbeat", {
             workerId,
             lastHeartbeatAt: row.last_heartbeat_at,
@@ -463,13 +474,19 @@ export function createFleetHealthMonitor(
         }
       }
 
-      if (unhealthy > 0 || reclaimed > 0 || gcDeleted > 0) {
+      if (
+        unhealthy > 0 ||
+        reclaimed > 0 ||
+        gcDeleted > 0 ||
+        unparseableHeartbeats > 0
+      ) {
         logger.info("fleet.health.cycle", {
           online,
           unhealthy,
           reclaimed,
           restartsAttempted,
           gcDeleted,
+          unparseableHeartbeats,
         });
       }
 

--- a/showcase/harness/src/fleet/control-plane/fleet-health.ts
+++ b/showcase/harness/src/fleet/control-plane/fleet-health.ts
@@ -263,7 +263,16 @@ export function createFleetHealthMonitor(
     let page: { items: JobView[] };
     try {
       page = await pb.list<JobView>(PROBE_JOBS_COLLECTION, {
-        filter: `(status = "claimed" || status = "running") && claimed_by = "${workerId}"`,
+        // `workerId` is read back from the workers roster row (DB-sourced, not
+        // a compile-time constant). The rest of the codebase deliberately
+        // neutralizes this sink class — orchestrator.ts:3240 already uses
+        // `JSON.stringify(workerId)` for the same field, queue-client uses the
+        // shared `escapeFilterLiteral` helper. A `"`-bearing worker_id (corrupt
+        // row, buggy self-registration) would otherwise break out of the
+        // literal and either throw the list (silently skipping this worker's
+        // reclaim every cycle) or widen the filter to claim OTHER workers'
+        // jobs. Match the sibling escape pattern.
+        filter: `(status = "claimed" || status = "running") && claimed_by = ${JSON.stringify(workerId)}`,
         perPage: RECLAIM_PAGE,
         skipTotal: true,
       });

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -321,6 +321,33 @@ describe("job-producer — per-service enqueue", () => {
     expect(result.enqueued).toBe(0);
     expect(queue.enqueued).toHaveLength(0);
   });
+
+  it("logs tick-start BEFORE the enumerator runs (a hung discovery still leaves a tick trace)", async () => {
+    // tick-start used to be logged AFTER the enumerate await — a discovery
+    // upstream that hung or threw left no trace that the tick had begun.
+    const events: string[] = [];
+    const logger: Logger = {
+      ...SILENT_LOGGER,
+      info: (msg) => {
+        events.push(msg);
+      },
+    };
+    const producer = createJobProducer({
+      queue: makeFakeQueue(),
+      enumerate: () => {
+        events.push("enumerate-invoked");
+        return d6Specs(["a"]);
+      },
+      logger,
+    });
+    producer.start();
+    await producer.tick();
+    const startIdx = events.indexOf("fleet.producer.tick-start");
+    const enumIdx = events.indexOf("enumerate-invoked");
+    expect(startIdx).toBeGreaterThanOrEqual(0);
+    expect(enumIdx).toBeGreaterThanOrEqual(0);
+    expect(startIdx).toBeLessThan(enumIdx);
+  });
 });
 
 describe("job-producer — per-family backlog dedupe", () => {
@@ -485,6 +512,28 @@ describe("job-producer — failure isolation", () => {
     // First tick always sweeps (lastSweepAt seeded null) — reclamation must
     // not be starved by a flaky enumerator.
     expect(result.sweptExpired).toBe(true);
+    expect(queue.sweepCalls).toEqual([1_000]);
+  });
+
+  it("routes an enumerator that resolves to a NON-ARRAY through the enumerate-failure handling", async () => {
+    // A misbehaving enumerator (bad wiring, a mock resolving undefined) used
+    // to bypass the enumerateFailed path entirely and blow up further down
+    // the tick. A non-array resolution is a FAILED enumeration, not an empty
+    // catalog.
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () =>
+        Promise.resolve(null) as unknown as Promise<ServiceJobSpec[]>,
+      logger: SILENT_LOGGER,
+      now: () => 1_000,
+    });
+    producer.start();
+    const result = await producer.tick();
+    expect(result.enumerateFailed).toBe(true);
+    expect(result.enqueued).toBe(0);
+    expect(queue.enqueued).toHaveLength(0);
+    // The sweep is still attempted, same as the throwing-enumerator path.
     expect(queue.sweepCalls).toEqual([1_000]);
   });
 
@@ -843,6 +892,50 @@ describe("job-producer — sweep cadence", () => {
     expect(received[0]![received[0]!.length - 1]!.jobId).toBe("fresh0");
   });
 
+  it("[REQ-B] warns ONCE (with jobIds) when swept comm errors exist but no sink is configured", async () => {
+    // Legacy logged-only mode drops the batch's dashboard signal with only a
+    // count in the sweep-reclaimed warn. Surface the wiring gap explicitly —
+    // once, with the dropped jobIds — without burying logs on every sweep.
+    const warns: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const logger: Logger = {
+      ...SILENT_LOGGER,
+      warn: (msg, meta) => {
+        warns.push({ msg, ...(meta !== undefined ? { meta } : {}) });
+      },
+    };
+    const queue = makeFakeQueue({
+      sweepImpl: async () => ({
+        reclaimed: 1,
+        commErrors: [
+          {
+            kind: "worker-reclaimed-pending",
+            message: "lease for job j1 expired; re-queued",
+            jobId: "j1",
+            observedAt: "2026-06-04T00:00:09.000Z",
+          },
+        ],
+      }),
+    });
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger,
+      sweepIntervalMs: 0, // sweep (and drop) on every tick
+      // no onSweepCommErrors sink
+    });
+    producer.start();
+    await producer.tick();
+    await producer.tick();
+    const noSinkWarns = warns.filter(
+      (w) => w.msg === "fleet.producer.sweep-commerrors-no-sink",
+    );
+    expect(noSinkWarns).toHaveLength(1);
+    expect(noSinkWarns[0]!.meta).toMatchObject({
+      commErrors: 1,
+      jobIds: ["j1"],
+    });
+  });
+
   it("defaults the sweep cadence to DEFAULT_SWEEP_INTERVAL_MS", async () => {
     let t = 0;
     const queue = makeFakeQueue();
@@ -1048,6 +1141,65 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
     expect(cancelled).toBe(1);
   });
 
+  it("counts a warm GET as fired only when the dispatch succeeded (sync-throwing fetch is not 'warmed')", async () => {
+    // `fired` used to be incremented BEFORE the dispatch try — a fetchImpl
+    // that threw synchronously still counted, so the `warmed` log overstated
+    // how many backends were actually poked.
+    const infos: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const logger: Logger = {
+      ...SILENT_LOGGER,
+      info: (msg, meta) => {
+        infos.push({ msg, ...(meta !== undefined ? { meta } : {}) });
+      },
+    };
+    const fetchImpl = ((input: string | URL | Request): Promise<Response> => {
+      if (String(input).includes("alpha")) {
+        throw new Error("sync EINVAL from fetch impl");
+      }
+      return Promise.resolve(new Response(null, { status: 200 }));
+    }) as typeof fetch;
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["alpha", "beta"]),
+      logger,
+      warmHealth: { fetchImpl },
+    });
+    producer.start();
+    await producer.tick();
+    const warmed = infos.find((e) => e.msg === "fleet.producer.warmed");
+    expect(warmed).toBeDefined();
+    expect(warmed!.meta).toMatchObject({ warmed: 1 }); // beta only
+  });
+
+  it("a throwing logger inside the warm chain never raises an unhandled rejection", async () => {
+    // The fire-and-forget chain's own handlers can throw (an injected logger
+    // whose transport is down). Without a terminal catch that surfaces as an
+    // unhandled rejection from a chain nobody awaits.
+    const throwingDebugLogger: Logger = {
+      ...SILENT_LOGGER,
+      debug: () => {
+        throw new Error("logger transport down");
+      },
+    };
+    const failingFetch = (async (): Promise<Response> => {
+      throw new Error("ECONNREFUSED (cold container still booting)");
+    }) as typeof fetch;
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["alpha"]),
+      logger: throwingDebugLogger,
+      warmHealth: { fetchImpl: failingFetch },
+    });
+    producer.start();
+    const result = await producer.tick();
+    expect(result.enqueued).toBe(1);
+    // Let the fire-and-forget chain settle: an unhandled rejection from the
+    // throwing logger fails the test run.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
   it("skips specs with no backendUrl (no bogus warm GET)", async () => {
     const { fetchImpl, calls } = makeFetchSpy();
     const queue = makeFakeQueue();
@@ -1076,15 +1228,23 @@ describe("job-producer — default run-id factory", () => {
   });
 
   it("two producers created back-to-back never collide for equal (timestamp, counter)", async () => {
-    // Four producers each get an INDEPENDENT default factory with its counter
+    // Two producers each get an INDEPENDENT default factory with its counter
     // starting at 0 — same-ms ticks with equal counts used to produce the SAME
     // id, and the aggregator groups by meta.runId. Pin the clock so both
     // producers see an identical (ts, counter) pair; the per-factory random
     // discriminator must still keep the ids distinct.
     vi.spyOn(Date, "now").mockReturnValue(1_765_000_000_000);
-    vi.spyOn(Math, "random")
-      .mockReturnValueOnce(0.1234567)
-      .mockReturnValueOnce(0.7654321);
+    // Derandomize with a never-exhausting deterministic sequence (distinct
+    // value per call). The previous two-shot mockReturnValueOnce form was
+    // fragile: a third Math.random call anywhere in the factory would fall
+    // through to the spy's undefined default and silently break the test's
+    // premise. The call-count guard below pins the one-draw-per-factory
+    // assumption instead.
+    let randomCalls = 0;
+    const randomSpy = vi.spyOn(Math, "random").mockImplementation(() => {
+      randomCalls += 1;
+      return randomCalls / 10;
+    });
     const make = () => {
       const producer = createJobProducer({
         queue: makeFakeQueue(),
@@ -1097,6 +1257,9 @@ describe("job-producer — default run-id factory", () => {
     };
     const p1 = make();
     const p2 = make();
+    // Length guard: the default factory draws its discriminator exactly ONCE
+    // per producer — if this count changes, revisit the derandomization.
+    expect(randomSpy).toHaveBeenCalledTimes(2);
     const r1 = await p1.tick();
     const r2 = await p2.tick();
     expect(r1.runId).not.toBe(r2.runId);
@@ -1335,6 +1498,24 @@ describe("job-producer — lifecycle seams (start/stop/tick)", () => {
     const result = await producer.tick();
     expect(result.enqueued).toBe(0);
     expect(queue.enqueued).toHaveLength(0);
+  });
+
+  it("a stopped tick does not mint a runId (no counter burn, no phantom runIds in logs)", async () => {
+    // The runId used to be minted BEFORE the running check — every tick that
+    // arrived outside the lifecycle burned the factory counter and logged a
+    // phantom runId no job would ever carry.
+    const runIdFactory = vi.fn(() => "run-phantom");
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger: SILENT_LOGGER,
+      runIdFactory,
+    });
+    // Never started.
+    const result = await producer.tick();
+    expect(result.runId).toBe("");
+    expect(runIdFactory).not.toHaveBeenCalled();
   });
 
   it("a tick after stop() enqueues nothing (no jobs leak past lifecycle)", async () => {

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -486,7 +486,7 @@ describe("job-producer — sweep cadence", () => {
         reclaimed: 2,
         commErrors: [
           {
-            kind: "worker-crashed-mid-job",
+            kind: "worker-reclaimed-pending",
             message: "lease expired",
             observedAt: new Date(nowMs).toISOString(),
           },
@@ -498,16 +498,16 @@ describe("job-producer — sweep cadence", () => {
     expect(result.reclaimed).toBe(2);
   });
 
-  it("[REQ-B] forwards the swept worker-crashed comm errors to the onSweepCommErrors sink", async () => {
-    // The whole point of REQ-B: a crashed/lease-expired worker's job is
-    // reclaimed and produces a worker-crashed-mid-job comm error. Previously
-    // the producer only LOGGED commErrors.length and DISCARDED the array, so
-    // the dashboard overlay was never written (the red state). Now the producer
-    // FORWARDS the array to an injected sink the control-plane routes to the
-    // aggregator.
+  it("[REQ-B] forwards the swept worker-reclaimed-pending comm errors to the onSweepCommErrors sink", async () => {
+    // The whole point of REQ-B: a lease-expired worker's job is reclaimed
+    // (re-queued to pending) and produces a worker-reclaimed-pending comm
+    // error. Previously the producer only LOGGED commErrors.length and
+    // DISCARDED the array, so the dashboard surface was never written. Now
+    // the producer FORWARDS the array to an injected sink the control-plane
+    // routes to the aggregator.
     const sweptErrors: PoolCommError[] = [
       {
-        kind: "worker-crashed-mid-job",
+        kind: "worker-reclaimed-pending",
         message: "lease for job j1 expired; re-queued",
         workerId: "worker-dead",
         jobId: "j1",
@@ -557,7 +557,7 @@ describe("job-producer — sweep cadence", () => {
         reclaimed: 1,
         commErrors: [
           {
-            kind: "worker-crashed-mid-job",
+            kind: "worker-reclaimed-pending",
             message: "lease expired",
             jobId: "j1",
             observedAt: "2026-06-04T00:00:09.000Z",

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -482,6 +482,62 @@ describe("job-producer — per-family backlog dedupe", () => {
     expect(result.skippedForBacklog).toBe(0);
   });
 
+  it("reports families KEPT via fail-open in TickResult.backlogGateFailedOpen and the tick-complete log (a failed gate must be distinguishable from a clean one)", async () => {
+    // A family kept because countPendingForFamily FAILED (non-poisoned) was
+    // indistinguishable in the tick outcome from a family whose gate read a
+    // clean zero — the same ambiguity class sweepFailed/enumerateFailed were
+    // added to remove. Surface the fail-open count.
+    const tickCompleteMeta: Array<Record<string, unknown> | undefined> = [];
+    const specs: ServiceJobSpec[] = [
+      ...d6Specs(["a"]),
+      { probeKey: "e2e-demos:a", serviceSlug: "a", driverKind: "e2e_demos" },
+    ];
+    const { producer } = startedProducer({
+      specs,
+      queue: makeFakeQueue({
+        countPendingImpl: async (family) => {
+          if (family === "d6") throw new Error("transient PB count blip");
+          return 0; // e2e-demos reads a clean zero
+        },
+      }),
+      logger: {
+        ...SILENT_LOGGER,
+        info: (msg, meta) => {
+          if (msg === "fleet.producer.tick-complete") tickCompleteMeta.push(meta);
+        },
+      },
+    });
+
+    const result = await producer.tick();
+
+    // Both families produced — but exactly ONE of them via fail-open.
+    expect(result.enqueued).toBe(2);
+    expect(result.backlogGateFailedOpen).toBe(1);
+    expect(tickCompleteMeta).toHaveLength(1);
+    expect(tickCompleteMeta[0]).toMatchObject({ backlogGateFailedOpen: 1 });
+  });
+
+  it("backlogGateFailedOpen is 0 on a clean gate, a triggered (gate-bypassing) tick, and a skipped tick", async () => {
+    const clean = startedProducer({ specs: d6Specs(["a"]) });
+    expect((await clean.producer.tick()).backlogGateFailedOpen).toBe(0);
+
+    const triggered = startedProducer({
+      specs: d6Specs(["a"]),
+      queue: makeFakeQueue({
+        countPendingImpl: async () => {
+          throw new Error("would fail open if consulted");
+        },
+      }),
+    });
+    expect(
+      (await triggered.producer.tick({ triggered: true })).backlogGateFailedOpen,
+    ).toBe(0);
+
+    const stopped = startedProducer({ specs: d6Specs(["a"]) });
+    await stopped.producer.stop();
+    expect((await stopped.producer.tick()).backlogGateFailedOpen).toBe(0);
+  });
+
   it("fails CLOSED when the backlog count is POISONED (the queue-client's fail-closed refusal must not be failed open)", async () => {
     // countPendingForFamily THROWS its documented refusal when PB hands back a
     // non-count totalItems (e.g. -1): returning the poisoned value would

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -1627,6 +1627,72 @@ describe("job-producer — stop() quiesce", () => {
     expect(warns).toContain("fleet.producer.enqueue-truncated-stopped");
   });
 
+  it("stop-truncated specs are ACCOUNTED in TickResult.truncatedByStop (and tick-complete's services line up)", async () => {
+    // Truncated specs used to VANISH from the tick outcome: services said 3,
+    // but enqueued + enqueueFailures + skippedForBacklog only summed to 1 —
+    // the two truncated jobs were uncounted in both the TickResult and the
+    // tick-complete log, so a stop-truncated run was indistinguishable from
+    // a partially-failed one whose failures went unreported.
+    let releaseEnqueue!: () => void;
+    const gate = new Promise<void>((resolve) => (releaseEnqueue = resolve));
+    const infos: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const logger: Logger = {
+      ...SILENT_LOGGER,
+      info: (msg, meta) => {
+        infos.push({ msg, ...(meta !== undefined ? { meta } : {}) });
+      },
+    };
+    const queue = makeFakeQueue({
+      enqueueImpl: async (input) => {
+        if (input.payload.serviceSlug === "a") await gate;
+        return jobView(input);
+      },
+    });
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a", "b", "c"]),
+      logger,
+    });
+    producer.start();
+    const tickP = producer.tick();
+    await vi.waitFor(() => {
+      expect(queue.enqueued).toHaveLength(1);
+    });
+    const stopP = producer.stop();
+    releaseEnqueue();
+    const result = await tickP;
+    await stopP;
+    // "b" and "c" were truncated by the stop — and COUNTED.
+    expect(result.truncatedByStop).toBe(2);
+    expect(result.enqueued).toBe(1);
+    // The tick outcome partitions the enumerated services exactly.
+    const complete = infos.find(
+      (e) => e.msg === "fleet.producer.tick-complete",
+    );
+    expect(complete).toBeDefined();
+    const meta = complete!.meta as {
+      services: number;
+      enqueued: number;
+      enqueueFailures: number;
+      skippedForBacklog: number;
+      truncatedByStop: number;
+    };
+    expect(meta.truncatedByStop).toBe(2);
+    expect(meta.services).toBe(
+      meta.enqueued +
+        meta.enqueueFailures +
+        meta.skippedForBacklog +
+        meta.truncatedByStop,
+    );
+  });
+
+  it("a tick that runs to completion reports truncatedByStop:0", async () => {
+    const { producer } = startedProducer({ specs: d6Specs(["a", "b"]) });
+    const result = await producer.tick();
+    expect(result.truncatedByStop).toBe(0);
+    expect(result.enqueued).toBe(2);
+  });
+
   it("stop() makes one final delivery attempt of buffered sweep comm errors", async () => {
     // Buffered comm errors used to be silently DROPPED at shutdown — the
     // reclaimed jobs' dashboard signal vanished with the process.

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -669,6 +669,45 @@ describe("job-producer — phantom probeKey guard", () => {
     expect(dropped!.meta).toMatchObject({ serviceSlug: "ghost" });
   });
 
+  it("a NON-OBJECT enumerator element (null/undefined/number) never rejects the tick promise and is counted as a failure", async () => {
+    // The phantom-probeKey guard dereferenced `spec.probeKey` without
+    // checking the ELEMENT itself is a non-null object — `[null]` from a
+    // misbehaving enumerator threw a TypeError out of the tick body,
+    // REJECTING the tick promise and violating the documented "a tick
+    // promise never rejects" invariant (a throw inside stop()'s shared
+    // completion would poison stopPromise for every later caller).
+    for (const ghost of [null, undefined, 42]) {
+      const errors: string[] = [];
+      const { producer, queue } = startedProducer({
+        specs: [
+          ghost as unknown as ServiceJobSpec,
+          ...d6Specs(["alpha"]),
+        ],
+        logger: {
+          ...SILENT_LOGGER,
+          error: (msg) => {
+            errors.push(msg);
+          },
+        },
+      });
+
+      // MUST resolve — never reject.
+      const result = await producer.tick();
+
+      // The valid spec still produced; the ghost is an honest failure in the
+      // existing invalid-spec accounting (partition invariant holds).
+      expect(queue.enqueued.map((e) => e.payload.probeKey)).toEqual([
+        "d6:alpha",
+      ]);
+      expect(result.enqueued).toBe(1);
+      expect(result.enqueueFailures).toBe(1);
+      expect(result.skippedForBacklog).toBe(0);
+      expect(result.truncatedByStop).toBe(0);
+      // Logged loudly like the empty-probeKey drop.
+      expect(errors).toContain("fleet.producer.spec-invalid-probekey");
+    }
+  });
+
   it("drops an empty-probeKey spec on a TRIGGERED tick too (gate bypass does not bypass the guard)", async () => {
     const { producer, queue } = startedProducer({
       specs: [GHOST_SPEC, ...d6Specs(["alpha"])],

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   createJobProducer,
   DEFAULT_SWEEP_INTERVAL_MS,
@@ -635,6 +635,12 @@ describe("job-producer — sweep cadence", () => {
 });
 
 describe("job-producer — #72 pre-dispatch health warm-up", () => {
+  afterEach(() => {
+    // restoreAllMocks does NOT undo vi.stubGlobal — a leaked global fetch stub
+    // poisons unrelated files under fork-reuse (repo discipline).
+    vi.unstubAllGlobals();
+  });
+
   /** A fetch spy that records each warm URL and resolves a 200. */
   function makeFetchSpy(): {
     fetchImpl: typeof fetch;
@@ -696,7 +702,14 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
   });
 
   it("does NOT warm when no warmHealth config is supplied (legacy behavior)", async () => {
-    const { fetchImpl, calls } = makeFetchSpy();
+    // Stub the GLOBAL fetch: the meaningful no-warm guarantee is that an
+    // unconfigured producer never falls back to `globalThis.fetch` for warm
+    // GETs. (The prior shape of this test asserted zero calls on a local spy
+    // it never wired in — vacuously true by construction.)
+    const globalFetchSpy = vi.fn(
+      async (): Promise<Response> => new Response(null, { status: 200 }),
+    );
+    vi.stubGlobal("fetch", globalFetchSpy);
     const queue = makeFakeQueue();
     const producer = createJobProducer({
       queue,
@@ -705,10 +718,10 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
       // no warmHealth
     });
     producer.start();
-    await producer.tick();
-    // fetchImpl was never wired, so nothing was warmed.
-    expect(calls).toHaveLength(0);
-    void fetchImpl;
+    const result = await producer.tick();
+    // The tick produced normally but fired no warm GET at all.
+    expect(result.enqueued).toBe(1);
+    expect(globalFetchSpy).not.toHaveBeenCalled();
   });
 
   it("a rejecting warm fetch never aborts job production (best-effort)", async () => {

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -541,6 +541,86 @@ describe("job-producer — per-family backlog dedupe", () => {
   });
 });
 
+describe("job-producer — phantom probeKey guard", () => {
+  // probeKeyFamily("") returns "" (contracts.ts), so an enumerator-supplied
+  // EMPTY probeKey flowed into countPendingForFamily("") (a phantom ""
+  // family gating nothing real) and, worse, into an enqueued claim row no
+  // dashboard status row can ever join. The producer must drop the spec at
+  // the boundary — loudly, and accounted in the tick's failure partition.
+
+  const GHOST_SPEC: ServiceJobSpec = {
+    probeKey: "",
+    serviceSlug: "ghost",
+    driverKind: "e2e_d6",
+  };
+
+  it("drops an empty-probeKey spec on a SCHEDULED tick (no phantom '' family count, no unjoinable row)", async () => {
+    const errors: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const { producer, queue } = startedProducer({
+      specs: [GHOST_SPEC, ...d6Specs(["alpha"])],
+      logger: {
+        ...SILENT_LOGGER,
+        error: (msg, meta) => {
+          errors.push({ msg, ...(meta !== undefined ? { meta } : {}) });
+        },
+      },
+    });
+
+    const result = await producer.tick();
+
+    // The backlog gate never saw the phantom "" family…
+    expect(queue.countCalls).toEqual(["d6"]);
+    // …and no unjoinable claim row was enqueued.
+    expect(queue.enqueued.map((e) => e.payload.probeKey)).toEqual(["d6:alpha"]);
+    // Accounted honestly: the dropped spec is a failure, and the partition
+    // invariant (services == enqueued + enqueueFailures + skippedForBacklog
+    // + truncatedByStop) still holds for the 2 enumerated specs.
+    expect(result.enqueued).toBe(1);
+    expect(result.enqueueFailures).toBe(1);
+    expect(result.skippedForBacklog).toBe(0);
+    expect(result.truncatedByStop).toBe(0);
+    // Logged loudly, with the offending spec identified.
+    const dropped = errors.find(
+      (e) => e.msg === "fleet.producer.spec-invalid-probekey",
+    );
+    expect(dropped).toBeDefined();
+    expect(dropped!.meta).toMatchObject({ serviceSlug: "ghost" });
+  });
+
+  it("drops an empty-probeKey spec on a TRIGGERED tick too (gate bypass does not bypass the guard)", async () => {
+    const { producer, queue } = startedProducer({
+      specs: [GHOST_SPEC, ...d6Specs(["alpha"])],
+    });
+
+    const result = await producer.tick({ triggered: true });
+
+    expect(queue.enqueued.map((e) => e.payload.probeKey)).toEqual(["d6:alpha"]);
+    expect(result.enqueued).toBe(1);
+    expect(result.enqueueFailures).toBe(1);
+  });
+
+  it("an empty-probeKey spec is never health-warmed (the warm loop only sees validated specs)", async () => {
+    const calls: string[] = [];
+    const fetchImpl = (async (input: string | URL | Request) => {
+      calls.push(String(input));
+      return new Response(null, { status: 200 });
+    }) as typeof fetch;
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => [
+        { ...GHOST_SPEC, driverInputs: { backendUrl: "https://ghost.example.com" } },
+        ...d6Specs(["alpha"]),
+      ],
+      logger: SILENT_LOGGER,
+      warmHealth: { fetchImpl },
+    });
+    producer.start();
+    await producer.tick();
+    expect(calls).toEqual(["https://alpha.example.com/health"]);
+  });
+});
+
 describe("job-producer — failure isolation", () => {
   it("isolates a per-service enqueue failure (other services still enqueue)", async () => {
     const queue = makeFakeQueue({

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -2609,6 +2609,52 @@ describe("job-producer — lifecycle seams (start/stop/tick)", () => {
     expect(producer.isRunning()).toBe(false);
   });
 
+  it("the tick-while-stopped warn discriminates never-started from stopped-after-running", async () => {
+    // The warn meta carried only `triggered` — an operator chasing a
+    // scheduler-wiring bug could not tell whether the stray tick fired
+    // BEFORE boot wiring started the producer or AFTER a shutdown stopped
+    // it; the two point at opposite ends of the lifecycle.
+    const warnMeta = (): {
+      producer: JobProducer;
+      metas: Array<Record<string, unknown> | undefined>;
+    } => {
+      const metas: Array<Record<string, unknown> | undefined> = [];
+      const producer = createJobProducer({
+        queue: makeFakeQueue(),
+        enumerate: () => d6Specs(["a"]),
+        logger: {
+          ...SILENT_LOGGER,
+          warn: (msg, meta) => {
+            if (msg === "fleet.producer.tick-while-stopped") metas.push(meta);
+          },
+        },
+      });
+      return { producer, metas };
+    };
+
+    // Never started.
+    const before = warnMeta();
+    await before.producer.tick();
+    expect(before.metas).toHaveLength(1);
+    expect(before.metas[0]).toMatchObject({
+      triggered: false,
+      started: false,
+      stopped: false,
+    });
+
+    // Stopped after running.
+    const after = warnMeta();
+    after.producer.start();
+    await after.producer.stop();
+    await after.producer.tick();
+    expect(after.metas).toHaveLength(1);
+    expect(after.metas[0]).toMatchObject({
+      triggered: false,
+      started: true,
+      stopped: true,
+    });
+  });
+
   it("does not restart after stop() (start-after-stop is a no-op)", async () => {
     const { producer } = startedProducer({ specs: d6Specs(["a"]) });
     await producer.stop();

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -1311,6 +1311,90 @@ describe("job-producer — tick re-entrancy guard", () => {
     expect(third.enqueued).toBe(1);
     expect(queue.enqueued).toHaveLength(2);
   });
+
+  it("queues an operator-TRIGGERED tick behind the in-flight tick instead of dropping it (operator intent wins)", async () => {
+    // The guard's rationale is backpressure on SCHEDULED ticks — but it used
+    // to skip TRIGGERED ticks too, silently losing an explicit operator "run
+    // it NOW" (the CLI even treats 0 enqueued as a failure) whenever a slow
+    // scheduled tick happened to be in flight. A triggered tick that hits the
+    // guard must QUEUE BEHIND the in-flight tick and run once it completes.
+    let releaseEnumerate!: () => void;
+    const gate = new Promise<void>((resolve) => (releaseEnumerate = resolve));
+    let enumerateCalls = 0;
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: async () => {
+        enumerateCalls += 1;
+        if (enumerateCalls === 1) await gate; // only the FIRST tick is slow
+        return d6Specs(["a"]);
+      },
+      logger: SILENT_LOGGER,
+    });
+    producer.start();
+    const firstP = producer.tick(); // scheduled, blocked inside enumerate
+    await vi.waitFor(() => expect(enumerateCalls).toBe(1));
+    const triggeredP = producer.tick({ triggered: true });
+    // The triggered tick is QUEUED, not skipped: it must not resolve while
+    // the in-flight tick is still blocked.
+    let triggeredResolved = false;
+    void triggeredP.then(() => {
+      triggeredResolved = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(triggeredResolved).toBe(false);
+    releaseEnumerate();
+    const first = await firstP;
+    const triggered = await triggeredP;
+    // BOTH ticks produced — the operator's batch ran after the in-flight one.
+    expect(first.enqueued).toBe(1);
+    expect(triggered.enqueued).toBe(1);
+    expect(triggered.runId).not.toBe("");
+    expect(queue.enqueued).toHaveLength(2);
+    expect(queue.enqueued[0]!.payload.meta.triggered).toBe(false);
+    expect(queue.enqueued[1]!.payload.meta.triggered).toBe(true);
+  });
+
+  it("caps the queue-behind at ONE trigger: a second concurrent trigger gets the skip + warn", async () => {
+    // Unbounded trigger queuing would let a trigger-happy operator stack an
+    // arbitrary backlog of "run NOW" batches behind one slow tick. One queued
+    // trigger preserves the intent; a second concurrent one is dropped (the
+    // queued trigger already covers "run after the in-flight tick").
+    let releaseEnumerate!: () => void;
+    const gate = new Promise<void>((resolve) => (releaseEnumerate = resolve));
+    let enumerateCalls = 0;
+    const warns: string[] = [];
+    const logger: Logger = {
+      ...SILENT_LOGGER,
+      warn: (msg) => {
+        warns.push(msg);
+      },
+    };
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: async () => {
+        enumerateCalls += 1;
+        if (enumerateCalls === 1) await gate;
+        return d6Specs(["a"]);
+      },
+      logger,
+    });
+    producer.start();
+    const firstP = producer.tick(); // blocked inside enumerate
+    await vi.waitFor(() => expect(enumerateCalls).toBe(1));
+    const queuedP = producer.tick({ triggered: true }); // queued behind
+    const second = await producer.tick({ triggered: true }); // dropped
+    expect(second.runId).toBe("");
+    expect(second.enqueued).toBe(0);
+    expect(warns).toContain("fleet.producer.tick-overlap-skipped");
+    releaseEnumerate();
+    await firstP;
+    const queued = await queuedP;
+    expect(queued.enqueued).toBe(1);
+    // Exactly TWO batches: the in-flight tick's and the ONE queued trigger's.
+    expect(queue.enqueued).toHaveLength(2);
+  });
 });
 
 describe("job-producer — stop() quiesce", () => {

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -297,6 +297,26 @@ describe("job-producer — per-service enqueue", () => {
     expect(queue.enqueued[0]!.payload.meta.triggered).toBe(true);
   });
 
+  it("does NOT forward a filter on a scheduled tick (a scheduled tick must never be scoped)", async () => {
+    // The filter is documented trigger-only: an operator filter accidentally
+    // threaded into a scheduled (cron) tick must not scope the run.
+    const seen: Array<{ triggered: boolean; filter?: unknown }> = [];
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: (ctx) => {
+        seen.push({ triggered: ctx.triggered, filter: ctx.filter });
+        return d6Specs(["a", "b"]);
+      },
+      logger: SILENT_LOGGER,
+    });
+    producer.start();
+    await producer.tick({ filter: { slugs: ["crewai"] } }); // NOT triggered
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.triggered).toBe(false);
+    expect(seen[0]!.filter).toBeUndefined();
+  });
+
   it("enqueues nothing when the enumerator returns no services", async () => {
     const { producer, queue } = startedProducer({ specs: [] });
     const result = await producer.tick();

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -1256,6 +1256,102 @@ describe("job-producer — sweep cadence", () => {
     expect(received[0]![received[0]!.length - 1]!.jobId).toBe("fresh0");
   });
 
+  it("[REQ-B] the buffer-overflow warn identifies the dropped jobs (capped jobIds sample), like its sibling drop paths", async () => {
+    // The overflow drop is one of THREE paths that permanently lose a comm
+    // error's dashboard signal. The other two (no-sink drop, stop()-drain
+    // drop) log the dropped jobIds; the overflow warn carried only a count —
+    // an operator could see THAT signals were lost but never WHICH jobs.
+    const errs = (n: number, prefix: string): PoolCommError[] =>
+      Array.from({ length: n }, (_, i) => ({
+        kind: "worker-reclaimed-pending" as const,
+        message: "lease expired",
+        jobId: `${prefix}${i}`,
+        observedAt: "2026-06-04T00:00:09.000Z",
+      }));
+    const OVERFLOW = 5;
+    const seeded = MAX_BUFFERED_SWEEP_COMM_ERRORS + OVERFLOW;
+    const queue = makeFakeQueue({
+      sweepImpl: async () => ({
+        reclaimed: seeded,
+        commErrors: errs(seeded, "old"),
+      }),
+    });
+    const warns: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger: {
+        ...SILENT_LOGGER,
+        warn: (msg, meta) => {
+          warns.push({ msg, ...(meta !== undefined ? { meta } : {}) });
+        },
+      },
+      sweepIntervalMs: 0,
+      onSweepCommErrors: () => {
+        throw new Error("aggregator down");
+      },
+    });
+    producer.start();
+    await producer.tick();
+
+    const overflow = warns.find(
+      (w) => w.msg === "fleet.producer.sweep-commerror-buffer-overflow",
+    );
+    expect(overflow).toBeDefined();
+    expect(overflow!.meta).toMatchObject({ dropped: OVERFLOW });
+    // The DROPPED (oldest) entries' jobIds, not the survivors'.
+    expect(overflow!.meta!.jobIds).toEqual([
+      "old0",
+      "old1",
+      "old2",
+      "old3",
+      "old4",
+    ]);
+  });
+
+  it("[REQ-B] the buffer-overflow warn caps its jobIds sample (a mass drop must not flood one log line)", async () => {
+    const errs = (n: number): PoolCommError[] =>
+      Array.from({ length: n }, (_, i) => ({
+        kind: "worker-reclaimed-pending" as const,
+        message: "lease expired",
+        jobId: `old${i}`,
+        observedAt: "2026-06-04T00:00:09.000Z",
+      }));
+    const OVERFLOW = 50; // more than the sample cap
+    const queue = makeFakeQueue({
+      sweepImpl: async () => ({
+        reclaimed: MAX_BUFFERED_SWEEP_COMM_ERRORS + OVERFLOW,
+        commErrors: errs(MAX_BUFFERED_SWEEP_COMM_ERRORS + OVERFLOW),
+      }),
+    });
+    const warns: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger: {
+        ...SILENT_LOGGER,
+        warn: (msg, meta) => {
+          warns.push({ msg, ...(meta !== undefined ? { meta } : {}) });
+        },
+      },
+      sweepIntervalMs: 0,
+      onSweepCommErrors: () => {
+        throw new Error("aggregator down");
+      },
+    });
+    producer.start();
+    await producer.tick();
+
+    const overflow = warns.find(
+      (w) => w.msg === "fleet.producer.sweep-commerror-buffer-overflow",
+    );
+    expect(overflow).toBeDefined();
+    expect(overflow!.meta).toMatchObject({ dropped: OVERFLOW });
+    const jobIds = overflow!.meta!.jobIds as string[];
+    expect(jobIds.length).toBeLessThan(OVERFLOW);
+    expect(jobIds[0]).toBe("old0");
+  });
+
   it("[REQ-B] warns ONCE (with jobIds) when swept comm errors exist but no sink is configured", async () => {
     // Legacy logged-only mode drops the batch's dashboard signal with only a
     // count in the sweep-reclaimed warn. Surface the wiring gap explicitly —

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -320,6 +320,30 @@ describe("job-producer — per-family backlog dedupe", () => {
     expect(result.skippedForBacklog).toBe(0);
   });
 
+  it("runs the sweep BEFORE the backlog gate so a tick whose own sweep drains a family's stale backlog enqueues in the SAME tick", async () => {
+    // A family whose backlog consists ONLY of stale pending rows: the sweep's
+    // stale-pending drain expires all of them. If the gate runs before the
+    // sweep, the tick still counts the about-to-be-expired backlog and skips
+    // the family — production resumes a full cron period late even though
+    // this very tick cleared the blockage.
+    let pending = 3;
+    const queue = makeFakeQueue({
+      countPendingImpl: async () => pending,
+      sweepImpl: async () => {
+        pending = 0; // the stale-pending drain expired the whole backlog
+        return { reclaimed: 0, commErrors: [], expiredPending: 3 };
+      },
+    });
+    const { producer } = startedProducer({ specs: d6Specs(["a"]), queue });
+
+    const result = await producer.tick();
+
+    expect(result.sweptExpired).toBe(true);
+    expect(result.skippedForBacklog).toBe(0);
+    expect(result.enqueued).toBe(1);
+    expect(queue.enqueued).toHaveLength(1);
+  });
+
   it("fails OPEN when the backlog check itself fails (a count blip must not stop production)", async () => {
     const { producer, queue } = startedProducer({
       specs: d6Specs(["a"]),

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -1924,6 +1924,35 @@ describe("job-producer — lifecycle seams (start/stop/tick)", () => {
     expect(queue.enqueued).toHaveLength(0);
   });
 
+  it("stop() BEFORE start() is a no-op: the producer can still start afterwards (no permanent brick)", async () => {
+    // The old !running early path latched `stopped` UNCONDITIONALLY, so a
+    // stop() that raced ahead of start() (e.g. a teardown registered before
+    // boot finished wiring) permanently bricked the producer: every later
+    // start() hit the start-after-stop latch. Stop-before-start must be a
+    // no-op (debug-logged), not a one-way latch.
+    const debugEvents: string[] = [];
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger: {
+        ...SILENT_LOGGER,
+        debug: (msg) => debugEvents.push(msg),
+      },
+    });
+
+    await producer.stop(); // never started — must NOT latch `stopped`
+    expect(debugEvents).toContain("fleet.producer.stop-before-start");
+
+    producer.start();
+    expect(producer.isRunning()).toBe(true);
+    const result = await producer.tick();
+    expect(result.enqueued).toBe(1);
+
+    await producer.stop();
+    expect(producer.isRunning()).toBe(false);
+  });
+
   it("does not restart after stop() (start-after-stop is a no-op)", async () => {
     const { producer } = startedProducer({ specs: d6Specs(["a"]) });
     await producer.stop();

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -762,6 +762,36 @@ describe("job-producer — sweep cadence", () => {
     expect(result.reclaimed).toBe(2);
   });
 
+  it("surfaces the sweep's reclaimedIndeterminate split on the TickResult when the queue reports it (optional access)", async () => {
+    // The queue-client splits out reclaims whose release outcome was
+    // INDETERMINATE (a transport failure after the CAS — the at-least-once /
+    // over-report slice of `reclaimed`). Read via optional access so the
+    // producer compiles against a SweepResult that doesn't carry the split.
+    const sweepResult = {
+      reclaimed: 3,
+      commErrors: [],
+      reclaimedIndeterminate: 2,
+    } as SweepResult;
+    const { producer } = startedProducer({
+      specs: d6Specs(["a"]),
+      queue: makeFakeQueue({ sweepImpl: async () => sweepResult }),
+    });
+    const result = await producer.tick();
+    expect(result.reclaimed).toBe(3);
+    expect(result.reclaimedIndeterminate).toBe(2);
+  });
+
+  it("omits reclaimedIndeterminate when the queue's sweep result does not carry the split", async () => {
+    const { producer } = startedProducer({
+      specs: d6Specs(["a"]),
+      queue: makeFakeQueue({
+        sweepImpl: async () => ({ reclaimed: 1, commErrors: [] }),
+      }),
+    });
+    const result = await producer.tick();
+    expect(result.reclaimedIndeterminate).toBeUndefined();
+  });
+
   it("[REQ-B] forwards the swept worker-reclaimed-pending comm errors to the onSweepCommErrors sink", async () => {
     // The whole point of REQ-B: a lease-expired worker's job is reclaimed
     // (re-queued to pending) and produces a worker-reclaimed-pending comm
@@ -1691,6 +1721,47 @@ describe("job-producer — stop() quiesce", () => {
     // its first enqueue.
     expect(queued.enqueued).toBe(0);
     expect(queue.enqueued).toHaveLength(0);
+  });
+
+  it("a queued trigger that executes AFTER stop logs its own debug event, not the misleading tick-while-stopped warn", async () => {
+    // Ordering: a trigger queues behind an in-flight tick, stop() flips
+    // `running` while it waits, then the queued trigger's turn arrives. That
+    // is a NORMAL quiesce ordering the producer itself orchestrated — logging
+    // the defensive "tick-while-stopped" WARN for it pointed operators at a
+    // scheduler-wiring bug that doesn't exist. It gets a distinct debug event.
+    const warns: string[] = [];
+    const debugs: string[] = [];
+    let releaseEnumerate!: () => void;
+    const gate = new Promise<void>((resolve) => (releaseEnumerate = resolve));
+    let enumerateCalls = 0;
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: async () => {
+        enumerateCalls += 1;
+        if (enumerateCalls === 1) await gate;
+        return d6Specs(["a"]);
+      },
+      logger: {
+        ...SILENT_LOGGER,
+        warn: (msg) => warns.push(msg),
+        debug: (msg) => debugs.push(msg),
+      },
+    });
+    producer.start();
+    const firstP = producer.tick(); // blocked inside enumerate
+    await vi.waitFor(() => expect(enumerateCalls).toBe(1));
+    const queuedP = producer.tick({ triggered: true }); // queued behind
+    const stopP = producer.stop();
+    releaseEnumerate();
+    await firstP;
+    await stopP;
+    const queued = await queuedP;
+
+    expect(queued.enqueued).toBe(0);
+    expect(queued.runId).toBe("");
+    expect(debugs).toContain("fleet.producer.queued-trigger-after-stop");
+    expect(warns).not.toContain("fleet.producer.tick-while-stopped");
   });
 
   it("a tick stopped mid-batch truncates the remaining enqueues (and logs the truncation)", async () => {

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -422,6 +422,43 @@ describe("job-producer — failure isolation", () => {
     expect(result.enqueued).toBe(2);
     expect(result.reclaimed).toBe(0);
   });
+
+  it("a failing sweep is reported as sweepFailed (not a clean zero-reclaim sweep)", async () => {
+    // Pre-fix the catch arm returned the same shape as a clean sweep that
+    // reclaimed nothing — `sweptExpired: true, reclaimed: 0` — so a thrown
+    // sweep was indistinguishable from success in the TickResult / tick log.
+    const queue = makeFakeQueue({
+      sweepImpl: async () => {
+        throw new Error("sweep endpoint 500");
+      },
+    });
+    const { producer } = startedProducer({
+      specs: d6Specs(["a"]),
+      queue,
+    });
+    const result = await producer.tick();
+    // The sweep RAN (cadence window consumed) but FAILED.
+    expect(result.sweptExpired).toBe(true);
+    expect(result.sweepFailed).toBe(true);
+    expect(result.reclaimed).toBe(0);
+  });
+
+  it("a clean sweep reports sweepFailed:false (and so does a skipped sweep)", async () => {
+    let t = 0;
+    const { producer } = startedProducer({
+      specs: d6Specs(["a"]),
+      now: () => t,
+      sweepIntervalMs: 30_000,
+    });
+    t = 0;
+    const first = await producer.tick(); // sweeps (first tick), succeeds
+    expect(first.sweptExpired).toBe(true);
+    expect(first.sweepFailed).toBe(false);
+    t = 10_000; // inside the cadence window — no sweep runs
+    const second = await producer.tick();
+    expect(second.sweptExpired).toBe(false);
+    expect(second.sweepFailed).toBe(false);
+  });
 });
 
 describe("job-producer — sweep cadence", () => {

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -503,7 +503,8 @@ describe("job-producer — per-family backlog dedupe", () => {
       logger: {
         ...SILENT_LOGGER,
         info: (msg, meta) => {
-          if (msg === "fleet.producer.tick-complete") tickCompleteMeta.push(meta);
+          if (msg === "fleet.producer.tick-complete")
+            tickCompleteMeta.push(meta);
         },
       },
     });
@@ -530,7 +531,8 @@ describe("job-producer — per-family backlog dedupe", () => {
       }),
     });
     expect(
-      (await triggered.producer.tick({ triggered: true })).backlogGateFailedOpen,
+      (await triggered.producer.tick({ triggered: true }))
+        .backlogGateFailedOpen,
     ).toBe(0);
 
     const stopped = startedProducer({ specs: d6Specs(["a"]) });
@@ -735,10 +737,7 @@ describe("job-producer — phantom probeKey guard", () => {
     for (const ghost of [null, undefined, 42]) {
       const errors: string[] = [];
       const { producer, queue } = startedProducer({
-        specs: [
-          ghost as unknown as ServiceJobSpec,
-          ...d6Specs(["alpha"]),
-        ],
+        specs: [ghost as unknown as ServiceJobSpec, ...d6Specs(["alpha"])],
         logger: {
           ...SILENT_LOGGER,
           error: (msg) => {
@@ -786,7 +785,10 @@ describe("job-producer — phantom probeKey guard", () => {
     const producer = createJobProducer({
       queue,
       enumerate: () => [
-        { ...GHOST_SPEC, driverInputs: { backendUrl: "https://ghost.example.com" } },
+        {
+          ...GHOST_SPEC,
+          driverInputs: { backendUrl: "https://ghost.example.com" },
+        },
         ...d6Specs(["alpha"]),
       ],
       logger: SILENT_LOGGER,

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -719,6 +719,7 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
     // restoreAllMocks does NOT undo vi.stubGlobal — a leaked global fetch stub
     // poisons unrelated files under fork-reuse (repo discipline).
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   /** A fetch spy that records each warm URL and resolves a 200. */
@@ -819,6 +820,83 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
     const result = await producer.tick();
     // Production proceeded despite every warm GET rejecting.
     expect(result.enqueued).toBe(2);
+  });
+
+  it("a SYNCHRONOUSLY-throwing warm fetch never aborts the tick (per-spec dispatch is isolated)", async () => {
+    // An injected fetchImpl that throws synchronously (not a rejected promise)
+    // must not escape the warm loop and abort the whole tick before any job
+    // is enqueued — warm-up must NEVER block or fail job production.
+    const fetchImpl = (() => {
+      throw new Error("sync EINVAL from fetch impl");
+    }) as unknown as typeof fetch;
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["alpha", "beta"]),
+      logger: SILENT_LOGGER,
+      warmHealth: { fetchImpl },
+    });
+    producer.start();
+    const result = await producer.tick();
+    expect(result.enqueued).toBe(2);
+    expect(queue.enqueued).toHaveLength(2);
+  });
+
+  it("aborts a hanging warm GET once the timeout elapses (AbortController path)", async () => {
+    vi.useFakeTimers();
+    let abortedCount = 0;
+    // A fetch that never settles until its signal aborts — models a hung cold
+    // container that would otherwise pin the request forever.
+    const fetchImpl = ((
+      _input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          abortedCount += 1;
+          reject(new Error("aborted"));
+        });
+      })) as typeof fetch;
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["alpha"]),
+      logger: SILENT_LOGGER,
+      warmHealth: { fetchImpl, timeoutMs: 1_000 },
+    });
+    producer.start();
+    const result = await producer.tick();
+    // The hung GET never blocked production…
+    expect(result.enqueued).toBe(1);
+    expect(abortedCount).toBe(0);
+    // …and the timeout reaps it.
+    vi.advanceTimersByTime(1_000);
+    expect(abortedCount).toBe(1);
+  });
+
+  it("consumes (cancels) the warm response body so an unread body can't pin the socket", async () => {
+    let cancelled = 0;
+    const fetchImpl = (async (): Promise<Response> => {
+      const body = new ReadableStream<Uint8Array>({
+        cancel() {
+          cancelled += 1;
+        },
+      });
+      return new Response(body, { status: 200 });
+    }) as typeof fetch;
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["alpha"]),
+      logger: SILENT_LOGGER,
+      warmHealth: { fetchImpl },
+    });
+    producer.start();
+    await producer.tick();
+    // The .then success handler runs on a later microtask than tick's return —
+    // yield so the fire-and-forget chain settles.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(cancelled).toBe(1);
   });
 
   it("skips specs with no backendUrl (no bogus warm GET)", async () => {

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -1445,6 +1445,86 @@ describe("job-producer — stop() quiesce", () => {
     expect(stopResolved).toBe(true);
   });
 
+  it("a SECOND concurrent stop() also awaits the in-flight tick (no early-return without quiescing)", async () => {
+    // The first stop() flips `running` synchronously, so a second concurrent
+    // stop() used to hit the !running early-return and resolve IMMEDIATELY —
+    // while the tick the first stop() was quiescing on kept enqueueing. For
+    // that second caller, "stopped" was a lie: a shutdown sequence racing two
+    // stop() calls could tear down the queue under a still-writing tick.
+    let releaseEnqueue!: () => void;
+    const gate = new Promise<void>((resolve) => (releaseEnqueue = resolve));
+    const queue = makeFakeQueue({
+      enqueueImpl: async (input) => {
+        await gate;
+        return jobView(input);
+      },
+    });
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger: SILENT_LOGGER,
+    });
+    producer.start();
+    const tickP = producer.tick();
+    await vi.waitFor(() => {
+      expect(queue.enqueued).toHaveLength(1); // tick reached the gated enqueue
+    });
+    const stop1 = producer.stop(); // flips running=false, quiesces
+    let stop2Resolved = false;
+    const stop2 = producer.stop().then(() => {
+      stop2Resolved = true;
+    });
+    // Give the second stop() every chance to (incorrectly) resolve early.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(stop2Resolved).toBe(false);
+    releaseEnqueue();
+    await tickP;
+    await stop1;
+    await stop2;
+    expect(stop2Resolved).toBe(true);
+  });
+
+  it("a concurrent stop() awaits the QUEUED trigger too (the queued trigger cannot outlive stop())", async () => {
+    // A triggered tick queued behind the in-flight one (see the re-entrancy
+    // guard) is part of the producer's outstanding work: stop() resolving
+    // while the queued trigger is still waiting would let it observe the
+    // stopped producer only via its own skipped runTick — fine — but a stop()
+    // that doesn't await it at all cannot guarantee even that ordering.
+    let releaseEnumerate!: () => void;
+    const gate = new Promise<void>((resolve) => (releaseEnumerate = resolve));
+    let enumerateCalls = 0;
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: async () => {
+        enumerateCalls += 1;
+        if (enumerateCalls === 1) await gate;
+        return d6Specs(["a"]);
+      },
+      logger: SILENT_LOGGER,
+    });
+    producer.start();
+    const firstP = producer.tick(); // blocked inside enumerate
+    await vi.waitFor(() => expect(enumerateCalls).toBe(1));
+    const queuedP = producer.tick({ triggered: true }); // queued behind
+    let queuedResolved = false;
+    void queuedP.then(() => {
+      queuedResolved = true;
+    });
+    const stopP = producer.stop();
+    releaseEnumerate();
+    await firstP;
+    await stopP;
+    // stop() resolved only AFTER the queued trigger fully unwound.
+    expect(queuedResolved).toBe(true);
+    const queued = await queuedP;
+    // The queued trigger observed the stop and produced nothing — and the
+    // first tick, released after stop flipped `running`, truncated before
+    // its first enqueue.
+    expect(queued.enqueued).toBe(0);
+    expect(queue.enqueued).toHaveLength(0);
+  });
+
   it("a tick stopped mid-batch truncates the remaining enqueues (and logs the truncation)", async () => {
     let releaseEnqueue!: () => void;
     const gate = new Promise<void>((resolve) => (releaseEnqueue = resolve));

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -16,6 +16,10 @@ import type {
   PoolCommError,
   SweepResult,
 } from "../contracts.js";
+import {
+  createFleetQueueClient,
+  PoisonedBacklogCountError,
+} from "../queue-client.js";
 import type { Logger } from "../../types/index.js";
 
 /**
@@ -489,9 +493,7 @@ describe("job-producer — per-family backlog dedupe", () => {
       specs: d6Specs(["a", "b"]),
       queue: makeFakeQueue({
         countPendingImpl: async () => {
-          throw new Error(
-            'queue-client: countPendingForFamily("d6") received a non-count totalItems (-1) despite skipTotal:false — refusing to fail the backlog gate open',
-          );
+          throw new PoisonedBacklogCountError("d6", -1);
         },
       }),
       logger: {
@@ -521,9 +523,7 @@ describe("job-producer — per-family backlog dedupe", () => {
       queue: makeFakeQueue({
         countPendingImpl: async (family) => {
           if (family === "d6") {
-            throw new Error(
-              "refusing to fail the backlog gate open (poisoned totalItems)",
-            );
+            throw new PoisonedBacklogCountError("d6", -1);
           }
           throw new Error("transient PB count blip");
         },
@@ -537,6 +537,88 @@ describe("job-producer — per-family backlog dedupe", () => {
       "e2e-demos:a",
     ]);
     expect(result.enqueued).toBe(1);
+    expect(result.skippedForBacklog).toBe(1);
+  });
+
+  it("fail-closed keys on the error CLASS, not message text — a reworded refusal still fails closed (drift guard)", async () => {
+    // The old gate matched a message substring copied from queue-client.ts.
+    // Any rewording of that message silently flipped this fail-closed class
+    // into the generic fail-open catch — the exact silent-fail-open hole the
+    // refusal exists to close. The class is the contract; pin it by throwing
+    // a PoisonedBacklogCountError whose message has fully drifted.
+    const drifted = new PoisonedBacklogCountError("d6", -1);
+    drifted.message = "completely reworded refusal text with no marker phrase";
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a"]),
+      queue: makeFakeQueue({
+        countPendingImpl: async () => {
+          throw drifted;
+        },
+      }),
+    });
+
+    const result = await producer.tick();
+
+    expect(queue.enqueued).toHaveLength(0);
+    expect(result.enqueued).toBe(0);
+    expect(result.skippedForBacklog).toBe(1);
+  });
+
+  it("the REAL queue-client poisoned-count refusal fails the gate closed end-to-end (no test-literal drift)", async () => {
+    // Integration drift guard: drive the producer's gate through the REAL
+    // createFleetQueueClient refusal (a backend returning totalItems -1
+    // despite skipTotal:false) instead of a hand-copied error literal — so
+    // a change to the refusal's class or construction breaks THIS test
+    // rather than silently failing the gate open in production.
+    const enqueued: EnqueueJobInput[] = [];
+    const fakePb = {
+      async list() {
+        return {
+          page: 1,
+          perPage: 1,
+          totalPages: -1,
+          totalItems: -1, // the poisoned non-count despite skipTotal:false
+          items: [],
+        };
+      },
+      async create(_c: string, record: Record<string, unknown>) {
+        enqueued.push({ payload: record.payload as never });
+        return record;
+      },
+      async getOne() {
+        return null;
+      },
+      async update() {
+        throw new Error("not used");
+      },
+      async delete() {
+        throw new Error("not used");
+      },
+    } as unknown as import("../../storage/pb-client.js").PbClient;
+    const realQueue = createFleetQueueClient({
+      pb: fakePb,
+      claim: {
+        claimJob: async () => ({ won: false }),
+        renewLease: async () => ({ renewed: false }),
+        releaseJob: async () => ({ released: false }),
+      },
+      logger: SILENT_LOGGER,
+      // Disable the stale-pending drain so the producer's first-tick sweep
+      // doesn't consume the fake's list responses (this test pins the GATE).
+      stalePending: { expiryPeriods: 0 },
+    });
+    const producer = createJobProducer({
+      queue: realQueue,
+      enumerate: () => d6Specs(["a"]),
+      logger: SILENT_LOGGER,
+      sweepIntervalMs: Number.MAX_SAFE_INTEGER,
+    });
+    producer.start();
+
+    const result = await producer.tick();
+
+    expect(enqueued).toHaveLength(0);
+    expect(result.enqueued).toBe(0);
     expect(result.skippedForBacklog).toBe(1);
   });
 });

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -1869,6 +1869,67 @@ describe("job-producer — stop() quiesce", () => {
     expect(dropLog).toBeDefined();
     expect(dropLog!.meta).toMatchObject({ dropped: 1, jobIds: ["j1"] });
   });
+
+  it("a SECOND concurrent stop() does not resolve before the FIRST stop's final comm-error drain completes", async () => {
+    // The secondary stop() path used to await only the in-flight tick /
+    // queued trigger — with neither in flight it returned IMMEDIATELY, while
+    // the primary stop() was still mid final-drain (awaiting the sink). A
+    // shutdown sequenced on the second stop() could then tear the aggregator
+    // down under the still-delivering drain. EVERY stop() resolution must
+    // imply the drain finished — both paths share one stop completion.
+    const queue = makeFakeQueue({
+      sweepImpl: async () => ({
+        reclaimed: 1,
+        commErrors: [
+          {
+            kind: "worker-reclaimed-pending",
+            message: "lease for job j1 expired; re-queued",
+            jobId: "j1",
+            observedAt: "2026-06-04T00:00:09.000Z",
+          },
+        ],
+      }),
+    });
+    let releaseDrain!: () => void;
+    const drainGate = new Promise<void>((resolve) => {
+      releaseDrain = resolve;
+    });
+    let sinkCalls = 0;
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger: SILENT_LOGGER,
+      onSweepCommErrors: async () => {
+        sinkCalls += 1;
+        if (sinkCalls === 1) throw new Error("aggregator down"); // buffer j1
+        await drainGate; // the stop()-drain delivery hangs until released
+      },
+    });
+    producer.start();
+    await producer.tick(); // sink fails — j1 buffered
+
+    const first = producer.stop(); // primary: quiesce + (gated) final drain
+    const second = producer.stop(); // concurrent secondary
+    let firstResolved = false;
+    let secondResolved = false;
+    void first.then(() => {
+      firstResolved = true;
+    });
+    void second.then(() => {
+      secondResolved = true;
+    });
+
+    // Let microtasks settle: the drain is gated, so NEITHER stop may resolve.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(sinkCalls).toBe(2); // the drain delivery is in flight
+    expect(firstResolved).toBe(false);
+    expect(secondResolved).toBe(false);
+
+    releaseDrain();
+    await Promise.all([first, second]);
+    expect(firstResolved).toBe(true);
+    expect(secondResolved).toBe(true);
+  });
 });
 
 describe("job-producer — lifecycle seams (start/stop/tick)", () => {

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -42,16 +42,26 @@ const SILENT_LOGGER: Logger = {
 function makeFakeQueue(opts?: {
   enqueueImpl?: (input: EnqueueJobInput) => Promise<JobView>;
   sweepImpl?: (nowMs: number) => Promise<SweepResult>;
+  /** Pending-count per family for the backlog dedupe gate; default 0 (clear). */
+  countPendingImpl?: (family: string) => Promise<number>;
 }): FleetQueueClient & {
   enqueued: EnqueueJobInput[];
   sweepCalls: number[];
+  countCalls: string[];
 } {
   const enqueued: EnqueueJobInput[] = [];
   const sweepCalls: number[] = [];
+  const countCalls: string[] = [];
   let jobSeq = 0;
   return {
     enqueued,
     sweepCalls,
+    countCalls,
+    async countPendingForFamily(family: string): Promise<number> {
+      countCalls.push(family);
+      if (opts?.countPendingImpl) return opts.countPendingImpl(family);
+      return 0;
+    },
     async enqueue(input: EnqueueJobInput): Promise<JobView> {
       enqueued.push(input);
       if (opts?.enqueueImpl) return opts.enqueueImpl(input);
@@ -230,6 +240,101 @@ describe("job-producer — per-service enqueue", () => {
     const result = await producer.tick();
     expect(result.enqueued).toBe(0);
     expect(queue.enqueued).toHaveLength(0);
+  });
+});
+
+describe("job-producer — per-family backlog dedupe", () => {
+  // ── ROOT CAUSE (verified in prod + staging) ─────────────────────────────
+  // Every scheduled tick enqueued a FRESH batch regardless of whether the
+  // family's PREVIOUS batch had even been claimed — with 2 serial browser
+  // workers against ~180 jobs/hr of inflow the backlog compounded without
+  // bound (staging: 3,734 pending, oldest 22h). A scheduled tick must SKIP
+  // its family's batch when that family already has pending (unclaimed)
+  // jobs, bounding the per-family backlog to one batch.
+
+  it("skips the whole batch when the family already has a pending backlog (scheduled tick)", async () => {
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a", "b", "c"]),
+      queue: makeFakeQueue({ countPendingImpl: async () => 4 }),
+    });
+
+    const result = await producer.tick();
+
+    expect(queue.countCalls).toEqual(["d6"]);
+    expect(queue.enqueued).toHaveLength(0);
+    expect(result.enqueued).toBe(0);
+    expect(result.enqueueFailures).toBe(0);
+    expect(result.skippedForBacklog).toBe(3);
+  });
+
+  it("enqueues normally when the family has no pending backlog", async () => {
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a", "b"]),
+      queue: makeFakeQueue({ countPendingImpl: async () => 0 }),
+    });
+
+    const result = await producer.tick();
+
+    expect(queue.enqueued).toHaveLength(2);
+    expect(result.enqueued).toBe(2);
+    expect(result.skippedForBacklog).toBe(0);
+  });
+
+  it("gates each family independently when a tick spans multiple families", async () => {
+    const specs: ServiceJobSpec[] = [
+      ...d6Specs(["a"]),
+      {
+        probeKey: "e2e-demos:a",
+        serviceSlug: "a",
+        driverKind: "e2e_demos",
+      },
+    ];
+    const { producer, queue } = startedProducer({
+      specs,
+      queue: makeFakeQueue({
+        countPendingImpl: async (family) => (family === "d6" ? 7 : 0),
+      }),
+    });
+
+    const result = await producer.tick();
+
+    // d6 is backlogged (skipped); e2e-demos is clear (enqueued).
+    expect(queue.enqueued.map((e) => e.payload.probeKey)).toEqual([
+      "e2e-demos:a",
+    ]);
+    expect(result.enqueued).toBe(1);
+    expect(result.skippedForBacklog).toBe(1);
+  });
+
+  it("operator-triggered ticks BYPASS the backlog gate (explicit intent wins)", async () => {
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a", "b"]),
+      queue: makeFakeQueue({ countPendingImpl: async () => 99 }),
+    });
+
+    const result = await producer.tick({ triggered: true });
+
+    expect(queue.countCalls).toEqual([]);
+    expect(queue.enqueued).toHaveLength(2);
+    expect(result.enqueued).toBe(2);
+    expect(result.skippedForBacklog).toBe(0);
+  });
+
+  it("fails OPEN when the backlog check itself fails (a count blip must not stop production)", async () => {
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a"]),
+      queue: makeFakeQueue({
+        countPendingImpl: async () => {
+          throw new Error("transient PB count blip");
+        },
+      }),
+    });
+
+    const result = await producer.tick();
+
+    expect(queue.enqueued).toHaveLength(1);
+    expect(result.enqueued).toBe(1);
+    expect(result.skippedForBacklog).toBe(0);
   });
 });
 

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -762,6 +762,48 @@ describe("job-producer — sweep cadence", () => {
     expect(received[0]!.map((e) => e.jobId)).toEqual(["j1", "j2"]);
   });
 
+  it("[REQ-B] drains the buffered batch even when the CURRENT sweep throws (a failing sweep must not starve a healthy sink)", async () => {
+    // The buffer exists precisely to ride out transient failures — but the
+    // drain used to live inside maybeSweep's try SUCCESS path, so a
+    // persistently-throwing sweepExpired (the exact failure mode the buffer
+    // rides out) never handed the buffered batch to a now-healthy sink.
+    // Tick 1: sweep succeeds, sink throws → j1 buffered. Tick 2: sweep
+    // THROWS, sink healthy → j1 must still be delivered.
+    const err = (jobId: string): PoolCommError => ({
+      kind: "worker-reclaimed-pending",
+      message: `lease for job ${jobId} expired; re-queued`,
+      jobId,
+      observedAt: "2026-06-04T00:00:09.000Z",
+    });
+    let sweepN = 0;
+    const queue = makeFakeQueue({
+      sweepImpl: async () => {
+        sweepN += 1;
+        if (sweepN === 1) return { reclaimed: 1, commErrors: [err("j1")] };
+        throw new Error("sweep endpoint 500");
+      },
+    });
+    const received: PoolCommError[][] = [];
+    let sinkCalls = 0;
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger: SILENT_LOGGER,
+      sweepIntervalMs: 0, // sweep every tick
+      onSweepCommErrors: (errs) => {
+        sinkCalls += 1;
+        if (sinkCalls === 1) throw new Error("aggregator down");
+        received.push(errs);
+      },
+    });
+    producer.start();
+    await producer.tick(); // sweep ok, sink fails — j1 buffered
+    const second = await producer.tick(); // sweep throws, sink healthy
+    expect(second.sweepFailed).toBe(true);
+    expect(received).toHaveLength(1);
+    expect(received[0]!.map((e) => e.jobId)).toEqual(["j1"]);
+  });
+
   it("[REQ-B] caps the undelivered buffer at MAX_BUFFERED_SWEEP_COMM_ERRORS, dropping oldest", async () => {
     const errs = (n: number, prefix: string): PoolCommError[] =>
       Array.from({ length: n }, (_, i) => ({

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -4,7 +4,11 @@ import {
   DEFAULT_SWEEP_INTERVAL_MS,
   MAX_BUFFERED_SWEEP_COMM_ERRORS,
 } from "./job-producer.js";
-import type { JobProducer, ServiceJobSpec } from "./job-producer.js";
+import type {
+  JobProducer,
+  ServiceJobSpec,
+  TickResult,
+} from "./job-producer.js";
 import type {
   EnqueueJobInput,
   FleetQueueClient,
@@ -46,6 +50,11 @@ function makeFakeQueue(opts?: {
   /** Pending-count per family for the backlog dedupe gate; default 0 (clear). */
   countPendingImpl?: (family: string) => Promise<number>;
 }): FleetQueueClient & {
+  /**
+   * Every enqueue ATTEMPT, recorded BEFORE a throwing `enqueueImpl` gets to
+   * reject — so for failure-injection tests this is attempts, not successful
+   * enqueues (`queue.enqueued.length` can exceed `result.enqueued`).
+   */
   enqueued: EnqueueJobInput[];
   sweepCalls: number[];
   countCalls: string[];
@@ -859,13 +868,17 @@ describe("job-producer — sweep cadence", () => {
         jobId: `${prefix}${i}`,
         observedAt: "2026-06-04T00:00:09.000Z",
       }));
+    // Derived from the cap so a retuned MAX_BUFFERED_SWEEP_COMM_ERRORS can't
+    // silently turn this into a no-overflow (vacuously green) test.
+    const OVERFLOW = 100;
+    const seeded = MAX_BUFFERED_SWEEP_COMM_ERRORS + OVERFLOW;
     let sweepN = 0;
     const queue = makeFakeQueue({
       sweepImpl: async () => {
         sweepN += 1;
         // Tick 1 reclaims more than the cap; tick 2 reclaims one more.
         return sweepN === 1
-          ? { reclaimed: 600, commErrors: errs(600, "old") }
+          ? { reclaimed: seeded, commErrors: errs(seeded, "old") }
           : { reclaimed: 1, commErrors: errs(1, "fresh") };
       },
     });
@@ -883,12 +896,13 @@ describe("job-producer — sweep cadence", () => {
       },
     });
     producer.start();
-    await producer.tick(); // 600 buffered → trimmed to newest 500
-    await producer.tick(); // delivers 500 buffered + 1 fresh
+    await producer.tick(); // `seeded` buffered → trimmed to the newest cap-ful
+    await producer.tick(); // delivers the capped buffer + 1 fresh
     expect(received).toHaveLength(1);
     expect(received[0]).toHaveLength(MAX_BUFFERED_SWEEP_COMM_ERRORS + 1);
-    // Oldest 100 dropped: the buffer starts at old100, ends with the fresh one.
-    expect(received[0]![0]!.jobId).toBe("old100");
+    // The OVERFLOW oldest entries were dropped: the buffer starts at the
+    // first surviving entry, ends with the fresh one.
+    expect(received[0]![0]!.jobId).toBe(`old${OVERFLOW}`);
     expect(received[0]![received[0]!.length - 1]!.jobId).toBe("fresh0");
   });
 
@@ -1151,6 +1165,11 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
   });
 
   it("aborts a hanging warm GET once the timeout elapses (AbortController path)", async () => {
+    // COUPLING PIN: this test (and the implementation) depend on the warm
+    // timeout being an AbortController + setTimeout pair. Do NOT "simplify"
+    // the implementation to AbortSignal.timeout() — its timer lives outside
+    // vitest's fake-timer patching, so advanceTimersByTime below would never
+    // fire the abort and this test would hang/fail for the wrong reason.
     vi.useFakeTimers();
     let abortedCount = 0;
     // A fetch that never settles until its signal aborts — models a hung cold
@@ -1363,7 +1382,27 @@ describe("job-producer — tick re-entrancy guard", () => {
     });
     producer.start();
     const firstP = producer.tick(); // blocked inside enumerate
-    const second = await producer.tick(); // the overlapping cron tick
+    // The overlapping cron tick. Raced against a short timer so a broken
+    // guard fails DIAGNOSTICALLY: an un-skipped second tick would await the
+    // same enumerate gate and deadlock the test into its global timeout.
+    let raceTimer!: ReturnType<typeof setTimeout>;
+    const notSkipped = new Promise<never>((_resolve, reject) => {
+      raceTimer = setTimeout(
+        () =>
+          reject(
+            new Error(
+              "overlapping scheduled tick was not skipped — it ran (and hung on the enumerate gate) instead of returning the skip sentinel",
+            ),
+          ),
+        1_000,
+      );
+    });
+    let second: TickResult;
+    try {
+      second = await Promise.race([producer.tick(), notSkipped]);
+    } finally {
+      clearTimeout(raceTimer); // the loser must not fire as an unhandled rejection
+    }
     // The overlapping tick is SKIPPED — no second batch, no phantom runId.
     expect(second.enqueued).toBe(0);
     expect(second.runId).toBe("");

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -2109,3 +2109,121 @@ describe("job-producer — lifecycle seams (start/stop/tick)", () => {
     expect(reportSpy).not.toHaveBeenCalled();
   });
 });
+
+describe("job-producer — throwing-logger hardening", () => {
+  // The documented invariant at `inFlightTick` — "a tick promise never
+  // rejects" — must hold even when the injected logger's TRANSPORT throws:
+  // the warm chain already hardens for this failure mode (its terminal
+  // .catch), but an unguarded logger.* call in the tick body rejected the
+  // tick promise, and one inside stop()'s completion permanently POISONED
+  // stopPromise (re-thrown to every later stop() caller). Logging is
+  // observability, never a correctness gate.
+
+  /** Every method throws — models a logger whose transport is down. */
+  function makeThrowingLogger(): Logger {
+    const boom = () => {
+      throw new Error("logger transport down");
+    };
+    return { info: boom, warn: boom, error: boom, debug: boom };
+  }
+
+  it("a throwing logger never rejects the tick promise (happy path)", async () => {
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["alpha"]),
+      logger: makeThrowingLogger(),
+    });
+    producer.start();
+    const result = await producer.tick(); // must resolve, not reject
+    expect(result.enqueued).toBe(1);
+    expect(queue.enqueued).toHaveLength(1);
+  });
+
+  it("a throwing logger never rejects the tick promise on the enumerate-failed path", async () => {
+    const producer = createJobProducer({
+      queue: makeFakeQueue(),
+      enumerate: () => {
+        throw new Error("discovery down");
+      },
+      logger: makeThrowingLogger(),
+    });
+    producer.start();
+    const result = await producer.tick(); // logger.error in the catch throws
+    expect(result.enumerateFailed).toBe(true);
+    expect(result.enqueued).toBe(0);
+  });
+
+  it("a throwing logger never rejects the tick promise on the enqueue-failed path", async () => {
+    const queue = makeFakeQueue({
+      enqueueImpl: async () => {
+        throw new Error("PB down");
+      },
+    });
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["alpha"]),
+      logger: makeThrowingLogger(),
+    });
+    producer.start();
+    const result = await producer.tick();
+    expect(result.enqueueFailures).toBe(1);
+  });
+
+  it("a throwing logger never rejects a tick that arrives outside the lifecycle", async () => {
+    const producer = createJobProducer({
+      queue: makeFakeQueue(),
+      enumerate: () => d6Specs(["alpha"]),
+      logger: makeThrowingLogger(),
+    });
+    // Never started — the tick-while-stopped warn throws.
+    const result = await producer.tick();
+    expect(result.runId).toBe("");
+  });
+
+  it("a throwing logger in stop() does not poison stopPromise (every stop() caller resolves)", async () => {
+    const producer = createJobProducer({
+      queue: makeFakeQueue(),
+      enumerate: () => d6Specs(["alpha"]),
+      logger: makeThrowingLogger(),
+    });
+    producer.start();
+    await producer.tick();
+    // The primary stop()'s trailing logger.info throws inside the shared
+    // completion — without hardening that rejects stopPromise FOREVER.
+    await expect(producer.stop()).resolves.toBeUndefined();
+    // A later stop() shares stopPromise: it must not re-throw.
+    await expect(producer.stop()).resolves.toBeUndefined();
+  });
+
+  it("a throwing logger in the final-drain catch does not poison stopPromise", async () => {
+    // Buffered comm errors whose final-drain delivery ALSO fails route
+    // through the dropped-loudly logger.error — a throw there must not
+    // reject stop().
+    const queue = makeFakeQueue({
+      sweepImpl: async () => ({
+        reclaimed: 1,
+        commErrors: [
+          {
+            kind: "worker-reclaimed-pending",
+            message: "lease for job j1 expired; re-queued",
+            jobId: "j1",
+            observedAt: "2026-06-04T00:00:09.000Z",
+          },
+        ],
+      }),
+    });
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["alpha"]),
+      logger: makeThrowingLogger(),
+      onSweepCommErrors: () => {
+        throw new Error("aggregator down for good");
+      },
+    });
+    producer.start();
+    await producer.tick(); // sink fails — j1 buffered
+    await expect(producer.stop()).resolves.toBeUndefined();
+    await expect(producer.stop()).resolves.toBeUndefined();
+  });
+});

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -1808,6 +1808,120 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
     await producer.tick();
     expect(calls).toHaveLength(0);
   });
+
+  it("logs a per-spec warm-skipped debug naming the slug and the skip reason (missing vs malformed backendUrl)", async () => {
+    // A warm-configured deployment whose enumerator stopped threading
+    // backendUrl (or threads a garbage one) silently lost ALL warm coverage
+    // — the skips left no trace at any level. Each skip names its spec and
+    // why, so the gap is greppable.
+    const debugs: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const { fetchImpl, calls } = makeFetchSpy();
+    const producer = createJobProducer({
+      queue: makeFakeQueue(),
+      enumerate: () => [
+        {
+          probeKey: "d6:nourl",
+          serviceSlug: "nourl",
+          driverKind: "e2e_d6",
+          // no driverInputs.backendUrl → "missing"
+        },
+        {
+          probeKey: "d6:badurl",
+          serviceSlug: "badurl",
+          driverKind: "e2e_d6",
+          // unparseable URL → deriveHealthUrl("") → "malformed"
+          driverInputs: { backendUrl: "::::not-a-url" },
+        },
+        ...d6Specs(["alpha"]), // still warmable — no zero-warmable warn
+      ],
+      logger: {
+        ...SILENT_LOGGER,
+        debug: (msg, meta) => {
+          if (msg === "fleet.producer.warm-skipped")
+            debugs.push({ msg, ...(meta !== undefined ? { meta } : {}) });
+        },
+      },
+      warmHealth: { fetchImpl },
+    });
+    producer.start();
+    await producer.tick();
+
+    expect(calls).toHaveLength(1); // alpha still warmed
+    expect(debugs).toHaveLength(2);
+    expect(debugs[0]!.meta).toMatchObject({
+      serviceSlug: "nourl",
+      reason: "missing-backendUrl",
+    });
+    expect(debugs[1]!.meta).toMatchObject({
+      serviceSlug: "badurl",
+      reason: "malformed-backendUrl",
+    });
+  });
+
+  it("warns ONCE per tick when warmHealth is configured but ZERO of N specs are warmable", async () => {
+    // The per-spec skips are debug-level; a tick where NOTHING could be
+    // warmed despite warm-up being configured is a wiring regression worth
+    // a warn (the #72 cold-start mitigation is silently inert).
+    const warns: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const { fetchImpl, calls } = makeFetchSpy();
+    const producer = createJobProducer({
+      queue: makeFakeQueue(),
+      enumerate: () => [
+        { probeKey: "d6:a", serviceSlug: "a", driverKind: "e2e_d6" },
+        { probeKey: "d6:b", serviceSlug: "b", driverKind: "e2e_d6" },
+      ],
+      logger: {
+        ...SILENT_LOGGER,
+        warn: (msg, meta) => {
+          if (msg === "fleet.producer.warm-none-warmable")
+            warns.push({ msg, ...(meta !== undefined ? { meta } : {}) });
+        },
+      },
+      warmHealth: { fetchImpl },
+    });
+    producer.start();
+    await producer.tick();
+
+    expect(calls).toHaveLength(0);
+    expect(warns).toHaveLength(1);
+    expect(warns[0]!.meta).toMatchObject({ services: 2 });
+  });
+
+  it("does NOT warn zero-warmable on an empty tick or when at least one spec warms", async () => {
+    const warns: string[] = [];
+    const logger: Logger = {
+      ...SILENT_LOGGER,
+      warn: (msg) => {
+        warns.push(msg);
+      },
+    };
+    const { fetchImpl } = makeFetchSpy();
+
+    // Empty enumeration: nothing to warm is not a warm-coverage gap.
+    const empty = createJobProducer({
+      queue: makeFakeQueue(),
+      enumerate: () => [],
+      logger,
+      warmHealth: { fetchImpl },
+    });
+    empty.start();
+    await empty.tick();
+
+    // Mixed: one warmable spec means coverage is not zero.
+    const mixed = createJobProducer({
+      queue: makeFakeQueue(),
+      enumerate: () => [
+        { probeKey: "d6:nourl", serviceSlug: "nourl", driverKind: "e2e_d6" },
+        ...d6Specs(["alpha"]),
+      ],
+      logger,
+      warmHealth: { fetchImpl },
+    });
+    mixed.start();
+    await mixed.tick();
+
+    expect(warns).not.toContain("fleet.producer.warm-none-warmable");
+  });
 });
 
 describe("job-producer — default run-id factory", () => {

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -1107,6 +1107,49 @@ describe("job-producer — default run-id factory", () => {
   });
 });
 
+describe("job-producer — tick re-entrancy guard", () => {
+  it("skips a tick that arrives while a previous tick is still in flight (gate-TOCTOU double-enqueue)", async () => {
+    // A slow tick (sluggish enumerate/PB) overlapping the next cron tick
+    // double-enqueued the same family: both ticks read the backlog gate's
+    // pending count BEFORE either had enqueued (classic TOCTOU), so both
+    // saw "no backlog" and both produced a batch — the exact concurrent
+    // same-service overlap the gate exists to prevent.
+    let releaseEnumerate!: () => void;
+    const gate = new Promise<void>((resolve) => (releaseEnumerate = resolve));
+    const warns: string[] = [];
+    const logger: Logger = {
+      ...SILENT_LOGGER,
+      warn: (msg) => {
+        warns.push(msg);
+      },
+    };
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: async () => {
+        await gate;
+        return d6Specs(["a"]);
+      },
+      logger,
+    });
+    producer.start();
+    const firstP = producer.tick(); // blocked inside enumerate
+    const second = await producer.tick(); // the overlapping cron tick
+    // The overlapping tick is SKIPPED — no second batch, no phantom runId.
+    expect(second.enqueued).toBe(0);
+    expect(second.runId).toBe("");
+    expect(warns).toContain("fleet.producer.tick-overlap-skipped");
+    releaseEnumerate();
+    const first = await firstP;
+    expect(first.enqueued).toBe(1);
+    expect(queue.enqueued).toHaveLength(1); // exactly ONE batch was produced
+    // The guard releases once the slow tick completes.
+    const third = await producer.tick();
+    expect(third.enqueued).toBe(1);
+    expect(queue.enqueued).toHaveLength(2);
+  });
+});
+
 describe("job-producer — stop() quiesce", () => {
   /** A JobView for the fake enqueueImpl gates below. */
   function jobView(input: EnqueueJobInput): JobView {

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -179,7 +179,6 @@ describe("job-producer — per-service enqueue", () => {
           cellIds: ["shared-state"],
           driverInputs: { backendUrl: "https://lg.example.com" },
           priority: 5,
-          leaseSeconds: 600,
         },
       ],
     });
@@ -193,7 +192,6 @@ describe("job-producer — per-service enqueue", () => {
       backendUrl: "https://lg.example.com",
     });
     expect(input.payload.meta.priority).toBe(5);
-    expect(input.leaseSeconds).toBe(600);
   });
 
   it("stamps ServiceJobMeta.enqueuedAt from the injected clock", async () => {

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -947,6 +947,43 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
   });
 });
 
+describe("job-producer — default run-id factory", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("two producers created back-to-back never collide for equal (timestamp, counter)", async () => {
+    // Four producers each get an INDEPENDENT default factory with its counter
+    // starting at 0 — same-ms ticks with equal counts used to produce the SAME
+    // id, and the aggregator groups by meta.runId. Pin the clock so both
+    // producers see an identical (ts, counter) pair; the per-factory random
+    // discriminator must still keep the ids distinct.
+    vi.spyOn(Date, "now").mockReturnValue(1_765_000_000_000);
+    vi.spyOn(Math, "random")
+      .mockReturnValueOnce(0.1234567)
+      .mockReturnValueOnce(0.7654321);
+    const make = () => {
+      const producer = createJobProducer({
+        queue: makeFakeQueue(),
+        enumerate: () => d6Specs(["a"]),
+        logger: SILENT_LOGGER,
+        // no runIdFactory → the DEFAULT factory under test
+      });
+      producer.start();
+      return producer;
+    };
+    const p1 = make();
+    const p2 = make();
+    const r1 = await p1.tick();
+    const r2 = await p2.tick();
+    expect(r1.runId).not.toBe(r2.runId);
+    // Ids stay sortable-prefixed (timestamp segment leads).
+    const ts36 = (1_765_000_000_000).toString(36);
+    expect(r1.runId.startsWith(`frun_${ts36}_`)).toBe(true);
+    expect(r2.runId.startsWith(`frun_${ts36}_`)).toBe(true);
+  });
+});
+
 describe("job-producer — lifecycle seams (start/stop/tick)", () => {
   it("isRunning reflects start()/stop()", async () => {
     const queue = makeFakeQueue();

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   createJobProducer,
   DEFAULT_SWEEP_INTERVAL_MS,
+  MAX_BUFFERED_SWEEP_COMM_ERRORS,
 } from "./job-producer.js";
 import type { JobProducer, ServiceJobSpec } from "./job-producer.js";
 import type {
@@ -612,6 +613,85 @@ describe("job-producer — sweep cadence", () => {
     const result = await producer.tick();
     expect(result.enqueued).toBe(2);
     expect(result.reclaimed).toBe(1);
+  });
+
+  it("[REQ-B] a failed sink delivery is BUFFERED and redelivered (prepended) on the next sweep's delivery", async () => {
+    // sweepExpired only synthesizes comm errors for rows reclaimed in THAT
+    // call — a transient sink failure must not permanently drop the reclaimed
+    // jobs' dashboard signal. Tick 1's sink throws; tick 2's sink call must
+    // deliver BOTH batches, tick 1's first.
+    const err = (jobId: string): PoolCommError => ({
+      kind: "worker-reclaimed-pending",
+      message: `lease for job ${jobId} expired; re-queued`,
+      jobId,
+      observedAt: "2026-06-04T00:00:09.000Z",
+    });
+    let sweepN = 0;
+    const queue = makeFakeQueue({
+      sweepImpl: async () => {
+        sweepN += 1;
+        return { reclaimed: 1, commErrors: [err(`j${sweepN}`)] };
+      },
+    });
+    const received: PoolCommError[][] = [];
+    let sinkCalls = 0;
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger: SILENT_LOGGER,
+      sweepIntervalMs: 0, // sweep every tick
+      onSweepCommErrors: (errs) => {
+        sinkCalls += 1;
+        if (sinkCalls === 1) throw new Error("aggregator down");
+        received.push(errs);
+      },
+    });
+    producer.start();
+    await producer.tick(); // sink fails — j1 buffered
+    await producer.tick(); // sink succeeds — j1 prepended to j2
+    expect(received).toHaveLength(1);
+    expect(received[0]!.map((e) => e.jobId)).toEqual(["j1", "j2"]);
+  });
+
+  it("[REQ-B] caps the undelivered buffer at MAX_BUFFERED_SWEEP_COMM_ERRORS, dropping oldest", async () => {
+    const errs = (n: number, prefix: string): PoolCommError[] =>
+      Array.from({ length: n }, (_, i) => ({
+        kind: "worker-reclaimed-pending" as const,
+        message: "lease expired",
+        jobId: `${prefix}${i}`,
+        observedAt: "2026-06-04T00:00:09.000Z",
+      }));
+    let sweepN = 0;
+    const queue = makeFakeQueue({
+      sweepImpl: async () => {
+        sweepN += 1;
+        // Tick 1 reclaims more than the cap; tick 2 reclaims one more.
+        return sweepN === 1
+          ? { reclaimed: 600, commErrors: errs(600, "old") }
+          : { reclaimed: 1, commErrors: errs(1, "fresh") };
+      },
+    });
+    const received: PoolCommError[][] = [];
+    let sinkCalls = 0;
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger: SILENT_LOGGER,
+      sweepIntervalMs: 0,
+      onSweepCommErrors: (batch) => {
+        sinkCalls += 1;
+        if (sinkCalls === 1) throw new Error("aggregator down");
+        received.push(batch);
+      },
+    });
+    producer.start();
+    await producer.tick(); // 600 buffered → trimmed to newest 500
+    await producer.tick(); // delivers 500 buffered + 1 fresh
+    expect(received).toHaveLength(1);
+    expect(received[0]).toHaveLength(MAX_BUFFERED_SWEEP_COMM_ERRORS + 1);
+    // Oldest 100 dropped: the buffer starts at old100, ends with the fresh one.
+    expect(received[0]![0]!.jobId).toBe("old100");
+    expect(received[0]![received[0]!.length - 1]!.jobId).toBe("fresh0");
   });
 
   it("defaults the sweep cadence to DEFAULT_SWEEP_INTERVAL_MS", async () => {

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -207,6 +207,69 @@ describe("job-producer — per-service enqueue", () => {
     );
   });
 
+  it("stamps enqueuedAt at ENQUEUE time, not tick start (a slow enumerate must not back-date it)", async () => {
+    // nowMs used to be captured BEFORE the potentially-seconds-long
+    // enumerate() await, so meta.enqueuedAt (documented as 'ISO timestamp the
+    // control-plane enqueued the job') was the tick-START time.
+    let t = 1_000;
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => {
+        t = 61_000; // a slow discovery: 60s elapse inside enumerate
+        return d6Specs(["a"]);
+      },
+      logger: SILENT_LOGGER,
+      now: () => t,
+    });
+    producer.start();
+    await producer.tick();
+    expect(queue.enqueued[0]!.payload.meta.enqueuedAt).toBe(
+      new Date(61_000).toISOString(),
+    );
+  });
+
+  it("re-reads the clock for the sweep AFTER enumerate (expiry decisions are not back-dated)", async () => {
+    let t = 1_000;
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => {
+        t = 61_000;
+        return d6Specs(["a"]);
+      },
+      logger: SILENT_LOGGER,
+      now: () => t,
+    });
+    producer.start();
+    await producer.tick();
+    // sweepExpired must be evaluated against the post-enumerate clock.
+    expect(queue.sweepCalls).toEqual([61_000]);
+  });
+
+  it("the default runId factory reads the INJECTED clock, not Date.now", async () => {
+    const dateNowSpy = vi
+      .spyOn(Date, "now")
+      .mockReturnValue(9_999_999_999_999);
+    try {
+      const queue = makeFakeQueue();
+      const producer = createJobProducer({
+        queue,
+        enumerate: () => d6Specs(["a"]),
+        logger: SILENT_LOGGER,
+        now: () => 123_456,
+        // no runIdFactory → default factory under test
+      });
+      producer.start();
+      const result = await producer.tick();
+      expect(
+        result.runId.startsWith(`frun_${(123_456).toString(36)}_`),
+      ).toBe(true);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
+  });
+
   it("marks scheduled (cron) ticks as triggered:false", async () => {
     const { producer, queue } = startedProducer({ specs: d6Specs(["a"]) });
     await producer.tick();

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -118,6 +118,7 @@ function startedProducer(overrides?: {
   sweepIntervalMs?: number;
   queue?: ReturnType<typeof makeFakeQueue>;
   runIdFactory?: () => string;
+  logger?: Logger;
 }): {
   producer: JobProducer;
   queue: ReturnType<typeof makeFakeQueue>;
@@ -128,7 +129,7 @@ function startedProducer(overrides?: {
   const producer = createJobProducer({
     queue,
     enumerate: () => specs,
-    logger: SILENT_LOGGER,
+    logger: overrides?.logger ?? SILENT_LOGGER,
     ...(overrides?.now ? { now: overrides.now } : {}),
     ...(overrides?.sweepIntervalMs !== undefined
       ? { sweepIntervalMs: overrides.sweepIntervalMs }
@@ -475,6 +476,68 @@ describe("job-producer — per-family backlog dedupe", () => {
     expect(queue.enqueued).toHaveLength(1);
     expect(result.enqueued).toBe(1);
     expect(result.skippedForBacklog).toBe(0);
+  });
+
+  it("fails CLOSED when the backlog count is POISONED (the queue-client's fail-closed refusal must not be failed open)", async () => {
+    // countPendingForFamily THROWS its documented refusal when PB hands back a
+    // non-count totalItems (e.g. -1): returning the poisoned value would
+    // silently open the gate on top of an existing backlog. The producer's
+    // broad fail-open catch must NOT defeat that — for THIS error class the
+    // family's batch is SKIPPED (fail closed), accounted as skippedForBacklog.
+    const poisonedErrors: unknown[] = [];
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a", "b"]),
+      queue: makeFakeQueue({
+        countPendingImpl: async () => {
+          throw new Error(
+            'queue-client: countPendingForFamily("d6") received a non-count totalItems (-1) despite skipTotal:false — refusing to fail the backlog gate open',
+          );
+        },
+      }),
+      logger: {
+        ...SILENT_LOGGER,
+        error: (msg) => {
+          if (msg === "fleet.producer.backlog-check-poisoned")
+            poisonedErrors.push(msg);
+        },
+      },
+    });
+
+    const result = await producer.tick();
+
+    expect(queue.enqueued).toHaveLength(0);
+    expect(result.enqueued).toBe(0);
+    expect(result.skippedForBacklog).toBe(2);
+    expect(poisonedErrors).toHaveLength(1);
+  });
+
+  it("a poisoned count gates ONLY its own family (other families still produce, fail-open class still fails open)", async () => {
+    const specs: ServiceJobSpec[] = [
+      ...d6Specs(["a"]),
+      { probeKey: "e2e-demos:a", serviceSlug: "a", driverKind: "e2e_demos" },
+    ];
+    const { producer, queue } = startedProducer({
+      specs,
+      queue: makeFakeQueue({
+        countPendingImpl: async (family) => {
+          if (family === "d6") {
+            throw new Error(
+              "refusing to fail the backlog gate open (poisoned totalItems)",
+            );
+          }
+          throw new Error("transient PB count blip");
+        },
+      }),
+    });
+
+    const result = await producer.tick();
+
+    // d6 fails CLOSED (skipped); e2e-demos's transient blip fails OPEN (kept).
+    expect(queue.enqueued.map((e) => e.payload.probeKey)).toEqual([
+      "e2e-demos:a",
+    ]);
+    expect(result.enqueued).toBe(1);
+    expect(result.skippedForBacklog).toBe(1);
   });
 });
 

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -407,6 +407,32 @@ describe("job-producer — failure isolation", () => {
     expect(queue.sweepCalls).toEqual([1_000]);
   });
 
+  it("a failing enumerate is reported as enumerateFailed (not a legitimately empty run)", async () => {
+    // Mirror of the sweepFailed test: pre-fix the enumerate-throw path
+    // returned the same shape as an enumerator that legitimately yielded no
+    // services — `enqueued: 0` — so a discovery outage was indistinguishable
+    // from an empty catalog in the TickResult.
+    const queue = makeFakeQueue();
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => {
+        throw new Error("railway discovery down");
+      },
+      logger: SILENT_LOGGER,
+    });
+    producer.start();
+    const result = await producer.tick();
+    expect(result.enqueued).toBe(0);
+    expect(result.enumerateFailed).toBe(true);
+  });
+
+  it("an empty (but successful) enumeration reports enumerateFailed:false", async () => {
+    const { producer } = startedProducer({ specs: [] });
+    const result = await producer.tick();
+    expect(result.enqueued).toBe(0);
+    expect(result.enumerateFailed).toBe(false);
+  });
+
   it("a failing sweep does not abort job production", async () => {
     const queue = makeFakeQueue({
       sweepImpl: async () => {

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -248,9 +248,7 @@ describe("job-producer — per-service enqueue", () => {
   });
 
   it("the default runId factory reads the INJECTED clock, not Date.now", async () => {
-    const dateNowSpy = vi
-      .spyOn(Date, "now")
-      .mockReturnValue(9_999_999_999_999);
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(9_999_999_999_999);
     try {
       const queue = makeFakeQueue();
       const producer = createJobProducer({
@@ -262,9 +260,9 @@ describe("job-producer — per-service enqueue", () => {
       });
       producer.start();
       const result = await producer.tick();
-      expect(
-        result.runId.startsWith(`frun_${(123_456).toString(36)}_`),
-      ).toBe(true);
+      expect(result.runId.startsWith(`frun_${(123_456).toString(36)}_`)).toBe(
+        true,
+      );
     } finally {
       dateNowSpy.mockRestore();
     }
@@ -1106,6 +1104,166 @@ describe("job-producer — default run-id factory", () => {
     const ts36 = (1_765_000_000_000).toString(36);
     expect(r1.runId.startsWith(`frun_${ts36}_`)).toBe(true);
     expect(r2.runId.startsWith(`frun_${ts36}_`)).toBe(true);
+  });
+});
+
+describe("job-producer — stop() quiesce", () => {
+  /** A JobView for the fake enqueueImpl gates below. */
+  function jobView(input: EnqueueJobInput): JobView {
+    return {
+      id: `job-${input.payload.serviceSlug}`,
+      probe_key: input.payload.probeKey,
+      status: "pending",
+      claimed_by: "",
+      lease_expires_at: null,
+      version: 1,
+    };
+  }
+
+  it("stop() awaits an in-flight tick (the tick cannot continue past stop()'s resolution)", async () => {
+    // stop() used to flip `running` and resolve immediately — an in-flight
+    // tick kept enumerating/sweeping/enqueueing AFTER stop() resolved, so
+    // "stopped" was a lie to the shutdown sequence that called it.
+    let releaseEnqueue!: () => void;
+    const gate = new Promise<void>((resolve) => (releaseEnqueue = resolve));
+    const queue = makeFakeQueue({
+      enqueueImpl: async (input) => {
+        await gate;
+        return jobView(input);
+      },
+    });
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger: SILENT_LOGGER,
+    });
+    producer.start();
+    const tickP = producer.tick();
+    await vi.waitFor(() => {
+      expect(queue.enqueued).toHaveLength(1); // tick reached the gated enqueue
+    });
+    let stopResolved = false;
+    const stopP = producer.stop().then(() => {
+      stopResolved = true;
+    });
+    // Give stop() every chance to (incorrectly) resolve before the tick ends.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(stopResolved).toBe(false);
+    releaseEnqueue();
+    await tickP;
+    await stopP;
+    expect(stopResolved).toBe(true);
+  });
+
+  it("a tick stopped mid-batch truncates the remaining enqueues (and logs the truncation)", async () => {
+    let releaseEnqueue!: () => void;
+    const gate = new Promise<void>((resolve) => (releaseEnqueue = resolve));
+    const warns: string[] = [];
+    const logger: Logger = {
+      ...SILENT_LOGGER,
+      warn: (msg) => {
+        warns.push(msg);
+      },
+    };
+    const queue = makeFakeQueue({
+      enqueueImpl: async (input) => {
+        if (input.payload.serviceSlug === "a") await gate;
+        return jobView(input);
+      },
+    });
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a", "b", "c"]),
+      logger,
+    });
+    producer.start();
+    const tickP = producer.tick();
+    await vi.waitFor(() => {
+      expect(queue.enqueued).toHaveLength(1);
+    });
+    const stopP = producer.stop(); // flips running=false, then quiesces
+    releaseEnqueue();
+    const result = await tickP;
+    await stopP;
+    // "a" completed; "b" and "c" were truncated, not enqueued post-stop.
+    expect(result.enqueued).toBe(1);
+    expect(queue.enqueued).toHaveLength(1);
+    expect(warns).toContain("fleet.producer.enqueue-truncated-stopped");
+  });
+
+  it("stop() makes one final delivery attempt of buffered sweep comm errors", async () => {
+    // Buffered comm errors used to be silently DROPPED at shutdown — the
+    // reclaimed jobs' dashboard signal vanished with the process.
+    const queue = makeFakeQueue({
+      sweepImpl: async () => ({
+        reclaimed: 1,
+        commErrors: [
+          {
+            kind: "worker-reclaimed-pending",
+            message: "lease for job j1 expired; re-queued",
+            jobId: "j1",
+            observedAt: "2026-06-04T00:00:09.000Z",
+          },
+        ],
+      }),
+    });
+    const received: PoolCommError[][] = [];
+    let sinkCalls = 0;
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger: SILENT_LOGGER,
+      onSweepCommErrors: (errs) => {
+        sinkCalls += 1;
+        if (sinkCalls === 1) throw new Error("aggregator down");
+        received.push(errs);
+      },
+    });
+    producer.start();
+    await producer.tick(); // sink fails — j1 buffered
+    await producer.stop(); // final drain: sink healthy again
+    expect(received).toHaveLength(1);
+    expect(received[0]!.map((e) => e.jobId)).toEqual(["j1"]);
+  });
+
+  it("stop() logs the dropped count + jobIds at error level when the final delivery also fails", async () => {
+    const errorLogs: Array<{ msg: string; meta?: Record<string, unknown> }> =
+      [];
+    const logger: Logger = {
+      ...SILENT_LOGGER,
+      error: (msg, meta) => {
+        errorLogs.push({ msg, ...(meta !== undefined ? { meta } : {}) });
+      },
+    };
+    const queue = makeFakeQueue({
+      sweepImpl: async () => ({
+        reclaimed: 1,
+        commErrors: [
+          {
+            kind: "worker-reclaimed-pending",
+            message: "lease for job j1 expired; re-queued",
+            jobId: "j1",
+            observedAt: "2026-06-04T00:00:09.000Z",
+          },
+        ],
+      }),
+    });
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger,
+      onSweepCommErrors: () => {
+        throw new Error("aggregator down for good");
+      },
+    });
+    producer.start();
+    await producer.tick(); // sink fails — j1 buffered
+    await producer.stop(); // final drain fails too — dropped, loudly
+    const dropLog = errorLogs.find(
+      (e) => e.msg === "fleet.producer.stop-commerrors-dropped",
+    );
+    expect(dropLog).toBeDefined();
+    expect(dropLog!.meta).toMatchObject({ dropped: 1, jobIds: ["j1"] });
   });
 });
 

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -1350,6 +1350,63 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
     expect(warmed!.meta).toMatchObject({ warmed: 1 }); // beta only
   });
 
+  it("a settled-but-failing warm response (e.g. 503) logs warm-failed with the status, NOT warm-ok", async () => {
+    // The success handler used to log warm-ok for ANY settled response —
+    // including 404/500/503 — so a misderived backendUrl could masquerade
+    // as healthy forever. A non-ok status is a warm FAILURE.
+    const debugs: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const logger: Logger = {
+      ...SILENT_LOGGER,
+      debug: (msg, meta) => {
+        debugs.push({ msg, ...(meta !== undefined ? { meta } : {}) });
+      },
+    };
+    const fetchImpl = (async (): Promise<Response> =>
+      new Response(null, { status: 503 })) as typeof fetch;
+    const producer = createJobProducer({
+      queue: makeFakeQueue(),
+      enumerate: () => d6Specs(["alpha"]),
+      logger,
+      warmHealth: { fetchImpl },
+    });
+    producer.start();
+    await producer.tick();
+    // Let the fire-and-forget chain settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(debugs.map((e) => e.msg)).not.toContain("fleet.producer.warm-ok");
+    const failed = debugs.find((e) => e.msg === "fleet.producer.warm-failed");
+    expect(failed).toBeDefined();
+    expect(failed!.meta).toMatchObject({
+      serviceSlug: "alpha",
+      healthUrl: "https://alpha.example.com/health",
+      status: 503,
+    });
+  });
+
+  it("an ok warm response logs warm-ok WITH the status", async () => {
+    const debugs: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const logger: Logger = {
+      ...SILENT_LOGGER,
+      debug: (msg, meta) => {
+        debugs.push({ msg, ...(meta !== undefined ? { meta } : {}) });
+      },
+    };
+    const fetchImpl = (async (): Promise<Response> =>
+      new Response(null, { status: 200 })) as typeof fetch;
+    const producer = createJobProducer({
+      queue: makeFakeQueue(),
+      enumerate: () => d6Specs(["alpha"]),
+      logger,
+      warmHealth: { fetchImpl },
+    });
+    producer.start();
+    await producer.tick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const ok = debugs.find((e) => e.msg === "fleet.producer.warm-ok");
+    expect(ok).toBeDefined();
+    expect(ok!.meta).toMatchObject({ status: 200 });
+  });
+
   it("a throwing logger inside the warm chain never raises an unhandled rejection", async () => {
     // The fire-and-forget chain's own handlers can throw (an injected logger
     // whose transport is down). Without a terminal catch that surfaces as an

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -933,6 +933,72 @@ describe("job-producer — sweep cadence", () => {
     expect(noSinkWarns[0]!.meta).toMatchObject({
       commErrors: 1,
       jobIds: ["j1"],
+      droppedTotal: 1,
+    });
+  });
+
+  it("[REQ-B] no-sink drops AFTER the first warn are logged at debug with jobIds + a running dropped-total", async () => {
+    // The one-shot warn keeps a sink-less deployment from burying its logs —
+    // but it made every SUBSEQUENT drop fully silent: reclaims kept being
+    // dropped with no trace at all of which jobs or how many. Later drops are
+    // logged at debug (greppable, not log-burying) with the dropped jobIds
+    // and a running dropped-total; the total also rides the first warn.
+    const warns: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const debugs: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    const logger: Logger = {
+      ...SILENT_LOGGER,
+      warn: (msg, meta) => {
+        warns.push({ msg, ...(meta !== undefined ? { meta } : {}) });
+      },
+      debug: (msg, meta) => {
+        debugs.push({ msg, ...(meta !== undefined ? { meta } : {}) });
+      },
+    };
+    let sweepN = 0;
+    const queue = makeFakeQueue({
+      sweepImpl: async () => {
+        sweepN += 1;
+        return {
+          reclaimed: 1,
+          commErrors: [
+            {
+              kind: "worker-reclaimed-pending",
+              message: `lease for job j${sweepN} expired; re-queued`,
+              jobId: `j${sweepN}`,
+              observedAt: "2026-06-04T00:00:09.000Z",
+            },
+          ],
+        };
+      },
+    });
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a"]),
+      logger,
+      sweepIntervalMs: 0, // sweep (and drop) on every tick
+      // no onSweepCommErrors sink
+    });
+    producer.start();
+    await producer.tick(); // first drop — the one-shot warn
+    await producer.tick(); // second drop — debug
+    await producer.tick(); // third drop — debug
+    const noSinkWarns = warns.filter(
+      (w) => w.msg === "fleet.producer.sweep-commerrors-no-sink",
+    );
+    expect(noSinkWarns).toHaveLength(1);
+    const noSinkDebugs = debugs.filter(
+      (d) => d.msg === "fleet.producer.sweep-commerrors-no-sink",
+    );
+    expect(noSinkDebugs).toHaveLength(2);
+    expect(noSinkDebugs[0]!.meta).toMatchObject({
+      commErrors: 1,
+      jobIds: ["j2"],
+      droppedTotal: 2,
+    });
+    expect(noSinkDebugs[1]!.meta).toMatchObject({
+      commErrors: 1,
+      jobIds: ["j3"],
+      droppedTotal: 3,
     });
   });
 

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -780,11 +780,31 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     const { fetchImpl } = warmHealth;
     const timeoutMs = warmHealth.timeoutMs ?? DEFAULT_WARM_TIMEOUT_MS;
     let fired = 0;
+    // Specs skipped before any warm dispatch (no/garbage backendUrl). Each
+    // skip is debug-logged with its reason so a per-spec coverage gap is
+    // greppable; when EVERY spec of a non-empty tick is skipped the #72
+    // mitigation is silently inert — that wiring regression gets one WARN
+    // per tick (see below).
+    let skipped = 0;
     for (const spec of specs) {
       const backendUrl = backendUrlFromSpec(spec);
-      if (backendUrl === undefined) continue;
+      if (backendUrl === undefined) {
+        skipped += 1;
+        logger.debug("fleet.producer.warm-skipped", {
+          serviceSlug: spec.serviceSlug,
+          reason: "missing-backendUrl",
+        });
+        continue;
+      }
       const healthUrl = deriveHealthUrl(backendUrl);
-      if (healthUrl === "") continue;
+      if (healthUrl === "") {
+        skipped += 1;
+        logger.debug("fleet.producer.warm-skipped", {
+          serviceSlug: spec.serviceSlug,
+          reason: "malformed-backendUrl",
+        });
+        continue;
+      }
       // Fire-and-forget: an AbortController bounds each GET so a hung cold
       // container can't leak a pending request across ticks. The whole chain is
       // swallowed — warm-up is a latency optimization, never a correctness gate.
@@ -855,6 +875,18 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     }
     if (fired > 0) {
       logger.info("fleet.producer.warmed", { warmed: fired });
+    }
+    // ZERO-WARMABLE WARN: warm-up is configured but NO spec of a non-empty
+    // tick could even be dispatched — the enumerator stopped threading
+    // backendUrl (or threads garbage), so the cold-start mitigation is
+    // silently inert fleet-wide. One warn per tick (the per-spec debug
+    // skips above carry the detail). Keyed on `skipped`, not `fired`: a
+    // sync-throwing fetchImpl still ATTEMPTED a warm — that is a dispatch
+    // failure (already logged), not a coverage gap.
+    if (specs.length > 0 && skipped === specs.length) {
+      logger.warn("fleet.producer.warm-none-warmable", {
+        services: specs.length,
+      });
     }
     return fired;
   }

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -237,13 +237,13 @@ export interface TickResult {
   /**
    * Expired leases reclaimed by the sweep, when one ran (else 0).
    *
-   * AT-LEAST-ONCE / MAY OVER-REPORT: a reclaim whose release transport call
-   * fails AFTER the queue committed the re-queue is still counted here (the
-   * producer cannot tell a failed release from a lost response), so under
-   * release transport failures this count can exceed the number of jobs
-   * actually returned to pending. When the queue client reports the
-   * indeterminate slice separately, it is surfaced via
-   * `reclaimedIndeterminate` below.
+   * Against the REAL queue-client this counts CAS-CONFIRMED re-queues ONLY:
+   * a release that THREW mid-flight (it may or may not have committed) lands
+   * exclusively in `reclaimedIndeterminate` below, never here — summing the
+   * two recovers the conservative at-least-once total. Only a queue
+   * implementation that does NOT report the split (the shared `SweepResult`
+   * contract keeps `reclaimedIndeterminate` optional) could fold
+   * indeterminate maybes into this count.
    */
   reclaimed: number;
   /**

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -775,10 +775,24 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
               } catch {
                 // a fake Response without a cancellable body — nothing to free
               }
-              logger.debug("fleet.producer.warm-ok", {
-                serviceSlug: spec.serviceSlug,
-                healthUrl,
-              });
+              if (res.ok) {
+                logger.debug("fleet.producer.warm-ok", {
+                  serviceSlug: spec.serviceSlug,
+                  healthUrl,
+                  status: res.status,
+                });
+              } else {
+                // A SETTLED response is not a warm success: a 404/500/503
+                // (e.g. a misderived backendUrl) logged as warm-ok would
+                // masquerade as healthy forever. Still debug-level — a cold
+                // container can 503 while booting, which is the expected
+                // case the warm exists for.
+                logger.debug("fleet.producer.warm-failed", {
+                  serviceSlug: spec.serviceSlug,
+                  healthUrl,
+                  status: res.status,
+                });
+              }
             },
             (err: unknown) => {
               // A cold container still booting / a network blip is EXPECTED here —

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -824,6 +824,15 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     async stop() {
       if (!running) {
         stopped = true;
+        // A SECOND concurrent stop() lands here (the first flipped `running`
+        // synchronously) — it must STILL quiesce: returning while the first
+        // stop()'s tick is mid-enqueue made "stopped" a lie to this caller
+        // (a shutdown racing two stop()s could tear the queue down under a
+        // still-writing tick). Await the in-flight tick AND any queued
+        // trigger, same as the primary path below.
+        while (inFlightTick !== null || queuedTrigger !== null) {
+          await (inFlightTick ?? queuedTrigger)!.catch(() => {});
+        }
         return;
       }
       running = false;
@@ -831,9 +840,12 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       // QUIESCE: an in-flight tick observed `running === true` at entry and
       // may still be enumerating/sweeping/enqueueing. "Stopped" must mean the
       // tick is DONE — its enqueue loop truncates on the flag flipped above,
-      // and stop() resolves only once the tick has fully unwound.
-      if (inFlightTick !== null) {
-        await inFlightTick.catch(() => {});
+      // and stop() resolves only once the tick has fully unwound. A LOOP, not
+      // a single await: a queued trigger (see the re-entrancy guard) takes
+      // the in-flight slot after the current tick resolves — its (skipped,
+      // `running` is false) run must also unwind before stop() resolves.
+      while (inFlightTick !== null || queuedTrigger !== null) {
+        await (inFlightTick ?? queuedTrigger)!.catch(() => {});
       }
       // FINAL DRAIN: buffered undelivered comm errors would otherwise die
       // with the process — `sweepExpired` cannot re-derive a missed batch.

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -64,8 +64,11 @@ import { deriveHealthUrl } from "../../probes/liveness.js";
  * synthesizes comm errors for rows reclaimed in THAT call, so a later sweep
  * cannot re-derive a missed batch; the producer instead BUFFERS undelivered
  * errors (capped at `MAX_BUFFERED_SWEEP_COMM_ERRORS`, oldest dropped) and
- * prepends them to the next sweep's sink delivery. Injected so the producer
- * stays dependency-free and unit-testable with a fake sink.
+ * prepends them to the next delivery attempt — which happens on EVERY sweep
+ * attempt, including one whose `sweepExpired` call throws, so a
+ * persistently-failing sweep never starves a healthy sink of the buffer.
+ * Injected so the producer stays dependency-free and unit-testable with a
+ * fake sink.
  */
 export type SweepCommErrorSink = (
   commErrors: PoolCommError[],
@@ -341,6 +344,40 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
   }
 
   /**
+   * REQ-B delivery: hand the buffered undelivered comm errors plus `fresh`
+   * (this sweep's batch, possibly empty) to the injected sink. Called on
+   * EVERY sweep attempt — success or failure — so a persistently-throwing
+   * `sweepExpired` (the exact failure mode the buffer rides out) can never
+   * starve a healthy sink of the buffered batch. Best-effort: a sink failure
+   * re-buffers the whole batch (capped at `MAX_BUFFERED_SWEEP_COMM_ERRORS`,
+   * oldest dropped, warned) and never aborts job production.
+   */
+  async function deliverSweepCommErrors(fresh: PoolCommError[]): Promise<void> {
+    if (!onSweepCommErrors) return;
+    const batch = [...undeliveredCommErrors, ...fresh];
+    undeliveredCommErrors = [];
+    if (batch.length === 0) return;
+    try {
+      await onSweepCommErrors(batch);
+    } catch (sinkErr) {
+      logger.error("fleet.producer.sweep-commerror-sink-failed", {
+        commErrors: batch.length,
+        err: sinkErr instanceof Error ? sinkErr.message : String(sinkErr),
+      });
+      undeliveredCommErrors = batch;
+      if (undeliveredCommErrors.length > MAX_BUFFERED_SWEEP_COMM_ERRORS) {
+        const dropped =
+          undeliveredCommErrors.length - MAX_BUFFERED_SWEEP_COMM_ERRORS;
+        undeliveredCommErrors = undeliveredCommErrors.slice(dropped);
+        logger.warn("fleet.producer.sweep-commerror-buffer-overflow", {
+          dropped,
+          buffered: MAX_BUFFERED_SWEEP_COMM_ERRORS,
+        });
+      }
+    }
+  }
+
+  /**
    * Run the lease sweep if the cadence window has elapsed. Returns the
    * sweep outcome (or a no-sweep sentinel). Sweep failures are logged and
    * swallowed — a transient PB blip on the reclamation path must NEVER
@@ -376,37 +413,21 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       // production. But `sweepExpired` only synthesizes comm errors for rows
       // reclaimed in THIS call — a later sweep canNOT re-derive a missed batch —
       // so a failed delivery is BUFFERED (not dropped) and the buffer is drained,
-      // prepended to the fresh batch, on the next sweep's delivery. The buffer is
-      // capped at MAX_BUFFERED_SWEEP_COMM_ERRORS (oldest dropped, warned).
-      if (onSweepCommErrors) {
-        const batch = [...undeliveredCommErrors, ...result.commErrors];
-        undeliveredCommErrors = [];
-        if (batch.length > 0) {
-          try {
-            await onSweepCommErrors(batch);
-          } catch (sinkErr) {
-            logger.error("fleet.producer.sweep-commerror-sink-failed", {
-              commErrors: batch.length,
-              err: sinkErr instanceof Error ? sinkErr.message : String(sinkErr),
-            });
-            undeliveredCommErrors = batch;
-            if (undeliveredCommErrors.length > MAX_BUFFERED_SWEEP_COMM_ERRORS) {
-              const dropped =
-                undeliveredCommErrors.length - MAX_BUFFERED_SWEEP_COMM_ERRORS;
-              undeliveredCommErrors = undeliveredCommErrors.slice(dropped);
-              logger.warn("fleet.producer.sweep-commerror-buffer-overflow", {
-                dropped,
-                buffered: MAX_BUFFERED_SWEEP_COMM_ERRORS,
-              });
-            }
-          }
-        }
-      }
+      // prepended to the fresh batch, on the next delivery attempt (see
+      // deliverSweepCommErrors — it runs on every sweep attempt, even a failed
+      // one). The buffer is capped at MAX_BUFFERED_SWEEP_COMM_ERRORS.
+      await deliverSweepCommErrors(result.commErrors);
       return { swept: true, sweepFailed: false, reclaimed: result.reclaimed };
     } catch (err) {
       logger.error("fleet.producer.sweep-failed", {
         err: err instanceof Error ? err.message : String(err),
       });
+      // Even though THIS sweep produced no comm errors, a PREVIOUS sweep's
+      // batch may be sitting in the buffer — drain it now. The drain must not
+      // depend on the current sweep call's success: a persistently-throwing
+      // sweepExpired is the exact failure mode the buffer exists to ride out,
+      // and gating the drain on sweep success starved a healthy sink forever.
+      await deliverSweepCommErrors([]);
       // A failed sweep still counts as "swept" for cadence purposes — we
       // don't want a persistently-failing sweep to fire on every tick and
       // bury the logs; the window already advanced via lastSweepAt. But it

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -535,6 +535,14 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
         services: specs.length,
       });
 
+      // SWEEP FIRST: the sweep's stale-pending drain can clear a family's
+      // entire backlog (a backlog of only-stale rows). Running it BEFORE the
+      // backlog gate means the very tick that drains a family also resumes
+      // its production — sweeping after the gate made production resume a
+      // full cron period late. Same cadence gate and fail-open semantics
+      // (maybeSweep swallows sweep failures); only the order changed.
+      const sweep = await maybeSweep(nowMs);
+
       // BACKLOG DEDUPE: scheduled ticks skip any family whose previous batch
       // is still pending (unclaimed) — see filterBackloggedFamilies. Operator-
       // triggered ticks BYPASS the gate: an explicit trigger is a deliberate
@@ -576,8 +584,6 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
           });
         }
       }
-
-      const sweep = await maybeSweep(nowMs);
 
       logger.info("fleet.producer.tick-complete", {
         runId,

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -385,8 +385,42 @@ function skippedTickResult(): TickResult {
   };
 }
 
+/**
+ * Wrap the injected logger so a THROWING transport can never break the
+ * producer's control flow. The documented invariant at `inFlightTick` — "a
+ * tick promise never rejects; every failure path inside the tick is caught"
+ * — was violated by any unguarded logger.* call in the tick body, and a
+ * throw inside stop()'s shared completion permanently POISONED
+ * `stopPromise`: every later stop() caller awaited the same rejected
+ * promise and re-threw. The warm chain already hardens for this exact
+ * failure mode (its terminal `.catch` backstop, kept as defense in depth);
+ * wrapping the logger ONCE at construction extends the same discipline to
+ * every call site in this module. Logging is observability, never a
+ * correctness gate — a throwing transport is swallowed.
+ */
+function safeLogger(logger: Logger): Logger {
+  const guard =
+    (level: "info" | "warn" | "error" | "debug") =>
+    (msg: string, meta?: Record<string, unknown>): void => {
+      try {
+        logger[level](msg, meta);
+      } catch {
+        // A broken log transport must never break production or shutdown.
+      }
+    };
+  return {
+    info: guard("info"),
+    warn: guard("warn"),
+    error: guard("error"),
+    debug: guard("debug"),
+  };
+}
+
 export function createJobProducer(opts: JobProducerOptions): JobProducer {
-  const { queue, enumerate, logger } = opts;
+  const { queue, enumerate } = opts;
+  // Hardened once here so EVERY logger.* call in this module upholds the
+  // "a tick promise never rejects" invariant — see safeLogger.
+  const logger = safeLogger(opts.logger);
   const now = opts.now ?? (() => Date.now());
   const sweepIntervalMs = opts.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS;
   const runIdFactory = opts.runIdFactory ?? defaultRunIdFactory(now);

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -324,6 +324,17 @@ export const DEFAULT_SWEEP_INTERVAL_MS = 30_000;
 export const MAX_BUFFERED_SWEEP_COMM_ERRORS = 500;
 
 /**
+ * The queue-client's poisoned-count refusal message marker (see
+ * `countPendingForFamily` in queue-client.ts: it THROWS rather than return a
+ * non-count totalItems that would silently fail the backlog gate open).
+ * Matched on the error MESSAGE substring because the queue-client does not
+ * export a dedicated error class for the refusal — a defensive string match
+ * keyed on the stable, documented phrase. If the queue-client ever exports
+ * the error type, switch the gate's catch to `instanceof`.
+ */
+const POISONED_COUNT_MARKER = "refusing to fail the backlog gate open";
+
+/**
  * The no-op `TickResult` for a tick that never RAN (skipped because a
  * previous tick was still in flight, or arrived outside the producer's
  * lifecycle). `runId` is the empty-string sentinel: no run was minted — a
@@ -547,10 +558,27 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
    * of a claimed-but-running one would double the family's concurrency.
    * Skipping the batch bounds the per-family backlog to ONE batch — the next
    * tick re-checks and produces again once the workers have finished it. Grouped per family so a (hypothetical)
-   * multi-family tick gates each family independently. Fail-OPEN on a count
-   * blip: a transient PB read failure must never stop job production (the
-   * legacy un-gated behavior is the safe fallback), mirroring maybeSweep's
-   * swallow-and-log discipline.
+   * multi-family tick gates each family independently — note the regroup
+   * means a multi-family tick's KEPT specs come out family-grouped, not in
+   * the enumerator's interleave order (harmless today: production ticks are
+   * single-family). TWO failure classes on the count read:
+   *   - POISONED COUNT (fail CLOSED): `countPendingForFamily` THROWS its
+   *     documented refusal when the backend hands back a non-count
+   *     totalItems — returning it would silently open the gate on top of an
+   *     existing backlog. Failing OPEN here would defeat that fail-closed
+   *     throw, so for this class the family's batch is SKIPPED (accounted
+   *     as skippedForBacklog) and logged at error.
+   *   - TRANSIENT READ BLIP (fail OPEN): any other count failure must never
+   *     stop job production (the legacy un-gated behavior is the safe
+   *     fallback), mirroring maybeSweep's swallow-and-log discipline.
+   *
+   * COUNT-SCOPE NOTE (consumer side): the non-terminal count includes rows
+   * the stale-pending sweeper currently holds mid-deletion (claimed under
+   * its sweeper id) — they are about to be deleted, not real backlog, so
+   * the gate can over-count by the in-flight deletion set for one tick.
+   * The status filter itself lives in the queue-client
+   * (`countPendingForFamily`); excluding sweeper-held rows would be a
+   * queue-client change, noted here only because this gate consumes it.
    */
   async function filterBackloggedFamilies(
     specs: ServiceJobSpec[],
@@ -570,10 +598,26 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       try {
         pendingCount = await queue.countPendingForFamily(family);
       } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes(POISONED_COUNT_MARKER)) {
+          // FAIL CLOSED: the queue-client refused a poisoned (non-count)
+          // totalItems rather than fail the gate open — honoring that means
+          // SKIPPING this family's batch, not producing on top of an
+          // unknowable backlog. The next tick re-checks.
+          skipped += group.length;
+          logger.error("fleet.producer.backlog-check-poisoned", {
+            runId,
+            family,
+            skippedJobs: group.length,
+            err: message,
+          });
+          continue;
+        }
+        // FAIL OPEN: a transient read blip must never stop production.
         logger.error("fleet.producer.backlog-check-failed", {
           runId,
           family,
-          err: err instanceof Error ? err.message : String(err),
+          err: message,
         });
         kept.push(...group);
         continue;

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -181,6 +181,14 @@ export interface TickResult {
   sweepFailed: boolean;
   /** Expired leases reclaimed by the sweep, when one ran (else 0). */
   reclaimed: number;
+  /**
+   * True iff the enumerator THREW on this tick (production short-circuited —
+   * nothing was enqueued). Without this flag a discovery outage was
+   * indistinguishable from a legitimately empty catalog in the tick outcome
+   * (both report `enqueued: 0`) — the same ambiguity class `sweepFailed`
+   * exists to remove.
+   */
+  enumerateFailed: boolean;
 }
 
 export interface JobProducerOptions {
@@ -563,6 +571,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
           sweptExpired: false,
           sweepFailed: false,
           reclaimed: 0,
+          enumerateFailed: false,
         };
       }
 
@@ -594,6 +603,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
           sweptExpired: sweep.swept,
           sweepFailed: sweep.sweepFailed,
           reclaimed: sweep.reclaimed,
+          enumerateFailed: true,
         };
       }
 
@@ -672,6 +682,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
         sweptExpired: sweep.swept,
         sweepFailed: sweep.sweepFailed,
         reclaimed: sweep.reclaimed,
+        enumerateFailed: false,
       };
     },
   };

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -899,8 +899,14 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       // discipline — no jobs leak past the producer's lifecycle. No runId
       // is minted: a stopped tick must not burn the factory counter or log
       // a phantom runId no job will ever carry.
+      // started/stopped discriminate the two opposite wiring bugs this warn
+      // flags: a tick BEFORE boot wiring started the producer (started:
+      // false) vs a scheduler still firing AFTER shutdown stopped it
+      // (started+stopped: true).
       logger.warn("fleet.producer.tick-while-stopped", {
         triggered: tickOpts?.triggered === true,
+        started,
+        stopped,
       });
       return skippedTickResult();
     }

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -370,6 +370,15 @@ export const DEFAULT_SWEEP_INTERVAL_MS = 30_000;
 export const MAX_BUFFERED_SWEEP_COMM_ERRORS = 500;
 
 /**
+ * Cap on the jobIds SAMPLE the buffer-overflow warn carries. The sibling
+ * drop paths (no-sink, stop()-drain) log every dropped jobId, but those
+ * batches are bounded by a single sweep; an overflow drop is bounded only
+ * by the inflow rate, so the warn samples the OLDEST (dropped-first) ids
+ * rather than flood one log line with thousands.
+ */
+export const OVERFLOW_DROP_JOBID_SAMPLE = 20;
+
+/**
  * The no-op `TickResult` for a tick that never RAN (skipped because a
  * previous tick was still in flight, or arrived outside the producer's
  * lifecycle). `runId` is the empty-string sentinel: no run was minted — a
@@ -564,10 +573,20 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       if (undeliveredCommErrors.length > MAX_BUFFERED_SWEEP_COMM_ERRORS) {
         const dropped =
           undeliveredCommErrors.length - MAX_BUFFERED_SWEEP_COMM_ERRORS;
+        const droppedEntries = undeliveredCommErrors.slice(0, dropped);
         undeliveredCommErrors = undeliveredCommErrors.slice(dropped);
+        // Identify the dropped jobs like the sibling drop paths (no-sink
+        // drop, stop()-drain drop) — a count alone says THAT signals were
+        // lost, never WHICH. SAMPLED (capped) unlike the siblings: an
+        // overflow drop is unbounded, and a mass drop must not flood one
+        // log line with thousands of ids.
         logger.warn("fleet.producer.sweep-commerror-buffer-overflow", {
           dropped,
           buffered: MAX_BUFFERED_SWEEP_COMM_ERRORS,
+          jobIds: droppedEntries
+            .slice(0, OVERFLOW_DROP_JOBID_SAMPLE)
+            .map((e) => e.jobId)
+            .filter((id): id is string => id !== undefined),
         });
       }
     }

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -188,10 +188,19 @@ export interface TickResult {
    * construction does not mint a runId.
    */
   runId: string;
-  /** Number of per-service jobs enqueued (services enumerated, minus enqueue failures and backlog-gate skips). */
+  /** Number of per-service jobs enqueued (services enumerated, minus enqueue failures, backlog-gate skips, AND stop truncation). */
   enqueued: number;
   /** Number of enqueue attempts that threw (a service that failed to enqueue). */
   enqueueFailures: number;
+  /**
+   * Number of per-service jobs NOT enqueued because `stop()` truncated the
+   * enqueue loop mid-batch (the quiesce re-check). Without this the
+   * truncated specs vanished from the tick outcome entirely: `services`
+   * could not be reconciled against `enqueued + enqueueFailures +
+   * skippedForBacklog`. The partition invariant is `services enumerated ==
+   * enqueued + enqueueFailures + skippedForBacklog + truncatedByStop`.
+   */
+  truncatedByStop: number;
   /**
    * Number of per-service jobs SKIPPED because their family already had a
    * non-terminal (pending/claimed/running) batch on the queue (scheduled
@@ -327,6 +336,7 @@ function skippedTickResult(): TickResult {
     enqueued: 0,
     enqueueFailures: 0,
     skippedForBacklog: 0,
+    truncatedByStop: 0,
     sweptExpired: false,
     sweepFailed: false,
     reclaimed: 0,
@@ -725,6 +735,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
         enqueued: 0,
         enqueueFailures: 0,
         skippedForBacklog: 0,
+        truncatedByStop: 0,
         sweptExpired: sweep.swept,
         sweepFailed: sweep.sweepFailed,
         reclaimed: sweep.reclaimed,
@@ -762,16 +773,19 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
 
     let enqueued = 0;
     let enqueueFailures = 0;
+    let truncatedByStop = 0;
     for (const spec of gate.specs) {
       // QUIESCE re-check: stop() flips `running` and then awaits this tick.
       // Dispatching the REST of the batch after stop began would leak jobs
-      // past the producer's lifecycle — truncate, loudly.
+      // past the producer's lifecycle — truncate, loudly, and ACCOUNT for
+      // the truncated specs (they must not vanish from the tick outcome).
       if (!running) {
+        truncatedByStop = gate.specs.length - enqueued - enqueueFailures;
         logger.warn("fleet.producer.enqueue-truncated-stopped", {
           runId,
           enqueued,
           enqueueFailures,
-          remaining: gate.specs.length - enqueued - enqueueFailures,
+          remaining: truncatedByStop,
         });
         break;
       }
@@ -801,6 +815,8 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       }
     }
 
+    // `services` partitions exactly: services == enqueued + enqueueFailures
+    // + skippedForBacklog + truncatedByStop (see TickResult.truncatedByStop).
     logger.info("fleet.producer.tick-complete", {
       runId,
       triggered,
@@ -808,6 +824,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       enqueued,
       enqueueFailures,
       skippedForBacklog: gate.skipped,
+      truncatedByStop,
       sweptExpired: sweep.swept,
       sweepFailed: sweep.sweepFailed,
       reclaimed: sweep.reclaimed,
@@ -818,6 +835,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       enqueued,
       enqueueFailures,
       skippedForBacklog: gate.skipped,
+      truncatedByStop,
       sweptExpired: sweep.swept,
       sweepFailed: sweep.sweepFailed,
       reclaimed: sweep.reclaimed,

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -207,8 +207,9 @@ export interface JobProducerOptions {
   sweepIntervalMs?: number;
   /**
    * Clock, injectable for tests. Returns ms-since-epoch. Used for the
-   * sweep cadence gate and `ServiceJobMeta.enqueuedAt`. Defaults to
-   * `Date.now`.
+   * sweep cadence gate (re-read after the enumerate await, never tick
+   * start), `ServiceJobMeta.enqueuedAt` (stamped at enqueue time), and the
+   * default run-id factory. Defaults to `Date.now`.
    */
   now?: () => number;
   /**
@@ -287,7 +288,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
   const { queue, enumerate, logger } = opts;
   const now = opts.now ?? (() => Date.now());
   const sweepIntervalMs = opts.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS;
-  const runIdFactory = opts.runIdFactory ?? defaultRunIdFactory();
+  const runIdFactory = opts.runIdFactory ?? defaultRunIdFactory(now);
   const onSweepCommErrors = opts.onSweepCommErrors;
   const warmHealth = opts.warmHealth;
 
@@ -576,8 +577,6 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       }
 
       const triggered = tickOpts?.triggered === true;
-      const nowMs = now();
-      const enqueuedAt = new Date(nowMs).toISOString();
 
       const enumerateCtx: EnumerateContext = { triggered, runId };
       if (tickOpts?.filter !== undefined) enumerateCtx.filter = tickOpts.filter;
@@ -588,13 +587,15 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       } catch (err) {
         // Enumeration failure short-circuits production (no services →
         // nothing to enqueue). Still attempt the sweep so dead-worker
-        // reclamation isn't starved by a flaky discovery upstream.
+        // reclamation isn't starved by a flaky discovery upstream. The clock
+        // is read AFTER the (potentially slow) enumerate await so the sweep's
+        // expiry decisions aren't back-dated to tick start.
         logger.error("fleet.producer.enumerate-failed", {
           runId,
           triggered,
           err: err instanceof Error ? err.message : String(err),
         });
-        const sweep = await maybeSweep(nowMs);
+        const sweep = await maybeSweep(now());
         return {
           runId,
           enqueued: 0,
@@ -618,8 +619,11 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       // backlog gate means the very tick that drains a family also resumes
       // its production — sweeping after the gate made production resume a
       // full cron period late. Same cadence gate and fail-open semantics
-      // (maybeSweep swallows sweep failures); only the order changed.
-      const sweep = await maybeSweep(nowMs);
+      // (maybeSweep swallows sweep failures); only the order changed. The
+      // clock is re-read HERE — after the potentially-seconds-long enumerate
+      // await — so lease-expiry decisions and lastSweepAt aren't back-dated
+      // to tick start.
+      const sweep = await maybeSweep(now());
 
       // BACKLOG DEDUPE: scheduled ticks skip any family whose previous batch
       // is still pending (unclaimed) — see filterBackloggedFamilies. Operator-
@@ -643,7 +647,10 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
         const meta: ServiceJobMeta = {
           runId,
           triggered,
-          enqueuedAt,
+          // Stamped at ENQUEUE time (the documented meaning: 'ISO timestamp
+          // the control-plane enqueued the job'), not at tick start — a slow
+          // enumerate/sweep must not back-date it.
+          enqueuedAt: new Date(now()).toISOString(),
         };
         if (spec.priority !== undefined) meta.priority = spec.priority;
         try {
@@ -696,13 +703,15 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
  * gets an INDEPENDENT default factory whose counter starts at 0 — without it,
  * two producers ticking in the same ms with equal tick counts minted the SAME
  * runId, and the aggregator groups results by `meta.runId`. The timestamp
- * segment still leads, keeping ids sortable-prefixed.
+ * segment still leads, keeping ids sortable-prefixed. Reads the producer's
+ * injected clock (injection-discipline consistency with the rest of the
+ * module); behavior is otherwise identical to the Date.now form.
  */
-function defaultRunIdFactory(): () => string {
+function defaultRunIdFactory(now: () => number = () => Date.now()): () => string {
   let counter = 0;
   const discriminator = Math.random().toString(36).slice(2, 8).padEnd(6, "0");
   return () => {
     counter += 1;
-    return `frun_${Date.now().toString(36)}_${discriminator}_${counter.toString(36)}`;
+    return `frun_${now().toString(36)}_${discriminator}_${counter.toString(36)}`;
   };
 }

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -194,8 +194,9 @@ export interface TickResult {
   enqueueFailures: number;
   /**
    * Number of per-service jobs SKIPPED because their family already had a
-   * pending (unclaimed) backlog on the queue (scheduled ticks only — the
-   * backlog dedupe gate; operator-triggered ticks bypass it).
+   * non-terminal (pending/claimed/running) batch on the queue (scheduled
+   * ticks only — the backlog dedupe gate; operator-triggered ticks bypass
+   * it).
    */
   skippedForBacklog: number;
   /** True iff a lease sweep ran during this tick. */
@@ -503,13 +504,16 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
 
   /**
    * BACKLOG DEDUPE GATE (scheduled ticks only). A producer tick must NOT
-   * enqueue a fresh batch for a family that already has pending (unclaimed)
-   * jobs on the queue: with 2 serial browser workers against ~180 jobs/hr of
-   * inflow the un-gated producers compounded a multi-thousand-row backlog
-   * (staging: 3,734 pending, oldest 22h) that starved low-frequency families
-   * out of the claim page entirely. Skipping the batch bounds the per-family
-   * backlog to ONE batch — the next tick re-checks and produces again once
-   * the workers have drained it. Grouped per family so a (hypothetical)
+   * enqueue a fresh batch for a family that already has NON-TERMINAL
+   * (pending/claimed/running) jobs on the queue: with 2 serial browser
+   * workers against ~180 jobs/hr of inflow the un-gated producers compounded
+   * a multi-thousand-row backlog (staging: 3,734 pending, oldest 22h) that
+   * starved low-frequency families out of the claim page entirely. Counting
+   * in-flight (claimed/running) rows too means the gate bounds the family's
+   * CONCURRENT RUNS, not just its unclaimed batches — a fresh batch on top
+   * of a claimed-but-running one would double the family's concurrency.
+   * Skipping the batch bounds the per-family backlog to ONE batch — the next
+   * tick re-checks and produces again once the workers have finished it. Grouped per family so a (hypothetical)
    * multi-family tick gates each family independently. Fail-OPEN on a count
    * blip: a transient PB read failure must never stop job production (the
    * legacy un-gated behavior is the safe fallback), mirroring maybeSweep's
@@ -717,7 +721,8 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     const sweep = await maybeSweep(now());
 
     // BACKLOG DEDUPE: scheduled ticks skip any family whose previous batch
-    // is still pending (unclaimed) — see filterBackloggedFamilies. Operator-
+    // is still non-terminal (pending/claimed/running) — see
+    // filterBackloggedFamilies. Operator-
     // triggered ticks BYPASS the gate: an explicit trigger is a deliberate
     // "run it NOW" (the CLI even treats 0 enqueued as a failure), so
     // operator intent wins over backpressure.

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -190,7 +190,11 @@ export interface TickResult {
   runId: string;
   /** Number of per-service jobs enqueued (services enumerated, minus enqueue failures, backlog-gate skips, AND stop truncation). */
   enqueued: number;
-  /** Number of enqueue attempts that threw (a service that failed to enqueue). */
+  /**
+   * Number of per-service specs that FAILED to become a queued job: enqueue
+   * attempts that threw, plus specs dropped at the boundary for an invalid
+   * (empty) probeKey — see the phantom-family guard in the tick body.
+   */
   enqueueFailures: number;
   /**
    * Number of per-service jobs NOT enqueued because `stop()` truncated the
@@ -900,6 +904,31 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       };
     }
 
+    // PHANTOM-FAMILY GUARD: the enumerator is injected, so a misbehaving
+    // upstream can hand back a spec with an EMPTY probeKey. Downstream that
+    // is poison twice over: `probeKeyFamily("")` returns "" (contracts.ts),
+    // so the backlog gate would count a phantom "" family that gates
+    // nothing real, and the enqueued claim row's empty probe_key can never
+    // join a dashboard status row. Dropped HERE — before the gate, the
+    // warm-up, and the enqueue loop, on scheduled AND triggered ticks —
+    // logged at error per spec, and counted into `enqueueFailures` (after
+    // the enqueue loop, see below) so the tick's partition invariant stays
+    // honest: the spec failed to become a job.
+    let invalidSpecs = 0;
+    const validSpecs: ServiceJobSpec[] = [];
+    for (const spec of specs) {
+      if (typeof spec.probeKey !== "string" || spec.probeKey.length === 0) {
+        invalidSpecs += 1;
+        logger.error("fleet.producer.spec-invalid-probekey", {
+          runId,
+          serviceSlug: spec.serviceSlug,
+          probeKey: String(spec.probeKey),
+        });
+        continue;
+      }
+      validSpecs.push(spec);
+    }
+
     // SWEEP FIRST: the sweep's stale-pending drain can clear a family's
     // entire backlog (a backlog of only-stale rows). Running it BEFORE the
     // backlog gate means the very tick that drains a family also resumes
@@ -918,8 +947,8 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     // "run it NOW" (the CLI even treats 0 enqueued as a failure), so
     // operator intent wins over backpressure.
     const gate = triggered
-      ? { specs, skipped: 0 }
-      : await filterBackloggedFamilies(specs, runId);
+      ? { specs: validSpecs, skipped: 0 }
+      : await filterBackloggedFamilies(validSpecs, runId);
 
     // #72 PRE-DISPATCH WARM-UP: fire fire-and-forget health GETs at every
     // backend that will actually be enqueued (post-gate) BEFORE enqueueing,
@@ -971,6 +1000,12 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
         });
       }
     }
+
+    // Fold the phantom-probeKey drops into the failure count AFTER the
+    // enqueue loop: the loop's truncation arithmetic is relative to
+    // `gate.specs` (already invalid-free), so folding earlier would
+    // double-subtract them from `truncatedByStop`.
+    enqueueFailures += invalidSpecs;
 
     // `services` partitions exactly: services == enqueued + enqueueFailures
     // + skippedForBacklog + truncatedByStop (see TickResult.truncatedByStop).

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -374,6 +374,14 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
    * tick is caught — but stop() guards with .catch anyway.)
    */
   let inFlightTick: Promise<TickResult> | null = null;
+  /**
+   * The ONE operator-triggered tick queued behind an overlapping in-flight
+   * tick, or null. A TRIGGERED tick that hits the re-entrancy guard is not
+   * dropped (operator intent wins — see tick()); it waits for the in-flight
+   * tick and then runs. Capped at one: a second concurrent trigger gets the
+   * skip — the already-queued trigger covers "run after the in-flight tick".
+   */
+  let queuedTrigger: Promise<TickResult> | null = null;
 
   /** Build a `ServiceJobPayload` from a spec + the run's shared meta. */
   function toEnqueueInput(
@@ -857,13 +865,41 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       // RE-ENTRANCY GUARD: a slow tick (sluggish enumerate/PB) overlapping
       // the next cron tick double-enqueued the same family — both ticks read
       // the backlog gate's pending count BEFORE either had enqueued (gate
-      // TOCTOU), so both saw "no backlog" and both produced a batch. Skip
-      // the overlapping tick instead; the cron's NEXT tick will produce.
+      // TOCTOU), so both saw "no backlog" and both produced a batch. A
+      // SCHEDULED overlapping tick is skipped — the cron's NEXT tick will
+      // produce. A TRIGGERED overlapping tick is NOT dropped (an explicit
+      // operator "run it NOW" must win — the same rationale that lets a
+      // trigger bypass the backlog gate): it QUEUES BEHIND the in-flight
+      // tick and runs once that tick completes. Capped at ONE queued
+      // trigger — a second concurrent trigger gets the skip, since the
+      // already-queued trigger covers "run after the in-flight tick".
+      const triggered = tickOpts?.triggered === true;
       if (inFlightTick !== null) {
-        logger.warn("fleet.producer.tick-overlap-skipped", {
-          triggered: tickOpts?.triggered === true,
-        });
-        return skippedTickResult();
+        if (!triggered || queuedTrigger !== null) {
+          logger.warn("fleet.producer.tick-overlap-skipped", {
+            triggered,
+            ...(triggered ? { reason: "trigger-already-queued" } : {}),
+          });
+          return skippedTickResult();
+        }
+        logger.warn("fleet.producer.trigger-queued-behind-overlap", {});
+        const queued = (async (): Promise<TickResult> => {
+          // Loop (not a single await): by the time the awaited tick's
+          // continuations run, another tick may already occupy the slot.
+          while (inFlightTick !== null) {
+            await inFlightTick.catch(() => {});
+          }
+          queuedTrigger = null;
+          const ticking = runTick(tickOpts);
+          inFlightTick = ticking;
+          try {
+            return await ticking;
+          } finally {
+            inFlightTick = null;
+          }
+        })();
+        queuedTrigger = queued;
+        return queued;
       }
       const ticking = runTick(tickOpts);
       inFlightTick = ticking;

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -169,6 +169,14 @@ export interface TickResult {
   skippedForBacklog: number;
   /** True iff a lease sweep ran during this tick. */
   sweptExpired: boolean;
+  /**
+   * True iff a sweep RAN during this tick but FAILED (the `sweepExpired` call
+   * threw). `sweptExpired` stays true in that case — a failed sweep still
+   * consumes its cadence window (see `maybeSweep`) — so without this flag a
+   * failed sweep was indistinguishable from a clean zero-reclaim sweep in the
+   * tick outcome.
+   */
+  sweepFailed: boolean;
   /** Expired leases reclaimed by the sweep, when one ran (else 0). */
   reclaimed: number;
 }
@@ -303,12 +311,12 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
    */
   async function maybeSweep(
     nowMs: number,
-  ): Promise<{ swept: boolean; reclaimed: number }> {
+  ): Promise<{ swept: boolean; sweepFailed: boolean; reclaimed: number }> {
     const due =
       sweepIntervalMs <= 0 ||
       lastSweepAt === null ||
       nowMs - lastSweepAt >= sweepIntervalMs;
-    if (!due) return { swept: false, reclaimed: 0 };
+    if (!due) return { swept: false, sweepFailed: false, reclaimed: 0 };
     lastSweepAt = nowMs;
     try {
       const result = await queue.sweepExpired(nowMs);
@@ -339,15 +347,17 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
           });
         }
       }
-      return { swept: true, reclaimed: result.reclaimed };
+      return { swept: true, sweepFailed: false, reclaimed: result.reclaimed };
     } catch (err) {
       logger.error("fleet.producer.sweep-failed", {
         err: err instanceof Error ? err.message : String(err),
       });
       // A failed sweep still counts as "swept" for cadence purposes — we
       // don't want a persistently-failing sweep to fire on every tick and
-      // bury the logs; the window already advanced via lastSweepAt.
-      return { swept: true, reclaimed: 0 };
+      // bury the logs; the window already advanced via lastSweepAt. But it
+      // is REPORTED as failed (`sweepFailed: true`) so the tick outcome no
+      // longer presents a thrown sweep as a clean zero-reclaim success.
+      return { swept: true, sweepFailed: true, reclaimed: 0 };
     }
   }
 
@@ -496,6 +506,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
           enqueueFailures: 0,
           skippedForBacklog: 0,
           sweptExpired: false,
+          sweepFailed: false,
           reclaimed: 0,
         };
       }
@@ -526,6 +537,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
           enqueueFailures: 0,
           skippedForBacklog: 0,
           sweptExpired: sweep.swept,
+          sweepFailed: sweep.sweepFailed,
           reclaimed: sweep.reclaimed,
         };
       }
@@ -593,6 +605,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
         enqueueFailures,
         skippedForBacklog: gate.skipped,
         sweptExpired: sweep.swept,
+        sweepFailed: sweep.sweepFailed,
         reclaimed: sweep.reclaimed,
       });
 
@@ -602,6 +615,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
         enqueueFailures,
         skippedForBacklog: gate.skipped,
         sweptExpired: sweep.swept,
+        sweepFailed: sweep.sweepFailed,
         reclaimed: sweep.reclaimed,
       };
     },

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -118,7 +118,11 @@ export interface ServiceJobSpec {
   cellIds?: string[];
   /** Free-form driver inputs threaded to the worker's driver. */
   driverInputs?: Record<string, unknown>;
-  /** Optional per-job priority hint (higher pulls first). */
+  /**
+   * Optional per-job priority hint, copied verbatim onto `meta.priority`.
+   * RESERVED: not currently consulted by `claimNext` (workers pull in queue
+   * order regardless of this value).
+   */
   priority?: number;
 }
 
@@ -143,7 +147,11 @@ export interface EnumerateContext {
   triggered: boolean;
   /** Stable id of this run batch (same id stamped onto every job's meta). */
   runId: string;
-  /** Optional operator filter (slug / feature scoping), trigger-only. */
+  /**
+   * Optional operator filter (slug / feature scoping). Only ever present on
+   * TRIGGERED runs — the producer never forwards a filter on a scheduled
+   * tick (a scheduled tick must never be scoped).
+   */
   filter?: { slugs?: string[]; featureTypes?: string[] };
 }
 
@@ -151,7 +159,11 @@ export interface EnumerateContext {
 export interface TickOptions {
   /** True when an operator triggered this run; default false (scheduled). */
   triggered?: boolean;
-  /** Operator filter forwarded to the enumerator (trigger-only). */
+  /**
+   * Operator filter forwarded to the enumerator — TRIGGERED ticks only. A
+   * filter passed without `triggered: true` is IGNORED (warned, not
+   * forwarded): a scheduled tick must never be scoped.
+   */
   filter?: { slugs?: string[]; featureTypes?: string[] };
 }
 
@@ -579,7 +591,16 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       const triggered = tickOpts?.triggered === true;
 
       const enumerateCtx: EnumerateContext = { triggered, runId };
-      if (tickOpts?.filter !== undefined) enumerateCtx.filter = tickOpts.filter;
+      // The filter is TRIGGER-ONLY: a scheduled (cron) tick must never be
+      // scoped, so a filter passed without `triggered: true` is dropped (and
+      // warned) rather than forwarded to the enumerator.
+      if (tickOpts?.filter !== undefined) {
+        if (triggered) {
+          enumerateCtx.filter = tickOpts.filter;
+        } else {
+          logger.warn("fleet.producer.filter-ignored-scheduled", { runId });
+        }
+      }
 
       let specs: ServiceJobSpec[];
       try {

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -52,8 +52,9 @@ import { deriveHealthUrl } from "../../probes/liveness.js";
 
 /**
  * Sink the producer hands its lease-sweep comm errors to (REQ-B). `sweepExpired`
- * reclaims a crashed/lease-expired worker's job and synthesizes one
- * `worker-crashed-mid-job` `PoolCommError` per reclaimed job; those errors only
+ * reclaims a lease-expired worker's job (re-queues it to pending) and
+ * synthesizes one neutral `worker-reclaimed-pending` `PoolCommError` per
+ * reclaimed job; those errors only
  * reach the dashboard once they are written onto the job's status row. The
  * producer does NOT own the status pipeline (it owns no PB/aggregator), so it
  * FORWARDS the swept errors to this injected sink — the wiring slot
@@ -156,7 +157,7 @@ export interface TickOptions {
 export interface TickResult {
   /** The run batch id every enqueued job in this tick shares. */
   runId: string;
-  /** Number of per-service jobs enqueued (== services enumerated, minus failures). */
+  /** Number of per-service jobs enqueued (services enumerated, minus enqueue failures and backlog-gate skips). */
   enqueued: number;
   /** Number of enqueue attempts that threw (a service that failed to enqueue). */
   enqueueFailures: number;
@@ -199,11 +200,11 @@ export interface JobProducerOptions {
    */
   runIdFactory?: () => string;
   /**
-   * Sink for the lease-sweep's `worker-crashed-mid-job` comm errors (REQ-B).
+   * Sink for the lease-sweep's `worker-reclaimed-pending` comm errors (REQ-B).
    * When omitted, swept errors are logged only (the legacy behaviour) — but the
-   * wiring slot injects this so a crashed worker's "unreachable" overlay reaches
-   * the dashboard via the aggregator. Failures are swallowed (logged) and never
-   * abort job production.
+   * wiring slot injects this so a reclaimed job's gray "re-queued" surface
+   * reaches the dashboard via the aggregator. Failures are swallowed (logged)
+   * and never abort job production.
    */
   onSweepCommErrors?: SweepCommErrorSink;
   /**
@@ -322,9 +323,9 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
           expiredPending: result.expiredPending ?? 0,
         });
       }
-      // REQ-B: forward the swept `worker-crashed-mid-job` comm errors to the
-      // injected sink so each reclaimed job's "unreachable" overlay reaches the
-      // dashboard (the producer owns no status pipeline of its own). Previously
+      // REQ-B: forward the swept `worker-reclaimed-pending` comm errors to the
+      // injected sink so each reclaimed job's gray "re-queued" surface reaches
+      // the dashboard (the producer owns no status pipeline of its own). Previously
       // these were DROPPED after logging their count — the crash/lease-expiry
       // overlay never surfaced. Best-effort: a sink failure must not abort job
       // production, so we log and swallow (the next sweep retries).

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -46,6 +46,7 @@ import type {
   PoolCommError,
   ServiceJobMeta,
   ServiceJobPayload,
+  SweepResult,
 } from "../contracts.js";
 import { probeKeyFamily } from "../contracts.js";
 import { deriveHealthUrl } from "../../probes/liveness.js";
@@ -218,8 +219,28 @@ export interface TickResult {
    * tick outcome.
    */
   sweepFailed: boolean;
-  /** Expired leases reclaimed by the sweep, when one ran (else 0). */
+  /**
+   * Expired leases reclaimed by the sweep, when one ran (else 0).
+   *
+   * AT-LEAST-ONCE / MAY OVER-REPORT: a reclaim whose release transport call
+   * fails AFTER the queue committed the re-queue is still counted here (the
+   * producer cannot tell a failed release from a lost response), so under
+   * release transport failures this count can exceed the number of jobs
+   * actually returned to pending. When the queue client reports the
+   * indeterminate slice separately, it is surfaced via
+   * `reclaimedIndeterminate` below.
+   */
   reclaimed: number;
+  /**
+   * Of `reclaimed`, the reclaims whose release outcome was INDETERMINATE
+   * (transport failure after the CAS — the over-report slice). OPTIONAL and
+   * read off the queue's sweep result via optional access: the split is
+   * provided by the queue-client's `SweepResult` extension (sibling branch);
+   * absent when the queue does not report it. INTEGRATOR NOTE: once the
+   * queue-client's `reclaimedIndeterminate` lands on the shared `SweepResult`
+   * contract, the optional access in `maybeSweep` can read it directly.
+   */
+  reclaimedIndeterminate?: number;
   /**
    * True iff the enumerator THREW on this tick (production short-circuited —
    * nothing was enqueued). Without this flag a discovery outage was
@@ -521,9 +542,12 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
    * swallowed — a transient PB blip on the reclamation path must NEVER
    * abort job production (the next tick retries).
    */
-  async function maybeSweep(
-    nowMs: number,
-  ): Promise<{ swept: boolean; sweepFailed: boolean; reclaimed: number }> {
+  async function maybeSweep(nowMs: number): Promise<{
+    swept: boolean;
+    sweepFailed: boolean;
+    reclaimed: number;
+    reclaimedIndeterminate?: number;
+  }> {
     const due =
       sweepIntervalMs <= 0 ||
       lastSweepAt === null ||
@@ -555,7 +579,22 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       // deliverSweepCommErrors — it runs on every sweep attempt, even a failed
       // one). The buffer is capped at MAX_BUFFERED_SWEEP_COMM_ERRORS.
       await deliverSweepCommErrors(result.commErrors);
-      return { swept: true, sweepFailed: false, reclaimed: result.reclaimed };
+      // OPTIONAL ACCESS (integrator coupling): the queue-client's sweep
+      // splits out reclaims whose release outcome was indeterminate
+      // (`reclaimedIndeterminate`, sibling branch) — read defensively so
+      // this module compiles against a SweepResult without the split, and
+      // surface it on the TickResult only when reported as a number.
+      const indeterminate = (
+        result as SweepResult & { reclaimedIndeterminate?: unknown }
+      ).reclaimedIndeterminate;
+      return {
+        swept: true,
+        sweepFailed: false,
+        reclaimed: result.reclaimed,
+        ...(typeof indeterminate === "number"
+          ? { reclaimedIndeterminate: indeterminate }
+          : {}),
+      };
     } catch (err) {
       logger.error("fleet.producer.sweep-failed", {
         err: err instanceof Error ? err.message : String(err),
@@ -812,6 +851,9 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
         sweptExpired: sweep.swept,
         sweepFailed: sweep.sweepFailed,
         reclaimed: sweep.reclaimed,
+        ...(sweep.reclaimedIndeterminate !== undefined
+          ? { reclaimedIndeterminate: sweep.reclaimedIndeterminate }
+          : {}),
         enumerateFailed: true,
       };
     }
@@ -901,6 +943,9 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       sweptExpired: sweep.swept,
       sweepFailed: sweep.sweepFailed,
       reclaimed: sweep.reclaimed,
+      ...(sweep.reclaimedIndeterminate !== undefined
+        ? { reclaimedIndeterminate: sweep.reclaimedIndeterminate }
+        : {}),
     });
 
     return {
@@ -912,6 +957,9 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       sweptExpired: sweep.swept,
       sweepFailed: sweep.sweepFailed,
       reclaimed: sweep.reclaimed,
+      ...(sweep.reclaimedIndeterminate !== undefined
+        ? { reclaimedIndeterminate: sweep.reclaimedIndeterminate }
+        : {}),
       enumerateFailed: false,
     };
   }
@@ -1027,6 +1075,15 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
             await inFlightTick.catch(() => {});
           }
           queuedTrigger = null;
+          if (!running) {
+            // stop() flipped `running` while this trigger waited behind the
+            // in-flight tick — a quiesce ordering the producer itself
+            // orchestrated, NOT the scheduler-wiring bug runTick's
+            // tick-while-stopped WARN flags. Distinct debug event so the
+            // ordering stays observable without a misleading warn.
+            logger.debug("fleet.producer.queued-trigger-after-stop");
+            return skippedTickResult();
+          }
           const ticking = runTick(tickOpts);
           inFlightTick = ticking;
           try {

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -311,10 +311,15 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     lastSweepAt = nowMs;
     try {
       const result = await queue.sweepExpired(nowMs);
-      if (result.reclaimed > 0 || result.commErrors.length > 0) {
+      if (
+        result.reclaimed > 0 ||
+        result.commErrors.length > 0 ||
+        (result.expiredPending ?? 0) > 0
+      ) {
         logger.warn("fleet.producer.sweep-reclaimed", {
           reclaimed: result.reclaimed,
           commErrors: result.commErrors.length,
+          expiredPending: result.expiredPending ?? 0,
         });
       }
       // REQ-B: forward the swept `worker-crashed-mid-job` comm errors to the

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -48,6 +48,7 @@ import type {
   ServiceJobPayload,
 } from "../contracts.js";
 import { probeKeyFamily } from "../contracts.js";
+import { PoisonedBacklogCountError } from "../queue-client.js";
 import { deriveHealthUrl } from "../../probes/liveness.js";
 
 /**
@@ -356,17 +357,6 @@ export const DEFAULT_SWEEP_INTERVAL_MS = 30_000;
  * the fresher dashboard signal.
  */
 export const MAX_BUFFERED_SWEEP_COMM_ERRORS = 500;
-
-/**
- * The queue-client's poisoned-count refusal message marker (see
- * `countPendingForFamily` in queue-client.ts: it THROWS rather than return a
- * non-count totalItems that would silently fail the backlog gate open).
- * Matched on the error MESSAGE substring because the queue-client does not
- * export a dedicated error class for the refusal — a defensive string match
- * keyed on the stable, documented phrase. If the queue-client ever exports
- * the error type, switch the gate's catch to `instanceof`.
- */
-const POISONED_COUNT_MARKER = "refusing to fail the backlog gate open";
 
 /**
  * The no-op `TickResult` for a tick that never RAN (skipped because a
@@ -699,11 +689,14 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
         pendingCount = await queue.countPendingForFamily(family);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        if (message.includes(POISONED_COUNT_MARKER)) {
+        if (err instanceof PoisonedBacklogCountError) {
           // FAIL CLOSED: the queue-client refused a poisoned (non-count)
           // totalItems rather than fail the gate open — honoring that means
           // SKIPPING this family's batch, not producing on top of an
-          // unknowable backlog. The next tick re-checks.
+          // unknowable backlog. The next tick re-checks. Discriminated via
+          // the DEDICATED exported class (instanceof) — the old
+          // message-substring match silently flipped this fail-closed class
+          // into the fail-open catch below on any message drift.
           skipped += group.length;
           logger.error("fleet.producer.backlog-check-poisoned", {
             runId,

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -298,9 +298,21 @@ function backendUrlFromSpec(spec: ServiceJobSpec): string | undefined {
  * shutdown.
  */
 export interface JobProducer {
-  /** Begin producing. Idempotent; after `stop()` it stays stopped. */
+  /**
+   * LIFECYCLE: created → start() → stop(), one-way. start() is idempotent
+   * while running; once a STARTED producer has been stop()ped it stays
+   * stopped (start-after-stop is a warned no-op — producers are not
+   * restartable). stop() BEFORE start() is a debug-logged NO-OP that does
+   * NOT latch the stopped state: a teardown that races ahead of boot wiring
+   * must not permanently brick a producer that never ran.
+   */
+  /** Begin producing. Idempotent; after a started producer's `stop()` it stays stopped. */
   start(): void;
-  /** Stop producing. After this, `tick()` is a no-op (returns 0 enqueued). */
+  /**
+   * Stop producing. After this, `tick()` is a no-op (returns 0 enqueued).
+   * Idempotent for a STARTED producer; a no-op before start() (see the
+   * lifecycle note above).
+   */
   stop(): Promise<void>;
   /**
    * Run one production cycle: enumerate per-service units, enqueue one job
@@ -364,6 +376,13 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
   const warmHealth = opts.warmHealth;
 
   let running = false;
+  /**
+   * True once start() has EVER run. Distinguishes "stopped after running"
+   * (one-way latch via `stopped`) from "never started": stop() before
+   * start() must be a no-op, not a brick — see the JobProducer lifecycle
+   * doc.
+   */
+  let started = false;
   let stopped = false;
   /**
    * ms-since-epoch of the last sweep, or null if none has run. Gates the
@@ -895,11 +914,21 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       }
       if (running) return;
       running = true;
+      started = true;
       logger.info("fleet.producer.start", { sweepIntervalMs });
     },
 
     async stop() {
       if (!running) {
+        if (!started) {
+          // stop() BEFORE start(): nothing ever ran, so there is nothing to
+          // quiesce or drain — and latching `stopped` here (the old
+          // behavior) permanently bricked the producer: every later start()
+          // hit the start-after-stop latch. A teardown racing ahead of boot
+          // wiring is a benign ordering, not a lifecycle end — no-op.
+          logger.debug("fleet.producer.stop-before-start");
+          return;
+        }
         stopped = true;
         // A SECOND concurrent stop() lands here (the first flipped `running`
         // synchronously) — it must STILL quiesce: returning while the first

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -172,7 +172,12 @@ export interface TickOptions {
 
 /** Outcome of one production cycle, returned to the wiring/scheduler layer. */
 export interface TickResult {
-  /** The run batch id every enqueued job in this tick shares. */
+  /**
+   * The run batch id every enqueued job in this tick shares. Empty string
+   * (`""`) when the tick never RAN — skipped because a previous tick was
+   * still in flight: a tick that produces nothing by construction does not
+   * mint a runId.
+   */
   runId: string;
   /** Number of per-service jobs enqueued (services enumerated, minus enqueue failures and backlog-gate skips). */
   enqueued: number;
@@ -298,6 +303,25 @@ export const DEFAULT_SWEEP_INTERVAL_MS = 30_000;
  * the fresher dashboard signal.
  */
 export const MAX_BUFFERED_SWEEP_COMM_ERRORS = 500;
+
+/**
+ * The no-op `TickResult` for a tick that never RAN (e.g. skipped because a
+ * previous tick was still in flight). `runId` is the empty-string sentinel:
+ * no run was minted — a tick that produces nothing by construction must not
+ * burn the run-id counter or log phantom runIds.
+ */
+function skippedTickResult(): TickResult {
+  return {
+    runId: "",
+    enqueued: 0,
+    enqueueFailures: 0,
+    skippedForBacklog: 0,
+    sweptExpired: false,
+    sweepFailed: false,
+    reclaimed: 0,
+    enumerateFailed: false,
+  };
+}
 
 export function createJobProducer(opts: JobProducerOptions): JobProducer {
   const { queue, enumerate, logger } = opts;
@@ -783,6 +807,17 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     },
 
     async tick(tickOpts?: TickOptions): Promise<TickResult> {
+      // RE-ENTRANCY GUARD: a slow tick (sluggish enumerate/PB) overlapping
+      // the next cron tick double-enqueued the same family — both ticks read
+      // the backlog gate's pending count BEFORE either had enqueued (gate
+      // TOCTOU), so both saw "no backlog" and both produced a batch. Skip
+      // the overlapping tick instead; the cron's NEXT tick will produce.
+      if (inFlightTick !== null) {
+        logger.warn("fleet.producer.tick-overlap-skipped", {
+          triggered: tickOpts?.triggered === true,
+        });
+        return skippedTickResult();
+      }
       const ticking = runTick(tickOpts);
       inFlightTick = ticking;
       try {

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -213,6 +213,17 @@ export interface TickResult {
    * it).
    */
   skippedForBacklog: number;
+  /**
+   * Number of FAMILIES the backlog gate kept via its FAIL-OPEN path:
+   * `countPendingForFamily` failed with a non-poisoned (transient) error, so
+   * the family's batch was produced WITHOUT a backlog check (the legacy
+   * un-gated behavior as the safe fallback). Without this count a
+   * failed-open gate was indistinguishable in the tick outcome from a gate
+   * that read a clean zero — the same ambiguity class `sweepFailed` /
+   * `enumerateFailed` exist to remove. 0 when the gate did not run at all
+   * (triggered ticks bypass it; skipped ticks never reach it).
+   */
+  backlogGateFailedOpen: number;
   /** True iff a lease sweep ran during this tick. */
   sweptExpired: boolean;
   /**
@@ -371,6 +382,7 @@ function skippedTickResult(): TickResult {
     enqueued: 0,
     enqueueFailures: 0,
     skippedForBacklog: 0,
+    backlogGateFailedOpen: 0,
     truncatedByStop: 0,
     sweptExpired: false,
     sweepFailed: false,
@@ -673,7 +685,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
   async function filterBackloggedFamilies(
     specs: ServiceJobSpec[],
     runId: string,
-  ): Promise<{ specs: ServiceJobSpec[]; skipped: number }> {
+  ): Promise<{ specs: ServiceJobSpec[]; skipped: number; failedOpen: number }> {
     const byFamily = new Map<string, ServiceJobSpec[]>();
     for (const spec of specs) {
       const family = probeKeyFamily(spec.probeKey);
@@ -683,6 +695,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     }
     const kept: ServiceJobSpec[] = [];
     let skipped = 0;
+    let failedOpen = 0;
     for (const [family, group] of byFamily) {
       let pendingCount: number;
       try {
@@ -707,6 +720,9 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
           continue;
         }
         // FAIL OPEN: a transient read blip must never stop production.
+        // Counted (per FAMILY) into the tick outcome so a failed-open gate
+        // is distinguishable from a clean zero-backlog read.
+        failedOpen += 1;
         logger.error("fleet.producer.backlog-check-failed", {
           runId,
           family,
@@ -727,7 +743,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       }
       kept.push(...group);
     }
-    return { specs: kept, skipped };
+    return { specs: kept, skipped, failedOpen };
   }
 
   /**
@@ -886,6 +902,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
         enqueued: 0,
         enqueueFailures: 0,
         skippedForBacklog: 0,
+        backlogGateFailedOpen: 0,
         truncatedByStop: 0,
         sweptExpired: sweep.swept,
         sweepFailed: sweep.sweepFailed,
@@ -954,7 +971,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     // "run it NOW" (the CLI even treats 0 enqueued as a failure), so
     // operator intent wins over backpressure.
     const gate = triggered
-      ? { specs: validSpecs, skipped: 0 }
+      ? { specs: validSpecs, skipped: 0, failedOpen: 0 }
       : await filterBackloggedFamilies(validSpecs, runId);
 
     // #72 PRE-DISPATCH WARM-UP: fire fire-and-forget health GETs at every
@@ -1023,6 +1040,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       enqueued,
       enqueueFailures,
       skippedForBacklog: gate.skipped,
+      backlogGateFailedOpen: gate.failedOpen,
       truncatedByStop,
       sweptExpired: sweep.swept,
       sweepFailed: sweep.sweepFailed,
@@ -1037,6 +1055,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       enqueued,
       enqueueFailures,
       skippedForBacklog: gate.skipped,
+      backlogGateFailedOpen: gate.failedOpen,
       truncatedByStop,
       sweptExpired: sweep.swept,
       sweepFailed: sweep.sweepFailed,

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -910,6 +910,20 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     let invalidSpecs = 0;
     const validSpecs: ServiceJobSpec[] = [];
     for (const spec of specs) {
+      // ELEMENT-SHAPE GUARD first: the enumerator is injected, so an element
+      // can be null/undefined/a primitive — dereferencing `.probeKey` on
+      // those THREW a TypeError out of the tick body, rejecting the tick
+      // promise (violating the "a tick promise never rejects" invariant; a
+      // rejection inside stop()'s quiesce would poison stopPromise). Same
+      // honest accounting as the empty-probeKey drop below.
+      if (spec === null || typeof spec !== "object") {
+        invalidSpecs += 1;
+        logger.error("fleet.producer.spec-invalid-probekey", {
+          runId,
+          spec: String(spec),
+        });
+        continue;
+      }
       if (typeof spec.probeKey !== "string" || spec.probeKey.length === 0) {
         invalidSpecs += 1;
         logger.error("fleet.producer.spec-invalid-probekey", {

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -689,14 +689,20 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
 }
 
 /**
- * Default run-id factory: timestamp + monotonic counter composite,
- * matching the scheduler's `nextRunId` idiom so two runs that land in the
- * same ms still get distinct ids.
+ * Default run-id factory: timestamp + per-factory random discriminator +
+ * monotonic counter composite, matching the scheduler's `nextRunId` idiom so
+ * two runs that land in the same ms still get distinct ids. The DISCRIMINATOR
+ * (generated once at factory creation) exists because every producer instance
+ * gets an INDEPENDENT default factory whose counter starts at 0 — without it,
+ * two producers ticking in the same ms with equal tick counts minted the SAME
+ * runId, and the aggregator groups results by `meta.runId`. The timestamp
+ * segment still leads, keeping ids sortable-prefixed.
  */
 function defaultRunIdFactory(): () => string {
   let counter = 0;
+  const discriminator = Math.random().toString(36).slice(2, 8).padEnd(6, "0");
   return () => {
     counter += 1;
-    return `frun_${Date.now().toString(36)}_${counter.toString(36)}`;
+    return `frun_${Date.now().toString(36)}_${discriminator}_${counter.toString(36)}`;
   };
 }

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -46,7 +46,6 @@ import type {
   PoolCommError,
   ServiceJobMeta,
   ServiceJobPayload,
-  SweepResult,
 } from "../contracts.js";
 import { probeKeyFamily } from "../contracts.js";
 import { deriveHealthUrl } from "../../probes/liveness.js";
@@ -233,12 +232,10 @@ export interface TickResult {
   reclaimed: number;
   /**
    * Of `reclaimed`, the reclaims whose release outcome was INDETERMINATE
-   * (transport failure after the CAS — the over-report slice). OPTIONAL and
-   * read off the queue's sweep result via optional access: the split is
-   * provided by the queue-client's `SweepResult` extension (sibling branch);
-   * absent when the queue does not report it. INTEGRATOR NOTE: once the
-   * queue-client's `reclaimedIndeterminate` lands on the shared `SweepResult`
-   * contract, the optional access in `maybeSweep` can read it directly.
+   * (transport failure after the CAS — the over-report slice). OPTIONAL,
+   * mirroring the shared `SweepResult.reclaimedIndeterminate` contract
+   * field `maybeSweep` reads directly: absent when the queue does not
+   * report the split (the real queue-client always does).
    */
   reclaimedIndeterminate?: number;
   /**
@@ -579,14 +576,11 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       // deliverSweepCommErrors — it runs on every sweep attempt, even a failed
       // one). The buffer is capped at MAX_BUFFERED_SWEEP_COMM_ERRORS.
       await deliverSweepCommErrors(result.commErrors);
-      // OPTIONAL ACCESS (integrator coupling): the queue-client's sweep
-      // splits out reclaims whose release outcome was indeterminate
-      // (`reclaimedIndeterminate`, sibling branch) — read defensively so
-      // this module compiles against a SweepResult without the split, and
-      // surface it on the TickResult only when reported as a number.
-      const indeterminate = (
-        result as SweepResult & { reclaimedIndeterminate?: unknown }
-      ).reclaimedIndeterminate;
+      // The queue-client's sweep splits out reclaims whose release outcome
+      // was indeterminate (`reclaimedIndeterminate`, optional on the shared
+      // `SweepResult` contract; the real queue-client always reports it).
+      // Surface it on the TickResult only when reported.
+      const indeterminate = result.reclaimedIndeterminate;
       return {
         swept: true,
         sweepFailed: false,

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -474,27 +474,48 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       // Fire-and-forget: an AbortController bounds each GET so a hung cold
       // container can't leak a pending request across ticks. The whole chain is
       // swallowed — warm-up is a latency optimization, never a correctness gate.
-      const ac = new AbortController();
-      const timer = setTimeout(() => ac.abort(), timeoutMs);
-      void fetchImpl(healthUrl, { method: "GET", signal: ac.signal })
-        .then(
-          () => {
-            logger.debug("fleet.producer.warm-ok", {
-              serviceSlug: spec.serviceSlug,
-              healthUrl,
-            });
-          },
-          (err: unknown) => {
-            // A cold container still booting / a network blip is EXPECTED here —
-            // the warm is precisely for the not-yet-ready case. Debug-level only.
-            logger.debug("fleet.producer.warm-failed", {
-              serviceSlug: spec.serviceSlug,
-              healthUrl,
-              err: err instanceof Error ? err.message : String(err),
-            });
-          },
-        )
-        .finally(() => clearTimeout(timer));
+      // The DISPATCH itself is try/caught too: an injected fetchImpl that throws
+      // SYNCHRONOUSLY must not escape the loop and abort the tick before any
+      // job is enqueued.
+      try {
+        const ac = new AbortController();
+        const timer = setTimeout(() => ac.abort(), timeoutMs);
+        // Never let a pending warm timer hold the process open (guarded:
+        // fake-timer impls may hand back handles without unref).
+        (timer as unknown as { unref?: () => void }).unref?.();
+        void fetchImpl(healthUrl, { method: "GET", signal: ac.signal })
+          .then(
+            (res) => {
+              // Consume the response: under undici an unread body pins the
+              // socket. Best-effort cancel, guarded for non-stream fakes.
+              try {
+                void res.body?.cancel()?.catch?.(() => {});
+              } catch {
+                // a fake Response without a cancellable body — nothing to free
+              }
+              logger.debug("fleet.producer.warm-ok", {
+                serviceSlug: spec.serviceSlug,
+                healthUrl,
+              });
+            },
+            (err: unknown) => {
+              // A cold container still booting / a network blip is EXPECTED here —
+              // the warm is precisely for the not-yet-ready case. Debug-level only.
+              logger.debug("fleet.producer.warm-failed", {
+                serviceSlug: spec.serviceSlug,
+                healthUrl,
+                err: err instanceof Error ? err.message : String(err),
+              });
+            },
+          )
+          .finally(() => clearTimeout(timer));
+      } catch (err) {
+        logger.debug("fleet.producer.warm-failed", {
+          serviceSlug: spec.serviceSlug,
+          healthUrl,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
     if (fired > 0) {
       logger.info("fleet.producer.warmed", { warmed: fired });

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -325,6 +325,14 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
    * at `MAX_BUFFERED_SWEEP_COMM_ERRORS`, oldest dropped on overflow.
    */
   let undeliveredCommErrors: PoolCommError[] = [];
+  /**
+   * The currently-executing tick's promise, or null when no tick is in
+   * flight. `stop()` awaits it so "stopped" means QUIESCED — an in-flight
+   * tick can no longer keep enumerating/sweeping/enqueueing after stop()
+   * resolves. (A tick promise never rejects — every failure path inside the
+   * tick is caught — but stop() guards with .catch anyway.)
+   */
+  let inFlightTick: Promise<TickResult> | null = null;
 
   /** Build a `ServiceJobPayload` from a spec + the run's shared meta. */
   function toEnqueueInput(
@@ -565,6 +573,164 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     return fired;
   }
 
+  /** One production cycle — the body `tick()` runs and `stop()` quiesces on. */
+  async function runTick(tickOpts?: TickOptions): Promise<TickResult> {
+    const runId = runIdFactory();
+    if (!running) {
+      // Defensive: a tick that arrives after stop() (or before start())
+      // produces nothing. Mirrors the scheduler's drain-after-stop
+      // discipline — no jobs leak past the producer's lifecycle.
+      logger.warn("fleet.producer.tick-while-stopped", { runId });
+      return {
+        runId,
+        enqueued: 0,
+        enqueueFailures: 0,
+        skippedForBacklog: 0,
+        sweptExpired: false,
+        sweepFailed: false,
+        reclaimed: 0,
+        enumerateFailed: false,
+      };
+    }
+
+    const triggered = tickOpts?.triggered === true;
+
+    const enumerateCtx: EnumerateContext = { triggered, runId };
+    // The filter is TRIGGER-ONLY: a scheduled (cron) tick must never be
+    // scoped, so a filter passed without `triggered: true` is dropped (and
+    // warned) rather than forwarded to the enumerator.
+    if (tickOpts?.filter !== undefined) {
+      if (triggered) {
+        enumerateCtx.filter = tickOpts.filter;
+      } else {
+        logger.warn("fleet.producer.filter-ignored-scheduled", { runId });
+      }
+    }
+
+    let specs: ServiceJobSpec[];
+    try {
+      specs = await enumerate(enumerateCtx);
+    } catch (err) {
+      // Enumeration failure short-circuits production (no services →
+      // nothing to enqueue). Still attempt the sweep so dead-worker
+      // reclamation isn't starved by a flaky discovery upstream. The clock
+      // is read AFTER the (potentially slow) enumerate await so the sweep's
+      // expiry decisions aren't back-dated to tick start.
+      logger.error("fleet.producer.enumerate-failed", {
+        runId,
+        triggered,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      const sweep = await maybeSweep(now());
+      return {
+        runId,
+        enqueued: 0,
+        enqueueFailures: 0,
+        skippedForBacklog: 0,
+        sweptExpired: sweep.swept,
+        sweepFailed: sweep.sweepFailed,
+        reclaimed: sweep.reclaimed,
+        enumerateFailed: true,
+      };
+    }
+
+    logger.info("fleet.producer.tick-start", {
+      runId,
+      triggered,
+      services: specs.length,
+    });
+
+    // SWEEP FIRST: the sweep's stale-pending drain can clear a family's
+    // entire backlog (a backlog of only-stale rows). Running it BEFORE the
+    // backlog gate means the very tick that drains a family also resumes
+    // its production — sweeping after the gate made production resume a
+    // full cron period late. Same cadence gate and fail-open semantics
+    // (maybeSweep swallows sweep failures); only the order changed. The
+    // clock is re-read HERE — after the potentially-seconds-long enumerate
+    // await — so lease-expiry decisions and lastSweepAt aren't back-dated
+    // to tick start.
+    const sweep = await maybeSweep(now());
+
+    // BACKLOG DEDUPE: scheduled ticks skip any family whose previous batch
+    // is still pending (unclaimed) — see filterBackloggedFamilies. Operator-
+    // triggered ticks BYPASS the gate: an explicit trigger is a deliberate
+    // "run it NOW" (the CLI even treats 0 enqueued as a failure), so
+    // operator intent wins over backpressure.
+    const gate = triggered
+      ? { specs, skipped: 0 }
+      : await filterBackloggedFamilies(specs, runId);
+
+    // #72 PRE-DISPATCH WARM-UP: fire fire-and-forget health GETs at every
+    // backend that will actually be enqueued (post-gate) BEFORE enqueueing,
+    // so cold containers start waking ahead of the pills that probe them.
+    // Best-effort and non-blocking — the GETs are dispatched (not awaited),
+    // so a slow cold container never delays the run's enqueue.
+    warmEnumeratedBackends(gate.specs);
+
+    let enqueued = 0;
+    let enqueueFailures = 0;
+    for (const spec of gate.specs) {
+      // QUIESCE re-check: stop() flips `running` and then awaits this tick.
+      // Dispatching the REST of the batch after stop began would leak jobs
+      // past the producer's lifecycle — truncate, loudly.
+      if (!running) {
+        logger.warn("fleet.producer.enqueue-truncated-stopped", {
+          runId,
+          enqueued,
+          enqueueFailures,
+          remaining: gate.specs.length - enqueued - enqueueFailures,
+        });
+        break;
+      }
+      const meta: ServiceJobMeta = {
+        runId,
+        triggered,
+        // Stamped at ENQUEUE time (the documented meaning: 'ISO timestamp
+        // the control-plane enqueued the job'), not at tick start — a slow
+        // enumerate/sweep must not back-date it.
+        enqueuedAt: new Date(now()).toISOString(),
+      };
+      if (spec.priority !== undefined) meta.priority = spec.priority;
+      try {
+        await queue.enqueue(toEnqueueInput(spec, meta));
+        enqueued++;
+      } catch (err) {
+        // One service failing to enqueue must NOT abort the rest of the
+        // run — the other services' jobs still get queued, mirroring the
+        // in-process invoker's per-target isolation.
+        enqueueFailures++;
+        logger.error("fleet.producer.enqueue-failed", {
+          runId,
+          probeKey: spec.probeKey,
+          serviceSlug: spec.serviceSlug,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    logger.info("fleet.producer.tick-complete", {
+      runId,
+      triggered,
+      enqueued,
+      enqueueFailures,
+      skippedForBacklog: gate.skipped,
+      sweptExpired: sweep.swept,
+      sweepFailed: sweep.sweepFailed,
+      reclaimed: sweep.reclaimed,
+    });
+
+    return {
+      runId,
+      enqueued,
+      enqueueFailures,
+      skippedForBacklog: gate.skipped,
+      sweptExpired: sweep.swept,
+      sweepFailed: sweep.sweepFailed,
+      reclaimed: sweep.reclaimed,
+      enumerateFailed: false,
+    };
+  }
+
   return {
     start() {
       if (stopped) {
@@ -583,6 +749,32 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       }
       running = false;
       stopped = true;
+      // QUIESCE: an in-flight tick observed `running === true` at entry and
+      // may still be enumerating/sweeping/enqueueing. "Stopped" must mean the
+      // tick is DONE — its enqueue loop truncates on the flag flipped above,
+      // and stop() resolves only once the tick has fully unwound.
+      if (inFlightTick !== null) {
+        await inFlightTick.catch(() => {});
+      }
+      // FINAL DRAIN: buffered undelivered comm errors would otherwise die
+      // with the process — `sweepExpired` cannot re-derive a missed batch.
+      // One best-effort delivery; if it fails too, the batch is dropped
+      // LOUDLY (count + jobIds at error level), never silently.
+      if (undeliveredCommErrors.length > 0 && onSweepCommErrors !== undefined) {
+        const batch = undeliveredCommErrors;
+        undeliveredCommErrors = [];
+        try {
+          await onSweepCommErrors(batch);
+        } catch (err) {
+          logger.error("fleet.producer.stop-commerrors-dropped", {
+            dropped: batch.length,
+            jobIds: batch
+              .map((e) => e.jobId)
+              .filter((id): id is string => id !== undefined),
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
       logger.info("fleet.producer.stop");
     },
 
@@ -591,148 +783,13 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     },
 
     async tick(tickOpts?: TickOptions): Promise<TickResult> {
-      const runId = runIdFactory();
-      if (!running) {
-        // Defensive: a tick that arrives after stop() (or before start())
-        // produces nothing. Mirrors the scheduler's drain-after-stop
-        // discipline — no jobs leak past the producer's lifecycle.
-        logger.warn("fleet.producer.tick-while-stopped", { runId });
-        return {
-          runId,
-          enqueued: 0,
-          enqueueFailures: 0,
-          skippedForBacklog: 0,
-          sweptExpired: false,
-          sweepFailed: false,
-          reclaimed: 0,
-          enumerateFailed: false,
-        };
-      }
-
-      const triggered = tickOpts?.triggered === true;
-
-      const enumerateCtx: EnumerateContext = { triggered, runId };
-      // The filter is TRIGGER-ONLY: a scheduled (cron) tick must never be
-      // scoped, so a filter passed without `triggered: true` is dropped (and
-      // warned) rather than forwarded to the enumerator.
-      if (tickOpts?.filter !== undefined) {
-        if (triggered) {
-          enumerateCtx.filter = tickOpts.filter;
-        } else {
-          logger.warn("fleet.producer.filter-ignored-scheduled", { runId });
-        }
-      }
-
-      let specs: ServiceJobSpec[];
+      const ticking = runTick(tickOpts);
+      inFlightTick = ticking;
       try {
-        specs = await enumerate(enumerateCtx);
-      } catch (err) {
-        // Enumeration failure short-circuits production (no services →
-        // nothing to enqueue). Still attempt the sweep so dead-worker
-        // reclamation isn't starved by a flaky discovery upstream. The clock
-        // is read AFTER the (potentially slow) enumerate await so the sweep's
-        // expiry decisions aren't back-dated to tick start.
-        logger.error("fleet.producer.enumerate-failed", {
-          runId,
-          triggered,
-          err: err instanceof Error ? err.message : String(err),
-        });
-        const sweep = await maybeSweep(now());
-        return {
-          runId,
-          enqueued: 0,
-          enqueueFailures: 0,
-          skippedForBacklog: 0,
-          sweptExpired: sweep.swept,
-          sweepFailed: sweep.sweepFailed,
-          reclaimed: sweep.reclaimed,
-          enumerateFailed: true,
-        };
+        return await ticking;
+      } finally {
+        inFlightTick = null;
       }
-
-      logger.info("fleet.producer.tick-start", {
-        runId,
-        triggered,
-        services: specs.length,
-      });
-
-      // SWEEP FIRST: the sweep's stale-pending drain can clear a family's
-      // entire backlog (a backlog of only-stale rows). Running it BEFORE the
-      // backlog gate means the very tick that drains a family also resumes
-      // its production — sweeping after the gate made production resume a
-      // full cron period late. Same cadence gate and fail-open semantics
-      // (maybeSweep swallows sweep failures); only the order changed. The
-      // clock is re-read HERE — after the potentially-seconds-long enumerate
-      // await — so lease-expiry decisions and lastSweepAt aren't back-dated
-      // to tick start.
-      const sweep = await maybeSweep(now());
-
-      // BACKLOG DEDUPE: scheduled ticks skip any family whose previous batch
-      // is still pending (unclaimed) — see filterBackloggedFamilies. Operator-
-      // triggered ticks BYPASS the gate: an explicit trigger is a deliberate
-      // "run it NOW" (the CLI even treats 0 enqueued as a failure), so
-      // operator intent wins over backpressure.
-      const gate = triggered
-        ? { specs, skipped: 0 }
-        : await filterBackloggedFamilies(specs, runId);
-
-      // #72 PRE-DISPATCH WARM-UP: fire fire-and-forget health GETs at every
-      // backend that will actually be enqueued (post-gate) BEFORE enqueueing,
-      // so cold containers start waking ahead of the pills that probe them.
-      // Best-effort and non-blocking — the GETs are dispatched (not awaited),
-      // so a slow cold container never delays the run's enqueue.
-      warmEnumeratedBackends(gate.specs);
-
-      let enqueued = 0;
-      let enqueueFailures = 0;
-      for (const spec of gate.specs) {
-        const meta: ServiceJobMeta = {
-          runId,
-          triggered,
-          // Stamped at ENQUEUE time (the documented meaning: 'ISO timestamp
-          // the control-plane enqueued the job'), not at tick start — a slow
-          // enumerate/sweep must not back-date it.
-          enqueuedAt: new Date(now()).toISOString(),
-        };
-        if (spec.priority !== undefined) meta.priority = spec.priority;
-        try {
-          await queue.enqueue(toEnqueueInput(spec, meta));
-          enqueued++;
-        } catch (err) {
-          // One service failing to enqueue must NOT abort the rest of the
-          // run — the other services' jobs still get queued, mirroring the
-          // in-process invoker's per-target isolation.
-          enqueueFailures++;
-          logger.error("fleet.producer.enqueue-failed", {
-            runId,
-            probeKey: spec.probeKey,
-            serviceSlug: spec.serviceSlug,
-            err: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
-
-      logger.info("fleet.producer.tick-complete", {
-        runId,
-        triggered,
-        enqueued,
-        enqueueFailures,
-        skippedForBacklog: gate.skipped,
-        sweptExpired: sweep.swept,
-        sweepFailed: sweep.sweepFailed,
-        reclaimed: sweep.reclaimed,
-      });
-
-      return {
-        runId,
-        enqueued,
-        enqueueFailures,
-        skippedForBacklog: gate.skipped,
-        sweptExpired: sweep.swept,
-        sweepFailed: sweep.sweepFailed,
-        reclaimed: sweep.reclaimed,
-        enumerateFailed: false,
-      };
     },
   };
 }
@@ -749,7 +806,9 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
  * injected clock (injection-discipline consistency with the rest of the
  * module); behavior is otherwise identical to the Date.now form.
  */
-function defaultRunIdFactory(now: () => number = () => Date.now()): () => string {
+function defaultRunIdFactory(
+  now: () => number = () => Date.now(),
+): () => string {
   let counter = 0;
   const discriminator = Math.random().toString(36).slice(2, 8).padEnd(6, "0");
   return () => {

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -69,6 +69,14 @@ import { deriveHealthUrl } from "../../probes/liveness.js";
  * persistently-failing sweep never starves a healthy sink of the buffer.
  * Injected so the producer stays dependency-free and unit-testable with a
  * fake sink.
+ *
+ * AT-LEAST-ONCE DELIVERY — the sink MUST be idempotent. A sink failure
+ * re-buffers and later re-delivers the WHOLE batch, including entries the
+ * receiver may already have processed before the failure surfaced (the
+ * producer cannot distinguish a partial sink failure from a total one).
+ * The aggregator behind this sink must therefore treat each comm error as
+ * idempotent per (jobId, observedAt): re-delivery of an already-aggregated
+ * entry must not duplicate its dashboard surface.
  */
 export type SweepCommErrorSink = (
   commErrors: PoolCommError[],
@@ -175,8 +183,9 @@ export interface TickResult {
   /**
    * The run batch id every enqueued job in this tick shares. Empty string
    * (`""`) when the tick never RAN — skipped because a previous tick was
-   * still in flight: a tick that produces nothing by construction does not
-   * mint a runId.
+   * still in flight, or because it arrived outside the producer's lifecycle
+   * (before start() / after stop()): a tick that produces nothing by
+   * construction does not mint a runId.
    */
   runId: string;
   /** Number of per-service jobs enqueued (services enumerated, minus enqueue failures and backlog-gate skips). */
@@ -305,10 +314,11 @@ export const DEFAULT_SWEEP_INTERVAL_MS = 30_000;
 export const MAX_BUFFERED_SWEEP_COMM_ERRORS = 500;
 
 /**
- * The no-op `TickResult` for a tick that never RAN (e.g. skipped because a
- * previous tick was still in flight). `runId` is the empty-string sentinel:
- * no run was minted — a tick that produces nothing by construction must not
- * burn the run-id counter or log phantom runIds.
+ * The no-op `TickResult` for a tick that never RAN (skipped because a
+ * previous tick was still in flight, or arrived outside the producer's
+ * lifecycle). `runId` is the empty-string sentinel: no run was minted — a
+ * tick that produces nothing by construction must not burn the run-id
+ * counter or log phantom runIds.
  */
 function skippedTickResult(): TickResult {
   return {
@@ -350,6 +360,12 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
    */
   let undeliveredCommErrors: PoolCommError[] = [];
   /**
+   * One-shot latch for the "comm errors swept but no sink configured" warn —
+   * see deliverSweepCommErrors. Without it a sink-less deployment would log
+   * the same wiring gap on every reclaiming sweep.
+   */
+  let warnedNoCommErrorSink = false;
+  /**
    * The currently-executing tick's promise, or null when no tick is in
    * flight. `stop()` awaits it so "stopped" means QUIESCED — an in-flight
    * tick can no longer keep enumerating/sweeping/enqueueing after stop()
@@ -385,7 +401,23 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
    * oldest dropped, warned) and never aborts job production.
    */
   async function deliverSweepCommErrors(fresh: PoolCommError[]): Promise<void> {
-    if (!onSweepCommErrors) return;
+    if (!onSweepCommErrors) {
+      // No sink wired (legacy logged-only mode): the batch's dashboard
+      // signal is dropped HERE, permanently — sweepExpired cannot re-derive
+      // it. Surface the wiring gap explicitly, with the dropped jobIds (not
+      // just a count), but only ONCE so a sink-less deployment doesn't bury
+      // its logs on every sweep.
+      if (fresh.length > 0 && !warnedNoCommErrorSink) {
+        warnedNoCommErrorSink = true;
+        logger.warn("fleet.producer.sweep-commerrors-no-sink", {
+          commErrors: fresh.length,
+          jobIds: fresh
+            .map((e) => e.jobId)
+            .filter((id): id is string => id !== undefined),
+        });
+      }
+      return;
+    }
     const batch = [...undeliveredCommErrors, ...fresh];
     undeliveredCommErrors = [];
     if (batch.length === 0) return;
@@ -544,7 +576,6 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       if (backendUrl === undefined) continue;
       const healthUrl = deriveHealthUrl(backendUrl);
       if (healthUrl === "") continue;
-      fired += 1;
       // Fire-and-forget: an AbortController bounds each GET so a hung cold
       // container can't leak a pending request across ticks. The whole chain is
       // swallowed — warm-up is a latency optimization, never a correctness gate.
@@ -582,7 +613,15 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
               });
             },
           )
-          .finally(() => clearTimeout(timer));
+          .finally(() => clearTimeout(timer))
+          // Terminal backstop: the handlers above can THEMSELVES throw (an
+          // injected logger whose transport is down) — without this catch
+          // that surfaces as an unhandled rejection from a fire-and-forget
+          // chain nobody awaits.
+          .catch(() => {});
+        // Counted AFTER the dispatch: a fetchImpl that throws synchronously
+        // lands in the catch below and must not be reported as "warmed".
+        fired += 1;
       } catch (err) {
         logger.debug("fleet.producer.warm-failed", {
           serviceSlug: spec.serviceSlug,
@@ -599,25 +638,23 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
 
   /** One production cycle — the body `tick()` runs and `stop()` quiesces on. */
   async function runTick(tickOpts?: TickOptions): Promise<TickResult> {
-    const runId = runIdFactory();
     if (!running) {
       // Defensive: a tick that arrives after stop() (or before start())
       // produces nothing. Mirrors the scheduler's drain-after-stop
-      // discipline — no jobs leak past the producer's lifecycle.
-      logger.warn("fleet.producer.tick-while-stopped", { runId });
-      return {
-        runId,
-        enqueued: 0,
-        enqueueFailures: 0,
-        skippedForBacklog: 0,
-        sweptExpired: false,
-        sweepFailed: false,
-        reclaimed: 0,
-        enumerateFailed: false,
-      };
+      // discipline — no jobs leak past the producer's lifecycle. No runId
+      // is minted: a stopped tick must not burn the factory counter or log
+      // a phantom runId no job will ever carry.
+      logger.warn("fleet.producer.tick-while-stopped", {
+        triggered: tickOpts?.triggered === true,
+      });
+      return skippedTickResult();
     }
-
+    const runId = runIdFactory();
     const triggered = tickOpts?.triggered === true;
+
+    // Logged BEFORE the enumerate await: a discovery upstream that hangs or
+    // throws must still leave a trace that this tick (and its runId) began.
+    logger.info("fleet.producer.tick-start", { runId, triggered });
 
     const enumerateCtx: EnumerateContext = { triggered, runId };
     // The filter is TRIGGER-ONLY: a scheduled (cron) tick must never be
@@ -633,7 +670,17 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
 
     let specs: ServiceJobSpec[];
     try {
-      specs = await enumerate(enumerateCtx);
+      const enumerated = await enumerate(enumerateCtx);
+      if (!Array.isArray(enumerated)) {
+        // A misbehaving enumerator (bad wiring, a mock resolving undefined)
+        // is a FAILED enumeration, not an empty catalog — route it through
+        // the same failure handling as a throw instead of letting the
+        // non-array value blow up further down the tick.
+        throw new Error(
+          `enumerator resolved to a non-array value (${typeof enumerated})`,
+        );
+      }
+      specs = enumerated;
     } catch (err) {
       // Enumeration failure short-circuits production (no services →
       // nothing to enqueue). Still attempt the sweep so dead-worker
@@ -657,12 +704,6 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
         enumerateFailed: true,
       };
     }
-
-    logger.info("fleet.producer.tick-start", {
-      runId,
-      triggered,
-      services: specs.length,
-    });
 
     // SWEEP FIRST: the sweep's stale-pending drain can clear a family's
     // entire backlog (a backlog of only-stale rows). Running it BEFORE the
@@ -735,6 +776,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     logger.info("fleet.producer.tick-complete", {
       runId,
       triggered,
+      services: specs.length,
       enqueued,
       enqueueFailures,
       skippedForBacklog: gate.skipped,

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -86,9 +86,12 @@ export type SweepCommErrorSink = (
 /**
  * Pre-dispatch HEALTH WARM-UP config (flap-band #72). Before a run's jobs are
  * enqueued, the producer fires a fire-and-forget `GET <backendUrl>/health`
- * against every enumerated backend so a cold (scaled-to-zero) container starts
- * waking BEFORE a pill actually probes it — removing most `current=0`
- * zero-output timeouts where the first pill paid the cold-start latency.
+ * against each backend WHOSE SPEC IS ACTUALLY ENQUEUED on this tick — the
+ * post-validation, post-backlog-gate `gate.specs` set, not the raw enumerated
+ * set — so a cold (scaled-to-zero) container starts waking BEFORE a pill
+ * actually probes it, removing most `current=0` zero-output timeouts where
+ * the first pill paid the cold-start latency. A fully-backlogged tick whose
+ * gate skipped every spec fires zero warm GETs (no jobs → nothing to warm).
  *
  * This is NOT an LLM call and NOT an agent turn — it is a cheap unauthenticated
  * liveness GET with a short timeout, fully best-effort: a warm failure (cold
@@ -207,10 +210,17 @@ export interface TickResult {
    */
   truncatedByStop: number;
   /**
-   * Number of per-service jobs SKIPPED because their family already had a
-   * non-terminal (pending/claimed/running) batch on the queue (scheduled
-   * ticks only — the backlog dedupe gate; operator-triggered ticks bypass
-   * it).
+   * Number of per-service jobs SKIPPED by `filterBackloggedFamilies`
+   * (scheduled ticks only — operator-triggered ticks bypass the gate). Two
+   * contributors:
+   *   1. The dedupe gate: the family already had a non-terminal
+   *      (pending/claimed/running) batch on the queue (`hasBacklog`).
+   *   2. The fail-CLOSED leg of the poisoned-count guard: when
+   *      `countPendingForFamily` throws a `PoisonedBacklogCountError` the
+   *      family is skipped (an unverifiable count is treated as backlogged,
+   *      preventing a stuck producer from flooding the queue).
+   * The fail-OPEN leg (transient `countPendingForFamily` failure) is
+   * counted SEPARATELY by `backlogGateFailedOpen` — it does NOT fold here.
    */
   skippedForBacklog: number;
   /**
@@ -247,11 +257,15 @@ export interface TickResult {
    */
   reclaimed: number;
   /**
-   * Of `reclaimed`, the reclaims whose release outcome was INDETERMINATE
-   * (transport failure after the CAS — the over-report slice). OPTIONAL,
-   * mirroring the shared `SweepResult.reclaimedIndeterminate` contract
-   * field `maybeSweep` reads directly: absent when the queue does not
-   * report the split (the real queue-client always does).
+   * In ADDITION to `reclaimed`, the reclaims whose release outcome was
+   * INDETERMINATE (transport failure after the CAS — the conservative
+   * over-report slice). DISJOINT from `reclaimed`: a thrown release lands
+   * here EXCLUSIVELY, never in `reclaimed`; summing the two recovers the
+   * at-least-once total (this matches the shared
+   * `SweepResultWithIndeterminate` contract pairing). OPTIONAL, mirroring
+   * the shared `SweepResult.reclaimedIndeterminate` contract field
+   * `maybeSweep` reads directly: absent when the queue does not report the
+   * split (the real queue-client always does).
    */
   reclaimedIndeterminate?: number;
   /**
@@ -300,10 +314,12 @@ export interface JobProducerOptions {
    */
   onSweepCommErrors?: SweepCommErrorSink;
   /**
-   * Pre-dispatch health warm-up (flap-band #72). When supplied, each tick fires
-   * a fire-and-forget `GET <backendUrl>/health` per enumerated spec right after
-   * enumeration and BEFORE enqueueing, so cold containers start waking before
-   * pills probe them. When omitted, no warm-up runs (the legacy behavior).
+   * Pre-dispatch health warm-up (flap-band #72). When supplied, each tick
+   * fires a fire-and-forget `GET <backendUrl>/health` per spec ACTUALLY
+   * ENQUEUED (post-validation, post-backlog-gate — `gate.specs`, not the raw
+   * enumerated set) right before enqueueing, so cold containers start waking
+   * before pills probe them. A fully-backlogged tick warms nothing. When
+   * omitted, no warm-up runs (the legacy behavior).
    */
   warmHealth?: WarmHealthConfig;
 }

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -60,8 +60,12 @@ import { deriveHealthUrl } from "../../probes/liveness.js";
  * FORWARDS the swept errors to this injected sink — the wiring slot
  * (control-plane) routes them to `ResultAggregator.aggregateCommError`. Called
  * best-effort: the producer awaits it but never lets a sink failure abort job
- * production (the next tick retries the sweep). Injected so the producer stays
- * dependency-free and unit-testable with a fake sink.
+ * production. A failed delivery does NOT lose the batch — `sweepExpired` only
+ * synthesizes comm errors for rows reclaimed in THAT call, so a later sweep
+ * cannot re-derive a missed batch; the producer instead BUFFERS undelivered
+ * errors (capped at `MAX_BUFFERED_SWEEP_COMM_ERRORS`, oldest dropped) and
+ * prepends them to the next sweep's sink delivery. Injected so the producer
+ * stays dependency-free and unit-testable with a fake sink.
  */
 export type SweepCommErrorSink = (
   commErrors: PoolCommError[],
@@ -263,6 +267,14 @@ export interface JobProducer {
 /** Default lease-sweep cadence: reclaim dead-worker leases every 30s. */
 export const DEFAULT_SWEEP_INTERVAL_MS = 30_000;
 
+/**
+ * Cap on the producer's buffer of UNDELIVERED sweep comm errors (REQ-B). A
+ * persistently-failing sink must not grow the buffer without bound, so past
+ * the cap the OLDEST entries are dropped (with a warn) — newer reclaims carry
+ * the fresher dashboard signal.
+ */
+export const MAX_BUFFERED_SWEEP_COMM_ERRORS = 500;
+
 export function createJobProducer(opts: JobProducerOptions): JobProducer {
   const { queue, enumerate, logger } = opts;
   const now = opts.now ?? (() => Date.now());
@@ -281,6 +293,14 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
    * orphaned leases from a prior crash reclaims them on its first cycle.
    */
   let lastSweepAt: number | null = null;
+  /**
+   * Sweep comm errors a previous sink delivery FAILED to hand off (REQ-B).
+   * `sweepExpired` only synthesizes comm errors for rows reclaimed in that
+   * call, so a dropped batch is gone for good — buffered batches are drained
+   * (prepended to the fresh batch) on the next sweep's sink delivery. Capped
+   * at `MAX_BUFFERED_SWEEP_COMM_ERRORS`, oldest dropped on overflow.
+   */
+  let undeliveredCommErrors: PoolCommError[] = [];
 
   /** Build a `ServiceJobPayload` from a spec + the run's shared meta. */
   function toEnqueueInput(
@@ -332,15 +352,33 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       // the dashboard (the producer owns no status pipeline of its own). Previously
       // these were DROPPED after logging their count — the crash/lease-expiry
       // overlay never surfaced. Best-effort: a sink failure must not abort job
-      // production, so we log and swallow (the next sweep retries).
-      if (onSweepCommErrors && result.commErrors.length > 0) {
-        try {
-          await onSweepCommErrors(result.commErrors);
-        } catch (sinkErr) {
-          logger.error("fleet.producer.sweep-commerror-sink-failed", {
-            commErrors: result.commErrors.length,
-            err: sinkErr instanceof Error ? sinkErr.message : String(sinkErr),
-          });
+      // production. But `sweepExpired` only synthesizes comm errors for rows
+      // reclaimed in THIS call — a later sweep canNOT re-derive a missed batch —
+      // so a failed delivery is BUFFERED (not dropped) and the buffer is drained,
+      // prepended to the fresh batch, on the next sweep's delivery. The buffer is
+      // capped at MAX_BUFFERED_SWEEP_COMM_ERRORS (oldest dropped, warned).
+      if (onSweepCommErrors) {
+        const batch = [...undeliveredCommErrors, ...result.commErrors];
+        undeliveredCommErrors = [];
+        if (batch.length > 0) {
+          try {
+            await onSweepCommErrors(batch);
+          } catch (sinkErr) {
+            logger.error("fleet.producer.sweep-commerror-sink-failed", {
+              commErrors: batch.length,
+              err: sinkErr instanceof Error ? sinkErr.message : String(sinkErr),
+            });
+            undeliveredCommErrors = batch;
+            if (undeliveredCommErrors.length > MAX_BUFFERED_SWEEP_COMM_ERRORS) {
+              const dropped =
+                undeliveredCommErrors.length - MAX_BUFFERED_SWEEP_COMM_ERRORS;
+              undeliveredCommErrors = undeliveredCommErrors.slice(dropped);
+              logger.warn("fleet.producer.sweep-commerror-buffer-overflow", {
+                dropped,
+                buffered: MAX_BUFFERED_SWEEP_COMM_ERRORS,
+              });
+            }
+          }
         }
       }
       return { swept: true, sweepFailed: false, reclaimed: result.reclaimed };

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -429,6 +429,16 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
    * skip — the already-queued trigger covers "run after the in-flight tick".
    */
   let queuedTrigger: Promise<TickResult> | null = null;
+  /**
+   * The PRIMARY stop()'s full completion — quiesce loop AND final
+   * comm-error drain — published synchronously by the first effective
+   * stop() and shared by every later/concurrent stop(). A secondary stop()
+   * that awaited only the in-flight tick could resolve while the primary
+   * was still mid drain (awaiting the sink); sharing ONE completion means
+   * EVERY stop() resolution implies the drain finished. null until the
+   * primary stop runs.
+   */
+  let stopPromise: Promise<void> | null = null;
 
   /** Build a `ServiceJobPayload` from a spec + the run's shared meta. */
   function toEnqueueInput(
@@ -919,60 +929,69 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     },
 
     async stop() {
-      if (!running) {
-        if (!started) {
-          // stop() BEFORE start(): nothing ever ran, so there is nothing to
-          // quiesce or drain — and latching `stopped` here (the old
-          // behavior) permanently bricked the producer: every later start()
-          // hit the start-after-stop latch. A teardown racing ahead of boot
-          // wiring is a benign ordering, not a lifecycle end — no-op.
-          logger.debug("fleet.producer.stop-before-start");
-          return;
-        }
-        stopped = true;
-        // A SECOND concurrent stop() lands here (the first flipped `running`
-        // synchronously) — it must STILL quiesce: returning while the first
-        // stop()'s tick is mid-enqueue made "stopped" a lie to this caller
-        // (a shutdown racing two stop()s could tear the queue down under a
-        // still-writing tick). Await the in-flight tick AND any queued
-        // trigger, same as the primary path below.
+      // ANY stop() after the primary — concurrent or later — shares the
+      // primary's full completion (quiesce loop AND final drain). The old
+      // secondary path awaited only the in-flight tick / queued trigger,
+      // so with neither in flight it resolved IMMEDIATELY while the primary
+      // was still mid final-drain (awaiting the sink) — a shutdown
+      // sequenced on the second stop() could tear the aggregator down
+      // under the still-delivering drain. Every stop() resolution must
+      // imply the drain finished.
+      if (stopPromise !== null) {
+        await stopPromise;
+        return;
+      }
+      if (!started) {
+        // stop() BEFORE start(): nothing ever ran, so there is nothing to
+        // quiesce or drain — and latching `stopped` here (the old
+        // behavior) permanently bricked the producer: every later start()
+        // hit the start-after-stop latch. A teardown racing ahead of boot
+        // wiring is a benign ordering, not a lifecycle end — no-op.
+        logger.debug("fleet.producer.stop-before-start");
+        return;
+      }
+      // PRIMARY stop. The flags AND stopPromise are published SYNCHRONOUSLY
+      // (before any await), so a concurrent second stop() always lands on
+      // the shared-completion path above — `started && !running` with a
+      // null stopPromise is unreachable.
+      running = false;
+      stopped = true;
+      stopPromise = (async () => {
+        // QUIESCE: an in-flight tick observed `running === true` at entry and
+        // may still be enumerating/sweeping/enqueueing. "Stopped" must mean the
+        // tick is DONE — its enqueue loop truncates on the flag flipped above,
+        // and stop() resolves only once the tick has fully unwound. A LOOP, not
+        // a single await: a queued trigger (see the re-entrancy guard) takes
+        // the in-flight slot after the current tick resolves — its (skipped,
+        // `running` is false) run must also unwind before stop() resolves.
         while (inFlightTick !== null || queuedTrigger !== null) {
           await (inFlightTick ?? queuedTrigger)!.catch(() => {});
         }
-        return;
-      }
-      running = false;
-      stopped = true;
-      // QUIESCE: an in-flight tick observed `running === true` at entry and
-      // may still be enumerating/sweeping/enqueueing. "Stopped" must mean the
-      // tick is DONE — its enqueue loop truncates on the flag flipped above,
-      // and stop() resolves only once the tick has fully unwound. A LOOP, not
-      // a single await: a queued trigger (see the re-entrancy guard) takes
-      // the in-flight slot after the current tick resolves — its (skipped,
-      // `running` is false) run must also unwind before stop() resolves.
-      while (inFlightTick !== null || queuedTrigger !== null) {
-        await (inFlightTick ?? queuedTrigger)!.catch(() => {});
-      }
-      // FINAL DRAIN: buffered undelivered comm errors would otherwise die
-      // with the process — `sweepExpired` cannot re-derive a missed batch.
-      // One best-effort delivery; if it fails too, the batch is dropped
-      // LOUDLY (count + jobIds at error level), never silently.
-      if (undeliveredCommErrors.length > 0 && onSweepCommErrors !== undefined) {
-        const batch = undeliveredCommErrors;
-        undeliveredCommErrors = [];
-        try {
-          await onSweepCommErrors(batch);
-        } catch (err) {
-          logger.error("fleet.producer.stop-commerrors-dropped", {
-            dropped: batch.length,
-            jobIds: batch
-              .map((e) => e.jobId)
-              .filter((id): id is string => id !== undefined),
-            err: err instanceof Error ? err.message : String(err),
-          });
+        // FINAL DRAIN: buffered undelivered comm errors would otherwise die
+        // with the process — `sweepExpired` cannot re-derive a missed batch.
+        // One best-effort delivery; if it fails too, the batch is dropped
+        // LOUDLY (count + jobIds at error level), never silently.
+        if (
+          undeliveredCommErrors.length > 0 &&
+          onSweepCommErrors !== undefined
+        ) {
+          const batch = undeliveredCommErrors;
+          undeliveredCommErrors = [];
+          try {
+            await onSweepCommErrors(batch);
+          } catch (err) {
+            logger.error("fleet.producer.stop-commerrors-dropped", {
+              dropped: batch.length,
+              jobIds: batch
+                .map((e) => e.jobId)
+                .filter((id): id is string => id !== undefined),
+              err: err instanceof Error ? err.message : String(err),
+            });
+          }
         }
-      }
-      logger.info("fleet.producer.stop");
+        logger.info("fleet.producer.stop");
+      })();
+      await stopPromise;
     },
 
     isRunning() {

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -116,8 +116,6 @@ export interface ServiceJobSpec {
   driverInputs?: Record<string, unknown>;
   /** Optional per-job priority hint (higher pulls first). */
   priority?: number;
-  /** Optional explicit lease seconds for the eventual claim. */
-  leaseSeconds?: number;
 }
 
 /**
@@ -298,9 +296,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     if (spec.cellIds !== undefined) payload.cellIds = spec.cellIds;
     if (spec.driverInputs !== undefined)
       payload.driverInputs = spec.driverInputs;
-    const input: EnqueueJobInput = { payload };
-    if (spec.leaseSeconds !== undefined) input.leaseSeconds = spec.leaseSeconds;
-    return input;
+    return { payload };
   }
 
   /**

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -363,9 +363,16 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
   /**
    * One-shot latch for the "comm errors swept but no sink configured" warn —
    * see deliverSweepCommErrors. Without it a sink-less deployment would log
-   * the same wiring gap on every reclaiming sweep.
+   * the same wiring gap on every reclaiming sweep. Drops AFTER the first are
+   * still logged — at debug, with the dropped jobIds — never fully silent.
    */
   let warnedNoCommErrorSink = false;
+  /**
+   * Running total of comm errors dropped because no sink is configured.
+   * Carried on every no-sink log line (the one-shot warn and each subsequent
+   * debug) so a single grepped line quantifies the cumulative loss.
+   */
+  let noSinkDroppedTotal = 0;
   /**
    * The currently-executing tick's promise, or null when no tick is in
    * flight. `stop()` awaits it so "stopped" means QUIESCED — an in-flight
@@ -414,16 +421,24 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       // No sink wired (legacy logged-only mode): the batch's dashboard
       // signal is dropped HERE, permanently — sweepExpired cannot re-derive
       // it. Surface the wiring gap explicitly, with the dropped jobIds (not
-      // just a count), but only ONCE so a sink-less deployment doesn't bury
-      // its logs on every sweep.
-      if (fresh.length > 0 && !warnedNoCommErrorSink) {
-        warnedNoCommErrorSink = true;
-        logger.warn("fleet.producer.sweep-commerrors-no-sink", {
+      // just a count) and the running dropped-total — the full WARN only
+      // ONCE so a sink-less deployment doesn't bury its logs on every sweep;
+      // every later drop still logs at debug (greppable, never fully silent).
+      if (fresh.length > 0) {
+        noSinkDroppedTotal += fresh.length;
+        const meta = {
           commErrors: fresh.length,
+          droppedTotal: noSinkDroppedTotal,
           jobIds: fresh
             .map((e) => e.jobId)
             .filter((id): id is string => id !== undefined),
-        });
+        };
+        if (!warnedNoCommErrorSink) {
+          warnedNoCommErrorSink = true;
+          logger.warn("fleet.producer.sweep-commerrors-no-sink", meta);
+        } else {
+          logger.debug("fleet.producer.sweep-commerrors-no-sink", meta);
+        }
       }
       return;
     }

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -47,6 +47,7 @@ import type {
   ServiceJobMeta,
   ServiceJobPayload,
 } from "../contracts.js";
+import { probeKeyFamily } from "../contracts.js";
 import { deriveHealthUrl } from "../../probes/liveness.js";
 
 /**
@@ -159,6 +160,12 @@ export interface TickResult {
   enqueued: number;
   /** Number of enqueue attempts that threw (a service that failed to enqueue). */
   enqueueFailures: number;
+  /**
+   * Number of per-service jobs SKIPPED because their family already had a
+   * pending (unclaimed) backlog on the queue (scheduled ticks only — the
+   * backlog dedupe gate; operator-triggered ticks bypass it).
+   */
+  skippedForBacklog: number;
   /** True iff a lease sweep ran during this tick. */
   sweptExpired: boolean;
   /** Expired leases reclaimed by the sweep, when one ran (else 0). */
@@ -339,6 +346,61 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
   }
 
   /**
+   * BACKLOG DEDUPE GATE (scheduled ticks only). A producer tick must NOT
+   * enqueue a fresh batch for a family that already has pending (unclaimed)
+   * jobs on the queue: with 2 serial browser workers against ~180 jobs/hr of
+   * inflow the un-gated producers compounded a multi-thousand-row backlog
+   * (staging: 3,734 pending, oldest 22h) that starved low-frequency families
+   * out of the claim page entirely. Skipping the batch bounds the per-family
+   * backlog to ONE batch — the next tick re-checks and produces again once
+   * the workers have drained it. Grouped per family so a (hypothetical)
+   * multi-family tick gates each family independently. Fail-OPEN on a count
+   * blip: a transient PB read failure must never stop job production (the
+   * legacy un-gated behavior is the safe fallback), mirroring maybeSweep's
+   * swallow-and-log discipline.
+   */
+  async function filterBackloggedFamilies(
+    specs: ServiceJobSpec[],
+    runId: string,
+  ): Promise<{ specs: ServiceJobSpec[]; skipped: number }> {
+    const byFamily = new Map<string, ServiceJobSpec[]>();
+    for (const spec of specs) {
+      const family = probeKeyFamily(spec.probeKey);
+      const group = byFamily.get(family);
+      if (group) group.push(spec);
+      else byFamily.set(family, [spec]);
+    }
+    const kept: ServiceJobSpec[] = [];
+    let skipped = 0;
+    for (const [family, group] of byFamily) {
+      let pendingCount: number;
+      try {
+        pendingCount = await queue.countPendingForFamily(family);
+      } catch (err) {
+        logger.error("fleet.producer.backlog-check-failed", {
+          runId,
+          family,
+          err: err instanceof Error ? err.message : String(err),
+        });
+        kept.push(...group);
+        continue;
+      }
+      if (pendingCount > 0) {
+        skipped += group.length;
+        logger.warn("fleet.producer.skipped-for-backlog", {
+          runId,
+          family,
+          pendingCount,
+          skippedJobs: group.length,
+        });
+        continue;
+      }
+      kept.push(...group);
+    }
+    return { specs: kept, skipped };
+  }
+
+  /**
    * Fire-and-forget pre-dispatch health warm-up (flap-band #72). For each
    * enumerated spec with a backend URL, fire a `GET <backendUrl>/health` so a
    * cold container starts waking before its pill probes it. Best-effort: every
@@ -426,6 +488,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
           runId,
           enqueued: 0,
           enqueueFailures: 0,
+          skippedForBacklog: 0,
           sweptExpired: false,
           reclaimed: 0,
         };
@@ -455,6 +518,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
           runId,
           enqueued: 0,
           enqueueFailures: 0,
+          skippedForBacklog: 0,
           sweptExpired: sweep.swept,
           reclaimed: sweep.reclaimed,
         };
@@ -466,16 +530,25 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
         services: specs.length,
       });
 
+      // BACKLOG DEDUPE: scheduled ticks skip any family whose previous batch
+      // is still pending (unclaimed) — see filterBackloggedFamilies. Operator-
+      // triggered ticks BYPASS the gate: an explicit trigger is a deliberate
+      // "run it NOW" (the CLI even treats 0 enqueued as a failure), so
+      // operator intent wins over backpressure.
+      const gate = triggered
+        ? { specs, skipped: 0 }
+        : await filterBackloggedFamilies(specs, runId);
+
       // #72 PRE-DISPATCH WARM-UP: fire fire-and-forget health GETs at every
-      // enumerated backend BEFORE enqueueing, so cold containers start waking
-      // ahead of the pills that probe them. Best-effort and non-blocking — the
-      // GETs are dispatched (not awaited), so a slow cold container never delays
-      // the run's enqueue.
-      warmEnumeratedBackends(specs);
+      // backend that will actually be enqueued (post-gate) BEFORE enqueueing,
+      // so cold containers start waking ahead of the pills that probe them.
+      // Best-effort and non-blocking — the GETs are dispatched (not awaited),
+      // so a slow cold container never delays the run's enqueue.
+      warmEnumeratedBackends(gate.specs);
 
       let enqueued = 0;
       let enqueueFailures = 0;
-      for (const spec of specs) {
+      for (const spec of gate.specs) {
         const meta: ServiceJobMeta = {
           runId,
           triggered,
@@ -506,6 +579,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
         triggered,
         enqueued,
         enqueueFailures,
+        skippedForBacklog: gate.skipped,
         sweptExpired: sweep.swept,
         reclaimed: sweep.reclaimed,
       });
@@ -514,6 +588,7 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
         runId,
         enqueued,
         enqueueFailures,
+        skippedForBacklog: gate.skipped,
         sweptExpired: sweep.swept,
         reclaimed: sweep.reclaimed,
       };

--- a/showcase/harness/src/fleet/job-claim.test.ts
+++ b/showcase/harness/src/fleet/job-claim.test.ts
@@ -239,7 +239,7 @@ describe("job-claim client", () => {
     expect(claimCalls).toBe(2);
   });
 
-  it("throws a descriptive error on a non-401 failure status", async () => {
+  it("throws a descriptive error on a non-401 failure status (renew/release)", async () => {
     const fetchImpl = authedFetch(() => new Response("boom", { status: 500 }));
     const client = createJobClaimClient({
       url: "http://pb",
@@ -248,8 +248,48 @@ describe("job-claim client", () => {
       logger,
       fetchImpl,
     });
+    await expect(client.renewLease("j1", "worker-7", 30)).rejects.toThrow(
+      /\/api\/fleet\/renew failed: 500/,
+    );
+    await expect(client.releaseJob("j1", "worker-7", "done")).rejects.toThrow(
+      /\/api\/fleet\/release failed: 500/,
+    );
+  });
+
+  it("claimJob maps a 5xx to a LOST CAS (won: false) instead of throwing", async () => {
+    // A WAL serialization/busy error escaping runInTransaction surfaces as a
+    // 500 — indistinguishable from losing the race (the row either was or
+    // will be won by a peer). Throwing aborted the caller's whole candidate
+    // rotation; mapping to won:false lets claimNext fall through to the next
+    // candidate. (4xx — caller bugs — still throw loud below.)
+    const fetchImpl = authedFetch(
+      () => new Response("wal busy", { status: 500 }),
+    );
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    const r = await client.claimJob("j1", "worker-7", 30);
+    expect(r.won).toBe(false);
+    expect(r.job).toBeUndefined();
+  });
+
+  it("claimJob still throws on a 4xx (caller bug, fail loud)", async () => {
+    const fetchImpl = authedFetch(
+      () => new Response("bad body", { status: 400 }),
+    );
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
     await expect(client.claimJob("j1", "worker-7", 30)).rejects.toThrow(
-      /\/api\/fleet\/claim failed: 500/,
+      /\/api\/fleet\/claim failed: 400/,
     );
   });
 

--- a/showcase/harness/src/fleet/job-claim.test.ts
+++ b/showcase/harness/src/fleet/job-claim.test.ts
@@ -243,6 +243,74 @@ describe("job-claim client", () => {
     expect(claimCalls).toBe(2);
   });
 
+  it("a 401 retry does NOT clobber a token a concurrent caller already refreshed (G1g)", async () => {
+    // RACE: caller A's request goes out under tok1 and 401s; while that
+    // response is in flight, caller B also 401s, re-auths, and installs
+    // tok2. A's 401 handling then blindly nulled authToken — discarding the
+    // FRESH tok2 and forcing a third auth round-trip (and under sustained
+    // concurrency, an auth stampede). A must only invalidate the token if it
+    // is STILL the one its failed request used.
+    let authCalls = 0;
+    let releaseJ1: ((r: Response) => void) | undefined;
+    const j1Gate = new Promise<Response>((res) => {
+      releaseJ1 = res;
+    });
+    let j1Calls = 0;
+    let j2Calls = 0;
+    const claimAuthHeaders: string[] = [];
+    const fetchImpl = makeFetch(async (url, init) => {
+      if (url.includes("auth-with-password")) {
+        authCalls += 1;
+        return new Response(JSON.stringify({ token: `tok${authCalls}` }), {
+          status: 200,
+        });
+      }
+      const body = JSON.parse(String(init?.body)) as { jobId: string };
+      claimAuthHeaders.push(
+        String((init?.headers as Record<string, string>).authorization),
+      );
+      if (body.jobId === "j1") {
+        j1Calls += 1;
+        // A's FIRST request hangs until the test releases it (after B's
+        // refresh has completed); its retry succeeds.
+        if (j1Calls === 1) return j1Gate;
+        return new Response(
+          JSON.stringify({ claimed: true, job: SAMPLE_JOB }),
+          { status: 200 },
+        );
+      }
+      j2Calls += 1;
+      if (j2Calls === 1) return new Response("unauthorized", { status: 401 });
+      return new Response(JSON.stringify({ claimed: true, job: SAMPLE_JOB }), {
+        status: 200,
+      });
+    });
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+
+    // A: auth (tok1) → POST j1 (hangs on the gate).
+    const pA = client.claimJob("j1", "wA", 30);
+    await new Promise((r) => setTimeout(r, 10));
+    // B: 401 under tok1 → re-auth (tok2) → retry wins.
+    const rB = await client.claimJob("j2", "wB", 30);
+    expect(rB.won).toBe(true);
+    // Now A's first request comes back 401 — but tok2 is already installed.
+    releaseJ1!(new Response("unauthorized", { status: 401 }));
+    const rA = await pA;
+    expect(rA.won).toBe(true);
+
+    // Exactly TWO auths total: the initial one and B's refresh. A's retry
+    // reused B's fresh tok2 instead of nulling it and re-authing a third
+    // time.
+    expect(authCalls).toBe(2);
+    expect(claimAuthHeaders[claimAuthHeaders.length - 1]).toBe("tok2");
+  });
+
   it("throws a descriptive error on a non-401 failure status (renew/release)", async () => {
     const fetchImpl = authedFetch(() => new Response("boom", { status: 500 }));
     const client = createJobClaimClient({

--- a/showcase/harness/src/fleet/job-claim.test.ts
+++ b/showcase/harness/src/fleet/job-claim.test.ts
@@ -401,6 +401,106 @@ describe("job-claim client", () => {
     expect((thrown as JobClaimEndpointError).path).toBe("/api/fleet/release");
   });
 
+  it("auth 4xx (rotated creds) throws JobClaimEndpointError carrying the auth path + status", async () => {
+    // The deterministic-4xx carve-outs (queue-client renewLease + the
+    // sweep's thrown-release handling) discriminate on
+    // `instanceof JobClaimEndpointError && 4xx`. A plain Error from a
+    // rotated-credential auth 400 routed those callers down the
+    // indeterminate path FOREVER: a phantom assumed-live lease on every
+    // renew beat plus a false worker-reclaimed-pending comm error per
+    // sweep. The auth rejection is deterministic (the same creds 400
+    // identically on every retry), so it must carry the discriminable
+    // class.
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("auth-with-password")) {
+        return new Response("invalid credentials", { status: 400 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "rotated-away",
+      logger,
+      fetchImpl,
+    });
+    let thrown: unknown;
+    try {
+      await client.renewLease("j1", "worker-7", 30);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(JobClaimEndpointError);
+    expect((thrown as JobClaimEndpointError).status).toBe(400);
+    expect((thrown as JobClaimEndpointError).path).toContain(
+      "auth-with-password",
+    );
+  });
+
+  it("auth 4xx on the 401-triggered RE-AUTH path also throws JobClaimEndpointError (rotated creds mid-session)", async () => {
+    // The live rotated-creds shape: the session token is invalidated (the
+    // endpoint 401s), postFleet re-auths, and the re-auth 400s. That throw
+    // surfaces from renew/release calls — it must be the discriminable
+    // class, not a plain Error.
+    let authCalls = 0;
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("auth-with-password")) {
+        authCalls += 1;
+        if (authCalls === 1) {
+          return new Response(JSON.stringify({ token: "tok1" }), {
+            status: 200,
+          });
+        }
+        return new Response("invalid credentials", { status: 400 });
+      }
+      return new Response("token expired", { status: 401 });
+    });
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    let thrown: unknown;
+    try {
+      await client.renewLease("j1", "worker-7", 30);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(JobClaimEndpointError);
+    expect((thrown as JobClaimEndpointError).status).toBe(400);
+    expect(authCalls).toBe(2);
+  });
+
+  it("auth 5xx stays a PLAIN Error — indeterminate, never the deterministic class", async () => {
+    // A momentarily-sick PB is not a deterministic rejection: the callers'
+    // conservative paths (assumed-live renew, at-least-once sweep) must
+    // keep handling it.
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("auth-with-password")) {
+        return new Response("pb melting", { status: 500 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    let thrown: unknown;
+    try {
+      await client.renewLease("j1", "worker-7", 30);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown).not.toBeInstanceOf(JobClaimEndpointError);
+    expect((thrown as Error).message).toMatch(/auth failed: 500/);
+  });
+
   it("claimJob maps a 5xx to a LOST CAS (won: false) instead of throwing", async () => {
     // A WAL serialization/busy error escaping runInTransaction surfaces as a
     // 500 — indistinguishable from losing the race (the row either was or
@@ -639,8 +739,10 @@ describe("job-claim client", () => {
       logger,
       fetchImpl,
     });
+    // A 4xx auth response throws the DETERMINISTIC class (see the rotated
+    // creds pins above) — still loud, now discriminable.
     await expect(client.claimJob("j1", "worker-7", 30)).rejects.toThrow(
-      /auth failed: 400/,
+      /auth-with-password failed: 400 bad creds/,
     );
   });
 });

--- a/showcase/harness/src/fleet/job-claim.test.ts
+++ b/showcase/harness/src/fleet/job-claim.test.ts
@@ -441,6 +441,75 @@ describe("job-claim client", () => {
     });
   });
 
+  it("memoizes the in-flight auth promise — a concurrent stampede authenticates ONCE", async () => {
+    let authCalls = 0;
+    const fetchImpl = makeFetch(async (url) => {
+      if (url.includes("auth-with-password")) {
+        authCalls += 1;
+        // Slow auth so the concurrent callers all arrive while it's in flight.
+        await new Promise((r) => setTimeout(r, 20));
+        return new Response(JSON.stringify({ token: "tok" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ claimed: false }), { status: 200 });
+    });
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    await Promise.all([
+      client.claimJob("j1", "w1", 30),
+      client.claimJob("j2", "w2", 30),
+      client.claimJob("j3", "w3", 30),
+    ]);
+    expect(authCalls).toBe(1);
+  });
+
+  it("wraps an unparseable auth body with context instead of a bare SyntaxError", async () => {
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("auth-with-password")) {
+        return new Response("<html>proxy intercept</html>", { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    await expect(client.claimJob("j1", "worker-7", 30)).rejects.toThrow(
+      /job-claim auth: unparseable response body \(status 200\)/,
+    );
+  });
+
+  it("treats a claimed:true response carrying an alreadyHeld marker as a plain win (no-op extra field)", async () => {
+    // The hook's claim idempotency for timeout-after-commit returns
+    // { claimed: true, alreadyHeld: true, job } when the SAME worker
+    // re-claims a row it already holds with a live lease. The client treats
+    // it as a win; the marker is informational.
+    const fetchImpl = authedFetch(
+      () =>
+        new Response(
+          JSON.stringify({ claimed: true, alreadyHeld: true, job: SAMPLE_JOB }),
+          { status: 200 },
+        ),
+    );
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    const r = await client.claimJob("j1", "worker-7", 30);
+    expect(r.won).toBe(true);
+    expect(r.job?.id).toBe("j1");
+  });
+
   it("throws when the auth endpoint itself fails", async () => {
     const fetchImpl = makeFetch((url) => {
       if (url.includes("auth-with-password")) {

--- a/showcase/harness/src/fleet/job-claim.test.ts
+++ b/showcase/harness/src/fleet/job-claim.test.ts
@@ -108,8 +108,7 @@ describe("job-claim client", () => {
       if (url.includes("/api/admins/auth-with-password")) {
         return new Response(JSON.stringify({ token: "tok" }), { status: 200 });
       }
-      claimAuthHeader = (init?.headers as Record<string, string>)
-        .authorization;
+      claimAuthHeader = (init?.headers as Record<string, string>).authorization;
       return new Response(JSON.stringify({ claimed: false }), { status: 200 });
     });
     const client = createJobClaimClient({

--- a/showcase/harness/src/fleet/job-claim.test.ts
+++ b/showcase/harness/src/fleet/job-claim.test.ts
@@ -1,10 +1,33 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   createJobClaimClient,
   JobClaimEndpointError,
   type JobView,
 } from "./job-claim.js";
-import { logger } from "../logger.js";
+import type { Logger } from "../types/index.js";
+
+/**
+ * Per-FILE SILENT logger (G1h) — deliberately NOT the shared `../logger.js`
+ * module object: the shared logger writes real output for every contained
+ * endpoint-error in these tests, and any spy a test (or a future test) puts
+ * on the SHARED object leaks into every other file under fork-reuse when an
+ * assertion failure skips its restore (the repo's known spy-leak class).
+ * Mirrors queue-client.test.ts: fresh vi.fn()s per test.
+ */
+const logger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  logger.debug = vi.fn();
+  logger.info = vi.fn();
+  logger.warn = vi.fn();
+  logger.error = vi.fn();
+});
 
 function makeFetch(
   handler: (
@@ -40,10 +63,19 @@ function authedFetch(
 }
 
 describe("job-claim client", () => {
-  it("authenticates as superuser before calling the claim endpoint", async () => {
+  it("authenticates as superuser BEFORE calling the claim endpoint (order pinned in one call log)", async () => {
+    // ORDER honesty (G1h): the auth and claim requests are recorded in the
+    // SAME array so the before/after relationship is asserted by INDEX —
+    // the old fixture filtered auth out of the log and only checked that
+    // the claim happened, which could not fail on a claim-before-auth bug.
     const calls: string[] = [];
-    const fetchImpl = authedFetch((url) => {
+    const fetchImpl = makeFetch((url) => {
       calls.push(url);
+      if (url.includes("auth-with-password")) {
+        return new Response(JSON.stringify({ token: "tok", record: {} }), {
+          status: 200,
+        });
+      }
       return new Response(JSON.stringify({ claimed: true, job: SAMPLE_JOB }), {
         status: 200,
       });
@@ -58,20 +90,26 @@ describe("job-claim client", () => {
     const r = await client.claimJob("j1", "worker-7", 30);
     expect(r.won).toBe(true);
     expect(r.job?.id).toBe("j1");
-    expect(calls[0]).toContain("/api/fleet/claim");
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toContain(
+      "/api/collections/_superusers/auth-with-password",
+    );
+    expect(calls[1]).toContain("/api/fleet/claim");
   });
 
-  it("falls back to /api/admins on a 404 from /_superusers", async () => {
-    const authPaths: string[] = [];
-    const fetchImpl = makeFetch((url) => {
+  it("falls back to /api/admins on a 404 from /_superusers (tried in that order) and carries the token to the endpoint", async () => {
+    const calls: string[] = [];
+    let claimAuthHeader: string | undefined;
+    const fetchImpl = makeFetch((url, init) => {
+      calls.push(url);
       if (url.includes("/_superusers/auth-with-password")) {
-        authPaths.push(url);
         return new Response("not found", { status: 404 });
       }
       if (url.includes("/api/admins/auth-with-password")) {
-        authPaths.push(url);
         return new Response(JSON.stringify({ token: "tok" }), { status: 200 });
       }
+      claimAuthHeader = (init?.headers as Record<string, string>)
+        .authorization;
       return new Response(JSON.stringify({ claimed: false }), { status: 200 });
     });
     const client = createJobClaimClient({
@@ -82,7 +120,16 @@ describe("job-claim client", () => {
       fetchImpl,
     });
     await client.claimJob("j1", "worker-7", 30);
-    expect(authPaths.some((p) => p.includes("/api/admins"))).toBe(true);
+    // _superusers FIRST (PB v0.23+ path), the v0.22 fallback second, then
+    // the claim — order pinned by index in the shared call log (G1h).
+    expect(calls).toHaveLength(3);
+    expect(calls[0]).toContain(
+      "/api/collections/_superusers/auth-with-password",
+    );
+    expect(calls[1]).toContain("/api/admins/auth-with-password");
+    expect(calls[2]).toContain("/api/fleet/claim");
+    // The fallback-acquired token is carried on the endpoint request.
+    expect(claimAuthHeader).toBe("tok");
   });
 
   it("reports won=false when the endpoint says the row was already taken", async () => {

--- a/showcase/harness/src/fleet/job-claim.test.ts
+++ b/showcase/harness/src/fleet/job-claim.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { createJobClaimClient, type JobView } from "./job-claim.js";
+import {
+  createJobClaimClient,
+  JobClaimEndpointError,
+  type JobView,
+} from "./job-claim.js";
 import { logger } from "../logger.js";
 
 function makeFetch(
@@ -254,6 +258,32 @@ describe("job-claim client", () => {
     await expect(client.releaseJob("j1", "worker-7", "done")).rejects.toThrow(
       /\/api\/fleet\/release failed: 500/,
     );
+  });
+
+  it("threads the HTTP status onto thrown endpoint errors (JobClaimEndpointError)", async () => {
+    // The sweep's thrown-release handling discriminates DETERMINISTIC 4xx
+    // refusals (the hook rejected the request — nothing committed) from
+    // indeterminate 5xx/transport throws (may have committed). That
+    // discrimination needs the status ON the error, not in its message.
+    const fetchImpl = authedFetch(
+      () => new Response("bad body", { status: 400 }),
+    );
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    let thrown: unknown;
+    try {
+      await client.releaseJob("j1", "", "pending");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(JobClaimEndpointError);
+    expect((thrown as JobClaimEndpointError).status).toBe(400);
+    expect((thrown as JobClaimEndpointError).path).toBe("/api/fleet/release");
   });
 
   it("claimJob maps a 5xx to a LOST CAS (won: false) instead of throwing", async () => {

--- a/showcase/harness/src/fleet/job-claim.test.ts
+++ b/showcase/harness/src/fleet/job-claim.test.ts
@@ -344,18 +344,71 @@ describe("job-claim client", () => {
     );
   });
 
-  it("treats an empty endpoint body as a non-win without throwing", async () => {
-    const fetchImpl = authedFetch(() => new Response("", { status: 200 }));
-    const client = createJobClaimClient({
-      url: "http://pb",
-      email: "a@b",
-      password: "pw",
-      logger,
-      fetchImpl,
+  describe("2xx indeterminate body (G1a) — a committed CAS must never fabricate a loss", () => {
+    // A 2xx means the endpoint COMMITTED the transition server-side. If the
+    // body is then unreadable/empty/unparseable, the OUTCOME is unknown —
+    // the old empty→`{}` mapping fabricated a CAS LOSS for an operation
+    // that may have WON: a won claim was abandoned (stranded claimed row),
+    // a successful renew killed the heartbeat (the false
+    // worker-crashed-mid-job class), a committed release reported the
+    // result discarded. Indeterminate must THROW with context; callers
+    // contain the throw (claimNext per-candidate, renewLease assumed-live,
+    // sweep conservative, report retry).
+    function client(fetchImpl: typeof fetch) {
+      return createJobClaimClient({
+        url: "http://pb",
+        email: "a@b",
+        password: "pw",
+        logger,
+        fetchImpl,
+      });
+    }
+
+    it("claimJob THROWS on a 2xx with an EMPTY body (not won:false)", async () => {
+      const c = client(authedFetch(() => new Response("", { status: 200 })));
+      await expect(c.claimJob("j1", "worker-7", 30)).rejects.toThrow(
+        /job-claim \/api\/fleet\/claim: 2xx body unreadable — outcome indeterminate/,
+      );
     });
-    const r = await client.claimJob("j1", "worker-7", 30);
-    expect(r.won).toBe(false);
-    expect(r.job).toBeUndefined();
+
+    it("renewLease THROWS on a 2xx with an EMPTY body (not renewed:false — no false worker-crashed)", async () => {
+      const c = client(authedFetch(() => new Response("", { status: 200 })));
+      await expect(c.renewLease("j1", "worker-7", 30)).rejects.toThrow(
+        /job-claim \/api\/fleet\/renew: 2xx body unreadable — outcome indeterminate/,
+      );
+    });
+
+    it("releaseJob THROWS on a 2xx with an EMPTY body (not released:false)", async () => {
+      const c = client(authedFetch(() => new Response("", { status: 200 })));
+      await expect(c.releaseJob("j1", "worker-7", "done")).rejects.toThrow(
+        /job-claim \/api\/fleet\/release: 2xx body unreadable — outcome indeterminate/,
+      );
+    });
+
+    it("THROWS on a 2xx whose body is unparseable JSON", async () => {
+      const c = client(
+        authedFetch(() => new Response("<html>proxy", { status: 200 })),
+      );
+      await expect(c.claimJob("j1", "worker-7", 30)).rejects.toThrow(
+        /2xx body unreadable — outcome indeterminate.*unparseable/,
+      );
+    });
+
+    it("THROWS on a 2xx whose body READ rejects (socket reset mid-body)", async () => {
+      const c = client(
+        authedFetch(
+          () =>
+            ({
+              ok: true,
+              status: 200,
+              text: () => Promise.reject(new Error("socket reset mid-body")),
+            }) as unknown as Response,
+        ),
+      );
+      await expect(c.renewLease("j1", "worker-7", 30)).rejects.toThrow(
+        /2xx body unreadable — outcome indeterminate.*socket reset mid-body/,
+      );
+    });
   });
 
   it("throws when the auth endpoint itself fails", async () => {

--- a/showcase/harness/src/fleet/job-claim.test.ts
+++ b/showcase/harness/src/fleet/job-claim.test.ts
@@ -166,6 +166,49 @@ describe("job-claim client", () => {
     });
   });
 
+  it("releaseJob threads the hook's refusal reason on released:false", async () => {
+    // report()'s retry truthfulness depends on this field reaching the
+    // caller: refused_terminal_same_holder means the caller's own earlier
+    // release committed (timeout-after-commit) and its result write is still
+    // authorized.
+    const fetchImpl = authedFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            released: false,
+            reason: "refused_terminal_same_holder",
+          }),
+          { status: 200 },
+        ),
+    );
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    const r = await client.releaseJob("j1", "worker-7", "done");
+    expect(r.released).toBe(false);
+    expect(r.reason).toBe("refused_terminal_same_holder");
+  });
+
+  it("releaseJob omits reason when the endpoint sends none (legacy body shape)", async () => {
+    const fetchImpl = authedFetch(
+      () => new Response(JSON.stringify({ released: false }), { status: 200 }),
+    );
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    const r = await client.releaseJob("j1", "worker-7", "done");
+    expect(r.released).toBe(false);
+    expect(r.reason).toBeUndefined();
+  });
+
   it("re-authenticates once on a 401 then retries the request", async () => {
     let claimCalls = 0;
     let authCalls = 0;

--- a/showcase/harness/src/fleet/job-claim.test.ts
+++ b/showcase/harness/src/fleet/job-claim.test.ts
@@ -132,6 +132,51 @@ describe("job-claim client", () => {
     expect(claimAuthHeader).toBe("tok");
   });
 
+  it("memoizes the auth route across re-auths — a v0.22 backend pays the /_superusers 404 probe ONCE, not per token expiry", async () => {
+    // The /_superusers→/api/admins fallback ran inside authenticate() with
+    // route discovery as a LOCAL — every re-auth (401 token expiry) re-paid
+    // a wasted 404 probe against a backend whose route cannot have changed.
+    const calls: string[] = [];
+    let tokenSeq = 0;
+    let expiredOnce = false;
+    const fetchImpl = makeFetch((url) => {
+      calls.push(url);
+      if (url.includes("/_superusers/auth-with-password")) {
+        return new Response("not found", { status: 404 });
+      }
+      if (url.includes("/api/admins/auth-with-password")) {
+        tokenSeq += 1;
+        return new Response(JSON.stringify({ token: `tok-${tokenSeq}` }), {
+          status: 200,
+        });
+      }
+      // First claim under tok-1: 401 once (expired) to force a re-auth.
+      if (!expiredOnce) {
+        expiredOnce = true;
+        return new Response("expired", { status: 401 });
+      }
+      return new Response(JSON.stringify({ claimed: false }), { status: 200 });
+    });
+    const client = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+
+    await client.claimJob("j1", "worker-7", 30);
+
+    // Sequence: _superusers 404 → admins ok → claim 401 → RE-AUTH (admins
+    // DIRECTLY, no second 404 probe) → claim retry.
+    const superuserProbes = calls.filter((u) =>
+      u.includes("/_superusers/auth-with-password"),
+    );
+    expect(superuserProbes).toHaveLength(1);
+    expect(calls.filter((u) => u.includes("/api/admins/")).length).toBe(2);
+    expect(calls[calls.length - 1]).toContain("/api/fleet/claim");
+  });
+
   it("reports won=false when the endpoint says the row was already taken", async () => {
     const fetchImpl = authedFetch(
       () => new Response(JSON.stringify({ claimed: false }), { status: 200 }),

--- a/showcase/harness/src/fleet/job-claim.ts
+++ b/showcase/harness/src/fleet/job-claim.ts
@@ -157,6 +157,12 @@ export interface JobClaimClient {
  * The 2xx-unreadable indeterminate throw is deliberately NOT this class:
  * it has no refusal semantics (the CAS committed; only the outcome is
  * unknown), so it must take callers' conservative paths.
+ *
+ * ALSO thrown by the superuser auth round-trip for 4xx auth responses
+ * (rotated/invalid creds — `path` is the auth-with-password route): an auth
+ * rejection fails identically on every retry, so it belongs to the same
+ * deterministic class the carve-outs key on. Auth 5xx / network failures
+ * stay plain Errors (indeterminate).
  */
 export class JobClaimEndpointError extends Error {
   readonly path: string;
@@ -209,16 +215,15 @@ export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
       password: config.password,
     });
     // PB v0.23+ → /_superusers; v0.22 → /api/admins. Match pb-client.ts.
-    let res = await fetchImpl(
-      `${baseUrl}/api/collections/_superusers/auth-with-password`,
-      {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: authBody,
-      },
-    );
+    let authPath = "/api/collections/_superusers/auth-with-password";
+    let res = await fetchImpl(`${baseUrl}${authPath}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: authBody,
+    });
     if (res.status === 404) {
-      res = await fetchImpl(`${baseUrl}/api/admins/auth-with-password`, {
+      authPath = "/api/admins/auth-with-password";
+      res = await fetchImpl(`${baseUrl}${authPath}`, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: authBody,
@@ -226,6 +231,20 @@ export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
     }
     if (!res.ok) {
       const text = await res.text().catch(() => "");
+      // DETERMINISTIC 4xx (rotated/invalid creds → PB 400s; route drift):
+      // the callers' deterministic-rejection carve-outs (queue-client's
+      // renewLease and sweepExpired) discriminate on
+      // `JobClaimEndpointError` + 4xx. A plain Error here routed every
+      // rotated-credential failure down the INDETERMINATE path forever — a
+      // phantom assumed-live lease on every renew beat and a false
+      // worker-reclaimed-pending comm error per sweep. The same creds fail
+      // identically on every retry, so thread the discriminable class with
+      // the auth path + HTTP status. 5xx (and thrown network errors) stay
+      // plain: a momentarily-sick PB is genuinely indeterminate and must
+      // keep the callers' conservative handling.
+      if (res.status >= 400 && res.status < 500) {
+        throw new JobClaimEndpointError(authPath, res.status, text);
+      }
       throw new Error(`job-claim auth failed: ${res.status} ${text}`);
     }
     const text = await res.text();

--- a/showcase/harness/src/fleet/job-claim.ts
+++ b/showcase/harness/src/fleet/job-claim.ts
@@ -287,10 +287,16 @@ export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
         },
         body: JSON.stringify(payload),
       });
+    // Snapshot the token THIS request goes out under: a concurrent caller
+    // can refresh `authToken` while our 401 response is in flight, and
+    // blindly nulling it here would discard the FRESH token — forcing a
+    // redundant re-auth round-trip per racing caller (an auth stampede
+    // under sustained concurrency). Only invalidate if it is unchanged.
+    const tokenUsed = authToken;
     let res = await doPost();
     // Single re-auth on 401 — token may have expired between calls.
     if (res.status === 401) {
-      authToken = null;
+      if (authToken === tokenUsed) authToken = null;
       await ensureAuth();
       res = await doPost();
     }
@@ -359,6 +365,15 @@ export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
         // whole candidate rotation for one contested row; won:false lets
         // claimNext fall through to the next candidate. (Already warned by
         // postFleet's endpoint-error log.)
+        //
+        // BOUNDED FALSE-OVERLAY SOURCE (documented, accepted): the 5xx can
+        // ALSO mask a claim that COMMITTED under THIS workerId before the
+        // error surfaced. The caller then treats it as lost and never
+        // renews/reports, so the row sits claimed until its lease expires
+        // and the sweeper re-queues it — synthesizing a neutral (gray)
+        // worker-reclaimed-pending overlay for a worker that never knew it
+        // held the job. Bounded by one lease duration, self-healing (the
+        // re-queued job re-runs), and never a red crash overlay.
         return { won: false };
       }
       return { won: body.claimed === true, job: body.job };

--- a/showcase/harness/src/fleet/job-claim.ts
+++ b/showcase/harness/src/fleet/job-claim.ts
@@ -227,8 +227,9 @@ export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
       await ensureAuth();
       res = await doPost();
     }
-    const text = await res.text().catch(() => "");
     if (!res.ok) {
+      // Failure path: the body is diagnostics only — a failed read is fine.
+      const text = await res.text().catch(() => "");
       logger.warn("job-claim.endpoint-error", {
         path,
         status: res.status,
@@ -239,7 +240,37 @@ export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
       if (opts?.nullOn5xx && res.status >= 500) return null;
       throw new Error(`job-claim ${path} failed: ${res.status} ${text}`);
     }
-    return text ? (JSON.parse(text) as ClaimEndpointBody) : {};
+    // 2xx: the endpoint COMMITTED the transition server-side. A body we
+    // cannot read/parse — or an empty one — means the OUTCOME of a committed
+    // CAS is UNKNOWN. The old empty→`{}` mapping FABRICATED a CAS loss for
+    // an operation that may have WON: a won claim was abandoned (stranded
+    // claimed row), a successful renew read back as `renewed: false` killed
+    // the worker's heartbeat (recreating the false worker-crashed-mid-job
+    // class), and a committed release read back as `released: false` made
+    // report() falsely declare the result discarded. Indeterminate must
+    // THROW with context; every caller contains the throw (claimNext
+    // per-candidate, queue-client renewLease assumed-live, the sweep's
+    // conservative path, report()'s retry).
+    const indeterminate = (detail: string): Error =>
+      new Error(
+        `job-claim ${path}: 2xx body unreadable — outcome indeterminate (${detail})`,
+      );
+    let text: string;
+    try {
+      text = await res.text();
+    } catch (err) {
+      throw indeterminate(
+        `read failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    if (!text) throw indeterminate("empty body");
+    try {
+      return JSON.parse(text) as ClaimEndpointBody;
+    } catch (err) {
+      throw indeterminate(
+        `unparseable JSON: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   return {

--- a/showcase/harness/src/fleet/job-claim.ts
+++ b/showcase/harness/src/fleet/job-claim.ts
@@ -178,6 +178,15 @@ interface ClaimEndpointBody {
   error?: string;
   /** Release refusal reason (released: false only) — see `ReleaseRefusalReason`. */
   reason?: string;
+  /**
+   * Claim idempotency marker (claimed: true only): the row was ALREADY held
+   * by this workerId with a live lease — a timeout-after-commit retry of the
+   * caller's own committed claim. Deliberately NOT threaded onto
+   * `ClaimResult`: the caller treats it as a plain win (the existing lease
+   * is retained, and the heartbeat renews on its normal cadence), so the
+   * marker is informational wire detail only.
+   */
+  alreadyHeld?: boolean;
 }
 
 export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {

--- a/showcase/harness/src/fleet/job-claim.ts
+++ b/showcase/harness/src/fleet/job-claim.ts
@@ -196,10 +196,20 @@ export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
     authToken = body.token;
   }
 
+  function postFleet(
+    path: string,
+    payload: Record<string, unknown>,
+  ): Promise<ClaimEndpointBody>;
+  function postFleet(
+    path: string,
+    payload: Record<string, unknown>,
+    opts: { nullOn5xx: boolean },
+  ): Promise<ClaimEndpointBody | null>;
   async function postFleet(
     path: string,
     payload: Record<string, unknown>,
-  ): Promise<ClaimEndpointBody> {
+    opts?: { nullOn5xx: boolean },
+  ): Promise<ClaimEndpointBody | null> {
     await ensureAuth();
     const doPost = async (): Promise<Response> =>
       fetchImpl(`${baseUrl}${path}`, {
@@ -224,6 +234,9 @@ export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
         status: res.status,
         body: text,
       });
+      // Opt-in 5xx containment (the claim CAS): a server error is returned
+      // as null for the caller to map; 4xx (caller bugs) ALWAYS throw loud.
+      if (opts?.nullOn5xx && res.status >= 500) return null;
       throw new Error(`job-claim ${path} failed: ${res.status} ${text}`);
     }
     return text ? (JSON.parse(text) as ClaimEndpointBody) : {};
@@ -231,11 +244,25 @@ export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
 
   return {
     async claimJob(jobId, workerId, leaseSeconds): Promise<ClaimResult> {
-      const body = await postFleet("/api/fleet/claim", {
-        jobId,
-        workerId,
-        leaseSeconds,
-      });
+      const body = await postFleet(
+        "/api/fleet/claim",
+        {
+          jobId,
+          workerId,
+          leaseSeconds,
+        },
+        { nullOn5xx: true },
+      );
+      if (body === null) {
+        // A 5xx from the claim CAS is treated as a LOST CAS, not an error: a
+        // WAL serialization/busy error escaping runInTransaction surfaces as
+        // a 500, and the contested row either was or will be won by a peer —
+        // exactly the lost-race shape. Throwing here aborted the caller's
+        // whole candidate rotation for one contested row; won:false lets
+        // claimNext fall through to the next candidate. (Already warned by
+        // postFleet's endpoint-error log.)
+        return { won: false };
+      }
       return { won: body.claimed === true, job: body.job };
     },
 

--- a/showcase/harness/src/fleet/job-claim.ts
+++ b/showcase/harness/src/fleet/job-claim.ts
@@ -137,6 +137,34 @@ export interface JobClaimClient {
   ): Promise<ReleaseResult>;
 }
 
+/**
+ * A non-2xx response from a fleet claim endpoint, with the HTTP status
+ * threaded as a FIELD (not just message text) so callers can discriminate
+ * DETERMINISTIC refusals from indeterminate failures:
+ *
+ *   - 4xx → the hook REJECTED the request before its transaction ran;
+ *     definitively NOTHING committed (the sweep uses this to avoid
+ *     synthesizing a false worker-reclaimed-pending for a wedge row it
+ *     can never actually release).
+ *   - 5xx → indeterminate; the transition may have committed before the
+ *     error surfaced — callers must stay conservative.
+ *
+ * The 2xx-unreadable indeterminate throw is deliberately NOT this class:
+ * it has no refusal semantics (the CAS committed; only the outcome is
+ * unknown), so it must take callers' conservative paths.
+ */
+export class JobClaimEndpointError extends Error {
+  readonly path: string;
+  readonly status: number;
+
+  constructor(path: string, status: number, body: string) {
+    super(`job-claim ${path} failed: ${status} ${body}`);
+    this.name = "JobClaimEndpointError";
+    this.path = path;
+    this.status = status;
+  }
+}
+
 interface ClaimEndpointBody {
   claimed?: boolean;
   renewed?: boolean;
@@ -238,7 +266,7 @@ export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
       // Opt-in 5xx containment (the claim CAS): a server error is returned
       // as null for the caller to map; 4xx (caller bugs) ALWAYS throw loud.
       if (opts?.nullOn5xx && res.status >= 500) return null;
-      throw new Error(`job-claim ${path} failed: ${res.status} ${text}`);
+      throw new JobClaimEndpointError(path, res.status, text);
     }
     // 2xx: the endpoint COMMITTED the transition server-side. A body we
     // cannot read/parse — or an empty one — means the OUTCOME of a committed

--- a/showcase/harness/src/fleet/job-claim.ts
+++ b/showcase/harness/src/fleet/job-claim.ts
@@ -201,6 +201,15 @@ export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
   const logger = config.logger;
   let authToken: string | null = null;
   let authInFlight: Promise<void> | null = null;
+  /**
+   * The auth route that WORKED last time (v0.23+ `/_superusers` vs the
+   * v0.22 `/api/admins` fallback), memoized across re-auths: route
+   * discovery used to be a local inside authenticate(), so EVERY token
+   * expiry re-paid a wasted 404 probe against a backend whose route cannot
+   * have changed mid-process. Only a SUCCESSFUL auth memoizes (a failed one
+   * proves nothing about the route); null until the first success.
+   */
+  let knownAuthPath: string | null = null;
 
   async function authenticate(): Promise<void> {
     if (!config.email || !config.password) {
@@ -215,13 +224,15 @@ export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
       password: config.password,
     });
     // PB v0.23+ → /_superusers; v0.22 → /api/admins. Match pb-client.ts.
-    let authPath = "/api/collections/_superusers/auth-with-password";
+    // A memoized route from a prior successful auth skips the 404 probe.
+    let authPath =
+      knownAuthPath ?? "/api/collections/_superusers/auth-with-password";
     let res = await fetchImpl(`${baseUrl}${authPath}`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: authBody,
     });
-    if (res.status === 404) {
+    if (res.status === 404 && knownAuthPath === null) {
       authPath = "/api/admins/auth-with-password";
       res = await fetchImpl(`${baseUrl}${authPath}`, {
         method: "POST",
@@ -264,6 +275,8 @@ export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
       throw new Error("job-claim auth returned empty or non-string token");
     }
     authToken = body.token;
+    // Memoize only on SUCCESS: the route is proven good for this backend.
+    knownAuthPath = authPath;
   }
 
   function ensureAuth(): Promise<void> {

--- a/showcase/harness/src/fleet/job-claim.ts
+++ b/showcase/harness/src/fleet/job-claim.ts
@@ -128,7 +128,12 @@ export interface JobClaimClient {
    * Record a terminal result for a job the caller holds. `status` is
    * `done` | `failed` to finish, or `pending` to re-queue. Fails
    * (`released: false`) if the caller is not the lease holder or the job
-   * is not in a running state.
+   * is no longer in a claimed/running state. NOTE the hook admits BOTH
+   * `claimed` and `running` rows (its RUNNING_STATES) — a row can be
+   * released terminal straight from `claimed`, which the queue-client's
+   * decode-failure cleanup depends on (it releases a just-won, never-renewed
+   * row as `failed`). This doc previously said "running state" only; the
+   * hook was always the broader (correct) side.
    */
   releaseJob(
     jobId: string,
@@ -180,9 +185,9 @@ export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
   const baseUrl = config.url.replace(/\/$/, "");
   const logger = config.logger;
   let authToken: string | null = null;
+  let authInFlight: Promise<void> | null = null;
 
-  async function ensureAuth(): Promise<void> {
-    if (authToken) return;
+  async function authenticate(): Promise<void> {
     if (!config.email || !config.password) {
       // No creds → the endpoints require auth; surface the gap loudly
       // rather than silently producing 401s the caller can't diagnose.
@@ -215,13 +220,38 @@ export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
       throw new Error(`job-claim auth failed: ${res.status} ${text}`);
     }
     const text = await res.text();
-    const body: { token?: unknown } = text
-      ? (JSON.parse(text) as { token?: unknown })
-      : {};
+    let body: { token?: unknown };
+    try {
+      body = text ? (JSON.parse(text) as { token?: unknown }) : {};
+    } catch (err) {
+      // A bare SyntaxError ("Unexpected token <...") gives the operator no
+      // idea WHICH request choked — wrap with the boundary + status.
+      throw new Error(
+        `job-claim auth: unparseable response body (status ${res.status}): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
     if (typeof body.token !== "string" || body.token.length === 0) {
       throw new Error("job-claim auth returned empty or non-string token");
     }
     authToken = body.token;
+  }
+
+  function ensureAuth(): Promise<void> {
+    if (authToken) return Promise.resolve();
+    // MEMOIZE the in-flight auth: concurrent callers (claimNext racing a
+    // heartbeat racing a report) used to each fire their own
+    // auth-with-password — a needless stampede on PB, and N redundant
+    // credential round-trips per token expiry. Share one promise; clear it
+    // in finally so a FAILED auth is retried by the next caller instead of
+    // caching the rejection forever.
+    if (!authInFlight) {
+      authInFlight = authenticate().finally(() => {
+        authInFlight = null;
+      });
+    }
+    return authInFlight;
   }
 
   function postFleet(

--- a/showcase/harness/src/fleet/job-claim.ts
+++ b/showcase/harness/src/fleet/job-claim.ts
@@ -65,9 +65,35 @@ export interface RenewResult {
   job?: JobView;
 }
 
+/**
+ * The release endpoint's refusal reason for `released: false` (threaded from
+ * the hook so callers can be truthful about WHY). The load-bearing value is
+ * `refused_terminal_same_holder`: the row is already terminal UNDER THE
+ * CALLER'S OWN workerId, which can only mean the caller's earlier release
+ * COMMITTED and its response was lost (timeout-after-commit) — the caller's
+ * result write is still authorized, so a report() retry must proceed to it
+ * rather than declare the result discarded. `refused_lease_live` is the
+ * TOCTOU-close refusal of a sweeper re-queue on a still-live lease;
+ * `refused_not_holder` covers everything else (unknown row, another holder,
+ * or a terminal-target release on an already-expired lease).
+ */
+export type ReleaseRefusalReason =
+  | "refused_terminal_same_holder"
+  | "refused_lease_live"
+  | "refused_not_holder";
+
+/** The committed-terminal-under-my-id refusal — see `ReleaseRefusalReason`. */
+export const RELEASE_REFUSED_TERMINAL_SAME_HOLDER =
+  "refused_terminal_same_holder" satisfies ReleaseRefusalReason;
+
 export interface ReleaseResult {
   released: boolean;
   job?: JobView;
+  /** Present (string) only when `released` is false AND the hook supplied a
+   * reason. Typed loose (`string`) because the wire value is untrusted —
+   * callers compare against the known `ReleaseRefusalReason` values and
+   * treat anything else as a generic refusal. */
+  reason?: string;
 }
 
 export interface JobClaimClient {
@@ -117,6 +143,8 @@ interface ClaimEndpointBody {
   released?: boolean;
   job?: JobView;
   error?: string;
+  /** Release refusal reason (released: false only) — see `ReleaseRefusalReason`. */
+  reason?: string;
 }
 
 export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
@@ -226,7 +254,11 @@ export function createJobClaimClient(config: JobClaimConfig): JobClaimClient {
         workerId,
         status,
       });
-      return { released: body.released === true, job: body.job };
+      return {
+        released: body.released === true,
+        job: body.job,
+        ...(typeof body.reason === "string" ? { reason: body.reason } : {}),
+      };
     },
   };
 }

--- a/showcase/harness/src/fleet/orchestrator.test.ts
+++ b/showcase/harness/src/fleet/orchestrator.test.ts
@@ -235,8 +235,9 @@ describe("runWorker loop-crash surfacing", () => {
     // stop() teardown contract below is observable: a rejecting loop.stop()
     // must still shut the pool down (PID-ceiling compounding otherwise).
     const shutdownSpy = vi.spyOn(BrowserPool.prototype, "shutdown");
+    let worker: Awaited<ReturnType<typeof runWorker>> | undefined;
     try {
-      const worker = await runWorker(config, {
+      worker = await runWorker(config, {
         queue,
         workerId: "worker-crash",
         logger,
@@ -313,6 +314,13 @@ describe("runWorker loop-crash surfacing", () => {
         expect(bodyLoopIfServed).not.toBe("ok");
       }
     } finally {
+      // Mirror the sibling default-boot test's try/finally teardown: if any
+      // assertion above failed BEFORE the explicit stop, the worker's bound
+      // /health server (and the pool) would leak across tests. stop()
+      // rejects with the loop-crash error BY DESIGN — the rejects.toThrow
+      // above is the assertion that cares; this safety-net swallow only
+      // guarantees both teardown arms (server close + pool shutdown) ran.
+      await worker?.stop().catch(() => {});
       shutdownSpy.mockRestore();
     }
   });

--- a/showcase/harness/src/fleet/orchestrator.test.ts
+++ b/showcase/harness/src/fleet/orchestrator.test.ts
@@ -129,6 +129,9 @@ function makeQueue(claims: ClaimedJob[]): RecordingQueue {
     async sweepExpired() {
       return { reclaimed: 0, commErrors: [] };
     },
+    async countPendingForFamily(): Promise<number> {
+      throw new Error("countPendingForFamily not used by worker");
+    },
   };
 }
 

--- a/showcase/harness/src/fleet/orchestrator.test.ts
+++ b/showcase/harness/src/fleet/orchestrator.test.ts
@@ -63,7 +63,8 @@ const headroomPidsReader: CgroupPidsReader = () => ({ current: 10, max: 1000 });
 function makeJobView(overrides: Partial<JobView> = {}): JobView {
   return {
     id: "job-1",
-    probe_key: "d6:langgraph-python",
+    // Joins the payload's probeKey (the tracer) — see makePayload below.
+    probe_key: "d6:tracer-slug",
     status: "claimed",
     claimed_by: "worker-test",
     lease_expires_at: "2026-06-04T00:05:00.000Z",
@@ -76,13 +77,21 @@ function makePayload(
   overrides: Partial<ServiceJobPayload> = {},
 ): ServiceJobPayload {
   return {
-    probeKey: "d6:langgraph-python",
-    serviceSlug: "langgraph-python",
+    probeKey: "d6:tracer-slug",
+    serviceSlug: "tracer-slug",
     driverKind: "e2e_d6",
     // A runnable d6 input with NO declared features → the d6 driver returns its
     // green "no D5 features declared" aggregate without acquiring a browser.
+    // `key` is a contract-conformant `d6:<slug>` TRACER (the fleet contract
+    // forbids `e2e_d6:<slug>` row keys on the fleet path — see
+    // ServiceJobResult.aggregateKey): a slug no production default ships,
+    // kept ALIGNED across probeKey/serviceSlug/driverInputs.key because the
+    // d6 driver derives its aggregate side-row slug from `input.key`
+    // (`deriveSlug`) while the worker loop filters that side row by
+    // `d6:<serviceSlug>` — a mismatched tracer slug would surface the side
+    // row as a phantom cell.
     driverInputs: {
-      key: "e2e_d6:langgraph-python",
+      key: "d6:tracer-slug",
       backendUrl: "https://lg.example.com",
     },
     meta: {
@@ -169,9 +178,15 @@ describe("runWorker default (self-contained) boot", () => {
     const result = queue.reports[0]!;
     // The e2e_d6 job was routed to the REAL d6 driver (not a protocol
     // violation): the d6 driver's green "no D5 features declared" aggregate.
+    // The aggregateKey is the TRACER `driverInputs.key` echoed back through
+    // the real driver (pass-through proof), and the signal note pins that
+    // the d6 driver itself produced the result.
     expect(result.commError).toBeUndefined();
     expect(result.aggregateState).toBe("green");
-    expect(result.aggregateKey).toBe("e2e_d6:langgraph-python");
+    expect(result.aggregateKey).toBe("d6:tracer-slug");
+    expect(result.aggregateSignal).toMatchObject({
+      note: "no D5 features declared",
+    });
   });
 });
 

--- a/showcase/harness/src/fleet/orchestrator.test.ts
+++ b/showcase/harness/src/fleet/orchestrator.test.ts
@@ -280,8 +280,38 @@ describe("runWorker loop-crash surfacing", () => {
       await expect(worker.stop()).rejects.toThrow("poison claim");
       expect(shutdownSpy).toHaveBeenCalledTimes(1);
       // The port no longer accepts connections — the health server really
-      // closed (a still-bound server would answer this fetch).
-      await expect(fetch(`http://127.0.0.1:${port}/health`)).rejects.toThrow();
+      // closed (a still-bound server would answer this fetch). Mirror the
+      // src/orchestrator.test.ts hardening: a parallel test process can
+      // legitimately reclaim the freed port, so a successful fetch is not
+      // by itself a failure — but whatever answered MUST NOT claim "ok".
+      let networkErrored = false;
+      let errorMessage = "";
+      let statusIfServed: number | null = null;
+      let bodyLoopIfServed: string | undefined;
+      try {
+        const r = await fetch(`http://127.0.0.1:${port}/health`);
+        statusIfServed = r.status;
+        const healthBody = (await r.json()) as { loop?: string };
+        bodyLoopIfServed = healthBody.loop;
+      } catch (err) {
+        networkErrored = true;
+        errorMessage = err instanceof Error ? err.message : String(err);
+      }
+      if (networkErrored) {
+        // Connection refused / fetch-failed / socket hang-up all prove the
+        // server shut down. Assert a meaningful error shape so an unrelated
+        // rejection (DNS failure, bad URL, TLS error) can't masquerade as
+        // a closed port.
+        expect(errorMessage.length).toBeGreaterThan(0);
+        expect(errorMessage).toMatch(
+          /fetch failed|ECONNREFUSED|ECONN|network|socket|closed/i,
+        );
+      } else {
+        // The port was reclaimed and another process answered: the response
+        // MUST NOT claim a healthy "ok" loop — OUR server is gone.
+        expect(statusIfServed).not.toBe(200);
+        expect(bodyLoopIfServed).not.toBe("ok");
+      }
     } finally {
       shutdownSpy.mockRestore();
     }

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -4232,6 +4232,98 @@ describe("FleetQueueClient.report", () => {
     expect(rows[0].result_processed).toBe(false);
   });
 
+  it("an intra-call write retry NEVER un-latches a committed-then-thrown first attempt (read-before-retry)", async () => {
+    // COMMITTED-THEN-THROWN: write attempt 1 commits server-side, then the
+    // response is lost (a thrown update). During the 250ms retry pause the
+    // consumer can read the row, aggregate the result, and LATCH
+    // result_processed: true. A blind attempt-2 rewrite re-seeds
+    // result_processed: false — un-latching a result the consumer already
+    // aggregated, which the consumer then aggregates a SECOND time. The
+    // CROSS-call retry path guards exactly this with a read-before-write;
+    // the INTRA-call retry loop must apply the same guard.
+    const { pb, rows } = makeFakePb([seededRow()]);
+    const realUpdate = pb.update.bind(pb);
+    let updateAttempts = 0;
+    pb.update = vi.fn(
+      async (
+        collection: string,
+        id: string,
+        record: Record<string, unknown>,
+      ) => {
+        updateAttempts++;
+        if (updateAttempts === 1) {
+          // COMMIT server-side, then lose the response.
+          await realUpdate(collection, id, record);
+          throw new Error("socket reset after commit");
+        }
+        return realUpdate(collection, id, record);
+      },
+    ) as PbClient["update"];
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({ released: true }),
+      ),
+    });
+    const q = createFleetQueueClient({
+      pb,
+      claim,
+      logger,
+      // The consumer aggregates + latches INSIDE the retry pause window.
+      sleep: async () => {
+        rows[0].result_processed = true;
+      },
+    });
+
+    const result = sampleResult();
+    await q.report({ jobId: "j1", workerId: "worker-7", result });
+
+    // Attempt 2 read the row, saw the committed result, and SKIPPED the
+    // rewrite — exactly one update landed and the consumer's latch survives.
+    expect(updateAttempts).toBe(1);
+    expect(rows[0].result).toEqual(result);
+    expect(rows[0].result_processed).toBe(true);
+  });
+
+  it("a failed pre-retry read refuses the blind rewrite (the retry is consumed, never a blind write)", async () => {
+    // If the read-before-retry guard itself fails, a blind write could still
+    // un-latch a committed first attempt — refuse it. The attempt is spent
+    // (lastErr recorded); on exhaustion report() surfaces the distinct
+    // result-lost error and stays retryable (the cross-call path re-reads).
+    const { pb, rows } = makeFakePb([seededRow()]);
+    const realUpdate = pb.update.bind(pb);
+    let updateAttempts = 0;
+    pb.update = vi.fn(
+      async (
+        collection: string,
+        id: string,
+        record: Record<string, unknown>,
+      ) => {
+        updateAttempts++;
+        // Commit-then-throw on EVERY update call that happens.
+        await realUpdate(collection, id, record);
+        throw new Error("socket reset after commit");
+      },
+    ) as PbClient["update"];
+    pb.getOne = vi.fn(async () => {
+      throw new Error("read blip");
+    }) as PbClient["getOne"];
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({ released: true }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger, sleep: async () => {} });
+
+    await expect(
+      q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() }),
+    ).rejects.toThrow(/result lost/i);
+
+    // Only the FIRST attempt wrote; every retry's failed pre-read refused
+    // the blind rewrite instead of re-seeding result_processed: false.
+    expect(updateAttempts).toBe(1);
+    expect(rows[0].result_processed).toBe(false);
+  });
+
   it("does NOT persist a result when the release CAS is refused", async () => {
     const { pb, rows } = makeFakePb([seededRow()]);
     const claim = makeFakeClaim({

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -381,7 +381,7 @@ function sampleResult(
 
 describe("test-fake honesty (the fakes must throw, not vacuously match)", () => {
   it("rowMatchesFilter throws on operators it cannot honor", () => {
-    const row: FilterableRow = { status: "pending", probe_key: "d6:a" };
+    const row: FilterableRow = { id: "r1", status: "pending", probe_key: "d6:a" };
     // Comparison operators are not modeled at all.
     expect(() => rowMatchesFilter(row, 'created < "2026-01-01"')).toThrow(
       /unsupported field/,
@@ -417,7 +417,7 @@ describe("test-fake honesty (the fakes must throw, not vacuously match)", () => 
     // negatives. Multiple positive clauses for ONE field joined by `&&`
     // therefore evaluate WRONG (the model would OR what the filter ANDs) —
     // a test exercising that shape must fail loudly, not pass vacuously.
-    const row: FilterableRow = { status: "pending", probe_key: "d6:a" };
+    const row: FilterableRow = { id: "r1", status: "pending", probe_key: "d6:a" };
     expect(() =>
       rowMatchesFilter(row, 'probe_key ~ "d6:%" && probe_key ~ "d4:%"'),
     ).toThrow(/positive probe_key clauses ANDed/);
@@ -2514,6 +2514,93 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       const third = await q.sweepExpired(muchLater);
       expect(third.expiredPending).toBe(1);
       expect(store.find((r) => r.id === "long-runner")).toBeUndefined();
+    });
+
+    it("a LONG-expired lease on a stale-aged row is claim-DELETED in the lease phase — never re-queued with a 'back in flight' signal the next sweep falsifies (G1d)", async () => {
+      // CROSS-SWEEP FALSIFICATION: a row whose lease expired BEYOND the
+      // family's stale window is past every protection the re-queue path
+      // offers — the per-call grace evaporates with the call, and the stale
+      // phase's recent-lease heuristic only covers leases expired WITHIN the
+      // window. Re-queueing it emits worker-reclaimed-pending ("back in
+      // flight"), and the NEXT sweep claim-deletes the very row that signal
+      // promised was re-running — the dashboard permanently shows
+      // "re-queued" for silently-discarded work. If the row is ALREADY
+      // stale-expirable (created-age past the window AND lease expired
+      // longer than the window), delete it claim-first like the stale phase
+      // — no comm error (the work is being discarded, not re-run).
+      const longDead: CreatedJobRow = {
+        ...jobView({
+          id: "long-dead",
+          probe_key: "d6:a",
+          status: "running",
+          claimed_by: "worker-dead",
+          // Lease expired 4h ago — LONGER than the 3h (3 × 60min) window.
+          lease_expires_at: new Date(T - 4 * HOUR).toISOString(),
+        }),
+        payload: samplePayload({ probeKey: "d6:a" }),
+        created: new Date(T - 8 * HOUR).toISOString(), // stale-aged
+      };
+      // CONTRAST: a recently-expired lease (1min ago) on an equally
+      // stale-aged row keeps today's re-queue + comm-error path — the
+      // recent-lease heuristic protects it across sweeps.
+      const recentDead: CreatedJobRow = {
+        ...jobView({
+          id: "recent-dead",
+          probe_key: "d6:b",
+          status: "running",
+          claimed_by: "worker-dead",
+          lease_expires_at: new Date(T - MIN).toISOString(),
+        }),
+        payload: samplePayload({ probeKey: "d6:b" }),
+        created: new Date(T - 4 * HOUR).toISOString(),
+      };
+      const { pb, store } = makePagingPb([longDead, recentDead]);
+      const releasedPending: string[] = [];
+      const claim: JobClaimClient = {
+        // CAS-faithful claim: admits pending rows AND claimed/running rows
+        // whose lease has expired (the hook's reclaim safety net — the
+        // lease-phase delete claims a long-dead claimed/running row).
+        async claimJob(jobId, workerId): Promise<ClaimResult> {
+          const r = store.find((x) => x.id === jobId);
+          if (!r) return { won: false };
+          const reclaimable =
+            r.status === "pending" ||
+            (["claimed", "running"].includes(r.status) &&
+              leaseExpired(r.lease_expires_at, T));
+          if (!reclaimable) return { won: false };
+          r.status = "claimed";
+          r.claimed_by = workerId;
+          r.version += 1;
+          return { won: true, job: { ...r } };
+        },
+        renewLease: vi.fn(
+          async (): Promise<RenewResult> => ({ renewed: false }),
+        ),
+        async releaseJob(jobId, workerId, status): Promise<ReleaseResult> {
+          const r = store.find((x) => x.id === jobId);
+          if (!r || r.claimed_by !== workerId) return { released: false };
+          if (status === "pending") releasedPending.push(jobId);
+          r.status = status;
+          r.claimed_by = "";
+          r.version += 1;
+          return { released: true, job: { ...r } };
+        },
+      };
+      const q = createFleetQueueClient({ pb, claim, logger });
+
+      const sweep = await q.sweepExpired(T);
+
+      // The long-dead row was DELETED (no re-queue, no comm error, not
+      // counted as reclaimed) and counted with the stale expiries.
+      expect(store.find((r) => r.id === "long-dead")).toBeUndefined();
+      expect(releasedPending).not.toContain("long-dead");
+      expect(sweep.commErrors.map((e) => e.jobId)).toEqual(["recent-dead"]);
+      expect(sweep.reclaimed).toBe(1);
+      expect(sweep.expiredPending).toBe(1);
+      // The recently-expired row took today's path: re-queued to pending.
+      expect(store.find((r) => r.id === "recent-dead")?.status).toBe(
+        "pending",
+      );
     });
 
     it("a release that THROWS after committing server-side still graces the row AND synthesizes its comm error (timeout-after-commit)", async () => {

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -575,6 +575,30 @@ describe("FleetQueueClient.enqueue", () => {
     expect(rows).toHaveLength(0);
   });
 
+  it("rejects a top-level ARRAY payload — the expando hole the nested meta check already closes", async () => {
+    // An array is `typeof "object"` and (as an in-process caller value) can
+    // carry expando fields that satisfy every per-field check below — the
+    // exact hole the meta check's Array.isArray guard closes one level down
+    // (and contracts' commErrorFromStatusSignal guards at its boundary). A
+    // top-level array payload is never a valid ServiceJobPayload; reject it
+    // before anything persists.
+    const { pb, rows } = makeFakePb();
+    const createSpy = vi.fn(pb.create.bind(pb));
+    pb.create = createSpy as PbClient["create"];
+    const claim = makeFakeClaim();
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const expandoArray = Object.assign(
+      [],
+      samplePayload(),
+    ) as unknown as ServiceJobPayload;
+    await expect(q.enqueue({ payload: expandoArray })).rejects.toThrow(
+      /no decodable payload/i,
+    );
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(rows).toHaveLength(0);
+  });
+
   it("rejects the documented forbidden EMPTY sentinels (probeKey/serviceSlug/driverKind/runId) before creating the row (G1c)", async () => {
     // emptyPayloadForLease documents empty serviceSlug/runId (and the rest)
     // as FORBIDDEN aggregation inputs: an empty runId groups into nothing in

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -22,8 +22,8 @@ import { logger } from "../logger.js";
  * over S0's JobClaimClient + the PB client. The three load-bearing behaviors
  * are an enqueue→claimNext round-trip (payload survives the row), report mapping
  * a result onto the terminal JobStatus S0's releaseJob expects, and
- * sweepExpired surfacing `worker-crashed-mid-job` comm errors for leases that
- * expired mid-run.
+ * sweepExpired re-queueing expired leases to pending and surfacing the neutral
+ * `worker-reclaimed-pending` comm errors for them.
  */
 
 function samplePayload(

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -4614,6 +4614,50 @@ describe("FleetQueueClient.report", () => {
 });
 
 describe("FleetQueueClient.sweepExpired", () => {
+  it("CONCURRENT sweepExpired calls share ONE in-flight sweep (multi-producer wiring over one client)", async () => {
+    // runControlPlane wires FOUR family producers over ONE queue client, so
+    // a cron overrun (or a local cron override) can overlap two producers'
+    // sweep calls. The grace set protecting just-re-queued rows from the
+    // stale phase is PER-CALL in-process state — a concurrent second sweep
+    // cannot see it and could claim-delete a row the first sweep just
+    // re-queued, falsifying its worker-reclaimed-pending comm error. The
+    // client therefore latches: a sweep arriving while one is in flight
+    // PIGGYBACKS on the in-flight sweep's result instead of racing it.
+    const { pb } = makeFakePb([]);
+    const realList = pb.list.bind(pb);
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let listCalls = 0;
+    pb.list = vi.fn(async (collection: string, opts?: ListOpts) => {
+      listCalls += 1;
+      await gate;
+      return realList(collection, opts);
+    }) as PbClient["list"];
+    const q = createFleetQueueClient({
+      pb,
+      claim: makeFakeClaim(),
+      logger,
+      // Disable the stale drain so exactly ONE list per sweep (lease phase).
+      stalePending: { expiryPeriods: 0 },
+    });
+
+    const nowMs = Date.parse("2026-06-04T00:05:00.000Z");
+    const first = q.sweepExpired(nowMs);
+    const second = q.sweepExpired(nowMs); // overlaps while first is gated
+    release();
+    const [r1, r2] = await Promise.all([first, second]);
+
+    // ONE underlying sweep ran; the second caller shared its outcome.
+    expect(listCalls).toBe(1);
+    expect(r2).toBe(r1);
+
+    // The latch CLEARS: a later (sequential) sweep runs for real.
+    await q.sweepExpired(nowMs + 1);
+    expect(listCalls).toBe(2);
+  });
+
   it("reclaims expired leases and emits worker-reclaimed-pending comm errors (flap-band #70)", async () => {
     const now = Date.parse("2026-06-04T00:05:00.000Z");
     // One running row with an EXPIRED lease (crashed worker), one with a live

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -5264,8 +5264,13 @@ describe("fleet-claim.pb.js hook parity (client ↔ JSVM contract pins)", () => 
     expect(routes.length).toBe(3);
     // Match the MIDDLEWARE POSITION (the handler-closing `}, $apis...);`),
     // not bare mentions — the header comment also names the middleware.
+    // Tolerant of formatter line-wrapping: the formatter may render the
+    // closing as `}, $apis.requireAdminAuth());` (single-line) or as
+    // `},\n  $apis.requireAdminAuth(),\n);` (split across lines). Both are
+    // the same routerAdd-with-middleware closer.
     const guarded =
-      hookSource.match(/\},\s*\$apis\.requireAdminAuth\(\)\);/g) ?? [];
+      hookSource.match(/\},\s*\$apis\.requireAdminAuth\(\)\s*[,)]\s*\)?;?/g) ??
+      [];
     expect(guarded.length).toBe(3);
   });
 

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -982,24 +982,31 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       );
 
       // Sweep 2 (the sweeper's lease has expired — the fake CAS leaves
-      // lease_expires_at null): the lease phase re-queues the row SILENTLY.
+      // lease_expires_at null): the lease phase re-queues the row SILENTLY,
+      // and the silent re-queue feeds the grace set — the SAME sweep's stale
+      // phase must NOT re-claim it (the retry contract is a LATER sweep), so
+      // the row ends this sweep PENDING and unclaimed.
       const second = await q.sweepExpired(T);
       expect(second.commErrors).toHaveLength(0);
       expect(second.reclaimed).toBe(0);
+      expect(second.expiredPending).toBe(0);
       expect(
         debugSpy.mock.calls.some(
           ([msg]) => msg === "queue-client.stale-sweeper-retry-requeue",
         ),
       ).toBe(true);
-      // Proof the re-queue happened: the SAME sweep's stale phase could only
-      // re-claim a PENDING row (the fake CAS refuses anything else); its
-      // delete failed again, so the row is back under the sweeper.
-      expect(store.find((r) => r.id === "old")?.claimed_by).toBe(
-        "stale-pending-sweeper",
-      );
+      // Proof the grace applied to the sweeper-retry row: the stale phase saw
+      // it pending and SKIPPED it instead of re-claiming it.
+      expect(
+        debugSpy.mock.calls.some(
+          ([msg]) => msg === "queue-client.sweep-stale-grace",
+        ),
+      ).toBe(true);
+      expect(store.find((r) => r.id === "old")?.status).toBe("pending");
+      expect(store.find((r) => r.id === "old")?.claimed_by).toBe("");
 
-      // Sweep 3 (delete healed): silent re-queue, then the stale phase
-      // claims-and-deletes cleanly — still no comm error anywhere.
+      // Sweep 3 (delete healed): the row is plain pending now, so the stale
+      // phase claims-and-deletes it cleanly — still no comm error anywhere.
       deleteFailures.delete("old");
       const third = await q.sweepExpired(T);
       expect(third.expiredPending).toBe(1);
@@ -1150,6 +1157,60 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       // phase re-queued in THIS call, not a blanket stale-phase skip.
       expect(sweep.expiredPending).toBe(1);
       expect(store.find((r) => r.id === "untouched-old")).toBeUndefined();
+    });
+
+    it("applies the grace set on EVERY page of the multi-page stale drain (pagination must not out-run the grace)", async () => {
+      // COMPOSITION: the one-sweep grace × the multi-page drain. A re-queued
+      // row whose `created` sorts AFTER a full page of older stale rows only
+      // surfaces on the drain's SECOND pass — if the grace check were applied
+      // per-sweep-entry instead of per-row-per-pass, pass 2 would delete it
+      // and falsify the worker-reclaimed-pending comm error just emitted.
+      const longClaimed: CreatedJobRow = {
+        ...jobView({
+          id: "long-claimed",
+          probe_key: "d6:graced",
+          status: "running",
+          claimed_by: "worker-dead",
+          lease_expires_at: new Date(T - MIN).toISOString(),
+        }),
+        payload: samplePayload({ probeKey: "d6:graced" }),
+        // Stale (3.5h > 3 × 60min default) but YOUNGER than every backlog row
+        // below, so after the lease-phase re-queue it lands beyond page 1 of
+        // the created-ascending drain.
+        created: new Date(T - 3.5 * HOUR).toISOString(),
+      };
+      // 60 older stale rows: page 1 of the drain (50) is saturated by them,
+      // pushing the graced row onto pass 2.
+      const backlog = Array.from({ length: 60 }, (_, i) =>
+        pendingRow(`stale-${i}`, "d6:a", T - 4 * HOUR - i * 1000),
+      );
+      const { pb, store } = makePagingPb([longClaimed, ...backlog]);
+      const base = makeStoreClaim(store);
+      const claim: JobClaimClient = {
+        ...base,
+        async releaseJob(jobId, workerId, status): Promise<ReleaseResult> {
+          const r = store.find((x) => x.id === jobId);
+          if (!r || r.claimed_by !== workerId) return { released: false };
+          r.status = status;
+          r.claimed_by = "";
+          r.version += 1;
+          return { released: true, job: { ...r } };
+        },
+      };
+      const q = createFleetQueueClient({ pb, claim, logger });
+
+      const sweep = await q.sweepExpired(T);
+
+      // Lease phase: re-queued the long-claimed row with the neutral signal.
+      expect(sweep.reclaimed).toBe(1);
+      expect(sweep.commErrors).toHaveLength(1);
+      expect(sweep.commErrors[0].jobId).toBe("long-claimed");
+      // Drain: the whole 60-row backlog dies across two passes, but the
+      // graced row — seen only on pass 2 — survives the sweep.
+      expect(sweep.expiredPending).toBe(60);
+      expect(store).toHaveLength(1);
+      expect(store[0].id).toBe("long-claimed");
+      expect(store[0].status).toBe("pending");
     });
   });
 

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -1090,6 +1090,35 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       debugSpy.mockRestore();
     });
 
+    it("a claimJob THROW mid stale-drain keeps the rows already expired in the partial result (REQ-B)", async () => {
+      // The first (oldest) stale row claims-and-deletes cleanly; the second
+      // row's claim CAS THROWS (transport blip). The phase must contain the
+      // throw and still report the work it DID do — letting it escape would
+      // also discard the lease phase's commErrors at the producer.
+      const ok = pendingRow("old-ok", "d6:a", T - 5 * HOUR);
+      const boom = pendingRow("old-boom", "d6:b", T - 4 * HOUR);
+      const { pb, store } = makePagingPb([ok, boom]);
+      const base = makeStoreClaim(store);
+      const claim: JobClaimClient = {
+        ...base,
+        async claimJob(jobId, workerId, leaseSeconds) {
+          if (jobId === "old-boom") throw new Error("cas 502");
+          return base.claimJob(jobId, workerId, leaseSeconds);
+        },
+      };
+      const q = createFleetQueueClient({ pb, claim, logger });
+
+      const sweep = await q.sweepExpired(T);
+
+      expect(sweep.expiredPending).toBe(1);
+      expect(store.find((r) => r.id === "old-ok")).toBeUndefined();
+      expect(store.find((r) => r.id === "old-boom")?.status).toBe("pending");
+      expect(logger.error).toHaveBeenCalledWith(
+        "queue-client.sweep-stale-phase-threw",
+        expect.objectContaining({ err: "cas 502" }),
+      );
+    });
+
     it("drains MULTIPLE pages of stale pending rows in ONE sweep (a backlog must not take hours to expire)", async () => {
       // 120 stale rows span 3 candidate pages (perPage 50). A single-page
       // sweep would expire only 50 — against the motivating 3,734-row staging
@@ -1754,6 +1783,90 @@ describe("FleetQueueClient.sweepExpired", () => {
       "j2",
       expect.anything(),
       expect.anything(),
+    );
+  });
+
+  it("a releaseJob THROW on one row does not abort the sweep or lose other rows' comm errors (REQ-B)", async () => {
+    const now = Date.parse("2026-06-04T00:05:00.000Z");
+    // Three expired leases; the MIDDLE row's release THROWS (transport blip,
+    // not a refused CAS). Without per-row containment the throw escapes
+    // sweepExpired, the producer's catch swallows it, and the comm errors
+    // ALREADY synthesized for rows ALREADY released to pending are discarded —
+    // their gray "re-queued" dashboard surfaces never render and are never
+    // regenerated (the rows are pending now, so no later sweep re-emits them).
+    const mkExpired = (id: string, worker: string): JobRow => ({
+      ...jobView({
+        id,
+        status: "running",
+        claimed_by: worker,
+        lease_expires_at: "2026-06-04T00:04:00.000Z",
+        version: 2,
+      }),
+      payload: samplePayload(),
+    });
+    const { pb } = makeFakePb([
+      mkExpired("j1", "w1"),
+      mkExpired("j2", "w2"),
+      mkExpired("j3", "w3"),
+    ]);
+    const releaseJob = vi.fn(
+      async (jobId: string): Promise<ReleaseResult> => {
+        if (jobId === "j2") throw new Error("pb 502 mid-release");
+        return { released: true };
+      },
+    );
+    const claim = makeFakeClaim({ releaseJob });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const sweep = await q.sweepExpired(now);
+
+    // j1 (released BEFORE the throw) and j3 (after) both survive the blip.
+    expect(sweep.reclaimed).toBe(2);
+    expect(sweep.commErrors.map((e) => e.jobId)).toEqual(["j1", "j3"]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.sweep-release-threw",
+      expect.objectContaining({ jobId: "j2", workerId: "w2" }),
+    );
+  });
+
+  it("a THROW in the stale-pending phase still returns the lease phase's partial result (REQ-B)", async () => {
+    const now = Date.parse("2026-06-04T00:05:00.000Z");
+    const expired: JobRow = {
+      ...jobView({
+        id: "j1",
+        status: "running",
+        claimed_by: "worker-dead",
+        lease_expires_at: "2026-06-04T00:04:00.000Z",
+      }),
+      payload: samplePayload(),
+    };
+    const { pb } = makeFakePb([expired]);
+    // The stale phase's pending list THROWS (PB blip). The lease phase's
+    // reclaim + comm error must still come back to the producer — losing them
+    // here is the same REQ-B hole as the per-row release throw above.
+    const realList = pb.list.bind(pb);
+    pb.list = vi.fn(async (collection: string, opts?: ListOpts) => {
+      if (opts?.filter?.includes('status = "pending"')) {
+        throw new Error("pb list 502");
+      }
+      return realList(collection, opts);
+    }) as PbClient["list"];
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({ released: true }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const sweep = await q.sweepExpired(now);
+
+    expect(sweep.reclaimed).toBe(1);
+    expect(sweep.commErrors).toHaveLength(1);
+    expect(sweep.commErrors[0].jobId).toBe("j1");
+    expect(sweep.expiredPending).toBe(0);
+    expect(logger.error).toHaveBeenCalledWith(
+      "queue-client.sweep-stale-phase-threw",
+      expect.objectContaining({ err: "pb list 502" }),
     );
   });
 

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -203,6 +203,16 @@ function rowMatchesFilter(row: FilterableRow, filter?: string): boolean {
   // ANDs negatives. Two positive clauses for ONE field joined WITHOUT a
   // `||` between them are ANDed in the real grammar — a shape this OR-model
   // would evaluate wrong, so it must throw rather than pass vacuously.
+  //
+  // KNOWN LIMITATION (interleaved `||`, G1h): the guard only checks that the
+  // RAW TEXT between two same-field positives contains a `||` — it is blind
+  // to grouping/precedence. A filter like
+  // `probe_key = "a" || status = "x" && probe_key = "b"` interleaves a
+  // different field between the two probe_key positives; the separator
+  // contains `||`, so the guard passes, yet the OR-model flattens what the
+  // real grammar binds as `a || (x && b)`. No production builder emits such
+  // a shape (inclusion groups are homogeneous parenthesized ORs); a future
+  // test that does must extend the matcher, not trust it.
   const assertPositivesOrJoined = (field: string, re: RegExp): void => {
     const ms = [...filter.matchAll(re)];
     for (let i = 1; i < ms.length; i++) {
@@ -294,17 +304,56 @@ function makeFakePb(rows: JobRow[] = []): {
       // sweepExpired scans are exercised the way real PB would serve them. A
       // clause on any OTHER field THROWS (see rowMatchesFilter) instead of
       // silently matching everything.
-      const items = store.filter((r) => rowMatchesFilter(r, opts.filter));
+      let items = store.filter((r) => rowMatchesFilter(r, opts.filter));
+      // SORT honesty (G1h): this fake used to IGNORE `sort` entirely — any
+      // test depending on an order the production query requested passed
+      // vacuously on insertion order. Model the two production sort keys
+      // (rows here usually lack `created`, where the STABLE sort preserves
+      // insertion order — PB's tie behavior for identical values) and THROW
+      // on anything else, matching the fakes' unsupported philosophy.
+      const desc = opts.sort?.startsWith("-") ?? false;
+      const sortKey = desc ? opts.sort!.slice(1) : opts.sort;
+      if (sortKey === "created") {
+        items = [...items].sort((a, b) =>
+          String((a as { created?: string }).created ?? "").localeCompare(
+            String((b as { created?: string }).created ?? ""),
+          ),
+        );
+      } else if (sortKey === "lease_expires_at") {
+        items = [...items].sort((a, b) =>
+          String(a.lease_expires_at ?? "").localeCompare(
+            String(b.lease_expires_at ?? ""),
+          ),
+        );
+      } else if (sortKey) {
+        throw new Error(
+          `fake-pb: unmodeled sort key "${sortKey}" — only created/lease_expires_at are honored`,
+        );
+      }
+      if (desc) items.reverse();
+      const totalItems = items.length;
+      // PAGING honesty (G1h): perPage used to be ignored — a matched set
+      // LARGER than the requested page came back whole, hiding truncation
+      // behavior the production pagination depends on. Slice like PB.
+      if (opts.perPage !== undefined) {
+        const page = opts.page ?? 1;
+        items = items.slice((page - 1) * opts.perPage, page * opts.perPage);
+      }
       return {
-        page: 1,
+        page: opts.page ?? 1,
         perPage: opts.perPage ?? items.length,
-        totalPages: 1,
+        totalPages:
+          opts.skipTotal === true
+            ? -1
+            : opts.perPage !== undefined
+              ? Math.max(1, Math.ceil(totalItems / opts.perPage))
+              : 1,
         // Faithful to PB: a skipTotal list returns totalItems -1, NOT the
         // real count. A fake that returned real counts under skipTotal
         // would green-light code reading totals it never requested (the
         // fail-open class countPendingForFamily's skipTotal:false pin
         // exists to prevent).
-        totalItems: opts.skipTotal === true ? -1 : items.length,
+        totalItems: opts.skipTotal === true ? -1 : totalItems,
         items: items as unknown as T[],
       };
     },
@@ -447,6 +496,27 @@ describe("test-fake honesty (the fakes must throw, not vacuously match)", () => 
         'status = "pending" && probe_key !~ "d4:%" && probe_key != "d4"',
       ),
     ).toBe(true);
+  });
+
+  it("makeFakePb throws on an unmodeled sort key and honors perPage truncation (no vacuous ordering/paging)", async () => {
+    const { pb } = makeFakePb([
+      { ...jobView({ id: "j1" }), payload: samplePayload() },
+      { ...jobView({ id: "j2" }), payload: samplePayload() },
+      { ...jobView({ id: "j3" }), payload: samplePayload() },
+    ]);
+    // Unmodeled sort key → throw (the fake used to silently not sort).
+    await expect(
+      pb.list("probe_jobs", { filter: 'status = "pending"', sort: "version" }),
+    ).rejects.toThrow(/unmodeled sort key "version"/);
+    // perPage smaller than the matched set → truncated like PB (the fake
+    // used to return the whole matched set regardless).
+    const page = await pb.list("probe_jobs", {
+      filter: 'status = "pending"',
+      sort: "created",
+      perPage: 2,
+      skipTotal: true,
+    });
+    expect(page.items).toHaveLength(2);
   });
 
   it("the fakes return totalItems -1 under skipTotal (faithful to PB, no fail-open counts)", async () => {
@@ -937,7 +1007,15 @@ describe("FleetQueueClient.claimNext", () => {
       claimJob: vi.fn(
         async (jobId, workerId): Promise<ClaimResult> => ({
           won: true,
-          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+          // Carry the SAME probe_key on the CAS view as the listed row: the
+          // fixture must not pin which internal source (candidate row vs
+          // returned view) the synthesis reads the key from.
+          job: jobView({
+            id: jobId,
+            probe_key: "d6:",
+            status: "claimed",
+            claimed_by: workerId,
+          }),
         }),
       ),
     });
@@ -3019,13 +3097,14 @@ describe("FleetQueueClient.renewLease", () => {
     expect(lease).toBeNull();
   });
 
-  it("still renews when the convenience re-read returns null (CAS won)", async () => {
-    // The CAS renewed and returned the lifecycle columns; a momentary PB read
-    // blip makes the convenience getOne return null. The heartbeat must NOT
-    // throw on that blip (throwing permanently stops heartbeating → the sweeper
-    // later reclaims a LIVE job and synthesizes a FALSE worker-crashed comm
-    // error). The payload is re-hydrated from the claim-time cache, so the
-    // re-read is unnecessary and its failure is non-fatal.
+  it("renews from the claim-time payload CACHE — the convenience re-read is never consulted on a cache hit", async () => {
+    // CACHE-HIT path (explicitly pinned): the CAS renewed and returned the
+    // lifecycle columns, and the payload comes from the claim-time cache —
+    // pb.getOne must NOT be called at all. (The stubbed null getOne below
+    // would be a failed re-read IF it were consulted; the not-called pin
+    // keeps this test honest about WHICH path it covers. The cache-MISS +
+    // failed-re-read path is pinned separately by the "cache miss AND
+    // reread fail" test below.)
     const payload = samplePayload();
     // Seed the store so claimNext can populate the payload cache, then the
     // renew re-read still works against this same row.
@@ -3057,8 +3136,8 @@ describe("FleetQueueClient.renewLease", () => {
       ),
       // getOne is never required for a successful renew.
     });
-    // Make the convenience re-read fail outright (null) to prove non-fatality.
-    pb.getOne = vi.fn(async () => null) as PbClient["getOne"];
+    const getOneSpy = vi.fn(async () => null);
+    pb.getOne = getOneSpy as PbClient["getOne"];
     const q = createFleetQueueClient({ pb, claim, logger });
 
     // Claim first so the payload cache is populated for this jobId.
@@ -3070,6 +3149,8 @@ describe("FleetQueueClient.renewLease", () => {
     expect(lease?.job.status).toBe("running");
     expect(lease?.leaseExpiresAt).toBe("2026-06-04T00:02:00.000Z");
     expect(lease?.payload).toEqual(payload);
+    // The cache HIT means the convenience re-read was never consulted.
+    expect(getOneSpy).not.toHaveBeenCalled();
   });
 
   it("EVICTS the cached payload when the renew CAS is lost (no payloadCache leak)", async () => {
@@ -3593,10 +3674,13 @@ describe("FleetQueueClient.report", () => {
 
   it("persists the ServiceJobResult onto the row, unprocessed, after the release", async () => {
     const { pb, rows } = makeFakePb([seededRow()]);
-    // Assert ordering: the result is only written AFTER the CAS release wins.
-    let releasedFirst = false;
+    // ORDERING (non-vacuous): capture the row's result AT RELEASE TIME —
+    // inside the releaseJob fake — and assert it was still unwritten. A
+    // released-first boolean checked after the fact is vacuously true
+    // whenever the release ran at all, regardless of write order.
+    let resultAtRelease: unknown = "sentinel-not-read";
     const releaseJob = vi.fn(async (): Promise<ReleaseResult> => {
-      releasedFirst = true;
+      resultAtRelease = rows[0].result;
       return { released: true };
     });
     const claim = makeFakeClaim({ releaseJob });
@@ -3605,8 +3689,11 @@ describe("FleetQueueClient.report", () => {
     const result = sampleResult();
     await q.report({ jobId: "j1", workerId: "worker-7", result });
 
-    expect(releasedFirst).toBe(true);
-    // The control-plane consumer reads this back to aggregate exactly once.
+    // Nothing was written before (or during) the release CAS…
+    expect(releaseJob).toHaveBeenCalledTimes(1);
+    expect(resultAtRelease).toBeUndefined();
+    // …and the control-plane consumer reads this back to aggregate exactly
+    // once afterwards.
     expect(rows[0].result).toEqual(result);
     expect(rows[0].result_processed).toBe(false);
   });

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -2555,6 +2555,32 @@ describe("fleet-claim.pb.js hook parity (client ↔ JSVM contract pins)", () => 
     expect(occurrences).toBeGreaterThanOrEqual(3);
   });
 
+  it("every routerAdd endpoint carries the superuser auth middleware (requireAdminAuth)", () => {
+    // SECURITY: the header contract says "superuser/worker auth required",
+    // and the client (job-claim.ts) already authenticates as superuser with
+    // a 401-reauth retry — but middleware-less routerAdd handlers are
+    // PUBLIC in PB 0.22. Every endpoint must append
+    // `$apis.requireAdminAuth()` (the PB 0.22 JSVM superuser-auth echo
+    // middleware) or any unauthenticated caller can claim/renew/release
+    // arbitrary jobs.
+    const routes = hookSource.match(/routerAdd\(/g) ?? [];
+    expect(routes.length).toBe(3);
+    // Match the MIDDLEWARE POSITION (the handler-closing `}, $apis...);`),
+    // not bare mentions — the header comment also names the middleware.
+    const guarded =
+      hookSource.match(/\},\s*\$apis\.requireAdminAuth\(\)\);/g) ?? [];
+    expect(guarded.length).toBe(3);
+  });
+
+  it("claim + renew clamp leaseSeconds (numeric, ceiling 3600, default 30 on garbage)", () => {
+    // A malformed/hostile leaseSeconds must not wedge a row behind a
+    // multi-day lease (ceiling) nor produce NaN expiries (numeric check →
+    // 30s default). Pinned at the source level for both lease-setting
+    // handlers (claim + renew; release sets no lease).
+    const clamps = hookSource.match(/Math\.min\(\s*n,\s*3600\s*\)/g) ?? [];
+    expect(clamps.length).toBe(2);
+  });
+
   it("the release handler re-checks lease expiry for a pending-target (sweeper) release — TOCTOU close", () => {
     // The sweeper decides "expired" from a LISTED SNAPSHOT, then releases on
     // behalf of the holder; the release CAS authorizes on `claimed_by`, which

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -5,6 +5,7 @@ import {
   createFleetQueueClient,
   leaseExpired,
   PB_DATE_SEP_RE,
+  RESULT_WRITE_MAX_ATTEMPTS,
 } from "./queue-client.js";
 import type {
   JobClaimClient,
@@ -134,19 +135,36 @@ interface FilterableRow {
 
 /**
  * Shared `status`/`probe_key` filter evaluation for BOTH fake PB clients
- * (`makeFakePb` + `makePagingPb`). A clause on a field the fakes can't honor
- * THROWS loudly — matching the fakes' own unsupported-method philosophy — so
- * a future test exercising an unmodeled filter shape can never pass
- * vacuously by silently matching every row.
+ * (`makeFakePb` + `makePagingPb`). A clause on a field OR OPERATOR the fakes
+ * can't honor THROWS loudly — matching the fakes' own unsupported-method
+ * philosophy — so a future test exercising an unmodeled filter shape can
+ * never pass vacuously by silently matching every row (the original matcher
+ * silently match-all'ed e.g. `status != "done"` or any `<`/`>` clause).
+ *
+ * KNOWN LIMITATION: the operator scan is regex-based over the RAW filter
+ * string, so an operator-looking sequence INSIDE a quoted literal would
+ * false-positive as a clause (and could throw spuriously). Acceptable here:
+ * probe keys are slugs and statuses are bare words, so no quoted literal in
+ * these filters legitimately carries operator characters.
  */
 function rowMatchesFilter(row: FilterableRow, filter?: string): boolean {
   if (!filter) return true;
-  for (const [, field] of filter.matchAll(
-    /([A-Za-z_][\w.]*)\s*(?:!~|!=|~|=)/g,
+  for (const [, field, op] of filter.matchAll(
+    /([A-Za-z_][\w.]*)\s*(\?~|\?=|!~|!=|<=|>=|<|>|~|=)/g,
   )) {
     if (field !== "status" && field !== "probe_key") {
       throw new Error(
         `fake-pb: filter clause on unsupported field "${field}" — only status/probe_key are honored (filter: ${filter})`,
+      );
+    }
+    if (field === "status" && op !== "=") {
+      throw new Error(
+        `fake-pb: status clause with unsupported operator "${op}" — only \`=\` is honored (filter: ${filter})`,
+      );
+    }
+    if (field === "probe_key" && !["=", "!=", "~", "!~"].includes(op)) {
+      throw new Error(
+        `fake-pb: probe_key clause with unsupported operator "${op}" (filter: ${filter})`,
       );
     }
   }
@@ -219,7 +237,12 @@ function makeFakePb(rows: JobRow[] = []): {
         page: 1,
         perPage: opts.perPage ?? items.length,
         totalPages: 1,
-        totalItems: items.length,
+        // Faithful to PB: a skipTotal list returns totalItems -1, NOT the
+        // real count. A fake that returned real counts under skipTotal
+        // would green-light code reading totals it never requested (the
+        // fail-open class countPendingForFamily's skipTotal:false pin
+        // exists to prevent).
+        totalItems: opts.skipTotal === true ? -1 : items.length,
         items: items as unknown as T[],
       };
     },
@@ -293,6 +316,55 @@ function sampleResult(
     ...overrides,
   };
 }
+
+describe("test-fake honesty (the fakes must throw, not vacuously match)", () => {
+  it("rowMatchesFilter throws on operators it cannot honor", () => {
+    const row: FilterableRow = { status: "pending", probe_key: "d6:a" };
+    // Comparison operators are not modeled at all.
+    expect(() => rowMatchesFilter(row, 'created < "2026-01-01"')).toThrow(
+      /unsupported field/,
+    );
+    expect(() => rowMatchesFilter(row, 'probe_key > "a"')).toThrow(
+      /unsupported operator/,
+    );
+    expect(() => rowMatchesFilter(row, 'probe_key ?~ "d6:%"')).toThrow(
+      /unsupported operator/,
+    );
+    expect(() => rowMatchesFilter(row, 'probe_key ?= "d6:a"')).toThrow(
+      /unsupported operator/,
+    );
+    // status is only modeled for `=` — negation/LIKE forms used to silently
+    // match ALL rows (a vacuous-pass hole for any test that exercised them).
+    expect(() => rowMatchesFilter(row, 'status != "done"')).toThrow(
+      /status clause with unsupported operator/,
+    );
+    expect(() => rowMatchesFilter(row, 'status ~ "pend%"')).toThrow(
+      /status clause with unsupported operator/,
+    );
+    expect(() => rowMatchesFilter(row, 'status !~ "done%"')).toThrow(
+      /status clause with unsupported operator/,
+    );
+    // The supported shapes still evaluate.
+    expect(rowMatchesFilter(row, 'status = "pending"')).toBe(true);
+    expect(rowMatchesFilter(row, 'probe_key !~ "d4:%"')).toBe(true);
+  });
+
+  it("the fakes return totalItems -1 under skipTotal (faithful to PB, no fail-open counts)", async () => {
+    const { pb } = makeFakePb([
+      { ...jobView({ id: "j1" }), payload: samplePayload() },
+    ]);
+    const skipped = await pb.list("probe_jobs", {
+      filter: 'status = "pending"',
+      skipTotal: true,
+    });
+    expect(skipped.totalItems).toBe(-1);
+    const counted = await pb.list("probe_jobs", {
+      filter: 'status = "pending"',
+      skipTotal: false,
+    });
+    expect(counted.totalItems).toBe(1);
+  });
+});
 
 describe("FleetQueueClient.enqueue", () => {
   it("writes a pending probe_jobs row carrying the serialized payload", async () => {
@@ -840,7 +912,17 @@ describe("FleetQueueClient.claimNext — CLAIM FAIRNESS (Part B contention)", ()
   }
 
   /** A pb that lists a FIXED ordered pending page (the shared snapshot all
-   *  workers see). Only `list` is exercised — claimNext never mutates here. */
+   *  workers see). Only `list` is exercised — claimNext never mutates here.
+   *
+   *  DELIBERATE FILTER BLINDNESS: this fake ignores ALL filters — including
+   *  the family-discovery EXCLUSION clauses — so every discovery iteration
+   *  re-yields the same head family and claimNext proceeds via the
+   *  duplicate-family defensive break (with its warn). That coupling is the
+   *  point: these fairness tests pin the per-poll ATTEMPT ORDER over one
+   *  fixed page, not the multi-family rotation (covered by the
+   *  filter-honoring `makeFakePb`/`makePagingPb` suites). Throwing on
+   *  exclusion clauses here would break discovery before any attempt
+   *  histogram could be collected. */
   function makeOrderedPb(orderedIds: string[]): PbClient {
     const unsupported = (name: string) => () => {
       throw new Error(`ordered-pb: ${name} not implemented`);
@@ -1015,7 +1097,12 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
         opts: ListOpts = {},
       ): Promise<ListResult<T>> {
         let items = store.filter((r) => rowMatchesFilter(r, opts.filter));
-        if (opts.sort && opts.sort.includes("lease_expires_at")) {
+        // Honor the sort DIRECTION too (PB's `-` prefix = descending): a
+        // fake that silently sorted ascending under a `-created` sort would
+        // vacuously pass any newest-first expectation.
+        const desc = opts.sort?.startsWith("-") ?? false;
+        const sortKey = desc ? opts.sort!.slice(1) : opts.sort;
+        if (sortKey && sortKey.includes("lease_expires_at")) {
           // PB ascending date sort; empty/null dates sort first (and a
           // null/empty lease counts as expired — leaseExpired(null) === true —
           // so "nulls first" is exactly the expired-first semantics).
@@ -1024,9 +1111,10 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
               String(b.lease_expires_at ?? ""),
             ),
           );
-        } else if (opts.sort && opts.sort.includes("created")) {
+        } else if (sortKey && sortKey.includes("created")) {
           items = [...items].sort((a, b) => a.created.localeCompare(b.created));
         }
+        if (desc) items.reverse();
         const totalItems = items.length;
         if (opts.perPage !== undefined) {
           // Honor `page` (1-based) the way PB does — the stale drain advances
@@ -1037,8 +1125,17 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
         return {
           page: opts.page ?? 1,
           perPage: opts.perPage ?? items.length,
-          totalPages: 1,
-          totalItems,
+          // Honest totalPages (PB computes it from the REAL total), -1 under
+          // skipTotal like totalItems.
+          totalPages:
+            opts.skipTotal === true
+              ? -1
+              : opts.perPage !== undefined
+                ? Math.max(1, Math.ceil(totalItems / opts.perPage))
+                : 1,
+          // Faithful to PB: skipTotal returns -1, never a real count the
+          // production code did not ask for (fail-open hole).
+          totalItems: opts.skipTotal === true ? -1 : totalItems,
           items: items as unknown as T[],
         };
       },
@@ -2487,8 +2584,9 @@ describe("FleetQueueClient.report", () => {
     ).rejects.toThrow(/result lost/i);
     // The release was attempted (and won) before the result write.
     expect(releaseJob).toHaveBeenCalledWith("j1", "worker-7", "done");
-    // The write was RETRIED, not attempted once.
-    expect(updateAttempts).toBeGreaterThan(1);
+    // The write was retried up to EXACTLY the production bound — pinned via
+    // the imported constant so the test can't drift from the implementation.
+    expect(updateAttempts).toBe(RESULT_WRITE_MAX_ATTEMPTS);
   });
 
   it("succeeds when the result write fails once then recovers (bounded retry)", async () => {

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -466,6 +466,129 @@ describe("FleetQueueClient.claimNext", () => {
     expect(claimed.lease?.job.id).toBe("j2");
   });
 
+  it("attributes a decode-failed row as worker-protocol-violation via a synthetic result (not a crash)", async () => {
+    // After the decode-fail release the row is terminal-but-RESULTLESS; the
+    // result consumer's contract synthesizes worker-crashed-mid-job (a RED
+    // "crashed" overlay) for such rows past grace. A poison payload is a
+    // PROTOCOL failure, not a crash — the queue-client must write a synthetic
+    // result carrying a worker-protocol-violation commError so the consumer
+    // renders the honest signal.
+    const { pb, rows } = makeFakePb([
+      {
+        ...jobView({ id: "j1" }),
+        payload: null as unknown as ServiceJobPayload,
+      },
+    ]);
+    const releaseJob = vi.fn(
+      async (): Promise<ReleaseResult> => ({ released: true }),
+    );
+    const claim = makeFakeClaim({
+      releaseJob,
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const claimed = await q.claimNext("worker-7", 30);
+
+    expect(claimed.claimed).toBe(false);
+    expect(releaseJob).toHaveBeenCalledWith("j1", "worker-7", "failed");
+    // The synthetic result landed on the row, unprocessed, attributing the
+    // poison payload — NOT left for the consumer's crash synthesis.
+    const written = rows[0].result as ServiceJobResult;
+    expect(written.commError?.kind).toBe("worker-protocol-violation");
+    expect(written.commError?.jobId).toBe("j1");
+    expect(written.commError?.workerId).toBe("worker-7");
+    expect(written.jobId).toBe("j1");
+    expect(written.workerId).toBe("worker-7");
+    // No decodable payload → aggregate key falls back to the row's probe_key.
+    expect(written.aggregateKey).toBe("d6:langgraph-python");
+    expect(written.aggregateState).toBe("error");
+    expect(rows[0].result_processed).toBe(false);
+  });
+
+  it("a releaseJob THROW during decode-fail cleanup must not strand the loop (warn + continue)", async () => {
+    // The decode-fail release can THROW (transport blip), not just refuse.
+    // claimNext must contain it — warn and fall through to the next
+    // candidate — or the whole claim poll dies on one poison row.
+    const { pb } = makeFakePb([
+      {
+        ...jobView({ id: "j1" }),
+        payload: null as unknown as ServiceJobPayload,
+      },
+      { ...jobView({ id: "j2" }), payload: samplePayload() },
+    ]);
+    const releaseJob = vi.fn(async (): Promise<ReleaseResult> => {
+      throw new Error("release transport blip");
+    });
+    const claim = makeFakeClaim({
+      releaseJob,
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        }),
+      ),
+    });
+    // Identity-order rng: j1 (poison) before j2.
+    const q = createFleetQueueClient({
+      pb,
+      claim,
+      logger,
+      rng: IDENTITY_ORDER_RNG,
+    });
+
+    const claimed = await q.claimNext("worker-7", 30);
+
+    expect(claimed.claimed).toBe(true);
+    expect(claimed.lease?.job.id).toBe("j2");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.claim-decode-release-failed",
+      expect.objectContaining({
+        jobId: "j1",
+        err: "release transport blip",
+      }),
+    );
+  });
+
+  it("returns { claimed: false } when EVERY candidate decode-fails (no throw, nothing stranded)", async () => {
+    const { pb } = makeFakePb([
+      {
+        ...jobView({ id: "j1" }),
+        payload: null as unknown as ServiceJobPayload,
+      },
+      {
+        ...jobView({ id: "j2" }),
+        payload: "garbage" as unknown as ServiceJobPayload,
+      },
+    ]);
+    const releaseJob = vi.fn(
+      async (): Promise<ReleaseResult> => ({ released: true }),
+    );
+    const claim = makeFakeClaim({
+      releaseJob,
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const claimed = await q.claimNext("worker-7", 30);
+
+    expect(claimed.claimed).toBe(false);
+    expect(claimed.lease).toBeUndefined();
+    // Both poison rows were released (none stranded for a false crash).
+    expect(releaseJob).toHaveBeenCalledWith("j1", "worker-7", "failed");
+    expect(releaseJob).toHaveBeenCalledWith("j2", "worker-7", "failed");
+  });
+
   it("falls through to the next candidate when it loses the CAS on the first", async () => {
     const { pb } = makeFakePb([
       { ...jobView({ id: "j1" }), payload: samplePayload() },

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -3930,6 +3930,89 @@ describe("FleetQueueClient.report", () => {
     expect(releaseJob).toHaveBeenCalledWith("j1", "worker-7", "failed");
   });
 
+  it("throws on a ReportJobInput equality-invariant violation BEFORE releasing anything", async () => {
+    // contracts.ts documents jobId === result.jobId and workerId ===
+    // result.workerId as the input invariant: release keys on the top-level
+    // ids while the persisted result echoes its own, so a mismatched caller
+    // would release ONE row while filing the result under ANOTHER
+    // job's/worker's ids. report() must fail loud before the release CAS.
+    const { pb, rows } = makeFakePb([seededRow()]);
+    const releaseJob = vi.fn(
+      async (): Promise<ReleaseResult> => ({ released: true }),
+    );
+    const claim = makeFakeClaim({ releaseJob });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await expect(
+      q.report({
+        jobId: "j1",
+        workerId: "worker-7",
+        result: sampleResult({ jobId: "j2" }),
+      }),
+    ).rejects.toThrow(/equality invariant/i);
+    await expect(
+      q.report({
+        jobId: "j1",
+        workerId: "worker-7",
+        result: sampleResult({ workerId: "worker-8" }),
+      }),
+    ).rejects.toThrow(/equality invariant/i);
+    expect(releaseJob).not.toHaveBeenCalled();
+    expect(rows[0].result).toBeUndefined();
+  });
+
+  it("evicts the cached payload even when the result is MALFORMED (status computed inside the try)", async () => {
+    // terminalJobStatus(input.result) used to run BEFORE the try/finally —
+    // a malformed result threw past the finally and the claim-time cache
+    // entry leaked (the same strand the finally exists to prevent: the
+    // worker is done with the job either way). Proof of eviction: a later
+    // successful renew must take the convenience RE-READ path (cache miss →
+    // pb.getOne); a leaked entry would skip it.
+    const payload = samplePayload();
+    const { pb } = makeFakePb([{ ...jobView({ id: "j1" }), payload }]);
+    const getOneSpy = vi.fn(pb.getOne.bind(pb));
+    pb.getOne = getOneSpy as PbClient["getOne"];
+    const releaseJob = vi.fn(
+      async (): Promise<ReleaseResult> => ({ released: true }),
+    );
+    const claim = makeFakeClaim({
+      releaseJob,
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        }),
+      ),
+      renewLease: vi.fn(
+        async (): Promise<RenewResult> => ({
+          renewed: true,
+          job: jobView({
+            id: "j1",
+            status: "running",
+            claimed_by: "worker-7",
+            lease_expires_at: "2026-06-04T00:02:00.000Z",
+            version: 2,
+          }),
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await q.claimNext("worker-7", 30);
+    await expect(
+      q.report({
+        jobId: "j1",
+        workerId: "worker-7",
+        result: null as unknown as ServiceJobResult,
+      }),
+    ).rejects.toThrow();
+    expect(releaseJob).not.toHaveBeenCalled();
+
+    const lease = await q.renewLease("j1", "worker-7", 30);
+    expect(lease).not.toBeNull();
+    expect(getOneSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("persists the ServiceJobResult onto the row, unprocessed, after the release", async () => {
     const { pb, rows } = makeFakePb([seededRow()]);
     // ORDERING (non-vacuous): capture the row's result AT RELEASE TIME —

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -2802,6 +2802,82 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       expect(store.find((r) => r.id === "long-runner")).toBeUndefined();
     });
 
+    it("an UNPARSEABLE lease on a stale-aged expired row is claim-DELETED in the lease phase — two sweeps compose honestly (no falsified 'back in flight')", async () => {
+      // COMPOSE HOLE: the long-expired carve-out used to require a FINITE
+      // parsed lease, so an expired claimed/running row with an
+      // unparseable lease_expires_at fell to the conservative re-queue —
+      // emitting worker-reclaimed-pending ("back in flight"). But the NEXT
+      // sweep's recent-lease protection ALSO requires a finite lease, so
+      // the re-queued row was claim-DELETED off its stale created age —
+      // the dashboard permanently showed "re-queued" for silently
+      // discarded work. An unparseable lease carries NO recent-flight
+      // evidence either phase can honor, so the lease phase must treat it
+      // as long-expired and delete directly: the emitted signal (none)
+      // matches the eventual outcome (discard).
+      const junkLease: CreatedJobRow = {
+        ...jobView({
+          id: "junk-lease",
+          probe_key: "d6:a",
+          status: "running",
+          claimed_by: "worker-dead",
+          // Unparseable: leaseExpired(NaN) → expired (never wedge), but
+          // neither the carve-out's finite-lease check nor the stale
+          // phase's recent-lease protection could read it.
+          lease_expires_at: "not-a-date",
+        }),
+        payload: samplePayload({ probeKey: "d6:a" }),
+        created: new Date(T - 4 * HOUR).toISOString(), // > 3 × 60min window
+      };
+      const { pb, store } = makePagingPb([junkLease]);
+      const releasedPending: string[] = [];
+      const claim: JobClaimClient = {
+        // CAS-faithful claim: admits pending rows AND claimed/running rows
+        // whose lease has expired (the hook's reclaim safety net).
+        async claimJob(jobId, workerId): Promise<ClaimResult> {
+          const r = store.find((x) => x.id === jobId);
+          if (!r) return { won: false };
+          const reclaimable =
+            r.status === "pending" ||
+            (["claimed", "running"].includes(r.status) &&
+              leaseExpired(r.lease_expires_at, T));
+          if (!reclaimable) return { won: false };
+          r.status = "claimed";
+          r.claimed_by = workerId;
+          r.version += 1;
+          return { won: true, job: { ...r } };
+        },
+        renewLease: vi.fn(
+          async (): Promise<RenewResult> => ({ renewed: false }),
+        ),
+        async releaseJob(jobId, workerId, status): Promise<ReleaseResult> {
+          const r = store.find((x) => x.id === jobId);
+          if (!r || r.claimed_by !== workerId) return { released: false };
+          if (status === "pending") releasedPending.push(jobId);
+          r.status = status;
+          r.claimed_by = "";
+          r.version += 1;
+          return { released: true, job: { ...r } };
+        },
+      };
+      const q = createFleetQueueClient({ pb, claim, logger });
+
+      // Sweep 1: deleted directly — no re-queue, no "back in flight" comm
+      // error to falsify, counted with the stale expiries.
+      const first = await q.sweepExpired(T);
+      expect(store.find((r) => r.id === "junk-lease")).toBeUndefined();
+      expect(releasedPending).toEqual([]);
+      expect(first.commErrors).toHaveLength(0);
+      expect(first.reclaimed).toBe(0);
+      expect(first.expiredPending).toBe(1);
+
+      // Sweep 2: nothing left to act on — the phases composed in ONE sweep
+      // instead of sweep 1 promising a re-run sweep 2 silently revokes.
+      const second = await q.sweepExpired(T);
+      expect(second.commErrors).toHaveLength(0);
+      expect(second.expiredPending).toBe(0);
+      expect(second.reclaimed).toBe(0);
+    });
+
     it("a LONG-expired lease on a stale-aged row is claim-DELETED in the lease phase — never re-queued with a 'back in flight' signal the next sweep falsifies (G1d)", async () => {
       // CROSS-SWEEP FALSIFICATION: a row whose lease expired BEYOND the
       // family's stale window is past every protection the re-queue path

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -5,6 +5,7 @@ import {
   createFleetQueueClient,
   leaseExpired,
   PB_DATE_SEP_RE,
+  PoisonedBacklogCountError,
   RESULT_WRITE_MAX_ATTEMPTS,
   RESULT_WRITE_RETRY_DELAY_MS,
 } from "./queue-client.js";
@@ -2313,6 +2314,13 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
 
     await expect(q.countPendingForFamily("d4")).rejects.toThrow(
       /non-count totalItems/i,
+    );
+    // The refusal is a DEDICATED EXPORTED CLASS, not just message text: the
+    // producer's backlog gate discriminates this fail-closed class via
+    // `instanceof` (message-substring matching silently flipped the gate
+    // fail-closed → fail-open on any message drift).
+    await expect(q.countPendingForFamily("d4")).rejects.toBeInstanceOf(
+      PoisonedBacklogCountError,
     );
   });
 

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -993,11 +993,23 @@ describe("FleetQueueClient.claimNext", () => {
     );
   });
 
-  it("warns on the protocol violation `won && !job` before falling through (CAS contract breach must be visible)", async () => {
+  it("releases a won-without-job row back to pending before falling through — never abandons a row this worker may own (G1e)", async () => {
+    // won:true with NO job view violates the endpoint contract — but the
+    // CAS may genuinely have committed, so this worker may now OWN the row.
+    // Falling through silently wedged a full lease window: nobody renews or
+    // reports the orphaned claim, the sweeper later reclaims it and paints a
+    // false worker-reclaimed-pending overlay. Mirror the decode-failure
+    // containment: best-effort release back to `pending` (no work happened —
+    // unlike the decode poison row, the job itself may be perfectly
+    // runnable) before moving on.
     const { pb } = makeFakePb([
       { ...jobView({ id: "j1" }), payload: samplePayload() },
     ]);
+    const releaseJob = vi.fn(
+      async (): Promise<ReleaseResult> => ({ released: true }),
+    );
     const claim = makeFakeClaim({
+      releaseJob,
       // won:true with NO job violates the endpoint contract (a win always
       // carries the row view).
       claimJob: vi.fn(async (): Promise<ClaimResult> => ({ won: true })),
@@ -1010,6 +1022,44 @@ describe("FleetQueueClient.claimNext", () => {
     expect(logger.warn).toHaveBeenCalledWith(
       "queue-client.claim-won-without-job",
       expect.objectContaining({ jobId: "j1" }),
+    );
+    // The possibly-owned row was released back to pending (no work ran).
+    expect(releaseJob).toHaveBeenCalledWith("j1", "worker-7", "pending");
+  });
+
+  it("a THROWN won-without-job release is swallowed with a warn — best-effort only (G1e)", async () => {
+    const { pb } = makeFakePb([
+      { ...jobView({ id: "j1" }), payload: samplePayload() },
+      { ...jobView({ id: "j2" }), payload: samplePayload() },
+    ]);
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(async (): Promise<ReleaseResult> => {
+        throw new Error("release transport blip");
+      }),
+      claimJob: vi.fn(async (jobId, workerId): Promise<ClaimResult> => {
+        if (jobId === "j1") return { won: true }; // breach on j1
+        return {
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        };
+      }),
+    });
+    // Identity order: the breach row j1 is tried before the healthy j2.
+    const q = createFleetQueueClient({
+      pb,
+      claim,
+      logger,
+      rng: IDENTITY_ORDER_RNG,
+    });
+
+    const claimed = await q.claimNext("worker-7", 30);
+
+    // The throw did not abort the rotation; j2 still claimed.
+    expect(claimed.claimed).toBe(true);
+    expect(claimed.lease?.job.id).toBe("j2");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.claim-won-without-job-release-failed",
+      expect.objectContaining({ jobId: "j1", err: "release transport blip" }),
     );
   });
 

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -3643,6 +3643,45 @@ describe("fleet-claim.pb.js hook parity (client ↔ JSVM contract pins)", () => 
     expect(clamps.length).toBe(2);
   });
 
+  it("claim + renew clamp leaseSeconds on the LOW side too (floor 1s — no 1ms thrash leases)", () => {
+    // n > 0 admits 0.001 → a 1ms lease: instantly expired, every claim
+    // immediately stealable, renew thrash. Both lease-setting handlers must
+    // floor the clamped value at 1 second.
+    const floors =
+      hookSource.match(/Math\.max\(\s*1,\s*Math\.min\(\s*n,\s*3600\s*\)\s*\)/g) ??
+      [];
+    expect(floors.length).toBe(2);
+  });
+
+  it("the release handler REQUIRES an explicit status (no silent default to done)", () => {
+    // `data.status || "done"` silently finished a job whose caller omitted
+    // (or sent an empty) status — a protocol bug masked as success. Status
+    // must be validated like jobId/workerId: explicit 400 when absent.
+    expect(hookSource).not.toContain('data.status || "done"');
+    expect(hookSource).toMatch(/status is required/);
+  });
+
+  it("every handler rejects a non-string workerId (a JSON number would coerce into the text column)", () => {
+    // PB coerces a numeric workerId into the text claimed_by column, but the
+    // holder then renews/releases with the STRING form — `claimed_by !==
+    // workerId` never matches and the row is wedged until lease expiry.
+    const guards =
+      hookSource.match(/typeof workerId !== "string"/g) ?? [];
+    expect(guards.length).toBe(3);
+  });
+
+  it("the claim handler returns an alreadyHeld marker for a same-holder live-lease re-claim (timeout-after-commit idempotency)", () => {
+    // A claim that COMMITTED whose response was lost is retried by the same
+    // worker; without idempotency the retry sees claimed:false (its own
+    // live claim is not reclaimable) and abandons a row it actually holds.
+    // The hook must answer claimed:true + alreadyHeld:true for a re-claim
+    // by the CURRENT holder while the lease is live.
+    expect(hookSource).toContain("alreadyHeld");
+    expect(hookSource).toMatch(
+      /rec\.get\("claimed_by"\) === workerId\s*&&\s*\n?\s*!leaseExpired\(rec\)/,
+    );
+  });
+
   it("the release handler reports a refusal reason (terminal-same-holder vs not-holder vs live-lease)", () => {
     // report()'s retryability depends on distinguishing "the row is terminal
     // under MY workerId" (my own earlier release committed → the result is

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -1133,6 +1133,54 @@ describe("FleetQueueClient.claimNext", () => {
     );
   });
 
+  it("the decode-failure synthetic result write is SINGLE-attempt — no retry pacing inside the claim race (G1g)", async () => {
+    // The synthetic write is best-effort with a documented backstop (the
+    // consumer's crash synthesis), so the bounded-retry + 250ms pacing of
+    // report()'s writeResult is pure latency injected into claimNext's
+    // candidate race — up to 500ms of sleeps per poison row while the whole
+    // claim poll waits. One attempt + the lost warn is the contract.
+    const { pb } = makeFakePb([
+      {
+        ...jobView({ id: "j1" }),
+        payload: null as unknown as ServiceJobPayload,
+      },
+    ]);
+    const updateSpy = vi.fn(async () => {
+      throw new Error("pb write blip");
+    });
+    pb.update = updateSpy as PbClient["update"];
+    const sleeps: number[] = [];
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({ released: true }),
+      ),
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({
+      pb,
+      claim,
+      logger,
+      sleep: async (ms: number) => {
+        sleeps.push(ms);
+      },
+    });
+
+    const claimed = await q.claimNext("worker-7", 30);
+
+    expect(claimed.claimed).toBe(false);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(sleeps).toEqual([]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.claim-decode-result-write-lost",
+      expect.objectContaining({ jobId: "j1", err: "pb write blip" }),
+    );
+  });
+
   it("uses the injected clock for the decode-failure synthetic result's timestamps", async () => {
     // The synthetic worker-protocol-violation result used `new Date()`
     // directly while the rest of the queue layer takes injected time —
@@ -2699,7 +2747,11 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       expect(sweep.commErrors).toHaveLength(1);
       expect(sweep.commErrors[0].kind).toBe("worker-reclaimed-pending");
       expect(sweep.commErrors[0].jobId).toBe("throw-commit");
-      expect(sweep.reclaimed).toBe(1);
+      // ...counted as an INDETERMINATE maybe, not a confirmed reclaim (G1g):
+      // `reclaimed` counts only CAS-confirmed releases; the conservative
+      // thrown-release maybes ride the separate at-least-once counter.
+      expect(sweep.reclaimed).toBe(0);
+      expect(sweep.reclaimedIndeterminate).toBe(1);
       // ...and the grace set protected the (committed-pending, stale) row
       // from the SAME sweep's stale phase — it survives to be re-claimed.
       expect(sweep.expiredPending).toBe(0);
@@ -3804,6 +3856,66 @@ describe("FleetQueueClient.report", () => {
     );
   });
 
+  it("a report() retry whose pre-write read resolves NULL refuses to blind-write (G1g)", async () => {
+    // pb.getOne resolves null for a missing/unreadable row — semantically a
+    // FAILED read, not "no result present". Falling through to writeResult
+    // on it is exactly the blind rewrite the guard exists to prevent (and
+    // would resurrect a row the consumer may have deleted). Throw loud;
+    // report() stays retryable.
+    const { pb, rows } = makeFakePb([
+      { ...jobView({ id: "j1" }), payload: samplePayload() },
+    ]);
+    pb.getOne = vi.fn(async () => null) as PbClient["getOne"];
+    const updateSpy = vi.fn(pb.update.bind(pb));
+    pb.update = updateSpy as PbClient["update"];
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({
+          released: false,
+          reason: "refused_terminal_same_holder",
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await expect(
+      q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() }),
+    ).rejects.toThrow(/cannot verify existing result/i);
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(rows[0].result).toBeUndefined();
+  });
+
+  it("a report() retry treats an EMPTY-STRING result as absent (PB unset-JSON shape) and completes the write (G1g)", async () => {
+    // PB returns "" (not undefined/null) for an unset JSON column on some
+    // read paths. The presence check treated "" as a written result and
+    // SKIPPED the write — silently dropping the retry's result (terminal
+    // resultless row → the consumer later synthesizes a false
+    // worker-crashed-mid-job). "" must take the no-result leg: fall through
+    // to writeResult (the original retryability contract).
+    const row: JobRow = {
+      ...jobView({ id: "j1", status: "done", claimed_by: "worker-7" }),
+      payload: samplePayload(),
+      result: "",
+      result_processed: false,
+    };
+    const { pb, rows } = makeFakePb([row]);
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({
+          released: false,
+          reason: "refused_terminal_same_holder",
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const result = sampleResult();
+    await q.report({ jobId: "j1", workerId: "worker-7", result });
+
+    expect(rows[0].result).toEqual(result);
+    expect(rows[0].result_processed).toBe(false);
+  });
+
   it("a report() retry that cannot READ the row refuses to blind-write (throws, retryable)", async () => {
     // If the pre-write read blips, falling through to writeResult would be
     // exactly the blind rewrite the guard exists to prevent. Fail the retry
@@ -3878,6 +3990,8 @@ describe("FleetQueueClient.sweepExpired", () => {
     const sweep = await q.sweepExpired(now);
 
     expect(sweep.reclaimed).toBe(1);
+    // A clean CAS-confirmed release carries no at-least-once maybes (G1g).
+    expect(sweep.reclaimedIndeterminate).toBe(0);
     expect(sweep.commErrors).toHaveLength(1);
     // flap-band #70: the sweep boundary cannot tell a real crash from an
     // expected platform teardown (both leave an identical expired lease), and
@@ -4008,8 +4122,11 @@ describe("FleetQueueClient.sweepExpired", () => {
     // and j2's throw is handled CONSERVATIVELY (timeout-after-commit): the
     // release may have committed server-side, so its comm error is
     // synthesized anyway (at-least-once — a duplicate gray overlay is
-    // harmless, a missing one is lost forever).
-    expect(sweep.reclaimed).toBe(3);
+    // harmless, a missing one is lost forever). The split count (G1g) keeps
+    // `reclaimed` exact (confirmed CAS releases only) while the maybe rides
+    // `reclaimedIndeterminate`.
+    expect(sweep.reclaimed).toBe(2);
+    expect(sweep.reclaimedIndeterminate).toBe(1);
     expect(sweep.commErrors.map((e) => e.jobId)).toEqual(["j1", "j2", "j3"]);
     expect(logger.warn).toHaveBeenCalledWith(
       "queue-client.sweep-release-threw",
@@ -4051,6 +4168,7 @@ describe("FleetQueueClient.sweepExpired", () => {
     const sweep = await q.sweepExpired(now);
 
     expect(sweep.reclaimed).toBe(0);
+    expect(sweep.reclaimedIndeterminate).toBe(0);
     expect(sweep.commErrors).toHaveLength(0);
     expect(logger.error).toHaveBeenCalledWith(
       "queue-client.sweep-release-rejected",
@@ -4085,8 +4203,10 @@ describe("FleetQueueClient.sweepExpired", () => {
     const sweep = await q.sweepExpired(now);
 
     // 5xx is indeterminate — the release may have committed server-side, so
-    // the comm error is synthesized anyway (at-least-once).
-    expect(sweep.reclaimed).toBe(1);
+    // the comm error is synthesized anyway (at-least-once), counted on the
+    // indeterminate counter rather than the confirmed one (G1g).
+    expect(sweep.reclaimed).toBe(0);
+    expect(sweep.reclaimedIndeterminate).toBe(1);
     expect(sweep.commErrors).toHaveLength(1);
     expect(sweep.commErrors[0].kind).toBe("worker-reclaimed-pending");
     expect(logger.warn).toHaveBeenCalledWith(
@@ -4313,6 +4433,15 @@ describe("fleet-claim.pb.js hook parity (client ↔ JSVM contract pins)", () => 
     // workerId` never matches and the row is wedged until lease expiry.
     const guards =
       hookSource.match(/typeof workerId !== "string"/g) ?? [];
+    expect(guards.length).toBe(3);
+  });
+
+  it("every handler rejects a non-string jobId (consistency with the workerId guard) — G1g", () => {
+    // `!jobId` admits a truthy non-string (a JSON number/object); the
+    // workerId guard rejects exactly that class for the text column, and
+    // jobId feeds findRecordById the same way — a numeric jobId must 400 at
+    // the boundary, not depend on the dao's coercion behavior.
+    const guards = hookSource.match(/typeof jobId !== "string"/g) ?? [];
     expect(guards.length).toBe(3);
   });
 

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -431,7 +431,11 @@ function sampleResult(
 
 describe("test-fake honesty (the fakes must throw, not vacuously match)", () => {
   it("rowMatchesFilter throws on operators it cannot honor", () => {
-    const row: FilterableRow = { id: "r1", status: "pending", probe_key: "d6:a" };
+    const row: FilterableRow = {
+      id: "r1",
+      status: "pending",
+      probe_key: "d6:a",
+    };
     // Comparison operators are not modeled at all.
     expect(() => rowMatchesFilter(row, 'created < "2026-01-01"')).toThrow(
       /unsupported field/,
@@ -467,7 +471,11 @@ describe("test-fake honesty (the fakes must throw, not vacuously match)", () => 
     // negatives. Multiple positive clauses for ONE field joined by `&&`
     // therefore evaluate WRONG (the model would OR what the filter ANDs) —
     // a test exercising that shape must fail loudly, not pass vacuously.
-    const row: FilterableRow = { id: "r1", status: "pending", probe_key: "d6:a" };
+    const row: FilterableRow = {
+      id: "r1",
+      status: "pending",
+      probe_key: "d6:a",
+    };
     expect(() =>
       rowMatchesFilter(row, 'probe_key ~ "d6:%" && probe_key ~ "d4:%"'),
     ).toThrow(/positive probe_key clauses ANDed/);
@@ -564,9 +572,7 @@ describe("FleetQueueClient.enqueue", () => {
 
     const poisoned = samplePayload();
     poisoned.meta = { ...poisoned.meta, priority: "high" as unknown as number };
-    await expect(q.enqueue({ payload: poisoned })).rejects.toThrow(
-      /priority/i,
-    );
+    await expect(q.enqueue({ payload: poisoned })).rejects.toThrow(/priority/i);
     expect(rows).toHaveLength(0);
 
     // A NUMBER priority (and an absent one) still passes.
@@ -592,9 +598,7 @@ describe("FleetQueueClient.enqueue", () => {
       ...samplePayload(),
       meta: "not-an-object",
     } as unknown as ServiceJobPayload;
-    await expect(q.enqueue({ payload: badPayload })).rejects.toThrow(
-      /meta/i,
-    );
+    await expect(q.enqueue({ payload: badPayload })).rejects.toThrow(/meta/i);
     expect(createSpy).not.toHaveBeenCalled();
     expect(rows).toHaveLength(0);
   });
@@ -870,7 +874,10 @@ describe("FleetQueueClient.claimNext", () => {
     // an older writer (or hand-edited) with an empty probeKey/serviceSlug/
     // driverKind/runId is released as failed and skipped, never handed to
     // the worker (where the empty sentinels corrupt aggregation).
-    const bad = (id: string, overrides: Partial<ServiceJobPayload>): JobRow => ({
+    const bad = (
+      id: string,
+      overrides: Partial<ServiceJobPayload>,
+    ): JobRow => ({
       ...jobView({ id }),
       payload: samplePayload(overrides),
     });
@@ -2622,7 +2629,10 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       expect(store.find((r) => r.id === "old-boom")?.status).toBe("pending");
       expect(logger.warn).toHaveBeenCalledWith(
         "queue-client.sweep-stale-claim-threw",
-        expect.objectContaining({ jobId: "old-boom", err: "cas 400 bad request" }),
+        expect.objectContaining({
+          jobId: "old-boom",
+          err: "cas 400 bad request",
+        }),
       );
       // Contained per row — the phase wrapper never saw it.
       expect(logger.error).not.toHaveBeenCalledWith(
@@ -2681,9 +2691,9 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
 
       // All 10 expirable d4 rows reclaimed in ONE sweep…
       expect(sweep.expiredPending).toBe(10);
-      expect(
-        store.filter((r) => r.probe_key.startsWith("d4:")),
-      ).toHaveLength(0);
+      expect(store.filter((r) => r.probe_key.startsWith("d4:"))).toHaveLength(
+        0,
+      );
       // …and the not-yet-expirable slow family is untouched.
       expect(store).toHaveLength(50);
     });
@@ -2858,9 +2868,7 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       expect(first.reclaimed).toBe(1);
       expect(first.commErrors[0]?.jobId).toBe("long-runner");
       expect(first.expiredPending).toBe(0);
-      expect(store.find((r) => r.id === "long-runner")?.status).toBe(
-        "pending",
-      );
+      expect(store.find((r) => r.id === "long-runner")?.status).toBe("pending");
 
       // Sweep 2: the grace set is per-call, so only the recent-lease
       // heuristic stands between the re-queued row and a claim-delete. The
@@ -2869,9 +2877,7 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       // re-claimed and actually re-run.
       const second = await q.sweepExpired(T);
       expect(second.expiredPending).toBe(0);
-      expect(store.find((r) => r.id === "long-runner")?.status).toBe(
-        "pending",
-      );
+      expect(store.find((r) => r.id === "long-runner")?.status).toBe("pending");
 
       // CONTROL: once the retained lease itself is OLDER than the family
       // window (no re-claim for a whole window — genuinely abandoned), the
@@ -3040,9 +3046,7 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       expect(sweep.reclaimed).toBe(1);
       expect(sweep.expiredPending).toBe(1);
       // The recently-expired row took today's path: re-queued to pending.
-      expect(store.find((r) => r.id === "recent-dead")?.status).toBe(
-        "pending",
-      );
+      expect(store.find((r) => r.id === "recent-dead")?.status).toBe("pending");
     });
 
     it("a release that THROWS after committing server-side still graces the row AND synthesizes its comm error (timeout-after-commit)", async () => {
@@ -3262,7 +3266,10 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       // warn fired here every sweep — pure noise with nothing truncated that
       // could matter.
       const rows = Array.from({ length: 50 }, (_, i) =>
-        runningRow(`live-${String(i).padStart(2, "0")}`, "2026-06-04T00:06:00.000Z"),
+        runningRow(
+          `live-${String(i).padStart(2, "0")}`,
+          "2026-06-04T00:06:00.000Z",
+        ),
       );
       const { pb, store } = makePagingPb(rows);
       const q = createFleetQueueClient({
@@ -3285,7 +3292,10 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       // means rows beyond the page (if any) could be expired too, so the
       // truncation is the one that matters and must be observable.
       const rows = Array.from({ length: 50 }, (_, i) =>
-        runningRow(`dead-${String(i).padStart(2, "0")}`, "2026-06-04T00:01:00.000Z"),
+        runningRow(
+          `dead-${String(i).padStart(2, "0")}`,
+          "2026-06-04T00:01:00.000Z",
+        ),
       );
       const { pb, store } = makePagingPb(rows);
       const q = createFleetQueueClient({
@@ -3501,7 +3511,11 @@ describe("FleetQueueClient.renewLease", () => {
     const q = createFleetQueueClient({ pb, claim, logger });
 
     await q.claimNext("worker-7", 30);
-    await q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() });
+    await q.report({
+      jobId: "j1",
+      workerId: "worker-7",
+      result: sampleResult(),
+    });
     // The cache entry died with the report; a renew (e.g. a late heartbeat
     // racing the report) must re-read rather than serve the stale entry.
     const lease = await q.renewLease("j1", "worker-7", 30);
@@ -3662,7 +3676,8 @@ describe("FleetQueueClient.renewLease", () => {
         }),
       ),
       renewLease: vi.fn(async (): Promise<RenewResult> => {
-        if (renewThrows) throw new Error("2xx body unreadable — outcome indeterminate");
+        if (renewThrows)
+          throw new Error("2xx body unreadable — outcome indeterminate");
         return {
           renewed: true,
           job: jobView({
@@ -3758,7 +3773,11 @@ describe("FleetQueueClient.renewLease", () => {
     expect(lost).toBeNull();
     expect(logger.error).toHaveBeenCalledWith(
       "queue-client.renew-rejected",
-      expect.objectContaining({ jobId: "j1", workerId: "worker-7", status: 400 }),
+      expect.objectContaining({
+        jobId: "j1",
+        workerId: "worker-7",
+        status: 400,
+      }),
     );
     // The assumed-live warn must NOT fire for a deterministic rejection.
     expect(logger.warn).not.toHaveBeenCalledWith(
@@ -3836,7 +3855,11 @@ describe("FleetQueueClient.renewLease", () => {
         }),
       ),
       renewLease: vi.fn(async (): Promise<RenewResult> => {
-        throw new JobClaimEndpointError("/api/fleet/renew", 429, "rate limited");
+        throw new JobClaimEndpointError(
+          "/api/fleet/renew",
+          429,
+          "rate limited",
+        );
       }),
     });
     const q = createFleetQueueClient({ pb, claim, logger });
@@ -4228,7 +4251,12 @@ describe("FleetQueueClient.report", () => {
     const claim = makeFakeClaim({ releaseJob });
     // No-op sleep: this test pins the retry COUNT, not the pacing (pinned
     // separately below) — keep it instant.
-    const q = createFleetQueueClient({ pb, claim, logger, sleep: async () => {} });
+    const q = createFleetQueueClient({
+      pb,
+      claim,
+      logger,
+      sleep: async () => {},
+    });
 
     await expect(
       q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() }),
@@ -4293,7 +4321,12 @@ describe("FleetQueueClient.report", () => {
         async (): Promise<ReleaseResult> => ({ released: true }),
       ),
     });
-    const q = createFleetQueueClient({ pb, claim, logger, sleep: async () => {} });
+    const q = createFleetQueueClient({
+      pb,
+      claim,
+      logger,
+      sleep: async () => {},
+    });
 
     const result = sampleResult();
     await q.report({ jobId: "j1", workerId: "worker-7", result });
@@ -4383,7 +4416,12 @@ describe("FleetQueueClient.report", () => {
         async (): Promise<ReleaseResult> => ({ released: true }),
       ),
     });
-    const q = createFleetQueueClient({ pb, claim, logger, sleep: async () => {} });
+    const q = createFleetQueueClient({
+      pb,
+      claim,
+      logger,
+      sleep: async () => {},
+    });
 
     await expect(
       q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() }),
@@ -4498,7 +4536,11 @@ describe("FleetQueueClient.report", () => {
     });
     const q = createFleetQueueClient({ pb, claim, logger });
 
-    await q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() });
+    await q.report({
+      jobId: "j1",
+      workerId: "worker-7",
+      result: sampleResult(),
+    });
 
     expect(updateSpy).not.toHaveBeenCalled();
     expect(rows[0].result).toEqual(aggregated);
@@ -4535,7 +4577,11 @@ describe("FleetQueueClient.report", () => {
     });
     const q = createFleetQueueClient({ pb, claim, logger });
 
-    await q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() });
+    await q.report({
+      jobId: "j1",
+      workerId: "worker-7",
+      result: sampleResult(),
+    });
 
     expect(updateSpy).not.toHaveBeenCalled();
     expect(rows[0].result).toEqual(written);
@@ -4841,12 +4887,10 @@ describe("FleetQueueClient.sweepExpired", () => {
       mkExpired("j2", "w2"),
       mkExpired("j3", "w3"),
     ]);
-    const releaseJob = vi.fn(
-      async (jobId: string): Promise<ReleaseResult> => {
-        if (jobId === "j2") throw new Error("pb 502 mid-release");
-        return { released: true };
-      },
-    );
+    const releaseJob = vi.fn(async (jobId: string): Promise<ReleaseResult> => {
+      if (jobId === "j2") throw new Error("pb 502 mid-release");
+      return { released: true };
+    });
     const claim = makeFakeClaim({ releaseJob });
     const q = createFleetQueueClient({ pb, claim, logger });
 
@@ -4929,7 +4973,11 @@ describe("FleetQueueClient.sweepExpired", () => {
     const { pb } = makeFakePb([expired]);
     const claim = makeFakeClaim({
       releaseJob: vi.fn(async (): Promise<ReleaseResult> => {
-        throw new JobClaimEndpointError("/api/fleet/release", 502, "bad gateway");
+        throw new JobClaimEndpointError(
+          "/api/fleet/release",
+          502,
+          "bad gateway",
+        );
       }),
     });
     const q = createFleetQueueClient({ pb, claim, logger });
@@ -5235,8 +5283,9 @@ describe("fleet-claim.pb.js hook parity (client ↔ JSVM contract pins)", () => 
     // immediately stealable, renew thrash. Both lease-setting handlers must
     // floor the clamped value at 1 second.
     const floors =
-      hookSource.match(/Math\.max\(\s*1,\s*Math\.min\(\s*n,\s*3600\s*\)\s*\)/g) ??
-      [];
+      hookSource.match(
+        /Math\.max\(\s*1,\s*Math\.min\(\s*n,\s*3600\s*\)\s*\)/g,
+      ) ?? [];
     expect(floors.length).toBe(2);
   });
 
@@ -5252,8 +5301,7 @@ describe("fleet-claim.pb.js hook parity (client ↔ JSVM contract pins)", () => 
     // PB coerces a numeric workerId into the text claimed_by column, but the
     // holder then renews/releases with the STRING form — `claimed_by !==
     // workerId` never matches and the row is wedged until lease expiry.
-    const guards =
-      hookSource.match(/typeof workerId !== "string"/g) ?? [];
+    const guards = hookSource.match(/typeof workerId !== "string"/g) ?? [];
     expect(guards.length).toBe(3);
   });
 

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -1733,6 +1733,96 @@ describe("FleetQueueClient.renewLease", () => {
     expect(lease?.payload).toEqual(payload);
   });
 
+  it("EVICTS the cached payload when the renew CAS is lost (no payloadCache leak)", async () => {
+    // A lost renew CAS means this worker never touches the job again — no
+    // report() (whose finally is the only other eviction), no further renew.
+    // Without eviction here the claim-time cache entry strands FOREVER and
+    // the per-client map grows with every abandoned/stolen job. Proof of
+    // eviction: a LATER successful renew for the same jobId must take the
+    // convenience RE-READ path (cache miss → pb.getOne), not the cache.
+    const payload = samplePayload();
+    const { pb } = makeFakePb([{ ...jobView({ id: "j1" }), payload }]);
+    const getOneSpy = vi.fn(pb.getOne.bind(pb));
+    pb.getOne = getOneSpy as PbClient["getOne"];
+    let renewWins = false;
+    const claim = makeFakeClaim({
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        }),
+      ),
+      renewLease: vi.fn(
+        async (): Promise<RenewResult> =>
+          renewWins
+            ? {
+                renewed: true,
+                job: jobView({
+                  id: "j1",
+                  status: "running",
+                  claimed_by: "worker-7",
+                  lease_expires_at: "2026-06-04T00:02:00.000Z",
+                  version: 2,
+                }),
+              }
+            : { renewed: false },
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    // Claim populates the cache…
+    await q.claimNext("worker-7", 30);
+    expect(getOneSpy).not.toHaveBeenCalled();
+    // …the renew LOSES the CAS → null AND the cache entry is evicted…
+    expect(await q.renewLease("j1", "worker-7", 30)).toBeNull();
+    // …so a later successful renew re-hydrates via the re-read, proving the
+    // entry is gone (a leaked entry would skip getOne entirely).
+    renewWins = true;
+    const lease = await q.renewLease("j1", "worker-7", 30);
+    expect(lease).not.toBeNull();
+    expect(lease?.payload).toEqual(payload);
+    expect(getOneSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("claim → report → renew takes the re-read path (report's eviction actually evicts)", async () => {
+    const payload = samplePayload();
+    const { pb } = makeFakePb([{ ...jobView({ id: "j1" }), payload }]);
+    const getOneSpy = vi.fn(pb.getOne.bind(pb));
+    pb.getOne = getOneSpy as PbClient["getOne"];
+    const claim = makeFakeClaim({
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        }),
+      ),
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({ released: true }),
+      ),
+      renewLease: vi.fn(
+        async (): Promise<RenewResult> => ({
+          renewed: true,
+          job: jobView({
+            id: "j1",
+            status: "running",
+            claimed_by: "worker-7",
+            lease_expires_at: "2026-06-04T00:02:00.000Z",
+            version: 2,
+          }),
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await q.claimNext("worker-7", 30);
+    await q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() });
+    // The cache entry died with the report; a renew (e.g. a late heartbeat
+    // racing the report) must re-read rather than serve the stale entry.
+    const lease = await q.renewLease("j1", "worker-7", 30);
+    expect(lease).not.toBeNull();
+    expect(getOneSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("returns a lease on a SUCCESSFUL CAS even when cache miss AND reread fail", async () => {
     // The CAS renewed (won), but there is NO prior same-process claim (cache
     // empty) AND the convenience re-read THROWS (PB blip). A successful CAS

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -2869,6 +2869,111 @@ describe("FleetQueueClient.report", () => {
       expect.objectContaining({ jobId: "j1", workerId: "worker-7" }),
     );
   });
+
+  it("a report() retry must NOT rewrite a result the consumer already AGGREGATED (no un-latch double-count)", async () => {
+    // DOUBLE-COUNT GUARD (G1c): writeResult always writes
+    // `result_processed: false`. On the refused_terminal_same_holder retry
+    // path, the first attempt's result may ALREADY be on the row and already
+    // aggregated (result_processed latched true by the consumer) — a blind
+    // rewrite UN-LATCHES it and the consumer aggregates the same result a
+    // second time. The retry must READ the row first and skip the write
+    // entirely when a processed result is present.
+    const aggregated = sampleResult();
+    const row: JobRow = {
+      ...jobView({ id: "j1", status: "done", claimed_by: "worker-7" }),
+      payload: samplePayload(),
+      result: aggregated,
+      result_processed: true,
+    };
+    const { pb, rows } = makeFakePb([row]);
+    const updateSpy = vi.fn(pb.update.bind(pb));
+    pb.update = updateSpy as PbClient["update"];
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({
+          released: false,
+          reason: "refused_terminal_same_holder",
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() });
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(rows[0].result).toEqual(aggregated);
+    expect(rows[0].result_processed).toBe(true);
+    expect(logger.info).toHaveBeenCalledWith(
+      "queue-client.result-already-aggregated",
+      expect.objectContaining({ jobId: "j1", workerId: "worker-7" }),
+    );
+  });
+
+  it("a report() retry skips the rewrite when a result is present but UNPROCESSED (idempotent)", async () => {
+    // The first attempt's writeResult landed but its response (or the
+    // release response before it) was lost. The result is already sitting
+    // on the row awaiting aggregation — rewriting it is at best a no-op and
+    // at worst races the consumer's latch (read result → aggregate → latch)
+    // mid-flight. Skip it.
+    const written = sampleResult();
+    const row: JobRow = {
+      ...jobView({ id: "j1", status: "done", claimed_by: "worker-7" }),
+      payload: samplePayload(),
+      result: written,
+      result_processed: false,
+    };
+    const { pb, rows } = makeFakePb([row]);
+    const updateSpy = vi.fn(pb.update.bind(pb));
+    pb.update = updateSpy as PbClient["update"];
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({
+          released: false,
+          reason: "refused_terminal_same_holder",
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() });
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(rows[0].result).toEqual(written);
+    expect(rows[0].result_processed).toBe(false);
+    expect(logger.info).toHaveBeenCalledWith(
+      "queue-client.result-already-written",
+      expect.objectContaining({ jobId: "j1", workerId: "worker-7" }),
+    );
+  });
+
+  it("a report() retry that cannot READ the row refuses to blind-write (throws, retryable)", async () => {
+    // If the pre-write read blips, falling through to writeResult would be
+    // exactly the blind rewrite the guard exists to prevent. Fail the retry
+    // loud instead — report() stays retryable and the NEXT retry re-reads.
+    const { pb, rows } = makeFakePb([
+      { ...jobView({ id: "j1" }), payload: samplePayload() },
+    ]);
+    pb.getOne = vi.fn(async () => {
+      throw new Error("pb read 502");
+    }) as PbClient["getOne"];
+    const updateSpy = vi.fn(pb.update.bind(pb));
+    pb.update = updateSpy as PbClient["update"];
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({
+          released: false,
+          reason: "refused_terminal_same_holder",
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await expect(
+      q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() }),
+    ).rejects.toThrow(/cannot verify existing result/i);
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(rows[0].result).toBeUndefined();
+  });
 });
 
 describe("FleetQueueClient.sweepExpired", () => {

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -1008,6 +1008,72 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       debugSpy.mockRestore();
     });
 
+    it("drains MULTIPLE pages of stale pending rows in ONE sweep (a backlog must not take hours to expire)", async () => {
+      // 120 stale rows span 3 candidate pages (perPage 50). A single-page
+      // sweep would expire only 50 — against the motivating 3,734-row staging
+      // backlog at ~10 sweeps/hour that is ~7.5h of drain. The sweep must
+      // loop pages (deletes shift pagination, so re-listing page 1 yields the
+      // next batch) until the backlog is gone or the per-sweep cap is hit.
+      const rows = Array.from({ length: 120 }, (_, i) =>
+        pendingRow(`stale-${i}`, "d6:a", T - 4 * HOUR - i * 1000),
+      );
+      const { pb, store } = makePagingPb(rows);
+      const q = createFleetQueueClient({
+        pb,
+        claim: makeStoreClaim(store),
+        logger,
+      });
+
+      const sweep = await q.sweepExpired(T);
+
+      expect(sweep.expiredPending).toBe(120);
+      expect(store).toHaveLength(0);
+    });
+
+    it("caps a single sweep at 10 pages (500 rows) so one sweep cannot monopolize the producer tick", async () => {
+      const rows = Array.from({ length: 520 }, (_, i) =>
+        pendingRow(`stale-${i}`, "d6:a", T - 4 * HOUR - i * 1000),
+      );
+      const { pb, store } = makePagingPb(rows);
+      const q = createFleetQueueClient({
+        pb,
+        claim: makeStoreClaim(store),
+        logger,
+      });
+
+      const sweep = await q.sweepExpired(T);
+
+      expect(sweep.expiredPending).toBe(500);
+      expect(store).toHaveLength(20);
+      // The overflow drains on the NEXT sweep — capped, not stranded.
+      const next = await q.sweepExpired(T);
+      expect(next.expiredPending).toBe(20);
+      expect(store).toHaveLength(0);
+    });
+
+    it("terminates a sweep pass that makes no progress (a page of non-expirable rows must not loop)", async () => {
+      // A full page of stale rows that all LOSE the CAS race (workers won
+      // them): re-listing pending would return rows the sweeper cannot act
+      // on... except a lost claim flips the row to "claimed" so it drops out
+      // of the pending filter. The truly re-listable no-progress case is
+      // unparseable `created` rows — pin that a page of them terminates.
+      const rows = Array.from({ length: 50 }, (_, i) => ({
+        ...pendingRow(`odd-${i}`, "d6:a", T),
+        created: "not-a-date",
+      }));
+      const { pb, store } = makePagingPb(rows);
+      const q = createFleetQueueClient({
+        pb,
+        claim: makeStoreClaim(store),
+        logger,
+      });
+
+      const sweep = await q.sweepExpired(T);
+
+      expect(sweep.expiredPending).toBe(0);
+      expect(store).toHaveLength(50);
+    });
+
     it("conservatively skips a pending row whose created timestamp is unparseable (delete is destructive)", async () => {
       const garbage = {
         ...pendingRow("odd", "d6:a", T),

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -618,6 +618,11 @@ describe("FleetQueueClient.enqueue", () => {
       { serviceSlug: "" },
       { driverKind: "" },
       { meta: { ...samplePayload().meta, runId: "" } },
+      // enqueuedAt: "" is `emptyPayloadForLease`'s never-aggregate sentinel
+      // — minted ONLY for heartbeat-only renew fallbacks, never decoded
+      // through this boundary. A caller-supplied empty enqueuedAt is the
+      // same forbidden class as the other empties: reject it.
+      { meta: { ...samplePayload().meta, enqueuedAt: "" } },
     ];
     for (const overrides of empties) {
       await expect(
@@ -1999,6 +2004,50 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
         maxFamilies: 16,
         // The 17th-oldest family is the first one the bound hid.
         nextProbeKey: "f16:svc",
+        // ...and it is a genuinely claimable (clause-safe) family.
+        nextFamilyClauseSafe: true,
+      }),
+    );
+  });
+
+  it("the truncation warn does not overclaim a hidden family when the head at the bound is clause-unsafe garbage", async () => {
+    // The head row AT the truncation index can itself be clause-unsafe
+    // garbage (an empty/backslash family) — discovery would never have
+    // CLAIMED it, only excluded it by row id. A warn that flatly announces
+    // a hidden family for it overclaims; thread the head's clause-safety so
+    // the operator can tell a starved REAL family from unclaimable junk.
+    const t0 = Date.parse("2026-06-04T00:00:00.000Z");
+    const rows = Array.from({ length: 16 }, (_, i) => {
+      const probeKey = `f${String(i).padStart(2, "0")}:svc`;
+      return {
+        ...jobView({ id: `r${i}`, probe_key: probeKey }),
+        payload: samplePayload({ probeKey }),
+        created: new Date(t0 + i * 1000).toISOString(),
+      };
+    });
+    // The 17th (youngest) pending row carries an empty probe_key — the
+    // clause-unsafe empty family.
+    rows.push({
+      ...jobView({ id: "garbage", probe_key: "" }),
+      payload: samplePayload(),
+      created: new Date(t0 + 17_000).toISOString(),
+    });
+    const { pb, store } = makePagingPb(rows);
+    const q = createFleetQueueClient({
+      pb,
+      claim: makeStoreClaim(store),
+      logger,
+    });
+
+    const claimed = await q.claimNext("w1", 30);
+
+    expect(claimed.claimed).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.family-discovery-truncated",
+      expect.objectContaining({
+        maxFamilies: 16,
+        nextProbeKey: "",
+        nextFamilyClauseSafe: false,
       }),
     );
   });
@@ -2793,7 +2842,7 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
         "pending",
       );
 
-      // CONTROl: once the retained lease itself is OLDER than the family
+      // CONTROL: once the retained lease itself is OLDER than the family
       // window (no re-claim for a whole window — genuinely abandoned), the
       // stale phase expires the row normally.
       const muchLater = T + 4 * HOUR;
@@ -3734,6 +3783,48 @@ describe("FleetQueueClient.renewLease", () => {
     );
   });
 
+  it("a thrown renew carrying 408/429 KEEPS the assumed-live containment — transient by meaning, not deterministic", async () => {
+    // 408 (timeout) and 429 (rate limit) are 4xx by status but TRANSIENT by
+    // meaning: a retry can succeed, so evicting the lease (heartbeat stops,
+    // sweeper reclaims a possibly-LIVE job) on a momentary rate-limit blip
+    // would manufacture the exact false worker-crashed class the
+    // assumed-live containment exists to prevent.
+    const payload = samplePayload();
+    const { pb } = makeFakePb([{ ...jobView({ id: "j1" }), payload }]);
+    const claim = makeFakeClaim({
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({
+            id: jobId,
+            status: "claimed",
+            claimed_by: workerId,
+            lease_expires_at: "2026-06-04T00:01:00.000Z",
+            version: 1,
+          }),
+        }),
+      ),
+      renewLease: vi.fn(async (): Promise<RenewResult> => {
+        throw new JobClaimEndpointError("/api/fleet/renew", 429, "rate limited");
+      }),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await q.claimNext("worker-7", 30);
+
+    const kept = await q.renewLease("j1", "worker-7", 30);
+    expect(kept).not.toBeNull();
+    expect(kept?.leaseExpiresAt).toBe("2026-06-04T00:01:00.000Z");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.renew-indeterminate",
+      expect.objectContaining({ jobId: "j1" }),
+    );
+    expect(logger.error).not.toHaveBeenCalledWith(
+      "queue-client.renew-rejected",
+      expect.anything(),
+    );
+  });
+
   it("renew under PERSISTENT auth-400 (rotated creds) stops the heartbeat — end-to-end through the REAL job-claim client", async () => {
     // Integration pin for the rotated-credentials path: the session token is
     // invalidated, the renew 401s, postFleet re-auths, and the re-auth 400s.
@@ -4640,6 +4731,45 @@ describe("FleetQueueClient.sweepExpired", () => {
     expect(logger.warn).toHaveBeenCalledWith(
       "queue-client.sweep-release-threw",
       expect.objectContaining({ jobId: "j1" }),
+    );
+  });
+
+  it("a thrown release carrying 408/429 KEEPS the conservative may-have-committed handling — transient, not deterministic", async () => {
+    // 408/429 are 4xx by status but transient by meaning — the SAME request
+    // can succeed on retry, so the request was not deterministically
+    // rejected and the at-least-once contract must hold (a missing gray
+    // overlay is lost forever; a duplicate is harmless).
+    const now = Date.parse("2026-06-04T00:05:00.000Z");
+    const expired: JobRow = {
+      ...jobView({
+        id: "j1",
+        status: "running",
+        claimed_by: "worker-dead",
+        lease_expires_at: "2026-06-04T00:04:00.000Z",
+      }),
+      payload: samplePayload(),
+    };
+    const { pb } = makeFakePb([expired]);
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(async (): Promise<ReleaseResult> => {
+        throw new JobClaimEndpointError("/api/fleet/release", 408, "timeout");
+      }),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const sweep = await q.sweepExpired(now);
+
+    expect(sweep.reclaimed).toBe(0);
+    expect(sweep.reclaimedIndeterminate).toBe(1);
+    expect(sweep.commErrors).toHaveLength(1);
+    expect(sweep.commErrors[0].kind).toBe("worker-reclaimed-pending");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.sweep-release-threw",
+      expect.objectContaining({ jobId: "j1" }),
+    );
+    expect(logger.error).not.toHaveBeenCalledWith(
+      "queue-client.sweep-release-rejected",
+      expect.anything(),
     );
   });
 

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -6,6 +6,7 @@ import {
   leaseExpired,
   PB_DATE_SEP_RE,
   RESULT_WRITE_MAX_ATTEMPTS,
+  RESULT_WRITE_RETRY_DELAY_MS,
 } from "./queue-client.js";
 import { JobClaimEndpointError } from "./job-claim.js";
 import type {
@@ -705,6 +706,125 @@ describe("FleetQueueClient.claimNext", () => {
         jobId: "j1",
         err: "release transport blip",
       }),
+    );
+  });
+
+  it("warns (with the hook's reason) when the decode-failure release is REFUSED", async () => {
+    // The decode-fail cleanup logged thrown releases but a REFUSED release
+    // (released:false) was silent — the poison row stays claimed with no
+    // breadcrumb tying the refusal to the decode failure. Warn with the
+    // hook's refusal reason.
+    const { pb } = makeFakePb([
+      {
+        ...jobView({ id: "j1" }),
+        payload: null as unknown as ServiceJobPayload,
+      },
+    ]);
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({
+          released: false,
+          reason: "refused_not_holder",
+        }),
+      ),
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const claimed = await q.claimNext("worker-7", 30);
+
+    expect(claimed.claimed).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.claim-decode-release-refused",
+      expect.objectContaining({ jobId: "j1", reason: "refused_not_holder" }),
+    );
+  });
+
+  it("recovers a non-empty serviceSlug for the synthetic result when the probe_key's slug segment is EMPTY", async () => {
+    // probeKeySlug("d6:") sliced to "" — the exact empty sentinel the
+    // synthetic worker-protocol-violation result is forbidden to carry
+    // (an empty serviceSlug corrupts the per-service rollup). An empty slug
+    // segment falls back to the WHOLE probe_key; a fully-empty probe_key
+    // falls back to a jobId-derived placeholder.
+    const { pb, rows } = makeFakePb([
+      {
+        ...jobView({ id: "j1", probe_key: "d6:" }),
+        payload: null as unknown as ServiceJobPayload,
+      },
+    ]);
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({ released: true }),
+      ),
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await q.claimNext("worker-7", 30);
+
+    const written = rows[0].result as ServiceJobResult;
+    expect(written.serviceSlug).toBe("d6:");
+    expect(written.serviceSlug).not.toBe("");
+  });
+
+  it("falls back to a jobId-derived serviceSlug when the probe_key itself is empty", async () => {
+    const { pb, rows } = makeFakePb([
+      {
+        ...jobView({ id: "j1", probe_key: "" }),
+        payload: null as unknown as ServiceJobPayload,
+      },
+    ]);
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({ released: true }),
+      ),
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({
+            id: jobId,
+            probe_key: "",
+            status: "claimed",
+            claimed_by: workerId,
+          }),
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await q.claimNext("worker-7", 30);
+
+    const written = rows[0].result as ServiceJobResult;
+    expect(written.serviceSlug).toBe("unknown-j1");
+  });
+
+  it("warns on the protocol violation `won && !job` before falling through (CAS contract breach must be visible)", async () => {
+    const { pb } = makeFakePb([
+      { ...jobView({ id: "j1" }), payload: samplePayload() },
+    ]);
+    const claim = makeFakeClaim({
+      // won:true with NO job violates the endpoint contract (a win always
+      // carries the row view).
+      claimJob: vi.fn(async (): Promise<ClaimResult> => ({ won: true })),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const claimed = await q.claimNext("worker-7", 30);
+
+    expect(claimed.claimed).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.claim-won-without-job",
+      expect.objectContaining({ jobId: "j1" }),
     );
   });
 
@@ -1502,6 +1622,35 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
     expect(c.lease?.job.id).toBe("ok-0");
   });
 
+  it("countPendingForFamily THROWS on a non-count totalItems instead of returning the poisoned value", async () => {
+    // skipTotal:false is requested, but a backend/client drift that still
+    // returns -1 (or garbage) must not reach the producer's backlog gate —
+    // -1 is never above the threshold, so the gate would silently fail
+    // open. Fail loud at the boundary.
+    const t0 = Date.parse("2026-06-04T00:00:00.000Z");
+    const { pb, store } = makePagingPb([
+      {
+        ...jobView({ id: "d4-0", probe_key: "d4:x" }),
+        payload: samplePayload({ probeKey: "d4:x" }),
+        created: new Date(t0).toISOString(),
+      },
+    ]);
+    const realList = pb.list.bind(pb);
+    pb.list = vi.fn(async (collection: string, opts?: ListOpts) => {
+      const page = await realList(collection, opts);
+      return { ...page, totalItems: -1 };
+    }) as PbClient["list"];
+    const q = createFleetQueueClient({
+      pb,
+      claim: makeStoreClaim(store),
+      logger,
+    });
+
+    await expect(q.countPendingForFamily("d4")).rejects.toThrow(
+      /non-count totalItems/i,
+    );
+  });
+
   it("countPendingForFamily explicitly requests totals (skipTotal: false) — the backlog gate must not fail open", async () => {
     // The gate reads totalItems off a perPage=1 list. If totals are skipped
     // (PB client default elsewhere in this file is skipTotal: true) PB
@@ -1747,19 +1896,22 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       debugSpy.mockRestore();
     });
 
-    it("a claimJob THROW mid stale-drain keeps the rows already expired in the partial result (REQ-B)", async () => {
+    it("a claimJob THROW on one row does NOT abort the drain — later rows still expire (per-row containment)", async () => {
       // The first (oldest) stale row claims-and-deletes cleanly; the second
-      // row's claim CAS THROWS (transport blip). The phase must contain the
-      // throw and still report the work it DID do — letting it escape would
-      // also discard the lease phase's commErrors at the producer.
+      // row's claim CAS THROWS (e.g. a deterministic 4xx, which job-claim
+      // throws loud). The drain used to let it escape to the PHASE wrapper —
+      // aborting the WHOLE drain for one sick row (every later stale row
+      // unprocessed this sweep). Contain it PER ROW: warn + continue; the
+      // third row must still expire in the SAME sweep.
       const ok = pendingRow("old-ok", "d6:a", T - 5 * HOUR);
       const boom = pendingRow("old-boom", "d6:b", T - 4 * HOUR);
-      const { pb, store } = makePagingPb([ok, boom]);
+      const after = pendingRow("old-after", "d6:c", T - 3.5 * HOUR);
+      const { pb, store } = makePagingPb([ok, boom, after]);
       const base = makeStoreClaim(store);
       const claim: JobClaimClient = {
         ...base,
         async claimJob(jobId, workerId, leaseSeconds) {
-          if (jobId === "old-boom") throw new Error("cas 502");
+          if (jobId === "old-boom") throw new Error("cas 400 bad request");
           return base.claimJob(jobId, workerId, leaseSeconds);
         },
       };
@@ -1767,12 +1919,19 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
 
       const sweep = await q.sweepExpired(T);
 
-      expect(sweep.expiredPending).toBe(1);
+      // BOTH healthy rows expired — the throw did not abort the drain.
+      expect(sweep.expiredPending).toBe(2);
       expect(store.find((r) => r.id === "old-ok")).toBeUndefined();
+      expect(store.find((r) => r.id === "old-after")).toBeUndefined();
       expect(store.find((r) => r.id === "old-boom")?.status).toBe("pending");
-      expect(logger.error).toHaveBeenCalledWith(
+      expect(logger.warn).toHaveBeenCalledWith(
+        "queue-client.sweep-stale-claim-threw",
+        expect.objectContaining({ jobId: "old-boom", err: "cas 400 bad request" }),
+      );
+      // Contained per row — the phase wrapper never saw it.
+      expect(logger.error).not.toHaveBeenCalledWith(
         "queue-client.sweep-stale-phase-threw",
-        expect.objectContaining({ err: "cas 502" }),
+        expect.anything(),
       );
     });
 
@@ -2527,6 +2686,23 @@ describe("FleetQueueClient.renewLease", () => {
     );
   });
 
+  it("warns on the protocol violation `renewed && !job` before treating it as a lost lease", async () => {
+    const { pb } = makeFakePb([{ ...jobView(), payload: samplePayload() }]);
+    const claim = makeFakeClaim({
+      // renewed:true with NO job violates the endpoint contract.
+      renewLease: vi.fn(async (): Promise<RenewResult> => ({ renewed: true })),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const lease = await q.renewLease("j1", "worker-7", 30);
+
+    expect(lease).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.renew-renewed-without-job",
+      expect.objectContaining({ jobId: "j1", workerId: "worker-7" }),
+    );
+  });
+
   it("a THROWN renew (5xx / unreadable-2xx) keeps the CURRENT lease assumed-live instead of killing the heartbeat", async () => {
     // INDETERMINACY CONTAINMENT (G1b): a renew that THROWS (transport blip,
     // 5xx, or job-claim's 2xx-unreadable indeterminate) may or may not have
@@ -2754,7 +2930,9 @@ describe("FleetQueueClient.report", () => {
       async (): Promise<ReleaseResult> => ({ released: true }),
     );
     const claim = makeFakeClaim({ releaseJob });
-    const q = createFleetQueueClient({ pb, claim, logger });
+    // No-op sleep: this test pins the retry COUNT, not the pacing (pinned
+    // separately below) — keep it instant.
+    const q = createFleetQueueClient({ pb, claim, logger, sleep: async () => {} });
 
     await expect(
       q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() }),
@@ -2764,6 +2942,39 @@ describe("FleetQueueClient.report", () => {
     // The write was retried up to EXACTLY the production bound — pinned via
     // the imported constant so the test can't drift from the implementation.
     expect(updateAttempts).toBe(RESULT_WRITE_MAX_ATTEMPTS);
+  });
+
+  it("pauses between result-write retries (no hot-loop hammering a blipping PB)", async () => {
+    // Back-to-back retries land inside the same transient blip window —
+    // a small delay between attempts gives the blip time to clear. Pinned
+    // via an injected sleep so the test is instant and exact: one pause
+    // between each consecutive attempt pair (never after the last).
+    const { pb } = makeFakePb([seededRow()]);
+    pb.update = vi.fn(async () => {
+      throw new Error("transient PB write blip");
+    }) as PbClient["update"];
+    const sleeps: number[] = [];
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({ released: true }),
+      ),
+    });
+    const q = createFleetQueueClient({
+      pb,
+      claim,
+      logger,
+      sleep: async (ms: number) => {
+        sleeps.push(ms);
+      },
+    });
+
+    await expect(
+      q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() }),
+    ).rejects.toThrow(/result lost/i);
+
+    expect(sleeps).toEqual(
+      Array(RESULT_WRITE_MAX_ATTEMPTS - 1).fill(RESULT_WRITE_RETRY_DELAY_MS),
+    );
   });
 
   it("succeeds when the result write fails once then recovers (bounded retry)", async () => {
@@ -2786,7 +2997,7 @@ describe("FleetQueueClient.report", () => {
         async (): Promise<ReleaseResult> => ({ released: true }),
       ),
     });
-    const q = createFleetQueueClient({ pb, claim, logger });
+    const q = createFleetQueueClient({ pb, claim, logger, sleep: async () => {} });
 
     const result = sampleResult();
     await q.report({ jobId: "j1", workerId: "worker-7", result });

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -1786,6 +1786,80 @@ describe("FleetQueueClient.sweepExpired", () => {
     );
   });
 
+  it("does NOT reclaim a job renewed between the list snapshot and the release CAS (TOCTOU close)", async () => {
+    const NOW = Date.parse("2026-06-04T00:05:00.000Z");
+    // CURRENT row state: the worker RENEWED moments ago — live lease.
+    const renewedRow: JobRow = {
+      ...jobView({
+        id: "j1",
+        status: "running",
+        claimed_by: "worker-live",
+        lease_expires_at: "2026-06-04T00:06:00.000Z",
+        version: 5,
+      }),
+      payload: samplePayload(),
+    };
+    const { pb, rows } = makeFakePb([renewedRow]);
+    // The sweeper's list SNAPSHOT is stale: it observed the pre-renew lease
+    // (expired) — the renew landed between the list and the release CAS.
+    const realList = pb.list.bind(pb);
+    pb.list = vi.fn(async (collection: string, opts?: ListOpts) => {
+      const page = await realList(collection, opts);
+      return {
+        ...page,
+        items: page.items.map((it) =>
+          (it as JobRow).id === "j1"
+            ? {
+                ...(it as JobRow),
+                lease_expires_at: "2026-06-04T00:04:00.000Z",
+                version: 4,
+              }
+            : it,
+        ),
+      };
+    }) as PbClient["list"];
+    // Hook-faithful releaseJob (fleet-claim.pb.js /api/fleet/release):
+    // authorizes on claimed_by AND — the TOCTOU close — refuses a
+    // pending-target release while the row's CURRENT lease is still live,
+    // re-checked at release time inside the transaction (NOT from the
+    // caller's snapshot). Expiry compared via the exported leaseExpired so
+    // this fake stays byte-equivalent with both sides of the contract.
+    const releaseJob = vi.fn(
+      async (
+        jobId: string,
+        workerId: string,
+        status: "done" | "failed" | "pending",
+      ): Promise<ReleaseResult> => {
+        const row = rows.find((r) => r.id === jobId);
+        if (!row || !["claimed", "running"].includes(row.status)) {
+          return { released: false };
+        }
+        if (row.claimed_by !== workerId) return { released: false };
+        if (status === "pending" && !leaseExpired(row.lease_expires_at, NOW)) {
+          return { released: false };
+        }
+        row.status = status;
+        row.claimed_by = "";
+        row.lease_expires_at = null;
+        return { released: true, job: { ...row } };
+      },
+    );
+    const claim = makeFakeClaim({ releaseJob });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const sweep = await q.sweepExpired(NOW);
+
+    // The release was ATTEMPTED (the stale snapshot looked expired)...
+    expect(releaseJob).toHaveBeenCalledWith("j1", "worker-live", "pending");
+    // ...but REFUSED server-side, so the live just-renewed job is untouched:
+    // no reclaim, no false worker-reclaimed-pending, no duplicate execution.
+    expect(sweep.reclaimed).toBe(0);
+    expect(sweep.commErrors).toHaveLength(0);
+    expect(rows[0].status).toBe("running");
+    expect(rows[0].claimed_by).toBe("worker-live");
+    expect(rows[0].lease_expires_at).toBe("2026-06-04T00:06:00.000Z");
+  });
+
   it("a releaseJob THROW on one row does not abort the sweep or lose other rows' comm errors (REQ-B)", async () => {
     const now = Date.parse("2026-06-04T00:05:00.000Z");
     // Three expired leases; the MIDDLE row's release THROWS (transport blip,
@@ -1995,5 +2069,18 @@ describe("fleet-claim.pb.js hook parity (client ↔ JSVM contract pins)", () => 
   it("every handler compares lease expiry with the client's operator (t <= now)", () => {
     const occurrences = hookSource.split("t <= Date.now()").length - 1;
     expect(occurrences).toBeGreaterThanOrEqual(3);
+  });
+
+  it("the release handler re-checks lease expiry for a pending-target (sweeper) release — TOCTOU close", () => {
+    // The sweeper decides "expired" from a LISTED SNAPSHOT, then releases on
+    // behalf of the holder; the release CAS authorizes on `claimed_by`, which
+    // a holder that RENEWED between the list and the release still matches.
+    // Without a server-side re-check the renewed (LIVE) job is yanked back to
+    // pending — duplicate execution plus a false worker-reclaimed-pending
+    // comm error. The hook must refuse a pending-target release while the
+    // row's CURRENT lease is still live, inside the same transaction.
+    expect(hookSource).toContain(
+      'if (target === "pending" && !leaseExpired(rec)) return;',
+    );
   });
 });

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -1004,6 +1004,37 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
     expect(await q.countPendingForFamily("d6")).toBe(0);
   });
 
+  it("countPendingForFamily explicitly requests totals (skipTotal: false) — the backlog gate must not fail open", async () => {
+    // The gate reads totalItems off a perPage=1 list. If totals are skipped
+    // (PB client default elsewhere in this file is skipTotal: true) PB
+    // returns totalItems: -1 — and -1 is never above the producer's backlog
+    // threshold, so the gate would silently FAIL OPEN and enqueue a fresh
+    // batch on top of an existing backlog. Pin the explicit request.
+    const t0 = Date.parse("2026-06-04T00:00:00.000Z");
+    const { pb, store } = makePagingPb([
+      {
+        ...jobView({ id: "d4-0", probe_key: "d4:x" }),
+        payload: samplePayload({ probeKey: "d4:x" }),
+        created: new Date(t0).toISOString(),
+      },
+    ]);
+    const captured: ListOpts[] = [];
+    const realList = pb.list.bind(pb);
+    pb.list = vi.fn(async (collection: string, opts?: ListOpts) => {
+      captured.push(opts ?? {});
+      return realList(collection, opts);
+    }) as PbClient["list"];
+    const q = createFleetQueueClient({
+      pb,
+      claim: makeStoreClaim(store),
+      logger,
+    });
+
+    expect(await q.countPendingForFamily("d4")).toBe(1);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].skipTotal).toBe(false);
+  });
+
   it("drains the remaining family once the other is exhausted", async () => {
     const t0 = Date.parse("2026-06-04T00:00:00.000Z");
     const rows: CreatedJobRow[] = [

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -1249,10 +1249,14 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
     expect(probeKeyFamily(c.lease!.job.probe_key)).toBe("e2e-demos");
   });
 
-  it("countPendingForFamily counts ONLY that family's pending rows (producer backlog gate)", async () => {
+  it("countPendingForFamily counts that family's NON-TERMINAL rows — claimed/running gate the family too (producer backlog gate)", async () => {
+    // The gate bounds CONCURRENT RUNS per family, not just unclaimed batches:
+    // a batch that has been claimed (or is running) is still in flight, and a
+    // scheduled tick that enqueues a fresh batch on top of it doubles the
+    // family's concurrency. Only TERMINAL rows (done/failed) stop gating.
     const t0 = Date.parse("2026-06-04T00:00:00.000Z");
     const rows: CreatedJobRow[] = [
-      // Two pending e2e-demos rows (the countable backlog)...
+      // Two pending e2e-demos rows (the classic countable backlog)...
       {
         ...jobView({ id: "demos-0", probe_key: "e2e-demos:a" }),
         payload: samplePayload({ probeKey: "e2e-demos:a" }),
@@ -1263,7 +1267,7 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
         payload: samplePayload({ probeKey: "e2e-demos:b" }),
         created: new Date(t0 + 1000).toISOString(),
       },
-      // ...one CLAIMED e2e-demos row (in flight — NOT backlog)...
+      // ...one CLAIMED e2e-demos row (in flight — MUST gate)...
       {
         ...jobView({
           id: "demos-2",
@@ -1273,6 +1277,27 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
         }),
         payload: samplePayload({ probeKey: "e2e-demos:c" }),
         created: new Date(t0 + 2000).toISOString(),
+      },
+      // ...one RUNNING e2e-demos row (in flight — MUST gate)...
+      {
+        ...jobView({
+          id: "demos-3",
+          probe_key: "e2e-demos:d",
+          status: "running",
+          claimed_by: "w9",
+        }),
+        payload: samplePayload({ probeKey: "e2e-demos:d" }),
+        created: new Date(t0 + 2500).toISOString(),
+      },
+      // ...one TERMINAL e2e-demos row (finished — must NOT count)...
+      {
+        ...jobView({
+          id: "demos-4",
+          probe_key: "e2e-demos:e",
+          status: "done",
+        }),
+        payload: samplePayload({ probeKey: "e2e-demos:e" }),
+        created: new Date(t0 + 2750).toISOString(),
       },
       // ...and a pending row from a DIFFERENT family (must not count).
       {
@@ -1288,9 +1313,36 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       logger,
     });
 
-    expect(await q.countPendingForFamily("e2e-demos")).toBe(2);
+    // pending(2) + claimed(1) + running(1); the done row is invisible.
+    expect(await q.countPendingForFamily("e2e-demos")).toBe(4);
     expect(await q.countPendingForFamily("d4")).toBe(1);
     expect(await q.countPendingForFamily("d6")).toBe(0);
+  });
+
+  it("countPendingForFamily gates a family whose batch is claimed-but-running with ZERO pending rows", async () => {
+    // The producer regression this pins: family's whole batch is claimed (no
+    // pending rows left) — a fresh scheduled batch on top would double the
+    // family's concurrent runs, so the count must still be non-zero.
+    const t0 = Date.parse("2026-06-04T00:00:00.000Z");
+    const { pb, store } = makePagingPb([
+      {
+        ...jobView({
+          id: "demos-0",
+          probe_key: "e2e-demos:a",
+          status: "running",
+          claimed_by: "w1",
+        }),
+        payload: samplePayload({ probeKey: "e2e-demos:a" }),
+        created: new Date(t0).toISOString(),
+      },
+    ]);
+    const q = createFleetQueueClient({
+      pb,
+      claim: makeStoreClaim(store),
+      logger,
+    });
+
+    expect(await q.countPendingForFamily("e2e-demos")).toBe(1);
   });
 
   it("warns when family discovery hits the MAX_PENDING_FAMILIES bound with families still hidden (17 families)", async () => {

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -1289,9 +1289,7 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       // Expired-first sort surfaces all 3 dead leases on the FIRST sweep.
       expect(sweep.reclaimed).toBe(3);
       for (let i = 0; i < 3; i++) {
-        expect(store.find((r) => r.id === `dead-${i}`)?.status).toBe(
-          "pending",
-        );
+        expect(store.find((r) => r.id === `dead-${i}`)?.status).toBe("pending");
       }
       // A full page means rows were truncated — that must be observable.
       expect(warnSpy).toHaveBeenCalledWith(

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -4060,6 +4060,54 @@ describe("FleetQueueClient.report", () => {
     expect(rows[0].result).toBeUndefined();
   });
 
+  it("does NOT evict the cached lease/payload on an equality-invariant rejection (the worker still holds the job)", async () => {
+    // The invariant rejection is a MALFORMED-INPUT refusal thrown BEFORE the
+    // release CAS — nothing was released, so the worker still legitimately
+    // holds the job and its heartbeat keeps renewing. The finally's
+    // unconditional eviction dropped the claim-time caches anyway, so the
+    // very next INDETERMINATE renew (thrown claim.renewLease) found no
+    // assumed-live lease to return and re-threw — killing the heartbeat and
+    // letting the sweeper reclaim a LIVE job (the false
+    // worker-crashed-mid-job class the caches exist to prevent).
+    const payload = samplePayload();
+    const { pb } = makeFakePb([{ ...jobView({ id: "j1" }), payload }]);
+    const releaseJob = vi.fn(
+      async (): Promise<ReleaseResult> => ({ released: true }),
+    );
+    const claim = makeFakeClaim({
+      releaseJob,
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        }),
+      ),
+      renewLease: vi.fn(async (): Promise<RenewResult> => {
+        throw new Error("transport blip — indeterminate renew");
+      }),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const claimed = await q.claimNext("worker-7", 30);
+    expect(claimed.claimed).toBe(true);
+
+    await expect(
+      q.report({
+        jobId: "j1",
+        workerId: "worker-7",
+        result: sampleResult({ jobId: "j2" }),
+      }),
+    ).rejects.toThrow(/equality invariant/i);
+    expect(releaseJob).not.toHaveBeenCalled();
+
+    // The caches survived: the indeterminate renew returns the claim-time
+    // lease ASSUMED-LIVE instead of re-throwing (heartbeat stays alive).
+    const lease = await q.renewLease("j1", "worker-7", 30);
+    expect(lease).not.toBeNull();
+    expect(lease!.job.id).toBe("j1");
+    expect(lease!.payload).toEqual(payload);
+  });
+
   it("evicts the cached payload even when the result is MALFORMED (status computed inside the try)", async () => {
     // terminalJobStatus(input.result) used to run BEFORE the try/finally —
     // a malformed result threw past the finally and the claim-time cache

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -1419,6 +1419,47 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
     expect(new Set(claimedFamilies)).toEqual(new Set(["d%", "d6"]));
   });
 
+  it("matches a whole-key (leading-colon) family by EQUALITY only — ':foo' must not fold ':foo:bar' into its clauses", async () => {
+    // probeKeyFamily treats a leading-colon key as its OWN family (the whole
+    // key), so family values can themselves contain colons. Expanding such a
+    // family with the `<family>:%` LIKE leg breaks the partition both ways:
+    // the inclusion/count legs for ":foo" would also match ":foo:bar" (a
+    // DIFFERENT family), and the discovery EXCLUSION leg would hide
+    // ":foo:bar" from rotation while ":foo" rows exist (starvation). See the
+    // equality-only invariant pinned on probeKeyFamily.
+    const t0 = Date.parse("2026-06-04T00:00:00.000Z");
+    const mk = (id: string, probeKey: string, offsetMs: number) => ({
+      ...jobView({ id, probe_key: probeKey }),
+      payload: samplePayload({ probeKey }),
+      created: new Date(t0 + offsetMs).toISOString(),
+    });
+    const { pb, store } = makePagingPb([
+      mk("colon-a", ":foo", 0),
+      mk("colon-b", ":foo:bar", 1000),
+    ]);
+    const q = createFleetQueueClient({
+      pb,
+      claim: makeStoreClaim(store),
+      logger,
+    });
+
+    // The count leg must partition exactly like probeKeyFamily: each
+    // whole-key family counts ONLY its own row.
+    expect(await q.countPendingForFamily(":foo")).toBe(1);
+    expect(await q.countPendingForFamily(":foo:bar")).toBe(1);
+
+    // Round-robin across BOTH whole-key families: with the LIKE leg in the
+    // exclusion clause, ":foo:bar" is never discovered while ":foo" rows
+    // exist, and the inclusion leg over-claims it under ":foo".
+    const claimedFamilies: string[] = [];
+    for (let i = 0; i < 2; i++) {
+      const c = await q.claimNext("w1", 30);
+      expect(c.claimed).toBe(true);
+      claimedFamilies.push(probeKeyFamily(c.lease!.job.probe_key));
+    }
+    expect(new Set(claimedFamilies)).toEqual(new Set([":foo", ":foo:bar"]));
+  });
+
   it("skips a family containing a backslash from clause building (charset guard, with a warn)", async () => {
     // The equality legs double `\` (quoted-literal escaping) while the LIKE
     // legs' fexpr verification covers only `%`/`_` — the two contracts

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -735,6 +735,50 @@ describe("FleetQueueClient.claimNext — FAMILY FAIRNESS (backlogged families mu
     expect(famOf(c.lease!.job.probe_key)).toBe("e2e-demos");
   });
 
+  it("countPendingForFamily counts ONLY that family's pending rows (producer backlog gate)", async () => {
+    const t0 = Date.parse("2026-06-04T00:00:00.000Z");
+    const rows: CreatedJobRow[] = [
+      // Two pending e2e-demos rows (the countable backlog)...
+      {
+        ...jobView({ id: "demos-0", probe_key: "e2e-demos:a" }),
+        payload: samplePayload({ probeKey: "e2e-demos:a" }),
+        created: new Date(t0).toISOString(),
+      },
+      {
+        ...jobView({ id: "demos-1", probe_key: "e2e-demos:b" }),
+        payload: samplePayload({ probeKey: "e2e-demos:b" }),
+        created: new Date(t0 + 1000).toISOString(),
+      },
+      // ...one CLAIMED e2e-demos row (in flight — NOT backlog)...
+      {
+        ...jobView({
+          id: "demos-2",
+          probe_key: "e2e-demos:c",
+          status: "claimed",
+          claimed_by: "w9",
+        }),
+        payload: samplePayload({ probeKey: "e2e-demos:c" }),
+        created: new Date(t0 + 2000).toISOString(),
+      },
+      // ...and a pending row from a DIFFERENT family (must not count).
+      {
+        ...jobView({ id: "d4-0", probe_key: "d4:x" }),
+        payload: samplePayload({ probeKey: "d4:x" }),
+        created: new Date(t0 + 3000).toISOString(),
+      },
+    ];
+    const { pb, store } = makePagingPb(rows);
+    const q = createFleetQueueClient({
+      pb,
+      claim: makeStoreClaim(store),
+      logger,
+    });
+
+    expect(await q.countPendingForFamily("e2e-demos")).toBe(2);
+    expect(await q.countPendingForFamily("d4")).toBe(1);
+    expect(await q.countPendingForFamily("d6")).toBe(0);
+  });
+
   it("drains the remaining family once the other is exhausted", async () => {
     const t0 = Date.parse("2026-06-04T00:00:00.000Z");
     const rows: CreatedJobRow[] = [

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -2803,7 +2803,7 @@ describe("FleetQueueClient.renewLease", () => {
     );
   });
 
-  it("warns on the protocol violation `renewed && !job` before treating it as a lost lease", async () => {
+  it("renewed-without-job with NO cached lease warns and returns null (nothing to assume-live from)", async () => {
     const { pb } = makeFakePb([{ ...jobView(), payload: samplePayload() }]);
     const claim = makeFakeClaim({
       // renewed:true with NO job violates the endpoint contract.
@@ -2811,6 +2811,7 @@ describe("FleetQueueClient.renewLease", () => {
     });
     const q = createFleetQueueClient({ pb, claim, logger });
 
+    // No prior claim in this process → no cached lease to keep alive.
     const lease = await q.renewLease("j1", "worker-7", 30);
 
     expect(lease).toBeNull();
@@ -2818,6 +2819,70 @@ describe("FleetQueueClient.renewLease", () => {
       "queue-client.renew-renewed-without-job",
       expect.objectContaining({ jobId: "j1", workerId: "worker-7" }),
     );
+  });
+
+  it("renewed-without-job with a CACHED lease keeps it assumed-live — a SUCCESSFUL renew must not stop the heartbeat (G1b)", async () => {
+    // The renew CAS WON (renewed:true) — the job is LIVE and this worker
+    // still holds it; only the response's job view is missing (a protocol
+    // violation in the endpoint, not a lost lease). Evicting the caches and
+    // returning null here made the heartbeat read a HEALTHY renew as a lost
+    // lease, stop beating, and let the sweeper falsely reclaim a LIVE job.
+    // Like the indeterminate path, the cached lease is returned assumed-live
+    // so the next beat retries; eviction is reserved for definitive losses.
+    const payload = samplePayload();
+    const { pb } = makeFakePb([{ ...jobView({ id: "j1" }), payload }]);
+    const getOneSpy = vi.fn(pb.getOne.bind(pb));
+    pb.getOne = getOneSpy as PbClient["getOne"];
+    let renewMode: "withoutJob" | "win" = "withoutJob";
+    const claim = makeFakeClaim({
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({
+            id: jobId,
+            status: "claimed",
+            claimed_by: workerId,
+            lease_expires_at: "2026-06-04T00:01:00.000Z",
+            version: 1,
+          }),
+        }),
+      ),
+      renewLease: vi.fn(async (): Promise<RenewResult> => {
+        if (renewMode === "withoutJob") return { renewed: true };
+        return {
+          renewed: true,
+          job: jobView({
+            id: "j1",
+            status: "running",
+            claimed_by: "worker-7",
+            lease_expires_at: "2026-06-04T00:02:00.000Z",
+            version: 2,
+          }),
+        };
+      }),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await q.claimNext("worker-7", 30);
+
+    // The breach is warned, but the cached (claim-time) lease comes back —
+    // NOT null — so the heartbeat keeps the live job alive.
+    const kept = await q.renewLease("j1", "worker-7", 30);
+    expect(kept).not.toBeNull();
+    expect(kept?.leaseExpiresAt).toBe("2026-06-04T00:01:00.000Z");
+    expect(kept?.payload).toEqual(payload);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.renew-renewed-without-job",
+      expect.objectContaining({ jobId: "j1", workerId: "worker-7" }),
+    );
+
+    // No eviction happened: the next (well-formed) renew re-hydrates from
+    // the claim-time cache, never the convenience re-read.
+    renewMode = "win";
+    const next = await q.renewLease("j1", "worker-7", 30);
+    expect(next?.leaseExpiresAt).toBe("2026-06-04T00:02:00.000Z");
+    expect(next?.payload).toEqual(payload);
+    expect(getOneSpy).not.toHaveBeenCalled();
   });
 
   it("a THROWN renew (5xx / unreadable-2xx) keeps the CURRENT lease assumed-live instead of killing the heartbeat", async () => {

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -149,6 +149,7 @@ function likeToRegExp(pattern: string): RegExp {
 
 /** The row shape the shared filter matcher evaluates. */
 interface FilterableRow {
+  id: string;
   status: JobStatus;
   probe_key: string;
 }
@@ -172,9 +173,9 @@ function rowMatchesFilter(row: FilterableRow, filter?: string): boolean {
   for (const [, field, op] of filter.matchAll(
     /([A-Za-z_][\w.]*)\s*(\?~|\?=|!~|!=|<=|>=|<|>|~|=)/g,
   )) {
-    if (field !== "status" && field !== "probe_key") {
+    if (field !== "status" && field !== "probe_key" && field !== "id") {
       throw new Error(
-        `fake-pb: filter clause on unsupported field "${field}" — only status/probe_key are honored (filter: ${filter})`,
+        `fake-pb: filter clause on unsupported field "${field}" — only status/probe_key/id are honored (filter: ${filter})`,
       );
     }
     if (field === "status" && op !== "=") {
@@ -185,6 +186,14 @@ function rowMatchesFilter(row: FilterableRow, filter?: string): boolean {
     if (field === "probe_key" && !["=", "!=", "~", "!~"].includes(op)) {
       throw new Error(
         `fake-pb: probe_key clause with unsupported operator "${op}" (filter: ${filter})`,
+      );
+    }
+    // `id` is honored for the NEGATIVE equality only (the discovery
+    // by-row-id exclusion for clause-unsafe families); anything else throws
+    // per the fakes' philosophy.
+    if (field === "id" && op !== "!=") {
+      throw new Error(
+        `fake-pb: id clause with unsupported operator "${op}" — only \`!=\` is honored (filter: ${filter})`,
       );
     }
   }
@@ -214,6 +223,10 @@ function rowMatchesFilter(row: FilterableRow, filter?: string): boolean {
     (m) => m[1],
   );
   if (statuses.length > 0 && !statuses.includes(row.status)) return false;
+  // id exclusions (ANDed negatives, like the probe_key negatives below).
+  for (const m of filter.matchAll(/(?<![\w.])id\s*!=\s*"([^"]*)"/g)) {
+    if (row.id === m[1]) return false;
+  }
   // KNOWN LIMITATION (value extraction): `"([^"]*)"` stops at the FIRST
   // quote, so a literal containing an ESCAPED quote (`\"`) would be
   // truncated at the escape and the remainder misparsed as filter text.
@@ -1824,6 +1837,87 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
     const c = await q.claimNext("w1", 30);
     expect(c.claimed).toBe(true);
     expect(c.lease?.job.id).toBe("ok-0");
+  });
+
+  it("an unsafe-family row must not starve YOUNGER families — excluded BY ID, discovery continues (G1f)", async () => {
+    // Discovery used to BREAK at the first clause-unsafe family (no safe
+    // family-exclusion clause exists for it), which starved EVERY younger
+    // family behind the offending row for as long as it sat in pending — up
+    // to its 3h stale window. The row itself needs no family-charset
+    // semantics to exclude: `id != "<rowId>"` (PB system ids are
+    // generated alphanumerics) lets discovery CONTINUE past it.
+    const t0 = Date.parse("2026-06-04T00:00:00.000Z");
+    const { pb, store } = makePagingPb([
+      // The unsafe row is the OLDEST — under the old break it occluded
+      // everything younger.
+      {
+        ...jobView({ id: "weird-0", probe_key: "d\\:a" }),
+        payload: samplePayload({ probeKey: "d\\:a" }),
+        created: new Date(t0).toISOString(),
+      },
+      {
+        ...jobView({ id: "ok-0", probe_key: "d6:y" }),
+        payload: samplePayload({ probeKey: "d6:y" }),
+        created: new Date(t0 + 1000).toISOString(),
+      },
+    ]);
+    const claim = makeStoreClaim(store);
+    const claimJobSpy = vi.spyOn(claim, "claimJob");
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const c = await q.claimNext("w1", 30);
+
+    // The younger family is still discovered and claimed…
+    expect(c.claimed).toBe(true);
+    expect(c.lease?.job.id).toBe("ok-0");
+    // …the unsafe row is skipped from claiming entirely (warned, not tried).
+    expect(claimJobSpy).not.toHaveBeenCalledWith(
+      "weird-0",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.family-clause-unsafe",
+      expect.objectContaining({ family: "d\\", probeKey: "d\\:a" }),
+    );
+  });
+
+  it("the EMPTY family's row is skipped by id while leading-colon families stay discoverable (G1c × G1f)", async () => {
+    // COMPOSITION: the empty family (G1c) is clause-unsafe AND its
+    // would-have-been exclusion clause is the one that hid all leading-colon
+    // families. With the by-id exclusion (G1f) the ":foo" whole-key family
+    // behind an empty-probe_key row is still discovered and claimed under
+    // its OWN family — never folded under "".
+    const t0 = Date.parse("2026-06-04T00:00:00.000Z");
+    const { pb, store } = makePagingPb([
+      {
+        ...jobView({ id: "empty-0", probe_key: "" }),
+        payload: samplePayload(),
+        created: new Date(t0).toISOString(),
+      },
+      {
+        ...jobView({ id: "colon-0", probe_key: ":foo" }),
+        payload: samplePayload({ probeKey: ":foo" }),
+        created: new Date(t0 + 1000).toISOString(),
+      },
+    ]);
+    const claim = makeStoreClaim(store);
+    const claimJobSpy = vi.spyOn(claim, "claimJob");
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const c = await q.claimNext("w1", 30);
+
+    expect(c.claimed).toBe(true);
+    expect(c.lease?.job.id).toBe("colon-0");
+    expect(claimJobSpy).not.toHaveBeenCalledWith(
+      "empty-0",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.family-clause-unsafe",
+      expect.objectContaining({ family: "" }),
+    );
   });
 
   it("refuses the EMPTY family from clause building (G1c) — its clauses would match every leading-colon key", async () => {

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -554,6 +554,29 @@ describe("FleetQueueClient.enqueue", () => {
     expect(rows[0].payload).toEqual(samplePayload());
   });
 
+  it("rejects a non-number meta.priority at the enqueue boundary (optional fields still have required shapes)", async () => {
+    // `priority` is the one optional META field; like cellIds/driverInputs
+    // it must have its required shape WHEN PRESENT. The untrusted JSON
+    // column could carry priority: "high" — accepted silently today, it
+    // round-trips to any future claimNext priority consumer as a non-number.
+    const { pb, rows } = makeFakePb();
+    const q = createFleetQueueClient({ pb, claim: makeFakeClaim(), logger });
+
+    const poisoned = samplePayload();
+    poisoned.meta = { ...poisoned.meta, priority: "high" as unknown as number };
+    await expect(q.enqueue({ payload: poisoned })).rejects.toThrow(
+      /priority/i,
+    );
+    expect(rows).toHaveLength(0);
+
+    // A NUMBER priority (and an absent one) still passes.
+    const fine = samplePayload();
+    fine.meta = { ...fine.meta, priority: 5 };
+    await q.enqueue({ payload: fine });
+    await q.enqueue({ payload: samplePayload() });
+    expect(rows).toHaveLength(2);
+  });
+
   it("validates the payload BEFORE creating the row (no poison row persisted)", async () => {
     // enqueue used to deref payload.meta.runId only AFTER pb.create — a
     // malformed caller payload threw AFTER persisting an undecodable row,

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -533,6 +533,247 @@ describe("FleetQueueClient.claimNext — CLAIM FAIRNESS (Part B contention)", ()
   });
 });
 
+describe("FleetQueueClient.claimNext — FAMILY FAIRNESS (backlogged families must not starve)", () => {
+  // ── ROOT CAUSE (verified in prod + staging) ─────────────────────────────────
+  // claimNext listed ONE global pending page (the oldest CLAIM_CANDIDATE_PAGE
+  // rows). With a persistent backlog from the high-frequency families (d4 + d5
+  // tick every 15min ≈ ~180 jobs/hr against 2 serial browser workers), the
+  // oldest-50 page is permanently saturated by those families — a low-frequency
+  // family's jobs (e2e-demos, hourly) NEVER enter the candidate page and are
+  // NEVER claimed. Prod: all 18 e2e-demos jobs stuck pending forever behind a
+  // 137-job backlog; staging: 3,734 pending with the oldest 22h old.
+  //
+  // ── THE FIX (what these tests pin) ──────────────────────────────────────────
+  // claimNext now discovers the DISTINCT families present in pending (oldest
+  // first) and tries them in ROTATION (round-robin across calls, resuming after
+  // the last family this client claimed), listing a PER-FAMILY candidate page
+  // for each. Every discovered family is attempted before claimNext gives up,
+  // so no family can starve while any of its jobs are claimable. The CAS
+  // exactly-one-winner semantics are untouched — only the candidate SELECTION
+  // changed.
+
+  /** probe_key → family (prefix before the first ":"), local to these tests. */
+  const famOf = (probeKey: string): string => {
+    const idx = probeKey.indexOf(":");
+    return idx === -1 ? probeKey : probeKey.slice(0, idx);
+  };
+
+  /** A JobRow carrying PB's system `created` column (the paging sort key). */
+  interface CreatedJobRow extends JobRow {
+    created: string;
+  }
+
+  /**
+   * A PAGING-FAITHFUL fake pb: unlike `makeFakePb` (which ignores `perPage` and
+   * probe_key clauses), this fake honors the parts of the PB list API the
+   * fairness fix depends on — `status` equality, `probe_key` `~`/`!~`/`=`/`!=`
+   * clauses with `%` globs, `created` ascending sort, and `perPage` truncation —
+   * so the production starvation (oldest-50 page saturated by one family) is
+   * reproduced faithfully.
+   */
+  function makePagingPb(rows: CreatedJobRow[]): {
+    pb: PbClient;
+    store: CreatedJobRow[];
+  } {
+    const store = [...rows];
+    const unsupported = (name: string) => () => {
+      throw new Error(`paging-pb: ${name} not implemented`);
+    };
+    const globToRegExp = (pattern: string): RegExp =>
+      new RegExp(
+        `^${pattern
+          .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+          .replace(/%/g, ".*")}$`,
+      );
+    const rowMatches = (row: CreatedJobRow, filter?: string): boolean => {
+      if (!filter) return true;
+      const statuses = [...filter.matchAll(/status\s*=\s*"(\w+)"/g)].map(
+        (m) => m[1],
+      );
+      if (statuses.length > 0 && !statuses.includes(row.status)) return false;
+      const clauses = [
+        ...filter.matchAll(/probe_key\s*(!~|!=|~|=)\s*"([^"]*)"/g),
+      ];
+      const positives = clauses.filter((m) => m[1] === "~" || m[1] === "=");
+      const negatives = clauses.filter((m) => m[1] === "!~" || m[1] === "!=");
+      for (const m of negatives) {
+        const matches =
+          m[1] === "!~"
+            ? globToRegExp(m[2]).test(row.probe_key)
+            : row.probe_key === m[2];
+        if (matches) return false;
+      }
+      if (positives.length > 0) {
+        const anyMatch = positives.some((m) =>
+          m[1] === "~"
+            ? globToRegExp(m[2]).test(row.probe_key)
+            : row.probe_key === m[2],
+        );
+        if (!anyMatch) return false;
+      }
+      return true;
+    };
+    const pb: PbClient = {
+      async list<T>(
+        _collection: string,
+        opts: ListOpts = {},
+      ): Promise<ListResult<T>> {
+        let items = store.filter((r) => rowMatches(r, opts.filter));
+        if (opts.sort && opts.sort.includes("created")) {
+          items = [...items].sort((a, b) => a.created.localeCompare(b.created));
+        }
+        const totalItems = items.length;
+        if (opts.perPage !== undefined) items = items.slice(0, opts.perPage);
+        return {
+          page: 1,
+          perPage: opts.perPage ?? items.length,
+          totalPages: 1,
+          totalItems,
+          items: items as unknown as T[],
+        };
+      },
+      getOne: unsupported("getOne") as PbClient["getOne"],
+      getFirst: unsupported("getFirst") as PbClient["getFirst"],
+      create: unsupported("create") as PbClient["create"],
+      update: unsupported("update") as PbClient["update"],
+      upsertByField: unsupported("upsertByField") as PbClient["upsertByField"],
+      delete: unsupported("delete") as PbClient["delete"],
+      deleteByFilter: unsupported(
+        "deleteByFilter",
+      ) as PbClient["deleteByFilter"],
+      health: unsupported("health") as PbClient["health"],
+      createBackup: unsupported("createBackup") as PbClient["createBackup"],
+      downloadBackup: unsupported(
+        "downloadBackup",
+      ) as PbClient["downloadBackup"],
+      deleteBackup: unsupported("deleteBackup") as PbClient["deleteBackup"],
+    };
+    return { pb, store };
+  }
+
+  /** A store-mutating CAS fake: exactly-one-winner over the shared store. */
+  function makeStoreClaim(
+    store: CreatedJobRow[],
+    opts?: { loseFor?: (row: CreatedJobRow) => boolean },
+  ): JobClaimClient {
+    return {
+      async claimJob(jobId, workerId): Promise<ClaimResult> {
+        const row = store.find((r) => r.id === jobId);
+        if (!row || row.status !== "pending") return { won: false };
+        if (opts?.loseFor?.(row)) return { won: false };
+        row.status = "claimed";
+        row.claimed_by = workerId;
+        row.version += 1;
+        return { won: true, job: { ...row } };
+      },
+      renewLease: vi.fn(async (): Promise<RenewResult> => ({ renewed: false })),
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({ released: false }),
+      ),
+    };
+  }
+
+  /** Seed: 60 old d4 jobs (oldest-50 page saturators) + 18 newer e2e-demos. */
+  function starvedStore(): CreatedJobRow[] {
+    const t0 = Date.parse("2026-06-04T00:00:00.000Z");
+    const rows: CreatedJobRow[] = [];
+    for (let i = 0; i < 60; i++) {
+      const probeKey = `d4:svc-${String(i).padStart(2, "0")}`;
+      rows.push({
+        ...jobView({ id: `d4-${i}`, probe_key: probeKey }),
+        payload: samplePayload({ probeKey, serviceSlug: `svc-${i}` }),
+        created: new Date(t0 + i * 1000).toISOString(),
+      });
+    }
+    for (let i = 0; i < 18; i++) {
+      const probeKey = `e2e-demos:svc-${String(i).padStart(2, "0")}`;
+      rows.push({
+        ...jobView({ id: `demos-${i}`, probe_key: probeKey }),
+        payload: samplePayload({ probeKey, serviceSlug: `svc-${i}` }),
+        created: new Date(t0 + 3_600_000 + i * 1000).toISOString(),
+      });
+    }
+    return rows;
+  }
+
+  it("claims a low-frequency family's jobs even when an older backlog saturates the candidate page (round-robin across families)", async () => {
+    const { pb, store } = makePagingPb(starvedStore());
+    const claim = makeStoreClaim(store);
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const claimedFamilies: string[] = [];
+    for (let i = 0; i < 6; i++) {
+      const c = await q.claimNext("w1", 30);
+      expect(c.claimed).toBe(true);
+      claimedFamilies.push(famOf(c.lease!.job.probe_key));
+    }
+
+    // The e2e-demos jobs sit ENTIRELY outside the oldest-50 global page (60
+    // older d4 rows precede them) — head-of-queue paging never claims them.
+    expect(claimedFamilies).toContain("e2e-demos");
+    // Round-robin: while BOTH families have pending jobs, consecutive claims
+    // alternate families instead of draining the older family first.
+    expect(new Set(claimedFamilies.slice(0, 2))).toEqual(
+      new Set(["d4", "e2e-demos"]),
+    );
+    expect(new Set(claimedFamilies.slice(2, 4))).toEqual(
+      new Set(["d4", "e2e-demos"]),
+    );
+  });
+
+  it("tries EVERY pending family before reporting not-claimed (peer contention on one family cannot starve the rest)", async () => {
+    const { pb, store } = makePagingPb(starvedStore());
+    // Peers win every d4 CAS race; only the e2e-demos family is winnable.
+    const claim = makeStoreClaim(store, {
+      loseFor: (row) => row.probe_key.startsWith("d4:"),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const c = await q.claimNext("w1", 30);
+
+    expect(c.claimed).toBe(true);
+    expect(famOf(c.lease!.job.probe_key)).toBe("e2e-demos");
+  });
+
+  it("drains the remaining family once the other is exhausted", async () => {
+    const t0 = Date.parse("2026-06-04T00:00:00.000Z");
+    const rows: CreatedJobRow[] = [
+      {
+        ...jobView({ id: "d4-0", probe_key: "d4:only" }),
+        payload: samplePayload({ probeKey: "d4:only" }),
+        created: new Date(t0).toISOString(),
+      },
+      {
+        ...jobView({ id: "demos-0", probe_key: "e2e-demos:a" }),
+        payload: samplePayload({ probeKey: "e2e-demos:a" }),
+        created: new Date(t0 + 1000).toISOString(),
+      },
+      {
+        ...jobView({ id: "demos-1", probe_key: "e2e-demos:b" }),
+        payload: samplePayload({ probeKey: "e2e-demos:b" }),
+        created: new Date(t0 + 2000).toISOString(),
+      },
+    ];
+    const { pb, store } = makePagingPb(rows);
+    const claim = makeStoreClaim(store);
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const claimedIds: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      const c = await q.claimNext("w1", 30);
+      expect(c.claimed).toBe(true);
+      claimedIds.push(c.lease!.job.id);
+    }
+    // All three jobs are claimed across families; nothing is stranded.
+    expect(new Set(claimedIds)).toEqual(
+      new Set(["d4-0", "demos-0", "demos-1"]),
+    );
+    // The queue is now empty.
+    const done = await q.claimNext("w1", 30);
+    expect(done.claimed).toBe(false);
+  });
+});
+
 describe("FleetQueueClient.renewLease", () => {
   it("delegates to S0 renewLease and returns the refreshed lease", async () => {
     const { pb } = makeFakePb([{ ...jobView(), payload: samplePayload() }]);

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -567,7 +567,8 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
    * A PAGING-FAITHFUL fake pb: unlike `makeFakePb` (which ignores `perPage` and
    * probe_key clauses), this fake honors the parts of the PB list API the
    * fairness fix depends on — `status` equality, `probe_key` `~`/`!~`/`=`/`!=`
-   * clauses with `%` globs, `created` ascending sort, and `perPage` truncation —
+   * clauses with `%` globs, `created`/`lease_expires_at` ascending sorts, and
+   * `perPage` truncation —
    * so the production starvation (oldest-50 page saturated by one family) is
    * reproduced faithfully.
    */
@@ -624,7 +625,16 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
         opts: ListOpts = {},
       ): Promise<ListResult<T>> {
         let items = store.filter((r) => rowMatches(r, opts.filter));
-        if (opts.sort && opts.sort.includes("created")) {
+        if (opts.sort && opts.sort.includes("lease_expires_at")) {
+          // PB ascending date sort; empty/null dates sort first (and a
+          // null/empty lease counts as expired — leaseExpired(null) === true —
+          // so "nulls first" is exactly the expired-first semantics).
+          items = [...items].sort((a, b) =>
+            String(a.lease_expires_at ?? "").localeCompare(
+              String(b.lease_expires_at ?? ""),
+            ),
+          );
+        } else if (opts.sort && opts.sort.includes("created")) {
           items = [...items].sort((a, b) => a.created.localeCompare(b.created));
         }
         const totalItems = items.length;
@@ -1074,6 +1084,120 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       // phase re-queued in THIS call, not a blanket stale-phase skip.
       expect(sweep.expiredPending).toBe(1);
       expect(store.find((r) => r.id === "untouched-old")).toBeUndefined();
+    });
+  });
+
+  describe("sweepExpired — LEASE-SCAN PAGING (mass worker crash backlog)", () => {
+    // The lease phase lists claimed/running rows with perPage 50. Under a mass
+    // worker crash (>50 such rows), an UNSORTED list left the page contents to
+    // PB's unspecified default order — the same 50 live-lease rows could come
+    // back every sweep, leaving expired leases beyond the page PERMANENTLY
+    // invisible (zero reclaimed, zero signal). The fix sorts by
+    // lease_expires_at ascending so the most-expired rows always land at the
+    // head of the page, and WARNs when the page is full (truncation is
+    // observable).
+
+    const NOW = Date.parse("2026-06-04T00:05:00.000Z");
+
+    function runningRow(id: string, leaseExpiresAt: string): CreatedJobRow {
+      return {
+        ...jobView({
+          id,
+          probe_key: `d6:${id}`,
+          status: "running",
+          claimed_by: `w-${id}`,
+          lease_expires_at: leaseExpiresAt,
+          version: 1,
+        }),
+        payload: samplePayload({ probeKey: `d6:${id}` }),
+        // Recent enough that the stale-pending phase never touches a
+        // reclaimed (now-pending) row in the same sweep.
+        created: "2026-06-04T00:00:00.000Z",
+      };
+    }
+
+    /** A store-mutating releaseJob: CAS on claimed_by, re-queues to pending. */
+    function makeStoreReleaseClaim(store: CreatedJobRow[]): JobClaimClient {
+      return {
+        ...makeStoreClaim(store),
+        async releaseJob(jobId, workerId, status): Promise<ReleaseResult> {
+          const row = store.find((r) => r.id === jobId);
+          if (!row || row.claimed_by !== workerId) return { released: false };
+          row.status = status as JobStatus;
+          row.claimed_by = "";
+          row.lease_expires_at = null;
+          row.version += 1;
+          return { released: true, job: { ...row } };
+        },
+      };
+    }
+
+    it("reclaims expired leases buried beyond the 50-row page on the FIRST sweep (lease_expires_at ascending) and warns on truncation", async () => {
+      // 52 live rows inserted FIRST, 3 expired rows LAST: under insertion
+      // order the perPage-50 page contains ONLY live rows, so the unsorted
+      // scan misses the expired ones on every sweep (RED: zero reclaimed
+      // across two sweeps).
+      const rows: CreatedJobRow[] = [];
+      for (let i = 0; i < 52; i++) {
+        rows.push(
+          runningRow(
+            `live-${String(i).padStart(2, "0")}`,
+            "2026-06-04T00:06:00.000Z",
+          ),
+        );
+      }
+      for (let i = 0; i < 3; i++) {
+        rows.push(runningRow(`dead-${i}`, "2026-06-04T00:01:00.000Z"));
+      }
+      const { pb, store } = makePagingPb(rows);
+      const q = createFleetQueueClient({
+        pb,
+        claim: makeStoreReleaseClaim(store),
+        logger,
+      });
+      const warnSpy = vi.spyOn(logger, "warn");
+
+      const sweep = await q.sweepExpired(NOW);
+
+      // Expired-first sort surfaces all 3 dead leases on the FIRST sweep.
+      expect(sweep.reclaimed).toBe(3);
+      for (let i = 0; i < 3; i++) {
+        expect(store.find((r) => r.id === `dead-${i}`)?.status).toBe(
+          "pending",
+        );
+      }
+      // A full page means rows were truncated — that must be observable.
+      expect(warnSpy).toHaveBeenCalledWith(
+        "queue-client.sweep-lease-page-truncated",
+        expect.objectContaining({ perPage: 50 }),
+      );
+
+      // A second sweep finds nothing further expired (and reclaims nothing
+      // twice) — forward progress, not the same-page-forever pathology.
+      const sweep2 = await q.sweepExpired(NOW);
+      expect(sweep2.reclaimed).toBe(0);
+      warnSpy.mockRestore();
+    });
+
+    it("does NOT warn about truncation when the claimed/running page is not full", async () => {
+      const { pb, store } = makePagingPb([
+        runningRow("dead-0", "2026-06-04T00:01:00.000Z"),
+      ]);
+      const q = createFleetQueueClient({
+        pb,
+        claim: makeStoreReleaseClaim(store),
+        logger,
+      });
+      const warnSpy = vi.spyOn(logger, "warn");
+
+      const sweep = await q.sweepExpired(NOW);
+
+      expect(sweep.reclaimed).toBe(1);
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        "queue-client.sweep-lease-page-truncated",
+        expect.anything(),
+      );
+      warnSpy.mockRestore();
     });
   });
 });

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -942,6 +942,66 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       expect(sweep.expiredPending).toBe(0);
       expect(store.find((r) => r.id === "odd")?.status).toBe("pending");
     });
+
+    it("grants one sweep of grace to a row re-queued by the lease phase in the SAME sweep (commError stands; control row still expires)", async () => {
+      // A long-claimed row: its lease just expired AND its `created` (the
+      // ORIGINAL enqueue time — the lease phase's re-queue does not touch it)
+      // already exceeds the stale window. Without the grace, the lease phase
+      // re-queues it to pending and emits `worker-reclaimed-pending` ("back in
+      // flight"), then the stale-pending phase of the SAME sweepExpired call
+      // lists pending fresh, ages it off `created`, and claims-then-deletes
+      // it — falsifying the comm error (and orphaning downstream overlay
+      // resolution on the deleted row).
+      const longClaimed: CreatedJobRow = {
+        ...jobView({
+          id: "long-claimed",
+          probe_key: "d6:a",
+          status: "running",
+          claimed_by: "worker-dead",
+          lease_expires_at: new Date(T - MIN).toISOString(),
+        }),
+        payload: samplePayload({ probeKey: "d6:a" }),
+        created: new Date(T - 4 * HOUR).toISOString(), // > 3 × 60min default
+      };
+      // Control: a genuinely stale pending row UNTOUCHED by the lease phase
+      // must still expire in this same sweep.
+      const untouchedStale = pendingRow("untouched-old", "d6:b", T - 4 * HOUR);
+      const { pb, store } = makePagingPb([longClaimed, untouchedStale]);
+      const base = makeStoreClaim(store);
+      const claim: JobClaimClient = {
+        ...base,
+        // Store-mutating release: the sweeper re-queues on behalf of the dead
+        // holder, flipping the row back to pending so the SAME call's fresh
+        // pending list (the bug path) actually sees it.
+        async releaseJob(jobId, workerId, status): Promise<ReleaseResult> {
+          const r = store.find((x) => x.id === jobId);
+          if (!r || r.claimed_by !== workerId) return { released: false };
+          r.status = status;
+          r.claimed_by = "";
+          r.version += 1;
+          return { released: true, job: { ...r } };
+        },
+      };
+      const q = createFleetQueueClient({ pb, claim, logger });
+
+      const sweep = await q.sweepExpired(T);
+
+      // Lease phase: re-queued and emitted the neutral comm error...
+      expect(sweep.reclaimed).toBe(1);
+      expect(sweep.commErrors).toHaveLength(1);
+      expect(sweep.commErrors[0].kind).toBe("worker-reclaimed-pending");
+      expect(sweep.commErrors[0].jobId).toBe("long-claimed");
+      // ...and the SAME sweep's stale phase must NOT delete it: one sweep of
+      // grace keeps "re-queued to pending" true. If truly stale it ages out
+      // on the NEXT sweep.
+      expect(store.find((r) => r.id === "long-claimed")?.status).toBe(
+        "pending",
+      );
+      // The control row still expires — the grace is scoped to rows the lease
+      // phase re-queued in THIS call, not a blanket stale-phase skip.
+      expect(sweep.expiredPending).toBe(1);
+      expect(store.find((r) => r.id === "untouched-old")).toBeUndefined();
+    });
   });
 });
 

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -1605,6 +1605,65 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       expect(store.find((r) => r.id === "untouched-old")).toBeUndefined();
     });
 
+    it("a release that THROWS after committing server-side still graces the row AND synthesizes its comm error (timeout-after-commit)", async () => {
+      // TIMEOUT-AFTER-COMMIT: the release CAS can COMMIT server-side and the
+      // response then be lost in transit (the client sees a throw). The row
+      // IS pending now, but a plain `continue` on the throw leaves it (a)
+      // absent from the grace set — the SAME call's stale phase can
+      // claim-and-delete it — and (b) without its worker-reclaimed-pending
+      // comm error, which no later sweep re-emits (the row is pending, so
+      // the lease phase never sees it again): the gray "re-queued" surface
+      // is lost FOREVER. The fix is conservative at-least-once handling: on
+      // a thrown release, grace the row and synthesize the comm error
+      // anyway. If the release did NOT commit, the next sweep retries and a
+      // duplicate gray overlay may render — harmless; a missing one is not.
+      const longClaimed: CreatedJobRow = {
+        ...jobView({
+          id: "throw-commit",
+          probe_key: "d6:a",
+          status: "running",
+          claimed_by: "worker-dead",
+          lease_expires_at: new Date(T - MIN).toISOString(),
+        }),
+        payload: samplePayload({ probeKey: "d6:a" }),
+        created: new Date(T - 4 * HOUR).toISOString(), // stale (> 3 × 60min)
+      };
+      const { pb, store } = makePagingPb([longClaimed]);
+      const base = makeStoreClaim(store);
+      const claim: JobClaimClient = {
+        ...base,
+        // COMMIT, then throw — the server applied the re-queue but the
+        // response never reached the client.
+        async releaseJob(jobId, workerId): Promise<ReleaseResult> {
+          const r = store.find((x) => x.id === jobId);
+          if (!r || r.claimed_by !== workerId) return { released: false };
+          r.status = "pending";
+          r.claimed_by = "";
+          r.version += 1;
+          throw new Error("socket timeout after commit");
+        },
+      };
+      const q = createFleetQueueClient({ pb, claim, logger });
+
+      const sweep = await q.sweepExpired(T);
+
+      // The comm error was synthesized despite the throw (at-least-once)...
+      expect(sweep.commErrors).toHaveLength(1);
+      expect(sweep.commErrors[0].kind).toBe("worker-reclaimed-pending");
+      expect(sweep.commErrors[0].jobId).toBe("throw-commit");
+      expect(sweep.reclaimed).toBe(1);
+      // ...and the grace set protected the (committed-pending, stale) row
+      // from the SAME sweep's stale phase — it survives to be re-claimed.
+      expect(sweep.expiredPending).toBe(0);
+      expect(store.find((r) => r.id === "throw-commit")?.status).toBe(
+        "pending",
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        "queue-client.sweep-release-threw",
+        expect.objectContaining({ jobId: "throw-commit" }),
+      );
+    });
+
     it("applies the grace set on EVERY page of the multi-page stale drain (pagination must not out-run the grace)", async () => {
       // COMPOSITION: the one-sweep grace × the multi-page drain. A re-queued
       // row whose `created` sorts AFTER a full page of older stale rows only
@@ -2378,9 +2437,13 @@ describe("FleetQueueClient.sweepExpired", () => {
 
     const sweep = await q.sweepExpired(now);
 
-    // j1 (released BEFORE the throw) and j3 (after) both survive the blip.
-    expect(sweep.reclaimed).toBe(2);
-    expect(sweep.commErrors.map((e) => e.jobId)).toEqual(["j1", "j3"]);
+    // j1 (released BEFORE the throw) and j3 (after) both survive the blip,
+    // and j2's throw is handled CONSERVATIVELY (timeout-after-commit): the
+    // release may have committed server-side, so its comm error is
+    // synthesized anyway (at-least-once — a duplicate gray overlay is
+    // harmless, a missing one is lost forever).
+    expect(sweep.reclaimed).toBe(3);
+    expect(sweep.commErrors.map((e) => e.jobId)).toEqual(["j1", "j2", "j3"]);
     expect(logger.warn).toHaveBeenCalledWith(
       "queue-client.sweep-release-threw",
       expect.objectContaining({ jobId: "j2", workerId: "w2" }),

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -582,6 +582,12 @@ describe("FleetQueueClient.claimNext", () => {
     // No decodable payload → aggregate key falls back to the row's probe_key.
     expect(written.aggregateKey).toBe("d6:langgraph-python");
     expect(written.aggregateState).toBe("error");
+    // The result must NOT carry the empty sentinels emptyPayloadForLease
+    // forbids feeding aggregation: serviceSlug is recovered from the
+    // probe_key's slug segment, and runId is a non-colliding synthetic id
+    // (an empty runId would silently group into nothing downstream).
+    expect(written.serviceSlug).toBe("langgraph-python");
+    expect(written.runId).toBe("pviol_j1");
     expect(rows[0].result_processed).toBe(false);
   });
 

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -491,6 +491,35 @@ describe("FleetQueueClient.enqueue", () => {
     expect(createSpy).not.toHaveBeenCalled();
     expect(rows).toHaveLength(0);
   });
+
+  it("rejects the documented forbidden EMPTY sentinels (probeKey/serviceSlug/driverKind/runId) before creating the row (G1c)", async () => {
+    // emptyPayloadForLease documents empty serviceSlug/runId (and the rest)
+    // as FORBIDDEN aggregation inputs: an empty runId groups into nothing in
+    // the aggregator, an empty serviceSlug corrupts the per-service rollup,
+    // and an empty probeKey yields the empty FAMILY whose filter clauses
+    // match every leading-colon key (the partition gap familyClauseSafe now
+    // refuses). The typeof checks alone admitted all four — the boundary
+    // must require non-empty strings.
+    const { pb, rows } = makeFakePb();
+    const createSpy = vi.fn(pb.create.bind(pb));
+    pb.create = createSpy as PbClient["create"];
+    const claim = makeFakeClaim();
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const empties: Array<Partial<ServiceJobPayload>> = [
+      { probeKey: "" },
+      { serviceSlug: "" },
+      { driverKind: "" },
+      { meta: { ...samplePayload().meta, runId: "" } },
+    ];
+    for (const overrides of empties) {
+      await expect(
+        q.enqueue({ payload: samplePayload(overrides) }),
+      ).rejects.toThrow(/non-empty/i);
+    }
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(rows).toHaveLength(0);
+  });
 });
 
 describe("FleetQueueClient.claimNext", () => {
@@ -699,6 +728,52 @@ describe("FleetQueueClient.claimNext", () => {
     expect(claimed.lease?.job.id).toBe("j5");
   });
 
+  it("treats the forbidden empty sentinels in a CLAIMED row's payload as decode failures (releases + skips) — G1c decode boundary", async () => {
+    // The encode and decode boundaries share assertServiceJobPayload, so the
+    // non-empty requirement must fail loud at BOTH ends: a row persisted by
+    // an older writer (or hand-edited) with an empty probeKey/serviceSlug/
+    // driverKind/runId is released as failed and skipped, never handed to
+    // the worker (where the empty sentinels corrupt aggregation).
+    const bad = (id: string, overrides: Partial<ServiceJobPayload>): JobRow => ({
+      ...jobView({ id }),
+      payload: samplePayload(overrides),
+    });
+    const { pb } = makeFakePb([
+      bad("j1", { probeKey: "" }),
+      bad("j2", { serviceSlug: "" }),
+      bad("j3", { driverKind: "" }),
+      bad("j4", { meta: { ...samplePayload().meta, runId: "" } }),
+      { ...jobView({ id: "j5" }), payload: samplePayload() },
+    ]);
+    const releaseJob = vi.fn(
+      async (): Promise<ReleaseResult> => ({ released: true }),
+    );
+    const claim = makeFakeClaim({
+      releaseJob,
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        }),
+      ),
+    });
+    // Identity order: poison rows j1–j4 are tried before the good j5.
+    const q = createFleetQueueClient({
+      pb,
+      claim,
+      logger,
+      rng: IDENTITY_ORDER_RNG,
+    });
+
+    const claimed = await q.claimNext("worker-7", 30);
+
+    for (const id of ["j1", "j2", "j3", "j4"]) {
+      expect(releaseJob).toHaveBeenCalledWith(id, "worker-7", "failed");
+    }
+    expect(claimed.claimed).toBe(true);
+    expect(claimed.lease?.job.id).toBe("j5");
+  });
+
   it("attributes a decode-failed row as worker-protocol-violation via a synthetic result (not a crash)", async () => {
     // After the decode-fail release the row is terminal-but-RESULTLESS; the
     // result consumer's contract synthesizes worker-crashed-mid-job (a RED
@@ -862,7 +937,14 @@ describe("FleetQueueClient.claimNext", () => {
     expect(written.serviceSlug).not.toBe("");
   });
 
-  it("falls back to a jobId-derived serviceSlug when the probe_key itself is empty", async () => {
+  it("skips an empty-probe_key row at discovery (its family is the clause-unsafe empty family) — never claimed (G1c)", async () => {
+    // probeKeyFamily("") === "" is the clause-unsafe EMPTY family (its
+    // prefix-LIKE clauses would match every leading-colon key), so an
+    // empty-probe_key row is excluded from discovery/claiming entirely with
+    // the charset-guard warn — it can no longer reach the decode-failure
+    // synthesis at all. (The synthesis call site keeps its jobId-derived
+    // `unknown-<jobId>` serviceSlug fallback as defense-in-depth for any
+    // future claim path that hands it an empty probe_key.)
     const { pb, rows } = makeFakePb([
       {
         ...jobView({ id: "j1", probe_key: "" }),
@@ -887,10 +969,15 @@ describe("FleetQueueClient.claimNext", () => {
     });
     const q = createFleetQueueClient({ pb, claim, logger });
 
-    await q.claimNext("worker-7", 30);
+    const claimed = await q.claimNext("worker-7", 30);
 
-    const written = rows[0].result as ServiceJobResult;
-    expect(written.serviceSlug).toBe("unknown-j1");
+    expect(claimed.claimed).toBe(false);
+    expect(claim.claimJob).not.toHaveBeenCalled();
+    expect(rows[0].result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.family-clause-unsafe",
+      expect.objectContaining({ family: "" }),
+    );
   });
 
   it("warns on the protocol violation `won && !job` before falling through (CAS contract breach must be visible)", async () => {
@@ -1737,6 +1824,38 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
     const c = await q.claimNext("w1", 30);
     expect(c.claimed).toBe(true);
     expect(c.lease?.job.id).toBe("ok-0");
+  });
+
+  it("refuses the EMPTY family from clause building (G1c) — its clauses would match every leading-colon key", async () => {
+    // probeKeyFamily("") === "" takes the prefix-LIKE leg of the clause
+    // builders: familyInclusionClause("") is `(probe_key ~ ":%" ||
+    // probe_key = "")` — matching EVERY leading-colon key (cross-family
+    // over-claim/over-count) — and familyExclusionClause("") hides ALL
+    // leading-colon families from discovery. The empty family must be
+    // clause-unsafe exactly like the backslash class: count refuses with 0 +
+    // warn instead of emitting the over-matching filter.
+    const t0 = Date.parse("2026-06-04T00:00:00.000Z");
+    const { pb, store } = makePagingPb([
+      {
+        ...jobView({ id: "colon-0", probe_key: ":foo" }),
+        payload: samplePayload({ probeKey: ":foo" }),
+        created: new Date(t0).toISOString(),
+      },
+    ]);
+    const q = createFleetQueueClient({
+      pb,
+      claim: makeStoreClaim(store),
+      logger,
+    });
+
+    // The over-matching clause would count the ":foo" row under family "".
+    expect(await q.countPendingForFamily("")).toBe(0);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.family-clause-unsafe",
+      expect.objectContaining({ family: "" }),
+    );
+    // The ":foo" row still counts under its OWN (whole-key) family.
+    expect(await q.countPendingForFamily(":foo")).toBe(1);
   });
 
   it("countPendingForFamily THROWS on a non-count totalItems instead of returning the poisoned value", async () => {

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -108,6 +108,14 @@ interface JobRow extends JobView {
  * character while unescaped `%`/`_` are wildcards. The fakes must honor the
  * escape form, or a family containing a wildcard char would over-match here
  * exactly as it would against real PB before the client escaped it.
+ *
+ * KNOWN LIMITATION (dangling backslash): a pattern ENDING in `\` has nothing
+ * to escape — the `i + 1 < pattern.length` guard fails and the trailing `\`
+ * falls to the else branch, matching a LITERAL backslash. SQLite's
+ * `ESCAPE '\'` behavior for a dangling escape is unspecified-ish; the
+ * production clause builders can never emit one (familyClauseSafe rejects
+ * backslash-bearing families outright), so the fake's literal reading is
+ * just the least-surprising fallback, not a verified PB contract.
  */
 function likeToRegExp(pattern: string): RegExp {
   const escapeRegExp = (ch: string): string =>
@@ -170,10 +178,39 @@ function rowMatchesFilter(row: FilterableRow, filter?: string): boolean {
       );
     }
   }
+  // BOOLEAN-CONNECTIVE GUARD: the evaluation below ORs all POSITIVE clauses
+  // per field (faithful to the production inclusion groups, which are
+  // `(probe_key ~ x || probe_key = y)` / `(status = a || status = b)`) and
+  // ANDs negatives. Two positive clauses for ONE field joined WITHOUT a
+  // `||` between them are ANDed in the real grammar — a shape this OR-model
+  // would evaluate wrong, so it must throw rather than pass vacuously.
+  const assertPositivesOrJoined = (field: string, re: RegExp): void => {
+    const ms = [...filter.matchAll(re)];
+    for (let i = 1; i < ms.length; i++) {
+      const prev = ms[i - 1];
+      const sep = filter.slice((prev.index ?? 0) + prev[0].length, ms[i].index);
+      if (!sep.includes("||")) {
+        throw new Error(
+          `fake-pb: multiple positive ${field} clauses ANDed — the OR-model cannot honor this shape (filter: ${filter})`,
+        );
+      }
+    }
+  };
+  // `(?:~|=)` requires the operator DIRECTLY after the field (`!~`/`!=`
+  // never match — the `!` breaks the adjacency), so these scan positives only.
+  assertPositivesOrJoined("status", /status\s*=\s*"\w+"/g);
+  assertPositivesOrJoined("probe_key", /probe_key\s*(?:~|=)\s*"[^"]*"/g);
   const statuses = [...filter.matchAll(/status\s*=\s*"(\w+)"/g)].map(
     (m) => m[1],
   );
   if (statuses.length > 0 && !statuses.includes(row.status)) return false;
+  // KNOWN LIMITATION (value extraction): `"([^"]*)"` stops at the FIRST
+  // quote, so a literal containing an ESCAPED quote (`\"`) would be
+  // truncated at the escape and the remainder misparsed as filter text.
+  // Acceptable here: probe keys are slugs and the client's
+  // escapeFilterLiteral only emits `\"` for quote-bearing inputs, which the
+  // production builders never receive (and familyClauseSafe rejects the
+  // backslash class outright).
   const clauses = [...filter.matchAll(/probe_key\s*(!~|!=|~|=)\s*"([^"]*)"/g)];
   const negatives = clauses.filter((m) => m[1] === "!~" || m[1] === "!=");
   const positives = clauses.filter((m) => m[1] === "~" || m[1] === "=");
@@ -349,6 +386,44 @@ describe("test-fake honesty (the fakes must throw, not vacuously match)", () => 
     // The supported shapes still evaluate.
     expect(rowMatchesFilter(row, 'status = "pending"')).toBe(true);
     expect(rowMatchesFilter(row, 'probe_key !~ "d4:%"')).toBe(true);
+  });
+
+  it("rowMatchesFilter throws on boolean-connective shapes its OR-model cannot honor (positives ANDed)", () => {
+    // The matcher ORs all positive clauses per field (faithful to the
+    // production inclusion groups, which are `(a ~ x || a = y)`), and ANDs
+    // negatives. Multiple positive clauses for ONE field joined by `&&`
+    // therefore evaluate WRONG (the model would OR what the filter ANDs) —
+    // a test exercising that shape must fail loudly, not pass vacuously.
+    const row: FilterableRow = { status: "pending", probe_key: "d6:a" };
+    expect(() =>
+      rowMatchesFilter(row, 'probe_key ~ "d6:%" && probe_key ~ "d4:%"'),
+    ).toThrow(/positive probe_key clauses ANDed/);
+    expect(() =>
+      rowMatchesFilter(row, 'probe_key = "d6:a" && probe_key ~ "d6:%"'),
+    ).toThrow(/positive probe_key clauses ANDed/);
+    expect(() =>
+      rowMatchesFilter(row, 'status = "pending" && status = "claimed"'),
+    ).toThrow(/positive status clauses ANDed/);
+    // The production OR-group shapes stay evaluable.
+    expect(
+      rowMatchesFilter(
+        row,
+        'status = "pending" && (probe_key ~ "d6:%" || probe_key = "d6")',
+      ),
+    ).toBe(true);
+    expect(
+      rowMatchesFilter(
+        row,
+        '(status = "pending" || status = "claimed" || status = "running") && (probe_key ~ "d6:%" || probe_key = "d6")',
+      ),
+    ).toBe(true);
+    // Negatives ANDed (the discovery exclusion shape) remain supported.
+    expect(
+      rowMatchesFilter(
+        row,
+        'status = "pending" && probe_key !~ "d4:%" && probe_key != "d4"',
+      ),
+    ).toBe(true);
   });
 
   it("the fakes return totalItems -1 under skipTotal (faithful to PB, no fail-open counts)", async () => {
@@ -1234,6 +1309,13 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
           );
         } else if (sortKey && sortKey.includes("created")) {
           items = [...items].sort((a, b) => a.created.localeCompare(b.created));
+        } else if (sortKey) {
+          // An unmodeled sort key used to fall through UNSORTED — a test
+          // depending on it would pass vacuously on insertion order. Throw,
+          // matching the fakes' unsupported-method philosophy.
+          throw new Error(
+            `paging-pb: unmodeled sort key "${sortKey}" — only created/lease_expires_at are honored`,
+          );
         }
         if (desc) items.reverse();
         const totalItems = items.length;
@@ -1330,6 +1412,31 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
     }
     return rows;
   }
+
+  it("makePagingPb throws on an unmodeled sort key instead of silently not sorting", async () => {
+    // The paging fake honors only `created` / `lease_expires_at` (± the `-`
+    // prefix). Any other sort key used to fall through UNSORTED — a test
+    // depending on e.g. a `version` sort would pass vacuously on insertion
+    // order. Unmodeled sorts must throw, matching the fakes' philosophy.
+    const t0 = Date.parse("2026-06-04T00:00:00.000Z");
+    const { pb } = makePagingPb([
+      {
+        ...jobView({ id: "j1", probe_key: "d6:a" }),
+        payload: samplePayload(),
+        created: new Date(t0).toISOString(),
+      },
+    ]);
+    await expect(
+      pb.list("probe_jobs", { filter: 'status = "pending"', sort: "version" }),
+    ).rejects.toThrow(/unmodeled sort key "version"/);
+    // The modeled keys still work, both directions.
+    await expect(
+      pb.list("probe_jobs", { sort: "created" }),
+    ).resolves.toBeTruthy();
+    await expect(
+      pb.list("probe_jobs", { sort: "-created" }),
+    ).resolves.toBeTruthy();
+  });
 
   it("claims a low-frequency family's jobs even when an older backlog saturates the candidate page (round-robin across families)", async () => {
     const { pb, store } = makePagingPb(starvedStore());

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -533,7 +533,7 @@ describe("FleetQueueClient.claimNext — CLAIM FAIRNESS (Part B contention)", ()
   });
 });
 
-describe("FleetQueueClient.claimNext — FAMILY FAIRNESS (backlogged families must not starve)", () => {
+describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not starve)", () => {
   // ── ROOT CAUSE (verified in prod + staging) ─────────────────────────────────
   // claimNext listed ONE global pending page (the oldest CLAIM_CANDIDATE_PAGE
   // rows). With a persistent backlog from the high-frequency families (d4 + d5
@@ -637,7 +637,11 @@ describe("FleetQueueClient.claimNext — FAMILY FAIRNESS (backlogged families mu
       create: unsupported("create") as PbClient["create"],
       update: unsupported("update") as PbClient["update"],
       upsertByField: unsupported("upsertByField") as PbClient["upsertByField"],
-      delete: unsupported("delete") as PbClient["delete"],
+      async delete(_collection: string, id: string): Promise<void> {
+        const idx = store.findIndex((r) => r.id === id);
+        if (idx === -1) throw new Error(`paging-pb: delete of missing ${id}`);
+        store.splice(idx, 1);
+      },
       deleteByFilter: unsupported(
         "deleteByFilter",
       ) as PbClient["deleteByFilter"],
@@ -815,6 +819,129 @@ describe("FleetQueueClient.claimNext — FAMILY FAIRNESS (backlogged families mu
     // The queue is now empty.
     const done = await q.claimNext("w1", 30);
     expect(done.claimed).toBe(false);
+  });
+
+  describe("sweepExpired — STALE-PENDING EXPIRY (structural backlog drain)", () => {
+    // sweepExpired only reclaimed claimed/running leases — a pending row had
+    // NO terminal path, so an accumulated backlog (staging: 3,734 pending,
+    // oldest 22h) could only drain through 2 serial workers and effectively
+    // never did. The sweep now ALSO expires pending jobs older than
+    // expiryPeriods × their family's production period (the job's data is
+    // stale — its family has long since enqueued fresher batches): each stale
+    // row is first CLAIMED via the S0 CAS under a synthetic sweeper id (so a
+    // racing worker can never lose a row out from under itself) and then
+    // DELETED.
+
+    const T = Date.parse("2026-06-04T12:00:00.000Z");
+    const HOUR = 60 * 60 * 1000;
+    const MIN = 60 * 1000;
+
+    function pendingRow(
+      id: string,
+      probeKey: string,
+      createdMs: number,
+    ): CreatedJobRow {
+      return {
+        ...jobView({ id, probe_key: probeKey }),
+        payload: samplePayload({ probeKey }),
+        created: new Date(createdMs).toISOString(),
+      };
+    }
+
+    it("claims-then-deletes pending jobs older than expiryPeriods × the (default) family period", async () => {
+      const stale = pendingRow("old", "d6:a", T - 4 * HOUR); // > 3 × 60min
+      const fresh = pendingRow("new", "d6:b", T - 10 * MIN);
+      const { pb, store } = makePagingPb([stale, fresh]);
+      const claimJobCalls: Array<[string, string]> = [];
+      const base = makeStoreClaim(store);
+      const claim: JobClaimClient = {
+        ...base,
+        async claimJob(jobId, workerId, leaseSeconds) {
+          claimJobCalls.push([jobId, workerId]);
+          return base.claimJob(jobId, workerId, leaseSeconds);
+        },
+      };
+      const q = createFleetQueueClient({ pb, claim, logger });
+
+      const sweep = await q.sweepExpired(T);
+
+      expect(sweep.expiredPending).toBe(1);
+      // The stale row was CLAIMED first (CAS — never delete a row a worker
+      // could be racing for) and then deleted.
+      expect(claimJobCalls.map(([id]) => id)).toEqual(["old"]);
+      expect(store.find((r) => r.id === "old")).toBeUndefined();
+      // The fresh row is untouched and still claimable.
+      expect(store.find((r) => r.id === "new")?.status).toBe("pending");
+      // No comm error for an expired-pending row — it never ran.
+      expect(sweep.commErrors).toHaveLength(0);
+    });
+
+    it("does NOT delete a stale pending row whose claim is lost to a racing worker", async () => {
+      const stale = pendingRow("old", "d6:a", T - 4 * HOUR);
+      const { pb, store } = makePagingPb([stale]);
+      // A worker wins every CAS race — the sweeper must back off.
+      const claim = makeStoreClaim(store, { loseFor: () => true });
+      const q = createFleetQueueClient({ pb, claim, logger });
+
+      const sweep = await q.sweepExpired(T);
+
+      expect(sweep.expiredPending).toBe(0);
+      expect(store.find((r) => r.id === "old")?.status).toBe("pending");
+    });
+
+    it("honors per-family periods from stalePending.familyPeriodsMs", async () => {
+      // 50min-old rows: stale for d4 (3 × 15min = 45min) but NOT for d6
+      // (default 3 × 60min = 3h).
+      const d4 = pendingRow("d4-old", "d4:a", T - 50 * MIN);
+      const d6 = pendingRow("d6-young", "d6:a", T - 50 * MIN);
+      const { pb, store } = makePagingPb([d4, d6]);
+      const q = createFleetQueueClient({
+        pb,
+        claim: makeStoreClaim(store),
+        logger,
+        stalePending: { familyPeriodsMs: { d4: 15 * MIN } },
+      });
+
+      const sweep = await q.sweepExpired(T);
+
+      expect(sweep.expiredPending).toBe(1);
+      expect(store.find((r) => r.id === "d4-old")).toBeUndefined();
+      expect(store.find((r) => r.id === "d6-young")?.status).toBe("pending");
+    });
+
+    it("is disabled when expiryPeriods <= 0", async () => {
+      const stale = pendingRow("old", "d6:a", T - 48 * HOUR);
+      const { pb, store } = makePagingPb([stale]);
+      const q = createFleetQueueClient({
+        pb,
+        claim: makeStoreClaim(store),
+        logger,
+        stalePending: { expiryPeriods: 0 },
+      });
+
+      const sweep = await q.sweepExpired(T);
+
+      expect(sweep.expiredPending).toBe(0);
+      expect(store.find((r) => r.id === "old")?.status).toBe("pending");
+    });
+
+    it("conservatively skips a pending row whose created timestamp is unparseable (delete is destructive)", async () => {
+      const garbage = {
+        ...pendingRow("odd", "d6:a", T),
+        created: "not-a-date",
+      };
+      const { pb, store } = makePagingPb([garbage]);
+      const q = createFleetQueueClient({
+        pb,
+        claim: makeStoreClaim(store),
+        logger,
+      });
+
+      const sweep = await q.sweepExpired(T);
+
+      expect(sweep.expiredPending).toBe(0);
+      expect(store.find((r) => r.id === "odd")?.status).toBe("pending");
+    });
   });
 });
 

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -2329,20 +2329,75 @@ describe("FleetQueueClient.report", () => {
     const { pb, rows } = makeFakePb([seededRow()]);
     const claim = makeFakeClaim({
       releaseJob: vi.fn(
-        async (): Promise<ReleaseResult> => ({ released: false }),
+        async (): Promise<ReleaseResult> => ({
+          released: false,
+          reason: "refused_not_holder",
+        }),
       ),
     });
     const q = createFleetQueueClient({ pb, claim, logger });
 
     // The error must say what actually happened: the computed result IS
-    // discarded and the job re-runs — NOT the old "nothing was lost" framing
-    // (the ROW isn't lost, but this worker's work product is).
+    // discarded, and the job re-runs ONLY if the sweeper reclaims it to
+    // pending — a terminal row never re-runs (the old wording claimed an
+    // unconditional re-run).
     await expect(
       q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() }),
-    ).rejects.toThrow(/release refused .* result is DISCARDED/i);
+    ).rejects.toThrow(
+      /release refused .* result is DISCARDED.*re-runs only if .* reclaimed to pending/i,
+    );
     // A refused release must never leave a result on a row this worker no
     // longer owns — the consumer would otherwise aggregate a stale result.
     expect(rows[0].result).toBeUndefined();
+  });
+
+  it("a refusal WITHOUT a reason (legacy hook) still throws (fail closed, not fail open)", async () => {
+    const { pb, rows } = makeFakePb([seededRow()]);
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({ released: false }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await expect(
+      q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() }),
+    ).rejects.toThrow(/release refused/i);
+    expect(rows[0].result).toBeUndefined();
+  });
+
+  it("skips to the result write when the refusal is refused_terminal_same_holder (report() is retryable)", async () => {
+    // TIMEOUT-AFTER-COMMIT retry truthfulness: report()'s first attempt can
+    // succeed the release CAS and then exhaust the result write (throwing
+    // "result lost"). A NATURAL RETRY of report() then gets the release
+    // REFUSED — the row is already terminal — and used to emit the
+    // "result is DISCARDED and the job re-runs" error: both halves false
+    // (the result is still writable by this holder; terminal rows never
+    // re-run). With the hook's reason field, a refusal that is
+    // refused_terminal_same_holder (terminal UNDER MY workerId — only this
+    // worker's own committed release can produce that) skips straight to
+    // writeResult, making report() retryable end-to-end.
+    const { pb, rows } = makeFakePb([seededRow()]);
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({
+          released: false,
+          reason: "refused_terminal_same_holder",
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const result = sampleResult();
+    await q.report({ jobId: "j1", workerId: "worker-7", result });
+
+    // The result landed for the consumer despite the refused (re-)release.
+    expect(rows[0].result).toEqual(result);
+    expect(rows[0].result_processed).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.release-refused-terminal-same-holder",
+      expect.objectContaining({ jobId: "j1", workerId: "worker-7" }),
+    );
   });
 });
 
@@ -2723,6 +2778,17 @@ describe("fleet-claim.pb.js hook parity (client ↔ JSVM contract pins)", () => 
     expect(clamps.length).toBe(2);
   });
 
+  it("the release handler reports a refusal reason (terminal-same-holder vs not-holder vs live-lease)", () => {
+    // report()'s retryability depends on distinguishing "the row is terminal
+    // under MY workerId" (my own earlier release committed → the result is
+    // still mine to write) from every other refusal. The hook must emit the
+    // reason on the released:false response.
+    expect(hookSource).toContain('"refused_terminal_same_holder"');
+    expect(hookSource).toContain('"refused_not_holder"');
+    expect(hookSource).toContain('"refused_lease_live"');
+    expect(hookSource).toContain("{ released: false, reason:");
+  });
+
   it("the release handler RETAINS lease_expires_at on a pending re-queue (last-in-flight marker)", () => {
     // The stale-pending sweep's recent-lease heuristic depends on the
     // re-queue keeping the expired lease around: nulling it would let the
@@ -2741,7 +2807,7 @@ describe("fleet-claim.pb.js hook parity (client ↔ JSVM contract pins)", () => 
     // comm error. The hook must refuse a pending-target release while the
     // row's CURRENT lease is still live, inside the same transaction.
     expect(hookSource).toContain(
-      'if (target === "pending" && !leaseExpired(rec)) return;',
+      'if (target === "pending" && !leaseExpired(rec)) {',
     );
   });
 });

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -1611,6 +1611,78 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       expect(store.find((r) => r.id === "untouched-old")).toBeUndefined();
     });
 
+    it("a re-queued long-runner survives the NEXT sweep (recent lease = stale-age evidence is stale)", async () => {
+      // Stale-pending age is anchored on PB `created` and re-queue does NOT
+      // re-anchor it. A job that legitimately ran LONGER than its family's
+      // expiry window therefore comes back from the lease sweep already
+      // "stale": sweep N re-queues it ("back in flight" comm error), the
+      // one-sweep grace protects it within sweep N, but sweep N+1's stale
+      // phase ages it off the ORIGINAL `created` and claim-deletes it before
+      // any plausible re-run — the dashboard permanently shows "re-queued"
+      // for silently-discarded work. The fix (no schema change): the hook
+      // RETAINS lease_expires_at on a pending re-queue, and the stale phase
+      // SKIPS rows whose retained lease is recent (parseable and within
+      // now - familyExpiryWindow) — the row was in flight recently, so its
+      // pending-age is stale evidence, not abandonment.
+      const longRunner: CreatedJobRow = {
+        ...jobView({
+          id: "long-runner",
+          probe_key: "d6:a",
+          status: "running",
+          claimed_by: "worker-dead",
+          lease_expires_at: new Date(T - MIN).toISOString(),
+        }),
+        payload: samplePayload({ probeKey: "d6:a" }),
+        created: new Date(T - 4 * HOUR).toISOString(), // > 3 × 60min default
+      };
+      const { pb, store } = makePagingPb([longRunner]);
+      const base = makeStoreClaim(store);
+      const claim: JobClaimClient = {
+        ...base,
+        // Hook-faithful pending release: drops ownership but RETAINS the
+        // (expired) lease as the row's last-in-flight marker — the hook no
+        // longer nulls lease_expires_at on re-queue (parity-pinned below).
+        async releaseJob(jobId, workerId, status): Promise<ReleaseResult> {
+          const r = store.find((x) => x.id === jobId);
+          if (!r || r.claimed_by !== workerId) return { released: false };
+          r.status = status;
+          r.claimed_by = "";
+          r.version += 1;
+          return { released: true, job: { ...r } };
+        },
+      };
+      const q = createFleetQueueClient({ pb, claim, logger });
+
+      // Sweep 1: lease phase re-queues + emits the comm error; the grace set
+      // protects the row within THIS sweep.
+      const first = await q.sweepExpired(T);
+      expect(first.reclaimed).toBe(1);
+      expect(first.commErrors[0]?.jobId).toBe("long-runner");
+      expect(first.expiredPending).toBe(0);
+      expect(store.find((r) => r.id === "long-runner")?.status).toBe(
+        "pending",
+      );
+
+      // Sweep 2: the grace set is per-call, so only the recent-lease
+      // heuristic stands between the re-queued row and a claim-delete. The
+      // row's retained lease (expired 1min ago) is WELL within the 3h family
+      // window — it was in flight a minute ago, so it must survive to be
+      // re-claimed and actually re-run.
+      const second = await q.sweepExpired(T);
+      expect(second.expiredPending).toBe(0);
+      expect(store.find((r) => r.id === "long-runner")?.status).toBe(
+        "pending",
+      );
+
+      // CONTROl: once the retained lease itself is OLDER than the family
+      // window (no re-claim for a whole window — genuinely abandoned), the
+      // stale phase expires the row normally.
+      const muchLater = T + 4 * HOUR;
+      const third = await q.sweepExpired(muchLater);
+      expect(third.expiredPending).toBe(1);
+      expect(store.find((r) => r.id === "long-runner")).toBeUndefined();
+    });
+
     it("a release that THROWS after committing server-side still graces the row AND synthesizes its comm error (timeout-after-commit)", async () => {
       // TIMEOUT-AFTER-COMMIT: the release CAS can COMMIT server-side and the
       // response then be lost in transit (the client sees a throw). The row
@@ -1754,7 +1826,9 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       };
     }
 
-    /** A store-mutating releaseJob: CAS on claimed_by, re-queues to pending. */
+    /** A store-mutating releaseJob: CAS on claimed_by, re-queues to pending.
+     * Hook-faithful: lease_expires_at is RETAINED on re-queue (the hook keeps
+     * it as the row's last-in-flight marker — parity-pinned below). */
     function makeStoreReleaseClaim(store: CreatedJobRow[]): JobClaimClient {
       return {
         ...makeStoreClaim(store),
@@ -1763,7 +1837,6 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
           if (!row || row.claimed_by !== workerId) return { released: false };
           row.status = status as JobStatus;
           row.claimed_by = "";
-          row.lease_expires_at = null;
           row.version += 1;
           return { released: true, job: { ...row } };
         },
@@ -2389,7 +2462,7 @@ describe("FleetQueueClient.sweepExpired", () => {
         }
         row.status = status;
         row.claimed_by = "";
-        row.lease_expires_at = null;
+        // Hook-faithful: lease_expires_at is RETAINED on re-queue.
         return { released: true, job: { ...row } };
       },
     );
@@ -2648,6 +2721,15 @@ describe("fleet-claim.pb.js hook parity (client ↔ JSVM contract pins)", () => 
     // handlers (claim + renew; release sets no lease).
     const clamps = hookSource.match(/Math\.min\(\s*n,\s*3600\s*\)/g) ?? [];
     expect(clamps.length).toBe(2);
+  });
+
+  it("the release handler RETAINS lease_expires_at on a pending re-queue (last-in-flight marker)", () => {
+    // The stale-pending sweep's recent-lease heuristic depends on the
+    // re-queue keeping the expired lease around: nulling it would let the
+    // NEXT sweep claim-delete a re-queued long-runner off its original
+    // `created` age. Claim admits pending rows regardless of lease, so
+    // retention is safe.
+    expect(hookSource).not.toContain('rec.set("lease_expires_at", null)');
   });
 
   it("the release handler re-checks lease expiry for a pending-target (sweeper) release — TOCTOU close", () => {

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -2526,6 +2526,89 @@ describe("FleetQueueClient.renewLease", () => {
     );
   });
 
+  it("a THROWN renew (5xx / unreadable-2xx) keeps the CURRENT lease assumed-live instead of killing the heartbeat", async () => {
+    // INDETERMINACY CONTAINMENT (G1b): a renew that THROWS (transport blip,
+    // 5xx, or job-claim's 2xx-unreadable indeterminate) may or may not have
+    // committed. The worker heartbeat catches a renewLease throw and BREAKS
+    // (worker-loop.ts), so an escaped throw stops heartbeating → the sweeper
+    // reclaims a LIVE job → a FALSE worker-crashed-mid-job. renewLease must
+    // contain the throw: warn, keep the last-known lease assumed-live, and
+    // let the NEXT beat retry. Only a definitive renewed:false stops the
+    // heartbeat.
+    const payload = samplePayload();
+    const { pb } = makeFakePb([{ ...jobView({ id: "j1" }), payload }]);
+    const getOneSpy = vi.fn(pb.getOne.bind(pb));
+    pb.getOne = getOneSpy as PbClient["getOne"];
+    let renewThrows = true;
+    const claim = makeFakeClaim({
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({
+            id: jobId,
+            status: "claimed",
+            claimed_by: workerId,
+            lease_expires_at: "2026-06-04T00:01:00.000Z",
+            version: 1,
+          }),
+        }),
+      ),
+      renewLease: vi.fn(async (): Promise<RenewResult> => {
+        if (renewThrows) throw new Error("2xx body unreadable — outcome indeterminate");
+        return {
+          renewed: true,
+          job: jobView({
+            id: "j1",
+            status: "running",
+            claimed_by: "worker-7",
+            lease_expires_at: "2026-06-04T00:02:00.000Z",
+            version: 2,
+          }),
+        };
+      }),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await q.claimNext("worker-7", 30);
+
+    // The thrown renew is contained: the CURRENT (claim-time) lease comes
+    // back unchanged — NOT null — so the heartbeat continues.
+    const kept = await q.renewLease("j1", "worker-7", 30);
+    expect(kept).not.toBeNull();
+    expect(kept?.leaseExpiresAt).toBe("2026-06-04T00:01:00.000Z");
+    expect(kept?.payload).toEqual(payload);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.renew-indeterminate",
+      expect.objectContaining({ jobId: "j1", workerId: "worker-7" }),
+    );
+
+    // The payload cache was NOT evicted by the indeterminate beat: the next
+    // (successful) renew re-hydrates from cache, never the convenience
+    // re-read.
+    renewThrows = false;
+    const next = await q.renewLease("j1", "worker-7", 30);
+    expect(next?.leaseExpiresAt).toBe("2026-06-04T00:02:00.000Z");
+    expect(next?.payload).toEqual(payload);
+    expect(getOneSpy).not.toHaveBeenCalled();
+  });
+
+  it("a thrown renew with NO locally-known lease still throws (nothing to assume-live from)", async () => {
+    const { pb } = makeFakePb([
+      { ...jobView({ id: "j1" }), payload: samplePayload() },
+    ]);
+    const claim = makeFakeClaim({
+      renewLease: vi.fn(async (): Promise<RenewResult> => {
+        throw new Error("renew transport blip");
+      }),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    // No prior claim in this process → no cached lease to keep alive.
+    await expect(q.renewLease("j1", "worker-7", 30)).rejects.toThrow(
+      /renew transport blip/,
+    );
+  });
+
   it("returns a lease on a SUCCESSFUL CAS even when cache miss AND reread fail", async () => {
     // The CAS renewed (won), but there is NO prior same-process claim (cache
     // empty) AND the convenience re-read THROWS (PB blip). A successful CAS

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -669,6 +669,118 @@ describe("FleetQueueClient.claimNext", () => {
     expect(releaseJob).toHaveBeenCalledWith("j2", "worker-7", "failed");
   });
 
+  it("a claimJob THROW on one candidate does not abort the rotation (warn + continue)", async () => {
+    // A transport blip on the claim CAS is indistinguishable from losing the
+    // race — a thrown claim used to escape raceCandidates and abort the
+    // WHOLE rotation (every remaining candidate and every remaining family
+    // unclaimed for this poll). Contain it per candidate: warn + continue.
+    const { pb } = makeFakePb([
+      { ...jobView({ id: "j1" }), payload: samplePayload() },
+      { ...jobView({ id: "j2" }), payload: samplePayload() },
+    ]);
+    const claim = makeFakeClaim({
+      claimJob: vi.fn(async (jobId, workerId): Promise<ClaimResult> => {
+        if (jobId === "j1") throw new Error("claim transport blip");
+        return {
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        };
+      }),
+    });
+    // Identity-order rng: j1 (the thrower) before j2.
+    const q = createFleetQueueClient({
+      pb,
+      claim,
+      logger,
+      rng: IDENTITY_ORDER_RNG,
+    });
+
+    const claimed = await q.claimNext("worker-7", 30);
+
+    expect(claimed.claimed).toBe(true);
+    expect(claimed.lease?.job.id).toBe("j2");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.claim-cas-threw",
+      expect.objectContaining({ jobId: "j1", err: "claim transport blip" }),
+    );
+  });
+
+  it("uses the injected clock for the decode-failure synthetic result's timestamps", async () => {
+    // The synthetic worker-protocol-violation result used `new Date()`
+    // directly while the rest of the queue layer takes injected time —
+    // making the observedAt/finishedAt unpinnable in tests and inconsistent
+    // under clock control. The client's `now` config (default Date.now) is
+    // the clock source.
+    const FIXED = Date.parse("2026-06-05T01:02:03.000Z");
+    const { pb, rows } = makeFakePb([
+      {
+        ...jobView({ id: "j1" }),
+        payload: null as unknown as ServiceJobPayload,
+      },
+    ]);
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(
+        async (): Promise<ReleaseResult> => ({ released: true }),
+      ),
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({
+      pb,
+      claim,
+      logger,
+      now: () => FIXED,
+    });
+
+    await q.claimNext("worker-7", 30);
+
+    const written = rows[0].result as ServiceJobResult;
+    expect(written.commError?.observedAt).toBe("2026-06-05T01:02:03.000Z");
+    expect(written.finishedAt).toBe("2026-06-05T01:02:03.000Z");
+  });
+
+  it("warns before the defensive duplicate-family break (a backend ignoring exclusions must be observable)", async () => {
+    // Family discovery relies on the exclusion clause shrinking each query's
+    // result. A backend that ignores it would re-yield the same family
+    // forever; the defensive break stops the spin but used to be SILENT —
+    // hiding both the backend defect and every undiscovered family.
+    const sameHead = { ...jobView({ id: "h1" }), payload: samplePayload() };
+    const pb = {
+      ...makeFakePb([sameHead]).pb,
+      // Ignore ALL filters: every list returns the same head row.
+      async list<T>(): Promise<ListResult<T>> {
+        return {
+          page: 1,
+          perPage: 1,
+          totalPages: 1,
+          totalItems: 1,
+          items: [sameHead] as unknown as T[],
+        };
+      },
+    } as PbClient;
+    const claim = makeFakeClaim({
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const claimed = await q.claimNext("worker-7", 30);
+
+    expect(claimed.claimed).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.family-discovery-duplicate",
+      expect.objectContaining({ family: "d6" }),
+    );
+  });
+
   it("falls through to the next candidate when it loses the CAS on the first", async () => {
     const { pb } = makeFakePb([
       { ...jobView({ id: "j1" }), payload: samplePayload() },
@@ -1156,6 +1268,47 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       claimedFamilies.push(probeKeyFamily(c.lease!.job.probe_key));
     }
     expect(new Set(claimedFamilies)).toEqual(new Set(["d%", "d6"]));
+  });
+
+  it("skips a family containing a backslash from clause building (charset guard, with a warn)", async () => {
+    // The equality legs double `\` (quoted-literal escaping) while the LIKE
+    // legs' fexpr verification covers only `%`/`_` — the two contracts
+    // cannot both hold for a backslash, so rather than emit a filter with
+    // unverified semantics, clause builders refuse backslash families:
+    // probe keys are slugs in practice, so such a family is garbage input.
+    const t0 = Date.parse("2026-06-04T00:00:00.000Z");
+    const { pb, store } = makePagingPb([
+      // Normal family first (oldest) so discovery still yields it.
+      {
+        ...jobView({ id: "ok-0", probe_key: "d6:y" }),
+        payload: samplePayload({ probeKey: "d6:y" }),
+        created: new Date(t0).toISOString(),
+      },
+      {
+        ...jobView({ id: "weird-0", probe_key: "d\\:a" }),
+        payload: samplePayload({ probeKey: "d\\:a" }),
+        created: new Date(t0 + 1000).toISOString(),
+      },
+    ]);
+    const q = createFleetQueueClient({
+      pb,
+      claim: makeStoreClaim(store),
+      logger,
+    });
+
+    // The count leg refuses the unsafe family outright (0 + warn) instead
+    // of emitting an unverified filter.
+    expect(await q.countPendingForFamily("d\\")).toBe(0);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.family-clause-unsafe",
+      expect.objectContaining({ family: "d\\" }),
+    );
+
+    // Discovery still rotates the families found BEFORE the unsafe one; the
+    // claim drains the safe family and reports the unsafe one via the warn.
+    const c = await q.claimNext("w1", 30);
+    expect(c.claimed).toBe(true);
+    expect(c.lease?.job.id).toBe("ok-0");
   });
 
   it("countPendingForFamily explicitly requests totals (skipTotal: false) — the backlog gate must not fail open", async () => {
@@ -2138,6 +2291,49 @@ describe("FleetQueueClient.renewLease", () => {
     const lease = await q.renewLease("j1", "worker-7", 30);
     expect(lease).not.toBeNull();
     expect(getOneSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs a renew re-read DECODE failure as a protocol violation, not a read blip", async () => {
+    // The re-read catch used to swallow decodePayload throws under the
+    // "queue-client.renew-reread-failed" READ-BLIP warn — but a row whose
+    // persisted payload no longer decodes is a PROTOCOL problem (a poison
+    // row), not a transient PB read failure, and triaging it as a blip
+    // hides it from anyone grepping for protocol violations. The renew
+    // itself still succeeds (heartbeat-only empty payload).
+    const { pb } = makeFakePb([
+      {
+        ...jobView({ id: "j1" }),
+        payload: "garbage" as unknown as ServiceJobPayload,
+      },
+    ]);
+    const claim = makeFakeClaim({
+      renewLease: vi.fn(
+        async (): Promise<RenewResult> => ({
+          renewed: true,
+          job: jobView({
+            id: "j1",
+            status: "running",
+            claimed_by: "worker-7",
+            lease_expires_at: "2026-06-04T00:02:00.000Z",
+            version: 2,
+          }),
+        }),
+      ),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    // No prior claim → cache miss → re-read returns the poison row.
+    const lease = await q.renewLease("j1", "worker-7", 30);
+
+    expect(lease).not.toBeNull();
+    expect(logger.error).toHaveBeenCalledWith(
+      "queue-client.renew-reread-protocol-violation",
+      expect.objectContaining({ jobId: "j1" }),
+    );
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      "queue-client.renew-reread-failed",
+      expect.anything(),
+    );
   });
 
   it("returns a lease on a SUCCESSFUL CAS even when cache miss AND reread fail", async () => {

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -574,8 +574,13 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
   function makePagingPb(rows: CreatedJobRow[]): {
     pb: PbClient;
     store: CreatedJobRow[];
+    /** Failure injection: `delete` THROWS for any row id in this set (the
+     * stale sweep's claim→delete window losing its delete). Mutable so a test
+     * can heal the fault between sweeps and watch the retry succeed. */
+    deleteFailures: Set<string>;
   } {
     const store = [...rows];
+    const deleteFailures = new Set<string>();
     const unsupported = (name: string) => () => {
       throw new Error(`paging-pb: ${name} not implemented`);
     };
@@ -638,6 +643,9 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       update: unsupported("update") as PbClient["update"],
       upsertByField: unsupported("upsertByField") as PbClient["upsertByField"],
       async delete(_collection: string, id: string): Promise<void> {
+        if (deleteFailures.has(id)) {
+          throw new Error(`paging-pb: injected delete failure for ${id}`);
+        }
         const idx = store.findIndex((r) => r.id === id);
         if (idx === -1) throw new Error(`paging-pb: delete of missing ${id}`);
         store.splice(idx, 1);
@@ -652,7 +660,7 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       ) as PbClient["downloadBackup"],
       deleteBackup: unsupported("deleteBackup") as PbClient["deleteBackup"],
     };
-    return { pb, store };
+    return { pb, store, deleteFailures };
   }
 
   /** A store-mutating CAS fake: exactly-one-winner over the shared store. */
@@ -923,6 +931,71 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
 
       expect(sweep.expiredPending).toBe(0);
       expect(store.find((r) => r.id === "old")?.status).toBe("pending");
+    });
+
+    it("re-queues a sweeper-claimed row whose delete failed SILENTLY (no comm error) and retries the delete on a later sweep", async () => {
+      // When the stale sweep wins the claim but the DELETE fails, the row
+      // sits claimed under "stale-pending-sweeper" until its short lease
+      // expires. The next lease sweep must NOT treat that like a crashed
+      // worker's job: it is stale garbage mid-deletion, so it is re-queued
+      // SILENTLY (no `worker-reclaimed-pending` comm error attributed to a
+      // non-existent worker, no gray "back in flight" dashboard overlay) and
+      // a later stale sweep retries the delete — the self-healing contract.
+      const stale = pendingRow("old", "d6:a", T - 4 * HOUR);
+      const { pb, store, deleteFailures } = makePagingPb([stale]);
+      deleteFailures.add("old");
+      const base = makeStoreClaim(store);
+      // The lease-phase re-queue needs a REAL releaseJob (makeStoreClaim's
+      // default vi.fn refuses): authorize on claimed_by, flip back to pending.
+      const claim: JobClaimClient = {
+        ...base,
+        async releaseJob(jobId, workerId, status): Promise<ReleaseResult> {
+          const row = store.find((r) => r.id === jobId);
+          if (!row || row.claimed_by !== workerId) return { released: false };
+          row.status = status as JobStatus;
+          row.claimed_by = "";
+          row.lease_expires_at = null;
+          row.version += 1;
+          return { released: true, job: { ...row } };
+        },
+      };
+      const q = createFleetQueueClient({ pb, claim, logger });
+      const debugSpy = vi.spyOn(logger, "debug");
+
+      // Sweep 1: stale phase claims the row, delete FAILS — not counted, not
+      // thrown; the row stays briefly claimed by the sweeper.
+      const first = await q.sweepExpired(T);
+      expect(first.expiredPending).toBe(0);
+      expect(first.commErrors).toHaveLength(0);
+      expect(store.find((r) => r.id === "old")?.claimed_by).toBe(
+        "stale-pending-sweeper",
+      );
+
+      // Sweep 2 (the sweeper's lease has expired — the fake CAS leaves
+      // lease_expires_at null): the lease phase re-queues the row SILENTLY.
+      const second = await q.sweepExpired(T);
+      expect(second.commErrors).toHaveLength(0);
+      expect(second.reclaimed).toBe(0);
+      expect(
+        debugSpy.mock.calls.some(
+          ([msg]) => msg === "queue-client.stale-sweeper-retry-requeue",
+        ),
+      ).toBe(true);
+      // Proof the re-queue happened: the SAME sweep's stale phase could only
+      // re-claim a PENDING row (the fake CAS refuses anything else); its
+      // delete failed again, so the row is back under the sweeper.
+      expect(store.find((r) => r.id === "old")?.claimed_by).toBe(
+        "stale-pending-sweeper",
+      );
+
+      // Sweep 3 (delete healed): silent re-queue, then the stale phase
+      // claims-and-deletes cleanly — still no comm error anywhere.
+      deleteFailures.delete("old");
+      const third = await q.sweepExpired(T);
+      expect(third.expiredPending).toBe(1);
+      expect(third.commErrors).toHaveLength(0);
+      expect(store.find((r) => r.id === "old")).toBeUndefined();
+      debugSpy.mockRestore();
     });
 
     it("conservatively skips a pending row whose created timestamp is unparseable (delete is destructive)", async () => {

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -310,6 +310,28 @@ describe("FleetQueueClient.enqueue", () => {
     expect(rows[0].claimed_by).toBe("");
     expect(rows[0].payload).toEqual(samplePayload());
   });
+
+  it("validates the payload BEFORE creating the row (no poison row persisted)", async () => {
+    // enqueue used to deref payload.meta.runId only AFTER pb.create — a
+    // malformed caller payload threw AFTER persisting an undecodable row,
+    // i.e. a poison row every claimer then has to release-as-failed. The
+    // validation must run first so nothing is written.
+    const { pb, rows } = makeFakePb();
+    const createSpy = vi.fn(pb.create.bind(pb));
+    pb.create = createSpy as PbClient["create"];
+    const claim = makeFakeClaim();
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const badPayload = {
+      ...samplePayload(),
+      meta: "not-an-object",
+    } as unknown as ServiceJobPayload;
+    await expect(q.enqueue({ payload: badPayload })).rejects.toThrow(
+      /meta/i,
+    );
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(rows).toHaveLength(0);
+  });
 });
 
 describe("FleetQueueClient.claimNext", () => {
@@ -464,6 +486,58 @@ describe("FleetQueueClient.claimNext", () => {
     expect(releaseJob).toHaveBeenCalledWith("j1", "worker-7", "failed");
     expect(claimed.claimed).toBe(true);
     expect(claimed.lease?.job.id).toBe("j2");
+  });
+
+  it("treats malformed meta.triggered/meta.enqueuedAt/cellIds/driverInputs as decode failures (releases + skips)", async () => {
+    // decodePayload used to validate only probeKey/serviceSlug/driverKind and
+    // meta.runId — the REST of the payload (meta.triggered, meta.enqueuedAt,
+    // cellIds, driverInputs) was cast through unchecked, deferring malformed
+    // shapes to undefined derefs deep in the worker/aggregator. Each bad
+    // shape must fail LOUD at this boundary: release the won row, move on.
+    const bad = (id: string, payload: unknown): JobRow => ({
+      ...jobView({ id }),
+      payload: payload as ServiceJobPayload,
+    });
+    const { pb } = makeFakePb([
+      bad("j1", {
+        ...samplePayload(),
+        meta: { ...samplePayload().meta, triggered: "yes" },
+      }),
+      bad("j2", {
+        ...samplePayload(),
+        meta: { ...samplePayload().meta, enqueuedAt: 1234 },
+      }),
+      bad("j3", { ...samplePayload(), cellIds: "shared-state" }),
+      bad("j4", { ...samplePayload(), driverInputs: ["not", "a", "record"] }),
+      { ...jobView({ id: "j5" }), payload: samplePayload() },
+    ]);
+    const releaseJob = vi.fn(
+      async (): Promise<ReleaseResult> => ({ released: true }),
+    );
+    const claim = makeFakeClaim({
+      releaseJob,
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({ id: jobId, status: "claimed", claimed_by: workerId }),
+        }),
+      ),
+    });
+    // Identity order: poison rows j1–j4 are tried before the good j5.
+    const q = createFleetQueueClient({
+      pb,
+      claim,
+      logger,
+      rng: IDENTITY_ORDER_RNG,
+    });
+
+    const claimed = await q.claimNext("worker-7", 30);
+
+    for (const id of ["j1", "j2", "j3", "j4"]) {
+      expect(releaseJob).toHaveBeenCalledWith(id, "worker-7", "failed");
+    }
+    expect(claimed.claimed).toBe(true);
+    expect(claimed.lease?.job.id).toBe("j5");
   });
 
   it("attributes a decode-failed row as worker-protocol-violation via a synthetic result (not a crash)", async () => {
@@ -1002,6 +1076,80 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
     expect(await q.countPendingForFamily("e2e-demos")).toBe(2);
     expect(await q.countPendingForFamily("d4")).toBe(1);
     expect(await q.countPendingForFamily("d6")).toBe(0);
+  });
+
+  it("warns when family discovery hits the MAX_PENDING_FAMILIES bound with families still hidden (17 families)", async () => {
+    // The discovery loop is bounded at 16 distinct families; tripping the
+    // bound used to be SILENT — the 17th family simply never entered the
+    // rotation, i.e. exactly the starvation class fairness exists to prevent,
+    // with zero observability. Mirror the sweep's truncation warn.
+    const t0 = Date.parse("2026-06-04T00:00:00.000Z");
+    const rows = Array.from({ length: 17 }, (_, i) => {
+      const probeKey = `f${String(i).padStart(2, "0")}:svc`;
+      return {
+        ...jobView({ id: `r${i}`, probe_key: probeKey }),
+        payload: samplePayload({ probeKey }),
+        created: new Date(t0 + i * 1000).toISOString(),
+      };
+    });
+    const { pb, store } = makePagingPb(rows);
+    const q = createFleetQueueClient({
+      pb,
+      claim: makeStoreClaim(store),
+      logger,
+    });
+
+    const claimed = await q.claimNext("w1", 30);
+
+    expect(claimed.claimed).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.family-discovery-truncated",
+      expect.objectContaining({
+        maxFamilies: 16,
+        // The 17th-oldest family is the first one the bound hid.
+        nextProbeKey: "f16:svc",
+      }),
+    );
+  });
+
+  it("escapes LIKE wildcards in family clauses — a '%' family must not occlude other families from discovery", async () => {
+    // PB's `~`/`!~` build SQL `LIKE ... ESCAPE '\\'` (PocketBase 0.22
+    // tools/search/filter.go), so `\\%`/`\\_` are LITERAL chars — escapable.
+    // Unescaped, a family like "d%" makes the discovery EXCLUSION leg
+    // `probe_key !~ "d%:%"` glob-match d6:/d4: keys too, hiding those
+    // families from discovery while "d%" rows exist (starvation), and makes
+    // the inclusion/count legs over-match symmetrically.
+    const t0 = Date.parse("2026-06-04T00:00:00.000Z");
+    const mk = (id: string, probeKey: string, offsetMs: number) => ({
+      ...jobView({ id, probe_key: probeKey }),
+      payload: samplePayload({ probeKey }),
+      created: new Date(t0 + offsetMs).toISOString(),
+    });
+    const { pb, store } = makePagingPb([
+      mk("weird-a", "d%:a", 0),
+      mk("weird-b", "d%:b", 1000),
+      mk("normal", "d6:y", 2000),
+    ]);
+    const q = createFleetQueueClient({
+      pb,
+      claim: makeStoreClaim(store),
+      logger,
+    });
+
+    // The count leg must not over-match: exactly the two literal d% rows.
+    expect(await q.countPendingForFamily("d%")).toBe(2);
+    expect(await q.countPendingForFamily("d6")).toBe(1);
+
+    // Round-robin across BOTH discovered families: with the unescaped
+    // exclusion leg, d6 is never discovered while d% rows exist and the
+    // first two claims would both come from d% (d6 starved).
+    const claimedFamilies: string[] = [];
+    for (let i = 0; i < 2; i++) {
+      const c = await q.claimNext("w1", 30);
+      expect(c.claimed).toBe(true);
+      claimedFamilies.push(probeKeyFamily(c.lease!.job.probe_key));
+    }
+    expect(new Set(claimedFamilies)).toEqual(new Set(["d%", "d6"]));
   });
 
   it("countPendingForFamily explicitly requests totals (skipTotal: false) — the backlog gate must not fail open", async () => {
@@ -2048,9 +2196,12 @@ describe("FleetQueueClient.report", () => {
     });
     const q = createFleetQueueClient({ pb, claim, logger });
 
+    // The error must say what actually happened: the computed result IS
+    // discarded and the job re-runs — NOT the old "nothing was lost" framing
+    // (the ROW isn't lost, but this worker's work product is).
     await expect(
       q.report({ jobId: "j1", workerId: "worker-7", result: sampleResult() }),
-    ).rejects.toThrow(/release/i);
+    ).rejects.toThrow(/release refused .* result is DISCARDED/i);
     // A refused release must never leave a result on a row this worker no
     // longer owns — the consumer would otherwise aggregate a stale result.
     expect(rows[0].result).toBeUndefined();

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect, vi } from "vitest";
-import { createFleetQueueClient, leaseExpired } from "./queue-client.js";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  createFleetQueueClient,
+  leaseExpired,
+  PB_DATE_SEP_RE,
+} from "./queue-client.js";
 import type {
   JobClaimClient,
   ClaimResult,
@@ -16,7 +22,36 @@ import type {
   ReportJobInput,
 } from "./contracts.js";
 import { probeKeyFamily } from "./contracts.js";
-import { logger } from "../logger.js";
+import type { Logger } from "../types/index.js";
+
+/**
+ * Per-FILE SILENT logger. Deliberately NOT the shared `../logger.js` module
+ * object: spying on the shared logger leaks the spy into every other test
+ * file under fork-reuse when an assertion failure skips `mockRestore()` (the
+ * repo's known spy-leak class). Each method is a `vi.fn()` so tests can
+ * assert log emissions directly (or via `vi.spyOn`, which is now safe — the
+ * spied object is file-local). `vi.restoreAllMocks()` in `afterEach` clears
+ * call history between tests even when an assertion fails mid-test.
+ */
+const logger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+afterEach(() => {
+  // Restore any vi.spyOn wrappers FIRST (even when an assertion failure
+  // skipped an in-test mockRestore), then REBUILD the logger methods: under
+  // vitest 3 a restored spy leaves a plain (non-mock) function behind, and a
+  // shared mock would otherwise carry call history across tests. Fresh
+  // vi.fn()s per test keep every emission assertion isolated.
+  vi.restoreAllMocks();
+  logger.debug = vi.fn();
+  logger.info = vi.fn();
+  logger.warn = vi.fn();
+  logger.error = vi.fn();
+});
 
 /**
  * Pins the control-plane ↔ worker QUEUE layer (S3): FleetQueueClient layered
@@ -64,6 +99,83 @@ interface JobRow extends JobView {
 }
 
 /**
+ * Convert a PB `~`/`!~` LIKE pattern into an anchored RegExp, faithful to
+ * PocketBase 0.22's semantics: the SQL is built as `LIKE ... ESCAPE '\'`
+ * (pocketbase tools/search/filter.go), so a `\`-escaped `%`/`_` is a LITERAL
+ * character while unescaped `%`/`_` are wildcards. The fakes must honor the
+ * escape form, or a family containing a wildcard char would over-match here
+ * exactly as it would against real PB before the client escaped it.
+ */
+function likeToRegExp(pattern: string): RegExp {
+  const escapeRegExp = (ch: string): string =>
+    ch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  let out = "";
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i];
+    if (ch === "\\" && i + 1 < pattern.length) {
+      out += escapeRegExp(pattern[i + 1]);
+      i += 1;
+    } else if (ch === "%") {
+      out += ".*";
+    } else if (ch === "_") {
+      out += ".";
+    } else {
+      out += escapeRegExp(ch);
+    }
+  }
+  return new RegExp(`^${out}$`);
+}
+
+/** The row shape the shared filter matcher evaluates. */
+interface FilterableRow {
+  status: JobStatus;
+  probe_key: string;
+}
+
+/**
+ * Shared `status`/`probe_key` filter evaluation for BOTH fake PB clients
+ * (`makeFakePb` + `makePagingPb`). A clause on a field the fakes can't honor
+ * THROWS loudly — matching the fakes' own unsupported-method philosophy — so
+ * a future test exercising an unmodeled filter shape can never pass
+ * vacuously by silently matching every row.
+ */
+function rowMatchesFilter(row: FilterableRow, filter?: string): boolean {
+  if (!filter) return true;
+  for (const [, field] of filter.matchAll(
+    /([A-Za-z_][\w.]*)\s*(?:!~|!=|~|=)/g,
+  )) {
+    if (field !== "status" && field !== "probe_key") {
+      throw new Error(
+        `fake-pb: filter clause on unsupported field "${field}" — only status/probe_key are honored (filter: ${filter})`,
+      );
+    }
+  }
+  const statuses = [...filter.matchAll(/status\s*=\s*"(\w+)"/g)].map(
+    (m) => m[1],
+  );
+  if (statuses.length > 0 && !statuses.includes(row.status)) return false;
+  const clauses = [...filter.matchAll(/probe_key\s*(!~|!=|~|=)\s*"([^"]*)"/g)];
+  const negatives = clauses.filter((m) => m[1] === "!~" || m[1] === "!=");
+  const positives = clauses.filter((m) => m[1] === "~" || m[1] === "=");
+  for (const m of negatives) {
+    const matches =
+      m[1] === "!~"
+        ? likeToRegExp(m[2]).test(row.probe_key)
+        : row.probe_key === m[2];
+    if (matches) return false;
+  }
+  if (positives.length > 0) {
+    const anyMatch = positives.some((m) =>
+      m[1] === "~"
+        ? likeToRegExp(m[2]).test(row.probe_key)
+        : row.probe_key === m[2],
+    );
+    if (!anyMatch) return false;
+  }
+  return true;
+}
+
+/**
  * Minimal fake PbClient backed by an in-memory row map. Only the methods the
  * queue-client actually calls are implemented; the rest throw so an accidental
  * dependency surfaces loudly rather than silently returning undefined.
@@ -97,17 +209,12 @@ function makeFakePb(rows: JobRow[] = []): {
       _collection: string,
       opts: ListOpts = {},
     ): Promise<ListResult<T>> {
-      let items = store;
-      // Honor a `status = "x"` / `status = "x" || status = "y"` filter the way
-      // the real client would, so both the claimNext candidate scan and the
-      // sweepExpired claimed-or-running scan are exercised faithfully.
-      const matches = [
-        ...(opts.filter ?? "").matchAll(/status\s*=\s*"(\w+)"/g),
-      ];
-      if (matches.length > 0) {
-        const wanted = new Set(matches.map((mm) => mm[1]));
-        items = store.filter((r) => wanted.has(r.status));
-      }
+      // Honor `status` AND `probe_key` clauses faithfully (shared matcher) so
+      // the claimNext candidate scan, the family-discovery exclusions, and the
+      // sweepExpired scans are exercised the way real PB would serve them. A
+      // clause on any OTHER field THROWS (see rowMatchesFilter) instead of
+      // silently matching everything.
+      const items = store.filter((r) => rowMatchesFilter(r, opts.filter));
       return {
         page: 1,
         perPage: opts.perPage ?? items.length,
@@ -170,12 +277,15 @@ function sampleResult(
 ): ServiceJobResult {
   return {
     jobId: "j1",
-    probeKey: "e2e_d6:langgraph-python",
+    // NOTE the probe-key POSITION carries the `d6:<slug>` aggregate row key —
+    // `e2e_d6` is the DRIVER KIND, which must never leak into a probe key
+    // (contracts.ts: "There is NO `e2e_d6:<slug>` row in the fleet path").
+    probeKey: "d6:langgraph-python",
     serviceSlug: "langgraph-python",
     runId: "run-1",
     workerId: "worker-7",
     aggregateState: "green",
-    aggregateKey: "e2e_d6:langgraph-python",
+    aggregateKey: "d6:langgraph-python",
     aggregateSignal: { failedCount: 0 },
     cells: [],
     rollup: { total: 1, passed: 1, failed: 0 },
@@ -564,11 +674,10 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
   }
 
   /**
-   * A PAGING-FAITHFUL fake pb: unlike `makeFakePb` (which ignores `perPage` and
-   * probe_key clauses), this fake honors the parts of the PB list API the
-   * fairness fix depends on — `status` equality, `probe_key` `~`/`!~`/`=`/`!=`
-   * clauses with `%` globs, `created`/`lease_expires_at` ascending sorts, and
-   * `perPage` truncation —
+   * A PAGING-FAITHFUL fake pb: unlike `makeFakePb` (which ignores `perPage`),
+   * this fake honors the parts of the PB list API the fairness fix depends
+   * on — the shared `status`/`probe_key` clause matcher (`rowMatchesFilter`),
+   * `created`/`lease_expires_at` ascending sorts, and `perPage` truncation —
    * so the production starvation (oldest-50 page saturated by one family) is
    * reproduced faithfully.
    */
@@ -585,46 +694,12 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
     const unsupported = (name: string) => () => {
       throw new Error(`paging-pb: ${name} not implemented`);
     };
-    const globToRegExp = (pattern: string): RegExp =>
-      new RegExp(
-        `^${pattern
-          .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-          .replace(/%/g, ".*")}$`,
-      );
-    const rowMatches = (row: CreatedJobRow, filter?: string): boolean => {
-      if (!filter) return true;
-      const statuses = [...filter.matchAll(/status\s*=\s*"(\w+)"/g)].map(
-        (m) => m[1],
-      );
-      if (statuses.length > 0 && !statuses.includes(row.status)) return false;
-      const clauses = [
-        ...filter.matchAll(/probe_key\s*(!~|!=|~|=)\s*"([^"]*)"/g),
-      ];
-      const positives = clauses.filter((m) => m[1] === "~" || m[1] === "=");
-      const negatives = clauses.filter((m) => m[1] === "!~" || m[1] === "!=");
-      for (const m of negatives) {
-        const matches =
-          m[1] === "!~"
-            ? globToRegExp(m[2]).test(row.probe_key)
-            : row.probe_key === m[2];
-        if (matches) return false;
-      }
-      if (positives.length > 0) {
-        const anyMatch = positives.some((m) =>
-          m[1] === "~"
-            ? globToRegExp(m[2]).test(row.probe_key)
-            : row.probe_key === m[2],
-        );
-        if (!anyMatch) return false;
-      }
-      return true;
-    };
     const pb: PbClient = {
       async list<T>(
         _collection: string,
         opts: ListOpts = {},
       ): Promise<ListResult<T>> {
-        let items = store.filter((r) => rowMatches(r, opts.filter));
+        let items = store.filter((r) => rowMatchesFilter(r, opts.filter));
         if (opts.sort && opts.sort.includes("lease_expires_at")) {
           // PB ascending date sort; empty/null dates sort first (and a
           // null/empty lease counts as expired — leaseExpired(null) === true —
@@ -1727,21 +1802,85 @@ describe("leaseExpired (anchored PB date-separator parse)", () => {
     expect(leaseExpired("2026-06-04T00:06:00.000Z", now)).toBe(false);
   });
 
-  it("ANCHORS the space rewrite to the date/time boundary, not the FIRST space anywhere", () => {
-    // A leading-space value is NOT the canonical `^YYYY-MM-DD ` shape, so the
-    // anchored rewrite must leave it UNTOUCHED (the date/time boundary further
-    // in is preserved). A bare String.replace(" ", "T") would rewrite the
-    // LEADING space into "T2099-..." → NaN → wrongly EXPIRED. The anchored
-    // form leaves the (future, year-2099) value parseable → correctly LIVE.
-    // This pins the client to the JSVM hook's anchored regex; it FAILS under a
-    // bare first-space replace.
-    expect(leaseExpired(" 2099-01-01 00:00:00.000Z", now)).toBe(false);
+  it("ANCHORS the space rewrite to the date/time boundary, not the FIRST space anywhere (string-level pin)", () => {
+    // Pinned at the STRING level, NOT through Date.parse: the discriminating
+    // input for the anchoring (a non-canonical shape like a leading-space
+    // value) is exactly where V8 and goja — the PB JSVM — DIVERGE in parse
+    // leniency (V8 parses " 2099-01-01 00:00:00.000Z" leniently; goja's
+    // stricter Date.parse returns NaN). A Date.parse-based assertion here
+    // would pin V8-specific behavior the hook does not share. The string
+    // rewrite itself IS engine-independent and is the byte-equivalent
+    // contract with the hook's `/^(\d{4}-\d{2}-\d{2}) /` anchor.
+    //
+    // RESIDUAL ENGINE DIVERGENCE (acknowledged, not closable here): after the
+    // anchored rewrite leaves a non-canonical value untouched, V8 may still
+    // parse it (→ live) where goja yields NaN (→ expired-by-policy). Such a
+    // value can only come from a corrupted/hand-written lease column — the
+    // canonical PB date form and the ISO form parse identically in both.
+    // Canonical PB shape: ONLY the date/time-boundary space is rewritten.
+    expect("2026-06-04 00:04:00.000Z".replace(PB_DATE_SEP_RE, "$1T")).toBe(
+      "2026-06-04T00:04:00.000Z",
+    );
+    // Non-canonical (leading space): NOT anchored at `^YYYY-MM-DD ` — left
+    // UNTOUCHED. A bare String.replace(" ", "T") would have produced
+    // "T2099-01-01 00:00:00.000Z" (mangled); this FAILS under a bare replace.
+    expect(" 2099-01-01 00:00:00.000Z".replace(PB_DATE_SEP_RE, "$1T")).toBe(
+      " 2099-01-01 00:00:00.000Z",
+    );
+    // Already-ISO value: no space at the boundary, untouched.
+    expect("2026-06-04T00:06:00.000Z".replace(PB_DATE_SEP_RE, "$1T")).toBe(
+      "2026-06-04T00:06:00.000Z",
+    );
   });
 
   it("treats a genuinely-unparseable value as expired (NaN → expired, not coerced)", () => {
     // An odd shape falls through to NaN → expired BY POLICY (never wedge the
     // queue) — but only because it genuinely failed to parse, NOT because a
-    // bare first-space replace mangled it into something parseable.
+    // bare first-space replace mangled it into something parseable. Both V8
+    // and goja agree this input is unparseable (the anchored rewrite yields
+    // "2099-01-01Tgarbage").
     expect(leaseExpired("2099-01-01 garbage", now)).toBe(true);
+  });
+
+  it("treats a lease expiring EXACTLY at nowMs as EXPIRED (boundary: <=, matching the hook)", () => {
+    // Shared fixture with the JSVM hook's semantics: BOTH sides compare with
+    // `t <= now` (client `t <= nowMs`; hook `t <= Date.now()` — operator
+    // parity is pinned against the hook source below), so a lease elapsing at
+    // exactly the observation millisecond is reclaimable on both sides. A
+    // `<`/`<=` mismatch would open a 1ms window where the client reclaims a
+    // row the hook still treats as live (or vice versa).
+    const expiry = "2026-06-04 00:05:00.000Z"; // canonical PB space form
+    const expiryMs = Date.parse("2026-06-04T00:05:00.000Z");
+    expect(leaseExpired(expiry, expiryMs)).toBe(true); // t <= now → expired
+    expect(leaseExpired(expiry, expiryMs - 1)).toBe(false); // 1ms early → live
+  });
+});
+
+describe("fleet-claim.pb.js hook parity (client ↔ JSVM contract pins)", () => {
+  // The client's leaseExpired and the hook's leaseExpired must agree BYTE FOR
+  // BYTE on the anchored date rewrite and on the comparison operator — the
+  // exactly-one-winner CAS depends on both sides deciding "expired" the same
+  // way. The hook runs under goja (untestable from vitest), so these pins
+  // assert against the hook SOURCE the deploy actually ships.
+  const hookSource = readFileSync(
+    fileURLToPath(
+      new URL(
+        "../../../pocketbase/pb_hooks/fleet-claim.pb.js",
+        import.meta.url,
+      ),
+    ),
+    "utf8",
+  );
+
+  it("every handler embeds the SAME anchored date-separator regex as the client", () => {
+    // PB_DATE_SEP_RE.source is the canonical anchor; the hook defines it
+    // inline per handler (PB 0.22 pooled-runtime gotcha), 3 handlers.
+    const occurrences = hookSource.split(PB_DATE_SEP_RE.source).length - 1;
+    expect(occurrences).toBeGreaterThanOrEqual(3);
+  });
+
+  it("every handler compares lease expiry with the client's operator (t <= now)", () => {
+    const occurrences = hookSource.split("t <= Date.now()").length - 1;
+    expect(occurrences).toBeGreaterThanOrEqual(3);
   });
 });

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -68,10 +68,20 @@ afterEach(() => {
 function samplePayload(
   overrides: Partial<ServiceJobPayload> = {},
 ): ServiceJobPayload {
+  const probeKey = overrides.probeKey ?? "d6:langgraph-python";
+  // Keep driverKind CONSISTENT with the probeKey's family: the many fixtures
+  // here that override probeKey to another family (d4:, e2e-demos:, fNN:)
+  // used to inherit the d6 default driverKind ("e2e_d6"), so a future
+  // cross-validation of payload coherence (probeKey family ↔ driverKind)
+  // would mass-fail these tests. Derivation mirrors the real pairs: `d6` ↔
+  // `e2e_d6`, `e2e-demos` ↔ `e2e_demos` — underscore the family and prefix
+  // `e2e_` unless it already leads with it. Explicit overrides still win.
+  const family = probeKeyFamily(probeKey).replace(/[^a-zA-Z0-9]+/g, "_");
+  const driverKind = family.startsWith("e2e") ? family : `e2e_${family}`;
   return {
-    probeKey: "d6:langgraph-python",
+    probeKey,
     serviceSlug: "langgraph-python",
-    driverKind: "e2e_d6",
+    driverKind,
     meta: {
       runId: "run-1",
       triggered: false,

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -1403,7 +1403,7 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       };
     }
 
-    it("reclaims expired leases buried beyond the 50-row page on the FIRST sweep (lease_expires_at ascending) and warns on truncation", async () => {
+    it("reclaims expired leases buried beyond the 50-row page on the FIRST sweep (lease_expires_at ascending); a live tail is NOT a truncation warn", async () => {
       // 52 live rows inserted FIRST, 3 expired rows LAST: under insertion
       // order the perPage-50 page contains ONLY live rows, so the unsorted
       // scan misses the expired ones on every sweep (RED: zero reclaimed
@@ -1435,10 +1435,13 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       for (let i = 0; i < 3; i++) {
         expect(store.find((r) => r.id === `dead-${i}`)?.status).toBe("pending");
       }
-      // A full page means rows were truncated — that must be observable.
-      expect(warnSpy).toHaveBeenCalledWith(
+      // The page IS full, but its TAIL lease is live — under the ascending
+      // sort every truncated row beyond it is live too, so nothing expirable
+      // was hidden and the truncation warn must NOT fire (it would be a false
+      // positive at any healthy ≥50-in-flight steady state).
+      expect(warnSpy).not.toHaveBeenCalledWith(
         "queue-client.sweep-lease-page-truncated",
-        expect.objectContaining({ perPage: 50 }),
+        expect.anything(),
       );
 
       // A second sweep finds nothing further expired (and reclaims nothing
@@ -1446,6 +1449,52 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
       const sweep2 = await q.sweepExpired(NOW);
       expect(sweep2.reclaimed).toBe(0);
       warnSpy.mockRestore();
+    });
+
+    it("does NOT warn on a FULL page of exactly 50 all-live leases (healthy steady state)", async () => {
+      // Boundary: exactly perPage healthy in-flight jobs. The old any-full-page
+      // warn fired here every sweep — pure noise with nothing truncated that
+      // could matter.
+      const rows = Array.from({ length: 50 }, (_, i) =>
+        runningRow(`live-${String(i).padStart(2, "0")}`, "2026-06-04T00:06:00.000Z"),
+      );
+      const { pb, store } = makePagingPb(rows);
+      const q = createFleetQueueClient({
+        pb,
+        claim: makeStoreReleaseClaim(store),
+        logger,
+      });
+
+      const sweep = await q.sweepExpired(NOW);
+
+      expect(sweep.reclaimed).toBe(0);
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        "queue-client.sweep-lease-page-truncated",
+        expect.anything(),
+      );
+    });
+
+    it("warns on a FULL page whose TAIL lease is expired (expirable rows may lie beyond)", async () => {
+      // Boundary: exactly perPage rows, ALL expired — the tail being expired
+      // means rows beyond the page (if any) could be expired too, so the
+      // truncation is the one that matters and must be observable.
+      const rows = Array.from({ length: 50 }, (_, i) =>
+        runningRow(`dead-${String(i).padStart(2, "0")}`, "2026-06-04T00:01:00.000Z"),
+      );
+      const { pb, store } = makePagingPb(rows);
+      const q = createFleetQueueClient({
+        pb,
+        claim: makeStoreReleaseClaim(store),
+        logger,
+      });
+
+      const sweep = await q.sweepExpired(NOW);
+
+      expect(sweep.reclaimed).toBe(50);
+      expect(logger.warn).toHaveBeenCalledWith(
+        "queue-client.sweep-lease-page-truncated",
+        expect.objectContaining({ perPage: 50 }),
+      );
     });
 
     it("does NOT warn about truncation when the claimed/running page is not full", async () => {

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -7,6 +7,7 @@ import {
   PB_DATE_SEP_RE,
   RESULT_WRITE_MAX_ATTEMPTS,
 } from "./queue-client.js";
+import { JobClaimEndpointError } from "./job-claim.js";
 import type {
   JobClaimClient,
   ClaimResult,
@@ -3156,6 +3157,84 @@ describe("FleetQueueClient.sweepExpired", () => {
     expect(logger.warn).toHaveBeenCalledWith(
       "queue-client.sweep-release-threw",
       expect.objectContaining({ jobId: "j2", workerId: "w2" }),
+    );
+  });
+
+  it("a thrown release carrying a DETERMINISTIC 4xx is NOT treated as may-have-committed (no false reclaim loop)", async () => {
+    // G1d: the conservative thrown-release path assumed every throw might
+    // have committed server-side. But a 4xx is the hook REJECTING the
+    // request — deterministically NOTHING committed. The concrete trigger: a
+    // wedge row with an EMPTY claimed_by — the sweep releases on behalf of
+    // holder "" and the hook 400s (workerId required) — produced a PERMANENT
+    // per-sweep false worker-reclaimed-pending overlay for a row that never
+    // moved. A 4xx must log at error level and synthesize NOTHING: no grace,
+    // no comm error, no reclaimed++.
+    const now = Date.parse("2026-06-04T00:05:00.000Z");
+    const wedge: JobRow = {
+      ...jobView({
+        id: "j1",
+        status: "running",
+        claimed_by: "", // the wedge: no holder to authorize the re-queue
+        lease_expires_at: "2026-06-04T00:04:00.000Z",
+      }),
+      payload: samplePayload(),
+    };
+    const { pb } = makeFakePb([wedge]);
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(async (): Promise<ReleaseResult> => {
+        throw new JobClaimEndpointError(
+          "/api/fleet/release",
+          400,
+          "jobId and workerId are required",
+        );
+      }),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const sweep = await q.sweepExpired(now);
+
+    expect(sweep.reclaimed).toBe(0);
+    expect(sweep.commErrors).toHaveLength(0);
+    expect(logger.error).toHaveBeenCalledWith(
+      "queue-client.sweep-release-rejected",
+      expect.objectContaining({ jobId: "j1", status: 400 }),
+    );
+    // The conservative (may-have-committed) warn must NOT fire for a 4xx.
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      "queue-client.sweep-release-threw",
+      expect.anything(),
+    );
+  });
+
+  it("a thrown release carrying a 5xx status KEEPS the conservative may-have-committed handling", async () => {
+    const now = Date.parse("2026-06-04T00:05:00.000Z");
+    const expired: JobRow = {
+      ...jobView({
+        id: "j1",
+        status: "running",
+        claimed_by: "worker-dead",
+        lease_expires_at: "2026-06-04T00:04:00.000Z",
+      }),
+      payload: samplePayload(),
+    };
+    const { pb } = makeFakePb([expired]);
+    const claim = makeFakeClaim({
+      releaseJob: vi.fn(async (): Promise<ReleaseResult> => {
+        throw new JobClaimEndpointError("/api/fleet/release", 502, "bad gateway");
+      }),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const sweep = await q.sweepExpired(now);
+
+    // 5xx is indeterminate — the release may have committed server-side, so
+    // the comm error is synthesized anyway (at-least-once).
+    expect(sweep.reclaimed).toBe(1);
+    expect(sweep.commErrors).toHaveLength(1);
+    expect(sweep.commErrors[0].kind).toBe("worker-reclaimed-pending");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.sweep-release-threw",
+      expect.objectContaining({ jobId: "j1" }),
     );
   });
 

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -15,6 +15,7 @@ import type {
   ServiceJobResult,
   ReportJobInput,
 } from "./contracts.js";
+import { probeKeyFamily } from "./contracts.js";
 import { logger } from "../logger.js";
 
 /**
@@ -552,11 +553,10 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
   // exactly-one-winner semantics are untouched — only the candidate SELECTION
   // changed.
 
-  /** probe_key → family (prefix before the first ":"), local to these tests. */
-  const famOf = (probeKey: string): string => {
-    const idx = probeKey.indexOf(":");
-    return idx === -1 ? probeKey : probeKey.slice(0, idx);
-  };
+  // probe_key → family extraction comes from the PRODUCTION helper
+  // (`probeKeyFamily` in contracts.ts) rather than a local re-implementation,
+  // so these tests can never drift from the family rule the queue actually
+  // partitions on.
 
   /** A JobRow carrying PB's system `created` column (the paging sort key). */
   interface CreatedJobRow extends JobRow {
@@ -727,7 +727,7 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
     for (let i = 0; i < 6; i++) {
       const c = await q.claimNext("w1", 30);
       expect(c.claimed).toBe(true);
-      claimedFamilies.push(famOf(c.lease!.job.probe_key));
+      claimedFamilies.push(probeKeyFamily(c.lease!.job.probe_key));
     }
 
     // The e2e-demos jobs sit ENTIRELY outside the oldest-50 global page (60
@@ -754,7 +754,7 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
     const c = await q.claimNext("w1", 30);
 
     expect(c.claimed).toBe(true);
-    expect(famOf(c.lease!.job.probe_key)).toBe("e2e-demos");
+    expect(probeKeyFamily(c.lease!.job.probe_key)).toBe("e2e-demos");
   });
 
   it("countPendingForFamily counts ONLY that family's pending rows (producer backlog gate)", async () => {

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -713,9 +713,14 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
           items = [...items].sort((a, b) => a.created.localeCompare(b.created));
         }
         const totalItems = items.length;
-        if (opts.perPage !== undefined) items = items.slice(0, opts.perPage);
+        if (opts.perPage !== undefined) {
+          // Honor `page` (1-based) the way PB does — the stale drain advances
+          // past a full page of rows it could not act on.
+          const page = opts.page ?? 1;
+          items = items.slice((page - 1) * opts.perPage, page * opts.perPage);
+        }
         return {
-          page: 1,
+          page: opts.page ?? 1,
           perPage: opts.perPage ?? items.length,
           totalPages: 1,
           totalItems,
@@ -1139,6 +1144,41 @@ describe("FleetQueueClient — FAMILY FAIRNESS (backlogged families must not sta
 
       expect(sweep.expiredPending).toBe(120);
       expect(store).toHaveLength(0);
+    });
+
+    it("drains expirable fast-family rows occluded behind a FULL page of not-yet-expirable slow-family rows (cross-family occlusion)", async () => {
+      // Expiry is PER FAMILY but the drain's sort is absolute `created`: 50
+      // OLDER d6 rows (default 3h window — NOT expirable at 1h old) fill page
+      // 1, while YOUNGER d4 rows (45min window, 50min old — expirable) sit on
+      // page 2. An early `if (passExpired === 0) break` stops at page 1 and
+      // strands the d4 rows for the whole sweep — the exact cross-family
+      // occlusion class the multi-page drain exists to fix. A full page that
+      // produced no claim attempts must ADVANCE to the next page (still
+      // bounded by the per-sweep page cap); only a NON-FULL page proves the
+      // queue's tail was seen.
+      const slow = Array.from({ length: 50 }, (_, i) =>
+        pendingRow(`slow-${i}`, "d6:a", T - HOUR - i * 1000),
+      );
+      const fast = Array.from({ length: 10 }, (_, i) =>
+        pendingRow(`fast-${i}`, "d4:a", T - 50 * MIN + i * 1000),
+      );
+      const { pb, store } = makePagingPb([...slow, ...fast]);
+      const q = createFleetQueueClient({
+        pb,
+        claim: makeStoreClaim(store),
+        logger,
+        stalePending: { familyPeriodsMs: { d4: 15 * MIN } },
+      });
+
+      const sweep = await q.sweepExpired(T);
+
+      // All 10 expirable d4 rows reclaimed in ONE sweep…
+      expect(sweep.expiredPending).toBe(10);
+      expect(
+        store.filter((r) => r.probe_key.startsWith("d4:")),
+      ).toHaveLength(0);
+      // …and the not-yet-expirable slow family is untouched.
+      expect(store).toHaveLength(50);
     });
 
     it("caps a single sweep at 10 pages (500 rows) so one sweep cannot monopolize the producer tick", async () => {

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -2886,6 +2886,120 @@ describe("FleetQueueClient.renewLease", () => {
     expect(getOneSpy).not.toHaveBeenCalled();
   });
 
+  it("a thrown renew carrying a DETERMINISTIC 4xx is a definitive loss — evicts the caches and returns null (G1a)", async () => {
+    // The indeterminate containment above is for failures that MAY have
+    // committed (5xx / transport / 2xx-unreadable). A 4xx from the renew
+    // endpoint is the hook REJECTING the request before its transaction ran
+    // (rotated creds → auth 400s, malformed ids, route drift) — it fails
+    // IDENTICALLY on every beat, so "assumed-live, retry next beat" never
+    // converges: the worker holds a phantom lease FOREVER while the server
+    // lease lapses and the sweeper hands the job to another worker
+    // (unbounded double-run — falsifying the documented one-lease-duration
+    // risk bound). A deterministic rejection must be treated like a lost
+    // CAS: error log, evict both caches, return null so the heartbeat stops.
+    const payload = samplePayload();
+    const { pb } = makeFakePb([{ ...jobView({ id: "j1" }), payload }]);
+    const getOneSpy = vi.fn(pb.getOne.bind(pb));
+    pb.getOne = getOneSpy as PbClient["getOne"];
+    let renewMode: "reject4xx" | "win" = "reject4xx";
+    const claim = makeFakeClaim({
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({
+            id: jobId,
+            status: "claimed",
+            claimed_by: workerId,
+            lease_expires_at: "2026-06-04T00:01:00.000Z",
+            version: 1,
+          }),
+        }),
+      ),
+      renewLease: vi.fn(async (): Promise<RenewResult> => {
+        if (renewMode === "reject4xx") {
+          throw new JobClaimEndpointError(
+            "/api/fleet/renew",
+            400,
+            "workerId must be a string",
+          );
+        }
+        return {
+          renewed: true,
+          job: jobView({
+            id: "j1",
+            status: "running",
+            claimed_by: "worker-7",
+            lease_expires_at: "2026-06-04T00:02:00.000Z",
+            version: 2,
+          }),
+        };
+      }),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await q.claimNext("worker-7", 30);
+
+    // Definitive loss: null (heartbeat stops), error-level log.
+    const lost = await q.renewLease("j1", "worker-7", 30);
+    expect(lost).toBeNull();
+    expect(logger.error).toHaveBeenCalledWith(
+      "queue-client.renew-rejected",
+      expect.objectContaining({ jobId: "j1", workerId: "worker-7", status: 400 }),
+    );
+    // The assumed-live warn must NOT fire for a deterministic rejection.
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      "queue-client.renew-indeterminate",
+      expect.anything(),
+    );
+
+    // Eviction proof: a later successful renew takes the convenience RE-READ
+    // path (cache miss → pb.getOne) — a leaked cache entry would skip it.
+    renewMode = "win";
+    const lease = await q.renewLease("j1", "worker-7", 30);
+    expect(lease).not.toBeNull();
+    expect(getOneSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("a thrown renew carrying a 5xx JobClaimEndpointError KEEPS the assumed-live containment (G1a contrast)", async () => {
+    // Only the DETERMINISTIC 4xx class is carved out: a 5xx is genuinely
+    // indeterminate (the renew may have committed before the error
+    // surfaced), so the lease stays assumed-live and the next beat retries.
+    const payload = samplePayload();
+    const { pb } = makeFakePb([{ ...jobView({ id: "j1" }), payload }]);
+    const claim = makeFakeClaim({
+      claimJob: vi.fn(
+        async (jobId, workerId): Promise<ClaimResult> => ({
+          won: true,
+          job: jobView({
+            id: jobId,
+            status: "claimed",
+            claimed_by: workerId,
+            lease_expires_at: "2026-06-04T00:01:00.000Z",
+            version: 1,
+          }),
+        }),
+      ),
+      renewLease: vi.fn(async (): Promise<RenewResult> => {
+        throw new JobClaimEndpointError("/api/fleet/renew", 502, "bad gateway");
+      }),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await q.claimNext("worker-7", 30);
+
+    const kept = await q.renewLease("j1", "worker-7", 30);
+    expect(kept).not.toBeNull();
+    expect(kept?.leaseExpiresAt).toBe("2026-06-04T00:01:00.000Z");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.renew-indeterminate",
+      expect.objectContaining({ jobId: "j1" }),
+    );
+    expect(logger.error).not.toHaveBeenCalledWith(
+      "queue-client.renew-rejected",
+      expect.anything(),
+    );
+  });
+
   it("a thrown renew with NO locally-known lease still throws (nothing to assume-live from)", async () => {
     const { pb } = makeFakePb([
       { ...jobView({ id: "j1" }), payload: samplePayload() },

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -1071,28 +1071,65 @@ describe("FleetQueueClient.claimNext", () => {
     );
   });
 
-  it("releases a won-without-job row back to pending before falling through — never abandons a row this worker may own (G1e)", async () => {
+  it("contains a won-without-job breach with a TERMINAL 'failed' release + synthetic worker-protocol-violation result (G1e)", async () => {
     // won:true with NO job view violates the endpoint contract — but the
-    // CAS may genuinely have committed, so this worker may now OWN the row.
-    // Falling through silently wedged a full lease window: nobody renews or
-    // reports the orphaned claim, the sweeper later reclaims it and paints a
-    // false worker-reclaimed-pending overlay. Mirror the decode-failure
-    // containment: best-effort release back to `pending` (no work happened —
-    // unlike the decode poison row, the job itself may be perfectly
-    // runnable) before moving on.
-    const { pb } = makeFakePb([
+    // CAS may genuinely have committed, so this worker may now OWN the row
+    // under a LIVE, just-minted lease. A release back to `pending` can NEVER
+    // succeed there: the hook refuses EVERY pending-target release while the
+    // row's lease is live (refused_lease_live — no holder exemption) and
+    // refused_not_holder otherwise, so a pending-target containment is
+    // INERT — the row wedges a full lease window and the sweeper later
+    // paints a FALSE worker-reclaimed-pending overlay. A TERMINAL target
+    // passes the live-lease gate (the expiry gate only rejects EXPIRED
+    // leases), so the containment mirrors the decode-failure path: release
+    // `failed` + a synthetic worker-protocol-violation result.
+    const NOW = Date.parse("2026-06-04T00:00:00.000Z");
+    const { pb, rows } = makeFakePb([
       { ...jobView({ id: "j1" }), payload: samplePayload() },
     ]);
-    const releaseJob = vi.fn(
-      async (): Promise<ReleaseResult> => ({ released: true }),
+    const claimJob = vi.fn(
+      async (jobId: string, workerId: string): Promise<ClaimResult> => {
+        // The CAS COMMITTED (row claimed under a live lease) but the
+        // response lost its job view — the breach under containment.
+        const row = rows.find((r) => r.id === jobId)!;
+        row.status = "claimed";
+        row.claimed_by = workerId;
+        row.lease_expires_at = new Date(NOW + 30_000).toISOString();
+        return { won: true };
+      },
     );
-    const claim = makeFakeClaim({
-      releaseJob,
-      // won:true with NO job violates the endpoint contract (a win always
-      // carries the row view).
-      claimJob: vi.fn(async (): Promise<ClaimResult> => ({ won: true })),
-    });
-    const q = createFleetQueueClient({ pb, claim, logger });
+    // Hook-faithful releaseJob (fleet-claim.pb.js /api/fleet/release):
+    // authorizes on claimed_by; REFUSES a pending-target release while the
+    // CURRENT lease is live (refused_lease_live — the TOCTOU close, no
+    // holder exemption) and a terminal-target release on an EXPIRED lease
+    // (refused_not_holder). Expiry via the exported leaseExpired so the
+    // fake stays byte-equivalent with both sides of the contract.
+    const releaseJob = vi.fn(
+      async (
+        jobId: string,
+        workerId: string,
+        status: "done" | "failed" | "pending",
+      ): Promise<ReleaseResult> => {
+        const row = rows.find((r) => r.id === jobId);
+        if (!row || !["claimed", "running"].includes(row.status)) {
+          return { released: false, reason: "refused_not_holder" };
+        }
+        if (row.claimed_by !== workerId) {
+          return { released: false, reason: "refused_not_holder" };
+        }
+        if (status === "pending" && !leaseExpired(row.lease_expires_at, NOW)) {
+          return { released: false, reason: "refused_lease_live" };
+        }
+        if (status !== "pending" && leaseExpired(row.lease_expires_at, NOW)) {
+          return { released: false, reason: "refused_not_holder" };
+        }
+        row.status = status;
+        if (status === "pending") row.claimed_by = "";
+        return { released: true, job: { ...row } };
+      },
+    );
+    const claim = makeFakeClaim({ claimJob, releaseJob });
+    const q = createFleetQueueClient({ pb, claim, logger, now: () => NOW });
 
     const claimed = await q.claimNext("worker-7", 30);
 
@@ -1101,8 +1138,57 @@ describe("FleetQueueClient.claimNext", () => {
       "queue-client.claim-won-without-job",
       expect.objectContaining({ jobId: "j1" }),
     );
-    // The possibly-owned row was released back to pending (no work ran).
-    expect(releaseJob).toHaveBeenCalledWith("j1", "worker-7", "pending");
+    // TERMINAL release — never the inert pending target (the hook-faithful
+    // fake would refuse it refused_lease_live).
+    expect(releaseJob).toHaveBeenCalledWith("j1", "worker-7", "failed");
+    expect(releaseJob).not.toHaveBeenCalledWith("j1", "worker-7", "pending");
+    expect(rows[0].status).toBe("failed");
+    // The synthetic result attributes the breach honestly (the taxonomy's
+    // protocol-violation kind, never a crash synthesis) and respects the
+    // no-empty-sentinel contract (slug recovered from probe_key, minted
+    // runId).
+    const result = rows[0].result as ServiceJobResult;
+    expect(result.commError?.kind).toBe("worker-protocol-violation");
+    expect(result.jobId).toBe("j1");
+    expect(result.workerId).toBe("worker-7");
+    expect(result.aggregateState).toBe("error");
+    expect(result.aggregateKey).toBe("d6:langgraph-python");
+    expect(result.serviceSlug).toBe("langgraph-python");
+    expect(result.runId).not.toBe("");
+    expect(rows[0].result_processed).toBe(false);
+  });
+
+  it("a REFUSED won-without-job terminal release writes nothing — the CAS never actually committed (G1e)", async () => {
+    // Contrast: the breach response may ALSO mean the CAS did NOT commit
+    // (this worker never owned the row). The hook then refuses the terminal
+    // release (refused_not_holder) — warn with the threaded reason, write NO
+    // result, and fall through.
+    const { pb, rows } = makeFakePb([
+      { ...jobView({ id: "j1" }), payload: samplePayload() },
+    ]);
+    const releaseJob = vi.fn(
+      async (): Promise<ReleaseResult> => ({
+        released: false,
+        reason: "refused_not_holder",
+      }),
+    );
+    const claim = makeFakeClaim({
+      releaseJob,
+      // Breach without a commit: the row is untouched (still pending).
+      claimJob: vi.fn(async (): Promise<ClaimResult> => ({ won: true })),
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const claimed = await q.claimNext("worker-7", 30);
+
+    expect(claimed.claimed).toBe(false);
+    expect(releaseJob).toHaveBeenCalledWith("j1", "worker-7", "failed");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "queue-client.claim-won-without-job-release-refused",
+      expect.objectContaining({ jobId: "j1", reason: "refused_not_holder" }),
+    );
+    expect(rows[0].result).toBeUndefined();
+    expect(rows[0].status).toBe("pending");
   });
 
   it("a THROWN won-without-job release is swallowed with a warn — best-effort only (G1e)", async () => {

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -8,7 +8,7 @@ import {
   RESULT_WRITE_MAX_ATTEMPTS,
   RESULT_WRITE_RETRY_DELAY_MS,
 } from "./queue-client.js";
-import { JobClaimEndpointError } from "./job-claim.js";
+import { createJobClaimClient, JobClaimEndpointError } from "./job-claim.js";
 import type {
   JobClaimClient,
   ClaimResult,
@@ -3634,6 +3634,78 @@ describe("FleetQueueClient.renewLease", () => {
     );
   });
 
+  it("renew under PERSISTENT auth-400 (rotated creds) stops the heartbeat — end-to-end through the REAL job-claim client", async () => {
+    // Integration pin for the rotated-credentials path: the session token is
+    // invalidated, the renew 401s, postFleet re-auths, and the re-auth 400s.
+    // The real job-claim client must surface that as the deterministic
+    // JobClaimEndpointError class so the carve-out above fires — a plain
+    // Error routed it down the indeterminate path FOREVER (phantom
+    // assumed-live lease on every beat while the sweeper hands the job to
+    // another worker).
+    const payload = samplePayload();
+    const { pb } = makeFakePb([{ ...jobView({ id: "j1" }), payload }]);
+    let authCalls = 0;
+    const fetchImpl = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const url = String(input);
+      if (url.includes("auth-with-password")) {
+        authCalls += 1;
+        if (authCalls === 1) {
+          return new Response(JSON.stringify({ token: "tok1" }), {
+            status: 200,
+          });
+        }
+        // Creds rotated after the claim: every later auth 400s.
+        return new Response("invalid credentials", { status: 400 });
+      }
+      if (url.includes("/api/fleet/claim")) {
+        const body = JSON.parse(String(init?.body)) as {
+          jobId: string;
+          workerId: string;
+        };
+        return new Response(
+          JSON.stringify({
+            claimed: true,
+            job: jobView({
+              id: body.jobId,
+              status: "claimed",
+              claimed_by: body.workerId,
+              lease_expires_at: "2026-06-04T00:01:00.000Z",
+              version: 1,
+            }),
+          }),
+          { status: 200 },
+        );
+      }
+      // The renew under the now-invalidated token: 401 → re-auth → 400.
+      return new Response("token expired", { status: 401 });
+    }) as unknown as typeof fetch;
+    const claim = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "pw",
+      logger,
+      fetchImpl,
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const claimed = await q.claimNext("worker-7", 30);
+    expect(claimed.claimed).toBe(true);
+
+    const lost = await q.renewLease("j1", "worker-7", 30);
+    expect(lost).toBeNull();
+    expect(logger.error).toHaveBeenCalledWith(
+      "queue-client.renew-rejected",
+      expect.objectContaining({ jobId: "j1", status: 400 }),
+    );
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      "queue-client.renew-indeterminate",
+      expect.anything(),
+    );
+  });
+
   it("a thrown renew with NO locally-known lease still throws (nothing to assume-live from)", async () => {
     const { pb } = makeFakePb([
       { ...jobView({ id: "j1" }), payload: samplePayload() },
@@ -4385,6 +4457,54 @@ describe("FleetQueueClient.sweepExpired", () => {
     expect(logger.warn).toHaveBeenCalledWith(
       "queue-client.sweep-release-threw",
       expect.objectContaining({ jobId: "j1" }),
+    );
+  });
+
+  it("sweep release under auth-400 (rotated creds) takes the DETERMINISTIC branch — end-to-end through the REAL job-claim client", async () => {
+    // Integration pin for the sweep half of the rotated-credentials path: a
+    // plain auth Error fell to the conservative may-have-committed handling,
+    // synthesizing a FALSE worker-reclaimed-pending comm error on EVERY
+    // sweep for a row the release can never move.
+    const now = Date.parse("2026-06-04T00:05:00.000Z");
+    const expired: JobRow = {
+      ...jobView({
+        id: "j1",
+        status: "running",
+        claimed_by: "worker-dead",
+        lease_expires_at: "2026-06-04T00:04:00.000Z",
+      }),
+      payload: samplePayload(),
+    };
+    const { pb } = makeFakePb([expired]);
+    const fetchImpl = (async (
+      input: string | URL | Request,
+    ): Promise<Response> => {
+      if (String(input).includes("auth-with-password")) {
+        return new Response("invalid credentials", { status: 400 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+    const claim = createJobClaimClient({
+      url: "http://pb",
+      email: "a@b",
+      password: "rotated-away",
+      logger,
+      fetchImpl,
+    });
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    const sweep = await q.sweepExpired(now);
+
+    expect(sweep.reclaimed).toBe(0);
+    expect(sweep.reclaimedIndeterminate).toBe(0);
+    expect(sweep.commErrors).toHaveLength(0);
+    expect(logger.error).toHaveBeenCalledWith(
+      "queue-client.sweep-release-rejected",
+      expect.objectContaining({ jobId: "j1", status: 400 }),
+    );
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      "queue-client.sweep-release-threw",
+      expect.anything(),
     );
   });
 

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -1034,12 +1034,16 @@ export function createFleetQueueClient(
       }
       // Producer backlog gate: a totals-bearing perPage=1 list — PB computes
       // the COUNT server-side (totalItems); we never page rows back.
+      // NON-TERMINAL, not just pending: the gate bounds the family's
+      // CONCURRENT RUNS — a batch that is claimed/running is still in flight,
+      // and enqueueing a fresh batch on top of it doubles the family's
+      // concurrency (only done/failed rows stop gating).
       // skipTotal MUST be explicitly false: if totals are skipped PB returns
       // totalItems: -1, and -1 is never above the producer's backlog
       // threshold — the gate would silently FAIL OPEN and enqueue fresh
       // batches on top of an existing backlog.
       const page = await pb.list<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
-        filter: `status = "pending" && ${familyInclusionClause(family)}`,
+        filter: `(status = "pending" || status = "claimed" || status = "running") && ${familyInclusionClause(family)}`,
         perPage: 1,
         skipTotal: false,
       });

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -203,17 +203,19 @@ interface ProbeJobRecord extends JobView {
 }
 
 /**
- * Decode a row's `payload` JSON into a typed `ServiceJobPayload`. The column is
- * a structured JSON object; PB returns it already-parsed. We do a minimal
- * structural check so a malformed/absent payload fails LOUD here (at the
- * enqueue→claim boundary) rather than surfacing as an `undefined` deref deep in
- * the worker.
+ * Structurally validate an (untrusted) value as a `ServiceJobPayload`,
+ * failing LOUD with `label` naming the boundary. Shared by BOTH ends of the
+ * row round-trip so the encode and decode checks can never drift apart:
+ * `enqueue` runs it BEFORE `pb.create` (a malformed caller payload must not
+ * persist a poison row), and `decodePayload` runs it on the claimed row's
+ * JSON column.
  */
-function decodePayload(jobId: string, raw: unknown): ServiceJobPayload {
+function assertServiceJobPayload(
+  label: string,
+  raw: unknown,
+): ServiceJobPayload {
   if (raw === null || typeof raw !== "object") {
-    throw new Error(
-      `queue-client: job ${jobId} has no decodable payload on its probe_jobs row`,
-    );
+    throw new Error(`queue-client: ${label} has no decodable payload`);
   }
   const candidate = raw as Partial<ServiceJobPayload>;
   if (
@@ -223,26 +225,62 @@ function decodePayload(jobId: string, raw: unknown): ServiceJobPayload {
     candidate.meta === undefined
   ) {
     throw new Error(
-      `queue-client: job ${jobId} payload is missing required fields (probeKey/serviceSlug/driverKind/meta)`,
+      `queue-client: ${label} payload is missing required fields (probeKey/serviceSlug/driverKind/meta)`,
     );
   }
   // `meta` is typed `ServiceJobMeta`, but the JSON column is untrusted: a
   // non-object `meta` (string/number/array) satisfies the `!== undefined`
   // check above yet would deref to `undefined` deep in the worker (the
-  // aggregator groups by `meta.runId`). Assert it is a non-null object with a
-  // string `runId` and fail LOUD at this boundary.
+  // aggregator groups by `meta.runId`). Assert the FULL required meta shape —
+  // `triggered`/`enqueuedAt` are consumed downstream just like `runId`, so a
+  // half-validated meta would only defer the failure past this boundary.
   const meta = candidate.meta as Partial<ServiceJobMeta> | null;
   if (
     meta === null ||
     typeof meta !== "object" ||
     Array.isArray(meta) ||
-    typeof meta.runId !== "string"
+    typeof meta.runId !== "string" ||
+    typeof meta.triggered !== "boolean" ||
+    typeof meta.enqueuedAt !== "string"
   ) {
     throw new Error(
-      `queue-client: job ${jobId} payload.meta must be a non-null object with a string runId`,
+      `queue-client: ${label} payload.meta must be a non-null object with a string runId, boolean triggered and string enqueuedAt`,
+    );
+  }
+  // Optional fields still have REQUIRED shapes when present: cellIds is a
+  // string array (the worker iterates it as feature ids) and driverInputs is
+  // a plain record (the worker reads keys off it).
+  if (
+    candidate.cellIds !== undefined &&
+    (!Array.isArray(candidate.cellIds) ||
+      candidate.cellIds.some((c) => typeof c !== "string"))
+  ) {
+    throw new Error(
+      `queue-client: ${label} payload.cellIds must be an array of strings when present`,
+    );
+  }
+  if (
+    candidate.driverInputs !== undefined &&
+    (candidate.driverInputs === null ||
+      typeof candidate.driverInputs !== "object" ||
+      Array.isArray(candidate.driverInputs))
+  ) {
+    throw new Error(
+      `queue-client: ${label} payload.driverInputs must be a plain object when present`,
     );
   }
   return candidate as ServiceJobPayload;
+}
+
+/**
+ * Decode a row's `payload` JSON into a typed `ServiceJobPayload`. The column is
+ * a structured JSON object; PB returns it already-parsed. The structural check
+ * (shared with `enqueue` — see `assertServiceJobPayload`) makes a
+ * malformed/absent payload fail LOUD here (at the enqueue→claim boundary)
+ * rather than surfacing as an `undefined` deref deep in the worker.
+ */
+function decodePayload(jobId: string, raw: unknown): ServiceJobPayload {
+  return assertServiceJobPayload(`job ${jobId}`, raw);
 }
 
 /** Build the `JobLease` a worker holds from a claimed row + its decoded payload. */
@@ -258,6 +296,16 @@ function leaseFromJob(job: JobView, payload: ServiceJobPayload): JobLease {
  * than a null that the heartbeat would misread as a lost lease. We seed the
  * join keys from the authoritative CAS row and leave the rest empty; a renew is
  * in practice always preceded by a same-process claim, so this path is rare.
+ *
+ * WARNING — HEARTBEAT-ONLY VALUE. This placeholder must NEVER feed
+ * aggregation or be persisted as (part of) a result: `serviceSlug` and
+ * `meta.runId` are empty sentinels, and an empty runId would silently group
+ * into nothing in the aggregator (which groups by `meta.runId`) while an
+ * empty serviceSlug would corrupt the per-service rollup. The contract is:
+ * a payload obtained from a RENEW exists only to keep the lease object
+ * shape intact for the heartbeat; reporting always uses the payload the
+ * worker received from its CLAIM. (A readonly marker field would need a
+ * contracts.ts change; this comment is the boundary documentation.)
  */
 function emptyPayloadForLease(job: JobView): ServiceJobPayload {
   return {
@@ -310,24 +358,44 @@ export function leaseExpired(
 }
 
 /**
- * Escape a value for embedding in a double-quoted PB filter literal. Families
- * come from probe_key prefixes (config-controlled slugs like `d6` /
- * `e2e-demos`), so this only needs to neutralize the quote/backslash chars
- * that could break out of the literal. LIKE wildcards (`%`/`_`) are not
- * expected in family names and are deliberately left alone.
+ * Escape a value for embedding in a double-quoted PB filter literal:
+ * neutralizes the quote/backslash chars that could break out of the literal.
+ * Sufficient on its own ONLY for the equality (`=`/`!=`) legs — the LIKE
+ * (`~`/`!~`) legs must ALSO escape SQL wildcards via `escapeLikeLiteral`.
  */
 function escapeFilterLiteral(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
 /**
+ * Escape a value for a `~`/`!~` LIKE leg. VERIFIED against PocketBase
+ * 0.22.21 (tools/search/filter.go): `~` builds SQL `LIKE ... ESCAPE '\'`,
+ * and its auto-`%`-wrap is skipped when the operand contains an unescaped
+ * `%` (ours always does — the trailing `:%` wildcard), so a
+ * backslash-escaped `%`/`_` reaches SQLite as a LITERAL character. fexpr
+ * (the filter tokenizer) passes non-quote backslashes through verbatim, so
+ * the single backslash emitted here survives filter parsing intact.
+ *
+ * Without this, a family containing `%`/`_` over-matches in BOTH directions:
+ * family `d%`'s discovery EXCLUSION leg `probe_key !~ "d%:%"` also excludes
+ * `d6:`/`d4:` keys, hiding those families from the rotation while `d%` rows
+ * exist (starvation), and the inclusion/count legs over-claim/over-count
+ * symmetrically.
+ */
+function escapeLikeLiteral(value: string): string {
+  return escapeFilterLiteral(value)
+    .replace(/%/g, "\\%")
+    .replace(/_/g, "\\_");
+}
+
+/**
  * PB filter clause matching every probe_key in `family`. Keys are
- * `<family>:<slug>` (the `~` LIKE leg); a colon-less probe_key IS its own
- * family (the `=` leg) so such rows are still claimable under fairness.
+ * `<family>:<slug>` (the `~` LIKE leg, family wildcard-escaped); a colon-less
+ * probe_key IS its own family (the `=` leg) so such rows are still claimable
+ * under fairness.
  */
 function familyInclusionClause(family: string): string {
-  const esc = escapeFilterLiteral(family);
-  return `(probe_key ~ "${esc}:%" || probe_key = "${esc}")`;
+  return `(probe_key ~ "${escapeLikeLiteral(family)}:%" || probe_key = "${escapeFilterLiteral(family)}")`;
 }
 
 /**
@@ -336,8 +404,7 @@ function familyInclusionClause(family: string): string {
  * grammar has no group negation.
  */
 function familyExclusionClause(family: string): string {
-  const esc = escapeFilterLiteral(family);
-  return `probe_key !~ "${esc}:%" && probe_key != "${esc}"`;
+  return `probe_key !~ "${escapeLikeLiteral(family)}:%" && probe_key != "${escapeFilterLiteral(family)}"`;
 }
 
 /**
@@ -433,7 +500,10 @@ export function createFleetQueueClient(
   async function discoverPendingFamilies(): Promise<string[]> {
     const families: string[] = [];
     const exclusions: string[] = [];
-    for (let i = 0; i < MAX_PENDING_FAMILIES; i++) {
+    // One iteration PAST the bound: iteration MAX_PENDING_FAMILIES never adds
+    // a family — it only probes whether MORE families exist beyond the cap,
+    // so tripping the bound is observable instead of silent.
+    for (let i = 0; i <= MAX_PENDING_FAMILIES; i++) {
       const filter = ['status = "pending"', ...exclusions].join(" && ");
       const page = await pb.list<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
         filter,
@@ -443,6 +513,18 @@ export function createFleetQueueClient(
       });
       const head = page.items[0];
       if (!head) break;
+      if (i === MAX_PENDING_FAMILIES) {
+        // The bound tripped with at least one family still hidden. A
+        // silently-undiscovered family never enters the rotation — exactly
+        // the starvation class fairness exists to prevent — so mirror the
+        // sweep's truncation warn. The hidden family is still claimable on
+        // later polls once the families ahead of it drain out of pending.
+        logger.warn("queue-client.family-discovery-truncated", {
+          maxFamilies: MAX_PENDING_FAMILIES,
+          nextProbeKey: head.probe_key,
+        });
+        break;
+      }
       const family = probeKeyFamily(head.probe_key);
       // Defensive: a backend that didn't honor the exclusion clause would
       // re-yield a seen family forever — break instead of spinning.
@@ -468,6 +550,19 @@ export function createFleetQueueClient(
   return {
     async enqueue(input: EnqueueJobInput): Promise<JobView> {
       const { payload } = input;
+      // Validate BEFORE creating the row: enqueue used to deref
+      // `payload.meta.runId` only AFTER `pb.create`, so a malformed caller
+      // payload threw AFTER persisting an undecodable row — a poison row
+      // every claimer then has to win, fail to decode, and release-as-failed.
+      // Failing loud first keeps the queue clean and keeps the encode and
+      // decode boundaries byte-symmetric (same shared assertion).
+      assertServiceJobPayload(
+        `enqueue(probe_key ${String(
+          (payload as Partial<ServiceJobPayload> | null)?.probeKey ??
+            "unknown",
+        )})`,
+        payload,
+      );
       // A fresh job is `pending` with no owner and no lease. `probe_key` is the
       // join key (== payload.probeKey, the d6 aggregate row key); the work
       // rides in the `payload` JSON column for the worker to read post-claim.
@@ -732,12 +827,14 @@ export function createFleetQueueClient(
         );
         if (!result.released) {
           // The CAS refused the release — not the lease holder, or the row is
-          // no longer running (likely already swept/reclaimed). The row is NOT
-          // terminal-by-us and carries NO result, so nothing was lost: the
-          // sweeper's reclaim path (REQ-B) covers the dashboard signal. Fail
-          // loud, but flag it as "release failed (job not lost)".
+          // no longer running (likely already swept/reclaimed). The JOB is not
+          // lost (the sweeper's reclaim path, REQ-B, keeps it in flight), but
+          // this worker's COMPUTED RESULT is: it is never persisted, and the
+          // re-queued job re-runs from scratch on another claim. Say exactly
+          // that — the old "nothing was lost" framing hid a full job's worth
+          // of discarded work from the operator reading the log.
           throw new Error(
-            `queue-client: release failed (job not lost) for job ${input.jobId} (worker ${input.workerId}, status ${status}) — not the lease holder or row not running`,
+            `queue-client: release refused for job ${input.jobId} (worker ${input.workerId}, status ${status}) — not the lease holder or row not running; this worker's computed result is DISCARDED and the job re-runs after reclamation`,
           );
         }
         // PERSIST the per-service result onto the now-terminal row so the

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -797,9 +797,14 @@ export function createFleetQueueClient(
     async countPendingForFamily(family: string): Promise<number> {
       // Producer backlog gate: a totals-bearing perPage=1 list — PB computes
       // the COUNT server-side (totalItems); we never page rows back.
+      // skipTotal MUST be explicitly false: if totals are skipped PB returns
+      // totalItems: -1, and -1 is never above the producer's backlog
+      // threshold — the gate would silently FAIL OPEN and enqueue fresh
+      // batches on top of an existing backlog.
       const page = await pb.list<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
         filter: `status = "pending" && ${familyInclusionClause(family)}`,
         perPage: 1,
+        skipTotal: false,
       });
       return page.totalItems;
     },

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -256,14 +256,25 @@ function assertServiceJobPayload(
     throw new Error(`queue-client: ${label} has no decodable payload`);
   }
   const candidate = raw as Partial<ServiceJobPayload>;
+  // NON-EMPTY required (G1c): the empty string satisfies a bare typeof
+  // check but is exactly the forbidden sentinel `emptyPayloadForLease`
+  // documents — an empty runId silently groups into nothing in the
+  // aggregator, an empty serviceSlug corrupts the per-service rollup, and an
+  // empty probeKey yields the empty FAMILY whose prefix-LIKE clauses match
+  // every leading-colon key (see `familyClauseSafe`). Fail loud at BOTH
+  // boundaries (enqueue + claim decode) so the sentinels never persist or
+  // reach the worker.
   if (
     typeof candidate.probeKey !== "string" ||
+    candidate.probeKey === "" ||
     typeof candidate.serviceSlug !== "string" ||
+    candidate.serviceSlug === "" ||
     typeof candidate.driverKind !== "string" ||
+    candidate.driverKind === "" ||
     candidate.meta === undefined
   ) {
     throw new Error(
-      `queue-client: ${label} payload is missing required fields (probeKey/serviceSlug/driverKind/meta)`,
+      `queue-client: ${label} payload is missing required fields (probeKey/serviceSlug/driverKind/meta must be present and non-empty)`,
     );
   }
   // `meta` is typed `ServiceJobMeta`, but the JSON column is untrusted: a
@@ -278,11 +289,12 @@ function assertServiceJobPayload(
     typeof meta !== "object" ||
     Array.isArray(meta) ||
     typeof meta.runId !== "string" ||
+    meta.runId === "" ||
     typeof meta.triggered !== "boolean" ||
     typeof meta.enqueuedAt !== "string"
   ) {
     throw new Error(
-      `queue-client: ${label} payload.meta must be a non-null object with a string runId, boolean triggered and string enqueuedAt`,
+      `queue-client: ${label} payload.meta must be a non-null object with a non-empty string runId, boolean triggered and string enqueuedAt`,
     );
   }
   // Optional fields still have REQUIRED shapes when present: cellIds is a
@@ -427,11 +439,20 @@ export function leaseExpired(
  * VERBATIM — both cannot hold for one input, and only the `%`/`_` handling
  * has actually been verified against PB source. Probe keys are slugs in
  * practice, so rather than ship an unverifiable dual contract, callers SKIP
- * families containing a backslash (with a warn): discovery stops at one
- * (no safe exclusion clause exists), and the count gate refuses it.
+ * families containing a backslash (with a warn), and the count gate refuses
+ * them.
+ *
+ * The EMPTY family ("" — from `probeKeyFamily("")`, i.e. an empty
+ * probe_key) is ALSO clause-unsafe (G1c): it takes the prefix-LIKE leg of
+ * the builders, so `familyInclusionClause("")` is `(probe_key ~ ":%" ||
+ * probe_key = "")` — matching EVERY leading-colon key (cross-family
+ * over-claim/over-count) — and `familyExclusionClause("")` symmetrically
+ * hides ALL leading-colon families from discovery. `assertServiceJobPayload`
+ * forbids an empty probeKey at both row boundaries, so this only fires on
+ * garbage rows written outside the queue client.
  */
 function familyClauseSafe(family: string): boolean {
-  return !family.includes("\\");
+  return family !== "" && !family.includes("\\");
 }
 
 /**

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -445,17 +445,32 @@ function escapeLikeLiteral(value: string): string {
  * `<family>:<slug>` (the `~` LIKE leg, family wildcard-escaped); a colon-less
  * probe_key IS its own family (the `=` leg) so such rows are still claimable
  * under fairness.
+ *
+ * WHOLE-KEY FAMILIES MATCH BY EQUALITY ONLY (see the invariant pinned on
+ * `probeKeyFamily`): a leading-colon probe_key is its own family — the WHOLE
+ * key — so the family value itself contains colons, and the `<family>:%`
+ * LIKE leg would wrongly fold the DIFFERENT family `":foo:bar"` under
+ * `":foo"`. Such families get the equality leg only. Normal prefix families
+ * cannot contain a colon by construction, so testing for a colon is exact.
  */
 function familyInclusionClause(family: string): string {
+  if (family.includes(":")) {
+    return `probe_key = "${escapeFilterLiteral(family)}"`;
+  }
   return `(probe_key ~ "${escapeLikeLiteral(family)}:%" || probe_key = "${escapeFilterLiteral(family)}")`;
 }
 
 /**
  * PB filter clause EXCLUDING every probe_key in `family` — the complement of
  * `familyInclusionClause`, spelled with `!~`/`!=` because the PB filter
- * grammar has no group negation.
+ * grammar has no group negation. Same whole-key (colon-bearing) family
+ * special case: equality-only, or the `!~ "<family>:%"` leg would hide the
+ * unrelated family `":foo:bar"` from discovery while `":foo"` rows exist.
  */
 function familyExclusionClause(family: string): string {
+  if (family.includes(":")) {
+    return `probe_key != "${escapeFilterLiteral(family)}"`;
+  }
   return `probe_key !~ "${escapeLikeLiteral(family)}:%" && probe_key != "${escapeFilterLiteral(family)}"`;
 }
 

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -46,7 +46,12 @@
 
 import type { Logger } from "../types/index.js";
 import type { PbClient } from "../storage/pb-client.js";
-import type { JobClaimClient, JobView, ReleaseResult } from "./job-claim.js";
+import type {
+  ClaimResult,
+  JobClaimClient,
+  JobView,
+  ReleaseResult,
+} from "./job-claim.js";
 import { RELEASE_REFUSED_TERMINAL_SAME_HOLDER } from "./job-claim.js";
 import { probeKeyFamily, terminalJobStatus } from "./contracts.js";
 import type {
@@ -192,6 +197,13 @@ export interface FleetQueueClientConfig {
    * deterministic.
    */
   rng?: () => number;
+  /**
+   * Injectable clock (epoch ms) for SYNTHETIC timestamps minted by this
+   * client (the decode-failure protocol-violation result's
+   * observedAt/finishedAt). Defaults to `Date.now`. `sweepExpired` keeps its
+   * explicit `nowMs` parameter — the sweep's caller owns that clock.
+   */
+  now?: () => number;
 }
 
 /** The persisted `probe_jobs` row shape as the PB records API returns it. */
@@ -377,10 +389,27 @@ export function leaseExpired(
 }
 
 /**
+ * CHARSET GUARD for family values destined for filter clauses. The two
+ * escape helpers below carry CONTRADICTORY backslash contracts: the quoted
+ * equality legs double `\` (PB quoted-literal escaping), while the LIKE
+ * legs' verified behavior has fexpr passing non-quote backslashes through
+ * VERBATIM — both cannot hold for one input, and only the `%`/`_` handling
+ * has actually been verified against PB source. Probe keys are slugs in
+ * practice, so rather than ship an unverifiable dual contract, callers SKIP
+ * families containing a backslash (with a warn): discovery stops at one
+ * (no safe exclusion clause exists), and the count gate refuses it.
+ */
+function familyClauseSafe(family: string): boolean {
+  return !family.includes("\\");
+}
+
+/**
  * Escape a value for embedding in a double-quoted PB filter literal:
  * neutralizes the quote/backslash chars that could break out of the literal.
  * Sufficient on its own ONLY for the equality (`=`/`!=`) legs — the LIKE
  * (`~`/`!~`) legs must ALSO escape SQL wildcards via `escapeLikeLiteral`.
+ * The backslash doubling is the quoted-literal contract; backslash-bearing
+ * families never reach this function (see `familyClauseSafe`).
  */
 function escapeFilterLiteral(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
@@ -388,12 +417,13 @@ function escapeFilterLiteral(value: string): string {
 
 /**
  * Escape a value for a `~`/`!~` LIKE leg. VERIFIED against PocketBase
- * 0.22.21 (tools/search/filter.go): `~` builds SQL `LIKE ... ESCAPE '\'`,
- * and its auto-`%`-wrap is skipped when the operand contains an unescaped
- * `%` (ours always does — the trailing `:%` wildcard), so a
- * backslash-escaped `%`/`_` reaches SQLite as a LITERAL character. fexpr
- * (the filter tokenizer) passes non-quote backslashes through verbatim, so
- * the single backslash emitted here survives filter parsing intact.
+ * 0.22.21 (tools/search/filter.go) FOR `%`/`_` ONLY: `~` builds SQL
+ * `LIKE ... ESCAPE '\'`, and its auto-`%`-wrap is skipped when the operand
+ * contains an unescaped `%` (ours always does — the trailing `:%`
+ * wildcard), so a backslash-escaped `%`/`_` reaches SQLite as a LITERAL
+ * character. The BACKSLASH leg is deliberately NOT part of that
+ * verification (fexpr's quoted-literal and LIKE handling of `\` differ);
+ * backslash-bearing inputs are excluded upstream by `familyClauseSafe`.
  *
  * Without this, a family containing `%`/`_` over-matches in BOTH directions:
  * family `d%`'s discovery EXCLUSION leg `probe_key !~ "d%:%"` also excludes
@@ -446,6 +476,7 @@ export function createFleetQueueClient(
 ): FleetQueueClient {
   const { pb, claim, logger } = config;
   const rng = config.rng ?? Math.random;
+  const now = config.now ?? Date.now;
   const stalePolicy = config.stalePending ?? {};
   const staleExpiryPeriods =
     stalePolicy.expiryPeriods ?? DEFAULT_STALE_PENDING_EXPIRY_PERIODS;
@@ -546,8 +577,29 @@ export function createFleetQueueClient(
       }
       const family = probeKeyFamily(head.probe_key);
       // Defensive: a backend that didn't honor the exclusion clause would
-      // re-yield a seen family forever — break instead of spinning.
-      if (families.includes(family)) break;
+      // re-yield a seen family forever — break instead of spinning. Warn
+      // first: a silent break hides BOTH the backend defect and every
+      // family the truncated discovery never reached.
+      if (families.includes(family)) {
+        logger.warn("queue-client.family-discovery-duplicate", {
+          family,
+          probeKey: head.probe_key,
+        });
+        break;
+      }
+      // CHARSET GUARD: a family containing a backslash cannot be embedded
+      // in a filter with verified semantics (see familyClauseSafe). Without
+      // a safe EXCLUSION clause the loop cannot see past this family's rows
+      // either — warn and stop discovery here; families already discovered
+      // still rotate, and the unsafe family's rows are skipped from
+      // claiming entirely (probe keys are slugs, so this is garbage input).
+      if (!familyClauseSafe(family)) {
+        logger.warn("queue-client.family-clause-unsafe", {
+          family,
+          probeKey: head.probe_key,
+        });
+        break;
+      }
       families.push(family);
       exclusions.push(familyExclusionClause(family));
     }
@@ -662,11 +714,28 @@ export function createFleetQueueClient(
         raceLeaseSeconds: number,
       ): Promise<ClaimedJob | null> {
         for (const candidate of candidates) {
-          const result = await claim.claimJob(
-            candidate.id,
-            raceWorkerId,
-            raceLeaseSeconds,
-          );
+          // PER-CANDIDATE containment: the claim CAS can THROW (transport
+          // blip) as well as lose. An escaped throw aborts the WHOLE
+          // rotation — every remaining candidate AND every remaining family
+          // goes unclaimed this poll — for one contested row. Warn and try
+          // the next candidate instead; the row is retried naturally on the
+          // next poll. (job-claim additionally maps a 5xx claim response to
+          // won:false, so this catch covers genuine transport throws.)
+          let result: ClaimResult;
+          try {
+            result = await claim.claimJob(
+              candidate.id,
+              raceWorkerId,
+              raceLeaseSeconds,
+            );
+          } catch (err) {
+            logger.warn("queue-client.claim-cas-threw", {
+              jobId: candidate.id,
+              workerId: raceWorkerId,
+              err: err instanceof Error ? err.message : String(err),
+            });
+            continue;
+          }
           if (!result.won || !result.job) continue;
           // The CAS already WON — this worker now OWNS the row. Decoding the
           // payload from the (pre-claim) candidate row can still throw on a
@@ -706,7 +775,9 @@ export function createFleetQueueClient(
                 // honest signal. Best-effort: if the write itself is lost the
                 // consumer's crash synthesis remains the fallback — log and
                 // move on, never throw out of claimNext.
-                const observedAt = new Date().toISOString();
+                // Injected clock (config.now) — not a bare `new Date()` — so
+                // the synthetic timestamps are pinnable under test clocks.
+                const observedAt = new Date(now()).toISOString();
                 const message = `job ${result.job.id} payload failed to decode at claim time: ${
                   err instanceof Error ? err.message : String(err)
                 }`;
@@ -805,15 +876,18 @@ export function createFleetQueueClient(
       // the re-read below is a non-fatal convenience used only on a cache miss.
       let payload = payloadCache.get(jobId);
       if (!payload) {
+        // SPLIT the failure triage: a thrown pb.getOne is a transient READ
+        // BLIP (warn), but a row that reads back fine and then fails
+        // decodePayload is a PROTOCOL VIOLATION — a poison payload persisted
+        // on a live row — and triaging it under the read-blip warn hides it
+        // from protocol-violation greps. Both are non-fatal here (the CAS
+        // renew already won; the heartbeat-only empty payload covers it).
+        let record: ProbeJobRecord | null = null;
         try {
-          const record = await pb.getOne<ProbeJobRecord>(
+          record = await pb.getOne<ProbeJobRecord>(
             PROBE_JOBS_COLLECTION,
             jobId,
           );
-          if (record) {
-            payload = decodePayload(jobId, record.payload);
-            payloadCache.set(jobId, payload);
-          }
         } catch (err) {
           // Read blip — log and fall through to the cache-miss handling below.
           logger.warn("queue-client.renew-reread-failed", {
@@ -821,6 +895,18 @@ export function createFleetQueueClient(
             workerId,
             err: err instanceof Error ? err.message : String(err),
           });
+        }
+        if (record) {
+          try {
+            payload = decodePayload(jobId, record.payload);
+            payloadCache.set(jobId, payload);
+          } catch (err) {
+            logger.error("queue-client.renew-reread-protocol-violation", {
+              jobId,
+              workerId,
+              err: err instanceof Error ? err.message : String(err),
+            });
+          }
         }
       }
       if (!payload) {
@@ -934,6 +1020,15 @@ export function createFleetQueueClient(
     },
 
     async countPendingForFamily(family: string): Promise<number> {
+      // CHARSET GUARD (see familyClauseSafe): refuse to embed a backslash
+      // family in a filter with unverified semantics. Returning 0 means the
+      // producer's backlog gate opens for such a family — acceptable: the
+      // slug-based producers can never mint one, so this only fires on
+      // garbage input, and the warn makes it observable.
+      if (!familyClauseSafe(family)) {
+        logger.warn("queue-client.family-clause-unsafe", { family });
+        return 0;
+      }
       // Producer backlog gate: a totals-bearing perPage=1 list — PB computes
       // the COUNT server-side (totalItems); we never page rows back.
       // skipTotal MUST be explicitly false: if totals are skipped PB returns
@@ -1003,6 +1098,16 @@ export function createFleetQueueClient(
       }
       const commErrors: PoolCommError[] = [];
       let reclaimed = 0;
+      // SINGLE-SWEEPER ASSUMPTION (load-bearing): this grace set is
+      // per-call, IN-PROCESS state. It protects re-queued rows only from
+      // THIS control-plane's own stale phase — a SECOND concurrent sweeper
+      // (another control-plane replica running sweepExpired) would not see
+      // it and could claim-delete a row this call just re-queued,
+      // falsifying its comm error. The fleet deploys exactly ONE
+      // control-plane instance (the producer/sweeper is a singleton); if
+      // that ever changes, the grace must move to ROW state (the retained
+      // lease heuristic in the stale phase already covers the cross-call
+      // case; a requeued_at column would cover both exactly).
       const requeuedThisSweep = new Set<string>();
       const observedAt = new Date(nowMs).toISOString();
       for (const row of page.items) {

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -703,11 +703,31 @@ export function createFleetQueueClient(
       // deleted row. If the job is truly stale it ages out on the NEXT sweep.
       // (Re-anchoring the age to the re-queue time would need a column; the
       // `created` anchor is kept otherwise.)
+      //
+      // MASS-CRASH PAGING: with >CLAIM_CANDIDATE_PAGE claimed/running rows
+      // (mass worker crash), an UNSORTED single page left the contents to PB's
+      // unspecified default order — the same page of live-lease rows could
+      // come back every sweep, leaving expired leases beyond it PERMANENTLY
+      // invisible. Sorting by `lease_expires_at` ascending (indexed —
+      // idx_probe_jobs_lease; empty dates sort first, and an empty lease
+      // counts as expired) puts the most-expired rows at the head of the page,
+      // so every sweep reclaims the oldest expirations first. We deliberately
+      // KEEP the single page per sweep: the sort guarantees forward progress
+      // (each reclaim frees head slots for the next sweep), so a backlog
+      // drains progressively without unbounded pagination inside one sweep.
       const page = await pb.list<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
         filter: 'status = "claimed" || status = "running"',
+        sort: "lease_expires_at",
         perPage: CLAIM_CANDIDATE_PAGE,
         skipTotal: true,
       });
+      if (page.items.length === CLAIM_CANDIDATE_PAGE) {
+        // A full page means rows beyond it were truncated this sweep — make
+        // that observable instead of silently draining over multiple sweeps.
+        logger.warn("queue-client.sweep-lease-page-truncated", {
+          perPage: CLAIM_CANDIDATE_PAGE,
+        });
+      }
       const commErrors: PoolCommError[] = [];
       let reclaimed = 0;
       const requeuedThisSweep = new Set<string>();

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -276,7 +276,11 @@ function assertServiceJobPayload(
   label: string,
   raw: unknown,
 ): ServiceJobPayload {
-  if (raw === null || typeof raw !== "object") {
+  // An ARRAY is `typeof "object"` and (as an in-process caller value) can
+  // carry expando fields that satisfy every per-field check below — the same
+  // hole the nested meta check's Array.isArray guard closes one level down.
+  // A top-level array is never a valid payload; reject it here.
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
     throw new Error(`queue-client: ${label} has no decodable payload`);
   }
   const candidate = raw as Partial<ServiceJobPayload>;

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -942,9 +942,12 @@ export function createFleetQueueClient(
       // ("back in flight" per the worker-reclaimed-pending comm error) and
       // then immediately claimed-and-deleted by the SAME call — falsifying the
       // comm error and nulling downstream aggregate-key resolution on the
-      // deleted row. If the job is truly stale it ages out on the NEXT sweep.
-      // (Re-anchoring the age to the re-queue time would need a column; the
-      // `created` anchor is kept otherwise.)
+      // deleted row. ACROSS calls the stale phase's RECENT-LEASE heuristic
+      // (see drainStalePending) protects the same row: the release hook
+      // retains the expired lease on re-queue, so a recently-in-flight row
+      // is not expired off its original `created` age by the NEXT sweep
+      // either. (Re-anchoring the age to the re-queue time would need a
+      // column; the retained lease is the schema-free approximation.)
       //
       // MASS-CRASH PAGING: with >CLAIM_CANDIDATE_PAGE claimed/running rows
       // (mass worker crash), an UNSORTED single page left the contents to PB's
@@ -1196,6 +1199,33 @@ export function createFleetQueueClient(
             const maxAgeMs = staleExpiryPeriods * stalePeriodMsFor(family);
             const ageMs = nowMs - createdMs;
             if (ageMs <= maxAgeMs) continue;
+            // RECENT-LEASE HEURISTIC (no schema change): the age above is
+            // anchored on PB `created`, which a re-queue does NOT touch — so
+            // a job that legitimately ran LONGER than its family window
+            // comes back from the lease sweep already "stale" and would be
+            // claim-deleted by the NEXT sweep before any plausible re-run
+            // (the dashboard then permanently shows "re-queued" for
+            // silently-discarded work). The release hook RETAINS the expired
+            // lease_expires_at on a pending re-queue, so a PARSEABLE lease
+            // within the family window means the row was IN FLIGHT recently
+            // and its `created`-based age is stale evidence — skip it; it
+            // expires normally once a full window passes with no re-claim.
+            // (A `requeued_at` column would be exact; the retained lease is
+            // the schema-free approximation.) Tradeoff: a sweeper-claimed
+            // row whose delete failed also carries a recent (60s) lease
+            // after its silent re-queue, so stale GARBAGE can linger up to
+            // one extra family window before the retry delete — harmless,
+            // and the self-healing contract still holds.
+            const leaseMs = Date.parse(
+              String(row.lease_expires_at ?? "").replace(PB_DATE_SEP_RE, "$1T"),
+            );
+            if (Number.isFinite(leaseMs) && leaseMs > nowMs - maxAgeMs) {
+              logger.debug("queue-client.sweep-stale-recent-lease-skip", {
+                jobId: row.id,
+                leaseExpiresAt: row.lease_expires_at,
+              });
+              continue;
+            }
             passAttempted += 1;
             const won = await claim.claimJob(
               row.id,

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -838,13 +838,50 @@ export function createFleetQueueClient(
           }
           if (result.won && !result.job) {
             // PROTOCOL VIOLATION: a win always carries the row view (the
-            // hook builds them together inside the transaction). Falling
-            // through silently abandons a row this worker may now OWN —
-            // make the contract breach visible before moving on.
+            // hook builds them together inside the transaction). The CAS may
+            // genuinely have committed, so this worker may now OWN the row —
+            // falling through without releasing wedged a full lease window
+            // (nobody renews or reports the orphaned claim; the sweeper
+            // later reclaims it under a FALSE worker-reclaimed-pending
+            // overlay). Make the breach visible, then mirror the
+            // decode-failure containment with a best-effort release back to
+            // `pending` (no work happened, and unlike a poison payload the
+            // job itself may be perfectly runnable). Failures are
+            // swallowed+warned: if this worker did NOT actually own the row,
+            // the release is refused/4xxs and nothing changes.
             logger.warn("queue-client.claim-won-without-job", {
               jobId: candidate.id,
               workerId: raceWorkerId,
             });
+            try {
+              const released = await claim.releaseJob(
+                candidate.id,
+                raceWorkerId,
+                "pending",
+              );
+              if (!released.released) {
+                logger.warn(
+                  "queue-client.claim-won-without-job-release-refused",
+                  {
+                    jobId: candidate.id,
+                    workerId: raceWorkerId,
+                    reason: released.reason ?? "unknown",
+                  },
+                );
+              }
+            } catch (releaseErr) {
+              logger.warn(
+                "queue-client.claim-won-without-job-release-failed",
+                {
+                  jobId: candidate.id,
+                  workerId: raceWorkerId,
+                  err:
+                    releaseErr instanceof Error
+                      ? releaseErr.message
+                      : String(releaseErr),
+                },
+              );
+            }
           }
           if (!result.won || !result.job) continue;
           // The CAS already WON — this worker now OWNS the row. Decoding the

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -131,6 +131,18 @@ const STALE_PENDING_SWEEPER_ID = "stale-pending-sweeper";
 const STALE_PENDING_SWEEPER_LEASE_SECONDS = 60;
 
 /**
+ * Max candidate pages the stale-pending drain processes in ONE sweep. A
+ * single-page (50-row) sweep was far slower than the incident it exists for:
+ * against the motivating 3,734-row staging backlog at ~10 sweeps/hour that is
+ * ~7.5 HOURS of drain. 10 pages × CLAIM_CANDIDATE_PAGE (50) = up to 500
+ * expirable rows per sweep drains the same backlog in well under an hour,
+ * while still bounding a single sweep's PB load (≤10 list calls + ≤500
+ * CAS-claim+delete pairs) so one sweep cannot monopolize a producer tick.
+ * The overflow simply drains on the next sweep.
+ */
+const STALE_PENDING_MAX_PAGES_PER_SWEEP = 10;
+
+/**
  * STALE-PENDING EXPIRY policy (`sweepExpired`). A pending job that sits
  * unclaimed for `expiryPeriods` × its family's production period is expired
  * (claimed via the S0 CAS under `STALE_PENDING_SWEEPER_ID`, then deleted) so
@@ -808,78 +820,98 @@ export function createFleetQueueClient(
       // race-free) and then deleted. No comm error is synthesized: an
       // expired-pending job never ran, and its family's next batch is the
       // dashboard signal.
+      // The drain LOOPS pages (up to STALE_PENDING_MAX_PAGES_PER_SWEEP): a
+      // single 50-row page per sweep would take ~7.5h to drain the motivating
+      // 3,734-row backlog at ~10 sweeps/hour. Each pass re-lists PAGE 1 —
+      // deleting rows shifts pagination, so the next listing naturally yields
+      // the next-oldest batch. A pass that expires NOTHING terminates the
+      // loop: every remaining page-1 row was skipped (too young / unparseable
+      // / claim lost), and re-listing would return the same rows forever.
       let expiredPending = 0;
       if (staleExpiryPeriods > 0) {
-        const pendingPage = await pb.list<ProbeJobRecord>(
-          PROBE_JOBS_COLLECTION,
-          {
-            filter: 'status = "pending"',
-            sort: "created",
-            perPage: CLAIM_CANDIDATE_PAGE,
-            skipTotal: true,
-          },
-        );
-        for (const row of pendingPage.items) {
-          // ONE SWEEP OF GRACE (see function header): a row the lease phase
-          // re-queued moments ago in THIS call is "back in flight" — deleting
-          // it now would falsify the worker-reclaimed-pending comm error just
-          // emitted for it. Skip it; if truly stale it expires next sweep.
-          if (requeuedThisSweep.has(row.id)) {
-            logger.debug("queue-client.sweep-stale-grace", { jobId: row.id });
-            continue;
-          }
-          // Age off PB's system `created` (space-separated date form —
-          // normalize with the SAME anchored rewrite as leaseExpired). Unlike
-          // the lease path, an unparseable value is conservatively SKIPPED:
-          // delete is destructive, and "never wedge the queue" doesn't apply —
-          // a pending row is claimable regardless.
-          const createdMs = Date.parse(
-            String(row.created ?? "").replace(PB_DATE_SEP_RE, "$1T"),
+        for (let pass = 0; pass < STALE_PENDING_MAX_PAGES_PER_SWEEP; pass++) {
+          const pendingPage = await pb.list<ProbeJobRecord>(
+            PROBE_JOBS_COLLECTION,
+            {
+              filter: 'status = "pending"',
+              sort: "created",
+              perPage: CLAIM_CANDIDATE_PAGE,
+              skipTotal: true,
+            },
           );
-          if (Number.isNaN(createdMs)) {
-            logger.warn("queue-client.sweep-stale-unparseable-created", {
+          if (pendingPage.items.length === 0) break;
+          let passExpired = 0;
+          for (const row of pendingPage.items) {
+            // ONE SWEEP OF GRACE (see function header): a row the lease phase
+            // re-queued moments ago in THIS call is "back in flight" — deleting
+            // it now would falsify the worker-reclaimed-pending comm error just
+            // emitted for it. Skip it; if truly stale it expires next sweep.
+            // Applied on EVERY pass of the drain loop — pagination must never
+            // out-run the grace set.
+            if (requeuedThisSweep.has(row.id)) {
+              logger.debug("queue-client.sweep-stale-grace", { jobId: row.id });
+              continue;
+            }
+            // Age off PB's system `created` (space-separated date form —
+            // normalize with the SAME anchored rewrite as leaseExpired). Unlike
+            // the lease path, an unparseable value is conservatively SKIPPED:
+            // delete is destructive, and "never wedge the queue" doesn't apply —
+            // a pending row is claimable regardless.
+            const createdMs = Date.parse(
+              String(row.created ?? "").replace(PB_DATE_SEP_RE, "$1T"),
+            );
+            if (Number.isNaN(createdMs)) {
+              logger.warn("queue-client.sweep-stale-unparseable-created", {
+                jobId: row.id,
+                created: row.created ?? null,
+              });
+              continue;
+            }
+            const family = probeKeyFamily(row.probe_key);
+            const maxAgeMs = staleExpiryPeriods * stalePeriodMsFor(family);
+            const ageMs = nowMs - createdMs;
+            if (ageMs <= maxAgeMs) continue;
+            const won = await claim.claimJob(
+              row.id,
+              STALE_PENDING_SWEEPER_ID,
+              STALE_PENDING_SWEEPER_LEASE_SECONDS,
+            );
+            if (!won.won) {
+              // A worker won the race — the job is in flight after all; not
+              // ours to expire. (The row left "pending", so it also drops out
+              // of the next pass's listing — no re-processing.)
+              logger.debug("queue-client.sweep-stale-claim-lost", {
+                jobId: row.id,
+              });
+              continue;
+            }
+            try {
+              await pb.delete(PROBE_JOBS_COLLECTION, row.id);
+            } catch (err) {
+              // The row stays claimed by the sweeper; its short lease expires
+              // and the NEXT lease sweep re-queues it to pending, where a later
+              // stale sweep retries — self-healing, so log and move on.
+              logger.error("queue-client.sweep-stale-delete-failed", {
+                jobId: row.id,
+                err: err instanceof Error ? err.message : String(err),
+              });
+              continue;
+            }
+            passExpired += 1;
+            logger.warn("queue-client.sweep-expired-pending", {
               jobId: row.id,
-              created: row.created ?? null,
+              probeKey: row.probe_key,
+              family,
+              ageMs,
+              maxAgeMs,
             });
-            continue;
           }
-          const family = probeKeyFamily(row.probe_key);
-          const maxAgeMs = staleExpiryPeriods * stalePeriodMsFor(family);
-          const ageMs = nowMs - createdMs;
-          if (ageMs <= maxAgeMs) continue;
-          const won = await claim.claimJob(
-            row.id,
-            STALE_PENDING_SWEEPER_ID,
-            STALE_PENDING_SWEEPER_LEASE_SECONDS,
-          );
-          if (!won.won) {
-            // A worker won the race — the job is in flight after all; not ours
-            // to expire.
-            logger.debug("queue-client.sweep-stale-claim-lost", {
-              jobId: row.id,
-            });
-            continue;
-          }
-          try {
-            await pb.delete(PROBE_JOBS_COLLECTION, row.id);
-          } catch (err) {
-            // The row stays claimed by the sweeper; its short lease expires
-            // and the NEXT lease sweep re-queues it to pending, where a later
-            // stale sweep retries — self-healing, so log and move on.
-            logger.error("queue-client.sweep-stale-delete-failed", {
-              jobId: row.id,
-              err: err instanceof Error ? err.message : String(err),
-            });
-            continue;
-          }
-          expiredPending += 1;
-          logger.warn("queue-client.sweep-expired-pending", {
-            jobId: row.id,
-            probeKey: row.probe_key,
-            family,
-            ageMs,
-            maxAgeMs,
-          });
+          expiredPending += passExpired;
+          // No progress → every remaining pending row is non-expirable; a
+          // short page → we have already seen the queue's tail. Either way
+          // there is nothing more for THIS sweep to do.
+          if (passExpired === 0) break;
+          if (pendingPage.items.length < CLAIM_CANDIDATE_PAGE) break;
         }
       }
 

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -667,7 +667,16 @@ export function createFleetQueueClient(
       leaseSeconds: number,
     ): Promise<JobLease | null> {
       const result = await claim.renewLease(jobId, workerId, leaseSeconds);
-      if (!result.renewed || !result.job) return null;
+      if (!result.renewed || !result.job) {
+        // The renew CAS was LOST: the lease is gone for this worker (stolen,
+        // swept, or already terminal) and it will never report or renew this
+        // job again — `report()`'s finally (the only other eviction) never
+        // runs for an abandoned job, so without evicting HERE the claim-time
+        // cache entry strands forever and the per-client map grows with
+        // every lost/abandoned job.
+        payloadCache.delete(jobId);
+        return null;
+      }
       // The renew CAS already returned the authoritative lifecycle columns. The
       // payload is the only thing it omits, so prefer the claim-time cache. A
       // momentary PB read blip must NEVER turn a SUCCESSFUL renew into a thrown

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -214,6 +214,27 @@ export interface FleetQueueClientWithSweepOutcome extends FleetQueueClient {
   sweepExpired(nowMs: number): Promise<SweepResultWithIndeterminate>;
 }
 
+/**
+ * Thrown by `countPendingForFamily` when the backend hands back a non-count
+ * `totalItems` despite `skipTotal:false` — a poisoned value (-1 or garbage)
+ * is never above the producer's backlog threshold, so returning it would
+ * silently FAIL the backlog gate OPEN. A DEDICATED EXPORTED CLASS (not just
+ * message text) because the producer's gate discriminates this fail-closed
+ * class from transient read blips (fail open): an `instanceof` check cannot
+ * drift, whereas the old message-substring match would silently flip the
+ * gate fail-closed → fail-open if this message was ever reworded.
+ */
+export class PoisonedBacklogCountError extends Error {
+  constructor(family: string, totalItems: unknown) {
+    super(
+      `queue-client: countPendingForFamily("${family}") received a non-count totalItems (${String(
+        totalItems,
+      )}) despite skipTotal:false — refusing to fail the backlog gate open`,
+    );
+    this.name = "PoisonedBacklogCountError";
+  }
+}
+
 export interface FleetQueueClientConfig {
   /** Record-level PB access for enqueue (create) + queue reads (list). */
   pb: PbClient;
@@ -1505,11 +1526,7 @@ export function createFleetQueueClient(
       // the backlog gate. Refuse the poisoned value loudly.
       const totalItems: unknown = page.totalItems;
       if (typeof totalItems !== "number" || totalItems < 0) {
-        throw new Error(
-          `queue-client: countPendingForFamily("${family}") received a non-count totalItems (${String(
-            totalItems,
-          )}) despite skipTotal:false — refusing to fail the backlog gate open`,
-        );
+        throw new PoisonedBacklogCountError(family, totalItems);
       }
       return totalItems;
     },

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -1388,12 +1388,21 @@ export function createFleetQueueClient(
     },
 
     async report(input: ReportJobInput): Promise<void> {
-      // The worker is DONE with this job either way (release refused, result
-      // write exhausted, or malformed input), so always evict the cached
-      // payload before returning — a leak here would slowly grow the
-      // per-client cache across reports. EVERYTHING that can throw runs
-      // INSIDE the try (including the invariant check and the status
-      // mapping below) so the finally's eviction can never be skipped.
+      // The worker is DONE with this job on every path that REACHED the
+      // release boundary (released, release refused, result write
+      // exhausted, malformed result) — evict the cached payload + lease
+      // before returning so those paths never leak entries. ONE carve-out:
+      // the EQUALITY-INVARIANT rejection below is a malformed-INPUT refusal
+      // thrown BEFORE the release CAS — nothing was released, the worker
+      // still legitimately holds the job, and its heartbeat keeps renewing.
+      // Evicting there dropped the assumed-live lease an INDETERMINATE
+      // renew depends on, killing the heartbeat of a live job (the false
+      // worker-crashed-mid-job class the caches exist to prevent).
+      // EVERYTHING that can throw runs INSIDE the try (including the
+      // invariant check and the status mapping below) so the finally's
+      // eviction can never be ACCIDENTALLY skipped — only the flagged
+      // invariant path opts out deliberately.
+      let workerStillHoldsJob = false;
       try {
         // EQUALITY INVARIANT (contracts.ts ReportJobInput): the release CAS
         // keys on the TOP-LEVEL ids while the persisted result echoes its
@@ -1404,6 +1413,12 @@ export function createFleetQueueClient(
           input.jobId !== input.result.jobId ||
           input.workerId !== input.result.workerId
         ) {
+          // No release happened (and none will): the worker still holds the
+          // job — skip the finally's eviction. NOTE the flag flips only on
+          // THIS check passing/failing cleanly: a result so malformed the
+          // comparison itself throws (null result) still evicts, matching
+          // the malformed-result eviction contract pinned by tests.
+          workerStillHoldsJob = true;
           throw new Error(
             `queue-client: report() input violates the ReportJobInput equality invariant (jobId "${input.jobId}" vs result.jobId "${input.result.jobId}"; workerId "${input.workerId}" vs result.workerId "${input.result.workerId}") — refusing to release one row while filing the result under another`,
           );
@@ -1548,11 +1563,16 @@ export function createFleetQueueClient(
           }`,
         );
       } finally {
-        // Terminal for this worker no matter the outcome — drop the cached
-        // payload + lease here so neither a refused release nor an exhausted
-        // result write leaks the entries.
-        payloadCache.delete(input.jobId);
-        leaseCache.delete(input.jobId);
+        // Terminal for this worker on every path that reached the release
+        // boundary — drop the cached payload + lease here so neither a
+        // refused release nor an exhausted result write leaks the entries.
+        // The equality-invariant rejection is the one deliberate exception
+        // (see the header note): nothing was released, the worker still
+        // holds the job, and the heartbeat needs the caches.
+        if (!workerStillHoldsJob) {
+          payloadCache.delete(input.jobId);
+          leaseCache.delete(input.jobId);
+        }
       }
     },
 

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -681,18 +681,24 @@ export function createFleetQueueClient(
         });
         break;
       }
-      // CHARSET GUARD: a family containing a backslash cannot be embedded
-      // in a filter with verified semantics (see familyClauseSafe). Without
-      // a safe EXCLUSION clause the loop cannot see past this family's rows
-      // either — warn and stop discovery here; families already discovered
-      // still rotate, and the unsafe family's rows are skipped from
-      // claiming entirely (probe keys are slugs, so this is garbage input).
+      // CHARSET GUARD: a clause-unsafe family (backslash, or the empty
+      // family) cannot be embedded in a filter with verified semantics (see
+      // familyClauseSafe), so its rows are skipped from claiming entirely
+      // (probe keys are slugs, so this is garbage input). Discovery used to
+      // BREAK here — starving every YOUNGER family behind the offending row
+      // for up to its 3h stale window. No FAMILY exclusion clause is needed
+      // to see past it: exclude the offending ROW by id (PB system ids are
+      // generated alphanumerics — no charset semantics in play) and
+      // CONTINUE. Each unsafe row burns one discovery iteration, so a page
+      // of them is still bounded by MAX_PENDING_FAMILIES (+ its warn).
       if (!familyClauseSafe(family)) {
         logger.warn("queue-client.family-clause-unsafe", {
           family,
           probeKey: head.probe_key,
+          rowId: head.id,
         });
-        break;
+        exclusions.push(`id != "${head.id}"`);
+        continue;
       }
       families.push(family);
       exclusions.push(familyExclusionClause(family));

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -97,12 +97,69 @@ const MAX_PENDING_FAMILIES = 16;
  */
 const RESULT_WRITE_MAX_ATTEMPTS = 3;
 
+/**
+ * Default multiple of a family's production period after which an unclaimed
+ * pending job is STALE (its family has enqueued ~3 fresher batches since; the
+ * job's eventual result would be ancient data). Tunable via
+ * `StalePendingPolicy.expiryPeriods`.
+ */
+export const DEFAULT_STALE_PENDING_EXPIRY_PERIODS = 3;
+
+/**
+ * Default per-family production period used when `familyPeriodsMs` has no
+ * entry for a family — one hour, the SLOWEST fleet producer cadence (d6 +
+ * e2e-demos tick hourly), so an unconfigured family is never expired more
+ * aggressively than the slowest known one.
+ */
+export const DEFAULT_STALE_PENDING_FAMILY_PERIOD_MS = 60 * 60 * 1000;
+
+/**
+ * Synthetic workerId the stale-pending sweep claims rows under before
+ * deleting them. The claim CAS is what makes the delete race-free (a racing
+ * worker either wins the row — and the sweeper backs off — or loses it and
+ * never sees it again); the id makes the sweeper's ownership legible in the
+ * CAS audit columns while it briefly holds the row.
+ */
+const STALE_PENDING_SWEEPER_ID = "stale-pending-sweeper";
+
+/** Lease the sweeper takes on a stale row for the claim→delete window. If the
+ * delete fails the lease simply expires and the NEXT lease sweep re-queues the
+ * row to pending, where a later stale sweep retries it — self-healing. */
+const STALE_PENDING_SWEEPER_LEASE_SECONDS = 60;
+
+/**
+ * STALE-PENDING EXPIRY policy (`sweepExpired`). A pending job that sits
+ * unclaimed for `expiryPeriods` × its family's production period is expired
+ * (claimed via the S0 CAS under `STALE_PENDING_SWEEPER_ID`, then deleted) so
+ * an accumulated backlog drains STRUCTURALLY instead of waiting on 2 serial
+ * workers to chew through thousands of obsolete rows (staging hit 3,734
+ * pending, oldest 22h). The producers re-enqueue fresh batches on their
+ * normal cadence, so nothing is lost but stale work.
+ */
+export interface StalePendingPolicy {
+  /**
+   * Production period per family (ms) — how often that family's producer
+   * ticks. The wiring slot derives this from the producer crons. Families
+   * absent here use `defaultPeriodMs`.
+   */
+  familyPeriodsMs?: Record<string, number>;
+  /** Fallback period for unlisted families. Default
+   * `DEFAULT_STALE_PENDING_FAMILY_PERIOD_MS` (1h, the slowest cadence). */
+  defaultPeriodMs?: number;
+  /** Periods a pending job may age before expiry. <= 0 disables the stale
+   * sweep entirely. Default `DEFAULT_STALE_PENDING_EXPIRY_PERIODS`. */
+  expiryPeriods?: number;
+}
+
 export interface FleetQueueClientConfig {
   /** Record-level PB access for enqueue (create) + queue reads (list). */
   pb: PbClient;
   /** S0's atomic claim/renew/release primitive. */
   claim: JobClaimClient;
   logger: Logger;
+  /** Stale-pending expiry policy for `sweepExpired`. Omitted → defaults
+   * (3 × 1h for every family). See `StalePendingPolicy`. */
+  stalePending?: StalePendingPolicy;
   /**
    * Injectable RNG in [0,1) used to RANDOMIZE the candidate-attempt order in
    * `claimNext` (defaults to `Math.random`). See the claim-fairness note in
@@ -122,6 +179,9 @@ export interface FleetQueueClientConfig {
 interface ProbeJobRecord extends JobView {
   /** The serialized per-service work (migration 1779989500 adds this column). */
   payload?: unknown;
+  /** PB system timestamp (space-separated date form) — the stale-pending
+   * sweep's age anchor. */
+  created?: string;
 }
 
 /**
@@ -277,6 +337,13 @@ export function createFleetQueueClient(
 ): FleetQueueClient {
   const { pb, claim, logger } = config;
   const rng = config.rng ?? Math.random;
+  const stalePolicy = config.stalePending ?? {};
+  const staleExpiryPeriods =
+    stalePolicy.expiryPeriods ?? DEFAULT_STALE_PENDING_EXPIRY_PERIODS;
+  const staleDefaultPeriodMs =
+    stalePolicy.defaultPeriodMs ?? DEFAULT_STALE_PENDING_FAMILY_PERIOD_MS;
+  const stalePeriodMsFor = (family: string): number =>
+    stalePolicy.familyPeriodsMs?.[family] ?? staleDefaultPeriodMs;
 
   // Per-client cache of a claimed job's decoded payload, keyed by jobId. The
   // renew CAS returns the lifecycle columns but NOT the payload, and the
@@ -675,7 +742,88 @@ export function createFleetQueueClient(
           workerId: row.claimed_by,
         });
       }
-      return { reclaimed, commErrors };
+
+      // ── STALE-PENDING EXPIRY (structural backlog drain) ──────────────────
+      // A pending row had NO terminal path: the lease sweep above only touches
+      // claimed/running rows, so an accumulated backlog (staging: 3,734
+      // pending, oldest 22h) could only drain through the 2 serial workers and
+      // effectively never did. Expire pending jobs older than expiryPeriods ×
+      // their family's production period — the family has enqueued ~3 fresher
+      // batches since, so the stale job's eventual result would be ancient
+      // data. Each stale row is CLAIMED via the S0 CAS first (a racing worker
+      // either wins the row — the sweeper backs off — or loses it and never
+      // sees it again; the exactly-one-winner invariant makes the delete
+      // race-free) and then deleted. No comm error is synthesized: an
+      // expired-pending job never ran, and its family's next batch is the
+      // dashboard signal.
+      let expiredPending = 0;
+      if (staleExpiryPeriods > 0) {
+        const pendingPage = await pb.list<ProbeJobRecord>(
+          PROBE_JOBS_COLLECTION,
+          {
+            filter: 'status = "pending"',
+            sort: "created",
+            perPage: CLAIM_CANDIDATE_PAGE,
+            skipTotal: true,
+          },
+        );
+        for (const row of pendingPage.items) {
+          // Age off PB's system `created` (space-separated date form —
+          // normalize with the SAME anchored rewrite as leaseExpired). Unlike
+          // the lease path, an unparseable value is conservatively SKIPPED:
+          // delete is destructive, and "never wedge the queue" doesn't apply —
+          // a pending row is claimable regardless.
+          const createdMs = Date.parse(
+            String(row.created ?? "").replace(PB_DATE_SEP_RE, "$1T"),
+          );
+          if (Number.isNaN(createdMs)) {
+            logger.warn("queue-client.sweep-stale-unparseable-created", {
+              jobId: row.id,
+              created: row.created ?? null,
+            });
+            continue;
+          }
+          const family = probeKeyFamily(row.probe_key);
+          const maxAgeMs = staleExpiryPeriods * stalePeriodMsFor(family);
+          const ageMs = nowMs - createdMs;
+          if (ageMs <= maxAgeMs) continue;
+          const won = await claim.claimJob(
+            row.id,
+            STALE_PENDING_SWEEPER_ID,
+            STALE_PENDING_SWEEPER_LEASE_SECONDS,
+          );
+          if (!won.won) {
+            // A worker won the race — the job is in flight after all; not ours
+            // to expire.
+            logger.debug("queue-client.sweep-stale-claim-lost", {
+              jobId: row.id,
+            });
+            continue;
+          }
+          try {
+            await pb.delete(PROBE_JOBS_COLLECTION, row.id);
+          } catch (err) {
+            // The row stays claimed by the sweeper; its short lease expires
+            // and the NEXT lease sweep re-queues it to pending, where a later
+            // stale sweep retries — self-healing, so log and move on.
+            logger.error("queue-client.sweep-stale-delete-failed", {
+              jobId: row.id,
+              err: err instanceof Error ? err.message : String(err),
+            });
+            continue;
+          }
+          expiredPending += 1;
+          logger.warn("queue-client.sweep-expired-pending", {
+            jobId: row.id,
+            probeKey: row.probe_key,
+            family,
+            ageMs,
+            maxAgeMs,
+          });
+        }
+      }
+
+      return { reclaimed, commErrors, expiredPending };
     },
   };
 }

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -351,9 +351,16 @@ function assertServiceJobPayload(
       `queue-client: ${label} payload.meta must be a non-null object with a non-empty string runId, boolean triggered and non-empty string enqueuedAt`,
     );
   }
-  // Optional fields still have REQUIRED shapes when present: cellIds is a
-  // string array (the worker iterates it as feature ids) and driverInputs is
-  // a plain record (the worker reads keys off it).
+  // Optional fields still have REQUIRED shapes when present: priority is a
+  // number (copied verbatim onto the row; a future claimNext priority
+  // consumer would read it as one), cellIds is a string array (the worker
+  // iterates it as feature ids) and driverInputs is a plain record (the
+  // worker reads keys off it).
+  if (meta.priority !== undefined && typeof meta.priority !== "number") {
+    throw new Error(
+      `queue-client: ${label} payload.meta.priority must be a number when present`,
+    );
+  }
   if (
     candidate.cellIds !== undefined &&
     (!Array.isArray(candidate.cellIds) ||
@@ -453,7 +460,9 @@ function probeKeySlug(probeKey: string): string {
  * meaning — a retry can succeed — so they stay on the callers'
  * indeterminate/conservative paths (evicting a lease or skipping a comm
  * error on a momentary rate-limit blip would manufacture the exact false
- * signals the containments exist to prevent).
+ * signals the containments exist to prevent). 401 IS deterministic here:
+ * job-claim's postFleet already re-auths once on a 401 before throwing, so
+ * a 401 that reaches this predicate means fresh credentials were rejected.
  */
 function deterministicEndpointRejection(
   err: unknown,
@@ -495,7 +504,12 @@ function protocolViolationResult(args: {
     runId: `pviol_${args.jobId}`,
     workerId: args.workerId,
     aggregateState: "error",
-    aggregateKey: args.probeKey,
+    // Same defense-in-depth as the serviceSlug fallback: an EMPTY probe_key
+    // cannot reach this builder through claimNext today (the G1c charset
+    // guard skips empty-family rows at discovery), but an empty aggregate
+    // key would write a row keyed "" downstream — fall back to the
+    // jobId-derived placeholder instead of an empty sentinel.
+    aggregateKey: args.probeKey || `unknown-${args.jobId}`,
     aggregateSignal: { error: args.message },
     cells: [],
     rollup: { total: 0, passed: 0, failed: 0 },
@@ -1020,6 +1034,15 @@ export function createFleetQueueClient(
           // the next candidate instead; the row is retried naturally on the
           // next poll. (job-claim additionally maps a 5xx claim response to
           // won:false, so this catch covers genuine transport throws.)
+          //
+          // ACCEPTED REPETITION (deterministic 4xx): a hook that REJECTS
+          // this row's claim deterministically (malformed id, route drift)
+          // re-warns here on every poll until the row leaves pending — no
+          // per-row escalation state is kept. Bounded: the stale-pending
+          // sweep eventually claims-and-deletes the row (its CAS path can
+          // share the same 4xx, but the sweep's own error-level logs cover
+          // that), and a FLEET-WIDE deterministic rejection (rotated creds)
+          // already escalates via renewLease's error-level renew-rejected.
           let result: ClaimResult;
           try {
             result = await claim.claimJob(

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -740,9 +740,19 @@ export function createFleetQueueClient(
         perPage: CLAIM_CANDIDATE_PAGE,
         skipTotal: true,
       });
-      if (page.items.length === CLAIM_CANDIDATE_PAGE) {
-        // A full page means rows beyond it were truncated this sweep — make
-        // that observable instead of silently draining over multiple sweeps.
+      const pageTail = page.items[page.items.length - 1];
+      if (
+        page.items.length === CLAIM_CANDIDATE_PAGE &&
+        pageTail !== undefined &&
+        leaseExpired(pageTail.lease_expires_at, nowMs)
+      ) {
+        // A full page whose TAIL lease is already expired: under the
+        // ascending lease sort, rows truncated beyond the page may be expired
+        // too — make that observable instead of silently draining over
+        // multiple sweeps. A full page with a LIVE tail is NOT warned: every
+        // truncated row has an even later expiry, so nothing expirable was
+        // hidden (warning there would false-positive on every sweep at any
+        // healthy ≥50-in-flight steady state).
         logger.warn("queue-client.sweep-lease-page-truncated", {
           perPage: CLAIM_CANDIDATE_PAGE,
         });

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -774,8 +774,14 @@ export function createFleetQueueClient(
         // gray "re-queued / back in flight" dashboard overlay for a row that
         // was never in flight, attributed to a non-existent worker. Not
         // counted in `reclaimed` either (that count is paired 1:1 with the
-        // commErrors it documents).
+        // commErrors it documents). It DOES feed the grace set: this call's
+        // stale phase must not claim-and-delete a row the lease phase just
+        // re-queued (the retry contract is a LATER sweep — re-deleting in the
+        // same sweep would race the very lease/delete failure that put the
+        // row here), so the sweeper-retry row gets the same one sweep of
+        // grace as a worker-reclaimed row.
         if (holder === STALE_PENDING_SWEEPER_ID) {
+          requeuedThisSweep.add(row.id);
           logger.debug("queue-client.stale-sweeper-retry-requeue", {
             jobId: row.id,
           });

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -46,7 +46,7 @@
 
 import type { Logger } from "../types/index.js";
 import type { PbClient } from "../storage/pb-client.js";
-import type { JobClaimClient, JobView } from "./job-claim.js";
+import type { JobClaimClient, JobView, ReleaseResult } from "./job-claim.js";
 import { probeKeyFamily, terminalJobStatus } from "./contracts.js";
 import type {
   ClaimedJob,
@@ -760,7 +760,26 @@ export function createFleetQueueClient(
         // Re-queue on behalf of the dead holder: the CAS authorizes on
         // `claimed_by` (still the dead worker), so this atomically flips the
         // row back to pending and drops ownership.
-        const released = await claim.releaseJob(row.id, holder, "pending");
+        //
+        // PER-ROW containment (REQ-B): a release that THROWS (transport blip —
+        // distinct from a refused CAS, handled below) must not escape the
+        // loop. The producer swallows a sweepExpired throw, so an escape would
+        // discard the commErrors ALREADY synthesized for rows ALREADY released
+        // to pending in this pass — their gray "re-queued" surfaces would
+        // never reach the dashboard and are never regenerated (those rows are
+        // pending now; no later sweep re-emits them). This row's lease is
+        // still expired, so the next sweep simply retries it.
+        let released: ReleaseResult;
+        try {
+          released = await claim.releaseJob(row.id, holder, "pending");
+        } catch (err) {
+          logger.warn("queue-client.sweep-release-threw", {
+            jobId: row.id,
+            workerId: holder,
+            err: err instanceof Error ? err.message : String(err),
+          });
+          continue;
+        }
         if (!released.released) {
           // Another sweeper or a late worker report won the race — not an
           // error, just nothing for us to reclaim on this row.
@@ -840,8 +859,32 @@ export function createFleetQueueClient(
       // the next-oldest batch. A pass that expires NOTHING terminates the
       // loop: every remaining page-1 row was skipped (too young / unparseable
       // / claim lost), and re-listing would return the same rows forever.
+      // PHASE containment (REQ-B): the whole stale drain is wrapped so a
+      // throw anywhere inside it (the pending pb.list, the claim CAS — only
+      // pb.delete was caught per-row) still returns the lease phase's partial
+      // result above. The producer swallows a sweepExpired throw, so an
+      // escape here would discard every commError the lease phase just
+      // synthesized — the same dashboard-signal loss as an escaped release.
+      // The drain itself is retried in full by the next sweep.
       let expiredPending = 0;
-      if (staleExpiryPeriods > 0) {
+      try {
+        await drainStalePending();
+      } catch (err) {
+        logger.error("queue-client.sweep-stale-phase-threw", {
+          expiredPendingBeforeThrow: expiredPending,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      return { reclaimed, commErrors, expiredPending };
+
+      /**
+       * The stale-pending drain loop (see the STALE-PENDING EXPIRY comment
+       * above). Mutates the enclosing `expiredPending` PER ROW (not per pass)
+       * so the partial count survives a mid-pass throw.
+       */
+      async function drainStalePending(): Promise<void> {
+        if (staleExpiryPeriods <= 0) return;
         for (let pass = 0; pass < STALE_PENDING_MAX_PAGES_PER_SWEEP; pass++) {
           const pendingPage = await pb.list<ProbeJobRecord>(
             PROBE_JOBS_COLLECTION,
@@ -911,6 +954,9 @@ export function createFleetQueueClient(
               continue;
             }
             passExpired += 1;
+            // Per ROW (not per pass) so a mid-pass throw caught by the phase
+            // wrapper still reports the rows already expired.
+            expiredPending += 1;
             logger.warn("queue-client.sweep-expired-pending", {
               jobId: row.id,
               probeKey: row.probe_key,
@@ -919,7 +965,6 @@ export function createFleetQueueClient(
               maxAgeMs,
             });
           }
-          expiredPending += passExpired;
           // No progress → every remaining pending row is non-expirable; a
           // short page → we have already seen the queue's tail. Either way
           // there is nothing more for THIS sweep to do.
@@ -927,8 +972,6 @@ export function createFleetQueueClient(
           if (pendingPage.items.length < CLAIM_CANDIDATE_PAGE) break;
         }
       }
-
-      return { reclaimed, commErrors, expiredPending };
     },
   };
 }

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -190,6 +190,30 @@ export interface StalePendingPolicy {
   expiryPeriods?: number;
 }
 
+/**
+ * `SweepResult` plus the AT-LEAST-ONCE split (G1g): `reclaimed` counts only
+ * CAS-CONFIRMED re-queues, while the conservative thrown-release maybes
+ * (timeout-after-commit — the release may or may not have committed; a comm
+ * error is synthesized either way) ride `reclaimedIndeterminate`. Summing the
+ * two recovers the old over-counting behavior; consumers that alert on
+ * reclaim counts should treat the indeterminate share as "at least zero, at
+ * most this many" extra re-queues.
+ *
+ * The contracts-level `SweepResult`/`TickResult` are sibling-owned: once
+ * `TickResult` gains the field, the producer threads it with a one-liner
+ * (`reclaimedIndeterminate: sweep.reclaimedIndeterminate`) where it copies
+ * `sweep.reclaimed` today.
+ */
+export interface SweepResultWithIndeterminate extends SweepResult {
+  /** Thrown-release conservative maybes (at-least-once; see above). */
+  reclaimedIndeterminate: number;
+}
+
+/** `FleetQueueClient` with this implementation's richer sweep result. */
+export interface FleetQueueClientWithSweepOutcome extends FleetQueueClient {
+  sweepExpired(nowMs: number): Promise<SweepResultWithIndeterminate>;
+}
+
 export interface FleetQueueClientConfig {
   /** Record-level PB access for enqueue (create) + queue reads (list). */
   pb: PbClient;
@@ -548,7 +572,7 @@ function shuffleInPlace<T>(arr: T[], rng: () => number): T[] {
 
 export function createFleetQueueClient(
   config: FleetQueueClientConfig,
-): FleetQueueClient {
+): FleetQueueClientWithSweepOutcome {
   const { pb, claim, logger } = config;
   const rng = config.rng ?? Math.random;
   const now = config.now ?? Date.now;
@@ -588,9 +612,11 @@ export function createFleetQueueClient(
    * TERMINAL probe_jobs row — the SEPARATE record write that follows a
    * release CAS (migration 1779989700 adds `result` + `result_processed`).
    * Never throws: returns `{ ok: true }` on success, or `{ ok: false,
-   * lastErr }` after RESULT_WRITE_MAX_ATTEMPTS attempts so each caller
-   * decides whether the loss is fatal (`report` — distinct "result lost"
-   * error) or best-effort (the decode-failure attribution in `claimNext`).
+   * lastErr }` after RESULT_WRITE_MAX_ATTEMPTS attempts so the caller
+   * decides what the loss means (`report` — distinct "result lost" error).
+   * Used by `report()` ONLY: the decode-failure attribution in `claimNext`
+   * is a deliberate single-attempt write (its retry pacing would stall the
+   * claim race, and the consumer's crash synthesis is its backstop).
    * `result_processed` seeds false: the consumer latches it true after
    * aggregating exactly once.
    */
@@ -971,19 +997,27 @@ export function createFleetQueueClient(
                     observedAt,
                   },
                 };
-                const write = await writeResult(
-                  result.job.id,
-                  raceWorkerId,
-                  violation,
-                );
-                if (!write.ok) {
+                // SINGLE attempt (G1g) — deliberately NOT writeResult's
+                // bounded retry + 250ms pacing: this write happens INSIDE
+                // the claim race, so each retry pause stalls the whole
+                // candidate rotation (up to 500ms per poison row per poll).
+                // The write is best-effort with a documented backstop — a
+                // lost write leaves a terminal resultless row the consumer
+                // synthesizes a crash result for past grace — so one try +
+                // the lost warn is the right trade.
+                try {
+                  await pb.update(PROBE_JOBS_COLLECTION, result.job.id, {
+                    result: violation,
+                    result_processed: false,
+                  });
+                } catch (writeErr) {
                   logger.warn("queue-client.claim-decode-result-write-lost", {
                     jobId: result.job.id,
                     workerId: raceWorkerId,
                     err:
-                      write.lastErr instanceof Error
-                        ? write.lastErr.message
-                        : String(write.lastErr),
+                      writeErr instanceof Error
+                        ? writeErr.message
+                        : String(writeErr),
                   });
                 }
               }
@@ -1194,6 +1228,12 @@ export function createFleetQueueClient(
             // exhausted the result write). The result is still THIS holder's
             // to write — proceed to writeResult instead of falsely declaring
             // it discarded; this is what makes report() retryable.
+            //
+            // DEPLOY SKEW: retryability depends on the HOOK threading this
+            // reason. Against an older fleet-claim.pb.js (no reason field)
+            // the same retry takes the generic-refusal throw below instead
+            // — fail-closed (the result is declared discarded), never a
+            // blind write. Roll the hook out before (or with) the harness.
             logger.warn("queue-client.release-refused-terminal-same-holder", {
               jobId: input.jobId,
               workerId: input.workerId,
@@ -1215,6 +1255,11 @@ export function createFleetQueueClient(
             //     retryability contract).
             // A failed read must NOT fall through to a blind write — throw
             // loud; report() stays retryable and the next retry re-reads.
+            // That includes a getOne that RESOLVES NULL (missing/unreadable
+            // row): semantically a failed read, not "no result present".
+            // And PB's unset-JSON shape reads back as "" — treat it as
+            // ABSENT so the retry still lands its result instead of
+            // skipping the write against an empty column.
             let existing: ProbeJobRecord | null;
             try {
               existing = await pb.getOne<ProbeJobRecord>(
@@ -1228,10 +1273,15 @@ export function createFleetQueueClient(
                 }`,
               );
             }
+            if (existing === null) {
+              throw new Error(
+                `queue-client: cannot verify existing result for job ${input.jobId} (worker ${input.workerId}) before retry rewrite — the pre-write read returned no row; refusing to blind-write`,
+              );
+            }
             if (
-              existing &&
               existing.result !== undefined &&
-              existing.result !== null
+              existing.result !== null &&
+              existing.result !== ""
             ) {
               logger.info(
                 existing.result_processed === true
@@ -1350,7 +1400,7 @@ export function createFleetQueueClient(
       return totalItems;
     },
 
-    async sweepExpired(nowMs: number): Promise<SweepResult> {
+    async sweepExpired(nowMs: number): Promise<SweepResultWithIndeterminate> {
       // Scan claimed/running rows for expired leases (crashed/unreachable
       // workers). PB lacks an OR-of-equals shortcut here, so list both running
       // states and filter by lease in-process.
@@ -1412,6 +1462,13 @@ export function createFleetQueueClient(
       }
       const commErrors: PoolCommError[] = [];
       let reclaimed = 0;
+      // AT-LEAST-ONCE SPLIT (G1g): thrown-release conservative maybes are
+      // counted HERE, not in `reclaimed` — a throw that did NOT commit
+      // would otherwise over-count confirmed reclaims (the count consumers
+      // alert on), while the comm errors deliberately keep their
+      // at-least-once duplication. commErrors length (excluding
+      // sweeper-held rows) = reclaimed + reclaimedIndeterminate.
+      let reclaimedIndeterminate = 0;
       // SINGLE-SWEEPER ASSUMPTION (load-bearing): this grace set is
       // per-call, IN-PROCESS state. It protects re-queued rows only from
       // THIS control-plane's own stale phase — a SECOND concurrent sweeper
@@ -1571,7 +1628,7 @@ export function createFleetQueueClient(
           });
           requeuedThisSweep.add(row.id);
           if (holder !== STALE_PENDING_SWEEPER_ID) {
-            reclaimed += 1;
+            reclaimedIndeterminate += 1;
             commErrors.push({
               kind: "worker-reclaimed-pending",
               message: `lease for job ${row.id} expired (worker ${holder || "unknown"} reclaimed); re-queue release threw mid-flight — conservatively reported as re-queued (at-least-once)`,
@@ -1599,8 +1656,9 @@ export function createFleetQueueClient(
         // SILENT: synthesizing `worker-reclaimed-pending` here would paint a
         // gray "re-queued / back in flight" dashboard overlay for a row that
         // was never in flight, attributed to a non-existent worker. Not
-        // counted in `reclaimed` either (that count is paired 1:1 with the
-        // commErrors it documents). It DOES feed the grace set: this call's
+        // counted in `reclaimed` either (reclaimed + reclaimedIndeterminate
+        // are paired 1:1 with the commErrors they document). It DOES feed
+        // the grace set: this call's
         // stale phase must not claim-and-delete a row the lease phase just
         // re-queued (the retry contract is a LATER sweep — re-deleting in the
         // same sweep would race the very lease/delete failure that put the
@@ -1683,7 +1741,7 @@ export function createFleetQueueClient(
         });
       }
 
-      return { reclaimed, commErrors, expiredPending };
+      return { reclaimed, reclaimedIndeterminate, commErrors, expiredPending };
 
       /**
        * The stale-pending drain loop (see the STALE-PENDING EXPIRY comment
@@ -1741,21 +1799,23 @@ export function createFleetQueueClient(
             if (ageMs <= maxAgeMs) continue;
             // RECENT-LEASE HEURISTIC (no schema change): the age above is
             // anchored on PB `created`, which a re-queue does NOT touch — so
-            // a job that legitimately ran LONGER than its family window
-            // comes back from the lease sweep already "stale" and would be
-            // claim-deleted by the NEXT sweep before any plausible re-run
-            // (the dashboard then permanently shows "re-queued" for
-            // silently-discarded work). The release hook RETAINS the expired
-            // lease_expires_at on a pending re-queue, so a PARSEABLE lease
-            // within the family window means the row was IN FLIGHT recently
-            // and its `created`-based age is stale evidence — skip it; it
-            // expires normally once a full window passes with no re-claim.
-            // (A `requeued_at` column would be exact; the retained lease is
-            // the schema-free approximation.) Tradeoff: a sweeper-claimed
-            // row whose delete failed also carries a recent (60s) lease
-            // after its silent re-queue, so stale GARBAGE can linger up to
-            // one extra family window before the retry delete — harmless,
-            // and the self-healing contract still holds.
+            // a job that legitimately ran LONGER than its family's STALE
+            // WINDOW (`maxAgeMs` = expiryPeriods × the family period — 3
+            // periods by default, NOT one) comes back from the lease sweep
+            // already "stale" and would be claim-deleted by the NEXT sweep
+            // before any plausible re-run (the dashboard then permanently
+            // shows "re-queued" for silently-discarded work). The release
+            // hook RETAINS the expired lease_expires_at on a pending
+            // re-queue, so a PARSEABLE lease within that stale window means
+            // the row was IN FLIGHT recently and its `created`-based age is
+            // stale evidence — skip it; it expires normally once a full
+            // stale window passes with no re-claim. (A `requeued_at` column
+            // would be exact; the retained lease is the schema-free
+            // approximation.) Tradeoff: a sweeper-claimed row whose delete
+            // failed also carries a recent (60s) lease after its silent
+            // re-queue, so stale GARBAGE can linger up to one extra stale
+            // window before the retry delete — harmless, and the
+            // self-healing contract still holds.
             const leaseMs = Date.parse(
               String(row.lease_expires_at ?? "").replace(PB_DATE_SEP_RE, "$1T"),
             );
@@ -1838,6 +1898,14 @@ export function createFleetQueueClient(
           // occlusion; see the drain header). Otherwise rows left pending and
           // pagination shifted back, so re-list the SAME page index to see
           // the shifted-in batch.
+          //
+          // PAGE-ADVANCE INDETERMINACY (accepted): a claim that THREW is not
+          // counted in passAttempted, but it may still have COMMITTED
+          // server-side (thrown-but-committed) — the row then LEFT pending
+          // and pagination shifted even though this pass looks attempt-free,
+          // so an advance here can skip shifted-in rows for the REST of this
+          // sweep. Bounded and self-healing: the next sweep re-lists from
+          // page 1 and re-evaluates everything skipped.
           if (passAttempted === 0) listPage += 1;
         }
       }

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -976,8 +976,22 @@ export function createFleetQueueClient(
         // discard the commErrors ALREADY synthesized for rows ALREADY released
         // to pending in this pass — their gray "re-queued" surfaces would
         // never reach the dashboard and are never regenerated (those rows are
-        // pending now; no later sweep re-emits them). This row's lease is
-        // still expired, so the next sweep simply retries it.
+        // pending now; no later sweep re-emits them).
+        //
+        // TIMEOUT-AFTER-COMMIT (at-least-once): a thrown release may have
+        // COMMITTED server-side before the response was lost — the row IS
+        // pending then, so (a) the SAME call's stale phase could
+        // claim-and-delete it unless it is in the grace set, and (b) its
+        // worker-reclaimed-pending comm error would be lost FOREVER (the row
+        // is pending; no later sweep re-emits it — the file's own contract
+        // above). So treat a thrown release CONSERVATIVELY as if it
+        // committed: grace the row and synthesize the comm error anyway. If
+        // the release did NOT commit, the next sweep retries the
+        // still-expired lease and a DUPLICATE gray "re-queued" overlay may
+        // render — harmless; a MISSING one is not. Sweeper-held rows stay
+        // silent (mirroring the committed path below). The known-refused CAS
+        // (`released: false`) stays a clean skip — only the indeterminate
+        // throw gets the conservative treatment.
         let released: ReleaseResult;
         try {
           released = await claim.releaseJob(row.id, holder, "pending");
@@ -987,6 +1001,17 @@ export function createFleetQueueClient(
             workerId: holder,
             err: err instanceof Error ? err.message : String(err),
           });
+          requeuedThisSweep.add(row.id);
+          if (holder !== STALE_PENDING_SWEEPER_ID) {
+            reclaimed += 1;
+            commErrors.push({
+              kind: "worker-reclaimed-pending",
+              message: `lease for job ${row.id} expired (worker ${holder || "unknown"} reclaimed); re-queue release threw mid-flight — conservatively reported as re-queued (at-least-once)`,
+              workerId: holder || undefined,
+              jobId: row.id,
+              observedAt,
+            });
+          }
           continue;
         }
         if (!released.released) {

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -217,6 +217,10 @@ interface ProbeJobRecord extends JobView {
   /** PB system timestamp (space-separated date form) — the stale-pending
    * sweep's age anchor. */
   created?: string;
+  /** Result-flow columns (migration 1779989700) — read by report()'s
+   * retry-idempotency guard before any rewrite. */
+  result?: unknown;
+  result_processed?: boolean;
 }
 
 /**
@@ -1022,6 +1026,48 @@ export function createFleetQueueClient(
               workerId: input.workerId,
               status,
             });
+            // RETRY IDEMPOTENCY (double-count guard): this refusal means an
+            // EARLIER report() attempt already released the row — and may
+            // ALSO have already written the result. writeResult always seeds
+            // `result_processed: false`, so a blind rewrite here would
+            // UN-LATCH a result the consumer already aggregated (it latches
+            // result_processed true after aggregating exactly once) and the
+            // same result would be counted TWICE. Read the row first:
+            //   - result present + processed   → fully done; skip the write.
+            //   - result present + unprocessed → awaiting aggregation; the
+            //     rewrite is at best a no-op and at worst races the
+            //     consumer's read→aggregate→latch mid-flight; skip it.
+            //   - no result                    → the first attempt's write
+            //     never landed; fall through to writeResult (the original
+            //     retryability contract).
+            // A failed read must NOT fall through to a blind write — throw
+            // loud; report() stays retryable and the next retry re-reads.
+            let existing: ProbeJobRecord | null;
+            try {
+              existing = await pb.getOne<ProbeJobRecord>(
+                PROBE_JOBS_COLLECTION,
+                input.jobId,
+              );
+            } catch (err) {
+              throw new Error(
+                `queue-client: cannot verify existing result for job ${input.jobId} (worker ${input.workerId}) before retry rewrite — refusing to blind-write (a rewrite could un-latch result_processed and double-count): ${
+                  err instanceof Error ? err.message : String(err)
+                }`,
+              );
+            }
+            if (
+              existing &&
+              existing.result !== undefined &&
+              existing.result !== null
+            ) {
+              logger.info(
+                existing.result_processed === true
+                  ? "queue-client.result-already-aggregated"
+                  : "queue-client.result-already-written",
+                { jobId: input.jobId, workerId: input.workerId, status },
+              );
+              return;
+            }
           } else {
             // The CAS refused the release — not the (effective) lease holder,
             // or the row was swept/stolen. The JOB is not lost (the sweeper's

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -960,6 +960,31 @@ export function createFleetQueueClient(
       try {
         result = await claim.renewLease(jobId, workerId, leaseSeconds);
       } catch (err) {
+        // DETERMINISTIC 4xx (mirrors the sweep's G1d carve-out): the hook
+        // REJECTED the request before its transaction ran (rotated creds →
+        // auth 400s, malformed ids, route drift) — it fails IDENTICALLY on
+        // every beat, so the assumed-live containment below would never
+        // converge: the worker holds a phantom lease FOREVER while the
+        // server lease lapses and the sweeper hands the job to another
+        // worker — UNBOUNDED double-run, falsifying the one-lease-duration
+        // risk bound documented below. Treat it like a definitively lost
+        // CAS: error log (an operator must look — the rejection recurs),
+        // evict both caches, return null so the heartbeat stops.
+        if (
+          err instanceof JobClaimEndpointError &&
+          err.status >= 400 &&
+          err.status < 500
+        ) {
+          logger.error("queue-client.renew-rejected", {
+            jobId,
+            workerId,
+            status: err.status,
+            err: err.message,
+          });
+          payloadCache.delete(jobId);
+          leaseCache.delete(jobId);
+          return null;
+        }
         // INDETERMINATE renew (thrown 5xx / transport blip / job-claim's
         // 2xx-unreadable): the renew may or may not have committed. The
         // worker heartbeat treats a renewLease THROW as fatal (it breaks),
@@ -967,7 +992,8 @@ export function createFleetQueueClient(
         // reclaims a possibly-LIVE job — a false worker-crashed-mid-job.
         // Contain it: keep the last-known lease ASSUMED-LIVE (no eviction,
         // not null) so the heartbeat retries on the next beat; only a
-        // definitive `renewed: false` stops it.
+        // definitive `renewed: false` (or a deterministic 4xx above) stops
+        // it.
         //
         // ACCEPTED RISK (at most one lease duration): if the renew really
         // did NOT commit, the server-side lease keeps ticking toward its

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -618,9 +618,7 @@ function escapeFilterLiteral(value: string): string {
  * symmetrically.
  */
 function escapeLikeLiteral(value: string): string {
-  return escapeFilterLiteral(value)
-    .replace(/%/g, "\\%")
-    .replace(/_/g, "\\_");
+  return escapeFilterLiteral(value).replace(/%/g, "\\%").replace(/_/g, "\\_");
 }
 
 /**
@@ -942,8 +940,7 @@ export function createFleetQueueClient(
       // decode boundaries byte-symmetric (same shared assertion).
       assertServiceJobPayload(
         `enqueue(probe_key ${String(
-          (payload as Partial<ServiceJobPayload> | null)?.probeKey ??
-            "unknown",
+          (payload as Partial<ServiceJobPayload> | null)?.probeKey ?? "unknown",
         )})`,
         payload,
       );
@@ -1133,17 +1130,14 @@ export function createFleetQueueClient(
                 }
               }
             } catch (releaseErr) {
-              logger.warn(
-                "queue-client.claim-won-without-job-release-failed",
-                {
-                  jobId: candidate.id,
-                  workerId: raceWorkerId,
-                  err:
-                    releaseErr instanceof Error
-                      ? releaseErr.message
-                      : String(releaseErr),
-                },
-              );
+              logger.warn("queue-client.claim-won-without-job-release-failed", {
+                jobId: candidate.id,
+                workerId: raceWorkerId,
+                err:
+                  releaseErr instanceof Error
+                    ? releaseErr.message
+                    : String(releaseErr),
+              });
             }
           }
           if (!result.won || !result.job) continue;
@@ -1410,7 +1404,10 @@ export function createFleetQueueClient(
         // rejection, or the renewed-without-job breach with nothing cached
         // (all handled above).
         logger.warn("queue-client.renew-no-payload", { jobId, workerId });
-        const fallback = leaseFromJob(result.job, emptyPayloadForLease(result.job));
+        const fallback = leaseFromJob(
+          result.job,
+          emptyPayloadForLease(result.job),
+        );
         leaseCache.set(jobId, fallback);
         return fallback;
       }
@@ -1672,526 +1669,526 @@ export function createFleetQueueClient(
   async function runSweepExpired(
     nowMs: number,
   ): Promise<SweepResultWithIndeterminate> {
-      // Scan claimed/running rows for expired leases (crashed/unreachable
-      // workers). PB lacks an OR-of-equals shortcut here, so list both running
-      // states and filter by lease in-process.
-      //
-      // ONE SWEEP OF GRACE: rows the lease phase re-queues below are tracked
-      // and EXCLUDED from this call's stale-pending phase. The stale phase
-      // ages off PB's system `created` (the ORIGINAL enqueue time — re-queue
-      // does not touch it), so a long-claimed job would otherwise be re-queued
-      // ("back in flight" per the worker-reclaimed-pending comm error) and
-      // then immediately claimed-and-deleted by the SAME call — falsifying the
-      // comm error and nulling downstream aggregate-key resolution on the
-      // deleted row. ACROSS calls the protection is split by HOW LONG the
-      // lease has been expired: a RECENTLY-expired lease (within the stale
-      // window) is re-queued, and the stale phase's RECENT-LEASE heuristic
-      // (see drainStalePending) protects it on later sweeps — the release
-      // hook retains the expired lease on re-queue, so a recently-in-flight
-      // row is not expired off its original `created` age by the NEXT sweep.
-      // A lease expired LONGER than the stale window on a stale-aged row is
-      // PAST that heuristic's reach: re-queueing it would emit a "back in
-      // flight" signal the NEXT sweep falsifies by claim-deleting the row —
-      // so the lease phase claim-deletes it DIRECTLY (G1d), with no comm
-      // error (the work is discarded, not re-run). (Re-anchoring the age to
-      // the re-queue time would need a column; the retained lease is the
-      // schema-free approximation.)
-      //
-      // MASS-CRASH PAGING: with >CLAIM_CANDIDATE_PAGE claimed/running rows
-      // (mass worker crash), an UNSORTED single page left the contents to PB's
-      // unspecified default order — the same page of live-lease rows could
-      // come back every sweep, leaving expired leases beyond it PERMANENTLY
-      // invisible. Sorting by `lease_expires_at` ascending (indexed —
-      // idx_probe_jobs_lease; empty dates sort first, and an empty lease
-      // counts as expired) puts the most-expired rows at the head of the page,
-      // so every sweep reclaims the oldest expirations first. We deliberately
-      // KEEP the single page per sweep: the sort guarantees forward progress
-      // (each reclaim frees head slots for the next sweep), so a backlog
-      // drains progressively without unbounded pagination inside one sweep.
-      const page = await pb.list<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
-        filter: 'status = "claimed" || status = "running"',
-        sort: "lease_expires_at",
+    // Scan claimed/running rows for expired leases (crashed/unreachable
+    // workers). PB lacks an OR-of-equals shortcut here, so list both running
+    // states and filter by lease in-process.
+    //
+    // ONE SWEEP OF GRACE: rows the lease phase re-queues below are tracked
+    // and EXCLUDED from this call's stale-pending phase. The stale phase
+    // ages off PB's system `created` (the ORIGINAL enqueue time — re-queue
+    // does not touch it), so a long-claimed job would otherwise be re-queued
+    // ("back in flight" per the worker-reclaimed-pending comm error) and
+    // then immediately claimed-and-deleted by the SAME call — falsifying the
+    // comm error and nulling downstream aggregate-key resolution on the
+    // deleted row. ACROSS calls the protection is split by HOW LONG the
+    // lease has been expired: a RECENTLY-expired lease (within the stale
+    // window) is re-queued, and the stale phase's RECENT-LEASE heuristic
+    // (see drainStalePending) protects it on later sweeps — the release
+    // hook retains the expired lease on re-queue, so a recently-in-flight
+    // row is not expired off its original `created` age by the NEXT sweep.
+    // A lease expired LONGER than the stale window on a stale-aged row is
+    // PAST that heuristic's reach: re-queueing it would emit a "back in
+    // flight" signal the NEXT sweep falsifies by claim-deleting the row —
+    // so the lease phase claim-deletes it DIRECTLY (G1d), with no comm
+    // error (the work is discarded, not re-run). (Re-anchoring the age to
+    // the re-queue time would need a column; the retained lease is the
+    // schema-free approximation.)
+    //
+    // MASS-CRASH PAGING: with >CLAIM_CANDIDATE_PAGE claimed/running rows
+    // (mass worker crash), an UNSORTED single page left the contents to PB's
+    // unspecified default order — the same page of live-lease rows could
+    // come back every sweep, leaving expired leases beyond it PERMANENTLY
+    // invisible. Sorting by `lease_expires_at` ascending (indexed —
+    // idx_probe_jobs_lease; empty dates sort first, and an empty lease
+    // counts as expired) puts the most-expired rows at the head of the page,
+    // so every sweep reclaims the oldest expirations first. We deliberately
+    // KEEP the single page per sweep: the sort guarantees forward progress
+    // (each reclaim frees head slots for the next sweep), so a backlog
+    // drains progressively without unbounded pagination inside one sweep.
+    const page = await pb.list<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
+      filter: 'status = "claimed" || status = "running"',
+      sort: "lease_expires_at",
+      perPage: CLAIM_CANDIDATE_PAGE,
+      skipTotal: true,
+    });
+    const pageTail = page.items[page.items.length - 1];
+    if (
+      page.items.length === CLAIM_CANDIDATE_PAGE &&
+      pageTail !== undefined &&
+      leaseExpired(pageTail.lease_expires_at, nowMs)
+    ) {
+      // A full page whose TAIL lease is already expired: under the
+      // ascending lease sort, rows truncated beyond the page may be expired
+      // too — make that observable instead of silently draining over
+      // multiple sweeps. A full page with a LIVE tail is NOT warned: every
+      // truncated row has an even later expiry, so nothing expirable was
+      // hidden (warning there would false-positive on every sweep at any
+      // healthy ≥50-in-flight steady state).
+      logger.warn("queue-client.sweep-lease-page-truncated", {
         perPage: CLAIM_CANDIDATE_PAGE,
-        skipTotal: true,
       });
-      const pageTail = page.items[page.items.length - 1];
-      if (
-        page.items.length === CLAIM_CANDIDATE_PAGE &&
-        pageTail !== undefined &&
-        leaseExpired(pageTail.lease_expires_at, nowMs)
-      ) {
-        // A full page whose TAIL lease is already expired: under the
-        // ascending lease sort, rows truncated beyond the page may be expired
-        // too — make that observable instead of silently draining over
-        // multiple sweeps. A full page with a LIVE tail is NOT warned: every
-        // truncated row has an even later expiry, so nothing expirable was
-        // hidden (warning there would false-positive on every sweep at any
-        // healthy ≥50-in-flight steady state).
-        logger.warn("queue-client.sweep-lease-page-truncated", {
-          perPage: CLAIM_CANDIDATE_PAGE,
-        });
+    }
+    const commErrors: PoolCommError[] = [];
+    let reclaimed = 0;
+    // AT-LEAST-ONCE SPLIT (G1g): thrown-release conservative maybes are
+    // counted HERE, not in `reclaimed` — a throw that did NOT commit
+    // would otherwise over-count confirmed reclaims (the count consumers
+    // alert on), while the comm errors deliberately keep their
+    // at-least-once duplication. commErrors length (excluding
+    // sweeper-held rows) = reclaimed + reclaimedIndeterminate.
+    let reclaimedIndeterminate = 0;
+    // GRACE-SET SCOPE (load-bearing): this set is per-call, IN-PROCESS
+    // state — it protects re-queued rows only from THIS sweep pass's own
+    // stale phase. IN-PROCESS concurrency is real (runControlPlane wires
+    // FOUR family producers over one queue client, and overlapping crons
+    // can call sweepExpired concurrently) and is closed by the
+    // CONCURRENT-SWEEP LATCH in `sweepExpired`: an overlapping caller
+    // piggybacks on the in-flight pass instead of racing this set.
+    // CROSS-PROCESS concurrency (a second control-plane REPLICA) is NOT
+    // covered — the fleet deploys exactly ONE control-plane instance; if
+    // that ever changes, the grace must move to ROW state (the retained
+    // lease heuristic in the stale phase already covers the cross-call
+    // case; a requeued_at column would cover both exactly).
+    const requeuedThisSweep = new Set<string>();
+    const observedAt = new Date(nowMs).toISOString();
+    // Stale expiries (deleted rows). Declared here — not at the stale
+    // phase — because the lease phase's long-expired carve-out below also
+    // deletes (G1d); both phases feed the same count.
+    let expiredPending = 0;
+    for (const row of page.items) {
+      if (!leaseExpired(row.lease_expires_at, nowMs)) continue;
+      // Snapshot the holder BEFORE the release CAS: the release drops
+      // ownership, and the special-case + comm-error attribution below must
+      // reflect who HELD the expired lease, not the post-release row.
+      const holder = row.claimed_by;
+      // LONG-EXPIRED CARVE-OUT (G1d): a row that is ALREADY
+      // stale-expirable — created-age past its family's stale window AND
+      // its lease expired LONGER than that window — is past the
+      // recent-lease heuristic's protection (see the header). Re-queueing
+      // it would emit a "back in flight" comm error the NEXT sweep
+      // falsifies by claim-deleting the row off its original `created`
+      // age. Delete it HERE, claim-first like the stale phase (the claim
+      // CAS admits an expired-lease claimed/running row — its reclaim
+      // safety net — so the delete stays race-free). No comm error and no
+      // reclaimed++: the work is discarded, not re-run. The carve-out
+      // requires a PARSEABLE created — an unparseable created stays on
+      // the conservative re-queue path below, and that COMPOSES honestly:
+      // the stale phase skips unparseable-created rows too, so the
+      // re-queued row stays claimable and "back in flight" stays true. An
+      // UNPARSEABLE (or empty) lease is the opposite: it carries no
+      // recent-flight evidence EITHER phase can honor — the stale phase's
+      // recent-lease protection needs a finite lease — so re-queueing
+      // would emit a "back in flight" signal the next sweep falsifies by
+      // claim-deleting the row off its stale created age. Treat it as
+      // long-expired and delete it HERE, so the emitted signal (none)
+      // matches the eventual outcome (discard). Sweeper-held rows
+      // (stale garbage mid-deletion, 60s lease) are always RECENTLY
+      // expired, so they keep their silent re-queue retry contract.
+      if (staleExpiryPeriods > 0 && holder !== STALE_PENDING_SWEEPER_ID) {
+        const family = probeKeyFamily(row.probe_key);
+        const maxAgeMs = staleExpiryPeriods * stalePeriodMsFor(family);
+        const createdMs = Date.parse(
+          String(row.created ?? "").replace(PB_DATE_SEP_RE, "$1T"),
+        );
+        const leaseMs = Date.parse(
+          String(row.lease_expires_at ?? "").replace(PB_DATE_SEP_RE, "$1T"),
+        );
+        const staleExpirable =
+          !Number.isNaN(createdMs) &&
+          nowMs - createdMs > maxAgeMs &&
+          (!Number.isFinite(leaseMs) || leaseMs <= nowMs - maxAgeMs);
+        if (staleExpirable) {
+          // PER-ROW containment mirrors the stale phase: a thrown claim is
+          // indeterminate (skip this sweep; the row is unchanged for the
+          // next), a lost claim means a peer acted on the row, and a
+          // failed delete leaves the row sweeper-claimed — its short lease
+          // expires and the silent re-queue + later stale sweep retry the
+          // delete (the existing self-healing contract).
+          let won: ClaimResult;
+          try {
+            won = await claim.claimJob(
+              row.id,
+              STALE_PENDING_SWEEPER_ID,
+              STALE_PENDING_SWEEPER_LEASE_SECONDS,
+            );
+          } catch (err) {
+            logger.warn("queue-client.sweep-lease-stale-claim-threw", {
+              jobId: row.id,
+              err: err instanceof Error ? err.message : String(err),
+            });
+            continue;
+          }
+          if (!won.won) {
+            logger.debug("queue-client.sweep-lease-stale-claim-lost", {
+              jobId: row.id,
+            });
+            continue;
+          }
+          try {
+            await pb.delete(PROBE_JOBS_COLLECTION, row.id);
+          } catch (err) {
+            logger.error("queue-client.sweep-lease-stale-delete-failed", {
+              jobId: row.id,
+              err: err instanceof Error ? err.message : String(err),
+            });
+            continue;
+          }
+          // COUNT-NAME CAVEAT: despite the name, `expiredPending` here
+          // counts a CLAIMED/RUNNING row (long-expired lease, stale
+          // created-age) deleted by this carve-out — not just stale
+          // PENDING rows from the drain phase. The shared contract doc
+          // (`SweepResult.expiredPending` in contracts.ts) documents this
+          // lease-phase carve-out explicitly — the two sides agree.
+          expiredPending += 1;
+          logger.warn("queue-client.sweep-lease-stale-deleted", {
+            jobId: row.id,
+            probeKey: row.probe_key,
+            family,
+            workerId: holder,
+            maxAgeMs,
+          });
+          continue;
+        }
       }
-      const commErrors: PoolCommError[] = [];
-      let reclaimed = 0;
-      // AT-LEAST-ONCE SPLIT (G1g): thrown-release conservative maybes are
-      // counted HERE, not in `reclaimed` — a throw that did NOT commit
-      // would otherwise over-count confirmed reclaims (the count consumers
-      // alert on), while the comm errors deliberately keep their
-      // at-least-once duplication. commErrors length (excluding
-      // sweeper-held rows) = reclaimed + reclaimedIndeterminate.
-      let reclaimedIndeterminate = 0;
-      // GRACE-SET SCOPE (load-bearing): this set is per-call, IN-PROCESS
-      // state — it protects re-queued rows only from THIS sweep pass's own
-      // stale phase. IN-PROCESS concurrency is real (runControlPlane wires
-      // FOUR family producers over one queue client, and overlapping crons
-      // can call sweepExpired concurrently) and is closed by the
-      // CONCURRENT-SWEEP LATCH in `sweepExpired`: an overlapping caller
-      // piggybacks on the in-flight pass instead of racing this set.
-      // CROSS-PROCESS concurrency (a second control-plane REPLICA) is NOT
-      // covered — the fleet deploys exactly ONE control-plane instance; if
-      // that ever changes, the grace must move to ROW state (the retained
-      // lease heuristic in the stale phase already covers the cross-call
-      // case; a requeued_at column would cover both exactly).
-      const requeuedThisSweep = new Set<string>();
-      const observedAt = new Date(nowMs).toISOString();
-      // Stale expiries (deleted rows). Declared here — not at the stale
-      // phase — because the lease phase's long-expired carve-out below also
-      // deletes (G1d); both phases feed the same count.
-      let expiredPending = 0;
-      for (const row of page.items) {
-        if (!leaseExpired(row.lease_expires_at, nowMs)) continue;
-        // Snapshot the holder BEFORE the release CAS: the release drops
-        // ownership, and the special-case + comm-error attribution below must
-        // reflect who HELD the expired lease, not the post-release row.
-        const holder = row.claimed_by;
-        // LONG-EXPIRED CARVE-OUT (G1d): a row that is ALREADY
-        // stale-expirable — created-age past its family's stale window AND
-        // its lease expired LONGER than that window — is past the
-        // recent-lease heuristic's protection (see the header). Re-queueing
-        // it would emit a "back in flight" comm error the NEXT sweep
-        // falsifies by claim-deleting the row off its original `created`
-        // age. Delete it HERE, claim-first like the stale phase (the claim
-        // CAS admits an expired-lease claimed/running row — its reclaim
-        // safety net — so the delete stays race-free). No comm error and no
-        // reclaimed++: the work is discarded, not re-run. The carve-out
-        // requires a PARSEABLE created — an unparseable created stays on
-        // the conservative re-queue path below, and that COMPOSES honestly:
-        // the stale phase skips unparseable-created rows too, so the
-        // re-queued row stays claimable and "back in flight" stays true. An
-        // UNPARSEABLE (or empty) lease is the opposite: it carries no
-        // recent-flight evidence EITHER phase can honor — the stale phase's
-        // recent-lease protection needs a finite lease — so re-queueing
-        // would emit a "back in flight" signal the next sweep falsifies by
-        // claim-deleting the row off its stale created age. Treat it as
-        // long-expired and delete it HERE, so the emitted signal (none)
-        // matches the eventual outcome (discard). Sweeper-held rows
-        // (stale garbage mid-deletion, 60s lease) are always RECENTLY
-        // expired, so they keep their silent re-queue retry contract.
-        if (staleExpiryPeriods > 0 && holder !== STALE_PENDING_SWEEPER_ID) {
-          const family = probeKeyFamily(row.probe_key);
-          const maxAgeMs = staleExpiryPeriods * stalePeriodMsFor(family);
-          const createdMs = Date.parse(
-            String(row.created ?? "").replace(PB_DATE_SEP_RE, "$1T"),
-          );
-          const leaseMs = Date.parse(
-            String(row.lease_expires_at ?? "").replace(PB_DATE_SEP_RE, "$1T"),
-          );
-          const staleExpirable =
-            !Number.isNaN(createdMs) &&
-            nowMs - createdMs > maxAgeMs &&
-            (!Number.isFinite(leaseMs) || leaseMs <= nowMs - maxAgeMs);
-          if (staleExpirable) {
-            // PER-ROW containment mirrors the stale phase: a thrown claim is
-            // indeterminate (skip this sweep; the row is unchanged for the
-            // next), a lost claim means a peer acted on the row, and a
-            // failed delete leaves the row sweeper-claimed — its short lease
-            // expires and the silent re-queue + later stale sweep retry the
-            // delete (the existing self-healing contract).
-            let won: ClaimResult;
-            try {
-              won = await claim.claimJob(
-                row.id,
-                STALE_PENDING_SWEEPER_ID,
-                STALE_PENDING_SWEEPER_LEASE_SECONDS,
-              );
-            } catch (err) {
-              logger.warn("queue-client.sweep-lease-stale-claim-threw", {
-                jobId: row.id,
-                err: err instanceof Error ? err.message : String(err),
-              });
-              continue;
-            }
-            if (!won.won) {
-              logger.debug("queue-client.sweep-lease-stale-claim-lost", {
-                jobId: row.id,
-              });
-              continue;
-            }
-            try {
-              await pb.delete(PROBE_JOBS_COLLECTION, row.id);
-            } catch (err) {
-              logger.error("queue-client.sweep-lease-stale-delete-failed", {
-                jobId: row.id,
-                err: err instanceof Error ? err.message : String(err),
-              });
-              continue;
-            }
-            // COUNT-NAME CAVEAT: despite the name, `expiredPending` here
-            // counts a CLAIMED/RUNNING row (long-expired lease, stale
-            // created-age) deleted by this carve-out — not just stale
-            // PENDING rows from the drain phase. The shared contract doc
-            // (`SweepResult.expiredPending` in contracts.ts) documents this
-            // lease-phase carve-out explicitly — the two sides agree.
-            expiredPending += 1;
-            logger.warn("queue-client.sweep-lease-stale-deleted", {
-              jobId: row.id,
-              probeKey: row.probe_key,
-              family,
-              workerId: holder,
-              maxAgeMs,
-            });
-            continue;
-          }
-        }
-        // Re-queue on behalf of the dead holder: the CAS authorizes on
-        // `claimed_by` (still the dead worker), so this atomically flips the
-        // row back to pending and drops ownership.
-        //
-        // PER-ROW containment (REQ-B): a release that THROWS (transport blip —
-        // distinct from a refused CAS, handled below) must not escape the
-        // loop. The producer swallows a sweepExpired throw, so an escape would
-        // discard the commErrors ALREADY synthesized for rows ALREADY released
-        // to pending in this pass — their gray "re-queued" surfaces would
-        // never reach the dashboard and are never regenerated (those rows are
-        // pending now; no later sweep re-emits them).
-        //
-        // TIMEOUT-AFTER-COMMIT (at-least-once): a thrown release may have
-        // COMMITTED server-side before the response was lost — the row IS
-        // pending then, so (a) the SAME call's stale phase could
-        // claim-and-delete it unless it is in the grace set, and (b) its
-        // worker-reclaimed-pending comm error would be lost FOREVER (the row
-        // is pending; no later sweep re-emits it — the file's own contract
-        // above). So treat a thrown release CONSERVATIVELY as if it
-        // committed: grace the row and synthesize the comm error anyway. If
-        // the release did NOT commit, the next sweep retries the
-        // still-expired lease and a DUPLICATE gray "re-queued" overlay may
-        // render — harmless; a MISSING one is not. Sweeper-held rows stay
-        // silent (mirroring the committed path below). The known-refused CAS
-        // (`released: false`) stays a clean skip, and a DETERMINISTIC 4xx
-        // (the hook rejected the request — nothing committed) is carved out
-        // below — only the genuinely indeterminate throw (5xx / transport /
-        // 2xx-unreadable) gets the conservative treatment.
-        let released: ReleaseResult;
-        try {
-          released = await claim.releaseJob(row.id, holder, "pending");
-        } catch (err) {
-          // DETERMINISTIC 4xx (G1d): the hook REJECTED the request before
-          // its transaction ran — definitively NOTHING committed, so the
-          // conservative at-least-once treatment below would be a LIE told
-          // EVERY sweep: a wedge row (concrete trigger: empty claimed_by →
-          // the hook 400s on the missing workerId) would paint a permanent
-          // per-sweep false worker-reclaimed-pending overlay for a row that
-          // never moves. Log loud (error — the row IS wedged and needs an
-          // operator) and synthesize nothing: no grace, no comm error, no
-          // reclaimed++. Only 5xx/transport/2xx-unreadable throws — plus
-          // the transient-by-meaning 408/429 (see
-          // deterministicEndpointRejection) — stay conservative.
-          if (deterministicEndpointRejection(err)) {
-            logger.error("queue-client.sweep-release-rejected", {
-              jobId: row.id,
-              workerId: holder,
-              status: err.status,
-              err: err.message,
-            });
-            continue;
-          }
-          logger.warn("queue-client.sweep-release-threw", {
+      // Re-queue on behalf of the dead holder: the CAS authorizes on
+      // `claimed_by` (still the dead worker), so this atomically flips the
+      // row back to pending and drops ownership.
+      //
+      // PER-ROW containment (REQ-B): a release that THROWS (transport blip —
+      // distinct from a refused CAS, handled below) must not escape the
+      // loop. The producer swallows a sweepExpired throw, so an escape would
+      // discard the commErrors ALREADY synthesized for rows ALREADY released
+      // to pending in this pass — their gray "re-queued" surfaces would
+      // never reach the dashboard and are never regenerated (those rows are
+      // pending now; no later sweep re-emits them).
+      //
+      // TIMEOUT-AFTER-COMMIT (at-least-once): a thrown release may have
+      // COMMITTED server-side before the response was lost — the row IS
+      // pending then, so (a) the SAME call's stale phase could
+      // claim-and-delete it unless it is in the grace set, and (b) its
+      // worker-reclaimed-pending comm error would be lost FOREVER (the row
+      // is pending; no later sweep re-emits it — the file's own contract
+      // above). So treat a thrown release CONSERVATIVELY as if it
+      // committed: grace the row and synthesize the comm error anyway. If
+      // the release did NOT commit, the next sweep retries the
+      // still-expired lease and a DUPLICATE gray "re-queued" overlay may
+      // render — harmless; a MISSING one is not. Sweeper-held rows stay
+      // silent (mirroring the committed path below). The known-refused CAS
+      // (`released: false`) stays a clean skip, and a DETERMINISTIC 4xx
+      // (the hook rejected the request — nothing committed) is carved out
+      // below — only the genuinely indeterminate throw (5xx / transport /
+      // 2xx-unreadable) gets the conservative treatment.
+      let released: ReleaseResult;
+      try {
+        released = await claim.releaseJob(row.id, holder, "pending");
+      } catch (err) {
+        // DETERMINISTIC 4xx (G1d): the hook REJECTED the request before
+        // its transaction ran — definitively NOTHING committed, so the
+        // conservative at-least-once treatment below would be a LIE told
+        // EVERY sweep: a wedge row (concrete trigger: empty claimed_by →
+        // the hook 400s on the missing workerId) would paint a permanent
+        // per-sweep false worker-reclaimed-pending overlay for a row that
+        // never moves. Log loud (error — the row IS wedged and needs an
+        // operator) and synthesize nothing: no grace, no comm error, no
+        // reclaimed++. Only 5xx/transport/2xx-unreadable throws — plus
+        // the transient-by-meaning 408/429 (see
+        // deterministicEndpointRejection) — stay conservative.
+        if (deterministicEndpointRejection(err)) {
+          logger.error("queue-client.sweep-release-rejected", {
             jobId: row.id,
             workerId: holder,
-            err: err instanceof Error ? err.message : String(err),
-          });
-          requeuedThisSweep.add(row.id);
-          if (holder !== STALE_PENDING_SWEEPER_ID) {
-            reclaimedIndeterminate += 1;
-            commErrors.push({
-              kind: "worker-reclaimed-pending",
-              message: `lease for job ${row.id} expired (worker ${holder || "unknown"} reclaimed); re-queue release threw mid-flight — conservatively reported as re-queued (at-least-once)`,
-              workerId: holder || undefined,
-              jobId: row.id,
-              observedAt,
-            });
-          }
-          continue;
-        }
-        if (!released.released) {
-          // Another sweeper or a late worker report won the race — not an
-          // error, just nothing for us to reclaim on this row.
-          logger.debug("queue-client.sweep-skip", {
-            jobId: row.id,
-            workerId: holder,
+            status: err.status,
+            err: err.message,
           });
           continue;
         }
-        // SPECIAL CASE: a row claimed by the STALE-PENDING SWEEPER is stale
-        // garbage mid-deletion (the stale sweep won the claim but its delete
-        // failed), NOT a crashed worker's job. The releaseJob above already
-        // re-queued it — which is exactly the self-healing retry contract (a
-        // later stale sweep re-claims and re-deletes it) — but it must be
-        // SILENT: synthesizing `worker-reclaimed-pending` here would paint a
-        // gray "re-queued / back in flight" dashboard overlay for a row that
-        // was never in flight, attributed to a non-existent worker. Not
-        // counted in `reclaimed` either (reclaimed + reclaimedIndeterminate
-        // are paired 1:1 with the commErrors they document). It DOES feed
-        // the grace set: this call's
-        // stale phase must not claim-and-delete a row the lease phase just
-        // re-queued (the retry contract is a LATER sweep — re-deleting in the
-        // same sweep would race the very lease/delete failure that put the
-        // row here), so the sweeper-retry row gets the same one sweep of
-        // grace as a worker-reclaimed row.
-        if (holder === STALE_PENDING_SWEEPER_ID) {
-          requeuedThisSweep.add(row.id);
-          logger.debug("queue-client.stale-sweeper-retry-requeue", {
-            jobId: row.id,
-          });
-          continue;
-        }
-        reclaimed += 1;
-        requeuedThisSweep.add(row.id);
-        // The sweep boundary CANNOT distinguish a real worker crash from an
-        // expected platform teardown (Railway scale-down / redeploy SIGKILL with
-        // no graceful drain) — both leave an identical expired lease on a
-        // claimed/running row. So we do NOT synthesize `worker-crashed-mid-job`
-        // here (that would flap the whole service red on every routine
-        // teardown). The job has been RE-QUEUED to pending by the releaseJob
-        // above, so it is back in flight; emit the neutral
-        // `worker-reclaimed-pending` kind, which the dashboard renders as a gray
-        // "re-queued" surface, NOT a red unreachable overlay. A genuine pool
-        // outage keeps re-surfacing this and the cell stays gray (no green) — the
-        // honest signal. (A graceful worker shutdown drains the in-flight job to
-        // a terminal report BEFORE the lease expires, so the sweep never sees it
-        // at all — see the SIGTERM drain handler in orchestrator.bootFleet.)
-        commErrors.push({
-          kind: "worker-reclaimed-pending",
-          message: `lease for job ${row.id} expired (worker ${holder || "unknown"} reclaimed); re-queued to pending`,
-          workerId: holder || undefined,
+        logger.warn("queue-client.sweep-release-threw", {
           jobId: row.id,
-          observedAt,
+          workerId: holder,
+          err: err instanceof Error ? err.message : String(err),
         });
-        logger.warn("queue-client.sweep-reclaimed", {
+        requeuedThisSweep.add(row.id);
+        if (holder !== STALE_PENDING_SWEEPER_ID) {
+          reclaimedIndeterminate += 1;
+          commErrors.push({
+            kind: "worker-reclaimed-pending",
+            message: `lease for job ${row.id} expired (worker ${holder || "unknown"} reclaimed); re-queue release threw mid-flight — conservatively reported as re-queued (at-least-once)`,
+            workerId: holder || undefined,
+            jobId: row.id,
+            observedAt,
+          });
+        }
+        continue;
+      }
+      if (!released.released) {
+        // Another sweeper or a late worker report won the race — not an
+        // error, just nothing for us to reclaim on this row.
+        logger.debug("queue-client.sweep-skip", {
           jobId: row.id,
           workerId: holder,
         });
+        continue;
       }
-
-      // ── STALE-PENDING EXPIRY (structural backlog drain) ──────────────────
-      // A pending row had NO terminal path: the lease sweep above only touches
-      // claimed/running rows, so an accumulated backlog (staging: 3,734
-      // pending, oldest 22h) could only drain through the 2 serial workers and
-      // effectively never did. Expire pending jobs older than expiryPeriods ×
-      // their family's production period — the family has enqueued ~3 fresher
-      // batches since, so the stale job's eventual result would be ancient
-      // data. Each stale row is CLAIMED via the S0 CAS first (a racing worker
-      // either wins the row — the sweeper backs off — or loses it and never
-      // sees it again; the exactly-one-winner invariant makes the delete
-      // race-free) and then deleted. No comm error is synthesized: an
-      // expired-pending job never ran, and its family's next batch is the
-      // dashboard signal.
-      // The drain LOOPS pages (up to STALE_PENDING_MAX_PAGES_PER_SWEEP): a
-      // single 50-row page per sweep would take ~7.5h to drain the motivating
-      // 3,734-row backlog at ~10 sweeps/hour. When a pass removed rows from
-      // pending (deleted, or a claim CAS ran — win or lose, the row LEFT
-      // pending), pagination shifted back, so the SAME page index is
-      // re-listed and naturally yields the shifted-in batch. When a FULL page
-      // produced no claim attempt at all (every row too young / graced /
-      // unparseable), nothing shifted — ADVANCE to the next page instead of
-      // stopping: expiry is per-FAMILY while the sort is absolute `created`,
-      // so younger expirable fast-family rows can sit BEYOND a full page of
-      // not-yet-expirable slow-family rows (cross-family occlusion — the
-      // class this drain exists to fix). Only a NON-FULL page proves the
-      // queue's tail was seen; the page cap still bounds a sweep's work.
-      // PHASE containment (REQ-B): the whole stale drain is wrapped so a
-      // throw anywhere inside it (the pending pb.list, the claim CAS — only
-      // pb.delete was caught per-row) still returns the lease phase's partial
-      // result above. The producer swallows a sweepExpired throw, so an
-      // escape here would discard every commError the lease phase just
-      // synthesized — the same dashboard-signal loss as an escaped release.
-      // The drain itself is retried in full by the next sweep.
-      try {
-        await drainStalePending();
-      } catch (err) {
-        logger.error("queue-client.sweep-stale-phase-threw", {
-          expiredPendingBeforeThrow: expiredPending,
-          err: err instanceof Error ? err.message : String(err),
+      // SPECIAL CASE: a row claimed by the STALE-PENDING SWEEPER is stale
+      // garbage mid-deletion (the stale sweep won the claim but its delete
+      // failed), NOT a crashed worker's job. The releaseJob above already
+      // re-queued it — which is exactly the self-healing retry contract (a
+      // later stale sweep re-claims and re-deletes it) — but it must be
+      // SILENT: synthesizing `worker-reclaimed-pending` here would paint a
+      // gray "re-queued / back in flight" dashboard overlay for a row that
+      // was never in flight, attributed to a non-existent worker. Not
+      // counted in `reclaimed` either (reclaimed + reclaimedIndeterminate
+      // are paired 1:1 with the commErrors they document). It DOES feed
+      // the grace set: this call's
+      // stale phase must not claim-and-delete a row the lease phase just
+      // re-queued (the retry contract is a LATER sweep — re-deleting in the
+      // same sweep would race the very lease/delete failure that put the
+      // row here), so the sweeper-retry row gets the same one sweep of
+      // grace as a worker-reclaimed row.
+      if (holder === STALE_PENDING_SWEEPER_ID) {
+        requeuedThisSweep.add(row.id);
+        logger.debug("queue-client.stale-sweeper-retry-requeue", {
+          jobId: row.id,
         });
+        continue;
       }
+      reclaimed += 1;
+      requeuedThisSweep.add(row.id);
+      // The sweep boundary CANNOT distinguish a real worker crash from an
+      // expected platform teardown (Railway scale-down / redeploy SIGKILL with
+      // no graceful drain) — both leave an identical expired lease on a
+      // claimed/running row. So we do NOT synthesize `worker-crashed-mid-job`
+      // here (that would flap the whole service red on every routine
+      // teardown). The job has been RE-QUEUED to pending by the releaseJob
+      // above, so it is back in flight; emit the neutral
+      // `worker-reclaimed-pending` kind, which the dashboard renders as a gray
+      // "re-queued" surface, NOT a red unreachable overlay. A genuine pool
+      // outage keeps re-surfacing this and the cell stays gray (no green) — the
+      // honest signal. (A graceful worker shutdown drains the in-flight job to
+      // a terminal report BEFORE the lease expires, so the sweep never sees it
+      // at all — see the SIGTERM drain handler in orchestrator.bootFleet.)
+      commErrors.push({
+        kind: "worker-reclaimed-pending",
+        message: `lease for job ${row.id} expired (worker ${holder || "unknown"} reclaimed); re-queued to pending`,
+        workerId: holder || undefined,
+        jobId: row.id,
+        observedAt,
+      });
+      logger.warn("queue-client.sweep-reclaimed", {
+        jobId: row.id,
+        workerId: holder,
+      });
+    }
 
-      return { reclaimed, reclaimedIndeterminate, commErrors, expiredPending };
+    // ── STALE-PENDING EXPIRY (structural backlog drain) ──────────────────
+    // A pending row had NO terminal path: the lease sweep above only touches
+    // claimed/running rows, so an accumulated backlog (staging: 3,734
+    // pending, oldest 22h) could only drain through the 2 serial workers and
+    // effectively never did. Expire pending jobs older than expiryPeriods ×
+    // their family's production period — the family has enqueued ~3 fresher
+    // batches since, so the stale job's eventual result would be ancient
+    // data. Each stale row is CLAIMED via the S0 CAS first (a racing worker
+    // either wins the row — the sweeper backs off — or loses it and never
+    // sees it again; the exactly-one-winner invariant makes the delete
+    // race-free) and then deleted. No comm error is synthesized: an
+    // expired-pending job never ran, and its family's next batch is the
+    // dashboard signal.
+    // The drain LOOPS pages (up to STALE_PENDING_MAX_PAGES_PER_SWEEP): a
+    // single 50-row page per sweep would take ~7.5h to drain the motivating
+    // 3,734-row backlog at ~10 sweeps/hour. When a pass removed rows from
+    // pending (deleted, or a claim CAS ran — win or lose, the row LEFT
+    // pending), pagination shifted back, so the SAME page index is
+    // re-listed and naturally yields the shifted-in batch. When a FULL page
+    // produced no claim attempt at all (every row too young / graced /
+    // unparseable), nothing shifted — ADVANCE to the next page instead of
+    // stopping: expiry is per-FAMILY while the sort is absolute `created`,
+    // so younger expirable fast-family rows can sit BEYOND a full page of
+    // not-yet-expirable slow-family rows (cross-family occlusion — the
+    // class this drain exists to fix). Only a NON-FULL page proves the
+    // queue's tail was seen; the page cap still bounds a sweep's work.
+    // PHASE containment (REQ-B): the whole stale drain is wrapped so a
+    // throw anywhere inside it (the pending pb.list, the claim CAS — only
+    // pb.delete was caught per-row) still returns the lease phase's partial
+    // result above. The producer swallows a sweepExpired throw, so an
+    // escape here would discard every commError the lease phase just
+    // synthesized — the same dashboard-signal loss as an escaped release.
+    // The drain itself is retried in full by the next sweep.
+    try {
+      await drainStalePending();
+    } catch (err) {
+      logger.error("queue-client.sweep-stale-phase-threw", {
+        expiredPendingBeforeThrow: expiredPending,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
 
-      /**
-       * The stale-pending drain loop (see the STALE-PENDING EXPIRY comment
-       * above). Mutates the enclosing `expiredPending` PER ROW (not per pass)
-       * so the partial count survives a mid-pass throw.
-       */
-      async function drainStalePending(): Promise<void> {
-        if (staleExpiryPeriods <= 0) return;
-        let listPage = 1;
-        for (let pass = 0; pass < STALE_PENDING_MAX_PAGES_PER_SWEEP; pass++) {
-          const pendingPage = await pb.list<ProbeJobRecord>(
-            PROBE_JOBS_COLLECTION,
-            {
-              filter: 'status = "pending"',
-              sort: "created",
-              page: listPage,
-              perPage: CLAIM_CANDIDATE_PAGE,
-              skipTotal: true,
-            },
-          );
-          if (pendingPage.items.length === 0) break;
-          // Rows that reached the claim CAS this pass — win or lose, such a
-          // row LEFT "pending" (won → claimed by the sweeper; lost → claimed
-          // by a racing worker), so any attempt means pagination shifted.
-          let passAttempted = 0;
-          for (const row of pendingPage.items) {
-            // ONE SWEEP OF GRACE (see function header): a row the lease phase
-            // re-queued moments ago in THIS call is "back in flight" — deleting
-            // it now would falsify the worker-reclaimed-pending comm error just
-            // emitted for it. Skip it; if truly stale it expires next sweep.
-            // Applied on EVERY pass of the drain loop — pagination must never
-            // out-run the grace set.
-            if (requeuedThisSweep.has(row.id)) {
-              logger.debug("queue-client.sweep-stale-grace", { jobId: row.id });
-              continue;
-            }
-            // Age off PB's system `created` (space-separated date form —
-            // normalize with the SAME anchored rewrite as leaseExpired). Unlike
-            // the lease path, an unparseable value is conservatively SKIPPED:
-            // delete is destructive, and "never wedge the queue" doesn't apply —
-            // a pending row is claimable regardless.
-            const createdMs = Date.parse(
-              String(row.created ?? "").replace(PB_DATE_SEP_RE, "$1T"),
-            );
-            if (Number.isNaN(createdMs)) {
-              logger.warn("queue-client.sweep-stale-unparseable-created", {
-                jobId: row.id,
-                created: row.created ?? null,
-              });
-              continue;
-            }
-            const family = probeKeyFamily(row.probe_key);
-            const maxAgeMs = staleExpiryPeriods * stalePeriodMsFor(family);
-            const ageMs = nowMs - createdMs;
-            if (ageMs <= maxAgeMs) continue;
-            // RECENT-LEASE HEURISTIC (no schema change): the age above is
-            // anchored on PB `created`, which a re-queue does NOT touch — so
-            // a job that legitimately ran LONGER than its family's STALE
-            // WINDOW (`maxAgeMs` = expiryPeriods × the family period — 3
-            // periods by default, NOT one) comes back from the lease sweep
-            // already "stale" and would be claim-deleted by the NEXT sweep
-            // before any plausible re-run (the dashboard then permanently
-            // shows "re-queued" for silently-discarded work). The release
-            // hook RETAINS the expired lease_expires_at on a pending
-            // re-queue, so a PARSEABLE lease within that stale window means
-            // the row was IN FLIGHT recently and its `created`-based age is
-            // stale evidence — skip it; it expires normally once a full
-            // stale window passes with no re-claim. (A `requeued_at` column
-            // would be exact; the retained lease is the schema-free
-            // approximation.) Tradeoff: a sweeper-claimed row whose delete
-            // failed also carries a recent (60s) lease after its silent
-            // re-queue, so stale GARBAGE can linger up to one extra stale
-            // window before the retry delete — harmless, and the
-            // self-healing contract still holds.
-            const leaseMs = Date.parse(
-              String(row.lease_expires_at ?? "").replace(PB_DATE_SEP_RE, "$1T"),
-            );
-            if (Number.isFinite(leaseMs) && leaseMs > nowMs - maxAgeMs) {
-              logger.debug("queue-client.sweep-stale-recent-lease-skip", {
-                jobId: row.id,
-                leaseExpiresAt: row.lease_expires_at,
-              });
-              continue;
-            }
-            // PER-ROW containment: the claim CAS can THROW (a deterministic
-            // 4xx from the hook, or a transport blip the 5xx mapping doesn't
-            // cover). Letting it escape to the phase wrapper aborts the
-            // WHOLE drain for one sick row — every later stale row goes
-            // unprocessed this sweep. Warn + continue; the row is NOT
-            // counted as attempted (indeterminate whether it left pending).
-            let won: ClaimResult;
-            try {
-              won = await claim.claimJob(
-                row.id,
-                STALE_PENDING_SWEEPER_ID,
-                STALE_PENDING_SWEEPER_LEASE_SECONDS,
-              );
-            } catch (err) {
-              logger.warn("queue-client.sweep-stale-claim-threw", {
-                jobId: row.id,
-                err: err instanceof Error ? err.message : String(err),
-              });
-              continue;
-            }
-            passAttempted += 1;
-            if (!won.won) {
-              // A worker won the race — the job is in flight after all; not
-              // ours to expire. (The row left "pending", so it also drops out
-              // of the next pass's listing — no re-processing.)
-              //
-              // CAVEAT on the "left pending" assumption feeding passAttempted:
-              // job-claim maps a claim 5xx to won:false WITHOUT the row
-              // necessarily leaving pending. Such a row re-appears when the
-              // same page index is re-listed, so a page of persistently-5xx
-              // rows is retried pass after pass — bounded by the
-              // STALE_PENDING_MAX_PAGES_PER_SWEEP cap, after which the sweep
-              // ends and the NEXT sweep retries. A bounded stall on a sick
-              // backend, never an infinite loop.
-              logger.debug("queue-client.sweep-stale-claim-lost", {
-                jobId: row.id,
-              });
-              continue;
-            }
-            try {
-              await pb.delete(PROBE_JOBS_COLLECTION, row.id);
-            } catch (err) {
-              // The row stays claimed by the sweeper; its short lease expires
-              // and the NEXT lease sweep re-queues it to pending, where a later
-              // stale sweep retries — self-healing, so log and move on.
-              logger.error("queue-client.sweep-stale-delete-failed", {
-                jobId: row.id,
-                err: err instanceof Error ? err.message : String(err),
-              });
-              continue;
-            }
-            // Per ROW (not per pass) so a mid-pass throw caught by the phase
-            // wrapper still reports the rows already expired.
-            expiredPending += 1;
-            logger.warn("queue-client.sweep-expired-pending", {
-              jobId: row.id,
-              probeKey: row.probe_key,
-              family,
-              ageMs,
-              maxAgeMs,
-            });
+    return { reclaimed, reclaimedIndeterminate, commErrors, expiredPending };
+
+    /**
+     * The stale-pending drain loop (see the STALE-PENDING EXPIRY comment
+     * above). Mutates the enclosing `expiredPending` PER ROW (not per pass)
+     * so the partial count survives a mid-pass throw.
+     */
+    async function drainStalePending(): Promise<void> {
+      if (staleExpiryPeriods <= 0) return;
+      let listPage = 1;
+      for (let pass = 0; pass < STALE_PENDING_MAX_PAGES_PER_SWEEP; pass++) {
+        const pendingPage = await pb.list<ProbeJobRecord>(
+          PROBE_JOBS_COLLECTION,
+          {
+            filter: 'status = "pending"',
+            sort: "created",
+            page: listPage,
+            perPage: CLAIM_CANDIDATE_PAGE,
+            skipTotal: true,
+          },
+        );
+        if (pendingPage.items.length === 0) break;
+        // Rows that reached the claim CAS this pass — win or lose, such a
+        // row LEFT "pending" (won → claimed by the sweeper; lost → claimed
+        // by a racing worker), so any attempt means pagination shifted.
+        let passAttempted = 0;
+        for (const row of pendingPage.items) {
+          // ONE SWEEP OF GRACE (see function header): a row the lease phase
+          // re-queued moments ago in THIS call is "back in flight" — deleting
+          // it now would falsify the worker-reclaimed-pending comm error just
+          // emitted for it. Skip it; if truly stale it expires next sweep.
+          // Applied on EVERY pass of the drain loop — pagination must never
+          // out-run the grace set.
+          if (requeuedThisSweep.has(row.id)) {
+            logger.debug("queue-client.sweep-stale-grace", { jobId: row.id });
+            continue;
           }
-          // A NON-FULL page → we have already seen the queue's tail; nothing
-          // more for this sweep to do. (A zero-EXPIRY pass is intentionally
-          // NOT a termination signal: claim-CAS-lost rows LEAVE pending, so
-          // expiring nothing does not mean re-listing returns the same rows.)
-          if (pendingPage.items.length < CLAIM_CANDIDATE_PAGE) break;
-          // A FULL page where no row even reached the claim CAS: nothing left
-          // pending, pagination did not shift — ADVANCE past it (cross-family
-          // occlusion; see the drain header). Otherwise rows left pending and
-          // pagination shifted back, so re-list the SAME page index to see
-          // the shifted-in batch.
-          //
-          // PAGE-ADVANCE INDETERMINACY (accepted): a claim that THREW is not
-          // counted in passAttempted, but it may still have COMMITTED
-          // server-side (thrown-but-committed) — the row then LEFT pending
-          // and pagination shifted even though this pass looks attempt-free,
-          // so an advance here can skip shifted-in rows for the REST of this
-          // sweep. Bounded and self-healing: the next sweep re-lists from
-          // page 1 and re-evaluates everything skipped.
-          if (passAttempted === 0) listPage += 1;
+          // Age off PB's system `created` (space-separated date form —
+          // normalize with the SAME anchored rewrite as leaseExpired). Unlike
+          // the lease path, an unparseable value is conservatively SKIPPED:
+          // delete is destructive, and "never wedge the queue" doesn't apply —
+          // a pending row is claimable regardless.
+          const createdMs = Date.parse(
+            String(row.created ?? "").replace(PB_DATE_SEP_RE, "$1T"),
+          );
+          if (Number.isNaN(createdMs)) {
+            logger.warn("queue-client.sweep-stale-unparseable-created", {
+              jobId: row.id,
+              created: row.created ?? null,
+            });
+            continue;
+          }
+          const family = probeKeyFamily(row.probe_key);
+          const maxAgeMs = staleExpiryPeriods * stalePeriodMsFor(family);
+          const ageMs = nowMs - createdMs;
+          if (ageMs <= maxAgeMs) continue;
+          // RECENT-LEASE HEURISTIC (no schema change): the age above is
+          // anchored on PB `created`, which a re-queue does NOT touch — so
+          // a job that legitimately ran LONGER than its family's STALE
+          // WINDOW (`maxAgeMs` = expiryPeriods × the family period — 3
+          // periods by default, NOT one) comes back from the lease sweep
+          // already "stale" and would be claim-deleted by the NEXT sweep
+          // before any plausible re-run (the dashboard then permanently
+          // shows "re-queued" for silently-discarded work). The release
+          // hook RETAINS the expired lease_expires_at on a pending
+          // re-queue, so a PARSEABLE lease within that stale window means
+          // the row was IN FLIGHT recently and its `created`-based age is
+          // stale evidence — skip it; it expires normally once a full
+          // stale window passes with no re-claim. (A `requeued_at` column
+          // would be exact; the retained lease is the schema-free
+          // approximation.) Tradeoff: a sweeper-claimed row whose delete
+          // failed also carries a recent (60s) lease after its silent
+          // re-queue, so stale GARBAGE can linger up to one extra stale
+          // window before the retry delete — harmless, and the
+          // self-healing contract still holds.
+          const leaseMs = Date.parse(
+            String(row.lease_expires_at ?? "").replace(PB_DATE_SEP_RE, "$1T"),
+          );
+          if (Number.isFinite(leaseMs) && leaseMs > nowMs - maxAgeMs) {
+            logger.debug("queue-client.sweep-stale-recent-lease-skip", {
+              jobId: row.id,
+              leaseExpiresAt: row.lease_expires_at,
+            });
+            continue;
+          }
+          // PER-ROW containment: the claim CAS can THROW (a deterministic
+          // 4xx from the hook, or a transport blip the 5xx mapping doesn't
+          // cover). Letting it escape to the phase wrapper aborts the
+          // WHOLE drain for one sick row — every later stale row goes
+          // unprocessed this sweep. Warn + continue; the row is NOT
+          // counted as attempted (indeterminate whether it left pending).
+          let won: ClaimResult;
+          try {
+            won = await claim.claimJob(
+              row.id,
+              STALE_PENDING_SWEEPER_ID,
+              STALE_PENDING_SWEEPER_LEASE_SECONDS,
+            );
+          } catch (err) {
+            logger.warn("queue-client.sweep-stale-claim-threw", {
+              jobId: row.id,
+              err: err instanceof Error ? err.message : String(err),
+            });
+            continue;
+          }
+          passAttempted += 1;
+          if (!won.won) {
+            // A worker won the race — the job is in flight after all; not
+            // ours to expire. (The row left "pending", so it also drops out
+            // of the next pass's listing — no re-processing.)
+            //
+            // CAVEAT on the "left pending" assumption feeding passAttempted:
+            // job-claim maps a claim 5xx to won:false WITHOUT the row
+            // necessarily leaving pending. Such a row re-appears when the
+            // same page index is re-listed, so a page of persistently-5xx
+            // rows is retried pass after pass — bounded by the
+            // STALE_PENDING_MAX_PAGES_PER_SWEEP cap, after which the sweep
+            // ends and the NEXT sweep retries. A bounded stall on a sick
+            // backend, never an infinite loop.
+            logger.debug("queue-client.sweep-stale-claim-lost", {
+              jobId: row.id,
+            });
+            continue;
+          }
+          try {
+            await pb.delete(PROBE_JOBS_COLLECTION, row.id);
+          } catch (err) {
+            // The row stays claimed by the sweeper; its short lease expires
+            // and the NEXT lease sweep re-queues it to pending, where a later
+            // stale sweep retries — self-healing, so log and move on.
+            logger.error("queue-client.sweep-stale-delete-failed", {
+              jobId: row.id,
+              err: err instanceof Error ? err.message : String(err),
+            });
+            continue;
+          }
+          // Per ROW (not per pass) so a mid-pass throw caught by the phase
+          // wrapper still reports the rows already expired.
+          expiredPending += 1;
+          logger.warn("queue-client.sweep-expired-pending", {
+            jobId: row.id,
+            probeKey: row.probe_key,
+            family,
+            ageMs,
+            maxAgeMs,
+          });
         }
+        // A NON-FULL page → we have already seen the queue's tail; nothing
+        // more for this sweep to do. (A zero-EXPIRY pass is intentionally
+        // NOT a termination signal: claim-CAS-lost rows LEAVE pending, so
+        // expiring nothing does not mean re-listing returns the same rows.)
+        if (pendingPage.items.length < CLAIM_CANDIDATE_PAGE) break;
+        // A FULL page where no row even reached the claim CAS: nothing left
+        // pending, pagination did not shift — ADVANCE past it (cross-family
+        // occlusion; see the drain header). Otherwise rows left pending and
+        // pagination shifted back, so re-list the SAME page index to see
+        // the shifted-in batch.
+        //
+        // PAGE-ADVANCE INDETERMINACY (accepted): a claim that THREW is not
+        // counted in passAttempted, but it may still have COMMITTED
+        // server-side (thrown-but-committed) — the row then LEFT pending
+        // and pagination shifted even though this pass looks attempt-free,
+        // so an advance here can skip shifted-in rows for the REST of this
+        // sweep. Bounded and self-healing: the next sweep re-lists from
+        // page 1 and re-evaluates everything skipped.
+        if (passAttempted === 0) listPage += 1;
       }
+    }
   }
 }

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -1018,13 +1018,22 @@ export function createFleetQueueClient(
       }
       if (result.renewed && !result.job) {
         // PROTOCOL VIOLATION: a successful renew always carries the row view.
-        // We still fall through to the lost-lease handling below (we cannot
-        // build a lease from nothing), but the breach must be visible — it
-        // means the endpoint contract drifted, not that the lease was lost.
+        // The breach must be visible — it means the endpoint contract
+        // drifted. But the CAS WON: the job is LIVE and this worker still
+        // holds it, so falling into the lost-lease eviction below would stop
+        // the heartbeat on a SUCCESSFUL renew → the sweeper falsely reclaims
+        // a live job. Keep the last-known lease ASSUMED-LIVE (like the
+        // indeterminate path) so the next beat retries; only with nothing
+        // cached (no same-process claim) is null the honest answer.
         logger.warn("queue-client.renew-renewed-without-job", {
           jobId,
           workerId,
         });
+        const known = leaseCache.get(jobId);
+        if (known) return known;
+        payloadCache.delete(jobId);
+        leaseCache.delete(jobId);
+        return null;
       }
       if (!result.renewed || !result.job) {
         // The renew CAS was LOST: the lease is gone for this worker (stolen,
@@ -1086,8 +1095,10 @@ export function createFleetQueueClient(
         // a LOST lease, stop heartbeating, and let the sweeper reclaim a LIVE
         // job → a FALSE `worker-crashed-mid-job`. The heartbeat does not
         // consume the payload, so return a lease with a best-effort EMPTY
-        // payload synthesized from the authoritative CAS row. We ONLY return
-        // null when the CAS itself failed (handled above).
+        // payload synthesized from the authoritative CAS row. null is
+        // reserved for definitive losses: a lost CAS, a deterministic 4xx
+        // rejection, or the renewed-without-job breach with nothing cached
+        // (all handled above).
         logger.warn("queue-client.renew-no-payload", { jobId, workerId });
         const fallback = leaseFromJob(result.job, emptyPayloadForLease(result.job));
         leaseCache.set(jobId, fallback);

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -1840,9 +1840,8 @@ export function createFleetQueueClient(
             // counts a CLAIMED/RUNNING row (long-expired lease, stale
             // created-age) deleted by this carve-out — not just stale
             // PENDING rows from the drain phase. The shared contract doc
-            // (`SweepResult.expiredPending`, contracts.ts: "STALE PENDING
-            // jobs ... sat unclaimed") describes only the drain phase and
-            // needs the same clarification.
+            // (`SweepResult.expiredPending` in contracts.ts) documents this
+            // lease-phase carve-out explicitly — the two sides agree.
             expiredPending += 1;
             logger.warn("queue-client.sweep-lease-stale-deleted", {
               jobId: row.id,

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -103,8 +103,11 @@ const MAX_PENDING_FAMILIES = 16;
  * We still retry a few times here before surfacing a distinct "result lost"
  * error, so the loss is unmistakable in logs and the common transient blip is
  * absorbed without dropping the result.
+ *
+ * Exported so the retry-bound test pins THIS constant rather than a magic
+ * number that could drift from the implementation.
  */
-const RESULT_WRITE_MAX_ATTEMPTS = 3;
+export const RESULT_WRITE_MAX_ATTEMPTS = 3;
 
 /**
  * Default multiple of a family's production period after which an unclaimed

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -124,7 +124,10 @@ const STALE_PENDING_SWEEPER_ID = "stale-pending-sweeper";
 
 /** Lease the sweeper takes on a stale row for the claim→delete window. If the
  * delete fails the lease simply expires and the NEXT lease sweep re-queues the
- * row to pending, where a later stale sweep retries it — self-healing. */
+ * row to pending SILENTLY (no comm error — the lease phase special-cases
+ * `claimed_by === STALE_PENDING_SWEEPER_ID`, since stale garbage mid-deletion
+ * is not a crashed worker's job), where a later stale sweep retries it —
+ * self-healing. */
 const STALE_PENDING_SWEEPER_LEASE_SECONDS = 60;
 
 /**
@@ -711,20 +714,36 @@ export function createFleetQueueClient(
       const observedAt = new Date(nowMs).toISOString();
       for (const row of page.items) {
         if (!leaseExpired(row.lease_expires_at, nowMs)) continue;
+        // Snapshot the holder BEFORE the release CAS: the release drops
+        // ownership, and the special-case + comm-error attribution below must
+        // reflect who HELD the expired lease, not the post-release row.
+        const holder = row.claimed_by;
         // Re-queue on behalf of the dead holder: the CAS authorizes on
         // `claimed_by` (still the dead worker), so this atomically flips the
         // row back to pending and drops ownership.
-        const released = await claim.releaseJob(
-          row.id,
-          row.claimed_by,
-          "pending",
-        );
+        const released = await claim.releaseJob(row.id, holder, "pending");
         if (!released.released) {
           // Another sweeper or a late worker report won the race — not an
           // error, just nothing for us to reclaim on this row.
           logger.debug("queue-client.sweep-skip", {
             jobId: row.id,
-            workerId: row.claimed_by,
+            workerId: holder,
+          });
+          continue;
+        }
+        // SPECIAL CASE: a row claimed by the STALE-PENDING SWEEPER is stale
+        // garbage mid-deletion (the stale sweep won the claim but its delete
+        // failed), NOT a crashed worker's job. The releaseJob above already
+        // re-queued it — which is exactly the self-healing retry contract (a
+        // later stale sweep re-claims and re-deletes it) — but it must be
+        // SILENT: synthesizing `worker-reclaimed-pending` here would paint a
+        // gray "re-queued / back in flight" dashboard overlay for a row that
+        // was never in flight, attributed to a non-existent worker. Not
+        // counted in `reclaimed` either (that count is paired 1:1 with the
+        // commErrors it documents).
+        if (holder === STALE_PENDING_SWEEPER_ID) {
+          logger.debug("queue-client.stale-sweeper-retry-requeue", {
+            jobId: row.id,
           });
           continue;
         }
@@ -745,14 +764,14 @@ export function createFleetQueueClient(
         // at all — see the SIGTERM drain handler in orchestrator.bootFleet.)
         commErrors.push({
           kind: "worker-reclaimed-pending",
-          message: `lease for job ${row.id} expired (worker ${row.claimed_by || "unknown"} reclaimed); re-queued to pending`,
-          workerId: row.claimed_by || undefined,
+          message: `lease for job ${row.id} expired (worker ${holder || "unknown"} reclaimed); re-queued to pending`,
+          workerId: holder || undefined,
           jobId: row.id,
           observedAt,
         });
         logger.warn("queue-client.sweep-reclaimed", {
           jobId: row.id,
-          workerId: row.claimed_by,
+          workerId: holder,
         });
       }
 

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -53,7 +53,10 @@ import type {
   ReleaseResult,
   RenewResult,
 } from "./job-claim.js";
-import { RELEASE_REFUSED_TERMINAL_SAME_HOLDER } from "./job-claim.js";
+import {
+  JobClaimEndpointError,
+  RELEASE_REFUSED_TERMINAL_SAME_HOLDER,
+} from "./job-claim.js";
 import { probeKeyFamily, terminalJobStatus } from "./contracts.js";
 import type {
   ClaimedJob,
@@ -1262,12 +1265,37 @@ export function createFleetQueueClient(
         // still-expired lease and a DUPLICATE gray "re-queued" overlay may
         // render — harmless; a MISSING one is not. Sweeper-held rows stay
         // silent (mirroring the committed path below). The known-refused CAS
-        // (`released: false`) stays a clean skip — only the indeterminate
-        // throw gets the conservative treatment.
+        // (`released: false`) stays a clean skip, and a DETERMINISTIC 4xx
+        // (the hook rejected the request — nothing committed) is carved out
+        // below — only the genuinely indeterminate throw (5xx / transport /
+        // 2xx-unreadable) gets the conservative treatment.
         let released: ReleaseResult;
         try {
           released = await claim.releaseJob(row.id, holder, "pending");
         } catch (err) {
+          // DETERMINISTIC 4xx (G1d): the hook REJECTED the request before
+          // its transaction ran — definitively NOTHING committed, so the
+          // conservative at-least-once treatment below would be a LIE told
+          // EVERY sweep: a wedge row (concrete trigger: empty claimed_by →
+          // the hook 400s on the missing workerId) would paint a permanent
+          // per-sweep false worker-reclaimed-pending overlay for a row that
+          // never moves. Log loud (error — the row IS wedged and needs an
+          // operator) and synthesize nothing: no grace, no comm error, no
+          // reclaimed++. Only 5xx/transport/2xx-unreadable throws — the
+          // genuinely indeterminate class — stay conservative.
+          if (
+            err instanceof JobClaimEndpointError &&
+            err.status >= 400 &&
+            err.status < 500
+          ) {
+            logger.error("queue-client.sweep-release-rejected", {
+              jobId: row.id,
+              workerId: holder,
+              status: err.status,
+              err: err.message,
+            });
+            continue;
+          }
           logger.warn("queue-client.sweep-release-threw", {
             jobId: row.id,
             workerId: holder,

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -1273,11 +1273,27 @@ export function createFleetQueueClient(
     },
 
     async report(input: ReportJobInput): Promise<void> {
-      const status = terminalJobStatus(input.result);
-      // The worker is DONE with this job either way (release refused or result
-      // write exhausted), so always evict the cached payload before returning —
-      // a leak here would slowly grow the per-client cache across reports.
+      // The worker is DONE with this job either way (release refused, result
+      // write exhausted, or malformed input), so always evict the cached
+      // payload before returning — a leak here would slowly grow the
+      // per-client cache across reports. EVERYTHING that can throw runs
+      // INSIDE the try (including the invariant check and the status
+      // mapping below) so the finally's eviction can never be skipped.
       try {
+        // EQUALITY INVARIANT (contracts.ts ReportJobInput): the release CAS
+        // keys on the TOP-LEVEL ids while the persisted result echoes its
+        // own — a mismatched caller would release one row while filing the
+        // result under another job's/worker's ids. Fail loud BEFORE the
+        // release so neither half happens.
+        if (
+          input.jobId !== input.result.jobId ||
+          input.workerId !== input.result.workerId
+        ) {
+          throw new Error(
+            `queue-client: report() input violates the ReportJobInput equality invariant (jobId "${input.jobId}" vs result.jobId "${input.result.jobId}"; workerId "${input.workerId}" vs result.workerId "${input.result.workerId}") — refusing to release one row while filing the result under another`,
+          );
+        }
+        const status = terminalJobStatus(input.result);
         const result = await claim.releaseJob(
           input.jobId,
           input.workerId,

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -703,6 +703,12 @@ export function createFleetQueueClient(
   // `renewed: false` stops it. Evicted exactly where payloadCache is.
   const leaseCache = new Map<string, JobLease>();
 
+  // CONCURRENT-SWEEP LATCH (see sweepExpired): the in-flight sweep's
+  // promise, or null when none is running. A sweep arriving while one is in
+  // flight piggybacks on this promise instead of racing the in-flight
+  // sweep's per-call grace set.
+  let sweepInFlight: Promise<SweepResultWithIndeterminate> | null = null;
+
   /**
    * Bounded-retry persistence of a per-service result onto an ALREADY
    * TERMINAL probe_jobs row — the SEPARATE record write that follows a
@@ -1613,6 +1619,33 @@ export function createFleetQueueClient(
     },
 
     async sweepExpired(nowMs: number): Promise<SweepResultWithIndeterminate> {
+      // CONCURRENT-SWEEP LATCH: the sweep's grace set (`requeuedThisSweep`)
+      // is per-CALL state — it protects rows this sweep just re-queued from
+      // this sweep's OWN stale phase, but a CONCURRENT sweep on the same
+      // client (runControlPlane wires FOUR family producers over ONE queue
+      // client; a cron overrun or local cron override can overlap their
+      // sweeps) would not see it and could claim-delete a row the first
+      // sweep just re-queued — falsifying its worker-reclaimed-pending comm
+      // error. So overlapping callers PIGGYBACK on the in-flight sweep's
+      // result (the sweep is global per queue, so a redundant concurrent
+      // pass does no additional good). The latch is in-process only: a
+      // second control-plane REPLICA would still race (the fleet deploys
+      // exactly one), where the stale phase's retained-lease heuristic is
+      // the cross-process/cross-call mitigation.
+      if (sweepInFlight !== null) return sweepInFlight;
+      const sweep = runSweepExpired(nowMs).finally(() => {
+        sweepInFlight = null;
+      });
+      sweepInFlight = sweep;
+      return sweep;
+    },
+  };
+
+  // The actual sweep pass `sweepExpired` latches around. A function
+  // DECLARATION (hoisted) so the method above can reference it.
+  async function runSweepExpired(
+    nowMs: number,
+  ): Promise<SweepResultWithIndeterminate> {
       // Scan claimed/running rows for expired leases (crashed/unreachable
       // workers). PB lacks an OR-of-equals shortcut here, so list both running
       // states and filter by lease in-process.
@@ -1681,13 +1714,15 @@ export function createFleetQueueClient(
       // at-least-once duplication. commErrors length (excluding
       // sweeper-held rows) = reclaimed + reclaimedIndeterminate.
       let reclaimedIndeterminate = 0;
-      // SINGLE-SWEEPER ASSUMPTION (load-bearing): this grace set is
-      // per-call, IN-PROCESS state. It protects re-queued rows only from
-      // THIS control-plane's own stale phase — a SECOND concurrent sweeper
-      // (another control-plane replica running sweepExpired) would not see
-      // it and could claim-delete a row this call just re-queued,
-      // falsifying its comm error. The fleet deploys exactly ONE
-      // control-plane instance (the producer/sweeper is a singleton); if
+      // GRACE-SET SCOPE (load-bearing): this set is per-call, IN-PROCESS
+      // state — it protects re-queued rows only from THIS sweep pass's own
+      // stale phase. IN-PROCESS concurrency is real (runControlPlane wires
+      // FOUR family producers over one queue client, and overlapping crons
+      // can call sweepExpired concurrently) and is closed by the
+      // CONCURRENT-SWEEP LATCH in `sweepExpired`: an overlapping caller
+      // piggybacks on the in-flight pass instead of racing this set.
+      // CROSS-PROCESS concurrency (a second control-plane REPLICA) is NOT
+      // covered — the fleet deploys exactly ONE control-plane instance; if
       // that ever changes, the grace must move to ROW state (the retained
       // lease heuristic in the stale phase already covers the cross-call
       // case; a requeued_at column would cover both exactly).
@@ -2126,6 +2161,5 @@ export function createFleetQueueClient(
           if (passAttempted === 0) listPage += 1;
         }
       }
-    },
-  };
+  }
 }

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -199,10 +199,10 @@ export interface StalePendingPolicy {
  * reclaim counts should treat the indeterminate share as "at least zero, at
  * most this many" extra re-queues.
  *
- * The contracts-level `SweepResult`/`TickResult` are sibling-owned: once
- * `TickResult` gains the field, the producer threads it with a one-liner
- * (`reclaimedIndeterminate: sweep.reclaimedIndeterminate`) where it copies
- * `sweep.reclaimed` today.
+ * The shared `SweepResult` contract carries the split as an OPTIONAL
+ * `reclaimedIndeterminate` (this implementation narrows it to required), and
+ * the producer threads it onto `TickResult` wherever it copies
+ * `sweep.reclaimed`.
  */
 export interface SweepResultWithIndeterminate extends SweepResult {
   /** Thrown-release conservative maybes (at-least-once; see above). */

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -311,6 +311,10 @@ function assertServiceJobPayload(
   // aggregator groups by `meta.runId`). Assert the FULL required meta shape —
   // `triggered`/`enqueuedAt` are consumed downstream just like `runId`, so a
   // half-validated meta would only defer the failure past this boundary.
+  // `enqueuedAt` must be NON-EMPTY like the other strings: the empty string
+  // is exactly `emptyPayloadForLease`'s never-aggregate sentinel — minted
+  // ONLY for heartbeat-only renew fallbacks that never cross this boundary —
+  // so a caller-supplied "" is the same forbidden class as an empty runId.
   const meta = candidate.meta as Partial<ServiceJobMeta> | null;
   if (
     meta === null ||
@@ -319,10 +323,11 @@ function assertServiceJobPayload(
     typeof meta.runId !== "string" ||
     meta.runId === "" ||
     typeof meta.triggered !== "boolean" ||
-    typeof meta.enqueuedAt !== "string"
+    typeof meta.enqueuedAt !== "string" ||
+    meta.enqueuedAt === ""
   ) {
     throw new Error(
-      `queue-client: ${label} payload.meta must be a non-null object with a non-empty string runId, boolean triggered and string enqueuedAt`,
+      `queue-client: ${label} payload.meta must be a non-null object with a non-empty string runId, boolean triggered and non-empty string enqueuedAt`,
     );
   }
   // Optional fields still have REQUIRED shapes when present: cellIds is a
@@ -416,6 +421,29 @@ function probeKeySlug(probeKey: string): string {
   // is the caller's problem (the synthesis call site substitutes a
   // jobId-derived placeholder).
   return slug === "" ? probeKey : slug;
+}
+
+/**
+ * TRUE for a thrown endpoint error in the DETERMINISTIC rejection class: the
+ * hook (or PB auth) rejected the request BEFORE any transaction ran, and the
+ * same request will be rejected identically on every retry — the renew and
+ * sweep carve-outs key on this to escape their conservative containments.
+ * 408 (timeout) and 429 (rate limit) are 4xx by STATUS but TRANSIENT by
+ * meaning — a retry can succeed — so they stay on the callers'
+ * indeterminate/conservative paths (evicting a lease or skipping a comm
+ * error on a momentary rate-limit blip would manufacture the exact false
+ * signals the containments exist to prevent).
+ */
+function deterministicEndpointRejection(
+  err: unknown,
+): err is JobClaimEndpointError {
+  return (
+    err instanceof JobClaimEndpointError &&
+    err.status >= 400 &&
+    err.status < 500 &&
+    err.status !== 408 &&
+    err.status !== 429
+  );
 }
 
 /**
@@ -736,9 +764,16 @@ export function createFleetQueueClient(
         // the starvation class fairness exists to prevent — so mirror the
         // sweep's truncation warn. The hidden family is still claimable on
         // later polls once the families ahead of it drain out of pending.
+        // The head at the bound can itself be clause-unsafe garbage (it
+        // would never have been DISCOVERED, only excluded by row id) —
+        // thread its clause-safety so the warn doesn't overclaim a hidden
+        // CLAIMABLE family for unclaimable junk.
         logger.warn("queue-client.family-discovery-truncated", {
           maxFamilies: MAX_PENDING_FAMILIES,
           nextProbeKey: head.probe_key,
+          nextFamilyClauseSafe: familyClauseSafe(
+            probeKeyFamily(head.probe_key),
+          ),
         });
         break;
       }
@@ -1132,12 +1167,10 @@ export function createFleetQueueClient(
         // worker — UNBOUNDED double-run, falsifying the one-lease-duration
         // risk bound documented below. Treat it like a definitively lost
         // CAS: error log (an operator must look — the rejection recurs),
-        // evict both caches, return null so the heartbeat stops.
-        if (
-          err instanceof JobClaimEndpointError &&
-          err.status >= 400 &&
-          err.status < 500
-        ) {
+        // evict both caches, return null so the heartbeat stops. 408/429
+        // are excluded (transient by meaning — see
+        // deterministicEndpointRejection).
+        if (deterministicEndpointRejection(err)) {
           logger.error("queue-client.renew-rejected", {
             jobId,
             workerId,
@@ -1695,13 +1728,10 @@ export function createFleetQueueClient(
           // per-sweep false worker-reclaimed-pending overlay for a row that
           // never moves. Log loud (error — the row IS wedged and needs an
           // operator) and synthesize nothing: no grace, no comm error, no
-          // reclaimed++. Only 5xx/transport/2xx-unreadable throws — the
-          // genuinely indeterminate class — stay conservative.
-          if (
-            err instanceof JobClaimEndpointError &&
-            err.status >= 400 &&
-            err.status < 500
-          ) {
+          // reclaimed++. Only 5xx/transport/2xx-unreadable throws — plus
+          // the transient-by-meaning 408/429 (see
+          // deterministicEndpointRejection) — stay conservative.
+          if (deterministicEndpointRejection(err)) {
             logger.error("queue-client.sweep-release-rejected", {
               jobId: row.id,
               workerId: holder,

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -415,6 +415,49 @@ function probeKeySlug(probeKey: string): string {
 }
 
 /**
+ * Build the synthetic `worker-protocol-violation` result the claim race
+ * persists when a row must be released terminal WITHOUT a decodable payload
+ * (a claim-time decode failure, or a won-without-job endpoint breach). A
+ * terminal resultless row past the consumer's grace window is synthesized as
+ * a RED `worker-crashed-mid-job` — a protocol breach is NOT a crash, so this
+ * result carries the honest taxonomy kind instead. Honors
+ * `emptyPayloadForLease`'s no-empty-sentinel contract: `serviceSlug` is
+ * recovered from the row's probe_key slug segment (jobId-derived placeholder
+ * when even that is empty) and `runId` is minted from the jobId
+ * (non-colliding), while the aggregate key falls back to the row's probe_key
+ * (the `d6:<slug>` aggregate row key) — mirroring the worker's comm-error
+ * result builder.
+ */
+function protocolViolationResult(args: {
+  jobId: string;
+  probeKey: string;
+  workerId: string;
+  message: string;
+  observedAt: string;
+}): ServiceJobResult {
+  return {
+    jobId: args.jobId,
+    probeKey: args.probeKey,
+    serviceSlug: probeKeySlug(args.probeKey) || `unknown-${args.jobId}`,
+    runId: `pviol_${args.jobId}`,
+    workerId: args.workerId,
+    aggregateState: "error",
+    aggregateKey: args.probeKey,
+    aggregateSignal: { error: args.message },
+    cells: [],
+    rollup: { total: 0, passed: 0, failed: 0 },
+    finishedAt: args.observedAt,
+    commError: {
+      kind: "worker-protocol-violation",
+      message: args.message,
+      workerId: args.workerId,
+      jobId: args.jobId,
+      observedAt: args.observedAt,
+    },
+  };
+}
+
+/**
  * Anchor the PB space→"T" date-separator rewrite to the canonical PB shape
  * (`YYYY-MM-DD ` then time) so we ONLY convert the date/time boundary, never an
  * arbitrary first space. MUST stay byte-for-byte identical to the JSVM hook's
@@ -870,11 +913,19 @@ export function createFleetQueueClient(
             // (nobody renews or reports the orphaned claim; the sweeper
             // later reclaims it under a FALSE worker-reclaimed-pending
             // overlay). Make the breach visible, then mirror the
-            // decode-failure containment with a best-effort release back to
-            // `pending` (no work happened, and unlike a poison payload the
-            // job itself may be perfectly runnable). Failures are
-            // swallowed+warned: if this worker did NOT actually own the row,
-            // the release is refused/4xxs and nothing changes.
+            // decode-failure containment below: release the row TERMINAL
+            // (`failed`) and persist a synthetic worker-protocol-violation
+            // result. A `pending`-target release can NEVER succeed here —
+            // the hook refuses every pending-target release while the row's
+            // lease is live (`refused_lease_live`, no holder exemption; a
+            // committed win just MINTED that lease) and `refused_not_holder`
+            // otherwise — whereas a terminal target passes the live-lease
+            // gate (the expiry gate only rejects EXPIRED leases). The job
+            // may have been perfectly runnable, but there is no honest path
+            // back to pending; the synthetic result attributes the discard
+            // to the breach instead of a false crash/reclaim overlay.
+            // Failures are swallowed+warned: if this worker did NOT actually
+            // own the row, the release is refused/4xxs and nothing changes.
             logger.warn("queue-client.claim-won-without-job", {
               jobId: candidate.id,
               workerId: raceWorkerId,
@@ -883,7 +934,7 @@ export function createFleetQueueClient(
               const released = await claim.releaseJob(
                 candidate.id,
                 raceWorkerId,
-                "pending",
+                "failed",
               );
               if (!released.released) {
                 logger.warn(
@@ -894,6 +945,39 @@ export function createFleetQueueClient(
                     reason: released.reason ?? "unknown",
                   },
                 );
+              } else {
+                // The row is now TERMINAL but RESULTLESS — write the
+                // best-effort synthetic result so the consumer renders the
+                // honest protocol-violation signal instead of synthesizing
+                // a RED crash past grace. SINGLE attempt, same trade as the
+                // decode-failure write below (G1g): this happens INSIDE the
+                // claim race, so retry pacing would stall the rotation.
+                const observedAt = new Date(now()).toISOString();
+                const violation = protocolViolationResult({
+                  jobId: candidate.id,
+                  probeKey: candidate.probe_key,
+                  workerId: raceWorkerId,
+                  message: `claim CAS for job ${candidate.id} returned won:true without a job view (endpoint contract breach)`,
+                  observedAt,
+                });
+                try {
+                  await pb.update(PROBE_JOBS_COLLECTION, candidate.id, {
+                    result: violation,
+                    result_processed: false,
+                  });
+                } catch (writeErr) {
+                  logger.warn(
+                    "queue-client.claim-won-without-job-result-write-lost",
+                    {
+                      jobId: candidate.id,
+                      workerId: raceWorkerId,
+                      err:
+                        writeErr instanceof Error
+                          ? writeErr.message
+                          : String(writeErr),
+                    },
+                  );
+                }
               }
             } catch (releaseErr) {
               logger.warn(
@@ -961,42 +1045,19 @@ export function createFleetQueueClient(
                 // move on, never throw out of claimNext.
                 // Injected clock (config.now) — not a bare `new Date()` — so
                 // the synthetic timestamps are pinnable under test clocks.
+                // No decodable payload → nothing to ECHO; the shared builder
+                // honors the no-empty-sentinel contract (slug recovered from
+                // the probe_key, runId minted from the jobId).
                 const observedAt = new Date(now()).toISOString();
-                const message = `job ${result.job.id} payload failed to decode at claim time: ${
-                  err instanceof Error ? err.message : String(err)
-                }`;
-                const violation: ServiceJobResult = {
+                const violation = protocolViolationResult({
                   jobId: result.job.id,
                   probeKey: candidate.probe_key,
-                  // No decodable payload → nothing to ECHO, but the result
-                  // must not carry the empty `serviceSlug`/`runId` sentinels
-                  // `emptyPayloadForLease` forbids feeding aggregation (an
-                  // empty runId groups into nothing; an empty serviceSlug
-                  // corrupts the per-service rollup). Recover the slug from
-                  // the row's probe_key (`d6:<slug>` → `<slug>`) and mint a
-                  // non-colliding synthetic runId from the jobId. The
-                  // aggregate key falls back to the row's probe_key (the
-                  // `d6:<slug>` aggregate row key), mirroring the worker's
-                  // comm-error result builder.
-                  serviceSlug:
-                    probeKeySlug(candidate.probe_key) ||
-                    `unknown-${result.job.id}`,
-                  runId: `pviol_${result.job.id}`,
                   workerId: raceWorkerId,
-                  aggregateState: "error",
-                  aggregateKey: candidate.probe_key,
-                  aggregateSignal: { error: message },
-                  cells: [],
-                  rollup: { total: 0, passed: 0, failed: 0 },
-                  finishedAt: observedAt,
-                  commError: {
-                    kind: "worker-protocol-violation",
-                    message,
-                    workerId: raceWorkerId,
-                    jobId: result.job.id,
-                    observedAt,
-                  },
-                };
+                  message: `job ${result.job.id} payload failed to decode at claim time: ${
+                    err instanceof Error ? err.message : String(err)
+                  }`,
+                  observedAt,
+                });
                 // SINGLE attempt (G1g) — deliberately NOT writeResult's
                 // bounded retry + 250ms pacing: this write happens INSIDE
                 // the claim race, so each retry pause stalls the whole

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -689,6 +689,17 @@ export function createFleetQueueClient(
       // Scan claimed/running rows for expired leases (crashed/unreachable
       // workers). PB lacks an OR-of-equals shortcut here, so list both running
       // states and filter by lease in-process.
+      //
+      // ONE SWEEP OF GRACE: rows the lease phase re-queues below are tracked
+      // and EXCLUDED from this call's stale-pending phase. The stale phase
+      // ages off PB's system `created` (the ORIGINAL enqueue time — re-queue
+      // does not touch it), so a long-claimed job would otherwise be re-queued
+      // ("back in flight" per the worker-reclaimed-pending comm error) and
+      // then immediately claimed-and-deleted by the SAME call — falsifying the
+      // comm error and nulling downstream aggregate-key resolution on the
+      // deleted row. If the job is truly stale it ages out on the NEXT sweep.
+      // (Re-anchoring the age to the re-queue time would need a column; the
+      // `created` anchor is kept otherwise.)
       const page = await pb.list<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
         filter: 'status = "claimed" || status = "running"',
         perPage: CLAIM_CANDIDATE_PAGE,
@@ -696,6 +707,7 @@ export function createFleetQueueClient(
       });
       const commErrors: PoolCommError[] = [];
       let reclaimed = 0;
+      const requeuedThisSweep = new Set<string>();
       const observedAt = new Date(nowMs).toISOString();
       for (const row of page.items) {
         if (!leaseExpired(row.lease_expires_at, nowMs)) continue;
@@ -717,6 +729,7 @@ export function createFleetQueueClient(
           continue;
         }
         reclaimed += 1;
+        requeuedThisSweep.add(row.id);
         // The sweep boundary CANNOT distinguish a real worker crash from an
         // expected platform teardown (Railway scale-down / redeploy SIGKILL with
         // no graceful drain) — both leave an identical expired lease on a
@@ -768,6 +781,14 @@ export function createFleetQueueClient(
           },
         );
         for (const row of pendingPage.items) {
+          // ONE SWEEP OF GRACE (see function header): a row the lease phase
+          // re-queued moments ago in THIS call is "back in flight" — deleting
+          // it now would falsify the worker-reclaimed-pending comm error just
+          // emitted for it. Skip it; if truly stale it expires next sweep.
+          if (requeuedThisSweep.has(row.id)) {
+            logger.debug("queue-client.sweep-stale-grace", { jobId: row.id });
+            continue;
+          }
           // Age off PB's system `created` (space-separated date form —
           // normalize with the SAME anchored rewrite as leaseExpired). Unlike
           // the lease path, an unparseable value is conservatively SKIPPED:

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -882,7 +882,10 @@ export function createFleetQueueClient(
       // familyClauseSafe), so its rows are skipped from claiming entirely
       // (probe keys are slugs, so this is garbage input). Discovery used to
       // BREAK here — starving every YOUNGER family behind the offending row
-      // for up to its 3h stale window. No FAMILY exclusion clause is needed
+      // for up to its FAMILY-CONFIGURED stale window (expiryPeriods × the
+      // family's production period; the wiring slot derives the periods
+      // from FLEET_FAMILY_PERIODS_MS in orchestrator.ts — there is no fixed
+      // 3h window). No FAMILY exclusion clause is needed
       // to see past it: exclude the offending ROW by id (PB system ids are
       // generated alphanumerics — no charset semantics in play) and
       // CONTINUE. Each unsafe row burns one discovery iteration, so a page
@@ -1810,6 +1813,13 @@ export function createFleetQueueClient(
               });
               continue;
             }
+            // COUNT-NAME CAVEAT: despite the name, `expiredPending` here
+            // counts a CLAIMED/RUNNING row (long-expired lease, stale
+            // created-age) deleted by this carve-out — not just stale
+            // PENDING rows from the drain phase. The shared contract doc
+            // (`SweepResult.expiredPending`, contracts.ts: "STALE PENDING
+            // jobs ... sat unclaimed") describes only the drain phase and
+            // needs the same clarification.
             expiredPending += 1;
             logger.warn("queue-client.sweep-lease-stale-deleted", {
               jobId: row.id,

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -306,6 +306,11 @@ function leaseFromJob(job: JobView, payload: ServiceJobPayload): JobLease {
  * shape intact for the heartbeat; reporting always uses the payload the
  * worker received from its CLAIM. (A readonly marker field would need a
  * contracts.ts change; this comment is the boundary documentation.)
+ * The one path that DOES persist a result without a decodable payload — the
+ * decode-failure worker-protocol-violation synthesis in `claimNext` — honors
+ * this contract by recovering `serviceSlug` from the probe_key's slug
+ * segment (`probeKeySlug`) and minting a non-colliding synthetic runId
+ * instead of writing these empty sentinels.
  */
 function emptyPayloadForLease(job: JobView): ServiceJobPayload {
   return {
@@ -314,6 +319,19 @@ function emptyPayloadForLease(job: JobView): ServiceJobPayload {
     driverKind: "",
     meta: { runId: "", triggered: false, enqueuedAt: "" },
   };
+}
+
+/**
+ * The slug segment of a probe key — the complement of
+ * `probeKeyFamily` (contracts.ts): `d6:langgraph-python` →
+ * `langgraph-python`. Mirrors that helper's `idx <= 0` rule: a colon-less
+ * (or leading-colon) key has no family prefix, so the whole key doubles as
+ * the slug. Used to recover a non-empty `serviceSlug` for the synthetic
+ * worker-protocol-violation result when the payload itself is undecodable.
+ */
+function probeKeySlug(probeKey: string): string {
+  const idx = probeKey.indexOf(":");
+  return idx <= 0 ? probeKey : probeKey.slice(idx + 1);
 }
 
 /**
@@ -694,12 +712,18 @@ export function createFleetQueueClient(
                 const violation: ServiceJobResult = {
                   jobId: result.job.id,
                   probeKey: candidate.probe_key,
-                  // No decodable payload → no serviceSlug/runId to echo; the
+                  // No decodable payload → nothing to ECHO, but the result
+                  // must not carry the empty `serviceSlug`/`runId` sentinels
+                  // `emptyPayloadForLease` forbids feeding aggregation (an
+                  // empty runId groups into nothing; an empty serviceSlug
+                  // corrupts the per-service rollup). Recover the slug from
+                  // the row's probe_key (`d6:<slug>` → `<slug>`) and mint a
+                  // non-colliding synthetic runId from the jobId. The
                   // aggregate key falls back to the row's probe_key (the
                   // `d6:<slug>` aggregate row key), mirroring the worker's
                   // comm-error result builder.
-                  serviceSlug: "",
-                  runId: "",
+                  serviceSlug: probeKeySlug(candidate.probe_key),
+                  runId: `pviol_${result.job.id}`,
                   workerId: raceWorkerId,
                   aggregateState: "error",
                   aggregateKey: candidate.probe_key,

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -57,6 +57,7 @@ import type {
   ReportJobInput,
   ServiceJobMeta,
   ServiceJobPayload,
+  ServiceJobResult,
   SweepResult,
 } from "./contracts.js";
 
@@ -376,6 +377,44 @@ export function createFleetQueueClient(
   // time and reuse it on renew, making the re-read a non-fatal convenience.
   const payloadCache = new Map<string, ServiceJobPayload>();
 
+  /**
+   * Bounded-retry persistence of a per-service result onto an ALREADY
+   * TERMINAL probe_jobs row — the SEPARATE record write that follows a
+   * release CAS (migration 1779989700 adds `result` + `result_processed`).
+   * Never throws: returns `{ ok: true }` on success, or `{ ok: false,
+   * lastErr }` after RESULT_WRITE_MAX_ATTEMPTS attempts so each caller
+   * decides whether the loss is fatal (`report` — distinct "result lost"
+   * error) or best-effort (the decode-failure attribution in `claimNext`).
+   * `result_processed` seeds false: the consumer latches it true after
+   * aggregating exactly once.
+   */
+  async function writeResult(
+    jobId: string,
+    workerId: string,
+    result: ServiceJobResult,
+  ): Promise<{ ok: boolean; lastErr?: unknown }> {
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= RESULT_WRITE_MAX_ATTEMPTS; attempt++) {
+      try {
+        await pb.update(PROBE_JOBS_COLLECTION, jobId, {
+          result,
+          result_processed: false,
+        });
+        return { ok: true };
+      } catch (err) {
+        lastErr = err;
+        logger.warn("queue-client.result-write-failed", {
+          jobId,
+          workerId,
+          attempt,
+          maxAttempts: RESULT_WRITE_MAX_ATTEMPTS,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    return { ok: false, lastErr };
+  }
+
   // FAMILY FAIRNESS rotation cursor: the family this client most recently
   // claimed from. The next claimNext starts its family rotation AFTER this
   // one, so consecutive claims round-robin across the distinct families
@@ -537,7 +576,66 @@ export function createFleetQueueClient(
             // forever. A refused release here is non-fatal — another sweeper or
             // a later reclaim handles it; we must not throw out of claimNext.
             try {
-              await claim.releaseJob(result.job.id, raceWorkerId, "failed");
+              const released = await claim.releaseJob(
+                result.job.id,
+                raceWorkerId,
+                "failed",
+              );
+              if (released.released) {
+                // The row is now TERMINAL but RESULTLESS — per the result
+                // consumer's contract a terminal resultless row past its grace
+                // window is synthesized as `worker-crashed-mid-job` (a RED
+                // "crashed" overlay). A poison payload is NOT a crash: write a
+                // best-effort synthetic result attributing the failure as
+                // `worker-protocol-violation` (the taxonomy's "failed
+                // schema/shape validation" kind) so the consumer renders the
+                // honest signal. Best-effort: if the write itself is lost the
+                // consumer's crash synthesis remains the fallback — log and
+                // move on, never throw out of claimNext.
+                const observedAt = new Date().toISOString();
+                const message = `job ${result.job.id} payload failed to decode at claim time: ${
+                  err instanceof Error ? err.message : String(err)
+                }`;
+                const violation: ServiceJobResult = {
+                  jobId: result.job.id,
+                  probeKey: candidate.probe_key,
+                  // No decodable payload → no serviceSlug/runId to echo; the
+                  // aggregate key falls back to the row's probe_key (the
+                  // `d6:<slug>` aggregate row key), mirroring the worker's
+                  // comm-error result builder.
+                  serviceSlug: "",
+                  runId: "",
+                  workerId: raceWorkerId,
+                  aggregateState: "error",
+                  aggregateKey: candidate.probe_key,
+                  aggregateSignal: { error: message },
+                  cells: [],
+                  rollup: { total: 0, passed: 0, failed: 0 },
+                  finishedAt: observedAt,
+                  commError: {
+                    kind: "worker-protocol-violation",
+                    message,
+                    workerId: raceWorkerId,
+                    jobId: result.job.id,
+                    observedAt,
+                  },
+                };
+                const write = await writeResult(
+                  result.job.id,
+                  raceWorkerId,
+                  violation,
+                );
+                if (!write.ok) {
+                  logger.warn("queue-client.claim-decode-result-write-lost", {
+                    jobId: result.job.id,
+                    workerId: raceWorkerId,
+                    err:
+                      write.lastErr instanceof Error
+                        ? write.lastErr.message
+                        : String(write.lastErr),
+                  });
+                }
+              }
             } catch (releaseErr) {
               logger.warn("queue-client.claim-decode-release-failed", {
                 jobId: result.job.id,
@@ -648,36 +746,26 @@ export function createFleetQueueClient(
         // consumer aggregates. If this write fails and we just gave up, the
         // result is SILENTLY DROPPED (terminal row, empty result → the consumer
         // latches it resultless past grace, the dashboard never updates). So
-        // RETRY the write (bounded) before surfacing a DISTINCT "result lost"
-        // error, so the failure mode is unmistakable in logs vs. a refused
-        // release.
-        let lastErr: unknown;
-        for (let attempt = 1; attempt <= RESULT_WRITE_MAX_ATTEMPTS; attempt++) {
-          try {
-            await pb.update(PROBE_JOBS_COLLECTION, input.jobId, {
-              result: input.result,
-              result_processed: false,
-            });
-            logger.debug("queue-client.reported", {
-              jobId: input.jobId,
-              workerId: input.workerId,
-              status,
-            });
-            return;
-          } catch (err) {
-            lastErr = err;
-            logger.warn("queue-client.result-write-failed", {
-              jobId: input.jobId,
-              workerId: input.workerId,
-              attempt,
-              maxAttempts: RESULT_WRITE_MAX_ATTEMPTS,
-              err: err instanceof Error ? err.message : String(err),
-            });
-          }
+        // the helper RETRIES the write (bounded) and we surface a DISTINCT
+        // "result lost" error on exhaustion, so the failure mode is
+        // unmistakable in logs vs. a refused release.
+        const write = await writeResult(
+          input.jobId,
+          input.workerId,
+          input.result,
+        );
+        if (write.ok) {
+          logger.debug("queue-client.reported", {
+            jobId: input.jobId,
+            workerId: input.workerId,
+            status,
+          });
+          return;
         }
         // Exhausted the retries: the release SUCCEEDED (row is terminal) but the
         // result write FAILED — the result is LOST. Surface this distinctly so
         // an operator can tell it apart from a refused release.
+        const lastErr = write.lastErr;
         logger.error("queue-client.result-write-lost", {
           jobId: input.jobId,
           workerId: input.workerId,

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -1566,8 +1566,17 @@ export function createFleetQueueClient(
         // CAS admits an expired-lease claimed/running row — its reclaim
         // safety net — so the delete stays race-free). No comm error and no
         // reclaimed++: the work is discarded, not re-run. The carve-out
-        // requires a PARSEABLE created AND lease — anything unparseable
-        // stays on the conservative re-queue path below. Sweeper-held rows
+        // requires a PARSEABLE created — an unparseable created stays on
+        // the conservative re-queue path below, and that COMPOSES honestly:
+        // the stale phase skips unparseable-created rows too, so the
+        // re-queued row stays claimable and "back in flight" stays true. An
+        // UNPARSEABLE (or empty) lease is the opposite: it carries no
+        // recent-flight evidence EITHER phase can honor — the stale phase's
+        // recent-lease protection needs a finite lease — so re-queueing
+        // would emit a "back in flight" signal the next sweep falsifies by
+        // claim-deleting the row off its stale created age. Treat it as
+        // long-expired and delete it HERE, so the emitted signal (none)
+        // matches the eventual outcome (discard). Sweeper-held rows
         // (stale garbage mid-deletion, 60s lease) are always RECENTLY
         // expired, so they keep their silent re-queue retry contract.
         if (staleExpiryPeriods > 0 && holder !== STALE_PENDING_SWEEPER_ID) {
@@ -1582,8 +1591,7 @@ export function createFleetQueueClient(
           const staleExpirable =
             !Number.isNaN(createdMs) &&
             nowMs - createdMs > maxAgeMs &&
-            Number.isFinite(leaseMs) &&
-            leaseMs <= nowMs - maxAgeMs;
+            (!Number.isFinite(leaseMs) || leaseMs <= nowMs - maxAgeMs);
           if (staleExpirable) {
             // PER-ROW containment mirrors the stale phase: a thrown claim is
             // indeterminate (skip this sweep; the row is unchanged for the

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -47,6 +47,7 @@
 import type { Logger } from "../types/index.js";
 import type { PbClient } from "../storage/pb-client.js";
 import type { JobClaimClient, JobView, ReleaseResult } from "./job-claim.js";
+import { RELEASE_REFUSED_TERMINAL_SAME_HOLDER } from "./job-claim.js";
 import { probeKeyFamily, terminalJobStatus } from "./contracts.js";
 import type {
   ClaimedJob,
@@ -850,16 +851,33 @@ export function createFleetQueueClient(
           status,
         );
         if (!result.released) {
-          // The CAS refused the release — not the lease holder, or the row is
-          // no longer running (likely already swept/reclaimed). The JOB is not
-          // lost (the sweeper's reclaim path, REQ-B, keeps it in flight), but
-          // this worker's COMPUTED RESULT is: it is never persisted, and the
-          // re-queued job re-runs from scratch on another claim. Say exactly
-          // that — the old "nothing was lost" framing hid a full job's worth
-          // of discarded work from the operator reading the log.
-          throw new Error(
-            `queue-client: release refused for job ${input.jobId} (worker ${input.workerId}, status ${status}) — not the lease holder or row not running; this worker's computed result is DISCARDED and the job re-runs after reclamation`,
-          );
+          if (result.reason === RELEASE_REFUSED_TERMINAL_SAME_HOLDER) {
+            // TIMEOUT-AFTER-COMMIT retry: the row is already terminal UNDER
+            // THIS workerId — only this worker's OWN earlier release can
+            // have committed that (a terminal release retains claimed_by).
+            // So the refusal is the second leg of a report() retry whose
+            // first attempt released and then lost the response (or
+            // exhausted the result write). The result is still THIS holder's
+            // to write — proceed to writeResult instead of falsely declaring
+            // it discarded; this is what makes report() retryable.
+            logger.warn("queue-client.release-refused-terminal-same-holder", {
+              jobId: input.jobId,
+              workerId: input.workerId,
+              status,
+            });
+          } else {
+            // The CAS refused the release — not the (effective) lease holder,
+            // or the row was swept/stolen. The JOB is not lost (the sweeper's
+            // reclaim path, REQ-B, keeps a reclaimable row in flight), but
+            // this worker's COMPUTED RESULT is: it is never persisted. The
+            // job RE-RUNS ONLY IF it is (or gets) reclaimed to pending — a
+            // row another worker drove to terminal never re-runs. Say
+            // exactly that — the old wording promised an unconditional
+            // re-run the queue does not guarantee.
+            throw new Error(
+              `queue-client: release refused for job ${input.jobId} (worker ${input.workerId}, status ${status}, reason ${result.reason ?? "unknown"}) — not the lease holder or row not running; this worker's computed result is DISCARDED, and the job re-runs only if it is reclaimed to pending (terminal rows never re-run)`,
+            );
+          }
         }
         // PERSIST the per-service result onto the now-terminal row so the
         // control-plane's result-consumer (a DIFFERENT process) can aggregate

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -33,13 +33,15 @@
  * the PB client returns.
  *
  * ── WHY sweepExpired RE-QUEUES VIA S0 releaseJob(pending) ──────────────────
- * A worker that crashes mid-job leaves its lease to expire with no terminal
- * report. The sweeper (control-plane S4) finds those rows, re-queues each via
- * S0's `releaseJob(..., "pending")` ON BEHALF of the dead holder (the CAS
- * checks `claimed_by`, which is still the dead worker, so the release is
- * authorized and atomic), and synthesizes a `worker-crashed-mid-job`
- * `PoolCommError` (REQ-B) per reclaimed job so the dashboard renders
- * "couldn't reach the pool" distinctly from a probe red.
+ * A lease that expires with no terminal report could be a real worker crash
+ * OR an expected platform teardown (Railway scale-down / redeploy SIGKILL) —
+ * the sweep boundary cannot tell them apart. The sweeper (control-plane S4)
+ * finds those rows, re-queues each via S0's `releaseJob(..., "pending")` ON
+ * BEHALF of the lapsed holder (the CAS checks `claimed_by`, which is still
+ * that worker, so the release is authorized and atomic), and synthesizes a
+ * neutral `worker-reclaimed-pending` `PoolCommError` (REQ-B) per reclaimed
+ * job — the dashboard renders it as a gray "re-queued" surface, NOT a red
+ * crash/unreachable overlay (the job is back in flight).
  */
 
 import type { Logger } from "../types/index.js";

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -280,8 +280,13 @@ function emptyPayloadForLease(job: JobView): ServiceJobPayload {
  * expired, or vice versa). An odd shape must fall through to NaN → expired
  * (never wedge the queue), but only because the value genuinely failed to
  * parse, not because we mangled it into a parseable one.
+ *
+ * Exported (like `leaseExpired`) for direct unit testing: the anchoring
+ * contract is pinned at the STRING level so the test does not depend on
+ * engine-specific `Date.parse` leniency (V8 parses some non-canonical shapes
+ * that goja — the PB JSVM — rejects; see the leaseExpired test suite).
  */
-const PB_DATE_SEP_RE = /^(\d{4}-\d{2}-\d{2}) /;
+export const PB_DATE_SEP_RE = /^(\d{4}-\d{2}-\d{2}) /;
 
 /**
  * Has `leaseExpiresAt` elapsed as of `nowMs`? A null/empty/unparseable lease is

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -608,6 +608,16 @@ export function createFleetQueueClient(
       }
     },
 
+    async countPendingForFamily(family: string): Promise<number> {
+      // Producer backlog gate: a totals-bearing perPage=1 list — PB computes
+      // the COUNT server-side (totalItems); we never page rows back.
+      const page = await pb.list<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
+        filter: `status = "pending" && ${familyInclusionClause(family)}`,
+        perPage: 1,
+      });
+      return page.totalItems;
+    },
+
     async sweepExpired(nowMs: number): Promise<SweepResult> {
       // Scan claimed/running rows for expired leases (crashed/unreachable
       // workers). PB lacks an OR-of-equals shortcut here, so list both running

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -854,11 +854,17 @@ export function createFleetQueueClient(
       // dashboard signal.
       // The drain LOOPS pages (up to STALE_PENDING_MAX_PAGES_PER_SWEEP): a
       // single 50-row page per sweep would take ~7.5h to drain the motivating
-      // 3,734-row backlog at ~10 sweeps/hour. Each pass re-lists PAGE 1 —
-      // deleting rows shifts pagination, so the next listing naturally yields
-      // the next-oldest batch. A pass that expires NOTHING terminates the
-      // loop: every remaining page-1 row was skipped (too young / unparseable
-      // / claim lost), and re-listing would return the same rows forever.
+      // 3,734-row backlog at ~10 sweeps/hour. When a pass removed rows from
+      // pending (deleted, or a claim CAS ran — win or lose, the row LEFT
+      // pending), pagination shifted back, so the SAME page index is
+      // re-listed and naturally yields the shifted-in batch. When a FULL page
+      // produced no claim attempt at all (every row too young / graced /
+      // unparseable), nothing shifted — ADVANCE to the next page instead of
+      // stopping: expiry is per-FAMILY while the sort is absolute `created`,
+      // so younger expirable fast-family rows can sit BEYOND a full page of
+      // not-yet-expirable slow-family rows (cross-family occlusion — the
+      // class this drain exists to fix). Only a NON-FULL page proves the
+      // queue's tail was seen; the page cap still bounds a sweep's work.
       // PHASE containment (REQ-B): the whole stale drain is wrapped so a
       // throw anywhere inside it (the pending pb.list, the claim CAS — only
       // pb.delete was caught per-row) still returns the lease phase's partial
@@ -885,18 +891,23 @@ export function createFleetQueueClient(
        */
       async function drainStalePending(): Promise<void> {
         if (staleExpiryPeriods <= 0) return;
+        let listPage = 1;
         for (let pass = 0; pass < STALE_PENDING_MAX_PAGES_PER_SWEEP; pass++) {
           const pendingPage = await pb.list<ProbeJobRecord>(
             PROBE_JOBS_COLLECTION,
             {
               filter: 'status = "pending"',
               sort: "created",
+              page: listPage,
               perPage: CLAIM_CANDIDATE_PAGE,
               skipTotal: true,
             },
           );
           if (pendingPage.items.length === 0) break;
-          let passExpired = 0;
+          // Rows that reached the claim CAS this pass — win or lose, such a
+          // row LEFT "pending" (won → claimed by the sweeper; lost → claimed
+          // by a racing worker), so any attempt means pagination shifted.
+          let passAttempted = 0;
           for (const row of pendingPage.items) {
             // ONE SWEEP OF GRACE (see function header): a row the lease phase
             // re-queued moments ago in THIS call is "back in flight" — deleting
@@ -927,6 +938,7 @@ export function createFleetQueueClient(
             const maxAgeMs = staleExpiryPeriods * stalePeriodMsFor(family);
             const ageMs = nowMs - createdMs;
             if (ageMs <= maxAgeMs) continue;
+            passAttempted += 1;
             const won = await claim.claimJob(
               row.id,
               STALE_PENDING_SWEEPER_ID,
@@ -953,7 +965,6 @@ export function createFleetQueueClient(
               });
               continue;
             }
-            passExpired += 1;
             // Per ROW (not per pass) so a mid-pass throw caught by the phase
             // wrapper still reports the rows already expired.
             expiredPending += 1;
@@ -965,11 +976,17 @@ export function createFleetQueueClient(
               maxAgeMs,
             });
           }
-          // No progress → every remaining pending row is non-expirable; a
-          // short page → we have already seen the queue's tail. Either way
-          // there is nothing more for THIS sweep to do.
-          if (passExpired === 0) break;
+          // A NON-FULL page → we have already seen the queue's tail; nothing
+          // more for this sweep to do. (A zero-EXPIRY pass is intentionally
+          // NOT a termination signal: claim-CAS-lost rows LEAVE pending, so
+          // expiring nothing does not mean re-listing returns the same rows.)
           if (pendingPage.items.length < CLAIM_CANDIDATE_PAGE) break;
+          // A FULL page where no row even reached the claim CAS: nothing left
+          // pending, pagination did not shift — ADVANCE past it (cross-family
+          // occlusion; see the drain header). Otherwise rows left pending and
+          // pagination shifted back, so re-list the SAME page index to see
+          // the shifted-in batch.
+          if (passAttempted === 0) listPage += 1;
         }
       }
     },

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -51,6 +51,7 @@ import type {
   JobClaimClient,
   JobView,
   ReleaseResult,
+  RenewResult,
 } from "./job-claim.js";
 import { RELEASE_REFUSED_TERMINAL_SAME_HOLDER } from "./job-claim.js";
 import { probeKeyFamily, terminalJobStatus } from "./contracts.js";
@@ -512,6 +513,17 @@ export function createFleetQueueClient(
   // time and reuse it on renew, making the re-read a non-fatal convenience.
   const payloadCache = new Map<string, ServiceJobPayload>();
 
+  // Last-known GOOD lease per held job, set at claim time and refreshed on
+  // every successful renew. This is what an INDETERMINATE renew (a thrown
+  // claim.renewLease — 5xx or 2xx-unreadable; the renew may or may not have
+  // committed) hands back to the heartbeat: the worker heartbeat treats a
+  // renewLease THROW like a lost lease (it breaks), so letting the throw
+  // escape kills the heartbeat → the sweeper reclaims a LIVE job → a FALSE
+  // worker-crashed-mid-job. Returning the current lease unchanged keeps the
+  // heartbeat alive so the NEXT beat retries; only a definitive
+  // `renewed: false` stops it. Evicted exactly where payloadCache is.
+  const leaseCache = new Map<string, JobLease>();
+
   /**
    * Bounded-retry persistence of a per-service result onto an ALREADY
    * TERMINAL probe_jobs row — the SEPARATE record write that follows a
@@ -858,13 +870,16 @@ export function createFleetQueueClient(
             continue;
           }
           // Cache for the renew path so a later heartbeat doesn't depend on a
-          // fresh PB re-read to re-hydrate the payload.
+          // fresh PB re-read to re-hydrate the payload, and remember the
+          // lease itself so an INDETERMINATE renew can keep it assumed-live.
           payloadCache.set(result.job.id, payload);
+          const lease = leaseFromJob(result.job, payload);
+          leaseCache.set(result.job.id, lease);
           logger.debug("queue-client.claimed", {
             jobId: result.job.id,
             workerId: raceWorkerId,
           });
-          return { claimed: true, lease: leaseFromJob(result.job, payload) };
+          return { claimed: true, lease };
         }
         return null;
       }
@@ -875,7 +890,40 @@ export function createFleetQueueClient(
       workerId: string,
       leaseSeconds: number,
     ): Promise<JobLease | null> {
-      const result = await claim.renewLease(jobId, workerId, leaseSeconds);
+      let result: RenewResult;
+      try {
+        result = await claim.renewLease(jobId, workerId, leaseSeconds);
+      } catch (err) {
+        // INDETERMINATE renew (thrown 5xx / transport blip / job-claim's
+        // 2xx-unreadable): the renew may or may not have committed. The
+        // worker heartbeat treats a renewLease THROW as fatal (it breaks),
+        // so an escaped throw stops heartbeating and the sweeper later
+        // reclaims a possibly-LIVE job — a false worker-crashed-mid-job.
+        // Contain it: keep the last-known lease ASSUMED-LIVE (no eviction,
+        // not null) so the heartbeat retries on the next beat; only a
+        // definitive `renewed: false` stops it.
+        //
+        // ACCEPTED RISK (at most one lease duration): if the renew really
+        // did NOT commit, the server-side lease keeps ticking toward its
+        // previous expiry while we assume-live — the sweeper may re-queue
+        // the job while this worker still runs it (duplicate execution for
+        // up to one lease window). That is bounded and safe: the release
+        // CAS arbitrates terminal writes, so the loser's report is refused.
+        const known = leaseCache.get(jobId);
+        if (known) {
+          logger.warn("queue-client.renew-indeterminate", {
+            jobId,
+            workerId,
+            msg: "renew indeterminate — keeping lease assumed-live, retrying next beat",
+            err: err instanceof Error ? err.message : String(err),
+          });
+          return known;
+        }
+        // No locally-known lease (no same-process claim preceded this renew
+        // — outside the worker flow): nothing to assume-live from, so stay
+        // loud rather than fabricate a lease.
+        throw err;
+      }
       if (!result.renewed || !result.job) {
         // The renew CAS was LOST: the lease is gone for this worker (stolen,
         // swept, or already terminal) and it will never report or renew this
@@ -884,6 +932,7 @@ export function createFleetQueueClient(
         // cache entry strands forever and the per-client map grows with
         // every lost/abandoned job.
         payloadCache.delete(jobId);
+        leaseCache.delete(jobId);
         return null;
       }
       // The renew CAS already returned the authoritative lifecycle columns. The
@@ -938,9 +987,13 @@ export function createFleetQueueClient(
         // payload synthesized from the authoritative CAS row. We ONLY return
         // null when the CAS itself failed (handled above).
         logger.warn("queue-client.renew-no-payload", { jobId, workerId });
-        return leaseFromJob(result.job, emptyPayloadForLease(result.job));
+        const fallback = leaseFromJob(result.job, emptyPayloadForLease(result.job));
+        leaseCache.set(jobId, fallback);
+        return fallback;
       }
-      return leaseFromJob(result.job, payload);
+      const renewedLease = leaseFromJob(result.job, payload);
+      leaseCache.set(jobId, renewedLease);
+      return renewedLease;
     },
 
     async report(input: ReportJobInput): Promise<void> {
@@ -1031,9 +1084,10 @@ export function createFleetQueueClient(
         );
       } finally {
         // Terminal for this worker no matter the outcome — drop the cached
-        // payload here so neither a refused release nor an exhausted result
-        // write leaks the entry.
+        // payload + lease here so neither a refused release nor an exhausted
+        // result write leaks the entries.
         payloadCache.delete(input.jobId);
+        leaseCache.delete(input.jobId);
       }
     },
 

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -723,6 +723,67 @@ export function createFleetQueueClient(
   ): Promise<{ ok: boolean; lastErr?: unknown }> {
     let lastErr: unknown;
     for (let attempt = 1; attempt <= RESULT_WRITE_MAX_ATTEMPTS; attempt++) {
+      // READ-BEFORE-RETRY (intra-call double-count guard, mirroring the
+      // cross-call guard in report()'s refused_terminal_same_holder path):
+      // a COMMITTED-THEN-THROWN attempt N leaves the result on the row, and
+      // the consumer can aggregate + LATCH result_processed: true inside
+      // the retry pause window. A blind attempt N+1 rewrite re-seeds
+      // result_processed: false — un-latching an already-aggregated result,
+      // which the consumer then counts TWICE. So every RETRY (never the
+      // first attempt) reads the row first:
+      //   - result present → the earlier attempt committed; skip the write.
+      //   - no result      → the earlier attempt truly failed; write.
+      //   - read failed / no row → REFUSE the blind rewrite (the un-latch
+      //     risk stands); the attempt is spent and a later retry re-reads.
+      if (attempt > 1) {
+        let existing: ProbeJobRecord | null = null;
+        let readFailed = false;
+        try {
+          existing = await pb.getOne<ProbeJobRecord>(
+            PROBE_JOBS_COLLECTION,
+            jobId,
+          );
+        } catch (readErr) {
+          readFailed = true;
+          lastErr = readErr;
+          logger.warn("queue-client.result-write-retry-read-failed", {
+            jobId,
+            workerId,
+            attempt,
+            err: readErr instanceof Error ? readErr.message : String(readErr),
+          });
+        }
+        if (!readFailed && existing === null) {
+          // Semantically a failed read (missing/unreadable row), not "no
+          // result present" — same refusal as the cross-call guard.
+          readFailed = true;
+          lastErr = new Error(
+            `queue-client: pre-retry read for job ${jobId} returned no row — refusing to blind-write`,
+          );
+        }
+        if (readFailed) {
+          if (attempt < RESULT_WRITE_MAX_ATTEMPTS) {
+            await sleep(RESULT_WRITE_RETRY_DELAY_MS);
+          }
+          continue;
+        }
+        // PB's unset-JSON shape reads back as "" — treat it as ABSENT (the
+        // same triage as the cross-call guard) so a genuinely-failed first
+        // attempt still lands its result.
+        if (
+          existing !== null &&
+          existing.result !== undefined &&
+          existing.result !== null &&
+          existing.result !== ""
+        ) {
+          logger.info("queue-client.result-write-already-landed", {
+            jobId,
+            workerId,
+            attempt,
+          });
+          return { ok: true };
+        }
+      }
       try {
         await pb.update(PROBE_JOBS_COLLECTION, jobId, {
           result,

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -45,7 +45,7 @@
 import type { Logger } from "../types/index.js";
 import type { PbClient } from "../storage/pb-client.js";
 import type { JobClaimClient, JobView } from "./job-claim.js";
-import { terminalJobStatus } from "./contracts.js";
+import { probeKeyFamily, terminalJobStatus } from "./contracts.js";
 import type {
   ClaimedJob,
   EnqueueJobInput,
@@ -67,8 +67,22 @@ import type {
  */
 export const PROBE_JOBS_COLLECTION = "probe_jobs";
 
-/** Max pending candidates `claimNext` scans per attempt — bounds the CAS race. */
+/**
+ * Max pending candidates `claimNext` scans PER FAMILY per attempt — bounds the
+ * CAS race. NOTE this is a per-family page, not one global page: a single
+ * oldest-50 global page let a high-frequency family's backlog permanently
+ * crowd a low-frequency family's jobs out of the candidate set (the e2e-demos
+ * starvation — see the FAMILY FAIRNESS note in `claimNext`).
+ */
 const CLAIM_CANDIDATE_PAGE = 50;
+
+/**
+ * Cap on the family-discovery loop in `claimNext` (one tiny query per distinct
+ * pending family). The fleet runs a handful of probe families (d4/d5/d6/
+ * e2e-demos); 16 is generous headroom while still bounding the per-poll query
+ * count if probe_key shapes ever proliferate unexpectedly.
+ */
+const MAX_PENDING_FAMILIES = 16;
 
 /**
  * Bounded retries for the post-release result write in `report()`. The release
@@ -213,6 +227,37 @@ export function leaseExpired(
 }
 
 /**
+ * Escape a value for embedding in a double-quoted PB filter literal. Families
+ * come from probe_key prefixes (config-controlled slugs like `d6` /
+ * `e2e-demos`), so this only needs to neutralize the quote/backslash chars
+ * that could break out of the literal. LIKE wildcards (`%`/`_`) are not
+ * expected in family names and are deliberately left alone.
+ */
+function escapeFilterLiteral(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * PB filter clause matching every probe_key in `family`. Keys are
+ * `<family>:<slug>` (the `~` LIKE leg); a colon-less probe_key IS its own
+ * family (the `=` leg) so such rows are still claimable under fairness.
+ */
+function familyInclusionClause(family: string): string {
+  const esc = escapeFilterLiteral(family);
+  return `(probe_key ~ "${esc}:%" || probe_key = "${esc}")`;
+}
+
+/**
+ * PB filter clause EXCLUDING every probe_key in `family` — the complement of
+ * `familyInclusionClause`, spelled with `!~`/`!=` because the PB filter
+ * grammar has no group negation.
+ */
+function familyExclusionClause(family: string): string {
+  const esc = escapeFilterLiteral(family);
+  return `probe_key !~ "${esc}:%" && probe_key != "${esc}"`;
+}
+
+/**
  * In-place Fisher-Yates shuffle used to randomize the candidate-attempt order
  * so concurrent workers don't all attack the same head-of-page row each poll.
  * Pure given the injected `rng`; mutates + returns `arr` for call-site brevity.
@@ -242,6 +287,56 @@ export function createFleetQueueClient(
   // time and reuse it on renew, making the re-read a non-fatal convenience.
   const payloadCache = new Map<string, ServiceJobPayload>();
 
+  // FAMILY FAIRNESS rotation cursor: the family this client most recently
+  // claimed from. The next claimNext starts its family rotation AFTER this
+  // one, so consecutive claims round-robin across the distinct families
+  // present in pending instead of draining the oldest family first.
+  let lastClaimedFamily: string | null = null;
+
+  /**
+   * Discover the DISTINCT families present in pending, oldest job first. PB's
+   * records API has no DISTINCT, so this peels one family per tiny query: read
+   * the single oldest pending row, note its family, and re-query with that
+   * family excluded until the queue is exhausted (or the MAX_PENDING_FAMILIES
+   * bound trips). At most F+1 perPage=1 queries for F families — cheap against
+   * the status-indexed probe_jobs table, and the price of never letting one
+   * family's backlog hide another family from the candidate scan.
+   */
+  async function discoverPendingFamilies(): Promise<string[]> {
+    const families: string[] = [];
+    const exclusions: string[] = [];
+    for (let i = 0; i < MAX_PENDING_FAMILIES; i++) {
+      const filter = ['status = "pending"', ...exclusions].join(" && ");
+      const page = await pb.list<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
+        filter,
+        sort: "created",
+        perPage: 1,
+        skipTotal: true,
+      });
+      const head = page.items[0];
+      if (!head) break;
+      const family = probeKeyFamily(head.probe_key);
+      // Defensive: a backend that didn't honor the exclusion clause would
+      // re-yield a seen family forever — break instead of spinning.
+      if (families.includes(family)) break;
+      families.push(family);
+      exclusions.push(familyExclusionClause(family));
+    }
+    return families;
+  }
+
+  /**
+   * Rotate `families` so iteration starts AFTER the family this client last
+   * claimed from (round-robin). An unknown/absent cursor keeps the discovered
+   * (oldest-first) order.
+   */
+  function rotateFamilies(families: string[]): string[] {
+    if (lastClaimedFamily === null) return families;
+    const idx = families.indexOf(lastClaimedFamily);
+    if (idx === -1) return families;
+    return [...families.slice(idx + 1), ...families.slice(0, idx + 1)];
+  }
+
   return {
     async enqueue(input: EnqueueJobInput): Promise<JobView> {
       const { payload } = input;
@@ -268,34 +363,69 @@ export function createFleetQueueClient(
       workerId: string,
       leaseSeconds: number,
     ): Promise<ClaimedJob> {
-      // List pending candidates, then race S0's atomic claim against each until
-      // one wins. Losing a CAS means a peer took it — fall through, don't error.
-      const page = await pb.list<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
-        filter: 'status = "pending"',
-        perPage: CLAIM_CANDIDATE_PAGE,
-        skipTotal: true,
-      });
-      // CLAIM FAIRNESS: every worker lists the SAME deterministically-ordered
-      // pending page (PB's default order is stable across callers), so iterating
-      // it head-first makes all 6 replicas thunder on the same head row every
-      // poll. The worker that re-polls fractionally first keeps winning the head;
-      // the losers burn extra CAS round-trips walking down the list, which makes
-      // them slower, poll less often, and claim less — compounding into a ~4x
-      // skew onto 2 hot workers (the observed staging contention that tipped legit
-      // settles past the per-turn budget). RANDOMIZING each worker's attempt
-      // order spreads the herd across the whole candidate page so a peer that
-      // already won the head doesn't force everyone else to serialize behind it —
-      // wins distribute evenly and no worker becomes a hot outlier. The CAS still
-      // guarantees exactly-one-winner per row; this only changes which order a
-      // given worker TRIES candidates, never the atomicity.
-      const candidates = shuffleInPlace([...page.items], rng);
-      for (const candidate of candidates) {
-        const result = await claim.claimJob(
-          candidate.id,
-          workerId,
-          leaseSeconds,
-        );
-        if (result.won && result.job) {
+      // FAMILY FAIRNESS: a single global oldest-50 pending page let a
+      // high-frequency family's persistent backlog (d4+d5 tick every 15min)
+      // permanently saturate the candidate page, so a low-frequency family's
+      // jobs (e2e-demos, hourly) NEVER entered it and were NEVER claimed
+      // (prod: all 18 e2e-demos jobs pending forever; staging: 3,734 pending,
+      // oldest 22h). So claimNext now discovers the DISTINCT families present
+      // in pending (oldest first) and tries them in ROTATION — round-robin
+      // across calls, resuming after the family this client last claimed —
+      // listing a PER-FAMILY candidate page for each. Every discovered family
+      // is attempted before giving up, so no family starves while any of its
+      // jobs are claimable. The CAS exactly-one-winner semantics are
+      // untouched; only the candidate SELECTION changed.
+      const families = rotateFamilies(await discoverPendingFamilies());
+      for (const family of families) {
+        // List this family's pending candidates (oldest first), then race
+        // S0's atomic claim against each until one wins. Losing a CAS means a
+        // peer took it — fall through, don't error.
+        const page = await pb.list<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
+          filter: `status = "pending" && ${familyInclusionClause(family)}`,
+          sort: "created",
+          perPage: CLAIM_CANDIDATE_PAGE,
+          skipTotal: true,
+        });
+        // CLAIM FAIRNESS (worker herd): every worker lists the SAME
+        // deterministically-ordered pending page, so iterating it head-first
+        // makes all 6 replicas thunder on the same head row every poll. The
+        // worker that re-polls fractionally first keeps winning the head; the
+        // losers burn extra CAS round-trips walking down the list, which makes
+        // them slower, poll less often, and claim less — compounding into a
+        // ~4x skew onto 2 hot workers (the observed staging contention that
+        // tipped legit settles past the per-turn budget). RANDOMIZING each
+        // worker's attempt order spreads the herd across the whole candidate
+        // page so a peer that already won the head doesn't force everyone else
+        // to serialize behind it — wins distribute evenly and no worker
+        // becomes a hot outlier. The CAS still guarantees exactly-one-winner
+        // per row; this only changes which order a given worker TRIES
+        // candidates, never the atomicity.
+        const candidates = shuffleInPlace([...page.items], rng);
+        const won = await raceCandidates(candidates, workerId, leaseSeconds);
+        if (won) {
+          lastClaimedFamily = family;
+          return won;
+        }
+      }
+      return { claimed: false };
+
+      /**
+       * Race S0's atomic claim against `candidates` in order until one wins.
+       * Returns the won ClaimedJob, or null when every candidate was lost to
+       * a peer (or released on decode failure).
+       */
+      async function raceCandidates(
+        candidates: ProbeJobRecord[],
+        raceWorkerId: string,
+        raceLeaseSeconds: number,
+      ): Promise<ClaimedJob | null> {
+        for (const candidate of candidates) {
+          const result = await claim.claimJob(
+            candidate.id,
+            raceWorkerId,
+            raceLeaseSeconds,
+          );
+          if (!result.won || !result.job) continue;
           // The CAS already WON — this worker now OWNS the row. Decoding the
           // payload from the (pre-claim) candidate row can still throw on a
           // malformed/absent payload; if we let that throw escape, the job is
@@ -311,18 +441,18 @@ export function createFleetQueueClient(
           } catch (err) {
             logger.error("queue-client.claim-decode-failed", {
               jobId: result.job.id,
-              workerId,
+              workerId: raceWorkerId,
               err: err instanceof Error ? err.message : String(err),
             });
             // Best-effort terminal release so the poison row doesn't re-list
             // forever. A refused release here is non-fatal — another sweeper or
             // a later reclaim handles it; we must not throw out of claimNext.
             try {
-              await claim.releaseJob(result.job.id, workerId, "failed");
+              await claim.releaseJob(result.job.id, raceWorkerId, "failed");
             } catch (releaseErr) {
               logger.warn("queue-client.claim-decode-release-failed", {
                 jobId: result.job.id,
-                workerId,
+                workerId: raceWorkerId,
                 err:
                   releaseErr instanceof Error
                     ? releaseErr.message
@@ -336,12 +466,12 @@ export function createFleetQueueClient(
           payloadCache.set(result.job.id, payload);
           logger.debug("queue-client.claimed", {
             jobId: result.job.id,
-            workerId,
+            workerId: raceWorkerId,
           });
           return { claimed: true, lease: leaseFromJob(result.job, payload) };
         }
+        return null;
       }
-      return { claimed: false };
     },
 
     async renewLease(

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -114,6 +114,14 @@ const MAX_PENDING_FAMILIES = 16;
 export const RESULT_WRITE_MAX_ATTEMPTS = 3;
 
 /**
+ * Pause between consecutive result-write attempts. Back-to-back retries land
+ * inside the same transient blip window (a PB restart/WAL hiccup spans more
+ * than a tick), so the bounded retry was burning all its attempts in
+ * microseconds. Exported so the pacing test pins this constant.
+ */
+export const RESULT_WRITE_RETRY_DELAY_MS = 250;
+
+/**
  * Default multiple of a family's production period after which an unclaimed
  * pending job is STALE (its family has enqueued ~3 fresher batches since; the
  * job's eventual result would be ancient data). Tunable via
@@ -211,6 +219,12 @@ export interface FleetQueueClientConfig {
    * explicit `nowMs` parameter — the sweep's caller owns that clock.
    */
   now?: () => number;
+  /**
+   * Injectable async pause used between result-write retry attempts
+   * (defaults to a real `setTimeout`). Injected so retry-pacing tests are
+   * instant and exact.
+   */
+  sleep?: (ms: number) => Promise<void>;
 }
 
 /** The persisted `probe_jobs` row shape as the PB records API returns it. */
@@ -355,7 +369,13 @@ function emptyPayloadForLease(job: JobView): ServiceJobPayload {
  */
 function probeKeySlug(probeKey: string): string {
   const idx = probeKey.indexOf(":");
-  return idx <= 0 ? probeKey : probeKey.slice(idx + 1);
+  const slug = idx <= 0 ? probeKey : probeKey.slice(idx + 1);
+  // A trailing-colon key ("d6:") slices to "" — the exact forbidden empty
+  // sentinel this helper exists to avoid (an empty serviceSlug corrupts the
+  // per-service rollup). Fall back to the WHOLE key; a fully-empty probe_key
+  // is the caller's problem (the synthesis call site substitutes a
+  // jobId-derived placeholder).
+  return slug === "" ? probeKey : slug;
 }
 
 /**
@@ -460,6 +480,14 @@ function escapeLikeLiteral(value: string): string {
  * LIKE leg would wrongly fold the DIFFERENT family `":foo:bar"` under
  * `":foo"`. Such families get the equality leg only. Normal prefix families
  * cannot contain a colon by construction, so testing for a colon is exact.
+ *
+ * KNOWN DIVERGENCE (documented, not fixed): SQLite `LIKE` is
+ * case-INSENSITIVE for ASCII while `=` is case-SENSITIVE, so for a
+ * MIXED-CASE family the two legs disagree — `probe_key ~ "D6:%"` would also
+ * match `d6:foo` rows while `probe_key = "D6"` would not match `d6` (and the
+ * exclusion clause diverges symmetrically). Unreachable in practice: probe
+ * keys are lowercase slugs by construction (the producers mint them from
+ * service slugs), so no mixed-case family ever reaches these builders.
  */
 function familyInclusionClause(family: string): string {
   if (family.includes(":")) {
@@ -503,6 +531,9 @@ export function createFleetQueueClient(
   const { pb, claim, logger } = config;
   const rng = config.rng ?? Math.random;
   const now = config.now ?? Date.now;
+  const sleep =
+    config.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const stalePolicy = config.stalePending ?? {};
   const staleExpiryPeriods =
     stalePolicy.expiryPeriods ?? DEFAULT_STALE_PENDING_EXPIRY_PERIODS;
@@ -564,6 +595,11 @@ export function createFleetQueueClient(
           maxAttempts: RESULT_WRITE_MAX_ATTEMPTS,
           err: err instanceof Error ? err.message : String(err),
         });
+        // Pace the retries: back-to-back attempts land inside the same
+        // transient blip window. Never sleep after the LAST attempt.
+        if (attempt < RESULT_WRITE_MAX_ATTEMPTS) {
+          await sleep(RESULT_WRITE_RETRY_DELAY_MS);
+        }
       }
     }
     return { ok: false, lastErr };
@@ -773,6 +809,16 @@ export function createFleetQueueClient(
             });
             continue;
           }
+          if (result.won && !result.job) {
+            // PROTOCOL VIOLATION: a win always carries the row view (the
+            // hook builds them together inside the transaction). Falling
+            // through silently abandons a row this worker may now OWN —
+            // make the contract breach visible before moving on.
+            logger.warn("queue-client.claim-won-without-job", {
+              jobId: candidate.id,
+              workerId: raceWorkerId,
+            });
+          }
           if (!result.won || !result.job) continue;
           // The CAS already WON — this worker now OWNS the row. Decoding the
           // payload from the (pre-claim) candidate row can still throw on a
@@ -801,6 +847,17 @@ export function createFleetQueueClient(
                 raceWorkerId,
                 "failed",
               );
+              if (!released.released) {
+                // A REFUSED release (vs a thrown one, logged in the catch
+                // below) was silent — the poison row stays claimed with no
+                // breadcrumb tying the refusal to the decode failure. The
+                // hook's reason says why (swept/stolen/already terminal).
+                logger.warn("queue-client.claim-decode-release-refused", {
+                  jobId: result.job.id,
+                  workerId: raceWorkerId,
+                  reason: released.reason ?? "unknown",
+                });
+              }
               if (released.released) {
                 // The row is now TERMINAL but RESULTLESS — per the result
                 // consumer's contract a terminal resultless row past its grace
@@ -831,7 +888,9 @@ export function createFleetQueueClient(
                   // aggregate key falls back to the row's probe_key (the
                   // `d6:<slug>` aggregate row key), mirroring the worker's
                   // comm-error result builder.
-                  serviceSlug: probeKeySlug(candidate.probe_key),
+                  serviceSlug:
+                    probeKeySlug(candidate.probe_key) ||
+                    `unknown-${result.job.id}`,
                   runId: `pviol_${result.job.id}`,
                   workerId: raceWorkerId,
                   aggregateState: "error",
@@ -930,6 +989,16 @@ export function createFleetQueueClient(
         // — outside the worker flow): nothing to assume-live from, so stay
         // loud rather than fabricate a lease.
         throw err;
+      }
+      if (result.renewed && !result.job) {
+        // PROTOCOL VIOLATION: a successful renew always carries the row view.
+        // We still fall through to the lost-lease handling below (we cannot
+        // build a lease from nothing), but the breach must be visible — it
+        // means the endpoint contract drifted, not that the lease was lost.
+        logger.warn("queue-client.renew-renewed-without-job", {
+          jobId,
+          workerId,
+        });
       }
       if (!result.renewed || !result.job) {
         // The renew CAS was LOST: the lease is gone for this worker (stolen,
@@ -1165,7 +1234,19 @@ export function createFleetQueueClient(
         perPage: 1,
         skipTotal: false,
       });
-      return page.totalItems;
+      // RUNTIME GUARD: even with skipTotal:false requested, a backend/client
+      // drift could still hand back -1 (or garbage) — and -1 is never above
+      // the producer's threshold, so returning it would silently FAIL OPEN
+      // the backlog gate. Refuse the poisoned value loudly.
+      const totalItems: unknown = page.totalItems;
+      if (typeof totalItems !== "number" || totalItems < 0) {
+        throw new Error(
+          `queue-client: countPendingForFamily("${family}") received a non-count totalItems (${String(
+            totalItems,
+          )}) despite skipTotal:false — refusing to fail the backlog gate open`,
+        );
+      }
+      return totalItems;
     },
 
     async sweepExpired(nowMs: number): Promise<SweepResult> {
@@ -1499,16 +1580,40 @@ export function createFleetQueueClient(
               });
               continue;
             }
+            // PER-ROW containment: the claim CAS can THROW (a deterministic
+            // 4xx from the hook, or a transport blip the 5xx mapping doesn't
+            // cover). Letting it escape to the phase wrapper aborts the
+            // WHOLE drain for one sick row — every later stale row goes
+            // unprocessed this sweep. Warn + continue; the row is NOT
+            // counted as attempted (indeterminate whether it left pending).
+            let won: ClaimResult;
+            try {
+              won = await claim.claimJob(
+                row.id,
+                STALE_PENDING_SWEEPER_ID,
+                STALE_PENDING_SWEEPER_LEASE_SECONDS,
+              );
+            } catch (err) {
+              logger.warn("queue-client.sweep-stale-claim-threw", {
+                jobId: row.id,
+                err: err instanceof Error ? err.message : String(err),
+              });
+              continue;
+            }
             passAttempted += 1;
-            const won = await claim.claimJob(
-              row.id,
-              STALE_PENDING_SWEEPER_ID,
-              STALE_PENDING_SWEEPER_LEASE_SECONDS,
-            );
             if (!won.won) {
               // A worker won the race — the job is in flight after all; not
               // ours to expire. (The row left "pending", so it also drops out
               // of the next pass's listing — no re-processing.)
+              //
+              // CAVEAT on the "left pending" assumption feeding passAttempted:
+              // job-claim maps a claim 5xx to won:false WITHOUT the row
+              // necessarily leaving pending. Such a row re-appears when the
+              // same page index is re-listed, so a page of persistently-5xx
+              // rows is retried pass after pass — bounded by the
+              // STALE_PENDING_MAX_PAGES_PER_SWEEP cap, after which the sweep
+              // ends and the NEXT sweep retries. A bounded stall on a sick
+              // backend, never an infinite loop.
               logger.debug("queue-client.sweep-stale-claim-lost", {
                 jobId: row.id,
               });

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -1325,12 +1325,19 @@ export function createFleetQueueClient(
       // ("back in flight" per the worker-reclaimed-pending comm error) and
       // then immediately claimed-and-deleted by the SAME call — falsifying the
       // comm error and nulling downstream aggregate-key resolution on the
-      // deleted row. ACROSS calls the stale phase's RECENT-LEASE heuristic
-      // (see drainStalePending) protects the same row: the release hook
-      // retains the expired lease on re-queue, so a recently-in-flight row
-      // is not expired off its original `created` age by the NEXT sweep
-      // either. (Re-anchoring the age to the re-queue time would need a
-      // column; the retained lease is the schema-free approximation.)
+      // deleted row. ACROSS calls the protection is split by HOW LONG the
+      // lease has been expired: a RECENTLY-expired lease (within the stale
+      // window) is re-queued, and the stale phase's RECENT-LEASE heuristic
+      // (see drainStalePending) protects it on later sweeps — the release
+      // hook retains the expired lease on re-queue, so a recently-in-flight
+      // row is not expired off its original `created` age by the NEXT sweep.
+      // A lease expired LONGER than the stale window on a stale-aged row is
+      // PAST that heuristic's reach: re-queueing it would emit a "back in
+      // flight" signal the NEXT sweep falsifies by claim-deleting the row —
+      // so the lease phase claim-deletes it DIRECTLY (G1d), with no comm
+      // error (the work is discarded, not re-run). (Re-anchoring the age to
+      // the re-queue time would need a column; the retained lease is the
+      // schema-free approximation.)
       //
       // MASS-CRASH PAGING: with >CLAIM_CANDIDATE_PAGE claimed/running rows
       // (mass worker crash), an UNSORTED single page left the contents to PB's
@@ -1380,12 +1387,91 @@ export function createFleetQueueClient(
       // case; a requeued_at column would cover both exactly).
       const requeuedThisSweep = new Set<string>();
       const observedAt = new Date(nowMs).toISOString();
+      // Stale expiries (deleted rows). Declared here — not at the stale
+      // phase — because the lease phase's long-expired carve-out below also
+      // deletes (G1d); both phases feed the same count.
+      let expiredPending = 0;
       for (const row of page.items) {
         if (!leaseExpired(row.lease_expires_at, nowMs)) continue;
         // Snapshot the holder BEFORE the release CAS: the release drops
         // ownership, and the special-case + comm-error attribution below must
         // reflect who HELD the expired lease, not the post-release row.
         const holder = row.claimed_by;
+        // LONG-EXPIRED CARVE-OUT (G1d): a row that is ALREADY
+        // stale-expirable — created-age past its family's stale window AND
+        // its lease expired LONGER than that window — is past the
+        // recent-lease heuristic's protection (see the header). Re-queueing
+        // it would emit a "back in flight" comm error the NEXT sweep
+        // falsifies by claim-deleting the row off its original `created`
+        // age. Delete it HERE, claim-first like the stale phase (the claim
+        // CAS admits an expired-lease claimed/running row — its reclaim
+        // safety net — so the delete stays race-free). No comm error and no
+        // reclaimed++: the work is discarded, not re-run. The carve-out
+        // requires a PARSEABLE created AND lease — anything unparseable
+        // stays on the conservative re-queue path below. Sweeper-held rows
+        // (stale garbage mid-deletion, 60s lease) are always RECENTLY
+        // expired, so they keep their silent re-queue retry contract.
+        if (staleExpiryPeriods > 0 && holder !== STALE_PENDING_SWEEPER_ID) {
+          const family = probeKeyFamily(row.probe_key);
+          const maxAgeMs = staleExpiryPeriods * stalePeriodMsFor(family);
+          const createdMs = Date.parse(
+            String(row.created ?? "").replace(PB_DATE_SEP_RE, "$1T"),
+          );
+          const leaseMs = Date.parse(
+            String(row.lease_expires_at ?? "").replace(PB_DATE_SEP_RE, "$1T"),
+          );
+          const staleExpirable =
+            !Number.isNaN(createdMs) &&
+            nowMs - createdMs > maxAgeMs &&
+            Number.isFinite(leaseMs) &&
+            leaseMs <= nowMs - maxAgeMs;
+          if (staleExpirable) {
+            // PER-ROW containment mirrors the stale phase: a thrown claim is
+            // indeterminate (skip this sweep; the row is unchanged for the
+            // next), a lost claim means a peer acted on the row, and a
+            // failed delete leaves the row sweeper-claimed — its short lease
+            // expires and the silent re-queue + later stale sweep retry the
+            // delete (the existing self-healing contract).
+            let won: ClaimResult;
+            try {
+              won = await claim.claimJob(
+                row.id,
+                STALE_PENDING_SWEEPER_ID,
+                STALE_PENDING_SWEEPER_LEASE_SECONDS,
+              );
+            } catch (err) {
+              logger.warn("queue-client.sweep-lease-stale-claim-threw", {
+                jobId: row.id,
+                err: err instanceof Error ? err.message : String(err),
+              });
+              continue;
+            }
+            if (!won.won) {
+              logger.debug("queue-client.sweep-lease-stale-claim-lost", {
+                jobId: row.id,
+              });
+              continue;
+            }
+            try {
+              await pb.delete(PROBE_JOBS_COLLECTION, row.id);
+            } catch (err) {
+              logger.error("queue-client.sweep-lease-stale-delete-failed", {
+                jobId: row.id,
+                err: err instanceof Error ? err.message : String(err),
+              });
+              continue;
+            }
+            expiredPending += 1;
+            logger.warn("queue-client.sweep-lease-stale-deleted", {
+              jobId: row.id,
+              probeKey: row.probe_key,
+              family,
+              workerId: holder,
+              maxAgeMs,
+            });
+            continue;
+          }
+        }
         // Re-queue on behalf of the dead holder: the CAS authorizes on
         // `claimed_by` (still the dead worker), so this atomically flips the
         // row back to pending and drops ownership.
@@ -1551,7 +1637,6 @@ export function createFleetQueueClient(
       // escape here would discard every commError the lease phase just
       // synthesized — the same dashboard-signal loss as an escaped release.
       // The drain itself is retried in full by the next sweep.
-      let expiredPending = 0;
       try {
         await drainStalePending();
       } catch (err) {

--- a/showcase/harness/src/fleet/worker/worker-loop.test.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.test.ts
@@ -204,6 +204,9 @@ function makeQueue(claims: ClaimedJob[]): RecordingQueue {
     async sweepExpired() {
       return { reclaimed: 0, commErrors: [] };
     },
+    async countPendingForFamily(): Promise<number> {
+      throw new Error("countPendingForFamily not used by worker");
+    },
   };
 }
 

--- a/showcase/harness/src/fleet/worker/worker-loop.test.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.test.ts
@@ -161,7 +161,12 @@ function makeDriver(args: {
         observedAt,
       });
       return {
-        key: `e2e_d6:${args.slug}`,
+        // The d6 AGGREGATE row key `d6:<slug>` — the fleet contract forbids an
+        // `e2e_d6:<slug>` row on the fleet path (see ServiceJobResult
+        // .aggregateKey), and the comm-error/driver-error paths in this file
+        // pin `d6:<slug>`; the success path must pin the SAME key form so a
+        // success≠error key drift can't hide.
+        key: `d6:${args.slug}`,
         state: args.aggregateState,
         signal: { shape: "package", slug: args.slug },
         observedAt,
@@ -261,7 +266,7 @@ describe("buildServiceJobResult", () => {
   it("echoes payload identity and folds in the aggregate + rollup", () => {
     const lease = makeLease();
     const aggregate: ProbeResult = {
-      key: "e2e_d6:langgraph-python",
+      key: "d6:langgraph-python",
       state: "green",
       signal: { ok: true },
       observedAt: "2026-06-04T00:04:00.000Z",
@@ -288,7 +293,7 @@ describe("buildServiceJobResult", () => {
     expect(result.runId).toBe("run-42");
     expect(result.workerId).toBe("worker-test");
     expect(result.aggregateState).toBe("green");
-    expect(result.aggregateKey).toBe("e2e_d6:langgraph-python");
+    expect(result.aggregateKey).toBe("d6:langgraph-python");
     expect(result.cells).toEqual(cells);
     expect(result.rollup).toEqual({ total: 1, passed: 1, failed: 0 });
     expect(result.commError).toBeUndefined();
@@ -303,7 +308,7 @@ describe("buildServiceJobResult", () => {
     // error result instead of persisting junk.
     const lease = makeLease();
     const aggregate = {
-      key: "e2e_d6:langgraph-python",
+      key: "d6:langgraph-python",
       state: "grene" as ProbeState,
       signal: {},
       observedAt: "2026-06-04T00:04:00.000Z",
@@ -377,7 +382,7 @@ describe("runClaimedJob", () => {
     );
     expect(result.rollup).toEqual({ total: 2, passed: 1, failed: 1 });
     expect(result.aggregateState).toBe("red");
-    expect(result.aggregateKey).toBe("e2e_d6:langgraph-python");
+    expect(result.aggregateKey).toBe("d6:langgraph-python");
     expect(result.commError).toBeUndefined();
   });
 
@@ -671,7 +676,7 @@ describe("runClaimedJob", () => {
         markStarted();
         await released;
         return {
-          key: "e2e_d6:langgraph-python",
+          key: "d6:langgraph-python",
           state: "green",
           signal: { shape: "package", slug: "langgraph-python" },
           observedAt: ctx.now().toISOString(),
@@ -742,7 +747,7 @@ describe("runClaimedJob", () => {
           await new Promise((r) => setTimeout(r, 0));
         }
         return {
-          key: "e2e_d6:langgraph-python",
+          key: "d6:langgraph-python",
           state: "green",
           signal: { shape: "package", slug: "langgraph-python" },
           observedAt: ctx.now().toISOString(),
@@ -1377,7 +1382,7 @@ describe("startWorkerLoop", () => {
           await ctx.writer.write(redAbortCell);
         }
         return {
-          key: "e2e_d6:langgraph-python",
+          key: "d6:langgraph-python",
           state: "red",
           signal: { shape: "package", slug: "langgraph-python" },
           observedAt,
@@ -1521,7 +1526,7 @@ describe("startWorkerLoop", () => {
         });
         reasonAfterAbort = ctx.drainReason;
         return {
-          key: "e2e_d6:langgraph-python",
+          key: "d6:langgraph-python",
           state: "red",
           signal: { shape: "package", slug: "langgraph-python" },
           observedAt: ctx.now().toISOString(),
@@ -1596,7 +1601,7 @@ describe("WorkerLoopHandle.drain() — deregister-first drain request", () => {
         await released;
         settled = true;
         return {
-          key: "e2e_d6:langgraph-python",
+          key: "d6:langgraph-python",
           state: "green",
           signal: { shape: "package", slug: "langgraph-python" },
           observedAt: ctx.now().toISOString(),
@@ -1786,7 +1791,7 @@ describe("WorkerLoopHandle.drain() — deregister-first drain request", () => {
         ctx: ServiceDriverContext,
         _input: unknown,
       ): Promise<ProbeResult> => ({
-        key: "e2e_d6:langgraph-python",
+        key: "d6:langgraph-python",
         state: "green",
         signal: { shape: "package", slug: "langgraph-python" },
         observedAt: ctx.now().toISOString(),
@@ -1955,7 +1960,7 @@ describe("drain grace (WORKER_DRAIN_GRACE_MS)", () => {
           // Deliberately IGNORE ctx.abortSignal — a wedged teardown.
           await released;
           return {
-            key: "e2e_d6:langgraph-python",
+            key: "d6:langgraph-python",
             state: "green",
             signal: { shape: "package", slug: "langgraph-python" },
             observedAt: ctx.now().toISOString(),

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -2889,6 +2889,9 @@ describe("drainFleetWorker — deregister-FIRST drain ordering", () => {
       async sweepExpired() {
         return { reclaimed: 0, commErrors: [] };
       },
+      async countPendingForFamily(): Promise<number> {
+        throw new Error("countPendingForFamily not used by worker");
+      },
     };
   }
 
@@ -3615,6 +3618,7 @@ describe("orchestrator runControlPlane REQ-B sweep wiring (control-plane integra
             swept = true;
             return { reclaimed: 1, commErrors: [sweptCommError] };
           },
+          countPendingForFamily: async () => 0,
         }),
       };
     });
@@ -3833,6 +3837,7 @@ describe("orchestrator runControlPlane REQ-B worker-self-report wiring (aggregat
           renewLease: async () => null,
           report: async () => undefined,
           sweepExpired: async () => ({ reclaimed: 0, commErrors: [] }),
+          countPendingForFamily: async () => 0,
         }),
       };
     });
@@ -5026,6 +5031,7 @@ describe("runControlPlane registers 4 producer schedules on the scheduler", () =
           renewLease: async () => null,
           report: async () => undefined,
           sweepExpired: async () => ({ reclaimed: 0, commErrors: [] }),
+          countPendingForFamily: async () => 0,
         }),
       };
     });

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -17,6 +17,7 @@ import {
   registerAllProbeDrivers,
   buildPooledBrowserDrivers,
   buildProducerSchedules,
+  FLEET_FAMILY_PERIODS_MS,
   FLEET_PRODUCER_SMOKE_CRON,
   FLEET_PRODUCER_DEMOS_CRON,
   FLEET_PRODUCER_DEEP_CRON,
@@ -60,8 +61,19 @@ import type {
   StatusWriter,
   OverlayWriteOutcome,
 } from "./writers/status-writer.js";
-import { FLEET_COMM_ERROR_SIGNAL_KEY } from "./fleet/contracts.js";
+import {
+  FLEET_COMM_ERROR_SIGNAL_KEY,
+  probeKeyFamily,
+} from "./fleet/contracts.js";
 import type { PoolCommError } from "./fleet/contracts.js";
+import {
+  createD6ServiceEnumerator,
+  createE2eSmokeServiceEnumerator,
+  createE2eDeepServiceEnumerator,
+  createE2eDemosServiceEnumerator,
+} from "./fleet/control-plane/catalog-enumerator.js";
+import type { DiscoverySource } from "./probes/types.js";
+import type { RailwayServiceInfo } from "./probes/discovery/railway-services.js";
 import { BrowserPool } from "./probes/helpers/browser-pool.js";
 import { createProbeRegistry } from "./probes/drivers/index.js";
 import type { createScheduler } from "./scheduler/scheduler.js";
@@ -5208,6 +5220,71 @@ describe("buildProducerSchedules (fleet multi-schedule manifest)", () => {
     expect(byId.get(FLEET_PRODUCER_DEMOS_SCHEDULE_ID)?.cron).toBe("10 * * * *");
     expect(byId.get(FLEET_PRODUCER_DEEP_SCHEDULE_ID)?.cron).toBe(
       "5,20,35,50 * * * *",
+    );
+  });
+});
+
+/**
+ * Drift-lock: FLEET_FAMILY_PERIODS_MS keys must EXACTLY match the probe-key
+ * families the four real enumerators enqueue under. The map feeds the queue
+ * client's stale-pending expiry; `stalePendingFilters` silently falls back to
+ * the 1h default for any family missing from the map, so a typo'd family key
+ * (e.g. "d5" vs "d5-single-pill-e2e") would never throw — it would just
+ * quietly mis-size that family's drain window. The families are derived by
+ * RUNNING each enumerator factory against a fake discovery source, so this
+ * test breaks if either side (map key or enumerator prefix) drifts.
+ *
+ * NOTE: this locks the NOMINAL period map only. The d6 cron-override drift
+ * (FLEET_PRODUCER_CRON changing d6's real cadence without updating the map)
+ * is a documented limitation on FLEET_FAMILY_PERIODS_MS, not testable here.
+ */
+describe("FLEET_FAMILY_PERIODS_MS ↔ enumerator family drift-lock", () => {
+  it("map keys exactly match the families the four enumerators enqueue under", async () => {
+    const service: RailwayServiceInfo = {
+      name: "showcase-langgraph-python",
+      imageRef: "ghcr.io/org/showcase-langgraph-python:latest",
+      publicUrl: "http://langgraph-python:10000",
+      env: {},
+      shape: "package",
+      deployedDigest: "",
+      demos: ["agentic_chat"],
+      notSupportedFeatures: [],
+      deployedAt: "",
+    };
+    const source = {
+      name: "railway-services",
+      async enumerate(): Promise<RailwayServiceInfo[]> {
+        return [service];
+      },
+    } as unknown as DiscoverySource<RailwayServiceInfo>;
+    const silent = {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    };
+    const deps = {
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: silent,
+    };
+
+    const enumerators = [
+      createD6ServiceEnumerator(deps),
+      createE2eSmokeServiceEnumerator(deps),
+      createE2eDeepServiceEnumerator(deps),
+      createE2eDemosServiceEnumerator(deps),
+    ];
+    const families = new Set<string>();
+    for (const enumerate of enumerators) {
+      const specs = await enumerate({ triggered: false, runId: "drift-lock" });
+      expect(specs.length).toBeGreaterThan(0);
+      for (const spec of specs) families.add(probeKeyFamily(spec.probeKey));
+    }
+
+    expect([...families].sort()).toEqual(
+      Object.keys(FLEET_FAMILY_PERIODS_MS).sort(),
     );
   });
 });

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -17,6 +17,7 @@ import {
   registerAllProbeDrivers,
   buildPooledBrowserDrivers,
   buildProducerSchedules,
+  buildSweepCommErrorSink,
   FLEET_FAMILY_PERIODS_MS,
   FLEET_PRODUCER_SMOKE_CRON,
   FLEET_PRODUCER_DEMOS_CRON,
@@ -5246,6 +5247,57 @@ describe("buildProducerSchedules (fleet multi-schedule manifest)", () => {
     expect(byId.get(FLEET_PRODUCER_DEEP_SCHEDULE_ID)?.cron).toBe(
       "5,20,35,50 * * * *",
     );
+  });
+});
+
+/**
+ * REQ-B late-bind at-least-once guard: `buildSweepCommErrorSink` must THROW
+ * while the control-plane ref is still unbound. The job-producer's
+ * `deliverSweepCommErrors` clears its undelivered buffer whenever the sink
+ * RESOLVES, so an unbound sink that resolved would mark a never-delivered
+ * batch as delivered — silently dropping the worker-crashed overlay
+ * (`sweepExpired` cannot re-derive a missed batch). A rejection makes the
+ * producer re-buffer and redeliver on a later sweep, after the bind.
+ */
+describe("buildSweepCommErrorSink (REQ-B late-bind at-least-once guard)", () => {
+  const commError: PoolCommError = {
+    kind: "worker-crashed-mid-job",
+    message: "lease expired; worker presumed crashed",
+    workerId: "worker-dead",
+    jobId: "job-unbound-1",
+    observedAt: "2026-06-10T00:00:00.000Z",
+  };
+
+  it("rejects while the control-plane is unbound (producer must re-buffer, not clear)", async () => {
+    const sink = buildSweepCommErrorSink(() => undefined);
+    await expect(sink([commError])).rejects.toThrow(
+      /control-plane.*not.*bound|before the control-plane/i,
+    );
+  });
+
+  it("forwards the batch to surfaceSweepCommErrors once bound, and resolves", async () => {
+    const seen: PoolCommError[][] = [];
+    let ref:
+      | { surfaceSweepCommErrors(errs: PoolCommError[]): Promise<void> }
+      | undefined;
+    // Built UNBOUND (mirroring runControlPlane's assembly order), bound after.
+    const sink = buildSweepCommErrorSink(() => ref);
+    ref = {
+      surfaceSweepCommErrors: async (errs) => {
+        seen.push(errs);
+      },
+    };
+    await expect(sink([commError])).resolves.toBeUndefined();
+    expect(seen).toEqual([[commError]]);
+  });
+
+  it("propagates a bound sink's rejection (the producer's re-buffer trigger)", async () => {
+    const sink = buildSweepCommErrorSink(() => ({
+      surfaceSweepCommErrors: async () => {
+        throw new Error("aggregator write failed");
+      },
+    }));
+    await expect(sink([commError])).rejects.toThrow("aggregator write failed");
   });
 });
 

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -3717,10 +3717,11 @@ describe("orchestrator runControlPlane REQ-B sweep wiring (control-plane integra
               cron: string;
               handler: () => Promise<unknown>;
             }) => {
-              // The d6 producer (`fleet-job-producer`) is the ONLY one wired
-              // with the REQ-B `onSweepCommErrors` sweep leg, so capture ITS
-              // handler specifically — the other three browser-family producer
-              // schedules + the `probe:*` HTTP entries also register here.
+              // Capture the d6 producer's (`fleet-job-producer`) handler
+              // specifically — all four producers share the REQ-B
+              // `onSweepCommErrors` sink (the non-d6 leg is covered by the
+              // sink fan-out sibling below); the other three browser-family
+              // producer schedules + `probe:*` HTTP entries also register here.
               if (entry.id === FLEET_PRODUCER_SCHEDULE_ID) {
                 producerHandler = entry.handler;
               }
@@ -3754,6 +3755,223 @@ describe("orchestrator runControlPlane REQ-B sweep wiring (control-plane integra
       expect(overlay).toBeDefined();
       expect(overlay!.kind).toBe("worker-crashed-mid-job");
       expect(overlay!.jobId).toBe("job-swept-1");
+    } finally {
+      await handle.stop();
+    }
+  });
+});
+
+/**
+ * REQ-B sweep-sink fan-out: a sweep performed by a NON-d6 producer must ALSO
+ * forward its comm errors to the aggregator.
+ *
+ * All four family producers run the same GLOBAL `queue.sweepExpired` on their
+ * own crons, and the sweep's S0 CAS means whichever producer sweeps FIRST wins
+ * each expired job's reclaim — and with it the synthesized
+ * `worker-reclaimed-pending` comm error. The job-producer's `maybeSweep`
+ * forwards those errors only when its `onSweepCommErrors` sink is wired, so a
+ * producer built WITHOUT the sink silently DROPS them. With only d6 wired
+ * (hourly @ :40) and smoke/demos/deep sweeping far more often (every-15min,
+ * :10 hourly, and :05/:20/:35/:50), the reclaim overlay was dropped ~11 of 12
+ * sweeps.
+ *
+ * This drives the SMOKE producer's tick (scheduler entry
+ * `FLEET_PRODUCER_SMOKE_SCHEDULE_ID`) through `runControlPlane`'s real
+ * assembly and asserts the swept overlay lands on the job's `d6:<slug>` status
+ * row. RED against d6-only wiring (the smoke producer has no sink); GREEN once
+ * all four producers share the control-plane sink.
+ */
+describe("orchestrator runControlPlane REQ-B sweep wiring — non-d6 producer (sink fan-out)", () => {
+  let port = 0;
+
+  beforeEach(async () => {
+    port = await pickPort();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("surfaces a swept job's overlay when the SMOKE producer performs the sweep", async () => {
+    vi.resetModules();
+
+    // SELF-CONTAINED MOCK SET: `vi.doMock` factories registered by sibling
+    // tests persist for the rest of the file (resetModules clears the module
+    // CACHE, not the mock REGISTRY), so explicitly unmock every module this
+    // test touches before re-mocking — the test must pass in isolation AND in
+    // file order regardless of which siblings leaked factories.
+    vi.doUnmock("@hono/node-server");
+    vi.doUnmock("./fleet/queue-client.js");
+    vi.doUnmock("./storage/pb-client.js");
+    vi.doUnmock("./storage/s3-backup.js");
+    vi.doUnmock("./writers/status-writer.js");
+    vi.doUnmock("./probes/run-history.js");
+    vi.doUnmock("./scheduler/scheduler.js");
+    vi.doUnmock("./fleet/control-plane/result-consumer.js");
+    vi.doUnmock("./events/event-bus.js");
+    vi.doUnmock("./probes/loader/probe-loader.js");
+
+    // The smoke/demos/deep producers always use their REAL catalog enumerators
+    // (`opts.fleetEnumerate` is a d6-ONLY test seam), so inject an empty
+    // roster via the LOCAL_SERVICES_JSON local-injection seam — the smoke tick
+    // enumerates [] without Railway creds, and `maybeSweep` runs regardless of
+    // what enumeration yields.
+    vi.stubEnv("LOCAL_SERVICES_JSON", "[]");
+
+    // We need the REAL serve() so this role binds cleanly and the producer
+    // tick can run — pin it (the async-bind siblings leak a rejecting stub).
+    vi.doMock("@hono/node-server", async () => {
+      const actual =
+        await vi.importActual<typeof import("@hono/node-server")>(
+          "@hono/node-server",
+        );
+      return { ...actual };
+    });
+
+    const sweptCommError: PoolCommError = {
+      kind: "worker-crashed-mid-job",
+      message: "lease expired; worker presumed crashed",
+      workerId: "worker-dead",
+      jobId: "job-swept-smoke",
+      observedAt: "2026-06-10T00:00:00.000Z",
+    };
+
+    // Queue fake: sweepExpired yields the swept comm error exactly once — to
+    // WHICHEVER producer sweeps first; this test only drives the SMOKE
+    // producer's tick, so the smoke producer wins the sweep.
+    vi.doMock("./fleet/queue-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./fleet/queue-client.js")
+      >("./fleet/queue-client.js");
+      let swept = false;
+      return {
+        ...actual,
+        createFleetQueueClient: () => ({
+          enqueue: async () => ({}) as never,
+          claimNext: async () => ({ claimed: false }) as never,
+          renewLease: async () => null,
+          report: async () => undefined,
+          sweepExpired: async () => {
+            if (swept) return { reclaimed: 0, commErrors: [] };
+            swept = true;
+            return { reclaimed: 1, commErrors: [sweptCommError] };
+          },
+          countPendingForFamily: async () => 0,
+        }),
+      };
+    });
+
+    // pb fake: getOne(probe_jobs, "job-swept-smoke") resolves the swept job's
+    // probe_key (the resolveSweepAggregateKey lookup); getFirst(status, ...)
+    // is the "never observed" path. health() true so the role boots clean.
+    vi.doMock("./storage/pb-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./storage/pb-client.js")
+      >("./storage/pb-client.js");
+      return {
+        ...actual,
+        createPbClient: () => ({
+          health: async () => true,
+          getOne: async (_collection: string, id: string) =>
+            id === "job-swept-smoke" ? { probe_key: "d6:swept-svc-smoke" } : null,
+          getFirst: async () => null,
+        }),
+      };
+    });
+
+    // Capture every status-writer write so we can assert the overlay landed on
+    // the d6:<slug> row.
+    const writes: ProbeResult<unknown>[] = [];
+    vi.doMock("./writers/status-writer.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./writers/status-writer.js")
+      >("./writers/status-writer.js");
+      return {
+        ...actual,
+        createStatusWriter: () => ({
+          write: async (r: ProbeResult<unknown>) => {
+            writes.push(r);
+            return undefined;
+          },
+        }),
+      };
+    });
+
+    // run-history writer is irrelevant to the sweep leg; stub it so the
+    // aggregator constructs without a real PB run-history collection.
+    vi.doMock("./probes/run-history.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./probes/run-history.js")
+      >("./probes/run-history.js");
+      return {
+        ...actual,
+        createProbeRunWriter: () => ({
+          findByJobId: async () => null,
+          start: async () => ({}) as never,
+          finishTerminal: async () => undefined,
+        }),
+      };
+    });
+
+    // Capture the SMOKE producer's scheduler handler so we can drive ITS tick
+    // (which runs the sweep) deterministically without waiting on cron.
+    let smokeHandler: (() => Promise<unknown>) | undefined;
+    vi.doMock("./scheduler/scheduler.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./scheduler/scheduler.js")
+      >("./scheduler/scheduler.js");
+      return {
+        ...actual,
+        createScheduler: (
+          deps: Parameters<typeof actual.createScheduler>[0],
+        ) => {
+          const real = actual.createScheduler(deps);
+          return {
+            ...real,
+            register: (entry: {
+              id: string;
+              cron: string;
+              handler: () => Promise<unknown>;
+            }) => {
+              // Capture the NON-d6 smoke producer's handler specifically —
+              // the d6 `fleet-job-producer`, the other two browser-family
+              // schedules, and the `probe:*` HTTP entries also register here.
+              if (entry.id === FLEET_PRODUCER_SMOKE_SCHEDULE_ID) {
+                smokeHandler = entry.handler;
+              }
+              return (real.register as (...a: unknown[]) => unknown)(entry);
+            },
+          };
+        },
+      };
+    });
+
+    const orchMod = await import("./orchestrator.js");
+
+    const handle = await orchMod.runControlPlane(
+      { role: "control-plane", poolCount: 1 },
+      // Empty d6 enumerator → no d6 enqueue churn (the smoke enumerator is
+      // emptied via LOCAL_SERVICES_JSON above).
+      { port, fleetEnumerate: async () => [] },
+    );
+
+    try {
+      expect(smokeHandler).toBeDefined();
+      // Drive one SMOKE producer tick → maybeSweep → onSweepCommErrors →
+      // surfaceSweepCommErrors → resolveSweepAggregateKey → aggregateCommError.
+      await smokeHandler!();
+
+      const overlayWrite = writes.find((w) => w.key === "d6:swept-svc-smoke");
+      expect(overlayWrite).toBeDefined();
+      const signal = overlayWrite!.signal as Record<string, unknown>;
+      const overlay = signal[FLEET_COMM_ERROR_SIGNAL_KEY] as
+        | PoolCommError
+        | undefined;
+      expect(overlay).toBeDefined();
+      expect(overlay!.kind).toBe("worker-crashed-mid-job");
+      expect(overlay!.jobId).toBe("job-swept-smoke");
     } finally {
       await handle.stop();
     }

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -102,6 +102,21 @@ import { buildWorkerHealthServer } from "./fleet/worker/worker-health.js";
  * the two probes F1.1 is about; pb-up status is orthogonal and already
  * covered by server.test.ts.
  */
+// FILE-LEVEL MOCK HYGIENE: vi.doMock factories persist across the whole file
+// (vi.resetModules clears the module CACHE, not the mock REGISTRY), so a
+// describe that doMocks a module and only runs resetModules/restoreAllMocks in
+// its afterEach leaks its factory into every later test that imports the same
+// module without re-mocking it. The HTTP-probes describe already doUnmocks its
+// own set per-describe; these three are doMocked by the REQ-B / worker-self-
+// report / 4-schedules describes which did NOT unmock them. Unmock after EVERY
+// test so a leaked queue-client/status-writer/result-consumer stub can never
+// poison a sibling.
+afterEach(() => {
+  vi.doUnmock("./fleet/queue-client.js");
+  vi.doUnmock("./writers/status-writer.js");
+  vi.doUnmock("./fleet/control-plane/result-consumer.js");
+});
+
 async function pickPort(): Promise<number> {
   return new Promise<number>((resolve, reject) => {
     const s = net.createServer();
@@ -1559,6 +1574,9 @@ describe("orchestrator webhook secrets fail-loud in production (R5-G4 D5)", () =
     const prevNodeEnv = process.env.NODE_ENV;
     const prevSecret = process.env.SHARED_SECRET;
     const prevPrev = process.env.SHARED_SECRET_PREV;
+    // Save/restore POCKETBASE_URL like the HF13-A2 tests — an unconditional
+    // `delete` in finally would clobber a pre-existing value for later tests.
+    const prevPbUrl = process.env.POCKETBASE_URL;
     process.env.NODE_ENV = "production";
     delete process.env.SHARED_SECRET;
     delete process.env.SHARED_SECRET_PREV;
@@ -1574,7 +1592,8 @@ describe("orchestrator webhook secrets fail-loud in production (R5-G4 D5)", () =
       else process.env.NODE_ENV = prevNodeEnv;
       if (prevSecret !== undefined) process.env.SHARED_SECRET = prevSecret;
       if (prevPrev !== undefined) process.env.SHARED_SECRET_PREV = prevPrev;
-      delete process.env.POCKETBASE_URL;
+      if (prevPbUrl === undefined) delete process.env.POCKETBASE_URL;
+      else process.env.POCKETBASE_URL = prevPbUrl;
     }
   });
 
@@ -1604,6 +1623,9 @@ describe("orchestrator webhook secrets fail-loud in production (R5-G4 D5)", () =
   it("boots successfully in production when at least one webhook secret is set", async () => {
     const prevNodeEnv = process.env.NODE_ENV;
     const prevSecret = process.env.SHARED_SECRET;
+    // Save/restore POCKETBASE_URL like the HF13-A2 tests — an unconditional
+    // `delete` in finally would clobber a pre-existing value for later tests.
+    const prevPbUrl = process.env.POCKETBASE_URL;
     process.env.NODE_ENV = "production";
     process.env.SHARED_SECRET = "test-secret-prod-ok";
     process.env.POCKETBASE_URL = "http://localhost:8090";
@@ -1620,7 +1642,8 @@ describe("orchestrator webhook secrets fail-loud in production (R5-G4 D5)", () =
       else process.env.NODE_ENV = prevNodeEnv;
       if (prevSecret !== undefined) process.env.SHARED_SECRET = prevSecret;
       else delete process.env.SHARED_SECRET;
-      delete process.env.POCKETBASE_URL;
+      if (prevPbUrl === undefined) delete process.env.POCKETBASE_URL;
+      else process.env.POCKETBASE_URL = prevPbUrl;
     }
   });
 });

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -3910,7 +3910,9 @@ describe("orchestrator runControlPlane REQ-B sweep wiring — non-d6 producer (s
         createPbClient: () => ({
           health: async () => true,
           getOne: async (_collection: string, id: string) =>
-            id === "job-swept-smoke" ? { probe_key: "d6:swept-svc-smoke" } : null,
+            id === "job-swept-smoke"
+              ? { probe_key: "d6:swept-svc-smoke" }
+              : null,
           getFirst: async () => null,
         }),
       };

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -3919,9 +3919,14 @@ describe("orchestrator runControlPlane REQ-B sweep wiring — non-d6 producer (s
       };
     });
 
-    // Capture every status-writer write so we can assert the overlay landed on
-    // the d6:<slug> row.
-    const writes: ProbeResult<unknown>[] = [];
+    // Capture every status-writer overlay so we can assert the overlay landed
+    // on the d6:<slug> row. Aggregator routes comm errors through writeOverlay
+    // (H1 path); `write` is unused by this leg but provided for the interface.
+    const writes: Array<{
+      key: string;
+      signal: Record<string, unknown>;
+      observedAt: string;
+    }> = [];
     vi.doMock("./writers/status-writer.js", async () => {
       const actual = await vi.importActual<
         typeof import("./writers/status-writer.js")
@@ -3929,9 +3934,14 @@ describe("orchestrator runControlPlane REQ-B sweep wiring — non-d6 producer (s
       return {
         ...actual,
         createStatusWriter: () => ({
-          write: async (r: ProbeResult<unknown>) => {
-            writes.push(r);
-            return undefined;
+          write: async (_r: ProbeResult<unknown>) => undefined,
+          writeOverlay: async (o: {
+            key: string;
+            signal: Record<string, unknown>;
+            observedAt: string;
+          }): Promise<OverlayWriteOutcome> => {
+            writes.push(o);
+            return { applied: true, state: null, historyPersisted: true };
           },
         }),
       };

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -84,6 +84,7 @@ import {
   PROBE_JOBS_COLLECTION,
 } from "./fleet/queue-client.js";
 import { WORKERS_COLLECTION } from "./fleet/contracts.js";
+import type { PoolCommError } from "./fleet/contracts.js";
 import { runWorker as runFleetWorker } from "./fleet/orchestrator.js";
 import {
   createPayloadToInput,

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -2456,22 +2456,33 @@ export async function runControlPlane(
     }
   };
 
-  // Forward-reference the assembled control-plane so the producer's sweep sink
-  // can call `surfaceSweepCommErrors` (the control-plane needs the producer, the
-  // producer needs the control-plane's sink — break the cycle with a late bind).
+  // Forward-reference the assembled control-plane so the producers' sweep sink
+  // can call `surfaceSweepCommErrors` (the control-plane needs the producers,
+  // the producers need the control-plane's sink — break the cycle with a late
+  // bind).
   let controlPlaneRef: ControlPlane | undefined;
+  // REQ-B: forward swept comm errors into the control-plane's surfacing sink,
+  // which resolves each `d6:<slug>` key and writes the overlay through the
+  // aggregator. Best-effort; never aborts production. ALL FOUR producers share
+  // this ONE sink: each family's cron runs the same GLOBAL `queue.sweepExpired`
+  // (the sweep is not family-scoped), and the sweep's S0 CAS means whichever
+  // producer's tick fires first wins each expired job's reclaim — and with it
+  // the synthesized comm error. With only d6 wired (hourly @ :40), the far more
+  // frequent smoke/demos/deep sweeps won most reclaims and DROPPED their comm
+  // errors (job-producer's `maybeSweep` forwards only when the sink is wired),
+  // so the worker-reclaimed overlay was lost ~11 of 12 sweeps. Sharing the sink
+  // is safe: the CAS guarantees exactly ONE producer reclaims (and forwards)
+  // each expired job, and `surfaceSweepCommErrors` is best-effort per error.
+  const onSweepCommErrors = async (
+    commErrors: PoolCommError[],
+  ): Promise<void> => {
+    await controlPlaneRef?.surfaceSweepCommErrors(commErrors);
+  };
   const producer = buildJobProducer({
     queue,
     enumerate,
     logger,
-    // REQ-B: forward swept comm errors into the control-plane's surfacing sink,
-    // which resolves each `d6:<slug>` key and writes the overlay through the
-    // aggregator. Best-effort; never aborts production. Only the d6 producer
-    // wires this sweep leg — it's the historic REQ-B path and stays unchanged;
-    // the three new browser-family producers below do not forward sweep errors.
-    onSweepCommErrors: async (commErrors) => {
-      await controlPlaneRef?.surfaceSweepCommErrors(commErrors);
-    },
+    onSweepCommErrors,
     // #72 PRE-DISPATCH WARM-UP: fire a fire-and-forget GET <backendUrl>/health
     // at every enumerated d6 backend before its pills run, so a cold
     // (scaled-to-zero) container starts waking ahead of the probe — removing
@@ -2481,23 +2492,27 @@ export async function runControlPlane(
     warmHealth: { fetchImpl: globalThis.fetch },
   });
   // The three non-d6 browser families each get their own producer over their
-  // family enumerator. They intentionally do NOT wire `onSweepCommErrors`: the
-  // single REQ-B sweep-surfacing leg stays on the d6 producer (preserving the
-  // current behavior); adding parallel sweep legs is out of scope for Phase 2.
+  // family enumerator. Each wires the SAME `onSweepCommErrors` sink as d6:
+  // their crons sweep the same global queue far more often than d6's hourly
+  // tick, so they must forward (not drop) the comm errors of the reclaims they
+  // win — see the sink's comment above.
   const smokeProducer = buildJobProducer({
     queue,
     enumerate: enumerateSmoke,
     logger,
+    onSweepCommErrors,
   });
   const demosProducer = buildJobProducer({
     queue,
     enumerate: enumerateDemos,
     logger,
+    onSweepCommErrors,
   });
   const deepProducer = buildJobProducer({
     queue,
     enumerate: enumerateDeep,
     logger,
+    onSweepCommErrors,
   });
 
   // Producer cron cadence. Defaults to the hourly-at-:40 rhythm

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -1316,6 +1316,15 @@ export const FLEET_PRODUCER_DEEP_SCHEDULE_ID = "fleet-producer-e2e-deep";
  * family has enqueued fresher batches since) and is swept off the queue so a
  * backlog drains instead of compounding. Keep in lockstep with the cron
  * constants above (and the d6 `DEFAULT_PRODUCER_CRON`).
+ *
+ * KNOWN DRIFT LIMITATION: the d6 entry assumes the DEFAULT cron. A
+ * `FLEET_PRODUCER_CRON` env override (the local fast-cadence seam — see
+ * `buildProducerSchedules`) changes d6's REAL production period without
+ * updating this map, so under an override the stale-pending expiry window for
+ * d6 is computed from the nominal hourly period, not the overridden cadence.
+ * Acceptable today (the override is a local/dev seam; staleness only widens or
+ * narrows the 3× drain window), but don't rely on this map being exact when
+ * the override is set.
  */
 export const FLEET_FAMILY_PERIODS_MS: Record<string, number> = {
   /** d6 — DEFAULT_PRODUCER_CRON `40 * * * *` (hourly). */

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -2234,6 +2234,44 @@ export function createRailwayAdapter(
 // ---------------------------------------------------------------------------
 
 /**
+ * Build the late-bound REQ-B sweep sink `runControlPlane` shares across all
+ * four family producers. The control-plane is assembled AFTER the producers
+ * (each needs the other — the cycle is broken with a late bind), so the sink
+ * dereferences the control-plane through `getControlPlane` on every delivery
+ * rather than capturing it at build time.
+ *
+ * AT-LEAST-ONCE GUARD: the job-producer's `deliverSweepCommErrors` treats a
+ * RESOLVED sink call as "delivered" and clears its undelivered-comm-error
+ * buffer — `sweepExpired` cannot re-derive a missed batch. If this sink
+ * resolved while the control-plane was still unbound (a sweep racing the
+ * assembly window, or the bind-failure teardown's final drain), the producer
+ * would clear a batch that never reached the aggregator — silently dropping
+ * the worker-crashed overlay. Throw instead: the producer logs, re-buffers
+ * the batch, and redelivers on a later sweep once the bind has happened.
+ *
+ * Exported for tests.
+ */
+export function buildSweepCommErrorSink(
+  getControlPlane: () =>
+    | Pick<ControlPlane, "surfaceSweepCommErrors">
+    | undefined,
+): (commErrors: PoolCommError[]) => Promise<void> {
+  return async (commErrors) => {
+    const controlPlane = getControlPlane();
+    if (controlPlane === undefined) {
+      // Resolving here would violate the producer's at-least-once contract
+      // (a resolved sink call clears the batch). Reject so the producer
+      // re-buffers and redelivers once the control-plane is bound.
+      throw new Error(
+        "sweep comm-error sink called before the control-plane was bound; " +
+          `re-buffering ${commErrors.length} comm error(s) for redelivery`,
+      );
+    }
+    await controlPlane.surfaceSweepCommErrors(commErrors);
+  };
+}
+
+/**
  * Control-plane role entrypoint: scheduler / queue / aggregator. Runs NO
  * Chromium / BrowserPool.
  *
@@ -2482,11 +2520,10 @@ export async function runControlPlane(
   // so the worker-reclaimed overlay was lost ~11 of 12 sweeps. Sharing the sink
   // is safe: the CAS guarantees exactly ONE producer reclaims (and forwards)
   // each expired job, and `surfaceSweepCommErrors` is best-effort per error.
-  const onSweepCommErrors = async (
-    commErrors: PoolCommError[],
-  ): Promise<void> => {
-    await controlPlaneRef?.surfaceSweepCommErrors(commErrors);
-  };
+  // While `controlPlaneRef` is still unbound the sink THROWS (see
+  // `buildSweepCommErrorSink`) so the producer re-buffers instead of clearing
+  // an undelivered batch.
+  const onSweepCommErrors = buildSweepCommErrorSink(() => controlPlaneRef);
   const producer = buildJobProducer({
     queue,
     enumerate,

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -1309,6 +1309,26 @@ export const FLEET_PRODUCER_DEMOS_SCHEDULE_ID = "fleet-producer-e2e-demos";
 export const FLEET_PRODUCER_DEEP_SCHEDULE_ID = "fleet-producer-e2e-deep";
 
 /**
+ * Nominal production period per probe FAMILY (the probe_key prefix each
+ * producer enqueues under — see `probeKeyFamily`), derived from the producer
+ * crons above. Feeds the queue client's STALE-PENDING EXPIRY policy: a
+ * pending job older than 3 × its family's period is structurally stale (its
+ * family has enqueued fresher batches since) and is swept off the queue so a
+ * backlog drains instead of compounding. Keep in lockstep with the cron
+ * constants above (and the d6 `DEFAULT_PRODUCER_CRON`).
+ */
+export const FLEET_FAMILY_PERIODS_MS: Record<string, number> = {
+  /** d6 — DEFAULT_PRODUCER_CRON `40 * * * *` (hourly). */
+  d6: 60 * 60 * 1000,
+  /** d4 smoke — FLEET_PRODUCER_SMOKE_CRON (every 15min). */
+  d4: 15 * 60 * 1000,
+  /** d5 deep — FLEET_PRODUCER_DEEP_CRON `5,20,35,50 * * * *` (every 15min). */
+  "d5-single-pill-e2e": 15 * 60 * 1000,
+  /** demos — FLEET_PRODUCER_DEMOS_CRON `10 * * * *` (hourly). */
+  "e2e-demos": 60 * 60 * 1000,
+};
+
+/**
  * Assemble the multi-schedule producer manifest `runControlPlane` passes to
  * `createControlPlane`. Pure (no I/O) so the schedule ids + crons are
  * unit-testable without booting the control-plane. Each browser family ticks on
@@ -2253,7 +2273,16 @@ export async function runControlPlane(
     logger,
   });
   const bus = createEventBus();
-  const queue = createFleetQueueClient({ pb, claim, logger });
+  // The control-plane's sweep expires stale pending jobs per family period
+  // (the structural backlog drain) — wire the per-family cadences so the
+  // 15min families (d4/d5) expire on a 45min window instead of the 3h
+  // default. The worker-side queue client never sweeps, so it stays unwired.
+  const queue = createFleetQueueClient({
+    pb,
+    claim,
+    logger,
+    stalePending: { familyPeriodsMs: FLEET_FAMILY_PERIODS_MS },
+  });
   const scheduler = createScheduler({ logger });
 
   // S5 aggregator — the ONLY authoritative dashboard writer — over the

--- a/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
+++ b/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
@@ -18,7 +18,11 @@
 // needs is defined INSIDE that handler's closure. (Verified against
 // PB 0.22.21 — the "leaseExpiryIso is not defined" failure mode.)
 //
-// Endpoints (all POST, JSON body, superuser/worker auth required):
+// Endpoints (all POST, JSON body, superuser auth ENFORCED server-side via the
+// `$apis.requireAdminAuth()` middleware on each routerAdd — PB 0.22's JSVM
+// superuser-auth echo middleware; a middleware-less routerAdd handler is
+// PUBLIC. The harness client (job-claim.ts) authenticates as superuser and
+// retries once on 401, so enforcement is compat-safe):
 //   /api/fleet/claim    { jobId, workerId, leaseSeconds }
 //                       → { claimed: bool, job? }   exactly-one-winner CAS
 //   /api/fleet/renew    { jobId, workerId, leaseSeconds }
@@ -28,8 +32,14 @@
 
 routerAdd("POST", "/api/fleet/claim", (c) => {
   const RUNNING_STATES = ["claimed", "running"];
+  // CLAMP leaseSeconds: the body is caller-supplied JSON, so a non-numeric /
+  // non-positive value (string, null, NaN) falls to the 30s default, and a
+  // huge value is capped at 3600s (1h) so a malformed caller can never wedge
+  // a row behind a multi-day lease the sweeper would wait out. NaN > 0 is
+  // false, so garbage routes to the default without an isFinite dependency.
   const leaseExpiryIso = (leaseSeconds) => {
-    const secs = leaseSeconds && leaseSeconds > 0 ? leaseSeconds : 30;
+    const n = typeof leaseSeconds === "number" ? leaseSeconds : NaN;
+    const secs = n > 0 ? Math.min(n, 3600) : 30;
     return new Date(Date.now() + secs * 1000).toISOString();
   };
   // A claimed/running row is reclaimable once its lease has elapsed. Empty
@@ -105,12 +115,18 @@ routerAdd("POST", "/api/fleet/claim", (c) => {
     200,
     claimed ? { claimed: true, job: view } : { claimed: false },
   );
-});
+}, $apis.requireAdminAuth());
 
 routerAdd("POST", "/api/fleet/renew", (c) => {
   const RUNNING_STATES = ["claimed", "running"];
+  // CLAMP leaseSeconds: the body is caller-supplied JSON, so a non-numeric /
+  // non-positive value (string, null, NaN) falls to the 30s default, and a
+  // huge value is capped at 3600s (1h) so a malformed caller can never wedge
+  // a row behind a multi-day lease the sweeper would wait out. NaN > 0 is
+  // false, so garbage routes to the default without an isFinite dependency.
   const leaseExpiryIso = (leaseSeconds) => {
-    const secs = leaseSeconds && leaseSeconds > 0 ? leaseSeconds : 30;
+    const n = typeof leaseSeconds === "number" ? leaseSeconds : NaN;
+    const secs = n > 0 ? Math.min(n, 3600) : 30;
     return new Date(Date.now() + secs * 1000).toISOString();
   };
   const leaseExpired = (rec) => {
@@ -184,7 +200,7 @@ routerAdd("POST", "/api/fleet/renew", (c) => {
     200,
     renewed ? { renewed: true, job: view } : { renewed: false },
   );
-});
+}, $apis.requireAdminAuth());
 
 routerAdd("POST", "/api/fleet/release", (c) => {
   const RUNNING_STATES = ["claimed", "running"];
@@ -288,4 +304,4 @@ routerAdd("POST", "/api/fleet/release", (c) => {
     200,
     released ? { released: true, job: view } : { released: false },
   );
-});
+}, $apis.requireAdminAuth());

--- a/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
+++ b/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
@@ -256,6 +256,21 @@ routerAdd("POST", "/api/fleet/release", (c) => {
     // claimed_by match above still authorizes it, and re-queue to pending is
     // always safe: it just resets the row to claimable.
     if (target !== "pending" && leaseExpired(rec)) return;
+    // TOCTOU close (the sweepers' list→release race): a "pending" release is
+    // a SWEEPER re-queueing an EXPIRED lease on behalf of its lapsed holder —
+    // but the sweeper decided "expired" from a LISTED SNAPSHOT. If the holder
+    // RENEWED between that list and this release, `claimed_by` still matches
+    // and an unguarded release would yank a LIVE, just-renewed job back to
+    // pending (duplicate execution + a false worker-reclaimed-pending comm
+    // error on the dashboard). Re-check expiry HERE, at release time, inside
+    // the same transaction: a still-live lease means the holder is alive —
+    // refuse, and the sweeper's released:false path skips the row (it retries
+    // on a later sweep once the lease has truly lapsed). This also guards
+    // fleet-health's reclaim of a heartbeat-stale worker whose job loop is
+    // still renewing: a renewing worker is alive, so refusal is correct
+    // there too. leaseExpired stays byte-equivalent to the client's anchored
+    // parse, so both sides agree on what "expired" means.
+    if (target === "pending" && !leaseExpired(rec)) return;
 
     rec.set("status", target);
     if (target === "pending") {

--- a/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
+++ b/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
@@ -243,17 +243,44 @@ routerAdd("POST", "/api/fleet/release", (c) => {
 
   let released = false;
   let view = null;
+  // REFUSAL REASON (threaded to the client on released:false). The caller's
+  // retry truthfulness depends on one distinction: a row that is TERMINAL
+  // UNDER THE CALLER'S OWN workerId can only mean the caller's earlier
+  // release COMMITTED and the response was lost (timeout-after-commit) — a
+  // terminal release retains claimed_by, and no other worker can set it.
+  // The client (queue-client report()) uses that to proceed to its result
+  // write instead of falsely declaring the result discarded.
+  //   refused_terminal_same_holder — row done|failed with claimed_by ===
+  //     workerId (the caller's own committed release; result still writable)
+  //   refused_lease_live           — pending-target (sweeper) release on a
+  //     still-live lease (the TOCTOU close below; holder is alive)
+  //   refused_not_holder           — everything else (unknown row, another
+  //     holder, or a terminal-target release on an already-expired lease —
+  //     the caller is no longer the EFFECTIVE holder)
+  let reason = null;
   $app.dao().runInTransaction((txDao) => {
     let rec;
     try {
       rec = txDao.findRecordById("probe_jobs", jobId);
     } catch (e) {
+      reason = "refused_not_holder";
       return;
     }
     // Only the current lease holder may release, and only while the row is in a
     // running state.
-    if (RUNNING_STATES.indexOf(rec.get("status")) === -1) return;
-    if (rec.get("claimed_by") !== workerId) return;
+    const status = rec.get("status");
+    if (RUNNING_STATES.indexOf(status) === -1) {
+      reason =
+        (status === "done" || status === "failed") &&
+        rec.get("claimed_by") === workerId
+          ? "refused_terminal_same_holder"
+          : "refused_not_holder";
+      return;
+    }
+    if (rec.get("claimed_by") !== workerId) {
+      reason = "refused_not_holder";
+      return;
+    }
     // The lease-expiry gate applies ONLY to TERMINAL targets (done|failed). If
     // the lease already expired the holder LOST it (the sweeper may have
     // re-queued it, or another worker may have stolen the claim) — letting a
@@ -271,7 +298,13 @@ routerAdd("POST", "/api/fleet/release", (c) => {
     // reclaims 0, no worker-crashed-mid-job comm error is ever synthesized). The
     // claimed_by match above still authorizes it, and re-queue to pending is
     // always safe: it just resets the row to claimable.
-    if (target !== "pending" && leaseExpired(rec)) return;
+    if (target !== "pending" && leaseExpired(rec)) {
+      // Expired lease on a terminal-target release: the caller is no longer
+      // the EFFECTIVE holder (the claim is stealable/swept), so this is the
+      // not-holder class, not the committed-terminal class.
+      reason = "refused_not_holder";
+      return;
+    }
     // TOCTOU close (the sweepers' list→release race): a "pending" release is
     // a SWEEPER re-queueing an EXPIRED lease on behalf of its lapsed holder —
     // but the sweeper decided "expired" from a LISTED SNAPSHOT. If the holder
@@ -286,7 +319,10 @@ routerAdd("POST", "/api/fleet/release", (c) => {
     // still renewing: a renewing worker is alive, so refusal is correct
     // there too. leaseExpired stays byte-equivalent to the client's anchored
     // parse, so both sides agree on what "expired" means.
-    if (target === "pending" && !leaseExpired(rec)) return;
+    if (target === "pending" && !leaseExpired(rec)) {
+      reason = "refused_lease_live";
+      return;
+    }
 
     rec.set("status", target);
     if (target === "pending") {
@@ -307,6 +343,8 @@ routerAdd("POST", "/api/fleet/release", (c) => {
 
   return c.json(
     200,
-    released ? { released: true, job: view } : { released: false },
+    released
+      ? { released: true, job: view }
+      : { released: false, reason: reason },
   );
 }, $apis.requireAdminAuth());

--- a/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
+++ b/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
@@ -98,6 +98,12 @@ routerAdd("POST", "/api/fleet/claim", (c) => {
   if (typeof workerId !== "string") {
     return c.json(400, { error: "workerId must be a string" });
   }
+  // Same class for jobId (consistency with the workerId guard): `!jobId`
+  // admits a truthy non-string (a JSON number/object) that would otherwise
+  // ride into findRecordById on the dao's coercion behavior. 400 up front.
+  if (typeof jobId !== "string") {
+    return c.json(400, { error: "jobId must be a string" });
+  }
 
   let claimed = false;
   let alreadyHeld = false;
@@ -213,6 +219,12 @@ routerAdd("POST", "/api/fleet/renew", (c) => {
   if (typeof workerId !== "string") {
     return c.json(400, { error: "workerId must be a string" });
   }
+  // Same class for jobId (consistency with the workerId guard): `!jobId`
+  // admits a truthy non-string (a JSON number/object) that would otherwise
+  // ride into findRecordById on the dao's coercion behavior. 400 up front.
+  if (typeof jobId !== "string") {
+    return c.json(400, { error: "jobId must be a string" });
+  }
 
   let renewed = false;
   let view = null;
@@ -291,6 +303,12 @@ routerAdd("POST", "/api/fleet/release", (c) => {
   // row wedges until lease expiry. Reject the type up front.
   if (typeof workerId !== "string") {
     return c.json(400, { error: "workerId must be a string" });
+  }
+  // Same class for jobId (consistency with the workerId guard): `!jobId`
+  // admits a truthy non-string (a JSON number/object) that would otherwise
+  // ride into findRecordById on the dao's coercion behavior. 400 up front.
+  if (typeof jobId !== "string") {
+    return c.json(400, { error: "jobId must be a string" });
   }
   if (!target) {
     return c.json(400, {

--- a/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
+++ b/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
@@ -24,11 +24,15 @@
 // PUBLIC. The harness client (job-claim.ts) authenticates as superuser and
 // retries once on 401, so enforcement is compat-safe):
 //   /api/fleet/claim    { jobId, workerId, leaseSeconds }
-//                       → { claimed: bool, job? }   exactly-one-winner CAS
+//                       → { claimed: bool, job?, alreadyHeld? }
+//                         exactly-one-winner CAS; alreadyHeld:true marks a
+//                         re-claim by the CURRENT holder on a live lease
+//                         (timeout-after-commit retry idempotency)
 //   /api/fleet/renew    { jobId, workerId, leaseSeconds }
 //                       → { renewed: bool, job? }   only the lease holder
 //   /api/fleet/release  { jobId, workerId, status }  status: done|failed|pending
-//                       → { released: bool, job? }   only the lease holder
+//                       (status REQUIRED — no default)
+//                       → { released: bool, job?, reason? }  only the holder
 
 routerAdd("POST", "/api/fleet/claim", (c) => {
   const RUNNING_STATES = ["claimed", "running"];
@@ -37,9 +41,12 @@ routerAdd("POST", "/api/fleet/claim", (c) => {
   // huge value is capped at 3600s (1h) so a malformed caller can never wedge
   // a row behind a multi-day lease the sweeper would wait out. NaN > 0 is
   // false, so garbage routes to the default without an isFinite dependency.
+  // FLOOR at 1s too: n > 0 admits e.g. 0.001 — a 1ms lease that is expired
+  // before the response lands, making every claim instantly stealable and
+  // every renew a thrash loop.
   const leaseExpiryIso = (leaseSeconds) => {
     const n = typeof leaseSeconds === "number" ? leaseSeconds : NaN;
-    const secs = n > 0 ? Math.min(n, 3600) : 30;
+    const secs = n > 0 ? Math.max(1, Math.min(n, 3600)) : 30;
     return new Date(Date.now() + secs * 1000).toISOString();
   };
   // A claimed/running row is reclaimable once its lease has elapsed. Empty
@@ -84,8 +91,16 @@ routerAdd("POST", "/api/fleet/claim", (c) => {
   if (!jobId || !workerId) {
     return c.json(400, { error: "jobId and workerId are required" });
   }
+  // A non-string workerId (a JSON number) would COERCE into the text
+  // claimed_by column on write — but the holder renews/releases with the
+  // string form, so `claimed_by !== workerId` never matches again and the
+  // row wedges until lease expiry. Reject the type up front.
+  if (typeof workerId !== "string") {
+    return c.json(400, { error: "workerId must be a string" });
+  }
 
   let claimed = false;
+  let alreadyHeld = false;
   let view = null;
   $app.dao().runInTransaction((txDao) => {
     let rec;
@@ -100,7 +115,27 @@ routerAdd("POST", "/api/fleet/claim", (c) => {
     const reclaimable =
       status === "pending" ||
       (RUNNING_STATES.indexOf(status) !== -1 && leaseExpired(rec));
-    if (!reclaimable) return;
+    if (!reclaimable) {
+      // TIMEOUT-AFTER-COMMIT IDEMPOTENCY: a claim that COMMITTED whose
+      // response was lost is retried by the SAME worker — the row is now
+      // claimed by THIS workerId with a live lease, which is not
+      // reclaimable, so a plain refusal would make the retry abandon a row
+      // it actually holds (claimed-but-orphaned until lease expiry). Answer
+      // the truth instead: the caller holds it. claimed:true so the client
+      // treats it as a win; alreadyHeld marks the re-claim (informational —
+      // the existing lease/expiry is RETAINED, not extended; the holder's
+      // heartbeat renews it on its normal cadence).
+      if (
+        RUNNING_STATES.indexOf(status) !== -1 &&
+        rec.get("claimed_by") === workerId &&
+        !leaseExpired(rec)
+      ) {
+        claimed = true;
+        alreadyHeld = true;
+        view = jobView(rec);
+      }
+      return;
+    }
 
     rec.set("status", "claimed");
     rec.set("claimed_by", workerId);
@@ -111,10 +146,10 @@ routerAdd("POST", "/api/fleet/claim", (c) => {
     view = jobView(rec);
   });
 
-  return c.json(
-    200,
-    claimed ? { claimed: true, job: view } : { claimed: false },
-  );
+  // No object-spread (goja compat caution): build the body imperatively.
+  const body = claimed ? { claimed: true, job: view } : { claimed: false };
+  if (alreadyHeld) body.alreadyHeld = true;
+  return c.json(200, body);
 }, $apis.requireAdminAuth());
 
 routerAdd("POST", "/api/fleet/renew", (c) => {
@@ -124,9 +159,12 @@ routerAdd("POST", "/api/fleet/renew", (c) => {
   // huge value is capped at 3600s (1h) so a malformed caller can never wedge
   // a row behind a multi-day lease the sweeper would wait out. NaN > 0 is
   // false, so garbage routes to the default without an isFinite dependency.
+  // FLOOR at 1s too: n > 0 admits e.g. 0.001 — a 1ms lease that is expired
+  // before the response lands, making every claim instantly stealable and
+  // every renew a thrash loop.
   const leaseExpiryIso = (leaseSeconds) => {
     const n = typeof leaseSeconds === "number" ? leaseSeconds : NaN;
-    const secs = n > 0 ? Math.min(n, 3600) : 30;
+    const secs = n > 0 ? Math.max(1, Math.min(n, 3600)) : 30;
     return new Date(Date.now() + secs * 1000).toISOString();
   };
   const leaseExpired = (rec) => {
@@ -167,6 +205,13 @@ routerAdd("POST", "/api/fleet/renew", (c) => {
   const leaseSeconds = data.leaseSeconds;
   if (!jobId || !workerId) {
     return c.json(400, { error: "jobId and workerId are required" });
+  }
+  // A non-string workerId (a JSON number) would COERCE into the text
+  // claimed_by column on write — but the holder renews/releases with the
+  // string form, so `claimed_by !== workerId` never matches again and the
+  // row wedges until lease expiry. Reject the type up front.
+  if (typeof workerId !== "string") {
+    return c.json(400, { error: "workerId must be a string" });
   }
 
   let renewed = false;
@@ -233,9 +278,24 @@ routerAdd("POST", "/api/fleet/release", (c) => {
   const data = $apis.requestInfo(c).data || {};
   const jobId = data.jobId;
   const workerId = data.workerId;
-  const target = data.status || "done";
+  // status is REQUIRED — the old `|| "done"` fallback silently FINISHED a
+  // job whose caller omitted (or sent an empty) status, masking a protocol
+  // bug as success. Validate it exactly like jobId/workerId.
+  const target = data.status;
   if (!jobId || !workerId) {
     return c.json(400, { error: "jobId and workerId are required" });
+  }
+  // A non-string workerId (a JSON number) would COERCE into the text
+  // claimed_by column on write — but the holder renews/releases with the
+  // string form, so `claimed_by !== workerId` never matches again and the
+  // row wedges until lease expiry. Reject the type up front.
+  if (typeof workerId !== "string") {
+    return c.json(400, { error: "workerId must be a string" });
+  }
+  if (!target) {
+    return c.json(400, {
+      error: "status is required (done|failed|pending)",
+    });
   }
   if (["done", "failed", "pending"].indexOf(target) === -1) {
     return c.json(400, { error: "status must be done|failed|pending" });

--- a/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
+++ b/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
@@ -111,49 +111,67 @@ routerAdd(
     let claimed = false;
     let alreadyHeld = false;
     let view = null;
-    $app.dao().runInTransaction((txDao) => {
-      let rec;
-      try {
-        rec = txDao.findRecordById("probe_jobs", jobId);
-      } catch (e) {
-        return; // unknown job → claimed stays false
-      }
-      const status = rec.get("status");
-      // Claimable if pending, OR if its prior claim's lease has expired
-      // (steal the lease from a dead worker). Terminal states never reclaim.
-      const reclaimable =
-        status === "pending" ||
-        (RUNNING_STATES.indexOf(status) !== -1 && leaseExpired(rec));
-      if (!reclaimable) {
-        // TIMEOUT-AFTER-COMMIT IDEMPOTENCY: a claim that COMMITTED whose
-        // response was lost is retried by the SAME worker — the row is now
-        // claimed by THIS workerId with a live lease, which is not
-        // reclaimable, so a plain refusal would make the retry abandon a row
-        // it actually holds (claimed-but-orphaned until lease expiry). Answer
-        // the truth instead: the caller holds it. claimed:true so the client
-        // treats it as a win; alreadyHeld marks the re-claim (informational —
-        // the existing lease/expiry is RETAINED, not extended; the holder's
-        // heartbeat renews it on its normal cadence).
-        if (
-          RUNNING_STATES.indexOf(status) !== -1 &&
-          rec.get("claimed_by") === workerId &&
-          !leaseExpired(rec)
-        ) {
-          claimed = true;
-          alreadyHeld = true;
-          view = jobView(rec);
+    // Wrap runInTransaction in try/catch so a thrown saveRecord (e.g. DB
+    // constraint, transient sqlite error) does NOT escape the handler as
+    // HTTP 500 — the worker client contract expects {claimed:false} on
+    // refusal, and a 500 makes the worker retry-storm without backoff or
+    // mis-classify the refusal class. The transaction itself rolls back on
+    // throw, so DB state is consistent; we reset the JS-side flags here
+    // because they may have been set inside the callback BEFORE the throw
+    // (no rollback semantics for JS-side variables).
+    try {
+      $app.dao().runInTransaction((txDao) => {
+        let rec;
+        try {
+          rec = txDao.findRecordById("probe_jobs", jobId);
+        } catch {
+          return; // unknown job → claimed stays false
         }
-        return;
-      }
+        const status = rec.get("status");
+        // Claimable if pending, OR if its prior claim's lease has expired
+        // (steal the lease from a dead worker). Terminal states never reclaim.
+        const reclaimable =
+          status === "pending" ||
+          (RUNNING_STATES.indexOf(status) !== -1 && leaseExpired(rec));
+        if (!reclaimable) {
+          // TIMEOUT-AFTER-COMMIT IDEMPOTENCY: a claim that COMMITTED whose
+          // response was lost is retried by the SAME worker — the row is now
+          // claimed by THIS workerId with a live lease, which is not
+          // reclaimable, so a plain refusal would make the retry abandon a row
+          // it actually holds (claimed-but-orphaned until lease expiry). Answer
+          // the truth instead: the caller holds it. claimed:true so the client
+          // treats it as a win; alreadyHeld marks the re-claim (informational —
+          // the existing lease/expiry is RETAINED, not extended; the holder's
+          // heartbeat renews it on its normal cadence).
+          if (
+            RUNNING_STATES.indexOf(status) !== -1 &&
+            rec.get("claimed_by") === workerId &&
+            !leaseExpired(rec)
+          ) {
+            claimed = true;
+            alreadyHeld = true;
+            view = jobView(rec);
+          }
+          return;
+        }
 
-      rec.set("status", "claimed");
-      rec.set("claimed_by", workerId);
-      rec.set("lease_expires_at", leaseExpiryIso(leaseSeconds));
-      rec.set("version", (rec.get("version") || 0) + 1);
-      txDao.saveRecord(rec);
-      claimed = true;
-      view = jobView(rec);
-    });
+        rec.set("status", "claimed");
+        rec.set("claimed_by", workerId);
+        rec.set("lease_expires_at", leaseExpiryIso(leaseSeconds));
+        rec.set("version", (rec.get("version") || 0) + 1);
+        txDao.saveRecord(rec);
+        claimed = true;
+        view = jobView(rec);
+      });
+    } catch {
+      // Transaction threw (commit failure, saveRecord exception, etc.).
+      // Reset JS-side flags — they may have been set inside the callback
+      // before the throw, but the DB rolled back, so the documented refusal
+      // shape is the truthful answer.
+      claimed = false;
+      alreadyHeld = false;
+      view = null;
+    }
 
     // No object-spread (goja compat caution): build the body imperatively.
     const body = claimed ? { claimed: true, job: view } : { claimed: false };
@@ -236,30 +254,39 @@ routerAdd(
 
     let renewed = false;
     let view = null;
-    $app.dao().runInTransaction((txDao) => {
-      let rec;
-      try {
-        rec = txDao.findRecordById("probe_jobs", jobId);
-      } catch (e) {
-        return;
-      }
-      const status = rec.get("status");
-      // Only the current lease holder may renew, and only while the row is
-      // still in a running state and the lease has NOT yet expired. If the
-      // lease already expired the holder lost it (another worker may have
-      // stolen it) — renew must fail so the original worker stops.
-      if (RUNNING_STATES.indexOf(status) === -1) return;
-      if (rec.get("claimed_by") !== workerId) return;
-      if (leaseExpired(rec)) return;
+    // Wrap runInTransaction in try/catch so a thrown saveRecord does NOT
+    // escape as HTTP 500 — worker clients expect {renewed:false} on refusal.
+    // The transaction rolls back on throw, so we reset JS-side flags to
+    // match the rolled-back DB state.
+    try {
+      $app.dao().runInTransaction((txDao) => {
+        let rec;
+        try {
+          rec = txDao.findRecordById("probe_jobs", jobId);
+        } catch {
+          return;
+        }
+        const status = rec.get("status");
+        // Only the current lease holder may renew, and only while the row is
+        // still in a running state and the lease has NOT yet expired. If the
+        // lease already expired the holder lost it (another worker may have
+        // stolen it) — renew must fail so the original worker stops.
+        if (RUNNING_STATES.indexOf(status) === -1) return;
+        if (rec.get("claimed_by") !== workerId) return;
+        if (leaseExpired(rec)) return;
 
-      // Promote claimed → running on first renew so the lifecycle is visible.
-      rec.set("status", "running");
-      rec.set("lease_expires_at", leaseExpiryIso(leaseSeconds));
-      rec.set("version", (rec.get("version") || 0) + 1);
-      txDao.saveRecord(rec);
-      renewed = true;
-      view = jobView(rec);
-    });
+        // Promote claimed → running on first renew so the lifecycle is visible.
+        rec.set("status", "running");
+        rec.set("lease_expires_at", leaseExpiryIso(leaseSeconds));
+        rec.set("version", (rec.get("version") || 0) + 1);
+        txDao.saveRecord(rec);
+        renewed = true;
+        view = jobView(rec);
+      });
+    } catch {
+      renewed = false;
+      view = null;
+    }
 
     return c.json(
       200,
@@ -349,88 +376,100 @@ routerAdd(
     //     holder, or a terminal-target release on an already-expired lease —
     //     the caller is no longer the EFFECTIVE holder)
     let reason = null;
-    $app.dao().runInTransaction((txDao) => {
-      let rec;
-      try {
-        rec = txDao.findRecordById("probe_jobs", jobId);
-      } catch (e) {
-        reason = "refused_not_holder";
-        return;
-      }
-      // Only the current lease holder may release, and only while the row is in a
-      // running state.
-      const status = rec.get("status");
-      if (RUNNING_STATES.indexOf(status) === -1) {
-        reason =
-          (status === "done" || status === "failed") &&
-          rec.get("claimed_by") === workerId
-            ? "refused_terminal_same_holder"
-            : "refused_not_holder";
-        return;
-      }
-      if (rec.get("claimed_by") !== workerId) {
-        reason = "refused_not_holder";
-        return;
-      }
-      // The lease-expiry gate applies ONLY to TERMINAL targets (done|failed). If
-      // the lease already expired the holder LOST it (the sweeper may have
-      // re-queued it, or another worker may have stolen the claim) — letting a
-      // stale worker clobber terminal state would violate the exactly-one-winner
-      // invariant. Mirror renew's holder-lost-it semantics: reject the terminal
-      // release so the stale worker stops. (`claimed_by` unchanged is NOT
-      // sufficient — a stolen-then-released race can transiently match; the lease
-      // check is the authoritative gate for terminal writes.)
-      //
-      // But target === "pending" is the SWEEPER's re-queue (queue-client
-      // sweepExpired calls releaseJob(jobId, claimed_by, "pending") on EXPIRED
-      // rows on behalf of a crashed worker). That path operates on expired leases
-      // BY DESIGN, so it must be allowed to proceed even when leaseExpired is
-      // true — gating it here makes REQ-B crash reclamation inert (the sweeper
-      // reclaims 0, no worker-reclaimed-pending comm error is ever synthesized). The
-      // claimed_by match above still authorizes it, and re-queue to pending is
-      // always safe: it just resets the row to claimable.
-      if (target !== "pending" && leaseExpired(rec)) {
-        // Expired lease on a terminal-target release: the caller is no longer
-        // the EFFECTIVE holder (the claim is stealable/swept), so this is the
-        // not-holder class, not the committed-terminal class.
-        reason = "refused_not_holder";
-        return;
-      }
-      // TOCTOU close (the sweepers' list→release race): a "pending" release is
-      // a SWEEPER re-queueing an EXPIRED lease on behalf of its lapsed holder —
-      // but the sweeper decided "expired" from a LISTED SNAPSHOT. If the holder
-      // RENEWED between that list and this release, `claimed_by` still matches
-      // and an unguarded release would yank a LIVE, just-renewed job back to
-      // pending (duplicate execution + a false worker-reclaimed-pending comm
-      // error on the dashboard). Re-check expiry HERE, at release time, inside
-      // the same transaction: a still-live lease means the holder is alive —
-      // refuse, and the sweeper's released:false path skips the row (it retries
-      // on a later sweep once the lease has truly lapsed). This also guards
-      // fleet-health's reclaim of a heartbeat-stale worker whose job loop is
-      // still renewing: a renewing worker is alive, so refusal is correct
-      // there too. leaseExpired stays byte-equivalent to the client's anchored
-      // parse, so both sides agree on what "expired" means.
-      if (target === "pending" && !leaseExpired(rec)) {
-        reason = "refused_lease_live";
-        return;
-      }
+    // Wrap runInTransaction in try/catch so a thrown saveRecord does NOT
+    // escape as HTTP 500 — worker clients expect {released:false, reason}
+    // on refusal. The transaction rolls back on throw; reset JS-side flags
+    // to match. Use refused_not_holder as the conservative reason for an
+    // unexpected throw (treats the caller as no-longer-effective-holder,
+    // which is the same class the client already handles defensively).
+    try {
+      $app.dao().runInTransaction((txDao) => {
+        let rec;
+        try {
+          rec = txDao.findRecordById("probe_jobs", jobId);
+        } catch {
+          reason = "refused_not_holder";
+          return;
+        }
+        // Only the current lease holder may release, and only while the row is in a
+        // running state.
+        const status = rec.get("status");
+        if (RUNNING_STATES.indexOf(status) === -1) {
+          reason =
+            (status === "done" || status === "failed") &&
+            rec.get("claimed_by") === workerId
+              ? "refused_terminal_same_holder"
+              : "refused_not_holder";
+          return;
+        }
+        if (rec.get("claimed_by") !== workerId) {
+          reason = "refused_not_holder";
+          return;
+        }
+        // The lease-expiry gate applies ONLY to TERMINAL targets (done|failed). If
+        // the lease already expired the holder LOST it (the sweeper may have
+        // re-queued it, or another worker may have stolen the claim) — letting a
+        // stale worker clobber terminal state would violate the exactly-one-winner
+        // invariant. Mirror renew's holder-lost-it semantics: reject the terminal
+        // release so the stale worker stops. (`claimed_by` unchanged is NOT
+        // sufficient — a stolen-then-released race can transiently match; the lease
+        // check is the authoritative gate for terminal writes.)
+        //
+        // But target === "pending" is the SWEEPER's re-queue (queue-client
+        // sweepExpired calls releaseJob(jobId, claimed_by, "pending") on EXPIRED
+        // rows on behalf of a crashed worker). That path operates on expired leases
+        // BY DESIGN, so it must be allowed to proceed even when leaseExpired is
+        // true — gating it here makes REQ-B crash reclamation inert (the sweeper
+        // reclaims 0, no worker-reclaimed-pending comm error is ever synthesized). The
+        // claimed_by match above still authorizes it, and re-queue to pending is
+        // always safe: it just resets the row to claimable.
+        if (target !== "pending" && leaseExpired(rec)) {
+          // Expired lease on a terminal-target release: the caller is no longer
+          // the EFFECTIVE holder (the claim is stealable/swept), so this is the
+          // not-holder class, not the committed-terminal class.
+          reason = "refused_not_holder";
+          return;
+        }
+        // TOCTOU close (the sweepers' list→release race): a "pending" release is
+        // a SWEEPER re-queueing an EXPIRED lease on behalf of its lapsed holder —
+        // but the sweeper decided "expired" from a LISTED SNAPSHOT. If the holder
+        // RENEWED between that list and this release, `claimed_by` still matches
+        // and an unguarded release would yank a LIVE, just-renewed job back to
+        // pending (duplicate execution + a false worker-reclaimed-pending comm
+        // error on the dashboard). Re-check expiry HERE, at release time, inside
+        // the same transaction: a still-live lease means the holder is alive —
+        // refuse, and the sweeper's released:false path skips the row (it retries
+        // on a later sweep once the lease has truly lapsed). This also guards
+        // fleet-health's reclaim of a heartbeat-stale worker whose job loop is
+        // still renewing: a renewing worker is alive, so refusal is correct
+        // there too. leaseExpired stays byte-equivalent to the client's anchored
+        // parse, so both sides agree on what "expired" means.
+        if (target === "pending" && !leaseExpired(rec)) {
+          reason = "refused_lease_live";
+          return;
+        }
 
-      rec.set("status", target);
-      if (target === "pending") {
-        // Re-queue: drop ownership so it's claimable again. The (expired)
-        // lease_expires_at is RETAINED — claim admits pending rows regardless
-        // of lease, and the stale value now serves as the row's
-        // "last in flight" marker: the queue-client's stale-pending sweep
-        // skips re-queued rows whose lease is recent, so a long-running job
-        // that out-lived its family's expiry window gets an actual re-run
-        // instead of being claim-deleted off its original `created` age.
-        rec.set("claimed_by", "");
-      }
-      rec.set("version", (rec.get("version") || 0) + 1);
-      txDao.saveRecord(rec);
-      released = true;
-      view = jobView(rec);
-    });
+        rec.set("status", target);
+        if (target === "pending") {
+          // Re-queue: drop ownership so it's claimable again. The (expired)
+          // lease_expires_at is RETAINED — claim admits pending rows regardless
+          // of lease, and the stale value now serves as the row's
+          // "last in flight" marker: the queue-client's stale-pending sweep
+          // skips re-queued rows whose lease is recent, so a long-running job
+          // that out-lived its family's expiry window gets an actual re-run
+          // instead of being claim-deleted off its original `created` age.
+          rec.set("claimed_by", "");
+        }
+        rec.set("version", (rec.get("version") || 0) + 1);
+        txDao.saveRecord(rec);
+        released = true;
+        view = jobView(rec);
+      });
+    } catch {
+      released = false;
+      view = null;
+      reason = "refused_not_holder";
+    }
 
     return c.json(
       200,

--- a/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
+++ b/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
@@ -295,7 +295,7 @@ routerAdd("POST", "/api/fleet/release", (c) => {
     // rows on behalf of a crashed worker). That path operates on expired leases
     // BY DESIGN, so it must be allowed to proceed even when leaseExpired is
     // true — gating it here makes REQ-B crash reclamation inert (the sweeper
-    // reclaims 0, no worker-crashed-mid-job comm error is ever synthesized). The
+    // reclaims 0, no worker-reclaimed-pending comm error is ever synthesized). The
     // claimed_by match above still authorizes it, and re-queue to pending is
     // always safe: it just resets the row to claimable.
     if (target !== "pending" && leaseExpired(rec)) {

--- a/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
+++ b/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
@@ -290,9 +290,14 @@ routerAdd("POST", "/api/fleet/release", (c) => {
 
     rec.set("status", target);
     if (target === "pending") {
-      // Re-queue: drop ownership so it's claimable again.
+      // Re-queue: drop ownership so it's claimable again. The (expired)
+      // lease_expires_at is RETAINED — claim admits pending rows regardless
+      // of lease, and the stale value now serves as the row's
+      // "last in flight" marker: the queue-client's stale-pending sweep
+      // skips re-queued rows whose lease is recent, so a long-running job
+      // that out-lived its family's expiry window gets an actual re-run
+      // instead of being claim-deleted off its original `created` age.
       rec.set("claimed_by", "");
-      rec.set("lease_expires_at", null);
     }
     rec.set("version", (rec.get("version") || 0) + 1);
     txDao.saveRecord(rec);

--- a/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
+++ b/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
@@ -34,395 +34,410 @@
 //                       (status REQUIRED — no default)
 //                       → { released: bool, job?, reason? }  only the holder
 
-routerAdd("POST", "/api/fleet/claim", (c) => {
-  const RUNNING_STATES = ["claimed", "running"];
-  // CLAMP leaseSeconds: the body is caller-supplied JSON, so a non-numeric /
-  // non-positive value (string, null, NaN) falls to the 30s default, and a
-  // huge value is capped at 3600s (1h) so a malformed caller can never wedge
-  // a row behind a multi-day lease the sweeper would wait out. NaN > 0 is
-  // false, so garbage routes to the default without an isFinite dependency.
-  // FLOOR at 1s too: n > 0 admits e.g. 0.001 — a 1ms lease that is expired
-  // before the response lands, making every claim instantly stealable and
-  // every renew a thrash loop.
-  const leaseExpiryIso = (leaseSeconds) => {
-    const n = typeof leaseSeconds === "number" ? leaseSeconds : NaN;
-    const secs = n > 0 ? Math.max(1, Math.min(n, 3600)) : 30;
-    return new Date(Date.now() + secs * 1000).toISOString();
-  };
-  // A claimed/running row is reclaimable once its lease has elapsed. Empty
-  // / unparseable lease is treated as expired (never let a row wedge the
-  // queue forever because of a malformed timestamp).
-  const leaseExpired = (rec) => {
-    const raw = rec.get("lease_expires_at");
-    if (!raw) return true;
-    // PB stores dates as "2006-01-02 15:04:05.000Z" (space separator).
-    // goja's Date.parse is strict and returns NaN for the space form
-    // (unlike V8/Node, which accept it) — so normalize the space to the
-    // ISO "T" separator before parsing. Without this every lease parses
-    // to NaN and is wrongly treated as expired, letting any caller steal
-    // a live claim. (Verified against PB 0.22.21 / goja.)
-    //
-    // ANCHOR the replacement to the date/time boundary
-    // ("YYYY-MM-DD ") so we ONLY rewrite the canonical PB shape. A bare
-    // String.replace(" ", "T") rewrites the FIRST space anywhere, which
-    // would coerce a malformed/non-standard value into something that
-    // parses, silently treating a LIVE claim as expired and defeating the
-    // exactly-one-winner CAS. An odd shape must fall through to NaN →
-    // expired-by-policy is intentional (never wedge the queue), but only
-    // because the value genuinely failed to parse, not because we mangled
-    // it into a parseable one.
-    const t = Date.parse(String(raw).replace(/^(\d{4}-\d{2}-\d{2}) /, "$1T"));
-    if (isNaN(t)) return true;
-    return t <= Date.now();
-  };
-  const jobView = (rec) => ({
-    id: rec.id,
-    probe_key: rec.get("probe_key"),
-    status: rec.get("status"),
-    claimed_by: rec.get("claimed_by"),
-    lease_expires_at: rec.get("lease_expires_at"),
-    version: rec.get("version"),
-  });
-
-  const data = $apis.requestInfo(c).data || {};
-  const jobId = data.jobId;
-  const workerId = data.workerId;
-  const leaseSeconds = data.leaseSeconds;
-  if (!jobId || !workerId) {
-    return c.json(400, { error: "jobId and workerId are required" });
-  }
-  // A non-string workerId (a JSON number) would COERCE into the text
-  // claimed_by column on write — but the holder renews/releases with the
-  // string form, so `claimed_by !== workerId` never matches again and the
-  // row wedges until lease expiry. Reject the type up front.
-  if (typeof workerId !== "string") {
-    return c.json(400, { error: "workerId must be a string" });
-  }
-  // Same class for jobId (consistency with the workerId guard): `!jobId`
-  // admits a truthy non-string (a JSON number/object) that would otherwise
-  // ride into findRecordById on the dao's coercion behavior. 400 up front.
-  if (typeof jobId !== "string") {
-    return c.json(400, { error: "jobId must be a string" });
-  }
-
-  let claimed = false;
-  let alreadyHeld = false;
-  let view = null;
-  $app.dao().runInTransaction((txDao) => {
-    let rec;
-    try {
-      rec = txDao.findRecordById("probe_jobs", jobId);
-    } catch (e) {
-      return; // unknown job → claimed stays false
-    }
-    const status = rec.get("status");
-    // Claimable if pending, OR if its prior claim's lease has expired
-    // (steal the lease from a dead worker). Terminal states never reclaim.
-    const reclaimable =
-      status === "pending" ||
-      (RUNNING_STATES.indexOf(status) !== -1 && leaseExpired(rec));
-    if (!reclaimable) {
-      // TIMEOUT-AFTER-COMMIT IDEMPOTENCY: a claim that COMMITTED whose
-      // response was lost is retried by the SAME worker — the row is now
-      // claimed by THIS workerId with a live lease, which is not
-      // reclaimable, so a plain refusal would make the retry abandon a row
-      // it actually holds (claimed-but-orphaned until lease expiry). Answer
-      // the truth instead: the caller holds it. claimed:true so the client
-      // treats it as a win; alreadyHeld marks the re-claim (informational —
-      // the existing lease/expiry is RETAINED, not extended; the holder's
-      // heartbeat renews it on its normal cadence).
-      if (
-        RUNNING_STATES.indexOf(status) !== -1 &&
-        rec.get("claimed_by") === workerId &&
-        !leaseExpired(rec)
-      ) {
-        claimed = true;
-        alreadyHeld = true;
-        view = jobView(rec);
-      }
-      return;
-    }
-
-    rec.set("status", "claimed");
-    rec.set("claimed_by", workerId);
-    rec.set("lease_expires_at", leaseExpiryIso(leaseSeconds));
-    rec.set("version", (rec.get("version") || 0) + 1);
-    txDao.saveRecord(rec);
-    claimed = true;
-    view = jobView(rec);
-  });
-
-  // No object-spread (goja compat caution): build the body imperatively.
-  const body = claimed ? { claimed: true, job: view } : { claimed: false };
-  if (alreadyHeld) body.alreadyHeld = true;
-  return c.json(200, body);
-}, $apis.requireAdminAuth());
-
-routerAdd("POST", "/api/fleet/renew", (c) => {
-  const RUNNING_STATES = ["claimed", "running"];
-  // CLAMP leaseSeconds: the body is caller-supplied JSON, so a non-numeric /
-  // non-positive value (string, null, NaN) falls to the 30s default, and a
-  // huge value is capped at 3600s (1h) so a malformed caller can never wedge
-  // a row behind a multi-day lease the sweeper would wait out. NaN > 0 is
-  // false, so garbage routes to the default without an isFinite dependency.
-  // FLOOR at 1s too: n > 0 admits e.g. 0.001 — a 1ms lease that is expired
-  // before the response lands, making every claim instantly stealable and
-  // every renew a thrash loop.
-  const leaseExpiryIso = (leaseSeconds) => {
-    const n = typeof leaseSeconds === "number" ? leaseSeconds : NaN;
-    const secs = n > 0 ? Math.max(1, Math.min(n, 3600)) : 30;
-    return new Date(Date.now() + secs * 1000).toISOString();
-  };
-  const leaseExpired = (rec) => {
-    const raw = rec.get("lease_expires_at");
-    if (!raw) return true;
-    // PB stores dates as "2006-01-02 15:04:05.000Z" (space separator).
-    // goja's Date.parse is strict and returns NaN for the space form
-    // (unlike V8/Node, which accept it) — so normalize the space to the
-    // ISO "T" separator before parsing. Without this every lease parses
-    // to NaN and is wrongly treated as expired, letting any caller steal
-    // a live claim. (Verified against PB 0.22.21 / goja.)
-    //
-    // ANCHOR the replacement to the date/time boundary
-    // ("YYYY-MM-DD ") so we ONLY rewrite the canonical PB shape. A bare
-    // String.replace(" ", "T") rewrites the FIRST space anywhere, which
-    // would coerce a malformed/non-standard value into something that
-    // parses, silently treating a LIVE claim as expired and defeating the
-    // exactly-one-winner CAS. An odd shape must fall through to NaN →
-    // expired-by-policy is intentional (never wedge the queue), but only
-    // because the value genuinely failed to parse, not because we mangled
-    // it into a parseable one.
-    const t = Date.parse(String(raw).replace(/^(\d{4}-\d{2}-\d{2}) /, "$1T"));
-    if (isNaN(t)) return true;
-    return t <= Date.now();
-  };
-  const jobView = (rec) => ({
-    id: rec.id,
-    probe_key: rec.get("probe_key"),
-    status: rec.get("status"),
-    claimed_by: rec.get("claimed_by"),
-    lease_expires_at: rec.get("lease_expires_at"),
-    version: rec.get("version"),
-  });
-
-  const data = $apis.requestInfo(c).data || {};
-  const jobId = data.jobId;
-  const workerId = data.workerId;
-  const leaseSeconds = data.leaseSeconds;
-  if (!jobId || !workerId) {
-    return c.json(400, { error: "jobId and workerId are required" });
-  }
-  // A non-string workerId (a JSON number) would COERCE into the text
-  // claimed_by column on write — but the holder renews/releases with the
-  // string form, so `claimed_by !== workerId` never matches again and the
-  // row wedges until lease expiry. Reject the type up front.
-  if (typeof workerId !== "string") {
-    return c.json(400, { error: "workerId must be a string" });
-  }
-  // Same class for jobId (consistency with the workerId guard): `!jobId`
-  // admits a truthy non-string (a JSON number/object) that would otherwise
-  // ride into findRecordById on the dao's coercion behavior. 400 up front.
-  if (typeof jobId !== "string") {
-    return c.json(400, { error: "jobId must be a string" });
-  }
-
-  let renewed = false;
-  let view = null;
-  $app.dao().runInTransaction((txDao) => {
-    let rec;
-    try {
-      rec = txDao.findRecordById("probe_jobs", jobId);
-    } catch (e) {
-      return;
-    }
-    const status = rec.get("status");
-    // Only the current lease holder may renew, and only while the row is
-    // still in a running state and the lease has NOT yet expired. If the
-    // lease already expired the holder lost it (another worker may have
-    // stolen it) — renew must fail so the original worker stops.
-    if (RUNNING_STATES.indexOf(status) === -1) return;
-    if (rec.get("claimed_by") !== workerId) return;
-    if (leaseExpired(rec)) return;
-
-    // Promote claimed → running on first renew so the lifecycle is visible.
-    rec.set("status", "running");
-    rec.set("lease_expires_at", leaseExpiryIso(leaseSeconds));
-    rec.set("version", (rec.get("version") || 0) + 1);
-    txDao.saveRecord(rec);
-    renewed = true;
-    view = jobView(rec);
-  });
-
-  return c.json(
-    200,
-    renewed ? { renewed: true, job: view } : { renewed: false },
-  );
-}, $apis.requireAdminAuth());
-
-routerAdd("POST", "/api/fleet/release", (c) => {
-  const RUNNING_STATES = ["claimed", "running"];
-  // A claimed/running row's lease is elapsed once its expiry timestamp has
-  // passed. Empty / unparseable lease is treated as expired (mirrors claim +
-  // renew). Defined INSIDE the handler closure — PB 0.22's pooled goja runtime
-  // does NOT see module-top-level declarations from a handler (the
-  // "X is not defined" gotcha documented at the top of this file).
-  const leaseExpired = (rec) => {
-    const raw = rec.get("lease_expires_at");
-    if (!raw) return true;
-    // PB stores dates as "2006-01-02 15:04:05.000Z" (space separator). goja's
-    // Date.parse is strict and returns NaN for the space form, so normalize the
-    // space to the ISO "T" separator before parsing — ANCHORED to the date/time
-    // boundary so we only rewrite the canonical PB shape (a bare replace would
-    // coerce a malformed value into something parseable, defeating the CAS).
-    const t = Date.parse(String(raw).replace(/^(\d{4}-\d{2}-\d{2}) /, "$1T"));
-    if (isNaN(t)) return true;
-    return t <= Date.now();
-  };
-  const jobView = (rec) => ({
-    id: rec.id,
-    probe_key: rec.get("probe_key"),
-    status: rec.get("status"),
-    claimed_by: rec.get("claimed_by"),
-    lease_expires_at: rec.get("lease_expires_at"),
-    version: rec.get("version"),
-  });
-
-  const data = $apis.requestInfo(c).data || {};
-  const jobId = data.jobId;
-  const workerId = data.workerId;
-  // status is REQUIRED — the old `|| "done"` fallback silently FINISHED a
-  // job whose caller omitted (or sent an empty) status, masking a protocol
-  // bug as success. Validate it exactly like jobId/workerId.
-  const target = data.status;
-  if (!jobId || !workerId) {
-    return c.json(400, { error: "jobId and workerId are required" });
-  }
-  // A non-string workerId (a JSON number) would COERCE into the text
-  // claimed_by column on write — but the holder renews/releases with the
-  // string form, so `claimed_by !== workerId` never matches again and the
-  // row wedges until lease expiry. Reject the type up front.
-  if (typeof workerId !== "string") {
-    return c.json(400, { error: "workerId must be a string" });
-  }
-  // Same class for jobId (consistency with the workerId guard): `!jobId`
-  // admits a truthy non-string (a JSON number/object) that would otherwise
-  // ride into findRecordById on the dao's coercion behavior. 400 up front.
-  if (typeof jobId !== "string") {
-    return c.json(400, { error: "jobId must be a string" });
-  }
-  if (!target) {
-    return c.json(400, {
-      error: "status is required (done|failed|pending)",
+routerAdd(
+  "POST",
+  "/api/fleet/claim",
+  (c) => {
+    const RUNNING_STATES = ["claimed", "running"];
+    // CLAMP leaseSeconds: the body is caller-supplied JSON, so a non-numeric /
+    // non-positive value (string, null, NaN) falls to the 30s default, and a
+    // huge value is capped at 3600s (1h) so a malformed caller can never wedge
+    // a row behind a multi-day lease the sweeper would wait out. NaN > 0 is
+    // false, so garbage routes to the default without an isFinite dependency.
+    // FLOOR at 1s too: n > 0 admits e.g. 0.001 — a 1ms lease that is expired
+    // before the response lands, making every claim instantly stealable and
+    // every renew a thrash loop.
+    const leaseExpiryIso = (leaseSeconds) => {
+      const n = typeof leaseSeconds === "number" ? leaseSeconds : NaN;
+      const secs = n > 0 ? Math.max(1, Math.min(n, 3600)) : 30;
+      return new Date(Date.now() + secs * 1000).toISOString();
+    };
+    // A claimed/running row is reclaimable once its lease has elapsed. Empty
+    // / unparseable lease is treated as expired (never let a row wedge the
+    // queue forever because of a malformed timestamp).
+    const leaseExpired = (rec) => {
+      const raw = rec.get("lease_expires_at");
+      if (!raw) return true;
+      // PB stores dates as "2006-01-02 15:04:05.000Z" (space separator).
+      // goja's Date.parse is strict and returns NaN for the space form
+      // (unlike V8/Node, which accept it) — so normalize the space to the
+      // ISO "T" separator before parsing. Without this every lease parses
+      // to NaN and is wrongly treated as expired, letting any caller steal
+      // a live claim. (Verified against PB 0.22.21 / goja.)
+      //
+      // ANCHOR the replacement to the date/time boundary
+      // ("YYYY-MM-DD ") so we ONLY rewrite the canonical PB shape. A bare
+      // String.replace(" ", "T") rewrites the FIRST space anywhere, which
+      // would coerce a malformed/non-standard value into something that
+      // parses, silently treating a LIVE claim as expired and defeating the
+      // exactly-one-winner CAS. An odd shape must fall through to NaN →
+      // expired-by-policy is intentional (never wedge the queue), but only
+      // because the value genuinely failed to parse, not because we mangled
+      // it into a parseable one.
+      const t = Date.parse(String(raw).replace(/^(\d{4}-\d{2}-\d{2}) /, "$1T"));
+      if (isNaN(t)) return true;
+      return t <= Date.now();
+    };
+    const jobView = (rec) => ({
+      id: rec.id,
+      probe_key: rec.get("probe_key"),
+      status: rec.get("status"),
+      claimed_by: rec.get("claimed_by"),
+      lease_expires_at: rec.get("lease_expires_at"),
+      version: rec.get("version"),
     });
-  }
-  if (["done", "failed", "pending"].indexOf(target) === -1) {
-    return c.json(400, { error: "status must be done|failed|pending" });
-  }
 
-  let released = false;
-  let view = null;
-  // REFUSAL REASON (threaded to the client on released:false). The caller's
-  // retry truthfulness depends on one distinction: a row that is TERMINAL
-  // UNDER THE CALLER'S OWN workerId can only mean the caller's earlier
-  // release COMMITTED and the response was lost (timeout-after-commit) — a
-  // terminal release retains claimed_by, and no other worker can set it.
-  // The client (queue-client report()) uses that to proceed to its result
-  // write instead of falsely declaring the result discarded.
-  //   refused_terminal_same_holder — row done|failed with claimed_by ===
-  //     workerId (the caller's own committed release; result still writable)
-  //   refused_lease_live           — pending-target (sweeper) release on a
-  //     still-live lease (the TOCTOU close below; holder is alive)
-  //   refused_not_holder           — everything else (unknown row, another
-  //     holder, or a terminal-target release on an already-expired lease —
-  //     the caller is no longer the EFFECTIVE holder)
-  let reason = null;
-  $app.dao().runInTransaction((txDao) => {
-    let rec;
-    try {
-      rec = txDao.findRecordById("probe_jobs", jobId);
-    } catch (e) {
-      reason = "refused_not_holder";
-      return;
+    const data = $apis.requestInfo(c).data || {};
+    const jobId = data.jobId;
+    const workerId = data.workerId;
+    const leaseSeconds = data.leaseSeconds;
+    if (!jobId || !workerId) {
+      return c.json(400, { error: "jobId and workerId are required" });
     }
-    // Only the current lease holder may release, and only while the row is in a
-    // running state.
-    const status = rec.get("status");
-    if (RUNNING_STATES.indexOf(status) === -1) {
-      reason =
-        (status === "done" || status === "failed") &&
-        rec.get("claimed_by") === workerId
-          ? "refused_terminal_same_holder"
-          : "refused_not_holder";
-      return;
+    // A non-string workerId (a JSON number) would COERCE into the text
+    // claimed_by column on write — but the holder renews/releases with the
+    // string form, so `claimed_by !== workerId` never matches again and the
+    // row wedges until lease expiry. Reject the type up front.
+    if (typeof workerId !== "string") {
+      return c.json(400, { error: "workerId must be a string" });
     }
-    if (rec.get("claimed_by") !== workerId) {
-      reason = "refused_not_holder";
-      return;
-    }
-    // The lease-expiry gate applies ONLY to TERMINAL targets (done|failed). If
-    // the lease already expired the holder LOST it (the sweeper may have
-    // re-queued it, or another worker may have stolen the claim) — letting a
-    // stale worker clobber terminal state would violate the exactly-one-winner
-    // invariant. Mirror renew's holder-lost-it semantics: reject the terminal
-    // release so the stale worker stops. (`claimed_by` unchanged is NOT
-    // sufficient — a stolen-then-released race can transiently match; the lease
-    // check is the authoritative gate for terminal writes.)
-    //
-    // But target === "pending" is the SWEEPER's re-queue (queue-client
-    // sweepExpired calls releaseJob(jobId, claimed_by, "pending") on EXPIRED
-    // rows on behalf of a crashed worker). That path operates on expired leases
-    // BY DESIGN, so it must be allowed to proceed even when leaseExpired is
-    // true — gating it here makes REQ-B crash reclamation inert (the sweeper
-    // reclaims 0, no worker-reclaimed-pending comm error is ever synthesized). The
-    // claimed_by match above still authorizes it, and re-queue to pending is
-    // always safe: it just resets the row to claimable.
-    if (target !== "pending" && leaseExpired(rec)) {
-      // Expired lease on a terminal-target release: the caller is no longer
-      // the EFFECTIVE holder (the claim is stealable/swept), so this is the
-      // not-holder class, not the committed-terminal class.
-      reason = "refused_not_holder";
-      return;
-    }
-    // TOCTOU close (the sweepers' list→release race): a "pending" release is
-    // a SWEEPER re-queueing an EXPIRED lease on behalf of its lapsed holder —
-    // but the sweeper decided "expired" from a LISTED SNAPSHOT. If the holder
-    // RENEWED between that list and this release, `claimed_by` still matches
-    // and an unguarded release would yank a LIVE, just-renewed job back to
-    // pending (duplicate execution + a false worker-reclaimed-pending comm
-    // error on the dashboard). Re-check expiry HERE, at release time, inside
-    // the same transaction: a still-live lease means the holder is alive —
-    // refuse, and the sweeper's released:false path skips the row (it retries
-    // on a later sweep once the lease has truly lapsed). This also guards
-    // fleet-health's reclaim of a heartbeat-stale worker whose job loop is
-    // still renewing: a renewing worker is alive, so refusal is correct
-    // there too. leaseExpired stays byte-equivalent to the client's anchored
-    // parse, so both sides agree on what "expired" means.
-    if (target === "pending" && !leaseExpired(rec)) {
-      reason = "refused_lease_live";
-      return;
+    // Same class for jobId (consistency with the workerId guard): `!jobId`
+    // admits a truthy non-string (a JSON number/object) that would otherwise
+    // ride into findRecordById on the dao's coercion behavior. 400 up front.
+    if (typeof jobId !== "string") {
+      return c.json(400, { error: "jobId must be a string" });
     }
 
-    rec.set("status", target);
-    if (target === "pending") {
-      // Re-queue: drop ownership so it's claimable again. The (expired)
-      // lease_expires_at is RETAINED — claim admits pending rows regardless
-      // of lease, and the stale value now serves as the row's
-      // "last in flight" marker: the queue-client's stale-pending sweep
-      // skips re-queued rows whose lease is recent, so a long-running job
-      // that out-lived its family's expiry window gets an actual re-run
-      // instead of being claim-deleted off its original `created` age.
-      rec.set("claimed_by", "");
-    }
-    rec.set("version", (rec.get("version") || 0) + 1);
-    txDao.saveRecord(rec);
-    released = true;
-    view = jobView(rec);
-  });
+    let claimed = false;
+    let alreadyHeld = false;
+    let view = null;
+    $app.dao().runInTransaction((txDao) => {
+      let rec;
+      try {
+        rec = txDao.findRecordById("probe_jobs", jobId);
+      } catch (e) {
+        return; // unknown job → claimed stays false
+      }
+      const status = rec.get("status");
+      // Claimable if pending, OR if its prior claim's lease has expired
+      // (steal the lease from a dead worker). Terminal states never reclaim.
+      const reclaimable =
+        status === "pending" ||
+        (RUNNING_STATES.indexOf(status) !== -1 && leaseExpired(rec));
+      if (!reclaimable) {
+        // TIMEOUT-AFTER-COMMIT IDEMPOTENCY: a claim that COMMITTED whose
+        // response was lost is retried by the SAME worker — the row is now
+        // claimed by THIS workerId with a live lease, which is not
+        // reclaimable, so a plain refusal would make the retry abandon a row
+        // it actually holds (claimed-but-orphaned until lease expiry). Answer
+        // the truth instead: the caller holds it. claimed:true so the client
+        // treats it as a win; alreadyHeld marks the re-claim (informational —
+        // the existing lease/expiry is RETAINED, not extended; the holder's
+        // heartbeat renews it on its normal cadence).
+        if (
+          RUNNING_STATES.indexOf(status) !== -1 &&
+          rec.get("claimed_by") === workerId &&
+          !leaseExpired(rec)
+        ) {
+          claimed = true;
+          alreadyHeld = true;
+          view = jobView(rec);
+        }
+        return;
+      }
 
-  return c.json(
-    200,
-    released
-      ? { released: true, job: view }
-      : { released: false, reason: reason },
-  );
-}, $apis.requireAdminAuth());
+      rec.set("status", "claimed");
+      rec.set("claimed_by", workerId);
+      rec.set("lease_expires_at", leaseExpiryIso(leaseSeconds));
+      rec.set("version", (rec.get("version") || 0) + 1);
+      txDao.saveRecord(rec);
+      claimed = true;
+      view = jobView(rec);
+    });
+
+    // No object-spread (goja compat caution): build the body imperatively.
+    const body = claimed ? { claimed: true, job: view } : { claimed: false };
+    if (alreadyHeld) body.alreadyHeld = true;
+    return c.json(200, body);
+  },
+  $apis.requireAdminAuth(),
+);
+
+routerAdd(
+  "POST",
+  "/api/fleet/renew",
+  (c) => {
+    const RUNNING_STATES = ["claimed", "running"];
+    // CLAMP leaseSeconds: the body is caller-supplied JSON, so a non-numeric /
+    // non-positive value (string, null, NaN) falls to the 30s default, and a
+    // huge value is capped at 3600s (1h) so a malformed caller can never wedge
+    // a row behind a multi-day lease the sweeper would wait out. NaN > 0 is
+    // false, so garbage routes to the default without an isFinite dependency.
+    // FLOOR at 1s too: n > 0 admits e.g. 0.001 — a 1ms lease that is expired
+    // before the response lands, making every claim instantly stealable and
+    // every renew a thrash loop.
+    const leaseExpiryIso = (leaseSeconds) => {
+      const n = typeof leaseSeconds === "number" ? leaseSeconds : NaN;
+      const secs = n > 0 ? Math.max(1, Math.min(n, 3600)) : 30;
+      return new Date(Date.now() + secs * 1000).toISOString();
+    };
+    const leaseExpired = (rec) => {
+      const raw = rec.get("lease_expires_at");
+      if (!raw) return true;
+      // PB stores dates as "2006-01-02 15:04:05.000Z" (space separator).
+      // goja's Date.parse is strict and returns NaN for the space form
+      // (unlike V8/Node, which accept it) — so normalize the space to the
+      // ISO "T" separator before parsing. Without this every lease parses
+      // to NaN and is wrongly treated as expired, letting any caller steal
+      // a live claim. (Verified against PB 0.22.21 / goja.)
+      //
+      // ANCHOR the replacement to the date/time boundary
+      // ("YYYY-MM-DD ") so we ONLY rewrite the canonical PB shape. A bare
+      // String.replace(" ", "T") rewrites the FIRST space anywhere, which
+      // would coerce a malformed/non-standard value into something that
+      // parses, silently treating a LIVE claim as expired and defeating the
+      // exactly-one-winner CAS. An odd shape must fall through to NaN →
+      // expired-by-policy is intentional (never wedge the queue), but only
+      // because the value genuinely failed to parse, not because we mangled
+      // it into a parseable one.
+      const t = Date.parse(String(raw).replace(/^(\d{4}-\d{2}-\d{2}) /, "$1T"));
+      if (isNaN(t)) return true;
+      return t <= Date.now();
+    };
+    const jobView = (rec) => ({
+      id: rec.id,
+      probe_key: rec.get("probe_key"),
+      status: rec.get("status"),
+      claimed_by: rec.get("claimed_by"),
+      lease_expires_at: rec.get("lease_expires_at"),
+      version: rec.get("version"),
+    });
+
+    const data = $apis.requestInfo(c).data || {};
+    const jobId = data.jobId;
+    const workerId = data.workerId;
+    const leaseSeconds = data.leaseSeconds;
+    if (!jobId || !workerId) {
+      return c.json(400, { error: "jobId and workerId are required" });
+    }
+    // A non-string workerId (a JSON number) would COERCE into the text
+    // claimed_by column on write — but the holder renews/releases with the
+    // string form, so `claimed_by !== workerId` never matches again and the
+    // row wedges until lease expiry. Reject the type up front.
+    if (typeof workerId !== "string") {
+      return c.json(400, { error: "workerId must be a string" });
+    }
+    // Same class for jobId (consistency with the workerId guard): `!jobId`
+    // admits a truthy non-string (a JSON number/object) that would otherwise
+    // ride into findRecordById on the dao's coercion behavior. 400 up front.
+    if (typeof jobId !== "string") {
+      return c.json(400, { error: "jobId must be a string" });
+    }
+
+    let renewed = false;
+    let view = null;
+    $app.dao().runInTransaction((txDao) => {
+      let rec;
+      try {
+        rec = txDao.findRecordById("probe_jobs", jobId);
+      } catch (e) {
+        return;
+      }
+      const status = rec.get("status");
+      // Only the current lease holder may renew, and only while the row is
+      // still in a running state and the lease has NOT yet expired. If the
+      // lease already expired the holder lost it (another worker may have
+      // stolen it) — renew must fail so the original worker stops.
+      if (RUNNING_STATES.indexOf(status) === -1) return;
+      if (rec.get("claimed_by") !== workerId) return;
+      if (leaseExpired(rec)) return;
+
+      // Promote claimed → running on first renew so the lifecycle is visible.
+      rec.set("status", "running");
+      rec.set("lease_expires_at", leaseExpiryIso(leaseSeconds));
+      rec.set("version", (rec.get("version") || 0) + 1);
+      txDao.saveRecord(rec);
+      renewed = true;
+      view = jobView(rec);
+    });
+
+    return c.json(
+      200,
+      renewed ? { renewed: true, job: view } : { renewed: false },
+    );
+  },
+  $apis.requireAdminAuth(),
+);
+
+routerAdd(
+  "POST",
+  "/api/fleet/release",
+  (c) => {
+    const RUNNING_STATES = ["claimed", "running"];
+    // A claimed/running row's lease is elapsed once its expiry timestamp has
+    // passed. Empty / unparseable lease is treated as expired (mirrors claim +
+    // renew). Defined INSIDE the handler closure — PB 0.22's pooled goja runtime
+    // does NOT see module-top-level declarations from a handler (the
+    // "X is not defined" gotcha documented at the top of this file).
+    const leaseExpired = (rec) => {
+      const raw = rec.get("lease_expires_at");
+      if (!raw) return true;
+      // PB stores dates as "2006-01-02 15:04:05.000Z" (space separator). goja's
+      // Date.parse is strict and returns NaN for the space form, so normalize the
+      // space to the ISO "T" separator before parsing — ANCHORED to the date/time
+      // boundary so we only rewrite the canonical PB shape (a bare replace would
+      // coerce a malformed value into something parseable, defeating the CAS).
+      const t = Date.parse(String(raw).replace(/^(\d{4}-\d{2}-\d{2}) /, "$1T"));
+      if (isNaN(t)) return true;
+      return t <= Date.now();
+    };
+    const jobView = (rec) => ({
+      id: rec.id,
+      probe_key: rec.get("probe_key"),
+      status: rec.get("status"),
+      claimed_by: rec.get("claimed_by"),
+      lease_expires_at: rec.get("lease_expires_at"),
+      version: rec.get("version"),
+    });
+
+    const data = $apis.requestInfo(c).data || {};
+    const jobId = data.jobId;
+    const workerId = data.workerId;
+    // status is REQUIRED — the old `|| "done"` fallback silently FINISHED a
+    // job whose caller omitted (or sent an empty) status, masking a protocol
+    // bug as success. Validate it exactly like jobId/workerId.
+    const target = data.status;
+    if (!jobId || !workerId) {
+      return c.json(400, { error: "jobId and workerId are required" });
+    }
+    // A non-string workerId (a JSON number) would COERCE into the text
+    // claimed_by column on write — but the holder renews/releases with the
+    // string form, so `claimed_by !== workerId` never matches again and the
+    // row wedges until lease expiry. Reject the type up front.
+    if (typeof workerId !== "string") {
+      return c.json(400, { error: "workerId must be a string" });
+    }
+    // Same class for jobId (consistency with the workerId guard): `!jobId`
+    // admits a truthy non-string (a JSON number/object) that would otherwise
+    // ride into findRecordById on the dao's coercion behavior. 400 up front.
+    if (typeof jobId !== "string") {
+      return c.json(400, { error: "jobId must be a string" });
+    }
+    if (!target) {
+      return c.json(400, {
+        error: "status is required (done|failed|pending)",
+      });
+    }
+    if (["done", "failed", "pending"].indexOf(target) === -1) {
+      return c.json(400, { error: "status must be done|failed|pending" });
+    }
+
+    let released = false;
+    let view = null;
+    // REFUSAL REASON (threaded to the client on released:false). The caller's
+    // retry truthfulness depends on one distinction: a row that is TERMINAL
+    // UNDER THE CALLER'S OWN workerId can only mean the caller's earlier
+    // release COMMITTED and the response was lost (timeout-after-commit) — a
+    // terminal release retains claimed_by, and no other worker can set it.
+    // The client (queue-client report()) uses that to proceed to its result
+    // write instead of falsely declaring the result discarded.
+    //   refused_terminal_same_holder — row done|failed with claimed_by ===
+    //     workerId (the caller's own committed release; result still writable)
+    //   refused_lease_live           — pending-target (sweeper) release on a
+    //     still-live lease (the TOCTOU close below; holder is alive)
+    //   refused_not_holder           — everything else (unknown row, another
+    //     holder, or a terminal-target release on an already-expired lease —
+    //     the caller is no longer the EFFECTIVE holder)
+    let reason = null;
+    $app.dao().runInTransaction((txDao) => {
+      let rec;
+      try {
+        rec = txDao.findRecordById("probe_jobs", jobId);
+      } catch (e) {
+        reason = "refused_not_holder";
+        return;
+      }
+      // Only the current lease holder may release, and only while the row is in a
+      // running state.
+      const status = rec.get("status");
+      if (RUNNING_STATES.indexOf(status) === -1) {
+        reason =
+          (status === "done" || status === "failed") &&
+          rec.get("claimed_by") === workerId
+            ? "refused_terminal_same_holder"
+            : "refused_not_holder";
+        return;
+      }
+      if (rec.get("claimed_by") !== workerId) {
+        reason = "refused_not_holder";
+        return;
+      }
+      // The lease-expiry gate applies ONLY to TERMINAL targets (done|failed). If
+      // the lease already expired the holder LOST it (the sweeper may have
+      // re-queued it, or another worker may have stolen the claim) — letting a
+      // stale worker clobber terminal state would violate the exactly-one-winner
+      // invariant. Mirror renew's holder-lost-it semantics: reject the terminal
+      // release so the stale worker stops. (`claimed_by` unchanged is NOT
+      // sufficient — a stolen-then-released race can transiently match; the lease
+      // check is the authoritative gate for terminal writes.)
+      //
+      // But target === "pending" is the SWEEPER's re-queue (queue-client
+      // sweepExpired calls releaseJob(jobId, claimed_by, "pending") on EXPIRED
+      // rows on behalf of a crashed worker). That path operates on expired leases
+      // BY DESIGN, so it must be allowed to proceed even when leaseExpired is
+      // true — gating it here makes REQ-B crash reclamation inert (the sweeper
+      // reclaims 0, no worker-reclaimed-pending comm error is ever synthesized). The
+      // claimed_by match above still authorizes it, and re-queue to pending is
+      // always safe: it just resets the row to claimable.
+      if (target !== "pending" && leaseExpired(rec)) {
+        // Expired lease on a terminal-target release: the caller is no longer
+        // the EFFECTIVE holder (the claim is stealable/swept), so this is the
+        // not-holder class, not the committed-terminal class.
+        reason = "refused_not_holder";
+        return;
+      }
+      // TOCTOU close (the sweepers' list→release race): a "pending" release is
+      // a SWEEPER re-queueing an EXPIRED lease on behalf of its lapsed holder —
+      // but the sweeper decided "expired" from a LISTED SNAPSHOT. If the holder
+      // RENEWED between that list and this release, `claimed_by` still matches
+      // and an unguarded release would yank a LIVE, just-renewed job back to
+      // pending (duplicate execution + a false worker-reclaimed-pending comm
+      // error on the dashboard). Re-check expiry HERE, at release time, inside
+      // the same transaction: a still-live lease means the holder is alive —
+      // refuse, and the sweeper's released:false path skips the row (it retries
+      // on a later sweep once the lease has truly lapsed). This also guards
+      // fleet-health's reclaim of a heartbeat-stale worker whose job loop is
+      // still renewing: a renewing worker is alive, so refusal is correct
+      // there too. leaseExpired stays byte-equivalent to the client's anchored
+      // parse, so both sides agree on what "expired" means.
+      if (target === "pending" && !leaseExpired(rec)) {
+        reason = "refused_lease_live";
+        return;
+      }
+
+      rec.set("status", target);
+      if (target === "pending") {
+        // Re-queue: drop ownership so it's claimable again. The (expired)
+        // lease_expires_at is RETAINED — claim admits pending rows regardless
+        // of lease, and the stale value now serves as the row's
+        // "last in flight" marker: the queue-client's stale-pending sweep
+        // skips re-queued rows whose lease is recent, so a long-running job
+        // that out-lived its family's expiry window gets an actual re-run
+        // instead of being claim-deleted off its original `created` age.
+        rec.set("claimed_by", "");
+      }
+      rec.set("version", (rec.get("version") || 0) + 1);
+      txDao.saveRecord(rec);
+      released = true;
+      view = jobView(rec);
+    });
+
+    return c.json(
+      200,
+      released
+        ? { released: true, job: view }
+        : { released: false, reason: reason },
+    );
+  },
+  $apis.requireAdminAuth(),
+);

--- a/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.lazy-signal.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.lazy-signal.test.tsx
@@ -345,7 +345,10 @@ describe("CellDrilldown — lazy signal fetch (real PocketBase SDK)", () => {
     );
 
     const healthBadge = getByTestId("drilldown-badge-health");
-    const e2eBadge = getByTestId("drilldown-badge-rt--round-trip-");
+    // The e2e row's label-derived testid: `RT (Round Trip)` now belongs to
+    // the D4 row (whose fixtures here have no chat/tools data), so the e2e
+    // row must be selected via its de-crossed `E2E (Demo)` label.
+    const e2eBadge = getByTestId("drilldown-badge-e2e--demo-");
 
     // The e2e badge's signal arrived → it renders its field and shows NO error.
     await waitFor(
@@ -423,7 +426,8 @@ describe("CellDrilldown — lazy signal fetch (real PocketBase SDK)", () => {
       />,
     );
 
-    const e2eBadge = getByTestId("drilldown-badge-rt--round-trip-");
+    // e2e row selected via its de-crossed `E2E (Demo)` label — see above.
+    const e2eBadge = getByTestId("drilldown-badge-e2e--demo-");
     await waitFor(
       () => expect(within(e2eBadge).getByTestId("signal-error")).toBeDefined(),
       { timeout: 5000 },

--- a/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
@@ -2,9 +2,20 @@
  * Unit tests for CellDrilldown — per-cell dimension detail panel.
  */
 import { describe, it, expect } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, within } from "@testing-library/react";
 import { CellDrilldown } from "../cell-drilldown";
+import { buildCellModel } from "@/lib/cell-model";
 import type { LiveStatusMap, StatusRow } from "@/lib/live-status";
+
+// The `row()` helper's hardcoded 2026-04-20 timestamps are STALE against the
+// health (45m) / e2e (6h) / d4 (1h) windows, and CellDrilldown calls
+// resolveCell with NO `now` (real Date.now() applies). Tests that need rows
+// to resolve FRESH must override observed_at/transitioned_at with this.
+const FRESH_OBSERVED_AT = new Date().toISOString();
+const FRESH = {
+  observed_at: FRESH_OBSERVED_AT,
+  transitioned_at: FRESH_OBSERVED_AT,
+} as const;
 
 function row(
   key: string,
@@ -33,12 +44,14 @@ function mapOf(rows: StatusRow[]): LiveStatusMap {
 }
 
 describe("CellDrilldown", () => {
-  it("renders all 5 badge dimensions", () => {
+  it("renders all 7 badge dimensions", () => {
     const live = mapOf([
-      row("health:lgp", "health", "green"),
-      row("e2e:lgp/agentic-chat", "e2e", "green"),
-      row("smoke:lgp", "smoke", "green"),
-      row("agent:lgp", "agent", "green"),
+      row("health:lgp", "health", "green", { ...FRESH }),
+      row("e2e:lgp/agentic-chat", "e2e", "green", { ...FRESH }),
+      row("smoke:lgp", "smoke", "green", { ...FRESH }),
+      row("agent:lgp", "agent", "green", { ...FRESH }),
+      row("chat:lgp", "chat", "green", { ...FRESH }),
+      row("tools:lgp", "tools", "green", { ...FRESH }),
     ]);
     const { getByTestId, getByText } = render(
       <CellDrilldown
@@ -51,11 +64,136 @@ describe("CellDrilldown", () => {
       />,
     );
     expect(getByTestId("cell-drilldown")).toBeDefined();
+    expect(getByText("Parity (Reference)")).toBeDefined();
+    expect(getByText("CV (Conversation)")).toBeDefined();
+    // `RT (Round Trip)` is now the D4 (chat+tools round-trip) row …
+    expect(getByText("RT (Round Trip)")).toBeDefined();
+    // … and the e2e row carries the de-crossed `E2E (Demo)` label.
+    expect(getByText("E2E (Demo)")).toBeDefined();
     expect(getByText("API (Agent)")).toBeDefined();
     expect(getByText("Health")).toBeDefined();
-    expect(getByText("RT (Round Trip)")).toBeDefined();
     expect(getByText("Smoke")).toBeDefined();
-    expect(getByText("CV (Conversation)")).toBeDefined();
+  });
+
+  it("renders a red RT (Round Trip) row for a red D4 fold while the service line stays green (headline drilldown-parity bug)", () => {
+    // The dimension that turns the pill red (D4: red tools round-trip) must
+    // be VISIBLE in the popup. Pre-fix the popup had no D4 row at all, so a
+    // pill-red cell showed nothing non-green to explain itself.
+    const live = mapOf([
+      row("health:lgp", "health", "green", { ...FRESH }),
+      row("e2e:lgp/agentic-chat", "e2e", "green", { ...FRESH }),
+      row("chat:lgp", "chat", "green", { ...FRESH }),
+      row("tools:lgp", "tools", "red", { ...FRESH }),
+    ]);
+    const { getByTestId, getByText } = render(
+      <CellDrilldown
+        slug="lgp"
+        featureId="agentic-chat"
+        integrationName="LangGraph Python"
+        featureName="Agentic Chat"
+        liveStatus={live}
+        onClose={() => {}}
+      />,
+    );
+    // The d4 row owns the `RT (Round Trip)` label (and so its derived testid).
+    const rtBadge = getByTestId("drilldown-badge-rt--round-trip-");
+    expect(rtBadge.textContent).toContain("RT (Round Trip)");
+    expect(rtBadge.textContent).toContain("✗");
+    // The service-scoped line (health + e2e) is still green — honest scope.
+    expect(getByText("green")).toBeDefined();
+    // Cross-resolver pin: the SAME map makes the pill red via buildCellModel's
+    // D1-D4 gate — so a pill-red cause now always has a visible non-green row.
+    expect(
+      buildCellModel(live, {
+        slug: "lgp",
+        featureId: "agentic-chat",
+        isSupported: true,
+        isWired: true,
+      }).chipColor,
+    ).toBe("red");
+  });
+
+  it("renders strikethrough n/a on the RT (Round Trip) row when chat/tools rows are absent", () => {
+    const live = mapOf([
+      row("health:lgp", "health", "green", { ...FRESH }),
+      row("e2e:lgp/agentic-chat", "e2e", "green", { ...FRESH }),
+    ]);
+    const { getByTestId } = render(
+      <CellDrilldown
+        slug="lgp"
+        featureId="agentic-chat"
+        integrationName="LangGraph Python"
+        featureName="Agentic Chat"
+        liveStatus={live}
+        onClose={() => {}}
+      />,
+    );
+    const rtBadge = getByTestId("drilldown-badge-rt--round-trip-");
+    expect(rtBadge.textContent).toContain("RT (Round Trip)");
+    expect(rtBadge.textContent).toContain("n/a");
+    expect(rtBadge.querySelector(".line-through")).not.toBeNull();
+  });
+
+  it("labels the rollup line with its honest scope — Service (health + e2e), not Rollup", () => {
+    const { getByText, queryByText } = render(
+      <CellDrilldown
+        slug="lgp"
+        featureId="agentic-chat"
+        integrationName="LangGraph Python"
+        featureName="Agentic Chat"
+        liveStatus={new Map()}
+        onClose={() => {}}
+      />,
+    );
+    expect(getByText("Service (health + e2e)")).toBeDefined();
+    expect(queryByText("Rollup")).toBeNull();
+  });
+
+  it("de-crosses the e2e label: E2E (Demo) renders and exactly ONE row is labelled RT (Round Trip)", () => {
+    const live = mapOf([
+      row("e2e:lgp/agentic-chat", "e2e", "green", { ...FRESH }),
+      row("chat:lgp", "chat", "green", { ...FRESH }),
+      row("tools:lgp", "tools", "green", { ...FRESH }),
+    ]);
+    const { getByText, getAllByText } = render(
+      <CellDrilldown
+        slug="lgp"
+        featureId="agentic-chat"
+        integrationName="LangGraph Python"
+        featureName="Agentic Chat"
+        liveStatus={live}
+        onClose={() => {}}
+      />,
+    );
+    expect(getByText("E2E (Demo)")).toBeDefined();
+    expect(getAllByText("RT (Round Trip)").length).toBe(1);
+  });
+
+  it("shows fail count and extracted Error field on a red RT (Round Trip) / D4 row", () => {
+    const live = mapOf([
+      row("chat:lgp", "chat", "green", { ...FRESH }),
+      row("tools:lgp", "tools", "red", {
+        ...FRESH,
+        fail_count: 3,
+        first_failure_at: "2026-04-19T10:00:00Z",
+        signal: { error: "boom" },
+      }),
+    ]);
+    const { getByTestId } = render(
+      <CellDrilldown
+        slug="lgp"
+        featureId="agentic-chat"
+        integrationName="LangGraph Python"
+        featureName="Agentic Chat"
+        liveStatus={live}
+        onClose={() => {}}
+      />,
+    );
+    const rtBadge = getByTestId("drilldown-badge-rt--round-trip-");
+    expect(within(rtBadge).getByTestId("fail-count").textContent).toBe("3");
+    expect(within(rtBadge).getByTestId("signal-field-error").textContent).toBe(
+      "boom",
+    );
   });
 
   it("shows integration and feature name in header", () => {
@@ -178,9 +316,11 @@ describe("CellDrilldown", () => {
   });
 
   it("does not show failure details for green badges", () => {
+    // FRESH is required: without it these rows resolve amber-stale (see header
+    // invariant) and the "green badges" premise silently breaks.
     const live = mapOf([
-      row("health:lgp", "health", "green"),
-      row("e2e:lgp/agentic-chat", "e2e", "green"),
+      row("health:lgp", "health", "green", { ...FRESH }),
+      row("e2e:lgp/agentic-chat", "e2e", "green", { ...FRESH }),
     ]);
     const { queryAllByTestId } = render(
       <CellDrilldown

--- a/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
@@ -203,13 +203,13 @@ const CHIP_CLASS: Record<ChipColor, string> = {
 //     asserted as the RENDERED badge tone class + glyph.
 // ===========================================================================
 
-describe("(1) per-depth badge rendering — API/RT/CV/D6", () => {
+describe("(1) per-depth badge rendering — E2E/RT/CV/D6", () => {
   // agentic-chat is 1:1 mapped (CATALOG_TO_D5_KEY["agentic-chat"] =
   // ["agentic-chat"]) so each depth is a single key, isolating one badge.
   const FEATURE = "agentic-chat";
 
   interface DepthCase {
-    badge: "API" | "RT" | "CV" | "D6";
+    badge: "E2E" | "RT" | "CV" | "D6";
     /** rows that set THIS depth's state; gate rows added automatically. */
     rows: StatusRow[];
     expectStatus: TestStatus;
@@ -218,14 +218,15 @@ describe("(1) per-depth badge rendering — API/RT/CV/D6", () => {
   // Each case sets the named depth's underlying row(s); for the chip to even
   // reach a given depth the lower rungs must be green, so we layer rows.
   const cases: DepthCase[] = [
-    // API (d3) — single e2e key
+    // E2E (d3) — single e2e key (legend-correct: D3 is the demo round-trip,
+    // formerly mislabelled "API" which is the D2 badge's name)
     {
-      badge: "API",
+      badge: "E2E",
       rows: [row(keyFor("e2e", SLUG, FEATURE), "e2e", "green")],
       expectStatus: "green",
     },
     {
-      badge: "API",
+      badge: "E2E",
       rows: [row(keyFor("e2e", SLUG, FEATURE), "e2e", "red")],
       expectStatus: "red",
     },
@@ -288,7 +289,7 @@ describe("(1) per-depth badge rendering — API/RT/CV/D6", () => {
     it(`${c.badge} ${c.expectStatus} → tone ${BADGE_RENDER[c.expectStatus ?? "null"].tone}, glyph ${BADGE_RENDER[c.expectStatus ?? "null"].glyph}`, () => {
       const live = mapOf(c.rows);
       const { container } = renderCell(live, FEATURE, ["health"]);
-      // Find the badge by its leading label text (API/RT/CV/D6).
+      // Find the badge by its leading label text (E2E/RT/CV/D6).
       const labels = Array.from(container.querySelectorAll("span")).filter(
         (s) => s.textContent === c.badge,
       );

--- a/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
@@ -207,9 +207,9 @@ describe("Overlay selector integration — real UI components", () => {
     expect(queryByTestId("depth-chip")).not.toBeInTheDocument();
     expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
 
-    // No health badges (API, RT, CV)
+    // No health badges (API, E2E, CV)
     expect(queryByText("API")).not.toBeInTheDocument();
-    expect(queryByText("RT")).not.toBeInTheDocument();
+    expect(queryByText("E2E")).not.toBeInTheDocument();
     expect(queryByText("CV")).not.toBeInTheDocument();
 
     // No docs indicators
@@ -240,7 +240,7 @@ describe("Overlay selector integration — real UI components", () => {
     expect(queryByText("</>")).not.toBeInTheDocument();
 
     // No health badges
-    expect(queryByText("RT")).not.toBeInTheDocument();
+    expect(queryByText("E2E")).not.toBeInTheDocument();
 
     // No docs indicators
     expect(queryByText("docs-og")).not.toBeInTheDocument();
@@ -250,7 +250,7 @@ describe("Overlay selector integration — real UI components", () => {
   // -------------------------------------------------------------------------
   // 3. Health only — the critical case (no docs indicators must appear)
   // -------------------------------------------------------------------------
-  it("health only: API/RT/CV badges visible, NO docs indicators", () => {
+  it("health only: API/E2E/CV badges visible, NO docs indicators", () => {
     // `agentic-chat` is a real CATALOG_TO_D5_KEY entry, so its d5 row resolves
     // green and the CV badge renders. An UNMAPPED feature's CV badge is gray
     // "?" and hidden by design (resolveD5Row returns null for unmapped
@@ -273,7 +273,7 @@ describe("Overlay selector integration — real UI components", () => {
     // Health layer present with real badges
     expect(getByTestId("health-layer")).toBeInTheDocument();
     expect(getByText("API")).toBeInTheDocument();
-    expect(getByText("RT")).toBeInTheDocument();
+    expect(getByText("E2E")).toBeInTheDocument();
     expect(getByText("CV")).toBeInTheDocument();
 
     // No docs indicators — this is the critical regression test for B2's fix
@@ -307,7 +307,7 @@ describe("Overlay selector integration — real UI components", () => {
     expect(queryByText("Demo")).not.toBeInTheDocument();
 
     // No health badges
-    expect(queryByText("RT")).not.toBeInTheDocument();
+    expect(queryByText("E2E")).not.toBeInTheDocument();
 
     // No depth chip
     expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
@@ -329,7 +329,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Nothing visible
     expect(queryByText("Demo")).not.toBeInTheDocument();
-    expect(queryByText("RT")).not.toBeInTheDocument();
+    expect(queryByText("E2E")).not.toBeInTheDocument();
     expect(queryByText("docs-og")).not.toBeInTheDocument();
     expect(queryByTestId("depth-chip")).not.toBeInTheDocument();
   });
@@ -359,7 +359,7 @@ describe("Overlay selector integration — real UI components", () => {
     // Health layer
     expect(getByTestId("health-layer")).toBeInTheDocument();
     expect(getByText("API")).toBeInTheDocument();
-    expect(getByText("RT")).toBeInTheDocument();
+    expect(getByText("E2E")).toBeInTheDocument();
     expect(getByText("CV")).toBeInTheDocument();
 
     // Docs layer
@@ -400,7 +400,7 @@ describe("Overlay selector integration — real UI components", () => {
     expect(getByTestId("depth-layer")).toBeInTheDocument();
     expect(getByTestId("depth-chip")).toBeInTheDocument();
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("RT")).toBeInTheDocument();
+    expect(getByText("E2E")).toBeInTheDocument();
     expect(getByTestId("docs-layer")).toBeInTheDocument();
     expect(getByText("docs-og")).toBeInTheDocument();
     expect(getByText("docs-shell")).toBeInTheDocument();
@@ -416,8 +416,8 @@ describe("Overlay selector integration — real UI components", () => {
     expect(
       children[1]?.querySelector("[data-testid='depth-chip']"),
     ).toBeTruthy();
-    // Third child: health (contains RT badge)
-    expect(children[2]?.textContent).toContain("RT");
+    // Third child: health (contains the E2E badge)
+    expect(children[2]?.textContent).toContain("E2E");
     // Fourth child: docs (contains docs-og)
     expect(children[3]?.textContent).toContain("docs-og");
   });
@@ -433,7 +433,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health badges present
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("RT")).toBeInTheDocument();
+    expect(getByText("E2E")).toBeInTheDocument();
 
     // Docs explicitly absent — this is the bug B2 fixed: CellStatus used to
     // render DocsRow, so "health only" would still show docs indicators.
@@ -457,7 +457,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // API and RT badges still visible for testing-kind
     expect(getByText("API")).toBeInTheDocument();
-    expect(getByText("RT")).toBeInTheDocument();
+    expect(getByText("E2E")).toBeInTheDocument();
 
     // CV hidden for testing-kind features (CellStatus hides them)
     expect(queryByText("CV")).not.toBeInTheDocument();
@@ -497,7 +497,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health badges
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("RT")).toBeInTheDocument();
+    expect(getByText("E2E")).toBeInTheDocument();
 
     // Docs indicators
     expect(getByTestId("docs-layer")).toBeInTheDocument();
@@ -529,7 +529,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health badges
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("RT")).toBeInTheDocument();
+    expect(getByText("E2E")).toBeInTheDocument();
 
     // No docs — critical: Assessment does NOT include docs
     expect(queryByText("docs-og")).not.toBeInTheDocument();
@@ -580,12 +580,12 @@ describe("Overlay selector integration — real UI components", () => {
       <ComposedCell ctx={ctx} overlays={overlaySet("health")} />,
     );
 
-    // With green live status rows, RT badge should show the green check
-    const rtBadge = getByText("RT");
-    expect(rtBadge).toBeInTheDocument();
+    // With green live status rows, the E2E badge should show the green check
+    const e2eBadge = getByText("E2E");
+    expect(e2eBadge).toBeInTheDocument();
     // The badge label "✓" (green state) should appear as a sibling span
-    const rtContainer = rtBadge.closest("[class*='whitespace-nowrap']");
-    expect(rtContainer?.textContent).toContain("✓");
+    const e2eContainer = e2eBadge.closest("[class*='whitespace-nowrap']");
+    expect(e2eContainer?.textContent).toContain("✓");
   });
 
   // -------------------------------------------------------------------------

--- a/showcase/shell-dashboard/src/components/__tests__/unified-cell.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/unified-cell.test.tsx
@@ -224,7 +224,7 @@ describe("UnifiedCell", () => {
       expect(queryByTestId("mock-depth-chip")).not.toBeInTheDocument();
 
       // No badges rendered
-      expect(queryByTestId("mock-badge-API")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-E2E")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-RT")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
 
@@ -298,7 +298,7 @@ describe("UnifiedCell", () => {
 
   // ── Test 3: Only shows badges for test levels that exist ──────────
   describe("badge existence filtering", () => {
-    it("shows API badge when D3 exists but hides RT badge when D4 is missing", () => {
+    it("shows E2E badge when D3 exists but hides RT badge when D4 is missing", () => {
       const ctx = makeCtx();
       const model = makeModel({
         d3: makeLevel(true, "green"),
@@ -309,8 +309,8 @@ describe("UnifiedCell", () => {
         <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("health")} />,
       );
 
-      // API badge present (D3 exists)
-      expect(getByTestId("mock-badge-API")).toBeInTheDocument();
+      // E2E badge present (D3 exists)
+      expect(getByTestId("mock-badge-E2E")).toBeInTheDocument();
       // RT badge absent (D4 does not exist)
       expect(queryByTestId("mock-badge-RT")).not.toBeInTheDocument();
       // CV badge present (D5 exists)
@@ -328,7 +328,7 @@ describe("UnifiedCell", () => {
         <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("health")} />,
       );
 
-      expect(queryByTestId("mock-badge-API")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-E2E")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-RT")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
     });
@@ -344,7 +344,7 @@ describe("UnifiedCell", () => {
         <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("health")} />,
       );
 
-      expect(queryByTestId("mock-badge-API")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-E2E")).not.toBeInTheDocument();
       expect(getByTestId("mock-badge-RT")).toBeInTheDocument();
       expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
     });
@@ -352,7 +352,7 @@ describe("UnifiedCell", () => {
 
   // ── Test 4: Shows all three badges when all levels exist ──────────
   describe("all badges visible", () => {
-    it("shows API, RT, and CV badges when all three levels exist", () => {
+    it("shows E2E, RT, and CV badges when all three levels exist", () => {
       const ctx = makeCtx();
       const model = makeModel({
         d3: makeLevel(true, "green"),
@@ -363,9 +363,9 @@ describe("UnifiedCell", () => {
         <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("health")} />,
       );
 
-      const apiBadge = getByTestId("mock-badge-API");
-      expect(apiBadge).toBeInTheDocument();
-      expect(apiBadge.getAttribute("data-tone")).toBe("green");
+      const e2eBadge = getByTestId("mock-badge-E2E");
+      expect(e2eBadge).toBeInTheDocument();
+      expect(e2eBadge.getAttribute("data-tone")).toBe("green");
 
       const rtBadge = getByTestId("mock-badge-RT");
       expect(rtBadge).toBeInTheDocument();
@@ -391,7 +391,7 @@ describe("UnifiedCell", () => {
       );
 
       expect(queryByTestId("health-layer")).not.toBeInTheDocument();
-      expect(queryByTestId("mock-badge-API")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-E2E")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-RT")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
     });
@@ -542,7 +542,7 @@ describe("UnifiedCell", () => {
         <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("health")} />,
       );
 
-      const badge = getByTestId("mock-badge-API");
+      const badge = getByTestId("mock-badge-E2E");
       expect(badge.getAttribute("data-tone")).toBe("green");
       expect(badge.textContent).toContain("✓");
     });
@@ -559,7 +559,7 @@ describe("UnifiedCell", () => {
       );
 
       // A no-data rung emits label "?", which the real Badge hides → no badge.
-      expect(queryByTestId("mock-badge-API")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-E2E")).not.toBeInTheDocument();
     });
   });
 

--- a/showcase/shell-dashboard/src/components/adaptive-legend.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-legend.tsx
@@ -56,7 +56,7 @@ function HealthLegend() {
       </LegendItem>
       <LegendItem>
         <span className="font-semibold text-[var(--text-secondary)]">D3</span>
-        Page Load: demo page loads in a browser
+        E2E (Demo): demo page loads and round-trips in a browser
       </LegendItem>
       <LegendItem>
         <span className="font-semibold text-[var(--text-secondary)]">D4</span>
@@ -69,7 +69,7 @@ function HealthLegend() {
       </LegendItem>
       <LegendItem>
         <span className="font-semibold text-[var(--text-secondary)]">D6</span>
-        Parity (PR): full all-pills run verified against the reference
+        Parity (Reference): full all-pills run verified against the reference
         integration
       </LegendItem>
       {/* Regression indicator */}
@@ -82,7 +82,7 @@ function HealthLegend() {
         <span className="text-[var(--ok)]">D4 ✓</span>/
         <span className="text-[var(--amber)]">~</span>/
         <span className="text-[var(--danger)]">✗</span>
-        round-trip check (green &lt;6h / amber stale / red fail)
+        round-trip check (green &lt;1h / amber stale / red fail)
       </LegendItem>
       <LegendItem>
         <span className="text-[var(--ok)]">D5</span>/

--- a/showcase/shell-dashboard/src/components/cell-drilldown.tsx
+++ b/showcase/shell-dashboard/src/components/cell-drilldown.tsx
@@ -3,9 +3,10 @@
  * CellDrilldown — popover panel showing per-badge dimension detail for a
  * single (integration, feature) cell.
  *
- * Renders all badge dimensions (d6/Parity, d5/CV, e2e/RT, d2/API, health, smoke)
- * with tone, label, and — for red/amber badges — failure metadata presented as
- * readable key-value pairs with the full signal collapsible for debugging.
+ * Renders all badge dimensions (d6/Parity, d5/CV, d4/RT, e2e/E2E, d2/API,
+ * health, smoke) with tone, label, and — for red/amber badges — failure
+ * metadata presented as readable key-value pairs with the full signal
+ * collapsible for debugging.
  */
 import { useEffect, useMemo, useState } from "react";
 import { resolveCell } from "@/lib/live-status";
@@ -29,14 +30,21 @@ export interface CellDrilldownProps {
   onClose: () => void;
 }
 
-/** Dimension metadata for display ordering. */
+/**
+ * Dimension metadata for display ordering (descending depth). Labels follow
+ * the legend's canonical taxonomy (adaptive-legend.tsx): D4 = "RT (Round
+ * Trip)" (chat+tools round-trip), D3/e2e = "E2E (Demo)" (the demo page loads
+ * and round-trips in a browser). BadgeRow derives its data-testid from the
+ * label, so labels must stay unique across rows.
+ */
 const DIMENSIONS: Array<{
   key: keyof Omit<CellState, "rollup">;
   label: string;
 }> = [
   { key: "d6", label: "Parity (Reference)" },
   { key: "d5", label: "CV (Conversation)" },
-  { key: "e2e", label: "RT (Round Trip)" },
+  { key: "d4", label: "RT (Round Trip)" },
+  { key: "e2e", label: "E2E (Demo)" },
   { key: "d2", label: "API (Agent)" },
   { key: "health", label: "Health" },
   { key: "smoke", label: "Smoke" },
@@ -584,7 +592,7 @@ export function CellDrilldown({
       {/* Rollup */}
       <div className="px-4 py-2 flex items-center gap-2 border-b border-[var(--border)]">
         <span className="text-[10px] text-[var(--text-muted)] uppercase tracking-wider">
-          Rollup
+          Service (health + e2e)
         </span>
         <span
           className={`inline-block w-2 h-2 rounded-full ${DOT_BG[cell.rollup]}`}

--- a/showcase/shell-dashboard/src/components/cell-pieces.signal-degrade.test.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.signal-degrade.test.tsx
@@ -120,8 +120,10 @@ function degradedHealthRowNoSignal(): StatusRow {
 }
 
 function rtTitle(container: HTMLElement): string | null {
+  // The e2e badge — renamed from the crossed "RT" label to "E2E" (the grid's
+  // RT name now belongs to the D4 chat/tools badge in unified-cell).
   const span = Array.from(container.querySelectorAll("span[title]")).find(
-    (s) => s.querySelector("span:first-child")?.textContent?.trim() === "RT",
+    (s) => s.querySelector("span:first-child")?.textContent?.trim() === "E2E",
   );
   return span ? span.getAttribute("title") : null;
 }

--- a/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
@@ -154,7 +154,7 @@ describe("CP1: tooltipOpen resets on mouseleave/blur", () => {
       liveStatus: new Map([[redE2eRow().key, redE2eRow()]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    const rtBadge = findBadgeByName(container, "RT");
+    const rtBadge = findBadgeByName(container, "E2E");
     fireEvent.mouseEnter(rtBadge);
     // Allow microtask to flush.
     await Promise.resolve();
@@ -173,7 +173,7 @@ describe("CP1: tooltipOpen resets on mouseleave/blur", () => {
     // and gated on open, never on close).
     expect(mockState.fetchCount).toBe(countAfterEnter);
     // The badge remains in the document after the reset.
-    expect(findBadgeByName(container, "RT")).toBeInTheDocument();
+    expect(findBadgeByName(container, "E2E")).toBeInTheDocument();
   });
 });
 
@@ -193,12 +193,12 @@ describe("CP2: transitionLine discriminates first/error", () => {
       liveStatus: new Map([[redE2eRow().key, redE2eRow()]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    const rtBadge = findBadgeByName(container, "RT");
+    const rtBadge = findBadgeByName(container, "E2E");
     fireEvent.mouseEnter(rtBadge);
     // Wait for the lazy fetch + state update (waitFor, not a fixed sleep, to
     // avoid flakiness — mirrors the sibling first/error/green_to_red cases).
     await waitFor(() => {
-      const el = findBadgeByName(container, "RT");
+      const el = findBadgeByName(container, "E2E");
       expect(el.getAttribute("title")).toContain("(initial: green)");
     });
   });
@@ -218,14 +218,14 @@ describe("CP2: transitionLine discriminates first/error", () => {
       liveStatus: new Map([[redE2eRow().key, redE2eRow()]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    const rtBadge = findBadgeByName(container, "RT");
+    const rtBadge = findBadgeByName(container, "E2E");
     fireEvent.mouseEnter(rtBadge);
     await waitFor(() => {
-      const el = findBadgeByName(container, "RT");
+      const el = findBadgeByName(container, "E2E");
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(el.getAttribute("title")!).toMatch(/\(error → red\)/);
     });
-    const updated = findBadgeByName(container, "RT");
+    const updated = findBadgeByName(container, "E2E");
     expect(updated.getAttribute("title")).toContain("(error → red)");
   });
 
@@ -244,14 +244,14 @@ describe("CP2: transitionLine discriminates first/error", () => {
       liveStatus: new Map([[redE2eRow().key, redE2eRow()]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    const rtBadge = findBadgeByName(container, "RT");
+    const rtBadge = findBadgeByName(container, "E2E");
     fireEvent.mouseEnter(rtBadge);
     await waitFor(() => {
-      const el = findBadgeByName(container, "RT");
+      const el = findBadgeByName(container, "E2E");
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(el.getAttribute("title")!).toMatch(/\(green → red\)/);
     });
-    const updated = findBadgeByName(container, "RT");
+    const updated = findBadgeByName(container, "E2E");
     expect(updated.getAttribute("title")).toContain("(green → red)");
   });
 });
@@ -398,7 +398,7 @@ describe("docs-only kind hides ALL badges", () => {
     const { container } = render(<CellStatus ctx={ctx} />);
     const text = container.textContent ?? "";
     expect(text).not.toContain("API");
-    expect(text).not.toContain("RT");
+    expect(text).not.toContain("E2E");
     expect(text).not.toContain("CV");
   });
 });

--- a/showcase/shell-dashboard/src/components/cell-pieces.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.tsx
@@ -305,7 +305,7 @@ function formatTransitionLine(row: {
 }
 
 /**
- * Shared status row: API / RT / CV badges (D2 API / D4 Round Trip / D5 Conversation).
+ * Shared status row: API / E2E / CV badges (D2 API / D3 E2E / D5 Conversation).
  * QA and HealthDot removed in Phase 3 (3.3 + 3.4). L1 health now in strip.
  * Smoke per-cell badge removed — integration-scoped smoke lives in the strip.
  * Docs rendering removed — handled exclusively by DocsLayer in ComposedCell,
@@ -344,7 +344,7 @@ export function CellStatus({ ctx }: { ctx: CellContext }) {
         dimensionKey={keyFor("agent", ctx.integration.slug)}
       />
       <LiveBadge
-        name="RT"
+        name="E2E"
         badge={cell.e2e}
         dimensionKey={keyFor("e2e", ctx.integration.slug, ctx.feature.id)}
       />

--- a/showcase/shell-dashboard/src/components/unified-cell.tsx
+++ b/showcase/shell-dashboard/src/components/unified-cell.tsx
@@ -225,7 +225,10 @@ function HealthLayer({ model }: { model: CellModel }) {
       data-testid="health-layer"
       className="flex items-center justify-center gap-2.5"
     >
-      <TestBadge name="API" level={model.d3} />
+      {/* Legend-correct names: D3 = E2E (demo round-trip in a browser; the
+          "API" name belongs to the D2 agent badge), D4 = RT (chat/tools
+          round-trip). */}
+      <TestBadge name="E2E" level={model.d3} />
       <TestBadge name="RT" level={model.d4} />
       <TestBadge name="CV" level={model.d5} />
       {/*

--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.test.tsx
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.test.tsx
@@ -62,6 +62,16 @@ const mockState = {
   // pages — offset pagination over a live-mutating collection drops/duplicates
   // rows without one.
   initialPageOpts: [] as { filter?: string; sort?: string }[],
+  // Rows served to the SUPPLEMENTAL comm-error aggregate fetch (CF7-F3 #1) —
+  // the narrow re-fetch of the FLEET_COMM_AGGREGATE_DIMENSIONS aggregate rows
+  // WITH `signal`. Served verbatim (full rows), the way real PB answers a
+  // request with no `fields` projection.
+  commAggregateRows: [] as Record<string, unknown>[],
+  // Supplemental comm-aggregate fetch instrumentation: call count + the last
+  // options, so tests can assert the filter shape and the skip behavior for
+  // dimension scopes outside the aggregate set.
+  commFetchCalls: 0,
+  lastCommFetchOpts: undefined as unknown,
 };
 
 // Build a PocketBase-style paged getList response over `mockState.initial`,
@@ -112,18 +122,19 @@ vi.mock("../lib/pb", () => {
       return out;
     },
     collection: (_name: string) => ({
-      // getList serves two callers, distinguished by `perPage`:
-      //   - heartbeat ping  → getList(1, 1, …)
-      //   - initial fetch   → getList(page, PB_PAGE_SIZE, …) for each page
-      // The initial fetch issues page 1 first (to read totalPages), then fans
-      // out pages 2..N concurrently. To prove the merge is order-safe, a test
-      // can set `pageResolveDelayMs` so a LATER page resolves BEFORE an earlier
-      // one — the hook must still return rows in page order.
+      // getList serves three callers:
+      //   - heartbeat ping       → getList(1, 1, …)            (perPage 1)
+      //   - supplemental comm    → filter contains `key !~`    (CF7-F3 #1)
+      //   - bulk initial fetch   → getList(page, PB_PAGE_SIZE, …) per page
+      // The bulk fetch issues page 1 first, then fans out pages 2..N
+      // concurrently. To prove the merge is order-safe, a test can set
+      // `pageResolveDelayMs` so a LATER page resolves BEFORE an earlier one —
+      // the hook must still return rows in page order.
       getList: vi.fn(
         async (
           page: number,
           perPage: number,
-          opts?: { filter?: string; sort?: string },
+          opts?: { filter?: string; sort?: string; fields?: string },
         ) => {
           // Heartbeat ping: perPage 1. Keep its 1-row contract + fail hook.
           if (perPage === 1) {
@@ -133,6 +144,27 @@ vi.mock("../lib/pb", () => {
               throw new Error("heartbeat-fail");
             }
             return pageResponse(1, 1);
+          }
+          // Supplemental comm-error aggregate fetch (CF7-F3 #1), identified
+          // by its aggregate-key filter marker (`key !~` — aggregate rows
+          // carry no `/<featureId>` segment). Served from a dedicated fixture
+          // VERBATIM (full rows, signal included — no `fields` projection is
+          // sent) and deliberately NOT recorded into the bulk-fetch
+          // instrumentation (initialPageRequestOrder / initialPageOpts /
+          // lastInitialGetListOpts) so the fan-out order/count assertions
+          // keep targeting the bulk fetch alone.
+          if (
+            typeof opts?.filter === "string" &&
+            opts.filter.includes("key !~")
+          ) {
+            mockState.getListCalls += 1;
+            mockState.commFetchCalls += 1;
+            mockState.lastCommFetchOpts = opts;
+            return {
+              items: page === 1 ? mockState.commAggregateRows : [],
+              page,
+              perPage,
+            };
           }
           // Initial paged fetch.
           mockState.getListCalls += 1;
@@ -150,7 +182,27 @@ vi.mock("../lib/pb", () => {
           // Apply the requested `sort` server-side (see pageResponse) so the
           // forwarded-sort contract is exercised behaviorally, not just by
           // inspecting the captured option string.
-          return pageResponse(page, perPage, opts?.sort);
+          const resp = pageResponse(page, perPage, opts?.sort);
+          // Honour the `fields` projection like real PB: the hook's bulk
+          // initial fetch projects `signal` away (STATUS_LIST_FIELDS), so the
+          // rows it receives must NOT carry `signal` — the old mock returned
+          // full rows here, which is exactly how the CF7-F3 #1 cold-fetch
+          // overlay bug stayed invisible to this suite.
+          const fields = opts?.fields;
+          if (
+            typeof fields === "string" &&
+            fields.length > 0 &&
+            !fields.split(",").includes("signal")
+          ) {
+            return {
+              ...resp,
+              items: resp.items.map(
+                ({ signal: _signal, ...rest }) =>
+                  rest as Record<string, unknown>,
+              ),
+            };
+          }
+          return resp;
         },
       ),
       subscribe: vi.fn(async (_topic: string, cb: Listener, opts?: unknown) => {
@@ -175,6 +227,8 @@ vi.mock("../lib/pb", () => {
 });
 
 import { useLiveStatus } from "./useLiveStatus";
+import { buildCellModel } from "../lib/cell-model";
+import { mergeRowsToMap } from "../lib/live-status";
 
 describe("useLiveStatus", () => {
   beforeEach(() => {
@@ -190,6 +244,9 @@ describe("useLiveStatus", () => {
     mockState.pageResolveDelayMs = {};
     mockState.initialPageRequestOrder = [];
     mockState.initialPageOpts = [];
+    mockState.commAggregateRows = [];
+    mockState.commFetchCalls = 0;
+    mockState.lastCommFetchOpts = undefined;
     // Reset the startTransition counter so the transition assertion can't pass
     // on stale state leaked from a prior test (A3).
     startTransitionCalls.count = 0;
@@ -762,5 +819,104 @@ describe("useLiveStatus", () => {
       });
     });
     expect(result.current.rows).toHaveLength(0);
+  });
+
+  describe("supplemental comm-error aggregate fetch (CF7-F3 #1)", () => {
+    // A fresh observedAt (relative to real Date.now(), which buildCellModel
+    // defaults to) so the comm error sits well inside the E2E staleness
+    // window from a cold load.
+    const COMM_OBSERVED_AT = new Date(Date.now() - 60_000).toISOString();
+    const COMM_SIGNAL = {
+      __fleetCommError: {
+        kind: "worker-unreachable",
+        message: "connect refused",
+        workerId: "fleet-worker-1",
+        observedAt: COMM_OBSERVED_AT,
+      },
+    };
+    // The d6:<slug> AGGREGATE row as it exists in the collection: the bulk
+    // initial fetch returns it WITHOUT signal (projection), the supplemental
+    // fetch returns it WITH signal.
+    const aggregateRow = {
+      id: "agg-acme",
+      key: "d6:acme",
+      dimension: "d6",
+      state: "green",
+      signal: COMM_SIGNAL,
+      observed_at: COMM_OBSERVED_AT,
+      transitioned_at: COMM_OBSERVED_AT,
+      fail_count: 0,
+      first_failure_at: null,
+    };
+
+    it("a mirrored comm error renders the overlay from a COLD initial fetch (no SSE delta)", async () => {
+      // REGRESSION (CF7-F3 #1): decodeCellCommError derives the REQ-B
+      // unreachable overlay from row.signal, but the bulk initial fetch
+      // projects signal away (STATUS_LIST_FIELDS) — so on every page refresh
+      // active overlays vanished until an SSE delta happened to re-deliver
+      // the row. The supplemental aggregate fetch must restore the signal on
+      // the comm-error candidate rows at cold-load time.
+      mockState.initial = [aggregateRow];
+      mockState.commAggregateRows = [aggregateRow];
+
+      const { result } = renderHook(() => useLiveStatus());
+      await waitFor(() => expect(result.current.status).toBe("live"));
+
+      // The hook's rows must carry the aggregate row WITH its signal —
+      // pre-fix the projected (signal-less) bulk row was all consumers saw.
+      const agg = result.current.rows.find((r) => r.key === "d6:acme");
+      expect(agg).toBeDefined();
+      expect(agg?.signal).toEqual(COMM_SIGNAL);
+
+      // End-to-end: the cell model derived from a cold fetch renders the
+      // unreachable overlay (this is what buildCellModel does per cell at
+      // render).
+      const model = buildCellModel(mergeRowsToMap([...result.current.rows]), {
+        slug: "acme",
+        featureId: "agentic-chat",
+        isSupported: true,
+        isWired: true,
+      });
+      expect(model.commError?.kind).toBe("worker-unreachable");
+      expect(model.surfaceState).toBe("unreachable");
+    });
+
+    it("requests ONLY aggregate-shaped keys for the comm-error dimensions (narrow filter)", async () => {
+      mockState.commAggregateRows = [aggregateRow];
+      const { result } = renderHook(() => useLiveStatus());
+      await waitFor(() => expect(result.current.status).toBe("live"));
+      expect(mockState.commFetchCalls).toBe(1);
+      const opts = mockState.lastCommFetchOpts as {
+        filter?: string;
+        fields?: string;
+      };
+      // All four comm-error aggregate dimensions, aggregate keys only
+      // (no `/<featureId>` segment).
+      expect(opts.filter).toContain('dimension = "d6"');
+      expect(opts.filter).toContain('dimension = "d4"');
+      expect(opts.filter).toContain('dimension = "e2e-demos"');
+      expect(opts.filter).toContain('dimension = "d5-single-pill-e2e"');
+      expect(opts.filter).toContain('key !~ "%/%"');
+      // Full rows: NO fields projection — signal must come back.
+      expect(opts.fields).toBeUndefined();
+    });
+
+    it("a dimension scope OUTSIDE the aggregate set skips the supplemental fetch entirely", async () => {
+      const { result } = renderHook(() => useLiveStatus("smoke"));
+      await waitFor(() => expect(result.current.status).toBe("live"));
+      expect(mockState.commFetchCalls).toBe(0);
+    });
+
+    it("a dimension scope INSIDE the aggregate set narrows the supplemental fetch to that dimension", async () => {
+      mockState.commAggregateRows = [aggregateRow];
+      const { result } = renderHook(() => useLiveStatus("d6"));
+      await waitFor(() => expect(result.current.status).toBe("live"));
+      expect(mockState.commFetchCalls).toBe(1);
+      const opts = mockState.lastCommFetchOpts as { filter?: string };
+      expect(opts.filter).toContain('dimension = "d6"');
+      expect(opts.filter).not.toContain("e2e-demos");
+      const agg = result.current.rows.find((r) => r.key === "d6:acme");
+      expect(agg?.signal).toEqual(COMM_SIGNAL);
+    });
   });
 });

--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.test.tsx
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.test.tsx
@@ -901,6 +901,45 @@ describe("useLiveStatus", () => {
       expect(opts.fields).toBeUndefined();
     });
 
+    it("a supplemental row OLDER than its bulk twin does NOT regress the newer bulk row (CF8 F3)", async () => {
+      // The supplemental fetch is kicked off CONCURRENTLY with the bulk
+      // pages, so the bulk copy of an aggregate row can be NEWER (the row's
+      // state changed between the two reads). The merge must not replace the
+      // newer bulk core fields with the supplemental response's older
+      // snapshot — and must not graft the older signal onto the newer row
+      // either: the reducer's no-op check compares signal PRESENCE only, so
+      // a chimera row (newer core + stale signal) could swallow the next SSE
+      // delta carrying the real current signal. The newer bulk row survives
+      // intact (signal-less); the live SSE subscription restores `signal`.
+      const NEWER_OBSERVED_AT = new Date(Date.now() - 30_000).toISOString();
+      const newerBulkRow = {
+        ...aggregateRow,
+        state: "red",
+        observed_at: NEWER_OBSERVED_AT,
+        transitioned_at: NEWER_OBSERVED_AT,
+        fail_count: 1,
+        first_failure_at: NEWER_OBSERVED_AT,
+      };
+      // Bulk snapshot carries the NEWER row (mock strips `signal` via the
+      // fields projection, like real PB); the supplemental response carries
+      // the OLDER signal-bearing snapshot.
+      mockState.initial = [newerBulkRow];
+      mockState.commAggregateRows = [aggregateRow];
+
+      const { result } = renderHook(() => useLiveStatus());
+      await waitFor(() => expect(result.current.status).toBe("live"));
+
+      const agg = result.current.rows.find((r) => r.key === "d6:acme");
+      expect(agg).toBeDefined();
+      // The newer bulk core fields survive the merge...
+      expect(agg?.state).toBe("red");
+      expect(agg?.observed_at).toBe(NEWER_OBSERVED_AT);
+      expect(agg?.fail_count).toBe(1);
+      // ...and the OLDER supplemental signal is NOT backfilled (unsafe — see
+      // the chimera rationale above).
+      expect(agg?.signal).toBeUndefined();
+    });
+
     it("a dimension scope OUTSIDE the aggregate set skips the supplemental fetch entirely", async () => {
       const { result } = renderHook(() => useLiveStatus("smoke"));
       await waitFor(() => expect(result.current.status).toBe("live"));

--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
@@ -2,7 +2,11 @@
 import { startTransition, useEffect, useRef, useState } from "react";
 import { getPb, pbIsMisconfigured, PB_MISCONFIG_MESSAGE } from "../lib/pb";
 import type { ConnectionStatus, StatusRow } from "../lib/live-status";
-import { STATUS_LIST_FIELDS, upsertByKey } from "../lib/live-status";
+import {
+  STATUS_LIST_FIELDS,
+  FLEET_COMM_AGGREGATE_DIMENSIONS,
+  upsertByKey,
+} from "../lib/live-status";
 
 // Back-compat alias: the connection-status union is owned by `live-status.ts`
 // as `ConnectionStatus` (the single source of truth shared with resolveCell /
@@ -213,6 +217,41 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
       ? pb.filter("dimension = {:dim}", { dim: dimension })
       : "";
 
+    // SUPPLEMENTAL comm-error aggregate filter (CF7-F3 #1). The bulk initial
+    // fetch projects `signal` away (STATUS_LIST_FIELDS), but
+    // `decodeCellCommError` (cell-model.ts) reads `row.signal` per cell at
+    // render to derive the REQ-B unreachable/pending overlay — so on a cold
+    // load every active overlay was invisible until an SSE delta happened to
+    // re-deliver the row. We re-fetch ONLY the comm-error candidate AGGREGATE
+    // rows WITH `signal`: the FLEET_COMM_AGGREGATE_DIMENSIONS dimensions
+    // (`d6`/`d4`/`e2e-demos`/`d5-single-pill-e2e`), restricted to
+    // integration-level aggregate keys (`key !~ "%/%"` — no `/<featureId>`
+    // segment), which is where the harness mirrors comm errors. That is a few
+    // rows per integration (~4 × #slugs), so the bulk projection's ~61%
+    // payload win is preserved; the per-cell rows under the same dimensions
+    // carry the heavy parity-diff signals and are deliberately NOT re-fetched
+    // (a stale per-cell comm error is only ever a same/lower-severity
+    // tie-break candidate against the aggregate mirror — see the
+    // decodeCellCommError scan doc).
+    //
+    // The dimension literals come from our own `as const` list (never caller
+    // input), so inline interpolation is safe; a caller-scoped `dimension` is
+    // honored by narrowing to the MATCHED literal (scopes outside the
+    // aggregate set skip the fetch entirely — their rows can't carry a
+    // mirrored comm error the dashboard would read).
+    const matchedCommDim =
+      dimension === undefined
+        ? undefined
+        : FLEET_COMM_AGGREGATE_DIMENSIONS.find((d) => d === dimension);
+    const commAggregateFilter: string | null =
+      dimension === undefined
+        ? `(${FLEET_COMM_AGGREGATE_DIMENSIONS.map(
+            (d) => `dimension = "${d}"`,
+          ).join(" || ")}) && key !~ "%/%"`
+        : matchedCommDim !== undefined
+          ? `dimension = "${matchedCommDim}" && key !~ "%/%"`
+          : null;
+
     function teardownSubscription(): void {
       if (cancel) {
         try {
@@ -393,6 +432,40 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
       }, HEARTBEAT_INTERVAL_MS);
     }
 
+    /**
+     * Fetch the comm-error candidate AGGREGATE rows WITH `signal` (no
+     * `fields` projection) — the narrow companion to the bulk projected
+     * fetch; see the `commAggregateFilter` doc above (CF7-F3 #1). Returns
+     * `[]` without a request when the hook's dimension scope cannot
+     * intersect the aggregate set. Length-bounded serial pagination: the
+     * result is ~4 rows per integration, so page 1 is essentially always the
+     * only page — the loop is a correctness guard, not a hot path.
+     */
+    async function fetchCommAggregateRows(): Promise<StatusRow[]> {
+      if (commAggregateFilter === null) return [];
+      // `requestKey: null` for the same reason as the bulk fetch: this hits
+      // the SAME path (`/api/collections/status/records`) concurrently with
+      // the bulk pages, so the SDK's default auto-key would cancel one or
+      // the other.
+      const opts = {
+        filter: commAggregateFilter,
+        sort: INITIAL_SORT,
+        skipTotal: true,
+        requestKey: null,
+      };
+      const rows: StatusRow[] = [];
+      let page = 1;
+      for (;;) {
+        const res = await pb
+          .collection("status")
+          .getList<StatusRow>(page, INITIAL_PAGE_SIZE, opts);
+        rows.push(...res.items);
+        if (res.items.length < INITIAL_PAGE_SIZE) break;
+        page += 1;
+      }
+      return rows;
+    }
+
     async function fetchInitial(): Promise<StatusRow[]> {
       // Best-effort consistent snapshot via a stable-sorted, LENGTH-bounded
       // CONCURRENT paged fetch.
@@ -419,7 +492,10 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
       // `fields: STATUS_LIST_FIELDS` projects every StatusRow field EXCEPT the
       // heavy `signal` blob (~61% of the payload), the dominant transfer-size
       // win for first paint; the SSE subscription still delivers full rows
-      // (signal included) for every subsequent delta.
+      // (signal included) for every subsequent delta, and the SUPPLEMENTAL
+      // comm-error aggregate fetch (kicked off below, CF7-F3 #1) restores
+      // `signal` on the few aggregate rows the comm-error overlay reads at
+      // render time.
       //
       // `sort: "id"` is forwarded to EVERY page request so all the concurrent
       // reads share the same ordering: for a STABLE collection that means no
@@ -454,52 +530,91 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
             requestKey: null,
           };
 
+      // Kick off the supplemental comm-error aggregate fetch (CF7-F3 #1)
+      // CONCURRENTLY with the bulk pages — it is independent of the page
+      // chain and its rows are merged in after the bulk completes. A no-op
+      // (resolved []) when the dimension scope can't intersect the aggregate
+      // set.
+      const commAggregatePromise = fetchCommAggregateRows();
       const pages: StatusRow[][] = [];
-      const first = await pb
-        .collection("status")
-        .getList<StatusRow>(1, INITIAL_PAGE_SIZE, listOpts);
-      pages.push(first.items);
-      // Page 1 short ⇒ single-page collection, no fan-out.
-      let lastPageFull = first.items.length === INITIAL_PAGE_SIZE;
-      let nextPage = 2;
-      while (lastPageFull) {
-        // Fan out one wave of consecutive pages CONCURRENTLY. `Promise.all`
-        // preserves request (array-index) order regardless of resolution
-        // order, so the merge stays deterministic page order.
-        const wave: Promise<{ items: StatusRow[] }>[] = [];
-        for (let i = 0; i < INITIAL_FANOUT_BATCH; i++) {
-          const page = nextPage + i;
-          wave.push(
-            pb
-              .collection("status")
-              .getList<StatusRow>(page, INITIAL_PAGE_SIZE, listOpts),
+      try {
+        const first = await pb
+          .collection("status")
+          .getList<StatusRow>(1, INITIAL_PAGE_SIZE, listOpts);
+        pages.push(first.items);
+        // Page 1 short ⇒ single-page collection, no fan-out.
+        let lastPageFull = first.items.length === INITIAL_PAGE_SIZE;
+        let nextPage = 2;
+        while (lastPageFull) {
+          // Fan out one wave of consecutive pages CONCURRENTLY. `Promise.all`
+          // preserves request (array-index) order regardless of resolution
+          // order, so the merge stays deterministic page order.
+          const wave: Promise<{ items: StatusRow[] }>[] = [];
+          for (let i = 0; i < INITIAL_FANOUT_BATCH; i++) {
+            const page = nextPage + i;
+            wave.push(
+              pb
+                .collection("status")
+                .getList<StatusRow>(page, INITIAL_PAGE_SIZE, listOpts),
+            );
+          }
+          const waveResults = await Promise.all(wave);
+          // Merge the wave in strict page (array-index) order, stopping at the
+          // FIRST short page. This is correct for ANY INITIAL_FANOUT_BATCH, not
+          // just 2: PocketBase pagination is monotonic, so once a page returns
+          // fewer than INITIAL_PAGE_SIZE items it is the LAST page with data and
+          // every page issued AFTER it in the same wave is past the end (empty).
+          // We locate that boundary, append pages up to AND INCLUDING it, and
+          // append nothing after — so no empty tail page is ever merged and no
+          // real tail row is ever dropped, regardless of how many pages a wave
+          // over-fetched past the end. (A larger batch only over-FETCHES extra
+          // empty pages on the wire; it can never corrupt the merge. This guards
+          // against silently reintroducing the #4504 over-fetch-past-end bug if
+          // the constant is tuned.)
+          const shortIdx = waveResults.findIndex(
+            (result) => result.items.length < INITIAL_PAGE_SIZE,
           );
+          const lastIdx = shortIdx === -1 ? waveResults.length - 1 : shortIdx;
+          for (let i = 0; i <= lastIdx; i++) {
+            pages.push(waveResults[i]!.items);
+          }
+          // The wave ended the collection iff it contained a short page.
+          lastPageFull = shortIdx === -1;
+          nextPage += INITIAL_FANOUT_BATCH;
         }
-        const waveResults = await Promise.all(wave);
-        // Merge the wave in strict page (array-index) order, stopping at the
-        // FIRST short page. This is correct for ANY INITIAL_FANOUT_BATCH, not
-        // just 2: PocketBase pagination is monotonic, so once a page returns
-        // fewer than INITIAL_PAGE_SIZE items it is the LAST page with data and
-        // every page issued AFTER it in the same wave is past the end (empty).
-        // We locate that boundary, append pages up to AND INCLUDING it, and
-        // append nothing after — so no empty tail page is ever merged and no
-        // real tail row is ever dropped, regardless of how many pages a wave
-        // over-fetched past the end. (A larger batch only over-FETCHES extra
-        // empty pages on the wire; it can never corrupt the merge. This guards
-        // against silently reintroducing the #4504 over-fetch-past-end bug if
-        // the constant is tuned.)
-        const shortIdx = waveResults.findIndex(
-          (result) => result.items.length < INITIAL_PAGE_SIZE,
-        );
-        const lastIdx = shortIdx === -1 ? waveResults.length - 1 : shortIdx;
-        for (let i = 0; i <= lastIdx; i++) {
-          pages.push(waveResults[i]!.items);
-        }
-        // The wave ended the collection iff it contained a short page.
-        lastPageFull = shortIdx === -1;
-        nextPage += INITIAL_FANOUT_BATCH;
+      } catch (err) {
+        // The bulk fetch failed — connect() retries the WHOLE initial fetch,
+        // supplemental included. Detach the in-flight supplemental promise so
+        // its eventual rejection (the backend is likely down for it too)
+        // can't surface as an unhandled rejection; its rows are useless
+        // without the bulk rows anyway.
+        commAggregatePromise.catch(() => {});
+        throw err;
       }
-      return pages.flat();
+      const bulk = pages.flat();
+      // Merge the supplemental signal-bearing aggregate rows over their
+      // projected bulk twins, BY KEY (CF7-F3 #1). A supplemental row replaces
+      // the projected row in place (preserving the bulk's deterministic page
+      // order); an aggregate row the bulk snapshot didn't carry (created
+      // between the two reads) is appended — the same eventual-consistency
+      // posture as the SSE reconciliation. A supplemental FAILURE intentionally
+      // propagates: a cold load that silently misses active comm-error
+      // overlays is the exact bug this fetch exists to fix, so it retries
+      // through the same connect() chain as the bulk fetch (fail loud, not
+      // fail half-blind).
+      const commAggregates = await commAggregatePromise;
+      if (commAggregates.length === 0) return bulk;
+      const fullByKey = new Map(commAggregates.map((r) => [r.key, r] as const));
+      const merged = bulk.map((r) => {
+        const full = fullByKey.get(r.key);
+        if (full === undefined) return r;
+        fullByKey.delete(r.key);
+        return full;
+      });
+      for (const leftover of fullByKey.values()) {
+        merged.push(leftover);
+      }
+      return merged;
     }
 
     async function connect(): Promise<void> {

--- a/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
+++ b/showcase/shell-dashboard/src/hooks/useLiveStatus.ts
@@ -98,6 +98,51 @@ const RECONNECT_BACKOFF_MAX_MS = 8000;
 const SUBSCRIBE_FLUSH_INTERVAL_MS = 16;
 
 /**
+ * `true` when the supplemental comm-aggregate row (`full`) is STRICTLY older
+ * than its projected bulk twin (`bulkRow`) — the freshness guard for the
+ * cold-load merge in `fetchInitial` (CF8 F3).
+ *
+ * The supplemental fetch runs CONCURRENTLY with the bulk pages, so the bulk
+ * copy of an aggregate row can be NEWER (the row's state changed between the
+ * two reads). Replacing it with the supplemental snapshot would regress
+ * `state`/`observed_at` to stale values until the row's next SSE delta —
+ * which for slow-cadence aggregate rows can be a long time. "Fresher wins" is
+ * judged on `observed_at`, the row's last-SEEN marker (it moves on every
+ * producer tick, while `transitioned_at` only moves on state change — so it is
+ * the strictly-later of the two and the right recency key; the staleness fold
+ * in cell-model.ts keys off the same field).
+ *
+ * Tie/parse semantics, both deliberate:
+ *   - EQUAL timestamps → NOT older → the supplemental row wins. It is the
+ *     field-complete twin of the same snapshot (it carries `signal`, which the
+ *     bulk projection drops), so preferring it is what makes the cold-load
+ *     comm-error overlay visible at all (CF7-F3 #1).
+ *   - UNPARSEABLE timestamp on either side → NOT older → supplemental wins.
+ *     We only suppress the replace when the supplemental row is POSITIVELY
+ *     known to be stale; an undecidable comparison falls back to the
+ *     signal-bearing row, the same eventual-consistency posture as before
+ *     (the SSE subscription reconciles either way).
+ *
+ * When the bulk row IS newer we keep it INTACT — we do NOT graft the older
+ * supplemental `signal` onto it. A chimera row (newer core fields + stale
+ * signal) is worse than a signal-less one: the reducer's no-op check
+ * (`rowsAreNoop`, live-status.ts) compares signal PRESENCE only, so the next
+ * SSE delta carrying the same core fields but the REAL current signal would be
+ * swallowed as a no-op and the stale signal would persist indefinitely. A
+ * signal-less bulk row instead makes that delta's `undefined → defined`
+ * presence flip observable, so the live subscription restores `signal` safely.
+ */
+function supplementalRowIsOlder(full: StatusRow, bulkRow: StatusRow): boolean {
+  // `Date.parse` yields NaN for a malformed value; NaN comparisons are false,
+  // but we gate explicitly so the fallback direction is documented, not an
+  // accident of IEEE semantics.
+  const fullTs = Date.parse(full.observed_at);
+  const bulkTs = Date.parse(bulkRow.observed_at);
+  if (Number.isNaN(fullTs) || Number.isNaN(bulkTs)) return false;
+  return fullTs < bulkTs;
+}
+
+/**
  * Subscribes to the `status` collection, scoped by `dimension`. Exposes
  * (rows, connection-status). Does NOT fall back to any cached bundle —
  * stale-green lies are worse than an offline banner (§5.3).
@@ -595,7 +640,13 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
       // Merge the supplemental signal-bearing aggregate rows over their
       // projected bulk twins, BY KEY (CF7-F3 #1). A supplemental row replaces
       // the projected row in place (preserving the bulk's deterministic page
-      // order); an aggregate row the bulk snapshot didn't carry (created
+      // order) — UNLESS the bulk twin is strictly fresher (CF8 F3): the two
+      // fetches run concurrently, so the bulk copy can carry a newer state
+      // than the supplemental snapshot, and "fresher wins" must hold in both
+      // directions (see `supplementalRowIsOlder` for the recency key, the
+      // equal-timestamp preference for the signal-bearing row, and why the
+      // newer bulk row is kept intact rather than grafted with the older
+      // signal). An aggregate row the bulk snapshot didn't carry (created
       // between the two reads) is appended — the same eventual-consistency
       // posture as the SSE reconciliation. A supplemental FAILURE intentionally
       // propagates: a cold load that silently misses active comm-error
@@ -609,6 +660,13 @@ export function useLiveStatus(dimension?: string): UseLiveStatusResult {
         const full = fullByKey.get(r.key);
         if (full === undefined) return r;
         fullByKey.delete(r.key);
+        // Freshness guard (CF8 F3): if the supplemental snapshot is STRICTLY
+        // older than its bulk twin, the bulk row's core fields are newer —
+        // keep it intact (signal-less) rather than regressing state/observed_at
+        // or grafting a stale signal onto a newer row. See
+        // `supplementalRowIsOlder` for tie/parse semantics and the chimera
+        // rationale.
+        if (supplementalRowIsOlder(full, r)) return r;
         return full;
       });
       for (const leftover of fullByKey.values()) {

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -1846,6 +1846,42 @@ describe("buildCellModel", () => {
         expect(model.commError?.kind).toBe("worker-reclaimed-pending");
       });
 
+      it("a reclaimed-pending comm error on a NO-DATA (gray) cell surfaces 'pending' — the deliberate dashboard-side asymmetry (G3d)", () => {
+        // The harness pending gate is green-ONLY because ProbeState has no
+        // no-data colour. The dashboard's gray IS its no-data colour, and a
+        // no-data cell awaiting a re-queued job is genuinely pending — so
+        // gray ALSO routes to "pending" here, deliberately diverging from
+        // the harness derivation (pinned shape-wise by
+        // commError-contract-drift.test.ts).
+        const live = mapOf([
+          // No probe rows at all for this cell → chip gray (no-data). The
+          // reclaim comm error rides the integration-level d6 aggregate row,
+          // which the per-cell resolvers never read (so the chip stays gray).
+          row(keyFor("d6", "agno"), "d6", "green", {
+            signal: reclaimSignal,
+          }),
+        ]);
+        const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+        expect(model.chipColor).toBe("gray");
+        expect(model.isRegression).toBe(false);
+        expect(model.surfaceState).toBe("pending");
+        expect(model.commError?.kind).toBe("worker-reclaimed-pending");
+      });
+
+      it("a reclaimed-pending comm error must NOT mask a RED chip — red passes through", () => {
+        const live = mapOf([
+          row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "red"),
+          row(keyFor("d6", "agno"), "d6", "green", {
+            signal: reclaimSignal,
+          }),
+        ]);
+        const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+        expect(model.chipColor).toBe("red");
+        expect(model.surfaceState).toBe("red");
+        expect(model.surfaceState).not.toBe("pending");
+        expect(model.commError?.kind).toBe("worker-reclaimed-pending");
+      });
+
       it("a crash (worker-crashed-mid-job) still surfaces red 'unreachable' — only reclaim is neutralized", () => {
         const live = mapOf([
           row(keyFor("d6", "agno", "agentic-chat"), "d6", "green", {

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -1341,6 +1341,40 @@ describe("buildCellModel", () => {
     const D4_STALE = D4_STALE_AFTER_MS + 60 * 1000;
     const FRESH = 60 * 1000;
 
+    it("D3: stale-green downgrade returns the EFFECTIVE row and .row.state matches .status (G3c)", () => {
+      // resolveD3's stale-green branch returned the RAW row (`status: "amber",
+      // row` with row.state still "green"), violating the `.row.state` ↔
+      // `.status` invariant resolveD4/D5/D6 maintain.
+      const live = mapOf([
+        rowAtAge(
+          keyFor("e2e", "agno", "agentic-chat"),
+          "e2e",
+          E2E_STALE,
+          "green",
+        ),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.d3?.status).toBe("amber");
+      expect(model.d3?.row?.state).toBe("degraded");
+    });
+
+    it("D3: fresh-green keeps the raw row (no spurious downgrade)", () => {
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.d3?.status).toBe("green");
+      expect(model.d3?.row?.state).toBe("green");
+    });
+
     it("D4: stale-green folds to amber and .row.state matches .status", () => {
       const live = mapOf([
         rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "green"),

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -3,6 +3,7 @@ import {
   buildCellModel,
   E2E_STALE_AFTER_MS,
   D4_STALE_AFTER_MS,
+  LIVENESS_STALE_AFTER_MS,
 } from "../cell-model";
 import type { CellModelInput } from "../cell-model";
 import type { LiveStatusMap, StatusRow, State } from "../live-status";
@@ -97,6 +98,33 @@ describe("buildCellModel", () => {
       });
       expect(model.supported).toBe(false);
       expect(model.chipColor).toBe("gray");
+    });
+  });
+
+  // ── G3e(i): shared singletons must be frozen ────────────────────────
+  // `UNSUPPORTED` and `NOT_WIRED_LEVEL` are module-level singletons returned
+  // by reference to every caller — one consumer mutating its "own" cell model
+  // would corrupt every other unsupported/not-wired cell. Freeze them.
+  describe("shared singleton immutability (G3e)", () => {
+    it("the unsupported CellModel singleton is frozen", () => {
+      const model = buildCellModel(mapOf([]), {
+        slug: "agno",
+        featureId: "agentic-chat",
+        isSupported: false,
+        isWired: false,
+      });
+      expect(Object.isFrozen(model)).toBe(true);
+    });
+
+    it("the shared NOT_WIRED_LEVEL TestLevel is frozen", () => {
+      const model = buildCellModel(mapOf([]), {
+        slug: "agno",
+        featureId: "agentic-chat",
+        isSupported: true,
+        isWired: false,
+      });
+      expect(Object.isFrozen(model.d3)).toBe(true);
+      expect(Object.isFrozen(model.d6)).toBe(true);
     });
   });
 
@@ -2039,6 +2067,62 @@ describe("buildCellModel", () => {
         );
         expect(model.surfaceState).toBe("unreachable");
         expect(model.commError?.kind).toBe("worker-crashed-mid-job");
+      });
+
+      it("scopes the window PER ROW FAMILY: a health-row comm error older than the liveness window is skipped (G3e)", () => {
+        // The candidate scan must not apply the 6h E2E window to
+        // liveness-cadence rows: a health row's comm error ages out on the
+        // SAME window its row family's resolvers use (45m liveness), while
+        // the identical-age comm error on the e2e-cadence d6 aggregate is
+        // still fresh under the 6h window.
+        const AGE = LIVENESS_STALE_AFTER_MS + 5 * 60 * 1000; // 50m
+        expect(AGE).toBeLessThan(E2E_STALE_AFTER_MS);
+        const staleHealthOnly = mapOf([
+          row(keyFor("health", "agno"), "health", "green", {
+            signal: { __fleetCommError: commErrorAtAge(AGE) },
+          }),
+        ]);
+        const healthModel = buildCellModel(
+          staleHealthOnly,
+          wiredInput("agno", "agentic-chat"),
+          NOW,
+        );
+        // Aged out for the liveness family → treated as recovered.
+        expect(healthModel.surfaceState).not.toBe("unreachable");
+        expect(healthModel.commError).toBeUndefined();
+
+        const freshAggregate = mapOf([
+          row(keyFor("d6", "agno"), "d6", "green", {
+            signal: { __fleetCommError: commErrorAtAge(AGE) },
+          }),
+        ]);
+        const aggModel = buildCellModel(
+          freshAggregate,
+          wiredInput("agno", "agentic-chat"),
+          NOW,
+        );
+        // The same age on the e2e-cadence aggregate is still fresh.
+        expect(aggModel.surfaceState).toBe("unreachable");
+      });
+
+      it("scopes the window PER ROW FAMILY: a chat/tools-row comm error uses the D4 window (G3e)", () => {
+        const AGE = D4_STALE_AFTER_MS + 60 * 1000; // 61m — stale for D4, fresh for e2e
+        expect(AGE).toBeLessThan(E2E_STALE_AFTER_MS);
+        const staleChatOnly = mapOf([
+          row(keyFor("chat", "agno"), "chat", "green", {
+            signal: { __fleetCommError: commErrorAtAge(AGE) },
+          }),
+          row(keyFor("tools", "agno"), "tools", "green", {
+            signal: { __fleetCommError: commErrorAtAge(AGE) },
+          }),
+        ]);
+        const model = buildCellModel(
+          staleChatOnly,
+          wiredInput("agno", "agentic-chat"),
+          NOW,
+        );
+        expect(model.surfaceState).not.toBe("unreachable");
+        expect(model.commError).toBeUndefined();
       });
 
       it("the SAME comm error aged past the staleness window → NOT unreachable (recovered)", () => {

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -2090,8 +2090,12 @@ describe("buildCellModel", () => {
       it.each(FAMILY_KEYS)(
         "a crash comm error on the %s aggregate row surfaces 'unreachable'",
         (key) => {
+          // Destructure-with-fallback (not a `[0]!` non-null assertion) so the
+          // shape stays valid under `noUncheckedIndexedAccess` and matches the
+          // assertion-free helper in src/lib/cell-model.test.ts.
+          const [dimension = ""] = key.split(":");
           const live = mapOf([
-            row(key, key.split(":")[0]!, "green", {
+            row(key, dimension, "green", {
               signal: {
                 __fleetCommError: {
                   kind: "worker-crashed-mid-job",

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -2013,6 +2013,64 @@ describe("buildCellModel", () => {
       expect(model.commError?.workerId).toBe("worker-PERCELL");
     });
 
+    // ── G3f: non-d6 fleet-family sweep aggregates ─────────────────────
+    // The global lease sweep reclaims jobs of ALL four fleet families and
+    // mirrors each comm error onto the status row keyed by the reclaimed
+    // job's `probe_key` (harness resolveSweepAggregateKey →
+    // aggregateCommError). For the non-d6 families those keys are
+    // `d4:<slug>` (smoke), `e2e-demos:<slug>` (demos), and
+    // `d5-single-pill-e2e:<slug>` (deep) — rows the dashboard reads NOWHERE
+    // else, so the candidate scan must include them or a reclaim/crash
+    // overlay on those families is invisible.
+    describe("non-d6 fleet-family sweep aggregate keys (G3f)", () => {
+      const FAMILY_KEYS = [
+        keyFor("d4", "agno"),
+        keyFor("e2e-demos", "agno"),
+        keyFor("d5-single-pill-e2e", "agno"),
+      ];
+
+      it.each(FAMILY_KEYS)(
+        "a crash comm error on the %s aggregate row surfaces 'unreachable'",
+        (key) => {
+          const live = mapOf([
+            row(key, key.split(":")[0]!, "green", {
+              signal: {
+                __fleetCommError: {
+                  kind: "worker-crashed-mid-job",
+                  message: "lease expired with no terminal report",
+                  workerId: "fleet-worker-2",
+                  observedAt: FRESH_OBSERVED_AT,
+                },
+              },
+            }),
+          ]);
+          const model = buildCellModel(
+            live,
+            wiredInput("agno", "agentic-chat"),
+          );
+          expect(model.surfaceState).toBe("unreachable");
+          expect(model.commError?.kind).toBe("worker-crashed-mid-job");
+        },
+      );
+
+      it("a reclaim comm error on the d4:<slug> aggregate row surfaces 'pending' on a no-data cell", () => {
+        const live = mapOf([
+          row(keyFor("d4", "agno"), "d4", "green", {
+            signal: {
+              __fleetCommError: {
+                kind: "worker-reclaimed-pending",
+                message: "lease for job j-3 expired; re-queued to pending",
+                observedAt: FRESH_OBSERVED_AT,
+              },
+            },
+          }),
+        ]);
+        const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+        expect(model.surfaceState).toBe("pending");
+        expect(model.commError?.kind).toBe("worker-reclaimed-pending");
+      });
+    });
+
     // ── Comm-error staleness window ───────────────────────────────────
     // A PoolCommError mirrored onto the `d6:<slug>` aggregate row is NOT
     // overwritten when the pool recovers (recovery writes fresh per-cell

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -295,16 +295,32 @@ describe("buildCellModel", () => {
 
   // ── D4 via tools instead of chat ────────────────────────────────────
   describe("D4 via tools row", () => {
-    it("resolves D4 from tools:<slug> when chat is absent", () => {
+    it("does NOT credit D4 green from tools:<slug> alone when chat is absent (G2f strictness)", () => {
+      // `chat:<slug>` is UNCONDITIONAL on the producer side (the D4 driver
+      // writes the L3 round-trip row for every probed integration), so a
+      // tools-only green fold means the always-expected sibling is missing —
+      // an unverified family that must collapse to no-data, mirroring the
+      // D5/D6 missing-mapped-sub-row strictness. (A green CHAT row with
+      // tools missing still credits D4 — tools is producer-conditional.)
       const live = mapOf([
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
         row(keyFor("tools", "agno"), "tools", "green"),
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
       expect(model.d4!.exists).toBe(true);
-      expect(model.d4!.status).toBe("green");
+      expect(model.d4!.status).toBeNull();
+      expect(model.d4!.row).toBeNull();
+      expect(model.achievedDepth).toBe(3);
+    });
+
+    it("a RED tools row still surfaces when chat is absent (red dominates no-data)", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("tools", "agno"), "tools", "red"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d4!.status).toBe("red");
       expect(model.d4!.row!.dimension).toBe("tools");
-      expect(model.achievedDepth).toBe(4);
     });
 
     it("worst-state wins when both chat and tools exist", () => {

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -2153,9 +2153,11 @@ describe("buildCellModel", () => {
       it.each(FAMILY_KEYS)(
         "a crash comm error on the %s aggregate row surfaces 'unreachable'",
         (key) => {
-          // Destructure-with-fallback (not a `[0]!` non-null assertion) so the
-          // shape stays valid under `noUncheckedIndexedAccess` and matches the
-          // assertion-free helper in src/lib/cell-model.test.ts.
+          // Destructure-with-fallback (not a `[0]!` non-null assertion):
+          // assertion-free, and it would stay valid if
+          // `noUncheckedIndexedAccess` were ever enabled (it is NOT in this
+          // package's tsconfig today). The sibling helper in
+          // src/lib/cell-model.test.ts uses the same shape.
           const [dimension = ""] = key.split(":");
           const live = mapOf([
             row(key, dimension, "green", {

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -334,6 +334,44 @@ describe("buildCellModel", () => {
       expect(model.d4!.status).toBe("red");
       expect(model.d4!.row!.dimension).toBe("tools");
     });
+
+    it("missing-chat collapse renders the GRAY no-data chip, not red (unverified ≠ failed)", () => {
+      // The tools-only collapse is documented as the no-data outcome
+      // ("mirroring the D5/D6 missing-mapped-sub-row strictness") — D5/D6's
+      // analogous collapse renders a GRAY chip, so a not-yet-emitted chat row
+      // must read as unverified (gray), NOT as a D1-D4 gate hard-failure (red).
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("tools", "agno"), "tools", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d4!.status).toBeNull();
+      expect(model.chipColor).toBe("gray");
+      expect(model.surfaceState).toBe("gray");
+      // The D6 claim stays blocked while the ladder below it is unverified.
+      expect(model.d6Effective).toBeNull();
+    });
+
+    it("a present RED chat row still fails the D1-D4 gate (red chip unchanged)", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "red"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d4!.status).toBe("red");
+      expect(model.chipColor).toBe("red");
+    });
+
+    it("missing-chat no-data does NOT mask a present red D5 (red dominates no-data)", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("tools", "agno"), "tools", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "red"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d4!.status).toBeNull();
+      expect(model.chipColor).toBe("red");
+    });
   });
 
   // ── D5 multi-key (CATALOG_TO_D5_KEY has multiple sub-keys) ──────────
@@ -1619,14 +1657,18 @@ describe("buildCellModel", () => {
       expect(model.achievedDepth).toBe(0);
     });
 
-    it("CHARACTERIZATION: an 'error'-state D4 row keeps status null but the gate check still reds the chip", () => {
+    it("an 'error'-state D4 row yields status red and fails the gate (out-of-vocab never reads as no-data)", () => {
+      // D4's `null` now means NO-DATA (the missing-chat collapse renders
+      // gray), so an out-of-vocabulary D4 state maps to "red" via
+      // foldStateToTestStatus — it must fail the gate loudly, never hide
+      // behind the no-data exclusion.
       const live = mapOf([
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
         row(keyFor("chat", "agno"), "chat", OUT_OF_VOCAB),
         row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
       ]);
       const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
-      expect(model.d4!.status).toBeNull();
+      expect(model.d4!.status).toBe("red");
       expect(model.chipColor).toBe("red");
       expect(model.achievedDepth).toBe(3);
     });

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -241,6 +241,65 @@ describe("buildCellModel", () => {
     });
   });
 
+  // ── Absent D3/D4 family → unverified gray, never green (CF7-F3 #2) ──
+  describe("absent D3/D4 family collapses to unverified gray (CF7-F3 #2)", () => {
+    it("only-D5/D6-green (no e2e/chat/tools rows at all) renders GRAY, not green", () => {
+      // The D1-D4 gate fires only on d3.exists/d4.exists, so a cell with ONLY
+      // green D5/D6 rows used to slip past it and render a green chip + green
+      // d6Effective with achievedDepth=0/ceilingDepth=0 — contradicting the
+      // strictness doctrine (a PRESENT-but-null D4 grays; D5-no-data grays the
+      // ladder; an ABSENT lower ladder must not be weaker than a present
+      // unverified one).
+      const live = mapOf([
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d3!.exists).toBe(false);
+      expect(model.d4!.exists).toBe(false);
+      expect(model.achievedDepth).toBe(0);
+      expect(model.ceilingDepth).toBe(0);
+      // Unverified ladder below D5 → gray, same shape as the other no-data
+      // collapses; the D6 claim stays blocked.
+      expect(model.chipColor).toBe("gray");
+      expect(model.d6Effective).toBeNull();
+      expect(model.surfaceState).toBe("gray");
+    });
+
+    it("with D3/D4 green the full-green ladder stays GREEN (unchanged)", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.chipColor).toBe("green");
+      expect(model.d6Effective).toBe("green");
+    });
+
+    it("absent D3/D4 + red D6 stays RED (red dominates the absent collapse)", () => {
+      const live = mapOf([
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "red"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.chipColor).toBe("red");
+      // The blocked D6 claim still never reads green through an unverified
+      // ladder — the chip carries the red.
+      expect(model.d6Effective).toBeNull();
+    });
+
+    it("absent D3/D4 + red D5 stays RED (red dominates the absent collapse)", () => {
+      const live = mapOf([
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "red"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.chipColor).toBe("red");
+      expect(model.d6Effective).toBeNull();
+    });
+  });
+
   // ── D3 fails → D0 achieved, red chip ───────────────────────────────
   describe("D3 fails", () => {
     it("returns achievedDepth=0 and red chip when D3 fails (tests exist but none pass)", () => {
@@ -1912,13 +1971,17 @@ describe("buildCellModel", () => {
       });
 
       it("a reclaimed-pending comm error must NOT mask an AMBER (partial-failure) chip — amber passes through", () => {
-        // D5 green + D6 red → chipColor amber (partial failure / degraded
-        // ladder). Amber is a GENUINE failure colour, not no-data: the
+        // Intact D1-D4 ladder + D5 green + D6 red → chipColor amber (partial
+        // failure / degraded ladder; the green e2e/chat rows keep the ladder
+        // verified so the CF7-F3 #2 absent-D3/D4 collapse doesn't turn this
+        // red). Amber is a GENUINE failure colour, not no-data: the
         // neutral "pending" overlay masking it would hide a real partial
         // regression behind a benign gray surface (the same never-mask rule
         // the red passthrough enforces — mirrors the harness
         // fleetSurfaceState, where only green becomes "pending").
         const live = mapOf([
+          row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+          row(keyFor("chat", "agno"), "chat", "green"),
           row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
           row(keyFor("d6", "agno", "agentic-chat"), "d6", "red", {
             signal: reclaimSignal,

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -1459,6 +1459,21 @@ describe("buildCellModel", () => {
       expect(model.d6!.row?.key).toBe("d6:agno/beautiful-chat-pie-chart");
     });
 
+    it("d5: missing sub-row + out-of-vocab sub-row yields a FAILING status, not no-data (G3b)", () => {
+      // Follow-through of the rank fold: the surfaced out-of-vocab winner must
+      // also MAP to a failing status — otherwise the collapse fix is undone
+      // one step later by stateToTestStatus mapping the unknown state to null.
+      const live = mapOf([
+        row(
+          keyFor("d5", "agno", "beautiful-chat-toggle-theme"),
+          "d5",
+          OUT_OF_VOCAB,
+        ),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "beautiful-chat"));
+      expect(model.d5!.status).toBe("red");
+    });
+
     it("d5: missing sub-row + green fold still collapses to no-data (strict handling preserved)", () => {
       // The rank guard must NOT weaken the strict missing-sub-row rule: a
       // present green fold with a missing sibling stays no-data.
@@ -1469,6 +1484,73 @@ describe("buildCellModel", () => {
       expect(model.d5!.exists).toBe(true);
       expect(model.d5!.status).toBeNull();
       expect(model.d5!.row).toBeNull();
+    });
+  });
+
+  // ── G3b: out-of-vocab states map to a FAILING status for D5/D6 ──────
+  // `stateToTestStatus` mapped unknown runtime states (e.g. "error" — the
+  // harness no-data representation) to `null`, swallowing the A2 rank-fold
+  // winner one step AFTER the fold surfaced it: the D5/D6 chip/badge rendered
+  // benign gray no-data while live-status's badge path renders the loud
+  // "error" tone for the same row. D5/D6 must map an out-of-vocab state to a
+  // failing ("red") status. D3/D4 keep the base mapping — their `null` is
+  // rescued by the chip's D1-D4 gate check (exists && status !== "green" →
+  // gate fails → red), pinned below.
+  describe("out-of-vocab state → failing D5/D6 status (G3b)", () => {
+    const OUT_OF_VOCAB = "error" as unknown as State;
+
+    it("an 'error'-state D5 row yields status red and a red (not gray) chip", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", OUT_OF_VOCAB),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d5!.status).toBe("red");
+      // Broken ladder at D5 → red chip; pre-fix this rendered gray (no-data).
+      expect(model.chipColor).toBe("red");
+      expect(model.achievedDepth).toBe(4);
+    });
+
+    it("an 'error'-state D6 row yields status red (passes through d6Effective on an intact ladder)", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", OUT_OF_VOCAB),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d6!.status).toBe("red");
+      // Ladder intact through D5 → the failing D6 surfaces on the badge/stat.
+      expect(model.d6Effective).toBe("red");
+      // D5 green + non-green D6 → amber chip (per the decision table).
+      expect(model.chipColor).toBe("amber");
+    });
+
+    it("CHARACTERIZATION: an 'error'-state D3 row keeps status null but the gate check still reds the chip", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", OUT_OF_VOCAB),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      // D3/D4 keep the base mapping (null for out-of-vocab)…
+      expect(model.d3!.status).toBeNull();
+      // …because the D1-D4 gate check rescues them: exists && !== "green".
+      expect(model.chipColor).toBe("red");
+      expect(model.achievedDepth).toBe(0);
+    });
+
+    it("CHARACTERIZATION: an 'error'-state D4 row keeps status null but the gate check still reds the chip", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", OUT_OF_VOCAB),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.d4!.status).toBeNull();
+      expect(model.chipColor).toBe("red");
+      expect(model.achievedDepth).toBe(3);
     });
   });
 

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -1414,6 +1414,64 @@ describe("buildCellModel", () => {
     });
   });
 
+  // ── G3a: rank-based anyMissing collapse (mirror of live-status Fix A2) ──
+  // resolveD5/resolveD6 collapse a present green/degraded fold to no-data
+  // when a mapped sub-row is missing. That collapse guard must be RANK-based,
+  // not the literal `worstState !== "red"`: `worstState` is typed `State` but
+  // can hold an out-of-vocabulary runtime value (e.g. "error" — the harness
+  // no-data representation), which the A2 rank machinery deliberately ranks
+  // ABOVE red. Literal equality matches neither, so exactly the state the
+  // rank fold exists to surface was being collapsed to benign gray no-data.
+  // Mirrors live-status.test.ts "missing sub-row + out-of-vocab sub-row
+  // SURFACES" for resolveD5Row/resolveD6Row.
+  describe("rank-based anyMissing collapse (G3a)", () => {
+    const OUT_OF_VOCAB = "error" as unknown as State;
+
+    it("d5: missing sub-row + out-of-vocab sub-row SURFACES the row, not the no-data collapse", () => {
+      // beautiful-chat maps to 5 d5 sub-keys; emit ONE row carrying "error"
+      // (4 siblings missing). The literal `!== "red"` guard collapsed this to
+      // { status: null, row: null }; the rank guard must surface the row —
+      // an unrecognized state out-ranks red and dominates no-data.
+      const live = mapOf([
+        row(
+          keyFor("d5", "agno", "beautiful-chat-toggle-theme"),
+          "d5",
+          OUT_OF_VOCAB,
+        ),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "beautiful-chat"));
+      expect(model.d5!.exists).toBe(true);
+      expect(model.d5!.row).not.toBeNull();
+      expect(model.d5!.row?.key).toBe("d5:agno/beautiful-chat-toggle-theme");
+    });
+
+    it("d6: missing sub-row + out-of-vocab sub-row SURFACES the row, not the no-data collapse", () => {
+      const live = mapOf([
+        row(
+          keyFor("d6", "agno", "beautiful-chat-pie-chart"),
+          "d6",
+          OUT_OF_VOCAB,
+        ),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "beautiful-chat"));
+      expect(model.d6!.exists).toBe(true);
+      expect(model.d6!.row).not.toBeNull();
+      expect(model.d6!.row?.key).toBe("d6:agno/beautiful-chat-pie-chart");
+    });
+
+    it("d5: missing sub-row + green fold still collapses to no-data (strict handling preserved)", () => {
+      // The rank guard must NOT weaken the strict missing-sub-row rule: a
+      // present green fold with a missing sibling stays no-data.
+      const live = mapOf([
+        row(keyFor("d5", "agno", "beautiful-chat-toggle-theme"), "d5", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "beautiful-chat"));
+      expect(model.d5!.exists).toBe(true);
+      expect(model.d5!.status).toBeNull();
+      expect(model.d5!.row).toBeNull();
+    });
+  });
+
   // ── CHARACTERIZATION: buildCellModel does NOT read health:/agent: rows ──
   // resolveD3 credits D3 from the `e2e:<slug>/<feature>` row ALONE. The
   // implicit "D1/D2 gate" (a failing liveness probe drags e2e down) is a

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -1651,6 +1651,27 @@ describe("buildCellModel", () => {
         expect(model.chipColor).toBe("green");
       });
 
+      it("a reclaimed-pending comm error must NOT mask an AMBER (partial-failure) chip — amber passes through", () => {
+        // D5 green + D6 red → chipColor amber (partial failure / degraded
+        // ladder). Amber is a GENUINE failure colour, not no-data: the
+        // neutral "pending" overlay masking it would hide a real partial
+        // regression behind a benign gray surface (the same never-mask rule
+        // the red passthrough enforces — mirrors the harness
+        // fleetSurfaceState, where only green becomes "pending").
+        const live = mapOf([
+          row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+          row(keyFor("d6", "agno", "agentic-chat"), "d6", "red", {
+            signal: reclaimSignal,
+          }),
+        ]);
+        const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+        expect(model.chipColor).toBe("amber");
+        expect(model.surfaceState).toBe("amber");
+        expect(model.surfaceState).not.toBe("pending");
+        // The comm error is still decoded (for the tooltip).
+        expect(model.commError?.kind).toBe("worker-reclaimed-pending");
+      });
+
       it("a crash (worker-crashed-mid-job) still surfaces red 'unreachable' — only reclaim is neutralized", () => {
         const live = mapOf([
           row(keyFor("d6", "agno", "agentic-chat"), "d6", "green", {

--- a/showcase/shell-dashboard/src/lib/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.test.ts
@@ -129,6 +129,45 @@ describe("buildCellModel — comm-error overlay precedence", () => {
     expect(model.surfaceState).toBe("unreachable");
   });
 
+  it("G2f: a green tools row with the chat row MISSING does not credit D4 (chat is unconditionally expected)", () => {
+    // The D4 producer ALWAYS writes `chat:<slug>` (the L3 round-trip) and
+    // writes `tools:<slug>` only for integrations whose demos include
+    // tool-rendering. A tools-only fold therefore means the unconditional
+    // chat row is missing — an unverified family that must NOT be credited
+    // green (mirrors the D5/D6 missing-mapped-sub-row collapse).
+    const live: LiveStatusMap = new Map();
+    live.set(keyFor("tools", SLUG), row(keyFor("tools", SLUG), "green"));
+
+    const model = buildCellModel(live, WIRED, NOW);
+
+    expect(model.d4?.exists).toBe(true);
+    expect(model.d4?.status).toBeNull();
+    expect(model.d4?.row).toBeNull();
+  });
+
+  it("G2f: a RED tools row still surfaces even when the chat row is missing (red dominates no-data)", () => {
+    const live: LiveStatusMap = new Map();
+    live.set(keyFor("tools", SLUG), row(keyFor("tools", SLUG), "red"));
+
+    const model = buildCellModel(live, WIRED, NOW);
+
+    expect(model.d4?.status).toBe("red");
+    expect(model.d4?.row?.key).toBe(keyFor("tools", SLUG));
+  });
+
+  it("G2f: a green chat row with tools missing keeps crediting D4 (tools is producer-conditional)", () => {
+    // tools:<slug> legitimately doesn't exist for integrations without the
+    // tool-rendering demo, and the dashboard has no per-integration demo
+    // mapping to distinguish "not expected" from "not yet emitted" — so a
+    // missing tools row stays lenient (documented on resolveD4).
+    const live: LiveStatusMap = new Map();
+    live.set(keyFor("chat", SLUG), row(keyFor("chat", SLUG), "green"));
+
+    const model = buildCellModel(live, WIRED, NOW);
+
+    expect(model.d4?.status).toBe("green");
+  });
+
   it("FF7: an unparseable observedAt is treated as stale (no phantom overlay)", () => {
     const live: LiveStatusMap = new Map();
     live.set(

--- a/showcase/shell-dashboard/src/lib/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.test.ts
@@ -185,4 +185,48 @@ describe("buildCellModel — comm-error overlay precedence", () => {
     expect(model.commError).toBeUndefined();
     expect(model.surfaceState).not.toBe("unreachable");
   });
+
+  it("CF7-F3 #4: a FUTURE-dated observedAt beyond skew tolerance is treated as stale (cannot pin the overlay)", () => {
+    // Clock skew / a corrupt producer timestamp: with observedAt ahead of
+    // `now`, `now - parsed > staleAfterMs` is NEVER true, so the staleness
+    // gate could never age the comm error out — the unreachable/pending
+    // overlay would be pinned indefinitely. A timestamp more than the skew
+    // tolerance (5min) in the future is as untrustworthy as an unparseable
+    // one and must be skipped the same way.
+    const live: LiveStatusMap = new Map();
+    live.set(
+      keyFor("e2e", SLUG, FEATURE),
+      row(keyFor("e2e", SLUG, FEATURE), "green", {
+        signal: commErrorSignal({
+          kind: "worker-unreachable",
+          // 1h ahead of NOW — far beyond any plausible clock skew.
+          observedAt: "2026-06-04T13:00:00.000Z",
+        }),
+      }),
+    );
+
+    const model = buildCellModel(live, WIRED, NOW);
+
+    expect(model.commError).toBeUndefined();
+    expect(model.surfaceState).not.toBe("unreachable");
+  });
+
+  it("CF7-F3 #4: a slightly-future observedAt WITHIN skew tolerance still surfaces (minor skew is normal)", () => {
+    const live: LiveStatusMap = new Map();
+    live.set(
+      keyFor("e2e", SLUG, FEATURE),
+      row(keyFor("e2e", SLUG, FEATURE), "green", {
+        signal: commErrorSignal({
+          kind: "worker-unreachable",
+          // 1min ahead of NOW — ordinary producer/browser clock skew.
+          observedAt: "2026-06-04T12:01:00.000Z",
+        }),
+      }),
+    );
+
+    const model = buildCellModel(live, WIRED, NOW);
+
+    expect(model.commError?.kind).toBe("worker-unreachable");
+    expect(model.surfaceState).toBe("unreachable");
+  });
 });

--- a/showcase/shell-dashboard/src/lib/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.test.ts
@@ -37,10 +37,14 @@ function row(
   opts: { signal?: unknown; observedAt?: string } = {},
 ): StatusRow {
   const observed = opts.observedAt ?? "2026-06-04T11:59:30.000Z";
+  // Destructure-with-fallback — assertion-free and matches the helper in
+  // __tests__/cell-model.test.ts (and stays valid if
+  // `noUncheckedIndexedAccess` is ever enabled).
+  const [dimension = ""] = key.split(":");
   return {
     id: key,
     key,
-    dimension: key.split(":")[0],
+    dimension,
     state,
     signal: opts.signal ?? null,
     observed_at: observed,

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -825,8 +825,8 @@ export function buildCellModel(
   // NOTE: D1/D2 (liveness) failure causes D3 (e2e-demos) to also fail, so
   // checking d3.status implicitly covers the D1/D2 gate.
   //
-  // Decision table over (d1d4GateFails, d4 no-data, d5.exists, d5.status,
-  // d6.status):
+  // Decision table over (d1d4GateFails, d4 no-data, D3/D4 absent, d5.exists,
+  // d5.status, d6.status):
   //   gate fails                                  → red  (gate dominates)
   //   D4 null (unverified family) + D5/D6 red     → red  (red dominates
   //                                                 no-data)
@@ -834,6 +834,15 @@ export function buildCellModel(
   //                                                 missing-chat collapse,
   //                                                 mirroring D5/D6's
   //                                                 anyMissing gray)
+  //   D3+D4 BOTH absent + D5/D6 red               → red  (red dominates
+  //                                                 no-data)
+  //   D3+D4 BOTH absent otherwise                 → gray (unverified — green
+  //                                                 is the strict reward for
+  //                                                 an INTACT ladder, and an
+  //                                                 ABSENT lower ladder can
+  //                                                 never be weaker evidence
+  //                                                 than a present-but-null
+  //                                                 one; see CF7-F3 #2)
   //   D5 unmapped (!d5.exists)                    → gray (ceiling is D4; D6
   //                                                 shares CATALOG_TO_D5_KEY,
   //                                                 so it is unmapped too)
@@ -855,15 +864,23 @@ export function buildCellModel(
   // Present-but-null D4: the unconditional chat row is missing, so the
   // real-time family is UNVERIFIED — the documented no-data outcome.
   const d4NoData = d4.exists && d4.status === null;
+  // ABSENT D1-D4 family (CF7-F3 #2): neither the D3 (e2e) row nor ANY D4
+  // (chat/tools) row exists, so the ladder below D5 is wholly unverified. The
+  // gate above can't catch this — it fires only on `exists` — so without this
+  // predicate a cell with ONLY green D5/D6 rows rendered a green chip (and a
+  // green d6Effective) at achievedDepth=0, a false top-of-ladder claim. Same
+  // strictness family as `d4NoData`: absence is no-data, never credit.
+  const d1d4Absent = !d3.exists && !d4.exists;
 
   let chipColor: ChipColor;
   if (d1d4GateFails) {
     // A failing/stale D1-D4 gate dominates everything below it.
     chipColor = "red";
-  } else if (d4NoData) {
-    // Unverified D4 family → no-data gray, exactly like the D5/D6 anyMissing
-    // collapse. A present red ABOVE it (D5/D6) still surfaces — red dominates
-    // no-data, mirroring the `D5 null + D6 red → red` row below.
+  } else if (d4NoData || d1d4Absent) {
+    // Unverified D4 family (missing-chat collapse) OR a wholly ABSENT D3/D4
+    // family → no-data gray, exactly like the D5/D6 anyMissing collapse. A
+    // present red ABOVE it (D5/D6) still surfaces — red dominates no-data,
+    // mirroring the `D5 null + D6 red → red` row below.
     chipColor = d5.status === "red" || d6.status === "red" ? "red" : "gray";
   } else if (!d5.exists) {
     // D5 is not mapped for this feature → ceiling is D4. resolveD5 and
@@ -897,6 +914,9 @@ export function buildCellModel(
   //   D4 no-data (status null)→ null (ladder UNVERIFIED at D4 — the
   //                             missing-chat collapse; same blocked outcome
   //                             as a failing gate, but the chip shows gray)
+  //   D3+D4 BOTH absent       → null (ladder UNVERIFIED below D5 by ABSENCE —
+  //                             the CF7-F3 #2 collapse; same blocked outcome
+  //                             as the D4 no-data collapse)
   //   D5 not mapped (!exists) → raw d6.status (no D5 rung to gate against;
   //                             D6 shares CATALOG_TO_D5_KEY so it is unmapped
   //                             too and the raw status is null today — the
@@ -908,7 +928,7 @@ export function buildCellModel(
   //                             green and never a false red — the CV badge
   //                             already shows the real lower-rung failure)
   let d6Effective: TestStatus;
-  if (d1d4GateFails || d4NoData) {
+  if (d1d4GateFails || d4NoData || d1d4Absent) {
     d6Effective = null;
   } else if (!d5.exists) {
     d6Effective = d6.status;

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -28,8 +28,8 @@ import {
 } from "./staleness";
 
 // Re-export the staleness windows so existing consumers that import them from
-// this module (e.g. `cell-model.test.ts`) keep resolving — the canonical
-// definitions now live in `./staleness`.
+// this module (e.g. `__tests__/cell-model.test.ts`) keep resolving — the
+// canonical definitions now live in `./staleness`.
 export {
   E2E_STALE_AFTER_MS,
   D4_STALE_AFTER_MS,

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -19,7 +19,12 @@ import {
   CATALOG_TO_D5_KEY,
   commErrorFromStatusSignal,
 } from "./live-status";
-import { E2E_STALE_AFTER_MS, D4_STALE_AFTER_MS, isStale } from "./staleness";
+import {
+  E2E_STALE_AFTER_MS,
+  D4_STALE_AFTER_MS,
+  LIVENESS_STALE_AFTER_MS,
+  isStale,
+} from "./staleness";
 
 // Re-export the staleness windows so existing consumers that import them from
 // this module (e.g. `cell-model.test.ts`) keep resolving — the canonical
@@ -62,9 +67,11 @@ export interface CellModel {
    *
    * D5-UNMAPPED EXCEPTION (`!d5.exists`): when D5 is not mapped for this feature
    * there is no D5 rung to gate against, so the raw `d6.status` passes through
-   * unchanged (a present failing D6 still surfaces — this mirrors the chip's
-   * `!d5.exists` branch, which goes red on a non-green D6). Only a PRESENT but
-   * non-green / no-data D5 collapses D6 to `null`.
+   * unchanged. Because D5 and D6 share the same `CATALOG_TO_D5_KEY` mapping,
+   * `!d5.exists` implies `!d6.exists` and the raw status is always `null`
+   * today — the passthrough only becomes observable if the two dimensions
+   * ever split onto separate maps. Only a PRESENT but non-green / no-data D5
+   * collapses D6 to `null`.
    *
    * Derived from the SAME contiguous-ladder algorithm as `chipColor` so the
    * badge, the stat, and the chip never disagree. When the ladder is intact
@@ -521,12 +528,16 @@ function chipColorToSurface(color: ChipColor): FleetSurfaceState {
  * control-plane mirrors a `PoolCommError` onto the `d6:<slug>` aggregate row but
  * NOTHING clears that blob on recovery — recovery just writes fresh green
  * per-cell rows. Without an age cap a single comm error would pin every cell of
- * the service to "unreachable" forever, even after the pool recovers. So a
- * decoded comm error whose `observedAt` is older than `E2E_STALE_AFTER_MS` (the
- * same window resolveD3/D5/D6 apply to stale-green rows; the comm error rides the
- * e2e-cadence d6 aggregate) is treated as recovered and skipped — exactly mirror-
- * ing the resolveDx stale-green downgrade. `now` is threaded in the same way
- * buildCellModel passes it to the resolveDx resolvers.
+ * the service to "unreachable" forever, even after the pool recovers. The
+ * window is scoped PER ROW FAMILY, mirroring the window each family's own
+ * resolver applies to stale-green rows: e2e-cadence rows (`d6`/`d5`/`e2e` and
+ * the fleet-family aggregates) use `E2E_STALE_AFTER_MS`, the D4 real-time rows
+ * (`chat`/`tools`) use `D4_STALE_AFTER_MS`, and the liveness row (`health`)
+ * uses `LIVENESS_STALE_AFTER_MS` — a liveness-cadence row must not carry a
+ * comm error for 6h when its own colour would have gone stale after 45m. A
+ * comm error older than its row's window is treated as recovered and skipped,
+ * exactly mirroring the resolveDx stale-green downgrade. `now` is threaded in
+ * the same way buildCellModel passes it to the resolveDx resolvers.
  *
  * SCOPE NOTE: this intentionally scans the integration-scoped aggregate
  * (`d6:<slug>`) and the chat/tools/health rows in addition to the cell's own
@@ -543,13 +554,22 @@ function decodeCellCommError(
   featureId: string,
   now: number,
 ): PoolCommError | undefined {
-  // Per-cell D6/D5 rows fan out over the mapped featureType family.
+  // Per-cell D6/D5 rows fan out over the mapped featureType family. Each
+  // candidate carries the staleness window of ITS row family (see the
+  // STALENESS WINDOW doc above) so a liveness-cadence row's comm error ages
+  // out on the liveness window, not the 6h e2e window.
   const familyKeys = CATALOG_TO_D5_KEY[featureId];
-  const candidateKeys: string[] = [];
+  const candidates: Array<{ key: string; staleAfterMs: number }> = [];
   if (familyKeys) {
     for (const ft of familyKeys) {
-      candidateKeys.push(keyFor("d6", slug, ft));
-      candidateKeys.push(keyFor("d5", slug, ft));
+      candidates.push({
+        key: keyFor("d6", slug, ft),
+        staleAfterMs: E2E_STALE_AFTER_MS,
+      });
+      candidates.push({
+        key: keyFor("d5", slug, ft),
+        staleAfterMs: E2E_STALE_AFTER_MS,
+      });
     }
   }
   // The d6 AGGREGATE row (`d6:<slug>`, no featureId) is where BOTH harness
@@ -560,11 +580,26 @@ function decodeCellCommError(
   // dashboard never surfaces the "unreachable" overlay even though the signal
   // is persisted. Checked alongside the per-cell rows so a worker-death comm
   // error lights up every cell of the affected service.
-  candidateKeys.push(keyFor("d6", slug));
-  candidateKeys.push(keyFor("e2e", slug, featureId));
-  candidateKeys.push(keyFor("chat", slug));
-  candidateKeys.push(keyFor("tools", slug));
-  candidateKeys.push(keyFor("health", slug));
+  candidates.push({
+    key: keyFor("d6", slug),
+    staleAfterMs: E2E_STALE_AFTER_MS,
+  });
+  candidates.push({
+    key: keyFor("e2e", slug, featureId),
+    staleAfterMs: E2E_STALE_AFTER_MS,
+  });
+  candidates.push({
+    key: keyFor("chat", slug),
+    staleAfterMs: D4_STALE_AFTER_MS,
+  });
+  candidates.push({
+    key: keyFor("tools", slug),
+    staleAfterMs: D4_STALE_AFTER_MS,
+  });
+  candidates.push({
+    key: keyFor("health", slug),
+    staleAfterMs: LIVENESS_STALE_AFTER_MS,
+  });
 
   // Decode every candidate and keep the WORST comm error, ranking by KIND
   // SEVERITY first and using recency only as a same-severity tie-break. A
@@ -580,7 +615,7 @@ function decodeCellCommError(
   let winner: PoolCommError | undefined;
   let winnerSeverity = Number.NEGATIVE_INFINITY;
   let winnerTs = Number.NEGATIVE_INFINITY;
-  for (const key of candidateKeys) {
+  for (const { key, staleAfterMs } of candidates) {
     const row = live.get(key);
     if (!row) continue;
     const commError = commErrorFromStatusSignal(row.signal);
@@ -588,13 +623,14 @@ function decodeCellCommError(
     // `observedAt` is an ISO string; `Date.parse` yields NaN for a malformed
     // value.
     const parsed = Date.parse(commError.observedAt);
-    // STALENESS GATE: a comm error older than the staleness window is treated
-    // as recovered and skipped — nothing clears the mirrored blob on recovery,
-    // so without this the cell would render "unreachable" forever. Mirrors the
-    // resolveDx stale-green downgrade. An UNPARSEABLE `observedAt` (NaN) is
-    // treated as stale too: it can never be cleared on recovery (its age is
-    // undefined), so surfacing it would strand a permanent phantom overlay.
-    if (Number.isNaN(parsed) || now - parsed > E2E_STALE_AFTER_MS) {
+    // STALENESS GATE: a comm error older than its row family's staleness
+    // window is treated as recovered and skipped — nothing clears the
+    // mirrored blob on recovery, so without this the cell would render
+    // "unreachable" forever. Mirrors the resolveDx stale-green downgrade. An
+    // UNPARSEABLE `observedAt` (NaN) is treated as stale too: it can never be
+    // cleared on recovery (its age is undefined), so surfacing it would
+    // strand a permanent phantom overlay.
+    if (Number.isNaN(parsed) || now - parsed > staleAfterMs) {
       continue;
     }
     // Severity tier: directly-observed crash kinds (everything except the
@@ -617,9 +653,16 @@ function decodeCellCommError(
 // Public API
 // ---------------------------------------------------------------------------
 
-const NOT_WIRED_LEVEL: TestLevel = { exists: false, status: null, row: null };
+// Module-level singletons returned BY REFERENCE to every caller — frozen so
+// one consumer mutating its "own" cell model cannot corrupt every other
+// unsupported/not-wired cell sharing the reference.
+const NOT_WIRED_LEVEL: TestLevel = Object.freeze({
+  exists: false,
+  status: null,
+  row: null,
+});
 
-const UNSUPPORTED: CellModel = {
+const UNSUPPORTED: CellModel = Object.freeze({
   supported: false,
   d3: null,
   d4: null,
@@ -631,7 +674,7 @@ const UNSUPPORTED: CellModel = {
   chipColor: "gray",
   isRegression: false,
   surfaceState: "gray",
-};
+});
 
 /**
  * Build the complete cell model for a single (integration, feature) pair.
@@ -715,7 +758,9 @@ export function buildCellModel(
   //
   // Decision table over (d1d4GateFails, d5.exists, d5.status, d6.status):
   //   gate fails                                  → red  (gate dominates)
-  //   D5 unmapped (!d5.exists), no D6             → gray (ceiling is D4)
+  //   D5 unmapped (!d5.exists)                    → gray (ceiling is D4; D6
+  //                                                 shares CATALOG_TO_D5_KEY,
+  //                                                 so it is unmapped too)
   //   D5 green + D6 green                         → green
   //   D5 green + D6 red/amber/missing             → amber
   //   D5 red/amber + (any D6)                     → red  (broken ladder)
@@ -730,12 +775,14 @@ export function buildCellModel(
     // A failing/stale D1-D4 gate dominates everything below it.
     chipColor = "red";
   } else if (!d5.exists) {
-    // D5 is not mapped for this feature → ceiling is D4 and D6 is not its
-    // gate. Green requires a contiguous D5, so an unmapped D5 never paints
-    // green. With the gate passing this resolves to gray (cell sits at its
-    // D4 ceiling with no further verification), unless a present D6 row is
-    // explicitly failing — which still surfaces as red.
-    chipColor = d6.exists && d6.status !== "green" ? "red" : "gray";
+    // D5 is not mapped for this feature → ceiling is D4. resolveD5 and
+    // resolveD6 derive `exists` from the SAME `CATALOG_TO_D5_KEY` entry, so
+    // `!d5.exists` IMPLIES `!d6.exists` — there is no "unmapped D5 but
+    // present D6" combination to consider. Green requires a contiguous D5,
+    // so the cell sits at its D4 ceiling with no further verification: gray.
+    // (Should the two dimensions ever split onto separate maps, a present
+    // failing D6 here would need to surface — re-introduce a D6 check then.)
+    chipColor = "gray";
   } else if (d5.status === "green") {
     // Mapped D5 is green → ladder intact up to D5. D6 decides green vs amber.
     chipColor = d6.status === "green" ? "green" : "amber";
@@ -756,10 +803,10 @@ export function buildCellModel(
   // ladder predicates the chip uses above (`d1d4GateFails`, `d5.status`) so the
   // badge/stat never contradict the chip:
   //   gate fails              → null (blocked; API/RT badge shows the failure)
-  //   D5 not mapped (!exists) → raw d6.status (D6 is not D5's gate here; a
-  //                             present failing D6 still surfaces — matches the
-  //                             chip's `!d5.exists` branch which goes red on a
-  //                             non-green D6)
+  //   D5 not mapped (!exists) → raw d6.status (no D5 rung to gate against;
+  //                             D6 shares CATALOG_TO_D5_KEY so it is unmapped
+  //                             too and the raw status is null today — the
+  //                             passthrough matters only if the maps split)
   //   D5 green                → raw d6.status (ladder intact through D5; a
   //                             genuine D6 red/amber/green passes through)
   //   D5 red/amber/null       → null (ladder BROKEN/unverified below D6 → the

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -483,10 +483,12 @@ function resolveD6(
 }
 
 /**
- * Map a derived `ChipColor` onto the presentation surface state. `FleetSurfaceState`
- * is `ChipColor | "unreachable"`, so every chip colour passes straight through;
- * the `"unreachable"` overlay is applied separately by the caller when a comm
- * error is present. Pure; no widening cast needed.
+ * Map a derived `ChipColor` onto the presentation surface state.
+ * `FleetSurfaceState` is `ChipColor | "unreachable" | "pending"`, so every
+ * chip colour passes straight through; the `"unreachable"` and `"pending"`
+ * overlay members are applied separately by the caller when a comm error is
+ * present (see the `surfaceState` derivation in `buildCellModel`). Pure; no
+ * widening cast needed.
  */
 function chipColorToSurface(color: ChipColor): FleetSurfaceState {
   return color;
@@ -833,11 +835,21 @@ export function buildCellModel(
         // cell's real probe result is healthy (green) or no-data (gray) and not
         // a regression. ANY failure colour — red OR amber (partial failure /
         // degraded ladder) — or a regression below the ceiling is a GENUINE
-        // failure that the neutral pending overlay must NOT mask (mirrors the
-        // harness fleetSurfaceState: only green becomes "pending"; every
-        // non-green failure state passes through) — otherwise DepthChip's
-        // "pending" early-return would hide a real failure. The failure colour
-        // wins; routine teardown (green/gray) still shows gray.
+        // failure that the neutral pending overlay must NOT mask — otherwise
+        // DepthChip's "pending" early-return would hide a real failure. The
+        // failure colour wins; routine teardown (green/gray) still shows gray.
+        //
+        // DELIBERATE ASYMMETRY vs the harness `fleetSurfaceState` gate: the
+        // harness derives over `ProbeState`, which has NO no-data colour, so
+        // its gate is green-only ("green becomes pending, everything else
+        // passes through"). The dashboard derives over `ChipColor`, whose
+        // `gray` is the dashboard-only no-data colour the harness cannot
+        // represent — and a no-data cell awaiting a re-queued job IS pending,
+        // so gray ALSO becomes "pending" here. Both sides agree on the
+        // never-mask rule: red / amber (degraded) / error-derived states /
+        // regression always pass through; ONLY the healthy-or-no-data cases
+        // become "pending". Pinned by the surface-state drift suite in
+        // commError-contract-drift.test.ts.
         chipColor === "red" || chipColor === "amber" || isRegression
         ? chipColorToSurface(chipColor)
         : "pending"

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -198,6 +198,22 @@ function foldStateToTestStatus(state: State): TestStatus {
  * D4 checks both `chat:<slug>` and `tools:<slug>`. When both exist the
  * worst-state wins — a green chat + red tools yields red D4, not green.
  *
+ * EXPECTATION MAPPING (which rows MUST exist — driven by the producer,
+ * `d4-chat-roundtrip.ts`):
+ *   - `chat:<slug>` is UNCONDITIONAL: the driver writes the L3 chat
+ *     round-trip row for every probed integration. A green tools row with
+ *     the chat row MISSING is therefore an unverified family — it collapses
+ *     a green/degraded fold to `status: null` (no-data), mirroring the
+ *     D5/D6 missing-mapped-sub-row strictness. A present RED tools row
+ *     still surfaces (red dominates no-data).
+ *   - `tools:<slug>` is CONDITIONAL: the driver side-emits it only when the
+ *     integration's demos include `tool-rendering`, so its absence is
+ *     legitimate for tool-less integrations. The dashboard has no
+ *     per-integration demo mapping to distinguish "not expected" from "not
+ *     yet emitted", so a missing tools row stays LENIENT (chat alone can
+ *     credit D4) — the safe default given the producer mapping lives
+ *     harness-side.
+ *
  * Staleness applies the same downgrade as `resolveD3`, but PER ROW and
  * BEFORE the worst-state fold (mirroring `resolveD5`): a green chat/tools
  * row whose `observed_at` is older than `D4_STALE_AFTER_MS` is treated as
@@ -242,6 +258,17 @@ function resolveD4(live: LiveStatusMap, slug: string, now: number): TestLevel {
   if (!winner || worstState === null) {
     // Both rows present-checked above, so this is unreachable in practice;
     // guard anyway instead of asserting (mirrors resolveD5/resolveD6).
+    return { exists: true, status: null, row: null };
+  }
+
+  // STRICT on the UNCONDITIONAL row: a missing `chat:<slug>` (the row the
+  // producer always writes) makes the family unverified — collapse a present
+  // green/degraded fold to no-data, exactly like the D5/D6 anyMissing
+  // collapse. RANK-based, not red-literal equality, so an out-of-vocabulary
+  // state (ranked above red by the A2 machinery) still surfaces. The
+  // conditional `tools:` row is deliberately NOT held to this (see the
+  // expectation mapping in the doc above).
+  if (!chatRow && rankOfState(worstState) < STATE_RANK.red) {
     return { exists: true, status: null, row: null };
   }
 
@@ -524,8 +551,9 @@ function chipColorToSurface(color: ChipColor): FleetSurfaceState {
  * an OLDER real crash. So we decode EVERY candidate row and return the
  * highest-SEVERITY comm error, using the most recent `observedAt` only to break
  * ties WITHIN a severity tier and falling back to scan order when timestamps are
- * equal/absent (stable tie-break). Returns `undefined` when no candidate row
- * carries a comm error (pool reachable).
+ * equal (stable tie-break; an UNPARSEABLE `observedAt` never reaches the
+ * tie-break — the staleness gate below skips it first). Returns `undefined`
+ * when no candidate row carries a comm error (pool reachable).
  *
  * STALENESS WINDOW: a comm error is only surfaced while it is RECENT. The
  * control-plane mirrors a `PoolCommError` onto the `d6:<slug>` aggregate row but
@@ -635,8 +663,9 @@ function decodeCellCommError(
   // a routine teardown. So a NEWER reclaim must NOT out-rank an OLDER real
   // crash — severity is the primary winner key, recency only the tie-break
   // WITHIN a tier. Within the same tier a later candidate wins only when its
-  // `observedAt` is strictly newer, so for equal/absent timestamps the
-  // first-in-scan-order error is retained (stable tie-break).
+  // `observedAt` is strictly newer, so for equal timestamps the
+  // first-in-scan-order error is retained (stable tie-break). An unparseable
+  // `observedAt` never reaches the tie-break: the staleness gate skips it.
   let winner: PoolCommError | undefined;
   let winnerSeverity = Number.NEGATIVE_INFINITY;
   let winnerTs = Number.NEGATIVE_INFINITY;

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -103,12 +103,14 @@ export interface CellModel {
    *   - `"unreachable"` — a `commError` of a directly-observed crash kind
    *     (`worker-crashed-mid-job`, `worker-unreachable`, …) is present: paint
    *     the red comm-error overlay.
-   *   - `"pending"` — a NON-RED `worker-reclaimed-pending` commError is present:
-   *     a lease lapsed and the job was re-queued (routine teardown, not a known
-   *     crash), so render the neutral gray "pending" surface.
+   *   - `"pending"` — a `worker-reclaimed-pending` commError is present on a
+   *     healthy/no-data (green/gray, non-regressed) cell: a lease lapsed and
+   *     the job was re-queued (routine teardown, not a known crash), so render
+   *     the neutral gray "pending" surface.
    *   - the cell's underlying probe colour (mapped from `chipColor`) — no
    *     commError, OR a `worker-reclaimed-pending` commError that must NOT mask
-   *     a red/regressed probe result (the genuine failure passes through).
+   *     a red/amber/regressed probe result (any genuine failure passes
+   *     through; only green/gray becomes "pending").
    */
   surfaceState: FleetSurfaceState;
 }
@@ -792,12 +794,15 @@ export function buildCellModel(
   const surfaceState: FleetSurfaceState = commError
     ? commError.kind === "worker-reclaimed-pending"
       ? // A reclaimed-pending overlay is NEUTRAL (gray "pending") ONLY when the
-        // cell's real probe result isn't itself red/regressed. A present red
-        // (or a regression below the ceiling) is a GENUINE failure that the
-        // neutral pending overlay must NOT mask — otherwise DepthChip's
-        // "pending" early-return would hide a real red. The red probe result
-        // wins; routine teardown (non-red) still shows gray.
-        chipColor === "red" || isRegression
+        // cell's real probe result is healthy (green) or no-data (gray) and not
+        // a regression. ANY failure colour — red OR amber (partial failure /
+        // degraded ladder) — or a regression below the ceiling is a GENUINE
+        // failure that the neutral pending overlay must NOT mask (mirrors the
+        // harness fleetSurfaceState: only green becomes "pending"; every
+        // non-green failure state passes through) — otherwise DepthChip's
+        // "pending" early-return would hide a real failure. The failure colour
+        // wins; routine teardown (green/gray) still shows gray.
+        chipColor === "red" || chipColor === "amber" || isRegression
         ? chipColorToSurface(chipColor)
         : "pending"
       : "unreachable"

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -590,6 +590,19 @@ function chipColorToSurface(color: ChipColor): FleetSurfaceState {
  * can't be reached cannot have produced any per-cell result), not a leak from "a
  * row the cell doesn't show".
  */
+/**
+ * Maximum tolerated FUTURE skew on a comm error's `observedAt` (CF7-F3 #4).
+ * The staleness gate in `decodeCellCommError` compares `now - parsed >
+ * staleAfterMs`, which is NEVER true for a future-dated timestamp — so clock
+ * skew (or a corrupt producer timestamp) would pin the unreachable/pending
+ * overlay indefinitely, exactly the permanent-phantom failure mode the
+ * unparseable-`observedAt` skip (FF7) exists to prevent. A timestamp more
+ * than this far ahead of `now` is as untrustworthy as an unparseable one and
+ * is treated the same way (stale → skipped); skew WITHIN the tolerance is
+ * ordinary clock drift and still surfaces.
+ */
+const COMM_ERROR_FUTURE_SKEW_TOLERANCE_MS = 5 * 60 * 1000;
+
 function decodeCellCommError(
   live: LiveStatusMap,
   slug: string,
@@ -698,8 +711,15 @@ function decodeCellCommError(
     // "unreachable" forever. Mirrors the resolveDx stale-green downgrade. An
     // UNPARSEABLE `observedAt` (NaN) is treated as stale too: it can never be
     // cleared on recovery (its age is undefined), so surfacing it would
-    // strand a permanent phantom overlay.
-    if (Number.isNaN(parsed) || now - parsed > staleAfterMs) {
+    // strand a permanent phantom overlay. A FUTURE-dated `observedAt` beyond
+    // the skew tolerance gets the same treatment (CF7-F3 #4): `now - parsed`
+    // is negative so the age check can never expire it — clock skew would pin
+    // the overlay indefinitely, the same permanent-phantom failure mode.
+    if (
+      Number.isNaN(parsed) ||
+      parsed - now > COMM_ERROR_FUTURE_SKEW_TOLERANCE_MS ||
+      now - parsed > staleAfterMs
+    ) {
       continue;
     }
     // Severity tier: directly-observed crash kinds (everything except the

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -183,10 +183,16 @@ function rankOfState(state: string): number {
  * for the same row. Map it to "red" (the failing status) so an unrecognized
  * state can never present as no-data on D5/D6.
  *
- * D3/D4 keep the base `stateToTestStatus` mapping: their `null` is rescued by
- * the chip's D1-D4 gate check (`exists && status !== "green"` → gate fails →
- * red), so an unknown state can never present as healthy there — see the
- * decision table in `buildCellModel`.
+ * D4 ALSO uses this mapping: its missing-chat collapse resolves to `status:
+ * null` (no-data — see `resolveD4`), so the chip's D1-D4 gate treats a null
+ * D4 as UNVERIFIED (gray), not failed. An out-of-vocabulary D4 state must
+ * therefore map to "red" HERE — it can no longer ride the gate's
+ * `!== "green"` catch-all without also painting the no-data collapse red.
+ *
+ * D3 keeps the base `stateToTestStatus` mapping: a present D3 row never
+ * resolves to `null` except for an out-of-vocabulary state, which the chip's
+ * D1-D4 gate check (`exists && status !== "green"` → gate fails → red) still
+ * rescues — see the decision table in `buildCellModel`.
  */
 function foldStateToTestStatus(state: State): TestStatus {
   return stateToTestStatus(state) ?? "red";
@@ -274,7 +280,11 @@ function resolveD4(live: LiveStatusMap, slug: string, now: number): TestLevel {
 
   return {
     exists: true,
-    status: stateToTestStatus(worstState),
+    // foldStateToTestStatus (not the base stateToTestStatus): D4's `null` now
+    // means NO-DATA to the chip's gate (the missing-chat collapse above), so
+    // an out-of-vocabulary fold winner must map to "red" here instead of
+    // relying on the gate's `!== "green"` catch-all — mirrors resolveD5/D6.
+    status: foldStateToTestStatus(worstState),
     row: winner,
   };
 }
@@ -810,8 +820,15 @@ export function buildCellModel(
   // NOTE: D1/D2 (liveness) failure causes D3 (e2e-demos) to also fail, so
   // checking d3.status implicitly covers the D1/D2 gate.
   //
-  // Decision table over (d1d4GateFails, d5.exists, d5.status, d6.status):
+  // Decision table over (d1d4GateFails, d4 no-data, d5.exists, d5.status,
+  // d6.status):
   //   gate fails                                  → red  (gate dominates)
+  //   D4 null (unverified family) + D5/D6 red     → red  (red dominates
+  //                                                 no-data)
+  //   D4 null (unverified family) otherwise       → gray (no-data — the
+  //                                                 missing-chat collapse,
+  //                                                 mirroring D5/D6's
+  //                                                 anyMissing gray)
   //   D5 unmapped (!d5.exists)                    → gray (ceiling is D4; D6
   //                                                 shares CATALOG_TO_D5_KEY,
   //                                                 so it is unmapped too)
@@ -820,14 +837,29 @@ export function buildCellModel(
   //   D5 red/amber + (any D6)                     → red  (broken ladder)
   //   D5 null  + D6 red                           → red
   //   D5 null  + D6 green/amber/missing           → gray (unverified ladder)
+  //
+  // The D4 leg of the gate excludes `null`: a present-but-null D4 is the
+  // missing-chat NO-DATA collapse (resolveD4), which is unverified, not
+  // failed. An out-of-vocabulary D4 fold winner cannot hide behind that
+  // exclusion — resolveD4 maps it to "red" via foldStateToTestStatus. D3 has
+  // no no-data collapse, so its leg keeps the `!== "green"` catch-all (which
+  // also rescues an out-of-vocabulary D3 state mapped to null).
   const d1d4GateFails =
     (d3.exists && d3.status !== "green") ||
-    (d4.exists && d4.status !== "green");
+    (d4.exists && d4.status !== "green" && d4.status !== null);
+  // Present-but-null D4: the unconditional chat row is missing, so the
+  // real-time family is UNVERIFIED — the documented no-data outcome.
+  const d4NoData = d4.exists && d4.status === null;
 
   let chipColor: ChipColor;
   if (d1d4GateFails) {
     // A failing/stale D1-D4 gate dominates everything below it.
     chipColor = "red";
+  } else if (d4NoData) {
+    // Unverified D4 family → no-data gray, exactly like the D5/D6 anyMissing
+    // collapse. A present red ABOVE it (D5/D6) still surfaces — red dominates
+    // no-data, mirroring the `D5 null + D6 red → red` row below.
+    chipColor = d5.status === "red" || d6.status === "red" ? "red" : "gray";
   } else if (!d5.exists) {
     // D5 is not mapped for this feature → ceiling is D4. resolveD5 and
     // resolveD6 derive `exists` from the SAME `CATALOG_TO_D5_KEY` entry, so
@@ -857,6 +889,9 @@ export function buildCellModel(
   // ladder predicates the chip uses above (`d1d4GateFails`, `d5.status`) so the
   // badge/stat never contradict the chip:
   //   gate fails              → null (blocked; API/RT badge shows the failure)
+  //   D4 no-data (status null)→ null (ladder UNVERIFIED at D4 — the
+  //                             missing-chat collapse; same blocked outcome
+  //                             as a failing gate, but the chip shows gray)
   //   D5 not mapped (!exists) → raw d6.status (no D5 rung to gate against;
   //                             D6 shares CATALOG_TO_D5_KEY so it is unmapped
   //                             too and the raw status is null today — the
@@ -868,7 +903,7 @@ export function buildCellModel(
   //                             green and never a false red — the CV badge
   //                             already shows the real lower-rung failure)
   let d6Effective: TestStatus;
-  if (d1d4GateFails) {
+  if (d1d4GateFails || d4NoData) {
     d6Effective = null;
   } else if (!d5.exists) {
     d6Effective = d6.status;

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -167,6 +167,25 @@ function rankOfState(state: string): number {
 }
 
 /**
+ * Map State → TestStatus for the D5/D6 rank-fold resolvers. Differs from
+ * `stateToTestStatus` ONLY for an out-of-vocabulary runtime state (e.g.
+ * "error" — see `rankOfState`): the A2 rank fold deliberately surfaces such a
+ * state as the WORST in the family, so mapping it to `null` here would swallow
+ * the fold winner one step later — the D5/D6 chip/badge would render benign
+ * gray no-data while live-status's badge path renders the loud "error" tone
+ * for the same row. Map it to "red" (the failing status) so an unrecognized
+ * state can never present as no-data on D5/D6.
+ *
+ * D3/D4 keep the base `stateToTestStatus` mapping: their `null` is rescued by
+ * the chip's D1-D4 gate check (`exists && status !== "green"` → gate fails →
+ * red), so an unknown state can never present as healthy there — see the
+ * decision table in `buildCellModel`.
+ */
+function foldStateToTestStatus(state: State): TestStatus {
+  return stateToTestStatus(state) ?? "red";
+}
+
+/**
  * Resolve the D4 (real-time) test level for `slug`.
  *
  * D4 checks both `chat:<slug>` and `tools:<slug>`. When both exist the
@@ -318,7 +337,7 @@ function resolveD5(
 
   return {
     exists: true,
-    status: stateToTestStatus(worstState),
+    status: foldStateToTestStatus(worstState),
     row: worstRow,
   };
 }
@@ -451,7 +470,7 @@ function resolveD6(
 
   return {
     exists: true,
-    status: stateToTestStatus(worstState),
+    status: foldStateToTestStatus(worstState),
     row: worstRow,
   };
 }

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -367,7 +367,14 @@ function resolveD3(
     return { exists: false, status: null, row: null };
   }
   if (row.state === "green" && isStale(row, now, E2E_STALE_AFTER_MS)) {
-    return { exists: true, status: "amber", row };
+    // Return the EFFECTIVE (downgraded) row so `.row.state` agrees with
+    // `.status` — the same invariant resolveD4/D5/D6 maintain (mirrors
+    // `buildBadge` in live-status.ts).
+    return {
+      exists: true,
+      status: "amber",
+      row: { ...row, state: "degraded" },
+    };
   }
   return {
     exists: true,

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -504,8 +504,11 @@ function chipColorToSurface(color: ChipColor): FleetSurfaceState {
 /**
  * Decode a pool comm-error (REQ-B) for this cell by scanning the status rows
  * the cell's overlay depends on: the per-cell D6 (parity) row family, D5
- * (conversation), the D3/e2e row, the D4 (chat/tools) rows, health, AND the
- * integration-level d6 AGGREGATE row (`d6:<slug>`). The control-plane mirrors a
+ * (conversation), the D3/e2e row, the D4 (chat/tools) rows, health, the
+ * integration-level d6 AGGREGATE row (`d6:<slug>`), AND the non-d6
+ * fleet-family sweep aggregates (`d4:<slug>`, `e2e-demos:<slug>`,
+ * `d5-single-pill-e2e:<slug>` — where the global lease sweep lands comm
+ * errors for the smoke/demos/deep families). The control-plane mirrors a
  * `PoolCommError` into the row signal under `FLEET_COMM_ERROR_SIGNAL_KEY` (see
  * `commErrorFromStatusSignal`).
  *
@@ -599,6 +602,28 @@ function decodeCellCommError(
   candidates.push({
     key: keyFor("health", slug),
     staleAfterMs: LIVENESS_STALE_AFTER_MS,
+  });
+  // NON-d6 FLEET-FAMILY AGGREGATES (G3f): the global lease sweep reclaims
+  // jobs of ALL four fleet families and mirrors each comm error onto the
+  // status row keyed by the reclaimed job's `probe_key` (harness
+  // resolveSweepAggregateKey → aggregateCommError — the same path that lands
+  // on `d6:<slug>` for the d6 family). For the non-d6 families those keys are
+  // `d4:<slug>` (smoke), `e2e-demos:<slug>` (demos), and
+  // `d5-single-pill-e2e:<slug>` (deep) — see the catalog-enumerator probeKey
+  // prefixes. The dashboard reads those rows NOWHERE else, so without
+  // scanning them here a reclaim/crash overlay on those families is
+  // invisible. They ride the job-queue (e2e) cadence → e2e window.
+  candidates.push({
+    key: keyFor("d4", slug),
+    staleAfterMs: E2E_STALE_AFTER_MS,
+  });
+  candidates.push({
+    key: keyFor("e2e-demos", slug),
+    staleAfterMs: E2E_STALE_AFTER_MS,
+  });
+  candidates.push({
+    key: keyFor("d5-single-pill-e2e", slug),
+    staleAfterMs: E2E_STALE_AFTER_MS,
   });
 
   // Decode every candidate and keep the WORST comm error, ranking by KIND

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -18,6 +18,7 @@ import {
   keyFor,
   CATALOG_TO_D5_KEY,
   commErrorFromStatusSignal,
+  FLEET_COMM_AGGREGATE_DIMENSIONS,
 } from "./live-status";
 import {
   E2E_STALE_AFTER_MS,
@@ -620,7 +621,13 @@ function decodeCellCommError(
   // `probe_key` (also `d6:<slug>`). Without scanning the aggregate key here the
   // dashboard never surfaces the "unreachable" overlay even though the signal
   // is persisted. Checked alongside the per-cell rows so a worker-death comm
-  // error lights up every cell of the affected service.
+  // error lights up every cell of the affected service. NOTE: the full set of
+  // comm-error aggregate dimensions lives in FLEET_COMM_AGGREGATE_DIMENSIONS
+  // (live-status.ts) — the same list useLiveStatus's supplemental initial
+  // fetch uses to re-fetch these rows WITH `signal` (CF7-F3 #1); `d6` is
+  // pushed here (before the per-cell e2e/chat/tools/health candidates — scan
+  // order is the documented equal-timestamp tie-break and is pinned by tests)
+  // and the non-d6 trio below (G3f).
   candidates.push({
     key: keyFor("d6", slug),
     staleAfterMs: E2E_STALE_AFTER_MS,
@@ -650,19 +657,17 @@ function decodeCellCommError(
   // `d5-single-pill-e2e:<slug>` (deep) — see the catalog-enumerator probeKey
   // prefixes. The dashboard reads those rows NOWHERE else, so without
   // scanning them here a reclaim/crash overlay on those families is
-  // invisible. They ride the job-queue (e2e) cadence → e2e window.
-  candidates.push({
-    key: keyFor("d4", slug),
-    staleAfterMs: E2E_STALE_AFTER_MS,
-  });
-  candidates.push({
-    key: keyFor("e2e-demos", slug),
-    staleAfterMs: E2E_STALE_AFTER_MS,
-  });
-  candidates.push({
-    key: keyFor("d5-single-pill-e2e", slug),
-    staleAfterMs: E2E_STALE_AFTER_MS,
-  });
+  // invisible. They ride the job-queue (e2e) cadence → e2e window. Derived
+  // from FLEET_COMM_AGGREGATE_DIMENSIONS (minus `d6`, pushed earlier — see
+  // the aggregate-row note above) so this scan and useLiveStatus's
+  // supplemental signal fetch can never drift apart.
+  for (const dim of FLEET_COMM_AGGREGATE_DIMENSIONS) {
+    if (dim === "d6") continue; // pushed above, in its pinned scan position
+    candidates.push({
+      key: keyFor(dim, slug),
+      staleAfterMs: E2E_STALE_AFTER_MS,
+    });
+  }
 
   // Decode every candidate and keep the WORST comm error, ranking by KIND
   // SEVERITY first and using recency only as a same-severity tie-break. A

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -715,6 +715,15 @@ function decodeCellCommError(
     // the skew tolerance gets the same treatment (CF7-F3 #4): `now - parsed`
     // is negative so the age check can never expire it — clock skew would pin
     // the overlay indefinitely, the same permanent-phantom failure mode.
+    //
+    // KNOWN FAIL-SAFE DIVERGENCE vs `isStale` (staleness.ts, CF7-F3 #3): the
+    // shared row-level predicate treats an unparseable `observed_at` as NOT
+    // stale ("staleness must be a positive signal"), because there a false
+    // `stale` would DOWNGRADE a live green row. Here the polarity inverts: a
+    // false NOT-stale would PIN an uncleared overlay forever, so an
+    // unparseable timestamp must read as stale/skip. The two sites fail safe
+    // in OPPOSITE directions by design of their respective blast radii;
+    // `isStale` itself predates this branch and is deliberately left as-is.
     if (
       Number.isNaN(parsed) ||
       parsed - now > COMM_ERROR_FUTURE_SKEW_TOLERANCE_MS ||

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -306,8 +306,13 @@ function resolveD5(
   // family is unverified. A present RED sub-row still signals a real failure
   // (red dominates no-data), but a present green/degraded fold must NOT be
   // credited — collapse it to no-data (status: null) so achievedDepth caps
-  // below 5 and the chip renders gray, not a false-green/amber.
-  if (anyMissing && worstState !== "red") {
+  // below 5 and the chip renders gray, not a false-green/amber. RANK-based,
+  // not `!== "red"` literal equality: `worstState` is typed `State` but can
+  // hold an out-of-vocabulary runtime value (e.g. "error"), which the A2 rank
+  // machinery deliberately ranks ABOVE red — literal equality would silently
+  // swallow exactly the state the rank fold exists to surface. Mirrors
+  // resolveD5Row/resolveD6Row in live-status.ts.
+  if (anyMissing && rankOfState(worstState) < STATE_RANK.red) {
     return { exists: true, status: null, row: null };
   }
 
@@ -434,8 +439,13 @@ function resolveD6(
   // family is unverified. A present RED sub-row still signals a real failure
   // (red dominates no-data), but a present green/degraded fold must NOT be
   // credited — collapse it to no-data (status: null) so the chip renders
-  // gray/amber per the ladder, not a false-green.
-  if (anyMissing && worstState !== "red") {
+  // gray/amber per the ladder, not a false-green. RANK-based, not `!== "red"`
+  // literal equality: `worstState` is typed `State` but can hold an
+  // out-of-vocabulary runtime value (e.g. "error"), which the A2 rank
+  // machinery deliberately ranks ABOVE red — literal equality would silently
+  // swallow exactly the state the rank fold exists to surface. Mirrors
+  // resolveD5Row/resolveD6Row in live-status.ts.
+  if (anyMissing && rankOfState(worstState) < STATE_RANK.red) {
     return { exists: true, status: null, row: null };
   }
 

--- a/showcase/shell-dashboard/src/lib/commError-contract-drift.test.ts
+++ b/showcase/shell-dashboard/src/lib/commError-contract-drift.test.ts
@@ -48,10 +48,10 @@ function dashboardCellModelSource(): string {
 /**
  * Parse the string-literal members of the harness `POOL_COMM_ERROR_KINDS`
  * array. Throws if the block can't be located so a shape change is loud, not a
- * silent pass.
+ * silent pass. Accepts an injectable `src` for the parser-robustness tests;
+ * production callers read the real harness file.
  */
-function parseHarnessKinds(): string[] {
-  const src = harnessSource();
+function parseHarnessKinds(src: string = harnessSource()): string[] {
   const block = src.match(
     /POOL_COMM_ERROR_KINDS\s*=\s*\[([\s\S]+?)\]\s*as const;/,
   );
@@ -61,10 +61,15 @@ function parseHarnessKinds(): string[] {
         "harness contracts.ts — if the source shape changed, update this regex.",
     );
   }
-  // Each member is a double-quoted kind on its own line (comment lines skipped
-  // because they have no quoted token matched by this pattern at line position).
+  // Strip comment lines BEFORE matching: the quoted-token pattern below is
+  // NOT line-anchored, so a `//` or `/** … */` doc comment quoting a kind
+  // (e.g. referencing a retired `"dead-kind"`) would otherwise parse as a
+  // live member. Each remaining member is a double-quoted kind.
+  const body = block[1]
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/.*$/gm, "");
   const kinds = Array.from(
-    block[1].matchAll(/"([a-z-]+)"/g),
+    body.matchAll(/"([a-z-]+)"/g),
     (m) => m[1] as string,
   );
   if (kinds.length === 0) {
@@ -153,6 +158,24 @@ function parseCommErrorDecoder(src: string, file: string): string {
   }
   return m[0];
 }
+
+describe("drift parser robustness", () => {
+  it("parseHarnessKinds ignores kinds quoted inside comments (line and block)", () => {
+    // The quoted-token pattern is not line-anchored, so without the comment
+    // strip a doc comment referencing a retired kind would parse as a live
+    // member and silently widen the pinned kind set.
+    const synthetic = [
+      "export const POOL_COMM_ERROR_KINDS = [",
+      '  // retired: "dead-line-kind" must not parse as a member',
+      "  /**",
+      '   * docs that mention "dead-block-kind" are not members either',
+      "   */",
+      '  "real-kind",',
+      "] as const;",
+    ].join("\n");
+    expect(parseHarnessKinds(synthetic)).toEqual(["real-kind"]);
+  });
+});
 
 describe("pool comm-error contract cross-package drift", () => {
   it("dashboard POOL_COMM_ERROR_KINDS exactly equals the harness kind set", () => {

--- a/showcase/shell-dashboard/src/lib/commError-contract-drift.test.ts
+++ b/showcase/shell-dashboard/src/lib/commError-contract-drift.test.ts
@@ -221,19 +221,25 @@ describe("fleet surface-state contract cross-package drift", () => {
     );
   });
 
-  it("harness fleetSurfaceState derivation routes worker-reclaimed-pending → 'pending' with red passthrough", () => {
+  it("harness fleetSurfaceState derivation routes worker-reclaimed-pending → 'pending' ONLY on green (failure passthrough)", () => {
     // Pins the harness DERIVATION shape: the sweep-inferred reclaim kind must
     // route to the neutral "pending" surface (never the red "unreachable"
-    // overlay), and a red probe colour must pass through unmasked — the same
-    // three-outcome derivation cell-model.ts applies on the dashboard side.
+    // overlay) ONLY when the row's last-known colour is green — ANY non-green
+    // failure state (red, degraded, error, out-of-vocab) must pass through
+    // unmasked. The same only-healthy-becomes-pending derivation cell-model.ts
+    // applies on the dashboard side over its ChipColor vocabulary.
     const body = parseHarnessSurfaceDerivation();
     expect(body).toContain('"worker-reclaimed-pending"');
     expect(body).toContain('"pending"');
     expect(body).toContain('"unreachable"');
-    expect(body).toContain('"red"');
+    // The pending gate must be expressed as only-green-becomes-pending —
+    // a literal red-equality check (`=== "red"`) masks degraded/error/
+    // out-of-vocab failure states behind the neutral overlay (G3a).
+    expect(body).toContain('=== "green"');
+    expect(body).not.toContain('=== "red"');
   });
 
-  it("dashboard cell-model derivation routes worker-reclaimed-pending → 'pending' with red passthrough", () => {
+  it("dashboard cell-model derivation routes worker-reclaimed-pending → 'pending' with failure passthrough", () => {
     // Same pin on the dashboard side (behaviorally covered by the flap-band
     // #70 tests in __tests__/cell-model.test.ts; this guards the SHAPE so a
     // refactor that drops the reclaim branch reds the drift suite too).
@@ -253,5 +259,10 @@ describe("fleet surface-state contract cross-package drift", () => {
     expect(body).toContain('"worker-reclaimed-pending"');
     expect(body).toContain('"pending"');
     expect(body).toContain('"unreachable"');
+    // The dashboard's pending gate must pass through EVERY failure colour in
+    // its ChipColor vocabulary — red AND amber (degraded/partial failure) —
+    // mirroring the harness only-green-becomes-pending semantics (G3a).
+    expect(body).toContain('chipColor === "red"');
+    expect(body).toContain('chipColor === "amber"');
   });
 });

--- a/showcase/shell-dashboard/src/lib/commError-contract-drift.test.ts
+++ b/showcase/shell-dashboard/src/lib/commError-contract-drift.test.ts
@@ -290,13 +290,14 @@ describe("fleet surface-state contract cross-package drift", () => {
     expect(body).not.toContain('=== "red"');
   });
 
-  it("dashboard cell-model derivation routes worker-reclaimed-pending → 'pending' with failure passthrough", () => {
-    // Same pin on the dashboard side (behaviorally covered by the flap-band
-    // #70 tests in __tests__/cell-model.test.ts; this guards the SHAPE so a
-    // refactor that drops the reclaim branch reds the drift suite too).
-    // Match to the END OF THE STATEMENT (a `;` at end-of-line followed by a
-    // blank line) — a bare non-greedy `;` would stop at a semicolon inside the
-    // derivation's own comments.
+  /**
+   * Extract the dashboard's `surfaceState` derivation statement from
+   * cell-model.ts. Match to the END OF THE STATEMENT (a `;` at end-of-line
+   * followed by a blank line) — a bare non-greedy `;` would stop at a
+   * semicolon inside the derivation's own comments. Throws if the statement
+   * can't be located so a refactor is loud.
+   */
+  function parseDashboardSurfaceDerivation(): string {
     const m = dashboardCellModelSource().match(
       /const surfaceState: FleetSurfaceState =[\s\S]*?;\n\n/,
     );
@@ -306,7 +307,14 @@ describe("fleet surface-state contract cross-package drift", () => {
           "cell-model.ts — if the source shape changed, update this regex.",
       );
     }
-    const body = m[0];
+    return m[0];
+  }
+
+  it("dashboard cell-model derivation routes worker-reclaimed-pending → 'pending' with failure passthrough", () => {
+    // Same pin on the dashboard side (behaviorally covered by the flap-band
+    // #70 tests in __tests__/cell-model.test.ts; this guards the SHAPE so a
+    // refactor that drops the reclaim branch reds the drift suite too).
+    const body = parseDashboardSurfaceDerivation();
     expect(body).toContain('"worker-reclaimed-pending"');
     expect(body).toContain('"pending"');
     expect(body).toContain('"unreachable"');
@@ -315,5 +323,30 @@ describe("fleet surface-state contract cross-package drift", () => {
     // mirroring the harness only-green-becomes-pending semantics (G3a).
     expect(body).toContain('chipColor === "red"');
     expect(body).toContain('chipColor === "amber"');
+  });
+
+  it("the pending-gate ASYMMETRY is deliberate: harness green-only, dashboard green-or-gray (G3d)", () => {
+    // The two derivations are NOT byte-mirrors and must not be: the harness
+    // derives over `ProbeState`, which has NO no-data colour, so its pending
+    // gate is GREEN-ONLY equality. The dashboard derives over `ChipColor`,
+    // whose `gray` is a dashboard-only no-data colour the harness cannot
+    // represent — there a reclaim on a no-data cell IS pending, so the gate
+    // is expressed as FAILURE-PASSTHROUGH (red / amber / regression pass
+    // through; green AND gray become "pending"). This test pins the
+    // DERIVATION DIFFERENCE itself so neither side can silently "fix" the
+    // asymmetry into a contradiction again.
+    //
+    // Harness side: green-equality gate, and no "gray" anywhere — the
+    // ProbeState vocabulary cannot name the no-data case.
+    const harnessBody = parseHarnessSurfaceDerivation();
+    expect(harnessBody).toContain('row.state === "green"');
+    expect(harnessBody).not.toContain('"gray"');
+    //
+    // Dashboard side: must NOT be a green-equality gate (that would drop the
+    // gray→pending leg), and must consult the regression flag — a regressed
+    // cell never reads as neutrally pending.
+    const dashboardBody = parseDashboardSurfaceDerivation();
+    expect(dashboardBody).not.toContain('chipColor === "green"');
+    expect(dashboardBody).toContain("isRegression");
   });
 });

--- a/showcase/shell-dashboard/src/lib/commError-contract-drift.test.ts
+++ b/showcase/shell-dashboard/src/lib/commError-contract-drift.test.ts
@@ -318,20 +318,57 @@ describe("fleet surface-state contract cross-package drift", () => {
    * cell-model.ts. Match to the END OF THE STATEMENT (a `;` at end-of-line
    * followed by a blank line) — a bare non-greedy `;` would stop at a
    * semicolon inside the derivation's own comments. Throws if the statement
-   * can't be located so a refactor is loud.
+   * can't be located so a refactor is loud. Accepts an injectable `src` for
+   * the parser-robustness test; production callers read the real file.
    */
-  function parseDashboardSurfaceDerivation(): string {
-    const m = dashboardCellModelSource().match(
-      /const surfaceState: FleetSurfaceState =[\s\S]*?;\n\n/,
-    );
+  function parseDashboardSurfaceDerivation(
+    src: string = dashboardCellModelSource(),
+  ): string {
+    const m = src.match(/const surfaceState: FleetSurfaceState =[\s\S]*?;\n\n/);
     if (!m) {
       throw new Error(
         "drift parser: could not locate the `surfaceState` derivation in " +
           "cell-model.ts — if the source shape changed, update this regex.",
       );
     }
+    // STRUCTURAL END GUARD: the non-greedy `;\n\n` anchor stops at the FIRST
+    // semicolon-before-blank-line, so an internal one would silently TRUNCATE
+    // the parsed body and make the negative assertions over it vacuous. The
+    // derivation's real end is the `chipColorToSurface(chipColor)` fallback —
+    // reject any match that does not terminate there (a refactor that renames
+    // the fallback must update this guard, loudly).
+    if (!m[0].endsWith("chipColorToSurface(chipColor);\n\n")) {
+      throw new Error(
+        "drift parser: the `surfaceState` derivation parse was TRUNCATED — it " +
+          "did not end at the `chipColorToSurface(chipColor)` terminal " +
+          "fallback. An internal `;` + blank line shortened the match; " +
+          "harden the anchor or update this guard.",
+      );
+    }
     return m[0];
   }
+
+  it("the surface-derivation parser rejects a TRUNCATED parse (internal `;` + blank line)", () => {
+    // The non-greedy `;\n\n` anchor stops at the FIRST semicolon followed by
+    // a blank line. A future edit introducing one INSIDE the derivation would
+    // silently shorten the parsed body — making the NEGATIVE assertions over
+    // it (e.g. `not.toContain('chipColor === "green"')`) pass vacuously. The
+    // parser must refuse any match that does not terminate at the
+    // derivation's structural end (the chipColorToSurface fallback).
+    const truncating = [
+      "const surfaceState: FleetSurfaceState = commError",
+      "  ? overlayFor(commError);",
+      "",
+      '  : chipColor === "green"',
+      "    ? hiddenFromNegativeAssertions",
+      "    : chipColorToSurface(chipColor);",
+      "",
+      "return surfaceState;",
+    ].join("\n");
+    expect(() => parseDashboardSurfaceDerivation(truncating)).toThrow(
+      /truncated/i,
+    );
+  });
 
   it("dashboard cell-model derivation routes worker-reclaimed-pending → 'pending' with failure passthrough", () => {
     // Same pin on the dashboard side (behaviorally covered by the flap-band

--- a/showcase/shell-dashboard/src/lib/commError-contract-drift.test.ts
+++ b/showcase/shell-dashboard/src/lib/commError-contract-drift.test.ts
@@ -28,14 +28,21 @@ import {
   FLEET_COMM_ERROR_SIGNAL_KEY,
   commErrorFromStatusSignal,
 } from "./live-status";
+import type { FleetSurfaceState } from "./live-status";
 
 const HARNESS_CONTRACTS_FILE = resolve(
   __dirname,
   "../../../harness/src/fleet/contracts.ts",
 );
 
+const DASHBOARD_CELL_MODEL_FILE = resolve(__dirname, "./cell-model.ts");
+
 function harnessSource(): string {
   return readFileSync(HARNESS_CONTRACTS_FILE, "utf8");
+}
+
+function dashboardCellModelSource(): string {
+  return readFileSync(DASHBOARD_CELL_MODEL_FILE, "utf8");
 }
 
 /**
@@ -84,6 +91,49 @@ function parseHarnessSignalKey(): string {
     );
   }
   return m[1];
+}
+
+/**
+ * Parse the string-literal members of the harness `FleetSurfaceState` union
+ * (the members BEYOND the base `ProbeState` colours). Throws if the union
+ * can't be located so a shape change is loud, not a silent pass.
+ */
+function parseHarnessSurfaceOverlayMembers(): string[] {
+  const src = harnessSource();
+  const m = src.match(/export type FleetSurfaceState\s*=\s*([^;]+);/);
+  if (!m || !m[1]) {
+    throw new Error(
+      "drift parser: could not locate the `FleetSurfaceState` union in " +
+        "harness contracts.ts — if the source shape changed, update this regex.",
+    );
+  }
+  const members = Array.from(
+    m[1].matchAll(/"([a-z-]+)"/g),
+    (mm) => mm[1] as string,
+  );
+  if (members.length === 0) {
+    throw new Error(
+      "drift parser: parsed zero literal members from the harness " +
+        "FleetSurfaceState union — regex likely drifted from the source shape.",
+    );
+  }
+  return members;
+}
+
+/**
+ * Parse the body of the harness `fleetSurfaceState` derivation function.
+ * Throws if the function can't be located so a rename is loud.
+ */
+function parseHarnessSurfaceDerivation(): string {
+  const src = harnessSource();
+  const m = src.match(/export function fleetSurfaceState\([\s\S]*?\n\}/);
+  if (!m) {
+    throw new Error(
+      "drift parser: could not locate `fleetSurfaceState` in harness " +
+        "contracts.ts — if the source shape changed, update this regex.",
+    );
+  }
+  return m[0];
 }
 
 describe("pool comm-error contract cross-package drift", () => {
@@ -145,5 +195,63 @@ describe("pool comm-error contract cross-package drift", () => {
       },
     };
     expect(commErrorFromStatusSignal(signal)).toBeUndefined();
+  });
+});
+
+describe("fleet surface-state contract cross-package drift", () => {
+  // The two `FleetSurfaceState` unions are expressed over DIFFERENT base
+  // colour vocabularies (the harness over `ProbeState`, the dashboard over
+  // `ChipColor` — see the live-status.ts union comment), so the pinned shared
+  // surface is the set of PRESENTATION OVERLAY members both sides must carry:
+  // the red "unreachable" crash overlay and the neutral gray "pending"
+  // re-queued surface. The `satisfies` clause makes this list a COMPILE-TIME
+  // pin of the dashboard union — dropping either member from the dashboard
+  // `FleetSurfaceState` reds the typecheck, not just this test.
+  const OVERLAY_MEMBERS = [
+    "unreachable",
+    "pending",
+  ] as const satisfies readonly FleetSurfaceState[];
+
+  it("harness FleetSurfaceState union carries exactly the overlay members the dashboard union does", () => {
+    // If the harness union gains/loses an overlay member the dashboard never
+    // renders (or vice versa), the two packages disagree about what a fleet
+    // surface can BE — the drift this file exists to catch.
+    expect(new Set(parseHarnessSurfaceOverlayMembers())).toEqual(
+      new Set<string>(OVERLAY_MEMBERS),
+    );
+  });
+
+  it("harness fleetSurfaceState derivation routes worker-reclaimed-pending → 'pending' with red passthrough", () => {
+    // Pins the harness DERIVATION shape: the sweep-inferred reclaim kind must
+    // route to the neutral "pending" surface (never the red "unreachable"
+    // overlay), and a red probe colour must pass through unmasked — the same
+    // three-outcome derivation cell-model.ts applies on the dashboard side.
+    const body = parseHarnessSurfaceDerivation();
+    expect(body).toContain('"worker-reclaimed-pending"');
+    expect(body).toContain('"pending"');
+    expect(body).toContain('"unreachable"');
+    expect(body).toContain('"red"');
+  });
+
+  it("dashboard cell-model derivation routes worker-reclaimed-pending → 'pending' with red passthrough", () => {
+    // Same pin on the dashboard side (behaviorally covered by the flap-band
+    // #70 tests in __tests__/cell-model.test.ts; this guards the SHAPE so a
+    // refactor that drops the reclaim branch reds the drift suite too).
+    // Match to the END OF THE STATEMENT (a `;` at end-of-line followed by a
+    // blank line) — a bare non-greedy `;` would stop at a semicolon inside the
+    // derivation's own comments.
+    const m = dashboardCellModelSource().match(
+      /const surfaceState: FleetSurfaceState =[\s\S]*?;\n\n/,
+    );
+    if (!m) {
+      throw new Error(
+        "drift parser: could not locate the `surfaceState` derivation in " +
+          "cell-model.ts — if the source shape changed, update this regex.",
+      );
+    }
+    const body = m[0];
+    expect(body).toContain('"worker-reclaimed-pending"');
+    expect(body).toContain('"pending"');
+    expect(body).toContain('"unreachable"');
   });
 });

--- a/showcase/shell-dashboard/src/lib/commError-contract-drift.test.ts
+++ b/showcase/shell-dashboard/src/lib/commError-contract-drift.test.ts
@@ -136,6 +136,24 @@ function parseHarnessSurfaceDerivation(): string {
   return m[0];
 }
 
+/**
+ * Extract the full `commErrorFromStatusSignal` function source from a file's
+ * contents (used to pin the harness and dashboard copies byte-identical).
+ * Throws if the function can't be located so a rename is loud.
+ */
+function parseCommErrorDecoder(src: string, file: string): string {
+  const m = src.match(
+    /export function commErrorFromStatusSignal\([\s\S]*?\n\}/,
+  );
+  if (!m) {
+    throw new Error(
+      `drift parser: could not locate commErrorFromStatusSignal in ${file} ` +
+        "— if the source shape changed, update this regex.",
+    );
+  }
+  return m[0];
+}
+
 describe("pool comm-error contract cross-package drift", () => {
   it("dashboard POOL_COMM_ERROR_KINDS exactly equals the harness kind set", () => {
     const harnessKinds = new Set(parseHarnessKinds());
@@ -207,24 +225,12 @@ describe("pool comm-error contract cross-package drift", () => {
     // structural mirror of the harness reader, and a fix landing on one side
     // only (e.g. the Array.isArray rejection) silently re-opens the gap on
     // the other. Pin the FULL function source byte-for-byte.
-    const extract = (src: string, file: string): string => {
-      const m = src.match(
-        /export function commErrorFromStatusSignal\([\s\S]*?\n\}/,
-      );
-      if (!m) {
-        throw new Error(
-          `drift parser: could not locate commErrorFromStatusSignal in ${file} ` +
-            "— if the source shape changed, update this regex.",
-        );
-      }
-      return m[0];
-    };
     const dashboardSource = readFileSync(
       resolve(__dirname, "./live-status.ts"),
       "utf8",
     );
-    expect(extract(dashboardSource, "live-status.ts")).toBe(
-      extract(harnessSource(), "contracts.ts"),
+    expect(parseCommErrorDecoder(dashboardSource, "live-status.ts")).toBe(
+      parseCommErrorDecoder(harnessSource(), "contracts.ts"),
     );
   });
 

--- a/showcase/shell-dashboard/src/lib/commError-contract-drift.test.ts
+++ b/showcase/shell-dashboard/src/lib/commError-contract-drift.test.ts
@@ -183,6 +183,51 @@ describe("pool comm-error contract cross-package drift", () => {
     expect(commErrorFromStatusSignal(signal)).toEqual(err);
   });
 
+  it("dashboard decode rejects an ARRAY embedded under the signal key", () => {
+    // Arrays are `typeof "object"`: an array carrying comm-error fields as
+    // EXPANDO properties would pass a bare typeof check and decode as if it
+    // were a well-formed PoolCommError. An array is never a valid wire shape,
+    // so the decoder must reject it explicitly (mirrors the harness copy —
+    // see the byte-identity pin below).
+    const harnessKey = parseHarnessSignalKey();
+    expect(commErrorFromStatusSignal({ [harnessKey]: [] })).toBeUndefined();
+    expect(
+      commErrorFromStatusSignal({
+        [harnessKey]: Object.assign([], {
+          kind: parseHarnessKinds()[0],
+          message: "x",
+          observedAt: "2026-06-04T12:00:00.000Z",
+        }),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("commErrorFromStatusSignal is byte-identical between harness and dashboard", () => {
+    // The two copies must never diverge: the dashboard's reader is a
+    // structural mirror of the harness reader, and a fix landing on one side
+    // only (e.g. the Array.isArray rejection) silently re-opens the gap on
+    // the other. Pin the FULL function source byte-for-byte.
+    const extract = (src: string, file: string): string => {
+      const m = src.match(
+        /export function commErrorFromStatusSignal\([\s\S]*?\n\}/,
+      );
+      if (!m) {
+        throw new Error(
+          `drift parser: could not locate commErrorFromStatusSignal in ${file} ` +
+            "— if the source shape changed, update this regex.",
+        );
+      }
+      return m[0];
+    };
+    const dashboardSource = readFileSync(
+      resolve(__dirname, "./live-status.ts"),
+      "utf8",
+    );
+    expect(extract(dashboardSource, "live-status.ts")).toBe(
+      extract(harnessSource(), "contracts.ts"),
+    );
+  });
+
   it("dashboard decode rejects an unknown kind (fail-safe to normal colour)", () => {
     // A kind the harness never declares must decode to undefined so the cell
     // renders its normal probe colour rather than a half-populated overlay.

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   CATALOG_TO_D5_KEY,
+  FLEET_COMM_ERROR_SIGNAL_KEY,
   STARTER_COLUMNS,
   STARTER_LEVELS,
   STATUS_LIST_FIELDS,
   buildStarterBadge,
+  commErrorFromStatusSignal,
   keyFor,
   mergeRowsToMap,
   resolveCell,
@@ -12,6 +14,7 @@ import {
   resolveD6Row,
   resolveStarterRow,
   starterIsSupported,
+  statusSignalHasCommErrorKey,
   upsertByKey,
 } from "./live-status";
 import type { LiveStatusMap, StatusRow, StarterLevel } from "./live-status";
@@ -52,6 +55,45 @@ function mapOf(rows: StatusRow[]): LiveStatusMap {
   for (const r of rows) m.set(r.key, r);
   return m;
 }
+
+describe("statusSignalHasCommErrorKey (sibling of the harness contract companion)", () => {
+  it("distinguishes 'key present but undecodable' from 'genuinely absent' without changing the decode contract", () => {
+    // Key present, kind unknown to this reader (the version-skew case): the
+    // decode fail-safes to undefined but the companion still sees the key.
+    const unknownKind = {
+      [FLEET_COMM_ERROR_SIGNAL_KEY]: {
+        kind: "some-future-kind",
+        message: "x",
+        observedAt: FRESH_OBSERVED_AT,
+      },
+    };
+    expect(commErrorFromStatusSignal(unknownKind)).toBeUndefined();
+    expect(statusSignalHasCommErrorKey(unknownKind)).toBe(true);
+
+    // Key present and well-formed: both sides agree.
+    const wellFormed = {
+      [FLEET_COMM_ERROR_SIGNAL_KEY]: {
+        kind: "worker-unreachable",
+        message: "connect ECONNREFUSED",
+        observedAt: FRESH_OBSERVED_AT,
+      },
+    };
+    expect(commErrorFromStatusSignal(wellFormed)).toBeDefined();
+    expect(statusSignalHasCommErrorKey(wellFormed)).toBe(true);
+
+    // Genuinely absent / never a valid wire shape (mirrors the decoder's
+    // null / non-object / array guards — including the key as an array
+    // expando property).
+    expect(statusSignalHasCommErrorKey({ failedCount: 0 })).toBe(false);
+    expect(statusSignalHasCommErrorKey(null)).toBe(false);
+    expect(statusSignalHasCommErrorKey("nope")).toBe(false);
+    expect(
+      statusSignalHasCommErrorKey(
+        Object.assign([], { [FLEET_COMM_ERROR_SIGNAL_KEY]: {} }),
+      ),
+    ).toBe(false);
+  });
+});
 
 describe("keyFor", () => {
   it("integration-level dimensions have no feature segment", () => {

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -150,6 +150,42 @@ describe("upsertByKey", () => {
     expect(after).not.toBe(before);
     expect(after[0]!.observed_at).toBe("2026-04-21T00:00:00Z");
   });
+  it("allocates a new array when only fail_count changes (not a no-op)", () => {
+    // A red row's fail_count increments on every consecutive failure while
+    // observed_at/transitioned_at can stay put within a tick; the drilldown
+    // and alerting surfaces read it, so the delta must NOT be swallowed.
+    const a = row("k:fc", "smoke", "red", { fail_count: 1 });
+    const b = row("k:fc", "smoke", "red", { fail_count: 2 });
+    const before = [a];
+    const after = upsertByKey(before, b);
+    expect(after).not.toBe(before);
+    expect(after[0]!.fail_count).toBe(2);
+  });
+  it("allocates a new array when only first_failure_at changes (load-bearing in tooltips)", () => {
+    // formatTooltip renders "red since <first_failure_at>" — a delta that
+    // moves only this field is observable copy and must not be discarded.
+    const a = row("k:ffa", "smoke", "red", {
+      first_failure_at: "2026-06-01T00:00:00.000Z",
+    });
+    const b = row("k:ffa", "smoke", "red", {
+      first_failure_at: "2026-06-02T00:00:00.000Z",
+    });
+    const before = [a];
+    const after = upsertByKey(before, b);
+    expect(after).not.toBe(before);
+    expect(after[0]!.first_failure_at).toBe("2026-06-02T00:00:00.000Z");
+  });
+  it("allocates a new array when only id changes (deleted-and-recreated PB row)", () => {
+    // A status row deleted and recreated upstream keeps its key but gets a
+    // fresh PB id; keeping the stale id in the map breaks any id-keyed
+    // follow-up fetch (e.g. the drilldown's full-row load).
+    const a = row("k:id", "smoke", "green", { id: "rec-old" });
+    const b = row("k:id", "smoke", "green", { id: "rec-new" });
+    const before = [a];
+    const after = upsertByKey(before, b);
+    expect(after).not.toBe(before);
+    expect(after[0]!.id).toBe("rec-new");
+  });
   it("applies a row whose signal goes from absent to present (SSE full-row delivery)", () => {
     // The initial fetch projection drops `signal`, so initial rows arrive with
     // `signal === undefined` and rely on SSE deltas to deliver the populated

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -10,6 +10,7 @@ import {
   keyFor,
   mergeRowsToMap,
   resolveCell,
+  resolveD4Row,
   resolveD5Row,
   resolveD6Row,
   resolveStarterRow,
@@ -20,6 +21,7 @@ import {
 import type { LiveStatusMap, StatusRow, StarterLevel } from "./live-status";
 import { formatTs } from "./format-ts";
 import {
+  D4_STALE_AFTER_MS,
   E2E_STALE_AFTER_MS,
   LIVENESS_STALE_AFTER_MS,
   STARTER_STALE_AFTER_MS,
@@ -396,6 +398,133 @@ describe("resolveD6Row / resolveD5Row — out-of-vocabulary state tolerance (Fix
   });
 });
 
+describe("resolveD4Row — worst-state fold mirroring cell-model resolveD4", () => {
+  // Fixed `now` so the stale/fresh boundary is deterministic (same
+  // convention as the staleness-downgrade suite below).
+  const NOW = Date.parse("2026-05-30T00:00:00Z");
+  const freshAt = (ageMs: number): string =>
+    new Date(NOW - ageMs).toISOString();
+
+  it("returns null when both chat and tools rows are missing (no-data)", () => {
+    expect(resolveD4Row(mapOf([]), "agno", NOW)).toBeNull();
+  });
+
+  it("green chat + green tools (fresh) → green CHAT row (chat wins equal-rank ties)", () => {
+    const live = mapOf([
+      row("chat:agno", "chat", "green", { observed_at: freshAt(0) }),
+      row("tools:agno", "tools", "green", { observed_at: freshAt(0) }),
+    ]);
+    const out = resolveD4Row(live, "agno", NOW);
+    expect(out).not.toBeNull();
+    expect(out?.state).toBe("green");
+    // Tie-break DIRECTION: the fold iterates [chatRow, toolsRow] with a
+    // strict `>` rank comparison, so at equal rank the CHAT row must win.
+    // Swapping the fold order to [toolsRow, chatRow] would return the
+    // tools row here — these identity assertions pin the documented order.
+    expect(out?.dimension).toBe("chat");
+    expect(out?.key).toBe("chat:agno");
+  });
+
+  it("red chat + red tools (equal-rank red tie) → CHAT row identity returned", () => {
+    // At an equal-rank RED tie the returned row's IDENTITY matters most:
+    // its signal/fail_count surface in the drilldown, so the fold must
+    // deterministically return the chat row, not whichever side happens
+    // to win after an order swap.
+    const live = mapOf([
+      row("chat:agno", "chat", "red", {
+        observed_at: freshAt(0),
+        fail_count: 3,
+      }),
+      row("tools:agno", "tools", "red", {
+        observed_at: freshAt(0),
+        fail_count: 7,
+      }),
+    ]);
+    const out = resolveD4Row(live, "agno", NOW);
+    expect(out).not.toBeNull();
+    expect(out?.state).toBe("red");
+    expect(out?.dimension).toBe("chat");
+    expect(out?.key).toBe("chat:agno");
+    expect(out?.fail_count).toBe(3);
+  });
+
+  it("green chat + red tools → red tools row wins the fold", () => {
+    const live = mapOf([
+      row("chat:agno", "chat", "green", { observed_at: freshAt(0) }),
+      row("tools:agno", "tools", "red", { observed_at: freshAt(0) }),
+    ]);
+    const out = resolveD4Row(live, "agno", NOW);
+    expect(out?.state).toBe("red");
+    expect(out?.dimension).toBe("tools");
+  });
+
+  it("red chat + green tools → red chat row wins the fold", () => {
+    const live = mapOf([
+      row("chat:agno", "chat", "red", { observed_at: freshAt(0) }),
+      row("tools:agno", "tools", "green", { observed_at: freshAt(0) }),
+    ]);
+    const out = resolveD4Row(live, "agno", NOW);
+    expect(out?.state).toBe("red");
+    expect(out?.dimension).toBe("chat");
+  });
+
+  it("stale-green chat alone (older than the 1h D4 window) → EFFECTIVE degraded row", () => {
+    // D4 uses the 1h window (D4_STALE_AFTER_MS), NOT the 6h e2e window —
+    // a 2h-old green chat row is stale for D4 but would be fresh for e2e.
+    // The returned winner must be the EFFECTIVE (downgraded) row so `.state`
+    // agrees with the rank that won the fold.
+    const live = mapOf([
+      row("chat:agno", "chat", "green", {
+        observed_at: freshAt(D4_STALE_AFTER_MS + 60 * 60 * 1000),
+      }),
+    ]);
+    const out = resolveD4Row(live, "agno", NOW);
+    expect(out).not.toBeNull();
+    expect(out?.state).toBe("degraded");
+  });
+
+  it("green tools only (chat missing) → null (unverified family collapses, e771c2351)", () => {
+    // `chat:<slug>` is producer-UNCONDITIONAL — a green tools row with the
+    // chat row missing is an unverified family and must collapse to no-data.
+    const live = mapOf([
+      row("tools:agno", "tools", "green", { observed_at: freshAt(0) }),
+    ]);
+    expect(resolveD4Row(live, "agno", NOW)).toBeNull();
+  });
+
+  it("red tools only (chat missing) → red row returned (red dominates no-data)", () => {
+    const live = mapOf([
+      row("tools:agno", "tools", "red", { observed_at: freshAt(0) }),
+    ]);
+    const out = resolveD4Row(live, "agno", NOW);
+    expect(out).not.toBeNull();
+    expect(out?.state).toBe("red");
+    expect(out?.dimension).toBe("tools");
+  });
+
+  it("green chat only (tools missing) → green (conditional tools row stays lenient)", () => {
+    const live = mapOf([
+      row("chat:agno", "chat", "green", { observed_at: freshAt(0) }),
+    ]);
+    const out = resolveD4Row(live, "agno", NOW);
+    expect(out?.state).toBe("green");
+    expect(out?.dimension).toBe("chat");
+  });
+
+  it("out-of-vocab tools state with chat missing still SURFACES (rank above red survives the collapse)", () => {
+    // The missing-unconditional-chat collapse must be RANK-based, not a
+    // `!== "red"` literal — an out-of-vocabulary "error" state is ranked
+    // ABOVE red by the A2 machinery and must never be silently swallowed.
+    const outOfVocab = "error" as unknown as StatusRow["state"];
+    const live = mapOf([
+      row("tools:agno", "tools", outOfVocab, { observed_at: freshAt(0) }),
+    ]);
+    const out = resolveD4Row(live, "agno", NOW);
+    expect(out).not.toBeNull();
+    expect(out?.state).toBe(outOfVocab);
+  });
+});
+
 describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
   // Order: red > degraded > green > error > unknown.
   // Rollup contributors: health, e2e (Decision #7: smokeRow dropped).
@@ -619,6 +748,63 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
     expect(c.d6.label).toBe("?");
     expect(c.d5.row).toBeNull();
     expect(c.d6.row).toBeNull();
+  });
+
+  it("resolves d4 from integration-scoped chat+tools rows (green fold)", () => {
+    const live = mapOf([
+      row("chat:agno", "chat", "green"),
+      row("tools:agno", "tools", "green"),
+    ]);
+    const c = resolveCell(live, "agno", "agentic-chat");
+    expect(c.d4.tone).toBe("green");
+    expect(c.d4.label).toBe("✓");
+  });
+
+  it("d4 red tools + green chat → red badge anchored on the tools row", () => {
+    const live = mapOf([
+      row("chat:agno", "chat", "green"),
+      row("tools:agno", "tools", "red"),
+    ]);
+    const c = resolveCell(live, "agno", "agentic-chat");
+    expect(c.d4.tone).toBe("red");
+    expect(c.d4.label).toBe("✗");
+    expect(c.d4.row?.dimension).toBe("tools");
+  });
+
+  it("d4 does NOT contribute to the rollup (informational only — Service scope is health + e2e)", () => {
+    // The pill's gate already consumes D4 via buildCellModel; the rollup's
+    // contributors stay health + e2e (the relabel decision). A red D4 fold
+    // must surface on its own badge while the service rollup stays green.
+    const live = mapOf([
+      row("health:agno", "health", "green"),
+      row("e2e:agno/agentic-chat", "e2e", "green"),
+      row("chat:agno", "chat", "green"),
+      row("tools:agno", "tools", "red"),
+    ]);
+    const c = resolveCell(live, "agno", "agentic-chat");
+    expect(c.d4.tone).toBe("red");
+    expect(c.rollup).toBe("green");
+  });
+
+  it("d4 stale-green chat (older than the 1h window) → amber badge with stale tooltip", () => {
+    const NOW = Date.parse("2026-05-30T00:00:00Z");
+    const live = mapOf([
+      row("chat:agno", "chat", "green", {
+        observed_at: new Date(
+          NOW - (D4_STALE_AFTER_MS + 60 * 60 * 1000),
+        ).toISOString(),
+      }),
+    ]);
+    const c = resolveCell(live, "agno", "agentic-chat", { now: NOW });
+    expect(c.d4.tone).toBe("amber");
+    expect(c.d4.tooltip).toContain("stale");
+  });
+
+  it("d4 falls through to gray '?' when chat/tools rows are absent", () => {
+    const c = resolveCell(mapOf([]), "agno", "agentic-chat");
+    expect(c.d4.tone).toBe("gray");
+    expect(c.d4.label).toBe("?");
+    expect(c.d4.row).toBeNull();
   });
 
   it("d5 / d6 do NOT contribute to the rollup (informational only)", () => {

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -92,6 +92,13 @@ describe("keyFor", () => {
     expect(() => keyFor("e2e", "agno", "bad:id")).toThrow(/must not contain/);
     expect(() => keyFor("e2e", "agno", "bad/id")).toThrow(/must not contain/);
   });
+  it("throws when dimension contains ':' or '/' (G3e — same guard as the other segments)", () => {
+    // `:` is the dimension/slug delimiter; a colon-bearing dimension would
+    // silently parse as a DIFFERENT dimension + slug suffix, and a
+    // slash-bearing one would fabricate a phantom feature segment.
+    expect(() => keyFor("bad:dim", "agno")).toThrow(/must not contain/);
+    expect(() => keyFor("bad/dim", "agno")).toThrow(/must not contain/);
+  });
   it("throws on an empty-string featureId instead of fabricating the aggregate key", () => {
     // An empty featureId is falsy, so a truthiness guard would skip the
     // delimiter validation AND the per-feature branch, silently producing the

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -92,6 +92,13 @@ describe("keyFor", () => {
     expect(() => keyFor("e2e", "agno", "bad:id")).toThrow(/must not contain/);
     expect(() => keyFor("e2e", "agno", "bad/id")).toThrow(/must not contain/);
   });
+  it("throws on an empty-string featureId instead of fabricating the aggregate key", () => {
+    // An empty featureId is falsy, so a truthiness guard would skip the
+    // delimiter validation AND the per-feature branch, silently producing the
+    // integration-aggregate key (`e2e:agno`) for what the caller meant as a
+    // per-feature lookup. Throw loudly, matching the guard's defensive posture.
+    expect(() => keyFor("e2e", "agno", "")).toThrow(/empty/);
+  });
   it("every CATALOG_TO_D5_KEY mapping value is delimiter-free (keyFor feeds these as featureId)", () => {
     // resolveD5Row/resolveD6Row pass each mapping value into keyFor as the
     // featureId segment. keyFor's guard protects slug + the caller-supplied

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -930,8 +930,9 @@ describe("resolveCell — staleness downgrade (unification A)", () => {
 
 describe("resolveD5Row / resolveD6Row — effective (stale-downgraded) winner (G2f)", () => {
   const NOW = Date.parse("2026-05-30T00:00:00Z");
-  const staleAt = new Date(NOW - E2E_STALE_AFTER_MS - 60 * 60 * 1000)
-    .toISOString();
+  const staleAt = new Date(
+    NOW - E2E_STALE_AFTER_MS - 60 * 60 * 1000,
+  ).toISOString();
   const freshAt = new Date(NOW).toISOString();
 
   it("resolveD5Row returns the EFFECTIVE row for a stale-green winner (.row.state agrees with the fold)", () => {
@@ -1017,8 +1018,9 @@ describe("formatTooltip behaviour (via resolveCell)", () => {
 
   it("an age-downgraded green row keeps the 'stale — last seen' copy (G2f)", () => {
     const NOW = Date.parse("2026-05-30T00:00:00Z");
-    const oldTs = new Date(NOW - E2E_STALE_AFTER_MS - 60 * 60 * 1000)
-      .toISOString();
+    const oldTs = new Date(
+      NOW - E2E_STALE_AFTER_MS - 60 * 60 * 1000,
+    ).toISOString();
     const live = mapOf([
       row("e2e:a/b", "e2e", "green", { observed_at: oldTs }),
     ]);

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -368,6 +368,26 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
     expect(resolveCell(liveE2eOnly, "agno", "ac").rollup).toBe("gray");
   });
 
+  it("an out-of-vocabulary contributor state (e.g. 'error') rolls up red-severity, never gray (A2)", () => {
+    // `StatusRow.state` is typed State (green|red|degraded), but the harness
+    // CAN persist an out-of-vocabulary value at runtime — notably "error"
+    // (the no-data representation; see harness result-aggregator). The rollup
+    // fold must route contributor states through the A2 rank machinery
+    // (worstStateRank ranks an unknown state ABOVE red), not literal
+    // includes() checks: a literal fold rolls the cell up GRAY (benign
+    // no-data) while the contributor's own badge renders the loud "error"
+    // tone — swallowing exactly the state the rank machinery exists to
+    // surface.
+    const outOfVocab = "error" as unknown as StatusRow["state"];
+    const live = mapOf([
+      row("health:agno", "health", outOfVocab),
+      row("e2e:agno/ac", "e2e", "green"),
+    ]);
+    const c = resolveCell(live, "agno", "ac");
+    expect(c.rollup).not.toBe("gray");
+    expect(c.rollup).toBe("red");
+  });
+
   it("rolls up to gray when no rows at all", () => {
     const live = mapOf([]);
     const c = resolveCell(live, "agno", "ac");

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -268,6 +268,21 @@ describe("mergeRowsToMap", () => {
     expect(warn).toHaveBeenCalledOnce();
     expect(warn.mock.calls[0]?.[0]).toMatch(/disjoint-key invariant violated/);
   });
+  it("does NOT warn when rows differ ONLY by signal presence (projection vs SSE provenance, CF7-F3 #5)", () => {
+    // The initial bulk fetch projects `signal` away while SSE deltas (and the
+    // comm-error supplemental fetch) deliver full rows, so the SAME logical
+    // row can legitimately exist in two groups with and without `signal`.
+    // That presence flip is expected provenance, not a disjoint-key invariant
+    // violation — warning on it is pure noise. (upsertByKey's reducer keeps
+    // treating the flip as observable; only THIS divergence warn excludes it.)
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const projected = row("d6:agno", "d6", "green", { signal: undefined });
+    const full = row("d6:agno", "d6", "green", { signal: { detail: "x" } });
+    const map = mergeRowsToMap([projected], [full]);
+    // Last-wins still applies — the signal-bearing row survives.
+    expect(map.get("d6:agno")?.signal).toEqual({ detail: "x" });
+    expect(warn).not.toHaveBeenCalled();
+  });
 });
 
 describe("resolveD6Row / resolveD5Row — out-of-vocabulary state tolerance (Fix A2)", () => {

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -8,6 +8,8 @@ import {
   keyFor,
   mergeRowsToMap,
   resolveCell,
+  resolveD5Row,
+  resolveD6Row,
   resolveStarterRow,
   starterIsSupported,
   upsertByKey,
@@ -926,6 +928,44 @@ describe("resolveCell — staleness downgrade (unification A)", () => {
   });
 });
 
+describe("resolveD5Row / resolveD6Row — effective (stale-downgraded) winner (G2f)", () => {
+  const NOW = Date.parse("2026-05-30T00:00:00Z");
+  const staleAt = new Date(NOW - E2E_STALE_AFTER_MS - 60 * 60 * 1000)
+    .toISOString();
+  const freshAt = new Date(NOW).toISOString();
+
+  it("resolveD5Row returns the EFFECTIVE row for a stale-green winner (.row.state agrees with the fold)", () => {
+    // The fold ranks the stale-green sub-row as degraded, but the resolver
+    // used to store the RAW row — a consumer reading .state saw a latent
+    // false-green that contradicted the rank that made it the winner.
+    // Mirrors cell-model.ts resolveD5's effective-row storage.
+    const live = mapOf([
+      row("d5:agno/agentic-chat", "d5", "green", { observed_at: staleAt }),
+    ]);
+    const r = resolveD5Row(live, "agno", "agentic-chat", NOW);
+    expect(r?.state).toBe("degraded");
+    // Producer fields preserved by the spread (drilldown metadata intact).
+    expect(r?.key).toBe("d5:agno/agentic-chat");
+    expect(r?.observed_at).toBe(staleAt);
+  });
+
+  it("resolveD6Row returns the EFFECTIVE row for a stale-green winner", () => {
+    const live = mapOf([
+      row("d6:agno/agentic-chat", "d6", "green", { observed_at: staleAt }),
+    ]);
+    const r = resolveD6Row(live, "agno", "agentic-chat", NOW);
+    expect(r?.state).toBe("degraded");
+  });
+
+  it("a fresh winner row passes through by reference, unmodified", () => {
+    const fresh = row("d5:agno/agentic-chat", "d5", "green", {
+      observed_at: freshAt,
+    });
+    const live = mapOf([fresh]);
+    expect(resolveD5Row(live, "agno", "agentic-chat", NOW)).toBe(fresh);
+  });
+});
+
 describe("formatTooltip behaviour (via resolveCell)", () => {
   it("degraded tooltip drops the hardcoded '>6h' threshold (LS2)", () => {
     const live = mapOf([
@@ -955,6 +995,36 @@ describe("formatTooltip behaviour (via resolveCell)", () => {
       `last seen @ ${formatTs("2026-04-22T08:00:00Z")}`,
     );
     expect(c.e2e.tooltip).not.toContain("last pass");
+  });
+
+  it("a FRESH producer-emitted degraded row says 'degraded', not 'stale' (G2f)", () => {
+    // The producer genuinely emitted `degraded` on a recent tick: labeling
+    // that "stale" told operators the row had stopped updating when the
+    // signal is actually fresh-and-degraded. The stale copy is reserved for
+    // rows that fail the SAME staleness check the badge tone uses.
+    const NOW = Date.parse("2026-05-30T00:00:00Z");
+    const freshTs = new Date(NOW - 60 * 1000).toISOString();
+    const live = mapOf([
+      row("e2e:a/b", "e2e", "degraded", {
+        observed_at: freshTs,
+        transitioned_at: freshTs,
+      }),
+    ]);
+    const c = resolveCell(live, "a", "b", { now: NOW });
+    expect(c.e2e.tooltip).toContain("degraded since");
+    expect(c.e2e.tooltip).not.toContain("stale");
+  });
+
+  it("an age-downgraded green row keeps the 'stale — last seen' copy (G2f)", () => {
+    const NOW = Date.parse("2026-05-30T00:00:00Z");
+    const oldTs = new Date(NOW - E2E_STALE_AFTER_MS - 60 * 60 * 1000)
+      .toISOString();
+    const live = mapOf([
+      row("e2e:a/b", "e2e", "green", { observed_at: oldTs }),
+    ]);
+    const c = resolveCell(live, "a", "b", { now: NOW });
+    expect(c.e2e.tone).toBe("amber");
+    expect(c.e2e.tooltip).toContain(`stale — last seen @ ${formatTs(oldTs)}`);
   });
 
   it("red tooltip surfaces non-empty signal summary (LS8)", () => {

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -258,6 +258,33 @@ describe("resolveD6Row / resolveD5Row — out-of-vocabulary state tolerance (Fix
     expect(c.d5.row).not.toBeNull();
     expect(c.d5.row?.state).toBe(OUT_OF_VOCAB);
   });
+
+  it("d6: missing sub-row + out-of-vocab sub-row SURFACES, not collapses to no-data", () => {
+    // The anyMissing collapse must be RANK-based, not `worstState !== "red"`
+    // literal equality: an out-of-vocabulary "error" sub-row is ranked ABOVE
+    // red by the A2 machinery ("never silently swallowed"), so a family with
+    // a missing sibling must still surface it — collapsing to null would
+    // swallow exactly the state the rank fold exists to surface.
+    const live = mapOf([
+      row("d6:agno/beautiful-chat-pie-chart", "d6", OUT_OF_VOCAB),
+      row("d6:agno/beautiful-chat-toggle-theme", "d6", "green"),
+      // the other 3 beautiful-chat sub-rows are MISSING
+    ]);
+    const c = resolveCell(live, "agno", "beautiful-chat");
+    expect(c.d6.row).not.toBeNull();
+    expect(c.d6.row?.state).toBe(OUT_OF_VOCAB);
+  });
+
+  it("d5: missing sub-row + out-of-vocab sub-row SURFACES, not collapses to no-data", () => {
+    const live = mapOf([
+      row("d5:agno/beautiful-chat-pie-chart", "d5", OUT_OF_VOCAB),
+      row("d5:agno/beautiful-chat-toggle-theme", "d5", "green"),
+      // the other 3 beautiful-chat sub-rows are MISSING
+    ]);
+    const c = resolveCell(live, "agno", "beautiful-chat");
+    expect(c.d5.row).not.toBeNull();
+    expect(c.d5.row?.state).toBe(OUT_OF_VOCAB);
+  });
 });
 
 describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -1027,6 +1027,52 @@ describe("formatTooltip behaviour (via resolveCell)", () => {
     expect(c.e2e.tooltip).toContain(`stale — last seen @ ${formatTs(oldTs)}`);
   });
 
+  // The health LABEL must honor the same staleness split as the tooltip —
+  // formatLabel hardcoding "stale" for every degraded health row contradicted
+  // the "degraded since …" tooltip on a fresh producer-emitted degradation.
+  it("a FRESH producer-emitted degraded health row labels 'degraded', not 'stale'", () => {
+    const NOW = Date.parse("2026-05-30T00:00:00Z");
+    const freshTs = new Date(NOW - 60 * 1000).toISOString();
+    const live = mapOf([
+      row("health:a", "health", "degraded", {
+        observed_at: freshTs,
+        transitioned_at: freshTs,
+      }),
+    ]);
+    const c = resolveCell(live, "a", "b", { now: NOW });
+    expect(c.health.label).toBe("degraded");
+    expect(c.health.tooltip).toContain("degraded since");
+  });
+
+  it("a degraded health row that stopped updating keeps the 'stale' label", () => {
+    const NOW = Date.parse("2026-05-30T00:00:00Z");
+    const oldTs = new Date(
+      NOW - LIVENESS_STALE_AFTER_MS - 60 * 1000,
+    ).toISOString();
+    const live = mapOf([
+      row("health:a", "health", "degraded", {
+        observed_at: oldTs,
+        transitioned_at: oldTs,
+      }),
+    ]);
+    const c = resolveCell(live, "a", "b", { now: NOW });
+    expect(c.health.label).toBe("stale");
+    expect(c.health.tooltip).toContain("stale — last seen");
+  });
+
+  it("an age-downgraded green health row labels 'stale' (the row froze while green)", () => {
+    const NOW = Date.parse("2026-05-30T00:00:00Z");
+    const oldTs = new Date(
+      NOW - LIVENESS_STALE_AFTER_MS - 60 * 1000,
+    ).toISOString();
+    const live = mapOf([
+      row("health:a", "health", "green", { observed_at: oldTs }),
+    ]);
+    const c = resolveCell(live, "a", "b", { now: NOW });
+    expect(c.health.tone).toBe("amber");
+    expect(c.health.label).toBe("stale");
+  });
+
   it("red tooltip surfaces non-empty signal summary (LS8)", () => {
     const live = mapOf([
       row("e2e:a/b", "e2e", "red", {

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -55,7 +55,12 @@ export const POOL_COMM_ERROR_KINDS = [
   "claim-comm-failure",
   /** The worker exceeded the protocol response deadline (hung, no crash). */
   "worker-protocol-timeout",
-  /** The worker died mid-job: lease expired with no terminal report. */
+  /**
+   * The worker's OWN self-monitor observed an in-driver pool-infra crash
+   * mid-job and reported it directly (a known crash — stays red). A lease
+   * that merely expired with no terminal report is NOT this kind; the sweep
+   * emits `worker-reclaimed-pending` for that.
+   */
   "worker-crashed-mid-job",
   /** A report arrived but failed schema/shape validation (protocol mismatch). */
   "worker-protocol-violation",

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -1146,6 +1146,28 @@ export function resolveCell(
  * equivalent signals upstream).
  */
 function rowsAreNoop(prev: unknown, next: unknown): boolean {
+  if (!coreRowFieldsEqual(prev, next)) return false;
+  if (prev === next) return true;
+  const a = prev as Record<string, unknown>;
+  const b = next as Record<string, unknown>;
+  return (a.signal === undefined) === (b.signal === undefined);
+}
+
+/**
+ * Equality on the SIGNAL-INDEPENDENT observable row fields (`id`, `key`,
+ * `state`, `observed_at`, `transitioned_at`, `fail_count`,
+ * `first_failure_at`) — `rowsAreNoop` minus the signal-presence term.
+ *
+ * Split out for `mergeRowsToMap`'s divergence warn (CF7-F3 #5): the initial
+ * bulk fetch projects `signal` away while SSE deltas and the comm-error
+ * supplemental fetch deliver full rows, so the SAME logical row legitimately
+ * appears with and without `signal` depending on provenance. The reducer
+ * (`upsertByKey` → `rowsAreNoop`) MUST keep treating that presence flip as
+ * observable (the signal-bearing row has to replace the projected one), but
+ * the disjoint-key invariant warn must NOT fire on it — it is expected
+ * provenance, not an upstream keyspace violation.
+ */
+function coreRowFieldsEqual(prev: unknown, next: unknown): boolean {
   if (prev === next) return true;
   if (
     typeof prev !== "object" ||
@@ -1163,8 +1185,7 @@ function rowsAreNoop(prev: unknown, next: unknown): boolean {
     a.observed_at === b.observed_at &&
     a.transitioned_at === b.transitioned_at &&
     a.fail_count === b.fail_count &&
-    a.first_failure_at === b.first_failure_at &&
-    (a.signal === undefined) === (b.signal === undefined)
+    a.first_failure_at === b.first_failure_at
   );
 }
 
@@ -1205,9 +1226,13 @@ export function upsertByKey<T extends StatusRow>(rows: T[], next: T): T[] {
  * eventual consistency).
  *
  * The warning fires only on GENUINE divergence — two rows with the same key
- * but a different observable state (compared via `rowsAreNoop`, the same
- * id/key/state/observed_at/transitioned_at/fail_count/first_failure_at +
- * signal-presence shallow check the reducer uses).
+ * but a different observable state (compared via `coreRowFieldsEqual`, the
+ * id/key/state/observed_at/transitioned_at/fail_count/first_failure_at
+ * shallow check the reducer uses — WITHOUT the reducer's signal-presence
+ * term, CF7-F3 #5: the initial fetch projects `signal` away while SSE deltas
+ * and the comm-error supplemental fetch deliver full rows, so a
+ * `signal` undefined⇄defined flip between groups is expected provenance, not
+ * a keyspace violation, and must not warn).
  * Identical-content-but-different-reference rows (e.g. the same producer row
  * re-allocated across two groups) are NOT a real invariant violation and used
  * to fire a noisy false warning under the old reference-based `prior !== r`
@@ -1218,7 +1243,7 @@ export function mergeRowsToMap(...rowGroups: StatusRow[][]): LiveStatusMap {
   for (const rows of rowGroups) {
     for (const r of rows) {
       const prior = map.get(r.key);
-      if (prior !== undefined && !rowsAreNoop(prior, r)) {
+      if (prior !== undefined && !coreRowFieldsEqual(prior, r)) {
         // eslint-disable-next-line no-console
         console.warn(
           `mergeRowsToMap: disjoint-key invariant violated for key="${r.key}" ` +

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -16,6 +16,7 @@
 
 import { formatTs } from "./format-ts";
 import {
+  D4_STALE_AFTER_MS,
   E2E_STALE_AFTER_MS,
   LIVENESS_STALE_AFTER_MS,
   STARTER_STALE_AFTER_MS,
@@ -293,6 +294,18 @@ export interface CellState {
    * this integration.
    */
   d2: BadgeRender;
+  /**
+   * D4 (chat round-trip + tool round-trip) per-integration badge. Sourced
+   * from `chat:<slug>` / `tools:<slug>` rows via `resolveD4Row` — a
+   * worst-state fold with the missing-unconditional-chat collapse (see the
+   * resolver doc). Integration-scoped — every feature within the same
+   * integration sees the same D4 badge. Stays `gray` / `?` until the
+   * d4-chat-roundtrip driver has ticked for this integration. Does NOT
+   * contribute to the rollup — informational only; the pill's gate already
+   * consumes D4 via `buildCellModel` (cell-model.ts), so the drilldown row
+   * exists to make that gate's input visible, not to re-derive the verdict.
+   */
+  d4: BadgeRender;
   /**
    * D5 (deep / multi-turn conversation) per-feature badge. Sourced from
    * `d5:<slug>/<featureId>` rows emitted by the `e2e-deep` driver. Stays
@@ -642,6 +655,72 @@ export function resolveD6Row(
   return worst;
 }
 
+/**
+ * Resolve the rolled-up D4 (chat round-trip + tool round-trip) row for an
+ * integration. INTEGRATION-scoped, not per-feature: the producer
+ * (`d4-chat-roundtrip.ts`) writes `chat:<slug>` / `tools:<slug>` rows once
+ * per integration.
+ *
+ * Mirrors `resolveD4` in cell-model.ts, including its EXPECTATION MAPPING:
+ *   - `chat:<slug>` is producer-UNCONDITIONAL (written for every probed
+ *     integration). A green/degraded fold with the chat row MISSING is an
+ *     unverified family and collapses to `null` (no-data → gray badge). A
+ *     present RED-or-worse tools row still surfaces — red dominates no-data,
+ *     and the collapse guard is RANK-based (not `!== "red"` literal) so an
+ *     out-of-vocabulary state ranked above red by the A2 machinery is never
+ *     silently swallowed.
+ *   - `tools:<slug>` is CONDITIONAL (side-emitted only when the
+ *     integration's demos include `tool-rendering`), so its absence stays
+ *     LENIENT — a green chat row alone credits D4.
+ *
+ * Fold semantics match resolveD5Row/resolveD6Row: per-row stale-green →
+ * degraded downgrade (D4 uses the 1h `D4_STALE_AFTER_MS` window) applied
+ * BEFORE the worst-state comparison; strict `>` rank comparison over
+ * `[chat, tools]` scan order, so on an equal rank the chat row is retained.
+ * Like its siblings, the returned winner is the EFFECTIVE (stale-downgraded)
+ * row, so `.state` always agrees with the rank that won the fold. Exported
+ * for tests and consumed by `resolveCell` for the drilldown's D4 badge.
+ */
+export function resolveD4Row(
+  live: LiveStatusMap,
+  slug: string,
+  now: number = Date.now(),
+): StatusRow | null {
+  const chatRow = live.get(keyFor("chat", slug)) ?? null;
+  const toolsRow = live.get(keyFor("tools", slug)) ?? null;
+
+  if (!chatRow && !toolsRow) {
+    return null;
+  }
+
+  let worst: StatusRow | null = null;
+  let worstState: State | null = null;
+  for (const candidate of [chatRow, toolsRow]) {
+    if (!candidate) continue;
+    const eff = effectiveState(candidate, now, D4_STALE_AFTER_MS);
+    if (
+      worstState === null ||
+      worstStateRank(eff) > worstStateRank(worstState)
+    ) {
+      // Store the EFFECTIVE (downgraded) row — see resolveD5Row.
+      worst =
+        eff === candidate.state ? candidate : { ...candidate, state: eff };
+      worstState = eff;
+    }
+  }
+
+  // STRICT on the UNCONDITIONAL row: a missing `chat:<slug>` collapses a
+  // below-red fold to no-data (mirrors cell-model.ts resolveD4 and the
+  // D5/D6 anyMissing collapse). Rank-based so out-of-vocab states survive.
+  if (
+    !chatRow &&
+    (worstState === null || worstStateRank(worstState) < WORST_STATE_RANK.red)
+  ) {
+    return null;
+  }
+  return worst;
+}
+
 /* ------------------------------------------------------------------ */
 /*  Starter row-group (spec §d / §a)                                    */
 /* ------------------------------------------------------------------ */
@@ -822,6 +901,7 @@ export type LiveDimension =
   | "agent"
   | "chat"
   | "tools"
+  | "d4"
   | "d5"
   | "d6"
   | "starter";
@@ -1053,6 +1133,10 @@ export function resolveCell(
   // weekly-rotation slot.
   const d5Row = resolveD5Row(live, slug, featureId, now);
   const d6Row = resolveD6Row(live, slug, featureId, now);
+  // D4 integration-scoped fold over `chat:<slug>`/`tools:<slug>` — same
+  // informational (non-rollup) model as d2/d5/d6; the pill's verification
+  // gate consumes D4 separately via buildCellModel.
+  const d4Row = resolveD4Row(live, slug, now);
 
   // Rollup contributors: health + e2e (Decision #7: smokeRow dropped).
   // Each contributor's stale-green is downgraded to degraded BEFORE tone
@@ -1115,7 +1199,8 @@ export function resolveCell(
   }
 
   // Per-badge stale-green downgrade windows: e2e/d5/d6 use the e2e (6h)
-  // window; health/d2(agent)/smoke use the tighter liveness (45m) window.
+  // window; d4 uses the D4 (1h) window; health/d2(agent)/smoke use the
+  // tighter liveness (45m) window.
   return {
     e2e: buildBadge("e2e", e2eRow, now, E2E_STALE_AFTER_MS, connection),
     smoke: buildBadge(
@@ -1133,6 +1218,7 @@ export function resolveCell(
       connection,
     ),
     d2: buildBadge("agent", agentRow, now, LIVENESS_STALE_AFTER_MS, connection),
+    d4: buildBadge("d4", d4Row, now, D4_STALE_AFTER_MS, connection),
     d5: buildBadge("d5", d5Row, now, E2E_STALE_AFTER_MS, connection),
     d6: buildBadge("d6", d6Row, now, E2E_STALE_AFTER_MS, connection),
     rollup,

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -148,7 +148,12 @@ export function commErrorFromStatusSignal(
 ): PoolCommError | undefined {
   if (signal === null || typeof signal !== "object") return undefined;
   const raw = (signal as Record<string, unknown>)[FLEET_COMM_ERROR_SIGNAL_KEY];
-  if (raw === null || typeof raw !== "object") return undefined;
+  // Array.isArray: arrays are typeof "object", and an array carrying
+  // comm-error fields as expando properties would otherwise decode as a
+  // well-formed PoolCommError — never a valid wire shape.
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return undefined;
+  }
   const candidate = raw as Partial<PoolCommError>;
   if (
     !isPoolCommErrorKind(candidate.kind) ||

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -111,6 +111,32 @@ export interface PoolCommError {
 export const FLEET_COMM_ERROR_SIGNAL_KEY = "__fleetCommError" as const;
 
 /**
+ * The status-row DIMENSIONS whose integration-level AGGREGATE rows
+ * (`<dimension>:<slug>`, no `/<featureId>` segment) carry mirrored fleet comm
+ * errors (REQ-B): the harness result-aggregator / control-plane fleet-health
+ * leg mirror onto `d6:<slug>`, and the global lease sweep mirrors onto the
+ * reclaimed job's `probe_key` — `d4:<slug>` (smoke), `e2e-demos:<slug>`
+ * (demos), and `d5-single-pill-e2e:<slug>` (deep) for the non-d6 families
+ * (see harness resolveSweepAggregateKey → aggregateCommError, and the G3f
+ * candidate scan in cell-model.ts `decodeCellCommError`).
+ *
+ * SINGLE SOURCE OF TRUTH shared by two consumers that must stay in lockstep:
+ *   - `decodeCellCommError` (cell-model.ts) scans these aggregate keys for
+ *     the unreachable/pending overlay, and
+ *   - `useLiveStatus`'s supplemental initial fetch re-fetches exactly these
+ *     rows WITH `signal` (the bulk initial fetch projects `signal` away — see
+ *     `STATUS_LIST_FIELDS` — so without the supplemental fetch a cold page
+ *     load would render every active comm-error overlay invisible until an
+ *     SSE delta happened to re-deliver the row; CF7-F3 #1).
+ */
+export const FLEET_COMM_AGGREGATE_DIMENSIONS = [
+  "d6",
+  "d4",
+  "e2e-demos",
+  "d5-single-pill-e2e",
+] as const;
+
+/**
  * The dashboard's per-cell presentation state: the cell's resolved colour
  * vocabulary (`green` | `amber` | `red` | `gray`, i.e. the `ChipColor` the cell
  * already renders) PLUS the comm-error overlay `"unreachable"`. A PRESENTATION
@@ -193,15 +219,26 @@ export interface StatusRow {
 export type LiveStatusMap = Map<string, StatusRow>;
 
 /**
- * Comma-joined PocketBase `fields` projection for the INITIAL status fetch —
- * every `StatusRow` field EXCEPT `signal`. The `signal` blob (probe output:
- * error messages, diffs, nested objects) is ~61% of the status payload by
- * size but is only ever read in the drilldown panel and the per-cell banner,
- * both of which lazy-load the full row on demand. Dropping it from the bulk
- * initial fetch (~2455 rows across ~5 pages) is the dominant transfer-size win
- * for first paint; the live SSE subscription still delivers full rows
- * (`signal` included) for every subsequent delta, so the drilldown/banner are
- * unaffected once a row updates.
+ * Comma-joined PocketBase `fields` projection for the BULK INITIAL status
+ * fetch — every `StatusRow` field EXCEPT `signal`. The `signal` blob (probe
+ * output: error messages, diffs, nested objects) is ~61% of the status
+ * payload by size. Dropping it from the bulk initial fetch (~2455 rows across
+ * ~5 pages) is the dominant transfer-size win for first paint; the live SSE
+ * subscription still delivers full rows (`signal` included) for every
+ * subsequent delta.
+ *
+ * `signal` IS read at render time, in three places:
+ *   - the drilldown panel and the per-cell banner, which lazy-load the full
+ *     row on demand (unaffected by this projection), and
+ *   - `buildCellModel` → `decodeCellCommError` (cell-model.ts), which reads
+ *     `row.signal` PER CELL on every render to derive the REQ-B
+ *     unreachable/pending comm-error overlay. That read cannot lazy-load —
+ *     so `useLiveStatus` issues a SUPPLEMENTAL initial fetch (CF7-F3 #1) of
+ *     ONLY the comm-error candidate aggregate rows
+ *     (`FLEET_COMM_AGGREGATE_DIMENSIONS`, `<dim>:<slug>` keys — a few rows
+ *     per integration, not the whole collection) WITH `signal`, keeping the
+ *     bulk projection's payload win while making active overlays visible
+ *     from a cold load instead of waiting for an SSE re-delivery.
  *
  * Guarded by `live-status.test.ts`: this list must equal `keyof StatusRow`
  * minus `signal`, so a new `StatusRow` field forces a conscious decision about
@@ -940,9 +977,7 @@ function buildBadge(
   // split (see formatTooltip's `stale` param) so the two can never disagree.
   const stale = row !== null && isStale(row, now, maxAgeMs);
   const effRow: StatusRow | null =
-    row && row.state === "green" && stale
-      ? { ...row, state: "degraded" }
-      : row;
+    row && row.state === "green" && stale ? { ...row, state: "degraded" } : row;
   return {
     tone: rowTone(effRow),
     label: formatLabel(dim, effRow, stale),

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -767,12 +767,20 @@ export type LiveDimension =
   | "d6"
   | "starter";
 
-function formatLabel(dim: LiveDimension, row: StatusRow | null): string {
+function formatLabel(
+  dim: LiveDimension,
+  row: StatusRow | null,
+  stale: boolean,
+): string {
   if (!row) return "?";
   if (dim === "health") {
     if (row.state === "green") return "up";
     if (row.state === "red") return "down";
-    if (row.state === "degraded") return "stale";
+    // Honor the SAME staleness split as formatTooltip: an age-downgraded
+    // green (or a degraded row that itself stopped updating) reads "stale",
+    // while a FRESH producer-emitted degraded reads "degraded" — hardcoding
+    // "stale" here contradicted the "degraded since …" tooltip.
+    if (row.state === "degraded") return stale ? "stale" : "degraded";
     // Exhaustiveness check for `health` dim — see rowTone() comment.
     const _exhaustive: never = row.state;
     void _exhaustive;
@@ -937,7 +945,7 @@ function buildBadge(
       : row;
   return {
     tone: rowTone(effRow),
-    label: formatLabel(dim, effRow),
+    label: formatLabel(dim, effRow, stale),
     tooltip: formatTooltip(dim, effRow, connection, stale),
     row: effRow,
   };

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -149,11 +149,14 @@ export type FleetSurfaceState =
 export function commErrorFromStatusSignal(
   signal: unknown,
 ): PoolCommError | undefined {
-  if (signal === null || typeof signal !== "object") return undefined;
+  // Array.isArray (BOTH levels): arrays are typeof "object", and an array
+  // carrying the signal key (here) or comm-error fields (below) as expando
+  // properties would otherwise decode as a well-formed PoolCommError — an
+  // array is never a valid wire shape at either level.
+  if (signal === null || typeof signal !== "object" || Array.isArray(signal)) {
+    return undefined;
+  }
   const raw = (signal as Record<string, unknown>)[FLEET_COMM_ERROR_SIGNAL_KEY];
-  // Array.isArray: arrays are typeof "object", and an array carrying
-  // comm-error fields as expando properties would otherwise decode as a
-  // well-formed PoolCommError — never a valid wire shape.
   if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
     return undefined;
   }

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -944,8 +944,24 @@ export function resolveCell(
     ? effectiveState(e2eRow, now, E2E_STALE_AFTER_MS)
     : null;
   const contributorStates: Array<State | null> = [healthEff, e2eEff];
-  const hasAnyRed = contributorStates.includes("red");
-  const hasAnyAmber = contributorStates.includes("degraded");
+  // Fold contributor states through the A2 rank machinery (worstStateRank),
+  // NOT literal includes() checks: a `State`-typed value can hold an
+  // out-of-vocabulary runtime state (e.g. "error" — see worstStateRank),
+  // which a literal fold matches against neither "red" nor "degraded", so
+  // the cell rolls up GRAY (benign no-data) while the contributor's own
+  // badge renders the loud "error" tone. The rank machinery deliberately
+  // ranks an unknown state ABOVE red, so it rolls up at least red-severity
+  // instead of being silently swallowed (the documented precedence
+  // red > degraded > green > error > unknown never demotes a present
+  // failure below red).
+  let worstContributorRank = 0;
+  for (const s of contributorStates) {
+    if (s === null) continue;
+    const rank = worstStateRank(s);
+    if (rank > worstContributorRank) worstContributorRank = rank;
+  }
+  const hasAnyRed = worstContributorRank >= WORST_STATE_RANK.red;
+  const hasAnyAmber = worstContributorRank === WORST_STATE_RANK.degraded;
   // `allGreen` is gated on `connection !== "error"` to avoid the stale-green
   // lie (spec §5.3): when the SSE stream has gone dark, any cached green
   // rows are by definition stale and must NOT be presented as authoritative

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -639,9 +639,11 @@ const STARTER_LEVEL_DESCRIPTION: Readonly<Record<StarterLevel, string>> = {
  *                      downgraded to degraded (delegated to `buildBadge`).
  *
  * The data-bearing states (green/red/stale/gray) are delegated to the shared
- * `buildBadge` path under the `health` dimension label so the level glyphs/copy
- * reuse the same staleness downgrade + tooltip machinery as every other badge;
- * the per-level descriptor is appended to the tooltip.
+ * `buildBadge` path under the `starter` dimension label — NOT `health`, whose
+ * dimension branch renders the up/down/stale word labels; the ✓/✗/~ glyph
+ * vocabulary above requires the non-health branch of `formatLabel`. The shared
+ * path supplies the same staleness downgrade + tooltip machinery as every
+ * other badge; the per-level descriptor is appended to the tooltip.
  */
 export function buildStarterBadge(
   level: StarterLevel,

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -460,9 +460,16 @@ function resolveD5Row(
     }
   }
   // A missing mapped sub-row makes the family unverified: collapse a
-  // present green/degraded fold to no-data (null). A present red still
-  // dominates (returns the red row).
-  if (anyMissing && worstState !== "red") {
+  // present green/degraded fold to no-data (null). A present red-or-worse
+  // still dominates (returns that row). RANK-based, not `!== "red"` literal
+  // equality: `worstState` is typed `State` but can hold an out-of-vocabulary
+  // runtime value (e.g. "error"), which the A2 rank machinery deliberately
+  // ranks ABOVE red — literal equality would silently swallow exactly the
+  // state the rank fold exists to surface.
+  if (
+    anyMissing &&
+    (worstState === null || worstStateRank(worstState) < WORST_STATE_RANK.red)
+  ) {
     return null;
   }
   return worst;
@@ -516,7 +523,13 @@ function resolveD6Row(
       worstState = eff;
     }
   }
-  if (anyMissing && worstState !== "red") {
+  // Rank-based anyMissing collapse — mirrors resolveD5Row: a present
+  // red-or-worse (including an out-of-vocab state ranked above red by the A2
+  // machinery) dominates no-data; only a green/degraded fold collapses.
+  if (
+    anyMissing &&
+    (worstState === null || worstStateRank(worstState) < WORST_STATE_RANK.red)
+  ) {
     return null;
   }
   return worst;

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -204,6 +204,28 @@ export function commErrorFromStatusSignal(
   return out;
 }
 
+/**
+ * Companion to `commErrorFromStatusSignal`: does the signal blob CARRY the
+ * well-known comm-error key at all, regardless of whether the embedded value
+ * decodes? Lets consumers distinguish "key present but undecodable" (a REQ-B
+ * overlay written by a NEWER producer — e.g. a new `PoolCommErrorKind` rolled
+ * out write-side first — that this reader silently drops; count/log it) from
+ * "genuinely absent" (nothing to report) without changing the decode's return
+ * contract. Mirrors the decoder's wire-shape guards: a null / non-object /
+ * array blob is never a valid signal, so the key cannot be "present" on one.
+ * Sibling of the harness contract's `statusSignalHasCommErrorKey`
+ * (`showcase/harness/src/fleet/contracts.ts`) — both live OUTSIDE the
+ * byte-identity region pinned by `commError-contract-drift.test.ts` (only the
+ * `commErrorFromStatusSignal` function source is mirrored). Pure;
+ * unit-tested.
+ */
+export function statusSignalHasCommErrorKey(signal: unknown): boolean {
+  if (signal === null || typeof signal !== "object" || Array.isArray(signal)) {
+    return false;
+  }
+  return FLEET_COMM_ERROR_SIGNAL_KEY in signal;
+}
+
 export interface StatusRow {
   id: string;
   key: string;

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -248,6 +248,14 @@ export interface CellState {
    * ANY cell fails and would mis-paint green cells red. A missing row resolves
    * to a gray `?` badge. Does NOT contribute to the rollup for the same reason
    * as D5.
+   *
+   * UNGATED — not for top-level D6 badges. This is the raw per-dimension D6
+   * fold with NO verification-ladder gate: a Coverage-tab D6 badge or D6
+   * stat MUST consume `CellModel.d6Effective` (cell-model.ts), which
+   * collapses a D6 claim to null when the ladder below it (D1-D5) is broken
+   * or unverified. The only intended consumer of THIS field is the
+   * cell-drilldown's raw per-dimension diagnostic row, where showing the
+   * ungated underlying D6 result is the point.
    */
   d6: BadgeRender;
   /** Rollup tone for the cell, by precedence red > degraded > green > error > unknown. */
@@ -438,8 +446,13 @@ function effectiveState(row: StatusRow, now: number, maxAgeMs: number): State {
  * them to anything. The caller (`resolveCell`) renders gray when no
  * row is returned, which surfaces "no data yet" distinctly from
  * green.
+ *
+ * Returns the EFFECTIVE (stale-downgraded) winner row — a stale-green
+ * winner comes back with `state: "degraded"`, matching the rank that made
+ * it win the fold, so `.state` never contradicts the resolution (mirrors
+ * `resolveD5` in cell-model.ts and `buildBadge` below). Exported for tests.
  */
-function resolveD5Row(
+export function resolveD5Row(
   live: LiveStatusMap,
   slug: string,
   featureId: string,
@@ -482,7 +495,9 @@ function resolveD5Row(
       worstState === null ||
       worstStateRank(eff) > worstStateRank(worstState)
     ) {
-      worst = row;
+      // Store the EFFECTIVE (downgraded) row so the returned `.state` agrees
+      // with the rank that won the fold — mirrors cell-model.ts `resolveD5`.
+      worst = eff === row.state ? row : { ...row, state: eff };
       worstState = eff;
     }
   }
@@ -520,9 +535,11 @@ function resolveD5Row(
  * sub-rows — a missing
  * mapped sub-row collapses a present green/degraded fold to `null` (no-data →
  * gray badge) UNLESS a present sub-row is red (red dominates no-data). An
- * unmapped feature returns `null` (no D6 test exists for it).
+ * unmapped feature returns `null` (no D6 test exists for it). Like
+ * `resolveD5Row`, the returned winner is the EFFECTIVE (stale-downgraded)
+ * row, so `.state` agrees with the fold. Exported for tests.
  */
-function resolveD6Row(
+export function resolveD6Row(
   live: LiveStatusMap,
   slug: string,
   featureId: string,
@@ -546,7 +563,8 @@ function resolveD6Row(
       worstState === null ||
       worstStateRank(eff) > worstStateRank(worstState)
     ) {
-      worst = row;
+      // Store the EFFECTIVE (downgraded) row — see resolveD5Row.
+      worst = eff === row.state ? row : { ...row, state: eff };
       worstState = eff;
     }
   }
@@ -806,10 +824,20 @@ function summarizeSignal(signal: unknown): string {
   return s.length > 80 ? `${s.slice(0, 77)}...` : s;
 }
 
+/**
+ * `stale` is the SAME per-row staleness check the badge tone derivation uses
+ * (`isStale(row, now, maxAgeMs)`, computed by `buildBadge`). It splits the
+ * degraded copy: an AGE-DOWNGRADED green (or a degraded row that has itself
+ * stopped updating) reads "stale — last seen @ …", while a FRESH
+ * producer-emitted degraded reads "degraded since …" — labeling a fresh
+ * degraded signal "stale" told operators the row had stopped updating when
+ * the producer genuinely emitted degradation on a recent tick.
+ */
 function formatTooltip(
   dim: LiveDimension,
   row: StatusRow | null,
   connection: ConnectionStatus,
+  stale: boolean,
 ): string {
   if (connection === "error") {
     // When the SSE stream is dead AND we have a recent red/degraded row,
@@ -837,7 +865,15 @@ function formatTooltip(
       // for a degraded row that timestamp is when degradation was
       // last observed. Earlier copy ("last pass @ ...") was misleading
       // operators into reading it as the last green tick.
-      const base = `${dim} stale — last seen @ ${formatTs(row.observed_at)}`;
+      if (stale) {
+        const base = `${dim} stale — last seen @ ${formatTs(row.observed_at)}`;
+        const sig = summarizeSignal(row.signal);
+        return sig ? `${base} — ${sig}` : base;
+      }
+      // FRESH producer-emitted degraded: the row IS updating — the signal is
+      // genuine degradation, not a frozen row. Mirrors the red copy's
+      // "since" anchored on the state transition.
+      const base = `${dim} degraded since ${formatTs(row.transitioned_at)}`;
       const sig = summarizeSignal(row.signal);
       return sig ? `${base} — ${sig}` : base;
     }
@@ -889,14 +925,17 @@ function buildBadge(
   maxAgeMs: number,
   connection: ConnectionStatus,
 ): BadgeRender {
+  // ONE staleness check shared by the tone downgrade AND the tooltip copy
+  // split (see formatTooltip's `stale` param) so the two can never disagree.
+  const stale = row !== null && isStale(row, now, maxAgeMs);
   const effRow: StatusRow | null =
-    row && row.state === "green" && isStale(row, now, maxAgeMs)
+    row && row.state === "green" && stale
       ? { ...row, state: "degraded" }
       : row;
   return {
     tone: rowTone(effRow),
     label: formatLabel(dim, effRow),
-    tooltip: formatTooltip(dim, effRow, connection),
+    tooltip: formatTooltip(dim, effRow, connection, stale),
     row: effRow,
   };
 }

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -56,10 +56,13 @@ export const POOL_COMM_ERROR_KINDS = [
   /** The worker exceeded the protocol response deadline (hung, no crash). */
   "worker-protocol-timeout",
   /**
-   * The worker's OWN self-monitor observed an in-driver pool-infra crash
-   * mid-job and reported it directly (a known crash — stays red). A lease
-   * that merely expired with no terminal report is NOT this kind; the sweep
-   * emits `worker-reclaimed-pending` for that.
+   * A known crash/loss on a specific job (stays red), reported by either of
+   * two sources: the worker's OWN self-monitor (observed an in-driver
+   * pool-infra crash mid-job), or the control-plane RESULT CONSUMER (a row
+   * went terminal but its separate result write never landed past the grace
+   * window — the result is lost). A lease that merely expired with no
+   * terminal report is NEITHER source; the sweep emits
+   * `worker-reclaimed-pending` for that. Mirror of the harness kind doc.
    */
   "worker-crashed-mid-job",
   /** A report arrived but failed schema/shape validation (protocol mismatch). */

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -269,10 +269,21 @@ export function keyFor(
       `keyFor: slug must not contain ':' or '/' (got ${JSON.stringify(slug)})`,
     );
   }
-  if (featureId && (featureId.includes(":") || featureId.includes("/"))) {
-    throw new Error(
-      `keyFor: featureId must not contain ':' or '/' (got ${JSON.stringify(featureId)})`,
-    );
+  if (featureId !== undefined) {
+    // An EMPTY featureId is falsy: a bare truthiness guard would skip the
+    // delimiter validation AND the per-feature branch below, silently
+    // fabricating the integration-aggregate key (`<dimension>:<slug>`) for
+    // what the caller meant as a per-feature lookup. Throw loudly instead.
+    if (featureId === "") {
+      throw new Error(
+        `keyFor: featureId must not be empty for a per-feature dimension key (dimension=${JSON.stringify(dimension)}, slug=${JSON.stringify(slug)})`,
+      );
+    }
+    if (featureId.includes(":") || featureId.includes("/")) {
+      throw new Error(
+        `keyFor: featureId must not contain ':' or '/' (got ${JSON.stringify(featureId)})`,
+      );
+    }
   }
   return featureId
     ? `${dimension}:${slug}/${featureId}`

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -114,7 +114,7 @@ export const FLEET_COMM_ERROR_SIGNAL_KEY = "__fleetCommError" as const;
  * type only — never a persisted column.
  *
  * This is the dashboard analogue of the harness `FleetSurfaceState`
- * (`ProbeState | "unreachable"`). The dashboard's cell render model uses
+ * (`ProbeState | "unreachable" | "pending"`). The dashboard's cell render model uses
  * `ChipColor` (with `gray` for no-data and `amber` for degraded) rather than
  * the raw probe `State`, so the union is expressed over `ChipColor` to avoid an
  * unsafe widen of the no-data `gray` case through `State`.

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -989,8 +989,17 @@ export function resolveCell(
 
 /**
  * Shallow equality on the row fields that change observably between
- * SSE updates: `key`, `state`, `observed_at`, `transitioned_at`, plus the
- * PRESENCE (not content) of `signal`.
+ * SSE updates: `id`, `key`, `state`, `observed_at`, `transitioned_at`,
+ * `fail_count`, `first_failure_at`, plus the PRESENCE (not content) of
+ * `signal`.
+ *
+ * `fail_count` and `first_failure_at` are observable on their own:
+ * `first_failure_at` is load-bearing in `formatTooltip` ("red since ..."),
+ * and `fail_count` feeds the drilldown/alerting surfaces — a delta moving
+ * only one of them must not be discarded. `id` changes when a status row is
+ * deleted and recreated upstream (same key, fresh PB record id); swallowing
+ * that delta would strand the stale id in the map and break any id-keyed
+ * follow-up fetch.
  *
  * Signal handling: the initial fetch projection drops `signal`, so initial
  * rows arrive with `signal === undefined` and rely on SSE deltas to deliver
@@ -1018,10 +1027,13 @@ function rowsAreNoop(prev: unknown, next: unknown): boolean {
   const a = prev as Record<string, unknown>;
   const b = next as Record<string, unknown>;
   return (
+    a.id === b.id &&
     a.key === b.key &&
     a.state === b.state &&
     a.observed_at === b.observed_at &&
     a.transitioned_at === b.transitioned_at &&
+    a.fail_count === b.fail_count &&
+    a.first_failure_at === b.first_failure_at &&
     (a.signal === undefined) === (b.signal === undefined)
   );
 }
@@ -1031,9 +1043,10 @@ function rowsAreNoop(prev: unknown, next: unknown): boolean {
  * live-subscribe reducer when the SSE stream emits a record update.
  *
  * Returns the SAME array reference when the incoming row is a no-op
- * (key + state + observed_at + transitioned_at unchanged AND signal
- * presence unchanged) so React's reference-equality short-circuit can
- * skip re-rendering downstream memoised components.
+ * (id + key + state + observed_at + transitioned_at + fail_count +
+ * first_failure_at unchanged AND signal presence unchanged) so React's
+ * reference-equality short-circuit can skip re-rendering downstream
+ * memoised components.
  */
 export function upsertByKey<T extends { key: string }>(
   rows: T[],
@@ -1061,8 +1074,8 @@ export function upsertByKey<T extends { key: string }>(
  *
  * The warning fires only on GENUINE divergence — two rows with the same key
  * but a different observable state (compared via `rowsAreNoop`, the same
- * key/state/observed_at/transitioned_at + signal-presence shallow check the
- * reducer uses).
+ * id/key/state/observed_at/transitioned_at/fail_count/first_failure_at +
+ * signal-presence shallow check the reducer uses).
  * Identical-content-but-different-reference rows (e.g. the same producer row
  * re-allocated across two groups) are NOT a real invariant violation and used
  * to fire a noisy false warning under the old reference-based `prior !== r`

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -272,6 +272,14 @@ export function keyFor(
   // collide in the lookup map (e.g. `smoke:a/b` vs `smoke:a` + `/b`).
   // Throw loudly so the bug surfaces at the call site instead of via
   // a phantom missing/duplicate badge downstream.
+  if (dimension.includes(":") || dimension.includes("/")) {
+    // Same guard as slug/featureId: a colon-bearing dimension would silently
+    // parse as a DIFFERENT dimension + slug suffix, and a slash-bearing one
+    // would fabricate a phantom feature segment.
+    throw new Error(
+      `keyFor: dimension must not contain ':' or '/' (got ${JSON.stringify(dimension)})`,
+    );
+  }
   if (slug.includes(":") || slug.includes("/")) {
     throw new Error(
       `keyFor: slug must not contain ':' or '/' (got ${JSON.stringify(slug)})`,
@@ -1084,11 +1092,13 @@ function rowsAreNoop(prev: unknown, next: unknown): boolean {
  * first_failure_at unchanged AND signal presence unchanged) so React's
  * reference-equality short-circuit can skip re-rendering downstream
  * memoised components.
+ *
+ * `T` is constrained to `StatusRow` (not a bare `{ key: string }`): the no-op
+ * decision compares StatusRow's discriminating fields, so a looser bound
+ * would let `rowsAreNoop` vacuously match a non-StatusRow type whose fields
+ * are all `undefined` — silently swallowing every update for that type.
  */
-export function upsertByKey<T extends { key: string }>(
-  rows: T[],
-  next: T,
-): T[] {
+export function upsertByKey<T extends StatusRow>(rows: T[], next: T): T[] {
   const idx = rows.findIndex((r) => r.key === next.key);
   if (idx === -1) return [...rows, next];
   const existing = rows[idx];


### PR DESCRIPTION
## Summary

Bundles two related dashboard/harness lanes that landed together once both reached green:

1. **CF #18 fairness / claim-fair lane** — the 23-commit base (`fix/fleet-claim-fairness` rebased onto its CF7 integration tip `80c5c9402`) carrying claim-spike, cf3/cf4/cf5/cf6/cf7 hardening waves, plus the **CF8 micro-fix** for the round-8 supplemental-merge finding:

   - **CF8 F3 supplemental-merge freshness guard** (`useLiveStatus.ts`): the cold-load comm-error supplemental fetch runs CONCURRENTLY with the bulk pages, so the bulk copy of an aggregate row can be NEWER than the supplemental snapshot. The previous merge replaced the bulk row unconditionally, regressing `state`/`observed_at` to stale values until the row's next SSE delta (long for slow-cadence aggregates). Added `supplementalRowIsOlder` — when the supplemental row is strictly older the newer bulk row stays INTACT (signal-less) rather than being grafted into a chimera (newer core + stale signal) that the reducer's signal-PRESENCE no-op check would silently swallow.

   - **Procedure 3 promotions** (bucket-c/d audit over the CF round-8 ledger): one functional fix (escape `workerId` in fleet-health's reclaim list filter — matches the `JSON.stringify` pattern used at orchestrator.ts:3240 for the same field; a `"`-bearing worker_id would otherwise break out of the literal) plus five doc reconciliations on the producer/contract surfaces flagged across slot1/slot2/slot4/slot5 (stale queue-client cross-reference, WarmHealthConfig doc vs `gate.specs` reality, TickResult.reclaimedIndeterminate "Of reclaimed" → "In addition to reclaimed", TickResult.skippedForBacklog poisoned-count contributor, SweepResult.commErrors equation scoping).

2. **Dashboard drilldown D4 parity** — three commits making the dashboard drilldown surface the D4 rung the same way the grid does:

   - `feat(showcase): add resolveD4Row + CellState.d4 so the drilldown can see the D4 rung` — exposes the D4 row on `CellState`, modeled after `resolveD3Row`.
   - `fix(showcase): drilldown shows the D4 row, de-crosses the e2e label, and scopes the rollup line honestly` — renders D4 in the drilldown panel, fixes the crossed e2e label, scopes the rollup line to its real source set.
   - `fix(showcase): unify dimension naming on the legend taxonomy across grid, legacy cells, and legend` — taxonomy cleanup so legend, grid, and legacy cells use one set of labels.

## Verification

- Dashboard `npx tsc --noEmit`: clean (only the pre-existing missing-`@/data/*.json` errors that exist on `main`).
- Dashboard `vitest run`: 59 files / 1012 tests passing, 1 skipped.
- Harness `npx tsc --noEmit`: clean.
- Harness `vitest run`: 121/122 files passing; 1 failed = `probe-invoker times out invoker-level even when driver ignores abortSignal` — the NAMED known wall-clock flake (per CF7 integration verification), re-run in isolation: 67/67 PASS.
- Rebase of drilldown-parity onto the updated `fix/cf8-m1` tip: ZERO conflicts (the two lanes touch disjoint files).

## Test plan

- [ ] CI green on the PR
- [ ] Dashboard drilldown shows D4 rung in addition to D3/D5/D6
- [ ] Legend taxonomy reads the same in legend, grid, drilldown
- [ ] (post-merge, in showcase) cold-load comm-error overlay still paints; a stale supplemental no longer regresses a freshly-failed aggregate row