### PR TITLE
fix(showcase/aimock): align catchall fixture shape for 6 remaining D5 reds

### DIFF
--- a/showcase/aimock/d6/agno/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/agno/tool-rendering-custom-catchall.json
@@ -2,7 +2,9 @@
   "_meta": {
     "description": "D6 fixtures for agno / tool-rendering-custom-catchall",
     "sourceFile": "d5-tool-rendering-custom-catchall.ts",
-    "created": "2026-05-22"
+    "created": "2026-05-22",
+    "updated": "2026-06-15",
+    "note": "Dropped hasToolResult:false gate on tool-emit fixtures. Reason: the D5 probe runs 'forecast for Tokyo' first, leaving a get_weather tool result in the thread. aimock's hasToolResult is messages.some(m=>m.role==='tool'), so it becomes permanently true on the AAPL turn — hasToolResult:false would never match → no fixture → 30s timeout. The toolCallId-gated narration fixtures still win on iteration 2 (last message is tool with matching id), so the tool-emit fixtures only fire on the first leg of each prompt."
   },
   "fixtures": [
     {
@@ -13,14 +15,13 @@
         "context": "agno"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy."
+        "content": "Tokyo is 22°C and partly cloudy."
       }
     },
     {
-      "_comment": "custom-catchall turn 1: 'weather in Tokyo' \u2014 emit get_weather tool call. The custom wildcard renderer fires for this tool because no per-tool renderer is registered. Probe asserts [data-testid='custom-wildcard-card'][data-tool-name='get_weather'] mounts.",
+      "_comment": "custom-catchall turn 1: 'weather in Tokyo' — emit get_weather tool call. The custom wildcard renderer fires for this tool because no per-tool renderer is registered. Probe asserts [data-testid='custom-wildcard-card'][data-tool-name='get_weather'] mounts. No hasToolResult gate: matches on userMessage+context alone; the toolCallId narration above wins after the tool result arrives.",
       "match": {
         "userMessage": "forecast for Tokyo",
-        "hasToolResult": false,
         "context": "agno"
       },
       "response": {
@@ -45,10 +46,9 @@
       }
     },
     {
-      "_comment": "custom-catchall turn 2: 'What's the current price of AAPL?' \u2014 emit get_stock_price tool call. Probe asserts BOTH get_weather and get_stock_price rendered through custom-wildcard-card (cross-tool snapshot).",
+      "_comment": "custom-catchall turn 2: 'What's the current price of AAPL?' — emit get_stock_price tool call. Probe asserts BOTH get_weather and get_stock_price rendered through custom-wildcard-card (cross-tool snapshot). No hasToolResult gate (the Tokyo tool result from turn 1 makes hasToolResult permanently true here).",
       "match": {
         "userMessage": "current price of AAPL",
-        "hasToolResult": false,
         "context": "agno"
       },
       "response": {

--- a/showcase/aimock/d6/claude-sdk-python/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/claude-sdk-python/tool-rendering-custom-catchall.json
@@ -3,7 +3,9 @@
     "description": "D6 fixtures for claude-sdk-python / tool-rendering-custom-catchall",
     "sourceScript": "d5-tool-rendering-custom-catchall.ts",
     "copiedFrom": "langgraph-python",
-    "created": "2026-05-22"
+    "created": "2026-05-22",
+    "updated": "2026-06-15",
+    "note": "Dropped the toolName gate on tool-emit fixtures and the no-tool-registered fallback. Reason: when toolName:get_stock_price failed to match (claude-sdk-python backend appears not to forward the tool definition uniformly on the second turn), the userMessage-only fallback returned plain content with no toolCall → no custom-wildcard card → D5 assertion fails with 'missing tool name [get_stock_price]'. Canonical pattern (no gate on tool-emit, toolCallId narration above for first-match-wins) lets the tool call always emit; the toolCallId narration fires on iteration 2 regardless of which tools the backend forwards."
   },
   "fixtures": [
     {
@@ -18,10 +20,9 @@
       }
     },
     {
-      "_comment": "custom-catchall: weather in Tokyo first leg: emit get_weather tool call. The custom wildcard renderer fires for this tool (no per-tool renderer registered).",
+      "_comment": "custom-catchall: weather in Tokyo first leg — emit get_weather tool call. The custom wildcard renderer fires for this tool. Matches on userMessage+context alone; the toolCallId narration above wins after the tool result arrives.",
       "match": {
         "userMessage": "forecast for Tokyo",
-        "toolName": "get_weather",
         "context": "claude-sdk-python"
       },
       "response": {
@@ -32,16 +33,6 @@
             "arguments": "{\"location\":\"Tokyo\"}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "custom-catchall: weather in Tokyo fallback when get_weather tool not registered.",
-      "match": {
-        "userMessage": "forecast for Tokyo",
-        "context": "claude-sdk-python"
-      },
-      "response": {
-        "content": "The weather in Tokyo is currently 22°C with partly cloudy skies and light easterly winds."
       }
     },
     {
@@ -56,10 +47,9 @@
       }
     },
     {
-      "_comment": "custom-catchall: AAPL stock price first leg: emit get_stock_price tool call.",
+      "_comment": "custom-catchall: AAPL stock price first leg — emit get_stock_price tool call. No toolName/hasToolResult gate so the tool call emits regardless of which tools the backend forwards on the second turn. The toolCallId narration above wins on iteration 2.",
       "match": {
         "userMessage": "What's the current price of AAPL?",
-        "toolName": "get_stock_price",
         "context": "claude-sdk-python"
       },
       "response": {
@@ -70,16 +60,6 @@
             "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "custom-catchall: AAPL fallback when no get_stock_price tool registered.",
-      "match": {
-        "userMessage": "What's the current price of AAPL?",
-        "context": "claude-sdk-python"
-      },
-      "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
       }
     }
   ]

