### PR TITLE
fix(showcase): LGP-align 10 catchall fixtures — strip match.toolName gate causing 24 prod reds

### DIFF
--- a/showcase/aimock/d6/claude-sdk-python/tool-rendering-default-catchall.json
+++ b/showcase/aimock/d6/claude-sdk-python/tool-rendering-default-catchall.json
@@ -6,21 +6,20 @@
   },
   "fixtures": [
     {
-      "_comment": "default-catchall: weather in Tokyo \u2014 follow-up content after get_weather tool result. MUST come before the tool-emitting fixture below (first-match-wins). The built-in default renderer (copilot-tool-render testid) fires for get_weather since no user-supplied renderer is registered.",
+      "_comment": "default-catchall: weather in Tokyo — follow-up content after get_weather tool result. MUST come before the tool-emitting fixture below (first-match-wins). The built-in default renderer (copilot-tool-render testid) fires for get_weather since no user-supplied renderer is registered.",
       "match": {
         "userMessage": "forecast for Tokyo",
         "toolCallId": "call_d5_get_weather_001",
         "context": "claude-sdk-python"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy."
+        "content": "Tokyo is 22°C and partly cloudy."
       }
     },
     {
-      "_comment": "default-catchall: weather in Tokyo \u2014 first leg: emit get_weather tool call.",
+      "_comment": "default-catchall: weather in Tokyo — first leg: emit get_weather tool call.",
       "match": {
         "userMessage": "forecast for Tokyo",
-        "toolName": "get_weather",
         "context": "claude-sdk-python"
       },
       "response": {
@@ -35,13 +34,13 @@
       }
     },
     {
-      "_comment": "default-catchall: weather in Tokyo \u2014 fallback when get_weather tool not registered.",
+      "_comment": "default-catchall: weather in Tokyo — fallback when get_weather tool not registered.",
       "match": {
         "userMessage": "forecast for Tokyo",
         "context": "claude-sdk-python"
       },
       "response": {
-        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies and light easterly winds."
+        "content": "The weather in Tokyo is currently 22°C with partly cloudy skies and light easterly winds."
       }
     }
   ]

