### PR TITLE
fix(harness): waitForTurnComplete reads LAST bubble (multi-step agent regression from #5462)

### DIFF
--- a/showcase/harness/src/probes/helpers/assistant-message-count.ts
+++ b/showcase/harness/src/probes/helpers/assistant-message-count.ts
@@ -318,6 +318,113 @@ export async function readCascadeState(
 }
 
 /**
+ * Atomic single-`page.evaluate` reader returning BOTH the assistant-bubble
+ * count and the text at the LAST bubble (`count - 1`) in the matched cascade
+ * tier — in ONE browser-side round-trip.
+ *
+ * Why "last" rather than a caller-supplied strict index: multi-step agents
+ * (LangGraph, Mastra, CrewAI, …) emit MULTIPLE assistant bubbles per turn
+ * (tool-call bubble + tool-render bubble + final-text bubble). Reading the
+ * bubble at strict index `turnIndex - 1` would land on an intermediate
+ * tool-call bubble whose scoped-text selectors (`[data-message-content]`,
+ * `.cpk\:prose`, `.prose`, `p`) are EMPTY — the tool-call's content lives
+ * in a sibling node outside the scoped-text cascade — so the cascade-
+ * pollution guard returns null forever and the text-stable conjunct times
+ * out with `reason=text-unstable`. The LAST bubble in a multi-step turn is
+ * the agent's final-text bubble whose `.cpk\:prose` contains the streamed
+ * message text, which is the only bubble whose stable text can settle the
+ * gate.
+ *
+ * Defect-2 protection (un-turn-scoped bubble selection) is preserved by the
+ * caller: `waitForTurnComplete` snapshots a `baselineCount` BEFORE submit
+ * and only treats `count > baselineCount` as "a new bubble for this turn
+ * has appeared", so reading the last bubble cannot leak a leftover from a
+ * prior turn.
+ *
+ * Contract — same as `readCascadeState` but with `idx` resolved internally:
+ *   - count: from whichever tier matched (first tier whose `length > 0`)
+ *   - text:  per-tier scoped text at index `count - 1` within that SAME tier,
+ *            using the same scoped-text cascade as `findAssistantBubbleAt`
+ *            (null when the last bubble's scoped selectors are all empty —
+ *            mid-stream placeholder state).
+ *   - When no tier matches: `{ count: 0, text: null }`.
+ *
+ * Implementation note: the closure body references `querySelectorAll` AND
+ * `textContent` AND the literal `{ count` — the unit-test fakes dispatch on
+ * those substrings to route the evaluate call to the cascade-state branch.
+ */
+export async function readCascadeStateLast(
+  page: Page,
+): Promise<{ count: number; text: string | null }> {
+  try {
+    return await page.evaluate(() => {
+      interface DomElement {
+        readonly textContent: string | null;
+        querySelector(sel: string): DomElement | null;
+      }
+      interface DomNodeList {
+        readonly length: number;
+        item(idx: number): DomElement | null;
+      }
+      const doc = (
+        globalThis as unknown as {
+          document: { querySelectorAll(sel: string): DomNodeList };
+        }
+      ).document;
+      const tiers: Array<{ bubble: string; textSelectors: string[] }> = [
+        {
+          bubble: '[data-testid="copilot-assistant-message"]',
+          textSelectors: ["[data-message-content]", ".cpk\\:prose", ".prose"],
+        },
+        {
+          bubble: '[role="article"][data-message-role="assistant"]',
+          textSelectors: ["[data-message-content]", "p"],
+        },
+        {
+          bubble: '[role="article"]:not([data-message-role="user"])',
+          textSelectors: ["[data-message-content]", "p"],
+        },
+        {
+          bubble: '[data-message-role="assistant"]',
+          textSelectors: ["[data-message-content]", "p"],
+        },
+      ];
+      for (const tier of tiers) {
+        const list = doc.querySelectorAll(tier.bubble);
+        if (list.length > 0) {
+          const count = list.length;
+          // Read the LAST bubble in the matched tier (count - 1) — see
+          // function docstring for why "last" rather than a strict index.
+          const lastIdx = count - 1;
+          const bubble = list.item(lastIdx);
+          if (!bubble) return { count, text: null };
+          for (const textSel of tier.textSelectors) {
+            const scoped = bubble.querySelector(textSel);
+            if (scoped !== null) {
+              const t = scoped.textContent ?? "";
+              if (t.trim().length > 0) {
+                return { count, text: t };
+              }
+            }
+          }
+          // Cascade-pollution guard mirroring `readCascadeState`:
+          // no scoped child has non-empty text — return null rather than
+          // falling back to the whole bubble's textContent (which would
+          // re-introduce LGP suggestion-pill / toolbar pollution).
+          return { count, text: null };
+        }
+      }
+      return { count: 0, text: null };
+    });
+  } catch (err) {
+    console.warn(
+      `[assistant-message-count] readCascadeStateLast: ${(err as Error).message ?? err}`,
+    );
+    return { count: 0, text: null };
+  }
+}
+
+/**
  * Pure sibling of the scoped-text cascade inside `findAssistantBubbleAt`'s
  * `page.evaluate` closure. Kept in lock-step with the closure body so unit
  * tests can exercise the empty-textContent fall-through without JSDOM.

--- a/showcase/harness/src/probes/helpers/conversation-runner.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.ts
@@ -33,7 +33,7 @@ import {
   ASSISTANT_MESSAGE_HEADLESS_SELECTOR,
   ASSISTANT_MESSAGE_PRIMARY_SELECTOR,
   countAssistantMessages,
-  readCascadeState,
+  readCascadeStateLast,
 } from "./assistant-message-count.js";
 import { formatCvdiag } from "./cv-diag.js";
 
@@ -570,6 +570,18 @@ export async function runConversation(
         }
       };
 
+      // Defect-2 sentinel for the multi-bubble hotfix: snapshot the count
+      // of assistant bubbles already in the DOM BEFORE this turn submits.
+      // Multi-step agents emit >1 bubble per turn — `waitForTurnComplete`
+      // gates on `count > baselineCount` to detect "a new bubble appeared
+      // for THIS turn" without assuming 1 bubble = 1 turn. Captured BEFORE
+      // sendTurnMessage so the assistant can't have started streaming yet
+      // (the user message hasn't been submitted), guaranteeing the
+      // snapshot reflects only prior-turn bubbles.
+      const baselineCount = await countAssistantMessages(
+        page as unknown as PlaywrightPage,
+      );
+
       await sendTurnMessage();
 
       console.debug(
@@ -632,6 +644,7 @@ export async function runConversation(
           settleMs,
           timeoutMs: turnTimeoutMs,
           baselineBannerText,
+          baselineCount,
         });
       } catch (settleErr) {
         // Translate a turn-incomplete failure observed alongside a
@@ -725,6 +738,16 @@ export async function runConversation(
           if (chatInputSelector === null) {
             throw translatedErr;
           }
+          // Re-snapshot the post-reload baseline assistant-bubble count
+          // BEFORE the cold-start re-send. The page DOM was torn down by
+          // page.reload() so the count is typically 0, but a demo with a
+          // prerendered seed conversation could expose pre-existing
+          // bubbles — capture the real count so the multi-bubble gate
+          // (`count > baselineCount`) cannot misread those as the retry's
+          // response.
+          const retryBaselineCount = await countAssistantMessages(
+            page as unknown as PlaywrightPage,
+          );
           await fillAndVerifySend(page, chatInputSelector, turn.input);
           // Re-snapshot the post-reload baseline banner. The page DOM was
           // torn down + repainted, so any banner now visible is the
@@ -753,6 +776,7 @@ export async function runConversation(
                 turnDeadline - Date.now(),
               ),
               baselineBannerText: retryBaselineBannerText,
+              baselineCount: retryBaselineCount,
             });
           } catch (retryErr) {
             if (retryErr instanceof BannerVisibleError) {
@@ -1352,6 +1376,25 @@ export interface WaitForTurnCompleteOpts {
    * (or a fresh visible-after-absent) counts as a candidate.
    */
   baselineBannerText?: string | null;
+  /**
+   * Pre-turn baseline assistant-bubble count snapshot. Captured by the
+   * runner BEFORE the user message is submitted so the gate can detect
+   * "a new bubble appeared for THIS turn" without assuming "1 turn = 1
+   * bubble" (multi-step agents — LangGraph, Mastra, CrewAI — emit
+   * 2-3+ bubbles per turn: tool-call + tool-render + final-text).
+   *
+   * Defect-2 protection: the gate requires `count > baselineCount` so a
+   * leftover bubble from a prior turn cannot be misread as this turn's
+   * response. The settled bubble is then the LAST in the matched cascade
+   * tier (read via `readCascadeStateLast`) — for a multi-step turn that's
+   * the agent's final-text bubble whose scoped text settles cleanly; for
+   * a single-bubble turn that's the only new bubble.
+   *
+   * When omitted, defaults to `turnIndex - 1` to preserve the
+   * pre-multi-step-fix semantics (1 bubble per turn) — used by unit-test
+   * fakes that script count progressions keyed to turn ordinals.
+   */
+  baselineCount?: number;
 }
 
 /** Result of a successful `waitForTurnComplete`. */
@@ -1427,7 +1470,16 @@ export async function waitForTurnComplete(
   const { page, turnIndex, settleMs, timeoutMs } = opts;
   const baselineBannerText = opts.baselineBannerText ?? null;
   const pollIntervalMs = opts.pollIntervalMs ?? POLL_INTERVAL_MS;
-  const bubbleIndex = turnIndex - 1;
+  // Defect-2 sentinel: per-turn baseline count of assistant bubbles already
+  // in the DOM BEFORE this turn submitted. The gate requires
+  // `count > baselineCount` so a leftover bubble from a prior turn cannot
+  // be misread as this turn's response. Defaults to `turnIndex - 1` for
+  // backward compat with unit-test fakes that script count progressions
+  // keyed to turn ordinals; production callers (the runner) snapshot the
+  // real pre-submit count and pass it explicitly. See the multi-bubble
+  // hotfix: multi-step agents (LangGraph, Mastra, CrewAI) emit 2-3+
+  // bubbles per turn, so "turn N = N bubbles" no longer holds.
+  const baselineCount = opts.baselineCount ?? turnIndex - 1;
   const startedAt = Date.now();
   // Track the last observed text per-poll so we can measure how long
   // the bubble has been stable. `null` is a distinct "no bubble yet"
@@ -1449,22 +1501,35 @@ export async function waitForTurnComplete(
   const pwPage = page as unknown as PlaywrightPage;
   while (Date.now() - startedAt < timeoutMs) {
     const runsFinished = await readRunsFinished(page);
-    // Atomic single-evaluate read: `readCascadeState` returns BOTH the
-    // count and the indexed text from the SAME cascade tier in ONE
-    // browser-side round-trip, eliminating a DOM-mutates-between-reads
-    // race where the count comes from one tier and the text from another.
-    const { count, text } = await readCascadeState(pwPage, bubbleIndex);
+    // Atomic single-evaluate read: `readCascadeStateLast` returns BOTH the
+    // count and the text of the LAST bubble in the matched cascade tier in
+    // ONE browser-side round-trip. The "last bubble" semantics is the
+    // multi-bubble hotfix: multi-step agents (LangGraph, Mastra, CrewAI)
+    // emit a tool-call bubble + tool-render bubble + final-text bubble
+    // per turn; only the LAST bubble's scoped text (`.cpk\:prose` etc.)
+    // is non-empty. The strict-index `turnIndex - 1` semantics this
+    // replaces landed on intermediate tool-call bubbles whose scoped
+    // selectors were empty forever → text-stable timeout across most
+    // multi-step demos.
+    const { count, text } = await readCascadeStateLast(pwPage);
     const now = Date.now();
     if (text !== lastText) {
       lastText = text;
       lastChangeAt = now;
     }
     const sseOk = runsFinished >= turnIndex;
-    const domOk = count > bubbleIndex;
+    // Defect-2 protection: a new bubble has appeared for THIS turn — not
+    // just "any bubble exists". `count > baselineCount` rejects a leftover
+    // bubble from a prior turn while accepting multi-step turns where >1
+    // bubble appears (we still want the LAST of the new arrivals).
+    const domOk = count > baselineCount;
     const textOk =
       text !== null && text.trim().length > 0 && now - lastChangeAt >= settleMs;
     if (sseOk && domOk && textOk) {
-      return { bubbleIndex, text: text! };
+      // bubbleIndex returned = last bubble in the matched tier at the
+      // moment of return, so callers consuming the assertions ctx see the
+      // same bubble whose text settled the gate.
+      return { bubbleIndex: count - 1, text: text! };
     }
     // Pre-conjunct banner fast-fail guard. We ONLY fire fast-fail when the
     // assistant hasn't yet produced a response for THIS turn (domOk =
@@ -1519,7 +1584,7 @@ export async function waitForTurnComplete(
   const reason: TurnNotCompleteError["reason"] =
     runsFinishedFinal < turnIndex
       ? "sse-missing"
-      : countFinal <= bubbleIndex
+      : countFinal <= baselineCount
         ? "dom-missing"
         : "text-unstable";
   throw new TurnNotCompleteError(


### PR DESCRIPTION
## Summary

**URGENT hotfix.** Staging is widely red for D5/D6 multi-step demos. Root cause confirmed via live Playwright DOM inspection on staging (langgraph-typescript : beautiful-chat : pie chart prompt).

PR #5462's defect-2 fix uses `bubbleIndex = turnIndex - 1`, which assumes one assistant bubble per turn. Multi-step agents (LangGraph, Mastra, CrewAI, llama-index, ag2, etc.) emit 2-3+ bubbles per turn — tool-call bubble + tool-render bubble + final-text bubble. The strict-index read lands on an intermediate **tool-call** bubble whose scoped-text selectors (`.cpk:prose`, `[data-message-content]`, `.prose`, `p`) are **empty** (tool-call content lives in a sibling card div outside the scoped cascade). The cascade-pollution guard correctly returns `null` → the text-stable conjunct never converges → `reason=text-unstable` timeout across virtually every multi-step demo (beautiful-chat-*, gen-ui-*, shared-state-*, agentic-chat on most backends).

## Live RED-GREEN proof (staging)

Standalone Playwright probe against `showcase-langgraph-typescript-staging.up.railway.app/demos/beautiful-chat`, prompt = `"pie chart of revenue distribution by category from the sample sales data"`, captured BOTH the OLD-logic read (`bubbleIndex = turnIndex - 1 = 0`) AND the NEW-logic read (`bubbleIndex = count - 1 = 2`) in ONE atomic page evaluate after the turn settled:

```
TOTAL BUBBLE COUNT FOR TURN 1: 3  (true multi-step — tool-call + tool-render + final-text)
FINAL TIER: [data-testid="copilot-assistant-message"]

OLD LOGIC (bubbleIndex = turnIndex - 1 = 0):
  count = 3
  text  = null
  reason = all scoped selectors empty           ← would time out: reason=text-unstable

NEW LOGIC (bubbleIndex = count - 1 = 2):
  count = 3
  text  = "Here is the pie chart showing the revenue distribution by category from the sample sales data."
  textLen = 94                                  ← gate settles cleanly
```

RED ≠ GREEN; new logic returns 94 chars of stable final-text where old logic returns `null`. The bug and the fix are proven on real staging DOM.

### Live DOM evidence
LangGraph TS beautiful-chat, prompt = "pie chart of revenue distribution by category…":
```
count = 3 bubbles in [data-testid="copilot-assistant-message"]
bubble[0]: tool-call "query_data"   — `.cpk:prose` exists but EMPTY (content in sibling <div class="my-1.5">)
bubble[1]: pie-chart card           — `.cpk:prose` exists but EMPTY (content in sibling styled card div)
bubble[2]: final text "Here is the pie chart..." — `.cpk:prose` has 94 chars + toolbar mounted
```

The old pre-#5462 runner read `list[last]` (always the last bubble — always bubble[2] above). The PR moved to `turnIndex - 1`, which is bubble[0] (the tool-call) for any multi-step turn → broken.

## Fix

Read the LAST bubble in the matched cascade tier (`count - 1`) instead of a fixed strict index. Defect-2 protection (don't read a leftover bubble from a prior turn) is preserved via an explicit **pre-submit baselineCount sentinel snapshot** in the runner — the gate now requires `count > baselineCount` rather than `count > turnIndex - 1`. This correctly rejects stale prior-turn bubbles **without assuming 1 bubble = 1 turn**.

### Changes
- `assistant-message-count.ts`: add `readCascadeStateLast(page)` — same atomic single-evaluate contract as `readCascadeState`, but resolves the bubble index internally as `count - 1`.
- `conversation-runner.ts`:
  - Snapshot `baselineCount = countAssistantMessages(page)` BEFORE `sendTurnMessage()` each turn.
  - Pass through to `waitForTurnComplete` via new `baselineCount` option (defaults to `turnIndex - 1` to preserve unit-test fake compatibility).
  - `waitForTurnComplete` reads via `readCascadeStateLast` and gates on `domOk = count > baselineCount`.
  - Cold-start retry re-snapshots `baselineCount` after `page.reload()`.
  - Returned `bubbleIndex` in the success ctx = `count - 1` (matches the bubble whose text settled the gate).
  - `dom-missing` reason classifier updated to `countFinal <= baselineCount`.

## Why this doesn't regress defect-2

The original defect-2 (un-turn-scoped bubble selection) leaked a later turn's bubble into THIS turn's assertions because `readLastAssistantText` read `list[last]` GLOBALLY with no per-turn baseline. The new fix re-introduces the "read last" semantics but adds the **per-turn pre-submit baseline count snapshot** — the gate only advances once a NEW bubble has appeared (`count > baselineCount`), so we cannot read a leftover from a prior turn, and the "last" we return is the last NEW bubble (which for multi-step turns is the final-text bubble whose scoped text actually settles).

## Test plan

- [x] **Live RED-GREEN staging probe** (see above) — confirms OLD logic = null and NEW logic = 94-char final-text on a real 3-bubble multi-step turn.
- [x] All 72 `conversation-runner.test.ts` + `assistant-message-count.test.ts` unit tests pass (default `baselineCount = turnIndex - 1` keeps existing count-progression scripts working).
- [x] Full harness vitest suite: 2758/2758 green across 129 test files.
- [x] `tsc --noEmit` clean on `showcase/harness`.
- [x] `oxfmt --check` clean on changed files.
- [x] `oxlint` clean on changed files.
- [ ] Staging D5/D6 sweep after merge confirms multi-step demos (beautiful-chat, gen-ui, shared-state, langgraph/mastra/crewai agentic-chat) recover from `text-unstable` red.

## Scope

Strictly the two files above. No unrelated changes. No refactors.
