### PR TITLE
refactor(showcase): probe taxonomy cleanup — drop Smoke, rename E2E (Demo) → UI (Frontend)

### DIFF
--- a/showcase/harness/src/probes/drivers/liveness.test.ts
+++ b/showcase/harness/src/probes/drivers/liveness.test.ts
@@ -9,15 +9,20 @@ import type {
   ProbeResultWriter,
 } from "../../types/index.js";
 
-// Driver-level tests for the smoke ProbeDriver. Deep behavioural coverage of
+// Driver-level tests for the liveness ProbeDriver. Deep behavioural coverage of
 // `deriveHealthUrl` + the legacy `livenessProbe.run` path lives in
 // `../liveness.test.ts`; this file verifies the driver-adapter layer:
 //   - schema accepts/rejects the expected YAML-static input shape
-//   - primary return value (smoke tick) matches the canonical ProbeResult
+//   - primary return value (health tick) matches the canonical ProbeResult
 //     shape per status code
-//   - side-emission of the paired `health:<slug>` tick via ctx.writer
+//   - side-emission of the paired `agent:<slug>` tick via ctx.writer
 //   - timeout at the driver level resolves to `timeout after Nms`
 //   - concurrency-safety across N parallel `run()` calls
+//
+// The `/smoke` GET probe was dropped (it had the same contract as `/health` on
+// the same service — pure redundancy). The driver now issues two HTTP calls
+// per tick (health + agent), emits `health:<slug>` as the primary return, and
+// `agent:<slug>` via writer side-emit.
 
 function mkWriter(): {
   writer: ProbeResultWriter;
@@ -51,27 +56,22 @@ function mkCtx(writer?: ProbeResultWriter): ProbeContext {
 function responseFor(
   url: string,
   opts: {
-    smokeStatus?: number;
     healthStatus?: number;
     agentStatus?: number;
-    smokeBody?: string;
     healthBody?: string;
     agentBody?: string;
   },
 ): Response {
   const isAgent = /\/api\/copilotkit(\/|\b|\?|$)/.test(url);
-  const isHealth = !isAgent && /\/health(\b|\/|\?|$)/.test(url);
   let status: number;
   let body: string;
   if (isAgent) {
     status = opts.agentStatus ?? 200;
     body = opts.agentBody ?? '{"status":"ok"}';
-  } else if (isHealth) {
+  } else {
+    // Everything else (`/health`, `/api/health`) is the health probe.
     status = opts.healthStatus ?? 200;
     body = opts.healthBody ?? '{"status":"ok"}';
-  } else {
-    status = opts.smokeStatus ?? 200;
-    body = opts.smokeBody ?? '{"status":"ok"}';
   }
   return new Response(body, {
     status,
@@ -79,12 +79,10 @@ function responseFor(
   });
 }
 
-/** Fake-fetch factory: answer smoke/health/agent differently per test case. */
+/** Fake-fetch factory: answer health/agent differently per test case. */
 function fakeFetch(opts: {
-  smokeStatus?: number;
   healthStatus?: number;
   agentStatus?: number;
-  smokeBody?: string;
   healthBody?: string;
   agentBody?: string;
 }): typeof fetch {
@@ -105,7 +103,10 @@ describe("livenessDriver", () => {
     vi.unstubAllGlobals();
   });
 
-  it("exposes kind === 'smoke'", () => {
+  it("exposes kind === 'smoke' (registry-key back-compat)", () => {
+    // Display dimension renamed (Smoke→Health), but the driver's kind stays
+    // `smoke` so YAML probe configs and orchestrator family wiring keep
+    // routing to this driver.
     expect(livenessDriver.kind).toBe("smoke");
   });
 
@@ -139,52 +140,81 @@ describe("livenessDriver", () => {
     expect(parsed.success).toBe(false);
   });
 
-  it("happy path: 200 /smoke + 200 /health + 200 /agent → green smoke + green health + green agent side-emissions", async () => {
-    vi.stubGlobal(
-      "fetch",
-      fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
-    );
+  it("happy path: 200 /health + 200 /agent → green health primary + green agent side-emission", async () => {
+    vi.stubGlobal("fetch", fakeFetch({ healthStatus: 200, agentStatus: 200 }));
     const { writer, writes } = mkWriter();
     const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
     expect(r.state).toBe("green");
-    expect(r.key).toBe("smoke:mastra");
+    // Primary return is health:<slug> (smoke:<slug> was redundant with health
+    // and was dropped).
+    expect(r.key).toBe("health:mastra");
     expect(r.signal.status).toBe(200);
-    expect(writes).toHaveLength(2);
-    expect(writes[0]!.key).toBe("health:mastra");
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.key).toBe("agent:mastra");
     expect(writes[0]!.state).toBe("green");
-    expect(writes[1]!.key).toBe("agent:mastra");
-    expect(writes[1]!.state).toBe("green");
   });
 
-  it("/smoke 500 → smoke red, health still probes", async () => {
-    vi.stubGlobal(
-      "fetch",
-      fakeFetch({ smokeStatus: 500, healthStatus: 200, agentStatus: 200 }),
-    );
+  it("never emits a `smoke:<slug>` key (primary or side-emit)", async () => {
+    // Regression guard for the taxonomy cleanup: the smoke endpoint and its
+    // `smoke:<slug>` ProbeResult were dropped. Neither the primary return nor
+    // any writer side-emission may carry a `smoke:` prefix.
+    vi.stubGlobal("fetch", fakeFetch({ healthStatus: 200, agentStatus: 200 }));
+    const { writer, writes } = mkWriter();
+    const r = await livenessDriver.run(mkCtx(writer), {
+      key: "smoke:mastra",
+      url: "https://x.example/smoke",
+    });
+    expect(r.key.startsWith("smoke:")).toBe(false);
+    for (const w of writes) {
+      expect(w.key.startsWith("smoke:")).toBe(false);
+    }
+  });
+
+  it("never issues a GET against `/smoke` or `/api/smoke`", async () => {
+    const calls: string[] = [];
+    const fetchImpl: typeof fetch = (async (url: string | URL) => {
+      const href = typeof url === "string" ? url : url.toString();
+      calls.push(href);
+      return responseFor(href, { healthStatus: 200, agentStatus: 200 });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+    const { writer } = mkWriter();
+    await livenessDriver.run(mkCtx(writer), {
+      key: "smoke:mastra",
+      url: "https://x.example/smoke",
+    });
+    for (const c of calls) {
+      expect(/\/smoke(\/|$|\?)/.test(new URL(c).pathname)).toBe(false);
+      expect(/\/api\/smoke(\/|$|\?)/.test(new URL(c).pathname)).toBe(false);
+    }
+    // Exactly two calls: one /health, one /api/copilotkit/.
+    expect(calls.length).toBe(2);
+  });
+
+  it("/health 500 → primary red, agent still probes", async () => {
+    vi.stubGlobal("fetch", fakeFetch({ healthStatus: 500, agentStatus: 200 }));
     const { writer, writes } = mkWriter();
     const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
     expect(r.state).toBe("red");
+    expect(r.key).toBe("health:mastra");
     expect(r.signal.errorDesc).toContain("500");
-    expect(writes).toHaveLength(2);
-    expect(writes[0]!.key).toBe("health:mastra");
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.key).toBe("agent:mastra");
     expect(writes[0]!.state).toBe("green");
-    expect(writes[1]!.key).toBe("agent:mastra");
-    expect(writes[1]!.state).toBe("green");
   });
 
-  it("/smoke 404 → smoke red with http 404 errorDesc", async () => {
+  it("/health 404 → primary red with http 404 errorDesc", async () => {
     vi.stubGlobal(
       "fetch",
       fakeFetch({
-        smokeStatus: 404,
-        smokeBody: "",
-        healthStatus: 200,
+        healthStatus: 404,
+        healthBody: "",
         agentStatus: 200,
       }),
     );
@@ -195,10 +225,10 @@ describe("livenessDriver", () => {
     });
     expect(r.state).toBe("red");
     expect(r.signal.errorDesc).toBe("http 404");
-    expect(writes).toHaveLength(2);
+    expect(writes).toHaveLength(1);
   });
 
-  it("/smoke times out → smoke red with 'timeout after Nms'", async () => {
+  it("/health times out → primary red with 'timeout after Nms'", async () => {
     // Fake fetch that waits on the AbortSignal and rejects with an
     // AbortError — mirrors what the real fetch does when aborted.
     const fetchImpl: typeof fetch = (async (
@@ -229,23 +259,18 @@ describe("livenessDriver", () => {
     });
     expect(r.state).toBe("red");
     expect(r.signal.errorDesc).toBe("timeout after 5ms");
-    // Health + agent ticks should also show a timeout (same fake-fetch).
-    expect(writes).toHaveLength(2);
+    // Agent tick should also show a timeout (same fake-fetch).
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.key).toBe("agent:mastra");
     expect(writes[0]!.state).toBe("red");
-    expect((writes[0]!.signal as { errorDesc?: string }).errorDesc).toBe(
-      "timeout after 5ms",
-    );
-    expect(writes[1]!.key).toBe("agent:mastra");
-    expect(writes[1]!.state).toBe("red");
   });
 
-  it("/smoke 200 with malformed JSON body → smoke red with parse reason", async () => {
+  it("/health 200 with malformed JSON body → primary red with parse reason", async () => {
     vi.stubGlobal(
       "fetch",
       fakeFetch({
-        smokeStatus: 200,
-        smokeBody: "<html>ServiceUnavailable</html>",
         healthStatus: 200,
+        healthBody: "<html>ServiceUnavailable</html>",
         agentStatus: 200,
       }),
     );
@@ -256,35 +281,27 @@ describe("livenessDriver", () => {
     });
     expect(r.state).toBe("red");
     expect(r.signal.errorDesc).toMatch(/malformed body/);
-    // Health + agent side-emits still OK.
-    expect(writes).toHaveLength(2);
+    // Agent side-emit still OK.
+    expect(writes).toHaveLength(1);
     expect(writes[0]!.state).toBe("green");
-    expect(writes[1]!.state).toBe("green");
   });
 
-  it("/health 503 → health red, smoke + agent unaffected", async () => {
-    vi.stubGlobal(
-      "fetch",
-      fakeFetch({ smokeStatus: 200, healthStatus: 503, agentStatus: 200 }),
-    );
+  it("/health 503 → primary red, agent unaffected", async () => {
+    vi.stubGlobal("fetch", fakeFetch({ healthStatus: 503, agentStatus: 200 }));
     const { writer, writes } = mkWriter();
     const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
-    expect(r.state).toBe("green");
-    expect(writes).toHaveLength(2);
-    expect(writes[0]!.key).toBe("health:mastra");
-    expect(writes[0]!.state).toBe("red");
-    expect((writes[0]!.signal as { errorDesc?: string }).errorDesc).toContain(
-      "503",
-    );
-    expect(writes[1]!.key).toBe("agent:mastra");
-    expect(writes[1]!.state).toBe("green");
+    expect(r.state).toBe("red");
+    expect(r.signal.errorDesc).toContain("503");
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.key).toBe("agent:mastra");
+    expect(writes[0]!.state).toBe("green");
   });
 
   it("missing writer logs a warning and does not throw", async () => {
-    vi.stubGlobal("fetch", fakeFetch({ smokeStatus: 200, healthStatus: 200 }));
+    vi.stubGlobal("fetch", fakeFetch({ healthStatus: 200 }));
     const r = await livenessDriver.run(mkCtx(undefined), {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
@@ -292,8 +309,8 @@ describe("livenessDriver", () => {
     expect(r.state).toBe("green");
   });
 
-  it("writer.write() throwing on side-emit does not break the primary smoke return", async () => {
-    vi.stubGlobal("fetch", fakeFetch({ smokeStatus: 200, healthStatus: 200 }));
+  it("writer.write() throwing on side-emit does not break the primary return", async () => {
+    vi.stubGlobal("fetch", fakeFetch({ healthStatus: 200 }));
     const writer: ProbeResultWriter = {
       async write() {
         throw new Error("writer exploded");
@@ -304,10 +321,10 @@ describe("livenessDriver", () => {
       url: "https://x.example/smoke",
     });
     expect(r.state).toBe("green");
-    expect(r.key).toBe("smoke:mastra");
+    expect(r.key).toBe("health:mastra");
   });
 
-  it("fetch throwing a generic network error → smoke red with raw message", async () => {
+  it("fetch throwing a generic network error → primary red with raw message", async () => {
     const fetchImpl: typeof fetch = (async () => {
       throw new Error("ECONNRESET");
     }) as unknown as typeof fetch;
@@ -319,10 +336,9 @@ describe("livenessDriver", () => {
     });
     expect(r.state).toBe("red");
     expect(r.signal.errorDesc).toContain("ECONNRESET");
-    expect(writes).toHaveLength(2);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.key).toBe("agent:mastra");
     expect(writes[0]!.state).toBe("red");
-    expect(writes[1]!.key).toBe("agent:mastra");
-    expect(writes[1]!.state).toBe("red");
   });
 
   it("10 parallel run() calls don't cross-contaminate URLs or keys", async () => {
@@ -331,7 +347,6 @@ describe("livenessDriver", () => {
       const href = typeof url === "string" ? url : url.toString();
       calls.push(href);
       return responseFor(href, {
-        smokeStatus: 200,
         healthStatus: 200,
         agentStatus: 200,
       });
@@ -350,34 +365,31 @@ describe("livenessDriver", () => {
       ),
     );
 
-    // All 10 smoke ticks green + 10 health + 10 agent side-emissions green.
+    // All 10 health ticks green + 10 agent side-emissions green.
     expect(results.map((r) => r.state)).toEqual(Array(10).fill("green"));
     expect(results.map((r) => r.key).sort()).toEqual(
-      slugs.map((s) => `smoke:${s}`).sort(),
+      slugs.map((s) => `health:${s}`).sort(),
     );
-    // writes has 20 entries: 10 health:<slug> + 10 agent:<slug>.
+    // writes has 10 entries: 10 agent:<slug>.
     const writeKeys = writes.map((w) => w.key).sort();
-    const expectedWriteKeys = [
-      ...slugs.map((s) => `health:${s}`),
-      ...slugs.map((s) => `agent:${s}`),
-    ].sort();
+    const expectedWriteKeys = slugs.map((s) => `agent:${s}`).sort();
     expect(writeKeys).toEqual(expectedWriteKeys);
     // Every fake-fetch call received a URL matching one of the expected
-    // smoke, health, or agent URLs — no cross-contamination.
+    // health or agent URLs — no cross-contamination.
     for (const href of calls) {
       expect(href).toMatch(
-        /^https:\/\/x-svc\d\.example\/(smoke|health|api\/copilotkit\/?)$/,
+        /^https:\/\/x-svc\d\.example\/(health|api\/copilotkit\/?)$/,
       );
     }
-    // Each slug's smoke + health + agent URL invoked exactly once (10 × 3 = 30).
-    expect(calls.length).toBe(30);
+    // Each slug's health + agent URL invoked exactly once (10 × 2 = 20).
+    expect(calls.length).toBe(20);
   });
 
-  it("/smoke 500 with long body truncates errorDesc at 160 chars + ellipsis", async () => {
+  it("/health 500 with long body truncates errorDesc at 160 chars + ellipsis", async () => {
     const longBody = "x".repeat(500);
     vi.stubGlobal(
       "fetch",
-      fakeFetch({ smokeStatus: 500, smokeBody: longBody, healthStatus: 200 }),
+      fakeFetch({ healthStatus: 500, healthBody: longBody }),
     );
     const { writer } = mkWriter();
     const r = await livenessDriver.run(mkCtx(writer), {
@@ -416,7 +428,7 @@ describe("livenessDriver", () => {
   });
 
   it("SMOKE_TIMEOUT_MS=invalid falls back to the 10s default", async () => {
-    vi.stubGlobal("fetch", fakeFetch({ smokeStatus: 200, healthStatus: 200 }));
+    vi.stubGlobal("fetch", fakeFetch({ healthStatus: 200 }));
     const { writer } = mkWriter();
     const ctx: ProbeContext = {
       now: () => new Date("2026-04-22T00:00:00Z"),
@@ -450,18 +462,17 @@ describe("livenessDriver", () => {
   });
 
   it("input key without ':' falls back to whole-key as slug", async () => {
-    vi.stubGlobal(
-      "fetch",
-      fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
-    );
+    vi.stubGlobal("fetch", fakeFetch({ healthStatus: 200, agentStatus: 200 }));
     const { writer, writes } = mkWriter();
     const r = await livenessDriver.run(mkCtx(writer), {
       key: "bare",
       url: "https://x.example/smoke",
     });
     expect(r.state).toBe("green");
-    expect(writes[0]!.key).toBe("health:bare");
-    expect(writes[1]!.key).toBe("agent:bare");
+    // A non-`smoke:`-prefixed key passes through verbatim — keeps an
+    // operator-authored key intact rather than coercing it.
+    expect(r.key).toBe("bare");
+    expect(writes[0]!.key).toBe("agent:bare");
   });
 
   // -------------------------------------------------------------------
@@ -469,10 +480,7 @@ describe("livenessDriver", () => {
   // -------------------------------------------------------------------
 
   it("/agent 200 → agent green with status 200", async () => {
-    vi.stubGlobal(
-      "fetch",
-      fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
-    );
+    vi.stubGlobal("fetch", fakeFetch({ healthStatus: 200, agentStatus: 200 }));
     const { writer, writes } = mkWriter();
     await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
@@ -487,10 +495,7 @@ describe("livenessDriver", () => {
     // The CopilotKit Hono router returns 400 for an empty `{}` body; this
     // is still an L2 success — any non-404 response proves the route
     // exists. Mirrors the `checkAgentEndpoint` contract.
-    vi.stubGlobal(
-      "fetch",
-      fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 400 }),
-    );
+    vi.stubGlobal("fetch", fakeFetch({ healthStatus: 200, agentStatus: 400 }));
     const { writer, writes } = mkWriter();
     await livenessDriver.run(mkCtx(writer), {
       key: "smoke:mastra",
@@ -505,7 +510,6 @@ describe("livenessDriver", () => {
     vi.stubGlobal(
       "fetch",
       fakeFetch({
-        smokeStatus: 200,
         healthStatus: 200,
         agentStatus: 404,
         agentBody: "",
@@ -527,7 +531,6 @@ describe("livenessDriver", () => {
     vi.stubGlobal(
       "fetch",
       fakeFetch({
-        smokeStatus: 200,
         healthStatus: 200,
         agentStatus: 404,
         agentBody: "<html>Next.js 404</html>",
@@ -556,7 +559,7 @@ describe("livenessDriver", () => {
       if (/\/api\/copilotkit/.test(href)) {
         throw new Error("EHOSTUNREACH");
       }
-      return responseFor(href, { smokeStatus: 200, healthStatus: 200 });
+      return responseFor(href, { healthStatus: 200 });
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
     const { writer, writes } = mkWriter();
@@ -564,7 +567,7 @@ describe("livenessDriver", () => {
       key: "smoke:mastra",
       url: "https://x.example/smoke",
     });
-    expect(callIdx).toBeGreaterThanOrEqual(3);
+    expect(callIdx).toBeGreaterThanOrEqual(2);
     const agent = writes.find((w) => w.key === "agent:mastra")!;
     expect(agent.state).toBe("red");
     expect((agent.signal as SmokeDriverSignal).errorDesc).toContain(
@@ -583,7 +586,6 @@ describe("livenessDriver", () => {
         agentInit = init;
       }
       return responseFor(href, {
-        smokeStatus: 200,
         healthStatus: 200,
         agentStatus: 200,
       });
@@ -606,7 +608,7 @@ describe("livenessDriver", () => {
   // -------------------------------------------------------------------
 
   it("inputSchema accepts discovery shape { key, name, publicUrl, imageRef, env }", () => {
-    const parsed = smokeInputSchema_safeParse({
+    const parsed = livenessInputSchema_safeParse({
       key: "smoke:ag2",
       name: "showcase-ag2",
       imageRef: "ghcr.io/copilotkit/showcase-ag2:latest",
@@ -617,7 +619,7 @@ describe("livenessDriver", () => {
   });
 
   it("inputSchema rejects when neither `url` nor (`name` + `publicUrl`) is set", () => {
-    const parsed = smokeInputSchema_safeParse({ key: "smoke:ag2" });
+    const parsed = livenessInputSchema_safeParse({ key: "smoke:ag2" });
     expect(parsed.success).toBe(false);
   });
 
@@ -627,7 +629,6 @@ describe("livenessDriver", () => {
       const href = typeof url === "string" ? url : url.toString();
       calls.push(href);
       return responseFor(href, {
-        smokeStatus: 200,
         healthStatus: 200,
         agentStatus: 200,
       });
@@ -642,24 +643,24 @@ describe("livenessDriver", () => {
       env: {},
     });
     expect(r.state).toBe("green");
-    expect(r.key).toBe("smoke:ag2");
-    expect(writes.map((w) => w.key).sort()).toEqual(
-      ["agent:ag2", "health:ag2"].sort(),
-    );
-    expect(calls).toContain("https://showcase-ag2.up.railway.app/api/smoke");
+    // Primary return key is the stripped-slug health row.
+    expect(r.key).toBe("health:ag2");
+    expect(writes.map((w) => w.key).sort()).toEqual(["agent:ag2"]);
     expect(calls).toContain("https://showcase-ag2.up.railway.app/api/health");
     expect(calls).toContain(
       "https://showcase-ag2.up.railway.app/api/copilotkit/",
     );
+    // No /smoke or /api/smoke call.
+    expect(calls.some((c) => /\/api\/smoke\b/.test(c))).toBe(false);
+    expect(calls.some((c) => /\/smoke$/.test(new URL(c).pathname))).toBe(false);
   });
 
-  it("package shape (explicit): hits /api/smoke + /api/health", async () => {
+  it("package shape (explicit): hits /api/health (no /api/smoke)", async () => {
     const calls: string[] = [];
     const fetchImpl: typeof fetch = (async (url: string | URL) => {
       const href = typeof url === "string" ? url : url.toString();
       calls.push(href);
       return responseFor(href, {
-        smokeStatus: 200,
         healthStatus: 200,
         agentStatus: 200,
       });
@@ -672,8 +673,8 @@ describe("livenessDriver", () => {
       publicUrl: "https://showcase-ag2.up.railway.app",
       shape: "package",
     });
-    expect(calls).toContain("https://showcase-ag2.up.railway.app/api/smoke");
     expect(calls).toContain("https://showcase-ag2.up.railway.app/api/health");
+    expect(calls.some((c) => /\/api\/smoke\b/.test(c))).toBe(false);
   });
 
   // -------------------------------------------------------------------
@@ -753,7 +754,7 @@ describe("livenessDriver", () => {
         }
         return new Response("{}", { status: 200 });
       }
-      return responseFor(href, { smokeStatus: 200, healthStatus: 200 });
+      return responseFor(href, { healthStatus: 200 });
     }) as unknown as typeof fetch;
     vi.stubGlobal("fetch", fetchImpl);
     const { writer } = mkWriter();
@@ -803,16 +804,12 @@ describe("livenessDriver", () => {
     expect(parsed.success).toBe(false);
   });
 
-  // Item-5 regression guards: the primary `smoke:<slug>` key is rewritten
-  // in discovery mode so YAML key_templates that interpolate `${name}`
-  // (producing `smoke:showcase-ag2`) land on the stripped slug
-  // (`smoke:ag2`) dashboards + alerts are actually keyed on. Static mode
-  // passes the YAML-authored key through verbatim.
-  it("discovery package: `smoke:showcase-ag2` is rewritten to `smoke:ag2`", async () => {
-    vi.stubGlobal(
-      "fetch",
-      fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
-    );
+  // The primary key rewriting rule: discovery mode is always
+  // `health:<slug>`; static mode rewrites a leading `smoke:` prefix to
+  // `health:` (since YAML key_templates historically use the smoke
+  // family) and otherwise passes the key through verbatim.
+  it("discovery package: `smoke:showcase-ag2` is rewritten to `health:ag2`", async () => {
+    vi.stubGlobal("fetch", fakeFetch({ healthStatus: 200, agentStatus: 200 }));
     const { writer } = mkWriter();
     const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:showcase-ag2",
@@ -820,20 +817,17 @@ describe("livenessDriver", () => {
       publicUrl: "https://showcase-ag2.up.railway.app",
       shape: "package",
     });
-    expect(r.key).toBe("smoke:ag2");
+    expect(r.key).toBe("health:ag2");
   });
 
-  it("static mode passes the YAML-authored key through verbatim", async () => {
-    vi.stubGlobal(
-      "fetch",
-      fakeFetch({ smokeStatus: 200, healthStatus: 200, agentStatus: 200 }),
-    );
+  it("static mode rewrites a `smoke:` prefix to `health:`", async () => {
+    vi.stubGlobal("fetch", fakeFetch({ healthStatus: 200, agentStatus: 200 }));
     const { writer } = mkWriter();
     const r = await livenessDriver.run(mkCtx(writer), {
       key: "smoke:custom-yaml-key",
       url: "https://x.example/smoke",
     });
-    expect(r.key).toBe("smoke:custom-yaml-key");
+    expect(r.key).toBe("health:custom-yaml-key");
   });
 
   it("discovery input with trailing `/` on publicUrl strips it before appending paths", async () => {
@@ -842,7 +836,6 @@ describe("livenessDriver", () => {
       const href = typeof url === "string" ? url : url.toString();
       calls.push(href);
       return responseFor(href, {
-        smokeStatus: 200,
         healthStatus: 200,
         agentStatus: 200,
       });
@@ -869,7 +862,7 @@ describe("livenessDriver", () => {
  * pull it through the existing `livenessDriver` import so the tested shape
  * matches exactly what the invoker hands in.
  */
-function smokeInputSchema_safeParse(input: unknown): { success: boolean } {
+function livenessInputSchema_safeParse(input: unknown): { success: boolean } {
   return livenessDriver.inputSchema.safeParse(input);
 }
 
@@ -902,8 +895,8 @@ async function startRealRedirectServer(spec: {
       res.end();
       return;
     }
-    // Smoke / health GETs land on `/smoke` / `/health` — respond 200 with
-    // a JSON body so those rows don't accidentally fail.
+    // Health GETs land on `/health` — respond 200 with a JSON body so
+    // those rows don't accidentally fail.
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end('{"status":"ok"}');
   });

--- a/showcase/harness/src/probes/drivers/liveness.ts
+++ b/showcase/harness/src/probes/drivers/liveness.ts
@@ -10,19 +10,17 @@ import type { ProbeDriver } from "../types.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
 
 /**
- * Driver wrapper around the existing smoke probe. Converts a single YAML-
- * static target (`{ key, url }`) OR a railway-services discovery record
- * (`{ key, name, imageRef, publicUrl, env }`) into the THREE ProbeResults
- * the smoke dimension now emits per tick:
+ * Driver wrapper around the liveness probe. Converts a single YAML-static
+ * target (`{ key, url }`) OR a railway-services discovery record
+ * (`{ key, name, imageRef, publicUrl, env }`) into the TWO ProbeResults
+ * this dimension emits per tick:
  *
- *   1. `smoke:<slug>`  — the RETURN VALUE of `run()`. The invoker runs
+ *   1. `health:<slug>` — the RETURN VALUE of `run()`. The derived /health
+ *      URL is GET-probed for a 200-OK JSON body. The invoker runs
  *      `writer.write()` on the returned result just like every other
- *      driver, so the primary smoke tick participates in the standard
+ *      driver, so the primary tick participates in the standard
  *      status-writer / alert-engine pipeline with no special-casing.
- *   2. `health:<slug>` — side-emission #1 via `ctx.writer.write()`.
- *      Derived /health URL (via `deriveHealthUrl`) is GET-probed for
- *      a 200-OK JSON body, same contract as the smoke tick.
- *   3. `agent:<slug>`  — side-emission #2 via `ctx.writer.write()`. L2
+ *   2. `agent:<slug>` — side-emission via `ctx.writer.write()`. L2
  *      coverage: POSTs to `${backendUrl}/api/copilotkit/` with an empty
  *      JSON body and asserts the response is non-404. Matches the
  *      contract of `checkAgentEndpoint` in the e2e helpers — any
@@ -31,20 +29,30 @@ import type { ProbeContext, ProbeResult } from "../../types/index.js";
  *      type, etc.). Green on non-404 2xx-5xx responses, red on 404 or
  *      transport failure.
  *
+ * The previous incarnation of this driver also issued a third HTTP probe
+ * to `/smoke` and emitted a `smoke:<slug>` primary result, but that probe
+ * was the same contract as `/health` (200-OK JSON body) on the same
+ * service — pure redundancy. Dropping it halves the per-tick HTTP cost
+ * on the smoke family and keeps the dashboard taxonomy honest: the
+ * "service is alive" signal is `health:<slug>`, full stop.
+ *
  * Why not return `ProbeResult[]`? The invoker's fan-out and bookkeeping
  * is uniform across ALL drivers — one input, one primary result, one
  * writer.write. Teaching every driver, every test helper, and every
  * fan-out path to handle an array-of-results for a single edge case
- * would bleed smoke-specific semantics into the driver-framework core.
+ * would bleed liveness-specific semantics into the driver-framework core.
  * Writer side-emission is already a first-class capability of the
- * writer-engine pipeline, so using it here keeps smoke's paired-probe
- * behaviour contained to this file.
+ * writer-engine pipeline, so using it here keeps the agent side-emit
+ * contained to this file.
  *
  * Input shapes: the driver accepts TWO inputs.
- *   - Static YAML: `{ key, url }`. `url` is the `/api/smoke` endpoint;
- *     the derived /api/health + agent URLs come from path manipulation.
- *   - Discovery: `{ key, name, imageRef, publicUrl, env }`. The smoke
- *     URL is `${publicUrl}/smoke`; slug is `name` with the `showcase-`
+ *   - Static YAML: `{ key, url }`. `url` is historically the `/api/smoke`
+ *     endpoint; the derived /api/health + agent URLs come from path
+ *     manipulation. The `url` field is kept for backwards-compatibility
+ *     with existing static-mode YAML configs even though the smoke
+ *     endpoint itself is no longer probed.
+ *   - Discovery: `{ key, name, imageRef, publicUrl, env }`. The base
+ *     URL is `publicUrl`; slug is `name` with the `showcase-`
  *     prefix stripped (`showcase-ag2` → `ag2`). `imageRef` + `env` are
  *     ignored by this driver but declared in the schema so the
  *     railway-services record passes through without a translation
@@ -53,16 +61,15 @@ import type { ProbeContext, ProbeResult } from "../../types/index.js";
  * Slug derivation priority: (1) if `name` is present, strip the
  * `showcase-` prefix; (2) otherwise split `key` on `:` and take the
  * second segment. This keeps static-YAML ticks emitting the same
- * `smoke:<slug>`/`health:<slug>`/`agent:<slug>` triple the dashboard
- * expects while letting discovery-sourced ticks emit the same triple
- * without the YAML operator hand-editing key strings.
+ * `health:<slug>`/`agent:<slug>` pair the dashboard expects while
+ * letting discovery-sourced ticks emit the same pair without the
+ * YAML operator hand-editing key strings.
  *
  * Timeout: the driver OWNS the timeout, not the probe-invoker. The
  * invoker's `cfg.timeout_ms` guard bounds the whole `run()` call; inside
- * `run()`, each of the three HTTP calls uses the same `timeout_ms` as an
- * AbortController limit so one slow endpoint (smoke OK, health hung)
- * can't gobble the invoker's whole budget and starve sibling targets
- * in the same tick.
+ * `run()`, each of the two HTTP calls uses the same `timeout_ms` as an
+ * AbortController limit so one slow endpoint (health hung) can't gobble
+ * the invoker's whole budget and starve sibling targets in the same tick.
  */
 
 /**
@@ -81,22 +88,27 @@ import type { ProbeContext, ProbeResult } from "../../types/index.js";
  * `RailwayServiceInfo` (`{ name, publicUrl, imageRef, env, shape }`)
  * into the input without pre-filtering fields.
  */
-const staticSmokeInputSchema = z
+const staticLivenessInputSchema = z
   .object({
     mode: z.literal("static").optional(),
     key: z.string().min(1),
-    /** Static mode: full `/smoke` URL. */
+    /**
+     * Static mode: historically the `/smoke` URL. Kept for backward
+     * compatibility with existing YAML configs; the driver derives the
+     * `/health` and `/api/copilotkit/` URLs from this path even though
+     * the `/smoke` endpoint itself is no longer probed.
+     */
     url: z.string().url(),
   })
   .strict();
 
-const discoverySmokeInputSchema = z
+const discoveryLivenessInputSchema = z
   .object({
     mode: z.literal("discovery").optional(),
     key: z.string().min(1),
     /** Discovery mode: Railway service name (`showcase-<slug>`). */
     name: z.string().min(1),
-    /** Discovery mode: `https://<domain>` base URL. The driver appends `/smoke` or `/api/health` per shape. */
+    /** Discovery mode: `https://<domain>` base URL. The driver appends `/api/health` per shape. */
     publicUrl: z.string().url(),
     /**
      * Deployment shape tag from the discovery source
@@ -109,11 +121,11 @@ const discoverySmokeInputSchema = z
   .passthrough();
 
 /**
- * Raw schema produced by `smokeInputSchema.parse()` / `.safeParse()`.
+ * Raw schema produced by `livenessInputSchema.parse()` / `.safeParse()`.
  * Both branches leave `mode` optional — `normaliseMode` at the top of
  * `run()` fills in the discriminator from field presence (`url` ⇒
  * static, `name+publicUrl` ⇒ discovery) and produces a
- * `NormalisedSmokeInput` that the rest of the driver narrows against.
+ * `NormalisedLivenessInput` that the rest of the driver narrows against.
  *
  * The union contract is re-asserted at parse time via `.superRefine()`:
  *   - Exactly one of `(url)` OR `(name + publicUrl)` must be present.
@@ -124,12 +136,12 @@ const discoverySmokeInputSchema = z
  *     `shape` with `url` is a structural mistake (static mode predates
  *     shape detection and is always package).
  *
- * Callers doing `smokeInputSchema.safeParse()` in isolation now see a
+ * Callers doing `livenessInputSchema.safeParse()` in isolation now see a
  * unified rejection path for structural invariants regardless of which
  * arm's strictness caught the bad field.
  */
-const smokeInputSchema = z
-  .union([staticSmokeInputSchema, discoverySmokeInputSchema])
+const livenessInputSchema = z
+  .union([staticLivenessInputSchema, discoveryLivenessInputSchema])
   .superRefine((val, ctx) => {
     const raw = val as {
       url?: unknown;
@@ -144,26 +156,26 @@ const smokeInputSchema = z
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message:
-          "smoke input: pass either `url` (static) OR `name`+`publicUrl` (discovery), not both",
+          "liveness input: pass either `url` (static) OR `name`+`publicUrl` (discovery), not both",
       });
     }
     if (!hasUrl && !hasDiscovery) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message:
-          "smoke input: requires either `url` (static) or `name`+`publicUrl` (discovery)",
+          "liveness input: requires either `url` (static) or `name`+`publicUrl` (discovery)",
       });
     }
     if (hasUrl && raw.shape !== undefined) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message:
-          "smoke input: `shape` is only valid with discovery mode (`name`+`publicUrl`)",
+          "liveness input: `shape` is only valid with discovery mode (`name`+`publicUrl`)",
       });
     }
   });
 
-type SmokeDriverInput = z.infer<typeof smokeInputSchema>;
+type LivenessDriverInput = z.infer<typeof livenessInputSchema>;
 
 /**
  * Internal, post-normalisation form. `mode` is required here so every
@@ -174,7 +186,7 @@ type SmokeDriverInput = z.infer<typeof smokeInputSchema>;
  * `mode === "discovery"` branch to be a TS error rather than silently
  * typechecking as `unknown`.
  */
-type NormalisedSmokeInput =
+type NormalisedLivenessInput =
   | { mode: "static"; key: string; url: string }
   | {
       mode: "discovery";
@@ -185,16 +197,16 @@ type NormalisedSmokeInput =
     };
 
 /**
- * Shared signal shape for the smoke, health, and agent ProbeResults.
- * `url` is the URL that was ACTUALLY probed (smoke URL, health URL, or
- * agent URL respectively) so dashboards can link operators directly to
- * the endpoint that failed; `status` is the numeric HTTP status (absent
- * on network error / timeout so templates can branch on its presence);
- * `errorDesc` is a human-readable reason that's safe to render in Slack.
- * `latencyMs` is wall-clock measured from `ctx.now()` so fake-timer
- * tests produce deterministic numbers.
+ * Shared signal shape for the health + agent ProbeResults.
+ * `url` is the URL that was ACTUALLY probed (health URL or agent URL
+ * respectively) so dashboards can link operators directly to the endpoint
+ * that failed; `status` is the numeric HTTP status (absent on network
+ * error / timeout so templates can branch on its presence); `errorDesc`
+ * is a human-readable reason that's safe to render in Slack. `latencyMs`
+ * is wall-clock measured from `ctx.now()` so fake-timer tests produce
+ * deterministic numbers.
  */
-export interface SmokeDriverSignal {
+export interface LivenessDriverSignal {
   slug: string;
   url: string;
   status?: number;
@@ -202,92 +214,99 @@ export interface SmokeDriverSignal {
   latencyMs: number;
 }
 
-export const livenessDriver: ProbeDriver<SmokeDriverInput, SmokeDriverSignal> =
-  {
-    kind: "smoke",
-    inputSchema: smokeInputSchema,
-    async run(ctx, rawInput) {
-      // Normalise mode at the boundary. Schema-parsed inputs (orchestrator
-      // path) carry `mode` via the union default; tests that hand a raw
-      // object to `driver.run()` omit it. Field presence is the runtime
-      // discriminator: `url` present ⇒ static, `name`+`publicUrl` ⇒
-      // discovery. After this cast the rest of the function narrows via
-      // `input.mode` alone.
-      const input = normaliseMode(rawInput);
-      const fetchImpl = ctx.fetchImpl ?? globalThis.fetch.bind(globalThis);
-      const timeoutMs = readTimeoutMs(ctx);
-      const slug = deriveSlug(input);
-      // Shape resolution delegates to the shared resolveShape helper in
-      // `discovery/railway-services.ts` — classifier wins on `name`, throws
-      // on explicit-vs-classifier disagreement, honours explicit `shape`
-      // otherwise. Thread `ctx.logger` so the classifier's audit-warn fires
-      // on the driver path too.
-      const shape = resolveShape(
-        input.mode === "discovery"
-          ? { name: input.name, shape: input.shape }
-          : {},
-        { logger: ctx.logger },
-      );
-      const { smokeUrl, healthUrl, agentUrl } = deriveUrls(input, shape);
-      // Primary key for the smoke ProbeResult. In DISCOVERY mode,
-      // `input.key` arrives as `smoke:showcase-ag2` because the
-      // `key_template` in YAML interpolates `${name}` and the template
-      // language has no string-munge function to strip the prefix.
-      // Rewrite to `smoke:<slug>` here so dashboards/alerts that match on
-      // `smoke:ag2` stay intact. In STATIC mode, pass the YAML-authored
-      // key through verbatim so legacy callers keep their exact
-      // `input.key` in the primary result.
-      const primaryKey =
-        input.mode === "discovery" ? `smoke:${slug}` : input.key;
+/**
+ * Backwards-compat alias. The signal shape was named `SmokeDriverSignal`
+ * when the driver still issued a `/smoke` probe; downstream code (tests,
+ * dashboards reading the signal blob) references the old name. Keep the
+ * alias so a rename of the underlying type doesn't ripple through every
+ * call site at once.
+ */
+export type SmokeDriverSignal = LivenessDriverSignal;
 
-      // Sequential issue of smoke + health + agent to keep inflight socket
-      // count bounded at max_concurrency × 3 — Railway's edge has
-      // historically rate-limited at higher parallelism, so we eat the
-      // wall-clock cost to stay well under any edge threshold.
-      const smokeResult = await probeOne({
-        fetchImpl,
-        url: smokeUrl,
-        key: primaryKey,
-        slug,
-        timeoutMs,
-        now: ctx.now,
-        method: "GET",
-      });
+export const livenessDriver: ProbeDriver<
+  LivenessDriverInput,
+  LivenessDriverSignal
+> = {
+  // `kind: "smoke"` is the registry/family identifier the orchestrator
+  // and YAML probe configs route through. The display dimension was
+  // renamed from "Smoke" to "Health" (the smoke endpoint was redundant
+  // with /health), but the registry key stays `smoke` to preserve YAML
+  // back-compat (`config/probes/*.yml` references `kind: smoke`) and the
+  // smoke-family producer wiring in `orchestrator.ts`.
+  kind: "smoke",
+  inputSchema: livenessInputSchema,
+  async run(ctx, rawInput) {
+    // Normalise mode at the boundary. Schema-parsed inputs (orchestrator
+    // path) carry `mode` via the union default; tests that hand a raw
+    // object to `driver.run()` omit it. Field presence is the runtime
+    // discriminator: `url` present ⇒ static, `name`+`publicUrl` ⇒
+    // discovery. After this cast the rest of the function narrows via
+    // `input.mode` alone.
+    const input = normaliseMode(rawInput);
+    const fetchImpl = ctx.fetchImpl ?? globalThis.fetch.bind(globalThis);
+    const timeoutMs = readTimeoutMs(ctx);
+    const slug = deriveSlug(input);
+    // Shape resolution delegates to the shared resolveShape helper in
+    // `discovery/railway-services.ts` — classifier wins on `name`, throws
+    // on explicit-vs-classifier disagreement, honours explicit `shape`
+    // otherwise. Thread `ctx.logger` so the classifier's audit-warn fires
+    // on the driver path too.
+    const shape = resolveShape(
+      input.mode === "discovery"
+        ? { name: input.name, shape: input.shape }
+        : {},
+      { logger: ctx.logger },
+    );
+    const { healthUrl, agentUrl } = deriveUrls(input, shape);
 
-      // Side-emit #1: health tick.
-      const healthKey = `health:${slug}`;
-      const healthResult = await probeOne({
-        fetchImpl,
-        url: healthUrl,
-        key: healthKey,
-        slug,
-        timeoutMs,
-        now: ctx.now,
-        method: "GET",
-      });
-      await sideEmit(ctx, healthResult, healthKey);
+    // Primary key for the health ProbeResult. The driver's primary return
+    // is now health:<slug> (smoke was redundant with health on the same
+    // service and was dropped). In DISCOVERY mode, `input.key` arrives
+    // shaped on the smoke family (`smoke:showcase-ag2` from the YAML
+    // key_template that interpolates `${name}`), so we rewrite to
+    // `health:<slug>` here. In STATIC mode the YAML-authored key is also
+    // smoke-family by convention; rewrite the leading `smoke:` segment to
+    // `health:` so static callers land on the same dashboard row as
+    // discovery-mode emissions. A non-smoke prefix passes through
+    // verbatim — preserves operator-authored keys that already use the
+    // intended `health:` prefix and avoids surprises for ad-hoc YAML.
+    const healthKey = deriveHealthKey(input, slug);
 
-      // Side-emit #2: agent endpoint POST. Non-404 2xx-5xx response is
-      // green (proves the CopilotKit runtime is mounted); 404 and
-      // transport failures are red. This mirrors the L2 `@agent`
-      // assertion in `integration-smoke.spec.ts:311`.
-      const agentKey = `agent:${slug}`;
-      const agentResult = await probeAgent({
-        fetchImpl,
-        url: agentUrl,
-        key: agentKey,
-        slug,
-        timeoutMs,
-        now: ctx.now,
-      });
-      await sideEmit(ctx, agentResult, agentKey);
+    // Sequential issue of health + agent to keep inflight socket count
+    // bounded — Railway's edge has historically rate-limited at higher
+    // parallelism, so we eat the wall-clock cost to stay well under any
+    // edge threshold.
+    const healthResult = await probeOne({
+      fetchImpl,
+      url: healthUrl,
+      key: healthKey,
+      slug,
+      timeoutMs,
+      now: ctx.now,
+      method: "GET",
+    });
 
-      return smokeResult;
-    },
-  };
+    // Side-emit: agent endpoint POST. Non-404 2xx-5xx response is green
+    // (proves the CopilotKit runtime is mounted); 404 and transport
+    // failures are red. This mirrors the L2 `@agent` assertion in
+    // `integration-smoke.spec.ts:311`.
+    const agentKey = `agent:${slug}`;
+    const agentResult = await probeAgent({
+      fetchImpl,
+      url: agentUrl,
+      key: agentKey,
+      slug,
+      timeoutMs,
+      now: ctx.now,
+    });
+    await sideEmit(ctx, agentResult, agentKey);
+
+    return healthResult;
+  },
+};
 
 /**
- * Normalise a driver input into the `SmokeDriverInput` discriminated
+ * Normalise a driver input into the `LivenessDriverInput` discriminated
  * union. Schema-parsed inputs already carry `mode` via the union
  * default, but callers that hand a raw object straight to `driver.run()`
  * (unit tests, ad-hoc integrations) omit it. We detect mode from field
@@ -296,10 +315,10 @@ export const livenessDriver: ProbeDriver<SmokeDriverInput, SmokeDriverSignal> =
  * `.refine()` guards enforced the same invariant and the discriminated
  * union needs to preserve that behaviour for unparsed-input callers.
  */
-function normaliseMode(input: unknown): NormalisedSmokeInput {
+function normaliseMode(input: unknown): NormalisedLivenessInput {
   const raw = input as Record<string, unknown> | null;
   if (!raw || typeof raw !== "object") {
-    throw new Error("smoke driver: input must be an object");
+    throw new Error("liveness driver: input must be an object");
   }
   // Field presence is the sole discriminator. A caller-supplied `raw.mode`
   // ("static" / "discovery") is ignored here — a previous early-return
@@ -309,7 +328,7 @@ function normaliseMode(input: unknown): NormalisedSmokeInput {
   // consistent between schema-parsed and raw inputs, and a bad shape
   // throws loud rather than coercing.
   if (typeof raw.key !== "string" || raw.key.length === 0) {
-    throw new Error("smoke driver: input.key is required");
+    throw new Error("liveness driver: input.key is required");
   }
   if (typeof raw.url === "string") {
     return {
@@ -332,15 +351,31 @@ function normaliseMode(input: unknown): NormalisedSmokeInput {
     };
   }
   throw new Error(
-    "smoke driver: input requires either `url` (static) or `name`+`publicUrl` (discovery)",
+    "liveness driver: input requires either `url` (static) or `name`+`publicUrl` (discovery)",
   );
+}
+
+/**
+ * Build the primary `health:<slug>` ProbeResult key. Single helper so
+ * the rewrite rule lives in one place: discovery mode is always
+ * `health:<slug>` (since `input.key` arrives shaped on the smoke
+ * family); static mode rewrites a leading `smoke:` segment to `health:`
+ * (the historical convention for static YAML) and otherwise passes the
+ * operator-authored key through.
+ */
+function deriveHealthKey(input: NormalisedLivenessInput, slug: string): string {
+  if (input.mode === "discovery") return `health:${slug}`;
+  if (input.key.startsWith("smoke:")) {
+    return `health:${input.key.slice("smoke:".length)}`;
+  }
+  return input.key;
 }
 
 /**
  * Write a side-emit ProbeResult through `ctx.writer`. Absent writer is a
  * wiring issue, not a per-tick failure — log-and-skip so the driver stays
  * usable in unit tests that only care about the primary return value. A
- * writer throw is non-fatal for the same reason: the primary smoke tick
+ * writer throw is non-fatal for the same reason: the primary health tick
  * is what the invoker is waiting on; a side-emit writer hiccup must not
  * take the primary result down with it.
  */
@@ -350,13 +385,13 @@ async function sideEmit<T>(
   key: string,
 ): Promise<void> {
   if (!ctx.writer) {
-    ctx.logger.warn("probe.smoke.writer-missing", { key });
+    ctx.logger.warn("probe.liveness.writer-missing", { key });
     return;
   }
   try {
     await ctx.writer.write(result);
   } catch (err) {
-    ctx.logger.error("probe.smoke.side-emit-writer-failed", {
+    ctx.logger.error("probe.liveness.side-emit-writer-failed", {
       key,
       err: err instanceof Error ? err.message : String(err),
     });
@@ -365,12 +400,10 @@ async function sideEmit<T>(
 
 /**
  * Per-endpoint GET probe — issues one HTTP request with an AbortController
- * timeout, maps the result to a ProbeResult<SmokeDriverSignal>. Shared
- * between the smoke and health code paths so both produce identical
- * shapes (dashboards, templates, tests can all treat the two keys as a
- * matched pair). The `method` parameter lets callers swap GET/POST when
- * a probe semantics differ — currently only GET is used here since the
- * agent POST path has distinct success criteria and lives in `probeAgent`.
+ * timeout, maps the result to a ProbeResult<LivenessDriverSignal>.
+ * The `method` parameter lets callers swap GET/POST when a probe semantic
+ * differs — currently only GET is used here since the agent POST path has
+ * distinct success criteria and lives in `probeAgent`.
  */
 async function probeOne(opts: {
   fetchImpl: typeof fetch;
@@ -380,7 +413,7 @@ async function probeOne(opts: {
   timeoutMs: number;
   now: () => Date;
   method: "GET" | "POST";
-}): Promise<ProbeResult<SmokeDriverSignal>> {
+}): Promise<ProbeResult<LivenessDriverSignal>> {
   const { fetchImpl, url, key, slug, timeoutMs, now, method } = opts;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -391,7 +424,7 @@ async function probeOne(opts: {
       signal: controller.signal,
     });
     const latencyMs = now().getTime() - started;
-    const signal: SmokeDriverSignal = {
+    const signal: LivenessDriverSignal = {
       slug,
       url,
       status: res.status,
@@ -417,7 +450,7 @@ async function probeOne(opts: {
       };
     }
     // Green path: sanity-check the body parses. A "200 OK" with an
-    // HTML error page (e.g. misrouted edge) should NOT pass smoke.
+    // HTML error page (e.g. misrouted edge) should NOT pass.
     const parseErr = await verifyJsonBody(res);
     if (parseErr) {
       return {
@@ -452,10 +485,10 @@ async function probeOne(opts: {
     return {
       key,
       state: "red",
-      // B2: drop the redundant outer sanitize wrap — `errorDesc` was already
-      // sanitized on the line above. Double-sanitize is harmless today but
-      // would turn into a silent escape-on-escape regression the moment
-      // sanitizeErrorDesc ever grows a non-idempotent rule.
+      // `errorDesc` was already sanitized on the line above. Double-sanitize
+      // is harmless today but would turn into a silent escape-on-escape
+      // regression the moment sanitizeErrorDesc ever grows a non-idempotent
+      // rule.
       signal: {
         slug,
         url,
@@ -493,7 +526,7 @@ async function probeAgent(opts: {
   slug: string;
   timeoutMs: number;
   now: () => Date;
-}): Promise<ProbeResult<SmokeDriverSignal>> {
+}): Promise<ProbeResult<LivenessDriverSignal>> {
   const { fetchImpl, url, key, slug, timeoutMs, now } = opts;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -514,7 +547,7 @@ async function probeAgent(opts: {
       redirect: "follow",
     });
     const latencyMs = now().getTime() - started;
-    const signal: SmokeDriverSignal = {
+    const signal: LivenessDriverSignal = {
       slug,
       url,
       status: res.status,
@@ -560,7 +593,7 @@ async function probeAgent(opts: {
     return {
       key,
       state: "red",
-      // B2: already sanitized above; drop the outer wrap.
+      // already sanitized above; no outer wrap.
       signal: {
         slug,
         url,
@@ -579,14 +612,14 @@ async function probeAgent(opts: {
  * `showcase-` prefix from `name` so `showcase-ag2` → `ag2`. Static
  * shape falls back to splitting the key on `:` — matches the
  * pre-discovery behaviour so static-YAML callers keep emitting the
- * same `smoke:<slug>` rows.
+ * same row keys.
  *
  * When neither field yields a non-empty slug, fall back to the whole
  * key so a hand-wired caller (`{key:"bare", url:...}`) still produces
  * a distinct `health:bare` / `agent:bare` side-tick rather than a
  * blank one.
  */
-function deriveSlug(input: NormalisedSmokeInput): string {
+function deriveSlug(input: NormalisedLivenessInput): string {
   if (input.mode === "discovery") {
     const stripped = input.name.replace(/^showcase-/, "");
     if (stripped.length > 0) return stripped;
@@ -599,24 +632,24 @@ function deriveSlug(input: NormalisedSmokeInput): string {
 }
 
 interface DerivedUrls {
-  smokeUrl: string;
   healthUrl: string;
   agentUrl: string;
 }
 
 /**
- * Derive the three per-target URLs from the input shape.
+ * Derive the two per-target URLs from the input shape.
  *
- *   - Discovery mode (`publicUrl` present): smoke = `${publicUrl}/api/smoke`,
- *     health = `${publicUrl}/api/health`, agent = `${publicUrl}/api/copilotkit/`.
+ *   - Discovery mode (`publicUrl` present): health = `${publicUrl}/api/health`,
+ *     agent = `${publicUrl}/api/copilotkit/`.
  *     The trailing slash on the agent path mirrors the runtime router's
  *     expectation — CopilotKit Hono routes are mounted at
  *     `/api/copilotkit/` with a trailing slash in every showcase.
- *   - Static mode (`url` present): smoke = input URL, health derived
- *     via `deriveHealthUrl`, agent derived by swapping the trailing
- *     `/smoke` for `/api/copilotkit/`.
+ *   - Static mode (`url` present): historically the YAML `url` field
+ *     points at `/smoke`; health is derived via `deriveHealthUrl`, agent
+ *     by swapping the trailing `/smoke` for `/api/copilotkit/`. The
+ *     `/smoke` endpoint itself is no longer probed.
  *
- * Static-mode agent URL derivation is the weak link — the smoke URL
+ * Static-mode agent URL derivation is the weak link — the YAML URL
  * doesn't carry the agent-path convention — but static mode is a
  * fallback for operator-authored test configs, not the production
  * path (which is discovery). When the discovery migration completes,
@@ -624,13 +657,12 @@ interface DerivedUrls {
  * schema extension if needed.
  */
 function deriveUrls(
-  input: NormalisedSmokeInput,
-  shape: ShowcaseServiceShape,
+  input: NormalisedLivenessInput,
+  _shape: ShowcaseServiceShape,
 ): DerivedUrls {
   if (input.mode === "discovery") {
     const base = input.publicUrl.replace(/\/$/, "");
     return {
-      smokeUrl: `${base}/api/smoke`,
       healthUrl: `${base}/api/health`,
       agentUrl: `${base}/api/copilotkit/`,
     };
@@ -638,19 +670,18 @@ function deriveUrls(
   // Static mode. The discriminated union guarantees `url` is present
   // here; static mode predates shape detection and always assumes
   // package shape — the YAML author already picked concrete URLs.
-  const smokeUrl = input.url;
-  const healthUrl = deriveHealthUrl(smokeUrl);
-  const agentUrl = deriveAgentUrl(smokeUrl);
-  return { smokeUrl, healthUrl, agentUrl };
+  const healthUrl = deriveHealthUrl(input.url);
+  const agentUrl = deriveAgentUrl(input.url);
+  return { healthUrl, agentUrl };
 }
 
 /**
- * Derive an agent URL from a smoke URL by swapping the trailing `/smoke`
- * path for `/api/copilotkit/`. Mirrors `deriveHealthUrl`'s approach so a
- * static-mode caller gets a best-effort agent path without hand-editing.
- * Empty string on parse failure — the probe will then hit `` which
- * fetch() rejects as a transport error, flipping the row red with a
- * readable reason.
+ * Derive an agent URL from a (historically `/smoke`-shaped) YAML URL by
+ * swapping the trailing `/smoke` path for `/api/copilotkit/`. Mirrors
+ * `deriveHealthUrl`'s approach so a static-mode caller gets a best-effort
+ * agent path without hand-editing. Empty string on parse failure — the
+ * probe will then hit `` which fetch() rejects as a transport error,
+ * flipping the row red with a readable reason.
  */
 function deriveAgentUrl(url: string): string {
   try {
@@ -674,7 +705,8 @@ function deriveAgentUrl(url: string): string {
  * but a driver-internal HTTP-level timeout is still required so one
  * hung endpoint doesn't starve its sibling probe on the same
  * invocation. Defaults to 10s — matches the YAML probe's
- * `timeout_ms: 10000`.
+ * `timeout_ms: 10000`. `SMOKE_TIMEOUT_MS` is retained as the env
+ * variable name for backwards compatibility with existing deploys.
  */
 function readTimeoutMs(ctx: ProbeContext): number {
   const fromEnv = ctx.env.SMOKE_TIMEOUT_MS;

--- a/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.lazy-signal.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.lazy-signal.test.tsx
@@ -347,8 +347,8 @@ describe("CellDrilldown — lazy signal fetch (real PocketBase SDK)", () => {
     const healthBadge = getByTestId("drilldown-badge-health");
     // The e2e row's label-derived testid: `RT (Round Trip)` now belongs to
     // the D4 row (whose fixtures here have no chat/tools data), so the e2e
-    // row must be selected via its de-crossed `E2E (Demo)` label.
-    const e2eBadge = getByTestId("drilldown-badge-e2e--demo-");
+    // row must be selected via its renamed `UI (Frontend)` label.
+    const e2eBadge = getByTestId("drilldown-badge-ui--frontend-");
 
     // The e2e badge's signal arrived → it renders its field and shows NO error.
     await waitFor(
@@ -426,8 +426,8 @@ describe("CellDrilldown — lazy signal fetch (real PocketBase SDK)", () => {
       />,
     );
 
-    // e2e row selected via its de-crossed `E2E (Demo)` label — see above.
-    const e2eBadge = getByTestId("drilldown-badge-e2e--demo-");
+    // e2e row selected via its renamed `UI (Frontend)` label — see above.
+    const e2eBadge = getByTestId("drilldown-badge-ui--frontend-");
     await waitFor(
       () => expect(within(e2eBadge).getByTestId("signal-error")).toBeDefined(),
       { timeout: 5000 },

--- a/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
@@ -47,16 +47,15 @@ function mapOf(rows: StatusRow[]): LiveStatusMap {
 }
 
 describe("CellDrilldown", () => {
-  it("renders all 7 badge dimensions", () => {
+  it("renders all 6 badge dimensions (smoke dropped — redundant w/ health)", () => {
     const live = mapOf([
       row("health:lgp", "health", "green", { ...FRESH }),
       row("e2e:lgp/agentic-chat", "e2e", "green", { ...FRESH }),
-      row("smoke:lgp", "smoke", "green", { ...FRESH }),
       row("agent:lgp", "agent", "green", { ...FRESH }),
       row("chat:lgp", "chat", "green", { ...FRESH }),
       row("tools:lgp", "tools", "green", { ...FRESH }),
     ]);
-    const { getByTestId, getByText } = render(
+    const { getByTestId, getByText, queryByText } = render(
       <CellDrilldown
         slug="lgp"
         featureId="agentic-chat"
@@ -71,11 +70,15 @@ describe("CellDrilldown", () => {
     expect(getByText("CV (Conversation)")).toBeDefined();
     // `RT (Round Trip)` is now the D4 (chat+tools round-trip) row …
     expect(getByText("RT (Round Trip)")).toBeDefined();
-    // … and the e2e row carries the de-crossed `E2E (Demo)` label.
-    expect(getByText("E2E (Demo)")).toBeDefined();
+    // … and the e2e row carries the renamed `UI (Frontend)` label
+    // (was `E2E (Demo)` — taxonomy cleanup).
+    expect(getByText("UI (Frontend)")).toBeDefined();
     expect(getByText("API (Agent)")).toBeDefined();
     expect(getByText("Health")).toBeDefined();
-    expect(getByText("Smoke")).toBeDefined();
+    // The "Smoke" row was dropped: the /smoke endpoint had the same contract
+    // as /health on the same service (pure redundancy) and is no longer
+    // probed or rendered.
+    expect(queryByText("Smoke")).toBeNull();
   });
 
   it("renders a red RT (Round Trip) row for a red D4 fold while the service line stays green (headline drilldown-parity bug)", () => {
@@ -152,7 +155,7 @@ describe("CellDrilldown", () => {
     expect(queryByText("Rollup")).toBeNull();
   });
 
-  it("de-crosses the e2e label: E2E (Demo) renders and exactly ONE row is labelled RT (Round Trip)", () => {
+  it("renames the e2e label to UI (Frontend); exactly ONE row is labelled RT (Round Trip)", () => {
     const live = mapOf([
       row("e2e:lgp/agentic-chat", "e2e", "green", { ...FRESH }),
       row("chat:lgp", "chat", "green", { ...FRESH }),
@@ -168,7 +171,9 @@ describe("CellDrilldown", () => {
         onClose={() => {}}
       />,
     );
-    expect(getByText("E2E (Demo)")).toBeDefined();
+    // E2E (Demo) was renamed to UI (Frontend); the underlying `e2e:<slug>/<feature>`
+    // probe key is preserved on PocketBase for backward compatibility.
+    expect(getByText("UI (Frontend)")).toBeDefined();
     expect(getAllByText("RT (Round Trip)").length).toBe(1);
   });
 

--- a/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
@@ -203,13 +203,13 @@ const CHIP_CLASS: Record<ChipColor, string> = {
 //     asserted as the RENDERED badge tone class + glyph.
 // ===========================================================================
 
-describe("(1) per-depth badge rendering — E2E/RT/CV/D6", () => {
+describe("(1) per-depth badge rendering — UI/RT/CV/D6", () => {
   // agentic-chat is 1:1 mapped (CATALOG_TO_D5_KEY["agentic-chat"] =
   // ["agentic-chat"]) so each depth is a single key, isolating one badge.
   const FEATURE = "agentic-chat";
 
   interface DepthCase {
-    badge: "E2E" | "RT" | "CV" | "D6";
+    badge: "UI" | "RT" | "CV" | "D6";
     /** rows that set THIS depth's state; gate rows added automatically. */
     rows: StatusRow[];
     expectStatus: TestStatus;
@@ -218,15 +218,16 @@ describe("(1) per-depth badge rendering — E2E/RT/CV/D6", () => {
   // Each case sets the named depth's underlying row(s); for the chip to even
   // reach a given depth the lower rungs must be green, so we layer rows.
   const cases: DepthCase[] = [
-    // E2E (d3) — single e2e key (legend-correct: D3 is the demo round-trip,
-    // formerly mislabelled "API" which is the D2 badge's name)
+    // UI (d3) — single e2e key (legend-correct: D3 is the frontend
+    // render — renamed from "E2E (Demo)" to "UI (Frontend)" in the
+    // taxonomy cleanup; the underlying probe key stays `e2e:<slug>/<feature>`)
     {
-      badge: "E2E",
+      badge: "UI",
       rows: [row(keyFor("e2e", SLUG, FEATURE), "e2e", "green")],
       expectStatus: "green",
     },
     {
-      badge: "E2E",
+      badge: "UI",
       rows: [row(keyFor("e2e", SLUG, FEATURE), "e2e", "red")],
       expectStatus: "red",
     },

--- a/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
@@ -207,9 +207,9 @@ describe("Overlay selector integration — real UI components", () => {
     expect(queryByTestId("depth-chip")).not.toBeInTheDocument();
     expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
 
-    // No health badges (API, E2E, CV)
+    // No health badges (API, UI, CV)
     expect(queryByText("API")).not.toBeInTheDocument();
-    expect(queryByText("E2E")).not.toBeInTheDocument();
+    expect(queryByText("UI")).not.toBeInTheDocument();
     expect(queryByText("CV")).not.toBeInTheDocument();
 
     // No docs indicators
@@ -240,7 +240,7 @@ describe("Overlay selector integration — real UI components", () => {
     expect(queryByText("</>")).not.toBeInTheDocument();
 
     // No health badges
-    expect(queryByText("E2E")).not.toBeInTheDocument();
+    expect(queryByText("UI")).not.toBeInTheDocument();
 
     // No docs indicators
     expect(queryByText("docs-og")).not.toBeInTheDocument();
@@ -250,7 +250,7 @@ describe("Overlay selector integration — real UI components", () => {
   // -------------------------------------------------------------------------
   // 3. Health only — the critical case (no docs indicators must appear)
   // -------------------------------------------------------------------------
-  it("health only: API/E2E/CV badges visible, NO docs indicators", () => {
+  it("health only: API/UI/CV badges visible, NO docs indicators", () => {
     // `agentic-chat` is a real CATALOG_TO_D5_KEY entry, so its d5 row resolves
     // green and the CV badge renders. An UNMAPPED feature's CV badge is gray
     // "?" and hidden by design (resolveD5Row returns null for unmapped
@@ -273,7 +273,7 @@ describe("Overlay selector integration — real UI components", () => {
     // Health layer present with real badges
     expect(getByTestId("health-layer")).toBeInTheDocument();
     expect(getByText("API")).toBeInTheDocument();
-    expect(getByText("E2E")).toBeInTheDocument();
+    expect(getByText("UI")).toBeInTheDocument();
     expect(getByText("CV")).toBeInTheDocument();
 
     // No docs indicators — this is the critical regression test for B2's fix
@@ -307,7 +307,7 @@ describe("Overlay selector integration — real UI components", () => {
     expect(queryByText("Demo")).not.toBeInTheDocument();
 
     // No health badges
-    expect(queryByText("E2E")).not.toBeInTheDocument();
+    expect(queryByText("UI")).not.toBeInTheDocument();
 
     // No depth chip
     expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
@@ -329,7 +329,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Nothing visible
     expect(queryByText("Demo")).not.toBeInTheDocument();
-    expect(queryByText("E2E")).not.toBeInTheDocument();
+    expect(queryByText("UI")).not.toBeInTheDocument();
     expect(queryByText("docs-og")).not.toBeInTheDocument();
     expect(queryByTestId("depth-chip")).not.toBeInTheDocument();
   });
@@ -359,7 +359,7 @@ describe("Overlay selector integration — real UI components", () => {
     // Health layer
     expect(getByTestId("health-layer")).toBeInTheDocument();
     expect(getByText("API")).toBeInTheDocument();
-    expect(getByText("E2E")).toBeInTheDocument();
+    expect(getByText("UI")).toBeInTheDocument();
     expect(getByText("CV")).toBeInTheDocument();
 
     // Docs layer
@@ -400,7 +400,7 @@ describe("Overlay selector integration — real UI components", () => {
     expect(getByTestId("depth-layer")).toBeInTheDocument();
     expect(getByTestId("depth-chip")).toBeInTheDocument();
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("E2E")).toBeInTheDocument();
+    expect(getByText("UI")).toBeInTheDocument();
     expect(getByTestId("docs-layer")).toBeInTheDocument();
     expect(getByText("docs-og")).toBeInTheDocument();
     expect(getByText("docs-shell")).toBeInTheDocument();
@@ -416,8 +416,8 @@ describe("Overlay selector integration — real UI components", () => {
     expect(
       children[1]?.querySelector("[data-testid='depth-chip']"),
     ).toBeTruthy();
-    // Third child: health (contains the E2E badge)
-    expect(children[2]?.textContent).toContain("E2E");
+    // Third child: health (contains the UI badge — renamed from E2E)
+    expect(children[2]?.textContent).toContain("UI");
     // Fourth child: docs (contains docs-og)
     expect(children[3]?.textContent).toContain("docs-og");
   });
@@ -433,7 +433,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health badges present
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("E2E")).toBeInTheDocument();
+    expect(getByText("UI")).toBeInTheDocument();
 
     // Docs explicitly absent — this is the bug B2 fixed: CellStatus used to
     // render DocsRow, so "health only" would still show docs indicators.
@@ -457,7 +457,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // API and RT badges still visible for testing-kind
     expect(getByText("API")).toBeInTheDocument();
-    expect(getByText("E2E")).toBeInTheDocument();
+    expect(getByText("UI")).toBeInTheDocument();
 
     // CV hidden for testing-kind features (CellStatus hides them)
     expect(queryByText("CV")).not.toBeInTheDocument();
@@ -497,7 +497,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health badges
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("E2E")).toBeInTheDocument();
+    expect(getByText("UI")).toBeInTheDocument();
 
     // Docs indicators
     expect(getByTestId("docs-layer")).toBeInTheDocument();
@@ -529,7 +529,7 @@ describe("Overlay selector integration — real UI components", () => {
 
     // Health badges
     expect(getByTestId("health-layer")).toBeInTheDocument();
-    expect(getByText("E2E")).toBeInTheDocument();
+    expect(getByText("UI")).toBeInTheDocument();
 
     // No docs — critical: Assessment does NOT include docs
     expect(queryByText("docs-og")).not.toBeInTheDocument();
@@ -580,8 +580,8 @@ describe("Overlay selector integration — real UI components", () => {
       <ComposedCell ctx={ctx} overlays={overlaySet("health")} />,
     );
 
-    // With green live status rows, the E2E badge should show the green check
-    const e2eBadge = getByText("E2E");
+    // With green live status rows, the UI badge (renamed from E2E) should show the green check
+    const e2eBadge = getByText("UI");
     expect(e2eBadge).toBeInTheDocument();
     // The badge label "✓" (green state) should appear as a sibling span
     const e2eContainer = e2eBadge.closest("[class*='whitespace-nowrap']");

--- a/showcase/shell-dashboard/src/components/__tests__/unified-cell.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/unified-cell.test.tsx
@@ -224,7 +224,7 @@ describe("UnifiedCell", () => {
       expect(queryByTestId("mock-depth-chip")).not.toBeInTheDocument();
 
       // No badges rendered
-      expect(queryByTestId("mock-badge-E2E")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-UI")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-RT")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
 
@@ -310,7 +310,7 @@ describe("UnifiedCell", () => {
       );
 
       // E2E badge present (D3 exists)
-      expect(getByTestId("mock-badge-E2E")).toBeInTheDocument();
+      expect(getByTestId("mock-badge-UI")).toBeInTheDocument();
       // RT badge absent (D4 does not exist)
       expect(queryByTestId("mock-badge-RT")).not.toBeInTheDocument();
       // CV badge present (D5 exists)
@@ -328,7 +328,7 @@ describe("UnifiedCell", () => {
         <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("health")} />,
       );
 
-      expect(queryByTestId("mock-badge-E2E")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-UI")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-RT")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
     });
@@ -344,7 +344,7 @@ describe("UnifiedCell", () => {
         <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("health")} />,
       );
 
-      expect(queryByTestId("mock-badge-E2E")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-UI")).not.toBeInTheDocument();
       expect(getByTestId("mock-badge-RT")).toBeInTheDocument();
       expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
     });
@@ -363,7 +363,7 @@ describe("UnifiedCell", () => {
         <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("health")} />,
       );
 
-      const e2eBadge = getByTestId("mock-badge-E2E");
+      const e2eBadge = getByTestId("mock-badge-UI");
       expect(e2eBadge).toBeInTheDocument();
       expect(e2eBadge.getAttribute("data-tone")).toBe("green");
 
@@ -391,7 +391,7 @@ describe("UnifiedCell", () => {
       );
 
       expect(queryByTestId("health-layer")).not.toBeInTheDocument();
-      expect(queryByTestId("mock-badge-E2E")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-UI")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-RT")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
     });
@@ -542,7 +542,7 @@ describe("UnifiedCell", () => {
         <UnifiedCell ctx={ctx} model={model} overlays={overlaySet("health")} />,
       );
 
-      const badge = getByTestId("mock-badge-E2E");
+      const badge = getByTestId("mock-badge-UI");
       expect(badge.getAttribute("data-tone")).toBe("green");
       expect(badge.textContent).toContain("✓");
     });
@@ -559,7 +559,7 @@ describe("UnifiedCell", () => {
       );
 
       // A no-data rung emits label "?", which the real Badge hides → no badge.
-      expect(queryByTestId("mock-badge-E2E")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-UI")).not.toBeInTheDocument();
     });
   });
 

--- a/showcase/shell-dashboard/src/components/adaptive-legend.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-legend.tsx
@@ -51,12 +51,18 @@ function HealthLegend() {
     <>
       {/* Depth explanations in ascending order */}
       <LegendItem>
+        <span className="font-semibold text-[var(--text-secondary)]">
+          Health
+        </span>
+        GET /api/health returns 200 OK with JSON body
+      </LegendItem>
+      <LegendItem>
         <span className="font-semibold text-[var(--text-secondary)]">D2</span>
         API: responds to a basic CopilotKit API call
       </LegendItem>
       <LegendItem>
         <span className="font-semibold text-[var(--text-secondary)]">D3</span>
-        E2E (Demo): demo page loads and round-trips in a browser
+        UI (Frontend): demo page renders in browser (Playwright)
       </LegendItem>
       <LegendItem>
         <span className="font-semibold text-[var(--text-secondary)]">D4</span>

--- a/showcase/shell-dashboard/src/components/cell-drilldown.tsx
+++ b/showcase/shell-dashboard/src/components/cell-drilldown.tsx
@@ -3,10 +3,16 @@
  * CellDrilldown — popover panel showing per-badge dimension detail for a
  * single (integration, feature) cell.
  *
- * Renders all badge dimensions (d6/Parity, d5/CV, d4/RT, e2e/E2E, d2/API,
- * health, smoke) with tone, label, and — for red/amber badges — failure
- * metadata presented as readable key-value pairs with the full signal
- * collapsible for debugging.
+ * Renders all relevant badge dimensions (d6/Parity, d5/CV, d4/RT,
+ * e2e/UI, d2/API, health) with tone, label, and — for red/amber badges —
+ * failure metadata presented as readable key-value pairs with the full
+ * signal collapsible for debugging.
+ *
+ * The legacy `smoke` row was dropped: the smoke endpoint was the same
+ * contract as `/health` on the same service (pure redundancy) and is no
+ * longer probed. The `e2e` row is labeled "UI (Frontend)" — the
+ * underlying probe key (`e2e:<slug>/<feature>`) is preserved on
+ * PocketBase for backward compatibility with historical rows.
  */
 import { useEffect, useMemo, useState } from "react";
 import { resolveCell } from "@/lib/live-status";
@@ -35,21 +41,25 @@ export interface CellDrilldownProps {
 /**
  * Dimension metadata for display ordering (descending depth). Labels follow
  * the legend's canonical taxonomy (adaptive-legend.tsx): D4 = "RT (Round
- * Trip)" (chat+tools round-trip), D3/e2e = "E2E (Demo)" (the demo page loads
- * and round-trips in a browser). BadgeRow derives its data-testid from the
- * label, so labels must stay unique across rows.
+ * Trip)" (chat+tools round-trip), D3/e2e = "UI (Frontend)" (the demo page
+ * renders in a browser). BadgeRow derives its data-testid from the label,
+ * so labels must stay unique across rows.
+ *
+ * The `smoke` row was dropped — the smoke endpoint was redundant with
+ * /health on the same service and is no longer probed. `CellState.smoke`
+ * is still populated by `resolveCell` for back-compat with consumers that
+ * read it (e.g. tests, but it is intentionally not rendered here).
  */
 const DIMENSIONS: Array<{
-  key: keyof Omit<CellState, "rollup">;
+  key: keyof Omit<CellState, "rollup" | "smoke">;
   label: string;
 }> = [
   { key: "d6", label: "Parity (Reference)" },
   { key: "d5", label: "CV (Conversation)" },
   { key: "d4", label: "RT (Round Trip)" },
-  { key: "e2e", label: "E2E (Demo)" },
+  { key: "e2e", label: "UI (Frontend)" },
   { key: "d2", label: "API (Agent)" },
   { key: "health", label: "Health" },
-  { key: "smoke", label: "Smoke" },
 ];
 
 function formatTimestamp(ts: string | null): string {

--- a/showcase/shell-dashboard/src/components/cell-pieces.signal-degrade.test.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.signal-degrade.test.tsx
@@ -120,10 +120,11 @@ function degradedHealthRowNoSignal(): StatusRow {
 }
 
 function rtTitle(container: HTMLElement): string | null {
-  // The e2e badge — renamed from the crossed "RT" label to "E2E" (the grid's
-  // RT name now belongs to the D4 chat/tools badge in unified-cell).
+  // The e2e badge — taxonomy cleanup renamed it from the crossed "RT" label
+  // to "UI" (formerly "E2E"; the grid's RT name now belongs to the D4
+  // chat/tools badge in unified-cell).
   const span = Array.from(container.querySelectorAll("span[title]")).find(
-    (s) => s.querySelector("span:first-child")?.textContent?.trim() === "E2E",
+    (s) => s.querySelector("span:first-child")?.textContent?.trim() === "UI",
   );
   return span ? span.getAttribute("title") : null;
 }

--- a/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
@@ -157,7 +157,7 @@ describe("CP1: tooltipOpen resets on mouseleave/blur", () => {
       liveStatus: new Map([[redE2eRow().key, redE2eRow()]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    const rtBadge = findBadgeByName(container, "E2E");
+    const rtBadge = findBadgeByName(container, "UI");
     fireEvent.mouseEnter(rtBadge);
     // Allow microtask to flush.
     await Promise.resolve();
@@ -176,7 +176,7 @@ describe("CP1: tooltipOpen resets on mouseleave/blur", () => {
     // and gated on open, never on close).
     expect(mockState.fetchCount).toBe(countAfterEnter);
     // The badge remains in the document after the reset.
-    expect(findBadgeByName(container, "E2E")).toBeInTheDocument();
+    expect(findBadgeByName(container, "UI")).toBeInTheDocument();
   });
 });
 
@@ -196,12 +196,12 @@ describe("CP2: transitionLine discriminates first/error", () => {
       liveStatus: new Map([[redE2eRow().key, redE2eRow()]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    const rtBadge = findBadgeByName(container, "E2E");
+    const rtBadge = findBadgeByName(container, "UI");
     fireEvent.mouseEnter(rtBadge);
     // Wait for the lazy fetch + state update (waitFor, not a fixed sleep, to
     // avoid flakiness — mirrors the sibling first/error/green_to_red cases).
     await waitFor(() => {
-      const el = findBadgeByName(container, "E2E");
+      const el = findBadgeByName(container, "UI");
       expect(el.getAttribute("title")).toContain("(initial: green)");
     });
   });
@@ -221,14 +221,14 @@ describe("CP2: transitionLine discriminates first/error", () => {
       liveStatus: new Map([[redE2eRow().key, redE2eRow()]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    const rtBadge = findBadgeByName(container, "E2E");
+    const rtBadge = findBadgeByName(container, "UI");
     fireEvent.mouseEnter(rtBadge);
     await waitFor(() => {
-      const el = findBadgeByName(container, "E2E");
+      const el = findBadgeByName(container, "UI");
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(el.getAttribute("title")!).toMatch(/\(error → red\)/);
     });
-    const updated = findBadgeByName(container, "E2E");
+    const updated = findBadgeByName(container, "UI");
     expect(updated.getAttribute("title")).toContain("(error → red)");
   });
 
@@ -247,14 +247,14 @@ describe("CP2: transitionLine discriminates first/error", () => {
       liveStatus: new Map([[redE2eRow().key, redE2eRow()]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    const rtBadge = findBadgeByName(container, "E2E");
+    const rtBadge = findBadgeByName(container, "UI");
     fireEvent.mouseEnter(rtBadge);
     await waitFor(() => {
-      const el = findBadgeByName(container, "E2E");
+      const el = findBadgeByName(container, "UI");
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(el.getAttribute("title")!).toMatch(/\(green → red\)/);
     });
-    const updated = findBadgeByName(container, "E2E");
+    const updated = findBadgeByName(container, "UI");
     expect(updated.getAttribute("title")).toContain("(green → red)");
   });
 });
@@ -401,7 +401,7 @@ describe("docs-only kind hides ALL badges", () => {
     const { container } = render(<CellStatus ctx={ctx} />);
     const text = container.textContent ?? "";
     expect(text).not.toContain("API");
-    expect(text).not.toContain("E2E");
+    expect(text).not.toContain("UI");
     expect(text).not.toContain("CV");
   });
 });
@@ -493,7 +493,7 @@ describe("§7.3: clock-glyph suffix on the stale-degraded badge", () => {
     });
     // lastSuccessAt 3 h ago > 2 × 1 h period → family silent → glyph.
     const { container } = renderWithWorkerRuns(ctx, [makeFamily()]);
-    const rt = findBadgeByName(container, "RT");
+    const rt = findBadgeByName(container, "UI");
     expect(rt.textContent).toContain("⏱");
     // The badge keeps its degraded label — the glyph is a SUFFIX, not a
     // replacement (spec §7.3 "minimal: suffix only").
@@ -508,7 +508,7 @@ describe("§7.3: clock-glyph suffix on the stale-degraded badge", () => {
       liveStatus: new Map([[red.key, red]]) as LiveStatusMap,
     });
     const { container } = renderWithWorkerRuns(ctx, [makeFamily()]);
-    const rt = findBadgeByName(container, "RT");
+    const rt = findBadgeByName(container, "UI");
     expect(rt.textContent).toContain("✗");
     expect(rt.textContent).not.toContain("⏱");
   });
@@ -529,7 +529,7 @@ describe("§7.3: clock-glyph suffix on the stale-degraded badge", () => {
       ]) as LiveStatusMap,
     });
     const { container } = renderWithWorkerRuns(ctx, [makeFamily()]);
-    const rt = findBadgeByName(container, "RT");
+    const rt = findBadgeByName(container, "UI");
     expect(rt.textContent).not.toContain("⏱");
   });
 
@@ -543,12 +543,12 @@ describe("§7.3: clock-glyph suffix on the stale-degraded badge", () => {
     const fast = renderWithWorkerRuns(ctx, [
       makeFamily({ periodMs: 900_000, lastSuccessAt }),
     ]);
-    expect(findBadgeByName(fast.container, "RT").textContent).toContain("⏱");
+    expect(findBadgeByName(fast.container, "UI").textContent).toContain("⏱");
     // Same payload but a 30 min period: 40 < 2×30 → not silent → no glyph.
     const slow = renderWithWorkerRuns(ctx, [
       makeFamily({ periodMs: 1_800_000, lastSuccessAt }),
     ]);
-    expect(findBadgeByName(slow.container, "RT").textContent).not.toContain(
+    expect(findBadgeByName(slow.container, "UI").textContent).not.toContain(
       "⏱",
     );
   });
@@ -564,14 +564,14 @@ describe("§7.3: clock-glyph suffix on the stale-degraded badge", () => {
       makeFamily({ lastSuccessAt: null }),
     ]);
     expect(
-      findBadgeByName(neverSucceeded.container, "RT").textContent,
+      findBadgeByName(neverSucceeded.container, "UI").textContent,
     ).toContain("⏱");
     // Zero batches: nothing to reference → never silent → no glyph.
     const zeroBatches = renderWithWorkerRuns(ctx, [
       makeFamily({ lastSuccessAt: null, lastRun: null, inflight: null }),
     ]);
     expect(
-      findBadgeByName(zeroBatches.container, "RT").textContent,
+      findBadgeByName(zeroBatches.container, "UI").textContent,
     ).not.toContain("⏱");
   });
 
@@ -581,6 +581,6 @@ describe("§7.3: clock-glyph suffix on the stale-degraded badge", () => {
       liveStatus: new Map([[row.key, row]]) as LiveStatusMap,
     });
     const { container } = render(<CellStatus ctx={ctx} />);
-    expect(findBadgeByName(container, "RT").textContent).not.toContain("⏱");
+    expect(findBadgeByName(container, "UI").textContent).not.toContain("⏱");
   });
 });

--- a/showcase/shell-dashboard/src/components/cell-pieces.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.tsx
@@ -340,7 +340,7 @@ function formatTransitionLine(row: {
 }
 
 /**
- * Shared status row: API / E2E / CV badges (D2 API / D3 E2E / D5 Conversation).
+ * Shared status row: API / UI / CV badges (D2 API / D3 UI / D5 Conversation).
  * QA and HealthDot removed in Phase 3 (3.3 + 3.4). L1 health now in strip.
  * Smoke per-cell badge removed — integration-scoped smoke lives in the strip.
  * Docs rendering removed — handled exclusively by DocsLayer in ComposedCell,
@@ -379,7 +379,7 @@ export function CellStatus({ ctx }: { ctx: CellContext }) {
         dimensionKey={keyFor("agent", ctx.integration.slug)}
       />
       <LiveBadge
-        name="E2E"
+        name="UI"
         badge={cell.e2e}
         dimensionKey={keyFor("e2e", ctx.integration.slug, ctx.feature.id)}
       />

--- a/showcase/shell-dashboard/src/components/unified-cell.tsx
+++ b/showcase/shell-dashboard/src/components/unified-cell.tsx
@@ -225,10 +225,10 @@ function HealthLayer({ model }: { model: CellModel }) {
       data-testid="health-layer"
       className="flex items-center justify-center gap-2.5"
     >
-      {/* Legend-correct names: D3 = E2E (demo round-trip in a browser; the
+      {/* Legend-correct names: D3 = UI (frontend renders in a browser; the
           "API" name belongs to the D2 agent badge), D4 = RT (chat/tools
           round-trip). */}
-      <TestBadge name="E2E" level={model.d3} />
+      <TestBadge name="UI" level={model.d3} />
       <TestBadge name="RT" level={model.d4} />
       <TestBadge name="CV" level={model.d5} />
       {/*


### PR DESCRIPTION
## Summary

The smoke probe was the same HTTP contract as `/health` on the same service (200-OK JSON body), so every tick paid two HTTP calls for the same liveness signal. This PR:

- Drops the `/smoke` GET probe and the `smoke:<slug>` primary `ProbeResult`. The driver now emits `health:<slug>` as the primary and `agent:<slug>` via writer side-emit (half the per-tick cost).
- Renames the dashboard's D3 / e2e row label from `E2E (Demo)` to `UI (Frontend)` (and the short cell badge from `E2E` to `UI`) — the row was already about "the demo page renders in a browser", not E2E in the traditional sense.
- Drops the `Smoke` row from the cell drilldown (CellState.smoke field is retained for back-compat so historical rows still parse).
- Adds an explicit `Health` row to the legend (was implicit).

The driver's registry `kind` stays `"smoke"` so existing YAML configs + orchestrator family wiring keep routing to this driver — the emission key (`health:<slug>`) is the taxonomy contract that matters. The underlying probe key (`e2e:<slug>/<feature>`) is preserved on PocketBase so historical rows render correctly during the rename window.

## RED proof (BEFORE)

`smoke:<slug>` primary emission in `liveness.ts` (origin/main):

```
18: *   1. `smoke:<slug>`  — the RETURN VALUE of `run()`. The invoker runs
56: * `smoke:<slug>`/`health:<slug>`/`agent:<slug>` triple the dashboard
241:        input.mode === "discovery" ? `smoke:${slug}` : input.key;
```

`E2E (Demo)` / `Smoke` strings in dashboard render code (origin/main):

```
cell-drilldown.tsx:38: * Trip)" (chat+tools round-trip), D3/e2e = "E2E (Demo)" (the demo page loads
cell-drilldown.tsx:49:  { key: "e2e", label: "E2E (Demo)" },
cell-drilldown.tsx:52:  { key: "smoke", label: "Smoke" },
cell-pieces.tsx:382:        name="E2E"
unified-cell.tsx:231:      <TestBadge name="E2E" level={model.d3} />
adaptive-legend.tsx:59:        E2E (Demo): demo page loads and round-trips in a browser
```

## GREEN proof (AFTER)

Primary emission rewritten — driver returns `health:<slug>` and no `smoke:<slug>` ProbeResult is ever emitted:

```
33: * to `/smoke` and emitted a `smoke:<slug>` primary result, but that probe
230:  // `kind: "smoke"` is the registry/family identifier the orchestrator
236:  kind: "smoke",        // registry-key back-compat; no smoke ProbeResult is emitted
367:  if (input.mode === "discovery") return `health:${slug}`;
368:  if (input.key.startsWith("smoke:")) {
369:    return `health:${input.key.slice("smoke:".length)}`;
```

New labels in dashboard:

```
cell-drilldown.tsx:60:  { key: "e2e", label: "UI (Frontend)" },
cell-pieces.tsx:382:        name="UI"
unified-cell.tsx:231:      <TestBadge name="UI" level={model.d3} />
adaptive-legend.tsx:65:        UI (Frontend): demo page renders in browser (Playwright)
```

Confirmation that the old labels are gone from render code:

```
$ grep -rn 'E2E (Demo)\|"Smoke"' cell-drilldown.tsx cell-pieces.tsx unified-cell.tsx adaptive-legend.tsx
(no matches — labels removed)
```

## Test results

- `pnpm exec vitest run` in `showcase/shell-dashboard`: **63 files, 1089 tests passed, 1 skipped**
- `pnpm exec vitest run` in `showcase/harness`: **129 files, 2760 tests passed**
- `pnpm exec tsc --noEmit` in both: clean

Liveness driver tests include a regression guard (`never emits a smoke:<slug> key`) so the smoke contract cannot be re-introduced silently.

## Test plan

- [x] Dashboard vitest green (1089/1089)
- [x] Harness vitest green (2760/2760)
- [x] tsc --noEmit green in both packages
- [x] Visual cross-check: drilldown renders 6 rows (no Smoke), e2e row labelled `UI (Frontend)`; cell strip shows `UI` badge in place of `E2E`; legend shows explicit `Health` row + `UI (Frontend)` D3 line