### PR TITLE
fix(core): keep agent.subscribe callable when detached from the agent instance

### DIFF
--- a/packages/core/src/__tests__/agent-detached-subscribe.test.ts
+++ b/packages/core/src/__tests__/agent-detached-subscribe.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { ProxiedCopilotRuntimeAgent } from "../agent";
+
+/**
+ * Issue #5000: `agent.subscribe()` is a prototype method, so holding a
+ * detached reference to it (destructuring, passing it as a callback, e.g.
+ * `useSyncExternalStore(agent.subscribe, ...)`) invokes it with
+ * `this === undefined` and throws
+ * "Cannot read properties of undefined (reading 'subscribers')".
+ *
+ * These React patterns are common enough that the agents CopilotKit hands
+ * out must keep `subscribe` callable without its receiver.
+ */
+describe("ProxiedCopilotRuntimeAgent detached subscribe (issue #5000)", () => {
+  function createAgent() {
+    return new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example/api",
+      agentId: "test-agent",
+      transport: "rest",
+      runtimeMode: "pending",
+    });
+  }
+
+  it("registers the subscriber when subscribe is invoked detached from the agent", () => {
+    const agent = createAgent();
+    const { subscribe } = agent;
+    const onRunFinalized = vi.fn();
+
+    expect(() => subscribe({ onRunFinalized })).not.toThrow();
+    expect(agent.subscribers).toContainEqual({ onRunFinalized });
+  });
+
+  it("unsubscribe returned by a detached subscribe call removes the subscriber", () => {
+    const agent = createAgent();
+    const { subscribe } = agent;
+    const subscriber = { onRunFinalized: vi.fn() };
+
+    const subscription = subscribe(subscriber);
+    subscription.unsubscribe();
+
+    expect(agent.subscribers).not.toContain(subscriber);
+  });
+});

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -147,6 +147,13 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
     if (this.transport === "single") {
       this.singleEndpointUrl = this.runtimeUrl;
     }
