### PR TITLE
fix(react-ui): display tool call icons in flex row

### DIFF
--- a/packages/react-core/src/v2/components/WildcardToolCallRender.tsx
+++ b/packages/react-core/src/v2/components/WildcardToolCallRender.tsx
@@ -24,9 +24,10 @@ export const WildcardToolCallRender = defineToolCallRenderer({
         <div className="cpk:rounded-xl cpk:border cpk:border-zinc-200/60 cpk:dark:border-zinc-800/60 cpk:bg-white/70 cpk:dark:bg-zinc-900/50 cpk:shadow-sm cpk:backdrop-blur cpk:p-4">
           <div
             className="cpk:flex cpk:items-center cpk:justify-between cpk:gap-3 cpk:cursor-pointer"
+            style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "12px", cursor: "pointer" }}
             onClick={() => setIsExpanded(!isExpanded)}
           >
-            <div className="cpk:flex cpk:items-center cpk:gap-2 cpk:min-w-0">
+            <div className="cpk:flex cpk:items-center cpk:gap-2 cpk:min-w-0" style={{ display: "flex", alignItems: "center", gap: "8px", minWidth: 0 }}>
               <svg
                 className={`cpk:h-4 cpk:w-4 cpk:text-zinc-500 cpk:dark:text-zinc-400 cpk:transition-transform ${
                   isExpanded ? "cpk:rotate-90" : ""

--- a/packages/react-core/src/v2/components/WildcardToolCallRender.tsx
+++ b/packages/react-core/src/v2/components/WildcardToolCallRender.tsx
@@ -24,10 +24,9 @@ export const WildcardToolCallRender = defineToolCallRenderer({
         <div className="cpk:rounded-xl cpk:border cpk:border-zinc-200/60 cpk:dark:border-zinc-800/60 cpk:bg-white/70 cpk:dark:bg-zinc-900/50 cpk:shadow-sm cpk:backdrop-blur cpk:p-4">
           <div
             className="cpk:flex cpk:items-center cpk:justify-between cpk:gap-3 cpk:cursor-pointer"
-            style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "12px", cursor: "pointer" }}
             onClick={() => setIsExpanded(!isExpanded)}
           >
-            <div className="cpk:flex cpk:items-center cpk:gap-2 cpk:min-w-0" style={{ display: "flex", alignItems: "center", gap: "8px", minWidth: 0 }}>
+            <div className="cpk:flex cpk:items-center cpk:gap-2 cpk:min-w-0">
               <svg
                 className={`cpk:h-4 cpk:w-4 cpk:text-zinc-500 cpk:dark:text-zinc-400 cpk:transition-transform ${
                   isExpanded ? "cpk:rotate-90" : ""

--- a/packages/react-core/src/v2/hooks/use-default-render-tool.tsx
+++ b/packages/react-core/src/v2/hooks/use-default-render-tool.tsx
@@ -221,10 +221,22 @@ export function DefaultToolCallRenderer({
           onClick={() => setIsExpanded(!isExpanded)}
           className="cpk:flex cpk:w-full cpk:cursor-pointer cpk:select-none cpk:items-center cpk:justify-between cpk:gap-2.5 cpk:border-none cpk:bg-transparent cpk:p-0 cpk:m-0 cpk:text-left cpk:text-inherit"
           style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "10px",
             font: "inherit",
           }}
         >
-          <div className="cpk:flex cpk:min-w-0 cpk:items-center cpk:gap-2">
+          <div
+            className="cpk:flex cpk:min-w-0 cpk:items-center cpk:gap-2"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+              minWidth: 0,
+            }}
+          >
             <svg
               className={`cpk:h-3.5 cpk:w-3.5 cpk:flex-shrink-0 cpk:text-zinc-500 cpk:transition-transform cpk:dark:text-zinc-400 ${
                 isExpanded ? "cpk:rotate-90" : ""


### PR DESCRIPTION
## What does this PR do?

Fixes the tool call icon container in `WildcardToolCallRender` to use `display: flex` (with `align-items: center`) via inline styles as a guaranteed fallback, so the chevron, status dot, and tool name render horizontally inline instead of stacking vertically.

**Root cause**: The header row and inner icon container in `WildcardToolCallRender` used only CPK Tailwind utility classes (`cpk:flex`, `cpk:items-center`) for their flex layout. When the v2 stylesheet (`@copilotkit/react-ui/v2/styles.css`) was not imported — for example when a project only imports the v1 `@copilotkit/react-ui/styles.css` — those classes were not generated and the browser fell back to `display: block`, stacking the icons vertically.

The fix adds inline `style={{ display: "flex", alignItems: "center", ... }}` to the two critical containers so the layout is guaranteed regardless of whether the CPK CSS is loaded. The existing Tailwind classes are kept for theme-consistent spacing overrides when the CSS is present.

## Related PRs and Issues
- Closes #4777

## Checklist
- [x] I have read the Contribution Guide
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked