### PR TITLE
fix(runtime): recognize nested MCP Apps resource metadata

### DIFF
--- a/.changeset/nested-mcp-apps-resource-uri.md
+++ b/.changeset/nested-mcp-apps-resource-uri.md
@@ -1,0 +1,7 @@
+---
+"@copilotkit/runtime": patch
+---
+
+fix(runtime): recognize nested MCP Apps resource metadata
+
+FastMCP Prefab app tools using `_meta.ui.resourceUri` now produce MCP Apps activities with their structured tool result preserved for the iframe renderer.

--- a/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts
+++ b/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts
@@ -4,12 +4,12 @@
  */
 import { EventType, HttpAgent } from "@ag-ui/client";
 import type { BaseEvent } from "@ag-ui/client";
-import { MCPAppsMiddleware } from "@ag-ui/mcp-apps-middleware";
 import {
   CopilotKitIntelligence,
   CopilotRuntime,
   createCopilotEndpoint,
   InMemoryAgentRunner,
+  MCPAppsMiddleware,
 } from "@copilotkit/runtime/v2";
 import { concatMap, of } from "rxjs";
 import { randomUUID } from "node:crypto";

--- a/examples/integrations/mcp-apps/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/mcp-apps/app/api/copilotkit/[[...slug]]/route.ts
@@ -3,9 +3,9 @@ import {
   CopilotRuntime,
   InMemoryAgentRunner,
   createCopilotEndpoint,
+  BuiltInAgent,
+  MCPAppsMiddleware,
 } from "@copilotkit/runtime/v2";
-import { BuiltInAgent } from "@copilotkit/runtime/v2";
-import { MCPAppsMiddleware } from "@ag-ui/mcp-apps-middleware";
 import { handle } from "hono/vercel";
 
 const middlewares = [

--- a/examples/showcases/generative-ui-playground/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/showcases/generative-ui-playground/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -8,14 +8,13 @@
  * The frontend uses the `agent` prop on CopilotKitProvider to select which agent to use.
  */
 
+import { BasicAgent, MCPAppsMiddleware } from "@copilotkit/runtime/v2";
 import {
   CopilotRuntime,
   createCopilotEndpoint,
   InMemoryAgentRunner,
 } from "@copilotkit/runtime";
 import { handle } from "hono/vercel";
-import { BasicAgent } from "@copilotkit/runtime/v2";
-import { MCPAppsMiddleware } from "@ag-ui/mcp-apps-middleware";
 import { A2AAgent } from "@ag-ui/a2a";
 import { A2AClient } from "@a2a-js/sdk/client";
 

--- a/examples/showcases/mcp-apps/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/showcases/mcp-apps/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -5,14 +5,13 @@
  * Reference: v2.x/apps/react/demo/src/app/api/copilotkit-mcp/[[...slug]]/route.ts
  */
 
+import { BuiltInAgent, MCPAppsMiddleware } from "@copilotkit/runtime/v2";
 import {
   CopilotRuntime,
   createCopilotEndpoint,
   InMemoryAgentRunner,
 } from "@copilotkit/runtime";
 import { handle } from "hono/vercel";
-import { BuiltInAgent } from "@copilotkit/runtime/v2";
-import { MCPAppsMiddleware } from "@ag-ui/mcp-apps-middleware";
 
 // Determine which LLM model to use based on available API keys
 const determineModel = () => {

--- a/examples/showcases/open-mcp-client/apps/web/app/api/copilotkit/route.ts
+++ b/examples/showcases/open-mcp-client/apps/web/app/api/copilotkit/route.ts
@@ -1,12 +1,16 @@
 import {
+  BuiltInAgent,
+  defineTool,
+  getServerHash,
+  MCPAppsMiddleware,
+} from "@copilotkit/runtime/v2";
+import {
   CopilotRuntime,
   ExperimentalEmptyAdapter,
   copilotRuntimeNextJSAppRouterEndpoint,
 } from "@copilotkit/runtime";
-import { BuiltInAgent, defineTool } from "@copilotkit/runtime/v2";
 import { z } from "zod";
 import { NextRequest } from "next/server";
-import { MCPAppsMiddleware, getServerHash } from "@ag-ui/mcp-apps-middleware";
 import { map } from "rxjs/operators";
 import { E2BWorkspaceProvider } from "@/lib/workspace/e2b";
 import { getDefaultMcpServers, type McpServerConfig } from "@/lib/mcp-defaults";

--- a/examples/v2/react/demo/src/app/api/copilotkit-mcp/[[...slug]]/route.ts
+++ b/examples/v2/react/demo/src/app/api/copilotkit-mcp/[[...slug]]/route.ts
@@ -3,9 +3,9 @@ import {
   createCopilotEndpoint,
   InMemoryAgentRunner,
   BasicAgent,
+  MCPAppsMiddleware,
 } from "@copilotkit/runtime/v2";
 import { handle } from "hono/vercel";
-import { MCPAppsMiddleware } from "@ag-ui/mcp-apps-middleware";
 
 const determineModel = () => {
   if (process.env.OPENAI_API_KEY?.trim()) {

--- a/examples/v2/vue/demo/server/utils/runtime.ts
+++ b/examples/v2/vue/demo/server/utils/runtime.ts
@@ -1,8 +1,8 @@
-import { MCPAppsMiddleware } from "@ag-ui/mcp-apps-middleware";
 import {
   BasicAgent,
   CopilotRuntime,
   InMemoryAgentRunner,
+  MCPAppsMiddleware,
 } from "@copilotkit/runtime/v2";
 import { TranscriptionServiceOpenAI } from "@copilotkit/voice";
 import OpenAI from "openai";

--- a/packages/runtime/src/v2/runtime/__tests__/mcp-apps-middleware-integration.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/mcp-apps-middleware-integration.test.ts
@@ -1,20 +1,27 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import {
-  AbstractAgent,
-  RunAgentInput,
+import { AbstractAgent, EventType } from "@ag-ui/client";
+import type {
+  ActivitySnapshotEvent,
   BaseEvent,
-  EventType,
+  RunAgentInput,
 } from "@ag-ui/client";
 import { Observable } from "rxjs";
 import { LLMock, MCPMock } from "@copilotkit/aimock";
-import { MCPAppsMiddleware, getServerHash } from "@ag-ui/mcp-apps-middleware";
+import {
+  MCPAppsActivityType,
+  MCPAppsMiddleware,
+  getServerHash,
+} from "../handlers/shared/mcp-apps-middleware";
 
 /**
  * A minimal next-agent that emits RUN_STARTED and RUN_FINISHED.
  * Used as the downstream agent when the middleware should NOT delegate.
  */
 class MockNextAgent extends AbstractAgent {
+  public lastInput?: RunAgentInput;
+
   run(input: RunAgentInput): Observable<BaseEvent> {
+    this.lastInput = input;
     return new Observable((subscriber) => {
       subscriber.next({
         type: EventType.RUN_STARTED,
@@ -32,6 +39,33 @@ class MockNextAgent extends AbstractAgent {
 
   clone(): AbstractAgent {
     return new MockNextAgent();
+  }
+
+  protected connect(): ReturnType<AbstractAgent["connect"]> {
+    throw new Error("not used");
+  }
+}
+
+class StreamingNextAgent extends AbstractAgent {
+  public lastInput?: RunAgentInput;
+
+  constructor(private readonly events: BaseEvent[]) {
+    super();
+  }
+
+  run(input: RunAgentInput): Observable<BaseEvent> {
+    this.lastInput = input;
+
+    return new Observable((subscriber) => {
+      for (const event of this.events) {
+        subscriber.next(event);
+      }
+      subscriber.complete();
+    });
+  }
+
+  clone(): AbstractAgent {
+    return new StreamingNextAgent(this.events);
   }
 
   protected connect(): ReturnType<AbstractAgent["connect"]> {
@@ -71,6 +105,8 @@ describe("MCPAppsMiddleware integration", () => {
   let mcpMock: MCPMock;
 
   afterEach(async () => {
+    vi.restoreAllMocks();
+
     if (llm) {
       await llm.stop().catch(() => {});
     }
@@ -103,6 +139,47 @@ describe("MCPAppsMiddleware integration", () => {
     llm.mount("/mcp", mcpMock);
     await llm.start();
     return `${llm.url}/mcp`;
+  }
+
+  async function startMcpServerWithUiTool(metaShape: "nested" | "flat") {
+    mcpMock = new MCPMock();
+    mcpMock.addTool({
+      name: "show_prefab",
+      description: "Show prefab UI",
+      inputSchema: {
+        type: "object",
+        properties: {
+          ticket: { type: "string" },
+          severity: { type: "string" },
+        },
+        required: ["ticket", "severity"],
+      },
+      _meta:
+        metaShape === "nested"
+          ? {
+              ui: {
+                resourceUri: "ui://prefab/renderer.html",
+              },
+            }
+          : {
+              "ui/resourceUri": "ui://prefab/renderer.html",
+            },
+    });
+    mcpMock.onToolCall("show_prefab", () => `Rendered ${metaShape} prefab`);
+
+    llm = new LLMock({ port: 0 });
+    llm.mount("/mcp", mcpMock);
+    await llm.start();
+
+    return {
+      serverConfig: {
+        type: "http" as const,
+        url: `${llm.url}/mcp`,
+        serverId: `${metaShape}-server`,
+      },
+      resourceUri: "ui://prefab/renderer.html",
+      toolName: "show_prefab",
+    };
   }
 
   it("can be created with mcpServers config pointing at MCPMock URL", async () => {
@@ -271,5 +348,264 @@ describe("MCPAppsMiddleware integration", () => {
     expect(resource).toBeDefined();
     expect(resource.uri).toBe("app://dashboard");
     expect(resource.text).toContain("Dashboard content here");
+  });
+
+  it("prefers serverId over serverHash for proxied requests", async () => {
+    const mcpUrl = await startMcpServer();
+
+    const middleware = new MCPAppsMiddleware({
+      mcpServers: [
+        {
+          type: "http",
+          url: mcpUrl,
+          serverId: "stable-server",
+        },
+      ],
+    });
+
+    const input = createRunInput({
+      forwardedProps: {
+        __proxiedMCPRequest: {
+          serverId: "stable-server",
+          serverHash: "wrong-hash",
+          method: "resources/read",
+          params: { uri: "app://dashboard" },
+        },
+      },
+    });
+
+    const events = await collectEvents(
+      middleware.run(input, new MockNextAgent()),
+    );
+    const runFinished = events.find(
+      (event) => event.type === EventType.RUN_FINISHED,
+    ) as BaseEvent & { result?: unknown };
+
+    const result = runFinished.result as {
+      contents?: Array<{ uri: string; text?: string }>;
+    };
+    expect(result.contents?.[0]?.uri).toBe("app://dashboard");
+    expect(result.contents?.[0]?.text).toContain("Dashboard content here");
+  });
+
+  it("adds nested _meta.ui.resourceUri tools and emits MCP Apps activities for pending tool calls", async () => {
+    const { serverConfig, resourceUri, toolName } =
+      await startMcpServerWithUiTool("nested");
+
+    const serverHash = getServerHash(serverConfig);
+    const prefabStructuredContent = {
+      version: "1",
+      view: {
+        type: "panel",
+        children: [{ type: "text", text: "Nested UI" }],
+      },
+      state: { ticket: "BUG-5382", severity: "high" },
+      defs: { styleVars: { brand: "#111111" } },
+    };
+    const result = {
+      content: [{ type: "text", text: "Rendered nested prefab" }],
+      structuredContent: prefabStructuredContent,
+      isError: false,
+    };
+    const executeToolCall = vi
+      .spyOn(
+        MCPAppsMiddleware.prototype as unknown as {
+          executeToolCall: (
+            serverConfig: unknown,
+            name: string,
+            toolInput: Record<string, unknown>,
+          ) => Promise<unknown>;
+        },
+        "executeToolCall",
+      )
+      .mockResolvedValue(result);
+
+    const nextAgent = new StreamingNextAgent([
+      {
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+      } as BaseEvent,
+      {
+        type: EventType.RUN_FINISHED,
+        threadId: "thread-1",
+        runId: "run-1",
+      } as BaseEvent,
+    ]);
+
+    const middleware = new MCPAppsMiddleware({
+      mcpServers: [serverConfig],
+    });
+
+    const input = createRunInput({
+      messages: [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "call-1",
+              type: "function",
+              function: {
+                name: toolName,
+                arguments: JSON.stringify({
+                  ticket: "BUG-5382",
+                  severity: "high",
+                }),
+              },
+            },
+          ],
+        },
+      ] as RunAgentInput["messages"],
+    });
+
+    const events = await collectEvents(middleware.run(input, nextAgent));
+
+    expect(nextAgent.lastInput?.tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: toolName,
+          uiResourceUri: resourceUri,
+        }),
+      ]),
+    );
+
+    const snapshot = events.find(
+      (event): event is ActivitySnapshotEvent =>
+        event.type === EventType.ACTIVITY_SNAPSHOT,
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.TOOL_CALL_RESULT,
+      EventType.ACTIVITY_SNAPSHOT,
+      EventType.RUN_FINISHED,
+    ]);
+    expect(snapshot).toBeDefined();
+    expect(snapshot!.activityType).toBe(MCPAppsActivityType);
+    expect(snapshot!.content).toEqual({
+      result,
+      resourceUri,
+      serverHash,
+      serverId: serverConfig.serverId,
+      toolInput: {
+        ticket: "BUG-5382",
+        severity: "high",
+      },
+    });
+    expect(
+      (snapshot!.content as { result: { structuredContent: unknown } }).result
+        .structuredContent,
+    ).toEqual(prefabStructuredContent);
+    expect(executeToolCall).toHaveBeenCalledWith(serverConfig, toolName, {
+      ticket: "BUG-5382",
+      severity: "high",
+    });
+  });
+
+  it('keeps legacy flat _meta["ui/resourceUri"] discovery working', async () => {
+    const { serverConfig, resourceUri, toolName } =
+      await startMcpServerWithUiTool("flat");
+
+    const middleware = new MCPAppsMiddleware({
+      mcpServers: [serverConfig],
+    });
+    const flatStructuredContent = {
+      version: "1",
+      view: {
+        type: "panel",
+        children: [{ type: "text", text: "flat UI" }],
+      },
+      state: { ticket: "BUG-5382", severity: "low" },
+      defs: { styleVars: { brand: "#111111" } },
+    };
+    const result = {
+      content: [{ type: "text", text: "Rendered flat prefab" }],
+      structuredContent: flatStructuredContent,
+      isError: false,
+    };
+    const executeToolCall = vi
+      .spyOn(
+        MCPAppsMiddleware.prototype as unknown as {
+          executeToolCall: (
+            serverConfig: unknown,
+            name: string,
+            toolInput: Record<string, unknown>,
+          ) => Promise<unknown>;
+        },
+        "executeToolCall",
+      )
+      .mockResolvedValue(result);
+    const nextAgent = new StreamingNextAgent([
+      {
+        type: EventType.RUN_STARTED,
+        threadId: "thread-1",
+        runId: "run-1",
+      } as BaseEvent,
+      {
+        type: EventType.RUN_FINISHED,
+        threadId: "thread-1",
+        runId: "run-1",
+      } as BaseEvent,
+    ]);
+
+    const events = await collectEvents(
+      middleware.run(
+        createRunInput({
+          messages: [
+            {
+              id: "assistant-flat",
+              role: "assistant",
+              content: "",
+              toolCalls: [
+                {
+                  id: "call-flat",
+                  type: "function",
+                  function: {
+                    name: toolName,
+                    arguments: JSON.stringify({
+                      ticket: "BUG-5382",
+                      severity: "low",
+                    }),
+                  },
+                },
+              ],
+            },
+          ] as RunAgentInput["messages"],
+        }),
+        nextAgent,
+      ),
+    );
+
+    expect(nextAgent.lastInput?.tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: toolName,
+          uiResourceUri: resourceUri,
+        }),
+      ]),
+    );
+
+    const snapshot = events.find(
+      (event): event is ActivitySnapshotEvent =>
+        event.type === EventType.ACTIVITY_SNAPSHOT,
+    );
+    expect(snapshot).toBeDefined();
+    expect(snapshot!.activityType).toBe(MCPAppsActivityType);
+    expect(snapshot!.content).toEqual({
+      result,
+      resourceUri,
+      serverHash: getServerHash(serverConfig),
+      serverId: serverConfig.serverId,
+      toolInput: {
+        ticket: "BUG-5382",
+        severity: "low",
+      },
+    });
+    expect(executeToolCall).toHaveBeenCalledWith(serverConfig, toolName, {
+      ticket: "BUG-5382",
+      severity: "low",
+    });
   });
 });

--- a/packages/runtime/src/v2/runtime/core/runtime.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime.ts
@@ -6,14 +6,13 @@ import type {
 import {
   RUNTIME_MODE_SSE,
   RUNTIME_MODE_INTELLIGENCE,
+  resolveDebugConfig,
 } from "@copilotkit/shared";
 import { createLicenseChecker } from "@copilotkit/license-verifier";
 import type { LicenseChecker } from "@copilotkit/license-verifier";
-import { resolveDebugConfig } from "@copilotkit/shared";
-import type { ResolvedDebugConfig, DebugConfig } from "@copilotkit/shared";
 import type { AbstractAgent } from "@ag-ui/client";
-import type { MCPClientConfig } from "@ag-ui/mcp-apps-middleware";
 import type { A2UIMiddlewareConfig } from "@ag-ui/a2ui-middleware";
+import type { MCPClientConfig } from "../handlers/shared/mcp-apps-middleware";
 import pkg from "../../../../package.json";
 import type {
   BeforeRequestMiddleware,

--- a/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
@@ -1,7 +1,6 @@
 import type { AbstractAgent, RunAgentInput } from "@ag-ui/client";
 import { RunAgentInputSchema } from "@ag-ui/client";
 import { A2UIMiddleware } from "@ag-ui/a2ui-middleware";
-import { MCPAppsMiddleware } from "@ag-ui/mcp-apps-middleware";
 import { MCPMiddleware } from "@ag-ui/mcp-middleware";
 import type { CopilotRuntimeLike } from "../../core/runtime";
 import {
@@ -14,6 +13,7 @@ import { INTELLIGENCE_USER_ID_HEADER } from "../../intelligence-platform/client"
 import { extractForwardableHeaders } from "../header-utils";
 import { resolveIntelligenceUser } from "./resolve-intelligence-user";
 import { logger } from "@copilotkit/shared";
+import { MCPAppsMiddleware } from "./mcp-apps-middleware";
 
 type MiddlewareCapableAgent = AbstractAgent & {
   use?: (middleware: unknown) => void;

--- a/packages/runtime/src/v2/runtime/handlers/shared/mcp-apps-middleware.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/mcp-apps-middleware.ts
@@ -1,0 +1,556 @@
+import { EventType, Middleware } from "@ag-ui/client";
+import type {
+  AbstractAgent,
+  ActivitySnapshotEvent,
+  BaseEvent,
+  Message,
+  RunAgentInput,
+  RunFinishedEvent,
+  RunStartedEvent,
+  Tool,
+  ToolCallResultEvent,
+} from "@ag-ui/client";
+import { createHash, randomUUID } from "node:crypto";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Observable } from "rxjs";
+import type { Subscriber } from "rxjs";
+
+export const MCPAppsActivityType = "mcp-apps";
+
+export interface ProxiedMCPRequest {
+  serverHash: string;
+  serverId?: string;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+type ExtractObservableType<T> = T extends Observable<infer U> ? U : never;
+type RunNextWithStateReturn = ReturnType<Middleware["runNextWithState"]>;
+type EventWithState = ExtractObservableType<RunNextWithStateReturn>;
+
+export interface MCPClientConfigHTTP {
+  type: "http";
+  url: string;
+  serverId?: string;
+}
+
+export interface MCPClientConfigSSE {
+  type: "sse";
+  url: string;
+  headers?: Record<string, string>;
+  serverId?: string;
+}
+
+export type MCPClientConfig = MCPClientConfigHTTP | MCPClientConfigSSE;
+
+export function getServerHash(config: MCPClientConfig): string {
+  const raw = JSON.stringify({
+    type: config.type,
+    url: config.url,
+    headers: config.type === "sse" ? config.headers : undefined,
+  });
+  return createHash("md5").update(raw).digest("hex");
+}
+
+export interface MCPAppsMiddlewareConfig {
+  mcpServers?: MCPClientConfig[];
+}
+
+export interface MCPAppTool extends Tool {
+  uiResourceUri?: string;
+}
+
+interface UIToolInfo {
+  resourceUri: string;
+  serverConfig: MCPClientConfig;
+  serverHash: string;
+  tool: MCPAppTool;
+}
+
+type PendingToolCall = NonNullable<
+  Extract<Message, { role: "assistant" }>["toolCalls"]
+>[number];
+
+function getUIResourceUri(meta: unknown): string | undefined {
+  if (!meta || typeof meta !== "object") {
+    return undefined;
+  }
+
+  const metaRecord = meta as Record<string, unknown>;
+  const nestedMeta = metaRecord.ui;
+  if (
+    nestedMeta &&
+    typeof nestedMeta === "object" &&
+    typeof (nestedMeta as Record<string, unknown>).resourceUri === "string"
+  ) {
+    return (nestedMeta as Record<string, string>).resourceUri;
+  }
+
+  const flatResourceUri = metaRecord["ui/resourceUri"];
+  return typeof flatResourceUri === "string" ? flatResourceUri : undefined;
+}
+
+export class MCPAppsMiddleware extends Middleware {
+  private readonly config: MCPAppsMiddlewareConfig;
+  private readonly serverConfigMapByHash = new Map<string, MCPClientConfig>();
+  private readonly serverConfigMapById = new Map<string, MCPClientConfig>();
+
+  constructor(config: MCPAppsMiddlewareConfig = {}) {
+    super();
+    this.config = config;
+
+    for (const serverConfig of config.mcpServers ?? []) {
+      this.serverConfigMapByHash.set(getServerHash(serverConfig), serverConfig);
+      if (serverConfig.serverId) {
+        this.serverConfigMapById.set(serverConfig.serverId, serverConfig);
+      }
+    }
+  }
+
+  run(input: RunAgentInput, next: AbstractAgent): Observable<BaseEvent> {
+    const proxiedRequest = input.forwardedProps?.__proxiedMCPRequest as
+      | ProxiedMCPRequest
+      | undefined;
+
+    if (proxiedRequest) {
+      return this.handleProxiedMCPRequest(input, proxiedRequest);
+    }
+
+    return new Observable<BaseEvent>((subscriber) => {
+      let innerSubscription:
+        | ReturnType<Observable<BaseEvent>["subscribe"]>
+        | undefined;
+      let cancelled = false;
+
+      void (async () => {
+        try {
+          const { nextInput, uiToolsByName } = await this.prepareInput(input);
+          if (cancelled) {
+            return;
+          }
+
+          innerSubscription = this.processStream(
+            this.runNextWithState(nextInput, next),
+            uiToolsByName,
+          ).subscribe(subscriber);
+        } catch (error) {
+          subscriber.error(error);
+        }
+      })();
+
+      return () => {
+        cancelled = true;
+        innerSubscription?.unsubscribe();
+      };
+    });
+  }
+
+  private handleProxiedMCPRequest(
+    input: RunAgentInput,
+    proxiedRequest: ProxiedMCPRequest,
+  ): Observable<BaseEvent> {
+    return new Observable<BaseEvent>((subscriber) => {
+      const started: RunStartedEvent = {
+        type: EventType.RUN_STARTED,
+        threadId: input.threadId,
+        runId: input.runId,
+      };
+      subscriber.next(started);
+
+      const serverConfig =
+        (proxiedRequest.serverId
+          ? this.serverConfigMapById.get(proxiedRequest.serverId)
+          : undefined) ??
+        this.serverConfigMapByHash.get(proxiedRequest.serverHash);
+
+      if (!serverConfig) {
+        const finished: RunFinishedEvent = {
+          type: EventType.RUN_FINISHED,
+          threadId: input.threadId,
+          runId: input.runId,
+          result: {
+            error: `Unknown MCP server: ${proxiedRequest.serverId || proxiedRequest.serverHash}`,
+          },
+        };
+        subscriber.next(finished);
+        subscriber.complete();
+        return;
+      }
+
+      void this.executeMCPRequest(
+        serverConfig,
+        proxiedRequest.method,
+        proxiedRequest.params,
+      )
+        .then((result) => {
+          const finished: RunFinishedEvent = {
+            type: EventType.RUN_FINISHED,
+            threadId: input.threadId,
+            runId: input.runId,
+            result,
+          };
+          subscriber.next(finished);
+          subscriber.complete();
+        })
+        .catch((error) => {
+          const finished: RunFinishedEvent = {
+            type: EventType.RUN_FINISHED,
+            threadId: input.threadId,
+            runId: input.runId,
+            result: {
+              error: error instanceof Error ? error.message : String(error),
+            },
+          };
+          subscriber.next(finished);
+          subscriber.complete();
+        });
+    });
+  }
+
+  private async executeMCPRequest(
+    serverConfig: MCPClientConfig,
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<unknown> {
+    const transport = this.createTransport(serverConfig);
+
+    const client = new Client(
+      { name: "mcp-apps-middleware", version: "1.0.0" },
+      {
+        capabilities: {
+          extensions: {
+            "io.modelcontextprotocol/ui": {
+              mimeTypes: ["text/html+mcp"],
+            },
+          },
+        },
+      },
+    );
+
+    try {
+      await client.connect(transport);
+
+      switch (method) {
+        case "tools/call":
+          return await client.callTool(
+            params as { name: string; arguments?: Record<string, unknown> },
+          );
+        case "resources/read":
+          return await client.readResource(params as { uri: string });
+        case "notifications/message":
+          await client.notification({
+            method: "notifications/message",
+            params,
+          });
+          return { success: true };
+        case "ping":
+          return await client.ping();
+        default:
+          throw new Error(`MCP method not allowed for UI proxy: ${method}`);
+      }
+    } finally {
+      await client.close();
+    }
+  }
+
+  private processStream(
+    source: Observable<EventWithState>,
+    uiToolsByName: Map<string, UIToolInfo>,
+  ): Observable<BaseEvent> {
+    return new Observable<BaseEvent>((subscriber) => {
+      let heldRunFinished: EventWithState | null = null;
+
+      const subscription = source.subscribe({
+        next: (eventWithState) => {
+          const event = eventWithState.event;
+
+          if (heldRunFinished) {
+            subscriber.next(heldRunFinished.event);
+            heldRunFinished = null;
+          }
+
+          if (event.type === EventType.RUN_FINISHED) {
+            heldRunFinished = eventWithState;
+            return;
+          }
+
+          subscriber.next(event);
+        },
+        error: (error) => {
+          if (heldRunFinished) {
+            subscriber.next(heldRunFinished.event);
+            heldRunFinished = null;
+          }
+          subscriber.error(error);
+        },
+        complete: () => {
+          void (async () => {
+            try {
+              if (heldRunFinished) {
+                await this.executePendingUIToolCalls(
+                  heldRunFinished.messages,
+                  uiToolsByName,
+                  subscriber,
+                );
+                subscriber.next(heldRunFinished.event);
+                heldRunFinished = null;
+              }
+              subscriber.complete();
+            } catch (error) {
+              subscriber.error(error);
+            }
+          })();
+        },
+      });
+
+      return () => subscription.unsubscribe();
+    });
+  }
+
+  private async executePendingUIToolCalls(
+    messages: Message[],
+    uiToolsByName: Map<string, UIToolInfo>,
+    subscriber: Subscriber<BaseEvent>,
+  ): Promise<void> {
+    const pendingToolCalls = this.findPendingToolCalls(messages);
+
+    for (const pendingToolCall of pendingToolCalls) {
+      const uiTool = uiToolsByName.get(pendingToolCall.function.name);
+      if (!uiTool) {
+        continue;
+      }
+
+      try {
+        const toolInput = this.parseToolInput(
+          pendingToolCall.function.arguments,
+        );
+        const result = await this.executeToolCall(
+          uiTool.serverConfig,
+          pendingToolCall.function.name,
+          toolInput,
+        );
+
+        const toolCallResult: ToolCallResultEvent = {
+          type: EventType.TOOL_CALL_RESULT,
+          messageId: randomUUID(),
+          toolCallId: pendingToolCall.id,
+          content: this.extractTextContent(
+            (result as { content?: unknown }).content,
+          ),
+        };
+        subscriber.next(toolCallResult);
+
+        const activitySnapshot: ActivitySnapshotEvent = {
+          type: EventType.ACTIVITY_SNAPSHOT,
+          messageId: randomUUID(),
+          activityType: MCPAppsActivityType,
+          content: {
+            result,
+            resourceUri: uiTool.resourceUri,
+            serverHash: uiTool.serverHash,
+            serverId: uiTool.serverConfig.serverId,
+            toolInput,
+          },
+          replace: true,
+        };
+        subscriber.next(activitySnapshot);
+      } catch (error) {
+        console.error(
+          `Failed to execute UI tool call ${pendingToolCall.function.name}:`,
+          error,
+        );
+        const toolCallResult: ToolCallResultEvent = {
+          type: EventType.TOOL_CALL_RESULT,
+          messageId: randomUUID(),
+          toolCallId: pendingToolCall.id,
+          content: JSON.stringify({ error: String(error) }),
+        };
+        subscriber.next(toolCallResult);
+      }
+    }
+  }
+
+  private async executeToolCall(
+    serverConfig: MCPClientConfig,
+    name: string,
+    toolInput: Record<string, unknown>,
+  ): Promise<unknown> {
+    return await this.executeMCPRequest(serverConfig, "tools/call", {
+      name,
+      arguments: toolInput,
+    });
+  }
+
+  private parseToolInput(toolArgs?: string): Record<string, unknown> {
+    if (!toolArgs) {
+      return {};
+    }
+
+    try {
+      const parsed = JSON.parse(toolArgs);
+      return parsed && typeof parsed === "object"
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+
+  private extractTextContent(content: unknown): string {
+    if (typeof content === "string") {
+      return content;
+    }
+
+    if (Array.isArray(content)) {
+      const textParts = content
+        .map((part) => {
+          if (
+            part &&
+            typeof part === "object" &&
+            (part as Record<string, unknown>).type === "text" &&
+            typeof (part as Record<string, unknown>).text === "string"
+          ) {
+            return (part as Record<string, string>).text;
+          }
+          return undefined;
+        })
+        .filter((part): part is string => Boolean(part));
+
+      if (textParts.length > 0) {
+        return textParts.join("\n");
+      }
+    }
+
+    try {
+      return JSON.stringify(content);
+    } catch {
+      return String(content);
+    }
+  }
+
+  private findPendingToolCalls(messages: Message[]) {
+    const pendingToolCalls = new Map<string, PendingToolCall>();
+    const completedToolCallIds = new Set<string>();
+
+    for (const message of messages) {
+      if (message.role === "assistant" && message.toolCalls) {
+        for (const toolCall of message.toolCalls) {
+          pendingToolCalls.set(toolCall.id, toolCall);
+        }
+      }
+
+      if (message.role === "tool" && message.toolCallId) {
+        completedToolCallIds.add(message.toolCallId);
+      }
+    }
+
+    for (const toolCallId of completedToolCallIds) {
+      pendingToolCalls.delete(toolCallId);
+    }
+
+    return Array.from(pendingToolCalls.values());
+  }
+
+  private async prepareInput(input: RunAgentInput) {
+    const uiTools = await this.fetchUITools();
+    const uiToolsByName = new Map<string, UIToolInfo>();
+    for (const uiTool of uiTools) {
+      uiToolsByName.set(uiTool.tool.name, uiTool);
+    }
+
+    return {
+      nextInput: {
+        ...input,
+        tools: [...input.tools, ...uiTools.map((uiTool) => uiTool.tool)],
+      },
+      uiToolsByName,
+    };
+  }
+
+  private async fetchUITools(): Promise<UIToolInfo[]> {
+    const uiTools: UIToolInfo[] = [];
+
+    for (const serverConfig of this.config.mcpServers ?? []) {
+      try {
+        const tools = await this.fetchToolsFromServer(serverConfig);
+        uiTools.push(...tools);
+      } catch (error) {
+        console.error(
+          `Failed to fetch tools from MCP server ${serverConfig.url}:`,
+          error,
+        );
+      }
+    }
+
+    return uiTools;
+  }
+
+  private async fetchToolsFromServer(
+    serverConfig: MCPClientConfig,
+  ): Promise<UIToolInfo[]> {
+    const transport = this.createTransport(serverConfig);
+
+    const client = new Client(
+      { name: "mcp-apps-middleware", version: "1.0.0" },
+      {
+        capabilities: {
+          extensions: {
+            "io.modelcontextprotocol/ui": {
+              mimeTypes: ["text/html+mcp"],
+            },
+          },
+        },
+      },
+    );
+
+    try {
+      await client.connect(transport);
+      const { tools } = await client.listTools();
+
+      return tools
+        .map((tool) => {
+          const resourceUri = getUIResourceUri(tool._meta);
+          if (!resourceUri) {
+            return undefined;
+          }
+
+          const toolDefinition: MCPAppTool = {
+            name: tool.name,
+            description: tool.description ?? "",
+            parameters: tool.inputSchema ?? {
+              type: "object",
+              properties: {},
+            },
+            uiResourceUri: resourceUri,
+          };
+
+          return {
+            tool: toolDefinition,
+            serverConfig,
+            resourceUri,
+            serverHash: getServerHash(serverConfig),
+          };
+        })
+        .filter((tool): tool is UIToolInfo => Boolean(tool));
+    } finally {
+      await client.close();
+    }
+  }
+
+  private createTransport(serverConfig: MCPClientConfig) {
+    if (serverConfig.type === "sse") {
+      const init = serverConfig.headers
+        ? { headers: serverConfig.headers }
+        : undefined;
+
+      return new SSEClientTransport(new URL(serverConfig.url), {
+        eventSourceInit: init,
+        requestInit: init,
+      });
+    }
+
+    return new StreamableHTTPClientTransport(new URL(serverConfig.url));
+  }
+}

--- a/packages/runtime/src/v2/runtime/index.ts
+++ b/packages/runtime/src/v2/runtime/index.ts
@@ -24,6 +24,15 @@ export {
 // into `mcpClients`; `MCPTransport` is the contract for custom transports.
 export type { MCPClient, MCPTransport } from "@ai-sdk/mcp";
 
+export {
+  MCPAppsMiddleware,
+  getServerHash,
+  type MCPAppsMiddlewareConfig,
+  type MCPClientConfig,
+  type MCPClientConfigHTTP,
+  type MCPClientConfigSSE,
+} from "./handlers/shared/mcp-apps-middleware";
+
 // Export framework-agnostic fetch handler
 export { createCopilotRuntimeHandler } from "./core/fetch-handler";
 export type {


### PR DESCRIPTION
## Summary
- Adds support for the nested `_meta.ui.resourceUri` shape used by FastMCP Prefab app tools, alongside the existing flat `_meta["ui/resourceUri"]` key
- Inlines `MCPAppsMiddleware` into the runtime package so the resource-URI extraction logic (`getUIResourceUri`) can be patched without waiting for an upstream `@ag-ui/mcp-apps-middleware` release
- Pending UI tool calls now produce `TOOL_CALL_RESULT` + `ACTIVITY_SNAPSHOT` events with the full `structuredContent` preserved for the iframe renderer

Closes #5382

## Test plan
- [x] `npx nx run @copilotkit/runtime-client-gql:graphql-codegen`
- [x] `pnpm exec oxlint packages/runtime/src/v2/runtime/core/runtime.ts packages/runtime/src/v2/runtime/handlers/shared/mcp-apps-middleware.ts packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts packages/runtime/src/v2/runtime/__tests__/mcp-apps-middleware-integration.test.ts`
- [x] `pnpm -C packages/runtime exec vitest run src/v2/runtime/__tests__/mcp-apps-middleware-integration.test.ts`
- [x] `pnpm run build`
- [ ] Manual: connect a FastMCP `prefab-ui` server and verify the form renders in the CopilotKit chat