### PR TITLE
fix(harness): cascade fallback to whole-bubble-minus-toolbar for tool-only responses (Class B)

### DIFF
--- a/showcase/harness/src/probes/helpers/assistant-message-count.test.ts
+++ b/showcase/harness/src/probes/helpers/assistant-message-count.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import type { Page } from "playwright";
 import {
   readCascadeState,
+  readCascadeStateLast,
   resolveBubbleTextFromSelectors,
 } from "./assistant-message-count.js";
 import type { BubbleTextElement } from "./assistant-message-count.js";
@@ -407,6 +408,207 @@ describe("readCascadeState", () => {
     } as unknown as Page;
 
     const r = await readCascadeState(page, 0);
+    expect(r).toEqual({ count: 0, text: null });
+  });
+});
+
+/**
+ * Unit coverage for `readCascadeStateLast` — Class B fallback path.
+ *
+ * Class B = single-bubble tool-only responses (gen-UI, recharts SVG, A2UI
+ * cards) whose scoped text selectors are ALL empty but whose `bubble.textContent`
+ * contains the rendered content in non-cascade children. The cascade-pollution
+ * guard in `readCascadeState` / `findAssistantBubbleAt` returns null in this
+ * shape (and rightly so — those readers can target intermediate bubbles
+ * mid-stream where whole-bubble text would flap across bubbles). For the LAST
+ * bubble specifically, by RUN_FINISHED the content has mounted and is stable,
+ * so `readCascadeStateLast` recovers it via a whole-bubble-minus-toolbar
+ * fallback.
+ *
+ * The closure body is exercised via the same `makePageForCascade` fake used
+ * by the `readCascadeState` suite — we don't unit-test the production
+ * closure directly (no JSDOM), but the fake mirrors the browser-side
+ * `globalThis.document.querySelectorAll(...).item(i)` shape and bubble
+ * `querySelector` / `textContent` access so the closure body executes as it
+ * would in Playwright.
+ */
+describe("readCascadeStateLast", () => {
+  const CANONICAL = '[data-testid="copilot-assistant-message"]';
+  const TOOLBAR_SEL = '[data-testid="copilot-assistant-toolbar"]';
+
+  function leafNode(textContent: string | null): StubNode {
+    return {
+      textContent,
+      querySelector(_sel: string): StubNode | null {
+        return null;
+      },
+    };
+  }
+
+  function bubbleWithScopedAndToolbar(
+    wholeTextContent: string | null,
+    scopedChildren: Record<string, { textContent: string | null }>,
+    toolbarText: string | null,
+  ): StubNode {
+    return {
+      textContent: wholeTextContent,
+      querySelector(sel: string): StubNode | null {
+        if (sel === TOOLBAR_SEL) {
+          return toolbarText === null ? null : leafNode(toolbarText);
+        }
+        const hit = scopedChildren[sel];
+        if (!hit) return null;
+        return leafNode(hit.textContent);
+      },
+    };
+  }
+
+  it("returns scoped text when last bubble's scoped selectors have content (no fallback path)", async () => {
+    const b0 = bubbleWithScopedAndToolbar(
+      "ignored-whole",
+      { "[data-message-content]": { textContent: "scoped-final-text" } },
+      "Copy Like Dislike",
+    );
+    const doc = makeDoc({ [CANONICAL]: [b0] });
+    const page = makePageForCascade(doc);
+
+    const r = await readCascadeStateLast(page);
+    expect(r).toEqual({ count: 1, text: "scoped-final-text" });
+  });
+
+  it("falls back to bubble.textContent MINUS toolbar when ALL scoped selectors are empty (Class B)", async () => {
+    // Reproduces the live Class B failure mode confirmed on
+    // showcase-ms-agent-python-staging /demos/beautiful-chat:
+    //   - canonical bubble matches, count=1
+    //   - [data-message-content], .cpk:prose, .prose are ALL empty
+    //   - bubble.textContent has 347+ chars of recharts SVG/text content
+    //   - toolbar.textContent appears as a trailing suffix of bubble.textContent
+    // Pre-fix the cascade returned text:null and the settle gate timed out
+    // with `text-unstable`. Post-fix we return wholeText minus the toolbar
+    // suffix, which is stable by RUN_FINISHED.
+    const wholeText =
+      "Monthly Sales for Q1 2026Breakdown of income generated each month.JanuaryFebruaryMarch0255075100Copy Like Dislike";
+    const toolbarText = "Copy Like Dislike";
+    const b = bubbleWithScopedAndToolbar(
+      wholeText,
+      {
+        "[data-message-content]": { textContent: "" },
+        ".cpk\\:prose": { textContent: "" },
+        ".prose": { textContent: "  " },
+      },
+      toolbarText,
+    );
+    const doc = makeDoc({ [CANONICAL]: [b] });
+    const page = makePageForCascade(doc);
+
+    const r = await readCascadeStateLast(page);
+    expect(r.count).toBe(1);
+    expect(r.text).not.toBeNull();
+    expect(r.text).toBe(
+      "Monthly Sales for Q1 2026Breakdown of income generated each month.JanuaryFebruaryMarch0255075100",
+    );
+    // Toolbar text must NOT appear in the returned text.
+    expect(r.text?.includes("Copy Like Dislike")).toBe(false);
+  });
+
+  it("Class B fallback works when there is no toolbar (headless / custom-composer bubbles)", async () => {
+    const wholeText = "Tool render output with no toolbar mounted yet.";
+    const b = bubbleWithScopedAndToolbar(
+      wholeText,
+      { "[data-message-content]": { textContent: "" } },
+      null, // no toolbar
+    );
+    const doc = makeDoc({ [CANONICAL]: [b] });
+    const page = makePageForCascade(doc);
+
+    const r = await readCascadeStateLast(page);
+    expect(r).toEqual({ count: 1, text: wholeText });
+  });
+
+  it("Class B fallback does NOT strip toolbar text when toolbar text is not a trailing suffix (defensive)", async () => {
+    // If the DOM shape ever changes such that toolbar text is NOT the
+    // trailing slice of bubble.textContent, we must not silently mangle
+    // the content. The suffix check guards this: when toolbarText is not
+    // a suffix, we return the whole bubble text as-is.
+    const wholeText = "Toolbar in the middleCopy Like Dislike of the bubble";
+    const toolbarText = "Copy Like Dislike";
+    const b = bubbleWithScopedAndToolbar(
+      wholeText,
+      { "[data-message-content]": { textContent: "" } },
+      toolbarText,
+    );
+    const doc = makeDoc({ [CANONICAL]: [b] });
+    const page = makePageForCascade(doc);
+
+    const r = await readCascadeStateLast(page);
+    expect(r.count).toBe(1);
+    // Toolbar text NOT at suffix → returned whole-bubble text unchanged.
+    expect(r.text).toBe(wholeText);
+  });
+
+  it("returns text:null when scoped selectors AND bubble.textContent are both empty", async () => {
+    // Pure placeholder state — nothing has mounted yet. The settle gate's
+    // `text !== null && text.trim().length > 0` check should keep polling.
+    const b = bubbleWithScopedAndToolbar(
+      "",
+      { "[data-message-content]": { textContent: "" } },
+      "",
+    );
+    const doc = makeDoc({ [CANONICAL]: [b] });
+    const page = makePageForCascade(doc);
+
+    const r = await readCascadeStateLast(page);
+    expect(r).toEqual({ count: 1, text: null });
+  });
+
+  it("returns text:null when bubble.textContent is whitespace-only after toolbar-strip", async () => {
+    // Edge case: toolbar text IS the entire whole-bubble text, so after
+    // stripping we're left with whitespace. Don't lock onto an empty value.
+    const b = bubbleWithScopedAndToolbar(
+      "Copy Like Dislike",
+      { "[data-message-content]": { textContent: "" } },
+      "Copy Like Dislike",
+    );
+    const doc = makeDoc({ [CANONICAL]: [b] });
+    const page = makePageForCascade(doc);
+
+    const r = await readCascadeStateLast(page);
+    expect(r).toEqual({ count: 1, text: null });
+  });
+
+  it("reads the LAST bubble (not the first) on multi-bubble responses with scoped text", async () => {
+    const b0 = bubbleWithScopedAndToolbar(
+      "ignored-whole-0",
+      { "[data-message-content]": { textContent: "first bubble" } },
+      "",
+    );
+    const b1 = bubbleWithScopedAndToolbar(
+      "ignored-whole-1",
+      { "[data-message-content]": { textContent: "last bubble final" } },
+      "",
+    );
+    const doc = makeDoc({ [CANONICAL]: [b0, b1] });
+    const page = makePageForCascade(doc);
+
+    const r = await readCascadeStateLast(page);
+    expect(r).toEqual({ count: 2, text: "last bubble final" });
+  });
+
+  it("returns {count:0, text:null} when no tier matches at all", async () => {
+    const doc = makeDoc({});
+    const page = makePageForCascade(doc);
+    const r = await readCascadeStateLast(page);
+    expect(r).toEqual({ count: 0, text: null });
+  });
+
+  it("swallows page.evaluate throws and returns {count:0, text:null}", async () => {
+    const page: Page = {
+      async evaluate(): Promise<unknown> {
+        throw new Error("browser-eval-blew-up");
+      },
+    } as unknown as Page;
+
+    const r = await readCascadeStateLast(page);
     expect(r).toEqual({ count: 0, text: null });
   });
 });

