### PR TITLE
fix: update cpk to use latest agui core packages

### DIFF
--- a/packages/agentcore-runner/package.json
+++ b/packages/agentcore-runner/package.json
@@ -31,7 +31,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.56",
+    "@ag-ui/client": "0.0.57",
     "@copilotkit/runtime": "workspace:*",
     "rxjs": "7.8.1"
   },

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -33,8 +33,8 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.56",
-    "@ag-ui/core": "0.0.56",
+    "@ag-ui/client": "0.0.57",
+    "@ag-ui/core": "0.0.57",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/shared": "workspace:*",
     "clsx": "^2.1.1",

--- a/packages/bot-slack/package.json
+++ b/packages/bot-slack/package.json
@@ -43,8 +43,8 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.53",
-    "@ag-ui/core": "0.0.53",
+    "@ag-ui/client": "0.0.57",
+    "@ag-ui/core": "0.0.57",
     "@copilotkit/bot": "workspace:~",
     "@copilotkit/bot-ui": "workspace:~",
     "@copilotkit/core": "workspace:^",

--- a/packages/bot-slack/src/sanitizing-http-agent.ts
+++ b/packages/bot-slack/src/sanitizing-http-agent.ts
@@ -35,7 +35,7 @@ export class SanitizingHttpAgent extends HttpAgent {
 
   run(input: RunAgentInput): Observable<BaseEvent> {
     return parseSSEStream(
-      runHttpRequest(this.url, this.requestInit(input)),
+      runHttpRequest(() => this.fetch(this.url, this.requestInit(input))),
       this.debugLogger,
     ).pipe(map((event: unknown) => coerceNullStrings(event) as BaseEvent));
   }

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -43,8 +43,8 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.53",
-    "@ag-ui/core": "0.0.53",
+    "@ag-ui/client": "0.0.57",
+    "@ag-ui/core": "0.0.57",
     "@copilotkit/bot-ui": "workspace:~",
     "@copilotkit/core": "workspace:^",
     "@copilotkit/shared": "workspace:^",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.56",
+    "@ag-ui/client": "0.0.57",
     "@copilotkit/shared": "workspace:*",
     "@tanstack/pacer": "^0.20.1",
     "phoenix": "^1.8.4",

--- a/packages/demo-agents/package.json
+++ b/packages/demo-agents/package.json
@@ -24,7 +24,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.56",
+    "@ag-ui/client": "0.0.57",
     "openai": "^4.85.1",
     "rxjs": "^7.8.1"
   },

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -74,8 +74,8 @@
     "attw": "attw --pack . --profile node16 --ignore-rules internal-resolution-error"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.56",
-    "@ag-ui/core": "0.0.56",
+    "@ag-ui/client": "0.0.57",
+    "@ag-ui/core": "0.0.57",
     "@copilotkit/a2ui-renderer": "workspace:*",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/runtime-client-gql": "workspace:*",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -74,7 +74,7 @@
     "unlink:global": "pnpm unlink --global"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.56",
