### PR TITLE
fix(core): execute frontend tools when backend returns placeholder result

### DIFF
--- a/.changeset/fix-frontend-tool-placeholder.md
+++ b/.changeset/fix-frontend-tool-placeholder.md
@@ -1,0 +1,7 @@
+---
+"@copilotkit/core": patch
+---
+
+fix(core): execute frontend tools when backend returns placeholder result
+
+Frontend tools registered via `useFrontendTool` now correctly execute after HITL approval with remote agents (Strands, LangGraph, CrewAI) instead of being silently skipped by the backend's placeholder result.

--- a/.changeset/fix-frontend-tool-placeholder.md
+++ b/.changeset/fix-frontend-tool-placeholder.md
@@ -1,7 +1,0 @@
----
-"@copilotkit/core": patch
----
-
-fix(core): execute frontend tools when backend returns placeholder result
-
-Frontend tools registered via `useFrontendTool` now correctly execute after HITL approval with remote agents (Strands, LangGraph, CrewAI) instead of being silently skipped by the backend's placeholder result.

--- a/packages/core/src/__tests__/core-edge-cases.test.ts
+++ b/packages/core/src/__tests__/core-edge-cases.test.ts
@@ -20,10 +20,10 @@ describe("CopilotKitCore.runAgent - Edge Cases", () => {
     vi.restoreAllMocks();
   });
 
