### PR TITLE
feat(bot-slack): agent-native Slack APIs — assistant pane + native streaming (default-on)

### DIFF
--- a/.changeset/slack-agent-native-apis.md
+++ b/.changeset/slack-agent-native-apis.md
@@ -1,0 +1,29 @@
+---
+"@copilotkit/bot-slack": minor
+"@copilotkit/bot": minor
+"@copilotkit/bot-ui": minor
+---
+
+feat(bot-slack): agent-native Slack APIs — assistant pane + native streaming, on by default
+
+The Slack adapter now activates Slack's agent-grade APIs with zero config:
+
+- **Assistant pane** ("Agents & AI Apps"): opening the pane greets the user with
+  tappable prompt chips, each pane conversation is its own thread (replies stay
+  in-thread), and the agent's run/tool lifecycle drives native composer status
+  ("is thinking…", "is using `tool`…") instead of placeholder/`:wrench:`
+  messages. Auto-titled from the first message.
+- **Native streaming** (`chat.startStream`/`appendStream`/`stopStream`): replies
+  stream as raw markdown wherever a thread exists, so real tables and fenced code
+  render natively. Flat DMs and workspaces without the streaming API fall back to
+  the legacy `chat.update` transport automatically — opting in can never break a
+  bot.
+
+Customize with the new `assistant` option (or `assistant: false` to disable the
+pane); force the old transport with `streaming: "legacy"`.
+
+The engine (`@copilotkit/bot`) grows the smallest portable surface: a
+`bot.onThreadStarted` lifecycle handler, capability-gated `thread.setSuggestedPrompts`
+/ `thread.setTitle`, two `SurfaceCapabilities` flags, and the matching optional
+`PlatformAdapter` methods — all degrade gracefully on surfaces that don't support
+them.

--- a/examples/slack/app/index.ts
+++ b/examples/slack/app/index.ts
@@ -43,6 +43,23 @@ async function main() {
       slack({
         botToken: required("SLACK_BOT_TOKEN"),
         appToken: required("SLACK_APP_TOKEN"),
+        // Assistant-pane behavior is ON by default; this just customizes it.
+        // The greeting + chips show when a user opens the pane (matching the
+        // app manifest's `assistant_view`); native streaming + status need no
+        // config. Pass `assistant: false` / `streaming: "legacy"` to opt out.
+        assistant: {
+          greeting: "Hi! I can triage issues, search docs, and more.",
+          suggestedPrompts: [
+            {
+              title: "Triage my open issues",
+              message: "Triage my open issues",
+            },
+            {
+              title: "What shipped this week?",
+              message: "Summarize what shipped this week",
+            },
+          ],
+        },
       }),
     ],
     // One AG-UI agent per Slack conversation. The backend is a CopilotKit
@@ -81,6 +98,23 @@ async function main() {
   // never fire (and registering both would risk double-handling).
   bot.onMention(async ({ thread, message }) => {
     await thread.runAgent({ context: senderContext(message.user) });
+  });
+
+  // Optional — dynamic behavior when a user opens the assistant pane. The
+  // adapter applies the static `assistant` defaults first (greeting + chips),
+  // then this layers on top: personalize the prompt chips for the opener.
+  bot.onThreadStarted(async ({ thread, user }) => {
+    if (!user?.name) return;
+    await thread.setSuggestedPrompts([
+      {
+        title: `Triage ${user.name}'s issues`,
+        message: "Triage my open issues",
+      },
+      {
+        title: "What shipped this week?",
+        message: "Summarize what shipped this week",
+      },
+    ]);
   });
 
   await bot.start();

--- a/examples/slack/slack-app-manifest.json
+++ b/examples/slack/slack-app-manifest.json
@@ -14,6 +14,19 @@
       "display_name": "CopilotKit Triage",
       "always_online": true
     },
+    "assistant_view": {
+      "assistant_description": "On-call triage assistant — query/file Linear issues and find/write Notion pages.",
+      "suggested_prompts": [
+        {
+          "title": "Triage my open issues",
+          "message": "Triage my open issues"
+        },
+        {
+          "title": "What shipped this week?",
+          "message": "Summarize what shipped this week"
+        }
+      ]
+    },
     "slash_commands": [
       {
         "command": "/agent",
@@ -34,6 +47,7 @@
       "user": ["chat:write"],
       "bot": [
         "app_mentions:read",
+        "assistant:write",
         "channels:history",
         "groups:history",
         "im:history",
@@ -63,6 +77,8 @@
     "event_subscriptions": {
       "bot_events": [
         "app_mention",
+        "assistant_thread_started",
+        "assistant_thread_context_changed",
         "message.channels",
         "message.groups",
         "message.im",

--- a/examples/slack/slack-app-manifest.yaml
+++ b/examples/slack/slack-app-manifest.yaml
@@ -6,6 +6,13 @@ features:
   bot_user:
     display_name: CopilotKit Triage
     always_online: true
+  # App Home: enable the Messages tab so users can DM the bot (and so the tab
+  # isn't read-only — otherwise Slack shows "Sending messages to this app has
+  # been turned off").
+  app_home:
+    home_tab_enabled: false
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
   # Enables the assistant pane ("Agents & AI Apps"). The greeting + chips here
   # mirror the `assistant` option in app/index.ts.
   assistant_view:

--- a/examples/slack/slack-app-manifest.yaml
+++ b/examples/slack/slack-app-manifest.yaml
@@ -6,6 +6,15 @@ features:
   bot_user:
     display_name: CopilotKit Triage
     always_online: true
+  # Enables the assistant pane ("Agents & AI Apps"). The greeting + chips here
+  # mirror the `assistant` option in app/index.ts.
+  assistant_view:
+    assistant_description: On-call triage assistant — query/file Linear issues and find/write Notion pages.
+    suggested_prompts:
+      - title: Triage my open issues
+        message: Triage my open issues
+      - title: What shipped this week?
+        message: Summarize what shipped this week
   slash_commands:
     - command: /agent
       description: Talk to the AG-UI agent from any channel
@@ -20,6 +29,7 @@ oauth_config:
     bot:
       # --- Read what the user said ---
       - app_mentions:read # see @mentions of the bot
+      - assistant:write # assistant pane: status, title, suggested prompts
       - channels:history # read messages in public channels bot is in
       - groups:history # read messages in private channels bot is in
       - im:history # read DMs
@@ -50,7 +60,9 @@ settings:
   event_subscriptions:
     bot_events:
       - app_mention
-      - message.im # DMs to the bot (for later, when we add DM flow)
+      - assistant_thread_started # user opened the assistant pane
+      - assistant_thread_context_changed # the channel/context the user is viewing
+      - message.im # DMs to the bot + assistant-pane messages
   interactivity:
     is_enabled: true
   socket_mode_enabled: true

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -66,19 +66,22 @@ pre-commit:
       # with `sh: 1: [: <path>: unexpected operator` because lefthook
       # interpolates the file list as space-separated words, not a single
       # quoted string, so [ saw 3+ args and tried to parse a binary op.
+      # IMPORTANT: keep this script DOUBLE-QUOTE-FREE. lefthook invokes a
+      # multi-line `run` as `sh -c "<script>"` and (in some versions / on
+      # Windows git-sh) does not escape embedded double quotes, so any `"$@"`
+      # / `[ "$#" ]` / `x=""` prematurely closes the `-c "…"` string and the
+      # shell aborts with `unexpected EOF`. Use unquoted `$@`/`$#` — staged
+      # paths in this monorepo never contain spaces. JSON is excluded from the
+      # glob above, so oxfmt never receives package.json (the old explicit
+      # package.json filter is unnecessary). ruff is scoped to .py via `case`.
       run: |
         set -- {staged_files}
-        if [ "$#" -gt 0 ]; then
-          pnpm exec oxlint --fix "$@"
-          # Defense-in-depth: filter package.json from explicit oxfmt args even though
-          # .oxfmtrc.json ignorePatterns covers it. Explicit-path invocations bypass the
-          # pattern in some tool versions; the shell filter makes the exclusion unconditional.
-          fmt_files=""; for f in "$@"; do case "$f" in */package.json|package.json) ;; *) fmt_files="$fmt_files $f" ;; esac; done
-          [ -n "$fmt_files" ] && pnpm exec oxfmt --write $fmt_files
-          # ruff v0.9+ formats JSON with trailing commas (JSONC), which breaks
-          # pnpm's JSON parser in the sync-lockfile hook. Scope it to .py only.
-          py_files=""; for f in "$@"; do case "$f" in *.py) py_files="$py_files $f";; esac; done
-          [ -n "$py_files" ] && ruff format $py_files 2>/dev/null || true
+        if [ $# -gt 0 ]; then
+          pnpm exec oxlint --fix $@
+          pnpm exec oxfmt --write $@
+          for f in $@; do
+            case $f in *.py) ruff format $f 2>/dev/null || true ;; esac
+          done
         fi
       stage_fixed: true
     test-and-check-packages:

--- a/package.json
+++ b/package.json
@@ -90,6 +90,9 @@
       }
     },
     "overrides": {
+      "@copilotkit/bot": "workspace:*",
+      "@copilotkit/bot-slack": "workspace:*",
+      "@copilotkit/bot-ui": "workspace:*",
       "@ag-ui/mcp-middleware>@ag-ui/client": "0.0.53",
       "streamdown>react": "^19.0.0",
       "@types/react": "19.1.8",

--- a/packages/bot-slack/ARCHITECTURE.md
+++ b/packages/bot-slack/ARCHITECTURE.md
@@ -27,9 +27,14 @@ and opaque-id interactions.
 `@copilotkit/bot`'s `PlatformAdapter`. The members it implements:
 
 - `platform`, `capabilities` (`supportsStreaming: true`, modals/typing/
-  reactions `false`, `maxBlocksPerMessage: 50`), `ackDeadlineMs` (3000)
+  reactions `false`, `maxBlocksPerMessage: 50`; `supportsSuggestedPrompts` /
+  `supportsThreadTitle` computed from whether the assistant pane is enabled),
+  `ackDeadlineMs` (3000)
 - `start(sink)` / `stop()` — bring the Bolt app up / down and push normalized
-  events into the engine's `IngressSink`
+  events into the engine's `IngressSink` (`onTurn` / `onInteraction` /
+  `onCommand` / `onThreadStarted`)
+- `setSuggestedPrompts` / `setThreadTitle` — back the capability-gated
+  `thread.setSuggestedPrompts` / `thread.setTitle` via `assistant.threads.*`
 - `render(ir)` — IR → Block Kit (`renderBlockKit`)
 - `post` / `update` / `stream` / `delete` — egress via the Slack Web client
 - `createRunRenderer(target)` — the AG-UI `RunRenderer` for a run
@@ -118,6 +123,37 @@ a hot-cache hit, or a **cold-path re-render rehydration** (load the snapshot,
 re-render the named component with frozen props, re-walk to the handler's
 path). A miss after restart degrades to "this action expired."
 
+## Agent-native Slack APIs (assistant pane + native streaming)
+
+Two agent-grade Slack API families are wired in, **on by default**, each
+degrading safely:
+
+- **Native streaming** (`native-stream.ts`). `NativeMessageStream` implements
+  the same `append(fullText)/finish()` contract as `MessageStream`, so the
+  event-renderer's text stream and `adapter.stream()` are transport-agnostic.
+  It drives `chat.startStream` / `appendStream` (raw `markdown_text`, no mrkdwn
+  translation) / `stopStream`, with the same ≥800ms throttle and a fence-aware
+  ~12k continuation split (reusing `auto-close-streaming`'s context detection).
+  Used wherever a `threadTs` exists; flat DMs and a failed first `startStream`
+  fall back to the legacy `chat.update` transport (the workspace is marked
+  legacy in-memory so later streams skip the native path). `streaming: "legacy"`
+  forces the old transport.
+- **Assistant pane** (`assistant.ts`). `attachAssistant` registers Bolt's
+  `Assistant` middleware and is the SOLE owner of pane events. On
+  `assistant_thread_started` it applies static defaults (greeting + suggested
+  prompts) then emits `sink.onThreadStarted` (engine handlers layer on top,
+  never race); a pane user message becomes exactly one `sink.onTurn` scoped to
+  the pane thread (`channelId::threadTs`), auto-titled from the first message.
+  Pane threads are tracked in-memory so `slack-listener.ts`'s one-line guard
+  skips the threaded `message.im` events the Assistant middleware already owns —
+  exactly one turn per pane message, with ordinary threaded DMs untouched. In a
+  pane thread the run lifecycle drives native composer status
+  (`assistant.threads.setStatus`) instead of placeholder / `:wrench:` messages.
+
+Status is **not** a `Thread` method — it stays renderer-managed from the
+run/tool lifecycle; only prompts and titles (which only the author knows) get
+`Thread` methods.
+
 ## Preserved mechanics
 
 These files carry over from the pre-rework package, lightly adapted:
@@ -139,7 +175,9 @@ These files carry over from the pre-rework package, lightly adapted:
 src/
 ├── index.ts                  # public exports
 ├── adapter.ts                # slack() factory + SlackAdapter (PlatformAdapter impl) + Bolt wiring
-├── event-renderer.ts         # createRunRenderer: AG-UI subscriber → stream + tool/interrupt capture
+├── assistant.ts              # attachAssistant: Bolt Assistant middleware ⇄ engine sink (pane events)
+├── native-stream.ts          # NativeMessageStream: chat.startStream/appendStream/stopStream (+ legacy fallback)
+├── event-renderer.ts         # createRunRenderer: AG-UI subscriber → stream + tool/interrupt capture + pane status
 ├── interaction.ts            # decodeInteraction (opaque id) + conversationKeyOf
 ├── render/
 │   ├── block-kit.ts          # renderBlockKit / renderSlackMessage (IR → Block Kit)
@@ -154,7 +192,7 @@ src/
 ├── sanitizing-http-agent.ts  # sanitizing AG-UI HTTP agent
 ├── built-in-tools.ts         # lookup_slack_user + defaultSlackTools (as BotTools)
 ├── built-in-context.ts       # tagging / mrkdwn / convo-model context entries
-└── types.ts                  # IncomingTurn, ReplyTarget, ConversationKey, DM_SCOPE
+└── types.ts                  # IncomingTurn, ReplyTarget, ConversationKey, DM_SCOPE, SlackAssistantOptions
 ```
 
 ## What's intentionally _not_ abstracted

--- a/packages/bot-slack/README.md
+++ b/packages/bot-slack/README.md
@@ -93,9 +93,54 @@ posted as `attachments: [{ color, blocks }]`).
 
 ### Streaming
 
-`thread.stream(...)` posts a placeholder and edits it in place via throttled
-`chat.update`, with multi-message chunking, mid-stream bracket auto-close, and
-Markdown → mrkdwn translation, so the in-flight message always renders.
+By default, replies stream via Slack's **native streaming API**
+(`chat.startStream` / `appendStream` / `stopStream`) wherever the reply target
+is a thread — a true streaming UI rendering **raw markdown** (so real tables and
+fenced code render natively), with the same throttle budget and fence-aware
+multi-message continuation as the legacy path. Flat DMs (no thread) and any
+workspace where the streaming API is unavailable fall back automatically to the
+shipped `chat.update` transport (throttled edits, multi-message chunking,
+mid-stream bracket auto-close, Markdown → mrkdwn translation). Pass
+`streaming: "legacy"` to force the `chat.update` transport everywhere. The
+fallback is transparent — **opting in can never break a bot**: the first
+`startStream` failure marks the workspace legacy and redoes the stream the old
+way.
+
+### Assistant pane (agent-native, default-on)
+
+When the Slack app has the **Agents & AI Apps** toggle (an `assistant_view`
+manifest block + the `assistant:write` scope and `assistant_thread_*` events),
+the adapter activates Slack's assistant pane with **zero config**:
+
+- Opening the pane posts a greeting + tappable prompt chips, and each pane
+  conversation is its own thread (replies stay in-thread).
+- While the agent runs, native composer status is shown
+  (`assistant.threads.setStatus`: "is thinking…", "is using \`tool\`…") instead
+  of placeholder/`:wrench:` messages.
+- The pane thread is auto-titled from the first message.
+
+Customize via the `assistant` option, or set `assistant: false` to disable pane
+handling entirely. Apps **without** the toggle behave exactly as before — the
+pane machinery lies dormant.
+
+```ts
+slack({
+  botToken,
+  appToken,
+  assistant: {
+    greeting: "Hi! I can triage issues, search docs, and more.",
+    suggestedPrompts: [
+      { title: "Triage my open issues", message: "Triage my open issues" },
+    ],
+  },
+});
+
+// Dynamic behavior when a user opens the pane (layers on top of the defaults):
+bot.onThreadStarted(async ({ thread, user }) => {
+  await thread.setSuggestedPrompts(promptsFor(user));
+  // await thread.setTitle(...) is also available
+});
+```
 
 ### Interactions (ack-first)
 
@@ -187,11 +232,12 @@ dynamically rather than registering them up front).
 
 ## Exports
 
-`slack`, `SlackAdapter`, `SlackAdapterOptions`; `createRunRenderer`;
-`decodeInteraction`, `conversationKeyOf`; `renderBlockKit`,
+`slack`, `SlackAdapter`, `SlackAdapterOptions`, `SlackAssistantOptions`;
+`createRunRenderer`; `decodeInteraction`, `conversationKeyOf`; `renderBlockKit`,
 `renderSlackMessage`, `SLACK_LIMITS`; `defaultSlackTools`,
 `lookupSlackUserTool`, `defaultSlackContext` (+ the individual context
 entries); `markdownToMrkdwn`; and the
 preserved mechanics (`SlackConversationStore`, `MessageStream`,
-`ChunkedMessageStream`, `attachSlackListener`, `SanitizingHttpAgent`,
-`buildFileContentParts`, `autoCloseOpenMarkdown`, and supporting types).
+`ChunkedMessageStream`, `NativeMessageStream`, `attachSlackListener`,
+`attachAssistant`, `SanitizingHttpAgent`, `buildFileContentParts`,
+`autoCloseOpenMarkdown`, and supporting types).

--- a/packages/bot-slack/src/__tests__/assistant.test.ts
+++ b/packages/bot-slack/src/__tests__/assistant.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Capture the `AssistantConfig` handed to `new Assistant(config)` so we can
+ * drive its middleware (threadStarted / userMessage) directly with fake Bolt
+ * utility args and assert what reaches the engine sink.
+ */
+interface CapturedConfig {
+  threadStarted: (args: Record<string, unknown>) => Promise<void>;
+  userMessage: (args: Record<string, unknown>) => Promise<void>;
+  threadContextChanged?: (args: Record<string, unknown>) => Promise<void>;
+}
+let capturedConfig: CapturedConfig | undefined;
+
+vi.mock("@slack/bolt", () => ({
+  Assistant: class {
+    config: CapturedConfig;
+    constructor(config: CapturedConfig) {
+      this.config = config;
+      capturedConfig = config;
+    }
+  },
+}));
+
+import { attachAssistant } from "../assistant.js";
+import type { IngressSink, PlatformUser } from "@copilotkit/bot";
+import type { SlackAssistantOptions } from "../types.js";
+
+function setup(opts: SlackAssistantOptions = {}) {
+  capturedConfig = undefined;
+  const onTurn = vi.fn(async () => {});
+  const onThreadStarted = vi.fn(async () => {});
+  const sink: IngressSink = {
+    onTurn,
+    onInteraction: vi.fn(),
+    onCommand: vi.fn(),
+    onThreadStarted,
+  };
+  const resolveUser = vi.fn(
+    async (id: string): Promise<PlatformUser> => ({ id, name: `name-${id}` }),
+  );
+  // The Bolt App is only used for `app.assistant(...)`, which our mocked
+  // Assistant ignores — capture happens in the constructor above.
+  const app = { assistant: vi.fn() } as never;
+  const handle = attachAssistant({ app, sink, opts, resolveUser });
+  return { handle, onTurn, onThreadStarted, resolveUser };
+}
+
+const threadStartedEvent = {
+  event: {
+    assistant_thread: {
+      user_id: "U1",
+      channel_id: "D1",
+      thread_ts: "100.0",
+    },
+  },
+};
+
+describe("attachAssistant — threadStarted", () => {
+  beforeEach(() => setup());
+
+  it("applies static defaults (greeting + prompts) BEFORE emitting onThreadStarted", async () => {
+    const { onThreadStarted } = setup({
+      greeting: "hello!",
+      suggestedPrompts: [{ title: "Triage", message: "Triage my issues" }],
+    });
+    const say = vi.fn(async () => {});
+    const setSuggestedPrompts = vi.fn(async () => {});
+
+    await capturedConfig!.threadStarted({
+      ...threadStartedEvent,
+      say,
+      setSuggestedPrompts,
+    });
+
+    expect(say).toHaveBeenCalledWith("hello!");
+    expect(setSuggestedPrompts).toHaveBeenCalledWith({
+      prompts: [{ title: "Triage", message: "Triage my issues" }],
+    });
+    expect(onThreadStarted).toHaveBeenCalledTimes(1);
+    // Ordering rule: defaults first, then the engine hook layers on top.
+    expect(say.mock.invocationCallOrder[0]!).toBeLessThan(
+      onThreadStarted.mock.invocationCallOrder[0]!,
+    );
+    expect(setSuggestedPrompts.mock.invocationCallOrder[0]!).toBeLessThan(
+      onThreadStarted.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("emits onThreadStarted with a thread-scoped key and recipientUserId", async () => {
+    const { onThreadStarted } = setup();
+    await capturedConfig!.threadStarted({
+      ...threadStartedEvent,
+      say: vi.fn(),
+      setSuggestedPrompts: vi.fn(),
+    });
+    expect(onThreadStarted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationKey: "D1::100.0",
+        replyTarget: {
+          channel: "D1",
+          threadTs: "100.0",
+          recipientUserId: "U1",
+        },
+        user: { id: "U1", name: "name-U1" },
+        platform: "slack",
+      }),
+    );
+  });
+
+  it("records the pane thread for the listener guard", async () => {
+    const { handle } = setup();
+    expect(handle.isAssistantThread("D1", "100.0")).toBe(false);
+    await capturedConfig!.threadStarted({
+      ...threadStartedEvent,
+      say: vi.fn(),
+      setSuggestedPrompts: vi.fn(),
+    });
+    expect(handle.isAssistantThread("D1", "100.0")).toBe(true);
+    expect(handle.isAssistantThread("D1", "999.0")).toBe(false);
+  });
+
+  it("does not post a greeting or prompts when none are configured", async () => {
+    const { onThreadStarted } = setup();
+    const say = vi.fn(async () => {});
+    const setSuggestedPrompts = vi.fn(async () => {});
+    await capturedConfig!.threadStarted({
+      ...threadStartedEvent,
+      say,
+      setSuggestedPrompts,
+    });
+    expect(say).not.toHaveBeenCalled();
+    expect(setSuggestedPrompts).not.toHaveBeenCalled();
+    expect(onThreadStarted).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("attachAssistant — userMessage", () => {
+  const msg = {
+    message: { channel: "D1", thread_ts: "100.0", text: "hello", user: "U1" },
+  };
+
+  it("delivers exactly one turn scoped to the pane thread, with recipientUserId", async () => {
+    const { onTurn } = setup();
+    await capturedConfig!.userMessage({ ...msg, setTitle: vi.fn() });
+    expect(onTurn).toHaveBeenCalledTimes(1);
+    expect(onTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationKey: "D1::100.0",
+        replyTarget: {
+          channel: "D1",
+          threadTs: "100.0",
+          recipientUserId: "U1",
+        },
+        userText: "hello",
+        platform: "slack",
+      }),
+    );
+  });
+
+  it("auto-titles from the FIRST user message only", async () => {
+    const { onTurn } = setup(); // title defaults to "auto"
+    const setTitle = vi.fn(async () => {});
+    await capturedConfig!.userMessage({ ...msg, setTitle });
+    await capturedConfig!.userMessage({
+      message: { ...msg.message, text: "second message" },
+      setTitle,
+    });
+    expect(setTitle).toHaveBeenCalledTimes(1);
+    expect(setTitle).toHaveBeenCalledWith("hello");
+    expect(onTurn).toHaveBeenCalledTimes(2);
+  });
+
+  it("never titles when title is disabled", async () => {
+    setup({ title: false });
+    const setTitle = vi.fn(async () => {});
+    await capturedConfig!.userMessage({ ...msg, setTitle });
+    expect(setTitle).not.toHaveBeenCalled();
+  });
+
+  it("ignores a message with no thread (not a pane message)", async () => {
+    const { onTurn } = setup();
+    await capturedConfig!.userMessage({
+      message: { channel: "D1", text: "no thread", user: "U1" },
+      setTitle: vi.fn(),
+    });
+    expect(onTurn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/bot-slack/src/__tests__/event-renderer.test.ts
+++ b/packages/bot-slack/src/__tests__/event-renderer.test.ts
@@ -412,13 +412,110 @@ describe("createRunRenderer", () => {
     await sub.onTextMessageEndEvent!({ event: { messageId: "a" } } as never);
     await sub.onTextMessageEndEvent!({ event: { messageId: "b" } } as never);
 
-    const lastUpdateForFirstTs = [...fake.updates]
-      .reverse()
-      .find((u) => u.ts === "1.000");
-    const lastUpdateForSecondTs = [...fake.updates]
-      .reverse()
-      .find((u) => u.ts === "2.000");
+    const lastUpdateForFirstTs = fake.updates
+      .filter((u) => u.ts === "1.000")
+      .at(-1);
+    const lastUpdateForSecondTs = fake.updates
+      .filter((u) => u.ts === "2.000")
+      .at(-1);
     expect(lastUpdateForFirstTs?.text).toBe("AAA");
     expect(lastUpdateForSecondTs?.text).toBe("BBB");
+  });
+});
+
+describe("createRunRenderer — assistant pane status mode", () => {
+  function makePaneClient() {
+    const statuses: { status: string; loading_messages?: string[] }[] = [];
+    const posts: { text: string; ts: string }[] = [];
+    const updates: { ts: string; text: string }[] = [];
+    let counter = 0;
+    const chat = {
+      postMessage: vi.fn(async (args: { text: string }) => {
+        counter++;
+        const ts = `${counter}.000`;
+        posts.push({ text: args.text, ts });
+        return { ok: true, ts };
+      }),
+      update: vi.fn(async (args: { ts: string; text: string }) => {
+        updates.push(args);
+        return { ok: true };
+      }),
+      delete: vi.fn(async () => ({ ok: true })),
+    };
+    const assistant = {
+      threads: {
+        setStatus: vi.fn(
+          async (args: { status: string; loading_messages?: string[] }) => {
+            statuses.push({
+              status: args.status,
+              loading_messages: args.loading_messages,
+            });
+            return { ok: true };
+          },
+        ),
+      },
+    };
+    const client = { chat, assistant } as unknown as WebClient;
+    return { client, statuses, posts };
+  }
+
+  it("sets native status on run start instead of posting a placeholder", async () => {
+    const f = makePaneClient();
+    const { subscriber: sub } = createRunRenderer({
+      client: f.client,
+      target: { channel: "D1", threadTs: "100.0" },
+      assistantStatus: { thinking: "is pondering…", loadingMessages: ["a"] },
+    });
+    await sub.onRunStartedEvent!({} as never);
+    expect(f.posts).toHaveLength(0);
+    expect(f.statuses[0]).toEqual({
+      status: "is pondering…",
+      loading_messages: ["a"],
+    });
+  });
+
+  it("surfaces tool calls as live status, not :wrench: rows", async () => {
+    const f = makePaneClient();
+    const { subscriber: sub } = createRunRenderer({
+      client: f.client,
+      target: { channel: "D1", threadTs: "100.0" },
+      assistantStatus: {},
+    });
+    await sub.onToolCallStartEvent!({
+      event: { toolCallId: "t1", toolCallName: "search" },
+    } as never);
+    expect(f.posts).toHaveLength(0);
+    expect(f.statuses.at(-1)?.status).toBe("is using `search`…");
+  });
+
+  it("clears the status once a reply is posted", async () => {
+    const f = makePaneClient();
+    const { subscriber: sub } = createRunRenderer({
+      client: f.client,
+      target: { channel: "D1", threadTs: "100.0" },
+      assistantStatus: {},
+    });
+    await sub.onRunStartedEvent!({} as never);
+    await sub.onTextMessageStartEvent!({
+      event: { messageId: "m", role: "assistant" },
+    } as never);
+    sub.onTextMessageContentEvent!({
+      event: { messageId: "m", delta: "hi" },
+      textMessageBuffer: "",
+    } as never);
+    await sub.onTextMessageEndEvent!({ event: { messageId: "m" } } as never);
+    expect(f.statuses.some((s) => s.status === "")).toBe(true);
+  });
+
+  it("clears the status on run finish when nothing was posted", async () => {
+    const f = makePaneClient();
+    const { subscriber: sub } = createRunRenderer({
+      client: f.client,
+      target: { channel: "D1", threadTs: "100.0" },
+      assistantStatus: { thinking: "t" },
+    });
+    await sub.onRunStartedEvent!({} as never);
+    await sub.onRunFinishedEvent!({} as never);
+    expect(f.statuses.at(-1)?.status).toBe("");
   });
 });

--- a/packages/bot-slack/src/__tests__/native-stream.test.ts
+++ b/packages/bot-slack/src/__tests__/native-stream.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi } from "vitest";
+import { NativeMessageStream } from "../native-stream.js";
+import type { NativeStreamTransport, TextStream } from "../native-stream.js";
+
+/**
+ * A fake `chat.startStream/appendStream/stopStream` transport that records the
+ * lifecycle of every streamed message in order, so tests can assert the
+ * concatenated deltas, the message splits, and the stop calls.
+ */
+function makeFakeTransport(opts?: {
+  failStart?: boolean;
+  failStartAfter?: number;
+}) {
+  const messages: { ts: string; appends: string[]; stopped: boolean }[] = [];
+  let counter = 0;
+  const transport: NativeStreamTransport = {
+    startStream: vi.fn(async () => {
+      if (opts?.failStart) throw new Error("startStream unavailable");
+      // Succeed for the first `failStartAfter` starts, then fail (simulates a
+      // continuation start failing after the first message already streamed).
+      if (
+        opts?.failStartAfter !== undefined &&
+        counter >= opts.failStartAfter
+      ) {
+        throw new Error("startStream unavailable (continuation)");
+      }
+      counter++;
+      const ts = `S${counter}`;
+      messages.push({ ts, appends: [], stopped: false });
+      return ts;
+    }),
+    appendStream: vi.fn(async (ts: string, md: string) => {
+      messages.find((m) => m.ts === ts)?.appends.push(md);
+    }),
+    stopStream: vi.fn(async (ts: string) => {
+      const m = messages.find((x) => x.ts === ts);
+      if (m) m.stopped = true;
+    }),
+  };
+  return { transport, messages };
+}
+
+/** A legacy fallback sink that just records the accumulated text it sees. */
+function makeFakeFallback(): TextStream & {
+  last: () => string;
+  finished: boolean;
+} {
+  let buf = "";
+  let finished = false;
+  return {
+    append(fullText: string) {
+      buf = fullText;
+    },
+    async finish() {
+      finished = true;
+    },
+    last: () => buf,
+    get finished() {
+      return finished;
+    },
+  };
+}
+
+describe("NativeMessageStream", () => {
+  it("starts one stream and appends only the deltas, in order", async () => {
+    const { transport, messages } = makeFakeTransport();
+    const stream = new NativeMessageStream({
+      transport,
+      fallback: makeFakeFallback,
+      minIntervalMs: 0,
+    });
+
+    stream.append("A");
+    stream.append("AL");
+    stream.append("ALPHA");
+    await stream.finish();
+
+    expect(transport.startStream).toHaveBeenCalledTimes(1);
+    expect(messages).toHaveLength(1);
+    // The concatenated deltas reconstruct the final buffer exactly.
+    expect(messages[0]!.appends.join("")).toBe("ALPHA");
+    expect(messages[0]!.stopped).toBe(true);
+    expect(stream.firstTs).toBe("S1");
+  });
+
+  it("never starts a stream when nothing is appended", async () => {
+    const { transport, messages } = makeFakeTransport();
+    const stream = new NativeMessageStream({
+      transport,
+      fallback: makeFakeFallback,
+      minIntervalMs: 0,
+    });
+    await stream.finish();
+    expect(transport.startStream).not.toHaveBeenCalled();
+    expect(messages).toHaveLength(0);
+  });
+
+  it("opens a continuation message when the budget is exceeded", async () => {
+    const { transport, messages } = makeFakeTransport();
+    const stream = new NativeMessageStream({
+      transport,
+      fallback: makeFakeFallback,
+      minIntervalMs: 0,
+      messageBudget: 10,
+    });
+
+    // 3 lines, each under the budget alone, but together over it.
+    const text = "line one\nline two\nline three";
+    stream.append(text);
+    await stream.finish();
+
+    // More than one streamed message, each finalized.
+    expect(messages.length).toBeGreaterThan(1);
+    expect(messages.every((m) => m.stopped)).toBe(true);
+    // The visible text (continuation openers are empty for plain text) equals
+    // the original — no content lost across the split.
+    expect(messages.map((m) => m.appends.join("")).join("")).toBe(text);
+  });
+
+  it("re-opens an unclosed code fence on the continuation message", async () => {
+    const { transport, messages } = makeFakeTransport();
+    const stream = new NativeMessageStream({
+      transport,
+      fallback: makeFakeFallback,
+      minIntervalMs: 0,
+      messageBudget: 16,
+    });
+
+    // A fence that opens before the split boundary and stays open across it.
+    const text = "```py\nprint(1)\nprint(2)\nprint(3)\n";
+    stream.append(text);
+    await stream.finish();
+
+    expect(messages.length).toBeGreaterThan(1);
+    // The continuation message must begin by re-opening the python fence so it
+    // renders as code rather than plain text.
+    expect(messages[1]!.appends[0]).toMatch(/^```py\n/);
+  });
+
+  it("falls back to the legacy transport when the first startStream fails", async () => {
+    const { transport } = makeFakeTransport({ failStart: true });
+    const fallback = makeFakeFallback();
+    const onStartFailure = vi.fn();
+    const stream = new NativeMessageStream({
+      transport,
+      fallback: () => fallback,
+      onStartFailure,
+      minIntervalMs: 0,
+    });
+
+    stream.append("hello");
+    stream.append("hello world");
+    await stream.finish();
+
+    expect(onStartFailure).toHaveBeenCalledTimes(1);
+    expect(transport.appendStream).not.toHaveBeenCalled();
+    // The accumulated buffer was replayed into the legacy transport.
+    expect(fallback.last()).toBe("hello world");
+    expect(fallback.finished).toBe(true);
+  });
+
+  it("fails over to legacy (no text lost) when a CONTINUATION startStream fails", async () => {
+    // First message streams natively; the second (continuation) startStream
+    // fails — the remainder must not be appended to the stopped first message
+    // and must reach the legacy fallback instead.
+    const { transport, messages } = makeFakeTransport({ failStartAfter: 1 });
+    const fallback = makeFakeFallback();
+    const onStartFailure = vi.fn();
+    const stream = new NativeMessageStream({
+      transport,
+      fallback: () => fallback,
+      onStartFailure,
+      minIntervalMs: 0,
+      messageBudget: 10,
+    });
+
+    const text = "line one\nline two\nline three"; // forces a continuation
+    stream.append(text);
+    await stream.finish();
+
+    expect(onStartFailure).toHaveBeenCalledTimes(1);
+    // Exactly one native message was opened (and finalized) before the failure.
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.stopped).toBe(true);
+    // The full response was replayed into the legacy transport — nothing lost.
+    expect(fallback.last()).toBe(text);
+    expect(fallback.finished).toBe(true);
+  });
+});

--- a/packages/bot-slack/src/__tests__/slack-listener.test.ts
+++ b/packages/bot-slack/src/__tests__/slack-listener.test.ts
@@ -68,6 +68,7 @@ function fakeStore(
 
 function setup(opts?: {
   ownedThreads?: Array<{ channelId: string; threadTs: string }>;
+  assistantThreads?: Array<{ channel: string; threadTs: string }>;
 }) {
   const store = fakeStore(
     (opts?.ownedThreads ?? []).map((t) => ({
@@ -84,12 +85,18 @@ function setup(opts?: {
     commands.push(cmd);
   });
   const fake = makeFakeApp();
+  const assistantKeys = new Set(
+    (opts?.assistantThreads ?? []).map((t) => `${t.channel}::${t.threadTs}`),
+  );
   attachSlackListener({
     app: fake.app,
     store,
     botUserId: BOT_USER_ID,
     onTurn,
     onCommand,
+    isAssistantThread: opts?.assistantThreads
+      ? (channel, threadTs) => assistantKeys.has(`${channel}::${threadTs}`)
+      : undefined,
   });
   return { ...fake, turns, onTurn, commands, onCommand, store };
 }
@@ -152,6 +159,62 @@ describe("slack-listener", () => {
       replyTarget: { channel: "D1" },
       userText: "hi bot",
     });
+    expect(f.turns[0]!.replyTarget.threadTs).toBeUndefined();
+  });
+
+  it("skips a pane message (assistant thread) — owned by the Assistant middleware", async () => {
+    const f = setup({
+      assistantThreads: [{ channel: "D1", threadTs: "100.0" }],
+    });
+    await f.fireMessage({
+      type: "message",
+      channel: "D1",
+      channel_type: "im",
+      user: "UATAI001",
+      ts: "300.0",
+      thread_ts: "100.0",
+      text: "in the pane",
+    });
+    // Exactly one turn per pane message is the Assistant middleware's job; the
+    // listener must NOT double-deliver it.
+    expect(f.turns).toHaveLength(0);
+  });
+
+  it("still flows an ordinary threaded DM that is NOT an assistant thread (per-thread gate)", async () => {
+    const f = setup({
+      assistantThreads: [{ channel: "D1", threadTs: "999.0" }],
+    });
+    await f.fireMessage({
+      type: "message",
+      channel: "D1",
+      channel_type: "im",
+      user: "UATAI001",
+      ts: "300.0",
+      thread_ts: "100.0", // a different thread — not the assistant one
+      text: "ordinary threaded dm",
+    });
+    // The guard is per-thread, never per-config: a non-assistant threaded DM
+    // is unaffected and flows as a flat DM (shipped behavior).
+    expect(f.turns).toHaveLength(1);
+    expect(f.turns[0]).toMatchObject({
+      conversation: { channelId: "D1", scope: DM_SCOPE },
+      replyTarget: { channel: "D1" },
+    });
+  });
+
+  it("leaves flat DMs untouched even when an assistant predicate is present", async () => {
+    const f = setup({
+      assistantThreads: [{ channel: "D1", threadTs: "100.0" }],
+    });
+    await f.fireMessage({
+      type: "message",
+      channel: "D1",
+      channel_type: "im",
+      user: "UATAI001",
+      ts: "300.0",
+      text: "flat dm, no thread", // no thread_ts → not a pane message
+    });
+    expect(f.turns).toHaveLength(1);
     expect(f.turns[0]!.replyTarget.threadTs).toBeUndefined();
   });
 

--- a/packages/bot-slack/src/adapter.test.ts
+++ b/packages/bot-slack/src/adapter.test.ts
@@ -410,11 +410,13 @@ describe("SlackAdapter action wiring", () => {
       ...(adapter as unknown as { client: object }).client,
       auth: { test: vi.fn(async () => ({ user_id: "UBOT" })) },
     } as never;
-    // attachSlackListener calls app.command/event/message — stub them.
+    // attachSlackListener calls app.command/event/message and (default-on)
+    // attachAssistant calls app.assistant — stub them.
     Object.assign(app, {
       command: vi.fn(),
       event: vi.fn(),
       message: vi.fn(),
+      assistant: vi.fn(),
     });
 
     const received: InteractionEvent[] = [];
@@ -424,6 +426,7 @@ describe("SlackAdapter action wiring", () => {
         received.push(evt);
       },
       onCommand: vi.fn(),
+      onThreadStarted: vi.fn(),
     };
     await adapter.start(sink);
 

--- a/packages/bot-slack/src/adapter.ts
+++ b/packages/bot-slack/src/adapter.ts
@@ -21,9 +21,18 @@ import { createRunRenderer } from "./event-renderer.js";
 import { decodeInteraction, conversationKeyOf } from "./interaction.js";
 import { renderBlockKit, renderSlackMessage } from "./render/block-kit.js";
 import { ChunkedMessageStream } from "./chunked-message-stream.js";
+import { NativeMessageStream } from "./native-stream.js";
+import type { TextStream, NativeStreamTransport } from "./native-stream.js";
+import { attachAssistant } from "./assistant.js";
+import type { AssistantHandle } from "./assistant.js";
 import { autoCloseOpenMarkdown } from "./auto-close-streaming.js";
 import { markdownToMrkdwn } from "./markdown-to-mrkdwn.js";
-import { DM_SCOPE, type ConversationKey, type ReplyTarget } from "./types.js";
+import { DM_SCOPE } from "./types.js";
+import type {
+  ConversationKey,
+  ReplyTarget,
+  SlackAssistantOptions,
+} from "./types.js";
 
 export interface SlackAdapterOptions {
   /** Slack bot token (xoxb-…). */
@@ -42,18 +51,26 @@ export interface SlackAdapterOptions {
   interruptEventNames?: ReadonlySet<string>;
   /** Surface `:wrench:`/`:white_check_mark:` tool-status rows. Default true. */
   showToolStatus?: boolean;
+  /**
+   * Assistant-pane behavior ("Agents & AI Apps"). ON by default — the pane
+   * activates whenever the app's Slack config has the toggle (see the README),
+   * and lies dormant without it. Pass an object to customize, or `false` to
+   * disable pane handling entirely.
+   */
+  assistant?: SlackAssistantOptions | false;
+  /**
+   * Reply-stream transport. "native" (default): `chat.startStream` wherever the
+   * reply target is a thread; flat DMs and workspaces where the streaming API
+   * is unavailable fall back to legacy automatically. "legacy": the shipped
+   * `chat.update` transport.
+   */
+  streaming?: "native" | "legacy";
 }
 
 /** Slack `PlatformAdapter`: ingress via Bolt, egress via Block Kit + streaming. */
 export class SlackAdapter implements PlatformAdapter {
   readonly platform = "slack";
-  readonly capabilities: SurfaceCapabilities = {
-    supportsModals: false,
-    supportsTyping: false,
-    supportsReactions: false,
-    supportsStreaming: true,
-    maxBlocksPerMessage: 50,
-  };
+  readonly capabilities: SurfaceCapabilities;
   readonly ackDeadlineMs = 3000;
 
   readonly app: App;
@@ -63,8 +80,28 @@ export class SlackAdapter implements PlatformAdapter {
   private sink: IngressSink | undefined;
   /** Per-id cache for sender-profile resolution (repeat turns are cheap). */
   private readonly userCache = new Map<string, PlatformUser>();
+  /** Set once the Assistant middleware is attached (when assistant !== false). */
+  private assistantHandle: AssistantHandle | undefined;
+  /** Our team id (from auth.test); native channel streams need it. */
+  private teamId: string | undefined;
+  /**
+   * In-memory native-streaming health for this workspace. Flipped to false the
+   * first time `chat.startStream` fails, so subsequent streams skip the native
+   * path and go straight to the legacy transport.
+   */
+  private nativeStreamingOk = true;
 
   constructor(private readonly opts: SlackAdapterOptions) {
+    const assistantEnabled = opts.assistant !== false;
+    this.capabilities = {
+      supportsModals: false,
+      supportsTyping: false,
+      supportsReactions: false,
+      supportsStreaming: true,
+      maxBlocksPerMessage: 50,
+      supportsSuggestedPrompts: assistantEnabled,
+      supportsThreadTitle: assistantEnabled,
+    };
     this.app = new App({
       token: opts.botToken,
       appToken: opts.appToken,
@@ -96,16 +133,35 @@ export class SlackAdapter implements PlatformAdapter {
     // guard (skip our own posts) is in place from the first event.
     const auth = await this.client.auth.test();
     this.botUserId = auth.user_id as string;
+    this.teamId = auth.team_id as string | undefined;
     (this.store as unknown as { botUserId: string }).botUserId = this.botUserId;
+
+    // Attach the assistant-pane middleware FIRST (when enabled) so its
+    // `isAssistantThread` predicate is available to the message listener's
+    // no-double-delivery guard below.
+    if (this.opts.assistant !== false) {
+      this.assistantHandle = attachAssistant({
+        app: this.app,
+        sink,
+        opts: this.opts.assistant ?? {},
+        resolveUser: (id) => this.resolveUser(id),
+      });
+    }
 
     attachSlackListener({
       app: this.app,
       store: this.store,
       botUserId: this.botUserId,
+      isAssistantThread: this.assistantHandle?.isAssistantThread,
       onTurn: async (turn) => {
         await sink.onTurn({
           conversationKey: conversationKeyOf(turn.conversation),
-          replyTarget: turn.replyTarget,
+          // Carry the sender id so native channel streams can pass
+          // `recipient_user_id` to chat.startStream.
+          replyTarget: {
+            ...turn.replyTarget,
+            recipientUserId: turn.senderUserId,
+          },
           userText: turn.userText,
           user: turn.senderUserId
             ? await this.resolveUser(turn.senderUserId)
@@ -211,49 +267,208 @@ export class SlackAdapter implements PlatformAdapter {
     const t = target as ReplyTarget;
     let firstTs: string | undefined;
     let channel = t.channel;
-    const stream = new ChunkedMessageStream({
-      postPlaceholder: async (text) => {
-        const posted = await this.client.chat.postMessage({
-          channel: t.channel,
-          thread_ts: t.threadTs,
-          text,
-          unfurl_links: false,
-          unfurl_media: false,
-        });
-        if (!posted.ts) throw new Error("postMessage returned no ts");
-        if (!firstTs) {
-          firstTs = posted.ts;
-          channel = posted.channel ?? t.channel;
-        }
-        return posted.ts;
-      },
-      updateAt: async (ts, text) => {
-        await this.client.chat.update({ channel: t.channel, ts, text });
-      },
-      transform: (s) => markdownToMrkdwn(autoCloseOpenMarkdown(s)),
-    });
+
+    // The shipped chat.update streamer — also the automatic fallback for native.
+    const makeLegacy = (): TextStream =>
+      new ChunkedMessageStream({
+        postPlaceholder: async (text) => {
+          const posted = await this.client.chat.postMessage({
+            channel: t.channel,
+            thread_ts: t.threadTs,
+            text,
+            unfurl_links: false,
+            unfurl_media: false,
+          });
+          if (!posted.ts) throw new Error("postMessage returned no ts");
+          if (!firstTs) {
+            firstTs = posted.ts;
+            channel = posted.channel ?? t.channel;
+          }
+          return posted.ts;
+        },
+        updateAt: async (ts, text) => {
+          await this.client.chat.update({ channel: t.channel, ts, text });
+        },
+        transform: (s) => markdownToMrkdwn(autoCloseOpenMarkdown(s)),
+      });
+
+    // Native streaming only where a thread exists (Slack requires streams to be
+    // thread replies); flat DMs always use the legacy streamer.
+    const useNative =
+      this.opts.streaming !== "legacy" &&
+      !!t.threadTs &&
+      this.nativeStreamingOk;
+
+    let sink: TextStream;
+    if (useNative) {
+      sink = new NativeMessageStream({
+        transport: this.nativeTransport(t, (ts, ch) => {
+          if (!firstTs) {
+            firstTs = ts;
+            channel = ch ?? t.channel;
+          }
+        }),
+        fallback: makeLegacy,
+        onStartFailure: () => {
+          this.nativeStreamingOk = false;
+        },
+      });
+    } else {
+      sink = makeLegacy();
+    }
 
     let acc = "";
     for await (const chunk of chunks) {
       acc += chunk;
-      stream.append(acc);
+      sink.append(acc);
     }
-    await stream.finish();
+    await sink.finish();
 
     return { id: firstTs ?? "", channel, ts: firstTs };
+  }
+
+  /**
+   * Build the {@link NativeStreamTransport} (chat.startStream/appendStream/
+   * stopStream) for a thread target. `onFirstTs` records the first streamed
+   * message's ts/channel for the returned MessageRef. Native channel streams
+   * pass `recipient_user_id` (the turn sender) + `recipient_team_id`.
+   */
+  private nativeTransport(
+    t: ReplyTarget,
+    onFirstTs: (ts: string, channel?: string) => void,
+  ): NativeStreamTransport {
+    return {
+      startStream: async () => {
+        const args: Record<string, unknown> = {
+          channel: t.channel,
+          thread_ts: t.threadTs,
+        };
+        if (t.recipientUserId) args.recipient_user_id = t.recipientUserId;
+        if (this.teamId) args.recipient_team_id = this.teamId;
+        const res = (await this.client.chat.startStream(
+          args as unknown as Parameters<WebClient["chat"]["startStream"]>[0],
+        )) as { ts?: string; channel?: string };
+        if (!res.ts) throw new Error("startStream returned no ts");
+        onFirstTs(res.ts, res.channel);
+        return res.ts;
+      },
+      appendStream: async (ts, markdownText) => {
+        await this.client.chat.appendStream({
+          channel: t.channel,
+          ts,
+          markdown_text: markdownText,
+        } as unknown as Parameters<WebClient["chat"]["appendStream"]>[0]);
+      },
+      stopStream: async (ts) => {
+        await this.client.chat.stopStream({
+          channel: t.channel,
+          ts,
+        } as unknown as Parameters<WebClient["chat"]["stopStream"]>[0]);
+      },
+    };
   }
 
   async delete(ref: MessageRef): Promise<void> {
     await this.client.chat.delete({ channel: channelOf(ref), ts: ref.id });
   }
 
+  /**
+   * True if `target` is a known assistant-pane thread (recorded by the
+   * Assistant middleware). Pane targets drive native status and back the
+   * pane-only `setSuggestedPrompts` / `setThreadTitle` methods.
+   */
+  private isPaneTarget(
+    t: ReplyTarget,
+  ): t is ReplyTarget & { threadTs: string } {
+    return Boolean(
+      t.threadTs &&
+      this.assistantHandle?.isAssistantThread(t.channel, t.threadTs),
+    );
+  }
+
   createRunRenderer(target: BotReplyTarget): RunRenderer {
+    const t = target as ReplyTarget;
+    const assistantOpts: SlackAssistantOptions | undefined =
+      this.opts.assistant === false ? undefined : (this.opts.assistant ?? {});
+    // Pane targets drive native status (setStatus) instead of placeholder +
+    // :wrench: rows.
+    const isPane = this.isPaneTarget(t);
+    // Native streaming wherever a thread exists (and the workspace supports it).
+    const useNative =
+      this.opts.streaming !== "legacy" &&
+      !!t.threadTs &&
+      this.nativeStreamingOk;
     return createRunRenderer({
       client: this.client,
-      target: target as ReplyTarget,
+      target: t,
       interruptEventNames: this.opts.interruptEventNames,
       showToolStatus: this.opts.showToolStatus,
+      assistantStatus: isPane ? (assistantOpts?.status ?? {}) : undefined,
+      nativeStreaming: useNative
+        ? {
+            transport: this.nativeTransport(t, () => {}),
+            onStartFailure: () => {
+              this.nativeStreamingOk = false;
+            },
+          }
+        : undefined,
     });
+  }
+
+  /** Backs the capability-gated `Thread.setSuggestedPrompts` for pane threads. */
+  async setSuggestedPrompts(
+    target: BotReplyTarget,
+    prompts: ReadonlyArray<{ title: string; message: string }>,
+    opts?: { title?: string },
+  ): Promise<{ ok: boolean; error?: string }> {
+    const t = target as ReplyTarget;
+    if (!this.isPaneTarget(t)) {
+      return {
+        ok: false,
+        error: "suggested prompts require an assistant-pane thread",
+      };
+    }
+    try {
+      await this.client.assistant.threads.setSuggestedPrompts({
+        channel_id: t.channel,
+        thread_ts: t.threadTs,
+        prompts: prompts.map((p) => ({
+          title: p.title,
+          message: p.message,
+        })) as [
+          { title: string; message: string },
+          ...{ title: string; message: string }[],
+        ],
+        ...(opts?.title ? { title: opts.title } : {}),
+      });
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: (e as Error).message };
+    }
+  }
+
+  /** Backs the capability-gated `Thread.setTitle` for pane threads. */
+  async setThreadTitle(
+    target: BotReplyTarget,
+    title: string,
+  ): Promise<{ ok: boolean; error?: string }> {
+    const t = target as ReplyTarget;
+    if (!this.isPaneTarget(t)) {
+      return {
+        ok: false,
+        error: "thread title requires an assistant-pane thread",
+      };
+    }
+    try {
+      await this.client.assistant.threads.setTitle({
+        channel_id: t.channel,
+        thread_ts: t.threadTs,
+        title,
+      });
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: (e as Error).message };
+    }
   }
 
   decodeInteraction(raw: unknown): InteractionEvent | undefined {

--- a/packages/bot-slack/src/assistant.ts
+++ b/packages/bot-slack/src/assistant.ts
@@ -1,0 +1,167 @@
+/**
+ * Slack assistant-pane wiring — the SOLE owner of pane (`assistant_thread_*`)
+ * events. Bridges Bolt's `Assistant` middleware to the engine `IngressSink`.
+ *
+ * Flow:
+ *   - `assistant_thread_started` → apply the adapter's STATIC defaults first
+ *     (greeting + suggested prompts), then emit `sink.onThreadStarted` so
+ *     `bot.onThreadStarted` handlers layer on top (never race the defaults).
+ *     Records the pane thread so the message listener's guard can skip it.
+ *   - a user message in the pane → exactly ONE `sink.onTurn`, scoped to the
+ *     pane thread's `ts` (`channelId::threadTs`, NOT the flat DM scope), with a
+ *     threaded reply target carrying `recipientUserId` (native streaming needs
+ *     it). First message + `title: "auto"` → `assistant.threads.setTitle`.
+ *   - `assistant_thread_context_changed` → persisted via Bolt's default
+ *     thread-context store (stored for a later release; not yet fed to the agent).
+ *
+ * Pane messages arrive as threaded `message.im` events, which the ordinary
+ * `app.message` listener also sees; `attachSlackListener` is given the
+ * `isAssistantThread` predicate returned here so each pane message becomes
+ * exactly one turn (see slack-listener.ts).
+ */
+import { Assistant } from "@slack/bolt";
+import type { App } from "@slack/bolt";
+import type { IngressSink, PlatformUser } from "@copilotkit/bot";
+import { conversationKeyOf } from "./interaction.js";
+import type { SlackAssistantOptions } from "./types.js";
+
+export interface AttachAssistantConfig {
+  app: App;
+  /** The engine sink — pane events are delivered straight to it. */
+  sink: IngressSink;
+  /** Static pane behavior (greeting / prompts / title). */
+  opts: SlackAssistantOptions;
+  /** Resolve a Slack user id to a richer PlatformUser (adapter-owned, cached). */
+  resolveUser: (userId: string) => Promise<PlatformUser>;
+}
+
+export interface AssistantHandle {
+  /** True if `(channel, threadTs)` is a known assistant-pane thread. */
+  isAssistantThread: (channel: string, threadTs: string) => boolean;
+}
+
+/** Register the Bolt `Assistant` middleware and bridge it to the engine sink. */
+export function attachAssistant(cfg: AttachAssistantConfig): AssistantHandle {
+  const { app, sink, opts, resolveUser } = cfg;
+
+  // Pane threads seen this process (channelId::threadTs). Populated on
+  // thread_started and (defensively, after a restart) on the first message.
+  const assistantThreads = new Set<string>();
+  // Threads we've already auto-titled, so only the FIRST user message titles.
+  const titled = new Set<string>();
+
+  const titleAuto = opts.title !== false; // default "auto"
+
+  const assistant = new Assistant({
+    threadStarted: async ({ event, say, setSuggestedPrompts }) => {
+      const at = (event as { assistant_thread?: AssistantThreadMeta })
+        .assistant_thread;
+      if (!at?.channel_id || !at.thread_ts) return;
+      const channelId = at.channel_id;
+      const threadTs = at.thread_ts;
+      assistantThreads.add(threadKey(channelId, threadTs));
+
+      // ── Static defaults first (greeting + prompts). Degrade, never throw. ──
+      if (opts.greeting) {
+        try {
+          await say(opts.greeting);
+        } catch (err) {
+          console.error("[slack-assistant] greeting failed:", err);
+        }
+      }
+      if (opts.suggestedPrompts && opts.suggestedPrompts.length > 0) {
+        try {
+          await setSuggestedPrompts({
+            prompts: opts.suggestedPrompts.map((p) => ({
+              title: p.title,
+              message: p.message,
+            })) as [
+              { title: string; message: string },
+              ...{ title: string; message: string }[],
+            ],
+          });
+        } catch (err) {
+          console.error("[slack-assistant] setSuggestedPrompts failed:", err);
+        }
+      }
+
+      // ── Then hand off to the engine (onThreadStarted handlers layer on top). ──
+      const user = at.user_id ? await resolveUser(at.user_id) : undefined;
+      await sink.onThreadStarted({
+        conversationKey: conversationKeyOf({ channelId, scope: threadTs }),
+        replyTarget: {
+          channel: channelId,
+          threadTs,
+          recipientUserId: at.user_id,
+        },
+        user,
+        platform: "slack",
+      });
+    },
+
+    userMessage: async ({ message, setTitle }) => {
+      const m = message as {
+        channel?: string;
+        thread_ts?: string;
+        text?: string;
+        user?: string;
+      };
+      // Pane messages are always threaded; ignore anything without a thread.
+      if (!m.channel || !m.thread_ts) return;
+      const channelId = m.channel;
+      const threadTs = m.thread_ts;
+      const key = conversationKeyOf({ channelId, scope: threadTs });
+      assistantThreads.add(threadKey(channelId, threadTs)); // defensive (post-restart)
+
+      const text = (m.text ?? "").trim();
+
+      // Auto-title from the first user message.
+      if (titleAuto && !titled.has(key)) {
+        titled.add(key);
+        const title = text.replace(/\s+/g, " ").slice(0, 80);
+        if (title) {
+          try {
+            await setTitle(title);
+          } catch (err) {
+            console.error("[slack-assistant] setTitle failed:", err);
+          }
+        }
+      }
+
+      await sink.onTurn({
+        conversationKey: key,
+        replyTarget: { channel: channelId, threadTs, recipientUserId: m.user },
+        userText: text,
+        user: m.user ? await resolveUser(m.user) : undefined,
+        platform: "slack",
+      });
+    },
+
+    threadContextChanged: async ({ saveThreadContext }) => {
+      // Persist via Bolt's default thread-context store. Stored for a later
+      // release; not yet consumed by the agent.
+      try {
+        await saveThreadContext();
+      } catch (err) {
+        console.error("[slack-assistant] saveThreadContext failed:", err);
+      }
+    },
+  });
+
+  app.assistant(assistant);
+
+  return {
+    isAssistantThread: (channel, threadTs) =>
+      assistantThreads.has(threadKey(channel, threadTs)),
+  };
+}
+
+interface AssistantThreadMeta {
+  user_id?: string;
+  channel_id?: string;
+  thread_ts?: string;
+  context?: Record<string, unknown>;
+}
+
+const threadKey = (channel: string, threadTs: string): string =>
+  `${channel}::${threadTs}`;

--- a/packages/bot-slack/src/event-renderer.ts
+++ b/packages/bot-slack/src/event-renderer.ts
@@ -8,6 +8,11 @@ import type {
 import { ChunkedMessageStream } from "./chunked-message-stream.js";
 import { markdownToMrkdwn } from "./markdown-to-mrkdwn.js";
 import { autoCloseOpenMarkdown } from "./auto-close-streaming.js";
+import { NativeMessageStream } from "./native-stream.js";
+import type { TextStream, NativeStreamTransport } from "./native-stream.js";
+import type { SlackAssistantOptions } from "./types.js";
+
+const DEFAULT_THINKING_STATUS = "is thinking…";
 
 /**
  * The display-transform applied to every streaming chunk before it hits
@@ -56,16 +61,66 @@ export function createRunRenderer(args: {
    * can't post two rows for the same logical call.
    */
   showToolStatus?: boolean;
+  /**
+   * Present only for assistant-pane targets. Drives Slack's native
+   * `assistant.threads.setStatus` ("is thinking…", "is using `tool`…")
+   * instead of posting a placeholder message and `:wrench:` rows.
+   */
+  assistantStatus?: SlackAssistantOptions["status"];
+  /**
+   * When set, agent text replies stream via `chat.startStream` (native) using
+   * this transport instead of `chat.update`. Falls back to the legacy
+   * transport automatically if `startStream` fails.
+   */
+  nativeStreaming?: {
+    transport: NativeStreamTransport;
+    onStartFailure?: (err: unknown) => void;
+  };
 }): RunRenderer {
   const { client, target } = args;
   const interruptEventNames =
     args.interruptEventNames ?? new Set<string>(["on_interrupt"]);
   const showToolStatus = args.showToolStatus ?? true;
 
+  // ── Assistant-pane status mode ──────────────────────────────────────
+  // In a pane thread the run lifecycle drives native status under the
+  // composer instead of placeholder/`:wrench:` messages.
+  const paneStatus = args.assistantStatus;
+  const paneMode = paneStatus !== undefined && target.threadTs !== undefined;
+  const paneToolStatus = paneStatus?.toolStatus ?? true;
+
+  const setPaneStatus = async (status: string): Promise<void> => {
+    if (!paneMode || !target.threadTs) return;
+    try {
+      await client.assistant.threads.setStatus({
+        channel_id: target.channel,
+        thread_ts: target.threadTs,
+        status,
+        ...(status && paneStatus?.loadingMessages
+          ? { loading_messages: [...paneStatus.loadingMessages] }
+          : {}),
+      });
+    } catch (err) {
+      console.error("[slack-renderer] setStatus failed:", err);
+    }
+  };
+  /** Clear the composer status (best-effort). */
+  const clearPaneStatus = async (): Promise<void> => {
+    if (!paneMode) return;
+    await setPaneStatus("");
+  };
+  /** Whether this run has posted any visible reply yet (drives status clear). */
+  let postedReply = false;
+  const onFirstReply = async (): Promise<void> => {
+    if (postedReply) return;
+    postedReply = true;
+    await clearPaneStatus();
+  };
+
   /** Per-AG-UI-message accumulated text (we accumulate deltas locally). */
   const buffers = new Map<string, string>();
-  /** Per-AG-UI-message ChunkedMessageStream. Lazily created on first content. */
-  const streams = new Map<string, ChunkedMessageStream>();
+  /** Per-AG-UI-message text stream (native or legacy). Lazily created on first content. */
+  const streams = new Map<string, TextStream>();
   /** Per-tool-call Slack message ts so we can edit it on END. */
   const toolStatusTs = new Map<string, string>();
   /**
@@ -169,38 +224,63 @@ export function createRunRenderer(args: {
     }
   };
 
-  const ensureStream = (
-    messageId: string,
-  ): ChunkedMessageStream | undefined => {
+  // The shipped chat.update streamer (mrkdwn-translated). Also the automatic
+  // fallback for the native transport. Reuses the standing "thinking…" message
+  // when one exists so the dots morph straight into the reply.
+  const makeLegacyStream = (): TextStream =>
+    new ChunkedMessageStream({
+      postPlaceholder: async (text) => {
+        const claimed = claimThinking();
+        if (claimed) {
+          await client.chat.update({
+            channel: target.channel,
+            ts: claimed,
+            text,
+          });
+          await onFirstReply();
+          return claimed;
+        }
+        const posted = await client.chat.postMessage({
+          channel: target.channel,
+          thread_ts: target.threadTs,
+          text,
+        });
+        if (!posted.ts) throw new Error("postMessage returned no ts");
+        await onFirstReply();
+        return posted.ts;
+      },
+      updateAt: async (ts, text) => {
+        await client.chat.update({ channel: target.channel, ts, text });
+      },
+      transform: displayTransform,
+    });
+
+  // Native chat.startStream transport — raw markdown, no mrkdwn translation.
+  const makeNativeStream = (): TextStream => {
+    const ns = args.nativeStreaming!;
+    return new NativeMessageStream({
+      transport: {
+        startStream: async () => {
+          const ts = await ns.transport.startStream();
+          // The native message owns the bubble now; drop the placeholder and
+          // clear any pane status (the reply is visible).
+          await clearThinking();
+          await onFirstReply();
+          return ts;
+        },
+        appendStream: (ts, md) => ns.transport.appendStream(ts, md),
+        stopStream: (ts) => ns.transport.stopStream(ts),
+      },
+      fallback: makeLegacyStream,
+      onStartFailure: ns.onStartFailure,
+    });
+  };
+
+  const ensureStream = (messageId: string): TextStream | undefined => {
     if (finalised.has(messageId)) return undefined;
     let s = streams.get(messageId);
     if (!s) {
-      s = new ChunkedMessageStream({
-        postPlaceholder: async (text) => {
-          // Reuse the "thinking…" message if one is standing — the dots
-          // morph straight into the streamed reply (no extra message).
-          const claimed = claimThinking();
-          if (claimed) {
-            await client.chat.update({
-              channel: target.channel,
-              ts: claimed,
-              text,
-            });
-            return claimed;
-          }
-          const posted = await client.chat.postMessage({
-            channel: target.channel,
-            thread_ts: target.threadTs,
-            text,
-          });
-          if (!posted.ts) throw new Error("postMessage returned no ts");
-          return posted.ts;
-        },
-        updateAt: async (ts, text) => {
-          await client.chat.update({ channel: target.channel, ts, text });
-        },
-        transform: displayTransform,
-      });
+      s = args.nativeStreaming ? makeNativeStream() : makeLegacyStream();
       streams.set(messageId, s);
     }
     return s;
@@ -224,13 +304,21 @@ export function createRunRenderer(args: {
     // ── 0. Run lifecycle: thinking indicator ───────────────────────────
     async onRunStartedEvent() {
       if (aborted) return;
-      await startThinking();
+      if (paneMode) {
+        // Native status under the composer instead of a placeholder message.
+        await setPaneStatus(paneStatus?.thinking || DEFAULT_THINKING_STATUS);
+      } else {
+        await startThinking();
+      }
     },
     async onRunFinishedEvent() {
       // If the run produced a streamed reply it already claimed the
       // placeholder; otherwise (tool/component/HITL output, or nothing)
       // this removes the leftover "thinking…" bubble.
       await clearThinking();
+      // In a pane thread, a posted reply auto-clears Slack's status; clear it
+      // explicitly when the run produced no visible reply.
+      if (paneMode && !postedReply) await clearPaneStatus();
     },
 
     // ── 1. Text streaming ──────────────────────────────────────────────
@@ -260,6 +348,14 @@ export function createRunRenderer(args: {
     // ── 2. Tool-call surfacing + capture ──────────────────────────────
     async onToolCallStartEvent({ event }) {
       if (aborted) return;
+      // Pane threads surface tool activity as live composer status, not rows.
+      // Each setStatus also resets Slack's status timeout.
+      if (paneMode) {
+        if (paneToolStatus) {
+          await setPaneStatus(`is using \`${event.toolCallName}\`…`);
+        }
+        return;
+      }
       // Dedup by toolCallId so a tool that re-emits START on resume can't
       // post a second status row.
       if (!showToolStatus) return;
