### PR TITLE
fix(react-core): stabilize useCoAgentStateRender updates

### DIFF
--- a/.changeset/stabilize-coagent-state-render.md
+++ b/.changeset/stabilize-coagent-state-render.md
@@ -1,0 +1,7 @@
+---
+"@copilotkit/react-core": patch
+---
+
+fix(react-core): stabilize useCoAgentStateRender updates
+
+Refresh Copilot Chat state-render output when live coagent state changes update the active node.

--- a/packages/react-core/src/hooks/__tests__/use-coagent-state-render.e2e.test.tsx
+++ b/packages/react-core/src/hooks/__tests__/use-coagent-state-render.e2e.test.tsx
@@ -366,6 +366,35 @@ describe("useCoAgentStateRender", () => {
     });
   });
 
+  it("re-renders from in-place live agent state updates", async () => {
+    const copilotContextValue = createTestCopilotContext();
+    const liveState = { current_step: "Processing..." };
+    mockAgent.state = liveState;
+
+    render(
+      <CopilotContext.Provider value={copilotContextValue}>
+        <CoAgentStateRendersProvider>
+          <LiveStateHarness
+            message={{ id: "msg-live-in-place", role: "assistant" }}
+          />
+        </CoAgentStateRendersProvider>
+      </CopilotContext.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("state").textContent).toBe("Processing...");
+    });
+
+    act(() => {
+      liveState.current_step = "Thinking...";
+      lastSubscriber?.onStateChanged?.({ state: liveState });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("state").textContent).toBe("Thinking...");
+    });
+  });
+
   it("renders state snapshots before any assistant message exists", async () => {
     const copilotContextValue = createTestCopilotContext({
       threadId: "thread-1",
@@ -404,8 +433,6 @@ describe("useCoAgentStateRender", () => {
     });
 
     expect(screen.getByTestId(placeholderTestId)).toBeTruthy();
-
-    const placeholderStep = screen.getByTestId("state").textContent;
 
     mockAgent.isRunning = false;
     mockAgent.state = {};

--- a/packages/react-core/src/hooks/use-coagent-state-render-bridge.tsx
+++ b/packages/react-core/src/hooks/use-coagent-state-render-bridge.tsx
@@ -1,5 +1,6 @@
-import { ReactCustomMessageRendererPosition, useAgent } from "../v2";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAgent } from "../v2";
+import type { ReactCustomMessageRendererPosition } from "../v2";
+import { useEffect, useState } from "react";
 import type { AgentSubscriber } from "@ag-ui/client";
 import { useCoAgentStateRenders } from "../context";
 import { parseJson } from "@copilotkit/shared";
@@ -108,13 +109,13 @@ export function useCoagentStateRenderBridge(
   const { coAgentStateRenders, claimsRef } = useCoAgentStateRenders();
   const { agent } = useAgent({ agentId });
   const [nodeName, setNodeName] = useState<string | undefined>(undefined);
-  const [, forceUpdate] = useState(0);
+  const [, setLiveUpdateVersion] = useState(0);
 
   useEffect(() => {
     if (!agent) return;
     const subscriber: AgentSubscriber = {
       onStateChanged: () => {
-        forceUpdate((value) => value + 1);
+        setLiveUpdateVersion((value) => value + 1);
       },
       onStepStartedEvent: ({ event }) => {
         if (event.stepName !== nodeName) {
@@ -135,26 +136,17 @@ export function useCoagentStateRenderBridge(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agentId, nodeName]);
 
-  const getStateRender = useCallback(
-    (messageId: string) => {
-      return Object.entries(coAgentStateRenders).find(
-        ([stateRenderId, stateRender]) => {
-          if (claimsRef.current[messageId]) {
-            return stateRenderId === claimsRef.current[messageId].stateRenderId;
-          }
-          const matchingAgentName = stateRender.name === agentId;
-          const matchesNodeContext = stateRender.nodeName
-            ? stateRender.nodeName === nodeName
-            : true;
-          return matchingAgentName && matchesNodeContext;
-        },
-      );
+  const stateRenderEntry = Object.entries(coAgentStateRenders).find(
+    ([stateRenderId, stateRender]) => {
+      if (claimsRef.current[message.id]) {
+        return stateRenderId === claimsRef.current[message.id].stateRenderId;
+      }
+      const matchingAgentName = stateRender.name === agentId;
+      const matchesNodeContext = stateRender.nodeName
+        ? stateRender.nodeName === nodeName
+        : true;
+      return matchingAgentName && matchesNodeContext;
     },
-    [coAgentStateRenders, nodeName, agentId],
-  );
-  const stateRenderEntry = useMemo(
-    () => getStateRender(message.id),
-    [getStateRender, message.id],
   );
   const stateRenderId = stateRenderEntry?.[0];
   const stateRender = stateRenderEntry?.[1];
@@ -174,47 +166,36 @@ export function useCoagentStateRenderBridge(
     claimsRef,
   });
 
-  return useMemo(() => {
-    if (!stateRender || !stateRenderId) {
-      return null;
-    }
-    if (!canRender) {
-      return null;
-    }
+  if (!stateRender || !stateRenderId) {
+    return null;
+  }
+  if (!canRender) {
+    return null;
+  }
 
-    if (stateRender.handler) {
-      stateRender.handler({
-        state: stateSnapshot
-          ? parseJson(stateSnapshot, stateSnapshot)
-          : (agent?.state ?? {}),
-        nodeName: nodeName ?? "",
-      });
-    }
+  if (stateRender.handler) {
+    stateRender.handler({
+      state: stateSnapshot
+        ? parseJson(stateSnapshot, stateSnapshot)
+        : (agent?.state ?? {}),
+      nodeName: nodeName ?? "",
+    });
+  }
 
-    if (stateRender.render) {
-      const status = agent?.isRunning
-        ? RenderStatus.InProgress
-        : RenderStatus.Complete;
+  if (stateRender.render) {
+    const status = agent?.isRunning
+      ? RenderStatus.InProgress
+      : RenderStatus.Complete;
 
-      if (typeof stateRender.render === "string") return stateRender.render;
+    if (typeof stateRender.render === "string") return stateRender.render;
 
-      return stateRender.render({
-        status,
-        // Always use state from claim, to make sure the state does not seem "wiped" for a fraction of a second
-        state: claimsRef.current[message.id].stateSnapshot ?? {},
-        nodeName: nodeName ?? "",
-      });
-    }
-  }, [
-    stateRender,
-    stateRenderId,
-    agent?.state,
-    agent?.isRunning,
-    nodeName,
-    message.id,
-    stateSnapshot,
-    canRender,
-  ]);
+    return stateRender.render({
+      status,
+      // Always use state from claim, to make sure the state does not seem "wiped" for a fraction of a second
+      state: claimsRef.current[message.id].stateSnapshot ?? {},
+      nodeName: nodeName ?? "",
+    });
+  }
 }
 
 export function CoAgentStateRenderBridge(props: CoAgentStateRenderBridgeProps) {


### PR DESCRIPTION

## Summary

`useCoAgentStateRender` can receive live coagent state updates while Copilot Chat keeps showing the previous state-render UI. The broken behavior sits in `@copilotkit/react-core`, where the chat bridge subscribes to `onStateChanged` but memoizes both the active state-render selection and the returned UI across rerenders.

## Root cause

`packages/react-core/src/hooks/use-coagent-state-render-bridge.tsx:116-118` intentionally forces a rerender when the agent emits `onStateChanged`, but the bridge then memoizes `getStateRender(message.id)` and the returned render output against dependencies that often stay referentially stable across live updates. That makes the rerender a no-op for in-place agent-state mutations, which are common on the live update path, even though `claimsRef.current` and the selected snapshot have already been refreshed by the registry. The result is a render pass that sees the event but reuses stale bridge output until some unrelated identity change breaks the memo chain.

## Changes

- `packages/react-core/src/hooks/use-coagent-state-render-bridge.tsx`: remove the stale memoization path so `onStateChanged` rerenders always re-resolve the active state-render entry and return fresh UI from the latest claim snapshot, while preserving the existing step-start and step-finish node tracking
- `packages/react-core/src/hooks/__tests__/use-coagent-state-render.e2e.test.tsx`: add a regression that mutates the same live agent-state object in place, fires `onStateChanged`, and verifies the active Copilot Chat row still refreshes
- `.changeset/stabilize-coagent-state-render.md`: patch release note for `@copilotkit/react-core` (~+6 lines)

## What is NOT changed

This PR does not change coagent message creation, message ordering, the registry's claim and snapshot semantics, step lifecycle handling outside the existing node-name updates, or any Copilot Chat rendering path that does not go through the state-render UI.

## Out of scope

This PR does not retune `useAgent` batching or throttling, and it does not redesign the broader state-render claim model. Adjacent stale or duplicate-render behaviors that would require a maintainer decision stay documented, not fixed, here.

## Related PRs and Issues

Closes #2931.
Builds on #2131 and #2236.

## Test plan

- [x] `pnpm -C packages/react-core exec vitest run src/hooks/__tests__/use-coagent-state-render.e2e.test.tsx` — 23/23 pass. Covers: live `onStateChanged` updates with both replacement and in-place-mutated agent state, placeholder-to-assistant handoff, locked-claim behavior, and cross-run state-render snapshot regressions in Copilot Chat.
- [x] `pnpm exec oxfmt --write packages/react-core/src/hooks/use-coagent-state-render-bridge.tsx packages/react-core/src/hooks/__tests__/use-coagent-state-render.e2e.test.tsx` — pass, scoped formatting only.
- [x] `pnpm exec oxlint packages/react-core/src/hooks/use-coagent-state-render-bridge.tsx packages/react-core/src/hooks/__tests__/use-coagent-state-render.e2e.test.tsx` — pass, scoped lint only.
- [ ] CI green (`static / quality`, `test / unit` on Node 20/22/24)
