### PR TITLE
feat(showcase/built-in-agent): D6 BIA component port — tool-rendering + headless-complete + LGP-canonical naming

### DIFF
--- a/showcase/aimock/d6/built-in-agent/gen-ui-headless-complete.json
+++ b/showcase/aimock/d6/built-in-agent/gen-ui-headless-complete.json
@@ -3,7 +3,7 @@
     "description": "D6 fixtures for built-in-agent / gen-ui-headless-complete",
     "sourceFile": "headless-complete.json",
     "copiedFrom": "langgraph-python",
-    "_note": "Alias of the headless-complete demo's 4 gen-UI pills (weather/stock/highlight/revenue) for the gen-ui-headless-complete probe (showcase/harness/src/probes/scripts/d5-gen-ui-headless-complete.ts -> fixtureFile 'gen-ui-headless-complete.json'), which had no matching fixture in any slug so its first leg 503'd under strict. Narration (toolCallId) fixtures FIRST so they win when the last message is a matching tool result; toolcall (userMessage+context) fixtures AFTER with NO turnIndex gate so each of the 4 sequential pill turns in one chat thread matches regardless of prior assistant/tool history (the turnIndex multi-turn match-gate bug). Modeled on the green langgraph-python pattern. Interrupt fixtures intentionally omitted (interrupt-headless is a separate cluster item)."
+    "_note": "Alias of the headless-complete demo's 4 gen-UI pills (weather/stock/highlight/revenue) for the gen-ui-headless-complete probe (showcase/harness/src/probes/scripts/d5-gen-ui-headless-complete.ts -> fixtureFile 'gen-ui-headless-complete.json'), which had no matching fixture in any slug so its first leg 503'd under strict. BIA-specific structure: each pill is a (sequenceIndex:0 emitter, narration fallback) pair. The emitter fires on the FIRST request matching the pill prompt (counter starts at 0) and emits the tool call; subsequent matches (the BIA TanStack server-tool reprompt with the tool result still in history — see PARITY_NOTES on the BIA /v1/responses id-rewrite + reprompt loop) fall through the now-exhausted emitter to the narration fallback. The toolCallId-keyed narration entries at the top of the file remain for non-rewriting code paths. Narration (toolCallId) fixtures FIRST so they win when the last message is a matching tool result; sequenceIndex:0 emitters AFTER; per-pill narration fallback LAST so it catches the BIA reprompt loop when the toolCallId chain fails. Modeled on the green langgraph-python pattern but with sequenceIndex gating to defeat the BIA reprompt loop without breaking multi-turn sessions where hasToolResult would be globally true. Interrupt fixtures intentionally omitted (interrupt-headless is a separate cluster item)."
   },
   "fixtures": [
     {
@@ -47,9 +47,10 @@
       }
     },
     {
-      "_comment": "headless-complete weather pill toolcall — emit get_weather for Tokyo. Probe sends \"What's the weather in Tokyo?\". Narrowed to the full phrase 'What's the weather in Tokyo' so this no longer shadows the D6 tool-rendering 'Chain tools' pill (whose prompt contains 'weather in Tokyo' as a substring) — that pill needs to hit its own 3-tool emission fixture in tool-rendering.json. Only userMessage+context discriminators because narration fixtures above (toolCallId) already win once the tool result lands.",
+      "_comment": "headless-complete weather pill toolcall — emit get_weather for Tokyo. Probe sends \"What's the weather in Tokyo?\". Narrowed to the full phrase 'What's the weather in Tokyo' so this no longer shadows the D6 tool-rendering 'Chain tools' pill (whose prompt contains 'weather in Tokyo' as a substring) — that pill needs to hit its own 3-tool emission fixture in tool-rendering.json. Gated on sequenceIndex:0 so the FIRST match emits the tool call; the BIA TanStack server-tool reprompt then falls through this now-exhausted emitter to the narration fallback below (the toolCallId-keyed narration above doesn't match because BIA's /v1/responses endpoint rewrites the assistant tool_call id to a runtime-generated `fc-…` value — see PARITY_NOTES). sequenceIndex (vs hasToolResult:false) preserves multi-turn correctness — hasToolResult is computed across the entire thread, so any earlier pill's tool result would permanently disable a hasToolResult:false emitter.",
       "match": {
         "userMessage": "What's the weather in Tokyo",
+        "sequenceIndex": 0,
         "context": "built-in-agent"
       },
       "response": {
@@ -63,9 +64,20 @@
       }
     },
     {
-      "_comment": "headless-complete stock pill toolcall — emit get_stock_price for AAPL. Probe sends \"What's the price of AAPL right now?\". Narrowed to 'price of AAPL right now' so this no longer shadows the D6 tool-rendering 'Stock price' pill which sends \"What's the current price of AAPL?\" (also containing 'price of AAPL' as a substring) — that pill needs its own deterministic-price fixture in tool-rendering.json.",
+      "_comment": "headless-complete weather pill narration fallback — fires on BIA TanStack reprompt iterations 2+ (sequenceIndex exhausted on the emitter above; toolCallId narration at the top fails because BIA rewrites the id). Matches every reprompt iteration with stable content; with no tool call emitted, the reprompt loop converges.",
+      "match": {
+        "userMessage": "What's the weather in Tokyo",
+        "context": "built-in-agent"
+      },
+      "response": {
+        "content": "Tokyo is 22°C and partly cloudy. The headless WeatherCard above shows the sunny snapshot from the tool."
+      }
+    },
+    {
+      "_comment": "headless-complete stock pill toolcall — emit get_stock_price for AAPL. Probe sends \"What's the price of AAPL right now?\". Narrowed to 'price of AAPL right now' so this no longer shadows the D6 tool-rendering 'Stock price' pill which sends \"What's the current price of AAPL?\" (also containing 'price of AAPL' as a substring) — that pill needs its own deterministic-price fixture in tool-rendering.json. sequenceIndex:0 gates the first emission; reprompts fall through to the narration fallback below (see weather pill comment for full rationale).",
       "match": {
         "userMessage": "price of AAPL right now",
+        "sequenceIndex": 0,
         "context": "built-in-agent"
       },
       "response": {
@@ -79,9 +91,20 @@
       }
     },
     {
-      "_comment": "headless-complete highlight pill toolcall — emit highlight_note. Probe sends \"Highlight this note for me: 'ship the demo on Friday'.\" so userMessage substring 'ship the demo on Friday' catches it.",
+      "_comment": "headless-complete stock pill narration fallback — fires on BIA TanStack reprompt iterations 2+ (see weather pill fallback for rationale).",
+      "match": {
+        "userMessage": "price of AAPL right now",
+        "context": "built-in-agent"
+      },
+      "response": {
+        "content": "AAPL is at $189.42, up 1.27% on the day."
+      }
+    },
+    {
+      "_comment": "headless-complete highlight pill toolcall — emit highlight_note. Probe sends \"Highlight this note for me: 'ship the demo on Friday'.\" so userMessage substring 'ship the demo on Friday' catches it. sequenceIndex:0 gates the first emission; reprompts fall through to the narration fallback below (see weather pill comment for full rationale).",
       "match": {
         "userMessage": "ship the demo on Friday",
+        "sequenceIndex": 0,
         "context": "built-in-agent"
       },
       "response": {
@@ -95,9 +118,20 @@
       }
     },
     {
-      "_comment": "headless-complete revenue chart toolcall — emit get_revenue_chart (no args). Probe sends 'Show me a chart of revenue over the last six months.'. Includes a short leading `content` snippet so the word 'revenue' lands in the assistant bubble synchronously with the tool-call emission. Without this, the chart card's title falls back to 'Chart' during the `executing` render phase (result still undefined), and the conversation-runner's count-based settle can fire its 1500ms quiet window before the narration follow-up message arrives — leaving the assistant text without 'revenue' on the probe's first attempt.",
+      "_comment": "headless-complete highlight pill narration fallback — fires on BIA TanStack reprompt iterations 2+ (see weather pill fallback for rationale).",
+      "match": {
+        "userMessage": "ship the demo on Friday",
+        "context": "built-in-agent"
+      },
+      "response": {
+        "content": "Highlighted 'ship the demo on Friday' for you above."
+      }
+    },
+    {
+      "_comment": "headless-complete revenue chart toolcall — emit get_revenue_chart (no args). Probe sends 'Show me a chart of revenue over the last six months.'. Includes a short leading `content` snippet so the word 'revenue' lands in the assistant bubble synchronously with the tool-call emission. Without this, the chart card's title falls back to 'Chart' during the `executing` render phase (result still undefined), and the conversation-runner's count-based settle can fire its 1500ms quiet window before the narration follow-up message arrives — leaving the assistant text without 'revenue' on the probe's first attempt. sequenceIndex:0 gates the first emission; reprompts fall through to the narration fallback below (see weather pill comment for full rationale).",
       "match": {
         "userMessage": "chart of revenue over the last six months",
+        "sequenceIndex": 0,
         "context": "built-in-agent"
       },
       "response": {
@@ -109,6 +143,16 @@
             "arguments": "{}"
           }
         ]
+      }
+    },
+    {
+      "_comment": "headless-complete revenue chart narration fallback — fires on BIA TanStack reprompt iterations 2+ (see weather pill fallback for rationale).",
+      "match": {
+        "userMessage": "chart of revenue over the last six months",
+        "context": "built-in-agent"
+      },
+      "response": {
+        "content": "Here is the chart of revenue over the last six months — quarterly revenue grew steadily, peaking in June."
       }
     }
   ]

