### PR TITLE
docs(examples): note monorepo deploy watch-paths for slack example

### DIFF
--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -313,6 +313,13 @@ set the same env vars, and (for Notion) run the
 `@notionhq/notion-mcp-server` sidecar alongside the runtime with
 `NOTION_MCP_URL` pointed at it.
 
+> **Deploying from this monorepo (e.g. Railway):** this example depends on the
+> published `@copilotkit/bot*` packages (`package.json`), so a standalone build
+> installs them from npm. The pnpm lockfile lives at the **repo root**, so make
+> sure each service's **watch paths** include `pnpm-lock.yaml` and `package.json`
+> (not just `examples/slack/**`) — otherwise a dependency bump won't trigger a
+> redeploy and a frozen install can fail with an out-of-date lockfile.
+
 ## Tests
 
 ```bash


### PR DESCRIPTION
## What

A small docs touch to `examples/slack/README.md` that (a) documents the monorepo-deploy watch-path gotcha and (b) **touches a watched path so Railway redeploys the slack services off latest `main`**.

## Why

PR #5478 fixed the example's lockfile so a standalone deploy resolves the published `@copilotkit/bot*` `0.0.2` — but that fix only changed **repo-root** files (`pnpm-lock.yaml`, `package.json`, `.npmrc`). The `kite-slack-bot` / `runtime` Railway services watch `examples/slack/**`, so they reported "watched paths not modified" and never picked up the fix. This commit changes a file under `examples/slack/**`, so merging it triggers a rebuild of latest `main` (which carries #5478's fix).

The added note also tells future deployers to include the repo-root `pnpm-lock.yaml` / `package.json` in their Railway watch paths so this doesn't recur.

Docs-only; no code change.
