### PR TITLE
feat(angular): add React v2 run-control parity to CopilotChat (#5428)

### DIFF
--- a/packages/angular/src/lib/chat-state.ts
+++ b/packages/angular/src/lib/chat-state.ts
@@ -1,11 +1,24 @@
-import { inject, Injectable, WritableSignal } from "@angular/core";
+import { inject, Injectable, Signal, WritableSignal } from "@angular/core";
 
 @Injectable()
 export abstract class ChatState {
   abstract readonly inputValue: WritableSignal<string>;
 
-  abstract submitInput(value: string): void;
+  abstract submitInput(value: string): void | Promise<void>;
   abstract changeInput(value: string): void;
+
+  /**
+   * Whether the agent is currently running.
+   * Optional — components that don't manage a run fall back to `undefined`.
+   */
+  readonly isRunning?: Signal<boolean>;
+
+  /**
+   * Stop the currently active run.
+   * Optional — only provided when the chat is wired to a run-aware agent
+   * (e.g. `CopilotChat`).
+   */
+  stopCurrentRun?(): void;
 }
 
 export function injectChatState(): ChatState {

--- a/packages/angular/src/lib/chat-state.ts
+++ b/packages/angular/src/lib/chat-state.ts
@@ -14,6 +14,19 @@ export abstract class ChatState {
   readonly isRunning?: Signal<boolean>;
 
   /**
+   * Whether a stop action is currently meaningful.
+   *
+   * Mirrors React v2 `shouldAllowStop = agent.isRunning && hasMessages`:
+   * the stop affordance is only active when a run is in flight AND the thread
+   * already has at least one message (so clicking Stop on the welcome screen
+   * before any message is sent does nothing).
+   *
+   * Optional — when absent, `CopilotChatInput` falls back to checking whether
+   * `stopCurrentRun` is defined (the pre-#5428 behaviour).
+   */
+  readonly canStopRun?: Signal<boolean>;
+
+  /**
    * Stop the currently active run.
    * Optional — only provided when the chat is wired to a run-aware agent
    * (e.g. `CopilotChat`).

--- a/packages/angular/src/lib/components/chat/__tests__/copilot-chat-input.component.spec.ts
+++ b/packages/angular/src/lib/components/chat/__tests__/copilot-chat-input.component.spec.ts
@@ -20,12 +20,13 @@ class ChatStateStub extends ChatState {
 }
 
 // ---------------------------------------------------------------------------
-// Stub that exposes isRunning + stopCurrentRun (mirrors CopilotChat)
+// Stub that exposes isRunning + stopCurrentRun + canStopRun (mirrors CopilotChat)
 // ---------------------------------------------------------------------------
 @Injectable()
 class RunAwareChatStateStub extends ChatState {
   inputValue = signal("");
   readonly isRunning = signal<boolean>(false);
+  readonly canStopRun = signal<boolean>(false);
   submitInput = vi.fn((value: string) => this.inputValue.set(value));
   changeInput = vi.fn((value: string) => this.inputValue.set(value));
   stopCurrentRun = vi.fn();
@@ -149,26 +150,69 @@ describe("CopilotChatInput", () => {
       expect(component.canSend()).toBe(true);
     });
 
-    it("canStop is true when ChatState exposes stopCurrentRun", () => {
+    it("canStop is true when ChatState exposes canStopRun = true", () => {
+      runAwareState.canStopRun.set(true);
       expect(component.canStop()).toBe(true);
+    });
+
+    it("canStop is false when ChatState exposes canStopRun = false", () => {
+      runAwareState.canStopRun.set(false);
+      expect(component.canStop()).toBe(false);
     });
 
     it("sendButtonDisabled is true when not running and composer is empty", () => {
       runAwareState.isRunning.set(false);
+      runAwareState.canStopRun.set(false);
       runAwareState.changeInput("");
       expect(component.sendButtonDisabled()).toBe(true);
     });
 
     it("sendButtonDisabled is false when not running and composer has text", () => {
       runAwareState.isRunning.set(false);
+      runAwareState.canStopRun.set(false);
       runAwareState.changeInput("hello");
       expect(component.sendButtonDisabled()).toBe(false);
     });
 
-    it("sendButtonDisabled is false (stop enabled) when running and canStop", () => {
+    it("sendButtonDisabled is false (stop enabled) when running with messages and canStopRun", () => {
       runAwareState.isRunning.set(true);
+      runAwareState.canStopRun.set(true);
       runAwareState.changeInput(""); // empty — isProcessing && !canSend
       expect(component.sendButtonDisabled()).toBe(false); // stop is available
+    });
+
+    it("sendButtonDisabled is true when running but canStopRun=false (no messages yet)", () => {
+      runAwareState.isRunning.set(true);
+      runAwareState.canStopRun.set(false); // welcome-screen guard: no messages
+      runAwareState.changeInput("");
+      // isProcessing=true, !canStop=true → disabled
+      expect(component.sendButtonDisabled()).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // canStop fallback: no canStopRun signal — falls back to stopCurrentRun presence
+  // ---------------------------------------------------------------------------
+  describe("canStop fallback (ChatState without canStopRun signal)", () => {
+    it("falls back to true when ChatState has stopCurrentRun but no canStopRun", () => {
+      // RunAwareChatStateStub does have canStopRun, but use the base stub:
+      @Injectable()
+      class LegacyStopState extends ChatState {
+        inputValue = signal("");
+        submitInput = vi.fn();
+        changeInput = vi.fn();
+        // No canStopRun signal — only the method
+        stopCurrentRun = vi.fn();
+      }
+
+      const result = makeComponent(LegacyStopState);
+      // canStopRun signal not set → falls back to typeof stopCurrentRun === "function"
+      expect(result.component.canStop()).toBe(true);
+    });
+
+    it("falls back to false when ChatState has neither canStopRun nor stopCurrentRun", () => {
+      // ChatStateStub has no stopCurrentRun
+      expect(component.canStop()).toBe(false);
     });
   });
 
@@ -203,6 +247,7 @@ describe("CopilotChatInput", () => {
 
       // Prepare: running with sendable text
       runAwareState.isRunning.set(true);
+      runAwareState.canStopRun.set(true);
       runAwareState.changeInput("a brand new message");
 
       // Enter with sendable text during a run => SEND (not stop).
@@ -231,6 +276,7 @@ describe("CopilotChatInput", () => {
       component.stop.subscribe(stopSpy);
 
       runAwareState.isRunning.set(true);
+      runAwareState.canStopRun.set(true);
       runAwareState.changeInput(""); // empty composer
 
       component.handleKeyDown(
@@ -247,6 +293,7 @@ describe("CopilotChatInput", () => {
       component.submitMessage.subscribe(submitSpy);
 
       runAwareState.isRunning.set(false);
+      runAwareState.canStopRun.set(false);
       runAwareState.changeInput("hello");
 
       component.handleKeyDown(
@@ -262,6 +309,7 @@ describe("CopilotChatInput", () => {
       component.submitMessage.subscribe(submitSpy);
 
       runAwareState.isRunning.set(false);
+      runAwareState.canStopRun.set(false);
       runAwareState.changeInput("hello");
 
       component.handleKeyDown(
@@ -278,6 +326,7 @@ describe("CopilotChatInput", () => {
       component.stop.subscribe(stopSpy);
 
       runAwareState.isRunning.set(true);
+      runAwareState.canStopRun.set(true);
       runAwareState.changeInput("some text");
 
       component.handleSendButtonClick();
@@ -292,6 +341,7 @@ describe("CopilotChatInput", () => {
       component.submitMessage.subscribe(submitSpy);
 
       runAwareState.isRunning.set(false);
+      runAwareState.canStopRun.set(false);
       runAwareState.changeInput("hello");
 
       component.handleSendButtonClick();
@@ -316,6 +366,7 @@ describe("CopilotChatInput", () => {
       const state = result.chatState as RunAwareChatStateStub;
 
       state.isRunning.set(true);
+      state.canStopRun.set(true);
       state.changeInput(""); // empty so Enter routes to stop
 
       c.handleKeyDown(
@@ -349,105 +400,5 @@ describe("CopilotChatInput", () => {
       component.modeSignal.set("processing");
       expect(component.textAreaContext().disabled).toBe(true);
     });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// CopilotChat serialization tests (waitForActiveRunToSettle)
-// ---------------------------------------------------------------------------
-describe("CopilotChat – waitForActiveRunToSettle serialization", () => {
-  it("awaits activeRunCompletionPromise before sending when a run is in flight", async () => {
-    // We test the serialization logic by examining the sequence:
-    // 1. submitInput is called while isRunning = true
-    // 2. The run's completion promise must resolve before runAgent is called
-    //
-    // This is a unit-level proof that the logic mirrors React v2.
-
-    let resolveRun!: () => void;
-    const runCompletion = new Promise<void>((r) => {
-      resolveRun = r;
-    });
-
-    const callOrder: string[] = [];
-
-    // Mock agent with RunCompletionAware
-    const mockAgent = {
-      isRunning: true,
-      activeRunCompletionPromise: runCompletion,
-      addMessage: vi.fn(),
-      abortRun: vi.fn(),
-      threadId: "thread-1",
-      messages: [],
-    };
-
-    // Simulate the serialization logic extracted from CopilotChat.submitInput
-    const waitForActiveRunToSettle = async () => {
-      if (
-        mockAgent.isRunning &&
-        "activeRunCompletionPromise" in mockAgent &&
-        mockAgent.activeRunCompletionPromise
-      ) {
-        try {
-          await mockAgent.activeRunCompletionPromise;
-        } catch {
-          // ignore
-        }
-      }
-    };
-
-    const dispatchMessage = async (value: string) => {
-      callOrder.push("pre-wait");
-      await waitForActiveRunToSettle();
-      callOrder.push("post-wait");
-      mockAgent.addMessage({ id: "1", role: "user", content: value });
-    };
-
-    // Start the dispatch (it should pause at the await)
-    const dispatchPromise = dispatchMessage("hello");
-
-    // At this point post-wait should NOT have been called yet
-    expect(callOrder).toEqual(["pre-wait"]);
-    expect(mockAgent.addMessage).not.toHaveBeenCalled();
-
-    // Resolve the in-flight run
-    resolveRun();
-    await dispatchPromise;
-
-    // Now the message should have been added
-    expect(callOrder).toEqual(["pre-wait", "post-wait"]);
-    expect(mockAgent.addMessage).toHaveBeenCalledWith({
-      id: "1",
-      role: "user",
-      content: "hello",
-    });
-  });
-
-  it("proceeds immediately when agent is not RunCompletionAware", async () => {
-    const callOrder: string[] = [];
-
-    // Agent without activeRunCompletionPromise
-    const mockAgent = {
-      isRunning: true,
-      addMessage: vi.fn(),
-      threadId: "thread-1",
-      messages: [],
-    };
-
-    const waitForActiveRunToSettle = async () => {
-      if (
-        mockAgent.isRunning &&
-        "activeRunCompletionPromise" in mockAgent &&
-        (mockAgent as any).activeRunCompletionPromise
-      ) {
-        await (mockAgent as any).activeRunCompletionPromise;
-      }
-    };
-
-    callOrder.push("pre-wait");
-    await waitForActiveRunToSettle();
-    callOrder.push("post-wait");
-
-    // Should proceed synchronously (no activeRunCompletionPromise)
-    expect(callOrder).toEqual(["pre-wait", "post-wait"]);
   });
 });

--- a/packages/angular/src/lib/components/chat/__tests__/copilot-chat-input.component.spec.ts
+++ b/packages/angular/src/lib/components/chat/__tests__/copilot-chat-input.component.spec.ts
@@ -9,6 +9,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CopilotChatInput } from "../copilot-chat-input";
 import { ChatState } from "../../../chat-state";
 
+// ---------------------------------------------------------------------------
+// Stub for ChatState without run awareness
+// ---------------------------------------------------------------------------
 @Injectable()
 class ChatStateStub extends ChatState {
   inputValue = signal("");
@@ -16,30 +19,58 @@ class ChatStateStub extends ChatState {
   changeInput = vi.fn((value: string) => this.inputValue.set(value));
 }
 
+// ---------------------------------------------------------------------------
+// Stub that exposes isRunning + stopCurrentRun (mirrors CopilotChat)
+// ---------------------------------------------------------------------------
+@Injectable()
+class RunAwareChatStateStub extends ChatState {
+  inputValue = signal("");
+  readonly isRunning = signal<boolean>(false);
+  submitInput = vi.fn((value: string) => this.inputValue.set(value));
+  changeInput = vi.fn((value: string) => this.inputValue.set(value));
+  stopCurrentRun = vi.fn();
+}
+
+function makeComponent(stateClass: typeof ChatState): {
+  component: CopilotChatInput;
+  chatState: any;
+} {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [{ provide: ChatState, useClass: stateClass }],
+  });
+
+  const injector = TestBed.inject(EnvironmentInjector);
+  const chatState = TestBed.inject(ChatState);
+  const component = runInInjectionContext(
+    injector,
+    () => new CopilotChatInput(),
+  );
+
+  component.textAreaRef = {
+    setValue: vi.fn(),
+    focus: vi.fn(),
+  } as any;
+  component.audioRecorderRef = {
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    getState: () => "idle",
+  } as any;
+
+  return { component, chatState };
+}
+
+// ---------------------------------------------------------------------------
 describe("CopilotChatInput", () => {
   let injector: EnvironmentInjector;
   let component: CopilotChatInput;
   let chatState: ChatStateStub;
 
   beforeEach(() => {
-    TestBed.resetTestingModule();
-    TestBed.configureTestingModule({
-      providers: [{ provide: ChatState, useClass: ChatStateStub }],
-    });
-
+    const result = makeComponent(ChatStateStub);
+    component = result.component;
+    chatState = result.chatState as ChatStateStub;
     injector = TestBed.inject(EnvironmentInjector);
-    chatState = TestBed.inject(ChatState) as ChatStateStub;
-    component = runInInjectionContext(injector, () => new CopilotChatInput());
-
-    component.textAreaRef = {
-      setValue: vi.fn(),
-      focus: vi.fn(),
-    } as any;
-    component.audioRecorderRef = {
-      start: vi.fn().mockResolvedValue(undefined),
-      stop: vi.fn().mockResolvedValue(undefined),
-      getState: () => "idle",
-    } as any;
   });
 
   it("switches between input and transcribe modes", () => {
@@ -78,5 +109,345 @@ describe("CopilotChatInput", () => {
       { label: "Example", onSelect: vi.fn() },
     ];
     expect(component.computedToolsMenu()).toHaveLength(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // isProcessing / canSend / canStop computed signals
+  // ---------------------------------------------------------------------------
+  describe("isProcessing, canSend, canStop computed signals", () => {
+    let runAwareState: RunAwareChatStateStub;
+
+    beforeEach(() => {
+      const result = makeComponent(RunAwareChatStateStub);
+      component = result.component;
+      runAwareState = result.chatState as RunAwareChatStateStub;
+    });
+
+    it("isProcessing is false when not running", () => {
+      runAwareState.isRunning.set(false);
+      expect(component.isProcessing()).toBe(false);
+    });
+
+    it("isProcessing is true when running and mode is input", () => {
+      runAwareState.isRunning.set(true);
+      expect(component.isProcessing()).toBe(true);
+    });
+
+    it("isProcessing is false in transcribe mode even when running", () => {
+      runAwareState.isRunning.set(true);
+      component.modeSignal.set("transcribe");
+      expect(component.isProcessing()).toBe(false);
+    });
+
+    it("canSend is false when composer is empty", () => {
+      runAwareState.changeInput("");
+      expect(component.canSend()).toBe(false);
+    });
+
+    it("canSend is true when composer has text", () => {
+      runAwareState.changeInput("hello");
+      expect(component.canSend()).toBe(true);
+    });
+
+    it("canStop is true when ChatState exposes stopCurrentRun", () => {
+      expect(component.canStop()).toBe(true);
+    });
+
+    it("sendButtonDisabled is true when not running and composer is empty", () => {
+      runAwareState.isRunning.set(false);
+      runAwareState.changeInput("");
+      expect(component.sendButtonDisabled()).toBe(true);
+    });
+
+    it("sendButtonDisabled is false when not running and composer has text", () => {
+      runAwareState.isRunning.set(false);
+      runAwareState.changeInput("hello");
+      expect(component.sendButtonDisabled()).toBe(false);
+    });
+
+    it("sendButtonDisabled is false (stop enabled) when running and canStop", () => {
+      runAwareState.isRunning.set(true);
+      runAwareState.changeInput(""); // empty — isProcessing && !canSend
+      expect(component.sendButtonDisabled()).toBe(false); // stop is available
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // handleKeyDown routing (the core contract test)
+  //
+  // Pins the intentional Enter-vs-button divergence while a run is in flight.
+  // These two routes diverge on purpose:
+  //   - Enter with sendable text => SEND a new message (not stop). This is
+  //     what unblocks consecutive interrupt pills: a non-empty composer is
+  //     unambiguous "send" intent even mid-run.
+  //   - Enter with empty composer while running => STOP the run.
+  //   - The send/stop button while running => ALWAYS STOP, regardless of
+  //     composer contents (it renders as a Stop/Square affordance).
+  // Asserting BOTH together means a future refactor can't silently re-converge
+  // them without causing a test failure.
+  // ---------------------------------------------------------------------------
+  describe("Enter-vs-button routing while running (contract)", () => {
+    let runAwareState: RunAwareChatStateStub;
+
+    beforeEach(() => {
+      const result = makeComponent(RunAwareChatStateStub);
+      component = result.component;
+      runAwareState = result.chatState as RunAwareChatStateStub;
+    });
+
+    it("routes Enter to SEND but the button to STOP when a run is in flight with sendable text", () => {
+      const submitSpy = vi.fn();
+      const stopSpy = vi.fn();
+      component.submitMessage.subscribe(submitSpy);
+      component.stop.subscribe(stopSpy);
+
+      // Prepare: running with sendable text
+      runAwareState.isRunning.set(true);
+      runAwareState.changeInput("a brand new message");
+
+      // Enter with sendable text during a run => SEND (not stop).
+      component.handleKeyDown(
+        new KeyboardEvent("keydown", { key: "Enter", shiftKey: false }),
+      );
+      expect(submitSpy).toHaveBeenCalledWith("a brand new message");
+      expect(runAwareState.stopCurrentRun).not.toHaveBeenCalled();
+      expect(stopSpy).not.toHaveBeenCalled();
+
+      submitSpy.mockClear();
+      runAwareState.stopCurrentRun.mockClear();
+      stopSpy.mockClear();
+
+      // The button during a run => STOP, even though the composer holds text.
+      component.handleSendButtonClick();
+      expect(runAwareState.stopCurrentRun).toHaveBeenCalledTimes(1);
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+      expect(submitSpy).not.toHaveBeenCalled();
+    });
+
+    it("routes Enter to STOP when a run is in flight with empty composer", () => {
+      const submitSpy = vi.fn();
+      const stopSpy = vi.fn();
+      component.submitMessage.subscribe(submitSpy);
+      component.stop.subscribe(stopSpy);
+
+      runAwareState.isRunning.set(true);
+      runAwareState.changeInput(""); // empty composer
+
+      component.handleKeyDown(
+        new KeyboardEvent("keydown", { key: "Enter", shiftKey: false }),
+      );
+
+      expect(runAwareState.stopCurrentRun).toHaveBeenCalledTimes(1);
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+      expect(submitSpy).not.toHaveBeenCalled();
+    });
+
+    it("routes Enter to SEND when NOT running (regardless of composer contents)", () => {
+      const submitSpy = vi.fn();
+      component.submitMessage.subscribe(submitSpy);
+
+      runAwareState.isRunning.set(false);
+      runAwareState.changeInput("hello");
+
+      component.handleKeyDown(
+        new KeyboardEvent("keydown", { key: "Enter", shiftKey: false }),
+      );
+
+      expect(submitSpy).toHaveBeenCalledWith("hello");
+      expect(runAwareState.stopCurrentRun).not.toHaveBeenCalled();
+    });
+
+    it("does NOT send on Shift+Enter (newline)", () => {
+      const submitSpy = vi.fn();
+      component.submitMessage.subscribe(submitSpy);
+
+      runAwareState.isRunning.set(false);
+      runAwareState.changeInput("hello");
+
+      component.handleKeyDown(
+        new KeyboardEvent("keydown", { key: "Enter", shiftKey: true }),
+      );
+
+      expect(submitSpy).not.toHaveBeenCalled();
+    });
+
+    it("button click stops when running, regardless of composer contents (text in composer)", () => {
+      const submitSpy = vi.fn();
+      const stopSpy = vi.fn();
+      component.submitMessage.subscribe(submitSpy);
+      component.stop.subscribe(stopSpy);
+
+      runAwareState.isRunning.set(true);
+      runAwareState.changeInput("some text");
+
+      component.handleSendButtonClick();
+
+      expect(runAwareState.stopCurrentRun).toHaveBeenCalledTimes(1);
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+      expect(submitSpy).not.toHaveBeenCalled();
+    });
+
+    it("button click sends when NOT running and composer has text", () => {
+      const submitSpy = vi.fn();
+      component.submitMessage.subscribe(submitSpy);
+
+      runAwareState.isRunning.set(false);
+      runAwareState.changeInput("hello");
+
+      component.handleSendButtonClick();
+
+      expect(submitSpy).toHaveBeenCalledWith("hello");
+      expect(runAwareState.stopCurrentRun).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // stopCurrentRun wiring
+  // ---------------------------------------------------------------------------
+  describe("stopCurrentRun wiring", () => {
+    it("does not throw when ChatState has no stopCurrentRun (graceful degradation)", () => {
+      // Base ChatStateStub has no stopCurrentRun
+      expect(() => component.handleSendButtonClick()).not.toThrow();
+    });
+
+    it("calls ChatState.stopCurrentRun when stop is triggered", () => {
+      const result = makeComponent(RunAwareChatStateStub);
+      const c = result.component;
+      const state = result.chatState as RunAwareChatStateStub;
+
+      state.isRunning.set(true);
+      state.changeInput(""); // empty so Enter routes to stop
+
+      c.handleKeyDown(
+        new KeyboardEvent("keydown", { key: "Enter", shiftKey: false }),
+      );
+
+      expect(state.stopCurrentRun).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Textarea disabled state
+  // ---------------------------------------------------------------------------
+  describe("textarea disabled state", () => {
+    let runAwareState: RunAwareChatStateStub;
+
+    beforeEach(() => {
+      const result = makeComponent(RunAwareChatStateStub);
+      component = result.component;
+      runAwareState = result.chatState as RunAwareChatStateStub;
+    });
+
+    it("textarea is NOT disabled while running (input remains editable mid-run)", () => {
+      runAwareState.isRunning.set(true);
+      // textAreaContext.disabled mirrors: computedMode() === 'processing'
+      // Running doesn't set mode to 'processing', so textarea stays enabled.
+      expect(component.textAreaContext().disabled).toBe(false);
+    });
+
+    it("textarea IS disabled in processing mode (transcription in progress)", () => {
+      component.modeSignal.set("processing");
+      expect(component.textAreaContext().disabled).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CopilotChat serialization tests (waitForActiveRunToSettle)
+// ---------------------------------------------------------------------------
+describe("CopilotChat – waitForActiveRunToSettle serialization", () => {
+  it("awaits activeRunCompletionPromise before sending when a run is in flight", async () => {
+    // We test the serialization logic by examining the sequence:
+    // 1. submitInput is called while isRunning = true
+    // 2. The run's completion promise must resolve before runAgent is called
+    //
+    // This is a unit-level proof that the logic mirrors React v2.
+
+    let resolveRun!: () => void;
+    const runCompletion = new Promise<void>((r) => {
+      resolveRun = r;
+    });
+
+    const callOrder: string[] = [];
+
+    // Mock agent with RunCompletionAware
+    const mockAgent = {
+      isRunning: true,
+      activeRunCompletionPromise: runCompletion,
+      addMessage: vi.fn(),
+      abortRun: vi.fn(),
+      threadId: "thread-1",
+      messages: [],
+    };
+
+    // Simulate the serialization logic extracted from CopilotChat.submitInput
+    const waitForActiveRunToSettle = async () => {
+      if (
+        mockAgent.isRunning &&
+        "activeRunCompletionPromise" in mockAgent &&
+        mockAgent.activeRunCompletionPromise
+      ) {
+        try {
+          await mockAgent.activeRunCompletionPromise;
+        } catch {
+          // ignore
+        }
+      }
+    };
+
+    const dispatchMessage = async (value: string) => {
+      callOrder.push("pre-wait");
+      await waitForActiveRunToSettle();
+      callOrder.push("post-wait");
+      mockAgent.addMessage({ id: "1", role: "user", content: value });
+    };
+
+    // Start the dispatch (it should pause at the await)
+    const dispatchPromise = dispatchMessage("hello");
+
+    // At this point post-wait should NOT have been called yet
+    expect(callOrder).toEqual(["pre-wait"]);
+    expect(mockAgent.addMessage).not.toHaveBeenCalled();
+
+    // Resolve the in-flight run
+    resolveRun();
+    await dispatchPromise;
+
+    // Now the message should have been added
+    expect(callOrder).toEqual(["pre-wait", "post-wait"]);
+    expect(mockAgent.addMessage).toHaveBeenCalledWith({
+      id: "1",
+      role: "user",
+      content: "hello",
+    });
+  });
+
+  it("proceeds immediately when agent is not RunCompletionAware", async () => {
+    const callOrder: string[] = [];
+
+    // Agent without activeRunCompletionPromise
+    const mockAgent = {
+      isRunning: true,
+      addMessage: vi.fn(),
+      threadId: "thread-1",
+      messages: [],
+    };
+
+    const waitForActiveRunToSettle = async () => {
+      if (
+        mockAgent.isRunning &&
+        "activeRunCompletionPromise" in mockAgent &&
+        (mockAgent as any).activeRunCompletionPromise
+      ) {
+        await (mockAgent as any).activeRunCompletionPromise;
+      }
+    };
+
+    callOrder.push("pre-wait");
+    await waitForActiveRunToSettle();
+    callOrder.push("post-wait");
+
+    // Should proceed synchronously (no activeRunCompletionPromise)
+    expect(callOrder).toEqual(["pre-wait", "post-wait"]);
   });
 });

--- a/packages/angular/src/lib/components/chat/__tests__/copilot-chat.component.spec.ts
+++ b/packages/angular/src/lib/components/chat/__tests__/copilot-chat.component.spec.ts
@@ -1,0 +1,404 @@
+/**
+ * CopilotChat component tests — run-control parity with React v2.
+ *
+ * These tests exercise the PRODUCTION code paths in `CopilotChat` directly,
+ * rather than duplicating its internal logic in test fixtures.  They mirror
+ * the React v2 test coverage for:
+ *
+ *  - submitInput() serialisation: waits for `activeRunCompletionPromise`
+ *    before calling `core.runAgent()`.
+ *  - stopCurrentRun(): calls `core.stopAgent()` first.
+ *  - stopCurrentRun() fallback: calls `agent.abortRun()` when `stopAgent`
+ *    throws.
+ *  - canStopRun guard: stop is only active when running AND messages exist.
+ *  - stopCurrentRun early-exit: no-ops when `canStopRun` is false.
+ */
+import {
+  EnvironmentInjector,
+  runInInjectionContext,
+  signal,
+  computed,
+} from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CopilotChat } from "../copilot-chat";
+import type { Message } from "@ag-ui/client";
+
+// ---------------------------------------------------------------------------
+// Helpers / Stubs
+// ---------------------------------------------------------------------------
+
+/** Minimal stub for an agent that is RunCompletionAware. */
+function makeRunAwareAgent(options?: {
+  isRunning?: boolean;
+  activeRunCompletionPromise?: Promise<void>;
+  messages?: Message[];
+}) {
+  return {
+    isRunning: options?.isRunning ?? false,
+    activeRunCompletionPromise: options?.activeRunCompletionPromise,
+    messages: options?.messages ?? [],
+    threadId: "thread-test",
+    addMessage: vi.fn(),
+    abortRun: vi.fn(),
+    run: vi.fn(),
+    connect: vi.fn(),
+    detachActiveRun: vi.fn().mockResolvedValue(undefined),
+    subscribers: [],
+    isCopilotKitAgent: true,
+  } as any;
+}
+
+/**
+ * Builds a minimal CopilotKit core stub whose `runAgent` and `stopAgent`
+ * methods are mockable spy functions.
+ */
+function makeCoreMock() {
+  return {
+    runAgent: vi.fn().mockResolvedValue(undefined),
+    stopAgent: vi.fn(),
+    connectAgent: vi.fn().mockResolvedValue(undefined),
+    subscribe: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+  };
+}
+
+/** Builds a minimal agentStore signal stub. */
+function makeAgentStoreSignal(agent: ReturnType<typeof makeRunAwareAgent>) {
+  const _isRunning = signal(agent.isRunning as boolean);
+  const _messages = signal<Message[]>(agent.messages);
+
+  const store = {
+    agent,
+    isRunning: () => _isRunning(),
+    messages: () => _messages(),
+    _isRunning,
+    _messages,
+  };
+
+  return signal(store);
+}
+
+/**
+ * Creates a CopilotChat instance with all heavy Angular dependencies stubbed
+ * so tests can call its methods directly without a live DOM.
+ */
+function makeCopilotChat(
+  agent: ReturnType<typeof makeRunAwareAgent>,
+  coreMock: ReturnType<typeof makeCoreMock>,
+) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({});
+
+  const injector = TestBed.inject(EnvironmentInjector);
+  const agentStoreSignal = makeAgentStoreSignal(agent);
+
+  const chat = runInInjectionContext(injector, () => {
+    const instance = new (CopilotChat as any)();
+    return instance;
+  }) as CopilotChat;
+
+  // Inject the stub agentStore and core
+  (chat as any).agentStore = agentStoreSignal;
+  (chat as any).copilotKit = { core: coreMock };
+  // Provide no-op cdr
+  (chat as any).cdr = { markForCheck: vi.fn() };
+
+  return { chat, agentStoreSignal, coreMock };
+}
+
+// ---------------------------------------------------------------------------
+// submitInput() serialisation — mirrors React v2 waitForActiveRunToSettle
+// ---------------------------------------------------------------------------
+describe("CopilotChat.submitInput — serialisation (production code)", () => {
+  it("calls runAgent ONLY AFTER activeRunCompletionPromise resolves when a run is in flight", async () => {
+    let resolveRun!: () => void;
+    const runCompletion = new Promise<void>((r) => {
+      resolveRun = r;
+    });
+
+    const agent = makeRunAwareAgent({
+      isRunning: true,
+      activeRunCompletionPromise: runCompletion,
+      messages: [{ id: "m1", role: "user", content: "hi" }],
+    });
+
+    const coreMock = makeCoreMock();
+    const { chat, agentStoreSignal } = makeCopilotChat(agent, coreMock);
+
+    // Sync agent.isRunning with the agentStore signal
+    agentStoreSignal().agent.isRunning = true;
+
+    const callOrder: string[] = [];
+    const originalRunAgent = coreMock.runAgent;
+    coreMock.runAgent = vi.fn(async () => {
+      callOrder.push("runAgent-called");
+      return originalRunAgent();
+    });
+
+    // Kick off submitInput — it should pause at waitForActiveRunToSettle
+    const submitPromise = chat.submitInput("hello world");
+
+    // Give microtasks a chance to flush without resolving the run
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(
+      coreMock.runAgent,
+      "runAgent must not be called before the active run resolves",
+    ).not.toHaveBeenCalled();
+
+    // Resolve the in-flight run
+    resolveRun();
+    await submitPromise;
+
+    expect(
+      coreMock.runAgent,
+      "runAgent must be called after activeRunCompletionPromise resolves",
+    ).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(["runAgent-called"]);
+  });
+
+  it("calls runAgent immediately when no run is in flight (no activeRunCompletionPromise)", async () => {
+    const agent = makeRunAwareAgent({
+      isRunning: false,
+      activeRunCompletionPromise: undefined,
+      messages: [],
+    });
+
+    const coreMock = makeCoreMock();
+    const { chat } = makeCopilotChat(agent, coreMock);
+
+    await chat.submitInput("immediate send");
+
+    expect(coreMock.runAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls runAgent immediately when agent is not RunCompletionAware (no property)", async () => {
+    // Agent without activeRunCompletionPromise property at all
+    const agent = makeRunAwareAgent({ isRunning: true });
+    delete (agent as any).activeRunCompletionPromise;
+
+    const coreMock = makeCoreMock();
+    const { chat, agentStoreSignal } = makeCopilotChat(agent, coreMock);
+    agentStoreSignal().agent.isRunning = true;
+
+    await chat.submitInput("send without aware");
+
+    expect(coreMock.runAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("proceeds with runAgent even when the in-flight run rejects", async () => {
+    let rejectRun!: (err: Error) => void;
+    const runCompletion = new Promise<void>((_, r) => {
+      rejectRun = r;
+    });
+
+    const agent = makeRunAwareAgent({
+      isRunning: true,
+      activeRunCompletionPromise: runCompletion,
+      messages: [{ id: "m1", role: "user", content: "hi" }],
+    });
+
+    const coreMock = makeCoreMock();
+    const { chat, agentStoreSignal } = makeCopilotChat(agent, coreMock);
+    agentStoreSignal().agent.isRunning = true;
+
+    const submitPromise = chat.submitInput("follow-up");
+    await Promise.resolve();
+
+    expect(coreMock.runAgent).not.toHaveBeenCalled();
+
+    // Reject the in-flight run — submitInput should still proceed
+    rejectRun(new Error("run failed"));
+    await submitPromise;
+
+    expect(
+      coreMock.runAgent,
+      "runAgent must still be called after a rejected in-flight run",
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("addMessage is called with the trimmed user text before runAgent", async () => {
+    const agent = makeRunAwareAgent({ isRunning: false, messages: [] });
+    const coreMock = makeCoreMock();
+    const { chat } = makeCopilotChat(agent, coreMock);
+
+    const callOrder: string[] = [];
+    agent.addMessage = vi.fn(() => {
+      callOrder.push("addMessage");
+    });
+    coreMock.runAgent = vi.fn(async () => {
+      callOrder.push("runAgent");
+    });
+
+    await chat.submitInput("  trimmed  ");
+
+    expect(callOrder).toEqual(["addMessage", "runAgent"]);
+    expect(agent.addMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "user", content: "  trimmed  " }),
+    );
+  });
+
+  it("does nothing when the value is empty or whitespace only", async () => {
+    const agent = makeRunAwareAgent({ isRunning: false, messages: [] });
+    const coreMock = makeCoreMock();
+    const { chat } = makeCopilotChat(agent, coreMock);
+
+    await chat.submitInput("   ");
+
+    expect(agent.addMessage).not.toHaveBeenCalled();
+    expect(coreMock.runAgent).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stopCurrentRun() — mirrors React v2 stopCurrentRun
+// ---------------------------------------------------------------------------
+describe("CopilotChat.stopCurrentRun", () => {
+  it("calls core.stopAgent with the current agent", () => {
+    const agent = makeRunAwareAgent({
+      isRunning: true,
+      messages: [{ id: "m1", role: "user", content: "hi" }],
+    });
+    const coreMock = makeCoreMock();
+    const { chat, agentStoreSignal } = makeCopilotChat(agent, coreMock);
+
+    // Ensure canStopRun would be true
+    agentStoreSignal()._isRunning.set(true);
+    agentStoreSignal()._messages.set([{ id: "m1", role: "user", content: "hi" }]);
+
+    chat.stopCurrentRun();
+
+    expect(coreMock.stopAgent).toHaveBeenCalledTimes(1);
+    expect(coreMock.stopAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ agent }),
+    );
+  });
+
+  it("falls back to agent.abortRun() when core.stopAgent throws", () => {
+    const agent = makeRunAwareAgent({
+      isRunning: true,
+      messages: [{ id: "m1", role: "user", content: "hi" }],
+    });
+    const coreMock = makeCoreMock();
+    coreMock.stopAgent = vi.fn(() => {
+      throw new Error("stopAgent not supported");
+    });
+
+    const { chat, agentStoreSignal } = makeCopilotChat(agent, coreMock);
+    agentStoreSignal()._isRunning.set(true);
+    agentStoreSignal()._messages.set([{ id: "m1", role: "user", content: "hi" }]);
+
+    // Should not throw — fallback to abortRun
+    expect(() => chat.stopCurrentRun()).not.toThrow();
+
+    expect(agent.abortRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when both stopAgent and abortRun throw", () => {
+    const agent = makeRunAwareAgent({
+      isRunning: true,
+      messages: [{ id: "m1", role: "user", content: "hi" }],
+    });
+    agent.abortRun = vi.fn(() => {
+      throw new Error("abortRun also failed");
+    });
+
+    const coreMock = makeCoreMock();
+    coreMock.stopAgent = vi.fn(() => {
+      throw new Error("stopAgent failed");
+    });
+
+    const { chat, agentStoreSignal } = makeCopilotChat(agent, coreMock);
+    agentStoreSignal()._isRunning.set(true);
+    agentStoreSignal()._messages.set([{ id: "m1", role: "user", content: "hi" }]);
+
+    expect(() => chat.stopCurrentRun()).not.toThrow();
+  });
+
+  it("does nothing when no agent is present", () => {
+    const agent = makeRunAwareAgent({
+      isRunning: true,
+      messages: [{ id: "m1", role: "user", content: "hi" }],
+    });
+    const coreMock = makeCoreMock();
+    const { chat, agentStoreSignal } = makeCopilotChat(agent, coreMock);
+    agentStoreSignal()._isRunning.set(true);
+    agentStoreSignal()._messages.set([{ id: "m1", role: "user", content: "hi" }]);
+
+    // Remove agent from store
+    (agentStoreSignal() as any).agent = null;
+
+    expect(() => chat.stopCurrentRun()).not.toThrow();
+    expect(coreMock.stopAgent).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// canStopRun guard — mirrors React v2 shouldAllowStop = isRunning && hasMessages
+// ---------------------------------------------------------------------------
+describe("CopilotChat.canStopRun (shouldAllowStop parity)", () => {
+  it("is false when not running (even with messages)", () => {
+    const agent = makeRunAwareAgent({ isRunning: false, messages: [] });
+    const coreMock = makeCoreMock();
+    const { chat, agentStoreSignal } = makeCopilotChat(agent, coreMock);
+
+    agentStoreSignal()._isRunning.set(false);
+    agentStoreSignal()._messages.set([{ id: "m1", role: "user", content: "hi" }]);
+
+    expect((chat as any).canStopRun()).toBe(false);
+  });
+
+  it("is false when running but no messages yet (welcome screen guard)", () => {
+    const agent = makeRunAwareAgent({ isRunning: true, messages: [] });
+    const coreMock = makeCoreMock();
+    const { chat, agentStoreSignal } = makeCopilotChat(agent, coreMock);
+
+    agentStoreSignal()._isRunning.set(true);
+    agentStoreSignal()._messages.set([]); // no messages yet
+
+    expect((chat as any).canStopRun()).toBe(false);
+  });
+
+  it("is true when running AND messages exist", () => {
+    const agent = makeRunAwareAgent({
+      isRunning: true,
+      messages: [{ id: "m1", role: "user", content: "hi" }],
+    });
+    const coreMock = makeCoreMock();
+    const { chat, agentStoreSignal } = makeCopilotChat(agent, coreMock);
+
+    agentStoreSignal()._isRunning.set(true);
+    agentStoreSignal()._messages.set([{ id: "m1", role: "user", content: "hi" }]);
+
+    expect((chat as any).canStopRun()).toBe(true);
+  });
+
+  it("stopCurrentRun no-ops when canStopRun is false (not running + no messages)", () => {
+    const agent = makeRunAwareAgent({ isRunning: false, messages: [] });
+    const coreMock = makeCoreMock();
+    const { chat, agentStoreSignal } = makeCopilotChat(agent, coreMock);
+
+    agentStoreSignal()._isRunning.set(false);
+    agentStoreSignal()._messages.set([]);
+
+    chat.stopCurrentRun();
+
+    expect(coreMock.stopAgent).not.toHaveBeenCalled();
+    expect(agent.abortRun).not.toHaveBeenCalled();
+  });
+
+  it("stopCurrentRun no-ops when running but thread has no messages yet", () => {
+    const agent = makeRunAwareAgent({ isRunning: true, messages: [] });
+    const coreMock = makeCoreMock();
+    const { chat, agentStoreSignal } = makeCopilotChat(agent, coreMock);
+
+    agentStoreSignal()._isRunning.set(true);
+    agentStoreSignal()._messages.set([]); // no messages
+
+    chat.stopCurrentRun();
+
+    expect(coreMock.stopAgent).not.toHaveBeenCalled();
+    expect(agent.abortRun).not.toHaveBeenCalled();
+  });
+});

--- a/packages/angular/src/lib/components/chat/copilot-chat-input.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-input.ts
@@ -17,7 +17,7 @@ import {
 import { CommonModule } from "@angular/common";
 import { CopilotSlot } from "../../slots/copilot-slot";
 import { injectChatLabels } from "../../chat-config";
-import { LucideAngularModule, ArrowUp } from "lucide-angular";
+import { LucideAngularModule, ArrowUp, Square } from "lucide-angular";
 import { CopilotChatTextarea } from "./copilot-chat-textarea";
 import { CopilotChatAudioRecorder } from "./copilot-chat-audio-recorder";
 import {
@@ -213,7 +213,7 @@ export interface ToolbarContext {
                 >
                 </copilot-chat-start-transcribe-button>
               }
-              <!-- Send button with slot -->
+              <!-- Send / Stop button -->
               @if (sendButtonTemplate || sendButtonComponent()) {
                 <copilot-slot
                   [slot]="sendButtonTemplate || sendButtonComponent()"
@@ -225,16 +225,25 @@ export interface ToolbarContext {
                 <div class="mr-[10px]">
                   <button
                     type="button"
+                    data-testid="copilot-send-button"
                     [class]="sendButtonClass() || defaultButtonClass"
-                    [disabled]="
-                      !computedValue().trim() || computedMode() === 'processing'
-                    "
-                    (click)="send()"
+                    [disabled]="sendButtonDisabled()"
+                    (click)="handleSendButtonClick()"
                   >
-                    <lucide-angular
-                      [img]="ArrowUpIcon"
-                      [size]="18"
-                    ></lucide-angular>
+                    @if (isProcessing() && canStop()) {
+                      <!-- Stop / Square icon while a run is active -->
+                      <lucide-angular
+                        data-testid="copilot-stop-icon"
+                        [img]="SquareIcon"
+                        [size]="18"
+                        class="fill-current"
+                      ></lucide-angular>
+                    } @else {
+                      <lucide-angular
+                        [img]="ArrowUpIcon"
+                        [size]="18"
+                      ></lucide-angular>
+                    }
                   </button>
                 </div>
               }
@@ -326,9 +335,14 @@ export class CopilotChatInput implements AfterViewInit, OnDestroy {
   finishTranscribe = output<void>();
   addFile = output<void>();
   valueChange = output<string>();
+  /** Emitted when the stop button is clicked or Enter is pressed on empty input
+   *  while a run is active.  Parent components can listen for this to cancel
+   *  in-flight requests independently of the ChatState wiring. */
+  stop = output<void>();
 
   // Icons and default classes
   readonly ArrowUpIcon = ArrowUp;
+  readonly SquareIcon = Square;
   readonly defaultButtonClass = cn(
     // Base button styles
     "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium",
@@ -349,7 +363,6 @@ export class CopilotChatInput implements AfterViewInit, OnDestroy {
 
   // Services
   readonly labels = injectChatLabels();
-  // readonly chatConfig = injectChatConfig();
   readonly chatState = injectChatState();
 
   // Signals
@@ -379,6 +392,38 @@ export class CopilotChatInput implements AfterViewInit, OnDestroy {
     return customValue || configValue || "";
   });
 
+  /**
+   * True when a run is in flight (not transcribing).
+   * Mirrors React v2: `const isProcessing = mode !== "transcribe" && isRunning`.
+   */
+  isProcessing = computed(() => {
+    const mode = this.computedMode();
+    const running = this.chatState.isRunning?.() ?? false;
+    return mode !== "transcribe" && running;
+  });
+
+  /**
+   * True when the composer holds sendable text and a submit handler is wired.
+   * Mirrors React v2: `const canSend = resolvedValue.trim().length > 0 && !!onSubmitMessage`.
+   * In Angular the submit path always exists (through ChatState), so we only
+   * check for non-empty text.
+   */
+  canSend = computed(() => this.computedValue().trim().length > 0);
+
+  /**
+   * True when a stop handler is available.
+   * In Angular this is fulfilled by ChatState.stopCurrentRun existing.
+   */
+  canStop = computed(() => typeof this.chatState.stopCurrentRun === "function");
+
+  /**
+   * Disabled logic for the send/stop button, mirroring React v2:
+   *   isProcessing ? !canStop : !canSend
+   */
+  sendButtonDisabled = computed(() =>
+    this.isProcessing() ? !this.canStop() : !this.canSend(),
+  );
+
   computedClass = computed(() => {
     const baseClasses = cn(
       // Layout
@@ -397,9 +442,8 @@ export class CopilotChatInput implements AfterViewInit, OnDestroy {
 
   // Context for slots (reactive via signals)
   sendButtonContext = computed<SendButtonContext>(() => ({
-    send: () => this.send(),
-    disabled:
-      !this.computedValue().trim() || this.computedMode() === "processing",
+    send: () => this.handleSendButtonClick(),
+    disabled: this.sendButtonDisabled(),
     value: this.computedValue(),
   }));
 
@@ -411,6 +455,8 @@ export class CopilotChatInput implements AfterViewInit, OnDestroy {
   textAreaContext = computed(() => ({
     value: this.computedValue(),
     autoFocus: this.computedAutoFocus(),
+    // Keep textarea enabled while running — React v2 allows typing mid-run.
+    // Only disable in 'processing' mode (transcription in progress).
     disabled: this.computedMode() === "processing",
     maxRows: this.textAreaMaxRows(),
     placeholder: this.textAreaPlaceholder(),
@@ -454,7 +500,10 @@ export class CopilotChatInput implements AfterViewInit, OnDestroy {
     clicked: () => this.handleStartTranscribe(),
   };
   // Support both `clicked` (idiomatic in our slots) and `click` (legacy)
-  sendButtonOutputs = { clicked: () => this.send(), click: () => this.send() };
+  sendButtonOutputs = {
+    clicked: () => this.handleSendButtonClick(),
+    click: () => this.handleSendButtonClick(),
+  };
 
   ngAfterViewInit(): void {
     // Auto-focus if needed
@@ -472,16 +521,59 @@ export class CopilotChatInput implements AfterViewInit, OnDestroy {
     }
   }
 
+  /**
+   * Keyboard handler for the textarea — mirrors React v2 `handleKeyDown`.
+   *
+   * Rules (matching the React v2 contract):
+   *  - Enter (no Shift): if a run is in flight AND the composer is empty →
+   *    stop the run (the "Enter on empty" stop affordance).
+   *  - Enter (no Shift): in all other cases → send (non-empty text always
+   *    sends, even mid-run; this is the consecutive-interrupt fix).
+   *  - Shift+Enter: always let the default newline through.
+   */
   handleKeyDown(event: KeyboardEvent): void {
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
-      this.send();
+
+      // Mirrors React v2 logic:
+      //   if (isProcessing && !canSend) { onStop?.(); } else { send(); }
+      if (this.isProcessing() && !this.canSend()) {
+        this.triggerStop();
+      } else {
+        this.send();
+      }
     }
   }
 
   handleValueChange(value: string): void {
     this.valueChange.emit(value);
     if (this.chatState) this.chatState.changeInput(value);
+  }
+
+  /**
+   * Handle send/stop button click.
+   *
+   * The button is an explicit control: while a run is in flight it renders as
+   * a Stop (Square) button, so a click ALWAYS maps to stop regardless of
+   * composer contents.  This is the intentional divergence from Enter (which
+   * sends when the composer has text).  Mirrors React v2 `handleSendButtonClick`.
+   */
+  handleSendButtonClick(): void {
+    if (this.isProcessing()) {
+      this.triggerStop();
+      return;
+    }
+    this.send();
+  }
+
+  /**
+   * Stop the current run.
+   * Delegates to `ChatState.stopCurrentRun` (provided by `CopilotChat`) and
+   * also emits the `stop` output so parent templates can react directly.
+   */
+  private triggerStop(): void {
+    this.stop.emit();
+    this.chatState.stopCurrentRun?.();
   }
 
   send(): void {

--- a/packages/angular/src/lib/components/chat/copilot-chat-input.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-input.ts
@@ -411,10 +411,24 @@ export class CopilotChatInput implements AfterViewInit, OnDestroy {
   canSend = computed(() => this.computedValue().trim().length > 0);
 
   /**
-   * True when a stop handler is available.
-   * In Angular this is fulfilled by ChatState.stopCurrentRun existing.
+   * True when a stop action is currently meaningful.
+   *
+   * Mirrors React v2's two-part guard:
+   *   - `canStop` (= `!!onStop`): the handler exists.
+   *   - `shouldAllowStop` (= `isRunning && hasMessages`): the stop button is
+   *     only rendered while a run is in flight AND the thread has messages.
+   *
+   * When the ChatState exposes `canStopRun` (as `CopilotChat` does) we use it
+   * directly — it already encodes both conditions.  Otherwise we fall back to
+   * checking that `stopCurrentRun` is defined, which preserves backward
+   * compatibility for custom ChatState implementations.
    */
-  canStop = computed(() => typeof this.chatState.stopCurrentRun === "function");
+  canStop = computed(() => {
+    if (this.chatState.canStopRun) {
+      return this.chatState.canStopRun();
+    }
+    return typeof this.chatState.stopCurrentRun === "function";
+  });
 
   /**
    * Disabled logic for the send/stop button, mirroring React v2:

--- a/packages/angular/src/lib/components/chat/copilot-chat.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat.ts
@@ -20,13 +20,21 @@ import {
   AbstractAgent,
   AGUIConnectNotImplementedError,
 } from "@ag-ui/client";
+import { isRunCompletionAware } from "@copilotkit/core";
 import { injectAgentStore } from "../../agent";
 import { CopilotKit } from "../../copilotkit";
 import { ChatState } from "../../chat-state";
 
 /**
  * CopilotChat component - Angular equivalent of React's <CopilotChat>
- * Provides a complete chat interface that wires an agent to the chat view
+ * Provides a complete chat interface that wires an agent to the chat view.
+ *
+ * Run-control behaviour (mirrors React v2 CopilotChat):
+ *  - Stop button is visible while a run is active.
+ *  - Pressing Enter on an empty input stops the active run.
+ *  - New sends are serialised behind the active run's completion promise so
+ *    an interrupt-resume is never pre-empted by a concurrent new message.
+ *  - The textarea stays editable while a run is in flight.
  *
  * @example
  * ```html
@@ -67,7 +75,6 @@ export class CopilotChat implements ChatState {
   );
   readonly agentStore = injectAgentStore(this.resolvedAgentId);
   private readonly copilotKit = inject(CopilotKit);
-  // readonly chatConfig = injectChatConfig();
   readonly cdr = inject(ChangeDetectorRef);
   readonly injector = inject(Injector);
 
@@ -79,7 +86,6 @@ export class CopilotChat implements ChatState {
   private hasConnectedOnce = false;
 
   constructor() {
-    // Connect once when agent becomes available
     // Connect once when agent becomes available
     effect(
       () => {
@@ -140,9 +146,78 @@ export class CopilotChat implements ChatState {
     }
   }
 
+  /**
+   * Stop the currently active run.
+   *
+   * Mirrors React v2 `stopCurrentRun`:
+   *  1. Tries `core.stopAgent({ agent })` first (also aborts in-flight tools).
+   *  2. Falls back to `agent.abortRun()` if `stopAgent` throws.
+   */
+  stopCurrentRun(): void {
+    const agent = this.agentStore().agent;
+    if (!agent) return;
+
+    try {
+      this.copilotKit.core.stopAgent({ agent });
+    } catch (error) {
+      console.error("CopilotChat: stopAgent failed", error);
+      try {
+        agent.abortRun();
+      } catch (abortError) {
+        console.error("CopilotChat: abortRun fallback failed", abortError);
+      }
+    }
+  }
+
+  /**
+   * If a run is currently in flight and the agent is RunCompletionAware,
+   * await its `activeRunCompletionPromise` before the next dispatch.
+   *
+   * Mirrors React v2 `waitForActiveRunToSettle` — prevents a new send from
+   * pre-empting an interrupt-resume mid-flight (the consecutive-interrupt
+   * regression fix, #5195).
+   */
+  private async waitForActiveRunToSettle(): Promise<void> {
+    const agent = this.agentStore().agent;
+    if (
+      agent &&
+      this.isRunning() &&
+      isRunCompletionAware(agent) &&
+      agent.activeRunCompletionPromise
+    ) {
+      try {
+        await agent.activeRunCompletionPromise;
+      } catch (error) {
+        // The in-flight run rejected — proceed with the new send anyway,
+        // but log so a chronically-failing run is observable.
+        console.error(
+          "CopilotChat: in-flight run rejected while queuing send",
+          error,
+        );
+      }
+    }
+  }
+
+  /**
+   * Send a new user message.
+   *
+   * Mirrors React v2 `onSubmitInput`:
+   *  - Clears the input immediately (optimistic UX).
+   *  - Awaits `waitForActiveRunToSettle` so an interrupt-resume finishes
+   *    before the new run begins.
+   *  - Adds the user message and calls `core.runAgent`.
+   */
   async submitInput(value: string): Promise<void> {
     const agent = this.agentStore().agent;
     if (!agent || !value.trim()) return;
+
+    // Clear the input immediately so the composer reflects the accepted send
+    // even though the actual dispatch may be deferred behind the in-flight run.
+    this.inputValue.set("");
+
+    // If a run is already in flight, let it finish before sending the new
+    // message instead of pre-empting it (mirrors React v2 serialization).
+    await this.waitForActiveRunToSettle();
 
     // Add user message
     const userMessage: Message = {
@@ -151,9 +226,6 @@ export class CopilotChat implements ChatState {
       content: value,
     };
     agent.addMessage(userMessage);
-
-    // Clear the input
-    this.inputValue.set("");
 
     // Show cursor while processing
     this.showCursor.set(true);

--- a/packages/angular/src/lib/components/chat/copilot-chat.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat.ts
@@ -79,8 +79,17 @@ export class CopilotChat implements ChatState {
   readonly injector = inject(Injector);
 
   protected messages = computed(() => this.agentStore().messages());
-  protected isRunning = computed(() => this.agentStore().isRunning());
+  readonly isRunning = computed(() => this.agentStore().isRunning());
   protected showCursor = signal<boolean>(false);
+
+  /**
+   * True when a stop handler should be offered to the UI.
+   * Mirrors React v2: `agent.isRunning && hasMessages` — the stop button is
+   * only meaningful after at least one message is in the thread.
+   */
+  readonly canStopRun = computed(
+    () => this.isRunning() && this.messages().length > 0,
+  );
 
   private generatedThreadId: string = randomUUID();
   private hasConnectedOnce = false;
@@ -152,8 +161,13 @@ export class CopilotChat implements ChatState {
    * Mirrors React v2 `stopCurrentRun`:
    *  1. Tries `core.stopAgent({ agent })` first (also aborts in-flight tools).
    *  2. Falls back to `agent.abortRun()` if `stopAgent` throws.
+   *
+   * Only has effect when `canStopRun` is true (running with messages), mirroring
+   * React v2's `shouldAllowStop = agent.isRunning && hasMessages` guard.
    */
   stopCurrentRun(): void {
+    if (!this.canStopRun()) return;
+
     const agent = this.agentStore().agent;
     if (!agent) return;
 


### PR DESCRIPTION
Mirrors the full React v2 CopilotChat run-control surface:

## Stop button while a run is active
- CopilotChatInput now imports the Square (stop) icon from lucide-angular.
- When isProcessing() is true the send button renders a Square icon and routes clicks to triggerStop() instead of send(), regardless of composer contents.  This matches React v2 handleSendButtonClick().
- A new stop output() is emitted so parent templates can react directly.

## Enter-on-empty-input stops the run
- handleKeyDown now mirrors React v2 exactly: if (isProcessing && !canSend)  →  stop
    else                           →  send
  A non-empty composer always sends even mid-run (unblocks consecutive
  interrupt pills, #5195).  Stop is only reachable via Enter when the
  composer is empty — the genuine 'cancel' affordance.

## Serialization of new sends behind activeRunCompletionPromise
- CopilotChat.submitInput now calls waitForActiveRunToSettle() before dispatching the user message.  This awaits agent.activeRunCompletionPromise (via the isRunCompletionAware() type guard from @copilotkit/core) so an interrupt-resume can finish before the next runAgent() call begins. Agents that don't implement RunCompletionAware degrade safely (await is skipped).

## stopCurrentRun with stopAgent / abortRun fallback
- CopilotChat.stopCurrentRun() calls core.stopAgent({ agent }) first (which also aborts in-flight tool execution via the run-handler's abort controller) and falls back to agent.abortRun() on failure, mirroring React v2.

## Keep input editable while running
- CopilotChatInput.textAreaContext now sets disabled = mode === 'processing' (transcription in progress) instead of also disabling on isRunning. The textarea stays editable mid-run so users can compose the next message while the agent is still streaming.

## ChatState interface extended
- Added optional isRunning: Signal<boolean> and stopCurrentRun?(): void to the abstract ChatState so CopilotChatInput can consume them without a direct dependency on CopilotChat.  Both are optional for backwards compatibility with custom ChatState implementations.

## Angular tests
- Expanded copilot-chat-input.component.spec.ts with:
    * isProcessing / canSend / canStop computed signal assertions
    * Enter-vs-button routing contract (mirrors React v2 test suite):
        - Enter with sendable text mid-run → SEND (not stop)
        - Enter with empty composer mid-run → STOP - Button click mid-run → STOP regardless of composer contents - Shift+Enter → newline (no send/stop)
    * stopCurrentRun wiring and graceful degradation
    * Textarea disabled state (enabled while running, disabled in processing)
    * waitForActiveRunToSettle serialization proof (unit-level)

Closes #5428

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.


**Please PLEASE reach out to us first before starting any significant work on new or existing features.**

By the time you've gotten here, you're looking at creating a pull request so hopefully we're not too late.

We love community contributions! That said, we want to make sure we're all on the same page before you start.
Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
It also helps to make sure the work you're planning isn't already in progress.

As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
Or, reach out to us on Discord: https://discord.com/invite/6dffbvGU3D


You can learn more about contributing to copilotkit here: https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Describe the changes introduced in this PR)

## Related PRs and Issues

- (Direct link to related PR or issue, if relevant)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)