@@ -298,6 +394,8 @@ export function createRunRenderer(args: {
         toolCallName,
         (toolCallArgs ?? {}) as Record<string, unknown>,
       );
+      // Pane threads use live status (set on START); no per-call rows to edit.
+      if (paneMode) return;
       if (!showToolStatus) return;
       const ts = toolStatusTs.get(event.toolCallId);
       if (!ts) return;
@@ -339,6 +437,7 @@ export function createRunRenderer(args: {
       // `_(interrupted)_` marker on the partial reply is the user-visible
       // signal in that case.
       await clearThinking();
+      if (paneMode) await clearPaneStatus();
       if (aborted) return;
       try {
         await client.chat.postMessage({
@@ -368,6 +467,7 @@ export function createRunRenderer(args: {
       // Drop any standing "thinking…" bubble; the interrupted marker (or
       // the next turn) is the user-visible signal now.
       await clearThinking();
+      if (paneMode) await clearPaneStatus();
       // For each in-flight text-message stream, append the interrupted
       // marker and drain. Streams that have no content yet are silently
       // dropped (the bot never posted anything for them).

--- a/packages/bot-slack/src/index.ts
+++ b/packages/bot-slack/src/index.ts
@@ -1,7 +1,12 @@
 export { SlackConversationStore } from "./conversation-store.js";
 export type { AgentSession } from "./conversation-store.js";
 
-export type { ConversationKey, IncomingTurn, ReplyTarget } from "./types.js";
+export type {
+  ConversationKey,
+  IncomingTurn,
+  ReplyTarget,
+  SlackAssistantOptions,
+} from "./types.js";
 export { DM_SCOPE } from "./types.js";
 
 export { MessageStream } from "./message-stream.js";
@@ -9,6 +14,16 @@ export type { MessageStreamConfig } from "./message-stream.js";
 
 export { ChunkedMessageStream } from "./chunked-message-stream.js";
 export type { ChunkedMessageStreamConfig } from "./chunked-message-stream.js";
+
+export { NativeMessageStream } from "./native-stream.js";
+export type {
+  NativeMessageStreamConfig,
+  NativeStreamTransport,
+  TextStream,
+} from "./native-stream.js";
+
+export { attachAssistant } from "./assistant.js";
+export type { AttachAssistantConfig, AssistantHandle } from "./assistant.js";
 
 export {
   autoCloseOpenMarkdown,

--- a/packages/bot-slack/src/native-stream.ts
+++ b/packages/bot-slack/src/native-stream.ts
@@ -1,0 +1,305 @@
+/**
+ * Native Slack streaming transport (`chat.startStream` / `appendStream` /
+ * `stopStream`, GA Oct 2025) behind the SAME `append(fullText)/finish()`
+ * contract as the shipped {@link MessageStream} — callers (the event-renderer's
+ * per-message stream, `adapter.stream()`) can't tell which transport ran.
+ *
+ * Differences from the legacy `chat.update` streamer:
+ *
+ *   - Slack renders a true streaming UI, and the payload is **raw markdown**
+ *     (`markdown_text`), so real tables / fenced code render natively — there
+ *     is NO mrkdwn translation and NO bracket auto-closing (Slack's streaming
+ *     renderer tolerates a mid-stream-unbalanced buffer).
+ *   - `appendStream` takes the *delta* since the last flush, not the full
+ *     accumulated text, so this class tracks how much it has already sent.
+ *   - A streamed message caps at ~12k characters of markdown; past that we
+ *     `stopStream` the current message and `startStream` a continuation,
+ *     prepending the open-markdown context (fence / bold / …) so the
+ *     continuation stands on its own — the same idea as
+ *     {@link ChunkedMessageStream}, reusing `detectOpenContext` /
+ *     `renderContextOpener`.
+ *
+ * Failure handling — "opting in can never break a bot": if the very first
+ * `startStream` throws (e.g. a workspace where the streaming API is
+ * unavailable), the stream transparently rebuilds itself on the supplied
+ * legacy `fallback()` transport and replays the buffer there. `onStartFailure`
+ * lets the adapter mark the workspace legacy so subsequent streams skip the
+ * native path entirely. Per-`appendStream` failures mid-stream are swallowed
+ * (logged) like the legacy streamer's failed edits.
+ *
+ * Nothing here imports `@slack/web-api` — the Slack calls are injected as a
+ * {@link NativeStreamTransport}, keeping the cadence/continuation logic
+ * unit-testable with fake timers and a fake transport.
+ */
+import {
+  detectOpenContext,
+  renderContextOpener,
+} from "./auto-close-streaming.js";
+
+/** A minimal `{ append(fullText), finish() }` streaming sink. */
+export interface TextStream {
+  /** Replace the in-flight buffer with the accumulated text. */
+  append(fullText: string): void;
+  /** Flush the final state and close the stream. */
+  finish(): Promise<void>;
+}
+
+/** The three Slack streaming calls, injected so this file stays SDK-free. */
+export interface NativeStreamTransport {
+  /** `chat.startStream` → resolves with the new streamed message's `ts`. Throws on failure. */
+  startStream(): Promise<string>;
+  /** `chat.appendStream` — append a markdown delta to the message at `ts`. */
+  appendStream(ts: string, markdownText: string): Promise<void>;
+  /** `chat.stopStream` — finalize the streamed message at `ts`. */
+  stopStream(ts: string): Promise<void>;
+}
+
+export interface NativeMessageStreamConfig {
+  transport: NativeStreamTransport;
+  /**
+   * Builds the legacy `chat.update` transport, used only if the first
+   * `startStream` throws. The accumulated buffer is replayed into it so no
+   * text is lost.
+   */
+  fallback: () => TextStream;
+  /** Called once when the first `startStream` fails (adapter marks the workspace legacy). */
+  onStartFailure?: (err: unknown) => void;
+  /** Minimum gap between flushes, in ms (defaults to 800, matching MessageStream). */
+  minIntervalMs?: number;
+  /** Soft per-message markdown budget; past it we start a continuation message. Default 12000. */
+  messageBudget?: number;
+}
+
+const DEFAULT_MIN_INTERVAL_MS = 800;
+/** Slack caps `markdown_text` (per message and per append) at ~12k chars. */
+const DEFAULT_MESSAGE_BUDGET = 12000;
+
+export class NativeMessageStream implements TextStream {
+  private buffer = "";
+  private queue: Promise<void> = Promise.resolve();
+  private lastFlushedAt = 0;
+  private flushTimer: ReturnType<typeof setTimeout> | undefined;
+  private finished = false;
+
+  /** Current streamed message ts (undefined until the first `startStream`). */
+  private curTs: string | undefined;
+  /** Buffer index where the current message's content begins. */
+  private curStart = 0;
+  /** Buffer chars already appended to the current message (excludes the opener prefix). */
+  private curPosted = 0;
+  /** Display length of the open-context opener prepended to a continuation message. */
+  private curOpenerLen = 0;
+  /** ts of the first streamed message (for the returned MessageRef). */
+  private firstTsValue: string | undefined;
+
+  /** Set once `startStream` has failed and we've fallen back to the legacy transport. */
+  private legacy: TextStream | undefined;
+
+  private readonly transport: NativeStreamTransport;
+  private readonly makeFallback: () => TextStream;
+  private readonly onStartFailure: ((err: unknown) => void) | undefined;
+  private readonly minIntervalMs: number;
+  private readonly messageBudget: number;
+
+  constructor(config: NativeMessageStreamConfig) {
+    this.transport = config.transport;
+    this.makeFallback = config.fallback;
+    this.onStartFailure = config.onStartFailure;
+    this.minIntervalMs = config.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS;
+    this.messageBudget = config.messageBudget ?? DEFAULT_MESSAGE_BUDGET;
+  }
+
+  /** The first streamed message's ts (or the fallback's), available after finish(). */
+  get firstTs(): string | undefined {
+    return this.firstTsValue;
+  }
+
+  append(fullText: string): void {
+    if (this.legacy) {
+      this.legacy.append(fullText);
+      return;
+    }
+    if (fullText === this.buffer) return;
+    this.buffer = fullText;
+    this.scheduleFlush();
+  }
+
+  async finish(): Promise<void> {
+    this.finished = true;
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = undefined;
+    }
+    this.enqueueFlush();
+    await this.queue;
+    if (this.legacy) {
+      await this.legacy.finish();
+      return;
+    }
+    // Finalize the streamed message (no-op if we never started one).
+    if (this.curTs) {
+      try {
+        await this.transport.stopStream(this.curTs);
+      } catch (err) {
+        console.error("[native-stream] stopStream failed:", err);
+      }
+    }
+  }
+
+  private scheduleFlush(): void {
+    if (this.flushTimer) return;
+    const elapsed = Date.now() - this.lastFlushedAt;
+    const delay = Math.max(0, this.minIntervalMs - elapsed);
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = undefined;
+      this.enqueueFlush();
+    }, delay);
+  }
+
+  private enqueueFlush(): void {
+    this.queue = this.queue.then(() => this.flushNow());
+  }
+
+  private async flushNow(): Promise<void> {
+    if (this.legacy) return; // appends are forwarded directly once failed over
+    if (this.buffer.length === 0) return; // never start an empty stream
+
+    // Lazy start. On failure, fall back to the legacy transport and replay.
+    if (!this.curTs) {
+      try {
+        this.curTs = await this.transport.startStream();
+        this.firstTsValue = this.curTs;
+      } catch (err) {
+        this.failOverToLegacy(err, "first");
+        return;
+      }
+    }
+
+    try {
+      await this.drainToNative();
+    } catch (err) {
+      // A mid-stream `appendStream` failure shouldn't sink the stream; the next
+      // append retries from the latest buffer (curPosted only advances on
+      // success). Continuation-start failures are handled inside drainToNative
+      // (failover), so anything reaching here is a genuine append failure.
+      console.error(
+        `[native-stream] appendStream failed (ts=${this.curTs}, posted=${this.curPosted}/${this.buffer.length}):`,
+        err,
+      );
+    } finally {
+      this.lastFlushedAt = Date.now();
+    }
+  }
+
+  /**
+   * Switch to the legacy `chat.update` transport and replay the full buffer so
+   * no text is lost. Used when either the first or a continuation `startStream`
+   * fails — "opting in can never break a bot". The full buffer is replayed (not
+   * just the un-posted remainder) because `append()` forwards the accumulated
+   * full text once `this.legacy` is set, so the legacy stream must own the whole
+   * response; the already-streamed native message(s) stay as-is.
+   */
+  private failOverToLegacy(
+    err: unknown,
+    where: "first" | "continuation",
+  ): void {
+    console.warn(
+      `[native-stream] ${where} startStream failed; using legacy transport:`,
+      err,
+    );
+    this.onStartFailure?.(err);
+    const legacy = this.makeFallback();
+    legacy.append(this.buffer);
+    this.legacy = legacy;
+  }
+
+  /** Append all un-posted buffer text to the native stream, splitting messages at the budget. */
+  private async drainToNative(): Promise<void> {
+    // Loop because a single flush may overflow the current message budget and
+    // need to open one (or more) continuation messages.
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const posTextLen = this.curOpenerLen + this.curPosted; // display chars in current msg
+      const available = this.buffer.length - (this.curStart + this.curPosted);
+      if (available <= 0) return;
+
+      // Does the rest fit in the current message's budget?
+      if (posTextLen + available <= this.messageBudget) {
+        await this.appendDelta(
+          this.curStart + this.curPosted,
+          this.buffer.length,
+        );
+        return;
+      }
+
+      // Overflow: fill the current message up to the budget at a clean boundary,
+      // finalize it, then open a continuation that re-opens any open markdown.
+      const searchFrom = this.curStart + this.curPosted;
+      // `hardEnd` is the budget ceiling for this message; clamp it to always sit
+      // past `searchFrom` so a clean boundary can be found and we always make
+      // forward progress (a degenerate opener can never stall the loop).
+      const hardEnd = Math.max(
+        searchFrom + 1,
+        this.curStart + (this.messageBudget - this.curOpenerLen),
+      );
+      const boundary = this.chooseBoundary(searchFrom, hardEnd);
+      if (boundary > searchFrom) {
+        await this.appendDelta(searchFrom, boundary);
+      }
+      const ts = this.curTs!;
+      try {
+        await this.transport.stopStream(ts);
+      } catch (err) {
+        console.error(
+          `[native-stream] stopStream (continuation) failed (ts=${ts}):`,
+          err,
+        );
+      }
+      // Open the continuation, prepending the still-open markdown context so it
+      // renders standalone (same as ChunkedMessageStream's re-opener path). A
+      // continuation-start failure fails over to legacy (replaying the full
+      // buffer) exactly like the first start — never dropping the remainder.
+      const opener = renderContextOpener(
+        detectOpenContext(this.buffer.slice(0, boundary)),
+      );
+      let nextTs: string;
+      try {
+        nextTs = await this.transport.startStream();
+      } catch (err) {
+        this.failOverToLegacy(err, "continuation");
+        return;
+      }
+      this.curTs = nextTs;
+      this.curStart = boundary;
+      this.curPosted = 0;
+      this.curOpenerLen = opener.length;
+      if (opener) await this.transport.appendStream(this.curTs, opener);
+    }
+  }
+
+  /** Append `buffer[from, to)` to the current message, chunked under the 12k per-append cap. */
+  private async appendDelta(from: number, to: number): Promise<void> {
+    let cursor = from;
+    while (cursor < to) {
+      const end = Math.min(cursor + DEFAULT_MESSAGE_BUDGET, to);
+      const delta = this.buffer.slice(cursor, end);
+      await this.transport.appendStream(this.curTs!, delta);
+      cursor = end;
+    }
+    this.curPosted = to - this.curStart;
+  }
+
+  /**
+   * Pick a split point in `[from, hardEnd]`: prefer the last newline (so a
+   * message ends on a line boundary), else the last space, else `hardEnd`.
+   * Never returns a point at or before `from` (that would post nothing and
+   * loop); falls back to `hardEnd` in that case.
+   */
+  private chooseBoundary(from: number, hardEnd: number): number {
+    const window = this.buffer.slice(from, hardEnd);
+    let rel = window.lastIndexOf("\n");
+    if (rel < window.length / 4) rel = window.lastIndexOf(" ");
+    const boundary = rel > 0 ? from + rel + 1 : hardEnd;
+    return boundary > from ? boundary : hardEnd;
+  }
+}

--- a/packages/bot-slack/src/slack-listener.ts
+++ b/packages/bot-slack/src/slack-listener.ts
@@ -39,6 +39,13 @@ export interface ListenerConfig {
   onTurn: TurnHandler;
   /** Where each slash command is dispatched. */
   onCommand: CommandHandler;
+  /**
+   * True if `(channel, threadTs)` is an assistant-pane thread (owned by the
+   * Assistant middleware). When provided, threaded `message.im` events for
+   * those threads are skipped here so each pane message becomes exactly one
+   * turn. Absent (or returning false) → messages flow as shipped.
+   */
+  isAssistantThread?: (channel: string, threadTs: string) => boolean;
 }
 
 const MENTION_RE = /<@[UW][A-Z0-9]+>/g;
@@ -121,6 +128,17 @@ export function attachSlackListener(config: ListenerConfig): void {
     if (!text && !hasFiles) return;
 
     const isDM = message.channel_type === "im";
+
+    // Pane messages are threaded DMs owned by the Assistant middleware — skip
+    // them here so each pane message becomes EXACTLY ONE turn. Gated per-THREAD
+    // (assistant threads tracked at runtime), never per-config: ordinary
+    // threaded DMs in apps without the Agents toggle keep flowing.
+    if (
+      isDM &&
+      message.thread_ts &&
+      config.isAssistantThread?.(message.channel, message.thread_ts)
+    )
+      return;
 
     if (isDM) {
       await onTurn(

--- a/packages/bot-slack/src/types.ts
+++ b/packages/bot-slack/src/types.ts
@@ -6,6 +6,36 @@ export interface ReplyTarget {
   channel: string;
   /** Thread ts to post into. Omit for flat replies (DMs). */
   threadTs?: string;
+  /**
+   * Turn sender's Slack user id. `chat.startStream` requires it
+   * (`recipient_user_id`) when streaming into a channel; carried here so the
+   * native streamer can read it off the target.
+   */
+  recipientUserId?: string;
+}
+
+/**
+ * Assistant-pane behavior ("Agents & AI Apps"). The pane is ON by default —
+ * it activates whenever the Slack app config has the Agents toggle, and lies
+ * dormant otherwise. Pass an object to {@link SlackAdapterOptions.assistant} to
+ * customize, or `false` to disable pane handling entirely.
+ */
+export interface SlackAssistantOptions {
+  /** Posted when a user opens the pane. */
+  greeting?: string;
+  /** Up to 4 prompt chips shown on thread start. */
+  suggestedPrompts?: ReadonlyArray<{ title: string; message: string }>;
+  /** "auto" (default): title the thread from the first user message. false: never title. */
+  title?: "auto" | false;
+  /** Native status shown under the composer while the agent runs. */
+  status?: {
+    /** Status while reasoning. Default "is thinking…". */
+    thinking?: string;
+    /** Up to 10 loading messages Slack rotates through. */
+    loadingMessages?: readonly string[];
+    /** Surface "is using `tool`…" per tool call. Default true. */
+    toolStatus?: boolean;
+  };
 }
 
 /**

--- a/packages/bot-ui/src/types.ts
+++ b/packages/bot-ui/src/types.ts
@@ -44,6 +44,13 @@ export interface Thread {
   getMessages(): Promise<ThreadMessage[]>;
   /** Resolve a platform user by a free-form query (capability-gated; returns `undefined` when unsupported). */
   lookupUser(query: string): Promise<PlatformUser | undefined>;
+  /** Pin suggested prompts (capability-gated; returns `{ ok: false }` on surfaces without support). */
+  setSuggestedPrompts(
+    prompts: ReadonlyArray<{ title: string; message: string }>,
+    opts?: { title?: string },
+  ): Promise<{ ok: boolean; error?: string }>;
+  /** Name this conversation (capability-gated; returns `{ ok: false }` on surfaces without support). */
+  setTitle(title: string): Promise<{ ok: boolean; error?: string }>;
 }
 export interface InteractionContext<TValue = unknown> {
   thread: Thread;

--- a/packages/bot/README.md
+++ b/packages/bot/README.md
@@ -44,6 +44,9 @@ await bot.start();
   `{ thread, message }`. (Routing is mention-preferred: if any mention
   handler is registered, all turns route to it; otherwise message handlers
   fire.)
+- `onThreadStarted(handler)` — a conversation surface opened (e.g. the Slack
+  assistant pane); receives `{ thread, user? }`. Greet, set suggested prompts
+  or a title, or run the agent. Adapters without the concept never fire it.
 - `onInteraction<TValue>(id, handler)` — explicit escape-hatch handler for a
   known action id, bypassing the registry; `ctx.action.value` is typed `TValue`.
 - `onInterrupt<TPayload>(eventName, handler)` — handle a captured agent
@@ -80,6 +83,12 @@ interface Thread {
   }): Promise<MessageRef | undefined>;
   resume(value: unknown): Promise<MessageRef | undefined>;
   awaitChoice<T = unknown>(ui: Renderable): Promise<T>;
+  // Capability-gated (return { ok: false } on surfaces without support):
+  setSuggestedPrompts(
+    prompts: ReadonlyArray<{ title: string; message: string }>,
+    opts?: { title?: string },
+  ): Promise<{ ok: boolean; error?: string }>;
+  setTitle(title: string): Promise<{ ok: boolean; error?: string }>;
 }
 ```
 
@@ -158,8 +167,9 @@ pass it as `actionStore` to make actions survive restarts.
 
 To target a new surface, implement `PlatformAdapter` from this package. The
 engine drives ingress through the `IngressSink` you receive in `start(sink)`
-(`sink.onTurn(IncomingTurn)` / `sink.onInteraction(InteractionEvent)`) and
-egress through your `post` / `update` / `stream` / `delete` (which receive
+(`sink.onTurn(IncomingTurn)` / `sink.onInteraction(InteractionEvent)` /
+`sink.onCommand(IncomingCommand)` / `sink.onThreadStarted(IncomingThreadStart)`)
+and egress through your `post` / `update` / `stream` / `delete` (which receive
 `BotNode[]` to translate to a native payload via `render`). You also provide
 `createRunRenderer(target)` (an AG-UI `RunRenderer`: the subscriber to stream
 into, plus accessors for captured tool calls and interrupts that the run-loop
@@ -168,7 +178,10 @@ reads after each `runAgent`), `decodeInteraction(raw)` (native event → opaque
 (`getOrCreate` → `AgentSession`), and the surface `capabilities` /
 `ackDeadlineMs`. Optional capability methods like `getMessages(target)` and
 `postFile(target, args)` back the matching `thread` methods when the surface
-supports them. Slash commands are also capability-gated: an adapter forwards
+supports them — likewise `setSuggestedPrompts(target, prompts, opts?)` and
+`setThreadTitle(target, title)` back `thread.setSuggestedPrompts` /
+`thread.setTitle`, and `sink.onThreadStarted(...)` emits the "conversation
+opened" lifecycle event. Slash commands are also capability-gated: an adapter forwards
 invocations via `sink.onCommand(IncomingCommand)`, and may implement
 `registerCommands(specs)` to publish the bot's declared commands up front
 (e.g. Discord's application-command API); adapters that omit it are skipped.
@@ -176,9 +189,10 @@ See `@copilotkit/bot-slack` for a complete implementation.
 
 ## Exports
 
-`createBot`, `Bot`, `CreateBotOptions`, `BotHandler`; `Thread`; the
-`PlatformAdapter` boundary types (`RunRenderer`, `IngressSink`,
-`IncomingTurn`, `InteractionEvent`, `IncomingCommand`, `SurfaceCapabilities`,
+`createBot`, `Bot`, `CreateBotOptions`, `BotHandler`, `ThreadStartHandler`;
+`Thread`; the `PlatformAdapter` boundary types (`RunRenderer`, `IngressSink`,
+`IncomingTurn`, `InteractionEvent`, `IncomingCommand`, `IncomingThreadStart`,
+`SurfaceCapabilities`,
 `ReplyTarget`, `ConversationStore`, `AgentSession`, `CapturedToolCall`,
 `CapturedInterrupt`, `UserQuery`); `ActionStore` / `InMemoryActionStore` /
 `ActionSnapshot` / `ActionRegistry` / `ActionExpiredError`; `BotTool` /

--- a/packages/bot/src/create-bot.ts
+++ b/packages/bot/src/create-bot.ts
@@ -4,28 +4,33 @@ import type {
   IncomingTurn,
   InteractionEvent,
   IncomingCommand,
+  IncomingThreadStart,
 } from "./platform-adapter.js";
 import { ActionRegistry, ActionExpiredError } from "./action-registry.js";
-import { InMemoryActionStore, type ActionStore } from "./action-store.js";
-import {
-  toAgentToolDescriptors,
-  parseToolArgs,
-  type BotTool,
-  type ContextEntry,
-} from "./tools.js";
-import {
-  normalizeCommandName,
-  toCommandSpec,
-  type BotCommand,
-  type CommandContext,
-} from "./commands.js";
-import { Thread, type ThreadDeps } from "./thread.js";
+import { InMemoryActionStore } from "./action-store.js";
+import type { ActionStore } from "./action-store.js";
+import { toAgentToolDescriptors, parseToolArgs } from "./tools.js";
+import type { BotTool, ContextEntry } from "./tools.js";
+import { normalizeCommandName, toCommandSpec } from "./commands.js";
+import type { BotCommand, CommandContext } from "./commands.js";
+import { Thread } from "./thread.js";
+import type { ThreadDeps } from "./thread.js";
 import type { AbstractAgent } from "@ag-ui/client";
-import type { InteractionContext, IncomingMessage } from "@copilotkit/bot-ui";
+import type {
+  InteractionContext,
+  IncomingMessage,
+  PlatformUser,
+} from "@copilotkit/bot-ui";
 
 export type BotHandler = (ctx: {
   thread: Thread;
   message: IncomingMessage;
+}) => void | Promise<void>;
+
+/** Handler for a "conversation opened" lifecycle event (e.g. the Slack assistant pane). */
+export type ThreadStartHandler = (ctx: {
+  thread: Thread;
+  user?: PlatformUser;
 }) => void | Promise<void>;
 
 export interface CreateBotOptions {
@@ -41,6 +46,12 @@ export interface CreateBotOptions {
 export interface Bot {
   onMention(h: BotHandler): void;
   onMessage(h: BotHandler): void;
+  /**
+   * A conversation surface opened (e.g. the Slack assistant pane). Greet, set
+   * suggested prompts, set a title, or run the agent. Adapters without the
+   * concept never fire this.
+   */
+  onThreadStarted(h: ThreadStartHandler): void;
   /** Handle clicks on a specific action `id`. `ctx.action.value` is typed as `TValue`. */
   onInteraction<TValue = unknown>(
     id: string,
@@ -90,6 +101,7 @@ export function createBot(opts: CreateBotOptions): Bot {
 
   const mentionHandlers: BotHandler[] = [];
   const messageHandlers: BotHandler[] = [];
+  const threadStartedHandlers: ThreadStartHandler[] = [];
   const interactionHandlers = new Map<
     string,
     (ctx: InteractionContext) => void | Promise<void>
@@ -212,6 +224,18 @@ export function createBot(opts: CreateBotOptions): Bot {
         };
         await command.handler(ctx);
       },
+      async onThreadStarted(evt: IncomingThreadStart) {
+        // The adapter has already applied its static defaults (greeting /
+        // prompts) before emitting this, so handlers layer on top and never
+        // race. Zero handlers → no-op.
+        const thread = makeThread(
+          adapter,
+          evt.replyTarget,
+          evt.conversationKey,
+        );
+        for (const h of threadStartedHandlers)
+          await h({ thread, user: evt.user });
+      },
     };
   }
 
@@ -221,6 +245,9 @@ export function createBot(opts: CreateBotOptions): Bot {
     },
     onMessage(h) {
       messageHandlers.push(h);
+    },
+    onThreadStarted(h) {
+      threadStartedHandlers.push(h);
     },
     onInteraction<TValue = unknown>(
       id: string,

--- a/packages/bot/src/index.ts
+++ b/packages/bot/src/index.ts
@@ -2,7 +2,12 @@
 
 // Bot orchestration
 export { createBot } from "./create-bot.js";
-export type { Bot, CreateBotOptions, BotHandler } from "./create-bot.js";
+export type {
+  Bot,
+  CreateBotOptions,
+  BotHandler,
+  ThreadStartHandler,
+} from "./create-bot.js";
 
 // Thread
 export { Thread } from "./thread.js";
@@ -16,6 +21,7 @@ export type {
   IncomingTurn,
   InteractionEvent,
   IncomingCommand,
+  IncomingThreadStart,
   SurfaceCapabilities,
   ReplyTarget,
   ConversationStore,

--- a/packages/bot/src/platform-adapter.test.ts
+++ b/packages/bot/src/platform-adapter.test.ts
@@ -11,6 +11,7 @@ describe("FakeAdapter", () => {
       },
       onInteraction: () => {},
       onCommand: () => {},
+      onThreadStarted: () => {},
     });
     a.emitTurn({ userText: "hi" });
     expect(got).toBe("hi");
@@ -27,6 +28,7 @@ describe("FakeAdapter", () => {
         id = e.id;
       },
       onCommand: () => {},
+      onThreadStarted: () => {},
     });
     a.emitInteraction({ id: "ck:abc" });
     expect(id).toBe("ck:abc");

--- a/packages/bot/src/platform-adapter.ts
+++ b/packages/bot/src/platform-adapter.ts
@@ -18,6 +18,10 @@ export interface SurfaceCapabilities {
   supportsReactions: boolean;
   supportsStreaming: boolean;
   maxBlocksPerMessage?: number;
+  /** Pinned prompt chips on a conversation surface (Slack assistant pane). */
+  supportsSuggestedPrompts?: boolean;
+  /** Nameable conversations (Slack assistant-thread titles). */
+  supportsThreadTitle?: boolean;
   [k: string]: unknown;
 }
 
@@ -72,11 +76,24 @@ export interface IncomingCommand {
   platform: string;
 }
 
+/**
+ * A "conversation opened" lifecycle event (Slack: `assistant_thread_started`).
+ * Adapters without the concept never emit it.
+ */
+export interface IncomingThreadStart {
+  conversationKey: string;
+  replyTarget: ReplyTarget;
+  user?: PlatformUser;
+  platform: string;
+}
+
 export interface IngressSink {
   onTurn(turn: IncomingTurn): void | Promise<void>;
   onInteraction(evt: InteractionEvent): void | Promise<void>;
   /** A slash command fired. Routed to the matching `bot.onCommand` handler (ignored if none). */
   onCommand(cmd: IncomingCommand): void | Promise<void>;
+  /** A conversation surface opened. Adapters without the concept never call it. */
+  onThreadStarted(evt: IncomingThreadStart): void | Promise<void>;
 }
 
 export interface UserQuery {
@@ -144,4 +161,24 @@ export interface PlatformAdapter {
    * commands at all simply omit it and command handlers never fire there.
    */
   registerCommands?(commands: readonly CommandSpec[]): void | Promise<void>;
+  /**
+   * Optional: pin suggested prompts on a conversation surface (backs the
+   * capability-gated `Thread.setSuggestedPrompts`). Adapters without the
+   * concept omit this, and `Thread.setSuggestedPrompts` returns
+   * `{ ok: false, error }` without throwing.
+   */
+  setSuggestedPrompts?(
+    target: ReplyTarget,
+    prompts: ReadonlyArray<{ title: string; message: string }>,
+    opts?: { title?: string },
+  ): Promise<{ ok: boolean; error?: string }>;
+  /**
+   * Optional: set the conversation's display title (backs `Thread.setTitle`).
+   * Adapters without the concept omit this, and `Thread.setTitle` returns
+   * `{ ok: false, error }` without throwing.
+   */
+  setThreadTitle?(
+    target: ReplyTarget,
+    title: string,
+  ): Promise<{ ok: boolean; error?: string }>;
 }

--- a/packages/bot/src/testing/fake-adapter.ts
+++ b/packages/bot/src/testing/fake-adapter.ts
@@ -10,6 +10,7 @@ import type {
   SurfaceCapabilities,
   IngressSink,
   IncomingTurn,
+  IncomingThreadStart,
   InteractionEvent,
   IncomingCommand,
   RunRenderer,
@@ -52,13 +53,36 @@ export function makeFakeRunRenderer(): RunRenderer {
 
 export class FakeAdapter implements PlatformAdapter {
   readonly platform = "fake";
-  readonly capabilities: SurfaceCapabilities = {
-    supportsModals: false,
-    supportsTyping: false,
-    supportsReactions: false,
-    supportsStreaming: true,
-  };
+  readonly capabilities: SurfaceCapabilities;
   readonly ackDeadlineMs = 3000;
+
+  /**
+   * @param fakeOpts.paneMethods When `false`, the optional
+   *   `setSuggestedPrompts`/`setThreadTitle` methods are omitted (and the
+   *   matching capability flags cleared) so tests can exercise the
+   *   capability-gated `{ ok: false }` path. Defaults to present.
+   */
+  constructor(fakeOpts: { paneMethods?: boolean } = {}) {
+    const paneMethods = fakeOpts.paneMethods !== false;
+    this.capabilities = {
+      supportsModals: false,
+      supportsTyping: false,
+      supportsReactions: false,
+      supportsStreaming: true,
+      supportsSuggestedPrompts: paneMethods,
+      supportsThreadTitle: paneMethods,
+    };
+    if (paneMethods) {
+      this.setSuggestedPrompts = async (target, prompts, opts) => {
+        this.suggestedPromptsCalls.push({ target, prompts, opts });
+        return { ok: true };
+      };
+      this.setThreadTitle = async (target, title) => {
+        this.threadTitleCalls.push({ target, title });
+        return { ok: true };
+      };
+    }
+  }
   readonly conversationStore: ConversationStore = {
     async getOrCreate(conversationKey, _replyTarget, makeAgent) {
       return { agent: makeAgent(conversationKey) };
@@ -117,12 +141,34 @@ export class FakeAdapter implements PlatformAdapter {
     return this.messages;
   }
 
+  /** Suggested-prompt calls recorded by the capability-gated method (when present). */
+  suggestedPromptsCalls: {
+    target: ReplyTarget;
+    prompts: ReadonlyArray<{ title: string; message: string }>;
+    opts?: { title?: string };
+  }[] = [];
+  setSuggestedPrompts?: PlatformAdapter["setSuggestedPrompts"];
+
+  /** Thread-title calls recorded by the capability-gated method (when present). */
+  threadTitleCalls: { target: ReplyTarget; title: string }[] = [];
+  setThreadTitle?: PlatformAdapter["setThreadTitle"];
+
   // --- test helpers ---
   emitTurn(partial: Partial<IncomingTurn>): void {
     void this.sink?.onTurn({
       conversationKey: "c",
       replyTarget: {},
       userText: "",
+      platform: "fake",
+      ...partial,
+    });
+  }
+  emitThreadStarted(
+    partial?: Partial<IncomingThreadStart>,
+  ): Promise<void> | void {
+    return this.sink?.onThreadStarted({
+      conversationKey: "c",
+      replyTarget: {},
       platform: "fake",
       ...partial,
     });

--- a/packages/bot/src/thread-capabilities.test.ts
+++ b/packages/bot/src/thread-capabilities.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { createBot } from "./create-bot.js";
+import { FakeAdapter } from "./testing/fake-adapter.js";
+
+describe("onThreadStarted routing", () => {
+  it("invokes registered handlers with the thread and user", async () => {
+    const fake = new FakeAdapter();
+    const bot = createBot({ adapters: [fake] });
+    const seen: { user?: string; platform: string }[] = [];
+    bot.onThreadStarted(({ thread, user }) => {
+      seen.push({ user: user?.id, platform: thread.platform });
+    });
+    await bot.start();
+
+    await fake.emitThreadStarted({ user: { id: "U1", name: "Ada" } });
+    expect(seen).toEqual([{ user: "U1", platform: "fake" }]);
+  });
+
+  it("invokes every registered handler in order", async () => {
+    const fake = new FakeAdapter();
+    const bot = createBot({ adapters: [fake] });
+    const order: number[] = [];
+    bot.onThreadStarted(() => {
+      order.push(1);
+    });
+    bot.onThreadStarted(() => {
+      order.push(2);
+    });
+    await bot.start();
+    await fake.emitThreadStarted();
+    expect(order).toEqual([1, 2]);
+  });
+
+  it("is a no-op when no handler is registered", async () => {
+    const fake = new FakeAdapter();
+    const bot = createBot({ adapters: [fake] });
+    await bot.start();
+    // Should not throw.
+    await expect(
+      Promise.resolve(fake.emitThreadStarted()),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("Thread.setSuggestedPrompts / setTitle capability gating", () => {
+  it("delegates to the adapter when supported", async () => {
+    const fake = new FakeAdapter();
+    const bot = createBot({ adapters: [fake] });
+    const results: { ok: boolean; error?: string }[] = [];
+    bot.onThreadStarted(async ({ thread }) => {
+      results.push(
+        await thread.setSuggestedPrompts(
+          [{ title: "Triage", message: "Triage my issues" }],
+          { title: "Try" },
+        ),
+      );
+      results.push(await thread.setTitle("My conversation"));
+    });
+    await bot.start();
+    await fake.emitThreadStarted({ replyTarget: { channel: "D1" } });
+
+    expect(results).toEqual([{ ok: true }, { ok: true }]);
+    expect(fake.suggestedPromptsCalls).toHaveLength(1);
+    expect(fake.suggestedPromptsCalls[0]).toMatchObject({
+      target: { channel: "D1" },
+      prompts: [{ title: "Triage", message: "Triage my issues" }],
+      opts: { title: "Try" },
+    });
+    expect(fake.threadTitleCalls).toEqual([
+      { target: { channel: "D1" }, title: "My conversation" },
+    ]);
+  });
+
+  it("returns { ok: false } without throwing when unsupported", async () => {
+    const fake = new FakeAdapter({ paneMethods: false });
+    const bot = createBot({ adapters: [fake] });
+    const results: { ok: boolean; error?: string }[] = [];
+    bot.onThreadStarted(async ({ thread }) => {
+      results.push(await thread.setSuggestedPrompts([]));
+      results.push(await thread.setTitle("nope"));
+    });
+    await bot.start();
+    await fake.emitThreadStarted();
+
+    expect(results[0]!.ok).toBe(false);
+    expect(results[0]!.error).toMatch(/does not support suggested prompts/);
+    expect(results[1]!.ok).toBe(false);
+    expect(results[1]!.error).toMatch(/does not support thread titles/);
+    expect(fake.suggestedPromptsCalls).toHaveLength(0);
+    expect(fake.threadTitleCalls).toHaveLength(0);
+  });
+});

--- a/packages/bot/src/thread.ts
+++ b/packages/bot/src/thread.ts
@@ -90,6 +90,33 @@ export class Thread implements ThreadInterface {
     return adapter.postFile(this.deps.replyTarget, args);
   }
 
+  /** Pin suggested prompts (returns `{ ok: false }` on surfaces without support). */
+  async setSuggestedPrompts(
+    prompts: ReadonlyArray<{ title: string; message: string }>,
+    opts?: { title?: string },
+  ): Promise<{ ok: boolean; error?: string }> {
+    const adapter = this.deps.adapter;
+    if (!adapter.setSuggestedPrompts) {
+      return {
+        ok: false,
+        error: `${this.platform} does not support suggested prompts`,
+      };
+    }
+    return adapter.setSuggestedPrompts(this.deps.replyTarget, prompts, opts);
+  }
+
+  /** Name this conversation (returns `{ ok: false }` on surfaces without support). */
+  async setTitle(title: string): Promise<{ ok: boolean; error?: string }> {
+    const adapter = this.deps.adapter;
+    if (!adapter.setThreadTitle) {
+      return {
+        ok: false,
+        error: `${this.platform} does not support thread titles`,
+      };
+    }
+    return adapter.setThreadTitle(this.deps.replyTarget, title);
+  }
+
   /** Read the conversation's messages (returns `[]` when the adapter can't read history). */
   async getMessages(): Promise<ThreadMessage[]> {
     return (await this.deps.adapter.getMessages?.(this.deps.replyTarget)) ?? [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@copilotkit/bot': workspace:*
+  '@copilotkit/bot-slack': workspace:*
+  '@copilotkit/bot-ui': workspace:*
   '@ag-ui/mcp-middleware>@ag-ui/client': 0.0.53
   streamdown>react: ^19.0.0
   '@types/react': 19.1.8
@@ -384,14 +387,14 @@ importers:
   examples/slack:
     dependencies:
       '@copilotkit/bot':
-        specifier: ~0.0.1
-        version: 0.0.1(encoding@0.1.13)(zod@3.25.76)
+        specifier: workspace:*
+        version: link:../../packages/bot
       '@copilotkit/bot-slack':
-        specifier: ~0.0.1
-        version: 0.0.1(@types/express@5.0.6)(encoding@0.1.13)
+        specifier: workspace:*
+        version: link:../../packages/bot-slack
       '@copilotkit/bot-ui':
-        specifier: ~0.0.1
-        version: 0.0.1(@ag-ui/core@0.0.57)(encoding@0.1.13)
+        specifier: workspace:*
+        version: link:../../packages/bot-ui
       '@copilotkit/runtime':
         specifier: ^1.59.5
         version: 1.59.5(4c17f358ce8005944aeca87c7a73a8ac)
@@ -2245,7 +2248,7 @@ importers:
         specifier: 0.0.57
         version: 0.0.57
       '@copilotkit/bot-ui':
-        specifier: workspace:~
+        specifier: workspace:*
         version: link:../bot-ui
       '@copilotkit/core':
         specifier: workspace:^
@@ -2282,10 +2285,10 @@ importers:
         specifier: 0.0.57
         version: 0.0.57
       '@copilotkit/bot':
-        specifier: workspace:~
+        specifier: workspace:*
         version: link:../bot
       '@copilotkit/bot-ui':
-        specifier: workspace:~
+        specifier: workspace:*
         version: link:../bot-ui
       '@copilotkit/core':
         specifier: workspace:^
@@ -5433,19 +5436,6 @@ packages:
         optional: true
       vitest:
         optional: true
-
-  '@copilotkit/bot-slack@0.0.1':
-    resolution: {integrity: sha512-qZK5PAELNas8B6uPP1lJ6hznREZmnIiOnLBDujIo5vz0V21wEMD/z2l8boys0u7Jye3fBHxsnVuhRtMuAWbn1Q==}
-
-  '@copilotkit/bot-ui@0.0.1':
-    resolution: {integrity: sha512-lZmpfvYGoQCokfT9ctnC92iXuSqZ4nuyRO2K9ShlwY6eZBq89s/gj+0E4fH8o5KwqRn9b/jre9cb1K4yreMO2g==}
-
-  '@copilotkit/bot@0.0.1':
-    resolution: {integrity: sha512-KsdY6lBs20uty2ryxu35wQFFojnU/S13M+cK0L9NveE17TZQSwGvzOzBYsnily0Cc6ap6pA0+9RhZqKvU6t7Nw==}
-
-  '@copilotkit/core@1.59.5':
-    resolution: {integrity: sha512-y1mR0dc2bkVtGHrv1Z86OXERH54tzpfpW4JX+RGJiyInMtblz40FWNQoGoQpOc4IwxdPynrMnpoiMVR/FrUI9g==}
-    engines: {node: '>=18'}
 
   '@copilotkit/license-verifier@0.4.2':
     resolution: {integrity: sha512-0+Rdtg4gOwOBFBpZFxYsjgwBcCLja5z03YC6WA3KEntHYhsnoJ2aqNG6c0we8ZExCNYlEO4M7kHIfG5LXzqMYQ==}
@@ -23876,8 +23866,8 @@ packages:
   vue-component-type-helpers@3.3.1:
     resolution: {integrity: sha512-pu58kqxmVyEH6VfNYW1UyEfR3XAnJ27ZXT3yzXxxpjLxVzAbyC35Zk/nm/RMs7ijWnJNSd9fWkeex2OhUsx3MA==}
 
-  vue-component-type-helpers@3.3.4:
-    resolution: {integrity: sha512-joip1uZTaQR0nD23N400gIdJ7xY+WiiiMA/BCKz842gvGBknqDQAzklUvDEhqFvvrhQY8S2ZANBMu4X70VMFGw==}
+  vue-component-type-helpers@3.3.5:
+    resolution: {integrity: sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==}
 
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
@@ -28277,67 +28267,6 @@ snapshots:
       jest: 29.7.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.9.3))
       vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@22.19.11)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
-  '@copilotkit/bot-slack@0.0.1(@types/express@5.0.6)(encoding@0.1.13)':
-    dependencies:
-      '@ag-ui/client': 0.0.53
-      '@ag-ui/core': 0.0.53
-      '@copilotkit/bot': 0.0.1(encoding@0.1.13)(zod@3.25.76)
-      '@copilotkit/bot-ui': 0.0.1(@ag-ui/core@0.0.53)(encoding@0.1.13)
-      '@copilotkit/core': 1.59.5(@ag-ui/core@0.0.53)(encoding@0.1.13)(zod@3.25.76)
-      '@copilotkit/shared': 1.59.5(@ag-ui/core@0.0.53)(encoding@0.1.13)
-      '@slack/bolt': 4.7.3(@types/express@5.0.6)
-      '@slack/types': 2.21.1
-      '@slack/web-api': 7.16.0
-      rxjs: 7.8.1
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@types/express'
-      - bufferutil
-      - debug
-      - encoding
-      - supports-color
-      - utf-8-validate
-
-  '@copilotkit/bot-ui@0.0.1(@ag-ui/core@0.0.53)(encoding@0.1.13)':
-    dependencies:
-      '@copilotkit/shared': 1.59.5(@ag-ui/core@0.0.53)(encoding@0.1.13)
-    transitivePeerDependencies:
-      - '@ag-ui/core'
-      - encoding
-
-  '@copilotkit/bot-ui@0.0.1(@ag-ui/core@0.0.57)(encoding@0.1.13)':
-    dependencies:
-      '@copilotkit/shared': 1.59.5(@ag-ui/core@0.0.57)(encoding@0.1.13)
-    transitivePeerDependencies:
-      - '@ag-ui/core'
-      - encoding
-
-  '@copilotkit/bot@0.0.1(encoding@0.1.13)(zod@3.25.76)':
-    dependencies:
-      '@ag-ui/client': 0.0.53
-      '@ag-ui/core': 0.0.53
-      '@copilotkit/bot-ui': 0.0.1(@ag-ui/core@0.0.53)(encoding@0.1.13)
-      '@copilotkit/core': 1.59.5(@ag-ui/core@0.0.53)(encoding@0.1.13)(zod@3.25.76)
-      '@copilotkit/shared': 1.59.5(@ag-ui/core@0.0.53)(encoding@0.1.13)
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - encoding
-      - zod
-
-  '@copilotkit/core@1.59.5(@ag-ui/core@0.0.53)(encoding@0.1.13)(zod@3.25.76)':
-    dependencies:
-      '@ag-ui/client': 0.0.53
-      '@copilotkit/shared': 1.59.5(@ag-ui/core@0.0.53)(encoding@0.1.13)
-      '@tanstack/pacer': 0.20.1
-      phoenix: 1.8.4
-      rxjs: 7.8.1
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@ag-ui/core'
-      - encoding
-      - zod
-
   '@copilotkit/license-verifier@0.4.2': {}
 
   '@copilotkit/runtime@1.59.5(4c17f358ce8005944aeca87c7a73a8ac)':
@@ -28412,22 +28341,6 @@ snapshots:
     dependencies:
       '@ag-ui/client': 0.0.53
       '@ag-ui/core': 0.0.53
-      '@copilotkit/license-verifier': 0.4.2
-      '@segment/analytics-node': 2.3.0(encoding@0.1.13)
-      '@standard-schema/spec': 1.1.0
-      chalk: 4.1.2
-      graphql: 16.12.0
-      partial-json: 0.1.7
-      uuid: 11.1.0
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - encoding
-
-  '@copilotkit/shared@1.59.5(@ag-ui/core@0.0.57)(encoding@0.1.13)':
-    dependencies:
-      '@ag-ui/client': 0.0.53
-      '@ag-ui/core': 0.0.57
       '@copilotkit/license-verifier': 0.4.2
       '@segment/analytics-node': 2.3.0(encoding@0.1.13)
       '@standard-schema/spec': 1.1.0
@@ -35917,7 +35830,7 @@ snapshots:
       storybook: 10.1.11(@testing-library/dom@10.4.0)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.34(typescript@5.8.2)
-      vue-component-type-helpers: 3.3.4
+      vue-component-type-helpers: 3.3.5
 
   '@swc/core-darwin-arm64@1.15.8':
     optional: true
@@ -53041,7 +52954,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.1: {}
 
-  vue-component-type-helpers@3.3.4: {}
+  vue-component-type-helpers@3.3.5: {}
 
   vue-devtools-stub@0.1.0: {}
 

--- a/showcase/shell-docs/src/content/docs/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/slack.mdx
@@ -5,6 +5,7 @@ icon: "lucide/Slack"
 hideTOC: true
 earlyAccess: slack
 ---
+
 This guide takes you from zero to a Slack bot you can @-mention in a channel, then adds an interactive button card. You write handlers in TypeScript, the agent's replies stream into the thread, and rich messages are JSX that the adapter renders to Block Kit (Slack's message-UI format). No public URL needed.
 
 ## Prerequisites
@@ -19,15 +20,15 @@ This guide takes you from zero to a Slack bot you can @-mention in a channel, th
     <Step>
         ### Create the Slack app from a manifest
 
-        The manifest declares everything the bot needs — scopes, events, Socket Mode, a `/agent` slash command — in one shot.
+        The manifest declares everything the bot needs — scopes, events, Socket Mode, a `/agent` slash command, and the **assistant pane** ("Agents & AI Apps") — in one shot.
 
         1. Open [api.slack.com/apps?new_app=1](https://api.slack.com/apps?new_app=1) and choose **From a manifest**.
         2. Pick your workspace.
         3. Switch the editor to the **YAML** tab (it defaults to JSON) and paste the contents of [`examples/slack/slack-app-manifest.yaml`](https://github.com/CopilotKit/CopilotKit/blob/main/examples/slack/slack-app-manifest.yaml).
         4. Review and create the app.
 
-        <Callout type="warn" title="If validation fails on assistant:write">
-          Delete these two lines if the manifest you pasted has them — Slack rejects `assistant:write` unless the app also declares an `assistant_view` feature block: `- assistant:write` (under `oauth_config.scopes.bot`) and `- assistant_thread_started` (under `settings.event_subscriptions.bot_events`).
+        <Callout type="info" title="The assistant pane is on by default">
+          The manifest's `assistant_view` block (plus the `assistant:write` scope and the `assistant_thread_started` / `assistant_thread_context_changed` events) turns on Slack's AI assistant pane: opening it greets the user with tappable prompt chips, replies stream natively with live "is thinking…" status, and each pane conversation is its own thread. To run a plain channel bot without the pane, drop the `assistant_view` block and the `assistant:*` scope/events, and pass `assistant: false` to `slack(...)`.
         </Callout>
     </Step>
     <Step>
@@ -238,6 +239,7 @@ This guide takes you from zero to a Slack bot you can @-mention in a channel, th
           Slack silently drops undeclared commands — declare new ones in the manifest's `slash_commands` (or **Slash Commands** in the app settings) first.
         </Callout>
     </Step>
+
 </Steps>
 
 ## Split the bot and the agent


### PR DESCRIPTION
## What

Activates Slack's agent-grade APIs as the **default** experience for `@copilotkit/bot-slack`, with zero config and safe degradation. Implements the Notion spec *"Slack Agent APIs in bot-slack — assistant pane + native streaming by default"* (Rev 2).

### Assistant pane ("Agents & AI Apps")
- Opening the pane greets the user + shows tappable prompt chips; each pane conversation is its own thread (replies stay in-thread, instead of leaking to a merged flat DM).
- While the agent runs, native composer status (`assistant.threads.setStatus`: "is thinking…", "is using `tool`…") replaces placeholder/`:wrench:` messages.
- Pane threads are auto-titled from the first message.
- Customize via the new `assistant` option; `assistant: false` disables pane handling. Apps without the Agents toggle behave exactly as before (pane machinery dormant).

### Native streaming
- Replies stream via `chat.startStream` / `appendStream` / `stopStream` (raw markdown — real tables / fenced code render natively) wherever a thread exists.
- Flat DMs and workspaces without the streaming API fall back to the legacy `chat.update` transport **automatically** — the first `startStream` failure marks the workspace legacy and replays via legacy. Opting in can never break a bot. `streaming: "legacy"` forces the old transport.

### Portable engine surface (`@copilotkit/bot`)
- `bot.onThreadStarted` lifecycle handler + `IncomingThreadStart` sink event.
- Capability-gated `thread.setSuggestedPrompts` / `thread.setTitle` (the shipped `postFile` gating pattern).
- Two `SurfaceCapabilities` flags + optional `PlatformAdapter` methods. All degrade gracefully on surfaces without support.

## Files
- **New:** `bot-slack/src/assistant.ts` (Bolt `Assistant` middleware ⇄ engine sink), `bot-slack/src/native-stream.ts` (`NativeMessageStream`, same `append/finish` contract as `MessageStream`, legacy fallback).
- **Engine:** `platform-adapter.ts`, `thread.ts`, `create-bot.ts`, `index.ts` (+ `bot-ui` `Thread` type).
- **Adapter:** `adapter.ts` (options/capabilities/stream branch/methods), `slack-listener.ts` (one-line no-double-delivery guard), `event-renderer.ts` (pane status mode + native text transport).
- **Example/docs:** `examples/slack` manifest (`assistant_view` + scope + events) & dev-ex, package READMEs/ARCHITECTURE, `slack.mdx`.
- **Hooks:** `chore(hooks)` makes the `lint-fix` script double-quote-free (it was breaking `sh -c "…"` on Windows/lefthook 2.1.1).

## Tests / verification (CI-runnable)
- New unit tests: `native-stream` (cadence, 12k continuation, fence re-open, first- **and** continuation-`startStream` fallback), `assistant` (defaults-before-onThreadStarted ordering, thread-scoped turn, auto-title), listener no-double-delivery, renderer pane-status mode, engine capability gating.
- Verified locally: `@copilotkit/bot` 31 tests, `@copilotkit/bot-slack` 199 tests, `bot-ui` tests; `tsc` clean (bot + bot-slack); build clean; oxlint/oxfmt clean; publint/attw pass.

## ⚠️ E2E not covered here
The §8 end-to-end flows need a **real Slack workspace** with the Agents toggle (open pane → chips → streamed reply w/ live status; channel mention → native markdown; kill `startStream` → legacy fallback; non-agent app → shipped behavior). `examples/slack` is the vehicle. Three items remain to confirm against a live workspace (spec §7 spikes): the `isAssistantThread` runtime detection, the exact `assistant_view` manifest acceptance, and `stopStream` finalize tolerance.

Spec: https://app.notion.com/p/copilotkit/Slack-Agent-APIs-in-bot-slack-assistant-pane-native-streaming-by-default-spec-37b3aa38185281f5948dc6a665064d04
