### PR TITLE
fix(react-core): add dark mode styling for default tool rendering

### DIFF
--- a/examples/v2/react/storybook/stories/CopilotChatMessageView.stories.tsx
+++ b/examples/v2/react/storybook/stories/CopilotChatMessageView.stories.tsx
@@ -641,3 +641,91 @@ export function WithToolCallsExample() {
     );
   },
 };
+
+export const DefaultToolRendererDarkTheme: Story = {
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        story:
+          "Shows the built-in zero-config tool-call fallback in a dark CopilotKit surface.",
+      },
+    },
+  },
+  decorators: [
+    (Story, context) => {
+      const isDarkTheme = context.globals.theme === "dark";
+
+      return (
+        <div
+          style={{
+            minHeight: "100vh",
+            margin: 0,
+            padding: "32px",
+            overflow: "auto",
+            background: isDarkTheme ? "#212121" : "#ffffff",
+          }}
+        >
+          <Story />
+        </div>
+      );
+    },
+  ],
+  render: () => {
+    const messages = [
+      {
+        id: "user-default-tools",
+        content:
+          "Find the latest CopilotKit release notes and check npm status.",
+        timestamp: new Date(),
+        role: "user" as const,
+      },
+      {
+        id: "assistant-default-tools",
+        content: "I'll check both sources and summarize what I find.",
+        timestamp: new Date(),
+        role: "assistant" as const,
+        toolCalls: [
+          {
+            id: "release-notes-tool",
+            type: "function" as const,
+            function: {
+              name: "searchReleaseNotes",
+              arguments: JSON.stringify({
+                query: "CopilotKit release notes",
+                includePrereleases: false,
+              }),
+            },
+          },
+          {
+            id: "npm-status-tool",
+            type: "function" as const,
+            function: {
+              name: "checkPackageStatus",
+              arguments: JSON.stringify({
+                packageName: "@copilotkit/react-core",
+              }),
+            },
+          },
+        ],
+      },
+      {
+        id: "tool-release-notes",
+        role: "tool" as const,
+        toolCallId: "release-notes-tool",
+        content:
+          "Found release notes for the current React core package and related runtime packages.",
+      },
+    ];
+
+    return (
+      <CopilotKitProvider runtimeUrl="https://copilotkit.ai">
+        <CopilotChatConfigurationProvider threadId={STORYBOOK_THREAD_ID}>
+          <div style={{ width: "min(760px, 100%)", margin: "0 auto" }}>
+            <CopilotChatMessageView messages={messages} />
+          </div>
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>
+    );
+  },
+};

--- a/packages/react-core/src/v2/hooks/__tests__/use-default-render-tool.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-default-render-tool.test.tsx
@@ -178,6 +178,42 @@ describe("useDefaultRenderTool", () => {
     expect(screen.getByText("done")).toBeDefined();
   });
 
