### PR TITLE
fix(showcase/harness): register /webhooks/deploy on CP path + fail-loud on missing SHARED_SECRET

### DIFF
--- a/showcase/harness/src/events/event-bus.ts
+++ b/showcase/harness/src/events/event-bus.ts
@@ -157,6 +157,14 @@ export interface BusEvents {
    */
   "internal.backup.init-failed": { err: string; bucket: string };
   /**
+   * Emitted by `subscribeDeployResults` when `writer.write(...)` rejects
+   * for a deploy.result-derived ProbeResult. Mirrors other `*.failed`
+   * surfaces (probes.reload.failed / rules.reload.failed / writer.failed)
+   * so alerting subscribers can observe deploy-writer failures as a
+   * first-class bus event rather than only via the error log line.
+   */
+  "deploy.writer.failed": { err: string };
+  /**
    * Emitted by the alert engine when a rule's `suppress.when` expression
    * throws at evaluation time (R24 bucket-a#7). Fail-closed semantics:
    * the triggering alert is suppressed on eval error to avoid spamming

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -1589,10 +1589,10 @@ describe("orchestrator webhook secrets fail-loud in production (R5-G4 D5)", () =
     try {
       await expect(
         boot({ configDir: tempDir, port, bootstrapWindowMs: 0 }),
-      // B2 fix tightened the predicate (now fails loud in any deployable
-      // mode, not just NODE_ENV='production') — the error message changed
-      // accordingly. Match the message common to both the old and new
-      // throws: FATAL-CONFIG + SHARED_SECRET.
+        // B2 fix tightened the predicate (now fails loud in any deployable
+        // mode, not just NODE_ENV='production') — the error message changed
+        // accordingly. Match the message common to both the old and new
+        // throws: FATAL-CONFIG + SHARED_SECRET.
       ).rejects.toThrow(/FATAL-CONFIG.*SHARED_SECRET/);
     } finally {
       if (prevNodeEnv === undefined) delete process.env.NODE_ENV;

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -5943,3 +5943,199 @@ describe("orchestrator R1-F1: deploy.result subscriber on CP path", () => {
     expect(after - before).toBe(1);
   });
 });
+
+/**
+ * R2-F1: `runControlPlane` must capture the unsub returned by
+ * `subscribeDeployResults` so `stop()` (and bind-failure teardown) release
+ * the listener. Pre-fix the CP path discarded the unsub — a repeated
+ * boot/stop cycle leaked the deploy.result handler against the stale
+ * writer, and post-stop bus.emit("deploy.result", ...) still routed
+ * through `writer.write(...)`.
+ *
+ * Assertion shape: bind the CP, capture writes (count=0), emit one
+ * deploy.result (writes=1), call handle.stop(), emit another
+ * deploy.result, assert writes stayed at 1 (the listener detached).
+ */
+describe("orchestrator R2-F1: CP deploy.result unsub release on stop", () => {
+  let port = 0;
+  let alertsDir: string;
+  let cpStopFn: (() => Promise<void>) | null = null;
+  const writes: ProbeResult[] = [];
+
+  beforeEach(async () => {
+    port = await pickPort();
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "harness-r2f1-"));
+    alertsDir = path.join(root, "alerts");
+    await fs.mkdir(alertsDir, { recursive: true });
+    writes.length = 0;
+  });
+
+  afterEach(async () => {
+    if (cpStopFn) {
+      await cpStopFn().catch(() => undefined);
+      cpStopFn = null;
+    }
+    await fs.rm(alertsDir, { recursive: true, force: true });
+    vi.resetModules();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.doUnmock("@hono/node-server");
+    vi.doUnmock("./storage/pb-client.js");
+    vi.doUnmock("./writers/status-writer.js");
+  });
+
+  async function mountMocks(): Promise<void> {
+    vi.resetModules();
+    vi.doMock("@hono/node-server", async () => {
+      const actual =
+        await vi.importActual<typeof import("@hono/node-server")>(
+          "@hono/node-server",
+        );
+      return { ...actual };
+    });
+    vi.doMock("./storage/pb-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./storage/pb-client.js")
+      >("./storage/pb-client.js");
+      return {
+        ...actual,
+        createPbClient: () => ({
+          health: async () => true,
+          getOne: async () => null,
+          getFirst: async () => null,
+          getList: async () => ({ items: [] }),
+        }),
+      };
+    });
+    vi.doMock("./writers/status-writer.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./writers/status-writer.js")
+      >("./writers/status-writer.js");
+      return {
+        ...actual,
+        createStatusWriter: (): StatusWriter => ({
+          write: async (result: ProbeResult) => {
+            writes.push(result);
+            return {
+              previousState: null,
+              newState: "green",
+              transition: "first",
+              firstFailureAt: null,
+              failCount: 0,
+              persisted: true,
+            };
+          },
+          writeOverlay: async (): Promise<OverlayWriteOutcome> => ({
+            applied: false,
+            state: null,
+            historyPersisted: false,
+          }),
+        }),
+      };
+    });
+  }
+
+  function emitDeployResult(bus: ReturnType<typeof createEventBus>): void {
+    bus.emit("deploy.result", {
+      runId: "r2f1-test-runid",
+      runUrl: "https://example.invalid/runs/r2f1",
+      services: ["showcase-shell-docs"],
+      failed: [],
+      succeeded: ["showcase-shell-docs"],
+      cancelled: false,
+      gateSkipped: false,
+      gateReason: undefined,
+      buildRunId: undefined,
+      buildRunUrl: undefined,
+    });
+  }
+
+  it("CP stop() releases the deploy.result subscription (post-stop emit does NOT route to writer.write)", async () => {
+    vi.stubEnv("SHARED_SECRET", "r2f1-test-secret");
+    vi.stubEnv("NODE_ENV", "test");
+    await mountMocks();
+    const orchMod = await import("./orchestrator.js");
+    const handle = await orchMod.runControlPlane(
+      { role: "control-plane", poolCount: 1 },
+      { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+    );
+
+    // Pre-stop: a deploy.result emit must reach writer.write (proves the
+    // subscription is live).
+    const baseline = writes.filter((r) => r.key === "deploy:overall").length;
+    emitDeployResult(handle.bus);
+    await Promise.resolve();
+    await Promise.resolve();
+    const afterEmit = writes.filter((r) => r.key === "deploy:overall").length;
+    expect(afterEmit - baseline).toBe(1);
+
+    // Stop the CP — R2-F1: the deploy.result unsub must run.
+    await handle.stop();
+    cpStopFn = null; // already stopped
+
+    // Post-stop: another deploy.result emit must NOT reach writer.write
+    // (pre-fix this would route through the leaked listener against the
+    // stale writer).
+    emitDeployResult(handle.bus);
+    await Promise.resolve();
+    await Promise.resolve();
+    const afterStopEmit = writes.filter(
+      (r) => r.key === "deploy:overall",
+    ).length;
+    expect(afterStopEmit).toBe(afterEmit);
+  });
+});
+
+/**
+ * R2-F2: `subscribeDeployResults` must emit `deploy.writer.failed` (in
+ * addition to logging) when `writer.write(...)` rejects, so alert rules /
+ * metrics subscribers can observe deploy-writer failures as a first-class
+ * bus event rather than only via the error log.
+ *
+ * Drives the helper directly with a real bus + a writer stub whose
+ * `write` rejects, then asserts the new event fired with the err message
+ * payload.
+ */
+describe("orchestrator R2-F2: deploy.writer.failed bus event on write failure", () => {
+  it("emits `deploy.writer.failed` when writer.write rejects", async () => {
+    const orchMod = await import("./orchestrator.js");
+    const bus = createEventBus();
+    const writer: Pick<StatusWriter, "write"> = {
+      write: async () => {
+        throw new Error("pb-blew-up");
+      },
+    };
+    const emits: Array<{ event: string; payload: unknown }> = [];
+    bus.on("deploy.writer.failed", (payload) => {
+      emits.push({ event: "deploy.writer.failed", payload });
+    });
+
+    const unsub = orchMod.subscribeDeployResults(bus, writer);
+
+    bus.emit("deploy.result", {
+      runId: "r2f2-runid",
+      runUrl: "https://example.invalid/runs/r2f2",
+      services: ["showcase-shell-docs"],
+      failed: ["showcase-shell-docs"],
+      succeeded: [],
+      cancelled: false,
+      gateSkipped: false,
+      gateReason: undefined,
+      buildRunId: undefined,
+      buildRunUrl: undefined,
+    });
+
+    // The handler's `.catch` runs on the next microtask after writer.write
+    // rejects — yield a couple of microtasks for the chain to settle.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(emits.length).toBe(1);
+    expect(emits[0].event).toBe("deploy.writer.failed");
+    const payload = emits[0].payload as { err: string };
+    expect(payload.err).toContain("pb-blew-up");
+
+    unsub();
+  });
+});

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -5674,6 +5674,10 @@ describe("orchestrator B2: /webhooks/deploy registered on CP + fail-loud on miss
     await fs.rm(tempDir, { recursive: true, force: true });
     vi.resetModules();
     vi.restoreAllMocks();
+    // CB-1 (Slot 2 #22): tests below use vi.stubEnv instead of direct
+    // process.env mutation so the test runner can guarantee restoration
+    // (restoreAllMocks does NOT undo stubEnv — explicit unstub required).
+    vi.unstubAllEnvs();
     vi.doUnmock("@hono/node-server");
     vi.doUnmock("./storage/pb-client.js");
   });
@@ -5714,104 +5718,60 @@ describe("orchestrator B2: /webhooks/deploy registered on CP + fail-loud on miss
       };
     });
 
-    const prevSecret = process.env.SHARED_SECRET;
-    const prevNodeEnv = process.env.NODE_ENV;
-    process.env.SHARED_SECRET = "b2-test-secret-cp";
-    process.env.NODE_ENV = "test";
-    try {
-      const orchMod = await import("./orchestrator.js");
-      const handle = await orchMod.runControlPlane(
-        { role: "control-plane", poolCount: 1 },
-        { port, configDir: alertsDir, fleetEnumerate: async () => [] },
-      );
-      cpStopFn = handle.stop;
+    vi.stubEnv("SHARED_SECRET", "b2-test-secret-cp");
+    vi.stubEnv("NODE_ENV", "test");
+    const orchMod = await import("./orchestrator.js");
+    const handle = await orchMod.runControlPlane(
+      { role: "control-plane", poolCount: 1 },
+      { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+    );
+    cpStopFn = handle.stop;
 
-      const status = await probeWebhookDeploy(port);
-      // Pre-fix: 404 (route omitted because CP buildServer call dropped
-      // webhookSecrets). Post-fix: 401 (route mounted, HMAC reject path
-      // fires on the unsigned POST).
-      expect(status).toBe(401);
-    } finally {
-      if (prevSecret === undefined) delete process.env.SHARED_SECRET;
-      else process.env.SHARED_SECRET = prevSecret;
-      if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
-      else process.env.NODE_ENV = prevNodeEnv;
-    }
+    const status = await probeWebhookDeploy(port);
+    // Pre-fix: 404 (route omitted because CP buildServer call dropped
+    // webhookSecrets). Post-fix: 401 (route mounted, HMAC reject path
+    // fires on the unsigned POST).
+    expect(status).toBe(401);
   });
 
   it("Test B: worker boot still registers POST /webhooks/deploy when SHARED_SECRET is set (401, regression guard)", async () => {
-    const prevSecret = process.env.SHARED_SECRET;
-    const prevNodeEnv = process.env.NODE_ENV;
-    process.env.SHARED_SECRET = "b2-test-secret-worker";
-    process.env.NODE_ENV = "test";
-    try {
-      const booted = await boot({
-        configDir: tempDir,
-        port,
-        bootstrapWindowMs: 0,
-      });
-      workerStopFn = booted.stop;
+    vi.stubEnv("SHARED_SECRET", "b2-test-secret-worker");
+    vi.stubEnv("NODE_ENV", "test");
+    const booted = await boot({
+      configDir: tempDir,
+      port,
+      bootstrapWindowMs: 0,
+    });
+    workerStopFn = booted.stop;
 
-      const status = await probeWebhookDeploy(port);
-      expect(status).toBe(401);
-    } finally {
-      if (prevSecret === undefined) delete process.env.SHARED_SECRET;
-      else process.env.SHARED_SECRET = prevSecret;
-      if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
-      else process.env.NODE_ENV = prevNodeEnv;
-    }
+    const status = await probeWebhookDeploy(port);
+    expect(status).toBe(401);
   });
 
   it("Test C: boot throws FATAL-CONFIG when SHARED_SECRET unset AND NODE_ENV is non-test (regardless of production)", async () => {
-    const prevSecret = process.env.SHARED_SECRET;
-    const prevPrev = process.env.SHARED_SECRET_PREV;
-    const prevNodeEnv = process.env.NODE_ENV;
-    const prevPbUrl = process.env.POCKETBASE_URL;
-    const prevEscape = process.env.HARNESS_ALLOW_NO_SECRET;
-    delete process.env.SHARED_SECRET;
-    delete process.env.SHARED_SECRET_PREV;
-    delete process.env.HARNESS_ALLOW_NO_SECRET;
+    vi.stubEnv("SHARED_SECRET", undefined as unknown as string);
+    vi.stubEnv("SHARED_SECRET_PREV", undefined as unknown as string);
+    vi.stubEnv("HARNESS_ALLOW_NO_SECRET", undefined as unknown as string);
     // "development" — pre-fix this booted silently (only NODE_ENV ===
     // "production" tripped the guard). Post-fix it must throw.
-    process.env.NODE_ENV = "development";
-    process.env.POCKETBASE_URL = "http://localhost:8090";
-    try {
-      await expect(
-        boot({ configDir: tempDir, port, bootstrapWindowMs: 0 }),
-      ).rejects.toThrow(/SHARED_SECRET/);
-    } finally {
-      if (prevSecret !== undefined) process.env.SHARED_SECRET = prevSecret;
-      if (prevPrev !== undefined) process.env.SHARED_SECRET_PREV = prevPrev;
-      if (prevEscape !== undefined)
-        process.env.HARNESS_ALLOW_NO_SECRET = prevEscape;
-      if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
-      else process.env.NODE_ENV = prevNodeEnv;
-      if (prevPbUrl === undefined) delete process.env.POCKETBASE_URL;
-      else process.env.POCKETBASE_URL = prevPbUrl;
-    }
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("POCKETBASE_URL", "http://localhost:8090");
+    await expect(
+      boot({ configDir: tempDir, port, bootstrapWindowMs: 0 }),
+    ).rejects.toThrow(/SHARED_SECRET/);
   });
 
   it("Test D: boot succeeds when SHARED_SECRET unset AND NODE_ENV=test (test-mode escape hatch)", async () => {
-    const prevSecret = process.env.SHARED_SECRET;
-    const prevPrev = process.env.SHARED_SECRET_PREV;
-    const prevNodeEnv = process.env.NODE_ENV;
-    delete process.env.SHARED_SECRET;
-    delete process.env.SHARED_SECRET_PREV;
-    process.env.NODE_ENV = "test";
-    try {
-      const booted = await boot({
-        configDir: tempDir,
-        port,
-        bootstrapWindowMs: 0,
-      });
-      workerStopFn = booted.stop;
-      expect(booted.port).toBe(port);
-    } finally {
-      if (prevSecret !== undefined) process.env.SHARED_SECRET = prevSecret;
-      if (prevPrev !== undefined) process.env.SHARED_SECRET_PREV = prevPrev;
-      if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
-      else process.env.NODE_ENV = prevNodeEnv;
-    }
+    vi.stubEnv("SHARED_SECRET", undefined as unknown as string);
+    vi.stubEnv("SHARED_SECRET_PREV", undefined as unknown as string);
+    vi.stubEnv("NODE_ENV", "test");
+    const booted = await boot({
+      configDir: tempDir,
+      port,
+      bootstrapWindowMs: 0,
+    });
+    workerStopFn = booted.stop;
+    expect(booted.port).toBe(port);
   });
 });
 

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -5747,3 +5747,173 @@ describe("orchestrator B2: /webhooks/deploy registered on CP + fail-loud on miss
     }
   });
 });
+
+/**
+ * R1-F1 (CR round 1, bucket a): the CP boot path MUST subscribe to
+ * `deploy.result` and route each event through its status writer so a valid
+ * signed POST against the CP host actually writes the deploy-overall
+ * dashboard row.
+ *
+ * Pre-fix: B2 mounted POST /webhooks/deploy on the CP role and the route
+ * emitted on the bus, but only the worker `boot()` path had a
+ * `bus.on("deploy.result", ...)` listener. CP signed POSTs returned 202
+ * (route accepted), but the bus event had no subscriber and the dashboard
+ * row never landed — the original B2 fix mounted the route without
+ * delivering the event.
+ */
+describe("orchestrator R1-F1: deploy.result subscriber on CP path", () => {
+  let port = 0;
+  let alertsDir: string;
+  let cpStopFn: (() => Promise<void>) | null = null;
+  let workerStopFn: (() => Promise<void>) | null = null;
+  let tempDir: string;
+  const writes: ProbeResult[] = [];
+
+  beforeEach(async () => {
+    port = await pickPort();
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "harness-r1f1-"));
+    alertsDir = path.join(root, "alerts");
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "harness-r1f1-worker-"));
+    await fs.mkdir(alertsDir, { recursive: true });
+    writes.length = 0;
+  });
+
+  afterEach(async () => {
+    if (cpStopFn) {
+      await cpStopFn().catch(() => undefined);
+      cpStopFn = null;
+    }
+    if (workerStopFn) {
+      await workerStopFn().catch(() => undefined);
+      workerStopFn = null;
+    }
+    await fs.rm(alertsDir, { recursive: true, force: true });
+    await fs.rm(tempDir, { recursive: true, force: true });
+    vi.resetModules();
+    vi.restoreAllMocks();
+    // R1-F1 tests use vi.stubEnv (modern pattern); restoreAllMocks does
+    // NOT undo stubEnv — explicit unstub.
+    vi.unstubAllEnvs();
+    vi.doUnmock("@hono/node-server");
+    vi.doUnmock("./storage/pb-client.js");
+    vi.doUnmock("./writers/status-writer.js");
+  });
+
+  async function mountCommonMocks(): Promise<void> {
+    vi.resetModules();
+    vi.doMock("@hono/node-server", async () => {
+      const actual =
+        await vi.importActual<typeof import("@hono/node-server")>(
+          "@hono/node-server",
+        );
+      return { ...actual };
+    });
+    vi.doMock("./storage/pb-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./storage/pb-client.js")
+      >("./storage/pb-client.js");
+      return {
+        ...actual,
+        createPbClient: () => ({
+          health: async () => true,
+          getOne: async () => null,
+          getFirst: async () => null,
+          getList: async () => ({ items: [] }),
+        }),
+      };
+    });
+    // Replace `createStatusWriter` with a stub that records every write so
+    // the test can assert the CP's deploy.result subscriber actually
+    // routed the event through `writer.write(...)`.
+    vi.doMock("./writers/status-writer.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./writers/status-writer.js")
+      >("./writers/status-writer.js");
+      return {
+        ...actual,
+        createStatusWriter: (): StatusWriter => ({
+          write: async (result: ProbeResult) => {
+            writes.push(result);
+            return {
+              previousState: null,
+              newState: "green",
+              transition: "first",
+              firstFailureAt: null,
+              failCount: 0,
+              persisted: true,
+            };
+          },
+          writeOverlay: async (): Promise<OverlayWriteOutcome> => ({
+            applied: false,
+            state: null,
+            historyPersisted: false,
+          }),
+        }),
+      };
+    });
+  }
+
+  function emitFakeDeployResult(bus: ReturnType<typeof createEventBus>): void {
+    bus.emit("deploy.result", {
+      runId: "r1f1-test-runid",
+      runUrl: "https://example.invalid/runs/123",
+      services: ["showcase-shell-docs"],
+      failed: [],
+      succeeded: ["showcase-shell-docs"],
+      cancelled: false,
+      gateSkipped: false,
+      gateReason: undefined,
+      buildRunId: undefined,
+      buildRunUrl: undefined,
+    });
+  }
+
+  it("CP boot subscribes deploy.result → writer.write fires with deploy-overall ProbeResult", async () => {
+    vi.stubEnv("SHARED_SECRET", "r1f1-test-secret");
+    vi.stubEnv("NODE_ENV", "test");
+    await mountCommonMocks();
+    const orchMod = await import("./orchestrator.js");
+    const handle = await orchMod.runControlPlane(
+      { role: "control-plane", poolCount: 1 },
+      { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+    );
+    cpStopFn = handle.stop;
+
+    // The subscriber's writer.write is sync from the bus' POV (the
+    // handler awaits internally and fire-and-forgets); the in-memory
+    // stub records synchronously inside the catch-free path, but yield
+    // one microtask to give any chained `.catch()` a chance to settle.
+    const before = writes.filter((r) => r.key === "deploy:overall").length;
+    emitFakeDeployResult(handle.bus);
+    await Promise.resolve();
+    await Promise.resolve();
+    const after = writes.filter((r) => r.key === "deploy:overall").length;
+    // deployEventToProbeResult keys the row "deploy:overall" — the
+    // subscriber must transform the event into a ProbeResult before
+    // writing (not pass the raw DeployResultEvent through).
+    expect(after - before).toBe(1);
+  });
+
+  it("worker boot subscribes deploy.result → writer.write fires (regression guard for helper extraction)", async () => {
+    vi.stubEnv("SHARED_SECRET", "r1f1-worker-secret");
+    vi.stubEnv("NODE_ENV", "test");
+    await mountCommonMocks();
+    const orchMod = await import("./orchestrator.js");
+    const booted = await orchMod.boot({
+      configDir: tempDir,
+      port,
+      bootstrapWindowMs: 0,
+    });
+    workerStopFn = booted.stop;
+
+    // The worker boot writes other keys at startup (browser-pool
+    // healthy/degraded, etc.) — filter to deploy-overall to assert the
+    // deploy.result handler specifically routed through writer.write.
+    const before = writes.filter((r) => r.key === "deploy:overall").length;
+    emitFakeDeployResult(booted.bus);
+    await Promise.resolve();
+    await Promise.resolve();
+    const after = writes.filter((r) => r.key === "deploy:overall").length;
+    expect(after - before).toBe(1);
+  });
+});

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -237,16 +237,83 @@ describe("orchestrator /health wiring (F1.1)", () => {
   it("HF13-A2: boot throws FATAL-CONFIG when NODE_ENV=production and POCKETBASE_URL unset", async () => {
     const prevNodeEnv = process.env.NODE_ENV;
     const prevPbUrl = process.env.POCKETBASE_URL;
+    const prevSecret = process.env.SHARED_SECRET;
     process.env.NODE_ENV = "production";
     delete process.env.POCKETBASE_URL;
+    // R1-F3: hoisted POCKETBASE_URL check now fires BEFORE
+    // loadWebhookSecrets — but production still requires both, so set a
+    // real SHARED_SECRET to ensure the test specifically asserts the
+    // POCKETBASE_URL guard, not the SHARED_SECRET one.
+    process.env.SHARED_SECRET = "hf13-a2-test-secret";
     try {
       await expect(
         boot({ configDir: tempDir, port, bootstrapWindowMs: 0 }),
-      ).rejects.toThrow(/FATAL-CONFIG: POCKETBASE_URL required in production/);
+      ).rejects.toThrow(/FATAL-CONFIG: POCKETBASE_URL/);
     } finally {
       if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
       else process.env.NODE_ENV = prevNodeEnv;
       if (prevPbUrl !== undefined) process.env.POCKETBASE_URL = prevPbUrl;
+      if (prevSecret === undefined) delete process.env.SHARED_SECRET;
+      else process.env.SHARED_SECRET = prevSecret;
+    }
+  });
+
+  // R1-F3: POCKETBASE_URL fail-loud is now symmetric with SHARED_SECRET —
+  // it throws on NODE_ENV=development (pre-fix this only fired on
+  // production), and the new HARNESS_ALLOW_NO_PB_URL=1 escape hatch
+  // permits unset POCKETBASE_URL the same way HARNESS_ALLOW_NO_SECRET=1
+  // does for SHARED_SECRET. Tests both branches.
+  it("R1-F3: boot throws FATAL-CONFIG when POCKETBASE_URL unset AND NODE_ENV is non-test (regardless of production)", async () => {
+    const prevNodeEnv = process.env.NODE_ENV;
+    const prevPbUrl = process.env.POCKETBASE_URL;
+    const prevSecret = process.env.SHARED_SECRET;
+    const prevEscape = process.env.HARNESS_ALLOW_NO_PB_URL;
+    process.env.NODE_ENV = "development";
+    delete process.env.POCKETBASE_URL;
+    delete process.env.HARNESS_ALLOW_NO_PB_URL;
+    process.env.SHARED_SECRET = "r1f3-test-secret";
+    try {
+      await expect(
+        boot({ configDir: tempDir, port, bootstrapWindowMs: 0 }),
+      ).rejects.toThrow(/FATAL-CONFIG: POCKETBASE_URL/);
+    } finally {
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = prevNodeEnv;
+      if (prevPbUrl !== undefined) process.env.POCKETBASE_URL = prevPbUrl;
+      if (prevSecret === undefined) delete process.env.SHARED_SECRET;
+      else process.env.SHARED_SECRET = prevSecret;
+      if (prevEscape !== undefined)
+        process.env.HARNESS_ALLOW_NO_PB_URL = prevEscape;
+    }
+  });
+
+  it("R1-F3: boot succeeds when POCKETBASE_URL unset AND HARNESS_ALLOW_NO_PB_URL=1 (escape hatch)", async () => {
+    const prevNodeEnv = process.env.NODE_ENV;
+    const prevPbUrl = process.env.POCKETBASE_URL;
+    const prevEscape = process.env.HARNESS_ALLOW_NO_PB_URL;
+    const prevSecret = process.env.SHARED_SECRET;
+    process.env.NODE_ENV = "development";
+    delete process.env.POCKETBASE_URL;
+    process.env.HARNESS_ALLOW_NO_PB_URL = "1";
+    // SHARED_SECRET also fail-loud on non-test NODE_ENV; set it so this
+    // test specifically exercises the POCKETBASE_URL escape hatch.
+    process.env.SHARED_SECRET = "r1f3-escape-test-secret";
+    try {
+      const booted = await boot({
+        configDir: tempDir,
+        port,
+        bootstrapWindowMs: 0,
+      });
+      stopFn = booted.stop;
+      expect(booted.port).toBe(port);
+    } finally {
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = prevNodeEnv;
+      if (prevPbUrl !== undefined) process.env.POCKETBASE_URL = prevPbUrl;
+      if (prevEscape === undefined) delete process.env.HARNESS_ALLOW_NO_PB_URL;
+      else process.env.HARNESS_ALLOW_NO_PB_URL = prevEscape;
+      if (prevSecret === undefined) delete process.env.SHARED_SECRET;
+      else process.env.SHARED_SECRET = prevSecret;
     }
   });
 
@@ -5791,8 +5858,7 @@ describe("orchestrator R1-F1: deploy.result subscriber on CP path", () => {
     await fs.rm(tempDir, { recursive: true, force: true });
     vi.resetModules();
     vi.restoreAllMocks();
-    // R1-F1 tests use vi.stubEnv (modern pattern); restoreAllMocks does
-    // NOT undo stubEnv — explicit unstub.
+    // CB-1: restoreAllMocks does NOT undo vi.stubEnv — explicit unstub.
     vi.unstubAllEnvs();
     vi.doUnmock("@hono/node-server");
     vi.doUnmock("./storage/pb-client.js");

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -1589,7 +1589,11 @@ describe("orchestrator webhook secrets fail-loud in production (R5-G4 D5)", () =
     try {
       await expect(
         boot({ configDir: tempDir, port, bootstrapWindowMs: 0 }),
-      ).rejects.toThrow(/FATAL-CONFIG: SHARED_SECRET required in production/);
+      // B2 fix tightened the predicate (now fails loud in any deployable
+      // mode, not just NODE_ENV='production') — the error message changed
+      // accordingly. Match the message common to both the old and new
+      // throws: FATAL-CONFIG + SHARED_SECRET.
+      ).rejects.toThrow(/FATAL-CONFIG.*SHARED_SECRET/);
     } finally {
       if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
       else process.env.NODE_ENV = prevNodeEnv;

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -2188,6 +2188,64 @@ describe("orchestrator OPS_TRIGGER_TOKEN empty-string handling (R2-B.3)", () => 
 });
 
 /**
+ * R3-F1: `OPS_TRIGGER_TOKEN` fail-loud check is hoisted to the TOP of both
+ * boot paths (worker `boot()` and `runControlPlane`) via the exported
+ * helper `loadOpsTriggerToken`, matching `loadWebhookSecrets` /
+ * `loadPocketbaseUrl`. Pre-fix the empty-string check lived AFTER pb /
+ * bus / scheduler / writer allocations, so a typo'd `OPS_TRIGGER_TOKEN=`
+ * allocated expensive resources before throwing.
+ *
+ * Unit-tests the helper directly so the predicate is locked in
+ * independently of either boot path's other config plumbing.
+ */
+describe("orchestrator R3-F1: loadOpsTriggerToken fail-loud helper", () => {
+  let prevToken: string | undefined;
+
+  beforeEach(() => {
+    prevToken = process.env.OPS_TRIGGER_TOKEN;
+  });
+
+  afterEach(() => {
+    if (prevToken === undefined) delete process.env.OPS_TRIGGER_TOKEN;
+    else process.env.OPS_TRIGGER_TOKEN = prevToken;
+  });
+
+  it("returns undefined when OPS_TRIGGER_TOKEN is unset (intentional disable)", async () => {
+    delete process.env.OPS_TRIGGER_TOKEN;
+    const orchMod = await import("./orchestrator.js");
+    expect(orchMod.loadOpsTriggerToken()).toBeUndefined();
+  });
+
+  it('throws fail-loud when OPS_TRIGGER_TOKEN="" (empty string)', async () => {
+    process.env.OPS_TRIGGER_TOKEN = "";
+    const orchMod = await import("./orchestrator.js");
+    expect(() => orchMod.loadOpsTriggerToken()).toThrow(
+      /OPS_TRIGGER_TOKEN.*empty/i,
+    );
+  });
+
+  it("throws fail-loud when OPS_TRIGGER_TOKEN is whitespace-only", async () => {
+    process.env.OPS_TRIGGER_TOKEN = "   ";
+    const orchMod = await import("./orchestrator.js");
+    expect(() => orchMod.loadOpsTriggerToken()).toThrow(
+      /OPS_TRIGGER_TOKEN.*empty/i,
+    );
+  });
+
+  it("returns the trimmed token when set with surrounding whitespace (R3-A.5 contract)", async () => {
+    process.env.OPS_TRIGGER_TOKEN = "  abc  ";
+    const orchMod = await import("./orchestrator.js");
+    expect(orchMod.loadOpsTriggerToken()).toBe("abc");
+  });
+
+  it("returns the verbatim token when set with no whitespace", async () => {
+    process.env.OPS_TRIGGER_TOKEN = "real-token";
+    const orchMod = await import("./orchestrator.js");
+    expect(orchMod.loadOpsTriggerToken()).toBe("real-token");
+  });
+});
+
+/**
  * R2-B.1: cron-rule unregister failure must NOT be fire-and-forget. Pre-fix,
  * `diffCronSchedules` called `scheduler.unregister(id)` without awaiting the
  * returned promise — a rejection became an unhandled rejection AND the
@@ -6135,6 +6193,92 @@ describe("orchestrator R2-F2: deploy.writer.failed bus event on write failure", 
     expect(emits[0].event).toBe("deploy.writer.failed");
     const payload = emits[0].payload as { err: string };
     expect(payload.err).toContain("pb-blew-up");
+
+    unsub();
+  });
+});
+
+/**
+ * R3-F2: `subscribeDeployResults` must ALSO emit `deploy.writer.failed`
+ * (and log) when the synchronous mapping helper `deployEventToProbeResult`
+ * THROWS — not just when the async `writer.write(...)` rejects. Pre-fix
+ * the `.catch` only covered the write promise, so a sync throw inside
+ * the mapping (malformed event, unexpected type drift) bypassed both the
+ * log and the bus emit, and the failure was effectively swallowed by
+ * the bus handler boundary.
+ */
+describe("orchestrator R3-F2: deploy.writer.failed on subscribeDeployResults sync throw", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("./probes/deploy-result.js");
+  });
+
+  it("emits `deploy.writer.failed` when deployEventToProbeResult throws synchronously", async () => {
+    vi.resetModules();
+    vi.doMock("./probes/deploy-result.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./probes/deploy-result.js")
+      >("./probes/deploy-result.js");
+      return {
+        ...actual,
+        deployEventToProbeResult: () => {
+          throw new Error("mapping-blew-up-sync");
+        },
+      };
+    });
+
+    const orchMod = await import("./orchestrator.js");
+    const busMod = await import("./events/event-bus.js");
+    const bus = busMod.createEventBus();
+    // Writer must NOT be called on a sync mapping throw — assert it stays
+    // untouched so the test pins down "throw fires before write".
+    let writeCalls = 0;
+    const writer: Pick<StatusWriter, "write"> = {
+      write: async () => {
+        writeCalls += 1;
+        return {
+          previousState: null,
+          newState: "green",
+          transition: "first",
+          firstFailureAt: null,
+          failCount: 0,
+          persisted: true,
+        };
+      },
+    };
+    const emits: Array<{ event: string; payload: unknown }> = [];
+    bus.on("deploy.writer.failed", (payload) => {
+      emits.push({ event: "deploy.writer.failed", payload });
+    });
+
+    const unsub = orchMod.subscribeDeployResults(bus, writer);
+
+    // Emit must NOT throw out of the bus handler boundary — the helper
+    // catches synchronously and converts to a bus emit.
+    expect(() => {
+      bus.emit("deploy.result", {
+        runId: "r3f2-runid",
+        runUrl: "https://example.invalid/runs/r3f2",
+        services: ["showcase-shell-docs"],
+        failed: [],
+        succeeded: ["showcase-shell-docs"],
+        cancelled: false,
+        gateSkipped: false,
+        gateReason: undefined,
+        buildRunId: undefined,
+        buildRunUrl: undefined,
+      });
+    }).not.toThrow();
+
+    // Sync throw — no microtask wait needed, but yield one for symmetry
+    // with the R2-F2 assertion shape.
+    await Promise.resolve();
+
+    expect(writeCalls).toBe(0);
+    expect(emits.length).toBe(1);
+    expect(emits[0].event).toBe("deploy.writer.failed");
+    const payload = emits[0].payload as { err: string };
+    expect(payload.err).toContain("mapping-blew-up-sync");
 
     unsub();
   });

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -5547,3 +5547,199 @@ describe("runControlPlane registers 4 producer schedules on the scheduler", () =
     }
   });
 });
