### PR TITLE
fix(showcase): allow harness to boot locally without SHARED_SECRET (unblock local verify)

### DIFF
--- a/showcase/docker-compose.local.yml
+++ b/showcase/docker-compose.local.yml
@@ -244,6 +244,18 @@ services:
       # bring up matching worker replicas). The control-plane reads this to
       # know how many workers to expect in the pool.
       - HARNESS_POOL_COUNT=${HARNESS_POOL_COUNT:-1}
+      # Local-dev escape hatch for the SHARED_SECRET fail-loud gate added in
+      # PR #5458 (commit c81b361f1). The harness refuses to boot in any
+      # deployable mode (NODE_ENV != "test") without SHARED_SECRET /
+      # SHARED_SECRET_PREV because POST /webhooks/deploy is only registered
+      # when webhookSecrets.length > 0 (see src/http/server.ts:119 and
+      # loadWebhookSecrets in src/orchestrator.ts). The local docker-compose
+      # stack does not run the Showcase: Verify Deploy webhook flow, so we
+      # enable the documented HARNESS_ALLOW_NO_SECRET=1 escape to let the
+      # harness boot locally. PROD IS UNAFFECTED: Railway sets SHARED_SECRET
+      # explicitly via env, so the gate fires normally there and this flag
+      # is never read.
+      - HARNESS_ALLOW_NO_SECRET=1
       # Control-plane needs PocketBase (the work queue + status store) but
       # runs no Chromium, so it does not need demo reachability for browsing.
       - POCKETBASE_URL=http://pocketbase:8090
@@ -318,6 +330,11 @@ services:
       # control-plane connection.
       - HARNESS_ROLE=worker
       - HARNESS_POOL_COUNT=${HARNESS_POOL_COUNT:-1}
+      # Local-dev escape hatch for the SHARED_SECRET fail-loud gate (see
+      # the matching comment on harness-control-plane above). Prod-on-Railway
+      # sets SHARED_SECRET explicitly; this flag only matters for the local
+      # docker-compose stack.
+      - HARNESS_ALLOW_NO_SECRET=1
       - POCKETBASE_URL=http://pocketbase:8090
       - POCKETBASE_SUPERUSER_EMAIL=admin@example.com
       - POCKETBASE_SUPERUSER_PASSWORD=showcase-local-dev


### PR DESCRIPTION
## Problem

PR #5458 (`c81b361f1` — *fix(showcase/harness): register /webhooks/deploy on CP path + fail-loud on missing SHARED_SECRET*) added a fail-loud gate to `loadWebhookSecrets` in `showcase/harness/src/orchestrator.ts` that refuses harness boot in any deployable mode (`NODE_ENV !== "test"`) without `SHARED_SECRET` (or `SHARED_SECRET_PREV`) set, because `POST /webhooks/deploy` is only registered when `webhookSecrets.length > 0` (gate at `showcase/harness/src/http/server.ts:119`).

The local `showcase/docker-compose.local.yml` harness services inherit `NODE_ENV=production` from the image and do not set `SHARED_SECRET` (and should not — that secret only matters for the Showcase: Verify Deploy webhook flow on Railway). As a result, the harness crash-loops on every local `bin/showcase test --d5/--d6` run:

```
FATAL-CONFIG: SHARED_SECRET (or SHARED_SECRET_PREV) is required — refusing to boot in any deployable mode … Set SHARED_SECRET (or SHARED_SECRET_PREV) in the env, or set NODE_ENV=test / HARNESS_ALLOW_NO_SECRET=1 for local dev. Current NODE_ENV=production.
```

…which blocks **all** local D5/D6 verify.

## Fix

Add `HARNESS_ALLOW_NO_SECRET=1` (the documented local-dev escape hatch — explicitly named in the FATAL-CONFIG message itself, and the dedicated env var checked by `loadWebhookSecrets` at `orchestrator.ts:190`) to both harness services in `showcase/docker-compose.local.yml`:

- `harness-control-plane`
- `harness-pool-worker`

Inline comments explain the rationale and pin the relevant source locations (the gate at `src/http/server.ts:119` and `loadWebhookSecrets` in `src/orchestrator.ts`).

Diff: 17 lines added (comments + 2 env vars), no other files touched.

## Prod impact: NONE

Railway sets `SHARED_SECRET` explicitly via env on every harness service, so `loadWebhookSecrets` sees a real secret, registers `POST /webhooks/deploy`, and **never reads `HARNESS_ALLOW_NO_SECRET`**. The escape hatch only takes effect when both secrets are absent. This change only affects the local docker-compose stack.

## Local verification

Brought up the slot-1 isolated stack with the fix applied via `SHOWCASE_ISO_SLOT=3 ./bin/showcase test langgraph-typescript --d6 --verbose --isolate` and observed clean boot:

```
showcase-iso1-harness                 Up 12 seconds (healthy)
showcase-iso1-langgraph-typescript    Up 12 seconds (healthy)
showcase-iso1-harness-pool-worker-1   Up 12 seconds (healthy)
showcase-iso1-dashboard               Up 13 seconds (healthy)
showcase-iso1-aimock                  Up 18 seconds (healthy)
showcase-iso1-pocketbase              Up 18 seconds (healthy)
```

Harness boot logs confirm:

- `fleet.role-selected` + `fleet.control-plane.started` + `showcase-harness.fleet.control-plane.boot` (port 8080) — control-plane up
- `webhook auth disabled — neither SHARED_SECRET nor SHARED_SECRET_PREV is set` with `escapeHatch:true` at **warn** level — the expected log produced by `loadWebhookSecrets` when the escape hatch fires
- `worker.registered` + `fleet.worker.boot` — worker self-registered
- `worker.claimed jobId=… probeKey=d6:langgraph-typescript` — real D6 job picked up and run end-to-end

NO `FATAL-CONFIG`, NO restart loop.

(The D6 cell may still be RED on this branch — that is a pre-existing issue, unrelated to this infra fix. The point of this PR is "harness boots and runs a job at all locally", which it now does.)

## References

- PR #5458 (`c81b361f1`): the fail-loud gate this PR re-enables an escape for
- `showcase/harness/src/orchestrator.ts` `loadWebhookSecrets` (~line 180-220): the predicate that reads `HARNESS_ALLOW_NO_SECRET`
- `showcase/harness/src/http/server.ts:119`: the route-registration gate