### PR TITLE
fix(showcase/shell): runtime-derived backend URLs, docs-host redirects, and middleware/builder hardening (SU)

### DIFF
--- a/showcase/harness/src/probes/drivers/seo-redirects.ts
+++ b/showcase/harness/src/probes/drivers/seo-redirects.ts
@@ -353,8 +353,10 @@ const SPECIFIC_FRAMEWORK: RedirectEntry[] = [
   },
   {
     id: "F13",
+    // Keeps the framework segment (aws-strands -> canonical `strands`),
+    // mirroring the shell copy — see the comment there.
     source: "/aws-strands/human-in-the-loop",
-    destination: "/human-in-the-loop",
+    destination: "/strands/human-in-the-loop",
   },
   {
     id: "F14",
@@ -428,13 +430,12 @@ const ROOT_RENAMES: RedirectEntry[] = [
     source: "/copilot-suggestions",
     destination: "/prebuilt-components",
   },
-  // /direct-to-llm and /integrations/built-in-agent → built-in-agent (BIA canonical)
+  // /direct-to-llm → built-in-agent (BIA canonical). R15/R17
+  // (/integrations/built-in-agent[/:path*]) are docs-host-only entries
+  // that live in the shell-docs copy — on the SHELL host that path is a
+  // LIVE registry product page; the shell copy dropped them (mirrored
+  // here per the sync policy above).
   { id: "R14", source: "/direct-to-llm", destination: "/built-in-agent" },
-  {
-    id: "R15",
-    source: "/integrations/built-in-agent",
-    destination: "/built-in-agent",
-  },
   { id: "R18", source: "/mcp", destination: "/coding-agents" },
   { id: "R19", source: "/vibe-coding-mcp", destination: "/coding-agents" },
   {
@@ -721,15 +722,11 @@ const WILDCARD_REDIRECTS: RedirectEntry[] = [
     source: "/crewai-crews/:path*",
     destination: "/crewai-crews/:path*",
   },
-  // Category 4 wildcards — direct-to-llm and /integrations/built-in-agent retire to BIA
+  // Category 4 wildcards — direct-to-llm retires to BIA. R17 is
+  // docs-host-only — see the R15 note in ROOT_RENAMES above.
   {
     id: "R16",
     source: "/direct-to-llm/:path*",
-    destination: "/built-in-agent/:path*",
-  },
-  {
-    id: "R17",
-    source: "/integrations/built-in-agent/:path*",
     destination: "/built-in-agent/:path*",
   },
   { id: "R26", source: "/shared/:path*", destination: "/:path*" },

--- a/showcase/harness/test/fixtures/redirect-decommission/cli-stdout-human.txt
+++ b/showcase/harness/test/fixtures/redirect-decommission/cli-stdout-human.txt
@@ -1,8 +1,8 @@
 === SEO Redirect Decommission Report (last 30 days) ===
-Total redirects defined: 390
+Total redirects defined: 388
 Total hits: 12,537
 Redirects with hits: 13
-Zero-hit candidates: 377
+Zero-hit candidates: 375
 
 Top 10 most-hit redirects:
   D1                        5,432 hits
@@ -76,7 +76,7 @@ Decommission candidates (zero hits):
   F10                       /langgraph/generative-ui/interactive/client-side → /langgraph-python/generative-ui/your-components/interactive
   F11                       /langgraph/human-in-the-loop/node-flow → /langgraph-python/human-in-the-loop/interrupt-flow
   F12                       /langgraph/human-in-the-loop/prebuilt-agents → /langgraph-python/prebuilt-components
-  F13                       /aws-strands/human-in-the-loop → /human-in-the-loop
+  F13                       /aws-strands/human-in-the-loop → /strands/human-in-the-loop
   F14                       /adk/shared-state/state-inputs-outputs → /google-adk/shared-state/workflow-execution
   F15                       /langgraph/shared-state/state-inputs-outputs → /langgraph-python/shared-state/workflow-execution
   F16                       /llamaindex/shared-state/state-inputs-outputs → /llamaindex/shared-state/workflow-execution
@@ -157,9 +157,7 @@ Decommission candidates (zero hits):
   R12                       /coding-agent-setup → /coding-agents
   R13                       /copilot-suggestions → /prebuilt-components
   R14                       /direct-to-llm → /built-in-agent
-  R15                       /integrations/built-in-agent → /built-in-agent
   R16                       /direct-to-llm/:path* → /built-in-agent/:path*
-  R17                       /integrations/built-in-agent/:path* → /built-in-agent/:path*
   R18                       /mcp → /coding-agents
   R19                       /vibe-coding-mcp → /coding-agents
   R20                       /agentic-protocols → /agentic-protocols

--- a/showcase/harness/test/fixtures/redirect-decommission/cli-stdout.txt
+++ b/showcase/harness/test/fixtures/redirect-decommission/cli-stdout.txt
@@ -1,8 +1,8 @@
 :bar_chart: *SEO Redirect Decommission Report* (last 30 days)
-Total redirects defined: 390
+Total redirects defined: 388
 Total hits: 12,537
 
-:warning: *377 redirect(s) with zero hits — decommission candidates:*
+:warning: *375 redirect(s) with zero hits — decommission candidates:*
   • B1
   • B2
   • B3
@@ -99,9 +99,7 @@ Total hits: 12,537
   • R12
   • R13
   • R14
-  • R15
   • R16
-  • R17
   • R18
   • R19
   • R20

--- a/showcase/scripts/__tests__/generate-registry-pattern.test.ts
+++ b/showcase/scripts/__tests__/generate-registry-pattern.test.ts
@@ -1,0 +1,80 @@
+// SHOWCASE_BACKEND_HOST_PATTERN contract tests for generate-registry.ts,
+// run as a subprocess (the script executes main() at module load, so it
+// cannot be imported). Two invariants:
+//
+// 1. A pattern without the `{slug}` placeholder must FAIL the build
+//    loudly (stderr + non-zero exit — the contract vitest.global-setup
+//    and CI consume), not silently bake the same backend host into
+//    every integration.
+// 2. Every `{slug}` occurrence is substituted (replaceAll parity with
+//    the runtime consumer backendUrlFromPattern in
+//    shell/src/lib/backend-url.ts), not just the first.
+
+import { describe, it, expect, beforeAll, afterEach, afterAll } from "vitest";
+import fs from "fs";
+import path from "path";
+import { execFileSync } from "child_process";
+import { FileSnapshotRestorer, execOptsFor } from "./test-cleanup";
+import { SCRIPTS_DIR, SHELL_DATA_DIR } from "./paths";
+
+const SHOWCASE_ROOT = path.resolve(SCRIPTS_DIR, "..");
+// Everything the generator writes — multi-emit registry/catalog plus the
+// shell-only constraints.json — so a pattern-override run can't leave
+// non-default artifacts behind for other suites or the dev server.
+const DATA_FILES = [
+  path.join(SHELL_DATA_DIR, "registry.json"),
+  path.join(SHELL_DATA_DIR, "catalog.json"),
+  path.join(SHELL_DATA_DIR, "constraints.json"),
+  ...["shell-docs", "shell-dojo", "shell-dashboard"].flatMap((pkg) => [
+    path.join(SHOWCASE_ROOT, pkg, "src", "data", "registry.json"),
+    path.join(SHOWCASE_ROOT, pkg, "src", "data", "catalog.json"),
+  ]),
+];
+const dataRestorer = new FileSnapshotRestorer(DATA_FILES);
+const EXEC_OPTS = execOptsFor(SCRIPTS_DIR);
+
+function runGenerator(pattern: string): string {
+  return execFileSync("npx", ["tsx", "generate-registry.ts"], {
+    ...EXEC_OPTS,
+    env: { ...process.env, SHOWCASE_BACKEND_HOST_PATTERN: pattern },
+  }).toString();
+}
+
+beforeAll(() => {
+  dataRestorer.snapshot();
+});
+
+afterEach(() => dataRestorer.restore());
+afterAll(() => dataRestorer.restore());
+
+describe("generate-registry SHOWCASE_BACKEND_HOST_PATTERN contract", () => {
+  it("fails loudly (stderr + exit 1) when the pattern lacks the {slug} placeholder", () => {
+    let thrown: unknown;
+    try {
+      runGenerator("no-placeholder.example.com");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(
+      thrown,
+      "a {slug}-less pattern must fail the build, not bake one host everywhere",
+    ).toBeInstanceOf(Error);
+    const e = thrown as Error & { status?: number; stderr?: string };
+    expect(e.status).toBe(1);
+    expect(e.stderr).toContain("SHOWCASE_BACKEND_HOST_PATTERN");
+    expect(e.stderr).toContain("{slug}");
+  });
+
+  it("substitutes EVERY {slug} occurrence into backend_url (replaceAll parity with backend-url.ts)", () => {
+    runGenerator("{slug}.demos.example.com/{slug}");
+    const registry = JSON.parse(
+      fs.readFileSync(path.join(SHELL_DATA_DIR, "registry.json"), "utf-8"),
+    ) as { integrations: Array<{ slug: string; backend_url: string }> };
+    expect(registry.integrations.length).toBeGreaterThan(0);
+    for (const { slug, backend_url } of registry.integrations) {
+      expect(backend_url, `backend_url for "${slug}"`).toBe(
+        `https://${slug}.demos.example.com/${slug}`,
+      );
+    }
+  });
+});

--- a/showcase/scripts/__tests__/generate-registry-pattern.test.ts
+++ b/showcase/scripts/__tests__/generate-registry-pattern.test.ts
@@ -257,9 +257,7 @@ describe("writeFileAtomicSync tmp naming matches the straggler-sweep convention 
     // `<target>.<pid>.tmp` shape was invisible to that sweep, so a
     // SIGTERM-killed generator (the one crash mode its try/finally
     // cannot clean up) accumulated un-swept stragglers forever.
-    expect(path.basename(tmp)).toMatch(
-      /^\.registry\.json\.[0-9a-f]{16}\.tmp$/,
-    );
+    expect(path.basename(tmp)).toMatch(/^\.registry\.json\.[0-9a-f]{16}\.tmp$/);
 
     // Contract proof: a straggler left at that path is reaped by the
     // restorer's sweep for the same target.

--- a/showcase/scripts/__tests__/generate-registry-pattern.test.ts
+++ b/showcase/scripts/__tests__/generate-registry-pattern.test.ts
@@ -1,80 +1,378 @@
-// SHOWCASE_BACKEND_HOST_PATTERN contract tests for generate-registry.ts,
-// run as a subprocess (the script executes main() at module load, so it
-// cannot be imported). Two invariants:
+// SHOWCASE_BACKEND_HOST_PATTERN + error-contract tests for
+// generate-registry.ts, run as a subprocess (the script executes main()
+// when invoked directly, so its CLI contract — stderr + exit codes — is
+// only observable subprocess-wise).
 //
-// 1. A pattern without the `{slug}` placeholder must FAIL the build
-//    loudly (stderr + non-zero exit — the contract vitest.global-setup
-//    and CI consume), not silently bake the same backend host into
-//    every integration.
-// 2. Every `{slug}` occurrence is substituted (replaceAll parity with
-//    the runtime consumer backendUrlFromPattern in
-//    shell/src/lib/backend-url.ts), not just the first.
+// ISOLATION (SU7-F3): every test runs the generator against a throwaway
+// tmpdir copy of the showcase tree (scripts + shared + a controlled set
+// of integrations), with ALL generator outputs landing inside that
+// tmpdir. A previous revision of this suite snapshot/restored the SAME
+// working-tree data files that generate-registry.test.ts snapshots,
+// violating test-cleanup.ts's documented disjointness contract under
+// `fileParallelism: true` — and it captured its baseline WITHOUT a
+// healing default generator run, so a crashed override run could poison
+// the snapshot for every later run. The per-suite tmpdir eliminates the
+// whole shared-mutable-file class structurally: no snapshot, no restore,
+// and no working-tree writes at all. This was chosen over merging into
+// generate-registry.test.ts (the one-restorer option) because override
+// runs here exercise FAILURE paths — keeping those away from the real
+// tree entirely is strictly safer than healing the real tree afterwards.
 
-import { describe, it, expect, beforeAll, afterEach, afterAll } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import fs from "fs";
+import os from "os";
 import path from "path";
+import { createRequire } from "module";
 import { execFileSync } from "child_process";
-import { FileSnapshotRestorer, execOptsFor } from "./test-cleanup";
-import { SCRIPTS_DIR, SHELL_DATA_DIR } from "./paths";
+import { FileSnapshotRestorer, SAFE_EXEC_OPTS } from "./test-cleanup";
+import { SCRIPTS_DIR } from "./paths";
 
 const SHOWCASE_ROOT = path.resolve(SCRIPTS_DIR, "..");
-// Everything the generator writes — multi-emit registry/catalog plus the
-// shell-only constraints.json — so a pattern-override run can't leave
-// non-default artifacts behind for other suites or the dev server.
-const DATA_FILES = [
-  path.join(SHELL_DATA_DIR, "registry.json"),
-  path.join(SHELL_DATA_DIR, "catalog.json"),
-  path.join(SHELL_DATA_DIR, "constraints.json"),
-  ...["shell-docs", "shell-dojo", "shell-dashboard"].flatMap((pkg) => [
-    path.join(SHOWCASE_ROOT, pkg, "src", "data", "registry.json"),
-    path.join(SHOWCASE_ROOT, pkg, "src", "data", "catalog.json"),
-  ]),
-];
-const dataRestorer = new FileSnapshotRestorer(DATA_FILES);
-const EXEC_OPTS = execOptsFor(SCRIPTS_DIR);
+const REFERENCE_SLUG = "langgraph-python";
+const NON_REFERENCE_SLUG = "mastra";
 
-function runGenerator(pattern: string): string {
-  return execFileSync("npx", ["tsx", "generate-registry.ts"], {
-    ...EXEC_OPTS,
-    env: { ...process.env, SHOWCASE_BACKEND_HOST_PATTERN: pattern },
+// Resolve the locally-installed tsx CLI from the real scripts dir and
+// spawn it via process.execPath — NOT `npx tsx`: npx without -y can
+// prompt-hang when the package isn't cached, and the tmpdir cwd must not
+// influence which tsx runs (same hardening as shell/vitest.global-setup.ts).
+const TSX_CLI = createRequire(path.join(SCRIPTS_DIR, "package.json")).resolve(
+  "tsx/cli",
+);
+
+interface Harness {
+  root: string;
+  scriptsDir: string;
+  /** Absolute path to a generator output/input file under the tmp root. */
+  file: (...rel: string[]) => string;
+}
+
+// Track harness roots and reap them after each test — a failed test must
+// not leak tmpdirs across runs.
+const harnessRoots: string[] = [];
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const root of harnessRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+/**
+ * Build a minimal throwaway showcase tree the generator can run against:
+ *
+ *   <root>/scripts/{generate-registry.ts, validate-constraints.ts,
+ *                   package.json, node_modules -> real node_modules}
+ *   <root>/shared/{manifest.schema.json, feature-registry.json[,
+ *                  constraints.yaml]}
+ *   <root>/integrations/<slug>/manifest.yaml   (copied real manifests)
+ *
+ * The generator resolves every path relative to its own location, so all
+ * reads AND writes stay inside the tmpdir.
+ */
+function makeHarness(
+  opts: { integrations?: string[]; constraints?: boolean } = {},
+): Harness {
+  const {
+    integrations = [REFERENCE_SLUG, NON_REFERENCE_SLUG],
+    constraints = true,
+  } = opts;
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), "generate-registry-harness-"),
+  );
+  harnessRoots.push(root);
+
+  const scriptsDir = path.join(root, "scripts");
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  for (const f of [
+    "generate-registry.ts",
+    "validate-constraints.ts",
+    "package.json",
+  ]) {
+    fs.copyFileSync(path.join(SCRIPTS_DIR, f), path.join(scriptsDir, f));
+  }
+  // Bare-specifier resolution (yaml, ajv, ajv-formats) for the copied
+  // script — symlink the real node_modules instead of installing.
+  fs.symlinkSync(
+    path.join(SCRIPTS_DIR, "node_modules"),
+    path.join(scriptsDir, "node_modules"),
+    "dir",
+  );
+
+  const sharedDir = path.join(root, "shared");
+  fs.mkdirSync(sharedDir, { recursive: true });
+  const sharedFiles = ["manifest.schema.json", "feature-registry.json"];
+  if (constraints) sharedFiles.push("constraints.yaml");
+  for (const f of sharedFiles) {
+    fs.copyFileSync(
+      path.join(SHOWCASE_ROOT, "shared", f),
+      path.join(sharedDir, f),
+    );
+  }
+
+  fs.mkdirSync(path.join(root, "integrations"), { recursive: true });
+  for (const slug of integrations) {
+    const dir = path.join(root, "integrations", slug);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.copyFileSync(
+      path.join(SHOWCASE_ROOT, "integrations", slug, "manifest.yaml"),
+      path.join(dir, "manifest.yaml"),
+    );
+  }
+
+  return { root, scriptsDir, file: (...rel) => path.join(root, ...rel) };
+}
+
+/**
+ * Run the harness's generator copy. `env` entries override the inherited
+ * environment; an explicit `undefined` deletes the variable. Ambient
+ * pattern vars are always stripped first so a developer shell exporting
+ * SHOWCASE_BACKEND_HOST_PATTERN can't skew default/fallback tests.
+ */
+function runGenerator(
+  harness: Harness,
+  env: Record<string, string | undefined> = {},
+): string {
+  const childEnv: NodeJS.ProcessEnv = { ...process.env };
+  delete childEnv.SHOWCASE_BACKEND_HOST_PATTERN;
+  delete childEnv.NEXT_PUBLIC_SHOWCASE_BACKEND_HOST_PATTERN;
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete childEnv[k];
+    else childEnv[k] = v;
+  }
+  return execFileSync(process.execPath, [TSX_CLI, "generate-registry.ts"], {
+    ...SAFE_EXEC_OPTS,
+    cwd: harness.scriptsDir,
+    env: childEnv,
   }).toString();
 }
 
-beforeAll(() => {
-  dataRestorer.snapshot();
+type ExecError = Error & { status?: number | null; stderr?: string };
+
+/** Run and expect a non-zero exit; returns the error for stderr asserts. */
+function runGeneratorExpectingFailure(
+  harness: Harness,
+  env: Record<string, string | undefined> = {},
+): ExecError {
+  let thrown: unknown;
+  try {
+    runGenerator(harness, env);
+  } catch (err) {
+    thrown = err;
+  }
+  expect(thrown, "expected the generator to exit non-zero").toBeInstanceOf(
+    Error,
+  );
+  return thrown as ExecError;
+}
+
+function readJson(harness: Harness, ...rel: string[]): any {
+  return JSON.parse(fs.readFileSync(harness.file(...rel), "utf-8"));
+}
+
+function readRegistry(harness: Harness): {
+  integrations: Array<{ slug: string; backend_url: string }>;
+} {
+  return readJson(harness, "shell", "src", "data", "registry.json");
+}
+
+const DEFAULT_BACKEND_HOST_PATTERN =
+  "showcase-{slug}-production.up.railway.app";
+
+describe("generate-registry reference-integration error contract (SU7-F3 #1)", () => {
+  it("supports the zero-manifests path: emits an empty registry AND an empty catalog, exit 0", () => {
+    // main() explicitly logs "No integration packages found. Generating
+    // empty registry." — generateCatalog used to crash right after on a
+    // non-null assertion for the (absent) reference integration,
+    // breaking the supported empty path with a TypeError.
+    const harness = makeHarness({ integrations: [] });
+    const stdout = runGenerator(harness);
+    expect(stdout).toContain("No integration packages found");
+    const registry = readRegistry(harness);
+    expect(registry.integrations).toEqual([]);
+    const catalog = readJson(harness, "shell", "src", "data", "catalog.json");
+    expect(catalog.cells).toEqual([]);
+    expect(catalog.metadata.total_cells).toBe(0);
+    expect(catalog.metadata.wired).toBe(0);
+  });
+
+  it(`fails loudly (stderr + exit 1) when integrations exist but the reference (${REFERENCE_SLUG}) is missing`, () => {
+    // Parity tiers are computed against the reference integration — with
+    // integrations present but the reference absent, the generator must
+    // fail per its error contract (labeled stderr + exit 1), not crash
+    // with a raw TypeError stack.
+    const harness = makeHarness({ integrations: [NON_REFERENCE_SLUG] });
+    const e = runGeneratorExpectingFailure(harness);
+    expect(e.status).toBe(1);
+    expect(e.stderr).toContain(REFERENCE_SLUG);
+    expect(e.stderr).toContain("reference");
+    expect(e.stderr).not.toContain("TypeError");
+  });
 });
 
-afterEach(() => dataRestorer.restore());
-afterAll(() => dataRestorer.restore());
+describe("generate-registry manifest-parse error contract (SU7-F3 #3)", () => {
+  it("treats an empty manifest.yaml (yaml.parse -> null) as a validation error, not a TypeError", () => {
+    const harness = makeHarness();
+    const brokenDir = harness.file("integrations", "broken-empty");
+    fs.mkdirSync(brokenDir, { recursive: true });
+    fs.writeFileSync(path.join(brokenDir, "manifest.yaml"), "");
+    const e = runGeneratorExpectingFailure(harness);
+    expect(e.status).toBe(1);
+    expect(e.stderr).toContain("manifest.yaml");
+    expect(e.stderr).toContain("YAML mapping");
+    expect(e.stderr).not.toContain("TypeError");
+  });
+
+  it("treats a scalar manifest.yaml as a validation error too", () => {
+    const harness = makeHarness();
+    const brokenDir = harness.file("integrations", "broken-scalar");
+    fs.mkdirSync(brokenDir, { recursive: true });
+    fs.writeFileSync(path.join(brokenDir, "manifest.yaml"), "just-a-string\n");
+    const e = runGeneratorExpectingFailure(harness);
+    expect(e.status).toBe(1);
+    expect(e.stderr).toContain("YAML mapping");
+    expect(e.stderr).not.toContain("TypeError");
+  });
+});
+
+describe("writeFileAtomicSync tmp naming matches the straggler-sweep convention (SU7-F3 #5)", () => {
+  it("names tmp siblings `.<basename>.<16hex>.tmp` so a SIGTERM-killed generator's stragglers get swept", async () => {
+    // Importing the generator module must NOT run main() — the script
+    // guards the call on direct invocation. Stub the pattern vars
+    // before the import anyway so a degenerate ambient value can't trip
+    // the module-load {slug} check (which would process.exit the vitest
+    // worker).
+    vi.stubEnv("SHOWCASE_BACKEND_HOST_PATTERN", "");
+    vi.stubEnv("NEXT_PUBLIC_SHOWCASE_BACKEND_HOST_PATTERN", "");
+    const { atomicTmpPath } = await import("../generate-registry");
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "atomic-tmp-naming-"));
+    harnessRoots.push(dir);
+    const target = path.join(dir, "registry.json");
+    fs.writeFileSync(target, "{}\n");
+
+    const tmp = atomicTmpPath(target);
+    // Same-directory sibling — rename(2) must stay on one filesystem.
+    expect(path.dirname(tmp)).toBe(dir);
+    // Named EXACTLY like FileSnapshotRestorer's snapshot-time sweep
+    // expects (`^\.<basename>\.[0-9a-f]{16}\.tmp$`). The previous
+    // `<target>.<pid>.tmp` shape was invisible to that sweep, so a
+    // SIGTERM-killed generator (the one crash mode its try/finally
+    // cannot clean up) accumulated un-swept stragglers forever.
+    expect(path.basename(tmp)).toMatch(
+      /^\.registry\.json\.[0-9a-f]{16}\.tmp$/,
+    );
+
+    // Contract proof: a straggler left at that path is reaped by the
+    // restorer's sweep for the same target.
+    fs.writeFileSync(tmp, "partial write from a killed generator");
+    const restorer = new FileSnapshotRestorer([target]);
+    restorer.snapshot();
+    expect(fs.existsSync(tmp)).toBe(false);
+    expect(fs.existsSync(target)).toBe(true);
+  });
+});
+
+describe("generate-registry constraints-read error contract (SU7-F3 #4)", () => {
+  it("fails with a labeled stderr message + exit 1 when constraints.yaml is missing, not a raw ENOENT stack", () => {
+    const harness = makeHarness({ constraints: false });
+    const e = runGeneratorExpectingFailure(harness);
+    expect(e.status).toBe(1);
+    expect(e.stderr).toContain("ERROR");
+    expect(e.stderr).toContain("constraints.yaml");
+    // The labeled contract, not an unhandled-exception stack trace.
+    expect(e.stderr).not.toContain("Object.readFileSync");
+  });
+});
 
 describe("generate-registry SHOWCASE_BACKEND_HOST_PATTERN contract", () => {
   it("fails loudly (stderr + exit 1) when the pattern lacks the {slug} placeholder", () => {
-    let thrown: unknown;
-    try {
-      runGenerator("no-placeholder.example.com");
-    } catch (err) {
-      thrown = err;
-    }
+    const harness = makeHarness();
+    const e = runGeneratorExpectingFailure(harness, {
+      SHOWCASE_BACKEND_HOST_PATTERN: "no-placeholder.example.com",
+    });
     expect(
-      thrown,
+      e.status,
       "a {slug}-less pattern must fail the build, not bake one host everywhere",
-    ).toBeInstanceOf(Error);
-    const e = thrown as Error & { status?: number; stderr?: string };
-    expect(e.status).toBe(1);
+    ).toBe(1);
     expect(e.stderr).toContain("SHOWCASE_BACKEND_HOST_PATTERN");
     expect(e.stderr).toContain("{slug}");
   });
 
   it("substitutes EVERY {slug} occurrence into backend_url (replaceAll parity with backend-url.ts)", () => {
-    runGenerator("{slug}.demos.example.com/{slug}");
-    const registry = JSON.parse(
-      fs.readFileSync(path.join(SHELL_DATA_DIR, "registry.json"), "utf-8"),
-    ) as { integrations: Array<{ slug: string; backend_url: string }> };
+    const harness = makeHarness();
+    runGenerator(harness, {
+      SHOWCASE_BACKEND_HOST_PATTERN: "{slug}.demos.example.com/{slug}",
+    });
+    const registry = readRegistry(harness);
     expect(registry.integrations.length).toBeGreaterThan(0);
     for (const { slug, backend_url } of registry.integrations) {
       expect(backend_url, `backend_url for "${slug}"`).toBe(
         `https://${slug}.demos.example.com/${slug}`,
       );
     }
+  });
+
+  // Build-time normalization parity with the runtime consumer
+  // (normalizeBackendHostPattern in shell/src/lib/backend-url.ts,
+  // SU7-F3): registry.json's baked backend_url values are consumed by
+  // shells with NO runtime re-derivation, so a misconfigured env var at
+  // build time must normalize the same way it would at request time —
+  // not ship corrupted URLs.
+  function expectAllBackendUrls(
+    harness: Harness,
+    hostForSlug: (slug: string) => string,
+  ): void {
+    const registry = readRegistry(harness);
+    expect(registry.integrations.length).toBeGreaterThan(0);
+    for (const { slug, backend_url } of registry.integrations) {
+      expect(backend_url, `backend_url for "${slug}"`).toBe(
+        `https://${hostForSlug(slug)}`,
+      );
+    }
+  }
+
+  it("strips a scheme-bearing pattern instead of baking https://https://… into the registry", () => {
+    const harness = makeHarness();
+    runGenerator(harness, {
+      SHOWCASE_BACKEND_HOST_PATTERN: "https://{slug}.demos.example.com",
+    });
+    expectAllBackendUrls(harness, (slug) => `${slug}.demos.example.com`);
+  });
+
+  it("strips a trailing slash so route concatenation can't yield '//'", () => {
+    const harness = makeHarness();
+    runGenerator(harness, {
+      SHOWCASE_BACKEND_HOST_PATTERN: "{slug}.demos.example.com/",
+    });
+    expectAllBackendUrls(harness, (slug) => `${slug}.demos.example.com`);
+  });
+
+  it("falls back to NEXT_PUBLIC_SHOWCASE_BACKEND_HOST_PATTERN when the primary var is unset (readEnvPair parity)", () => {
+    const harness = makeHarness();
+    runGenerator(harness, {
+      SHOWCASE_BACKEND_HOST_PATTERN: undefined,
+      NEXT_PUBLIC_SHOWCASE_BACKEND_HOST_PATTERN: "{slug}.alt.example.com",
+    });
+    expectAllBackendUrls(harness, (slug) => `${slug}.alt.example.com`);
+  });
+
+  it("treats an empty-string primary as unset and falls through to the alternate (readEnvPair parity)", () => {
+    const harness = makeHarness();
+    runGenerator(harness, {
+      SHOWCASE_BACKEND_HOST_PATTERN: "",
+      NEXT_PUBLIC_SHOWCASE_BACKEND_HOST_PATTERN: "{slug}.alt.example.com",
+    });
+    expectAllBackendUrls(harness, (slug) => `${slug}.alt.example.com`);
+  });
+
+  it("falls back to the DEFAULT pattern for a degenerate value that cannot form a URL", () => {
+    const harness = makeHarness();
+    // "https://" normalizes to "" after the scheme strip — unusable, so
+    // the generator must fall back to the default pattern (like the
+    // runtime does) instead of baking "https://https://" into every
+    // backend_url.
+    runGenerator(harness, { SHOWCASE_BACKEND_HOST_PATTERN: "https://" });
+    expectAllBackendUrls(harness, (slug) =>
+      DEFAULT_BACKEND_HOST_PATTERN.replaceAll("{slug}", slug),
+    );
   });
 });

--- a/showcase/scripts/__tests__/generate-registry.test.ts
+++ b/showcase/scripts/__tests__/generate-registry.test.ts
@@ -5,14 +5,26 @@ import { execFileSync } from "child_process";
 import { FileSnapshotRestorer, execOptsFor } from "./test-cleanup";
 import { SCRIPTS_DIR, SHELL_DATA_DIR } from "./paths";
 
-// `generate-registry.ts` writes to showcase/shell/src/data/registry.json AND
-// showcase/shell/src/data/constraints.json. Without this, every test run
-// leaks regenerated JSON into the working tree. Snapshot in beforeAll;
-// restore after each test and at the end of the suite. Assumes vitest's
-// `fileParallelism: false` config.
+// `generate-registry.ts` multi-emits registry.json + catalog.json into
+// EVERY shell's src/data plus the shell-only constraints.json. Without
+// this, every test run leaks regenerated JSON into the working tree —
+// catalog.json drifts on every run (its metadata carries a generated_at
+// timestamp), so the full write set must be snapshotted, not just the
+// shell registry/constraints pair. Snapshot in beforeAll; restore after
+// each test and at the end of the suite. This suite is the ONLY one that
+// snapshots these paths — test-cleanup.ts's disjointness contract under
+// the `fileParallelism: true` config requires suites' snapshot targets
+// never overlap (the pattern suite runs against a per-suite tmpdir
+// harness instead — see generate-registry-pattern.test.ts, SU7-F3).
+const SHOWCASE_ROOT = path.resolve(SCRIPTS_DIR, "..");
 const DATA_FILES = [
   path.join(SHELL_DATA_DIR, "registry.json"),
+  path.join(SHELL_DATA_DIR, "catalog.json"),
   path.join(SHELL_DATA_DIR, "constraints.json"),
+  ...["shell-docs", "shell-dojo", "shell-dashboard"].flatMap((pkg) => [
+    path.join(SHOWCASE_ROOT, pkg, "src", "data", "registry.json"),
+    path.join(SHOWCASE_ROOT, pkg, "src", "data", "catalog.json"),
+  ]),
 ];
 const dataRestorer = new FileSnapshotRestorer(DATA_FILES);
 
@@ -29,13 +41,21 @@ function runGenerator(): string {
 
 beforeAll(() => {
   // Generate the data files (they're gitignored, so they may not exist).
+  // Running the DEFAULT generator before snapshotting also heals any
+  // drift a previously crashed run left behind — the baseline is always
+  // fresh default output, never leaked override artifacts (SU7-F3).
   runGenerator();
   dataRestorer.snapshot();
-  if (dataRestorer.snapshotMap.size === 0) {
+  // Every file in the write set must have been captured — a missing
+  // entry means the generator's outputs and DATA_FILES have drifted
+  // apart, and the un-snapshotted file would leak mutations into the
+  // working tree with no restore (SU7-F3).
+  const missing = DATA_FILES.filter((p) => !dataRestorer.snapshotMap.has(p));
+  if (missing.length > 0) {
     throw new Error(
-      `generate-registry.test.ts: data snapshot is empty. Expected generated` +
-        ` files at:\n` +
-        DATA_FILES.map((p) => `  ${p}`).join("\n"),
+      `generate-registry.test.ts: snapshot is missing generated files —` +
+        ` DATA_FILES has drifted from the generator's write set:\n` +
+        missing.map((p) => `  ${p}`).join("\n"),
     );
   }
 });

--- a/showcase/scripts/__tests__/test-cleanup.ts
+++ b/showcase/scripts/__tests__/test-cleanup.ts
@@ -391,8 +391,10 @@ function restoreFromGitHeadLocked(
     // Belt-and-braces: handles a race where a tracked file is removed
     // between partitionTrackedPaths and this checkout (e.g. a parallel
     // rm from another harness touching the same tree). Realistically
-    // unreachable in this suite — we run with fileParallelism: false and
-    // no concurrent harness — but cheap to tolerate. Git produces this as
+    // unreachable in this suite — suites run under fileParallelism:
+    // true, but their snapshot targets are disjoint (see the
+    // PARALLELISM note above) and no concurrent harness removes
+    // tracked files — but cheap to tolerate. Git produces this as
     // `error: pathspec '…' did not match any file(s) known to git`
     // (exit 1). Anything else — EACCES, git missing, corrupt worktree —
     // bubbles up so the suite fails loudly instead of seeding a drifted

--- a/showcase/scripts/generate-registry.ts
+++ b/showcase/scripts/generate-registry.ts
@@ -25,21 +25,62 @@ const FEATURE_REGISTRY_PATH = path.join(
   "feature-registry.json",
 );
 
-// Backend host pattern — used to synthesize `backend_url` for any manifest
-// that omits it. `{slug}` is the only placeholder. Default reproduces the
-// Railway hostname convention every existing manifest already uses, so this
-// PR is a no-op for the current dataset (manifest value wins in dual-read).
-//
-// Future PRs will (a) drop `backend_url` from manifests so this synthesis
-// becomes the source of truth, and (b) let CI/tests point a single deployed
-// image at a different env by overriding this var.
+// Backend host pattern — used to synthesize `backend_url` for every
+// manifest. `{slug}` is the only placeholder. Manifests no longer ship
+// `backend_url` (PR2 stripped them all), so this synthesis IS the source
+// of truth; a manifest-supplied value is still honored in the dual-read
+// below for safety/backporting. The default reproduces the Railway
+// hostname convention, and CI/tests can point a single deployed image at
+// a different env by overriding this var — same env var and semantics as
+// the runtime consumer (shell/src/lib/backend-url.ts).
 const DEFAULT_BACKEND_HOST_PATTERN =
   "showcase-{slug}-production.up.railway.app";
 const BACKEND_HOST_PATTERN =
   process.env.SHOWCASE_BACKEND_HOST_PATTERN || DEFAULT_BACKEND_HOST_PATTERN;
 
+// {slug} placeholder validation — build-time fail-loud: a pattern without
+// the placeholder bakes the SAME backend host into every integration's
+// backend_url, silently. At runtime that is only an advisory warn (the
+// request must still be served — see normalizeBackendHostPattern in
+// shell/src/lib/backend-url.ts); here refusing is cheap and correct.
+// stderr + process.exit(1) (not a bare throw) is the error contract this
+// script's consumers rely on: vitest.global-setup.ts and CI run it with
+// stdout ignored and stderr inherited, so a failure must surface as a
+// non-zero exit with the reason on stderr.
+if (!BACKEND_HOST_PATTERN.includes("{slug}")) {
+  console.error(
+    `ERROR: SHOWCASE_BACKEND_HOST_PATTERN ` +
+      `${JSON.stringify(BACKEND_HOST_PATTERN)} lacks the {slug} ` +
+      `placeholder — every integration would resolve to the same backend ` +
+      `host. Fix the env var (default: ${DEFAULT_BACKEND_HOST_PATTERN}).`,
+  );
+  process.exit(1);
+}
+
 function synthesizeBackendUrl(slug: string): string {
-  return `https://${BACKEND_HOST_PATTERN.replace("{slug}", slug)}`;
+  // replaceAll + function replacer — parity with the runtime consumer
+  // (backendUrlFromPattern in shell/src/lib/backend-url.ts): replace()
+  // substitutes only the FIRST {slug} occurrence, and a plain string
+  // replacement is subject to `$` substitution patterns ("$&", "$'", …).
+  return `https://${BACKEND_HOST_PATTERN.replaceAll("{slug}", () => slug)}`;
+}
+
+// Atomic write (SU4-A7): write to a temp sibling, then rename(2) into
+// place. A concurrent reader (a vitest worker importing registry.json,
+// a dev-server build) racing a bare writeFileSync could observe a
+// half-written file — rename within the same directory is atomic on
+// POSIX, so readers see either the old complete file or the new one.
+// try/finally unlink (SU5-A5): a crash between write and rename used to
+// litter the data dir with orphaned .tmp files. After a successful
+// rename the tmp path no longer exists — rmSync(force:true) is a no-op.
+function writeFileAtomicSync(filePath: string, contents: string): void {
+  const tmpPath = `${filePath}.${process.pid}.tmp`;
+  try {
+    fs.writeFileSync(tmpPath, contents);
+    fs.renameSync(tmpPath, filePath);
+  } finally {
+    fs.rmSync(tmpPath, { force: true });
+  }
 }
 // Registry is consumed by ALL shells:
 //   - shell: home grid, integrations catalog, matrix, middleware
@@ -647,29 +688,35 @@ function main() {
     packages,
   };
 
+  // Compute and serialize ALL outputs BEFORE the first file write
+  // (SU5-A5): catalog generation used to run AFTER the registry and
+  // constraints files were already on disk, so a generateCatalog throw
+  // left a partial multi-file emit (fresh registry.json, stale or
+  // missing catalog.json). All-or-nothing: any failure below this
+  // comment exits before a single byte is written.
   const registryJson = JSON.stringify(registry, null, 2) + "\n";
+  const constraintsJson = JSON.stringify(constraints, null, 2) + "\n";
+
+  // --- Catalog generation (D0-D4 dashboard matrix) ---
+  const catalog = generateCatalog(featureRegistry, integrations);
+  const catalogJson = JSON.stringify(catalog, null, 2) + "\n";
+
   for (const dir of OUTPUT_DIRS) {
     fs.mkdirSync(dir, { recursive: true });
     const outputPath = path.join(dir, "registry.json");
-    fs.writeFileSync(outputPath, registryJson);
+    writeFileAtomicSync(outputPath, registryJson);
     console.log(
       `\nRegistry generated: ${outputPath} (${integrations.length} integrations)`,
     );
   }
 
   // Write constraints.json for the shell's client-side filtering
-  fs.writeFileSync(
-    CONSTRAINTS_OUTPUT_PATH,
-    JSON.stringify(constraints, null, 2) + "\n",
-  );
+  writeFileAtomicSync(CONSTRAINTS_OUTPUT_PATH, constraintsJson);
   console.log(`Constraints written: ${CONSTRAINTS_OUTPUT_PATH}`);
 
-  // --- Catalog generation (D0-D4 dashboard matrix) ---
-  const catalog = generateCatalog(featureRegistry, integrations);
-  const catalogJson = JSON.stringify(catalog, null, 2) + "\n";
   for (const dir of OUTPUT_DIRS) {
     const catalogPath = path.join(dir, "catalog.json");
-    fs.writeFileSync(catalogPath, catalogJson);
+    writeFileAtomicSync(catalogPath, catalogJson);
     console.log(
       `Catalog generated: ${catalogPath} (${catalog.metadata.total_cells} cells)`,
     );

--- a/showcase/scripts/generate-registry.ts
+++ b/showcase/scripts/generate-registry.ts
@@ -934,9 +934,7 @@ function isDirectRun(): boolean {
   const entry = process.argv[1];
   if (!entry) return false;
   try {
-    return (
-      fs.realpathSync(path.resolve(entry)) === fs.realpathSync(__filename)
-    );
+    return fs.realpathSync(path.resolve(entry)) === fs.realpathSync(__filename);
   } catch {
     return false;
   }

--- a/showcase/scripts/generate-registry.ts
+++ b/showcase/scripts/generate-registry.ts
@@ -5,6 +5,7 @@
 //
 // Usage: npx tsx showcase/scripts/generate-registry.ts
 
+import crypto from "crypto";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -35,8 +36,114 @@ const FEATURE_REGISTRY_PATH = path.join(
 // the runtime consumer (shell/src/lib/backend-url.ts).
 const DEFAULT_BACKEND_HOST_PATTERN =
   "showcase-{slug}-production.up.railway.app";
-const BACKEND_HOST_PATTERN =
-  process.env.SHOWCASE_BACKEND_HOST_PATTERN || DEFAULT_BACKEND_HOST_PATTERN;
+
+// Env resolution parity with the runtime consumer (readEnvPair in
+// shell/src/lib/runtime-config.ts): values are trimmed, an empty or
+// whitespace-only primary counts as unset, and the NEXT_PUBLIC_-prefixed
+// alternate is honored before the default (SU7-F3).
+function readBackendHostPatternEnv(): string | undefined {
+  for (const key of [
+    "SHOWCASE_BACKEND_HOST_PATTERN",
+    "NEXT_PUBLIC_SHOWCASE_BACKEND_HOST_PATTERN",
+  ]) {
+    const value = process.env[key]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+// Matches an explicit URL scheme prefix — local copy of SCHEME_RE from
+// shell/src/lib/backend-url.ts (scripts cannot import shell src).
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+/**
+ * Can the normalized pattern actually form a backend URL? Probe by
+ * substituting a registry-shaped slug and parsing the consumer's exact
+ * composition (`https://` + pattern) — same gate as the runtime's
+ * isUsablePattern/patternForbiddenComponent pair: empty results,
+ * internal whitespace, anything `new URL` rejects, and forbidden
+ * components (userinfo/query/fragment) all fail.
+ */
+function isUsableBackendHostPattern(normalized: string): boolean {
+  if (normalized.length === 0) return false;
+  try {
+    const probe = new URL(
+      `https://${normalized.replaceAll("{slug}", "probe")}`,
+    );
+    return (
+      probe.hostname.length > 0 &&
+      !/^https?$/i.test(probe.hostname) &&
+      probe.username === "" &&
+      probe.password === "" &&
+      probe.search === "" &&
+      probe.hash === ""
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build-time equivalent of normalizeBackendHostPattern in
+ * shell/src/lib/backend-url.ts (scripts cannot import shell src — keep
+ * the two in sync; they consume the same env var). Without this, the
+ * "same semantics" claim above was false in exactly the misconfig cases
+ * the runtime normalizes (SU7-F3): a scheme-bearing value baked
+ * `https://https://…` into registry.json — which shells consume with NO
+ * runtime re-derivation — a trailing slash shipped `host//route`
+ * concatenations, and a degenerate value shipped unusable URLs instead
+ * of falling back to the default. Warnings go to stderr (console.warn);
+ * the {slug} check below stays the build-time fail-loud exception.
+ */
+function normalizeBackendHostPattern(raw: string): string {
+  let normalized = raw.trim();
+  if (normalized !== raw) {
+    console.warn(
+      `WARN: SHOWCASE_BACKEND_HOST_PATTERN ${JSON.stringify(raw)} contains ` +
+        `surrounding whitespace — trimming.`,
+    );
+  }
+  // Loop the scheme strip to convergence (parity with the runtime): a
+  // single pass would leave "https://https://host" scheme-bearing.
+  const strippedSchemes: string[] = [];
+  for (
+    let scheme = SCHEME_RE.exec(normalized);
+    scheme;
+    scheme = SCHEME_RE.exec(normalized)
+  ) {
+    strippedSchemes.push(scheme[0]);
+    normalized = normalized.slice(scheme[0].length);
+  }
+  if (strippedSchemes.length > 0) {
+    console.warn(
+      `WARN: SHOWCASE_BACKEND_HOST_PATTERN ${JSON.stringify(raw)} includes ` +
+        `a scheme — the generator prepends https://; stripping ` +
+        strippedSchemes.map((s) => JSON.stringify(s)).join(", ") +
+        `.`,
+    );
+  }
+  if (/\/+$/.test(normalized)) {
+    console.warn(
+      `WARN: SHOWCASE_BACKEND_HOST_PATTERN ${JSON.stringify(raw)} has a ` +
+        `trailing slash — route concatenation would yield "//"; trimming.`,
+    );
+    normalized = normalized.replace(/\/+$/, "");
+  }
+  if (!isUsableBackendHostPattern(normalized)) {
+    console.warn(
+      `WARN: SHOWCASE_BACKEND_HOST_PATTERN ${JSON.stringify(raw)} ` +
+        `normalizes to ${JSON.stringify(normalized)}, which cannot form a ` +
+        `usable backend URL — falling back to the default pattern ` +
+        `${DEFAULT_BACKEND_HOST_PATTERN}.`,
+    );
+    return DEFAULT_BACKEND_HOST_PATTERN;
+  }
+  return normalized;
+}
+
+const BACKEND_HOST_PATTERN = normalizeBackendHostPattern(
+  readBackendHostPatternEnv() ?? DEFAULT_BACKEND_HOST_PATTERN,
+);
 
 // {slug} placeholder validation — build-time fail-loud: a pattern without
 // the placeholder bakes the SAME backend host into every integration's
@@ -73,8 +180,26 @@ function synthesizeBackendUrl(slug: string): string {
 // try/finally unlink (SU5-A5): a crash between write and rename used to
 // litter the data dir with orphaned .tmp files. After a successful
 // rename the tmp path no longer exists — rmSync(force:true) is a no-op.
+/**
+ * Temp-sibling path for atomic writes (exported for tests, SU7-F3).
+ * `.<basename>.<16hex>.tmp` in the target's own directory — the EXACT
+ * shape FileSnapshotRestorer's snapshot-time straggler sweep matches
+ * (`^\.<basename>\.[0-9a-f]{16}\.tmp$` in __tests__/test-cleanup.ts).
+ * The previous `<target>.<pid>.tmp` naming was invisible to that sweep,
+ * so a SIGTERM-killed generator (the one crash mode the try/finally
+ * below cannot clean up) accumulated un-swept stragglers in tracked
+ * data directories.
+ */
+export function atomicTmpPath(filePath: string): string {
+  const suffix = crypto.randomBytes(8).toString("hex");
+  return path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${suffix}.tmp`,
+  );
+}
+
 function writeFileAtomicSync(filePath: string, contents: string): void {
-  const tmpPath = `${filePath}.${process.pid}.tmp`;
+  const tmpPath = atomicTmpPath(filePath);
   try {
     fs.writeFileSync(tmpPath, contents);
     fs.renameSync(tmpPath, filePath);
@@ -294,7 +419,8 @@ interface Catalog {
  *   takes precedence over the wired/stub/unshipped fallthrough.
  * - wired: manifest declares the feature AND has a demo with a route for it
  * - stub: manifest declares the feature AND has a demo, but no route
- * - unshipped: feature is not in the manifest at all
+ * - unshipped: feature is not in the manifest at all, OR is declared in
+ *   `features` without any matching demo entry
  */
 function determineCellStatus(
   featureId: string,
@@ -327,8 +453,10 @@ function determineCellStatus(
 }
 
 /**
- * Generate the full 663-cell catalog by cross-joining features x integrations,
- * plus 17 starter cells. Parity tiers are auto-derived from manifest data.
+ * Generate the full catalog by cross-joining features x integrations
+ * (features.length × integrations.length integrated cells), plus one
+ * starter cell per integration that declares a `starter` block. Parity
+ * tiers are auto-derived from manifest data.
  */
 function generateCatalog(
   featureRegistry: {
@@ -437,8 +565,43 @@ function generateCatalog(
   // Step 2: Reference integration — always langgraph-python.
   const referenceSlug = "langgraph-python";
 
-  const referenceWiredFeatures =
-    wiredFeaturesPerIntegration.get(referenceSlug)!;
+  const referenceWiredFeatures = wiredFeaturesPerIntegration.get(referenceSlug);
+  if (referenceWiredFeatures === undefined) {
+    if (integrations.length === 0) {
+      // The zero-manifests "empty registry" path is supported — main()
+      // logs "No integration packages found." and continues — so the
+      // catalog must short-circuit cleanly instead of crashing on the
+      // absent reference (SU7-F3).
+      console.log("\nCatalog: no integrations — emitting an empty catalog.");
+      return {
+        metadata: {
+          reference: referenceSlug,
+          total_cells: 0,
+          wired: 0,
+          stub: 0,
+          unshipped: 0,
+          unsupported: 0,
+          docs_only: 0,
+          generated_at: new Date().toISOString(),
+        },
+        cells: [],
+      };
+    }
+    // Integrations exist but the reference is absent: every parity tier
+    // is computed against it, so the catalog is meaningless. Fail per
+    // the script's error contract — labeled stderr + exit 1, the same
+    // contract as the {slug} check at the top of this file (consumers
+    // run with stdout ignored and stderr inherited).
+    console.error(
+      `ERROR: reference integration "${referenceSlug}" is missing from the ` +
+        `validated integrations (${integrations
+          .map((i) => i.slug)
+          .join(", ")}) — parity tiers cannot be computed. Restore ` +
+        `integrations/${referenceSlug}/manifest.yaml (or fix its ` +
+        `validation errors).`,
+    );
+    process.exit(1);
+  }
   console.log(
     `\nCatalog: reference integration = ${referenceSlug} (${referenceWiredFeatures.size} wired features)`,
   );
@@ -493,7 +656,8 @@ function generateCatalog(
     }
   }
 
-  // Step 5: Add 17 starter cells
+  // Step 5: Add one starter cell per integration that declares a
+  // `starter` block
   for (const integration of integrations) {
     const slug = integration.slug as string;
     const integrationName = integration.name as string;
@@ -581,6 +745,28 @@ function main() {
       continue;
     }
 
+    // yaml.parse returns null for an empty document and a scalar/array
+    // for degenerate ones — validateManifest assumes a mapping and used
+    // to TypeError on null (SU7-F3). Treat a non-mapping parse result
+    // as a validation error like any other malformed manifest
+    // (aggregated; exit 1 below).
+    if (
+      manifest === null ||
+      typeof manifest !== "object" ||
+      Array.isArray(manifest)
+    ) {
+      const shape =
+        manifest === null
+          ? "null"
+          : Array.isArray(manifest)
+            ? "an array"
+            : `a ${typeof manifest}`;
+      allErrors.push(
+        `${manifestPath}: manifest must be a YAML mapping (parsed to ${shape})`,
+      );
+      continue;
+    }
+
     const errors = validateManifest(
       manifest,
       validate,
@@ -639,8 +825,21 @@ function main() {
     manifest.docs_links = loadDocsLinks(pkgDir, allErrors);
   }
 
-  // Constraint validation
-  const constraintsRaw = fs.readFileSync(CONSTRAINTS_PATH, "utf-8");
+  // Constraint validation. A missing or unreadable constraints.yaml
+  // used to surface as a raw ENOENT stack (SU7-F3) — fail per the same
+  // labeled stderr + exit(1) contract as the {slug} check and the
+  // missing-reference check (consumers run with stdout ignored and
+  // stderr inherited).
+  let constraintsRaw: string;
+  try {
+    constraintsRaw = fs.readFileSync(CONSTRAINTS_PATH, "utf-8");
+  } catch (e) {
+    console.error(
+      `ERROR: failed to read constraints file ${CONSTRAINTS_PATH}: ` +
+        `${(e as Error).message}`,
+    );
+    process.exit(1);
+  }
   const constraints = yaml.parse(constraintsRaw);
 
   for (const manifest of integrations) {
@@ -723,4 +922,26 @@ function main() {
   }
 }
 
-main();
+// Direct-run guard (SU7-F3): execute main() only when this file is the
+// CLI entry — every real invocation (`tsx generate-registry.ts` from the
+// shells' dev/build scripts, vitest.global-setup, CI, the test
+// harnesses) runs it directly, and tsx sets process.argv[1] to the
+// resolved script path. Importing the module (unit tests import
+// atomicTmpPath) must not regenerate the registry as a side effect.
+// realpath both sides so a symlinked cwd/tmpdir can't produce a false
+// negative.
+function isDirectRun(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return (
+      fs.realpathSync(path.resolve(entry)) === fs.realpathSync(__filename)
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectRun()) {
+  main();
+}

--- a/showcase/shell/next.config.ts
+++ b/showcase/shell/next.config.ts
@@ -20,7 +20,7 @@ function localBackendsEnv(): string {
   return JSON.stringify(map);
 }
 
-// NOTE: the docs-host 301s (/docs, /ag-ui, /reference and the
+// NOTE: the docs-host 308s (/docs, /ag-ui, /reference and the
 // /<framework-slug> routes) intentionally do NOT live here. A
 // next.config `redirects()` table is baked into the build artifact, so
 // the destination host would freeze to whatever was current at Docker

--- a/showcase/shell/next.config.ts
+++ b/showcase/shell/next.config.ts
@@ -9,12 +9,31 @@ function localBackendsEnv(): string {
   if (process.env.SHOWCASE_LOCAL !== "1") return "";
   const portsPath = path.resolve(__dirname, "..", "shared", "local-ports.json");
   if (!fs.existsSync(portsPath)) return "";
-  const ports = JSON.parse(fs.readFileSync(portsPath, "utf-8")) as Record<
-    string,
-    number
-  >;
+  // This runs at build time, so failing the build IS the loud path —
+  // name the offending file instead of surfacing a bare SyntaxError.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(portsPath, "utf-8"));
+  } catch (err) {
+    throw new Error(`${portsPath} is not valid JSON: ${String(err)}`, {
+      cause: err,
+    });
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `${portsPath} must be a JSON object mapping slug -> port (got ` +
+        `${Array.isArray(parsed) ? "an array" : typeof parsed}).`,
+    );
+  }
   const map: Record<string, string> = {};
-  for (const [slug, port] of Object.entries(ports)) {
+  for (const [slug, port] of Object.entries(parsed)) {
+    if (typeof port !== "number" || !Number.isFinite(port)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[next.config] ${portsPath}: port for "${slug}" is not a number — skipping it.`,
+      );
+      continue;
+    }
     map[slug] = `http://localhost:${port}`;
   }
   return JSON.stringify(map);

--- a/showcase/shell/next.config.ts
+++ b/showcase/shell/next.config.ts
@@ -20,53 +20,14 @@ function localBackendsEnv(): string {
   return JSON.stringify(map);
 }
 
-// Read registry to get the list of framework slugs owned by the docs
-// shell. Any path whose first segment is a framework slug must 301 to
-// docs.showcase.copilotkit.ai. This list is derived at build time so
-// the redirect table tracks registry changes automatically — no manual
-// sync between next.config.ts and the docs shell's ownership list.
-function frameworkSlugs(): string[] {
-  const registryPath = path.resolve(__dirname, "src", "data", "registry.json");
-  if (!fs.existsSync(registryPath)) {
-    // In production the registry is a required build-time artifact; missing
-    // it means our redirect table is wrong. Fail loud so the deploy stops
-    // rather than silently shipping a site where /<slug> 404s. In dev the
-    // file may legitimately not exist yet (e.g. before generate-registry.ts
-    // has run) so we stay quiet — returning [] matches dev-server behavior.
-    if (process.env.NODE_ENV === "production") {
-      throw new Error(
-        `[next.config] registry.json missing at ${registryPath} — ` +
-          `framework redirects cannot be built. Run generate-registry.ts before building.`,
-      );
-    }
-    return [];
-  }
-  try {
-    const registry = JSON.parse(fs.readFileSync(registryPath, "utf-8")) as {
-      integrations?: { slug: string }[];
-    };
-    return (registry.integrations ?? []).map((i) => i.slug);
-  } catch (err) {
-    // Corrupt registry: in production, rip the cord — every /<slug> redirect
-    // would vanish and we'd silently serve 404s for every framework route.
-    // In dev, log and keep going so the dev loop isn't fatally broken by a
-    // transient mid-write or bad hand edit.
-    const message = (err as Error).message;
-    if (process.env.NODE_ENV === "production") {
-      throw new Error(
-        `[next.config] registry.json at ${registryPath} is unparseable: ${message}. ` +
-          `Refusing to build with missing framework redirects.`,
-      );
-    }
-    console.warn(
-      `[next.config] registry.json at ${registryPath} is unparseable: ${message}. ` +
-        `Framework redirects will be empty until fixed.`,
-    );
-    return [];
-  }
-}
-
-const DOCS_HOST = "https://docs.showcase.copilotkit.ai";
+// NOTE: the docs-host 301s (/docs, /ag-ui, /reference and the
+// /<framework-slug> routes) intentionally do NOT live here. A
+// next.config `redirects()` table is baked into the build artifact, so
+// the destination host would freeze to whatever was current at Docker
+// build (staging shells 301'd to the PROD docs host). They are issued
+// by src/middleware.ts instead, resolving the docs host from runtime
+// config (DOCS_HOST env var) on every request — see
+// src/lib/docs-redirects.ts.
 
 const nextConfig: NextConfig = {
   env: {
@@ -78,61 +39,6 @@ const nextConfig: NextConfig = {
     NEXT_PUBLIC_LOCAL_BACKENDS: localBackendsEnv(),
   },
   serverExternalPackages: ["@copilotkit/runtime", "@copilotkitnext/runtime"],
-  async redirects() {
-    const slugs = frameworkSlugs();
-    // Fixed docs-route redirects — whole sections (docs, ag-ui, reference)
-    // now live on docs.showcase.copilotkit.ai. Use 301 (permanent) so
-    // search engines carry authority over to the new host.
-    const fixed = [
-      {
-        source: "/docs",
-        destination: `${DOCS_HOST}`,
-        permanent: true,
-      },
-      {
-        source: "/docs/:path*",
-        destination: `${DOCS_HOST}/:path*`,
-        permanent: true,
-      },
-      {
-        source: "/ag-ui",
-        destination: `${DOCS_HOST}/ag-ui`,
-        permanent: true,
-      },
-      {
-        source: "/ag-ui/:path*",
-        destination: `${DOCS_HOST}/ag-ui/:path*`,
-        permanent: true,
-      },
-      {
-        source: "/reference",
-        destination: `${DOCS_HOST}/reference`,
-        permanent: true,
-      },
-      {
-        source: "/reference/:path*",
-        destination: `${DOCS_HOST}/reference/:path*`,
-        permanent: true,
-      },
-    ];
-    // Framework-scoped routes — /<slug> and /<slug>/... both go to the
-    // docs host. Enumerated from registry rather than a `:slug*` wildcard
-    // so we DON'T blanket-redirect /integrations or /matrix (which are
-    // owned by shell).
-    const frameworkRedirects = slugs.flatMap((slug) => [
-      {
-        source: `/${slug}`,
-        destination: `${DOCS_HOST}/${slug}`,
-        permanent: true,
-      },
-      {
-        source: `/${slug}/:path*`,
-        destination: `${DOCS_HOST}/${slug}/:path*`,
-        permanent: true,
-      },
-    ]);
-    return [...fixed, ...frameworkRedirects];
-  },
 };
 
 export default nextConfig;

--- a/showcase/shell/next.config.ts
+++ b/showcase/shell/next.config.ts
@@ -1,43 +1,18 @@
 import type { NextConfig } from "next";
-import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+// Logic lives in src/lib so vitest can cover it (missing-file warning,
+// TCP-port validation) — see src/lib/local-backends-env.test.ts.
+import { localBackendsEnv } from "./src/lib/local-backends-env";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-function localBackendsEnv(): string {
-  if (process.env.SHOWCASE_LOCAL !== "1") return "";
-  const portsPath = path.resolve(__dirname, "..", "shared", "local-ports.json");
-  if (!fs.existsSync(portsPath)) return "";
-  // This runs at build time, so failing the build IS the loud path —
-  // name the offending file instead of surfacing a bare SyntaxError.
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(fs.readFileSync(portsPath, "utf-8"));
-  } catch (err) {
-    throw new Error(`${portsPath} is not valid JSON: ${String(err)}`, {
-      cause: err,
-    });
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(
-      `${portsPath} must be a JSON object mapping slug -> port (got ` +
-        `${Array.isArray(parsed) ? "an array" : typeof parsed}).`,
-    );
-  }
-  const map: Record<string, string> = {};
-  for (const [slug, port] of Object.entries(parsed)) {
-    if (typeof port !== "number" || !Number.isFinite(port)) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `[next.config] ${portsPath}: port for "${slug}" is not a number — skipping it.`,
-      );
-      continue;
-    }
-    map[slug] = `http://localhost:${port}`;
-  }
-  return JSON.stringify(map);
-}
+const LOCAL_PORTS_PATH = path.resolve(
+  __dirname,
+  "..",
+  "shared",
+  "local-ports.json",
+);
 
 // NOTE: the docs-host 308s (/docs, /ag-ui, /reference and the
 // /<framework-slug> routes) intentionally do NOT live here. A
@@ -55,7 +30,7 @@ const nextConfig: NextConfig = {
     // re-bakes the build-time value into every chunk). NEXT_PUBLIC_LOCAL_BACKENDS
     // is fine to bake because it is computed from `shared/local-ports.json`
     // (a JSON file on disk, not an env var) and only used in local-dev.
-    NEXT_PUBLIC_LOCAL_BACKENDS: localBackendsEnv(),
+    NEXT_PUBLIC_LOCAL_BACKENDS: localBackendsEnv(LOCAL_PORTS_PATH),
   },
   serverExternalPackages: ["@copilotkit/runtime", "@copilotkitnext/runtime"],
 };

--- a/showcase/shell/package-lock.json
+++ b/showcase/shell/package-lock.json
@@ -25,6 +25,7 @@
         "rehype-highlight": "^7.0.2",
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.0",
+        "server-only": "^0.0.1",
         "yaml": "^2.7.0"
       },
       "devDependencies": {
@@ -12143,6 +12144,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/showcase/shell/package-lock.json
+++ b/showcase/shell/package-lock.json
@@ -12,6 +12,7 @@
         "@copilotkitnext/agent": "next",
         "@copilotkitnext/react": "next",
         "@copilotkitnext/runtime": "next",
+        "client-only": "0.0.1",
         "gray-matter": "^4.0.3",
         "highlight.js": "^11.11.1",
         "hono": "^4.6.0",

--- a/showcase/shell/package.json
+++ b/showcase/shell/package.json
@@ -28,6 +28,7 @@
     "rehype-highlight": "^7.0.2",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.0",
+    "server-only": "^0.0.1",
     "yaml": "^2.7.0"
   },
   "devDependencies": {

--- a/showcase/shell/package.json
+++ b/showcase/shell/package.json
@@ -15,6 +15,7 @@
     "@copilotkitnext/agent": "next",
     "@copilotkitnext/react": "next",
     "@copilotkitnext/runtime": "next",
+    "client-only": "0.0.1",
     "gray-matter": "^4.0.3",
     "highlight.js": "^11.11.1",
     "hono": "^4.6.0",

--- a/showcase/shell/src/app/integrations/[slug]/[demo]/page.tsx
+++ b/showcase/shell/src/app/integrations/[slug]/[demo]/page.tsx
@@ -8,6 +8,8 @@ import remarkGfm from "remark-gfm";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
 import type { Demo, Integration } from "@/lib/registry";
+import { getRuntimeConfig } from "@/lib/runtime-config.client";
+import { resolveBackendUrl } from "@/lib/backend-url";
 
 type Tab = "preview" | "code" | "docs";
 
@@ -62,10 +64,14 @@ export default function DemoViewerPage() {
   }
 
   // Command-only demos (e.g. `langgraph-python::cli-start`) have no
-  // `route`, so there's no iframe URL to build. Surface that explicitly
-  // rather than rendering `${backend_url}undefined`.
+  // `route`, so iframeSrc stays null and the preview tab shows the CLI
+  // instructions instead of an iframe. For demos with a route, the
+  // backend host is derived at request time from the injected runtime
+  // config's host pattern — never the build-baked registry backend_url
+  // (see preview/page.tsx for rationale). This line only runs
+  // post-hydration, so the injected runtime config is present.
   const iframeSrc = demo.route
-    ? `${integration.backend_url}${demo.route}`
+    ? `${resolveBackendUrl(integration.slug, getRuntimeConfig().backendHostPattern)}${demo.route}`
     : null;
 
   const tabs: { id: Tab; label: string }[] = [

--- a/showcase/shell/src/app/integrations/[slug]/[demo]/preview/page.tsx
+++ b/showcase/shell/src/app/integrations/[slug]/[demo]/preview/page.tsx
@@ -3,6 +3,8 @@
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import type { Integration, Demo } from "@/lib/registry";
+import { getRuntimeConfig } from "@/lib/runtime-config.client";
+import { resolveBackendUrl } from "@/lib/backend-url";
 
 export default function StandalonePreviewPage() {
   const params = useParams<{ slug: string; demo: string }>();
@@ -56,12 +58,17 @@ export default function StandalonePreviewPage() {
     );
   }
 
-  let localBackends: Record<string, string> = {};
-  try {
-    const raw = process.env.NEXT_PUBLIC_LOCAL_BACKENDS;
-    if (raw) localBackends = JSON.parse(raw);
-  } catch {}
-  const base = localBackends[integration.slug] ?? integration.backend_url;
+  // Derive the backend host at runtime from the injected config —
+  // never from registry.json's backend_url, which is baked at Docker
+  // build time (a staging shell would iframe PROD backends).
+  // resolveBackendUrl keeps the NEXT_PUBLIC_LOCAL_BACKENDS local-dev
+  // override. Safe to read here: this point is only reachable
+  // post-hydration (registry loads in useEffect), so the real
+  // window.__SHOWCASE_CONFIG__ is present.
+  const base = resolveBackendUrl(
+    integration.slug,
+    getRuntimeConfig().backendHostPattern,
+  );
   const src = `${base}${demo.route}`;
 
   return (

--- a/showcase/shell/src/app/integrations/[slug]/page.tsx
+++ b/showcase/shell/src/app/integrations/[slug]/page.tsx
@@ -34,9 +34,14 @@ export default async function IntegrationProfilePage({
   const allIntegrations = getIntegrations().filter(
     (i) => i.deployed && i.slug !== slug,
   );
+  // No backendUrl here: this page is statically prerendered
+  // (generateStaticParams), so any URL computed server-side would be
+  // frozen at build time — the exact baked-prod-URL defect this fixes.
+  // ProfileClient derives backend URLs client-side from the runtime
+  // config pattern.
   const demoAlternatives: Record<
     string,
-    Array<{ slug: string; name: string; backendUrl: string }>
+    Array<{ slug: string; name: string }>
   > = {};
   for (const demo of integration.demos) {
     const alts = allIntegrations
@@ -44,7 +49,6 @@ export default async function IntegrationProfilePage({
       .map((i) => ({
         slug: i.slug,
         name: i.name,
-        backendUrl: i.backend_url,
       }));
     if (alts.length > 0) {
       demoAlternatives[demo.id] = alts;

--- a/showcase/shell/src/app/integrations/[slug]/profile-client.tsx
+++ b/showcase/shell/src/app/integrations/[slug]/profile-client.tsx
@@ -9,6 +9,8 @@ import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import { DemoDrawer } from "@/components/demo-drawer";
 import type { Demo, Integration } from "@/lib/registry";
+import { getRuntimeConfig } from "@/lib/runtime-config.client";
+import { resolveBackendUrl } from "@/lib/backend-url";
 
 interface StarterFile {
   filename: string;
@@ -33,10 +35,7 @@ export function ProfileClient({
   featureInfos: FeatureInfo[];
   categoryLabel: string;
   languageLabel: string;
-  demoAlternatives?: Record<
-    string,
-    Array<{ slug: string; name: string; backendUrl: string }>
-  >;
+  demoAlternatives?: Record<string, Array<{ slug: string; name: string }>>;
 }) {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [activeDemo, setActiveDemo] = useState<Demo | null>(null);
@@ -509,6 +508,11 @@ export function ProfileClient({
       </div>
 
       {/* Drawer */}
+      {/* Backend URLs are derived at runtime from the injected config
+          pattern (never the build-baked registry backend_url). Safe:
+          activeDemo is only set by a click, i.e. post-hydration, so
+          window.__SHOWCASE_CONFIG__ is populated by the time these
+          evaluate. */}
       {activeDemo && (
         <DemoDrawer
           isOpen={drawerOpen}
@@ -517,14 +521,23 @@ export function ProfileClient({
           integrationName={integration.name}
           demoId={activeDemo.id}
           demoName={activeDemo.name}
-          backendUrl={integration.backend_url}
+          backendUrl={resolveBackendUrl(
+            integration.slug,
+            getRuntimeConfig().backendHostPattern,
+          )}
           demoRoute={activeDemo.route ?? ""}
           wide={
             activeDemo.id.includes("gen-ui") ||
             activeDemo.id.includes("shared-state") ||
             activeDemo.id.includes("subagent")
           }
-          alternatives={demoAlternatives[activeDemo.id]}
+          alternatives={demoAlternatives[activeDemo.id]?.map((alt) => ({
+            ...alt,
+            backendUrl: resolveBackendUrl(
+              alt.slug,
+              getRuntimeConfig().backendHostPattern,
+            ),
+          }))}
         />
       )}
     </>

--- a/showcase/shell/src/app/integrations/[slug]/profile-client.tsx
+++ b/showcase/shell/src/app/integrations/[slug]/profile-client.tsx
@@ -267,7 +267,7 @@ export function ProfileClient({
                           fontSize: "13px",
                           lineHeight: "1.6",
                           padding: "16px 20px",
-                          maxHeight: showAllFiles ? "none" : "none",
+                          maxHeight: showAllFiles ? "none" : "600px",
                         }}
                         showLineNumbers
                         lineNumberStyle={{

--- a/showcase/shell/src/lib/backend-url.test.ts
+++ b/showcase/shell/src/lib/backend-url.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  backendUrlFromPattern,
+  normalizeBackendHostPattern,
+  parseLocalBackends,
+  resolveBackendUrl,
+} from "./backend-url";
+
+describe("backendUrlFromPattern", () => {
+  it("substitutes {slug} into the host pattern and prepends https://", () => {
+    expect(
+      backendUrlFromPattern(
+        "showcase-{slug}-production.up.railway.app",
+        "mastra",
+      ),
+    ).toBe("https://showcase-mastra-production.up.railway.app");
+  });
+
+  it("matches the registry-baked prod URL for the default pattern (byte parity)", () => {
+    // generate-registry.ts synthesizes backend_url with the exact same
+    // pattern + https:// prefix. The runtime derivation MUST reproduce
+    // it byte-for-byte so prod behavior is unchanged with env unset.
+    expect(
+      backendUrlFromPattern(
+        "showcase-{slug}-production.up.railway.app",
+        "langgraph-python",
+      ),
+    ).toBe("https://showcase-langgraph-python-production.up.railway.app");
+  });
+
+  it("supports a staging-style pattern override", () => {
+    expect(
+      backendUrlFromPattern("showcase-{slug}-staging.up.railway.app", "agno"),
+    ).toBe("https://showcase-agno-staging.up.railway.app");
+  });
+
+  it("substitutes EVERY {slug} occurrence, not just the first", () => {
+    expect(
+      backendUrlFromPattern("{slug}.demos.example.com/{slug}", "mastra"),
+    ).toBe("https://mastra.demos.example.com/mastra");
+  });
+});
+
+describe("normalizeBackendHostPattern", () => {
+  let warns: string[];
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warns = [];
+    warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation((m: string) => warns.push(m));
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("passes a well-formed pattern through untouched, no warning", () => {
+    expect(
+      normalizeBackendHostPattern("showcase-{slug}-production.up.railway.app"),
+    ).toBe("showcase-{slug}-production.up.railway.app");
+    expect(warns).toEqual([]);
+  });
+
+  it("strips a leading scheme (consumer prepends https://) and warns", () => {
+    // A scheme-bearing env value would otherwise yield `https://https://…`.
+    expect(
+      normalizeBackendHostPattern(
+        "https://showcase-{slug}-staging.up.railway.app",
+      ),
+    ).toBe("showcase-{slug}-staging.up.railway.app");
+    expect(warns.some((m) => m.includes("scheme"))).toBe(true);
+  });
+
+  it("trims trailing slashes (route concat would yield //route) and warns", () => {
+    expect(
+      normalizeBackendHostPattern("showcase-{slug}-staging.up.railway.app/"),
+    ).toBe("showcase-{slug}-staging.up.railway.app");
+    expect(warns.some((m) => m.includes("trailing"))).toBe(true);
+  });
+
+  it("warns when the pattern lacks {slug} (all integrations → one host)", () => {
+    expect(normalizeBackendHostPattern("showcase-static.example.com")).toBe(
+      "showcase-static.example.com",
+    );
+    expect(warns.some((m) => m.includes("{slug}"))).toBe(true);
+  });
+
+  it("warns once per distinct pattern value, not per call", () => {
+    const pattern = "https://warn-once-{slug}.example.com/";
+    normalizeBackendHostPattern(pattern);
+    const after = warns.length;
+    expect(after).toBeGreaterThan(0);
+    normalizeBackendHostPattern(pattern);
+    expect(warns.length).toBe(after);
+  });
+});
+
+describe("parseLocalBackends", () => {
+  let warns: string[];
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warns = [];
+    warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation((m: string) => warns.push(m));
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("returns {} for undefined / empty / invalid JSON", () => {
+    expect(parseLocalBackends(undefined)).toEqual({});
+    expect(parseLocalBackends("")).toEqual({});
+    expect(parseLocalBackends("not json")).toEqual({});
+  });
+
+  it("names the env var in a warning when the JSON is unparseable", () => {
+    expect(parseLocalBackends("not json")).toEqual({});
+    expect(
+      warns.some((m) => m.includes("NEXT_PUBLIC_LOCAL_BACKENDS")),
+    ).toBe(true);
+  });
+
+  it("parses a slug->url map", () => {
+    expect(parseLocalBackends('{"mastra":"http://localhost:4111"}')).toEqual({
+      mastra: "http://localhost:4111",
+    });
+    expect(warns).toEqual([]);
+  });
+
+  it("skips (and warns about) non-string values instead of passing them through", () => {
+    expect(
+      parseLocalBackends(
+        '{"mastra":"http://localhost:4111","agno":4111,"crewai":null}',
+      ),
+    ).toEqual({ mastra: "http://localhost:4111" });
+    expect(warns.some((m) => m.includes("agno"))).toBe(true);
+    expect(warns.some((m) => m.includes("crewai"))).toBe(true);
+  });
+});
+
+describe("resolveBackendUrl", () => {
+  const ORIGINAL = process.env.NEXT_PUBLIC_LOCAL_BACKENDS;
+
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_LOCAL_BACKENDS;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) {
+      delete process.env.NEXT_PUBLIC_LOCAL_BACKENDS;
+    } else {
+      process.env.NEXT_PUBLIC_LOCAL_BACKENDS = ORIGINAL;
+    }
+  });
+
+  it("derives from the pattern when no local backend override exists", () => {
+    expect(
+      resolveBackendUrl("mastra", "showcase-{slug}-production.up.railway.app"),
+    ).toBe("https://showcase-mastra-production.up.railway.app");
+  });
+
+  it("prefers NEXT_PUBLIC_LOCAL_BACKENDS in local dev (behavior preserved)", () => {
+    process.env.NEXT_PUBLIC_LOCAL_BACKENDS = JSON.stringify({
+      mastra: "http://localhost:4111",
+    });
+    expect(
+      resolveBackendUrl("mastra", "showcase-{slug}-production.up.railway.app"),
+    ).toBe("http://localhost:4111");
+    // Slugs absent from the local map still derive from the pattern.
+    expect(
+      resolveBackendUrl("agno", "showcase-{slug}-production.up.railway.app"),
+    ).toBe("https://showcase-agno-production.up.railway.app");
+  });
+
+  it("ignores an empty-string local override instead of yielding an empty URL", () => {
+    // A `??` fallback treated `{"mastra": ""}` as a valid override and
+    // returned "" — which renders an iframe src of just the route.
+    process.env.NEXT_PUBLIC_LOCAL_BACKENDS = JSON.stringify({ mastra: "" });
+    expect(
+      resolveBackendUrl("mastra", "showcase-{slug}-production.up.railway.app"),
+    ).toBe("https://showcase-mastra-production.up.railway.app");
+  });
+});

--- a/showcase/shell/src/lib/backend-url.test.ts
+++ b/showcase/shell/src/lib/backend-url.test.ts
@@ -48,12 +48,31 @@ describe("backendUrlFromPattern", () => {
     ).toBe("https://mastra.demos.example.com/mastra");
   });
 
-  it("inserts the slug literally even when it contains $-substitution patterns", () => {
-    // String replacement treats "$&" as "the matched text" — a slug of
-    // "$&" would re-insert "{slug}" instead of the slug itself.
-    expect(
-      backendUrlFromPattern("showcase-{slug}.example.com", "$&"),
-    ).toBe("https://showcase-$&.example.com");
+  it("throws on a slug outside [a-z0-9-] (host-injection choke point)", () => {
+    // Every backend URL flows through here and the slug lands in the
+    // HOST of an iframe src — "." or "/" in a slug is host/path
+    // injection. All registry slugs are [a-z0-9-]; anything else is a
+    // contract violation, not data to be passed through.
+    for (const bad of [
+      "evil.example.com",
+      "slug/../path",
+      "$&",
+      "UPPER",
+      "under_score",
+      "",
+      "white space",
+    ]) {
+      expect(
+        () => backendUrlFromPattern("showcase-{slug}.example.com", bad),
+        `slug ${JSON.stringify(bad)} should throw`,
+      ).toThrow(/invalid integration slug/);
+    }
+    // The registry's real slug shapes all pass.
+    for (const ok of ["mastra", "langgraph-python", "ag2", "ms-agent-dotnet"]) {
+      expect(() =>
+        backendUrlFromPattern("showcase-{slug}.example.com", ok),
+      ).not.toThrow();
+    }
   });
 });
 
@@ -117,6 +136,30 @@ describe("normalizeBackendHostPattern", () => {
     expect(warns.some((m) => m.includes("whitespace"))).toBe(true);
   });
 
+  it("whitespace warn text matches the actual outcomes (host position falls back, path position ships)", () => {
+    // The old text claimed internal whitespace "yields a broken backend
+    // host" unconditionally — but HOST-position whitespace fails the
+    // usability gate and gets the DEFAULT fallback (it never ships),
+    // while PATH-position whitespace parses and genuinely ships broken.
+    normalizeFresh(" showcase-{slug}.example.com ");
+    const w = warns.find((m) => m.includes("whitespace"));
+    expect(w).toBeDefined();
+    expect(w).toContain("falls back");
+    expect(w).toContain("path");
+    expect(w).not.toContain("yields a broken backend host");
+  });
+
+  it("names EVERY stripped scheme on a stacked-scheme pattern", () => {
+    // The strip loop is once-guarded per pattern — the second
+    // iteration's warn was swallowed, so only the first scheme was ever
+    // named and the log understated what was removed.
+    normalizeFresh("https://http://showcase-{slug}.example.com");
+    const w = warns.find((m) => m.includes("scheme"));
+    expect(w).toBeDefined();
+    expect(w).toContain('"https://"');
+    expect(w).toContain('"http://"');
+  });
+
   it("warns once per distinct pattern value, not per call", () => {
     const pattern = "https://warn-once-{slug}.example.com/";
     normalizeFresh(pattern);
@@ -124,6 +167,153 @@ describe("normalizeBackendHostPattern", () => {
     expect(after).toBeGreaterThan(0);
     normalizeFresh(pattern);
     expect(warns.length).toBe(after);
+  });
+
+  it("warns when the pattern carries an internal path segment (bare-host contract)", () => {
+    // `host.app/base/{slug}` silently violates the documented bare-host
+    // contract — the consumer prepends https:// and concatenates routes,
+    // so a base path lands in every backend URL unannounced.
+    expect(normalizeFresh("backends.example.com/base/{slug}")).toBe(
+      "backends.example.com/base/{slug}",
+    );
+    expect(warns.some((m) => m.includes("path"))).toBe(true);
+  });
+
+  it("does not fire the path warning for a path-free pattern", () => {
+    normalizeFresh("showcase-{slug}-production.up.railway.app");
+    expect(warns.some((m) => m.includes("path segment"))).toBe(false);
+  });
+
+  it("strips a stacked scheme to convergence (https://https://host)", () => {
+    // The strip previously ran ONCE — `https://https://host` left a
+    // scheme behind, and the consumer prepends https:// on top: a
+    // double-prepended garbage host.
+    expect(
+      normalizeFresh("https://https://showcase-{slug}.example.com"),
+    ).toBe("showcase-{slug}.example.com");
+    expect(warns.some((m) => m.includes("scheme"))).toBe(true);
+  });
+
+  describe("degenerate patterns fall back to the default with one FATAL", () => {
+    let errs: string[];
+    let errSpy: MockInstance<typeof console.error>;
+
+    beforeEach(() => {
+      // The FATAL-CONFIG error (with Railway guidance) is the PROD
+      // posture — in dev the same fallback logs a warn instead (see the
+      // dev-mode test below). NODE_ENV is read at call time.
+      vi.stubEnv("NODE_ENV", "production");
+      errs = [];
+      errSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation((m: string) => void errs.push(m));
+    });
+
+    afterEach(() => {
+      errSpy.mockRestore();
+      vi.unstubAllEnvs();
+    });
+
+    it.each([
+      ["bare scheme", "https://"],
+      ["lone slash", "/"],
+      ["whitespace only", "   "],
+      ["internal whitespace (unparseable host)", "ho st-{slug}.example.com"],
+    ])(
+      "%s (%j) yields the default pattern, never an empty string",
+      (_label, bad) => {
+        const result = normalizeFresh(bad);
+        expect(result).toBe("showcase-{slug}-production.up.railway.app");
+        expect(result.length).toBeGreaterThan(0);
+        expect(
+          errs.some(
+            (m) =>
+              m.includes("FATAL-CONFIG") &&
+              m.includes("SHOWCASE_BACKEND_HOST_PATTERN"),
+          ),
+        ).toBe(true);
+      },
+    );
+
+    it("rejects a credentialed pattern (userinfo) with the default fallback + one FATAL", () => {
+      // A credentialed pattern yields iframe srcs that Chromium
+      // silently blocks — the integration pane just never loads, with
+      // zero signal. Same userinfo rejection validateBaseUrl has
+      // (runtime-config.ts).
+      for (const bad of [
+        "user:pass@showcase-{slug}.example.com",
+        // Scheme-bearing form: the strip leaves the credentials behind.
+        "https://user:pass@showcase-{slug}.example.com",
+      ]) {
+        const result = normalizeFresh(bad);
+        expect(result, `pattern ${JSON.stringify(bad)}`).toBe(
+          "showcase-{slug}-production.up.railway.app",
+        );
+        expect(
+          errs.some(
+            (m) =>
+              m.includes("FATAL-CONFIG") &&
+              m.includes("SHOWCASE_BACKEND_HOST_PATTERN") &&
+              m.includes("userinfo"),
+          ),
+          `pattern ${JSON.stringify(bad)} should log a userinfo FATAL`,
+        ).toBe(true);
+      }
+    });
+
+    it("rejects a pattern carrying a query or fragment with the default fallback + one FATAL", () => {
+      // Route concatenation appends demo routes to the composed URL —
+      // `https://host?x=1` + `/route` yields `https://host?x=1/route`,
+      // corrupting EVERY backend URL. Same gate class as userinfo.
+      for (const [bad, component] of [
+        ["showcase-{slug}.example.com?x=1", "query"],
+        ["showcase-{slug}.example.com#frag", "fragment"],
+      ] as const) {
+        const result = normalizeFresh(bad);
+        expect(result, `pattern ${JSON.stringify(bad)}`).toBe(
+          "showcase-{slug}-production.up.railway.app",
+        );
+        expect(
+          errs.some(
+            (m) =>
+              m.includes("FATAL-CONFIG") &&
+              m.includes("SHOWCASE_BACKEND_HOST_PATTERN") &&
+              m.includes(component),
+          ),
+          `pattern ${JSON.stringify(bad)} should log a ${component} FATAL`,
+        ).toBe(true);
+      }
+    });
+
+    it("FATAL fires once per distinct value, not per call", () => {
+      normalizeFresh("https://");
+      const after = errs.length;
+      expect(after).toBeGreaterThan(0);
+      normalizeFresh("https://");
+      expect(errs.length).toBe(after);
+    });
+
+    it("a well-formed pattern never trips the fallback or the FATAL", () => {
+      expect(normalizeFresh("showcase-{slug}-staging.up.railway.app")).toBe(
+        "showcase-{slug}-staging.up.railway.app",
+      );
+      expect(errs).toEqual([]);
+    });
+
+    it("dev-mode degenerate pattern warns (no FATAL-CONFIG / Railway guidance) and still falls back", () => {
+      // Same dev-vs-prod branch validateBaseUrl has (runtime-config.ts):
+      // Railway guidance is useless on a laptop — dev logs a warn, prod
+      // keeps the FATAL-CONFIG error. The fallback VALUE is identical.
+      vi.stubEnv("NODE_ENV", "development");
+      expect(normalizeFresh("https://")).toBe(
+        "showcase-{slug}-production.up.railway.app",
+      );
+      expect(errs).toEqual([]);
+      expect(
+        warns.some((m) => m.includes("SHOWCASE_BACKEND_HOST_PATTERN")),
+      ).toBe(true);
+      expect(warns.some((m) => m.includes("Railway"))).toBe(false);
+    });
   });
 });
 
@@ -205,6 +395,20 @@ describe("parseLocalBackends", () => {
       parseSpy.mockRestore();
     }
   });
+
+  it("returns frozen objects (the memo is shared across every caller)", () => {
+    // The memoized object is handed to EVERY caller — a consumer
+    // mutating its "own" map would silently change the local-backend
+    // overrides for the whole process.
+    const parsed = parseFresh('{"mastra":"http://localhost:4111"}');
+    expect(Object.isFrozen(parsed)).toBe(true);
+    expect(() => {
+      (parsed as Record<string, string>).mastra = "http://evil.example.com";
+    }).toThrow(TypeError);
+    // The unset/empty/invalid paths return shared objects too.
+    expect(Object.isFrozen(parseFresh(undefined))).toBe(true);
+    expect(Object.isFrozen(parseFresh("not json"))).toBe(true);
+  });
 });
 
 describe("resolveBackendUrl", () => {
@@ -241,6 +445,39 @@ describe("resolveBackendUrl", () => {
     ).toBe("https://showcase-agno-production.up.railway.app");
   });
 
+  it("trims trailing slashes from an accepted local override (host//route class)", () => {
+    // The pattern path guarantees trailing-slash normalization
+    // (normalizeBackendHostPattern) — an override skipping it yields
+    // `host//route` when consumers concatenate demo routes.
+    process.env.NEXT_PUBLIC_LOCAL_BACKENDS = JSON.stringify({
+      mastra: "http://localhost:4111/",
+      agno: "http://localhost:4112//",
+    });
+    expect(
+      resolveBackendUrl("mastra", "showcase-{slug}-production.up.railway.app"),
+    ).toBe("http://localhost:4111");
+    expect(
+      resolveBackendUrl("agno", "showcase-{slug}-production.up.railway.app"),
+    ).toBe("http://localhost:4112");
+  });
+
+  it("returns the parsed-normalized form of an accepted override (host case, default port)", () => {
+    // The override is already parsed for validation — returning the raw
+    // string leaked un-normalized values (uppercase hosts, explicit
+    // default ports) into iframe srcs, while the pattern path always
+    // yields canonical hosts.
+    process.env.NEXT_PUBLIC_LOCAL_BACKENDS = JSON.stringify({
+      mastra: "http://LOCALHOST:4111/Api/",
+      agno: "https://Proxy.Example.COM:443",
+    });
+    expect(
+      resolveBackendUrl("mastra", "showcase-{slug}-production.up.railway.app"),
+    ).toBe("http://localhost:4111/Api");
+    expect(
+      resolveBackendUrl("agno", "showcase-{slug}-production.up.railway.app"),
+    ).toBe("https://proxy.example.com");
+  });
+
   it("ignores an empty-string local override instead of yielding an empty URL", () => {
     // A `??` fallback treated `{"mastra": ""}` as a valid override and
     // returned "" — which renders an iframe src of just the route.
@@ -248,5 +485,114 @@ describe("resolveBackendUrl", () => {
     expect(
       resolveBackendUrl("mastra", "showcase-{slug}-production.up.railway.app"),
     ).toBe("https://showcase-mastra-production.up.railway.app");
+  });
+
+  it("warns and ignores a local override with a non-http(s) scheme (iframe-src injection guard)", async () => {
+    // `javascript://...` and `ftp://...` are scheme-bearing AND
+    // parseable, so they previously passed straight into iframe srcs.
+    // Fresh module instance: the warn-once latch is module state.
+    vi.resetModules();
+    const { resolveBackendUrl: resolveFresh } = await import("./backend-url");
+    const warns: string[] = [];
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation((m: string) => void warns.push(m));
+    try {
+      process.env.NEXT_PUBLIC_LOCAL_BACKENDS = JSON.stringify({
+        mastra: "javascript://alert(1)",
+        agno: "ftp://files.example.com",
+        crewai: "http://localhost:4112",
+      });
+      expect(
+        resolveFresh("mastra", "showcase-{slug}-production.up.railway.app"),
+      ).toBe("https://showcase-mastra-production.up.railway.app");
+      expect(
+        resolveFresh("agno", "showcase-{slug}-production.up.railway.app"),
+      ).toBe("https://showcase-agno-production.up.railway.app");
+      // http(s) overrides still win.
+      expect(
+        resolveFresh("crewai", "showcase-{slug}-production.up.railway.app"),
+      ).toBe("http://localhost:4112");
+      expect(warns.some((m) => m.includes("mastra"))).toBe(true);
+      expect(warns.some((m) => m.includes("agno"))).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("warns and ignores a local override carrying userinfo, query, or fragment components", async () => {
+    // An override lands verbatim in iframe srcs and route concatenation:
+    // userinfo gets silently blocked by Chromium (same rejection the
+    // pattern path has), and a query/fragment corrupts every composed
+    // URL (`http://host?x=1` + `/route` → `http://host?x=1/route`).
+    // Fresh module instance: the warn-once latch is module state.
+    vi.resetModules();
+    const { resolveBackendUrl: resolveFresh } = await import("./backend-url");
+    const warns: string[] = [];
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation((m: string) => void warns.push(m));
+    try {
+      process.env.NEXT_PUBLIC_LOCAL_BACKENDS = JSON.stringify({
+        mastra: "http://user:pass@localhost:4111",
+        agno: "http://localhost:4112?x=1",
+        crewai: "http://localhost:4113#frag",
+        adk: "http://localhost:4114",
+      });
+      for (const slug of ["mastra", "agno", "crewai"]) {
+        expect(
+          resolveFresh(slug, "showcase-{slug}-production.up.railway.app"),
+          `override for "${slug}" should be rejected`,
+        ).toBe(`https://showcase-${slug}-production.up.railway.app`);
+        expect(
+          warns.some((m) => m.includes(slug)),
+          `rejecting "${slug}" should warn`,
+        ).toBe(true);
+      }
+      // A clean http(s) override still wins.
+      expect(
+        resolveFresh("adk", "showcase-{slug}-production.up.railway.app"),
+      ).toBe("http://localhost:4114");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("warns and ignores a local override that is not a scheme-bearing parseable URL", async () => {
+    // `{"mastra": "localhost:4111"}` (no scheme) or outright garbage
+    // would land verbatim in an iframe src — fall back to the pattern
+    // instead, with a warn.
+    //
+    // Fresh module instance: the warn-once latch is module state, so
+    // asserting on the STATIC import is not retry-safe (a --retry rerun
+    // finds the latch already consumed) — same discipline as the
+    // sibling describes.
+    vi.resetModules();
+    const { resolveBackendUrl: resolveFresh } = await import("./backend-url");
+    const warns: string[] = [];
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation((m: string) => void warns.push(m));
+    try {
+      process.env.NEXT_PUBLIC_LOCAL_BACKENDS = JSON.stringify({
+        mastra: "localhost:4111",
+        agno: "http://exa mple/",
+        crewai: "http://localhost:4112",
+      });
+      expect(
+        resolveFresh("mastra", "showcase-{slug}-production.up.railway.app"),
+      ).toBe("https://showcase-mastra-production.up.railway.app");
+      expect(
+        resolveFresh("agno", "showcase-{slug}-production.up.railway.app"),
+      ).toBe("https://showcase-agno-production.up.railway.app");
+      // A well-formed override still wins.
+      expect(
+        resolveFresh("crewai", "showcase-{slug}-production.up.railway.app"),
+      ).toBe("http://localhost:4112");
+      expect(warns.some((m) => m.includes("mastra"))).toBe(true);
+      expect(warns.some((m) => m.includes("agno"))).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/showcase/shell/src/lib/backend-url.test.ts
+++ b/showcase/shell/src/lib/backend-url.test.ts
@@ -136,6 +136,21 @@ describe("normalizeBackendHostPattern", () => {
     expect(warns.some((m) => m.includes("whitespace"))).toBe(true);
   });
 
+  it("strips internal tab/CR/LF instead of shipping raw control characters", () => {
+    // The WHATWG URL parser deletes \t\r\n BEFORE parsing, so a
+    // tab-bearing pattern passed the usability gate (the probe parsed
+    // fine) while the RAW control character shipped in every iframe
+    // src — and the old warn text claimed it would "fall back". Strip
+    // them exactly the way the parser would, and warn.
+    expect(
+      normalizeFresh("showcase-{slug}\t-staging.up.railway.app"),
+    ).toBe("showcase-{slug}-staging.up.railway.app");
+    expect(
+      normalizeFresh("show\rcase-{slug}.example\n.com"),
+    ).toBe("showcase-{slug}.example.com");
+    expect(warns.some((m) => m.includes("whitespace"))).toBe(true);
+  });
+
   it("whitespace warn text matches the actual outcomes (host position falls back, path position ships)", () => {
     // The old text claimed internal whitespace "yields a broken backend
     // host" unconditionally — but HOST-position whitespace fails the
@@ -147,6 +162,27 @@ describe("normalizeBackendHostPattern", () => {
     expect(w).toContain("falls back");
     expect(w).toContain("path");
     expect(w).not.toContain("yields a broken backend host");
+  });
+
+  it("canonicalizes the authority like the override path (lowercase host, :443 elided)", () => {
+    // The override path returns the parsed-normalized form (lowercase
+    // host, default port elided) — the pattern path shipped the RAW
+    // string into iframe srcs, leaking uppercase hosts and an explicit
+    // :443. Hosts are case-insensitive and the consumer always
+    // prepends https://, so this matches what the URL parser does to
+    // the composed URL anyway. The {slug} placeholder is lowercase and
+    // survives verbatim.
+    expect(
+      normalizeFresh("SHOWCASE-{slug}-Staging.UP.Railway.App:443"),
+    ).toBe("showcase-{slug}-staging.up.railway.app");
+    // :80 is NOT the https default — a real port must survive.
+    expect(normalizeFresh("showcase-{slug}.example.com:80")).toBe(
+      "showcase-{slug}.example.com:80",
+    );
+    // Path segments are case-SENSITIVE and stay untouched.
+    expect(normalizeFresh("Backends.example.com/Base/{slug}")).toBe(
+      "backends.example.com/Base/{slug}",
+    );
   });
 
   it("names EVERY stripped scheme on a stacked-scheme pattern", () => {
@@ -285,6 +321,77 @@ describe("normalizeBackendHostPattern", () => {
       }
     });
 
+    it("rejects an empty-userinfo '@' in the authority (empty username/password evade the getters)", () => {
+      // `https://@host` and `https://:@host` parse with username ===
+      // "" AND password === "" — the present-but-EMPTY userinfo slips
+      // the getter check, so the RAW `@`-bearing string previously
+      // shipped into every iframe src.
+      for (const bad of [
+        "@showcase-{slug}.example.com",
+        ":@showcase-{slug}.example.com",
+      ]) {
+        const result = normalizeFresh(bad);
+        expect(result, `pattern ${JSON.stringify(bad)}`).toBe(
+          "showcase-{slug}-production.up.railway.app",
+        );
+        expect(
+          errs.some(
+            (m) =>
+              m.includes("FATAL-CONFIG") &&
+              m.includes("SHOWCASE_BACKEND_HOST_PATTERN") &&
+              m.includes("userinfo"),
+          ),
+          `pattern ${JSON.stringify(bad)} should log a userinfo FATAL`,
+        ).toBe(true);
+      }
+    });
+
+    it("rejects a bare trailing '?' / '#' (empty component evades the WHATWG getters)", () => {
+      // `https://host?` parses with search === "" and `https://host#`
+      // with hash === "" — a present-but-EMPTY component slips the
+      // probe getters, so the RAW string (literal `?`/`#` included)
+      // previously shipped, and route concatenation swallowed every
+      // demo route into the query/fragment.
+      for (const [bad, component] of [
+        ["showcase-{slug}.example.com?", "query"],
+        ["showcase-{slug}.example.com#", "fragment"],
+      ] as const) {
+        const result = normalizeFresh(bad);
+        expect(result, `pattern ${JSON.stringify(bad)}`).toBe(
+          "showcase-{slug}-production.up.railway.app",
+        );
+        expect(
+          errs.some(
+            (m) =>
+              m.includes("FATAL-CONFIG") &&
+              m.includes("SHOWCASE_BACKEND_HOST_PATTERN") &&
+              m.includes(component),
+          ),
+          `pattern ${JSON.stringify(bad)} should log a ${component} FATAL`,
+        ).toBe(true);
+      }
+    });
+
+    it("calls out a stray scheme fragment (host literally http/https) instead of claiming unparseable", () => {
+      // `https:/host` (missing one slash, so SCHEME_RE never strips
+      // it) probes to `https://https:/host` — hostname "https". The
+      // value DOES parse, so the old "cannot form a parseable backend
+      // URL" text was a lie that hid the actual problem: a stray
+      // scheme fragment in host position.
+      for (const bad of ["https:/showcase-{slug}.example.com", "http"]) {
+        const result = normalizeFresh(bad);
+        expect(result, `pattern ${JSON.stringify(bad)}`).toBe(
+          "showcase-{slug}-production.up.railway.app",
+        );
+        const e = errs.find(
+          (m) => m.includes("FATAL-CONFIG") && m.includes(JSON.stringify(bad)),
+        );
+        expect(e, `pattern ${JSON.stringify(bad)} should FATAL`).toBeDefined();
+        expect(e).toContain("stray scheme fragment");
+        expect(e).not.toContain("cannot form a parseable");
+      }
+    });
+
     it("FATAL fires once per distinct value, not per call", () => {
       normalizeFresh("https://");
       const after = errs.length;
@@ -382,18 +489,48 @@ describe("parseLocalBackends", () => {
     expect(warns.filter((m) => m.includes("not valid JSON")).length).toBe(1);
   });
 
-  it("memoizes the parse on the raw string (no per-call JSON.parse)", () => {
-    const parseSpy = vi.spyOn(JSON, "parse");
-    try {
-      const raw = '{"mastra":"http://localhost:4111"}';
-      const first = parseFresh(raw);
-      const second = parseFresh(raw);
-      expect(second).toEqual({ mastra: "http://localhost:4111" });
-      expect(second).toBe(first);
-      expect(parseSpy).toHaveBeenCalledTimes(1);
-    } finally {
-      parseSpy.mockRestore();
-    }
+  it("memoizes the parse on the raw string (same object identity per raw)", () => {
+    // Identity is the OBSERVABLE memo contract. (A global JSON.parse
+    // call-count spy used to assert "called once" — fragile: ANY other
+    // code touching JSON.parse during the test, including vitest
+    // internals, breaks it for reasons unrelated to this module.)
+    const raw = '{"mastra":"http://localhost:4111"}';
+    const first = parseFresh(raw);
+    const second = parseFresh(raw);
+    expect(second).toEqual({ mastra: "http://localhost:4111" });
+    expect(second).toBe(first);
+  });
+
+  it("does not poison the memo when the uncached parse throws mid-compute", () => {
+    // The memo key (raw) was committed BEFORE the value was computed —
+    // if the compute throws (console.warn is a foreign call, and a
+    // logging shim CAN throw), the next call with the same raw found
+    // the key already cached and returned the PREVIOUS raw's value.
+    const good = parseFresh('{"mastra":"http://localhost:4111"}');
+    expect(good).toEqual({ mastra: "http://localhost:4111" });
+    // Make the warn inside the compute throw once ("not json" warns).
+    warnSpy.mockImplementationOnce(() => {
+      throw new Error("logging shim exploded");
+    });
+    expect(() => parseFresh("not json")).toThrow("logging shim exploded");
+    // Same raw again (warn restored): must NOT return the stale good
+    // map committed under the previous raw.
+    expect(parseFresh("not json")).toEqual({});
+  });
+
+  it("keeps a __proto__ key as map data instead of silently dropping it", () => {
+    // The accumulator was a plain `{}` — assigning `backends["__proto__"]`
+    // hits the Object.prototype setter and is a silent no-op, so the
+    // entry vanished with NO warning (every other rejected entry warns).
+    // A null-prototype accumulator makes it an ordinary own property.
+    const parsed = parseFresh(
+      '{"__proto__":"http://localhost:4111","mastra":"http://localhost:4112"}',
+    );
+    expect(Object.keys(parsed)).toContain("__proto__");
+    expect(parsed["__proto__"]).toBe("http://localhost:4111");
+    expect(parsed["mastra"]).toBe("http://localhost:4112");
+    // And it must land as DATA — never as prototype pollution.
+    expect(({} as Record<string, unknown>).mastra).toBeUndefined();
   });
 
   it("returns frozen objects (the memo is shared across every caller)", () => {
@@ -478,13 +615,31 @@ describe("resolveBackendUrl", () => {
     ).toBe("https://proxy.example.com");
   });
 
-  it("ignores an empty-string local override instead of yielding an empty URL", () => {
+  it("warns about and ignores an empty-string local override instead of yielding an empty URL", async () => {
     // A `??` fallback treated `{"mastra": ""}` as a valid override and
-    // returned "" — which renders an iframe src of just the route.
-    process.env.NEXT_PUBLIC_LOCAL_BACKENDS = JSON.stringify({ mastra: "" });
-    expect(
-      resolveBackendUrl("mastra", "showcase-{slug}-production.up.railway.app"),
-    ).toBe("https://showcase-mastra-production.up.railway.app");
+    // returned "" — which renders an iframe src of just the route. The
+    // emptiness skip then happened BEFORE the warn block, so the dead
+    // override was ignored with ZERO signal — the one bad-override
+    // class that never warned. Fresh module instance: the warn-once
+    // latch is module state.
+    vi.resetModules();
+    const { resolveBackendUrl: resolveFresh } = await import("./backend-url");
+    const warns: string[] = [];
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation((m: string) => void warns.push(m));
+    try {
+      process.env.NEXT_PUBLIC_LOCAL_BACKENDS = JSON.stringify({ mastra: "" });
+      expect(
+        resolveFresh("mastra", "showcase-{slug}-production.up.railway.app"),
+      ).toBe("https://showcase-mastra-production.up.railway.app");
+      expect(
+        warns.some((m) => m.includes("mastra") && m.includes("empty")),
+        "ignoring an empty override should warn, naming the slug",
+      ).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("warns and ignores a local override with a non-http(s) scheme (iframe-src injection guard)", async () => {
@@ -553,6 +708,67 @@ describe("resolveBackendUrl", () => {
       expect(
         resolveFresh("adk", "showcase-{slug}-production.up.railway.app"),
       ).toBe("http://localhost:4114");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("trims a whitespace-padded local override before validating it (paste artifact)", async () => {
+    // The pattern path trims paste artifacts (normalizeBackendHostPattern)
+    // — the override path rejected " http://localhost:4111" outright,
+    // because the SCHEME_RE anchor fails on the leading space even
+    // though the URL parser accepts the value. Align the philosophy:
+    // trim first, then validate. Whitespace-ONLY collapses to the
+    // empty-override warn path.
+    vi.resetModules();
+    const { resolveBackendUrl: resolveFresh } = await import("./backend-url");
+    const warns: string[] = [];
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation((m: string) => void warns.push(m));
+    try {
+      process.env.NEXT_PUBLIC_LOCAL_BACKENDS = JSON.stringify({
+        mastra: " http://localhost:4111\t",
+        agno: "   ",
+      });
+      expect(
+        resolveFresh("mastra", "showcase-{slug}-production.up.railway.app"),
+      ).toBe("http://localhost:4111");
+      expect(warns.some((m) => m.includes("mastra"))).toBe(false);
+      expect(
+        resolveFresh("agno", "showcase-{slug}-production.up.railway.app"),
+      ).toBe("https://showcase-agno-production.up.railway.app");
+      expect(
+        warns.some((m) => m.includes("agno") && m.includes("empty")),
+      ).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("explains WHY a slashless-but-parseable override (http:localhost:4111) is rejected", async () => {
+    // `http:localhost:4111` IS parseable (special schemes tolerate
+    // missing slashes — it parses to http://localhost:4111/), so the
+    // old "is not a plain parseable http(s) base URL" warn sent the
+    // developer chasing a parse problem that doesn't exist. The real
+    // rejection is the explicit `scheme://` requirement.
+    vi.resetModules();
+    const { resolveBackendUrl: resolveFresh } = await import("./backend-url");
+    const warns: string[] = [];
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation((m: string) => void warns.push(m));
+    try {
+      process.env.NEXT_PUBLIC_LOCAL_BACKENDS = JSON.stringify({
+        mastra: "http:localhost:4111",
+      });
+      expect(
+        resolveFresh("mastra", "showcase-{slug}-production.up.railway.app"),
+      ).toBe("https://showcase-mastra-production.up.railway.app");
+      const w = warns.find((m) => m.includes("mastra"));
+      expect(w).toBeDefined();
+      expect(w).toContain("://");
+      expect(w).not.toContain("not a plain parseable");
     } finally {
       warnSpy.mockRestore();
     }

--- a/showcase/shell/src/lib/backend-url.test.ts
+++ b/showcase/shell/src/lib/backend-url.test.ts
@@ -99,9 +99,9 @@ describe("normalizeBackendHostPattern", () => {
   });
 
   it("passes a well-formed pattern through untouched, no warning", () => {
-    expect(
-      normalizeFresh("showcase-{slug}-production.up.railway.app"),
-    ).toBe("showcase-{slug}-production.up.railway.app");
+    expect(normalizeFresh("showcase-{slug}-production.up.railway.app")).toBe(
+      "showcase-{slug}-production.up.railway.app",
+    );
     expect(warns).toEqual([]);
   });
 
@@ -114,9 +114,9 @@ describe("normalizeBackendHostPattern", () => {
   });
 
   it("trims trailing slashes (route concat would yield //route) and warns", () => {
-    expect(
-      normalizeFresh("showcase-{slug}-staging.up.railway.app/"),
-    ).toBe("showcase-{slug}-staging.up.railway.app");
+    expect(normalizeFresh("showcase-{slug}-staging.up.railway.app/")).toBe(
+      "showcase-{slug}-staging.up.railway.app",
+    );
     expect(warns.some((m) => m.includes("trailing"))).toBe(true);
   });
 
@@ -130,9 +130,9 @@ describe("normalizeBackendHostPattern", () => {
   it("trims leading/trailing whitespace (paste artifact) and warns", () => {
     // Previously the ONE misconfig class with zero warning — a pasted
     // ` host` survives into `https:// host` iframe srcs.
-    expect(
-      normalizeFresh(" showcase-{slug}-staging.up.railway.app\t"),
-    ).toBe("showcase-{slug}-staging.up.railway.app");
+    expect(normalizeFresh(" showcase-{slug}-staging.up.railway.app\t")).toBe(
+      "showcase-{slug}-staging.up.railway.app",
+    );
     expect(warns.some((m) => m.includes("whitespace"))).toBe(true);
   });
 
@@ -142,12 +142,12 @@ describe("normalizeBackendHostPattern", () => {
     // fine) while the RAW control character shipped in every iframe
     // src — and the old warn text claimed it would "fall back". Strip
     // them exactly the way the parser would, and warn.
-    expect(
-      normalizeFresh("showcase-{slug}\t-staging.up.railway.app"),
-    ).toBe("showcase-{slug}-staging.up.railway.app");
-    expect(
-      normalizeFresh("show\rcase-{slug}.example\n.com"),
-    ).toBe("showcase-{slug}.example.com");
+    expect(normalizeFresh("showcase-{slug}\t-staging.up.railway.app")).toBe(
+      "showcase-{slug}-staging.up.railway.app",
+    );
+    expect(normalizeFresh("show\rcase-{slug}.example\n.com")).toBe(
+      "showcase-{slug}.example.com",
+    );
     expect(warns.some((m) => m.includes("whitespace"))).toBe(true);
   });
 
@@ -172,9 +172,9 @@ describe("normalizeBackendHostPattern", () => {
     // prepends https://, so this matches what the URL parser does to
     // the composed URL anyway. The {slug} placeholder is lowercase and
     // survives verbatim.
-    expect(
-      normalizeFresh("SHOWCASE-{slug}-Staging.UP.Railway.App:443"),
-    ).toBe("showcase-{slug}-staging.up.railway.app");
+    expect(normalizeFresh("SHOWCASE-{slug}-Staging.UP.Railway.App:443")).toBe(
+      "showcase-{slug}-staging.up.railway.app",
+    );
     // :80 is NOT the https default — a real port must survive.
     expect(normalizeFresh("showcase-{slug}.example.com:80")).toBe(
       "showcase-{slug}.example.com:80",
@@ -224,9 +224,9 @@ describe("normalizeBackendHostPattern", () => {
     // The strip previously ran ONCE — `https://https://host` left a
     // scheme behind, and the consumer prepends https:// on top: a
     // double-prepended garbage host.
-    expect(
-      normalizeFresh("https://https://showcase-{slug}.example.com"),
-    ).toBe("showcase-{slug}.example.com");
+    expect(normalizeFresh("https://https://showcase-{slug}.example.com")).toBe(
+      "showcase-{slug}.example.com",
+    );
     expect(warns.some((m) => m.includes("scheme"))).toBe(true);
   });
 
@@ -452,18 +452,16 @@ describe("parseLocalBackends", () => {
 
   it("names the env var in a warning when the JSON is unparseable", () => {
     expect(parseFresh("not json")).toEqual({});
-    expect(
-      warns.some((m) => m.includes("NEXT_PUBLIC_LOCAL_BACKENDS")),
-    ).toBe(true);
+    expect(warns.some((m) => m.includes("NEXT_PUBLIC_LOCAL_BACKENDS"))).toBe(
+      true,
+    );
   });
 
   it("ignores non-object JSON top-levels (array / string / null) with a warning", () => {
     expect(parseFresh("[1,2]")).toEqual({});
     expect(parseFresh('"str"')).toEqual({});
     expect(parseFresh("null")).toEqual({});
-    expect(warns.filter((m) => m.includes("not a JSON object")).length).toBe(
-      3,
-    );
+    expect(warns.filter((m) => m.includes("not a JSON object")).length).toBe(3);
   });
 
   it("parses a slug->url map", () => {
@@ -738,9 +736,9 @@ describe("resolveBackendUrl", () => {
       expect(
         resolveFresh("agno", "showcase-{slug}-production.up.railway.app"),
       ).toBe("https://showcase-agno-production.up.railway.app");
-      expect(
-        warns.some((m) => m.includes("agno") && m.includes("empty")),
-      ).toBe(true);
+      expect(warns.some((m) => m.includes("agno") && m.includes("empty"))).toBe(
+        true,
+      );
     } finally {
       warnSpy.mockRestore();
     }

--- a/showcase/shell/src/lib/backend-url.test.ts
+++ b/showcase/shell/src/lib/backend-url.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
 import {
   backendUrlFromPattern,
   normalizeBackendHostPattern,
@@ -39,17 +47,32 @@ describe("backendUrlFromPattern", () => {
       backendUrlFromPattern("{slug}.demos.example.com/{slug}", "mastra"),
     ).toBe("https://mastra.demos.example.com/mastra");
   });
+
+  it("inserts the slug literally even when it contains $-substitution patterns", () => {
+    // String replacement treats "$&" as "the matched text" — a slug of
+    // "$&" would re-insert "{slug}" instead of the slug itself.
+    expect(
+      backendUrlFromPattern("showcase-{slug}.example.com", "$&"),
+    ).toBe("https://showcase-$&.example.com");
+  });
 });
 
 describe("normalizeBackendHostPattern", () => {
   let warns: string[];
-  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: MockInstance<typeof console.warn>;
+  let normalizeFresh: typeof normalizeBackendHostPattern;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // The warn-once guard is module state, which makes warning
+    // assertions non-idempotent under vitest --retry — use a fresh
+    // module instance per test.
+    vi.resetModules();
+    normalizeFresh = (await import("./backend-url"))
+      .normalizeBackendHostPattern;
     warns = [];
     warnSpy = vi
       .spyOn(console, "warn")
-      .mockImplementation((m: string) => warns.push(m));
+      .mockImplementation((m: string) => void warns.push(m));
   });
 
   afterEach(() => {
@@ -58,7 +81,7 @@ describe("normalizeBackendHostPattern", () => {
 
   it("passes a well-formed pattern through untouched, no warning", () => {
     expect(
-      normalizeBackendHostPattern("showcase-{slug}-production.up.railway.app"),
+      normalizeFresh("showcase-{slug}-production.up.railway.app"),
     ).toBe("showcase-{slug}-production.up.railway.app");
     expect(warns).toEqual([]);
   });
@@ -66,46 +89,58 @@ describe("normalizeBackendHostPattern", () => {
   it("strips a leading scheme (consumer prepends https://) and warns", () => {
     // A scheme-bearing env value would otherwise yield `https://https://…`.
     expect(
-      normalizeBackendHostPattern(
-        "https://showcase-{slug}-staging.up.railway.app",
-      ),
+      normalizeFresh("https://showcase-{slug}-staging.up.railway.app"),
     ).toBe("showcase-{slug}-staging.up.railway.app");
     expect(warns.some((m) => m.includes("scheme"))).toBe(true);
   });
 
   it("trims trailing slashes (route concat would yield //route) and warns", () => {
     expect(
-      normalizeBackendHostPattern("showcase-{slug}-staging.up.railway.app/"),
+      normalizeFresh("showcase-{slug}-staging.up.railway.app/"),
     ).toBe("showcase-{slug}-staging.up.railway.app");
     expect(warns.some((m) => m.includes("trailing"))).toBe(true);
   });
 
   it("warns when the pattern lacks {slug} (all integrations → one host)", () => {
-    expect(normalizeBackendHostPattern("showcase-static.example.com")).toBe(
+    expect(normalizeFresh("showcase-static.example.com")).toBe(
       "showcase-static.example.com",
     );
     expect(warns.some((m) => m.includes("{slug}"))).toBe(true);
   });
 
+  it("trims leading/trailing whitespace (paste artifact) and warns", () => {
+    // Previously the ONE misconfig class with zero warning — a pasted
+    // ` host` survives into `https:// host` iframe srcs.
+    expect(
+      normalizeFresh(" showcase-{slug}-staging.up.railway.app\t"),
+    ).toBe("showcase-{slug}-staging.up.railway.app");
+    expect(warns.some((m) => m.includes("whitespace"))).toBe(true);
+  });
+
   it("warns once per distinct pattern value, not per call", () => {
     const pattern = "https://warn-once-{slug}.example.com/";
-    normalizeBackendHostPattern(pattern);
+    normalizeFresh(pattern);
     const after = warns.length;
     expect(after).toBeGreaterThan(0);
-    normalizeBackendHostPattern(pattern);
+    normalizeFresh(pattern);
     expect(warns.length).toBe(after);
   });
 });
 
 describe("parseLocalBackends", () => {
   let warns: string[];
-  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: MockInstance<typeof console.warn>;
+  let parseFresh: typeof parseLocalBackends;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // Warn-once + memo module state: a fresh module instance per test
+    // keeps the warning assertions order-independent and retry-safe.
+    vi.resetModules();
+    parseFresh = (await import("./backend-url")).parseLocalBackends;
     warns = [];
     warnSpy = vi
       .spyOn(console, "warn")
-      .mockImplementation((m: string) => warns.push(m));
+      .mockImplementation((m: string) => void warns.push(m));
   });
 
   afterEach(() => {
@@ -113,20 +148,29 @@ describe("parseLocalBackends", () => {
   });
 
   it("returns {} for undefined / empty / invalid JSON", () => {
-    expect(parseLocalBackends(undefined)).toEqual({});
-    expect(parseLocalBackends("")).toEqual({});
-    expect(parseLocalBackends("not json")).toEqual({});
+    expect(parseFresh(undefined)).toEqual({});
+    expect(parseFresh("")).toEqual({});
+    expect(parseFresh("not json")).toEqual({});
   });
 
   it("names the env var in a warning when the JSON is unparseable", () => {
-    expect(parseLocalBackends("not json")).toEqual({});
+    expect(parseFresh("not json")).toEqual({});
     expect(
       warns.some((m) => m.includes("NEXT_PUBLIC_LOCAL_BACKENDS")),
     ).toBe(true);
   });
 
+  it("ignores non-object JSON top-levels (array / string / null) with a warning", () => {
+    expect(parseFresh("[1,2]")).toEqual({});
+    expect(parseFresh('"str"')).toEqual({});
+    expect(parseFresh("null")).toEqual({});
+    expect(warns.filter((m) => m.includes("not a JSON object")).length).toBe(
+      3,
+    );
+  });
+
   it("parses a slug->url map", () => {
-    expect(parseLocalBackends('{"mastra":"http://localhost:4111"}')).toEqual({
+    expect(parseFresh('{"mastra":"http://localhost:4111"}')).toEqual({
       mastra: "http://localhost:4111",
     });
     expect(warns).toEqual([]);
@@ -134,12 +178,32 @@ describe("parseLocalBackends", () => {
 
   it("skips (and warns about) non-string values instead of passing them through", () => {
     expect(
-      parseLocalBackends(
+      parseFresh(
         '{"mastra":"http://localhost:4111","agno":4111,"crewai":null}',
       ),
     ).toEqual({ mastra: "http://localhost:4111" });
     expect(warns.some((m) => m.includes("agno"))).toBe(true);
     expect(warns.some((m) => m.includes("crewai"))).toBe(true);
+  });
+
+  it("warns once per distinct raw value, not per call", () => {
+    parseFresh("not json");
+    parseFresh("not json");
+    expect(warns.filter((m) => m.includes("not valid JSON")).length).toBe(1);
+  });
+
+  it("memoizes the parse on the raw string (no per-call JSON.parse)", () => {
+    const parseSpy = vi.spyOn(JSON, "parse");
+    try {
+      const raw = '{"mastra":"http://localhost:4111"}';
+      const first = parseFresh(raw);
+      const second = parseFresh(raw);
+      expect(second).toEqual({ mastra: "http://localhost:4111" });
+      expect(second).toBe(first);
+      expect(parseSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      parseSpy.mockRestore();
+    }
   });
 });
 

--- a/showcase/shell/src/lib/backend-url.ts
+++ b/showcase/shell/src/lib/backend-url.ts
@@ -1,0 +1,134 @@
+// Runtime derivation of integration backend URLs.
+//
+// The registry's `backend_url` is synthesized at Docker BUILD time by
+// scripts/generate-registry.ts, which bakes the production hostnames
+// into every image — so a staging shell iframed prod integrations.
+// These helpers derive the backend host at REQUEST time from the
+// `backendHostPattern` carried in RuntimeConfig (env var
+// SHOWCASE_BACKEND_HOST_PATTERN, default = the prod pattern), keeping
+// registry.json as the source for non-URL metadata only.
+//
+// Pattern semantics are IDENTICAL to generate-registry.ts: the pattern
+// is a bare host with `{slug}` as the only placeholder, and `https://`
+// is prepended. Keep the two in sync — they consume the same env var.
+//
+// This module is import-safe from client components, server components,
+// and middleware (pure functions, no next/* imports).
+
+// Matches an explicit URL scheme prefix (e.g. `https://`, `http://`).
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+// Warn once per distinct (pattern, issue) — config is re-read every
+// request, and per-request warn spam would drown real signal.
+const patternWarnings = new Set<string>();
+
+function warnPatternOnce(key: string, message: string): void {
+  if (patternWarnings.has(key)) return;
+  patternWarnings.add(key);
+  // eslint-disable-next-line no-console
+  console.warn(`[backend-url] SHOWCASE_BACKEND_HOST_PATTERN ${message}`);
+}
+
+/**
+ * Normalize a backend host pattern read from the environment. The
+ * pattern contract (same as scripts/generate-registry.ts) is a bare
+ * host with `{slug}` as the only placeholder — but env misconfigs are
+ * easy and were previously silent:
+ *
+ * - a scheme-bearing value would yield `https://https://…` (consumer
+ *   prepends the scheme) → strip it and warn;
+ * - a trailing slash would yield `host//route` on concat → trim and warn;
+ * - a missing `{slug}` placeholder silently sends EVERY integration to
+ *   the same host → warn (can't fix it for the operator).
+ *
+ * Warnings fire once per distinct value, not per request.
+ */
+export function normalizeBackendHostPattern(pattern: string): string {
+  let normalized = pattern;
+  const scheme = SCHEME_RE.exec(normalized);
+  if (scheme) {
+    warnPatternOnce(
+      `scheme:${pattern}`,
+      `"${pattern}" includes a scheme — the consumer prepends https://; stripping "${scheme[0]}".`,
+    );
+    normalized = normalized.slice(scheme[0].length);
+  }
+  if (/\/+$/.test(normalized)) {
+    warnPatternOnce(
+      `trailing-slash:${pattern}`,
+      `"${pattern}" has a trailing slash — route concatenation would yield "//"; trimming.`,
+    );
+    normalized = normalized.replace(/\/+$/, "");
+  }
+  if (!normalized.includes("{slug}")) {
+    warnPatternOnce(
+      `no-slug:${pattern}`,
+      `"${pattern}" lacks the {slug} placeholder — EVERY integration will resolve to the same backend host.`,
+    );
+  }
+  return normalized;
+}
+
+/** Substitute `{slug}` into the host pattern and prepend `https://`. */
+export function backendUrlFromPattern(pattern: string, slug: string): string {
+  return `https://${pattern.replaceAll("{slug}", slug)}`;
+}
+
+/**
+ * Parse the NEXT_PUBLIC_LOCAL_BACKENDS map (baked at build from
+ * shared/local-ports.json — local-dev only, empty in deployed images).
+ * Tolerant of unset/empty/corrupt values: local dev convenience must
+ * never break rendering.
+ */
+export function parseLocalBackends(
+  raw: string | undefined,
+): Record<string, string> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      // Validate values instead of an unchecked `as Record<string,
+      // string>` flow-through — a non-string value would otherwise
+      // surface much later as a garbage iframe src.
+      const backends: Record<string, string> = {};
+      for (const [slug, url] of Object.entries(parsed)) {
+        if (typeof url === "string") {
+          backends[slug] = url;
+        } else {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[backend-url] NEXT_PUBLIC_LOCAL_BACKENDS value for "${slug}" is not a string — skipping it.`,
+          );
+        }
+      }
+      return backends;
+    }
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[backend-url] NEXT_PUBLIC_LOCAL_BACKENDS is not a JSON object — ignoring it.",
+    );
+  } catch {
+    // Treat unparseable as unset (local-dev convenience must never
+    // break rendering) — but say so, instead of silently eating it.
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[backend-url] NEXT_PUBLIC_LOCAL_BACKENDS is not valid JSON — ignoring it.",
+    );
+  }
+  return {};
+}
+
+/**
+ * Resolve an integration's backend base URL: a local-dev override from
+ * NEXT_PUBLIC_LOCAL_BACKENDS wins (preserving the pre-existing
+ * `SHOWCASE_LOCAL=1` behavior), otherwise derive from the runtime host
+ * pattern.
+ */
+export function resolveBackendUrl(slug: string, pattern: string): string {
+  const local = parseLocalBackends(process.env.NEXT_PUBLIC_LOCAL_BACKENDS);
+  // Length-aware: an empty-string override (e.g. `{"mastra": ""}`) is
+  // not a usable URL — `??` would accept it and yield an empty base.
+  const override = local[slug];
+  if (override !== undefined && override.length > 0) return override;
+  return backendUrlFromPattern(pattern, slug);
+}

--- a/showcase/shell/src/lib/backend-url.ts
+++ b/showcase/shell/src/lib/backend-url.ts
@@ -74,22 +74,34 @@ function fatalPatternOnce(key: string, message: string): void {
  * the per-issue normalizations can't fix: empty results ("https://" or
  * "/" normalize to ""), internal whitespace, and anything else
  * `new URL` rejects or that parses without a real host.
+ *
+ * Returns `undefined` when usable, otherwise a reason discriminant so
+ * the FATAL can be honest: a probe whose HOST is literally
+ * "http"/"https" (e.g. `https:/host` — one slash short, so SCHEME_RE
+ * never strips it) DOES parse — calling it "unparseable" would hide
+ * the actual problem (a stray scheme fragment in host position).
  */
-function isUsablePattern(normalized: string): boolean {
-  if (normalized.length === 0) return false;
+function patternUsabilityProblem(
+  normalized: string,
+): "unparseable" | "stray-scheme-fragment" | undefined {
+  if (normalized.length === 0) return "unparseable";
   try {
     const probe = new URL(
       `https://${normalized.replaceAll("{slug}", "probe")}`,
     );
-    return probe.hostname.length > 0 && !/^https?$/i.test(probe.hostname);
+    if (probe.hostname.length === 0) return "unparseable";
+    if (/^https?$/i.test(probe.hostname)) return "stray-scheme-fragment";
+    return undefined;
   } catch {
-    return false;
+    return "unparseable";
   }
 }
 
 /**
  * Does the pattern carry a component no backend base URL may have?
- * Probed via the same consumer-exact composition as isUsablePattern.
+ * Detected on the LITERAL delimiter characters (see inline comments —
+ * the WHATWG getters return "" for present-but-empty components, so a
+ * probe-based check leaks bare `?`/`#`/`@`).
  * Returns a human-readable component name for the FATAL log, or
  * undefined when the pattern is clean. Three rejected classes (same
  * gates validateBaseUrl has in runtime-config.ts):
@@ -100,24 +112,35 @@ function isUsablePattern(normalized: string): boolean {
  * - query / fragment: consumers concatenate demo routes onto the
  *   composed URL, so `https://host?x=1` + `/route` yields
  *   `https://host?x=1/route` — every backend URL ships corrupted.
- *
- * An unparseable value returns undefined here; the usability gate
- * handles it.
  */
 function patternForbiddenComponent(normalized: string): string | undefined {
-  try {
-    const probe = new URL(
-      `https://${normalized.replaceAll("{slug}", "probe")}`,
-    );
-    if (probe.username !== "" || probe.password !== "") {
-      return "userinfo credentials";
-    }
-    if (probe.search !== "") return "a query component";
-    if (probe.hash !== "") return "a fragment component";
-    return undefined;
-  } catch {
-    return undefined;
+  // Query/fragment are detected on the LITERAL characters, not the
+  // probe getters: WHATWG getters return "" for a present-but-EMPTY
+  // component (`https://host?` has search === ""), so a bare trailing
+  // `?`/`#` would slip a getter check while the raw character still
+  // ships in the pattern — and route concatenation then swallows every
+  // demo route into the query/fragment. The literal check is strictly
+  // stronger than the getter check (a non-empty search/hash implies the
+  // literal character), so the getters aren't consulted at all. Which
+  // component a literal introduces follows URL precedence: `#` starts
+  // the fragment; `?` starts a query only when no `#` precedes it.
+  const hashAt = normalized.indexOf("#");
+  const queryAt = normalized.indexOf("?");
+  if (queryAt !== -1 && (hashAt === -1 || queryAt < hashAt)) {
+    return "a query component";
   }
+  if (hashAt !== -1) return "a fragment component";
+  // Userinfo is a literal check too: `https://@host` and
+  // `https://:@host` parse with username === "" AND password === ""
+  // (present-but-EMPTY userinfo), so the getter check let the raw
+  // `@`-bearing string ship. Any `@` in the AUTHORITY (the part before
+  // the first `/` — query/fragment are already rejected above) is a
+  // userinfo delimiter; it is never valid inside a hostname.
+  const slashAt = normalized.indexOf("/");
+  const authority =
+    slashAt === -1 ? normalized : normalized.slice(0, slashAt);
+  if (authority.includes("@")) return "userinfo credentials";
+  return undefined;
 }
 
 /**
@@ -139,15 +162,19 @@ export function normalizeBackendHostPattern(pattern: string): string {
   if (/\s/.test(normalized)) {
     // Whitespace was the ONE misconfig class with zero warning — a
     // pasted ` host` yields an iframe src like `https:// host`. Trim
-    // the ends (fixable); internal whitespace splits by position:
-    // host-position whitespace makes the pattern unparseable, so the
-    // usability gate below falls back to the DEFAULT (it never ships);
-    // path-position whitespace parses and genuinely ships broken.
+    // the ends (fixable) and strip internal tab/CR/LF (the WHATWG URL
+    // parser deletes \t\r\n pre-parse, so a tab-bearing pattern would
+    // pass the usability gate while the RAW control character shipped
+    // in every iframe src — stripping matches what the parser does
+    // anyway). Internal SPACES split by position: a host-position
+    // space makes the pattern unparseable, so the usability gate below
+    // falls back to the DEFAULT (it never ships); a path-position
+    // space parses and genuinely ships broken.
     warnPatternOnce(
       `whitespace:${pattern}`,
-      `"${pattern}" contains whitespace — trimming the ends. Internal whitespace in the host cannot form a usable pattern (falls back to the default); internal whitespace in a path segment ships in every backend URL.`,
+      `"${pattern}" contains whitespace — trimming the ends and stripping internal tab/CR/LF (the URL parser ignores them anyway). An internal space in the host cannot form a usable pattern (falls back to the default); a space in a path segment ships in every backend URL.`,
     );
-    normalized = normalized.trim();
+    normalized = normalized.replace(/[\t\r\n]/g, "").trim();
   }
   // Loop the strip to convergence: a single pass left "https://https://
   // host" with a scheme that the consumer then double-prepends. Collect
@@ -184,6 +211,16 @@ export function normalizeBackendHostPattern(pattern: string): string {
   // "https://", and the injected "" failed the client reader's
   // REQUIRED_CONFIG_FIELDS check, crashing every client component with
   // a message blaming the layout injection instead of this env var.
+  //
+  // DESIGN DECISION — degenerate/forbidden patterns fail OPEN to
+  // DEFAULT_BACKEND_HOST_PATTERN, which is the PROD host pattern. On a
+  // staging deploy, a mistyped SHOWCASE_BACKEND_HOST_PATTERN therefore
+  // silently (FATAL log aside) iframes PROD integrations — the exact
+  // staging→prod leakage this module exists to prevent. The
+  // alternative (fail CLOSED: ship "" and break every integration
+  // pane) was rejected because a hard outage is worse than serving
+  // prod content with a FATAL-CONFIG log; revisit if staging/prod
+  // divergence ever becomes load-bearing for correctness.
   const forbidden = patternForbiddenComponent(normalized);
   if (forbidden !== undefined) {
     fatalPatternOnce(
@@ -196,15 +233,39 @@ export function normalizeBackendHostPattern(pattern: string): string {
     );
     return DEFAULT_BACKEND_HOST_PATTERN;
   }
-  if (!isUsablePattern(normalized)) {
+  // Fails OPEN to the prod pattern too — see the DESIGN DECISION note
+  // above the forbidden-component gate.
+  const usabilityProblem = patternUsabilityProblem(normalized);
+  if (usabilityProblem !== undefined) {
     fatalPatternOnce(
       `degenerate:${pattern}`,
-      `${JSON.stringify(pattern)} normalizes to ${JSON.stringify(normalized)}, ` +
-        `which cannot form a parseable backend URL; falling back to the ` +
-        `default pattern ${DEFAULT_BACKEND_HOST_PATTERN}.`,
+      usabilityProblem === "stray-scheme-fragment"
+        ? `${JSON.stringify(pattern)} normalizes to ` +
+            `${JSON.stringify(normalized)}, whose host is literally ` +
+            `"http"/"https" — it looks like a stray scheme fragment, not ` +
+            `a backend host; falling back to the default pattern ` +
+            `${DEFAULT_BACKEND_HOST_PATTERN}.`
+        : `${JSON.stringify(pattern)} normalizes to ` +
+            `${JSON.stringify(normalized)}, which cannot form a parseable ` +
+            `backend URL; falling back to the default pattern ` +
+            `${DEFAULT_BACKEND_HOST_PATTERN}.`,
     );
     return DEFAULT_BACKEND_HOST_PATTERN;
   }
+  // Canonicalize the authority for parity with the override path,
+  // which returns the parsed-normalized form (lowercase host, default
+  // port elided) — the pattern path ships this string RAW into iframe
+  // srcs, leaking uppercase hosts and an explicit :443. Hosts are
+  // case-insensitive and the consumer always prepends https://, so
+  // lowercasing the authority and stripping a trailing :443 (the https
+  // default — :80 is a REAL port under https and must survive) matches
+  // what the URL parser does to the composed URL anyway. The path part
+  // (from the first "/") is case-SENSITIVE and stays untouched; the
+  // lowercase {slug} placeholder survives lowercasing verbatim.
+  const pathAt = normalized.indexOf("/");
+  const authority = pathAt === -1 ? normalized : normalized.slice(0, pathAt);
+  const pathPart = pathAt === -1 ? "" : normalized.slice(pathAt);
+  normalized = authority.toLowerCase().replace(/:443$/, "") + pathPart;
   if (!normalized.includes("{slug}")) {
     warnPatternOnce(
       `no-slug:${pattern}`,
@@ -285,8 +346,14 @@ export function parseLocalBackends(
 ): Record<string, string> {
   if (!raw) return NO_LOCAL_BACKENDS;
   if (raw !== lastLocalBackendsRaw) {
+    // Compute FIRST, then commit key and value together: committing
+    // the key before the value meant a throw mid-compute (console.warn
+    // is a foreign call — a logging shim CAN throw) left the memo
+    // poisoned, and the next call with the same raw returned the
+    // PREVIOUS raw's value.
+    const backends = Object.freeze(parseLocalBackendsUncached(raw));
     lastLocalBackendsRaw = raw;
-    lastLocalBackends = Object.freeze(parseLocalBackendsUncached(raw));
+    lastLocalBackends = backends;
   }
   return lastLocalBackends;
 }
@@ -298,7 +365,13 @@ function parseLocalBackendsUncached(raw: string): Record<string, string> {
       // Validate values instead of an unchecked `as Record<string,
       // string>` flow-through — a non-string value would otherwise
       // surface much later as a garbage iframe src.
-      const backends: Record<string, string> = {};
+      //
+      // Null-prototype accumulator: on a plain `{}`, assigning a
+      // "__proto__" key hits the Object.prototype setter and is a
+      // silent no-op — the entry would vanish with no warning (every
+      // other rejected entry warns). With no prototype it lands as an
+      // ordinary own data property.
+      const backends: Record<string, string> = Object.create(null);
       for (const [slug, url] of Object.entries(parsed)) {
         if (typeof url === "string") {
           backends[slug] = url;
@@ -338,10 +411,26 @@ export function resolveBackendUrl(slug: string, pattern: string): string {
   // so a live server-side value would silently diverge from what client
   // components resolve.
   const local = parseLocalBackends(process.env.NEXT_PUBLIC_LOCAL_BACKENDS);
-  // Length-aware: an empty-string override (e.g. `{"mastra": ""}`) is
-  // not a usable URL — `??` would accept it and yield an empty base.
-  const override = local[slug];
-  if (override !== undefined && override.length > 0) {
+  const rawOverride = local[slug];
+  if (rawOverride !== undefined) {
+    // Trim before validating — the same paste-artifact tolerance the
+    // pattern path applies (normalizeBackendHostPattern trims the
+    // ends): a leading-space override otherwise fails the SCHEME_RE
+    // anchor even though the URL parser accepts the value.
+    const override = rawOverride.trim();
+    // Length-aware: an empty/whitespace-only override (e.g.
+    // `{"mastra": ""}`) is not a usable URL — `??` would accept it and
+    // yield an empty base. The emptiness check lives INSIDE the
+    // override block so it warns like every other bad override:
+    // skipping it in the outer condition ignored the dead override
+    // with zero signal.
+    if (override.length === 0) {
+      warnLocalBackendsOnce(
+        `bad-override:${slug}:empty`,
+        `override for "${slug}" is empty (or whitespace-only) — ignoring it.`,
+      );
+      return backendUrlFromPattern(pattern, slug);
+    }
     // The override lands verbatim in an iframe src — require a
     // scheme-bearing, parseable URL (`localhost:4111` without a scheme
     // parses as scheme "localhost:"!) whose protocol is http(s):
@@ -372,10 +461,16 @@ export function resolveBackendUrl(slug: string, pattern: string): string {
       // origin + pathname IS the whole URL.
       return (parsed.origin + parsed.pathname).replace(/\/+$/, "");
     }
+    // Name the actual requirements instead of "not parseable":
+    // `http:localhost:4111` IS parseable (special schemes tolerate
+    // missing slashes), but it fails the explicit `scheme://`
+    // requirement — a "not parseable" claim sends the developer
+    // chasing a parse problem that doesn't exist.
     warnLocalBackendsOnce(
       `bad-override:${slug}:${override}`,
-      `override for "${slug}" (${JSON.stringify(override)}) is not a plain ` +
-        `parseable http(s) base URL (no userinfo/query/fragment) — ignoring it.`,
+      `override for "${slug}" (${JSON.stringify(override)}) must be an ` +
+        `http(s) URL with an explicit "scheme://" and no userinfo, query, ` +
+        `or fragment — ignoring it.`,
     );
   }
   return backendUrlFromPattern(pattern, slug);

--- a/showcase/shell/src/lib/backend-url.ts
+++ b/showcase/shell/src/lib/backend-url.ts
@@ -20,6 +20,15 @@
 // (this module is import-safe everywhere, so the dependency is free).
 export const SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
 
+// Default backend host pattern — reproduces today's baked prod values
+// exactly, so a deploy with the env var unset (i.e. current prod)
+// behaves byte-identically. Lives HERE (not runtime-config.ts, which
+// re-exports it) because normalizeBackendHostPattern falls back to it
+// for degenerate values and runtime-config already imports this module
+// — defining it there would create an import cycle.
+export const DEFAULT_BACKEND_HOST_PATTERN =
+  "showcase-{slug}-production.up.railway.app";
+
 // Warn once per distinct (pattern, issue) — config is re-read every
 // request, and per-request warn spam would drown real signal.
 const patternWarnings = new Set<string>();
@@ -29,6 +38,86 @@ function warnPatternOnce(key: string, message: string): void {
   patternWarnings.add(key);
   // eslint-disable-next-line no-console
   console.warn(`[backend-url] SHOWCASE_BACKEND_HOST_PATTERN ${message}`);
+}
+
+// FATAL once per distinct degenerate pattern value — parity with the
+// FATAL-CONFIG once-guards in runtime-config.ts (readUrl/readDocsHost).
+const patternFatals = new Set<string>();
+
+// Same dev-vs-prod branch as validateBaseUrl/readDocsHost
+// (runtime-config.ts): in production this is a FATAL-CONFIG error with
+// Railway guidance; in dev it degrades to a warn — Railway guidance is
+// useless on a laptop, and the dev contract is frictionless iteration.
+// NODE_ENV is read at CALL time (this module is import-safe everywhere;
+// Next statically inlines the literal read in client bundles).
+function fatalPatternOnce(key: string, message: string): void {
+  if (patternFatals.has(key)) return;
+  patternFatals.add(key);
+  if (process.env.NODE_ENV === "production") {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[backend-url] FATAL-CONFIG: SHOWCASE_BACKEND_HOST_PATTERN ${message} ` +
+        `Fix the SHOWCASE_BACKEND_HOST_PATTERN env var on the Railway service.`,
+    );
+  } else {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[backend-url] SHOWCASE_BACKEND_HOST_PATTERN ${message}`,
+    );
+  }
+}
+
+/**
+ * Can the normalized pattern actually form a backend URL? Probe by
+ * substituting a registry-shaped slug and parsing the consumer's exact
+ * composition (`https://` + pattern). Catches the degenerate classes
+ * the per-issue normalizations can't fix: empty results ("https://" or
+ * "/" normalize to ""), internal whitespace, and anything else
+ * `new URL` rejects or that parses without a real host.
+ */
+function isUsablePattern(normalized: string): boolean {
+  if (normalized.length === 0) return false;
+  try {
+    const probe = new URL(
+      `https://${normalized.replaceAll("{slug}", "probe")}`,
+    );
+    return probe.hostname.length > 0 && !/^https?$/i.test(probe.hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Does the pattern carry a component no backend base URL may have?
+ * Probed via the same consumer-exact composition as isUsablePattern.
+ * Returns a human-readable component name for the FATAL log, or
+ * undefined when the pattern is clean. Three rejected classes (same
+ * gates validateBaseUrl has in runtime-config.ts):
+ *
+ * - userinfo credentials: a credentialed pattern yields iframe srcs
+ *   that Chromium silently blocks — the integration pane just never
+ *   loads, with zero signal;
+ * - query / fragment: consumers concatenate demo routes onto the
+ *   composed URL, so `https://host?x=1` + `/route` yields
+ *   `https://host?x=1/route` — every backend URL ships corrupted.
+ *
+ * An unparseable value returns undefined here; the usability gate
+ * handles it.
+ */
+function patternForbiddenComponent(normalized: string): string | undefined {
+  try {
+    const probe = new URL(
+      `https://${normalized.replaceAll("{slug}", "probe")}`,
+    );
+    if (probe.username !== "" || probe.password !== "") {
+      return "userinfo credentials";
+    }
+    if (probe.search !== "") return "a query component";
+    if (probe.hash !== "") return "a fragment component";
+    return undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -50,20 +139,36 @@ export function normalizeBackendHostPattern(pattern: string): string {
   if (/\s/.test(normalized)) {
     // Whitespace was the ONE misconfig class with zero warning — a
     // pasted ` host` yields an iframe src like `https:// host`. Trim
-    // the ends (fixable); internal whitespace can only be flagged.
+    // the ends (fixable); internal whitespace splits by position:
+    // host-position whitespace makes the pattern unparseable, so the
+    // usability gate below falls back to the DEFAULT (it never ships);
+    // path-position whitespace parses and genuinely ships broken.
     warnPatternOnce(
       `whitespace:${pattern}`,
-      `"${pattern}" contains whitespace — trimming the ends. Internal whitespace cannot be fixed and yields a broken backend host.`,
+      `"${pattern}" contains whitespace — trimming the ends. Internal whitespace in the host cannot form a usable pattern (falls back to the default); internal whitespace in a path segment ships in every backend URL.`,
     );
     normalized = normalized.trim();
   }
-  const scheme = SCHEME_RE.exec(normalized);
-  if (scheme) {
+  // Loop the strip to convergence: a single pass left "https://https://
+  // host" with a scheme that the consumer then double-prepends. Collect
+  // every stripped scheme first so the once-guarded warn can name them
+  // ALL — warning inside the loop swallowed every name after the first.
+  const strippedSchemes: string[] = [];
+  for (
+    let scheme = SCHEME_RE.exec(normalized);
+    scheme;
+    scheme = SCHEME_RE.exec(normalized)
+  ) {
+    strippedSchemes.push(scheme[0]);
+    normalized = normalized.slice(scheme[0].length);
+  }
+  if (strippedSchemes.length > 0) {
     warnPatternOnce(
       `scheme:${pattern}`,
-      `"${pattern}" includes a scheme — the consumer prepends https://; stripping "${scheme[0]}".`,
+      `"${pattern}" includes a scheme — the consumer prepends https://; stripping ${strippedSchemes
+        .map((s) => `"${s}"`)
+        .join(", ")}.`,
     );
-    normalized = normalized.slice(scheme[0].length);
   }
   if (/\/+$/.test(normalized)) {
     warnPatternOnce(
@@ -72,20 +177,73 @@ export function normalizeBackendHostPattern(pattern: string): string {
     );
     normalized = normalized.replace(/\/+$/, "");
   }
+  // Usability gate AFTER the fixable normalizations, BEFORE the
+  // advisory warns ({slug}/path) — a degenerate value ("https://", "/",
+  // whitespace) normalizes to "" or an unparseable host, and previously
+  // flowed out with NO fallback: server-side iframe srcs became
+  // "https://", and the injected "" failed the client reader's
+  // REQUIRED_CONFIG_FIELDS check, crashing every client component with
+  // a message blaming the layout injection instead of this env var.
+  const forbidden = patternForbiddenComponent(normalized);
+  if (forbidden !== undefined) {
+    fatalPatternOnce(
+      `forbidden:${forbidden}:${pattern}`,
+      `${JSON.stringify(pattern)} carries ${forbidden} — userinfo makes ` +
+        `Chromium silently block every iframe src formed from it, and a ` +
+        `query/fragment corrupts every backend URL when consumers ` +
+        `concatenate demo routes; falling back to the default pattern ` +
+        `${DEFAULT_BACKEND_HOST_PATTERN}.`,
+    );
+    return DEFAULT_BACKEND_HOST_PATTERN;
+  }
+  if (!isUsablePattern(normalized)) {
+    fatalPatternOnce(
+      `degenerate:${pattern}`,
+      `${JSON.stringify(pattern)} normalizes to ${JSON.stringify(normalized)}, ` +
+        `which cannot form a parseable backend URL; falling back to the ` +
+        `default pattern ${DEFAULT_BACKEND_HOST_PATTERN}.`,
+    );
+    return DEFAULT_BACKEND_HOST_PATTERN;
+  }
   if (!normalized.includes("{slug}")) {
     warnPatternOnce(
       `no-slug:${pattern}`,
       `"${pattern}" lacks the {slug} placeholder — EVERY integration will resolve to the same backend host.`,
     );
   }
+  if (normalized.includes("/")) {
+    // The documented contract is a BARE host — an internal path segment
+    // (`host.app/base/{slug}`) violates it silently: the consumer
+    // prepends https:// and concatenates routes, so the base path lands
+    // in every backend URL. Can't fix it for the operator (the intent
+    // is ambiguous) — flag it.
+    warnPatternOnce(
+      `path:${pattern}`,
+      `"${pattern}" contains a path segment — the contract is a bare host; the path will be embedded in every backend URL.`,
+    );
+  }
   return normalized;
 }
 
+// Registry slug contract — see scripts/generate-registry.ts manifests.
+const SLUG_RE = /^[a-z0-9-]+$/;
+
 /** Substitute `{slug}` into the host pattern and prepend `https://`. */
 export function backendUrlFromPattern(pattern: string, slug: string): string {
+  // Charset assert at the choke point: every backend URL flows through
+  // here and the slug lands in the HOST of an iframe src — a slug
+  // containing "." or "/" is host/path injection. All registry slugs
+  // match [a-z0-9-]+; anything else is a contract violation upstream
+  // (call sites resolve slugs from the registry), not data.
+  if (!SLUG_RE.test(slug)) {
+    throw new Error(
+      `[backend-url] invalid integration slug ${JSON.stringify(slug)} — ` +
+        `slugs must match ${String(SLUG_RE)} (host-injection guard).`,
+    );
+  }
   // Function replacer: a plain string replacement is subject to `$`
   // substitution patterns ("$&", "$'", ...), which would corrupt the
-  // host for any slug containing `$`.
+  // host for any slug containing `$` (defense in depth behind SLUG_RE).
   return `https://${pattern.replaceAll("{slug}", () => slug)}`;
 }
 
@@ -101,11 +259,15 @@ function warnLocalBackendsOnce(key: string, message: string): void {
   console.warn(`[backend-url] NEXT_PUBLIC_LOCAL_BACKENDS ${message}`);
 }
 
+// Shared frozen empty map for the unset path — a fresh mutable {} per
+// call would dodge the freeze guarantee below.
+const NO_LOCAL_BACKENDS: Record<string, string> = Object.freeze({});
+
 // Memoized on the raw string: the env value is baked at build time and
 // effectively constant, so re-running JSON.parse on every render is
 // pure waste.
 let lastLocalBackendsRaw: string | undefined;
-let lastLocalBackends: Record<string, string> = {};
+let lastLocalBackends: Record<string, string> = NO_LOCAL_BACKENDS;
 
 /**
  * Parse the NEXT_PUBLIC_LOCAL_BACKENDS map (baked at build from
@@ -113,14 +275,18 @@ let lastLocalBackends: Record<string, string> = {};
  * Tolerant of unset/empty/corrupt values: local dev convenience must
  * never break rendering. The parse is memoized on the raw string and
  * warnings fire once per distinct (value, issue), not per call.
+ *
+ * The returned object is FROZEN: the memo is shared across every
+ * caller, so a consumer mutating its "own" map would change the
+ * local-backend overrides process-wide.
  */
 export function parseLocalBackends(
   raw: string | undefined,
 ): Record<string, string> {
-  if (!raw) return {};
+  if (!raw) return NO_LOCAL_BACKENDS;
   if (raw !== lastLocalBackendsRaw) {
     lastLocalBackendsRaw = raw;
-    lastLocalBackends = parseLocalBackendsUncached(raw);
+    lastLocalBackends = Object.freeze(parseLocalBackendsUncached(raw));
   }
   return lastLocalBackends;
 }
@@ -167,10 +333,60 @@ function parseLocalBackendsUncached(raw: string): Record<string, string> {
  * pattern.
  */
 export function resolveBackendUrl(slug: string, pattern: string): string {
+  // ASSUMPTION: the server must never SET NEXT_PUBLIC_LOCAL_BACKENDS at
+  // runtime post-build — the client bundle bakes the build-time value,
+  // so a live server-side value would silently diverge from what client
+  // components resolve.
   const local = parseLocalBackends(process.env.NEXT_PUBLIC_LOCAL_BACKENDS);
   // Length-aware: an empty-string override (e.g. `{"mastra": ""}`) is
   // not a usable URL — `??` would accept it and yield an empty base.
   const override = local[slug];
-  if (override !== undefined && override.length > 0) return override;
+  if (override !== undefined && override.length > 0) {
+    // The override lands verbatim in an iframe src — require a
+    // scheme-bearing, parseable URL (`localhost:4111` without a scheme
+    // parses as scheme "localhost:"!) whose protocol is http(s):
+    // `javascript://...` and `ftp://...` are scheme-bearing AND
+    // parseable, but have no business in an iframe src. Userinfo,
+    // query, and fragment components are rejected too (same gates the
+    // pattern path has): Chromium silently blocks credentialed iframe
+    // srcs, and a query/fragment corrupts every composed URL when
+    // consumers concatenate demo routes. Warn and fall back otherwise.
+    const parsed = parseUrl(override);
+    if (
+      parsed !== undefined &&
+      SCHEME_RE.test(override) &&
+      /^https?:$/i.test(parsed.protocol) &&
+      parsed.username === "" &&
+      parsed.password === "" &&
+      parsed.search === "" &&
+      parsed.hash === ""
+    ) {
+      // Return the parsed-normalized form (origin + path), not the raw
+      // string: the parse already happened, and the raw form leaks
+      // un-normalized values (uppercase hosts, explicit default ports)
+      // into iframe srcs. The trailing-slash trim matches the
+      // normalization the pattern path guarantees
+      // (normalizeBackendHostPattern) — an override skipping it yields
+      // `host//route` when consumers concatenate demo routes. Query,
+      // fragment, and userinfo are empty here (gated above), so
+      // origin + pathname IS the whole URL.
+      return (parsed.origin + parsed.pathname).replace(/\/+$/, "");
+    }
+    warnLocalBackendsOnce(
+      `bad-override:${slug}:${override}`,
+      `override for "${slug}" (${JSON.stringify(override)}) is not a plain ` +
+        `parseable http(s) base URL (no userinfo/query/fragment) — ignoring it.`,
+    );
+  }
   return backendUrlFromPattern(pattern, slug);
+}
+
+function parseUrl(value: string): URL | undefined {
+  // URL.canParse needs Node 18.17+/modern browsers — try/catch keeps
+  // this safe on every runtime the shell targets.
+  try {
+    return new URL(value);
+  } catch {
+    return undefined;
+  }
 }

--- a/showcase/shell/src/lib/backend-url.ts
+++ b/showcase/shell/src/lib/backend-url.ts
@@ -16,7 +16,9 @@
 // and middleware (pure functions, no next/* imports).
 
 // Matches an explicit URL scheme prefix (e.g. `https://`, `http://`).
-const SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+// Exported as the single source of truth — runtime-config.ts shares it
+// (this module is import-safe everywhere, so the dependency is free).
+export const SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
 
 // Warn once per distinct (pattern, issue) — config is re-read every
 // request, and per-request warn spam would drown real signal.
@@ -45,6 +47,16 @@ function warnPatternOnce(key: string, message: string): void {
  */
 export function normalizeBackendHostPattern(pattern: string): string {
   let normalized = pattern;
+  if (/\s/.test(normalized)) {
+    // Whitespace was the ONE misconfig class with zero warning — a
+    // pasted ` host` yields an iframe src like `https:// host`. Trim
+    // the ends (fixable); internal whitespace can only be flagged.
+    warnPatternOnce(
+      `whitespace:${pattern}`,
+      `"${pattern}" contains whitespace — trimming the ends. Internal whitespace cannot be fixed and yields a broken backend host.`,
+    );
+    normalized = normalized.trim();
+  }
   const scheme = SCHEME_RE.exec(normalized);
   if (scheme) {
     warnPatternOnce(
@@ -71,19 +83,49 @@ export function normalizeBackendHostPattern(pattern: string): string {
 
 /** Substitute `{slug}` into the host pattern and prepend `https://`. */
 export function backendUrlFromPattern(pattern: string, slug: string): string {
-  return `https://${pattern.replaceAll("{slug}", slug)}`;
+  // Function replacer: a plain string replacement is subject to `$`
+  // substitution patterns ("$&", "$'", ...), which would corrupt the
+  // host for any slug containing `$`.
+  return `https://${pattern.replaceAll("{slug}", () => slug)}`;
 }
+
+// Warn once per distinct (raw value, issue) — resolveBackendUrl runs on
+// every render, so per-call warns would spam exactly like the pattern
+// warnings the patternWarnings set above exists to prevent.
+const localBackendsWarnings = new Set<string>();
+
+function warnLocalBackendsOnce(key: string, message: string): void {
+  if (localBackendsWarnings.has(key)) return;
+  localBackendsWarnings.add(key);
+  // eslint-disable-next-line no-console
+  console.warn(`[backend-url] NEXT_PUBLIC_LOCAL_BACKENDS ${message}`);
+}
+
+// Memoized on the raw string: the env value is baked at build time and
+// effectively constant, so re-running JSON.parse on every render is
+// pure waste.
+let lastLocalBackendsRaw: string | undefined;
+let lastLocalBackends: Record<string, string> = {};
 
 /**
  * Parse the NEXT_PUBLIC_LOCAL_BACKENDS map (baked at build from
  * shared/local-ports.json — local-dev only, empty in deployed images).
  * Tolerant of unset/empty/corrupt values: local dev convenience must
- * never break rendering.
+ * never break rendering. The parse is memoized on the raw string and
+ * warnings fire once per distinct (value, issue), not per call.
  */
 export function parseLocalBackends(
   raw: string | undefined,
 ): Record<string, string> {
   if (!raw) return {};
+  if (raw !== lastLocalBackendsRaw) {
+    lastLocalBackendsRaw = raw;
+    lastLocalBackends = parseLocalBackendsUncached(raw);
+  }
+  return lastLocalBackends;
+}
+
+function parseLocalBackendsUncached(raw: string): Record<string, string> {
   try {
     const parsed = JSON.parse(raw) as unknown;
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
@@ -95,24 +137,24 @@ export function parseLocalBackends(
         if (typeof url === "string") {
           backends[slug] = url;
         } else {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `[backend-url] NEXT_PUBLIC_LOCAL_BACKENDS value for "${slug}" is not a string — skipping it.`,
+          warnLocalBackendsOnce(
+            `non-string:${slug}:${raw}`,
+            `value for "${slug}" is not a string — skipping it.`,
           );
         }
       }
       return backends;
     }
-    // eslint-disable-next-line no-console
-    console.warn(
-      "[backend-url] NEXT_PUBLIC_LOCAL_BACKENDS is not a JSON object — ignoring it.",
+    warnLocalBackendsOnce(
+      `non-object:${raw}`,
+      "is not a JSON object — ignoring it.",
     );
   } catch {
     // Treat unparseable as unset (local-dev convenience must never
     // break rendering) — but say so, instead of silently eating it.
-    // eslint-disable-next-line no-console
-    console.warn(
-      "[backend-url] NEXT_PUBLIC_LOCAL_BACKENDS is not valid JSON — ignoring it.",
+    warnLocalBackendsOnce(
+      `invalid-json:${raw}`,
+      "is not valid JSON — ignoring it.",
     );
   }
   return {};

--- a/showcase/shell/src/lib/backend-url.ts
+++ b/showcase/shell/src/lib/backend-url.ts
@@ -61,9 +61,7 @@ function fatalPatternOnce(key: string, message: string): void {
     );
   } else {
     // eslint-disable-next-line no-console
-    console.warn(
-      `[backend-url] SHOWCASE_BACKEND_HOST_PATTERN ${message}`,
-    );
+    console.warn(`[backend-url] SHOWCASE_BACKEND_HOST_PATTERN ${message}`);
   }
 }
 
@@ -137,8 +135,7 @@ function patternForbiddenComponent(normalized: string): string | undefined {
   // the first `/` — query/fragment are already rejected above) is a
   // userinfo delimiter; it is never valid inside a hostname.
   const slashAt = normalized.indexOf("/");
-  const authority =
-    slashAt === -1 ? normalized : normalized.slice(0, slashAt);
+  const authority = slashAt === -1 ? normalized : normalized.slice(0, slashAt);
   if (authority.includes("@")) return "userinfo credentials";
   return undefined;
 }

--- a/showcase/shell/src/lib/docs-redirects.test.ts
+++ b/showcase/shell/src/lib/docs-redirects.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveDocsHostRedirect } from "./docs-redirects";
+import { resolveDocsHostRedirect, resolveSeoDestination } from "./docs-redirects";
 
 const DOCS_HOST = "https://docs.showcase.copilotkit.ai";
 const SLUGS = new Set(["mastra", "agno", "langgraph-python"]);
@@ -101,6 +101,43 @@ describe("resolveDocsHostRedirect", () => {
     ).toBeNull();
     // Non-framework docs routes are unaffected by the slug set.
     expect(resolveDocsHostRedirect("/docs", DOCS_HOST, empty)).toBe(DOCS_HOST);
+  });
+
+  it("matches case-insensitively, preserving the remainder's case (SU3-A4)", () => {
+    // Parity with the removed next.config rules (path-to-regexp
+    // sensitive:false): prefixes and slugs match in any case; the
+    // destination uses the canonical lowercase prefix while the matched
+    // remainder keeps its original case (path-to-regexp param behavior).
+    expect(resolveDocsHostRedirect("/DOCS", DOCS_HOST, SLUGS)).toBe(DOCS_HOST);
+    expect(resolveDocsHostRedirect("/DOCS/Quickstart", DOCS_HOST, SLUGS)).toBe(
+      `${DOCS_HOST}/Quickstart`,
+    );
+    expect(resolveDocsHostRedirect("/AG-UI/Events", DOCS_HOST, SLUGS)).toBe(
+      `${DOCS_HOST}/ag-ui/Events`,
+    );
+    expect(resolveDocsHostRedirect("/Reference", DOCS_HOST, SLUGS)).toBe(
+      `${DOCS_HOST}/reference`,
+    );
+    expect(resolveDocsHostRedirect("/Mastra/Quickstart", DOCS_HOST, SLUGS)).toBe(
+      `${DOCS_HOST}/mastra/Quickstart`,
+    );
+    // Case-insensitivity must not loosen the prefix-lookalike guards.
+    expect(resolveDocsHostRedirect("/DOCSify", DOCS_HOST, SLUGS)).toBeNull();
+    expect(resolveDocsHostRedirect("/AG-UI-extra", DOCS_HOST, SLUGS)).toBeNull();
+  });
+
+  it("throws on an empty (post-trim) docs host instead of parsing the path AS the host (SU5-A6)", () => {
+    // "" normalizes to the origin "https://", and
+    // new URL("https:///faq") triggers WHATWG slash-skipping: "faq" is
+    // parsed as the AUTHORITY — the destination path silently becomes
+    // the redirect HOST (Location: https://faq/). Fail loudly instead;
+    // runtime-config never hands middleware an empty host, so the
+    // throw is unreachable through validated callers.
+    expect(() => resolveSeoDestination("/faq", "")).toThrow(/docs host/i);
+    expect(() => resolveSeoDestination("/faq", "///")).toThrow(/docs host/i);
+    expect(() => resolveDocsHostRedirect("/docs/x", "", SLUGS)).toThrow(
+      /docs host/i,
+    );
   });
 
   it("does NOT redirect shell-owned routes", () => {

--- a/showcase/shell/src/lib/docs-redirects.test.ts
+++ b/showcase/shell/src/lib/docs-redirects.test.ts
@@ -57,6 +57,22 @@ describe("resolveDocsHostRedirect", () => {
     );
   });
 
+  it("collapses duplicate slashes in destinations (SU-13)", () => {
+    expect(resolveDocsHostRedirect("/docs//mastra", DOCS_HOST, SLUGS)).toBe(
+      `${DOCS_HOST}/mastra`,
+    );
+    expect(resolveDocsHostRedirect("//mastra", DOCS_HOST, SLUGS)).toBe(
+      `${DOCS_HOST}/mastra`,
+    );
+    expect(resolveDocsHostRedirect("/ag-ui//events", DOCS_HOST, SLUGS)).toBe(
+      `${DOCS_HOST}/ag-ui/events`,
+    );
+    // A trailing slash on the docs host must not double up either.
+    expect(
+      resolveDocsHostRedirect("/docs/quickstart", `${DOCS_HOST}/`, SLUGS),
+    ).toBe(`${DOCS_HOST}/quickstart`);
+  });
+
   it("does NOT redirect shell-owned routes", () => {
     expect(resolveDocsHostRedirect("/", DOCS_HOST, SLUGS)).toBeNull();
     expect(

--- a/showcase/shell/src/lib/docs-redirects.test.ts
+++ b/showcase/shell/src/lib/docs-redirects.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveDocsHostRedirect, resolveSeoDestination } from "./docs-redirects";
+import {
+  resolveDocsHostRedirect,
+  resolveSeoDestination,
+} from "./docs-redirects";
 
 const DOCS_HOST = "https://docs.showcase.copilotkit.ai";
 const SLUGS = new Set(["mastra", "agno", "langgraph-python"]);
@@ -118,12 +121,14 @@ describe("resolveDocsHostRedirect", () => {
     expect(resolveDocsHostRedirect("/Reference", DOCS_HOST, SLUGS)).toBe(
       `${DOCS_HOST}/reference`,
     );
-    expect(resolveDocsHostRedirect("/Mastra/Quickstart", DOCS_HOST, SLUGS)).toBe(
-      `${DOCS_HOST}/mastra/Quickstart`,
-    );
+    expect(
+      resolveDocsHostRedirect("/Mastra/Quickstart", DOCS_HOST, SLUGS),
+    ).toBe(`${DOCS_HOST}/mastra/Quickstart`);
     // Case-insensitivity must not loosen the prefix-lookalike guards.
     expect(resolveDocsHostRedirect("/DOCSify", DOCS_HOST, SLUGS)).toBeNull();
-    expect(resolveDocsHostRedirect("/AG-UI-extra", DOCS_HOST, SLUGS)).toBeNull();
+    expect(
+      resolveDocsHostRedirect("/AG-UI-extra", DOCS_HOST, SLUGS),
+    ).toBeNull();
   });
 
   it("throws on an empty (post-trim) docs host instead of parsing the path AS the host (SU5-A6)", () => {

--- a/showcase/shell/src/lib/docs-redirects.test.ts
+++ b/showcase/shell/src/lib/docs-redirects.test.ts
@@ -73,6 +73,36 @@ describe("resolveDocsHostRedirect", () => {
     ).toBe(`${DOCS_HOST}/quickstart`);
   });
 
+  it("prepends https:// to a scheme-less docs host (SU2-A8)", () => {
+    // normalizeDocsHostOrigin's scheme-less branch: an operator can set
+    // DOCS_HOST host-only (the sibling SHOWCASE_BACKEND_HOST_PATTERN
+    // format) — destinations must still be absolute https URLs.
+    expect(
+      resolveDocsHostRedirect("/docs/quickstart", "docs.example.com", SLUGS),
+    ).toBe("https://docs.example.com/quickstart");
+    expect(resolveDocsHostRedirect("/mastra", "docs.example.com", SLUGS)).toBe(
+      "https://docs.example.com/mastra",
+    );
+    // An explicit scheme is left untouched.
+    expect(
+      resolveDocsHostRedirect("/docs", "http://localhost:3001", SLUGS),
+    ).toBe("http://localhost:3001");
+  });
+
+  it("redirects /docs/ (trailing slash, rest === '/') to the origin (SU2-A8)", () => {
+    expect(resolveDocsHostRedirect("/docs/", DOCS_HOST, SLUGS)).toBe(DOCS_HOST);
+  });
+
+  it("falls through to null for framework paths when the slug set is empty (SU2-A8)", () => {
+    const empty = new Set<string>();
+    expect(resolveDocsHostRedirect("/mastra", DOCS_HOST, empty)).toBeNull();
+    expect(
+      resolveDocsHostRedirect("/mastra/quickstart", DOCS_HOST, empty),
+    ).toBeNull();
+    // Non-framework docs routes are unaffected by the slug set.
+    expect(resolveDocsHostRedirect("/docs", DOCS_HOST, empty)).toBe(DOCS_HOST);
+  });
+
   it("does NOT redirect shell-owned routes", () => {
     expect(resolveDocsHostRedirect("/", DOCS_HOST, SLUGS)).toBeNull();
     expect(

--- a/showcase/shell/src/lib/docs-redirects.test.ts
+++ b/showcase/shell/src/lib/docs-redirects.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { resolveDocsHostRedirect } from "./docs-redirects";
+
+const DOCS_HOST = "https://docs.showcase.copilotkit.ai";
+const SLUGS = new Set(["mastra", "agno", "langgraph-python"]);
+
+describe("resolveDocsHostRedirect", () => {
+  it("redirects /docs to the docs host root (prefix stripped)", () => {
+    expect(resolveDocsHostRedirect("/docs", DOCS_HOST, SLUGS)).toBe(DOCS_HOST);
+    expect(resolveDocsHostRedirect("/docs/quickstart", DOCS_HOST, SLUGS)).toBe(
+      `${DOCS_HOST}/quickstart`,
+    );
+    expect(resolveDocsHostRedirect("/docs/guides/a/b", DOCS_HOST, SLUGS)).toBe(
+      `${DOCS_HOST}/guides/a/b`,
+    );
+  });
+
+  it("redirects /ag-ui and /reference keeping their prefix", () => {
+    expect(resolveDocsHostRedirect("/ag-ui", DOCS_HOST, SLUGS)).toBe(
+      `${DOCS_HOST}/ag-ui`,
+    );
+    expect(resolveDocsHostRedirect("/ag-ui/events", DOCS_HOST, SLUGS)).toBe(
+      `${DOCS_HOST}/ag-ui/events`,
+    );
+    expect(resolveDocsHostRedirect("/reference", DOCS_HOST, SLUGS)).toBe(
+      `${DOCS_HOST}/reference`,
+    );
+    expect(
+      resolveDocsHostRedirect(
+        "/reference/hooks/useCopilotKit",
+        DOCS_HOST,
+        SLUGS,
+      ),
+    ).toBe(`${DOCS_HOST}/reference/hooks/useCopilotKit`);
+  });
+
+  it("redirects framework-slug paths to the docs host, path preserved", () => {
+    expect(resolveDocsHostRedirect("/mastra", DOCS_HOST, SLUGS)).toBe(
+      `${DOCS_HOST}/mastra`,
+    );
+    expect(
+      resolveDocsHostRedirect(
+        "/langgraph-python/agentic-chat",
+        DOCS_HOST,
+        SLUGS,
+      ),
+    ).toBe(`${DOCS_HOST}/langgraph-python/agentic-chat`);
+  });
+
+  it("uses the provided (runtime) docs host — staging host wires through", () => {
+    const staging = "https://docs-staging.example.com";
+    expect(resolveDocsHostRedirect("/docs/quickstart", staging, SLUGS)).toBe(
+      `${staging}/quickstart`,
+    );
+    expect(resolveDocsHostRedirect("/mastra", staging, SLUGS)).toBe(
+      `${staging}/mastra`,
+    );
+  });
+
+  it("does NOT redirect shell-owned routes", () => {
+    expect(resolveDocsHostRedirect("/", DOCS_HOST, SLUGS)).toBeNull();
+    expect(
+      resolveDocsHostRedirect("/integrations", DOCS_HOST, SLUGS),
+    ).toBeNull();
+    expect(
+      resolveDocsHostRedirect("/integrations/mastra", DOCS_HOST, SLUGS),
+    ).toBeNull();
+    expect(resolveDocsHostRedirect("/matrix", DOCS_HOST, SLUGS)).toBeNull();
+    // Prefix lookalikes must not match (/docsify is not /docs/...).
+    expect(resolveDocsHostRedirect("/docsify", DOCS_HOST, SLUGS)).toBeNull();
+    expect(
+      resolveDocsHostRedirect("/ag-ui-extra", DOCS_HOST, SLUGS),
+    ).toBeNull();
+    expect(resolveDocsHostRedirect("/references", DOCS_HOST, SLUGS)).toBeNull();
+  });
+});

--- a/showcase/shell/src/lib/docs-redirects.ts
+++ b/showcase/shell/src/lib/docs-redirects.ts
@@ -3,7 +3,7 @@
 // These permanent (308) redirects used to live in next.config.ts
 // `redirects()` (`permanent: true` emits 308), which bakes
 // the destination host into the build artifact (`DOCS_HOST` was a
-// hardcoded const) — so a staging shell 301'd docs routes to the PROD
+// hardcoded const) — so a staging shell 308'd docs routes to the PROD
 // docs host (cross-origin RSC prefetch → CORS). The table now resolves
 // per-request in middleware against the runtime `docsHost` from
 // RuntimeConfig (env var DOCS_HOST, default = the prod host).
@@ -25,9 +25,10 @@ const KEPT_PREFIXES = ["/ag-ui", "/reference"] as const;
 /**
  * Normalize a destination path: collapse runs of slashes and strip a
  * trailing slash (root "/" survives). Collapsing the LEADING run is
- * security-relevant — a path like `//evil.com` is scheme-relative when
- * handed to `new URL()` and would redirect off-site (see the
- * middleware's SEO wildcard substitution).
+ * defense-in-depth plus cosmetics: at every call site the path is
+ * appended AFTER a fixed `https://<docs-host>` origin, so a leading
+ * `//` can never be parsed as a scheme-relative URL — it would only
+ * produce an ugly double-slash path on a host we own.
  */
 export function normalizeRedirectPath(path: string): string {
   let normalized = path.replace(/\/{2,}/g, "/");

--- a/showcase/shell/src/lib/docs-redirects.ts
+++ b/showcase/shell/src/lib/docs-redirects.ts
@@ -1,6 +1,7 @@
 // Docs-host redirect resolution — shared by middleware.
 //
-// These 301s used to live in next.config.ts `redirects()`, which bakes
+// These permanent (308) redirects used to live in next.config.ts
+// `redirects()` (`permanent: true` emits 308), which bakes
 // the destination host into the build artifact (`DOCS_HOST` was a
 // hardcoded const) — so a staging shell 301'd docs routes to the PROD
 // docs host (cross-origin RSC prefetch → CORS). The table now resolves
@@ -22,6 +23,45 @@
 const KEPT_PREFIXES = ["/ag-ui", "/reference"] as const;
 
 /**
+ * Normalize a destination path: collapse runs of slashes and strip a
+ * trailing slash (root "/" survives). Collapsing the LEADING run is
+ * security-relevant — a path like `//evil.com` is scheme-relative when
+ * handed to `new URL()` and would redirect off-site (see the
+ * middleware's SEO wildcard substitution).
+ */
+export function normalizeRedirectPath(path: string): string {
+  let normalized = path.replace(/\/{2,}/g, "/");
+  if (normalized.length > 1 && normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+/**
+ * Defensive docs-host normalization: strip trailing slashes and ensure
+ * a scheme so `new URL(...)` consumers never throw or emit
+ * scheme-relative URLs if the runtime config hands us a bare host.
+ */
+function normalizeDocsHostOrigin(docsHost: string): string {
+  const trimmed = docsHost.replace(/\/+$/, "");
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+}
+
+/**
+ * Resolve an SEO-table destination path (which targets the DOCS routing
+ * surface) to an absolute URL on the docs host.
+ */
+export function resolveSeoDestination(
+  destinationPath: string,
+  docsHost: string,
+): URL {
+  const origin = normalizeDocsHostOrigin(docsHost);
+  return new URL(`${origin}${normalizeRedirectPath(destinationPath)}`);
+}
+
+/**
  * Returns the absolute destination URL (without query string) when
  * `pathname` belongs to the docs shell, or `null` when the path is
  * shell-owned and must fall through to normal handling.
@@ -31,16 +71,19 @@ export function resolveDocsHostRedirect(
   docsHost: string,
   frameworkSlugs: ReadonlySet<string>,
 ): string | null {
+  const origin = normalizeDocsHostOrigin(docsHost);
+
   // /docs → docs-host root; /docs/x → docs-host /x (prefix stripped).
-  if (pathname === "/docs") return docsHost;
+  if (pathname === "/docs") return origin;
   if (pathname.startsWith("/docs/")) {
-    return `${docsHost}${pathname.slice("/docs".length)}`;
+    const rest = normalizeRedirectPath(pathname.slice("/docs".length));
+    return rest === "/" ? origin : `${origin}${rest}`;
   }
 
   // /ag-ui and /reference keep their prefix on the docs host.
   for (const prefix of KEPT_PREFIXES) {
     if (pathname === prefix || pathname.startsWith(`${prefix}/`)) {
-      return `${docsHost}${pathname}`;
+      return `${origin}${normalizeRedirectPath(pathname)}`;
     }
   }
 
@@ -48,7 +91,7 @@ export function resolveDocsHostRedirect(
   // must exactly match a registry slug.
   const first = pathname.split("/").filter(Boolean)[0];
   if (first && frameworkSlugs.has(first)) {
-    return `${docsHost}${pathname}`;
+    return `${origin}${normalizeRedirectPath(pathname)}`;
   }
 
   return null;

--- a/showcase/shell/src/lib/docs-redirects.ts
+++ b/showcase/shell/src/lib/docs-redirects.ts
@@ -1,0 +1,55 @@
+// Docs-host redirect resolution — shared by middleware.
+//
+// These 301s used to live in next.config.ts `redirects()`, which bakes
+// the destination host into the build artifact (`DOCS_HOST` was a
+// hardcoded const) — so a staging shell 301'd docs routes to the PROD
+// docs host (cross-origin RSC prefetch → CORS). The table now resolves
+// per-request in middleware against the runtime `docsHost` from
+// RuntimeConfig (env var DOCS_HOST, default = the prod host).
+//
+// Route semantics are copied 1:1 from the removed next.config rules:
+//   /docs            -> <docsHost>            (prefix STRIPPED — the
+//   /docs/:path*     -> <docsHost>/:path*      docs shell serves at root)
+//   /ag-ui[/:path*]  -> <docsHost>/ag-ui[/:path*]      (prefix kept)
+//   /reference[/:path*] -> <docsHost>/reference[/:path*] (prefix kept)
+//   /<slug>[/:path*] -> <docsHost>/<slug>[/:path*]  for every registry
+//     framework slug — enumerated (not a wildcard) so shell-owned
+//     routes like /integrations and /matrix are never hijacked.
+//
+// Pure function, Edge-safe (no next/* imports).
+
+/** Prefixes forwarded with the prefix KEPT on the destination path. */
+const KEPT_PREFIXES = ["/ag-ui", "/reference"] as const;
+
+/**
+ * Returns the absolute destination URL (without query string) when
+ * `pathname` belongs to the docs shell, or `null` when the path is
+ * shell-owned and must fall through to normal handling.
+ */
+export function resolveDocsHostRedirect(
+  pathname: string,
+  docsHost: string,
+  frameworkSlugs: ReadonlySet<string>,
+): string | null {
+  // /docs → docs-host root; /docs/x → docs-host /x (prefix stripped).
+  if (pathname === "/docs") return docsHost;
+  if (pathname.startsWith("/docs/")) {
+    return `${docsHost}${pathname.slice("/docs".length)}`;
+  }
+
+  // /ag-ui and /reference keep their prefix on the docs host.
+  for (const prefix of KEPT_PREFIXES) {
+    if (pathname === prefix || pathname.startsWith(`${prefix}/`)) {
+      return `${docsHost}${pathname}`;
+    }
+  }
+
+  // Framework-scoped routes: /<slug> and /<slug>/... — first segment
+  // must exactly match a registry slug.
+  const first = pathname.split("/").filter(Boolean)[0];
+  if (first && frameworkSlugs.has(first)) {
+    return `${docsHost}${pathname}`;
+  }
+
+  return null;
+}

--- a/showcase/shell/src/lib/docs-redirects.ts
+++ b/showcase/shell/src/lib/docs-redirects.ts
@@ -17,7 +17,10 @@
 //     framework slug — enumerated (not a wildcard) so shell-owned
 //     routes like /integrations and /matrix are never hijacked.
 //
-// Pure function, Edge-safe (no next/* imports).
+// Pure functions, Edge-safe (no next/* imports — backend-url is also
+// next-free; middleware already runs it on the Edge).
+
+import { SCHEME_RE } from "./backend-url";
 
 /** Prefixes forwarded with the prefix KEPT on the destination path. */
 const KEPT_PREFIXES = ["/ag-ui", "/reference"] as const;
@@ -40,14 +43,30 @@ export function normalizeRedirectPath(path: string): string {
 
 /**
  * Defensive docs-host normalization: strip trailing slashes and ensure
- * a scheme so `new URL(...)` consumers never throw or emit
- * scheme-relative URLs if the runtime config hands us a bare host.
+ * a scheme. For VALIDATED hosts (everything runtime-config hands
+ * middleware) the `new URL(...)` consumers never throw or emit
+ * scheme-relative URLs even when the value is a bare host. An
+ * empty-post-trim host THROWS instead (SU5-A6): "" would normalize to
+ * the origin "https://", and `new URL("https:///faq")` triggers WHATWG
+ * slash-skipping — the destination PATH gets parsed as the authority,
+ * silently redirecting to https://faq/. Unreachable through
+ * runtime-config-validated callers; fail loud for any future raw one.
  */
 function normalizeDocsHostOrigin(docsHost: string): string {
   const trimmed = docsHost.replace(/\/+$/, "");
-  return /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)
-    ? trimmed
-    : `https://${trimmed}`;
+  if (trimmed === "") {
+    throw new Error(
+      `[docs-redirects] docs host is empty after trimming (${JSON.stringify(
+        docsHost,
+      )}) — refusing to compose a redirect origin: "https://" + a path ` +
+        "would let WHATWG slash-skipping parse the destination path as " +
+        "the redirect host.",
+    );
+  }
+  // SCHEME_RE is the shared scheme detector from backend-url (SU4-A6) —
+  // the same test middleware's normalizePosthogHost uses; an inline
+  // copy here had already drifted into a maintenance trap.
+  return SCHEME_RE.test(trimmed) ? trimmed : `https://${trimmed}`;
 }
 
 /**
@@ -66,6 +85,12 @@ export function resolveSeoDestination(
  * Returns the absolute destination URL (without query string) when
  * `pathname` belongs to the docs shell, or `null` when the path is
  * shell-owned and must fall through to normal handling.
+ *
+ * Leading-slash runs are collapsed in ONE place — middleware()
+ * (SU4-A3) — so `pathname` arrives with a single leading "/". The
+ * framework-slug branch's /^\/+/ regex below still tolerates runs as
+ * defense-in-depth for other callers, but the ===/startsWith prefix
+ * branches deliberately do NOT re-normalize.
  */
 export function resolveDocsHostRedirect(
   pathname: string,
@@ -74,25 +99,38 @@ export function resolveDocsHostRedirect(
 ): string | null {
   const origin = normalizeDocsHostOrigin(docsHost);
 
+  // Case-insensitive matching (SU3-A4): parity with the removed
+  // next.config rules (path-to-regexp sensitive:false). Prefixes and
+  // slugs match in any case; the destination uses the canonical
+  // lowercase prefix/slug literal while the matched remainder keeps the
+  // ORIGINAL case (exactly what a path-to-regexp :path* param did).
+  // toLowerCase() is length-preserving on the ASCII pathnames Next
+  // hands us, so positional slicing against `pathname` is safe.
+  const lower = pathname.toLowerCase();
+
   // /docs → docs-host root; /docs/x → docs-host /x (prefix stripped).
-  if (pathname === "/docs") return origin;
-  if (pathname.startsWith("/docs/")) {
+  if (lower === "/docs") return origin;
+  if (lower.startsWith("/docs/")) {
     const rest = normalizeRedirectPath(pathname.slice("/docs".length));
     return rest === "/" ? origin : `${origin}${rest}`;
   }
 
   // /ag-ui and /reference keep their prefix on the docs host.
   for (const prefix of KEPT_PREFIXES) {
-    if (pathname === prefix || pathname.startsWith(`${prefix}/`)) {
-      return `${origin}${normalizeRedirectPath(pathname)}`;
+    if (lower === prefix || lower.startsWith(`${prefix}/`)) {
+      return `${origin}${normalizeRedirectPath(prefix + pathname.slice(prefix.length))}`;
     }
   }
 
   // Framework-scoped routes: /<slug> and /<slug>/... — first segment
-  // must exactly match a registry slug.
-  const first = pathname.split("/").filter(Boolean)[0];
+  // must exactly match a registry slug (registry slugs are canonical
+  // lowercase). Match on the lowercased segment; forward the lowercase
+  // slug + original-case remainder.
+  const segmentMatch = /^\/+([^/]+)/.exec(lower);
+  const first = segmentMatch?.[1];
   if (first && frameworkSlugs.has(first)) {
-    return `${origin}${normalizeRedirectPath(pathname)}`;
+    const rest = pathname.slice(segmentMatch[0].length);
+    return `${origin}${normalizeRedirectPath(`/${first}${rest}`)}`;
   }
 
   return null;

--- a/showcase/shell/src/lib/local-backends-env.test.ts
+++ b/showcase/shell/src/lib/local-backends-env.test.ts
@@ -1,0 +1,227 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { localBackendsEnv } from "./local-backends-env";
+
+describe("localBackendsEnv (next.config build-time helper)", () => {
+  let dir: string;
+  let portsPath: string;
+  let warns: string[];
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "local-backends-env-"));
+    portsPath = path.join(dir, "local-ports.json");
+    vi.stubEnv("SHOWCASE_LOCAL", "1");
+    warns = [];
+    warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation((m: string) => void warns.push(m));
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    vi.unstubAllEnvs();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns '' without touching the file when SHOWCASE_LOCAL is not 1", () => {
+    vi.stubEnv("SHOWCASE_LOCAL", "");
+    expect(localBackendsEnv(portsPath)).toBe("");
+    expect(warns).toEqual([]);
+  });
+
+  it("stays silent for unset AND blank/whitespace-only SHOWCASE_LOCAL (both mean off)", () => {
+    // Unset (never exported) and blank (`SHOWCASE_LOCAL= npm run build`
+    // to explicitly disable) are both deliberate "off" states — neither
+    // reads the ports file or logs anything.
+    for (const off of [undefined, "", "  \t"]) {
+      warns.length = 0;
+      vi.stubEnv("SHOWCASE_LOCAL", off);
+      expect(
+        localBackendsEnv(portsPath),
+        `SHOWCASE_LOCAL=${JSON.stringify(off)} should be silent off`,
+      ).toBe("");
+      expect(warns).toEqual([]);
+    }
+  });
+
+  it("warns (naming the value) when SHOWCASE_LOCAL is set to something other than '1'", () => {
+    // A developer exporting SHOWCASE_LOCAL=true (or =yes, or =0)
+    // believes they toggled local backends — the strict "1" contract
+    // made that a silent no-op ("why are my local backends not
+    // wired?" with zero signal). Set-but-not-"1" must warn; the value
+    // is still treated as off.
+    for (const bad of ["true", "yes", "0"]) {
+      warns.length = 0;
+      vi.stubEnv("SHOWCASE_LOCAL", bad);
+      expect(localBackendsEnv(portsPath)).toBe("");
+      expect(
+        warns.some(
+          (m) =>
+            m.includes("SHOWCASE_LOCAL") && m.includes(JSON.stringify(bad)),
+        ),
+        `SHOWCASE_LOCAL=${JSON.stringify(bad)} should warn naming the value`,
+      ).toBe(true);
+    }
+  });
+
+  it("treats a whitespace-padded '1' as enabled (paste-artifact tolerance)", () => {
+    // Same whitespace tolerance runtime-config.ts applies to every env
+    // value (readEnvPair trims) — `SHOWCASE_LOCAL=" 1"` previously
+    // failed the strict !== "1" gate and silently disabled local
+    // backends.
+    vi.stubEnv("SHOWCASE_LOCAL", " 1\t");
+    fs.writeFileSync(portsPath, JSON.stringify({ mastra: 3104 }));
+    expect(JSON.parse(localBackendsEnv(portsPath))).toEqual({
+      mastra: "http://localhost:3104",
+    });
+    expect(warns).toEqual([]);
+  });
+
+  it("maps slugs to localhost URLs for valid integer ports", () => {
+    fs.writeFileSync(portsPath, JSON.stringify({ mastra: 3104, agno: 3109 }));
+    expect(JSON.parse(localBackendsEnv(portsPath))).toEqual({
+      mastra: "http://localhost:3104",
+      agno: "http://localhost:3109",
+    });
+    expect(warns).toEqual([]);
+  });
+
+  it("warns loudly (naming the path) when SHOWCASE_LOCAL=1 but the file is missing", () => {
+    // The developer explicitly opted in — a silent '' here means "why
+    // are my local backends not wired?" with zero signal, while corrupt
+    // JSON in the same file THROWS. Missing must be loud too.
+    expect(localBackendsEnv(portsPath)).toBe("");
+    expect(warns.some((m) => m.includes(portsPath))).toBe(true);
+  });
+
+  it("THROWS (naming the slug) on non-integer and out-of-range ports (3.5 / 0 / -1 / 99999)", () => {
+    // This runs at BUILD time — the file's stated fail-loud posture is
+    // that throwing IS the loud path. A warn+skip silently shipped a
+    // build with that integration's override missing.
+    for (const [slug, port] of [
+      ["frac", 3.5],
+      ["zero", 0],
+      ["neg", -1],
+      ["huge", 99999],
+    ] as const) {
+      fs.writeFileSync(portsPath, JSON.stringify({ [slug]: port, ok: 3104 }));
+      expect(
+        () => localBackendsEnv(portsPath),
+        `port ${port} for "${slug}" should throw`,
+      ).toThrow(new RegExp(`"${slug}"`));
+    }
+    // Boundary values stay valid.
+    fs.writeFileSync(portsPath, JSON.stringify({ ok: 65535, low: 1 }));
+    expect(JSON.parse(localBackendsEnv(portsPath))).toEqual({
+      ok: "http://localhost:65535",
+      low: "http://localhost:1",
+    });
+  });
+
+  it("THROWS (naming the slug) on non-number port values", () => {
+    fs.writeFileSync(portsPath, JSON.stringify({ str: "3104", ok: 3104 }));
+    expect(() => localBackendsEnv(portsPath)).toThrow(/"str"/);
+  });
+
+  it("throws (naming the path) on corrupt JSON", () => {
+    fs.writeFileSync(portsPath, "{not json");
+    expect(() => localBackendsEnv(portsPath)).toThrow(portsPath);
+  });
+
+  it("labels an unreadable file as a read failure, not as invalid JSON", () => {
+    // fs.readFileSync used to live INSIDE the JSON.parse try — an
+    // EACCES surfaced as "<path> is not valid JSON", sending the
+    // developer to inspect a file's syntax when the problem is its
+    // permissions.
+    fs.writeFileSync(portsPath, "{}");
+    fs.chmodSync(portsPath, 0o000);
+    try {
+      let thrown: unknown;
+      try {
+        localBackendsEnv(portsPath);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(Error);
+      const message = (thrown as Error).message;
+      expect(message).toContain(portsPath);
+      expect(message).toContain("could not be read");
+      expect(message).not.toContain("not valid JSON");
+    } finally {
+      fs.chmodSync(portsPath, 0o600);
+    }
+  });
+
+  it("labels an unsearchable parent directory as a read failure, not as a missing file", () => {
+    // fs.existsSync returns false for EACCES on the parent directory —
+    // the old guard masked a permissions problem as "file does not
+    // exist", defeating the labeled-throw design the read/parse split
+    // exists for. The direct-read ENOENT branch keeps missing-file
+    // semantics while every OTHER read error throws with its real cause.
+    fs.writeFileSync(portsPath, "{}");
+    fs.chmodSync(dir, 0o000);
+    try {
+      let thrown: unknown;
+      try {
+        localBackendsEnv(portsPath);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(Error);
+      const message = (thrown as Error).message;
+      expect(message).toContain(portsPath);
+      expect(message).toContain("could not be read");
+      // It must NOT have taken the missing-file warn path.
+      expect(warns.some((m) => m.includes("does not exist"))).toBe(false);
+    } finally {
+      fs.chmodSync(dir, 0o700);
+    }
+  });
+
+  it("warns (naming the key) on slugs that violate the [a-z0-9-]+ contract", () => {
+    // Registry slugs are [a-z0-9-]+ (see backend-url.ts SLUG_RE) — a
+    // key like "Mastra" can never match an integration slug, so its
+    // override is a silent no-op at runtime. Warn at build time.
+    fs.writeFileSync(
+      portsPath,
+      JSON.stringify({ Mastra: 3104, under_score: 3105, ok: 3106 }),
+    );
+    const out = JSON.parse(localBackendsEnv(portsPath)) as Record<
+      string,
+      string
+    >;
+    expect(out.ok).toBe("http://localhost:3106");
+    expect(warns.some((m) => m.includes('"Mastra"'))).toBe(true);
+    expect(warns.some((m) => m.includes('"under_score"'))).toBe(true);
+    // A contract-conforming map stays silent.
+    warns.length = 0;
+    fs.writeFileSync(portsPath, JSON.stringify({ "langgraph-python": 3104 }));
+    localBackendsEnv(portsPath);
+    expect(warns).toEqual([]);
+  });
+
+  it("warns loudly when SHOWCASE_LOCAL=1 in a production build (localhost targets in a prod image)", () => {
+    // `next build` runs with NODE_ENV=production — refusing outright
+    // would break the documented local production-build flow, but a
+    // silent pass bakes localhost iframe targets into an image that
+    // must never deploy. Loud warn.
+    vi.stubEnv("NODE_ENV", "production");
+    fs.writeFileSync(portsPath, JSON.stringify({ mastra: 3104 }));
+    expect(JSON.parse(localBackendsEnv(portsPath))).toEqual({
+      mastra: "http://localhost:3104",
+    });
+    expect(
+      warns.some(
+        (m) => m.includes("SHOWCASE_LOCAL") && m.includes("production"),
+      ),
+    ).toBe(true);
+  });
+
+  it("throws (naming the path) on a non-object top level", () => {
+    fs.writeFileSync(portsPath, "[1,2]");
+    expect(() => localBackendsEnv(portsPath)).toThrow(portsPath);
+  });
+});

--- a/showcase/shell/src/lib/local-backends-env.test.ts
+++ b/showcase/shell/src/lib/local-backends-env.test.ts
@@ -26,7 +26,11 @@ describe("localBackendsEnv (next.config build-time helper)", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("returns '' without touching the file when SHOWCASE_LOCAL is not 1", () => {
+  it("returns '' silently (file untouched) when SHOWCASE_LOCAL is explicitly blank", () => {
+    // Blank is a deliberate "off" state and stays SILENT — a non-blank
+    // value other than "1" warns instead (see the dedicated test
+    // below), so the old "is not 1" title misdescribed what this
+    // covers. No missing-file warn = the ports file was never read.
     vi.stubEnv("SHOWCASE_LOCAL", "");
     expect(localBackendsEnv(portsPath)).toBe("");
     expect(warns).toEqual([]);
@@ -131,7 +135,12 @@ describe("localBackendsEnv (next.config build-time helper)", () => {
     expect(() => localBackendsEnv(portsPath)).toThrow(portsPath);
   });
 
-  it("labels an unreadable file as a read failure, not as invalid JSON", () => {
+  // chmod-based denial tests are meaningless as root (root bypasses
+  // permission bits, so the read SUCCEEDS and the assertions fail for
+  // a reason unrelated to the code under test) — skip them there.
+  const runningAsRoot = process.getuid?.() === 0;
+
+  it.skipIf(runningAsRoot)("labels an unreadable file as a read failure, not as invalid JSON", () => {
     // fs.readFileSync used to live INSIDE the JSON.parse try — an
     // EACCES surfaced as "<path> is not valid JSON", sending the
     // developer to inspect a file's syntax when the problem is its
@@ -155,7 +164,7 @@ describe("localBackendsEnv (next.config build-time helper)", () => {
     }
   });
 
-  it("labels an unsearchable parent directory as a read failure, not as a missing file", () => {
+  it.skipIf(runningAsRoot)("labels an unsearchable parent directory as a read failure, not as a missing file", () => {
     // fs.existsSync returns false for EACCES on the parent directory —
     // the old guard masked a permissions problem as "file does not
     // exist", defeating the labeled-throw design the read/parse split
@@ -193,7 +202,14 @@ describe("localBackendsEnv (next.config build-time helper)", () => {
       string,
       string
     >;
-    expect(out.ok).toBe("http://localhost:3106");
+    // Pin the include-vs-skip behavior: warn-only entries are still
+    // EMITTED (the warn says "can never apply", not "dropped") — a
+    // silent skip here would contradict the warn text.
+    expect(out).toEqual({
+      Mastra: "http://localhost:3104",
+      under_score: "http://localhost:3105",
+      ok: "http://localhost:3106",
+    });
     expect(warns.some((m) => m.includes('"Mastra"'))).toBe(true);
     expect(warns.some((m) => m.includes('"under_score"'))).toBe(true);
     // A contract-conforming map stays silent.
@@ -201,6 +217,23 @@ describe("localBackendsEnv (next.config build-time helper)", () => {
     fs.writeFileSync(portsPath, JSON.stringify({ "langgraph-python": 3104 }));
     localBackendsEnv(portsPath);
     expect(warns).toEqual([]);
+  });
+
+  it("emits a __proto__ key as map data instead of silently dropping it", () => {
+    // The accumulator was a plain `{}` — `map["__proto__"] = ...` hits
+    // the Object.prototype setter and is a silent no-op, so the entry
+    // vanished from the emitted JSON even though the slug-contract warn
+    // fired. A null-prototype accumulator makes it an ordinary own
+    // property (and the [a-z0-9-]+ warn still flags it).
+    fs.writeFileSync(portsPath, '{"__proto__": 3104, "ok": 3105}');
+    const out = JSON.parse(localBackendsEnv(portsPath)) as Record<
+      string,
+      string
+    >;
+    expect(Object.keys(out)).toContain("__proto__");
+    expect(out["__proto__"]).toBe("http://localhost:3104");
+    expect(out.ok).toBe("http://localhost:3105");
+    expect(warns.some((m) => m.includes('"__proto__"'))).toBe(true);
   });
 
   it("warns loudly when SHOWCASE_LOCAL=1 in a production build (localhost targets in a prod image)", () => {

--- a/showcase/shell/src/lib/local-backends-env.test.ts
+++ b/showcase/shell/src/lib/local-backends-env.test.ts
@@ -140,55 +140,61 @@ describe("localBackendsEnv (next.config build-time helper)", () => {
   // a reason unrelated to the code under test) — skip them there.
   const runningAsRoot = process.getuid?.() === 0;
 
-  it.skipIf(runningAsRoot)("labels an unreadable file as a read failure, not as invalid JSON", () => {
-    // fs.readFileSync used to live INSIDE the JSON.parse try — an
-    // EACCES surfaced as "<path> is not valid JSON", sending the
-    // developer to inspect a file's syntax when the problem is its
-    // permissions.
-    fs.writeFileSync(portsPath, "{}");
-    fs.chmodSync(portsPath, 0o000);
-    try {
-      let thrown: unknown;
+  it.skipIf(runningAsRoot)(
+    "labels an unreadable file as a read failure, not as invalid JSON",
+    () => {
+      // fs.readFileSync used to live INSIDE the JSON.parse try — an
+      // EACCES surfaced as "<path> is not valid JSON", sending the
+      // developer to inspect a file's syntax when the problem is its
+      // permissions.
+      fs.writeFileSync(portsPath, "{}");
+      fs.chmodSync(portsPath, 0o000);
       try {
-        localBackendsEnv(portsPath);
-      } catch (err) {
-        thrown = err;
+        let thrown: unknown;
+        try {
+          localBackendsEnv(portsPath);
+        } catch (err) {
+          thrown = err;
+        }
+        expect(thrown).toBeInstanceOf(Error);
+        const message = (thrown as Error).message;
+        expect(message).toContain(portsPath);
+        expect(message).toContain("could not be read");
+        expect(message).not.toContain("not valid JSON");
+      } finally {
+        fs.chmodSync(portsPath, 0o600);
       }
-      expect(thrown).toBeInstanceOf(Error);
-      const message = (thrown as Error).message;
-      expect(message).toContain(portsPath);
-      expect(message).toContain("could not be read");
-      expect(message).not.toContain("not valid JSON");
-    } finally {
-      fs.chmodSync(portsPath, 0o600);
-    }
-  });
+    },
+  );
 
-  it.skipIf(runningAsRoot)("labels an unsearchable parent directory as a read failure, not as a missing file", () => {
-    // fs.existsSync returns false for EACCES on the parent directory —
-    // the old guard masked a permissions problem as "file does not
-    // exist", defeating the labeled-throw design the read/parse split
-    // exists for. The direct-read ENOENT branch keeps missing-file
-    // semantics while every OTHER read error throws with its real cause.
-    fs.writeFileSync(portsPath, "{}");
-    fs.chmodSync(dir, 0o000);
-    try {
-      let thrown: unknown;
+  it.skipIf(runningAsRoot)(
+    "labels an unsearchable parent directory as a read failure, not as a missing file",
+    () => {
+      // fs.existsSync returns false for EACCES on the parent directory —
+      // the old guard masked a permissions problem as "file does not
+      // exist", defeating the labeled-throw design the read/parse split
+      // exists for. The direct-read ENOENT branch keeps missing-file
+      // semantics while every OTHER read error throws with its real cause.
+      fs.writeFileSync(portsPath, "{}");
+      fs.chmodSync(dir, 0o000);
       try {
-        localBackendsEnv(portsPath);
-      } catch (err) {
-        thrown = err;
+        let thrown: unknown;
+        try {
+          localBackendsEnv(portsPath);
+        } catch (err) {
+          thrown = err;
+        }
+        expect(thrown).toBeInstanceOf(Error);
+        const message = (thrown as Error).message;
+        expect(message).toContain(portsPath);
+        expect(message).toContain("could not be read");
+        // It must NOT have taken the missing-file warn path.
+        expect(warns.some((m) => m.includes("does not exist"))).toBe(false);
+      } finally {
+        fs.chmodSync(dir, 0o700);
       }
-      expect(thrown).toBeInstanceOf(Error);
-      const message = (thrown as Error).message;
-      expect(message).toContain(portsPath);
-      expect(message).toContain("could not be read");
-      // It must NOT have taken the missing-file warn path.
-      expect(warns.some((m) => m.includes("does not exist"))).toBe(false);
-    } finally {
-      fs.chmodSync(dir, 0o700);
-    }
-  });
+    },
+  );
 
   it("warns (naming the key) on slugs that violate the [a-z0-9-]+ contract", () => {
     // Registry slugs are [a-z0-9-]+ (see backend-url.ts SLUG_RE) — a

--- a/showcase/shell/src/lib/local-backends-env.ts
+++ b/showcase/shell/src/lib/local-backends-env.ts
@@ -97,7 +97,12 @@ export function localBackendsEnv(portsPath: string): string {
         `${Array.isArray(parsed) ? "an array" : typeof parsed}).`,
     );
   }
-  const map: Record<string, string> = {};
+  // Null-prototype accumulator: on a plain `{}`, a "__proto__" key in
+  // the ports file would hit the Object.prototype setter — a silent
+  // no-op that drops the entry from the emitted JSON even though the
+  // slug-contract warn below fires. With no prototype it lands as an
+  // ordinary own data property (JSON.stringify serializes it fine).
+  const map: Record<string, string> = Object.create(null);
   for (const [slug, port] of Object.entries(parsed)) {
     // Registry slugs are [a-z0-9-]+ (see lib/backend-url.ts SLUG_RE) —
     // a key outside that contract can never match an integration slug,

--- a/showcase/shell/src/lib/local-backends-env.ts
+++ b/showcase/shell/src/lib/local-backends-env.ts
@@ -1,0 +1,133 @@
+// Build-time helper for next.config.ts: computes the
+// NEXT_PUBLIC_LOCAL_BACKENDS env value from shared/local-ports.json when
+// SHOWCASE_LOCAL=1 (local-dev only — deployed images bake "").
+//
+// Extracted from next.config.ts so the logic is unit-testable (vitest
+// only includes src/**); next.config.ts imports it and passes the real
+// ports path. Node-only (fs/path) — never import from app/middleware
+// code.
+
+import fs from "fs";
+
+/**
+ * Returns the JSON string to bake into NEXT_PUBLIC_LOCAL_BACKENDS, or
+ * "" when local backends are not in play.
+ *
+ * Failure posture (this runs at BUILD time, so throwing IS the loud
+ * path): an unreadable file, corrupt JSON, a non-object top level, or
+ * an invalid port all throw, naming the file (read failures and parse
+ * failures are labeled distinctly — an EACCES is not a syntax error).
+ * A MISSING file with SHOWCASE_LOCAL=1 set warns instead of silently
+ * returning "" — the developer explicitly opted in, so "why are my
+ * local backends not wired?" must have a signal. SHOWCASE_LOCAL=1
+ * combined with NODE_ENV=production warns loudly: it bakes localhost
+ * iframe targets into the image, which must never deploy (not a throw
+ * — `next build` always sets NODE_ENV=production, so refusing would
+ * break the documented local production-build flow).
+ */
+export function localBackendsEnv(portsPath: string): string {
+  // Unset-vs-blank distinction: unset (never exported) and
+  // blank/whitespace-only (`SHOWCASE_LOCAL= npm run build` to
+  // explicitly disable) are BOTH deliberate "off" states and stay
+  // silent. The value is trimmed before the comparison — the same
+  // paste-artifact tolerance runtime-config.ts applies to every env
+  // value — so `SHOWCASE_LOCAL=" 1"` still opts in instead of
+  // silently disabling local backends.
+  const rawLocal = process.env.SHOWCASE_LOCAL;
+  const showcaseLocal = rawLocal === undefined ? "" : rawLocal.trim();
+  if (showcaseLocal !== "1") {
+    // Set to a non-blank value other than "1" ("true", "yes", "0", …):
+    // the developer believes they toggled local backends, but only "1"
+    // opts in — a silent no-op here is exactly the "why are my local
+    // backends not wired?" zero-signal failure the missing-file warn
+    // below exists to prevent. Warn, treat as off.
+    if (showcaseLocal !== "") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[next.config] SHOWCASE_LOCAL is set to ${JSON.stringify(rawLocal)} ` +
+          `but only "1" enables local backend overrides — treating it as ` +
+          `off. Set SHOWCASE_LOCAL=1 (or unset it).`,
+      );
+    }
+    return "";
+  }
+  if (process.env.NODE_ENV === "production") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[next.config] SHOWCASE_LOCAL=1 in a production build — localhost ` +
+        `backend overrides will be baked into this image. NEVER deploy it; ` +
+        `unset SHOWCASE_LOCAL for deployable builds.`,
+    );
+  }
+  // Read directly and branch on ENOENT instead of a separate existsSync
+  // guard: existsSync returns false for an EACCES on the parent
+  // directory too, which masked a permissions problem as "missing file"
+  // — defeating the labeled-throw design the read/parse split exists
+  // for. The read also stays OUTSIDE the parse try: an EACCES inside it
+  // was mislabeled "not valid JSON", sending the developer to inspect
+  // the file's syntax when the problem is its permissions.
+  let rawText: string;
+  try {
+    rawText = fs.readFileSync(portsPath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[next.config] SHOWCASE_LOCAL=1 but ${portsPath} does not exist — ` +
+          `no local backend overrides will be baked. Generate it (or unset ` +
+          `SHOWCASE_LOCAL).`,
+      );
+      return "";
+    }
+    throw new Error(`${portsPath} could not be read: ${String(err)}`, {
+      cause: err,
+    });
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch (err) {
+    throw new Error(`${portsPath} is not valid JSON: ${String(err)}`, {
+      cause: err,
+    });
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `${portsPath} must be a JSON object mapping slug -> port (got ` +
+        `${Array.isArray(parsed) ? "an array" : typeof parsed}).`,
+    );
+  }
+  const map: Record<string, string> = {};
+  for (const [slug, port] of Object.entries(parsed)) {
+    // Registry slugs are [a-z0-9-]+ (see lib/backend-url.ts SLUG_RE) —
+    // a key outside that contract can never match an integration slug,
+    // so its override is a silent no-op at runtime. Warn, don't throw:
+    // the entry breaks nothing, it just never applies.
+    if (!/^[a-z0-9-]+$/.test(slug)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[next.config] ${portsPath}: key ${JSON.stringify(slug)} does not ` +
+          `match the integration slug contract ([a-z0-9-]+) — its override ` +
+          `can never apply (silent no-op at runtime).`,
+      );
+    }
+    // Full TCP-port validation, not just typeof: 3.5 / 0 / -1 / 99999
+    // are all numbers, and every one of them yields a URL that can
+    // never connect. THROW — this is build time (the file's stated
+    // fail-loud posture); a warn+skip silently shipped a build with
+    // that integration's override missing.
+    if (
+      typeof port !== "number" ||
+      !Number.isInteger(port) ||
+      port <= 0 ||
+      port > 65535
+    ) {
+      throw new Error(
+        `${portsPath}: port for "${slug}" is not a valid TCP port ` +
+          `(integer 1-65535); got ${JSON.stringify(port)}.`,
+      );
+    }
+    map[slug] = `http://localhost:${port}`;
+  }
+  return JSON.stringify(map);
+}

--- a/showcase/shell/src/lib/runtime-config.client.test.ts
+++ b/showcase/shell/src/lib/runtime-config.client.test.ts
@@ -42,6 +42,44 @@ describe("client getRuntimeConfig (shell)", () => {
     );
   });
 
+  it("throws when the injection ran with empty inputs (incomplete config)", () => {
+    // `!cfg` alone would accept a truthy-but-useless object — the
+    // fail-loud contract covers empty injected fields too.
+    for (const broken of [
+      { baseUrl: "", backendHostPattern: "showcase-{slug}.example.com" },
+      { baseUrl: "https://showcase.example.com", backendHostPattern: "" },
+    ]) {
+      (
+        window as Window & { __SHOWCASE_CONFIG__?: unknown }
+      ).__SHOWCASE_CONFIG__ = {
+        posthogHost: "https://eu.i.posthog.com",
+        docsHost: "https://docs.showcase.copilotkit.ai",
+        ...broken,
+      };
+      expect(() => getRuntimeConfig()).toThrow(
+        /__SHOWCASE_CONFIG__ is incomplete/,
+      );
+    }
+  });
+
+  it("returns a frozen object so consumers cannot mutate the shared config", () => {
+    (window as Window & { __SHOWCASE_CONFIG__?: unknown }).__SHOWCASE_CONFIG__ =
+      {
+        baseUrl: "https://showcase.example.com",
+        posthogHost: "https://eu.i.posthog.com",
+        backendHostPattern: "showcase-{slug}-production.up.railway.app",
+        docsHost: "https://docs.showcase.copilotkit.ai",
+      };
+    const cfg = getRuntimeConfig();
+    expect(Object.isFrozen(cfg)).toBe(true);
+    // window.__SHOWCASE_CONFIG__ is a process-wide singleton; a strict-
+    // mode write must throw instead of silently changing it for everyone.
+    expect(() => {
+      (cfg as { baseUrl: string }).baseUrl = "https://evil.example.com";
+    }).toThrow(TypeError);
+    expect(getRuntimeConfig().baseUrl).toBe("https://showcase.example.com");
+  });
+
   it("returns SSR sentinel placeholder when window is undefined", () => {
     // Simulate SSR by removing window. "use client" component
     // bodies execute on the server during SSR, so this reader
@@ -61,6 +99,8 @@ describe("client getRuntimeConfig (shell)", () => {
       // placeholder so substitution still yields a syntactically
       // valid (non-resolvable) host during SSR.
       expect(cfg.backendHostPattern).toContain("{slug}");
+      // The placeholder is shared module state — must be frozen too.
+      expect(Object.isFrozen(cfg)).toBe(true);
     } finally {
       (globalThis as { window?: typeof w }).window = w;
     }

--- a/showcase/shell/src/lib/runtime-config.client.test.ts
+++ b/showcase/shell/src/lib/runtime-config.client.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getRuntimeConfig } from "./runtime-config.client";
 
 describe("client getRuntimeConfig (shell)", () => {
@@ -154,6 +154,22 @@ describe("client getRuntimeConfig (shell)", () => {
     expect(getRuntimeConfig().posthogKey).toBe("phc_x");
   });
 
+  it("throws (naming posthogKey) when a PRESENT posthogKey is an empty string", () => {
+    // The server reader can never produce "" (readEnvPair maps empty to
+    // undefined), so a present-but-empty key is the same wiring-bug
+    // class as a wrong type — NOT the legitimate absence case.
+    (
+      window as unknown as { __SHOWCASE_CONFIG__?: unknown }
+    ).__SHOWCASE_CONFIG__ = {
+      baseUrl: "https://showcase.example.com",
+      posthogHost: "https://eu.i.posthog.com",
+      backendHostPattern: "showcase-{slug}-production.up.railway.app",
+      docsHost: "https://docs.showcase.copilotkit.ai",
+      posthogKey: "",
+    };
+    expect(() => getRuntimeConfig()).toThrow(/"posthogKey"/);
+  });
+
   it("returns a frozen object so consumers cannot mutate the shared config", () => {
     (window as Window & { __SHOWCASE_CONFIG__?: unknown }).__SHOWCASE_CONFIG__ =
       {
@@ -173,20 +189,28 @@ describe("client getRuntimeConfig (shell)", () => {
   });
 
   it("returns SSR sentinel placeholder when window is undefined", () => {
-    // Simulate SSR by removing window. "use client" component
-    // bodies execute on the server during SSR, so this reader
+    // Simulate SSR by stubbing window to undefined. "use client"
+    // component bodies execute on the server during SSR, so this reader
     // MUST be SSR-safe (returns parseable-URL placeholders so
     // `new URL()` in consumers doesn't throw) and NOT throw —
-    // otherwise the whole server-rendered HTML 500s.
-    const w = globalThis.window;
-    // @ts-expect-error — deliberately removing window for the test
-    delete globalThis.window;
+    // otherwise the whole server-rendered HTML 500s. stubGlobal (not
+    // delete/reassign) per repo discipline: vitest restores the
+    // original even if an assertion throws mid-test (same pattern as
+    // runtime-url-wiring.test.ts).
+    vi.stubGlobal("window", undefined);
     try {
       const cfg = getRuntimeConfig();
       // URL fields must be parseable.
       expect(() => new URL(cfg.baseUrl)).not.toThrow();
       expect(() => new URL(cfg.posthogHost)).not.toThrow();
       expect(() => new URL(cfg.docsHost)).not.toThrow();
+      // Structural parity with the server reader: every real value is
+      // slashless (the server strips trailing slashes at every exit
+      // path), so the SSR placeholder must be slashless too — consumers
+      // string-compose against these values and must see ONE form.
+      expect(cfg.baseUrl).not.toMatch(/\/$/);
+      expect(cfg.posthogHost).not.toMatch(/\/$/);
+      expect(cfg.docsHost).not.toMatch(/\/$/);
       // The host pattern is not a URL but must keep the {slug}
       // placeholder so substitution still yields a syntactically
       // valid (non-resolvable) host during SSR.
@@ -194,7 +218,7 @@ describe("client getRuntimeConfig (shell)", () => {
       // The placeholder is shared module state — must be frozen too.
       expect(Object.isFrozen(cfg)).toBe(true);
     } finally {
-      (globalThis as { window?: typeof w }).window = w;
+      vi.unstubAllGlobals();
     }
   });
 });

--- a/showcase/shell/src/lib/runtime-config.client.test.ts
+++ b/showcase/shell/src/lib/runtime-config.client.test.ts
@@ -13,6 +13,11 @@ describe("client getRuntimeConfig (shell)", () => {
 
   afterEach(() => {
     (globalThis as { window?: Window }).window = originalWindow;
+    // Clean up the injected config HERE, not only in the next test's
+    // beforeEach — the last test in this file must not leak
+    // __SHOWCASE_CONFIG__ into other test files under worker reuse.
+    delete (globalThis.window as Window & { __SHOWCASE_CONFIG__?: unknown })
+      .__SHOWCASE_CONFIG__;
   });
 
   it("returns the injected config", () => {
@@ -20,10 +25,14 @@ describe("client getRuntimeConfig (shell)", () => {
       {
         baseUrl: "https://showcase.example.com",
         posthogHost: "https://eu.i.posthog.com",
+        backendHostPattern: "showcase-{slug}-production.up.railway.app",
+        docsHost: "https://docs.showcase.copilotkit.ai",
       };
     expect(getRuntimeConfig()).toEqual({
       baseUrl: "https://showcase.example.com",
       posthogHost: "https://eu.i.posthog.com",
+      backendHostPattern: "showcase-{slug}-production.up.railway.app",
+      docsHost: "https://docs.showcase.copilotkit.ai",
     });
   });
 
@@ -47,6 +56,11 @@ describe("client getRuntimeConfig (shell)", () => {
       // URL fields must be parseable.
       expect(() => new URL(cfg.baseUrl)).not.toThrow();
       expect(() => new URL(cfg.posthogHost)).not.toThrow();
+      expect(() => new URL(cfg.docsHost)).not.toThrow();
+      // The host pattern is not a URL but must keep the {slug}
+      // placeholder so substitution still yields a syntactically
+      // valid (non-resolvable) host during SSR.
+      expect(cfg.backendHostPattern).toContain("{slug}");
     } finally {
       (globalThis as { window?: typeof w }).window = w;
     }

--- a/showcase/shell/src/lib/runtime-config.client.test.ts
+++ b/showcase/shell/src/lib/runtime-config.client.test.ts
@@ -5,19 +5,30 @@ describe("client getRuntimeConfig (shell)", () => {
   const originalWindow = globalThis.window;
 
   beforeEach(() => {
-    // jsdom provides `window` by default in this vitest config.
-    // Reset any prior injection.
-    delete (globalThis.window as Window & { __SHOWCASE_CONFIG__?: unknown })
-      .__SHOWCASE_CONFIG__;
+    // jsdom provides `window` by default in this vitest config — but a
+    // prior test that deleted `window` and failed before its restore
+    // would leave it undefined, and an unguarded dereference here turns
+    // that one failure into a cascade across the whole file. Restore
+    // first, then guard the delete.
+    (globalThis as { window?: Window }).window = originalWindow;
+    if (globalThis.window) {
+      delete (globalThis.window as Window & { __SHOWCASE_CONFIG__?: unknown })
+        .__SHOWCASE_CONFIG__;
+    }
   });
 
   afterEach(() => {
+    // Restore BEFORE the delete: if the test under teardown removed
+    // `window` (the SSR test), the unguarded dereference would throw
+    // inside the hook and mask the real failure.
     (globalThis as { window?: Window }).window = originalWindow;
     // Clean up the injected config HERE, not only in the next test's
     // beforeEach — the last test in this file must not leak
     // __SHOWCASE_CONFIG__ into other test files under worker reuse.
-    delete (globalThis.window as Window & { __SHOWCASE_CONFIG__?: unknown })
-      .__SHOWCASE_CONFIG__;
+    if (globalThis.window) {
+      delete (globalThis.window as Window & { __SHOWCASE_CONFIG__?: unknown })
+        .__SHOWCASE_CONFIG__;
+    }
   });
 
   it("returns the injected config", () => {
@@ -44,22 +55,103 @@ describe("client getRuntimeConfig (shell)", () => {
 
   it("throws when the injection ran with empty inputs (incomplete config)", () => {
     // `!cfg` alone would accept a truthy-but-useless object — the
-    // fail-loud contract covers empty injected fields too.
+    // fail-loud contract covers empty injected fields too. ALL FOUR
+    // URL-bearing fields are checked symmetrically (docsHost feeds
+    // docs links, posthogHost feeds capture — an empty value in either
+    // is the same wiring bug as an empty baseUrl).
     for (const broken of [
-      { baseUrl: "", backendHostPattern: "showcase-{slug}.example.com" },
-      { baseUrl: "https://showcase.example.com", backendHostPattern: "" },
+      { baseUrl: "" },
+      { backendHostPattern: "" },
+      { docsHost: "" },
+      { posthogHost: "" },
     ]) {
       (
         window as Window & { __SHOWCASE_CONFIG__?: unknown }
       ).__SHOWCASE_CONFIG__ = {
+        baseUrl: "https://showcase.example.com",
         posthogHost: "https://eu.i.posthog.com",
+        backendHostPattern: "showcase-{slug}.example.com",
         docsHost: "https://docs.showcase.copilotkit.ai",
         ...broken,
       };
-      expect(() => getRuntimeConfig()).toThrow(
-        /__SHOWCASE_CONFIG__ is incomplete/,
-      );
+      expect(
+        () => getRuntimeConfig(),
+        `empty ${Object.keys(broken)[0]} should throw`,
+      ).toThrow(/__SHOWCASE_CONFIG__ is incomplete/);
     }
+  });
+
+  it("throws (naming the field) when an injected field is not a string", () => {
+    // A layout bug injecting a number previously sailed through the
+    // truthiness check and exploded far from the cause (e.g. inside a
+    // consumer's replaceAll).
+    for (const [field, value] of [
+      ["baseUrl", 42],
+      ["backendHostPattern", null],
+      ["docsHost", { url: "https://docs.example.com" }],
+      ["posthogHost", 1],
+    ] as const) {
+      (
+        window as Window & { __SHOWCASE_CONFIG__?: unknown }
+      ).__SHOWCASE_CONFIG__ = {
+        baseUrl: "https://showcase.example.com",
+        posthogHost: "https://eu.i.posthog.com",
+        backendHostPattern: "showcase-{slug}.example.com",
+        docsHost: "https://docs.showcase.copilotkit.ai",
+        [field]: value,
+      };
+      expect(
+        () => getRuntimeConfig(),
+        `non-string ${field} should throw`,
+      ).toThrow(new RegExp(`"${field}"`));
+    }
+  });
+
+  it("accepts a config without posthogKey (optional field)", () => {
+    // posthogKey is legitimately absent off-prod — it must NOT be part
+    // of the fail-loud required set.
+    (window as Window & { __SHOWCASE_CONFIG__?: unknown }).__SHOWCASE_CONFIG__ =
+      {
+        baseUrl: "https://showcase.example.com",
+        posthogHost: "https://eu.i.posthog.com",
+        backendHostPattern: "showcase-{slug}-production.up.railway.app",
+        docsHost: "https://docs.showcase.copilotkit.ai",
+      };
+    expect(getRuntimeConfig().posthogKey).toBeUndefined();
+  });
+
+  it("throws (naming posthogKey) when a PRESENT posthogKey is not a string", () => {
+    // posthogKey's absence exemption (legitimately unset off-prod) must
+    // not exempt wrong TYPES: a layout bug injecting a number would
+    // sail through and explode far from the cause in a capture consumer.
+    for (const bad of [42, null, { key: "phc_x" }]) {
+      // Full-replacement cast (not an intersection): the global Window
+      // augmentation types the field as RuntimeConfig, which would
+      // reject the deliberately-wrong posthogKey at compile time.
+      (
+        window as unknown as { __SHOWCASE_CONFIG__?: unknown }
+      ).__SHOWCASE_CONFIG__ = {
+        baseUrl: "https://showcase.example.com",
+        posthogHost: "https://eu.i.posthog.com",
+        backendHostPattern: "showcase-{slug}-production.up.railway.app",
+        docsHost: "https://docs.showcase.copilotkit.ai",
+        posthogKey: bad,
+      };
+      expect(
+        () => getRuntimeConfig(),
+        `posthogKey ${JSON.stringify(bad)} should throw`,
+      ).toThrow(/"posthogKey"/);
+    }
+    // A present STRING key still passes.
+    (window as Window & { __SHOWCASE_CONFIG__?: unknown }).__SHOWCASE_CONFIG__ =
+      {
+        baseUrl: "https://showcase.example.com",
+        posthogHost: "https://eu.i.posthog.com",
+        backendHostPattern: "showcase-{slug}-production.up.railway.app",
+        docsHost: "https://docs.showcase.copilotkit.ai",
+        posthogKey: "phc_x",
+      };
+    expect(getRuntimeConfig().posthogKey).toBe("phc_x");
   });
 
   it("returns a frozen object so consumers cannot mutate the shared config", () => {

--- a/showcase/shell/src/lib/runtime-config.client.ts
+++ b/showcase/shell/src/lib/runtime-config.client.ts
@@ -39,13 +39,16 @@ declare global {
  * that inline config values at render time should read them in an
  * effect/state instead.
  */
-// URL fields use a parseable `https://ssr-placeholder.invalid/` sentinel
+// URL fields use a parseable `https://ssr-placeholder.invalid` sentinel
 // — NOT the empty string — because consumer components may call
 // `new URL(cfg.someUrl)` inline during render, and `new URL("")` throws
 // a TypeError that escapes the SSR response as a 500. The `.invalid`
 // TLD is reserved by RFC 2606 so the URL also can't accidentally
-// resolve.
-const SSR_PLACEHOLDER_URL = "https://ssr-placeholder.invalid/";
+// resolve. Declared WITHOUT a trailing slash: the server reader strips
+// trailing slashes at every exit path, so every REAL value is slashless
+// — the placeholder keeps the SSR and client forms structurally
+// identical for consumers that string-compose against them.
+const SSR_PLACEHOLDER_URL = "https://ssr-placeholder.invalid";
 const SSR_PLACEHOLDER: Readonly<RuntimeConfig> = Object.freeze({
   baseUrl: SSR_PLACEHOLDER_URL,
   posthogHost: SSR_PLACEHOLDER_URL,
@@ -115,15 +118,24 @@ export function getRuntimeConfig(): Readonly<RuntimeConfig> {
   }
   // posthogKey is exempt from the REQUIRED set because ABSENCE is a
   // valid state (legitimately unset off-prod) — but the absence
-  // exemption must not exempt wrong TYPES: a layout bug injecting a
-  // number would sail through and explode far from the cause inside a
-  // capture consumer.
-  if (cfg.posthogKey !== undefined && typeof cfg.posthogKey !== "string") {
+  // exemption must not exempt wrong TYPES or the empty string: a layout
+  // bug injecting a number would sail through and explode far from the
+  // cause inside a capture consumer, and the server reader can never
+  // produce "" (readEnvPair maps empty to undefined), so a present-but-
+  // empty key is the same wiring-bug class.
+  if (
+    cfg.posthogKey !== undefined &&
+    (typeof cfg.posthogKey !== "string" || cfg.posthogKey.length === 0)
+  ) {
     throw new Error(
       `[runtime-config.client] window.__SHOWCASE_CONFIG__ is malformed: ` +
-        `field "posthogKey" is of type ${typeof cfg.posthogKey} (expected ` +
-        `a string or absence). The root layout injection ran with broken ` +
-        `inputs — check the server-side runtime config.`,
+        `field "posthogKey" is ${
+          typeof cfg.posthogKey === "string"
+            ? "empty"
+            : `of type ${typeof cfg.posthogKey}`
+        } (expected a non-empty string or absence). The root layout ` +
+        `injection ran with broken inputs — check the server-side ` +
+        `runtime config.`,
     );
   }
   return Object.freeze(cfg);

--- a/showcase/shell/src/lib/runtime-config.client.ts
+++ b/showcase/shell/src/lib/runtime-config.client.ts
@@ -55,6 +55,9 @@ const SSR_PLACEHOLDER: Readonly<RuntimeConfig> = Object.freeze({
   // that is only populated post-hydration.
   backendHostPattern: "showcase-{slug}.ssr-placeholder.invalid",
   docsHost: SSR_PLACEHOLDER_URL,
+  // Optional field (legitimately absent off-prod) — no placeholder
+  // needed; client capture consumers must gate on it anyway.
+  posthogKey: undefined,
 });
 
 /**
@@ -88,15 +91,47 @@ export function getRuntimeConfig(): Readonly<RuntimeConfig> {
         "The root layout must inject runtime config before client mount.",
     );
   }
-  // Minimal field validation: an injection that ran with empty inputs
-  // (layout wired to a broken server read) yields an object that is
-  // truthy but useless — fail loud instead of rendering empty URLs.
-  if (!cfg.baseUrl || !cfg.backendHostPattern) {
+  // Field validation: an injection that ran with empty inputs (layout
+  // wired to a broken server read) yields an object that is truthy but
+  // useless — fail loud instead of rendering empty URLs. ALL FOUR
+  // URL-bearing fields are checked symmetrically (docsHost feeds docs
+  // links, posthogHost feeds capture — an empty value in either is the
+  // same wiring bug as an empty baseUrl). The typeof check catches a
+  // layout bug injecting a non-string (e.g. a number), which previously
+  // sailed through truthiness and exploded far from the cause inside a
+  // consumer's replaceAll. posthogKey is deliberately NOT required —
+  // it is legitimately absent off-prod.
+  for (const field of REQUIRED_CONFIG_FIELDS) {
+    const value = cfg[field];
+    if (typeof value !== "string" || value.length === 0) {
+      throw new Error(
+        `[runtime-config.client] window.__SHOWCASE_CONFIG__ is incomplete: ` +
+          `field "${field}" is ${
+            typeof value === "string" ? "empty" : `of type ${typeof value}`
+          }. The root layout injection ran with broken inputs — check the ` +
+          `server-side runtime config.`,
+      );
+    }
+  }
+  // posthogKey is exempt from the REQUIRED set because ABSENCE is a
+  // valid state (legitimately unset off-prod) — but the absence
+  // exemption must not exempt wrong TYPES: a layout bug injecting a
+  // number would sail through and explode far from the cause inside a
+  // capture consumer.
+  if (cfg.posthogKey !== undefined && typeof cfg.posthogKey !== "string") {
     throw new Error(
-      "[runtime-config.client] window.__SHOWCASE_CONFIG__ is incomplete " +
-        "(empty baseUrl or backendHostPattern). The root layout injection " +
-        "ran with empty inputs — check the server-side runtime config.",
+      `[runtime-config.client] window.__SHOWCASE_CONFIG__ is malformed: ` +
+        `field "posthogKey" is of type ${typeof cfg.posthogKey} (expected ` +
+        `a string or absence). The root layout injection ran with broken ` +
+        `inputs — check the server-side runtime config.`,
     );
   }
   return Object.freeze(cfg);
 }
+
+const REQUIRED_CONFIG_FIELDS = [
+  "baseUrl",
+  "posthogHost",
+  "backendHostPattern",
+  "docsHost",
+] as const satisfies readonly (keyof RuntimeConfig)[];

--- a/showcase/shell/src/lib/runtime-config.client.ts
+++ b/showcase/shell/src/lib/runtime-config.client.ts
@@ -36,6 +36,12 @@ const SSR_PLACEHOLDER_URL = "https://ssr-placeholder.invalid/";
 const SSR_PLACEHOLDER: RuntimeConfig = {
   baseUrl: SSR_PLACEHOLDER_URL,
   posthogHost: SSR_PLACEHOLDER_URL,
+  // Keep the {slug} placeholder so an SSR-phase substitution still
+  // yields a parseable, RFC-2606-unresolvable host. No iframe ever
+  // renders from this: backend-URL consumers gate on client state
+  // that is only populated post-hydration.
+  backendHostPattern: "showcase-{slug}.ssr-placeholder.invalid",
+  docsHost: SSR_PLACEHOLDER_URL,
 };
 
 /**

--- a/showcase/shell/src/lib/runtime-config.client.ts
+++ b/showcase/shell/src/lib/runtime-config.client.ts
@@ -4,6 +4,13 @@
 // is the ONLY public API for these URLs in client code — never read
 // process.env.NEXT_PUBLIC_* directly.
 
+// Build-time guard: importing this module from a Server Component
+// previously failed SILENTLY — the SSR branch below returns
+// placeholders, so a server-side consumer would render permanent
+// placeholder URLs with no signal. `client-only` turns that mistake
+// into a Next.js build error.
+import "client-only";
+
 import type { RuntimeConfig } from "./runtime-config";
 
 export type { RuntimeConfig };
@@ -19,21 +26,27 @@ declare global {
  * components in the Next.js App Router are server-side rendered on the
  * initial request (that's how the HTML is streamed before hydration),
  * which means their function bodies execute on the server too. We can't
- * throw here without breaking SSR — instead we return a placeholder, and
- * post-hydration the next render reads the real values out of
- * window.__SHOWCASE_CONFIG__. Server components that need the live env
- * values MUST import getRuntimeConfig from runtime-config.ts (the server
- * variant), not this file.
+ * throw here without breaking SSR — instead we return a placeholder.
+ *
+ * Hydration story: the inline <script> in the root layout runs BEFORE
+ * React hydrates, so window.__SHOWCASE_CONFIG__ is already populated by
+ * the time the hydration render executes — the FIRST client render sees
+ * the real values (there is no "post-hydration next render"). The
+ * hazard is the opposite direction: the server-rendered HTML was
+ * produced with THIS placeholder, so a component that renders a config
+ * value directly into markup (text/attribute) will hydrate with a
+ * server/client MISMATCH (React warning, possible flash). Consumers
+ * that inline config values at render time should read them in an
+ * effect/state instead.
  */
 // URL fields use a parseable `https://ssr-placeholder.invalid/` sentinel
 // — NOT the empty string — because consumer components may call
 // `new URL(cfg.someUrl)` inline during render, and `new URL("")` throws
 // a TypeError that escapes the SSR response as a 500. The `.invalid`
 // TLD is reserved by RFC 2606 so the URL also can't accidentally
-// resolve. Post-hydration the next render reads the real value out of
-// window.__SHOWCASE_CONFIG__.
+// resolve.
 const SSR_PLACEHOLDER_URL = "https://ssr-placeholder.invalid/";
-const SSR_PLACEHOLDER: RuntimeConfig = {
+const SSR_PLACEHOLDER: Readonly<RuntimeConfig> = Object.freeze({
   baseUrl: SSR_PLACEHOLDER_URL,
   posthogHost: SSR_PLACEHOLDER_URL,
   // Keep the {slug} placeholder so an SSR-phase substitution still
@@ -42,33 +55,48 @@ const SSR_PLACEHOLDER: RuntimeConfig = {
   // that is only populated post-hydration.
   backendHostPattern: "showcase-{slug}.ssr-placeholder.invalid",
   docsHost: SSR_PLACEHOLDER_URL,
-};
+});
 
 /**
  * Returns the runtime config injected by the root server layout.
  *
- * During SSR (no window) returns a sentinel placeholder; client code
- * re-reads after hydration and gets the real values. If the inline
- * <script> never runs (a route bypassed the layout, or injection ran
- * with empty inputs), the post-hydration read throws — surfacing the
- * wiring bug loudly rather than silently rendering empty URLs.
+ * During SSR (no window) returns a sentinel placeholder; the inline
+ * <script> runs before hydration, so every client render — including
+ * the hydration render — sees the real values (see the hydration note
+ * on SSR_PLACEHOLDER above). If the inline <script> never ran (a route
+ * bypassed the layout) or injected an empty/incomplete object, this
+ * read throws — surfacing the wiring bug loudly rather than silently
+ * rendering empty URLs.
+ *
+ * The returned object is frozen: window.__SHOWCASE_CONFIG__ is a
+ * process-wide singleton, so a consumer mutating its copy would change
+ * the config for EVERY component.
  */
-export function getRuntimeConfig(): RuntimeConfig {
+export function getRuntimeConfig(): Readonly<RuntimeConfig> {
   if (typeof window === "undefined") {
     // SSR phase — "use client" component bodies execute here too.
-    // Return placeholder; hydration will re-render with real values.
+    // Return placeholder; the hydration render reads the real values.
     return SSR_PLACEHOLDER;
   }
   const cfg = window.__SHOWCASE_CONFIG__;
   if (!cfg) {
     // The root layout always emits the <script> tag, so a missing
-    // value here is a wiring bug (e.g. a route bypassed the layout,
-    // or the injection script ran with empty inputs). Surface it
-    // loudly rather than silently returning empty strings.
+    // value here is a wiring bug (e.g. a route bypassed the layout).
+    // Surface it loudly rather than silently returning empty strings.
     throw new Error(
       "[runtime-config.client] window.__SHOWCASE_CONFIG__ is missing. " +
         "The root layout must inject runtime config before client mount.",
     );
   }
-  return cfg;
+  // Minimal field validation: an injection that ran with empty inputs
+  // (layout wired to a broken server read) yields an object that is
+  // truthy but useless — fail loud instead of rendering empty URLs.
+  if (!cfg.baseUrl || !cfg.backendHostPattern) {
+    throw new Error(
+      "[runtime-config.client] window.__SHOWCASE_CONFIG__ is incomplete " +
+        "(empty baseUrl or backendHostPattern). The root layout injection " +
+        "ran with empty inputs — check the server-side runtime config.",
+    );
+  }
+  return Object.freeze(cfg);
 }

--- a/showcase/shell/src/lib/runtime-config.test.ts
+++ b/showcase/shell/src/lib/runtime-config.test.ts
@@ -45,17 +45,28 @@ describe("server getRuntimeConfig (shell)", () => {
   });
 
   it("returns env values when all are set (production)", () => {
+    // ALL five env values actually set — the test name promises it, and
+    // the exact-shape toEqual pins the full config (including posthogKey
+    // PRESENCE; a regression dropping the field from the return object
+    // would otherwise pass against an undefined-tolerant comparison).
     (process.env as Record<string, string>).NODE_ENV = "production";
     process.env.BASE_URL = "https://showcase.copilotkit.ai";
     process.env.POSTHOG_HOST = "https://eu.i.posthog.com";
-    expect(getRuntimeConfig()).toEqual({
+    process.env.POSTHOG_KEY = "phc_test_key";
+    process.env.DOCS_HOST = "https://docs-staging.example.com";
+    process.env.SHOWCASE_BACKEND_HOST_PATTERN =
+      "showcase-{slug}-staging.up.railway.app";
+    const cfg = getRuntimeConfig();
+    expect(cfg).toEqual({
       baseUrl: "https://showcase.copilotkit.ai",
       posthogHost: "https://eu.i.posthog.com",
-      // Defaults preserved when the new env vars are unset — prod
-      // requires NO env change.
-      backendHostPattern: "showcase-{slug}-production.up.railway.app",
-      docsHost: "https://docs.showcase.copilotkit.ai",
+      posthogKey: "phc_test_key",
+      backendHostPattern: "showcase-{slug}-staging.up.railway.app",
+      docsHost: "https://docs-staging.example.com",
     });
+    // toEqual treats a missing key and an undefined value as equal —
+    // pin posthogKey presence explicitly.
+    expect(cfg.posthogKey).toBe("phc_test_key");
   });
 
   it("backendHostPattern/docsHost default to prod values when unset (both envs, no FATAL log)", async () => {
@@ -69,9 +80,11 @@ describe("server getRuntimeConfig (shell)", () => {
       vi.resetModules();
       const { getRuntimeConfig: freshGet } = await import("./runtime-config");
       const errs: string[] = [];
-      const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
-        errs.push(m);
-      });
+      const spy = vi
+        .spyOn(console, "error")
+        .mockImplementation(
+          (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+        );
       // try/finally so a failing assertion can't leak the spy into
       // other tests (matches every other spy in this file).
       let cfg: ReturnType<typeof freshGet>;
@@ -146,7 +159,9 @@ describe("server getRuntimeConfig (shell)", () => {
       const errs: string[] = [];
       const errSpy = vi
         .spyOn(console, "error")
-        .mockImplementation((m: string) => void errs.push(m));
+        .mockImplementation(
+          (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+        );
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {
         const cfg = freshGet();
@@ -203,6 +218,71 @@ describe("server getRuntimeConfig (shell)", () => {
     expect(getRuntimeConfig().docsHost).toBe("http://[::1]:3005");
   });
 
+  it("rejects a loopback BASE_URL in production with the sentinel + FATAL (no silent http:// prepend)", async () => {
+    // The loopback http:// prepend exists for frictionless DEV — in
+    // production it silently "fixed" BASE_URL=localhost:3000, so
+    // canonical hrefs, OG metadata, and the docs loop guard all ran
+    // against localhost with zero log. Prod loopback is always a
+    // misconfig: FATAL path, not the prepend.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    for (const bad of [
+      "localhost:3000",
+      "http://127.0.0.1:3000",
+      "[::1]:3000",
+    ]) {
+      process.env.BASE_URL = bad;
+      vi.resetModules();
+      const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+      const errs: string[] = [];
+      const spy = vi
+        .spyOn(console, "error")
+        .mockImplementation(
+          (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+        );
+      try {
+        expect(freshGet().baseUrl, `value ${JSON.stringify(bad)}`).toBe(
+          "https://shell-base-url-missing.invalid",
+        );
+        expect(
+          errs.some((m) => m.includes("BASE_URL") && m.includes("loopback")),
+          `value ${JSON.stringify(bad)} should log a loopback FATAL`,
+        ).toBe(true);
+      } finally {
+        spy.mockRestore();
+      }
+    }
+  });
+
+  it("rejects a loopback DOCS_HOST in production with the default fallback + FATAL", async () => {
+    // Same class as the BASE_URL case: `DOCS_HOST=localhost:3005` is
+    // documented local-dev wiring — in production it would 308 every
+    // docs visitor to localhost, silently.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    for (const bad of ["localhost:3005", "http://localhost:3005"]) {
+      process.env.DOCS_HOST = bad;
+      vi.resetModules();
+      const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+      const errs: string[] = [];
+      const spy = vi
+        .spyOn(console, "error")
+        .mockImplementation(
+          (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+        );
+      try {
+        expect(freshGet().docsHost, `value ${JSON.stringify(bad)}`).toBe(
+          "https://docs.showcase.copilotkit.ai",
+        );
+        expect(
+          errs.some((m) => m.includes("DOCS_HOST") && m.includes("loopback")),
+          `value ${JSON.stringify(bad)} should log a loopback FATAL`,
+        ).toBe(true);
+      } finally {
+        spy.mockRestore();
+      }
+    }
+  });
+
   it("preserves an explicit http:// scheme on DOCS_HOST", () => {
     (process.env as Record<string, string>).NODE_ENV = "development";
     process.env.BASE_URL = "http://localhost:3000";
@@ -220,9 +300,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
-      errs.push(m);
-    });
+    const spy = vi.spyOn(console, "error").mockImplementation(
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
     try {
       const cfg = freshGet();
       expect(cfg.docsHost).toBe("https://docs.showcase.copilotkit.ai");
@@ -247,9 +327,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
-      errs.push(m);
-    });
+    const spy = vi.spyOn(console, "error").mockImplementation(
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
     try {
       const cfg = freshGet();
       expect(cfg.docsHost).toBe("https://docs.showcase.copilotkit.ai");
@@ -272,9 +352,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
-      errs.push(m);
-    });
+    const spy = vi.spyOn(console, "error").mockImplementation(
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
     try {
       const cfg = freshGet();
       expect(cfg.baseUrl).toBe("https://shell.copilotkit.ai");
@@ -295,9 +375,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
-      errs.push(m);
-    });
+    const spy = vi.spyOn(console, "error").mockImplementation(
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
     try {
       const cfg = freshGet();
       expect(cfg.baseUrl).toBe("https://shell-base-url-missing.invalid");
@@ -330,7 +410,9 @@ describe("server getRuntimeConfig (shell)", () => {
       const errs: string[] = [];
       const spy = vi
         .spyOn(console, "error")
-        .mockImplementation((m: string) => void errs.push(m));
+        .mockImplementation(
+          (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+        );
       try {
         const cfg = freshGet();
         expect(cfg.baseUrl, `value ${JSON.stringify(bad)}`).toBe(
@@ -358,7 +440,9 @@ describe("server getRuntimeConfig (shell)", () => {
     const errs: string[] = [];
     const spy = vi
       .spyOn(console, "error")
-      .mockImplementation((m: string) => void errs.push(m));
+      .mockImplementation(
+          (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+        );
     try {
       expect(freshGet().baseUrl).toBe("https://shell-base-url-missing.invalid");
       expect(errs.some((m) => m.includes("BASE_URL"))).toBe(true);
@@ -383,7 +467,9 @@ describe("server getRuntimeConfig (shell)", () => {
       const warns: string[] = [];
       const spy = vi
         .spyOn(console, "warn")
-        .mockImplementation((m: string) => void warns.push(m));
+        .mockImplementation(
+          (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
+        );
       try {
         expect(freshGet().baseUrl, `${why} should normalize to origin`).toBe(
           "https://shell.example.com",
@@ -411,10 +497,14 @@ describe("server getRuntimeConfig (shell)", () => {
     const errs: string[] = [];
     const warnSpy = vi
       .spyOn(console, "warn")
-      .mockImplementation((m: string) => void warns.push(m));
+      .mockImplementation(
+          (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
+        );
     const errSpy = vi
       .spyOn(console, "error")
-      .mockImplementation((m: string) => void errs.push(m));
+      .mockImplementation(
+          (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+        );
     try {
       const cfg = freshGet();
       expect(cfg.baseUrl).toBe("http://localhost:3000");
@@ -436,7 +526,9 @@ describe("server getRuntimeConfig (shell)", () => {
     const errs: string[] = [];
     const spy = vi
       .spyOn(console, "error")
-      .mockImplementation((m: string) => void errs.push(m));
+      .mockImplementation(
+          (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+        );
     try {
       freshGet();
       const fatal = errs.find((m) => m.includes("BASE_URL is unset"));
@@ -454,9 +546,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
-      errs.push(m);
-    });
+    const spy = vi.spyOn(console, "error").mockImplementation(
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
     try {
       const cfg = freshGet();
       expect(cfg.baseUrl).toBe("https://shell-base-url-missing.invalid");
@@ -485,9 +577,11 @@ describe("server getRuntimeConfig (shell)", () => {
       vi.resetModules();
       const { getRuntimeConfig: freshGet } = await import("./runtime-config");
       const warns: string[] = [];
-      const spy = vi.spyOn(console, "warn").mockImplementation((m: string) => {
-        warns.push(m);
-      });
+      const spy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(
+          (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
+        );
       try {
         const cfg = freshGet();
         expect(cfg.docsHost, `${why} should normalize to origin`).toBe(
@@ -513,9 +607,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
-      errs.push(m);
-    });
+    const spy = vi.spyOn(console, "error").mockImplementation(
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
     try {
       const cfg = freshGet();
       expect(cfg.docsHost).toBe("https://docs.showcase.copilotkit.ai");
@@ -553,7 +647,9 @@ describe("server getRuntimeConfig (shell)", () => {
       const errs: string[] = [];
       const spy = vi
         .spyOn(console, "error")
-        .mockImplementation((m: string) => void errs.push(m));
+        .mockImplementation(
+          (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+        );
       try {
         const cfg = freshGet();
         expect(cfg.docsHost, `value ${JSON.stringify(bad)}`).toBe(
@@ -578,9 +674,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
-      errs.push(m);
-    });
+    const spy = vi.spyOn(console, "error").mockImplementation(
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
     try {
       freshGet();
       expect(
@@ -606,10 +702,14 @@ describe("server getRuntimeConfig (shell)", () => {
     const errs: string[] = [];
     const warnSpy = vi
       .spyOn(console, "warn")
-      .mockImplementation((m: string) => void warns.push(m));
+      .mockImplementation(
+          (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
+        );
     const errSpy = vi
       .spyOn(console, "error")
-      .mockImplementation((m: string) => void errs.push(m));
+      .mockImplementation(
+          (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+        );
     try {
       const cfg = freshGet();
       // Same fallback VALUE as prod — only the log level/text branches.
@@ -637,9 +737,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
-      errs.push(m);
-    });
+    const spy = vi.spyOn(console, "error").mockImplementation(
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
     try {
       const cfg = freshGet();
       expect(cfg.docsHost).toBe("https://docs.showcase.copilotkit.ai");
@@ -665,9 +765,9 @@ describe("server getRuntimeConfig (shell)", () => {
     const { getRuntimeConfig: freshGet, DOCS_REDIRECTS_DISABLED_HOST } =
       await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
-      errs.push(m);
-    });
+    const spy = vi.spyOn(console, "error").mockImplementation(
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
     try {
       const cfg = freshGet();
       expect(cfg.docsHost).toBe(DOCS_REDIRECTS_DISABLED_HOST);
@@ -702,9 +802,9 @@ describe("server getRuntimeConfig (shell)", () => {
     const { getRuntimeConfig: freshGet, DOCS_REDIRECTS_DISABLED_HOST } =
       await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
-      errs.push(m);
-    });
+    const spy = vi.spyOn(console, "error").mockImplementation(
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
     try {
       const cfg = freshGet();
       expect(cfg.docsHost).toBe(DOCS_REDIRECTS_DISABLED_HOST);
@@ -716,6 +816,62 @@ describe("server getRuntimeConfig (shell)", () => {
       );
     } finally {
       spy.mockRestore();
+    }
+  });
+
+  it("re-logs the DOCS_HOST fallback when the shell host or mode changes the outcome (guard key covers both)", async () => {
+    // The fallback log's MESSAGE and OUTCOME (default vs disabled
+    // sentinel) depend on shellHost — a live BASE_URL re-read — and its
+    // LEVEL depends on the mode. A once-guard keyed on the raw value
+    // alone swallows a changed outcome: the deploy silently flips to
+    // redirects-disabled with zero log.
+    process.env.DOCS_HOST = "https://";
+    (process.env as Record<string, string>).NODE_ENV = "development";
+    process.env.BASE_URL = "https://shell.example.com";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet, DOCS_REDIRECTS_DISABLED_HOST } =
+      await import("./runtime-config");
+    const errs: string[] = [];
+    const warns: string[] = [];
+    const errSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(
+        (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
+      );
+    try {
+      // Dev: warn-level fallback consumed the raw-value guard.
+      expect(freshGet().docsHost).toBe("https://docs.showcase.copilotkit.ai");
+      expect(warns.some((m) => m.includes("DOCS_HOST"))).toBe(true);
+      // Same raw value, PROD mode: the FATAL must still fire.
+      (process.env as Record<string, string>).NODE_ENV = "production";
+      expect(freshGet().docsHost).toBe("https://docs.showcase.copilotkit.ai");
+      expect(
+        errs.some((m) => m.includes("FATAL-CONFIG") && m.includes("DOCS_HOST")),
+        "prod FATAL must not be swallowed by the dev warn's guard entry",
+      ).toBe(true);
+      // Same raw value, same mode, but BASE_URL moved to the default
+      // docs host: the OUTCOME flips to the disabled sentinel — that
+      // must be logged, not silently returned.
+      process.env.BASE_URL = "https://docs.showcase.copilotkit.ai";
+      const before = errs.length;
+      expect(freshGet().docsHost).toBe(DOCS_REDIRECTS_DISABLED_HOST);
+      expect(
+        errs.slice(before).some((m) => m.includes("disabled")),
+        "outcome change (fallback → disabled sentinel) must re-log",
+      ).toBe(true);
+      // And the guard still holds per (mode, shellHost, value): an
+      // identical repeat call logs nothing new.
+      const after = errs.length;
+      freshGet();
+      expect(errs.length).toBe(after);
+    } finally {
+      errSpy.mockRestore();
+      warnSpy.mockRestore();
     }
   });
 
@@ -731,6 +887,47 @@ describe("server getRuntimeConfig (shell)", () => {
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
       expect(freshGet().docsHost).toBe("https://docs.showcase.copilotkit.ai");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("trips the self-host loop guard for a trailing-dot FQDN spelling (both compare sides)", async () => {
+    // `shell.example.com.` is the same authority as `shell.example.com`
+    // to DNS and browsers — the redirect table's self-referential paths
+    // loop just the same, but a literal host compare let the dotted
+    // spelling evade the guard.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://shell.example.com";
+    process.env.DOCS_HOST = "https://shell.example.com.";
+    vi.resetModules();
+    let { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const errs: string[] = [];
+    let spy = vi
+      .spyOn(console, "error")
+      .mockImplementation(
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
+    try {
+      expect(freshGet().docsHost).toBe("https://docs.showcase.copilotkit.ai");
+      expect(
+        errs.some((m) => m.includes("DOCS_HOST") && m.includes("own host")),
+      ).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+
+    // Dotted spelling on the SHELL side: the fallback collision
+    // re-check must normalize too, or a shell deployed at
+    // `docs.showcase.copilotkit.ai.` hands out the looping default.
+    process.env.BASE_URL = "https://docs.showcase.copilotkit.ai.";
+    delete process.env.DOCS_HOST;
+    vi.resetModules();
+    const fresh2 = await import("./runtime-config");
+    freshGet = fresh2.getRuntimeConfig;
+    spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(freshGet().docsHost).toBe(fresh2.DOCS_REDIRECTS_DISABLED_HOST);
     } finally {
       spy.mockRestore();
     }
@@ -793,9 +990,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
-      errs.push(m);
-    });
+    const spy = vi.spyOn(console, "error").mockImplementation(
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
     // try/finally so a throwing call can't leak the spy into other
     // tests (matches every other spy in this file).
     let cfg: ReturnType<typeof freshGet>;
@@ -825,9 +1022,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
-      errs.push(m);
-    });
+    const spy = vi.spyOn(console, "error").mockImplementation(
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
     try {
       freshGet();
       expect(errs.filter((m) => m.includes("BASE_URL")).length).toBe(1);
@@ -844,9 +1041,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const warns: string[] = [];
-    const spy = vi.spyOn(console, "warn").mockImplementation((m: string) => {
-      warns.push(m);
-    });
+    const spy = vi.spyOn(console, "warn").mockImplementation(
+        (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
+      );
     try {
       freshGet();
       expect(warns.filter((m) => m.includes("BASE_URL")).length).toBe(1);
@@ -954,9 +1151,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const warns: string[] = [];
-    const spy = vi.spyOn(console, "warn").mockImplementation((m: string) => {
-      warns.push(m);
-    });
+    const spy = vi.spyOn(console, "warn").mockImplementation(
+        (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
+      );
     try {
       const cfg = freshGet();
       expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
@@ -977,14 +1174,56 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const warns: string[] = [];
-    const spy = vi.spyOn(console, "warn").mockImplementation((m: string) => {
-      warns.push(m);
-    });
+    const spy = vi.spyOn(console, "warn").mockImplementation(
+        (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
+      );
     try {
       expect(freshGet().posthogHost).toBe("https://eu.i.posthog.com");
       expect(warns.some((m) => m.includes("POSTHOG_HOST"))).toBe(true);
     } finally {
       spy.mockRestore();
+    }
+  });
+
+  it("labels POSTHOG_HOST rejections accurately (scheme vs degenerate vs parse failure)", async () => {
+    // `ftp://ph.example.com` PARSED fine and no prepend happened — the
+    // previous catch-all warn claimed the value "is not a usable http(s)
+    // URL (even after prepending https://)": both clauses false. Same
+    // for the degenerate bare-scheme value (it parses too). Each
+    // rejection class must name its actual reason — the same branched
+    // labeling readDocsHost has.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    for (const [bad, mustInclude, parsedFine] of [
+      ["ftp://ph.example.com", "scheme", true],
+      ["https://", "no usable host", true],
+      ["not a posthog host", "not a parseable URL", false],
+    ] as const) {
+      process.env.POSTHOG_HOST = bad;
+      vi.resetModules();
+      const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+      const warns: string[] = [];
+      const spy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(
+          (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
+        );
+      try {
+        expect(freshGet().posthogHost, `value ${JSON.stringify(bad)}`).toBe(
+          "https://eu.i.posthog.com",
+        );
+        const warn = warns.find((m) => m.includes("POSTHOG_HOST"));
+        expect(warn, `value ${JSON.stringify(bad)} should warn`).toBeDefined();
+        expect(warn, `value ${JSON.stringify(bad)}`).toContain(mustInclude);
+        if (parsedFine) {
+          // The value parsed and (for ftp://) no prepend happened — the
+          // parse-failure clauses must not appear.
+          expect(warn).not.toContain("not a parseable URL");
+          expect(warn).not.toContain("even after prepending");
+        }
+      } finally {
+        spy.mockRestore();
+      }
     }
   });
 
@@ -1006,7 +1245,9 @@ describe("server getRuntimeConfig (shell)", () => {
       const warns: string[] = [];
       const spy = vi
         .spyOn(console, "warn")
-        .mockImplementation((m: string) => void warns.push(m));
+        .mockImplementation(
+          (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
+        );
       try {
         const cfg = freshGet();
         expect(cfg.posthogHost, `value ${JSON.stringify(bad)}`).toBe(
@@ -1063,7 +1304,9 @@ describe("server getRuntimeConfig (shell)", () => {
       const warns: string[] = [];
       const spy = vi
         .spyOn(console, "warn")
-        .mockImplementation((m: string) => void warns.push(m));
+        .mockImplementation(
+          (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
+        );
       try {
         expect(freshGet().posthogHost, `value ${JSON.stringify(bad)}`).toBe(
           expected,

--- a/showcase/shell/src/lib/runtime-config.test.ts
+++ b/showcase/shell/src/lib/runtime-config.test.ts
@@ -17,8 +17,12 @@ describe("server getRuntimeConfig (shell)", () => {
     for (const k of [
       "BASE_URL",
       "POSTHOG_HOST",
+      "DOCS_HOST",
+      "SHOWCASE_BACKEND_HOST_PATTERN",
       "NEXT_PUBLIC_BASE_URL",
       "NEXT_PUBLIC_POSTHOG_HOST",
+      "NEXT_PUBLIC_DOCS_HOST",
+      "NEXT_PUBLIC_SHOWCASE_BACKEND_HOST_PATTERN",
       "NODE_ENV",
     ]) {
       delete (process.env as Record<string, string | undefined>)[k];
@@ -26,6 +30,15 @@ describe("server getRuntimeConfig (shell)", () => {
   });
 
   afterEach(() => {
+    // Full restore, not just value restore: Object.assign alone cannot
+    // DELETE keys a test added (e.g. DOCS_HOST set by a test but absent
+    // from the snapshot), which poisons other test FILES under vitest
+    // worker reuse. Drop added keys first, then restore values.
+    for (const key of Object.keys(process.env)) {
+      if (!(key in ORIGINAL_ENV)) {
+        delete (process.env as Record<string, string | undefined>)[key];
+      }
+    }
     Object.assign(process.env, ORIGINAL_ENV);
   });
 
@@ -36,7 +49,113 @@ describe("server getRuntimeConfig (shell)", () => {
     expect(getRuntimeConfig()).toEqual({
       baseUrl: "https://showcase.copilotkit.ai",
       posthogHost: "https://eu.i.posthog.com",
+      // Defaults preserved when the new env vars are unset — prod
+      // requires NO env change.
+      backendHostPattern: "showcase-{slug}-production.up.railway.app",
+      docsHost: "https://docs.showcase.copilotkit.ai",
     });
+  });
+
+  it("backendHostPattern/docsHost default to prod values when unset (both envs, no FATAL log)", () => {
+    for (const nodeEnv of ["production", "development"]) {
+      (process.env as Record<string, string>).NODE_ENV = nodeEnv;
+      process.env.BASE_URL = "https://showcase.copilotkit.ai";
+      const errs: string[] = [];
+      const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
+        errs.push(m);
+      });
+      const cfg = getRuntimeConfig();
+      spy.mockRestore();
+      expect(cfg.backendHostPattern).toBe(
+        "showcase-{slug}-production.up.railway.app",
+      );
+      expect(cfg.docsHost).toBe("https://docs.showcase.copilotkit.ai");
+      // These have legitimate prod defaults — never FATAL-CONFIG noise.
+      expect(errs.some((m) => m.includes("DOCS_HOST"))).toBe(false);
+      expect(
+        errs.some((m) => m.includes("SHOWCASE_BACKEND_HOST_PATTERN")),
+      ).toBe(false);
+    }
+  });
+
+  it("honors SHOWCASE_BACKEND_HOST_PATTERN and DOCS_HOST at request time", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://staging.example.com";
+    process.env.SHOWCASE_BACKEND_HOST_PATTERN =
+      "showcase-{slug}-staging.up.railway.app";
+    process.env.DOCS_HOST = "https://docs-staging.example.com/";
+    const cfg = getRuntimeConfig();
+    expect(cfg.backendHostPattern).toBe(
+      "showcase-{slug}-staging.up.railway.app",
+    );
+    // docsHost is a URL — trailing slash stripped like the others.
+    expect(cfg.docsHost).toBe("https://docs-staging.example.com");
+
+    // Live re-read on each call (no module-load freeze).
+    process.env.DOCS_HOST = "https://docs-staging2.example.com";
+    expect(getRuntimeConfig().docsHost).toBe(
+      "https://docs-staging2.example.com",
+    );
+  });
+
+  it("normalizes a scheme-bearing / slash-trailing SHOWCASE_BACKEND_HOST_PATTERN", () => {
+    // The consumer (backendUrlFromPattern) prepends `https://` and
+    // concatenates routes — a scheme-bearing value would yield
+    // `https://https://…` and a trailing slash would yield `//route`.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    process.env.SHOWCASE_BACKEND_HOST_PATTERN =
+      "https://showcase-{slug}-staging.up.railway.app/";
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(getRuntimeConfig().backendHostPattern).toBe(
+        "showcase-{slug}-staging.up.railway.app",
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("prepends https:// when DOCS_HOST lacks a scheme (host-only misconfig)", () => {
+    // Middleware does `new URL(docsHost)` on every docs route. A
+    // host-only DOCS_HOST (the documented format of the sibling
+    // SHOWCASE_BACKEND_HOST_PATTERN var, an easy misconfig) must NOT
+    // produce an unparseable URL that 500s every docs request.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    process.env.DOCS_HOST = "docs-staging.example.com";
+    const cfg = getRuntimeConfig();
+    expect(cfg.docsHost).toBe("https://docs-staging.example.com");
+    expect(() => new URL(cfg.docsHost)).not.toThrow();
+  });
+
+  it("preserves an explicit http:// scheme on DOCS_HOST", () => {
+    (process.env as Record<string, string>).NODE_ENV = "development";
+    process.env.DOCS_HOST = "http://localhost:3005";
+    expect(getRuntimeConfig().docsHost).toBe("http://localhost:3005");
+  });
+
+  it("falls back to the default docs host (with one loud log) when DOCS_HOST is unparseable", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    // Spaces make the host unparseable even after prepending https://.
+    process.env.DOCS_HOST = "not a parseable host";
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
+      errs.push(m);
+    });
+    try {
+      const cfg = getRuntimeConfig();
+      expect(cfg.docsHost).toBe("https://docs.showcase.copilotkit.ai");
+      expect(() => new URL(cfg.docsHost)).not.toThrow();
+      expect(errs.some((m) => m.includes("DOCS_HOST"))).toBe(true);
+      // Loud log fires ONCE per bad value, not per request.
+      const before = errs.length;
+      getRuntimeConfig();
+      expect(errs.length).toBe(before);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("strips trailing slashes", () => {
@@ -122,19 +241,26 @@ describe("server getRuntimeConfig (shell)", () => {
   it("getRuntimeConfigForMiddleware skips noStore() (Edge runtime path)", async () => {
     const cacheMod = await import("next/cache");
     const noStoreSpy = vi.spyOn(cacheMod, "unstable_noStore");
-    (process.env as Record<string, string>).NODE_ENV = "production";
-    process.env.BASE_URL = "https://edge.example.com";
-    process.env.POSTHOG_HOST = "https://edge-posthog.example.com";
+    // try/finally so a failing assertion can't leak the spy into other
+    // tests — mockRestore after the assertions alone never runs on failure.
+    try {
+      (process.env as Record<string, string>).NODE_ENV = "production";
+      process.env.BASE_URL = "https://edge.example.com";
+      process.env.POSTHOG_HOST = "https://edge-posthog.example.com";
 
-    const { getRuntimeConfigForMiddleware } = await import("./runtime-config");
-    const cfg = getRuntimeConfigForMiddleware();
-    expect(cfg.baseUrl).toBe("https://edge.example.com");
-    expect(noStoreSpy).not.toHaveBeenCalled();
+      const { getRuntimeConfigForMiddleware } = await import(
+        "./runtime-config"
+      );
+      const cfg = getRuntimeConfigForMiddleware();
+      expect(cfg.baseUrl).toBe("https://edge.example.com");
+      expect(noStoreSpy).not.toHaveBeenCalled();
 
-    // And confirm the default entrypoint DOES call noStore().
-    noStoreSpy.mockClear();
-    getRuntimeConfig();
-    expect(noStoreSpy).toHaveBeenCalledTimes(1);
-    noStoreSpy.mockRestore();
+      // And confirm the default entrypoint DOES call noStore().
+      noStoreSpy.mockClear();
+      getRuntimeConfig();
+      expect(noStoreSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      noStoreSpy.mockRestore();
+    }
   });
 });

--- a/showcase/shell/src/lib/runtime-config.test.ts
+++ b/showcase/shell/src/lib/runtime-config.test.ts
@@ -300,7 +300,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation(
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation(
         (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
       );
     try {
@@ -327,7 +329,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation(
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation(
         (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
       );
     try {
@@ -352,7 +356,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation(
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation(
         (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
       );
     try {
@@ -375,7 +381,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation(
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation(
         (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
       );
     try {
@@ -441,8 +449,8 @@ describe("server getRuntimeConfig (shell)", () => {
     const spy = vi
       .spyOn(console, "error")
       .mockImplementation(
-          (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
-        );
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
     try {
       expect(freshGet().baseUrl).toBe("https://shell-base-url-missing.invalid");
       expect(errs.some((m) => m.includes("BASE_URL"))).toBe(true);
@@ -498,13 +506,13 @@ describe("server getRuntimeConfig (shell)", () => {
     const warnSpy = vi
       .spyOn(console, "warn")
       .mockImplementation(
-          (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
-        );
+        (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
+      );
     const errSpy = vi
       .spyOn(console, "error")
       .mockImplementation(
-          (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
-        );
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
     try {
       const cfg = freshGet();
       expect(cfg.baseUrl).toBe("http://localhost:3000");
@@ -527,8 +535,8 @@ describe("server getRuntimeConfig (shell)", () => {
     const spy = vi
       .spyOn(console, "error")
       .mockImplementation(
-          (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
-        );
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
     try {
       freshGet();
       const fatal = errs.find((m) => m.includes("BASE_URL is unset"));
@@ -546,7 +554,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation(
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation(
         (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
       );
     try {
@@ -607,7 +617,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation(
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation(
         (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
       );
     try {
@@ -674,7 +686,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation(
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation(
         (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
       );
     try {
@@ -703,13 +717,13 @@ describe("server getRuntimeConfig (shell)", () => {
     const warnSpy = vi
       .spyOn(console, "warn")
       .mockImplementation(
-          (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
-        );
+        (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
+      );
     const errSpy = vi
       .spyOn(console, "error")
       .mockImplementation(
-          (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
-        );
+        (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
+      );
     try {
       const cfg = freshGet();
       // Same fallback VALUE as prod — only the log level/text branches.
@@ -737,7 +751,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation(
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation(
         (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
       );
     try {
@@ -765,7 +781,9 @@ describe("server getRuntimeConfig (shell)", () => {
     const { getRuntimeConfig: freshGet, DOCS_REDIRECTS_DISABLED_HOST } =
       await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation(
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation(
         (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
       );
     try {
@@ -802,7 +820,9 @@ describe("server getRuntimeConfig (shell)", () => {
     const { getRuntimeConfig: freshGet, DOCS_REDIRECTS_DISABLED_HOST } =
       await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation(
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation(
         (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
       );
     try {
@@ -990,7 +1010,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation(
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation(
         (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
       );
     // try/finally so a throwing call can't leak the spy into other
@@ -1022,7 +1044,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
-    const spy = vi.spyOn(console, "error").mockImplementation(
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation(
         (...args: unknown[]) => void errs.push(args.map(String).join(" ")),
       );
     try {
@@ -1041,7 +1065,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const warns: string[] = [];
-    const spy = vi.spyOn(console, "warn").mockImplementation(
+    const spy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(
         (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
       );
     try {
@@ -1151,7 +1177,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const warns: string[] = [];
-    const spy = vi.spyOn(console, "warn").mockImplementation(
+    const spy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(
         (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
       );
     try {
@@ -1174,7 +1202,9 @@ describe("server getRuntimeConfig (shell)", () => {
     vi.resetModules();
     const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const warns: string[] = [];
-    const spy = vi.spyOn(console, "warn").mockImplementation(
+    const spy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(
         (...args: unknown[]) => void warns.push(args.map(String).join(" ")),
       );
     try {

--- a/showcase/shell/src/lib/runtime-config.test.ts
+++ b/showcase/shell/src/lib/runtime-config.test.ts
@@ -17,10 +17,12 @@ describe("server getRuntimeConfig (shell)", () => {
     for (const k of [
       "BASE_URL",
       "POSTHOG_HOST",
+      "POSTHOG_KEY",
       "DOCS_HOST",
       "SHOWCASE_BACKEND_HOST_PATTERN",
       "NEXT_PUBLIC_BASE_URL",
       "NEXT_PUBLIC_POSTHOG_HOST",
+      "NEXT_PUBLIC_POSTHOG_KEY",
       "NEXT_PUBLIC_DOCS_HOST",
       "NEXT_PUBLIC_SHOWCASE_BACKEND_HOST_PATTERN",
       "NODE_ENV",
@@ -56,16 +58,28 @@ describe("server getRuntimeConfig (shell)", () => {
     });
   });
 
-  it("backendHostPattern/docsHost default to prod values when unset (both envs, no FATAL log)", () => {
+  it("backendHostPattern/docsHost default to prod values when unset (both envs, no FATAL log)", async () => {
     for (const nodeEnv of ["production", "development"]) {
       (process.env as Record<string, string>).NODE_ENV = nodeEnv;
       process.env.BASE_URL = "https://showcase.copilotkit.ai";
+      // The no-FATAL assertions below are about ABSENCE — on the static
+      // module instance they can pass vacuously when a prior test
+      // already consumed the once-guard for these keys. Fresh module so
+      // a log would actually fire if the code were wrong.
+      vi.resetModules();
+      const { getRuntimeConfig: freshGet } = await import("./runtime-config");
       const errs: string[] = [];
       const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
         errs.push(m);
       });
-      const cfg = getRuntimeConfig();
-      spy.mockRestore();
+      // try/finally so a failing assertion can't leak the spy into
+      // other tests (matches every other spy in this file).
+      let cfg: ReturnType<typeof freshGet>;
+      try {
+        cfg = freshGet();
+      } finally {
+        spy.mockRestore();
+      }
       expect(cfg.backendHostPattern).toBe(
         "showcase-{slug}-production.up.railway.app",
       );
@@ -116,6 +130,46 @@ describe("server getRuntimeConfig (shell)", () => {
     }
   });
 
+  it("degenerate SHOWCASE_BACKEND_HOST_PATTERN falls back to the default pattern, never an empty string", async () => {
+    // Fix-round interaction bug: "https://" normalized to "" with NO
+    // fallback — server-side iframe srcs became literally "https://",
+    // and the injected "" failed the client reader's
+    // REQUIRED_CONFIG_FIELDS check, crashing EVERY client component
+    // with a message blaming the layout injection instead of the env
+    // var. The degenerate value must produce the default + one FATAL.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    for (const bad of ["https://", "/"]) {
+      process.env.SHOWCASE_BACKEND_HOST_PATTERN = bad;
+      vi.resetModules();
+      const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+      const errs: string[] = [];
+      const errSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation((m: string) => void errs.push(m));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const cfg = freshGet();
+        expect(cfg.backendHostPattern, `pattern ${JSON.stringify(bad)}`).toBe(
+          "showcase-{slug}-production.up.railway.app",
+        );
+        // The client reader requires a non-empty string — this is the
+        // exact invariant the round-3 check enforces.
+        expect(cfg.backendHostPattern.length).toBeGreaterThan(0);
+        expect(
+          errs.some(
+            (m) =>
+              m.includes("FATAL-CONFIG") &&
+              m.includes("SHOWCASE_BACKEND_HOST_PATTERN"),
+          ),
+        ).toBe(true);
+      } finally {
+        errSpy.mockRestore();
+        warnSpy.mockRestore();
+      }
+    }
+  });
+
   it("prepends https:// when DOCS_HOST lacks a scheme (host-only misconfig)", () => {
     // Middleware does `new URL(docsHost)` on every docs route. A
     // host-only DOCS_HOST (the documented format of the sibling
@@ -127,6 +181,26 @@ describe("server getRuntimeConfig (shell)", () => {
     const cfg = getRuntimeConfig();
     expect(cfg.docsHost).toBe("https://docs-staging.example.com");
     expect(() => new URL(cfg.docsHost)).not.toThrow();
+  });
+
+  it("prepends http:// (not https://) to scheme-less LOOPBACK hosts", () => {
+    // The documented local-dev DOCS_HOST wiring is `localhost:3005` —
+    // an https:// prepend turns it into a TLS-failing destination with
+    // zero warn (nothing serves TLS on a local dev port). Loopback
+    // hosts (localhost, 127.0.0.1, [::1]) get http:// instead, across
+    // every ensureScheme consumer (BASE_URL, DOCS_HOST, POSTHOG_HOST).
+    (process.env as Record<string, string>).NODE_ENV = "development";
+    process.env.BASE_URL = "localhost:3000";
+    process.env.DOCS_HOST = "localhost:3005";
+    process.env.POSTHOG_HOST = "127.0.0.1:8010";
+    const cfg = getRuntimeConfig();
+    expect(cfg.baseUrl).toBe("http://localhost:3000");
+    expect(cfg.docsHost).toBe("http://localhost:3005");
+    expect(cfg.posthogHost).toBe("http://127.0.0.1:8010");
+
+    // IPv6 loopback too.
+    process.env.DOCS_HOST = "[::1]:3005";
+    expect(getRuntimeConfig().docsHost).toBe("http://[::1]:3005");
   });
 
   it("preserves an explicit http:// scheme on DOCS_HOST", () => {
@@ -185,6 +259,511 @@ describe("server getRuntimeConfig (shell)", () => {
     }
   });
 
+  it("prepends https:// when BASE_URL lacks a scheme (host-only misconfig)", async () => {
+    // Consumers compose `new URL(path, baseUrl)` — a scheme-less value
+    // previously passed readUrl unvalidated and threw at every compose
+    // site: opaque 500s with NO log (the env var IS set, so the
+    // unset-fallback never fires).
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "shell.copilotkit.ai";
+    // The no-FATAL assertion below is an ABSENCE assertion — vacuous on
+    // the static module instance if a prior test consumed the BASE_URL
+    // once-guard. Fresh module so a log would actually fire.
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
+      errs.push(m);
+    });
+    try {
+      const cfg = freshGet();
+      expect(cfg.baseUrl).toBe("https://shell.copilotkit.ai");
+      expect(() => new URL("/some/path", cfg.baseUrl)).not.toThrow();
+      // The prepend FIXES the value — no FATAL noise for it.
+      expect(errs.some((m) => m.includes("BASE_URL"))).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("falls back to the sentinel (one loud log naming the value) for a degenerate BASE_URL of just a scheme", async () => {
+    // `https://` is reduced to `https:` by the trailing-slash strip,
+    // ensureScheme yields `https://https:` which PARSES (hostname
+    // "https") — it must be rejected, not silently returned.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
+      errs.push(m);
+    });
+    try {
+      const cfg = freshGet();
+      expect(cfg.baseUrl).toBe("https://shell-base-url-missing.invalid");
+      expect(() => new URL("/some/path", cfg.baseUrl)).not.toThrow();
+      // The log must NAME the bad value so the operator can find it.
+      // (readUrl's trailing-slash strip runs first, so the named value
+      // is the post-strip "https:" — still unambiguous.)
+      expect(
+        errs.some((m) => m.includes("BASE_URL") && m.includes('"https:')),
+      ).toBe(true);
+      // Once-guarded — not per request.
+      const before = errs.length;
+      freshGet();
+      expect(errs.length).toBe(before);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("rejects a non-http(s) BASE_URL scheme with the sentinel (ftp:// and the dot-scheme edge)", async () => {
+    // `ftp://shell.x` parses fine; `example.com://oops` matches
+    // SCHEME_RE (dot is a valid scheme char) so ensureScheme leaves it
+    // and it parses with protocol "example.com:" and hostname "oops".
+    // Neither can serve consumers composing http(s) URLs.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    for (const bad of ["ftp://shell.example.com", "example.com://oops"]) {
+      process.env.BASE_URL = bad;
+      vi.resetModules();
+      const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+      const errs: string[] = [];
+      const spy = vi
+        .spyOn(console, "error")
+        .mockImplementation((m: string) => void errs.push(m));
+      try {
+        const cfg = freshGet();
+        expect(cfg.baseUrl, `value ${JSON.stringify(bad)}`).toBe(
+          "https://shell-base-url-missing.invalid",
+        );
+        expect(
+          errs.some((m) => m.includes("BASE_URL") && m.includes("scheme")),
+          `value ${JSON.stringify(bad)} should log a scheme rejection`,
+        ).toBe(true);
+      } finally {
+        spy.mockRestore();
+      }
+    }
+  });
+
+  it("rejects a mailto: BASE_URL (userinfo after the https:// prepend) with the sentinel", async () => {
+    // `mailto:ops@example.com` lacks `://` so SCHEME_RE misses it and
+    // the prepend yields `https://mailto:ops@example.com` — a URL with
+    // userinfo "mailto:ops" and host "example.com" that previously
+    // sailed through validation.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "mailto:ops@example.com";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const errs: string[] = [];
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation((m: string) => void errs.push(m));
+    try {
+      expect(freshGet().baseUrl).toBe("https://shell-base-url-missing.invalid");
+      expect(errs.some((m) => m.includes("BASE_URL"))).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("origin-normalizes a BASE_URL carrying a path/query/fragment with one warn (subpath deploys unsupported)", async () => {
+    // Consumers compose `new URL(path, baseUrl)` — a path/query/fragment
+    // silently corrupts every composed URL (a base path is dropped by
+    // composition, a fragment swallows the path).
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    for (const [bad, why] of [
+      ["https://shell.example.com/sub", "path"],
+      ["https://shell.example.com?a=b", "query"],
+      ["https://shell.example.com#frag", "fragment"],
+    ] as const) {
+      process.env.BASE_URL = bad;
+      vi.resetModules();
+      const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+      const warns: string[] = [];
+      const spy = vi
+        .spyOn(console, "warn")
+        .mockImplementation((m: string) => void warns.push(m));
+      try {
+        expect(freshGet().baseUrl, `${why} should normalize to origin`).toBe(
+          "https://shell.example.com",
+        );
+        expect(warns.some((m) => m.includes("BASE_URL"))).toBe(true);
+        // Once-guarded — not per request.
+        const before = warns.length;
+        freshGet();
+        expect(warns.length).toBe(before);
+      } finally {
+        spy.mockRestore();
+      }
+    }
+  });
+
+  it("dev-mode SET-but-malformed BASE_URL falls back to localhost with a dev warn, not the prod sentinel", async () => {
+    // The module's contract is frictionless dev: a malformed value in
+    // development previously fell to the PROD `.invalid` sentinel with
+    // Railway-flavored guidance — useless on a laptop.
+    (process.env as Record<string, string>).NODE_ENV = "development";
+    process.env.BASE_URL = "https://";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const warns: string[] = [];
+    const errs: string[] = [];
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation((m: string) => void warns.push(m));
+    const errSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation((m: string) => void errs.push(m));
+    try {
+      const cfg = freshGet();
+      expect(cfg.baseUrl).toBe("http://localhost:3000");
+      expect(warns.some((m) => m.includes("BASE_URL"))).toBe(true);
+      // No FATAL noise and no Railway guidance in dev.
+      expect(errs.some((m) => m.includes("BASE_URL"))).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+
+  it("unset-BASE_URL FATAL names the post-strip sentinel (consistent with the returned value)", async () => {
+    // readUrl returns the trailing-slash-stripped fallback but printed
+    // the PRE-strip form — the log named a value that never appears.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const errs: string[] = [];
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation((m: string) => void errs.push(m));
+    try {
+      freshGet();
+      const fatal = errs.find((m) => m.includes("BASE_URL is unset"));
+      expect(fatal).toBeDefined();
+      expect(fatal).toContain("https://shell-base-url-missing.invalid");
+      expect(fatal).not.toContain("shell-base-url-missing.invalid/");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("falls back to the sentinel (one loud log) when BASE_URL is unparseable garbage", async () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "not a base url";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
+      errs.push(m);
+    });
+    try {
+      const cfg = freshGet();
+      expect(cfg.baseUrl).toBe("https://shell-base-url-missing.invalid");
+      expect(
+        errs.some(
+          (m) => m.includes("BASE_URL") && m.includes('"not a base url"'),
+        ),
+      ).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("normalizes a DOCS_HOST carrying a path/query/fragment to its origin (one warn)", async () => {
+    // docs-redirects composes destination paths against this value — a
+    // fragment swallows the path (`https://docs.x.ai#frag` + `/docs/y`
+    // lands on the docs ROOT), a query/path corrupts every destination.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    for (const [bad, why] of [
+      ["https://docs.example.com/sub", "path"],
+      ["https://docs.example.com?a=b", "query"],
+      ["https://docs.example.com#frag", "fragment"],
+    ] as const) {
+      process.env.DOCS_HOST = bad;
+      vi.resetModules();
+      const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+      const warns: string[] = [];
+      const spy = vi.spyOn(console, "warn").mockImplementation((m: string) => {
+        warns.push(m);
+      });
+      try {
+        const cfg = freshGet();
+        expect(cfg.docsHost, `${why} should normalize to origin`).toBe(
+          "https://docs.example.com",
+        );
+        expect(warns.some((m) => m.includes("DOCS_HOST"))).toBe(true);
+        // Once-guarded — not per request.
+        const before = warns.length;
+        freshGet();
+        expect(warns.length).toBe(before);
+      } finally {
+        spy.mockRestore();
+      }
+    }
+  });
+
+  it("rejects a non-http(s) DOCS_HOST scheme (ftp://) with the loud fallback", async () => {
+    // `ftp://docs.example.com` parses fine — but no middleware redirect
+    // destination can ever use it; it must not pass validation silently.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    process.env.DOCS_HOST = "ftp://docs.example.com";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
+      errs.push(m);
+    });
+    try {
+      const cfg = freshGet();
+      expect(cfg.docsHost).toBe("https://docs.showcase.copilotkit.ai");
+      // The reason must be the scheme — NOT the catch-all "not a
+      // parseable URL" mislabel (it parsed just fine).
+      expect(
+        errs.some(
+          (m) =>
+            m.includes("DOCS_HOST") &&
+            m.includes("scheme") &&
+            !m.includes("not a parseable URL"),
+        ),
+      ).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("rejects a credentialed DOCS_HOST (userinfo) with the loud fallback", async () => {
+    // A credentialed DOCS_HOST lands userinfo in every 308 Location —
+    // browsers strip or silently block credentialed redirect
+    // destinations, so docs redirects break with zero signal. Same
+    // rejection validateBaseUrl has.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    for (const bad of [
+      "https://user:pass@docs.example.com",
+      // Scheme-less form: the https:// prepend manufactures the
+      // userinfo (`user:pass@docs…` → `https://user:pass@docs…`).
+      "user:pass@docs.example.com",
+    ]) {
+      process.env.DOCS_HOST = bad;
+      vi.resetModules();
+      const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+      const errs: string[] = [];
+      const spy = vi
+        .spyOn(console, "error")
+        .mockImplementation((m: string) => void errs.push(m));
+      try {
+        const cfg = freshGet();
+        expect(cfg.docsHost, `value ${JSON.stringify(bad)}`).toBe(
+          "https://docs.showcase.copilotkit.ai",
+        );
+        expect(
+          errs.some((m) => m.includes("DOCS_HOST") && m.includes("userinfo")),
+          `value ${JSON.stringify(bad)} should log a userinfo rejection`,
+        ).toBe(true);
+      } finally {
+        spy.mockRestore();
+      }
+    }
+  });
+
+  it("labels the degenerate-host rejection as such, not as a parse failure", async () => {
+    // `https://` DID parse (hostname "https") — the operator-facing log
+    // must not send them hunting for a syntax error that isn't there.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    process.env.DOCS_HOST = "https://";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
+      errs.push(m);
+    });
+    try {
+      freshGet();
+      expect(
+        errs.some(
+          (m) => m.includes("DOCS_HOST") && !m.includes("not a parseable URL"),
+        ),
+      ).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("dev-mode SET-but-broken DOCS_HOST falls back with a dev warn, not FATAL-CONFIG / Railway guidance", async () => {
+    // Same dev-vs-prod branch validateBaseUrl has: the FATAL-CONFIG
+    // error and Railway guidance are useless on a laptop — the dev
+    // contract is frictionless iteration with a warn.
+    (process.env as Record<string, string>).NODE_ENV = "development";
+    process.env.BASE_URL = "http://localhost:3000";
+    process.env.DOCS_HOST = "https://";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const warns: string[] = [];
+    const errs: string[] = [];
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation((m: string) => void warns.push(m));
+    const errSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation((m: string) => void errs.push(m));
+    try {
+      const cfg = freshGet();
+      // Same fallback VALUE as prod — only the log level/text branches.
+      expect(cfg.docsHost).toBe("https://docs.showcase.copilotkit.ai");
+      expect(warns.some((m) => m.includes("DOCS_HOST"))).toBe(true);
+      // No FATAL noise and no Railway guidance in dev.
+      expect(errs.some((m) => m.includes("DOCS_HOST"))).toBe(false);
+      expect(
+        warns.some((m) => m.includes("DOCS_HOST") && m.includes("Railway")),
+      ).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+
+  it("falls back to the default docs host (one loud log) when DOCS_HOST points at the shell's own host", async () => {
+    // The redirect table has self-referential entries (/faq → /faq etc.)
+    // that terminate ONLY because the destination host differs. An
+    // operator pointing DOCS_HOST at the shell's own host turns ~15
+    // paths into ERR_TOO_MANY_REDIRECTS loops.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://shell.example.com";
+    process.env.DOCS_HOST = "https://shell.example.com";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
+      errs.push(m);
+    });
+    try {
+      const cfg = freshGet();
+      expect(cfg.docsHost).toBe("https://docs.showcase.copilotkit.ai");
+      expect(errs.some((m) => m.includes("DOCS_HOST"))).toBe(true);
+      // Once-guarded — not per request.
+      const before = errs.length;
+      freshGet();
+      expect(errs.length).toBe(before);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("disables docs redirects (sentinel) when the shell is deployed AT the default docs host with DOCS_HOST unset", async () => {
+    // The unconditional DEFAULT_DOCS_HOST fallback can carry the same
+    // defect it's escaping: shell deployed at the docs host with
+    // DOCS_HOST unset used to log a self-contradictory FATAL ("falling
+    // back to <the same looping value>") AND return the looping value.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://docs.showcase.copilotkit.ai";
+    // DOCS_HOST deliberately unset.
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet, DOCS_REDIRECTS_DISABLED_HOST } =
+      await import("./runtime-config");
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
+      errs.push(m);
+    });
+    try {
+      const cfg = freshGet();
+      expect(cfg.docsHost).toBe(DOCS_REDIRECTS_DISABLED_HOST);
+      // The sentinel must be parseable (incidental new URL consumers)
+      // and distinct from the looping default.
+      expect(() => new URL(cfg.docsHost)).not.toThrow();
+      expect(cfg.docsHost).not.toBe("https://docs.showcase.copilotkit.ai");
+      // Branched message: names the UNSET case and says redirects are
+      // disabled — never the self-contradictory "falling back to" the
+      // very value that loops.
+      const fatal = errs.find((m) => m.includes("DOCS_HOST"));
+      expect(fatal).toBeDefined();
+      expect(fatal).toContain("unset");
+      expect(fatal).toContain("disabled");
+      expect(fatal).not.toContain(
+        "falling back to https://docs.showcase.copilotkit.ai",
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("disables docs redirects (sentinel) when DOCS_HOST is rejected AND the default fallback also collides", async () => {
+    // Shell deployed at the docs host with DOCS_HOST explicitly SET to
+    // that same host: the configured value is rejected (self-host) and
+    // the default fallback has the identical defect — return the
+    // disabled sentinel, not the looping default.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://docs.showcase.copilotkit.ai";
+    process.env.DOCS_HOST = "https://docs.showcase.copilotkit.ai";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet, DOCS_REDIRECTS_DISABLED_HOST } =
+      await import("./runtime-config");
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
+      errs.push(m);
+    });
+    try {
+      const cfg = freshGet();
+      expect(cfg.docsHost).toBe(DOCS_REDIRECTS_DISABLED_HOST);
+      const fatal = errs.find((m) => m.includes("DOCS_HOST"));
+      expect(fatal).toBeDefined();
+      expect(fatal).toContain("disabled");
+      expect(fatal).not.toContain(
+        "falling back to https://docs.showcase.copilotkit.ai",
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("still falls back to the default docs host when only the CONFIGURED value collides", async () => {
+    // The fallback re-check must not over-trigger: a shell at its own
+    // (non-docs) host with a colliding DOCS_HOST keeps the working
+    // default — redirects stay enabled.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://shell.example.com";
+    process.env.DOCS_HOST = "https://shell.example.com";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(freshGet().docsHost).toBe("https://docs.showcase.copilotkit.ai");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("does NOT trip the loop guard for same-hostname different-port docs (local dev)", () => {
+    // The loop predicate is the full authority (host:port), not the
+    // hostname: localhost:3000 (shell) → localhost:3005 (docs) is the
+    // documented dev wiring and terminates fine.
+    (process.env as Record<string, string>).NODE_ENV = "development";
+    process.env.BASE_URL = "http://localhost:3000";
+    process.env.DOCS_HOST = "http://localhost:3005";
+    expect(getRuntimeConfig().docsHost).toBe("http://localhost:3005");
+  });
+
+  it("returns the parsed-normalized form (host case, default port) for BASE_URL/DOCS_HOST/POSTHOG_HOST", () => {
+    // Validation already PARSES every value — returning the raw
+    // candidate string instead of the parsed form leaked un-normalized
+    // values (uppercase hosts, explicit default ports) to consumers,
+    // while the internal comparisons (e.g. the docs self-host guard)
+    // operate on parsed forms: the same authority could compare unequal
+    // to itself depending on which side was spelled canonically.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://Shell.Example.COM:443";
+    process.env.DOCS_HOST = "https://Docs.Example.COM:443";
+    process.env.POSTHOG_HOST = "https://Proxy.Example.COM:443/ingest";
+    const cfg = getRuntimeConfig();
+    expect(cfg.baseUrl).toBe("https://shell.example.com");
+    expect(cfg.docsHost).toBe("https://docs.example.com");
+    // Path preserved (reverse-proxy ingest), host normalized.
+    expect(cfg.posthogHost).toBe("https://proxy.example.com/ingest");
+  });
+
   it("strips trailing slashes", () => {
     (process.env as Record<string, string>).NODE_ENV = "production";
     process.env.BASE_URL = "https://showcase.example.com/";
@@ -217,8 +796,14 @@ describe("server getRuntimeConfig (shell)", () => {
     const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
       errs.push(m);
     });
-    const cfg = freshGet();
-    spy.mockRestore();
+    // try/finally so a throwing call can't leak the spy into other
+    // tests (matches every other spy in this file).
+    let cfg: ReturnType<typeof freshGet>;
+    try {
+      cfg = freshGet();
+    } finally {
+      spy.mockRestore();
+    }
     expect(cfg.baseUrl).toBe("https://shell-base-url-missing.invalid");
     // The sentinel must be a hierarchical URL: the previous
     // `about:blank#...` form was opaque-path, and `new URL(path, base)`
@@ -358,7 +943,172 @@ describe("server getRuntimeConfig (shell)", () => {
     expect(cfg.posthogHost).toBe("https://alt-ph.example.com");
   });
 
+  it("rejects a degenerate POSTHOG_HOST of just a scheme with one warn + default fallback", async () => {
+    // `https://` → readKey strips to `https:` → ensureScheme yields
+    // `https://https:` which PARSES (hostname "https") and would point
+    // every capture fetch at an unresolvable host — all analytics die
+    // via DNS, silently. Same rejection readDocsHost has.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    process.env.POSTHOG_HOST = "https://";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const warns: string[] = [];
+    const spy = vi.spyOn(console, "warn").mockImplementation((m: string) => {
+      warns.push(m);
+    });
+    try {
+      const cfg = freshGet();
+      expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
+      expect(warns.some((m) => m.includes("POSTHOG_HOST"))).toBe(true);
+      // Once-guarded — not per request.
+      const before = warns.length;
+      freshGet();
+      expect(warns.length).toBe(before);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("rejects a non-http(s) POSTHOG_HOST scheme with the default fallback", async () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    process.env.POSTHOG_HOST = "ftp://ph.example.com";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const warns: string[] = [];
+    const spy = vi.spyOn(console, "warn").mockImplementation((m: string) => {
+      warns.push(m);
+    });
+    try {
+      expect(freshGet().posthogHost).toBe("https://eu.i.posthog.com");
+      expect(warns.some((m) => m.includes("POSTHOG_HOST"))).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("rejects a credentialed POSTHOG_HOST (userinfo) with one warn + default fallback", async () => {
+    // The Fetch spec forbids credentialed request URLs — a userinfo-
+    // bearing POSTHOG_HOST makes every capture fetch throw a TypeError
+    // that middleware misattributes as a net-class failure. Same
+    // rejection validateBaseUrl/readDocsHost have.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    for (const bad of [
+      "https://user:pass@ph.example.com",
+      // Scheme-less form: the https:// prepend manufactures the userinfo.
+      "user:pass@ph.example.com",
+    ]) {
+      process.env.POSTHOG_HOST = bad;
+      vi.resetModules();
+      const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+      const warns: string[] = [];
+      const spy = vi
+        .spyOn(console, "warn")
+        .mockImplementation((m: string) => void warns.push(m));
+      try {
+        const cfg = freshGet();
+        expect(cfg.posthogHost, `value ${JSON.stringify(bad)}`).toBe(
+          "https://eu.i.posthog.com",
+        );
+        expect(
+          warns.some(
+            (m) => m.includes("POSTHOG_HOST") && m.includes("userinfo"),
+          ),
+          `value ${JSON.stringify(bad)} should warn a userinfo rejection`,
+        ).toBe(true);
+        // Once-guarded — not per request.
+        const before = warns.length;
+        freshGet();
+        expect(warns.length).toBe(before);
+      } finally {
+        spy.mockRestore();
+      }
+    }
+  });
+
+  it("preserves a path-bearing POSTHOG_HOST (reverse-proxy ingest paths are legitimate)", () => {
+    // Unlike DOCS_HOST, a path here is NOT a misconfig: path-based
+    // PostHog reverse proxies (e.g. /ingest) are a documented pattern.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    process.env.POSTHOG_HOST = "https://proxy.example.com/ingest";
+    expect(getRuntimeConfig().posthogHost).toBe(
+      "https://proxy.example.com/ingest",
+    );
+  });
+
+  it("strips a query/fragment from POSTHOG_HOST (keeping the path) with one warn", async () => {
+    // Capture URLs are composed against this value — a `?x=1` or
+    // `#frag` corrupts every capture into a persistent root-POST with
+    // misattributed http-class warns. The PATH is kept: path-based
+    // reverse proxies (/ingest) are the documented pattern.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    for (const [bad, expected] of [
+      [
+        "https://proxy.example.com/ingest?x=1",
+        "https://proxy.example.com/ingest",
+      ],
+      [
+        "https://proxy.example.com/ingest#frag",
+        "https://proxy.example.com/ingest",
+      ],
+      ["https://eu.i.posthog.com?x=1", "https://eu.i.posthog.com"],
+    ] as const) {
+      process.env.POSTHOG_HOST = bad;
+      vi.resetModules();
+      const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+      const warns: string[] = [];
+      const spy = vi
+        .spyOn(console, "warn")
+        .mockImplementation((m: string) => void warns.push(m));
+      try {
+        expect(freshGet().posthogHost, `value ${JSON.stringify(bad)}`).toBe(
+          expected,
+        );
+        expect(warns.some((m) => m.includes("POSTHOG_HOST"))).toBe(true);
+        // Once-guarded — not per request.
+        const before = warns.length;
+        freshGet();
+        expect(warns.length).toBe(before);
+      } finally {
+        spy.mockRestore();
+      }
+    }
+  });
+
+  it("exposes posthogKey with readEnvPair semantics (trim + NEXT_PUBLIC_ fallback)", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+
+    // Unset → undefined (legitimately absent off-prod; no log).
+    expect(getRuntimeConfig().posthogKey).toBeUndefined();
+
+    // Whitespace paste artifacts trimmed.
+    process.env.POSTHOG_KEY = " phc_primary \n";
+    expect(getRuntimeConfig().posthogKey).toBe("phc_primary");
+
+    // NEXT_PUBLIC_ fallback when the bare name is unset/empty.
+    process.env.POSTHOG_KEY = "";
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_alt";
+    expect(getRuntimeConfig().posthogKey).toBe("phc_alt");
+
+    // Bare name wins when both are set.
+    process.env.POSTHOG_KEY = "phc_primary";
+    expect(getRuntimeConfig().posthogKey).toBe("phc_primary");
+  });
+
   it("getRuntimeConfigForMiddleware skips noStore() (Edge runtime path)", async () => {
+    // Fresh module pair (SU6-B7): earlier tests in this file call
+    // vi.resetModules(), so the STATIC getRuntimeConfig import is bound
+    // to a stale module instance — whether its next/cache binding is
+    // the object spied on below depends on vitest mock-registry
+    // caching internals. Reset and import BOTH modules from the same
+    // fresh registry generation so the spy provably wraps the exact
+    // unstable_noStore these calls go through.
+    vi.resetModules();
     const cacheMod = await import("next/cache");
     const noStoreSpy = vi.spyOn(cacheMod, "unstable_noStore");
     // try/finally so a failing assertion can't leak the spy into other
@@ -368,16 +1118,16 @@ describe("server getRuntimeConfig (shell)", () => {
       process.env.BASE_URL = "https://edge.example.com";
       process.env.POSTHOG_HOST = "https://edge-posthog.example.com";
 
-      const { getRuntimeConfigForMiddleware } = await import(
-        "./runtime-config"
-      );
+      const { getRuntimeConfigForMiddleware, getRuntimeConfig: freshGet } =
+        await import("./runtime-config");
       const cfg = getRuntimeConfigForMiddleware();
       expect(cfg.baseUrl).toBe("https://edge.example.com");
       expect(noStoreSpy).not.toHaveBeenCalled();
 
-      // And confirm the default entrypoint DOES call noStore().
+      // And confirm the default entrypoint DOES call noStore() — via
+      // the SAME fresh module instance, not the stale static import.
       noStoreSpy.mockClear();
-      getRuntimeConfig();
+      freshGet();
       expect(noStoreSpy).toHaveBeenCalledTimes(1);
     } finally {
       noStoreSpy.mockRestore();

--- a/showcase/shell/src/lib/runtime-config.test.ts
+++ b/showcase/shell/src/lib/runtime-config.test.ts
@@ -131,28 +131,55 @@ describe("server getRuntimeConfig (shell)", () => {
 
   it("preserves an explicit http:// scheme on DOCS_HOST", () => {
     (process.env as Record<string, string>).NODE_ENV = "development";
+    process.env.BASE_URL = "http://localhost:3000";
     process.env.DOCS_HOST = "http://localhost:3005";
     expect(getRuntimeConfig().docsHost).toBe("http://localhost:3005");
   });
 
-  it("falls back to the default docs host (with one loud log) when DOCS_HOST is unparseable", () => {
+  it("falls back to the default docs host (with one loud log) when DOCS_HOST is unparseable", async () => {
     (process.env as Record<string, string>).NODE_ENV = "production";
     process.env.BASE_URL = "https://showcase.copilotkit.ai";
     // Spaces make the host unparseable even after prepending https://.
     process.env.DOCS_HOST = "not a parseable host";
+    // Warn-once module state — fresh module instance so the assertion
+    // is order-independent and retry-safe.
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
     const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
       errs.push(m);
     });
     try {
-      const cfg = getRuntimeConfig();
+      const cfg = freshGet();
       expect(cfg.docsHost).toBe("https://docs.showcase.copilotkit.ai");
       expect(() => new URL(cfg.docsHost)).not.toThrow();
       expect(errs.some((m) => m.includes("DOCS_HOST"))).toBe(true);
       // Loud log fires ONCE per bad value, not per request.
       const before = errs.length;
-      getRuntimeConfig();
+      freshGet();
       expect(errs.length).toBe(before);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("rejects a degenerate DOCS_HOST of just a scheme (https://) with the loud fallback", async () => {
+    // `https://` strips to `https:`, the prepend yields
+    // `https://https:`, and that PARSES (hostname "https") — it used to
+    // slip through silently and break every docs redirect.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    process.env.DOCS_HOST = "https://";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
+      errs.push(m);
+    });
+    try {
+      const cfg = freshGet();
+      expect(cfg.docsHost).toBe("https://docs.showcase.copilotkit.ai");
+      expect(errs.some((m) => m.includes("DOCS_HOST"))).toBe(true);
     } finally {
       spy.mockRestore();
     }
@@ -169,24 +196,80 @@ describe("server getRuntimeConfig (shell)", () => {
 
   it("falls back to dev defaults when unset in non-production", () => {
     (process.env as Record<string, string>).NODE_ENV = "development";
-    const cfg = getRuntimeConfig();
-    expect(cfg.baseUrl).toBe("http://localhost:3000");
-    expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
+    // Spy to keep the dev-fallback warning out of the test output.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const cfg = getRuntimeConfig();
+      expect(cfg.baseUrl).toBe("http://localhost:3000");
+      expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
-  it("falls back to sentinel and console.errors in production (BASE_URL only)", () => {
+  it("falls back to sentinel and console.errors in production (BASE_URL only)", async () => {
     (process.env as Record<string, string>).NODE_ENV = "production";
+    // The FATAL-CONFIG log is once-guarded module state — fresh module
+    // instance so the assertion survives test reordering / --retry.
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
     const errs: string[] = [];
     const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
       errs.push(m);
     });
-    const cfg = getRuntimeConfig();
+    const cfg = freshGet();
     spy.mockRestore();
-    expect(cfg.baseUrl).toBe("about:blank#shell-base-url-missing");
+    expect(cfg.baseUrl).toBe("https://shell-base-url-missing.invalid");
+    // The sentinel must be a hierarchical URL: the previous
+    // `about:blank#...` form was opaque-path, and `new URL(path, base)`
+    // throws on opaque bases — the sentinel itself 500'd composing
+    // consumers.
+    expect(() => new URL("/some/path", cfg.baseUrl)).not.toThrow();
     // POSTHOG_HOST falls back silently (analytics key — legitimately absent in some envs).
     expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
     expect(errs.some((m) => m.includes("BASE_URL"))).toBe(true);
     expect(errs.some((m) => m.includes("POSTHOG_HOST"))).toBe(false);
+  });
+
+  it("FATAL-CONFIG for unset BASE_URL logs once per process, not per request", async () => {
+    // Middleware + the root layout call getRuntimeConfig() per request;
+    // without the once-guard an unset prod BASE_URL spams console.error
+    // on EVERY request. Fresh module instance so the guard state is
+    // deterministic regardless of test order / retries.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((m: string) => {
+      errs.push(m);
+    });
+    try {
+      freshGet();
+      expect(errs.filter((m) => m.includes("BASE_URL")).length).toBe(1);
+      freshGet();
+      freshGet();
+      expect(errs.filter((m) => m.includes("BASE_URL")).length).toBe(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("dev fallback warning for unset BASE_URL logs once per process, not per call", async () => {
+    (process.env as Record<string, string>).NODE_ENV = "development";
+    vi.resetModules();
+    const { getRuntimeConfig: freshGet } = await import("./runtime-config");
+    const warns: string[] = [];
+    const spy = vi.spyOn(console, "warn").mockImplementation((m: string) => {
+      warns.push(m);
+    });
+    try {
+      freshGet();
+      expect(warns.filter((m) => m.includes("BASE_URL")).length).toBe(1);
+      freshGet();
+      expect(warns.filter((m) => m.includes("BASE_URL")).length).toBe(1);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("reads live process.env on each call (no module-load freeze)", () => {
@@ -218,6 +301,24 @@ describe("server getRuntimeConfig (shell)", () => {
     expect(cfg.baseUrl).toBe("https://primary.example.com");
   });
 
+  it("trims whitespace paste artifacts from env values", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "  https://showcase.copilotkit.ai \n";
+    process.env.POSTHOG_HOST = " https://eu.i.posthog.com ";
+    process.env.DOCS_HOST = "\thttps://docs-staging.example.com ";
+    const cfg = getRuntimeConfig();
+    expect(cfg.baseUrl).toBe("https://showcase.copilotkit.ai");
+    expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
+    expect(cfg.docsHost).toBe("https://docs-staging.example.com");
+  });
+
+  it("whitespace-only primary counts as unset (falls through to alternate)", () => {
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "   ";
+    process.env.NEXT_PUBLIC_BASE_URL = "https://alt.example.com";
+    expect(getRuntimeConfig().baseUrl).toBe("https://alt.example.com");
+  });
+
   it("empty-string primary does not mask a set alternate (length-aware fallback)", () => {
     // A deliberately-empty BASE_URL must NOT win over a populated
     // NEXT_PUBLIC_BASE_URL. The prior `??` form treated `""` as
@@ -228,6 +329,25 @@ describe("server getRuntimeConfig (shell)", () => {
     process.env.NEXT_PUBLIC_BASE_URL = "https://alt.example.com";
     const cfg = getRuntimeConfig();
     expect(cfg.baseUrl).toBe("https://alt.example.com");
+  });
+
+  it("prepends https:// when POSTHOG_HOST lacks a scheme (host-only misconfig)", () => {
+    // Middleware capture fetches build URLs from posthogHost and swallow
+    // failures by design — a scheme-less value would make EVERY capture
+    // throw, forever and silently. Same hardening as DOCS_HOST.
+    (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.BASE_URL = "https://showcase.copilotkit.ai";
+    process.env.POSTHOG_HOST = "eu.i.posthog.com";
+    const cfg = getRuntimeConfig();
+    expect(cfg.posthogHost).toBe("https://eu.i.posthog.com");
+    expect(() => new URL(cfg.posthogHost)).not.toThrow();
+  });
+
+  it("preserves an explicit scheme on POSTHOG_HOST", () => {
+    (process.env as Record<string, string>).NODE_ENV = "development";
+    process.env.BASE_URL = "http://localhost:3000";
+    process.env.POSTHOG_HOST = "http://localhost:8010";
+    expect(getRuntimeConfig().posthogHost).toBe("http://localhost:8010");
   });
 
   it("accepts NEXT_PUBLIC_POSTHOG_HOST as a fallback when POSTHOG_HOST is unset", () => {

--- a/showcase/shell/src/lib/runtime-config.ts
+++ b/showcase/shell/src/lib/runtime-config.ts
@@ -1,18 +1,24 @@
 // Server-side runtime config for the showcase shell.
 //
-// This module reads URL / analytics env values at REQUEST time. It must
-// only be imported from server components (and from middleware via the
-// Edge-safe wrapper below). Importing it from a client component would
-// cause Next.js to inline `next/cache` into the client bundle (build
-// fails) and would freeze the URLs back into the artifact — defeating
-// the runtime switch. See Next.js App Router docs on Dynamic Rendering.
+// This module reads URL / analytics env values at REQUEST time. Note
+// the import boundary is NOT the protective mechanism here: `next/cache`
+// is imported at module top level, so any bundle that pulls in this
+// module (including the Edge middleware bundle, via
+// getRuntimeConfigForMiddleware below) already contains it — and the
+// build succeeds. The real hazard is CALLING `unstable_noStore()` in a
+// scope that has no Next.js request store (Edge middleware, or any
+// non-render scope): the call throws at runtime. The middleware wrapper
+// below therefore skips the CALL, not the import.
 //
-// This module MUST NOT be imported from client components. The matching
-// client-side reader lives in runtime-config.client.ts and reads from
-// window.__SHOWCASE_CONFIG__ which the root layout injects.
+// Client components must use runtime-config.client.ts instead — not
+// because this module fails their build, but because the server env
+// vars it reads (BASE_URL, DOCS_HOST, ...) are not exposed to the
+// browser (a client render would see the dev/sentinel fallbacks) and
+// calling noStore() during a client render throws. The client reader
+// consumes window.__SHOWCASE_CONFIG__ which the root layout injects.
 
 import { unstable_noStore as noStore } from "next/cache";
-import { normalizeBackendHostPattern } from "./backend-url";
+import { SCHEME_RE, normalizeBackendHostPattern } from "./backend-url";
 
 export interface RuntimeConfig {
   /** Canonical shell base URL — used for canonical hrefs, OG metadata, etc. */
@@ -29,11 +35,17 @@ export interface RuntimeConfig {
    * by the consumer (see lib/backend-url.ts).
    */
   backendHostPattern: string;
-  /** Docs shell host — middleware 301s /docs, /ag-ui, /reference and framework-slug routes here. */
+  /** Docs shell host — middleware 308s /docs, /ag-ui, /reference and framework-slug routes here. */
   docsHost: string;
 }
 
-const PROD_INVALID_BASE_URL = "about:blank#shell-base-url-missing";
+// Sentinel for a missing prod BASE_URL. Must be a normal hierarchical
+// https URL (parity with the client reader's `.invalid` sentinel) — the
+// previous `about:blank#...` form was an opaque-path URL, and
+// `new URL(path, baseUrl)` THROWS on opaque bases, so the sentinel
+// itself would 500 any consumer composing URLs. `.invalid` is reserved
+// by RFC 2606, so the breakage stays visible without resolving anywhere.
+const PROD_INVALID_BASE_URL = "https://shell-base-url-missing.invalid/";
 
 // Defaults reproduce today's baked prod values exactly, so a deploy
 // with neither env var set (i.e. current prod) behaves byte-identically.
@@ -42,8 +54,10 @@ export const DEFAULT_BACKEND_HOST_PATTERN =
 export const DEFAULT_DOCS_HOST = "https://docs.showcase.copilotkit.ai";
 
 /**
- * Resolve the runtime config for shell. Called once per request by the
- * root layout and by middleware (via the Edge wrapper below).
+ * Resolve the runtime config for shell. Called by the root layout and
+ * by middleware (via the wrapper below) — both on every request, and
+ * each CALL re-reads process.env (no value caching; the only module
+ * state is the warn-once log guards).
  *
  * Fail-loud strategy mirrors shell-dashboard: in production, missing
  * URL env vars produce sentinel URLs (visible breakage) AND a
@@ -54,11 +68,13 @@ export const DEFAULT_DOCS_HOST = "https://docs.showcase.copilotkit.ai";
  * `opts.noStore` (default `true`) controls whether to call
  * `unstable_noStore()`. The Node.js server runtime needs the opt-out so
  * Next.js does not statically prerender callers and freeze the URLs into
- * the build artifact. The Edge runtime (middleware) MUST pass
- * `{ noStore: false }` — `unstable_noStore()` is unavailable there, and
- * middleware always runs per-request by definition so there is no
- * static cache to opt out of. The thin `getRuntimeConfigForMiddleware()` wrapper
- * below makes this explicit at the call site.
+ * the build artifact. Middleware MUST pass `{ noStore: false }`: the
+ * `next/cache` IMPORT is fine in the Edge bundle (the build proves it),
+ * but CALLING `unstable_noStore()` outside a Node.js render scope
+ * throws at runtime — and middleware always runs per-request by
+ * definition, so there is no static cache to opt out of anyway. The
+ * thin `getRuntimeConfigForMiddleware()` wrapper below makes this
+ * explicit at the call site.
  */
 export function getRuntimeConfig(
   opts: { noStore?: boolean } = {},
@@ -73,8 +89,14 @@ export function getRuntimeConfig(
   );
   // PostHog host: legitimately absent on non-production deploys; never
   // log a FATAL-CONFIG for it. The historic default (`eu.i.posthog.com`)
-  // matches the previous middleware behavior.
-  const posthogHost = readKey("POSTHOG_HOST", "https://eu.i.posthog.com");
+  // matches the previous middleware behavior. Scheme-less operator
+  // values get https:// prepended (same hardening as readDocsHost) — a
+  // scheme-less host would make every middleware capture fetch throw on
+  // an unparseable URL, and those failures are deliberately swallowed,
+  // so analytics would fail forever and silently.
+  const posthogHost = ensureScheme(
+    readKey("POSTHOG_HOST", "https://eu.i.posthog.com"),
+  );
 
   // Both URL-routing values have legitimate prod defaults — unset env
   // means "production behavior", so (like POSTHOG_HOST) they never log
@@ -95,32 +117,47 @@ export function getRuntimeConfig(
   return { baseUrl, posthogHost, backendHostPattern, docsHost };
 }
 
-// Matches an explicit URL scheme prefix (e.g. `https://`, `http://`).
-const SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+// Prepend https:// to scheme-less host values so downstream
+// `new URL(...)` / fetch consumers don't throw on a host-only env value.
+function ensureScheme(value: string): string {
+  return SCHEME_RE.test(value) ? value : `https://${value}`;
+}
 
 // One loud log per distinct bad DOCS_HOST value — not per request.
 const docsHostFallbackLogged = new Set<string>();
 
 /**
- * Read DOCS_HOST defensively. Middleware calls `new URL(docsHost)` on
- * every docs-host route, so an unparseable value would 500 ALL docs
- * traffic. Two hardening steps:
+ * Read DOCS_HOST defensively. Middleware composes redirect destinations
+ * from this value and hands them to `new URL(...)` (docs-redirects also
+ * re-normalizes the host on its side — this is defense-in-depth, not
+ * the only guard), so an unparseable value would 500 ALL docs traffic.
+ * Hardening steps:
  *
  * 1. A scheme-less, host-only value (e.g. `docs-staging.example.com`)
  *    gets `https://` prepended. This is a likely misconfig: the sibling
  *    SHOWCASE_BACKEND_HOST_PATTERN var is documented as scheme-less,
  *    and an operator can easily carry that format over.
- * 2. If the value still isn't parseable as a URL, log loudly once and
- *    fall back to the default docs host — degraded-but-working docs
- *    redirects beat a sitewide docs 500.
+ * 2. Degenerate values that parse but carry no real host (e.g.
+ *    `DOCS_HOST="https://"`, which strips to `https:` and yields a
+ *    "host" of `https`) are rejected.
+ * 3. If the value isn't usable, log loudly once and fall back to the
+ *    default docs host — degraded-but-working docs redirects beat a
+ *    sitewide docs 500.
  */
 function readDocsHost(): string {
   const raw = readKey("DOCS_HOST", DEFAULT_DOCS_HOST);
-  const candidate = SCHEME_RE.test(raw) ? raw : `https://${raw}`;
+  const candidate = ensureScheme(raw);
   try {
     // Parse for validation only — return the string form so trailing-slash
     // stripping (readKey) is preserved.
-    new URL(candidate);
+    const parsed = new URL(candidate);
+    // `DOCS_HOST="https://"` slips through parsing: readKey strips the
+    // slashes to "https:", ensureScheme yields "https://https:", and
+    // the URL parses with hostname "https". Reject empty/scheme-word
+    // hosts so the loud fallback fires instead.
+    if (!parsed.hostname || /^https?$/i.test(parsed.hostname)) {
+      throw new Error("degenerate docs host");
+    }
     return candidate;
   } catch {
     if (!docsHostFallbackLogged.has(raw)) {
@@ -137,15 +174,19 @@ function readDocsHost(): string {
 }
 
 /**
- * Edge-runtime variant. Identical semantics to `getRuntimeConfig()`
- * except `unstable_noStore()` is skipped — `next/cache`'s no-store
- * helper is not available in the Edge runtime, and middleware always
- * runs per-request by definition so there is no static cache to opt
- * out of. Thin wrapper to keep the body single-sourced.
+ * Middleware variant. Identical semantics to `getRuntimeConfig()`
+ * except the `unstable_noStore()` CALL is skipped. To be precise about
+ * the mechanism: importing this wrapper pulls `next/cache` into the
+ * Edge bundle exactly as importing `getRuntimeConfig` would (the
+ * top-level import above is unconditional) and the build succeeds
+ * either way. What breaks is CALLING `unstable_noStore()` in a scope
+ * with no Next.js request store — it throws at runtime. Middleware
+ * always runs per-request by definition, so skipping the call loses
+ * nothing. Thin wrapper to keep the body single-sourced.
  *
- * Middleware (`src/middleware.ts`) MUST import this rather than
- * `getRuntimeConfig` — otherwise the Edge bundle pulls in `next/cache`
- * and the build fails with "module not found in edge runtime."
+ * Middleware (`src/middleware.ts`) MUST call this rather than
+ * `getRuntimeConfig()` so the noStore() call never executes in the
+ * Edge scope.
  */
 export function getRuntimeConfigForMiddleware(): RuntimeConfig {
   return getRuntimeConfig({ noStore: false });
@@ -165,29 +206,41 @@ function altEnvName(envKey: string): string {
 // Length-aware env coalesce: a deliberately-empty primary (e.g. an
 // operator clearing `BASE_URL=""` on a Railway service) must NOT mask a
 // populated alternate. Treat empty-string as "unset" and fall through to
-// the alternate.
+// the alternate. Values are .trim()ed — whitespace paste artifacts in
+// deploy config (e.g. `BASE_URL=" https://x "`) would otherwise survive
+// into URLs/hosts; a whitespace-only value counts as unset.
 function readEnvPair(envKey: string): string | undefined {
-  const primary = process.env[envKey];
+  const primary = process.env[envKey]?.trim();
   if (primary && primary.length > 0) return primary;
-  const alt = process.env[altEnvName(envKey)];
+  const alt = process.env[altEnvName(envKey)]?.trim();
   if (alt && alt.length > 0) return alt;
   return undefined;
 }
 
+// One loud log per distinct (mode, env key) — middleware and the root
+// layout both call getRuntimeConfig() on EVERY request, so an unset
+// BASE_URL in prod would otherwise console.error per request. Mirrors
+// the once-guards in readDocsHost and normalizeBackendHostPattern.
+const urlFallbackLogged = new Set<string>();
+
 function readUrl(envKey: string, fallback: string, isProd: boolean): string {
   const value = readEnvPair(envKey);
   if (value !== undefined) return value.replace(/\/+$/, "");
-  if (isProd) {
-    // eslint-disable-next-line no-console
-    console.error(
-      `[shell runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
-        `using sentinel ${fallback}. Set the env var on the Railway service.`,
-    );
-  } else {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[shell runtime-config] ${envKey} unset; using dev fallback ${fallback}`,
-    );
+  const logKey = `${isProd ? "prod" : "dev"}:${envKey}`;
+  if (!urlFallbackLogged.has(logKey)) {
+    urlFallbackLogged.add(logKey);
+    if (isProd) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[shell runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
+          `using sentinel ${fallback}. Set the env var on the Railway service.`,
+      );
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[shell runtime-config] ${envKey} unset; using dev fallback ${fallback}`,
+      );
+    }
   }
   return fallback.replace(/\/+$/, "");
 }

--- a/showcase/shell/src/lib/runtime-config.ts
+++ b/showcase/shell/src/lib/runtime-config.ts
@@ -12,15 +12,34 @@
 // window.__SHOWCASE_CONFIG__ which the root layout injects.
 
 import { unstable_noStore as noStore } from "next/cache";
+import { normalizeBackendHostPattern } from "./backend-url";
 
 export interface RuntimeConfig {
   /** Canonical shell base URL — used for canonical hrefs, OG metadata, etc. */
   baseUrl: string;
   /** PostHog host — middleware ships seo_redirect events here. */
   posthogHost: string;
+  /**
+   * Backend host pattern — `{slug}` is the only placeholder. Used to
+   * derive each integration's backend URL at request time instead of
+   * trusting the registry value baked at Docker build (which froze
+   * prod hostnames into every image — staging iframed prod). Same
+   * semantics as SHOWCASE_BACKEND_HOST_PATTERN in
+   * scripts/generate-registry.ts: host only, `https://` is prepended
+   * by the consumer (see lib/backend-url.ts).
+   */
+  backendHostPattern: string;
+  /** Docs shell host — middleware 301s /docs, /ag-ui, /reference and framework-slug routes here. */
+  docsHost: string;
 }
 
 const PROD_INVALID_BASE_URL = "about:blank#shell-base-url-missing";
+
+// Defaults reproduce today's baked prod values exactly, so a deploy
+// with neither env var set (i.e. current prod) behaves byte-identically.
+export const DEFAULT_BACKEND_HOST_PATTERN =
+  "showcase-{slug}-production.up.railway.app";
+export const DEFAULT_DOCS_HOST = "https://docs.showcase.copilotkit.ai";
 
 /**
  * Resolve the runtime config for shell. Called once per request by the
@@ -57,7 +76,64 @@ export function getRuntimeConfig(
   // matches the previous middleware behavior.
   const posthogHost = readKey("POSTHOG_HOST", "https://eu.i.posthog.com");
 
-  return { baseUrl, posthogHost };
+  // Both URL-routing values have legitimate prod defaults — unset env
+  // means "production behavior", so (like POSTHOG_HOST) they never log
+  // FATAL-CONFIG. Staging/preview deploys override them per-request via
+  // SHOWCASE_BACKEND_HOST_PATTERN / DOCS_HOST service variables.
+  //
+  // backendHostPattern is a host *pattern*, not a URL — don't run it
+  // through readKey/readUrl (`{slug}` must survive untouched). It IS
+  // normalized against common env misconfigs (leading scheme, trailing
+  // slash, missing `{slug}`) with warn-once guards — see
+  // normalizeBackendHostPattern in lib/backend-url.ts.
+  const backendHostPattern = normalizeBackendHostPattern(
+    readEnvPair("SHOWCASE_BACKEND_HOST_PATTERN") ??
+      DEFAULT_BACKEND_HOST_PATTERN,
+  );
+  const docsHost = readDocsHost();
+
+  return { baseUrl, posthogHost, backendHostPattern, docsHost };
+}
+
+// Matches an explicit URL scheme prefix (e.g. `https://`, `http://`).
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+// One loud log per distinct bad DOCS_HOST value — not per request.
+const docsHostFallbackLogged = new Set<string>();
+
+/**
+ * Read DOCS_HOST defensively. Middleware calls `new URL(docsHost)` on
+ * every docs-host route, so an unparseable value would 500 ALL docs
+ * traffic. Two hardening steps:
+ *
+ * 1. A scheme-less, host-only value (e.g. `docs-staging.example.com`)
+ *    gets `https://` prepended. This is a likely misconfig: the sibling
+ *    SHOWCASE_BACKEND_HOST_PATTERN var is documented as scheme-less,
+ *    and an operator can easily carry that format over.
+ * 2. If the value still isn't parseable as a URL, log loudly once and
+ *    fall back to the default docs host — degraded-but-working docs
+ *    redirects beat a sitewide docs 500.
+ */
+function readDocsHost(): string {
+  const raw = readKey("DOCS_HOST", DEFAULT_DOCS_HOST);
+  const candidate = SCHEME_RE.test(raw) ? raw : `https://${raw}`;
+  try {
+    // Parse for validation only — return the string form so trailing-slash
+    // stripping (readKey) is preserved.
+    new URL(candidate);
+    return candidate;
+  } catch {
+    if (!docsHostFallbackLogged.has(raw)) {
+      docsHostFallbackLogged.add(raw);
+      // eslint-disable-next-line no-console
+      console.error(
+        `[shell runtime-config] FATAL-CONFIG: DOCS_HOST ${JSON.stringify(raw)} is not a ` +
+          `parseable URL (even after prepending https://); falling back to ` +
+          `${DEFAULT_DOCS_HOST}. Fix the DOCS_HOST env var on the Railway service.`,
+      );
+    }
+    return DEFAULT_DOCS_HOST;
+  }
 }
 
 /**

--- a/showcase/shell/src/lib/runtime-config.ts
+++ b/showcase/shell/src/lib/runtime-config.ts
@@ -594,8 +594,7 @@ function readDocsHost(baseUrl: string, isProd: boolean): string {
         `docs host ${DEFAULT_DOCS_HOST} points at the shell's own host ` +
         `"${shellHost}" — docs redirects are disabled for this deploy ` +
         `(sentinel ${DOCS_REDIRECTS_DISABLED_HOST}).`;
-      guidance =
-        `Set DOCS_HOST on the Railway service to a host other than the shell's.`;
+      guidance = `Set DOCS_HOST on the Railway service to a host other than the shell's.`;
     } else if (fallbackCollides) {
       core =
         `DOCS_HOST ${JSON.stringify(raw)} ${reason}, ` +
@@ -611,9 +610,7 @@ function readDocsHost(baseUrl: string, isProd: boolean): string {
     }
     if (isProd) {
       // eslint-disable-next-line no-console
-      console.error(
-        `[shell runtime-config] FATAL-CONFIG: ${core} ${guidance}`,
-      );
+      console.error(`[shell runtime-config] FATAL-CONFIG: ${core} ${guidance}`);
     } else {
       // eslint-disable-next-line no-console
       console.warn(`[shell runtime-config] ${core}`);

--- a/showcase/shell/src/lib/runtime-config.ts
+++ b/showcase/shell/src/lib/runtime-config.ts
@@ -148,7 +148,7 @@ export function getRuntimeConfig(
   // log a FATAL-CONFIG when UNSET. A SET-but-broken value is still
   // validated (scheme prepend, degenerate-host rejection) — see
   // readPosthogHost.
-  const posthogHost = readPosthogHost();
+  const posthogHost = readPosthogHost(isProd);
   // PostHog project key: same readEnvPair semantics as every other env
   // value (trim + NEXT_PUBLIC_ fallback). Middleware previously read
   // process.env.POSTHOG_KEY raw, bypassing both.
@@ -193,7 +193,10 @@ function isLoopbackHostValue(value: string): boolean {
 // `new URL(...)` / fetch consumers don't throw on a host-only env value.
 // https:// by default; http:// for loopback hosts — the documented
 // local-dev DOCS_HOST wiring (`localhost:3005`) would otherwise become
-// a TLS-failing https destination with zero warn.
+// a TLS-failing https destination with zero warn. The loopback prepend
+// serves DEV only: validateBaseUrl/readDocsHost reject loopback hosts
+// outright in production (POSTHOG_HOST deliberately keeps them — a
+// loopback capture proxy degrades analytics, not the site).
 function ensureScheme(value: string): string {
   if (SCHEME_RE.test(value)) return value;
   return isLoopbackHostValue(value) ? `http://${value}` : `https://${value}`;
@@ -208,7 +211,9 @@ function ensureScheme(value: string): string {
 // One loud log per distinct (mode, malformed BASE_URL value) — not per
 // request.
 const baseUrlInvalidLogged = new Set<string>();
-// One warn per distinct origin-normalized BASE_URL value.
+// One warn per distinct (mode, origin-normalized BASE_URL value) —
+// mode-prefixed for consistency with every other guard key in this
+// module, even though the warn's text is mode-independent.
 const baseUrlNormalizedLogged = new Set<string>();
 
 /**
@@ -234,7 +239,10 @@ const baseUrlNormalizedLogged = new Set<string>();
  *    "mailto:ops") — a base URL carrying credentials is always a
  *    misconfig;
  * 4. degenerate values that parse but carry no real host (`https://` →
- *    `https:` → hostname "https") are rejected;
+ *    `https:` → hostname "https") are rejected — and in PRODUCTION,
+ *    loopback hosts are rejected too: the dev-only http:// prepend
+ *    (ensureScheme) must not silently point a prod deploy's canonical
+ *    URLs at localhost;
  * 5. a path/query/fragment is normalized to the origin with one warn —
  *    consumers compose paths against this value, so subpath deploys
  *    are deliberately UNSUPPORTED (composition would drop the subpath
@@ -257,13 +265,23 @@ function validateBaseUrl(value: string, isProd: boolean): string {
       reason = `carries userinfo credentials after the https:// prepend (e.g. a mailto: value)`;
     } else if (!parsed.hostname || /^https?$/i.test(parsed.hostname)) {
       reason = `carries no usable host (a bare scheme like "https://")`;
+    } else if (isProd && LOOPBACK_HOSTNAME_RE.test(parsed.hostname)) {
+      // The loopback http:// prepend (ensureScheme) exists for
+      // frictionless DEV — in production it would silently "fix"
+      // BASE_URL=localhost:3000 and run canonical hrefs, OG metadata,
+      // and the docs loop guard against localhost with zero log.
+      reason =
+        `points at loopback host "${parsed.hostname}" in a production ` +
+        `deploy (canonical URLs, OG metadata, and the docs loop guard ` +
+        `would all target localhost)`;
     } else if (
       parsed.pathname !== "/" ||
       parsed.search !== "" ||
       parsed.hash !== ""
     ) {
-      if (!baseUrlNormalizedLogged.has(value)) {
-        baseUrlNormalizedLogged.add(value);
+      const normalizedLogKey = `${isProd ? "prod" : "dev"}:${value}`;
+      if (!baseUrlNormalizedLogged.has(normalizedLogKey)) {
+        baseUrlNormalizedLogged.add(normalizedLogKey);
         // eslint-disable-next-line no-console
         console.warn(
           `[shell runtime-config] BASE_URL ${JSON.stringify(value)} carries a ` +
@@ -305,9 +323,12 @@ function validateBaseUrl(value: string, isProd: boolean): string {
   return fallback;
 }
 
-// One warn per distinct bad POSTHOG_HOST value — not per request.
+// One warn per distinct (mode, bad POSTHOG_HOST value) — not per
+// request. Mode-prefixed for consistency with every other guard key in
+// this module (the warn's text is mode-independent).
 const posthogHostInvalidLogged = new Set<string>();
-// One warn per distinct query/fragment-normalized POSTHOG_HOST value.
+// One warn per distinct (mode, query/fragment-normalized POSTHOG_HOST
+// value).
 const posthogHostNormalizedLogged = new Set<string>();
 
 /**
@@ -328,43 +349,41 @@ const posthogHostNormalizedLogged = new Set<string>();
  * - the fallback logs console.warn, not FATAL-CONFIG console.error —
  *   broken analytics degrade reporting, they don't break the site.
  */
-function readPosthogHost(): string {
+function readPosthogHost(isProd: boolean): string {
   const raw = readKey("POSTHOG_HOST", DEFAULT_POSTHOG_HOST);
   const candidate = ensureScheme(raw);
+  // isProd feeds only the guard keys (the module-wide mode-prefixed
+  // convention) — the warn level and text are mode-independent here.
+  const logKey = `${isProd ? "prod" : "dev"}:${raw}`;
+  // Branched rejection reason (same labeling readDocsHost has): the
+  // previous catch-all warn claimed every rejected value "is not a
+  // usable http(s) URL (even after prepending https://)" — false twice
+  // for `ftp://ph.x` (it parsed fine, and no prepend happened) and for
+  // the degenerate bare-scheme value (it parses too).
+  let reason: string;
   try {
     const parsed = new URL(candidate);
     if (!/^https?:$/i.test(parsed.protocol)) {
-      throw new Error("unsupported posthog host scheme");
-    }
-    if (parsed.username !== "" || parsed.password !== "") {
+      reason = `uses unsupported scheme "${parsed.protocol}" (capture calls must target an http(s) host)`;
+    } else if (parsed.username !== "" || parsed.password !== "") {
       // Same userinfo rejection validateBaseUrl/readDocsHost have: the
       // Fetch spec forbids credentialed request URLs, so a userinfo-
       // bearing host makes EVERY capture fetch throw a TypeError that
       // middleware misattributes as a net-class failure.
-      if (!posthogHostInvalidLogged.has(raw)) {
-        posthogHostInvalidLogged.add(raw);
-        // eslint-disable-next-line no-console
-        console.warn(
-          `[shell runtime-config] POSTHOG_HOST ${JSON.stringify(raw)} carries ` +
-            `userinfo credentials after the https:// prepend (e.g. a mailto: ` +
-            `value) — the Fetch spec forbids credentialed URLs, so every ` +
-            `capture call would throw; falling back to ${DEFAULT_POSTHOG_HOST}. ` +
-            `Fix the POSTHOG_HOST env var on the Railway service.`,
-        );
-      }
-      return DEFAULT_POSTHOG_HOST;
-    }
-    if (!parsed.hostname || /^https?$/i.test(parsed.hostname)) {
-      throw new Error("degenerate posthog host");
-    }
-    if (parsed.search !== "" || parsed.hash !== "") {
+      reason =
+        `carries userinfo credentials after the https:// prepend (e.g. a ` +
+        `mailto: value) — the Fetch spec forbids credentialed URLs, so ` +
+        `every capture call would throw`;
+    } else if (!parsed.hostname || /^https?$/i.test(parsed.hostname)) {
+      reason = `carries no usable host (a bare scheme like "https://")`;
+    } else if (parsed.search !== "" || parsed.hash !== "") {
       // Strip query/fragment but KEEP the path (reverse-proxy ingest
       // paths are documented config) — capture URLs are composed
       // against this value, and a `?x=1`/`#frag` corrupts every
       // capture into a persistent root-POST with misattributed
       // http-class warns from middleware.
-      if (!posthogHostNormalizedLogged.has(raw)) {
-        posthogHostNormalizedLogged.add(raw);
+      if (!posthogHostNormalizedLogged.has(logKey)) {
+        posthogHostNormalizedLogged.add(logKey);
         // eslint-disable-next-line no-console
         console.warn(
           `[shell runtime-config] POSTHOG_HOST ${JSON.stringify(raw)} carries a ` +
@@ -375,30 +394,45 @@ function readPosthogHost(): string {
         );
       }
       return (parsed.origin + parsed.pathname).replace(/\/+$/, "");
+    } else {
+      // Parsed-normalized form (origin + path), not the raw candidate:
+      // query/fragment are empty here, so this is the whole URL — and the
+      // raw form leaks un-normalized spellings (uppercase hosts, explicit
+      // default ports) into every composed capture URL. The trailing-slash
+      // strip preserves the readKey contract for a bare "/" pathname.
+      return (parsed.origin + parsed.pathname).replace(/\/+$/, "");
     }
-    // Parsed-normalized form (origin + path), not the raw candidate:
-    // query/fragment are empty here, so this is the whole URL — and the
-    // raw form leaks un-normalized spellings (uppercase hosts, explicit
-    // default ports) into every composed capture URL. The trailing-slash
-    // strip preserves the readKey contract for a bare "/" pathname.
-    return (parsed.origin + parsed.pathname).replace(/\/+$/, "");
   } catch {
-    if (!posthogHostInvalidLogged.has(raw)) {
-      posthogHostInvalidLogged.add(raw);
-      // eslint-disable-next-line no-console
-      console.warn(
-        `[shell runtime-config] POSTHOG_HOST ${JSON.stringify(raw)} is not a usable ` +
-          `http(s) URL (even after prepending https://); falling back to ` +
-          `${DEFAULT_POSTHOG_HOST}. Fix the POSTHOG_HOST env var on the Railway service.`,
-      );
-    }
-    return DEFAULT_POSTHOG_HOST;
+    reason = "is not a parseable URL (even after prepending https://)";
   }
+  if (!posthogHostInvalidLogged.has(logKey)) {
+    posthogHostInvalidLogged.add(logKey);
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[shell runtime-config] POSTHOG_HOST ${JSON.stringify(raw)} ${reason}; ` +
+        `falling back to ${DEFAULT_POSTHOG_HOST}. Fix the POSTHOG_HOST env ` +
+        `var on the Railway service.`,
+    );
+  }
+  return DEFAULT_POSTHOG_HOST;
 }
 
-// One loud log per distinct bad DOCS_HOST value — not per request.
+// Strip the trailing dot of a fully-qualified (root-anchored) hostname
+// from a URL authority for comparison purposes: `shell.example.com.`
+// and `shell.example.com` are the SAME authority to DNS and browsers.
+// The lookahead keeps a port intact (`shell.example.com.:8080` →
+// `shell.example.com:8080`); only the hostname's terminal dot matches.
+function stripTrailingHostDot(host: string): string {
+  return host.replace(/\.(?=$|:)/, "");
+}
+
+// One loud log per distinct (mode, shell host, bad DOCS_HOST value) —
+// not per request. The shell host is part of the key because the
+// message AND the outcome (default fallback vs disabled sentinel)
+// depend on it, and it re-reads live BASE_URL: a raw-only key would
+// silently swallow an outcome flip to redirects-disabled.
 const docsHostFallbackLogged = new Set<string>();
-// One warn per distinct origin-normalized DOCS_HOST value.
+// One warn per distinct (mode, origin-normalized DOCS_HOST value).
 const docsHostNormalizedLogged = new Set<string>();
 
 /**
@@ -416,14 +450,19 @@ const docsHostNormalizedLogged = new Set<string>();
  *    serve as a redirect destination — rejected.
  * 3. Degenerate values that parse but carry no real host (e.g.
  *    `DOCS_HOST="https://"`, which strips to `https:` and yields a
- *    "host" of `https`) are rejected.
+ *    "host" of `https`) are rejected. In PRODUCTION, loopback hosts are
+ *    rejected too — the dev-only http:// prepend (ensureScheme) must
+ *    not silently 308 a prod deploy's docs traffic to localhost.
  * 4. A value pointing at the shell's OWN host is rejected: the redirect
  *    table has self-referential path entries (/faq → /faq etc.) that
  *    terminate only because the destination host differs — same-host
  *    docs redirects loop (ERR_TOO_MANY_REDIRECTS) on ~15 paths. The
  *    comparison uses the full authority (URL.host, i.e. hostname:port),
  *    not the hostname: localhost:3000 → localhost:3005 is the
- *    documented local-dev wiring and must keep working.
+ *    documented local-dev wiring and must keep working. Both sides are
+ *    normalized through stripTrailingHostDot — a trailing-dot FQDN
+ *    spelling (`shell.example.com.`) is the same authority and loops
+ *    the same.
  * 5. A value carrying a path, query, or fragment is normalized to its
  *    origin with one warn: docs-redirects composes destination paths
  *    against this value, so the extra parts would silently corrupt
@@ -440,10 +479,13 @@ const docsHostNormalizedLogged = new Set<string>();
  */
 function readDocsHost(baseUrl: string, isProd: boolean): string {
   // Best-effort shell authority for the loop guard — baseUrl has been
-  // through validateBaseUrl, but guard the parse anyway.
+  // through validateBaseUrl, but guard the parse anyway. Normalized via
+  // stripTrailingHostDot (as is every authority this is compared to):
+  // a trailing-dot FQDN spelling on either side is the SAME authority
+  // to DNS and browsers, so it loops the same.
   let shellHost: string | undefined;
   try {
-    shellHost = new URL(baseUrl).host;
+    shellHost = stripTrailingHostDot(new URL(baseUrl).host);
   } catch {
     shellHost = undefined;
   }
@@ -470,12 +512,28 @@ function readDocsHost(baseUrl: string, isProd: boolean): string {
       // zero signal.
       reason = `carries userinfo credentials after the https:// prepend (e.g. a mailto: value) — browsers strip or block credentialed redirect destinations`;
     } else if (!parsed.hostname || /^https?$/i.test(parsed.hostname)) {
-      // `DOCS_HOST="https://"` slips through parsing: readKey strips the
-      // slashes to "https:", ensureScheme yields "https://https:", and
-      // the URL parses with hostname "https". Reject empty/scheme-word
+      // `DOCS_HOST="https://"` slips through parsing: this function's
+      // own trailing-slash strip (the `raw` computation above) reduces
+      // it to "https:", ensureScheme yields "https://https:", and the
+      // URL parses with hostname "https". Reject empty/scheme-word
       // hosts so the loud fallback fires instead.
       reason = `carries no usable host (a bare scheme like "https://")`;
-    } else if (shellHost !== undefined && parsed.host === shellHost) {
+    } else if (isProd && LOOPBACK_HOSTNAME_RE.test(parsed.hostname)) {
+      // The loopback http:// prepend (ensureScheme) exists for the
+      // documented local-dev wiring (`localhost:3005`) — in production
+      // it would silently accept a loopback docs host and 308 every
+      // docs visitor to localhost.
+      reason =
+        `points at loopback host "${parsed.hostname}" in a production ` +
+        `deploy (every docs redirect would 308 visitors to localhost)`;
+    } else if (
+      shellHost !== undefined &&
+      stripTrailingHostDot(parsed.host) === shellHost
+    ) {
+      // Authority-only compare, deliberately scheme-INSENSITIVE: an
+      // http:// docs host on the shell's https authority hits the same
+      // middleware again (one scheme hop, then the same-host loop), so
+      // over-flagging the cross-scheme case is the safe direction.
       reason =
         `points at the shell's own host "${shellHost}" — the redirect table's ` +
         `self-referential paths would loop (ERR_TOO_MANY_REDIRECTS)`;
@@ -484,8 +542,9 @@ function readDocsHost(baseUrl: string, isProd: boolean): string {
       parsed.search !== "" ||
       parsed.hash !== ""
     ) {
-      if (!docsHostNormalizedLogged.has(raw)) {
-        docsHostNormalizedLogged.add(raw);
+      const normalizedLogKey = `${isProd ? "prod" : "dev"}:${raw}`;
+      if (!docsHostNormalizedLogged.has(normalizedLogKey)) {
+        docsHostNormalizedLogged.add(normalizedLogKey);
         // eslint-disable-next-line no-console
         console.warn(
           `[shell runtime-config] DOCS_HOST ${JSON.stringify(raw)} carries a ` +
@@ -516,13 +575,15 @@ function readDocsHost(baseUrl: string, isProd: boolean): string {
   let fallbackCollides = false;
   if (shellHost !== undefined) {
     try {
-      fallbackCollides = new URL(DEFAULT_DOCS_HOST).host === shellHost;
+      fallbackCollides =
+        stripTrailingHostDot(new URL(DEFAULT_DOCS_HOST).host) === shellHost;
     } catch {
       fallbackCollides = false;
     }
   }
-  if (!docsHostFallbackLogged.has(raw)) {
-    docsHostFallbackLogged.add(raw);
+  const logKey = `${isProd ? "prod" : "dev"}:${shellHost ?? "<unparseable>"}:${raw}`;
+  if (!docsHostFallbackLogged.has(logKey)) {
+    docsHostFallbackLogged.add(logKey);
     // Core message without log-level dressing — the dev-vs-prod branch
     // below picks the level and (prod only) appends Railway guidance.
     let core: string;

--- a/showcase/shell/src/lib/runtime-config.ts
+++ b/showcase/shell/src/lib/runtime-config.ts
@@ -17,8 +17,25 @@
 // calling noStore() during a client render throws. The client reader
 // consumes window.__SHOWCASE_CONFIG__ which the root layout injects.
 
+// Build-time guard (mirror of the `client-only` import in
+// runtime-config.client.ts): importing this module from a Client
+// Component bundle previously failed SILENTLY — the browser doesn't
+// have the server env vars, so a client consumer would render the
+// dev/sentinel fallbacks with no signal. `server-only` turns that
+// mistake into a Next.js build error. It only errors in CLIENT bundles:
+// the RSC layer and the middleware/Edge layer resolve the package's
+// empty `react-server` export (verified via `next build` — middleware
+// imports this module through getRuntimeConfigForMiddleware). Vitest
+// resolves it to the same empty marker via a resolve.alias in
+// vitest.config.ts (plain Node hits the throwing `default` export).
+import "server-only";
+
 import { unstable_noStore as noStore } from "next/cache";
-import { SCHEME_RE, normalizeBackendHostPattern } from "./backend-url";
+import {
+  DEFAULT_BACKEND_HOST_PATTERN,
+  SCHEME_RE,
+  normalizeBackendHostPattern,
+} from "./backend-url";
 
 export interface RuntimeConfig {
   /** Canonical shell base URL — used for canonical hrefs, OG metadata, etc. */
@@ -37,6 +54,16 @@ export interface RuntimeConfig {
   backendHostPattern: string;
   /** Docs shell host — middleware 308s /docs, /ag-ui, /reference and framework-slug routes here. */
   docsHost: string;
+  /**
+   * PostHog project API key — middleware authenticates capture calls
+   * with it. Optional: legitimately absent on non-production deploys
+   * (capture is disabled, with a warn in middleware). PostHog project
+   * keys are public-by-design (they ship in client bundles), so this
+   * field riding along in the root layout's window.__SHOWCASE_CONFIG__
+   * injection is safe. Optional in the type for the same reason —
+   * absence is a valid state, not a wiring bug.
+   */
+  posthogKey?: string;
 }
 
 // Sentinel for a missing prod BASE_URL. Must be a normal hierarchical
@@ -45,13 +72,40 @@ export interface RuntimeConfig {
 // `new URL(path, baseUrl)` THROWS on opaque bases, so the sentinel
 // itself would 500 any consumer composing URLs. `.invalid` is reserved
 // by RFC 2606, so the breakage stays visible without resolving anywhere.
-const PROD_INVALID_BASE_URL = "https://shell-base-url-missing.invalid/";
+// Declared WITHOUT a trailing slash — consumers receive it exactly as
+// written (the previous slash-bearing form was stripped at every exit
+// path, so the declared value never appeared anywhere).
+const PROD_INVALID_BASE_URL = "https://shell-base-url-missing.invalid";
 
 // Defaults reproduce today's baked prod values exactly, so a deploy
 // with neither env var set (i.e. current prod) behaves byte-identically.
-export const DEFAULT_BACKEND_HOST_PATTERN =
-  "showcase-{slug}-production.up.railway.app";
+// DEFAULT_BACKEND_HOST_PATTERN moved to backend-url.ts (its normalizer
+// falls back to it, and defining it here would create an import cycle)
+// — re-exported to keep this module's public surface unchanged.
+export { DEFAULT_BACKEND_HOST_PATTERN };
 export const DEFAULT_DOCS_HOST = "https://docs.showcase.copilotkit.ai";
+
+/**
+ * Sentinel docs host meaning "docs redirects are DISABLED for this
+ * deploy". Returned by readDocsHost when NO usable docs host exists:
+ * the configured value was rejected for pointing at the shell's own
+ * host AND the DEFAULT_DOCS_HOST fallback has the same defect (the
+ * shell is deployed AT the docs host — e.g. DOCS_HOST unset on that
+ * very service). Falling back to the default there would re-create the
+ * exact redirect loop the self-host guard exists to prevent.
+ *
+ * CONSUMER CONTRACT (middleware / docs-redirects): when
+ * `config.docsHost === DOCS_REDIRECTS_DISABLED_HOST`, skip the
+ * docs-host redirect step entirely (resolveDocsHostRedirect's callers
+ * must not issue 308s to this host). The value is a normal parseable
+ * https URL so incidental `new URL(docsHost)` consumers don't throw,
+ * and uses the RFC-2606-reserved `.invalid` TLD so it can never
+ * resolve if a redirect slips through anyway.
+ */
+export const DOCS_REDIRECTS_DISABLED_HOST =
+  "https://docs-redirects-disabled.invalid";
+// Historic default — matches the previous middleware behavior.
+export const DEFAULT_POSTHOG_HOST = "https://eu.i.posthog.com";
 
 /**
  * Resolve the runtime config for shell. Called by the root layout and
@@ -82,21 +136,23 @@ export function getRuntimeConfig(
   if (opts.noStore !== false) noStore();
   const isProd = process.env.NODE_ENV === "production";
 
-  const baseUrl = readUrl(
-    "BASE_URL",
-    isProd ? PROD_INVALID_BASE_URL : "http://localhost:3000",
+  const baseUrl = validateBaseUrl(
+    readUrl(
+      "BASE_URL",
+      isProd ? PROD_INVALID_BASE_URL : "http://localhost:3000",
+      isProd,
+    ),
     isProd,
   );
   // PostHog host: legitimately absent on non-production deploys; never
-  // log a FATAL-CONFIG for it. The historic default (`eu.i.posthog.com`)
-  // matches the previous middleware behavior. Scheme-less operator
-  // values get https:// prepended (same hardening as readDocsHost) — a
-  // scheme-less host would make every middleware capture fetch throw on
-  // an unparseable URL, and those failures are deliberately swallowed,
-  // so analytics would fail forever and silently.
-  const posthogHost = ensureScheme(
-    readKey("POSTHOG_HOST", "https://eu.i.posthog.com"),
-  );
+  // log a FATAL-CONFIG when UNSET. A SET-but-broken value is still
+  // validated (scheme prepend, degenerate-host rejection) — see
+  // readPosthogHost.
+  const posthogHost = readPosthogHost();
+  // PostHog project key: same readEnvPair semantics as every other env
+  // value (trim + NEXT_PUBLIC_ fallback). Middleware previously read
+  // process.env.POSTHOG_KEY raw, bypassing both.
+  const posthogKey = readEnvPair("POSTHOG_KEY");
 
   // Both URL-routing values have legitimate prod defaults — unset env
   // means "production behavior", so (like POSTHOG_HOST) they never log
@@ -112,19 +168,238 @@ export function getRuntimeConfig(
     readEnvPair("SHOWCASE_BACKEND_HOST_PATTERN") ??
       DEFAULT_BACKEND_HOST_PATTERN,
   );
-  const docsHost = readDocsHost();
+  const docsHost = readDocsHost(baseUrl, isProd);
 
-  return { baseUrl, posthogHost, backendHostPattern, docsHost };
+  return { baseUrl, posthogHost, backendHostPattern, docsHost, posthogKey };
 }
 
-// Prepend https:// to scheme-less host values so downstream
+// Loopback hostnames that can never serve TLS on a local dev port —
+// scheme-less values pointing at them get http:// prepended instead of
+// https:// (see ensureScheme). The WHATWG URL hostname for an IPv6
+// literal keeps its brackets, hence the `[::1]` form.
+const LOOPBACK_HOSTNAME_RE = /^(localhost|127\.0\.0\.1|\[::1\])$/i;
+
+function isLoopbackHostValue(value: string): boolean {
+  // Probe-parse with https:// to extract the hostname; an unparseable
+  // value is not loopback (the caller's validation rejects it later).
+  try {
+    return LOOPBACK_HOSTNAME_RE.test(new URL(`https://${value}`).hostname);
+  } catch {
+    return false;
+  }
+}
+
+// Prepend a scheme to scheme-less host values so downstream
 // `new URL(...)` / fetch consumers don't throw on a host-only env value.
+// https:// by default; http:// for loopback hosts — the documented
+// local-dev DOCS_HOST wiring (`localhost:3005`) would otherwise become
+// a TLS-failing https destination with zero warn.
 function ensureScheme(value: string): string {
-  return SCHEME_RE.test(value) ? value : `https://${value}`;
+  if (SCHEME_RE.test(value)) return value;
+  return isLoopbackHostValue(value) ? `http://${value}` : `https://${value}`;
+}
+
+// NOTE on once-guard scope: every warn/error once-guard Set in this
+// module is per-ISOLATE module state. The Node server and the Edge
+// middleware runtime each instantiate their own copy (and a restart
+// resets them), so a misconfig can log once per isolate rather than
+// once globally. Intended: bounded repetition beats lost signal.
+
+// One loud log per distinct (mode, malformed BASE_URL value) — not per
+// request.
+const baseUrlInvalidLogged = new Set<string>();
+// One warn per distinct origin-normalized BASE_URL value.
+const baseUrlNormalizedLogged = new Set<string>();
+
+/**
+ * Validate the BASE_URL value AFTER the unset-fallback resolution.
+ * readUrl only covers the UNSET case — a SET-but-malformed value
+ * (scheme-less `shell.copilotkit.ai`, or a bare `https://` that the
+ * trailing-slash strip reduces to `https:`) previously passed through
+ * unvalidated, and every consumer composing `new URL(path, baseUrl)`
+ * threw: opaque 500s with NO log, because the env var IS set so the
+ * unset-fallback (and its FATAL-CONFIG log) never fires. Same hardening
+ * as its siblings (readDocsHost / readPosthogHost) — the scheme and
+ * degenerate-host rejections originated there; the userinfo rejection
+ * (3) originated HERE and is mirrored into both siblings:
+ *
+ * 1. scheme-less host-only values get `https://` prepended (fixable
+ *    misconfig — no log);
+ * 2. non-http(s) schemes are rejected: `ftp://x` parses fine, and the
+ *    SCHEME_RE dot-scheme edge (`example.com://oops`) parses with
+ *    protocol "example.com:" — neither can serve consumers composing
+ *    http(s) URLs;
+ * 3. userinfo-bearing values are rejected: `mailto:ops@x` lacks `://`
+ *    so the prepend yields `https://mailto:ops@x` (userinfo
+ *    "mailto:ops") — a base URL carrying credentials is always a
+ *    misconfig;
+ * 4. degenerate values that parse but carry no real host (`https://` →
+ *    `https:` → hostname "https") are rejected;
+ * 5. a path/query/fragment is normalized to the origin with one warn —
+ *    consumers compose paths against this value, so subpath deploys
+ *    are deliberately UNSUPPORTED (composition would drop the subpath
+ *    silently anyway);
+ * 6. anything unusable falls back with a once-guarded log NAMING the
+ *    bad value — in production the `.invalid` sentinel plus a
+ *    FATAL-CONFIG error (Railway guidance); in dev the localhost
+ *    fallback plus a console.warn (the module's frictionless-dev
+ *    contract — the prod sentinel and Railway guidance are useless on
+ *    a laptop).
+ */
+function validateBaseUrl(value: string, isProd: boolean): string {
+  const candidate = ensureScheme(value);
+  let reason: string;
+  try {
+    const parsed = new URL(candidate);
+    if (!/^https?:$/i.test(parsed.protocol)) {
+      reason = `uses unsupported scheme "${parsed.protocol}" (consumers compose http(s) URLs against it)`;
+    } else if (parsed.username !== "" || parsed.password !== "") {
+      reason = `carries userinfo credentials after the https:// prepend (e.g. a mailto: value)`;
+    } else if (!parsed.hostname || /^https?$/i.test(parsed.hostname)) {
+      reason = `carries no usable host (a bare scheme like "https://")`;
+    } else if (
+      parsed.pathname !== "/" ||
+      parsed.search !== "" ||
+      parsed.hash !== ""
+    ) {
+      if (!baseUrlNormalizedLogged.has(value)) {
+        baseUrlNormalizedLogged.add(value);
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[shell runtime-config] BASE_URL ${JSON.stringify(value)} carries a ` +
+            `path/query/fragment — consumers compose paths against this value ` +
+            `(subpath deploys are unsupported), so the extra parts would ` +
+            `corrupt every composed URL; using origin ${parsed.origin}.`,
+        );
+      }
+      return parsed.origin;
+    } else {
+      // Parsed-normalized form, not the raw candidate: the value is
+      // guaranteed origin-only here (path/query/fragment branch above),
+      // and the raw form leaks un-normalized spellings (uppercase
+      // hosts, explicit default ports) to every consumer while internal
+      // comparisons use parsed forms.
+      return parsed.origin;
+    }
+  } catch {
+    reason = "is not a parseable URL (even after prepending https://)";
+  }
+  const fallback = isProd ? PROD_INVALID_BASE_URL : "http://localhost:3000";
+  const logKey = `${isProd ? "prod" : "dev"}:${value}`;
+  if (!baseUrlInvalidLogged.has(logKey)) {
+    baseUrlInvalidLogged.add(logKey);
+    if (isProd) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[shell runtime-config] FATAL-CONFIG: BASE_URL ${JSON.stringify(value)} ${reason}; ` +
+          `using sentinel ${fallback}. Fix the BASE_URL env var on the Railway service.`,
+      );
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[shell runtime-config] BASE_URL ${JSON.stringify(value)} ${reason}; ` +
+          `using dev fallback ${fallback}.`,
+      );
+    }
+  }
+  return fallback;
+}
+
+// One warn per distinct bad POSTHOG_HOST value — not per request.
+const posthogHostInvalidLogged = new Set<string>();
+// One warn per distinct query/fragment-normalized POSTHOG_HOST value.
+const posthogHostNormalizedLogged = new Set<string>();
+
+/**
+ * Read POSTHOG_HOST with the same degenerate-host rejection readDocsHost
+ * has: `POSTHOG_HOST="https://"` strips to `https:`, ensureScheme yields
+ * `https://https:`, and that PARSES (hostname "https") — every capture
+ * fetch then dies on DNS. Middleware warn-onces per capture-failure
+ * class (see warnCaptureFailureOnce in src/middleware.ts), so the
+ * breakage would be LOGGED — but capture stays down until the value is
+ * fixed, hence the validation here. Differences from readDocsHost,
+ * both deliberate:
+ *
+ * - a non-root PATH is preserved: path-based PostHog reverse proxies
+ *   (e.g. `https://proxy.example.com/ingest`) are a documented pattern,
+ *   so a path here is legitimate config — but a query/fragment IS
+ *   stripped (with one warn), since it corrupts every composed capture
+ *   URL;
+ * - the fallback logs console.warn, not FATAL-CONFIG console.error —
+ *   broken analytics degrade reporting, they don't break the site.
+ */
+function readPosthogHost(): string {
+  const raw = readKey("POSTHOG_HOST", DEFAULT_POSTHOG_HOST);
+  const candidate = ensureScheme(raw);
+  try {
+    const parsed = new URL(candidate);
+    if (!/^https?:$/i.test(parsed.protocol)) {
+      throw new Error("unsupported posthog host scheme");
+    }
+    if (parsed.username !== "" || parsed.password !== "") {
+      // Same userinfo rejection validateBaseUrl/readDocsHost have: the
+      // Fetch spec forbids credentialed request URLs, so a userinfo-
+      // bearing host makes EVERY capture fetch throw a TypeError that
+      // middleware misattributes as a net-class failure.
+      if (!posthogHostInvalidLogged.has(raw)) {
+        posthogHostInvalidLogged.add(raw);
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[shell runtime-config] POSTHOG_HOST ${JSON.stringify(raw)} carries ` +
+            `userinfo credentials after the https:// prepend (e.g. a mailto: ` +
+            `value) — the Fetch spec forbids credentialed URLs, so every ` +
+            `capture call would throw; falling back to ${DEFAULT_POSTHOG_HOST}. ` +
+            `Fix the POSTHOG_HOST env var on the Railway service.`,
+        );
+      }
+      return DEFAULT_POSTHOG_HOST;
+    }
+    if (!parsed.hostname || /^https?$/i.test(parsed.hostname)) {
+      throw new Error("degenerate posthog host");
+    }
+    if (parsed.search !== "" || parsed.hash !== "") {
+      // Strip query/fragment but KEEP the path (reverse-proxy ingest
+      // paths are documented config) — capture URLs are composed
+      // against this value, and a `?x=1`/`#frag` corrupts every
+      // capture into a persistent root-POST with misattributed
+      // http-class warns from middleware.
+      if (!posthogHostNormalizedLogged.has(raw)) {
+        posthogHostNormalizedLogged.add(raw);
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[shell runtime-config] POSTHOG_HOST ${JSON.stringify(raw)} carries a ` +
+            `query/fragment — capture URLs are composed against this value, ` +
+            `so the extra parts would corrupt every capture call; using ` +
+            `${(parsed.origin + parsed.pathname).replace(/\/+$/, "")} (path kept ` +
+            `for reverse-proxy setups).`,
+        );
+      }
+      return (parsed.origin + parsed.pathname).replace(/\/+$/, "");
+    }
+    // Parsed-normalized form (origin + path), not the raw candidate:
+    // query/fragment are empty here, so this is the whole URL — and the
+    // raw form leaks un-normalized spellings (uppercase hosts, explicit
+    // default ports) into every composed capture URL. The trailing-slash
+    // strip preserves the readKey contract for a bare "/" pathname.
+    return (parsed.origin + parsed.pathname).replace(/\/+$/, "");
+  } catch {
+    if (!posthogHostInvalidLogged.has(raw)) {
+      posthogHostInvalidLogged.add(raw);
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[shell runtime-config] POSTHOG_HOST ${JSON.stringify(raw)} is not a usable ` +
+          `http(s) URL (even after prepending https://); falling back to ` +
+          `${DEFAULT_POSTHOG_HOST}. Fix the POSTHOG_HOST env var on the Railway service.`,
+      );
+    }
+    return DEFAULT_POSTHOG_HOST;
+  }
 }
 
 // One loud log per distinct bad DOCS_HOST value — not per request.
 const docsHostFallbackLogged = new Set<string>();
+// One warn per distinct origin-normalized DOCS_HOST value.
+const docsHostNormalizedLogged = new Set<string>();
 
 /**
  * Read DOCS_HOST defensively. Middleware composes redirect destinations
@@ -137,40 +412,153 @@ const docsHostFallbackLogged = new Set<string>();
  *    gets `https://` prepended. This is a likely misconfig: the sibling
  *    SHOWCASE_BACKEND_HOST_PATTERN var is documented as scheme-less,
  *    and an operator can easily carry that format over.
- * 2. Degenerate values that parse but carry no real host (e.g.
+ * 2. Non-http(s) schemes (e.g. `ftp://docs.x`) parse fine but can never
+ *    serve as a redirect destination — rejected.
+ * 3. Degenerate values that parse but carry no real host (e.g.
  *    `DOCS_HOST="https://"`, which strips to `https:` and yields a
  *    "host" of `https`) are rejected.
- * 3. If the value isn't usable, log loudly once and fall back to the
- *    default docs host — degraded-but-working docs redirects beat a
- *    sitewide docs 500.
+ * 4. A value pointing at the shell's OWN host is rejected: the redirect
+ *    table has self-referential path entries (/faq → /faq etc.) that
+ *    terminate only because the destination host differs — same-host
+ *    docs redirects loop (ERR_TOO_MANY_REDIRECTS) on ~15 paths. The
+ *    comparison uses the full authority (URL.host, i.e. hostname:port),
+ *    not the hostname: localhost:3000 → localhost:3005 is the
+ *    documented local-dev wiring and must keep working.
+ * 5. A value carrying a path, query, or fragment is normalized to its
+ *    origin with one warn: docs-redirects composes destination paths
+ *    against this value, so the extra parts would silently corrupt
+ *    EVERY redirect (a `#frag` swallows the path entirely — all
+ *    redirects land on the docs root).
+ * 6. If the value isn't usable, log loudly once — with a reason that
+ *    matches the actual rejection, not a catch-all "not parseable"
+ *    mislabel — and fall back to the default docs host:
+ *    degraded-but-working docs redirects beat a sitewide docs 500.
+ *    Same dev-vs-prod branch as validateBaseUrl: in production the log
+ *    is a FATAL-CONFIG console.error with Railway guidance; in dev it
+ *    is a console.warn (the Railway guidance is useless on a laptop).
+ *    The fallback VALUE is identical in both modes.
  */
-function readDocsHost(): string {
-  const raw = readKey("DOCS_HOST", DEFAULT_DOCS_HOST);
-  const candidate = ensureScheme(raw);
+function readDocsHost(baseUrl: string, isProd: boolean): string {
+  // Best-effort shell authority for the loop guard — baseUrl has been
+  // through validateBaseUrl, but guard the parse anyway.
+  let shellHost: string | undefined;
   try {
-    // Parse for validation only — return the string form so trailing-slash
-    // stripping (readKey) is preserved.
-    const parsed = new URL(candidate);
-    // `DOCS_HOST="https://"` slips through parsing: readKey strips the
-    // slashes to "https:", ensureScheme yields "https://https:", and
-    // the URL parses with hostname "https". Reject empty/scheme-word
-    // hosts so the loud fallback fires instead.
-    if (!parsed.hostname || /^https?$/i.test(parsed.hostname)) {
-      throw new Error("degenerate docs host");
-    }
-    return candidate;
+    shellHost = new URL(baseUrl).host;
   } catch {
-    if (!docsHostFallbackLogged.has(raw)) {
-      docsHostFallbackLogged.add(raw);
+    shellHost = undefined;
+  }
+  // Read the env pair directly (same trim/fallback semantics as
+  // readKey) so the fallback path below can branch its FATAL message on
+  // set-vs-unset — with DOCS_HOST unset on a shell deployed AT the docs
+  // host, "DOCS_HOST <default> points at the shell's own host" sends
+  // the operator hunting for an env var that does not exist.
+  const envValue = readEnvPair("DOCS_HOST");
+  const raw = (envValue ?? DEFAULT_DOCS_HOST).replace(/\/+$/, "");
+  const candidate = ensureScheme(raw);
+  // Branched rejection reason: the previous catch-all labeled values
+  // that DID parse (degenerate host) as "not a parseable URL", sending
+  // the operator hunting for a syntax error that isn't there.
+  let reason: string;
+  try {
+    const parsed = new URL(candidate);
+    if (!/^https?:$/i.test(parsed.protocol)) {
+      reason = `uses unsupported scheme "${parsed.protocol}" (docs redirect destinations must be http/https)`;
+    } else if (parsed.username !== "" || parsed.password !== "") {
+      // Same userinfo rejection validateBaseUrl has: a credentialed
+      // DOCS_HOST lands userinfo in every 308 Location header, which
+      // browsers strip or silently block — docs redirects break with
+      // zero signal.
+      reason = `carries userinfo credentials after the https:// prepend (e.g. a mailto: value) — browsers strip or block credentialed redirect destinations`;
+    } else if (!parsed.hostname || /^https?$/i.test(parsed.hostname)) {
+      // `DOCS_HOST="https://"` slips through parsing: readKey strips the
+      // slashes to "https:", ensureScheme yields "https://https:", and
+      // the URL parses with hostname "https". Reject empty/scheme-word
+      // hosts so the loud fallback fires instead.
+      reason = `carries no usable host (a bare scheme like "https://")`;
+    } else if (shellHost !== undefined && parsed.host === shellHost) {
+      reason =
+        `points at the shell's own host "${shellHost}" — the redirect table's ` +
+        `self-referential paths would loop (ERR_TOO_MANY_REDIRECTS)`;
+    } else if (
+      parsed.pathname !== "/" ||
+      parsed.search !== "" ||
+      parsed.hash !== ""
+    ) {
+      if (!docsHostNormalizedLogged.has(raw)) {
+        docsHostNormalizedLogged.add(raw);
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[shell runtime-config] DOCS_HOST ${JSON.stringify(raw)} carries a ` +
+            `path/query/fragment — docs redirects compose destination paths ` +
+            `against this value, so the extra parts would corrupt every ` +
+            `redirect; using origin ${parsed.origin}.`,
+        );
+      }
+      return parsed.origin;
+    } else {
+      // Parsed-normalized form, not the raw candidate: the value is
+      // guaranteed origin-only here (path/query/fragment branch above),
+      // and the raw form leaks un-normalized spellings (uppercase
+      // hosts, explicit default ports) into every redirect destination.
+      // parsed.origin never carries a trailing slash, so the strip
+      // applied to `raw` above is preserved too.
+      return parsed.origin;
+    }
+  } catch {
+    reason = "is not a parseable URL (even after prepending https://)";
+  }
+  // Re-check the FALLBACK against the shell host before handing it out:
+  // the unconditional DEFAULT_DOCS_HOST fallback can carry the same
+  // defect the configured value was just rejected for (shell deployed
+  // AT the docs host). Without this, the unset-on-the-docs-host case
+  // logged a self-contradictory "falling back to <the same looping
+  // value>" AND returned the looping value.
+  let fallbackCollides = false;
+  if (shellHost !== undefined) {
+    try {
+      fallbackCollides = new URL(DEFAULT_DOCS_HOST).host === shellHost;
+    } catch {
+      fallbackCollides = false;
+    }
+  }
+  if (!docsHostFallbackLogged.has(raw)) {
+    docsHostFallbackLogged.add(raw);
+    // Core message without log-level dressing — the dev-vs-prod branch
+    // below picks the level and (prod only) appends Railway guidance.
+    let core: string;
+    let guidance: string;
+    if (fallbackCollides && envValue === undefined) {
+      core =
+        `DOCS_HOST is unset and the default ` +
+        `docs host ${DEFAULT_DOCS_HOST} points at the shell's own host ` +
+        `"${shellHost}" — docs redirects are disabled for this deploy ` +
+        `(sentinel ${DOCS_REDIRECTS_DISABLED_HOST}).`;
+      guidance =
+        `Set DOCS_HOST on the Railway service to a host other than the shell's.`;
+    } else if (fallbackCollides) {
+      core =
+        `DOCS_HOST ${JSON.stringify(raw)} ${reason}, ` +
+        `and the default docs host ${DEFAULT_DOCS_HOST} ALSO points at the ` +
+        `shell's own host "${shellHost}" — docs redirects are disabled for ` +
+        `this deploy (sentinel ${DOCS_REDIRECTS_DISABLED_HOST}).`;
+      guidance = `Fix the DOCS_HOST env var on the Railway service.`;
+    } else {
+      core =
+        `DOCS_HOST ${JSON.stringify(raw)} ${reason}; ` +
+        `falling back to ${DEFAULT_DOCS_HOST}.`;
+      guidance = `Fix the DOCS_HOST env var on the Railway service.`;
+    }
+    if (isProd) {
       // eslint-disable-next-line no-console
       console.error(
-        `[shell runtime-config] FATAL-CONFIG: DOCS_HOST ${JSON.stringify(raw)} is not a ` +
-          `parseable URL (even after prepending https://); falling back to ` +
-          `${DEFAULT_DOCS_HOST}. Fix the DOCS_HOST env var on the Railway service.`,
+        `[shell runtime-config] FATAL-CONFIG: ${core} ${guidance}`,
       );
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn(`[shell runtime-config] ${core}`);
     }
-    return DEFAULT_DOCS_HOST;
   }
+  return fallbackCollides ? DOCS_REDIRECTS_DISABLED_HOST : DEFAULT_DOCS_HOST;
 }
 
 /**
@@ -209,6 +597,11 @@ function altEnvName(envKey: string): string {
 // the alternate. Values are .trim()ed — whitespace paste artifacts in
 // deploy config (e.g. `BASE_URL=" https://x "`) would otherwise survive
 // into URLs/hosts; a whitespace-only value counts as unset.
+//
+// The dynamic `process.env[key]` reads assume a self-hosted Node runtime
+// (next start / Docker): Edge platforms that statically inline only
+// LITERAL `process.env.X` reads at build would see undefined here and
+// silently fall back to defaults.
 function readEnvPair(envKey: string): string | undefined {
   const primary = process.env[envKey]?.trim();
   if (primary && primary.length > 0) return primary;
@@ -226,6 +619,9 @@ const urlFallbackLogged = new Set<string>();
 function readUrl(envKey: string, fallback: string, isProd: boolean): string {
   const value = readEnvPair(envKey);
   if (value !== undefined) return value.replace(/\/+$/, "");
+  // Strip BEFORE logging so the message names the exact value callers
+  // receive — the pre-strip form (trailing slash) never appears anywhere.
+  const stripped = fallback.replace(/\/+$/, "");
   const logKey = `${isProd ? "prod" : "dev"}:${envKey}`;
   if (!urlFallbackLogged.has(logKey)) {
     urlFallbackLogged.add(logKey);
@@ -233,16 +629,16 @@ function readUrl(envKey: string, fallback: string, isProd: boolean): string {
       // eslint-disable-next-line no-console
       console.error(
         `[shell runtime-config] FATAL-CONFIG: ${envKey} is unset in a production deploy; ` +
-          `using sentinel ${fallback}. Set the env var on the Railway service.`,
+          `using sentinel ${stripped}. Set the env var on the Railway service.`,
       );
     } else {
       // eslint-disable-next-line no-console
       console.warn(
-        `[shell runtime-config] ${envKey} unset; using dev fallback ${fallback}`,
+        `[shell runtime-config] ${envKey} unset; using dev fallback ${stripped}`,
       );
     }
   }
-  return fallback.replace(/\/+$/, "");
+  return stripped;
 }
 
 // Analytics keys (POSTHOG_HOST etc.) are legitimately absent on

--- a/showcase/shell/src/lib/runtime-url-wiring.test.ts
+++ b/showcase/shell/src/lib/runtime-url-wiring.test.ts
@@ -14,10 +14,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { execFileSync } from "node:child_process";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { backendUrlFromPattern } from "./backend-url";
 import { getRuntimeConfig as getClientRuntimeConfig } from "./runtime-config.client";
+import { REGISTRY_FRAMEWORK_SLUGS } from "../middleware";
 
 const SHELL_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -33,31 +33,29 @@ let registry: RegistryShape;
 
 beforeAll(() => {
   // registry.json is a generated, gitignored artifact (see
-  // showcase/.gitignore). On a fresh checkout it doesn't exist yet —
-  // generate it the same way `npm run dev`/`build` do so this suite is
-  // runnable standalone. Generous timeout: the generator validates every
-  // manifest and emits catalogs for all shells.
-  if (!fs.existsSync(REGISTRY_PATH)) {
-    execFileSync("npx", ["tsx", "../scripts/generate-registry.ts"], {
-      cwd: SHELL_ROOT,
-      stdio: "ignore",
-    });
-  }
-  registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, "utf8")) as unknown as RegistryShape;
-}, 120_000);
+  // showcase/.gitignore). The vitest globalSetup (vitest.global-setup.ts)
+  // generates it before any worker starts — if this assert fires, the
+  // setup didn't run (or wrote somewhere unexpected).
+  expect(
+    fs.existsSync(REGISTRY_PATH),
+    `registry.json missing at ${REGISTRY_PATH} — vitest.global-setup.ts should have generated it`,
+  ).toBe(true);
+  registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, "utf8")) as RegistryShape;
+});
 
 describe("registry framework slugs (real registry.json)", () => {
   it("derives a non-empty slug set (middleware docs-301 precondition)", () => {
-    // Same derivation expression as REGISTRY_FRAMEWORK_SLUGS in
-    // src/middleware.ts — keep in sync.
-    const slugs = new Set(
-      (registry.integrations ?? []).map((i) => i.slug),
-    );
-    expect(slugs.size).toBeGreaterThan(0);
-    for (const slug of slugs) {
+    // Assert the PRODUCTION value — the actual Set middleware builds at
+    // module load from registry.json — not a re-implementation of the
+    // derivation that could drift out of sync.
+    expect(REGISTRY_FRAMEWORK_SLUGS.size).toBeGreaterThan(0);
+    for (const slug of REGISTRY_FRAMEWORK_SLUGS) {
       expect(typeof slug).toBe("string");
       expect(slug.length).toBeGreaterThan(0);
     }
+    // And it must reflect the real artifact 1:1.
+    const fromFile = new Set((registry.integrations ?? []).map((i) => i.slug));
+    expect(REGISTRY_FRAMEWORK_SLUGS).toEqual(fromFile);
   });
 });
 
@@ -67,10 +65,10 @@ describe("SSR placeholder composed with backendUrlFromPattern", () => {
     expect(slug).toBeTruthy();
 
     // Simulate the SSR phase: no `window`, so the client reader returns
-    // the placeholder config rather than throwing.
-    const w = globalThis.window;
-    // @ts-expect-error — deliberately removing window for the test
-    delete globalThis.window;
+    // the placeholder config rather than throwing. stubGlobal (not
+    // delete/reassign) so vitest restores the original even if an
+    // assertion throws mid-test.
+    vi.stubGlobal("window", undefined);
     try {
       const cfg = getClientRuntimeConfig();
       const url = backendUrlFromPattern(cfg.backendHostPattern, slug!);
@@ -79,7 +77,7 @@ describe("SSR placeholder composed with backendUrlFromPattern", () => {
       expect(() => new URL(url)).not.toThrow();
       expect(url).toBe(`https://showcase-${slug}.ssr-placeholder.invalid`);
     } finally {
-      (globalThis as { window?: typeof w }).window = w;
+      vi.unstubAllGlobals();
     }
   });
 });

--- a/showcase/shell/src/lib/runtime-url-wiring.test.ts
+++ b/showcase/shell/src/lib/runtime-url-wiring.test.ts
@@ -1,0 +1,85 @@
+// Wiring tests for the runtime-URL pipeline against the REAL generated
+// registry — not fixtures. Two invariants that unit tests with synthetic
+// data cannot catch:
+//
+// 1. The framework-slug set middleware derives from registry.json must be
+//    non-empty. An empty set (schema drift, generator regression) would
+//    silently disable every framework-scoped docs 301 — requests would
+//    fall through to the SEO redirect table instead.
+// 2. The SSR placeholder config (runtime-config.client.ts) composed with
+//    backendUrlFromPattern must yield a parseable, RFC-2606-unresolvable
+//    URL for a real registry slug — `new URL()` in consumers must not
+//    throw during SSR.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+import { beforeAll, describe, expect, it } from "vitest";
+import { backendUrlFromPattern } from "./backend-url";
+import { getRuntimeConfig as getClientRuntimeConfig } from "./runtime-config.client";
+
+const SHELL_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const REGISTRY_PATH = path.join(SHELL_ROOT, "src", "data", "registry.json");
+
+interface RegistryShape {
+  integrations?: { slug: string }[];
+}
+
+let registry: RegistryShape;
+
+beforeAll(() => {
+  // registry.json is a generated, gitignored artifact (see
+  // showcase/.gitignore). On a fresh checkout it doesn't exist yet —
+  // generate it the same way `npm run dev`/`build` do so this suite is
+  // runnable standalone. Generous timeout: the generator validates every
+  // manifest and emits catalogs for all shells.
+  if (!fs.existsSync(REGISTRY_PATH)) {
+    execFileSync("npx", ["tsx", "../scripts/generate-registry.ts"], {
+      cwd: SHELL_ROOT,
+      stdio: "ignore",
+    });
+  }
+  registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, "utf8")) as unknown as RegistryShape;
+}, 120_000);
+
+describe("registry framework slugs (real registry.json)", () => {
+  it("derives a non-empty slug set (middleware docs-301 precondition)", () => {
+    // Same derivation expression as REGISTRY_FRAMEWORK_SLUGS in
+    // src/middleware.ts — keep in sync.
+    const slugs = new Set(
+      (registry.integrations ?? []).map((i) => i.slug),
+    );
+    expect(slugs.size).toBeGreaterThan(0);
+    for (const slug of slugs) {
+      expect(typeof slug).toBe("string");
+      expect(slug.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("SSR placeholder composed with backendUrlFromPattern", () => {
+  it("produces a parseable .invalid URL for a real registry slug", () => {
+    const slug = registry.integrations?.[0]?.slug;
+    expect(slug).toBeTruthy();
+
+    // Simulate the SSR phase: no `window`, so the client reader returns
+    // the placeholder config rather than throwing.
+    const w = globalThis.window;
+    // @ts-expect-error — deliberately removing window for the test
+    delete globalThis.window;
+    try {
+      const cfg = getClientRuntimeConfig();
+      const url = backendUrlFromPattern(cfg.backendHostPattern, slug!);
+      // Parseable (consumers may `new URL()` it inline during SSR) and
+      // unresolvable (.invalid is RFC-2606 reserved — no real fetch).
+      expect(() => new URL(url)).not.toThrow();
+      expect(url).toBe(`https://showcase-${slug}.ssr-placeholder.invalid`);
+    } finally {
+      (globalThis as { window?: typeof w }).window = w;
+    }
+  });
+});

--- a/showcase/shell/src/lib/runtime-url-wiring.test.ts
+++ b/showcase/shell/src/lib/runtime-url-wiring.test.ts
@@ -14,10 +14,16 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { backendUrlFromPattern } from "./backend-url";
 import { getRuntimeConfig as getClientRuntimeConfig } from "./runtime-config.client";
-import { REGISTRY_FRAMEWORK_SLUGS } from "../middleware";
+
+// Imported dynamically in beforeAll AFTER spying console.warn:
+// middleware emits its module-load table warns (duplicate
+// exact/wildcard sources) at import time, and a static import would
+// land them raw in the test output whenever this file is the first in
+// its worker to load the module.
+let REGISTRY_FRAMEWORK_SLUGS: ReadonlySet<string>;
 
 const SHELL_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -26,12 +32,18 @@ const SHELL_ROOT = path.resolve(
 const REGISTRY_PATH = path.join(SHELL_ROOT, "src", "data", "registry.json");
 
 interface RegistryShape {
-  integrations?: { slug: string }[];
+  // `slug` typed as unknown, not string: this test reads the REAL
+  // generated artifact, and the comparison below must mirror
+  // middleware's drop semantics for malformed entries rather than
+  // assume the happy shape.
+  integrations?: { slug?: unknown }[];
 }
 
 let registry: RegistryShape;
 
-beforeAll(() => {
+beforeAll(async () => {
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  ({ REGISTRY_FRAMEWORK_SLUGS } = await import("../middleware"));
   // registry.json is a generated, gitignored artifact (see
   // showcase/.gitignore). The vitest globalSetup (vitest.global-setup.ts)
   // generates it before any worker starts — if this assert fires, the
@@ -41,6 +53,10 @@ beforeAll(() => {
     `registry.json missing at ${REGISTRY_PATH} — vitest.global-setup.ts should have generated it`,
   ).toBe(true);
   registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, "utf8")) as RegistryShape;
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
 });
 
 describe("registry framework slugs (real registry.json)", () => {
@@ -53,8 +69,21 @@ describe("registry framework slugs (real registry.json)", () => {
       expect(typeof slug).toBe("string");
       expect(slug.length).toBeGreaterThan(0);
     }
-    // And it must reflect the real artifact 1:1.
-    const fromFile = new Set((registry.integrations ?? []).map((i) => i.slug));
+    // And it must reflect the real artifact 1:1 — modulo middleware's
+    // construction-time lowercasing (SU4-A4): compare against the
+    // LOWERCASED file slugs (SU5-A6), or a future mixed-case registry
+    // slug fails this wiring test even though middleware handles it.
+    // The re-derivation mirrors extractFrameworkSlugs' DROP semantics
+    // (SU6-B6): entries with a missing or non-string slug are skipped,
+    // not dereferenced — the previous `i.slug.toLowerCase()` would
+    // TypeError on a malformed entry that middleware merely drops,
+    // turning a meaningful set-diff failure into an unrelated crash.
+    const fromFile = new Set(
+      (registry.integrations ?? [])
+        .map((i) => i.slug)
+        .filter((s): s is string => typeof s === "string")
+        .map((s) => s.toLowerCase()),
+    );
     expect(REGISTRY_FRAMEWORK_SLUGS).toEqual(fromFile);
   });
 });
@@ -62,7 +91,14 @@ describe("registry framework slugs (real registry.json)", () => {
 describe("SSR placeholder composed with backendUrlFromPattern", () => {
   it("produces a parseable .invalid URL for a real registry slug", () => {
     const slug = registry.integrations?.[0]?.slug;
-    expect(slug).toBeTruthy();
+    // Hard narrow (not a bare truthiness expect): slug is `unknown` in
+    // RegistryShape, and the substitution below needs a real string.
+    if (typeof slug !== "string" || slug.length === 0) {
+      throw new Error(
+        "registry.json's first integration carries no string slug — " +
+          "the generated artifact is malformed",
+      );
+    }
 
     // Simulate the SSR phase: no `window`, so the client reader returns
     // the placeholder config rather than throwing. stubGlobal (not
@@ -71,7 +107,7 @@ describe("SSR placeholder composed with backendUrlFromPattern", () => {
     vi.stubGlobal("window", undefined);
     try {
       const cfg = getClientRuntimeConfig();
-      const url = backendUrlFromPattern(cfg.backendHostPattern, slug!);
+      const url = backendUrlFromPattern(cfg.backendHostPattern, slug);
       // Parseable (consumers may `new URL()` it inline during SSR) and
       // unresolvable (.invalid is RFC-2606 reserved — no real fetch).
       expect(() => new URL(url)).not.toThrow();

--- a/showcase/shell/src/lib/runtime-url-wiring.test.ts
+++ b/showcase/shell/src/lib/runtime-url-wiring.test.ts
@@ -52,7 +52,9 @@ beforeAll(async () => {
     fs.existsSync(REGISTRY_PATH),
     `registry.json missing at ${REGISTRY_PATH} — vitest.global-setup.ts should have generated it`,
   ).toBe(true);
-  registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, "utf8")) as RegistryShape;
+  registry = JSON.parse(
+    fs.readFileSync(REGISTRY_PATH, "utf8"),
+  ) as RegistryShape;
 });
 
 afterAll(() => {

--- a/showcase/shell/src/lib/seo-redirects.ts
+++ b/showcase/shell/src/lib/seo-redirects.ts
@@ -16,6 +16,28 @@
  * to the new canonical homes.
  *
  * Spec & Inventory: https://www.notion.so/33c3aa38185281d7b243c5cf0a7c14cb
+ *
+ * STEP-0 SHADOWING (middleware.ts): the docs-host redirect (step 0 in
+ * middleware — /docs, /ag-ui, /reference, /<registry-framework-slug>)
+ * runs BEFORE this table, so several entry classes can never match on
+ * the SHELL host and are effectively docs-host-only / dead here:
+ *
+ *   - every `/docs/*` source (R2, DI-*, DOCS-root, DOCS-wild): step 0
+ *     308s `/docs/:path*` to the docs host with the prefix stripped;
+ *   - every `/reference*` source (FI-reference, P9, P10): step 0 308s
+ *     `/reference/:path*` to the docs host with the prefix kept;
+ *   - sources whose first segment is a CURRENT registry slug —
+ *     today's registry-overlap slugs are `mastra`, `agno`, `ag2`,
+ *     `llamaindex`, `pydantic-ai` (e.g. F3-F6, S1×mastra, P1×agno):
+ *     step 0 forwards `/<slug>/...` verbatim to the docs host.
+ *
+ * Verified double-hop behavior: such a request 308s to the docs host
+ * with the path unchanged, and the DOCS host's own redirect layer then
+ * applies the rename there (e.g. shell /mastra/quickstart/mastra →
+ * docs-host /mastra/quickstart/mastra → docs-host /mastra/quickstart).
+ * The entries stay in this table because validate-redirects.ts and the
+ * decommission report still consume them, and because non-overlapping
+ * legacy slugs (e.g. `langgraph`, `adk`, `aws-strands`) DO match here.
  */
 
 export interface RedirectEntry {

--- a/showcase/shell/src/lib/seo-redirects.ts
+++ b/showcase/shell/src/lib/seo-redirects.ts
@@ -17,19 +17,24 @@
  *
  * Spec & Inventory: https://www.notion.so/33c3aa38185281d7b243c5cf0a7c14cb
  *
- * STEP-0 SHADOWING (middleware.ts): the docs-host redirect (step 0 in
- * middleware — /docs, /ag-ui, /reference, /<registry-framework-slug>)
+ * DOCS-HOST SHADOWING (middleware.ts): the docs-host redirect (step 1
+ * in middleware — /docs, /ag-ui, /reference, /<registry-framework-slug>)
  * runs BEFORE this table, so several entry classes can never match on
  * the SHELL host and are effectively docs-host-only / dead here:
  *
- *   - every `/docs/*` source (R2, DI-*, DOCS-root, DOCS-wild): step 0
- *     308s `/docs/:path*` to the docs host with the prefix stripped;
- *   - every `/reference*` source (FI-reference, P9, P10): step 0 308s
+ *   - every `/docs/*` source (R2, DI-*, DOCS-root, DOCS-wild): it 308s
+ *     `/docs/:path*` to the docs host with the prefix stripped;
+ *   - every `/reference*` source (FI-reference, P9, P10): it 308s
  *     `/reference/:path*` to the docs host with the prefix kept;
  *   - sources whose first segment is a CURRENT registry slug —
  *     today's registry-overlap slugs are `mastra`, `agno`, `ag2`,
- *     `llamaindex`, `pydantic-ai` (e.g. F3-F6, S1×mastra, P1×agno):
- *     step 0 forwards `/<slug>/...` verbatim to the docs host.
+ *     `llamaindex`, `pydantic-ai` and `crewai-crews` (e.g. F3-F6,
+ *     S1×mastra, P1×agno, and L13/L14 — both /crewai-crews entries are
+ *     dead here): the docs-host step forwards `/<slug>/...` verbatim to
+ *     the docs host. NOTE (SU4-A6): this list must enumerate EVERY
+ *     table source whose FIRST segment is a registry slug — recheck it
+ *     against registry.json whenever a slug is added or a source class
+ *     is introduced.
  *
  * Verified double-hop behavior: such a request 308s to the docs host
  * with the path unchanged, and the DOCS host's own redirect layer then
@@ -45,7 +50,14 @@ export interface RedirectEntry {
   id: string;
   /** Source path pattern. Use :path* for wildcard suffix matching. */
   source: string;
-  /** Destination path on the showcase. Use :path* to carry over the wildcard. */
+  /**
+   * Destination path on the DOCS routing surface (shell-docs serves at
+   * the docs host root) — NOT on the showcase shell. Use :path* to
+   * carry over the wildcard. middleware resolves these against the
+   * runtime docsHost; resolving them against the shell origin is the
+   * exact misconception behind the historic self-redirect loop (e.g.
+   * M3 /faq -> shell /faq -> ERR_TOO_MANY_REDIRECTS).
+   */
   destination: string;
 }
 
@@ -56,6 +68,13 @@ export interface RedirectEntry {
 // Historical framework slugs that appear in legacy upstream URLs.
 // These are the slugs the SEO surface SAW pre-cutover — destinations are
 // remapped via SLUG_RENAMES below to the canonical shell-docs slugs.
+//
+// DATA-CONTRACT NOTE (SU5-A7): `a2a` and `agent-spec` have no
+// SLUG_RENAMES entry AND are not registry framework slugs, so their
+// generated destinations (e.g. /a2a/prebuilt-components) may 404 on the
+// docs host — the redirects fire correctly but land on nothing. Flagged
+// for the docs-host inventory check; until then they are kept for
+// Notion-spec parity like the other generated classes.
 const FRAMEWORKS = [
   "langgraph",
   "adk",
@@ -367,8 +386,13 @@ const SPECIFIC_FRAMEWORK: RedirectEntry[] = [
   },
   {
     id: "F13",
+    // Keeps the framework segment (aws-strands → canonical `strands`),
+    // matching F11/F12, the S× renames and the P1×aws-strands
+    // catch-all. An earlier revision dropped the segment
+    // (→ /human-in-the-loop) with no spec justification, landing on the
+    // framework-agnostic page instead of the strands one.
     source: "/aws-strands/human-in-the-loop",
-    destination: "/human-in-the-loop",
+    destination: "/strands/human-in-the-loop",
   },
   {
     id: "F14",
@@ -442,13 +466,19 @@ const ROOT_RENAMES: RedirectEntry[] = [
     source: "/copilot-suggestions",
     destination: "/prebuilt-components",
   },
-  // /direct-to-llm and /integrations/built-in-agent → built-in-agent (BIA canonical)
+  // /direct-to-llm → built-in-agent (BIA canonical)
+  //
+  // R15 (/integrations/built-in-agent → /built-in-agent) is deliberately
+  // ABSENT from this (shell) copy: it targets legacy DOCS-host URLs
+  // (47 /integrations/built-in-agent/* URLs in the upstream sitemap —
+  // see e2bef7a0b) and lives in the shell-docs copy where it belongs.
+  // On the SHELL host, /integrations/built-in-agent is a LIVE registry
+  // product page (linked from search-modal.tsx and
+  // integration-explorer.tsx) that the entry would hijack — middleware's
+  // namespace guard (its FIRST step, ahead of even the docs-host
+  // redirect — SU4-A1) keeps EVERY redirect step out of /integrations/*,
+  // structurally. Same applies to its wildcard twin R17 below.
   { id: "R14", source: "/direct-to-llm", destination: "/built-in-agent" },
-  {
-    id: "R15",
-    source: "/integrations/built-in-agent",
-    destination: "/built-in-agent",
-  },
   { id: "R18", source: "/mcp", destination: "/coding-agents" },
   { id: "R19", source: "/vibe-coding-mcp", destination: "/coding-agents" },
   {
@@ -521,7 +551,10 @@ const ROOT_RENAMES: RedirectEntry[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Category 2: Legacy Redirect Chains (coagents -> langgraph-python, crewai-crews -> crewai-crews)
+// Category 2: Legacy Redirect Chains (coagents -> langgraph-python; the
+// /crewai-crews entries L13/L14 are SELF-redirects — crewai-crews is the
+// canonical slug, and they are kept for inventory parity with the Notion
+// spec, not because anything renames)
 // Specific entries BEFORE the catch-all wildcards
 // ---------------------------------------------------------------------------
 
@@ -720,7 +753,12 @@ const SLUG_RENAME_REDIRECTS: RedirectEntry[] = Object.entries(
 
 // ---------------------------------------------------------------------------
 // Wildcard redirects (legacy chains + pattern rules)
-// These MUST come LAST — they are catch-alls
+// Order matters only RELATIVE TO OTHER WILDCARDS: middleware splits the
+// table into an exact-match map and an ordered wildcard list, so exact
+// entries always win regardless of where a wildcard sits. Among
+// wildcards, earlier = higher priority (first matching prefix wins),
+// which is why the more specific wildcard groups precede the
+// per-framework P1× catch-alls below.
 // ---------------------------------------------------------------------------
 
 const WILDCARD_REDIRECTS: RedirectEntry[] = [
@@ -735,15 +773,12 @@ const WILDCARD_REDIRECTS: RedirectEntry[] = [
     source: "/crewai-crews/:path*",
     destination: "/crewai-crews/:path*",
   },
-  // Category 4 wildcards — direct-to-llm and /integrations/built-in-agent retire to BIA
+  // Category 4 wildcards — direct-to-llm retires to BIA. R17
+  // (/integrations/built-in-agent/:path*) is docs-host-only and lives in
+  // the shell-docs copy — see the R15 note in ROOT_RENAMES above.
   {
     id: "R16",
     source: "/direct-to-llm/:path*",
-    destination: "/built-in-agent/:path*",
-  },
-  {
-    id: "R17",
-    source: "/integrations/built-in-agent/:path*",
     destination: "/built-in-agent/:path*",
   },
   { id: "R26", source: "/shared/:path*", destination: "/:path*" },
@@ -776,6 +811,12 @@ const WILDCARD_REDIRECTS: RedirectEntry[] = [
     destination: "/built-in-agent/guides/:path*",
   },
   { id: "P12", source: "/backend/:path*", destination: "/backend/:path*" },
+  // NOTE (SU5-A7): the BARE /learn (zero-segment :path*) lands on
+  // docs-host /concepts, a folder with no index page — reaching content
+  // depends on the DOCS host's own /concepts -> /concepts/architecture
+  // redirect (the docs-host twin of FI-concepts above): a deliberate
+  // double hop. If that docs-host redirect ever disappears, bare /learn
+  // 404s even though this entry still fires.
   { id: "P3", source: "/learn/:path*", destination: "/concepts/:path*" },
   {
     id: "P4",
@@ -817,7 +858,17 @@ const WILDCARD_REDIRECTS: RedirectEntry[] = [
 
 // ---------------------------------------------------------------------------
 // Combined export — ordered most-specific to least-specific
-// Middleware evaluates top-to-bottom, first match wins
+//
+// How middleware ACTUALLY evaluates this table (buildRedirectLookup in
+// middleware.ts): entries are split into an exact-match map and an
+// ordered wildcard list, and EVERY exact source is tried before ANY
+// wildcard — an exact entry beats a wildcard even if the wildcard
+// appears earlier in this array. "Top-to-bottom, first match wins"
+// holds in two narrower senses: (a) among WILDCARDS, earlier entries
+// have higher priority (the linear scan short-circuits), and (b) for
+// DUPLICATE exact sources or duplicate wildcard prefixes, the first
+// table entry claims the id (later duplicates are dropped with a
+// module-load warn).
 // ---------------------------------------------------------------------------
 
 export const seoRedirects: RedirectEntry[] = [
@@ -831,7 +882,8 @@ export const seoRedirects: RedirectEntry[] = [
   ...DOCS_PREFIX,
   ...MIGRATION_GUIDES,
   ...FOLDER_INDEX,
-  // 2. Generated per-framework subpath renames (exact paths)
+  // 2. Generated per-framework subpath renames (mostly exact paths,
+  // plus the S13w×<fw> concepts/:path* wildcards)
   ...generateFrameworkRenames(),
   // 3. Wildcard catch-alls last — order matters: most-specific wildcard first
   ...DOCS_INTEGRATIONS_RENAMES.filter((e) => e.source.includes(":path*")),

--- a/showcase/shell/src/middleware.test.ts
+++ b/showcase/shell/src/middleware.test.ts
@@ -412,6 +412,14 @@ describe("matcher boundaries (SU-15)", () => {
     tokensToRegexp(parseMatcherPath(config.matcher[0])).source,
   );
 
+  it("pins a single matcher entry — every boundary below compiles config.matcher[0] only (SU7-F3)", () => {
+    // A second matcher entry would be entirely untested by this
+    // describe (matcherRe compiles only the first); fail HERE with a
+    // self-explanatory message instead of silently green-lighting an
+    // unverified pattern.
+    expect(config.matcher).toHaveLength(1);
+  });
+
   it("runs middleware on /api and /api-reference (SEO sources R1/R3)", () => {
     expect(matcherRe.test("/api")).toBe(true);
     expect(matcherRe.test("/api-reference")).toBe(true);
@@ -561,8 +569,14 @@ describe("empty framework-slug set guard (SU-20)", () => {
     vi.stubEnv("NODE_ENV", "production");
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     warnIfNoFrameworkSlugs(new Set());
-    expect(error).toHaveBeenCalledOnce();
-    expect(error.mock.calls[0][0]).toContain("ZERO framework slugs");
+    // Message-filtered count (SU6-A6, applied SU7-F3): a bare
+    // toHaveBeenCalledOnce() would absorb any unrelated error into this
+    // count — or mask a missing slug error when exactly one unrelated
+    // error fired.
+    const slugErrors = error.mock.calls.filter(([msg]) =>
+      String(msg).includes("ZERO framework slugs"),
+    );
+    expect(slugErrors).toHaveLength(1);
   });
 
   it("console.warns outside production when the slug set is empty", () => {
@@ -903,6 +917,27 @@ describe("buildRedirectLookup rejects malformed entries (SU3-A3)", () => {
     expect(warns).toHaveLength(1);
   });
 
+  it("rejects+warns a root EXACT source '/' — it would hijack the homepage (SU7-F3)", () => {
+    // The twin of the root-wildcard guard: "/" passes every source
+    // check (starts with "/", no "//", no ?/#, length-1 so the
+    // trailing-slash guard skips it) and lands in the exact map, where
+    // it matches the HOMEPAGE — never a legitimate SEO entry.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { exactMap } = buildRedirectLookup([
+      { id: "root-exact", source: "/", destination: "/y" },
+      { id: "ok", source: "/ok", destination: "/fine" },
+    ]);
+    expect(exactMap.has("/")).toBe(false);
+    expect(exactMap.size).toBe(1);
+    expect(exactMap.get("/ok")?.id).toBe("ok");
+    const warns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("hijack the homepage"),
+    );
+    expect(warns).toHaveLength(1);
+    expect(String(warns[0][0])).toContain("root-exact");
+    expect(String(warns[0][0])).not.toContain("(ok)");
+  });
+
   it("skips+warns destinations that are not root-relative or carry ?/#", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { exactMap, wildcardEntries } = buildRedirectLookup([
@@ -982,6 +1017,34 @@ describe("buildRedirectLookup rejects malformed entries (SU3-A3)", () => {
     for (const id of ["no-slash", "query", "frag", "wild-no-slash"]) {
       expect(String(warns[0][0])).toContain(id);
     }
+  });
+
+  it("rejects+warns entries whose source or destination contains non-printable-ASCII (SU7-F3)", () => {
+    // NextRequest pathnames are percent-encoded ASCII, so a source with
+    // a raw space or a non-ASCII character can never match — previously
+    // a silent dead entry. The check also enforces the ASCII
+    // length-preservation assumption the positional-slicing comments
+    // rely on (toLowerCase is only guaranteed length-preserving for
+    // ASCII).
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { exactMap, wildcardEntries } = buildRedirectLookup([
+      { id: "space-src", source: "/with space", destination: "/y" },
+      { id: "uni-src", source: "/café", destination: "/y" },
+      { id: "uni-dest", source: "/ok-src", destination: "/naïve" },
+      { id: "wild-uni", source: "/wü/:path*", destination: "/y/:path*" },
+      { id: "ok", source: "/ok", destination: "/fine" },
+    ]);
+    expect(exactMap.size).toBe(1);
+    expect(exactMap.get("/ok")?.id).toBe("ok");
+    expect(wildcardEntries).toHaveLength(0);
+    const warns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("non-printable-ASCII"),
+    );
+    expect(warns).toHaveLength(1);
+    for (const id of ["space-src", "uni-src", "uni-dest", "wild-uni"]) {
+      expect(String(warns[0][0])).toContain(id);
+    }
+    expect(String(warns[0][0])).not.toContain("(ok)");
   });
 
   it("skips+warns trailing-slash exact sources — unreachable after stripping (SU4-A2)", () => {
@@ -1151,6 +1214,65 @@ describe("buildRedirectLookup rejects malformed entries (SU3-A3)", () => {
     expect(warns).toHaveLength(1);
     expect(String(warns[0][0])).toContain("typo-collapse");
     expect(String(warns[0][0])).not.toContain("kept-ok");
+  });
+
+  it("classifies a discarded same-destination tokenless wildcard twin as a silent duplicate — ZERO tokenless warns (SU7-F3)", () => {
+    // The duplicate-prefix owner check used to run AFTER the
+    // miscased/tokenless destination checks, so an entry that was about
+    // to be DISCARDED as a duplicate still fired destination warns —
+    // misclassifying a harmless same-destination twin as a tokenless
+    // table bug and desensitizing that channel (the exact failure mode
+    // the SU5-A3 twin allowlist exists to prevent).
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { wildcardEntries } = buildRedirectLookup([
+      // Allowlisted deliberate collapse — silent by design (SU6-A2).
+      {
+        id: "P10",
+        source: "/reference/v1/:path*",
+        destination: "/reference/v2",
+      },
+      // Same-destination twin whose id is NOT allowlisted: it must be
+      // skipped silently as a duplicate, never reaching the tokenless
+      // check.
+      {
+        id: "P10-twin",
+        source: "/reference/v1/:path*",
+        destination: "/reference/v2",
+      },
+    ]);
+    expect(wildcardEntries).toHaveLength(1);
+    expect(wildcardEntries[0].id).toBe("P10");
+    const tokenlessWarns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes('no ":path*" token'),
+    );
+    expect(tokenlessWarns).toHaveLength(0);
+    const dupWarns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("duplicate"),
+    );
+    expect(dupWarns).toHaveLength(0);
+  });
+
+  it("classifies a miscased-destination duplicate as a DUPLICATE, not a miscased-token bug (SU7-F3)", () => {
+    // A diverging duplicate is discarded whatever its destination looks
+    // like — it must warn on the duplicate channel (naming the shadowing
+    // owner), not on the miscased-token channel.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { wildcardEntries } = buildRedirectLookup([
+      { id: "owner", source: "/x/:path*", destination: "/a/:path*" },
+      { id: "twin", source: "/x/:path*", destination: "/a/:PATH*" },
+    ]);
+    expect(wildcardEntries).toHaveLength(1);
+    expect(wildcardEntries[0].id).toBe("owner");
+    const miscasedWarns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("miscased"),
+    );
+    expect(miscasedWarns).toHaveLength(0);
+    const dupWarns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("duplicate wildcard"),
+    );
+    expect(dupWarns).toHaveLength(1);
+    expect(String(dupWarns[0][0])).toContain("twin");
+    expect(String(dupWarns[0][0])).toContain("owner");
   });
 
   it("stays silent for the documented deliberate-collapse wildcard entries (SU6-A2)", () => {
@@ -1392,6 +1514,18 @@ describe("normalizePosthogHost — use-site guard (SU2-A6/SU4-A7)", () => {
     );
     expect(normalizePosthogHost("https://eu.posthog.com")).toBe(
       "https://eu.posthog.com",
+    );
+  });
+
+  it("strips trailing slashes so the /capture/ concatenation never yields '//' (SU7-F3)", () => {
+    // The guard exists to keep `${host}/capture/` well-formed for ANY
+    // raw value a future caller hands it — completing that contract
+    // means a trailing-slash host must not produce "host//capture/".
+    expect(normalizePosthogHost("https://eu.posthog.example.test/")).toBe(
+      "https://eu.posthog.example.test",
+    );
+    expect(normalizePosthogHost("eu.posthog.example.test//")).toBe(
+      "https://eu.posthog.example.test",
     );
   });
 });

--- a/showcase/shell/src/middleware.test.ts
+++ b/showcase/shell/src/middleware.test.ts
@@ -201,7 +201,9 @@ describe("docs-host redirects at the middleware level (SU-11)", () => {
     // page. /integrations/* is a shell-owned namespace — the guard runs
     // FIRST in middleware (SU4-A1), so no redirect step (docs-host OR
     // SEO table) may ever match under it, structurally.
-    expect(run("/integrations/built-in-agent").headers.get("location")).toBeNull();
+    expect(
+      run("/integrations/built-in-agent").headers.get("location"),
+    ).toBeNull();
     expect(
       run("/integrations/built-in-agent/agentic-chat").headers.get("location"),
     ).toBeNull();
@@ -1373,9 +1375,7 @@ describe("buildRedirectLookup rejects malformed entries (SU3-A3)", () => {
       "/a/z/b/z",
     );
     expect(substituteWildcardTemplate("/a/:path*", "$&x")).toBe("/a/$&x");
-    expect(substituteWildcardTemplate("/a/:path*", ":path*")).toBe(
-      "/a/:path*",
-    );
+    expect(substituteWildcardTemplate("/a/:path*", ":path*")).toBe("/a/:path*");
     expect(substituteWildcardTemplate("/fixed", "anything")).toBe("/fixed");
   });
 });

--- a/showcase/shell/src/middleware.test.ts
+++ b/showcase/shell/src/middleware.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { pathToRegexp } from "next/dist/compiled/path-to-regexp";
 import { NextRequest } from "next/server";
 import type { NextFetchEvent } from "next/server";
-import { config, middleware, warnIfNoFrameworkSlugs } from "./middleware";
+import {
+  buildRedirectLookup,
+  config,
+  middleware,
+  warnIfNoFrameworkSlugs,
+} from "./middleware";
 
 const DOCS_HOST = "https://docs.example.test";
 const SHELL_ORIGIN = "https://shell.example.test";
@@ -22,6 +28,16 @@ function location(res: Response): URL {
 
 beforeEach(() => {
   vi.stubEnv("DOCS_HOST", DOCS_HOST);
+  // An ambient POSTHOG_KEY (developer shell, CI secrets) would make every
+  // SEO-redirect test fire a REAL fetch to PostHog — global fetch is only
+  // stubbed inside the PostHog describe. Force tracking off by default;
+  // tests that exercise tracking stub their own key (and fetch).
+  vi.stubEnv("POSTHOG_KEY", "");
+  vi.stubEnv("POSTHOG_HOST", "");
+  // With tracking forced off, the first redirect test trips the
+  // statically-imported module's warn-once latch — spy at file level so
+  // no real console.warn escapes (restoreAllMocks in afterEach resets it).
+  vi.spyOn(console, "warn").mockImplementation(() => {});
 });
 
 afterEach(() => {
@@ -144,9 +160,15 @@ describe("redirect status codes (SU-2)", () => {
 });
 
 describe("matcher boundaries (SU-15)", () => {
-  // The matcher is a path-to-regexp pattern of the shape "/(<regex>.*)";
-  // anchoring it as a plain RegExp reproduces Next's matching for it.
-  const matcherRe = new RegExp(`^${config.matcher[0]}$`);
+  // Compile the matcher with Next's own vendored path-to-regexp and the
+  // option set Next uses for middleware matchers — a homemade anchored
+  // RegExp only happens to work for this pattern shape and would
+  // diverge from Next on any path-to-regexp syntax in the matcher.
+  const matcherRe = pathToRegexp(config.matcher[0], [], {
+    delimiter: "/",
+    sensitive: false,
+    strict: true,
+  });
 
   it("runs middleware on /api and /api-reference (SEO sources R1/R3)", () => {
     expect(matcherRe.test("/api")).toBe(true);
@@ -195,28 +217,217 @@ describe("empty framework-slug set guard (SU-20)", () => {
 });
 
 describe("PostHog tracking lifetime (SU-14)", () => {
+  // middleware.ts keeps a module-level warn-once latch (posthogKeyWarned).
+  // On the statically-imported instance, whichever earlier test triggered
+  // the first no-key redirect already consumed it, which makes the warn
+  // path untestable here — reset modules and import a fresh middleware
+  // per test so this describe owns the latch.
+  let freshMiddleware: typeof middleware;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ middleware: freshMiddleware } = await import("./middleware"));
+  });
+
+  function runFresh(pathAndQuery: string, event: NextFetchEvent) {
+    return freshMiddleware(
+      new NextRequest(`${SHELL_ORIGIN}${pathAndQuery}`),
+      event,
+    );
+  }
+
   it("registers the tracking fetch with event.waitUntil", () => {
     vi.stubEnv("POSTHOG_KEY", "phc_test");
     const fetchMock = vi.fn(() => Promise.resolve(new Response("ok")));
     vi.stubGlobal("fetch", fetchMock);
     const event = makeEvent();
-    run("/faq", event);
+    runFresh("/faq", event);
     expect(fetchMock).toHaveBeenCalledOnce();
     // Without waitUntil the Edge runtime may terminate right after the
     // redirect response, dropping the in-flight capture.
     expect(event.waitUntil).toHaveBeenCalledOnce();
   });
 
-  it("does not call waitUntil when tracking is disabled (no POSTHOG_KEY)", () => {
-    vi.stubEnv("POSTHOG_KEY", "");
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("warns exactly once and skips fetch/waitUntil when tracking is disabled (no POSTHOG_KEY)", () => {
+    // POSTHOG_KEY is already stubbed to "" by the file-level beforeEach.
+    const warn = vi.spyOn(console, "warn");
     const fetchMock = vi.fn(() => Promise.resolve(new Response("ok")));
     vi.stubGlobal("fetch", fetchMock);
+    const first = makeEvent();
+    const second = makeEvent();
+    runFresh("/faq", first);
+    runFresh("/learn", second);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(first.waitUntil).not.toHaveBeenCalled();
+    expect(second.waitUntil).not.toHaveBeenCalled();
+    // The latch warns once per cold start, not once per request.
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain("POSTHOG_KEY");
+  });
+});
+
+describe("duplicate exact sources: first match wins (SU2-A3)", () => {
+  it("attributes /unselected to SR-root×unselected, not the later P2× entry", () => {
+    // The table doc says "first match wins"; a Map last-write-wins build
+    // inverted that and skewed PostHog redirect_id attribution for the
+    // duplicate sources (P2×unselected overrode SR-root×unselected).
+    vi.stubEnv("POSTHOG_KEY", "phc_test");
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(new Response("ok")),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const res = run("/unselected");
+    expect(location(res).pathname).toBe("/built-in-agent");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    expect(body.properties.redirect_id).toBe("SR-root×unselected");
+  });
+
+  it("rejects wildcard sources whose prefix lacks a '/' boundary (SU2-A7v)", () => {
+    // Without the boundary, `startsWith(prefix)` would match prefix
+    // LOOKALIKES (e.g. "/x:path*" matching "/xylophone").
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { wildcardEntries } = buildRedirectLookup([
+      { id: "bad", source: "/x:path*", destination: "/y/:path*" },
+      { id: "good", source: "/a/:path*", destination: "/b/:path*" },
+    ]);
+    expect(wildcardEntries).toHaveLength(1);
+    expect(wildcardEntries[0].id).toBe("good");
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain("/x:path*");
+  });
+
+  it("keeps the first entry and warns once, naming the duplicate keys", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { exactMap } = buildRedirectLookup([
+      { id: "first", source: "/dup", destination: "/x" },
+      { id: "second", source: "/dup", destination: "/y" },
+      { id: "only", source: "/solo", destination: "/z" },
+    ]);
+    expect(exactMap.get("/dup")?.id).toBe("first");
+    expect(exactMap.get("/dup")?.destination).toBe("/x");
+    expect(exactMap.get("/solo")?.id).toBe("only");
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain("/dup");
+    expect(warn.mock.calls[0][0]).toContain("second");
+  });
+});
+
+describe("wildcard substitution is replacement-pattern safe (SU2-A1)", () => {
+  it("does not expand $-patterns from the user-controlled path remainder", () => {
+    // String-form String.prototype.replace treats `$&`, "$`", `$'`, `$$`
+    // in the REPLACEMENT as special patterns: `$&` re-inserts the matched
+    // substring, leaking the literal ":path*" token into the Location.
+    const res = run("/coagents/$&foo");
+    const dest = location(res);
+    expect(dest.pathname).not.toContain(":path*");
+    expect(dest.pathname).toBe("/langgraph-python/$&foo");
+  });
+
+  it("keeps literal $$ and $` sequences intact", () => {
+    expect(location(run("/coagents/$$bar")).pathname).toBe(
+      "/langgraph-python/$$bar",
+    );
+    expect(location(run("/coagents/$`baz")).pathname).toBe(
+      "/langgraph-python/$%60baz",
+    );
+  });
+});
+
+describe("capture payload disambiguates the destination host (SU2-A5)", () => {
+  it("emits to_url with the docs host alongside to_path", async () => {
+    // Self-referential docs-host entries (e.g. M3 /faq -> /faq) used to
+    // emit from_path === to_path, which is ambiguous for the
+    // decommission report — the destination actually lives on the DOCS
+    // host, not the shell.
+    vi.stubEnv("POSTHOG_KEY", "phc_test");
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(new Response("ok")),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    run("/faq?utm_source=x");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    expect(body.properties.from_path).toBe("/faq");
+    expect(body.properties.to_path).toBe("/faq");
+    // Host included; query string excluded (it varies per request and
+    // would explode property cardinality).
+    expect(body.properties.to_url).toBe(`${DOCS_HOST}/faq`);
+  });
+});
+
+describe("PostHog capture failures are observable (SU2-A2)", () => {
+  // The decommission report deletes redirects that show zero PostHog
+  // traffic — silently-broken capture (swallowed rejections, unchecked
+  // 4xx/5xx) causes wrongful deletions. Each failure class must warn
+  // once (not per request).
+
+  async function flushCapture(event: NextFetchEvent): Promise<void> {
+    const waitUntil = event.waitUntil as ReturnType<typeof vi.fn>;
+    await Promise.all(waitUntil.mock.calls.map((c) => c[0]));
+  }
+
+  it("warns once per HTTP-status failure class when capture returns non-2xx", async () => {
+    vi.stubEnv("POSTHOG_KEY", "phc_test");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response("err", { status: 500 }))),
+    );
     const event = makeEvent();
     run("/faq", event);
-    expect(fetchMock).not.toHaveBeenCalled();
-    expect(event.waitUntil).not.toHaveBeenCalled();
-    warn.mockRestore();
+    run("/quickstart", event);
+    await flushCapture(event);
+    const captureWarns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("http:500"),
+    );
+    expect(captureWarns).toHaveLength(1);
+  });
+
+  it("warns once per network failure class when capture rejects", async () => {
+    vi.stubEnv("POSTHOG_KEY", "phc_test");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new TypeError("fetch failed"))),
+    );
+    const event = makeEvent();
+    run("/faq", event);
+    run("/quickstart", event);
+    await flushCapture(event);
+    const captureWarns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("net:TypeError"),
+    );
+    expect(captureWarns).toHaveLength(1);
+  });
+});
+
+describe("scheme-less POSTHOG_HOST is normalized at the use site (SU2-A6)", () => {
+  it("prepends https:// so the capture fetch URL is absolute", () => {
+    vi.stubEnv("POSTHOG_KEY", "phc_test");
+    vi.stubEnv("POSTHOG_HOST", "eu.posthog.example.test");
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(new Response("ok")),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    run("/faq");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    // A scheme-less host yields a relative URL, which fetch() rejects on
+    // every capture in the Edge runtime.
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://eu.posthog.example.test/capture/",
+    );
+  });
+
+  it("leaves an explicit scheme untouched", () => {
+    vi.stubEnv("POSTHOG_KEY", "phc_test");
+    vi.stubEnv("POSTHOG_HOST", "http://localhost:8000");
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(new Response("ok")),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    run("/faq");
+    expect(fetchMock.mock.calls[0][0]).toBe("http://localhost:8000/capture/");
   });
 });
 

--- a/showcase/shell/src/middleware.test.ts
+++ b/showcase/shell/src/middleware.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import type { NextFetchEvent } from "next/server";
+import { config, middleware, warnIfNoFrameworkSlugs } from "./middleware";
+
+const DOCS_HOST = "https://docs.example.test";
+const SHELL_ORIGIN = "https://shell.example.test";
+
+function makeEvent(): NextFetchEvent {
+  return { waitUntil: vi.fn() } as unknown as NextFetchEvent;
+}
+
+function run(pathAndQuery: string, event: NextFetchEvent = makeEvent()) {
+  return middleware(new NextRequest(`${SHELL_ORIGIN}${pathAndQuery}`), event);
+}
+
+function location(res: Response): URL {
+  const loc = res.headers.get("location");
+  expect(loc).not.toBeNull();
+  return new URL(loc as string);
+}
+
+beforeEach(() => {
+  vi.stubEnv("DOCS_HOST", DOCS_HOST);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("middleware SEO redirects resolve against the docs host (SU-17)", () => {
+  it("redirects /faq to the docs host, never to itself on the shell origin", () => {
+    const res = run("/faq");
+    const dest = location(res);
+    // The destination table targets the DOCS routing surface. Resolving
+    // against the shell origin makes /faq -> shell /faq, an infinite
+    // 301 loop (ERR_TOO_MANY_REDIRECTS in prod).
+    expect(dest.origin).toBe(DOCS_HOST);
+    expect(dest.pathname).toBe("/faq");
+  });
+
+  it("sends exact-match destinations to the docs host in one hop", () => {
+    const res = run("/coagents/quickstart");
+    const dest = location(res);
+    expect(dest.origin).toBe(DOCS_HOST);
+    expect(dest.pathname).toBe("/langgraph-python/quickstart");
+  });
+
+  it("sends wildcard-match destinations to the docs host in one hop", () => {
+    const res = run("/troubleshooting/common-issues");
+    const dest = location(res);
+    expect(dest.origin).toBe(DOCS_HOST);
+    expect(dest.pathname).toBe("/troubleshooting/common-issues");
+  });
+});
+
+describe("SEO redirects forward the query string (SU-16)", () => {
+  it("preserves the query string on exact-match redirects", () => {
+    const res = run("/faq?utm_source=newsletter");
+    const dest = location(res);
+    expect(dest.pathname).toBe("/faq");
+    expect(dest.search).toBe("?utm_source=newsletter");
+  });
+
+  it("preserves the query string on wildcard-match redirects", () => {
+    const res = run("/coagents/foo?utm_source=newsletter&x=1");
+    const dest = location(res);
+    expect(dest.pathname).toBe("/langgraph-python/foo");
+    expect(dest.search).toBe("?utm_source=newsletter&x=1");
+  });
+});
+
+describe("wildcard sources match the bare path with zero segments (SU-19)", () => {
+  // next.config `/x/:path*` semantics: :path* is ZERO or more segments,
+  // so the bare /x must redirect too (11 such sources regressed to 404).
+  it("redirects /backend (P12) like /backend/:path* with zero segments", () => {
+    const res = run("/backend");
+    const dest = location(res);
+    expect(res.status).toBe(301);
+    expect(dest.origin).toBe(DOCS_HOST);
+    expect(dest.pathname).toBe("/backend");
+  });
+
+  it("redirects /guides (P11) to /built-in-agent/guides without a trailing slash", () => {
+    const dest = location(run("/guides"));
+    expect(dest.pathname).toBe("/built-in-agent/guides");
+  });
+
+  it("redirects /learn (P3) to /concepts", () => {
+    const dest = location(run("/learn"));
+    expect(dest.pathname).toBe("/concepts");
+  });
+});
+
+describe("docs-host redirects at the middleware level (SU-11)", () => {
+  it("redirects /docs/:path* to the docs host with the prefix stripped", () => {
+    const res = run("/docs/quickstart");
+    expect(res.status).toBe(308);
+    const dest = location(res);
+    expect(dest.origin).toBe(DOCS_HOST);
+    expect(dest.pathname).toBe("/quickstart");
+  });
+
+  it("forwards the query string on docs-host redirects", () => {
+    const dest = location(run("/docs/quickstart?utm_source=newsletter"));
+    expect(dest.pathname).toBe("/quickstart");
+    expect(dest.search).toBe("?utm_source=newsletter");
+  });
+
+  it("takes precedence over the SEO table (next.config-before-middleware parity)", () => {
+    // /docs/api is ALSO an SEO source (R2 -> /reference/v2); step 0 must
+    // win and strip the /docs prefix instead, like config redirects did.
+    const res = run("/docs/api");
+    expect(res.status).toBe(308);
+    expect(location(res).pathname).toBe("/api");
+
+    // A registry framework slug is step-0 territory even when the SEO
+    // table has wildcard entries that could match it.
+    const slugRes = run("/mastra/quickstart/mastra");
+    expect(slugRes.status).toBe(308);
+    expect(location(slugRes).pathname).toBe("/mastra/quickstart/mastra");
+  });
+
+  it("does not redirect shell-owned routes", () => {
+    const res = run("/integrations/mastra");
+    expect(res.headers.get("location")).toBeNull();
+  });
+});
+
+describe("redirect status codes (SU-2)", () => {
+  it("emits 308 for docs-host redirects, matching next.config permanent:true", () => {
+    // The removed next.config rules used `permanent: true`, which Next
+    // emits as 308 — a 1:1 port must keep the status code.
+    expect(run("/docs/quickstart").status).toBe(308);
+    expect(run("/ag-ui").status).toBe(308);
+  });
+
+  it("keeps 301 for SEO-table redirects (their original middleware status)", () => {
+    expect(run("/faq").status).toBe(301);
+    expect(run("/coagents/foo").status).toBe(301);
+  });
+});
+
+describe("matcher boundaries (SU-15)", () => {
+  // The matcher is a path-to-regexp pattern of the shape "/(<regex>.*)";
+  // anchoring it as a plain RegExp reproduces Next's matching for it.
+  const matcherRe = new RegExp(`^${config.matcher[0]}$`);
+
+  it("runs middleware on /api and /api-reference (SEO sources R1/R3)", () => {
+    expect(matcherRe.test("/api")).toBe(true);
+    expect(matcherRe.test("/api-reference")).toBe(true);
+  });
+
+  it("still excludes real API routes and internals", () => {
+    expect(matcherRe.test("/api/runtime")).toBe(false);
+    expect(matcherRe.test("/_next/static/chunk.js")).toBe(false);
+    expect(matcherRe.test("/previews/foo")).toBe(false);
+    expect(matcherRe.test("/favicon.ico")).toBe(false);
+  });
+
+  it("redirects /api and /api-reference to /reference/v2 on the docs host", () => {
+    const apiDest = location(run("/api"));
+    expect(apiDest.origin).toBe(DOCS_HOST);
+    expect(apiDest.pathname).toBe("/reference/v2");
+    const apiRefDest = location(run("/api-reference"));
+    expect(apiRefDest.pathname).toBe("/reference/v2");
+  });
+});
+
+describe("empty framework-slug set guard (SU-20)", () => {
+  it("console.errors in production when the slug set is empty", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    warnIfNoFrameworkSlugs(new Set());
+    expect(error).toHaveBeenCalledOnce();
+    expect(error.mock.calls[0][0]).toContain("ZERO framework slugs");
+  });
+
+  it("console.warns outside production when the slug set is empty", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    warnIfNoFrameworkSlugs(new Set());
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("stays silent when slugs are present", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    warnIfNoFrameworkSlugs(new Set(["mastra"]));
+    expect(error).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("PostHog tracking lifetime (SU-14)", () => {
+  it("registers the tracking fetch with event.waitUntil", () => {
+    vi.stubEnv("POSTHOG_KEY", "phc_test");
+    const fetchMock = vi.fn(() => Promise.resolve(new Response("ok")));
+    vi.stubGlobal("fetch", fetchMock);
+    const event = makeEvent();
+    run("/faq", event);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    // Without waitUntil the Edge runtime may terminate right after the
+    // redirect response, dropping the in-flight capture.
+    expect(event.waitUntil).toHaveBeenCalledOnce();
+  });
+
+  it("does not call waitUntil when tracking is disabled (no POSTHOG_KEY)", () => {
+    vi.stubEnv("POSTHOG_KEY", "");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchMock = vi.fn(() => Promise.resolve(new Response("ok")));
+    vi.stubGlobal("fetch", fetchMock);
+    const event = makeEvent();
+    run("/faq", event);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(event.waitUntil).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe("open redirect via duplicate slashes (SU-18)", () => {
+  it("does NOT redirect /shared//evil.com off-site via a scheme-relative URL", () => {
+    const res = run("/shared//evil.com");
+    const dest = location(res);
+    // Reproduced pre-fix: R26 /shared/:path* -> /:path* yields
+    // "//evil.com", which `new URL()` treats as scheme-relative —
+    // Location landed on https://evil.com/. Duplicate-slash collapsing
+    // in resolveSeoDestination keeps the redirect on a host we own.
+    expect(dest.host).not.toContain("evil.com");
+    expect(dest.origin).toBe(DOCS_HOST);
+    expect(dest.pathname).toBe("/evil.com");
+  });
+});

--- a/showcase/shell/src/middleware.test.ts
+++ b/showcase/shell/src/middleware.test.ts
@@ -1,11 +1,29 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { pathToRegexp } from "next/dist/compiled/path-to-regexp";
+import {
+  parse as parseMatcherPath,
+  tokensToRegexp,
+} from "next/dist/compiled/path-to-regexp";
 import { NextRequest } from "next/server";
 import type { NextFetchEvent } from "next/server";
+
+// The statically-imported middleware module emits its table-validation
+// warns (duplicate exact sources / duplicate wildcard prefixes) at
+// IMPORT time — before any beforeEach spy exists — so they printed raw
+// on every run (SU4-A7). vi.hoisted executes before the static imports
+// below, swallowing them; the file-level beforeEach re-spies per test
+// and afterEach's restoreAllMocks puts the real console.warn back.
+vi.hoisted(() => {
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
 import {
   buildRedirectLookup,
   config,
+  DELIBERATE_COLLAPSE_WILDCARD_IDS,
   middleware,
+  normalizePosthogHost,
+  REGISTRY_FRAMEWORK_SLUGS,
+  substituteWildcardTemplate,
   warnIfNoFrameworkSlugs,
 } from "./middleware";
 
@@ -34,10 +52,32 @@ beforeEach(() => {
   // tests that exercise tracking stub their own key (and fetch).
   vi.stubEnv("POSTHOG_KEY", "");
   vi.stubEnv("POSTHOG_HOST", "");
+  // ALSO stub the NEXT_PUBLIC_ alternates (SU4-A7): readEnvPair treats
+  // an empty-string primary as unset and falls through to the alt name,
+  // so an ambient NEXT_PUBLIC_POSTHOG_KEY (developer shell, CI secrets)
+  // would re-enable REAL PostHog POSTs straight through the
+  // empty-string primary stubs above.
+  vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "");
+  vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "");
+  // Pin BASE_URL explicitly: runtime-config console.warns once per
+  // isolate when it is unset, and the warn-count assertions below only
+  // passed because Vitest happens to mirror Vite's BASE_URL="/" into
+  // process.env — an implementation detail, not a contract. Without
+  // this stub, fresh-imported middleware instances (resetModules
+  // re-runs runtime-config's warn-once latches too) would emit an
+  // unrelated warn into those counts.
+  vi.stubEnv("BASE_URL", "http://localhost:3000");
   // With tracking forced off, the first redirect test trips the
   // statically-imported module's warn-once latch — spy at file level so
   // no real console.warn escapes (restoreAllMocks in afterEach resets it).
   vi.spyOn(console, "warn").mockImplementation(() => {});
+  // mockClear is load-bearing (SU5-A6): when console.warn is ALREADY a
+  // mock (the vi.hoisted spy, before the first afterEach restores it),
+  // spyOn returns that same mock WITHOUT clearing its history — under
+  // .only/-t/--shuffle the module-load table warns would poison
+  // bare-count assertions (toHaveBeenCalledOnce) in whichever test runs
+  // first.
+  vi.mocked(console.warn).mockClear();
 });
 
 afterEach(() => {
@@ -111,6 +151,14 @@ describe("wildcard sources match the bare path with zero segments (SU-19)", () =
 });
 
 describe("docs-host redirects at the middleware level (SU-11)", () => {
+  it("pins 'mastra' as a registry slug — slug-dependent tests rely on it (SU4-A7)", () => {
+    // Several tests in this file (and below) route /mastra/* through
+    // the docs-host step. If the registry ever drops or renames the
+    // mastra integration, fail HERE with a self-explanatory message
+    // instead of as a baffling 301-vs-308 mismatch downstream.
+    expect(REGISTRY_FRAMEWORK_SLUGS.has("mastra")).toBe(true);
+  });
+
   it("redirects /docs/:path* to the docs host with the prefix stripped", () => {
     const res = run("/docs/quickstart");
     expect(res.status).toBe(308);
@@ -126,14 +174,15 @@ describe("docs-host redirects at the middleware level (SU-11)", () => {
   });
 
   it("takes precedence over the SEO table (next.config-before-middleware parity)", () => {
-    // /docs/api is ALSO an SEO source (R2 -> /reference/v2); step 0 must
-    // win and strip the /docs prefix instead, like config redirects did.
+    // /docs/api is ALSO an SEO source (R2 -> /reference/v2); the
+    // docs-host step must win and strip the /docs prefix instead, like
+    // config redirects did.
     const res = run("/docs/api");
     expect(res.status).toBe(308);
     expect(location(res).pathname).toBe("/api");
 
-    // A registry framework slug is step-0 territory even when the SEO
-    // table has wildcard entries that could match it.
+    // A registry framework slug is docs-host-step territory even when
+    // the SEO table has wildcard entries that could match it.
     const slugRes = run("/mastra/quickstart/mastra");
     expect(slugRes.status).toBe(308);
     expect(location(slugRes).pathname).toBe("/mastra/quickstart/mastra");
@@ -142,6 +191,194 @@ describe("docs-host redirects at the middleware level (SU-11)", () => {
   it("does not redirect shell-owned routes", () => {
     const res = run("/integrations/mastra");
     expect(res.headers.get("location")).toBeNull();
+  });
+
+  it("never lets the SEO table hijack the /integrations namespace (SU3-A1)", () => {
+    // /integrations/built-in-agent is a LIVE shell product page (a
+    // deployed registry integration, internally linked from
+    // search-modal.tsx and integration-explorer.tsx). R15/R17 used to
+    // 301 it (and every subpath) to the docs host, hijacking the live
+    // page. /integrations/* is a shell-owned namespace — the guard runs
+    // FIRST in middleware (SU4-A1), so no redirect step (docs-host OR
+    // SEO table) may ever match under it, structurally.
+    expect(run("/integrations/built-in-agent").headers.get("location")).toBeNull();
+    expect(
+      run("/integrations/built-in-agent/agentic-chat").headers.get("location"),
+    ).toBeNull();
+    expect(run("/integrations").headers.get("location")).toBeNull();
+  });
+
+  it("guards /integrations even if 'integrations' appears as a registry slug (SU4-A1)", () => {
+    // Before the hoist, the guard ran AFTER the docs-host redirect: the
+    // protection was data-dependent — a registry slug literally named
+    // "integrations" would have let step 1 308 live shell pages to the
+    // docs host before the guard executed. Stub the slug set to contain
+    // it and prove the guard is structural.
+    //
+    // Shared-state hygiene (SU5-A6): REGISTRY_FRAMEWORK_SLUGS is the
+    // live module-level Set every other test in this worker reads.
+    // Capture whether the slug pre-existed and only delete what THIS
+    // test added — an unconditional finally-delete would erase a real
+    // registry slug for the rest of the run if one ever appeared.
+    const had = REGISTRY_FRAMEWORK_SLUGS.has("integrations");
+    // Precondition: the stub below is only meaningful while the real
+    // registry does NOT claim the slug (if it ever does, the guard's
+    // structural claim needs re-proving with a different slug).
+    expect(had).toBe(false);
+    REGISTRY_FRAMEWORK_SLUGS.add("integrations");
+    try {
+      expect(
+        run("/integrations/built-in-agent").headers.get("location"),
+      ).toBeNull();
+      expect(run("/integrations").headers.get("location")).toBeNull();
+      expect(run("/Integrations/anything").headers.get("location")).toBeNull();
+    } finally {
+      if (!had) REGISTRY_FRAMEWORK_SLUGS.delete("integrations");
+    }
+  });
+});
+
+describe("case-insensitive matching parity (SU3-A4)", () => {
+  // The next.config rules this layer replaced were compiled by
+  // path-to-regexp with sensitive:false — /FAQ and /Mastra/quickstart
+  // matched. The middleware port's Map/startsWith/Set lookups are
+  // case-sensitive and regressed those URLs to 404. Matching is now
+  // case-insensitive; the wildcard remainder keeps its ORIGINAL case
+  // (path-to-regexp preserves matched-param case in destinations).
+  it("redirects /FAQ exactly like /faq", () => {
+    const res = run("/FAQ");
+    expect(res.status).toBe(301);
+    const dest = location(res);
+    expect(dest.origin).toBe(DOCS_HOST);
+    expect(dest.pathname).toBe("/faq");
+  });
+
+  it("forwards /Mastra/Quickstart to the docs host with the original-case tail", () => {
+    const res = run("/Mastra/Quickstart");
+    expect(res.status).toBe(308);
+    const dest = location(res);
+    expect(dest.origin).toBe(DOCS_HOST);
+    // Slug literal is canonical lowercase; the matched remainder keeps
+    // its original case, exactly as a path-to-regexp :path* param did.
+    expect(dest.pathname).toBe("/mastra/Quickstart");
+  });
+
+  it("matches SEO wildcard prefixes case-insensitively, keeping the rest's case", () => {
+    const res = run("/Coagents/Foo");
+    expect(res.status).toBe(301);
+    expect(location(res).pathname).toBe("/langgraph-python/Foo");
+  });
+
+  it("matches kept docs prefixes (/AG-UI) and /DOCS case-insensitively", () => {
+    const agui = run("/AG-UI/Events");
+    expect(agui.status).toBe(308);
+    expect(location(agui).pathname).toBe("/ag-ui/Events");
+
+    const docs = run("/DOCS/Quickstart");
+    expect(docs.status).toBe(308);
+    expect(location(docs).pathname).toBe("/Quickstart");
+  });
+
+  it("still guards the /integrations namespace case-insensitively", () => {
+    expect(
+      run("/Integrations/built-in-agent").headers.get("location"),
+    ).toBeNull();
+  });
+});
+
+describe("trailing-slash normalization for matching (SU3-A5)", () => {
+  it("redirects /faq/ via the exact entry in ONE hop (no 308 detour)", () => {
+    // A trailing slash missed the exact map, falling through to Next's
+    // own trailing-slash 308 — an extra hop for every such URL.
+    const res = run("/faq/");
+    expect(res.status).toBe(301);
+    const dest = location(res);
+    expect(dest.origin).toBe(DOCS_HOST);
+    expect(dest.pathname).toBe("/faq");
+  });
+
+  it("attributes /coagents/ to the exact entry L1, not the wildcard L12", () => {
+    vi.stubEnv("POSTHOG_KEY", "phc_test");
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(new Response("ok")),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const res = run("/coagents/");
+    expect(location(res).pathname).toBe("/langgraph-python");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    expect(body.properties.redirect_id).toBe("L1");
+  });
+
+  it("does not strip the root path", () => {
+    expect(run("/").headers.get("location")).toBeNull();
+  });
+
+  it("strips a WHOLE trailing-slash run, not just one slash (SU4-A3)", () => {
+    // slice(0, -1) only removed ONE slash: "/faq//" became "/faq/" and
+    // still missed the exact map.
+    const res = run("/faq//");
+    expect(res.status).toBe(301);
+    expect(location(res).pathname).toBe("/faq");
+    expect(location(run("/coagents///")).pathname).toBe("/langgraph-python");
+  });
+});
+
+describe("leading-slash runs are collapsed for matching (SU4-A3)", () => {
+  // "//docs/foo" and "//ag-ui/x" fell through the docs-host step's
+  // strict ===/startsWith branches (only the framework-slug regex
+  // tolerated runs) AND missed the SEO wildcard scan → 404. The run is
+  // collapsed once in middleware() for ALL matching steps.
+  it("redirects //docs/foo like /docs/foo (308, prefix stripped)", () => {
+    const res = run("//docs/foo");
+    expect(res.status).toBe(308);
+    const dest = location(res);
+    expect(dest.origin).toBe(DOCS_HOST);
+    expect(dest.pathname).toBe("/foo");
+  });
+
+  it("redirects //ag-ui/x like /ag-ui/x (prefix kept)", () => {
+    const res = run("//ag-ui/x");
+    expect(res.status).toBe(308);
+    expect(location(res).pathname).toBe("/ag-ui/x");
+  });
+
+  it("redirects ///coagents/foo through the SEO wildcard scan", () => {
+    const res = run("///coagents/foo");
+    expect(res.status).toBe(301);
+    expect(location(res).pathname).toBe("/langgraph-python/foo");
+  });
+
+  it("still guards the /integrations namespace behind a slash run", () => {
+    expect(run("//integrations/mastra").headers.get("location")).toBeNull();
+  });
+
+  it("collapses an all-slash path to root and passes it through", () => {
+    expect(run("///").headers.get("location")).toBeNull();
+  });
+});
+
+describe("table-entry pins (SU3-A6)", () => {
+  it("matches MG3's uppercase source against the lowercase live URL", () => {
+    // The table source is "/migration-guides/1.10.X" (uppercase X) but
+    // live URLs are lowercase — before case-insensitive matching (SU3-A4
+    // lowercases BOTH the table keys and the request path) this entry
+    // could never fire.
+    expect(location(run("/migration-guides/1.10.x")).pathname).toBe(
+      "/migrate/v2",
+    );
+    expect(location(run("/migration-guides/1.10.X")).pathname).toBe(
+      "/migrate/v2",
+    );
+  });
+
+  it("keeps the framework segment on F13 like every comparable rule", () => {
+    // F13 dropped the framework segment (→ /human-in-the-loop), unlike
+    // F11/F12, the S× renames and the P1×aws-strands catch-all, which
+    // all map onto the canonical slug (aws-strands → strands).
+    expect(location(run("/aws-strands/human-in-the-loop")).pathname).toBe(
+      "/strands/human-in-the-loop",
+    );
   });
 });
 
@@ -160,15 +397,20 @@ describe("redirect status codes (SU-2)", () => {
 });
 
 describe("matcher boundaries (SU-15)", () => {
-  // Compile the matcher with Next's own vendored path-to-regexp and the
-  // option set Next uses for middleware matchers — a homemade anchored
-  // RegExp only happens to work for this pattern shape and would
-  // diverge from Next on any path-to-regexp syntax in the matcher.
-  const matcherRe = pathToRegexp(config.matcher[0], [], {
-    delimiter: "/",
-    sensitive: false,
-    strict: true,
-  });
+  // Compile the matcher EXACTLY as Next does (SU6-A6 — see
+  // tryToParsePath in next/dist/lib/try-to-parse-path.ts, which
+  // getMiddlewareMatchers uses at build): parse() + tokensToRegexp()
+  // with NO options, keeping only the regex SOURCE — the build manifest
+  // stores `.source` and the runtime re-hydrates it with
+  // `new RegExp(matcher.regexp)` (middleware-route-matcher.ts),
+  // DROPPING the `i` flag that tokensToRegexp's sensitive:false default
+  // implies. Runtime matcher matching is therefore case-SENSITIVE. The
+  // previous homemade option set ({ delimiter: "/", sensitive: false,
+  // strict: true }) was NOT what Next uses and diverged on exactly that
+  // class of input (a case-variant of an excluded prefix).
+  const matcherRe = new RegExp(
+    tokensToRegexp(parseMatcherPath(config.matcher[0])).source,
+  );
 
   it("runs middleware on /api and /api-reference (SEO sources R1/R3)", () => {
     expect(matcherRe.test("/api")).toBe(true);
@@ -178,8 +420,42 @@ describe("matcher boundaries (SU-15)", () => {
   it("still excludes real API routes and internals", () => {
     expect(matcherRe.test("/api/runtime")).toBe(false);
     expect(matcherRe.test("/_next/static/chunk.js")).toBe(false);
+    expect(matcherRe.test("/_next/image")).toBe(false);
     expect(matcherRe.test("/previews/foo")).toBe(false);
     expect(matcherRe.test("/favicon.ico")).toBe(false);
+  });
+
+  it("excludes ALL _next/* internals wholesale (SU4-A6)", () => {
+    // The old `_next/static|_next/image` pair let /_next/data and every
+    // other /_next/* internal run the middleware for nothing — no table
+    // source or registry slug starts with `_next`.
+    expect(matcherRe.test("/_next/data/build-id/foo.json")).toBe(false);
+    expect(matcherRe.test("/_next/postponed/resume")).toBe(false);
+    // A lookalike OUTSIDE the _next/ prefix still runs the middleware.
+    expect(matcherRe.test("/_nextdoor")).toBe(true);
+  });
+
+  it("matches case-SENSITIVELY, like Next's runtime regexp (SU6-A6)", () => {
+    // The runtime rebuilds the matcher with `new RegExp(source)` — no
+    // `i` flag — so a case-variant of an excluded prefix still reaches
+    // the middleware (which then passes it through; no table source
+    // starts with /API or /_NEXT).
+    expect(matcherRe.test("/API/runtime")).toBe(true);
+    expect(matcherRe.test("/_NEXT/static/chunk.js")).toBe(true);
+  });
+
+  it("lets bare /api/ (trailing slash) reach middleware for the single-hop R1 redirect (SU5-A4)", () => {
+    // The blanket `api/` exclusion also swallowed the BARE "/api/":
+    // Next then 308'd it to /api (trailing-slash normalization) before
+    // R1 could 301 — a needless double hop. Narrowed to `api/.+`, the
+    // bare trailing-slash form reaches middleware and R1 redirects in
+    // ONE hop; real API routes (/api/<anything>) stay excluded.
+    expect(matcherRe.test("/api/")).toBe(true);
+    const res = run("/api/");
+    expect(res.status).toBe(301);
+    const dest = location(res);
+    expect(dest.origin).toBe(DOCS_HOST);
+    expect(dest.pathname).toBe("/reference/v2");
   });
 
   it("redirects /api and /api-reference to /reference/v2 on the docs host", () => {
@@ -188,6 +464,95 @@ describe("matcher boundaries (SU-15)", () => {
     expect(apiDest.pathname).toBe("/reference/v2");
     const apiRefDest = location(run("/api-reference"));
     expect(apiRefDest.pathname).toBe("/reference/v2");
+  });
+});
+
+describe("REGISTRY_FRAMEWORK_SLUGS lowercase-normalizes registry slugs (SU4-A4)", () => {
+  afterEach(() => {
+    vi.doUnmock("@/data/registry.json");
+    vi.resetModules();
+  });
+
+  it("matches a mixed-case registry slug after construction-time lowercasing", async () => {
+    // docs-redirects compares the LOWERCASED first segment against the
+    // set — a mixed-case slug stored verbatim would silently never
+    // match, disabling its docs-host redirect with no signal.
+    vi.resetModules();
+    vi.doMock("@/data/registry.json", () => ({
+      default: { integrations: [{ slug: "MiXedCase" }] },
+    }));
+    const fresh = await import("./middleware");
+    expect(fresh.REGISTRY_FRAMEWORK_SLUGS.has("mixedcase")).toBe(true);
+    const res = fresh.middleware(
+      new NextRequest(`${SHELL_ORIGIN}/MixedCase/quickstart`),
+      makeEvent(),
+    );
+    expect(res.status).toBe(308);
+    expect(location(res).pathname).toBe("/mixedcase/quickstart");
+  });
+});
+
+describe("REGISTRY_FRAMEWORK_SLUGS survives a malformed registry (SU5-A1)", () => {
+  // Module-load defensiveness: the slug-set construction used to do
+  // `i.slug.toLowerCase()` through a bare `as` cast — a registry that is
+  // null, has a non-array `integrations`, or contains entries with a
+  // missing/non-string slug would TypeError at MODULE LOAD: the exact
+  // 500-every-request failure warnIfNoFrameworkSlugs exists to prevent.
+  afterEach(() => {
+    vi.doUnmock("@/data/registry.json");
+    vi.resetModules();
+  });
+
+  async function importWithRegistry(registryShape: unknown) {
+    vi.resetModules();
+    vi.doMock("@/data/registry.json", () => ({ default: registryShape }));
+    return import("./middleware");
+  }
+
+  it("imports without throwing when the registry is null", async () => {
+    const fresh = await importWithRegistry(null);
+    expect(fresh.REGISTRY_FRAMEWORK_SLUGS.size).toBe(0);
+  });
+
+  it("imports without throwing when integrations is not an array", async () => {
+    const fresh = await importWithRegistry({ integrations: "corrupt" });
+    expect(fresh.REGISTRY_FRAMEWORK_SLUGS.size).toBe(0);
+  });
+
+  it("drops entries with a missing or non-string slug and warns, keeping valid ones", async () => {
+    const fresh = await importWithRegistry({
+      integrations: [
+        { slug: "Good" },
+        { name: "no-slug-key" },
+        { slug: 42 },
+        null,
+      ],
+    });
+    expect(fresh.REGISTRY_FRAMEWORK_SLUGS.has("good")).toBe(true);
+    expect(fresh.REGISTRY_FRAMEWORK_SLUGS.size).toBe(1);
+    // The drop is observable next to warnIfNoFrameworkSlugs's module-load
+    // guard — a silently-shrunken slug set disables docs-host redirects
+    // with no signal otherwise.
+    const dropWarns = vi
+      .mocked(console.warn)
+      .mock.calls.filter(([msg]) =>
+        String(msg).includes("dropped from the framework-slug set"),
+      );
+    expect(dropWarns).toHaveLength(1);
+    // Count-phrase match (SU6-A6): a bare toContain("3") would match a
+    // "3" anywhere in the message (ids, paths, "SU3-..."), not the
+    // dropped-entry count.
+    expect(String(dropWarns[0][0])).toContain("has 3 integration");
+  });
+
+  it("stays silent about drops for a fully well-formed registry", async () => {
+    await importWithRegistry({ integrations: [{ slug: "fine" }] });
+    const dropWarns = vi
+      .mocked(console.warn)
+      .mock.calls.filter(([msg]) =>
+        String(msg).includes("dropped from the framework-slug set"),
+      );
+    expect(dropWarns).toHaveLength(0);
   });
 });
 
@@ -204,7 +569,12 @@ describe("empty framework-slug set guard (SU-20)", () => {
     vi.stubEnv("NODE_ENV", "development");
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     warnIfNoFrameworkSlugs(new Set());
-    expect(warn).toHaveBeenCalledOnce();
+    // Message-filtered count (SU6-A6): a bare toHaveBeenCalledOnce()
+    // would absorb any unrelated warn into this count.
+    const slugWarns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("ZERO framework slugs"),
+    );
+    expect(slugWarns).toHaveLength(1);
   });
 
   it("stays silent when slugs are present", () => {
@@ -213,6 +583,70 @@ describe("empty framework-slug set guard (SU-20)", () => {
     warnIfNoFrameworkSlugs(new Set(["mastra"]));
     expect(error).not.toHaveBeenCalled();
     expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("docs-redirects-disabled sentinel consumer (SU4-B2)", () => {
+  // middleware.ts keeps a module-level warn-once latch
+  // (docsRedirectsDisabledWarned) — reset modules and import a fresh
+  // middleware per test so this describe owns the latch (same pattern
+  // as the PostHog tracking-lifetime describe below).
+  let freshMiddleware: typeof middleware;
+
+  beforeEach(async () => {
+    // Shell deployed AT the default docs host with DOCS_HOST pointing
+    // there too: the configured value is rejected (self-host) AND the
+    // DEFAULT_DOCS_HOST fallback carries the identical defect, so
+    // runtime-config hands middleware the DOCS_REDIRECTS_DISABLED_HOST
+    // sentinel instead of a looping host.
+    vi.stubEnv("BASE_URL", "https://docs.showcase.copilotkit.ai");
+    vi.stubEnv("DOCS_HOST", "https://docs.showcase.copilotkit.ai");
+    // The FATAL-CONFIG console.error asserted below is the PROD posture
+    // — readDocsHost branches dev-vs-prod (dev logs a warn instead).
+    vi.stubEnv("NODE_ENV", "production");
+    vi.resetModules();
+    ({ middleware: freshMiddleware } = await import("./middleware"));
+    // Fresh import re-runs module-load warnings into the file-level
+    // warn spy — clear them so the once-assertions below only count
+    // request-time warns.
+    vi.mocked(console.warn).mockClear();
+  });
+
+  it("skips the docs-host step (no 308 to the sentinel) and warns once", () => {
+    // runtime-config console.errors its FATAL-CONFIG diagnosis at
+    // request time (fresh latches after resetModules) — swallow it so
+    // nothing prints raw, and assert it fired.
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const sentinelWarns = () =>
+      vi
+        .mocked(console.warn)
+        .mock.calls.filter((c) =>
+          String(c[0]).includes("docs redirects are DISABLED"),
+        );
+
+    const first = freshMiddleware(
+      new NextRequest(`${SHELL_ORIGIN}/docs/foo`),
+      makeEvent(),
+    );
+    // The redirect steps are skipped entirely: /docs/foo would normally
+    // 308 to the docs host (and the SEO DOCS-wild entry would otherwise
+    // 301 it to the same docsHost) — with the sentinel the request
+    // passes straight through to NextResponse.next(), never a redirect
+    // to the guaranteed-dead `.invalid` sentinel origin.
+    expect(first.headers.get("location")).toBeNull();
+    expect(first.status).toBe(200);
+    expect(sentinelWarns()).toHaveLength(1);
+    expect(
+      error.mock.calls.some((c) => String(c[0]).includes("FATAL-CONFIG")),
+    ).toBe(true);
+
+    // Second request: still no redirect, and the warn-once latch holds.
+    const second = freshMiddleware(
+      new NextRequest(`${SHELL_ORIGIN}/docs/bar`),
+      makeEvent(),
+    );
+    expect(second.headers.get("location")).toBeNull();
+    expect(sentinelWarns()).toHaveLength(1);
   });
 });
 
@@ -227,6 +661,10 @@ describe("PostHog tracking lifetime (SU-14)", () => {
   beforeEach(async () => {
     vi.resetModules();
     ({ middleware: freshMiddleware } = await import("./middleware"));
+    // The fresh import re-runs module-load warnings (e.g. the duplicate
+    // exact-sources warn from SU2-A3) into the file-level warn spy —
+    // clear them so assertions below only count request-time warns.
+    vi.mocked(console.warn).mockClear();
   });
 
   function runFresh(pathAndQuery: string, event: NextFetchEvent) {
@@ -261,8 +699,85 @@ describe("PostHog tracking lifetime (SU-14)", () => {
     expect(first.waitUntil).not.toHaveBeenCalled();
     expect(second.waitUntil).not.toHaveBeenCalled();
     // The latch warns once per cold start, not once per request.
-    expect(warn).toHaveBeenCalledOnce();
-    expect(warn.mock.calls[0][0]).toContain("POSTHOG_KEY");
+    // Filter by message: a bare toHaveBeenCalledOnce() would absorb any
+    // unrelated warn (module-load table warns, runtime-config fallbacks)
+    // into this count and fail — or worse, mask a missing key warn when
+    // exactly one unrelated warn fired.
+    const keyWarns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("POSTHOG_KEY"),
+    );
+    expect(keyWarns).toHaveLength(1);
+  });
+
+  it("console.errors (not warns) in production when POSTHOG_KEY is missing (SU4-A5)", () => {
+    // Mirrors warnIfNoFrameworkSlugs's NODE_ENV branching: on dev /
+    // preview deploys a missing key is legitimate, but in production it
+    // is a wiring bug that silently under-counts the decommission
+    // report — it must hit the error stream.
+    vi.stubEnv("NODE_ENV", "production");
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn");
+    const event = makeEvent();
+    runFresh("/faq", event);
+    const keyErrors = error.mock.calls.filter(([msg]) =>
+      String(msg).includes("POSTHOG_KEY"),
+    );
+    expect(keyErrors).toHaveLength(1);
+    expect(String(keyErrors[0][0])).toContain("wiring bug");
+    const keyWarns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("POSTHOG_KEY"),
+    );
+    expect(keyWarns).toHaveLength(0);
+  });
+
+  it("console.warns (not errors) outside production when POSTHOG_KEY is missing (SU4-A5)", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn");
+    const event = makeEvent();
+    runFresh("/faq", event);
+    const keyWarns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("POSTHOG_KEY"),
+    );
+    expect(keyWarns).toHaveLength(1);
+    const keyErrors = error.mock.calls.filter(([msg]) =>
+      String(msg).includes("POSTHOG_KEY"),
+    );
+    expect(keyErrors).toHaveLength(0);
+  });
+
+  it("surfaces the missing-key wiring bug on the FIRST request, even when no redirect fires (SU6-A5)", () => {
+    // The check used to live inside trackRedirect, which only runs when
+    // a redirect MATCHES — a prod deploy whose traffic never hits a
+    // redirect source got ZERO signal that every seo_redirect would go
+    // uncaptured. It now runs at config-resolution time on every
+    // middleware invocation (latched once per isolate).
+    vi.stubEnv("NODE_ENV", "production");
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const keyErrors = () =>
+      error.mock.calls.filter(([msg]) => String(msg).includes("POSTHOG_KEY"));
+    // A pass-through path: no redirect step matches it.
+    const res = runFresh("/integrations/built-in-agent", makeEvent());
+    expect(res.headers.get("location")).toBeNull();
+    expect(keyErrors()).toHaveLength(1);
+    // Second request: the once-latch holds.
+    runFresh("/integrations/built-in-agent", makeEvent());
+    expect(keyErrors()).toHaveLength(1);
+  });
+
+  it("does NOT capture PostHog events for docs-host redirects (parity pin)", () => {
+    // Deliberate parity choice (see the docs-host step): the next.config
+    // `redirects()` rules these replace were never tracked — only the
+    // SEO table calls trackRedirect. Pin it so a future refactor doesn't
+    // silently start double-counting docs traffic as seo_redirect events.
+    vi.stubEnv("POSTHOG_KEY", "phc_test");
+    const fetchMock = vi.fn(() => Promise.resolve(new Response("ok")));
+    vi.stubGlobal("fetch", fetchMock);
+    const event = makeEvent();
+    const res = runFresh("/docs/quickstart", event);
+    expect(res.status).toBe(308);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(event.waitUntil).not.toHaveBeenCalled();
   });
 });
 
@@ -293,8 +808,49 @@ describe("duplicate exact sources: first match wins (SU2-A3)", () => {
     ]);
     expect(wildcardEntries).toHaveLength(1);
     expect(wildcardEntries[0].id).toBe("good");
-    expect(warn).toHaveBeenCalledOnce();
-    expect(warn.mock.calls[0][0]).toContain("/x:path*");
+    // Message-filtered count (SU6-A6): a bare toHaveBeenCalledOnce()
+    // would absorb any unrelated warn into this count.
+    const malformedWarns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("malformed wildcard"),
+    );
+    expect(malformedWarns).toHaveLength(1);
+    expect(String(malformedWarns[0][0])).toContain("/x:path*");
+  });
+
+  it("applies first-match-wins + warn to duplicate WILDCARD prefixes (SU3-A2)", () => {
+    // Exact sources got first-match-wins + a module-load warn in round 2;
+    // wildcard sources have the same shadowing problem (six SR-wild×
+    // prefixes duplicate the later P1× entries). Without dedup the
+    // shadowed ids silently get zero traffic attribution — and the
+    // decommission report then proposes deleting a LIVE redirect.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { wildcardEntries } = buildRedirectLookup([
+      { id: "first-wild", source: "/x/:path*", destination: "/a/:path*" },
+      { id: "second-wild", source: "/x/:path*", destination: "/b/:path*" },
+      { id: "other", source: "/y/:path*", destination: "/c/:path*" },
+    ]);
+    expect(wildcardEntries).toHaveLength(2);
+    expect(wildcardEntries[0].id).toBe("first-wild");
+    expect(wildcardEntries[1].id).toBe("other");
+    const dupWarns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("duplicate wildcard"),
+    );
+    expect(dupWarns).toHaveLength(1);
+    expect(String(dupWarns[0][0])).toContain("second-wild");
+    expect(String(dupWarns[0][0])).toContain("first-wild");
+  });
+
+  it("attributes /langgraph/foo to SR-wild×langgraph, not the later P1× entry (SU3-A2)", () => {
+    vi.stubEnv("POSTHOG_KEY", "phc_test");
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(new Response("ok")),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const res = run("/langgraph/foo");
+    expect(location(res).pathname).toBe("/langgraph-python/foo");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    expect(body.properties.redirect_id).toBe("SR-wild×langgraph");
   });
 
   it("keeps the first entry and warns once, naming the duplicate keys", () => {
@@ -307,9 +863,398 @@ describe("duplicate exact sources: first match wins (SU2-A3)", () => {
     expect(exactMap.get("/dup")?.id).toBe("first");
     expect(exactMap.get("/dup")?.destination).toBe("/x");
     expect(exactMap.get("/solo")?.id).toBe("only");
-    expect(warn).toHaveBeenCalledOnce();
-    expect(warn.mock.calls[0][0]).toContain("/dup");
-    expect(warn.mock.calls[0][0]).toContain("second");
+    // Message-filtered count (SU6-A6): a bare toHaveBeenCalledOnce()
+    // would absorb any unrelated warn into this count.
+    const dupWarns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("duplicate exact sources"),
+    );
+    expect(dupWarns).toHaveLength(1);
+    expect(String(dupWarns[0][0])).toContain("/dup");
+    expect(String(dupWarns[0][0])).toContain("second");
+  });
+});
+
+describe("buildRedirectLookup rejects malformed entries (SU3-A3)", () => {
+  it("skips+warns wildcard sources with segments AFTER :path*", () => {
+    // "/x/:path*/y" silently truncated to prefix "/x/" — over-matching
+    // every /x/* path instead of only /x/*/y shapes.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { wildcardEntries } = buildRedirectLookup([
+      { id: "trailing", source: "/x/:path*/y", destination: "/z/:path*" },
+      { id: "good", source: "/a/:path*", destination: "/b/:path*" },
+    ]);
+    expect(wildcardEntries).toHaveLength(1);
+    expect(wildcardEntries[0].id).toBe("good");
+    const warns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("/x/:path*/y"),
+    );
+    expect(warns).toHaveLength(1);
+  });
+
+  it("rejects+warns a root wildcard source /:path* (would hijack the entire site)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { wildcardEntries } = buildRedirectLookup([
+      { id: "root-wild", source: "/:path*", destination: "/y/:path*" },
+    ]);
+    expect(wildcardEntries).toHaveLength(0);
+    const warns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("root-wild"),
+    );
+    expect(warns).toHaveLength(1);
+  });
+
+  it("skips+warns destinations that are not root-relative or carry ?/#", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { exactMap, wildcardEntries } = buildRedirectLookup([
+      // Absolute URL: would be mangled into a docs-host path
+      // ("https://<docsHost>https://evil.test/x").
+      { id: "abs", source: "/abs", destination: "https://evil.test/x" },
+      // "?" query: silently wiped by the per-request search overwrite.
+      { id: "query", source: "/query", destination: "/q?x=y" },
+      // "#" fragment: same overwrite/mangling class.
+      { id: "frag", source: "/frag", destination: "/f#sec" },
+      { id: "wild-q", source: "/wq/:path*", destination: "/w/:path*?x=y" },
+      // "//" run (SU6-A4): request-time normalizeRedirectPath WOULD
+      // collapse it (so it can never become a scheme-relative open
+      // redirect — SU-18), but an authored "//" is a presumed typo,
+      // same as in sources — reject it loudly instead of silently
+      // papering over it.
+      { id: "dbl", source: "/dbl", destination: "/a//b" },
+      { id: "wild-dbl", source: "/wd/:path*", destination: "//w/:path*" },
+      { id: "ok", source: "/ok", destination: "/fine" },
+    ]);
+    expect(exactMap.size).toBe(1);
+    expect(exactMap.get("/ok")?.id).toBe("ok");
+    expect(wildcardEntries).toHaveLength(0);
+    const warns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("invalid destination"),
+    );
+    expect(warns).toHaveLength(1);
+    for (const id of ["abs", "query", "frag", "wild-q", "dbl", "wild-dbl"]) {
+      expect(String(warns[0][0])).toContain(id);
+    }
+  });
+
+  it("rejects+warns sources containing '//' — '//:path*' bypasses the root-wildcard guard (SU5-A2)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { exactMap, wildcardEntries } = buildRedirectLookup([
+      // "//:path*" passed every builder check (prefix "//" ends with
+      // "/", :path* terminates the source, prefix !== "/") — but the
+      // matcher derives bareSource = prefix minus one slash = "/", so
+      // the entry matched the HOMEPAGE: the exact hijack the
+      // root-wildcard guard exists to reject.
+      { id: "root-bypass", source: "//:path*", destination: "/y/:path*" },
+      // A leading-"//" exact source is unreachable too — middleware
+      // collapses leading slash runs before any lookup — and previously
+      // sat in the table as a silent dead entry with no warn.
+      { id: "dead-exact", source: "//x", destination: "/x" },
+      { id: "ok", source: "/ok", destination: "/fine" },
+    ]);
+    expect(wildcardEntries).toHaveLength(0);
+    expect(exactMap.size).toBe(1);
+    expect(exactMap.get("/ok")?.id).toBe("ok");
+    const warns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("invalid source"),
+    );
+    expect(warns).toHaveLength(1);
+    expect(String(warns[0][0])).toContain("root-bypass");
+    expect(String(warns[0][0])).toContain("dead-exact");
+  });
+
+  it("skips+warns sources that are not root-relative or carry ?/# (SU4-A2)", () => {
+    // NextRequest pathnames always start with "/" and never carry a
+    // query/fragment — such a source can never match.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { exactMap, wildcardEntries } = buildRedirectLookup([
+      { id: "no-slash", source: "faq", destination: "/faq" },
+      { id: "query", source: "/q?x=y", destination: "/q" },
+      { id: "frag", source: "/f#sec", destination: "/f" },
+      { id: "wild-no-slash", source: "x/:path*", destination: "/y/:path*" },
+      { id: "ok", source: "/ok", destination: "/fine" },
+    ]);
+    expect(exactMap.size).toBe(1);
+    expect(exactMap.get("/ok")?.id).toBe("ok");
+    expect(wildcardEntries).toHaveLength(0);
+    const warns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("invalid source"),
+    );
+    expect(warns).toHaveLength(1);
+    for (const id of ["no-slash", "query", "frag", "wild-no-slash"]) {
+      expect(String(warns[0][0])).toContain(id);
+    }
+  });
+
+  it("skips+warns trailing-slash exact sources — unreachable after stripping (SU4-A2)", () => {
+    // matchPath strips trailing slashes before the exact lookup, so a
+    // "/faq/" key can never be queried.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { exactMap } = buildRedirectLookup([
+      { id: "trail", source: "/faq/", destination: "/faq" },
+      { id: "ok", source: "/ok", destination: "/fine" },
+    ]);
+    expect(exactMap.size).toBe(1);
+    expect(exactMap.get("/ok")?.id).toBe("ok");
+    const warns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("trailing"),
+    );
+    expect(warns).toHaveLength(1);
+    expect(String(warns[0][0])).toContain("trail");
+  });
+
+  it("skips+warns EXACT entries whose destination contains :path* (SU4-A2)", () => {
+    // Exact matches never substitute — the literal token would leak
+    // into the Location header.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { exactMap } = buildRedirectLookup([
+      { id: "leak", source: "/leak", destination: "/x/:path*" },
+      { id: "ok", source: "/ok", destination: "/fine" },
+    ]);
+    expect(exactMap.size).toBe(1);
+    expect(exactMap.get("/ok")?.id).toBe("ok");
+    const warns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("literal token"),
+    );
+    expect(warns).toHaveLength(1);
+    expect(String(warns[0][0])).toContain("leak");
+  });
+
+  it("warns when a wildcard prefix falls under an EARLIER wildcard prefix (SU4-A2)", () => {
+    // First-match-wins scan: the longer, later prefix is unreachable —
+    // zero PostHog traffic, wrongful-decommission class.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { wildcardEntries } = buildRedirectLookup([
+      { id: "broad", source: "/x/:path*", destination: "/a/:path*" },
+      { id: "narrow", source: "/x/sub/:path*", destination: "/b/:path*" },
+      // The inverse order (more specific FIRST) is normal and silent.
+      { id: "specific", source: "/y/sub/:path*", destination: "/c/:path*" },
+      { id: "general", source: "/y/other/:path*", destination: "/d/:path*" },
+    ]);
+    expect(wildcardEntries).toHaveLength(4);
+    const warns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("EARLIER wildcard prefix —"),
+    );
+    expect(warns).toHaveLength(1);
+    expect(String(warns[0][0])).toContain("narrow");
+    expect(String(warns[0][0])).toContain("broad");
+    expect(String(warns[0][0])).not.toContain("specific");
+  });
+
+  it("raises ZERO validation warns on the real table (SU5-A3 health pin)", async () => {
+    // Health pin for the live seoRedirects table: the deliberate twins
+    // (P2× behind SR-root×, P1× behind SR-wild× — same destinations)
+    // are allowlisted as same-destination duplicates and no longer fire
+    // the table-bug warn channel on every cold start (which was
+    // desensitizing the signal). EVERY validation class must therefore
+    // be at zero — ANY warn here means a table regression.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { seoRedirects } = await import("@/lib/seo-redirects");
+    buildRedirectLookup(seoRedirects);
+    const classes = warn.mock.calls
+      .map(([msg]) => String(msg))
+      .filter((msg) => msg.includes("[middleware] seo-redirects"));
+    expect(classes).toEqual([]);
+  });
+
+  it("silently skips same-destination duplicates — the documented twin allowlist (SU5-A3)", () => {
+    // The SR-wild×/P1× and SR-root×/P2× twins are DELIBERATE table
+    // entries with identical destinations: warning on them at every
+    // cold start desensitized the duplicate warn channel. A duplicate
+    // whose destination matches the first claimant is harmless (same
+    // redirect, first id keeps the PostHog attribution) — skip it
+    // silently; only UNEXPECTED (different-destination) duplicates warn.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { exactMap, wildcardEntries } = buildRedirectLookup([
+      { id: "SR-root×x", source: "/x", destination: "/y" },
+      { id: "P2×x", source: "/x", destination: "/y" },
+      { id: "SR-wild×x", source: "/x/:path*", destination: "/y/:path*" },
+      { id: "P1×x", source: "/x/:path*", destination: "/y/:path*" },
+    ]);
+    expect(exactMap.get("/x")?.id).toBe("SR-root×x");
+    expect(wildcardEntries).toHaveLength(1);
+    expect(wildcardEntries[0].id).toBe("SR-wild×x");
+    const dupWarns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("duplicate"),
+    );
+    expect(dupWarns).toHaveLength(0);
+  });
+
+  it("detects the :path* token case-insensitively (SU5-A3)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { exactMap, wildcardEntries } = buildRedirectLookup([
+      // A miscased token fell through indexOf(":path*") and became a
+      // silent dead EXACT entry keyed "/x/:path*".
+      { id: "upper-wild", source: "/x/:PATH*", destination: "/a/:path*" },
+      // A miscased token in an EXACT destination slipped past the
+      // literal-token check and leaked into the Location header.
+      { id: "upper-dest", source: "/leak", destination: "/x/:Path*" },
+    ]);
+    expect(wildcardEntries).toHaveLength(1);
+    expect(wildcardEntries[0].id).toBe("upper-wild");
+    expect(wildcardEntries[0].prefix).toBe("/x/");
+    expect(exactMap.size).toBe(0);
+    const leakWarns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("literal token"),
+    );
+    expect(leakWarns).toHaveLength(1);
+    expect(String(leakWarns[0][0])).toContain("upper-dest");
+  });
+
+  it("rejects+warns WILDCARD destinations whose :path* token is miscased (SU6-A1)", () => {
+    // Substitution (substituteWildcardTemplate) replaces the literal
+    // lowercase ":path*" only — a miscased token in a WILDCARD
+    // destination never substitutes and leaks verbatim into the
+    // Location header: the same leak class the exact-branch
+    // literal-token check rejects (SU5-A3), which only covered EXACT
+    // entries.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { wildcardEntries } = buildRedirectLookup([
+      { id: "upper-dest", source: "/x/:path*", destination: "/a/:PATH*" },
+      // Mixed case leaks too: the lowercase token substitutes but the
+      // miscased one survives.
+      {
+        id: "mixed-dest",
+        source: "/y/:path*",
+        destination: "/a/:path*/b/:Path*",
+      },
+      { id: "ok", source: "/z/:path*", destination: "/b/:path*" },
+    ]);
+    expect(wildcardEntries).toHaveLength(1);
+    expect(wildcardEntries[0].id).toBe("ok");
+    const warns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("miscased"),
+    );
+    expect(warns).toHaveLength(1);
+    expect(String(warns[0][0])).toContain("upper-dest");
+    expect(String(warns[0][0])).toContain("mixed-dest");
+    expect(String(warns[0][0])).not.toContain("(ok)");
+  });
+
+  it("warns (without skipping) when a wildcard destination has NO :path* token (SU6-A2)", () => {
+    // A tokenless wildcard destination silently DROPS the matched
+    // remainder — every subpath collapses onto one page. That is
+    // sometimes deliberate (see the allowlist test below) and sometimes
+    // a forgotten token, so the builder warns but KEEPS the entry: the
+    // collapse is well-defined behavior either way.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { wildcardEntries } = buildRedirectLookup([
+      { id: "typo-collapse", source: "/x/:path*", destination: "/a" },
+      { id: "kept-ok", source: "/y/:path*", destination: "/b/:path*" },
+    ]);
+    expect(wildcardEntries).toHaveLength(2);
+    expect(wildcardEntries.map((wc) => wc.id)).toEqual([
+      "typo-collapse",
+      "kept-ok",
+    ]);
+    const warns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes('no ":path*" token'),
+    );
+    expect(warns).toHaveLength(1);
+    expect(String(warns[0][0])).toContain("typo-collapse");
+    expect(String(warns[0][0])).not.toContain("kept-ok");
+  });
+
+  it("stays silent for the documented deliberate-collapse wildcard entries (SU6-A2)", () => {
+    // P10 (all of /reference/v1/* onto the v2 reference root) and the
+    // S13w×<fw> family (each framework's removed concepts/* section
+    // onto the framework root) collapse ON PURPOSE — warning on them
+    // at every cold start would desensitize the table-bug channel,
+    // exactly like the duplicate twins before the SU5-A3 allowlist.
+    expect(DELIBERATE_COLLAPSE_WILDCARD_IDS.test("P10")).toBe(true);
+    expect(DELIBERATE_COLLAPSE_WILDCARD_IDS.test("S13w×mastra")).toBe(true);
+    // No accidental prefix over-matching: P10× variants are NOT P10.
+    expect(DELIBERATE_COLLAPSE_WILDCARD_IDS.test("P10×other")).toBe(false);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    buildRedirectLookup([
+      {
+        id: "P10",
+        source: "/reference/v1/:path*",
+        destination: "/reference/v2",
+      },
+      {
+        id: "S13w×mastra",
+        source: "/mastra/concepts/:path*",
+        destination: "/mastra",
+      },
+    ]);
+    const warns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes('no ":path*" token'),
+    );
+    expect(warns).toHaveLength(0);
+  });
+
+  it("compares exact-under-wildcard destinations with the ORIGINAL-case remainder (SU5-A3)", () => {
+    // The divergence check sliced the remainder from the LOWERCASED key,
+    // so an exact entry whose destination preserves the source's
+    // original case (exactly what the wildcard produces at request time
+    // — middleware slices the rest from the original-case path) was a
+    // false-positive "DIFFERENT destination" warn, and the diagnostic
+    // printed a wildcardDestination the author never wrote.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    buildRedirectLookup([
+      { id: "wild", source: "/x/:path*", destination: "/a/:path*" },
+      { id: "exact-case", source: "/x/Page", destination: "/a/Page" },
+    ]);
+    const warns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("exact beats"),
+    );
+    expect(warns).toHaveLength(0);
+  });
+
+  it("normalizes twin-allowlist comparisons like request time — a trailing slash is not a divergence (SU6-A3)", () => {
+    // "/y/" and "/y" resolve to the SAME URL at request time
+    // (resolveSeoDestination runs every destination through
+    // normalizeRedirectPath) — the raw-string compare wrongly flagged
+    // such twins as different-destination duplicates, a false-positive
+    // warn on the channel the SU5-A3 allowlist exists to keep quiet.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { exactMap, wildcardEntries } = buildRedirectLookup([
+      { id: "first", source: "/x", destination: "/y" },
+      { id: "second", source: "/x", destination: "/y/" },
+      { id: "w-first", source: "/w/:path*", destination: "/y/:path*" },
+      { id: "w-second", source: "/w/:path*", destination: "/y/:path*/" },
+    ]);
+    expect(exactMap.get("/x")?.id).toBe("first");
+    expect(wildcardEntries).toHaveLength(1);
+    expect(wildcardEntries[0].id).toBe("w-first");
+    const dupWarns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("duplicate"),
+    );
+    expect(dupWarns).toHaveLength(0);
+  });
+
+  it("warns when an exact source under an earlier wildcard has a DIFFERENT destination (SU4-A2)", () => {
+    // Exact beats wildcard regardless of table order — a top-to-bottom
+    // reading of the table says otherwise, so flag the divergence.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    buildRedirectLookup([
+      { id: "wild", source: "/x/:path*", destination: "/a/:path*" },
+      { id: "diverges", source: "/x/page", destination: "/elsewhere" },
+      // Same destination (modulo the trailing slash a zero-segment
+      // substitution leaves) is harmless — stays silent.
+      { id: "agrees", source: "/x/other", destination: "/a/other" },
+    ]);
+    const warns = warn.mock.calls.filter(([msg]) =>
+      String(msg).includes("exact beats"),
+    );
+    expect(warns).toHaveLength(1);
+    expect(String(warns[0][0])).toContain("diverges");
+    expect(String(warns[0][0])).toContain("wild");
+    expect(String(warns[0][0])).not.toContain("agrees");
+  });
+
+  it("substitutes EVERY :path* token in a destination template", () => {
+    // Single .replace() left the 2nd+ tokens as literal ":path*" in the
+    // Location header. Function replacer keeps user-controlled rest
+    // ($&, $', $`) literal — and replaceAll never rescans inserted text,
+    // so a rest of ":path*" cannot loop or double-substitute.
+    expect(substituteWildcardTemplate("/a/:path*/b/:path*", "z")).toBe(
+      "/a/z/b/z",
+    );
+    expect(substituteWildcardTemplate("/a/:path*", "$&x")).toBe("/a/$&x");
+    expect(substituteWildcardTemplate("/a/:path*", ":path*")).toBe(
+      "/a/:path*",
+    );
+    expect(substituteWildcardTemplate("/fixed", "anything")).toBe("/fixed");
   });
 });
 
@@ -325,9 +1270,14 @@ describe("wildcard substitution is replacement-pattern safe (SU2-A1)", () => {
   });
 
   it("keeps literal $$ and $` sequences intact", () => {
+    // $$ is the live sub-case: it reaches the replacer verbatim and the
+    // string form of .replace() would collapse it to a single "$".
     expect(location(run("/coagents/$$bar")).pathname).toBe(
       "/langgraph-python/$$bar",
     );
+    // The backtick is percent-encoded by URL parsing BEFORE the
+    // replacer ever sees it ("$%60baz"), so this sub-case can't
+    // exercise $`-expansion — it pins the encoding passthrough instead.
     expect(location(run("/coagents/$`baz")).pathname).toBe(
       "/langgraph-python/$%60baz",
     );
@@ -361,6 +1311,28 @@ describe("PostHog capture failures are observable (SU2-A2)", () => {
   // traffic — silently-broken capture (swallowed rejections, unchecked
   // 4xx/5xx) causes wrongful deletions. Each failure class must warn
   // once (not per request).
+  //
+  // The warn-once latch (captureFailureWarnings) is module-level: on
+  // the statically-imported instance these tests only pass while no
+  // earlier test — or a retry of THIS test — has tripped the same
+  // failure class. Fresh-import per test (the SU-14 pattern) so each
+  // test owns the latch and stays retry/order-safe.
+  let freshMiddleware: typeof middleware;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ middleware: freshMiddleware } = await import("./middleware"));
+    // Clear the module-load warns the fresh import re-emitted so the
+    // class-filtered counts below start from zero.
+    vi.mocked(console.warn).mockClear();
+  });
+
+  function runFresh(pathAndQuery: string, event: NextFetchEvent) {
+    return freshMiddleware(
+      new NextRequest(`${SHELL_ORIGIN}${pathAndQuery}`),
+      event,
+    );
+  }
 
   async function flushCapture(event: NextFetchEvent): Promise<void> {
     const waitUntil = event.waitUntil as ReturnType<typeof vi.fn>;
@@ -375,8 +1347,8 @@ describe("PostHog capture failures are observable (SU2-A2)", () => {
       vi.fn(() => Promise.resolve(new Response("err", { status: 500 }))),
     );
     const event = makeEvent();
-    run("/faq", event);
-    run("/quickstart", event);
+    runFresh("/faq", event);
+    runFresh("/quickstart", event);
     await flushCapture(event);
     const captureWarns = warn.mock.calls.filter(([msg]) =>
       String(msg).includes("http:500"),
@@ -392,8 +1364,8 @@ describe("PostHog capture failures are observable (SU2-A2)", () => {
       vi.fn(() => Promise.reject(new TypeError("fetch failed"))),
     );
     const event = makeEvent();
-    run("/faq", event);
-    run("/quickstart", event);
+    runFresh("/faq", event);
+    runFresh("/quickstart", event);
     await flushCapture(event);
     const captureWarns = warn.mock.calls.filter(([msg]) =>
       String(msg).includes("net:TypeError"),
@@ -402,7 +1374,29 @@ describe("PostHog capture failures are observable (SU2-A2)", () => {
   });
 });
 
-describe("scheme-less POSTHOG_HOST is normalized at the use site (SU2-A6)", () => {
+describe("normalizePosthogHost — use-site guard (SU2-A6/SU4-A7)", () => {
+  // The scheme-less branch is UNREACHABLE through middleware():
+  // runtime-config's ensureScheme normalizes POSTHOG_HOST before the
+  // value is threaded in, so only direct unit tests can exercise the
+  // guard itself (the describe below pins the through-middleware
+  // behavior).
+  it("prepends https:// to a raw scheme-less host", () => {
+    expect(normalizePosthogHost("eu.posthog.example.test")).toBe(
+      "https://eu.posthog.example.test",
+    );
+  });
+
+  it("leaves an explicit scheme untouched", () => {
+    expect(normalizePosthogHost("http://localhost:8000")).toBe(
+      "http://localhost:8000",
+    );
+    expect(normalizePosthogHost("https://eu.posthog.com")).toBe(
+      "https://eu.posthog.com",
+    );
+  });
+});
+
+describe("scheme-less POSTHOG_HOST yields an absolute capture URL — normalized upstream in runtime-config (SU2-A6)", () => {
   it("prepends https:// so the capture fetch URL is absolute", () => {
     vi.stubEnv("POSTHOG_KEY", "phc_test");
     vi.stubEnv("POSTHOG_HOST", "eu.posthog.example.test");

--- a/showcase/shell/src/middleware.ts
+++ b/showcase/shell/src/middleware.ts
@@ -2,8 +2,13 @@ import { NextResponse } from "next/server";
 import type { NextFetchEvent, NextRequest } from "next/server";
 import { seoRedirects } from "@/lib/seo-redirects";
 import type { RedirectEntry } from "@/lib/seo-redirects";
-import { getRuntimeConfigForMiddleware } from "@/lib/runtime-config";
 import {
+  DOCS_REDIRECTS_DISABLED_HOST,
+  getRuntimeConfigForMiddleware,
+} from "@/lib/runtime-config";
+import { SCHEME_RE } from "@/lib/backend-url";
+import {
+  normalizeRedirectPath,
   resolveDocsHostRedirect,
   resolveSeoDestination,
 } from "@/lib/docs-redirects";
@@ -14,12 +19,37 @@ import registry from "@/data/registry.json";
 // ---------------------------------------------------------------------------
 
 /**
+ * Known deliberate-collapse wildcard entries (SU6-A2, exported for
+ * tests): their destinations carry NO ":path*" token ON PURPOSE — every
+ * matched subpath collapses onto a single page (P10: all of
+ * /reference/v1/* onto the v2 reference root; S13w×<fw>: each
+ * framework's removed concepts/* section onto the framework root). The
+ * tokenless-destination warn in buildRedirectLookup would otherwise
+ * fire for them on every cold start, desensitizing the table-bug
+ * channel exactly like the duplicate twins did before the SU5-A3
+ * same-destination allowlist.
+ */
+export const DELIBERATE_COLLAPSE_WILDCARD_IDS = /^(?:P10$|S13w×)/;
+
+/**
  * Build the exact-match map and wildcard list from the redirect table
  * (exported for tests). The table is documented as "first match wins" —
  * a plain Map.set loop silently inverted that to LAST-write-wins for
  * the duplicate exact sources (e.g. P2×unselected overrode
  * SR-root×unselected), skewing PostHog redirect_id attribution. Skip
- * later duplicates and warn once at module load, naming them.
+ * later duplicates and warn once at module load, naming them — EXCEPT
+ * same-destination duplicates (SU5-A3): the table's deliberate
+ * SR-root×/P2× and SR-wild×/P1× twins redirect to the same place, so
+ * they skip silently and only unexpected duplicates warn.
+ *
+ * PRECEDENCE (deliberate, SU4-A2): an EXACT source always beats a
+ * WILDCARD source, regardless of table order — middleware tries the
+ * exact map before the wildcard scan. "First match wins" therefore only
+ * holds WITHIN each kind (among exacts for duplicate keys; among
+ * wildcards for the linear scan). An exact source that falls under an
+ * earlier wildcard prefix with a DIFFERENT destination contradicts a
+ * naive top-to-bottom reading of the table, so it gets a module-load
+ * warn below.
  */
 export function buildRedirectLookup(entries: readonly RedirectEntry[]): {
   /** Exact-match map: source path -> { id, destination } */
@@ -33,33 +63,279 @@ export function buildRedirectLookup(entries: readonly RedirectEntry[]): {
     id: string;
     destinationTemplate: string;
   }[] = [];
+  // First-claimed wildcard prefix -> claiming entry (id + destination
+  // template). Matching is by prefix, so two entries with the same
+  // prefix shadow exactly like duplicate exact sources do (the linear
+  // scan would never reach the second) — dedup with the same
+  // first-match-wins + module-load warn, or the shadowed ids show zero
+  // PostHog traffic and the decommission report proposes deleting a
+  // live redirect. The destination template is kept for the
+  // same-destination twin allowlist (SU5-A3) below.
+  const wildcardPrefixOwners = new Map<
+    string,
+    { id: string; destinationTemplate: string }
+  >();
   const duplicateSources: string[] = [];
+  const duplicateWildcardSources: string[] = [];
   const malformedWildcards: string[] = [];
+  const invalidSources: string[] = [];
+  const invalidDestinations: string[] = [];
+  const unreachableTrailingSlashSources: string[] = [];
+  const exactDestinationsWithToken: string[] = [];
+  const wildcardDestinationsWithMiscasedToken: string[] = [];
+  const tokenlessWildcardDestinations: string[] = [];
+  const shadowedWildcardPrefixes: string[] = [];
+  const exactsUnderEarlierWildcard: string[] = [];
+
+  // Destination comparisons (the same-destination twin allowlists and
+  // the exact-under-wildcard divergence check below) run BOTH sides
+  // through normalizeRedirectPath (docs-redirects): interior slash-run
+  // collapse + trailing-slash strip, root "/" survives. That is EXACTLY
+  // what resolveSeoDestination applies to each destination at request
+  // time (SU5-A7: the normalization lives in normalizeRedirectPath;
+  // resolveSeoDestination merely calls it) — a previous local copy
+  // stripped trailing slashes only (half of the request-time
+  // normalization), so two entries that resolve identically could
+  // still be flagged as a different-destination duplicate or
+  // divergence: a false-positive warn (SU6-A3).
 
   for (const entry of entries) {
-    const wildcardIdx = entry.source.indexOf(":path*");
+    // Sources must be root-relative paths with no query/fragment
+    // (SU4-A2): NextRequest pathnames always start with "/" and never
+    // carry "?"/"#", so a source violating that can never match —
+    // worse, a non-"/" wildcard source would produce a prefix the
+    // matcher could partially collide with. Warn and skip.
+    //
+    // "//" anywhere in the source is rejected too (SU5-A2): middleware
+    // collapses LEADING slash runs before any lookup, so a leading-"//"
+    // source is an unreachable dead entry — and the wildcard source
+    // "//:path*" sailed past every later check (prefix "//" ends with
+    // "/", :path* terminates it, prefix !== "/") only for the matcher's
+    // bareSource (prefix minus one slash) to come out as "/", matching
+    // the HOMEPAGE: the exact hijack the root-wildcard guard rejects.
+    // An INTERIOR "//" (e.g. "/a//b") is technically matchable (only
+    // LEADING runs are collapsed; matchPath keeps interior runs) but no
+    // live URL is authored that way — it is a presumed typo, rejected
+    // under the same check (SU6-A4).
+    if (
+      !entry.source.startsWith("/") ||
+      entry.source.includes("//") ||
+      entry.source.includes("?") ||
+      entry.source.includes("#")
+    ) {
+      invalidSources.push(`${entry.source} (${entry.id})`);
+      continue;
+    }
+    // Destinations must be root-relative paths with no query/fragment:
+    // an absolute URL gets appended after the docs-host origin and
+    // mangled into a path ("https://<docsHost>https://..."); a "?"/"#"
+    // suffix is silently wiped by the per-request
+    // `dest.search = request.nextUrl.search` overwrite. Either way the
+    // entry cannot do what its author intended — warn and skip.
+    //
+    // "//" in a destination is a presumed typo, same as in sources
+    // above (SU6-A4): request-time normalizeRedirectPath WOULD collapse
+    // the run — so it can never become a scheme-relative open redirect
+    // (SU-18) — but the author plainly didn't mean to write it; reject
+    // loudly instead of silently papering over it.
+    if (
+      !entry.destination.startsWith("/") ||
+      entry.destination.includes("//") ||
+      entry.destination.includes("?") ||
+      entry.destination.includes("#")
+    ) {
+      invalidDestinations.push(
+        `${entry.source} -> ${entry.destination} (${entry.id})`,
+      );
+      continue;
+    }
+    // Token detection is case-insensitive (SU5-A3): a typo like
+    // ":PATH*" otherwise slips past indexOf and the source becomes a
+    // silent dead EXACT entry (its key can never be a request path).
+    // toLowerCase is length-preserving on these ASCII sources, so the
+    // index is valid against the original-case string.
+    const wildcardIdx = entry.source.toLowerCase().indexOf(":path*");
     if (wildcardIdx === -1) {
-      const existing = exactMap.get(entry.source);
-      if (existing) {
-        duplicateSources.push(
-          `${entry.source} (${entry.id} shadowed by ${existing.id})`,
+      // Keys are lowercased: matching is case-insensitive (parity with
+      // the next.config rules' path-to-regexp sensitive:false — see
+      // matchPath in middleware()). Also makes a source typo like MG3's
+      // "/migration-guides/1.10.X" match the lowercase live URL.
+      const key = entry.source.toLowerCase();
+      // A trailing-slash exact source is UNREACHABLE (SU4-A2):
+      // middleware strips trailing slashes from matchPath before the
+      // lookup, so a key ending in "/" (other than root) can never be
+      // queried. Warn and skip — the author meant the slashless form.
+      if (key.length > 1 && key.endsWith("/")) {
+        unreachableTrailingSlashSources.push(`${entry.source} (${entry.id})`);
+        continue;
+      }
+      // An exact entry never substitutes — a ":path*" in its destination
+      // would leak the literal token into the Location header (SU4-A2).
+      // Case-insensitive (SU5-A3): a miscased ":PATH*" leaks just the
+      // same.
+      if (entry.destination.toLowerCase().includes(":path*")) {
+        exactDestinationsWithToken.push(
+          `${entry.source} -> ${entry.destination} (${entry.id})`,
         );
         continue;
       }
-      exactMap.set(entry.source, {
+      const existing = exactMap.get(key);
+      if (existing) {
+        // Same-destination twin allowlist (SU5-A3): the table carries
+        // DELIBERATE duplicate pairs (the six SR-root×/P2× exacts and
+        // six SR-wild×/P1× wildcards) whose destinations are identical
+        // — warning on them at every cold start desensitized the
+        // table-bug channel. A duplicate that redirects to the SAME
+        // place is harmless (first id keeps the PostHog attribution):
+        // skip silently; only UNEXPECTED (different-destination)
+        // duplicates warn. "Same destination" means same AFTER the
+        // request-time normalization — see the comparator note above
+        // the loop (SU6-A3).
+        if (
+          normalizeRedirectPath(existing.destination) !==
+          normalizeRedirectPath(entry.destination)
+        ) {
+          duplicateSources.push(
+            `${entry.source} (${entry.id} shadowed by ${existing.id})`,
+          );
+        }
+        continue;
+      }
+      // Exact-beats-wildcard precedence check (SU4-A2, see docstring):
+      // when this exact source falls under a wildcard prefix that
+      // appears EARLIER in the table, a top-to-bottom reading says the
+      // wildcard wins — but the exact map is consulted first, so this
+      // entry does. Only warn when the two would produce DIFFERENT
+      // destinations (same-destination overlap is harmless, e.g. each
+      // S13e×<fw> exact under its own S13w×<fw> wildcard).
+      const coveringWildcard = wildcardEntries.find(
+        (wc) => key.startsWith(wc.prefix) || key === wc.prefix.slice(0, -1),
+      );
+      if (coveringWildcard) {
+        // Slice the remainder from the ORIGINAL-case source (SU5-A3),
+        // not the lowercased key — that is what middleware does at
+        // request time (the rest forwards verbatim from strippedPath),
+        // so an exact destination that preserves the source's case is
+        // NOT a divergence, and the diagnostic prints a
+        // wildcardDestination the author actually recognizes. Offsets
+        // align because toLowerCase is length-preserving here.
+        const rest =
+          key === coveringWildcard.prefix.slice(0, -1)
+            ? ""
+            : entry.source.slice(coveringWildcard.prefix.length);
+        const wildcardDestination = substituteWildcardTemplate(
+          coveringWildcard.destinationTemplate,
+          rest,
+        );
+        if (
+          normalizeRedirectPath(wildcardDestination) !==
+          normalizeRedirectPath(entry.destination)
+        ) {
+          exactsUnderEarlierWildcard.push(
+            `${entry.source} (${entry.id} wins over earlier wildcard ` +
+              `${coveringWildcard.id}: ${entry.destination} vs ` +
+              `${wildcardDestination})`,
+          );
+        }
+      }
+      exactMap.set(key, {
         id: entry.id,
         destination: entry.destination,
       });
     } else {
-      const prefix = entry.source.slice(0, wildcardIdx);
+      // Lowercased for case-insensitive prefix matching — see above.
+      const prefix = entry.source.slice(0, wildcardIdx).toLowerCase();
       // A wildcard prefix MUST end with "/" — the matcher's
       // `startsWith(prefix)` would otherwise match prefix LOOKALIKES
-      // (e.g. a source "/x:path*" matching "/xylophone"). Treat a
-      // violation as a table bug: warn loudly and skip the entry.
-      if (!prefix.endsWith("/")) {
+      // (e.g. a source "/x:path*" matching "/xylophone"). And :path*
+      // must TERMINATE the source: the lookup keeps only the prefix, so
+      // segments after the token (e.g. "/x/:path*/y") would silently
+      // over-match every /x/* path. Treat both as table bugs: warn
+      // loudly and skip the entry.
+      if (
+        !prefix.endsWith("/") ||
+        wildcardIdx + ":path*".length !== entry.source.length
+      ) {
         malformedWildcards.push(`${entry.source} (${entry.id})`);
         continue;
       }
+      // A root wildcard ("/:path*", prefix "/") would match EVERY path
+      // on the site — that is never a legitimate SEO entry; reject it
+      // before it can hijack all traffic.
+      if (prefix === "/") {
+        malformedWildcards.push(
+          `${entry.source} (${entry.id}: root wildcard would match every path)`,
+        );
+        continue;
+      }
+      // Substitution is CASE-SENSITIVE — substituteWildcardTemplate
+      // replaces the literal lowercase ":path*" only — so a miscased
+      // token in a WILDCARD destination (":PATH*") never substitutes
+      // and leaks verbatim into the Location header: the same leak
+      // class the exact-branch literal-token check above rejects.
+      // Mirror its case-insensitive detection here (SU6-A1) by
+      // comparing the case-insensitive occurrence count against the
+      // literal count — any mismatch means at least one token survives
+      // substitution (a mixed-case template leaks its miscased token
+      // even though the lowercase one substitutes).
+      const tokenCount = entry.destination.match(/:path\*/gi)?.length ?? 0;
+      const literalTokenCount =
+        entry.destination.match(/:path\*/g)?.length ?? 0;
+      if (tokenCount !== literalTokenCount) {
+        wildcardDestinationsWithMiscasedToken.push(
+          `${entry.source} -> ${entry.destination} (${entry.id})`,
+        );
+        continue;
+      }
+      // A wildcard destination with NO token drops the matched
+      // remainder entirely — every subpath collapses onto one page.
+      // That is sometimes DELIBERATE (the allowlisted entries above
+      // buildRedirectLookup) and sometimes a forgotten token, so warn
+      // WITHOUT skipping: the collapse is well-defined behavior either
+      // way (SU6-A2).
+      if (
+        tokenCount === 0 &&
+        !DELIBERATE_COLLAPSE_WILDCARD_IDS.test(entry.id)
+      ) {
+        tokenlessWildcardDestinations.push(
+          `${entry.source} -> ${entry.destination} (${entry.id})`,
+        );
+      }
+      const owner = wildcardPrefixOwners.get(prefix);
+      if (owner) {
+        // Same-destination twin allowlist — see the exact-map branch
+        // above (SU5-A3); same request-time-normalized comparison
+        // (SU6-A3).
+        if (
+          normalizeRedirectPath(owner.destinationTemplate) !==
+          normalizeRedirectPath(entry.destination)
+        ) {
+          duplicateWildcardSources.push(
+            `${entry.source} (${entry.id} shadowed by ${owner.id})`,
+          );
+        }
+        continue;
+      }
+      // Overlapping wildcard prefixes (SU4-A2): the scan is first-match-
+      // wins, so when an EARLIER wildcard's prefix is a prefix of this
+      // one, every path this entry could match is already claimed — the
+      // entry is unreachable, shows zero PostHog traffic, and the
+      // decommission report would wrongly propose deleting it. (The
+      // inverse — an earlier LONGER prefix — is the normal
+      // most-specific-first ordering and is fine.)
+      const shadowingEntry = wildcardEntries.find((wc) =>
+        prefix.startsWith(wc.prefix),
+      );
+      if (shadowingEntry) {
+        shadowedWildcardPrefixes.push(
+          `${entry.source} (${entry.id} unreachable behind ` +
+            `${shadowingEntry.id})`,
+        );
+      }
+      wildcardPrefixOwners.set(prefix, {
+        id: entry.id,
+        destinationTemplate: entry.destination,
+      });
       wildcardEntries.push({
         prefix,
         id: entry.id,
@@ -69,20 +345,124 @@ export function buildRedirectLookup(entries: readonly RedirectEntry[]): {
   }
 
   if (duplicateSources.length > 0) {
+    // eslint-disable-next-line no-console
     console.warn(
       "[middleware] seo-redirects has duplicate exact sources — first " +
         `match wins, later entries are ignored: ${duplicateSources.join(", ")}`,
     );
   }
-  if (malformedWildcards.length > 0) {
+  if (duplicateWildcardSources.length > 0) {
+    // eslint-disable-next-line no-console
     console.warn(
-      "[middleware] seo-redirects has wildcard sources whose prefix does " +
-        'not end with "/" — they would match prefix lookalikes and are ' +
-        `ignored: ${malformedWildcards.join(", ")}`,
+      "[middleware] seo-redirects has duplicate wildcard prefixes — first " +
+        "match wins, later entries are ignored: " +
+        duplicateWildcardSources.join(", "),
+    );
+  }
+  if (malformedWildcards.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[middleware] seo-redirects has malformed wildcard sources — the " +
+        'prefix must end on a "/" boundary (no prefix lookalikes), :path* ' +
+        "must be the final token, and a bare /:path* is never legal; " +
+        `they are ignored: ${malformedWildcards.join(", ")}`,
+    );
+  }
+  if (invalidDestinations.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[middleware] seo-redirects has entries with an invalid destination " +
+        '(must be a root-relative path starting with "/", with no "//", ' +
+        `"?" or "#") — they are ignored: ${invalidDestinations.join(", ")}`,
+    );
+  }
+  if (invalidSources.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[middleware] seo-redirects has entries with an invalid source " +
+        '(must be a root-relative path starting with "/", with no "//", ' +
+        `"?" or "#") — they are ignored: ${invalidSources.join(", ")}`,
+    );
+  }
+  if (unreachableTrailingSlashSources.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[middleware] seo-redirects has exact sources with a trailing " +
+        "slash — matching strips trailing slashes before the lookup, so " +
+        "they can never match; they are ignored: " +
+        unreachableTrailingSlashSources.join(", "),
+    );
+  }
+  if (exactDestinationsWithToken.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[middleware] seo-redirects has EXACT sources whose destination " +
+        'contains ":path*" — exact matches never substitute, so the ' +
+        "literal token would leak into the Location header; they are " +
+        `ignored: ${exactDestinationsWithToken.join(", ")}`,
+    );
+  }
+  if (wildcardDestinationsWithMiscasedToken.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[middleware] seo-redirects has WILDCARD sources whose destination " +
+        'contains a miscased ":path*" token — substitution replaces the ' +
+        "literal lowercase token only, so the miscased token would leak " +
+        "into the Location header; they are ignored: " +
+        wildcardDestinationsWithMiscasedToken.join(", "),
+    );
+  }
+  if (tokenlessWildcardDestinations.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[middleware] seo-redirects has WILDCARD sources whose destination " +
+        'has no ":path*" token — the matched remainder is silently ' +
+        "dropped (every subpath collapses onto the same destination). " +
+        "If deliberate, add the id to DELIBERATE_COLLAPSE_WILDCARD_IDS; " +
+        `otherwise add the token: ${tokenlessWildcardDestinations.join(", ")}`,
+    );
+  }
+  if (shadowedWildcardPrefixes.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[middleware] seo-redirects has wildcard sources whose prefix " +
+        "falls under an EARLIER wildcard prefix — the scan is first-" +
+        "match-wins, so they are unreachable (zero PostHog traffic; the " +
+        "decommission report would wrongly propose deleting them): " +
+        shadowedWildcardPrefixes.join(", "),
+    );
+  }
+  if (exactsUnderEarlierWildcard.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[middleware] seo-redirects has exact sources under an EARLIER " +
+        "wildcard prefix with a DIFFERENT destination — exact beats " +
+        "wildcard regardless of table order (see buildRedirectLookup), " +
+        "contradicting a top-to-bottom reading: " +
+        exactsUnderEarlierWildcard.join(", "),
     );
   }
 
   return { exactMap, wildcardEntries };
+}
+
+/**
+ * Substitute the matched path remainder into a destination template
+ * (exported for tests). replaceAll, not a single replace — a template
+ * with multiple :path* tokens would otherwise leak the literal token
+ * into the Location header. Function replacer because `rest` is
+ * user-controlled and the string form of String.prototype.replace
+ * expands `$&`, "$`", `$'`, `$$` in the replacement (e.g.
+ * /coagents/$&foo would re-insert the matched ":path*" token).
+ * replaceAll never rescans inserted text, so a rest of ":path*" cannot
+ * loop or double-substitute.
+ */
+export function substituteWildcardTemplate(
+  template: string,
+  rest: string,
+): string {
+  if (!template.includes(":path*")) return template;
+  return template.replaceAll(":path*", () => rest);
 }
 
 const { exactMap, wildcardEntries } = buildRedirectLookup(seoRedirects);
@@ -91,10 +471,48 @@ const { exactMap, wildcardEntries } = buildRedirectLookup(seoRedirects);
 // PostHog tracking via fetch (Edge Runtime compatible — no posthog-node SDK)
 // ---------------------------------------------------------------------------
 
+// Warn-once latch. NOTE: all the once-guards in this module
+// (posthogKeyWarned, captureFailureWarnings, the module-load table
+// warns above) are per-ISOLATE, not per-process — the Edge runtime can
+// run several isolates side by side and recycles them, so "once" means
+// once per isolate cold start. Expect occasional repeats in production
+// logs; that's the mechanism, not a bug.
 let posthogKeyWarned = false;
 
+/**
+ * Once-guarded missing-POSTHOG_KEY signal, fired at config-resolution
+ * time on EVERY middleware invocation — NOT lazily inside trackRedirect
+ * (SU6-A5): the lazy check only ran when a redirect MATCHED, so a prod
+ * deploy whose traffic never hit a redirect source got ZERO signal that
+ * every seo_redirect would go uncaptured.
+ *
+ * Mirrors warnIfNoFrameworkSlugs's NODE_ENV branching (SU4-A5): a
+ * missing key is legitimate on dev/preview deploys (warn), but in
+ * production it is a wiring bug — every redirect goes uncaptured and
+ * the decommission report silently under-counts live traffic, the
+ * wrongful-deletion class.
+ */
+function warnIfPosthogKeyMissing(posthogKey: string | undefined): void {
+  if (posthogKey || posthogKeyWarned) return;
+  posthogKeyWarned = true;
+  const message =
+    "[middleware] POSTHOG_KEY is not set — redirect tracking disabled";
+  if (process.env.NODE_ENV === "production") {
+    // eslint-disable-next-line no-console
+    console.error(
+      `${message}. In production this is a wiring bug: seo_redirect ` +
+        "events are not recorded, so the redirect decommission report " +
+        "under-counts this deploy's traffic.",
+    );
+  } else {
+    // eslint-disable-next-line no-console
+    console.warn(message);
+  }
+}
+
 // One loud log per distinct capture-failure class (`http:<status>` /
-// `net:<error name>`), not per request — mirrors the patternWarnings
+// `net:<error name>`), not per request (and per isolate — see the note
+// on posthogKeyWarned above) — mirrors the patternWarnings
 // pattern in lib/backend-url.ts. Observability here is load-bearing:
 // the redirect-decommission report deletes redirects that show ZERO
 // PostHog traffic, so silently-broken capture (a swallowed rejection or
@@ -104,6 +522,7 @@ const captureFailureWarnings = new Set<string>();
 function warnCaptureFailureOnce(failureClass: string, detail: string): void {
   if (captureFailureWarnings.has(failureClass)) return;
   captureFailureWarnings.add(failureClass);
+  // eslint-disable-next-line no-console
   console.warn(
     `[middleware] PostHog redirect capture failing (${failureClass}): ` +
       `${detail} — seo_redirect events are not being recorded, so the ` +
@@ -112,16 +531,18 @@ function warnCaptureFailureOnce(failureClass: string, detail: string): void {
 }
 
 /**
- * Defensive use-site normalization: POSTHOG_HOST can be set scheme-less
- * (the sibling SHOWCASE_BACKEND_HOST_PATTERN var is documented as
- * host-only, an easy format to carry over), and a scheme-less host makes
- * the capture `fetch()` reject a relative URL on EVERY redirect. Proper
- * normalization belongs in runtime-config (readDocsHost already does
- * this for DOCS_HOST) — that is a sibling fix; this guard keeps the
- * middleware safe regardless.
+ * Defense-in-depth use-site normalization (exported for tests —
+ * SU4-A7): runtime-config already ensures a scheme on POSTHOG_HOST
+ * (getRuntimeConfig → ensureScheme, same hardening as readDocsHost), so
+ * by the time middleware() threads the value here it is normally
+ * absolute — the scheme-less branch is UNREACHABLE through middleware()
+ * and only unit tests can exercise it. The guard keeps the capture
+ * fetch safe if a future caller ever hands trackRedirect a raw env
+ * value — a scheme-less host would make `fetch()` reject a relative
+ * URL on EVERY redirect, silently zeroing the decommission report.
  */
-function normalizePosthogHost(host: string): string {
-  return /^[a-z][a-z0-9+.-]*:\/\//i.test(host) ? host : `https://${host}`;
+export function normalizePosthogHost(host: string): string {
+  return SCHEME_RE.test(host) ? host : `https://${host}`;
 }
 
 function trackRedirect(
@@ -136,15 +557,10 @@ function trackRedirect(
   fromPath: string,
   dest: URL,
 ): void {
-  if (!posthogKey) {
-    if (!posthogKeyWarned) {
-      console.warn(
-        "[middleware] POSTHOG_KEY is not set — redirect tracking disabled",
-      );
-      posthogKeyWarned = true;
-    }
-    return;
-  }
+  // The missing-key signal fires at config-resolution time in
+  // middleware() (warnIfPosthogKeyMissing, SU6-A5) — here we only skip
+  // the capture.
+  if (!posthogKey) return;
 
   const captureUrl = `${normalizePosthogHost(posthogHost)}/capture/`;
 
@@ -202,11 +618,47 @@ function trackRedirect(
 // redirects (e.g. S1×mastra: `/mastra/agentic-chat-ui` →
 // `/mastra/prebuilt-components`) can never hijack it even when legacy
 // framework keys overlap with registry slugs.
-export const REGISTRY_FRAMEWORK_SLUGS: Set<string> = new Set(
-  (registry as { integrations?: { slug: string }[] }).integrations?.map(
-    (i) => i.slug,
-  ) ?? [],
-);
+// Lowercased at construction (SU4-A4): docs-redirects matches the
+// LOWERCASED first path segment against this set (case-insensitive
+// parity, SU3-A4). Registry slugs are canonical lowercase today, but a
+// future mixed-case slug would otherwise silently never match — its
+// docs-host redirect would just be disabled with no signal.
+// Defensive extraction (SU5-A1, exported for tests): the previous
+// construction reached through a bare `as` cast straight to
+// `i.slug.toLowerCase()` — a malformed registry (null, a non-array
+// `integrations`, entries missing `slug` or carrying a non-string slug)
+// would TypeError at MODULE LOAD: the exact 500-every-request failure
+// warnIfNoFrameworkSlugs exists to prevent. Extract structurally
+// instead, counting dropped entries so the module-load guard below can
+// warn alongside warnIfNoFrameworkSlugs.
+export function extractFrameworkSlugs(registryData: unknown): {
+  slugs: Set<string>;
+  dropped: number;
+} {
+  const integrations = (
+    registryData as { integrations?: unknown } | null | undefined
+  )?.integrations;
+  if (!Array.isArray(integrations)) {
+    // Zero slugs — warnIfNoFrameworkSlugs screams about this shape.
+    return { slugs: new Set(), dropped: 0 };
+  }
+  const slugs = new Set<string>();
+  let dropped = 0;
+  for (const entry of integrations) {
+    const slug = (entry as { slug?: unknown } | null | undefined)?.slug;
+    if (typeof slug === "string") {
+      slugs.add(slug.toLowerCase());
+    } else {
+      dropped += 1;
+    }
+  }
+  return { slugs, dropped };
+}
+
+const { slugs: registrySlugs, dropped: droppedRegistryEntries } =
+  extractFrameworkSlugs(registry);
+
+export const REGISTRY_FRAMEWORK_SLUGS: Set<string> = registrySlugs;
 
 /**
  * Loud guard (exported for tests): the old next.config build THREW when
@@ -223,13 +675,35 @@ export function warnIfNoFrameworkSlugs(slugs: ReadonlySet<string>): void {
     "missing or corrupt; run generate-registry.ts before building (the " +
     "old next.config build failed loudly here).";
   if (process.env.NODE_ENV === "production") {
+    // eslint-disable-next-line no-console
     console.error(message);
   } else {
+    // eslint-disable-next-line no-console
     console.warn(message);
   }
 }
 
 warnIfNoFrameworkSlugs(REGISTRY_FRAMEWORK_SLUGS);
+if (droppedRegistryEntries > 0) {
+  // Companion to warnIfNoFrameworkSlugs (SU5-A1): a PARTIALLY corrupt
+  // registry yields a non-empty set that sails past the zero-slug guard
+  // while the malformed integrations silently lose their docs-host
+  // redirects — same failure class, so it gets the same loud signal.
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[middleware] registry.json has ${droppedRegistryEntries} integration ` +
+      "entry(ies) with a missing or non-string slug — they were dropped " +
+      "from the framework-slug set, so their /<framework-slug> docs-host " +
+      "redirects are DISABLED. The registry is corrupt; run " +
+      "generate-registry.ts before building.",
+  );
+}
+
+// Warn-once latch for the docs-redirects-disabled sentinel (per-isolate,
+// like posthogKeyWarned — see the note above it). runtime-config already
+// console.errors the FATAL-CONFIG diagnosis once; this is the
+// middleware-side breadcrumb that the redirect steps are being skipped.
+let docsRedirectsDisabledWarned = false;
 
 export function middleware(request: NextRequest, event: NextFetchEvent) {
   const { pathname } = request.nextUrl;
@@ -237,18 +711,106 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
   // time, no `next/cache` import) ONCE per request and thread the
   // values through — see getRuntimeConfigForMiddleware in
   // src/lib/runtime-config.ts.
-  const { docsHost, posthogHost } = getRuntimeConfigForMiddleware();
-  const posthogKey = process.env.POSTHOG_KEY;
+  const { docsHost, posthogHost, posthogKey } = getRuntimeConfigForMiddleware();
+  // Surface a missing POSTHOG_KEY on the FIRST request through the
+  // middleware — see warnIfPosthogKeyMissing (SU6-A5).
+  warnIfPosthogKeyMissing(posthogKey);
 
-  // 0. Docs-host routes (/docs, /ag-ui, /reference, /<framework-slug>).
+  // Case-insensitive matching parity (SU3-A4): the next.config rules
+  // this layer replaced were compiled by path-to-regexp with
+  // sensitive:false, so /FAQ and /Mastra/quickstart matched. The ported
+  // Map/startsWith lookups are case-sensitive and regressed those URLs
+  // to 404. Lowercase ONCE here for MATCHING only — matchPath feeds the
+  // namespace guard (step 0) and the SEO steps (2-3); the docs-host
+  // resolver (step 1) deliberately receives the ORIGINAL-case collapsed
+  // path and lowercases INTERNALLY, because it needs the original case
+  // to preserve the matched remainder (SU4-A6). The ORIGINAL-case
+  // pathname likewise provides the wildcard remainder (path-to-regexp
+  // preserves matched-param case in destinations) and the PostHog
+  // from_path. Lowercasing is length-preserving here: NextRequest
+  // pathnames are percent-encoded ASCII, so positional slicing against
+  // `strippedPath` with `matchPath`-derived offsets is safe.
+  //
+  // Leading-slash normalization (SU4-A3): "//docs/foo" and "//ag-ui/x"
+  // fell through the docs-host step's strict ===/startsWith branches AND
+  // missed the SEO wildcard scan (only the framework-slug branch's
+  // /^\/+/ regex tolerated runs) → 404. Collapse the LEADING run exactly
+  // ONCE, HERE — this is the single normalization point for every
+  // matching step below: the docs-host resolver receives the collapsed
+  // (original-case) path, and strippedPath/matchPath derive from it, so
+  // positional slicing stays aligned. Interior runs are left alone for
+  // matching; destinations collapse them via normalizeRedirectPath
+  // (SU-18/SU-13).
+  const collapsedPath = pathname.replace(/^\/{2,}/, "/");
+  // Trailing-slash normalization (SU3-A5, hardened SU4-A3): "/faq/" used
+  // to miss the exact map and detour through Next's own trailing-slash
+  // 308 (an extra hop), and "/coagents/" mis-attributed to the wildcard
+  // L12 instead of the exact L1. Strip the WHOLE trailing-slash run
+  // (a single slice(0, -1) left "/faq//" matching nothing); root "/"
+  // survives because the guard requires length > 1 and the leading
+  // collapse already reduced all-slash paths to "/". The wildcard
+  // remainder is sliced from the stripped ORIGINAL-case path so a
+  // trailing slash never leaks into destinations either.
+  const strippedPath =
+    collapsedPath.length > 1 && collapsedPath.endsWith("/")
+      ? collapsedPath.replace(/\/+$/, "")
+      : collapsedPath;
+  const matchPath = strippedPath.toLowerCase();
+
+  // 0. Shell-owned namespace guard: /integrations/* hosts LIVE shell
+  // product pages. It runs BEFORE the docs-host redirect (SU4-A1): when
+  // the guard sat after it, "no redirect may ever fire under
+  // /integrations" was only DATA-dependent — true while no registry slug
+  // happened to be named "integrations", but a future slug with that
+  // name would have let the docs-host step hijack live shell pages
+  // before the guard executed. Hoisted above every redirect step, the
+  // protection is structural: neither the docs-host enumeration nor any
+  // SEO-table entry can match under /integrations, regardless of what
+  // the registry or the table contains (R15/R17 once hijacked
+  // /integrations/built-in-agent, a deployed page with internal links).
+  if (
+    matchPath === "/integrations" ||
+    matchPath.startsWith("/integrations/")
+  ) {
+    return NextResponse.next();
+  }
+
+  // 1. Docs-host routes (/docs, /ag-ui, /reference, /<framework-slug>).
   // These permanent (308) redirects used to live in next.config.ts
   // `redirects()` (as `permanent: true`, which Next emits as 308) — which
-  // runs BEFORE middleware, hence this check sits FIRST to preserve
-  // the exact same precedence over the SEO table. They moved here so
-  // the destination host resolves from the runtime config (DOCS_HOST
-  // env var) at request time instead of being baked into the image.
+  // runs BEFORE middleware, hence this check precedes the SEO table to
+  // preserve the exact same precedence. They moved here so the
+  // destination host resolves from the runtime config (DOCS_HOST env
+  // var) at request time instead of being baked into the image.
+  // Receives collapsedPath (NOT matchPath): the resolver lowercases
+  // internally to preserve the remainder's original case, and it
+  // handles trailing slashes itself via normalizeRedirectPath.
+  //
+  // Sentinel consumer (SU4-B2): when runtime-config could not find ANY
+  // usable docs host (configured value self-hosts AND the default
+  // fallback collides too), it returns DOCS_REDIRECTS_DISABLED_HOST
+  // instead of a looping host. Honor the contract documented on the
+  // constant: skip the docs-host redirect step — and the SEO steps (2-3)
+  // below too, because resolveSeoDestination composes EVERY table
+  // destination against this same docsHost. Issuing any redirect here
+  // would trade a redirect loop for a guaranteed-dead `.invalid` host.
+  // Pass through instead; runtime-config already console.errored the
+  // FATAL-CONFIG diagnosis with the fix.
+  if (docsHost === DOCS_REDIRECTS_DISABLED_HOST) {
+    if (!docsRedirectsDisabledWarned) {
+      docsRedirectsDisabledWarned = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[middleware] docs redirects are DISABLED for this deploy " +
+          `(docsHost is the ${DOCS_REDIRECTS_DISABLED_HOST} sentinel) — ` +
+          "skipping the docs-host and SEO redirect steps. See the " +
+          "FATAL-CONFIG error from runtime-config for the root cause.",
+      );
+    }
+    return NextResponse.next();
+  }
   const docsDestination = resolveDocsHostRedirect(
-    pathname,
+    collapsedPath,
     docsHost,
     REGISTRY_FRAMEWORK_SLUGS,
   );
@@ -266,7 +828,7 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
     return NextResponse.redirect(dest, 308);
   }
 
-  // 1. Exact match (O(1) Map lookup)
+  // 2. Exact match (O(1) Map lookup)
   //
   // The SEO table's destinations target the DOCS routing surface
   // (shell-docs serves at the docs host root), NOT the shell. Resolving
@@ -274,18 +836,18 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
   // entries (e.g. /faq -> /faq) 301 to themselves forever
   // (ERR_TOO_MANY_REDIRECTS) and sent everything else to a shell 404 or
   // through a needless double hop — so resolve against the docs host.
-  const exact = exactMap.get(pathname);
+  const exact = exactMap.get(matchPath);
   if (exact) {
     const dest = resolveSeoDestination(exact.destination, docsHost);
-    // Forward the query string, matching step 0 (and next.config
-    // redirects' default behavior).
+    // Forward the query string, matching the docs-host step (and
+    // next.config redirects' default behavior).
     dest.search = request.nextUrl.search;
     trackRedirect(event, posthogHost, posthogKey, exact.id, pathname, dest);
     return NextResponse.redirect(dest, 301);
   }
 
-  // 2. Wildcard match (linear scan — short-circuits on first match).
-  // Destinations resolve against the docs host — see step 1.
+  // 3. Wildcard match (linear scan — short-circuits on first match).
+  // Destinations resolve against the docs host — see step 2.
   //
   // next.config `:path*` semantics are ZERO or more segments: a source
   // `/x/:path*` also matches the bare `/x` (rest = ""), so e.g.
@@ -293,22 +855,21 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
   // resolveSeoDestination collapses the trailing slash a zero-segment
   // substitution leaves behind.
   for (const wc of wildcardEntries) {
-    const bareSource = wc.prefix.endsWith("/")
-      ? wc.prefix.slice(0, -1)
-      : wc.prefix;
-    if (pathname.startsWith(wc.prefix) || pathname === bareSource) {
+    // Builder invariant: every wildcard prefix ends with "/" —
+    // buildRedirectLookup skips sources without the "/" boundary as
+    // malformedWildcards — so the bare (zero-segment) source is always
+    // the prefix minus exactly that one slash (SU4-A6).
+    const bareSource = wc.prefix.slice(0, -1);
+    if (matchPath.startsWith(wc.prefix) || matchPath === bareSource) {
+      // Sliced from the ORIGINAL-case (trailing-slash-stripped) path —
+      // only the prefix match is case-insensitive; the remainder
+      // forwards verbatim.
       const rest =
-        pathname === bareSource ? "" : pathname.slice(wc.prefix.length);
-      let destination: string;
-      if (wc.destinationTemplate.includes(":path*")) {
-        // Function replacer: `rest` is user-controlled, and the string
-        // form of String.prototype.replace expands `$&`, "$`", `$'`,
-        // `$$` in the replacement (e.g. /coagents/$&foo would leak the
-        // literal ":path*" token into the Location header).
-        destination = wc.destinationTemplate.replace(":path*", () => rest);
-      } else {
-        destination = wc.destinationTemplate;
-      }
+        matchPath === bareSource ? "" : strippedPath.slice(wc.prefix.length);
+      const destination = substituteWildcardTemplate(
+        wc.destinationTemplate,
+        rest,
+      );
       const dest = resolveSeoDestination(destination, docsHost);
       dest.search = request.nextUrl.search;
       trackRedirect(event, posthogHost, posthogKey, wc.id, pathname, dest);
@@ -316,17 +877,30 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
     }
   }
 
-  // 3. No match — pass through
+  // 4. No match — pass through
   return NextResponse.next();
 }
 
 export const config = {
   matcher: [
-    // Run on all paths except static assets, API routes, and Next.js
-    // internals. Note the trailing slash on `api/`: only real API routes
-    // (/api/...) are excluded — the bare /api and prefix lookalikes like
-    // /api-reference are SEO sources (R1/R3) and must reach the
-    // middleware.
-    "/((?!api/|_next/static|_next/image|favicon\\.ico|previews/).*)",
+    // Exclusions, in order (SU4-A6 — prose kept in sync with the
+    // pattern):
+    //   - `api/.+`: real API routes only — /api/<anything>. The bare
+    //     /api and prefix lookalikes like /api-reference are SEO
+    //     sources (R1/R3) and must reach the middleware; the bare
+    //     trailing-slash "/api/" must too (SU5-A4), so R1 redirects it
+    //     in ONE hop instead of detouring through Next's own
+    //     trailing-slash 308 (a double hop).
+    //   - `_next/`: ALL Next.js internals, wholesale. The previous
+    //     `_next/static|_next/image` pair let /_next/data and every
+    //     other /_next/* path run the middleware for nothing — no table
+    //     source or registry slug starts with `_next` (verified against
+    //     seo-redirects.ts and registry.json).
+    //   - `favicon\.ico`: PREFIX-based like every alternative here — it
+    //     also excludes e.g. /favicon.ico.png; that's fine, nothing
+    //     under that prefix is a redirect source.
+    //   - `previews/`: the shell's preview-asset namespace; never a
+    //     redirect source.
+    "/((?!api/.+|_next/|favicon\\.ico|previews/).*)",
   ],
 };

--- a/showcase/shell/src/middleware.ts
+++ b/showcase/shell/src/middleware.ts
@@ -31,6 +31,14 @@ import registry from "@/data/registry.json";
  */
 export const DELIBERATE_COLLAPSE_WILDCARD_IDS = /^(?:P10$|S13w×)/;
 
+// Printable-ASCII gate for sources and destinations (SU7-F3): request
+// pathnames are percent-encoded ASCII, so an entry containing a raw
+// space or any non-ASCII character can never match — a silent dead
+// entry. It also enforces the length-preservation assumption every
+// positional-slicing comment in this module relies on: toLowerCase is
+// only guaranteed length-preserving for ASCII.
+const PRINTABLE_ASCII_RE = /^[\x21-\x7e]+$/;
+
 /**
  * Build the exact-match map and wildcard list from the redirect table
  * (exported for tests). The table is documented as "first match wins" —
@@ -80,6 +88,8 @@ export function buildRedirectLookup(entries: readonly RedirectEntry[]): {
   const malformedWildcards: string[] = [];
   const invalidSources: string[] = [];
   const invalidDestinations: string[] = [];
+  const rootExactSources: string[] = [];
+  const nonAsciiEntries: string[] = [];
   const unreachableTrailingSlashSources: string[] = [];
   const exactDestinationsWithToken: string[] = [];
   const wildcardDestinationsWithMiscasedToken: string[] = [];
@@ -100,6 +110,19 @@ export function buildRedirectLookup(entries: readonly RedirectEntry[]): {
   // divergence: a false-positive warn (SU6-A3).
 
   for (const entry of entries) {
+    // Printable-ASCII gate FIRST (SU7-F3, see PRINTABLE_ASCII_RE): a
+    // non-ASCII or whitespace-bearing source can never match a request
+    // pathname (silent dead entry), and every later check slices by
+    // position under the ASCII length-preservation assumption.
+    if (
+      !PRINTABLE_ASCII_RE.test(entry.source) ||
+      !PRINTABLE_ASCII_RE.test(entry.destination)
+    ) {
+      nonAsciiEntries.push(
+        `${entry.source} -> ${entry.destination} (${entry.id})`,
+      );
+      continue;
+    }
     // Sources must be root-relative paths with no query/fragment
     // (SU4-A2): NextRequest pathnames always start with "/" and never
     // carry "?"/"#", so a source violating that can never match —
@@ -161,6 +184,15 @@ export function buildRedirectLookup(entries: readonly RedirectEntry[]): {
       // matchPath in middleware()). Also makes a source typo like MG3's
       // "/migration-guides/1.10.X" match the lowercase live URL.
       const key = entry.source.toLowerCase();
+      // A root EXACT source ("/") would match the HOMEPAGE — the twin
+      // of the root-wildcard guard in the wildcard branch below: it
+      // passes every other source check (root-relative, no "//", no
+      // ?/#, and the trailing-slash guard skips length-1 keys), yet is
+      // never a legitimate SEO entry. Reject it loudly (SU7-F3).
+      if (key === "/") {
+        rootExactSources.push(`${entry.source} (${entry.id})`);
+        continue;
+      }
       // A trailing-slash exact source is UNREACHABLE (SU4-A2):
       // middleware strips trailing slashes from matchPath before the
       // lookup, so a key ending in "/" (other than root) can never be
@@ -268,6 +300,28 @@ export function buildRedirectLookup(entries: readonly RedirectEntry[]): {
         );
         continue;
       }
+      // Duplicate-prefix owner check FIRST (SU7-F3): a later entry for
+      // an already-claimed prefix is DISCARDED whatever its destination
+      // looks like, so it must classify as a duplicate — running the
+      // miscased/tokenless destination checks below on it would fire
+      // table-bug warns for an entry that never ships (a harmless
+      // same-destination tokenless twin stayed loud, desensitizing the
+      // channel exactly like the duplicate twins before SU5-A3).
+      const owner = wildcardPrefixOwners.get(prefix);
+      if (owner) {
+        // Same-destination twin allowlist — see the exact-map branch
+        // above (SU5-A3); same request-time-normalized comparison
+        // (SU6-A3).
+        if (
+          normalizeRedirectPath(owner.destinationTemplate) !==
+          normalizeRedirectPath(entry.destination)
+        ) {
+          duplicateWildcardSources.push(
+            `${entry.source} (${entry.id} shadowed by ${owner.id})`,
+          );
+        }
+        continue;
+      }
       // Substitution is CASE-SENSITIVE — substituteWildcardTemplate
       // replaces the literal lowercase ":path*" only — so a miscased
       // token in a WILDCARD destination (":PATH*") never substitutes
@@ -300,21 +354,6 @@ export function buildRedirectLookup(entries: readonly RedirectEntry[]): {
         tokenlessWildcardDestinations.push(
           `${entry.source} -> ${entry.destination} (${entry.id})`,
         );
-      }
-      const owner = wildcardPrefixOwners.get(prefix);
-      if (owner) {
-        // Same-destination twin allowlist — see the exact-map branch
-        // above (SU5-A3); same request-time-normalized comparison
-        // (SU6-A3).
-        if (
-          normalizeRedirectPath(owner.destinationTemplate) !==
-          normalizeRedirectPath(entry.destination)
-        ) {
-          duplicateWildcardSources.push(
-            `${entry.source} (${entry.id} shadowed by ${owner.id})`,
-          );
-        }
-        continue;
       }
       // Overlapping wildcard prefixes (SU4-A2): the scan is first-match-
       // wins, so when an EARLIER wildcard's prefix is a prefix of this
@@ -382,6 +421,24 @@ export function buildRedirectLookup(entries: readonly RedirectEntry[]): {
       "[middleware] seo-redirects has entries with an invalid source " +
         '(must be a root-relative path starting with "/", with no "//", ' +
         `"?" or "#") — they are ignored: ${invalidSources.join(", ")}`,
+    );
+  }
+  if (nonAsciiEntries.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[middleware] seo-redirects has entries whose source or " +
+        "destination contains non-printable-ASCII characters (raw " +
+        "whitespace or non-ASCII) — request pathnames are " +
+        "percent-encoded ASCII, so they can never match; they are " +
+        `ignored: ${nonAsciiEntries.join(", ")}`,
+    );
+  }
+  if (rootExactSources.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[middleware] seo-redirects has a root ("/") EXACT source — it ' +
+        "would hijack the homepage (the root-wildcard guard's exact " +
+        `twin); it is ignored: ${rootExactSources.join(", ")}`,
     );
   }
   if (unreachableTrailingSlashSources.length > 0) {
@@ -542,7 +599,14 @@ function warnCaptureFailureOnce(failureClass: string, detail: string): void {
  * URL on EVERY redirect, silently zeroing the decommission report.
  */
 export function normalizePosthogHost(host: string): string {
-  return SCHEME_RE.test(host) ? host : `https://${host}`;
+  // Trailing slashes are stripped FIRST (SU7-F3) so the caller's
+  // `${host}/capture/` concatenation never yields "host//capture/" —
+  // the same defense-in-depth posture as the scheme guard below
+  // (runtime-config's readUrl already strips them for values threaded
+  // through middleware(), so like the scheme branch this is only
+  // reachable by future direct callers).
+  const stripped = host.replace(/\/+$/, "");
+  return SCHEME_RE.test(stripped) ? stripped : `https://${stripped}`;
 }
 
 function trackRedirect(

--- a/showcase/shell/src/middleware.ts
+++ b/showcase/shell/src/middleware.ts
@@ -1,8 +1,11 @@
 import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
+import type { NextFetchEvent, NextRequest } from "next/server";
 import { seoRedirects } from "@/lib/seo-redirects";
 import { getRuntimeConfigForMiddleware } from "@/lib/runtime-config";
-import { resolveDocsHostRedirect } from "@/lib/docs-redirects";
+import {
+  resolveDocsHostRedirect,
+  resolveSeoDestination,
+} from "@/lib/docs-redirects";
 import registry from "@/data/registry.json";
 
 // ---------------------------------------------------------------------------
@@ -42,7 +45,12 @@ for (const entry of seoRedirects) {
 
 let posthogKeyWarned = false;
 
-function trackRedirect(id: string, fromPath: string, toPath: string): void {
+function trackRedirect(
+  event: NextFetchEvent,
+  id: string,
+  fromPath: string,
+  toPath: string,
+): void {
   const apiKey = process.env.POSTHOG_KEY;
   if (!apiKey) {
     if (!posthogKeyWarned) {
@@ -59,8 +67,10 @@ function trackRedirect(id: string, fromPath: string, toPath: string): void {
   // getRuntimeConfigForMiddleware in src/lib/runtime-config.ts).
   const posthogHost = getRuntimeConfigForMiddleware().posthogHost;
 
-  // Fire-and-forget — don't await
-  fetch(`${posthogHost}/capture/`, {
+  // Don't await (never block the redirect), but DO hand the promise to
+  // event.waitUntil — the Edge runtime may otherwise terminate as soon
+  // as the redirect response is returned, dropping the in-flight capture.
+  const capture = fetch(`${posthogHost}/capture/`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -76,6 +86,7 @@ function trackRedirect(id: string, fromPath: string, toPath: string): void {
   }).catch(() => {
     // Silently ignore tracking failures — don't block redirects
   });
+  event.waitUntil(capture);
 }
 
 // ---------------------------------------------------------------------------
@@ -84,7 +95,7 @@ function trackRedirect(id: string, fromPath: string, toPath: string): void {
 
 // Framework slugs owned by the docs shell. Any path whose first
 // segment matches one of these is a framework-scoped docs URL — it
-// 301s to the docs host BEFORE the SEO-redirect table runs, so legacy
+// 308s to the docs host BEFORE the SEO-redirect table runs, so legacy
 // redirects (e.g. `/mastra/agentic-chat-ui` →
 // `/docs/integrations/mastra/prebuilt-components`) can never hijack it
 // even when legacy framework keys overlap with registry slugs.
@@ -94,18 +105,43 @@ const REGISTRY_FRAMEWORK_SLUGS: Set<string> = new Set(
   ) ?? [],
 );
 
-export function middleware(request: NextRequest) {
+/**
+ * Loud guard (exported for tests): the old next.config build THREW when
+ * registry.json was missing or corrupt in production. Middleware cannot
+ * afford to throw at module load — that would 500 every request — so it
+ * screams in the logs instead: an empty slug set silently disables every
+ * /<framework-slug> docs-host redirect.
+ */
+export function warnIfNoFrameworkSlugs(slugs: ReadonlySet<string>): void {
+  if (slugs.size > 0) return;
+  const message =
+    "[middleware] registry.json produced ZERO framework slugs — " +
+    "/<framework-slug> docs-host redirects are DISABLED. The registry is " +
+    "missing or corrupt; run generate-registry.ts before building (the " +
+    "old next.config build failed loudly here).";
+  if (process.env.NODE_ENV === "production") {
+    console.error(message);
+  } else {
+    console.warn(message);
+  }
+}
+
+warnIfNoFrameworkSlugs(REGISTRY_FRAMEWORK_SLUGS);
+
+export function middleware(request: NextRequest, event: NextFetchEvent) {
   const { pathname } = request.nextUrl;
+  const docsHost = getRuntimeConfigForMiddleware().docsHost;
 
   // 0. Docs-host routes (/docs, /ag-ui, /reference, /<framework-slug>).
-  // These 301s used to live in next.config.ts `redirects()` — which
+  // These permanent (308) redirects used to live in next.config.ts
+  // `redirects()` (as `permanent: true`, which Next emits as 308) — which
   // runs BEFORE middleware, hence this check sits FIRST to preserve
   // the exact same precedence over the SEO table. They moved here so
   // the destination host resolves from the runtime config (DOCS_HOST
   // env var) at request time instead of being baked into the image.
   const docsDestination = resolveDocsHostRedirect(
     pathname,
-    getRuntimeConfigForMiddleware().docsHost,
+    docsHost,
     REGISTRY_FRAMEWORK_SLUGS,
   );
   if (docsDestination) {
@@ -113,28 +149,58 @@ export function middleware(request: NextRequest) {
     // next.config redirects forward the query string by default — keep
     // that behavior.
     dest.search = request.nextUrl.search;
-    return NextResponse.redirect(dest, 301);
+    // Parity choice: docs-host redirects are deliberately NOT tracked in
+    // PostHog — the next.config `redirects()` rules they replace never
+    // were either; only the SEO table below calls trackRedirect.
+    //
+    // 308, not 301: the old rules used `permanent: true`, which Next
+    // emits as 308 (permanent, method-preserving).
+    return NextResponse.redirect(dest, 308);
   }
 
   // 1. Exact match (O(1) Map lookup)
+  //
+  // The SEO table's destinations target the DOCS routing surface
+  // (shell-docs serves at the docs host root), NOT the shell. Resolving
+  // them against `request.url` (the shell origin) made self-referential
+  // entries (e.g. /faq -> /faq) 301 to themselves forever
+  // (ERR_TOO_MANY_REDIRECTS) and sent everything else to a shell 404 or
+  // through a needless double hop — so resolve against the docs host.
   const exact = exactMap.get(pathname);
   if (exact) {
-    trackRedirect(exact.id, pathname, exact.destination);
-    return NextResponse.redirect(new URL(exact.destination, request.url), 301);
+    const dest = resolveSeoDestination(exact.destination, docsHost);
+    // Forward the query string, matching step 0 (and next.config
+    // redirects' default behavior).
+    dest.search = request.nextUrl.search;
+    trackRedirect(event, exact.id, pathname, dest.pathname);
+    return NextResponse.redirect(dest, 301);
   }
 
-  // 2. Wildcard match (linear scan — short-circuits on first match)
+  // 2. Wildcard match (linear scan — short-circuits on first match).
+  // Destinations resolve against the docs host — see step 1.
+  //
+  // next.config `:path*` semantics are ZERO or more segments: a source
+  // `/x/:path*` also matches the bare `/x` (rest = ""), so e.g.
+  // /backend, /guides, /learn keep redirecting instead of 404ing.
+  // resolveSeoDestination collapses the trailing slash a zero-segment
+  // substitution leaves behind.
   for (const wc of wildcardEntries) {
-    if (pathname.startsWith(wc.prefix)) {
-      const rest = pathname.slice(wc.prefix.length);
+    const bareSource = wc.prefix.endsWith("/")
+      ? wc.prefix.slice(0, -1)
+      : wc.prefix;
+    if (pathname.startsWith(wc.prefix) || pathname === bareSource) {
+      const rest =
+        pathname === bareSource ? "" : pathname.slice(wc.prefix.length);
       let destination: string;
       if (wc.destinationTemplate.includes(":path*")) {
         destination = wc.destinationTemplate.replace(":path*", rest);
       } else {
         destination = wc.destinationTemplate;
       }
-      trackRedirect(wc.id, pathname, destination);
-      return NextResponse.redirect(new URL(destination, request.url), 301);
+      const dest = resolveSeoDestination(destination, docsHost);
+      dest.search = request.nextUrl.search;
+      trackRedirect(event, wc.id, pathname, dest.pathname);
+      return NextResponse.redirect(dest, 301);
     }
   }
 
@@ -144,7 +210,11 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    // Run on all paths except static assets, API routes, and Next.js internals
-    "/((?!api|_next/static|_next/image|favicon\\.ico|previews/).*)",
+    // Run on all paths except static assets, API routes, and Next.js
+    // internals. Note the trailing slash on `api/`: only real API routes
+    // (/api/...) are excluded — the bare /api and prefix lookalikes like
+    // /api-reference are SEO sources (R1/R3) and must reach the
+    // middleware.
+    "/((?!api/|_next/static|_next/image|favicon\\.ico|previews/).*)",
   ],
 };

--- a/showcase/shell/src/middleware.ts
+++ b/showcase/shell/src/middleware.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { seoRedirects } from "@/lib/seo-redirects";
 import { getRuntimeConfigForMiddleware } from "@/lib/runtime-config";
+import { resolveDocsHostRedirect } from "@/lib/docs-redirects";
 import registry from "@/data/registry.json";
 
 // ---------------------------------------------------------------------------
@@ -81,35 +82,38 @@ function trackRedirect(id: string, fromPath: string, toPath: string): void {
 // Middleware
 // ---------------------------------------------------------------------------
 
-// Framework slugs owned by the new `/<framework>/<...slug>` catch-all
-// route. Any path whose first segment matches one of these is a
-// first-class framework-scoped docs URL — the SEO-redirect table must
-// NOT hijack it even when the legacy framework keys (`mastra`,
-// `agno`, `llamaindex`, `pydantic-ai`, `ag2`) overlap with registry
-// slugs. Concretely: `/mastra/agentic-chat-ui` is the new docs URL,
-// not a legacy SEO path.
+// Framework slugs owned by the docs shell. Any path whose first
+// segment matches one of these is a framework-scoped docs URL — it
+// 301s to the docs host BEFORE the SEO-redirect table runs, so legacy
+// redirects (e.g. `/mastra/agentic-chat-ui` →
+// `/docs/integrations/mastra/prebuilt-components`) can never hijack it
+// even when legacy framework keys overlap with registry slugs.
 const REGISTRY_FRAMEWORK_SLUGS: Set<string> = new Set(
   (registry as { integrations?: { slug: string }[] }).integrations?.map(
     (i) => i.slug,
   ) ?? [],
 );
 
-function pathIsFrameworkScoped(pathname: string): boolean {
-  const first = pathname.split("/").filter(Boolean)[0];
-  return Boolean(first) && REGISTRY_FRAMEWORK_SLUGS.has(first);
-}
-
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // Short-circuit: paths owned by the framework-scoped docs route
-  // should never be touched by the SEO-redirect table. This prevents
-  // legacy redirects (e.g. `/mastra/agentic-chat-ui` →
-  // `/docs/integrations/mastra/prebuilt-components`) from fighting the
-  // new catch-all, which wants `/mastra/agentic-chat-ui` to render the
-  // Mastra-scoped Agentic Chat UI docs in place.
-  if (pathIsFrameworkScoped(pathname)) {
-    return NextResponse.next();
+  // 0. Docs-host routes (/docs, /ag-ui, /reference, /<framework-slug>).
+  // These 301s used to live in next.config.ts `redirects()` — which
+  // runs BEFORE middleware, hence this check sits FIRST to preserve
+  // the exact same precedence over the SEO table. They moved here so
+  // the destination host resolves from the runtime config (DOCS_HOST
+  // env var) at request time instead of being baked into the image.
+  const docsDestination = resolveDocsHostRedirect(
+    pathname,
+    getRuntimeConfigForMiddleware().docsHost,
+    REGISTRY_FRAMEWORK_SLUGS,
+  );
+  if (docsDestination) {
+    const dest = new URL(docsDestination);
+    // next.config redirects forward the query string by default — keep
+    // that behavior.
+    dest.search = request.nextUrl.search;
+    return NextResponse.redirect(dest, 301);
   }
 
   // 1. Exact match (O(1) Map lookup)

--- a/showcase/shell/src/middleware.ts
+++ b/showcase/shell/src/middleware.ts
@@ -63,7 +63,11 @@ export function buildRedirectLookup(entries: readonly RedirectEntry[]): {
   /** Exact-match map: source path -> { id, destination } */
   exactMap: Map<string, { id: string; destination: string }>;
   /** Wildcard entries: source has :path* -- stored as { prefix, id, destination } */
-  wildcardEntries: { prefix: string; id: string; destinationTemplate: string }[];
+  wildcardEntries: {
+    prefix: string;
+    id: string;
+    destinationTemplate: string;
+  }[];
 } {
   const exactMap = new Map<string, { id: string; destination: string }>();
   const wildcardEntries: {
@@ -832,10 +836,7 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
   // SEO-table entry can match under /integrations, regardless of what
   // the registry or the table contains (R15/R17 once hijacked
   // /integrations/built-in-agent, a deployed page with internal links).
-  if (
-    matchPath === "/integrations" ||
-    matchPath.startsWith("/integrations/")
-  ) {
+  if (matchPath === "/integrations" || matchPath.startsWith("/integrations/")) {
     return NextResponse.next();
   }
 

--- a/showcase/shell/src/middleware.ts
+++ b/showcase/shell/src/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextFetchEvent, NextRequest } from "next/server";
 import { seoRedirects } from "@/lib/seo-redirects";
+import type { RedirectEntry } from "@/lib/seo-redirects";
 import { getRuntimeConfigForMiddleware } from "@/lib/runtime-config";
 import {
   resolveDocsHostRedirect,
@@ -12,32 +13,79 @@ import registry from "@/data/registry.json";
 // Build lookup structures at module load (once per cold start)
 // ---------------------------------------------------------------------------
 
-/** Exact-match map: source path -> { id, destination } */
-const exactMap = new Map<string, { id: string; destination: string }>();
+/**
+ * Build the exact-match map and wildcard list from the redirect table
+ * (exported for tests). The table is documented as "first match wins" —
+ * a plain Map.set loop silently inverted that to LAST-write-wins for
+ * the duplicate exact sources (e.g. P2×unselected overrode
+ * SR-root×unselected), skewing PostHog redirect_id attribution. Skip
+ * later duplicates and warn once at module load, naming them.
+ */
+export function buildRedirectLookup(entries: readonly RedirectEntry[]): {
+  /** Exact-match map: source path -> { id, destination } */
+  exactMap: Map<string, { id: string; destination: string }>;
+  /** Wildcard entries: source has :path* -- stored as { prefix, id, destination } */
+  wildcardEntries: { prefix: string; id: string; destinationTemplate: string }[];
+} {
+  const exactMap = new Map<string, { id: string; destination: string }>();
+  const wildcardEntries: {
+    prefix: string;
+    id: string;
+    destinationTemplate: string;
+  }[] = [];
+  const duplicateSources: string[] = [];
+  const malformedWildcards: string[] = [];
 
-/** Wildcard entries: source has :path* -- stored as { prefix, id, destination } */
-const wildcardEntries: {
-  prefix: string;
-  id: string;
-  destinationTemplate: string;
-}[] = [];
-
-for (const entry of seoRedirects) {
-  const wildcardIdx = entry.source.indexOf(":path*");
-  if (wildcardIdx === -1) {
-    exactMap.set(entry.source, {
-      id: entry.id,
-      destination: entry.destination,
-    });
-  } else {
-    const prefix = entry.source.slice(0, wildcardIdx);
-    wildcardEntries.push({
-      prefix,
-      id: entry.id,
-      destinationTemplate: entry.destination,
-    });
+  for (const entry of entries) {
+    const wildcardIdx = entry.source.indexOf(":path*");
+    if (wildcardIdx === -1) {
+      const existing = exactMap.get(entry.source);
+      if (existing) {
+        duplicateSources.push(
+          `${entry.source} (${entry.id} shadowed by ${existing.id})`,
+        );
+        continue;
+      }
+      exactMap.set(entry.source, {
+        id: entry.id,
+        destination: entry.destination,
+      });
+    } else {
+      const prefix = entry.source.slice(0, wildcardIdx);
+      // A wildcard prefix MUST end with "/" — the matcher's
+      // `startsWith(prefix)` would otherwise match prefix LOOKALIKES
+      // (e.g. a source "/x:path*" matching "/xylophone"). Treat a
+      // violation as a table bug: warn loudly and skip the entry.
+      if (!prefix.endsWith("/")) {
+        malformedWildcards.push(`${entry.source} (${entry.id})`);
+        continue;
+      }
+      wildcardEntries.push({
+        prefix,
+        id: entry.id,
+        destinationTemplate: entry.destination,
+      });
+    }
   }
+
+  if (duplicateSources.length > 0) {
+    console.warn(
+      "[middleware] seo-redirects has duplicate exact sources — first " +
+        `match wins, later entries are ignored: ${duplicateSources.join(", ")}`,
+    );
+  }
+  if (malformedWildcards.length > 0) {
+    console.warn(
+      "[middleware] seo-redirects has wildcard sources whose prefix does " +
+        'not end with "/" — they would match prefix lookalikes and are ' +
+        `ignored: ${malformedWildcards.join(", ")}`,
+    );
+  }
+
+  return { exactMap, wildcardEntries };
 }
+
+const { exactMap, wildcardEntries } = buildRedirectLookup(seoRedirects);
 
 // ---------------------------------------------------------------------------
 // PostHog tracking via fetch (Edge Runtime compatible — no posthog-node SDK)
@@ -45,14 +93,50 @@ for (const entry of seoRedirects) {
 
 let posthogKeyWarned = false;
 
+// One loud log per distinct capture-failure class (`http:<status>` /
+// `net:<error name>`), not per request — mirrors the patternWarnings
+// pattern in lib/backend-url.ts. Observability here is load-bearing:
+// the redirect-decommission report deletes redirects that show ZERO
+// PostHog traffic, so silently-broken capture (a swallowed rejection or
+// an unchecked 4xx/5xx) leads to wrongful deletions.
+const captureFailureWarnings = new Set<string>();
+
+function warnCaptureFailureOnce(failureClass: string, detail: string): void {
+  if (captureFailureWarnings.has(failureClass)) return;
+  captureFailureWarnings.add(failureClass);
+  console.warn(
+    `[middleware] PostHog redirect capture failing (${failureClass}): ` +
+      `${detail} — seo_redirect events are not being recorded, so the ` +
+      "redirect decommission report will under-count this traffic.",
+  );
+}
+
+/**
+ * Defensive use-site normalization: POSTHOG_HOST can be set scheme-less
+ * (the sibling SHOWCASE_BACKEND_HOST_PATTERN var is documented as
+ * host-only, an easy format to carry over), and a scheme-less host makes
+ * the capture `fetch()` reject a relative URL on EVERY redirect. Proper
+ * normalization belongs in runtime-config (readDocsHost already does
+ * this for DOCS_HOST) — that is a sibling fix; this guard keeps the
+ * middleware safe regardless.
+ */
+function normalizePosthogHost(host: string): string {
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(host) ? host : `https://${host}`;
+}
+
 function trackRedirect(
   event: NextFetchEvent,
+  // posthogHost/posthogKey are resolved ONCE per request in middleware()
+  // and passed in — trackRedirect used to call
+  // getRuntimeConfigForMiddleware() again, resolving the config twice
+  // per redirected request.
+  posthogHost: string,
+  posthogKey: string | undefined,
   id: string,
   fromPath: string,
-  toPath: string,
+  dest: URL,
 ): void {
-  const apiKey = process.env.POSTHOG_KEY;
-  if (!apiKey) {
+  if (!posthogKey) {
     if (!posthogKeyWarned) {
       console.warn(
         "[middleware] POSTHOG_KEY is not set — redirect tracking disabled",
@@ -62,30 +146,49 @@ function trackRedirect(
     return;
   }
 
-  // Read the PostHog host from the Edge-safe runtime config (live
-  // process.env at request time, no `next/cache` import — see
-  // getRuntimeConfigForMiddleware in src/lib/runtime-config.ts).
-  const posthogHost = getRuntimeConfigForMiddleware().posthogHost;
+  const captureUrl = `${normalizePosthogHost(posthogHost)}/capture/`;
 
   // Don't await (never block the redirect), but DO hand the promise to
   // event.waitUntil — the Edge runtime may otherwise terminate as soon
   // as the redirect response is returned, dropping the in-flight capture.
-  const capture = fetch(`${posthogHost}/capture/`, {
+  const capture = fetch(captureUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      api_key: apiKey,
+      api_key: posthogKey,
       event: "seo_redirect",
       distinct_id: "seo-redirect-tracker",
       properties: {
         redirect_id: id,
         from_path: fromPath,
-        to_path: toPath,
+        // to_path alone is ambiguous for self-referential entries (e.g.
+        // M3 /faq -> docs-host /faq emits from_path === to_path) — the
+        // decommission report needs the destination HOST to tell them
+        // apart. to_path is kept for continuity with historic events;
+        // to_url adds the host but excludes the query string (it varies
+        // per request and would explode property cardinality).
+        to_path: dest.pathname,
+        to_url: `${dest.origin}${dest.pathname}`,
       },
     }),
-  }).catch(() => {
-    // Silently ignore tracking failures — don't block redirects
-  });
+  })
+    .then((res) => {
+      // A 4xx/5xx resolves the fetch promise — without this check a
+      // misconfigured key/host fails capture silently forever.
+      if (!res.ok) {
+        warnCaptureFailureOnce(
+          `http:${res.status}`,
+          `POST ${captureUrl} returned ${res.status}`,
+        );
+      }
+    })
+    .catch((err: unknown) => {
+      // Never block or fail the redirect on tracking errors — but DO
+      // surface them (once per class) instead of swallowing.
+      const name = err instanceof Error ? err.name : typeof err;
+      const message = err instanceof Error ? err.message : String(err);
+      warnCaptureFailureOnce(`net:${name}`, message);
+    });
   event.waitUntil(capture);
 }
 
@@ -96,10 +199,10 @@ function trackRedirect(
 // Framework slugs owned by the docs shell. Any path whose first
 // segment matches one of these is a framework-scoped docs URL — it
 // 308s to the docs host BEFORE the SEO-redirect table runs, so legacy
-// redirects (e.g. `/mastra/agentic-chat-ui` →
-// `/docs/integrations/mastra/prebuilt-components`) can never hijack it
-// even when legacy framework keys overlap with registry slugs.
-const REGISTRY_FRAMEWORK_SLUGS: Set<string> = new Set(
+// redirects (e.g. S1×mastra: `/mastra/agentic-chat-ui` →
+// `/mastra/prebuilt-components`) can never hijack it even when legacy
+// framework keys overlap with registry slugs.
+export const REGISTRY_FRAMEWORK_SLUGS: Set<string> = new Set(
   (registry as { integrations?: { slug: string }[] }).integrations?.map(
     (i) => i.slug,
   ) ?? [],
@@ -130,7 +233,12 @@ warnIfNoFrameworkSlugs(REGISTRY_FRAMEWORK_SLUGS);
 
 export function middleware(request: NextRequest, event: NextFetchEvent) {
   const { pathname } = request.nextUrl;
-  const docsHost = getRuntimeConfigForMiddleware().docsHost;
+  // Resolve the Edge-safe runtime config (live process.env at request
+  // time, no `next/cache` import) ONCE per request and thread the
+  // values through — see getRuntimeConfigForMiddleware in
+  // src/lib/runtime-config.ts.
+  const { docsHost, posthogHost } = getRuntimeConfigForMiddleware();
+  const posthogKey = process.env.POSTHOG_KEY;
 
   // 0. Docs-host routes (/docs, /ag-ui, /reference, /<framework-slug>).
   // These permanent (308) redirects used to live in next.config.ts
@@ -172,7 +280,7 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
     // Forward the query string, matching step 0 (and next.config
     // redirects' default behavior).
     dest.search = request.nextUrl.search;
-    trackRedirect(event, exact.id, pathname, dest.pathname);
+    trackRedirect(event, posthogHost, posthogKey, exact.id, pathname, dest);
     return NextResponse.redirect(dest, 301);
   }
 
@@ -193,13 +301,17 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
         pathname === bareSource ? "" : pathname.slice(wc.prefix.length);
       let destination: string;
       if (wc.destinationTemplate.includes(":path*")) {
-        destination = wc.destinationTemplate.replace(":path*", rest);
+        // Function replacer: `rest` is user-controlled, and the string
+        // form of String.prototype.replace expands `$&`, "$`", `$'`,
+        // `$$` in the replacement (e.g. /coagents/$&foo would leak the
+        // literal ":path*" token into the Location header).
+        destination = wc.destinationTemplate.replace(":path*", () => rest);
       } else {
         destination = wc.destinationTemplate;
       }
       const dest = resolveSeoDestination(destination, docsHost);
       dest.search = request.nextUrl.search;
-      trackRedirect(event, wc.id, pathname, dest.pathname);
+      trackRedirect(event, posthogHost, posthogKey, wc.id, pathname, dest);
       return NextResponse.redirect(dest, 301);
     }
   }

--- a/showcase/shell/src/next-path-to-regexp.d.ts
+++ b/showcase/shell/src/next-path-to-regexp.d.ts
@@ -1,0 +1,11 @@
+// Minimal typing for Next's vendored path-to-regexp — the compiled
+// module (next/dist/compiled/path-to-regexp) ships no .d.ts. Used by
+// middleware.test.ts to compile the middleware `matcher` exactly the
+// way Next does.
+declare module "next/dist/compiled/path-to-regexp" {
+  export function pathToRegexp(
+    path: string,
+    keys?: unknown[],
+    options?: { delimiter?: string; sensitive?: boolean; strict?: boolean },
+  ): RegExp;
+}

--- a/showcase/shell/src/next-path-to-regexp.d.ts
+++ b/showcase/shell/src/next-path-to-regexp.d.ts
@@ -1,8 +1,15 @@
 // Minimal typing for Next's vendored path-to-regexp — the compiled
 // module (next/dist/compiled/path-to-regexp) ships no .d.ts. Used by
 // middleware.test.ts to compile the middleware `matcher` exactly the
-// way Next does.
+// way Next does (SU6-A6): tryToParsePath (next/dist/lib/
+// try-to-parse-path.ts) calls parse() + tokensToRegexp() with NO
+// options and keeps only the regex source, which the runtime
+// re-hydrates with `new RegExp(...)`.
 declare module "next/dist/compiled/path-to-regexp" {
+  /** Opaque parse result — only ever passed back to tokensToRegexp. */
+  export type Token = string | object;
+  export function parse(path: string): Token[];
+  export function tokensToRegexp(tokens: Token[]): RegExp;
   export function pathToRegexp(
     path: string,
     keys?: unknown[],

--- a/showcase/shell/vitest.config.ts
+++ b/showcase/shell/vitest.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
     globals: true,
     include: ["src/**/*.test.{ts,tsx}"],
     exclude: ["node_modules/**"],
+    // Generates the gitignored registry.json (statically imported by
+    // src/middleware.ts) before any worker transforms a test module —
+    // see vitest.global-setup.ts.
+    globalSetup: "./vitest.global-setup.ts",
   },
   resolve: {
     alias: {

--- a/showcase/shell/vitest.config.ts
+++ b/showcase/shell/vitest.config.ts
@@ -1,12 +1,18 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
+import { createRequire } from "node:module";
 import path from "node:path";
+
+const require = createRequire(import.meta.url);
 
 export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
     include: ["src/**/*.test.{ts,tsx}"],
-    exclude: ["node_modules/**"],
+    // Vitest's DEFAULT excludes (node_modules, dist, .git, ...) — the
+    // previous hand-rolled ["node_modules/**"] silently REPLACED the
+    // defaults instead of extending them (SU5-A5).
+    exclude: [...configDefaults.exclude],
     // Generates the gitignored registry.json (statically imported by
     // src/middleware.ts) before any worker transforms a test module —
     // see vitest.global-setup.ts.
@@ -15,6 +21,17 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // `server-only` (imported by src/lib/runtime-config.ts as a
+      // client-bundle guard) THROWS under the plain-Node `default`
+      // export condition vitest resolves with — point it at the
+      // package's own empty `react-server` marker instead, exactly
+      // what Next's server/middleware layers resolve. Located via
+      // require.resolve (SU5-A5): a hard-coded ./node_modules path
+      // breaks when the package manager hoists the package.
+      "server-only": path.join(
+        path.dirname(require.resolve("server-only")),
+        "empty.js",
+      ),
     },
   },
 });

--- a/showcase/shell/vitest.global-setup.ts
+++ b/showcase/shell/vitest.global-setup.ts
@@ -9,8 +9,8 @@
 // races other workers and leaves every other file broken when it doesn't
 // run first).
 //
-// Idempotent: if the registry already exists (dev/build ran, or a prior
-// test run generated it), this is a no-op.
+// Idempotent: if the registry already exists AND is valid (dev/build
+// ran, or a prior test run generated it), this is a no-op.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -21,8 +21,30 @@ import { execFileSync } from "node:child_process";
 const SHELL_ROOT = path.dirname(fileURLToPath(import.meta.url));
 const REGISTRY_PATH = path.join(SHELL_ROOT, "src", "data", "registry.json");
 
+// Validate before the early return (SU4-A7): a corrupt or stale
+// registry.json (interrupted generator, truncated write) used to pass
+// the bare existsSync check and then break EVERY middleware test at
+// import with an unrelated-looking JSON/transform error. Parse it and
+// require a non-empty integrations array; regenerate otherwise.
+function isValidRegistry(registryPath: string): boolean {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(registryPath, "utf-8")) as {
+      integrations?: unknown;
+    };
+    return Array.isArray(parsed.integrations) && parsed.integrations.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 export default function setup(): void {
-  if (fs.existsSync(REGISTRY_PATH)) return;
+  if (fs.existsSync(REGISTRY_PATH)) {
+    if (isValidRegistry(REGISTRY_PATH)) return;
+    console.warn(
+      `[vitest.global-setup] ${REGISTRY_PATH} exists but is corrupt or ` +
+        "has no integrations — regenerating.",
+    );
+  }
 
   // Run the local generator through the current node binary + the locally
   // installed tsx CLI — NOT `npx tsx`: npx without -y can prompt-hang when
@@ -40,4 +62,18 @@ export default function setup(): void {
     stdio: ["ignore", "ignore", "inherit"],
     timeout: 120_000,
   });
+
+  // Re-validate AFTER regeneration (SU5-A5): a generator that exits 0
+  // but emits an unusable registry (schema drift, empty integrations,
+  // output path moved) would otherwise resurface as the exact baffling
+  // transform error in whichever test file imports middleware first —
+  // the failure this setup exists to prevent. Fail HERE, loudly.
+  if (!isValidRegistry(REGISTRY_PATH)) {
+    throw new Error(
+      `[vitest.global-setup] generate-registry.ts completed but ` +
+        `${REGISTRY_PATH} is still missing, corrupt, or has no ` +
+        "integrations — the registry generator (or its output path) is " +
+        "broken; fix it before running the shell test suite.",
+    );
+  }
 }

--- a/showcase/shell/vitest.global-setup.ts
+++ b/showcase/shell/vitest.global-setup.ts
@@ -51,7 +51,12 @@ export default function setup(): void {
   // the package isn't cached, and `npx` itself isn't directly spawnable on
   // Windows (execFile needs the .cmd shim).
   const tsxCli = createRequire(import.meta.url).resolve("tsx/cli");
-  const generator = path.join(SHELL_ROOT, "..", "scripts", "generate-registry.ts");
+  const generator = path.join(
+    SHELL_ROOT,
+    "..",
+    "scripts",
+    "generate-registry.ts",
+  );
 
   // Generous timeout: the generator validates every manifest and emits
   // catalogs for all shells. Keep stdout quiet but surface stderr — with

--- a/showcase/shell/vitest.global-setup.ts
+++ b/showcase/shell/vitest.global-setup.ts
@@ -1,0 +1,43 @@
+// Vitest globalSetup: generate the gitignored registry.json BEFORE any
+// test worker starts.
+//
+// src/middleware.ts statically imports `@/data/registry.json`, a generated
+// artifact (see showcase/.gitignore) that `npm run dev`/`build` produce.
+// On a fresh checkout it doesn't exist, and vitest workers have no
+// ordering guarantee — so generation must happen here, once, before
+// module transform, not in any single test file's beforeAll (which both
+// races other workers and leaves every other file broken when it doesn't
+// run first).
+//
+// Idempotent: if the registry already exists (dev/build ran, or a prior
+// test run generated it), this is a no-op.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import { execFileSync } from "node:child_process";
+
+const SHELL_ROOT = path.dirname(fileURLToPath(import.meta.url));
+const REGISTRY_PATH = path.join(SHELL_ROOT, "src", "data", "registry.json");
+
+export default function setup(): void {
+  if (fs.existsSync(REGISTRY_PATH)) return;
+
+  // Run the local generator through the current node binary + the locally
+  // installed tsx CLI — NOT `npx tsx`: npx without -y can prompt-hang when
+  // the package isn't cached, and `npx` itself isn't directly spawnable on
+  // Windows (execFile needs the .cmd shim).
+  const tsxCli = createRequire(import.meta.url).resolve("tsx/cli");
+  const generator = path.join(SHELL_ROOT, "..", "scripts", "generate-registry.ts");
+
+  // Generous timeout: the generator validates every manifest and emits
+  // catalogs for all shells. Keep stdout quiet but surface stderr — with
+  // stdio "ignore" a generator failure is a bare exit-code-1 with nothing
+  // to debug on CI.
+  execFileSync(process.execPath, [tsxCli, generator], {
+    cwd: SHELL_ROOT,
+    stdio: ["ignore", "ignore", "inherit"],
+    timeout: 120_000,
+  });
+}


### PR DESCRIPTION
## Summary

End-to-end hardening of the showcase shell's URL plane:

- Carries `backendHostPattern` + `docsHost` in the shell runtime config (no longer baked from `registry.json` at Docker build time). Derives demo backend URLs at runtime from the pattern, so a new pattern via env reconfigures every integration on the next deploy without a registry rebuild.
- Issues docs-host 301/308 redirects from middleware with a runtime `DOCS_HOST`; misconfigured values no longer 500 every docs route — they fall back to a sentinel that disables the docs-redirect step.
- Hardens the redirect table builder + matcher: first-match-wins for duplicate exact sources, deduped wildcard prefixes with warn, malformed entries rejected at lookup-build time, case-insensitive matching parity, trailing-slash normalization, structural `/integrations` namespace guard above the docs-host redirect (closes R15/R17 hijack class).
- Hardens runtime-config + backend-url env readers: scheme/whitespace/control-char normalization, query/fragment/userinfo rejection on `DOCS_HOST` / `POSTHOG_HOST` / backend-host pattern / local-override URLs, present-but-empty `posthogKey` rejection, prod loopback `BASE_URL`/`DOCS_HOST` rejection (no silent `http://` prepend), once-guarded FATAL logging (no per-request spam).
- Brings the build-time twin in `showcase/scripts/generate-registry.ts` to parity with the runtime normalizer (scheme/trailing-slash strip, degenerate fallback, `NEXT_PUBLIC` fallback, slug validation).
- Surfaces PostHog capture failures once per failure class; keeps capture alive across the redirect via `event.waitUntil`; missing `POSTHOG_KEY` is `console.error` in production and surfaces at config-resolution time (not first redirect).
- Open-redirect hardening on `/shared//evil.com` (SU-18); `//` rejected at both source and destination; root `/` exact-source and `/:path*` wildcard sources rejected; non-printable-ASCII source/destination rejected.

Stream: SU (shell-runtime-urls). Subject groups SU-2/8/11/13/14/15/16/17/18/19/20 (initial), SU2-A/B (env-hardening), CR2-C (test infra), SU5-A1..A7 (registry/builder/lint/matcher boundary), SU6-A1..A6 (request-time normalization parity), SU6-B1..B7 (parsed-normalized return forms, SHOWCASE_LOCAL states, generator `{slug}` validation), SU7-F1..F3 (final-round backend-pattern + POSTHOG + table + script-side parity).

## Test plan

- [x] `pnpm test` in `showcase/shell` — 7 files, 235/235 pass
- [x] `pnpm test` in `showcase/scripts` — 51 files, 1857/1857 pass (one pre-existing flake in `generate-registry.test.ts` unrelated to this diff; passes on subsequent runs, classic vitest fork-reuse cross-file pollution)
- [x] `pnpm exec tsc --noEmit` in `showcase/shell` — clean
- [x] `oxlint` on every changed file — 0 warnings, 0 errors
- [x] `oxfmt --check` on every changed file — clean
- [x] `pnpm build` in `showcase/shell` (full Next 15.x build with registry+demo-content+starter-content+search-index generation) — clean
- [ ] CI green on the PR — confirm via `gh pr checks` after push