--- a/showcase/harness/src/probes/helpers/assistant-message-count.ts
+++ b/showcase/harness/src/probes/helpers/assistant-message-count.ts
@@ -344,9 +344,16 @@ export async function readCascadeState(
  * Contract — same as `readCascadeState` but with `idx` resolved internally:
  *   - count: from whichever tier matched (first tier whose `length > 0`)
  *   - text:  per-tier scoped text at index `count - 1` within that SAME tier,
- *            using the same scoped-text cascade as `findAssistantBubbleAt`
- *            (null when the last bubble's scoped selectors are all empty —
- *            mid-stream placeholder state).
+ *            using the same scoped-text cascade as `findAssistantBubbleAt`.
+ *            When ALL scoped selectors are empty, this reader falls back to
+ *            `bubble.textContent` minus the assistant-toolbar's textContent
+ *            (the "Class B fallback") — load-bearing for tool-only-response
+ *            bubbles (gen-UI, recharts, A2UI cards) whose content lives in
+ *            non-cascade children. The fallback is safe ONLY on the LAST
+ *            bubble (by RUN_FINISHED its content has mounted), which is why
+ *            it lives here and NOT in `readCascadeState` / `findAssistantBubbleAt`
+ *            (those address arbitrary indices and would re-introduce the
+ *            cross-bubble flap PR #5462 fixed).
  *   - When no tier matches: `{ count: 0, text: null }`.
  *
  * Implementation note: the closure body references `querySelectorAll` AND
@@ -407,10 +414,44 @@ export async function readCascadeStateLast(
               }
             }
           }
