### PR TITLE
feat(showcase): make showcase_promote.yml dep-aware so single-slug promotes include aimock + harness + dashboard + per-integration container

### DIFF
--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -152,7 +152,32 @@ jobs:
               echo "::error::Ambiguous service '$INPUT' matches multiple SSOT entries: $LIST"
               exit 1
             fi
-            CSV="$MATCHES"
+            # Dep-aware expansion: integration promotes must also bounce the
+            # shared infra they run against (aimock + harness + dashboard at
+            # minimum) or prod drifts off staging. SSOT carries the dep set
+            # on each integration (railway-envs.ts → ServiceEntry.promoteDeps);
+            # the generated JSON exposes it under `.promoteDeps`. Here we read
+            # the dep list from the resolved entry, re-validate each dep is
+            # prod-probe-eligible (defense-in-depth against a runtime-edited
+            # generated JSON — the SSOT validator already enforces this at
+            # module load), append the parent, and dedupe while PRESERVING
+            # order (deps-before-parent so promote-fleet.sh bounces infra
+            # before the integration that consumes it; `unique` would re-sort
+            # alphabetically and drop that ordering).
+            CSV=$(jq -r --arg s "$MATCHES" '
+              ( .services[] | select(.name == $s) ) as $svc
+              | ($svc.promoteDeps // []) as $deps
+              | [ $deps[] as $d
+                  | (.services[] | select(.name == $d) | select(.probe.prod == true) | .name)
+                ] as $okDeps
+              | ($okDeps + [$s])
+              | reduce .[] as $x ([]; if index($x) then . else . + [$x] end)
+              | join(",")
+            ' "$GENERATED")
+            if [ -z "$CSV" ]; then
+              echo "::error::resolve-targets emitted empty CSV for '$INPUT' (post-expansion). This is a contract violation."
+              exit 1
+            fi
           fi
           echo "services_csv=$CSV" >> "$GITHUB_OUTPUT"
 

--- a/showcase/scripts/emit-railway-envs-json.ts
+++ b/showcase/scripts/emit-railway-envs-json.ts
@@ -49,6 +49,14 @@ interface Emitted {
     repoNameOverride?: { prod?: string; staging?: string };
     domains: { staging: string; prod: string };
     probe: { staging: boolean; prod: boolean; driver: string };
+    /**
+     * SSOT keys of OTHER services to promote alongside this one when
+     * showcase_promote.yml resolves it as a single-service target. Emitted
+     * ONLY when set (matches the legacy output's "omit-when-unset" idiom for
+     * repoNameOverride). resolve-targets reads this field to expand the CSV;
+     * see ServiceEntry.promoteDeps in railway-envs.ts.
+     */
+    promoteDeps?: string[];
   }>;
 }
 
@@ -116,6 +124,13 @@ function projectServiceToLegacyJson(
       prod: prodEnv ? (prodEnv.probe ?? true) : false,
       driver: entry.probeDriver,
     },
+    // promoteDeps is OPTIONAL on the SSOT (infra leaves have none); emit
+    // only when set so the JSON shape for non-integration services stays
+    // identical to the pre-feature output (jq's `.promoteDeps[]?` accepts
+    // either form so consumers are unaffected by the omission).
+    ...(entry.promoteDeps !== undefined && entry.promoteDeps.length > 0
+      ? { promoteDeps: [...entry.promoteDeps] }
+      : {}),
   };
 }
 

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -217,7 +217,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-agno",
@@ -235,7 +240,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-built-in-agent",
@@ -253,7 +263,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-claude-sdk-python",
@@ -271,7 +286,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-claude-sdk-typescript",
@@ -289,7 +309,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-crewai-crews",
@@ -307,7 +332,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-google-adk",
@@ -325,7 +355,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-langgraph-fastapi",
@@ -343,7 +378,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-langgraph-python",
@@ -361,7 +401,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-langgraph-typescript",
@@ -379,7 +424,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-langroid",
@@ -397,7 +447,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-llamaindex",
@@ -415,7 +470,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-mastra",
@@ -433,7 +493,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-ms-agent-dotnet",
@@ -451,7 +516,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-ms-agent-harness-dotnet",
@@ -469,7 +539,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-ms-agent-python",
@@ -487,7 +562,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-pydantic-ai",
@@ -505,7 +585,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-spring-ai",
@@ -523,7 +608,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "showcase-strands",
@@ -541,7 +631,12 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteDeps": [
+        "aimock",
+        "harness",
+        "dashboard"
+      ]
     },
     {
       "name": "webhooks",

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -218,11 +218,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-agno",
@@ -241,11 +237,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-built-in-agent",
@@ -264,11 +256,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-claude-sdk-python",
@@ -287,11 +275,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-claude-sdk-typescript",
@@ -310,11 +294,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-crewai-crews",
@@ -333,11 +313,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-google-adk",
@@ -356,11 +332,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-langgraph-fastapi",
@@ -379,11 +351,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-langgraph-python",
@@ -402,11 +370,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-langgraph-typescript",
@@ -425,11 +389,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-langroid",
@@ -448,11 +408,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-llamaindex",
@@ -471,11 +427,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-mastra",
@@ -494,11 +446,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-ms-agent-dotnet",
@@ -517,11 +465,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-ms-agent-harness-dotnet",
@@ -540,11 +484,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-ms-agent-python",
@@ -563,11 +503,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-pydantic-ai",
@@ -586,11 +522,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-spring-ai",
@@ -609,11 +541,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "showcase-strands",
@@ -632,11 +560,7 @@
         "prod": true,
         "driver": "agent"
       },