+  it("default renderer includes dark-theme-aware classes", () => {
+    render(
+      <DefaultToolCallRenderer
+        name="searchDocs"
+        toolCallId="tc-default-dark-theme"
+        parameters={{ query: "copilot" }}
+        status="complete"
+        result="done"
+      />,
+    );
+
+    const wrapper = screen.getByTestId("copilot-tool-render");
+    const card = wrapper.firstElementChild as HTMLElement | null;
+    expect(card).not.toBeNull();
+    expect(card!.className).toContain("cpk:dark:border-zinc-800/60");
+    expect(card!.className).toContain("cpk:dark:bg-zinc-900/50");
+
+    const name = screen.getByTestId("copilot-tool-render-name");
+    expect(name.className).toContain("cpk:dark:text-zinc-100");
+
+    const status = screen.getByTestId("copilot-tool-render-status");
+    expect(status.className).toContain("cpk:dark:bg-emerald-500/15");
+    expect(status.className).toContain("cpk:dark:text-emerald-400");
+
+    const headerButton = name.closest("button");
+    expect(headerButton).not.toBeNull();
+    fireEvent.click(headerButton!);
+
+    const details = wrapper.querySelectorAll("pre");
+    expect(details.length).toBeGreaterThan(0);
+    for (const detail of details) {
+      expect(detail.className).toContain("cpk:dark:bg-zinc-800/60");
+      expect(detail.className).toContain("cpk:dark:text-zinc-200");
+    }
+  });
+
   it("default renderer emits stable copilot-tool-render testid and metadata attrs", () => {
     render(
       <DefaultToolCallRenderer

--- a/packages/react-core/src/v2/hooks/use-default-render-tool.tsx
+++ b/packages/react-core/src/v2/hooks/use-default-render-tool.tsx
@@ -190,9 +190,16 @@ export function DefaultToolCallRenderer({
   const isComplete = status === "complete";
 
   const statusLabel = isActive ? "Running" : isComplete ? "Done" : status;
-  const dotColor = isActive ? "#f59e0b" : isComplete ? "#10b981" : "#a1a1aa";
-  const badgeBg = isActive ? "#fef3c7" : isComplete ? "#d1fae5" : "#f4f4f5";
-  const badgeColor = isActive ? "#92400e" : isComplete ? "#065f46" : "#3f3f46";
+  const dotClassName = isActive
+    ? "cpk:bg-amber-500"
+    : isComplete
+      ? "cpk:bg-emerald-500"
+      : "cpk:bg-zinc-400";
+  const badgeClassName = isActive
+    ? "cpk:bg-amber-100 cpk:text-amber-800 cpk:dark:bg-amber-500/15 cpk:dark:text-amber-400"
+    : isComplete
+      ? "cpk:bg-emerald-100 cpk:text-emerald-800 cpk:dark:bg-emerald-500/15 cpk:dark:text-emerald-400"
+      : "cpk:bg-zinc-100 cpk:text-zinc-800 cpk:dark:bg-zinc-700/40 cpk:dark:text-zinc-300";
 
   return (
     <div
@@ -202,19 +209,9 @@ export function DefaultToolCallRenderer({
       data-status={status}
       data-args={safeStringifyForAttr(parameters)}
       data-result={safeStringifyForAttr(result)}
-      style={{
-        marginTop: "8px",
-        paddingBottom: "8px",
-      }}
+      className="cpk:mt-2 cpk:pb-2"
     >
-      <div
-        style={{
-          borderRadius: "12px",
-          border: "1px solid #e4e4e7",
-          backgroundColor: "#fafafa",
-          padding: "14px 16px",
-        }}
-      >
+      <div className="cpk:rounded-xl cpk:border cpk:border-zinc-200/60 cpk:bg-white/70 cpk:p-4 cpk:shadow-sm cpk:backdrop-blur cpk:dark:border-zinc-800/60 cpk:dark:bg-zinc-900/50">
         {/* Header row — always visible. A real <button> with aria-expanded
             and reset styles so it visually matches the previous <div> but
             is keyboard-accessible (Enter/Space toggle natively). */}
@@ -222,40 +219,16 @@ export function DefaultToolCallRenderer({
           type="button"
           aria-expanded={isExpanded}
           onClick={() => setIsExpanded(!isExpanded)}
+          className="cpk:flex cpk:w-full cpk:cursor-pointer cpk:select-none cpk:items-center cpk:justify-between cpk:gap-2.5 cpk:border-none cpk:bg-transparent cpk:p-0 cpk:m-0 cpk:text-left cpk:text-inherit"
           style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            gap: "10px",
-            cursor: "pointer",
-            userSelect: "none",
-            width: "100%",
-            border: "none",
-            padding: 0,
-            margin: 0,
-            background: "transparent",
-            textAlign: "left",
             font: "inherit",
-            color: "inherit",
           }}
         >
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "8px",
-              minWidth: 0,
-            }}
-          >
+          <div className="cpk:flex cpk:min-w-0 cpk:items-center cpk:gap-2">
             <svg
-              style={{
-                height: "14px",
-                width: "14px",
-                color: "#71717a",
-                transition: "transform 0.15s",
-                transform: isExpanded ? "rotate(90deg)" : "rotate(0deg)",
-                flexShrink: 0,
-              }}
+              className={`cpk:h-3.5 cpk:w-3.5 cpk:flex-shrink-0 cpk:text-zinc-500 cpk:transition-transform cpk:dark:text-zinc-400 ${
+                isExpanded ? "cpk:rotate-90" : ""
+              }`}
               fill="none"
               viewBox="0 0 24 24"
               strokeWidth={2}
@@ -268,25 +241,11 @@ export function DefaultToolCallRenderer({
               />
             </svg>
             <span
-              style={{
-                display: "inline-block",
-                height: "8px",
-                width: "8px",
-                borderRadius: "50%",
-                backgroundColor: dotColor,
-                flexShrink: 0,
-              }}
+              className={`cpk:inline-block cpk:h-2 cpk:w-2 cpk:flex-shrink-0 cpk:rounded-full ${dotClassName}`}
             />
             <span
               data-testid="copilot-tool-render-name"
-              style={{
-                fontSize: "13px",
-                fontWeight: 600,
-                color: "#18181b",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
+              className="cpk:truncate cpk:text-[13px] cpk:font-semibold cpk:text-zinc-900 cpk:dark:text-zinc-100"
             >
               {name}
             </span>
@@ -294,17 +253,7 @@ export function DefaultToolCallRenderer({
 
           <span
             data-testid="copilot-tool-render-status"
-            style={{
-              display: "inline-flex",
-              alignItems: "center",
-              borderRadius: "9999px",
-              padding: "2px 8px",
-              fontSize: "11px",
-              fontWeight: 500,
-              backgroundColor: badgeBg,
-              color: badgeColor,
-              flexShrink: 0,
-            }}
+            className={`cpk:inline-flex cpk:flex-shrink-0 cpk:items-center cpk:rounded-full cpk:px-2 cpk:py-0.5 cpk:text-[11px] cpk:font-medium ${badgeClassName}`}
           >
             {statusLabel}
           </span>
@@ -312,64 +261,22 @@ export function DefaultToolCallRenderer({
 
         {/* Expandable details */}
         {isExpanded && (
-          <div style={{ marginTop: "12px", display: "grid", gap: "12px" }}>
+          <div className="cpk:mt-3 cpk:grid cpk:gap-3">
             <div>
-              <div
-                style={{
-                  fontSize: "10px",
-                  textTransform: "uppercase",
-                  letterSpacing: "0.05em",
-                  color: "#71717a",
-                }}
-              >
+              <div className="cpk:text-[10px] cpk:uppercase cpk:text-zinc-500 cpk:dark:text-zinc-400">
                 Arguments
               </div>
-              <pre
-                style={{
-                  marginTop: "6px",
-                  maxHeight: "200px",
-                  overflow: "auto",
-                  borderRadius: "6px",
-                  backgroundColor: "#f4f4f5",
-                  padding: "10px",
-                  fontSize: "11px",
-                  lineHeight: 1.6,
-                  color: "#27272a",
-                  whiteSpace: "pre-wrap",
-                  wordBreak: "break-word",
-                }}
-              >
+              <pre className="cpk:mt-1.5 cpk:max-h-[200px] cpk:overflow-auto cpk:rounded-md cpk:bg-zinc-100 cpk:p-2.5 cpk:text-[11px] cpk:leading-relaxed cpk:text-zinc-800 cpk:whitespace-pre-wrap cpk:break-words cpk:dark:bg-zinc-800/60 cpk:dark:text-zinc-200">
                 {safeStringifyForPre(parameters ?? {})}
               </pre>
             </div>
 
             {result !== undefined && (
               <div>
-                <div
-                  style={{
-                    fontSize: "10px",
-                    textTransform: "uppercase",
-                    letterSpacing: "0.05em",
-                    color: "#71717a",
-                  }}
-                >
+                <div className="cpk:text-[10px] cpk:uppercase cpk:text-zinc-500 cpk:dark:text-zinc-400">
                   Result
                 </div>
-                <pre
-                  style={{
-                    marginTop: "6px",
-                    maxHeight: "200px",
-                    overflow: "auto",
-                    borderRadius: "6px",
-                    backgroundColor: "#f4f4f5",
-                    padding: "10px",
-                    fontSize: "11px",
-                    lineHeight: 1.6,
-                    color: "#27272a",
-                    whiteSpace: "pre-wrap",
-                    wordBreak: "break-word",
-                  }}
-                >
+                <pre className="cpk:mt-1.5 cpk:max-h-[200px] cpk:overflow-auto cpk:rounded-md cpk:bg-zinc-100 cpk:p-2.5 cpk:text-[11px] cpk:leading-relaxed cpk:text-zinc-800 cpk:whitespace-pre-wrap cpk:break-words cpk:dark:bg-zinc-800/60 cpk:dark:text-zinc-200">
                   {typeof result === "string"
                     ? result
                     : safeStringifyForPre(result)}


### PR DESCRIPTION
## Summary
- Update the default tool-call renderer to use dark-theme-aware classes for the card, header, status badge, and detail panels
- Add coverage for the dark theme styling path in unit tests
- Add a Storybook example that demonstrates the default tool renderer on a dark CopilotKit surface

## Testing
- Added unit tests for the renderer’s dark-theme class output and expanded details state
- Not run (not requested)