-          // Cascade-pollution guard mirroring `readCascadeState`:
-          // no scoped child has non-empty text — return null rather than
-          // falling back to the whole bubble's textContent (which would
-          // re-introduce LGP suggestion-pill / toolbar pollution).
+          // Class B fallback: tool-only-response bubbles where ALL scoped
+          // text selectors are empty but the bubble has substantial content
+          // in non-cascade children (recharts SVG text, gen-UI / A2UI cards,
+          // tool-call render output, etc.). Use `bubble.textContent` EXCLUDING
+          // the toolbar (the LGP-pill / post-message area), so we capture the
+          // real rendered content without re-introducing the toolbar-icon /
+          // suggestion-pill pollution the scoped cascade was added to prevent.
+          //
+          // This is gated to the LAST bubble for two reasons:
+          //   (a) `readCascadeStateLast` only reads the last bubble — by
+          //       RUN_FINISHED the last bubble's non-cascade children have
+          //       fully mounted, so whole-bubble text is stable.
+          //   (b) intermediate bubbles in multi-step responses can transiently
+          //       carry empty scoped text while the NEXT bubble is mounting;
+          //       reading whole-bubble there would re-introduce the
+          //       cross-bubble text flap r4f2 (PR #5462) sought to prevent.
+          // The toolbar is a leaf sibling of the prose div, so its textContent
+          // is the trailing slice of the bubble's full textContent — strip it
+          // by suffix when present.
+          const toolbar = bubble.querySelector(
+            '[data-testid="copilot-assistant-toolbar"]',
+          );
+          const wholeText = bubble.textContent ?? "";
+          const toolbarText =
+            toolbar !== null ? (toolbar.textContent ?? "") : "";
+          let contentText = wholeText;
+          if (toolbarText.length > 0 && contentText.endsWith(toolbarText)) {
+            contentText = contentText.slice(
+              0,
+              contentText.length - toolbarText.length,
+            );
+          }
+          const trimmed = contentText.trim();
+          if (trimmed.length > 0) {
+            return { count, text: trimmed };
+          }
+          // Still nothing — keep the settle gate polling rather than locking
+          // onto an empty placeholder.
           return { count, text: null };
         }
       }


