### PR TITLE
fix(showcase/harness): bubble-race elimination — 4 defects + atomic readCascadeState + cold-start retry + SSE counter

### DIFF
--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -68,7 +68,54 @@ function makePage(script: PageScript = {}): E2eFullPage {
       }
     },
     async evaluate<R>(fn: () => R): Promise<R> {
-      void fn;
+      // The conversation-runner now makes structurally different
+      // page.evaluate calls — `countAssistantMessages` (returns number),
+      // `readCascadeState` (returns `{count, text}`), `readErrorBanner`
+      // (returns `{state, text?}`), `readRunsFinished` (number), and
+      // `captureDiagnostics` (an object). Dispatch on the closure body so
+      // each branch returns the right shape. Mirrors the dispatch table
+      // used by the conversation-runner.test.ts fake (kept in lock-step).
+      const fnBody = typeof fn === "function" ? fn.toString() : "";
+      // SSE counter — readRunsFinished returns a number; surface the
+      // current messageCount so the SSE conjunct in waitForTurnComplete
+      // ticks alongside the DOM count.
+      if (fnBody.includes("__hk_runsFinished")) {
+        return messageCount as unknown as R;
+      }
+      // Error-banner probe — return `{state: "absent"}` (the validated
+      // shape) so readErrorBanner reports absent and fast-fail stays
+      // disarmed in these tests.
+      if (fnBody.includes("copilot-error-banner")) {
+        return { state: "absent" } as unknown as R;
+      }
+      // Atomic cascade-state read — readCascadeState returns
+      // `{count, text}`. The closure body contains BOTH `querySelectorAll`
+      // and `textContent` AND `{ count` in its return literal.
+      if (
+        fnBody.includes("querySelectorAll") &&
+        fnBody.includes("textContent") &&
+        fnBody.includes("{ count")
+      ) {
+        const text =
+          messageCount > 0 ? `assistant-bubble-text-${messageCount}` : null;
+        return { count: messageCount, text } as unknown as R;
+      }
+      // Diagnostics capture (captureDiagnostics) — returns an object
+      // shape consumed by `diagnostics.assistantMsgCount = ...` merge.
+      if (fnBody.includes("userMsgCount") || fnBody.includes("apiRequests")) {
+        return {
+          userMsgCount: 0,
+          apiRequestCount: 0,
+          apiRequests: [],
+          pageErrors: [],
+          chatContainerExists: true,
+          url: "about:blank",
+          title: "",
+          bodyTextSnippet: "",
+        } as unknown as R;
+      }
+      // Default — assistant/user message COUNT (countAssistantMessages
+      // and similar) returns a number.
       return messageCount as unknown as R;
     },
     async click() {},
