### PR TITLE
fix(react-core): await runAgent in useInterrupt::resolve and propagate to demo-local hooks

### DIFF
--- a/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
@@ -63,6 +63,7 @@ describe("useInterrupt", () => {
     // F21: clean up the test-only global installed by the 2nd-interrupt
     // BugHarness so it cannot leak across tests.
     delete (globalThis as { __forceRerender?: () => void }).__forceRerender;
+    runAgentMock.mockReset();
   });
 
   function Harness({
@@ -628,6 +629,133 @@ describe("useInterrupt", () => {
     expect(handler).not.toHaveBeenCalled();
     expect(screen.queryByTestId("interrupt")).toBeNull();
     expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  // RESUME-PATH regression: `resolve()` MUST return a Promise that settles
+  // only when the underlying `copilotkit.runAgent` call settles. Callers
+  // (e.g. the showcase `interrupt-headless` demo's `useHeadlessInterrupt`,
+  // or any consumer that wants to chain post-resume UI like the harness
+  // DOM settle-check for the confirmation bubble) cannot sequence against
+  // the resume run otherwise. The showcase quarantine of `interrupt-headless`
+  // cites exactly this failure mode: backend resumes + streams (HTTP 200),
+  // but downstream observers can't tell when the resume has actually
+  // landed because resolve() returns void instead of a Promise.
+  it("resolve returns a Promise that settles when runAgent settles (RESUME-PATH)", async () => {
+    // Make runAgent return a manually-controlled promise so we can assert
+    // resolve() awaits it rather than fire-and-forget.
+    let releaseRunAgent: ((result: { newMessages: never[] }) => void) | null =
+      null;
+    runAgentMock.mockImplementation(
+      () =>
+        new Promise((res) => {
+          releaseRunAgent = res;
+        }),
+    );
+
+    let capturedResolve: ((response: unknown) => unknown) | null = null;
+    function CaptureHarness() {
+      useInterrupt({
+        renderInChat: false,
+        render: ({ event, resolve }) => {
+          capturedResolve = resolve;
+          return <button data-testid="interrupt">{String(event.value)}</button>;
+        },
+      });
+      return <div />;
+    }
+
+    render(<CaptureHarness />);
+    emitInterrupt("resume-me");
+
+    // resolve must exist and must return a thenable.
+    expect(capturedResolve).toBeTypeOf("function");
+    const returnedFromResolve = capturedResolve!({ approved: true });
+    expect(returnedFromResolve).toBeDefined();
+    expect(
+      returnedFromResolve &&
+        typeof (returnedFromResolve as { then?: unknown }).then === "function",
+    ).toBe(true);
+
+    // runAgent was dispatched.
+    expect(runAgentMock).toHaveBeenCalledTimes(1);
+
+    // Race against a sentinel to assert the returned promise has NOT yet
+    // settled (runAgent is still pending). Deterministic regardless of
+    // internal microtask-chain depth.
+    const before = await Promise.race([
+      returnedFromResolve as Promise<unknown>,
+      Promise.resolve("pending"),
+    ]);
+    expect(before).toBe("pending");
+
+    // Settle the runAgent promise and deterministically await the
+    // returned promise inside act() so React state updates flush.
+    await act(async () => {
+      releaseRunAgent!({ newMessages: [] });
+      await returnedFromResolve;
+    });
+
+    // The returned promise must resolve with the runAgent result, not
+    // just settle. A regression where resolve() returns a different
+    // settled promise (or `undefined` cast as thenable) would otherwise
+    // still pass.
+    const value = await returnedFromResolve;
+    expect(value).toEqual({ newMessages: [] });
+  });
+
+  // RESUME-PATH-REJECT regression (CR Round 3 Fix D): if `runAgent` rejects
+  // synchronously / before the run actually starts (network error, auth
+  // failure, validation reject), `onRunFailed` may never fire — meaning the
+  // popup would stay mounted indefinitely. The framework `resolve` catch
+  // MUST clear `pendingEvent` AND rethrow so callers see the error. This
+  // test asserts both: rejection propagates, console.error fires, and the
+  // popup unmounts (no `interrupt` test-id in the DOM).
+  it("resolve rejects when runAgent rejects, logs the failure, and clears pending (RESUME-PATH-REJECT)", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const rejection = new Error("boom");
+    runAgentMock.mockImplementationOnce(() => Promise.reject(rejection));
+
+    let capturedResolve: ((response: unknown) => unknown) | null = null;
+    function RejectHarness() {
+      const element = useInterrupt({
+        renderInChat: false,
+        render: ({ event, resolve }) => {
+          capturedResolve = resolve;
+          return <button data-testid="interrupt">{String(event.value)}</button>;
+        },
+      });
+      return <div data-testid="reject-container">{element}</div>;
+    }
+
+    render(<RejectHarness />);
+    emitInterrupt("reject-me");
+
+    // The popup should currently be mounted (pending event was set).
+    expect(screen.queryByTestId("interrupt")).not.toBeNull();
+    expect(capturedResolve).toBeTypeOf("function");
+
+    // Call resolve and await rejection inside act so React state flushes.
+    const returnedFromResolve = capturedResolve!({
+      approved: true,
+    }) as Promise<unknown>;
+
+    await act(async () => {
+      await expect(returnedFromResolve).rejects.toBe(rejection);
+    });
+
+    expect(runAgentMock).toHaveBeenCalledTimes(1);
+
+    // Console.error MUST have been called with the rejection (so callers
+    // grepping logs can detect the failure even if they don't `await`).
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("runAgent rejected"),
+      rejection,
+    );
+
+    // Popup MUST be unmounted — pendingEvent cleared by the catch.
+    expect(screen.queryByTestId("interrupt")).toBeNull();
+
     errorSpy.mockRestore();
   });
 });

