### PR TITLE
fix(react-ui): wrap CopilotKit CSS selectors in :where() to reduce specificity

### DIFF
--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -396,7 +396,7 @@
  * historical-replay turn renders directly in its settled state with no
  * animation — which is the desired behavior.
  */
-.cpk-intelligence-indicator {
+:where(.cpk-intelligence-indicator) {
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -413,7 +413,7 @@
 
 /* ─── Chrome layer (bg, border, shadow, backdrop-blur) ──────────────── */
 
-.cpk-intelligence-indicator__chrome {
+:where(.cpk-intelligence-indicator__chrome) {
   position: absolute;
   inset: 0;
   border-radius: 999px;
@@ -435,14 +435,14 @@
   transition: opacity 400ms ease-out 250ms;
 }
 
-.cpk-intelligence-indicator[data-status="finished"]
-  .cpk-intelligence-indicator__chrome {
+:where(.cpk-intelligence-indicator)[data-status="finished"]
+  :where(.cpk-intelligence-indicator__chrome) {
   opacity: 0;
 }
 
 /* ─── Content layer (icon + label) ──────────────────────────────────── */
 
-.cpk-intelligence-indicator__content {
+:where(.cpk-intelligence-indicator__content) {
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -463,8 +463,8 @@
   transition: color 400ms ease-out 250ms;
 }
 
-.cpk-intelligence-indicator[data-status="finished"]
-  .cpk-intelligence-indicator__content {
+:where(.cpk-intelligence-indicator)[data-status="finished"]
+  :where(.cpk-intelligence-indicator__content) {
   /* True-neutral gray (`#737373`, R=G=B) at 0.8 alpha. No hue cast in
      either direction (slate would lean blue, stone would lean warm).
      The combination of pure-neutral hue + slight transparency reads
@@ -484,18 +484,18 @@
    sans-serif system fonts used by default, the browser-synthesized
    italic is itself a slant on the upright forms, so this approach
    matches what `font-style: italic` would have rendered anyway. */
-.cpk-intelligence-indicator__label {
+:where(.cpk-intelligence-indicator__label) {
   display: inline-block;
   transform: skewX(0deg);
   transition: transform 400ms ease-out 250ms;
 }
 
-.cpk-intelligence-indicator[data-status="finished"]
-  .cpk-intelligence-indicator__label {
+:where(.cpk-intelligence-indicator)[data-status="finished"]
+  :where(.cpk-intelligence-indicator__label) {
   transform: skewX(-10deg);
 }
 
-.cpk-intelligence-indicator__icon {
+:where(.cpk-intelligence-indicator__icon) {
   display: block;
   flex-shrink: 0;
   /* The icon holds two overlaid paths: a spinning arc (in-progress)
@@ -512,8 +512,8 @@
    out while the checkmark draws itself in (stroke-dashoffset) — a smooth,
    cross-browser stand-in for the old Blink-only `d:` morph. */
 
-.cpk-intelligence-indicator__icon-arc,
-.cpk-intelligence-indicator__icon-check {
+:where(.cpk-intelligence-indicator__icon-arc),
+:where(.cpk-intelligence-indicator__icon-check) {
   fill: none;
   stroke: currentColor;
   stroke-width: 2.5;
@@ -534,7 +534,7 @@
    in Chrome). The animation is `infinite` and is left running in the finished
    state, so the arc keeps rotating while its opacity fades to 0 (fades out
    mid-spin rather than stopping dead). */
-.cpk-intelligence-indicator__icon-arc {
+:where(.cpk-intelligence-indicator__icon-arc) {
   stroke-dasharray: 0.53 0.47;
   opacity: 1;
   transform-box: fill-box;
@@ -547,7 +547,7 @@
    checkmark starts fully offset (undrawn) and, on finish, draws itself in by
    animating stroke-dashoffset 1 → 0 — slightly delayed and overlapping the
    arc's fade so the spinner resolves into the tick rather than hard-cutting. */
-.cpk-intelligence-indicator__icon-check {
+:where(.cpk-intelligence-indicator__icon-check) {
   stroke-dasharray: 1;
   stroke-dashoffset: 1;
   opacity: 0;
@@ -556,14 +556,14 @@
     opacity 140ms linear 90ms;
 }
 
-.cpk-intelligence-indicator[data-status="finished"]
-  .cpk-intelligence-indicator__icon-arc {
+:where(.cpk-intelligence-indicator)[data-status="finished"]
+  :where(.cpk-intelligence-indicator__icon-arc) {
   /* Spin is intentionally left running here (now invisible): stopping it
      would snap the arc back to 0° mid-fade. The cost is negligible. */
   opacity: 0;
 }
-.cpk-intelligence-indicator[data-status="finished"]
-  .cpk-intelligence-indicator__icon-check {
+:where(.cpk-intelligence-indicator)[data-status="finished"]
+  :where(.cpk-intelligence-indicator__icon-check) {
   stroke-dashoffset: 0;
   opacity: 1;
 }
@@ -582,14 +582,14 @@
    pill + label still convey "working", and the static check still conveys
    "done" — the information is intact, just without movement. */
 @media (prefers-reduced-motion: reduce) {
-  .cpk-intelligence-indicator__icon-arc {
+  :where(.cpk-intelligence-indicator__icon-arc) {
     animation: none;
   }
-  .cpk-intelligence-indicator__chrome,
-  .cpk-intelligence-indicator__content,
-  .cpk-intelligence-indicator__label,
-  .cpk-intelligence-indicator__icon-arc,
-  .cpk-intelligence-indicator__icon-check {
+  :where(.cpk-intelligence-indicator__chrome),
+  :where(.cpk-intelligence-indicator__content),
+  :where(.cpk-intelligence-indicator__label),
+  :where(.cpk-intelligence-indicator__icon-arc),
+  :where(.cpk-intelligence-indicator__icon-check) {
     transition: none;
   }
 }

--- a/packages/react-ui/src/css/animations.css
+++ b/packages/react-ui/src/css/animations.css
@@ -1,10 +1,10 @@
-.copilotKitActivityDot1 {
+:where(.copilotKitActivityDot1) {
   animation: copilotKitActivityDotsAnimation 1.05s infinite;
 }
-.copilotKitActivityDot2 {
+:where(.copilotKitActivityDot2) {
   animation-delay: 0.1s;
 }
-.copilotKitActivityDot3 {
+:where(.copilotKitActivityDot3) {
   animation-delay: 0.2s;
 }
 @keyframes copilotKitActivityDotsAnimation {

--- a/packages/react-ui/src/css/attachments.css
+++ b/packages/react-ui/src/css/attachments.css
@@ -1,5 +1,5 @@
 /* Attachment Queue */
-.copilotKitAttachmentQueue {
+:where(.copilotKitAttachmentQueue) {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
@@ -7,7 +7,7 @@
   padding: 8px;
 }
 
-.copilotKitAttachmentQueueItem {
+:where(.copilotKitAttachmentQueueItem) {
   position: relative;
   display: inline-flex;
   border-radius: 8px;
@@ -16,25 +16,25 @@
   background: var(--copilot-kit-input-background-color);
 }
 
-.copilotKitAttachmentQueueItem--image,
-.copilotKitAttachmentQueueItem--video {
+:where(.copilotKitAttachmentQueueItem--image),
+:where(.copilotKitAttachmentQueueItem--video) {
   width: 72px;
   height: 72px;
 }
 
-.copilotKitAttachmentQueueItem--audio {
+:where(.copilotKitAttachmentQueueItem--audio) {
   min-width: 200px;
   max-width: 280px;
   flex-direction: column;
   padding: 4px;
 }
 
-.copilotKitAttachmentQueueItem--document {
+:where(.copilotKitAttachmentQueueItem--document) {
   padding: 8px 12px;
   max-width: 200px;
 }
 
-.copilotKitAttachmentQueueOverlay {
+:where(.copilotKitAttachmentQueueOverlay) {
   position: absolute;
   inset: 0;
   display: flex;
@@ -44,7 +44,7 @@
   z-index: 1;
 }
 
-.copilotKitAttachmentQueueSpinner {
+:where(.copilotKitAttachmentQueueSpinner) {
   width: 20px;
   height: 20px;
   border: 2px solid rgba(255, 255, 255, 0.3);
@@ -59,7 +59,7 @@
   }
 }
 
-.copilotKitAttachmentQueueRemoveButton {
+:where(.copilotKitAttachmentQueueRemoveButton) {
   position: absolute;
   top: 4px;
   right: 4px;
@@ -79,49 +79,49 @@
   line-height: 1;
 }
 
-.copilotKitAttachmentQueueRemoveButton:hover {
+:where(.copilotKitAttachmentQueueRemoveButton):hover {
   background: rgba(0, 0, 0, 0.8);
 }
 
-.copilotKitAttachmentQueuePreviewPlaceholder {
+:where(.copilotKitAttachmentQueuePreviewPlaceholder) {
   width: 100%;
   height: 100%;
   background: var(--copilot-kit-input-background-color);
 }
 
-.copilotKitAttachmentQueuePreviewImage {
+:where(.copilotKitAttachmentQueuePreviewImage) {
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
 
 /* Audio preview in queue */
-.copilotKitAttachmentQueuePreviewAudio {
+:where(.copilotKitAttachmentQueuePreviewAudio) {
   display: flex;
   flex-direction: column;
   gap: 4px;
   width: 100%;
 }
 
-.copilotKitAttachmentQueuePreviewAudio audio {
+:where(.copilotKitAttachmentQueuePreviewAudio) audio {
   width: 100%;
   height: 32px;
 }
 
 /* Video preview in queue */
-.copilotKitAttachmentQueuePreviewVideo {
+:where(.copilotKitAttachmentQueuePreviewVideo) {
   width: 100%;
   height: 100%;
 }
 
 /* Document preview in queue */
-.copilotKitAttachmentQueuePreviewDocument {
+:where(.copilotKitAttachmentQueuePreviewDocument) {
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.copilotKitAttachmentQueueDocIcon {
+:where(.copilotKitAttachmentQueueDocIcon) {
   width: 32px;
   height: 32px;
   border-radius: 6px;
@@ -135,14 +135,14 @@
   flex-shrink: 0;
 }
 
-.copilotKitAttachmentQueueDocInfo {
+:where(.copilotKitAttachmentQueueDocInfo) {
   display: flex;
   flex-direction: column;
   gap: 2px;
   min-width: 0;
 }
 
-.copilotKitAttachmentQueueFilename {
+:where(.copilotKitAttachmentQueueFilename) {
   font-size: 12px;
   font-weight: 500;
   overflow: hidden;
@@ -150,39 +150,39 @@
   white-space: nowrap;
 }
 
-.copilotKitAttachmentQueueFileSize {
+:where(.copilotKitAttachmentQueueFileSize) {
   font-size: 11px;
   color: var(--copilot-kit-secondary-contrast-color);
 }
 
 /* Drag-and-drop overlay */
-.copilotKitDragOver {
+:where(.copilotKitDragOver) {
   outline: 2px dashed var(--copilot-kit-primary-color, #6366f1);
   outline-offset: -4px;
   border-radius: 8px;
 }
 
 /* Attachment Rendering in Messages */
-.copilotKitAttachment {
+:where(.copilotKitAttachment) {
   display: inline-flex;
   flex-direction: column;
   gap: 4px;
   max-width: 100%;
 }
 
-.copilotKitAttachmentAudio audio {
+:where(.copilotKitAttachmentAudio) audio {
   max-width: 300px;
   width: 100%;
   height: 40px;
 }
 
-.copilotKitAttachmentVideo video {
+:where(.copilotKitAttachmentVideo) video {
   max-width: 400px;
   width: 100%;
   border-radius: 8px;
 }
 
-.copilotKitAttachmentDocument {
+:where(.copilotKitAttachmentDocument) {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -192,7 +192,7 @@
   background: var(--copilot-kit-input-background-color);
 }
 
-.copilotKitAttachmentDocIcon {
+:where(.copilotKitAttachmentDocIcon) {
   width: 28px;
   height: 28px;
   border-radius: 6px;
@@ -206,14 +206,14 @@
   flex-shrink: 0;
 }
 
-.copilotKitAttachmentDocInfo {
+:where(.copilotKitAttachmentDocInfo) {
   display: flex;
   flex-direction: column;
   gap: 1px;
   min-width: 0;
 }
 
-.copilotKitAttachmentDocName {
+:where(.copilotKitAttachmentDocName) {
   font-size: 13px;
   font-weight: 500;
   overflow: hidden;
@@ -221,7 +221,7 @@
   white-space: nowrap;
 }
 
-.copilotKitAttachmentDocMeta {
+:where(.copilotKitAttachmentDocMeta) {
   font-size: 11px;
   color: var(--copilot-kit-secondary-contrast-color);
 }

--- a/packages/react-ui/src/css/button.css
+++ b/packages/react-ui/src/css/button.css
@@ -1,4 +1,4 @@
-.copilotKitButton {
+:where(.copilotKitButton) {
   width: 3.5rem;
   height: 3.5rem;
   display: flex;
@@ -16,17 +16,17 @@
   box-shadow: var(--copilot-kit-shadow-sm);
 }
 
-.copilotKitButton:hover {
+:where(.copilotKitButton):hover {
   transform: scale(1.05);
   box-shadow: var(--copilot-kit-shadow-md);
 }
 
-.copilotKitButton:active {
+:where(.copilotKitButton):active {
   transform: scale(0.95);
   box-shadow: var(--copilot-kit-shadow-sm);
 }
 
-.copilotKitButtonIcon {
+:where(.copilotKitButtonIcon) {
   transition:
     opacity 100ms,
     transform 300ms;
@@ -39,29 +39,29 @@
   justify-content: center;
 }
 
-.copilotKitButtonIcon svg {
+:where(.copilotKitButtonIcon) svg {
   width: 1.5rem;
   height: 1.5rem;
 }
 
 /* State when the chat is open */
-.copilotKitButton.open .copilotKitButtonIconOpen {
+:where(.copilotKitButton.open) :where(.copilotKitButtonIconOpen) {
   transform: translate(-50%, -50%) scale(0) rotate(90deg);
   opacity: 0;
 }
 
-.copilotKitButton.open .copilotKitButtonIconClose {
+:where(.copilotKitButton.open) :where(.copilotKitButtonIconClose) {
   transform: translate(-50%, -50%) scale(1) rotate(0deg);
   opacity: 1;
 }
 
 /* State when the chat is closed */
-.copilotKitButton:not(.open) .copilotKitButtonIconOpen {
+:where(.copilotKitButton):not(.open) :where(.copilotKitButtonIconOpen) {
   transform: translate(-50%, -50%) scale(1) rotate(0deg);
   opacity: 1;
 }
 
-.copilotKitButton:not(.open) .copilotKitButtonIconClose {
+:where(.copilotKitButton):not(.open) :where(.copilotKitButtonIconClose) {
   transform: translate(-50%, -50%) scale(0) rotate(-90deg);
   opacity: 0;
 }

--- a/packages/react-ui/src/css/console.css
+++ b/packages/react-ui/src/css/console.css
@@ -1,15 +1,15 @@
-.copilotKitDevConsole {
+:where(.copilotKitDevConsole) {
   display: flex;
   align-items: center;
   gap: 5px;
   margin: 0 15px;
 }
 
-.copilotKitDevConsole.copilotKitDevConsoleWarnOutdated {
+:where(.copilotKitDevConsole.copilotKitDevConsoleWarnOutdated) {
   background-color: var(--copilot-kit-dev-console-bg);
 }
 
-.copilotKitDevConsole .copilotKitVersionInfo {
+:where(.copilotKitDevConsole) :where(.copilotKitVersionInfo) {
   display: flex;
   position: absolute;
   bottom: -25px;
@@ -23,7 +23,7 @@
   background: #ebb305;
 }
 
-.copilotKitDevConsole .copilotKitVersionInfo button {
+:where(.copilotKitDevConsole) :where(.copilotKitVersionInfo) button {
   font-size: 11px;
   font-weight: normal;
   font-family: monospace;
@@ -40,19 +40,19 @@
   text-overflow: ellipsis;
 }
 
-.copilotKitDevConsole .copilotKitVersionInfo aside {
+:where(.copilotKitDevConsole) :where(.copilotKitVersionInfo) aside {
   display: inline;
   font-weight: normal;
   color: #7f7a7a;
   margin-left: 5px;
 }
 
-.copilotKitDevConsole .copilotKitVersionInfo svg {
+:where(.copilotKitDevConsole) :where(.copilotKitVersionInfo) svg {
   margin-left: 3px;
   margin-top: -3px;
 }
 
-.copilotKitDevConsole .copilotKitDebugMenuTriggerButton {
+:where(.copilotKitDevConsole) :where(.copilotKitDebugMenuTriggerButton) {
   font-size: 11px;
   font-weight: bold;
   display: flex;
@@ -66,7 +66,7 @@
   outline: none;
 }
 
-.copilotKitDebugMenuTriggerButton.compact {
+:where(.copilotKitDebugMenuTriggerButton.compact) {
   width: 35px;
   color: var(--copilot-kit-dev-console-bg);
   justify-content: center;
@@ -74,7 +74,7 @@
   font-size: 8px;
 }
 
-.copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover {
+:where(.copilotKitDevConsole) :where(.copilotKitDebugMenuTriggerButton):hover {
   background-color: color-mix(
     in srgb,
     var(--copilot-kit-dev-console-bg) 85%,
@@ -83,31 +83,31 @@
   color: var(--copilot-kit-dev-console-text);
 }
 
-.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
-html.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
-body.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
-[data-theme="dark"] .copilotKitDevConsole .copilotKitDebugMenuTriggerButton,
+.dark :where(.copilotKitDevConsole) :where(.copilotKitDebugMenuTriggerButton),
+html.dark :where(.copilotKitDevConsole) :where(.copilotKitDebugMenuTriggerButton),
+body.dark :where(.copilotKitDevConsole) :where(.copilotKitDebugMenuTriggerButton),
+[data-theme="dark"] :where(.copilotKitDevConsole) :where(.copilotKitDebugMenuTriggerButton),
 html[style*="color-scheme: dark"]
-  .copilotKitDevConsole
-  .copilotKitDebugMenuTriggerButton,
+  :where(.copilotKitDevConsole)
+  :where(.copilotKitDebugMenuTriggerButton),
 body[style*="color-scheme: dark"]
-  .copilotKitDevConsole
-  .copilotKitDebugMenuTriggerButton {
+  :where(.copilotKitDevConsole)
+  :where(.copilotKitDebugMenuTriggerButton) {
   color: white;
 }
 
-.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
-html.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
-body.dark .copilotKitDevConsole .copilotKitDebugMenuTriggerButton:hover,
+.dark :where(.copilotKitDevConsole) :where(.copilotKitDebugMenuTriggerButton):hover,
+html.dark :where(.copilotKitDevConsole) :where(.copilotKitDebugMenuTriggerButton):hover,
+body.dark :where(.copilotKitDevConsole) :where(.copilotKitDebugMenuTriggerButton):hover,
 [data-theme="dark"]
-  .copilotKitDevConsole
-  .copilotKitDebugMenuTriggerButton:hover,
+  :where(.copilotKitDevConsole)
+  :where(.copilotKitDebugMenuTriggerButton):hover,
 html[style*="color-scheme: dark"]
-  .copilotKitDevConsole
-  .copilotKitDebugMenuTriggerButton:hover,
+  :where(.copilotKitDevConsole)
+  :where(.copilotKitDebugMenuTriggerButton):hover,
 body[style*="color-scheme: dark"]
-  .copilotKitDevConsole
-  .copilotKitDebugMenuTriggerButton:hover {
+  :where(.copilotKitDevConsole)
+  :where(.copilotKitDebugMenuTriggerButton):hover {
   background-color: color-mix(
     in srgb,
     var(--copilot-kit-dev-console-bg) 20%,
@@ -115,11 +115,11 @@ body[style*="color-scheme: dark"]
   );
 }
 
-.copilotKitDevConsole .copilotKitDebugMenuTriggerButton > svg {
+:where(.copilotKitDevConsole) :where(.copilotKitDebugMenuTriggerButton) > svg {
   margin-left: 10px;
 }
 
-.copilotKitDebugMenu {
+:where(.copilotKitDebugMenu) {
   --copilot-kit-dev-console-border: color-mix(
     in srgb,
     var(--copilot-kit-dev-console-bg) 80%,
@@ -134,7 +134,7 @@ body[style*="color-scheme: dark"]
   font-size: 13px;
 }
 
-.copilotKitDebugMenuItem {
+:where(.copilotKitDebugMenuItem) {
   padding-top: 3px;
   padding-bottom: 3px;
   padding-left: 10px;
@@ -148,7 +148,7 @@ body[style*="color-scheme: dark"]
   color: var(--copilot-kit-dev-console-text);
 }
 
-.copilotKitDebugMenuItem:hover {
+:where(.copilotKitDebugMenuItem):hover {
   background-color: color-mix(
     in srgb,
     var(--copilot-kit-dev-console-bg) 95%,
@@ -157,24 +157,24 @@ body[style*="color-scheme: dark"]
   border-radius: 4px;
 }
 
-.copilotKitDebugMenu[data-closed] {
+:where(.copilotKitDebugMenu)[data-closed] {
   transform: scale(0.95); /* data-[closed]:scale-95 */
   opacity: 0; /* data-[closed]:opacity-0 */
 }
 
-.copilotKitDebugMenu hr {
+:where(.copilotKitDebugMenu) hr {
   height: 1px;
   border: none; /* Remove 3D look */
   background-color: var(--copilot-kit-dev-console-border);
   margin: 0.25rem;
 }
 
-.copilotKitHelpModal {
+:where(.copilotKitHelpModal) {
   background-color: var(--copilot-kit-dev-console-bg);
   color: var(--copilot-kit-dev-console-text);
 }
 
-.copilotKitHelpItemButton {
+:where(.copilotKitHelpItemButton) {
   display: block;
   text-align: center;
   width: 100%;
@@ -188,7 +188,7 @@ body[style*="color-scheme: dark"]
     0 2px 3px 0px rgba(0, 0, 0, 0.02);
   background-color: var(--copilot-kit-dev-console-bg);
 }
-.copilotKitHelpItemButton:hover {
+:where(.copilotKitHelpItemButton):hover {
   background-color: color-mix(
     in srgb,
     var(--copilot-kit-dev-console-bg) 95%,

--- a/packages/react-ui/src/css/header.css
+++ b/packages/react-ui/src/css/header.css
@@ -1,4 +1,4 @@
-.copilotKitHeader {
+:where(.copilotKitHeader) {
   height: 56px;
   font-weight: 500;
   display: flex;
@@ -14,21 +14,21 @@
   z-index: 2;
 }
 
-.copilotKitSidebar .copilotKitHeader {
+:where(.copilotKitSidebar) :where(.copilotKitHeader) {
   border-radius: 0;
 }
 
-.copilotKitHeaderControls {
+:where(.copilotKitHeaderControls) {
   display: flex;
 }
 
-.copilotKitHeaderCloseButton {
+:where(.copilotKitHeaderCloseButton) {
   background: none;
   border: none;
 }
 
 @media (min-width: 640px) {
-  .copilotKitHeader {
+  :where(.copilotKitHeader) {
     padding-left: 1.5rem;
     padding-right: 24px;
     border-top-left-radius: 8px;
@@ -36,7 +36,7 @@
   }
 }
 
-.copilotKitHeader > button {
+:where(.copilotKitHeader) > button {
   border: 0;
   padding: 8px;
   position: absolute;
@@ -56,10 +56,10 @@
   height: 35px;
 }
 
-.copilotKitHeader > button:hover {
+:where(.copilotKitHeader) > button:hover {
   color: color-mix(in srgb, var(--copilot-kit-muted-color) 80%, black);
 }
 
-.copilotKitHeader > button:focus {
+:where(.copilotKitHeader) > button:focus {
   outline: none;
 }

--- a/packages/react-ui/src/css/input.css
+++ b/packages/react-ui/src/css/input.css
@@ -1,4 +1,4 @@
-.copilotKitInput {
+:where(.copilotKitInput) {
   cursor: text;
   position: relative;
   background-color: var(--copilot-kit-input-background-color);
@@ -10,7 +10,7 @@
   width: 95%;
 }
 
-.copilotKitInputContainer {
+:where(.copilotKitInputContainer) {
   width: 100%;
   padding: 0;
   padding-bottom: 15px;
@@ -19,12 +19,12 @@
   border-bottom-right-radius: 0.75rem;
 }
 
-.copilotKitSidebar .copilotKitInputContainer {
+:where(.copilotKitSidebar) :where(.copilotKitInputContainer) {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
 
-.copilotKitInputControlButton {
+:where(.copilotKitInputControlButton) {
   padding: 0;
   cursor: pointer;
   transition-property: transform;
@@ -51,26 +51,26 @@
   height: 24px;
 }
 
-.copilotKitInputControlButton:not([disabled]) {
+:where(.copilotKitInputControlButton):not([disabled]) {
   color: var(--copilot-kit-primary-color);
 }
 
-.copilotKitInputControlButton:not([disabled]):hover {
+:where(.copilotKitInputControlButton):not([disabled]):hover {
   color: color-mix(in srgb, var(--copilot-kit-primary-color) 80%, black);
   transform: scale(1.05);
 }
 
-.copilotKitInputControlButton[disabled] {
+:where(.copilotKitInputControlButton)[disabled] {
   color: var(--copilot-kit-muted-color);
   cursor: default;
 }
 
-.copilotKitInputControls {
+:where(.copilotKitInputControls) {
   display: flex;
   gap: 3px;
 }
 
-.copilotKitInput > textarea {
+:where(.copilotKitInput) > textarea {
   flex: 1; /* Allow textarea to take up remaining space */
   outline: 2px solid transparent;
   outline-offset: 2px;
@@ -92,12 +92,12 @@
   width: 100%;
 }
 
-.copilotKitInput > textarea::placeholder {
+:where(.copilotKitInput) > textarea::placeholder {
   color: #808080;
   opacity: 1;
 }
 
-.copilotKitInputControlButton.copilotKitPushToTalkRecording {
+:where(.copilotKitInputControlButton.copilotKitPushToTalkRecording) {
   background-color: #ec0000;
   color: white;
   border-radius: 50%;
@@ -105,15 +105,15 @@
 }
 
 /* Scrollbar styles */
-.copilotKitInput textarea::-webkit-scrollbar {
+:where(.copilotKitInput) textarea::-webkit-scrollbar {
   width: 9px; /* Width of the entire scrollbar */
 }
 
-.copilotKitInput textarea::-webkit-scrollbar-track {
+:where(.copilotKitInput) textarea::-webkit-scrollbar-track {
   background: transparent; /* Color of the tracking area */
 }
 
-.copilotKitInput textarea::-webkit-scrollbar-thumb {
+:where(.copilotKitInput) textarea::-webkit-scrollbar-thumb {
   background-color: rgb(200 200 200); /* Color of the scroll thumb */
   border-radius: 10px; /* Roundness of the scroll thumb */
   border: 2px solid transparent; /* Creates padding around scroll thumb */
@@ -121,7 +121,7 @@
   cursor: pointer;
 }
 
-.copilotKitInput textarea::-webkit-scrollbar-thumb:hover {
+:where(.copilotKitInput) textarea::-webkit-scrollbar-thumb:hover {
   background-color: color-mix(
     in srgb,
     rgb(200 200 200) 80%,

--- a/packages/react-ui/src/css/markdown.css
+++ b/packages/react-ui/src/css/markdown.css
@@ -1,68 +1,68 @@
-h1.copilotKitMarkdownElement,
-h2.copilotKitMarkdownElement,
-h3.copilotKitMarkdownElement,
-h4.copilotKitMarkdownElement,
-h5.copilotKitMarkdownElement,
-h6.copilotKitMarkdownElement {
+h1:where(.copilotKitMarkdownElement),
+h2:where(.copilotKitMarkdownElement),
+h3:where(.copilotKitMarkdownElement),
+h4:where(.copilotKitMarkdownElement),
+h5:where(.copilotKitMarkdownElement),
+h6:where(.copilotKitMarkdownElement) {
   font-weight: bold;
   line-height: 1.2;
 }
 
-h1.copilotKitMarkdownElement:not(:last-child),
-h2.copilotKitMarkdownElement:not(:last-child),
-h3.copilotKitMarkdownElement:not(:last-child),
-h4.copilotKitMarkdownElement:not(:last-child),
-h5.copilotKitMarkdownElement:not(:last-child),
-h6.copilotKitMarkdownElement:not(:last-child) {
+h1:where(.copilotKitMarkdownElement):not(:last-child),
+h2:where(.copilotKitMarkdownElement):not(:last-child),
+h3:where(.copilotKitMarkdownElement):not(:last-child),
+h4:where(.copilotKitMarkdownElement):not(:last-child),
+h5:where(.copilotKitMarkdownElement):not(:last-child),
+h6:where(.copilotKitMarkdownElement):not(:last-child) {
   margin-bottom: 1rem;
 }
 
-h1.copilotKitMarkdownElement {
+h1:where(.copilotKitMarkdownElement) {
   font-size: 1.5em;
 }
 
-h2.copilotKitMarkdownElement {
+h2:where(.copilotKitMarkdownElement) {
   font-size: 1.25em;
   font-weight: 600;
 }
 
-h3.copilotKitMarkdownElement {
+h3:where(.copilotKitMarkdownElement) {
   font-size: 1.1em;
 }
 
-h4.copilotKitMarkdownElement {
+h4:where(.copilotKitMarkdownElement) {
   font-size: 1em;
 }
 
-h5.copilotKitMarkdownElement {
+h5:where(.copilotKitMarkdownElement) {
   font-size: 0.9em;
 }
 
-h6.copilotKitMarkdownElement {
+h6:where(.copilotKitMarkdownElement) {
   font-size: 0.8em;
 }
 
-a.copilotKitMarkdownElement {
+a:where(.copilotKitMarkdownElement) {
   color: blue;
   text-decoration: underline;
 }
 
-.copilotKitParagraph {
+:where(.copilotKitParagraph) {
   padding: 0px;
   margin: 0px;
   line-height: 1.75;
   font-size: 1rem;
 }
 
-.copilotKitParagraph:not(:last-child),
-pre.copilotKitMarkdownElement:not(:last-child),
-ol.copilotKitMarkdownElement:not(:last-child),
-ul.copilotKitMarkdownElement:not(:last-child),
-blockquote.copilotKitMarkdownElement:not(:last-child) {
+:where(.copilotKitParagraph):not(:last-child),
+pre:where(.copilotKitMarkdownElement):not(:last-child),
+ol:where(.copilotKitMarkdownElement):not(:last-child),
+ul:where(.copilotKitMarkdownElement):not(:last-child),
+blockquote:where(.copilotKitMarkdownElement):not(:last-child) {
   margin-bottom: 1.25em;
 }
 
-blockquote.copilotKitMarkdownElement {
+blockquote:where(.copilotKitMarkdownElement) {
   border-color: rgb(142, 142, 160);
   border-left-width: 2px;
   border-left-style: solid;
@@ -70,17 +70,17 @@ blockquote.copilotKitMarkdownElement {
   padding-left: 10px;
 }
 
-blockquote.copilotKitMarkdownElement .copilotKitParagraph {
+blockquote:where(.copilotKitMarkdownElement) :where(.copilotKitParagraph) {
   padding: 0.7em 0;
 }
 
-ul.copilotKitMarkdownElement {
+ul:where(.copilotKitMarkdownElement) {
   list-style-type: disc;
   padding-left: 20px;
   overflow: visible;
 }
 
-li.copilotKitMarkdownElement {
+li:where(.copilotKitMarkdownElement) {
   list-style-type: inherit;
   list-style-position: outside;
   margin-left: 0;
@@ -89,14 +89,14 @@ li.copilotKitMarkdownElement {
   overflow: visible;
 }
 
-.copilotKitCodeBlock {
+:where(.copilotKitCodeBlock) {
   position: relative;
   width: 100%;
   background-color: rgb(9 9 11);
   border-radius: 0.375rem;
 }
 
-.copilotKitCodeBlockToolbar {
+:where(.copilotKitCodeBlockToolbar) {
   display: flex;
   width: 100%;
   align-items: center;
@@ -111,20 +111,20 @@ li.copilotKitMarkdownElement {
   font-family: sans-serif;
 }
 
-.copilotKitCodeBlockToolbarLanguage {
+:where(.copilotKitCodeBlockToolbarLanguage) {
   font-size: 0.75rem;
   line-height: 1rem;
   text-transform: lowercase;
 }
 
-.copilotKitCodeBlockToolbarButtons {
+:where(.copilotKitCodeBlockToolbarButtons) {
   display: flex;
   align-items: center;
   margin-right: 0.25rem;
   margin-left: 0.25rem;
 }
 
-.copilotKitCodeBlockToolbarButton {
+:where(.copilotKitCodeBlockToolbarButton) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -137,11 +137,11 @@ li.copilotKitMarkdownElement {
   margin: 2px;
 }
 
-.copilotKitCodeBlockToolbarButton:hover {
+:where(.copilotKitCodeBlockToolbarButton):hover {
   background-color: rgb(55, 55, 58);
 }
 
-.copilotKitInlineCode {
+:where(.copilotKitInlineCode) {
   background-color: var(--copilot-kit-input-background-color);
   border: 1px solid var(--copilot-kit-separator-color);
   border-radius: 0.375rem;

--- a/packages/react-ui/src/css/messages.css
+++ b/packages/react-ui/src/css/messages.css
@@ -1,4 +1,4 @@
-.copilotKitMessages {
+:where(.copilotKitMessages) {
   overflow-y: scroll;
   flex: 1;
   display: flex;
@@ -9,13 +9,13 @@
   z-index: 1;
 }
 
-.copilotKitMessagesContainer {
+:where(.copilotKitMessagesContainer) {
   padding: 1rem 24px;
   display: flex;
   flex-direction: column;
 }
 
-.copilotKitMessagesFooter {
+:where(.copilotKitMessagesFooter) {
   display: flex;
   padding: 0.5rem 0.75rem;
   margin: 8px auto 0 auto;
@@ -25,25 +25,25 @@
   box-sizing: border-box;
 }
 
-.copilotKitMessages::-webkit-scrollbar {
+:where(.copilotKitMessages)::-webkit-scrollbar {
   width: 6px;
 }
 
-.copilotKitMessages::-webkit-scrollbar-thumb {
+:where(.copilotKitMessages)::-webkit-scrollbar-thumb {
   background-color: var(--copilot-kit-separator-color);
   border-radius: 10rem;
   border: 2px solid var(--copilot-kit-background-color);
 }
 
-.copilotKitMessages::-webkit-scrollbar-track-piece:start {
+:where(.copilotKitMessages)::-webkit-scrollbar-track-piece:start {
   background: transparent;
 }
 
-.copilotKitMessages::-webkit-scrollbar-track-piece:end {
+:where(.copilotKitMessages)::-webkit-scrollbar-track-piece:end {
   background: transparent;
 }
 
-.copilotKitMessage {
+:where(.copilotKitMessage) {
   border-radius: 15px;
   padding: 8px 12px;
   font-size: 1rem;
@@ -53,7 +53,7 @@
   margin-bottom: 0.5rem;
 }
 
-.copilotKitMessage.copilotKitUserMessage {
+:where(.copilotKitMessage.copilotKitUserMessage) {
   background: var(--copilot-kit-primary-color);
   color: var(--copilot-kit-contrast-color);
   margin-left: auto;
@@ -62,7 +62,7 @@
   font-size: 1rem;
 }
 
-.copilotKitMessage.copilotKitAssistantMessage {
+:where(.copilotKitMessage.copilotKitAssistantMessage) {
   background: transparent;
   margin-right: auto;
   padding-left: 0;
@@ -71,7 +71,7 @@
   color: var(--copilot-kit-secondary-contrast-color);
 }
 
-.copilotKitMessage.copilotKitAssistantMessage .copilotKitMessageControls {
+:where(.copilotKitMessage.copilotKitAssistantMessage) :where(.copilotKitMessageControls) {
   position: absolute;
   left: 0;
   display: flex;
@@ -81,22 +81,22 @@
   padding: 5px 0 0 0;
 }
 
-.copilotKitMessageControls.currentMessage {
+:where(.copilotKitMessageControls.currentMessage) {
   opacity: 1 !important;
 }
 
-.copilotKitMessage.copilotKitAssistantMessage:hover .copilotKitMessageControls {
+:where(.copilotKitMessage.copilotKitAssistantMessage):hover :where(.copilotKitMessageControls) {
   opacity: 1;
 }
 
 /* Always show controls on mobile */
 @media (max-width: 768px) {
-  .copilotKitMessage.copilotKitAssistantMessage .copilotKitMessageControls {
+  :where(.copilotKitMessage.copilotKitAssistantMessage) :where(.copilotKitMessageControls) {
     opacity: 1;
   }
 }
 
-.copilotKitMessageControlButton {
+:where(.copilotKitMessageControlButton) {
   width: 20px;
   height: 20px;
   display: flex;
@@ -113,22 +113,22 @@
   border: none;
 }
 
-.copilotKitMessageControlButton:hover {
+:where(.copilotKitMessageControlButton):hover {
   color: color-mix(in srgb, var(--copilot-kit-primary-color) 80%, black);
   transform: scale(1.05);
 }
 
-.copilotKitMessageControlButton:active {
+:where(.copilotKitMessageControlButton):active {
   color: color-mix(in srgb, var(--copilot-kit-primary-color) 80%, black);
   transform: scale(1.05);
 }
 
-.copilotKitMessageControlButton.active {
+:where(.copilotKitMessageControlButton.active) {
   background-color: var(--copilot-kit-primary-color);
   color: var(--copilot-kit-contrast-color);
 }
 
-.copilotKitMessageControlButton.active:hover {
+:where(.copilotKitMessageControlButton.active):hover {
   background-color: color-mix(
     in srgb,
     var(--copilot-kit-primary-color) 90%,
@@ -137,24 +137,24 @@
   color: var(--copilot-kit-contrast-color);
 }
 
-.copilotKitMessageControlButton svg {
+:where(.copilotKitMessageControlButton) svg {
   width: 1rem;
   height: 1rem;
   display: block;
   pointer-events: none;
 }
 
-.copilotKitMessage.copilotKitAssistantMessage
-  + .copilotKitMessage.copilotKitUserMessage {
+:where(.copilotKitMessage.copilotKitAssistantMessage)
+  + :where(.copilotKitMessage.copilotKitUserMessage) {
   margin-top: 1.5rem;
 }
 
-.copilotKitCustomAssistantMessage {
+:where(.copilotKitCustomAssistantMessage) {
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
 }
 
-.copilotKitMessage .inProgressLabel {
+:where(.copilotKitMessage) .inProgressLabel {
   margin-left: 10px;
   opacity: 0.7;
 }
@@ -168,7 +168,7 @@
   }
 }
 
-.copilotKitSpinner {
+:where(.copilotKitSpinner) {
   display: inline-block;
   width: 16px;
   height: 16px;
@@ -191,7 +191,7 @@
   }
 }
 
-.copilotKitActivityDot {
+:where(.copilotKitActivityDot) {
   display: inline-block;
   width: 6px;
   height: 6px;
@@ -201,13 +201,13 @@
 }
 
 /* Image Rendering Styles */
-.copilotKitImageRendering {
+:where(.copilotKitImageRendering) {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-.copilotKitImageRenderingImage {
+:where(.copilotKitImageRenderingImage) {
   max-width: 80px;
   max-height: 80px;
   width: auto;
@@ -219,7 +219,7 @@
   cursor: pointer;
 }
 
-.copilotKitImageRenderingContent {
+:where(.copilotKitImageRenderingContent) {
   margin-top: 8px;
   padding: 0 16px;
   font-size: 0.875rem;
@@ -228,7 +228,7 @@
 }
 
 /* Image Error State Styles */
-.copilotKitImageRenderingError {
+:where(.copilotKitImageRenderingError) {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -238,7 +238,7 @@
   background-color: var(--copilot-kit-input-background-color);
 }
 
-.copilotKitImageRenderingErrorMessage {
+:where(.copilotKitImageRenderingErrorMessage) {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -251,7 +251,7 @@
   font-weight: 500;
 }
 
-.copilotKitImageRenderingErrorMessage::before {
+:where(.copilotKitImageRenderingErrorMessage)::before {
   content: "⚠️";
   font-size: 1rem;
 }

--- a/packages/react-ui/src/css/panel.css
+++ b/packages/react-ui/src/css/panel.css
@@ -1,4 +1,4 @@
-.copilotKitChat {
+:where(.copilotKitChat) {
   z-index: 30;
   line-height: 1.5;
   -webkit-text-size-adjust: 100%;
@@ -29,11 +29,11 @@
   /* height: 100%; */
 }
 
-.copilotKitChat svg {
+:where(.copilotKitChat) svg {
   display: inline-block;
   vertical-align: middle;
 }
 
-.copilotKitChat .copilotKitMessages {
+:where(.copilotKitChat) :where(.copilotKitMessages) {
   flex-grow: 1;
 }

--- a/packages/react-ui/src/css/popup.css
+++ b/packages/react-ui/src/css/popup.css
@@ -1,4 +1,4 @@
-.copilotKitPopup {
+:where(.copilotKitPopup) {
   position: fixed;
   bottom: 1rem;
   right: 1rem;
@@ -28,7 +28,7 @@
   touch-action: manipulation;
 }
 
-.copilotKitPopup svg {
+:where(.copilotKitPopup) svg {
   display: inline-block;
   vertical-align: middle;
 }

--- a/packages/react-ui/src/css/sidebar.css
+++ b/packages/react-ui/src/css/sidebar.css
@@ -1,4 +1,4 @@
-.copilotKitSidebar {
+:where(.copilotKitSidebar) {
   position: fixed;
   bottom: 1rem;
   right: 1rem;
@@ -28,19 +28,19 @@
   touch-action: manipulation;
 }
 
-.copilotKitSidebar svg {
+:where(.copilotKitSidebar) svg {
   display: inline-block;
   vertical-align: middle;
 }
 
-.copilotKitSidebarContentWrapper {
+:where(.copilotKitSidebarContentWrapper) {
   overflow: visible;
   margin-right: 0px;
   transition: margin-right 0.3s ease;
 }
 
 @media (min-width: 640px) {
-  .copilotKitSidebarContentWrapper.sidebarExpanded {
+  :where(.copilotKitSidebarContentWrapper.sidebarExpanded) {
     margin-right: 28rem;
   }
 }

--- a/packages/react-ui/src/css/suggestions.css
+++ b/packages/react-ui/src/css/suggestions.css
@@ -1,16 +1,16 @@
-.copilotKitMessages footer .suggestions {
+:where(.copilotKitMessages) footer .suggestions {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
 }
 
-.copilotKitMessages footer h6 {
+:where(.copilotKitMessages) footer h6 {
   font-weight: 500;
   font-size: 0.7rem;
   margin-bottom: 8px;
 }
 
-.copilotKitMessages footer .suggestions .suggestion {
+:where(.copilotKitMessages) footer .suggestions .suggestion {
   padding: 6px 10px;
   font-size: 0.7rem;
   border-radius: 15px;
@@ -21,25 +21,25 @@
     0 2px 3px 0px rgba(0, 0, 0, 0.02);
 }
 
-.copilotKitMessages footer .suggestions .suggestion.loading {
+:where(.copilotKitMessages) footer .suggestions .suggestion.loading {
   padding: 0;
   font-size: 0.7rem;
   border: none;
   color: var(--copilot-kit-secondary-contrast-color);
 }
 
-.copilotKitMessages footer .suggestions button {
+:where(.copilotKitMessages) footer .suggestions button {
   transition: transform 0.3s ease;
 }
 
-.copilotKitMessages footer .suggestions button:not(:disabled):hover {
+:where(.copilotKitMessages) footer .suggestions button:not(:disabled):hover {
   transform: scale(1.03);
 }
 
-.copilotKitMessages footer .suggestions button:disabled {
+:where(.copilotKitMessages) footer .suggestions button:disabled {
   cursor: wait;
 }
 
-.copilotKitMessages footer .suggestions button svg {
+:where(.copilotKitMessages) footer .suggestions button svg {
   margin-right: 6px;
 }

--- a/packages/react-ui/src/css/window.css
+++ b/packages/react-ui/src/css/window.css
@@ -1,4 +1,4 @@
-.copilotKitWindow {
+:where(.copilotKitWindow) {
   position: fixed;
   inset: 0px;
   transform-origin: bottom;
@@ -16,23 +16,23 @@
   pointer-events: none;
 }
 
-.copilotKitSidebar .copilotKitWindow {
+:where(.copilotKitSidebar) :where(.copilotKitWindow) {
   border-radius: 0;
   opacity: 1;
   transform: translateX(100%);
 }
 
-.copilotKitWindow.open {
+:where(.copilotKitWindow.open) {
   opacity: 1;
   transform: scale(1) translateY(0);
   pointer-events: auto;
 }
 
-.copilotKitSidebar .copilotKitWindow.open {
+:where(.copilotKitSidebar) :where(.copilotKitWindow.open) {
   transform: translateX(0);
 }
 
-.copilotKitChatBody {
+:where(.copilotKitChatBody) {
   flex: 1 1 0%;
   display: flex;
   flex-direction: column;
@@ -40,7 +40,7 @@
 }
 
 @media (min-width: 640px) {
-  .copilotKitWindow {
+  :where(.copilotKitWindow) {
     transform-origin: bottom right;
     bottom: 5rem;
     right: 1rem;
@@ -54,7 +54,7 @@
     max-height: calc(100% - 6rem);
   }
 
-  .copilotKitSidebar .copilotKitWindow {
+  :where(.copilotKitSidebar) :where(.copilotKitWindow) {
     bottom: 0;
     right: 0;
     top: auto;


### PR DESCRIPTION
## What does this PR do?
Wraps CopilotKit namespace CSS selectors (`.copilotKit*`, `.cpk-*`) in the `:where()` pseudo-class, which has zero specificity. This allows users to override CopilotKit styles with their own selectors without needing `!important`. Previously, compound selectors like `.copilotKitButton .icon` (specificity 0,2,0) would win over a user's single-class selectors (0,1,0). With `:where()`, the specificity drops to the element/combinator level only. Fixes #263.

## Related PRs and Issues
- Closes #263

## Checklist
- [x] I have read the Contribution Guide
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked