### PR TITLE
fix(showcase/harness): override LOCAL_SERVICES_JSON in --isolate generator to target the requested slug

### DIFF
--- a/showcase/scripts/cli/_common.sh
+++ b/showcase/scripts/cli/_common.sh
@@ -482,6 +482,13 @@ _release_isolate_slot() {
 # for cleanup of the claimed slot (and, once created, the runs/<name> dir).
 apply_isolation() {
   local name="${1:-}"
+  # Slug the run is scoped to (from `showcase test <slug>`). Used below to
+  # override the persistent stack's hardcoded LOCAL_SERVICES_JSON — that value
+  # points at langgraph-python's agentic-chat cell for fast N=1 local demos, so
+  # an iso stack for a DIFFERENT slug would inherit the wrong roster and the
+  # harness's railway-services local-injection seam would enumerate the wrong
+  # service (discovery.railway-services.local-injection count:1 names:["showcase-langgraph-python"]).
+  local slug="${2:-}"
   # NB: ISOLATE_ACTIVE is deliberately NOT set here. cmd-test.sh arms
   # `trap restore_isolation EXIT` BEFORE calling this function, so if we
   # flipped it true before COMPOSE_CMD is repointed at the isolated project,
@@ -663,6 +670,53 @@ content = re.sub(r'(\s+dockerfile:\s+)\./([^\n]+)', lambda m: _abs(m.group(1), m
 content = re.sub(r'(\s+-\s+)\./([^:\n]+:)', lambda m: _abs(m.group(1), m.group(2), ROOT), content)
 # env_file: .env            →  <showcase>/.env
 content = re.sub(r'(\s+env_file:\s+)\.env(\b)', lambda m: m.group(1) + ROOT + '/.env' + m.group(2), content)
+
+# Per-slug LOCAL_SERVICES_JSON override. The persistent stack hardcodes the
+# roster to langgraph-python's agentic-chat (a fast N=1 local-demo default).
+# An iso stack scoped to a DIFFERENT slug would inherit that value and the
+# harness's railway-services local-injection seam would enumerate the wrong
+# service. Rewrite the line to point at the requested slug. Demos are sourced
+# from the slug's manifest.yaml; if absent or unparseable, fall back to the
+# representative d5 cell ('agentic-chat') so the iso run still targets the
+# right container — just with a narrower demo set than d6 would normally use.
+SLUG = '$slug'
+if SLUG:
+    import json as _json, os as _os
+    demos = []
+    for _mp in (
+        _osp.join(ROOT, 'integrations', SLUG, 'manifest.yaml'),
+        _osp.join(ROOT, 'packages', SLUG, 'manifest.yaml'),
+    ):
+        if _os.path.exists(_mp):
+            with open(_mp) as _mf:
+                _in_demos = False
+                for _line in _mf:
+                    _stripped = _line.rstrip('\n')
+                    if re.match(r'^demos:\s*$', _stripped):
+                        _in_demos = True
+                        continue
+                    if _in_demos:
+                        if re.match(r'^\S', _stripped):
+                            break
+                        _m = re.match(r'^\s+-\s+id:\s*[\"\']?([A-Za-z0-9_\-]+)', _stripped)
+                        if _m:
+                            demos.append(_m.group(1))
+            break
+    if not demos:
+        demos = ['agentic-chat']
+    _override = _json.dumps([{
+        'name': f'showcase-{SLUG}',
+        'publicUrl': f'http://{SLUG}:10000',
+        'demos': demos,
+    }])
+    # Replace the entire folded-scalar LOCAL_SERVICES_JSON=[...] payload line.
+    # docker-compose.local.yml writes it as:  '        LOCAL_SERVICES_JSON=[...]'
+    content = re.sub(
+        r'(^\s+)LOCAL_SERVICES_JSON=\[[^\n]*\]',
+        lambda m: m.group(1) + 'LOCAL_SERVICES_JSON=' + _override,
+        content,
+        flags=re.MULTILINE,
+    )
 
 with open('$tmp_compose', 'w') as f:
     f.write(content)

--- a/showcase/scripts/cli/_common.sh
+++ b/showcase/scripts/cli/_common.sh
@@ -629,8 +629,11 @@ with open('$tmp_ports', 'w') as f:
 
   # Generate offset compose file in the temp dir
   local tmp_compose="$ISOLATE_TMPDIR/docker-compose.local.yml"
-  python3 -c "
-import re
+  # Pass slug via env var instead of bash-interpolating into the python
+  # source — a slug containing a single quote would break the python literal.
+  # Internal-tool risk only (slug is developer-typed), but cheap to harden.
+  SHOWCASE_ISO_SLUG="$slug" python3 -c "
+import os, re
 with open('$COMPOSE_FILE') as f:
     content = f.read()
 
@@ -679,9 +682,10 @@ content = re.sub(r'(\s+env_file:\s+)\.env(\b)', lambda m: m.group(1) + ROOT + '/
 # from the slug's manifest.yaml; if absent or unparseable, fall back to the
 # representative d5 cell ('agentic-chat') so the iso run still targets the
 # right container — just with a narrower demo set than d6 would normally use.
-SLUG = '$slug'
+SLUG = os.environ.get('SHOWCASE_ISO_SLUG', '')
 if SLUG:
-    import json as _json, os as _os
+    import json as _json
+    _os = os
     demos = []
     for _mp in (
         _osp.join(ROOT, 'integrations', SLUG, 'manifest.yaml'),

--- a/showcase/scripts/cli/cmd-test.sh
+++ b/showcase/scripts/cli/cmd-test.sh
@@ -122,7 +122,7 @@ cmd_test() {
   # reaped.
   if $use_isolate; then
     trap restore_isolation EXIT
-    apply_isolation "${isolate_name:-}"
+    apply_isolation "${isolate_name:-}" "$slug"
     if $ISOLATE_KEEP; then
       info "--keep set: isolated stack will be left standing after the run (teardown command printed at exit)"
     fi


### PR DESCRIPTION
## Summary
- `showcase/docker-compose.local.yml:262` hardcodes `LOCAL_SERVICES_JSON` to `showcase-langgraph-python` (intentional N=1 demo default).
- `showcase/bin/showcase test <slug> --d6 --isolate` was inheriting that value verbatim into the iso1 stack, so the iso1 control-plane discovered `showcase-langgraph-python` instead of `showcase-<requested-slug>`.
- Result: iso1 probes targeted the wrong service. Visible in iso1 harness logs as `discovery.railway-services.local-injection count:1 names:["showcase-langgraph-python"]` regardless of CLI arg.
- This PR teaches the iso1 compose generator (`apply_isolation` in `showcase/scripts/cli/_common.sh`) to inject a per-slug `LOCAL_SERVICES_JSON` override built from the slug's manifest.yaml demos list. Fallback to `["agentic-chat"]` if manifest absent.

## Scope
Two files, ~55 LOC added: `showcase/scripts/cli/cmd-test.sh` (pass slug arg), `showcase/scripts/cli/_common.sh` (inject regex sub in python rewriter). Bash + embedded python only; no TypeScript changed.

## Verification
- **Local `--isolate` discovery confirmed correct:** `showcase/bin/showcase test ms-agent-python --d6 --isolate` — iso1 harness log now shows `discovery.railway-services.local-injection names:["showcase-ms-agent-python"]` (was `showcase-langgraph-python` before this PR).
- Persistent stack default behavior (langgraph-python N=1) preserved via fallback when no slug arg provided.
- **Heredoc hardening scope:** commit edc77f809 moves `$slug` from bash-interpolation into the python rewriter to an env var. This is a slug-only carve-out — `$slug` is the only value that originates from the CLI arg path. The other bash-interpolated `$VAR`s embedded in the heredoc (`$PORTS_FILE`, `$COMPOSE_FILE`, `$name`, `$SHOWCASE_ROOT`, `$ISOLATE_PORT_OFFSET`) remain script-internal: each is constructed inside `_common.sh` from validated sources (manifest reads, computed offsets, fixed roots), not from user input, and CR Round 1 + Round 2 slot 5 both verified they are not user-tainted. A broader env-var-pass-all-vars refactor would be a separate concern and is out of scope for this PR.

## Out of scope
- Worker heartbeat clock-skew issue (`fleet.health.worker-unhealthy lastHeartbeatAt N min stale`) is a separate bug; not touched.
- `buildLocalServicesJson` in `cli/control-plane-run.ts` has a similar comment-vs-code disagreement (JSDoc says "filter", code returns env verbatim) — flagged but not auto-fixed, as iso1 override is the correct insertion point.
- Generalized env-var-pass for all heredoc-embedded $VARs (see Verification) — separate refactor concern.