-  it("should skip tool call when result already exists in newMessages", async () => {
+  it("should replace placeholder and execute handler when tool has a handler and result already exists", async () => {
     const tool = createTool({
       name: "alreadyProcessedTool",
-      handler: vi.fn(async () => "Should not be called"),
+      handler: vi.fn(async () => "Real result"),
     });
     copilotKitCore.addTool(tool);
 
@@ -51,7 +51,8 @@ describe("CopilotKitCore.runAgent - Edge Cases", () => {
 
     await copilotKitCore.runAgent({ agent: agent as any });
 
-    expect(tool.handler).not.toHaveBeenCalled();
+    // With the placeholder fix, a tool with a handler replaces the placeholder
+    expect(tool.handler).toHaveBeenCalled();
   });
 
   it("should handle empty tool function name", async () => {

--- a/packages/core/src/__tests__/core-edge-cases.test.ts
+++ b/packages/core/src/__tests__/core-edge-cases.test.ts
@@ -20,7 +20,7 @@ describe("CopilotKitCore.runAgent - Edge Cases", () => {
     vi.restoreAllMocks();
   });
 
-  it("should replace placeholder and execute handler when tool has a handler and result already exists", async () => {
+  it("should preserve non-placeholder results when tool has a handler and result already exists", async () => {
     const tool = createTool({
       name: "alreadyProcessedTool",
       handler: vi.fn(async () => "Real result"),
@@ -51,8 +51,13 @@ describe("CopilotKitCore.runAgent - Edge Cases", () => {
 
     await copilotKitCore.runAgent({ agent: agent as any });
 
-    // With the placeholder fix, a tool with a handler replaces the placeholder
-    expect(tool.handler).toHaveBeenCalled();
+    expect(tool.handler).not.toHaveBeenCalled();
+
+    const toolMessages = agent.messages.filter(
+      (m) => m.role === "tool" && m.toolCallId === toolCallId,
+    );
+    expect(toolMessages).toHaveLength(1);
+    expect((toolMessages[0] as any).content).toBe("Already processed");
   });
 
   it("should handle empty tool function name", async () => {

--- a/packages/core/src/__tests__/core-frontend-tool-placeholder.test.ts
+++ b/packages/core/src/__tests__/core-frontend-tool-placeholder.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { CopilotKitCore } from "../core";
+import {
+  MockAgent,
+  createToolCallMessage,
+  createToolResultMessage,
+  createTool,
+} from "./test-utils";
+
+describe("CopilotKitCore - Frontend Tool Placeholder (remote agent HITL)", () => {
+  let copilotKitCore: CopilotKitCore;
+
+  beforeEach(() => {
+    copilotKitCore = new CopilotKitCore({});
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should execute handler and replace placeholder when backend returns a placeholder result", async () => {
+    const handler = vi.fn(async () => "Real result");
+    const tool = createTool({ name: "myTool", handler, followUp: false });
+    copilotKitCore.addTool(tool);
+
+    const toolCallMsg = createToolCallMessage("myTool");
+    const toolCallId = (toolCallMsg as any).toolCalls![0].id;
+    const placeholder = createToolResultMessage(
+      toolCallId,
+      "Forwarded to client",
+    );
+
+    const agent = new MockAgent({ newMessages: [toolCallMsg, placeholder] });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    // Handler was called
+    expect(handler).toHaveBeenCalledOnce();
+
+    // The real result message should be present; the placeholder must be gone
+    const toolMessages = agent.messages.filter(
+      (m) => m.role === "tool" && m.toolCallId === toolCallId,
+    );
+    expect(toolMessages).toHaveLength(1);
+    expect((toolMessages[0] as any).content).not.toBe("Forwarded to client");
+  });
+
+  it("should preserve placeholder and skip execution when tool has no handler", async () => {
+    // A tool definition without a handler represents a backend-only tool
+    const tool = createTool({
+      name: "backendTool",
+      handler: undefined,
+      followUp: false,
+    });
+    copilotKitCore.addTool(tool);
+
+    const toolCallMsg = createToolCallMessage("backendTool");
+    const toolCallId = (toolCallMsg as any).toolCalls![0].id;
+    const placeholder = createToolResultMessage(
+      toolCallId,
+      "Forwarded to client",
+    );
+
+    const agent = new MockAgent({ newMessages: [toolCallMsg, placeholder] });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    // The placeholder should remain untouched
+    const toolMessages = agent.messages.filter(
+      (m) => m.role === "tool" && m.toolCallId === toolCallId,
+    );
+    expect(toolMessages).toHaveLength(1);
+    expect((toolMessages[0] as any).content).toBe("Forwarded to client");
+  });
+
+  it("should execute handler normally when no existing result (BuiltInAgent regression)", async () => {
+    const handler = vi.fn(async () => "Result");
+    const tool = createTool({ name: "localTool", handler, followUp: false });
+    copilotKitCore.addTool(tool);
+
+    // No placeholder — mirrors BuiltInAgent / Vercel AI SDK behaviour
+    const toolCallMsg = createToolCallMessage("localTool");
+    const agent = new MockAgent({ newMessages: [toolCallMsg] });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    expect(handler).toHaveBeenCalledOnce();
+
+    const toolCallId = (toolCallMsg as any).toolCalls![0].id;
+    const toolMessages = agent.messages.filter(
+      (m) => m.role === "tool" && m.toolCallId === toolCallId,
+    );
+    expect(toolMessages).toHaveLength(1);
+  });
+
+  it("should invoke wildcard handler when no specific tool is registered and no existing result", async () => {
+    const wildcardHandler = vi.fn(async () => "Wildcard result");
+    const wildcardTool = createTool({
+      name: "*",
+      handler: wildcardHandler,
+      followUp: false,
+    });
+    copilotKitCore.addTool(wildcardTool);
+
+    const toolCallMsg = createToolCallMessage("unknownTool");
+    const agent = new MockAgent({ newMessages: [toolCallMsg] });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    expect(wildcardHandler).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/__tests__/core-frontend-tool-placeholder.test.ts
+++ b/packages/core/src/__tests__/core-frontend-tool-placeholder.test.ts
@@ -82,6 +82,32 @@ describe("CopilotKitCore - Frontend Tool Placeholder (remote agent HITL)", () =>
     expect((toolMessages[0] as any).content).toBe("Forwarded to client");
   });
 
+  it("should preserve non-placeholder backend results when a frontend handler is registered", async () => {
+    const handler = vi.fn(async () => "Real result");
+    const tool = createTool({ name: "myTool", handler, followUp: false });
+    copilotKitCore.addTool(tool);
+
+    const toolCallMsg = createToolCallMessage("myTool");
+    const toolCallId = (toolCallMsg as any).toolCalls![0].id;
+    const backendResult = createToolResultMessage(toolCallId, "Backend result");
+
+    const agent = new MockAgent({ newMessages: [toolCallMsg, backendResult] });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    expect(handler).not.toHaveBeenCalled();
+
+    const toolMessages = agent.messages.filter(
+      (m) => m.role === "tool" && m.toolCallId === toolCallId,
+    );
+    expect(toolMessages).toHaveLength(1);
+    expect((toolMessages[0] as any).content).toBe("Backend result");
+  });
+
   it("should execute handler normally when no existing result (BuiltInAgent regression)", async () => {
     const handler = vi.fn(async () => "Result");
     const tool = createTool({ name: "localTool", handler, followUp: false });
@@ -125,5 +151,101 @@ describe("CopilotKitCore - Frontend Tool Placeholder (remote agent HITL)", () =>
     await copilotKitCore.runAgent({ agent: agent as any });
 
     expect(wildcardHandler).toHaveBeenCalledOnce();
+  });
+
+  it("should invoke the wildcard handler when the placeholder is the only existing result", async () => {
+    const wildcardHandler = vi.fn(async () => "Wildcard result");
+    const wildcardTool = createTool({
+      name: "*",
+      handler: wildcardHandler,
+      followUp: false,
+    });
+    copilotKitCore.addTool(wildcardTool);
+
+    const toolCallMsg = createToolCallMessage("unknownTool");
+    const toolCallId = (toolCallMsg as any).toolCalls![0].id;
+    const placeholder = createToolResultMessage(
+      toolCallId,
+      "Forwarded to client",
+    );
+
+    const agent = new MockAgent({ newMessages: [toolCallMsg, placeholder] });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    expect(wildcardHandler).toHaveBeenCalledOnce();
+
+    const toolMessages = agent.messages.filter(
+      (m) => m.role === "tool" && m.toolCallId === toolCallId,
+    );
+    expect(toolMessages).toHaveLength(1);
+    expect((toolMessages[0] as any).content).toBe("Wildcard result");
+  });
+
+  it("should send exactly one real tool message into the follow-up run after replacing the placeholder", async () => {
+    let agent: MockAgent;
+    const toolMessagesSeenByFollowUp: Array<{
+      content: unknown;
+      count: number;
+      hasAssistantToolCall: boolean;
+    }> = [];
+
+    const handler = vi.fn(async () => {
+      agent.setNewMessages([]);
+      return "Real result";
+    });
+    const tool = createTool({ name: "myTool", handler, followUp: true });
+    copilotKitCore.addTool(tool);
+
+    const toolCallMsg = createToolCallMessage("myTool");
+    const toolCallId = (toolCallMsg as any).toolCalls![0].id;
+    const placeholder = createToolResultMessage(
+      toolCallId,
+      "Forwarded to client",
+    );
+
+    agent = new MockAgent({
+      newMessages: [toolCallMsg, placeholder],
+      runAgentCallback: () => {
+        if (agent.runAgentCalls.length !== 2) {
+          return;
+        }
+
+        const toolMessages = agent.messages.filter(
+          (m) => m.role === "tool" && m.toolCallId === toolCallId,
+        );
+        toolMessagesSeenByFollowUp.push({
+          content: (toolMessages[0] as any)?.content,
+          count: toolMessages.length,
+          hasAssistantToolCall: agent.messages.some(
+            (m) =>
+              m.role === "assistant" &&
+              (m as any).toolCalls?.some(
+                (toolCall: any) => toolCall.id === toolCallId,
+              ),
+          ),
+        });
+      },
+    });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(agent.runAgentCalls).toHaveLength(2);
+    expect(toolMessagesSeenByFollowUp).toEqual([
+      {
+        content: "Real result",
+        count: 1,
+        hasAssistantToolCall: true,
+      },
+    ]);
   });
 });

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -482,15 +482,47 @@ export class RunHandler {
       for (const message of newMessages) {
         if (message.role === "assistant") {
           for (const toolCall of message.toolCalls || []) {
-            if (
-              newMessages.findIndex(
-                (m) => m.role === "tool" && m.toolCallId === toolCall.id,
-              ) === -1
-            ) {
-              const tool = this.getTool({
-                toolName: toolCall.function.name,
+            const tool = this.getTool({
+              toolName: toolCall.function.name,
+                agentId: agent.agentId,
+            });
+
+            let wildcardTool: FrontendTool<any> | undefined;
+            const getWildcardTool = () => {
+              if (tool || wildcardTool) {
+                return wildcardTool;
+              }
+              wildcardTool = this.getTool({
+                toolName: "*",
                 agentId: agent.agentId,
               });
+              return wildcardTool;
+            };
+
+            let existingResultIndex = newMessages.findIndex(
+              (m) => m.role === "tool" && m.toolCallId === toolCall.id,
+            );
+            const existingResult =
+              existingResultIndex === -1 ? undefined : newMessages[existingResultIndex];
+            const executableTool = tool ?? getWildcardTool();
+
+            if (
+              existingResult &&
+              executableTool?.handler &&
+              this.isFrontendPlaceholderResult(existingResult)
+            ) {
+              newMessages.splice(existingResultIndex, 1);
+              existingResultIndex = -1;
+
+              const agentMsgIdx = agent.messages.findIndex(
+                (m) => m.role === "tool" && m.toolCallId === toolCall.id,
+              );
+              if (agentMsgIdx !== -1) {
+                agent.messages.splice(agentMsgIdx, 1);
+              }
+            }
+
+            if (existingResultIndex === -1) {
               if (tool) {
                 const followUp = await this.executeSpecificTool(
                   tool,
@@ -503,11 +535,7 @@ export class RunHandler {
                   needsFollowUp = true;
                 }
               } else {
-                // Wildcard fallback for undefined tools
-                const wildcardTool = this.getTool({
-                  toolName: "*",
-                  agentId: agent.agentId,
-                });
+                const wildcardTool = getWildcardTool();
                 if (wildcardTool) {
                   const followUp = await this.executeWildcardTool(
                     wildcardTool,
@@ -555,6 +583,53 @@ export class RunHandler {
     void this._internal.suggestionEngine.reloadSuggestions(agentId);
 
     return runAgentResult;
+  }
+
+  private isFrontendPlaceholderResult(message: Message): boolean {
+    if (message.role !== "tool") {
+      return false;
+    }
+
+    const normalized = this.normalizeToolResultContent(message.content);
+    return normalized === "Forwarded to client";
+  }
+
+  private normalizeToolResultContent(content: unknown): string | null {
+    if (typeof content === "string") {
+      return content.trim();
+    }
+
+    if (Array.isArray(content)) {
+      const text = content
+        .flatMap((part) => {
+          if (typeof part === "string") {
+            return [part];
+          }
+          if (
+            part &&
+            typeof part === "object" &&
+            "text" in part &&
+            typeof (part as { text?: unknown }).text === "string"
+          ) {
+            return [(part as { text: string }).text];
+          }
+          return [];
+        })
+        .join("")
+        .trim();
+      return text.length > 0 ? text : null;
+    }
+
+    if (
+      content &&
+      typeof content === "object" &&
+      "text" in content &&
+      typeof (content as { text?: unknown }).text === "string"
+    ) {
+      return (content as { text: string }).text.trim();
+    }
+
+    return null;
   }
 
   /**

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -484,7 +484,7 @@ export class RunHandler {
           for (const toolCall of message.toolCalls || []) {
             const tool = this.getTool({
               toolName: toolCall.function.name,
-                agentId: agent.agentId,
+              agentId: agent.agentId,
             });
 
             let wildcardTool: FrontendTool<any> | undefined;
@@ -503,7 +503,9 @@ export class RunHandler {
               (m) => m.role === "tool" && m.toolCallId === toolCall.id,
             );
             const existingResult =
-              existingResultIndex === -1 ? undefined : newMessages[existingResultIndex];
+              existingResultIndex === -1
+                ? undefined
+                : newMessages[existingResultIndex];
             const executableTool = tool ?? getWildcardTool();
 
             if (
@@ -535,10 +537,10 @@ export class RunHandler {
                   needsFollowUp = true;
                 }
               } else {
-                const wildcardTool = getWildcardTool();
-                if (wildcardTool) {
+                const fallbackTool = getWildcardTool();
+                if (fallbackTool) {
                   const followUp = await this.executeWildcardTool(
-                    wildcardTool,
+                    fallbackTool,
                     toolCall,
                     message,
                     agent,


### PR DESCRIPTION
## Summary

Fixes the remote-agent HITL case where a frontend tool is skipped because the backend returns the placeholder result `Forwarded to client`.

The recovery is now marker-based. `processAgentResult` only removes an existing tool result when the content normalizes to that exact placeholder and there is an executable frontend handler on the current path. Every other backend result stays authoritative and blocks frontend re-execution.

## Implementation

- `packages/core/src/core/run-handler.ts` keeps the current `executeFrontendTools` and follow-up flow, then replaces the old existence-only check with exact placeholder detection at https://github.com/CopilotKit/CopilotKit/blob/7449f6d790dbe80ab8e0950f66b04a9bf4acde2c/packages/core/src/core/run-handler.ts#L484-L599
- the placeholder is removed from both `newMessages` and `agent.messages` before the existing specific or wildcard execution path inserts the real result
- `.changeset/fix-frontend-tool-placeholder.md` is dropped because current `main` no longer carries a `.changeset` tree

## Regression coverage

- exact placeholder replacement for a named frontend tool: https://github.com/CopilotKit/CopilotKit/blob/7449f6d790dbe80ab8e0950f66b04a9bf4acde2c/packages/core/src/__tests__/core-frontend-tool-placeholder.test.ts#L22-L51
- placeholder passthrough when the tool has no handler: https://github.com/CopilotKit/CopilotKit/blob/7449f6d790dbe80ab8e0950f66b04a9bf4acde2c/packages/core/src/__tests__/core-frontend-tool-placeholder.test.ts#L53-L82
- genuine backend-result preservation for a named frontend tool: https://github.com/CopilotKit/CopilotKit/blob/7449f6d790dbe80ab8e0950f66b04a9bf4acde2c/packages/core/src/__tests__/core-frontend-tool-placeholder.test.ts#L85-L109
- existing edge-case guard for a non-placeholder result: https://github.com/CopilotKit/CopilotKit/blob/7449f6d790dbe80ab8e0950f66b04a9bf4acde2c/packages/core/src/__tests__/core-edge-cases.test.ts#L23-L54
- existing wildcard execution still works with no pre-existing result: https://github.com/CopilotKit/CopilotKit/blob/7449f6d790dbe80ab8e0950f66b04a9bf4acde2c/packages/core/src/__tests__/core-frontend-tool-placeholder.test.ts#L111-L154
- wildcard placeholder replacement also stays on the exact marker path: https://github.com/CopilotKit/CopilotKit/blob/7449f6d790dbe80ab8e0950f66b04a9bf4acde2c/packages/core/src/__tests__/core-frontend-tool-placeholder.test.ts#L156-L187
- the recursive follow-up starts with the assistant tool call intact and exactly one real tool message for the same `toolCallId`: https://github.com/CopilotKit/CopilotKit/blob/7449f6d790dbe80ab8e0950f66b04a9bf4acde2c/packages/core/src/__tests__/core-frontend-tool-placeholder.test.ts#L189-L250

Closes #3442.

## Validation

- [x] `pnpm exec oxfmt --check packages/core/src/core/run-handler.ts packages/core/src/__tests__/core-edge-cases.test.ts packages/core/src/__tests__/core-frontend-tool-placeholder.test.ts`
- [x] `pnpm exec oxlint packages/core/src/core/run-handler.ts packages/core/src/__tests__/core-edge-cases.test.ts packages/core/src/__tests__/core-frontend-tool-placeholder.test.ts`
- [x] `pnpm -C packages/shared exec tsdown`
- [x] `pnpm -C packages/core exec tsdown`
- [x] `pnpm -C packages/core exec vitest run src/__tests__/core-frontend-tool-placeholder.test.ts src/__tests__/core-edge-cases.test.ts` 17/17
- [x] `pnpm -C packages/core exec vitest run` 54 files, 590 tests
- [ ] CI green on the rebased head