-      "promoteDeps": [
-        "aimock",
-        "harness",
-        "dashboard"
-      ]
+      "promoteDeps": ["aimock", "harness", "dashboard"]
     },
     {
       "name": "webhooks",

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -12,6 +12,7 @@ import {
   assertDispatchNamesUnique,
   assertEnvRegistryConsistent,
   assertImageConsumersValid,
+  assertPromoteDepsValid,
   assertServiceAndInstanceIdsUnique,
   domainFor,
   envsFor,
@@ -938,5 +939,137 @@ describe("railway-envs SSOT — domains + probe", () => {
       repoName: "showcase-example",
     };
     expect(sample.probe).toBe(false);
+  });
+});
+
+describe("promoteDeps invariant + integration coverage", () => {
+  // Lockstep guard: showcase_promote.yml expands an integration target by
+  // unioning its promoteDeps into the CSV. If the SSOT drops aimock (or any
+  // shared-infra dep) from an integration's list, a single-slug promote will
+  // silently leave that infra stale in prod — exactly the drift this field
+  // exists to prevent. Encode the minimum-set contract as data so a future
+  // human editing a single integration entry trips this immediately.
+  const REQUIRED_INFRA_DEPS = ["aimock", "harness", "dashboard"] as const;
+
+  it("the production SSOT's promoteDeps are all valid", () => {
+    // The real SERVICES map must pass — module-load assertion already runs
+    // it, but include the explicit positive-case test alongside the negative
+    // cases below to mirror the imageOf invariant suite's shape.
+    expect(() => assertPromoteDepsValid()).not.toThrow();
+  });
+
+  it("every agent integration declares aimock+harness+dashboard in promoteDeps", () => {
+    // Integration = probeDriver "agent" AND has prod env. Each one MUST
+    // carry the full shared-infra dep set or its single-slug promote leaves
+    // prod drifted. Failure mode this catches: someone adds a new
+    // integration entry and forgets the promoteDeps line.
+    const integrations = Object.entries(SERVICES).filter(
+      ([, entry]) =>
+        entry.probeDriver === "agent" && entry.environments?.prod !== undefined,
+    );
+    expect(integrations.length).toBeGreaterThan(0);
+    for (const [name, entry] of integrations) {
+      const deps = entry.promoteDeps ?? [];
+      for (const required of REQUIRED_INFRA_DEPS) {
+        expect(
+          deps,
+          `integration "${name}" must list "${required}" in promoteDeps`,
+        ).toContain(required);
+      }
+    }
+  });
+
+  it("leaf infra entries (aimock/harness/dashboard) carry NO promoteDeps", () => {
+    // Inverting the graph (e.g. aimock listing every integration) would mean
+    // a routine aimock bump re-promotes the world. The contract is one-way:
+    // integrations → infra. Verify the three named leaves explicitly.
+    for (const leaf of REQUIRED_INFRA_DEPS) {
+      const entry = SERVICES[leaf];
+      expect(entry, `expected SSOT entry "${leaf}"`).toBeDefined();
+      const deps = entry.promoteDeps ?? [];
+      expect(
+        deps,
+        `leaf infra "${leaf}" must not declare promoteDeps (one-way graph)`,
+      ).toEqual([]);
+    }
+  });
+
+  it("throws on a promoteDeps entry that is not an SSOT key (dangling)", () => {
+    const synthetic = {
+      "showcase-foo": {
+        promoteDeps: ["no-such-service"],
+        environments: { prod: { probe: true } },
+      },
+      aimock: { environments: { prod: { probe: true } } },
+    };
+    expect(() => assertPromoteDepsValid(synthetic)).toThrow(
+      /showcase-foo.*"no-such-service".*not an SSOT key/i,
+    );
+  });
+
+  it("throws on a one-level cycle (dep points back at parent)", () => {
+    const synthetic = {
+      "showcase-foo": {
+        promoteDeps: ["aimock"],
+        environments: { prod: { probe: true } },
+      },
+      aimock: {
+        promoteDeps: ["showcase-foo"],
+        environments: { prod: { probe: true } },
+      },
+    };
+    expect(() => assertPromoteDepsValid(synthetic)).toThrow(/cycle/i);
+  });
+
+  it("throws on a self-referencing promoteDeps entry", () => {
+    const synthetic = {
+      "showcase-foo": {
+        promoteDeps: ["showcase-foo"],
+        environments: { prod: { probe: true } },
+      },
+    };
+    expect(() => assertPromoteDepsValid(synthetic)).toThrow(
+      /showcase-foo.*lists itself/i,
+    );
+  });
+
+  it("throws on a dep that is not prod-probe-eligible", () => {
+    // probe.prod === false ⇒ promote will never run against this dep;
+    // including it would either fail promote-fleet or be silently filtered.
+    // Fail loud at SSOT load instead.
+    const synthetic = {
+      "showcase-foo": {
+        promoteDeps: ["aimock"],
+        environments: { prod: { probe: true } },
+      },
+      aimock: { environments: { prod: { probe: false } } },
+    };
+    expect(() => assertPromoteDepsValid(synthetic)).toThrow(
+      /aimock.*probe === false/i,
+    );
+  });
+
+  it("throws on a dep that has no prod env at all", () => {
+    const synthetic = {
+      "showcase-foo": {
+        promoteDeps: ["staging-only"],
+        environments: { prod: { probe: true } },
+      },
+      "staging-only": { environments: { staging: { probe: true } } },
+    };
+    expect(() => assertPromoteDepsValid(synthetic)).toThrow(
+      /staging-only.*no prod env/i,
+    );
+  });
+
+  it("ignores entries without promoteDeps (leaves are valid)", () => {
+    const synthetic = {
+      "leaf-a": { environments: { prod: { probe: true } } },
+      "leaf-b": {
+        promoteDeps: [],
+        environments: { prod: { probe: true } },
+      },
+    };
+    expect(() => assertPromoteDepsValid(synthetic)).not.toThrow();
   });
 });

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -269,6 +269,35 @@ export interface ServiceEntry {
      */
     repoNameOverride?: { prod?: string; staging?: string };
   };
+  /**
+   * SSOT keys of OTHER services that must be promoted ALONGSIDE this one
+   * whenever a human picks this service from the showcase_promote.yml
+   * dropdown. The drift this exists to prevent: promoting just
+   * `langgraph-typescript` left `showcase-aimock` + `showcase-harness` +
+   * `shell-dashboard` on whatever stale image happened to be in prod
+   * (observed at ~00:46Z 2026-06-15). The reverse case (promoting just
+   * `showcase-aimock`) left every integration on its stale image.
+   *
+   * Population rule: every integration (probeDriver:"agent") carries the
+   * shared-infra deps it runs against — at minimum `aimock`, `harness`,
+   * `dashboard` (SSOT keys, NOT dispatch names; resolve-targets emits the
+   * SSOT-key form of the CSV that bin/railway promote validates against
+   * STAGING_SERVICES). Infra leaves carry no deps (a promote of just the
+   * leaf is a deliberate narrow op — do NOT invert the graph or every
+   * leaf promote would drag the world).
+   *
+   * `service=all` ignores this field entirely (already promotes everything
+   * `probe.prod === true`). The expansion happens ONLY on a single-service
+   * resolve in showcase_promote.yml.
+   *
+   * Validator (`assertPromoteDepsValid`, called at module load): every dep
+   * must resolve to an existing SSOT entry, must be prod-probe-eligible
+   * (`environments.prod.probe !== false`), no self-reference, and no
+   * one-level cycle (a dep cannot itself declare `promoteDeps` pointing
+   * back at the parent — keeps the graph one-level so jq expansion stays
+   * trivial). Empty/undefined is fine and means "no extra services."
+   */
+  promoteDeps?: string[];
 }
 
 /**
@@ -583,6 +612,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "ag2",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "de571c97-03fd-486b-8a54-9767a4a53f95",
@@ -602,6 +638,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "agno",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "026d12fb-2844-42af-8f92-b47bc8a06bc8",
@@ -621,6 +664,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "built-in-agent",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "40018ef7-1ed1-4979-b80c-9c2d957b6d88",
@@ -640,6 +690,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "claude-sdk-python",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "bb18caaf-9a3e-4fdd-85ec-562fd82a3a89",
@@ -659,6 +716,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "claude-sdk-typescript",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "bee425e4-9661-4a88-8888-922b8cd4b61d",
@@ -678,6 +742,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "crewai-crews",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "3dab0cc3-cab1-4579-b772-947268088514",
@@ -697,6 +768,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "google-adk",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "7b2da5db-87d2-40ad-a3d9-b2d7a5485a22",
@@ -716,6 +794,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "langgraph-fastapi",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "105b7e01-acd0-48e2-9a09-541e2103e8d2",
@@ -735,6 +820,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "langgraph-python",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "aec504f7-63d7-4ea6-9d50-601b00d2ae80",
@@ -754,6 +846,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "langgraph-typescript",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "f53e9fdc-7c3e-4dfd-9fa8-d7241fd55bb8",
@@ -773,6 +872,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "langroid",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "6b5e20b5-8f8e-4ec3-9288-7a41122e42e5",
@@ -792,6 +898,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "llamaindex",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "b778856e-9f90-4136-9415-fb2b41173f8d",
@@ -811,6 +924,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "mastra",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "eaeddd9c-8b75-426f-b033-0fd935cbf6ef",
@@ -830,6 +950,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "ms-agent-dotnet",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "93ca0edf-7b59-4de4-b1fd-3412bb07bc6a",
@@ -849,6 +976,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "ms-agent-harness-dotnet",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "8f91ebc6-95c0-4433-b1f7-657ff49c2d59",
@@ -868,6 +1002,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "ms-agent-python",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "323ed911-4d28-45ab-8fc0-7d151828b938",
@@ -887,6 +1028,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "pydantic-ai",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "192cd647-6824-4f01-937a-1da675d83805",
@@ -906,6 +1054,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "spring-ai",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "2fbf1db2-5e51-44c9-983c-3f2242d95c61",
@@ -925,6 +1080,13 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "strands",
     probeDriver: "agent",
+    // Integration → shared-infra dep set. Promoting this integration alone
+    // would otherwise leave aimock/harness/dashboard on whatever stale
+    // image was in prod; expanding to these three (SSOT keys, NOT dispatch
+    // names) in showcase_promote.yml's resolve-targets keeps the four
+    // services in lockstep. Validated at module load by
+    // assertPromoteDepsValid.
+    promoteDeps: ["aimock", "harness", "dashboard"],
     environments: {
       prod: {
         instanceId: "2123c71b-9385-443c-a1c3-bcf4b1669eeb",
@@ -1482,6 +1644,100 @@ export function assertServiceAndInstanceIdsUnique(
   }
 }
 
+/**
+ * Throw on SSOT load if any `promoteDeps` entry is mis-wired. Without this,
+ * a typo in a dep name (or a dep that isn't prod-eligible) silently widens
+ * or narrows the promote scope and we re-introduce exactly the drift the
+ * field exists to prevent. Constraints:
+ *
+ *   (i)   every dep name resolves to an existing SSOT key — a dangling dep
+ *         would otherwise be filtered to nothing by jq and silently dropped;
+ *   (ii)  every dep must be prod-probe-eligible (declares `prod` AND
+ *         `environments.prod.probe !== false`); a non-eligible dep can never
+ *         be promoted and would either fail promote-fleet or get silently
+ *         filtered out — fail loud at module load instead;
+ *   (iii) no self-reference;
+ *   (iv)  graph stays ONE LEVEL: a dep cannot itself declare `promoteDeps`
+ *         pointing back at its parent (a true cycle) AND no dep should
+ *         itself have `promoteDeps` at all (infra leaves are leaves), so the
+ *         jq expansion in resolve-targets is `parent ∪ deps` without
+ *         recursion. We enforce the cycle case loudly; a dep with its own
+ *         `promoteDeps` that does NOT point back is permitted but its deeper
+ *         deps are deliberately NOT expanded.
+ *
+ * Accepts an injected map for testing; defaults to the real SERVICES map.
+ */
+export function assertPromoteDepsValid(
+  services: Record<
+    string,
+    {
+      promoteDeps?: string[];
+      environments?: Record<string, { probe?: boolean }>;
+    }
+  > = SERVICES,
+): void {
+  const problems: string[] = [];
+  for (const [key, entry] of Object.entries(services)) {
+    const deps = entry.promoteDeps;
+    if (deps === undefined || deps.length === 0) continue;
+    const seen = new Set<string>();
+    for (const dep of deps) {
+      if (dep === key) {
+        problems.push(`  - "${key}" lists itself in promoteDeps`);
+        continue;
+      }
+      if (seen.has(dep)) {
+        problems.push(
+          `  - "${key}" lists "${dep}" twice in promoteDeps — deduplicate`,
+        );
+        continue;
+      }
+      seen.add(dep);
+      // Own-property lookup so an inherited Object.prototype key
+      // (e.g. "toString") reports as dangling, not as a truthy non-entry.
+      if (!Object.hasOwn(services, dep)) {
+        problems.push(
+          `  - "${key}" promoteDeps "${dep}" is not an SSOT key in SERVICES`,
+        );
+        continue;
+      }
+      const depEntry = services[dep];
+      const prodCfg = depEntry.environments?.prod;
+      if (prodCfg === undefined) {
+        problems.push(
+          `  - "${key}" promoteDeps "${dep}" has no prod env — not promote-eligible`,
+        );
+        continue;
+      }
+      if (prodCfg.probe === false) {
+        problems.push(
+          `  - "${key}" promoteDeps "${dep}" has prod.probe === false — not promote-eligible`,
+        );
+        continue;
+      }
+      // One-level cycle: dep declares promoteDeps pointing back at the
+      // parent. A true cycle would make the jq expansion ambiguous; the
+      // SSOT contract is that deps are infra leaves with no further deps,
+      // and definitely none pointing back. (A dep with its OWN promoteDeps
+      // that does NOT name the parent is permitted but deliberately not
+      // recursively expanded.)
+      const depDeps = depEntry.promoteDeps ?? [];
+      if (depDeps.includes(key)) {
+        problems.push(
+          `  - cycle: "${key}" → "${dep}" → "${key}" (one-level cycle); promoteDeps must be acyclic`,
+        );
+      }
+    }
+  }
+  if (problems.length > 0) {
+    throw new Error(
+      `railway-envs SSOT invariant violated:\n${problems.join("\n")}\n` +
+        `Fix: every promoteDeps entry must be an existing, prod-probe-eligible ` +
+        `SSOT key (no self-reference, no one-level cycle).`,
+    );
+  }
+}
+
 // Module-load assertions: fail any importer if the SSOT drifts into a
 // collision, a mis-wired image consumer, an inconsistent env registry, or
 // a duplicated Railway ID. Tests that exercise the invariants with
