### PR TITLE
fix(examples): make slack example lockfile deployable (drop workspace override)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -6,4 +6,7 @@ minimum-release-age-exclude[]=@ag-ui/proto
 minimum-release-age-exclude[]=@ag-ui/langgraph
 minimum-release-age-exclude[]=@ag-ui/a2ui-middleware
 minimum-release-age-exclude[]=@ag-ui/a2ui-toolkit
+minimum-release-age-exclude[]=@copilotkit/bot
+minimum-release-age-exclude[]=@copilotkit/bot-slack
+minimum-release-age-exclude[]=@copilotkit/bot-ui
 block-exotic-subdeps=true

--- a/package.json
+++ b/package.json
@@ -90,9 +90,6 @@
       }
     },
     "overrides": {
-      "@copilotkit/bot": "workspace:*",
-      "@copilotkit/bot-slack": "workspace:*",
-      "@copilotkit/bot-ui": "workspace:*",
       "@ag-ui/mcp-middleware>@ag-ui/client": "0.0.53",
       "streamdown>react": "^19.0.0",
       "@types/react": "19.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@copilotkit/bot': workspace:*
-  '@copilotkit/bot-slack': workspace:*
-  '@copilotkit/bot-ui': workspace:*
   '@ag-ui/mcp-middleware>@ag-ui/client': 0.0.53
   streamdown>react: ^19.0.0
   '@types/react': 19.1.8
@@ -387,14 +384,14 @@ importers:
   examples/slack:
     dependencies:
       '@copilotkit/bot':
-        specifier: workspace:*
-        version: link:../../packages/bot
+        specifier: ~0.0.2
+        version: 0.0.2(encoding@0.1.13)(zod@3.25.76)
       '@copilotkit/bot-slack':
-        specifier: workspace:*
-        version: link:../../packages/bot-slack
+        specifier: ~0.0.2
+        version: 0.0.2(@types/express@5.0.6)(encoding@0.1.13)
       '@copilotkit/bot-ui':
-        specifier: workspace:*
-        version: link:../../packages/bot-ui
+        specifier: ~0.0.2
+        version: 0.0.2(@ag-ui/core@0.0.57)(encoding@0.1.13)
       '@copilotkit/runtime':
         specifier: ^1.59.5
         version: 1.59.5(4c17f358ce8005944aeca87c7a73a8ac)
@@ -2248,7 +2245,7 @@ importers:
         specifier: 0.0.57
         version: 0.0.57
       '@copilotkit/bot-ui':
-        specifier: workspace:*
+        specifier: workspace:~
         version: link:../bot-ui
       '@copilotkit/core':
         specifier: workspace:^
@@ -2285,10 +2282,10 @@ importers:
         specifier: 0.0.57
         version: 0.0.57
       '@copilotkit/bot':
-        specifier: workspace:*
+        specifier: workspace:~
         version: link:../bot
       '@copilotkit/bot-ui':
-        specifier: workspace:*
+        specifier: workspace:~
         version: link:../bot-ui
       '@copilotkit/core':
         specifier: workspace:^
@@ -5437,6 +5434,19 @@ packages:
       vitest:
         optional: true
 
+  '@copilotkit/bot-slack@0.0.2':
+    resolution: {integrity: sha512-CgkmTFSfJSvZft2tdBsCSeBhA2G1RyIihMpbILcSZdo+rElq4aUkqvQJzQ8ASERWspp6unpVr+Sz9swZMR1OFg==}
+
+  '@copilotkit/bot-ui@0.0.2':
+    resolution: {integrity: sha512-Xzq03QcKE2bnkDNQ3Re8fG8oP9QwMi7+7ueZQyC36omKANbg5UCIHLV3O8cEgGXkr4fEXLin0u7UOB17JlIWpg==}
+
+  '@copilotkit/bot@0.0.2':
+    resolution: {integrity: sha512-qv1o3+Jq1t8Yqr5lEiSjkeo0rTt/dTHni5elU3M09wRPnHTtIiVO7BKXtFE0Lb9Geypl/Z7vkrFEcpy3uef/AQ==}
+
+  '@copilotkit/core@1.60.1':
+    resolution: {integrity: sha512-5IuY5PaCh1v4//pj7BRTiMGGJAEa97NHH1IE756ku5pE+ZEcSnhgWE3j5lXiFQZC1YzNuMo9amiZtV8DQ+wDMQ==}
+    engines: {node: '>=18'}
+
   '@copilotkit/license-verifier@0.4.2':
     resolution: {integrity: sha512-0+Rdtg4gOwOBFBpZFxYsjgwBcCLja5z03YC6WA3KEntHYhsnoJ2aqNG6c0we8ZExCNYlEO4M7kHIfG5LXzqMYQ==}
 
@@ -5475,6 +5485,11 @@ packages:
 
   '@copilotkit/shared@1.59.5':
     resolution: {integrity: sha512-QMIaJDuSdrA4LuzkgmBzXodXkFJTZY9HrPXf1FbeWu5V4pGZ97Jk5gbuKLQaGbmkVt6dDX9aGBBu0ujCqpsf3w==}
+    peerDependencies:
+      '@ag-ui/core': '>=0.0.48'
+
+  '@copilotkit/shared@1.60.1':
+    resolution: {integrity: sha512-8KTxK6xnuxmFjGy9pHkHOMDElQl5Smisx0q8hx8je1NEkwrxFKrCK653APqn83QyQLifdPBqExXEUpGkqhoGcw==}
     peerDependencies:
       '@ag-ui/core': '>=0.0.48'
 
@@ -28267,6 +28282,60 @@ snapshots:
       jest: 29.7.0(@types/node@22.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@22.19.11)(typescript@5.9.3))
       vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@22.19.11)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  '@copilotkit/bot-slack@0.0.2(@types/express@5.0.6)(encoding@0.1.13)':