+    "@ag-ui/client": "0.0.57",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/react-core": "workspace:*",
     "@copilotkit/shared": "workspace:*",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -78,9 +78,9 @@
   },
   "dependencies": {
     "@ag-ui/a2ui-middleware": "0.0.8",
-    "@ag-ui/client": "0.0.56",
-    "@ag-ui/core": "0.0.56",
-    "@ag-ui/encoder": "0.0.56",
+    "@ag-ui/client": "0.0.57",
+    "@ag-ui/core": "0.0.57",
+    "@ag-ui/encoder": "0.0.57",
     "@ag-ui/langgraph": "0.0.41",
     "@ag-ui/mcp-apps-middleware": "0.0.3",
     "@ag-ui/mcp-middleware": "0.0.1",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -50,7 +50,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.56",
+    "@ag-ui/client": "0.0.57",
     "@copilotkit/license-verifier": "~0.4.2",
     "@segment/analytics-node": "^2.1.2",
     "@standard-schema/spec": "^1.0.0",

--- a/packages/sqlite-runner/package.json
+++ b/packages/sqlite-runner/package.json
@@ -31,7 +31,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.56",
+    "@ag-ui/client": "0.0.57",
     "@copilotkit/runtime": "workspace:*",
     "rxjs": "7.8.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -78,8 +78,8 @@
   },
   "dependencies": {
     "@a2ui/web_core": "0.9.0",
-    "@ag-ui/client": "0.0.56",
-    "@ag-ui/core": "0.0.56",
+    "@ag-ui/client": "0.0.57",
+    "@ag-ui/core": "0.0.57",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/shared": "workspace:*",
     "@copilotkit/web-inspector": "workspace:*",

--- a/packages/web-inspector/package.json
+++ b/packages/web-inspector/package.json
@@ -34,7 +34,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.56",
+    "@ag-ui/client": "0.0.57",
     "@copilotkit/core": "workspace:*",
     "lit": "^3.2.0",
     "lucide": "^0.525.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,7 +312,7 @@ importers:
         version: 0.8.3(signal-polyfill@0.2.2)
       '@ag-ui/a2a':
         specifier: ^0.0.6
-        version: 0.0.6(@ag-ui/client@0.0.42)(@ag-ui/core@0.0.56)
+        version: 0.0.6(@ag-ui/client@0.0.42)(@ag-ui/core@0.0.57)
       '@ag-ui/a2a-middleware':
         specifier: ^0.0.2
         version: 0.0.2(rxjs@7.8.1)
@@ -391,7 +391,7 @@ importers:
         version: 0.0.1(@types/express@5.0.6)(encoding@0.1.13)
       '@copilotkit/bot-ui':
         specifier: ~0.0.1
-        version: 0.0.1(@ag-ui/core@0.0.56)(encoding@0.1.13)
+        version: 0.0.1(@ag-ui/core@0.0.57)(encoding@0.1.13)
       '@copilotkit/runtime':
         specifier: ^1.59.5
         version: 1.59.5(4c17f358ce8005944aeca87c7a73a8ac)
@@ -1920,7 +1920,7 @@ importers:
         version: 0.0.52
       '@ag-ui/mcp-apps-middleware':
         specifier: 0.0.2
-        version: 0.0.2(@ag-ui/client@0.0.56)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
+        version: 0.0.2(@ag-ui/client@0.0.57)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../../../../packages/core
@@ -2078,8 +2078,8 @@ importers:
   packages/agentcore-runner:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.56
-        version: 0.0.56
+        specifier: 0.0.57
+        version: 0.0.57
       '@copilotkit/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -2106,11 +2106,11 @@ importers:
   packages/angular:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.56
-        version: 0.0.56
+        specifier: 0.0.57
+        version: 0.0.57
       '@ag-ui/core':
-        specifier: 0.0.56
-        version: 0.0.56
+        specifier: 0.0.57
+        version: 0.0.57
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -2239,11 +2239,11 @@ importers:
   packages/bot:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.57
+        version: 0.0.57
       '@ag-ui/core':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.57
+        version: 0.0.57
       '@copilotkit/bot-ui':
         specifier: workspace:~
         version: link:../bot-ui
@@ -2276,11 +2276,11 @@ importers:
   packages/bot-slack:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.57
+        version: 0.0.57
       '@ag-ui/core':
-        specifier: 0.0.53
-        version: 0.0.53
+        specifier: 0.0.57
+        version: 0.0.57
       '@copilotkit/bot':
         specifier: workspace:~
         version: link:../bot
@@ -2347,8 +2347,8 @@ importers:
   packages/core:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.56
-        version: 0.0.56
+        specifier: 0.0.57
+        version: 0.0.57
       '@copilotkit/shared':
         specifier: workspace:*
         version: link:../shared
@@ -2399,8 +2399,8 @@ importers:
   packages/demo-agents:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.56
-        version: 0.0.56
+        specifier: 0.0.57
+        version: 0.0.57
       openai:
         specifier: ^4.85.1
         version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
@@ -2427,11 +2427,11 @@ importers:
   packages/react-core:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.56
-        version: 0.0.56
+        specifier: 0.0.57
+        version: 0.0.57
       '@ag-ui/core':
-        specifier: 0.0.56
-        version: 0.0.56
+        specifier: 0.0.57
+        version: 0.0.57
       '@copilotkit/a2ui-renderer':
         specifier: workspace:*
         version: link:../a2ui-renderer
@@ -2593,8 +2593,8 @@ importers:
   packages/react-native:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.56
-        version: 0.0.56
+        specifier: 0.0.57
+        version: 0.0.57
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -2843,22 +2843,22 @@ importers:
     dependencies:
       '@ag-ui/a2ui-middleware':
         specifier: 0.0.8
-        version: 0.0.8(@ag-ui/client@0.0.56)(rxjs@7.8.1)
+        version: 0.0.8(@ag-ui/client@0.0.57)(rxjs@7.8.1)
       '@ag-ui/client':
-        specifier: 0.0.56
-        version: 0.0.56
+        specifier: 0.0.57
+        version: 0.0.57
       '@ag-ui/core':
-        specifier: 0.0.56
-        version: 0.0.56
+        specifier: 0.0.57
+        version: 0.0.57
       '@ag-ui/encoder':
-        specifier: 0.0.56
-        version: 0.0.56
+        specifier: 0.0.57
+        version: 0.0.57
       '@ag-ui/langgraph':
         specifier: 0.0.41
-        version: 0.0.41(@ag-ui/client@0.0.56)(@ag-ui/core@0.0.56)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+        version: 0.0.41(@ag-ui/client@0.0.57)(@ag-ui/core@0.0.57)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@ag-ui/mcp-apps-middleware':
         specifier: 0.0.3
-        version: 0.0.3(@ag-ui/client@0.0.56)(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+        version: 0.0.3(@ag-ui/client@0.0.57)(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@ag-ui/mcp-middleware':
         specifier: 0.0.1
         version: 0.0.1(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
@@ -3130,7 +3130,7 @@ importers:
     dependencies:
       '@ag-ui/langgraph':
         specifier: 0.0.41
-        version: 0.0.41(@ag-ui/client@0.0.56)(@ag-ui/core@0.0.56)(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
+        version: 0.0.41(@ag-ui/client@0.0.57)(@ag-ui/core@0.0.57)(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@copilotkit/shared':
         specifier: workspace:*
         version: link:../shared
@@ -3184,8 +3184,8 @@ importers:
   packages/shared:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.56
-        version: 0.0.56
+        specifier: 0.0.57
+        version: 0.0.57
       '@ag-ui/core':
         specifier: '>=0.0.48'
         version: 0.0.51
@@ -3248,8 +3248,8 @@ importers:
   packages/sqlite-runner:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.56
-        version: 0.0.56
+        specifier: 0.0.57
+        version: 0.0.57
       '@copilotkit/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -3320,11 +3320,11 @@ importers:
         specifier: 0.9.0
         version: 0.9.0
       '@ag-ui/client':
-        specifier: 0.0.56
-        version: 0.0.56
+        specifier: 0.0.57
+        version: 0.0.57
       '@ag-ui/core':
-        specifier: 0.0.56
-        version: 0.0.56
+        specifier: 0.0.57
+        version: 0.0.57
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -3444,8 +3444,8 @@ importers:
   packages/web-inspector:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.56
-        version: 0.0.56
+        specifier: 0.0.57
+        version: 0.0.57
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -3683,8 +3683,8 @@ packages:
   '@ag-ui/client@0.0.53':
     resolution: {integrity: sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==}
 
-  '@ag-ui/client@0.0.56':
-    resolution: {integrity: sha512-dxen4qVnDQB1xC9x1nND9W/plidoy0qwDarUPuasHCrtlkMl1EUlc+rNJM7Lr1NtnRmGHHX8gHrSeUXP3vPVHA==}
+  '@ag-ui/client@0.0.57':
+    resolution: {integrity: sha512-Xap2alG9Z0/j5kb3x4D7oTpe2sw1dfrC9rgJJr2NZu5vKcm8dzIPNd31mF2B4zS3BKqYIu245yxKPhEtT30MHw==}
 
   '@ag-ui/core@0.0.36':
     resolution: {integrity: sha512-uYUrzw6uxuw4qVQ61mdSeiG0mFh2n/VAWmWsWzwETDuhqJZT7rFmd07IajcFWcyItMr1wjqxFDdlklucAyEYNA==}
@@ -3704,8 +3704,8 @@ packages:
   '@ag-ui/core@0.0.53':
     resolution: {integrity: sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ==}
 
-  '@ag-ui/core@0.0.56':
-    resolution: {integrity: sha512-PD26s7qk8dG6/TOGmOv23ByTaGwJs2Wzm53OwsM40jSjio3xmswGZzDaFpjMNP6FsASNGovCPB8xICAyWhYx8A==}
+  '@ag-ui/core@0.0.57':
+    resolution: {integrity: sha512-gho1OWjNE6E3Rl7ZEZ1wr2CEpUHjLFU0FqzCZZk439TicLu+BfLCMkMokB07bMGlRmbJ60hM6LW60iOVauCx+Q==}
 
   '@ag-ui/encoder@0.0.36':
     resolution: {integrity: sha512-p8UNh6a77G/oe/4EZmwkTeYCN/5SnqSY2Cz8f8psZpk4LKzzrPkRNykrUAIBsi1wMp50/VQiM27oTRaade/Qkw==}
@@ -3719,8 +3719,8 @@ packages:
   '@ag-ui/encoder@0.0.53':
     resolution: {integrity: sha512-bAOcfVdm6U4H6G6tW+DZfwPEQm1w/snVBTwaFn9nJcEMW69M7/HZuwvEc/7Zo0rK1jRL32N/j60PwTAeky19fw==}
 
-  '@ag-ui/encoder@0.0.56':
-    resolution: {integrity: sha512-JkR7OGby8hBUOOlrvli0bArM5qvfCoavj3ajUp8324n20wYMrfN+/TR3GUm7wW1japrV+2dS7JEVX5dylrPF1A==}
+  '@ag-ui/encoder@0.0.57':
+    resolution: {integrity: sha512-ifD9NctR4xyPDR58xF9GK1bj/S8oECFkTeDfuYD8tXdbcOstIJ2TOqU2zhiCKnw7Vw+zR9Qv3TbsM9E7Gi9X3Q==}
 
   '@ag-ui/langgraph@0.0.11':
     resolution: {integrity: sha512-3xUkaOelnpQ5tbsbuoOTin71tTgWEN0GDZBjGs/7xAwly2Dn4fahbBAoscXullO/pH9kTGGgbuJ0rWDUgo6fKQ==}
@@ -3771,8 +3771,8 @@ packages:
   '@ag-ui/proto@0.0.53':
     resolution: {integrity: sha512-swjz22xWT8YUZt5OhmUwkARDQdwt8XM1hmGZbQrhRnNPXKwrKJX9ELlbnQ4iFUQIKkMWpphzE3vA3yNKs2bbKw==}
 
-  '@ag-ui/proto@0.0.56':
-    resolution: {integrity: sha512-D72l/Xa3vHRBJtlxa+gG3VcycrEwDCHwCTh8BGkyrnRdraYPFl92eeWSV0tnF9+i7xLyNqCdww+NgCoPlrdhZQ==}
+  '@ag-ui/proto@0.0.57':
+    resolution: {integrity: sha512-pPENOZt0P6ibH8sCTgq05wLYXi5t3P9B5r/1bWYehXjUxtyOdnukSlWM++SsCIwUXsQdm/b3aBgGjEeTF7RenA==}
 
   '@ai-sdk/anthropic@2.0.71':
     resolution: {integrity: sha512-JXTtAwlyxGzzRtpiAXk/O93aOTgdfoVX28EoUuRNVqZRgtkoniLQTtqeb8uZ4oXljNJlXzaJLNasS/U90w/wjw==}
@@ -24513,11 +24513,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ag-ui/a2a@0.0.6(@ag-ui/client@0.0.42)(@ag-ui/core@0.0.56)':
+  '@ag-ui/a2a@0.0.6(@ag-ui/client@0.0.42)(@ag-ui/core@0.0.57)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
       '@ag-ui/client': 0.0.42
-      '@ag-ui/core': 0.0.56
+      '@ag-ui/core': 0.0.57
       rxjs: 7.8.1
     transitivePeerDependencies:
       - supports-color
@@ -24528,10 +24528,10 @@ snapshots:
       clarinet: 0.12.6
       rxjs: 7.8.1
 
-  '@ag-ui/a2ui-middleware@0.0.8(@ag-ui/client@0.0.56)(rxjs@7.8.1)':
+  '@ag-ui/a2ui-middleware@0.0.8(@ag-ui/client@0.0.57)(rxjs@7.8.1)':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.2
-      '@ag-ui/client': 0.0.56
+      '@ag-ui/client': 0.0.57
       clarinet: 0.12.6
       rxjs: 7.8.1
 
@@ -24592,11 +24592,11 @@ snapshots:
       uuid: 11.1.0
       zod: 3.25.76
 
-  '@ag-ui/client@0.0.56':
+  '@ag-ui/client@0.0.57':
     dependencies:
-      '@ag-ui/core': 0.0.56
-      '@ag-ui/encoder': 0.0.56
-      '@ag-ui/proto': 0.0.56
+      '@ag-ui/core': 0.0.57
+      '@ag-ui/encoder': 0.0.57
+      '@ag-ui/proto': 0.0.57
       '@types/uuid': 10.0.0
       compare-versions: 6.1.1
       fast-json-patch: 3.1.1
@@ -24631,7 +24631,7 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  '@ag-ui/core@0.0.56':
+  '@ag-ui/core@0.0.57':
     dependencies:
       zod: 3.25.76
 
@@ -24655,10 +24655,10 @@ snapshots:
       '@ag-ui/core': 0.0.53
       '@ag-ui/proto': 0.0.53
 
-  '@ag-ui/encoder@0.0.56':
+  '@ag-ui/encoder@0.0.57':
     dependencies:
-      '@ag-ui/core': 0.0.56
-      '@ag-ui/proto': 0.0.56
+      '@ag-ui/core': 0.0.57
+      '@ag-ui/proto': 0.0.57
 
   '@ag-ui/langgraph@0.0.11(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.19.0)':
     dependencies:
@@ -24698,11 +24698,11 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  '@ag-ui/langgraph@0.0.41(@ag-ui/client@0.0.56)(@ag-ui/core@0.0.56)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@ag-ui/langgraph@0.0.41(@ag-ui/client@0.0.57)(@ag-ui/core@0.0.57)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.3
-      '@ag-ui/client': 0.0.56
-      '@ag-ui/core': 0.0.56
+      '@ag-ui/client': 0.0.57
+      '@ag-ui/core': 0.0.57
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))
       langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
@@ -24720,11 +24720,11 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  '@ag-ui/langgraph@0.0.41(@ag-ui/client@0.0.56)(@ag-ui/core@0.0.56)(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@ag-ui/langgraph@0.0.41(@ag-ui/client@0.0.57)(@ag-ui/core@0.0.57)(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.3
-      '@ag-ui/client': 0.0.56
-      '@ag-ui/core': 0.0.56
+      '@ag-ui/client': 0.0.57
+      '@ag-ui/core': 0.0.57
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))
       langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@3.25.76))
