### PR TITLE
fix(showcase/aimock): add forecast-Tokyo + AAPL catchall fixtures to flip remaining D5 reds

### DIFF
--- a/showcase/aimock/d6/google-adk/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/google-adk/tool-rendering-custom-catchall.json
@@ -7,6 +7,84 @@
   },
   "fixtures": [
     {
+      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "toolCallId": "call_d6_cc_google_adk_weather_001",
+        "context": "google-adk"
+      },
+      "response": {
+        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "toolName": "get_weather",
+        "context": "google-adk"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_cc_google_adk_weather_001",
+            "name": "get_weather",
+            "arguments": "{\"location\":\"Tokyo\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "turnIndex": 0,
+        "context": "google-adk"
+      },
+      "response": {
+        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies."
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
+      "match": {
+        "userMessage": "What's the current price of AAPL?",
+        "toolCallId": "call_d6_cc_google_adk_stock_001",
+        "context": "google-adk"
+      },
+      "response": {
+        "content": "AAPL is trading at $338.37, down 2.96% \u2014 rendered through the custom wildcard catchall."
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
+      "match": {
+        "userMessage": "What's the current price of AAPL?",
+        "toolName": "get_stock_price",
+        "context": "google-adk"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_cc_google_adk_stock_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
+      "match": {
+        "userMessage": "What's the current price of AAPL?",
+        "turnIndex": 0,
+        "context": "google-adk"
+      },
+      "response": {
+        "content": "AAPL is trading at $338.37, down 2.96% on the day."
+      }
+    },
+    {
       "_comment": "Chain tools \u2014 follow-up after all 3 tools ran. Anchored on whichever of the 3 chain toolCallIds appears last in the request (LangGraph's ToolNode preserves tool_calls order). MUST come before the toolCalls-emitting fixture below so iteration 2 of the chain-tools loop hits this branch instead of re-emitting.",
       "match": {
         "userMessage": "Chain a few tools in this single turn",

--- a/showcase/aimock/d6/langgraph-fastapi/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/langgraph-fastapi/tool-rendering-custom-catchall.json
@@ -6,6 +6,84 @@
   },
   "fixtures": [
     {
+      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "toolCallId": "call_d6_cc_langgraph_fastapi_weather_001",
+        "context": "langgraph-fastapi"
+      },
+      "response": {
+        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "toolName": "get_weather",
+        "context": "langgraph-fastapi"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_cc_langgraph_fastapi_weather_001",
+            "name": "get_weather",
+            "arguments": "{\"location\":\"Tokyo\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "turnIndex": 0,
+        "context": "langgraph-fastapi"
+      },
+      "response": {
+        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies."
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
+      "match": {
+        "userMessage": "What's the current price of AAPL?",
+        "toolCallId": "call_d6_cc_langgraph_fastapi_stock_001",
+        "context": "langgraph-fastapi"
+      },
+      "response": {
+        "content": "AAPL is trading at $338.37, down 2.96% \u2014 rendered through the custom wildcard catchall."
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
+      "match": {
+        "userMessage": "What's the current price of AAPL?",
+        "toolName": "get_stock_price",
+        "context": "langgraph-fastapi"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_cc_langgraph_fastapi_stock_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
+      "match": {
+        "userMessage": "What's the current price of AAPL?",
+        "turnIndex": 0,
+        "context": "langgraph-fastapi"
+      },
+      "response": {
+        "content": "AAPL is trading at $338.37, down 2.96% on the day."
+      }
+    },
+    {
       "_comment": "custom-catchall — Weather in SF pill. get_weather tool call. Same tools as tool-rendering but the frontend registers a single branded wildcard renderer via useDefaultRenderTool.",
       "match": {
         "userMessage": "Weather in SF",

--- a/showcase/aimock/d6/langgraph-fastapi/tool-rendering-default-catchall.json
+++ b/showcase/aimock/d6/langgraph-fastapi/tool-rendering-default-catchall.json
@@ -6,6 +6,45 @@
   },
   "fixtures": [
     {
+      "_comment": "default-catchall \u2014 weather in Tokyo. Follow-up content after get_weather tool ran. Keyed by toolCallId. MUST come before the tool-emitting fixture below.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "toolCallId": "call_d6_langgraph_fastapi_dc_weather_001",
+        "context": "langgraph-fastapi"
+      },
+      "response": {
+        "content": "Tokyo is 22\u00b0C and partly cloudy."
+      }
+    },
+    {
+      "_comment": "default-catchall \u2014 weather in Tokyo, emit get_weather. Uses toolName gate.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "toolName": "get_weather",
+        "context": "langgraph-fastapi"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_langgraph_fastapi_dc_weather_001",
+            "name": "get_weather",
+            "arguments": "{\"location\":\"Tokyo\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "default-catchall \u2014 weather in Tokyo, fallback content when no toolName gate matches.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "turnIndex": 0,
+        "context": "langgraph-fastapi"
+      },
+      "response": {
+        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies and light easterly winds."
+      }
+    },
+    {
       "_comment": "default-catchall — Weather in SF pill. get_weather tool call. Same tools as tool-rendering but the frontend registers ZERO custom render hooks, relying on the built-in DefaultToolCallRenderer.",
       "match": {
         "userMessage": "Weather in SF",

--- a/showcase/aimock/d6/langgraph-typescript/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/langgraph-typescript/tool-rendering-custom-catchall.json
@@ -8,6 +8,84 @@
   },
   "fixtures": [
     {
+      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "toolCallId": "call_d6_cc_langgraph_typescript_weather_001",
+        "context": "langgraph-typescript"
+      },
+      "response": {
+        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "toolName": "get_weather",
+        "context": "langgraph-typescript"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_cc_langgraph_typescript_weather_001",
+            "name": "get_weather",
+            "arguments": "{\"location\":\"Tokyo\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "turnIndex": 0,
+        "context": "langgraph-typescript"
+      },
+      "response": {
+        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies."
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
+      "match": {
+        "userMessage": "What's the current price of AAPL?",
+        "toolCallId": "call_d6_cc_langgraph_typescript_stock_001",
+        "context": "langgraph-typescript"
+      },
+      "response": {
+        "content": "AAPL is trading at $338.37, down 2.96% \u2014 rendered through the custom wildcard catchall."
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
+      "match": {
+        "userMessage": "What's the current price of AAPL?",
+        "toolName": "get_stock_price",
+        "context": "langgraph-typescript"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_cc_langgraph_typescript_stock_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
+      "match": {
+        "userMessage": "What's the current price of AAPL?",
+        "turnIndex": 0,
+        "context": "langgraph-typescript"
+      },
+      "response": {
+        "content": "AAPL is trading at $338.37, down 2.96% on the day."
+      }
+    },
+    {
       "_comment": "Chain tools \u2014 follow-up content after all 3 tool results return (gated on whichever chained id arrives last).",
       "match": {
         "userMessage": "Chain a few tools in this single turn",

--- a/showcase/aimock/d6/langgraph-typescript/tool-rendering-default-catchall.json
+++ b/showcase/aimock/d6/langgraph-typescript/tool-rendering-default-catchall.json
@@ -7,6 +7,45 @@
   },
   "fixtures": [
     {
+      "_comment": "default-catchall \u2014 weather in Tokyo. Follow-up content after get_weather tool ran. Keyed by toolCallId. MUST come before the tool-emitting fixture below.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "toolCallId": "call_d6_langgraph_typescript_dc_weather_001",
+        "context": "langgraph-typescript"
+      },
+      "response": {
+        "content": "Tokyo is 22\u00b0C and partly cloudy."
+      }
+    },
+    {
+      "_comment": "default-catchall \u2014 weather in Tokyo, emit get_weather. Uses toolName gate.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "toolName": "get_weather",
+        "context": "langgraph-typescript"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_langgraph_typescript_dc_weather_001",
+            "name": "get_weather",
+            "arguments": "{\"location\":\"Tokyo\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "default-catchall \u2014 weather in Tokyo, fallback content when no toolName gate matches.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "turnIndex": 0,
+        "context": "langgraph-typescript"
+      },
+      "response": {
+        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies and light easterly winds."
+      }
+    },
+    {
       "_comment": "default-catchall pill: Chain tools \u2014 follow-up after all 3 tools ran.",
       "match": {
         "userMessage": "Chain a few tools in this single turn",

--- a/showcase/aimock/d6/ms-agent-dotnet/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/ms-agent-dotnet/tool-rendering-custom-catchall.json
@@ -7,6 +7,84 @@
   },
   "fixtures": [
     {
+      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "toolCallId": "call_d6_cc_ms_agent_dotnet_weather_001",
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "toolName": "get_weather",
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_cc_ms_agent_dotnet_weather_001",
+            "name": "get_weather",
+            "arguments": "{\"location\":\"Tokyo\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
+        "turnIndex": 0,
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies."
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
+      "match": {
+        "userMessage": "What's the current price of AAPL?",
+        "toolCallId": "call_d6_cc_ms_agent_dotnet_stock_001",
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "content": "AAPL is trading at $338.37, down 2.96% \u2014 rendered through the custom wildcard catchall."
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
+      "match": {
+        "userMessage": "What's the current price of AAPL?",
+        "toolName": "get_stock_price",
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_cc_ms_agent_dotnet_stock_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
+      "match": {
+        "userMessage": "What's the current price of AAPL?",
+        "turnIndex": 0,
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "content": "AAPL is trading at $338.37, down 2.96% on the day."
+      }
+    },
+    {
       "_comment": "Chain tools — follow-up after all 3 tools ran. Anchored on whichever of the 3 chain toolCallIds appears last in the request (LangGraph's ToolNode preserves tool_calls order). MUST come before the toolCalls-emitting fixture below so iteration 2 of the chain-tools loop hits this branch instead of re-emitting.",
       "match": {
         "userMessage": "Chain a few tools in this single turn",


### PR DESCRIPTION
## Summary
PR #5453 renamed stale catchall userMessage `"check Tokyo weather forecast"` → `"forecast for Tokyo"` to match the D5 probe input. But some integrations' catchall fixtures used **pill-aligned userMessages** (e.g. LG-TS, LG-FastAPI used `"Chain a few tools in this single turn"`, `"What's the weather in San Francisco?"`) — they had no `"forecast for Tokyo"` matcher to rename. Result: D5 catchall probe still misses → live LLM fallback → cells stay red on staging.

## Fix
Add the canonical emit+narrate fixture pairs for `"forecast for Tokyo"` (default + custom catchall) and `"What's the current price of AAPL?"` (custom catchall only) — adapting mastra's working template — to each integration that was missing them.

## Scope
4 integrations × 1-2 files each (6 files total):
- LG-TS, LG-FastAPI: both default + custom catchall
- google-adk, ms-agent-dotnet: custom catchall only (their default is already green)

Existing pill-aligned fixtures preserved (pure prepend at start of array). First-match-wins means new fixtures match the D5 probe inputs ("forecast for Tokyo", "What's the current price of AAPL?") without colliding with existing pill prompts. `toolCallId` values are unique per integration to avoid cross-integration shadowing.

Note: the originally-flagged langroid, llamaindex, agno, claude-sdk-python, and strands files already have `forecast for Tokyo` + AAPL matchers in their catchall fixtures (likely from a prior pass) — they did not need changes and are not in this PR. If those staging cells are still red, the root cause is elsewhere (control-plane staleness, deploy lag, or different probe variant).

## Verification
Post-merge, fleet-cp's e2e-deep probe will re-run within ≤6h staleness. Cells should flip d6:<slug>/tool-rendering-{default,custom}-catchall = green.