### PR TITLE
chore(examples): bump slack example to @copilotkit/bot* 0.0.2

### DIFF
--- a/examples/slack/package.json
+++ b/examples/slack/package.json
@@ -16,9 +16,9 @@
     "e2e:restart": "tsx e2e/restart-recovery.ts"
   },
   "dependencies": {
-    "@copilotkit/bot": "~0.0.1",
-    "@copilotkit/bot-slack": "~0.0.1",
-    "@copilotkit/bot-ui": "~0.0.1",
+    "@copilotkit/bot": "~0.0.2",
+    "@copilotkit/bot-slack": "~0.0.2",
+    "@copilotkit/bot-ui": "~0.0.2",
     "@copilotkit/runtime": "^1.59.5",
     "@slack/bolt": "^4.2.0",
     "@slack/types": "^2.21.1",


### PR DESCRIPTION
## What

Bumps the `examples/slack` dependency ranges for the bot packages from `~0.0.1` to `~0.0.2`, now that `@copilotkit/bot`, `@copilotkit/bot-slack`, and `@copilotkit/bot-ui` are all published at **0.0.2** (the agent-native assistant pane + native streaming release).

```diff
-    "@copilotkit/bot": "~0.0.1",
-    "@copilotkit/bot-slack": "~0.0.1",
-    "@copilotkit/bot-ui": "~0.0.1",
+    "@copilotkit/bot": "~0.0.2",
+    "@copilotkit/bot-slack": "~0.0.2",
+    "@copilotkit/bot-ui": "~0.0.2",
```

## Why

A standalone/deployed install of the example (outside the monorepo) resolves these from npm. At `~0.0.1` it would pull `bot-slack@0.0.2` but could still resolve `bot`/`bot-ui@0.0.1`, which lack the engine surface the pane code calls at runtime (`sink.onThreadStarted`, `thread.setSuggestedPrompts/setTitle`, the new capability flags) — so the assistant pane would crash. Pinning all three to `~0.0.2` keeps the trio aligned.

## Notes

- **Lockfile unchanged**: local monorepo installs already resolve these to the workspace copies via the root `pnpm.overrides` (`@copilotkit/bot* → workspace:*`), so this range bump only affects deployed/standalone installs.
- No code changes — `package.json` only.