@@ -1161,7 +1208,44 @@ function makeRetryLauncherFull(opts: { attempt1DelayMs: number }): {
             async press() {
               messageCount++;
             },
-            async evaluate<R>() {
+            async evaluate<R>(fn: () => R): Promise<R> {
+              // Dispatch on closure body — see `makePage` for the
+              // full rationale; this launcher needs the same routing
+              // so readCascadeState/readErrorBanner/captureDiagnostics
+              // each get the right return shape.
+              const fnBody = typeof fn === "function" ? fn.toString() : "";
+              if (fnBody.includes("__hk_runsFinished")) {
+                return messageCount as unknown as R;
+              }
+              if (fnBody.includes("copilot-error-banner")) {
+                return { state: "absent" } as unknown as R;
+              }
+              if (
+                fnBody.includes("querySelectorAll") &&
+                fnBody.includes("textContent") &&
+                fnBody.includes("{ count")
+              ) {
+                const text =
+                  messageCount > 0
+                    ? `assistant-bubble-text-${messageCount}`
+                    : null;
+                return { count: messageCount, text } as unknown as R;
+              }
+              if (
+                fnBody.includes("userMsgCount") ||
+                fnBody.includes("apiRequests")
+              ) {
+                return {
+                  userMsgCount: 0,
+                  apiRequestCount: 0,
+                  apiRequests: [],
+                  pageErrors: [],
+                  chatContainerExists: true,
+                  url: "about:blank",
+                  title: "",
+                  bodyTextSnippet: "",
+                } as unknown as R;
+              }
               return messageCount as unknown as R;
             },
             async click() {},

--- a/showcase/harness/src/probes/drivers/d6-all-pills.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.ts
@@ -12,11 +12,18 @@ import type {
 } from "../helpers/d5-registry.js";
 import { demosToFeatureTypes } from "../helpers/d5-feature-mapping.js";
 import { D5_REPRESENTATIVES } from "../helpers/d5-representatives.js";
+import type { Page as PlaywrightPage } from "playwright";
+import { countAssistantMessages } from "../helpers/assistant-message-count.js";
 import { runConversation } from "../helpers/conversation-runner.js";
 import type {
   ConversationResult,
   Page,
 } from "../helpers/conversation-runner.js";
+import {
+  installPrePaintFromEnv,
+  messagesOverrideFromEnv,
+} from "../helpers/init-scripts.js";
+import { attachSseInterceptor } from "../helpers/sse-interceptor.js";
 import {
   formatCvdiag,
   appendHop,
@@ -25,10 +32,8 @@ import {
   X_DIAG_RUN_ID,
   X_DIAG_HOPS,
 } from "../helpers/cv-diag.js";
-import {
-  writeDiagEvent,
-  type DiagSinkClient,
-} from "../../storage/diag-sink.js";
+import { writeDiagEvent } from "../../storage/diag-sink.js";
+import type { DiagSinkClient } from "../../storage/diag-sink.js";
 import type { ProbeDriver } from "../types.js";
 import type { Logger, ProbeContext, ProbeResult } from "../../types/index.js";
 import type { BrowserPool } from "../helpers/browser-pool.js";
@@ -472,8 +477,20 @@ const defaultLauncher: E2eFullBrowserLauncher =
               press: (s, k, o) => page.press(s, k, o),
               evaluate: <R>(fn: () => R) => page.evaluate(fn),
               inputValue: (s) => page.inputValue(s),
-              goto: (u, gotoOpts) =>
-                page.goto(u, gotoOpts as Parameters<typeof page.goto>[1]),
+              goto: async (u, gotoOpts) => {
+                // Order is load-bearing per Phase 3 Task 3.2:
+                // installPrePaintFromEnv FIRST (defect-4 pre-paint
+                // injection, no-op in production), attachSseInterceptor
+                // SECOND. Both must complete before page.goto so the
+                // init scripts (pre-paint DOM seed + __hk_runsFinished
+                // window counter) are registered at document_start.
+                await installPrePaintFromEnv(page);
+                await attachSseInterceptor(page);
+                return page.goto(
+                  u,
+                  gotoOpts as Parameters<typeof page.goto>[1],
+                );
+              },
               close: () => page.close(),
               click: (s, o) => page.click(s, o),
               waitForFunction: (fn, wfOpts) =>
@@ -598,8 +615,20 @@ export function createPooledE2eFullLauncher(
               press: (s, k, o) => page.press(s, k, o),
               evaluate: <R>(fn: () => R) => page.evaluate(fn),
               inputValue: (s) => page.inputValue(s),
-              goto: (u, gotoOpts) =>
-                page.goto(u, gotoOpts as Parameters<typeof page.goto>[1]),
+              goto: async (u, gotoOpts) => {
+                // Order is load-bearing per Phase 3 Task 3.2:
+                // installPrePaintFromEnv FIRST (defect-4 pre-paint
+                // injection, no-op in production), attachSseInterceptor
+                // SECOND. Both must complete before page.goto so the
+                // init scripts (pre-paint DOM seed + __hk_runsFinished
+                // window counter) are registered at document_start.
+                await installPrePaintFromEnv(page);
+                await attachSseInterceptor(page);
+                return page.goto(
+                  u,
+                  gotoOpts as Parameters<typeof page.goto>[1],
+                );
+              },
               close: () => page.close(),
               click: (s, o) => page.click(s, o),
               waitForFunction: (fn, wfOpts) =>
@@ -1676,11 +1705,19 @@ async function runFeature(opts: {
       hydrationMs: Date.now() - hydrationStart,
     });
 
-    const turns = script.buildTurns(buildCtx);
+    const defaultTurns = script.buildTurns(buildCtx);
+    // BUBBLE_RACE_MESSAGES env override (bubble-race-repro integration
+    // tests only — no-op in production). When set, replaces the demo's
+    // default turn sequence with one `{ input: <string> }` per env
+    // message so per-scenario test inputs flow through ONE channel
+    // rather than scattering test logic across each defect commit.
+    const turnsOverride = messagesOverrideFromEnv();
+    const turns = turnsOverride ?? defaultTurns;
     logger.debug("probe.e2e-full.runFeature.turns-built", {
       turnCount: turns.length,
       featureType: buildCtx.featureType,
       slug: buildCtx.integrationSlug,
+      bubbleRaceMessagesOverride: turnsOverride !== undefined,
     });
     const conversation = await runConversation(page, turns);
 
@@ -1784,6 +1821,18 @@ async function captureDiagnostics(
     }
     return { pageClosed: true };
   }
+  // Read the assistant-message count Node-side via the shared cascade
+  // BEFORE entering page.evaluate, then merge it into the diagnostics
+  // object. Routing through `countAssistantMessages` here is what
+  // closes defect 3 by construction — the conversation runner reads
+  // its settled count via the same helper, so diagnostics and runner
+  // can no longer report mismatched counts for the same frame.
+  // `page.evaluate` cannot await a Node-side helper from inside the
+  // browser context, so the call is hoisted out (per plan §2.2/N6).
+  const assistantMsgCount = await countAssistantMessages(
+    page as unknown as PlaywrightPage,
+  );
+
   try {
     diagnostics = await page.evaluate(() => {
       type EvalElement = {
@@ -1811,9 +1860,6 @@ async function captureDiagnostics(
         location: { href: string };
       };
 
-      const assistantMsgs = win.document.querySelectorAll(
-        '[data-testid="copilot-assistant-message"]',
-      );
       const userMsgs = win.document.querySelectorAll(
         '[data-testid="copilot-user-message"]',
       );
@@ -1841,7 +1887,6 @@ async function captureDiagnostics(
       );
 
       return {
-        assistantMsgCount: assistantMsgs.length,
         userMsgCount: userMsgs.length,
         apiRequestCount: apiEntries.length,
         apiRequests: apiEntries.slice(0, 5),
@@ -1856,6 +1901,15 @@ async function captureDiagnostics(
     });
   } catch {
     // Page may be closed or crashed — can't gather DOM diagnostics.
+  }
+
+  // Merge the shared-cascade count Node-side. Done only when the
+  // browser-side evaluate succeeded so a crashed/closed page still
+  // produces the same `undefined` diagnostics as before this refactor
+  // — preserving the prior failure shape exactly. The browser-diag
+  // merge below independently hydrates a fresh object when needed.
+  if (diagnostics) {
+    diagnostics.assistantMsgCount = assistantMsgCount;
   }
 
   const browserDiag = page.getDiagnostics?.();

--- a/showcase/harness/src/probes/helpers/assistant-message-count.test.ts
+++ b/showcase/harness/src/probes/helpers/assistant-message-count.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect } from "vitest";
+import type { Page } from "playwright";
+import {
+  readCascadeState,
+  resolveBubbleTextFromSelectors,
+} from "./assistant-message-count.js";
+import type { BubbleTextElement } from "./assistant-message-count.js";
+
+/**
+ * Unit coverage for the empty-textContent fall-through inside
+ * `findAssistantBubbleAt`'s scoped-text cascade. The cascade itself runs in
+ * `page.evaluate` (browser context) so we cannot exercise the closure
+ * directly without JSDOM (which the harness package does not depend on).
+ * Instead, the closure's per-tier loop is mirrored in the pure helper
+ * `resolveBubbleTextFromSelectors` exported alongside it — the two MUST
+ * stay in lock-step; the contract test below pins the failure mode that
+ * triggered this fix (data-message-content matches but is empty).
+ */
+
+interface StubBubble extends BubbleTextElement {
+  readonly textContent: string | null;
+  querySelector(sel: string): StubBubble | null;
+}
+
+function bubble(
+  ownText: string | null,
+  children: Record<string, { textContent: string | null }>,
+): StubBubble {
+  return {
+    textContent: ownText,
+    querySelector(sel: string): StubBubble | null {
+      const hit = children[sel];
+      if (!hit) return null;
+      return {
+        textContent: hit.textContent,
+        querySelector(): StubBubble | null {
+          return null;
+        },
+      };
+    },
+  };
+}
+
+describe("resolveBubbleTextFromSelectors", () => {
+  it("returns first non-empty scoped selector match", () => {
+    const b = bubble("full-bubble-text", {
+      "[data-message-content]": { textContent: "scoped-content" },
+      ".cpk\\:prose": { textContent: "should-not-reach" },
+    });
+    expect(
+      resolveBubbleTextFromSelectors(b, [
+        "[data-message-content]",
+        ".cpk\\:prose",
+      ]),
+    ).toBe("scoped-content");
+  });
+
+  it("falls through empty [data-message-content] to .cpk:prose (Finding E / Bug 10)", () => {
+    // Repro the exact failure mode: the wrapper that matches the FIRST
+    // text selector is mounted but empty (e.g. mounted before children
+    // populate, or used as a static-empty marker). The real streamed
+    // text lives in the next selector. Pre-fix, the function returned ""
+    // and the settle gate spun on `text-unstable` until timeout.
+    const b = bubble("ignored-fallback", {
+      "[data-message-content]": { textContent: "" },
+      ".cpk\\:prose": { textContent: "real streamed answer" },
+    });
+    expect(
+      resolveBubbleTextFromSelectors(b, [
+        "[data-message-content]",
+        ".cpk\\:prose",
+        ".prose",
+      ]),
+    ).toBe("real streamed answer");
+  });
+
+  it("treats whitespace-only textContent as empty and falls through", () => {
+    const b = bubble("ignored-fallback", {
+      "[data-message-content]": { textContent: "   \n\t  " },
+      ".cpk\\:prose": { textContent: "actual text" },
+    });
+    expect(
+      resolveBubbleTextFromSelectors(b, [
+        "[data-message-content]",
+        ".cpk\\:prose",
+      ]),
+    ).toBe("actual text");
+  });
+
+  it("falls through null textContent to next selector", () => {
+    const b = bubble("ignored-fallback", {
+      "[data-message-content]": { textContent: null },
+      p: { textContent: "paragraph text" },
+    });
+    expect(
+      resolveBubbleTextFromSelectors(b, ["[data-message-content]", "p"]),
+    ).toBe("paragraph text");
+  });
+
+  it("returns null instead of bubble.textContent when ALL scoped selectors are empty (cascade-pollution guard, Round 4 #3 / Bug 8)", () => {
+    // The whole-bubble `textContent` conflates the message text with the
+    // post-message UI affordances (LGP suggestion-pills, the canonical
+    // assistant toolbar). Returning it would re-introduce the exact
+    // pollution this scoped cascade exists to prevent. Returning `null`
+    // keeps the settle gate polling until a scoped child populates.
+    const b = bubble("whole-bubble-pollution-incl-LGP-pills-and-toolbar", {
+      "[data-message-content]": { textContent: "" },
+      ".cpk\\:prose": { textContent: "  " },
+    });
+    expect(
+      resolveBubbleTextFromSelectors(b, [
+        "[data-message-content]",
+        ".cpk\\:prose",
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns null instead of bubble.textContent when no scoped selectors match at all", () => {
+    // Same cascade-pollution guard: when no scoped child matches, the
+    // whole bubble's textContent is just as polluted as when scoped
+    // children matched but were empty. Return null in both cases.
+    const b = bubble("only-fallback-pollution", {});
+    expect(
+      resolveBubbleTextFromSelectors(b, [
+        "[data-message-content]",
+        ".cpk\\:prose",
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns null when neither scoped nor bubble textContent is present", () => {
+    // The settle-gate caller's guard is `text !== null && text.trim().length > 0`;
+    // returning null keeps the gate polling rather than locking onto an
+    // empty placeholder or synthesising a bogus value.
+    const b = bubble(null, {
+      "[data-message-content]": { textContent: "" },
+    });
+    expect(
+      resolveBubbleTextFromSelectors(b, ["[data-message-content]"]),
+    ).toBeNull();
+  });
+
+  it("does not invoke later selectors after the first non-empty match", () => {
+    let prose_lookups = 0;
+    const stub: BubbleTextElement = {
+      textContent: "irrelevant",
+      querySelector(sel: string): BubbleTextElement | null {
+        if (sel === "[data-message-content]") {
+          return {
+            textContent: "winning text",
+            querySelector(): BubbleTextElement | null {
+              return null;
+            },
+          };
+        }
+        if (sel === ".cpk\\:prose") {
+          prose_lookups += 1;
+          return {
+            textContent: "later",
+            querySelector(): BubbleTextElement | null {
+              return null;
+            },
+          };
+        }
+        return null;
+      },
+    };
+    expect(
+      resolveBubbleTextFromSelectors(stub, [
+        "[data-message-content]",
+        ".cpk\\:prose",
+      ]),
+    ).toBe("winning text");
+    expect(prose_lookups).toBe(0);
+  });
+});
+
+/**
+ * Unit coverage for `readCascadeState` — the atomic single-`page.evaluate`
+ * reader that returns BOTH the cascade count and the indexed text from the
+ * SAME tier in one round-trip. The closure body is invoked client-side by
+ * Playwright; for unit purposes we drive it via a fake `Page.evaluate` that
+ * sets up `globalThis.document` and EXECUTES the closure body directly.
+ * This is the same shape as the production browser context — the closure
+ * uses `globalThis.document.querySelectorAll` and `bubble.querySelector`.
+ *
+ * The tests pin the cross-tier consistency property the helper exists for:
+ * count and text MUST come from the same tier.
+ */
+interface StubNode {
+  textContent: string | null;
+  querySelector?(sel: string): StubNode | null;
+}
+
+function makeDoc(tiersFound: Record<string, StubNode[]>): {
+  querySelectorAll: (sel: string) => {
+    length: number;
+    item: (i: number) => StubNode | null;
+  };
+} {
+  return {
+    querySelectorAll(sel: string) {
+      const list = tiersFound[sel] ?? [];
+      return {
+        length: list.length,
+        item(i: number): StubNode | null {
+          return list[i] ?? null;
+        },
+      };
+    },
+  };
+}
+
+/**
+ * Build a fake Playwright `Page` whose `evaluate` runs the closure body
+ * directly in a sandbox where `globalThis.document` is `doc`. The closure
+ * receives its second runtime arg (here `bubbleIndex`) as Playwright would.
+ */
+function makePageForCascade(doc: ReturnType<typeof makeDoc>): Page {
+  return {
+    async evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fn: (...args: any[]) => unknown,
+      arg?: unknown,
+    ): Promise<unknown> {
+      const origDoc = (globalThis as unknown as { document?: unknown })
+        .document;
+      (globalThis as unknown as { document: unknown }).document = doc;
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return await (fn as (a: any) => unknown)(arg);
+      } finally {
+        (globalThis as unknown as { document: unknown }).document = origDoc;
+      }
+    },
+  } as unknown as Page;
+}
+
+describe("readCascadeState", () => {
+  const CANONICAL = '[data-testid="copilot-assistant-message"]';
+  const ARTICLE_ROLE = '[role="article"][data-message-role="assistant"]';
+  const ARTICLE_NOT_USER = '[role="article"]:not([data-message-role="user"])';
+  const HEADLESS = '[data-message-role="assistant"]';
+
+  function leafBubble(textContent: string | null): StubNode {
+    return {
+      textContent,
+      querySelector(_sel: string): StubNode | null {
+        return null;
+      },
+    };
+  }
+
+  function scopedBubble(
+    children: Record<string, { textContent: string | null }>,
+  ): StubNode {
+    return {
+      textContent: "ignored-whole-bubble",
+      querySelector(sel: string): StubNode | null {
+        const c = children[sel];
+        if (!c) return null;
+        return leafBubble(c.textContent);
+      },
+    };
+  }
+
+  it("returns canonical tier count + scoped text when tier 1 matches", async () => {
+    const b0 = scopedBubble({
+      "[data-message-content]": { textContent: "first answer" },
+    });
+    const b1 = scopedBubble({
+      "[data-message-content]": { textContent: "second answer" },
+    });
+    const doc = makeDoc({ [CANONICAL]: [b0, b1] });
+    const page = makePageForCascade(doc);
+
+    const r0 = await readCascadeState(page, 0);
+    expect(r0).toEqual({ count: 2, text: "first answer" });
+    const r1 = await readCascadeState(page, 1);
+    expect(r1).toEqual({ count: 2, text: "second answer" });
+  });
+
+  it("returns text:null instead of polluted whole-bubble fallback when scoped children are empty (cascade-pollution guard)", async () => {
+    // The canonical bubble's whole `textContent` includes the toolbar +
+    // LGP suggestion-pill text; returning it would re-introduce the
+    // exact pollution the scoped cascade exists to prevent. The atomic
+    // reader returns text:null so the settle-gate keeps polling.
+    const polluted = {
+      textContent: "TOOLBAR-PILLS-POLLUTION",
+      querySelector(sel: string): StubNode | null {
+        if (sel === "[data-message-content]") return leafBubble("");
+        if (sel === ".cpk\\:prose") return leafBubble("  ");
+        if (sel === ".prose") return leafBubble("\n\t");
+        return null;
+      },
+    };
+    const doc = makeDoc({ [CANONICAL]: [polluted] });
+    const page = makePageForCascade(doc);
+
+    const r = await readCascadeState(page, 0);
+    expect(r).toEqual({ count: 1, text: null });
+  });
+
+  it("returns {count:0, text:null} when NO tier matches at all (empty DOM)", async () => {
+    const doc = makeDoc({}); // no tiers found
+    const page = makePageForCascade(doc);
+    const r = await readCascadeState(page, 0);
+    expect(r).toEqual({ count: 0, text: null });
+  });
+
+  it("returns {count, text:null} when bubbleIndex is out of range within the matched tier", async () => {
+    const b0 = scopedBubble({
+      "[data-message-content]": { textContent: "only one" },
+    });
+    const doc = makeDoc({ [CANONICAL]: [b0] });
+    const page = makePageForCascade(doc);
+
+    // bubbleIndex=1 is out of range (only 1 bubble at index 0).
+    const r = await readCascadeState(page, 1);
+    expect(r).toEqual({ count: 1, text: null });
+  });
+
+  it("count and text come from the SAME tier (cross-tier consistency)", async () => {
+    // Canonical tier has 3 bubbles, headless tier has 7. The closure picks
+    // the FIRST tier whose length > 0 (canonical wins) and reads both
+    // count and indexed text from that tier — NOT from headless.
+    const canonical = [
+      scopedBubble({ "[data-message-content]": { textContent: "c-0" } }),
+      scopedBubble({ "[data-message-content]": { textContent: "c-1" } }),
+      scopedBubble({ "[data-message-content]": { textContent: "c-2" } }),
+    ];
+    const headless = [
+      scopedBubble({ "[data-message-content]": { textContent: "h-0" } }),
+      scopedBubble({ "[data-message-content]": { textContent: "h-1" } }),
+      scopedBubble({ "[data-message-content]": { textContent: "h-2" } }),
+      scopedBubble({ "[data-message-content]": { textContent: "h-3" } }),
+      scopedBubble({ "[data-message-content]": { textContent: "h-4" } }),
+      scopedBubble({ "[data-message-content]": { textContent: "h-5" } }),
+      scopedBubble({ "[data-message-content]": { textContent: "h-6" } }),
+    ];
+    const doc = makeDoc({ [CANONICAL]: canonical, [HEADLESS]: headless });
+    const page = makePageForCascade(doc);
+
+    const r = await readCascadeState(page, 2);
+    // Same-tier guarantee: count=3 (canonical), text="c-2" (canonical),
+    // never count=7 / text="h-2" (cross-tier).
+    expect(r).toEqual({ count: 3, text: "c-2" });
+  });
+
+  it("falls through to a later tier when canonical has zero matches", async () => {
+    const articleBubble = scopedBubble({
+      "[data-message-content]": { textContent: "article-text" },
+    });
+    const doc = makeDoc({
+      [ARTICLE_ROLE]: [articleBubble],
+    });
+    const page = makePageForCascade(doc);
+
+    const r = await readCascadeState(page, 0);
+    expect(r).toEqual({ count: 1, text: "article-text" });
+  });
+
+  it("tier 3 article-not-user matches when role+role+assistant tiers are empty", async () => {
+    const b = scopedBubble({ p: { textContent: "non-user article" } });
+    const doc = makeDoc({ [ARTICLE_NOT_USER]: [b] });
+    const page = makePageForCascade(doc);
+
+    const r = await readCascadeState(page, 0);
+    expect(r).toEqual({ count: 1, text: "non-user article" });
+  });
+
+  it("models count growth across polls — same atomic reader returns the new tier-count + text", async () => {
+    // Simulate the mid-stream race: poll 1 sees 1 bubble at the canonical
+    // tier, poll 2 sees 2 bubbles (a new bubble mounted). With the atomic
+    // reader, both reads in each poll come from the SAME tier — no
+    // cross-tier inconsistency.
+    let polls = 0;
+    const polled = (): ReturnType<typeof makeDoc> => {
+      polls += 1;
+      const list: StubNode[] = [
+        scopedBubble({
+          "[data-message-content]": { textContent: "bubble-0" },
+        }),
+      ];
+      if (polls >= 2) {
+        list.push(
+          scopedBubble({
+            "[data-message-content]": { textContent: "bubble-1" },
+          }),
+        );
+      }
+      return makeDoc({ [CANONICAL]: list });
+    };
+
+    const r1 = await readCascadeState(makePageForCascade(polled()), 0);
+    expect(r1).toEqual({ count: 1, text: "bubble-0" });
+
+    const r2 = await readCascadeState(makePageForCascade(polled()), 1);
+    expect(r2).toEqual({ count: 2, text: "bubble-1" });
+  });
+
+  it("swallows page.evaluate throws and returns {count:0, text:null}", async () => {
+    const page: Page = {
+      async evaluate(): Promise<unknown> {
+        throw new Error("browser-eval-blew-up");
+      },
+    } as unknown as Page;
+
+    const r = await readCascadeState(page, 0);
+    expect(r).toEqual({ count: 0, text: null });
+  });
+});

--- a/showcase/harness/src/probes/helpers/assistant-message-count.ts
+++ b/showcase/harness/src/probes/helpers/assistant-message-count.ts
@@ -1,0 +1,357 @@
+import type { Page } from "playwright";
+
+/**
+ * Single source of truth for the assistant-bubble DOM cascade used
+ * by both the conversation runner AND the d5/d6 diagnostics paths.
+ *
+ * Cascade lives in assistant-message-count.ts (single source of truth).
+ * Sibling readers (_hitl-shared, _gen-ui-shared, d5-agentic-chat,
+ * d5-shared-state) import these constants directly; conversation-runner
+ * re-exports them for back-compat with any older import paths.
+ *
+ * The cascade tiers (in order):
+ *   1. Canonical: [data-testid="copilot-assistant-message"]
+ *   2. Tagged article: [role="article"][data-message-role="assistant"]
+ *   3. Non-user article: [role="article"]:not([data-message-role="user"])
+ *   4. Headless: [data-message-role="assistant"]
+ *
+ * Each helper picks the FIRST tier whose match-count is > 0 and
+ * uses that tier exclusively. This mirrors readMessageCount's prior
+ * behaviour (conversation-runner.ts:936-:980 at plan-author time).
+ *
+ * Note: the 3-constant re-exports (PRIMARY/FALLBACK/HEADLESS) reflect a
+ * historical 3-tier read used by the sibling scripts that predates the
+ * 4-tier `[role="article"][data-message-role="assistant"]` insertion
+ * for the canonical cascade. The constants are intentionally limited to
+ * tiers 1, 3, 4 to preserve those scripts' established cascade order —
+ * tier 2 is reachable inside `countAssistantMessages`/`findAssistantBubbleAt`
+ * via the inlined cascade body below.
+ *
+ * The DOM types are reached via a type-erased indirection because the
+ * package's tsconfig intentionally excludes the `dom` lib (server-side
+ * Node code). Same pattern used in `_gen-ui-shared.ts:154-186` and
+ * `conversation-runner.ts:readMessageCount`.
+ */
+
+/** Canonical CopilotKit assistant-message testid (cascade tier 1). */
+export const ASSISTANT_MESSAGE_PRIMARY_SELECTOR =
+  '[data-testid="copilot-assistant-message"]';
+/** ARIA article fallback excluding explicit user bubbles (cascade tier 3). */
+export const ASSISTANT_MESSAGE_FALLBACK_SELECTOR =
+  '[role="article"]:not([data-message-role="user"])';
+/** Headless/custom-composer last-resort (cascade tier 4). */
+export const ASSISTANT_MESSAGE_HEADLESS_SELECTOR =
+  '[data-message-role="assistant"]';
+
+export async function countAssistantMessages(page: Page): Promise<number> {
+  try {
+    return await page.evaluate(() => {
+      const win = globalThis as unknown as {
+        document: { querySelectorAll(sel: string): { length: number } };
+      };
+      const tiers = [
+        '[data-testid="copilot-assistant-message"]',
+        '[role="article"][data-message-role="assistant"]',
+        '[role="article"]:not([data-message-role="user"])',
+        '[data-message-role="assistant"]',
+      ];
+      for (const sel of tiers) {
+        const n = win.document.querySelectorAll(sel).length;
+        if (n > 0) return n;
+      }
+      return 0;
+    });
+  } catch (err) {
+    console.warn(
+      `[assistant-message-count] countAssistantMessages: ${(err as Error).message ?? err}`,
+    );
+    return 0;
+  }
+}
+
+/**
+ * Resolve the assistant bubble at strict index `bubbleIndex` (0-based)
+ * via the same cascade as countAssistantMessages. Returns the bubble's
+ * MESSAGE-TEXT textContent (scoped to the bubble's inner message-content
+ * region — NOT the whole bubble wrapper) or null when the index is out
+ * of range.
+ *
+ * Why scoped, not whole-bubble: LGP-canonical chat (and other v2 demos
+ * that opt into suggestion-pills via `useConfigureSuggestions`) inject
+ * trailing suggestion-pill DOM into the assistant bubble's surrounding
+ * area AFTER the streamed message text has landed. The canonical
+ * assistant bubble (`[data-testid="copilot-assistant-message"]`) also
+ * carries a toolbar (`[data-testid="copilot-assistant-toolbar"]`) as a
+ * sibling of the markdown wrapper — its icon/aria text content shifts
+ * once the toolbar mounts post-stream. Reading the whole bubble's
+ * `textContent` therefore conflates "message text" with "post-message
+ * UI affordances", and the text-stable conjunct in `waitForTurnComplete`
+ * will see the textContent shift forever (defect-1 + defect-4 RED with
+ * `reason=text-unstable`). Scoping the read to the markdown-content
+ * child element decouples the conjunct from the UI affordances that
+ * canonically arrive AFTER the message.
+ *
+ * Per-tier message-text selectors (each scoped INSIDE the bubble found
+ * at `idx` in the matched cascade tier):
+ *   - canonical `[data-testid="copilot-assistant-message"]`:
+ *       first `.cpk\:prose` child (the Streamdown wrapper in
+ *       `CopilotChatAssistantMessage.tsx` — its sibling is the toolbar +
+ *       any tool-calls view).
+ *   - `[role="article"]` + `[data-message-role="assistant"]` tiers
+ *     (e.g. langgraph-python:headless-simple via
+ *     `showcase/integrations/STAR/headless-simple/message-bubble.tsx`):
+ *       first paragraph child of the bubble — these custom bubbles wrap
+ *       the streamed content in a single paragraph element.
+ *
+ * If no scoped match is found within a matched bubble (or every scoped
+ * match is empty/whitespace-only mid-stream), we DO NOT fall back to the
+ * bubble's full `textContent` — returning the whole bubble would re-introduce
+ * the LGP-pill / toolbar pollution this cascade was added to prevent
+ * (see the per-tier scoping rationale above). Instead we return `null` so
+ * the settle gate's `text !== null && text.trim().length > 0` guard keeps
+ * polling until a scoped child populates.
+ *
+ * The bubble is resolved from whichever tier matched in the same call,
+ * so a runner that observed `count=N` at tier-T can ask for any
+ * `bubbleIndex < N` and trust they share a tier.
+ *
+ * Implementation note: the body still references `querySelectorAll`
+ * AND `textContent` as anchor strings — the unit-test fake in
+ * `conversation-runner.test.ts` + `probe-contract.test.ts` dispatches
+ * on those substrings to route the evaluate call to the text-at-index
+ * branch (see `conversation-runner.test.ts:228`).
+ */
+export async function findAssistantBubbleAt(
+  page: Page,
+  bubbleIndex: number,
+): Promise<string | null> {
+  try {
+    return await page.evaluate((idx: number) => {
+      // Per-tier (bubble-selector, scoped-text-selectors). The scoped
+      // selectors are queried via `bubble.querySelector` once we've
+      // resolved the bubble at `idx`. We use `document.querySelectorAll`
+      // directly (Playwright runs this in the browser context where the
+      // global `document` is the DOM document) — no type-erased globalThis
+      // indirection, which has caused undefined-item bugs in the past.
+      // The DOM lib is intentionally excluded from this package's tsconfig
+      // (this file runs in Node-land code-gen, but the closure is shipped
+      // to the browser via page.evaluate). Re-establish the shape locally.
+      interface DomElement {
+        readonly textContent: string | null;
+        querySelector(sel: string): DomElement | null;
+      }
+      interface DomNodeList {
+        readonly length: number;
+        item(idx: number): DomElement | null;
+      }
+      const doc = (
+        globalThis as unknown as {
+          document: { querySelectorAll(sel: string): DomNodeList };
+        }
+      ).document;
+      const tiers: Array<{ bubble: string; textSelectors: string[] }> = [
+        {
+          bubble: '[data-testid="copilot-assistant-message"]',
+          textSelectors: ["[data-message-content]", ".cpk\\:prose", ".prose"],
+        },
+        {
+          bubble: '[role="article"][data-message-role="assistant"]',
+          textSelectors: ["[data-message-content]", "p"],
+        },
+        {
+          bubble: '[role="article"]:not([data-message-role="user"])',
+          textSelectors: ["[data-message-content]", "p"],
+        },
+        {
+          bubble: '[data-message-role="assistant"]',
+          textSelectors: ["[data-message-content]", "p"],
+        },
+      ];
+      for (const tier of tiers) {
+        const list = doc.querySelectorAll(tier.bubble);
+        if (list.length > 0) {
+          if (idx < 0 || idx >= list.length) return null;
+          const bubble = list.item(idx);
+          if (!bubble) return null;
+          // Fall through to the next scoped selector when the matched
+          // element exists but has empty/whitespace-only textContent —
+          // some bubble shapes mount `[data-message-content]` as a
+          // static-empty wrapper before children populate (or the real
+          // text lives in a sibling `.cpk\:prose` / `p`). Returning ""
+          // here would lock the settle gate on `text-unstable` until
+          // timeout. See `resolveBubbleTextFromSelectors` (sibling
+          // pure helper) — kept in lock-step with the closure body so
+          // unit tests can exercise the cascade without JSDOM.
+          for (const textSel of tier.textSelectors) {
+            const scoped = bubble.querySelector(textSel);
+            if (scoped !== null) {
+              const t = scoped.textContent ?? "";
+              if (t.trim().length > 0) {
+                return t;
+              }
+            }
+          }
+          // Cascade-pollution guard: ALL per-tier scoped selectors are
+          // present-but-empty (a transient mid-stream state). DO NOT fall
+          // through to `bubble.textContent` — the whole bubble conflates
+          // message text with post-message UI affordances (LGP suggestion
+          // pills, the canonical assistant toolbar) and re-introduces the
+          // exact pollution this scoped cascade exists to prevent.
+          // Return null so the runner's `text !== null && text.trim().length > 0`
+          // settle gate keeps polling rather than locking onto polluted text.
+          return null;
+        }
+      }
+      return null;
+    }, bubbleIndex);
+  } catch (err) {
+    console.warn(
+      `[assistant-message-count] findAssistantBubbleAt: ${(err as Error).message ?? err}`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Atomic single-`page.evaluate` reader returning BOTH the assistant-bubble
+ * count and the text at `bubbleIndex` from the SAME cascade tier in ONE
+ * browser-side round-trip.
+ *
+ * Why: callers that need both (e.g. `waitForTurnComplete`) used to call
+ * `countAssistantMessages` then `findAssistantBubbleAt` in two sequential
+ * `page.evaluate` calls. Between the two round-trips the DOM can mutate —
+ * the count read may resolve to tier 2 (4 bubbles), then a tier-1 bubble
+ * mounts and the subsequent text read resolves to tier 1 (now 5 bubbles).
+ * The two reads' "bubble at index N" would refer to DIFFERENT DOM nodes
+ * across tiers. This atomic helper picks ONE tier inside the closure and
+ * returns the count + indexed text from that SAME tier, eliminating the
+ * cross-tier race.
+ *
+ * Contract:
+ *   - count: from whichever tier matched (the first tier whose `length > 0`)
+ *   - text:  per-tier scoped text at `bubbleIndex` within that SAME tier,
+ *            using the same scoped-text cascade as `findAssistantBubbleAt`
+ *            (returns null when no scoped child has non-empty text, NOT
+ *            the whole-bubble textContent — see that function for why).
+ *   - When no tier matches at all: `{ count: 0, text: null }`.
+ *   - When `bubbleIndex` is out of range within the matched tier:
+ *     `{ count: <matched tier count>, text: null }`.
+ *
+ * The standalone `countAssistantMessages` and `findAssistantBubbleAt`
+ * functions remain exported for callers that need only one of the two
+ * (e.g. `_gen-ui-shared`, `d6-all-pills`, `countFinal` re-classification).
+ *
+ * Implementation note: the closure body references `querySelectorAll`
+ * AND `textContent` as anchor substrings — the unit-test fakes in
+ * `conversation-runner.test.ts` and `assistant-message-count.test.ts`
+ * dispatch on those substrings to route the evaluate call.
+ */
+export async function readCascadeState(
+  page: Page,
+  bubbleIndex: number,
+): Promise<{ count: number; text: string | null }> {
+  try {
+    return await page.evaluate((idx: number) => {
+      interface DomElement {
+        readonly textContent: string | null;
+        querySelector(sel: string): DomElement | null;
+      }
+      interface DomNodeList {
+        readonly length: number;
+        item(idx: number): DomElement | null;
+      }
+      const doc = (
+        globalThis as unknown as {
+          document: { querySelectorAll(sel: string): DomNodeList };
+        }
+      ).document;
+      const tiers: Array<{ bubble: string; textSelectors: string[] }> = [
+        {
+          bubble: '[data-testid="copilot-assistant-message"]',
+          textSelectors: ["[data-message-content]", ".cpk\\:prose", ".prose"],
+        },
+        {
+          bubble: '[role="article"][data-message-role="assistant"]',
+          textSelectors: ["[data-message-content]", "p"],
+        },
+        {
+          bubble: '[role="article"]:not([data-message-role="user"])',
+          textSelectors: ["[data-message-content]", "p"],
+        },
+        {
+          bubble: '[data-message-role="assistant"]',
+          textSelectors: ["[data-message-content]", "p"],
+        },
+      ];
+      for (const tier of tiers) {
+        const list = doc.querySelectorAll(tier.bubble);
+        if (list.length > 0) {
+          const count = list.length;
+          if (idx < 0 || idx >= count) {
+            return { count, text: null };
+          }
+          const bubble = list.item(idx);
+          if (!bubble) return { count, text: null };
+          for (const textSel of tier.textSelectors) {
+            const scoped = bubble.querySelector(textSel);
+            if (scoped !== null) {
+              const t = scoped.textContent ?? "";
+              if (t.trim().length > 0) {
+                return { count, text: t };
+              }
+            }
+          }
+          // Cascade-pollution guard mirroring `findAssistantBubbleAt`:
+          // no scoped child has non-empty text — return null rather than
+          // falling back to the whole bubble's textContent.
+          return { count, text: null };
+        }
+      }
+      return { count: 0, text: null };
+    }, bubbleIndex);
+  } catch (err) {
+    console.warn(
+      `[assistant-message-count] readCascadeState: ${(err as Error).message ?? err}`,
+    );
+    return { count: 0, text: null };
+  }
+}
+
+/**
+ * Pure sibling of the scoped-text cascade inside `findAssistantBubbleAt`'s
+ * `page.evaluate` closure. Kept in lock-step with the closure body so unit
+ * tests can exercise the empty-textContent fall-through without JSDOM.
+ *
+ * Contract: walk `textSelectors` in order; for each selector return its
+ * `textContent` only when non-empty/non-whitespace; otherwise fall through
+ * to the next selector. After exhausting `textSelectors`, return `null` —
+ * the closure body MUST NOT fall back to `bubble.textContent`, which would
+ * re-introduce the LGP suggestion-pill / assistant-toolbar pollution this
+ * scoped cascade exists to prevent.
+ *
+ * Any change to the closure's per-tier scoped-text loop MUST be mirrored
+ * here, and vice-versa.
+ */
+export interface BubbleTextElement {
+  readonly textContent: string | null;
+  querySelector(sel: string): BubbleTextElement | null;
+}
+export function resolveBubbleTextFromSelectors(
+  bubble: BubbleTextElement,
+  textSelectors: readonly string[],
+): string | null {
+  for (const textSel of textSelectors) {
+    const scoped = bubble.querySelector(textSel);
+    if (scoped !== null) {
+      const t = scoped.textContent ?? "";
+      if (t.trim().length > 0) {
+        return t;
+      }
+    }
+  }
+  // No scoped selector produced non-empty text. Return null instead of
+  // `bubble.textContent` so the settle gate keeps polling rather than
+  // locking onto the polluted whole-bubble text (toolbar icons, LGP
+  // suggestion-pill text). See `findAssistantBubbleAt` for the rationale.
+  return null;
+}

--- a/showcase/harness/src/probes/helpers/conversation-runner.test.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.test.ts
@@ -4,6 +4,7 @@ import {
   fillAndVerifySend,
   readUserMessageCount,
   waitForContentAndSend,
+  readErrorBanner,
   AssistantErroredError,
 } from "./conversation-runner.js";
 import type { ConversationTurn, Page } from "./conversation-runner.js";
@@ -36,7 +37,7 @@ interface PageScript {
   evaluateValues?: number[];
   // Optional override for `page.evaluate` so tests can spy on its
   // semantics directly when they need to.
-  evaluate?: (fn: () => unknown) => Promise<unknown>;
+  evaluate?: (fn: () => unknown, arg?: unknown) => Promise<unknown>;
   // Errors to throw on individual page-API calls.
   throwOnFill?: Error;
   throwOnPress?: Error;
@@ -85,7 +86,23 @@ function wrapEvaluateForUserMessages(
   inner: (...args: any[]) => Promise<any>,
 ): Page["evaluate"] {
   let userCalls = 0;
-  return (async <R>(fn: () => R): Promise<R> => {
+  // Track the most recent assistant-count value returned by `inner` so the
+  // post-cutover `waitForTurnComplete` primitive's auxiliary reads (SSE
+  // run-finished counter, bubble-text-at-index) can be synthesised from the
+  // SAME scripted count progression the test author provided. This mirrors
+  // `makePage`'s branch dispatch so tests that use this helper see the same
+  // shape from every read branch as tests that use `makePage` directly.
+  let latestCount = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return async function (this: unknown, fn: (...a: any[]) => unknown) {
+    // Playwright's real Page accepts (fn, arg); the structural Page
+    // surface erases the second arg. Grab it via `arguments` so any
+    // probe that passes a runtime arg (e.g. `findAssistantBubbleAt`'s
+    // bubbleIndex) still reaches the inner / synthesised branches.
+    // eslint-disable-next-line prefer-rest-params
+    const argRuntime = (arguments as unknown as IArguments)[1] as
+      | number
+      | undefined;
     const body = fn.toString();
     if (body.includes("copilot-user-message")) {
       return userCalls++ as never;
@@ -100,8 +117,69 @@ function wrapEvaluateForUserMessages(
     if (body.includes("copilot-error-banner")) {
       return { visible: false } as never;
     }
-    return inner(fn) as Promise<R>;
-  }) as Page["evaluate"];
+    // SSE run-finished counter read (`waitForTurnComplete` conjunct 1).
+    // Synthesised from the latest observed assistant count: whenever the
+    // assistant DOM has N bubbles, the server must have flushed N
+    // RUN_FINISHED events. This keeps existing single-queue inner scripts
+    // (0 → 1 stable) satisfying the SSE conjunct without per-test
+    // augmentation — exact parity with `makePage`'s `__hk_runsFinished`
+    // branch.
+    if (body.includes("__hk_runsFinished")) {
+      return latestCount as never;
+    }
+    // Atomic cascade-state read (`readCascadeState`): returns BOTH the
+    // count and the indexed text from the SAME cascade tier in ONE
+    // round-trip. Routed BEFORE the legacy text-only branch because the
+    // closure body matches BOTH dispatch heuristics (`querySelectorAll`
+    // + `textContent`); the distinguishing substring is the literal
+    // `{ count` the closure uses to construct its return object. We
+    // forward to `inner` to drain the count progression the test author
+    // scripted, then synthesise the text from the resulting latestCount.
+    if (
+      body.includes("querySelectorAll") &&
+      body.includes("textContent") &&
+      body.includes("{ count")
+    ) {
+      // eslint-disable-next-line prefer-rest-params
+      const innerArgsCascade = Array.from(arguments as unknown as IArguments);
+      const innerResult = (await (
+        inner as (...a: unknown[]) => Promise<unknown>
+      )(...innerArgsCascade)) as unknown;
+      if (typeof innerResult === "number") {
+        latestCount = innerResult;
+      }
+      const idx = argRuntime ?? 0;
+      const text =
+        idx < 0 || idx >= latestCount
+          ? null
+          : `assistant-bubble-text-${latestCount}`;
+      return { count: latestCount, text } as never;
+    }
+    // Assistant-bubble TEXT read (`findAssistantBubbleAt`). Mirror
+    // `makePage`'s text branch: return a non-empty placeholder whenever
+    // a bubble at the requested index exists (latestCount surpasses idx),
+    // null otherwise. The text value tracks the latest count so the
+    // text-stable conjunct of `waitForTurnComplete` holds as soon as the
+    // count stops changing.
+    if (body.includes("querySelectorAll") && body.includes("textContent")) {
+      const idx = argRuntime ?? 0;
+      if (idx < 0 || idx >= latestCount) return null as never;
+      return `assistant-bubble-text-${latestCount}` as never;
+    }
+    // Default branch: forward to the inner script (and the runtime arg,
+    // so a script that needs it isn't silently passed `undefined`). Cache
+    // the result as the new `latestCount` for the synthesised SSE/text
+    // branches above.
+    // eslint-disable-next-line prefer-rest-params
+    const innerArgs = Array.from(arguments as unknown as IArguments);
+    const result = (await (inner as (...a: unknown[]) => Promise<unknown>)(
+      ...innerArgs,
+    )) as unknown;
+    if (typeof result === "number") {
+      latestCount = result;
+    }
+    return result as never;
+  } as Page["evaluate"];
 }
 
 /**
@@ -119,6 +197,38 @@ function shapeBannerProbeText(text: string): string {
   return text;
 }
 
+/**
+ * Detect whether an `evaluate` callback body is the atomic `readCascadeState`
+ * closure. The production closure builds a `{ count, text }` object and so its
+ * stringified body contains the literal `{ count` — distinct from the legacy
+ * count-only and text-only branches whose bodies don't construct that object.
+ *
+ * Hand-rolled `page.evaluate` fakes use this to return the `{ count, text }`
+ * shape instead of a raw number when the runner's `waitForTurnComplete` is
+ * making its single atomic cascade read.
+ */
+function isReadCascadeStateBody(body: string): boolean {
+  return (
+    body.includes("querySelectorAll") &&
+    body.includes("textContent") &&
+    body.includes("{ count")
+  );
+}
+
+/**
+ * Synthesise a cascade-state result from a scalar count, mirroring the shape
+ * `readCascadeState` returns. Hand-rolled fakes use this to translate their
+ * legacy count-only return value into the atomic `{ count, text }` shape.
+ */
+function cascadeStateOf(
+  count: number,
+  idx: number,
+): { count: number; text: string | null } {
+  const text =
+    idx < 0 || idx >= count ? null : `assistant-bubble-text-${count}`;
+  return { count, text };
+}
+
 function makePage(script: PageScript = {}): Page {
   const queue = [...(script.evaluateValues ?? [])];
   const userQueue = [...(script.userMessageValues ?? [])];
@@ -127,6 +237,17 @@ function makePage(script: PageScript = {}): Page {
   // Auto-succeed counter: first user-message read = 0 (baseline),
   // subsequent reads = 1 (growth detected → verify loop succeeds).
   let autoUserCalls = 0;
+  // Track the most recent assistant-count value drained from the queue.
+  // The post-cutover `waitForTurnComplete` primitive makes THREE reads
+  // per poll iteration (SSE counter, count, text). Tests script
+  // `evaluateValues` as count progressions; the SSE counter is
+  // auto-derived from the latest count (any time the assistant DOM has
+  // grown to N bubbles, the server must have flushed N RUN_FINISHED
+  // events) and the text branch returns a non-empty placeholder
+  // whenever the count surpasses the requested index. This keeps
+  // existing single-queue test scripts working without per-test
+  // SSE/text augmentation.
+  let latestCount = 0;
   return {
     async waitForSelector() {
       // No-op — the runner uses this only to confirm the chat input exists.
@@ -139,14 +260,32 @@ function makePage(script: PageScript = {}): Page {
       if (script.throwOnPress) throw script.throwOnPress;
       script.recorded?.presses.push(_key);
     },
-    async evaluate(fn) {
-      if (script.evaluate) return script.evaluate(fn) as never;
+    async evaluate(fn: () => unknown) {
+      // The structural Page surface declares evaluate as single-arg, but
+      // Playwright's real Page accepts (fn, arg) — `findAssistantBubbleAt`
+      // calls it with a bubbleIndex as the second arg. We grab the optional
+      // second runtime arg via `arguments` since the structural signature
+      // erases it.
+      // eslint-disable-next-line prefer-rest-params
+      const argRuntime = (arguments as unknown as IArguments)[1] as
+        | number
+        | undefined;
+      if (script.evaluate) return script.evaluate(fn, argRuntime) as never;
 
       // Detect whether the evaluate call is reading user messages or
       // assistant messages by inspecting the function body. The
       // readUserMessageCount function references "copilot-user-message"
-      // while readMessageCount references "copilot-assistant-message".
+      // while countAssistantMessages references "copilot-assistant-message".
       const fnBody = fn.toString();
+      // SSE run-finished counter read (`waitForTurnComplete` conjunct
+      // 1). The page-side counter is exposed by attachSseInterceptor in
+      // production; in this unit test we synthesise it as the latest
+      // observed assistant count so any scripted count progression
+      // (0 → 1 → 1 → …) trivially satisfies "SSE caught up to turn N"
+      // whenever the corresponding bubble exists in the DOM.
+      if (fnBody.includes("__hk_runsFinished")) {
+        return latestCount as never;
+      }
       // Error-banner visibility probe references "copilot-error-banner".
       // Routed before the message-count branches so it gets its own
       // scripted queue. Defaults to `false` (no banner) when unscripted
@@ -185,12 +324,71 @@ function makePage(script: PageScript = {}): Page {
         return autoUserCalls++ as never;
       }
 
+      // Atomic cascade-state read (`readCascadeState`): returns BOTH the
+      // count and the indexed text from the SAME cascade tier in ONE
+      // round-trip. Routed BEFORE the legacy text-only branch because the
+      // closure body matches BOTH dispatch heuristics (`querySelectorAll`
+      // + `textContent`); the distinguishing substring is the literal
+      // `{ count` the closure uses to construct its return object.
+      //
+      // The drain happens INLINE here (rather than at the default-branch
+      // tail like the legacy 3-call flow) because the post-cutover
+      // `waitForTurnComplete` makes only TWO reads per poll (SSE counter
+      // + cascade-state), so this is the call that must advance the
+      // scripted count progression for each poll.
+      if (
+        fnBody.includes("querySelectorAll") &&
+        fnBody.includes("textContent") &&
+        fnBody.includes("{ count")
+      ) {
+        let drained: number;
+        if (queue.length === 0) {
+          drained = 0;
+        } else if (queue.length === 1) {
+          drained = queue[0]!;
+        } else {
+          drained = queue.shift()!;
+        }
+        latestCount = drained;
+        const idx = argRuntime ?? 0;
+        const text =
+          idx < 0 || idx >= latestCount
+            ? null
+            : `assistant-bubble-text-${latestCount}`;
+        return { count: latestCount, text } as never;
+      }
+      // Assistant-bubble TEXT read (`findAssistantBubbleAt`). The
+      // production helper passes a 0-based bubbleIndex as the second
+      // arg to page.evaluate; the playwright Page surface accepts
+      // (fn, arg) — both reach this fake via the rest param. Return
+      // a non-empty placeholder whenever a bubble at that index exists
+      // (i.e. latestCount surpasses the requested index), null
+      // otherwise — matches the production cascade's null-when-index-
+      // out-of-range behaviour. The text value mirrors the latest count
+      // so the `waitForTurnComplete` text-stable conjunct holds as soon
+      // as the count stops changing.
+      if (
+        fnBody.includes("querySelectorAll") &&
+        fnBody.includes("textContent")
+      ) {
+        const idx = argRuntime ?? 0;
+        if (idx < 0 || idx >= latestCount) return null as never;
+        return `assistant-bubble-text-${latestCount}` as never;
+      }
+
       // Drain one value per call. Once exhausted, freeze on the last
       // value so any post-script poll sees the steady-state count
       // (matches a real assistant message that has finished streaming).
-      if (queue.length === 0) return 0 as never;
-      if (queue.length === 1) return queue[0]! as never;
-      return queue.shift()! as never;
+      let value: number;
+      if (queue.length === 0) {
+        value = 0;
+      } else if (queue.length === 1) {
+        value = queue[0]!;
+      } else {
+        value = queue.shift()!;
+      }
+      latestCount = value;
+      return value as never;
     },
     // inputValue is only provided when the script includes inputValues,
     // mirroring the optional nature of the Page interface member.
@@ -374,7 +572,15 @@ describe("runConversation", () => {
     expect(result.total_turns).toBe(1);
     expect(result.failure_turn).toBe(1);
     expect(result.error).toBeDefined();
-    expect(result.error!.toLowerCase()).toContain("timeout");
+    // `waitForTurnComplete` surfaces the failure as
+    // "turn N did not complete within Xms (reason=…)" — the canonical
+    // settle-deadline message. Either the historical "timeout" word or the
+    // current "did not complete within" phrase satisfies the contract: the
+    // assertion is "the runner timed out waiting for the assistant", not the
+    // exact wording of the message.
+    expect(result.error!.toLowerCase()).toMatch(
+      /timeout|did not complete within/i,
+    );
     // Failed turn's duration is not recorded (spec: length === turns_completed).
     expect(result.turn_durations_ms).toHaveLength(0);
   });
@@ -550,13 +756,20 @@ describe("runConversation", () => {
     const recorded = { fills: [] as string[], presses: [] as string[] };
     const page = makePage({
       // Assistant count stays AT baseline (0) through the flicker poll so the
-      // flicker is evaluated while `current <= baselineCount` — exercising the
-      // real debounce-reset path, NOT the success-in-flight disarm. THEN it
-      // grows to 1 and freezes so the turn settles AFTER the flicker poll has
-      // been seen. Evaluate draws (a `readMessageCount` per read): #1=boot
-      // baseline (conversation-runner.ts:362), #2=waitForAssistantSettled
-      // initial lastCount, #3=loop poll1, #4=loop poll2 (the flicker poll —
-      // still 0, so debounce path runs), #5=loop poll3 (1), then frozen at 1
+      // flicker is evaluated while no response has yet been produced —
+      // exercising the real debounce-reset path, NOT the success-in-flight
+      // disarm. THEN it grows to 1 and freezes so the turn settles AFTER the
+      // flicker poll has been seen. `waitForTurnComplete` makes THREE
+      // page.evaluate reads per poll: (1) the SSE counter
+      // `window.__hk_runsFinished`, (2) `countAssistantMessages` (DOM count),
+      // (3) `findAssistantBubbleAt(idx).textContent`. Only the count read
+      // drains this scripted `evaluateValues` queue — the SSE counter is
+      // synthesized from the latest observed count in the fake (so it tracks
+      // the count trivially) and the text branch returns a non-empty
+      // placeholder whenever the count surpasses the requested index. The
+      // queue values therefore describe the SUCCESSIVE COUNT READS the fake
+      // returns: poll1=0, poll2=0, poll3=0, poll4=0 (the flicker poll — count
+      // still at baseline, so debounce path runs), poll5=1, then frozen at 1
       // → count change resets lastChangeAt, settle fires after settleMs.
       evaluateValues: [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
       // Banner sequence (1st entry = baseline snapshot, rest = per-poll):
@@ -653,14 +866,19 @@ describe("runConversation", () => {
     const recorded = { fills: [] as string[], presses: [] as string[] };
     const page = makePage({
       // Assistant count stays AT baseline (0) through the flicker poll so the
-      // fresh-banner flicker is evaluated while `current <= baselineCount` —
-      // exercising the real debounce-reset path, NOT the success-in-flight
-      // disarm. THEN it grows to 1 and freezes → settles AFTER the flicker
-      // poll is reached. Draws (a `readMessageCount` per read): #1=boot
-      // baseline (conversation-runner.ts:362), #2=waitForAssistantSettled
-      // initial lastCount, #3=loop poll1, #4=loop poll2 (the flicker poll —
-      // still 0, so debounce path runs), #5=loop poll3 (1), frozen 1 → count
-      // change resets lastChangeAt, settle fires after settleMs.
+      // fresh-banner flicker is evaluated while no response has yet been
+      // produced — exercising the real debounce-reset path, NOT the
+      // success-in-flight disarm. THEN it grows to 1 and freezes → settles
+      // AFTER the flicker poll is reached. `waitForTurnComplete` makes THREE
+      // page.evaluate reads per poll: (1) SSE counter
+      // `window.__hk_runsFinished`, (2) `countAssistantMessages` (DOM count),
+      // (3) `findAssistantBubbleAt(idx).textContent`. Only the count read
+      // drains this scripted `evaluateValues` queue — the SSE counter and
+      // text branch are synthesized from the latest count in the fake. So
+      // the queue values are the SUCCESSIVE COUNT READS: poll1=0, poll2=0,
+      // poll3=0, poll4=0 (the flicker poll — count still at baseline, so the
+      // debounce path runs), poll5=1, frozen at 1 → count change resets
+      // lastChangeAt, settle fires after settleMs.
       evaluateValues: [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
       // No banner at baseline. A FRESH banner appears for exactly ONE poll
       // (poll2) then disappears (poll3+ not visible). Single isolated poll ⇒
@@ -824,7 +1042,7 @@ describe("runConversation", () => {
         // observes fresh user-message growth.
         userCalls = 0;
       },
-      async evaluate<R>(fn: () => R): Promise<R> {
+      async evaluate<R>(fn: () => R, arg?: unknown): Promise<R> {
         const body = fn.toString();
         if (body.includes("copilot-error-banner")) {
           // After reload: banner gone → attempt 2 settles cleanly.
@@ -846,9 +1064,17 @@ describe("runConversation", () => {
         // Assistant-message count. Before reload: pinned at baseline 0 (no
         // response) so attempt 1 cannot settle and the fresh banner fast-fails.
         // After reload: grows to 1 and freezes → settles.
-        if (!reloaded) return 0 as never;
-        assistantCallsAfterReload++;
-        return (assistantCallsAfterReload > 1 ? 1 : 0) as never;
+        let count: number;
+        if (!reloaded) {
+          count = 0;
+        } else {
+          assistantCallsAfterReload++;
+          count = assistantCallsAfterReload > 1 ? 1 : 0;
+        }
+        if (isReadCascadeStateBody(body)) {
+          return cascadeStateOf(count, (arg as number) ?? 0) as never;
+        }
+        return count as never;
       },
     };
 
@@ -873,14 +1099,16 @@ describe("runConversation", () => {
     // The bound that keeps #5142 intact: the cold-start retry fires AT MOST
     // ONCE, only on turn 1, only for an AssistantErroredError. If the error
     // banner is a REAL sustained failure that survives the page.reload() and
-    // re-send, the second waitForAssistantSettled fast-fails again and the
-    // runner re-throws — the turn fails with the distinguished
-    // AssistantErroredError, NOT a generic timeout, and NOT a false success.
+    // re-send, the second `waitForTurnComplete` invocation throws a
+    // `TurnNotCompleteError` that the runner translates into the distinguished
+    // `AssistantErroredError` (via the post-settle `readErrorBanner` check) —
+    // the turn fails with that error, NOT a generic timeout, and NOT a false
+    // success.
     let reloadCount = 0;
     const recorded = { fills: [] as string[], presses: [] as string[] };
     let userCalls = 0;
     // Per-attempt banner-read counter, reset on each reload. Each
-    // waitForAssistantSettled invocation snapshots the banner ONCE at its
+    // `waitForTurnComplete` invocation snapshots the banner ONCE at its
     // baseline (first read) — that must be NOT visible so the subsequent
     // sustained banner reads as a differs-from-baseline NEW error and
     // fast-fails. A genuine failure does this on BOTH attempts.
@@ -898,7 +1126,7 @@ describe("runConversation", () => {
         userCalls = 0;
         bannerReadsThisAttempt = 0;
       },
-      async evaluate<R>(fn: () => R): Promise<R> {
+      async evaluate<R>(fn: () => R, arg?: unknown): Promise<R> {
         const body = fn.toString();
         if (body.includes("copilot-error-banner")) {
           // NOT visible on each attempt's baseline snapshot (first read),
@@ -913,6 +1141,9 @@ describe("runConversation", () => {
           return userCalls++ as never;
         }
         // Assistant never produces a response on either attempt.
+        if (isReadCascadeStateBody(body)) {
+          return cascadeStateOf(0, (arg as number) ?? 0) as never;
+        }
         return 0 as never;
       },
     };
@@ -964,11 +1195,25 @@ describe("runConversation", () => {
       async waitForSelector() {},
       async fill() {},
       async press() {},
+      // Defense-in-depth stub. Today the production skipSend branch in
+      // `sendTurnMessage` (conversation-runner.ts) explicitly does NOT call
+      // `waitForContentAndSend` — skipSend's submission came from `preFill`
+      // and the textarea is never touched — so `page.inputValue` is not
+      // exercised on this code path. We still stub it so that if the
+      // production runner ever grows a pre-submit textarea-content
+      // verification on the skipSend path, this test fails with the
+      // BANNER-FAST-FAIL assertion it's designed to pin, not with the
+      // `"page.inputValue is required"` contract throw from
+      // `waitForContentAndSend` (see the sibling "throws when page.inputValue
+      // is not implemented" test). Do NOT strip as unused.
+      async inputValue() {
+        return "stub-prefilled-text";
+      },
       async reload() {
         // Must NEVER be reached for a skipSend turn — the retry is gated off.
         reloaded = true;
       },
-      async evaluate<R>(fn: () => R): Promise<R> {
+      async evaluate<R>(fn: () => R, arg?: unknown): Promise<R> {
         const body = fn.toString();
         if (body.includes("copilot-error-banner")) {
           bannerReads++;
@@ -982,6 +1227,9 @@ describe("runConversation", () => {
           } as never;
         }
         // Assistant never produces a response — the only exit is the fast-fail.
+        if (isReadCascadeStateBody(body)) {
+          return cascadeStateOf(0, (arg as number) ?? 0) as never;
+        }
         return 0 as never;
       },
     };
@@ -1038,7 +1286,7 @@ describe("runConversation", () => {
         bannerReads = 0;
         userCalls = 0;
       },
-      async evaluate<R>(fn: () => R): Promise<R> {
+      async evaluate<R>(fn: () => R, arg?: unknown): Promise<R> {
         const body = fn.toString();
         if (body.includes("copilot-error-banner")) {
           bannerReads++;
@@ -1053,6 +1301,9 @@ describe("runConversation", () => {
           return userCalls++ as never;
         }
         // Assistant never responds → the retry settle-times-out.
+        if (isReadCascadeStateBody(body)) {
+          return cascadeStateOf(0, (arg as number) ?? 0) as never;
+        }
         return 0 as never;
       },
     };
@@ -1074,6 +1325,157 @@ describe("runConversation", () => {
     // ≥ 2000ms here).
     expect(elapsed).toBeLessThan(TURN_TIMEOUT * 1.8);
   }, 20_000);
+
+  it("cold-start retry: settle floor honours settleMs so the retry does NOT misclassify as text-unstable (R8F1)", async () => {
+    // R8F1 Concern A. The cold-start retry's `timeoutMs` is
+    // `Math.max(floor, turnDeadline - Date.now())`. The OLD floor
+    // (`3 * POLL_INTERVAL_MS` = 300ms) was strictly less than the default
+    // `assistantSettleMs` (1500ms), so when the first attempt nearly
+    // exhausted the budget the retry would enter `waitForTurnComplete` with
+    // `timeoutMs=300, settleMs=1500` — a MATHEMATICALLY IMPOSSIBLE gate
+    // (the loop must hold text stable for `settleMs` but times out before
+    // any settle window can complete). Every retry under exhausted budget
+    // was GUARANTEED to misclassify as `reason=text-unstable`, hiding the
+    // real cause (budget exhausted) and — in the assistant-recovers case —
+    // failing a turn that would have succeeded with a real settle window.
+    //
+    // With the new floor (`settleMs + POLL_INTERVAL_MS`) the retry gets a
+    // real settle window even when the first attempt exhausted the budget,
+    // so an assistant that responds promptly post-reload can SUCCEED.
+    const TURN_TIMEOUT = 500;
+    const SETTLE_MS = 400; // > 3 * POLL_INTERVAL_MS (300) — under the OLD floor the gate would be impossible
+    let reloaded = false;
+    let bannerReads = 0;
+    let userCalls = 0;
+    let assistantCount = 0;
+    let pollsSinceReload = 0;
+    const recorded = { fills: [] as string[], presses: [] as string[] };
+    const page: Page & { reload: () => Promise<void> } = {
+      async waitForSelector() {},
+      async fill(_selector, value) {
+        recorded.fills.push(value);
+      },
+      async press(_selector, key) {
+        recorded.presses.push(key);
+      },
+      async reload() {
+        reloaded = true;
+        // Burn most of the first attempt's budget BEFORE reload completes
+        // so the retry inherits a tiny remaining slice of the turn deadline.
+        // This is what the OLD floor failed to compensate for.
+        await new Promise((r) => setTimeout(r, TURN_TIMEOUT));
+        bannerReads = 0;
+        userCalls = 0;
+        assistantCount = 0;
+        pollsSinceReload = 0;
+      },
+      async evaluate<R>(fn: () => R, arg?: unknown): Promise<R> {
+        const body = fn.toString();
+        if (body.includes("copilot-error-banner")) {
+          bannerReads++;
+          // First attempt: a banner is visible across ≥2 polls → fast-fail.
+          // Post-reload: banner is gone (the cold-start condition cleared).
+          if (reloaded) return { visible: false } as never;
+          if (bannerReads <= 1) return { visible: false } as never;
+          return { visible: true, text: "cold start" } as never;
+        }
+        if (body.includes("copilot-user-message")) {
+          return userCalls++ as never;
+        }
+        if (body.includes("__hk_runsFinished")) {
+          return assistantCount as never;
+        }
+        if (
+          body.includes("querySelectorAll") &&
+          body.includes("textContent") &&
+          body.includes("{ count")
+        ) {
+          // Post-reload: grow to 1 on the first cascade read then hold
+          // stable so the retry's settle gate has time to converge under
+          // the NEW floor (settleMs + POLL_INTERVAL_MS = 500ms).
+          if (reloaded) {
+            pollsSinceReload++;
+            if (pollsSinceReload >= 1) assistantCount = 1;
+          }
+          return cascadeStateOf(assistantCount, (arg as number) ?? 0) as never;
+        }
+        if (body.includes("querySelectorAll") && body.includes("textContent")) {
+          const idx = (arg as number) ?? 0;
+          if (idx < 0 || idx >= assistantCount) return null as never;
+          return `assistant-bubble-text-${assistantCount}` as never;
+        }
+        return 0 as never;
+      },
+    };
+
+    const result = await runConversation(
+      page,
+      [{ input: "cold-then-recovers", responseTimeoutMs: TURN_TIMEOUT }],
+      { assistantSettleMs: SETTLE_MS },
+    );
+
+    // The page WAS reloaded (cold-start retry fired) AND the turn
+    // RECOVERED on the retry — proving the floor honoured `settleMs` so
+    // the post-reload assistant had a real chance to settle. Under the
+    // OLD 300ms floor with settleMs=400, the retry would have been
+    // mathematically unable to complete a settle window and the turn
+    // would have failed with `reason=text-unstable`.
+    expect(reloaded).toBe(true);
+    expect(result.failure_turn).toBeUndefined();
+    expect(result.error).toBeUndefined();
+    expect(result.turns_completed).toBe(1);
+    // The fill was issued twice — original + retry — proving the bounded
+    // retry executed and re-sent.
+    expect(recorded.fills).toEqual([
+      "cold-then-recovers",
+      "cold-then-recovers",
+    ]);
+  }, 20_000);
+
+  it("cold-start retry null-narrowing guard throws translatedErr (AssistantErroredError), not settleErr (R8F1 — source pin)", async () => {
+    // R8F1 Concern B. The null-narrowing guard in the cold-start retry
+    // path is entered specifically because
+    // `translatedErr instanceof AssistantErroredError`. The OLD code
+    // threw `settleErr` (the original `TurnNotCompleteError` or
+    // `BannerVisibleError`) instead of `translatedErr` — losing the
+    // distinguished error class that downstream consumers (and PR #5142's
+    // fast-fail surface) pin on. The fix throws `translatedErr` so the
+    // AssistantErroredError surface is preserved on this fail-loud path.
+    //
+    // The branch is structurally unreachable via the public API today
+    // (`resolveChatInputSelector` throws rather than returns `null`, and
+    // the per-turn resolve at the top of the try block always runs before
+    // a turn enters the fast-fail catch). The guard is defensive against
+    // a future refactor that ever lets `chatInputSelector` reach the
+    // retry path as `null`. Pin the contract at the SOURCE level: assert
+    // the file contains the corrected `throw translatedErr;` inside the
+    // null-narrowing block and does NOT contain the regressed
+    // `throw settleErr;` form. A regression that swaps the two would fail
+    // this test even though the runtime branch is dead code today.
+    const { readFileSync } = await import("node:fs");
+    const { fileURLToPath } = await import("node:url");
+    const sourcePath = fileURLToPath(
+      new URL("./conversation-runner.ts", import.meta.url),
+    );
+    const source = readFileSync(sourcePath, "utf8");
+
+    // Locate the null-narrowing guard block. The block is uniquely
+    // identified by the `chatInputSelector === null` check inside the
+    // retry path. Extract the next non-whitespace statement after that
+    // check — it MUST be `throw translatedErr;`.
+    const guardMatch = source.match(
+      /if \(chatInputSelector === null\) \{\s*throw (\w+);/,
+    );
+    expect(guardMatch).not.toBeNull();
+    expect(guardMatch![1]).toBe("translatedErr");
+    expect(guardMatch![1]).not.toBe("settleErr");
+
+    // Belt-and-suspenders: scan the whole file for any remaining
+    // `throw settleErr;` — the only place `settleErr` ever flowed was
+    // this guard, so its absence proves the regression cannot resurface
+    // by accident.
+    expect(source).not.toMatch(/throw\s+settleErr\s*;/);
+  });
 
   it("empty turns array: returns zeroes immediately", async () => {
     const page = makePage();
@@ -1321,19 +1723,20 @@ describe("runConversation", () => {
 
   it("survives transient evaluate() errors (caught + treated as count=0)", async () => {
     // page.evaluate throws on the very first read (baseline) but recovers
-    // on subsequent reads. The runner's readMessageCount catch returns 0
-    // on error so the baseline becomes 0 and the turn still settles when
-    // the count grows.
+    // on subsequent reads. The runner's `countAssistantMessages` swallows
+    // evaluate errors and returns 0 so the baseline becomes 0 and the turn
+    // still settles when the count grows.
     let assistantCalls = 0;
     let userCalls = 0;
     const page: Page = {
       async waitForSelector() {},
       async fill() {},
       async press() {},
-      async evaluate(fn) {
+      async evaluate(fn, ...rest: unknown[]) {
+        const body = fn.toString();
         // User-message reads return a monotonically increasing count
         // so fillAndVerifySend sees growth and doesn't retry.
-        if (fn.toString().includes("copilot-user-message")) {
+        if (body.includes("copilot-user-message")) {
           return userCalls++ as never;
         }
         // Error-banner visibility probe: return the runner-expected
@@ -1341,11 +1744,14 @@ describe("runConversation", () => {
         // Without this branch the read fell through to the assistant-count
         // path and returned a NUMBER — the no-banner path only "passed" by
         // the accident that `(number).visible` is `undefined` (falsy).
-        if (fn.toString().includes("copilot-error-banner")) {
+        if (body.includes("copilot-error-banner")) {
           return { visible: false } as never;
         }
         assistantCalls++;
         if (assistantCalls === 1) throw new Error("evaluate boom");
+        if (isReadCascadeStateBody(body)) {
+          return cascadeStateOf(1, (rest[0] as number) ?? 0) as never;
+        }
         return 1 as never;
       },
     };
@@ -1364,32 +1770,58 @@ describe("runConversation", () => {
     // count from 0 to 2 across consecutive evaluate() invocations.
     const queriedSelectors: string[] = [];
     let evalCount = 0;
+    // A minimal `NodeList`-shaped object: `length` for the cascade-tier
+    // selector (count read) AND `item(idx)` returning a synthetic bubble
+    // for the atomic `readCascadeState` closure's per-tier text read.
+    // The synthetic bubble's `querySelector` resolves the first scoped
+    // selector to a non-empty `textContent` so the settle gate's
+    // text-stable conjunct fires once the count grows past baseline.
+    const matchList = (
+      length: number,
+    ): {
+      length: number;
+      item: (i: number) => {
+        textContent: string;
+        querySelector: (s: string) => { textContent: string } | null;
+      } | null;
+    } => ({
+      length,
+      item(i: number) {
+        if (i < 0 || i >= length) return null;
+        return {
+          textContent: `bubble-${i}`,
+          querySelector(_s: string) {
+            return { textContent: `bubble-${i}` };
+          },
+        };
+      },
+    });
     const fakeDocument = {
-      querySelectorAll: (sel: string): { length: number } => {
+      querySelectorAll: (sel: string) => {
         queriedSelectors.push(sel);
         // Canonical testid: 0 (forces fallback path).
         if (sel === '[data-testid="copilot-assistant-message"]') {
-          return { length: 0 };
+          return matchList(0);
         }
         // Tagged-assistant articles: 0 (forces narrowed-article path).
         if (sel === '[role="article"][data-message-role="assistant"]') {
-          return { length: 0 };
+          return matchList(0);
         }
         // Narrowed-article selector excludes user-tagged articles.
         // First call (baseline) → 0; subsequent calls → 2 (settled).
         if (sel === '[role="article"]:not([data-message-role="user"])') {
-          return { length: evalCount === 0 ? 0 : 2 };
+          return matchList(evalCount === 0 ? 0 : 2);
         }
         // Headless tier: present in cascade for custom-composer demos
         // (e.g. headless-simple) that don't use [role="article"].
         // Returns 0 here so the narrowed-article tier is the one that
         // actually drives the settle loop.
         if (sel === '[data-message-role="assistant"]') {
-          return { length: 0 };
+          return matchList(0);
         }
         // ANY other [role="article"] selector means we leaked the
         // unscoped fallback that this fix was supposed to remove.
-        return { length: 999 };
+        return matchList(999);
       },
       // The error-banner probe (readErrorBanner) calls
       // document.querySelector — returning null exercises the genuine
@@ -1409,6 +1841,17 @@ describe("runConversation", () => {
         // only care about assistant-message selector queries here.
         if (fn.toString().includes("copilot-user-message")) {
           return userMsgCalls1++ as never;
+        }
+        // The SSE run-finished counter (`window.__hk_runsFinished`) is
+        // read by `waitForTurnComplete`'s SSE conjunct. The bare-document
+        // fake doesn't seed that global, so without an explicit branch the
+        // SSE check returns 0 forever and the turn times out. Mirror
+        // `makePage`'s synthesis rule: once the assistant DOM has any
+        // bubbles, the server must have flushed at least that many
+        // RUN_FINISHED events. Use the narrowed-article post-baseline
+        // count (2) once the test has stepped past its baseline read.
+        if (fn.toString().includes("__hk_runsFinished")) {
+          return (evalCount === 0 ? 0 : 2) as never;
         }
         // Patch globalThis.document with our fake for the duration
         // of the evaluate call. The selector-fn closes over
@@ -1459,16 +1902,39 @@ describe("runConversation", () => {
     // tagged.length > 0 short-circuits the function.
     const queriedSelectors: string[] = [];
     let evalCount = 0;
+    // See sibling test above for `matchList` rationale — provides
+    // both `length` AND `item(idx)` so the atomic `readCascadeState`
+    // closure can read per-tier scoped text in the same call.
+    const matchList = (
+      length: number,
+    ): {
+      length: number;
+      item: (i: number) => {
+        textContent: string;
+        querySelector: (s: string) => { textContent: string } | null;
+      } | null;
+    } => ({
+      length,
+      item(i: number) {
+        if (i < 0 || i >= length) return null;
+        return {
+          textContent: `bubble-${i}`,
+          querySelector(_s: string) {
+            return { textContent: `bubble-${i}` };
+          },
+        };
+      },
+    });
     const fakeDocument = {
-      querySelectorAll: (sel: string): { length: number } => {
+      querySelectorAll: (sel: string) => {
         queriedSelectors.push(sel);
         if (sel === '[data-testid="copilot-assistant-message"]') {
-          return { length: 0 };
+          return matchList(0);
         }
         if (sel === '[role="article"][data-message-role="assistant"]') {
-          return { length: evalCount === 0 ? 1 : 2 };
+          return matchList(evalCount === 0 ? 1 : 2);
         }
-        return { length: 999 };
+        return matchList(999);
       },
       // The error-banner probe (readErrorBanner) calls
       // document.querySelector — returning null exercises the genuine
@@ -1485,6 +1951,14 @@ describe("runConversation", () => {
         // User-message reads bypass the fake document entirely.
         if (fn.toString().includes("copilot-user-message")) {
           return userMsgCalls2++ as never;
+        }
+        // Seed the SSE run-finished counter for the same reason as the
+        // sibling narrowed-fallback test — `waitForTurnComplete`'s SSE
+        // conjunct must converge or the turn times out. Tagged-assistant
+        // count is 1 at baseline and 2 thereafter, so any post-baseline
+        // poll has at least 2 RUN_FINISHED equivalents.
+        if (fn.toString().includes("__hk_runsFinished")) {
+          return (evalCount === 0 ? 1 : 2) as never;
         }
         // Patch document + getComputedStyle so the error-banner probe
         // runs its real "no banner" path (see the narrowing test above).
@@ -2023,5 +2497,81 @@ describe("waitForContentAndSend", () => {
     await waitForContentAndSend(page, "textarea", 5000);
 
     expect(recorded.presses).toEqual(["Enter"]);
+  });
+});
+
+describe("readErrorBanner shape handling", () => {
+  /**
+   * Build a minimal `Page` whose `evaluate` returns a scripted value
+   * regardless of what the production reader actually queries. Used to
+   * smuggle "unknown shape" / "legacy shape" / "primitive" return values
+   * into `readErrorBanner` so we can assert how each branch classifies
+   * the raw value coming back from the browser side.
+   */
+  function pageReturning(raw: unknown): Page {
+    return {
+      async waitForSelector() {},
+      async fill() {},
+      async press() {},
+      async evaluate(_fn: () => unknown) {
+        return raw as never;
+      },
+    };
+  }
+
+  it("maps an unknown object shape to unreadable (not absent)", async () => {
+    const result = await readErrorBanner(pageReturning({ foo: "bar" }));
+    expect(result.state).toBe("unreadable");
+    if (result.state === "unreadable") {
+      expect(result.detail.length).toBeGreaterThan(0);
+      expect(result.detail).toContain("unknown shape");
+    }
+  });
+
+  it("maps a non-object primitive return to unreadable", async () => {
+    const result = await readErrorBanner(pageReturning("not an object at all"));
+    expect(result.state).toBe("unreadable");
+    if (result.state === "unreadable") {
+      expect(result.detail.length).toBeGreaterThan(0);
+      expect(result.detail).toContain("unknown shape");
+    }
+  });
+
+  it("maps null return to unreadable", async () => {
+    const result = await readErrorBanner(pageReturning(null));
+    expect(result.state).toBe("unreadable");
+    if (result.state === "unreadable") {
+      expect(result.detail.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("caps detail at <= 200 chars even for objects with many keys", async () => {
+    const fat: Record<string, unknown> = {};
+    for (let i = 0; i < 200; i++) fat[`key_${i}`] = i;
+    const result = await readErrorBanner(pageReturning(fat));
+    expect(result.state).toBe("unreadable");
+    if (result.state === "unreadable") {
+      expect(result.detail.length).toBeLessThanOrEqual(200);
+    }
+  });
+
+  it("still honours the new {state:'absent'} shape", async () => {
+    const result = await readErrorBanner(pageReturning({ state: "absent" }));
+    expect(result.state).toBe("absent");
+  });
+
+  it("still honours the legacy {visible:false} shape", async () => {
+    const result = await readErrorBanner(pageReturning({ visible: false }));
+    expect(result.state).toBe("absent");
+  });
+
+  it("still honours the legacy {visible:true,text} shape", async () => {
+    const result = await readErrorBanner(
+      pageReturning({ visible: true, text: "boom" }),
+    );
+    expect(result.state).toBe("visible");
+    if (result.state === "visible") {
+      expect(result.text).toBe("boom");
+    }
   });
 });

--- a/showcase/harness/src/probes/helpers/conversation-runner.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.ts
@@ -27,7 +27,30 @@
  * structural typing makes it transparent.
  */
 
+import type { Page as PlaywrightPage } from "playwright";
+import {
+  ASSISTANT_MESSAGE_FALLBACK_SELECTOR,
+  ASSISTANT_MESSAGE_HEADLESS_SELECTOR,
+  ASSISTANT_MESSAGE_PRIMARY_SELECTOR,
+  countAssistantMessages,
+  readCascadeState,
+} from "./assistant-message-count.js";
 import { formatCvdiag } from "./cv-diag.js";
+
+/**
+ * Re-exports of the cascade tier constants. Cascade lives in
+ * `assistant-message-count.ts` (single source of truth) — these
+ * re-exports preserve the historical import path
+ * `from "./conversation-runner.js"` used by the d5/d6 sibling scripts
+ * (`_hitl-shared`, `_gen-ui-shared`, `d5-agentic-chat`,
+ * `d5-shared-state`). New code should import from
+ * `./assistant-message-count.js` directly.
+ */
+export {
+  ASSISTANT_MESSAGE_FALLBACK_SELECTOR,
+  ASSISTANT_MESSAGE_HEADLESS_SELECTOR,
+  ASSISTANT_MESSAGE_PRIMARY_SELECTOR,
+};
 
 /** Chat-input selector cascade — matches `e2e-demos.ts` READY_SELECTORS.
  *
@@ -69,38 +92,6 @@ const CHAT_INPUT_SELECTORS = [
 ] as const;
 
 /**
- * Canonical assistant-message selector. Used by `readMessageCount`
- * and re-exported so sibling helpers / scripts (`_hitl-shared`,
- * `_gen-ui-shared`, `d5-agentic-chat`, `d5-shared-state`) all read
- * the same DOM nodes the runner uses to detect "response settled".
- *
- * Drift between this and any sibling reader meant the runner could
- * settle on N messages while a sibling read N+M (counting user
- * bubbles toward the assistant total). Pinning the selector here is
- * the single-source-of-truth fix.
- *
- * The cascade has three preferences:
- *   1. `[data-testid="copilot-assistant-message"]` — canonical CopilotKit testid.
- *   2. `[role="article"]:not([data-message-role="user"])` — generic
- *      ARIA + explicit user-bubble exclusion. This clause is
- *      load-bearing: some composers tag their bubbles
- *      `[role="article"][data-message-role="user"]` and a bare
- *      `[role="article"]` would over-count.
- *   3. `[data-message-role="assistant"]` — last-resort fallback for
- *      headless / custom-composer demos that don't wrap bubbles in
- *      `[role="article"]` at all. The headless-simple template tags
- *      its assistant `<div>` with `data-message-role="assistant"` so
- *      the runner can still detect "response settled" without the
- *      canonical CopilotKit testids being present.
- */
-export const ASSISTANT_MESSAGE_PRIMARY_SELECTOR =
-  '[data-testid="copilot-assistant-message"]';
-export const ASSISTANT_MESSAGE_FALLBACK_SELECTOR =
-  '[role="article"]:not([data-message-role="user"])';
-export const ASSISTANT_MESSAGE_HEADLESS_SELECTOR =
-  '[data-message-role="assistant"]';
-
-/**
  * Stable testid rendered by `@copilotkit/react-core` and
  * `@copilotkit/react-ui` whenever a chat turn ERRORS (the `ErrorMessage`
  * chat bubble, the `UsageBanner`, and the toast `BannerErrorDisplay` all
@@ -117,24 +108,23 @@ export const ERROR_BANNER_SELECTOR = '[data-testid="copilot-error-banner"]';
  * and we don't want to dump the whole thing into the runner's failure log.
  *
  * Critically, this truncation is applied ONLY when shaping the thrown
- * message — NOT to the value `waitForAssistantSettled` compares across polls
- * to re-arm fast-fail. Comparing truncated text would make two DIFFERENT
- * errors that share a 300-char prefix (e.g. identical human copy + differing
- * request-id/suffix) look equal, suppressing the fast-fail and forcing the
- * full settle timeout. The comparison therefore uses the FULL banner text;
- * see `readErrorBanner` (returns untruncated text) and the `textChanged`
- * check in `waitForAssistantSettled`.
+ * message — NOT to the FULL banner text the runner uses when classifying
+ * a chat-errored turn. `readErrorBanner` always returns untruncated text;
+ * the cap only fires when constructing the thrown `AssistantErroredError`
+ * message string.
  */
 const BANNER_MESSAGE_MAX_LENGTH = 300;
 
 /**
- * Distinguished error thrown by `waitForAssistantSettled` when the chat
- * error banner becomes visible during the settle wait. Carrying its own
- * type lets callers tell a fast errored turn apart from a slow settle
- * timeout. The conversation runner maps any thrown turn error to the
- * driver's `conversation-error` classification, so an errored turn is
- * reported as a (fast) `conversation-error` rather than waiting out the
- * timeout and racing the wall-clock `feature-timeout`.
+ * Distinguished error thrown when the chat error banner is observed
+ * visible without an accompanying assistant response (the runner now
+ * checks the banner on a `TurnNotCompleteError` from `waitForTurnComplete`
+ * and re-throws this distinguished class so the caller can tell a fast
+ * errored turn apart from a slow settle timeout). The conversation
+ * runner maps any thrown turn error to the driver's `conversation-error`
+ * classification, so an errored turn is reported as a (fast)
+ * `conversation-error` rather than waiting out the timeout and racing
+ * the wall-clock `feature-timeout`.
  */
 export class AssistantErroredError extends Error {
   constructor(bannerText?: string) {
@@ -145,6 +135,32 @@ export class AssistantErroredError extends Error {
         : "chat errored: copilot-error-banner visible",
     );
     this.name = "AssistantErroredError";
+  }
+}
+
+/**
+ * Distinguished error thrown by `waitForTurnComplete` when the chat error
+ * banner has been visible for 2 consecutive polls during the in-poll
+ * banner-check (a "sustained" banner). The runner's outer catch translates
+ * this into `AssistantErroredError` so the historical fast-fail surface
+ * (and the bounded turn-1 cold-start retry gating) is preserved.
+ *
+ * Distinct from the post-`TurnNotCompleteError` banner check: this error
+ * fires DURING the settle poll loop (not after the full-timeout throw),
+ * so a sustained banner short-circuits the wait instead of burning the
+ * full `timeoutMs`. The 2-consecutive-poll debounce keeps a single-poll
+ * flicker (a transient toast that auto-dismisses, a render glitch) from
+ * spuriously fast-failing a succeeding turn.
+ */
+export class BannerVisibleError extends Error {
+  constructor(readonly bannerText: string) {
+    super(
+      `waitForTurnComplete: copilot-error-banner visible across 2 consecutive polls — ${bannerText.slice(
+        0,
+        BANNER_MESSAGE_MAX_LENGTH,
+      )}`,
+    );
+    this.name = "BannerVisibleError";
   }
 }
 
@@ -179,17 +195,32 @@ const POLL_INTERVAL_MS = 100;
 const COLD_START_RETRY_MAX = 1;
 
 /**
- * Floor for the cold-start retry's settle budget (#71/FF20). The retry shares
- * the turn's single deadline so a retried turn cannot run ~2× the budget, but
- * if the first attempt consumed nearly all of it the remaining window can drop
- * below the fast-fail debounce (2 consecutive polls). A zero-or-near-zero retry
- * window would convert a SUSTAINED real banner — which #5142 requires to
- * fast-fail again on the 2nd attempt — into a generic settle timeout, silently
- * weakening that guarantee. Flooring the retry window at a few poll intervals
- * keeps wall-clock close to 1× (never the old ~2×) while preserving the
- * fast-fail debounce so a real banner still re-throws `AssistantErroredError`.
+ * Compute the floor for the cold-start retry's settle budget (#71/FF20 + R8F1).
+ * The retry SHARES the turn's single deadline EXCEPT for this floor — if the
+ * first attempt consumed nearly the full budget, the retry still gets at least
+ * one full settle window plus one poll tick.
+ *
+ * Why `settleMs + POLL_INTERVAL_MS` and NOT a small constant like
+ * `3 * POLL_INTERVAL_MS` (the old value): `waitForTurnComplete` requires
+ * `text` to hold stable for `settleMs` before declaring the turn complete. If
+ * `timeoutMs < settleMs` the settle gate is MATHEMATICALLY IMPOSSIBLE to
+ * satisfy — the loop times out before any settle window can complete and
+ * misclassifies the failure as `reason=text-unstable` (hiding the real cause:
+ * budget exhausted). The floor must therefore be ≥ `settleMs` so the gate has
+ * a real chance to converge; we add one `POLL_INTERVAL_MS` so the loop runs
+ * at least one full settle window plus one poll tick.
+ *
+ * A zero-or-near-zero retry window would convert a SUSTAINED real banner —
+ * which #5142 requires to fast-fail again on the 2nd attempt — into a generic
+ * settle timeout, silently weakening that guarantee. Total elapsed wall-clock
+ * for a retried turn can therefore push slightly past `turnTimeoutMs` (worst
+ * case: `turnTimeoutMs + settleMs + POLL_INTERVAL_MS`), but stays far below
+ * the old ~2× regime (#71/FF20 pre-fix) while preserving the fast-fail
+ * debounce so a real banner still re-throws `AssistantErroredError`.
  */
-const COLD_START_RETRY_MIN_SETTLE_MS = 3 * POLL_INTERVAL_MS;
+function coldStartRetryMinSettleMs(settleMs: number): number {
+  return settleMs + POLL_INTERVAL_MS;
+}
 
 /**
  * Minimal Page surface the runner depends on. Real `playwright.Page`
@@ -218,8 +249,17 @@ export interface Page {
    * (NOT `page.textContent(...)`) for the assistant-message count poll
    * because Playwright's selector-based reads auto-wait up to 30 s,
    * which would defeat the polling cadence.
+   *
+   * The `arg` parameter is structurally optional so the runner can call
+   * `page.evaluate(() => …)` (no arg) AND `page.evaluate((idx) => …,
+   * bubbleIndex)` (one arg) through the SAME signature —
+   * `findAssistantBubbleAt` needs the second form to pass the strict
+   * bubble index into the browser-side closure without a closure-capture
+   * race. The real Playwright `Page.evaluate` is variadic and satisfies
+   * both call shapes natively; test fakes that need the arg path read
+   * the second runtime arg from `arguments`.
    */
-  evaluate<R>(fn: () => R): Promise<R>;
+  evaluate<R, A = unknown>(fn: (arg?: A) => R, arg?: A): Promise<R>;
   /**
    * Read the current value of an input/textarea element. Used by the
    * `skipFill` path to poll for non-empty content before pressing Enter
@@ -298,8 +338,27 @@ export interface ConversationTurn {
    * Optional assertion callback executed AFTER the assistant response
    * settles. Any throw from this function is captured as the turn's
    * failure and stops the conversation.
+   *
+   * Receives a `ctx` object carrying the turn-scoped resolution of the
+   * assistant bubble for THIS turn:
+   *   - `bubbleIndex`: 0-based DOM index of the assistant bubble
+   *     produced by this turn (cascade-resolved by the same helper the
+   *     runner used to settle the turn).
+   *   - `text`: the untruncated `textContent` of that bubble.
+   *
+   * `ctx` is REQUIRED — the runner sources it from `waitForTurnComplete`'s
+   * return value, which always yields a turn-scoped `{ bubbleIndex, text }`
+   * pair on success (a failure throws `TurnNotCompleteError` before the
+   * assertions callback is invoked). Probes MUST consume `ctx.text`
+   * instead of calling `readLastAssistantText` — the latter reads
+   * `list[list.length - 1]` and can leak a later turn's bubble into THIS
+   * turn's assertions (defect 2). Unit tests driving `turn.assertions`
+   * directly must supply a synthetic ctx (`{ bubbleIndex, text }`).
    */
-  assertions?: (page: Page) => Promise<void>;
+  assertions?: (
+    page: Page,
+    ctx: { bubbleIndex: number; text: string },
+  ) => Promise<void>;
   /**
    * Per-turn override for the assistant-response timeout. Defaults to
    * 30 s (`DEFAULT_RESPONSE_TIMEOUT_MS`). A turn whose response fails
@@ -384,15 +443,15 @@ export async function runConversation(
   // selector so we don't re-probe per turn.
   let chatInputSelector: string | null = null;
   // Try to resolve the chat input AT BOOT first — when it works
-  // (every demo except idiomatic-shape auth), capture the baseline
-  // assistant-message count BEFORE turn 1's preFill runs. Demos like
-  // /demos/headless-complete fire the user message inside preFill (a
-  // chip click), so reading the baseline AFTER preFill would observe
-  // the assistant's response already appended and the settle would
-  // wait forever for further growth that never comes. The deferred
-  // path is only used when boot-time resolution fails — that's
-  // specifically the auth shape, where the chat tree mounts later.
-  let baselineCount = 0;
+  // (every demo except idiomatic-shape auth), we can fall straight into
+  // the turn loop without an extra cascade probe per turn. Under the
+  // new `waitForTurnComplete` settle path each turn is keyed on its
+  // 1-based ordinal (NOT a pre-turn baseline count), so there is no
+  // boot-time baseline-count read here anymore: a pre-paint placeholder
+  // or stale bubble in the DOM at boot can no longer poison the turn-1
+  // settle (defect 4). The deferred path is only used when boot-time
+  // resolution fails — that's specifically the auth shape, where the
+  // chat tree mounts later.
   try {
     chatInputSelector = await resolveChatInputSelector(
       page,
@@ -401,11 +460,6 @@ export async function runConversation(
     console.debug(
       "[conversation-runner] resolved chat input selector at boot",
       { selector: chatInputSelector },
-    );
-    baselineCount = await readMessageCount(page);
-    console.debug(
-      "[conversation-runner] initial baseline assistant message count (boot)",
-      { baselineCount },
     );
   } catch (bootErr) {
     console.debug(
@@ -435,7 +489,14 @@ export async function runConversation(
     // retry's settle wait (#71/FF20). Without this the retry would get a fresh
     // full `turnTimeoutMs`, letting a cold-start turn run ~2× its budget. The
     // first wait uses the full `turnTimeoutMs`; the retry wait uses only the
-    // time remaining against this deadline.
+    // time remaining against this deadline, EXCEPT for the floor returned by
+    // `coldStartRetryMinSettleMs(settleMs)` (see that function's docstring):
+    // if the first attempt nearly exhausted the budget, the retry still gets
+    // at least one full settle window plus one poll tick. Total elapsed
+    // wall-clock for a retried turn can therefore push slightly past
+    // `turnTimeoutMs` (worst case: `turnTimeoutMs + settleMs +
+    // POLL_INTERVAL_MS`) — far below the old ~2× regime, while preserving
+    // #5142's fast-fail debounce.
     const turnDeadline = startedAt + turnTimeoutMs;
     // Bounded once-per-turn cold-start retry counter. Only ever consulted on
     // turn 1 (the cold-start window); declaring it per-iteration scopes it to
@@ -448,7 +509,6 @@ export async function runConversation(
       {
         input: turn.input,
         timeoutMs: turnTimeoutMs,
-        baselineCount,
       },
     );
 
@@ -473,11 +533,6 @@ export async function runConversation(
             selector: chatInputSelector,
             turnNum,
           });
-          baselineCount = await readMessageCount(page);
-          console.debug(
-            "[conversation-runner] initial baseline assistant message count",
-            { baselineCount },
-          );
         } catch (err) {
           console.debug(
             "[conversation-runner] chat input selector cascade FAILED",
@@ -521,15 +576,18 @@ export async function runConversation(
         `[conversation-runner] turn ${turnNum}/${total} — waiting for assistant settle`,
         {
           selector: chatInputSelector,
-          baselineCount,
+          turnIndex: turnNum,
           settleMs,
           timeoutMs: turnTimeoutMs,
         },
       );
 
-      // Wait for the assistant-message count to grow past the baseline
-      // and then stay stable for `settleMs`. If the deadline passes
-      // before we see growth, fail the turn with a timeout error.
+      // Wait for the per-turn 3-conjunct gate: SSE run-finished counter
+      // has caught up to the turn ordinal, the strict-index bubble for
+      // THIS turn exists in the DOM, and that bubble's text has held
+      // stable for `settleMs`. On success the primitive returns the
+      // turn-scoped `{ bubbleIndex, text }` — the assertions callback
+      // receives that ctx directly without re-reading the DOM.
       //
       // Bounded turn-1 cold-start retry: if the FIRST turn fast-fails with an
       // `AssistantErroredError` (a banner appeared with no response produced —
@@ -544,36 +602,99 @@ export async function runConversation(
       // `AssistantErroredError` (NOT a settle timeout). This does NOT widen the
       // catch to generic timeouts and does NOT defeat #5142: a sustained real
       // banner still fast-fails on the 2nd attempt.
-      let newCount: number;
+      //
+      // The cold-start retry's `AssistantErroredError` source: the runner
+      // checks for a visible error banner BEFORE calling `waitForTurnComplete`
+      // (when no response has yet been produced for this turn) and after the
+      // primitive throws `TurnNotCompleteError`. A banner observed at either
+      // checkpoint is re-thrown as `AssistantErroredError` so #5142's fast-fail
+      // semantics persist across the runner rewrite.
+      // Snapshot the baseline banner text BEFORE entering the settle
+      // wait. CopilotKit error banners persist across turns, so a banner
+      // already visible at this checkpoint is a stale leftover from a
+      // prior errored turn — NOT a fresh fast-fail signal for THIS turn.
+      // The settle loop's debounce keys on "differs from baseline" rather
+      // than mere visibility (see `baselineBannerText` in
+      // `WaitForTurnCompleteOpts`), so a stale same-text banner stays
+      // ignored and only a NEW or text-CHANGED banner re-arms the
+      // fast-fail. An `unreadable` baseline read collapses to `null`
+      // (treat-as-absent) — we don't know the baseline so any visible
+      // banner during settle is a candidate, preserving the historical
+      // "fresh banner ⇒ fast-fail" behaviour on a transient probe hiccup.
+      const baselineBanner = await readErrorBanner(page);
+      const baselineBannerText =
+        baselineBanner.state === "visible" ? baselineBanner.text : null;
+      let settleResult: WaitForTurnCompleteResult;
       try {
-        newCount = await waitForAssistantSettled({
+        settleResult = await waitForTurnComplete({
           page,
-          baselineCount,
+          turnIndex: turnNum,
           settleMs,
           timeoutMs: turnTimeoutMs,
+          baselineBannerText,
         });
       } catch (settleErr) {
-        // The cold-start retry can ONLY meaningfully recover a turn it can
-        // RE-ISSUE: a plain-fill turn (reload the page + re-fill the textarea +
-        // re-send). skipSend/skipFill submissions are issued by `turn.preFill`
-        // (skipSend → preFill auto-sent via the agent surface; skipFill →
-        // preFill populated the textarea), which a reload would wipe — so for
-        // those turns there is nothing to re-issue and the retry could only
-        // false-settle against the first attempt's stale DOM, run on an
-        // unbounded budget, or no-op. Gate the retry to plain-fill turns; for
-        // skipSend/skipFill turns let the original `AssistantErroredError`
-        // propagate (PR #5142 fast-fail — the pre-retry behavior for those
-        // turns, not a regression).
+        // Translate a turn-incomplete failure observed alongside a
+        // copilot-error-banner into the historical `AssistantErroredError`
+        // surface so #5142's fast-fail contract — and the cold-start retry
+        // gating below — survive the runner rewrite. A banner that's NOT
+        // accompanied by a response counts as a chat-errored turn; without
+        // a banner the failure propagates as a settle timeout (the
+        // `TurnNotCompleteError`'s message preserves the classified reason).
+        //
+        // `waitForTurnComplete` also throws `BannerVisibleError` directly
+        // from its in-poll banner check (a sustained banner observed
+        // DURING the settle loop, before the full-timeout throw). We
+        // translate that to `AssistantErroredError` here so the historical
+        // surface — and the cold-start retry gating below — fire for
+        // in-poll fast-fails too.
+        let translatedErr: unknown = settleErr;
+        if (settleErr instanceof BannerVisibleError) {
+          translatedErr = new AssistantErroredError(settleErr.bannerText);
+        } else if (settleErr instanceof TurnNotCompleteError) {
+          const banner = await readErrorBanner(page);
+          if (
+            banner.state === "visible" &&
+            (baselineBannerText === null || banner.text !== baselineBannerText)
+          ) {
+            // A visible banner whose text DIFFERS from the pre-turn
+            // baseline is a fresh error this turn — translate to the
+            // historical AssistantErroredError surface. A banner whose
+            // text MATCHES the baseline is a stale leftover (CopilotKit
+            // banners persist across turns) and must not convert a
+            // settle timeout into a chat-errored failure — surface the
+            // original TurnNotCompleteError instead so the operator
+            // sees the real reason (sse-missing / dom-missing / etc.).
+            translatedErr = new AssistantErroredError(banner.text);
+          } else if (banner.state === "unreadable") {
+            // Surface the unreadable-banner detail in CVDIAG and propagate
+            // the original `TurnNotCompleteError` unchanged — we don't have
+            // a banner text to attach, so we cannot honestly classify the
+            // turn as a chat-errored turn.
+            console.warn(
+              formatCvdiag({
+                component: "conversation-runner",
+                boundary: "fixture-match",
+                status: "error",
+                error: `post-settle banner read unreadable: ${banner.detail.slice(0, 120)}`,
+              }),
+            );
+          }
+        }
+
         const isPlainFillTurn = !turn.skipSend && !turn.skipFill;
         const isColdStartWindow =
           turnNum === 1 &&
           coldStartRetries < COLD_START_RETRY_MAX &&
           isPlainFillTurn;
-        if (settleErr instanceof AssistantErroredError && isColdStartWindow) {
+        if (
+          translatedErr instanceof AssistantErroredError &&
+          isColdStartWindow
+        ) {
           coldStartRetries++;
           console.warn(
             `[conversation-runner] turn ${turnNum}/${total} — cold-start banner fast-fail; reloading + re-sending ONCE before fast-fail`,
-            { error: errorMessage(settleErr) },
+            { error: errorMessage(translatedErr) },
           );
           // Reload to clear the transient cold-start banner. Safe on turn 1 —
           // no conversation state exists yet — and the plain-fill re-send below
@@ -587,54 +708,124 @@ export async function runConversation(
               page,
               opts.chatInputSelector,
             );
-            // Re-read the baseline so growth is measured against the post-reload
-            // message count, then re-send the same message.
-            baselineCount = await readMessageCount(page);
+          }
+          // Explicit narrowing guard. `chatInputSelector` is `string | null`;
+          // TypeScript cannot narrow it to non-null across the optional
+          // `if (page.reload)` reassignment above, and the no-reload branch
+          // retains whatever value flowed in (today: always non-null, since
+          // the per-turn resolve at the top of the try block has already
+          // executed). Fail LOUD with the DISTINGUISHED `translatedErr`
+          // rather than silently calling `fillAndVerifySend` with `null` if a
+          // future refactor ever nullifies the selector on this path. This
+          // branch is entered specifically because `translatedErr instanceof
+          // AssistantErroredError`, so throwing `translatedErr` preserves the
+          // distinguished error class that downstream consumers and tests pin
+          // (throwing `settleErr` would lose that — the original could be a
+          // plain `TurnNotCompleteError` or `BannerVisibleError`).
+          if (chatInputSelector === null) {
+            throw translatedErr;
           }
           await fillAndVerifySend(page, chatInputSelector, turn.input);
+          // Re-snapshot the post-reload baseline banner. The page DOM was
+          // torn down + repainted, so any banner now visible is the
+          // SECOND attempt's baseline (the cold-start banner may have
+          // re-painted, or a fresh banner may have appeared). The retry's
+          // fast-fail debounce keys on "differs from THIS retry's
+          // baseline" — a re-painted same-text banner is the steady state
+          // for the retry attempt and must not auto-fast-fail.
+          const retryBaselineBanner = await readErrorBanner(page);
+          const retryBaselineBannerText =
+            retryBaselineBanner.state === "visible"
+              ? retryBaselineBanner.text
+              : null;
           // Re-enter the settle wait, sharing the turn deadline (#71/FF20) so
           // the retry only ever consumes the time remaining in the turn budget
           // rather than a fresh full `turnTimeoutMs`. A banner that survives
           // this attempt throws again (AssistantErroredError) and the outer
           // catch records the turn failure — #5142 stays intact.
-          newCount = await waitForAssistantSettled({
-            page,
-            baselineCount,
-            settleMs,
-            timeoutMs: Math.max(
-              COLD_START_RETRY_MIN_SETTLE_MS,
-              turnDeadline - Date.now(),
-            ),
-          });
+          try {
+            settleResult = await waitForTurnComplete({
+              page,
+              turnIndex: turnNum,
+              settleMs,
+              timeoutMs: Math.max(
+                coldStartRetryMinSettleMs(settleMs),
+                turnDeadline - Date.now(),
+              ),
+              baselineBannerText: retryBaselineBannerText,
+            });
+          } catch (retryErr) {
+            if (retryErr instanceof BannerVisibleError) {
+              throw new AssistantErroredError(retryErr.bannerText);
+            }
+            if (retryErr instanceof TurnNotCompleteError) {
+              const banner = await readErrorBanner(page);
+              if (
+                banner.state === "visible" &&
+                (retryBaselineBannerText === null ||
+                  banner.text !== retryBaselineBannerText)
+              ) {
+                throw new AssistantErroredError(banner.text);
+              }
+              if (banner.state === "unreadable") {
+                console.warn(
+                  formatCvdiag({
+                    component: "conversation-runner",
+                    boundary: "fixture-match",
+                    status: "error",
+                    error: `retry post-settle banner read unreadable: ${banner.detail.slice(0, 120)}`,
+                  }),
+                );
+              }
+            }
+            throw retryErr;
+          }
         } else {
           // Not the cold-start case (later turn, already retried, a
-          // skipSend/skipFill turn, or a settle timeout) — propagate to the
-          // per-turn catch unchanged.
-          throw settleErr;
+          // skipSend/skipFill turn, or a settle timeout) — propagate the
+          // translated error to the per-turn catch unchanged.
+          throw translatedErr;
         }
       }
 
       console.debug(
         `[conversation-runner] turn ${turnNum}/${total} — assistant settled`,
         {
-          newCount,
-          previousBaseline: baselineCount,
+          bubbleIndex: settleResult.bubbleIndex,
+          textLength: settleResult.text.length,
           hasAssertions: !!turn.assertions,
         },
+      );
+      // Preserve the runner's diagnostic log contract — Phase 0 Task 0.3
+      // / Phase 5 Task 5.1 Step 6 / OPEN ISSUE #4: the bubble-race repro
+      // driver parses `[conversation-runner] turn N/total — settled text
+      // { turnNum, text: '…' }` out of verbose stdout. The settled-text
+      // value is now sourced from `waitForTurnComplete`'s return value
+      // (turn-scoped, cascade-consistent, defect-2 safe) instead of a
+      // separate post-settle `page.evaluate` read.
+      console.debug(
+        `[conversation-runner] turn ${turnNum}/${total} — settled text`,
+        { turnNum, text: settleResult.text.slice(0, 200) },
       );
 
       if (turn.assertions) {
         console.debug(
           `[conversation-runner] turn ${turnNum}/${total} — running assertions`,
+          {
+            bubbleIndex: settleResult.bubbleIndex,
+            textLength: settleResult.text.length,
+          },
         );
-        await turn.assertions(page);
+        await turn.assertions(page, {
+          bubbleIndex: settleResult.bubbleIndex,
+          text: settleResult.text,
+        });
         console.debug(
           `[conversation-runner] turn ${turnNum}/${total} — assertions passed`,
         );
       }
 
       durations.push(Date.now() - startedAt);
-      baselineCount = newCount;
     } catch (err) {
       // Spec: `turn_durations_ms.length === turns_completed`. The failed
       // turn's partial duration is intentionally NOT recorded so callers
@@ -642,7 +833,6 @@ export async function runConversation(
       // failure outliers skewing the result. The wall-clock cost of the
       // failed turn is still recoverable from `observedAt` deltas if
       // operators need it.
-      void startedAt;
       let failureDiagnostics: Record<string, unknown> = {};
       try {
         failureDiagnostics = await page.evaluate(() => {
@@ -705,13 +895,13 @@ export async function runConversation(
 
 /**
  * Read the current count of user-message DOM nodes via `page.evaluate`.
- * Mirrors `readMessageCount` but targets user bubbles instead of
+ * Mirrors `countAssistantMessages` but targets user bubbles instead of
  * assistant bubbles. Used by `fillAndVerifySend` to detect whether a
  * user message actually appeared after pressing Enter — if the count
  * hasn't grown, the React hydration race likely swallowed the keypress.
  *
  * Returns 0 on any read error (same resilience strategy as
- * `readMessageCount`).
+ * `countAssistantMessages`).
  */
 export async function readUserMessageCount(page: Page): Promise<number> {
   try {
@@ -760,7 +950,7 @@ export async function readUserMessageCount(page: Page): Promise<number> {
  * `SEND_VERIFY_MAX_ATTEMPTS` times.
  *
  * After all retries are exhausted without a user message appearing, the
- * function returns silently — the downstream `waitForAssistantSettled`
+ * function returns silently — the downstream `waitForTurnComplete`
  * timeout will catch the failure with better diagnostics than we can
  * provide here.
  */
@@ -924,84 +1114,87 @@ async function resolveChatInputSelector(
 }
 
 /**
- * Read the current count of assistant-message DOM nodes via
- * `page.evaluate`. Returns 0 on any read error — the caller's polling
- * loop will retry, so a transient DOM-read hiccup doesn't fail the
- * whole turn.
- *
- * The DOM types are reached via a type-erased indirection because the
- * package's tsconfig intentionally excludes the `dom` lib (server-side
- * Node code). Same pattern used in `e2e-smoke.ts`.
+ * Discriminated union returned by `readErrorBanner`. Three states:
+ *   - `absent`     — banner element missing / not visible.
+ *   - `visible`    — banner is present and visibly painted; `text` is
+ *                    the UNTRUNCATED `textContent` for downstream
+ *                    comparison / classification.
+ *   - `unreadable` — the `page.evaluate` itself threw (a transient DOM
+ *                    hiccup, the page is mid-navigation, …). `detail`
+ *                    carries the captured error message. Callers MUST
+ *                    NOT collapse this into `absent` — an unreadable
+ *                    state disables fast-fail for that poll (we don't
+ *                    know what the banner is), but it must NOT translate
+ *                    a `TurnNotCompleteError` into `AssistantErroredError`
+ *                    either (we have no banner text to attach).
  */
-async function readMessageCount(page: Page): Promise<number> {
-  try {
-    return await page.evaluate(() => {
-      const win = globalThis as unknown as {
-        document: {
-          querySelectorAll(sel: string): { length: number };
-        };
-      };
-      // Match either the canonical CopilotKit testid or a narrowed
-      // `[role="article"]` that excludes user-side articles.
-      // The canonical testid wins; if absent, fall back to articles
-      // that are explicitly tagged as assistant (or are not tagged
-      // user) so we never count user-input bubbles toward "assistant
-      // response settled".
-      const canonical = win.document.querySelectorAll(
-        '[data-testid="copilot-assistant-message"]',
-      );
-      if (canonical.length > 0) return canonical.length;
-      // Prefer an explicit assistant-tagged article when present.
-      const tagged = win.document.querySelectorAll(
-        '[role="article"][data-message-role="assistant"]',
-      );
-      if (tagged.length > 0) return tagged.length;
-      // Next: any [role="article"] that is NOT explicitly tagged as a
-      // user message. This still matches untagged articles (the
-      // historical behaviour) but excludes user bubbles that some
-      // composers tag with `data-message-role="user"`.
-      const fallback = win.document.querySelectorAll(
-        '[role="article"]:not([data-message-role="user"])',
-      );
-      if (fallback.length > 0) return fallback.length;
-      // Last resort: headless / custom-composer demos that don't use
-      // [role="article"] at all but tag their assistant bubble with
-      // `data-message-role="assistant"`. Without this tier the runner
-      // would never detect "response settled" on the headless-simple
-      // template since none of the prior selectors match its DOM.
-      const headless = win.document.querySelectorAll(
-        '[data-message-role="assistant"]',
-      );
-      return headless.length;
-    });
-  } catch {
-    return 0;
-  }
-}
+export type ErrorBannerReadResult =
+  | { state: "absent" }
+  | { state: "visible"; text: string }
+  | { state: "unreadable"; detail: string };
 
 /**
  * Read whether a chat error banner (`[data-testid="copilot-error-banner"]`)
  * is currently VISIBLE in the page, and return its FULL text when present.
  * Visibility (not mere presence) matters: a banner kept in the DOM but
  * hidden (`display:none` / zero-size / `visibility:hidden`) is not an
- * active error. Returns `{ visible: false }` on any read error so a
- * transient DOM hiccup never spuriously fast-fails a turn.
+ * active error.
  *
- * Returns the UNTRUNCATED `textContent` on purpose: `waitForAssistantSettled`
- * compares this text across polls to re-arm fast-fail, and truncating here
- * would make two distinct errors sharing a long common prefix compare equal
- * (suppressing the fast-fail). The length cap for log hygiene is applied
- * downstream, only when building the thrown `AssistantErroredError` message
+ * Returns a 3-state discriminated union — see `ErrorBannerReadResult`.
+ * In particular, a transient `page.evaluate` throw is surfaced as
+ * `{ state: "unreadable" }` (NOT collapsed to `absent`); collapsing every
+ * read error to "no banner" would silently disarm the fast-fail path
+ * whenever the page hiccuped, which is the exact failure mode this
+ * 3-state union exists to prevent. By the same rule, a browser-side
+ * return whose shape does NOT match any known variant
+ * (`{state:"absent"}`, `{state:"visible",text}`, `{state:"unreadable",detail}`,
+ * or the legacy `{visible,text?}`) is also surfaced as `unreadable` with
+ * a short shape summary, NOT collapsed to `absent` — a stale browser
+ * script returning a foreign shape must remain observable rather than
+ * silently masquerade as "no banner."
+ *
+ * The visible-state `text` is the UNTRUNCATED `textContent` on purpose:
+ * callers may compare this text across polls (e.g. to re-arm fast-fail
+ * logic) and truncating here would make two distinct errors sharing a
+ * long common prefix compare equal. The length cap for log hygiene is
+ * applied downstream, only when building the thrown
+ * `AssistantErroredError` / `BannerVisibleError` message
  * (`BANNER_MESSAGE_MAX_LENGTH`).
  *
- * Reached via the same type-erased `globalThis` indirection as
- * `readMessageCount` because the package tsconfig excludes the `dom` lib.
+ * Reached via the same type-erased `globalThis` indirection used in
+ * `countAssistantMessages` because the package tsconfig excludes the
+ * `dom` lib.
  */
-async function readErrorBanner(
-  page: Page,
-): Promise<{ visible: boolean; text?: string }> {
+/**
+ * Best-effort shape summary for an unknown browser-side return value.
+ * Stringifies only TOP-LEVEL KEYS (not values) when `raw` is an object, so
+ * the resulting detail message never leaks large payloads. Falls back to
+ * `typeof` (and the literal stringified primitive, for non-objects) so the
+ * detail is always non-empty. Result is capped at 200 chars including the
+ * containing message constructed by the caller.
+ */
+function safeStringifyShape(raw: unknown): string {
+  if (raw === null) return "null";
+  const t = typeof raw;
+  if (t !== "object") {
+    // Primitives: stringify directly but cap length to avoid runaway strings.
+    const s = String(raw);
+    return `${t}(${s.slice(0, 80)})`;
+  }
   try {
-    return await page.evaluate(() => {
+    const keys = Object.keys(raw as Record<string, unknown>);
+    return `object{keys:${JSON.stringify(keys).slice(0, 120)}}`;
+  } catch {
+    return "object(unintrospectable)";
+  }
+}
+
+export async function readErrorBanner(
+  page: Page,
+): Promise<ErrorBannerReadResult> {
+  let raw: unknown;
+  try {
+    raw = await page.evaluate(() => {
       const win = globalThis as unknown as {
         document: {
           querySelector(sel: string): {
@@ -1017,220 +1210,72 @@ async function readErrorBanner(
       const el = win.document.querySelector(
         '[data-testid="copilot-error-banner"]',
       );
-      if (!el) return { visible: false };
+      if (!el) return { state: "absent" } as const;
       const style = win.getComputedStyle(el);
       if (style.display === "none" || style.visibility === "hidden") {
-        return { visible: false };
+        return { state: "absent" } as const;
       }
       const rect = el.getBoundingClientRect();
       if (rect.width === 0 && rect.height === 0) {
-        return { visible: false };
+        return { state: "absent" } as const;
       }
       return {
-        visible: true,
+        state: "visible" as const,
         // FULL text — see docstring. Truncation happens only when shaping
-        // the thrown AssistantErroredError message, never on the value
-        // compared across polls to re-arm fast-fail.
+        // the thrown error messages, never on the value compared across
+        // polls to re-arm fast-fail.
         text: el.textContent ?? "",
       };
     });
-  } catch {
-    return { visible: false };
+  } catch (err) {
+    const detail = errorMessage(err).slice(0, 120);
+    // CVDIAG: surface the unreadable banner read so it's greppable. We do
+    // NOT collapse to `absent` — see docstring.
+    console.warn(
+      formatCvdiag({
+        component: "conversation-runner",
+        boundary: "inbound",
+        status: "error",
+        error: `error-banner read failed: ${detail}`,
+      }),
+    );
+    return { state: "unreadable", detail };
   }
-}
-
-/**
- * Block until the assistant-message count has grown past `baselineCount`
- * AND remained stable for `settleMs`, OR until `timeoutMs` elapses.
- * Returns the final stable count on success. Throws a `timeout` Error
- * on deadline.
- *
- * Algorithm: poll at `POLL_INTERVAL_MS`. Track `lastChangeAt` — the
- * timestamp of the most recent count change. If the current poll's
- * count is positive, has surpassed baseline, and `now - lastChangeAt
- * >= settleMs`, the response has settled.
- *
- * Fast-fail (ONE unified rule). Each poll also checks the chat error banner
- * (`[data-testid="copilot-error-banner"]`). We snapshot the banner's
- * visibility AND text ONCE at the turn's baseline (`bannerVisibleAtBaseline`,
- * `bannerTextAtBaseline`), then each poll compute a single boolean:
- *
- *   errorStateNow = banner.visible &&
- *                   (!bannerVisibleAtBaseline ||
- *                    banner.text !== bannerTextAtBaseline)
- *
- * i.e. "an error banner is present in a state that DIFFERS from baseline".
- * This single condition covers BOTH a brand-new banner (none at baseline)
- * AND a persisted banner whose text changed — and it stays true even if the
- * banner text keeps mutating each poll (a retry countdown, a live timestamp,
- * a rotating request-id), because it only requires "differs from baseline",
- * not a stable exact value across polls.
- *
- * We fast-fail (throw `AssistantErroredError`) only when ALL of:
- *   (a) `errorStateNow` is true on 2 CONSECUTIVE polls. A single consecutive
- *       counter debounces BOTH the new-banner and changed-banner cases; any
- *       poll where `errorStateNow` is false resets it to 0. A single isolated
- *       differs-from-baseline poll (a transient toast flicker, a one-poll
- *       text glitch on a succeeding turn) therefore does NOT fire.
- *   (b) the assistant has NOT produced a response this turn — the message
- *       count has NOT grown past `baselineCount`. Success-in-flight wins: if
- *       `current > baselineCount`, we never fast-fail (a non-fatal warning
- *       banner alongside a real answer must not force-fail the turn); the
- *       settle path governs instead.
- *
- * CopilotKit error banners persist across turns, so a stale same-text banner
- * left over from a prior turn keeps `errorStateNow` false (text == baseline,
- * banner was visible at baseline) and is intentionally NOT treated as this
- * turn's error. The full (untruncated) banner text is compared — truncation
- * applies only to the thrown message (`BANNER_MESSAGE_MAX_LENGTH`) — so two
- * errors diverging only after the first 300 chars still differ from baseline.
- *
- * Inherent (now much smaller) limitation: a differs-from-baseline state that
- * flickers true for only single ISOLATED polls (never 2 in a row) won't fire,
- * and a brand-new error whose banner text is byte-identical to a persisted
- * stale banner cannot be distinguished from it (both keep `errorStateNow`
- * false). Both fall back to the settle/timeout path. This is intended.
- */
-async function waitForAssistantSettled(opts: {
-  page: Page;
-  baselineCount: number;
-  settleMs: number;
-  timeoutMs: number;
-}): Promise<number> {
-  const { page, baselineCount, settleMs, timeoutMs } = opts;
-  const deadline = Date.now() + timeoutMs;
-  let lastCount = await readMessageCount(page);
-  let lastChangeAt = Date.now();
-  let pollCount = 0;
-  let lastLoggedCount = lastCount;
-  // Snapshot the error banner's visibility AND text ONCE BEFORE this turn's
-  // response arrives. A pre-existing (stale) banner must not be mistaken for
-  // this turn's error — but because CopilotKit banners persist across turns,
-  // a boolean "was it visible" snapshot alone would disable fast-fail for the
-  // whole turn whenever any banner lingered. Capturing the text lets the
-  // unified `errorStateNow` condition re-arm on a NEW or text-CHANGED banner
-  // even while a stale same-text banner is still on screen.
-  const baselineBanner = await readErrorBanner(page);
-  const bannerVisibleAtBaseline = baselineBanner.visible;
-  const bannerTextAtBaseline = baselineBanner.text;
-  // Single debounce counter shared by BOTH the new-banner and changed-banner
-  // cases: the number of CONSECUTIVE polls on which `errorStateNow` has been
-  // true. Any poll where `errorStateNow` is false resets it to 0. Fast-fail
-  // fires once it reaches 2 — see the unified rule in the docstring above.
-  let consecutiveErrorPolls = 0;
-
-  console.debug("[conversation-runner] waitForAssistantSettled — start", {
-    baselineCount,
-    initialCount: lastCount,
-    settleMs,
-    timeoutMs,
-    bannerVisibleAtBaseline,
-    bannerTextAtBaseline,
-  });
-
-  while (Date.now() < deadline) {
-    await sleep(POLL_INTERVAL_MS);
-
-    const current = await readMessageCount(page);
-    pollCount++;
-
-    // Unified fast-fail rule. Compute a single boolean: an error banner is
-    // present in a state that DIFFERS from baseline (a brand-new banner, OR a
-    // persisted banner whose text changed). This stays true even if the text
-    // keeps mutating each poll, since it only requires "differs from
-    // baseline", not a stable exact value.
-    const banner = await readErrorBanner(page);
-    const errorStateNow =
-      banner.visible &&
-      (!bannerVisibleAtBaseline || banner.text !== bannerTextAtBaseline);
-
-    // Condition (b): success-in-flight wins. If the assistant produced a
-    // response this turn (count grew past baseline), NEVER fast-fail — a
-    // non-fatal warning banner alongside a real answer must not force-fail
-    // the turn; the settle path governs. A produced response also disarms
-    // the consecutive-error counter so a banner that appears only after the
-    // response can't retroactively fire.
-    if (current > baselineCount) {
-      consecutiveErrorPolls = 0;
-    } else if (errorStateNow) {
-      // Condition (a): require 2 CONSECUTIVE differs-from-baseline polls
-      // before fast-failing, so a single isolated flicker (a transient toast,
-      // a one-poll text glitch on a succeeding turn) does not raise a spurious
-      // error.
-      consecutiveErrorPolls++;
-      if (consecutiveErrorPolls >= 2) {
-        console.debug(
-          "[conversation-runner] waitForAssistantSettled — error banner differs from baseline across 2 consecutive polls (no response produced), fast-failing",
-          {
-            baselineCount,
-            lastCount,
-            current,
-            pollCount,
-            elapsedMs: Date.now() - (deadline - timeoutMs),
-            bannerText: banner.text,
-            baselineBannerText: bannerTextAtBaseline,
-            bannerVisibleAtBaseline,
-          },
-        );
-        throw new AssistantErroredError(banner.text);
-      }
-    } else {
-      // No differing error state this poll → disarm the debounce.
-      consecutiveErrorPolls = 0;
+  // Validate the shape — tests (and a future older browser-side script)
+  // may return arbitrary values. Anything that isn't the new union shape
+  // is treated as "absent" so we never trip on a stale fake.
+  if (raw && typeof raw === "object" && "state" in raw) {
+    const r = raw as { state: unknown; text?: unknown; detail?: unknown };
+    if (r.state === "absent") return { state: "absent" };
+    if (r.state === "visible") {
+      const text = typeof r.text === "string" ? r.text : "";
+      return { state: "visible", text };
     }
-
-    if (current !== lastCount) {
-      console.debug(
-        "[conversation-runner] waitForAssistantSettled — message count changed",
-        {
-          previous: lastCount,
-          current,
-          baselineCount,
-          pollCount,
-          elapsedMs: Date.now() - (deadline - timeoutMs),
-        },
-      );
-      lastCount = current;
-      lastLoggedCount = current;
-      lastChangeAt = Date.now();
-      continue;
-    }
-    // Stable. Settled iff (a) we've grown past baseline AND (b) the
-    // quiet window has elapsed. "Stable at baseline" means no response
-    // arrived yet — keep polling.
-    if (current > baselineCount && Date.now() - lastChangeAt >= settleMs) {
-      console.debug("[conversation-runner] waitForAssistantSettled — settled", {
-        count: current,
-        baselineCount,
-        quietWindowMs: Date.now() - lastChangeAt,
-        totalPollCount: pollCount,
-        totalElapsedMs: Date.now() - (deadline - timeoutMs),
-      });
-      return current;
-    }
-    // Log a periodic status when still waiting at baseline (every ~5s)
-    if (current === lastLoggedCount && pollCount % 50 === 0) {
-      console.debug(
-        "[conversation-runner] waitForAssistantSettled — still polling",
-        {
-          current,
-          baselineCount,
-          pollCount,
-          elapsedMs: Date.now() - (deadline - timeoutMs),
-          remainingMs: deadline - Date.now(),
-        },
-      );
+    if (r.state === "unreadable") {
+      const detail = typeof r.detail === "string" ? r.detail : "";
+      return { state: "unreadable", detail };
     }
   }
-  console.debug("[conversation-runner] waitForAssistantSettled — TIMEOUT", {
-    baselineCount,
-    lastCount,
-    timeoutMs,
-    totalPollCount: pollCount,
-  });
-  throw new Error(
-    `timeout: assistant did not respond within ${timeoutMs}ms (baseline=${baselineCount}, current=${lastCount})`,
-  );
+  // Back-compat: a fake (or legacy browser script) that still returns
+  // the old `{ visible, text? }` shape gets translated into the new
+  // union so the SUT sees a consistent contract.
+  if (raw && typeof raw === "object" && "visible" in raw) {
+    const r = raw as { visible: unknown; text?: unknown };
+    if (r.visible === true) {
+      const text = typeof r.text === "string" ? r.text : "";
+      return { state: "visible", text };
+    }
+    return { state: "absent" };
+  }
+  // Unknown shape — a stale browser-side script returned something we
+  // don't recognize. Per the `ErrorBannerReadResult` docstring, callers
+  // MUST NOT collapse an unknown read into `absent` (that would silently
+  // disarm fast-fail); surface as `unreadable` with a short shape summary
+  // so the failure is observable.
+  const detail = (
+    "unknown shape from browser-side reader: " + safeStringifyShape(raw)
+  ).slice(0, 200);
+  return { state: "unreadable", detail };
 }
 
 function sleep(ms: number): Promise<void> {
@@ -1240,4 +1285,247 @@ function sleep(ms: number): Promise<void> {
 function errorMessage(err: unknown): string {
   if (err instanceof Error) return err.message;
   return String(err);
+}
+
+// ============================================================
+// waitForTurnComplete — 3-conjunct turn-complete primitive (s8)
+// ============================================================
+//
+// Composes three INDEPENDENT readiness signals into one settle gate
+// for a single turn (1-based ordinal):
+//
+//   1. SSE   — `window.__hk_runsFinished >= turnIndex`. The s7 SSE
+//              interceptor increments this counter on each RUN_FINISHED
+//              event; reaching the turn ordinal proves the server has
+//              flushed its terminal event for THIS turn.
+//   2. DOM   — the bubble at strict index `turnIndex - 1` exists under
+//              the shared assistant-message cascade. Strict-index — not
+//              "last bubble" — because the runner has already seen
+//              earlier bubbles and we need turn-local resolution to
+//              avoid the "previous turn's text leaks into this turn's
+//              assertions" race that motivated this overhaul.
+//   3. TEXT  — that bubble's `textContent` is non-empty AND has been
+//              stable for `settleMs` ms across consecutive polls. The
+//              non-empty guard preserves the defect-1 invariant: an
+//              empty pre-paint placeholder must NOT be treated as
+//              settled regardless of how long it stays empty.
+//
+// All three conjuncts must hold simultaneously on the same poll for
+// the primitive to return — partial-truth states (DOM without SSE,
+// SSE without text, etc.) keep polling until either everything aligns
+// or `timeoutMs` elapses.
+//
+// On timeout we throw `TurnNotCompleteError` with a classified reason
+// (sse-missing > dom-missing > text-unstable, in order of precedence
+// — the precedence reflects "blame the earliest signal that hadn't
+// arrived" so the error message points the operator at the right
+// upstream layer). Callers MUST treat the throw as a real failure;
+// silently swallowing here defeats the purpose of the gate (see
+// fail-loud-discipline upstream).
+//
+// This is the SOLE settle primitive for the conversation runner —
+// `runConversation` calls it directly each turn and consumes its
+// `{ bubbleIndex, text }` result as the assertions ctx. The prior
+// count-baseline `waitForAssistantSettled` gate was deleted alongside
+// this cutover (Phase 5 of the bubble-race-fix plan).
+
+/** Options accepted by `waitForTurnComplete`. */
+export interface WaitForTurnCompleteOpts {
+  page: Page;
+  /** 1-based turn ordinal — the Nth user->assistant exchange in the conversation. */
+  turnIndex: number;
+  /** Quiescence window the bubble's textContent must hold steady before returning. */
+  settleMs: number;
+  /** Hard ceiling. Beyond this we throw `TurnNotCompleteError`. */
+  timeoutMs: number;
+  /** Optional poll cadence. Default 100ms — fast enough for fast-replay aimock. */
+  pollIntervalMs?: number;
+  /**
+   * Pre-turn baseline error-banner text snapshot. CopilotKit error banners
+   * persist across turns — a banner already visible at THIS turn's baseline
+   * is a stale leftover from a prior turn, NOT a fresh fast-fail signal. The
+   * fast-fail debounce keys on "current banner text differs from baseline"
+   * rather than mere visibility, so a stale same-text banner is ignored and
+   * a NEW or text-CHANGED banner re-arms the fast-fail. `null` means no
+   * banner was visible at baseline → any fresh banner is a candidate; a
+   * string means a banner WAS visible at baseline and only a different text
+   * (or a fresh visible-after-absent) counts as a candidate.
+   */
+  baselineBannerText?: string | null;
+}
+
+/** Result of a successful `waitForTurnComplete`. */
+export interface WaitForTurnCompleteResult {
+  /** 0-based DOM index of the resolved bubble (= turnIndex - 1). */
+  bubbleIndex: number;
+  /** Untruncated textContent of the resolved bubble at the moment of return. */
+  text: string;
+}
+
+/**
+ * Thrown by `waitForTurnComplete` when `timeoutMs` elapses without all
+ * three conjuncts holding. The `reason` field classifies which signal
+ * was missing at the FINAL post-loop read (precedence: sse-missing >
+ * dom-missing > text-unstable). Carries `turnIndex` + `observedAtMs`
+ * (elapsed time inside the loop) so callers + log scrapers can build
+ * structured diagnostics without re-parsing the message.
+ */
+export class TurnNotCompleteError extends Error {
+  constructor(
+    readonly reason: "sse-missing" | "dom-missing" | "text-unstable",
+    readonly turnIndex: number,
+    readonly observedAtMs: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "TurnNotCompleteError";
+  }
+}
+
+/**
+ * Read the page-side SSE-run counter set by `attachSseInterceptor`.
+ * Returns 0 if the counter hasn't been seeded yet (pre-navigation) or
+ * if the `evaluate` itself fails — both are equivalent to "no run has
+ * finished" from the primitive's vantage.
+ */
+async function readRunsFinished(page: Page): Promise<number> {
+  try {
+    return await page.evaluate(
+      () =>
+        (globalThis as unknown as { __hk_runsFinished?: number })
+          .__hk_runsFinished ?? 0,
+    );
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Block until ALL THREE of the following are true for turn `turnIndex`:
+ *   1. SSE:  window.__hk_runsFinished >= turnIndex
+ *   2. DOM:  the bubble at bubbleIndex = turnIndex - 1 exists under the
+ *            shared cascade (countAssistantMessages > turnIndex - 1)
+ *   3. TEXT: that bubble's textContent is non-empty AND has been stable
+ *            for settleMs across consecutive polls
+ *
+ * AND, as a pre-conjunct fast-fail guard: if the `copilot-error-banner`
+ * is observed VISIBLE for 2 consecutive polls (debounced — a single-poll
+ * flicker is ignored) AND no response has yet been produced for this turn
+ * (the DOM bubble for this turnIndex isn't there yet, so the assistant
+ * hasn't streamed), the primitive short-circuits with `BannerVisibleError`
+ * instead of burning the full `timeoutMs`. The runner translates that to
+ * `AssistantErroredError` so #5142's fast-fail surface persists.
+ *
+ * Throws `TurnNotCompleteError` when any conjunct fails to converge
+ * inside `timeoutMs`. The reason field is classified by the post-loop
+ * read with precedence sse-missing > dom-missing > text-unstable, so
+ * the operator sees the earliest-failing signal in the message.
+ */
+export async function waitForTurnComplete(
+  opts: WaitForTurnCompleteOpts,
+): Promise<WaitForTurnCompleteResult> {
+  const { page, turnIndex, settleMs, timeoutMs } = opts;
+  const baselineBannerText = opts.baselineBannerText ?? null;
+  const pollIntervalMs = opts.pollIntervalMs ?? POLL_INTERVAL_MS;
+  const bubbleIndex = turnIndex - 1;
+  const startedAt = Date.now();
+  // Track the last observed text per-poll so we can measure how long
+  // the bubble has been stable. `null` is a distinct "no bubble yet"
+  // state — different from the empty-string placeholder, so flipping
+  // null -> "" resets the stability window (and "" -> "" stays stable
+  // but the non-empty guard below keeps the gate closed).
+  let lastText: string | null = null;
+  let lastChangeAt = startedAt;
+  // Banner fast-fail debounce: how many consecutive polls have seen
+  // the banner in a DIFFERS-FROM-BASELINE state (visible AND its text
+  // differs from `baselineBannerText`, or visible when baseline was
+  // absent). We require 2 consecutive differs polls before short-circuiting
+  // so a single-poll flicker (transient toast, render glitch, countdown
+  // tick on a persisted banner) cannot spuriously fast-fail a turn that's
+  // actually settling. A poll where the banner matches baseline (same
+  // stale text) resets the counter — the banner is not a fresh error.
+  let consecutiveBannerDiffersFromBaseline = 0;
+  let lastBannerText = "";
+  const pwPage = page as unknown as PlaywrightPage;
+  while (Date.now() - startedAt < timeoutMs) {
+    const runsFinished = await readRunsFinished(page);
+    // Atomic single-evaluate read: `readCascadeState` returns BOTH the
+    // count and the indexed text from the SAME cascade tier in ONE
+    // browser-side round-trip, eliminating a DOM-mutates-between-reads
+    // race where the count comes from one tier and the text from another.
+    const { count, text } = await readCascadeState(pwPage, bubbleIndex);
+    const now = Date.now();
+    if (text !== lastText) {
+      lastText = text;
+      lastChangeAt = now;
+    }
+    const sseOk = runsFinished >= turnIndex;
+    const domOk = count > bubbleIndex;
+    const textOk =
+      text !== null && text.trim().length > 0 && now - lastChangeAt >= settleMs;
+    if (sseOk && domOk && textOk) {
+      return { bubbleIndex, text: text! };
+    }
+    // Pre-conjunct banner fast-fail guard. We ONLY fire fast-fail when the
+    // assistant hasn't yet produced a response for THIS turn (domOk =
+    // false) — a banner alongside a real response is success-in-flight and
+    // must not trip fast-fail. The 2-consecutive-differs-from-baseline
+    // debounce gates a single-poll flicker AND a stale same-text persisted
+    // banner. A banner matching baseline (same stale text) resets the
+    // counter so it cannot accumulate a spurious fast-fail. `unreadable`
+    // also resets (we don't know the banner state, so we can't honestly
+    // count this poll as differing).
+    if (!domOk) {
+      const banner = await readErrorBanner(page);
+      if (banner.state === "visible") {
+        // "Differs from baseline" = (a) baseline was absent and we now see
+        // a banner, OR (b) baseline was visible but with a different text.
+        const differsFromBaseline =
+          baselineBannerText === null || banner.text !== baselineBannerText;
+        if (differsFromBaseline) {
+          consecutiveBannerDiffersFromBaseline += 1;
+          lastBannerText = banner.text;
+          if (consecutiveBannerDiffersFromBaseline >= 2) {
+            throw new BannerVisibleError(lastBannerText);
+          }
+        } else {
+          // Banner visible but identical to baseline — a stale persisted
+          // banner from a prior turn. NOT a fresh error signal; reset the
+          // debounce so a later flicker on top of the stale text still
+          // needs 2 consecutive differs polls to fire.
+          consecutiveBannerDiffersFromBaseline = 0;
+        }
+      } else {
+        // Either `absent` or `unreadable` — reset the debounce. We don't
+        // treat `unreadable` as "still differs" because that would let a
+        // single transient page.evaluate throw arm fast-fail with a stale
+        // last-seen banner text we can't trust.
+        consecutiveBannerDiffersFromBaseline = 0;
+      }
+    } else {
+      // Success-in-flight (assistant has produced a response this turn):
+      // the banner is now ignored — disarm the debounce so a late banner
+      // does not race the settle path.
+      consecutiveBannerDiffersFromBaseline = 0;
+    }
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+  // Re-read the final state to classify the failure. We do NOT reuse
+  // the loop's last-seen snapshot — a race where the world settled
+  // exactly between the last poll and the deadline should classify as
+  // "we didn't see it in time", which the final read reproduces faithfully.
+  const runsFinishedFinal = await readRunsFinished(page);
+  const countFinal = await countAssistantMessages(pwPage);
+  const reason: TurnNotCompleteError["reason"] =
+    runsFinishedFinal < turnIndex
+      ? "sse-missing"
+      : countFinal <= bubbleIndex
+        ? "dom-missing"
+        : "text-unstable";
+  throw new TurnNotCompleteError(
+    reason,
+    turnIndex,
+    Date.now() - startedAt,
+    `waitForTurnComplete: turn ${turnIndex} did not complete within ${timeoutMs}ms (reason=${reason}, runsFinished=${runsFinishedFinal}, count=${countFinal})`,
+  );
 }

--- a/showcase/harness/src/probes/helpers/init-scripts.ts
+++ b/showcase/harness/src/probes/helpers/init-scripts.ts
@@ -1,0 +1,199 @@
+import type { Page } from "playwright";
+
+import type { ConversationTurn } from "./conversation-runner.js";
+
+/**
+ * Install the bubble-race pre-paint placeholder via Playwright's
+ * `addInitScript`. The injected HTML is appended to document.body
+ * BEFORE any navigation, so the placeholder is in the DOM before
+ * `waitForTurnComplete` makes its first cascade count read on turn 1.
+ *
+ * Since the `waitForTurnComplete` cutover deleted the boot-time
+ * `readMessageCount` baseline read, the pre-paint placeholder is now
+ * exercised primarily by defect-4 repro infrastructure (the
+ * bubble-race repro tests in
+ * `test/integration/bubble-race-repro-defect-4.test.ts`) rather than
+ * the production settle path.
+ *
+ * Reads `BUBBLE_RACE_PRE_PAINT` from process.env. When unset, this is
+ * a no-op — production runs are unaffected.
+ *
+ * Also wires the strip-selector hook used by defect 3 (when no
+ * natural cascade-fallback-only demo exists). Env-driven and a
+ * no-op in production.
+ *
+ * The per-scenario messages override (`BUBBLE_RACE_MESSAGES`) is NOT
+ * installed via `addInitScript` — see `messagesOverrideFromEnv` for
+ * the Node-side helper consumed at the `runConversation` callsite.
+ *
+ * Implementation note: the pre-paint script is passed to
+ * `page.addInitScript` as a STRING rather than a function. The
+ * function-form gets serialized through tsx's TypeScript transform,
+ * which can inject helper symbols (e.g. `__name`, `_a`) that the
+ * page context cannot resolve, causing the script to register but
+ * silently no-op at document_start. A self-contained ES5-shape IIFE
+ * sidesteps this entirely.
+ */
+export async function installPrePaintFromEnv(page: Page): Promise<void> {
+  const html = process.env.BUBBLE_RACE_PRE_PAINT;
+  if (html) {
+    // Pass as a string to dodge tsx/TypeScript helper injection
+    // that can poison addInitScript function-serialization. The
+    // IIFE seeds the placeholder at document_start (appended to
+    // `documentElement` when body isn't yet parsed) and re-seeds
+    // on `DOMContentLoaded` (into body, as a safety net against
+    // React hydration stripping the early node). `waitForTurnComplete`
+    // runs after `page.goto({ waitUntil: "load" })` returns AND after
+    // the chat input selector resolves (a Playwright `waitForSelector`
+    // cycle), so DOMContentLoaded has long fired and the body-targeted
+    // injection is present in the DOM before the first cascade count
+    // read on turn 1.
+    // Navigation re-entry contract: Playwright's `addInitScript` runs at
+    // document_start of EACH new document — every navigation creates a
+    // fresh JS realm with a fresh `globalThis`. So the
+    // `__bubble_race_prepaint_installed` guard is `undefined` on entry
+    // for every navigation, and the script re-injects the placeholder
+    // into the new document. The guard is NOT a cross-navigation skip;
+    // its purpose is to protect against the script source being
+    // registered more than once within a single document's realm (e.g.
+    // if `addInitScript` were ever called multiple times). The inner
+    // `injected_once` flag handles the document_start + DOMContentLoaded
+    // dual-fire WITHIN a single document. This contract is pinned by
+    // `bubble-race-mechanisms.test.ts` ("pre-paint re-injects on
+    // same-context navigation"); a regression that aliases state across
+    // navigations will fail that test.
+    const initScriptSource = `
+            (function(injected) {
+              var g = globalThis;
+              if (g.__bubble_race_prepaint_installed) return;
+              g.__bubble_race_prepaint_installed = true;
+              var d = g.document;
+              // Whichever inject() fires first (immediate-at-document_start
+              // or DOMContentLoaded) wins. The other no-ops via this flag,
+              // preventing a double-insert that would inflate the cascade
+              // count seen by waitForTurnComplete and defeat defect-4's repro.
+              // Per the navigation re-entry contract above, both this flag
+              // and the outer __bubble_race_prepaint_installed guard reset
+              // per navigation (fresh realm), so they only deduplicate
+              // within a single document lifetime.
+              var injected_once = false;
+              function inject() {
+                if (injected_once) return;
+                try {
+                  if (d.body) {
+                    d.body.insertAdjacentHTML('beforeend', injected);
+                    injected_once = true;
+                  } else if (d.documentElement) {
+                    d.documentElement.insertAdjacentHTML('beforeend', injected);
+                    injected_once = true;
+                  }
+                } catch (e) {
+                  try { (g.console && g.console.warn) && g.console.warn('[init-scripts] pre-paint inject failed: ' + (e && e.message ? e.message : String(e))); } catch (_) {}
+                }
+              }
+              try {
+                inject();
+                d.addEventListener('DOMContentLoaded', function() { inject(); });
+              } catch (e) {
+                try { (g.console && g.console.warn) && g.console.warn('[init-scripts] pre-paint setup failed: ' + (e && e.message ? e.message : String(e))); } catch (_) {}
+              }
+            })(${JSON.stringify(html)});
+        `;
+    await page.addInitScript(initScriptSource);
+  }
+  const stripSel = process.env.BUBBLE_RACE_STRIP_SELECTOR;
+  if (stripSel) {
+    // Same string-form rationale as the pre-paint script above:
+    // tsx-injected helper symbols would break a function-form
+    // addInitScript silently.
+    const stripScriptSource = `
+            (function(sel) {
+              var g = globalThis;
+              if (g.__bubble_race_strip_installed) return;
+              g.__bubble_race_strip_installed = true;
+              var d = g.document;
+              function strip() {
+                try {
+                  var nodes = d.querySelectorAll(sel);
+                  for (var i = 0; i < nodes.length; i++) {
+                    nodes[i].removeAttribute('data-testid');
+                  }
+                } catch (e) {
+                  try { (g.console && g.console.warn) && g.console.warn('[init-scripts] strip failed: ' + (e && e.message ? e.message : String(e))); } catch (_) {}
+                }
+              }
+              try {
+                // setInterval(strip, 50) is intentionally fragile-but-bounded.
+                // It only runs in defect-3 repro paths when no natural
+                // cascade-fallback-only demo exists. A MutationObserver would
+                // be more robust but adds complexity for a narrow test-only
+                // fallback. The interval is cleared on beforeunload to avoid
+                // leaking across navigations in pooled contexts.
+                var intervalId = g.setInterval(strip, 50);
+                g.__bubble_race_strip_interval_id = intervalId;
+                if (g.addEventListener) {
+                  g.addEventListener('beforeunload', function() {
+                    try { g.clearInterval && g.clearInterval(intervalId); } catch (_) {}
+                  }, { once: true });
+                }
+              } catch (e) {
+                try { (g.console && g.console.warn) && g.console.warn('[init-scripts] strip setup failed: ' + (e && e.message ? e.message : String(e))); } catch (_) {}
+              }
+            })(${JSON.stringify(stripSel)});
+        `;
+    await page.addInitScript(stripScriptSource);
+  }
+}
+
+/**
+ * Node-side helper that consumes `BUBBLE_RACE_MESSAGES` from the
+ * environment and, when set, returns the per-turn override array
+ * the d5/d6 driver should pass to `runConversation` in place of
+ * the demo's default `script.buildTurns(buildCtx)` result.
+ *
+ * The env var is set by `bubble-race-repro.ts` (the integration
+ * test driver) as `JSON.stringify(opts.messages)` — an array of
+ * user-input strings. Each string becomes a `{ input: <string> }`
+ * `ConversationTurn`. Other turn fields (skipFill, skipSend,
+ * preFill, assertions, etc.) are intentionally NOT overridable:
+ * the bubble-race repros drive plain text turns only, and any
+ * future override surface area should be added explicitly rather
+ * than implicitly through env JSON.
+ *
+ * Returns `undefined` when the env var is unset, malformed, or
+ * empty — callers fall back to the demo's default turn sequence.
+ * Malformed payloads are silently ignored so a stray env var
+ * cannot poison a production run; the integration test owns the
+ * contract on its own value.
+ */
+export function messagesOverrideFromEnv(): ConversationTurn[] | undefined {
+  const raw = process.env.BUBBLE_RACE_MESSAGES;
+  if (!raw) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    console.warn(
+      `[init-scripts] BUBBLE_RACE_MESSAGES rejected: invalid JSON (${
+        e instanceof Error ? e.message : String(e)
+      })`,
+    );
+    return undefined;
+  }
+  if (!Array.isArray(parsed)) {
+    console.warn("[init-scripts] BUBBLE_RACE_MESSAGES rejected: not an array");
+    return undefined;
+  }
+  if (parsed.length === 0) return undefined;
+  const turns: ConversationTurn[] = [];
+  for (const m of parsed) {
+    if (typeof m !== "string") {
+      console.warn(
+        `[init-scripts] BUBBLE_RACE_MESSAGES rejected: non-string entry (${typeof m})`,
+      );
+      return undefined;
+    }
+    turns.push({ input: m });
+  }
+  return turns;
+}

--- a/showcase/harness/src/probes/helpers/sse-interceptor.test.ts
+++ b/showcase/harness/src/probes/helpers/sse-interceptor.test.ts
@@ -4,11 +4,13 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   assembleCapture,
+  attachSseInterceptor,
   collectContractShape,
   computeStreamProfile,
   extractToolCallNames,
   parseSseEvents,
 } from "./sse-interceptor.js";
+import type { Page } from "playwright";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES_DIR = path.resolve(
@@ -300,5 +302,133 @@ describe("assembleCapture", () => {
       'data: {"type":"B"}\n\n';
     const cap = assembleCapture(payload, [], 0, ["TOOL_CALL_START"]);
     expect(cap.raw_event_count).toBe(2);
+  });
+});
+
+/**
+ * r4f4 regression: doStop must detach the `framenavigated` listener
+ * BEFORE awaiting getResponseBody / the loadingFinished loop. Otherwise
+ * a main-frame navigation fired between the start of doStop and the
+ * CDP body fetch wipes payload + per-stream tracking state mid-flight
+ * and the returned capture is empty.
+ *
+ * We exercise this by building a fake Playwright Page + CDP surface
+ * whose `Network.getResponseBody` handler synchronously fires a fake
+ * main-frame `framenavigated` BEFORE returning the body. If the
+ * listener is still attached at that moment, the listener resets
+ * `payload` (clobbering the body we just received via cdp.send).
+ * With the fix in place the listener is detached first, the reset
+ * never fires during doStop, and the assembled capture reflects the
+ * real RUN_FINISHED-bearing payload.
+ */
+describe("attachSseInterceptor doStop framenavigated detach race (r4f4)", () => {
+  interface ListenerMap {
+    [event: string]: Array<(...args: unknown[]) => void>;
+  }
+
+  function makeFakeCdp(payloadBody: string, onBeforeBody: () => void) {
+    const listeners: ListenerMap = {};
+    return {
+      detachCount: 0,
+      on(event: string, fn: (...args: unknown[]) => void) {
+        (listeners[event] ??= []).push(fn);
+      },
+      off(event: string, fn: (...args: unknown[]) => void) {
+        const arr = listeners[event];
+        if (!arr) return;
+        const i = arr.indexOf(fn);
+        if (i !== -1) arr.splice(i, 1);
+      },
+      async send(method: string, _params?: unknown) {
+        if (method === "Network.enable") return {};
+        if (method === "Network.getResponseBody") {
+          // Simulate a navigation racing with the body fetch — this is
+          // the exact window r4f4 guards against.
+          onBeforeBody();
+          return { body: payloadBody, base64Encoded: false };
+        }
+        return {};
+      },
+      async detach() {
+        this.detachCount++;
+      },
+      emit(event: string, ...args: unknown[]) {
+        const arr = listeners[event];
+        if (!arr) return;
+        for (const fn of arr.slice()) fn(...args);
+      },
+    };
+  }
+
+  function makeFakePage(cdp: ReturnType<typeof makeFakeCdp>) {
+    const pageListeners: ListenerMap = {};
+    const mainFrame = { url: () => "https://test.invalid/" };
+    const fakePage = {
+      mainFrame: () => mainFrame,
+      on(event: string, fn: (...args: unknown[]) => void) {
+        (pageListeners[event] ??= []).push(fn);
+      },
+      off(event: string, fn: (...args: unknown[]) => void) {
+        const arr = pageListeners[event];
+        if (!arr) return;
+        const i = arr.indexOf(fn);
+        if (i !== -1) arr.splice(i, 1);
+      },
+      async addInitScript(_src: string) {},
+      context: () => ({
+        async newCDPSession(_p: unknown) {
+          return cdp;
+        },
+      }),
+      __emit(event: string, ...args: unknown[]) {
+        const arr = pageListeners[event];
+        if (!arr) return;
+        for (const fn of arr.slice()) fn(...args);
+      },
+      __frame: mainFrame,
+    };
+    return fakePage;
+  }
+
+  it("does NOT clobber payload when framenavigated fires during getResponseBody", async () => {
+    const realPayload =
+      'data: {"type":"RUN_STARTED","threadId":"t"}\n\n' +
+      'data: {"type":"TOOL_CALL_START","toolCallName":"my_tool"}\n\n' +
+      'data: {"type":"RUN_FINISHED"}\n\n';
+
+    // Holder so the cdp can reach the page to fire framenavigated.
+    const holder: { page: ReturnType<typeof makeFakePage> | null } = {
+      page: null,
+    };
+    const cdp = makeFakeCdp(realPayload, () => {
+      // Fire a main-frame framenavigated BEFORE body is returned.
+      // With the bug, the listener is still attached and resets
+      // payload + chunkTimestampsMs; with the fix, it has already
+      // been detached at the top of doStop and the reset never fires.
+      holder.page?.__emit("framenavigated", holder.page.__frame);
+    });
+    const fakePage = makeFakePage(cdp);
+    holder.page = fakePage;
+
+    const handle = await attachSseInterceptor(fakePage as unknown as Page);
+
+    // Simulate the request being observed (so trackedRequestId is set
+    // and doStop's body-fetch branch is reached).
+    cdp.emit("Network.requestWillBeSent", {
+      requestId: "req-1",
+      request: { url: "https://test.invalid/api/copilotkit/agent/x/run" },
+      wallTime: Date.now() / 1000,
+    });
+    cdp.emit("Network.dataReceived", { requestId: "req-1" });
+    cdp.emit("Network.loadingFinished", { requestId: "req-1" });
+
+    const cap = await handle.stop();
+
+    // The capture must reflect the REAL payload — not a wiped one.
+    expect(cap.raw_event_count).toBe(3);
+    expect(cap.toolCalls).toEqual(["my_tool"]);
+    expect(cap.contractFields["type"]).toBe("string");
+    // CDP detach should still have happened exactly once at end of doStop.
+    expect(cdp.detachCount).toBe(1);
   });
 });

--- a/showcase/harness/src/probes/helpers/sse-interceptor.ts
+++ b/showcase/harness/src/probes/helpers/sse-interceptor.ts
@@ -42,7 +42,7 @@
  * required for the malformed-chunk recovery test).
  */
 
-import type { Page } from "playwright";
+import type { Frame, Page } from "playwright";
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- CDP payload typing
    intentionally unconstrained: we narrow at the read-site rather than
@@ -96,9 +96,12 @@ export interface SseCapture {
  *
  * - `endpointPattern`     URL filter for which response stream to watch.
  *                         Matches against the full URL (string `includes`
- *                         or regex `test`). Defaults to `/api/copilotkit/`
- *                         which covers the runtime SSE endpoints across
- *                         all 17 showcase integrations.
+ *                         or regex `test`). Defaults to
+ *                         `/\/api\/copilotkit(\/|-|$|\?)/` so that all
+ *                         five runtime URL shapes the v2 client emits
+ *                         match (see `DEFAULT_ENDPOINT_PATTERN` for the
+ *                         full enumeration); covers every showcase
+ *                         integration without per-demo configuration.
  * - `toolCallEventTypes`  SSE event-type values that signal a new tool-call
  *                         beginning. Defaults to `["TOOL_CALL_START"]`
  *                         which is the canonical ag-ui event; a list lets
@@ -113,9 +116,66 @@ export interface SseInterceptorOptions {
 /** Public handle returned by `attachSseInterceptor`. */
 export interface SseInterceptorHandle {
   stop(): Promise<SseCapture>;
+  /**
+   * Internal flag flipped to `true` once `doStop`'s teardown completes —
+   * the CDP session is detached, listeners removed, payload assembled
+   * and resolved. `attachSseInterceptor`'s cache-check treats a cached
+   * handle with `consumed === true` as a cache MISS and creates a fresh
+   * handle.
+   *
+   * Defense-in-depth alongside the `delete pageHandleCache.__hk_sse_attached`
+   * in `doStop`: if the cache delete fails (e.g., the page object has been
+   * collected, or another reference holds the same shape and re-publishes
+   * the stale handle), the consumed flag still prevents
+   * `attachSseInterceptor` from handing the dead handle back to a caller
+   * that started a brand-new SSE stream on the same page lifecycle.
+   */
+  consumed?: boolean;
 }
 
-const DEFAULT_ENDPOINT_PATTERN = /\/api\/copilotkit\//;
+/**
+ * Default URL filter for the SSE runtime endpoint.
+ *
+ * Must match every URL CopilotKit's v2 client actually hits — the
+ * shapes that flow are:
+ *
+ *   (a) `/api/copilotkit`                            — v2 single-route
+ *       transport (the showcase's default; runtimeUrl is hit verbatim
+ *       with NO trailing slash and NO `/agent/<id>/run` suffix).
+ *       `ProxiedCopilotRuntimeAgent` strips a trailing `/` from
+ *       `runtimeUrl` and uses that exact string as the run URL when
+ *       `transport === "single"` (`packages/core/src/agent.ts:117-125`).
+ *   (b) `/api/copilotkit/agent/<id>/run`              — v2 REST
+ *       transport (the URL `ProxiedCopilotRuntimeAgent` constructs in
+ *       non-single mode at the same call site).
+ *   (c) `/api/copilotkit/info`                        — v2 REST runtime
+ *       info GET; not an SSE stream but kept under one filter so
+ *       future probes don't have to re-derive what "the runtime URL"
+ *       means.
+ *   (d) `/api/copilotkit-<demo>` and
+ *       `/api/copilotkit-<demo>/...`                  — per-demo
+ *       dedicated runtime endpoints (declarative-hashbrown, ogui,
+ *       multimodal, mcp-apps, auth, voice, beautiful-chat, …). Each
+ *       has its own Next.js route handler; the v2 client still hits
+ *       `<runtimeUrl>` in single mode and `<runtimeUrl>/agent/<id>/run`
+ *       in REST mode.
+ *
+ * The previous filter `/\/api\/copilotkit\//` required a TRAILING
+ * SLASH after `copilotkit` and so failed (a) entirely — the s7
+ * mechanism-GREEN test used a `page.route` fake that served from
+ * `…/api/copilotkit/agent/runtime` (an `/agent/…` URL that matches the
+ * old filter), masking the production mismatch. Against the real
+ * showcase runtime the wrapper saw a `/api/copilotkit` POST, ignored
+ * it, and `__hk_runsFinished` stayed at 0 even though the assistant
+ * rendered text. `waitForTurnComplete`'s SSE conjunct then never
+ * fired and the turn timed out with reason=sse-missing.
+ *
+ * The new filter accepts `/api/copilotkit` followed by `/`, `-`,
+ * end-of-string, or `?` so all five shapes above match while
+ * `/api/copilotkit_underscore_suffix` or `/api/copilotkitfoo` still
+ * fall through.
+ */
+const DEFAULT_ENDPOINT_PATTERN = /\/api\/copilotkit(\/|-|$|\?)/;
 const DEFAULT_TOOL_CALL_EVENT_TYPES = ["TOOL_CALL_START"];
 
 /**
@@ -241,12 +301,26 @@ export function collectContractShape(
  * Walking all four is intentional: the spec's reading list flagged
  * uncertainty about the on-wire shape, and the parity-compare engine
  * needs to cope with reference implementations that haven't migrated to
- * ag-ui canonical naming yet. Order is load-bearing — STRUCTURED
- * variants (`tool_call.name` / `tool_use.name`) are checked BEFORE the
- * bare `name` field because some transports include a top-level `name`
- * for an event/step label alongside a structured tool descriptor;
- * picking `name` first would harvest the label instead of the actual
- * tool name. First matching field wins per event.
+ * ag-ui canonical naming yet.
+ *
+ * Order is load-bearing. `pickToolCallName` checks fields in this exact
+ * precedence (first match wins per event):
+ *
+ *   1. `toolCallName` — PREFERRED. This is the canonical ag-ui
+ *      event-level field; when present it is unambiguously the
+ *      tool-call name (no risk of conflation with a step/event label).
+ *   2. `tool_call.name` / `tool_use.name` — FALLBACK for transports
+ *      that surface tool descriptors as nested objects rather than the
+ *      ag-ui canonical top-level field. A `tool_call` / `tool_use`
+ *      container is a strong (though not perfect) tool-call indicator,
+ *      so it's moderately unambiguous.
+ *   3. bare top-level `name` — LAST RESORT. This is the sharp edge:
+ *      some transports include a top-level `name` for an event/step
+ *      label alongside a structured tool descriptor, so picking `name`
+ *      ahead of the structured variants would harvest the label
+ *      instead of the actual tool name and poison the parity
+ *      comparison's tool-call list. Only consult it after the
+ *      structured variants have been exhausted.
  */
 export function extractToolCallNames(
   events: ParsedSseEvent[],
@@ -266,12 +340,16 @@ export function extractToolCallNames(
 }
 
 function pickToolCallName(p: Record<string, unknown>): string | undefined {
+  // 1) `toolCallName` — ag-ui canonical event-level field; preferred
+  // when present. See the docstring above `extractToolCallNames` for
+  // the full precedence rationale.
   if (typeof p["toolCallName"] === "string") return p["toolCallName"];
-  // Structured variants first — see the docstring above for why
-  // `name` is the LAST resort. Some transports surface a step/event
-  // label as top-level `name` alongside a structured tool descriptor,
-  // and picking that label up before the structured field would
-  // poison the parity comparison's tool-call list.
+  // 2) Structured variants (`tool_call.name` / `tool_use.name`) —
+  // fallback for transports that surface tool descriptors as nested
+  // objects. Checked BEFORE bare `name` because some transports use
+  // top-level `name` for an event/step label alongside a structured
+  // tool descriptor; picking that label up before the structured
+  // field would poison the parity comparison's tool-call list.
   const tc = p["tool_call"];
   if (
     tc !== null &&
@@ -288,6 +366,9 @@ function pickToolCallName(p: Record<string, unknown>): string | undefined {
   ) {
     return (tu as Record<string, unknown>)["name"] as string;
   }
+  // 3) Bare top-level `name` — last resort; could be a step/event
+  // label rather than a tool name, so only consult after the
+  // structured variants above.
   if (typeof p["name"] === "string") return p["name"];
   return undefined;
 }
@@ -382,6 +463,172 @@ function matchesEndpoint(url: string, pattern: string | RegExp): boolean {
 }
 
 /**
+ * Build the page-side init script source that:
+ *
+ *   (a) seeds `window.__hk_runsFinished = 0` so a `page.evaluate`
+ *       read at any later point returns a defined number (never
+ *       `undefined`), and
+ *   (b) wraps `window.fetch` so that any matched SSE response has
+ *       its body teed and parsed inline for `RUN_FINISHED` records,
+ *       incrementing `window.__hk_runsFinished` per event observed.
+ *
+ * Implementation notes:
+ *   - Passed to `page.addInitScript` as a STRING (not a function).
+ *     Identical rationale to `init-scripts.ts`: tsx's TypeScript
+ *     transform can inject helper symbols (`__name`, `_a`, …) into
+ *     a function-form `addInitScript` payload that the page context
+ *     cannot resolve, causing the script to register but silently
+ *     no-op at document_start. A self-contained ES5-shape IIFE
+ *     sidesteps the issue and matches the pattern s4 established in
+ *     `installPrePaintFromEnv`.
+ *   - The fetch wrapper tees the response body via
+ *     `response.clone().body.getReader()` (the original stream still
+ *     flows to the caller untouched — no buffering, no re-injection,
+ *     same chunk timing the parity-compare engine measures). The
+ *     clone path is parsed in a background async loop; counter
+ *     updates land best-effort.
+ *   - The page-side counter is independent of the Node-side CDP
+ *     capture. `assembleCapture` (Node) still counts events at
+ *     `stop()` time for `SseCapture.raw_event_count`; the page-side
+ *     counter exists only to serve `waitForTurnComplete`'s
+ *     `page.evaluate(() => __hk_runsFinished)` real-time conjunct.
+ */
+function buildPageSideCounterScript(endpointPattern: string | RegExp): string {
+  // Serialize the pattern into a value the page-side script can
+  // rebuild. We pass either a literal string or a RegExp-source +
+  // flags pair so the page side can re-construct the RegExp.
+  const patternLiteral =
+    typeof endpointPattern === "string"
+      ? JSON.stringify({ kind: "string", value: endpointPattern })
+      : JSON.stringify({
+          kind: "regex",
+          source: endpointPattern.source,
+          flags: endpointPattern.flags,
+        });
+  return `
+    (function(patternSpec) {
+      var g = globalThis;
+      if (typeof g.__hk_runsFinished !== 'number') {
+        g.__hk_runsFinished = 0;
+      }
+      // Already wrapped (e.g. multiple attachSseInterceptor calls in
+      // one page lifecycle) — leave the existing wrapper in place.
+      if (g.__hk_fetchWrapped === true) return;
+      g.__hk_fetchWrapped = true;
+      var pattern;
+      try {
+        if (patternSpec.kind === 'regex') {
+          pattern = new RegExp(patternSpec.source, patternSpec.flags);
+        } else {
+          pattern = patternSpec.value;
+        }
+      } catch (_) {
+        pattern = '/api/copilotkit/';
+      }
+      function matches(url) {
+        if (!url) return false;
+        if (typeof pattern === 'string') return url.indexOf(pattern) !== -1;
+        try { return pattern.test(url); } catch (_) { return false; }
+      }
+      function urlOf(input) {
+        if (typeof input === 'string') return input;
+        if (input && typeof input === 'object') {
+          if (typeof input.url === 'string') return input.url;
+          try { return String(input); } catch (_) { return ''; }
+        }
+        return '';
+      }
+      function processChunk(buf, leftover) {
+        // Concatenate any prior leftover, normalize CRLF, split on
+        // blank-line record separators, increment for each
+        // RUN_FINISHED-typed JSON payload observed. Returns the new
+        // leftover (incomplete trailing record).
+        var text = leftover + buf;
+        text = text.split('\\r\\n').join('\\n');
+        var idx = text.lastIndexOf('\\n\\n');
+        var complete;
+        var newLeftover;
+        if (idx === -1) {
+          complete = '';
+          newLeftover = text;
+        } else {
+          complete = text.slice(0, idx);
+          newLeftover = text.slice(idx + 2);
+        }
+        if (complete.length > 0) {
+          var records = complete.split(/\\n\\n+/);
+          for (var i = 0; i < records.length; i++) {
+            var record = records[i];
+            if (!record) continue;
+            var lines = record.split('\\n');
+            var dataParts = [];
+            for (var j = 0; j < lines.length; j++) {
+              var line = lines[j];
+              if (!line) continue;
+              if (line.charAt(0) === ':') continue;
+              if (line.indexOf('data:') === 0) {
+                var v = line.substring(5);
+                if (v.charAt(0) === ' ') v = v.substring(1);
+                dataParts.push(v);
+              }
+            }
+            if (dataParts.length === 0) continue;
+            var raw = dataParts.join('\\n');
+            try {
+              var parsed = JSON.parse(raw);
+              if (parsed && typeof parsed === 'object' && parsed.type === 'RUN_FINISHED') {
+                g.__hk_runsFinished = (g.__hk_runsFinished | 0) + 1;
+              }
+            } catch (_) {
+              // Malformed record — skip silently. The Node-side
+              // capture surfaces parse errors via raw_event_count.
+            }
+          }
+        }
+        return newLeftover;
+      }
+      var originalFetch = g.fetch;
+      if (typeof originalFetch !== 'function') return;
+      g.fetch = function(input, init) {
+        var url = urlOf(input);
+        var p = originalFetch.call(this, input, init);
+        if (!matches(url)) return p;
+        return p.then(function(response) {
+          try {
+            var cloned = response.clone();
+            var body = cloned.body;
+            if (!body || typeof body.getReader !== 'function') return response;
+            var reader = body.getReader();
+            var decoder = new TextDecoder();
+            var leftover = '';
+            function pump() {
+              return reader.read().then(function(step) {
+                if (step.done) {
+                  // Flush any trailing complete record.
+                  if (leftover.length > 0) {
+                    leftover = processChunk('\\n\\n', leftover);
+                  }
+                  return;
+                }
+                var chunk = decoder.decode(step.value, { stream: true });
+                leftover = processChunk(chunk, leftover);
+                return pump();
+              }).catch(function() { /* swallow — best-effort */ });
+            }
+            pump();
+          } catch (_) {
+            // Cloning failed (body already consumed, etc.) — leave
+            // the response untouched; counter simply doesn't update
+            // for this stream.
+          }
+          return response;
+        });
+      };
+    })(${patternLiteral});
+  `;
+}
+
+/**
  * Attach a CDP-based SSE interceptor to a Playwright page.
  *
  * The handler returned by `stop()` detaches all CDP listeners, fetches
@@ -404,6 +651,53 @@ export async function attachSseInterceptor(
   const toolCallEventTypes =
     opts.toolCallEventTypes ?? DEFAULT_TOOL_CALL_EVENT_TYPES;
 
+  // Page-level idempotency. `d6-all-pills.ts` calls
+  // `attachSseInterceptor` on every `page.goto(...)` to re-seed the
+  // page-side counter and Node-side CDP capture for the new run.
+  // Without a guard each call would:
+  //   (a) re-register the addInitScript (page-side counter script
+  //       accumulates registrations, even though the `__hk_fetchWrapped`
+  //       IIFE-internal sentinel prevents the wrapper from double-
+  //       installing on the live page),
+  //   (b) open a fresh CDP session, register Network.enable, and attach
+  //       four listeners — and the returned handle from the prior call
+  //       is dropped at the call site, leaking the session.
+  // Cache the handle on the page object and return it on subsequent
+  // calls so we install everything exactly once per page lifecycle.
+  //
+  // Post-stop cache invalidation (r6f1): once a handle's `stop()` has
+  // run, the CDP session is detached and `stopPromise` is permanently
+  // resolved. If a caller later attaches a NEW SSE stream on the same
+  // page lifecycle (e.g., re-uses a page across separate captures),
+  // returning the cached, already-stopped handle would silently hand
+  // them the FIRST stream's capture (cached resolved promise) AND
+  // never instrument the second stream (CDP already detached). Two
+  // layers of defense:
+  //   (a) `doStop` deletes `pageHandleCache.__hk_sse_attached` after
+  //       teardown completes, so the next attach call sees no cache;
+  //   (b) the handle carries a `consumed` flag flipped by `doStop`;
+  //       this check treats a cached-but-consumed handle as a cache
+  //       MISS, in case (a) fails to clear the cache (e.g., the page
+  //       object has been collected or another reference holds the
+  //       same shape).
+  const pageHandleCache = page as unknown as {
+    __hk_sse_attached?: SseInterceptorHandle;
+  };
+  const cached = pageHandleCache.__hk_sse_attached;
+  if (cached !== undefined && cached.consumed !== true) {
+    return cached;
+  }
+
+  // Page-side counter: seed `window.__hk_runsFinished = 0` at
+  // document_start and wrap `fetch` so any matched SSE response's
+  // body is teed and parsed inline. This is what
+  // `waitForTurnComplete` reads via
+  // `page.evaluate(() => __hk_runsFinished)`. Independent of the
+  // Node-side CDP capture below — that path still produces
+  // `SseCapture.raw_event_count` at `stop()`-time for the parity
+  // engine, and stays the authoritative end-of-run count.
+  await page.addInitScript(buildPageSideCounterScript(endpointPattern));
+
   // Newer Playwright versions expose `page.context().newCDPSession(page)`;
   // older ones only `browserContext.newCDPSession`. Both APIs return the
   // same shape, but the public type surface in playwright@1.59 is
@@ -413,10 +707,19 @@ export async function attachSseInterceptor(
 
   // The first request whose URL matches the pattern wins the slot; ignore
   // subsequent matches.
+  //
+  // These five vars (incl. `payload` declared below) are the per-stream
+  // tracking state that the `framenavigated` listener resets on a
+  // cold-start retry / reload — see `onFrameNavigated` further down for
+  // the why.
   let trackedRequestId: string | null = null;
   let requestStartMs = 0;
   const chunkTimestampsMs: number[] = [];
   let loadingFinished = false;
+  // `payload` is hoisted into the closure so the framenavigated reset
+  // can clear it. `doStop` assigns into the same variable when it
+  // fetches the final response body from CDP.
+  let payload = "";
 
   const onRequestWillBeSent = (params: any): void => {
     if (trackedRequestId !== null) return;
@@ -460,8 +763,60 @@ export async function attachSseInterceptor(
   cdp.on("Network.loadingFinished", onLoadingFinished);
   cdp.on("Network.loadingFailed", onLoadingFailed);
 
-  const stop = async (): Promise<SseCapture> => {
-    let payload = "";
+  // Cold-start retry recovery: `runConversation` will `page.reload()`
+  // when turn 1 fails to stream, but the CDP session and the
+  // surrounding closure persist across the reload. Without resetting
+  // the per-stream tracking vars, `trackedRequestId` stays pinned to
+  // the pre-reload (now-defunct) request — the first matching
+  // post-reload request is silently ignored, AND `getResponseBody`
+  // for the dead request ID will fail because Chromium evicts the
+  // response body buffer after main-frame navigation. Net effect:
+  // D6 capture for the retried turn is empty/incorrect with no
+  // operator-visible signal.
+  //
+  // Reset on every main-frame `framenavigated`. Subframe navigations
+  // (iframes, sandboxed widgets) do NOT touch the SSE stream and
+  // must NOT trigger a reset, so we gate on `frame === page.mainFrame()`.
+  const onFrameNavigated = (frame: Frame): void => {
+    if (frame !== page.mainFrame()) return;
+    // Emit a structured signal so the operator can correlate a
+    // retry/reload with the tracking-state reset. `console.debug`
+    // matches the surrounding helper's preference for low-volume
+    // diagnostic lines; the same prefix is used at log-grep time
+    // by the parity engine's debug pipeline.
+    // eslint-disable-next-line no-console
+    console.debug(
+      "[sse-interceptor] mainFrame framenavigated — resetting per-stream tracking state",
+      { url: frame.url(), hadTrackedRequest: trackedRequestId !== null },
+    );
+    trackedRequestId = null;
+    requestStartMs = 0;
+    chunkTimestampsMs.length = 0;
+    loadingFinished = false;
+    payload = "";
+  };
+  page.on("framenavigated", onFrameNavigated);
+
+  // `stop()` may be invoked twice in practice: once explicitly by the
+  // caller (to read the capture) and once by the page-close listener
+  // installed below (belt-and-suspenders cleanup if the caller drops
+  // the handle, as `d6-all-pills.ts` does). Cache the first invocation's
+  // promise so re-entry returns the same capture and the CDP detach +
+  // listener-off calls run exactly once.
+  let stopPromise: Promise<SseCapture> | null = null;
+  const stop = (): Promise<SseCapture> => {
+    if (stopPromise !== null) return stopPromise;
+    stopPromise = doStop();
+    return stopPromise;
+  };
+  const doStop = async (): Promise<SseCapture> => {
+    // Detached FIRST so a navigation between here and getResponseBody can't wipe payload mid-flight (r4f4).
+    try {
+      page.off("framenavigated", onFrameNavigated);
+    } catch {
+      // Page already closed — `off` may throw on a torn-down Page; ignore.
+    }
+
     if (trackedRequestId !== null) {
       // Wait briefly for loadingFinished if the caller stopped mid-stream
       // — gives the in-flight tail a chance to land before we request the
@@ -498,6 +853,26 @@ export async function attachSseInterceptor(
       // Already detached (page closed) — ignore.
     }
 
+    // Post-stop cache invalidation (r6f1). Two complementary signals so
+    // a subsequent `attachSseInterceptor(page)` doesn't hand the
+    // already-detached handle back to a caller starting a NEW SSE
+    // stream on the same page lifecycle:
+    //   (1) flip the handle's `consumed` flag, so even if our cache
+    //       delete below silently fails the attach-side check still
+    //       sees the consumed handle and treats it as a cache miss;
+    //   (2) delete the page-side cache entry so the next attach call
+    //       creates a fresh handle from scratch. Wrap in try/catch
+    //       because the page object may have been GC'd (close
+    //       handler ran the same `stop()`).
+    handle.consumed = true;
+    try {
+      delete pageHandleCache.__hk_sse_attached;
+    } catch {
+      // Page object collected or property non-configurable — the
+      // `consumed` flag above is the load-bearing path; this delete
+      // is defense in depth.
+    }
+
     return assembleCapture(
       payload,
       chunkTimestampsMs,
@@ -506,5 +881,22 @@ export async function attachSseInterceptor(
     );
   };
 
-  return { stop };
+  const handle: SseInterceptorHandle = { stop, consumed: false };
+  pageHandleCache.__hk_sse_attached = handle;
+
+  // End-of-page cleanup. The idempotency guard above keeps the CDP
+  // session from accumulating across same-page re-attaches, but on
+  // page close we still want the session detached and the listeners
+  // released. `stop()` is internally idempotent (see `stopPromise`
+  // above) so an explicit caller `stop()` followed by this close-fired
+  // `stop()` is a no-op on the second call.
+  page.on("close", () => {
+    void stop().catch(() => {
+      // Page already gone — CDP detach + getResponseBody will reject;
+      // swallow so we don't surface an unhandled rejection during
+      // test teardown.
+    });
+  });
+
+  return handle;
 }

--- a/showcase/harness/src/probes/scripts/_gen-ui-shared.ts
+++ b/showcase/harness/src/probes/scripts/_gen-ui-shared.ts
@@ -29,12 +29,34 @@
  * through `globalThis`. Same pattern as `conversation-runner.ts`.
  */
 
-import {
-  ASSISTANT_MESSAGE_FALLBACK_SELECTOR,
-  ASSISTANT_MESSAGE_HEADLESS_SELECTOR,
-  ASSISTANT_MESSAGE_PRIMARY_SELECTOR,
-  type Page,
-} from "../helpers/conversation-runner.js";
+import type { Page as PlaywrightPage } from "playwright";
+
+import { findAssistantBubbleAt } from "../helpers/assistant-message-count.js";
+import { type Page } from "../helpers/conversation-runner.js";
+
+/**
+ * Turn-scoped replacement for `readLastAssistantText`. Resolves the
+ * assistant bubble at strict 0-based `bubbleIndex` via the shared
+ * cascade (`findAssistantBubbleAt`) and returns its untruncated
+ * `textContent`. Returns `""` when the bubble is absent — callers MUST
+ * treat empty as "turn not yet complete", not as "turn produced an
+ * empty answer".
+ *
+ * The runner's structural `Page` surface erases playwright's overload
+ * set, so we widen via `unknown as PlaywrightPage` at the boundary —
+ * same pattern as `readMessageCount` in `conversation-runner.ts`. The
+ * helper only invokes `page.evaluate(...)` which both surfaces satisfy.
+ */
+export async function readAssistantTextAt(
+  page: Page,
+  bubbleIndex: number,
+): Promise<string> {
+  const text = await findAssistantBubbleAt(
+    page as unknown as PlaywrightPage,
+    bubbleIndex,
+  );
+  return text ?? "";
+}
 
 /**
  * Selector cascade used to find a rendered gen-UI component in the
@@ -270,92 +292,6 @@ export async function readSvgChartShape(page: Page): Promise<SvgChartShape> {
       drawingChildren: circles.length + paths.length + rects.length,
     };
   });
-}
-
-/**
- * Look up the assistant's most recent textual content — used by the
- * headless assertion to confirm the model acknowledged the rendered
- * component (per the recorded fixture, the second-leg response is a
- * short narration of what was shown). Returns the empty string when
- * no assistant text is present.
- *
- * IMPORTANT: The canonical CopilotKit assistant message DOM is:
- *
- *   <div data-testid="copilot-assistant-message">
- *     <div class="cpk:prose ...">   ← text content (markdown)
- *     tool-call renders             ← rendered components (SVG charts, cards, etc.)
- *     toolbar                       ← copy/thumbs/read-aloud buttons
- *   </div>
- *
- * Reading `textContent` on the outer wrapper picks up EVERYTHING —
- * including rendered tool-component labels (e.g. pie-chart SVG text
- * like "Electronics42,000" or "Clothing28,000"). This function
- * targets ONLY the prose div (first child) to extract the actual
- * assistant text message, not rendered component output.
- *
- * For non-canonical selectors (role="article", data-message-role)
- * the prose-scoping is attempted but falls back to the full element
- * when the expected DOM structure isn't present.
- */
-export async function readLastAssistantText(page: Page): Promise<string> {
-  const code = `
-    (() => {
-      const doc = globalThis.document;
-      const canonical = doc.querySelectorAll(${JSON.stringify(
-        ASSISTANT_MESSAGE_PRIMARY_SELECTOR,
-      )});
-      let list = canonical.length > 0
-        ? canonical
-        : doc.querySelectorAll(${JSON.stringify(
-          ASSISTANT_MESSAGE_FALLBACK_SELECTOR,
-        )});
-      if (list.length === 0) {
-        list = doc.querySelectorAll(${JSON.stringify(
-          ASSISTANT_MESSAGE_HEADLESS_SELECTOR,
-        )});
-      }
-      if (list.length === 0) return "";
-      const last = list[list.length - 1];
-      if (!last) return "";
-
-      // Scope to the prose/markdown child to exclude rendered tool
-      // components (charts, cards) and toolbar buttons. The prose div
-      // is always the first child of the canonical assistant-message
-      // wrapper and carries a class containing "prose".
-      var proseChild = last.querySelector && last.querySelector('[class*="prose"]');
-      if (!proseChild) {
-        // Fallback: first child div (the prose wrapper is always the
-        // first <div> child in the canonical layout).
-        var firstDiv = last.querySelector && last.querySelector(':scope > div:first-child');
-        if (firstDiv) {
-          // Only use this if the assistant message has more than one
-          // child (i.e. there's a tool-call render or toolbar sibling).
-          // If there's only one child, the whole element IS the text.
-          if (last.childElementCount > 1) {
-            proseChild = firstDiv;
-          }
-        }
-      }
-
-      var target = proseChild || last;
-      var text = (target.textContent || "").trim();
-
-      // Debug: log what we're reading so production traces show exactly
-      // which element was selected and what text was extracted.
-      if (typeof console !== "undefined" && console.log) {
-        console.log(
-          "[readLastAssistantText] selector=" +
-          (canonical.length > 0 ? ${JSON.stringify(ASSISTANT_MESSAGE_PRIMARY_SELECTOR)} : "fallback") +
-          " scoped=" + (proseChild ? "prose" : "full") +
-          " text=" + JSON.stringify(text.slice(0, 120))
-        );
-      }
-
-      return text;
-    })()
-  `;
-  const fn = new Function(`return ${code.trim()};`) as () => string;
-  return await page.evaluate(fn);
 }
 
 function sleep(ms: number): Promise<void> {

--- a/showcase/harness/src/probes/scripts/d5-agentic-chat.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-agentic-chat.test.ts
@@ -155,7 +155,9 @@ describe("d5-agentic-chat script", () => {
     // Assistant replied without recalling the goldfish's name. The
     // context-retention check must throw to surface this regression.
     const page = makePageReturning("I don't recall what we discussed earlier.");
-    await expect(turn3.assertions!(page)).rejects.toThrow(/turn 3/);
+    await expect(
+      turn3.assertions!(page, { bubbleIndex: 0, text: "" }),
+    ).rejects.toThrow(/turn 3/);
   });
 
   it("turn-3 assertion passes a present-name response (case-insensitive)", async () => {
@@ -171,7 +173,9 @@ describe("d5-agentic-chat script", () => {
     const page = makePageReturning(
       "We named the goldfish BUBBLES, and the tank The Bubble Bowl.",
     );
-    await expect(turn3.assertions!(page)).resolves.toBeUndefined();
+    await expect(
+      turn3.assertions!(page, { bubbleIndex: 0, text: "" }),
+    ).resolves.toBeUndefined();
   });
 
   it("turn-1 assertion fails on an empty assistant response", async () => {
@@ -184,6 +188,8 @@ describe("d5-agentic-chat script", () => {
     // Whitespace-only transcript — this is the common runtime-bug
     // signature the assertion is designed to surface.
     const page = makePageReturning("   ");
-    await expect(turn1.assertions!(page)).rejects.toThrow(/turn 1/);
+    await expect(
+      turn1.assertions!(page, { bubbleIndex: 0, text: "" }),
+    ).rejects.toThrow(/turn 1/);
   });
 });

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-custom.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-custom.test.ts
@@ -54,6 +54,20 @@ function makeAssertionPage(opts: {
   };
 }
 
+/**
+ * Synthetic turn ctx for direct `turn.assertions(page, ctx)` invocations
+ * in unit tests. The runner sources ctx from `waitForTurnComplete`'s
+ * return value in production; tests that drive `turn.assertions`
+ * directly must supply their own ctx since the contract is now
+ * required (Phase 5 cutover).
+ */
+function syntheticCtx(
+  text = "",
+  bubbleIndex = 0,
+): { bubbleIndex: number; text: string } {
+  return { bubbleIndex, text };
+}
+
 describe("d5-gen-ui-custom script", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -120,7 +134,9 @@ describe("d5-gen-ui-custom script", () => {
       },
     });
 
-    await expect(turn.assertions!(page)).rejects.toThrow(/no <svg> rendered/);
+    await expect(turn.assertions!(page, syntheticCtx())).rejects.toThrow(
+      /no <svg> rendered/,
+    );
   });
 
   it("pie chart: assertion FAILS when SVG has too few drawing children", async () => {
@@ -146,7 +162,9 @@ describe("d5-gen-ui-custom script", () => {
       },
     });
 
-    await expect(turn.assertions!(page)).rejects.toThrow(/1 drawing children/);
+    await expect(turn.assertions!(page, syntheticCtx())).rejects.toThrow(
+      /1 drawing children/,
+    );
   });
 
   it("pie chart: assertion FAILS when assistant follow-up is missing expected tokens", async () => {
@@ -175,7 +193,12 @@ describe("d5-gen-ui-custom script", () => {
       },
     });
 
-    await expect(turn.assertions!(page)).rejects.toThrow(/missing tokens/);
+    await expect(
+      turn.assertions!(
+        page,
+        syntheticCtx("Done — let me know if you want anything else."),
+      ),
+    ).rejects.toThrow(/missing tokens/);
   });
 
   it("pie chart: assertion PASSES on a healthy donut render with full narration", async () => {
@@ -204,7 +227,14 @@ describe("d5-gen-ui-custom script", () => {
       },
     });
 
-    await expect(turn.assertions!(page)).resolves.toBeUndefined();
+    await expect(
+      turn.assertions!(
+        page,
+        syntheticCtx(
+          "Pie chart rendered above — Electronics is the largest slice, followed by Clothing, Food, and Books.",
+        ),
+      ),
+    ).resolves.toBeUndefined();
   });
 
   // --- Haiku card path (all non-LGP integrations) ---
@@ -230,7 +260,7 @@ describe("d5-gen-ui-custom script", () => {
       },
     });
 
-    await expect(turn.assertions!(page)).rejects.toThrow(
+    await expect(turn.assertions!(page, syntheticCtx())).rejects.toThrow(
       /no haiku card or rendered component/,
     );
   });
@@ -262,7 +292,9 @@ describe("d5-gen-ui-custom script", () => {
       },
     });
 
-    await expect(turn.assertions!(page)).rejects.toThrow(/zero children/);
+    await expect(turn.assertions!(page, syntheticCtx())).rejects.toThrow(
+      /zero children/,
+    );
   });
 
   it("haiku: assertion PASSES on a healthy haiku card render (no narration check)", async () => {
@@ -295,7 +327,9 @@ describe("d5-gen-ui-custom script", () => {
       },
     });
 
-    await expect(turn.assertions!(page)).resolves.toBeUndefined();
+    await expect(
+      turn.assertions!(page, syntheticCtx()),
+    ).resolves.toBeUndefined();
   });
 
   it("haiku: assertion PASSES with fallback selector (no testid)", async () => {
@@ -328,6 +362,8 @@ describe("d5-gen-ui-custom script", () => {
       },
     });
 
-    await expect(turn.assertions!(page)).resolves.toBeUndefined();
+    await expect(
+      turn.assertions!(page, syntheticCtx()),
+    ).resolves.toBeUndefined();
   });
 });

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-custom.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-custom.ts
@@ -29,11 +29,7 @@
 import { registerD5Script } from "../helpers/d5-registry.js";
 import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
-import {
-  readLastAssistantText,
-  readSvgChartShape,
-  waitForGenUiComponent,
-} from "./_gen-ui-shared.js";
+import { readSvgChartShape, waitForGenUiComponent } from "./_gen-ui-shared.js";
 
 /**
  * Integrations that register chart tools (`render_pie_chart` and/or
@@ -92,7 +88,7 @@ export function buildTurns(ctx: D5BuildContext): ConversationTurn[] {
   return [
     {
       input: usePieChart ? PIE_CHART_USER_MESSAGE : HAIKU_USER_MESSAGE,
-      assertions: async (page) => {
+      assertions: async (page, ctx) => {
         // 1. Cascade-find the rendered component. Gen-UI components
         //    surface through the same selector hooks regardless of which
         //    tool fired.
@@ -110,7 +106,18 @@ export function buildTurns(ctx: D5BuildContext): ConversationTurn[] {
           // Narration check: the second-leg LLM response must
           // mention the chart. Token-level so wording drift doesn't
           // fail the probe.
-          const text = (await readLastAssistantText(page)).toLowerCase();
+          //
+          // `ctx.text` is the SAME turn-scoped text resolved by the
+          // runner's settle path — the values returned by
+          // `waitForTurnComplete` (turn-indexed bubble lookup, defect-2
+          // safe). We no longer read `readLastAssistantText` here
+          // because that returned `list[list.length - 1]` and could
+          // leak a later turn's bubble into THIS turn's assertions.
+          //
+          // `ctx` is REQUIRED on the runner's `ConversationTurn` type;
+          // unit tests driving `turn.assertions` directly must supply
+          // a synthetic ctx (`{ bubbleIndex, text }`).
+          const text = ctx.text.toLowerCase();
           console.debug("[d5-gen-ui-custom] pie chart follow-up text check", {
             expectedTokens: [...PIE_CHART_FOLLOWUP_TOKENS],
             assistantText: text.slice(0, 300),

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-open-advanced.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-open-advanced.ts
@@ -117,7 +117,12 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
   return [
     {
       input: "Inline expression evaluator",
-      assertions: assertAdvancedIframe,
+      // Wrapped so the assertions callback ignores the Phase-4 `ctx`
+      // argument: `assertAdvancedIframe` takes `(page, timeoutMs?)`, not
+      // `(page, ctx)`, and ctx is irrelevant to the iframe-mount probe.
+      assertions: async (page) => {
+        await assertAdvancedIframe(page);
+      },
     },
   ];
 }

--- a/showcase/harness/src/probes/scripts/d5-hitl-approve-deny.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-hitl-approve-deny.test.ts
@@ -87,7 +87,7 @@ describe("d5-hitl-approve-deny script", () => {
       },
     };
 
-    await turns[0]!.assertions!(page);
+    await turns[0]!.assertions!(page, { bubbleIndex: 0, text: "" });
     // Approve button was clicked.
     expect(
       calls.some((c) => c.method === "click" && c.selector.includes("approve")),
@@ -117,9 +117,9 @@ describe("d5-hitl-approve-deny script", () => {
       // intentionally NOT providing `click`
     } as unknown as import("../helpers/conversation-runner.js").Page;
 
-    await expect(turns[0]!.assertions!(pageWithoutClick)).rejects.toThrow(
-      /missing click/,
-    );
+    await expect(
+      turns[0]!.assertions!(pageWithoutClick, { bubbleIndex: 0, text: "" }),
+    ).rejects.toThrow(/missing click/);
   });
 
   it("anchors approve-button selectors under the resolved approval-dialog selector", async () => {
@@ -168,7 +168,7 @@ describe("d5-hitl-approve-deny script", () => {
       },
     };
 
-    await turns[0]!.assertions!(page);
+    await turns[0]!.assertions!(page, { bubbleIndex: 0, text: "" });
 
     // Dialog overlay selector queried first (outermost portal'd element).
     expect(seenSelectors[0]).toBe('[data-testid="approval-dialog-overlay"]');
@@ -209,7 +209,9 @@ describe("d5-hitl-approve-deny script", () => {
       },
     };
 
-    await expect(turns[0]!.assertions!(page)).rejects.toThrow(/missing token/);
+    await expect(
+      turns[0]!.assertions!(page, { bubbleIndex: 0, text: "" }),
+    ).rejects.toThrow(/missing token/);
   });
 });
 

--- a/showcase/harness/src/probes/scripts/d5-hitl-text-input.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-hitl-text-input.test.ts
@@ -69,7 +69,7 @@ describe("d5-hitl-text-input script", () => {
       },
     };
 
-    await turns[0]!.assertions!(page);
+    await turns[0]!.assertions!(page, { bubbleIndex: 0, text: "" });
     // Time-picker card was probed AND a slot button was clicked.
     expect(
       calls.some(
@@ -103,7 +103,9 @@ describe("d5-hitl-text-input script", () => {
       },
     };
 
-    await expect(turns[0]!.assertions!(page)).rejects.toThrow(/missing token/);
+    await expect(
+      turns[0]!.assertions!(page, { bubbleIndex: 0, text: "" }),
+    ).rejects.toThrow(/missing token/);
   });
 });
 

--- a/showcase/harness/src/probes/scripts/d5-mcp-apps.ts
+++ b/showcase/harness/src/probes/scripts/d5-mcp-apps.ts
@@ -132,7 +132,12 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
     {
       input:
         "Open Excalidraw and sketch a system diagram with a client, server, and database.",
-      assertions: assertIframePresent,
+      // Wrapped so the assertions callback ignores the Phase-4 `ctx`
+      // argument: `assertIframePresent` takes `(page, timeoutMs?)`, not
+      // `(page, ctx)`, and ctx is irrelevant to the iframe-mount probe.
+      assertions: async (page) => {
+        await assertIframePresent(page);
+      },
     },
   ];
 }

--- a/showcase/harness/src/probes/scripts/d5-multimodal.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-multimodal.test.ts
@@ -135,6 +135,7 @@ describe("d5-multimodal script", () => {
     await expect(
       turns[0]!.assertions!(
         makePage("the image attachment shows a small abstract test pattern"),
+        { bubbleIndex: 0, text: "" },
       ),
     ).resolves.toBeUndefined();
   });
@@ -150,7 +151,10 @@ describe("d5-multimodal script", () => {
     // the assertion has time to exhaust its budget and throw the
     // missing-keyword error.
     await expect(
-      turns[0]!.assertions!(makePage("nothing here")),
+      turns[0]!.assertions!(makePage("nothing here"), {
+        bubbleIndex: 0,
+        text: "",
+      }),
     ).rejects.toThrow(/missing keyword "image"/);
   }, 8_000);
 });

--- a/showcase/harness/src/probes/scripts/d5-shared-state.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-shared-state.test.ts
@@ -137,9 +137,9 @@ describe("d5-shared-state turn 2 invariant (state retention)", () => {
       evaluateText: "i don't recall any preferences from our conversation.",
     });
 
-    await expect(turn2.assertions!(page)).rejects.toThrow(
-      /shared state did not persist/i,
-    );
+    await expect(
+      turn2.assertions!(page, { bubbleIndex: 0, text: "" }),
+    ).rejects.toThrow(/shared state did not persist/i);
   });
 
   it("PASSES when the response contains 'blue'", async () => {
@@ -151,7 +151,9 @@ describe("d5-shared-state turn 2 invariant (state retention)", () => {
     });
 
     // Assertion must NOT throw on a passing response.
-    await expect(turn2.assertions!(page)).resolves.toBeUndefined();
+    await expect(
+      turn2.assertions!(page, { bubbleIndex: 0, text: "" }),
+    ).resolves.toBeUndefined();
   });
 
   it("FAILS when no assistant message text is found at all", async () => {
@@ -160,9 +162,9 @@ describe("d5-shared-state turn 2 invariant (state retention)", () => {
 
     const page = makePage({ evaluateText: "" });
 
-    await expect(turn2.assertions!(page)).rejects.toThrow(
-      /no assistant message text found/i,
-    );
+    await expect(
+      turn2.assertions!(page, { bubbleIndex: 0, text: "" }),
+    ).rejects.toThrow(/no assistant message text found/i);
   });
 });
 
@@ -175,7 +177,9 @@ describe("d5-shared-state turn 1 relevance check", () => {
       evaluateText: "got it — i have noted that your favorite color is blue.",
     });
 
-    await expect(turn1.assertions!(page)).resolves.toBeUndefined();
+    await expect(
+      turn1.assertions!(page, { bubbleIndex: 0, text: "" }),
+    ).resolves.toBeUndefined();
   });
 
   it("FAILS when response is unrelated (no color/blue mention)", async () => {
@@ -186,9 +190,9 @@ describe("d5-shared-state turn 1 relevance check", () => {
       evaluateText: "ok, what else would you like to discuss?",
     });
 
-    await expect(turn1.assertions!(page)).rejects.toThrow(
-      /did not mention color\/blue/i,
-    );
+    await expect(
+      turn1.assertions!(page, { bubbleIndex: 0, text: "" }),
+    ).rejects.toThrow(/did not mention color\/blue/i);
   });
 
   it("FAILS when no assistant message text is found at all", async () => {
@@ -197,9 +201,9 @@ describe("d5-shared-state turn 1 relevance check", () => {
 
     const page = makePage({ evaluateText: "" });
 
-    await expect(turn1.assertions!(page)).rejects.toThrow(
-      /no assistant message text found/i,
-    );
+    await expect(
+      turn1.assertions!(page, { bubbleIndex: 0, text: "" }),
+    ).rejects.toThrow(/no assistant message text found/i);
   });
 });
 

--- a/showcase/harness/src/probes/scripts/d5-subagents.ts
+++ b/showcase/harness/src/probes/scripts/d5-subagents.ts
@@ -239,7 +239,12 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
   return [
     {
       input: USER_PROMPT,
-      assertions: assertSubagentsChain,
+      // Wrapped so the assertions callback ignores the Phase-4 `ctx`
+      // argument: `assertSubagentsChain` takes `(page, timeoutMs?, dwellMs?)`,
+      // not `(page, ctx)`, and ctx is irrelevant to the chain-card probe.
+      assertions: async (page) => {
+        await assertSubagentsChain(page);
+      },
       // The chain involves 3 LLM round-trips; bump the per-turn
       // response timeout to match the polling budget so the runner
       // doesn't declare timeout BEFORE the assertion has a chance to

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-default-catchall.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-default-catchall.ts
@@ -200,7 +200,12 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
   return [
     {
       input: "forecast for Tokyo",
-      assertions: assertDefaultCatchall,
+      // Wrapped so the assertions callback ignores the Phase-4 `ctx`
+      // argument: `assertDefaultCatchall` takes `(page, timeoutMs?)`, not
+      // `(page, ctx)`, and ctx is irrelevant to the default-catchall probe.
+      assertions: async (page) => {
+        await assertDefaultCatchall(page);
+      },
     },
   ];
 }

--- a/showcase/harness/src/probes/scripts/d5-voice.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-voice.test.ts
@@ -181,7 +181,9 @@ describe("d5-voice script", () => {
         evaluateValues: ["the weather in tokyo is 22°c and partly cloudy"],
       });
 
-      await expect(turn.assertions!(page)).resolves.toBeUndefined();
+      await expect(
+        turn.assertions!(page, { bubbleIndex: 0, text: "" }),
+      ).resolves.toBeUndefined();
     });
 
     it("passes on temperature-only mention (matches the weather/tokyo/temperature OR cascade)", async () => {
@@ -195,7 +197,9 @@ describe("d5-voice script", () => {
         evaluateValues: ["current temperature: 22 degrees"],
       });
 
-      await expect(turn.assertions!(page)).resolves.toBeUndefined();
+      await expect(
+        turn.assertions!(page, { bubbleIndex: 0, text: "" }),
+      ).resolves.toBeUndefined();
     });
 
     it("throws when the assistant transcript is unrelated to weather", async () => {
@@ -212,9 +216,9 @@ describe("d5-voice script", () => {
       // The assertion polls for up to 5s before giving up — give the
       // test enough headroom to observe the rejection rather than
       // racing it against vitest's default 5000ms timeout.
-      await expect(turn.assertions!(page)).rejects.toThrow(
-        /assistant transcript missing weather\/Tokyo content/,
-      );
+      await expect(
+        turn.assertions!(page, { bubbleIndex: 0, text: "" }),
+      ).rejects.toThrow(/assistant transcript missing weather\/Tokyo content/);
     }, 10_000);
   });
 });

--- a/showcase/harness/test/integration/bubble-race-mechanisms.test.ts
+++ b/showcase/harness/test/integration/bubble-race-mechanisms.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { chromium, type Browser } from "playwright";
+import { countAssistantMessages } from "../../src/probes/helpers/assistant-message-count.js";
+import { installPrePaintFromEnv } from "../../src/probes/helpers/init-scripts.js";
+import { runBubbleRaceRepro } from "./bubble-race-repro.js";
+
+/**
+ * Snapshot env keys, apply overrides, run `fn`, then restore the original
+ * values in a try/finally — even if `fn` throws. Snapshots are taken at
+ * call time (NOT at module load), so concurrent/serial sibling tests
+ * cannot poison the captured "original" via vitest singleFork reuse.
+ *
+ * `undefined` in the overrides map deletes the key for the duration of
+ * `fn` and restores whatever was there before (which may itself be
+ * `undefined`, in which case the restore is a `delete`).
+ */
+async function withEnv<T>(
+  overrides: Record<string, string | undefined>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const keys = Object.keys(overrides);
+  const snapshot: Record<string, string | undefined> = {};
+  for (const k of keys) {
+    snapshot[k] = process.env[k];
+  }
+  for (const k of keys) {
+    const v = overrides[k];
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const k of keys) {
+      const v = snapshot[k];
+      if (v === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = v;
+      }
+    }
+  }
+}
+
+/**
+ * Mechanism-GREEN retrofit for s1/s4/s5.
+ *
+ * s1 landed the conversation driver + production diagnostic log
+ * `[conversation-runner] turn N/total — settled text { turnNum, text }`
+ * that the test harness parses out of subprocess stdout.
+ *
+ * s4 landed `installPrePaintFromEnv` — the Playwright `addInitScript`
+ * hook that injects `BUBBLE_RACE_PRE_PAINT` HTML at document_start so
+ * the runner's first cascade count poll sees a non-zero count. The
+ * boot-time baselineCount read this once supported was deleted in the
+ * `waitForTurnComplete` cutover; this test verifies the injection
+ * mechanism itself via direct DOM observation.
+ *
+ * s5 (carried forward via s6 in this worktree) landed the shared
+ * `countAssistantMessages` cascade helper — the single source of truth
+ * for the d5/d6 driver, conversation runner, and diagnostics paths.
+ *
+ * These three mechanisms previously had no slot-owned mechanism-GREEN
+ * tests — downstream slots verified them indirectly. This file pins
+ * each one explicitly so future regressions surface at the mechanism
+ * boundary, not three layers downstream.
+ */
+
+describe("bubble-race mechanism — s1 driver production diagnostic log", () => {
+  it("emits parseable turn-settled lines and the driver parses them", async () => {
+    const result = await runBubbleRaceRepro({
+      slug: "langgraph-python:agentic-chat",
+      level: "d5",
+      messages: ["good name for a goldfish"],
+    });
+    // The production log line the driver depends on:
+    //   [conversation-runner] turn N/total — settled text { turnNum: …, text: '…' }
+    // util.inspect renders the structured 2nd-arg with single-quoted
+    // string fields, so the regex looks for a `text: '…'` member with
+    // standard escape semantics.
+    const productionLineRe =
+      /\[conversation-runner\] turn (\d+)\/\d+ — settled text \{[^}]*text:\s*'(?:[^'\\]|\\.)*'/;
+    expect(result.stdout).toMatch(productionLineRe);
+    // And the driver actually parsed at least one turn out of stdout.
+    expect(result.turns.length).toBeGreaterThanOrEqual(1);
+  }, 120_000);
+});
+
+describe("bubble-race mechanism — s4 installPrePaintFromEnv", () => {
+  // Direct DOM observation: spawn a fresh chromium Page, set
+  // BUBBLE_RACE_PRE_PAINT, install the hook via the SAME helper the d6
+  // driver uses, navigate to a blank data: URL, and assert the injected
+  // placeholder is in the DOM by the time `load` fires.
+  //
+  // Why direct-observation rather than the full subprocess repro: the
+  // prior version of this test relied on a `[conversation-runner] initial
+  // baseline assistant message count (boot) { baselineCount: N }` log
+  // line emitted by the runner. That log line was deleted alongside the
+  // pre-turn baseline-count read in the `waitForTurnComplete` cutover
+  // (1-based turn ordinals replaced the pre-turn count), so there is no
+  // longer a runner-emitted signal to grep for. Observing the DOM the
+  // mechanism actually mutates pins the wiring at its own boundary —
+  // independent of how downstream consumers happen to log today.
+  let browser: Browser | undefined;
+
+  afterAll(async () => {
+    if (browser) await browser.close();
+  });
+
+  it("injects a role=article placeholder visible in the DOM after load", async () => {
+    // role="article" intentionally matches tier 3 of the cascade
+    // (`[role="article"]:not([data-message-role="user"])`), so the
+    // shared `countAssistantMessages` helper sees it — proving the
+    // addInitScript wiring fired before `load`. data-bubble-race-marker
+    // is a stable hook that isolates the injected node from any other
+    // role="article" content the navigated page might carry.
+    //
+    // Env-var lifecycle is owned by `withEnv` — snapshot at call time,
+    // restore in try/finally — so vitest singleFork cannot leak the
+    // override into sibling tests that run before/after this one.
+    await withEnv(
+      {
+        BUBBLE_RACE_PRE_PAINT:
+          '<div role="article" data-bubble-race-marker>placeholder</div>',
+      },
+      async () => {
+        browser = await chromium.launch({
+          headless: true,
+          args: ["--no-sandbox", "--disable-dev-shm-usage"],
+        });
+        const ctx = await browser.newContext();
+        const page = await ctx.newPage();
+        try {
+          // Install the hook BEFORE navigation — addInitScript only fires
+          // for subsequent navigations, matching how d6-all-pills.ts wires
+          // it (`installPrePaintFromEnv(page)` before `page.goto`).
+          await installPrePaintFromEnv(page);
+
+          // Navigate to a blank data: URL. The page itself has no
+          // assistant-message DOM, so any non-zero count comes from the
+          // injected placeholder alone.
+          const dataUrl =
+            "data:text/html;charset=utf-8," +
+            encodeURIComponent("<!doctype html><html><body></body></html>");
+          await page.goto(dataUrl);
+
+          // Marker node is in the DOM.
+          const markerCount = await page
+            .locator("[data-bubble-race-marker]")
+            .count();
+          expect(markerCount).toBe(1);
+
+          // And the shared cascade helper sees it via tier 3 — this is
+          // the exact path the runner's first count poll uses.
+          const cascadeCount = await countAssistantMessages(page);
+          expect(cascadeCount).toBeGreaterThan(0);
+        } finally {
+          await ctx.close();
+        }
+      },
+    );
+  }, 30_000);
+
+  it("re-injects the placeholder on same-context navigation (each navigation gets a fresh realm)", async () => {
+    // Pins the navigation re-entry contract for the pre-paint init
+    // script. `addInitScript` re-runs at document_start of EVERY
+    // navigation in the context; each navigation is a fresh JS realm
+    // with a fresh `globalThis`, so the script's outer
+    // `__bubble_race_prepaint_installed` guard is `undefined` on entry
+    // and the placeholder is re-injected. A regression where state is
+    // aliased across navigations (e.g. via a context-level singleton)
+    // would leave the second page without the placeholder and fail
+    // this test.
+    await withEnv(
+      {
+        BUBBLE_RACE_PRE_PAINT:
+          '<div role="article" data-bubble-race-marker>placeholder</div>',
+      },
+      async () => {
+        if (!browser) {
+          browser = await chromium.launch({
+            headless: true,
+            args: ["--no-sandbox", "--disable-dev-shm-usage"],
+          });
+        }
+        const ctx = await browser.newContext();
+        const page = await ctx.newPage();
+        try {
+          await installPrePaintFromEnv(page);
+
+          // Same-context navigation #1 — to a blank data: URL.
+          const dataUrlA =
+            "data:text/html;charset=utf-8," +
+            encodeURIComponent(
+              "<!doctype html><html><body><p>page-a</p></body></html>",
+            );
+          await page.goto(dataUrlA);
+          expect(await page.locator("[data-bubble-race-marker]").count()).toBe(
+            1,
+          );
+
+          // Same-context navigation #2 — to a DIFFERENT blank data: URL
+          // on the SAME page in the SAME context. If the navigation
+          // re-entry contract holds, addInitScript fires again, the
+          // outer guard is `undefined` in the fresh realm, and the
+          // placeholder reappears in the new document. If state leaks
+          // across navigations, the count is 0 and this fails.
+          const dataUrlB =
+            "data:text/html;charset=utf-8," +
+            encodeURIComponent(
+              "<!doctype html><html><body><p>page-b</p></body></html>",
+            );
+          await page.goto(dataUrlB);
+          expect(await page.locator("[data-bubble-race-marker]").count()).toBe(
+            1,
+          );
+
+          // And the shared cascade helper still sees it via tier 3.
+          const cascadeCount = await countAssistantMessages(page);
+          expect(cascadeCount).toBeGreaterThan(0);
+        } finally {
+          await ctx.close();
+        }
+      },
+    );
+  }, 30_000);
+});
+
+describe("bubble-race mechanism — s5 countAssistantMessages cascade", () => {
+  let browser: Browser | undefined;
+
+  afterAll(async () => {
+    if (browser) await browser.close();
+  });
+
+  /**
+   * Spin up a real chromium Page against a `data:` URL containing the
+   * desired tier-only DOM, then assert `countAssistantMessages(page)`
+   * returns the expected count. This pins the cascade ordering at the
+   * mechanism boundary — first-non-zero-tier wins.
+   *
+   * The pages are designed so ONLY the targeted tier has matches:
+   * - Tier 1 page has data-testid nodes (no role/data-message-role).
+   * - Tier 2 page has role="article" + data-message-role="assistant".
+   * - Tier 3 page has role="article" only (no data-message-role).
+   * - Tier 4 page has data-message-role="assistant" only (no role).
+   */
+  async function loadPage(html: string) {
+    if (!browser) {
+      browser = await chromium.launch({
+        headless: true,
+        args: ["--no-sandbox", "--disable-dev-shm-usage"],
+      });
+    }
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    const dataUrl =
+      "data:text/html;charset=utf-8," +
+      encodeURIComponent(`<!doctype html><html><body>${html}</body></html>`);
+    await page.goto(dataUrl);
+    return { page, ctx };
+  }
+
+  it("tier 1 (data-testid=copilot-assistant-message) wins with count = 2", async () => {
+    const tier1 = Array.from({ length: 2 })
+      .map(() => '<div data-testid="copilot-assistant-message">x</div>')
+      .join("");
+    const { page, ctx } = await loadPage(tier1);
+    try {
+      const n = await countAssistantMessages(page);
+      expect(n).toBe(2);
+    } finally {
+      await ctx.close();
+    }
+  }, 30_000);
+
+  it("tier 2 (role=article + data-message-role=assistant) wins with count = 3", async () => {
+    const tier2 = Array.from({ length: 3 })
+      .map(() => '<div role="article" data-message-role="assistant">x</div>')
+      .join("");
+    const { page, ctx } = await loadPage(tier2);
+    try {
+      const n = await countAssistantMessages(page);
+      expect(n).toBe(3);
+    } finally {
+      await ctx.close();
+    }
+  }, 30_000);
+
+  it("tier 3 (role=article, no data-message-role) wins with count = 4", async () => {
+    const tier3 = Array.from({ length: 4 })
+      .map(() => '<div role="article">x</div>')
+      .join("");
+    const { page, ctx } = await loadPage(tier3);
+    try {
+      const n = await countAssistantMessages(page);
+      expect(n).toBe(4);
+    } finally {
+      await ctx.close();
+    }
+  }, 30_000);
+
+  it("tier 4 (data-message-role=assistant, no role) wins with count = 5", async () => {
+    const tier4 = Array.from({ length: 5 })
+      .map(() => '<div data-message-role="assistant">x</div>')
+      .join("");
+    const { page, ctx } = await loadPage(tier4);
+    try {
+      const n = await countAssistantMessages(page);
+      expect(n).toBe(5);
+    } finally {
+      await ctx.close();
+    }
+  }, 30_000);
+});

--- a/showcase/harness/test/integration/bubble-race-repro-defect-1.test.ts
+++ b/showcase/harness/test/integration/bubble-race-repro-defect-1.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { runBubbleRaceRepro } from "./bubble-race-repro.js";
+
+describe("bubble-race repro (defect 1: settle-on-count-not-text)", () => {
+  it("reads non-empty text from the assistant bubble on fast SSE replay", async () => {
+    const result = await runBubbleRaceRepro({
+      slug: "langgraph-python:agentic-chat",
+      level: "d5",
+      messages: ["good name for a goldfish"],
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.turns).toHaveLength(1);
+    // The defect manifests as the runner reading the empty wrapper or a
+    // partial-stream prefix (e.g. "I" or "Th") that satisfies a naive
+    // /[A-Za-z]/ regex while STILL representing the very settle-on-count-
+    // not-text bug we're guarding against. Two layered assertions pin
+    // the canonical, fully-streamed response:
+    //   (a) non-trivial length (the empty wrapper or 1-2 char prefix
+    //       both fail this) — defends against the partial-prefix case
+    //       that motivated this strengthening.
+    //   (b) presence of "Bubbles" — the canonical fixture token for
+    //       "good name for a goldfish" (see aimock/d6/langgraph-python/
+    //       agentic-chat.json; same token defect-2 turn-1 asserts on).
+    expect(result.turns[0].assistantText.trim().length).toBeGreaterThanOrEqual(
+      10,
+    );
+    expect(result.turns[0].assistantText).toContain("Bubbles");
+  }, 120_000);
+});

--- a/showcase/harness/test/integration/bubble-race-repro-defect-2.test.ts
+++ b/showcase/harness/test/integration/bubble-race-repro-defect-2.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { runBubbleRaceRepro } from "./bubble-race-repro.js";
+
+/**
+ * Phase 1 Task 1.2 — defect 2 (un-turn-scoped bubble selection).
+ *
+ * This file pairs the defect-RED test with a mechanism-GREEN test for
+ * `messagesOverrideFromEnv()` (the Node-side helper in
+ * `harness/src/probes/helpers/init-scripts.ts` consumed at the
+ * `runConversation` callsite in `d6-all-pills.ts:1697`). The
+ * mechanism-GREEN exists so a wiring regression of the override
+ * channel surfaces immediately rather than masquerading as a
+ * defect-2 failure. Per the user's tight-TDD-loop directive, the
+ * mechanism test is asserted to PASS against the current state
+ * (Phase-1 baseline at s4 commit 69b383d0c) before the defect-RED
+ * test is permitted to run.
+ *
+ * Inputs use the canonical 3-turn sequence from
+ * `aimock/d6/langgraph-python/agentic-chat.json`:
+ *   1. "good name for a goldfish" -> response contains "Bubbles"
+ *   2. "name for its tank"        -> response contains "Bubble Bowl"
+ *   3. "what we named the goldfish" -> recall, response contains
+ *      BOTH "Bubbles" AND "Bubble Bowl"
+ *
+ * Defect-2 manifests because `readLastAssistantText` in
+ * `_gen-ui-shared.ts` reads `list[list.length - 1]` GLOBALLY (i.e.
+ * the last bubble in the DOM at the moment of read), not the bubble
+ * for the just-settled turn. On a 3-turn fixture with no mid-stream
+ * cascade flicker, turn N's "last bubble" is the right one once
+ * the COUNT settles, but the defect surfaces in two ways:
+ *   (a) any cascade flicker between tiers mid-stream causes the
+ *       "last" index to point at the wrong tier's list.
+ *   (b) more importantly: turn N is supposed to read the bubble at
+ *       INDEX N-1 (0-based), not the last index. The current
+ *       implementation conflates "count grew past baseline" with
+ *       "last bubble is mine"; under the new turn-indexed contract,
+ *       a per-turn substring assertion will pin the correct read.
+ *
+ * Even on the happy path, turn-1's read can race the SSE stream
+ * for turn-2 if the count-baseline settle window closes before
+ * turn-2's bubble appears: turn-1's "last" suddenly becomes
+ * turn-2's content. The substring assertion fails for the right
+ * reason: turn 1 reads "Bubble Bowl" (turn-2's marker) instead of
+ * "Bubbles" (turn-1's marker).
+ */
+
+describe("bubble-race repro (defect 2: mechanism-GREEN — messagesOverrideFromEnv)", () => {
+  it("BUBBLE_RACE_MESSAGES drives the canonical 3-turn sequence through the harness end-to-end", async () => {
+    const messages = [
+      "good name for a goldfish",
+      "name for its tank",
+      "what we named the goldfish",
+    ];
+    const result = await runBubbleRaceRepro({
+      slug: "langgraph-python:agentic-chat",
+      level: "d5",
+      messages,
+    });
+    expect(result.exitCode).toBe(0);
+    // 3 settled turns means messagesOverrideFromEnv() got past the
+    // env parse, became 3 ConversationTurns, was selected at the
+    // override callsite, and each turn drove a settled assistant
+    // response. This is the end-to-end wiring proof.
+    expect(result.turns).toHaveLength(3);
+    // Each of the 3 user inputs was echoed by the runner's
+    // `[conversation-runner] turn N/total — sending message
+    //  { input: '<msg>', ... }` log immediately before the send.
+    // util.inspect renders the object across multiple lines, so the
+    // regex uses [\s\S]*? to span the structured-2nd-arg block. The
+    // sending-message log is emitted BEFORE the settle wait, so it
+    // is present even on turns that would later mis-settle — making
+    // this assertion strictly about the SEND-channel wiring, not
+    // about settled assistant text.
+    for (const msg of messages) {
+      const escaped = msg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const sendRe = new RegExp(
+        `\\[conversation-runner\\] turn \\d+/\\d+ — sending message[\\s\\S]*?input:\\s*'${escaped}'`,
+        "m",
+      );
+      expect(
+        result.stdout,
+        `expected stdout to contain a sending-message log echoing input='${msg}'`,
+      ).toMatch(sendRe);
+    }
+  }, 240_000);
+});
+
+describe("bubble-race repro (defect 2: un-turn-scoped bubble selection)", () => {
+  it("reads each turn's distinct text in order across the canonical 3-turn fixture", async () => {
+    const result = await runBubbleRaceRepro({
+      slug: "langgraph-python:agentic-chat",
+      level: "d5",
+      messages: [
+        "good name for a goldfish",
+        "name for its tank",
+        "what we named the goldfish",
+      ],
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.turns).toHaveLength(3);
+    // Turn 1's canonical response: "How about Bubbles? It is friendly, ..."
+    // Defect-2 manifests when turn-1's read picks up turn-2's or
+    // turn-3's content via the global `list[last]` selector.
+    expect(result.turns[0].assistantText).toContain("Bubbles");
+    expect(result.turns[0].assistantText).not.toContain("Bubble Bowl");
+    // Turn 2's canonical response: "Following the Bubbles theme, you
+    // could call the tank The Bubble Bowl. ..."
+    expect(result.turns[1].assistantText).toContain("Bubble Bowl");
+    // Turn 3's canonical response is the recall confirmation:
+    // "We named the goldfish Bubbles, and the tank The Bubble Bowl."
+    // The recall is distinguished by containing BOTH names AND the
+    // "named" verb (turn 1's "Bubbles" line never uses "named").
+    expect(result.turns[2].assistantText).toContain("Bubbles");
+    expect(result.turns[2].assistantText).toContain("Bubble Bowl");
+    expect(result.turns[2].assistantText).toMatch(/named/i);
+  }, 240_000);
+});

--- a/showcase/harness/test/integration/bubble-race-repro-defect-3.test.ts
+++ b/showcase/harness/test/integration/bubble-race-repro-defect-3.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { runBubbleRaceRepro } from "./bubble-race-repro.js";
+
+/**
+ * Defect 3 — diagnostic selector blindness under cascade fallback (closed).
+ *
+ * Historical context: `captureDiagnostics` in `d6-all-pills.ts` originally
+ * queried ONLY the canonical `[data-testid="copilot-assistant-message"]`
+ * selector to compute `assistantMsgCount`, while the conversation runner
+ * cascaded through four tiers (canonical → tagged article → non-user
+ * article → headless `[data-message-role="assistant"]`). Demos whose
+ * bubbles only satisfied a non-canonical tier produced "RED with no
+ * errors" diagnostics — the runner settled correctly via the fallback
+ * tier, but the diagnostic read was blind to the bubble. The runner's
+ * own `[conversation-runner] turn N/total — settled text { turnNum, text }`
+ * log line previously read via the same canonical-only selector, so a
+ * settled-via-fallback turn would log empty text.
+ *
+ * Phase 2 (s6) consolidated the cascade behind `countAssistantMessages` /
+ * `findAssistantBubbleAt` and routed both `captureDiagnostics` and the
+ * conversation runner's settled-text read through it. The runner now
+ * sources `settled text` from `waitForTurnComplete`'s
+ * `findAssistantBubbleAt(pwPage, bubbleIndex)` return value — the same
+ * cascade the count uses — so a tier-4-only demo like
+ * `langgraph-python:headless-simple` settles AND surfaces non-empty
+ * assistant text in the diagnostic log.
+ *
+ * Natural fallback target: `langgraph-python:headless-simple`. Its
+ * `AssistantBubble` component (showcase/integrations/langgraph-python
+ * /src/app/demos/headless-simple/message-bubble.tsx) emits
+ *   <div data-testid="headless-message-assistant"
+ *        data-message-role="assistant" …>
+ *     <p>…</p>
+ *   </div>
+ * — NO `data-testid="copilot-assistant-message"`, NO `role="article"`.
+ * Cascade tiers 1, 2, 3 all yield 0; tier 4 (`[data-message-role=
+ * "assistant"]` → `<p>` child read) matches. This test pins the
+ * post-cascade GREEN state: the runner finds the bubble AND the
+ * settled-text log is non-empty.
+ */
+describe("bubble-race repro (defect 3: diagnostic selector blindness — closed by shared cascade)", () => {
+  it("headless-simple settles a turn AND the runner's settled-text diagnostic reads via the cascade (non-empty)", async () => {
+    const result = await runBubbleRaceRepro({
+      slug: "langgraph-python:headless-simple",
+      level: "d5",
+      messages: ["Say hello in one short sentence"],
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.turns).toHaveLength(1);
+    // With the shared cascade in place, the settled-text diagnostic
+    // surfaces the tier-4 bubble's text. If this ever flips back to
+    // empty, defect-3 has regressed — the runner's `settled text` log
+    // is reading via a canonical-only selector again instead of the
+    // shared `findAssistantBubbleAt` cascade.
+    expect(result.turns[0].assistantText.trim().length).toBeGreaterThan(0);
+  }, 180_000);
+});

--- a/showcase/harness/test/integration/bubble-race-repro-defect-4.test.ts
+++ b/showcase/harness/test/integration/bubble-race-repro-defect-4.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { runBubbleRaceRepro } from "./bubble-race-repro.js";
+
+describe("bubble-race repro (defect 4: boot-time baseline staleness)", () => {
+  it("first turn completes within 30s when a pre-paint placeholder is present", async () => {
+    const start = Date.now();
+    const result = await runBubbleRaceRepro({
+      slug: "langgraph-python:agentic-chat",
+      level: "d5",
+      messages: ["good name for a goldfish"],
+      prePaint:
+        '<div role="article" data-bubble-race-placeholder>placeholder</div>',
+    });
+    const elapsedMs = Date.now() - start;
+    expect(result.exitCode).toBe(0);
+    // Defect manifests as a 30s+ settle-timeout. Assertion is on
+    // observable wall-clock + first-turn text — NOT on internal log
+    // strings or internal exception types unique to the old
+    // implementation (the test must survive the deletion of
+    // `waitForAssistantSettled` in Phase 5).
+    expect(elapsedMs).toBeLessThan(30_000);
+    expect(result.turns[0].assistantText.trim().length).toBeGreaterThan(0);
+  }, 90_000);
+});

--- a/showcase/harness/test/integration/bubble-race-repro.ts
+++ b/showcase/harness/test/integration/bubble-race-repro.ts
@@ -1,0 +1,163 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Resolve the showcase root relative to THIS source file so the repro
+// drives the same checkout the test is being run from (worktree or
+// main). Hard-coding /Users/jpr5/proj/cpk/cpk/showcase would drive the
+// main checkout from inside a worktree and the runner edits from the
+// worktree would never execute. The test file lives at
+// showcase/harness/test/integration/bubble-race-repro.ts; the showcase
+// root is three directories up.
+const SHOWCASE_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+);
+
+export interface BubbleRaceReproOpts {
+  /** Harness target — `<slug>` or `<slug>:<demo>` per cli.ts:52. */
+  slug: string;
+  /** Probe depth shorthand — one of "smoke"|"d4"|"d5"|"d6". */
+  level: "smoke" | "d4" | "d5" | "d6";
+  /**
+   * User messages to drive into the existing canonical fixture for
+   * `<slug>:<demo>`. The aimock match contract is content-based
+   * (userMessage + context), so per-scenario behavior is selected by
+   * sending the right message rather than swapping fixture files.
+   */
+  messages: string[];
+  /**
+   * Optional HTML injected via Playwright `addInitScript` BEFORE
+   * navigation — used by defect 4 only. Forwarded to the harness via
+   * the `BUBBLE_RACE_PRE_PAINT` env var; `helpers/init-scripts.ts`
+   * reads it and calls `page.addInitScript` against the d5/d6 drivers'
+   * pre-navigation hook (the first `page.goto` callsite for the path
+   * the test drives).
+   */
+  prePaint?: string;
+  /**
+   * Optional CSS selector whose matching nodes have their
+   * `data-testid` attribute stripped via Playwright `addInitScript`
+   * BEFORE navigation — used by defect 3 only when no natural
+   * cascade-fallback-only demo exists. Forwarded to the harness via
+   * the `BUBBLE_RACE_STRIP_SELECTOR` env var; `helpers/init-scripts.ts`
+   * reads it and calls `page.addInitScript` to remove the testid from
+   * any rendered node matching the selector, forcing the runner's
+   * cascade to fall through to a non-canonical tier.
+   */
+  prePaintStrip?: string;
+}
+
+export interface BubbleRaceTurnResult {
+  turnIndex: number;
+  assistantText: string;
+}
+
+export interface BubbleRaceReproResult {
+  exitCode: number;
+  turns: BubbleRaceTurnResult[];
+  /** Absolute path to the harness run-artifacts directory (parsed from stdout). */
+  runDir: string;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Drives `bin/showcase test <slug> --<level> --verbose` (which in turn
+ * runs `npx tsx harness/src/cli.ts test …` per cmd-test.sh:143). The
+ * harness runs from source — no Docker image of the harness exists in
+ * the local path. Parses per-turn assistant-text emissions out of
+ * verbose stdout.
+ *
+ * The driver depends on TWO production log lines added in the SAME
+ * commit that lands this driver:
+ *   1. `[conversation-runner] turn N/total — settled text { turnNum, text }`
+ *      — added inside the runner immediately after the existing
+ *      `assistant settled` debug block (~line 461), matching the
+ *      surrounding "turn N/total — phrase" + structured-2nd-arg
+ *      style. Moves into `waitForTurnComplete` in Phase 3 and
+ *      survives Phase 5 cutover.
+ *   2. `[harness] runDir=…` — the harness already prints the run
+ *      artifacts directory in --verbose mode; the driver captures it
+ *      out of stdout. If the existing log uses a different label,
+ *      adjust the parser accordingly (verified during Phase 0).
+ *
+ * Per-scenario behavior is configured via `messages` (the array of
+ * user inputs the harness sends — wired into the d5/d6 probe drivers'
+ * existing user-message channel) and optionally `prePaint` (defect 4
+ * only, forwarded via BUBBLE_RACE_PRE_PAINT env to init-scripts.ts).
+ */
+export async function runBubbleRaceRepro(
+  opts: BubbleRaceReproOpts,
+): Promise<BubbleRaceReproResult> {
+  const env = {
+    ...process.env,
+    BUBBLE_RACE_MESSAGES: JSON.stringify(opts.messages),
+    ...(opts.prePaint ? { BUBBLE_RACE_PRE_PAINT: opts.prePaint } : {}),
+    ...(opts.prePaintStrip
+      ? { BUBBLE_RACE_STRIP_SELECTOR: opts.prePaintStrip }
+      : {}),
+  };
+  // `--direct` runs d5/d6 via the in-process driver in cli.ts rather than
+  // the control-plane worker path. This is REQUIRED for the bubble-race
+  // repros because the driver parses `[conversation-runner] turn N/total —
+  // settled text …` lines out of the CLI subprocess's stdout; in
+  // control-plane mode, those logs are emitted inside a separate worker
+  // process whose stdout never reaches the CLI. The `--direct` switch is
+  // exposed by cmd-test.sh (line 17/62) and the harness CLI (cli.ts:80).
+  const proc = spawn(
+    "bin/showcase",
+    ["test", opts.slug, `--${opts.level}`, "--direct", "--verbose"],
+    { cwd: SHOWCASE_ROOT, env },
+  );
+  let stdout = "";
+  let stderr = "";
+  proc.stdout.on("data", (b) => (stdout += b.toString()));
+  proc.stderr.on("data", (b) => (stderr += b.toString()));
+  proc.on("error", (err) => {
+    console.warn(
+      `[bubble-race-repro] spawn error: ${(err as Error).message ?? err}`,
+    );
+  });
+  const exitCode: number = await new Promise((resolve) =>
+    proc.on("close", (code) => resolve(code ?? -1)),
+  );
+  const turns: BubbleRaceTurnResult[] = [];
+  // Match the structured-2nd-arg console.debug emission, e.g.
+  //   [conversation-runner] turn 1/3 — settled text { turnNum: 1, text: 'Bubbles' }
+  // The 2nd-arg object is rendered by Node's util.inspect when the
+  // shell captures stdout; the production emission shape is
+  // `{ turnNum: N, text: <quoted> }`. util.inspect picks the quote
+  // character based on string content: single quotes by default, but
+  // SWITCHES to double quotes when the string contains a `'` and no
+  // `"` (and backticks when it contains both). The parser must accept
+  // either single- or double-quoted form; the two-alternation regex
+  // below mirrors util.inspect's standard escape semantics for each
+  // (backslash-escape of the same quote + a literal backslash). The
+  // PRE-text segment is anchored on the literal `turnNum: <digits>,
+  // text:` key sequence rather than `[^}]*` so a stray `}` anywhere in
+  // the line can't collapse the match boundary; the quoted-string
+  // capture itself already terminates on the unescaped closing quote,
+  // so by the time we're past it the only legal trailer is ` }`.
+  // Also tolerates the multi-line pretty-printed inspect output
+  // (`{\n  turnNum: …,\n  text: …\n}`) via the leading `\s*`.
+  const re =
+    /\[conversation-runner\] turn (\d+)\/\d+ — settled text \{\s*turnNum:\s*\d+,\s*text:\s*(?:'((?:[^'\\]|\\.)*)'|"((?:[^"\\]|\\.)*)")\s*\}/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(stdout)) !== null) {
+    // Un-escape the util.inspect output. The escape rules differ by
+    // quote character — `\'` inside single-quoted, `\"` inside
+    // double-quoted — but `\\` is the same in both. m[2] holds the
+    // single-quoted capture; m[3] holds the double-quoted capture.
+    const raw = m[2] ?? m[3] ?? "";
+    const escaped =
+      m[2] !== undefined ? raw.replace(/\\'/g, "'") : raw.replace(/\\"/g, '"');
+    const text = escaped.replace(/\\\\/g, "\\");
+    turns.push({ turnIndex: Number(m[1]), assistantText: text });
+  }
+  const runDirMatch = stdout.match(/\[harness\] runDir=(\S+)/);
+  const runDir = runDirMatch ? runDirMatch[1] : "";
+  return { exitCode, turns, runDir, stdout, stderr };
+}

--- a/showcase/harness/test/integration/probe-contract.test.ts
+++ b/showcase/harness/test/integration/probe-contract.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Mechanism-GREEN tests for the Phase-4 probe contract migration.
+ *
+ * Phase 4 introduces two contract changes the runner + probes must
+ * cooperatively obey:
+ *
+ *   1. `readAssistantTextAt(page, bubbleIndex)` is the turn-scoped
+ *      replacement for `readLastAssistantText(page)`. It MUST resolve
+ *      the bubble at the strict index supplied — not "the last bubble
+ *      currently in the DOM". The "last-bubble" approach is what
+ *      motivated defect 2 in the bubble-race fix: a stale prior-turn
+ *      bubble leaking into the current turn's assertions.
+ *
+ *   2. The `turn.assertions(...)` callback receives a SECOND argument
+ *      `ctx: { bubbleIndex, text }`. Phase 4 wires a bridge inside
+ *      `conversation-runner.ts` that synthesises the ctx from a
+ *      post-settle `readMessageCount` + `readAssistantTextAt(...)`
+ *      pair (Phase 5 replaces that bridge with the values returned by
+ *      `waitForTurnComplete`). This file pins the bridge contract so
+ *      Phase 5's swap can't silently drop the ctx parameter.
+ *
+ * Both tests use scripted structural Page fakes — same idiom as the
+ * sibling `wait-for-turn-complete.test.ts` — so each case runs
+ * millisecond-cheap and stays deterministic without spinning up a
+ * real browser. The scripts dispatch on the function body of the
+ * evaluate call so we can route SSE / count / text reads to distinct
+ * fixture values, mirroring the real production read shapes.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  runConversation,
+  type ConversationTurn,
+  type Page,
+} from "../../src/probes/helpers/conversation-runner.js";
+import { readAssistantTextAt } from "../../src/probes/scripts/_gen-ui-shared.js";
+
+/**
+ * Build a Page double that returns a fixed list of assistant bubble
+ * textContents under the shared cascade. The cascade dispatch lives
+ * inside `findAssistantBubbleAt`'s page.evaluate — which calls
+ * `querySelectorAll(tier)` to discover bubble count, then reads
+ * `list[idx].textContent` for the requested index. We emulate that
+ * shape by branching on the presence of `arg` (the index): no arg =
+ * count, arg = textContent-at-index.
+ */
+function makeBubblePage(bubbleTexts: string[]): Page {
+  const evaluate: Page["evaluate"] = (async (
+    fn: unknown,
+    arg?: unknown,
+  ): Promise<unknown> => {
+    // findAssistantBubbleAt calls page.evaluate(fn, idx). When no arg is
+    // present we're answering a count-shaped probe; with an index we
+    // return that bubble's text (or null when out of range — same as
+    // the production helper).
+    if (arg === undefined) return bubbleTexts.length;
+    const idx = arg as number;
+    if (idx < 0 || idx >= bubbleTexts.length) return null;
+    void fn;
+    return bubbleTexts[idx] ?? "";
+  }) as Page["evaluate"];
+  return {
+    async waitForSelector() {
+      /* no-op */
+    },
+    async fill() {
+      /* no-op */
+    },
+    async press() {
+      /* no-op */
+    },
+    evaluate,
+  };
+}
+
+/**
+ * Build a Page double tailored to driving `runConversation` end-to-end
+ * with the new assertions-ctx contract.
+ *
+ * The runner's evaluate calls (in approximate order per turn):
+ *   - user-message count probes (`copilot-user-message`)
+ *   - error-banner visibility (`copilot-error-banner`)
+ *   - assistant-message count probes (the rest)
+ *   - after settle, the bridge calls readMessageCount + readAssistantTextAt
+ *
+ * The script consumes one assistant-count per assistant-count read
+ * (queue-style; freezes on the last value when exhausted). The bridge
+ * read uses page.evaluate(fn, idx) — branched on arg-presence to
+ * return the bubble text fixture.
+ */
+function makeRunnerPage(opts: {
+  assistantCounts: number[];
+  bubbleTexts: string[];
+}): Page {
+  const queue = [...opts.assistantCounts];
+  let userCalls = 0;
+  // Track the most recent assistant-count value drained from the queue.
+  // The post-cutover `waitForTurnComplete` primitive reads BOTH an SSE
+  // run-finished counter (`window.__hk_runsFinished`) and the atomic
+  // `readCascadeState` `{count, text}` shape per poll. We synthesise
+  // the SSE counter from the latest observed count (any time the
+  // assistant DOM has grown to N bubbles, the server must have
+  // flushed N RUN_FINISHED events) and the cascade-state text from
+  // `opts.bubbleTexts[idx]` — mirroring the `wrapEvaluateForUserMessages`
+  // helper in `conversation-runner.test.ts`.
+  let latestCount = 0;
+  const evaluate: Page["evaluate"] = (async (
+    fn: unknown,
+    arg?: unknown,
+  ): Promise<unknown> => {
+    const body = String(fn);
+    // SSE run-finished counter read (`waitForTurnComplete` conjunct 1).
+    // Routed BEFORE the arg-presence text branch because the SSE closure
+    // is called with NO runtime arg, and BEFORE the count branch because
+    // its body doesn't reference `querySelectorAll`. Synthesised from
+    // the latest observed assistant count.
+    if (body.includes("__hk_runsFinished")) {
+      return latestCount;
+    }
+    // Atomic cascade-state read (`readCascadeState`): returns BOTH the
+    // count and the indexed text from the SAME cascade tier in ONE
+    // round-trip. The closure body matches BOTH the legacy text-at-index
+    // dispatch heuristics (`querySelectorAll` + `textContent`) AND a
+    // runtime arg (the bubbleIndex), so it MUST be routed before the
+    // legacy arg-presence text branch. The distinguishing substring is
+    // the literal `{ count` the closure uses to construct its return
+    // object. Drain the count queue (same as the count-only branch),
+    // then synthesise the text from `opts.bubbleTexts[idx]`.
+    if (
+      body.includes("querySelectorAll") &&
+      body.includes("textContent") &&
+      body.includes("{ count")
+    ) {
+      // Drain the count progression as a count-shaped read so a script
+      // like [0, 0, 1, 1, ...] advances through the same plateau values
+      // it would for a stand-alone `countAssistantMessages` call.
+      let nextCount: number;
+      if (queue.length === 0) nextCount = 0;
+      else if (queue.length === 1) nextCount = queue[0]!;
+      else nextCount = queue.shift()!;
+      latestCount = nextCount;
+      const idx = (arg as number | undefined) ?? 0;
+      const text =
+        idx < 0 || idx >= nextCount ? null : (opts.bubbleTexts[idx] ?? "");
+      return { count: nextCount, text };
+    }
+    // Text-at-index branch (findAssistantBubbleAt).
+    if (arg !== undefined) {
+      const idx = arg as number;
+      if (idx < 0 || idx >= opts.bubbleTexts.length) return null;
+      return opts.bubbleTexts[idx] ?? "";
+    }
+    if (body.includes("copilot-error-banner")) {
+      return { visible: false };
+    }
+    if (body.includes("copilot-user-message")) {
+      // Auto-succeeding monotonic counter so fillAndVerifySend sees
+      // growth and never blocks the test on the user-bubble settle.
+      return userCalls++;
+    }
+    // The runner's post-settle diagnostic log calls `querySelector(...)?.textContent`
+    // to capture the settled text for trace purposes — distinct from the
+    // count/text-at-index probes above. Detect the single-selector
+    // textContent shape and return the first bubble's text so the
+    // `.slice(0, 200)` log call has a string to operate on.
+    if (body.includes("textContent") && !body.includes("querySelectorAll")) {
+      return opts.bubbleTexts[0] ?? "";
+    }
+    // Assistant-message count probe (default).
+    let nextCount: number;
+    if (queue.length === 0) nextCount = 0;
+    else if (queue.length === 1) nextCount = queue[0]!;
+    else nextCount = queue.shift()!;
+    latestCount = nextCount;
+    return nextCount;
+  }) as Page["evaluate"];
+  return {
+    async waitForSelector() {
+      /* no-op */
+    },
+    async fill() {
+      /* no-op */
+    },
+    async press() {
+      /* no-op */
+    },
+    evaluate,
+  };
+}
+
+describe("readAssistantTextAt (mechanism-GREEN)", () => {
+  it("returns the text of the bubble at the requested INDEX — not the last bubble globally", async () => {
+    // Three bubbles in the DOM. Asking for index 1 must return the
+    // MIDDLE bubble's text, not the last one. This is the exact race
+    // defect 2 motivates: the prior `readLastAssistantText` would
+    // return `list[list.length - 1]`, leaking a later bubble's content
+    // into the assertions for an earlier turn.
+    const page = makeBubblePage([
+      "first bubble text",
+      "second bubble text",
+      "third bubble text",
+    ]);
+    const text = await readAssistantTextAt(page as never, 1);
+    expect(text).toBe("second bubble text");
+  });
+
+  it("returns empty string when the requested index is out of range", async () => {
+    // Out-of-range index is a "turn not yet complete" signal, NOT a
+    // hard error. The helper coerces null to "" so callers can keep
+    // polling without a try/catch.
+    const page = makeBubblePage(["only bubble"]);
+    const text = await readAssistantTextAt(page as never, 5);
+    expect(text).toBe("");
+  });
+});
+
+describe("assertions(page, ctx) bridge (mechanism-GREEN)", () => {
+  it("invokes the turn's assertions callback with a ctx carrying bubbleIndex:number + text:string", async () => {
+    // Drive a single-turn conversation with scripted assistant counts
+    // (0 → 1 → 1 ...) so the settle loop sees one bubble appear and
+    // stabilise. The bridge in conversation-runner then reads the
+    // bubble's text and supplies it as ctx.text to assertions.
+    const recordedCtx: Array<{
+      bubbleIndex: number;
+      text: string;
+      bubbleIndexType: string;
+      textType: string;
+    }> = [];
+    const turns: ConversationTurn[] = [
+      {
+        input: "hello",
+        // The new signature: a second `ctx` param. TypeScript only
+        // requires it to match the production callback signature
+        // post-Phase 4; until then we use a permissive shape so this
+        // file compiles regardless of whether ConversationTurn's
+        // assertions field has been widened yet. The runtime check
+        // verifies the bridge actually passes the values.
+        assertions: (async (_page: Page, ctx: unknown) => {
+          const c = ctx as { bubbleIndex: number; text: string };
+          recordedCtx.push({
+            bubbleIndex: c.bubbleIndex,
+            text: c.text,
+            bubbleIndexType: typeof c.bubbleIndex,
+            textType: typeof c.text,
+          });
+        }) as ConversationTurn["assertions"],
+      },
+    ];
+
+    // 0 baseline, then 1 (a single assistant bubble appears and stays).
+    const page = makeRunnerPage({
+      assistantCounts: [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+      bubbleTexts: ["assistant reply text"],
+    });
+
+    const result = await runConversation(page, turns, {
+      assistantSettleMs: 50,
+    });
+
+    expect(result.failure_turn).toBeUndefined();
+    expect(result.turns_completed).toBe(1);
+    expect(recordedCtx).toHaveLength(1);
+    expect(recordedCtx[0]!.bubbleIndexType).toBe("number");
+    expect(recordedCtx[0]!.textType).toBe("string");
+    expect(recordedCtx[0]!.bubbleIndex).toBe(0);
+    expect(recordedCtx[0]!.text).toBe("assistant reply text");
+  }, 20_000);
+
+  it("supplies turn-scoped ctx across a multi-turn conversation — each turn's ctx carries its OWN bubbleIndex and bubble text (not a prior turn's)", async () => {
+    // Defect 2's whole point: turn N's assertions must receive a ctx
+    // pointing at turn N's bubble — NOT a stale prior-turn bubble that
+    // happens to be "last in the DOM". A single-turn test cannot
+    // distinguish "bridge correctly passes ctx" from "bridge accidentally
+    // hands every turn turn-1's ctx" — both look identical when there's
+    // only one turn. This multi-turn fixture forces the bridge to
+    // advance bubbleIndex per turn AND to read each turn's distinct
+    // text, locking the turn-scoped contract.
+    const recordedCtx: Array<{ bubbleIndex: number; text: string }> = [];
+    const bubbleTexts = [
+      "turn-1 assistant reply",
+      "turn-2 assistant reply",
+      "turn-3 assistant reply",
+    ];
+    const turns: ConversationTurn[] = bubbleTexts.map((_, i) => ({
+      input: `user message ${i + 1}`,
+      assertions: (async (_page: Page, ctx: unknown) => {
+        const c = ctx as { bubbleIndex: number; text: string };
+        recordedCtx.push({ bubbleIndex: c.bubbleIndex, text: c.text });
+      }) as ConversationTurn["assertions"],
+    }));
+
+    // Assistant-count script: baseline 0; then settles to 1, 2, 3 as
+    // each turn's bubble appears. The queue freezes on its last value
+    // once exhausted (makeRunnerPage semantics), so the settle loop
+    // sees stable counts within each turn. We pad each plateau with
+    // enough samples to clear assistantSettleMs at 50ms tick.
+    const page = makeRunnerPage({
+      assistantCounts: [
+        0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3,
+        3, 3, 3, 3, 3, 3, 3, 3,
+      ],
+      bubbleTexts,
+    });
+
+    const result = await runConversation(page, turns, {
+      assistantSettleMs: 50,
+    });
+
+    expect(result.failure_turn).toBeUndefined();
+    expect(result.turns_completed).toBe(3);
+    expect(recordedCtx).toHaveLength(3);
+    // Each turn's ctx must point at its OWN 0-indexed bubble position
+    // AND that bubble's text. A bug that hands every turn ctx from a
+    // single (e.g. the first or the last) bubble would fail one of
+    // these per-turn assertions.
+    for (let i = 0; i < 3; i++) {
+      expect(recordedCtx[i]!.bubbleIndex).toBe(i);
+      expect(recordedCtx[i]!.text).toBe(bubbleTexts[i]);
+    }
+  }, 30_000);
+});

--- a/showcase/harness/test/integration/sse-counter.test.ts
+++ b/showcase/harness/test/integration/sse-counter.test.ts
@@ -1,0 +1,393 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { chromium } from "playwright";
+import type { Browser } from "playwright";
+
+import { attachSseInterceptor } from "../../src/probes/helpers/sse-interceptor.js";
+
+/**
+ * Phase 3 Task 3.1 mechanism-GREEN test for the
+ * `__hk_runsFinished` page-side counter exposed by
+ * `attachSseInterceptor`.
+ *
+ * This test launches a real chromium page, attaches the interceptor,
+ * intercepts a fake SSE response via `page.route`, and asserts that
+ * `window.__hk_runsFinished` increases monotonically as
+ * `RUN_FINISHED` events are observed on the SSE stream.
+ *
+ * Why this lives under `test/integration/` (and not
+ * `src/probes/helpers/sse-interceptor.test.ts`):
+ *   - launches a real Chromium browser process (the existing
+ *     `sse-interceptor.test.ts` is a pure-function unit test with no
+ *     browser at all);
+ *   - asserts an observable on `window` produced by Playwright
+ *     `page.addInitScript` wiring — only meaningful in a real page
+ *     context;
+ *   - `vitest.integration.config.ts` uses `singleFork: true` so the
+ *     browser launch cost is paid once for the suite.
+ *
+ * IMPORTANT — fresh BrowserContext per interceptor-attaching test:
+ *   Every test in this file that calls `attachSseInterceptor` MUST
+ *   create its own `browser.newContext()` + `context.newPage()`,
+ *   wrapped in `try/finally` with `await context.close()`. The
+ *   interceptor's page-level `__hk_sse_attached` cache and the
+ *   page-side `__hk_fetchWrapped` guard are cumulative on a context:
+ *   reusing a context across tests silently no-ops subsequent
+ *   `attachSseInterceptor` calls (the FIRST-registered endpointPattern
+ *   wins) and bleeds init-script wiring across tests. See r3f4
+ *   (commit f5e1a810a) and r4f3 for the historical fixes that landed
+ *   this discipline. Do NOT add a shared `context`/`page` back to
+ *   `beforeAll` for interceptor-attaching tests.
+ */
+
+const ENDPOINT_PATH = "/api/copilotkit/agent/runtime";
+const ENDPOINT_URL = `https://example.invalid${ENDPOINT_PATH}`;
+
+// v2 single-route transport hits `runtimeUrl` verbatim — for
+// `runtimeUrl="/api/copilotkit"` (the showcase default for
+// langgraph-python + many others) the actual streaming-POST URL is
+// `…/api/copilotkit` with NO trailing slash and NO `/agent/<id>/run`
+// suffix (see ProxiedCopilotRuntimeAgent.constructor in
+// packages/core/src/agent.ts and the v2 single-route handler at
+// packages/runtime/src/v2/runtime/endpoints/hono-single.ts). Bug s12
+// fixed a default-pattern mismatch where the regex required a trailing
+// slash and so failed (a) entirely while the existing mechanism test
+// (which uses an `/agent/…` URL) kept passing — this constant exists
+// to lock that production URL shape into the test fixture.
+const ROOT_ENDPOINT_PATH = "/api/copilotkit";
+const ROOT_ENDPOINT_URL = `https://example.invalid${ROOT_ENDPOINT_PATH}`;
+
+/** Build a minimal SSE payload with `runFinishedCount` RUN_FINISHED events. */
+function buildSsePayload(runFinishedCount: number): string {
+  const records: string[] = ['data: {"type":"RUN_STARTED","threadId":"t-1"}\n'];
+  for (let i = 0; i < runFinishedCount; i++) {
+    records.push(`data: {"type":"RUN_FINISHED","threadId":"t-1","seq":${i}}\n`);
+  }
+  return records.join("\n") + "\n";
+}
+
+describe("sse-interceptor __hk_runsFinished counter (mechanism-GREEN)", () => {
+  let browser: Browser;
+
+  beforeAll(async () => {
+    browser = await chromium.launch({ headless: true });
+  }, 60_000);
+
+  afterAll(async () => {
+    await browser?.close().catch(() => {});
+  });
+
+  it("initializes window.__hk_runsFinished to 0 before any RUN_FINISHED arrives", async () => {
+    // Fresh BrowserContext per interceptor-attaching test — see the
+    // file-level comment above. Reusing a context across tests would
+    // let `__hk_sse_attached` / `__hk_fetchWrapped` no-op subsequent
+    // attaches and bleed init-script wiring into siblings.
+    const freshContext = await browser.newContext();
+    const freshPage = await freshContext.newPage();
+    try {
+      await attachSseInterceptor(freshPage);
+      await freshPage.goto("data:text/html,<html><body>idle</body></html>");
+      const initial = await freshPage.evaluate(
+        () =>
+          (globalThis as unknown as { __hk_runsFinished?: number })
+            .__hk_runsFinished,
+      );
+      // The counter is exposed at page boot (via addInitScript) and
+      // starts at zero. If this read returns `undefined`, the init
+      // script never ran — the page-side wiring is broken.
+      expect(initial).toBe(0);
+    } finally {
+      await freshContext.close().catch(() => {});
+    }
+  }, 30_000);
+
+  it("increments window.__hk_runsFinished on each RUN_FINISHED event on a matched SSE stream", async () => {
+    // A fresh BrowserContext is required because `attachSseInterceptor`
+    // installs a page-side fetch wrapper guarded by an idempotency cache
+    // (`g.__hk_fetchWrapped` / `g.__hk_sse_attached`) — any subsequent
+    // call on the same context NO-OPS and the FIRST-registered
+    // endpointPattern wins. Since the previous test already attached the
+    // interceptor with the DEFAULT pattern on the shared context, calling
+    // `attachSseInterceptor(page, { endpointPattern: ENDPOINT_PATH })`
+    // there would not actually re-bind to ENDPOINT_PATH. See
+    // `attachSseInterceptor` in src/probes/helpers/sse-interceptor.ts.
+    const freshContext = await browser.newContext();
+    const freshPage = await freshContext.newPage();
+    try {
+      const handle = await attachSseInterceptor(freshPage, {
+        endpointPattern: ENDPOINT_PATH,
+      });
+      // Serve a fake SSE stream from a page-loaded HTML fixture so
+      // the interceptor sees a matching request fly from this page.
+      await freshPage.route(ENDPOINT_URL, async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "text/event-stream",
+          body: buildSsePayload(2),
+        });
+      });
+      await freshPage.goto(
+        "data:text/html,<html><body>fetch-driver</body></html>",
+      );
+      await freshPage.evaluate(async (url) => {
+        const res = await fetch(url);
+        // Drain the body to give the interceptor a chance to
+        // observe every chunk via its tee/wrap of the streaming
+        // response.
+        await res.text();
+      }, ENDPOINT_URL);
+      // Allow microtask drain for the page-side counter increment to settle.
+      await freshPage.waitForFunction(
+        () =>
+          ((globalThis as unknown as { __hk_runsFinished?: number })
+            .__hk_runsFinished ?? 0) >= 2,
+        null,
+        { timeout: 10_000 },
+      );
+      const finalCount = await freshPage.evaluate(
+        () =>
+          (globalThis as unknown as { __hk_runsFinished?: number })
+            .__hk_runsFinished,
+      );
+      expect(finalCount).toBe(2);
+      await handle.stop().catch(() => {});
+    } finally {
+      await freshContext.close().catch(() => {});
+    }
+  }, 30_000);
+
+  it("resets per-stream tracking state on mainFrame framenavigated so a post-reload SSE request is captured", async () => {
+    // Cold-start retry repro: `runConversation` calls
+    // `page.reload()` when turn 1 fails to stream. The CDP session
+    // and surrounding closure persist, but the FIRST matching
+    // request before the reload pinned `trackedRequestId`. Without
+    // a framenavigated reset, the post-reload request is silently
+    // ignored AND the final `Network.getResponseBody` call uses
+    // the dead pre-reload request ID — Chromium has already evicted
+    // that body buffer, so the capture comes back empty with no
+    // operator-visible signal.
+    //
+    // This test drives the failure mode end-to-end on a fresh
+    // BrowserContext so init-script state from the prior tests
+    // doesn't bleed in:
+    //   (a) attach interceptor (default pattern),
+    //   (b) goto a fresh page, fire a first request matching the
+    //       pattern (this would pin trackedRequestId pre-fix),
+    //   (c) call `page.reload()` — mainFrame framenavigated must
+    //       fire and reset the tracker,
+    //   (d) fire a SECOND request, stop the interceptor, assert
+    //       the capture reflects the post-reload stream's contents
+    //       (one TOOL_CALL_START with the post-reload tool name).
+    const freshContext = await browser.newContext();
+    const freshPage = await freshContext.newPage();
+    try {
+      const RELOAD_PATH = "/api/copilotkit";
+      const RELOAD_URL = `https://example.invalid${RELOAD_PATH}`;
+      let requestCount = 0;
+      await freshPage.route(RELOAD_URL, async (route) => {
+        requestCount++;
+        const which = requestCount === 1 ? "pre" : "post";
+        const records = [
+          'data: {"type":"RUN_STARTED","threadId":"t-1"}\n',
+          `data: {"type":"TOOL_CALL_START","toolCallId":"tc-${which}","toolCallName":"${which}_reload_tool"}\n`,
+          'data: {"type":"RUN_FINISHED","threadId":"t-1"}\n',
+        ];
+        await route.fulfill({
+          status: 200,
+          contentType: "text/event-stream",
+          body: records.join("\n") + "\n",
+        });
+      });
+      const handle = await attachSseInterceptor(freshPage); // DEFAULT pattern
+      await freshPage.goto(
+        "data:text/html,<html><body>pre-reload</body></html>",
+      );
+      // First request — would pin trackedRequestId pre-fix.
+      await freshPage.evaluate(async (url) => {
+        const res = await fetch(url);
+        await res.text();
+      }, RELOAD_URL);
+      // Wait for the first stream to complete so __hk_runsFinished
+      // settles to 1 before the reload.
+      await freshPage.waitForFunction(
+        () =>
+          ((globalThis as unknown as { __hk_runsFinished?: number })
+            .__hk_runsFinished ?? 0) >= 1,
+        null,
+        { timeout: 10_000 },
+      );
+      // Reload — mainFrame framenavigated must fire and reset the
+      // tracking vars. Re-register the same route on the (new)
+      // page object isn't necessary because page.route is bound
+      // to the Page, not the navigation; the route still serves.
+      await freshPage.reload();
+      // Second request after reload — without the fix, the
+      // interceptor would ignore it (trackedRequestId still
+      // points at the pre-reload request id).
+      await freshPage.evaluate(async (url) => {
+        const res = await fetch(url);
+        await res.text();
+      }, RELOAD_URL);
+      const capture = await handle.stop();
+      // The post-reload stream's tool-call name must appear in the
+      // capture. Pre-fix, `getResponseBody` for the dead pre-reload
+      // request id either errored (→ empty payload) or returned the
+      // already-consumed first stream's body — neither path includes
+      // `post_reload_tool`.
+      expect(capture.toolCalls).toContain("post_reload_tool");
+      expect(capture.toolCalls).not.toContain("pre_reload_tool");
+      // raw_event_count > 0 confirms the post-reload body was
+      // fetched successfully (not evicted).
+      expect(capture.raw_event_count).toBeGreaterThan(0);
+      // Sanity: the route was hit twice (first + post-reload).
+      expect(requestCount).toBe(2);
+    } finally {
+      await freshContext.close().catch(() => {});
+    }
+  }, 30_000);
+
+  it("invalidates the page handle cache after stop() so a second attach instruments a fresh stream (r6f1)", async () => {
+    // r6f1 regression repro: the page-level `__hk_sse_attached` cache
+    // (added by r1f2) returned the SAME handle to every
+    // `attachSseInterceptor(page)` call on a given page lifecycle.
+    // After the first caller's `stop()` ran, `stopPromise` cached the
+    // resolved capture and the CDP session was detached. A SECOND
+    // caller that re-attached on the same page would silently:
+    //   (a) get the cached handle back from attachSseInterceptor,
+    //   (b) receive the FIRST stream's capture from `stop()` (cached
+    //       resolved promise), and
+    //   (c) never instrument the second stream at all because the CDP
+    //       session is already detached.
+    //
+    // Fix: `doStop` flips a `consumed` flag on the handle AND deletes
+    // the page cache entry. The attach-side check treats a
+    // cached-but-consumed handle as a cache miss and creates a fresh
+    // handle. This test exercises that contract end-to-end.
+    //
+    // Fresh BrowserContext per the file-level discipline above.
+    const freshContext = await browser.newContext();
+    const freshPage = await freshContext.newPage();
+    try {
+      const CACHE_PATH = "/api/copilotkit";
+      const CACHE_URL = `https://example.invalid${CACHE_PATH}`;
+      let requestCount = 0;
+      await freshPage.route(CACHE_URL, async (route) => {
+        requestCount++;
+        const which = requestCount === 1 ? "first" : "second";
+        const records = [
+          'data: {"type":"RUN_STARTED","threadId":"t-1"}\n',
+          `data: {"type":"TOOL_CALL_START","toolCallId":"tc-${which}","toolCallName":"${which}_attach_tool"}\n`,
+          'data: {"type":"RUN_FINISHED","threadId":"t-1"}\n',
+        ];
+        await route.fulfill({
+          status: 200,
+          contentType: "text/event-stream",
+          body: records.join("\n") + "\n",
+        });
+      });
+
+      // Attach #1 → request → stop(). Asserts the first capture sees
+      // the first stream.
+      const handle1 = await attachSseInterceptor(freshPage);
+      await freshPage.goto(
+        "data:text/html,<html><body>cache-invalidation</body></html>",
+      );
+      await freshPage.evaluate(async (url) => {
+        const res = await fetch(url);
+        await res.text();
+      }, CACHE_URL);
+      const capture1 = await handle1.stop();
+      expect(capture1.toolCalls).toContain("first_attach_tool");
+      expect(capture1.toolCalls).not.toContain("second_attach_tool");
+
+      // Attach #2 on the SAME page after stop(). Pre-fix, the cache
+      // would short-circuit and return the same `handle1` object —
+      // and `handle2.stop()` would resolve to `capture1` from the
+      // cached `stopPromise`. Post-fix, the cache was invalidated by
+      // doStop (both via consumed-flag and via cache delete) so we
+      // get a fresh handle with a fresh CDP session.
+      const handle2 = await attachSseInterceptor(freshPage);
+      expect(handle2).not.toBe(handle1);
+
+      // Fire the SECOND request; the fresh interceptor must capture
+      // it on the new CDP session.
+      await freshPage.evaluate(async (url) => {
+        const res = await fetch(url);
+        await res.text();
+      }, CACHE_URL);
+      const capture2 = await handle2.stop();
+      // The contract: the second capture reflects the SECOND request,
+      // not the cached first capture.
+      expect(capture2.toolCalls).toContain("second_attach_tool");
+      expect(capture2.toolCalls).not.toContain("first_attach_tool");
+      expect(capture2.raw_event_count).toBeGreaterThan(0);
+
+      // Sanity: the route was hit twice (one per attach cycle).
+      expect(requestCount).toBe(2);
+    } finally {
+      await freshContext.close().catch(() => {});
+    }
+  }, 30_000);
+
+  it("increments __hk_runsFinished against the production single-route URL shape (no trailing slash, no /agent/<id>/run suffix)", async () => {
+    // Production-shape integration assertion. The v2 single-route
+    // transport hits `runtimeUrl` exactly — so for the default
+    // showcase wiring (`runtimeUrl="/api/copilotkit"`, single
+    // transport) the streaming POST goes to `…/api/copilotkit` with
+    // NO trailing slash. The previous default endpoint pattern
+    // (`/\/api\/copilotkit\//`, with trailing slash) failed to match
+    // that URL — the wrapper installed by `attachSseInterceptor`
+    // saw the fetch, decided it was off-target, and let the body
+    // flow through unparsed. `__hk_runsFinished` stayed at 0 even
+    // though the assistant streamed text successfully, and
+    // `waitForTurnComplete` timed out every defect-1/defect-4 turn
+    // with reason=sse-missing. This test exercises THAT URL shape
+    // with the DEFAULT pattern (no per-test override) so any future
+    // regression of the pattern fails here before it reaches the
+    // bubble-race suite.
+    //
+    // A fresh BrowserContext is used because `page.addInitScript`
+    // is CUMULATIVE on a context: the prior tests' attachSseInterceptor
+    // calls registered init scripts with overridden patterns that still
+    // run on every navigation, and the in-page wrapper has an
+    // idempotency guard (`g.__hk_fetchWrapped === true`) that no-ops
+    // every subsequent registration. Without a fresh context the
+    // FIRST-registered pattern (a path-string override from the
+    // mechanism test) would win and the default-pattern assertion
+    // we're trying to make here would be silently invalidated.
+    const freshContext = await browser.newContext();
+    const freshPage = await freshContext.newPage();
+    try {
+      const handle = await attachSseInterceptor(freshPage); // uses DEFAULT pattern
+      await freshPage.route(ROOT_ENDPOINT_URL, async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "text/event-stream",
+          body: buildSsePayload(1),
+        });
+      });
+      await freshPage.goto(
+        "data:text/html,<html><body>fetch-driver-root</body></html>",
+      );
+      await freshPage.evaluate(async (url) => {
+        const res = await fetch(url);
+        await res.text();
+      }, ROOT_ENDPOINT_URL);
+      await freshPage.waitForFunction(
+        () =>
+          ((globalThis as unknown as { __hk_runsFinished?: number })
+            .__hk_runsFinished ?? 0) >= 1,
+        null,
+        { timeout: 10_000 },
+      );
+      const finalCount = await freshPage.evaluate(
+        () =>
+          (globalThis as unknown as { __hk_runsFinished?: number })
+            .__hk_runsFinished,
+      );
+      expect(finalCount).toBe(1);
+      await handle.stop().catch(() => {});
+    } finally {
+      await freshContext.close().catch(() => {});
+    }
+  }, 30_000);
+});

--- a/showcase/harness/test/integration/wait-for-turn-complete.test.ts
+++ b/showcase/harness/test/integration/wait-for-turn-complete.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Mechanism-GREEN tests for the `waitForTurnComplete` 3-conjunct primitive.
+ *
+ * This primitive composes three independent readiness signals into one
+ * settle gate for a single turn:
+ *
+ *   1. SSE       — `window.__hk_runsFinished >= turnIndex` (s7 counter)
+ *   2. DOM       — bubble at strict index `turnIndex - 1` exists under
+ *                  the shared cascade (s5/s6 helper)
+ *   3. TEXT      — that bubble's textContent is non-empty AND stable
+ *                  across `settleMs` of consecutive polls
+ *
+ * We don't need a real Playwright Page here — we hand the primitive a
+ * structural fake whose `evaluate()` dispatches on the function body
+ * (the SSE read references `__hk_runsFinished`, the atomic cascade read
+ * uses `querySelectorAll` + `textContent` + the literal `{ count`
+ * substring the closure uses to construct its return object). That keeps
+ * each case deterministic + millisecond-cheap, while still exercising the
+ * EXACT runtime code path of the primitive (same dispatch the production
+ * helpers make).
+ *
+ * Post-r4f2 (commit 6a98baef1) the runner uses `readCascadeState` which
+ * returns `{ count, text }` atomically in a single `page.evaluate` — so
+ * each poll makes TWO evaluates (SSE counter + atomic cascade state),
+ * not three (previously SSE + count + text).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  waitForTurnComplete,
+  TurnNotCompleteError,
+} from "../../src/probes/helpers/conversation-runner.js";
+
+interface ScriptStep {
+  runsFinished: number;
+  count: number;
+  text: string | null;
+}
+
+/**
+ * Build a structural Page double whose successive `evaluate()` calls
+ * return values from a pre-baked script. Each script step represents
+ * "the state of the world the next time the primitive looks at it" —
+ * so a single step is consumed by the two reads the primitive makes
+ * per iteration (sse + atomic cascade state). We collapse those two
+ * into one step by branching on the function body.
+ *
+ * The dispatch heuristic:
+ *   - body mentions `__hk_runsFinished` -> SSE read; return runsFinished
+ *   - body mentions `querySelectorAll` AND `textContent` AND `{ count`
+ *     -> atomic `readCascadeState` read; return `{ count, text }`
+ *     mirroring the production helper's return shape (see
+ *     `assistant-message-count.ts:readCascadeState`).
+ *   - body mentions `querySelectorAll` but NOT `textContent` and NOT
+ *     `{ count` -> `countAssistantMessages` (the final-classification
+ *     count-only re-read after timeout); return `step.count`.
+ *
+ * We do NOT advance the script on every evaluate — we advance once per
+ * "tick" (2 evaluates: sse + cascade state). That keeps the script
+ * 1:1 with poll iterations during the in-loop polling phase.
+ *
+ * Final-classification reads (`readRunsFinished` + `countAssistantMessages`
+ * after the timeout) drain from the frozen last script step, which mirrors
+ * "steady state at the deadline".
+ *
+ * Why `{ count` as the discriminator: the production `readCascadeState`
+ * closure body contains both `querySelectorAll` and `textContent`, AND
+ * the literal substring `{ count` (it constructs `{ count, text }`
+ * objects to return). The unit-test fakes in `conversation-runner.test.ts`
+ * use the same `{ count` substring to route the call to the atomic
+ * cascade branch — we mirror that pattern here.
+ */
+function makeScriptedPage(script: ScriptStep[]) {
+  let tickIdx = 0;
+  let evalsInTick = 0;
+  const currentStep = (): ScriptStep =>
+    script[Math.min(tickIdx, script.length - 1)];
+  return {
+    async evaluate(fn: unknown, arg?: unknown): Promise<unknown> {
+      const body = String(fn);
+      const step = currentStep();
+      evalsInTick += 1;
+      // Every 2 evals advances one script step (sse + cascade state).
+      // Post-r4f2 (commit 6a98baef1) the runner uses the atomic
+      // `readCascadeState` helper so each poll makes TWO evaluates,
+      // not three.
+      if (evalsInTick >= 2) {
+        evalsInTick = 0;
+        tickIdx += 1;
+      }
+      if (body.includes("__hk_runsFinished")) return step.runsFinished;
+      // Atomic cascade-state read (`readCascadeState`): returns BOTH the
+      // count and the indexed text from the SAME cascade tier in ONE
+      // round-trip. The distinguishing substring is the literal `{ count`
+      // that the production closure uses to construct its return object —
+      // same dispatch pattern as `conversation-runner.test.ts`'s fake.
+      if (
+        body.includes("querySelectorAll") &&
+        body.includes("textContent") &&
+        body.includes("{ count")
+      ) {
+        const idx = (arg as number | undefined) ?? 0;
+        if (idx < 0 || idx >= step.count) {
+          return { count: step.count, text: null };
+        }
+        // Only index 0 has populated text in our scripts; mirror the
+        // null-when-out-of-range behaviour of the production cascade.
+        const text = idx === 0 ? step.text : null;
+        return { count: step.count, text };
+      }
+      // Count-only re-read (`countAssistantMessages`): used by the
+      // final-classification path AFTER the polling loop times out.
+      // The closure body iterates cascade tiers and returns the first
+      // tier's `.length` — `querySelectorAll` present, `textContent`
+      // absent, `{ count` absent. Mirror the cascade by returning the
+      // current step's count.
+      if (body.includes("querySelectorAll")) {
+        return step.count;
+      }
+      return 0;
+    },
+  } as unknown as Parameters<typeof waitForTurnComplete>[0]["page"];
+}
+
+describe("waitForTurnComplete (mechanism-GREEN)", () => {
+  it("happy path — returns once SSE + DOM + stable text all hold", async () => {
+    // Steady state from step 0: SSE=1, count=1, text="hello" for long enough
+    // that the stable-text window of 50ms elapses across multiple polls.
+    const steady: ScriptStep = {
+      runsFinished: 1,
+      count: 1,
+      text: "hello",
+    };
+    const page = makeScriptedPage([
+      { runsFinished: 0, count: 0, text: null },
+      steady,
+      steady,
+      steady,
+      steady,
+      steady,
+      steady,
+      steady,
+      steady,
+    ]);
+    const result = await waitForTurnComplete({
+      page,
+      turnIndex: 1,
+      settleMs: 50,
+      timeoutMs: 5_000,
+      pollIntervalMs: 20,
+    });
+    expect(result.bubbleIndex).toBe(0);
+    expect(result.text).toBe("hello");
+  });
+
+  it("sse-missing — throws TurnNotCompleteError with reason 'sse-missing' when RUN_FINISHED never arrives", async () => {
+    // DOM + text are ready immediately, but the SSE counter NEVER ticks
+    // to 1. We expect the primitive to time out and classify the cause
+    // as sse-missing (runsFinished < turnIndex at the final read).
+    const page = makeScriptedPage([
+      { runsFinished: 0, count: 1, text: "premature" },
+    ]);
+    let caught: unknown = null;
+    try {
+      await waitForTurnComplete({
+        page,
+        turnIndex: 1,
+        settleMs: 20,
+        timeoutMs: 300,
+        pollIntervalMs: 20,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(TurnNotCompleteError);
+    expect((caught as TurnNotCompleteError).reason).toBe("sse-missing");
+    expect((caught as TurnNotCompleteError).turnIndex).toBe(1);
+  });
+
+  it("dom-missing — throws TurnNotCompleteError with reason 'dom-missing' when bubble at index never appears", async () => {
+    // SSE counter ticks to 1, but the cascade never finds any bubble.
+    // Final-classification preference order is sse-missing > dom-missing
+    // > text-unstable, so with sse>=turnIndex at the final read this must
+    // surface as dom-missing.
+    const page = makeScriptedPage([{ runsFinished: 1, count: 0, text: null }]);
+    let caught: unknown = null;
+    try {
+      await waitForTurnComplete({
+        page,
+        turnIndex: 1,
+        settleMs: 20,
+        timeoutMs: 300,
+        pollIntervalMs: 20,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(TurnNotCompleteError);
+    expect((caught as TurnNotCompleteError).reason).toBe("dom-missing");
+    expect((caught as TurnNotCompleteError).turnIndex).toBe(1);
+  });
+
+  it("text-unstable — throws TurnNotCompleteError with reason 'text-unstable' when text never settles", async () => {
+    // SSE counter ticks to 1, cascade returns count=1 throughout, but the
+    // bubble's text keeps changing on every poll — settle window never
+    // closes. With sse>=turnIndex and count>bubbleIndex at the final
+    // read, the classification falls through to text-unstable.
+    const flapping: ScriptStep[] = [];
+    for (let i = 0; i < 50; i += 1) {
+      flapping.push({
+        runsFinished: 1,
+        count: 1,
+        text: `chunk-${i}`,
+      });
+    }
+    const page = makeScriptedPage(flapping);
+    let caught: unknown = null;
+    try {
+      await waitForTurnComplete({
+        page,
+        turnIndex: 1,
+        settleMs: 200,
+        timeoutMs: 300,
+        pollIntervalMs: 20,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(TurnNotCompleteError);
+    expect((caught as TurnNotCompleteError).reason).toBe("text-unstable");
+    expect((caught as TurnNotCompleteError).turnIndex).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes 4 bubble-race defects in the CopilotKit showcase e2e harness's conversation runner that caused flaky turn-completion detection on slow-streaming and cold-start integrations.

**Defects fixed (RED → GREEN):**
- **Defect 1** (fast-replay): turn settled on count, not text/SSE → false-positive settle
- **Defect 2** (multi-turn flicker): un-turn-scoped bubble selection via `list[last]` → cross-turn leak
- **Defect 3** (cascade blindness): diagnostic cascade picked wrong tier → wrong bubble text
- **Defect 4** (boot-time baseline staleness): pre-paint/stale bubble at boot poisoned turn-1 settle

**Core changes:**
- `waitForTurnComplete` 3-conjunct primitive (SSE counter + DOM-at-index + text-quiet for settleMs)
- Atomic `readCascadeState` helper — single `page.evaluate` returns `{count, text}` from one cascade tier (prevents within-poll cross-tier inconsistency)
- Probe contract: `assertions(page, ctx: {bubbleIndex, text})` — turn-scoped bubble retrieval (replaces `list[last]`)
- SSE interceptor — `__hk_runsFinished` counter via CDP + page-side fetch wrap; idempotent attach/detach + handle-cache invalidation on stop + `framenavigated` reset (cold-start retry compatible)
- Cold-start retry — single bounded retry on first-attempt banner; reload + re-resolve chat input + settleMs floor honoring shared turn deadline
- Banner fast-fail — baseline banner snapshot + differs-from-baseline 2-poll debounce; in-poll `BannerVisibleError` translates to `AssistantErroredError`
- Pre-paint placeholder env adapter for defect-4 repro infrastructure

**Defect repro tests:** real-browser tests in `test/integration/bubble-race-repro-defect-{1,2,3,4}.test.ts` plus mechanism-GREEN tests and `wait-for-turn-complete.test.ts` (3-conjunct classification matrix), `probe-contract.test.ts` (ctx bridge), `sse-counter.test.ts` (counter increment + framenavigated reset + handle-cache invalidation).

## Test plan

- [x] Full harness vitest: 2742/2742 passing
- [x] Defect-1, defect-2, defect-4 RED tests verified GREEN after fix
- [x] Mechanism-GREEN tests pin internal contracts (cascade pollution guard, SSE counter atomicity, init-script navigation re-entry, etc.)
- [x] cr-loop converged across 10 rounds (25→6→6→6→4→2→0 bucket-(a) findings) + Procedure 3 audit clean
- [x] `oxfmt --check` clean across all 31 changed TS files
- [x] `tsc -p tsconfig.build.json` clean
- [ ] CI green on this PR
- [ ] Manual smoke: `bin/showcase test --d5 langgraph-python:agentic-chat` post-merge

## Follow-up debt (deferred from cr-loop; not subject-scope)

Detected by cr-loop reviewers but out of this PR's scope:
- `d6-all-pills.ts` deploy-churn NSF aggregation — features in `notSupportedFeatures` lose `incapable` classification during deploy-churn skip
- `d6-all-pills.ts` `joinAimockJournal` slug fallback under D6 concurrency — can pick wrong-feature entry when aimock doesn't echo `x-diag-run-id`
- `d6-all-pills.ts` `BrowserDisconnectedError` sentinel is constructed but never matched in `runFeature` catch — gets bucketed as `driver-error`
- `d5-tool-rendering-default-catchall.ts` Path B narration false-positive (substring matches in assistant prose)
- HITL registry side-effect tests use manual fallback registration that masks real registration failures
- `installPrePaintFromEnv` and `attachSseInterceptor` are re-registered on every `page.goto` — accumulate init scripts; harmless today via in-script idempotency guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