+
+    // React idioms routinely detach methods from the instance — destructuring
+    // (`const { subscribe } = agent`), `useSyncExternalStore(agent.subscribe, ...)`,
+    // passing `agent.subscribe` as a callback — which invokes them with
+    // `this === undefined` and crashes in AbstractAgent.subscribe (#5000).
+    // Bind the subscription surface so a detached reference stays callable.
+    this.subscribe = this.subscribe.bind(this);
   }
 
   /**

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent-subscribe.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent-subscribe.test.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect } from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AbstractAgent, AgentSubscriber } from "@ag-ui/client";
+import { useCopilotKit } from "../../context";
+import { useAgent } from "../use-agent";
+import { CopilotKitCoreRuntimeConnectionStatus } from "@copilotkit/core";
+
+// Mock the CopilotKit context to control copilotkit state directly
+vi.mock("../../context", () => ({
+  useCopilotKit: vi.fn(),
+}));
+
+const mockUseCopilotKit = useCopilotKit as ReturnType<typeof vi.fn>;
+
+/**
+ * Issue #5000: subscribing to the agent returned by useAgent() in a mount
+ * effect threw "Cannot read properties of undefined (reading 'subscribers')"
+ * when `subscribe` was invoked detached from the agent — the natural shape of
+ * several React patterns (destructuring, `useSyncExternalStore(agent.subscribe, ...)`).
+ *
+ * The agent useAgent returns on first render (a provisional
+ * ProxiedCopilotRuntimeAgent while the runtime is connecting) must be
+ * subscribable immediately, including via a detached reference.
+ */
+describe("useAgent subscribe on mount (issue #5000)", () => {
+  beforeEach(() => {
+    mockUseCopilotKit.mockReturnValue({
+      copilotkit: {
+        getAgent: vi.fn(() => undefined),
+        runtimeUrl: "http://localhost:3000/api/copilotkit",
+        runtimeConnectionStatus:
+          CopilotKitCoreRuntimeConnectionStatus.Connecting,
+        runtimeTransport: "rest",
+        headers: {},
+        agents: {},
+        subscribeToAgentWithOptions: (
+          agent: AbstractAgent,
+          subscriber: AgentSubscriber,
+        ) => agent.subscribe(subscriber),
+      },
+      executingToolCallIds: new Set(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function renderSubscriber(
+    subscribeFromEffect: (agent: AbstractAgent) => void,
+  ): { effectError: Error | null } {
+    const result: { effectError: Error | null } = { effectError: null };
+
+    function AgentSubscriberProbe() {
+      const { agent } = useAgent({ agentId: "test-agent" });
+      useEffect(() => {
+        try {
+          subscribeFromEffect(agent);
+        } catch (err) {
+          result.effectError = err as Error;
+        }
+      }, [agent]);
+      return <div>ok</div>;
+    }
+
+    render(<AgentSubscriberProbe />);
+    return result;
+  }
+
+  it("supports the issue's literal repro: agent.subscribe() in a useEffect on first render", () => {
+    const { effectError } = renderSubscriber((agent) => {
+      const sub = agent.subscribe({ onRunFinalized: vi.fn() });
+      sub.unsubscribe();
+    });
+
+    expect(effectError).toBeNull();
+  });
+
+  it("supports subscribe invoked detached from the agent", () => {
+    const { effectError } = renderSubscriber((agent) => {
+      const { subscribe } = agent;
+      const sub = subscribe({ onRunFinalized: vi.fn() });
+      sub.unsubscribe();
+    });
+
+    expect(effectError).toBeNull();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Triage + fix for #5000 (`agent.subscribe()` throws `TypeError: Cannot read properties of undefined (reading 'subscribers')` on mount).

### Triage

The issue's literal repro — `agent.subscribe({...})` called as a method inside a `useEffect` on first render — **does not reproduce**: verified empirically against the published `@copilotkit/react-core@1.57.1` packages with the runtime in every connection state (the provisional `ProxiedCopilotRuntimeAgent` is fully constructed and subscribable synchronously). The `isReady` flag requested in the issue is based on a misdiagnosis — there is no async-initialization race.

The reported error *is* reproduced (byte-for-byte, including the `AbstractAgent.subscribe` stack frame) when `subscribe` is invoked **detached** from the agent:

```ts
const { subscribe } = agent;            // or: useSyncExternalStore(agent.subscribe, ...)
subscribe({ onRunFinalized: ... });     // this === undefined → TypeError
```

`AbstractAgent.subscribe` is a prototype method, and these callback-reference shapes are idiomatic React, so the footgun is easy to hit and the resulting error is hostile.

### Fix

Bind `subscribe` in the `ProxiedCopilotRuntimeAgent` constructor. Every agent CopilotKit itself constructs (provisional agents from the React/Vue/Angular hooks, runtime-discovered agents, `registerProxiedAgent` results, clones) keeps `subscribe` callable without its receiver. Subclass overrides still win — `this.subscribe` resolves through the prototype chain at construction time.

Red/green: both new test files were written first and failed with the exact reported TypeError; the hook-level test also pins the issue's literal repro (direct call on first render) as a regression guard.

### Verification

- `@copilotkit/core`: full suite + new `agent-detached-subscribe.test.ts` ✅
- `@copilotkit/react-core`: 1275/1275 incl. new `use-agent-subscribe.test.tsx` ✅
- `@copilotkit/vue`: 1001/1001 ✅
- `oxfmt --check` / `oxlint` clean; pre-commit gate (tests + publint + attw across 19 projects) green ✅
- `core:check-types` has a pre-existing 393-error baseline on main (extension-less-import TS2835s across every test file); stash-baseline comparison confirms the production change adds zero errors — the one new entry is the new test file's package-conventional import style. The enforced type gate (`core:build` dts emission) passes.

Upstream follow-up: the same footgun exists for any raw `AbstractAgent`/`HttpAgent` the user constructs themselves — the comprehensive fix belongs in `ag-ui`'s `AbstractAgent`.

## Related PRs and Issues

- Fixes #5000

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation (no doc change needed — docs only show receiver-attached `agent.subscribe(...)` calls, which always worked)
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)