+
+/**
+ * B2 fix: `POST /webhooks/deploy` must be registered on BOTH boot paths
+ * (worker via boot(), control-plane via runControlPlane), AND the
+ * FATAL-CONFIG guard on missing SHARED_SECRET must fire regardless of
+ * NODE_ENV (gated only by an explicit test/escape-hatch).
+ *
+ * Pre-fix: the CP path's buildServer call omitted webhookSecrets/metrics
+ * entirely, so the server.ts gate (deps.webhookSecrets?.length > 0)
+ * silently skipped route registration — every notify-harness POST from
+ * the Showcase: Verify Deploy workflow returned 404 on the public host.
+ *
+ * Test plan (red-green-refactor):
+ *   - Test A: CP boot with SHARED_SECRET set → POST /webhooks/deploy
+ *     without HMAC headers returns 401 (route IS mounted; the route's own
+ *     HMAC reject path fires). Pre-fix this returned 404.
+ *   - Test B: worker boot with SHARED_SECRET set → same 401 probe
+ *     (regression guard so the worker path keeps working).
+ *   - Test C: SHARED_SECRET unset + NODE_ENV != "test" / no escape hatch
+ *     → boot throws FATAL-CONFIG mentioning SHARED_SECRET. Pre-fix this
+ *     silently booted unless NODE_ENV === "production".
+ *   - Test D: SHARED_SECRET unset + NODE_ENV === "test" → boot succeeds
+ *     (test-mode escape hatch preserved).
+ */
+describe("orchestrator B2: /webhooks/deploy registered on CP + fail-loud on missing SHARED_SECRET", () => {
+  let tempDir: string;
+  let alertsDir: string;
+  let probesDir: string;
+  let port = 0;
+  let cpStopFn: (() => Promise<void>) | null = null;
+  let workerStopFn: (() => Promise<void>) | null = null;
+
+  beforeEach(async () => {
+    port = await pickPort();
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "harness-cp-b2-"));
+    alertsDir = path.join(root, "alerts");
+    probesDir = path.join(root, "probes");
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "harness-worker-b2-"));
+    await fs.mkdir(alertsDir, { recursive: true });
+    await fs.mkdir(probesDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (cpStopFn) {
+      await cpStopFn().catch(() => undefined);
+      cpStopFn = null;
+    }
+    if (workerStopFn) {
+      await workerStopFn().catch(() => undefined);
+      workerStopFn = null;
+    }
+    await fs.rm(alertsDir, { recursive: true, force: true });
+    await fs.rm(probesDir, { recursive: true, force: true });
+    await fs.rm(tempDir, { recursive: true, force: true });
+    vi.resetModules();
+    vi.restoreAllMocks();
+    vi.doUnmock("@hono/node-server");
+    vi.doUnmock("./storage/pb-client.js");
+  });
+
+  // Helper: probe POST /webhooks/deploy with no HMAC headers. Expected
+  // outcomes: 404 when the route is NOT mounted (pre-fix CP), 401 when
+  // it IS mounted (the route's HMAC reject path rejects unsigned bodies).
+  async function probeWebhookDeploy(p: number): Promise<number> {
+    const res = await fetch(`http://127.0.0.1:${p}/webhooks/deploy`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    return res.status;
+  }
+
+  it("Test A: CP boot registers POST /webhooks/deploy when SHARED_SECRET is set (401, not 404)", async () => {
+    vi.resetModules();
+    vi.doMock("@hono/node-server", async () => {
+      const actual =
+        await vi.importActual<typeof import("@hono/node-server")>(
+          "@hono/node-server",
+        );
+      return { ...actual };
+    });
+    vi.doMock("./storage/pb-client.js", async () => {
+      const actual = await vi.importActual<
+        typeof import("./storage/pb-client.js")
+      >("./storage/pb-client.js");
+      return {
+        ...actual,
+        createPbClient: () => ({
+          health: async () => true,
+          getOne: async () => null,
+          getFirst: async () => null,
+          getList: async () => ({ items: [] }),
+        }),
+      };
+    });
+
+    const prevSecret = process.env.SHARED_SECRET;
+    const prevNodeEnv = process.env.NODE_ENV;
+    process.env.SHARED_SECRET = "b2-test-secret-cp";
+    process.env.NODE_ENV = "test";
+    try {
+      const orchMod = await import("./orchestrator.js");
+      const handle = await orchMod.runControlPlane(
+        { role: "control-plane", poolCount: 1 },
+        { port, configDir: alertsDir, fleetEnumerate: async () => [] },
+      );
+      cpStopFn = handle.stop;
+
+      const status = await probeWebhookDeploy(port);
+      // Pre-fix: 404 (route omitted because CP buildServer call dropped
+      // webhookSecrets). Post-fix: 401 (route mounted, HMAC reject path
+      // fires on the unsigned POST).
+      expect(status).toBe(401);
+    } finally {
+      if (prevSecret === undefined) delete process.env.SHARED_SECRET;
+      else process.env.SHARED_SECRET = prevSecret;
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = prevNodeEnv;
+    }
+  });
+
+  it("Test B: worker boot still registers POST /webhooks/deploy when SHARED_SECRET is set (401, regression guard)", async () => {
+    const prevSecret = process.env.SHARED_SECRET;
+    const prevNodeEnv = process.env.NODE_ENV;
+    process.env.SHARED_SECRET = "b2-test-secret-worker";
+    process.env.NODE_ENV = "test";
+    try {
+      const booted = await boot({
+        configDir: tempDir,
+        port,
+        bootstrapWindowMs: 0,
+      });
+      workerStopFn = booted.stop;
+
+      const status = await probeWebhookDeploy(port);
+      expect(status).toBe(401);
+    } finally {
+      if (prevSecret === undefined) delete process.env.SHARED_SECRET;
+      else process.env.SHARED_SECRET = prevSecret;
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = prevNodeEnv;
+    }
+  });
+
+  it("Test C: boot throws FATAL-CONFIG when SHARED_SECRET unset AND NODE_ENV is non-test (regardless of production)", async () => {
+    const prevSecret = process.env.SHARED_SECRET;
+    const prevPrev = process.env.SHARED_SECRET_PREV;
+    const prevNodeEnv = process.env.NODE_ENV;
+    const prevPbUrl = process.env.POCKETBASE_URL;
+    const prevEscape = process.env.HARNESS_ALLOW_NO_SECRET;
+    delete process.env.SHARED_SECRET;
+    delete process.env.SHARED_SECRET_PREV;
+    delete process.env.HARNESS_ALLOW_NO_SECRET;
+    // "development" — pre-fix this booted silently (only NODE_ENV ===
+    // "production" tripped the guard). Post-fix it must throw.
+    process.env.NODE_ENV = "development";
+    process.env.POCKETBASE_URL = "http://localhost:8090";
+    try {
+      await expect(
+        boot({ configDir: tempDir, port, bootstrapWindowMs: 0 }),
+      ).rejects.toThrow(/SHARED_SECRET/);
+    } finally {
+      if (prevSecret !== undefined) process.env.SHARED_SECRET = prevSecret;
+      if (prevPrev !== undefined) process.env.SHARED_SECRET_PREV = prevPrev;
+      if (prevEscape !== undefined)
+        process.env.HARNESS_ALLOW_NO_SECRET = prevEscape;
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = prevNodeEnv;
+      if (prevPbUrl === undefined) delete process.env.POCKETBASE_URL;
+      else process.env.POCKETBASE_URL = prevPbUrl;
+    }
+  });
+
+  it("Test D: boot succeeds when SHARED_SECRET unset AND NODE_ENV=test (test-mode escape hatch)", async () => {
+    const prevSecret = process.env.SHARED_SECRET;
+    const prevPrev = process.env.SHARED_SECRET_PREV;
+    const prevNodeEnv = process.env.NODE_ENV;
+    delete process.env.SHARED_SECRET;
+    delete process.env.SHARED_SECRET_PREV;
+    process.env.NODE_ENV = "test";
+    try {
+      const booted = await boot({
+        configDir: tempDir,
+        port,
+        bootstrapWindowMs: 0,
+      });
+      workerStopFn = booted.stop;
+      expect(booted.port).toBe(port);
+    } finally {
+      if (prevSecret !== undefined) process.env.SHARED_SECRET = prevSecret;
+      if (prevPrev !== undefined) process.env.SHARED_SECRET_PREV = prevPrev;
+      if (prevNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = prevNodeEnv;
+    }
+  });
+});

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -147,6 +147,69 @@ export interface BootOptions {
   fleetEnumerate?: ServiceEnumerator;
 }
 