+    dependencies:
+      '@ag-ui/client': 0.0.57
+      '@ag-ui/core': 0.0.57
+      '@copilotkit/bot': 0.0.2(encoding@0.1.13)(zod@3.25.76)
+      '@copilotkit/bot-ui': 0.0.2(@ag-ui/core@0.0.57)(encoding@0.1.13)
+      '@copilotkit/core': 1.60.1(@ag-ui/core@0.0.57)(encoding@0.1.13)(zod@3.25.76)
+      '@copilotkit/shared': 1.60.1(@ag-ui/core@0.0.57)(encoding@0.1.13)
+      '@slack/bolt': 4.7.3(@types/express@5.0.6)
+      '@slack/types': 2.21.1
+      '@slack/web-api': 7.16.0
+      rxjs: 7.8.1
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@types/express'
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@copilotkit/bot-ui@0.0.2(@ag-ui/core@0.0.57)(encoding@0.1.13)':
+    dependencies:
+      '@copilotkit/shared': 1.60.1(@ag-ui/core@0.0.57)(encoding@0.1.13)
+    transitivePeerDependencies:
+      - '@ag-ui/core'
+      - encoding
+
+  '@copilotkit/bot@0.0.2(encoding@0.1.13)(zod@3.25.76)':
+    dependencies:
+      '@ag-ui/client': 0.0.57
+      '@ag-ui/core': 0.0.57
+      '@copilotkit/bot-ui': 0.0.2(@ag-ui/core@0.0.57)(encoding@0.1.13)
+      '@copilotkit/core': 1.60.1(@ag-ui/core@0.0.57)(encoding@0.1.13)(zod@3.25.76)
+      '@copilotkit/shared': 1.60.1(@ag-ui/core@0.0.57)(encoding@0.1.13)
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - encoding
+      - zod
+
+  '@copilotkit/core@1.60.1(@ag-ui/core@0.0.57)(encoding@0.1.13)(zod@3.25.76)':
+    dependencies:
+      '@ag-ui/client': 0.0.57
+      '@copilotkit/shared': 1.60.1(@ag-ui/core@0.0.57)(encoding@0.1.13)
+      '@tanstack/pacer': 0.20.1
+      phoenix: 1.8.4
+      rxjs: 7.8.1
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@ag-ui/core'
+      - encoding
+      - zod
+
   '@copilotkit/license-verifier@0.4.2': {}
 
   '@copilotkit/runtime@1.59.5(4c17f358ce8005944aeca87c7a73a8ac)':
@@ -28341,6 +28410,22 @@ snapshots:
     dependencies:
       '@ag-ui/client': 0.0.53
       '@ag-ui/core': 0.0.53
+      '@copilotkit/license-verifier': 0.4.2
+      '@segment/analytics-node': 2.3.0(encoding@0.1.13)
+      '@standard-schema/spec': 1.1.0
+      chalk: 4.1.2
+      graphql: 16.12.0
+      partial-json: 0.1.7
+      uuid: 11.1.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - encoding
+
+  '@copilotkit/shared@1.60.1(@ag-ui/core@0.0.57)(encoding@0.1.13)':
+    dependencies:
+      '@ag-ui/client': 0.0.57
+      '@ag-ui/core': 0.0.57
       '@copilotkit/license-verifier': 0.4.2
       '@segment/analytics-node': 2.3.0(encoding@0.1.13)
       '@standard-schema/spec': 1.1.0


### PR DESCRIPTION
## What

Fixes the Railway deploy of `examples/slack` failing with `ERR_PNPM_OUTDATED_LOCKFILE`.

## Why it broke

PR #5476 bumped the example's `@copilotkit/bot*` deps to `~0.0.2` but the lockfile didn't change — because the root `pnpm.overrides` (`@copilotkit/bot* → workspace:*`, added for local dev) pinned those deps to **workspace links** for every importer. So the committed lockfile recorded the example's bot deps as `~0.0.1` / `link:../../packages/bot`, which:
- frozen-install validates fine **inside** the monorepo (the override masks it), but
- a **standalone Railway deploy** frozen-installs only `examples/slack`, sees `package.json ~0.0.2` vs lockfile `~0.0.1`, and can't resolve `link:` paths → crash.

## The fix

Now that `bot`/`bot-slack`/`bot-ui` are published at `0.0.2`:
- **Drop the three `@copilotkit/bot*` overrides** from root `package.json`. Workspace packages still link each other via `workspace:~`; only the **example** switches to consuming the published versions — the correct model for a deployable demo.
- **Regenerate `pnpm-lock.yaml`** — the example's importer now records `specifier: ~0.0.2` resolving to the **registry** `0.0.2` (not a `link:`), so a standalone frozen install resolves cleanly.
- **Add `@copilotkit/bot*` to `minimum-release-age-exclude`** in `.npmrc` (matching the existing `@ag-ui/*` entries) so the freshly-published `0.0.2` resolves past the 24h supply-chain gate.

## Verified
- `pnpm install --frozen-lockfile` → "Lockfile is up to date"; the registry `0.0.2` packages download cleanly.
- Example importer: `specifier: ~0.0.2`, `version: 0.0.2(...)` (registry, no `link:`).
- Full pre-commit suite + commitlint green.

## Trade-off
Local monorepo dev of the example now consumes the **published** `0.0.2` rather than live worktree source. To iterate on the bot packages against the example locally, temporarily set the example's bot deps to `workspace:*` (or re-add the overrides) — don't commit that.
