### PR TITLE
fix(showcase/harness): redefine family lastSuccessAt — terminal-completion, not all-green

### DIFF
--- a/showcase/harness/src/fleet/control-plane/family-silence-monitor.test.ts
+++ b/showcase/harness/src/fleet/control-plane/family-silence-monitor.test.ts
@@ -6,12 +6,12 @@ import {
   SILENCE_ALERT_RATE_LIMIT_MS,
   SILENCE_PERIOD_MULTIPLIER,
 } from "./family-silence-monitor.js";
-import {
-  FLEET_FAMILIES,
-  type FamilySummaryEntry,
-  type FamilySummaryResponse,
-  type InflightState,
-  type RunBatch,
+import { FLEET_FAMILIES } from "./run-view.js";
+import type {
+  FamilySummaryEntry,
+  FamilySummaryResponse,
+  InflightState,
+  RunBatch,
 } from "./run-view.js";
 import type { ProducerSchedule } from "./control-plane.js";
 import type { JobProducer } from "./job-producer.js";
@@ -302,6 +302,57 @@ describe("family-silence monitor — silence alert", () => {
       `has never completed a run since ${iso(oldest)}`,
     );
     expect(posts[0]).toContain("last attempt: failed (worker-crashed-mid-job)");
+  });
+
+  it("does not alert when the family runs every cycle with cell-level reds but no commError (chronic-reds, worker healthy)", async () => {
+    // Regression for the D5/D6 family-silence false-alarm: the monitor reads
+    // §5.2.1 `lastSuccessAt`, whose new semantic counts a batch where every
+    // job reached a terminal state with no commError — i.e. cells red is
+    // fine. Synthesize the dashboard's observed shape: lastSuccessAt is fresh
+    // (one tick ago), lastRun outcome="failed" (chronic content reds), no
+    // inflight. The silence banner must STAY SILENT.
+    const now = BASE + 5 * PERIOD;
+    const { monitor, posts } = makeMonitor({
+      get: async () =>
+        response(
+          withD6(now, {
+            lastSuccessAt: iso(now - PERIOD),
+            lastRun: batch({
+              outcome: "failed",
+              enqueuedAt: iso(now - PERIOD - 120_000),
+              finishedAt: iso(now - PERIOD),
+              jobs: { total: 18, done: 1, failed: 17, reclaimed: 0 },
+              cells: { total: 180, passed: 50, failed: 130 },
+              commErrorKinds: [],
+            }),
+          }),
+        ),
+    });
+    await monitor.tick(now);
+    expect(posts).toEqual([]);
+  });
+
+  it("still alerts when the family STOPS emitting results entirely (real outage)", async () => {
+    // Negative case to preserve: a real worker outage (lastSuccessAt very
+    // stale, fresh inflight that's also stalled) must still trip the banner.
+    const now = BASE + 5 * PERIOD;
+    const { monitor, posts } = makeMonitor({
+      get: async () =>
+        response(
+          withD6(now, {
+            lastSuccessAt: iso(now - 4 * PERIOD),
+            lastRun: batch({
+              outcome: "failed",
+              enqueuedAt: iso(now - 4 * PERIOD - 120_000),
+              finishedAt: iso(now - 4 * PERIOD),
+              commErrorKinds: ["worker-crashed-mid-job"],
+            }),
+          }),
+        ),
+    });
+    await monitor.tick(now);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toContain("worker family D6 all-pills silent");
   });
 
   it("zero-batch family never alerts", async () => {

--- a/showcase/harness/src/fleet/control-plane/run-view.test.ts
+++ b/showcase/harness/src/fleet/control-plane/run-view.test.ts
@@ -17,11 +17,6 @@ import { buildProducerSchedules } from "../../orchestrator.js";
 import type { ProducerSchedule } from "./control-plane.js";
 import {
   FLEET_FAMILIES,
-  type FamilySummaryEntry,
-  type FamilySummaryResponse,
-  type ProbeJobRecord,
-  type RunViewDeps,
-  type WorkerRow,
   classifyInflight,
   createMemoizedFamilySummary,
   deriveOutcome,
@@ -29,6 +24,13 @@ import {
   periodMsFromCron,
   projectRunBatch,
   projectWorker,
+} from "./run-view.js";
+import type {
+  FamilySummaryEntry,
+  FamilySummaryResponse,
+  ProbeJobRecord,
+  RunViewDeps,
+  WorkerRow,
 } from "./run-view.js";
 
 // ───────────────────────────────────────────────────────────────────────
@@ -693,7 +695,7 @@ describe("createMemoizedFamilySummary", () => {
     const { pb } = makeFakePb({});
     const summary = await createMemoizedFamilySummary(makeDeps({ pb })).get();
     expect(summary.families.map((f) => f.family).sort()).toEqual(
-      [...FLEET_FAMILIES.map((f) => f.family)].sort(),
+      FLEET_FAMILIES.map((f) => f.family).sort(),
     );
     for (const fam of FLEET_FAMILIES) {
       const entry = familyEntry(summary, fam.family);
@@ -783,11 +785,13 @@ describe("createMemoizedFamilySummary", () => {
     expect(d6.lastRun?.runId).toBe("run-prev");
   });
 
-  it("lastSuccessAt walk-back: a newest done JOB inside an overall-failed batch does not count; the prior completed batch's finish wins", async () => {
+  it("lastSuccessAt walk-back: a newest done JOB inside a batch with a comm-error sibling does not count; the prior terminal-completion batch's finish wins", async () => {
     const { pb } = makeFakePb({
       jobs: [
-        // Newest batch: overall failed, but contains a done job whose
-        // finished_at is the newest timestamp anywhere.
+        // Newest batch: NOT a terminal completion — one job carries a
+        // worker-comm-level failure (`commError`). The done sibling's
+        // finished_at is the newest timestamp anywhere, but a single
+        // comm-erroring job disqualifies the whole batch.
         batchRow({
           runId: "run-failed",
           status: "done",
@@ -799,8 +803,9 @@ describe("createMemoizedFamilySummary", () => {
           status: "failed",
           enqueuedAt: iso(-10 * 60_000),
           finishedAt: iso(-2 * 60_000),
+          result: { commError: { kind: "worker-crashed-mid-job" } },
         }),
-        // Prior batch: completed.
+        // Prior batch: terminal completion (all jobs done, no commError).
         batchRow({
           runId: "run-ok",
           status: "done",
@@ -821,7 +826,13 @@ describe("createMemoizedFamilySummary", () => {
     expect(d6.lastSuccessAt).toBe(iso(-64 * 60_000));
   });
 
-  it("lastSuccessAt is null when no completed batch exists in the capped window", async () => {
+  it("lastSuccessAt is null when every batch in the capped window has a commError (real outage)", async () => {
+    // §5.2.1 "terminal completion" semantics: a `status: "failed"` job WITH
+    // a `result.commError` means the worker couldn't reach the pool / crashed
+    // / was reclaimed — that's NOT a terminal completion, it's a real outage
+    // signal. Only when every batch in the window contains such jobs does
+    // `lastSuccessAt` stay null. (Cell-level reds without commError are
+    // covered by the "advances even with cell-fail counts" test below.)
     const { pb } = makeFakePb({
       jobs: [
         batchRow({
@@ -829,12 +840,136 @@ describe("createMemoizedFamilySummary", () => {
           status: "failed",
           enqueuedAt: iso(-10 * 60_000),
           finishedAt: iso(-9 * 60_000),
+          result: { commError: { kind: "worker-crashed-mid-job" } },
         }),
         batchRow({
           runId: "run-0",
           status: "failed",
           enqueuedAt: iso(-70 * 60_000),
           finishedAt: iso(-69 * 60_000),
+          result: { commError: { kind: "worker-crashed-mid-job" } },
+        }),
+      ],
+    });
+    const summary = await createMemoizedFamilySummary(makeDeps({ pb })).get();
+    expect(familyEntry(summary, "d6").lastSuccessAt).toBeNull();
+  });
+
+  it("lastSuccessAt advances when all jobs reach a terminal state with no commError, even if cells failed", async () => {
+    // Regression for the D5/D6 family-silence banner false alarm: chronic
+    // content-reds left every batch's outcome="failed" (cell-level), which
+    // under the OLD all-green-only definition pinned lastSuccessAt=null
+    // forever and tripped the "worker family X has not completed successfully
+    // since Yh ago" banner even though workers were healthy. Under the new
+    // §5.2.1 terminal-completion definition, a batch where every job reached
+    // a terminal state without a `commError` IS a successful evaluation
+    // cycle — cells red, worker green.
+    const { pb } = makeFakePb({
+      jobs: [
+        // Newest batch: every job terminal, one done one failed-with-reds,
+        // both carry a rollup but NEITHER carries a commError.
+        batchRow({
+          runId: "run-recent",
+          status: "done",
+          probeKey: "d6:langgraph-python",
+          enqueuedAt: iso(-10 * 60_000),
+          finishedAt: iso(-9 * 60_000),
+          result: { rollup: { total: 6, passed: 6, failed: 0 } },
+        }),
+        batchRow({
+          runId: "run-recent",
+          status: "failed",
+          probeKey: "d6:crew",
+          enqueuedAt: iso(-10 * 60_000),
+          finishedAt: iso(-8 * 60_000),
+          result: { rollup: { total: 6, passed: 3, failed: 3 } },
+        }),
+      ],
+    });
+    const summary = await createMemoizedFamilySummary(makeDeps({ pb })).get();
+    const d6 = familyEntry(summary, "d6");
+    // The §5.2.1 outcome precedence still derives "failed" for the run.
+    expect(d6.lastRun?.outcome).toBe("failed");
+    // But lastSuccessAt now reflects the worker terminally completing the
+    // batch — the newest finished_at across the terminal-completion batch.
+    expect(d6.lastSuccessAt).toBe(iso(-8 * 60_000));
+  });
+
+  it("lastSuccessAt does NOT count a batch where any job carries a commError (worker-outage signal)", async () => {
+    const { pb } = makeFakePb({
+      jobs: [
+        // Newest batch: one done, one failed-with-commError → real outage,
+        // does NOT count as a terminal completion.
+        batchRow({
+          runId: "run-outage",
+          status: "done",
+          probeKey: "d6:langgraph-python",
+          enqueuedAt: iso(-5 * 60_000),
+          finishedAt: iso(-4 * 60_000),
+          result: { rollup: { total: 6, passed: 6, failed: 0 } },
+        }),
+        batchRow({
+          runId: "run-outage",
+          status: "failed",
+          probeKey: "d6:crew",
+          enqueuedAt: iso(-5 * 60_000),
+          finishedAt: iso(-4 * 60_000),
+          result: { commError: { kind: "worker-crashed-mid-job" } },
+        }),
+        // Prior batch: terminal completion, cells some-red but no commError —
+        // this one DOES count.
+        batchRow({
+          runId: "run-prior",
+          status: "failed",
+          probeKey: "d6:langgraph-python",
+          enqueuedAt: iso(-70 * 60_000),
+          finishedAt: iso(-66 * 60_000),
+          result: { rollup: { total: 6, passed: 5, failed: 1 } },
+        }),
+        batchRow({
+          runId: "run-prior",
+          status: "done",
+          probeKey: "d6:crew",
+          enqueuedAt: iso(-70 * 60_000),
+          finishedAt: iso(-65 * 60_000),
+          result: { rollup: { total: 6, passed: 6, failed: 0 } },
+        }),
+      ],
+    });
+    const summary = await createMemoizedFamilySummary(makeDeps({ pb })).get();
+    const d6 = familyEntry(summary, "d6");
+    // The newest batch is skipped (commError present); the prior batch wins.
+    expect(d6.lastSuccessAt).toBe(iso(-65 * 60_000));
+  });
+
+  it("lastSuccessAt does NOT count a batch with non-terminal jobs (worker never finished)", async () => {
+    // A `pending` or `claimed` job in the newest non-inflight slot means the
+    // worker never reached a terminal state — that batch is a stall / abandon
+    // signal, not a successful completion. (The actual newest-group is the
+    // inflight and is excluded by run-view's existing skip; this fixture
+    // exercises an OLDER stalled batch.)
+    const { pb } = makeFakePb({
+      jobs: [
+        // Newest batch: live inflight (skipped by the existing rule).
+        batchRow({
+          runId: "run-live",
+          status: "running",
+          probeKey: "d6:langgraph-python",
+          enqueuedAt: iso(-2 * 60_000),
+        }),
+        // Older batch: one job zombied pending (worker never finished).
+        batchRow({
+          runId: "run-stalled",
+          status: "pending",
+          probeKey: "d6:crew",
+          enqueuedAt: iso(-70 * 60_000),
+        }),
+        batchRow({
+          runId: "run-stalled",
+          status: "done",
+          probeKey: "d6:langgraph-python",
+          enqueuedAt: iso(-70 * 60_000),
+          finishedAt: iso(-65 * 60_000),
         }),
       ],
     });

--- a/showcase/harness/src/fleet/control-plane/run-view.ts
+++ b/showcase/harness/src/fleet/control-plane/run-view.ts
@@ -37,17 +37,15 @@ import {
   isPoolCommErrorKind,
 } from "../contracts.js";
 import { PROBE_JOBS_COLLECTION } from "../queue-client.js";
-import {
-  PROBE_RUNS_COLLECTION,
-  type ProbeRunSummary,
-} from "../../probes/run-history.js";
+import { PROBE_RUNS_COLLECTION } from "../../probes/run-history.js";
+import type { ProbeRunSummary } from "../../probes/run-history.js";
 import {
   FLEET_PRODUCER_DEEP_SCHEDULE_ID,
   FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
   FLEET_PRODUCER_SCHEDULE_ID,
   FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
-  type ProducerSchedule,
 } from "./control-plane.js";
+import type { ProducerSchedule } from "./control-plane.js";
 
 // ───────────────────────────────────────────────────────────────────────
 // §5.1 family registry
@@ -225,11 +223,19 @@ export interface FamilySummaryEntry {
   lastRun?: RunBatch | null;
   inflight?: InflightState | null;
   /**
-   * Finish of the newest completed batch within the capped walk-back, or null
-   * (no completed batch in window / never succeeded / fresh env). Null
-   * consumers (§7.3 glyph, §7.4 banner, §9 alert) fall back to the OLDEST
-   * known batch's enqueuedAt as the staleness reference; with zero batches at
-   * all they stay silent (§5.2.1 null semantics).
+   * Finish of the newest "terminal completion" batch within the capped
+   * walk-back, or null (no terminal completion in window / never succeeded /
+   * fresh env). A batch counts as a terminal completion when EVERY job
+   * reached a terminal state (done | failed) AND no job carries a
+   * `result.commError` — i.e. the worker reached the pool, ran the probe,
+   * and returned a result, even if cells were red. Cell-level failures (the
+   * §5.2.1 outcome=="failed" via rollup.failed > 0) do NOT block this
+   * timestamp: chronic content reds with healthy workers must not fool the
+   * §7.4 silence banner / §9 silence monitor into reporting "no successful
+   * run since Xh ago". Null consumers (§7.3 glyph, §7.4 banner, §9 alert)
+   * still fall back to the OLDEST known batch's enqueuedAt as the staleness
+   * reference; with zero batches at all they stay silent (§5.2.1 null
+   * semantics).
    */
   lastSuccessAt?: string | null;
 }
@@ -781,14 +787,48 @@ function eligibleGroups(
   return groups.slice(0, -1);
 }
 
-/** Index of the first batch in walk-order with derived outcome "completed". */
-function findCompletedBatch(groups: RunBatchRows[]): RunBatchRows | null {
+/**
+ * §5.2.1 "terminal completion" predicate for `lastSuccessAt`: a batch where
+ * every job reached a terminal state (done | failed) AND no job carries a
+ * `commError` on its result. A batch with cell-level failures but no
+ * comm-error IS a terminal completion — the worker reached the pool, ran the
+ * probe, and returned a result; cells red is a content-quality signal, not a
+ * worker-outage signal.
+ *
+ * This is deliberately LOOSER than the §5.2.1 outcome=="completed"
+ * all-cells-green precedence (which still drives `lastRun.outcome`). The
+ * silence banner (§7.4) and the §9 silence monitor want to fire on "the
+ * worker stopped producing results" — chronic content reds with healthy
+ * workers must NOT fool that fallback into "no successful run since Xh ago"
+ * (the regression that motivated this redefinition).
+ */
+function isTerminalCompletionBatch(batch: RunBatchRows): boolean {
+  // All jobs must be in a terminal status (done | failed).
+  if (batch.rows.some((row) => !isTerminal(row))) return false;
+  // No job may carry a worker-comm-level failure (crashed / reclaimed /
+  // lease-expired). resultView().commErrorKind === undefined means there is
+  // either no result object or a result with no commError (cells-red only).
+  for (const row of batch.rows) {
+    if (resultView(row).commErrorKind !== undefined) return false;
+  }
+  return true;
+}
+
+/**
+ * Index of the first batch in walk-order qualifying as a §5.2.1 terminal
+ * completion (the `lastSuccessAt` reference). Skips the newest group when
+ * it's the live inflight batch (any non-terminal row) — that batch is the
+ * current attempt, never the last success.
+ */
+function findTerminalCompletionBatch(
+  groups: RunBatchRows[],
+): RunBatchRows | null {
   for (let i = 0; i < groups.length; i++) {
     const group = groups[i];
     // The newest group, while non-terminal, is the inflight batch — it is
     // not a terminal outcome and can never be the last success.
     if (i === 0 && group.rows.some((row) => !isTerminal(row))) continue;
-    if (deriveOutcome(group, i > 0) === "completed") return group;
+    if (isTerminalCompletionBatch(group)) return group;
   }
   return null;
 }
@@ -823,13 +863,13 @@ async function projectFamily(
   // One indexed list (1 page) covers lastRun + inflight (a batch is ≤ ~25
   // jobs; 200 rows ≈ several batches). Only the lastSuccessAt walk-back
   // extends to the §5.2.2 capped loop, and only when the first page holds
-  // no completed batch.
+  // no terminal-completion batch.
   const first = await fetchFamilyJobRows(deps, fam.family, undefined, 1);
   let rows = first.rows;
   let exhausted = first.exhausted;
   let groups = eligibleGroups(groupBatches(rows), exhausted);
-  let completed = findCompletedBatch(groups);
-  if (completed === null && !exhausted && rows.length > 0) {
+  let terminalCompletion = findTerminalCompletionBatch(groups);
+  if (terminalCompletion === null && !exhausted && rows.length > 0) {
     const oldest = rows[rows.length - 1];
     const more = await fetchFamilyJobRows(
       deps,
@@ -840,7 +880,7 @@ async function projectFamily(
     rows = [...rows, ...more.rows];
     exhausted = more.exhausted;
     groups = eligibleGroups(groupBatches(rows), exhausted);
-    completed = findCompletedBatch(groups);
+    terminalCompletion = findTerminalCompletionBatch(groups);
   }
 
   // inflight = the newest group only (§5.2.1) — null when all-terminal.
@@ -877,7 +917,9 @@ async function projectFamily(
     nextRunAt: nextRun ? nextRun.toISOString() : null,
     lastRun,
     inflight,
-    lastSuccessAt: completed ? maxFinishedAtIso(completed) : null,
+    lastSuccessAt: terminalCompletion
+      ? maxFinishedAtIso(terminalCompletion)
+      : null,
   };
 }
 

--- a/showcase/harness/src/http/fleet-runs.test.ts
+++ b/showcase/harness/src/http/fleet-runs.test.ts
@@ -22,24 +22,25 @@ import {
   FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
   FLEET_PRODUCER_SCHEDULE_ID,
   FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
-  type ProducerSchedule,
 } from "../fleet/control-plane/control-plane.js";
+import type { ProducerSchedule } from "../fleet/control-plane/control-plane.js";
 import {
   FLEET_FAMILIES,
   createMemoizedFamilySummary,
-  type FamilySummaryResponse,
-  type ProbeJobRecord,
-  type RunBatch,
-  type RunViewDeps,
+} from "../fleet/control-plane/run-view.js";
+import type {
+  FamilySummaryResponse,
+  ProbeJobRecord,
+  RunBatch,
+  RunViewDeps,
 } from "../fleet/control-plane/run-view.js";
 import {
   HISTORY_MEMO_MAX_KEYS,
   HISTORY_RATE_LIMIT_MAX,
   createLruTtlMemo,
   registerFleetRunsRoutes,
-  type FamilyHistoryResponse,
-  type RunDetailResponse,
 } from "./fleet-runs.js";
+import type { FamilyHistoryResponse, RunDetailResponse } from "./fleet-runs.js";
 
 // ───────────────────────────────────────────────────────────────────────
 // Fixtures
@@ -126,6 +127,13 @@ function batchFixture(
     batchGapMs?: number;
     rowGapMs?: number;
     newestMs?: number;
+    /**
+     * Optional per-batch `result` payload. Returning a value with a `commError`
+     * is how a fixture flags a batch as a real worker outage (the §5.2.1
+     * terminal-completion predicate excludes batches with any commError, so
+     * those batches do NOT count toward `lastSuccessAt`).
+     */
+    resultFor?: (batchIdx: number) => unknown;
   } = {},
 ): ProbeJobRecord[] {
   const batchGapMs = opts.batchGapMs ?? 3_600_000;
@@ -134,6 +142,7 @@ function batchFixture(
   const rows: ProbeJobRecord[] = [];
   for (let b = 0; b < batchCount; b++) {
     const status = opts.statusFor ? opts.statusFor(b) : "done";
+    const result = opts.resultFor ? opts.resultFor(b) : undefined;
     for (let r = 0; r < size; r++) {
       const createdMs =
         newestMs - b * batchGapMs - (opts.sameMsWithinBatch ? 0 : r * rowGapMs);
@@ -147,6 +156,7 @@ function batchFixture(
           ...(status === "done" || status === "failed"
             ? { finishedAt: new Date(createdMs + 30_000).toISOString() }
             : {}),
+          ...(result !== undefined ? { result } : {}),
         }),
       );
     }
@@ -367,7 +377,7 @@ describe("GET /api/runs", () => {
     );
     expect(status).toBe(200);
     expect(body.families.map((f) => f.family).sort()).toEqual(
-      [...FLEET_FAMILIES.map((f) => f.family)].sort(),
+      FLEET_FAMILIES.map((f) => f.family).sort(),
     );
     for (const fam of FLEET_FAMILIES) {
       const entry = body.families.find((f) => f.family === fam.family);
@@ -437,13 +447,17 @@ describe("GET /api/runs", () => {
     expect(d5?.lastRun?.redsCleared).toBeNull();
   });
 
-  it("lastSuccessAt walk-back extends past page 1: a completed batch beyond the first 200 rows is found (gate-assigned T5 multi-page coverage)", async () => {
-    // 20 failed batches × 10 rows fill page 1 exactly (200 rows, NOT
-    // exhausted); the only completed batch sits on page 2 — the walk-back
-    // extension must fetch beyond page 1 to find it.
+  it("lastSuccessAt walk-back extends past page 1: a terminal-completion batch beyond the first 200 rows is found (gate-assigned T5 multi-page coverage)", async () => {
+    // 20 outage batches × 10 rows fill page 1 exactly (200 rows, NOT
+    // exhausted); the only terminal-completion batch sits on page 2 — the
+    // walk-back extension must fetch beyond page 1 to find it. Each page-1
+    // batch carries a `commError` on its result so it does NOT satisfy the
+    // §5.2.1 terminal-completion predicate (cells-red without commError WOULD
+    // qualify; that's the whole point of the redefinition).
     const failed = batchFixture("d6", 20, 10, {
       statusFor: () => "failed",
       batchGapMs: 3_600_000,
+      resultFor: () => ({ commError: { kind: "worker-crashed-mid-job" } }),
     });
     const completedCreatedMs = NOW_MS - 600_000 - 20 * 3_600_000;
     const completed: ProbeJobRecord[] = [];


### PR DESCRIPTION
## Symptom

Dashboard banner false alarm: *"Worker family E2E demos has not completed successfully since 2h 40m ago"* (and the same on D5/D6) firing while workers were healthy and emitting results every cycle.

## Triage (already done)

The D5/D6 family-silence banner fires because:

- `lastSuccessAt` is computed via `maxFinishedAtIso(completed)` where `completed` requires the §5.2.1 `deriveOutcome` to return `"completed"` (all jobs `done`, zero cell failures) — see `showcase/harness/src/fleet/control-plane/run-view.ts` (pre-fix `findCompletedBatch` + the `lastSuccessAt` line in `projectFamily`).
- With chronic content-reds present, every batch lands with `jobs.done=1, jobs.failed=17` (cells failing inside the probes). The outcome derives `"failed"`, no batch satisfies `outcome === "completed"`, and `findCompletedBatch` returns null.
- The family-silence monitor falls back to oldest-batch-`enqueuedAt` and fires after `now − oldest > 3 × period` (see `family-silence-monitor.ts`).
- The worker is fine: per-job `commError: null`, jobs completing with real cell results, just `<100%` pass-rate.

This is a DEFINITIONAL bug. The worker is healthy; the definition of "success" was conflating worker-completion with cells-all-green.

## The fix

Redefine "success" as **terminal-state accounting**, not pass-rate.

A batch counts as a terminal completion when:
1. Every job is in a terminal status (`done` or `failed`), AND
2. No job carries a `result.commError` (i.e. no worker-crashed-mid-job, lease-expired, or other comm-level outage signal).

Cells red without a `commError` IS a terminal completion — the worker reached the pool, ran the probe, and returned a result. Chronic content reds become "known bad" instead of "stalled."

The strict §5.2.1 `outcome=="completed"` all-green semantic is unchanged — it still drives `lastRun.outcome` and §6.2 dashboard rendering. No external caller of run-view consumed the old strict `lastSuccessAt` for logic beyond the banner and monitor (grep verified — every reference outside this file is either a test fixture or the silence-banner display surface), so renaming was unnecessary; only the definition was redirected.

The fallback path in `family-silence-monitor.ts` (oldest-batch-enqueuedAt when `lastSuccessAt` is null) is intentionally **untouched** — with the new semantics, `lastSuccessAt` advances every sweep on a healthy family, so the fallback only fires on true never-completed envs (the rule it was designed for).

## Affected files

- `showcase/harness/src/fleet/control-plane/run-view.ts` — new `isTerminalCompletionBatch` + `findTerminalCompletionBatch` predicates; `projectFamily` now sources `lastSuccessAt` from terminal completion; doc comment on the type updated.
- `showcase/harness/src/fleet/control-plane/run-view.test.ts` — 3 new tests; 1 existing walk-back fixture updated to add a `commError` so its original intent (skip non-completion batches) survives the new predicate.
- `showcase/harness/src/fleet/control-plane/family-silence-monitor.test.ts` — 2 new tests: chronic-reds stays silent; real outage still fires.
- `showcase/harness/src/http/fleet-runs.test.ts` — T5 multi-page walk-back fixture updated to flag its 20 "outage" batches with a `commError` (so the walk-back still has to extend to page 2); `batchFixture` gained an optional `resultFor` parameter.

## Tests (RED → GREEN)

Confirmed the 2 net-new predicate tests fail under the old implementation and pass under the new:

- `lastSuccessAt advances when all jobs reach a terminal state with no commError, even if cells failed` — old: `null`, new: newest finishedAt
- `lastSuccessAt does NOT count a batch where any job carries a commError (worker-outage signal)` — old: `null` (walk-back to prior worked but for the wrong reason — strict all-green semantics), new: walks back past the comm-erroring batch to the terminal-completion batch

Negative cases preserved:
- `lastSuccessAt is null when every batch in the capped window has a commError` — real outage stays loud
- `lastSuccessAt does NOT count a batch with non-terminal jobs` — stall/abandon still excluded
- Family-silence monitor still alerts on real outages

Final test counts: harness `2700/2700` green, fleet/control-plane + fleet-runs slice `355/355` green; format / lint / typecheck / build all clean.

## Follow-up

Per the minimize-PRs directive, the D5+D6 banner remediation and `redsCleared` semantic refresh are tracked separately in the coordinate channel handoff — this PR is scoped to the `lastSuccessAt` definitional fix.