### PR TITLE
ci(e2e-dojo): run dojo suites on 4-vCPU runner (−40% wall-clock)

### DIFF
--- a/.github/workflows/test_e2e-dojo.yml
+++ b/.github/workflows/test_e2e-dojo.yml
@@ -61,7 +61,9 @@ jobs:
   dojo:
     needs: detect-changes
     name: ${{ matrix.suite }}
-    runs-on: depot-ubuntu-24.04
+    # 4-vCPU runner (was depot-ubuntu-24.04 = 2 vCPU) to speed the build, the
+    # dojo prep, and Playwright worker parallelism on the long-pole suites.
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 30
     permissions:
       contents: read
@@ -266,7 +268,8 @@ jobs:
         working-directory: CopilotKit
         env:
           NODE_OPTIONS: --max-old-space-size=8192
-          NX_PARALLEL: 2
+          # Match the 4-vCPU runner so the monorepo build uses the extra cores.
+          NX_PARALLEL: 4
         run: pnpm build
 
       - name: Install ag-ui dependencies


### PR DESCRIPTION
Bumps the dojo e2e matrix from `depot-ubuntu-24.04` (2 vCPU) to `depot-ubuntu-24.04-4` (4 vCPU) and `NX_PARALLEL: 4` so the build uses the extra cores. This is the non-serializing way to cut dojo wall-clock (the build-once dedup tried in #5450 regressed wall-clock and was reverted).

## Result: −40% wall-clock (measured on CI)

Dojo wall-clock = the single slowest suite (the 15 run in parallel). Comparison vs the 2-vCPU baseline:

| metric | 2-vCPU baseline | 4-vCPU | Δ |
|---|---|---|---|
| **wall-clock** (long pole `langgraph-python`) | 623s (10.4m) | **373s (6.2m)** | **−40%** |
| runner-minutes (wall summed, 15 suites) | 105m | 76m | −28% |
| **billed compute** (vCPU-min; 4-vCPU ≈ 2× rate) | ~210 | ~304 | **+45%** |

Every suite got faster; the long-pole suites benefited most:

| suite | 2-vCPU | 4-vCPU |
|---|---|---|
| langgraph-python | 623s | 373s |
| langgraph-typescript | 547s | 362s |
| langgraph-fastapi | 500s | 337s |
| adk-middleware | 414s | 286s |
| (… all 15 faster …) | | |

Long-pole `langgraph-python` step breakdown:

| phase | 2-vCPU | 4-vCPU |
|---|---|---|
| Build cpk | 82s | 48s |
| Prep dojo | 94s | 52s |
| **Run tests (Playwright)** | **271s** | **117s** |
| total | 623s | 373s |

**Key finding:** the Playwright phase more than halved → the e2e suites are **CPU/worker-bound, not LLM-latency-bound**. A bigger runner is the right lever; test sharding is not needed to reach ~6 min.

## Trade-off
−40% wall-clock for **~+45% billed compute** (4-vCPU costs ~2×/min, partly offset by finishing 28% sooner). If the cost bump isn't worth it across all 15 suites, a follow-up can scope `-4` to just the slow suites via a per-matrix `runner` field (wall ~6.5m, smaller cost increase).

Companion to #5450 (unit-test `nx affected`).