### PR TITLE
fix(shared): preserve lambda client cjs export

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -46,7 +46,7 @@
     "check-types": "tsc --noEmit",
     "link:global": "pnpm link --global",
     "unlink:global": "pnpm unlink --global",
-    "publint": "publint .",
+    "publint": "publint . && node scripts/verify-cjs-exports.cjs",
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {

--- a/packages/shared/scripts/verify-cjs-exports.cjs
+++ b/packages/shared/scripts/verify-cjs-exports.cjs
@@ -1,0 +1,16 @@
+(async () => {
+  const { pathToFileURL } = require("node:url");
+
+  const cjs = require("../dist/index.cjs");
+
+  if (typeof cjs.lambdaClient?.send !== "function") {
+    throw new Error(
+      "Expected CommonJS export lambdaClient.send to be a function",
+    );
+  }
+
+  const esm = await import(pathToFileURL(require.resolve("../dist/index.mjs")));
+  if (typeof esm.lambdaClient?.send !== "function") {
+    throw new Error("Expected ESM export lambdaClient.send to be a function");
+  }
+})();

--- a/packages/shared/src/telemetry/index.ts
+++ b/packages/shared/src/telemetry/index.ts
@@ -1,6 +1,6 @@
 export * from "./telemetry-client";
-export { default as lambdaClient } from "./lambda-client";
 export {
+  lambdaClient,
   parseTelemetryIdFromLicense,
   parseAndWarnTelemetryId,
 } from "./lambda-client";

--- a/packages/shared/src/telemetry/lambda-client.ts
+++ b/packages/shared/src/telemetry/lambda-client.ts
@@ -150,4 +150,4 @@ export async function send(opts: LambdaSendOptions): Promise<void> {
   }
 }
 
-export default { send };
+export const lambdaClient = { send };

--- a/packages/shared/src/telemetry/telemetry-client.test.ts
+++ b/packages/shared/src/telemetry/telemetry-client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { MockInstance } from "vitest";
-import lambdaClient from "./lambda-client";
+import { lambdaClient } from "./lambda-client";
 import { TelemetryClient, isTelemetryDisabled } from "./telemetry-client";
 
 // Module mock so constructing TelemetryClient doesn't spin up segment's

--- a/packages/shared/src/telemetry/telemetry-client.ts
+++ b/packages/shared/src/telemetry/telemetry-client.ts
@@ -2,7 +2,7 @@ import { Analytics } from "@segment/analytics-node";
 import type { AnalyticsEvents } from "./events";
 import { flattenObject } from "./utils";
 import { v4 as uuidv4 } from "uuid";
-import lambdaClient, { parseAndWarnTelemetryId } from "./lambda-client";
+import { lambdaClient, parseAndWarnTelemetryId } from "./lambda-client";
 
 /**
  * Checks if telemetry is disabled via environment variables.


### PR DESCRIPTION
## Summary
- export the telemetry lambda client as a named binding instead of default-reexporting it through the shared barrel
- update shared telemetry internals/tests to consume the named binding
- add a built-package smoke check to ensure both CommonJS and ESM expose `lambdaClient.send`

## Root Cause
`@copilotkit/shared` re-exported `lambdaClient` from a default export. The unbundled CommonJS build emitted `exports.lambdaClient = require_lambda_client`, so CommonJS consumers received the module namespace object instead of the `{ send }` client. `@copilotkit/runtime` then called `lambdaClient.send(...)` and crashed because `send` was nested under `lambdaClient.default`.

## Validation
- `pnpm nx run @copilotkit/shared:build --skip-nx-cache`
- `node packages/shared/scripts/verify-cjs-exports.cjs`
- `pnpm nx run @copilotkit/shared:test --skip-nx-cache`
- `pnpm nx run @copilotkit/shared:check-types --skip-nx-cache`
- `pnpm nx run @copilotkit/shared:publint --skip-nx-cache`
- `pnpm nx run @copilotkit/runtime:build --skip-nx-cache`
- runtime CJS telemetry capture smoke test
- `pnpm nx run @copilotkit/runtime:test --skip-nx-cache -- src/v2/runtime/__tests__/telemetry.test.ts`
- pre-commit hook: `pnpm run test && pnpm run check:packages`