@@ -1490,3 +1746,4 @@ assertDispatchNamesUnique();
 assertImageConsumersValid();
 assertEnvRegistryConsistent();
 assertServiceAndInstanceIdsUnique();
+assertPromoteDepsValid();


### PR DESCRIPTION
## Gap
Promoting an integration alone (e.g. `service=langgraph-typescript`) currently leaves stale `showcase-aimock`, `showcase-harness`, and `shell-dashboard` in prod. We hit this with today's prod-vs-staging drift after aimock-only promote at 00:46Z 2026-06-15.

## Fix
- Add optional `promoteDeps?: string[]` to `ServiceEntry` in `railway-envs.ts` (SSOT).
- Every integration declares its runtime deps: `[aimock, harness, dashboard]` (SSOT keys, one level deep).
- `showcase_promote.yml` `resolve-targets` reads the SSOT JSON and unions the deps into `services_csv` with deps-before-parent ordering so promote-fleet bounces infra before the integration that consumes it.
- `service=all` is unchanged (still promotes every `probe.prod == true` entry).
- Infra leaves (aimock/harness/dashboard/shell-*/webhooks) carry no deps — one-way graph; reverse would re-promote the world on every aimock bump.

## Dep graph (one-level)
All 19 agent integrations carry `promoteDeps: [aimock, harness, dashboard]`:

