### PR TITLE
fix(showcase/aimock): BIA tool-rendering cross-pill shadow on hasToolResult narration

### DIFF
--- a/showcase/aimock/d6/built-in-agent/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/built-in-agent/tool-rendering-custom-catchall.json
@@ -6,7 +6,18 @@
   },
   "fixtures": [
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 first prompt 'weather in Tokyo'. Emits get_weather tool call. The custom wildcard renderer fires for any tool the user doesn't explicitly handle. hasToolResult:false on the tool-emitting fixtures.",
+      "_comment": "tool-rendering-custom-catchall — follow-up narration after get_weather tool result. Scoped via toolCallId (per-leg) so it only matches the weather tool-result turn; ordered BEFORE the tool-emit sibling so first-match-wins picks narration when the tool result is present.",
+      "match": {
+        "userMessage": "check Tokyo weather forecast",
+        "toolCallId": "call_d6_cc_weather_001",
+        "context": "built-in-agent"
+      },
+      "response": {
+        "content": "Tokyo is 22°C and partly cloudy — the custom wildcard renderer should show the tool card above."
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall — first prompt 'weather in Tokyo'. Emits get_weather tool call. The custom wildcard renderer fires for any tool the user doesn't explicitly handle. hasToolResult:false on the tool-emitting fixtures.",
       "match": {
         "userMessage": "check Tokyo weather forecast",
         "hasToolResult": false,
@@ -23,18 +34,18 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 follow-up after get_weather tool result.",
+      "_comment": "tool-rendering-custom-catchall — follow-up narration after get_stock_price tool result. Scoped via toolCallId (per-leg) so it only matches the stock tool-result turn; ordered BEFORE the tool-emit sibling so first-match-wins picks narration when the tool result is present.",
       "match": {
-        "userMessage": "check Tokyo weather forecast",
-        "hasToolResult": true,
+        "userMessage": "current price of AAPL",
+        "toolCallId": "call_d6_cc_stock_001",
         "context": "built-in-agent"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 the custom wildcard renderer should show the tool card above."
+        "content": "AAPL is trading at $189.42, up 1.27% — rendered through the custom wildcard catchall renderer."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 second prompt 'What's the current price of AAPL?'. Emits get_stock_price tool call to exercise a DIFFERENT tool through the same wildcard renderer.",
+      "_comment": "tool-rendering-custom-catchall — second prompt 'What's the current price of AAPL?'. Emits get_stock_price tool call to exercise a DIFFERENT tool through the same wildcard renderer.",
       "match": {
         "userMessage": "current price of AAPL",
         "hasToolResult": false,
@@ -48,17 +59,6 @@
             "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":189.42,\"change_pct\":1.27}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 follow-up after get_stock_price tool result.",
-      "match": {
-        "userMessage": "current price of AAPL",
-        "hasToolResult": true,
-        "context": "built-in-agent"
-      },
-      "response": {
-        "content": "AAPL is trading at $189.42, up 1.27% \u2014 rendered through the custom wildcard catchall renderer."
       }
     }
   ]

--- a/showcase/aimock/d6/built-in-agent/tool-rendering.json
+++ b/showcase/aimock/d6/built-in-agent/tool-rendering.json
@@ -182,47 +182,30 @@
       }
     },
     {
-      "_comment": "Stock price — follow-up content fallback for BIA /v1/responses id-rewriting (same rationale as SF-weather hasToolResult:true fixture).",
+      "_comment": "Stock price — first-leg tool-emit. Uses sequenceIndex:0 (per-test counter) instead of hasToolResult/turnIndex because the tool-rendering-custom-catchall probe sends 'weather in Tokyo' first which leaves a tool result + assistant turn in history, making BOTH hasToolResult:false AND turnIndex:0 false-y when AAPL arrives at turn 2. sequenceIndex:0 fires exactly once per test; on iteration 2 (count=1) it falls through to the bare narration below, breaking the emit→tool-result→re-emit loop without depending on hasToolResult-based history inspection. Ordered BEFORE the bare narration so first-match-wins on iteration 1.",
       "match": {
         "userMessage": "What's the current price of AAPL?",
-        "hasToolResult": true,
+        "sequenceIndex": 0,
+        "context": "built-in-agent"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_tr_stock_aapl_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "Stock price — narration after get_stock_price ran. No hasToolResult constraint: in a multi-pill session a prior pill's tool result poisons hasToolResult:true with a false positive AND blocks hasToolResult:false on the first AAPL turn. The sequenceIndex:0 emitter above fires once on iteration 1; this bare narration takes over on iteration 2 onward (after the emitter is exhausted). The toolCallId-keyed narration above keeps the non-BIA fast path; this is the BIA fallback that no longer cross-shadows a sibling pill's first turn.",
+      "match": {
+        "userMessage": "What's the current price of AAPL?",
         "context": "built-in-agent"
       },
       "response": {
         "content": "AAPL is trading at $338.37, down 2.96% on the day."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "What's the current price of AAPL?",
-        "turnIndex": 0,
-        "context": "built-in-agent"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_tr_stock_aapl_001",
-            "name": "get_stock_price",
-            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "Stock price — first-turn tool-emit fallback for multi-pill demo sessions where a PRIOR pill already left an assistant message in the thread, so turnIndex is not 0 and the fixture above is skipped. Anchored on hasToolResult:false so it only emits BEFORE any tool has run.",
-      "match": {
-        "userMessage": "What's the current price of AAPL?",
-        "hasToolResult": false,
-        "context": "built-in-agent"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_tr_stock_aapl_001",
-            "name": "get_stock_price",
-            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
-          }
-        ]
       }
     },
     {
@@ -399,47 +382,30 @@
       }
     },
     {
-      "_comment": "AAPL probe — follow-up content fallback for BIA /v1/responses id-rewriting (same rationale as SF-weather hasToolResult:true fixture). Must precede the first-leg emitter below. Tightened from bare 'AAPL' to 'current price of AAPL' to avoid shadowing gen-ui-headless-complete.json's 'price of AAPL right now' pill.",
+      "_comment": "AAPL probe — first-leg tool-emit. Uses sequenceIndex:0 (fires once per test) instead of hasToolResult:false because the tool-rendering-custom-catchall probe sends 'weather in Tokyo' first which leaves a tool result in history, making hasToolResult:false false-y for the AAPL turn. sequenceIndex:0 is stable across multi-pill sessions (per-test counter resets) AND breaks the emit→tool-result→re-emit loop on iteration 2 (count=1, seqIdx:0 mismatch → falls through to narration below). Ordered BEFORE the bare-userMessage narration so first-match-wins on iteration 1.",
       "match": {
         "userMessage": "current price of AAPL",
-        "hasToolResult": true,
+        "sequenceIndex": 0,
+        "context": "built-in-agent"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d5_get_stock_price_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"AAPL\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "AAPL probe — narration after get_stock_price ran. No hasToolResult constraint: in a multi-pill session a prior pill's tool result poisons hasToolResult:true with a false positive AND blocks hasToolResult:false on the first AAPL turn. The sequenceIndex:0 emitter above fires once on iteration 1; this bare narration takes over on iteration 2 onward (after the emitter is exhausted). The toolCallId-keyed narration above keeps the non-BIA fast path; this is the BIA fallback that no longer cross-shadows because the emitter is gated by sequenceIndex rather than hasToolResult.",
+      "match": {
+        "userMessage": "current price of AAPL",
         "context": "built-in-agent"
       },
       "response": {
         "content": "AAPL is trading at $189.42, up 1.27% on the day. The card above shows the live ticker and the percentage change."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "current price of AAPL",
-        "turnIndex": 0,
-        "context": "built-in-agent"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d5_get_stock_price_001",
-            "name": "get_stock_price",
-            "arguments": "{\"ticker\":\"AAPL\"}"
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "AAPL probe — first-leg tool-emit fallback for multi-pill sessions where turnIndex is not 0 (the custom-catchall probe sends 'weather in Tokyo' first, then 'AAPL'). Anchored on hasToolResult:false so it only emits BEFORE the stock tool has run. Tightened from bare 'AAPL' to 'current price of AAPL' to avoid shadowing gen-ui-headless-complete.json's 'price of AAPL right now' pill.",
-      "match": {
-        "userMessage": "current price of AAPL",
-        "hasToolResult": false,
-        "context": "built-in-agent"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d5_get_stock_price_001",
-            "name": "get_stock_price",
-            "arguments": "{\"ticker\":\"AAPL\"}"
-          }
-        ]
       }
     },
     {


### PR DESCRIPTION
## Summary

The `built-in-agent:tool-rendering-custom-catchall` probe sends `"weather in Tokyo"` then `"What's the current price of AAPL?"` in one session. After the weather tool runs in turn 1, `hasToolResult` is true across the rest of the thread — which fires `tool-rendering.json`'s AAPL `hasToolResult:true` narration prematurely on turn 2 iteration 1, returning prose without ever emitting `get_stock_price`. The custom-catchall assertion (both tools rendered through the wildcard testid) then fails with missing `get_stock_price`.

The bug was structural: the (hasToolResult:true narration + hasToolResult:false/turnIndex:0 emitter) layered fallbacks were authored as if hasToolResult tracked the CURRENT pill's tool, but the matcher checks for ANY tool result in history.

## Fix

Replace the layered hasToolResult fallbacks with a `sequenceIndex:0` emitter ordered BEFORE a bare `userMessage+context` narration. The per-test fixture-match counter resets each run, so the emitter fires exactly once on iteration 1 regardless of prior pills' tool history, then falls through to the narration on iteration 2. The toolCallId-keyed narration above each block is retained for the non-BIA fast path.

Applied symmetrically to the two AAPL blocks in `tool-rendering.json` (the `"What's the current price of AAPL?"` block at the top and the legacy `"current price of AAPL"` alias block lower down).

The earlier partial fix to `tool-rendering-custom-catchall.json` is kept — those fixtures never match real probe traffic (they use unique `"check Tokyo weather forecast"` substring) but the reordering is consistent with the cross-file pattern.

## Verification

- `./bin/showcase test built-in-agent:tool-rendering --d6 --direct` → green
- `./bin/showcase test built-in-agent:tool-rendering-custom-catchall --d6 --direct` → green (turn 2 emits get_stock_price; cross-tool signature pass)
- `./bin/showcase test built-in-agent:tool-rendering-default-catchall --d6 --direct` → green
- `pnpm vitest run __tests__/aimock-fixtures.test.ts` (showcase/scripts) → 737 pass; collision/shadow ceilings unchanged.

## Test plan

- [x] tool-rendering local green
- [x] tool-rendering-custom-catchall local green
- [x] tool-rendering-default-catchall local green
- [x] aimock-fixtures.test.ts collision/shadow ceilings unchanged
- [ ] CI green