### PR DESCRIPTION
## Summary

Adds a **Class B cascade fallback** in `readCascadeStateLast` so the harness settle gate can resolve text for **single-bubble tool-only responses** (recharts SVG, gen-UI cards, A2UI render-only output). These bubbles have ALL scoped text selectors empty but carry substantial rendered content in non-cascade children. The current cascade-pollution guard correctly returns `null` for arbitrary-index reads (`readCascadeState` / `findAssistantBubbleAt`) — but for the LAST bubble, by `RUN_FINISHED` the content is mounted and stable, so we can safely fall back to `bubble.textContent` MINUS the assistant-toolbar's textContent (the suffix the toolbar contributes).

This is the residual fix on top of PR #5472 (Class A: multi-bubble last-bubble-has-prose) and #5473 (probe taxonomy cleanup). The ~200-red plateau on PocketBase after #5472 landed is consistent with Class B affecting the long tail of tool-render-only demos (ms-agent-python:beautiful-chat-*, plus other tool-render-only Class-B-shaped demos).

## Class B failure mode (live-confirmed)

Probed against `https://showcase-ms-agent-python-staging.up.railway.app/demos/beautiful-chat` with the prompt _"Show me a bar chart of monthly sales for Q1 2026."_:

- `count = 1` (single canonical bubble)
- `bubble.querySelector('[data-message-content]')` -> empty string
- `bubble.querySelector('.cpk:prose')` -> empty string
- `bubble.querySelector('.prose')` -> empty string
- `bubble.textContent` -> **351 chars** of real content (chart title, axis labels, animation styles, query metadata)
- Current `readCascadeStateLast` returns `text=null` -> settle gate spins on `text-unstable` until timeout (RED).

## Red-green proof (verbatim from /tmp/cr/class-b-red-green.mjs)

The probe runs TWO in-browser readers against the same DOM snapshot — the OLD (current production) and the NEW (with fallback). Run live against staging, **before any code changes** in this PR:

```
[probe] navigating to https://showcase-ms-agent-python-staging.up.railway.app/demos/beautiful-chat
[probe] locating chat input
[probe] sending prompt: Show me a bar chart of monthly sales for Q1 2026.
[probe] waiting 20000ms for response to render
[probe] result: {
  "count": 1,
  "oldText": null,
  "newText": "query_dataquery:\"monthly sales for Q1 2026\"\n        @keyframes barSlideIn {\n          from { transform: translateY(40px); opacity: 0; }\n          20% { opacity: 1; }\n          to { transform: translateY(0); opacity: 1; }\n        }\n      Monthly Sales for Q1 2026Breakdown of income generated each month in Q1 2026.JanuaryFebruaryMarch0255075100January",
  "oldLen": null,
  "newLen": 351,
  "newPreview": "query_dataquery:\"monthly sales for Q1 2026\"\n        @keyframes barSlideIn {\n          from { transform: translateY(40px); opacity: 0; }\n          20% { opacity: 1; }\n          to { transform: translat"
}
[probe] verdict: {
  "red": true,
  "green": true,
  "count": 1
}
[probe] RED-GREEN confirmed: old=null, new=non-empty.
```