--- a/showcase/aimock/d6/built-in-agent/tool-rendering-reasoning-chain.json
+++ b/showcase/aimock/d6/built-in-agent/tool-rendering-reasoning-chain.json
@@ -66,7 +66,7 @@
       }
     },
     {
-      "_comment": "tool-rendering-reasoning-chain pill 2 (dice) — second leg: after roll_dice(sides=20) returns, chain a smaller die for contrast.",
+      "_comment": "tool-rendering-reasoning-chain pill 2 (dice) — second leg: after roll_d20(value=20) returns, chain a smaller die for contrast.",
       "match": {
         "userMessage": "compare it to a smaller one",
         "toolCallId": "call_rc_dice_d20_001",
@@ -78,14 +78,14 @@
         "toolCalls": [
           {
             "id": "call_rc_dice_d6_001",
-            "name": "roll_dice",
-            "arguments": "{\"sides\":6}"
+            "name": "roll_d20",
+            "arguments": "{\"value\":6}"
           }
         ]
       }
     },
     {
-      "_comment": "tool-rendering-reasoning-chain pill 2 (dice) — first leg: emit roll_dice(sides=20). Unique substring 'compare it to a smaller one' keeps us scoped to this demo (other integrations' dice pills still send 'Roll a 20-sided die for me.' and fall through to the older 5x roll_d20 fixtures further down). NB: aimock's `toolName` gate is a tool-LIST gate, not a tool-CALL gate; we don't use it here because the reasoning-chain agents across the fleet all register `roll_dice`, so a `toolName: roll_dice` claim would NOT have distinguished this demo from the others.",
+      "_comment": "tool-rendering-reasoning-chain pill 2 (dice) — first leg: emit roll_d20(value=20). Unique substring 'compare it to a smaller one' keeps us scoped to this demo (other integrations' dice pills still send 'Roll a 20-sided die for me.' and fall through to the older 5x roll_d20 fixtures further down). NB: aimock's `toolName` gate is a tool-LIST gate, not a tool-CALL gate; we don't use it here because the reasoning-chain agents across the fleet all register `roll_d20`, so a `toolName: roll_d20` claim would NOT have distinguished this demo from the others.",
       "match": {
         "userMessage": "compare it to a smaller one",
         "context": "built-in-agent"
@@ -96,8 +96,8 @@
         "toolCalls": [
           {
             "id": "call_rc_dice_d20_001",
-            "name": "roll_dice",
-            "arguments": "{\"sides\":20}"
+            "name": "roll_d20",
+            "arguments": "{\"value\":20}"
           }
         ]
       }

--- a/showcase/aimock/d6/built-in-agent/tool-rendering.json
+++ b/showcase/aimock/d6/built-in-agent/tool-rendering.json
@@ -3,7 +3,8 @@
     "description": "D6 fixtures for built-in-agent / tool-rendering",
     "sourceFile": "d5-all.json",
     "copiedFrom": "langgraph-python",
-    "created": "2026-05-21"
+    "created": "2026-05-21",
+    "lastEditedNote": "BIA's /v1/responses endpoint REWRITES assistant tool_call ids to runtime-generated `fc-…` values, so toolCallId-keyed follow-ups never match on iteration 2 across the fleet. Each pill therefore uses a layered matcher: (a) toolCallId follow-up retained for the non-rewriting code path, (b) hasToolResult:true follow-up that fires regardless of id rewrites, (c) hasToolResult:false first-leg tool emitter so multi-pill sessions still trigger the tool. Mirrors the SF-weather pattern already in this file."
   },
   "fixtures": [
     {
@@ -38,10 +39,21 @@
       }
     },
     {
-      "_comment": "tool-rendering pill: Chain tools — emit 3 tool calls in one assistant turn (get_weather Tokyo + search_flights SFO->Tokyo + roll_d20=11). MUST appear before the bare 'weather in Tokyo' fixture below; substring match would otherwise leak into this prompt. No hasToolResult gate: in multi-pill demo sessions prior clicks leave tool results in the thread, which previously caused this fixture to be skipped in favour of the follow-up content fixture and the pill rendered no cards.",
+      "_comment": "Chain tools — follow-up fallback for BIA /v1/responses id-rewriting (mirrors the SF-weather hasToolResult:true pattern). Fires AFTER any of the 3 chain tools ran when the toolCallId-chained fixtures above couldn't match because the id was rewritten to `fc-…`. Must precede the first-leg emitter below.",
       "match": {
         "userMessage": "Chain a few tools in this single turn",
-        "turnIndex": 0,
+        "hasToolResult": true,
+        "context": "built-in-agent"
+      },
+      "response": {
+        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
+      }
+    },
+    {
+      "_comment": "tool-rendering pill: Chain tools — emit 3 tool calls in one assistant turn (get_weather Tokyo + search_flights SFO->Tokyo + roll_d20=11). MUST appear before the bare 'weather in Tokyo' fixture below; substring match would otherwise leak into this prompt. hasToolResult:false anchors the first-leg so multi-pill sessions (prior pills already left tool results) still emit the chain.",
+      "match": {
+        "userMessage": "Chain a few tools in this single turn",
+        "hasToolResult": false,
         "context": "built-in-agent"
       },
       "response": {
@@ -131,6 +143,34 @@
       }
     },
     {
+      "_comment": "Find flights — follow-up content fallback for BIA /v1/responses id-rewriting. Same rationale as SF-weather hasToolResult:true fixture: if the toolCallId chain above missed because the id was rewritten to `fc-…`, this fires after search_flights ran. Must precede the first-leg emitter below.",
+      "match": {
+        "userMessage": "Find flights from SFO to JFK.",
+        "hasToolResult": true,
+        "context": "built-in-agent"
+      },
+      "response": {
+        "content": "Three flights from SFO to JFK — United UA231 at 08:15 ($348), Delta DL412 at 11:20 ($312), and JetBlue B6722 at 17:05 ($289)."
+      }
+    },
+    {
+      "_comment": "Find flights — first leg: emit search_flights tool call. Anchored on hasToolResult:false so multi-pill demo sessions (prior pills left tool results) still emit; the hasToolResult:true follow-up above handles iteration 2 so there's no emit loop.",
+      "match": {
+        "userMessage": "Find flights from SFO to JFK.",
+        "hasToolResult": false,
+        "context": "built-in-agent"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_tr_flights_sfo_jfk_001",
+            "name": "search_flights",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"JFK\"}"
+          }
+        ]
+      }
+    },
+    {
       "_comment": "tool-rendering pill: Stock price — follow-up content after get_stock_price tool ran. MUST come before the tool-emitting fixture below (first-match-wins) so iteration 2 of the loop hits this branch instead of re-emitting an infinite loop of tool calls.",
       "match": {
         "userMessage": "What's the current price of AAPL?",
@@ -142,9 +182,37 @@
       }
     },
     {
+      "_comment": "Stock price — follow-up content fallback for BIA /v1/responses id-rewriting (same rationale as SF-weather hasToolResult:true fixture).",
+      "match": {
+        "userMessage": "What's the current price of AAPL?",
+        "hasToolResult": true,
+        "context": "built-in-agent"
+      },
+      "response": {
+        "content": "AAPL is trading at $338.37, down 2.96% on the day."
+      }
+    },
+    {
       "match": {
         "userMessage": "What's the current price of AAPL?",
         "turnIndex": 0,
+        "context": "built-in-agent"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_tr_stock_aapl_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Stock price — first-turn tool-emit fallback for multi-pill demo sessions where a PRIOR pill already left an assistant message in the thread, so turnIndex is not 0 and the fixture above is skipped. Anchored on hasToolResult:false so it only emits BEFORE any tool has run.",
+      "match": {
+        "userMessage": "What's the current price of AAPL?",
+        "hasToolResult": false,
         "context": "built-in-agent"
       },
       "response": {
@@ -233,10 +301,10 @@
       }
     },
     {
-      "_comment": "First roll. Matches the initial user prompt (no prior d20 tool result in this chain yet). Comes after the toolCallId-chained fixtures above so iterations 2-6 of the loop hit those first.",
+      "_comment": "First roll. Matches the initial user prompt (no prior d20 tool result in this chain yet). Comes after the toolCallId-chained fixtures above so iterations 2-6 of the loop hit those first. Anchored on hasToolResult:false rather than turnIndex:0 so multi-pill demo sessions (prior pills' tool results in the thread) still trigger the first roll.",
       "match": {
         "userMessage": "Roll a 20-sided die.",
-        "turnIndex": 0,
+        "hasToolResult": false,
         "context": "built-in-agent"
       },
       "response": {
@@ -254,6 +322,17 @@
       "match": {
         "userMessage": "weather in Tokyo",
         "toolCallId": "call_d5_get_weather_001",
+        "context": "built-in-agent"
+      },
+      "response": {
+        "content": "Tokyo is 22°C and partly cloudy."
+      }
+    },
+    {
+      "_comment": "weather in Tokyo — follow-up content fallback for BIA /v1/responses id-rewriting (same rationale as SF-weather hasToolResult:true fixture). Must precede the tool-emitting fixtures below.",
+      "match": {
+        "userMessage": "weather in Tokyo",
+        "hasToolResult": true,
         "context": "built-in-agent"
       },
       "response": {
@@ -319,9 +398,37 @@
       }
     },
     {
+      "_comment": "AAPL probe — follow-up content fallback for BIA /v1/responses id-rewriting (same rationale as SF-weather hasToolResult:true fixture). Must precede the first-leg emitter below.",
+      "match": {
+        "userMessage": "AAPL",
+        "hasToolResult": true,
+        "context": "built-in-agent"
+      },
+      "response": {
+        "content": "AAPL is trading at $189.42, up 1.27% on the day. The card above shows the live ticker and the percentage change."
+      }
+    },
+    {
       "match": {
         "userMessage": "AAPL",
         "turnIndex": 0,
+        "context": "built-in-agent"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_get_stock_price_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"AAPL\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "AAPL probe — first-leg tool-emit fallback for multi-pill sessions where turnIndex is not 0 (the custom-catchall probe sends 'weather in Tokyo' first, then 'AAPL'). Anchored on hasToolResult:false so it only emits BEFORE the stock tool has run.",
+      "match": {
+        "userMessage": "AAPL",
+        "hasToolResult": false,
         "context": "built-in-agent"
       },
       "response": {

--- a/showcase/aimock/d6/built-in-agent/tool-rendering.json
+++ b/showcase/aimock/d6/built-in-agent/tool-rendering.json
@@ -388,8 +388,9 @@
       }
     },
     {
+      "_comment": "Legacy 'current price of AAPL' probe (tool-rendering Stock-price pill alias). MUST NOT be loosened to bare 'AAPL' — bare 'AAPL' matches the headless-complete probe's 'What's the price of AAPL right now?' as a substring and shadows gen-ui-headless-complete.json's tighter matcher when the BIA reprompt loop fires after id rewriting.",
       "match": {
-        "userMessage": "AAPL",
+        "userMessage": "current price of AAPL",
         "toolCallId": "call_d5_get_stock_price_001",
         "context": "built-in-agent"
       },
@@ -398,9 +399,9 @@
       }
     },
     {
-      "_comment": "AAPL probe — follow-up content fallback for BIA /v1/responses id-rewriting (same rationale as SF-weather hasToolResult:true fixture). Must precede the first-leg emitter below.",
+      "_comment": "AAPL probe — follow-up content fallback for BIA /v1/responses id-rewriting (same rationale as SF-weather hasToolResult:true fixture). Must precede the first-leg emitter below. Tightened from bare 'AAPL' to 'current price of AAPL' to avoid shadowing gen-ui-headless-complete.json's 'price of AAPL right now' pill.",
       "match": {
-        "userMessage": "AAPL",
+        "userMessage": "current price of AAPL",
         "hasToolResult": true,
         "context": "built-in-agent"
       },
@@ -410,7 +411,7 @@
     },
     {
       "match": {
-        "userMessage": "AAPL",
+        "userMessage": "current price of AAPL",
         "turnIndex": 0,
         "context": "built-in-agent"
       },
@@ -425,9 +426,9 @@
       }
     },
     {
-      "_comment": "AAPL probe — first-leg tool-emit fallback for multi-pill sessions where turnIndex is not 0 (the custom-catchall probe sends 'weather in Tokyo' first, then 'AAPL'). Anchored on hasToolResult:false so it only emits BEFORE the stock tool has run.",
+      "_comment": "AAPL probe — first-leg tool-emit fallback for multi-pill sessions where turnIndex is not 0 (the custom-catchall probe sends 'weather in Tokyo' first, then 'AAPL'). Anchored on hasToolResult:false so it only emits BEFORE the stock tool has run. Tightened from bare 'AAPL' to 'current price of AAPL' to avoid shadowing gen-ui-headless-complete.json's 'price of AAPL right now' pill.",
       "match": {
-        "userMessage": "AAPL",
+        "userMessage": "current price of AAPL",
         "hasToolResult": false,
         "context": "built-in-agent"
       },

--- a/showcase/integrations/built-in-agent/PARITY_NOTES.md
+++ b/showcase/integrations/built-in-agent/PARITY_NOTES.md
@@ -164,6 +164,21 @@ layer.
   integration.
 - Action: tracked in follow-up PR against `packages/react-core`.
 
+### headless-complete turns 3+4 (highlight_note, revenue_chart) — server-tool reprompt loop
+
+BIA registers `get_weather` / `get_stock_price` / `get_revenue_chart` / `highlight_note` as **server-executed** tools via TanStack's `chat()` engine. After the LLM returns a tool call, TanStack runs the server tool and reprompts the LLM with the result. The aimock fixture's userMessage-keyed toolcall entries fire again on each reprompt (the original user pill text remains in conversation history), so the loop never converges: server executes → tool result returned → LLM reprompted → fixture fires again → repeat until the harness's 60s window expires.
+
+Turns 1 (weather) and 2 (stock) pass under this architecture because they don't accumulate enough reprompts to balloon the assistant message count before assertion. Turns 3 (highlight_note) and 4 (revenue_chart) hit message counts of 70+ within the timeout window.
+
+LGP works because LGP runs these tools INSIDE the Python agent and emits them as AG-UI events directly — no TanStack reprompt cycle. The mismatch is architectural.
+
+Fix options (all outside this PR's scope):
+- (a) Exclude these tools from BIA's default agent server-tool list for the headless-complete demo
+- (b) Harden aimock matcher precedence so `toolCallId` narration always wins when a tool result is the last message
+- (c) Tighten BIA fixture matchers (e.g. require absence of a matching tool result in history before firing the userMessage fixture)
+
+Tracked separately.
+
 ## Doc maintenance
 
 PARITY_NOTES inaccuracies surfaced by staging verify after PR #5413 merge — fixed 2026-06-12.

--- a/showcase/integrations/built-in-agent/PARITY_NOTES.md
+++ b/showcase/integrations/built-in-agent/PARITY_NOTES.md
@@ -164,21 +164,13 @@ layer.
   integration.
 - Action: tracked in follow-up PR against `packages/react-core`.
 
-### headless-complete turns 3+4 (highlight_note, revenue_chart) — server-tool reprompt loop
+### headless-complete server-tool reprompt loop — resolved via sequenceIndex gating
 
-BIA registers `get_weather` / `get_stock_price` / `get_revenue_chart` / `highlight_note` as **server-executed** tools via TanStack's `chat()` engine. After the LLM returns a tool call, TanStack runs the server tool and reprompts the LLM with the result. The aimock fixture's userMessage-keyed toolcall entries fire again on each reprompt (the original user pill text remains in conversation history), so the loop never converges: server executes → tool result returned → LLM reprompted → fixture fires again → repeat until the harness's 60s window expires.
+BIA registers `get_weather` / `get_stock_price` / `get_revenue_chart` / `highlight_note` as **server-executed** tools via TanStack's `chat()` engine. After the LLM returns a tool call, TanStack runs the server tool and reprompts the LLM with the result; the original user pill text remains in conversation history, so userMessage-keyed toolcall fixtures would naively fire on every reprompt and the loop never converges. BIA's `/v1/responses` endpoint also rewrites assistant `tool_call_id`s to runtime-generated `fc-…` values, breaking the toolCallId-keyed narration fallback that works on non-rewriting backends.
 
-Turns 1 (weather) and 2 (stock) pass under this architecture because they don't accumulate enough reprompts to balloon the assistant message count before assertion. Turns 3 (highlight_note) and 4 (revenue_chart) hit message counts of 70+ within the timeout window.
+Resolution (#5427 follow-up): `d6/built-in-agent/gen-ui-headless-complete.json` now structures each pill as a `(sequenceIndex:0 emitter, narration fallback)` pair. The emitter matches the FIRST request for the pill prompt (counter starts at 0) and emits the tool call; subsequent BIA reprompt iterations fall through the now-exhausted emitter to the narration fallback (no tool call), so the loop converges. `sequenceIndex` is chosen over `hasToolResult:false` because `hasToolResult` is computed across the entire thread — any earlier pill's tool result would permanently disable a `hasToolResult:false` emitter, breaking multi-turn sessions.
 
-LGP works because LGP runs these tools INSIDE the Python agent and emits them as AG-UI events directly — no TanStack reprompt cycle. The mismatch is architectural.
-
-Fix options (all outside this PR's scope):
-
-- (a) Exclude these tools from BIA's default agent server-tool list for the headless-complete demo
-- (b) Harden aimock matcher precedence so `toolCallId` narration always wins when a tool result is the last message
-- (c) Tighten BIA fixture matchers (e.g. require absence of a matching tool result in history before firing the userMessage fixture)
-
-Tracked separately.
+This pattern is BIA-specific because LGP runs these tools INSIDE the Python agent and emits them as AG-UI events directly — no TanStack reprompt cycle — so LGP's `gen-ui-headless-complete.json` retains the simpler userMessage-only emitter pattern.
 
 ## Doc maintenance
 

--- a/showcase/integrations/built-in-agent/PARITY_NOTES.md
+++ b/showcase/integrations/built-in-agent/PARITY_NOTES.md
@@ -173,6 +173,7 @@ Turns 1 (weather) and 2 (stock) pass under this architecture because they don't 
 LGP works because LGP runs these tools INSIDE the Python agent and emits them as AG-UI events directly — no TanStack reprompt cycle. The mismatch is architectural.
 
 Fix options (all outside this PR's scope):
+
 - (a) Exclude these tools from BIA's default agent server-tool list for the headless-complete demo
 - (b) Harden aimock matcher precedence so `toolCallId` narration always wins when a tool result is the last message
 - (c) Tighten BIA fixture matchers (e.g. require absence of a matching tool result in history before firing the userMessage fixture)

--- a/showcase/integrations/built-in-agent/src/app/demos/headless-complete/assistant-bubble.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/headless-complete/assistant-bubble.tsx
@@ -12,6 +12,7 @@ export function AssistantBubble({ children }: { children: React.ReactNode }) {
   return (
     <div
       data-testid="headless-message-assistant"
+      data-message-role="assistant"
       className="flex justify-start"
     >
       <div className="max-w-[85%] flex flex-col gap-2">

--- a/showcase/integrations/built-in-agent/src/app/demos/headless-complete/chart-card.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/headless-complete/chart-card.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import React from "react";
+import {
+  Bar,
+  BarChart as RechartsBarChart,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+/**
+ * Compact revenue chart card rendered when the backend `get_revenue_chart`
+ * tool runs. Wired to the manual `useRenderToolCall` path via the
+ * `useRenderTool({ name: "get_revenue_chart", ... })` registration in
+ * `tool-renderers.tsx`.
+ *
+ * Visual chrome matches the sibling WeatherCard / StockCard (raw tailwind
+ * card around a content body) — we deliberately do NOT import shadcn
+ * `Card` primitives here so the three headless cards stay visually
+ * consistent within the built-in-agent integration.
+ */
+
+export type ChartPoint = { label: string; value: number };
+
+export interface ChartCardProps {
+  loading: boolean;
+  title?: string;
+  subtitle?: string;
+  data?: ChartPoint[];
+}
+
+const BAR_COLORS = [
+  "#6366f1",
+  "#8b5cf6",
+  "#ec4899",
+  "#f97316",
+  "#10b981",
+  "#0ea5e9",
+];
+
+export function ChartCard({ loading, title, subtitle, data }: ChartCardProps) {
+  const points = Array.isArray(data) ? data : [];
+  const hasData = points.length > 0;
+
+  return (
+    <div
+      data-testid="headless-revenue-chart"
+      className="mt-2 mb-2 max-w-sm rounded-xl border border-[#DBDBE5] bg-white p-3 shadow-sm"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[10px] uppercase tracking-[0.14em] text-[#838389]">
+            {loading ? "Building chart" : "Revenue"}
+          </div>
+          <div className="truncate text-sm font-semibold text-[#010507]">
+            {title || "Chart"}
+          </div>
+        </div>
+      </div>
+      {subtitle && (
+        <div className="mt-1 text-[11px] text-[#57575B]">{subtitle}</div>
+      )}
+      {hasData ? (
+        <div className="mt-2 h-44 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <RechartsBarChart
+              data={points}
+              margin={{ top: 4, right: 8, bottom: 0, left: -16 }}
+            >
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 11, fill: "currentColor" }}
+                tickLine={false}
+                axisLine={false}
+                className="text-[#57575B]"
+              />
+              <YAxis
+                tick={{ fontSize: 11, fill: "currentColor" }}
+                tickLine={false}
+                axisLine={false}
+                className="text-[#57575B]"
+                width={32}
+              />
+              <Tooltip
+                cursor={{ fill: "#EDEDF5", opacity: 0.5 }}
+                contentStyle={{
+                  background: "#ffffff",
+                  border: "1px solid #DBDBE5",
+                  borderRadius: "8px",
+                  fontSize: "12px",
+                  color: "#010507",
+                }}
+              />
+              <Bar dataKey="value" radius={[4, 4, 0, 0]} maxBarSize={36}>
+                {points.map((_, i) => (
+                  <Cell key={i} fill={BAR_COLORS[i % BAR_COLORS.length]} />
+                ))}
+              </Bar>
+            </RechartsBarChart>
+          </ResponsiveContainer>
+        </div>
+      ) : (
+        <div className="py-6 text-center text-xs text-[#57575B]">
+          {loading ? "Building chart…" : "No data"}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/showcase/integrations/built-in-agent/src/app/demos/headless-complete/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/headless-complete/page.tsx
@@ -153,18 +153,22 @@ function ChatBody({
 }) {
   useHeadlessCompleteToolRenderers();
 
+  // Canonical 4-pill prompts shared with the LangGraph Python
+  // headless-complete demo. The D6 gen-ui-headless-complete probe drives
+  // these in order (weather → stock → highlight → revenue chart); keep in
+  // sync with `showcase/integrations/langgraph-python/src/app/demos/
+  // headless-complete/hooks/use-headless-suggestions.ts`.
   const suggestions = [
-    { title: "Weather in Tokyo", message: "What's the weather in Tokyo?" },
-    { title: "AAPL stock price", message: "What's AAPL trading at right now?" },
+    { title: "Weather", message: "What's the weather in Tokyo?" },
+    { title: "Stock price", message: "What's the price of AAPL right now?" },
     {
       title: "Highlight a note",
-      message: "Highlight 'meeting at 3pm' in yellow.",
+      message: "Highlight this note for me: 'ship the demo on Friday'.",
     },
     {
-      title: "Sketch a diagram",
-      message: "Use Excalidraw to sketch a simple system diagram.",
+      title: "Revenue chart",
+      message: "Show me a chart of revenue over the last six months.",
     },
-    { title: "Largest continent", message: "What is the largest continent?" },
   ];
 
   return (

--- a/showcase/integrations/built-in-agent/src/app/demos/headless-complete/stock-card.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/headless-complete/stock-card.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import React from "react";
+
+/**
+ * Compact gray/green/red stock card rendered when the backend
+ * `get_stock_price` tool runs. Wired through the manual
+ * `useRenderToolCall` path via `useRenderTool({ name: "get_stock_price", ... })`
+ * in `tool-renderers.tsx`.
+ */
+export interface StockCardProps {
+  loading: boolean;
+  ticker: string;
+  price?: number;
+  changePct?: number;
+}
+
+export function StockCard({
+  loading,
+  ticker,
+  price,
+  changePct,
+}: StockCardProps) {
+  const isUp = (changePct ?? 0) >= 0;
+  const accent = isUp ? "text-[#189370]" : "text-[#FA5F67]";
+  const arrow = isUp ? "▲" : "▼";
+  return (
+    <div
+      data-testid="headless-stock-card"
+      className="mt-2 mb-2 max-w-xs rounded-xl border border-[#DBDBE5] bg-white p-3 shadow-sm"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[10px] uppercase tracking-[0.14em] text-[#838389]">
+            {loading ? "Loading" : "Stock"}
+          </div>
+          <div className="truncate text-sm font-semibold text-[#010507] font-mono">
+            {ticker ? ticker.toUpperCase() : "--"}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-base font-semibold leading-none text-[#010507] font-mono">
+            {loading ? "..." : price != null ? `$${price.toFixed(2)}` : "--"}
+          </div>
+          {!loading && changePct != null && (
+            <div
+              className={`mt-0.5 text-[11px] font-medium font-mono ${accent}`}
+            >
+              {arrow} {Math.abs(changePct).toFixed(2)}%
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/showcase/integrations/built-in-agent/src/app/demos/headless-complete/tool-renderers.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/headless-complete/tool-renderers.tsx
@@ -10,24 +10,30 @@ import { z } from "zod";
 import { WeatherCard } from "./weather-card";
 import { HaikuCard } from "./haiku-card";
 import { HighlightNote, highlightNotePropsSchema } from "./highlight-note";
+import { StockCard } from "./stock-card";
+import { ChartCard, type ChartPoint } from "./chart-card";
 
 /**
  * Central registration hook for tool-call rendering surfaces in the
  * headless-complete cell.
  *
- *   - `useRenderTool({ name: "weather", ... })` — backend weather tool
- *     (built-in-agent's `weather` server tool) -> blue card.
+ *   - `useRenderTool({ name: "get_weather", ... })` — backend weather tool
+ *     (built-in-agent's `get_weather` server tool) -> blue card.
  *   - `useRenderTool({ name: "haiku", ... })` — backend haiku tool ->
  *     branded card.
+ *   - `useRenderTool({ name: "get_stock_price", ... })` — backend stock
+ *     price tool -> branded StockCard.
+ *   - `useRenderTool({ name: "get_revenue_chart", ... })` — backend
+ *     revenue chart tool -> branded ChartCard (recharts).
  *   - `useComponent({ name: "highlight_note", ... })` — frontend-only
  *     tool the agent can invoke via the same useRenderToolCall path.
  *   - `useDefaultRenderTool()` — wildcard catch-all for any other tool.
  */
 export function useHeadlessCompleteToolRenderers() {
-  // Per-tool renderer #1: backend `weather` -> branded WeatherCard.
+  // Per-tool renderer #1: backend `get_weather` -> branded WeatherCard.
   useRenderTool(
     {
-      name: "weather",
+      name: "get_weather",
       parameters: z.object({
         city: z.string(),
       }),
@@ -69,6 +75,58 @@ export function useHeadlessCompleteToolRenderers() {
             loading={loading}
             topic={parameters?.topic ?? parsed.topic ?? ""}
             lines={parsed.lines}
+          />
+        );
+      },
+    },
+    [],
+  );
+
+  // Per-tool renderer #3: backend `get_stock_price` -> branded StockCard.
+  useRenderTool(
+    {
+      name: "get_stock_price",
+      parameters: z.object({
+        ticker: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<{
+          ticker?: string;
+          price_usd?: number;
+          change_pct?: number;
+        }>(result);
+        return (
+          <StockCard
+            loading={loading}
+            ticker={parameters?.ticker ?? parsed.ticker ?? ""}
+            price={parsed.price_usd}
+            changePct={parsed.change_pct}
+          />
+        );
+      },
+    },
+    [],
+  );
+
+  // Per-tool renderer #4: backend `get_revenue_chart` -> branded ChartCard.
+  useRenderTool(
+    {
+      name: "get_revenue_chart",
+      parameters: z.object({}),
+      render: ({ result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<{
+          title?: string;
+          subtitle?: string;
+          data?: ChartPoint[];
+        }>(result);
+        return (
+          <ChartCard
+            loading={loading}
+            title={parsed.title}
+            subtitle={parsed.subtitle}
+            data={parsed.data}
           />
         );
       },

--- a/showcase/integrations/built-in-agent/src/app/demos/headless-complete/user-bubble.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/headless-complete/user-bubble.tsx
@@ -5,7 +5,11 @@ import React from "react";
 // @region[custom-bubbles]
 export function UserBubble({ children }: { children: React.ReactNode }) {
   return (
-    <div data-testid="headless-message-user" className="flex justify-end">
+    <div
+      data-testid="headless-message-user"
+      data-message-role="user"
+      className="flex justify-end"
+    >
       <div className="max-w-[75%] rounded-2xl rounded-br-sm bg-[#010507] text-white px-4 py-2 text-sm whitespace-pre-wrap break-words">
         {children}
       </div>

--- a/showcase/integrations/built-in-agent/src/app/demos/tool-rendering-custom-catchall/README.md
+++ b/showcase/integrations/built-in-agent/src/app/demos/tool-rendering-custom-catchall/README.md
@@ -15,5 +15,5 @@ every tool call — no per-tool renderers yet.
 
 Reuses the default route at `src/app/api/copilotkit/route.ts` (TanStack
 AI + `openaiText("gpt-4o")`). The mock tools (`get_weather`,
-`search_flights`, `get_stock_price`, `roll_dice`) are defined in
+`search_flights`, `get_stock_price`, `roll_d20`) are defined in
 `src/lib/factory/server-tools.ts`.

--- a/showcase/integrations/built-in-agent/src/app/demos/tool-rendering-default-catchall/README.md
+++ b/showcase/integrations/built-in-agent/src/app/demos/tool-rendering-default-catchall/README.md
@@ -13,5 +13,5 @@ collapsible Arguments / Result).
 
 Reuses the default route at `src/app/api/copilotkit/route.ts`, wired to
 `createBuiltInAgent` in `src/lib/factory/tanstack-factory.ts`. The mock
-tools (`get_weather`, `search_flights`, `get_stock_price`, `roll_dice`)
+tools (`get_weather`, `search_flights`, `get_stock_price`, `roll_d20`)
 live in `src/lib/factory/server-tools.ts`.

--- a/showcase/integrations/built-in-agent/src/app/demos/tool-rendering-default-catchall/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/tool-rendering-default-catchall/page.tsx
@@ -4,7 +4,7 @@
 //
 // The simplest entry point in the tool-rendering progression. The
 // backend exposes a handful of mock tools (get_weather, search_flights,
-// get_stock_price, roll_dice) and the frontend opts into CopilotKit's
+// get_stock_price, roll_d20) and the frontend opts into CopilotKit's
 // built-in default tool-call card by calling `useDefaultRenderTool()`
 // with no config — every tool call falls through to the package-shipped
 // `DefaultToolCallRenderer`.

--- a/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/custom-catchall-renderer.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/custom-catchall-renderer.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import React from "react";
+
+// Branded catch-all renderer for tools that don't have a dedicated
+// per-tool renderer. Registered via `useDefaultRenderTool` in
+// tool-renderers.tsx, this component handles every tool call NOT
+// claimed by a named `useRenderTool` registration.
+//
+// Shows the tool name, a status badge, pretty-printed arguments, and
+// the result (as JSON). Each cell is self-contained, so this file is
+// intentionally duplicated from the `tool-rendering-custom-catchall`
+// cell rather than imported across cell boundaries.
+
+export type CatchallToolStatus = "inProgress" | "executing" | "complete";
+
+export interface CustomCatchallRendererProps {
+  name: string;
+  status: CatchallToolStatus;
+  parameters: unknown;
+  result: string | undefined;
+}
+
+export function CustomCatchallRenderer({
+  name,
+  status,
+  parameters,
+  result,
+}: CustomCatchallRendererProps) {
+  const parsedResult = parseResult(result);
+  const done = status === "complete";
+
+  return (
+    <div
+      data-testid="custom-catchall-card"
+      data-tool-name={name}
+      data-status={status}
+      className="my-3 overflow-hidden rounded-2xl border border-[#DBDBE5] bg-white shadow-sm"
+    >
+      <div className="flex items-center justify-between border-b border-[#E9E9EF] bg-[#FAFAFC] px-4 py-2.5">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] uppercase tracking-[0.14em] text-[#838389]">
+            Tool
+          </span>
+          <span
+            data-testid="custom-catchall-tool-name"
+            className="font-mono text-sm text-[#010507]"
+          >
+            {name}
+          </span>
+        </div>
+        <StatusBadge status={status} />
+      </div>
+
+      <div className="grid gap-3 p-4 text-sm">
+        <Section label="Arguments">
+          <pre
+            data-testid="custom-catchall-args"
+            className="overflow-x-auto rounded-lg border border-[#E9E9EF] bg-[#FAFAFC] p-2.5 font-mono text-xs text-[#010507]"
+          >
+            {safeStringify(parameters)}
+          </pre>
+        </Section>
+
+        <Section label="Result">
+          {done ? (
+            <pre
+              data-testid="custom-catchall-result"
+              className="overflow-x-auto rounded-lg border border-[#85ECCE4D] bg-[#85ECCE]/10 p-2.5 font-mono text-xs text-[#010507]"
+            >
+              {parsedResult !== undefined
+                ? safeStringify(parsedResult)
+                : "(empty)"}
+            </pre>
+          ) : (
+            <p className="text-xs italic text-[#838389]">
+              waiting for tool to finish…
+            </p>
+          )}
+        </Section>
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-1.5 text-[10px] font-medium uppercase tracking-[0.14em] text-[#838389]">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: CatchallToolStatus }) {
+  const { label, tone } = describeStatus(status);
+  return (
+    <span
+      data-testid="custom-catchall-status"
+      className={`rounded-full px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] ${tone}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function describeStatus(status: CatchallToolStatus): {
+  label: string;
+  tone: string;
+} {
+  switch (status) {
+    case "inProgress":
+      return {
+        label: "streaming",
+        tone: "border border-[#FFAC4D33] bg-[#FFAC4D]/15 text-[#57575B]",
+      };
+    case "executing":
+      return {
+        label: "running",
+        tone: "border border-[#BEC2FF] bg-[#BEC2FF1A] text-[#010507]",
+      };
+    case "complete":
+      return {
+        label: "done",
+        tone: "border border-[#85ECCE4D] bg-[#85ECCE]/20 text-[#189370]",
+      };
+  }
+}
+
+function parseResult(result: string | undefined): unknown {
+  if (result === undefined || result === null) return undefined;
+  if (typeof result !== "string") return result;
+  try {
+    return JSON.parse(result);
+  } catch {
+    return result;
+  }
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}

--- a/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/d20-card.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/d20-card.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import React from "react";
+
+// Per-tool renderer for the `roll_d20` backend tool. The fixture-driven
+// e2e suite scripts the d20 mock as exactly five sequential calls
+// returning [7, 14, 3, 19, 20], so each card carries a stable
+// `data-testid="d20-card"` and a `data-d20-result` attribute for
+// deterministic assertions.
+
+export interface D20CardProps {
+  loading: boolean;
+  value?: number;
+}
+
+export function D20Card({ loading, value }: D20CardProps) {
+  const display = typeof value === "number" ? value : undefined;
+  const isCrit = display === 20;
+  return (
+    <div
+      data-testid="d20-card"
+      data-d20-result={display === undefined ? "" : String(display)}
+      className={`my-3 inline-flex items-center gap-3 rounded-2xl border border-[#DBDBE5] bg-white p-4 shadow-sm ${
+        isCrit ? "ring-2 ring-[#85ECCE]" : ""
+      }`}
+    >
+      <span
+        className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#BEC2FF1A] text-lg"
+        aria-hidden
+      >
+        d20
+      </span>
+      <div>
+        <div className="text-[10px] uppercase tracking-[0.14em] text-[#57575B]">
+          Roll
+        </div>
+        <div
+          data-testid="d20-value"
+          className="font-mono text-2xl font-semibold text-[#010507]"
+        >
+          {loading ? "…" : (display ?? "—")}
+        </div>
+      </div>
+      {isCrit ? (
+        <span className="rounded-full border border-[#85ECCE4D] bg-[#85ECCE]/20 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-[#189370]">
+          critical!
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/flight-list-card.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/flight-list-card.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import React from "react";
+
+// Rich per-tool renderer for the `search_flights` backend tool.
+//
+// Registered in tool-renderers.tsx via
+// `useRenderTool({ name: "search_flights", ... })`, this card shows the
+// search origin/destination and a short list of flight results. It only
+// renders once the backend returns; while the tool is still running it
+// shows a compact loading state so the chat doesn't look frozen.
+
+export interface Flight {
+  airline?: string;
+  flight?: string;
+  depart?: string;
+  arrive?: string;
+  price_usd?: number;
+}
+
+export interface FlightListCardProps {
+  loading: boolean;
+  origin: string;
+  destination: string;
+  flights: Flight[];
+}
+
+export function FlightListCard({
+  loading,
+  origin,
+  destination,
+  flights,
+}: FlightListCardProps) {
+  return (
+    <div
+      data-testid="flights-card"
+      className="my-3 rounded-2xl border border-[#DBDBE5] bg-white p-5 shadow-sm"
+    >
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <span
+            className="flex h-8 w-8 items-center justify-center rounded-full bg-[#BEC2FF1A] text-[#010507]"
+            aria-hidden
+          >
+            ✈
+          </span>
+          <div className="font-semibold text-[#010507]">
+            <span data-testid="flight-origin">{origin || "?"}</span>
+            <span className="mx-1.5 text-[#838389]">→</span>
+            <span data-testid="flight-destination">{destination || "?"}</span>
+          </div>
+        </div>
+        {loading ? (
+          <span className="text-[10px] uppercase tracking-[0.14em] text-[#57575B]">
+            searching…
+          </span>
+        ) : (
+          <span className="rounded-full border border-[#DBDBE5] bg-[#F7F7F9] px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-[#57575B]">
+            {flights.length} result{flights.length === 1 ? "" : "s"}
+          </span>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="space-y-2">
+          <Skeleton />
+          <Skeleton />
+          <Skeleton />
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {flights.length === 0 ? (
+            <li className="text-sm italic text-[#57575B]">
+              No flights returned.
+            </li>
+          ) : (
+            flights.map((f, i) => (
+              <li
+                key={`${f.flight ?? "flight"}-${i}`}
+                data-testid="flight-row"
+                className="flex items-center justify-between rounded-xl border border-[#E9E9EF] bg-[#FAFAFC] px-3 py-2.5 text-sm"
+              >
+                <div>
+                  <div className="font-medium text-[#010507]">
+                    {f.airline ?? "—"}{" "}
+                    <span className="font-mono text-xs text-[#838389]">
+                      {f.flight ?? ""}
+                    </span>
+                  </div>
+                  <div className="text-xs text-[#57575B] mt-0.5">
+                    {f.depart ?? "?"} → {f.arrive ?? "?"}
+                  </div>
+                </div>
+                <div className="font-mono text-sm font-medium text-[#189370]">
+                  {f.price_usd !== undefined ? `$${f.price_usd}` : "—"}
+                </div>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function Skeleton() {
+  return (
+    <div className="h-10 animate-pulse rounded-xl bg-[#F0F0F4]" aria-hidden />
+  );
+}

--- a/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/page.tsx
@@ -1,13 +1,17 @@
 "use client";
 
-// @region[render-weather-tool]
-import {
-  CopilotKitProvider,
-  CopilotChat,
-  useRenderTool,
-  useDefaultRenderTool,
-} from "@copilotkit/react-core/v2";
-import { z } from "zod";
+// Tool Rendering — PRIMARY (per-tool + catch-all) variant for
+// built-in-agent. Ports the LGP `tool-rendering` cell:
+//
+//   get_weather     → <WeatherCard />       (per-tool renderer)
+//   search_flights  → <FlightListCard />    (per-tool renderer)
+//   get_stock_price → <StockCard />         (per-tool renderer)
+//   roll_d20        → <D20Card />           (per-tool renderer)
+//   *               → <CustomCatchallRenderer /> (wildcard fallback)
+
+import { CopilotKitProvider, CopilotChat } from "@copilotkit/react-core/v2";
+import { useToolRenderingRenderers } from "./tool-renderers";
+import { useSuggestions } from "./suggestions";
 
 export default function ToolRendering() {
   return (
@@ -18,134 +22,14 @@ export default function ToolRendering() {
 }
 
 function Demo() {
-  useRenderTool({
-    name: "get_weather",
-    parameters: z.object({ location: z.string() }),
-    render: ({ parameters, result, status }) => {
-      return (
-        <WeatherCard
-          loading={status !== "complete"}
-          parameters={parameters}
-          result={result}
-        />
-      );
-    },
-  });
-  // @endregion[render-weather-tool]
-
-  // @region[catchall-renderer]
-  useDefaultRenderTool({
-    render: GenericToolCard,
-  });
-  // @endregion[catchall-renderer]
+  useToolRenderingRenderers();
+  useSuggestions();
 
   return (
-    <main className="p-8">
-      <h1 className="text-2xl font-semibold mb-4">Tool Rendering</h1>
-      <p className="text-sm opacity-70 mb-6">
-        Try: &ldquo;What&apos;s the weather in Tokyo?&rdquo; The
-        <code className="mx-1 px-1 bg-gray-100 rounded">get_weather</code>tool
-        renders with a custom card; everything else falls back to a generic
-        renderer.
-      </p>
-      <CopilotChat />
-    </main>
-  );
-}
-
-/**
- * WeatherCard — rendered via `useRenderTool({ name: "get_weather" })`.
- *
- * Receives `loading`, `parameters` (tool args), and `result` (tool output).
- * The server tool returns: { city, temperature, humidity, wind_speed, conditions }.
- */
-function WeatherCard({
-  loading,
-  parameters,
-  result,
-}: {
-  loading: boolean;
-  parameters?: { location?: string };
-  result?: unknown;
-}) {
-  if (loading || !result) {
-    return (
-      <div className="border rounded p-3 my-2 opacity-70 text-sm">
-        Fetching weather…
-      </div>
-    );
-  }
-
-  let data: {
-    city?: string;
-    temperature?: number;
-    tempF?: number;
-    condition?: string;
-    conditions?: string;
-    humidity?: number;
-    wind_speed?: number;
-  } = {};
-  try {
-    data =
-      typeof result === "string" ? JSON.parse(result) : (result as typeof data);
-  } catch {
-    // Leave data empty on parse failure
-  }
-  const city = data.city ?? parameters?.location ?? "—";
-  const temp = data.temperature ?? data.tempF;
-  const condition = data.conditions ?? data.condition;
-  const humidityVal = data.humidity;
-  const humidityStr =
-    humidityVal != null
-      ? humidityVal < 1
-        ? `${Math.round(humidityVal * 100)}%`
-        : `${humidityVal}%`
-      : "—";
-  return (
-    <div data-testid="weather-card" className="border rounded p-3 my-2">
-      <div className="font-medium">Weather in {city}</div>
-      <div className="grid grid-cols-3 gap-2 text-sm mt-2">
-        <div>
-          <div className="opacity-60">Temp</div>
-          <div>{temp != null ? `${temp}°F` : "—"}</div>
-        </div>
-        <div>
-          <div className="opacity-60">Condition</div>
-          <div>{condition ?? "—"}</div>
-        </div>
-        <div>
-          <div className="opacity-60">Humidity</div>
-          <div>{humidityStr}</div>
-        </div>
+    <div className="flex justify-center items-center h-screen w-full">
+      <div className="h-full w-full max-w-4xl">
+        <CopilotChat className="h-full rounded-2xl" />
       </div>
     </div>
   );
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function GenericToolCard(props: any) {
-  const { name, status, parameters, result } = props;
-  return (
-    <div className="border rounded p-2 my-2 text-xs">
-      <div className="font-mono opacity-60">
-        {name} <span className="opacity-50">[{status}]</span>
-      </div>
-      <pre className="overflow-auto text-[10px] mt-1">
-        {JSON.stringify(
-          status === "complete" ? safeParse(result) : parameters,
-          null,
-          2,
-        )}
-      </pre>
-    </div>
-  );
-}
-
-function safeParse(value: unknown): unknown {
-  if (typeof value !== "string") return value;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
 }

--- a/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/stock-card.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/stock-card.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import React from "react";
+
+// Per-tool renderer for the `get_stock_price` backend tool. Registered
+// in tool-renderers.tsx via
+// `useRenderTool({ name: "get_stock_price", ... })`. Carries a stable
+// `data-testid="stock-card"` and inner price/change testids so the
+// cell's e2e tests can pin to deterministic fixture values.
+
+export interface StockCardProps {
+  loading: boolean;
+  ticker: string;
+  priceUsd?: number;
+  changePct?: number;
+}
+
+export function StockCard({
+  loading,
+  ticker,
+  priceUsd,
+  changePct,
+}: StockCardProps) {
+  const upper = (ticker || "").toUpperCase();
+  const positive = (changePct ?? 0) >= 0;
+  const changeStr =
+    changePct === undefined
+      ? "--"
+      : `${positive ? "+" : ""}${changePct.toFixed(2)}%`;
+
+  return (
+    <div
+      data-testid="stock-card"
+      className="my-3 rounded-2xl border border-[#DBDBE5] bg-white p-5 shadow-sm"
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <span
+            className="flex h-8 w-8 items-center justify-center rounded-full bg-[#BEC2FF1A] font-semibold text-[#010507]"
+            aria-hidden
+          >
+            $
+          </span>
+          <div>
+            <div className="text-[10px] uppercase tracking-[0.14em] text-[#57575B]">
+              Stock
+            </div>
+            <div
+              data-testid="stock-ticker"
+              className="font-mono text-base font-semibold text-[#010507]"
+            >
+              {upper || "—"}
+            </div>
+          </div>
+        </div>
+        {loading ? (
+          <span className="text-[10px] uppercase tracking-[0.14em] text-[#57575B]">
+            fetching…
+          </span>
+        ) : null}
+      </div>
+
+      {!loading ? (
+        <div className="mt-4 flex items-end justify-between border-t border-[#DBDBE5] pt-4">
+          <div>
+            <div className="text-[10px] uppercase tracking-[0.14em] text-[#57575B]">
+              Price
+            </div>
+            <div
+              data-testid="stock-price"
+              className="mt-1 text-2xl font-semibold text-[#010507] tracking-tight"
+            >
+              {priceUsd !== undefined ? `$${priceUsd.toFixed(2)}` : "—"}
+            </div>
+          </div>
+          <div className="text-right">
+            <div className="text-[10px] uppercase tracking-[0.14em] text-[#57575B]">
+              Change
+            </div>
+            <div
+              data-testid="stock-change"
+              className={`mt-1 font-mono text-sm font-medium ${
+                positive ? "text-[#189370]" : "text-[#D14343]"
+              }`}
+            >
+              {changeStr}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/tool-renderers.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/tool-renderers.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import React from "react";
+import { useRenderTool, useDefaultRenderTool } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+import { WeatherCard } from "./weather-card";
+import { FlightListCard, type Flight } from "./flight-list-card";
+import { StockCard } from "./stock-card";
+import { D20Card } from "./d20-card";
+import {
+  CustomCatchallRenderer,
+  type CatchallToolStatus,
+} from "./custom-catchall-renderer";
+
+interface WeatherResult {
+  city?: string;
+  temperature?: number;
+  humidity?: number;
+  wind_speed?: number;
+  conditions?: string;
+}
+
+interface FlightSearchResult {
+  origin?: string;
+  destination?: string;
+  flights?: Flight[];
+}
+
+interface StockResult {
+  ticker?: string;
+  price_usd?: number;
+  change_pct?: number;
+}
+
+interface D20Result {
+  value?: number;
+  result?: number;
+  sides?: number;
+}
+
+/**
+ * Central registration hook for tool-call rendering surfaces in the
+ * built-in-agent `tool-rendering` cell. Mirrors the LGP cell at
+ * `langgraph-python/src/app/demos/tool-rendering/page.tsx`:
+ *
+ *   - get_weather     → WeatherCard
+ *   - search_flights  → FlightListCard
+ *   - get_stock_price → StockCard
+ *   - roll_d20        → D20Card
+ *   - *               → CustomCatchallRenderer (wildcard fallback)
+ */
+export function useToolRenderingRenderers() {
+  // Per-tool renderer #1: get_weather → branded WeatherCard.
+  // @region[render-weather-tool]
+  useRenderTool(
+    {
+      name: "get_weather",
+      parameters: z.object({
+        location: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<WeatherResult>(result);
+        return (
+          <WeatherCard
+            loading={loading}
+            location={parameters?.location ?? parsed.city ?? ""}
+            temperature={parsed.temperature}
+            humidity={parsed.humidity}
+            windSpeed={parsed.wind_speed}
+            conditions={parsed.conditions}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-weather-tool]
+
+  // Per-tool renderer #2: search_flights → branded FlightListCard.
+  // @region[render-flight-tool]
+  useRenderTool(
+    {
+      name: "search_flights",
+      parameters: z.object({
+        origin: z.string(),
+        destination: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<FlightSearchResult>(result);
+        return (
+          <FlightListCard
+            loading={loading}
+            origin={parameters?.origin ?? parsed.origin ?? ""}
+            destination={parameters?.destination ?? parsed.destination ?? ""}
+            flights={parsed.flights ?? []}
+          />
+        );
+      },
+    },
+    [],
+  );
+  // @endregion[render-flight-tool]
+
+  // Per-tool renderer #3: get_stock_price → branded StockCard.
+  useRenderTool(
+    {
+      name: "get_stock_price",
+      parameters: z.object({
+        ticker: z.string(),
+      }),
+      render: ({ parameters, result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<StockResult>(result);
+        return (
+          <StockCard
+            loading={loading}
+            ticker={parameters?.ticker ?? parsed.ticker ?? ""}
+            priceUsd={parsed.price_usd}
+            changePct={parsed.change_pct}
+          />
+        );
+      },
+    },
+    [],
+  );
+
+  // Per-tool renderer #4: roll_d20 → branded D20Card. Each tool call
+  // mounts its own card so e2e tests can count them.
+  useRenderTool(
+    {
+      name: "roll_d20",
+      parameters: z.object({
+        value: z.number().optional(),
+      }),
+      render: ({ result, status }) => {
+        const loading = status !== "complete";
+        const parsed = parseJsonResult<D20Result>(result);
+        const value =
+          typeof parsed.value === "number"
+            ? parsed.value
+            : typeof parsed.result === "number"
+              ? parsed.result
+              : undefined;
+        return <D20Card loading={loading} value={value} />;
+      },
+    },
+    [],
+  );
+
+  // @region[catchall-renderer]
+  // Wildcard catch-all for anything that doesn't match a per-tool
+  // renderer above.
+  useDefaultRenderTool(
+    {
+      render: ({ name, parameters, status, result }) => (
+        <CustomCatchallRenderer
+          name={name}
+          parameters={parameters}
+          status={status as CatchallToolStatus}
+          result={result}
+        />
+      ),
+    },
+    [],
+  );
+  // @endregion[catchall-renderer]
+}
+
+function parseJsonResult<T>(result: unknown): T {
+  if (!result) return {} as T;
+  try {
+    return (typeof result === "string" ? JSON.parse(result) : result) as T;
+  } catch {
+    return {} as T;
+  }
+}

--- a/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/weather-card.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/tool-rendering/weather-card.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React from "react";
+
+export interface WeatherCardProps {
+  loading: boolean;
+  location: string;
+  temperature?: number;
+  humidity?: number;
+  windSpeed?: number;
+  conditions?: string;
+}
+
+export function WeatherCard({
+  loading,
+  location,
+  temperature,
+  humidity,
+  windSpeed,
+  conditions,
+}: WeatherCardProps) {
+  return (
+    <div
+      data-testid="weather-card"
+      className="rounded-2xl mt-4 mb-4 max-w-md w-full bg-[#EDEDF5] border border-[#DBDBE5] text-[#010507] shadow-sm"
+    >
+      <div className="p-5">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="text-[10px] uppercase tracking-[0.14em] text-[#57575B] mb-1">
+              Current weather
+            </div>
+            <h3
+              data-testid="weather-city"
+              className="text-xl font-semibold capitalize text-[#010507]"
+            >
+              {location || "Weather"}
+            </h3>
+            <p className="text-[#57575B] text-sm mt-0.5">
+              {loading ? "Fetching weather..." : conditions || "—"}
+            </p>
+          </div>
+          <div className="text-4xl leading-none" aria-hidden>
+            {loading ? "..." : conditionsEmoji(conditions)}
+          </div>
+        </div>
+
+        {!loading && (
+          <>
+            <div className="mt-5 text-4xl font-semibold text-[#010507] tracking-tight">
+              {temperature ?? "--"}&deg;
+              <span className="ml-1 text-lg font-normal text-[#57575B]">F</span>
+            </div>
+            <div className="mt-5 pt-4 border-t border-[#DBDBE5] grid grid-cols-2 gap-3 text-sm">
+              <div data-testid="weather-humidity">
+                <p className="text-[10px] uppercase tracking-[0.14em] text-[#57575B]">
+                  Humidity
+                </p>
+                <p className="mt-1 font-medium text-[#010507]">
+                  {humidity ?? "--"}%
+                </p>
+              </div>
+              <div data-testid="weather-wind">
+                <p className="text-[10px] uppercase tracking-[0.14em] text-[#57575B]">
+                  Wind
+                </p>
+                <p className="mt-1 font-medium text-[#010507]">
+                  {windSpeed ?? "--"} mph
+                </p>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function conditionsEmoji(conditions?: string): string {
+  if (!conditions) return "";
+  const c = conditions.toLowerCase();
+  if (c.includes("sun") || c.includes("clear")) return "sun";
+  if (c.includes("rain") || c.includes("storm")) return "rain";
+  if (c.includes("cloud")) return "cloud";
+  if (c.includes("snow")) return "snow";
+  return "";
+}

--- a/showcase/integrations/built-in-agent/src/lib/factory/reasoning-factory.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/reasoning-factory.ts
@@ -127,7 +127,7 @@ export function createReasoningDefaultRenderAgent() {
 /**
  * Built-in agent for `tool-rendering-reasoning-chain` — combines visible
  * reasoning with sequential tool calls (get_weather, search_flights,
- * roll_dice, get_stock_price) so the demo can show an interleaved
+ * roll_d20, get_stock_price) so the demo can show an interleaved
  * reasoning + tool-call chain.
  */
 export function createToolRenderingReasoningChainAgent() {

--- a/showcase/integrations/built-in-agent/src/lib/factory/server-tools.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/server-tools.ts
@@ -108,8 +108,8 @@ export const getStockPriceTool = toolDefinition({
   };
 });
 
-export const rollDiceTool = toolDefinition({
-  name: "roll_dice",
+export const rollD20Tool = toolDefinition({
+  name: "roll_d20",
   description: "Roll a single die with the given number of sides.",
   inputSchema: z.object({
     sides: z.number().int().min(2).default(6),
@@ -143,6 +143,6 @@ export const baseServerTools = [
   getWeatherTool,
   searchFlightsTool,
   getStockPriceTool,
-  rollDiceTool,
+  rollD20Tool,
   setNotesTool,
 ] as const;

--- a/showcase/integrations/built-in-agent/src/lib/factory/server-tools.ts
+++ b/showcase/integrations/built-in-agent/src/lib/factory/server-tools.ts
@@ -108,6 +108,31 @@ export const getStockPriceTool = toolDefinition({
   };
 });
 
+// Mock revenue chart for the headless-complete demo's "Revenue chart"
+// pill. Returns six months of quarterly revenue data so the
+// `get_revenue_chart` tool result drives the ChartCard renderer with a
+// deterministic shape (label/value pairs, peaking in June). Mirrors the
+// LangGraph Python reference agent's `get_revenue_chart` tool.
+export const getRevenueChartTool = toolDefinition({
+  name: "get_revenue_chart",
+  description:
+    "Get a mock chart of quarterly revenue over the last six months. " +
+    "Returns label/value points (one per month, Jan–Jun) plus a title " +
+    "and subtitle so the client can render a bar chart.",
+  inputSchema: z.object({}),
+}).server(async () => ({
+  title: "Quarterly revenue",
+  subtitle: "USD thousands",
+  data: [
+    { label: "Jan", value: 42 },
+    { label: "Feb", value: 51 },
+    { label: "Mar", value: 58 },
+    { label: "Apr", value: 64 },
+    { label: "May", value: 73 },
+    { label: "Jun", value: 81 },
+  ],
+}));
+
 export const rollD20Tool = toolDefinition({
   name: "roll_d20",
   description: "Roll a single die with the given number of sides.",
@@ -143,6 +168,7 @@ export const baseServerTools = [
   getWeatherTool,
   searchFlightsTool,
   getStockPriceTool,
+  getRevenueChartTool,
   rollD20Tool,
   setNotesTool,
 ] as const;

--- a/showcase/integrations/built-in-agent/tests/e2e/tool-rendering-reasoning-chain.spec.ts
+++ b/showcase/integrations/built-in-agent/tests/e2e/tool-rendering-reasoning-chain.spec.ts
@@ -9,11 +9,11 @@ import { test, expect } from "@playwright/test";
 //     `messageView.reasoningMessage` slot (<ReasoningBlock>).
 //   - Per-tool renderers wired via `useRenderTool` for `get_weather` and
 //     `search_flights`, plus a `useDefaultRenderTool` catchall that
-//     paints `get_stock_price` and `roll_dice`.
+//     paints `get_stock_price` and `roll_d20`.
 //
 // Every pill drives a CHAINED two-tool flow:
 //   - Stocks: get_stock_price(AAPL) → get_stock_price(MSFT) → comparison.
-//   - Dice: roll_dice(sides=20) → roll_dice(sides=6) → contrast.
+//   - Dice: roll_d20(sides=20) → roll_d20(sides=6) → contrast.
 //   - Flights+weather: search_flights(SFO,JFK) → get_weather(JFK) → plan.
 //
 // Aimock fixtures live in showcase/aimock/d5-all.json (and the matching
@@ -109,7 +109,7 @@ test.describe("Tool Rendering — Reasoning Chain", () => {
       .click();
 
     const diceCards = page.locator(
-      '[data-testid="custom-catchall-card"][data-tool-name="roll_dice"]',
+      '[data-testid="custom-catchall-card"][data-tool-name="roll_d20"]',
     );
     await expect
       .poll(async () => diceCards.count(), { timeout: TOOL_TIMEOUT })
@@ -213,7 +213,7 @@ test.describe("Tool Rendering — Reasoning Chain", () => {
       .first()
       .click();
     const diceCards = page.locator(
-      '[data-testid="custom-catchall-card"][data-tool-name="roll_dice"]',
+      '[data-testid="custom-catchall-card"][data-tool-name="roll_d20"]',
     );
     await expect
       .poll(async () => diceCards.count(), { timeout: TOOL_TIMEOUT })

--- a/showcase/scripts/__tests__/aimock-fixtures.test.ts
+++ b/showcase/scripts/__tests__/aimock-fixtures.test.ts
@@ -232,7 +232,17 @@ describe("fixture collision detection", () => {
     // prebuilt-popup.json / prebuilt-sidebar.json entries for that context.
     // Disambiguated at runtime by the probe's fixtureFile / demo route, like
     // the other cross-feature overlaps above.
-    const KNOWN_DUPLICATE_CEILING = 290;
+    //
+    // Bumped 290 → 291 (+1) in #5427 when BIA tool-rendering.json's bare 'AAPL'
+    // matchers were tightened to 'current price of AAPL' to stop shadowing
+    // gen-ui-headless-complete.json's 'price of AAPL right now' headless pill.
+    // The tightened matchers share keys with tool-rendering-custom-catchall.json's
+    // pre-existing 'current price of AAPL' entries in the same BIA context (the
+    // hasToolResult:false emitter pair and the hasToolResult:true narration pair).
+    // Disambiguated at runtime by feature route (tool-rendering vs custom-catchall
+    // fixtureFile) plus the catchall's distinct first prompt ('check Tokyo weather
+    // forecast') that gates the multi-pill session before the AAPL pill fires.
+    const KNOWN_DUPLICATE_CEILING = 291;
 
     const collisions: string[] = [];
 
@@ -289,7 +299,17 @@ describe("fixture collision detection", () => {
     // fixtures from the BIA 5-tool D6 port (weather/flight/stock/d20/
     // catchall pill variants), runtime-disambiguated by toolName +
     // toolCallId.
-    const KNOWN_SHADOW_CEILING = 134;
+    //
+    // Ratcheted 134→132 (-2) in #5427 follow-up: BIA tool-rendering.json's
+    // bare 'AAPL' matchers were tightened to 'current price of AAPL' (no
+    // longer a substring of gen-ui-headless-complete's 'price of AAPL right
+    // now' pill), removing 2 pre-existing shadow pairs. The companion
+    // sequenceIndex-gated emitter + narration-fallback pairs in
+    // gen-ui-headless-complete.json do not introduce new shadows — the
+    // narration fallbacks share the same userMessage prefix as the emitters
+    // (which the shadow detector skips because identical strings are caught
+    // by the exact-duplicate test, not the shadow test).
+    const KNOWN_SHADOW_CEILING = 132;
 
     const shadows: string[] = [];
 

--- a/showcase/scripts/__tests__/aimock-fixtures.test.ts
+++ b/showcase/scripts/__tests__/aimock-fixtures.test.ts
@@ -284,7 +284,12 @@ describe("fixture collision detection", () => {
     // gen-ui-declarative + cst/tool-rendering fixtures, runtime-disambiguated
     // by toolCallId chunk boundaries and load-order ordering of inner-call
     // mirrors before outer fixtures (see _meta._note in those files).
-    const KNOWN_SHADOW_CEILING = 128;
+    // Bumped 128→134 in #5427: 6 new substring overlaps in
+    // d6/built-in-agent/{tool-rendering, tool-rendering-reasoning-chain}
+    // fixtures from the BIA 5-tool D6 port (weather/flight/stock/d20/
+    // catchall pill variants), runtime-disambiguated by toolName +
+    // toolCallId.
+    const KNOWN_SHADOW_CEILING = 134;
 
     const shadows: string[] = [];
 


### PR DESCRIPTION
## Summary

BIA D6 component port (#4 from PR #5413 followup list). Companion to PR #5407 (claude-sdk-python), PR #5413 (initial BIA D6), PR #5421 (BIA D6 small follow-ups). Brings BIA closer to LGP gold-standard parity.

### What's in

- **tool-rendering**: 5 LGP-mirrored companion components (`weather-card`, `flight-list-card`, `stock-card`, `d20-card`, `custom-catchall-renderer`) + extracted `tool-renderers.tsx` wiring. **D6 GREEN.**
- **headless-complete**: 2 new components (`stock-card`, `chart-card`) + `get_revenue_chart` server tool + LGP-aligned 4 pill suggestions + `data-message-role` on bubble cascade + `get_weather` tool name fix in tool-renderers. Turns 1 (weather) + 2 (stock) GREEN.
- **roll_dice → roll_d20 rename** across BIA backend + reasoning-chain references (LGP canonical naming).
- **aimock fixtures**: BIA-namespaced `tool-rendering.json` updated + `tool-rendering-reasoning-chain.json` realigned to the rename.
- **PARITY_NOTES**: documents the server-tool reprompt loop architectural gap blocking turns 3+4 of headless-complete.

### Known issue (documented in PARITY_NOTES.md, out-of-PR-scope)

headless-complete turns 3 (highlight_note) and 4 (revenue_chart) RED due to BIA's TanStack multi-turn server-tool reprompt cycle + aimock userMessage-keyed fixtures looping until timeout. Three remediation options identified — all require changes outside this PR's scope (BIA agent architecture / aimock matcher precedence / fixture matcher gating).

### Test plan

- [x] Local `--direct` D6 on tool-rendering: GREEN (2.8s)
- [x] Local `--direct` D6 on headless-complete: turns 1+2 GREEN, turns 3+4 RED (documented)
- [x] CI green on PR