--- a/showcase/aimock/d6/langroid/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/langroid/tool-rendering-custom-catchall.json
@@ -2,14 +2,26 @@
   "_meta": {
     "description": "D6 fixtures for langroid / tool-rendering-custom-catchall",
     "sourceScript": "d5-tool-rendering-custom-catchall.ts",
-    "created": "2026-05-22"
+    "created": "2026-05-22",
+    "updated": "2026-06-15",
+    "note": "Restructured to canonical pattern: toolCallId-keyed narration BEFORE userMessage-only tool-emit fixtures, first-match-wins. Previously used hasToolResult:true/false gates which break on the multi-prompt AAPL turn (the Tokyo tool result from turn 1 makes hasToolResult permanently true)."
   },
   "fixtures": [
     {
-      "_comment": "Custom catchall turn 1: weather in Tokyo \u2014 emits get_weather tool call. The custom wildcard renderer fires for this tool. hasToolResult:false on first leg.",
+      "_comment": "Custom catchall turn 1 follow-up: after get_weather tool result. Keyed by toolCallId so it only fires on the post-tool leg; ordered before the tool-emit fixture below for first-match-wins.",
       "match": {
         "userMessage": "forecast for Tokyo",
-        "hasToolResult": false,
+        "toolCallId": "call_d6_lr_cc_weather_001",
+        "context": "langroid"
+      },
+      "response": {
+        "content": "Tokyo is 22°C and partly cloudy."
+      }
+    },
+    {
+      "_comment": "Custom catchall turn 1: weather in Tokyo — emit get_weather tool call. The custom wildcard renderer fires for this tool. Matches on userMessage+context alone (no hasToolResult gate); the toolCallId narration above wins after the tool result arrives.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
         "context": "langroid"
       },
       "response": {
@@ -23,21 +35,20 @@
       }
     },
     {
-      "_comment": "Custom catchall turn 1: weather in Tokyo \u2014 follow-up after tool result.",
+      "_comment": "Custom catchall turn 2 follow-up: after get_stock_price tool result. Keyed by toolCallId; must come before the tool-emit fixture below.",
       "match": {
-        "userMessage": "forecast for Tokyo",
-        "hasToolResult": true,
+        "userMessage": "current price of AAPL",
+        "toolCallId": "call_d6_lr_cc_stock_001",
         "context": "langroid"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy."
+        "content": "AAPL is trading at $338.37, down 2.96% on the day."
       }
     },
     {
-      "_comment": "Custom catchall turn 2: AAPL stock price \u2014 emits get_stock_price tool call. Both this and get_weather must render through the same custom-wildcard-card testid. hasToolResult:false on first leg.",
+      "_comment": "Custom catchall turn 2: AAPL stock price — emit get_stock_price tool call. Both this and get_weather must render through the same custom-wildcard-card testid. No hasToolResult gate (the Tokyo tool result from turn 1 makes hasToolResult permanently true).",
       "match": {
         "userMessage": "current price of AAPL",
-        "hasToolResult": false,
         "context": "langroid"
       },
       "response": {
@@ -48,17 +59,6 @@
             "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "Custom catchall turn 2: AAPL stock price \u2014 follow-up after tool result.",
-      "match": {
-        "userMessage": "current price of AAPL",
-        "hasToolResult": true,
-        "context": "langroid"
-      },
-      "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
       }
     }
   ]