@@ -24762,9 +24762,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@ag-ui/mcp-apps-middleware@0.0.2(@ag-ui/client@0.0.56)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
+  '@ag-ui/mcp-apps-middleware@0.0.2(@ag-ui/client@0.0.57)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
     dependencies:
-      '@ag-ui/client': 0.0.56
+      '@ag-ui/client': 0.0.57
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       rxjs: 7.8.1
     transitivePeerDependencies:
@@ -24782,9 +24782,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@ag-ui/mcp-apps-middleware@0.0.3(@ag-ui/client@0.0.56)(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+  '@ag-ui/mcp-apps-middleware@0.0.3(@ag-ui/client@0.0.57)(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@ag-ui/client': 0.0.56
+      '@ag-ui/client': 0.0.57
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       rxjs: 7.8.1
     transitivePeerDependencies:
@@ -24826,9 +24826,9 @@ snapshots:
       '@bufbuild/protobuf': 2.11.0
       '@protobuf-ts/protoc': 2.11.1
 
-  '@ag-ui/proto@0.0.56':
+  '@ag-ui/proto@0.0.57':
     dependencies:
-      '@ag-ui/core': 0.0.56
+      '@ag-ui/core': 0.0.57
       '@bufbuild/protobuf': 2.11.0
       '@protobuf-ts/protoc': 2.11.1
 
@@ -28306,9 +28306,9 @@ snapshots:
       - '@ag-ui/core'
       - encoding
 
-  '@copilotkit/bot-ui@0.0.1(@ag-ui/core@0.0.56)(encoding@0.1.13)':
+  '@copilotkit/bot-ui@0.0.1(@ag-ui/core@0.0.57)(encoding@0.1.13)':
     dependencies:
-      '@copilotkit/shared': 1.59.5(@ag-ui/core@0.0.56)(encoding@0.1.13)
+      '@copilotkit/shared': 1.59.5(@ag-ui/core@0.0.57)(encoding@0.1.13)
     transitivePeerDependencies:
       - '@ag-ui/core'
       - encoding
@@ -28424,10 +28424,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@copilotkit/shared@1.59.5(@ag-ui/core@0.0.56)(encoding@0.1.13)':
+  '@copilotkit/shared@1.59.5(@ag-ui/core@0.0.57)(encoding@0.1.13)':
     dependencies:
       '@ag-ui/client': 0.0.53
-      '@ag-ui/core': 0.0.56
+      '@ag-ui/core': 0.0.57
       '@copilotkit/license-verifier': 0.4.2
       '@segment/analytics-node': 2.3.0(encoding@0.1.13)
       '@standard-schema/spec': 1.1.0

--- a/showcase/scripts/__tests__/integration-smoke-registry.test.ts
+++ b/showcase/scripts/__tests__/integration-smoke-registry.test.ts
@@ -43,7 +43,13 @@ let INTEGRATIONS: Array<{
 }>;
 
 beforeAll(() => {
-  runGenerator();
+  // Only regenerate if registry.json is absent. When generate-registry.test.ts
+  // runs concurrently (fileParallelism: true), its beforeAll already creates
+  // the file; re-running the generator here would race with that suite's
+  // sentinel test (atomic rename clobbers the appended sentinel).
+  if (!fs.existsSync(path.join(SHELL_DATA_DIR, "registry.json"))) {
+    runGenerator();
+  }
   dataRestorer.snapshot();
 
   const registryPath = path.join(SHELL_DATA_DIR, "registry.json");


### PR DESCRIPTION
## Summary

- Bumps `@ag-ui/client`, `@ag-ui/core`, and `@ag-ui/encoder` to `0.0.57` across all packages under `packages/`
- Updates `pnpm-lock.yaml` to reflect the new versions

## Test plan

- [ ] Verify packages build successfully
- [ ] Confirm no runtime regressions in ag-ui communication