--- a/packages/react-core/src/v2/hooks/use-interrupt.tsx
+++ b/packages/react-core/src/v2/hooks/use-interrupt.tsx
@@ -212,6 +212,7 @@ export function useInterrupt<
       },
       onRunFailed: () => {
         localInterrupt = null;
+        setPendingEvent(null);
       },
     });
 
@@ -219,20 +220,39 @@ export function useInterrupt<
   }, [agent]);
 
   const resolve = useCallback(
-    (response: unknown) => {
+    async (response: unknown) => {
       // Do NOT synchronously clear pendingEvent here — onRunStartedEvent
       // already clears it when the resume run begins. Clearing synchronously
       // unmounts the card before commit, which previously forced consumers
       // to wrap their resolve() in a 500ms setTimeout to keep the UI alive.
-      copilotkit.runAgent({
-        agent,
-        forwardedProps: {
-          command: {
-            resume: response,
-            interruptEvent: pendingEventRef.current?.value,
+      //
+      // RESUME-PATH: await runAgent and return the result so callers can
+      // sequence post-resume UI (e.g. harness DOM settle-check waiting for
+      // the assistant confirmation bubble). Returning void here is the bug
+      // that quarantined the showcase manifests' interrupt-headless feature.
+      try {
+        return await copilotkit.runAgent({
+          agent,
+          forwardedProps: {
+            command: {
+              resume: response,
+              interruptEvent: pendingEventRef.current?.value,
+            },
           },
-        },
-      });
+        });
+      } catch (err) {
+        // Catastrophic rejection path: runAgent rejected before/around the
+        // run actually starting (network error, auth failure, validation
+        // reject). In that case `onRunFailed` may never fire — so clear
+        // `pendingEvent` here so the popup unmounts. Symmetric with the
+        // `onRunFailed` handler above; both write null, so no race.
+        console.error(
+          "[CopilotKit] useInterrupt resolve: runAgent rejected; clearing pending + rethrowing",
+          err,
+        );
+        setPendingEvent(null);
+        throw err;
+      }
     },
     [agent, copilotkit],
   );

--- a/packages/react-core/src/v2/types/interrupt.ts
+++ b/packages/react-core/src/v2/types/interrupt.ts
@@ -1,3 +1,5 @@
+import type { RunAgentResult } from "@ag-ui/client";
+
 export interface InterruptEvent<TValue = unknown> {
   name: string;
   value: TValue;
@@ -5,11 +7,11 @@ export interface InterruptEvent<TValue = unknown> {
 
 export interface InterruptHandlerProps<TValue = unknown> {
   event: InterruptEvent<TValue>;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<RunAgentResult>;
 }
 
 export interface InterruptRenderProps<TValue = unknown, TResult = unknown> {
   event: InterruptEvent<TValue>;
   result: TResult;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<RunAgentResult>;
 }

--- a/showcase/integrations/ag2/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/interrupt-headless/page.tsx
@@ -10,7 +10,7 @@
 // popup vanishes, and the agent confirms back in chat.
 
 // @region[headless-useinterrupt-primitives]
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -71,11 +71,13 @@ function Layout() {
 
 function useHeadlessInterrupt(agentId: string): {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 } {
   const { copilotkit } = useCopilotKit();
   const { agent } = useAgent({ agentId });
   const [pending, setPending] = useState<InterruptEvent | null>(null);
+  const pendingRef = useRef<InterruptEvent | null>(null);
+  pendingRef.current = pending;
 
   useEffect(() => {
     let local: InterruptEvent | null = null;
@@ -105,17 +107,17 @@ function useHeadlessInterrupt(agentId: string): {
       },
       onRunFailed: () => {
         local = null;
+        setPending(null);
       },
     });
     return () => sub.unsubscribe();
   }, [agent]);
 
   const resolve = useMemo(
-    () => (response: unknown) => {
-      const snapshot = pending;
-      setPending(null);
-      void copilotkit
-        .runAgent({
+    () => async (response: unknown) => {
+      const snapshot = pendingRef.current;
+      try {
+        return await copilotkit.runAgent({
           agent,
           forwardedProps: {
             command: {
@@ -123,10 +125,22 @@ function useHeadlessInterrupt(agentId: string): {
               interruptEvent: snapshot?.value,
             },
           },
-        })
-        .catch(() => {});
+        });
+      } catch (err) {
+        // Catastrophic rejection (network error, auth failure, validation
+        // reject) may fire before the run starts, so onRunFailed never runs.
+        // Clear pending here so the popup unmounts. Symmetric with the
+        // framework resolve catch + onRunFailed handler — all write null,
+        // no race. Caller still sees the rethrow.
+        console.error(
+          "[interrupt-headless] resume runAgent rejected; clearing pending + rethrowing",
+          err,
+        );
+        setPending(null);
+        throw err;
+      }
     },
-    [agent, copilotkit, pending],
+    [agent, copilotkit],
   );
 
   return { pending, resolve };
@@ -135,7 +149,7 @@ function useHeadlessInterrupt(agentId: string): {
 
 type AppSurfaceProps = {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 };
 
 function AppSurface({ pending, resolve }: AppSurfaceProps) {

--- a/showcase/integrations/agno/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/interrupt-headless/page.tsx
@@ -10,7 +10,7 @@
 // popup vanishes, and the agent confirms back in chat.
 
 // @region[headless-useinterrupt-primitives]
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -71,11 +71,13 @@ function Layout() {
 
 function useHeadlessInterrupt(agentId: string): {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 } {
   const { copilotkit } = useCopilotKit();
   const { agent } = useAgent({ agentId });
   const [pending, setPending] = useState<InterruptEvent | null>(null);
+  const pendingRef = useRef<InterruptEvent | null>(null);
+  pendingRef.current = pending;
 
   useEffect(() => {
     let local: InterruptEvent | null = null;
@@ -105,17 +107,17 @@ function useHeadlessInterrupt(agentId: string): {
       },
       onRunFailed: () => {
         local = null;
+        setPending(null);
       },
     });
     return () => sub.unsubscribe();
   }, [agent]);
 
   const resolve = useMemo(
-    () => (response: unknown) => {
-      const snapshot = pending;
-      setPending(null);
-      void copilotkit
-        .runAgent({
+    () => async (response: unknown) => {
+      const snapshot = pendingRef.current;
+      try {
+        return await copilotkit.runAgent({
           agent,
           forwardedProps: {
             command: {
@@ -123,10 +125,22 @@ function useHeadlessInterrupt(agentId: string): {
               interruptEvent: snapshot?.value,
             },
           },
-        })
-        .catch(() => {});
+        });
+      } catch (err) {
+        // Catastrophic rejection (network error, auth failure, validation
+        // reject) may fire before the run starts, so onRunFailed never runs.
+        // Clear pending here so the popup unmounts. Symmetric with the
+        // framework resolve catch + onRunFailed handler — all write null,
+        // no race. Caller still sees the rethrow.
+        console.error(
+          "[interrupt-headless] resume runAgent rejected; clearing pending + rethrowing",
+          err,
+        );
+        setPending(null);
+        throw err;
+      }
     },
-    [agent, copilotkit, pending],
+    [agent, copilotkit],
   );
 
   return { pending, resolve };
@@ -135,7 +149,7 @@ function useHeadlessInterrupt(agentId: string): {
 
 type AppSurfaceProps = {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 };
 
 function AppSurface({ pending, resolve }: AppSurfaceProps) {

--- a/showcase/integrations/claude-sdk-typescript/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/integrations/claude-sdk-typescript/src/app/demos/interrupt-headless/page.tsx
@@ -10,7 +10,7 @@
 // popup vanishes, and the agent confirms back in chat.
 
 // @region[headless-useinterrupt-primitives]
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -71,11 +71,13 @@ function Layout() {
 
 function useHeadlessInterrupt(agentId: string): {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 } {
   const { copilotkit } = useCopilotKit();
   const { agent } = useAgent({ agentId });
   const [pending, setPending] = useState<InterruptEvent | null>(null);
+  const pendingRef = useRef<InterruptEvent | null>(null);
+  pendingRef.current = pending;
 
   useEffect(() => {
     let local: InterruptEvent | null = null;
@@ -105,17 +107,17 @@ function useHeadlessInterrupt(agentId: string): {
       },
       onRunFailed: () => {
         local = null;
+        setPending(null);
       },
     });
     return () => sub.unsubscribe();
   }, [agent]);
 
   const resolve = useMemo(
-    () => (response: unknown) => {
-      const snapshot = pending;
-      setPending(null);
-      void copilotkit
-        .runAgent({
+    () => async (response: unknown) => {
+      const snapshot = pendingRef.current;
+      try {
+        return await copilotkit.runAgent({
           agent,
           forwardedProps: {
             command: {
@@ -123,10 +125,22 @@ function useHeadlessInterrupt(agentId: string): {
               interruptEvent: snapshot?.value,
             },
           },
-        })
-        .catch(() => {});
+        });
+      } catch (err) {
+        // Catastrophic rejection (network error, auth failure, validation
+        // reject) may fire before the run starts, so onRunFailed never runs.
+        // Clear pending here so the popup unmounts. Symmetric with the
+        // framework resolve catch + onRunFailed handler — all write null,
+        // no race. Caller still sees the rethrow.
+        console.error(
+          "[interrupt-headless] resume runAgent rejected; clearing pending + rethrowing",
+          err,
+        );
+        setPending(null);
+        throw err;
+      }
     },
-    [agent, copilotkit, pending],
+    [agent, copilotkit],
   );
 
   return { pending, resolve };
@@ -135,7 +149,7 @@ function useHeadlessInterrupt(agentId: string): {
 
 type AppSurfaceProps = {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 };
 
 function AppSurface({ pending, resolve }: AppSurfaceProps) {

--- a/showcase/integrations/crewai-crews/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/interrupt-headless/page.tsx
@@ -10,7 +10,7 @@
 // popup vanishes, and the agent confirms back in chat.
 
 // @region[headless-useinterrupt-primitives]
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -71,11 +71,13 @@ function Layout() {
 
 function useHeadlessInterrupt(agentId: string): {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 } {
   const { copilotkit } = useCopilotKit();
   const { agent } = useAgent({ agentId });
   const [pending, setPending] = useState<InterruptEvent | null>(null);
+  const pendingRef = useRef<InterruptEvent | null>(null);
+  pendingRef.current = pending;
 
   useEffect(() => {
     let local: InterruptEvent | null = null;
@@ -105,17 +107,17 @@ function useHeadlessInterrupt(agentId: string): {
       },
       onRunFailed: () => {
         local = null;
+        setPending(null);
       },
     });
     return () => sub.unsubscribe();
   }, [agent]);
 
   const resolve = useMemo(
-    () => (response: unknown) => {
-      const snapshot = pending;
-      setPending(null);
-      void copilotkit
-        .runAgent({
+    () => async (response: unknown) => {
+      const snapshot = pendingRef.current;
+      try {
+        return await copilotkit.runAgent({
           agent,
           forwardedProps: {
             command: {
@@ -123,10 +125,22 @@ function useHeadlessInterrupt(agentId: string): {
               interruptEvent: snapshot?.value,
             },
           },
-        })
-        .catch(() => {});
+        });
+      } catch (err) {
+        // Catastrophic rejection (network error, auth failure, validation
+        // reject) may fire before the run starts, so onRunFailed never runs.
+        // Clear pending here so the popup unmounts. Symmetric with the
+        // framework resolve catch + onRunFailed handler — all write null,
+        // no race. Caller still sees the rethrow.
+        console.error(
+          "[interrupt-headless] resume runAgent rejected; clearing pending + rethrowing",
+          err,
+        );
+        setPending(null);
+        throw err;
+      }
     },
-    [agent, copilotkit, pending],
+    [agent, copilotkit],
   );
 
   return { pending, resolve };
@@ -135,7 +149,7 @@ function useHeadlessInterrupt(agentId: string): {
 
 type AppSurfaceProps = {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 };
 
 function AppSurface({ pending, resolve }: AppSurfaceProps) {

--- a/showcase/integrations/langgraph-fastapi/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/integrations/langgraph-fastapi/src/app/demos/interrupt-headless/page.tsx
@@ -10,7 +10,7 @@
 // popup vanishes, and the agent confirms back in chat.
 
 // @region[headless-useinterrupt-primitives]
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -71,11 +71,13 @@ function Layout() {
 
 function useHeadlessInterrupt(agentId: string): {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 } {
   const { copilotkit } = useCopilotKit();
   const { agent } = useAgent({ agentId });
   const [pending, setPending] = useState<InterruptEvent | null>(null);
+  const pendingRef = useRef<InterruptEvent | null>(null);
+  pendingRef.current = pending;
 
   useEffect(() => {
     let local: InterruptEvent | null = null;
@@ -105,17 +107,17 @@ function useHeadlessInterrupt(agentId: string): {
       },
       onRunFailed: () => {
         local = null;
+        setPending(null);
       },
     });
     return () => sub.unsubscribe();
   }, [agent]);
 
   const resolve = useMemo(
-    () => (response: unknown) => {
-      const snapshot = pending;
-      setPending(null);
-      void copilotkit
-        .runAgent({
+    () => async (response: unknown) => {
+      const snapshot = pendingRef.current;
+      try {
+        return await copilotkit.runAgent({
           agent,
           forwardedProps: {
             command: {
@@ -123,10 +125,22 @@ function useHeadlessInterrupt(agentId: string): {
               interruptEvent: snapshot?.value,
             },
           },
-        })
-        .catch(() => {});
+        });
+      } catch (err) {
+        // Catastrophic rejection (network error, auth failure, validation
+        // reject) may fire before the run starts, so onRunFailed never runs.
+        // Clear pending here so the popup unmounts. Symmetric with the
+        // framework resolve catch + onRunFailed handler — all write null,
+        // no race. Caller still sees the rethrow.
+        console.error(
+          "[interrupt-headless] resume runAgent rejected; clearing pending + rethrowing",
+          err,
+        );
+        setPending(null);
+        throw err;
+      }
     },
-    [agent, copilotkit, pending],
+    [agent, copilotkit],
   );
 
   return { pending, resolve };
@@ -135,7 +149,7 @@ function useHeadlessInterrupt(agentId: string): {
 
 type AppSurfaceProps = {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 };
 
 function AppSurface({ pending, resolve }: AppSurfaceProps) {

--- a/showcase/integrations/langgraph-python/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/interrupt-headless/page.tsx
@@ -10,7 +10,7 @@
 // popup vanishes, and the agent confirms back in chat.
 
 // @region[headless-useinterrupt-primitives]
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -71,11 +71,13 @@ function Layout() {
 
 function useHeadlessInterrupt(agentId: string): {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 } {
   const { copilotkit } = useCopilotKit();
   const { agent } = useAgent({ agentId });
   const [pending, setPending] = useState<InterruptEvent | null>(null);
+  const pendingRef = useRef<InterruptEvent | null>(null);
+  pendingRef.current = pending;
 
   useEffect(() => {
     let local: InterruptEvent | null = null;
@@ -105,17 +107,17 @@ function useHeadlessInterrupt(agentId: string): {
       },
       onRunFailed: () => {
         local = null;
+        setPending(null);
       },
     });
     return () => sub.unsubscribe();
   }, [agent]);
 
   const resolve = useMemo(
-    () => (response: unknown) => {
-      const snapshot = pending;
-      setPending(null);
-      void copilotkit
-        .runAgent({
+    () => async (response: unknown) => {
+      const snapshot = pendingRef.current;
+      try {
+        return await copilotkit.runAgent({
           agent,
           forwardedProps: {
             command: {
@@ -123,10 +125,22 @@ function useHeadlessInterrupt(agentId: string): {
               interruptEvent: snapshot?.value,
             },
           },
-        })
-        .catch(() => {});
+        });
+      } catch (err) {
+        // Catastrophic rejection (network error, auth failure, validation
+        // reject) may fire before the run starts, so onRunFailed never runs.
+        // Clear pending here so the popup unmounts. Symmetric with the
+        // framework resolve catch + onRunFailed handler — all write null,
+        // no race. Caller still sees the rethrow.
+        console.error(
+          "[interrupt-headless] resume runAgent rejected; clearing pending + rethrowing",
+          err,
+        );
+        setPending(null);
+        throw err;
+      }
     },
-    [agent, copilotkit, pending],
+    [agent, copilotkit],
   );
 
   return { pending, resolve };
@@ -135,7 +149,7 @@ function useHeadlessInterrupt(agentId: string): {
 
 type AppSurfaceProps = {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 };
 
 function AppSurface({ pending, resolve }: AppSurfaceProps) {

--- a/showcase/integrations/langgraph-typescript/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/interrupt-headless/page.tsx
@@ -10,7 +10,7 @@
 // popup vanishes, and the agent confirms back in chat.
 
 // @region[headless-useinterrupt-primitives]
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -71,11 +71,13 @@ function Layout() {
 
 function useHeadlessInterrupt(agentId: string): {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 } {
   const { copilotkit } = useCopilotKit();
   const { agent } = useAgent({ agentId });
   const [pending, setPending] = useState<InterruptEvent | null>(null);
+  const pendingRef = useRef<InterruptEvent | null>(null);
+  pendingRef.current = pending;
 
   useEffect(() => {
     let local: InterruptEvent | null = null;
@@ -105,17 +107,17 @@ function useHeadlessInterrupt(agentId: string): {
       },
       onRunFailed: () => {
         local = null;
+        setPending(null);
       },
     });
     return () => sub.unsubscribe();
   }, [agent]);
 
   const resolve = useMemo(
-    () => (response: unknown) => {
-      const snapshot = pending;
-      setPending(null);
-      void copilotkit
-        .runAgent({
+    () => async (response: unknown) => {
+      const snapshot = pendingRef.current;
+      try {
+        return await copilotkit.runAgent({
           agent,
           forwardedProps: {
             command: {
@@ -123,10 +125,22 @@ function useHeadlessInterrupt(agentId: string): {
               interruptEvent: snapshot?.value,
             },
           },
-        })
-        .catch(() => {});
+        });
+      } catch (err) {
+        // Catastrophic rejection (network error, auth failure, validation
+        // reject) may fire before the run starts, so onRunFailed never runs.
+        // Clear pending here so the popup unmounts. Symmetric with the
+        // framework resolve catch + onRunFailed handler — all write null,
+        // no race. Caller still sees the rethrow.
+        console.error(
+          "[interrupt-headless] resume runAgent rejected; clearing pending + rethrowing",
+          err,
+        );
+        setPending(null);
+        throw err;
+      }
     },
-    [agent, copilotkit, pending],
+    [agent, copilotkit],
   );
 
   return { pending, resolve };
@@ -135,7 +149,7 @@ function useHeadlessInterrupt(agentId: string): {
 
 type AppSurfaceProps = {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 };
 
 function AppSurface({ pending, resolve }: AppSurfaceProps) {

--- a/showcase/integrations/langroid/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/interrupt-headless/page.tsx
@@ -10,7 +10,7 @@
 // popup vanishes, and the agent confirms back in chat.
 
 // @region[headless-useinterrupt-primitives]
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -71,11 +71,13 @@ function Layout() {
 
 function useHeadlessInterrupt(agentId: string): {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 } {
   const { copilotkit } = useCopilotKit();
   const { agent } = useAgent({ agentId });
   const [pending, setPending] = useState<InterruptEvent | null>(null);
+  const pendingRef = useRef<InterruptEvent | null>(null);
+  pendingRef.current = pending;
 
   useEffect(() => {
     let local: InterruptEvent | null = null;
@@ -105,17 +107,17 @@ function useHeadlessInterrupt(agentId: string): {
       },
       onRunFailed: () => {
         local = null;
+        setPending(null);
       },
     });
     return () => sub.unsubscribe();
   }, [agent]);
 
   const resolve = useMemo(
-    () => (response: unknown) => {
-      const snapshot = pending;
-      setPending(null);
-      void copilotkit
-        .runAgent({
+    () => async (response: unknown) => {
+      const snapshot = pendingRef.current;
+      try {
+        return await copilotkit.runAgent({
           agent,
           forwardedProps: {
             command: {
@@ -123,10 +125,22 @@ function useHeadlessInterrupt(agentId: string): {
               interruptEvent: snapshot?.value,
             },
           },
-        })
-        .catch(() => {});
+        });
+      } catch (err) {
+        // Catastrophic rejection (network error, auth failure, validation
+        // reject) may fire before the run starts, so onRunFailed never runs.
+        // Clear pending here so the popup unmounts. Symmetric with the
+        // framework resolve catch + onRunFailed handler — all write null,
+        // no race. Caller still sees the rethrow.
+        console.error(
+          "[interrupt-headless] resume runAgent rejected; clearing pending + rethrowing",
+          err,
+        );
+        setPending(null);
+        throw err;
+      }
     },
-    [agent, copilotkit, pending],
+    [agent, copilotkit],
   );
 
   return { pending, resolve };
@@ -135,7 +149,7 @@ function useHeadlessInterrupt(agentId: string): {
 
 type AppSurfaceProps = {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 };
 
 function AppSurface({ pending, resolve }: AppSurfaceProps) {

--- a/showcase/integrations/llamaindex/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/interrupt-headless/page.tsx
@@ -10,7 +10,7 @@
 // popup vanishes, and the agent confirms back in chat.
 
 // @region[headless-useinterrupt-primitives]
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -71,11 +71,13 @@ function Layout() {
 
 function useHeadlessInterrupt(agentId: string): {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 } {
   const { copilotkit } = useCopilotKit();
   const { agent } = useAgent({ agentId });
   const [pending, setPending] = useState<InterruptEvent | null>(null);
+  const pendingRef = useRef<InterruptEvent | null>(null);
+  pendingRef.current = pending;
 
   useEffect(() => {
     let local: InterruptEvent | null = null;
@@ -105,17 +107,17 @@ function useHeadlessInterrupt(agentId: string): {
       },
       onRunFailed: () => {
         local = null;
+        setPending(null);
       },
     });
     return () => sub.unsubscribe();
   }, [agent]);
 
   const resolve = useMemo(
-    () => (response: unknown) => {
-      const snapshot = pending;
-      setPending(null);
-      void copilotkit
-        .runAgent({
+    () => async (response: unknown) => {
+      const snapshot = pendingRef.current;
+      try {
+        return await copilotkit.runAgent({
           agent,
           forwardedProps: {
             command: {
@@ -123,10 +125,22 @@ function useHeadlessInterrupt(agentId: string): {
               interruptEvent: snapshot?.value,
             },
           },
-        })
-        .catch(() => {});
+        });
+      } catch (err) {
+        // Catastrophic rejection (network error, auth failure, validation
+        // reject) may fire before the run starts, so onRunFailed never runs.
+        // Clear pending here so the popup unmounts. Symmetric with the
+        // framework resolve catch + onRunFailed handler — all write null,
+        // no race. Caller still sees the rethrow.
+        console.error(
+          "[interrupt-headless] resume runAgent rejected; clearing pending + rethrowing",
+          err,
+        );
+        setPending(null);
+        throw err;
+      }
     },
-    [agent, copilotkit, pending],
+    [agent, copilotkit],
   );
 
   return { pending, resolve };
@@ -135,7 +149,7 @@ function useHeadlessInterrupt(agentId: string): {
 
 type AppSurfaceProps = {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 };
 
 function AppSurface({ pending, resolve }: AppSurfaceProps) {

--- a/showcase/integrations/mastra/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/integrations/mastra/src/app/demos/interrupt-headless/page.tsx
@@ -10,7 +10,7 @@
 // popup vanishes, and the agent confirms back in chat.
 
 // @region[headless-useinterrupt-primitives]
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -71,11 +71,13 @@ function Layout() {
 
 function useHeadlessInterrupt(agentId: string): {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 } {
   const { copilotkit } = useCopilotKit();
   const { agent } = useAgent({ agentId });
   const [pending, setPending] = useState<InterruptEvent | null>(null);
+  const pendingRef = useRef<InterruptEvent | null>(null);
+  pendingRef.current = pending;
 
   useEffect(() => {
     let local: InterruptEvent | null = null;
@@ -105,17 +107,17 @@ function useHeadlessInterrupt(agentId: string): {
       },
       onRunFailed: () => {
         local = null;
+        setPending(null);
       },
     });
     return () => sub.unsubscribe();
   }, [agent]);
 
   const resolve = useMemo(
-    () => (response: unknown) => {
-      const snapshot = pending;
-      setPending(null);
-      void copilotkit
-        .runAgent({
+    () => async (response: unknown) => {
+      const snapshot = pendingRef.current;
+      try {
+        return await copilotkit.runAgent({
           agent,
           forwardedProps: {
             command: {
@@ -123,10 +125,22 @@ function useHeadlessInterrupt(agentId: string): {
               interruptEvent: snapshot?.value,
             },
           },
-        })
-        .catch(() => {});
+        });
+      } catch (err) {
+        // Catastrophic rejection (network error, auth failure, validation
+        // reject) may fire before the run starts, so onRunFailed never runs.
+        // Clear pending here so the popup unmounts. Symmetric with the
+        // framework resolve catch + onRunFailed handler — all write null,
+        // no race. Caller still sees the rethrow.
+        console.error(
+          "[interrupt-headless] resume runAgent rejected; clearing pending + rethrowing",
+          err,
+        );
+        setPending(null);
+        throw err;
+      }
     },
-    [agent, copilotkit, pending],
+    [agent, copilotkit],
   );
 
   return { pending, resolve };
@@ -135,7 +149,7 @@ function useHeadlessInterrupt(agentId: string): {
 
 type AppSurfaceProps = {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 };
 
 function AppSurface({ pending, resolve }: AppSurfaceProps) {

--- a/showcase/integrations/pydantic-ai/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/interrupt-headless/page.tsx
@@ -10,7 +10,7 @@
 // popup vanishes, and the agent confirms back in chat.
 
 // @region[headless-useinterrupt-primitives]
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -71,11 +71,13 @@ function Layout() {
 
 function useHeadlessInterrupt(agentId: string): {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 } {
   const { copilotkit } = useCopilotKit();
   const { agent } = useAgent({ agentId });
   const [pending, setPending] = useState<InterruptEvent | null>(null);
+  const pendingRef = useRef<InterruptEvent | null>(null);
+  pendingRef.current = pending;
 
   useEffect(() => {
     let local: InterruptEvent | null = null;
@@ -105,17 +107,17 @@ function useHeadlessInterrupt(agentId: string): {
       },
       onRunFailed: () => {
         local = null;
+        setPending(null);
       },
     });
     return () => sub.unsubscribe();
   }, [agent]);
 
   const resolve = useMemo(
-    () => (response: unknown) => {
-      const snapshot = pending;
-      setPending(null);
-      void copilotkit
-        .runAgent({
+    () => async (response: unknown) => {
+      const snapshot = pendingRef.current;
+      try {
+        return await copilotkit.runAgent({
           agent,
           forwardedProps: {
             command: {
@@ -123,10 +125,22 @@ function useHeadlessInterrupt(agentId: string): {
               interruptEvent: snapshot?.value,
             },
           },
-        })
-        .catch(() => {});
+        });
+      } catch (err) {
+        // Catastrophic rejection (network error, auth failure, validation
+        // reject) may fire before the run starts, so onRunFailed never runs.
+        // Clear pending here so the popup unmounts. Symmetric with the
+        // framework resolve catch + onRunFailed handler — all write null,
+        // no race. Caller still sees the rethrow.
+        console.error(
+          "[interrupt-headless] resume runAgent rejected; clearing pending + rethrowing",
+          err,
+        );
+        setPending(null);
+        throw err;
+      }
     },
-    [agent, copilotkit, pending],
+    [agent, copilotkit],
   );
 
   return { pending, resolve };
@@ -135,7 +149,7 @@ function useHeadlessInterrupt(agentId: string): {
 
 type AppSurfaceProps = {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 };
 
 function AppSurface({ pending, resolve }: AppSurfaceProps) {

--- a/showcase/integrations/spring-ai/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/interrupt-headless/page.tsx
@@ -10,7 +10,7 @@
 // popup vanishes, and the agent confirms back in chat.
 
 // @region[headless-useinterrupt-primitives]
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -71,11 +71,13 @@ function Layout() {
 
 function useHeadlessInterrupt(agentId: string): {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 } {
   const { copilotkit } = useCopilotKit();
   const { agent } = useAgent({ agentId });
   const [pending, setPending] = useState<InterruptEvent | null>(null);
+  const pendingRef = useRef<InterruptEvent | null>(null);
+  pendingRef.current = pending;
 
   useEffect(() => {
     let local: InterruptEvent | null = null;
@@ -105,17 +107,17 @@ function useHeadlessInterrupt(agentId: string): {
       },
       onRunFailed: () => {
         local = null;
+        setPending(null);
       },
     });
     return () => sub.unsubscribe();
   }, [agent]);
 
   const resolve = useMemo(
-    () => (response: unknown) => {
-      const snapshot = pending;
-      setPending(null);
-      void copilotkit
-        .runAgent({
+    () => async (response: unknown) => {
+      const snapshot = pendingRef.current;
+      try {
+        return await copilotkit.runAgent({
           agent,
           forwardedProps: {
             command: {
@@ -123,10 +125,22 @@ function useHeadlessInterrupt(agentId: string): {
               interruptEvent: snapshot?.value,
             },
           },
-        })
-        .catch(() => {});
+        });
+      } catch (err) {
+        // Catastrophic rejection (network error, auth failure, validation
+        // reject) may fire before the run starts, so onRunFailed never runs.
+        // Clear pending here so the popup unmounts. Symmetric with the
+        // framework resolve catch + onRunFailed handler — all write null,
+        // no race. Caller still sees the rethrow.
+        console.error(
+          "[interrupt-headless] resume runAgent rejected; clearing pending + rethrowing",
+          err,
+        );
+        setPending(null);
+        throw err;
+      }
     },
-    [agent, copilotkit, pending],
+    [agent, copilotkit],
   );
 
   return { pending, resolve };
@@ -135,7 +149,7 @@ function useHeadlessInterrupt(agentId: string): {
 
 type AppSurfaceProps = {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 };
 
 function AppSurface({ pending, resolve }: AppSurfaceProps) {

--- a/showcase/integrations/strands/src/app/demos/interrupt-headless/page.tsx
+++ b/showcase/integrations/strands/src/app/demos/interrupt-headless/page.tsx
@@ -10,7 +10,7 @@
 // popup vanishes, and the agent confirms back in chat.
 
 // @region[headless-useinterrupt-primitives]
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -71,11 +71,13 @@ function Layout() {
 
 function useHeadlessInterrupt(agentId: string): {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 } {
   const { copilotkit } = useCopilotKit();
   const { agent } = useAgent({ agentId });
   const [pending, setPending] = useState<InterruptEvent | null>(null);
+  const pendingRef = useRef<InterruptEvent | null>(null);
+  pendingRef.current = pending;
 
   useEffect(() => {
     let local: InterruptEvent | null = null;
@@ -105,17 +107,17 @@ function useHeadlessInterrupt(agentId: string): {
       },
       onRunFailed: () => {
         local = null;
+        setPending(null);
       },
     });
     return () => sub.unsubscribe();
   }, [agent]);
 
   const resolve = useMemo(
-    () => (response: unknown) => {
-      const snapshot = pending;
-      setPending(null);
-      void copilotkit
-        .runAgent({
+    () => async (response: unknown) => {
+      const snapshot = pendingRef.current;
+      try {
+        return await copilotkit.runAgent({
           agent,
           forwardedProps: {
             command: {
@@ -123,10 +125,22 @@ function useHeadlessInterrupt(agentId: string): {
               interruptEvent: snapshot?.value,
             },
           },
-        })
-        .catch(() => {});
+        });
+      } catch (err) {
+        // Catastrophic rejection (network error, auth failure, validation
+        // reject) may fire before the run starts, so onRunFailed never runs.
+        // Clear pending here so the popup unmounts. Symmetric with the
+        // framework resolve catch + onRunFailed handler — all write null,
+        // no race. Caller still sees the rethrow.
+        console.error(
+          "[interrupt-headless] resume runAgent rejected; clearing pending + rethrowing",
+          err,
+        );
+        setPending(null);
+        throw err;
+      }
     },
-    [agent, copilotkit, pending],
+    [agent, copilotkit],
   );
 
   return { pending, resolve };
@@ -135,7 +149,7 @@ function useHeadlessInterrupt(agentId: string): {
 
 type AppSurfaceProps = {
   pending: InterruptEvent | null;
-  resolve: (response: unknown) => void;
+  resolve: (response: unknown) => Promise<unknown>;
 };
 
 function AppSurface({ pending, resolve }: AppSurfaceProps) {


### PR DESCRIPTION
## Summary

Convert `useInterrupt::resolve` and the demo-local `useHeadlessInterrupt::resolve` callbacks from fire-and-forget into `async` + `return await copilotkit.runAgent(...)`, so callers receive a Promise that settles when the resume run settles.

## Mechanism

Pre-fix: `resolve(...)` called `copilotkit.runAgent({...})` without `await` and without `return` — the arrow returned `undefined`. The showcase harness DOM-settle check on the assistant confirmation bubble timed out because consumers had no handle to sequence against the resume run's settle.

Post-fix:
- Framework `useInterrupt::resolve` is `async`, `return await`s `runAgent`, wraps in try/catch + `setPendingEvent(null)` + `console.error` + rethrow on rejection.
- `onRunFailed` now also `setPendingEvent(null)` — symmetric with `onRunStartedEvent`, prevents stuck popups on run failure.
- `InterruptHandlerProps.resolve` / `InterruptRenderProps.resolve` typed `() => Promise<RunAgentResult>` (was `() => void`).
- The same fix-pattern applied to 13 demo-local `useHeadlessInterrupt` implementations across integrations: ag2, agno, claude-sdk-typescript, crewai-crews, langgraph-{fastapi,python,typescript}, langroid, llamaindex, mastra, pydantic-ai, spring-ai, strands.

## Verification

- **Unit:** new tests `resolve returns a Promise that settles when runAgent settles (RESUME-PATH)` + `resolve rejects when runAgent rejects, logs the failure, and clears pending (RESUME-PATH-REJECT)`. Red-then-green on baseline. 22/22 react-core hook tests passing.
- **Backplane (end-to-end):** showcase control plane on langgraph-python via `./bin/showcase test langgraph-python:gen-ui-interrupt --d5 --direct --verbose` (GREEN, 70.1s, was RED-RESUME-PATH baseline) and `:interrupt-headless --d5 --direct --verbose` (GREEN, 7.7s, was RED-RESUME-PATH baseline). Built Docker artifact + aimock D6 fixture replay — staging-equivalent path.

## CR

4 review rounds × 7 unbiased agents = 28 agent-runs. 2 Procedure 3 audits (3 promotions in round 1 → Fix C + D; 0 promotions in round 2). Convergence achieved per agent-confirmed `bucket (a) empty` + Procedure 3 zero `PROMOTE_TO_A`.

## Out of scope (deferred follow-ups)

- **No manifest unquarantine.** A prior version of this branch flipped `interrupt-headless` and `gen-ui-interrupt` from `not_supported_features` to `features` across 12 manifests, but Phase 4 backplane validation across 8 PATCHED integrations × 2 demos surfaced (a) `langgraph-fastapi:gen-ui-interrupt` still RED-RESUME-PATH because the framework patch doesn't propagate from workspace to the integration's Docker image without a published `@copilotkit/react-core` release, and (b) a separate popup-mount RED-RUNTIME-OTHER cluster across 6 integrations that's pre-existing rot unrelated to this PR. Manifest unquarantine + `@copilotkit/react-core` version bump are deferred to a follow-up `copilotkit-release` PR after this fix lands.
- **No version bump.** Release follows in a separate PR.
- **Bucket (c) follow-up backlog** (audit verdicts: 11 STAY_IN_C):
  - JSON.parse guarding in showcase demos (pre-existing, all 13)
  - Type-design quirks in `InterruptHandlerProps.result` (non-nullable in type, nullable in runtime)
  - `renderInChat` dynamic toggle leak (pre-existing edge case)
  - JSDoc clarity ("symmetric with onRunFailed" wording, `@typeParam TRenderInChat`, `event.value` "any" → "unknown")
  - StrictMode test coverage gap
  - 13× duplicate `useHeadlessInterrupt` → bucket (d): consolidate into a shared module in a future PR

## Files changed

16 files, +486/-154:
- `packages/react-core/src/v2/hooks/use-interrupt.tsx`
- `packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx`
- `packages/react-core/src/v2/types/interrupt.ts`
- 13× `showcase/integrations/<integ>/src/app/demos/interrupt-headless/page.tsx`

## Test plan

- [x] react-core unit tests (22/22 passing including new RESUME-PATH + RESUME-PATH-REJECT regression tests)
- [x] Backplane D5 probe on langgraph-python (gen-ui-interrupt + interrupt-headless GREEN end-to-end via the showcase control plane)
- [ ] CI green on this PR