```
showcase-ag2, showcase-agno, showcase-built-in-agent,
showcase-claude-sdk-python, showcase-claude-sdk-typescript,
showcase-crewai-crews, showcase-google-adk,
showcase-langgraph-fastapi, showcase-langgraph-python,
showcase-langgraph-typescript, showcase-langroid,
showcase-llamaindex, showcase-mastra,
showcase-ms-agent-dotnet, showcase-ms-agent-harness-dotnet,
showcase-ms-agent-python, showcase-pydantic-ai,
showcase-spring-ai, showcase-strands
    -> [aimock, harness, dashboard]
```

## Validation guards (new `assertPromoteDepsValid`, runs at module load)
- every dep resolves to an SSOT key (own-property lookup, prototype-safe)
- every dep is `prod` AND `prod.probe !== false`
- no self-reference
- one-level depth (rejects cycles — dep cannot list parent in its own `promoteDeps`)
- no duplicate entries

## Tests
- Real SERVICES map passes `assertPromoteDepsValid` (positive case)
- Every `probeDriver:"agent"` integration with a prod env lists all of aimock+harness+dashboard
- Leaves (aimock/harness/dashboard) carry zero `promoteDeps`
- Synthetic cycle rejected
- Synthetic dangling dep rejected
- Self-reference rejected
- Non-prod-eligible dep (`probe === false`) rejected
- Dep with no `prod` env rejected
- Empty / undefined `promoteDeps` accepted

## Local verify
- `npx vitest run railway-envs.test.ts` -> 84 passed
- `npx tsx emit-railway-envs-json.ts` -> clean regen
- `yamllint -d relaxed` -> warnings only (line-length, pre-existing)
- `bats showcase/scripts/__tests__/promote-fleet.bats` -> 12/12 ok
- `actionlint` not installed locally; CI will run it.
- Cannot dry-run `workflow_dispatch` locally; verified by CI.