- **RED**: `oldText = null`, `oldLen = null` — matches current production behavior; settle gate cannot resolve text.
- **GREEN**: `newText` is 351 chars of stable rendered content; settle gate can lock in `text-stable`.

## The fix

In `showcase/harness/src/probes/helpers/assistant-message-count.ts`, inside `readCascadeStateLast`'s per-tier loop — AFTER the existing scoped-selector cascade exhausts without a non-empty match and BEFORE returning `{count, text: null}`:

1. Read `bubble.textContent` (whole bubble).
2. Read `bubble.querySelector('[data-testid="copilot-assistant-toolbar"]').textContent` if present.
3. If the toolbar's text is a **trailing suffix** of the whole-bubble text (which it canonically is — toolbar is a leaf sibling of the prose div), strip it.
4. If what remains is non-empty after trim -> return `{count, text: <trimmed>}`.
5. Otherwise (no toolbar, no content, or only-toolbar text) -> return `{count, text: null}` to keep polling.

The same fallback is NOT applied to `findAssistantBubbleAt` / `readCascadeState` because those address arbitrary indices and intermediate bubbles in multi-step responses can transiently carry empty scoped text while the NEXT bubble is mounting. Reading whole-bubble at intermediate indices would re-introduce the cross-bubble text flap PR #5462 was designed to prevent. The LAST bubble in a multi-step turn is the agent's terminal output, mounted by `RUN_FINISHED`.

## Why the fallback is safe (toolbar-suffix invariant)

In the canonical CopilotKit assistant bubble (`CopilotChatAssistantMessage.tsx`), the toolbar is the **last child** of the bubble, mounted as a leaf sibling of the prose/markdown wrapper. Its `textContent` is therefore the trailing slice of `bubble.textContent`. Stripping it by suffix-match yields the message content. When the suffix-match fails (defensive — e.g. the DOM shape changes), we return `bubble.textContent` unchanged rather than mangle it. When the toolbar isn't present (headless / custom-composer), we return whole text. When even whole-text is empty, we return `null` (don't lock the settle gate on a placeholder).

## Tests

- `assistant-message-count.test.ts`: 9 new test cases under a new `describe("readCascadeStateLast")` block. Pins:
  - non-empty scoped text path unchanged (no fallback when scoped works)
  - Class B fallback: scoped empty + whole-bubble non-empty + toolbar suffix -> strip suffix, return content
  - Class B fallback works without a toolbar (returns whole text)
  - defensive: toolbar text NOT a suffix -> return whole text unchanged
  - everything empty -> return `text:null` (settle gate keeps polling)
  - only-toolbar text -> return `text:null` after strip
  - multi-bubble: reads the LAST bubble, not the first
  - no tier matches -> `{count:0, text:null}`
  - `evaluate()` throws -> swallowed -> `{count:0, text:null}`
- Full harness suite: **2769 / 2769 passing across 129 files** (`pnpm exec vitest run` in `showcase/harness`).
- TypeScript: `pnpm exec tsc --noEmit` clean.
- Lint: `oxlint` 0 warnings, 0 errors.
- Format: `oxfmt --check` clean.

## Out-of-scope (untouched)

- `conversation-runner.ts` (the settle-gate logic stays — the cascade does the right thing now).
- `sse-interceptor.ts`, `init-scripts.ts`, `d6-all-pills.ts`.
- `findAssistantBubbleAt` / `readCascadeState` (intentionally retain the pollution guard — they address arbitrary indices).
- `resolveBubbleTextFromSelectors` (pure sibling of `findAssistantBubbleAt`, intentionally retains pollution-guard semantics).

## Verification plan after merge

1. Watch CI green on the PR.
2. Promote `showcase-ms-agent-python` and other tool-render-only services.
3. Observe PocketBase D6 red counts: expect the ~200-red plateau to drop further toward baseline.
4. If any demo regresses, revert `readCascadeStateLast` alone.

## Files changed

- `showcase/harness/src/probes/helpers/assistant-message-count.ts` (production fix)
- `showcase/harness/src/probes/helpers/assistant-message-count.test.ts` (9 new tests)
