### PR TITLE
fix(angular): serialize sends while agent is running

### DIFF
--- a/packages/angular/src/lib/chat-state.ts
+++ b/packages/angular/src/lib/chat-state.ts
@@ -1,11 +1,14 @@
-import { inject, Injectable, WritableSignal } from "@angular/core";
+import { inject, Injectable, Signal, WritableSignal } from "@angular/core";
 
 @Injectable()
 export abstract class ChatState {
   abstract readonly inputValue: WritableSignal<string>;
 
-  abstract submitInput(value: string): void;
+  abstract submitInput(value: string): void | Promise<void>;
   abstract changeInput(value: string): void;
+
+  readonly isRunning?: Signal<boolean>;
+  stopCurrentRun?(): void;
 }
 
 export function injectChatState(): ChatState {

--- a/packages/angular/src/lib/components/chat/__tests__/copilot-chat-input.component.spec.ts
+++ b/packages/angular/src/lib/components/chat/__tests__/copilot-chat-input.component.spec.ts
@@ -4,6 +4,7 @@ import {
   runInInjectionContext,
   signal,
 } from "@angular/core";
+import type { Signal } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CopilotChatInput } from "../copilot-chat-input";
@@ -14,6 +15,17 @@ class ChatStateStub extends ChatState {
   inputValue = signal("");
   submitInput = vi.fn((value: string) => this.inputValue.set(value));
   changeInput = vi.fn((value: string) => this.inputValue.set(value));
+  isRunning?: Signal<boolean>;
+  stopCurrentRun?: () => void;
+}
+
+@Injectable()
+class RunAwareChatStateStub extends ChatState {
+  inputValue = signal("");
+  isRunning = signal(false);
+  submitInput = vi.fn((value: string) => this.inputValue.set(value));
+  changeInput = vi.fn((value: string) => this.inputValue.set(value));
+  stopCurrentRun = vi.fn();
 }
 
 describe("CopilotChatInput", () => {
@@ -78,5 +90,79 @@ describe("CopilotChatInput", () => {
       { label: "Example", onSelect: vi.fn() },
     ];
     expect(component.computedToolsMenu()).toHaveLength(1);
+  });
+
+  it("keeps the textarea enabled while the agent is running", () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [{ provide: ChatState, useClass: RunAwareChatStateStub }],
+    });
+
+    injector = TestBed.inject(EnvironmentInjector);
+    const runAwareState = TestBed.inject(ChatState) as RunAwareChatStateStub;
+    component = runInInjectionContext(injector, () => new CopilotChatInput());
+
+    runAwareState.isRunning.set(true);
+
+    expect(component.textAreaContext().disabled).toBe(false);
+  });
+
+  it("routes Enter with text to send, but the running button to stop", () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [{ provide: ChatState, useClass: RunAwareChatStateStub }],
+    });
+
+    injector = TestBed.inject(EnvironmentInjector);
+    const runAwareState = TestBed.inject(ChatState) as RunAwareChatStateStub;
+    component = runInInjectionContext(injector, () => new CopilotChatInput());
+    component.textAreaRef = {
+      setValue: vi.fn(),
+      focus: vi.fn(),
+    } as any;
+    const submitSpy = vi.fn();
+    const stopSpy = vi.fn();
+    component.submitMessage.subscribe(submitSpy);
+    component.stop.subscribe(stopSpy);
+
+    runAwareState.isRunning.set(true);
+    runAwareState.changeInput("another turn");
+
+    component.handleKeyDown(
+      new KeyboardEvent("keydown", { key: "Enter", shiftKey: false }),
+    );
+
+    expect(submitSpy).toHaveBeenCalledWith("another turn");
+    expect(runAwareState.stopCurrentRun).not.toHaveBeenCalled();
+
+    submitSpy.mockClear();
+    component.handleValueChange("another turn");
+    component.handleSendButtonClick();
+
+    expect(submitSpy).not.toHaveBeenCalled();
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(runAwareState.stopCurrentRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes Enter with an empty input to stop while running", () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [{ provide: ChatState, useClass: RunAwareChatStateStub }],
+    });
+
+    injector = TestBed.inject(EnvironmentInjector);
+    const runAwareState = TestBed.inject(ChatState) as RunAwareChatStateStub;
+    component = runInInjectionContext(injector, () => new CopilotChatInput());
+    const stopSpy = vi.fn();
+    component.stop.subscribe(stopSpy);
+
+    runAwareState.isRunning.set(true);
+
+    component.handleKeyDown(
+      new KeyboardEvent("keydown", { key: "Enter", shiftKey: false }),
+    );
+
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(runAwareState.stopCurrentRun).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/angular/src/lib/components/chat/__tests__/copilot-chat.component.spec.ts
+++ b/packages/angular/src/lib/components/chat/__tests__/copilot-chat.component.spec.ts
@@ -1,0 +1,161 @@
+import { ChangeDetectorRef } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AbstractAgent } from "@ag-ui/client";
+import type {
+  AgentSubscriber,
+  BaseEvent,
+  RunAgentInput,
+} from "@ag-ui/client";
+import { Observable } from "rxjs";
+import { CopilotChat } from "../copilot-chat";
+import { CopilotKit } from "../../../copilotkit";
+import { CopilotKitCore } from "@copilotkit/core";
+
+const DUMMY_RUN_INPUT: RunAgentInput = {
+  threadId: "",
+  runId: "",
+  state: {},
+  messages: [],
+  tools: [],
+  context: [],
+  forwardedProps: {},
+};
+
+class Deferred {
+  promise: Promise<void>;
+  resolve!: () => void;
+
+  constructor() {
+    this.promise = new Promise<void>((resolve) => {
+      this.resolve = resolve;
+    });
+  }
+}
+
+class MockAgent extends AbstractAgent {
+  constructor() {
+    super();
+    this.agentId = "default";
+  }
+
+  run(_input: RunAgentInput): Observable<BaseEvent> {
+    return new Observable();
+  }
+
+  setActiveRunCompletionPromise(promise: Promise<void>): void {
+    Object.defineProperty(this, "activeRunCompletionPromise", {
+      configurable: true,
+      value: promise,
+    });
+  }
+
+  emitRunInitialized(): void {
+    this.emit((subscriber) =>
+      subscriber.onRunInitialized?.({
+        messages: this.messages,
+        state: this.state,
+        agent: this,
+        input: DUMMY_RUN_INPUT,
+      }),
+    );
+  }
+
+  emitRunFinalized(): void {
+    this.emit((subscriber) =>
+      subscriber.onRunFinalized?.({
+        messages: this.messages,
+        state: this.state,
+        agent: this,
+        input: DUMMY_RUN_INPUT,
+      }),
+    );
+  }
+
+  private emit(callback: (subscriber: AgentSubscriber) => void): void {
+    for (const subscriber of this.subscribers) callback(subscriber);
+  }
+}
+
+class CopilotKitStub {
+  agent = new MockAgent();
+  coreInstance = new CopilotKitCore({});
+  agents = vi.fn(() => ({ default: this.agent }));
+  runtimeConnectionStatus = vi.fn(() => undefined);
+  runtimeUrl = vi.fn(() => undefined);
+  runtimeTransport = vi.fn(() => "auto");
+  headers = vi.fn(() => ({}));
+  getAgent = vi.fn(() => this.agent);
+  core = {
+    subscribeToAgentWithOptions:
+      this.coreInstance.subscribeToAgentWithOptions.bind(this.coreInstance),
+    connectAgent: vi.fn(),
+    runAgent: vi.fn().mockResolvedValue(undefined),
+    stopAgent: vi.fn(),
+    runtimeConnectionStatus: undefined,
+    runtimeUrl: undefined,
+    runtimeTransport: "auto",
+    headers: {},
+  };
+}
+
+describe("CopilotChat", () => {
+  let copilotKit: CopilotKitStub;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    copilotKit = new CopilotKitStub();
+    TestBed.configureTestingModule({
+      imports: [CopilotChat],
+      providers: [
+        { provide: CopilotKit, useValue: copilotKit },
+        { provide: ChangeDetectorRef, useValue: { markForCheck: vi.fn() } },
+      ],
+    });
+  });
+
+  it("waits for the active run to finish before adding the next message", async () => {
+    const fixture = TestBed.createComponent(CopilotChat);
+    fixture.detectChanges();
+    const deferred = new Deferred();
+
+    copilotKit.agent.setActiveRunCompletionPromise(deferred.promise);
+    copilotKit.agent.emitRunInitialized();
+
+    const submitPromise = fixture.componentInstance.submitInput("next turn");
+
+    await Promise.resolve();
+
+    expect(copilotKit.agent.messages).toHaveLength(0);
+    expect(copilotKit.core.runAgent).not.toHaveBeenCalled();
+
+    deferred.resolve();
+    await submitPromise;
+
+    expect(copilotKit.agent.messages).toMatchObject([
+      { role: "user", content: "next turn" },
+    ]);
+    expect(copilotKit.core.runAgent).toHaveBeenCalledWith({
+      agent: copilotKit.agent,
+    });
+  });
+
+  it("stops through core.stopAgent and falls back to abortRun when needed", () => {
+    const fixture = TestBed.createComponent(CopilotChat);
+    fixture.detectChanges();
+    const abortRun = vi.spyOn(copilotKit.agent, "abortRun");
+
+    fixture.componentInstance.stopCurrentRun();
+    expect(copilotKit.core.stopAgent).toHaveBeenCalledWith({
+      agent: copilotKit.agent,
+    });
+    expect(abortRun).not.toHaveBeenCalled();
+
+    copilotKit.core.stopAgent.mockImplementationOnce(() => {
+      throw new Error("stop failed");
+    });
+
+    fixture.componentInstance.stopCurrentRun();
+    expect(abortRun).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/angular/src/lib/components/chat/copilot-chat-input.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-input.ts
@@ -17,7 +17,7 @@ import {
 import { CommonModule } from "@angular/common";
 import { CopilotSlot } from "../../slots/copilot-slot";
 import { injectChatLabels } from "../../chat-config";
-import { LucideAngularModule, ArrowUp } from "lucide-angular";
+import { LucideAngularModule, ArrowUp, Square } from "lucide-angular";
 import { CopilotChatTextarea } from "./copilot-chat-textarea";
 import { CopilotChatAudioRecorder } from "./copilot-chat-audio-recorder";
 import {
@@ -42,6 +42,8 @@ export interface SendButtonContext {
   send: () => void;
   disabled: boolean;
   value: string;
+  stop: () => void;
+  isRunning: boolean;
 }
 
 export interface ToolbarContext {
@@ -226,15 +228,21 @@ export interface ToolbarContext {
                   <button
                     type="button"
                     [class]="sendButtonClass() || defaultButtonClass"
-                    [disabled]="
-                      !computedValue().trim() || computedMode() === 'processing'
-                    "
-                    (click)="send()"
+                    [disabled]="sendButtonDisabled()"
+                    (click)="handleSendButtonClick()"
                   >
-                    <lucide-angular
-                      [img]="ArrowUpIcon"
-                      [size]="18"
-                    ></lucide-angular>
+                    @if (isProcessing() && canStop()) {
+                      <lucide-angular
+                        [img]="SquareIcon"
+                        [size]="18"
+                        class="fill-current"
+                      ></lucide-angular>
+                    } @else {
+                      <lucide-angular
+                        [img]="ArrowUpIcon"
+                        [size]="18"
+                      ></lucide-angular>
+                    }
                   </button>
                 </div>
               }
@@ -326,9 +334,11 @@ export class CopilotChatInput implements AfterViewInit, OnDestroy {
   finishTranscribe = output<void>();
   addFile = output<void>();
   valueChange = output<string>();
+  stop = output<void>();
 
   // Icons and default classes
   readonly ArrowUpIcon = ArrowUp;
+  readonly SquareIcon = Square;
   readonly defaultButtonClass = cn(
     // Base button styles
     "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium",
@@ -379,6 +389,17 @@ export class CopilotChatInput implements AfterViewInit, OnDestroy {
     return customValue || configValue || "";
   });
 
+  isProcessing = computed(
+    () =>
+      this.computedMode() !== "transcribe" &&
+      (this.chatState.isRunning?.() ?? false),
+  );
+  canSend = computed(() => this.computedValue().trim().length > 0);
+  canStop = computed(() => typeof this.chatState.stopCurrentRun === "function");
+  sendButtonDisabled = computed(() =>
+    this.isProcessing() ? !this.canStop() : !this.canSend(),
+  );
+
   computedClass = computed(() => {
     const baseClasses = cn(
       // Layout
@@ -397,10 +418,11 @@ export class CopilotChatInput implements AfterViewInit, OnDestroy {
 
   // Context for slots (reactive via signals)
   sendButtonContext = computed<SendButtonContext>(() => ({
-    send: () => this.send(),
-    disabled:
-      !this.computedValue().trim() || this.computedMode() === "processing",
+    send: () => this.handleSendButtonClick(),
+    disabled: this.sendButtonDisabled(),
     value: this.computedValue(),
+    stop: () => this.triggerStop(),
+    isRunning: this.isProcessing(),
   }));
 
   toolbarContext = computed<ToolbarContext>(() => ({
@@ -454,7 +476,10 @@ export class CopilotChatInput implements AfterViewInit, OnDestroy {
     clicked: () => this.handleStartTranscribe(),
   };
   // Support both `clicked` (idiomatic in our slots) and `click` (legacy)
-  sendButtonOutputs = { clicked: () => this.send(), click: () => this.send() };
+  sendButtonOutputs = {
+    clicked: () => this.handleSendButtonClick(),
+    click: () => this.handleSendButtonClick(),
+  };
 
   ngAfterViewInit(): void {
     // Auto-focus if needed
@@ -475,6 +500,10 @@ export class CopilotChatInput implements AfterViewInit, OnDestroy {
   handleKeyDown(event: KeyboardEvent): void {
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
+      if (this.isProcessing() && !this.canSend()) {
+        this.triggerStop();
+        return;
+      }
       this.send();
     }
   }
@@ -482,6 +511,19 @@ export class CopilotChatInput implements AfterViewInit, OnDestroy {
   handleValueChange(value: string): void {
     this.valueChange.emit(value);
     if (this.chatState) this.chatState.changeInput(value);
+  }
+
+  handleSendButtonClick(): void {
+    if (this.isProcessing()) {
+      this.triggerStop();
+      return;
+    }
+    this.send();
+  }
+
+  private triggerStop(): void {
+    this.stop.emit();
+    this.chatState.stopCurrentRun?.();
   }
 
   send(): void {

--- a/packages/angular/src/lib/components/chat/copilot-chat.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat.ts
@@ -72,7 +72,7 @@ export class CopilotChat implements ChatState {
   readonly injector = inject(Injector);
 
   protected messages = computed(() => this.agentStore().messages());
-  protected isRunning = computed(() => this.agentStore().isRunning());
+  readonly isRunning = computed(() => this.agentStore().isRunning());
   protected showCursor = signal<boolean>(false);
 
   private generatedThreadId: string = randomUUID();
@@ -140,9 +140,56 @@ export class CopilotChat implements ChatState {
     }
   }
 
+  stopCurrentRun(): void {
+    const agent = this.agentStore().agent;
+    if (!agent) return;
+
+    try {
+      this.copilotKit.core.stopAgent({ agent });
+    } catch (error) {
+      console.error("CopilotChat: stopAgent failed", error);
+      try {
+        agent.abortRun();
+      } catch (abortError) {
+        console.error("CopilotChat: abortRun fallback failed", abortError);
+      }
+    }
+  }
+
+  private getActiveRunCompletionPromise(
+    agent: AbstractAgent,
+  ): Promise<void> | undefined {
+    if (!("activeRunCompletionPromise" in agent)) return undefined;
+
+    return (agent as unknown as { activeRunCompletionPromise?: Promise<void> })
+      .activeRunCompletionPromise;
+  }
+
+  private async waitForActiveRunToSettle(): Promise<void> {
+    const agent = this.agentStore().agent;
+    const activeRunCompletionPromise = agent
+      ? this.getActiveRunCompletionPromise(agent)
+      : undefined;
+
+    if (this.isRunning() && activeRunCompletionPromise) {
+      try {
+        await activeRunCompletionPromise;
+      } catch (error) {
+        console.error(
+          "CopilotChat: in-flight run rejected while queuing send",
+          error,
+        );
+      }
+    }
+  }
+
   async submitInput(value: string): Promise<void> {
     const agent = this.agentStore().agent;
     if (!agent || !value.trim()) return;
+
+    this.inputValue.set("");
+
+    await this.waitForActiveRunToSettle();
 
     // Add user message
     const userMessage: Message = {
@@ -151,9 +198,6 @@ export class CopilotChat implements ChatState {
       content: value,
     };
     agent.addMessage(userMessage);
-
-    // Clear the input
-    this.inputValue.set("");
 
     // Show cursor while processing
     this.showCursor.set(true);


### PR DESCRIPTION
## Summary

Fix Angular CopilotChat run-control parity with React v2.

This updates the Angular chat input so an active agent run shows a stop affordance, keeps the textarea editable while streaming, and routes run-time actions correctly:
-> clicking the running button stops the active run
-> pressing Enter with empty input stops the active run
-> pressing Enter with text sends the next message instead of stopping

The parent `CopilotChat` now also serializes new sends behind the active run completion promise before adding the next user message or calling `runAgent`, preventing a new turn from pre-empting an interrupt resume.

## Changes

-> Added optional run-control APIs to `ChatState`
-> Wired Angular `CopilotChatInput` to render/send/stop like React v2
-> Added `CopilotChat.stopCurrentRun()` with `core.stopAgent()` and `abortRun()` fallback
-> Added active-run send serialization in `CopilotChat.submitInput()`
-> Added input behavior tests and parent-level `CopilotChat` tests for serialization and stop fallback

## Testing

-> `oxlint` passed on all touched files
-> `git diff --check` passed
-> `tsc -p packages/angular/tsconfig.spec.json --noEmit` reports unrelated existing Angular spec errors, but no errors from this patch
-> Vitest/Nx Angular test execution hung locally on Windows, including existing specs

## Related Issue

Closes #5428