--- a/showcase/aimock/d6/llamaindex/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/llamaindex/tool-rendering-custom-catchall.json
@@ -2,7 +2,9 @@
   "_meta": {
     "description": "D6 fixtures for llamaindex / tool-rendering-custom-catchall",
     "sourceScript": "d5-tool-rendering-custom-catchall.ts",
-    "created": "2026-05-22"
+    "created": "2026-05-22",
+    "updated": "2026-06-15",
+    "note": "Dropped hasToolResult:false on tool-emit fixtures — the Tokyo tool result from turn 1 stays in the thread, making hasToolResult permanently true on the AAPL turn → no fixture match → 30s timeout. toolCallId-keyed narration above still wins on iteration 2."
   },
   "fixtures": [
     {
@@ -20,7 +22,6 @@
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo first leg: emit get_weather tool call. The custom catchall renderer fires for this tool since there's no per-tool renderer registered.",
       "match": {
         "userMessage": "forecast for Tokyo",
-        "hasToolResult": false,
         "context": "llamaindex"
       },
       "response": {
@@ -48,7 +49,6 @@
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price first leg: emit get_stock_price tool call. Second prompt in the cross-tool assertion pair.",
       "match": {
         "userMessage": "current price of AAPL",
-        "hasToolResult": false,
         "context": "llamaindex"
       },
       "response": {

--- a/showcase/aimock/d6/strands/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/strands/tool-rendering-custom-catchall.json
@@ -2,14 +2,26 @@
   "_meta": {
     "description": "D6 fixtures for strands / tool-rendering-custom-catchall",
     "sourceFile": "d5-tool-rendering-custom-catchall.ts",
-    "created": "2026-05-22"
+    "created": "2026-05-22",
+    "updated": "2026-06-15",
+    "note": "Reordered toolCallId-keyed narration BEFORE tool-emit fixtures (first-match-wins) and dropped hasToolResult:false gates. Reason: with the previous tool-emit-first ordering the toolCallId narration could not pre-empt re-emission on iteration 2; hasToolResult:false also breaks on the AAPL turn because the Tokyo tool result from turn 1 persists in the thread."
   },
   "fixtures": [
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 'weather in Tokyo' first turn. Emits get_weather tool call. The custom wildcard renderer fires for ANY tool the integration didn't register a per-tool renderer for, rendering [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
+      "_comment": "tool-rendering-custom-catchall — weather follow-up after tool result. MUST come before the tool-emitting fixture (first-match-wins).",
       "match": {
         "userMessage": "forecast for Tokyo",
-        "hasToolResult": false,
+        "toolCallId": "call_d6_custom_catchall_weather_001",
+        "context": "strands"
+      },
+      "response": {
+        "content": "Tokyo is 22°C and partly cloudy with a gentle easterly breeze."
+      }
+    },
+    {
+      "_comment": "tool-rendering-custom-catchall — 'weather in Tokyo' first turn. Emits get_weather tool call. The custom wildcard renderer fires for ANY tool the integration didn't register a per-tool renderer for, rendering [data-testid='custom-wildcard-card'][data-tool-name='get_weather']. Matches on userMessage+context alone; toolCallId narration above wins after the tool result arrives.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
         "context": "strands"
       },
       "response": {
@@ -23,21 +35,20 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather follow-up after tool result.",
+      "_comment": "tool-rendering-custom-catchall — stock follow-up after tool result. MUST come before the tool-emitting fixture.",
       "match": {
-        "userMessage": "forecast for Tokyo",
-        "toolCallId": "call_d6_custom_catchall_weather_001",
+        "userMessage": "current price of AAPL",
+        "toolCallId": "call_d6_custom_catchall_stock_001",
         "context": "strands"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy with a gentle easterly breeze."
+        "content": "AAPL is trading at $338.37, down 2.96% on the day."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 'AAPL stock price' second turn. Emits get_stock_price tool call. The custom wildcard renderer fires again with [data-tool-name='get_stock_price']. The cross-tool assertion verifies BOTH tool names rendered through the same custom-wildcard-card testid.",
+      "_comment": "tool-rendering-custom-catchall — 'AAPL stock price' second turn. Emits get_stock_price tool call. The custom wildcard renderer fires again with [data-tool-name='get_stock_price']. The cross-tool assertion verifies BOTH tool names rendered through the same custom-wildcard-card testid. No hasToolResult gate (the Tokyo tool result from turn 1 makes hasToolResult permanently true).",
       "match": {
         "userMessage": "current price of AAPL",
-        "hasToolResult": false,
         "context": "strands"
       },
       "response": {
@@ -48,17 +59,6 @@
             "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 stock follow-up after tool result.",
-      "match": {
-        "userMessage": "current price of AAPL",
-        "toolCallId": "call_d6_custom_catchall_stock_001",
-        "context": "strands"
-      },
-      "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
       }
     }
   ]

--- a/showcase/aimock/d6/strands/tool-rendering-default-catchall.json
+++ b/showcase/aimock/d6/strands/tool-rendering-default-catchall.json
@@ -2,14 +2,26 @@
   "_meta": {
     "description": "D6 fixtures for strands / tool-rendering-default-catchall",
     "sourceFile": "d5-tool-rendering-default-catchall.ts",
-    "created": "2026-05-22"
+    "created": "2026-05-22",
+    "updated": "2026-06-15",
+    "note": "Reordered toolCallId-keyed narration BEFORE the tool-emit fixture (first-match-wins) and dropped hasToolResult:false on the tool-emit fixture for consistency with the canonical pattern. Single-prompt demo so hasToolResult:false would still work in isolation, but the canonical shape is more robust to thread-state changes."
   },
   "fixtures": [
     {
-      "_comment": "tool-rendering-default-catchall \u2014 'weather in Tokyo' turn. Emits get_weather tool call. The built-in default catchall renderer fires (CopilotKit's own renderer for unhandled tools), rendering [data-testid='copilot-tool-render'][data-tool-name='get_weather'] with a status pill.",
+      "_comment": "tool-rendering-default-catchall — follow-up after get_weather tool result. MUST come before the tool-emitting fixture (first-match-wins).",
       "match": {
         "userMessage": "forecast for Tokyo",
-        "hasToolResult": false,
+        "toolCallId": "call_d6_default_catchall_weather_001",
+        "context": "strands"
+      },
+      "response": {
+        "content": "Tokyo is 22°C and partly cloudy with light easterly winds."
+      }
+    },
+    {
+      "_comment": "tool-rendering-default-catchall — 'weather in Tokyo' turn. Emits get_weather tool call. The built-in default catchall renderer fires (CopilotKit's own renderer for unhandled tools), rendering [data-testid='copilot-tool-render'][data-tool-name='get_weather'] with a status pill. Matches on userMessage+context alone; toolCallId narration above wins after the tool result arrives.",
+      "match": {
+        "userMessage": "forecast for Tokyo",
         "context": "strands"
       },
       "response": {
@@ -20,17 +32,6 @@
             "arguments": "{\"location\":\"Tokyo\"}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-default-catchall \u2014 follow-up after get_weather tool result.",
-      "match": {
-        "userMessage": "forecast for Tokyo",
-        "toolCallId": "call_d6_default_catchall_weather_001",
-        "context": "strands"
-      },
-      "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy with light easterly winds."
       }
     }
   ]


### PR DESCRIPTION
## Summary

Follow-up to #5459. That PR added the right `userMessage` matchers ("forecast for Tokyo" + "current price of AAPL") and flipped most integrations green, but 6 cells stayed red because the FIXTURE SHAPE on the matched fixtures was also broken.

**Failing cells (post-#5459 deploy):**

- `d5:agno/tool-rendering-custom-catchall`
- `d5:llamaindex/tool-rendering-custom-catchall`
- `d5:langroid/tool-rendering-custom-catchall`
- `d5:claude-sdk-python/tool-rendering-custom-catchall`
- `d5:strands/tool-rendering-custom-catchall`
- `d5:strands/tool-rendering-default-catchall`

## Root cause

The failing tool-emit fixtures all used `hasToolResult: false` (or `toolName: "<tool>"`) as their gate. The custom-catchall probe drives TWO sequential prompts (Tokyo, then AAPL). After Tokyo's tool result lands in the thread, aimock's `hasToolResult` is permanently true (`messages.some(m => m.role === 'tool')`), so `hasToolResult:false` can never match the AAPL turn → no fixture → 30s timeout.

PocketBase confirms this exact mode — e.g. agno:

```
errorDesc: "timeout: assistant did not respond within 30000ms"
failure_turn: 2
turns_completed: 1 / 2
```

claude-sdk-python's `toolName` gate fails for an analogous reason on the second turn when the backend doesn't forward the tool definition uniformly.

The same trap is documented in `showcase/aimock/d6/langgraph-python/tool-rendering.json`:

> Gated on toolName:get_stock_price rather than hasToolResult:false. The D5 tool-rendering-custom-catchall probe runs 'weather in Tokyo' first, which leaves a get_weather tool result in the thread; the aimock router implements hasToolResult as messages.some(m=>m.role==='tool'), so hasToolResult is permanently true on the AAPL turn and a hasToolResult:false gate could never match (→ no_fixture_match → 503 → 30s timeout).

## Fix

Align all 6 files to the canonical pattern used by working integrations (mastra, spring-ai, built-in-agent):

1. `toolCallId`-keyed narration fixture FIRST
2. tool-emit fixture SECOND, gated ONLY on `userMessage` + `context` (no `hasToolResult` / `toolName`)

aimock's `toolCallId` matcher checks `messages[last].role === 'tool' && tool_call_id === ...`, which correctly fires only on the post-tool-result iteration regardless of older tool results in the thread. The tool-emit fixture below it always matches on turn-init (last message is user).

Strands' two files additionally needed REORDERING — they had the tool-emit fixture before the toolCallId fixture, defeating first-match-wins.

## Scope discipline

- Pure fixture-content alignment — no harness, probe, frontend, or backend changes.
- Did NOT touch `showcase/harness/**` (peer session territory per `/tmp/coordinate/showcase-reds-coord/CHANNEL.md`).
- Did NOT touch the two `d5-tool-rendering-*-catchall.ts` probes.

## Caveat (strands)

During investigation, `showcase-strands-staging.up.railway.app` was returning 502 / page-load failures (infra, not fixture). Strands' fixture defects are still real and worth correcting, but the cells may stay red until the backend recovers.

## Test plan

- [ ] CI green
- [ ] Wait for `showcase_build.yml -f service=aimock` rebuild + Railway redeploy
- [ ] Re-check PocketBase `state` for the 6 cells flips to `green` (excluding strands if backend stays down)
- [ ] Confirm no regression on the other catchall cells already green post-#5459