+/**
+ * Load the deploy-webhook HMAC secrets from env and fail loud if absent
+ * in any deployable boot mode.
+ *
+ * Background: `POST /webhooks/deploy` is only registered when
+ * `webhookSecrets.length > 0` (see `buildServer` at
+ * `src/http/server.ts:119`). Pre-fix, the FATAL-CONFIG guard only fired
+ * when `NODE_ENV === "production"` — so any deploy that booted with a
+ * non-"production" NODE_ENV (unset, "prod", or set after the check by a
+ * launch hook) silently shipped with `webhookSecrets = []`, the gate
+ * skipped route registration, and every notify-harness POST from the
+ * `Showcase: Verify Deploy` workflow returned 404 without a peep.
+ *
+ * Predicate: throw unless either
+ *   - at least one of SHARED_SECRET / SHARED_SECRET_PREV is set, OR
+ *   - we are explicitly in a non-deployable mode: `NODE_ENV === "test"`
+ *     or the escape-hatch `HARNESS_ALLOW_NO_SECRET === "1"` (local dev).
+ *
+ * The escape hatch is intentionally narrow: NODE_ENV must be EXACTLY
+ * "test" (not "testing", not unset). Any other NODE_ENV value — incl.
+ * the unset case staging deploys hit — is treated as deployable and
+ * must carry a real secret.
+ *
+ * Called from BOTH boot paths (worker `boot()` and control-plane
+ * `runControlPlane`) so the deploy webhook is registered uniformly and
+ * a missing secret fails loud regardless of which role is selected.
+ */
+export function loadWebhookSecrets(logger_: typeof logger = logger): string[] {
+  const sharedSecret = process.env.SHARED_SECRET;
+  const sharedSecretPrev = process.env.SHARED_SECRET_PREV;
+  const webhookSecrets = [sharedSecret, sharedSecretPrev].filter(
+    (s): s is string => typeof s === "string" && s.length > 0,
+  );
+
+  if (webhookSecrets.length > 0) return webhookSecrets;
+
+  const isTestMode = process.env.NODE_ENV === "test";
+  const escapeHatch = process.env.HARNESS_ALLOW_NO_SECRET === "1";
+  if (isTestMode || escapeHatch) {
+    logger_.info("orchestrator.webhook-auth-bypass", {
+      msg: "webhook auth disabled — neither SHARED_SECRET nor SHARED_SECRET_PREV is set",
+      nodeEnv: process.env.NODE_ENV ?? "(unset)",
+      escapeHatch,
+    });
+    return webhookSecrets;
+  }
+
+  logger_.error("orchestrator.FATAL-CONFIG", {
+    msg: "SHARED_SECRET required — refusing to boot",
+    nodeEnv: process.env.NODE_ENV ?? "(unset)",
+  });
+  throw new Error(
+    "FATAL-CONFIG: SHARED_SECRET (or SHARED_SECRET_PREV) is required — refusing to boot " +
+      "in any deployable mode (gate at src/http/server.ts:119 only registers " +
+      "POST /webhooks/deploy when webhookSecrets.length > 0, so booting without " +
+      "a secret would silently 404 every notify-harness POST from the " +
+      "Showcase: Verify Deploy workflow). " +
+      "Set SHARED_SECRET (or SHARED_SECRET_PREV) in the env, or set " +
+      "NODE_ENV=test / HARNESS_ALLOW_NO_SECRET=1 for local dev. " +
+      `Current NODE_ENV=${process.env.NODE_ENV ?? "(unset)"}.`,
+  );
+}
+
 export async function boot(opts: BootOptions = {}): Promise<{
   stop: () => Promise<void>;
   port: number;
@@ -769,31 +832,15 @@ export async function boot(opts: BootOptions = {}): Promise<{
     }),
   );
 
-  const sharedSecret = process.env.SHARED_SECRET;
-  const sharedSecretPrev = process.env.SHARED_SECRET_PREV;
-  const webhookSecrets = [sharedSecret, sharedSecretPrev].filter(
-    (s): s is string => typeof s === "string" && s.length > 0,
-  );
-  // R5-G4 D5: empty webhookSecrets silently disables auth on the
-  // deploy.result webhook — anyone who knows the URL can POST. Mirror
-  // the POCKETBASE_URL fail-loud pattern: in production the missing
-  // config is a deploy bug that must surface immediately. In dev/test
-  // emit an info log so developers see the bypass.
-  if (webhookSecrets.length === 0) {
-    if (process.env.NODE_ENV === "production") {
-      logger.error("orchestrator.FATAL-CONFIG", {
-        msg: "SHARED_SECRET required in production",
-        nodeEnv: process.env.NODE_ENV,
-      });
-      throw new Error(
-        "FATAL-CONFIG: SHARED_SECRET required in production (NODE_ENV=production)",
-      );
-    }
-    logger.info("orchestrator.webhook-auth-bypass", {
-      msg: "webhook auth disabled — neither SHARED_SECRET nor SHARED_SECRET_PREV is set",
-      nodeEnv: process.env.NODE_ENV ?? "(unset)",
-    });
-  }
+  // B2 fix: webhook-secrets loading + FATAL-CONFIG fail-loud now live in
+  // `loadWebhookSecrets` so the CP boot path (runControlPlane) consumes the
+  // same predicate. The previous inline guard fired ONLY on
+  // `NODE_ENV === "production"`, which meant a deploy whose NODE_ENV was unset
+  // / "prod" / "staging" silently shipped with webhookSecrets=[], the server
+  // gate at http/server.ts:119 skipped POST /webhooks/deploy registration, and
+  // every notify-harness POST returned 404. See the helper's doc for the new
+  // predicate (test-mode or escape-hatch only).
+  const webhookSecrets = loadWebhookSecrets(logger);
 
   let loopAlive = true;
   // `schedulerRunning` closes the boot-window honesty gap in /health: the
@@ -2360,6 +2407,22 @@ export async function runControlPlane(
   });
   const scheduler = createScheduler({ logger });
 
+  // B2 fix: load deploy-webhook HMAC secrets here so the CP `buildServer`
+  // call below ACTUALLY registers POST /webhooks/deploy (the gate at
+  // http/server.ts:119 needs `webhookSecrets.length > 0`). Pre-fix the CP
+  // path omitted both `webhookSecrets` and `metrics` from buildServer, so
+  // the public Railway host running the control-plane role returned 404 on
+  // every notify-harness POST from the Showcase: Verify Deploy workflow.
+  // `loadWebhookSecrets` also runs the tightened FATAL-CONFIG guard, so a
+  // CP boot with no SHARED_SECRET fails loud here regardless of NODE_ENV
+  // (only NODE_ENV=test / HARNESS_ALLOW_NO_SECRET=1 permits empty secrets).
+  const webhookSecrets = loadWebhookSecrets(logger);
+  // A metrics registry on the CP role lets /metrics expose webhook
+  // rejection / HMAC-failure counters from the deploy webhook (same surface
+  // the worker boot exposes). Cheap (in-process counters only, no scrape
+  // server) and matches the worker buildServer call's wiring.
+  const metrics = createMetricsRegistry();
+
   // S5 aggregator — the ONLY authoritative dashboard writer — over the
   // UNCHANGED status + run-history pipelines (preserves the dashboard row
   // shapes exactly; see result-aggregator.ts). It is the single sink for BOTH
