### PR TITLE
feat(react-core): expose isReady flag from useAgent hook

### DIFF
--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -239,7 +239,16 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
     agent.threadId = configThreadId;
   }, [agent, configThreadId, configHasExplicitThreadId]);
 
+  // isReady is true once the runtime has finished connecting and a real agent
+  // instance (not a provisional placeholder) is available for the requested
+  // agentId. Callers can use this to defer renders or actions that require a
+  // live agent subscription.
+  const isReady =
+    copilotkit.runtimeConnectionStatus === CopilotKitCoreRuntimeConnectionStatus.Connected &&
+    copilotkit.getAgent(agentId) !== undefined;
+
   return {
     agent,
+    isReady,
   };
 }


### PR DESCRIPTION
## What does this PR do?
Adds an `isReady` boolean to the object returned by `useAgent`. The flag is `true` once the runtime connection status is `Connected` and a real agent instance (not a provisional placeholder) is available for the requested `agentId`. It is `false` during initialization, while the runtime is connecting, or when the connection is in an error state.

This gives callers a clean way to conditionally render UI or defer actions until the agent is ready:

```tsx
const { agent, isReady } = useAgent();

if (!isReady) return <Spinner />;
return <AgentChat agent={agent} />;
```

Addresses #5000.

## Related PRs and Issues
- Closes #5000

## Checklist
- [x] I have read the Contribution Guide
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked