### PR TITLE
fix(showcase/claude-sdk-python): hitl hook import fix + gen-ui-interrupt testid backfill

### DIFF
--- a/showcase/integrations/claude-sdk-python/src/app/demos/gen-ui-interrupt/time-picker-card.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/gen-ui-interrupt/time-picker-card.tsx
@@ -92,6 +92,7 @@ export function TimePickerCard({
       </div>
       <button
         disabled={disabled}
+        data-testid="time-picker-cancel"
         onClick={() => {
           setCancelled(true);
           onSubmit({ cancelled: true });

--- a/showcase/integrations/claude-sdk-python/src/app/demos/hitl/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/hitl/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import React, { useState } from "react";
-import { CopilotKit, useLangGraphInterrupt } from "@copilotkit/react-core";
+import { CopilotKit } from "@copilotkit/react-core";
 import {
   CopilotChat,
   useHumanInTheLoop,
+  useInterrupt,
   useConfigureSuggestions,
 } from "@copilotkit/react-core/v2";
 import { z } from "zod";
@@ -37,7 +38,7 @@ function DemoContent() {
     available: "always",
   });
 
-  useLangGraphInterrupt({
+  useInterrupt({
     render: ({ event, resolve }) => (
       <StepSelector
         steps={event.value?.steps || []}


### PR DESCRIPTION
## Summary

Two surgical fixes against the `claude-sdk-python` showcase integration, scoped to `showcase/integrations/claude-sdk-python/src/`:

1. **`hitl/page.tsx` — wrong framework hook**: replace `useLangGraphInterrupt` (LangGraph-specific, from `@copilotkit/react-core`) with `useInterrupt` (framework-agnostic CopilotKit v2 hook, from `@copilotkit/react-core/v2`). Matches the canonical LGP `hitl/page.tsx` pattern and is the correct surface for non-LangGraph backends.
2. **`gen-ui-interrupt/time-picker-card.tsx` — testid backfill**: add `data-testid=\"time-picker-cancel\"` to the existing \"None of these work\" cancel button so the canonical LGP testid is now emitted. Pure attribute add, no behavior change.

## STOP-and-surface: remaining audit gaps are NOT pure testid-add

The audit at `/tmp/cr/audit/claude-sdk-python.md` lists ~12 demos with missing canon testids (largest: `tool-rendering` with 14). On inspection, the vast majority of those gaps are **missing features / missing components**, not missing `data-testid` attributes on already-rendered JSX:

- `tool-rendering` (14 missing): canon emits testids on `custom-catchall`, `d20`, `flights`, `stock` renderers — claude-sdk-python's tool-rendering demo only ships the weather card. Adding the testids would require adding the missing renderers (behavior change).
- `headless-simple` / `headless-complete`: missing `headless-composer`, `headless-message-*` ids — corresponding components don't exist in claude variant.
- `declarative-gen-ui` (5): canon emits testids from a2ui renderer overrides for `declarative-card`, `declarative-bar-chart`, etc. — claude has no matching renderer overrides.
- `a2ui-fixed-schema` (1): canon emits `a2ui-fixed-card` from a `Card` renderer override; claude omits the Card override entirely.
- `auth` (4): canon has a sign-in card flow with `auth-sign-in-card`, `auth-sign-in-button`, `auth-demo-token`, `auth-demo-error-message` — claude variant uses a banner-only flow.
- `chat-slots` (2): canon emits `custom-welcome-message` + `custom-feather` from separate slot components; claude doesn't ship them.
- `readonly-state-agent-context` (3): canon emits `identity-*` testids from an identity card section; claude doesn't render one.
- `subagents` (5+), `tool-rendering-default-catchall` (5), `multimodal` (1 built-in): same pattern — missing JSX.

Per the task brief (\"Do NOT change behavior — testid only\" / \"If any test fails or any demo's correct testid set is unclear: STOP and surface\"), these are all out of scope for a testid-only PR. They are feature-parity tasks that belong in a separate effort scoped against the claude-sdk-python backend capabilities.

## Test plan
- [x] Branch verified pre/post each commit (`fix/claude-sdk-python-testid-backfill`)
- [x] Typecheck delta: no new errors introduced (all pre-existing TS errors stem from upstream module resolution / e2e Playwright types — confirmed by baseline tsc against HEAD~2)
- [x] No vitest test files exercise the touched demos directly; e2e specs reference these testids and will pick up `time-picker-cancel` going forward
- [x] Formatter run (`oxfmt --write`) on both files
- [ ] Reviewer: confirm the STOP-and-surface scope is acceptable; if a follow-up is wanted for the structural backfill, file separately