### PR TITLE
fix(showcase): BIA D6 followups — PARITY_NOTES NSF naming + STATE_DELTA op:add

### DIFF
--- a/showcase/integrations/built-in-agent/PARITY_NOTES.md
+++ b/showcase/integrations/built-in-agent/PARITY_NOTES.md
@@ -148,10 +148,6 @@ layer.
 - Action: tracked in follow-up PR; bundled with the
   `a2ui-fixed-schema` renderer-host fix.
 
-### `sub-agents` — RED (pending diagnose)
-
-TODO(sub-agents): pending diagnose follow-up; current staging state RED.
-
 ### `gen-ui-agent` — RED (state never reaches frontend)
 
 - D6 status: RED — `StepsPanel` stays in its placeholder "No plan yet"

--- a/showcase/integrations/built-in-agent/PARITY_NOTES.md
+++ b/showcase/integrations/built-in-agent/PARITY_NOTES.md
@@ -77,10 +77,18 @@ PR that bumps `@copilotkit/react-core`.
 
 Two demos render a graceful "not supported" banner with
 `data-testid="not-supported-banner"` so the harness can detect them
-deterministically instead of timing out on missing UI:
+deterministically instead of timing out on missing UI (mount wired by
+PR #5413, commit `3585c33b8`):
 
-- `hitl` (superseded by `hitl-in-chat` + `hitl-in-chat-booking`)
+- `gen-ui-interrupt` (NSF-quarantined: BIA has no `interrupt()` primitive;
+  see Strategy-B adaptations above for the async-handler model used by the
+  non-quarantined HITL demos)
 - `shared-state-streaming` (BIA has no per-token state-delta streaming)
+
+The dashboard-labeled "In-chat" and "In-app" HITL demos (`hitl-in-chat`,
+`hitl-in-app`) are GREEN on staging — they are NOT NSF. They use
+`useFrontendTool` with async handlers per the Strategy-B adaptation
+documented above.
 
 D6 probes should treat a `not-supported-banner` hit as PASS-SKIPPED, not
 FAIL.
@@ -140,6 +148,10 @@ layer.
 - Action: tracked in follow-up PR; bundled with the
   `a2ui-fixed-schema` renderer-host fix.
 
+### `sub-agents` — RED (pending diagnose)
+
+TODO(sub-agents): pending diagnose follow-up; current staging state RED.
+
 ### `gen-ui-agent` — RED (state never reaches frontend)
 
 - D6 status: RED — `StepsPanel` stays in its placeholder "No plan yet"
@@ -155,3 +167,7 @@ layer.
   `useAgent` / `useCoAgent` state-subscription path), not the BIA
   integration.
 - Action: tracked in follow-up PR against `packages/react-core`.
+
+## Doc maintenance
+
+PARITY_NOTES inaccuracies surfaced by staging verify after PR #5413 merge — fixed 2026-06-12.

--- a/showcase/integrations/built-in-agent/src/lib/factory/tanstack-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/tanstack-factory.ts
@@ -168,9 +168,18 @@ async function* convertStream(
       }
       // `set_steps` is the gen-ui-agent demo's custom plan tool (see
       // state-tools.ts). The tool's server handler returns `{ steps }`;
-      // translate that into a STATE_DELTA that replaces `/steps` on the
+      // translate that into a STATE_DELTA that adds `/steps` on the
       // agent state, so the frontend `useAgent` subscriber sees the
       // plan update and `StepsPanel` mounts `agent-state-card`.
+      //
+      // Use RFC-6902 `add` (not `replace`): the agent's initial state is
+      // `{}` (no STATE_SNAPSHOT precedes the first STATE_DELTA), and
+      // `fast-json-patch` in strict mode rejects `replace` on an
+      // unresolvable path with OPERATION_PATH_UNRESOLVABLE.
+      // `@ag-ui/client@0.0.57` swallows that throw with `console.warn`
+      // and never updates state, so `replace` results in the panel
+      // staying in its placeholder. `add` creates `/steps` on first
+      // emission and idempotently overwrites on subsequent calls.
       if (
         toolName === "set_steps" &&
         parsedContent &&
@@ -181,7 +190,7 @@ async function* convertStream(
           type: EventType.STATE_DELTA,
           delta: [
             {
-              op: "replace",
+              op: "add",
               path: "/steps",
               value: (parsedContent as { steps: unknown }).steps,
             },


### PR DESCRIPTION
## Summary

Small followups to PR #5413 (BIA D6 readiness, merged 2026-06-12).

- **`PARITY_NOTES.md` NSF naming**: corrected `hitl` (which is supported in BIA via Strategy-B `useFrontendTool`) to call out the actual NSF-quarantined demos `gen-ui-interrupt` and `shared-state-streaming` per the manifest. PR #5413's NSF banner commit (`3585c33b8`) mounted the banners on the correct demos.
- **Sub-Agents TODO removed**: post-merge staging dashboard showed sub-agents RED; diagnose confirmed code on `5e828aed9` is correct (local `--direct` D6 PASSES). The staging RED was stale dashboard image / fixture cache, not code. PARITY_NOTES no longer claims sub-agents is a known-issue.
- **gen-ui-agent STATE_DELTA op fix**: BIA's `set_steps` tool emission used RFC-6902 `op: "replace"` on path `/steps`, but the agent's initial state is `{}` and `fast-json-patch` rejects unresolvable paths in strict mode (`@ag-ui/client@0.0.57` swallows the throw with `console.warn`). Changing to `op: "add"` creates the path on first emission and idempotently overwrites on subsequent calls. Single-line fix in `tanstack-factory.ts`.

## Out-of-scope (tracked separately)

- **a2ui-fixed-schema + declarative-gen-ui** (PR #5413 documented known-issues): root cause is in `@copilotkit/runtime/v2` v2-stack pipeline OR `@ag-ui/a2ui-middleware@0.0.8` JSON.parse gap — one upstream fix likely unblocks both. Diagnose reports at `/tmp/cr/bia-rxr-diagnose/{a2ui-fixed-schema,declarative-gen-ui}.md`. Needs separate packages PR.
- **tool-rendering port + headless-complete missing components**: BIA needs StockCard, ChartCard, `get_revenue_chart` server tool, UI primitives. Separate component-port PR.
- **shadcn catchall**: product/design call pending (escalate to PM).

## Test plan

- [x] Local `--direct` D6 verify on `gen-ui-agent` after the JSON-Patch op fix
- [x] CI green on PR