@@ -2981,6 +3044,14 @@ export async function runControlPlane(
     schedulerJobCount: () => scheduler.list().length,
     schedulerIsStopped: () => scheduler.isStopped(),
     bus,
+    // B2 fix: register POST /webhooks/deploy on the CP role too — the public
+    // Railway host running the CP role is the one that receives the
+    // notify-harness POST after every main deploy. Pre-fix the gate at
+    // http/server.ts:119 silently skipped registration because these two were
+    // omitted from the CP buildServer call (worker boot path had them), so
+    // every POST returned 404 since at least 2026-06-12.
+    webhookSecrets,
+    metrics,
     probes: probesDeps,
     // §5.2 unconditional CP mount: unlike `probes` (token-gated), the
     // read-only fleet-runs routes are ALWAYS supplied on the control-plane

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -213,6 +213,58 @@ export function loadWebhookSecrets(logger_: typeof logger = logger): string[] {
 }
 
 /**
+ * Resolve the PocketBase URL with the SAME symmetric fail-loud predicate
+ * as `loadWebhookSecrets`: throw unless either
+ *   - POCKETBASE_URL is set to a non-empty string, OR
+ *   - we are explicitly in a non-deployable mode: `NODE_ENV === "test"`
+ *     OR the escape-hatch `HARNESS_ALLOW_NO_PB_URL === "1"` (local dev).
+ *
+ * R1-F3 fix: pre-fix the inline guard only fired when
+ * `NODE_ENV === "production"`, so a staging / unset / "development" deploy
+ * silently bound to `http://localhost:8090` and every PB read/write hit a
+ * non-existent host. That was asymmetric with `loadWebhookSecrets` (which
+ * already used the test-or-escape-hatch predicate) — now both checks share
+ * one predicate so staging deploys fail loud on either misconfig.
+ *
+ * NOTE: the legacy single-purpose `HARNESS_ALLOW_NO_SECRET` flag is kept
+ * separate (this skill could unify them under a single HARNESS_DEV_LOCAL
+ * but doing so in this PR risks a tooling-env footgun — defer).
+ *
+ * Called from BOTH boot paths (worker `boot()` and the CP's
+ * `resolveFleetPbConfig`) so neither role can silently bind to a fake PB.
+ */
+export function loadPocketbaseUrl(logger_: typeof logger = logger): string {
+  const rawPbUrl = process.env.POCKETBASE_URL;
+  if (typeof rawPbUrl === "string" && rawPbUrl.length > 0) return rawPbUrl;
+
+  const isTestMode = process.env.NODE_ENV === "test";
+  const escapeHatch = process.env.HARNESS_ALLOW_NO_PB_URL === "1";
+  if (isTestMode || escapeHatch) {
+    const logLevel = escapeHatch && !isTestMode ? "warn" : "info";
+    logger_[logLevel]("orchestrator.pocketbase-url-default", {
+      msg: "POCKETBASE_URL unset — defaulting to http://localhost:8090",
+      nodeEnv: process.env.NODE_ENV ?? "(unset)",
+      escapeHatch,
+    });
+    return "http://localhost:8090";
+  }
+
+  logger_.error("orchestrator.FATAL-CONFIG", {
+    msg: "POCKETBASE_URL required — refusing to boot",
+    nodeEnv: process.env.NODE_ENV ?? "(unset)",
+  });
+  throw new Error(
+    "FATAL-CONFIG: POCKETBASE_URL is required — refusing to boot " +
+      "in any deployable mode. A missing POCKETBASE_URL pre-fix silently " +
+      "bound the orchestrator to http://localhost:8090, causing every " +
+      "PB read/write to fail against a non-existent host. " +
+      "Set POCKETBASE_URL in the env, or set " +
+      "NODE_ENV=test / HARNESS_ALLOW_NO_PB_URL=1 for local dev. " +
+      `Current NODE_ENV=${process.env.NODE_ENV ?? "(unset)"}.`,
+  );
+}
+
+/**
  * Subscribe to `deploy.result` events on the given bus, routing each event
  * through `writer.write(deployEventToProbeResult(...))` so the deploy
  * webhook POST emits a `status.changed` row on the dashboard.
@@ -259,24 +311,21 @@ export async function boot(opts: BootOptions = {}): Promise<{
    */
   bus: ReturnType<typeof createEventBus>;
 }> {
-  // HF13-A2: fail loud on missing POCKETBASE_URL in production. Pre-fix the
-  // `?? "http://localhost:8090"` fallback silently bound a prod orchestrator
-  // to a non-existent localhost PB — no status reads, no state writes, no
-  // alerts. Shell-dashboard's `pb.ts` uses a `pbIsMisconfigured` sentinel and
-  // fails loud; orchestrator was asymmetric. Now it throws on boot in prod so
-  // the deploy CI (or Railway health-check) catches it immediately instead of
-  // discovering it hours later via silent alert suppression.
-  const rawPbUrl = process.env.POCKETBASE_URL;
-  if (!rawPbUrl && process.env.NODE_ENV === "production") {
-    logger.error("orchestrator.FATAL-CONFIG", {
-      msg: "POCKETBASE_URL required in production",
-      nodeEnv: process.env.NODE_ENV,
-    });
-    throw new Error(
-      "FATAL-CONFIG: POCKETBASE_URL required in production (NODE_ENV=production)",
-    );
-  }
-  const pbUrl = rawPbUrl ?? "http://localhost:8090";
+  // R1-F2: hoist all fail-loud config validation to the TOP of boot() —
+  // BEFORE any pb client / bus / scheduler / writer / S3 uploader allocations.
+  // Pre-fix `loadWebhookSecrets` lived AFTER the entire scheduler+writer
+  // setup, and `POCKETBASE_URL` had a narrower predicate than SHARED_SECRET
+  // (only NODE_ENV=production), so a misconfigured staging boot allocated
+  // expensive resources, mounted file watchers, and registered scheduler
+  // entries before throwing. Now both checks fire here, before anything that
+  // would need teardown.
+  //
+  // R1-F3: `loadPocketbaseUrl` replaces the inline production-only guard
+  // with the same test-or-escape-hatch predicate `loadWebhookSecrets` uses,
+  // so staging/development/unset NODE_ENV fail loud on BOTH config misses
+  // instead of just SHARED_SECRET.
+  const pbUrl = loadPocketbaseUrl(logger);
+  const webhookSecrets = loadWebhookSecrets(logger);
   // These authenticate against `/api/collections/_superusers/auth-with-password`
   // in pb-client, so the env var names intentionally mirror "superuser" —
   // previously `POCKETBASE_WRITER_*`, renamed to eliminate the naming drift
@@ -859,16 +908,6 @@ export async function boot(opts: BootOptions = {}): Promise<{
   // subscription lived only here, so a valid signed POST against the CP host
   // returned 202 and the event vanished (no dashboard row written).
   busUnsubs.push(subscribeDeployResults(bus, writer, logger));
-
-  // B2 fix: webhook-secrets loading + FATAL-CONFIG fail-loud now live in
-  // `loadWebhookSecrets` so the CP boot path (runControlPlane) consumes the
-  // same predicate. The previous inline guard fired ONLY on
-  // `NODE_ENV === "production"`, which meant a deploy whose NODE_ENV was unset
-  // / "prod" / "staging" silently shipped with webhookSecrets=[], the server
-  // gate at http/server.ts:119 skipped POST /webhooks/deploy registration, and
-  // every notify-harness POST returned 404. See the helper's doc for the new
-  // predicate (test-mode or escape-hatch only).
-  const webhookSecrets = loadWebhookSecrets(logger);
 
   let loopAlive = true;
   // `schedulerRunning` closes the boot-window honesty gap in /health: the
@@ -2406,10 +2445,21 @@ export async function runControlPlane(
     poolCount: config.poolCount,
   });
 
+  // R1-F2: hoist all fail-loud config validation to the TOP of
+  // runControlPlane — BEFORE any pb client / queue / bus / scheduler /
+  // aggregator / fleet-health allocations. Pre-fix `loadWebhookSecrets`
+  // ran AFTER pb+claim+bus+queue+scheduler were already constructed, so
+  // a misconfigured CP boot allocated five resources before throwing.
+  // Now both checks fire here; if either throws, no teardown is needed.
+  //
+  // R1-F3: `resolveFleetPbConfig` now defers to `loadPocketbaseUrl` so
+  // the CP path's POCKETBASE_URL predicate matches `loadWebhookSecrets`'
+  // semantics (test-or-escape-hatch instead of production-only).
+  const webhookSecrets = loadWebhookSecrets(logger);
+  const pbCfg = resolveFleetPbConfig();
+
   const env = process.env;
   const port = opts.port ?? (Number(env.PORT ?? 8080) || 8080);
-
-  const pbCfg = resolveFleetPbConfig();
   const pb = createPbClient({
     url: pbCfg.url,
     email: pbCfg.email,
@@ -2435,20 +2485,11 @@ export async function runControlPlane(
   });
   const scheduler = createScheduler({ logger });
 
-  // B2 fix: load deploy-webhook HMAC secrets here so the CP `buildServer`
-  // call below ACTUALLY registers POST /webhooks/deploy (the gate at
-  // http/server.ts:119 needs `webhookSecrets.length > 0`). Pre-fix the CP
-  // path omitted both `webhookSecrets` and `metrics` from buildServer, so
-  // the public Railway host running the control-plane role returned 404 on
-  // every notify-harness POST from the Showcase: Verify Deploy workflow.
-  // `loadWebhookSecrets` also runs the tightened FATAL-CONFIG guard, so a
-  // CP boot with no SHARED_SECRET fails loud here regardless of NODE_ENV
-  // (only NODE_ENV=test / HARNESS_ALLOW_NO_SECRET=1 permits empty secrets).
-  const webhookSecrets = loadWebhookSecrets(logger);
   // A metrics registry on the CP role lets /metrics expose webhook
   // rejection / HMAC-failure counters from the deploy webhook (same surface
   // the worker boot exposes). Cheap (in-process counters only, no scrape
   // server) and matches the worker buildServer call's wiring.
+  // (R1-F2: `webhookSecrets` hoisted to the top — see above.)
   const metrics = createMetricsRegistry();
 
   // S5 aggregator — the ONLY authoritative dashboard writer — over the
@@ -3309,18 +3350,13 @@ function resolveFleetPbConfig(): {
   email?: string;
   password?: string;
 } {
-  const rawPbUrl = process.env.POCKETBASE_URL;
-  if (!rawPbUrl && process.env.NODE_ENV === "production") {
-    logger.error("orchestrator.FATAL-CONFIG", {
-      msg: "POCKETBASE_URL required in production",
-      nodeEnv: process.env.NODE_ENV,
-    });
-    throw new Error(
-      "FATAL-CONFIG: POCKETBASE_URL required in production (NODE_ENV=production)",
-    );
-  }
+  // R1-F3: use the shared `loadPocketbaseUrl` so the CP path's
+  // POCKETBASE_URL predicate matches `loadWebhookSecrets`' semantics
+  // (throw unless NODE_ENV=test OR HARNESS_ALLOW_NO_PB_URL=1). Pre-fix
+  // the predicate was production-only, so a staging/unset/"development"
+  // boot silently bound to http://localhost:8090.
   return {
-    url: rawPbUrl ?? "http://localhost:8090",
+    url: loadPocketbaseUrl(logger),
     email: process.env.POCKETBASE_SUPERUSER_EMAIL,
     password: process.env.POCKETBASE_SUPERUSER_PASSWORD,
   };

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -299,11 +299,16 @@ export function subscribeDeployResults(
   };
   return bus.on("deploy.result", (event: DeployResultEvent) => {
     const result = deployEventToProbeResult(event, deployCtx);
-    writer
-      .write(result)
-      .catch((err) =>
-        logErrorWithStack(logger_, "orchestrator.deploy-writer-failed", err),
-      );
+    writer.write(result).catch((err) => {
+      logErrorWithStack(logger_, "orchestrator.deploy-writer-failed", err);
+      // R2-F2: emit a bus event in addition to logging so alert rules /
+      // metrics subscribers can observe deploy-writer write failures as a
+      // first-class signal (matching other `*.failed` surfaces like
+      // `writer.failed`, `probes.reload.failed`, `rules.reload.failed`).
+      bus.emit("deploy.writer.failed", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    });
   });
 }
 
@@ -2515,15 +2520,22 @@ export async function runControlPlane(
     writtenBy: "fleet-cp",
   });
 
+  // Track CP-side bus subscriptions so stop() / bind-failure teardown can
+  // release them symmetrically (mirrors worker `boot()`'s `busUnsubs`
+  // pattern). Pre-fix the CP path discarded the unsub returned by
+  // `subscribeDeployResults`, so a repeated boot/stop cycle (e.g. tests
+  // that exercise the CP role multiple times) leaked the deploy.result
+  // handler against the prior writer.
+  const cpUnsubs: Array<() => void> = [];
+
   // R1-F1: subscribe `deploy.result` events through the CP's status writer
   // so a valid signed POST against the CP host actually writes the
   // deploy-overall dashboard row. Pre-fix this subscription only existed in
   // worker `boot()` — after B2 mounted the route on the CP, signed POSTs
   // returned 202 but the bus event had no listener and the dashboard row
-  // never landed. The CP keeps the subscription alive for the lifetime of
-  // `bus` (no per-handler teardown — bus drops with the process; the
-  // worker boot path collects the unsubscribe into `busUnsubs`).
-  subscribeDeployResults(bus, statusWriter, logger);
+  // never landed. R2-F1: the returned unsub is captured into `cpUnsubs` so
+  // stop() and the bind-failure teardown release the listener.
+  cpUnsubs.push(subscribeDeployResults(bus, statusWriter, logger));
 
   // REQ-B: read the CURRENT dashboard status-row colour for an aggregate key.
   // Validates the read value against the known State set; a never-observed key
@@ -3186,6 +3198,18 @@ export async function runControlPlane(
           unwatchErr instanceof Error ? unwatchErr.message : String(unwatchErr),
       });
     }
+    // R2-F1: release every CP-side bus subscription so a failed bind never
+    // leaves the deploy.result handler attached against a now-stale writer.
+    for (const u of cpUnsubs) {
+      try {
+        u();
+      } catch (unsubErr) {
+        logger.error("fleet.control-plane.bus-unsub-after-bind-failure", {
+          err: unsubErr instanceof Error ? unsubErr.message : String(unsubErr),
+        });
+      }
+    }
+    cpUnsubs.length = 0;
     await controlPlane.stop().catch((stopErr) =>
       logger.error("fleet.control-plane.stop-after-bind-failure", {
         err: stopErr instanceof Error ? stopErr.message : String(stopErr),
@@ -3260,6 +3284,20 @@ export async function runControlPlane(
           err: err instanceof Error ? err.message : String(err),
         });
       }
+      // R2-F1: release every CP-side bus subscription so a repeated
+      // boot/stop cycle never leaks the deploy.result handler against the
+      // prior status writer (mirrors worker `boot()`'s `busUnsubs` drain).
+      for (const u of cpUnsubs) {
+        try {
+          u();
+        } catch (unsubErr) {
+          logger.error("fleet.control-plane.bus-unsub-on-stop-failed", {
+            err:
+              unsubErr instanceof Error ? unsubErr.message : String(unsubErr),
+          });
+        }
+      }
+      cpUnsubs.length = 0;
       // controlPlane.stop() clears its own internal fleet-health + consumer
       // intervals (REQ-B seams now own that lifecycle).
       await controlPlane.stop();

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -9,6 +9,7 @@ import {
   assertSafeKey,
 } from "./storage/alert-state-store.js";
 import { createEventBus } from "./events/event-bus.js";
+import type { DeployResultEvent } from "./events/event-bus.js";
 import { createRuleLoader } from "./rules/rule-loader.js";
 import type { CompiledRule } from "./rules/rule-loader.js";
 import { createRenderer } from "./render/renderer.js";
@@ -16,6 +17,7 @@ import { createAlertEngine } from "./alerts/alert-engine.js";
 import { createScheduler } from "./scheduler/scheduler.js";
 import type { Scheduler } from "./scheduler/scheduler.js";
 import { createStatusWriter } from "./writers/status-writer.js";
+import type { StatusWriter } from "./writers/status-writer.js";
 import { createSlackWebhookTarget } from "./targets/slack-webhook.js";
 import { createMetricsRegistry } from "./http/metrics.js";
 import {
@@ -208,6 +210,42 @@ export function loadWebhookSecrets(logger_: typeof logger = logger): string[] {
       "NODE_ENV=test / HARNESS_ALLOW_NO_SECRET=1 for local dev. " +
       `Current NODE_ENV=${process.env.NODE_ENV ?? "(unset)"}.`,
   );
+}
+
+/**
+ * Subscribe to `deploy.result` events on the given bus, routing each event
+ * through `writer.write(deployEventToProbeResult(...))` so the deploy
+ * webhook POST emits a `status.changed` row on the dashboard.
+ *
+ * R1-F1 fix: pre-fix this subscription lived inline in worker `boot()`
+ * only — the CP `runControlPlane` path registered POST /webhooks/deploy
+ * (after B2) but had no subscriber, so a valid signed POST returned 202
+ * and the event vanished. Extracted so BOTH boot paths can share the
+ * exact same handler logic.
+ *
+ * The returned function is the bus unsubscribe handle — callers append
+ * it to their teardown array (worker `boot()`'s `busUnsubs`); the CP
+ * path keeps it alive for the lifetime of the bus (no per-handler
+ * teardown is needed; the bus itself drops with the process).
+ */
+export function subscribeDeployResults(
+  bus: ReturnType<typeof createEventBus>,
+  writer: Pick<StatusWriter, "write">,
+  logger_: typeof logger = logger,
+): () => void {
+  const deployCtx = {
+    now: () => new Date(),
+    logger: logger_,
+    env: process.env as Readonly<Record<string, string | undefined>>,
+  };
+  return bus.on("deploy.result", (event: DeployResultEvent) => {
+    const result = deployEventToProbeResult(event, deployCtx);
+    writer
+      .write(result)
+      .catch((err) =>
+        logErrorWithStack(logger_, "orchestrator.deploy-writer-failed", err),
+      );
+  });
 }
 
 export async function boot(opts: BootOptions = {}): Promise<{
@@ -815,22 +853,12 @@ export async function boot(opts: BootOptions = {}): Promise<{
       });
   });
 
-  // Route deploy.result webhook events through the writer so they emit status.changed.
-  const deployCtx = {
-    now: () => new Date(),
-    logger,
-    env: process.env as Readonly<Record<string, string | undefined>>,
-  };
-  busUnsubs.push(
-    bus.on("deploy.result", (event) => {
-      const result = deployEventToProbeResult(event, deployCtx);
-      writer
-        .write(result)
-        .catch((err) =>
-          logErrorWithStack(logger, "orchestrator.deploy-writer-failed", err),
-        );
-    }),
-  );
+  // R1-F1: route deploy.result webhook events through the writer so they
+  // emit status.changed. Extracted into `subscribeDeployResults` so the CP
+  // boot path (runControlPlane) shares the IDENTICAL handler — pre-fix the
+  // subscription lived only here, so a valid signed POST against the CP host
+  // returned 202 and the event vanished (no dashboard row written).
+  busUnsubs.push(subscribeDeployResults(bus, writer, logger));
 
   // B2 fix: webhook-secrets loading + FATAL-CONFIG fail-loud now live in
   // `loadWebhookSecrets` so the CP boot path (runControlPlane) consumes the
@@ -2438,6 +2466,17 @@ export async function runControlPlane(
     logger,
     writtenBy: "fleet-cp",
   });
+
+  // R1-F1: subscribe `deploy.result` events through the CP's status writer
+  // so a valid signed POST against the CP host actually writes the
+  // deploy-overall dashboard row. Pre-fix this subscription only existed in
+  // worker `boot()` — after B2 mounted the route on the CP, signed POSTs
+  // returned 202 but the bus event had no listener and the dashboard row
+  // never landed. The CP keeps the subscription alive for the lifetime of
+  // `bus` (no per-handler teardown — bus drops with the process; the
+  // worker boot path collects the unsubscribe into `busUnsubs`).
+  subscribeDeployResults(bus, statusWriter, logger);
+
   // REQ-B: read the CURRENT dashboard status-row colour for an aggregate key.
   // Validates the read value against the known State set; a never-observed key
   // (no row) returns null, never a fabricated green. Self-defensive: a lookup

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -163,7 +163,8 @@ export interface BootOptions {
  * `Showcase: Verify Deploy` workflow returned 404 without a peep.
  *
  * Predicate: throw unless either
- *   - at least one of SHARED_SECRET / SHARED_SECRET_PREV is set, OR
+ *   - at least one of SHARED_SECRET / SHARED_SECRET_PREV is set to a
+ *     non-empty string, OR
  *   - we are explicitly in a non-deployable mode: `NODE_ENV === "test"`
  *     or the escape-hatch `HARNESS_ALLOW_NO_SECRET === "1"` (local dev).
  *
@@ -188,8 +189,14 @@ export function loadWebhookSecrets(logger_: typeof logger = logger): string[] {
   const isTestMode = process.env.NODE_ENV === "test";
   const escapeHatch = process.env.HARNESS_ALLOW_NO_SECRET === "1";
   if (isTestMode || escapeHatch) {
-    logger_.info("orchestrator.webhook-auth-bypass", {
-      msg: "webhook auth disabled — neither SHARED_SECRET nor SHARED_SECRET_PREV is set",
+    // CB-2 (Slot 2 #28): when the escape hatch fires with a real-looking
+    // NODE_ENV (anything except "test"), log at `warn` so a production
+    // typo (e.g. NODE_ENV=staging + HARNESS_ALLOW_NO_SECRET=1) is visible
+    // in dashboards / log alerting. Pure local-dev (NODE_ENV=test) stays
+    // at info level so a normal unit-test boot doesn't spam warnings.
+    const logLevel = escapeHatch && !isTestMode ? "warn" : "info";
+    logger_[logLevel]("orchestrator.webhook-auth-bypass", {
+      msg: "webhook auth disabled — neither SHARED_SECRET nor SHARED_SECRET_PREV is set to a non-empty value",
       nodeEnv: process.env.NODE_ENV ?? "(unset)",
       escapeHatch,
     });

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -272,6 +272,43 @@ export function loadPocketbaseUrl(logger_: typeof logger = logger): string {
 }
 
 /**
+ * Resolve `OPS_TRIGGER_TOKEN` with the SAME fail-loud-at-top discipline as
+ * `loadWebhookSecrets` / `loadPocketbaseUrl`: a set-but-empty (or
+ * whitespace-only) value is a misconfiguration and throws; unset means
+ * "router intentionally disabled" and returns `undefined`; a real value is
+ * returned trimmed (matches the auth-layer's symmetric trim — see
+ * R3-A.5).
+ *
+ * R3-F1 fix: pre-fix the empty-string check lived AFTER pb / bus /
+ * scheduler / writer / S3 uploader allocations in BOTH boot paths
+ * (worker `boot()` and `runControlPlane`), so a typo'd
+ * `OPS_TRIGGER_TOKEN=` allocated expensive resources before throwing.
+ * Hoisting via this helper puts the check next to the other fail-loud
+ * predicates at the top of each boot path.
+ *
+ * Returns the trimmed token string, or `undefined` when the env var is
+ * unset (intentional disable — callers log "router-disabled" and omit
+ * the /api/probes router).
+ */
+export function loadOpsTriggerToken(
+  logger_: typeof logger = logger,
+): string | undefined {
+  const rawTriggerToken = process.env.OPS_TRIGGER_TOKEN;
+  if (rawTriggerToken === undefined) return undefined;
+  if (rawTriggerToken.trim() === "") {
+    logger_.error("orchestrator.FATAL-CONFIG", {
+      msg: "OPS_TRIGGER_TOKEN set but empty — refusing to boot",
+    });
+    throw new Error(
+      "OPS_TRIGGER_TOKEN is set but empty — refusing to mount probes router with insecure auth",
+    );
+  }
+  // R3-A.5: trim defense-in-depth so the value passed downstream matches
+  // exactly what the bearer-auth middleware compares against (see auth.ts).
+  return rawTriggerToken.trim();
+}
+
+/**
  * Subscribe to `deploy.result` events on the given bus, routing each event
  * through `writer.write(deployEventToProbeResult(...))` so the deploy
  * webhook POST emits a `status.changed` row on the dashboard.
@@ -298,7 +335,26 @@ export function subscribeDeployResults(
     env: process.env as Readonly<Record<string, string | undefined>>,
   };
   return bus.on("deploy.result", (event: DeployResultEvent) => {
-    const result = deployEventToProbeResult(event, deployCtx);
+    // R3-F2: a synchronous throw inside `deployEventToProbeResult`
+    // (malformed event, unexpected type drift, etc.) pre-fix bypassed
+    // the `.catch` below — the bus saw the throw and we lost both the
+    // log AND the `deploy.writer.failed` emit. Mirror the rejection
+    // path here so alert rules / metrics subscribers observe sync
+    // throws the same way they observe async write failures.
+    let result;
+    try {
+      result = deployEventToProbeResult(event, deployCtx);
+    } catch (err) {
+      logErrorWithStack(
+        logger_,
+        "orchestrator.deploy-writer-failed",
+        err as unknown,
+      );
+      bus.emit("deploy.writer.failed", {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
     writer.write(result).catch((err) => {
       logErrorWithStack(logger_, "orchestrator.deploy-writer-failed", err);
       // R2-F2: emit a bus event in addition to logging so alert rules /
@@ -336,8 +392,15 @@ export async function boot(opts: BootOptions = {}): Promise<{
   // with the same test-or-escape-hatch predicate `loadWebhookSecrets` uses,
   // so staging/development/unset NODE_ENV fail loud on BOTH config misses
   // instead of just SHARED_SECRET.
+  //
+  // R3-F1: hoist `OPS_TRIGGER_TOKEN` set-but-empty fail-loud here too.
+  // Pre-fix this check lived AFTER pb / bus / scheduler / writer / S3
+  // uploader allocations, so a typo'd `OPS_TRIGGER_TOKEN=` allocated
+  // expensive resources before throwing. Now all three fail-loud config
+  // predicates fire at the top, before anything that would need teardown.
   const pbUrl = loadPocketbaseUrl(logger);
   const webhookSecrets = loadWebhookSecrets(logger);
+  const triggerToken = loadOpsTriggerToken(logger);
   // These authenticate against `/api/collections/_superusers/auth-with-password`
   // in pb-client, so the env var names intentionally mirror "superuser" —
   // previously `POCKETBASE_WRITER_*`, renamed to eliminate the naming drift
@@ -929,31 +992,15 @@ export async function boot(opts: BootOptions = {}): Promise<{
   // in stop() so post-shutdown probes also read correctly.
   let schedulerRunning = false;
 
-  // F1: only mount the /api/probes router when an OPS_TRIGGER_TOKEN is
-  // configured. The router's bearer-auth middleware is fail-loud at
-  // construction (MissingAuthTokenError) — wiring it unconditionally would
-  // break every test / dev boot that doesn't set the env var. When unset we
-  // log at info level so operators can see the routes were intentionally
-  // skipped, then flag it as a hardening concern in the boot summary.
-  //
-  // R2-B.3: distinguish "unset" (intentional disable) from "set-but-empty"
-  // (misconfiguration). An operator who mistypes `OPS_TRIGGER_TOKEN=`
-  // (no value) ships an empty string AND would otherwise see a silent-skip
-  // log instead of the load-bearing fail-loud error. Whitespace-only is
-  // treated identically: trim() then reject if zero-length.
-  const rawTriggerToken = process.env.OPS_TRIGGER_TOKEN;
-  if (rawTriggerToken !== undefined && rawTriggerToken.trim() === "") {
-    throw new Error(
-      "OPS_TRIGGER_TOKEN is set but empty — refusing to mount probes router with insecure auth",
-    );
-  }
-  // R3-A.5: trim defense-in-depth. The auth layer (auth.ts) also trims
-  // both sides at construction, but normalising here keeps the orchestrator
-  // contract honest — the value passed downstream is the same one the
-  // bearer-auth middleware will compare against. Pre-fix, a "  abc  "
-  // token boot'd successfully but the auth layer's asymmetric trimming
-  // (presented trimmed, expected verbatim) silently 401'd every request.
-  const triggerToken = rawTriggerToken?.trim(); // undefined or non-empty
+  // F1 / R2-B.3 / R3-A.5 / R3-F1: only mount the /api/probes router when
+  // an OPS_TRIGGER_TOKEN is configured. The router's bearer-auth
+  // middleware is fail-loud at construction (MissingAuthTokenError) —
+  // wiring it unconditionally would break every test / dev boot that
+  // doesn't set the env var. When unset we log at info level so operators
+  // can see the routes were intentionally skipped, then flag it as a
+  // hardening concern in the boot summary. Set-but-empty (incl.
+  // whitespace-only) is rejected fail-loud by `loadOpsTriggerToken` at
+  // the top of boot() — see the hoisted call above.
   const probesDeps = triggerToken
     ? {
         scheduler,
@@ -2467,7 +2514,13 @@ export async function runControlPlane(
   // R1-F3: `resolveFleetPbConfig` now defers to `loadPocketbaseUrl` so
   // the CP path's POCKETBASE_URL predicate matches `loadWebhookSecrets`'
   // semantics (test-or-escape-hatch instead of production-only).
+  //
+  // R3-F1: hoist `OPS_TRIGGER_TOKEN` set-but-empty fail-loud here too.
+  // Pre-fix this check lived AFTER pb / claim / bus / queue / scheduler /
+  // statusWriter / aggregator / fleet-health allocations, so a typo'd
+  // `OPS_TRIGGER_TOKEN=` allocated all of those before throwing.
   const webhookSecrets = loadWebhookSecrets(logger);
+  const triggerToken = loadOpsTriggerToken(logger);
   const pbCfg = resolveFleetPbConfig();
 
   const env = process.env;
@@ -3095,13 +3148,10 @@ export async function runControlPlane(
   // Token handling mirrors boot() exactly (fail-safe): unset → router omitted;
   // set-but-empty (incl. whitespace-only) → fail-loud at boot so a mistyped
   // `OPS_TRIGGER_TOKEN=` can't silently ship an insecure/always-reject route.
-  const rawTriggerToken = process.env.OPS_TRIGGER_TOKEN;
-  if (rawTriggerToken !== undefined && rawTriggerToken.trim() === "") {
-    throw new Error(
-      "OPS_TRIGGER_TOKEN is set but empty — refusing to mount probes router with insecure auth",
-    );
-  }
-  const triggerToken = rawTriggerToken?.trim(); // undefined or non-empty
+  // R3-F1: the empty-string / whitespace-only fail-loud check is now hoisted
+  // via `loadOpsTriggerToken(logger)` at the TOP of runControlPlane (above)
+  // — `triggerToken` here is already either undefined (intentional disable)
+  // or a trimmed non-empty string. Re-bind locally is unnecessary.
   const probesDeps = triggerToken
     ? {
         scheduler,


### PR DESCRIPTION
## Problem

The \`Showcase: Verify Deploy\` workflow runs \`notify-harness\` after every merge to \`main\` and POSTs an HMAC-signed payload to \`\${SHOWCASE_HARNESS_URL}/webhooks/deploy\`. That POST has been returning **404** on every main deploy since at least 2026-06-12 (5+ consecutive failures), so the harness dashboard has not reflected any recent deploys.

**Root cause:**

1. \`POST /webhooks/deploy\` is only registered when \`webhookSecrets.length > 0\` — gate at \`showcase/harness/src/http/server.ts:119\`.
2. The CP \`buildServer\` call in \`runControlPlane\` (\`showcase/harness/src/orchestrator.ts\` ~line 2961 pre-fix) **omitted** both \`webhookSecrets\` and \`metrics\`. The public Railway host running the CP role never mounted the route — every notify-harness POST returned 404.
3. The FATAL-CONFIG guard on missing \`SHARED_SECRET\` (pre-fix \`orchestrator.ts:782-790\`) only fired when \`NODE_ENV === "production"\`. Any deploy whose NODE_ENV was unset, set to something other than the literal \`"production"\`, or set after the check, silently booted with \`webhookSecrets=[]\` and no fatal error.

## Fix

**Part 1: Register the route on the CP path.**
- Lifted the env→secrets loader into a new exported helper \`loadWebhookSecrets()\` (orchestrator.ts ~175-209) so both boot paths consume the same predicate.
- Worker \`boot()\` (~line 836) calls it; CP \`runControlPlane\` (~line 2421) now also calls it.
- The CP \`buildServer\` call (~line 3047) now passes \`webhookSecrets\` and \`metrics\` alongside the existing \`bus\`/\`probes\`/\`fleetRuns\` wiring — same shape as the worker call.

**Part 2: Tighten the FATAL-CONFIG predicate.**
- New predicate (inside \`loadWebhookSecrets\`): throw unless EITHER a secret is set OR \`NODE_ENV === "test"\` OR \`HARNESS_ALLOW_NO_SECRET === "1"\` (narrow escape hatch for local dev).
- Thrown error message names the env-vars, the gate location (\`src/http/server.ts:119\`), the silent-404 symptom, and the escape hatches — so an operator reading the deploy log can recover without spelunking.

## Test coverage

Four new red-green tests in \`orchestrator.test.ts\` under \`B2: /webhooks/deploy registered on CP + fail-loud on missing SHARED_SECRET\`:

- **Test A** — CP boot registers \`POST /webhooks/deploy\` when \`SHARED_SECRET\` is set. Probe with no HMAC headers: pre-fix returned 404, post-fix returns 401 (route mounted, HMAC reject path fires). RED→GREEN.
- **Test B** — Worker boot still registers the route (regression guard). Pre-fix and post-fix both 401.
- **Test C** — FATAL-CONFIG fires when \`SHARED_SECRET\` unset AND \`NODE_ENV=development\`. Pre-fix resolved silently, post-fix rejects with \`/FATAL-CONFIG.*SHARED_SECRET/\`. RED→GREEN.
- **Test D** — Boot succeeds when \`SHARED_SECRET\` unset AND \`NODE_ENV=test\` (escape hatch). Pre-fix and post-fix both green.

Existing R5-G4 D5 test (orchestrator.test.ts:1592) updated to match the new error message via \`/FATAL-CONFIG.*SHARED_SECRET/\` — same throw, broader match.

## Verification

- Full harness suite: **2719/2719 green** across 128 files
- \`tsc --noEmit\`: clean
- RED capture pre-fix:
  - Test A: \`AssertionError: expected 404 to be 401\`
  - Test C: \`AssertionError: promise resolved "{ port: ..., bus: { ... }, ... }" instead of rejecting\`

## Deploy note

Requires a CP-role redeploy on the public Railway host for the new route registration to take effect — once redeployed, the next \`notify-harness\` POST will land on the harness dashboard.

## Test plan

- [x] B2 Tests A-D pass post-fix (red→green captured)
- [x] Full harness vitest suite green (2719/2719)
- [x] \`tsc --noEmit\` clean
- [ ] Post-deploy: confirm next \`Showcase: Verify Deploy\` run shows a 2xx notify-harness POST (not 404)
- [ ] Post-deploy: confirm harness dashboard reflects the next deploy