### PR TITLE
docs(shell-docs): emit canonical versioned URLs for reference pages in llms-full.txt

### DIFF
--- a/showcase/shell-docs/src/lib/llm-text.ts
+++ b/showcase/shell-docs/src/lib/llm-text.ts
@@ -37,9 +37,13 @@ import matter from "gray-matter";
 import { CONTENT_DIR, inlineSnippets, loadDoc } from "./docs-render";
 import { getDocsFolder, getIntegrations } from "./registry";
 import {
+  REFERENCE_VERSIONS,
+  loadReferenceVersionItems,
+  resolveReferencePage,
+} from "./reference-items";
+import {
   AG_UI_CONTENT_DIR,
   DOCS_CONTENT_DIR,
-  REFERENCE_CONTENT_DIR,
   walkMdx,
 } from "./sitemap-helpers";
 import demoContent from "@/data/demo-content.json";
@@ -177,18 +181,52 @@ export function getAllLlmPages(): LlmPage[] {
     }
   }
 
-  // 3. Reference docs.
-  for (const { slug, filePath } of walkMdx(REFERENCE_CONTENT_DIR)) {
-    const meta = readMetaFromFile(filePath);
-    push({
-      url: slug ? `reference/${slug}` : "reference",
-      title: meta.title ?? slug,
-      description: meta.description,
-      filePath,
-      // Reference docs live outside CONTENT_DIR; we can't reuse
-      // loadDoc(). Caller branches on this prefix when reading source.
-      loadSlug: `__reference__/${slug || "index"}`,
-    });
+  // 3. Reference docs — all SDK versions at their canonical versioned URLs.
+  //
+  //    The v2 (current) API reference lives at the root of
+  //    `src/content/reference/` (e.g. `hooks/useCopilotAction.mdx`) and is
+  //    served at `/reference/v2/hooks/useCopilotAction`. Older versions live
+  //    under their own subfolder (`v1/`, `react-native/`, etc.) and are
+  //    served at `/reference/v1/hooks/...`.
+  //
+  //    We enumerate via `loadReferenceVersionItems` (which already knows the
+  //    canonical URL for each version) rather than walking the filesystem
+  //    directly, so that LLM consumers see the same versioned URL they would
+  //    navigate to in the browser.
+  for (const version of REFERENCE_VERSIONS) {
+    // Version root index page (e.g. `/reference/v2`, `/reference/v1`).
+    const rootResolved = resolveReferencePage([version]);
+    if (rootResolved) {
+      const rootMeta = readMetaFromFile(rootResolved.filePath);
+      push({
+        url: `reference/${version}`,
+        title: rootMeta.title ?? version,
+        description: rootMeta.description,
+        filePath: rootResolved.filePath,
+        loadSlug: `__reference__/${rootResolved.contentSlug}`,
+      });
+    }
+
+    // Individual API reference pages within this version.
+    for (const item of loadReferenceVersionItems(version)) {
+      // item.url is the canonical path, e.g. "/reference/v2/hooks/foo".
+      // Strip the leading "/" so LlmPage.url has no leading slash.
+      const url = item.url.replace(/^\//, "");
+      // Resolve the source file via the same logic the page renderer uses.
+      const resolved = resolveReferencePage(
+        url.replace(/^reference\//, "").split("/"),
+      );
+      if (!resolved) continue;
+      push({
+        url,
+        title: item.title,
+        description: item.description,
+        filePath: resolved.filePath,
+        // Reference docs live outside CONTENT_DIR; readSource branches on
+        // this prefix to read via fs.readFileSync instead of loadDoc().
+        loadSlug: `__reference__/${resolved.contentSlug}`,
+      });
+    }
   }
 
   // 4. AG-UI.


### PR DESCRIPTION
## What does this PR do?

`getAllLlmPages()` in `llm-text.ts` previously walked `src/content/reference/` directly and emitted reference pages at `reference/<slug>` (e.g. `reference/hooks/useCopilotAction`). The live site serves those pages at their versioned canonical URL — `/reference/v2/hooks/useCopilotAction` for the current v2 API — so `llms-full.txt` contained non-canonical source URLs that diverged from what users see in the browser.

**Root cause:** The v2 API reference lives at the _root_ of `src/content/reference/` (no `v2/` subfolder), so a bare filesystem walk cannot distinguish v2 from older SDK versions. It emits `reference/hooks/foo` instead of the correct `reference/v2/hooks/foo`.

**Fix:** Replace step 3 with an enumeration via `loadReferenceVersionItems` (which already knows the canonical URL per version) and `resolveReferencePage` (which resolves the content file path). This matches the URL scheme used by the `/reference/[...slug]` route handler.

**Result:**
- v2 hooks/components now appear at `reference/v2/hooks/...` in `llms-full.txt`
- v1, react-native, core, and bot pages appear at their correct versioned prefixes
- Version root index pages (`reference/v2`, `reference/v1`, ...) are included
- The migration guide (`migrate/v2`) was already included via the docs walk (step 1 unchanged)

## Related PRs and Issues
- Closes #3385

## Checklist
- I have read the Contribution Guide
- If the PR changes or adds functionality, I have updated the relevant documentation
- "Allow edits by maintainers" is checked
