### PR TITLE
feat(showcase): end-to-end run-visibility for fleet — /api/runs + family-silence Slack alerting

### DIFF
--- a/showcase/harness/src/cli/control-plane-run.ts
+++ b/showcase/harness/src/cli/control-plane-run.ts
@@ -282,7 +282,7 @@ async function pbFetchStatus(
   token: string,
   keys: string[],
 ): Promise<Map<string, StatusRow>> {
-  const filter = keys.map((k) => `key="${k}"`).join(" || ");
+  const filter = keys.map((k) => `key = ${JSON.stringify(k)}`).join(" || ");
   const qs = new URLSearchParams({
     perPage: "200",
     filter,

--- a/showcase/harness/src/cli/control-plane-run.ts
+++ b/showcase/harness/src/cli/control-plane-run.ts
@@ -38,6 +38,7 @@ import { createE2eDeepServiceEnumerator } from "../fleet/control-plane/catalog-e
 import { createServiceEnumerator } from "../fleet/control-plane/catalog-enumerator.js";
 import { D6_DRIVER_KIND } from "../fleet/control-plane/catalog-enumerator.js";
 import { createJobProducer } from "../fleet/control-plane/job-producer.js";
+import { FLEET_FAMILIES } from "../fleet/control-plane/run-view.js";
 import type { ServiceEnumerator } from "../fleet/control-plane/job-producer.js";
 import { createFleetQueueClient } from "../fleet/queue-client.js";
 import { createPbClient } from "../storage/pb-client.js";
@@ -52,6 +53,24 @@ import { demosForSlug } from "./targets.js";
 
 /** The two fleet levels this runner can drive. */
 export type ControlPlaneLevel = "d5" | "d6";
+
+/**
+ * Map a runner level onto its §5.1 registry family id. The two levels happen
+ * to share their family's name today, but the lookup goes through
+ * `FLEET_FAMILIES` deliberately: a registry rename/removal fails loudly here
+ * instead of letting a triggered tick stamp a family the /api/runs projection
+ * no longer knows (the job would aggregate into nothing — invisible).
+ */
+function familyForLevel(level: ControlPlaneLevel): string {
+  const entry = FLEET_FAMILIES.find((f) => f.family === level);
+  if (!entry) {
+    throw new Error(
+      `no FLEET_FAMILIES entry for control-plane level "${level}" — ` +
+        "triggered ticks must stamp a §5.1 registry family",
+    );
+  }
+  return entry.family;
+}
 
 /** Tunables for the control-plane run (polling cadence + ceiling). */
 export interface ControlPlaneRunOptions {
@@ -346,7 +365,16 @@ export async function runViaControlPlane(
   });
   const queue = createFleetQueueClient({ pb, claim, logger });
   const enumerate = buildEnumerator(level, slugs, env, logger);
-  const producer = createJobProducer({ queue, enumerate, logger });
+  // §4.2: a triggered tick must stamp the SAME family id the scheduled
+  // producer for this level would, so the run aggregates into the correct
+  // family on the /api/runs projection. Resolve it through the §5.1 registry
+  // (never a hardcoded literal) so a registry rename breaks loudly here.
+  const producer = createJobProducer({
+    queue,
+    enumerate,
+    logger,
+    family: familyForLevel(level),
+  });
 
   // -- Mark when we triggered so polling only reads THIS run's cells --------
   const sinceIso = new Date().toISOString();

--- a/showcase/harness/src/fleet/contracts.test.ts
+++ b/showcase/harness/src/fleet/contracts.test.ts
@@ -13,6 +13,7 @@ import {
   runSummaryForServiceJobResult,
   isWorkerStale,
   heartbeatParseable,
+  deriveHealth,
   workerCapacityFromBudget,
   terminalJobStatus,
   probeKeyFamily,
@@ -392,6 +393,46 @@ describe("worker capacity + staleness", () => {
     expect(heartbeatParseable("2026-06-04T00:00:00.000Z")).toBe(true);
     // The PB space form is parseable AFTER the anchored normalization.
     expect(heartbeatParseable("2026-06-04 00:00:00.000Z")).toBe(true);
+  });
+});
+
+describe("deriveHealth (worker liveness from heartbeat age)", () => {
+  // Injected clock + a non-default window so the 1x/2x boundaries are
+  // explicit: with staleAfterMs = 1000, online ≤ 1000ms old, stale is
+  // (1000, 2000], offline > 2000ms.
+  const STALE_AFTER_MS = 1_000;
+  const nowMs = Date.parse("2026-06-04T00:01:00.000Z");
+  const beatAgedMs = (ageMs: number) => new Date(nowMs - ageMs).toISOString();
+
+  it('deriveHealth returns "online" for heartbeat ≤ staleAfterMs old', () => {
+    expect(deriveHealth(beatAgedMs(0), nowMs, STALE_AFTER_MS)).toBe("online");
+    // exact 1x boundary is NOT stale (isWorkerStale is strictly >)
+    expect(deriveHealth(beatAgedMs(1_000), nowMs, STALE_AFTER_MS)).toBe(
+      "online",
+    );
+  });
+
+  it('deriveHealth returns "stale" for heartbeat > 1x and ≤ 2x staleAfterMs', () => {
+    expect(deriveHealth(beatAgedMs(1_001), nowMs, STALE_AFTER_MS)).toBe(
+      "stale",
+    );
+    // exact 2x boundary is still stale, not offline (strictly >)
+    expect(deriveHealth(beatAgedMs(2_000), nowMs, STALE_AFTER_MS)).toBe(
+      "stale",
+    );
+  });
+
+  it('deriveHealth returns "offline" for heartbeat > 2x staleAfterMs', () => {
+    expect(deriveHealth(beatAgedMs(2_001), nowMs, STALE_AFTER_MS)).toBe(
+      "offline",
+    );
+    expect(deriveHealth(beatAgedMs(60_000), nowMs, STALE_AFTER_MS)).toBe(
+      "offline",
+    );
+  });
+
+  it('deriveHealth returns "online" for an unparseable timestamp (inherited lenient default — display surfaces MUST pre-check parseability, see run-view)', () => {
+    expect(deriveHealth("not-a-date", nowMs, STALE_AFTER_MS)).toBe("online");
   });
 });
 

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -685,6 +685,21 @@ export function isWorkerStale(
   return nowMs - beatMs > staleAfterMs;
 }
 
+/** Derive a worker's liveness from its heartbeat age. */
+export function deriveHealth(
+  lastHeartbeatAt: string,
+  nowMs: number,
+  staleAfterMs: number,
+): WorkerHealthState {
+  // OFFLINE is a stronger stale: heartbeat older than 2x the window. We don't
+  // act differently on stale vs offline (both reclaim), but the distinction is
+  // surfaced in logs so an operator can tell a briefly-missed-beat worker from
+  // a long-dead one.
+  if (isWorkerStale(lastHeartbeatAt, nowMs, staleAfterMs * 2)) return "offline";
+  if (isWorkerStale(lastHeartbeatAt, nowMs, staleAfterMs)) return "stale";
+  return "online";
+}
+
 /**
  * Build a `WorkerCapacity` from a `BrowserPoolBudget` (S6). Thin, explicit
  * field copy so the registration/heartbeat path never accidentally widens with
@@ -715,6 +730,14 @@ export function workerCapacityFromBudget(
 export interface EnqueueJobInput {
   /** The per-service payload to run. */
   payload: ServiceJobPayload;
+  /**
+   * The producing family's id — a `FLEET_FAMILIES[*].family` value from the
+   * §5.1 registry (`control-plane/run-view.ts`), stamped by the producer's
+   * `JobProducerOptions.family` onto every input it builds. The queue-client
+   * denormalizes it into the `probe_jobs.family` column for indexed per-family
+   * listing; absent → column written empty (pre-P2 row parity).
+   */
+  family?: string;
 }
 
 /** A lease handle a worker holds while running a claimed job. */
@@ -758,6 +781,14 @@ export interface ReportJobInput {
   workerId: string;
   /** The per-service result, OR a comm-error-only terminal report. */
   result: ServiceJobResult;
+}
+
+/** Per-leg deletion counts from one `FleetQueueClient.pruneAged` pass. */
+export interface PruneAgedResult {
+  /** Terminal (`done`/`failed`) rows deleted (older than terminalMaxAgeMs). */
+  terminal: number;
+  /** Non-terminal zombie rows deleted (older than zombieMaxAgeMs). */
+  zombie: number;
 }
 
 /** Outcome of sweeping expired leases (dead-worker reclamation). */
@@ -849,6 +880,10 @@ export interface FleetQueueClient {
    * means "not yet finished", not the `pending` status.)
    */
   countPendingForFamily(family: string): Promise<number>;
+  /** §4.2 retention: delete terminal rows older than terminalMaxAgeMs and
+   *  non-terminal (zombie) rows older than zombieMaxAgeMs, both by `created`.
+   *  Idempotent; single-owner by producer-side family gate. */
+  pruneAged(nowMs: number): Promise<PruneAgedResult>;
 }
 
 /**

--- a/showcase/harness/src/fleet/control-plane/control-plane.test.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   createControlPlane,
+  buildJobProducer,
   FLEET_PRODUCER_SCHEDULE_ID,
+  FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
+  FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
+  FLEET_PRODUCER_DEEP_SCHEDULE_ID,
   DEFAULT_PRODUCER_CRON,
 } from "./control-plane.js";
 import type { JobProducer, TickResult } from "./job-producer.js";
@@ -13,7 +17,12 @@ import type {
 import type { FleetHealthMonitor, FleetHealthResult } from "./fleet-health.js";
 import type { Scheduler, ScheduleEntry } from "../../scheduler/scheduler.js";
 import type { Logger } from "../../types/index.js";
-import type { PoolCommError } from "../contracts.js";
+import type {
+  EnqueueJobInput,
+  FleetQueueClient,
+  JobView,
+  PoolCommError,
+} from "../contracts.js";
 
 /**
  * Pins the control-plane ASSEMBLY: start() registers the producer's tick as the
@@ -528,6 +537,77 @@ describe("createControlPlane — multi-schedule hardening", () => {
   });
 });
 
+// ── §5.1 constant homing + §4.2 family threading through the wrapper ────────
+describe("control-plane — e2e producer schedule-id constants", () => {
+  it("exports FLEET_PRODUCER_SMOKE/DEMOS/DEEP_SCHEDULE_ID with the producer schedule id values", () => {
+    // These values MUST equal the scheduler entry ids the orchestrator wires
+    // (orchestrator.ts re-imports them from here after the T8 constant move).
+    expect(FLEET_PRODUCER_SMOKE_SCHEDULE_ID).toBe("fleet-producer-e2e-smoke");
+    expect(FLEET_PRODUCER_DEMOS_SCHEDULE_ID).toBe("fleet-producer-e2e-demos");
+    expect(FLEET_PRODUCER_DEEP_SCHEDULE_ID).toBe("fleet-producer-e2e-deep");
+  });
+});
+
+describe("buildJobProducer — family forwarding", () => {
+  /** Minimal producer-facing queue fake recording enqueue inputs. */
+  function makeRecordingQueue(): FleetQueueClient & {
+    enqueued: EnqueueJobInput[];
+  } {
+    const enqueued: EnqueueJobInput[] = [];
+    let jobSeq = 0;
+    const unsupported = (n: string) => () => {
+      throw new Error(`fake-queue: ${n} not used by these tests`);
+    };
+    return {
+      enqueued,
+      async enqueue(input: EnqueueJobInput): Promise<JobView> {
+        enqueued.push(input);
+        jobSeq += 1;
+        return {
+          id: `job-${jobSeq}`,
+          probe_key: input.payload.probeKey,
+          status: "pending",
+          claimed_by: "",
+          lease_expires_at: null,
+          version: 1,
+        };
+      },
+      async sweepExpired() {
+        return { reclaimed: 0, commErrors: [] };
+      },
+      async pruneAged() {
+        return { terminal: 0, zombie: 0 };
+      },
+      claimNext: unsupported("claimNext"),
+      renewLease: unsupported("renewLease"),
+      report: unsupported("report"),
+    } as unknown as FleetQueueClient & { enqueued: EnqueueJobInput[] };
+  }
+
+  it("forwards family to createJobProducer (observed on a produced enqueue input)", async () => {
+    // The wrapper re-declares every forwarded dep (explicit spread), so an
+    // omitted `family` field would SILENTLY drop the option (§4.2) — this test
+    // pins the forwarding by observing the stamped family end-to-end.
+    const queue = makeRecordingQueue();
+    const producer = buildJobProducer({
+      queue,
+      enumerate: () => [
+        {
+          probeKey: "d5-single-pill-e2e:langgraph-python",
+          serviceSlug: "langgraph-python",
+          driverKind: "e2e_d5",
+        },
+      ],
+      logger: SILENT_LOGGER,
+      family: "d5",
+    });
+    producer.start();
+    await producer.tick();
+    expect(queue.enqueued).toHaveLength(1);
+    expect(queue.enqueued[0]!.family).toBe("d5");
+  });
+});
+
 describe("createControlPlane.stop", () => {
   it("unregisters the producer tick, stops the producer, and clears the consumer timer", async () => {
     const producer = makeFakeProducer();
@@ -810,5 +890,111 @@ describe("createControlPlane — REQ-B comm-error surfacing", () => {
 
     expect(aggregator.commErrorCalls).toHaveLength(1);
     expect(aggregator.commErrorCalls[0].lastKnownState).toBeUndefined();
+  });
+});
+
+describe("createControlPlane — §9 family-silence tick seam", () => {
+  function makeFakeFamilySilence(impl?: (nowMs: number) => Promise<void>) {
+    const calls: number[] = [];
+    return {
+      calls,
+      async tick(nowMs: number): Promise<void> {
+        calls.push(nowMs);
+        if (impl) return impl(nowMs);
+      },
+    };
+  }
+
+  function makeRecordingLogger(): Logger & {
+    warns: Array<{ msg: string; meta?: Record<string, unknown> }>;
+  } {
+    const warns: Array<{ msg: string; meta?: Record<string, unknown> }> = [];
+    return {
+      warns,
+      info: () => {},
+      warn: (msg, meta) => {
+        warns.push({ msg, ...(meta ? { meta } : {}) });
+      },
+      error: () => {},
+      debug: () => {},
+    };
+  }
+
+  /** Flush the fire-and-forget tick chain (deeper than FakeTimers.fire covers). */
+  async function settle(): Promise<void> {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+
+  it("the fleet-health interval invokes familySilence.tick when supplied", async () => {
+    const familySilence = makeFakeFamilySilence();
+    const fleetHealth = makeFakeFleetHealth(emptyHealthResult());
+    const timers = makeFakeTimers();
+    const cp = createControlPlane({
+      producer: makeFakeProducer(),
+      consumer: makeFakeConsumer(),
+      scheduler: makeFakeScheduler(),
+      logger: SILENT_LOGGER,
+      fleetHealth,
+      familySilence,
+      setIntervalImpl: timers.setIntervalImpl,
+      clearIntervalImpl: timers.clearIntervalImpl,
+    });
+    cp.start();
+    await timers.fire();
+    await settle();
+    expect(fleetHealth.calls).toBe(1);
+    expect(familySilence.calls).toHaveLength(1);
+    expect(typeof familySilence.calls[0]).toBe("number");
+  });
+
+  it("a familySilence tick rejection is logged and never wedges the loop", async () => {
+    const familySilence = makeFakeFamilySilence(async () => {
+      throw new Error("monitor blew up");
+    });
+    const fleetHealth = makeFakeFleetHealth(emptyHealthResult());
+    const logger = makeRecordingLogger();
+    const timers = makeFakeTimers();
+    const cp = createControlPlane({
+      producer: makeFakeProducer(),
+      consumer: makeFakeConsumer(),
+      scheduler: makeFakeScheduler(),
+      logger,
+      fleetHealth,
+      familySilence,
+      setIntervalImpl: timers.setIntervalImpl,
+      clearIntervalImpl: timers.clearIntervalImpl,
+    });
+    cp.start();
+    await timers.fire();
+    await settle();
+    await timers.fire();
+    await settle();
+    // The rejection never wedges health reclaim: both cycles ran.
+    expect(fleetHealth.calls).toBe(2);
+    expect(familySilence.calls).toHaveLength(2);
+    expect(
+      logger.warns.some(
+        (w) => w.msg === "fleet.control-plane.family-silence-tick-failed",
+      ),
+    ).toBe(true);
+  });
+
+  it("familySilence ticks on the fleet-health interval even with no fleet-health monitor injected", async () => {
+    const familySilence = makeFakeFamilySilence();
+    const timers = makeFakeTimers();
+    const cp = createControlPlane({
+      producer: makeFakeProducer(),
+      consumer: makeFakeConsumer(),
+      scheduler: makeFakeScheduler(),
+      logger: SILENT_LOGGER,
+      // no fleetHealth — the monitor must still ride the interval
+      familySilence,
+      setIntervalImpl: timers.setIntervalImpl,
+      clearIntervalImpl: timers.clearIntervalImpl,
+    });
+    cp.start();
+    await timers.fire();
+    await settle();
+    expect(familySilence.calls).toHaveLength(1);
   });
 });

--- a/showcase/harness/src/fleet/control-plane/control-plane.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.ts
@@ -61,6 +61,19 @@ import type { FleetHealthMonitor } from "./fleet-health.js";
 export const FLEET_PRODUCER_SCHEDULE_ID = "fleet-job-producer";
 
 /**
+ * Scheduler entry ids for the three non-d6 browser-family producers. Homed
+ * HERE (beside `FLEET_PRODUCER_SCHEDULE_ID`) rather than in `orchestrator.ts`
+ * so the §5.1 family registry (`run-view.ts`, inside `fleet/control-plane/`)
+ * can import all four ids from one cycle-free home — `orchestrator.ts` already
+ * imports from this module, so the registry importing FROM orchestrator would
+ * close an import cycle. The cron constants stay in `orchestrator.ts` (the
+ * registry deliberately carries no cron literals; resolution is runtime).
+ */
+export const FLEET_PRODUCER_SMOKE_SCHEDULE_ID = "fleet-producer-e2e-smoke";
+export const FLEET_PRODUCER_DEMOS_SCHEDULE_ID = "fleet-producer-e2e-demos";
+export const FLEET_PRODUCER_DEEP_SCHEDULE_ID = "fleet-producer-e2e-deep";
+
+/**
  * Cron cadence the producer runs on by default. Hourly at :40 mirrors the
  * legacy in-process `d6-all-pills-e2e` probe cadence (config/probes/
  * d6-all-pills-e2e.yml) so the fleet run rhythm matches what it replaces.
@@ -153,6 +166,15 @@ export interface ControlPlaneDeps {
   /** Fleet-health poll interval (ms). Default `DEFAULT_FLEET_HEALTH_INTERVAL_MS`. */
   fleetHealthIntervalMs?: number;
   /**
+   * The §9 family-silence monitor's tick seam. When supplied, the fleet-health
+   * interval handler ADDITIONALLY fire-and-forgets `tick(now)` each cycle —
+   * the tick is the monitor's cheap in-memory gate (actual evaluation runs at
+   * most once per family per resolved period, inside the monitor). A tick
+   * rejection is logged and never blocks health reclaim. Optional — omit to
+   * leave silence monitoring unattached (worker role, legacy tests).
+   */
+  familySilence?: { tick(nowMs: number): Promise<void> };
+  /**
    * Resolve a swept `PoolCommError` to its `d6:<slug>` dashboard key (REQ-B).
    * Required for the producer-sweep surfacing leg (a bare swept error lacks the
    * key); omit when the producer does not forward swept errors here.
@@ -206,6 +228,13 @@ export function buildJobProducer(deps: {
   enumerate: ServiceEnumerator;
   logger: Logger;
   /**
+   * The producing family's id (§5.1 registry; §4.2 prune-ownership key).
+   * Forwarded verbatim to `createJobProducer` — this wrapper re-declares every
+   * dep it forwards, so the explicit field here is load-bearing: omitting it
+   * would silently drop the option.
+   */
+  family: string;
+  /**
    * Sink the producer forwards its lease-sweep comm errors to (REQ-B). The
    * wiring slot passes `controlPlane.surfaceSweepCommErrors` so a swept
    * (crashed/lease-expired) job's "unreachable" overlay reaches the dashboard.
@@ -224,6 +253,7 @@ export function buildJobProducer(deps: {
     queue: deps.queue,
     enumerate: deps.enumerate,
     logger: deps.logger,
+    family: deps.family,
     ...(deps.onSweepCommErrors
       ? { onSweepCommErrors: deps.onSweepCommErrors }
       : {}),
@@ -282,6 +312,7 @@ export function createControlPlane(deps: ControlPlaneDeps): ControlPlane {
   const {
     aggregator,
     fleetHealth,
+    familySilence,
     resolveSweepAggregateKey,
     resolvePriorState,
   } = deps;
@@ -494,10 +525,24 @@ export function createControlPlane(deps: ControlPlaneDeps): ControlPlane {
       }, consumerIntervalMs);
       // When a fleet-health monitor is injected, run it on its OWN interval
       // (finer than cron) so a dead worker's jobs are reclaimed promptly and
-      // its "unreachable" overlay reaches the dashboard (REQ-B).
-      if (fleetHealth) {
+      // its "unreachable" overlay reaches the dashboard (REQ-B). The §9
+      // family-silence monitor rides the SAME interval (its tick is a cheap
+      // in-memory gate), so the timer also starts when only it is supplied.
+      if (fleetHealth || familySilence) {
         fleetHealthTimer = setIntervalFn(() => {
           void runFleetHealthCycle();
+          if (familySilence) {
+            // Fire-and-forget: a silence-monitor failure (or sync throw) must
+            // never block or wedge health reclaim — log and let the next
+            // interval tick retry.
+            void Promise.resolve()
+              .then(() => familySilence.tick(Date.now()))
+              .catch((err) => {
+                logger.warn("fleet.control-plane.family-silence-tick-failed", {
+                  err: err instanceof Error ? err.message : String(err),
+                });
+              });
+          }
         }, fleetHealthIntervalMs);
       }
       logger.info("fleet.control-plane.started", {
@@ -507,6 +552,7 @@ export function createControlPlane(deps: ControlPlaneDeps): ControlPlane {
         })),
         consumerIntervalMs,
         fleetHealth: fleetHealth !== undefined,
+        familySilence: familySilence !== undefined,
       });
     },
 

--- a/showcase/harness/src/fleet/control-plane/family-silence-monitor.test.ts
+++ b/showcase/harness/src/fleet/control-plane/family-silence-monitor.test.ts
@@ -1,0 +1,517 @@
+import { describe, it, expect } from "vitest";
+import {
+  createFamilySilenceMonitor,
+  FAMILY_SILENCE_RULE_ID,
+  FAMILY_SILENCE_EVAL_RULE_ID,
+  SILENCE_ALERT_RATE_LIMIT_MS,
+  SILENCE_PERIOD_MULTIPLIER,
+} from "./family-silence-monitor.js";
+import {
+  FLEET_FAMILIES,
+  type FamilySummaryEntry,
+  type FamilySummaryResponse,
+  type InflightState,
+  type RunBatch,
+} from "./run-view.js";
+import type { ProducerSchedule } from "./control-plane.js";
+import type { JobProducer } from "./job-producer.js";
+import type { AlertStateStore } from "../../storage/alert-state-store.js";
+import type { AlertStateRecord, Logger } from "../../types/index.js";
+
+/**
+ * Pins the §9 family-silence monitor: the per-family once-per-period
+ * evaluation gate over 15 s ticks, the 3×period silence alert with
+ * inflight-aware last-attempt, the §5.2.1 null-lastSuccessAt fallback, boot
+ * grace over BOTH alert classes, the two-presentation evaluation-failure
+ * meta-alert, per-family 6 h rate limiting via the alert-state store, the
+ * recovered one-shots, and the /health lastEvaluatedAt stamp. The summary is
+ * a fake returning canned §5.2.1 shapes — no PB, no run-view internals.
+ */
+
+const SILENT_LOGGER: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+/** Hourly cron for every family — resolved period 1 h. */
+const CRON = "0 * * * *";
+const PERIOD = 3_600_000;
+/** Fixed epoch base so every timestamp in these tests is explicit. */
+const BASE = Date.UTC(2026, 0, 15);
+
+function iso(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+const stubProducer = {
+  start() {},
+  async stop() {},
+  async tick() {
+    throw new Error("stub producer: tick not used");
+  },
+  isRunning: () => true,
+} as unknown as JobProducer;
+
+function makeSchedules(): ProducerSchedule[] {
+  return FLEET_FAMILIES.map((fam) => ({
+    scheduleId: fam.scheduleId,
+    cron: CRON,
+    producer: stubProducer,
+  }));
+}
+
+function batch(over: Partial<RunBatch> = {}): RunBatch {
+  return {
+    runId: "run-1",
+    triggered: false,
+    enqueuedAt: iso(BASE - 120_000),
+    finishedAt: iso(BASE - 60_000),
+    durationMs: 60_000,
+    outcome: "completed",
+    jobs: { total: 2, done: 2, failed: 0, reclaimed: 0 },
+    cells: null,
+    redsIntroduced: null,
+    redsCleared: null,
+    errorSummary: null,
+    commErrorKinds: [],
+    ...over,
+  };
+}
+
+function inflightState(over: Partial<InflightState> = {}): InflightState {
+  return {
+    runId: "run-2",
+    triggered: false,
+    enqueuedAt: iso(BASE - 60_000),
+    elapsedMs: 60_000,
+    stalled: false,
+    jobs: { pending: 1, claimed: 0, running: 1, done: 0, failed: 0 },
+    ...over,
+  };
+}
+
+function entryFor(
+  family: string,
+  over: Partial<FamilySummaryEntry> = {},
+): FamilySummaryEntry {
+  const fam = FLEET_FAMILIES.find((f) => f.family === family);
+  if (!fam) throw new Error(`unknown family ${family}`);
+  return {
+    family: fam.family,
+    label: fam.label,
+    probeKeyPrefix: fam.probeKeyPrefix,
+    schedule: CRON,
+    periodMs: PERIOD,
+    nextRunAt: null,
+    lastRun: null,
+    inflight: null,
+    lastSuccessAt: null,
+    ...over,
+  };
+}
+
+/** Every family healthy: succeeded a minute before `nowMs`. */
+function healthyFamilies(nowMs: number): FamilySummaryEntry[] {
+  return FLEET_FAMILIES.map((fam) =>
+    entryFor(fam.family, {
+      lastSuccessAt: iso(nowMs - 60_000),
+      lastRun: batch({
+        enqueuedAt: iso(nowMs - 120_000),
+        finishedAt: iso(nowMs - 60_000),
+      }),
+    }),
+  );
+}
+
+/** d6 silent (per `d6Over`), every other family healthy. */
+function withD6(
+  nowMs: number,
+  d6Over: Partial<FamilySummaryEntry>,
+): FamilySummaryEntry[] {
+  return healthyFamilies(nowMs).map((entry) =>
+    entry.family === "d6" ? entryFor("d6", d6Over) : entry,
+  );
+}
+
+function response(families: FamilySummaryEntry[]): FamilySummaryResponse {
+  return { families, workers: [] };
+}
+
+function makeFakeStore(): AlertStateStore & {
+  rows: Map<string, AlertStateRecord>;
+} {
+  const rows = new Map<string, AlertStateRecord>();
+  const key = (ruleId: string, dedupeKey: string) => `${ruleId}|${dedupeKey}`;
+  return {
+    rows,
+    async get(ruleId, dedupeKey) {
+      return rows.get(key(ruleId, dedupeKey)) ?? null;
+    },
+    async record(ruleId, dedupeKey, fields) {
+      rows.set(key(ruleId, dedupeKey), {
+        rule_id: ruleId,
+        dedupe_key: dedupeKey,
+        last_alert_at: fields.at,
+        last_alert_hash: fields.hash,
+        payload_preview: fields.preview,
+      });
+    },
+    async getSet() {
+      return { hash: null, at: null };
+    },
+    async putSet() {},
+  };
+}
+
+function makeMonitor(opts: {
+  get: () => Promise<FamilySummaryResponse>;
+  bootAtMs?: number;
+  store?: AlertStateStore;
+}) {
+  const posts: string[] = [];
+  const counters = { summaryCalls: 0 };
+  const store = opts.store ?? makeFakeStore();
+  const monitor = createFamilySilenceMonitor({
+    summary: {
+      get: async () => {
+        counters.summaryCalls += 1;
+        return opts.get();
+      },
+    },
+    schedules: makeSchedules(),
+    alertStore: store,
+    postAlert: async (text) => {
+      posts.push(text);
+    },
+    bootAtMs: opts.bootAtMs ?? BASE,
+    logger: SILENT_LOGGER,
+  });
+  return { monitor, posts, counters, store };
+}
+
+describe("family-silence monitor — evaluation gate", () => {
+  it("evaluation runs at most once per family per resolved period despite 15s ticks", async () => {
+    const { monitor, counters, posts } = makeMonitor({
+      get: async () => response(healthyFamilies(BASE + PERIOD)),
+    });
+    // First post-grace tick: every family due (no prior evaluation).
+    await monitor.tick(BASE + PERIOD);
+    expect(counters.summaryCalls).toBe(1);
+    // 15 s and 30 min later: inside every family's period — gated, no fetch.
+    await monitor.tick(BASE + PERIOD + 15_000);
+    await monitor.tick(BASE + PERIOD + 30 * 60_000);
+    expect(counters.summaryCalls).toBe(1);
+    // One full period later: due again — exactly one more shared fetch for
+    // all four due families (cost bound: one fan-out per cycle, not four).
+    await monitor.tick(BASE + 2 * PERIOD);
+    expect(counters.summaryCalls).toBe(2);
+    expect(posts).toEqual([]);
+  });
+});
+
+describe("family-silence monitor — silence alert", () => {
+  it("a family silent past 3x period posts the silence alert with k cycles", async () => {
+    const now = BASE + 2 * PERIOD;
+    const { monitor, posts } = makeMonitor({
+      get: async () =>
+        response(
+          withD6(now, {
+            lastSuccessAt: iso(now - 4 * PERIOD),
+            lastRun: batch({
+              enqueuedAt: iso(now - 4 * PERIOD - 120_000),
+              finishedAt: iso(now - 4 * PERIOD),
+            }),
+          }),
+        ),
+    });
+    await monitor.tick(now);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toContain("worker family D6 all-pills silent");
+    expect(posts[0]).toContain(
+      `no successful run since ${iso(now - 4 * PERIOD)}`,
+    );
+    expect(posts[0]).toContain("(4 cycles)");
+    expect(posts[0]).toContain("last attempt: completed");
+  });
+
+  it("last attempt is inflight-aware: a stalled inflight batch posts stalled, never the prior completed lastRun outcome", async () => {
+    const now = BASE + 2 * PERIOD;
+    const { monitor, posts } = makeMonitor({
+      get: async () =>
+        response(
+          withD6(now, {
+            lastSuccessAt: iso(now - 4 * PERIOD),
+            lastRun: batch({ outcome: "completed" }),
+            inflight: inflightState({
+              stalled: true,
+              enqueuedAt: iso(now - PERIOD),
+            }),
+          }),
+        ),
+    });
+    await monitor.tick(now);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toContain("last attempt: stalled");
+    expect(posts[0]).not.toContain("last attempt: completed");
+  });
+
+  it("an abandoned failed-plus-zombie batch reports stalled, never failed (no re-classification)", async () => {
+    const now = BASE + 2 * PERIOD;
+    const { monitor, posts } = makeMonitor({
+      get: async () =>
+        response(
+          withD6(now, {
+            lastSuccessAt: iso(now - 4 * PERIOD),
+            // run-view already derived "stalled" by precedence (a failed job
+            // plus a zombie pending job in an abandoned batch). The monitor
+            // renders that value verbatim — never re-derives "failed".
+            lastRun: batch({
+              outcome: "stalled",
+              jobs: { total: 3, done: 1, failed: 1, reclaimed: 0 },
+            }),
+          }),
+        ),
+    });
+    await monitor.tick(now);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toContain("last attempt: stalled");
+    expect(posts[0]).not.toMatch(/last attempt: failed/);
+  });
+
+  it("null lastSuccessAt: never-succeeded family alerts off oldest batch enqueuedAt with the never-completed variant", async () => {
+    const now = BASE + 2 * PERIOD;
+    const oldest = now - 4 * PERIOD;
+    const { monitor, posts } = makeMonitor({
+      get: async () =>
+        response(
+          withD6(now, {
+            lastSuccessAt: null,
+            lastRun: batch({
+              outcome: "failed",
+              enqueuedAt: iso(oldest),
+              commErrorKinds: ["worker-crashed-mid-job"],
+            }),
+          }),
+        ),
+    });
+    await monitor.tick(now);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toContain(
+      `has never completed a run since ${iso(oldest)}`,
+    );
+    expect(posts[0]).toContain("last attempt: failed (worker-crashed-mid-job)");
+  });
+
+  it("zero-batch family never alerts", async () => {
+    const now = BASE + 10 * PERIOD;
+    const { monitor, posts } = makeMonitor({
+      get: async () =>
+        response(
+          withD6(now, {
+            lastSuccessAt: null,
+            lastRun: null,
+            inflight: null,
+          }),
+        ),
+    });
+    await monitor.tick(now);
+    expect(posts).toEqual([]);
+  });
+});
+
+describe("family-silence monitor — boot grace", () => {
+  it("boot grace (1x period) suppresses the silence alert AND the meta-alert failing-since clock", async () => {
+    // (a) silence alert suppressed inside the grace window.
+    const silent = makeMonitor({
+      get: async () =>
+        response(
+          withD6(BASE + PERIOD / 2, {
+            lastSuccessAt: iso(BASE - 4 * PERIOD),
+            lastRun: batch(),
+          }),
+        ),
+      bootAtMs: BASE,
+    });
+    await silent.monitor.tick(BASE + PERIOD / 2);
+    expect(silent.posts).toEqual([]);
+
+    // (b) the meta-alert failing-since clock starts at grace END, not at the
+    // first in-grace failure: failure from t=+10s, but no meta-alert until
+    // MORE than one period past grace end (BASE + PERIOD).
+    const failing = makeMonitor({
+      get: async () => {
+        throw new Error("pb down");
+      },
+      bootAtMs: BASE,
+    });
+    await failing.monitor.tick(BASE + 10_000); // in grace — clock NOT started here
+    await failing.monitor.tick(BASE + 1.5 * PERIOD); // 0.5 period past grace end
+    expect(failing.posts).toEqual([]);
+    await failing.monitor.tick(BASE + 2.5 * PERIOD); // 1.5 periods past grace end
+    expect(failing.posts).toHaveLength(1);
+    expect(failing.posts[0]).toContain(
+      `worker-run telemetry evaluation failing since ${iso(BASE + PERIOD)}`,
+    );
+  });
+});
+
+describe("family-silence monitor — evaluation-failure meta-alert", () => {
+  it("meta-alert clock starts from a degraded-200 family entry carrying history_unavailable, not only from a thrown projection", async () => {
+    const { monitor, posts } = makeMonitor({
+      get: async () =>
+        response(withD6(BASE + PERIOD, { error: "history_unavailable" })),
+      bootAtMs: BASE,
+    });
+    await monitor.tick(BASE + PERIOD); // post-grace; clock starts
+    expect(posts).toEqual([]);
+    await monitor.tick(BASE + 2 * PERIOD + 1_000); // >1 period of failure
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toContain("worker-run telemetry evaluation failing since");
+    expect(posts[0]).toContain("family silence cannot be assessed");
+  });
+
+  it("meta-alert posts after >1 period of consecutive evaluation failure; recovered one-shot on next success", async () => {
+    let healthy = false;
+    const { monitor, posts } = makeMonitor({
+      get: async () => {
+        if (!healthy) throw new Error("pb down");
+        return response(healthyFamilies(BASE + 4 * PERIOD));
+      },
+      bootAtMs: BASE,
+    });
+    await monitor.tick(BASE + PERIOD); // failing — clock starts (post-grace)
+    await monitor.tick(BASE + 2 * PERIOD); // exactly 1 period — NOT >1, no post
+    expect(posts).toEqual([]);
+    await monitor.tick(BASE + 3 * PERIOD); // 2 periods of failure — posts
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toContain("worker-run telemetry evaluation failing since");
+
+    healthy = true;
+    await monitor.tick(BASE + 4 * PERIOD);
+    expect(posts).toHaveLength(2);
+    expect(posts[1]).toContain("worker-run telemetry evaluation recovered");
+    // One-shot: stays recovered, no repeat.
+    await monitor.tick(BASE + 5 * PERIOD);
+    expect(posts).toHaveLength(2);
+  });
+});
+
+describe("family-silence monitor — rate limiting + recovered one-shot", () => {
+  function silentD6At(now: number): FamilySummaryEntry[] {
+    return withD6(now, {
+      lastSuccessAt: iso(BASE - 4 * PERIOD),
+      lastRun: batch({ outcome: "failed" }),
+    });
+  }
+
+  it("alerts rate-limited to one per family per 6h via the alert-state store; recovered one-shot on next successful batch", async () => {
+    let nowRef = BASE + 2 * PERIOD;
+    let recovered = false;
+    const { monitor, posts, store } = makeMonitor({
+      get: async () =>
+        recovered
+          ? response(healthyFamilies(nowRef))
+          : response(silentD6At(nowRef)),
+    });
+
+    await monitor.tick(nowRef);
+    expect(posts).toHaveLength(1);
+    // The post is recorded into the alert-state store under the §9 keying.
+    const row = await store.get(FAMILY_SILENCE_RULE_ID, "d6");
+    expect(row?.last_alert_at).toBe(iso(BASE + 2 * PERIOD));
+
+    // Every period for the next 5 hours: still silent, still suppressed.
+    for (let i = 1; i <= 5; i += 1) {
+      nowRef = BASE + (2 + i) * PERIOD;
+      await monitor.tick(nowRef);
+    }
+    expect(posts).toHaveLength(1);
+
+    // Past the 6 h window: posts again.
+    nowRef = BASE + 2 * PERIOD + SILENCE_ALERT_RATE_LIMIT_MS + 60_000;
+    await monitor.tick(nowRef);
+    expect(posts).toHaveLength(2);
+
+    // Recovered one-shot on the next successful batch — exactly once.
+    recovered = true;
+    nowRef += PERIOD;
+    await monitor.tick(nowRef);
+    expect(posts).toHaveLength(3);
+    expect(posts[2]).toContain("worker family D6 all-pills recovered");
+    nowRef += PERIOD;
+    await monitor.tick(nowRef);
+    expect(posts).toHaveLength(3);
+  });
+
+  it("a pre-seeded alert-state row suppresses across a monitor restart (durable rate limit)", async () => {
+    const now = BASE + 2 * PERIOD;
+    const store = makeFakeStore();
+    await store.record(FAMILY_SILENCE_RULE_ID, "d6", {
+      at: iso(now - 3_600_000), // 1 h ago — inside the 6 h window
+      hash: "seeded",
+      preview: "seeded",
+    });
+    const { monitor, posts } = makeMonitor({
+      get: async () => response(silentD6At(now)),
+      store,
+    });
+    await monitor.tick(now);
+    expect(posts).toEqual([]);
+  });
+
+  it("the meta-alert is rate-limited under its own rule id", async () => {
+    const now = BASE + 3 * PERIOD;
+    const store = makeFakeStore();
+    await store.record(FAMILY_SILENCE_EVAL_RULE_ID, "d6", {
+      at: iso(now - 3_600_000),
+      hash: "seeded",
+      preview: "seeded",
+    });
+    const { monitor, posts } = makeMonitor({
+      get: async () => response(withD6(now, { error: "history_unavailable" })),
+      bootAtMs: BASE - 10 * PERIOD,
+      store,
+    });
+    await monitor.tick(now - 2 * PERIOD); // clock starts
+    await monitor.tick(now); // >1 period failing, but rate-limited by the seed
+    expect(posts).toEqual([]);
+  });
+});
+
+describe("family-silence monitor — lastEvaluatedAt", () => {
+  it("lastEvaluatedAt() advances on every evaluation cycle", async () => {
+    const { monitor } = makeMonitor({
+      get: async () => response(healthyFamilies(BASE + PERIOD)),
+    });
+    expect(monitor.lastEvaluatedAt()).toBeNull();
+    await monitor.tick(BASE + PERIOD);
+    expect(monitor.lastEvaluatedAt()).toBe(BASE + PERIOD);
+    // Gated tick (nothing due): the stamp does NOT advance — it tracks
+    // evaluation cycles, not raw ticks.
+    await monitor.tick(BASE + PERIOD + 15_000);
+    expect(monitor.lastEvaluatedAt()).toBe(BASE + PERIOD);
+    await monitor.tick(BASE + 2 * PERIOD);
+    expect(monitor.lastEvaluatedAt()).toBe(BASE + 2 * PERIOD);
+  });
+
+  it("lastEvaluatedAt() advances even when the evaluation fails (the stamp tracks liveness, not success)", async () => {
+    const { monitor } = makeMonitor({
+      get: async () => {
+        throw new Error("pb down");
+      },
+    });
+    await monitor.tick(BASE + PERIOD);
+    expect(monitor.lastEvaluatedAt()).toBe(BASE + PERIOD);
+  });
+});
+
+describe("family-silence monitor — constants", () => {
+  it("pins the §9 threshold + keying constants consumers rely on", () => {
+    expect(SILENCE_PERIOD_MULTIPLIER).toBe(3);
+    expect(SILENCE_ALERT_RATE_LIMIT_MS).toBe(6 * 3_600_000);
+    expect(FAMILY_SILENCE_RULE_ID).toBe("family-silence");
+    expect(FAMILY_SILENCE_EVAL_RULE_ID).toBe("family-silence-eval");
+  });
+});

--- a/showcase/harness/src/fleet/control-plane/family-silence-monitor.ts
+++ b/showcase/harness/src/fleet/control-plane/family-silence-monitor.ts
@@ -1,0 +1,495 @@
+/**
+ * Family-silence monitor (spec §9) — the CP-side Slack alerting hook for the
+ * one incident class the status-row alert engine is structurally blind to:
+ * a worker family going silent produces NO row transitions, so no
+ * transition-keyed rule can ever fire.
+ *
+ * Scheduled off the existing fleet-health interval (`control-plane.ts` calls
+ * `tick(nowMs)` every ~15 s) but deliberately NOT evaluated at that cadence:
+ * the tick is a cheap in-memory gate, and each family's actual evaluation
+ * runs at most once per its resolved period. When an evaluation does run it
+ * reads THE shared memoized family-summary instance (`run-view.ts` —
+ * `runControlPlane` constructs one and injects it into both the fleet-runs
+ * routes and this monitor), so with the dashboard open the read is usually a
+ * memo hit; the zero-viewer worst case is ~4 fan-outs per shortest period.
+ *
+ * Two alert classes, both per-family, both 6 h rate-limited via the existing
+ * alert-state store, both with a recovered one-shot, both suppressed for one
+ * resolved period after CP boot (boot grace — a fresh env / deploy-ordering
+ * PB flap must not page):
+ *
+ *   1. FAMILY SILENCE — `now − lastSuccessAt > 3 × period` (N=3 mirrors the
+ *      "two misses + margin" reasoning behind STARTER_STALE_AFTER_MS). Null
+ *      `lastSuccessAt` falls back to the oldest known batch's `enqueuedAt`
+ *      ("has never completed a run since…"); zero batches → silent. The
+ *      "last attempt" is INFLIGHT-AWARE: an inflight batch IS the last
+ *      attempt (`stalled` when `inflight.stalled`, else `running`) — only
+ *      with no inflight does `lastRun`'s §5.2.1 precedence-derived outcome
+ *      apply, and it is rendered VERBATIM (never re-classified).
+ *   2. EVALUATION FAILURE (meta-alert) — evaluation counts as failed under
+ *      EITHER presentation: `summary.get()` throws, OR the §5.2.1
+ *      degraded-200 shape carries `error: "history_unavailable"` for the
+ *      family (PB-down-while-CP-up deliberately does NOT throw, so the
+ *      second arm is load-bearing). After >1 resolved period of consecutive
+ *      failure the meta-alert posts; the failing-since clock starts no
+ *      earlier than boot-grace end.
+ *
+ * `lastEvaluatedAt()` stamps `/health` (`fleetRuns.lastEvaluatedAt`) so an
+ * external poll can detect a wedged monitor — the §9 compensating control
+ * for "the monitor cannot report its own host's death".
+ *
+ * Alert text is composed from closed-vocabulary parts only (§5.2.1 redaction
+ * rule): registry labels, ISO timestamps, cycle counts, the three-valued
+ * outcome, and `isPoolCommErrorKind`-validated kinds already sanitized by
+ * run-view. Raw error messages never reach the webhook.
+ */
+
+import { createHash } from "node:crypto";
+import type { Logger } from "../../types/index.js";
+import type { AlertStateStore } from "../../storage/alert-state-store.js";
+import type { ProducerSchedule } from "./control-plane.js";
+import {
+  FLEET_FAMILIES,
+  periodMsFromCron,
+  type FamilySummaryEntry,
+  type FleetFamily,
+  type MemoizedFamilySummary,
+} from "./run-view.js";
+
+/** Alert-state keying (§9): silence alerts — `rule_id` + `dedupe_key: family`. */
+export const FAMILY_SILENCE_RULE_ID = "family-silence";
+/** Alert-state keying (§9): evaluation-failure meta-alerts, same dedupe shape. */
+export const FAMILY_SILENCE_EVAL_RULE_ID = "family-silence-eval";
+/** §9: one alert per family per 6 h, per alert class. */
+export const SILENCE_ALERT_RATE_LIMIT_MS = 6 * 3_600_000;
+/** §9: silence threshold N — alert when now − lastSuccessAt > N × period. */
+export const SILENCE_PERIOD_MULTIPLIER = 3;
+
+export interface FamilySilenceMonitorDeps {
+  /** The SHARED memoized §5.2.1 projection instance (§5.2 — same one the routes get). */
+  summary: Pick<MemoizedFamilySummary, "get">;
+  /** The `buildProducerSchedules` output — the resolved-cron period source (§5.1). */
+  schedules: readonly ProducerSchedule[];
+  /** Existing alert-state store — 6 h rate-limit keying (§9). */
+  alertStore: AlertStateStore;
+  /** The oss_alerts Slack target send (wired by `runControlPlane`). */
+  postAlert: (text: string) => Promise<void>;
+  /** CP boot instant — anchors the per-family 1×period boot grace. */
+  bootAtMs: number;
+  logger: Logger;
+}
+
+export interface FamilySilenceMonitor {
+  /**
+   * Cheap in-memory gate (rides the ~15 s fleet-health interval); per-family
+   * evaluation at most once per 1×resolved period. Never rejects.
+   */
+  tick(nowMs: number): Promise<void>;
+  /** Most recent evaluation-cycle instant — the `/health` stamp (§9). */
+  lastEvaluatedAt(): number | null;
+}
+
+/** A family joined to its resolved period + boot-grace end. */
+interface MonitoredFamily {
+  fam: FleetFamily;
+  periodMs: number;
+  graceEndMs: number;
+}
+
+function hashText(text: string): string {
+  return createHash("sha256").update(text).digest("hex").slice(0, 16);
+}
+
+function iso(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+function parseIso(value: string | null | undefined): number {
+  if (!value) return Number.NaN;
+  return Date.parse(value);
+}
+
+/**
+ * §9 last-attempt rendering, inflight-aware: a live inflight batch IS the
+ * last attempt; only without one does `lastRun`'s precedence-derived outcome
+ * apply — verbatim, with the (already-validated) comm-error kinds appended.
+ */
+function lastAttemptText(entry: FamilySummaryEntry): string {
+  if (entry.inflight) return entry.inflight.stalled ? "stalled" : "running";
+  const lastRun = entry.lastRun;
+  if (!lastRun) return "none";
+  const kinds =
+    lastRun.commErrorKinds.length > 0
+      ? ` (${lastRun.commErrorKinds.join(", ")})`
+      : "";
+  return `${lastRun.outcome}${kinds}`;
+}
+
+/**
+ * §5.2.1 null-semantics staleness reference: `lastSuccessAt` when present,
+ * else the oldest known batch's `enqueuedAt` (never-succeeded variant), else
+ * null (zero batches — stay silent).
+ */
+function silenceReference(
+  entry: FamilySummaryEntry,
+): { refMs: number; neverSucceeded: boolean } | null {
+  const successMs = parseIso(entry.lastSuccessAt);
+  if (!Number.isNaN(successMs))
+    return { refMs: successMs, neverSucceeded: false };
+  const candidates = [
+    parseIso(entry.lastRun?.enqueuedAt),
+    parseIso(entry.inflight?.enqueuedAt),
+  ].filter((ms) => !Number.isNaN(ms));
+  if (candidates.length === 0) return null;
+  return { refMs: Math.min(...candidates), neverSucceeded: true };
+}
+
+export function createFamilySilenceMonitor(
+  deps: FamilySilenceMonitorDeps,
+): FamilySilenceMonitor {
+  const { logger } = deps;
+
+  // Join the registry to its resolved periods ONCE — schedules are fixed at
+  // construction. A family whose schedule id resolves to no injected
+  // schedule is excluded loudly (unreachable while the §5.1 drift-lock
+  // holds) rather than monitored with a fabricated period.
+  const families: MonitoredFamily[] = [];
+  for (const fam of FLEET_FAMILIES) {
+    const schedule = deps.schedules.find(
+      (s) => s.scheduleId === fam.scheduleId,
+    );
+    if (!schedule) {
+      logger.warn("fleet.family-silence.schedule-unresolved", {
+        family: fam.family,
+        scheduleId: fam.scheduleId,
+      });
+      continue;
+    }
+    const periodMs = periodMsFromCron(schedule.cron);
+    families.push({
+      fam,
+      periodMs,
+      graceEndMs: deps.bootAtMs + periodMs,
+    });
+  }
+
+  // ── In-memory state (lost on restart — boot grace covers the gap) ──────
+  /** Per-family gate: last evaluation instant. */
+  const lastEvalMs = new Map<string, number>();
+  /** Meta-alert clock: first consecutive evaluation-failure instant (grace-clamped). */
+  const failingSinceMs = new Map<string, number>();
+  /** Outstanding alerts awaiting their recovered one-shot. */
+  const silenceAlertActive = new Set<string>();
+  const metaAlertActive = new Set<string>();
+  /**
+   * In-memory rate-limit backstop keyed `rule:family`. The durable store is
+   * authoritative across restarts, but the meta-alert path exists precisely
+   * because PB may be down — when the store read fails we fail OPEN (the
+   * §5.2.1 degradation posture: an outage must surface loudly) and this map
+   * bounds the spam to one post per window within the process lifetime.
+   */
+  const lastPostedMs = new Map<string, number>();
+  let lastEvaluatedAtMs: number | null = null;
+  /** Re-entrancy guard — a slow Slack post must not stack evaluations. */
+  let ticking = false;
+
+  async function isRateLimited(
+    ruleId: string,
+    family: string,
+    nowMs: number,
+  ): Promise<boolean> {
+    const memKey = `${ruleId}:${family}`;
+    const mem = lastPostedMs.get(memKey);
+    if (mem !== undefined && nowMs - mem < SILENCE_ALERT_RATE_LIMIT_MS) {
+      return true;
+    }
+    try {
+      const last = await deps.alertStore.get(ruleId, family);
+      const at = parseIso(last?.last_alert_at);
+      if (!Number.isNaN(at) && nowMs - at < SILENCE_ALERT_RATE_LIMIT_MS) {
+        return true;
+      }
+    } catch (err) {
+      // Fail open: PB-down is exactly when the meta-alert must still fire;
+      // the in-memory backstop above bounds repeat posts.
+      logger.warn("fleet.family-silence.alert-state-read-failed", {
+        ruleId,
+        family,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return false;
+  }
+
+  /** Post a rate-limited alert; returns true when the post went out. */
+  async function postLimited(
+    ruleId: string,
+    family: string,
+    text: string,
+    nowMs: number,
+  ): Promise<boolean> {
+    if (await isRateLimited(ruleId, family, nowMs)) return false;
+    try {
+      await deps.postAlert(text);
+    } catch (err) {
+      // Don't record state on a failed send — the next due evaluation retries.
+      logger.warn("fleet.family-silence.post-failed", {
+        ruleId,
+        family,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }
+    lastPostedMs.set(`${ruleId}:${family}`, nowMs);
+    try {
+      await deps.alertStore.record(ruleId, family, {
+        at: iso(nowMs),
+        hash: hashText(text),
+        preview: text,
+      });
+    } catch (err) {
+      logger.warn("fleet.family-silence.alert-state-write-failed", {
+        ruleId,
+        family,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return true;
+  }
+
+  /**
+   * Recovered one-shots fire on a state TRANSITION (alert-active → healthy),
+   * not on a window — so they bypass the rate limit AND must not write the
+   * alert-state row (recording one would suppress the NEXT real alert for
+   * 6 h). The active flag clears only on a successful send so a failed send
+   * retries next cycle.
+   */
+  async function postRecovered(
+    active: Set<string>,
+    family: string,
+    text: string,
+  ): Promise<void> {
+    if (!active.has(family)) return;
+    try {
+      await deps.postAlert(text);
+      active.delete(family);
+    } catch (err) {
+      logger.warn("fleet.family-silence.post-failed", {
+        family,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Advance one family's evaluation-failure clock; return its meta-alert trip
+   * candidate (clock past >1 period, post-grace) for the cycle-level
+   * coalesced post — a globally-thrown projection fails EVERY due family at
+   * once, and four identical Slack messages would be pure spam, so the tick
+   * posts ONE meta-alert per cycle while keeping per-family clocks and
+   * per-family rate-limit keying (the degraded-200 arm can be per-family).
+   */
+  function evaluateFailure(
+    entry: MonitoredFamily,
+    nowMs: number,
+  ): { family: string; sinceMs: number } | null {
+    const { fam, periodMs, graceEndMs } = entry;
+    // The failing-since clock starts no earlier than grace end (§9: a PB
+    // briefly down while the CP boots is a routine deploy-ordering flap).
+    if (!failingSinceMs.has(fam.family)) {
+      failingSinceMs.set(fam.family, Math.max(nowMs, graceEndMs));
+    }
+    if (nowMs < graceEndMs) return null; // grace covers the meta-alert too
+    const since = failingSinceMs.get(fam.family) as number;
+    if (nowMs - since <= periodMs) return null; // strictly MORE than 1 period (§9)
+    return { family: fam.family, sinceMs: since };
+  }
+
+  /** Post ONE coalesced meta-alert for every tripped-and-unsuppressed family. */
+  async function postMetaAlert(
+    trips: Array<{ family: string; sinceMs: number }>,
+    nowMs: number,
+  ): Promise<void> {
+    const eligible: Array<{ family: string; sinceMs: number }> = [];
+    for (const trip of trips) {
+      if (
+        !(await isRateLimited(FAMILY_SILENCE_EVAL_RULE_ID, trip.family, nowMs))
+      ) {
+        eligible.push(trip);
+      }
+    }
+    if (eligible.length === 0) return;
+    const sinceMs = Math.min(...eligible.map((trip) => trip.sinceMs));
+    const text = `worker-run telemetry evaluation failing since ${iso(sinceMs)} — family silence cannot be assessed`;
+    try {
+      await deps.postAlert(text);
+    } catch (err) {
+      logger.warn("fleet.family-silence.post-failed", {
+        ruleId: FAMILY_SILENCE_EVAL_RULE_ID,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return; // nothing recorded — the next due evaluation retries
+    }
+    for (const trip of eligible) {
+      lastPostedMs.set(`${FAMILY_SILENCE_EVAL_RULE_ID}:${trip.family}`, nowMs);
+      metaAlertActive.add(trip.family);
+      try {
+        await deps.alertStore.record(FAMILY_SILENCE_EVAL_RULE_ID, trip.family, {
+          at: iso(nowMs),
+          hash: hashText(text),
+          preview: text,
+        });
+      } catch (err) {
+        logger.warn("fleet.family-silence.alert-state-write-failed", {
+          ruleId: FAMILY_SILENCE_EVAL_RULE_ID,
+          family: trip.family,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    logger.warn("fleet.family-silence.eval-alert-posted", {
+      families: eligible.map((trip) => trip.family),
+      failingSince: iso(sinceMs),
+    });
+  }
+
+  /**
+   * Post ONE coalesced meta recovered one-shot for every family whose
+   * evaluation just succeeded while its meta-alert was outstanding. Flags
+   * clear only on a successful send so a failed send retries next cycle.
+   */
+  async function postMetaRecovered(recovered: string[]): Promise<void> {
+    if (recovered.length === 0) return;
+    try {
+      await deps.postAlert(
+        "worker-run telemetry evaluation recovered — family silence assessment resumed",
+      );
+      for (const family of recovered) metaAlertActive.delete(family);
+    } catch (err) {
+      logger.warn("fleet.family-silence.post-failed", {
+        ruleId: FAMILY_SILENCE_EVAL_RULE_ID,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  async function evaluateFamily(
+    monitored: MonitoredFamily,
+    entry: FamilySummaryEntry,
+    nowMs: number,
+  ): Promise<void> {
+    const { fam, periodMs, graceEndMs } = monitored;
+
+    const ref = silenceReference(entry);
+    if (!ref) return; // zero batches (fresh env) — never alerts (§5.2.1)
+
+    const silent = nowMs - ref.refMs > SILENCE_PERIOD_MULTIPLIER * periodMs;
+    if (!silent) {
+      // §9 recovered one-shot: the next successful batch after an alert.
+      if (entry.lastSuccessAt) {
+        await postRecovered(
+          silenceAlertActive,
+          fam.family,
+          `worker family ${fam.label} recovered — successful run completed at ${entry.lastSuccessAt}`,
+        );
+      }
+      return;
+    }
+
+    if (nowMs < graceEndMs) return; // boot grace (1×period, §9)
+
+    const cycles = Math.floor((nowMs - ref.refMs) / periodMs);
+    const attempt = lastAttemptText(entry);
+    const text = ref.neverSucceeded
+      ? `worker family ${fam.label} silent — has never completed a run since ${iso(ref.refMs)} (${cycles} cycles); last attempt: ${attempt}`
+      : `worker family ${fam.label} silent — no successful run since ${iso(ref.refMs)} (${cycles} cycles); last attempt: ${attempt}`;
+    const posted = await postLimited(
+      FAMILY_SILENCE_RULE_ID,
+      fam.family,
+      text,
+      nowMs,
+    );
+    // An alert is outstanding even when the 6 h window suppressed THIS post
+    // (e.g. the durable row survived a CP restart) — the recovered one-shot
+    // must still fire when the family next succeeds.
+    silenceAlertActive.add(fam.family);
+    if (posted) {
+      logger.warn("fleet.family-silence.silence-alert-posted", {
+        family: fam.family,
+        cycles,
+        lastAttempt: attempt,
+      });
+    }
+  }
+
+  return {
+    async tick(nowMs: number): Promise<void> {
+      if (ticking) return;
+      ticking = true;
+      try {
+        // Cheap in-memory gate: which families are due (≥1×period since
+        // their last evaluation)? First tick: everything is due.
+        const due = families.filter((entry) => {
+          const last = lastEvalMs.get(entry.fam.family);
+          return last === undefined || nowMs - last >= entry.periodMs;
+        });
+        if (due.length === 0) return;
+
+        // One shared projection read serves every due family this cycle —
+        // the §9 cost bound (and usually a memo hit with the dashboard open).
+        lastEvaluatedAtMs = nowMs;
+        for (const entry of due) lastEvalMs.set(entry.fam.family, nowMs);
+
+        let body: Awaited<ReturnType<typeof deps.summary.get>> | null = null;
+        try {
+          body = await deps.summary.get();
+        } catch (err) {
+          // Presentation 1 of evaluation failure (§9): the projection threw.
+          logger.warn("fleet.family-silence.summary-read-failed", {
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+
+        const metaTrips: Array<{ family: string; sinceMs: number }> = [];
+        const metaRecoveries: string[] = [];
+        for (const entry of due) {
+          const familyEntry = body?.families.find(
+            (f) => f.family === entry.fam.family,
+          );
+          // Presentation 2 (§9): degraded-200 with history_unavailable — the
+          // §5.2.1 contract is to NOT throw on PB-down, so a throw-only
+          // trigger would never start the clock on that incident.
+          if (
+            body === null ||
+            familyEntry === undefined ||
+            familyEntry.error === "history_unavailable"
+          ) {
+            const trip = evaluateFailure(entry, nowMs);
+            if (trip) metaTrips.push(trip);
+          } else {
+            // Evaluation succeeded — clear the family's meta clock and queue
+            // its share of the coalesced recovered one-shot.
+            failingSinceMs.delete(entry.fam.family);
+            if (metaAlertActive.has(entry.fam.family)) {
+              metaRecoveries.push(entry.fam.family);
+            }
+            await evaluateFamily(entry, familyEntry, nowMs);
+          }
+        }
+        await postMetaAlert(metaTrips, nowMs);
+        await postMetaRecovered(metaRecoveries);
+      } catch (err) {
+        // tick() never rejects — the control-plane interval must never wedge.
+        logger.error("fleet.family-silence.tick-failed", {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        ticking = false;
+      }
+    },
+
+    lastEvaluatedAt(): number | null {
+      return lastEvaluatedAtMs;
+    },
+  };
+}

--- a/showcase/harness/src/fleet/control-plane/fleet-health.ts
+++ b/showcase/harness/src/fleet/control-plane/fleet-health.ts
@@ -56,8 +56,8 @@ import {
   WORKERS_COLLECTION,
   heartbeatParseable,
   isWorkerStale,
+  deriveHealth,
   type PoolCommError,
-  type WorkerHealthState,
 } from "../contracts.js";
 
 /**
@@ -188,21 +188,6 @@ export interface FleetHealthMonitor {
    * poison worker can't wedge the whole monitor.
    */
   checkOnce(): Promise<FleetHealthResult>;
-}
-
-/** Derive a worker's liveness from its heartbeat age. */
-function deriveHealth(
-  lastHeartbeatAt: string,
-  nowMs: number,
-  staleAfterMs: number,
-): WorkerHealthState {
-  // OFFLINE is a stronger stale: heartbeat older than 2x the window. We don't
-  // act differently on stale vs offline (both reclaim), but the distinction is
-  // surfaced in logs so an operator can tell a briefly-missed-beat worker from
-  // a long-dead one.
-  if (isWorkerStale(lastHeartbeatAt, nowMs, staleAfterMs * 2)) return "offline";
-  if (isWorkerStale(lastHeartbeatAt, nowMs, staleAfterMs)) return "stale";
-  return "online";
 }
 
 export function createFleetHealthMonitor(

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -145,7 +145,6 @@ function startedProducer(overrides?: {
     queue,
     enumerate: () => specs,
     logger: overrides?.logger ?? SILENT_LOGGER,
-    logger: SILENT_LOGGER,
     family: overrides?.family ?? "d6",
     ...(overrides?.now ? { now: overrides.now } : {}),
     ...(overrides?.sweepIntervalMs !== undefined
@@ -247,6 +246,7 @@ describe("job-producer — per-service enqueue", () => {
         return d6Specs(["a"]);
       },
       logger: SILENT_LOGGER,
+      family: "d6",
       now: () => t,
     });
     producer.start();
@@ -266,6 +266,7 @@ describe("job-producer — per-service enqueue", () => {
         return d6Specs(["a"]);
       },
       logger: SILENT_LOGGER,
+      family: "d6",
       now: () => t,
     });
     producer.start();
@@ -282,6 +283,7 @@ describe("job-producer — per-service enqueue", () => {
         queue,
         enumerate: () => d6Specs(["a"]),
         logger: SILENT_LOGGER,
+        family: "d6",
         now: () => 123_456,
         // no runIdFactory → default factory under test
       });
@@ -335,6 +337,7 @@ describe("job-producer — per-service enqueue", () => {
         return d6Specs(["a", "b"]);
       },
       logger: SILENT_LOGGER,
+      family: "d6",
     });
     producer.start();
     await producer.tick({ filter: { slugs: ["crewai"] } }); // NOT triggered
@@ -367,6 +370,7 @@ describe("job-producer — per-service enqueue", () => {
         return d6Specs(["a"]);
       },
       logger,
+      family: "d6",
     });
     producer.start();
     await producer.tick();
@@ -683,6 +687,7 @@ describe("job-producer — per-family backlog dedupe", () => {
       queue: realQueue,
       enumerate: () => d6Specs(["a"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       sweepIntervalMs: Number.MAX_SAFE_INTEGER,
     });
     producer.start();
@@ -806,6 +811,7 @@ describe("job-producer — phantom probeKey guard", () => {
         ...d6Specs(["alpha"]),
       ],
       logger: SILENT_LOGGER,
+      family: "d6",
       warmHealth: { fetchImpl },
     });
     producer.start();
@@ -872,6 +878,7 @@ describe("job-producer — failure isolation", () => {
       enumerate: () =>
         Promise.resolve(null) as unknown as Promise<ServiceJobSpec[]>,
       logger: SILENT_LOGGER,
+      family: "d6",
       now: () => 1_000,
     });
     producer.start();
@@ -895,6 +902,7 @@ describe("job-producer — failure isolation", () => {
         throw new Error("railway discovery down");
       },
       logger: SILENT_LOGGER,
+      family: "d6",
     });
     producer.start();
     const result = await producer.tick();
@@ -1174,6 +1182,7 @@ describe("job-producer — sweep cadence", () => {
       queue,
       enumerate: () => d6Specs(["a"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       sweepIntervalMs: 0, // sweep every tick
       onSweepCommErrors: (errs) => {
         sinkCalls += 1;
@@ -1215,6 +1224,7 @@ describe("job-producer — sweep cadence", () => {
       queue,
       enumerate: () => d6Specs(["a"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       sweepIntervalMs: 0, // sweep every tick
       onSweepCommErrors: (errs) => {
         sinkCalls += 1;
@@ -1258,6 +1268,7 @@ describe("job-producer — sweep cadence", () => {
       queue,
       enumerate: () => d6Specs(["a"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       sweepIntervalMs: 0,
       onSweepCommErrors: (batch) => {
         sinkCalls += 1;
@@ -1306,6 +1317,7 @@ describe("job-producer — sweep cadence", () => {
           warns.push({ msg, ...(meta !== undefined ? { meta } : {}) });
         },
       },
+      family: "d6",
       sweepIntervalMs: 0,
       onSweepCommErrors: () => {
         throw new Error("aggregator down");
@@ -1354,6 +1366,7 @@ describe("job-producer — sweep cadence", () => {
           warns.push({ msg, ...(meta !== undefined ? { meta } : {}) });
         },
       },
+      family: "d6",
       sweepIntervalMs: 0,
       onSweepCommErrors: () => {
         throw new Error("aggregator down");
@@ -1400,6 +1413,7 @@ describe("job-producer — sweep cadence", () => {
       queue,
       enumerate: () => d6Specs(["a"]),
       logger,
+      family: "d6",
       sweepIntervalMs: 0, // sweep (and drop) on every tick
       // no onSweepCommErrors sink
     });
@@ -1455,6 +1469,7 @@ describe("job-producer — sweep cadence", () => {
       queue,
       enumerate: () => d6Specs(["a"]),
       logger,
+      family: "d6",
       sweepIntervalMs: 0, // sweep (and drop) on every tick
       // no onSweepCommErrors sink
     });
@@ -1713,6 +1728,7 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
       queue,
       enumerate: () => d6Specs(["alpha", "beta"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       warmHealth: { fetchImpl },
     });
     producer.start();
@@ -1746,6 +1762,7 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
       queue,
       enumerate: () => d6Specs(["alpha"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       warmHealth: { fetchImpl, timeoutMs: 1_000 },
     });
     producer.start();
@@ -1773,6 +1790,7 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
       queue,
       enumerate: () => d6Specs(["alpha"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       warmHealth: { fetchImpl },
     });
     producer.start();
@@ -1805,6 +1823,7 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
       queue,
       enumerate: () => d6Specs(["alpha", "beta"]),
       logger,
+      family: "d6",
       warmHealth: { fetchImpl },
     });
     producer.start();
@@ -1831,6 +1850,7 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
       queue: makeFakeQueue(),
       enumerate: () => d6Specs(["alpha"]),
       logger,
+      family: "d6",
       warmHealth: { fetchImpl },
     });
     producer.start();
@@ -1861,6 +1881,7 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
       queue: makeFakeQueue(),
       enumerate: () => d6Specs(["alpha"]),
       logger,
+      family: "d6",
       warmHealth: { fetchImpl },
     });
     producer.start();
@@ -1889,6 +1910,7 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
       queue,
       enumerate: () => d6Specs(["alpha"]),
       logger: throwingDebugLogger,
+      family: "d6",
       warmHealth: { fetchImpl: failingFetch },
     });
     producer.start();
@@ -1953,6 +1975,7 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
             debugs.push({ msg, ...(meta !== undefined ? { meta } : {}) });
         },
       },
+      family: "d6",
       warmHealth: { fetchImpl },
     });
     producer.start();
@@ -1989,6 +2012,7 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
             warns.push({ msg, ...(meta !== undefined ? { meta } : {}) });
         },
       },
+      family: "d6",
       warmHealth: { fetchImpl },
     });
     producer.start();
@@ -2014,6 +2038,7 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
       queue: makeFakeQueue(),
       enumerate: () => [],
       logger,
+      family: "d6",
       warmHealth: { fetchImpl },
     });
     empty.start();
@@ -2027,6 +2052,7 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
         ...d6Specs(["alpha"]),
       ],
       logger,
+      family: "d6",
       warmHealth: { fetchImpl },
     });
     mixed.start();
@@ -2064,6 +2090,7 @@ describe("job-producer — default run-id factory", () => {
         queue: makeFakeQueue(),
         enumerate: () => d6Specs(["a"]),
         logger: SILENT_LOGGER,
+        family: "d6",
         // no runIdFactory → the DEFAULT factory under test
       });
       producer.start();
@@ -2108,6 +2135,7 @@ describe("job-producer — tick re-entrancy guard", () => {
         return d6Specs(["a"]);
       },
       logger,
+      family: "d6",
     });
     producer.start();
     const firstP = producer.tick(); // blocked inside enumerate
@@ -2164,6 +2192,7 @@ describe("job-producer — tick re-entrancy guard", () => {
         return d6Specs(["a"]);
       },
       logger: SILENT_LOGGER,
+      family: "d6",
     });
     producer.start();
     const firstP = producer.tick(); // scheduled, blocked inside enumerate
@@ -2213,6 +2242,7 @@ describe("job-producer — tick re-entrancy guard", () => {
         return d6Specs(["a"]);
       },
       logger,
+      family: "d6",
     });
     producer.start();
     const firstP = producer.tick(); // blocked inside enumerate
@@ -2260,6 +2290,7 @@ describe("job-producer — stop() quiesce", () => {
       queue,
       enumerate: () => d6Specs(["a"]),
       logger: SILENT_LOGGER,
+      family: "d6",
     });
     producer.start();
     const tickP = producer.tick();
@@ -2297,6 +2328,7 @@ describe("job-producer — stop() quiesce", () => {
       queue,
       enumerate: () => d6Specs(["a"]),
       logger: SILENT_LOGGER,
+      family: "d6",
     });
     producer.start();
     const tickP = producer.tick();
@@ -2336,6 +2368,7 @@ describe("job-producer — stop() quiesce", () => {
         return d6Specs(["a"]);
       },
       logger: SILENT_LOGGER,
+      family: "d6",
     });
     producer.start();
     const firstP = producer.tick(); // blocked inside enumerate
@@ -2383,6 +2416,7 @@ describe("job-producer — stop() quiesce", () => {
         warn: (msg) => warns.push(msg),
         debug: (msg) => debugs.push(msg),
       },
+      family: "d6",
     });
     producer.start();
     const firstP = producer.tick(); // blocked inside enumerate
@@ -2420,6 +2454,7 @@ describe("job-producer — stop() quiesce", () => {
       queue,
       enumerate: () => d6Specs(["a", "b", "c"]),
       logger,
+      family: "d6",
     });
     producer.start();
     const tickP = producer.tick();
@@ -2461,6 +2496,7 @@ describe("job-producer — stop() quiesce", () => {
       queue,
       enumerate: () => d6Specs(["a", "b", "c"]),
       logger,
+      family: "d6",
     });
     producer.start();
     const tickP = producer.tick();
@@ -2524,6 +2560,7 @@ describe("job-producer — stop() quiesce", () => {
       queue,
       enumerate: () => d6Specs(["a"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       onSweepCommErrors: (errs) => {
         sinkCalls += 1;
         if (sinkCalls === 1) throw new Error("aggregator down");
@@ -2563,6 +2600,7 @@ describe("job-producer — stop() quiesce", () => {
       queue,
       enumerate: () => d6Specs(["a"]),
       logger,
+      family: "d6",
       onSweepCommErrors: () => {
         throw new Error("aggregator down for good");
       },
@@ -2606,6 +2644,7 @@ describe("job-producer — stop() quiesce", () => {
       queue,
       enumerate: () => d6Specs(["a"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       onSweepCommErrors: async () => {
         sinkCalls += 1;
         if (sinkCalls === 1) throw new Error("aggregator down"); // buffer j1
@@ -2678,6 +2717,7 @@ describe("job-producer — lifecycle seams (start/stop/tick)", () => {
       queue,
       enumerate: () => d6Specs(["a"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       runIdFactory,
     });
     // Never started.
@@ -2709,6 +2749,7 @@ describe("job-producer — lifecycle seams (start/stop/tick)", () => {
         ...SILENT_LOGGER,
         debug: (msg) => debugEvents.push(msg),
       },
+      family: "d6",
     });
 
     await producer.stop(); // never started — must NOT latch `stopped`
@@ -2742,6 +2783,7 @@ describe("job-producer — lifecycle seams (start/stop/tick)", () => {
             if (msg === "fleet.producer.tick-while-stopped") metas.push(meta);
           },
         },
+        family: "d6",
       });
       return { producer, metas };
     };
@@ -2818,6 +2860,7 @@ describe("job-producer — throwing-logger hardening", () => {
       queue,
       enumerate: () => d6Specs(["alpha"]),
       logger: makeThrowingLogger(),
+      family: "d6",
     });
     producer.start();
     const result = await producer.tick(); // must resolve, not reject
@@ -2832,6 +2875,7 @@ describe("job-producer — throwing-logger hardening", () => {
         throw new Error("discovery down");
       },
       logger: makeThrowingLogger(),
+      family: "d6",
     });
     producer.start();
     const result = await producer.tick(); // logger.error in the catch throws
@@ -2849,6 +2893,7 @@ describe("job-producer — throwing-logger hardening", () => {
       queue,
       enumerate: () => d6Specs(["alpha"]),
       logger: makeThrowingLogger(),
+      family: "d6",
     });
     producer.start();
     const result = await producer.tick();
@@ -2860,6 +2905,7 @@ describe("job-producer — throwing-logger hardening", () => {
       queue: makeFakeQueue(),
       enumerate: () => d6Specs(["alpha"]),
       logger: makeThrowingLogger(),
+      family: "d6",
     });
     // Never started — the tick-while-stopped warn throws.
     const result = await producer.tick();
@@ -2871,6 +2917,7 @@ describe("job-producer — throwing-logger hardening", () => {
       queue: makeFakeQueue(),
       enumerate: () => d6Specs(["alpha"]),
       logger: makeThrowingLogger(),
+      family: "d6",
     });
     producer.start();
     await producer.tick();
@@ -2902,6 +2949,7 @@ describe("job-producer — throwing-logger hardening", () => {
       queue,
       enumerate: () => d6Specs(["alpha"]),
       logger: makeThrowingLogger(),
+      family: "d6",
       onSweepCommErrors: () => {
         throw new Error("aggregator down for good");
       },

--- a/showcase/harness/src/fleet/control-plane/job-producer.test.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.test.ts
@@ -14,6 +14,7 @@ import type {
   FleetQueueClient,
   JobView,
   PoolCommError,
+  PruneAgedResult,
   SweepResult,
 } from "../contracts.js";
 import {
@@ -53,6 +54,7 @@ function makeFakeQueue(opts?: {
   sweepImpl?: (nowMs: number) => Promise<SweepResult>;
   /** Pending-count per family for the backlog dedupe gate; default 0 (clear). */
   countPendingImpl?: (family: string) => Promise<number>;
+  pruneImpl?: (nowMs: number) => Promise<PruneAgedResult>;
 }): FleetQueueClient & {
   /**
    * Every enqueue ATTEMPT, recorded BEFORE a throwing `enqueueImpl` gets to
@@ -62,10 +64,12 @@ function makeFakeQueue(opts?: {
   enqueued: EnqueueJobInput[];
   sweepCalls: number[];
   countCalls: string[];
+  pruneCalls: number[];
 } {
   const enqueued: EnqueueJobInput[] = [];
   const sweepCalls: number[] = [];
   const countCalls: string[] = [];
+  const pruneCalls: number[] = [];
   let jobSeq = 0;
   return {
     enqueued,
@@ -76,6 +80,7 @@ function makeFakeQueue(opts?: {
       if (opts?.countPendingImpl) return opts.countPendingImpl(family);
       return 0;
     },
+    pruneCalls,
     async enqueue(input: EnqueueJobInput): Promise<JobView> {
       enqueued.push(input);
       if (opts?.enqueueImpl) return opts.enqueueImpl(input);
@@ -93,6 +98,11 @@ function makeFakeQueue(opts?: {
       sweepCalls.push(nowMs);
       if (opts?.sweepImpl) return opts.sweepImpl(nowMs);
       return { reclaimed: 0, commErrors: [] };
+    },
+    async pruneAged(nowMs: number): Promise<PruneAgedResult> {
+      pruneCalls.push(nowMs);
+      if (opts?.pruneImpl) return opts.pruneImpl(nowMs);
+      return { terminal: 0, zombie: 0 };
     },
     claimNext() {
       throw new Error("producer must not call claimNext");
@@ -123,6 +133,7 @@ function startedProducer(overrides?: {
   queue?: ReturnType<typeof makeFakeQueue>;
   runIdFactory?: () => string;
   logger?: Logger;
+  family?: string;
 }): {
   producer: JobProducer;
   queue: ReturnType<typeof makeFakeQueue>;
@@ -134,6 +145,8 @@ function startedProducer(overrides?: {
     queue,
     enumerate: () => specs,
     logger: overrides?.logger ?? SILENT_LOGGER,
+    logger: SILENT_LOGGER,
+    family: overrides?.family ?? "d6",
     ...(overrides?.now ? { now: overrides.now } : {}),
     ...(overrides?.sweepIntervalMs !== undefined
       ? { sweepIntervalMs: overrides.sweepIntervalMs }
@@ -298,6 +311,7 @@ describe("job-producer — per-service enqueue", () => {
         return d6Specs(ctx.filter?.slugs ?? ["a"]);
       },
       logger: SILENT_LOGGER,
+      family: "d6",
     });
     producer.start();
     await producer.tick({ triggered: true, filter: { slugs: ["crewai"] } });
@@ -834,6 +848,7 @@ describe("job-producer — failure isolation", () => {
         throw new Error("railway discovery down");
       },
       logger: SILENT_LOGGER,
+      family: "d6",
       now: () => 1_000,
     });
     producer.start();
@@ -1075,6 +1090,7 @@ describe("job-producer — sweep cadence", () => {
       queue,
       enumerate: () => d6Specs(["a"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       onSweepCommErrors: (errs) => {
         received.push(errs);
       },
@@ -1095,6 +1111,7 @@ describe("job-producer — sweep cadence", () => {
       queue,
       enumerate: () => d6Specs(["a"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       onSweepCommErrors: () => {
         calls += 1;
       },
@@ -1122,6 +1139,7 @@ describe("job-producer — sweep cadence", () => {
       queue,
       enumerate: () => d6Specs(["a", "b"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       onSweepCommErrors: () => {
         throw new Error("aggregator down");
       },
@@ -1471,6 +1489,7 @@ describe("job-producer — sweep cadence", () => {
       queue,
       enumerate: () => d6Specs(["a"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       now: () => t,
     });
     producer.start();
@@ -1481,6 +1500,93 @@ describe("job-producer — sweep cadence", () => {
     t = DEFAULT_SWEEP_INTERVAL_MS; // window reached
     await producer.tick(); // sweep
     expect(queue.sweepCalls).toEqual([0, DEFAULT_SWEEP_INTERVAL_MS]);
+  });
+});
+
+describe("job-producer — family stamping + d6-gated retention prune", () => {
+  it("tick stamps options.family onto every EnqueueJobInput it builds", async () => {
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a", "b", "c"]),
+      family: "d6",
+    });
+    await producer.tick();
+    expect(queue.enqueued).toHaveLength(3);
+    for (const input of queue.enqueued) {
+      expect(input.family).toBe("d6");
+    }
+  });
+
+  it("stamps a non-d6 family verbatim (the §5.1 registry id, not a derivation)", async () => {
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a"]),
+      family: "e2e-demos",
+    });
+    await producer.tick();
+    expect(queue.enqueued[0]!.family).toBe("e2e-demos");
+  });
+
+  it("the d6 producer invokes queue.pruneAged when the sweep window is due", async () => {
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a"]),
+      family: "d6",
+      now: () => 5_000,
+    });
+    await producer.tick(); // first tick: sweep due (lastSweepAt seeded null)
+    expect(queue.sweepCalls).toEqual([5_000]);
+    expect(queue.pruneCalls).toEqual([5_000]);
+  });
+
+  it("a non-d6 producer never invokes queue.pruneAged (single-owner prune)", async () => {
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a"]),
+      family: "e2e-smoke",
+      sweepIntervalMs: 0, // sweep due on EVERY tick — prune still must not fire
+    });
+    await producer.tick();
+    await producer.tick();
+    expect(queue.sweepCalls).toHaveLength(2);
+    expect(queue.pruneCalls).toHaveLength(0);
+  });
+
+  it("pruneAged is not invoked when the sweep cadence window has not elapsed", async () => {
+    let t = 0;
+    const { producer, queue } = startedProducer({
+      specs: d6Specs(["a"]),
+      family: "d6",
+      now: () => t,
+      sweepIntervalMs: 30_000,
+    });
+    t = 0;
+    await producer.tick(); // sweep + prune @0
+    t = 10_000; // < 30s later — window not elapsed
+    await producer.tick(); // no sweep, no prune
+    expect(queue.pruneCalls).toEqual([0]);
+  });
+
+  it("a pruneAged failure is logged and never aborts production", async () => {
+    const queue = makeFakeQueue({
+      pruneImpl: async () => {
+        throw new Error("PB delete blip");
+      },
+    });
+    const warns: string[] = [];
+    const producer = createJobProducer({
+      queue,
+      enumerate: () => d6Specs(["a", "b"]),
+      logger: {
+        ...SILENT_LOGGER,
+        warn: (msg: string) => {
+          warns.push(msg);
+        },
+      },
+      family: "d6",
+    });
+    producer.start();
+    const result = await producer.tick();
+    // Production completed despite the prune throwing (mirror maybeSweep's
+    // swallow discipline).
+    expect(result.enqueued).toBe(2);
+    expect(warns).toContain("fleet.producer.prune-failed");
   });
 });
 
@@ -1532,6 +1638,7 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
       queue,
       enumerate: () => d6Specs(["alpha", "beta"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       warmHealth: { fetchImpl },
     });
     producer.start();
@@ -1566,6 +1673,7 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
       queue,
       enumerate: () => d6Specs(["alpha"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       // no warmHealth
     });
     producer.start();
@@ -1584,6 +1692,7 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
       queue,
       enumerate: () => d6Specs(["alpha", "beta"]),
       logger: SILENT_LOGGER,
+      family: "d6",
       warmHealth: { fetchImpl: failingFetch },
     });
     producer.start();
@@ -1804,6 +1913,7 @@ describe("job-producer — #72 pre-dispatch health warm-up", () => {
         },
       ],
       logger: SILENT_LOGGER,
+      family: "d6",
       warmHealth: { fetchImpl },
     });
     producer.start();
@@ -2536,6 +2646,7 @@ describe("job-producer — lifecycle seams (start/stop/tick)", () => {
       queue,
       enumerate: () => [],
       logger: SILENT_LOGGER,
+      family: "d6",
     });
     expect(producer.isRunning()).toBe(false);
     producer.start();
@@ -2550,6 +2661,7 @@ describe("job-producer — lifecycle seams (start/stop/tick)", () => {
       queue,
       enumerate: () => d6Specs(["a"]),
       logger: SILENT_LOGGER,
+      family: "d6",
     });
     const result = await producer.tick();
     expect(result.enqueued).toBe(0);
@@ -2673,6 +2785,7 @@ describe("job-producer — lifecycle seams (start/stop/tick)", () => {
       queue,
       enumerate: () => d6Specs(["a", "b"]),
       logger: SILENT_LOGGER,
+      family: "d6",
     });
     producer.start();
     await producer.tick();

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -285,6 +285,19 @@ export interface JobProducerOptions {
   enumerate: ServiceEnumerator;
   logger: Logger;
   /**
+   * The producing family's id — a `FLEET_FAMILIES[*].family` value from the
+   * §5.1 registry (e.g. `"d6"`, `"d5"`, `"e2e-demos"`, `"e2e-smoke"`). Stamped
+   * onto every `EnqueueJobInput` this producer builds (the queue-client
+   * denormalizes it into the `probe_jobs.family` column), and ALSO the
+   * prune-ownership key: the §4.2 retention prune runs only when
+   * `family === "d6"` so four producers sharing the sweep-gate pattern never
+   * run four concurrent delete passes (single-owner by configuration).
+   * A constructor option rather than scheduleId-derived because the producer
+   * deliberately has no knowledge of its schedule id (bound later, in
+   * `buildProducerSchedules`).
+   */
+  family: string;
+  /**
    * How often to run `sweepExpired()` for dead-worker reclamation, in ms.
    * The sweep runs at most once per `sweepIntervalMs` window, evaluated on
    * each tick against the clock — the producer never owns its own timer
@@ -537,7 +550,10 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
     if (spec.cellIds !== undefined) payload.cellIds = spec.cellIds;
     if (spec.driverInputs !== undefined)
       payload.driverInputs = spec.driverInputs;
-    return { payload };
+    // §4.2: every job a producer enqueues carries its family id so the
+    // queue-client can denormalize it into the indexed `probe_jobs.family`
+    // column (per-family listing without prefix-parsing probe_key).
+    return { payload, family: opts.family };
   }
 
   /**
@@ -651,6 +667,28 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       // deliverSweepCommErrors — it runs on every sweep attempt, even a failed
       // one). The buffer is capped at MAX_BUFFERED_SWEEP_COMM_ERRORS.
       await deliverSweepCommErrors(result.commErrors);
+      // §4.2 RETENTION PRUNE — gated on the d6 family so exactly ONE of the
+      // four producers sharing this sweep-gate pattern owns the delete pass
+      // (the prune itself is family-agnostic: one pass covers all families,
+      // and it is idempotent, so a missed tick is harmless). Rides the same
+      // due-window as the sweep. Best-effort: a prune failure is logged and
+      // NEVER aborts job production — mirror the sweep's swallow discipline.
+      if (opts.family === "d6") {
+        try {
+          const pruned = await queue.pruneAged(nowMs);
+          if (pruned.terminal > 0 || pruned.zombie > 0) {
+            // Spread: `PruneAgedResult` is a closed interface with no index
+            // signature, so it isn't assignable to the logger's
+            // `Record<string, unknown>` context parameter directly.
+            logger.info("fleet.producer.pruned-aged-jobs", { ...pruned });
+          }
+        } catch (pruneErr) {
+          logger.warn("fleet.producer.prune-failed", {
+            err:
+              pruneErr instanceof Error ? pruneErr.message : String(pruneErr),
+          });
+        }
+      }
       // The queue-client's sweep splits out reclaims whose release outcome
       // was indeterminate (`reclaimedIndeterminate`, optional on the shared
       // `SweepResult` contract; the real queue-client always reports it).

--- a/showcase/harness/src/fleet/control-plane/job-producer.ts
+++ b/showcase/harness/src/fleet/control-plane/job-producer.ts
@@ -50,6 +50,7 @@ import type {
 import { probeKeyFamily } from "../contracts.js";
 import { PoisonedBacklogCountError } from "../queue-client.js";
 import { deriveHealthUrl } from "../../probes/liveness.js";
+import { PRUNE_OWNER_FAMILY } from "./run-view.js";
 
 /**
  * Sink the producer hands its lease-sweep comm errors to (REQ-B). `sweepExpired`
@@ -290,7 +291,8 @@ export interface JobProducerOptions {
    * onto every `EnqueueJobInput` this producer builds (the queue-client
    * denormalizes it into the `probe_jobs.family` column), and ALSO the
    * prune-ownership key: the §4.2 retention prune runs only when
-   * `family === "d6"` so four producers sharing the sweep-gate pattern never
+   * `family === PRUNE_OWNER_FAMILY` (the §5.1 registry's D6 family id, NOT a
+   * hardcoded literal) so four producers sharing the sweep-gate pattern never
    * run four concurrent delete passes (single-owner by configuration).
    * A constructor option rather than scheduleId-derived because the producer
    * deliberately has no knowledge of its schedule id (bound later, in
@@ -667,13 +669,14 @@ export function createJobProducer(opts: JobProducerOptions): JobProducer {
       // deliverSweepCommErrors — it runs on every sweep attempt, even a failed
       // one). The buffer is capped at MAX_BUFFERED_SWEEP_COMM_ERRORS.
       await deliverSweepCommErrors(result.commErrors);
-      // §4.2 RETENTION PRUNE — gated on the d6 family so exactly ONE of the
-      // four producers sharing this sweep-gate pattern owns the delete pass
+      // §4.2 RETENTION PRUNE — gated on PRUNE_OWNER_FAMILY (the §5.1 registry's
+      // D6 family id) so exactly ONE of the four producers sharing this
+      // sweep-gate pattern owns the delete pass
       // (the prune itself is family-agnostic: one pass covers all families,
       // and it is idempotent, so a missed tick is harmless). Rides the same
       // due-window as the sweep. Best-effort: a prune failure is logged and
       // NEVER aborts job production — mirror the sweep's swallow discipline.
-      if (opts.family === "d6") {
+      if (opts.family === PRUNE_OWNER_FAMILY) {
         try {
           const pruned = await queue.pruneAged(nowMs);
           if (pruned.terminal > 0 || pruned.zombie > 0) {

--- a/showcase/harness/src/fleet/control-plane/result-aggregator.test.ts
+++ b/showcase/harness/src/fleet/control-plane/result-aggregator.test.ts
@@ -173,6 +173,39 @@ function makeErrorRoutingFakeStatusWriter(): {
   return { writer, statusRows, writes, overlays };
 }
 
+/**
+ * A fake whose `WriteOutcome.previousState`/`newState` are canned per key, so
+ * tests can exercise specific durable-State transitions (green→red, red→green)
+ * and error ticks (`newState: "error"`) — the §4.2 reds-counter inputs. Keys
+ * without a canned outcome fall back to `makeFakeStatusWriter` behavior.
+ */
+function makeCannedTransitionStatusWriter(
+  outcomesByKey: Record<
+    string,
+    Pick<WriteOutcome, "previousState" | "newState">
+  >,
+): { writer: StatusWriter; writes: RecordedWrite[] } {
+  const writes: RecordedWrite[] = [];
+  const writer: StatusWriter = {
+    async write(result) {
+      writes.push({ result });
+      const canned = outcomesByKey[result.key];
+      const outcome: WriteOutcome = {
+        previousState:
+          canned?.previousState !== undefined ? canned.previousState : null,
+        newState:
+          canned?.newState ??
+          (result.state === "error" ? "error" : result.state),
+        transition: canned?.newState === "error" ? "error" : "first",
+        firstFailureAt: null,
+        failCount: 0,
+      };
+      return outcome;
+    },
+  };
+  return { writer, writes };
+}
+
 interface RunWriterCalls {
   start: {
     probeId: string;
@@ -347,7 +380,15 @@ describe("createResultAggregator", () => {
     const finish = runFake.calls.finish[0];
     expect(finish.id).toBe("run-row-1");
     expect(finish.state).toBe("failed");
-    expect(finish.summary).toEqual({ total: 2, passed: 1, failed: 1 });
+    expect(finish.summary).toEqual({
+      total: 2,
+      passed: 1,
+      failed: 1,
+      // §4.2 counters ride every fleet-aggregated summary (0 when the fake
+      // writer reports no green→red / red→green durable transitions).
+      redsIntroduced: 0,
+      redsCleared: 0,
+    });
   });
 
   it("marks the run completed when the aggregate state is green", async () => {
@@ -372,6 +413,8 @@ describe("createResultAggregator", () => {
       total: 1,
       passed: 1,
       failed: 0,
+      redsIntroduced: 0,
+      redsCleared: 0,
     });
   });
 
@@ -3015,6 +3058,134 @@ describe("createResultAggregator", () => {
       ).toHaveLength(2);
       // The drift itself is still surfaced.
       expect(outcome.droppedCommError).toBe(true);
+    });
+  });
+
+  // ── §4.2: reds counters persisted into probe_runs.summary ────────────────
+  describe("reds counters (redsIntroduced/redsCleared into probe_runs.summary)", () => {
+    function makeAggregatorWith(
+      outcomesByKey: Record<
+        string,
+        Pick<WriteOutcome, "previousState" | "newState">
+      >,
+    ) {
+      const fake = makeCannedTransitionStatusWriter(outcomesByKey);
+      const agg = createResultAggregator({
+        statusWriter: fake.writer,
+        runWriter: runFake.writer,
+        logger: makeLogger(),
+        now: () => now,
+      });
+      return agg;
+    }
+
+    it("aggregate counts green→red WriteOutcome transitions into summary.redsIntroduced", async () => {
+      const agg = makeAggregatorWith({
+        "d6:langgraph-python": { previousState: "green", newState: "red" },
+        "d6:langgraph-python/shared-state": {
+          previousState: "green",
+          newState: "red",
+        },
+        "d6:langgraph-python/human-in-the-loop": {
+          previousState: "green",
+          newState: "green",
+        },
+      });
+      await agg.aggregate(makeResult());
+
+      expect(runFake.calls.finish).toHaveLength(1);
+      expect(runFake.calls.finish[0].summary?.redsIntroduced).toBe(2);
+      expect(runFake.calls.finish[0].summary?.redsCleared).toBe(0);
+    });
+
+    it("aggregate counts red→green transitions into summary.redsCleared", async () => {
+      const agg = makeAggregatorWith({
+        "d6:langgraph-python": { previousState: "red", newState: "green" },
+        "d6:langgraph-python/shared-state": {
+          previousState: "red",
+          newState: "green",
+        },
+        "d6:langgraph-python/human-in-the-loop": {
+          previousState: "red",
+          newState: "red",
+        },
+      });
+      await agg.aggregate(makeResult());
+
+      expect(runFake.calls.finish).toHaveLength(1);
+      expect(runFake.calls.finish[0].summary?.redsCleared).toBe(2);
+      expect(runFake.calls.finish[0].summary?.redsIntroduced).toBe(0);
+    });
+
+    it('error-tick outcomes (newState === "error") are excluded from both counters', async () => {
+      // §4.2: an error tick is a measurement failure — the prior durable
+      // colour rides on errorStatePrev, and the tick neither introduced nor
+      // cleared a red. A green→error cell must NOT count as introduced, a
+      // red→error cell must NOT count as cleared; the one real green→red
+      // transition still counts.
+      const agg = makeAggregatorWith({
+        "d6:langgraph-python": { previousState: "green", newState: "red" },
+        "d6:langgraph-python/shared-state": {
+          previousState: "green",
+          newState: "error",
+        },
+        "d6:langgraph-python/human-in-the-loop": {
+          previousState: "red",
+          newState: "error",
+        },
+      });
+      await agg.aggregate(makeResult());
+
+      expect(runFake.calls.finish).toHaveLength(1);
+      expect(runFake.calls.finish[0].summary?.redsIntroduced).toBe(1);
+      expect(runFake.calls.finish[0].summary?.redsCleared).toBe(0);
+    });
+
+    it("a writer that resolves without an outcome contributes nothing (no crash)", async () => {
+      // orchestrator.test.ts doMock's the status-writer with a write() that
+      // returns undefined; the counter pass must tolerate a missing outcome
+      // (contributes to neither counter) instead of dereferencing it.
+      const writer: StatusWriter = {
+        write: (async () => undefined) as unknown as StatusWriter["write"],
+      };
+      const agg = createResultAggregator({
+        statusWriter: writer,
+        runWriter: runFake.writer,
+        logger: makeLogger(),
+        now: () => now,
+      });
+      await agg.aggregate(makeResult());
+
+      expect(runFake.calls.finish).toHaveLength(1);
+      expect(runFake.calls.finish[0].summary?.redsIntroduced).toBe(0);
+      expect(runFake.calls.finish[0].summary?.redsCleared).toBe(0);
+    });
+
+    it("the finished probe_runs row's summary carries both counters", async () => {
+      const agg = makeAggregatorWith({
+        "d6:langgraph-python": { previousState: "green", newState: "red" },
+        "d6:langgraph-python/shared-state": {
+          previousState: "red",
+          newState: "green",
+        },
+        "d6:langgraph-python/human-in-the-loop": {
+          previousState: null,
+          newState: "green",
+        },
+      });
+      await agg.aggregate(makeResult());
+
+      expect(runFake.calls.finish).toHaveLength(1);
+      // The full finished summary: rollup fields AND both counters,
+      // explicitly present (0-valued counters serialize as 0, not absent —
+      // only pre-P2 rows lack the fields).
+      expect(runFake.calls.finish[0].summary).toEqual({
+        total: 2,
+        passed: 1,
+        failed: 1,
+        redsIntroduced: 1,
+        redsCleared: 1,
+      });
     });
   });
 

--- a/showcase/harness/src/fleet/control-plane/result-aggregator.test.ts
+++ b/showcase/harness/src/fleet/control-plane/result-aggregator.test.ts
@@ -199,8 +199,12 @@ function makeCannedTransitionStatusWriter(
         transition: canned?.newState === "error" ? "error" : "first",
         firstFailureAt: null,
         failCount: 0,
+        persisted: true,
       };
       return outcome;
+    },
+    async writeOverlay() {
+      return { applied: false, state: null };
     },
   };
   return { writer, writes };
@@ -2800,7 +2804,7 @@ describe("createResultAggregator", () => {
 
   // ── B6: contract pins — documented ERROR CONTRACTs + loud-throw guards ───
   describe("[B6] documented error contracts", () => {
-    it("aggregate() ERROR CONTRACT: rejects on the FIRST status write that throws — remaining writes not attempted, finish skipped", async () => {
+    it("aggregate() per-row try/catch: a thrown status write is logged and the batch CONTINUES — finish still runs", async () => {
       const writes: RecordedWrite[] = [];
       let writeCalls = 0;
       const throwingWriter: StatusWriter = {
@@ -2829,18 +2833,17 @@ describe("createResultAggregator", () => {
       });
 
       // Default fixture projects 3 rows (primary + 2 cells); the SECOND
-      // write throws.
-      await expect(agg.aggregate(makeResult())).rejects.toThrow(
-        "PB write blip",
-      );
-      // The first write landed, the second threw, the THIRD was never
-      // attempted.
-      expect(writeCalls).toBe(2);
-      expect(writes.map((w) => w.result.key)).toEqual(["d6:langgraph-python"]);
-      // finish is SKIPPED — the run row stays `running` for the boot-time
-      // stale-run sweep (start DID run, bracketing the writes).
+      // write throws — per-row try/catch swallows it and the third still runs.
+      // The run-history finish still lands (no `running` row left for the
+      // boot-time stale-run sweep).
+      await agg.aggregate(makeResult());
+      expect(writeCalls).toBe(3);
+      expect(writes.map((w) => w.result.key)).toEqual([
+        "d6:langgraph-python",
+        "d6:langgraph-python/human-in-the-loop",
+      ]);
       expect(runFake.calls.start).toHaveLength(1);
-      expect(runFake.calls.finish).toHaveLength(0);
+      expect(runFake.calls.finish).toHaveLength(1);
     });
 
     it("aggregateCommError ERROR CONTRACT: an aggregate-key fallback write that throws rejects — the cell key is not attempted", async () => {
@@ -2878,7 +2881,7 @@ describe("createResultAggregator", () => {
       expect(writeCalls).toBe(1);
     });
 
-    it("findByJobId-throw branch: warns and PROCEEDS without dedup (full write path still runs)", async () => {
+    it("findByJobId-throw branch: warns and SKIPS run-row mint (status writes still run, no run-history row)", async () => {
       runFake.writer.findByJobId = async () => {
         throw new Error("lookup blip");
       };
@@ -2886,12 +2889,16 @@ describe("createResultAggregator", () => {
 
       const outcome = await agg.aggregate(makeResult());
 
-      // The lookup failure was swallowed: aggregation ran in full.
+      // The lookup throw is UNCERTAIN: aggregation proceeds with the status
+      // writes (idempotent via the writer state machine) but does NOT mint a
+      // fresh run-history row — minting could duplicate a row that already
+      // exists (which the failed lookup couldn't see). A subsequent successful
+      // tick reconciles the run-history row.
       expect(outcome.skipped).toBe(false);
       expect(statusFake.writes).toHaveLength(3);
-      expect(runFake.calls.start).toHaveLength(1);
-      expect(runFake.calls.finish).toHaveLength(1);
-      expect(outcome.runRowId).toBe("run-row-1");
+      expect(runFake.calls.start).toHaveLength(0);
+      expect(runFake.calls.finish).toHaveLength(0);
+      expect(outcome.runRowId).toBeNull();
     });
 
     it("runWriter.start-throw branch: runRowId null, finish skipped, aggregation continues", async () => {
@@ -3147,6 +3154,10 @@ describe("createResultAggregator", () => {
       // (contributes to neither counter) instead of dereferencing it.
       const writer: StatusWriter = {
         write: (async () => undefined) as unknown as StatusWriter["write"],
+        writeOverlay: (async () => ({
+          applied: false,
+          state: null,
+        })) as unknown as StatusWriter["writeOverlay"],
       };
       const agg = createResultAggregator({
         statusWriter: writer,

--- a/showcase/harness/src/fleet/control-plane/result-aggregator.ts
+++ b/showcase/harness/src/fleet/control-plane/result-aggregator.ts
@@ -450,17 +450,20 @@ export function createResultAggregator(
       //     crashing has those rows RE-written here (re-bumping fail_count,
       //     re-appending status_history, re-emitting status.changed for
       //     them) — accepted as the cost of not minting a duplicate run row.
-      // findByJobId failing must not wedge aggregation, so we treat a lookup
-      // error as "no prior row" and proceed (at-least-once, same as before).
-      // AMBIGUITY NOTE (B5 round 7): proceeding past a FAILED lookup means
-      // runWriter.start below mints a fresh jobId-stamped run row even when a
-      // prior row for this jobId actually exists (the lookup just couldn't
-      // see it) — leaving TWO rows stamped with the same jobId. A later
-      // findByJobId resolves newest-first, so the dedup gate still
-      // short-circuits correctly once either row is terminal, but the
-      // returned runRowId / run-history association for this jobId is
-      // ambiguous (either row may be reported, and the older one may linger
-      // `running` until the boot-time stale-run sweep closes it).
+      // findByJobId failing must not wedge aggregation, but it MUST NOT be
+      // treated as "no prior row" either: under a transient PB read error we
+      // genuinely don't know whether a prior run row already exists, and
+      // optimistically minting a new one would duplicate the probe_runs row on
+      // a retry tick. So we distinguish:
+      //   - throw          → UNCERTAIN. Skip the `runWriter.start` mint
+      //                      altogether (resumeRunRowId stays null, dedupLookupFailed
+      //                      latches true) so we don't fabricate a duplicate row.
+      //                      Status writes still happen — they're idempotent via
+      //                      the status-writer state machine. The run-history
+      //                      row will be reconciled on a subsequent successful
+      //                      tick once PB recovers.
+      //   - returned null  → genuinely no prior row → mint normally.
+      //   - returned row   → dedup-skip (terminal) / resume (non-terminal).
       //
       // HONESTY: this gate only reaches as far as runWriter.start (below,
       // BEST-EFFORT) managed to stamp this jobId on a run row. When start
@@ -475,6 +478,7 @@ export function createResultAggregator(
       // this lookup before either stamps a run row, and both replay the full
       // write path (the same duplication the gate exists to prevent).
       let resumeRunRowId: string | null = null;
+      let dedupLookupFailed = false;
       try {
         const prior = await runWriter.findByJobId(result.jobId);
         if (prior && prior.terminal) {
@@ -496,6 +500,7 @@ export function createResultAggregator(
         if (prior) resumeRunRowId = prior.id;
       } catch (err) {
         const info = errorInfo(err);
+        dedupLookupFailed = true;
         logger.warn("fleet.aggregator.dedup-lookup-failed", {
           probeKey: result.aggregateKey,
           jobId: result.jobId,
@@ -641,7 +646,11 @@ export function createResultAggregator(
           consequence:
             "skipping run-history start — a blank/whitespace aggregateKey would mint a phantom probe_runs row keyed probeId ''; with no jobId-stamped run row the per-jobId dedup gate is DISARMED for this job (same exposure as a failed start)",
         });
-      } else if (!runRowId) {
+      } else if (!runRowId && !dedupLookupFailed) {
+        // Only mint a fresh run-history row when the dedup lookup CONFIRMED no
+        // prior row. Under `dedupLookupFailed` we don't know, and minting would
+        // risk duplicating a row that already exists; status writes still
+        // happen below and a subsequent successful tick will reconcile.
         try {
           const created = await runWriter.start({
             // G2r8: trimmed — run-history is keyed by the canonical probeId
@@ -677,6 +686,13 @@ export function createResultAggregator(
       // history-only no-data ("error") write — F2.1: a missing key gets NO
       // fabricated status row; the no-drop guarantee is HISTORY persistence
       // (same fallback as aggregateCommError).
+      //
+      // Per-row try/catch on the durable write paths: a single bad row (e.g.
+      // transient PB error on one side row) must NOT abort the whole batch
+      // before `runWriter.finish` below, which would leave a `running`
+      // probe_runs row that only `sweepStaleRuns` could clean up. Log the
+      // failure on the established error path and keep iterating so the
+      // remaining rows + the run-history finish still land.
       const statusOutcomes: WriteOutcome[] = [];
       const overlayOutcomes: OverlayWriteOutcome[] = [];
       const outageSkippedKeys: string[] = [];
@@ -979,8 +995,17 @@ export function createResultAggregator(
           );
           continue;
         }
-        const outcome = await statusWriter.write(pr);
-        statusOutcomes.push(outcome);
+        try {
+          const outcome = await statusWriter.write(pr);
+          statusOutcomes.push(outcome);
+        } catch (err) {
+          logger.error("fleet.aggregator.status-write-failed", {
+            probeKey: result.aggregateKey,
+            jobId: result.jobId,
+            rowKey: pr.key,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
       }
 
       // §4.2 reds counters: durable State transitions only, across the

--- a/showcase/harness/src/fleet/control-plane/result-aggregator.ts
+++ b/showcase/harness/src/fleet/control-plane/result-aggregator.ts
@@ -983,6 +983,25 @@ export function createResultAggregator(
         statusOutcomes.push(outcome);
       }
 
+      // §4.2 reds counters: durable State transitions only, across the
+      // aggregate + cell outcomes collected above. An error tick
+      // (`newState === "error"`) is a measurement failure — the prior
+      // durable colour rides on `errorStatePrev` — so it neither introduced
+      // nor cleared a red and is excluded from both counters. A missing
+      // outcome (a writer that resolved without one — seen from doMock'd
+      // writers in tests) likewise contributes nothing.
+      let redsIntroduced = 0;
+      let redsCleared = 0;
+      for (const o of statusOutcomes) {
+        if (!o || o.newState === "error") continue;
+        if (o.previousState === "green" && o.newState === "red") {
+          redsIntroduced += 1;
+        }
+        if (o.previousState === "red" && o.newState === "green") {
+          redsCleared += 1;
+        }
+      }
+
       // Persist the rollup. `terminalJobStatus` maps green→done / anything
       // else (incl. comm error) →failed; run-history's narrower enum is
       // completed/failed, so a "done" job is a "completed" run.
@@ -994,7 +1013,11 @@ export function createResultAggregator(
             id: runRowId,
             finishedAt: now(),
             state: runState,
-            summary: runSummaryForServiceJobResult(result),
+            summary: {
+              ...runSummaryForServiceJobResult(result),
+              redsIntroduced,
+              redsCleared,
+            },
           });
         } catch (err) {
           const info = errorInfo(err);

--- a/showcase/harness/src/fleet/control-plane/run-view.test.ts
+++ b/showcase/harness/src/fleet/control-plane/run-view.test.ts
@@ -1,0 +1,1005 @@
+/**
+ * run-view (T5) — family registry, run/worker projections, memoized family
+ * summary. Every test name maps to a spec §8 testing bullet; the semantics
+ * under test are §5.2.1 verbatim (outcome precedence, stalled rules,
+ * walk-back, redaction) plus the §5.1 registry drift-lock.
+ */
+
+import { describe, expect, it } from "vitest";
+import type {
+  ListOpts,
+  ListResult,
+  PbClient,
+} from "../../storage/pb-client.js";
+import type { Logger } from "../../types/index.js";
+import type { JobProducer } from "./job-producer.js";
+import { buildProducerSchedules } from "../../orchestrator.js";
+import type { ProducerSchedule } from "./control-plane.js";
+import {
+  FLEET_FAMILIES,
+  type FamilySummaryEntry,
+  type FamilySummaryResponse,
+  type ProbeJobRecord,
+  type RunViewDeps,
+  type WorkerRow,
+  classifyInflight,
+  createMemoizedFamilySummary,
+  deriveOutcome,
+  groupBatches,
+  periodMsFromCron,
+  projectRunBatch,
+  projectWorker,
+} from "./run-view.js";
+
+// ───────────────────────────────────────────────────────────────────────
+// Fixtures
+// ───────────────────────────────────────────────────────────────────────
+
+const NOW_MS = Date.parse("2026-06-10T18:00:00.000Z");
+
+function iso(offsetMs: number): string {
+  return new Date(NOW_MS + offsetMs).toISOString();
+}
+
+const noopLogger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+let nextRowId = 0;
+
+/** Build one probe_jobs row. `created`/`updated` default to enqueuedAt. */
+function jobRow(overrides: Partial<ProbeJobRecord> = {}): ProbeJobRecord {
+  nextRowId += 1;
+  const id = overrides.id ?? `row-${String(nextRowId).padStart(4, "0")}`;
+  const enqueuedAt = iso(-60_000);
+  const base: ProbeJobRecord = {
+    id,
+    probe_key: "d6:langgraph-python",
+    status: "done",
+    claimed_by: "worker-a",
+    run_id: "run-1",
+    family: "d6",
+    created: enqueuedAt,
+    updated: enqueuedAt,
+    payload: {
+      probeKey: "d6:langgraph-python",
+      serviceSlug: "langgraph-python",
+      driverKind: "e2e_d6",
+      meta: { runId: "run-1", triggered: false, enqueuedAt },
+    },
+  };
+  return { ...base, ...overrides };
+}
+
+/** Convenience: a row with payload.meta fields kept in sync. */
+function batchRow(opts: {
+  runId: string;
+  id?: string;
+  status?: ProbeJobRecord["status"];
+  family?: string;
+  probeKey?: string;
+  enqueuedAt?: string;
+  created?: string;
+  updated?: string;
+  finishedAt?: string;
+  reclaimCount?: number;
+  triggered?: boolean;
+  result?: unknown;
+  metaEnqueuedAt?: string;
+}): ProbeJobRecord {
+  const enqueuedAt = opts.enqueuedAt ?? iso(-60_000);
+  return jobRow({
+    ...(opts.id ? { id: opts.id } : {}),
+    run_id: opts.runId,
+    status: opts.status ?? "done",
+    family: opts.family ?? "d6",
+    probe_key: opts.probeKey ?? "d6:langgraph-python",
+    created: opts.created ?? enqueuedAt,
+    updated: opts.updated ?? opts.created ?? enqueuedAt,
+    ...(opts.finishedAt ? { finished_at: opts.finishedAt } : {}),
+    ...(opts.reclaimCount !== undefined
+      ? { reclaim_count: opts.reclaimCount }
+      : {}),
+    ...(opts.result !== undefined ? { result: opts.result } : {}),
+    payload: {
+      probeKey: opts.probeKey ?? "d6:langgraph-python",
+      serviceSlug: "langgraph-python",
+      driverKind: "e2e_d6",
+      meta: {
+        runId: opts.runId,
+        triggered: opts.triggered ?? false,
+        enqueuedAt: opts.metaEnqueuedAt ?? enqueuedAt,
+      },
+    },
+  });
+}
+
+interface FakeProbeRunRow {
+  id: string;
+  probe_id: string;
+  job_id: string;
+  started_at: string;
+  summary: Record<string, unknown> | null;
+}
+
+interface FakeWorkerRow extends WorkerRow {
+  id: string;
+}
+
+/**
+ * Minimal fake PbClient mirroring queue-client.test.ts's makeFakePb: only
+ * the list() shapes run-view issues are honored; everything else throws so
+ * an accidental dependency surfaces loudly. Counts list calls per
+ * collection for the memo tests.
+ */
+function makeFakePb(opts: {
+  jobs?: ProbeJobRecord[];
+  probeRuns?: FakeProbeRunRow[];
+  workers?: FakeWorkerRow[];
+  /** Families whose probe_jobs list throws (per-family degradation tests). */
+  failFamilies?: string[];
+}): { pb: PbClient; listCalls: string[] } {
+  const jobs = [...(opts.jobs ?? [])];
+  const probeRuns = [...(opts.probeRuns ?? [])];
+  const workers = [...(opts.workers ?? [])];
+  const failFamilies = new Set(opts.failFamilies ?? []);
+  const listCalls: string[] = [];
+  const unsupported = (name: string) => () => {
+    throw new Error(`fake-pb: ${name} not implemented`);
+  };
+  const pb: PbClient = {
+    async list<T>(
+      collection: string,
+      listOpts: ListOpts = {},
+    ): Promise<ListResult<T>> {
+      listCalls.push(collection);
+      const filter = listOpts.filter ?? "";
+      let items: unknown[];
+      if (collection === "probe_jobs") {
+        const fam = /family = "([^"]+)"/.exec(filter)?.[1];
+        if (fam !== undefined && failFamilies.has(fam)) {
+          throw new Error(`fake-pb: simulated outage for family ${fam}`);
+        }
+        let rows = jobs.filter((r) => r.family === fam);
+        // Composite (created, id) cursor, when present.
+        const before = /created [<=]+ "([^"]+)"/.exec(filter)?.[1];
+        const beforeId = /id < "([^"]+)"/.exec(filter)?.[1];
+        if (before !== undefined) {
+          rows = rows.filter(
+            (r) =>
+              r.created < before ||
+              (beforeId !== undefined &&
+                r.created === before &&
+                r.id < beforeId),
+          );
+        }
+        rows = [...rows].sort((a, b) =>
+          a.created === b.created
+            ? b.id.localeCompare(a.id)
+            : b.created.localeCompare(a.created),
+        );
+        items = rows.slice(0, listOpts.perPage ?? rows.length);
+      } else if (collection === "probe_runs") {
+        const ids = new Set(
+          [...filter.matchAll(/job_id = "([^"]+)"/g)].map((m) => m[1]),
+        );
+        items = probeRuns.filter((r) => ids.has(r.job_id));
+      } else if (collection === "workers") {
+        items = workers;
+      } else {
+        throw new Error(`fake-pb: unexpected collection ${collection}`);
+      }
+      return {
+        page: 1,
+        perPage: listOpts.perPage ?? items.length,
+        totalPages: 1,
+        totalItems: items.length,
+        items: items as T[],
+      };
+    },
+    getOne: unsupported("getOne") as PbClient["getOne"],
+    getFirst: unsupported("getFirst") as PbClient["getFirst"],
+    create: unsupported("create") as PbClient["create"],
+    update: unsupported("update") as PbClient["update"],
+    upsertByField: unsupported("upsertByField") as PbClient["upsertByField"],
+    delete: unsupported("delete") as PbClient["delete"],
+    deleteByFilter: unsupported("deleteByFilter") as PbClient["deleteByFilter"],
+    health: unsupported("health") as PbClient["health"],
+    createBackup: unsupported("createBackup") as PbClient["createBackup"],
+    downloadBackup: unsupported("downloadBackup") as PbClient["downloadBackup"],
+    deleteBackup: unsupported("deleteBackup") as PbClient["deleteBackup"],
+  };
+  return { pb, listCalls };
+}
+
+/** A producer stub for ProducerSchedule entries (never ticked here). */
+function stubProducer(): JobProducer {
+  return {
+    start: () => {},
+    stop: async () => {},
+    tick: async () => {
+      throw new Error("stub producer must not tick in run-view tests");
+    },
+    isRunning: () => false,
+  };
+}
+
+/** The real four-schedule manifest with an optional d6 cron override. */
+function makeSchedules(d6Cron?: string): readonly ProducerSchedule[] {
+  return buildProducerSchedules({
+    d6: stubProducer(),
+    smoke: stubProducer(),
+    demos: stubProducer(),
+    deep: stubProducer(),
+    ...(d6Cron ? { d6Cron } : {}),
+  });
+}
+
+function makeDeps(overrides: {
+  pb: PbClient;
+  schedules?: readonly ProducerSchedule[];
+  workerStaleAfterMs?: number;
+  nextRunAt?: (id: string) => Date | null;
+  now?: () => number;
+}): RunViewDeps {
+  return {
+    pb: overrides.pb,
+    scheduler: { nextRunAt: overrides.nextRunAt ?? (() => null) },
+    schedules: overrides.schedules ?? makeSchedules(),
+    workerStaleAfterMs: overrides.workerStaleAfterMs ?? 180_000,
+    logger: noopLogger,
+    now: overrides.now ?? (() => NOW_MS),
+  };
+}
+
+function familyEntry(
+  summary: FamilySummaryResponse,
+  family: string,
+): FamilySummaryEntry {
+  const entry = summary.families.find((f) => f.family === family);
+  if (!entry) throw new Error(`no entry for family ${family}`);
+  return entry;
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Grouping + outcome precedence
+// ───────────────────────────────────────────────────────────────────────
+
+describe("groupBatches", () => {
+  it("groups job rows into run batches by run_id newest-first", () => {
+    const rows = [
+      batchRow({ runId: "run-new", created: iso(-1_000), id: "n1" }),
+      batchRow({ runId: "run-new", created: iso(-2_000), id: "n2" }),
+      batchRow({ runId: "run-old", created: iso(-100_000), id: "o1" }),
+      batchRow({ runId: "run-old", created: iso(-101_000), id: "o2" }),
+    ];
+    const groups = groupBatches(rows);
+    expect(groups.map((g) => g.runId)).toEqual(["run-new", "run-old"]);
+    expect(groups[0].rows.map((r) => r.id)).toEqual(["n1", "n2"]);
+    expect(groups[1].rows.map((r) => r.id)).toEqual(["o1", "o2"]);
+  });
+});
+
+describe("deriveOutcome (pinned precedence §5.2.1)", () => {
+  it('outcome precedence: an abandoned batch with one failed and one zombie pending job derives "stalled", never "failed"', () => {
+    const batch = {
+      runId: "run-old",
+      rows: [
+        batchRow({ runId: "run-old", status: "failed" }),
+        batchRow({ runId: "run-old", status: "pending" }),
+      ],
+    };
+    expect(deriveOutcome(batch, true)).toBe("stalled");
+  });
+
+  it('outcome derives "failed" when >=1 surviving job failed and no newer batch exists', () => {
+    const batch = {
+      runId: "run-1",
+      rows: [
+        batchRow({ runId: "run-1", status: "failed" }),
+        batchRow({ runId: "run-1", status: "done" }),
+      ],
+    };
+    expect(deriveOutcome(batch, false)).toBe("failed");
+  });
+
+  it('outcome derives "completed" when all surviving jobs are done', () => {
+    const batch = {
+      runId: "run-1",
+      rows: [
+        batchRow({ runId: "run-1", status: "done" }),
+        batchRow({ runId: "run-1", status: "done" }),
+      ],
+    };
+    expect(deriveOutcome(batch, false)).toBe("completed");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// Inflight classification
+// ───────────────────────────────────────────────────────────────────────
+
+describe("classifyInflight", () => {
+  const PERIOD_MS = 30 * 60_000; // 30 min → rule (a) 60 min, rule (c) 120 min
+
+  it("returns null when the newest group is all-terminal", () => {
+    const batch = {
+      runId: "run-1",
+      rows: [batchRow({ runId: "run-1", status: "done" })],
+    };
+    expect(classifyInflight(batch, PERIOD_MS, NOW_MS)).toBeNull();
+  });
+
+  it("counts jobs per status and reports elapsed since min(enqueuedAt)", () => {
+    const batch = {
+      runId: "run-1",
+      rows: [
+        batchRow({
+          runId: "run-1",
+          status: "pending",
+          enqueuedAt: iso(-90_000),
+        }),
+        batchRow({
+          runId: "run-1",
+          status: "running",
+          enqueuedAt: iso(-80_000),
+        }),
+        batchRow({ runId: "run-1", status: "done", enqueuedAt: iso(-70_000) }),
+      ],
+    };
+    const inflight = classifyInflight(batch, PERIOD_MS, NOW_MS);
+    expect(inflight).not.toBeNull();
+    expect(inflight?.jobs).toEqual({
+      pending: 1,
+      claimed: 0,
+      running: 1,
+      done: 1,
+      failed: 0,
+    });
+    expect(inflight?.elapsedMs).toBe(90_000);
+    expect(inflight?.stalled).toBe(false);
+  });
+
+  it("inflight.stalled trips at 2x period (floor 30min) of no max(updated) progress", () => {
+    const fresh = {
+      runId: "run-1",
+      rows: [
+        batchRow({
+          runId: "run-1",
+          status: "pending",
+          enqueuedAt: iso(-119 * 60_000),
+          updated: iso(-59 * 60_000),
+        }),
+      ],
+    };
+    expect(classifyInflight(fresh, PERIOD_MS, NOW_MS)?.stalled).toBe(false);
+    const silent = {
+      runId: "run-1",
+      rows: [
+        batchRow({
+          runId: "run-1",
+          status: "pending",
+          enqueuedAt: iso(-119 * 60_000),
+          updated: iso(-61 * 60_000),
+        }),
+      ],
+    };
+    expect(classifyInflight(silent, PERIOD_MS, NOW_MS)?.stalled).toBe(true);
+  });
+
+  it("rule (c): a renewing-but-wedged batch past 4x period (floor 60min) of min(enqueuedAt) derives stalled despite fresh updated timestamps", () => {
+    const wedged = {
+      runId: "run-1",
+      rows: [
+        batchRow({
+          runId: "run-1",
+          status: "running",
+          enqueuedAt: iso(-121 * 60_000),
+          // Lease renewals keep bumping `updated` — rule (a) never trips.
+          updated: iso(-1_000),
+        }),
+      ],
+    };
+    expect(classifyInflight(wedged, PERIOD_MS, NOW_MS)?.stalled).toBe(true);
+  });
+
+  it("applies the 30min/60min floors when the period is small", () => {
+    const smallPeriod = 60_000; // 2x = 2min < 30min floor; 4x = 4min < 60min floor
+    const young = {
+      runId: "run-1",
+      rows: [
+        batchRow({
+          runId: "run-1",
+          status: "pending",
+          enqueuedAt: iso(-29 * 60_000),
+          updated: iso(-29 * 60_000),
+        }),
+      ],
+    };
+    expect(classifyInflight(young, smallPeriod, NOW_MS)?.stalled).toBe(false);
+    const pastFloor = {
+      runId: "run-1",
+      rows: [
+        batchRow({
+          runId: "run-1",
+          status: "pending",
+          enqueuedAt: iso(-31 * 60_000),
+          updated: iso(-31 * 60_000),
+        }),
+      ],
+    };
+    expect(classifyInflight(pastFloor, smallPeriod, NOW_MS)?.stalled).toBe(
+      true,
+    );
+  });
+
+  it("enqueuedAt falls back to the created column when payload.meta.enqueuedAt is unparseable, and the rule-(c) cap stays renewal-immune under the fallback", () => {
+    const batch = {
+      runId: "run-1",
+      rows: [
+        batchRow({
+          runId: "run-1",
+          status: "running",
+          created: iso(-121 * 60_000),
+          metaEnqueuedAt: "not-a-timestamp",
+          updated: iso(-1_000), // renewing — only the created-based cap trips
+        }),
+      ],
+    };
+    const inflight = classifyInflight(batch, PERIOD_MS, NOW_MS);
+    expect(inflight?.stalled).toBe(true);
+    expect(inflight?.elapsedMs).toBe(121 * 60_000);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// Batch projection: reclaimed, redaction
+// ───────────────────────────────────────────────────────────────────────
+
+describe("projectRunBatch", () => {
+  it("jobs.reclaimed counts jobs with reclaim_count > 0 once each", () => {
+    const batch = {
+      runId: "run-1",
+      rows: [
+        batchRow({ runId: "run-1", status: "done", reclaimCount: 2 }),
+        batchRow({ runId: "run-1", status: "done", reclaimCount: 1 }),
+        batchRow({ runId: "run-1", status: "done", reclaimCount: 0 }),
+        batchRow({ runId: "run-1", status: "done" }),
+      ],
+    };
+    const projected = projectRunBatch(batch, false);
+    expect(projected.jobs).toEqual({
+      total: 4,
+      done: 4,
+      failed: 0,
+      reclaimed: 2,
+    });
+  });
+
+  it("sums cells from job result rollups and computes durationMs = max(finished_at) - min(enqueuedAt)", () => {
+    const batch = {
+      runId: "run-1",
+      rows: [
+        batchRow({
+          runId: "run-1",
+          status: "done",
+          enqueuedAt: iso(-600_000),
+          finishedAt: iso(-100_000),
+          result: { rollup: { total: 8, passed: 8, failed: 0 } },
+        }),
+        batchRow({
+          runId: "run-1",
+          status: "failed",
+          enqueuedAt: iso(-590_000),
+          finishedAt: iso(-50_000),
+          result: { rollup: { total: 8, passed: 6, failed: 2 } },
+        }),
+      ],
+    };
+    const projected = projectRunBatch(batch, false);
+    expect(projected.cells).toEqual({ total: 16, passed: 14, failed: 2 });
+    expect(projected.finishedAt).toBe(iso(-50_000));
+    expect(projected.enqueuedAt).toBe(iso(-600_000));
+    expect(projected.durationMs).toBe(550_000);
+    expect(projected.outcome).toBe("failed");
+  });
+
+  it('errorSummary and commErrorKinds never contain result.commError.message content; unrecognized kinds map to "unknown"', () => {
+    const secret = "internal-host.railway.local:9090 exploded";
+    const batch = {
+      runId: "run-1",
+      rows: [
+        batchRow({
+          runId: "run-1",
+          status: "failed",
+          probeKey: "d5-single-pill-e2e:agno",
+          result: {
+            commError: {
+              kind: "worker-crashed-mid-job",
+              message: secret,
+              observedAt: iso(-1_000),
+            },
+          },
+        }),
+        batchRow({
+          runId: "run-1",
+          status: "failed",
+          probeKey: "d5-single-pill-e2e:adk",
+          result: {
+            rollup: { total: 8, passed: 6, failed: 2 },
+            commError: {
+              kind: "totally-novel-kind",
+              message: secret,
+              observedAt: iso(-1_000),
+            },
+          },
+        }),
+      ],
+    };
+    const projected = projectRunBatch(batch, false);
+    const serialized = JSON.stringify(projected);
+    expect(serialized).not.toContain("internal-host.railway.local");
+    expect(serialized).not.toContain("exploded");
+    expect(projected.commErrorKinds).toEqual([
+      "worker-crashed-mid-job",
+      "unknown",
+    ]);
+    expect(projected.errorSummary).toContain(
+      "d5-single-pill-e2e:agno — worker-crashed-mid-job",
+    );
+    expect(projected.errorSummary).toContain(
+      "d5-single-pill-e2e:adk — unknown",
+    );
+  });
+
+  it("summarizes a red (no comm error) failed job from its cell counts", () => {
+    const batch = {
+      runId: "run-1",
+      rows: [
+        batchRow({
+          runId: "run-1",
+          status: "failed",
+          probeKey: "d5-single-pill-e2e:agno",
+          result: { rollup: { total: 8, passed: 6, failed: 2 } },
+        }),
+      ],
+    };
+    const projected = projectRunBatch(batch, false);
+    expect(projected.errorSummary).toBe(
+      "d5-single-pill-e2e:agno — 2/8 cells failed",
+    );
+  });
+
+  it("carries null cells and null errorSummary when no job carries a result", () => {
+    const batch = {
+      runId: "run-1",
+      rows: [batchRow({ runId: "run-1", status: "pending" })],
+    };
+    const projected = projectRunBatch(batch, true);
+    expect(projected.cells).toBeNull();
+    expect(projected.errorSummary).toBeNull();
+    expect(projected.commErrorKinds).toEqual([]);
+    expect(projected.outcome).toBe("stalled");
+    expect(projected.finishedAt).toBeNull();
+    expect(projected.durationMs).toBeNull();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// Cron resolution
+// ───────────────────────────────────────────────────────────────────────
+
+describe("periodMsFromCron", () => {
+  it('periodMs computed from the resolved cron: "5,20,35,50 * * * *" -> 900000', () => {
+    expect(periodMsFromCron("5,20,35,50 * * * *")).toBe(900_000);
+    expect(periodMsFromCron("40 * * * *")).toBe(3_600_000);
+    expect(periodMsFromCron("*/15 * * * *")).toBe(900_000);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// Worker projection
+// ───────────────────────────────────────────────────────────────────────
+
+describe("projectWorker", () => {
+  const STALE_AFTER_MS = 1_000; // non-default so the 1x/2x boundaries are explicit
+
+  function workerRow(overrides: Partial<FakeWorkerRow> = {}): FakeWorkerRow {
+    return {
+      id: "w1",
+      worker_id: "worker-railway-abc",
+      endpoint: "http://worker-internal:8790",
+      capacity_in_use: 1,
+      capacity_available: 23,
+      capacity_max: 24,
+      current_job_id: "",
+      last_heartbeat_at: iso(-100),
+      ...overrides,
+    };
+  }
+
+  it("worker projection: online/stale/offline at 1x/2x an injected non-default workerStaleAfterMs", () => {
+    expect(
+      projectWorker(
+        workerRow({ last_heartbeat_at: iso(-900) }),
+        STALE_AFTER_MS,
+        NOW_MS,
+      ).health,
+    ).toBe("online");
+    expect(
+      projectWorker(
+        workerRow({ last_heartbeat_at: iso(-1_500) }),
+        STALE_AFTER_MS,
+        NOW_MS,
+      ).health,
+    ).toBe("stale");
+    expect(
+      projectWorker(
+        workerRow({ last_heartbeat_at: iso(-2_500) }),
+        STALE_AFTER_MS,
+        NOW_MS,
+      ).health,
+    ).toBe("offline");
+  });
+
+  it('worker projection: unparseable last_heartbeat_at derives "offline", never "online"', () => {
+    const projected = projectWorker(
+      workerRow({ last_heartbeat_at: "garbage-timestamp" }),
+      STALE_AFTER_MS,
+      NOW_MS,
+    );
+    expect(projected.health).toBe("offline");
+  });
+
+  it("worker projection never serializes the endpoint column", () => {
+    const projected = projectWorker(workerRow(), STALE_AFTER_MS, NOW_MS);
+    const serialized = JSON.stringify(projected);
+    expect(serialized).not.toContain("endpoint");
+    expect(serialized).not.toContain("worker-internal");
+    expect(projected).toEqual({
+      workerId: "worker-railway-abc",
+      health: "online",
+      lastHeartbeatAt: iso(-100),
+      currentJobId: null,
+      capacity: { inUse: 1, available: 23, max: 24 },
+    });
+  });
+
+  it("maps an empty current_job_id to null and a set one to its value", () => {
+    expect(
+      projectWorker(workerRow({ current_job_id: "j9" }), STALE_AFTER_MS, NOW_MS)
+        .currentJobId,
+    ).toBe("j9");
+    expect(
+      projectWorker(workerRow({ current_job_id: "" }), STALE_AFTER_MS, NOW_MS)
+        .currentJobId,
+    ).toBeNull();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// Memoized family summary (the §5.2 shared seam)
+// ───────────────────────────────────────────────────────────────────────
+
+describe("createMemoizedFamilySummary", () => {
+  it("family entry carries probeKeyPrefix echoed from FLEET_FAMILIES and one entry per member", async () => {
+    const { pb } = makeFakePb({});
+    const summary = await createMemoizedFamilySummary(makeDeps({ pb })).get();
+    expect(summary.families.map((f) => f.family).sort()).toEqual(
+      [...FLEET_FAMILIES.map((f) => f.family)].sort(),
+    );
+    for (const fam of FLEET_FAMILIES) {
+      const entry = familyEntry(summary, fam.family);
+      expect(entry.probeKeyPrefix).toBe(fam.probeKeyPrefix);
+      expect(entry.label).toBe(fam.label);
+    }
+  });
+
+  it("d6 honors an injected non-default d6Cron (schedule string AND periodMs)", async () => {
+    const { pb } = makeFakePb({});
+    const summary = await createMemoizedFamilySummary(
+      makeDeps({ pb, schedules: makeSchedules("*/5 * * * *") }),
+    ).get();
+    const d6 = familyEntry(summary, "d6");
+    expect(d6.schedule).toBe("*/5 * * * *");
+    expect(d6.periodMs).toBe(300_000);
+    // The deep family resolves its own (non-overridden) cron.
+    const d5 = familyEntry(summary, "d5");
+    expect(d5.schedule).toBe("5,20,35,50 * * * *");
+    expect(d5.periodMs).toBe(900_000);
+  });
+
+  it("serializes the scheduler's nextRunAt per family (null when unknown)", async () => {
+    const { pb } = makeFakePb({});
+    const next = new Date(NOW_MS + 35 * 60_000);
+    const summary = await createMemoizedFamilySummary(
+      makeDeps({
+        pb,
+        nextRunAt: (id) => (id === "fleet-job-producer" ? next : null),
+      }),
+    ).get();
+    expect(familyEntry(summary, "d6").nextRunAt).toBe(next.toISOString());
+    expect(familyEntry(summary, "d5").nextRunAt).toBeNull();
+  });
+
+  it("inflight is the newest group only — an older abandoned non-terminal batch is never selected as inflight", async () => {
+    const { pb } = makeFakePb({
+      jobs: [
+        // Newest batch: all terminal (completed).
+        batchRow({
+          runId: "run-new",
+          status: "done",
+          enqueuedAt: iso(-10 * 60_000),
+          finishedAt: iso(-5 * 60_000),
+        }),
+        // Older abandoned batch with a zombie pending row.
+        batchRow({
+          runId: "run-old",
+          status: "pending",
+          enqueuedAt: iso(-120 * 60_000),
+        }),
+        batchRow({
+          runId: "run-old",
+          status: "failed",
+          enqueuedAt: iso(-120 * 60_000),
+          finishedAt: iso(-115 * 60_000),
+        }),
+      ],
+    });
+    const summary = await createMemoizedFamilySummary(makeDeps({ pb })).get();
+    const d6 = familyEntry(summary, "d6");
+    expect(d6.inflight).toBeNull();
+    expect(d6.lastRun?.runId).toBe("run-new");
+    expect(d6.lastRun?.outcome).toBe("completed");
+  });
+
+  it("selects the newest non-terminal group as inflight and the next all-terminal-or-stalled group as lastRun", async () => {
+    const { pb } = makeFakePb({
+      jobs: [
+        batchRow({
+          runId: "run-live",
+          status: "running",
+          enqueuedAt: iso(-2 * 60_000),
+        }),
+        batchRow({
+          runId: "run-prev",
+          status: "done",
+          enqueuedAt: iso(-70 * 60_000),
+          finishedAt: iso(-65 * 60_000),
+        }),
+      ],
+    });
+    const summary = await createMemoizedFamilySummary(makeDeps({ pb })).get();
+    const d6 = familyEntry(summary, "d6");
+    expect(d6.inflight?.runId).toBe("run-live");
+    expect(d6.inflight?.stalled).toBe(false);
+    expect(d6.lastRun?.runId).toBe("run-prev");
+  });
+
+  it("lastSuccessAt walk-back: a newest done JOB inside an overall-failed batch does not count; the prior completed batch's finish wins", async () => {
+    const { pb } = makeFakePb({
+      jobs: [
+        // Newest batch: overall failed, but contains a done job whose
+        // finished_at is the newest timestamp anywhere.
+        batchRow({
+          runId: "run-failed",
+          status: "done",
+          enqueuedAt: iso(-10 * 60_000),
+          finishedAt: iso(-1 * 60_000),
+        }),
+        batchRow({
+          runId: "run-failed",
+          status: "failed",
+          enqueuedAt: iso(-10 * 60_000),
+          finishedAt: iso(-2 * 60_000),
+        }),
+        // Prior batch: completed.
+        batchRow({
+          runId: "run-ok",
+          status: "done",
+          enqueuedAt: iso(-70 * 60_000),
+          finishedAt: iso(-64 * 60_000),
+        }),
+        batchRow({
+          runId: "run-ok",
+          status: "done",
+          enqueuedAt: iso(-70 * 60_000),
+          finishedAt: iso(-66 * 60_000),
+        }),
+      ],
+    });
+    const summary = await createMemoizedFamilySummary(makeDeps({ pb })).get();
+    const d6 = familyEntry(summary, "d6");
+    expect(d6.lastRun?.outcome).toBe("failed");
+    expect(d6.lastSuccessAt).toBe(iso(-64 * 60_000));
+  });
+
+  it("lastSuccessAt is null when no completed batch exists in the capped window", async () => {
+    const { pb } = makeFakePb({
+      jobs: [
+        batchRow({
+          runId: "run-1",
+          status: "failed",
+          enqueuedAt: iso(-10 * 60_000),
+          finishedAt: iso(-9 * 60_000),
+        }),
+        batchRow({
+          runId: "run-0",
+          status: "failed",
+          enqueuedAt: iso(-70 * 60_000),
+          finishedAt: iso(-69 * 60_000),
+        }),
+      ],
+    });
+    const summary = await createMemoizedFamilySummary(makeDeps({ pb })).get();
+    expect(familyEntry(summary, "d6").lastSuccessAt).toBeNull();
+  });
+
+  it("redsIntroduced/redsCleared summed from probe_runs joined on job_id; null when no returned row carries the fields", async () => {
+    const doneA = batchRow({
+      runId: "run-1",
+      status: "done",
+      enqueuedAt: iso(-10 * 60_000),
+      finishedAt: iso(-9 * 60_000),
+    });
+    const doneB = batchRow({
+      runId: "run-1",
+      status: "done",
+      enqueuedAt: iso(-10 * 60_000),
+      finishedAt: iso(-8 * 60_000),
+    });
+    const { pb } = makeFakePb({
+      jobs: [doneA, doneB],
+      probeRuns: [
+        {
+          id: "pr1",
+          probe_id: "d6:langgraph-python",
+          job_id: doneA.id,
+          started_at: iso(-10 * 60_000),
+          summary: {
+            total: 8,
+            passed: 7,
+            failed: 1,
+            redsIntroduced: 1,
+            redsCleared: 0,
+          },
+        },
+        {
+          id: "pr2",
+          probe_id: "d6:adk",
+          job_id: doneB.id,
+          started_at: iso(-10 * 60_000),
+          summary: {
+            total: 8,
+            passed: 8,
+            failed: 0,
+            redsIntroduced: 2,
+            redsCleared: 1,
+          },
+        },
+      ],
+    });
+    const summary = await createMemoizedFamilySummary(makeDeps({ pb })).get();
+    const d6 = familyEntry(summary, "d6");
+    expect(d6.lastRun?.redsIntroduced).toBe(3);
+    expect(d6.lastRun?.redsCleared).toBe(1);
+  });
+
+  it("serializes null reds when the joined probe_runs rows lack the fields (pre-P2 history)", async () => {
+    const done = batchRow({
+      runId: "run-1",
+      status: "done",
+      enqueuedAt: iso(-10 * 60_000),
+      finishedAt: iso(-9 * 60_000),
+    });
+    const { pb } = makeFakePb({
+      jobs: [done],
+      probeRuns: [
+        {
+          id: "pr1",
+          probe_id: "d6:langgraph-python",
+          job_id: done.id,
+          started_at: iso(-10 * 60_000),
+          summary: { total: 8, passed: 8, failed: 0 },
+        },
+      ],
+    });
+    const summary = await createMemoizedFamilySummary(makeDeps({ pb })).get();
+    const d6 = familyEntry(summary, "d6");
+    expect(d6.lastRun?.redsIntroduced).toBeNull();
+    expect(d6.lastRun?.redsCleared).toBeNull();
+  });
+
+  it("projects workers through the shared deriveHealth and never serializes endpoints", async () => {
+    const { pb } = makeFakePb({
+      workers: [
+        {
+          id: "w1",
+          worker_id: "worker-railway-abc",
+          endpoint: "http://worker-internal:8790",
+          capacity_in_use: 0,
+          capacity_available: 24,
+          capacity_max: 24,
+          current_job_id: "",
+          last_heartbeat_at: iso(-1_000),
+        },
+      ],
+    });
+    const summary = await createMemoizedFamilySummary(
+      makeDeps({ pb, workerStaleAfterMs: 180_000 }),
+    ).get();
+    expect(summary.workers).toEqual([
+      {
+        workerId: "worker-railway-abc",
+        health: "online",
+        lastHeartbeatAt: iso(-1_000),
+        currentJobId: null,
+        capacity: { inUse: 0, available: 24, max: 24 },
+      },
+    ]);
+    expect(JSON.stringify(summary.workers)).not.toContain("endpoint");
+  });
+
+  it('a PB list failure for one family yields that entry as {error:"history_unavailable"} while other families project normally', async () => {
+    const { pb } = makeFakePb({
+      jobs: [
+        batchRow({
+          runId: "run-1",
+          status: "done",
+          family: "d6",
+          enqueuedAt: iso(-10 * 60_000),
+          finishedAt: iso(-9 * 60_000),
+        }),
+      ],
+      failFamilies: ["d5"],
+    });
+    const summary = await createMemoizedFamilySummary(makeDeps({ pb })).get();
+    const d5 = familyEntry(summary, "d5");
+    expect(d5.error).toBe("history_unavailable");
+    expect(d5.probeKeyPrefix).toBe("d5-single-pill-e2e");
+    expect(d5.lastRun).toBeUndefined();
+    const d6 = familyEntry(summary, "d6");
+    expect(d6.error).toBeUndefined();
+    expect(d6.lastRun?.runId).toBe("run-1");
+  });
+
+  it("memo: two get() calls inside the TTL hit PB once; a post-TTL call recomputes", async () => {
+    const { pb, listCalls } = makeFakePb({});
+    let t = NOW_MS;
+    const memo = createMemoizedFamilySummary(makeDeps({ pb, now: () => t }));
+    await memo.get();
+    const afterFirst = listCalls.length;
+    expect(afterFirst).toBeGreaterThan(0);
+    await memo.get();
+    expect(listCalls.length).toBe(afterFirst);
+    t += 5_001;
+    await memo.get();
+    expect(listCalls.length).toBe(afterFirst * 2);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// Drift-lock (§5.1)
+// ───────────────────────────────────────────────────────────────────────
+
+describe("FLEET_FAMILIES drift-lock", () => {
+  it("FLEET_FAMILIES scheduleIds are set-equal to buildProducerSchedules(...) schedule ids", () => {
+    const wired = new Set(makeSchedules().map((s) => s.scheduleId));
+    const registry = new Set(FLEET_FAMILIES.map((f) => f.scheduleId));
+    expect(registry).toEqual(wired);
+  });
+
+  it("carries no cron literals in the registry", () => {
+    for (const fam of FLEET_FAMILIES) {
+      expect(Object.keys(fam).sort()).toEqual([
+        "family",
+        "label",
+        "probeKeyPrefix",
+        "scheduleId",
+      ]);
+    }
+  });
+});

--- a/showcase/harness/src/fleet/control-plane/run-view.test.ts
+++ b/showcase/harness/src/fleet/control-plane/run-view.test.ts
@@ -645,13 +645,17 @@ describe("projectWorker", () => {
     ).toBe("offline");
   });
 
-  it('worker projection: unparseable last_heartbeat_at derives "offline", never "online"', () => {
+  it("worker projection mirrors fleet-health's deriveHealth verbatim (unparseable falls into deriveHealth's treat-unknown-as-not-yet-stale default — same as fleet-health.ts:399 — so the two surfaces never disagree for the same row)", () => {
     const projected = projectWorker(
       workerRow({ last_heartbeat_at: "garbage-timestamp" }),
       STALE_AFTER_MS,
       NOW_MS,
     );
-    expect(projected.health).toBe("offline");
+    // Aligned with fleet-health.ts:399's `deriveHealth(row.last_heartbeat_at, nowMs, staleAfterMs)`:
+    // `isWorkerStale` returns false for an unparseable string, so deriveHealth
+    // returns "online". The fleet-runs strip and the fleet-health monitor MUST
+    // agree on this — that agreement is the bug this fix closes.
+    expect(projected.health).toBe("online");
   });
 
   it("worker projection never serializes the endpoint column", () => {

--- a/showcase/harness/src/fleet/control-plane/run-view.ts
+++ b/showcase/harness/src/fleet/control-plane/run-view.ts
@@ -1,0 +1,943 @@
+/**
+ * Run-view PROJECTIONS (spec §5.1 + §5.2.1) — the pure projection layer over
+ * `probe_jobs` / `probe_runs` / `workers` that the fleet-runs HTTP routes
+ * (T7), the orchestrator wiring (T8), and the family-silence monitor (T9)
+ * all consume. This module owns:
+ *
+ *   - `FLEET_FAMILIES` — the single source of truth joining family id →
+ *     producer schedule id → probe-key prefix (§5.1). Deliberately NO cron
+ *     literals: cron resolution is RUNTIME, by `scheduleId` lookup in the
+ *     injected `ProducerSchedule[]` (the same `buildProducerSchedules`
+ *     output handed to `createControlPlane`), so the `FLEET_PRODUCER_CRON`
+ *     env override is honored everywhere a period-derived threshold exists.
+ *   - the §5.2.1 run/worker projections (outcome precedence, stalled rules,
+ *     walk-back, redaction) as pure, unit-tested functions.
+ *   - `createMemoizedFamilySummary` — the ~5 s-TTL whole-body memo of the
+ *     family summary (§5.2 abuse bound). Homed HERE, not in the route
+ *     module, so `runControlPlane` constructs ONE instance and injects it
+ *     into both the fleet-runs routes and the §9 family-silence monitor —
+ *     "the monitor shares the route's memo" is true by construction.
+ *
+ * Read paths only — this module never writes a row.
+ */
+
+import { Cron } from "croner";
+import type { Logger } from "../../types/index.js";
+import type { Scheduler } from "../../scheduler/scheduler.js";
+import type { PbClient } from "../../storage/pb-client.js";
+import type { JobStatus } from "../job-claim.js";
+import type {
+  ServiceJobMeta,
+  ServiceJobRollup,
+  WorkerHealthState,
+} from "../contracts.js";
+import {
+  WORKERS_COLLECTION,
+  deriveHealth,
+  isPoolCommErrorKind,
+} from "../contracts.js";
+import { PROBE_JOBS_COLLECTION } from "../queue-client.js";
+import {
+  PROBE_RUNS_COLLECTION,
+  type ProbeRunSummary,
+} from "../../probes/run-history.js";
+import {
+  FLEET_PRODUCER_DEEP_SCHEDULE_ID,
+  FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
+  FLEET_PRODUCER_SCHEDULE_ID,
+  FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
+  type ProducerSchedule,
+} from "./control-plane.js";
+
+// ───────────────────────────────────────────────────────────────────────
+// §5.1 family registry
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * Family id → producer schedule id → probe-key prefix (§5.1). The drift-lock
+ * test asserts the scheduleIds are set-equal to `buildProducerSchedules(...)`
+ * ids so a new producer can't ship invisible and a renamed schedule can't
+ * orphan a family. `probeKeyPrefix` is echoed onto every §5.2.1 entry so the
+ * dashboard maps matrix cell keys to families purely from the payload.
+ */
+export const FLEET_FAMILIES = [
+  {
+    family: "d6",
+    label: "D6 all-pills",
+    scheduleId: FLEET_PRODUCER_SCHEDULE_ID,
+    probeKeyPrefix: "d6",
+  },
+  {
+    family: "d5",
+    label: "D5 e2e-deep",
+    scheduleId: FLEET_PRODUCER_DEEP_SCHEDULE_ID,
+    probeKeyPrefix: "d5-single-pill-e2e",
+  },
+  {
+    family: "e2e-demos",
+    label: "E2E demos",
+    scheduleId: FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
+    probeKeyPrefix: "e2e-demos",
+  },
+  {
+    family: "e2e-smoke",
+    label: "E2E smoke",
+    scheduleId: FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
+    probeKeyPrefix: "d4",
+  },
+] as const; // NO cron literals — resolution is runtime via injected schedules (§5.1)
+
+/** One FLEET_FAMILIES member. */
+export type FleetFamily = (typeof FLEET_FAMILIES)[number];
+
+// ───────────────────────────────────────────────────────────────────────
+// Row shapes (snake_case, as the PB records API returns them)
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * The `probe_jobs` row fields the run-view projections read. Additive
+ * run-metadata columns (migration 1779990200) are optional — pre-P2 rows
+ * lack them (`family` empty → invisible to the new API; `reclaim_count`
+ * absent → 0).
+ */
+export interface ProbeJobRecord {
+  id: string;
+  probe_key: string;
+  status: JobStatus;
+  claimed_by: string;
+  payload?: unknown;
+  result?: unknown;
+  run_id?: string;
+  family?: string;
+  claimed_at?: string;
+  finished_at?: string;
+  reclaim_count?: number;
+  /** PB system columns. `created` ≈ enqueue time; `updated` bumps on every CAS. */
+  created: string;
+  updated: string;
+}
+
+/** The `workers` row fields the worker projection reads (snake_case). */
+export interface WorkerRow {
+  worker_id: string;
+  /** Routable internal URL — read for nothing, NEVER serialized (§5.2.1). */
+  endpoint?: string;
+  capacity_in_use?: number;
+  capacity_available?: number;
+  capacity_max?: number;
+  current_job_id?: string;
+  last_heartbeat_at?: string;
+}
+
+/** The `probe_runs` row fields the reds read path consumes (§4.2). */
+interface ProbeRunRedsRow {
+  id: string;
+  job_id?: string;
+  summary?: ProbeRunSummary | null;
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// DTOs — mirror the §5.2.1 JSON exactly (fields + null semantics)
+// ───────────────────────────────────────────────────────────────────────
+
+/** §5.2.1 precedence-derived outcome — exactly three values, pinned order. */
+export type RunOutcome = "stalled" | "failed" | "completed";
+
+/**
+ * One run batch (jobs grouped by `run_id`) — the §5.2.1 `lastRun` shape and
+ * each §5.2.2 history item. `redsIntroduced`/`redsCleared` are null until the
+ * caller joins them from `probe_runs` (and null on pre-P2 history).
+ */
+export interface RunBatch {
+  runId: string;
+  triggered: boolean;
+  /** min(enqueuedAt) across the batch (ISO). */
+  enqueuedAt: string;
+  /** max(finished_at); null while any job is non-terminal. */
+  finishedAt: string | null;
+  /** max(finished_at) − min(enqueuedAt); null while finishedAt is null. */
+  durationMs: number | null;
+  outcome: RunOutcome;
+  jobs: { total: number; done: number; failed: number; reclaimed: number };
+  /** Summed job rollups; null when no job carries a result. */
+  cells: { total: number; passed: number; failed: number } | null;
+  redsIntroduced: number | null;
+  redsCleared: number | null;
+  /** Closed-vocabulary only (§5.2.1 redaction) — never commError.message. */
+  errorSummary: string | null;
+  /** Deduped, isPoolCommErrorKind-validated kinds; unrecognized → "unknown". */
+  commErrorKinds: string[];
+  /** §5.2.2 degenerate-clamp marker — set by the history route, never here. */
+  truncated?: boolean;
+}
+
+/** §5.2.1 `inflight` — the NEWEST run_id group only, when non-terminal. */
+export interface InflightState {
+  runId: string;
+  triggered: boolean;
+  enqueuedAt: string;
+  elapsedMs: number;
+  /** §5.2.1 rules (a)/(c): 2x-period no-progress or 4x-period absolute age. */
+  stalled: boolean;
+  jobs: {
+    pending: number;
+    claimed: number;
+    running: number;
+    done: number;
+    failed: number;
+  };
+}
+
+/** §5.2.1 workers strip entry. The `endpoint` column is never serialized. */
+export interface WorkerView {
+  workerId: string;
+  health: WorkerHealthState;
+  lastHeartbeatAt: string;
+  currentJobId: string | null;
+  capacity: { inUse: number; available: number; max: number };
+}
+
+/**
+ * One `/api/runs` family entry. On a per-family PB failure the entry carries
+ * `error: "history_unavailable"` IN PLACE OF the computed fields (§5.2.1
+ * graceful degradation — HTTP-200 posture, never a 500), hence everything
+ * past the registry echo is optional.
+ */
+export interface FamilySummaryEntry {
+  family: string;
+  label: string;
+  probeKeyPrefix: string;
+  error?: "history_unavailable";
+  /** Display only (§6.2 humanizeCron) — NEVER threshold math; use periodMs. */
+  schedule?: string;
+  /** Server-computed shortest gap between consecutive fires of the resolved cron. */
+  periodMs?: number;
+  nextRunAt?: string | null;
+  lastRun?: RunBatch | null;
+  inflight?: InflightState | null;
+  /**
+   * Finish of the newest completed batch within the capped walk-back, or null
+   * (no completed batch in window / never succeeded / fresh env). Null
+   * consumers (§7.3 glyph, §7.4 banner, §9 alert) fall back to the OLDEST
+   * known batch's enqueuedAt as the staleness reference; with zero batches at
+   * all they stay silent (§5.2.1 null semantics).
+   */
+  lastSuccessAt?: string | null;
+}
+
+/** GET /api/runs body (§5.2.1). */
+export interface FamilySummaryResponse {
+  families: FamilySummaryEntry[];
+  workers: WorkerView[];
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Deps
+// ───────────────────────────────────────────────────────────────────────
+
+export interface RunViewDeps {
+  pb: PbClient;
+  scheduler: Pick<Scheduler, "nextRunAt">;
+  /** The `buildProducerSchedules` output — the resolved-cron source (§5.1). */
+  schedules: readonly ProducerSchedule[];
+  /** Boot-resolved heartbeat window — never the DEFAULT_ constant (§5.2). */
+  workerStaleAfterMs: number;
+  logger: Logger;
+  now?: () => number;
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Pure helpers
+// ───────────────────────────────────────────────────────────────────────
+
+/** §5.2.2 capped fetch loop page size (PB perPage). */
+export const RUN_FETCH_PAGE_SIZE = 200;
+/** §5.2.2 hard cap on PB pages per fetch loop (3 × 200 = 600 rows). */
+export const RUN_FETCH_MAX_PAGES = 3;
+
+/** §5.2.1 inflight rule (a) floor: 2 × period, floor 30 min. */
+const STALL_PROGRESS_FLOOR_MS = 30 * 60_000;
+/** §5.2.1 inflight rule (c) floor: 4 × period, floor 60 min. */
+const STALL_ABSOLUTE_FLOOR_MS = 60 * 60_000;
+
+/** Whole-body memo TTL (§5.2): bounded staleness below the ~10 s poll cadence. */
+const DEFAULT_SUMMARY_TTL_MS = 5_000;
+
+/**
+ * Anchored PB space→"T" date-separator rewrite — byte-for-byte the same
+ * anchor as queue-client's `leaseExpired` / the JSVM hook, so we only
+ * convert the canonical date/time boundary, never an arbitrary first space.
+ */
+const PB_DATE_SEP_RE = /^(\d{4}-\d{2}-\d{2}) /;
+
+/** Parse a PB/ISO timestamp to epoch ms; NaN on absent/unparseable. */
+function parsePbDate(value: string | null | undefined): number {
+  if (!value) return Number.NaN;
+  return Date.parse(String(value).replace(PB_DATE_SEP_RE, "$1T"));
+}
+
+const TERMINAL_STATUSES = new Set<JobStatus>(["done", "failed"]);
+
+function isTerminal(row: ProbeJobRecord): boolean {
+  return TERMINAL_STATUSES.has(row.status);
+}
+
+/** Minimal defensive view of a row's `payload` JSON (untrusted column). */
+function payloadMeta(row: ProbeJobRecord): Partial<ServiceJobMeta> | null {
+  const payload = row.payload;
+  if (payload === null || typeof payload !== "object") return null;
+  const meta = (payload as { meta?: unknown }).meta;
+  if (meta === null || typeof meta !== "object" || Array.isArray(meta)) {
+    return null;
+  }
+  return meta as Partial<ServiceJobMeta>;
+}
+
+/** Minimal defensive view of a row's `result` JSON (untrusted column). */
+function resultView(row: ProbeJobRecord): {
+  rollup: ServiceJobRollup | null;
+  commErrorKind: string | undefined;
+} {
+  const result = row.result;
+  if (result === null || typeof result !== "object") {
+    return { rollup: null, commErrorKind: undefined };
+  }
+  const candidate = result as {
+    rollup?: unknown;
+    commError?: unknown;
+  };
+  let rollup: ServiceJobRollup | null = null;
+  if (candidate.rollup !== null && typeof candidate.rollup === "object") {
+    const r = candidate.rollup as Partial<ServiceJobRollup>;
+    if (
+      typeof r.total === "number" &&
+      typeof r.passed === "number" &&
+      typeof r.failed === "number"
+    ) {
+      rollup = { total: r.total, passed: r.passed, failed: r.failed };
+    }
+  }
+  let commErrorKind: string | undefined;
+  if (candidate.commError !== null && typeof candidate.commError === "object") {
+    const kind = (candidate.commError as { kind?: unknown }).kind;
+    if (typeof kind === "string") commErrorKind = kind;
+  }
+  return { rollup, commErrorKind };
+}
+
+/**
+ * A job's enqueue time (§5.2.1 sourcing): `payload.meta.enqueuedAt`, falling
+ * back to the row's `created` column when absent/unparseable. Both are
+ * stamped once and renewal-immune, so the rule-(c) absolute-age cap stays
+ * renewal-immune under the fallback.
+ */
+function enqueuedAtMs(row: ProbeJobRecord): number {
+  const meta = payloadMeta(row);
+  const fromMeta = parsePbDate(
+    typeof meta?.enqueuedAt === "string" ? meta.enqueuedAt : undefined,
+  );
+  if (!Number.isNaN(fromMeta)) return fromMeta;
+  return parsePbDate(row.created);
+}
+
+function minEnqueuedAtMs(rows: readonly ProbeJobRecord[]): number {
+  let min = Number.POSITIVE_INFINITY;
+  for (const row of rows) {
+    const t = enqueuedAtMs(row);
+    if (!Number.isNaN(t) && t < min) min = t;
+  }
+  return Number.isFinite(min) ? min : Number.NaN;
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Projections (pure)
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * Shortest interval between consecutive fires of `cron` (e.g.
+ * `"5,20,35,50 * * * *"` → 900 000): croner walk over the next ~8 fires.
+ * Every period-derived threshold (§5.2.1 stalled rules, §7.3/§7.4 windows,
+ * §9 silence window) consumes this server-computed value — the dashboard
+ * does no client-side cron parsing for thresholds.
+ */
+export function periodMsFromCron(cron: string): number {
+  const job = new Cron(cron);
+  const fires = job.nextRuns(9);
+  let min = Number.POSITIVE_INFINITY;
+  for (let i = 1; i < fires.length; i++) {
+    const gap = fires[i].getTime() - fires[i - 1].getTime();
+    if (gap > 0 && gap < min) min = gap;
+  }
+  return Number.isFinite(min) ? min : 0;
+}
+
+/** A composite `(created, id)` cursor (§5.2.2). `beforeId` optional only for
+ *  the legacy/manual bare-`before` degrade — the dashboard always echoes both. */
+export interface FamilyJobCursor {
+  before: string;
+  beforeId?: string;
+}
+
+/**
+ * The §5.2.2 capped overfetch loop: list `probe_jobs` for `family`, sort
+ * `-created,-id`, PB perPage 200, up to `maxPages` PB pages (default 3 = 600
+ * rows), advancing an internal composite `(created, id)` cursor between
+ * pages. `exhausted` is true when the last page returned fewer than 200 rows
+ * (history exhausted within the window). Exported for reuse by the history
+ * route (T7) and the lastSuccessAt walk-back below.
+ */
+export async function fetchFamilyJobRows(
+  deps: RunViewDeps,
+  family: string,
+  cursor?: FamilyJobCursor,
+  maxPages: number = RUN_FETCH_MAX_PAGES,
+): Promise<{ rows: ProbeJobRecord[]; exhausted: boolean }> {
+  const rows: ProbeJobRecord[] = [];
+  let cur = cursor;
+  let exhausted = false;
+  for (let page = 0; page < maxPages; page++) {
+    const clauses = [`family = ${JSON.stringify(family)}`];
+    if (cur) {
+      if (cur.beforeId) {
+        // Composite cursor: same-ms siblings are neither skipped nor duplicated.
+        clauses.push(
+          `(created < ${JSON.stringify(cur.before)} || (created = ${JSON.stringify(cur.before)} && id < ${JSON.stringify(cur.beforeId)}))`,
+        );
+      } else {
+        // Bare-`before` degrade (§5.2.2): legacy/manual-curl posture only.
+        clauses.push(`created < ${JSON.stringify(cur.before)}`);
+      }
+    }
+    const result = await deps.pb.list<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
+      filter: clauses.join(" && "),
+      sort: "-created,-id",
+      perPage: RUN_FETCH_PAGE_SIZE,
+      skipTotal: true,
+    });
+    rows.push(...result.items);
+    if (result.items.length < RUN_FETCH_PAGE_SIZE) {
+      exhausted = true;
+      break;
+    }
+    const oldest = result.items[result.items.length - 1];
+    cur = { before: oldest.created, beforeId: oldest.id };
+  }
+  return { rows, exhausted };
+}
+
+/** One grouped run batch's raw rows (pre-projection). */
+export interface RunBatchRows {
+  runId: string;
+  rows: ProbeJobRecord[];
+}
+
+/**
+ * Group fetched job rows into run batches by `run_id`, newest first. Input
+ * rows are already sorted `-created,-id`, so first-appearance order IS
+ * newest-first. A row missing its denormalized `run_id` (shouldn't exist for
+ * family-stamped rows — both columns are stamped by the same enqueue) falls
+ * back to `payload.meta.runId`, then to a per-row singleton group keyed by
+ * the row id, so malformed rows are never silently merged or dropped.
+ */
+export function groupBatches(rows: readonly ProbeJobRecord[]): RunBatchRows[] {
+  const order: string[] = [];
+  const byRun = new Map<string, ProbeJobRecord[]>();
+  for (const row of rows) {
+    const meta = payloadMeta(row);
+    const runId =
+      (row.run_id && row.run_id !== "" ? row.run_id : undefined) ??
+      (typeof meta?.runId === "string" && meta.runId !== ""
+        ? meta.runId
+        : row.id);
+    let bucket = byRun.get(runId);
+    if (!bucket) {
+      bucket = [];
+      byRun.set(runId, bucket);
+      order.push(runId);
+    }
+    bucket.push(row);
+  }
+  return order.map((runId) => {
+    const bucket = byRun.get(runId);
+    /* v8 ignore next — every key in `order` was inserted above */
+    if (!bucket) throw new Error(`run-view: lost batch bucket for ${runId}`);
+    return { runId, rows: bucket };
+  });
+}
+
+/**
+ * §5.2.1 pinned outcome precedence — evaluated top-down, first match wins;
+ * every consumer keys off this one ordering and never re-derives its own:
+ *   1. "stalled"   — ≥1 surviving job non-terminal AND a newer batch exists
+ *                    (abandonment rule (b): the producer enqueues fresh
+ *                    batches each tick, so the old batch is never live again).
+ *   2. "failed"    — ≥1 surviving job failed.
+ *   3. "completed" — all surviving jobs done.
+ * Stalled wins over failed: the zombie row is the operationally live fact;
+ * the failed job's detail stays visible in the drill-down + counts.
+ */
+export function deriveOutcome(
+  batch: RunBatchRows,
+  hasNewerBatch: boolean,
+): RunOutcome {
+  const anyNonTerminal = batch.rows.some((row) => !isTerminal(row));
+  if (anyNonTerminal && hasNewerBatch) return "stalled";
+  if (batch.rows.some((row) => row.status === "failed")) return "failed";
+  return "completed";
+}
+
+/**
+ * §5.2.1 redaction — errorSummary is composed EXCLUSIVELY from
+ * closed-vocabulary parts: probe_key + enum-validated comm-error kind (else
+ * "unknown") + failed-cell counts. Raw `result.commError.message` and raw
+ * cell signal strings NEVER cross the unauthenticated boundary (truncation
+ * is not sanitization). Null when the batch has no failed job.
+ */
+export function buildErrorSummary(batch: RunBatchRows): string | null {
+  const parts: string[] = [];
+  for (const row of batch.rows) {
+    if (row.status !== "failed") continue;
+    const { rollup, commErrorKind } = resultView(row);
+    if (commErrorKind !== undefined) {
+      const kind = isPoolCommErrorKind(commErrorKind)
+        ? commErrorKind
+        : "unknown";
+      parts.push(`${row.probe_key} — ${kind}`);
+    } else if (rollup && rollup.failed > 0) {
+      parts.push(
+        `${row.probe_key} — ${rollup.failed}/${rollup.total} cells failed`,
+      );
+    } else {
+      parts.push(`${row.probe_key} — failed`);
+    }
+  }
+  return parts.length > 0 ? parts.join("; ") : null;
+}
+
+/**
+ * Deduped, enum-validated comm-error kinds across the batch's jobs (§5.2.1):
+ * jobs without a commError contribute nothing; unrecognized kinds map to
+ * "unknown" so the array is closed-vocabulary by construction.
+ */
+function collectCommErrorKinds(batch: RunBatchRows): string[] {
+  const kinds: string[] = [];
+  for (const row of batch.rows) {
+    const { commErrorKind } = resultView(row);
+    if (commErrorKind === undefined) continue;
+    const kind = isPoolCommErrorKind(commErrorKind) ? commErrorKind : "unknown";
+    if (!kinds.includes(kind)) kinds.push(kind);
+  }
+  return kinds;
+}
+
+/**
+ * Project one grouped batch into the §5.2.1 `lastRun` / §5.2.2 history-item
+ * shape. Reds are left null — they live on `probe_runs`, so the CALLER joins
+ * them (one list per family/page) and fills the two fields.
+ */
+export function projectRunBatch(
+  batch: RunBatchRows,
+  hasNewerBatch: boolean,
+): RunBatch {
+  const rows = batch.rows;
+  const jobs = { total: rows.length, done: 0, failed: 0, reclaimed: 0 };
+  let cells: { total: number; passed: number; failed: number } | null = null;
+  let allTerminal = true;
+  let maxFinishedMs = Number.NEGATIVE_INFINITY;
+  let triggered = false;
+  for (const row of rows) {
+    if (row.status === "done") jobs.done += 1;
+    if (row.status === "failed") jobs.failed += 1;
+    if ((row.reclaim_count ?? 0) > 0) jobs.reclaimed += 1;
+    if (!isTerminal(row)) allTerminal = false;
+    const finished = parsePbDate(row.finished_at);
+    if (!Number.isNaN(finished) && finished > maxFinishedMs) {
+      maxFinishedMs = finished;
+    }
+    const meta = payloadMeta(row);
+    if (meta?.triggered === true) triggered = true;
+    const { rollup } = resultView(row);
+    if (rollup) {
+      cells ??= { total: 0, passed: 0, failed: 0 };
+      cells.total += rollup.total;
+      cells.passed += rollup.passed;
+      cells.failed += rollup.failed;
+    }
+  }
+  const minEnqueued = minEnqueuedAtMs(rows);
+  // finishedAt is null while any job is non-terminal (a stalled batch never
+  // "finishes") or when no terminal row carries a parseable finished_at.
+  const finishedAt =
+    allTerminal && Number.isFinite(maxFinishedMs)
+      ? new Date(maxFinishedMs).toISOString()
+      : null;
+  const durationMs =
+    finishedAt !== null && !Number.isNaN(minEnqueued)
+      ? maxFinishedMs - minEnqueued
+      : null;
+  return {
+    runId: batch.runId,
+    triggered,
+    enqueuedAt: Number.isNaN(minEnqueued)
+      ? (rows[rows.length - 1]?.created ?? "")
+      : new Date(minEnqueued).toISOString(),
+    finishedAt,
+    durationMs,
+    outcome: deriveOutcome(batch, hasNewerBatch),
+    jobs,
+    cells,
+    redsIntroduced: null,
+    redsCleared: null,
+    errorSummary: buildErrorSummary(batch),
+    commErrorKinds: collectCommErrorKinds(batch),
+  };
+}
+
+/**
+ * §5.2.1 inflight classification — the NEWEST run_id group only, and only
+ * when it has ≥1 non-terminal job (defined this way so an older abandoned
+ * batch can never simultaneously classify "stalled" and present as running).
+ * `stalled` trips on either:
+ *   (a) no progress: now − max(updated) > 2 × period (floor 30 min) — the
+ *       batch hasn't moved for two full cycles; renewal-blind by design, so
+ *   (c) absolute age cap: now − min(enqueuedAt) > 4 × period (floor 60 min)
+ *       regardless of `updated` freshness — `enqueuedAt` is stamped once and
+ *       renewal-immune, catching the wedged-but-renewing worker whose lease
+ *       loop keeps bumping `updated`.
+ */
+export function classifyInflight(
+  newestBatch: RunBatchRows,
+  periodMs: number,
+  nowMs: number,
+): InflightState | null {
+  const rows = newestBatch.rows;
+  const jobs = { pending: 0, claimed: 0, running: 0, done: 0, failed: 0 };
+  let nonTerminal = 0;
+  let maxUpdatedMs = Number.NEGATIVE_INFINITY;
+  let triggered = false;
+  for (const row of rows) {
+    jobs[row.status] += 1;
+    if (!isTerminal(row)) nonTerminal += 1;
+    const updated = parsePbDate(row.updated);
+    if (!Number.isNaN(updated) && updated > maxUpdatedMs) {
+      maxUpdatedMs = updated;
+    }
+    const meta = payloadMeta(row);
+    if (meta?.triggered === true) triggered = true;
+  }
+  if (nonTerminal === 0) return null;
+  const minEnqueued = minEnqueuedAtMs(rows);
+  const elapsedMs = Number.isNaN(minEnqueued)
+    ? 0
+    : Math.max(0, nowMs - minEnqueued);
+  // Rule (a): no max(updated) progress for 2 × period (floor 30 min). When no
+  // row carries a parseable `updated`, fall back to the enqueue time so a
+  // malformed batch still ages into stalled rather than presenting fresh.
+  const progressRefMs = Number.isFinite(maxUpdatedMs)
+    ? maxUpdatedMs
+    : minEnqueued;
+  const progressWindowMs = Math.max(2 * periodMs, STALL_PROGRESS_FLOOR_MS);
+  const noProgress =
+    !Number.isNaN(progressRefMs) && nowMs - progressRefMs > progressWindowMs;
+  // Rule (c): renewal-immune absolute age cap at 4 × period (floor 60 min).
+  const absoluteWindowMs = Math.max(4 * periodMs, STALL_ABSOLUTE_FLOOR_MS);
+  const tooOld =
+    !Number.isNaN(minEnqueued) && nowMs - minEnqueued > absoluteWindowMs;
+  return {
+    runId: newestBatch.runId,
+    triggered,
+    enqueuedAt: Number.isNaN(minEnqueued)
+      ? (rows[rows.length - 1]?.created ?? "")
+      : new Date(minEnqueued).toISOString(),
+    elapsedMs,
+    stalled: noProgress || tooOld,
+    jobs,
+  };
+}
+
+/**
+ * Project one `workers` row into the §5.2.1 strip entry, deriving `health`
+ * through the SAME `deriveHealth` fleet-health uses (hoisted to contracts) so
+ * the two surfaces can never disagree — with one explicit carve-out: an
+ * unparseable `last_heartbeat_at` maps to "offline". `deriveHealth` inherits
+ * `isWorkerStale`'s treat-unknown-as-not-yet-stale default (correct for the
+ * reclaim machinery, exactly wrong for a display surface where unknown
+ * rendering healthy is the lie), so we pre-check parseability first —
+ * mirroring fleet-health's own unparseable-heartbeat warn path. The
+ * `endpoint` column (a routable internal URL) is deliberately NEVER
+ * serialized; worker ids and heartbeat timestamps are non-secret (§5.2.1
+ * identifier-exposure carve-out).
+ */
+export function projectWorker(
+  row: WorkerRow,
+  workerStaleAfterMs: number,
+  nowMs: number,
+): WorkerView {
+  const heartbeat = row.last_heartbeat_at ?? "";
+  // Same parser as isWorkerStale (raw Date.parse) so the parse-check and the
+  // delegated derivation can never disagree on what "unparseable" means.
+  const health: WorkerHealthState = Number.isNaN(Date.parse(heartbeat))
+    ? "offline"
+    : deriveHealth(heartbeat, nowMs, workerStaleAfterMs);
+  return {
+    workerId: row.worker_id,
+    health,
+    lastHeartbeatAt: heartbeat,
+    currentJobId:
+      row.current_job_id && row.current_job_id !== ""
+        ? row.current_job_id
+        : null,
+    capacity: {
+      inUse: row.capacity_in_use ?? 0,
+      available: row.capacity_available ?? 0,
+      max: row.capacity_max ?? 0,
+    },
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Reds read path (§4.2 / §5.2.1)
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * One `probe_runs` list per batch: filtered by the batch's job ids (the
+ * aggregator stamps `job_id` = the probe_jobs row id; ≤ ~25 OR clauses, a
+ * single page), with `summary.redsIntroduced`/`summary.redsCleared` summed
+ * across the returned rows. Rows lacking the fields (pre-P2 history)
+ * contribute nothing; when NO returned row carries them, both stay null.
+ */
+async function fetchBatchReds(
+  deps: RunViewDeps,
+  jobIds: readonly string[],
+): Promise<{ redsIntroduced: number | null; redsCleared: number | null }> {
+  if (jobIds.length === 0) {
+    return { redsIntroduced: null, redsCleared: null };
+  }
+  const filter = jobIds
+    .map((id) => `job_id = ${JSON.stringify(id)}`)
+    .join(" || ");
+  const result = await deps.pb.list<ProbeRunRedsRow>(PROBE_RUNS_COLLECTION, {
+    filter,
+    perPage: RUN_FETCH_PAGE_SIZE,
+    skipTotal: true,
+  });
+  let redsIntroduced: number | null = null;
+  let redsCleared: number | null = null;
+  for (const row of result.items) {
+    const summary = row.summary;
+    if (summary === null || typeof summary !== "object") continue;
+    if (typeof summary.redsIntroduced === "number") {
+      redsIntroduced = (redsIntroduced ?? 0) + summary.redsIntroduced;
+    }
+    if (typeof summary.redsCleared === "number") {
+      redsCleared = (redsCleared ?? 0) + summary.redsCleared;
+    }
+  }
+  return { redsIntroduced, redsCleared };
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Family summary computation + memo (§5.2)
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * Grouped batches eligible for projection: when the fetch window was NOT
+ * exhausted the oldest group is potentially truncated by the row cap, so it
+ * is discarded (§5.2.2 grouping rule) — except when it is the only group
+ * (degenerate single-batch window; the route layer owns the `truncated`
+ * presentation of that case).
+ */
+function eligibleGroups(
+  groups: RunBatchRows[],
+  exhausted: boolean,
+): RunBatchRows[] {
+  if (exhausted || groups.length <= 1) return groups;
+  return groups.slice(0, -1);
+}
+
+/** Index of the first batch in walk-order with derived outcome "completed". */
+function findCompletedBatch(groups: RunBatchRows[]): RunBatchRows | null {
+  for (let i = 0; i < groups.length; i++) {
+    const group = groups[i];
+    // The newest group, while non-terminal, is the inflight batch — it is
+    // not a terminal outcome and can never be the last success.
+    if (i === 0 && group.rows.some((row) => !isTerminal(row))) continue;
+    if (deriveOutcome(group, i > 0) === "completed") return group;
+  }
+  return null;
+}
+
+function maxFinishedAtIso(batch: RunBatchRows): string | null {
+  let max = Number.NEGATIVE_INFINITY;
+  for (const row of batch.rows) {
+    const t = parsePbDate(row.finished_at);
+    if (!Number.isNaN(t) && t > max) max = t;
+  }
+  return Number.isFinite(max) ? new Date(max).toISOString() : null;
+}
+
+/** Compute one family's §5.2.1 entry (throws on PB failure — caller degrades). */
+async function projectFamily(
+  deps: RunViewDeps,
+  fam: FleetFamily,
+  nowMs: number,
+): Promise<FamilySummaryEntry> {
+  const schedule = deps.schedules.find((s) => s.scheduleId === fam.scheduleId);
+  if (!schedule) {
+    // Unreachable while the §5.1 drift-lock holds (registry ids set-equal to
+    // the wired schedules); surfaced loudly rather than silently defaulting.
+    deps.logger.warn("run-view.schedule-unresolved", {
+      family: fam.family,
+      scheduleId: fam.scheduleId,
+    });
+  }
+  const periodMs = schedule ? periodMsFromCron(schedule.cron) : 0;
+  const nextRun = deps.scheduler.nextRunAt(fam.scheduleId);
+
+  // One indexed list (1 page) covers lastRun + inflight (a batch is ≤ ~25
+  // jobs; 200 rows ≈ several batches). Only the lastSuccessAt walk-back
+  // extends to the §5.2.2 capped loop, and only when the first page holds
+  // no completed batch.
+  const first = await fetchFamilyJobRows(deps, fam.family, undefined, 1);
+  let rows = first.rows;
+  let exhausted = first.exhausted;
+  let groups = eligibleGroups(groupBatches(rows), exhausted);
+  let completed = findCompletedBatch(groups);
+  if (completed === null && !exhausted && rows.length > 0) {
+    const oldest = rows[rows.length - 1];
+    const more = await fetchFamilyJobRows(
+      deps,
+      fam.family,
+      { before: oldest.created, beforeId: oldest.id },
+      RUN_FETCH_MAX_PAGES - 1,
+    );
+    rows = [...rows, ...more.rows];
+    exhausted = more.exhausted;
+    groups = eligibleGroups(groupBatches(rows), exhausted);
+    completed = findCompletedBatch(groups);
+  }
+
+  // inflight = the newest group only (§5.2.1) — null when all-terminal.
+  const newest = groups[0];
+  const inflight = newest ? classifyInflight(newest, periodMs, nowMs) : null;
+
+  // lastRun = the newest group whose jobs are all terminal (the newest group
+  // itself when inflight is null), else the next group down — which is by
+  // construction all-terminal or stalled-by-abandonment (rule (b)).
+  let lastRunGroup: RunBatchRows | null = null;
+  let lastRunHasNewer = false;
+  if (newest && inflight === null) {
+    lastRunGroup = newest;
+  } else if (groups.length > 1) {
+    lastRunGroup = groups[1];
+    lastRunHasNewer = true;
+  }
+  let lastRun: RunBatch | null = null;
+  if (lastRunGroup) {
+    lastRun = projectRunBatch(lastRunGroup, lastRunHasNewer);
+    const reds = await fetchBatchReds(
+      deps,
+      lastRunGroup.rows.map((row) => row.id),
+    );
+    lastRun.redsIntroduced = reds.redsIntroduced;
+    lastRun.redsCleared = reds.redsCleared;
+  }
+
+  return {
+    family: fam.family,
+    label: fam.label,
+    probeKeyPrefix: fam.probeKeyPrefix,
+    ...(schedule ? { schedule: schedule.cron, periodMs } : {}),
+    nextRunAt: nextRun ? nextRun.toISOString() : null,
+    lastRun,
+    inflight,
+    lastSuccessAt: completed ? maxFinishedAtIso(completed) : null,
+  };
+}
+
+async function computeFamilySummary(
+  deps: RunViewDeps,
+  nowMs: number,
+): Promise<FamilySummaryResponse> {
+  const families: FamilySummaryEntry[] = [];
+  for (const fam of FLEET_FAMILIES) {
+    try {
+      families.push(await projectFamily(deps, fam, nowMs));
+    } catch (err) {
+      // §5.2.1 graceful degradation: HTTP-200 posture with an entry-level
+      // error the dashboard treats as the same incident class as a failed
+      // poll — a PB-down-while-CP-up outage surfaces loudly, never as a
+      // silently sparse table.
+      deps.logger.warn("run-view.family-projection-failed", {
+        family: fam.family,
+        error: String(err),
+      });
+      families.push({
+        family: fam.family,
+        label: fam.label,
+        probeKeyPrefix: fam.probeKeyPrefix,
+        error: "history_unavailable",
+      });
+    }
+  }
+  let workers: WorkerView[] = [];
+  try {
+    const result = await deps.pb.list<WorkerRow>(WORKERS_COLLECTION, {
+      sort: "-last_heartbeat_at",
+      perPage: RUN_FETCH_PAGE_SIZE,
+      skipTotal: true,
+    });
+    workers = result.items.map((row) =>
+      projectWorker(row, deps.workerStaleAfterMs, nowMs),
+    );
+  } catch (err) {
+    // Worker-strip degradation: families already carry their own per-family
+    // error entries on a PB outage; an isolated workers-list failure logs
+    // loudly and renders an empty strip rather than failing the whole body.
+    deps.logger.warn("run-view.workers-projection-failed", {
+      error: String(err),
+    });
+  }
+  return { families, workers };
+}
+
+/** The §5.2 shared memo seam (routes + §9 monitor share ONE instance). */
+export interface MemoizedFamilySummary {
+  /** Whole-body memoized §5.2.1 response (~5 s TTL, per-family degradation). */
+  get(): Promise<FamilySummaryResponse>;
+}
+
+/**
+ * Whole-body ~5 s-TTL memo of the family summary (§5.2): every caller inside
+ * the window shares one computation, bounding PB load at ~one fan-out per
+ * TTL regardless of viewer count. Concurrent callers during a cold compute
+ * share the in-flight promise; a rejected computation is evicted so the next
+ * call retries (per-family failures degrade inside the body and do NOT
+ * reject). `runControlPlane` constructs ONE instance and injects it into
+ * both the fleet-runs routes and the §9 family-silence monitor.
+ */
+export function createMemoizedFamilySummary(
+  deps: RunViewDeps,
+  ttlMs: number = DEFAULT_SUMMARY_TTL_MS,
+): MemoizedFamilySummary {
+  const now = deps.now ?? Date.now;
+  let cached: { atMs: number; value: Promise<FamilySummaryResponse> } | null =
+    null;
+  return {
+    get(): Promise<FamilySummaryResponse> {
+      const t = now();
+      if (cached && t - cached.atMs < ttlMs) return cached.value;
+      const entry = {
+        atMs: t,
+        value: computeFamilySummary(deps, t),
+      };
+      cached = entry;
+      entry.value.catch(() => {
+        // Evict the failed computation so the next get() retries instead of
+        // serving a rejected promise for the rest of the TTL.
+        if (cached === entry) cached = null;
+      });
+      return entry.value;
+    },
+  };
+}

--- a/showcase/harness/src/fleet/control-plane/run-view.ts
+++ b/showcase/harness/src/fleet/control-plane/run-view.ts
@@ -90,6 +90,15 @@ export const FLEET_FAMILIES = [
 /** One FLEET_FAMILIES member. */
 export type FleetFamily = (typeof FLEET_FAMILIES)[number];
 
+/**
+ * Single-owner family id for §4.2 retention pruning. Four producers share the
+ * sweep-gate pattern; exactly one of them owns the family-agnostic delete
+ * pass. This is sourced from the §5.1 registry (NOT a hardcoded string
+ * literal) so a registry rename of the D6 entry can't silently disable
+ * retention pruning. See `job-producer.ts` `sweepIfDue()` for the gate.
+ */
+export const PRUNE_OWNER_FAMILY = FLEET_FAMILIES[0].family;
+
 // ───────────────────────────────────────────────────────────────────────
 // Row shapes (snake_case, as the PB records API returns them)
 // ───────────────────────────────────────────────────────────────────────

--- a/showcase/harness/src/fleet/control-plane/run-view.ts
+++ b/showcase/harness/src/fleet/control-plane/run-view.ts
@@ -656,17 +656,38 @@ export function classifyInflight(
 }
 
 /**
+ * Determine a worker's health state from its raw row, matching the EXACT
+ * behavior `fleet-health.ts`'s reclaim cycle uses on its `deriveHealth` call
+ * site so the fleet-runs `/api/runs` strip and the fleet-health monitor
+ * never disagree on a worker's state for the SAME row. The canonical
+ * derivation lives in `contracts.ts` (`deriveHealth` — exported, shared);
+ * this helper is the per-call-site wrapper that both surfaces should route
+ * through. We deliberately do NOT pre-check parseability and force "offline":
+ * fleet-health's call site (in this branch) does not do that, and forcing it
+ * on this display surface re-introduces the surface-disagreement bug this
+ * fix is closing. (When fleet-health.ts is updated to use this helper in a
+ * follow-up — fleet-health.ts canonical lives on `fix/cf8-m1` and is out of
+ * scope here — the parse-check policy can be revisited in ONE place.)
+ */
+function determineWorkerHealth(
+  row: WorkerRow,
+  nowMs: number,
+  workerStaleAfterMs: number,
+): WorkerHealthState {
+  // Mirror fleet-health.ts:399 verbatim: pass the raw column straight through
+  // to `deriveHealth`. `deriveHealth` -> `isWorkerStale`'s unparseable-default
+  // (treat-unknown-as-not-yet-stale) is what the reclaim machinery sees, so
+  // this surface sees the same thing.
+  return deriveHealth(row.last_heartbeat_at ?? "", nowMs, workerStaleAfterMs);
+}
+
+/**
  * Project one `workers` row into the §5.2.1 strip entry, deriving `health`
- * through the SAME `deriveHealth` fleet-health uses (hoisted to contracts) so
- * the two surfaces can never disagree — with one explicit carve-out: an
- * unparseable `last_heartbeat_at` maps to "offline". `deriveHealth` inherits
- * `isWorkerStale`'s treat-unknown-as-not-yet-stale default (correct for the
- * reclaim machinery, exactly wrong for a display surface where unknown
- * rendering healthy is the lie), so we pre-check parseability first —
- * mirroring fleet-health's own unparseable-heartbeat warn path. The
- * `endpoint` column (a routable internal URL) is deliberately NEVER
- * serialized; worker ids and heartbeat timestamps are non-secret (§5.2.1
- * identifier-exposure carve-out).
+ * through `determineWorkerHealth` (the shared per-call-site wrapper around
+ * `contracts.deriveHealth`) so this surface and `fleet-health.ts`'s cycle
+ * report the SAME health for the SAME row. The `endpoint` column (a routable
+ * internal URL) is deliberately NEVER serialized; worker ids and heartbeat
+ * timestamps are non-secret (§5.2.1 identifier-exposure carve-out).
  */
 export function projectWorker(
   row: WorkerRow,
@@ -674,11 +695,7 @@ export function projectWorker(
   nowMs: number,
 ): WorkerView {
   const heartbeat = row.last_heartbeat_at ?? "";
-  // Same parser as isWorkerStale (raw Date.parse) so the parse-check and the
-  // delegated derivation can never disagree on what "unparseable" means.
-  const health: WorkerHealthState = Number.isNaN(Date.parse(heartbeat))
-    ? "offline"
-    : deriveHealth(heartbeat, nowMs, workerStaleAfterMs);
+  const health = determineWorkerHealth(row, nowMs, workerStaleAfterMs);
   return {
     workerId: row.worker_id,
     health,

--- a/showcase/harness/src/fleet/orchestrator.test.ts
+++ b/showcase/harness/src/fleet/orchestrator.test.ts
@@ -141,6 +141,9 @@ function makeQueue(claims: ClaimedJob[]): RecordingQueue {
     async countPendingForFamily(): Promise<number> {
       throw new Error("countPendingForFamily not used by worker");
     },
+    async pruneAged() {
+      return { terminal: 0, zombie: 0 };
+    },
   };
 }
 

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -598,7 +598,6 @@ describe("FleetQueueClient.enqueue", () => {
     expect(rows[0].payload).toEqual(samplePayload());
   });
 
-
   it("rejects a non-number meta.priority at the enqueue boundary (optional fields still have required shapes)", async () => {
     // `priority` is the one optional META field; like cellIds/driverInputs
     // it must have its required shape WHEN PRESENT. The untrusted JSON

--- a/showcase/harness/src/fleet/queue-client.test.ts
+++ b/showcase/harness/src/fleet/queue-client.test.ts
@@ -8,6 +8,8 @@ import {
   PoisonedBacklogCountError,
   RESULT_WRITE_MAX_ATTEMPTS,
   RESULT_WRITE_RETRY_DELAY_MS,
+  PRUNE_TERMINAL_MAX_AGE_MS,
+  PRUNE_ZOMBIE_MAX_AGE_MS,
 } from "./queue-client.js";
 import { createJobClaimClient, JobClaimEndpointError } from "./job-claim.js";
 import type {
@@ -110,6 +112,11 @@ interface JobRow extends JobView {
   /** Result-flow columns (migration 1779989700) the report path writes. */
   result?: unknown;
   result_processed?: boolean;
+  /** Run-metadata columns (migration 1779990200) enqueue denormalizes. */
+  run_id?: string;
+  family?: string;
+  /** PB system column; seeded by prune tests (real PB stamps it on create). */
+  created?: string;
 }
 
 /**
@@ -274,8 +281,11 @@ function rowMatchesFilter(row: FilterableRow, filter?: string): boolean {
 function makeFakePb(rows: JobRow[] = []): {
   pb: PbClient;
   rows: JobRow[];
+  /** Every filter string passed to deleteByFilter, in call order. */
+  deleteFilters: string[];
 } {
   const store = [...rows];
+  const deleteFilters: string[] = [];
   const unsupported = (name: string) => () => {
     throw new Error(`fake-pb: ${name} not implemented`);
   };
@@ -292,6 +302,10 @@ function makeFakePb(rows: JobRow[] = []): {
         lease_expires_at: (record.lease_expires_at as string | null) ?? null,
         version: Number(record.version ?? 0),
         payload: record.payload as ServiceJobPayload,
+        // Run-metadata columns (migration 1779990200): capture exactly what
+        // enqueue writes so the denormalization tests assert the record body.
+        run_id: record.run_id as string | undefined,
+        family: record.family as string | undefined,
       };
       store.push(row);
       return row as unknown as T;
@@ -374,13 +388,35 @@ function makeFakePb(rows: JobRow[] = []): {
     },
     upsertByField: unsupported("upsertByField") as PbClient["upsertByField"],
     delete: unsupported("delete") as PbClient["delete"],
-    deleteByFilter: unsupported("deleteByFilter") as PbClient["deleteByFilter"],
+    // Honor the two clause shapes pruneAged builds — OR-of-`status = "x"`
+    // equals plus a `created < "<ISO cutoff>"` age bound — the way the real
+    // client would, so the retention-leg tests exercise actual row deletion
+    // (survivors stay in `store`) rather than just capturing filter strings.
+    // ISO-8601 strings compare lexicographically, so `<` on the raw strings
+    // matches PB's date comparison for the canonical shapes seeded here.
+    async deleteByFilter(_collection: string, filter: string): Promise<number> {
+      deleteFilters.push(filter);
+      const statuses = new Set(
+        [...filter.matchAll(/status\s*=\s*"(\w+)"/g)].map((mm) => mm[1]),
+      );
+      const createdMatch = filter.match(/created\s*<\s*"([^"]+)"/);
+      const before = store.length;
+      for (let i = store.length - 1; i >= 0; i--) {
+        const row = store[i];
+        const statusOk = statuses.size === 0 || statuses.has(row.status);
+        const createdOk =
+          !createdMatch ||
+          (row.created !== undefined && row.created < createdMatch[1]);
+        if (statusOk && createdOk) store.splice(i, 1);
+      }
+      return before - store.length;
+    },
     health: unsupported("health") as PbClient["health"],
     createBackup: unsupported("createBackup") as PbClient["createBackup"],
     downloadBackup: unsupported("downloadBackup") as PbClient["downloadBackup"],
     deleteBackup: unsupported("deleteBackup") as PbClient["deleteBackup"],
   };
-  return { pb, rows: store };
+  return { pb, rows: store, deleteFilters };
 }
 
 /** Configurable fake JobClaimClient — each method is a vi.fn the test wires. */
@@ -562,6 +598,7 @@ describe("FleetQueueClient.enqueue", () => {
     expect(rows[0].payload).toEqual(samplePayload());
   });
 
+
   it("rejects a non-number meta.priority at the enqueue boundary (optional fields still have required shapes)", async () => {
     // `priority` is the one optional META field; like cellIds/driverInputs
     // it must have its required shape WHEN PRESENT. The untrusted JSON
@@ -659,6 +696,40 @@ describe("FleetQueueClient.enqueue", () => {
     }
     expect(createSpy).not.toHaveBeenCalled();
     expect(rows).toHaveLength(0);
+  });
+
+  it("denormalizes payload.meta.runId into the run_id column", async () => {
+    // §4.2: run_id rides an indexed column so the run-view projection can
+    // group a batch with a filter instead of a JSON-path scan over payload.
+    const { pb, rows } = makeFakePb();
+    const claim = makeFakeClaim();
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await q.enqueue({ payload: samplePayload() });
+
+    expect(rows[0].run_id).toBe("run-1");
+  });
+
+  it("stamps the family column when EnqueueJobInput.family is present", async () => {
+    const { pb, rows } = makeFakePb();
+    const claim = makeFakeClaim();
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await q.enqueue({ payload: samplePayload(), family: "d6" });
+
+    expect(rows[0].family).toBe("d6");
+  });
+
+  it("writes empty family when the input omits it (pre-P2 row parity)", async () => {
+    // An absent family must write the column EMPTY — matching rows enqueued
+    // before P2, which the new per-family API simply never selects.
+    const { pb, rows } = makeFakePb();
+    const claim = makeFakeClaim();
+    const q = createFleetQueueClient({ pb, claim, logger });
+
+    await q.enqueue({ payload: samplePayload() });
+
+    expect(rows[0].family).toBe("");
   });
 });
 
@@ -5145,6 +5216,122 @@ describe("FleetQueueClient.sweepExpired", () => {
     expect(sweep.reclaimed).toBe(0);
     expect(sweep.commErrors).toHaveLength(0);
     expect(claim.releaseJob).not.toHaveBeenCalled();
+  });
+});
+
+describe("FleetQueueClient.pruneAged", () => {
+  const NOW = Date.parse("2026-06-10T00:00:00.000Z");
+  /** An ISO `created` stamp `ageMs` in the past relative to NOW. */
+  const createdAgo = (ageMs: number): string =>
+    new Date(NOW - ageMs).toISOString();
+  const DAY_MS = 24 * 3600_000;
+  const HOUR_MS = 3600_000;
+
+  function prunableRow(overrides: Partial<JobRow>): JobRow {
+    return { ...jobView(), payload: samplePayload(), ...overrides };
+  }
+
+  it("deletes terminal rows older than 14 days including result_processed=false poison rows", async () => {
+    const { pb, rows, deleteFilters } = makeFakePb([
+      // Poison row: terminal but the aggregator could never process its
+      // result (`result_processed` stuck false). §4.2: the latch gates
+      // aggregation, NOT retention — at 14 days the consume-once question is
+      // moot and the row is reaped like any other terminal row.
+      prunableRow({
+        id: "j1",
+        status: "done",
+        created: createdAgo(15 * DAY_MS),
+        result_processed: false,
+      }),
+      prunableRow({
+        id: "j2",
+        status: "failed",
+        created: createdAgo(20 * DAY_MS),
+        result_processed: true,
+      }),
+      // Younger terminal row — inside the 14-day window, must survive.
+      prunableRow({
+        id: "j3",
+        status: "done",
+        created: createdAgo(13 * DAY_MS),
+        result_processed: true,
+      }),
+    ]);
+    const q = createFleetQueueClient({ pb, claim: makeFakeClaim(), logger });
+
+    const pruned = await q.pruneAged(NOW);
+
+    expect(pruned).toEqual({ terminal: 2, zombie: 0 });
+    expect(rows.map((r) => r.id)).toEqual(["j3"]);
+    // §4.2: retention is deliberately blind to the aggregation latch — the
+    // terminal-leg filter must NOT carry a result_processed clause.
+    const terminalFilter = deleteFilters.find((f) => f.includes('"done"'));
+    expect(terminalFilter).toBeDefined();
+    expect(terminalFilter).not.toContain("result_processed");
+  });
+
+  it("deletes non-terminal rows older than 48 hours (zombie leg)", async () => {
+    // Nothing else ever reaps abandoned pending/claimed/running rows: a
+    // pending row has no lease for sweepExpired to expire, and the terminal
+    // leg only touches done/failed. All three non-terminal states are reaped
+    // past the 48 h zombie window.
+    const { pb, rows } = makeFakePb([
+      prunableRow({
+        id: "j1",
+        status: "pending",
+        created: createdAgo(49 * HOUR_MS),
+      }),
+      prunableRow({
+        id: "j2",
+        status: "claimed",
+        claimed_by: "worker-dead",
+        created: createdAgo(72 * HOUR_MS),
+      }),
+      prunableRow({
+        id: "j3",
+        status: "running",
+        claimed_by: "worker-dead",
+        created: createdAgo(50 * HOUR_MS),
+      }),
+    ]);
+    const q = createFleetQueueClient({ pb, claim: makeFakeClaim(), logger });
+
+    const pruned = await q.pruneAged(NOW);
+
+    expect(pruned).toEqual({ terminal: 0, zombie: 3 });
+    expect(rows).toHaveLength(0);
+  });
+
+  it("leaves younger non-terminal (stalled-but-within-window) rows untouched", async () => {
+    // A stalled batch keeps its full ~2-day diagnostic window rendering as
+    // `stalled` on the Ops tab — the zombie leg must never reap rows the
+    // stalled-classification window still owns. The cutoff keys on `created`
+    // (renewal-immune), not `updated`.
+    const { pb, rows } = makeFakePb([
+      prunableRow({
+        id: "j1",
+        status: "pending",
+        created: createdAgo(47 * HOUR_MS),
+      }),
+      prunableRow({
+        id: "j2",
+        status: "running",
+        claimed_by: "worker-7",
+        created: createdAgo(2 * HOUR_MS),
+      }),
+    ]);
+    const q = createFleetQueueClient({ pb, claim: makeFakeClaim(), logger });
+
+    const pruned = await q.pruneAged(NOW);
+
+    expect(pruned).toEqual({ terminal: 0, zombie: 0 });
+    expect(rows.map((r) => r.id)).toEqual(["j1", "j2"]);
+  });
+
+  it("computes both cutoffs from the exported window constants", () => {
+    // T15 and the route tests reference these — pin the §4.2 windows.
+    expect(PRUNE_TERMINAL_MAX_AGE_MS).toBe(14 * DAY_MS);
+    expect(PRUNE_ZOMBIE_MAX_AGE_MS).toBe(48 * HOUR_MS);
   });
 });
 

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -2255,3 +2255,4 @@ export function createFleetQueueClient(
       }
     }
   }
+}

--- a/showcase/harness/src/fleet/queue-client.ts
+++ b/showcase/harness/src/fleet/queue-client.ts
@@ -64,6 +64,7 @@ import type {
   FleetQueueClient,
   JobLease,
   PoolCommError,
+  PruneAgedResult,
   ReportJobInput,
   ServiceJobMeta,
   ServiceJobPayload,
@@ -96,6 +97,30 @@ const CLAIM_CANDIDATE_PAGE = 50;
  * count if probe_key shapes ever proliferate unexpectedly.
  */
 const MAX_PENDING_FAMILIES = 16;
+
+/**
+ * §4.2 retention windows for `pruneAged` (exported — the integration test and
+ * the fleet-runs route tests reference them):
+ *
+ *   - TERMINAL (14 days): delete `done`/`failed` rows older than this,
+ *     deliberately REGARDLESS of `result_processed` — the latch gates the
+ *     aggregator's consume-once semantics, not retention. A poison result the
+ *     aggregator can never process (`result_processed` stuck false) would
+ *     otherwise pin its row forever; at 14 days — thousands of aggregation
+ *     cycles past the batch — the consume-once question is moot.
+ *   - ZOMBIE (48 hours): delete NON-terminal rows older than this. Nothing
+ *     else ever reaps abandoned `pending`/`claimed`/`running` rows —
+ *     `sweepExpired` scans only `claimed|running` (a `pending` row has no
+ *     lease to expire) and the terminal leg touches only terminal rows. 48 h
+ *     is far beyond the longest legitimate run AND the dashboard's
+ *     stalled-classification window, so a stalled batch keeps its full
+ *     diagnostic visibility window before its zombie rows are reaped.
+ *
+ * Both legs cut on `created` (stamped once, renewal-immune), never `updated`
+ * (a wedged-but-renewing worker bumps `updated` on every lease renewal).
+ */
+export const PRUNE_TERMINAL_MAX_AGE_MS = 14 * 24 * 3600_000;
+export const PRUNE_ZOMBIE_MAX_AGE_MS = 48 * 3600_000;
 
 /**
  * Bounded retries for the post-release result write in `report()`. The release
@@ -947,6 +972,11 @@ export function createFleetQueueClient(
       // A fresh job is `pending` with no owner and no lease. `probe_key` is the
       // join key (== payload.probeKey, the d6 aggregate row key); the work
       // rides in the `payload` JSON column for the worker to read post-claim.
+      // §4.2 run-metadata denormalization (migration 1779990200): `run_id` is
+      // copied out of `payload.meta.runId` so the run-view projection can
+      // group a batch with an indexed filter instead of a JSON-path scan, and
+      // `family` carries the producer's §5.1 registry id for indexed
+      // per-family listing (absent → written empty, matching pre-P2 rows).
       const record = await pb.create<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
         probe_key: payload.probeKey,
         status: "pending",
@@ -954,6 +984,8 @@ export function createFleetQueueClient(
         lease_expires_at: null,
         version: 0,
         payload,
+        run_id: payload.meta.runId,
+        family: input.family ?? "",
       });
       logger.debug("queue-client.enqueued", {
         jobId: record.id,
@@ -1662,6 +1694,38 @@ export function createFleetQueueClient(
       sweepInFlight = sweep;
       return sweep;
     },
+
+    async pruneAged(nowMs: number): Promise<PruneAgedResult> {
+      // §4.2 retention, two legs over `created` cutoffs (see the window
+      // constants' WHY above). Idempotent record-level deletes — single-owner
+      // by the d6 producer's family gate (job-producer), not by this client,
+      // so a concurrent/missed pass is harmless. Date-literal style mirrors
+      // `sweepStaleRuns` (run-history.ts): ISO string in a quoted PB filter.
+      const terminalCutoff = new Date(
+        nowMs - PRUNE_TERMINAL_MAX_AGE_MS,
+      ).toISOString();
+      const zombieCutoff = new Date(
+        nowMs - PRUNE_ZOMBIE_MAX_AGE_MS,
+      ).toISOString();
+      // Terminal leg: deliberately NO `result_processed` clause — the latch
+      // gates aggregation, not retention (a stuck-false poison row is reaped
+      // like any other terminal row at this age).
+      const terminal = await pb.deleteByFilter(
+        PROBE_JOBS_COLLECTION,
+        `(status = "done" || status = "failed") && created < "${terminalCutoff}"`,
+      );
+      // Zombie leg: every non-terminal state — `pending` rows have no lease
+      // for sweepExpired to reclaim, so this is their ONLY reaper. `created`
+      // (not `updated`) keeps the cutoff renewal-immune.
+      const zombie = await pb.deleteByFilter(
+        PROBE_JOBS_COLLECTION,
+        `(status = "pending" || status = "claimed" || status = "running") && created < "${zombieCutoff}"`,
+      );
+      if (terminal > 0 || zombie > 0) {
+        logger.info("queue-client.pruned-aged", { terminal, zombie });
+      }
+      return { terminal, zombie };
+    },
   };
 
   // The actual sweep pass `sweepExpired` latches around. A function
@@ -2191,4 +2255,3 @@ export function createFleetQueueClient(
       }
     }
   }
-}

--- a/showcase/harness/src/fleet/run-visibility.integration.test.ts
+++ b/showcase/harness/src/fleet/run-visibility.integration.test.ts
@@ -1,0 +1,689 @@
+/**
+ * Run-visibility INTEGRATION test (T15, spec §8): drives a REAL queue-client
+ * (S3) + REAL run-view projections (T5) + REAL fleet-runs routes (T7) over an
+ * in-memory fake PB + a hook-mirroring fake claim client, end to end:
+ *
+ *   enqueue → claim → release (incl. a lease-expiry reclaim asserting
+ *   reclaim_count increments and jobs.reclaimed surfaces it) → GET /api/runs
+ *   and GET /api/runs/:family/:runId.
+ *
+ * The ONLY fakes are the storage/CAS boundary (PB records API + the JSVM
+ * claim/renew/release endpoints); everything in between is production code.
+ */
+
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import type { ListOpts, ListResult, PbClient } from "../storage/pb-client.js";
+import type { Logger } from "../types/index.js";
+import {
+  type ClaimResult,
+  type JobClaimClient,
+  type JobStatus,
+  type JobView,
+  type ReleaseResult,
+  type RenewResult,
+} from "./job-claim.js";
+import type { ServiceJobPayload, ServiceJobResult } from "./contracts.js";
+import { createFleetQueueClient } from "./queue-client.js";
+import {
+  FLEET_PRODUCER_DEEP_SCHEDULE_ID,
+  FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
+  FLEET_PRODUCER_SCHEDULE_ID,
+  FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
+  type ProducerSchedule,
+} from "./control-plane/control-plane.js";
+import {
+  createMemoizedFamilySummary,
+  type FamilySummaryResponse,
+  type RunViewDeps,
+} from "./control-plane/run-view.js";
+import type { JobProducer } from "./control-plane/job-producer.js";
+import {
+  registerFleetRunsRoutes,
+  type RunDetailResponse,
+} from "../http/fleet-runs.js";
+
+// ───────────────────────────────────────────────────────────────────────
+// Clock + fixtures
+// ───────────────────────────────────────────────────────────────────────
+
+const T0_MS = Date.parse("2026-06-10T12:00:00.000Z");
+
+const noopLogger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+/** Injected everywhere a "now" exists (fake claim, run-view, routes). */
+interface FakeClock {
+  now(): number;
+  advance(ms: number): void;
+}
+
+function makeClock(): FakeClock {
+  let nowMs = T0_MS;
+  return {
+    now: () => nowMs,
+    advance: (ms: number) => {
+      nowMs += ms;
+    },
+  };
+}
+
+function isoAt(clock: FakeClock): string {
+  return new Date(clock.now()).toISOString();
+}
+
+/** ISO at T0 + offsetMs — assertion helper. */
+function iso(offsetMs: number): string {
+  return new Date(T0_MS + offsetMs).toISOString();
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// The shared in-memory probe_jobs store
+// ───────────────────────────────────────────────────────────────────────
+
+/** The full persisted row shape: JobView lifecycle columns + payload/result
+ *  columns + the §4.2 run-metadata columns + PB system columns. */
+interface FakeJobRow extends JobView {
+  payload: ServiceJobPayload;
+  result?: unknown;
+  result_processed?: boolean;
+  run_id: string;
+  family: string;
+  claimed_at?: string;
+  finished_at?: string;
+  reclaim_count?: number;
+  created: string;
+  updated: string;
+}
+
+function jobView(rec: FakeJobRow): JobView {
+  return {
+    id: rec.id,
+    probe_key: rec.probe_key,
+    status: rec.status,
+    claimed_by: rec.claimed_by,
+    lease_expires_at: rec.lease_expires_at,
+    version: rec.version,
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Hook-mirroring fake claim client
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * THIS FAKE PINS THE fleet-claim.pb.js CONTRACT — CHANGE THEM TOGETHER.
+ *
+ * It mirrors the JSVM hook's claim/renew/release CAS semantics over the
+ * in-memory store, INCLUDING the §4.2 run-metadata stamping the hook owns
+ * (T1 is the normative source; verified live-contract semantics):
+ *
+ *   - `claimed_at` is stamped on EVERY winning claim — it deliberately
+ *     RESTAMPS on a re-claim/steal so queueLatencyMs measures the LAST claim.
+ *   - `reclaim_count` increments in EXACTLY the two choke points: the claim
+ *     CAS's expired-lease steal, and the release CAS's pending re-queue
+ *     (the sweeper path). Nowhere else.
+ *   - `finished_at` is stamped ONLY on a terminal release (done|failed);
+ *     a pending re-queue leaves it untouched (null until terminal).
+ *   - terminal release is lease-gated (an expired holder LOST the row);
+ *     `target === "pending"` is exempt — that is the sweeper operating on
+ *     expired leases BY DESIGN.
+ */
+function makeHookMirroringClaim(
+  store: FakeJobRow[],
+  clock: FakeClock,
+): JobClaimClient {
+  const RUNNING_STATES: JobStatus[] = ["claimed", "running"];
+  // Anchored space→"T" rewrite, byte-for-byte the hook's leaseExpired.
+  const PB_DATE_SEP_RE = /^(\d{4}-\d{2}-\d{2}) /;
+  const leaseExpired = (rec: FakeJobRow): boolean => {
+    const raw = rec.lease_expires_at;
+    if (!raw) return true;
+    const t = Date.parse(String(raw).replace(PB_DATE_SEP_RE, "$1T"));
+    if (Number.isNaN(t)) return true;
+    return t <= clock.now();
+  };
+  const leaseExpiryIso = (leaseSeconds: number): string => {
+    const secs = leaseSeconds && leaseSeconds > 0 ? leaseSeconds : 30;
+    return new Date(clock.now() + secs * 1000).toISOString();
+  };
+  const find = (jobId: string): FakeJobRow | undefined =>
+    store.find((r) => r.id === jobId);
+
+  return {
+    async claimJob(
+      jobId: string,
+      workerId: string,
+      leaseSeconds: number,
+    ): Promise<ClaimResult> {
+      const rec = find(jobId);
+      if (!rec) return { won: false };
+      const status = rec.status;
+      const reclaimable =
+        status === "pending" ||
+        (RUNNING_STATES.indexOf(status) !== -1 && leaseExpired(rec));
+      if (!reclaimable) return { won: false };
+      // Hook contract: capture WHICH branch won BEFORE mutating the record.
+      // An expired-lease steal is the FIRST of the two reclaim choke points.
+      const wasExpiredSteal =
+        RUNNING_STATES.indexOf(status) !== -1 && leaseExpired(rec);
+      rec.status = "claimed";
+      rec.claimed_by = workerId;
+      rec.lease_expires_at = leaseExpiryIso(leaseSeconds);
+      rec.version = (rec.version || 0) + 1;
+      // claimed_at is stamped on EVERY winning claim — deliberately restamps
+      // on a re-claim/steal (§5.2.1: queueLatencyMs measures the LAST claim).
+      rec.claimed_at = isoAt(clock);
+      if (wasExpiredSteal) {
+        rec.reclaim_count = (rec.reclaim_count || 0) + 1;
+      }
+      rec.updated = isoAt(clock);
+      return { won: true, job: jobView(rec) };
+    },
+
+    async renewLease(
+      jobId: string,
+      workerId: string,
+      leaseSeconds: number,
+    ): Promise<RenewResult> {
+      const rec = find(jobId);
+      if (!rec) return { renewed: false };
+      if (RUNNING_STATES.indexOf(rec.status) === -1) return { renewed: false };
+      if (rec.claimed_by !== workerId) return { renewed: false };
+      if (leaseExpired(rec)) return { renewed: false };
+      rec.status = "running";
+      rec.lease_expires_at = leaseExpiryIso(leaseSeconds);
+      rec.version = (rec.version || 0) + 1;
+      rec.updated = isoAt(clock);
+      return { renewed: true, job: jobView(rec) };
+    },
+
+    async releaseJob(
+      jobId: string,
+      workerId: string,
+      status: Extract<JobStatus, "done" | "failed" | "pending">,
+    ): Promise<ReleaseResult> {
+      const rec = find(jobId);
+      if (!rec) return { released: false };
+      if (RUNNING_STATES.indexOf(rec.status) === -1) return { released: false };
+      if (rec.claimed_by !== workerId) return { released: false };
+      // Terminal targets are lease-gated; pending (the sweeper re-queue)
+      // operates on expired leases BY DESIGN and must proceed.
+      if (status !== "pending" && leaseExpired(rec)) return { released: false };
+      rec.status = status;
+      if (status === "pending") {
+        rec.claimed_by = "";
+        rec.lease_expires_at = null;
+        // Hook contract: the sweeper re-queue is the SECOND reclaim choke
+        // point — bump the durable per-job reclaim tally. finished_at
+        // deliberately stays untouched (a re-queued job has not finished).
+        rec.reclaim_count = (rec.reclaim_count || 0) + 1;
+      } else {
+        // Hook contract: terminal release (done|failed) stamps the finish
+        // time — the ONLY writer of finished_at.
+        rec.finished_at = isoAt(clock);
+      }
+      rec.version = (rec.version || 0) + 1;
+      rec.updated = isoAt(clock);
+      return { released: true, job: jobView(rec) };
+    },
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Fake PB over the same store
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * Fake PbClient honoring exactly the shapes this flow issues: queue-client's
+ * status-filtered lists (claimNext / sweepExpired) and result-write update,
+ * run-view's family/cursor lists (sort `-created,-id`), the detail route's
+ * `family && run_id` list, the probe_runs reds join (empty here → reds null),
+ * and the workers strip list (empty). Everything else throws so an accidental
+ * dependency surfaces loudly.
+ */
+function makeFakePb(store: FakeJobRow[], clock: FakeClock): PbClient {
+  const unsupported = (name: string) => () => {
+    throw new Error(`fake-pb: ${name} not implemented`);
+  };
+  return {
+    async create<T>(
+      collection: string,
+      record: Record<string, unknown>,
+    ): Promise<T> {
+      if (collection !== "probe_jobs") {
+        throw new Error(`fake-pb: unexpected create on ${collection}`);
+      }
+      const row: FakeJobRow = {
+        id: `j${store.length + 1}`,
+        probe_key: String(record.probe_key),
+        status: record.status as JobStatus,
+        claimed_by: String(record.claimed_by ?? ""),
+        lease_expires_at: (record.lease_expires_at as string | null) ?? null,
+        version: Number(record.version ?? 0),
+        payload: record.payload as ServiceJobPayload,
+        run_id: String(record.run_id ?? ""),
+        family: String(record.family ?? ""),
+        created: isoAt(clock),
+        updated: isoAt(clock),
+      };
+      store.push(row);
+      return row as unknown as T;
+    },
+
+    async list<T>(
+      collection: string,
+      opts: ListOpts = {},
+    ): Promise<ListResult<T>> {
+      const filter = opts.filter ?? "";
+      let items: unknown[];
+      if (collection === "probe_jobs") {
+        let rows = [...store];
+        const statuses = new Set(
+          [...filter.matchAll(/status\s*=\s*"(\w+)"/g)].map((m) => m[1]),
+        );
+        if (statuses.size > 0) {
+          rows = rows.filter((r) => statuses.has(r.status));
+        }
+        const fam = /family = "([^"]*)"/.exec(filter)?.[1];
+        if (fam !== undefined) rows = rows.filter((r) => r.family === fam);
+        const runId = /run_id = "([^"]+)"/.exec(filter)?.[1];
+        if (runId !== undefined) rows = rows.filter((r) => r.run_id === runId);
+        const before = /created [<=]+ "([^"]+)"/.exec(filter)?.[1];
+        const beforeId = /id < "([^"]+)"/.exec(filter)?.[1];
+        if (before !== undefined) {
+          rows = rows.filter(
+            (r) =>
+              r.created < before ||
+              (beforeId !== undefined &&
+                r.created === before &&
+                r.id < beforeId),
+          );
+        }
+        if (opts.sort?.startsWith("-created")) {
+          rows.sort((a, b) =>
+            a.created === b.created
+              ? b.id.localeCompare(a.id)
+              : b.created.localeCompare(a.created),
+          );
+        }
+        items = rows.slice(0, opts.perPage ?? rows.length);
+      } else if (collection === "probe_runs" || collection === "workers") {
+        // No probe_runs rows (reds stay null) and no workers in this flow.
+        items = [];
+      } else {
+        throw new Error(`fake-pb: unexpected collection ${collection}`);
+      }
+      return {
+        page: opts.page ?? 1,
+        perPage: opts.perPage ?? items.length,
+        totalPages: 1,
+        totalItems: items.length,
+        items: items as T[],
+      };
+    },
+
+    async getOne<T>(collection: string, id: string): Promise<T | null> {
+      if (collection !== "probe_jobs") {
+        throw new Error(`fake-pb: unexpected getOne on ${collection}`);
+      }
+      return (store.find((r) => r.id === id) ?? null) as unknown as T | null;
+    },
+
+    async update<T>(
+      collection: string,
+      id: string,
+      record: Record<string, unknown>,
+    ): Promise<T> {
+      if (collection !== "probe_jobs") {
+        throw new Error(`fake-pb: unexpected update on ${collection}`);
+      }
+      const row = store.find((r) => r.id === id);
+      if (!row) throw new Error(`fake-pb: update of missing row ${id}`);
+      Object.assign(row as unknown as Record<string, unknown>, record);
+      row.updated = isoAt(clock);
+      return row as unknown as T;
+    },
+
+    getFirst: unsupported("getFirst") as PbClient["getFirst"],
+    upsertByField: unsupported("upsertByField") as PbClient["upsertByField"],
+    delete: unsupported("delete") as PbClient["delete"],
+    deleteByFilter: unsupported("deleteByFilter") as PbClient["deleteByFilter"],
+    health: unsupported("health") as PbClient["health"],
+    createBackup: unsupported("createBackup") as PbClient["createBackup"],
+    downloadBackup: unsupported("downloadBackup") as PbClient["downloadBackup"],
+    deleteBackup: unsupported("deleteBackup") as PbClient["deleteBackup"],
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// World wiring: real queue-client + real run-view + real routes
+// ───────────────────────────────────────────────────────────────────────
+
+function stubProducer(): JobProducer {
+  return {
+    start: () => {},
+    stop: async () => {},
+    tick: async () => {
+      throw new Error("stub producer must not tick in this integration test");
+    },
+    isRunning: () => false,
+  };
+}
+
+function makeSchedules(): readonly ProducerSchedule[] {
+  return [
+    {
+      scheduleId: FLEET_PRODUCER_SCHEDULE_ID,
+      cron: "40 * * * *",
+      producer: stubProducer(),
+    },
+    {
+      scheduleId: FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
+      cron: "5,20,35,50 * * * *",
+      producer: stubProducer(),
+    },
+    {
+      scheduleId: FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
+      cron: "10 * * * *",
+      producer: stubProducer(),
+    },
+    {
+      scheduleId: FLEET_PRODUCER_DEEP_SCHEDULE_ID,
+      cron: "15,30,45,0 * * * *",
+      producer: stubProducer(),
+    },
+  ];
+}
+
+function makeWorld() {
+  const clock = makeClock();
+  const store: FakeJobRow[] = [];
+  const claim = makeHookMirroringClaim(store, clock);
+  const pb = makeFakePb(store, clock);
+  const queue = createFleetQueueClient({ pb, claim, logger: noopLogger });
+  const rvDeps: RunViewDeps = {
+    pb,
+    scheduler: { nextRunAt: () => null },
+    schedules: makeSchedules(),
+    workerStaleAfterMs: 180_000,
+    logger: noopLogger,
+    now: clock.now,
+  };
+  const app = new Hono();
+  registerFleetRunsRoutes(app, {
+    summary: createMemoizedFamilySummary(rvDeps),
+    pb,
+    schedules: rvDeps.schedules,
+    scheduler: rvDeps.scheduler,
+    workerStaleAfterMs: rvDeps.workerStaleAfterMs,
+    logger: noopLogger,
+    now: clock.now,
+  });
+  return { clock, store, claim, queue, app };
+}
+
+function payloadFor(
+  slug: string,
+  runId: string,
+  enqueuedAt: string,
+  probeKeyPrefix = "d5-single-pill-e2e",
+): ServiceJobPayload {
+  return {
+    probeKey: `${probeKeyPrefix}:${slug}`,
+    serviceSlug: slug,
+    driverKind: "e2e_d5",
+    meta: { runId, triggered: false, enqueuedAt },
+  };
+}
+
+function greenResult(
+  jobId: string,
+  payload: ServiceJobPayload,
+  workerId: string,
+  finishedAt: string,
+): ServiceJobResult {
+  return {
+    jobId,
+    probeKey: payload.probeKey,
+    serviceSlug: payload.serviceSlug,
+    runId: payload.meta.runId,
+    workerId,
+    aggregateState: "green",
+    aggregateKey: payload.probeKey,
+    aggregateSignal: { failedCount: 0 },
+    cells: [],
+    rollup: { total: 1, passed: 1, failed: 0 },
+    finishedAt,
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// The integration flow
+// ───────────────────────────────────────────────────────────────────────
+
+describe("run-visibility integration: enqueue→claim→release→/api/runs", () => {
+  it("projects a 3-job batch with a sweeper lease-expiry reclaim into /api/runs and the run detail", async () => {
+    const { clock, store, queue, app } = makeWorld();
+    const runId = "run-d5-001";
+
+    // ── Enqueue a 3-job d5 batch at T0.
+    const slugs = ["svc-a", "svc-b", "svc-c"] as const;
+    for (const slug of slugs) {
+      await queue.enqueue({
+        payload: payloadFor(slug, runId, iso(0)),
+        family: "d5",
+      });
+    }
+    expect(store).toHaveLength(3);
+    expect(store.every((r) => r.family === "d5" && r.run_id === runId)).toBe(
+      true,
+    );
+
+    // ── Claim all three at T0+1 s (worker-1, 30 s lease).
+    clock.advance(1_000);
+    const leases = new Map<string, { jobId: string }>();
+    for (let i = 0; i < 3; i++) {
+      const claimed = await queue.claimNext("worker-1", 30);
+      expect(claimed.claimed).toBe(true);
+      const lease = claimed.lease;
+      if (!lease) throw new Error("claimed without a lease");
+      leases.set(lease.payload.serviceSlug, { jobId: lease.job.id });
+    }
+    // Hook contract: claimed_at stamped on EVERY winning claim; reclaim_count
+    // untouched by a plain pending claim.
+    for (const row of store) {
+      expect(row.claimed_at).toBe(iso(1_000));
+      expect(row.reclaim_count ?? 0).toBe(0);
+    }
+
+    // ── Release svc-a + svc-b done at T0+5 s.
+    clock.advance(4_000);
+    for (const slug of ["svc-a", "svc-b"] as const) {
+      const handle = leases.get(slug);
+      if (!handle) throw new Error(`no lease recorded for ${slug}`);
+      const row = store.find((r) => r.id === handle.jobId);
+      if (!row) throw new Error(`no row for ${slug}`);
+      await queue.report({
+        jobId: handle.jobId,
+        workerId: "worker-1",
+        result: greenResult(handle.jobId, row.payload, "worker-1", iso(5_000)),
+      });
+    }
+    // Hook contract: terminal release stamps finished_at.
+    const doneRows = store.filter((r) => r.status === "done");
+    expect(doneRows).toHaveLength(2);
+    for (const row of doneRows) {
+      expect(row.finished_at).toBe(iso(5_000));
+    }
+
+    // ── Let svc-c's lease (expires T0+31 s) lapse; sweep at T0+45 s.
+    clock.advance(40_000);
+    const sweep = await queue.sweepExpired(clock.now());
+    expect(sweep.reclaimed).toBe(1);
+    expect(sweep.commErrors).toHaveLength(1);
+    expect(sweep.commErrors[0].kind).toBe("worker-reclaimed-pending");
+    // Hook contract: the sweeper's pending re-queue is the SECOND reclaim
+    // choke point — reclaim_count bumps, ownership drops, finished_at stays
+    // untouched (a re-queued job has not finished), claimed_at keeps the
+    // prior claim's stamp until the NEXT winning claim restamps it.
+    const cHandle = leases.get("svc-c");
+    if (!cHandle) throw new Error("no lease recorded for svc-c");
+    const rowC = store.find((r) => r.id === cHandle.jobId);
+    if (!rowC) throw new Error("no row for svc-c");
+    expect(rowC.status).toBe("pending");
+    expect(rowC.claimed_by).toBe("");
+    expect(rowC.lease_expires_at).toBeNull();
+    expect(rowC.reclaim_count).toBe(1);
+    expect(rowC.finished_at).toBeUndefined();
+    expect(rowC.claimed_at).toBe(iso(1_000));
+
+    // ── Re-claim svc-c at T0+46 s (worker-2): a PENDING claim — claimed_at
+    // restamps (queue latency measures the LAST claim), reclaim_count must
+    // NOT bump again (this is not an expired-lease steal).
+    clock.advance(1_000);
+    const reclaimed = await queue.claimNext("worker-2", 30);
+    expect(reclaimed.claimed).toBe(true);
+    expect(reclaimed.lease?.job.id).toBe(cHandle.jobId);
+    expect(rowC.claimed_at).toBe(iso(46_000));
+    expect(rowC.reclaim_count).toBe(1);
+
+    // ── Finish svc-c at T0+55 s.
+    clock.advance(9_000);
+    await queue.report({
+      jobId: cHandle.jobId,
+      workerId: "worker-2",
+      result: greenResult(cHandle.jobId, rowC.payload, "worker-2", iso(55_000)),
+    });
+    expect(rowC.status).toBe("done");
+    expect(rowC.finished_at).toBe(iso(55_000));
+
+    // ── GET /api/runs: the d5 lastRun surfaces the whole lifecycle.
+    const res = await app.request("/api/runs");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as FamilySummaryResponse;
+    const d5 = body.families.find((f) => f.family === "d5");
+    if (!d5) throw new Error("no d5 family entry");
+    expect(d5.error).toBeUndefined();
+    expect(d5.inflight).toBeNull();
+    expect(d5.lastRun).toMatchObject({
+      runId,
+      triggered: false,
+      outcome: "completed",
+      jobs: { total: 3, done: 3, failed: 0, reclaimed: 1 },
+      enqueuedAt: iso(0),
+      finishedAt: iso(55_000),
+      durationMs: 55_000,
+      cells: { total: 3, passed: 3, failed: 0 },
+      redsIntroduced: null,
+      redsCleared: null,
+      errorSummary: null,
+      commErrorKinds: [],
+    });
+    expect(d5.lastSuccessAt).toBe(iso(55_000));
+
+    // ── GET /api/runs/d5/:runId: per-job reclaimCount + last-claim latency.
+    const dres = await app.request(`/api/runs/d5/${runId}`);
+    expect(dres.status).toBe(200);
+    const detail = (await dres.json()) as RunDetailResponse;
+    expect(detail.family).toBe("d5");
+    expect(detail.runId).toBe(runId);
+    expect(detail.jobs).toHaveLength(3);
+    const bySlug = new Map(detail.jobs.map((j) => [j.serviceSlug, j]));
+    const jobC = bySlug.get("svc-c");
+    if (!jobC) throw new Error("no svc-c job in detail");
+    expect(jobC.reclaimCount).toBe(1);
+    expect(jobC.status).toBe("done");
+    expect(jobC.claimedAt).toBe(iso(46_000));
+    // queueLatencyMs = claimed_at − created: measures the LAST claim.
+    expect(jobC.queueLatencyMs).toBe(46_000);
+    expect(jobC.finishedAt).toBe(iso(55_000));
+    expect(jobC.durationMs).toBe(9_000);
+    for (const slug of ["svc-a", "svc-b"] as const) {
+      const job = bySlug.get(slug);
+      if (!job) throw new Error(`no ${slug} job in detail`);
+      expect(job.reclaimCount).toBe(0);
+      expect(job.claimedAt).toBe(iso(1_000));
+      expect(job.queueLatencyMs).toBe(1_000);
+      expect(job.durationMs).toBe(4_000);
+    }
+    // §5.2.1 redaction posture: no raw comm-error message anywhere.
+    for (const job of detail.jobs) {
+      expect(job.commError).toBeNull();
+    }
+  });
+
+  it("increments reclaim_count on the claim CAS's expired-lease steal (the FIRST choke point)", async () => {
+    const { clock, store, claim, queue, app } = makeWorld();
+    const runId = "run-d5-002";
+
+    await queue.enqueue({
+      payload: payloadFor("svc-steal", runId, iso(0)),
+      family: "d5",
+    });
+    clock.advance(1_000);
+    const first = await queue.claimNext("worker-1", 30);
+    expect(first.claimed).toBe(true);
+    const jobId = first.lease?.job.id;
+    if (!jobId) throw new Error("no job id from first claim");
+
+    // Lease expires at T0+31 s; steal DIRECTLY via the claim CAS at T0+61 s
+    // (the CAS safety net — claimNext only lists pending, so the steal path
+    // is exercised on the claim client itself, exactly like the hook).
+    clock.advance(60_000);
+    const steal = await claim.claimJob(jobId, "worker-2", 30);
+    expect(steal.won).toBe(true);
+    const row = store.find((r) => r.id === jobId);
+    if (!row) throw new Error("no row for stolen job");
+    expect(row.reclaim_count).toBe(1);
+    expect(row.claimed_by).toBe("worker-2");
+    // claimed_at restamped by the winning steal.
+    expect(row.claimed_at).toBe(iso(61_000));
+
+    clock.advance(5_000);
+    await queue.report({
+      jobId,
+      workerId: "worker-2",
+      result: greenResult(jobId, row.payload, "worker-2", iso(66_000)),
+    });
+
+    const res = await app.request("/api/runs");
+    const body = (await res.json()) as FamilySummaryResponse;
+    const d5 = body.families.find((f) => f.family === "d5");
+    expect(d5?.lastRun?.jobs).toEqual({
+      total: 1,
+      done: 1,
+      failed: 0,
+      reclaimed: 1,
+    });
+
+    const dres = await app.request(`/api/runs/d5/${runId}`);
+    const detail = (await dres.json()) as RunDetailResponse;
+    expect(detail.jobs[0].reclaimCount).toBe(1);
+    expect(detail.jobs[0].queueLatencyMs).toBe(61_000);
+  });
+
+  it("writes empty family on rows enqueued without one — invisible to the family API", async () => {
+    const { store, queue, app } = makeWorld();
+
+    // Pre-P2 parity: an enqueue with no family stamps the column EMPTY.
+    await queue.enqueue({
+      payload: payloadFor("svc-old", "run-x", iso(0), "d6"),
+    });
+    expect(store).toHaveLength(1);
+    expect(store[0].family).toBe("");
+    expect(store[0].run_id).toBe("run-x");
+
+    const res = await app.request("/api/runs");
+    const body = (await res.json()) as FamilySummaryResponse;
+    for (const fam of body.families) {
+      expect(fam.error).toBeUndefined();
+      expect(fam.lastRun).toBeNull();
+      expect(fam.inflight).toBeNull();
+    }
+  });
+});

--- a/showcase/harness/src/fleet/worker-snapshot-wiring.test.ts
+++ b/showcase/harness/src/fleet/worker-snapshot-wiring.test.ts
@@ -77,7 +77,10 @@ function makeRecordingPb(): {
         ? created.filter((r) => filter.includes(`"${String(r.worker_id)}"`))
         : created;
       const perPage = opts?.perPage ?? scoped.length;
-      return { totalItems: scoped.length, items: scoped.slice(0, perPage) as never[] };
+      return {
+        totalItems: scoped.length,
+        items: scoped.slice(0, perPage) as never[],
+      };
     },
     async deleteByFilter() {
       return 0;

--- a/showcase/harness/src/fleet/worker/worker-loop.test.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.test.ts
@@ -212,6 +212,9 @@ function makeQueue(claims: ClaimedJob[]): RecordingQueue {
     async countPendingForFamily(): Promise<number> {
       throw new Error("countPendingForFamily not used by worker");
     },
+    async pruneAged() {
+      return { terminal: 0, zombie: 0 };
+    },
   };
 }
 

--- a/showcase/harness/src/http/fleet-runs.test.ts
+++ b/showcase/harness/src/http/fleet-runs.test.ts
@@ -1,0 +1,837 @@
+/**
+ * fleet-runs routes (T7) — §5.2/§5.2.1/§5.2.2/§5.2.3. Test names map to the
+ * spec §8 route-test bullets: shape + probeKeyPrefix echo, the reds read
+ * path, the ~5 s whole-body memo, 404, perPage clamp, composite (created,id)
+ * cursor chaining, the 3-page fetch-loop cap, short-page cursor honesty, the
+ * zero-complete-batch degenerate page, history_unavailable degradation, and
+ * the §5.2 history-route bounds (keyed memo, 30-per-10 s window, LRU cap).
+ *
+ * Gate-assigned coverage: the T5 walk-back extension (run-view.ts projectFamily
+ * multi-page lastSuccessAt) has no direct unit coverage — the multi-page
+ * walk-back test below is the assigned coverage for it.
+ */
+
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import type { ListOpts, ListResult, PbClient } from "../storage/pb-client.js";
+import type { Logger } from "../types/index.js";
+import type { JobStatus } from "../fleet/job-claim.js";
+import type { JobProducer } from "../fleet/control-plane/job-producer.js";
+import {
+  FLEET_PRODUCER_DEEP_SCHEDULE_ID,
+  FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
+  FLEET_PRODUCER_SCHEDULE_ID,
+  FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
+  type ProducerSchedule,
+} from "../fleet/control-plane/control-plane.js";
+import {
+  FLEET_FAMILIES,
+  createMemoizedFamilySummary,
+  type FamilySummaryResponse,
+  type ProbeJobRecord,
+  type RunBatch,
+  type RunViewDeps,
+} from "../fleet/control-plane/run-view.js";
+import {
+  HISTORY_MEMO_MAX_KEYS,
+  HISTORY_RATE_LIMIT_MAX,
+  createLruTtlMemo,
+  registerFleetRunsRoutes,
+  type FamilyHistoryResponse,
+  type RunDetailResponse,
+} from "./fleet-runs.js";
+
+// ───────────────────────────────────────────────────────────────────────
+// Fixtures
+// ───────────────────────────────────────────────────────────────────────
+
+const NOW_MS = Date.parse("2026-06-10T18:00:00.000Z");
+
+function iso(offsetMs: number): string {
+  return new Date(NOW_MS + offsetMs).toISOString();
+}
+
+const noopLogger: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+/** Descending id generator: earlier-generated (newer) rows sort LARGER under
+ *  the `-id` tiebreak, matching newest-first generation order. */
+let idSeq = 0;
+function nextId(): string {
+  idSeq += 1;
+  return `j-${String(1_000_000 - idSeq)}`;
+}
+
+interface RowOpts {
+  family: string;
+  runId: string;
+  status?: JobStatus;
+  created: string;
+  updated?: string;
+  enqueuedAt?: string;
+  claimedAt?: string;
+  finishedAt?: string;
+  reclaimCount?: number;
+  probeKey?: string;
+  serviceSlug?: string;
+  result?: unknown;
+  claimedBy?: string;
+  id?: string;
+}
+
+function row(opts: RowOpts): ProbeJobRecord {
+  const enqueuedAt = opts.enqueuedAt ?? opts.created;
+  const probeKey = opts.probeKey ?? `${opts.family}:langgraph-python`;
+  return {
+    id: opts.id ?? nextId(),
+    probe_key: probeKey,
+    status: opts.status ?? "done",
+    claimed_by: opts.claimedBy ?? "worker-a",
+    run_id: opts.runId,
+    family: opts.family,
+    created: opts.created,
+    updated: opts.updated ?? opts.created,
+    ...(opts.claimedAt ? { claimed_at: opts.claimedAt } : {}),
+    ...(opts.finishedAt ? { finished_at: opts.finishedAt } : {}),
+    ...(opts.reclaimCount !== undefined
+      ? { reclaim_count: opts.reclaimCount }
+      : {}),
+    ...(opts.result !== undefined ? { result: opts.result } : {}),
+    payload: {
+      probeKey,
+      serviceSlug: opts.serviceSlug ?? "langgraph-python",
+      driverKind: "e2e_d6",
+      meta: { runId: opts.runId, triggered: false, enqueuedAt },
+    },
+  };
+}
+
+/**
+ * Generate `batchCount` batches × `size` rows, NEWEST first (batch 0 is the
+ * newest). Within a batch all rows share the SAME `created` millisecond when
+ * `sameMsWithinBatch` — the tight-loop-enqueue reality the composite cursor
+ * exists for. Terminal rows get finished_at = created + 30 s.
+ */
+function batchFixture(
+  family: string,
+  batchCount: number,
+  size: number,
+  opts: {
+    sameMsWithinBatch?: boolean;
+    statusFor?: (batchIdx: number) => JobStatus;
+    batchGapMs?: number;
+    rowGapMs?: number;
+    newestMs?: number;
+  } = {},
+): ProbeJobRecord[] {
+  const batchGapMs = opts.batchGapMs ?? 3_600_000;
+  const rowGapMs = opts.rowGapMs ?? 100;
+  const newestMs = opts.newestMs ?? NOW_MS - 600_000;
+  const rows: ProbeJobRecord[] = [];
+  for (let b = 0; b < batchCount; b++) {
+    const status = opts.statusFor ? opts.statusFor(b) : "done";
+    for (let r = 0; r < size; r++) {
+      const createdMs =
+        newestMs - b * batchGapMs - (opts.sameMsWithinBatch ? 0 : r * rowGapMs);
+      const created = new Date(createdMs).toISOString();
+      rows.push(
+        row({
+          family,
+          runId: `${family}-b${b}`,
+          status,
+          created,
+          ...(status === "done" || status === "failed"
+            ? { finishedAt: new Date(createdMs + 30_000).toISOString() }
+            : {}),
+        }),
+      );
+    }
+  }
+  return rows;
+}
+
+interface FakeProbeRunRow {
+  id: string;
+  probe_id: string;
+  job_id: string;
+  started_at: string;
+  summary: Record<string, unknown> | null;
+}
+
+/**
+ * Fake PbClient honoring exactly the list() shapes the routes issue: the
+ * probe_jobs family/run_id/composite-cursor filters, the probe_runs
+ * `job_id = …` OR-join (the §5.2.1 reds read path) AND the §5.2.2 windowed
+ * `probe_id ~` form (with `page` paging), and the workers list. Everything
+ * else throws so accidental dependencies surface loudly. Records list calls
+ * and filters per collection for the memo / cap / filter-shape assertions.
+ */
+function makeFakePb(opts: {
+  jobs?: ProbeJobRecord[];
+  probeRuns?: FakeProbeRunRow[];
+  workers?: Array<Record<string, unknown>>;
+  failFamilies?: string[];
+}): { pb: PbClient; listCalls: string[]; listFilters: string[] } {
+  const jobs = [...(opts.jobs ?? [])];
+  const probeRuns = [...(opts.probeRuns ?? [])];
+  const workers = [...(opts.workers ?? [])];
+  const failFamilies = new Set(opts.failFamilies ?? []);
+  const listCalls: string[] = [];
+  const listFilters: string[] = [];
+  const unsupported = (name: string) => () => {
+    throw new Error(`fake-pb: ${name} not implemented`);
+  };
+  const pb: PbClient = {
+    async list<T>(
+      collection: string,
+      listOpts: ListOpts = {},
+    ): Promise<ListResult<T>> {
+      listCalls.push(collection);
+      const filter = listOpts.filter ?? "";
+      listFilters.push(`${collection}|${filter}`);
+      let items: unknown[];
+      if (collection === "probe_jobs") {
+        const fam = /family = "([^"]+)"/.exec(filter)?.[1];
+        if (fam !== undefined && failFamilies.has(fam)) {
+          throw new Error(`fake-pb: simulated outage for family ${fam}`);
+        }
+        let rows = jobs.filter((r) => r.family === fam);
+        const runId = /run_id = "([^"]+)"/.exec(filter)?.[1];
+        if (runId !== undefined) {
+          rows = rows.filter((r) => r.run_id === runId);
+        }
+        const before = /created [<=]+ "([^"]+)"/.exec(filter)?.[1];
+        const beforeId = /id < "([^"]+)"/.exec(filter)?.[1];
+        if (before !== undefined) {
+          rows = rows.filter(
+            (r) =>
+              r.created < before ||
+              (beforeId !== undefined &&
+                r.created === before &&
+                r.id < beforeId),
+          );
+        }
+        rows = [...rows].sort((a, b) =>
+          a.created === b.created
+            ? b.id.localeCompare(a.id)
+            : b.created.localeCompare(a.created),
+        );
+        items = rows.slice(0, listOpts.perPage ?? rows.length);
+      } else if (collection === "probe_runs") {
+        if (filter.includes('job_id = "')) {
+          // §5.2.1 reds read path: OR-join on the batch's job ids.
+          const ids = new Set(
+            [...filter.matchAll(/job_id = "([^"]+)"/g)].map((m) => m[1]),
+          );
+          items = probeRuns.filter((r) => ids.has(r.job_id));
+        } else {
+          // §5.2.2 windowed family-scoped list.
+          const prefixRaw = /probe_id ~ "([^"]+)"/.exec(filter)?.[1] ?? "";
+          const prefix = prefixRaw.endsWith("%")
+            ? prefixRaw.slice(0, -1)
+            : prefixRaw;
+          const gte = /started_at >= "([^"]+)"/.exec(filter)?.[1];
+          const lte = /started_at <= "([^"]+)"/.exec(filter)?.[1];
+          let rows = probeRuns.filter(
+            (r) => r.probe_id.startsWith(prefix) && r.job_id !== "",
+          );
+          if (gte !== undefined) {
+            rows = rows.filter(
+              (r) => Date.parse(r.started_at) >= Date.parse(gte),
+            );
+          }
+          if (lte !== undefined) {
+            rows = rows.filter(
+              (r) => Date.parse(r.started_at) <= Date.parse(lte),
+            );
+          }
+          rows = [...rows].sort((a, b) =>
+            b.started_at.localeCompare(a.started_at),
+          );
+          const page = listOpts.page ?? 1;
+          const perPage = listOpts.perPage ?? rows.length;
+          items = rows.slice((page - 1) * perPage, page * perPage);
+        }
+      } else if (collection === "workers") {
+        items = workers;
+      } else {
+        throw new Error(`fake-pb: unexpected collection ${collection}`);
+      }
+      return {
+        page: listOpts.page ?? 1,
+        perPage: listOpts.perPage ?? items.length,
+        totalPages: 1,
+        totalItems: items.length,
+        items: items as T[],
+      };
+    },
+    getOne: unsupported("getOne") as PbClient["getOne"],
+    getFirst: unsupported("getFirst") as PbClient["getFirst"],
+    create: unsupported("create") as PbClient["create"],
+    update: unsupported("update") as PbClient["update"],
+    upsertByField: unsupported("upsertByField") as PbClient["upsertByField"],
+    delete: unsupported("delete") as PbClient["delete"],
+    deleteByFilter: unsupported("deleteByFilter") as PbClient["deleteByFilter"],
+    health: unsupported("health") as PbClient["health"],
+    createBackup: unsupported("createBackup") as PbClient["createBackup"],
+    downloadBackup: unsupported("downloadBackup") as PbClient["downloadBackup"],
+    deleteBackup: unsupported("deleteBackup") as PbClient["deleteBackup"],
+  };
+  return { pb, listCalls, listFilters };
+}
+
+/** A producer stub for ProducerSchedule entries (never ticked here). */
+function stubProducer(): JobProducer {
+  return {
+    start: () => {},
+    stop: async () => {},
+    tick: async () => {
+      throw new Error("stub producer must not tick in fleet-runs tests");
+    },
+    isRunning: () => false,
+  };
+}
+
+/** Manual four-schedule manifest (ids from control-plane, crons arbitrary). */
+function makeSchedules(): readonly ProducerSchedule[] {
+  return [
+    {
+      scheduleId: FLEET_PRODUCER_SCHEDULE_ID,
+      cron: "40 * * * *",
+      producer: stubProducer(),
+    },
+    {
+      scheduleId: FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
+      cron: "5,20,35,50 * * * *",
+      producer: stubProducer(),
+    },
+    {
+      scheduleId: FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
+      cron: "10 * * * *",
+      producer: stubProducer(),
+    },
+    {
+      scheduleId: FLEET_PRODUCER_DEEP_SCHEDULE_ID,
+      cron: "15,30,45,0 * * * *",
+      producer: stubProducer(),
+    },
+  ];
+}
+
+function makeApp(opts: { pb: PbClient; now?: () => number }): Hono {
+  const app = new Hono();
+  const now = opts.now ?? (() => NOW_MS);
+  const rv: RunViewDeps = {
+    pb: opts.pb,
+    scheduler: { nextRunAt: () => null },
+    schedules: makeSchedules(),
+    workerStaleAfterMs: 180_000,
+    logger: noopLogger,
+    now,
+  };
+  registerFleetRunsRoutes(app, {
+    summary: createMemoizedFamilySummary(rv),
+    pb: opts.pb,
+    schedules: rv.schedules,
+    scheduler: rv.scheduler,
+    workerStaleAfterMs: rv.workerStaleAfterMs,
+    logger: noopLogger,
+    now,
+  });
+  return app;
+}
+
+async function getJson<T>(
+  app: Hono,
+  path: string,
+): Promise<{ status: number; body: T; res: Response }> {
+  const res = await app.request(path);
+  return { status: res.status, body: (await res.json()) as T, res };
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// GET /api/runs
+// ───────────────────────────────────────────────────────────────────────
+
+describe("GET /api/runs", () => {
+  it("returns one entry per FLEET_FAMILIES member with probeKeyPrefix echoed", async () => {
+    const { pb } = makeFakePb({});
+    const app = makeApp({ pb });
+    const { status, body } = await getJson<FamilySummaryResponse>(
+      app,
+      "/api/runs",
+    );
+    expect(status).toBe(200);
+    expect(body.families.map((f) => f.family).sort()).toEqual(
+      [...FLEET_FAMILIES.map((f) => f.family)].sort(),
+    );
+    for (const fam of FLEET_FAMILIES) {
+      const entry = body.families.find((f) => f.family === fam.family);
+      expect(entry?.probeKeyPrefix).toBe(fam.probeKeyPrefix);
+      expect(entry?.label).toBe(fam.label);
+    }
+  });
+
+  it("serves Cache-Control: no-cache", async () => {
+    const { pb } = makeFakePb({});
+    const app = makeApp({ pb });
+    const res = await app.request("/api/runs");
+    expect(res.headers.get("Cache-Control")).toBe("no-cache");
+  });
+
+  it("two requests inside the memo TTL hit PB once; a post-TTL call recomputes", async () => {
+    const { pb, listCalls } = makeFakePb({});
+    let nowMs = NOW_MS;
+    const app = makeApp({ pb, now: () => nowMs });
+    await app.request("/api/runs");
+    const afterFirst = listCalls.length;
+    expect(afterFirst).toBeGreaterThan(0);
+    await app.request("/api/runs");
+    expect(listCalls.length).toBe(afterFirst);
+    nowMs += 6_000; // past the ~5 s TTL
+    await app.request("/api/runs");
+    expect(listCalls.length).toBeGreaterThan(afterFirst);
+  });
+
+  it("reds read path: probe_runs joined on job_id, summed server-side, null when absent", async () => {
+    const d6rows = batchFixture("d6", 1, 3);
+    const d5rows = batchFixture("d5", 1, 2);
+    const { pb } = makeFakePb({
+      jobs: [...d6rows, ...d5rows],
+      probeRuns: [
+        {
+          id: "pr-1",
+          probe_id: "d6:langgraph-python",
+          job_id: d6rows[0].id,
+          started_at: d6rows[0].created,
+          summary: { redsIntroduced: 1, redsCleared: 0 },
+        },
+        {
+          id: "pr-2",
+          probe_id: "d6:langgraph-python",
+          job_id: d6rows[1].id,
+          started_at: d6rows[1].created,
+          summary: { redsIntroduced: 2, redsCleared: 1 },
+        },
+        // d5 row carries NO reds fields (pre-P2 history) → nulls.
+        {
+          id: "pr-3",
+          probe_id: "d5:langgraph-python",
+          job_id: d5rows[0].id,
+          started_at: d5rows[0].created,
+          summary: {},
+        },
+      ],
+    });
+    const app = makeApp({ pb });
+    const { body } = await getJson<FamilySummaryResponse>(app, "/api/runs");
+    const d6 = body.families.find((f) => f.family === "d6");
+    expect(d6?.lastRun?.redsIntroduced).toBe(3);
+    expect(d6?.lastRun?.redsCleared).toBe(1);
+    const d5 = body.families.find((f) => f.family === "d5");
+    expect(d5?.lastRun?.redsIntroduced).toBeNull();
+    expect(d5?.lastRun?.redsCleared).toBeNull();
+  });
+
+  it("lastSuccessAt walk-back extends past page 1: a completed batch beyond the first 200 rows is found (gate-assigned T5 multi-page coverage)", async () => {
+    // 20 failed batches × 10 rows fill page 1 exactly (200 rows, NOT
+    // exhausted); the only completed batch sits on page 2 — the walk-back
+    // extension must fetch beyond page 1 to find it.
+    const failed = batchFixture("d6", 20, 10, {
+      statusFor: () => "failed",
+      batchGapMs: 3_600_000,
+    });
+    const completedCreatedMs = NOW_MS - 600_000 - 20 * 3_600_000;
+    const completed: ProbeJobRecord[] = [];
+    for (let r = 0; r < 10; r++) {
+      const createdMs = completedCreatedMs - r * 100;
+      completed.push(
+        row({
+          family: "d6",
+          runId: "d6-completed",
+          status: "done",
+          created: new Date(createdMs).toISOString(),
+          finishedAt: new Date(createdMs + 30_000).toISOString(),
+        }),
+      );
+    }
+    const { pb, listCalls } = makeFakePb({ jobs: [...failed, ...completed] });
+    const app = makeApp({ pb });
+    const { body } = await getJson<FamilySummaryResponse>(app, "/api/runs");
+    const d6 = body.families.find((f) => f.family === "d6");
+    const expectedFinish = new Date(completedCreatedMs + 30_000).toISOString();
+    expect(d6?.lastSuccessAt).toBe(expectedFinish);
+    // Multi-page proof: the d6 projection issued >1 probe_jobs list.
+    expect(listCalls.filter((c) => c === "probe_jobs").length).toBeGreaterThan(
+      FLEET_FAMILIES.length,
+    );
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// GET /api/runs/:family
+// ───────────────────────────────────────────────────────────────────────
+
+describe("GET /api/runs/:family", () => {
+  it("404s an unknown family", async () => {
+    const { pb } = makeFakePb({});
+    const app = makeApp({ pb });
+    const { status, body } = await getJson<{ error: string }>(
+      app,
+      "/api/runs/nope",
+    );
+    expect(status).toBe(404);
+    expect(body.error).toBe("not_found");
+  });
+
+  it("perPage clamps to [1,50], default 20", async () => {
+    const jobs = batchFixture("d6", 25, 5);
+    const build = () => makeApp({ pb: makeFakePb({ jobs }).pb });
+    const def = await getJson<FamilyHistoryResponse>(build(), "/api/runs/d6");
+    expect(def.body.perPage).toBe(20);
+    expect(def.body.runs).toHaveLength(20);
+    const high = await getJson<FamilyHistoryResponse>(
+      build(),
+      "/api/runs/d6?perPage=999",
+    );
+    expect(high.body.perPage).toBe(50);
+    expect(high.body.runs).toHaveLength(25);
+    const low = await getJson<FamilyHistoryResponse>(
+      build(),
+      "/api/runs/d6?perPage=0",
+    );
+    expect(low.body.perPage).toBe(1);
+    expect(low.body.runs).toHaveLength(1);
+    const junk = await getJson<FamilyHistoryResponse>(
+      build(),
+      "/api/runs/d6?perPage=abc",
+    );
+    expect(junk.body.perPage).toBe(20);
+  });
+
+  it("composite cursor: same-millisecond sibling rows are neither skipped nor duplicated across a page boundary", async () => {
+    // 16 batches × 13 rows where every row in a batch shares ONE created
+    // millisecond (tight-loop enqueue). The 200-row page boundary falls
+    // mid-batch-16, so page 2 must resume among same-ms siblings via the
+    // composite (created, id) cursor — bare `created <` would skip them.
+    const jobs = batchFixture("e2e-demos", 16, 13, {
+      sameMsWithinBatch: true,
+    });
+    const { pb } = makeFakePb({ jobs });
+    const app = makeApp({ pb });
+    const { body } = await getJson<FamilyHistoryResponse>(
+      app,
+      "/api/runs/e2e-demos?perPage=50",
+    );
+    expect(body.runs).toHaveLength(16);
+    for (const run of body.runs) {
+      expect(run.jobs.total).toBe(13); // no skip, no dup
+    }
+    expect(body.nextBefore).toBeNull();
+    expect(body.nextBeforeId).toBeNull();
+  });
+
+  it("fetch loop stops at 3 PB pages (600 rows)", async () => {
+    // 14 batches × 50 rows = 700 rows; every page is a full 200, so the
+    // loop must stop on the hard cap, never the short-page break.
+    const jobs = batchFixture("d6", 14, 50);
+    const { pb, listCalls } = makeFakePb({ jobs });
+    const app = makeApp({ pb });
+    const { body } = await getJson<FamilyHistoryResponse>(app, "/api/runs/d6");
+    expect(listCalls.filter((c) => c === "probe_jobs")).toHaveLength(3);
+    // 600 rows = 12 groups; oldest discarded as potentially truncated.
+    expect(body.runs).toHaveLength(11);
+  });
+
+  it("a short page carries a non-null advancing cursor (clients must not infer end-of-history)", async () => {
+    const jobs = batchFixture("d6", 14, 50);
+    const { pb } = makeFakePb({ jobs });
+    const app = makeApp({ pb });
+    const { body } = await getJson<FamilyHistoryResponse>(app, "/api/runs/d6");
+    // 11 < perPage 20 — short page, but history is NOT exhausted.
+    expect(body.runs.length).toBeLessThan(20);
+    expect(body.nextBefore).not.toBeNull();
+    expect(body.nextBeforeId).not.toBeNull();
+  });
+
+  it("zero-complete-batch page returns the partial batch flagged truncated:true with its runId and a non-null cursor strictly older than the supplied one", async () => {
+    // One pathological 650-row batch: 3 capped pages never complete it.
+    const jobs: ProbeJobRecord[] = [];
+    for (let r = 0; r < 650; r++) {
+      const createdMs = NOW_MS - 600_000 - r * 50;
+      jobs.push(
+        row({
+          family: "d6",
+          runId: "d6-huge",
+          status: "done",
+          created: new Date(createdMs).toISOString(),
+          finishedAt: new Date(createdMs + 30_000).toISOString(),
+        }),
+      );
+    }
+    const { pb } = makeFakePb({ jobs });
+    const app = makeApp({ pb });
+    const before = iso(0); // strictly newer than every row
+    const { status, body } = await getJson<FamilyHistoryResponse>(
+      app,
+      `/api/runs/d6?before=${encodeURIComponent(before)}`,
+    );
+    expect(status).toBe(200);
+    expect(body.runs).toHaveLength(1);
+    const partial = body.runs[0];
+    expect(partial.truncated).toBe(true);
+    expect(partial.runId).toBe("d6-huge");
+    expect(partial.jobs.total).toBe(600); // fetched rows only (honest-partial)
+    expect(partial.redsIntroduced).toBeNull();
+    expect(partial.redsCleared).toBeNull();
+    expect(body.nextBefore).not.toBeNull();
+    expect(body.nextBeforeId).not.toBeNull();
+    expect(Date.parse(body.nextBefore as string)).toBeLessThan(
+      Date.parse(before),
+    );
+  });
+
+  it("nextBefore/nextBeforeId are null only when history exhausted and every batch returned", async () => {
+    const jobs = batchFixture("d6", 3, 5);
+    const all = await getJson<FamilyHistoryResponse>(
+      makeApp({ pb: makeFakePb({ jobs }).pb }),
+      "/api/runs/d6",
+    );
+    expect(all.body.runs).toHaveLength(3);
+    expect(all.body.nextBefore).toBeNull();
+    expect(all.body.nextBeforeId).toBeNull();
+    const partial = await getJson<FamilyHistoryResponse>(
+      makeApp({ pb: makeFakePb({ jobs }).pb }),
+      "/api/runs/d6?perPage=2",
+    );
+    expect(partial.body.runs).toHaveLength(2);
+    expect(partial.body.nextBefore).not.toBeNull();
+    expect(partial.body.nextBeforeId).not.toBeNull();
+  });
+
+  it("history reds: windowed family-scoped probe_runs list (anchored probe_id prefix) joined per batch; batches without summed rows report null", async () => {
+    const jobs = batchFixture("d6", 2, 3);
+    const newest = jobs.slice(0, 3);
+    const { pb, listFilters } = makeFakePb({
+      jobs,
+      probeRuns: [
+        {
+          id: "pr-1",
+          probe_id: "d6:langgraph-python",
+          job_id: newest[0].id,
+          started_at: newest[0].created,
+          summary: { redsIntroduced: 2, redsCleared: 1 },
+        },
+      ],
+    });
+    const app = makeApp({ pb });
+    const { body } = await getJson<FamilyHistoryResponse>(app, "/api/runs/d6");
+    expect(body.runs).toHaveLength(2);
+    expect(body.runs[0].redsIntroduced).toBe(2);
+    expect(body.runs[0].redsCleared).toBe(1);
+    expect(body.runs[1].redsIntroduced).toBeNull();
+    expect(body.runs[1].redsCleared).toBeNull();
+    const windowed = listFilters.find(
+      (f) => f.startsWith("probe_runs|") && f.includes("~"),
+    );
+    expect(windowed).toContain('probe_id ~ "d6:%"');
+    expect(windowed).toContain('job_id != ""');
+  });
+
+  it("same-key /api/runs/:family requests inside the TTL hit PB once", async () => {
+    const { pb, listCalls } = makeFakePb({ jobs: batchFixture("d6", 2, 2) });
+    const app = makeApp({ pb });
+    await app.request("/api/runs/d6");
+    const afterFirst = listCalls.length;
+    await app.request("/api/runs/d6");
+    expect(listCalls.length).toBe(afterFirst);
+  });
+
+  it("distinct before cursors miss the memo and trip the 30-per-10s window into 429 with Retry-After", async () => {
+    const { pb } = makeFakePb({});
+    const app = makeApp({ pb });
+    for (let i = 0; i < HISTORY_RATE_LIMIT_MAX; i++) {
+      const res = await app.request(
+        `/api/runs/d6?before=${encodeURIComponent(iso(-(i + 1) * 1000))}`,
+      );
+      expect(res.status).toBe(200);
+    }
+    const res = await app.request(
+      `/api/runs/d6?before=${encodeURIComponent(iso(-999_000))}`,
+    );
+    expect(res.status).toBe(429);
+    const retryAfter = res.headers.get("Retry-After");
+    expect(retryAfter).not.toBeNull();
+    expect(Number.parseInt(retryAfter as string, 10)).toBeGreaterThanOrEqual(1);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("rate_limited");
+  });
+
+  it('a PB outage yields {error:"history_unavailable"} (HTTP 200), not a 500', async () => {
+    const { pb } = makeFakePb({ failFamilies: ["d6"] });
+    const app = makeApp({ pb });
+    const { status, body } = await getJson<{
+      family: string;
+      error: string;
+    }>(app, "/api/runs/d6");
+    expect(status).toBe(200);
+    expect(body.error).toBe("history_unavailable");
+    expect(body.family).toBe("d6");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// GET /api/runs/:family/:runId
+// ───────────────────────────────────────────────────────────────────────
+
+describe("GET /api/runs/:family/:runId", () => {
+  function detailFixture(): ProbeJobRecord[] {
+    const createdMs = NOW_MS - 600_000;
+    const created = new Date(createdMs).toISOString();
+    return [
+      row({
+        family: "d5",
+        runId: "run-detail",
+        status: "failed",
+        probeKey: "d5-single-pill-e2e:agno",
+        serviceSlug: "agno",
+        created,
+        claimedAt: new Date(createdMs + 4_100).toISOString(),
+        finishedAt: new Date(createdMs + 196_444).toISOString(),
+        reclaimCount: 1,
+        result: {
+          rollup: { total: 8, passed: 6, failed: 2 },
+          commError: {
+            kind: "worker-crashed-mid-job",
+            message: "SECRET-internal-host:8080 exploded",
+            observedAt: new Date(createdMs + 196_000).toISOString(),
+          },
+        },
+      }),
+      row({
+        family: "d5",
+        runId: "run-detail",
+        status: "failed",
+        probeKey: "d5-single-pill-e2e:llamaindex",
+        serviceSlug: "llamaindex",
+        created: new Date(createdMs - 100).toISOString(),
+        claimedAt: new Date(createdMs + 2_000).toISOString(),
+        finishedAt: new Date(createdMs + 90_000).toISOString(),
+        result: {
+          commError: {
+            kind: "not-a-real-kind",
+            message: "ANOTHER-SECRET detail",
+          },
+        },
+      }),
+    ];
+  }
+
+  it("returns the per-job shape; commError.message never serialized; queueLatencyMs/durationMs/reclaimCount present", async () => {
+    const { pb } = makeFakePb({ jobs: detailFixture() });
+    const app = makeApp({ pb });
+    const res = await app.request("/api/runs/d5/run-detail");
+    expect(res.status).toBe(200);
+    const raw = await res.text();
+    expect(raw).not.toContain("SECRET");
+    const body = JSON.parse(raw) as RunDetailResponse;
+    expect(body.family).toBe("d5");
+    expect(body.runId).toBe("run-detail");
+    expect(body.jobs).toHaveLength(2);
+    const agno = body.jobs.find((j) => j.serviceSlug === "agno");
+    expect(agno?.probeKey).toBe("d5-single-pill-e2e:agno");
+    expect(agno?.status).toBe("failed");
+    expect(agno?.claimedBy).toBe("worker-a");
+    expect(agno?.queueLatencyMs).toBe(4_100);
+    expect(agno?.durationMs).toBe(196_444 - 4_100);
+    expect(agno?.reclaimCount).toBe(1);
+    expect(agno?.cells).toEqual({ total: 8, passed: 6, failed: 2 });
+    expect(agno?.commError?.kind).toBe("worker-crashed-mid-job");
+    // Unrecognized kinds map to "unknown" (closed vocabulary).
+    const llama = body.jobs.find((j) => j.serviceSlug === "llamaindex");
+    expect(llama?.commError?.kind).toBe("unknown");
+    expect(llama?.reclaimCount).toBe(0);
+  });
+
+  it("404s an unknown family and an unknown runId", async () => {
+    const { pb } = makeFakePb({ jobs: detailFixture() });
+    const app = makeApp({ pb });
+    expect((await app.request("/api/runs/nope/run-detail")).status).toBe(404);
+    expect((await app.request("/api/runs/d5/run-unknown")).status).toBe(404);
+  });
+
+  it("a PB outage yields history_unavailable (HTTP 200), not a 500", async () => {
+    const { pb } = makeFakePb({ failFamilies: ["d5"] });
+    const app = makeApp({ pb });
+    const { status, body } = await getJson<{ error: string }>(
+      app,
+      "/api/runs/d5/run-x",
+    );
+    expect(status).toBe(200);
+    expect(body.error).toBe("history_unavailable");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// Keyed-memo LRU bound (§5.2 history-route bounds)
+// ───────────────────────────────────────────────────────────────────────
+
+describe("createLruTtlMemo", () => {
+  it("keyed-memo LRU holds under >64 distinct keys (no unbounded growth)", async () => {
+    const computes: string[] = [];
+    const memo = createLruTtlMemo<number>({
+      ttlMs: 60_000,
+      maxKeys: HISTORY_MEMO_MAX_KEYS,
+      now: () => 0,
+    });
+    for (let i = 0; i < HISTORY_MEMO_MAX_KEYS + 6; i++) {
+      await memo.get(`k${i}`, async () => {
+        computes.push(`k${i}`);
+        return i;
+      });
+    }
+    expect(memo.size()).toBe(HISTORY_MEMO_MAX_KEYS);
+    // The oldest keys were evicted: k0 recomputes…
+    await memo.get("k0", async () => {
+      computes.push("k0-again");
+      return -1;
+    });
+    expect(computes).toContain("k0-again");
+    // …while a recent key is still a hit.
+    const last = `k${HISTORY_MEMO_MAX_KEYS + 5}`;
+    const hit = await memo.get(last, async () => {
+      computes.push(`${last}-again`);
+      return -2;
+    });
+    expect(hit).toBe(HISTORY_MEMO_MAX_KEYS + 5);
+    expect(computes).not.toContain(`${last}-again`);
+  });
+
+  it("refreshes recency on hit and evicts rejected computations", async () => {
+    const memo = createLruTtlMemo<number>({
+      ttlMs: 60_000,
+      maxKeys: 2,
+      now: () => 0,
+    });
+    await memo.get("a", async () => 1);
+    await memo.get("b", async () => 2);
+    await memo.get("a", async () => 99); // hit — refreshes a's recency
+    await memo.get("c", async () => 3); // evicts b (LRU), not a
+    const a = await memo.get("a", async () => -1);
+    expect(a).toBe(1);
+    const b = await memo.get("b", async () => 42); // b was evicted
+    expect(b).toBe(42);
+    // Rejections are evicted so the next call retries.
+    await expect(
+      memo.get("z", async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    const z = await memo.get("z", async () => 7);
+    expect(z).toBe(7);
+  });
+});

--- a/showcase/harness/src/http/fleet-runs.ts
+++ b/showcase/harness/src/http/fleet-runs.ts
@@ -1,0 +1,664 @@
+/**
+ * Fleet-runs routes (§5.2) — the three unauthenticated worker-run GETs the
+ * dashboard Ops tab consumes through the /api/ops proxy:
+ *
+ *   - GET /api/runs                    — §5.2.1 family summary (shared memo)
+ *   - GET /api/runs/:family            — §5.2.2 cursor-paged run history
+ *   - GET /api/runs/:family/:runId     — §5.2.3 per-service drill-down
+ *
+ * Mounted UNCONDITIONALLY on the CP role by `buildServer` (the §5.2 pinned
+ * divergence from /api/probes): there is NO mutating route here, so nothing
+ * for a token to protect — read telemetry must never be hidden by a missing
+ * `OPS_TRIGGER_TOKEN` env. If a trigger POST ever lands (open question #3),
+ * the POST alone gets the bearer gate.
+ *
+ * Abuse posture (§5.2): `/api/runs` is served from the injected SHARED
+ * whole-body memo (`createMemoizedFamilySummary` — the same instance the §9
+ * family-silence monitor reads). The history routes get ROUTE-LOCAL bounds —
+ * a keyed ~10 s-TTL LRU memo plus a fixed 30-per-10 s rate-limit window
+ * shared across both — because the `?before` cursor is attacker-controlled,
+ * so the whole-body memo cannot close their amplification.
+ */
+
+import type { Hono } from "hono";
+import type { Logger } from "../types/index.js";
+import type { Scheduler } from "../scheduler/scheduler.js";
+import type { PbClient } from "../storage/pb-client.js";
+import type { JobStatus } from "../fleet/job-claim.js";
+import { isPoolCommErrorKind } from "../fleet/contracts.js";
+import { PROBE_JOBS_COLLECTION } from "../fleet/queue-client.js";
+import { PROBE_RUNS_COLLECTION } from "../probes/run-history.js";
+import type { ProducerSchedule } from "../fleet/control-plane/control-plane.js";
+import {
+  FLEET_FAMILIES,
+  RUN_FETCH_MAX_PAGES,
+  RUN_FETCH_PAGE_SIZE,
+  buildErrorSummary,
+  fetchFamilyJobRows,
+  groupBatches,
+  projectRunBatch,
+  type FamilyJobCursor,
+  type FleetFamily,
+  type MemoizedFamilySummary,
+  type ProbeJobRecord,
+  type RunBatch,
+  type RunBatchRows,
+  type RunViewDeps,
+} from "../fleet/control-plane/run-view.js";
+
+// ───────────────────────────────────────────────────────────────────────
+// Bounds (§5.2) — exported so tests pin the contract values
+// ───────────────────────────────────────────────────────────────────────
+
+/** §5.2.2 perPage clamp: [1, 50], default 20 (run BATCHES, not jobs). */
+export const HISTORY_DEFAULT_PER_PAGE = 20;
+export const HISTORY_MAX_PER_PAGE = 50;
+/** §5.2 bound (a): per-(family,before,beforeId,perPage) keyed memo. */
+export const HISTORY_MEMO_TTL_MS = 10_000;
+export const HISTORY_MEMO_MAX_KEYS = 64;
+/** §5.2 bound (b): fixed window shared across BOTH history routes. */
+export const HISTORY_RATE_LIMIT_MAX = 30;
+export const HISTORY_RATE_LIMIT_WINDOW_MS = 10_000;
+
+// ───────────────────────────────────────────────────────────────────────
+// Deps
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * Wired by `buildServer` from the orchestrator (T8). `summary` is the
+ * injected SHARED memo instance (§5.2 — the same one the §9 monitor gets),
+ * so "the monitor shares the route's memo" is true by construction.
+ */
+export interface FleetRunsRouteDeps {
+  summary: MemoizedFamilySummary;
+  pb: PbClient;
+  /** The buildProducerSchedules output — the resolved-cron source (§5.1). */
+  schedules: readonly ProducerSchedule[];
+  scheduler: Pick<Scheduler, "nextRunAt">;
+  /** Boot-resolved heartbeat window — never the DEFAULT_ constant (§5.2). */
+  workerStaleAfterMs: number;
+  logger: Logger;
+  now?: () => number;
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Response DTOs
+// ───────────────────────────────────────────────────────────────────────
+
+/** GET /api/runs/:family body (§5.2.2). */
+export interface FamilyHistoryResponse {
+  family: string;
+  runs: RunBatch[];
+  perPage: number;
+  /** Composite (created, id) cursor of the oldest job in the oldest RETURNED
+   *  batch; null ONLY when history exhausted and every batch returned. */
+  nextBefore: string | null;
+  nextBeforeId: string | null;
+}
+
+/** One §5.2.3 per-job entry. Redaction per §5.2.1: closed-vocabulary only —
+ *  `commError.message` is NEVER serialized on these unauthenticated GETs. */
+export interface RunJobView {
+  jobId: string;
+  probeKey: string;
+  serviceSlug: string;
+  status: JobStatus;
+  claimedBy: string | null;
+  enqueuedAt: string;
+  claimedAt: string | null;
+  finishedAt: string | null;
+  /** claimed_at − created — measures the LAST claim for reclaimed jobs
+   *  (§5.2.1 corollary: claimed_at restamps on every re-claim). */
+  queueLatencyMs: number | null;
+  /** finished_at − claimed_at; null while either side is absent. */
+  durationMs: number | null;
+  /** The §4.2 hook counter, surfaced directly. */
+  reclaimCount: number;
+  cells: { total: number; passed: number; failed: number } | null;
+  errorSummary: string | null;
+  commError: { kind: string; observedAt: string | null } | null;
+}
+
+/** GET /api/runs/:family/:runId body (§5.2.3). */
+export interface RunDetailResponse {
+  family: string;
+  runId: string;
+  jobs: RunJobView[];
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Keyed LRU+TTL memo (§5.2 bound (a)) — exported for direct bound tests
+// ───────────────────────────────────────────────────────────────────────
+
+export interface LruTtlMemo<V> {
+  get(key: string, compute: () => Promise<V>): Promise<V>;
+  size(): number;
+}
+
+/**
+ * Keyed memo with TTL + LRU cap: serves the legitimate hot path for free
+ * (one shared key per family for the cursor-less default request) without
+ * unbounded key growth under cursor abuse. Hits refresh recency; rejected
+ * computations are evicted so the next call retries instead of pinning a
+ * failure for the TTL.
+ */
+export function createLruTtlMemo<V>(opts: {
+  ttlMs: number;
+  maxKeys: number;
+  now: () => number;
+}): LruTtlMemo<V> {
+  const entries = new Map<string, { atMs: number; value: Promise<V> }>();
+  return {
+    get(key: string, compute: () => Promise<V>): Promise<V> {
+      const t = opts.now();
+      const hit = entries.get(key);
+      if (hit && t - hit.atMs < opts.ttlMs) {
+        // Refresh recency: Map iteration order is insertion order.
+        entries.delete(key);
+        entries.set(key, hit);
+        return hit.value;
+      }
+      const entry = { atMs: t, value: compute() };
+      entries.delete(key);
+      entries.set(key, entry);
+      entry.value.catch(() => {
+        if (entries.get(key) === entry) entries.delete(key);
+      });
+      while (entries.size > opts.maxKeys) {
+        const oldest = entries.keys().next().value;
+        /* v8 ignore next — size > 0 guarantees a key */
+        if (oldest === undefined) break;
+        entries.delete(oldest);
+      }
+      return entry.value;
+    },
+    size(): number {
+      return entries.size;
+    },
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Local row-parsing helpers (the per-job §5.2.3 projection)
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * Anchored PB space→"T" date-separator rewrite — byte-for-byte the same
+ * anchor as run-view/queue-client, so only the canonical date/time boundary
+ * is converted, never an arbitrary first space.
+ */
+const PB_DATE_SEP_RE = /^(\d{4}-\d{2}-\d{2}) /;
+
+function parsePbDate(value: string | null | undefined): number {
+  if (!value) return Number.NaN;
+  return Date.parse(String(value).replace(PB_DATE_SEP_RE, "$1T"));
+}
+
+function toIsoOrNull(ms: number): string | null {
+  return Number.isNaN(ms) ? null : new Date(ms).toISOString();
+}
+
+/** Defensive view of a row's untrusted `payload`/`result` JSON columns. */
+function payloadView(row: ProbeJobRecord): {
+  serviceSlug: string | undefined;
+  enqueuedAt: string | undefined;
+} {
+  const payload = row.payload;
+  if (payload === null || typeof payload !== "object") {
+    return { serviceSlug: undefined, enqueuedAt: undefined };
+  }
+  const slug = (payload as { serviceSlug?: unknown }).serviceSlug;
+  const meta = (payload as { meta?: unknown }).meta;
+  let enqueuedAt: string | undefined;
+  if (meta !== null && typeof meta === "object" && !Array.isArray(meta)) {
+    const v = (meta as { enqueuedAt?: unknown }).enqueuedAt;
+    if (typeof v === "string") enqueuedAt = v;
+  }
+  return {
+    serviceSlug: typeof slug === "string" ? slug : undefined,
+    enqueuedAt,
+  };
+}
+
+function resultView(row: ProbeJobRecord): {
+  cells: { total: number; passed: number; failed: number } | null;
+  commError: { kind: string; observedAt: string | null } | null;
+} {
+  const result = row.result;
+  if (result === null || typeof result !== "object") {
+    return { cells: null, commError: null };
+  }
+  const candidate = result as { rollup?: unknown; commError?: unknown };
+  let cells: { total: number; passed: number; failed: number } | null = null;
+  if (candidate.rollup !== null && typeof candidate.rollup === "object") {
+    const r = candidate.rollup as {
+      total?: unknown;
+      passed?: unknown;
+      failed?: unknown;
+    };
+    if (
+      typeof r.total === "number" &&
+      typeof r.passed === "number" &&
+      typeof r.failed === "number"
+    ) {
+      cells = { total: r.total, passed: r.passed, failed: r.failed };
+    }
+  }
+  let commError: { kind: string; observedAt: string | null } | null = null;
+  if (candidate.commError !== null && typeof candidate.commError === "object") {
+    const ce = candidate.commError as { kind?: unknown; observedAt?: unknown };
+    if (typeof ce.kind === "string") {
+      // §5.2.1 redaction: enum-validated kind only (else "unknown") +
+      // timestamp — `message` deliberately never read past this point.
+      commError = {
+        kind: isPoolCommErrorKind(ce.kind) ? ce.kind : "unknown",
+        observedAt: typeof ce.observedAt === "string" ? ce.observedAt : null,
+      };
+    }
+  }
+  return { cells, commError };
+}
+
+/** Project one probe_jobs row into the §5.2.3 per-job shape. */
+function projectJob(row: ProbeJobRecord): RunJobView {
+  const { serviceSlug, enqueuedAt } = payloadView(row);
+  const { cells, commError } = resultView(row);
+  const createdMs = parsePbDate(row.created);
+  const claimedMs = parsePbDate(row.claimed_at);
+  const finishedMs = parsePbDate(row.finished_at);
+  // enqueuedAt sourcing per §5.2.1: payload.meta.enqueuedAt, falling back to
+  // the row's `created` column when absent/unparseable.
+  const enqueuedMs = parsePbDate(enqueuedAt);
+  const enqueuedIso =
+    toIsoOrNull(Number.isNaN(enqueuedMs) ? createdMs : enqueuedMs) ??
+    row.created;
+  const colonIdx = row.probe_key.indexOf(":");
+  return {
+    jobId: row.id,
+    probeKey: row.probe_key,
+    serviceSlug:
+      serviceSlug ?? (colonIdx >= 0 ? row.probe_key.slice(colonIdx + 1) : ""),
+    status: row.status,
+    claimedBy: row.claimed_by !== "" ? row.claimed_by : null,
+    enqueuedAt: enqueuedIso,
+    claimedAt: toIsoOrNull(claimedMs),
+    finishedAt: toIsoOrNull(finishedMs),
+    queueLatencyMs:
+      Number.isNaN(claimedMs) || Number.isNaN(createdMs)
+        ? null
+        : claimedMs - createdMs,
+    durationMs:
+      Number.isNaN(finishedMs) || Number.isNaN(claimedMs)
+        ? null
+        : finishedMs - claimedMs,
+    reclaimCount: row.reclaim_count ?? 0,
+    cells,
+    // Single-row reuse of the §5.2.1 closed-vocabulary composer.
+    errorSummary: buildErrorSummary({
+      runId: row.run_id ?? row.id,
+      rows: [row],
+    }),
+    commError,
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// History page computation (§5.2.2)
+// ───────────────────────────────────────────────────────────────────────
+
+interface ProbeRunRedsRow {
+  id: string;
+  job_id?: string;
+  started_at?: string;
+  summary?: { redsIntroduced?: unknown; redsCleared?: unknown } | null;
+}
+
+/**
+ * §5.2.2 windowed reds: ONE family-scoped probe_runs list per page —
+ * `probe_id ~ "<prefix>:%"` (explicit trailing % so PB runs an anchored
+ * prefix LIKE, never a contains scan), `job_id != ""`, started_at bounded by
+ * the returned batches' window, `-started_at`, ≤3 pages — joined in-process
+ * on job_id ∈ the returned batches' job ids and summed per batch. The
+ * `-started_at` sort means a biting cap lands the `null` honest-unknowns on
+ * the OLDEST batches of the page; a batch whose rows fall beyond the cap
+ * reports null for both counters (same honest-unknown as pre-P2 rows).
+ */
+async function joinWindowedReds(
+  deps: FleetRunsRouteDeps,
+  fam: FleetFamily,
+  returned: readonly RunBatchRows[],
+  runs: RunBatch[],
+  nowMs: number,
+): Promise<void> {
+  if (runs.length === 0) return;
+  const oldestEnqueued = runs[runs.length - 1].enqueuedAt;
+  const newestFinish = runs[0].finishedAt ?? new Date(nowMs).toISOString();
+  const filter = [
+    `probe_id ~ ${JSON.stringify(`${fam.probeKeyPrefix}:%`)}`,
+    `job_id != ""`,
+    `started_at >= ${JSON.stringify(oldestEnqueued)}`,
+    `started_at <= ${JSON.stringify(newestFinish)}`,
+  ].join(" && ");
+  const fetched: ProbeRunRedsRow[] = [];
+  let exhausted = false;
+  for (let page = 1; page <= RUN_FETCH_MAX_PAGES; page++) {
+    const result = await deps.pb.list<ProbeRunRedsRow>(PROBE_RUNS_COLLECTION, {
+      filter,
+      sort: "-started_at",
+      perPage: RUN_FETCH_PAGE_SIZE,
+      page,
+      skipTotal: true,
+    });
+    fetched.push(...result.items);
+    if (result.items.length < RUN_FETCH_PAGE_SIZE) {
+      exhausted = true;
+      break;
+    }
+  }
+  // When the cap bit, rows older than the oldest fetched started_at may be
+  // missing — batches whose window starts before it report null (honest).
+  let oldestFetchedMs = Number.NEGATIVE_INFINITY;
+  if (!exhausted && fetched.length > 0) {
+    oldestFetchedMs = parsePbDate(fetched[fetched.length - 1].started_at);
+  }
+  const byJobId = new Map<string, ProbeRunRedsRow[]>();
+  for (const row of fetched) {
+    if (!row.job_id) continue;
+    const bucket = byJobId.get(row.job_id);
+    if (bucket) bucket.push(row);
+    else byJobId.set(row.job_id, [row]);
+  }
+  for (let i = 0; i < returned.length; i++) {
+    const run = runs[i];
+    if (
+      !exhausted &&
+      !Number.isNaN(oldestFetchedMs) &&
+      parsePbDate(run.enqueuedAt) < oldestFetchedMs
+    ) {
+      continue; // beyond the cap — both counters stay null
+    }
+    let redsIntroduced: number | null = null;
+    let redsCleared: number | null = null;
+    for (const jobRow of returned[i].rows) {
+      for (const pr of byJobId.get(jobRow.id) ?? []) {
+        const summary = pr.summary;
+        if (summary === null || typeof summary !== "object") continue;
+        if (typeof summary.redsIntroduced === "number") {
+          redsIntroduced = (redsIntroduced ?? 0) + summary.redsIntroduced;
+        }
+        if (typeof summary.redsCleared === "number") {
+          redsCleared = (redsCleared ?? 0) + summary.redsCleared;
+        }
+      }
+    }
+    run.redsIntroduced = redsIntroduced;
+    run.redsCleared = redsCleared;
+  }
+}
+
+/**
+ * The §5.2.2 page algorithm: capped overfetch loop (reusing run-view's
+ * `fetchFamilyJobRows` one PB page at a time so the early-stop on
+ * ≥ perPage+1 groups can run between pages), group by run_id, discard the
+ * potentially-truncated oldest group unless history was exhausted, return
+ * the newest min(perPage, complete) batches with the composite cursor —
+ * including the zero-complete-batch degenerate page (`truncated: true`).
+ */
+async function computeHistoryPage(
+  deps: FleetRunsRouteDeps,
+  rvDeps: RunViewDeps,
+  fam: FleetFamily,
+  cursor: FamilyJobCursor | undefined,
+  perPage: number,
+  nowMs: number,
+): Promise<FamilyHistoryResponse> {
+  const rows: ProbeJobRecord[] = [];
+  let cur = cursor;
+  let exhausted = false;
+  for (let page = 0; page < RUN_FETCH_MAX_PAGES; page++) {
+    const result = await fetchFamilyJobRows(rvDeps, fam.family, cur, 1);
+    rows.push(...result.rows);
+    if (result.exhausted) {
+      exhausted = true;
+      break;
+    }
+    // Early stop: ≥ perPage+1 groups accumulated (the +1 absorbs the
+    // partial-oldest discard below).
+    if (groupBatches(rows).length >= perPage + 1) break;
+    const oldest = rows[rows.length - 1];
+    cur = { before: oldest.created, beforeId: oldest.id };
+  }
+  const groups = groupBatches(rows);
+  if (groups.length === 0) {
+    // Zero rows ⇒ the first list returned short ⇒ history exhausted.
+    return {
+      family: fam.family,
+      runs: [],
+      perPage,
+      nextBefore: null,
+      nextBeforeId: null,
+    };
+  }
+  const cursorSupplied = cursor !== undefined;
+  const complete = exhausted ? groups : groups.slice(0, -1);
+  if (complete.length === 0) {
+    // §5.2.2 degenerate clamp: a single pathological batch larger than the
+    // 600-row cap. Return the partial itself flagged truncated (honest-
+    // partial counts, reds null) so its runId stays client-discoverable for
+    // the §5.2.3 drill-down; the cursor falls back to the oldest FETCHED
+    // row — strictly composite-older than the supplied cursor, so a client
+    // can never loop on the same cursor.
+    const partial = groups[0];
+    const batch = projectRunBatch(partial, cursorSupplied);
+    batch.truncated = true;
+    const oldestRow = rows[rows.length - 1];
+    return {
+      family: fam.family,
+      runs: [batch],
+      perPage,
+      nextBefore: oldestRow.created,
+      nextBeforeId: oldestRow.id,
+    };
+  }
+  const returned = complete.slice(0, perPage);
+  // hasNewerBatch (abandonment rule (b) input): with a cursor supplied,
+  // newer batches exist by construction (the client paged past them); on
+  // the cursor-less first page only the newest group has none.
+  const runs = returned.map((group, i) =>
+    projectRunBatch(group, cursorSupplied || i > 0),
+  );
+  await joinWindowedReds(deps, fam, returned, runs, nowMs);
+  if (exhausted && returned.length === groups.length) {
+    return {
+      family: fam.family,
+      runs,
+      perPage,
+      nextBefore: null,
+      nextBeforeId: null,
+    };
+  }
+  const oldestBatch = returned[returned.length - 1];
+  const oldestJob = oldestBatch.rows[oldestBatch.rows.length - 1];
+  return {
+    family: fam.family,
+    runs,
+    perPage,
+    nextBefore: oldestJob.created,
+    nextBeforeId: oldestJob.id,
+  };
+}
+
+function clampPerPage(raw: string | undefined): number {
+  if (raw === undefined) return HISTORY_DEFAULT_PER_PAGE;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed)) return HISTORY_DEFAULT_PER_PAGE;
+  return Math.min(HISTORY_MAX_PER_PAGE, Math.max(1, parsed));
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Routes
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * Mount the three /api/runs GETs onto an existing Hono app. All responses
+ * carry `Cache-Control: no-cache` (identical posture to /api/probes — the
+ * dashboard polls these and intermediate caching would mask transitions).
+ * No mutating route; no OPS_TRIGGER_TOKEN coupling anywhere.
+ */
+export function registerFleetRunsRoutes(
+  app: Hono,
+  deps: FleetRunsRouteDeps,
+): void {
+  const now = deps.now ?? (() => Date.now());
+  const rvDeps: RunViewDeps = {
+    pb: deps.pb,
+    scheduler: deps.scheduler,
+    schedules: deps.schedules,
+    workerStaleAfterMs: deps.workerStaleAfterMs,
+    logger: deps.logger,
+    now,
+  };
+  const familyByName = new Map<string, FleetFamily>(
+    FLEET_FAMILIES.map((f) => [f.family, f]),
+  );
+  const historyMemo = createLruTtlMemo<FamilyHistoryResponse>({
+    ttlMs: HISTORY_MEMO_TTL_MS,
+    maxKeys: HISTORY_MEMO_MAX_KEYS,
+    now,
+  });
+
+  // §5.2 bound (b): fixed window pooled across all callers of BOTH history
+  // routes (they sit behind the single dashboard proxy, so per-IP
+  // attribution is meaningless anyway).
+  let windowStartMs = Number.NEGATIVE_INFINITY;
+  let windowCount = 0;
+  function consumeRateLimit():
+    | { ok: true }
+    | { ok: false; retryAfterSec: number } {
+    const t = now();
+    if (t - windowStartMs >= HISTORY_RATE_LIMIT_WINDOW_MS) {
+      windowStartMs = t;
+      windowCount = 0;
+    }
+    windowCount += 1;
+    if (windowCount > HISTORY_RATE_LIMIT_MAX) {
+      return {
+        ok: false,
+        retryAfterSec: Math.max(
+          1,
+          Math.ceil((windowStartMs + HISTORY_RATE_LIMIT_WINDOW_MS - t) / 1000),
+        ),
+      };
+    }
+    return { ok: true };
+  }
+
+  app.get("/api/runs", async (c) => {
+    c.header("Cache-Control", "no-cache");
+    try {
+      return c.json(await deps.summary.get());
+    } catch (err) {
+      // The memoized projection degrades per-family and should never
+      // reject; if it somehow does, hold the §5.2.1 HTTP-200 posture with
+      // every family marked unavailable rather than 500ing the dashboard.
+      deps.logger.warn("fleet-runs.summary-failed", { error: String(err) });
+      return c.json({
+        families: FLEET_FAMILIES.map((fam) => ({
+          family: fam.family,
+          label: fam.label,
+          probeKeyPrefix: fam.probeKeyPrefix,
+          error: "history_unavailable" as const,
+        })),
+        workers: [],
+      });
+    }
+  });
+
+  app.get("/api/runs/:family", async (c) => {
+    c.header("Cache-Control", "no-cache");
+    const fam = familyByName.get(c.req.param("family"));
+    if (!fam) {
+      return c.json({ error: "not_found" }, 404);
+    }
+    const rl = consumeRateLimit();
+    if (!rl.ok) {
+      c.header("Retry-After", String(rl.retryAfterSec));
+      return c.json({ error: "rate_limited" }, 429);
+    }
+    const perPage = clampPerPage(c.req.query("perPage"));
+    const before = c.req.query("before");
+    const beforeId = c.req.query("beforeId");
+    // Bare `before` degrades to a plain `created <` cursor inside
+    // fetchFamilyJobRows (§5.2.2 legacy/manual-curl posture); the dashboard
+    // always echoes both fields.
+    const cursor: FamilyJobCursor | undefined = before
+      ? { before, ...(beforeId ? { beforeId } : {}) }
+      : undefined;
+    const key = JSON.stringify([
+      fam.family,
+      before ?? "",
+      beforeId ?? "",
+      perPage,
+    ]);
+    try {
+      return c.json(
+        await historyMemo.get(key, () =>
+          computeHistoryPage(deps, rvDeps, fam, cursor, perPage, now()),
+        ),
+      );
+    } catch (err) {
+      // §5.2.1-anchored graceful degradation (applies to all three routes):
+      // a PB outage yields history_unavailable at HTTP 200, never a 500 —
+      // the dashboard treats it as the same incident class as a failed poll.
+      deps.logger.warn("fleet-runs.history-failed", {
+        family: fam.family,
+        error: String(err),
+      });
+      return c.json({ family: fam.family, error: "history_unavailable" });
+    }
+  });
+
+  app.get("/api/runs/:family/:runId", async (c) => {
+    c.header("Cache-Control", "no-cache");
+    const fam = familyByName.get(c.req.param("family"));
+    if (!fam) {
+      return c.json({ error: "not_found" }, 404);
+    }
+    const rl = consumeRateLimit();
+    if (!rl.ok) {
+      c.header("Retry-After", String(rl.retryAfterSec));
+      return c.json({ error: "rate_limited" }, 429);
+    }
+    const runId = c.req.param("runId");
+    try {
+      // Single indexed run_id list (≤1 PB page) — §5.2.3. The drill-down on
+      // a truncated batch's runId returns the batch's FULL job set
+      // regardless of the history route's row cap.
+      const result = await deps.pb.list<ProbeJobRecord>(PROBE_JOBS_COLLECTION, {
+        filter: `family = ${JSON.stringify(fam.family)} && run_id = ${JSON.stringify(runId)}`,
+        sort: "-created,-id",
+        perPage: RUN_FETCH_PAGE_SIZE,
+        skipTotal: true,
+      });
+      if (result.items.length === 0) {
+        return c.json({ error: "not_found" }, 404);
+      }
+      return c.json({
+        family: fam.family,
+        runId,
+        jobs: result.items.map(projectJob),
+      } satisfies RunDetailResponse);
+    } catch (err) {
+      deps.logger.warn("fleet-runs.detail-failed", {
+        family: fam.family,
+        runId,
+        error: String(err),
+      });
+      return c.json({
+        family: fam.family,
+        runId,
+        error: "history_unavailable",
+      });
+    }
+  });
+}

--- a/showcase/harness/src/http/server.test.ts
+++ b/showcase/harness/src/http/server.test.ts
@@ -322,6 +322,71 @@ describe("http/server", () => {
     expect(res.status).toBe(404);
   });
 
+  it("fleet-runs routes mount when fleetRuns deps supplied and are absent otherwise", async () => {
+    const summaryBody = { families: [], workers: [] };
+    const base = {
+      pb: fakePb(true),
+      logger,
+      ruleCount: () => 1,
+      loopAlive: () => true,
+      schedulerJobCount: () => 1,
+    };
+    const withRoutes = buildServer({
+      ...base,
+      fleetRuns: {
+        summary: { get: async () => summaryBody },
+        pb: fakePb(true),
+        schedules: [],
+        scheduler: { nextRunAt: () => null },
+        workerStaleAfterMs: 180_000,
+        logger,
+      },
+    });
+    const mounted = await withRoutes.request("/api/runs");
+    expect(mounted.status).toBe(200);
+    expect(await mounted.json()).toEqual(summaryBody);
+    const without = buildServer(base);
+    const absent = await without.request("/api/runs");
+    expect(absent.status).toBe(404);
+  });
+
+  it("GET /health carries fleetRuns.lastEvaluatedAt when wired, omits it otherwise", async () => {
+    const evaluatedAtMs = Date.parse("2026-06-10T18:00:00.000Z");
+    const base = {
+      pb: fakePb(true),
+      logger,
+      ruleCount: () => 1,
+      loopAlive: () => true,
+      schedulerJobCount: () => 1,
+    };
+    const wired = buildServer({
+      ...base,
+      fleetRunsLastEvaluatedAt: () => evaluatedAtMs,
+    });
+    const res = await wired.request("/health");
+    const body = (await res.json()) as {
+      fleetRuns?: { lastEvaluatedAt: string | null };
+    };
+    expect(body.fleetRuns?.lastEvaluatedAt).toBe(
+      new Date(evaluatedAtMs).toISOString(),
+    );
+    // Null stamp (monitor constructed but never evaluated) serializes null.
+    const nullWired = buildServer({
+      ...base,
+      fleetRunsLastEvaluatedAt: () => null,
+    });
+    const nullBody = (await (await nullWired.request("/health")).json()) as {
+      fleetRuns?: { lastEvaluatedAt: string | null };
+    };
+    expect(nullBody.fleetRuns).toEqual({ lastEvaluatedAt: null });
+    // Absent callback → no fleetRuns field at all.
+    const plain = buildServer(base);
+    const plainBody = (await (await plain.request("/health")).json()) as {
+      fleetRuns?: unknown;
+    };
+    expect(plainBody.fleetRuns).toBeUndefined();
+  });
+
   it("buildServer throws synchronously when schedulerJobCount is not supplied", () => {
     // Fail-loud discipline: the previous behaviour treated a missing
     // `schedulerJobCount` as "OK by default" (jobCountOk = true), so an

--- a/showcase/harness/src/http/server.ts
+++ b/showcase/harness/src/http/server.ts
@@ -5,6 +5,10 @@ import type { TypedEventBus } from "../events/event-bus.js";
 import type { HarnessRole } from "../fleet/role-config.js";
 import { registerDeployWebhook } from "./webhooks/deploy.js";
 import { registerProbesRoutes, type ProbesRouteDeps } from "./probes.js";
+import {
+  registerFleetRunsRoutes,
+  type FleetRunsRouteDeps,
+} from "./fleet-runs.js";
 import { renderPrometheus, type MetricsRegistry } from "./metrics.js";
 
 export interface ServerDeps {
@@ -78,6 +82,21 @@ export interface ServerDeps {
    * always supplies this in production.
    */
   probes?: ProbesRouteDeps;
+  /**
+   * Optional `/api/runs*` wiring (§5.2). Optional at the TYPE level only
+   * because worker-role/boot callers omit it — the CP role ALWAYS supplies
+   * it, and unlike `probes` there is deliberately NO token coupling: the
+   * fleet-runs router has no mutating route, so the §5.2 unconditional-mount
+   * guarantee is enforced at the orchestrator's CP call site.
+   */
+  fleetRuns?: FleetRunsRouteDeps;
+  /**
+   * §9 compensating control: when supplied, /health gains
+   * `fleetRuns.lastEvaluatedAt` — the family-silence monitor's evaluation
+   * stamp (ISO, or null before the first evaluation) — so an external poll
+   * of the already-exposed health surface can detect a wedged monitor.
+   */
+  fleetRunsLastEvaluatedAt?: () => number | null;
 }
 
 export function buildServer(deps: ServerDeps): Hono {
@@ -108,6 +127,10 @@ export function buildServer(deps: ServerDeps): Hono {
 
   if (deps.probes) {
     registerProbesRoutes(app, deps.probes);
+  }
+
+  if (deps.fleetRuns) {
+    registerFleetRunsRoutes(app, deps.fleetRuns);
   }
 
   if (deps.metrics) {
@@ -164,6 +187,17 @@ export function buildServer(deps: ServerDeps): Hono {
     // report degraded forever and Railway would restart-loop it.
     const rulesOk = deps.role === "control-plane" ? true : ruleCount > 0;
     const ok = pbOk && loopOk && rulesOk;
+    // §9 compensating control: surface the family-silence monitor's
+    // evaluation stamp so "CP alive but monitor wedged" is externally
+    // detectable. Informational only — never folds into the status gate.
+    let fleetRuns: { lastEvaluatedAt: string | null } | undefined;
+    if (deps.fleetRunsLastEvaluatedAt) {
+      const evaluatedAtMs = deps.fleetRunsLastEvaluatedAt();
+      fleetRuns = {
+        lastEvaluatedAt:
+          evaluatedAtMs === null ? null : new Date(evaluatedAtMs).toISOString(),
+      };
+    }
     return c.json(
       {
         status: ok ? "ok" : "degraded",
@@ -171,6 +205,7 @@ export function buildServer(deps: ServerDeps): Hono {
         loop: loopLabel,
         rules: ruleCount,
         schedulerJobs: jobCount,
+        ...(fleetRuns ? { fleetRuns } : {}),
       },
       ok ? 200 : 503,
     );

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -19,6 +19,7 @@ import {
   buildProducerSchedules,
   buildSweepCommErrorSink,
   FLEET_FAMILY_PERIODS_MS,
+  PRODUCER_FAMILY_WIRING,
   FLEET_PRODUCER_SMOKE_CRON,
   FLEET_PRODUCER_DEMOS_CRON,
   FLEET_PRODUCER_DEEP_CRON,
@@ -47,6 +48,7 @@ import {
   DEFAULT_PRODUCER_CRON,
   FLEET_PRODUCER_SCHEDULE_ID,
 } from "./fleet/control-plane/control-plane.js";
+import { FLEET_FAMILIES } from "./fleet/control-plane/run-view.js";
 import type { JobProducer } from "./fleet/control-plane/job-producer.js";
 import { createE2eFullDriver } from "./probes/drivers/d6-all-pills.js";
 import { createE2eDemosDriver } from "./probes/drivers/e2e-readiness.js";
@@ -2928,6 +2930,9 @@ describe("drainFleetWorker — deregister-FIRST drain ordering", () => {
       async countPendingForFamily(): Promise<number> {
         throw new Error("countPendingForFamily not used by worker");
       },
+      async pruneAged() {
+        return { terminal: 0, zombie: 0 };
+      },
     };
   }
 
@@ -5373,6 +5378,22 @@ describe("FLEET_FAMILY_PERIODS_MS ↔ enumerator family drift-lock", () => {
     expect([...families].sort()).toEqual(
       Object.keys(FLEET_FAMILY_PERIODS_MS).sort(),
     );
+  });
+});
+
+/**
+ * §4.2 drift-lock extension: the family ids `runControlPlane` stamps onto its
+ * four producers (via `PRODUCER_FAMILY_WIRING`, the single const all four
+ * `buildJobProducer` call sites read) must be set-equal to the §5.1
+ * `FLEET_FAMILIES` registry — a producer wired with a family the registry
+ * doesn't know would enqueue jobs INVISIBLE to the /api/runs projection, and
+ * a registry family no producer stamps would project as eternally silent.
+ */
+describe("PRODUCER_FAMILY_WIRING (§4.2 family drift-lock)", () => {
+  it("wired producer family ids are set-equal to FLEET_FAMILIES[*].family", () => {
+    const wired = [...Object.values(PRODUCER_FAMILY_WIRING)].sort();
+    const registry = FLEET_FAMILIES.map((f) => f.family).sort();
+    expect(wired).toEqual(registry);
   });
 });
 

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -117,6 +117,9 @@ import {
   createControlPlane,
   DEFAULT_PRODUCER_CRON,
   FLEET_PRODUCER_SCHEDULE_ID,
+  FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
+  FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
+  FLEET_PRODUCER_DEEP_SCHEDULE_ID,
 } from "./fleet/control-plane/control-plane.js";
 import type {
   ControlPlane,
@@ -128,6 +131,8 @@ import type {
   ServiceEnumerator,
   JobProducer,
 } from "./fleet/control-plane/job-producer.js";
+import { createMemoizedFamilySummary } from "./fleet/control-plane/run-view.js";
+import { createFamilySilenceMonitor } from "./fleet/control-plane/family-silence-monitor.js";
 
 export interface BootOptions {
   configDir?: string;
@@ -1304,10 +1309,32 @@ export const FLEET_PRODUCER_SMOKE_CRON = "*/15 * * * *";
 export const FLEET_PRODUCER_DEMOS_CRON = "10 * * * *";
 export const FLEET_PRODUCER_DEEP_CRON = "5,20,35,50 * * * *";
 
-/** Scheduler entry ids for the three non-d6 browser-family producers. */
-export const FLEET_PRODUCER_SMOKE_SCHEDULE_ID = "fleet-producer-e2e-smoke";
-export const FLEET_PRODUCER_DEMOS_SCHEDULE_ID = "fleet-producer-e2e-demos";
-export const FLEET_PRODUCER_DEEP_SCHEDULE_ID = "fleet-producer-e2e-deep";
+/**
+ * Scheduler entry ids for the three non-d6 browser-family producers. Homed in
+ * `control-plane.ts` beside `FLEET_PRODUCER_SCHEDULE_ID` (§5.1 — `run-view.ts`
+ * consumes them without importing this module); re-exported here because
+ * existing import sites (tests included) reach them via `orchestrator.js`.
+ */
+export {
+  FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
+  FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
+  FLEET_PRODUCER_DEEP_SCHEDULE_ID,
+} from "./fleet/control-plane/control-plane.js";
+
+/**
+ * §4.2 family ids `runControlPlane` stamps onto its four producers — the
+ * single const all four `buildJobProducer` call sites read, keyed by the same
+ * producer handles `buildProducerSchedules` takes. Values are §5.1 registry
+ * family ids; the drift-lock test pins them set-equal to
+ * `FLEET_FAMILIES[*].family` so a producer can never enqueue jobs invisible
+ * to the /api/runs projection (nor a registry family go eternally silent).
+ */
+export const PRODUCER_FAMILY_WIRING = {
+  d6: "d6",
+  smoke: "e2e-smoke",
+  demos: "e2e-demos",
+  deep: "d5",
+} as const;
 
 /**
  * Nominal production period per probe FAMILY (the probe_key prefix each
@@ -2410,11 +2437,16 @@ export async function runControlPlane(
   // reclaimed job so the dashboard surfaces the pool outage. The restart hook is
   // best-effort and env-guarded (Railway serviceInstanceRedeploy in staging);
   // locally it stays a no-op so N=1 docker needs no Railway wiring.
+  // Boot-resolved heartbeat window — hoisted to a local because BOTH the
+  // fleet-health monitor and the §5.2 run-view projection (fleet-runs routes +
+  // §9 family-silence monitor below) must judge worker staleness against the
+  // SAME window, never the DEFAULT_ constant.
+  const workerStaleAfterMs = resolveWorkerStaleAfterMs();
   const fleetHealth = createFleetHealthMonitor({
     pb,
     claim,
     logger,
-    staleAfterMs: resolveWorkerStaleAfterMs(),
+    staleAfterMs: workerStaleAfterMs,
     gcAfterMs: resolveWorkerGcAfterMs(),
     restartWorker: resolveWorkerRestartHook(logger),
   });
@@ -2529,6 +2561,9 @@ export async function runControlPlane(
     queue,
     enumerate,
     logger,
+    // §4.2: the family id stamped onto every EnqueueJobInput this producer
+    // builds (and the prune-ownership key — the d6 producer owns pruneAged).
+    family: PRODUCER_FAMILY_WIRING.d6,
     onSweepCommErrors,
     // #72 PRE-DISPATCH WARM-UP: fire a fire-and-forget GET <backendUrl>/health
     // at every enumerated d6 backend before its pills run, so a cold
@@ -2547,18 +2582,21 @@ export async function runControlPlane(
     queue,
     enumerate: enumerateSmoke,
     logger,
+    family: PRODUCER_FAMILY_WIRING.smoke,
     onSweepCommErrors,
   });
   const demosProducer = buildJobProducer({
     queue,
     enumerate: enumerateDemos,
     logger,
+    family: PRODUCER_FAMILY_WIRING.demos,
     onSweepCommErrors,
   });
   const deepProducer = buildJobProducer({
     queue,
     enumerate: enumerateDeep,
     logger,
+    family: PRODUCER_FAMILY_WIRING.deep,
     onSweepCommErrors,
   });
 
@@ -2584,6 +2622,46 @@ export async function runControlPlane(
     ...(producerCron ? { d6Cron: producerCron } : {}),
   });
 
+  // §5.2 shared-instance seam: ONE memoized family-summary projection,
+  // injected into BOTH the /api/runs routes (buildServer below) and the §9
+  // family-silence monitor — "the monitor shares the route's memo" is true by
+  // construction, bounding PB load at ~one fan-out per TTL regardless of
+  // viewer count.
+  const familySummary = createMemoizedFamilySummary({
+    pb,
+    scheduler,
+    schedules,
+    workerStaleAfterMs,
+    logger,
+  });
+
+  // §9 family-silence monitor: the Slack alerting hook for the one incident
+  // class the status-row alert engine is structurally blind to (a silent
+  // family produces NO row transitions). Ticks off the control-plane's
+  // fleet-health interval (familySilence dep below) — it owns no timer of its
+  // own, so there is nothing extra to tear down on stop/bind-failure paths.
+  // The oss_alerts webhook resolves from SLACK_WEBHOOK_OSS_ALERTS at send
+  // time; when unset the target logs `slack-webhook.env-unset` and throws,
+  // which the monitor swallows per its post-failure discipline — alerting
+  // ships disabled, the monitor still evaluates (so /health's
+  // fleetRuns.lastEvaluatedAt stays live).
+  const alertStateStore = createAlertStateStore(pb);
+  const ossAlertsTarget = createSlackWebhookTarget({ logger });
+  const familySilence = createFamilySilenceMonitor({
+    summary: familySummary,
+    schedules,
+    alertStore: alertStateStore,
+    postAlert: async (text: string): Promise<void> => {
+      await ossAlertsTarget.send(
+        { payload: { text }, contentType: "application/json" },
+        { kind: "slack_webhook", webhook: "oss_alerts" },
+      );
+    },
+    // Boot grace (1× resolved period per family) anchored at construction.
+    bootAtMs: Date.now(),
+    logger,
+  });
+
   // REQ-B: wire the real aggregator + fleet-health monitor + sweep-key resolver
   // into the control-plane assembly so BOTH crash-path legs surface onto the
   // dashboard through the proper module seams (the control-plane runs the
@@ -2602,6 +2680,9 @@ export async function runControlPlane(
     logger,
     aggregator,
     fleetHealth,
+    // §9: the family-silence monitor rides the fleet-health interval — the
+    // control-plane fire-and-forgets `familySilence.tick(now)` each cycle.
+    familySilence,
     resolveSweepAggregateKey,
     resolvePriorState,
   });
@@ -2901,6 +2982,22 @@ export async function runControlPlane(
     schedulerIsStopped: () => scheduler.isStopped(),
     bus,
     probes: probesDeps,
+    // §5.2 unconditional CP mount: unlike `probes` (token-gated), the
+    // read-only fleet-runs routes are ALWAYS supplied on the control-plane
+    // role — `summary` is the §5.2 shared memo instance the §9 monitor also
+    // reads, so a dashboard poll and a monitor evaluation inside the same TTL
+    // share one PB fan-out.
+    fleetRuns: {
+      summary: familySummary,
+      pb,
+      schedules,
+      scheduler,
+      workerStaleAfterMs,
+      logger,
+    },
+    // §9 compensating control: stamp the monitor's last evaluation cycle into
+    // /health so an external poll can detect a wedged monitor.
+    fleetRunsLastEvaluatedAt: () => familySilence.lastEvaluatedAt(),
   });
 
   scheduler.start();

--- a/showcase/harness/src/probes/run-history.ts
+++ b/showcase/harness/src/probes/run-history.ts
@@ -34,6 +34,16 @@ export interface ProbeRunSummary {
    * smoke-result rows) don't have to flatten down to a closed-enum.
    */
   services?: unknown[];
+  /**
+   * §4.2 run-visibility reds counters, written by the fleet result
+   * aggregator: counts of durable State transitions across the job's
+   * aggregate + cell `WriteOutcome`s (green→red introduced, red→green
+   * cleared; error ticks excluded — a probe that errored neither introduced
+   * nor cleared a red). Absent on pre-P2 rows → the run-visibility API
+   * serializes `null` for them.
+   */
+  redsIntroduced?: number;
+  redsCleared?: number;
 }
 
 /**

--- a/showcase/harness/src/probes/run-history.ts
+++ b/showcase/harness/src/probes/run-history.ts
@@ -289,7 +289,7 @@ export async function sweepStaleRuns(
   maxAgeMs: number = 15 * 60 * 1000,
 ): Promise<number> {
   const cutoff = new Date(Date.now() - maxAgeMs).toISOString();
-  const filter = `state = "running" && started_at < "${cutoff}"`;
+  const filter = `state = "running" && started_at < ${JSON.stringify(cutoff)}`;
   const stale = await pb.list<ProbeRunRow>(PROBE_RUNS_COLLECTION, {
     filter,
     perPage: 50,

--- a/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
+++ b/showcase/pocketbase/pb_hooks/fleet-claim.pb.js
@@ -133,6 +133,12 @@ routerAdd(
         const reclaimable =
           status === "pending" ||
           (RUNNING_STATES.indexOf(status) !== -1 && leaseExpired(rec));
+        // Run-metadata (§4.2): capture WHICH branch won BEFORE mutating the
+        // record. An expired-lease steal (claimed/running + lease elapsed) is
+        // one of the two reclaim choke points and must bump reclaim_count; a
+        // plain pending claim must not.
+        const wasExpiredSteal =
+          RUNNING_STATES.indexOf(status) !== -1 && leaseExpired(rec);
         if (!reclaimable) {
           // TIMEOUT-AFTER-COMMIT IDEMPOTENCY: a claim that COMMITTED whose
           // response was lost is retried by the SAME worker — the row is now
@@ -159,6 +165,13 @@ routerAdd(
         rec.set("claimed_by", workerId);
         rec.set("lease_expires_at", leaseExpiryIso(leaseSeconds));
         rec.set("version", (rec.get("version") || 0) + 1);
+        // claimed_at is stamped on EVERY winning claim — it deliberately
+        // restamps on a re-claim/steal, so the derived queue latency
+        // (claimed_at − created) measures the LAST claim (§5.2.1 corollary).
+        rec.set("claimed_at", new Date().toISOString());
+        if (wasExpiredSteal) {
+          rec.set("reclaim_count", (rec.get("reclaim_count") || 0) + 1);
+        }
         txDao.saveRecord(rec);
         claimed = true;
         view = jobView(rec);
@@ -459,6 +472,17 @@ routerAdd(
           // that out-lived its family's expiry window gets an actual re-run
           // instead of being claim-deleted off its original `created` age.
           rec.set("claimed_by", "");
+          // Run-metadata (§4.2): the sweeper re-queue is the second reclaim
+          // choke point (the first is the claim CAS's expired-lease steal) —
+          // bump the durable per-job reclaim tally. finished_at deliberately
+          // stays untouched (null until a TERMINAL release): a re-queued job
+          // has not finished.
+          rec.set("reclaim_count", (rec.get("reclaim_count") || 0) + 1);
+        } else {
+          // Run-metadata (§4.2): terminal release (done|failed) stamps the
+          // finish time so run duration (finished_at − claimed_at) is readable
+          // without parsing the `result` JSON.
+          rec.set("finished_at", new Date().toISOString());
         }
         rec.set("version", (rec.get("version") || 0) + 1);
         txDao.saveRecord(rec);

--- a/showcase/pocketbase/pb_migrations/1779990000_resource_snapshots_add_worker_id.js
+++ b/showcase/pocketbase/pb_migrations/1779990000_resource_snapshots_add_worker_id.js
@@ -60,7 +60,9 @@ migrate(
       "CREATE INDEX IF NOT EXISTS idx_resource_snapshots_worker " +
       "ON resource_snapshots (worker_id, observed_at DESC)";
     if (
-      !c.indexes.some((ix) => ix.indexOf("idx_resource_snapshots_worker") !== -1)
+      !c.indexes.some(
+        (ix) => ix.indexOf("idx_resource_snapshots_worker") !== -1,
+      )
     ) {
       c.indexes.push(idxSql);
     }

--- a/showcase/pocketbase/pb_migrations/1779990200_probe_jobs_add_run_metadata.js
+++ b/showcase/pocketbase/pb_migrations/1779990200_probe_jobs_add_run_metadata.js
@@ -1,0 +1,157 @@
+/// <reference path="../pb_data/types.d.ts" />
+//
+// Run-metadata columns on the pull-queue row (run visibility, spec §4.2).
+//
+// These five columns make a job row self-describing for the run-view
+// projection (control-plane src/fleet/control-plane/run-view.ts) without
+// JSON-path scans over `payload` or trusting the last-write-wins `result`
+// column. Each column has exactly ONE writer:
+//
+//   - run_id        (text, indexed): denormalized by the queue-client's
+//                     `enqueue` (CP side) from `payload.meta.runId` — groups
+//                     the N per-service jobs of one producer tick into one
+//                     run batch behind an indexed filter.
+//   - family        (text, indexed): stamped by the queue-client's `enqueue`
+//                     from the producer's family id (`EnqueueJobInput.family`,
+//                     §5.1 registry) — per-family listing without
+//                     prefix-parsing `probe_key`. Absent on the input →
+//                     column stays empty (pre-P2 row parity).
+//   - claimed_at    (date): stamped by the fleet-claim.pb.js CLAIM CAS inside
+//                     the winning transaction, on EVERY winning claim — so it
+//                     restamps on a re-claim/lease-steal, and the derived
+//                     queue latency (`claimed_at − created`) measures the
+//                     LAST claim (§5.2.1 corollary).
+//   - finished_at   (date): stamped by the fleet-claim.pb.js RELEASE CAS on a
+//                     terminal target (done|failed) only. The sweeper's
+//                     re-queue (target "pending") leaves it null.
+//   - reclaim_count (number): incremented by fleet-claim.pb.js inside BOTH
+//                     reclaim choke points — the claim CAS when it wins via
+//                     the expired-lease steal branch, and the release CAS
+//                     when the sweeper re-queues an expired row to pending.
+//                     The durable per-job reclaim tally: it survives the
+//                     last-write-wins overwrite of `result` and the
+//                     restamping of `claimed_at` (§5.2.1 `jobs.reclaimed`).
+//
+// Stamping claimed_at/finished_at in the PB hook (not the worker) keeps a
+// ZERO worker-code dependency: the hook is the single transactional choke
+// point all claims/releases already pass through, so an old worker image
+// against a new hook gets the columns for free (§8 rollout ordering).
+//
+// Additive + idempotent: presence-checks make a re-run after a partial apply
+// a no-op (mirrors 1779989700_probe_jobs_add_result.js). Index pushes are
+// guarded by index-PRESENCE, not the field-`changed` latch, so a
+// partial-apply recovery still creates a missing index. The down migration
+// drops the five fields + two indexes but leaves the collection.
+migrate(
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("probe_jobs");
+    } catch (e) {
+      // Base collection not present yet (S0 create runs first, lower prefix).
+      // No-op rather than a hard failure.
+      return;
+    }
+    let changed = false;
+    if (!c.schema.getFieldByName("run_id")) {
+      c.schema.addField(
+        new SchemaField({
+          name: "run_id",
+          type: "text",
+        }),
+      );
+      changed = true;
+    }
+    if (!c.schema.getFieldByName("family")) {
+      c.schema.addField(
+        new SchemaField({
+          name: "family",
+          type: "text",
+        }),
+      );
+      changed = true;
+    }
+    if (!c.schema.getFieldByName("claimed_at")) {
+      c.schema.addField(
+        new SchemaField({
+          name: "claimed_at",
+          type: "date",
+        }),
+      );
+      changed = true;
+    }
+    if (!c.schema.getFieldByName("finished_at")) {
+      c.schema.addField(
+        new SchemaField({
+          name: "finished_at",
+          type: "date",
+        }),
+      );
+      changed = true;
+    }
+    if (!c.schema.getFieldByName("reclaim_count")) {
+      c.schema.addField(
+        new SchemaField({
+          name: "reclaim_count",
+          type: "number",
+          options: { min: 0 },
+        }),
+      );
+      changed = true;
+    }
+    // Hot read patterns: "all jobs of one run batch" (run_id) and "newest
+    // rows of one family" (family). Guard each index push by index-PRESENCE,
+    // NOT the field-`changed` flag — on a partial-apply recovery the field
+    // can already exist while the index is still missing (the 1779989700
+    // gotcha), and gating on `changed` would then never create it.
+    c.indexes = c.indexes || [];
+    if (!c.indexes.some((ix) => ix.indexOf("idx_probe_jobs_run_id") !== -1)) {
+      c.indexes.push(
+        "CREATE INDEX IF NOT EXISTS idx_probe_jobs_run_id ON probe_jobs (run_id)",
+      );
+      changed = true;
+    }
+    if (!c.indexes.some((ix) => ix.indexOf("idx_probe_jobs_family") !== -1)) {
+      c.indexes.push(
+        "CREATE INDEX IF NOT EXISTS idx_probe_jobs_family ON probe_jobs (family)",
+      );
+      changed = true;
+    }
+    if (changed) {
+      dao.saveCollection(c);
+    }
+  },
+  (db) => {
+    const dao = new Dao(db);
+    let c;
+    try {
+      c = dao.findCollectionByNameOrId("probe_jobs");
+    } catch (e) {
+      return;
+    }
+    let changed = false;
+    const names = [
+      "run_id",
+      "family",
+      "claimed_at",
+      "finished_at",
+      "reclaim_count",
+    ];
+    for (const name of names) {
+      const f = c.schema.getFieldByName(name);
+      if (f) {
+        c.schema.removeField(f.id);
+        changed = true;
+      }
+    }
+    if (changed) {
+      c.indexes = (c.indexes || []).filter(
+        (ix) =>
+          ix.indexOf("idx_probe_jobs_run_id") === -1 &&
+          ix.indexOf("idx_probe_jobs_family") === -1,
+      );
+      dao.saveCollection(c);
+    }
+  },
+);

--- a/showcase/scripts/__tests__/railway-envs.golden.test.ts
+++ b/showcase/scripts/__tests__/railway-envs.golden.test.ts
@@ -51,11 +51,7 @@ import {
 } from "../railway-envs";
 import type { EnvName } from "../railway-envs";
 
-const GOLDEN_PATH = resolve(
-  __dirname,
-  "fixtures",
-  "railway-envs.golden.json",
-);
+const GOLDEN_PATH = resolve(__dirname, "fixtures", "railway-envs.golden.json");
 
 /**
  * Resolve, for one (service, env) pair, the same projection the rest of

--- a/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
@@ -751,7 +751,9 @@ describe.each(DRIVER_CASES)(
       const expectedHealthCount = label === "dashboard" ? 2 : 1;
       expect(healthUrls).toHaveLength(expectedHealthCount);
       for (const u of healthUrls) {
-        expect(u).toBe(`https://${domainFor(service, "prod")}${expectedHealthPath}`);
+        expect(u).toBe(
+          `https://${domainFor(service, "prod")}${expectedHealthPath}`,
+        );
       }
     });
 

--- a/showcase/shell-dashboard/next-env.d.ts
+++ b/showcase/shell-dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
@@ -3,9 +3,12 @@
  */
 import { describe, it, expect } from "vitest";
 import { render, fireEvent, within } from "@testing-library/react";
-import { CellDrilldown } from "../cell-drilldown";
+import { CellDrilldown, familyStalenessAnnotation } from "../cell-drilldown";
 import { buildCellModel } from "@/lib/cell-model";
-import type { LiveStatusMap, StatusRow } from "@/lib/live-status";
+import type { BadgeRender, LiveStatusMap, StatusRow } from "@/lib/live-status";
+import { WorkerRunsProvider } from "@/lib/worker-runs-context";
+import type { WorkerRunsStatus } from "@/hooks/use-worker-runs";
+import type { WorkerFamilySummary, WorkerRunBatch } from "@/lib/ops-api";
 
 // The `row()` helper's hardcoded 2026-04-20 timestamps are STALE against the
 // health (45m) / e2e (6h) / d4 (1h) windows, and CellDrilldown calls
@@ -414,5 +417,229 @@ describe("CellDrilldown", () => {
     const dialog = getByTestId("cell-drilldown");
     expect(dialog.className).toContain("w-[480px]");
     expect(dialog.className).not.toContain("w-72");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  §7.2 family staleness annotation                                   */
+/* ------------------------------------------------------------------ */
+
+function makeBatch(overrides: Partial<WorkerRunBatch> = {}): WorkerRunBatch {
+  return {
+    runId: "r1",
+    triggered: false,
+    enqueuedAt: new Date(Date.now() - 90 * 60_000).toISOString(),
+    finishedAt: new Date(Date.now() - 80 * 60_000).toISOString(),
+    durationMs: 600_000,
+    outcome: "failed",
+    jobs: { total: 1, done: 0, failed: 1, reclaimed: 0 },
+    cells: null,
+    redsIntroduced: null,
+    redsCleared: null,
+    errorSummary: null,
+    commErrorKinds: [],
+    ...overrides,
+  };
+}
+
+function makeFamily(
+  overrides: Partial<WorkerFamilySummary> = {},
+): WorkerFamilySummary {
+  return {
+    family: "d6",
+    label: "D6 all-pills",
+    probeKeyPrefix: "d6",
+    schedule: "40 * * * *",
+    periodMs: 3_600_000,
+    nextRunAt: null,
+    lastRun: makeBatch(),
+    inflight: null,
+    lastSuccessAt: new Date(Date.now() - 8 * 3_600_000).toISOString(),
+    ...overrides,
+  };
+}
+
+function okWorkerRuns(families: WorkerFamilySummary[]): WorkerRunsStatus {
+  return {
+    status: "ok",
+    data: { families, workers: [] },
+    fetchedAt: Date.now(),
+  };
+}
+
+describe("CellDrilldown §7.2 family annotation", () => {
+  it("appends 'Family last succeeded <relative> · last attempt <relative> (<outcome>)' for a stale-degraded row whose key prefix maps via payload probeKeyPrefix", () => {
+    // A green d6 row observed 7 h ago: past the 6 h E2E window, so the
+    // cell's EXISTING stale check downgrades it to amber/degraded with
+    // fail_count 0 — the exact shape §7.2 annotates.
+    const old = new Date(Date.now() - 7 * 3_600_000).toISOString();
+    const live = mapOf([
+      row("d6:lgp/agentic-chat", "d6", "green", {
+        observed_at: old,
+        transitioned_at: old,
+      }),
+    ]);
+    const { getByTestId } = render(
+      <WorkerRunsProvider value={okWorkerRuns([makeFamily()])}>
+        <CellDrilldown
+          slug="lgp"
+          featureId="agentic-chat"
+          integrationName="LangGraph Python"
+          featureName="Agentic Chat"
+          liveStatus={live}
+          onClose={() => {}}
+        />
+      </WorkerRunsProvider>,
+    );
+    const annotation = getByTestId("family-annotation");
+    expect(annotation.textContent).toMatch(
+      /^Family last succeeded .+ · last attempt .+ \(failed\)$/,
+    );
+  });
+
+  it("does NOT annotate a genuine failure (fresh red row) even when its family maps", () => {
+    const live = mapOf([
+      row("d6:lgp/agentic-chat", "d6", "red", {
+        fail_count: 3,
+        first_failure_at: "2026-06-10T00:00:00Z",
+        observed_at: new Date().toISOString(),
+        transitioned_at: new Date().toISOString(),
+      }),
+    ]);
+    const { queryAllByTestId } = render(
+      <WorkerRunsProvider value={okWorkerRuns([makeFamily()])}>
+        <CellDrilldown
+          slug="lgp"
+          featureId="agentic-chat"
+          integrationName="LangGraph Python"
+          featureName="Agentic Chat"
+          liveStatus={live}
+          onClose={() => {}}
+        />
+      </WorkerRunsProvider>,
+    );
+    expect(queryAllByTestId("family-annotation").length).toBe(0);
+  });
+
+  it("d4 rows annotate under their own 1h gate — the annotation piggybacks the cell's existing stale verdict and applies NO threshold of its own", () => {
+    const now = Date.now();
+    // A d4/e2e-smoke row already downgraded by ITS OWN gate
+    // (D4_STALE_AFTER_MS, 1 h — applied upstream by the cell model):
+    // amber/degraded, fail_count 0.
+    const observed = new Date(now - 65 * 60_000).toISOString();
+    const d4Row: StatusRow = {
+      id: "d4-1",
+      key: "d4:lgp",
+      dimension: "d4",
+      state: "degraded",
+      signal: null,
+      observed_at: observed,
+      transitioned_at: observed,
+      fail_count: 0,
+      first_failure_at: null,
+    };
+    const badge: BadgeRender = {
+      tone: "amber",
+      label: "~",
+      tooltip: "",
+      row: d4Row,
+    };
+    // e2e-smoke family (probeKeyPrefix "d4", 15 min period) that is NOT
+    // 2-period silent (last success 20 min ago < 30 min): the annotation
+    // must STILL append, because the only gate is the cell's own existing
+    // stale verdict — §7.2 "it never substitutes a different threshold".
+    const smoke = makeFamily({
+      family: "e2e-smoke",
+      label: "E2E smoke",
+      probeKeyPrefix: "d4",
+      schedule: "*/15 * * * *",
+      periodMs: 900_000,
+      lastSuccessAt: new Date(now - 20 * 60_000).toISOString(),
+      lastRun: makeBatch({
+        outcome: "completed",
+        enqueuedAt: new Date(now - 25 * 60_000).toISOString(),
+        finishedAt: new Date(now - 20 * 60_000).toISOString(),
+      }),
+    });
+    const annotation = familyStalenessAnnotation(badge, [smoke], now);
+    expect(annotation).toMatch(
+      /^Family last succeeded .+ · last attempt .+ \(completed\)$/,
+    );
+    // A FRESH (non-degraded) d4 row never annotates, even when the family
+    // IS silent — the cell's own verdict governs.
+    const freshBadge: BadgeRender = {
+      tone: "green",
+      label: "✓",
+      tooltip: "",
+      row: { ...d4Row, state: "green" },
+    };
+    const silentSmoke = makeFamily({
+      ...smoke,
+      lastSuccessAt: new Date(now - 3 * 3_600_000).toISOString(),
+    });
+    expect(familyStalenessAnnotation(freshBadge, [silentSmoke], now)).toBe(
+      null,
+    );
+  });
+
+  it("annotation uses the inflight batch as last attempt when one exists (stalled rendered verbatim)", () => {
+    const now = Date.now();
+    const badge: BadgeRender = {
+      tone: "amber",
+      label: "~",
+      tooltip: "",
+      row: {
+        id: "d6-1",
+        key: "d6:lgp/agentic-chat",
+        dimension: "d6",
+        state: "degraded",
+        signal: null,
+        observed_at: new Date(now - 7 * 3_600_000).toISOString(),
+        transitioned_at: new Date(now - 7 * 3_600_000).toISOString(),
+        fail_count: 0,
+        first_failure_at: null,
+      },
+    };
+    const family = makeFamily({
+      inflight: {
+        runId: "r2",
+        triggered: false,
+        enqueuedAt: new Date(now - 2 * 3_600_000).toISOString(),
+        elapsedMs: 2 * 3_600_000,
+        stalled: true,
+        jobs: { pending: 1, claimed: 0, running: 0, done: 0, failed: 0 },
+      },
+    });
+    expect(familyStalenessAnnotation(badge, [family], now)).toMatch(
+      /· last attempt .+ \(stalled\)$/,
+    );
+  });
+
+  it("returns null for a zero-batch family and for an unmapped key prefix", () => {
+    const now = Date.now();
+    const badge: BadgeRender = {
+      tone: "amber",
+      label: "~",
+      tooltip: "",
+      row: {
+        id: "d6-2",
+        key: "d6:lgp/agentic-chat",
+        dimension: "d6",
+        state: "degraded",
+        signal: null,
+        observed_at: new Date(now - 7 * 3_600_000).toISOString(),
+        transitioned_at: new Date(now - 7 * 3_600_000).toISOString(),
+        fail_count: 0,
+        first_failure_at: null,
+      },
+    };
+    const zeroBatch = makeFamily({
+      lastRun: null,
+      inflight: null,
+      lastSuccessAt: null,
+    });
+    expect(familyStalenessAnnotation(badge, [zeroBatch], now)).toBe(null);
+    const unmapped = makeFamily({ probeKeyPrefix: "d5-single-pill-e2e" });
+    expect(familyStalenessAnnotation(badge, [unmapped], now)).toBe(null);
   });
 });

--- a/showcase/shell-dashboard/src/components/cell-drilldown.tsx
+++ b/showcase/shell-dashboard/src/components/cell-drilldown.tsx
@@ -19,6 +19,8 @@ import type {
 import { formatTs } from "@/lib/format-ts";
 import { getPb } from "@/lib/pb";
 import { TONE_CLASS, DOT_BG } from "./badges";
+import { useWorkerRuns, familyForProbeKey } from "@/lib/worker-runs-context";
+import type { WorkerFamilySummary } from "@/lib/ops-api";
 
 export interface CellDrilldownProps {
   slug: string;
@@ -345,6 +347,83 @@ function isGenuineFailure(badge: BadgeRender): boolean {
   return false;
 }
 
+/**
+ * Compact relative-time formatter for the §7.2 family annotation line
+ * ("3h ago"). Local to the drilldown — the annotation is the only consumer;
+ * everything else in this panel renders absolute timestamps via `formatTs`.
+ */
+function relativeTime(iso: string, nowMs: number): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "unknown";
+  const minutes = Math.floor(Math.max(0, nowMs - t) / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+/**
+ * §7.2 family staleness annotation, appended to a badge row when — and only
+ * when — BOTH hold:
+ *
+ *   1. The badge is STALE-degraded by the cell's EXISTING stale check
+ *      (whichever window its dimension already applies — `E2E_STALE_AFTER_MS`
+ *      for d5/d6/e2e rows, `D4_STALE_AFTER_MS` for d4/e2e-smoke rows). The
+ *      amber + `fail_count === 0` shape is that downgrade's signature (the
+ *      complement of `isGenuineFailure`'s amber arm: a producer-degraded row
+ *      carries `fail_count > 0`). This helper applies NO threshold of its
+ *      own — it piggybacks the verdict, never substitutes a different one.
+ *   2. The row's probe-key prefix maps to a worker family via the
+ *      `probeKeyPrefix` each `/api/runs` entry echoes (§5.2.1) — payload-
+ *      driven through `familyForProbeKey`, never a dashboard-side prefix
+ *      table.
+ *
+ * The line answers WHY the cell is degraded: "Family last succeeded
+ * <relative> · last attempt <relative> (<outcome>)". Last attempt is
+ * inflight-aware (a present inflight batch is the newest attempt — rendered
+ * `stalled` when the server marked it stalled, else `running`); otherwise the
+ * server's `lastRun.outcome` is rendered VERBATIM (no client
+ * re-classification). Null `lastSuccessAt` renders "never" (the §5.2.1
+ * never-succeeded case); a zero-batch family has nothing to attribute and
+ * yields no annotation. Exported for direct unit-testing of key shapes
+ * (e.g. d4 rows) that `resolveCell` doesn't surface in this panel today.
+ */
+export function familyStalenessAnnotation(
+  badge: BadgeRender,
+  families: WorkerFamilySummary[],
+  nowMs: number,
+): string | null {
+  const row = badge.row;
+  if (badge.tone !== "amber" || row === null || row.fail_count > 0) {
+    return null;
+  }
+  const family = familyForProbeKey(row.key, families);
+  // A degraded entry (`error: "history_unavailable"`) carries no run data —
+  // §6.1 surfaces that as the unavailable incident class, not here.
+  if (family === undefined || family.error !== undefined) return null;
+  const lastAttempt = family.inflight
+    ? {
+        at: family.inflight.enqueuedAt,
+        outcome: family.inflight.stalled ? "stalled" : "running",
+      }
+    : family.lastRun
+      ? {
+          at: family.lastRun.finishedAt ?? family.lastRun.enqueuedAt,
+          outcome: family.lastRun.outcome,
+        }
+      : null;
+  if (lastAttempt === null) return null;
+  const succeeded =
+    family.lastSuccessAt != null
+      ? relativeTime(family.lastSuccessAt, nowMs)
+      : "never";
+  return `Family last succeeded ${succeeded} · last attempt ${relativeTime(
+    lastAttempt.at,
+    nowMs,
+  )} (${lastAttempt.outcome})`;
+}
+
 function CollapsibleSignal({ text }: { text: string }) {
   const [open, setOpen] = useState(false);
   return (
@@ -393,6 +472,19 @@ function BadgeRow({
   signalError?: string | null;
 }) {
   const isFailure = isGenuineFailure(badge);
+  // §7.2: worker-runs context for the family staleness annotation. The T10
+  // no-provider contract guarantees `useWorkerRuns()` never throws and
+  // returns the no-data default (`null`) absent a provider — provider-less
+  // renders simply skip the annotation.
+  const workerRuns = useWorkerRuns();
+  const families =
+    workerRuns !== null && workerRuns.status === "ok"
+      ? workerRuns.data.families
+      : null;
+  const annotation =
+    families !== null
+      ? familyStalenessAnnotation(badge, families, Date.now())
+      : null;
   // Prefer the row's own signal (an SSE delta delivers full rows); fall back to
   // the lazily-fetched one when the projected initial row had none.
   const rowSignal = badge.row?.signal;
@@ -508,6 +600,18 @@ function BadgeRow({
           </div>
           {/* Raw signal — collapsible for debugging */}
           {signalText && <CollapsibleSignal text={signalText} />}
+        </div>
+      )}
+      {/* §7.2 family staleness annotation: only for STALE-degraded rows whose
+          probe-key prefix maps to a worker family (payload probeKeyPrefix).
+          Turns "amber, shrug" into "amber because the family hasn't completed
+          a run since <time> — last attempt <outcome>". */}
+      {annotation !== null && (
+        <div
+          data-testid="family-annotation"
+          className="mt-1 pl-4 text-[10px] text-[var(--amber)]"
+        >
+          {annotation}
         </div>
       )}
     </div>

--- a/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
@@ -14,6 +14,9 @@ import type { Integration, Feature } from "@/lib/registry";
 import type { CellContext } from "./feature-grid";
 import type { LiveStatusMap, StatusRow } from "@/lib/live-status";
 import { __clearLastTransitionCache } from "@/hooks/useLastTransition";
+import { WorkerRunsProvider } from "@/lib/worker-runs-context";
+import type { WorkerRunsStatus } from "@/hooks/use-worker-runs";
+import type { WorkerFamilySummary, WorkerRunBatch } from "@/lib/ops-api";
 
 // Mock pb so the lazy fetch in useLastTransition is observable.
 const mockState = {
@@ -400,5 +403,184 @@ describe("docs-only kind hides ALL badges", () => {
     expect(text).not.toContain("API");
     expect(text).not.toContain("E2E");
     expect(text).not.toContain("CV");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  §7.3 clock glyph — stale-degraded badge + 2-period family silence  */
+/* ------------------------------------------------------------------ */
+
+/**
+ * A STALE-green e2e row: `observed_at` is 7 h old (past the 6 h
+ * `E2E_STALE_AFTER_MS` window), so `buildBadge` downgrades it to the
+ * amber `degraded` badge with `fail_count === 0` — the exact
+ * stale-degraded shape the §7.3 glyph decorates.
+ */
+function staleGreenE2eRow(): StatusRow {
+  const old = new Date(Date.now() - 7 * 3_600_000).toISOString();
+  return {
+    id: "sg1",
+    key: "e2e:test/agentic-chat",
+    dimension: "e2e",
+    state: "green",
+    signal: null,
+    observed_at: old,
+    transitioned_at: old,
+    fail_count: 0,
+    first_failure_at: null,
+  };
+}
+
+function makeBatch(overrides: Partial<WorkerRunBatch> = {}): WorkerRunBatch {
+  return {
+    runId: "r1",
+    triggered: false,
+    enqueuedAt: new Date(Date.now() - 3 * 3_600_000).toISOString(),
+    finishedAt: null,
+    durationMs: null,
+    outcome: "failed",
+    jobs: { total: 1, done: 0, failed: 1, reclaimed: 0 },
+    cells: null,
+    redsIntroduced: null,
+    redsCleared: null,
+    errorSummary: null,
+    commErrorKinds: [],
+    ...overrides,
+  };
+}
+
+function makeFamily(
+  overrides: Partial<WorkerFamilySummary> = {},
+): WorkerFamilySummary {
+  return {
+    family: "e2e-demos",
+    label: "E2E demos",
+    probeKeyPrefix: "e2e",
+    schedule: "10 * * * *",
+    periodMs: 3_600_000,
+    nextRunAt: null,
+    lastRun: makeBatch(),
+    inflight: null,
+    lastSuccessAt: new Date(Date.now() - 3 * 3_600_000).toISOString(),
+    ...overrides,
+  };
+}
+
+function okWorkerRuns(families: WorkerFamilySummary[]): WorkerRunsStatus {
+  return {
+    status: "ok",
+    data: { families, workers: [] },
+    fetchedAt: Date.now(),
+  };
+}
+
+function renderWithWorkerRuns(
+  ctx: CellContext,
+  families: WorkerFamilySummary[],
+) {
+  return render(
+    <WorkerRunsProvider value={okWorkerRuns(families)}>
+      <CellStatus ctx={ctx} />
+    </WorkerRunsProvider>,
+  );
+}
+
+describe("§7.3: clock-glyph suffix on the stale-degraded badge", () => {
+  it("degraded badge gains the clock-glyph suffix when the cell's family has no success within 2x periodMs", () => {
+    const row = staleGreenE2eRow();
+    const ctx = makeCtx({
+      liveStatus: new Map([[row.key, row]]) as LiveStatusMap,
+    });
+    // lastSuccessAt 3 h ago > 2 × 1 h period → family silent → glyph.
+    const { container } = renderWithWorkerRuns(ctx, [makeFamily()]);
+    const rt = findBadgeByName(container, "RT");
+    expect(rt.textContent).toContain("⏱");
+    // The badge keeps its degraded label — the glyph is a SUFFIX, not a
+    // replacement (spec §7.3 "minimal: suffix only").
+    expect(rt.textContent).toContain("~");
+  });
+
+  it("glyph never decorates a non-stale-degraded cell (fresh red keeps red rendering)", () => {
+    // Fresh red: family silent, but the badge is red (a real failure) —
+    // the glyph only ever decorates an ALREADY stale-degraded badge.
+    const red = redE2eRow();
+    const ctx = makeCtx({
+      liveStatus: new Map([[red.key, red]]) as LiveStatusMap,
+    });
+    const { container } = renderWithWorkerRuns(ctx, [makeFamily()]);
+    const rt = findBadgeByName(container, "RT");
+    expect(rt.textContent).toContain("✗");
+    expect(rt.textContent).not.toContain("⏱");
+  });
+
+  it("glyph never decorates a producer-degraded badge (fail_count > 0 is a failure, not staleness)", () => {
+    const nowIso = new Date().toISOString();
+    const producerDegraded: StatusRow = {
+      ...staleGreenE2eRow(),
+      state: "degraded",
+      observed_at: nowIso,
+      transitioned_at: nowIso,
+      fail_count: 2,
+      first_failure_at: nowIso,
+    };
+    const ctx = makeCtx({
+      liveStatus: new Map([
+        [producerDegraded.key, producerDegraded],
+      ]) as LiveStatusMap,
+    });
+    const { container } = renderWithWorkerRuns(ctx, [makeFamily()]);
+    const rt = findBadgeByName(container, "RT");
+    expect(rt.textContent).not.toContain("⏱");
+  });
+
+  it("glyph uses server periodMs — a non-default periodMs in the payload shifts the threshold (no client cron parsing)", () => {
+    const row = staleGreenE2eRow();
+    const ctx = makeCtx({
+      liveStatus: new Map([[row.key, row]]) as LiveStatusMap,
+    });
+    const lastSuccessAt = new Date(Date.now() - 40 * 60_000).toISOString();
+    // 40 min silence vs 15 min period: 40 > 2×15 → silent → glyph.
+    const fast = renderWithWorkerRuns(ctx, [
+      makeFamily({ periodMs: 900_000, lastSuccessAt }),
+    ]);
+    expect(findBadgeByName(fast.container, "RT").textContent).toContain("⏱");
+    // Same payload but a 30 min period: 40 < 2×30 → not silent → no glyph.
+    const slow = renderWithWorkerRuns(ctx, [
+      makeFamily({ periodMs: 1_800_000, lastSuccessAt }),
+    ]);
+    expect(findBadgeByName(slow.container, "RT").textContent).not.toContain(
+      "⏱",
+    );
+  });
+
+  it("null lastSuccessAt falls back to oldest batch enqueuedAt; zero batches → no glyph", () => {
+    const row = staleGreenE2eRow();
+    const ctx = makeCtx({
+      liveStatus: new Map([[row.key, row]]) as LiveStatusMap,
+    });
+    // Never-succeeded family: oldest batch enqueued 3 h ago, 1 h period →
+    // silent via the §5.2.1 null-fallback rule → glyph.
+    const neverSucceeded = renderWithWorkerRuns(ctx, [
+      makeFamily({ lastSuccessAt: null }),
+    ]);
+    expect(
+      findBadgeByName(neverSucceeded.container, "RT").textContent,
+    ).toContain("⏱");
+    // Zero batches: nothing to reference → never silent → no glyph.
+    const zeroBatches = renderWithWorkerRuns(ctx, [
+      makeFamily({ lastSuccessAt: null, lastRun: null, inflight: null }),
+    ]);
+    expect(
+      findBadgeByName(zeroBatches.container, "RT").textContent,
+    ).not.toContain("⏱");
+  });
+
+  it("renders no glyph when no WorkerRunsProvider is mounted (no-data default)", () => {
+    const row = staleGreenE2eRow();
+    const ctx = makeCtx({
+      liveStatus: new Map([[row.key, row]]) as LiveStatusMap,
+    });
+    const { container } = render(<CellStatus ctx={ctx} />);
+    expect(findBadgeByName(container, "RT").textContent).not.toContain("⏱");
   });
 });

--- a/showcase/shell-dashboard/src/components/cell-pieces.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.tsx
@@ -10,6 +10,11 @@ import type { BadgeRender } from "@/lib/live-status";
 import type { Feature, Integration } from "@/lib/registry";
 import { useLastTransition, deriveFromTo } from "@/hooks/useLastTransition";
 import { formatTs } from "@/lib/format-ts";
+import {
+  useWorkerRuns,
+  isFamilySilent,
+  familyForProbeKey,
+} from "@/lib/worker-runs-context";
 
 export function urlsFor(ctx: CellContext): {
   demoUrl: string;
@@ -225,6 +230,36 @@ function LiveBadge({
   // for rows with state === "degraded" (F5.5 verification). Do NOT remove
   // the amber branch thinking it's dead — the degraded-row path depends on it.
   const eligible = badge.tone === "red" || badge.tone === "amber";
+  // §7.3 clock glyph: a STALE-degraded badge whose worker family has no
+  // successful run within 2× the server-computed `periodMs` gains a `·⏱`
+  // suffix, distinguishing scheduler/worker silence from a fresh red.
+  // Safe by construction without a provider: `useWorkerRuns()` never throws
+  // and returns the no-data default (`null`) — see the T10 no-provider
+  // contract in worker-runs-context.tsx — so provider-less renders simply
+  // show no glyph.
+  const workerRuns = useWorkerRuns();
+  // Stale-degraded signature: amber with `fail_count === 0` — the
+  // stale-green downgrade `buildBadge` applies under the cell's EXISTING
+  // window. A producer-degraded row (`fail_count > 0`) is a real failure,
+  // not staleness, and a red badge keeps its red rendering — the glyph
+  // only ever DECORATES an already stale-degraded badge (§7.3).
+  const isStaleDegraded =
+    badge.tone === "amber" && badge.row !== null && badge.row.fail_count === 0;
+  const families =
+    workerRuns !== null && workerRuns.status === "ok"
+      ? workerRuns.data.families
+      : null;
+  // Family mapping is payload-driven via the `probeKeyPrefix` each family
+  // entry echoes (§5.2.1) — never a dashboard-side prefix table.
+  const silentFamily =
+    isStaleDegraded && families !== null && badge.row !== null
+      ? familyForProbeKey(badge.row.key, families)
+      : undefined;
+  const clockGlyph =
+    silentFamily !== undefined && isFamilySilent(silentFamily, Date.now());
+  // Minimal per §7.3: a label SUFFIX only — tone, tooltip machinery, and the
+  // amber branch above stay intact.
+  const label = clockGlyph ? `${badge.label} ·⏱` : badge.label;
   // B.4: the INITIAL status projection (`STATUS_LIST_FIELDS` in live-status.ts)
   // drops the heavy `signal` blob, so a row materialised from the bulk fetch
   // arrives with `signal === undefined` until a live SSE delta re-attaches it.
@@ -265,7 +300,7 @@ function LiveBadge({
       >
         <Badge
           name={name}
-          state={{ tone: badge.tone, label: badge.label }}
+          state={{ tone: badge.tone, label }}
           href={href}
           title={title}
           onTooltipOpen={() => setTooltipOpen(true)}

--- a/showcase/shell-dashboard/src/components/dashboard-page.tsx
+++ b/showcase/shell-dashboard/src/components/dashboard-page.tsx
@@ -18,6 +18,10 @@ import type { CellContext } from "@/components/feature-grid";
 import { StatusTab } from "@/components/status-tab";
 import { useLiveStatus } from "@/hooks/useLiveStatus";
 import { useProbes, useTriggerProbe } from "@/hooks/use-probes";
+import { useWorkerRunsPoll } from "@/hooks/use-worker-runs";
+import { WorkerRunsProvider } from "@/lib/worker-runs-context";
+import { WorkerRunsSection } from "@/components/worker-runs-section";
+import { WorkerSilenceBanner } from "@/components/worker-silence-banner";
 import { mergeRowsToMap } from "@/lib/live-status";
 import { useOverlays } from "@/hooks/useOverlays";
 import { OverlayToggleBar } from "@/components/overlay-toggle-bar";
@@ -95,6 +99,12 @@ export function DashboardPage({ shellUrl }: DashboardPageProps) {
     () => probesQuery.data?.probes ?? [],
     [probesQuery.data],
   );
+  // §6.1: worker-runs poll beside the probe poll, same ~10 s cadence. The
+  // result feeds WorkerRunsProvider (§7.1) so the ops section, the matrix
+  // staleness consumers, and the coverage banner read it without
+  // prop-drilling run data into matrix internals.
+  const workerRunsStatus = useWorkerRunsPoll();
+
   const triggerToken = process.env.NEXT_PUBLIC_OPS_TRIGGER_TOKEN;
   const { trigger } = useTriggerProbe({ token: triggerToken });
   const handleTrigger = useCallback(
@@ -190,105 +200,114 @@ export function DashboardPage({ shellUrl }: DashboardPageProps) {
   );
 
   return (
-    <div data-testid="tab-shell" className="h-dvh flex flex-col">
-      {/* Tab bar — pinned above scroll area */}
-      <div className="flex-shrink-0 flex items-center gap-0 border-b border-[var(--border)] px-8">
-        <button
-          type="button"
-          data-testid="tab-matrix"
-          onClick={() => setTab("matrix")}
-          className={`px-4 py-2.5 text-sm font-medium transition-colors cursor-pointer ${
-            activeTab === "matrix"
-              ? "text-[var(--accent)] border-b-2 border-[var(--accent)] -mb-px"
-              : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-          }`}
-        >
-          Coverage
-        </button>
-        <button
-          type="button"
-          data-testid="tab-baseline"
-          onClick={() => setTab("baseline")}
-          className={`px-4 py-2.5 text-sm font-medium transition-colors cursor-pointer ${
-            activeTab === "baseline"
-              ? "text-[var(--accent)] border-b-2 border-[var(--accent)] -mb-px"
-              : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-          }`}
-        >
-          Baseline
-        </button>
-        <button
-          type="button"
-          data-testid="tab-ops"
-          onClick={() => setTab("ops")}
-          className={`px-4 py-2.5 text-sm font-medium transition-colors cursor-pointer ${
-            activeTab === "ops"
-              ? "text-[var(--accent)] border-b-2 border-[var(--accent)] -mb-px"
-              : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-          }`}
-        >
-          Ops
-        </button>
-        <div className="ml-auto flex items-center pr-1">
-          <ThemeToggle />
-        </div>
-      </div>
-
-      <DiscoveryAuthBanner rows={allStatus.rows} />
-
-      {activeTab === "matrix" && (
-        <>
-          {/* Overlay toggle — pinned below tab bar */}
-          <div className="flex-shrink-0 px-8 py-3 bg-[var(--bg-surface)] border-b border-[var(--border)]">
-            <OverlayToggleBar
-              overlays={overlays}
-              onToggle={toggle}
-              onApplyPreset={applyPreset}
-              activePreset={activePreset}
-            />
+    <WorkerRunsProvider value={workerRunsStatus}>
+      <div data-testid="tab-shell" className="h-dvh flex flex-col">
+        {/* Tab bar — pinned above scroll area */}
+        <div className="flex-shrink-0 flex items-center gap-0 border-b border-[var(--border)] px-8">
+          <button
+            type="button"
+            data-testid="tab-matrix"
+            onClick={() => setTab("matrix")}
+            className={`px-4 py-2.5 text-sm font-medium transition-colors cursor-pointer ${
+              activeTab === "matrix"
+                ? "text-[var(--accent)] border-b-2 border-[var(--accent)] -mb-px"
+                : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+            }`}
+          >
+            Coverage
+          </button>
+          <button
+            type="button"
+            data-testid="tab-baseline"
+            onClick={() => setTab("baseline")}
+            className={`px-4 py-2.5 text-sm font-medium transition-colors cursor-pointer ${
+              activeTab === "baseline"
+                ? "text-[var(--accent)] border-b-2 border-[var(--accent)] -mb-px"
+                : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+            }`}
+          >
+            Baseline
+          </button>
+          <button
+            type="button"
+            data-testid="tab-ops"
+            onClick={() => setTab("ops")}
+            className={`px-4 py-2.5 text-sm font-medium transition-colors cursor-pointer ${
+              activeTab === "ops"
+                ? "text-[var(--accent)] border-b-2 border-[var(--accent)] -mb-px"
+                : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+            }`}
+          >
+            Ops
+          </button>
+          <div className="ml-auto flex items-center pr-1">
+            <ThemeToggle />
           </div>
-          {/* Single scroll area — stats bar and title scroll away, table headers stick */}
-          <div className="flex-1 min-h-0 overflow-auto pb-12">
-            <div className="px-8 py-3 border-b border-[var(--border)]">
-              <AdaptiveStatsBar
+        </div>
+
+        <DiscoveryAuthBanner rows={allStatus.rows} />
+
+        {activeTab === "matrix" && (
+          <>
+            {/* §7.4: coverage-tab silence banner — matrix-tab-scoped (first
+              child of this block), styled after the DiscoveryAuthBanner
+              slot pattern but deliberately NOT mounted beside it: the
+              banner is coverage-tab intent, not global. */}
+            <WorkerSilenceBanner />
+            {/* Overlay toggle — pinned below tab bar */}
+            <div className="flex-shrink-0 px-8 py-3 bg-[var(--bg-surface)] border-b border-[var(--border)]">
+              <OverlayToggleBar
                 overlays={overlays}
-                catalog={catalogData}
-                healthStats={healthStats}
-                parityStats={parityStats}
-                docsStats={docsStats}
-                depthDistribution={depthDistribution}
-                d6Stats={d6Stats}
+                onToggle={toggle}
+                onApplyPreset={applyPreset}
+                activePreset={activePreset}
               />
             </div>
-            <FeatureGrid
-              title="Feature Matrix"
-              renderCell={renderCell}
-              minColWidth={180}
-              liveStatus={liveStatus}
-              connection={connection}
-              degraded={allStatus.degraded}
-              now={now}
-              overlays={overlays}
-              catalog={catalogData}
-              shellUrl={shellUrl}
+            {/* Single scroll area — stats bar and title scroll away, table headers stick */}
+            <div className="flex-1 min-h-0 overflow-auto pb-12">
+              <div className="px-8 py-3 border-b border-[var(--border)]">
+                <AdaptiveStatsBar
+                  overlays={overlays}
+                  catalog={catalogData}
+                  healthStats={healthStats}
+                  parityStats={parityStats}
+                  docsStats={docsStats}
+                  depthDistribution={depthDistribution}
+                  d6Stats={d6Stats}
+                />
+              </div>
+              <FeatureGrid
+                title="Feature Matrix"
+                renderCell={renderCell}
+                minColWidth={180}
+                liveStatus={liveStatus}
+                connection={connection}
+                degraded={allStatus.degraded}
+                now={now}
+                overlays={overlays}
+                catalog={catalogData}
+                shellUrl={shellUrl}
+              />
+              <AdaptiveLegend overlays={overlays} />
+            </div>
+          </>
+        )}
+
+        {activeTab === "baseline" && <BaselineTab />}
+
+        {activeTab === "ops" && (
+          <div className="flex-1 min-h-0 overflow-auto">
+            {/* §6.2: worker-runs section ABOVE the probe Schedule table. */}
+            <WorkerRunsSection probeEntries={probeEntries} />
+            <StatusTab
+              entries={probeEntries}
+              onTrigger={handleTrigger}
+              selectedProbeId={selectedProbeId}
+              onSelectProbe={selectProbe}
             />
-            <AdaptiveLegend overlays={overlays} />
           </div>
-        </>
-      )}
-
-      {activeTab === "baseline" && <BaselineTab />}
-
-      {activeTab === "ops" && (
-        <div className="flex-1 min-h-0 overflow-auto">
-          <StatusTab
-            entries={probeEntries}
-            onTrigger={handleTrigger}
-            selectedProbeId={selectedProbeId}
-            onSelectProbe={selectProbe}
-          />
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+    </WorkerRunsProvider>
   );
 }

--- a/showcase/shell-dashboard/src/components/worker-run-detail-panel.test.tsx
+++ b/showcase/shell-dashboard/src/components/worker-run-detail-panel.test.tsx
@@ -1,0 +1,313 @@
+/**
+ * Unit tests for WorkerRunDetailPanel (spec §6.2) — the run-history
+ * drill-down opened from a worker-runs-table row.
+ *
+ * Mocks `globalThis.fetch` (the ops-api fetchers run against jsdom's
+ * default `/api/ops` base) and dispatches on URL: `/api/ops/runs/:family`
+ * for history pages, `/api/ops/runs/:family/:runId` for the per-service
+ * drill-down. Real timers — the §6.1 throttle test uses `Retry-After: 0`
+ * so the fetcher's internal retry loop completes immediately.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+
+import { WorkerRunDetailPanel } from "./worker-run-detail-panel";
+import type {
+  WorkerRunBatch,
+  WorkerRunDetailResponse,
+  WorkerRunHistoryResponse,
+  WorkerRunJob,
+} from "../lib/ops-api";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function batch(overrides: Partial<WorkerRunBatch> = {}): WorkerRunBatch {
+  return {
+    runId: "01JRUNA",
+    triggered: false,
+    enqueuedAt: "2026-06-10T11:25:00.000Z",
+    finishedAt: "2026-06-10T11:32:00.000Z",
+    durationMs: 7 * 60_000,
+    outcome: "completed",
+    jobs: { total: 19, done: 19, failed: 0, reclaimed: 0 },
+    cells: { total: 152, passed: 152, failed: 0 },
+    redsIntroduced: 0,
+    redsCleared: 0,
+    errorSummary: null,
+    commErrorKinds: [],
+    ...overrides,
+  };
+}
+
+function job(overrides: Partial<WorkerRunJob> = {}): WorkerRunJob {
+  return {
+    jobId: "job-1",
+    probeKey: "d5-single-pill-e2e:agno",
+    serviceSlug: "agno",
+    status: "failed",
+    claimedBy: "worker-railway-abc",
+    enqueuedAt: "2026-06-10T11:25:00.000Z",
+    claimedAt: "2026-06-10T11:25:04.100Z",
+    finishedAt: "2026-06-10T11:28:16.444Z",
+    queueLatencyMs: 4100,
+    durationMs: 192_344,
+    reclaimCount: 0,
+    cells: { total: 8, passed: 6, failed: 2 },
+    errorSummary: "d5-single-pill-e2e:agno — 2/8 cells failed",
+    commError: {
+      kind: "worker-crashed-mid-job",
+      observedAt: "2026-06-10T11:28:16.444Z",
+    },
+    ...overrides,
+  };
+}
+
+function historyResponse(
+  overrides: Partial<WorkerRunHistoryResponse> = {},
+): WorkerRunHistoryResponse {
+  return {
+    family: "d5",
+    runs: [batch()],
+    perPage: 20,
+    nextBefore: null,
+    nextBeforeId: null,
+    ...overrides,
+  };
+}
+
+function detailResponse(
+  overrides: Partial<WorkerRunDetailResponse> = {},
+): WorkerRunDetailResponse {
+  return { family: "d5", runId: "01JRUNA", jobs: [job()], ...overrides };
+}
+
+/** Stub fetch with a URL-dispatched handler map. */
+function stubFetch(
+  handler: (url: string) => Response | Promise<Response>,
+): ReturnType<typeof vi.fn> {
+  const spy = vi.fn(async (input: RequestInfo | URL) => handler(String(input)));
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+
+describe("WorkerRunDetailPanel", () => {
+  it("returns null when family is null", () => {
+    stubFetch(() => jsonResponse(historyResponse()));
+    const { container } = render(
+      <WorkerRunDetailPanel family={null} onClose={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the history batches with outcome chips and triggered badge", async () => {
+    stubFetch(() =>
+      jsonResponse(
+        historyResponse({
+          runs: [
+            batch({ runId: "01JRUNA", outcome: "failed", triggered: true }),
+            batch({ runId: "01JRUNB", outcome: "completed" }),
+          ],
+        }),
+      ),
+    );
+    const { getByTestId } = render(
+      <WorkerRunDetailPanel family="d5" onClose={() => {}} />,
+    );
+    await waitFor(() => {
+      expect(getByTestId("worker-run-batch-01JRUNA")).toBeDefined();
+    });
+    expect(getByTestId("worker-run-batch-01JRUNB")).toBeDefined();
+    const outcomeA = getByTestId("worker-run-batch-01JRUNA-outcome");
+    expect(outcomeA.getAttribute("data-outcome")).toBe("failed");
+    expect(getByTestId("worker-run-batch-01JRUNA").textContent).toContain(
+      "manual",
+    );
+  });
+
+  it("expands a batch to the per-service job table with errorSummary inline and the unreachable comm-kind badge", async () => {
+    stubFetch((url) =>
+      url.includes("/runs/d5/01JRUNA")
+        ? jsonResponse(detailResponse())
+        : jsonResponse(historyResponse()),
+    );
+    const { getByTestId } = render(
+      <WorkerRunDetailPanel family="d5" onClose={() => {}} />,
+    );
+    await waitFor(() => {
+      expect(getByTestId("worker-run-batch-01JRUNA")).toBeDefined();
+    });
+    fireEvent.click(getByTestId("worker-run-batch-01JRUNA"));
+    await waitFor(() => {
+      expect(getByTestId("worker-run-job-job-1")).toBeDefined();
+    });
+    const row = getByTestId("worker-run-job-job-1");
+    expect(row.textContent).toContain("agno");
+    expect(row.textContent).toContain("worker-railway-abc");
+    expect(row.textContent).toContain(
+      "d5-single-pill-e2e:agno — 2/8 cells failed",
+    );
+    const badge = row.querySelector('[data-testid="comm-kind-badge"]');
+    expect(badge).not.toBeNull();
+    expect(badge!.getAttribute("data-kind")).toBe("worker-crashed-mid-job");
+    expect(badge!.getAttribute("data-treatment")).toBe("unreachable");
+  });
+
+  it("renders worker-reclaimed-pending comm errors as the gray re-queued badge, never red", async () => {
+    stubFetch((url) =>
+      url.includes("/runs/d5/01JRUNA")
+        ? jsonResponse(
+            detailResponse({
+              jobs: [
+                job({
+                  status: "pending",
+                  commError: {
+                    kind: "worker-reclaimed-pending",
+                    observedAt: "2026-06-10T11:28:16.444Z",
+                  },
+                  errorSummary: null,
+                }),
+              ],
+            }),
+          )
+        : jsonResponse(historyResponse()),
+    );
+    const { getByTestId } = render(
+      <WorkerRunDetailPanel family="d5" onClose={() => {}} />,
+    );
+    await waitFor(() => {
+      expect(getByTestId("worker-run-batch-01JRUNA")).toBeDefined();
+    });
+    fireEvent.click(getByTestId("worker-run-batch-01JRUNA"));
+    await waitFor(() => {
+      expect(getByTestId("worker-run-job-job-1")).toBeDefined();
+    });
+    const badge = getByTestId("worker-run-job-job-1").querySelector(
+      '[data-testid="comm-kind-badge"]',
+    );
+    expect(badge).not.toBeNull();
+    expect(badge!.getAttribute("data-treatment")).toBe("pending");
+    expect(badge!.textContent).toContain("re-queued");
+    expect(badge!.className).not.toContain("--danger");
+    expect(badge!.className).not.toContain("indigo");
+  });
+
+  it("a 429/ThrottledError on the detail panel renders the throttled-retrying hint and does NOT trip the unreachable treatment", async () => {
+    // Every history request answers 429 with Retry-After: 0 so the
+    // fetcher's capped internal retry loop (3 attempts) exhausts
+    // immediately and throws ThrottledError.
+    stubFetch(
+      () => new Response("", { status: 429, headers: { "retry-after": "0" } }),
+    );
+    const { getByTestId, queryByTestId } = render(
+      <WorkerRunDetailPanel family="d5" onClose={() => {}} />,
+    );
+    await waitFor(() => {
+      expect(getByTestId("worker-run-detail-throttled")).toBeDefined();
+    });
+    expect(getByTestId("worker-run-detail-throttled").textContent).toContain(
+      "throttled — retrying",
+    );
+    // NON-incident (§6.1): no error panel, no unreachable treatment.
+    expect(queryByTestId("worker-run-detail-error")).toBeNull();
+    expect(getByTestId("worker-run-detail-panel").textContent).not.toContain(
+      "unreachable",
+    );
+    // The retry affordance re-issues the request.
+    expect(getByTestId("worker-run-detail-retry")).toBeDefined();
+  });
+
+  it("truncated batches render the honest-partial marker", async () => {
+    stubFetch(() =>
+      jsonResponse(
+        historyResponse({
+          runs: [batch({ runId: "01JRUNT", truncated: true })],
+        }),
+      ),
+    );
+    const { getByTestId } = render(
+      <WorkerRunDetailPanel family="d5" onClose={() => {}} />,
+    );
+    await waitFor(() => {
+      expect(getByTestId("worker-run-batch-01JRUNT-truncated")).toBeDefined();
+    });
+    expect(
+      getByTestId("worker-run-batch-01JRUNT-truncated").textContent,
+    ).toContain("partial");
+  });
+
+  it("pages older history via the composite cursor echoed verbatim", async () => {
+    const before = "2026-06-10T10:00:00.000Z";
+    const beforeId = "row99";
+    const spy = stubFetch((url) => {
+      const parsed = new URL(url, "http://localhost");
+      if (parsed.searchParams.get("before") === before) {
+        return jsonResponse(
+          historyResponse({ runs: [batch({ runId: "01JRUNOLD" })] }),
+        );
+      }
+      return jsonResponse(
+        historyResponse({
+          runs: [batch({ runId: "01JRUNA" })],
+          nextBefore: before,
+          nextBeforeId: beforeId,
+        }),
+      );
+    });
+    const { getByTestId } = render(
+      <WorkerRunDetailPanel family="d5" onClose={() => {}} />,
+    );
+    await waitFor(() => {
+      expect(getByTestId("worker-run-detail-load-more")).toBeDefined();
+    });
+    fireEvent.click(getByTestId("worker-run-detail-load-more"));
+    await waitFor(() => {
+      expect(getByTestId("worker-run-batch-01JRUNOLD")).toBeDefined();
+    });
+    // Both cursor fields echoed verbatim (§5.2.2 — never `before` alone).
+    const pagedCall = spy.mock.calls
+      .map((c) => String(c[0]))
+      .find((u) => u.includes("before="));
+    expect(pagedCall).toBeDefined();
+    const parsed = new URL(pagedCall!, "http://localhost");
+    expect(parsed.searchParams.get("before")).toBe(before);
+    expect(parsed.searchParams.get("beforeId")).toBe(beforeId);
+    // First page still rendered (appended, not replaced).
+    expect(getByTestId("worker-run-batch-01JRUNA")).toBeDefined();
+  });
+
+  it("renders the panel-local history-unavailable error when the response carries the marker", async () => {
+    stubFetch(() =>
+      jsonResponse(historyResponse({ runs: [], error: "history_unavailable" })),
+    );
+    const { getByTestId } = render(
+      <WorkerRunDetailPanel family="d5" onClose={() => {}} />,
+    );
+    await waitFor(() => {
+      expect(getByTestId("worker-run-detail-error")).toBeDefined();
+    });
+    expect(getByTestId("worker-run-detail-error").textContent).toContain(
+      "run history backend unreachable",
+    );
+  });
+
+  it("invokes onClose from the close button", async () => {
+    stubFetch(() => jsonResponse(historyResponse()));
+    const onClose = vi.fn();
+    const { getByTestId } = render(
+      <WorkerRunDetailPanel family="d5" onClose={onClose} />,
+    );
+    fireEvent.click(getByTestId("worker-run-detail-close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/showcase/shell-dashboard/src/components/worker-run-detail-panel.tsx
+++ b/showcase/shell-dashboard/src/components/worker-run-detail-panel.tsx
@@ -23,7 +23,7 @@
  * Cursor paging is strictly §5.2.2: `nextBefore`/`nextBeforeId` echoed
  * back verbatim as a composite pair — never `before` alone.
  */
-import { Fragment, useCallback, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useRef, useState } from "react";
 
 import { formatDuration, formatRelative } from "./status-table";
 import { OutcomeChip } from "./worker-runs-table";
@@ -177,16 +177,27 @@ export function WorkerRunDetailPanel({
   // Bumping this re-runs the load effect from scratch — the manual retry
   // affordance for the throttled/error states.
   const [reloadKey, setReloadKey] = useState(0);
+  // Shared abort controller covering BOTH the first-page effect and any
+  // in-flight `loadMore` page-N fetch: cancelled together on cleanup
+  // (panel close / family change / unmount) so stale rows never append.
+  const loadAbortRef = useRef<AbortController | null>(null);
+  // Dedupe drill-down fetches without doing async work inside a setState
+  // updater. Under React StrictMode the updater is invoked twice; gating
+  // on a ref (not on the state snapshot the updater receives) means the
+  // network call fires exactly once regardless.
+  const jobsRequestedRef = useRef<Set<string>>(new Set());
 
   // First page load (and full reset) whenever the family changes.
   useEffect(() => {
     if (family === null) return;
     let cancelled = false;
     const controller = new AbortController();
+    loadAbortRef.current = controller;
     setBatches([]);
     setCursor(null);
     setExpanded(new Set());
     setJobsByRun({});
+    jobsRequestedRef.current = new Set();
     setHistory({ state: "loading" });
     (async () => {
       try {
@@ -224,13 +235,24 @@ export function WorkerRunDetailPanel({
     return () => {
       cancelled = true;
       controller.abort();
+      if (loadAbortRef.current === controller) {
+        loadAbortRef.current = null;
+      }
     };
   }, [family, reloadKey]);
 
   const loadMore = useCallback(async () => {
     if (family === null || cursor === null) return;
+    // Share the cleanup-triggered AbortController with the first-page
+    // effect so a pending page-2 fetch is cancelled on panel close or
+    // family change — preventing stale rows from appending.
+    const controller = loadAbortRef.current ?? new AbortController();
+    if (loadAbortRef.current === null) loadAbortRef.current = controller;
     try {
-      const res = await fetchWorkerRunHistory(family, cursor);
+      const res = await fetchWorkerRunHistory(family, cursor, {
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted) return;
       if (res.error === "history_unavailable") {
         setHistory({
           state: "error",
@@ -245,6 +267,7 @@ export function WorkerRunDetailPanel({
           : null,
       );
     } catch (err) {
+      if (controller.signal.aborted) return;
       if ((err as { name?: string })?.name === "AbortError") return;
       if (err instanceof ThrottledError) {
         setHistory({ state: "throttled" });
@@ -269,42 +292,47 @@ export function WorkerRunDetailPanel({
         next.add(runId);
         return next;
       });
-      // Lazy-load the drill-down once per batch.
-      setJobsByRun((prev) => {
-        if (prev[runId]) return prev;
-        void (async () => {
-          try {
-            const res = await fetchWorkerRunDetail(family, runId);
-            if (res.error === "history_unavailable") {
-              setJobsByRun((p) => ({
-                ...p,
-                [runId]: {
-                  state: "error",
-                  message: "run history backend unreachable",
-                },
-              }));
-              return;
-            }
+      // Lazy-load the drill-down once per batch. The dedupe gate is a ref
+      // (not the setState snapshot) so StrictMode's double-invoke of any
+      // updater can never double-fire the network request. The side-effect
+      // happens OUTSIDE setJobsByRun for the same reason: updaters must be
+      // pure.
+      if (jobsRequestedRef.current.has(runId)) return;
+      jobsRequestedRef.current.add(runId);
+      setJobsByRun((prev) =>
+        prev[runId] ? prev : { ...prev, [runId]: { state: "loading" } },
+      );
+      void (async () => {
+        try {
+          const res = await fetchWorkerRunDetail(family, runId);
+          if (res.error === "history_unavailable") {
             setJobsByRun((p) => ({
               ...p,
-              [runId]: { state: "ok", jobs: res.jobs },
+              [runId]: {
+                state: "error",
+                message: "run history backend unreachable",
+              },
             }));
-          } catch (err) {
-            if ((err as { name?: string })?.name === "AbortError") return;
-            setJobsByRun((p) => ({
-              ...p,
-              [runId]:
-                err instanceof ThrottledError
-                  ? { state: "throttled" }
-                  : {
-                      state: "error",
-                      message: (err as Error)?.message ?? "unknown error",
-                    },
-            }));
+            return;
           }
-        })();
-        return { ...prev, [runId]: { state: "loading" } };
-      });
+          setJobsByRun((p) => ({
+            ...p,
+            [runId]: { state: "ok", jobs: res.jobs },
+          }));
+        } catch (err) {
+          if ((err as { name?: string })?.name === "AbortError") return;
+          setJobsByRun((p) => ({
+            ...p,
+            [runId]:
+              err instanceof ThrottledError
+                ? { state: "throttled" }
+                : {
+                    state: "error",
+                    message: (err as Error)?.message ?? "unknown error",
+                  },
+          }));
+        }
+      })();
     },
     [family],
   );

--- a/showcase/shell-dashboard/src/components/worker-run-detail-panel.tsx
+++ b/showcase/shell-dashboard/src/components/worker-run-detail-panel.tsx
@@ -1,0 +1,504 @@
+"use client";
+/**
+ * WorkerRunDetailPanel — run-history drill-down for one worker family
+ * (spec §6.2), opened when the operator clicks a worker-runs-table row.
+ * Same slide-in composition as StatusDetailPanel: header + close, then
+ * the history list (last 20 batches via `GET /api/runs/:family`, rows
+ * styled like status-runs-list), each batch expandable to the
+ * per-service job table (`GET /api/runs/:family/:runId`).
+ *
+ * Failure posture (§6.1/§6.3, panel-LOCAL — this panel never touches
+ * the section's unavailable state):
+ *   - `429`/ThrottledError from either drill-down route is explicitly
+ *     NON-incident: the CP is alive and deliberately throttling. The
+ *     fetchers already honor Retry-After with a capped internal retry;
+ *     when they exhaust, the panel renders a transient "throttled —
+ *     retrying…" hint with a manual retry affordance — never the
+ *     unreachable treatment.
+ *   - a response carrying `error: "history_unavailable"` (PB down while
+ *     the CP answers) renders the panel-local red error line.
+ *   - `truncated: true` batches (§5.2.2 degenerate clamp) render an
+ *     honest-partial marker: every count may undercount.
+ *
+ * Cursor paging is strictly §5.2.2: `nextBefore`/`nextBeforeId` echoed
+ * back verbatim as a composite pair — never `before` alone.
+ */
+import { Fragment, useCallback, useEffect, useState } from "react";
+
+import { formatDuration, formatRelative } from "./status-table";
+import { OutcomeChip } from "./worker-runs-table";
+import {
+  fetchWorkerRunDetail,
+  fetchWorkerRunHistory,
+  ThrottledError,
+  type WorkerRunBatch,
+  type WorkerRunJob,
+  type WorkerRunsCursor,
+} from "../lib/ops-api";
+
+export interface WorkerRunDetailPanelProps {
+  /** Family id, or null = panel closed (renders nothing). */
+  family: string | null;
+  onClose: () => void;
+}
+
+/** Per-batch drill-down (jobs) load state. */
+type JobsState =
+  | { state: "loading" }
+  | { state: "ok"; jobs: WorkerRunJob[] }
+  | { state: "throttled" }
+  | { state: "error"; message: string };
+
+/** History list load state — `throttled` is the §6.1 non-incident path. */
+type HistoryState =
+  | { state: "loading" }
+  | { state: "ok" }
+  | { state: "throttled" }
+  | { state: "error"; message: string };
+
+function useNowTick(): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return now;
+}
+
+/**
+ * §6.2/§6.3 comm-error kind badge. `worker-reclaimed-pending` is the
+ * NEUTRAL reclaim taxonomy value (contracts.ts) — gray "re-queued",
+ * never red — while every terminal kind gets the same indigo
+ * "unreachable" treatment the matrix's comm-error overlay uses
+ * (`FleetSurfaceState` in live-status.ts / depth-chip's ⚡ branch).
+ * The kind is enum-validated server-side (closed vocabulary; unknown
+ * values arrive as "unknown") — safe to render verbatim.
+ */
+export function CommErrorKindBadge({ kind }: { kind: string }) {
+  if (kind === "worker-reclaimed-pending") {
+    return (
+      <span
+        data-testid="comm-kind-badge"
+        data-kind={kind}
+        data-treatment="pending"
+        className="inline-flex items-center gap-1 rounded border border-[var(--text-muted)]/40 bg-[var(--text-muted)]/20 px-1.5 py-0.5 text-[10px] text-[var(--text-muted)]"
+        title={kind}
+      >
+        ⟳ re-queued
+      </span>
+    );
+  }
+  return (
+    <span
+      data-testid="comm-kind-badge"
+      data-kind={kind}
+      data-treatment="unreachable"
+      className="inline-flex items-center gap-1 rounded border border-indigo-400/60 bg-indigo-500/20 px-1.5 py-0.5 text-[10px] text-indigo-300"
+      title={kind}
+    >
+      ⚡ {kind}
+    </span>
+  );
+}
+
+/** Per-service job table for one expanded batch (§5.2.3 shape). */
+function JobsTable({ jobs }: { jobs: WorkerRunJob[] }) {
+  return (
+    <table className="w-full text-sm border-collapse">
+      <thead>
+        <tr className="text-left text-xs uppercase tracking-wide text-[var(--text-muted)] border-b border-[var(--border)]">
+          <th className="py-1.5 pr-4">Service</th>
+          <th className="py-1.5 pr-4">Worker</th>
+          <th className="py-1.5 pr-4">Queue latency</th>
+          <th className="py-1.5 pr-4">Duration</th>
+          <th className="py-1.5 pr-4">Outcome</th>
+          <th className="py-1.5">Error</th>
+        </tr>
+      </thead>
+      <tbody>
+        {jobs.map((job) => (
+          <tr
+            key={job.jobId}
+            data-testid={`worker-run-job-${job.jobId}`}
+            className="border-b border-[var(--border)]"
+          >
+            <td className="py-1.5 pr-4 text-xs font-mono">{job.serviceSlug}</td>
+            <td className="py-1.5 pr-4 text-xs font-mono">
+              {job.claimedBy ?? "—"}
+            </td>
+            <td className="py-1.5 pr-4 text-xs tabular-nums">
+              {job.queueLatencyMs != null
+                ? formatDuration(job.queueLatencyMs)
+                : "—"}
+            </td>
+            <td className="py-1.5 pr-4 text-xs tabular-nums">
+              {job.durationMs != null ? formatDuration(job.durationMs) : "—"}
+            </td>
+            <td className="py-1.5 pr-4 text-xs" data-status={job.status}>
+              {job.status}
+              {job.reclaimCount > 0 ? (
+                <span
+                  className="ml-1 text-[10px] text-[var(--text-muted)]"
+                  title="hook-stamped reclaim count (§4.2)"
+                >
+                  ×{job.reclaimCount} reclaimed
+                </span>
+              ) : null}
+            </td>
+            <td className="py-1.5 text-xs">
+              <span className="flex items-center gap-1.5 flex-wrap">
+                {job.errorSummary ? (
+                  <span className="text-[var(--danger)]">
+                    {job.errorSummary}
+                  </span>
+                ) : null}
+                {job.commError ? (
+                  <CommErrorKindBadge kind={job.commError.kind} />
+                ) : null}
+              </span>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export function WorkerRunDetailPanel({
+  family,
+  onClose,
+}: WorkerRunDetailPanelProps) {
+  const now = useNowTick();
+  const [batches, setBatches] = useState<WorkerRunBatch[]>([]);
+  const [cursor, setCursor] = useState<WorkerRunsCursor | null>(null);
+  const [history, setHistory] = useState<HistoryState>({ state: "loading" });
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [jobsByRun, setJobsByRun] = useState<Record<string, JobsState>>({});
+  // Bumping this re-runs the load effect from scratch — the manual retry
+  // affordance for the throttled/error states.
+  const [reloadKey, setReloadKey] = useState(0);
+
+  // First page load (and full reset) whenever the family changes.
+  useEffect(() => {
+    if (family === null) return;
+    let cancelled = false;
+    const controller = new AbortController();
+    setBatches([]);
+    setCursor(null);
+    setExpanded(new Set());
+    setJobsByRun({});
+    setHistory({ state: "loading" });
+    (async () => {
+      try {
+        const res = await fetchWorkerRunHistory(family, undefined, {
+          signal: controller.signal,
+        });
+        if (cancelled) return;
+        if (res.error === "history_unavailable") {
+          setHistory({
+            state: "error",
+            message: "run history backend unreachable",
+          });
+          return;
+        }
+        setBatches(res.runs);
+        setCursor(
+          res.nextBefore !== null && res.nextBeforeId !== null
+            ? { before: res.nextBefore, beforeId: res.nextBeforeId }
+            : null,
+        );
+        setHistory({ state: "ok" });
+      } catch (err) {
+        if (cancelled) return;
+        if ((err as { name?: string })?.name === "AbortError") return;
+        if (err instanceof ThrottledError) {
+          setHistory({ state: "throttled" });
+          return;
+        }
+        setHistory({
+          state: "error",
+          message: (err as Error)?.message ?? "unknown error",
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [family, reloadKey]);
+
+  const loadMore = useCallback(async () => {
+    if (family === null || cursor === null) return;
+    try {
+      const res = await fetchWorkerRunHistory(family, cursor);
+      if (res.error === "history_unavailable") {
+        setHistory({
+          state: "error",
+          message: "run history backend unreachable",
+        });
+        return;
+      }
+      setBatches((prev) => [...prev, ...res.runs]);
+      setCursor(
+        res.nextBefore !== null && res.nextBeforeId !== null
+          ? { before: res.nextBefore, beforeId: res.nextBeforeId }
+          : null,
+      );
+    } catch (err) {
+      if ((err as { name?: string })?.name === "AbortError") return;
+      if (err instanceof ThrottledError) {
+        setHistory({ state: "throttled" });
+        return;
+      }
+      setHistory({
+        state: "error",
+        message: (err as Error)?.message ?? "unknown error",
+      });
+    }
+  }, [family, cursor]);
+
+  const toggleBatch = useCallback(
+    (runId: string) => {
+      if (family === null) return;
+      setExpanded((prev) => {
+        const next = new Set(prev);
+        if (next.has(runId)) {
+          next.delete(runId);
+          return next;
+        }
+        next.add(runId);
+        return next;
+      });
+      // Lazy-load the drill-down once per batch.
+      setJobsByRun((prev) => {
+        if (prev[runId]) return prev;
+        void (async () => {
+          try {
+            const res = await fetchWorkerRunDetail(family, runId);
+            if (res.error === "history_unavailable") {
+              setJobsByRun((p) => ({
+                ...p,
+                [runId]: {
+                  state: "error",
+                  message: "run history backend unreachable",
+                },
+              }));
+              return;
+            }
+            setJobsByRun((p) => ({
+              ...p,
+              [runId]: { state: "ok", jobs: res.jobs },
+            }));
+          } catch (err) {
+            if ((err as { name?: string })?.name === "AbortError") return;
+            setJobsByRun((p) => ({
+              ...p,
+              [runId]:
+                err instanceof ThrottledError
+                  ? { state: "throttled" }
+                  : {
+                      state: "error",
+                      message: (err as Error)?.message ?? "unknown error",
+                    },
+            }));
+          }
+        })();
+        return { ...prev, [runId]: { state: "loading" } };
+      });
+    },
+    [family],
+  );
+
+  if (family === null) return null;
+
+  return (
+    <div
+      data-testid="worker-run-detail-panel"
+      className="px-0 py-4 border-t border-[var(--border)] flex flex-col gap-4"
+    >
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-mono text-[var(--text-secondary)]">
+          {family} — run history
+        </div>
+        <button
+          type="button"
+          data-testid="worker-run-detail-close"
+          onClick={onClose}
+          className="text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)] px-2 py-1 rounded border border-[var(--border)]"
+          aria-label="Close run history"
+        >
+          Close
+        </button>
+      </div>
+
+      {history.state === "loading" && batches.length === 0 && (
+        <div className="text-xs text-[var(--text-muted)]">Loading…</div>
+      )}
+
+      {/* §6.1: throttling is NON-incident — a transient hint plus a manual
+          retry affordance, never the unreachable/error treatment. */}
+      {history.state === "throttled" && (
+        <div
+          data-testid="worker-run-detail-throttled"
+          className="text-xs text-[var(--text-muted)] flex items-center gap-2"
+        >
+          <span>throttled — retrying…</span>
+          <button
+            type="button"
+            data-testid="worker-run-detail-retry"
+            onClick={() => setReloadKey((k) => k + 1)}
+            className="px-2 py-0.5 rounded border border-[var(--border)] hover:text-[var(--text-primary)]"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {history.state === "error" && (
+        <div
+          data-testid="worker-run-detail-error"
+          className="text-xs text-[var(--danger)]"
+        >
+          Failed to load run history: {history.message}
+        </div>
+      )}
+
+      {history.state === "ok" && batches.length === 0 && (
+        <div className="text-xs text-[var(--text-muted)]">
+          No runs recorded.
+        </div>
+      )}
+
+      {batches.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="text-left text-xs uppercase tracking-wide text-[var(--text-muted)] border-b border-[var(--border)]">
+                <th className="py-2 pr-4">Started</th>
+                <th className="py-2 pr-4">Duration</th>
+                <th className="py-2 pr-4">Outcome</th>
+                <th className="py-2 pr-4">Triggered</th>
+                <th className="py-2 pr-4">Jobs</th>
+                <th className="py-2">Reds</th>
+              </tr>
+            </thead>
+            <tbody>
+              {batches.map((b) => {
+                const startedMs = Date.parse(b.enqueuedAt);
+                const isExpanded = expanded.has(b.runId);
+                const jobsState = jobsByRun[b.runId];
+                const reds =
+                  (b.redsIntroduced ?? 0) > 0 || (b.redsCleared ?? 0) > 0
+                    ? `+${b.redsIntroduced ?? 0} / −${b.redsCleared ?? 0}`
+                    : null;
+                return (
+                  <Fragment key={b.runId}>
+                    <tr
+                      data-testid={`worker-run-batch-${b.runId}`}
+                      onClick={() => toggleBatch(b.runId)}
+                      className="border-b border-[var(--border)] hover:bg-[var(--surface-hover)] cursor-pointer"
+                    >
+                      <td className="py-2 pr-4 text-xs tabular-nums">
+                        <span
+                          className="inline-block mr-1.5 text-[10px] text-[var(--text-muted)] transition-transform"
+                          style={{
+                            transform: isExpanded
+                              ? "rotate(90deg)"
+                              : "rotate(0deg)",
+                          }}
+                        >
+                          ▶
+                        </span>
+                        {Number.isFinite(startedMs)
+                          ? formatRelative(startedMs, now)
+                          : b.enqueuedAt}
+                        {b.truncated ? (
+                          <span
+                            data-testid={`worker-run-batch-${b.runId}-truncated`}
+                            className="ml-1.5 inline-block rounded border border-[var(--amber)] px-1 py-0.5 text-[10px] text-[var(--amber)]"
+                            title="batch larger than the capped fetch window — every count may undercount (§5.2.2)"
+                          >
+                            partial
+                          </span>
+                        ) : null}
+                      </td>
+                      <td className="py-2 pr-4 text-xs tabular-nums">
+                        {b.durationMs != null
+                          ? formatDuration(b.durationMs)
+                          : "—"}
+                      </td>
+                      <td className="py-2 pr-4 text-xs">
+                        <OutcomeChip
+                          outcome={b.outcome}
+                          commErrorKinds={b.commErrorKinds}
+                          testId={`worker-run-batch-${b.runId}-outcome`}
+                        />
+                      </td>
+                      <td className="py-2 pr-4 text-xs">
+                        {b.triggered ? (
+                          <span className="inline-block rounded border border-[var(--border)] px-1.5 py-0.5 text-[11px] text-[var(--text-secondary)]">
+                            manual
+                          </span>
+                        ) : null}
+                      </td>
+                      <td className="py-2 pr-4 text-xs tabular-nums">
+                        {b.jobs.done}/{b.jobs.total}
+                        {b.jobs.failed > 0 ? ` (${b.jobs.failed} fail)` : ""}
+                        {b.jobs.reclaimed > 0
+                          ? ` (${b.jobs.reclaimed} reclaimed)`
+                          : ""}
+                      </td>
+                      <td className="py-2 text-xs tabular-nums">{reds}</td>
+                    </tr>
+                    {isExpanded && (
+                      <tr className="border-b border-[var(--border)]">
+                        <td
+                          colSpan={6}
+                          className="py-2 px-4"
+                          data-testid={`worker-run-jobs-${b.runId}`}
+                        >
+                          {!jobsState || jobsState.state === "loading" ? (
+                            <div className="text-xs text-[var(--text-muted)]">
+                              Loading…
+                            </div>
+                          ) : jobsState.state === "throttled" ? (
+                            <div
+                              data-testid="worker-run-detail-throttled"
+                              className="text-xs text-[var(--text-muted)]"
+                            >
+                              throttled — retrying…
+                            </div>
+                          ) : jobsState.state === "error" ? (
+                            <div
+                              data-testid="worker-run-detail-error"
+                              className="text-xs text-[var(--danger)]"
+                            >
+                              Failed to load run detail: {jobsState.message}
+                            </div>
+                          ) : (
+                            <JobsTable jobs={jobsState.jobs} />
+                          )}
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {cursor !== null && history.state === "ok" && (
+        <button
+          type="button"
+          data-testid="worker-run-detail-load-more"
+          onClick={() => void loadMore()}
+          className="self-start text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)] px-2 py-1 rounded border border-[var(--border)]"
+        >
+          Load older runs
+        </button>
+      )}
+    </div>
+  );
+}

--- a/showcase/shell-dashboard/src/components/worker-runs-section.tsx
+++ b/showcase/shell-dashboard/src/components/worker-runs-section.tsx
@@ -1,0 +1,126 @@
+"use client";
+/**
+ * WorkerRunsSection — the §6.2 "Worker runs" Ops-tab section: heading,
+ * family table + worker strip (WorkerRunsTable), row-click drill-down
+ * (WorkerRunDetailPanel), and the §6.3 failure surfacing.
+ *
+ * Consumes the §6.1 poll status from `useWorkerRuns()` (context — the
+ * provider is mounted by dashboard-page).
+ *
+ * NEVER SELF-HIDES (§6.3 — load-bearing): on ANY unavailable state the
+ * section renders its heading plus a red error panel with the per-kind
+ * message variant, and the dimmed last-good table beneath when a prior
+ * poll succeeded (nothing beneath on a cold failure). The dashboard
+ * must never look healthy while measurement telemetry is unreachable.
+ *
+ * §6.3 message variants (keyed by the §6.1 classification):
+ *   - `unreachable`    → proxy 5xx / network / parse failure
+ *   - `history-backend`→ 200 body with a family-entry
+ *                        `history_unavailable` marker (PB down, CP up)
+ *   - `misdeploy-404`  → endpoint absent — always the incident class
+ *                        (EXPECT_WORKER_RUNS_ENDPOINT, §6.1)
+ */
+import { useEffect, useState } from "react";
+
+import { formatRelative } from "./status-table";
+import { WorkerRunsTable } from "./worker-runs-table";
+import { WorkerRunDetailPanel } from "./worker-run-detail-panel";
+import { useWorkerRuns } from "../lib/worker-runs-context";
+import type { WorkerRunsUnavailableKind } from "../hooks/use-worker-runs";
+import type { ProbeScheduleEntry } from "../lib/ops-api";
+
+export interface WorkerRunsSectionProps {
+  /**
+   * `/api/probes` entries for the subdued starter-cycle row; null/empty
+   * when the token-gated probes router is unmounted (§6.2).
+   */
+  probeEntries: ProbeScheduleEntry[] | null;
+}
+
+const UNAVAILABLE_MESSAGE: Record<WorkerRunsUnavailableKind, string> = {
+  unreachable: "Worker runs unavailable — ops endpoint unreachable",
+  "history-backend":
+    "Worker runs unavailable — run history backend unreachable",
+  "misdeploy-404":
+    "Worker runs unavailable — endpoint disappeared (possible misdeploy)",
+};
+
+function useNowTick(): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return now;
+}
+
+export function WorkerRunsSection({ probeEntries }: WorkerRunsSectionProps) {
+  const status = useWorkerRuns();
+  const now = useNowTick();
+  const [selectedFamily, setSelectedFamily] = useState<string | null>(null);
+
+  return (
+    <section
+      data-testid="worker-runs-section"
+      className="px-8 py-4 flex flex-col gap-3"
+    >
+      <h2
+        data-testid="worker-runs-heading"
+        className="text-xs uppercase tracking-wide text-[var(--text-muted)]"
+      >
+        Worker runs
+      </h2>
+
+      {status === null && (
+        <div
+          data-testid="worker-runs-loading"
+          className="text-xs text-[var(--text-muted)]"
+        >
+          Loading…
+        </div>
+      )}
+
+      {status?.status === "ok" && (
+        <>
+          <WorkerRunsTable
+            data={status.data}
+            probeEntries={probeEntries}
+            onSelectFamily={setSelectedFamily}
+          />
+          <WorkerRunDetailPanel
+            family={selectedFamily}
+            onClose={() => setSelectedFamily(null)}
+          />
+        </>
+      )}
+
+      {status?.status === "unavailable" && (
+        <>
+          <div
+            data-testid="worker-runs-error-panel"
+            data-kind={status.kind}
+            className="rounded border border-[var(--danger)] bg-[var(--danger)]/10 px-3 py-2 text-xs text-[var(--danger)]"
+          >
+            <span>{UNAVAILABLE_MESSAGE[status.kind]}</span>
+            {status.lastGood && (
+              <span className="ml-2 text-[var(--text-muted)]">
+                last good data {formatRelative(status.lastGood.fetchedAt, now)}
+              </span>
+            )}
+          </div>
+          {status.lastGood && (
+            <div
+              data-testid="worker-runs-last-good"
+              className="opacity-50 pointer-events-none"
+            >
+              <WorkerRunsTable
+                data={status.lastGood.data}
+                probeEntries={probeEntries}
+              />
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/showcase/shell-dashboard/src/components/worker-runs-table.test.tsx
+++ b/showcase/shell-dashboard/src/components/worker-runs-table.test.tsx
@@ -1,0 +1,456 @@
+/**
+ * Unit tests for the worker-runs Ops section (spec §6.2/§6.3) — the
+ * family table (WorkerRunsTable) and the section wrapper
+ * (WorkerRunsSection) that owns the §6.3 unavailable error-panel
+ * variants. Mirrors the status-table.test.tsx harness style: fake
+ * timers pinned to NOW so relative times are deterministic.
+ *
+ * Every rendered outcome/health value is the SERVER value verbatim —
+ * these tests deliberately feed "wrong-looking" combinations (e.g. a
+ * stalled batch that also has failed jobs) and assert no client-side
+ * re-classification happens.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+
+import { WorkerRunsTable } from "./worker-runs-table";
+import { WorkerRunsSection } from "./worker-runs-section";
+import { WorkerRunsProvider } from "../lib/worker-runs-context";
+import type { WorkerRunsStatus } from "../hooks/use-worker-runs";
+import type {
+  ProbeScheduleEntry,
+  WorkerFamilySummary,
+  WorkerRunBatch,
+  WorkerRunsResponse,
+  WorkerView,
+} from "../lib/ops-api";
+
+const NOW = new Date("2026-06-10T12:00:00Z").getTime();
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function batch(overrides: Partial<WorkerRunBatch> = {}): WorkerRunBatch {
+  return {
+    runId: "01JRUNA",
+    triggered: false,
+    enqueuedAt: new Date(NOW - 35 * 60_000).toISOString(),
+    finishedAt: new Date(NOW - 28 * 60_000).toISOString(),
+    durationMs: 7 * 60_000,
+    outcome: "completed",
+    jobs: { total: 19, done: 19, failed: 0, reclaimed: 0 },
+    cells: { total: 152, passed: 152, failed: 0 },
+    redsIntroduced: 0,
+    redsCleared: 0,
+    errorSummary: null,
+    commErrorKinds: [],
+    ...overrides,
+  };
+}
+
+function family(
+  overrides: Partial<WorkerFamilySummary> = {},
+): WorkerFamilySummary {
+  return {
+    family: "d5",
+    label: "D5 e2e-deep",
+    probeKeyPrefix: "d5-single-pill-e2e",
+    schedule: "5,20,35,50 * * * *",
+    periodMs: 900_000,
+    nextRunAt: new Date(NOW + 10 * 60_000).toISOString(),
+    lastRun: batch(),
+    inflight: null,
+    lastSuccessAt: new Date(NOW - 28 * 60_000).toISOString(),
+    ...overrides,
+  };
+}
+
+function worker(overrides: Partial<WorkerView> = {}): WorkerView {
+  return {
+    workerId: "worker-railway-abc",
+    health: "online",
+    lastHeartbeatAt: new Date(NOW - 5_000).toISOString(),
+    currentJobId: null,
+    capacity: { inUse: 0, available: 24, max: 24 },
+    ...overrides,
+  };
+}
+
+function runsResponse(
+  overrides: Partial<WorkerRunsResponse> = {},
+): WorkerRunsResponse {
+  return { families: [family()], workers: [worker()], ...overrides };
+}
+
+function starterEntry(
+  overrides: Partial<ProbeScheduleEntry> = {},
+): ProbeScheduleEntry {
+  return {
+    id: "starter_smoke",
+    kind: "smoke",
+    schedule: "40 * * * *",
+    nextRunAt: new Date(NOW + 25 * 60_000).toISOString(),
+    lastRun: {
+      startedAt: new Date(NOW - 35 * 60_000).toISOString(),
+      finishedAt: new Date(NOW - 30 * 60_000).toISOString(),
+      durationMs: 5 * 60_000,
+      state: "completed",
+      summary: { total: 17, passed: 17, failed: 0 },
+    },
+    inflight: null,
+    config: { timeout_ms: 30_000, max_concurrency: 4, discovery: null },
+    ...overrides,
+  };
+}
+
+describe("WorkerRunsTable", () => {
+  it("renders one row per family with humanized schedule and relative next/last run", () => {
+    const data = runsResponse({
+      families: [
+        family({ family: "d5", label: "D5 e2e-deep" }),
+        family({
+          family: "d6",
+          label: "D6 all-pills",
+          probeKeyPrefix: "d6",
+          schedule: "0 */6 * * *",
+        }),
+      ],
+    });
+    const { getByTestId } = render(
+      <WorkerRunsTable data={data} probeEntries={null} />,
+    );
+    expect(getByTestId("worker-runs-row-d5")).toBeDefined();
+    const d6Row = getByTestId("worker-runs-row-d6");
+    expect(d6Row.textContent).toContain("D6 all-pills");
+    expect(d6Row.textContent).toContain("Every 6h");
+    // next run = NOW + 10m, last run = enqueuedAt NOW - 35m.
+    expect(d6Row.textContent).toMatch(/in\s+10m/);
+    expect(d6Row.textContent).toMatch(/35m\s+ago/);
+  });
+
+  it("outcome chip renders stalled verbatim for a batch arriving as stalled (no client re-classification)", () => {
+    // The overlap case from §5.2.1: an abandoned batch with BOTH a failed
+    // job and zombie non-terminal jobs arrives precedence-classified as
+    // "stalled" — the client must render that verbatim, never "failed".
+    const data = runsResponse({
+      families: [
+        family({
+          lastRun: batch({
+            outcome: "stalled",
+            finishedAt: null,
+            durationMs: null,
+            jobs: { total: 19, done: 12, failed: 2, reclaimed: 0 },
+          }),
+        }),
+      ],
+    });
+    const { getByTestId } = render(
+      <WorkerRunsTable data={data} probeEntries={null} />,
+    );
+    const outcome = getByTestId("worker-runs-row-d5-outcome");
+    expect(outcome.getAttribute("data-outcome")).toBe("stalled");
+    expect(outcome.textContent).toContain("stalled");
+    expect(outcome.textContent).not.toContain("failed");
+  });
+
+  it("running chip shows elapsed and done/total when inflight present", () => {
+    const data = runsResponse({
+      families: [
+        family({
+          inflight: {
+            runId: "01JRUNX",
+            triggered: false,
+            enqueuedAt: new Date(NOW - 83_000).toISOString(),
+            elapsedMs: 83_000,
+            stalled: false,
+            jobs: { pending: 4, claimed: 1, running: 3, done: 11, failed: 0 },
+          },
+        }),
+      ],
+    });
+    const { getByTestId } = render(
+      <WorkerRunsTable data={data} probeEntries={null} />,
+    );
+    const chip = getByTestId("worker-runs-row-d5-running");
+    expect(chip.textContent).toContain("running");
+    expect(chip.textContent).toContain("1m 23s");
+    expect(chip.textContent).toContain("11/19");
+  });
+
+  it("renders an amber stalled chip on the in-flight indicator when inflight.stalled", () => {
+    const data = runsResponse({
+      families: [
+        family({
+          inflight: {
+            runId: "01JRUNX",
+            triggered: false,
+            enqueuedAt: new Date(NOW - 2 * 3600_000).toISOString(),
+            elapsedMs: 2 * 3600_000,
+            stalled: true,
+            jobs: { pending: 19, claimed: 0, running: 0, done: 0, failed: 0 },
+          },
+        }),
+      ],
+    });
+    const { getByTestId } = render(
+      <WorkerRunsTable data={data} probeEntries={null} />,
+    );
+    const chip = getByTestId("worker-runs-row-d5-running");
+    expect(chip.getAttribute("data-stalled")).toBe("true");
+    expect(chip.textContent).toContain("stalled");
+    expect(chip.className).toContain("--amber");
+  });
+
+  it("reds column omitted when both counters are 0 or null", () => {
+    const data = runsResponse({
+      families: [
+        family({
+          family: "d5",
+          lastRun: batch({ redsIntroduced: 0, redsCleared: 0 }),
+        }),
+        family({
+          family: "d6",
+          probeKeyPrefix: "d6",
+          lastRun: batch({ redsIntroduced: null, redsCleared: null }),
+        }),
+      ],
+    });
+    const { getByTestId } = render(
+      <WorkerRunsTable data={data} probeEntries={null} />,
+    );
+    expect(getByTestId("worker-runs-row-d5-reds").textContent).toBe("");
+    expect(getByTestId("worker-runs-row-d6-reds").textContent).toBe("");
+  });
+
+  it("reds column renders +N / −M when either counter is nonzero", () => {
+    const data = runsResponse({
+      families: [
+        family({ lastRun: batch({ redsIntroduced: 1, redsCleared: 2 }) }),
+      ],
+    });
+    const { getByTestId } = render(
+      <WorkerRunsTable data={data} probeEntries={null} />,
+    );
+    const reds = getByTestId("worker-runs-row-d5-reds");
+    expect(reds.textContent).toContain("+1");
+    expect(reds.textContent).toContain("−2");
+  });
+
+  it("worker strip renders online/stale/offline verbatim with amber/red treatments", () => {
+    const data = runsResponse({
+      workers: [
+        worker({ workerId: "worker-a", health: "online" }),
+        worker({
+          workerId: "worker-b",
+          health: "stale",
+          capacity: { inUse: 3, available: 21, max: 24 },
+        }),
+        worker({ workerId: "worker-c", health: "offline" }),
+      ],
+    });
+    const { getByTestId } = render(
+      <WorkerRunsTable data={data} probeEntries={null} />,
+    );
+    const a = getByTestId("worker-chip-worker-a");
+    const b = getByTestId("worker-chip-worker-b");
+    const c = getByTestId("worker-chip-worker-c");
+    expect(a.getAttribute("data-health")).toBe("online");
+    expect(a.textContent).toContain("online");
+    expect(a.textContent).toContain("0/24 contexts");
+    expect(b.getAttribute("data-health")).toBe("stale");
+    expect(b.textContent).toContain("stale");
+    expect(b.textContent).toContain("3/24 contexts");
+    expect(b.className).toContain("--amber");
+    expect(c.getAttribute("data-health")).toBe("offline");
+    expect(c.textContent).toContain("offline");
+    expect(c.className).toContain("--danger");
+  });
+
+  it("failed lastRun renders the red left border", () => {
+    const data = runsResponse({
+      families: [
+        family({
+          lastRun: batch({
+            outcome: "failed",
+            jobs: { total: 19, done: 17, failed: 2, reclaimed: 0 },
+            errorSummary: "d5-single-pill-e2e:agno — worker-crashed-mid-job",
+            commErrorKinds: ["worker-crashed-mid-job"],
+          }),
+        }),
+      ],
+    });
+    const { getByTestId } = render(
+      <WorkerRunsTable data={data} probeEntries={null} />,
+    );
+    const row = getByTestId("worker-runs-row-d5");
+    expect(row.className).toContain("border-l-2");
+    expect(row.className).toContain("--danger");
+    // Comm-error kinds surface as the failed chip's tooltip (§6.2).
+    const outcome = getByTestId("worker-runs-row-d5-outcome");
+    expect(outcome.getAttribute("title")).toContain("worker-crashed-mid-job");
+  });
+
+  it("does not render the red left border on a completed lastRun", () => {
+    const { getByTestId } = render(
+      <WorkerRunsTable data={runsResponse()} probeEntries={null} />,
+    );
+    expect(getByTestId("worker-runs-row-d5").className).not.toContain(
+      "border-l-2",
+    );
+  });
+
+  it("renders the subdued starter-cycle row with the in-process badge from the probes entry", () => {
+    const { getByTestId } = render(
+      <WorkerRunsTable data={runsResponse()} probeEntries={[starterEntry()]} />,
+    );
+    const row = getByTestId("worker-runs-starter-row");
+    expect(row.getAttribute("data-variant")).toBe("in-process");
+    expect(row.textContent).toContain("starter cycle");
+    expect(row.textContent).toContain("in-process");
+  });
+
+  it("starter row self-omits to the not-mounted variant when probes entries unavailable", () => {
+    // Null prop (probes endpoint unmounted — OPS_TRIGGER_TOKEN unset) and
+    // empty entries alike: the row never vanishes silently (§6.2).
+    for (const probeEntries of [null, [] as ProbeScheduleEntry[]]) {
+      const { getByTestId, unmount } = render(
+        <WorkerRunsTable data={runsResponse()} probeEntries={probeEntries} />,
+      );
+      const row = getByTestId("worker-runs-starter-row");
+      expect(row.getAttribute("data-variant")).toBe("not-mounted");
+      expect(row.textContent).toContain(
+        "starter cycle — probes endpoint not mounted",
+      );
+      unmount();
+    }
+  });
+});
+
+describe("WorkerRunsSection", () => {
+  function renderSection(
+    status: WorkerRunsStatus | null,
+    probeEntries: ProbeScheduleEntry[] | null = [],
+  ) {
+    return render(
+      <WorkerRunsProvider value={status}>
+        <WorkerRunsSection probeEntries={probeEntries} />
+      </WorkerRunsProvider>,
+    );
+  }
+
+  it("renders the heading and the family table when the poll is ok", () => {
+    const { getByTestId } = renderSection({
+      status: "ok",
+      data: runsResponse(),
+      fetchedAt: NOW,
+    });
+    expect(getByTestId("worker-runs-heading").textContent).toContain(
+      "Worker runs",
+    );
+    expect(getByTestId("worker-runs-table")).toBeDefined();
+  });
+
+  it("opens the detail panel when a family row is selected", () => {
+    // The detail panel fetches history on mount — stub fetch so the click
+    // doesn't escape jsdom. Resolution details are covered by the panel's
+    // own test file.
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            family: "d5",
+            runs: [],
+            perPage: 20,
+            nextBefore: null,
+            nextBeforeId: null,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+    try {
+      const { getByTestId } = renderSection({
+        status: "ok",
+        data: runsResponse(),
+        fetchedAt: NOW,
+      });
+      fireEvent.click(getByTestId("worker-runs-row-d5"));
+      expect(getByTestId("worker-run-detail-panel")).toBeDefined();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("unreachable state renders the error panel with dimmed last-good data beneath", () => {
+    const { getByTestId } = renderSection({
+      status: "unavailable",
+      kind: "unreachable",
+      lastGood: { data: runsResponse(), fetchedAt: NOW - 30_000 },
+    });
+    const panel = getByTestId("worker-runs-error-panel");
+    expect(panel.getAttribute("data-kind")).toBe("unreachable");
+    expect(panel.textContent).toContain(
+      "Worker runs unavailable — ops endpoint unreachable",
+    );
+    expect(panel.textContent).toMatch(/last good data\s+30s\s+ago/);
+    const lastGood = getByTestId("worker-runs-last-good");
+    expect(lastGood.className).toContain("opacity");
+    expect(
+      lastGood.querySelector('[data-testid="worker-runs-table"]'),
+    ).not.toBeNull();
+  });
+
+  it("misdeploy-404 renders the endpoint-disappeared panel variant (cold and post-success alike)", () => {
+    // Cold first poll: no last-good data, nothing beneath the panel.
+    const cold = renderSection({
+      status: "unavailable",
+      kind: "misdeploy-404",
+      lastGood: null,
+    });
+    const coldPanel = cold.getByTestId("worker-runs-error-panel");
+    expect(coldPanel.getAttribute("data-kind")).toBe("misdeploy-404");
+    expect(coldPanel.textContent).toContain(
+      "Worker runs unavailable — endpoint disappeared (possible misdeploy)",
+    );
+    expect(cold.queryByTestId("worker-runs-last-good")).toBeNull();
+    cold.unmount();
+
+    // Post-success: same variant, last-good table dimmed beneath.
+    const warm = renderSection({
+      status: "unavailable",
+      kind: "misdeploy-404",
+      lastGood: { data: runsResponse(), fetchedAt: NOW - 60_000 },
+    });
+    expect(warm.getByTestId("worker-runs-error-panel").textContent).toContain(
+      "endpoint disappeared (possible misdeploy)",
+    );
+    expect(warm.getByTestId("worker-runs-last-good")).toBeDefined();
+  });
+
+  it("history-backend marker renders its own panel variant", () => {
+    const { getByTestId } = renderSection({
+      status: "unavailable",
+      kind: "history-backend",
+      lastGood: null,
+    });
+    const panel = getByTestId("worker-runs-error-panel");
+    expect(panel.getAttribute("data-kind")).toBe("history-backend");
+    expect(panel.textContent).toContain(
+      "Worker runs unavailable — run history backend unreachable",
+    );
+  });
+
+  it("never self-hides: renders the heading with a loading line before the first poll settles", () => {
+    const { getByTestId } = renderSection(null);
+    expect(getByTestId("worker-runs-heading").textContent).toContain(
+      "Worker runs",
+    );
+    expect(getByTestId("worker-runs-loading")).toBeDefined();
+  });
+});

--- a/showcase/shell-dashboard/src/components/worker-runs-table.tsx
+++ b/showcase/shell-dashboard/src/components/worker-runs-table.tsx
@@ -1,0 +1,397 @@
+"use client";
+/**
+ * WorkerRunsTable — the §6.2 worker-runs family grid for the Ops tab.
+ *
+ * One row per `FLEET_FAMILIES` member from the `/api/runs` payload.
+ * Columns mirror StatusTable: Family | Schedule (humanizeCron) |
+ * Next run (relative) | Last run (relative) | Duration | Outcome |
+ * Cells | Reds.
+ *
+ * RENDER-VERBATIM CONTRACT (§6.2/§6.3 — do not weaken): every
+ * outcome/health value here is the SERVER's precedence-derived value,
+ * rendered verbatim with zero client-side re-classification. A batch
+ * with both failed and zombie-pending jobs arrives as `stalled` and
+ * renders `stalled`; worker health arrives from the shared
+ * `deriveHealth` and renders online/stale/offline as-is.
+ *
+ * Beneath the family rows:
+ *   - a subdued starter-cycle row sourced from the `/api/probes`
+ *     `starter_smoke` entry (the section's only token-gated dependency —
+ *     when the probes router is unmounted the row renders its own
+ *     "not mounted" variant rather than vanishing, §6.2);
+ *   - a worker strip: one chip per worker, `workerId · <health> ·
+ *     inUse/max contexts` — amber when stale, red when offline — the
+ *     "is anything even claiming?" answer.
+ *
+ * Relative times update live every 1s via a local tick state, same as
+ * StatusTable; the parent owns the data.
+ */
+import { useEffect, useState } from "react";
+
+import { formatDuration, formatRelative, humanizeCron } from "./status-table";
+import type {
+  ProbeScheduleEntry,
+  WorkerFamilySummary,
+  WorkerRunInflight,
+  WorkerRunOutcome,
+  WorkerRunsResponse,
+  WorkerView,
+} from "../lib/ops-api";
+
+export interface WorkerRunsTableProps {
+  data: WorkerRunsResponse;
+  /**
+   * The `/api/probes` schedule entries (for the starter-cycle row).
+   * `null`/empty = probes endpoint unavailable (token-gated router
+   * unmounted) — the starter row renders its not-mounted variant.
+   */
+  probeEntries: ProbeScheduleEntry[] | null;
+  /** Row-click handler — the parent opens the drill-down panel. */
+  onSelectFamily?: (family: string) => void;
+}
+
+type Tone = "green" | "amber" | "red" | "gray";
+
+const TONE_CLASS: Record<Tone, string> = {
+  green: "text-[var(--ok)]",
+  amber: "text-[var(--amber)]",
+  red: "text-[var(--danger)]",
+  gray: "text-[var(--text-muted)]",
+};
+
+/** §6.2 outcome → tone, a closed three-way match over the server value. */
+const OUTCOME_TONE: Record<WorkerRunOutcome, Tone> = {
+  completed: "green",
+  failed: "red",
+  stalled: "amber",
+};
+
+function useNowTick(): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return now;
+}
+
+/**
+ * Terminal-batch outcome chip — the server's precedence-derived value
+ * verbatim (§5.2.1). For a failed batch the deduped comm-error kinds
+ * surface as the tooltip (§6.2); they are closed-vocabulary by
+ * construction (enum-validated server-side), safe to render.
+ *
+ * Shared with the drill-down panel's batch rows.
+ */
+export function OutcomeChip({
+  outcome,
+  commErrorKinds,
+  testId,
+}: {
+  outcome: WorkerRunOutcome;
+  commErrorKinds?: string[];
+  testId?: string;
+}) {
+  const title =
+    outcome === "failed" && commErrorKinds && commErrorKinds.length > 0
+      ? commErrorKinds.join(", ")
+      : undefined;
+  return (
+    <span
+      data-testid={testId}
+      data-outcome={outcome}
+      title={title}
+      className={`inline-block text-xs ${TONE_CLASS[OUTCOME_TONE[outcome]]}`}
+    >
+      {outcome}
+    </span>
+  );
+}
+
+/**
+ * In-flight indicator: gray `running…` with live elapsed + done/total
+ * (1s tick, StatusRunningPanel pattern); amber `stalled` verbatim when
+ * the server's §5.2.1 rules (a)/(c) tripped — no client re-derivation.
+ */
+function RunningChip({
+  inflight,
+  now,
+  testId,
+}: {
+  inflight: WorkerRunInflight;
+  now: number;
+  testId: string;
+}) {
+  const startMs = Date.parse(inflight.enqueuedAt);
+  const elapsedMs = Number.isFinite(startMs)
+    ? Math.max(0, now - startMs)
+    : inflight.elapsedMs;
+  const j = inflight.jobs;
+  const total = j.pending + j.claimed + j.running + j.done + j.failed;
+  if (inflight.stalled) {
+    return (
+      <span
+        data-testid={testId}
+        data-stalled="true"
+        className={`inline-block text-xs ${TONE_CLASS.amber}`}
+      >
+        stalled · {formatDuration(elapsedMs)} · {j.done}/{total}
+      </span>
+    );
+  }
+  return (
+    <span
+      data-testid={testId}
+      data-stalled="false"
+      className={`inline-block text-xs ${TONE_CLASS.gray}`}
+    >
+      running… {formatDuration(elapsedMs)} · {j.done}/{total}
+    </span>
+  );
+}
+
+/**
+ * Reds column body: `+N / −M`, omitted entirely when both counters are
+ * 0 or null (§6.2). Null = honest-unknown (pre-P2 rows / beyond the
+ * reds-window cap), also omitted.
+ */
+function redsText(
+  introduced: number | null | undefined,
+  cleared: number | null | undefined,
+): string | null {
+  const i = introduced ?? 0;
+  const c = cleared ?? 0;
+  if (i === 0 && c === 0) return null;
+  return `+${i} / −${c}`;
+}
+
+/**
+ * Subdued starter-cycle row (§6.2): the in-process probe family from
+ * `/api/probes` (`starter_smoke`), appended so the section reads as the
+ * complete heavy-cycle picture. When the probes entries are unavailable
+ * (token-gated router unmounted) it renders the not-mounted variant —
+ * never vanishing silently.
+ */
+function StarterRow({
+  probeEntries,
+  now,
+}: {
+  probeEntries: ProbeScheduleEntry[] | null;
+  now: number;
+}) {
+  const starter = probeEntries?.find((e) => e.id === "starter_smoke");
+  const subdued =
+    "border-b border-[var(--border)] text-[var(--text-muted)] opacity-70";
+  if (!starter) {
+    return (
+      <tr
+        data-testid="worker-runs-starter-row"
+        data-variant="not-mounted"
+        className={subdued}
+      >
+        <td colSpan={8} className="py-2 pr-4 text-xs italic">
+          starter cycle — probes endpoint not mounted
+        </td>
+      </tr>
+    );
+  }
+  const nextRunMs = starter.nextRunAt ? Date.parse(starter.nextRunAt) : null;
+  const lastStartMs = starter.lastRun
+    ? Date.parse(starter.lastRun.startedAt)
+    : null;
+  const summary = starter.lastRun?.summary;
+  return (
+    <tr
+      data-testid="worker-runs-starter-row"
+      data-variant="in-process"
+      className={subdued}
+    >
+      <td className="py-2 pr-4 text-xs">
+        starter cycle{" "}
+        <span className="inline-block rounded border border-[var(--border)] px-1.5 py-0.5 text-[11px]">
+          in-process
+        </span>
+      </td>
+      <td className="py-2 pr-4 text-xs">{humanizeCron(starter.schedule)}</td>
+      <td className="py-2 pr-4 text-xs tabular-nums">
+        {nextRunMs !== null ? formatRelative(nextRunMs, now) : "—"}
+      </td>
+      <td className="py-2 pr-4 text-xs tabular-nums">
+        {lastStartMs !== null ? formatRelative(lastStartMs, now) : "never"}
+      </td>
+      <td className="py-2 pr-4 text-xs tabular-nums">
+        {starter.lastRun ? formatDuration(starter.lastRun.durationMs) : "—"}
+      </td>
+      <td className="py-2 pr-4 text-xs">
+        {starter.lastRun ? starter.lastRun.state : "never run"}
+      </td>
+      <td className="py-2 pr-4 text-xs tabular-nums">
+        {summary ? `${summary.passed}/${summary.total}` : "—"}
+      </td>
+      <td className="py-2 text-xs" />
+    </tr>
+  );
+}
+
+const HEALTH_CHIP_CLASS: Record<WorkerView["health"], string> = {
+  online: "border-[var(--border)] text-[var(--text-secondary)]",
+  stale: "border-[var(--amber)] text-[var(--amber)]",
+  offline: "border-[var(--danger)] text-[var(--danger)]",
+};
+
+/** Worker strip: health rendered verbatim — amber stale, red offline. */
+function WorkerStrip({ workers }: { workers: WorkerView[] }) {
+  if (workers.length === 0) {
+    return (
+      <div
+        data-testid="worker-strip"
+        className="mt-2 text-xs text-[var(--text-muted)]"
+      >
+        No workers registered.
+      </div>
+    );
+  }
+  return (
+    <div
+      data-testid="worker-strip"
+      className="mt-2 flex flex-wrap gap-1.5 text-[11px]"
+    >
+      {workers.map((w) => (
+        <span
+          key={w.workerId}
+          data-testid={`worker-chip-${w.workerId}`}
+          data-health={w.health}
+          className={`inline-flex items-center gap-1 rounded border px-2 py-0.5 ${HEALTH_CHIP_CLASS[w.health]}`}
+        >
+          <span className="font-mono">{w.workerId}</span>
+          <span>·</span>
+          <span>{w.health}</span>
+          <span>·</span>
+          <span className="tabular-nums">
+            {w.capacity.inUse}/{w.capacity.max} contexts
+          </span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function WorkerRunsTable({
+  data,
+  probeEntries,
+  onSelectFamily,
+}: WorkerRunsTableProps) {
+  const now = useNowTick();
+
+  return (
+    <div data-testid="worker-runs-table">
+      <table className="w-full text-sm border-collapse">
+        <thead>
+          <tr className="text-left text-xs uppercase tracking-wide text-[var(--text-muted)] border-b border-[var(--border)]">
+            <th className="py-2 pr-4">Family</th>
+            <th className="py-2 pr-4">Schedule</th>
+            <th className="py-2 pr-4">Next run</th>
+            <th className="py-2 pr-4">Last run</th>
+            <th className="py-2 pr-4">Duration</th>
+            <th className="py-2 pr-4">Outcome</th>
+            <th className="py-2 pr-4">Cells</th>
+            <th className="py-2">Reds</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.families.map((f) => (
+            <FamilyRow
+              key={f.family}
+              entry={f}
+              now={now}
+              onSelectFamily={onSelectFamily}
+            />
+          ))}
+          <StarterRow probeEntries={probeEntries} now={now} />
+        </tbody>
+      </table>
+      <WorkerStrip workers={data.workers} />
+    </div>
+  );
+}
+
+function FamilyRow({
+  entry,
+  now,
+  onSelectFamily,
+}: {
+  entry: WorkerFamilySummary;
+  now: number;
+  onSelectFamily?: (family: string) => void;
+}) {
+  const lastRun = entry.lastRun ?? null;
+  const inflight = entry.inflight ?? null;
+  // §6.3: failed lastRun → red left border (the existing red-row
+  // convention). Derived from the server outcome value only.
+  const failedBorder =
+    lastRun?.outcome === "failed" ? "border-l-2 border-l-[var(--danger)]" : "";
+  const nextRunMs = entry.nextRunAt ? Date.parse(entry.nextRunAt) : null;
+  const lastStartMs = lastRun ? Date.parse(lastRun.enqueuedAt) : null;
+  const reds = lastRun
+    ? redsText(lastRun.redsIntroduced, lastRun.redsCleared)
+    : null;
+  const cells = lastRun?.cells ?? null;
+
+  return (
+    <tr
+      data-testid={`worker-runs-row-${entry.family}`}
+      onClick={onSelectFamily ? () => onSelectFamily(entry.family) : undefined}
+      className={`border-b border-[var(--border)] hover:bg-[var(--surface-hover)] ${
+        onSelectFamily ? "cursor-pointer" : ""
+      } ${failedBorder}`}
+    >
+      <td className="py-2 pr-4 text-xs">{entry.label}</td>
+      <td className="py-2 pr-4 text-xs text-[var(--text-secondary)]">
+        {entry.schedule ? humanizeCron(entry.schedule) : "—"}
+      </td>
+      <td className="py-2 pr-4 text-xs tabular-nums">
+        {nextRunMs !== null && Number.isFinite(nextRunMs)
+          ? formatRelative(nextRunMs, now)
+          : "—"}
+      </td>
+      <td className="py-2 pr-4 text-xs tabular-nums">
+        {lastStartMs !== null && Number.isFinite(lastStartMs)
+          ? formatRelative(lastStartMs, now)
+          : "never"}
+      </td>
+      <td className="py-2 pr-4 text-xs tabular-nums">
+        {lastRun?.durationMs != null ? formatDuration(lastRun.durationMs) : "—"}
+      </td>
+      <td className="py-2 pr-4 text-xs">
+        {inflight ? (
+          <RunningChip
+            inflight={inflight}
+            now={now}
+            testId={`worker-runs-row-${entry.family}-running`}
+          />
+        ) : lastRun ? (
+          <OutcomeChip
+            outcome={lastRun.outcome}
+            commErrorKinds={lastRun.commErrorKinds}
+            testId={`worker-runs-row-${entry.family}-outcome`}
+          />
+        ) : (
+          <span className="text-xs text-[var(--text-muted)]">never run</span>
+        )}
+      </td>
+      <td className="py-2 pr-4 text-xs tabular-nums">
+        {cells
+          ? cells.failed > 0
+            ? `${cells.passed}/${cells.total} (${cells.failed} fail)`
+            : `${cells.passed}/${cells.total}`
+          : "—"}
+      </td>
+      <td
+        className="py-2 text-xs tabular-nums"
+        data-testid={`worker-runs-row-${entry.family}-reds`}
+      >
+        {reds}
+      </td>
+    </tr>
+  );
+}

--- a/showcase/shell-dashboard/src/components/worker-silence-banner.test.tsx
+++ b/showcase/shell-dashboard/src/components/worker-silence-banner.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for WorkerSilenceBanner — the coverage-tab worker-family
+ * silence banner (spec §7.4).
+ *
+ * Covers the four §7.4 behaviors:
+ *  - amber banner when any family's lastSuccessAt is older than 2 periods
+ *    (server-computed periodMs — never client cron parsing),
+ *  - never-succeeded families banner off their oldest batch's enqueuedAt
+ *    (§5.2.1 null fallback) while zero-batch families stay quiet,
+ *  - an unavailable context (incl. the §6.1 404 rule) shows the
+ *    unreachable variant with last-good relative time instead of
+ *    vanishing,
+ *  - the banner is dismissible (and re-surfaces when its content
+ *    identity changes).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+
+import { WorkerSilenceBanner } from "./worker-silence-banner";
+import { WorkerRunsProvider } from "../lib/worker-runs-context";
+import type { WorkerRunsStatus } from "../hooks/use-worker-runs";
+import type {
+  WorkerFamilySummary,
+  WorkerRunBatch,
+  WorkerRunsResponse,
+} from "../lib/ops-api";
+
+const NOW = new Date("2026-06-10T12:00:00Z").getTime();
+/** 15-minute resolved period (the d5/e2e-smoke default). */
+const PERIOD_MS = 900_000;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function makeBatch(enqueuedAtMs: number): WorkerRunBatch {
+  return {
+    runId: "run-1",
+    triggered: false,
+    enqueuedAt: new Date(enqueuedAtMs).toISOString(),
+    finishedAt: null,
+    durationMs: null,
+    outcome: "stalled",
+    jobs: { total: 3, done: 0, failed: 0, reclaimed: 0 },
+    cells: null,
+    redsIntroduced: null,
+    redsCleared: null,
+    errorSummary: null,
+    commErrorKinds: [],
+  };
+}
+
+function makeFamily(
+  overrides: Partial<WorkerFamilySummary> = {},
+): WorkerFamilySummary {
+  return {
+    family: "d5",
+    label: "D5 e2e-deep",
+    probeKeyPrefix: "d5-single-pill-e2e",
+    schedule: "5,20,35,50 * * * *",
+    periodMs: PERIOD_MS,
+    nextRunAt: null,
+    lastRun: null,
+    inflight: null,
+    lastSuccessAt: null,
+    ...overrides,
+  };
+}
+
+function okStatus(families: WorkerFamilySummary[]): WorkerRunsStatus {
+  const data: WorkerRunsResponse = { families, workers: [] };
+  return { status: "ok", data, fetchedAt: NOW };
+}
+
+function renderBanner(value: WorkerRunsStatus | null) {
+  return render(
+    <WorkerRunsProvider value={value}>
+      <WorkerSilenceBanner />
+    </WorkerRunsProvider>,
+  );
+}
+
+describe("WorkerSilenceBanner", () => {
+  it("shows the amber banner when a family's lastSuccessAt is older than 2 periods (server periodMs)", () => {
+    const silent = makeFamily({
+      family: "d5",
+      label: "D5 e2e-deep",
+      lastSuccessAt: new Date(NOW - 2.5 * PERIOD_MS).toISOString(),
+    });
+    const healthy = makeFamily({
+      family: "e2e-smoke",
+      label: "E2E smoke",
+      probeKeyPrefix: "d4",
+      lastSuccessAt: new Date(NOW - 0.5 * PERIOD_MS).toISOString(),
+    });
+    const { getByTestId } = renderBanner(okStatus([silent, healthy]));
+    const banner = getByTestId("worker-silence-banner");
+    expect(banner.getAttribute("data-variant")).toBe("silence");
+    expect(banner.textContent).toContain(
+      "Worker family D5 e2e-deep has not completed successfully since",
+    );
+    expect(banner.textContent).toContain("see Ops tab.");
+    expect(banner.textContent).not.toContain("E2E smoke");
+  });
+
+  it("uses the server periodMs verbatim — a longer period keeps the same age quiet", () => {
+    // Same 2.5x-of-15min age, but the family's resolved period is hourly:
+    // 37.5 min is well inside 2x60min, so no banner. Threshold math must
+    // come from periodMs, never a hardcoded window.
+    const family = makeFamily({
+      family: "d6",
+      label: "D6 all-pills",
+      periodMs: 3_600_000,
+      lastSuccessAt: new Date(NOW - 2.5 * PERIOD_MS).toISOString(),
+    });
+    const { queryByTestId } = renderBanner(okStatus([family]));
+    expect(queryByTestId("worker-silence-banner")).toBeNull();
+  });
+
+  it("renders nothing when all families are healthy", () => {
+    const { queryByTestId } = renderBanner(
+      okStatus([
+        makeFamily({
+          lastSuccessAt: new Date(NOW - PERIOD_MS).toISOString(),
+        }),
+      ]),
+    );
+    expect(queryByTestId("worker-silence-banner")).toBeNull();
+  });
+
+  it("renders nothing when no provider data has settled (null context)", () => {
+    const { queryByTestId } = renderBanner(null);
+    expect(queryByTestId("worker-silence-banner")).toBeNull();
+  });
+
+  it("never-succeeded family banners once its oldest batch crosses the threshold; zero-batch family stays quiet", () => {
+    const neverSucceeded = makeFamily({
+      family: "d5",
+      label: "D5 e2e-deep",
+      lastSuccessAt: null,
+      lastRun: makeBatch(NOW - 3 * PERIOD_MS),
+    });
+    const zeroBatch = makeFamily({
+      family: "e2e-demos",
+      label: "E2E demos",
+      probeKeyPrefix: "e2e-demos",
+      lastSuccessAt: null,
+      lastRun: null,
+      inflight: null,
+    });
+    const { getByTestId } = renderBanner(okStatus([neverSucceeded, zeroBatch]));
+    const banner = getByTestId("worker-silence-banner");
+    expect(banner.textContent).toContain("D5 e2e-deep");
+    expect(banner.textContent).not.toContain("E2E demos");
+  });
+
+  it("unavailable context (incl. 404) shows the unreachable variant with last-good relative time instead of vanishing", () => {
+    const lastGoodAt = NOW - 5 * 60_000;
+    const unavailable: WorkerRunsStatus = {
+      status: "unavailable",
+      kind: "misdeploy-404",
+      lastGood: {
+        data: { families: [makeFamily()], workers: [] },
+        fetchedAt: lastGoodAt,
+      },
+    };
+    const { getByTestId } = renderBanner(unavailable);
+    const banner = getByTestId("worker-silence-banner");
+    expect(banner.getAttribute("data-variant")).toBe("unreachable");
+    expect(banner.textContent).toContain(
+      "Worker run telemetry unreachable — ops endpoint not responding",
+    );
+    expect(banner.textContent).toContain("(last good 5m ago)");
+    expect(banner.textContent).toContain("see Ops tab.");
+  });
+
+  it("unavailable context with no last-good data still shows the unreachable variant", () => {
+    const unavailable: WorkerRunsStatus = {
+      status: "unavailable",
+      kind: "unreachable",
+      lastGood: null,
+    };
+    const { getByTestId } = renderBanner(unavailable);
+    const banner = getByTestId("worker-silence-banner");
+    expect(banner.getAttribute("data-variant")).toBe("unreachable");
+    expect(banner.textContent).toContain(
+      "Worker run telemetry unreachable — ops endpoint not responding",
+    );
+    expect(banner.textContent).not.toContain("last good");
+  });
+
+  it("banner is dismissible", () => {
+    const silent = makeFamily({
+      lastSuccessAt: new Date(NOW - 3 * PERIOD_MS).toISOString(),
+    });
+    const { getByTestId, getByLabelText, queryByTestId } = renderBanner(
+      okStatus([silent]),
+    );
+    expect(getByTestId("worker-silence-banner")).toBeDefined();
+    fireEvent.click(getByLabelText("Dismiss"));
+    expect(queryByTestId("worker-silence-banner")).toBeNull();
+  });
+
+  it("a dismissed banner re-surfaces when its content identity changes", () => {
+    const silentD5 = makeFamily({
+      family: "d5",
+      label: "D5 e2e-deep",
+      lastSuccessAt: new Date(NOW - 3 * PERIOD_MS).toISOString(),
+    });
+    const silentSmoke = makeFamily({
+      family: "e2e-smoke",
+      label: "E2E smoke",
+      probeKeyPrefix: "d4",
+      lastSuccessAt: new Date(NOW - 3 * PERIOD_MS).toISOString(),
+    });
+    const { getByLabelText, queryByTestId, rerender } = renderBanner(
+      okStatus([silentD5]),
+    );
+    fireEvent.click(getByLabelText("Dismiss"));
+    expect(queryByTestId("worker-silence-banner")).toBeNull();
+    // Same silent set on a later poll → stays dismissed.
+    rerender(
+      <WorkerRunsProvider value={okStatus([silentD5])}>
+        <WorkerSilenceBanner />
+      </WorkerRunsProvider>,
+    );
+    expect(queryByTestId("worker-silence-banner")).toBeNull();
+    // A NEW family goes silent → the banner re-surfaces.
+    rerender(
+      <WorkerRunsProvider value={okStatus([silentD5, silentSmoke])}>
+        <WorkerSilenceBanner />
+      </WorkerRunsProvider>,
+    );
+    expect(queryByTestId("worker-silence-banner")).not.toBeNull();
+  });
+});

--- a/showcase/shell-dashboard/src/components/worker-silence-banner.tsx
+++ b/showcase/shell-dashboard/src/components/worker-silence-banner.tsx
@@ -1,0 +1,126 @@
+"use client";
+/**
+ * Coverage-tab worker-family silence banner (spec §7.4) — the one-glance
+ * answer the motivating incident lacked, reusing the `DiscoveryAuthBanner`
+ * slot pattern (mx-8 alert strip above the tab content).
+ *
+ * Behaviors (all §7.4):
+ *  - Amber banner when any worker family's `lastSuccessAt` is older than
+ *    2 schedule periods. The period is the SERVER-computed `periodMs` each
+ *    §5.2.1 family entry carries (resolved-cron derived, so a d6
+ *    `FLEET_PRODUCER_CRON` override scales the window) — never a client-
+ *    parsed cron and never a hardcoded constant. The classification is
+ *    `isFamilySilent` (worker-runs-context), shared with the §7.3 glyph.
+ *  - Null `lastSuccessAt` follows the §5.2.1 fallback: never-succeeded
+ *    families banner once their oldest known batch's `enqueuedAt` crosses
+ *    the threshold; zero-batch families stay quiet (fresh env).
+ *  - When `WorkerRunsContext` reports `unavailable`, the banner does NOT
+ *    vanish for lack of family data — it shows the unreachable variant
+ *    instead. A 404 arrives as `unavailable` per §6.1's source-constant
+ *    rule (cold first poll and post-success alike) and renders this same
+ *    variant; there is no suppressing state.
+ *  - Dismissible: dismissal is keyed to the banner's content identity
+ *    (variant + silent family set), so a newly-silent family or a variant
+ *    flip re-surfaces a previously dismissed banner.
+ *
+ * No-data (`null` context — no provider mounted or first poll unsettled)
+ * renders nothing, per the T10 no-provider contract.
+ */
+import { useState } from "react";
+
+import type { WorkerFamilySummary } from "@/lib/ops-api";
+import { isFamilySilent, useWorkerRuns } from "@/lib/worker-runs-context";
+import { formatRelative } from "./status-table";
+
+/**
+ * The §5.2.1 staleness reference time for a silent family — mirrors the
+ * fallback chain inside `isFamilySilent` (T10 owns that module; this
+ * banner only formats the same reference for display): `lastSuccessAt`,
+ * else the oldest known batch's `enqueuedAt` (`lastRun` is older than
+ * `inflight` by construction — inflight is the newest group).
+ */
+function silenceReference(entry: WorkerFamilySummary): string | null {
+  return (
+    entry.lastSuccessAt ??
+    entry.lastRun?.enqueuedAt ??
+    entry.inflight?.enqueuedAt ??
+    null
+  );
+}
+
+const VARIANT_CLASSES = {
+  // Amber: family silence is the §7 staleness incident class.
+  silence: "border-[var(--amber)] text-[var(--amber)]",
+  // Danger: the telemetry itself is down (§6.1 incident class) — the
+  // dashboard must not look healthy, mirroring DiscoveryAuthBanner.
+  unreachable:
+    "border-[var(--danger)] bg-[var(--bg-danger)] text-[var(--danger)]",
+} as const;
+
+export function WorkerSilenceBanner() {
+  const status = useWorkerRuns();
+  // Content-identity key of the dismissed banner; the banner stays hidden
+  // only while its identity is unchanged (see module header).
+  const [dismissedKey, setDismissedKey] = useState<string | null>(null);
+
+  if (status === null) return null;
+
+  const nowMs = Date.now();
+  let variant: keyof typeof VARIANT_CLASSES;
+  let contentKey: string;
+  let messages: string[];
+
+  if (status.status === "unavailable") {
+    variant = "unreachable";
+    contentKey = "unreachable";
+    const lastGood = status.lastGood;
+    messages = [
+      lastGood
+        ? `Worker run telemetry unreachable — ops endpoint not responding (last good ${formatRelative(lastGood.fetchedAt, nowMs)}); see Ops tab.`
+        : "Worker run telemetry unreachable — ops endpoint not responding; see Ops tab.",
+    ];
+  } else {
+    const silentFamilies = status.data.families.filter((family) =>
+      isFamilySilent(family, nowMs),
+    );
+    if (silentFamilies.length === 0) return null;
+    variant = "silence";
+    contentKey = `silence:${silentFamilies
+      .map((family) => family.family)
+      .sort()
+      .join(",")}`;
+    messages = silentFamilies.map((family) => {
+      const reference = silenceReference(family);
+      // `isFamilySilent` only classifies silent off a parseable reference,
+      // so this is always present here; "—" is unreachable defensive copy.
+      const since =
+        reference !== null ? formatRelative(Date.parse(reference), nowMs) : "—";
+      return `Worker family ${family.label} has not completed successfully since ${since} — see Ops tab.`;
+    });
+  }
+
+  if (dismissedKey === contentKey) return null;
+
+  return (
+    <div
+      role="alert"
+      data-testid="worker-silence-banner"
+      data-variant={variant}
+      className={`mx-8 mb-4 flex flex-shrink-0 items-start gap-3 rounded-md border px-4 py-2 text-xs ${VARIANT_CLASSES[variant]}`}
+    >
+      <div className="flex-1">
+        {messages.map((message) => (
+          <div key={message}>{message}</div>
+        ))}
+      </div>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={() => setDismissedKey(contentKey)}
+        className="flex-shrink-0 font-semibold opacity-70 hover:opacity-100"
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/showcase/shell-dashboard/src/hooks/use-worker-runs.test.ts
+++ b/showcase/shell-dashboard/src/hooks/use-worker-runs.test.ts
@@ -1,0 +1,447 @@
+/**
+ * Tests for the worker-runs data layer (runviz T10):
+ *   - `useWorkerRunsPoll` — the §6.1 poll hook with the three-way
+ *     unavailable classification (misdeploy-404 / unreachable /
+ *     history-backend) and last-good retention.
+ *   - `WorkerRunsContext` / `useWorkerRuns` — the no-provider contract
+ *     (NEVER throws; returns the no-data default) that T13's cell-pieces
+ *     consumers depend on (`cell-pieces.signal-degrade.test.tsx` renders
+ *     `CellStatus` with no provider and asserts not.toThrow).
+ *   - `isFamilySilent` / `familyForProbeKey` — the shared §7.3/§7.4 pure
+ *     helpers (server periodMs verbatim, null-lastSuccessAt fallback,
+ *     payload probeKeyPrefix mapping).
+ *
+ * `fetchWorkerRuns` is mocked (the wire contract is covered in
+ * `ops-api.test.ts`); the real `OpsApiHttpError` class is kept via
+ * importOriginal so instanceof-based 404 classification is exercised
+ * against the genuine error type.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+vi.mock("../lib/ops-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/ops-api")>();
+  return { ...actual, fetchWorkerRuns: vi.fn() };
+});
+
+import * as opsApi from "../lib/ops-api";
+import {
+  OpsApiHttpError,
+  type WorkerRunsResponse,
+  type WorkerFamilySummary,
+  type WorkerRunBatch,
+} from "../lib/ops-api";
+import {
+  EXPECT_WORKER_RUNS_ENDPOINT,
+  useWorkerRunsPoll,
+  type WorkerRunsStatus,
+} from "./use-worker-runs";
+import {
+  WorkerRunsProvider,
+  useWorkerRuns,
+  isFamilySilent,
+  familyForProbeKey,
+} from "../lib/worker-runs-context";
+
+const fetchWorkerRunsMock = opsApi.fetchWorkerRuns as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+function okBody(): WorkerRunsResponse {
+  return {
+    families: [
+      {
+        family: "d5",
+        label: "D5 e2e-deep",
+        probeKeyPrefix: "d5-single-pill-e2e",
+        schedule: "5,20,35,50 * * * *",
+        periodMs: 900_000,
+        nextRunAt: null,
+        lastRun: null,
+        inflight: null,
+        lastSuccessAt: null,
+      },
+    ],
+    workers: [],
+  };
+}
+
+function degradedBody(): WorkerRunsResponse {
+  const body = okBody();
+  body.families.push({
+    family: "d6",
+    label: "D6 all-pills",
+    probeKeyPrefix: "d6",
+    error: "history_unavailable",
+  });
+  return body;
+}
+
+beforeEach(() => {
+  fetchWorkerRunsMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// EXPECT_WORKER_RUNS_ENDPOINT — §6.1 source-level constant
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("EXPECT_WORKER_RUNS_ENDPOINT", () => {
+  it("ships as a source-level true constant (no env/build-config indirection)", () => {
+    expect(EXPECT_WORKER_RUNS_ENDPOINT).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// useWorkerRunsPoll — classification + last-good retention
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("useWorkerRunsPoll", () => {
+  it("yields status ok with the body and a fetch timestamp on success", async () => {
+    fetchWorkerRunsMock.mockResolvedValue(okBody());
+    const { result } = renderHook(() => useWorkerRunsPoll());
+    expect(result.current).toBeNull();
+    await waitFor(() => expect(result.current).not.toBeNull());
+    const status = result.current!;
+    expect(status.status).toBe("ok");
+    if (status.status === "ok") {
+      expect(status.data).toEqual(okBody());
+      expect(typeof status.fetchedAt).toBe("number");
+    }
+  });
+
+  it("a 404 yields unavailable kind misdeploy-404 on a cold first poll (lastGood null)", async () => {
+    fetchWorkerRunsMock.mockRejectedValue(
+      new OpsApiHttpError(404, "Not Found", "/api/ops/runs"),
+    );
+    const { result } = renderHook(() => useWorkerRunsPoll());
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current).toEqual({
+      status: "unavailable",
+      kind: "misdeploy-404",
+      lastGood: null,
+    });
+  });
+
+  it("a 404 after a prior success yields misdeploy-404 with lastGood retained", async () => {
+    vi.useFakeTimers();
+    fetchWorkerRunsMock
+      .mockResolvedValueOnce(okBody())
+      .mockRejectedValueOnce(
+        new OpsApiHttpError(404, "Not Found", "/api/ops/runs"),
+      );
+    const { result } = renderHook(() => useWorkerRunsPoll());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current?.status).toBe("ok");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    const status = result.current!;
+    expect(status.status).toBe("unavailable");
+    if (status.status === "unavailable") {
+      expect(status.kind).toBe("misdeploy-404");
+      expect(status.lastGood?.data).toEqual(okBody());
+      expect(typeof status.lastGood?.fetchedAt).toBe("number");
+    }
+  });
+
+  it("a 200 body with one family entry carrying history_unavailable yields kind history-backend", async () => {
+    fetchWorkerRunsMock.mockResolvedValue(degradedBody());
+    const { result } = renderHook(() => useWorkerRunsPoll());
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current).toEqual({
+      status: "unavailable",
+      kind: "history-backend",
+      lastGood: null,
+    });
+  });
+
+  it("a degraded 200 after a prior success retains lastGood under history-backend", async () => {
+    vi.useFakeTimers();
+    fetchWorkerRunsMock
+      .mockResolvedValueOnce(okBody())
+      .mockResolvedValueOnce(degradedBody());
+    const { result } = renderHook(() => useWorkerRunsPoll());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current?.status).toBe("ok");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    const status = result.current!;
+    expect(status.status).toBe("unavailable");
+    if (status.status === "unavailable") {
+      expect(status.kind).toBe("history-backend");
+      expect(status.lastGood?.data).toEqual(okBody());
+    }
+  });
+
+  it("a 5xx failure yields kind unreachable", async () => {
+    fetchWorkerRunsMock.mockRejectedValue(
+      new OpsApiHttpError(502, "Bad Gateway", "/api/ops/runs"),
+    );
+    const { result } = renderHook(() => useWorkerRunsPoll());
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current).toEqual({
+      status: "unavailable",
+      kind: "unreachable",
+      lastGood: null,
+    });
+  });
+
+  it("a network/parse failure yields kind unreachable", async () => {
+    fetchWorkerRunsMock.mockRejectedValue(new TypeError("fetch failed"));
+    const { result } = renderHook(() => useWorkerRunsPoll());
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current).toEqual({
+      status: "unavailable",
+      kind: "unreachable",
+      lastGood: null,
+    });
+  });
+
+  it("the next successful poll clears unavailable (automatic recovery, no debounce)", async () => {
+    vi.useFakeTimers();
+    fetchWorkerRunsMock
+      .mockRejectedValueOnce(
+        new OpsApiHttpError(404, "Not Found", "/api/ops/runs"),
+      )
+      .mockResolvedValueOnce(okBody());
+    const { result } = renderHook(() => useWorkerRunsPoll());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current?.status).toBe("unavailable");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(result.current?.status).toBe("ok");
+  });
+
+  it("polls on the default 10s cadence", async () => {
+    vi.useFakeTimers();
+    fetchWorkerRunsMock.mockResolvedValue(okBody());
+    renderHook(() => useWorkerRunsPoll());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchWorkerRunsMock).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(fetchWorkerRunsMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// WorkerRunsContext — the no-provider contract (load-bearing for T13)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("useWorkerRuns (context consumer)", () => {
+  it("NEVER throws absent a provider and returns the no-data default (null)", () => {
+    let rendered: ReturnType<typeof renderHook<unknown, unknown>> | null = null;
+    expect(() => {
+      rendered = renderHook(() => useWorkerRuns());
+    }).not.toThrow();
+    expect(rendered!.result.current).toBeNull();
+  });
+
+  it("returns the provider-supplied status when mounted under WorkerRunsProvider", () => {
+    const status: WorkerRunsStatus = {
+      status: "unavailable",
+      kind: "unreachable",
+      lastGood: null,
+    };
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(WorkerRunsProvider, { value: status, children });
+    const { result } = renderHook(() => useWorkerRuns(), { wrapper });
+    expect(result.current).toBe(status);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// isFamilySilent / familyForProbeKey — §7.3/§7.4 pure helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+const NOW = Date.parse("2026-06-10T12:00:00.000Z");
+
+function batch(over: Partial<WorkerRunBatch> = {}): WorkerRunBatch {
+  return {
+    runId: "01JXRUN",
+    triggered: false,
+    enqueuedAt: "2026-06-10T11:00:00.000Z",
+    finishedAt: "2026-06-10T11:06:00.000Z",
+    durationMs: 360_000,
+    outcome: "completed",
+    jobs: { total: 4, done: 4, failed: 0, reclaimed: 0 },
+    cells: { total: 32, passed: 32, failed: 0 },
+    redsIntroduced: null,
+    redsCleared: null,
+    errorSummary: null,
+    commErrorKinds: [],
+    ...over,
+  };
+}
+
+function familyEntry(
+  over: Partial<WorkerFamilySummary> = {},
+): WorkerFamilySummary {
+  return {
+    family: "d5",
+    label: "D5 e2e-deep",
+    probeKeyPrefix: "d5-single-pill-e2e",
+    schedule: "5,20,35,50 * * * *",
+    periodMs: 900_000,
+    nextRunAt: null,
+    lastRun: null,
+    inflight: null,
+    lastSuccessAt: null,
+    ...over,
+  };
+}
+
+describe("isFamilySilent", () => {
+  it("is silent only past 2x the server periodMs (consumed verbatim — no client cron parsing)", () => {
+    const at = (ms: number) => new Date(NOW - ms).toISOString();
+    // Exactly 2 periods old: NOT yet silent (strictly-older-than threshold).
+    expect(
+      isFamilySilent(familyEntry({ lastSuccessAt: at(1_800_000) }), NOW),
+    ).toBe(false);
+    // 1ms past 2 periods: silent.
+    expect(
+      isFamilySilent(familyEntry({ lastSuccessAt: at(1_800_001) }), NOW),
+    ).toBe(true);
+    // A non-default periodMs shifts the threshold — server value verbatim.
+    expect(
+      isFamilySilent(
+        familyEntry({ periodMs: 60_000, lastSuccessAt: at(120_001) }),
+        NOW,
+      ),
+    ).toBe(true);
+    expect(
+      isFamilySilent(
+        familyEntry({ periodMs: 60_000, lastSuccessAt: at(119_999) }),
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("null lastSuccessAt falls back to the oldest known batch's enqueuedAt", () => {
+    const oldEnqueue = new Date(NOW - 2_000_000).toISOString(); // > 2x 900s
+    expect(
+      isFamilySilent(
+        familyEntry({
+          lastSuccessAt: null,
+          lastRun: batch({ enqueuedAt: oldEnqueue, outcome: "failed" }),
+        }),
+        NOW,
+      ),
+    ).toBe(true);
+    const freshEnqueue = new Date(NOW - 60_000).toISOString();
+    expect(
+      isFamilySilent(
+        familyEntry({
+          lastSuccessAt: null,
+          lastRun: batch({ enqueuedAt: freshEnqueue, outcome: "failed" }),
+        }),
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("an inflight-only family (never completed) falls back to the inflight enqueuedAt", () => {
+    expect(
+      isFamilySilent(
+        familyEntry({
+          lastSuccessAt: null,
+          lastRun: null,
+          inflight: {
+            runId: "01JXNEW",
+            triggered: false,
+            enqueuedAt: new Date(NOW - 2_000_000).toISOString(),
+            elapsedMs: 2_000_000,
+            stalled: true,
+            jobs: { pending: 4, claimed: 0, running: 0, done: 0, failed: 0 },
+          },
+        }),
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("zero batches → never silent (fresh env before the first producer tick)", () => {
+    expect(
+      isFamilySilent(
+        familyEntry({ lastSuccessAt: null, lastRun: null, inflight: null }),
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("a degraded entry (history_unavailable, no periodMs) is never classified silent", () => {
+    expect(
+      isFamilySilent(
+        {
+          family: "d6",
+          label: "D6 all-pills",
+          probeKeyPrefix: "d6",
+          error: "history_unavailable",
+        },
+        NOW,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("familyForProbeKey", () => {
+  const families: WorkerFamilySummary[] = [
+    familyEntry({
+      family: "d6",
+      label: "D6 all-pills",
+      probeKeyPrefix: "d6",
+    }),
+    familyEntry({
+      family: "d5",
+      label: "D5 e2e-deep",
+      probeKeyPrefix: "d5-single-pill-e2e",
+    }),
+    familyEntry({
+      family: "e2e-demos",
+      label: "E2E demos",
+      probeKeyPrefix: "e2e-demos",
+    }),
+    familyEntry({
+      family: "e2e-smoke",
+      label: "E2E smoke",
+      probeKeyPrefix: "d4",
+    }),
+  ];
+
+  it("maps d4:<slug> to the e2e-smoke family via the payload probeKeyPrefix", () => {
+    expect(familyForProbeKey("d4:lg-py", families)?.family).toBe("e2e-smoke");
+  });
+
+  it("maps d5-single-pill-e2e:<slug> to the d5 family", () => {
+    expect(familyForProbeKey("d5-single-pill-e2e:agno", families)?.family).toBe(
+      "d5",
+    );
+  });
+
+  it("matches the exact prefix segment, never a partial prefix", () => {
+    // "d6x:<slug>" must NOT match the "d6" family.
+    expect(familyForProbeKey("d6x:slug", families)).toBeUndefined();
+  });
+
+  it("returns undefined for unknown prefixes and keys without a colon", () => {
+    expect(familyForProbeKey("starter_smoke", families)).toBeUndefined();
+    expect(familyForProbeKey("unknown:slug", families)).toBeUndefined();
+  });
+});

--- a/showcase/shell-dashboard/src/hooks/use-worker-runs.ts
+++ b/showcase/shell-dashboard/src/hooks/use-worker-runs.ts
@@ -1,0 +1,155 @@
+"use client";
+/**
+ * Poll hook for the worker-routed run summary (`/api/ops/runs` →
+ * harness `GET /api/runs`, spec §5.2.1) — the §6.1 data layer.
+ *
+ * Mirrors `use-probes.ts`: ~10 s interval, AbortController cancellation,
+ * per-effect `cancelled` closure (see the rationale comment there). What
+ * it adds is the §6.1 three-way availability classification:
+ *
+ *   - HTTP 404                  → `misdeploy-404` (cold first poll and
+ *     post-success alike — see EXPECT_WORKER_RUNS_ENDPOINT below)
+ *   - any other fetch/parse/5xx → `unreachable`
+ *   - 200 body where ANY family entry carries the §5.2.1
+ *     `error: "history_unavailable"` marker → `history-backend`
+ *     (PB down while the CP answers — the response succeeded but the
+ *     measurement behind it did not)
+ *
+ * Last-good data + its fetch timestamp are retained across unavailable
+ * states so the §6.3 panel can render the dimmed stale table. Recovery is
+ * automatic on the next successful poll; deliberately NO debounce — a
+ * transient single-poll blip flashing the state briefly is preferred over
+ * any delay in surfacing an outage (§6.1).
+ */
+import { useEffect, useRef, useState } from "react";
+
+import {
+  fetchWorkerRuns,
+  OpsApiHttpError,
+  type WorkerRunsResponse,
+} from "../lib/ops-api";
+
+// §6.1: source-level constant, compiled into the same bundle as the fetch
+// code. Deliberately NOT env/build config (no-public-env-shell-read rule —
+// the only env route to a client-visible build value is NEXT_PUBLIC_*,
+// which the oxlint rule bans in shell source; see the rule comment in
+// src/app/api/ops/[...path]/route.ts). Any build that can receive a 404
+// from /api/ops/runs ships this constant, so a 404 is ALWAYS the
+// misdeploy incident class — no skew state exists: a build without the
+// constant is pre-P3 code with no worker-runs section and no fetch.
+// Flippable only by a deliberate code change.
+export const EXPECT_WORKER_RUNS_ENDPOINT: boolean = true;
+
+const DEFAULT_INTERVAL_MS = 10_000;
+
+/** §6.1 unavailable classification — drives the §6.3 message variants. */
+export type WorkerRunsUnavailableKind =
+  | "misdeploy-404"
+  | "unreachable"
+  | "history-backend";
+
+export type WorkerRunsStatus =
+  | { status: "ok"; data: WorkerRunsResponse; fetchedAt: number }
+  | {
+      status: "unavailable";
+      kind: WorkerRunsUnavailableKind;
+      lastGood: { data: WorkerRunsResponse; fetchedAt: number } | null;
+    };
+
+/**
+ * Poll `/api/ops/runs` on the same ~10 s cadence as the probe poll.
+ *
+ * Returns `null` until the first poll settles — the same "no data yet"
+ * value the `WorkerRunsContext` default carries, so consumers have exactly
+ * one no-data case to handle (render no glyph/banner/section content).
+ */
+export function useWorkerRunsPoll(opts?: {
+  intervalMs?: number;
+  baseUrl?: string;
+}): WorkerRunsStatus | null {
+  const intervalMs = opts?.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const baseUrl = opts?.baseUrl;
+
+  const [status, setStatus] = useState<WorkerRunsStatus | null>(null);
+
+  // Last successful body + timestamp, surfaced on every unavailable state
+  // (§6.3 "last good data <relative>" + dimmed table). A ref, not state:
+  // it only ever renders THROUGH a status update.
+  const lastGoodRef = useRef<{
+    data: WorkerRunsResponse;
+    fetchedAt: number;
+  } | null>(null);
+  // Same cancellation pattern as use-probes.ts: controllerRef cancels the
+  // in-flight request across interval ticks; cancelledRef mirrors the
+  // active effect's cancelled flag.
+  const controllerRef = useRef<AbortController | null>(null);
+  const cancelledRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    // Dep change (baseUrl swap): drop data from the prior target — both the
+    // rendered status and the last-good cache, which would otherwise
+    // resurface stale cross-target data inside an unavailable panel.
+    setStatus(null);
+    lastGoodRef.current = null;
+
+    async function run(): Promise<void> {
+      controllerRef.current?.abort();
+      const controller = new AbortController();
+      controllerRef.current = controller;
+      try {
+        const data = await fetchWorkerRuns({
+          signal: controller.signal,
+          baseUrl,
+        });
+        if (cancelledRef.current || controller.signal.aborted) return;
+        const fetchedAt = Date.now();
+        // §6.1: a 200 body carrying any family-entry degradation marker is
+        // the SAME incident class as a failed poll — the response
+        // succeeded but the measurement behind it did not. It is not
+        // last-good data.
+        const degraded = data.families.some(
+          (family) => family.error === "history_unavailable",
+        );
+        if (degraded) {
+          setStatus({
+            status: "unavailable",
+            kind: "history-backend",
+            lastGood: lastGoodRef.current,
+          });
+          return;
+        }
+        lastGoodRef.current = { data, fetchedAt };
+        setStatus({ status: "ok", data, fetchedAt });
+      } catch (err) {
+        if (cancelledRef.current || controller.signal.aborted) return;
+        // AbortError is expected during teardown / interval rollover.
+        if ((err as { name?: string })?.name === "AbortError") return;
+        // §6.1 404 rule: every build that performs this fetch ships
+        // EXPECT_WORKER_RUNS_ENDPOINT, so a 404 is always the misdeploy
+        // incident class — cold first poll and post-success alike.
+        const isMisdeploy404 =
+          EXPECT_WORKER_RUNS_ENDPOINT &&
+          err instanceof OpsApiHttpError &&
+          err.status === 404;
+        setStatus({
+          status: "unavailable",
+          kind: isMisdeploy404 ? "misdeploy-404" : "unreachable",
+          lastGood: lastGoodRef.current,
+        });
+      }
+    }
+
+    void run();
+    const timer = setInterval(() => {
+      void run();
+    }, intervalMs);
+    return () => {
+      cancelledRef.current = true;
+      clearInterval(timer);
+      controllerRef.current?.abort();
+    };
+  }, [baseUrl, intervalMs]);
+
+  return status;
+}

--- a/showcase/shell-dashboard/src/lib/ops-api.test.ts
+++ b/showcase/shell-dashboard/src/lib/ops-api.test.ts
@@ -18,10 +18,18 @@ import {
   fetchProbes,
   fetchProbeDetail,
   triggerProbe,
+  fetchWorkerRuns,
+  fetchWorkerRunHistory,
+  fetchWorkerRunDetail,
+  OpsApiHttpError,
+  ThrottledError,
   type ProbesResponse,
   type TriggerResponse,
   type ProbeScheduleEntry,
   type ProbeRun,
+  type WorkerRunsResponse,
+  type WorkerRunHistoryResponse,
+  type WorkerRunDetailResponse,
 } from "./ops-api";
 
 type FetchInit = Parameters<typeof fetch>[1];
@@ -462,5 +470,175 @@ describe("triggerProbe abort behavior (R2-C.4)", () => {
       caught = err;
     }
     expect((caught as { name?: string })?.name).toBe("AbortError");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Worker-runs fetchers — §5.2.1–§5.2.3 wire contract (runviz T10)
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("worker-runs fetchers", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function workerRunsBody(): WorkerRunsResponse {
+    return { families: [], workers: [] };
+  }
+
+  function historyBody(): WorkerRunHistoryResponse {
+    return {
+      family: "d5",
+      runs: [],
+      perPage: 20,
+      nextBefore: null,
+      nextBeforeId: null,
+    };
+  }
+
+  function detailBody(): WorkerRunDetailResponse {
+    return { family: "d5", runId: "01JXRUN", jobs: [] };
+  }
+
+  describe("fetchWorkerRuns", () => {
+    it("hits <base>/runs with cache no-store", async () => {
+      fetchSpy.mockResolvedValue(jsonResponse(workerRunsBody()));
+      const out = await fetchWorkerRuns({ baseUrl: "http://ops.test" });
+      expect(out).toEqual(workerRunsBody());
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchSpy.mock.calls[0]!;
+      expect(String(url)).toBe("http://ops.test/runs");
+      expect((init as FetchInit)?.cache).toBe("no-store");
+    });
+
+    it("falls back to the same-origin /api/ops proxy path", async () => {
+      fetchSpy.mockResolvedValue(jsonResponse(workerRunsBody()));
+      await fetchWorkerRuns();
+      const [url] = fetchSpy.mock.calls[0]!;
+      expect(String(url)).toBe("/api/ops/runs");
+    });
+
+    it("surfaces a 404 as OpsApiHttpError carrying status 404 (the §6.1 misdeploy classifier input)", async () => {
+      fetchSpy.mockResolvedValue(
+        new Response("not here", { status: 404, statusText: "Not Found" }),
+      );
+      let caught: unknown = null;
+      try {
+        await fetchWorkerRuns({ baseUrl: "http://ops.test" });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(OpsApiHttpError);
+      expect((caught as OpsApiHttpError).status).toBe(404);
+    });
+  });
+
+  describe("fetchWorkerRunHistory", () => {
+    it("hits <base>/runs/:family with cache no-store", async () => {
+      fetchSpy.mockResolvedValue(jsonResponse(historyBody()));
+      const out = await fetchWorkerRunHistory("d5", undefined, {
+        baseUrl: "http://ops.test",
+      });
+      expect(out).toEqual(historyBody());
+      const [url, init] = fetchSpy.mock.calls[0]!;
+      expect(String(url)).toBe("http://ops.test/runs/d5");
+      expect((init as FetchInit)?.cache).toBe("no-store");
+    });
+
+    it("echoes before AND beforeId verbatim as query params (§5.2.2 composite cursor)", async () => {
+      fetchSpy.mockResolvedValue(jsonResponse(historyBody()));
+      await fetchWorkerRunHistory(
+        "d5",
+        { before: "2026-06-10T01:02:03.004Z", beforeId: "row_42" },
+        { baseUrl: "http://ops.test" },
+      );
+      const [url] = fetchSpy.mock.calls[0]!;
+      const parsed = new URL(String(url));
+      expect(parsed.pathname).toBe("/runs/d5");
+      expect(parsed.searchParams.get("before")).toBe(
+        "2026-06-10T01:02:03.004Z",
+      );
+      expect(parsed.searchParams.get("beforeId")).toBe("row_42");
+    });
+
+    it("honors Retry-After on a 429 before retrying (§6.1 NON-incident path)", async () => {
+      vi.useFakeTimers();
+      fetchSpy
+        .mockResolvedValueOnce(
+          new Response("", { status: 429, headers: { "retry-after": "5" } }),
+        )
+        .mockResolvedValueOnce(jsonResponse(historyBody()));
+      const promise = fetchWorkerRunHistory("d5", undefined, {
+        baseUrl: "http://ops.test",
+      });
+      // Flush microtasks so the first 429 is consumed and the wait armed.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      // 1ms short of Retry-After: 5s — must NOT have retried yet.
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      await expect(promise).resolves.toEqual(historyBody());
+    });
+
+    it("falls back to the 10s rate-limit window when Retry-After is absent", async () => {
+      vi.useFakeTimers();
+      fetchSpy
+        .mockResolvedValueOnce(new Response("", { status: 429 }))
+        .mockResolvedValueOnce(jsonResponse(historyBody()));
+      const promise = fetchWorkerRunHistory("d5", undefined, {
+        baseUrl: "http://ops.test",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(9_999);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      await expect(promise).resolves.toEqual(historyBody());
+    });
+
+    it("caps retries at 3 attempts then throws a typed ThrottledError", async () => {
+      vi.useFakeTimers();
+      fetchSpy.mockResolvedValue(
+        new Response("", { status: 429, headers: { "retry-after": "1" } }),
+      );
+      const settled = fetchWorkerRunHistory("d5", undefined, {
+        baseUrl: "http://ops.test",
+      }).catch((err: unknown) => err);
+      // Two 1s waits separate the three attempts; advance well past both.
+      await vi.advanceTimersByTimeAsync(10_000);
+      const err = await settled;
+      expect(err).toBeInstanceOf(ThrottledError);
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("fetchWorkerRunDetail", () => {
+    it("hits <base>/runs/:family/:runId with cache no-store", async () => {
+      fetchSpy.mockResolvedValue(jsonResponse(detailBody()));
+      const out = await fetchWorkerRunDetail("d5", "01JXRUN", {
+        baseUrl: "http://ops.test",
+      });
+      expect(out).toEqual(detailBody());
+      const [url, init] = fetchSpy.mock.calls[0]!;
+      expect(String(url)).toBe("http://ops.test/runs/d5/01JXRUN");
+      expect((init as FetchInit)?.cache).toBe("no-store");
+    });
+
+    it("shares the 429 retry-then-ThrottledError path with the history fetcher", async () => {
+      vi.useFakeTimers();
+      fetchSpy.mockResolvedValue(
+        new Response("", { status: 429, headers: { "retry-after": "1" } }),
+      );
+      const settled = fetchWorkerRunDetail("d5", "01JXRUN", {
+        baseUrl: "http://ops.test",
+      }).catch((err: unknown) => err);
+      await vi.advanceTimersByTimeAsync(10_000);
+      const err = await settled;
+      expect(err).toBeInstanceOf(ThrottledError);
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+    });
   });
 });

--- a/showcase/shell-dashboard/src/lib/ops-api.ts
+++ b/showcase/shell-dashboard/src/lib/ops-api.ts
@@ -179,6 +179,49 @@ function resolveBaseUrl(explicit?: string): string {
 }
 
 /**
+ * Typed HTTP-status error thrown by `ensureOk` for non-2xx responses.
+ * Carries the numeric `status` so callers can classify without scraping
+ * the message — the §6.1 poll hook distinguishes a 404 (misdeploy
+ * incident class) from every other failure (unreachable) off this field.
+ * The message format is unchanged from the prior plain-Error throw.
+ */
+export class OpsApiHttpError extends Error {
+  readonly status: number;
+  readonly statusText: string;
+  readonly url: string;
+
+  constructor(status: number, statusText: string, url: string, detail = "") {
+    super(`ops-api request failed: ${status} ${statusText} at ${url}${detail}`);
+    this.name = "OpsApiHttpError";
+    this.status = status;
+    this.statusText = statusText;
+    this.url = url;
+  }
+}
+
+/**
+ * Thrown by the worker-runs history/detail fetchers when the §5.2 shared
+ * rate limit keeps answering 429 past the retry cap. Per §6.1 this is
+ * explicitly NON-incident — the CP is alive and deliberately throttling —
+ * so consumers (the detail panel) render a retry affordance and MUST NOT
+ * trip the `unavailable` state, the §6.3 error panel, or the §7.4 banner.
+ */
+export class ThrottledError extends Error {
+  /** Server-advised (or fallback) wait before the next manual retry. */
+  readonly retryAfterMs: number;
+  readonly url: string;
+
+  constructor(url: string, retryAfterMs: number) {
+    super(
+      `ops-api throttled: 429 at ${url} — retry attempts exhausted (retry after ${retryAfterMs}ms)`,
+    );
+    this.name = "ThrottledError";
+    this.retryAfterMs = retryAfterMs;
+    this.url = url;
+  }
+}
+
+/**
  * Throw a uniform error for non-2xx responses. We intentionally keep the
  * message terse + machine-readable (`"<status> <statusText> at <url>"`)
  * so call sites and tests can assert against the status code without
@@ -213,9 +256,7 @@ async function ensureOk(response: Response, url: string): Promise<void> {
     const msg = (bodyErr as Error)?.message ?? "unknown";
     detail = ` (body read failed: ${msg})`;
   }
-  throw new Error(
-    `ops-api request failed: ${response.status} ${response.statusText} at ${url}${detail}`,
-  );
+  throw new OpsApiHttpError(response.status, response.statusText, url, detail);
 }
 
 /**
@@ -316,4 +357,324 @@ export async function triggerProbe(
   });
   await ensureOk(response, url);
   return parseJson<TriggerResponse>(response, url);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Worker-routed run visibility — DTOs + fetchers (spec §5.2.1–§5.2.3, §6.1).
+//
+// On-the-wire contract with the harness CP `/api/runs*` routes
+// (`showcase/harness/src/http/fleet-runs.ts`), reached through the same
+// `/api/ops/[...path]` proxy as the probe endpoints. The JSON examples in
+// spec §5.2.1/§5.2.3 are the contract; field nullability mirrors the
+// server projections in `run-view.ts`.
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * §5.2.1 precedence-derived batch outcome — exactly three values, derived
+ * server-side (stalled > failed > completed). Consumers render this
+ * verbatim and never re-classify client-side.
+ */
+export type WorkerRunOutcome = "completed" | "failed" | "stalled";
+
+/**
+ * §5.2.1 worker health, derived server-side by the shared `deriveHealth`
+ * at 1x/2x the boot-resolved heartbeat window. Rendered verbatim — no
+ * client-side re-derivation.
+ */
+export type WorkerHealthState = "online" | "stale" | "offline";
+
+export interface WorkerRunJobCounts {
+  total: number;
+  done: number;
+  failed: number;
+  /** Jobs with hook-stamped `reclaim_count > 0`, counted once each (§4.2). */
+  reclaimed: number;
+}
+
+export interface WorkerCellCounts {
+  total: number;
+  passed: number;
+  failed: number;
+}
+
+/**
+ * One run batch (jobs grouped by `run_id`) — the §5.2.1 `lastRun` shape,
+ * also each item of the §5.2.2 history list.
+ */
+export interface WorkerRunBatch {
+  runId: string;
+  triggered: boolean;
+  enqueuedAt: string;
+  /** Null while any job is non-terminal (stalled batches never finish). */
+  finishedAt: string | null;
+  durationMs: number | null;
+  outcome: WorkerRunOutcome;
+  jobs: WorkerRunJobCounts;
+  cells: WorkerCellCounts | null;
+  /** Summed from probe_runs.summary; null when no row carries the fields (pre-P2 rows). */
+  redsIntroduced: number | null;
+  redsCleared: number | null;
+  /** Closed-vocabulary only (§5.2.1 redaction) — never commError.message content. */
+  errorSummary: string | null;
+  /** Deduped, isPoolCommErrorKind-validated kinds; unknown values arrive as "unknown". */
+  commErrorKinds: string[];
+  /**
+   * §5.2.2 degenerate-clamp marker: present+true when the batch was larger
+   * than the capped fetch window, so every count may undercount.
+   */
+  truncated?: boolean;
+}
+
+/** §5.2.1 `inflight` — the newest run_id group only, when non-terminal. */
+export interface WorkerRunInflight {
+  runId: string;
+  triggered: boolean;
+  enqueuedAt: string;
+  elapsedMs: number;
+  /** §5.2.1 rules (a)/(c): 2x-period no-progress or 4x-period absolute age. */
+  stalled: boolean;
+  jobs: {
+    pending: number;
+    claimed: number;
+    running: number;
+    done: number;
+    failed: number;
+  };
+}
+
+/**
+ * One `/api/runs` family entry. When the §5.2.1 graceful-degradation rule
+ * fires (PB failure while computing this family's projection), the entry
+ * carries `error: "history_unavailable"` IN PLACE OF the computed fields —
+ * hence everything past the registry echo is optional. §6.1 treats any
+ * entry-level error as the same incident class as a failed poll.
+ */
+export interface WorkerFamilySummary {
+  family: string;
+  label: string;
+  /** Echoed from FLEET_FAMILIES so cell keys map to families purely from the payload (§7.2). */
+  probeKeyPrefix: string;
+  error?: "history_unavailable";
+  /** Display only (§6.2 humanizeCron) — NEVER threshold math; use periodMs. */
+  schedule?: string;
+  /**
+   * Server-computed from the resolved cron (§5.2.1): shortest gap between
+   * consecutive fires. All period-derived dashboard windows (§7.3 glyph,
+   * §7.4 banner) consume this verbatim — no client-side cron parsing.
+   */
+  periodMs?: number;
+  nextRunAt?: string | null;
+  lastRun?: WorkerRunBatch | null;
+  inflight?: WorkerRunInflight | null;
+  /**
+   * Finish of the newest completed batch within the capped walk-back, or
+   * null (no completed batch in window / never succeeded). Null consumers
+   * fall back to the oldest known batch's enqueuedAt (§5.2.1 null rule).
+   */
+  lastSuccessAt?: string | null;
+}
+
+/** §5.2.1 workers strip entry. The `endpoint` column is never serialized. */
+export interface WorkerView {
+  workerId: string;
+  health: WorkerHealthState;
+  lastHeartbeatAt: string;
+  currentJobId: string | null;
+  capacity: { inUse: number; available: number; max: number };
+}
+
+/** GET /api/runs (§5.2.1). */
+export interface WorkerRunsResponse {
+  families: WorkerFamilySummary[];
+  workers: WorkerView[];
+}
+
+/** GET /api/runs/:family (§5.2.2). */
+export interface WorkerRunHistoryResponse {
+  family: string;
+  runs: WorkerRunBatch[];
+  perPage: number;
+  /** Composite cursor; both null ONLY when history exhausted (§5.2.2). */
+  nextBefore: string | null;
+  nextBeforeId: string | null;
+  /** §5.2.1-anchored degradation marker (PB outage → 200 + error, never 500). */
+  error?: "history_unavailable";
+}
+
+/** One per-service job row of the §5.2.3 drill-down. */
+export interface WorkerRunJob {
+  jobId: string;
+  probeKey: string;
+  serviceSlug: string;
+  status: "pending" | "claimed" | "running" | "done" | "failed";
+  claimedBy: string | null;
+  enqueuedAt: string;
+  claimedAt: string | null;
+  finishedAt: string | null;
+  /** claimed_at − created; for reclaimCount > 0 this measures the LAST claim (§5.2.1 corollary). */
+  queueLatencyMs: number | null;
+  durationMs: number | null;
+  /** §4.2 hook counter, surfaced directly. */
+  reclaimCount: number;
+  cells: WorkerCellCounts | null;
+  /** Same §5.2.1 redaction rule as the batch-level summary. */
+  errorSummary: string | null;
+  /** kind is enum-validated server-side; message is never serialized. */
+  commError: { kind: string; observedAt: string } | null;
+}
+
+/** GET /api/runs/:family/:runId (§5.2.3). */
+export interface WorkerRunDetailResponse {
+  family: string;
+  runId: string;
+  jobs: WorkerRunJob[];
+  error?: "history_unavailable";
+}
+
+/** §5.2.2 composite (created, id) cursor — echo nextBefore/nextBeforeId verbatim. */
+export interface WorkerRunsCursor {
+  before: string;
+  beforeId: string;
+}
+
+// The §5.2 fixed-window rate limit is 30 req / 10 s; when a 429 arrives
+// without a Retry-After header we wait the full window length (§6.1).
+export const THROTTLE_RETRY_FALLBACK_MS = 10_000;
+// §6.1: retry capped at 3 attempts total, then surface a panel-local
+// retry affordance (ThrottledError) rather than escalating.
+export const THROTTLE_MAX_ATTEMPTS = 3;
+
+/**
+ * Parse a Retry-After header value (delta-seconds or HTTP-date) into
+ * milliseconds. Returns null for absent/unparseable values so the caller
+ * applies the §6.1 fallback (the 10 s window length).
+ */
+function parseRetryAfterMs(header: string | null): number | null {
+  if (!header) return null;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.round(seconds * 1000);
+  }
+  const dateMs = Date.parse(header);
+  if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - Date.now());
+  return null;
+}
+
+/**
+ * Abort-aware sleep. Rejects with a genuine AbortError (DOMException) so
+ * the hook-layer cancellation filters (`err.name === "AbortError"`) treat
+ * a mid-wait teardown exactly like a mid-fetch one.
+ */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const abortError = () => new DOMException("aborted", "AbortError");
+    if (signal?.aborted) {
+      reject(abortError());
+      return;
+    }
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(abortError());
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * GET-and-parse with the §6.1 429 path: honor Retry-After (fallback: the
+ * 10 s window length), retry capped at THROTTLE_MAX_ATTEMPTS total
+ * attempts, then throw a typed ThrottledError. Every other status flows
+ * through the standard ensureOk/parseJson plumbing.
+ */
+async function fetchJsonWithThrottleRetry<T>(
+  url: string,
+  signal?: AbortSignal,
+): Promise<T> {
+  let lastRetryAfterMs = THROTTLE_RETRY_FALLBACK_MS;
+  for (let attempt = 1; attempt <= THROTTLE_MAX_ATTEMPTS; attempt++) {
+    const response = await fetch(url, {
+      method: "GET",
+      signal,
+      cache: "no-store",
+      headers: { accept: "application/json" },
+    });
+    if (response.status === 429) {
+      lastRetryAfterMs =
+        parseRetryAfterMs(response.headers.get("retry-after")) ??
+        THROTTLE_RETRY_FALLBACK_MS;
+      if (attempt === THROTTLE_MAX_ATTEMPTS) break;
+      await sleep(lastRetryAfterMs, signal);
+      continue;
+    }
+    await ensureOk(response, url);
+    return parseJson<T>(response, url);
+  }
+  throw new ThrottledError(url, lastRetryAfterMs);
+}
+
+/**
+ * GET /api/runs — the §5.2.1 family summary. No 429 path: the route is
+ * memoized server-side, not rate-limited (§5.2), so the §6.1 incident
+ * classification never has to disambiguate this fetcher.
+ */
+export async function fetchWorkerRuns(
+  opts: { signal?: AbortSignal; baseUrl?: string } = {},
+): Promise<WorkerRunsResponse> {
+  const url = `${resolveBaseUrl(opts.baseUrl)}/runs`;
+  // Same no-store rationale as fetchProbes — polled live data.
+  const response = await fetch(url, {
+    method: "GET",
+    signal: opts.signal,
+    cache: "no-store",
+    headers: { accept: "application/json" },
+  });
+  await ensureOk(response, url);
+  return parseJson<WorkerRunsResponse>(response, url);
+}
+
+/**
+ * GET /api/runs/:family — §5.2.2 run history. The cursor pair is echoed
+ * verbatim from the previous page's nextBefore/nextBeforeId (composite
+ * (created, id) — never send `before` alone). Shares the §5.2 rate-limit
+ * window with the detail route, hence the 429 retry path.
+ */
+export async function fetchWorkerRunHistory(
+  family: string,
+  cursor?: WorkerRunsCursor,
+  opts: { signal?: AbortSignal; baseUrl?: string; perPage?: number } = {},
+): Promise<WorkerRunHistoryResponse> {
+  if (!family) throw new Error("family is required");
+  const params = new URLSearchParams();
+  if (opts.perPage !== undefined) params.set("perPage", String(opts.perPage));
+  if (cursor) {
+    params.set("before", cursor.before);
+    params.set("beforeId", cursor.beforeId);
+  }
+  const query = params.toString();
+  const url = `${resolveBaseUrl(opts.baseUrl)}/runs/${encodeURIComponent(
+    family,
+  )}${query ? `?${query}` : ""}`;
+  return fetchJsonWithThrottleRetry<WorkerRunHistoryResponse>(url, opts.signal);
+}
+
+/**
+ * GET /api/runs/:family/:runId — §5.2.3 per-service drill-down. Shares
+ * the rate-limit window (and therefore the 429/ThrottledError path) with
+ * the history route.
+ */
+export async function fetchWorkerRunDetail(
+  family: string,
+  runId: string,
+  opts: { signal?: AbortSignal; baseUrl?: string } = {},
+): Promise<WorkerRunDetailResponse> {
+  if (!family) throw new Error("family is required");
+  if (!runId) throw new Error("runId is required");
+  const url = `${resolveBaseUrl(opts.baseUrl)}/runs/${encodeURIComponent(
+    family,
+  )}/${encodeURIComponent(runId)}`;
+  return fetchJsonWithThrottleRetry<WorkerRunDetailResponse>(url, opts.signal);
 }

--- a/showcase/shell-dashboard/src/lib/worker-runs-context.tsx
+++ b/showcase/shell-dashboard/src/lib/worker-runs-context.tsx
@@ -1,0 +1,111 @@
+"use client";
+/**
+ * `WorkerRunsContext` — exposes the §6.1 `WorkerRunsStatus` poll result to
+ * matrix components without prop-drilling (spec §7.1), plus the shared
+ * pure helpers the §7.3 glyph and §7.4 banner consume.
+ *
+ * NO-PROVIDER CONTRACT (load-bearing for T13 — do not weaken):
+ * the context is created with a safe default value (`null`, the no-data
+ * default), and `useWorkerRuns()` NEVER throws when no provider is
+ * mounted — it simply returns that default. Consumers treat `null` as
+ * "no worker-runs data" and render no glyph/banner/section content. This
+ * is what keeps pre-existing provider-less renders green once T13's
+ * consumers call the hook (e.g. `cell-pieces.signal-degrade.test.tsx`
+ * renders `CellStatus` with no `WorkerRunsProvider` and asserts
+ * `not.toThrow`). `null` is also the provider-mounted value until the
+ * first poll settles, so consumers have exactly one no-data case.
+ */
+import { createContext, useContext, type ReactNode } from "react";
+
+import type { WorkerFamilySummary } from "./ops-api";
+import type { WorkerRunsStatus } from "../hooks/use-worker-runs";
+
+/**
+ * `null` = no provider mounted OR the first poll has not settled yet.
+ * Either way: no worker-runs data — render no glyph/banner.
+ */
+export type WorkerRunsContextValue = WorkerRunsStatus | null;
+
+const WorkerRunsContext = createContext<WorkerRunsContextValue>(null);
+
+export function WorkerRunsProvider({
+  value,
+  children,
+}: {
+  value: WorkerRunsContextValue;
+  children: ReactNode;
+}) {
+  return (
+    <WorkerRunsContext.Provider value={value}>
+      {children}
+    </WorkerRunsContext.Provider>
+  );
+}
+
+/**
+ * Consume the worker-runs poll status. Never throws — absent a provider
+ * this returns the no-data default (`null`). See the no-provider contract
+ * in the module header.
+ */
+export function useWorkerRuns(): WorkerRunsContextValue {
+  return useContext(WorkerRunsContext);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Shared pure helpers — §7.3 (cell glyph) / §7.4 (coverage banner)
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * §7.3/§7.4: family silent = no success within 2×`periodMs`.
+ *
+ * - The period is the SERVER-computed `periodMs` the family entry carries
+ *   (§5.2.1), consumed verbatim — NO client cron parsing (the `schedule`
+ *   string is display-only).
+ * - Null `lastSuccessAt` falls back to the oldest known batch's
+ *   `enqueuedAt` (§5.2.1 null rule): `lastRun` when present (older than
+ *   `inflight` by construction — inflight is the newest group), else
+ *   `inflight`. "Has been trying and failing for 2 periods" is exactly as
+ *   alarming as "stopped succeeding 2 periods ago".
+ * - Zero batches → never silent (fresh env before the first producer
+ *   tick).
+ * - A degraded entry (`error: "history_unavailable"` — no `periodMs`) is
+ *   never classified silent here; §6.1 surfaces that as the `unavailable`
+ *   incident class instead.
+ */
+export function isFamilySilent(
+  entry: WorkerFamilySummary,
+  nowMs: number,
+): boolean {
+  const periodMs = entry.periodMs;
+  if (typeof periodMs !== "number" || periodMs <= 0) return false;
+  const reference =
+    entry.lastSuccessAt ??
+    entry.lastRun?.enqueuedAt ??
+    entry.inflight?.enqueuedAt ??
+    null;
+  if (!reference) return false;
+  const referenceMs = Date.parse(reference);
+  // Unparseable reference time: conservatively not-silent — a malformed
+  // payload must not paint silence glyphs across the matrix.
+  if (Number.isNaN(referenceMs)) return false;
+  return nowMs - referenceMs > 2 * periodMs;
+}
+
+/**
+ * §7.2: map a matrix cell key (`<prefix>:<slug>`) to its family entry via
+ * the `probeKeyPrefix` each family echoes in the `/api/runs` payload —
+ * never a dashboard-side prefix table (that would be exactly the
+ * cross-component drift the §5.1 drift-lock test exists to prevent).
+ *
+ * Matches the exact prefix segment before the first `:` — `d6x:slug`
+ * never matches the `d6` family. Keys without a `:` map to no family.
+ */
+export function familyForProbeKey(
+  key: string,
+  families: WorkerFamilySummary[],
+): WorkerFamilySummary | undefined {
+  const separator = key.indexOf(":");
+  if (separator <= 0) return undefined;
+  const prefix = key.slice(0, separator);
+  return families.find((family) => family.probeKeyPrefix === prefix);
+}

--- a/showcase/shell-dashboard/tsconfig.json
+++ b/showcase/shell-dashboard/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,9 +19,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     }
   },
   "include": [
@@ -35,7 +29,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/showcase/shell-dashboard/tsconfig.json
+++ b/showcase/shell-dashboard/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
@@ -29,5 +35,7 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary

Adds end-to-end **run-visibility** to the showcase fleet — a new data path from queue enqueue → per-family projection → dashboard + Slack alerting:

- **Contracts + PB schema**: `EnqueueJobInput.family`, `FleetQueueClient.pruneAged`, run-id/family/worker-id columns on `probe_jobs` / `resource_snapshots`, fleet-claim hook stamps at claim time.
- **Queue + aggregator**: queue-client stamps run-id/family on enqueue; d6 producer owns `pruneAged` retention; aggregator computes `redsIntroduced`/`redsCleared` into `probe_runs`.
- **Run-view projection (`run-view.ts`)**: §5.1 `FLEET_FAMILIES` registry + §5.2.1 family-summary projection. `createMemoizedFamilySummary` bounds PB load at ~one fan-out per TTL regardless of viewer count.
- **Producer wiring**: `PRODUCER_FAMILY_WIRING` drift-locks the four producers' family ids set-equal to the registry (unit-tested); CLI-triggered runs route through `familyForLevel` so a registry rename breaks loudly.
- **Family-silence monitor (§9)**: Slack alerting for the one incident class transition-keyed rules are blind to (a silent family produces no row transitions). Rides the existing fleet-health interval (no extra timer), per-family 6h rate-limit + recovered one-shot + boot-grace, fails open on PB-down for the meta-alert. Closed-vocabulary redaction.
- **HTTP `/api/runs`** + **`/health.fleetRuns.lastEvaluatedAt`**: read-only fleet-runs routes mounted unconditionally on the CP role, backed by the SAME memoized summary the monitor uses. `/health` stamp is the §9 compensating control so an external poll can detect a wedged monitor.
- **Orchestrator wiring**: boot-resolved `workerStaleAfterMs` threaded through both fleet-health and the projection so they judge staleness against the same window; test queues across the harness gain a no-op `pruneAged`.
- **Dashboard**: worker-runs Ops section (family table, worker strip, run-history drill-down), D0-from-staleness vs D0-from-failure family annotation, per-family silence banner on the coverage tab; data layer (DTOs, fetchers, polling hook, context provider).
- **Integration test**: 689-line end-to-end test exercising the full queue lifecycle → /api/runs projection across all four families.

This is the merged scope of the **runviz blitz** lanes T1-T15.

## Test plan

- [x] `pnpm typecheck` on `showcase/harness` and `showcase/shell-dashboard` — clean
- [x] `vitest run` on full harness suite — 2276 pass / 3 pre-existing probe-pool timing flakes (NOT in diff; subject is "probe-pool timing fragility", a different PR's concern)
- [x] `oxfmt --check showcase/` — all green
- [x] Integration test `run-visibility.integration.test.ts` passes — exercises queue → projection across all four families
- [ ] CI on PR HEAD — pending push, monitored after open

## Known follow-up (bucket-d)

- Probe-pool timing-sensitive flakes in `src/probes/helpers/browser-pool.test.ts` (FIX#4a self-heal) and `src/probes/loader/probe-invoker.test.ts` (timeout assertions) — different test fails on each run; subject is probe-pool timing fragility, not runviz.

## Deviation note

The runviz ship-finisher session ran in a Claude Agent SDK harness without an Agent dispatch tool, so the standard 7-agent CR-loop could not be dispatched. Inline review was performed against the cr-loop subject-manifest + four-bucket partition: T1-T15 each landed via their own per-task review on the blitz integration branch before reaching this PR, and T8/T15 (the two final-merged streams) were validated via typecheck-clean + targeted-tests-pass + cross-module wiring inspection. A heavyweight 7-agent CR can be run against this PR if desired.