--- a/showcase/aimock/d6/google-adk/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/google-adk/tool-rendering-custom-catchall.json
@@ -7,21 +7,20 @@
   },
   "fixtures": [
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
+      "_comment": "tool-rendering-custom-catchall — weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
       "match": {
         "userMessage": "forecast for Tokyo",
         "toolCallId": "call_d6_cc_google_adk_weather_001",
         "context": "google-adk"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
+        "content": "Tokyo is 22°C and partly cloudy — rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
+      "_comment": "tool-rendering-custom-catchall — weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
       "match": {
         "userMessage": "forecast for Tokyo",
-        "toolName": "get_weather",
         "context": "google-adk"
       },
       "response": {
@@ -35,32 +34,20 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
-      "match": {
-        "userMessage": "forecast for Tokyo",
-        "turnIndex": 0,
-        "context": "google-adk"
-      },
-      "response": {
-        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies."
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
+      "_comment": "tool-rendering-custom-catchall — AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
       "match": {
         "userMessage": "What's the current price of AAPL?",
         "toolCallId": "call_d6_cc_google_adk_stock_001",
         "context": "google-adk"
       },
       "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% \u2014 rendered through the custom wildcard catchall."
+        "content": "AAPL is trading at $338.37, down 2.96% — rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
+      "_comment": "tool-rendering-custom-catchall — AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
       "match": {
         "userMessage": "What's the current price of AAPL?",
-        "toolName": "get_stock_price",
         "context": "google-adk"
       },
       "response": {
@@ -74,25 +61,14 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
-      "match": {
-        "userMessage": "What's the current price of AAPL?",
-        "turnIndex": 0,
-        "context": "google-adk"
-      },
-      "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
-      }
-    },
-    {
-      "_comment": "Chain tools \u2014 follow-up after all 3 tools ran. Anchored on whichever of the 3 chain toolCallIds appears last in the request (LangGraph's ToolNode preserves tool_calls order). MUST come before the toolCalls-emitting fixture below so iteration 2 of the chain-tools loop hits this branch instead of re-emitting.",
+      "_comment": "Chain tools — follow-up after all 3 tools ran. Anchored on whichever of the 3 chain toolCallIds appears last in the request (LangGraph's ToolNode preserves tool_calls order). MUST come before the toolCalls-emitting fixture below so iteration 2 of the chain-tools loop hits this branch instead of re-emitting.",
       "match": {
         "userMessage": "Chain a few tools in this single turn",
         "toolCallId": "call_trcc_chain_roll_001",
         "context": "google-adk"
       },
       "response": {
-        "content": "Done \u2014 Tokyo is sunny, three flights found, and the d20 came up 11."
+        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
       }
     },
     {
@@ -102,7 +78,7 @@
         "context": "google-adk"
       },
       "response": {
-        "content": "Done \u2014 Tokyo is sunny, three flights found, and the d20 came up 11."
+        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
       }
     },
     {
@@ -112,11 +88,11 @@
         "context": "google-adk"
       },
       "response": {
-        "content": "Done \u2014 Tokyo is sunny, three flights found, and the d20 came up 11."
+        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
       }
     },
     {
-      "_comment": "Chain tools \u2014 emit 3 tool calls in one assistant turn (get_weather Tokyo + search_flights SFO->Tokyo + roll_d20=11). No turnIndex/hasToolResult gate: in multi-pill demo sessions prior clicks leave tool results AND additional user turns in the thread; the toolCallId fixtures above eat iteration 2 via last-message tool_call_id gating.",
+      "_comment": "Chain tools — emit 3 tool calls in one assistant turn (get_weather Tokyo + search_flights SFO->Tokyo + roll_d20=11). No turnIndex/hasToolResult gate: in multi-pill demo sessions prior clicks leave tool results AND additional user turns in the thread; the toolCallId fixtures above eat iteration 2 via last-message tool_call_id gating.",
       "match": {
         "userMessage": "Chain a few tools in this single turn",
         "context": "google-adk"
@@ -142,18 +118,18 @@
       }
     },
     {
-      "_comment": "Weather in SF \u2014 follow-up content after get_weather tool ran. MUST come before the tool-emitting fixture below (first-match-wins) so iteration 2 of the loop hits this branch instead of re-emitting. toolCallId chain keeps the fixture stateless across multi-pill thread history.",
+      "_comment": "Weather in SF — follow-up content after get_weather tool ran. MUST come before the tool-emitting fixture below (first-match-wins) so iteration 2 of the loop hits this branch instead of re-emitting. toolCallId chain keeps the fixture stateless across multi-pill thread history.",
       "match": {
         "userMessage": "What's the weather in San Francisco?",
         "toolCallId": "call_trcc_weather_sf_001",
         "context": "google-adk"
       },
       "response": {
-        "content": "San Francisco is currently 68\u00b0F and sunny with light winds \u2014 rendered through the custom wildcard catchall."
+        "content": "San Francisco is currently 68°F and sunny with light winds — rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "Weather in SF \u2014 first turn: emit get_weather tool call with location=San Francisco. The wildcard renderer paints [data-testid='custom-wildcard-card'][data-tool-name='get_weather'] with args containing 'San Francisco'.",
+      "_comment": "Weather in SF — first turn: emit get_weather tool call with location=San Francisco. The wildcard renderer paints [data-testid='custom-wildcard-card'][data-tool-name='get_weather'] with args containing 'San Francisco'.",
       "match": {
         "userMessage": "What's the weather in San Francisco?",
         "context": "google-adk"
@@ -169,18 +145,18 @@
       }
     },
     {
-      "_comment": "Find flights \u2014 follow-up content after search_flights ran. MUST come BEFORE the first-leg fixture below \u2014 the matcher is first-match-wins, and the second leg is uniquely identified by `toolCallId` (last message is a tool with this id), so it cannot accidentally swallow the first-leg request (whose last message is the user prompt). The result block of the wildcard card surfaces the tool execution JSON (which already contains 'United', 'Delta', 'JetBlue' from the Python backend); this narration is just to terminate the agent loop.",
+      "_comment": "Find flights — follow-up content after search_flights ran. MUST come BEFORE the first-leg fixture below — the matcher is first-match-wins, and the second leg is uniquely identified by `toolCallId` (last message is a tool with this id), so it cannot accidentally swallow the first-leg request (whose last message is the user prompt). The result block of the wildcard card surfaces the tool execution JSON (which already contains 'United', 'Delta', 'JetBlue' from the Python backend); this narration is just to terminate the agent loop.",
       "match": {
         "userMessage": "Find flights from SFO to JFK.",
         "toolCallId": "call_trcc_flights_sfo_jfk_001",
         "context": "google-adk"
       },
       "response": {
-        "content": "Three flights from SFO to JFK \u2014 United UA231 at 08:15 ($348), Delta DL412 at 11:20 ($312), and JetBlue B6722 at 17:05 ($289)."
+        "content": "Three flights from SFO to JFK — United UA231 at 08:15 ($348), Delta DL412 at 11:20 ($312), and JetBlue B6722 at 17:05 ($289)."
       }
     },
     {
-      "_comment": "Find flights \u2014 first turn: emit search_flights tool call (SFO -> JFK). Backend executes and returns the 3-flight result list; the wildcard renderer surfaces 'United'/'Delta'/'JetBlue' in the result block.",
+      "_comment": "Find flights — first turn: emit search_flights tool call (SFO -> JFK). Backend executes and returns the 3-flight result list; the wildcard renderer surfaces 'United'/'Delta'/'JetBlue' in the result block.",
       "match": {
         "userMessage": "Find flights from SFO to JFK.",
         "context": "google-adk"
@@ -196,7 +172,7 @@
       }
     },
     {
-      "_comment": "Roll a d20 \u2014 exactly 5 sequential roll_d20 calls returning [7, 14, 3, 19, 20]. Chained by toolCallId so the sequence is stateless across thread history. Specific-toolCallId fixtures MUST come before the userMessage-only fixture below; first-match-wins. The 5th roll has value=20 so the result block of the 5th card surfaces \"value\":20.",
+      "_comment": "Roll a d20 — exactly 5 sequential roll_d20 calls returning [7, 14, 3, 19, 20]. Chained by toolCallId so the sequence is stateless across thread history. Specific-toolCallId fixtures MUST come before the userMessage-only fixture below; first-match-wins. The 5th roll has value=20 so the result block of the 5th card surfaces \"value\":20.",
       "match": {
         "userMessage": "Roll a 20-sided die.",
         "toolCallId": "call_trcc_d20_seq_001",
@@ -267,11 +243,11 @@
         "context": "google-adk"
       },
       "response": {
-        "content": "Rolled the d20 five times \u2014 landed on 20 on the final roll."
+        "content": "Rolled the d20 five times — landed on 20 on the final roll."
       }
     },
     {
-      "_comment": "First roll. Matches the initial user prompt (no prior d20 tool result in this chain yet). Comes after the toolCallId-chained fixtures above so iterations 2-6 of the loop hit those first. The multi-pill sequential e2e test clicks 'Find flights' first which leaves prior turns in the thread, so a new 'Roll a 20-sided die.' user message is no longer at turnIndex 0 \u2014 keep this fixture turnIndex-less. The toolCallId-chained fixtures still take precedence for iterations 2-6 because their last-message gate (role=tool with the chained id) only matches mid-chain \u2014 this fixture only matches when last-message.role=user.",
+      "_comment": "First roll. Matches the initial user prompt (no prior d20 tool result in this chain yet). Comes after the toolCallId-chained fixtures above so iterations 2-6 of the loop hit those first. The multi-pill sequential e2e test clicks 'Find flights' first which leaves prior turns in the thread, so a new 'Roll a 20-sided die.' user message is no longer at turnIndex 0 — keep this fixture turnIndex-less. The toolCallId-chained fixtures still take precedence for iterations 2-6 because their last-message gate (role=tool with the chained id) only matches mid-chain — this fixture only matches when last-message.role=user.",
       "match": {
         "userMessage": "Roll a 20-sided die.",
         "context": "google-adk"

--- a/showcase/aimock/d6/google-adk/tool-rendering-default-catchall.json
+++ b/showcase/aimock/d6/google-adk/tool-rendering-default-catchall.json
@@ -6,21 +6,20 @@
   },
   "fixtures": [
     {
-      "_comment": "tool-rendering-default-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch. The built-in default renderer renders [data-testid='copilot-tool-render'][data-tool-name='get_weather'] with a status pill [data-testid='copilot-tool-render-status'].",
+      "_comment": "tool-rendering-default-catchall — weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch. The built-in default renderer renders [data-testid='copilot-tool-render'][data-tool-name='get_weather'] with a status pill [data-testid='copilot-tool-render-status'].",
       "match": {
         "userMessage": "forecast for Tokyo",
         "toolCallId": "call_d6_dc_weather_001",
         "context": "google-adk"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 the default catchall renderer displayed the tool card above."
+        "content": "Tokyo is 22°C and partly cloudy — the default catchall renderer displayed the tool card above."
       }
     },
     {
-      "_comment": "tool-rendering-default-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call that the built-in default catchall renderer handles.",
+      "_comment": "tool-rendering-default-catchall — weather in Tokyo (first turn). Emits get_weather tool call that the built-in default catchall renderer handles.",
       "match": {
         "userMessage": "forecast for Tokyo",
-        "toolName": "get_weather",
         "context": "google-adk"
       },
       "response": {
@@ -31,17 +30,6 @@
             "arguments": "{\"location\":\"Tokyo\"}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-default-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
-      "match": {
-        "userMessage": "forecast for Tokyo",
-        "turnIndex": 0,
-        "context": "google-adk"
-      },
-      "response": {
-        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies and light easterly winds."
       }
     }
   ]

--- a/showcase/aimock/d6/langgraph-fastapi/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/langgraph-fastapi/tool-rendering-custom-catchall.json
@@ -6,21 +6,20 @@
   },
   "fixtures": [
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
+      "_comment": "tool-rendering-custom-catchall — weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
       "match": {
         "userMessage": "forecast for Tokyo",
         "toolCallId": "call_d6_cc_langgraph_fastapi_weather_001",
         "context": "langgraph-fastapi"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
+        "content": "Tokyo is 22°C and partly cloudy — rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
+      "_comment": "tool-rendering-custom-catchall — weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
       "match": {
         "userMessage": "forecast for Tokyo",
-        "toolName": "get_weather",
         "context": "langgraph-fastapi"
       },
       "response": {
@@ -34,32 +33,20 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
-      "match": {
-        "userMessage": "forecast for Tokyo",
-        "turnIndex": 0,
-        "context": "langgraph-fastapi"
-      },
-      "response": {
-        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies."
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
+      "_comment": "tool-rendering-custom-catchall — AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
       "match": {
         "userMessage": "What's the current price of AAPL?",
         "toolCallId": "call_d6_cc_langgraph_fastapi_stock_001",
         "context": "langgraph-fastapi"
       },
       "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% \u2014 rendered through the custom wildcard catchall."
+        "content": "AAPL is trading at $338.37, down 2.96% — rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
+      "_comment": "tool-rendering-custom-catchall — AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
       "match": {
         "userMessage": "What's the current price of AAPL?",
-        "toolName": "get_stock_price",
         "context": "langgraph-fastapi"
       },
       "response": {
@@ -70,17 +57,6 @@
             "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
-      "match": {
-        "userMessage": "What's the current price of AAPL?",
-        "turnIndex": 0,
-        "context": "langgraph-fastapi"
-      },
-      "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
       }
     },
     {
@@ -216,7 +192,6 @@
       "_comment": "First roll. turnIndex=0 fires on initial user prompt before any tool results exist in the chain.",
       "match": {
         "userMessage": "Roll a d20",
-        "turnIndex": 0,
         "context": "langgraph-fastapi"
       },
       "response": {
@@ -263,7 +238,6 @@
     {
       "match": {
         "userMessage": "Chain tools",
-        "turnIndex": 0,
         "context": "langgraph-fastapi"
       },
       "response": {

--- a/showcase/aimock/d6/langgraph-fastapi/tool-rendering-default-catchall.json
+++ b/showcase/aimock/d6/langgraph-fastapi/tool-rendering-default-catchall.json
@@ -6,21 +6,20 @@
   },
   "fixtures": [
     {
-      "_comment": "default-catchall \u2014 weather in Tokyo. Follow-up content after get_weather tool ran. Keyed by toolCallId. MUST come before the tool-emitting fixture below.",
+      "_comment": "default-catchall — weather in Tokyo. Follow-up content after get_weather tool ran. Keyed by toolCallId. MUST come before the tool-emitting fixture below.",
       "match": {
         "userMessage": "forecast for Tokyo",
         "toolCallId": "call_d6_langgraph_fastapi_dc_weather_001",
         "context": "langgraph-fastapi"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy."
+        "content": "Tokyo is 22°C and partly cloudy."
       }
     },
     {
-      "_comment": "default-catchall \u2014 weather in Tokyo, emit get_weather. Uses toolName gate.",
+      "_comment": "default-catchall — weather in Tokyo, emit get_weather. Uses toolName gate.",
       "match": {
         "userMessage": "forecast for Tokyo",
-        "toolName": "get_weather",
         "context": "langgraph-fastapi"
       },
       "response": {
@@ -31,17 +30,6 @@
             "arguments": "{\"location\":\"Tokyo\"}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "default-catchall \u2014 weather in Tokyo, fallback content when no toolName gate matches.",
-      "match": {
-        "userMessage": "forecast for Tokyo",
-        "turnIndex": 0,
-        "context": "langgraph-fastapi"
-      },
-      "response": {
-        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies and light easterly winds."
       }
     },
     {
@@ -177,7 +165,6 @@
       "_comment": "First roll. turnIndex=0 fires on initial user prompt before any tool results exist in the chain.",
       "match": {
         "userMessage": "Roll a d20",
-        "turnIndex": 0,
         "context": "langgraph-fastapi"
       },
       "response": {
@@ -224,7 +211,6 @@
     {
       "match": {
         "userMessage": "Chain tools",
-        "turnIndex": 0,
         "context": "langgraph-fastapi"
       },
       "response": {

--- a/showcase/aimock/d6/langgraph-typescript/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/langgraph-typescript/tool-rendering-custom-catchall.json
@@ -8,21 +8,20 @@
   },
   "fixtures": [
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
+      "_comment": "tool-rendering-custom-catchall — weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
       "match": {
         "userMessage": "forecast for Tokyo",
         "toolCallId": "call_d6_cc_langgraph_typescript_weather_001",
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
+        "content": "Tokyo is 22°C and partly cloudy — rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
+      "_comment": "tool-rendering-custom-catchall — weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
       "match": {
         "userMessage": "forecast for Tokyo",
-        "toolName": "get_weather",
         "context": "langgraph-typescript"
       },
       "response": {
@@ -36,32 +35,20 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
-      "match": {
-        "userMessage": "forecast for Tokyo",
-        "turnIndex": 0,
-        "context": "langgraph-typescript"
-      },
-      "response": {
-        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies."
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
+      "_comment": "tool-rendering-custom-catchall — AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
       "match": {
         "userMessage": "What's the current price of AAPL?",
         "toolCallId": "call_d6_cc_langgraph_typescript_stock_001",
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% \u2014 rendered through the custom wildcard catchall."
+        "content": "AAPL is trading at $338.37, down 2.96% — rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
+      "_comment": "tool-rendering-custom-catchall — AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
       "match": {
         "userMessage": "What's the current price of AAPL?",
-        "toolName": "get_stock_price",
         "context": "langgraph-typescript"
       },
       "response": {
@@ -75,25 +62,14 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
-      "match": {
-        "userMessage": "What's the current price of AAPL?",
-        "turnIndex": 0,
-        "context": "langgraph-typescript"
-      },
-      "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
-      }
-    },
-    {
-      "_comment": "Chain tools \u2014 follow-up content after all 3 tool results return (gated on whichever chained id arrives last).",
+      "_comment": "Chain tools — follow-up content after all 3 tool results return (gated on whichever chained id arrives last).",
       "match": {
         "userMessage": "Chain a few tools in this single turn",
         "toolCallId": "call_tr_chain_roll_001",
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "Done \u2014 Tokyo is sunny, three flights found, and the d20 came up 11."
+        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
       }
     },
     {
@@ -103,7 +79,7 @@
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "Done \u2014 Tokyo is sunny, three flights found, and the d20 came up 11."
+        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
       }
     },
     {
@@ -113,11 +89,11 @@
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "Done \u2014 Tokyo is sunny, three flights found, and the d20 came up 11."
+        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
       }
     },
     {
-      "_comment": "Chain tools first turn \u2014 emit 3 tool calls (weather Tokyo + flights SFO->Tokyo + roll_d20=11). No turnIndex / hasToolResult gate: in multi-pill demo sessions prior clicks leave tool results in the thread, which would skip this fixture and fall through to tool-rendering.json's \"weather in Tokyo\" matcher (substring of this prompt). The toolCallId fixtures above eat iteration 2 via last-message tool_call_id gating, so removing the hasToolResult gate is safe.",
+      "_comment": "Chain tools first turn — emit 3 tool calls (weather Tokyo + flights SFO->Tokyo + roll_d20=11). No turnIndex / hasToolResult gate: in multi-pill demo sessions prior clicks leave tool results in the thread, which would skip this fixture and fall through to tool-rendering.json's \"weather in Tokyo\" matcher (substring of this prompt). The toolCallId fixtures above eat iteration 2 via last-message tool_call_id gating, so removing the hasToolResult gate is safe.",
       "match": {
         "userMessage": "Chain a few tools in this single turn",
         "context": "langgraph-typescript"
@@ -143,18 +119,18 @@
       }
     },
     {
-      "_comment": "Weather in SF \u2014 follow-up content after get_weather ran.",
+      "_comment": "Weather in SF — follow-up content after get_weather ran.",
       "match": {
         "userMessage": "What's the weather in San Francisco?",
         "toolCallId": "call_tr_weather_sf_001",
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "San Francisco is currently 68\u00b0F and sunny with light winds."
+        "content": "San Francisco is currently 68°F and sunny with light winds."
       }
     },
     {
-      "_comment": "Weather in SF \u2014 first turn, emits get_weather('San Francisco'). No turnIndex gate.",
+      "_comment": "Weather in SF — first turn, emits get_weather('San Francisco'). No turnIndex gate.",
       "match": {
         "userMessage": "What's the weather in San Francisco?",
         "context": "langgraph-typescript"
@@ -170,18 +146,18 @@
       }
     },
     {
-      "_comment": "Find flights \u2014 follow-up content after search_flights ran. Contains United/Delta/JetBlue tokens for the spec assertion on `data-testid='custom-wildcard-result'`.",
+      "_comment": "Find flights — follow-up content after search_flights ran. Contains United/Delta/JetBlue tokens for the spec assertion on `data-testid='custom-wildcard-result'`.",
       "match": {
         "userMessage": "Find flights from SFO to JFK.",
         "toolCallId": "call_tr_flights_sfo_jfk_001",
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "Three flights from SFO to JFK \u2014 United UA231 at 08:15 ($348), Delta DL412 at 11:20 ($312), and JetBlue B6722 at 17:05 ($289)."
+        "content": "Three flights from SFO to JFK — United UA231 at 08:15 ($348), Delta DL412 at 11:20 ($312), and JetBlue B6722 at 17:05 ($289)."
       }
     },
     {
-      "_comment": "Find flights \u2014 first turn, emits search_flights. Spec asserts on result containing United/Delta/JetBlue \u2014 bake those into the tool args so the catchall renderer surfaces them.",
+      "_comment": "Find flights — first turn, emits search_flights. Spec asserts on result containing United/Delta/JetBlue — bake those into the tool args so the catchall renderer surfaces them.",
       "match": {
         "userMessage": "Find flights from SFO to JFK.",
         "context": "langgraph-typescript"
@@ -197,7 +173,7 @@
       }
     },
     {
-      "_comment": "Roll a d20 \u2014 sequence chained by toolCallId. Iteration 1 emits seq_001 (value 7); subsequent iterations are keyed to the prior id.",
+      "_comment": "Roll a d20 — sequence chained by toolCallId. Iteration 1 emits seq_001 (value 7); subsequent iterations are keyed to the prior id.",
       "match": {
         "userMessage": "Roll a 20-sided die.",
         "toolCallId": "call_tr_d20_seq_001",
@@ -268,11 +244,11 @@
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "Rolled the d20 five times \u2014 landed on 20 on the final roll."
+        "content": "Rolled the d20 five times — landed on 20 on the final roll."
       }
     },
     {
-      "_comment": "Roll a d20 \u2014 first roll. No turnIndex gate so multi-pill sessions work; the toolCallId-chained fixtures above take precedence for iterations 2-6.",
+      "_comment": "Roll a d20 — first roll. No turnIndex gate so multi-pill sessions work; the toolCallId-chained fixtures above take precedence for iterations 2-6.",
       "match": {
         "userMessage": "Roll a 20-sided die.",
         "context": "langgraph-typescript"

--- a/showcase/aimock/d6/langgraph-typescript/tool-rendering-default-catchall.json
+++ b/showcase/aimock/d6/langgraph-typescript/tool-rendering-default-catchall.json
@@ -7,21 +7,20 @@
   },
   "fixtures": [
     {
-      "_comment": "default-catchall \u2014 weather in Tokyo. Follow-up content after get_weather tool ran. Keyed by toolCallId. MUST come before the tool-emitting fixture below.",
+      "_comment": "default-catchall — weather in Tokyo. Follow-up content after get_weather tool ran. Keyed by toolCallId. MUST come before the tool-emitting fixture below.",
       "match": {
         "userMessage": "forecast for Tokyo",
         "toolCallId": "call_d6_langgraph_typescript_dc_weather_001",
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy."
+        "content": "Tokyo is 22°C and partly cloudy."
       }
     },
     {
-      "_comment": "default-catchall \u2014 weather in Tokyo, emit get_weather. Uses toolName gate.",
+      "_comment": "default-catchall — weather in Tokyo, emit get_weather. Uses toolName gate.",
       "match": {
         "userMessage": "forecast for Tokyo",
-        "toolName": "get_weather",
         "context": "langgraph-typescript"
       },
       "response": {
@@ -35,25 +34,14 @@
       }
     },
     {
-      "_comment": "default-catchall \u2014 weather in Tokyo, fallback content when no toolName gate matches.",
-      "match": {
-        "userMessage": "forecast for Tokyo",
-        "turnIndex": 0,
-        "context": "langgraph-typescript"
-      },
-      "response": {
-        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies and light easterly winds."
-      }
-    },
-    {
-      "_comment": "default-catchall pill: Chain tools \u2014 follow-up after all 3 tools ran.",
+      "_comment": "default-catchall pill: Chain tools — follow-up after all 3 tools ran.",
       "match": {
         "userMessage": "Chain a few tools in this single turn",
         "toolCallId": "call_tr_chain_roll_001",
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "Done \u2014 Tokyo is sunny, three flights found, and the d20 came up 11."
+        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
       }
     },
     {
@@ -63,7 +51,7 @@
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "Done \u2014 Tokyo is sunny, three flights found, and the d20 came up 11."
+        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
       }
     },
     {
@@ -73,11 +61,11 @@
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "Done \u2014 Tokyo is sunny, three flights found, and the d20 came up 11."
+        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
       }
     },
     {
-      "_comment": "default-catchall pill: Chain tools \u2014 emit 3 tool calls in one turn.",
+      "_comment": "default-catchall pill: Chain tools — emit 3 tool calls in one turn.",
       "match": {
         "userMessage": "Chain a few tools in this single turn",
         "context": "langgraph-typescript",
@@ -104,14 +92,14 @@
       }
     },
     {
-      "_comment": "default-catchall pill: Weather in SF \u2014 follow-up after get_weather ran.",
+      "_comment": "default-catchall pill: Weather in SF — follow-up after get_weather ran.",
       "match": {
         "userMessage": "What's the weather in San Francisco?",
         "toolCallId": "call_tr_weather_sf_001",
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "San Francisco is currently 68\u00b0F and sunny with light winds."
+        "content": "San Francisco is currently 68°F and sunny with light winds."
       }
     },
     {
@@ -130,14 +118,14 @@
       }
     },
     {
-      "_comment": "default-catchall pill: Find flights \u2014 second leg.",
+      "_comment": "default-catchall pill: Find flights — second leg.",
       "match": {
         "userMessage": "Find flights from SFO to JFK.",
         "toolCallId": "call_tr_flights_sfo_jfk_001",
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "Three flights from SFO to JFK \u2014 United UA231 at 08:15 ($348), Delta DL412 at 11:20 ($312), and JetBlue B6722 at 17:05 ($289)."
+        "content": "Three flights from SFO to JFK — United UA231 at 08:15 ($348), Delta DL412 at 11:20 ($312), and JetBlue B6722 at 17:05 ($289)."
       }
     },
     {
@@ -156,7 +144,7 @@
       }
     },
     {
-      "_comment": "default-catchall pill: Roll a d20 \u2014 5-roll chain via toolCallId. Seq: 7\u219214\u21923\u219219\u219220.",
+      "_comment": "default-catchall pill: Roll a d20 — 5-roll chain via toolCallId. Seq: 7→14→3→19→20.",
       "match": {
         "userMessage": "Roll a 20-sided die.",
         "toolCallId": "call_tr_d20_seq_001",
@@ -227,11 +215,11 @@
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "Rolled the d20 five times \u2014 landed on 20 on the final roll."
+        "content": "Rolled the d20 five times — landed on 20 on the final roll."
       }
     },
     {
-      "_comment": "First roll \u2014 initial user prompt, no prior d20 tool result.",
+      "_comment": "First roll — initial user prompt, no prior d20 tool result.",
       "match": {
         "userMessage": "Roll a 20-sided die.",
         "context": "langgraph-typescript"

--- a/showcase/aimock/d6/ms-agent-dotnet/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/ms-agent-dotnet/tool-rendering-custom-catchall.json
@@ -7,21 +7,20 @@
   },
   "fixtures": [
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
+      "_comment": "tool-rendering-custom-catchall — weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
       "match": {
         "userMessage": "forecast for Tokyo",
         "toolCallId": "call_d6_cc_ms_agent_dotnet_weather_001",
         "context": "ms-agent-dotnet"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
+        "content": "Tokyo is 22°C and partly cloudy — rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
+      "_comment": "tool-rendering-custom-catchall — weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
       "match": {
         "userMessage": "forecast for Tokyo",
-        "toolName": "get_weather",
         "context": "ms-agent-dotnet"
       },
       "response": {
@@ -35,32 +34,20 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
-      "match": {
-        "userMessage": "forecast for Tokyo",
-        "turnIndex": 0,
-        "context": "ms-agent-dotnet"
-      },
-      "response": {
-        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies."
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
+      "_comment": "tool-rendering-custom-catchall — AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
       "match": {
         "userMessage": "What's the current price of AAPL?",
         "toolCallId": "call_d6_cc_ms_agent_dotnet_stock_001",
         "context": "ms-agent-dotnet"
       },
       "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% \u2014 rendered through the custom wildcard catchall."
+        "content": "AAPL is trading at $338.37, down 2.96% — rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
+      "_comment": "tool-rendering-custom-catchall — AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
       "match": {
         "userMessage": "What's the current price of AAPL?",
-        "toolName": "get_stock_price",
         "context": "ms-agent-dotnet"
       },
       "response": {
@@ -71,17 +58,6 @@
             "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
-      "match": {
-        "userMessage": "What's the current price of AAPL?",
-        "turnIndex": 0,
-        "context": "ms-agent-dotnet"
-      },
-      "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
       }
     },
     {

--- a/showcase/aimock/d6/ms-agent-dotnet/tool-rendering-default-catchall.json
+++ b/showcase/aimock/d6/ms-agent-dotnet/tool-rendering-default-catchall.json
@@ -20,7 +20,6 @@
       "_comment": "tool-rendering-default-catchall — weather in Tokyo (first turn). Emits get_weather tool call that the built-in default catchall renderer handles.",
       "match": {
         "userMessage": "forecast for Tokyo",
-        "toolName": "get_weather",
         "context": "ms-agent-dotnet"
       },
       "response": {
@@ -31,17 +30,6 @@
             "arguments": "{\"location\":\"Tokyo\"}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-default-catchall — weather in Tokyo fallback when no get_weather tool registered.",
-      "match": {
-        "userMessage": "forecast for Tokyo",
-        "turnIndex": 0,
-        "context": "ms-agent-dotnet"
-      },
-      "response": {
-        "content": "The weather in Tokyo is currently 22°C with partly cloudy skies and light easterly winds."
       }
     }
   ]

--- a/showcase/aimock/d6/spring-ai/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/spring-ai/tool-rendering-custom-catchall.json
@@ -20,7 +20,6 @@
       "_comment": "custom-catchall turn 1 — emit get_weather tool call. The custom wildcard renderer fires for any tool. toolName-gated so agents without get_weather still fall through to tool-rendering.json's content-only fallback; hasToolResult:false keeps this off the post-tool leg.",
       "match": {
         "userMessage": "forecast for Tokyo",
-        "toolName": "get_weather",
         "hasToolResult": false,
         "context": "spring-ai"
       },
@@ -49,7 +48,6 @@
       "_comment": "custom-catchall turn 2 — emit get_stock_price tool call. Both turns render through the same custom-wildcard-card testid with different data-tool-name values. The old hasToolResult:false gate could never match turn 2: turn 1's get_weather tool result is still in the thread (hasToolResult is a whole-thread check), so the request fell through to no-match -> backend RuntimeException -> RUN_ERROR. Deliberately NO turnIndex/hasToolResult gate: spring-ai's MessageListFilter reshapes prior-turn messages, making both counts unreliable (a turnIndex:2 gate also failed live). Loop safety comes from ordering — the toolCallId-gated follow-up above matches the post-tool leg first. This file loads before tool-rendering.json, so this also absorbs that demo's turnIndex:0 AAPL pill leg; that is benign-equivalent (same get_stock_price name, same ticker/price_usd/change_pct argument shape, near-identical follow-up content).",
       "match": {
         "userMessage": "current price of AAPL",
-        "toolName": "get_stock_price",
         "context": "spring-ai"
       },
       "response": {


### PR DESCRIPTION
## Summary

LGP-align 10 D6 catchall fixture files by stripping the broken `match.toolName` gate and the `turnIndex:0` content-fallback fixtures. Targets 24 production reds (12 d5 + 12 d6) on the `tool-rendering-default-catchall` and `tool-rendering-custom-catchall` demos.

## Root cause

Catchall demos use `useDefaultRenderTool` (wildcard renderer) — the frontend does NOT advertise a named tool. aimock's matcher (`/Users/jpr5/proj/aimock/src/agui-handler.ts:114-117`) defines `match.toolName` as: *the named tool must appear in `input.tools` (frontend-advertised tools)*. With a wildcard renderer, `toolName: "get_weather"` / `"get_stock_price"` ALWAYS evaluates false → tool-emit fixture skipped → matcher falls through.

Three failure modes from this single root cause:

- **Cluster 1** (10 reds — langgraph-fastapi, langroid, claude-sdk-python, spring-ai, built-in-agent d5+d6): "missing tool name(s) [get_stock_price]; observed: [get_weather]" — turn 2 re-rendered turn 1's tool because the gated stock fixture was skipped and matcher fell through to a userMessage-only get_weather fixture.
- **Cluster 2** (10 reds — agno, llamaindex, google-adk, ms-agent-dotnet, strands d5+d6): 30s timeout — no fixture matched turn 2 (the `turnIndex:0` content-fallback fixtures also failed at turn 2), backend hung waiting on a real LLM response.
- **Cluster 3** (4 reds — langgraph-typescript default+custom catchall d5+d6): turn 1 emitted CONTENT instead of a tool call — fixture fell through to `tool-rendering.json`'s content-emitting fallback for "weather in Tokyo".

## Fix

Per `/tmp/diag-classb-report.md` Fix A — pure JSON edits mirroring the LGP-gold matcher discipline (LGP custom-catchall uses ONLY `userMessage + toolCallId + context` — NO `toolName`, NO `turnIndex` gates):

- Strip `match.toolName` from every catchall fixture (15 instances across 10 files).
- Delete `match.turnIndex: 0` content-fallback fixtures (12 instances) — they shadow turn 2 in multi-turn probe sessions and are redundant once the `toolName` gate is removed.
- Strip `match.turnIndex: 0` keys from tool-emit fixtures that retained the key alongside `userMessage + context` (4 instances) — first-match-wins ordering with the `toolCallId` follow-up fixtures above keeps them iteration-1-only.

Total: 10 files changed, +78/-229 lines.

The 12 sibling catchall files under `d6/{agno,built-in-agent,langroid,llamaindex,strands}/`, plus `spring-ai/tool-rendering-default-catchall.json` and `claude-sdk-python/tool-rendering-custom-catchall.json`, already use the LGP-gold matcher discipline and require no edit.

## Risk

Low. Pure additive removal of broken gates — no backend, frontend, or probe code changes. No new live LLM paths introduced (the fix REMOVES gates that currently force fall-through to broken fallbacks; it does not add new dynamic resolution).

## Local D6 verify status

Local `showcase/bin/showcase test langgraph-typescript --d6 --verbose --isolate` could not be completed in this session: the local Docker daemon's buildx had a multi-minute hung-build pattern (0% CPU after 1-2min) under concurrent worktree pressure from another active session. The fix is JSON-only against a deterministic matcher; CI will exercise the full D6 suite on this PR.

## Test plan

- [ ] CI: `showcase_e2e_d6` matrix turns the 12 affected cells (d6: 12 integrations × 1 cell each per dimension) GREEN.
- [ ] CI: `showcase_e2e_d5` matrix turns the same 12 cells GREEN (d5 shares the same fixture).
- [ ] No regression on the 12 unmodified catchall siblings (agno, built-in-agent, langroid, llamaindex, strands × both catchall variants + spring-ai default + claude-sdk-python custom).
- [ ] No regression on `tool-rendering` (non-catchall) cells.

## References

- Diag report: `/tmp/diag-classb-report.md`
- Gold reference: `showcase/aimock/d6/langgraph-python/tool-rendering-custom-catchall.json`
- aimock matcher: `aimock/src/agui-handler.ts:114-117`