### PR TITLE
feat(bot-slack): native streaming + pending feedback in channels

### DIFF
--- a/packages/bot-slack/src/__tests__/event-renderer.test.ts
+++ b/packages/bot-slack/src/__tests__/event-renderer.test.ts
@@ -519,3 +519,87 @@ describe("createRunRenderer — assistant pane status mode", () => {
     expect(f.statuses.at(-1)?.status).toBe("");
   });
 });
+
+describe("createRunRenderer — native streaming in a channel (no status)", () => {
+  // A non-pane thread (e.g. a channel mention) with native streaming: Slack
+  // has no composer-status surface here, so the renderer posts NO "thinking…"
+  // placeholder and NO `:wrench:` tool rows — the native stream is the only
+  // surface. Tool calls are still captured for the run-loop.
+  function makeNativeTransport() {
+    let counter = 0;
+    const appended: string[] = [];
+    const transport = {
+      startStream: vi.fn(async () => {
+        counter++;
+        return `ns${counter}`;
+      }),
+      appendStream: vi.fn(async (_ts: string, md: string) => {
+        appended.push(md);
+      }),
+      stopStream: vi.fn(async (_ts: string) => {}),
+    };
+    return { transport, appended };
+  }
+
+  it("posts no placeholder on run start", async () => {
+    const f = makeFakeClient();
+    const nt = makeNativeTransport();
+    const { subscriber: sub } = createRunRenderer({
+      client: f.client,
+      target: { channel: "C1", threadTs: "100.0" },
+      nativeStreaming: { transport: nt.transport },
+    });
+    await sub.onRunStartedEvent!({} as never);
+    expect(f.posts).toHaveLength(0);
+  });
+
+  it("posts no :wrench: rows for tool calls, but still captures them", async () => {
+    const f = makeFakeClient();
+    const nt = makeNativeTransport();
+    const { subscriber: sub, getCapturedToolCalls } = createRunRenderer({
+      client: f.client,
+      target: { channel: "C1", threadTs: "100.0" },
+      nativeStreaming: { transport: nt.transport },
+    });
+    await sub.onToolCallStartEvent!({
+      event: { toolCallId: "t1", toolCallName: "search" },
+    } as never);
+    await sub.onToolCallEndEvent!({
+      event: { toolCallId: "t1" },
+      toolCallName: "search",
+      toolCallArgs: { q: "x" },
+    } as never);
+    // No placeholder, no `:wrench:`/checkmark rows.
+    expect(f.posts).toHaveLength(0);
+    expect(f.updates).toHaveLength(0);
+    // The run-loop still sees the tool call.
+    expect(getCapturedToolCalls()).toEqual([
+      { toolCallId: "t1", toolCallName: "search", toolCallArgs: { q: "x" } },
+    ]);
+  });
+
+  it("streams the reply via the native transport, not chat.update", async () => {
+    const f = makeFakeClient();
+    const nt = makeNativeTransport();
+    const { subscriber: sub } = createRunRenderer({
+      client: f.client,
+      target: { channel: "C1", threadTs: "100.0" },
+      nativeStreaming: { transport: nt.transport },
+    });
+    await sub.onRunStartedEvent!({} as never);
+    await sub.onTextMessageStartEvent!({
+      event: { messageId: "m", role: "assistant" },
+    } as never);
+    sub.onTextMessageContentEvent!({
+      event: { messageId: "m", delta: "hello" },
+      textMessageBuffer: "",
+    } as never);
+    await sub.onTextMessageEndEvent!({ event: { messageId: "m" } } as never);
+    expect(nt.transport.startStream).toHaveBeenCalledTimes(1);
+    expect(nt.transport.stopStream).toHaveBeenCalledTimes(1);
+    expect(nt.appended.join("")).toContain("hello");
+    // Legacy posting path is never touched.
+    expect(f.posts).toHaveLength(0);
+    expect(f.updates).toHaveLength(0);
+  });
+});

--- a/packages/bot-slack/src/__tests__/event-renderer.test.ts
+++ b/packages/bot-slack/src/__tests__/event-renderer.test.ts
@@ -523,8 +523,10 @@ describe("createRunRenderer — assistant pane status mode", () => {
 describe("createRunRenderer — native streaming in a channel (no status)", () => {
   // A non-pane thread (e.g. a channel mention) with native streaming: Slack
   // has no composer-status surface here, so the renderer posts NO "thinking…"
-  // placeholder and NO `:wrench:` tool rows — the native stream is the only
-  // surface. Tool calls are still captured for the run-loop.
+  // placeholder and NO `:wrench:` tool rows. Instead it opens the native stream
+  // eagerly at run start (pending feedback before the first token) and the
+  // reply continues on that bubble. Tool calls are still captured for the
+  // run-loop.
   function makeNativeTransport() {
     let counter = 0;
     const appended: string[] = [];
@@ -537,11 +539,12 @@ describe("createRunRenderer — native streaming in a channel (no status)", () =
         appended.push(md);
       }),
       stopStream: vi.fn(async (_ts: string) => {}),
+      discardStream: vi.fn(async (_ts: string) => {}),
     };
     return { transport, appended };
   }
 
-  it("posts no placeholder on run start", async () => {
+  it("opens the stream eagerly on run start (no legacy placeholder)", async () => {
     const f = makeFakeClient();
     const nt = makeNativeTransport();
     const { subscriber: sub } = createRunRenderer({
@@ -550,7 +553,26 @@ describe("createRunRenderer — native streaming in a channel (no status)", () =
       nativeStreaming: { transport: nt.transport },
     });
     await sub.onRunStartedEvent!({} as never);
+    // Native bubble is opened immediately — the "pending feedback" surface —
+    // but nothing is appended yet and no legacy `:hourglass:` message is posted.
+    expect(nt.transport.startStream).toHaveBeenCalledTimes(1);
+    expect(nt.transport.appendStream).not.toHaveBeenCalled();
     expect(f.posts).toHaveLength(0);
+  });
+
+  it("discards the empty bubble when the run produces no text", async () => {
+    const f = makeFakeClient();
+    const nt = makeNativeTransport();
+    const { subscriber: sub } = createRunRenderer({
+      client: f.client,
+      target: { channel: "C1", threadTs: "100.0" },
+      nativeStreaming: { transport: nt.transport },
+    });
+    await sub.onRunStartedEvent!({} as never);
+    await sub.onRunFinishedEvent!({} as never);
+    // The eagerly-opened bubble got no content → it is deleted, not finalized.
+    expect(nt.transport.discardStream).toHaveBeenCalledTimes(1);
+    expect(nt.transport.stopStream).not.toHaveBeenCalled();
   });
 
   it("posts no :wrench: rows for tool calls, but still captures them", async () => {
@@ -578,7 +600,7 @@ describe("createRunRenderer — native streaming in a channel (no status)", () =
     ]);
   });
 
-  it("streams the reply via the native transport, not chat.update", async () => {
+  it("adopts the eager stream for the reply (no second startStream, no chat.update)", async () => {
     const f = makeFakeClient();
     const nt = makeNativeTransport();
     const { subscriber: sub } = createRunRenderer({
@@ -595,8 +617,11 @@ describe("createRunRenderer — native streaming in a channel (no status)", () =
       textMessageBuffer: "",
     } as never);
     await sub.onTextMessageEndEvent!({ event: { messageId: "m" } } as never);
+    // The reply continues on the eagerly-opened bubble — the stream is started
+    // exactly once and finalized (not discarded, since it has content).
     expect(nt.transport.startStream).toHaveBeenCalledTimes(1);
     expect(nt.transport.stopStream).toHaveBeenCalledTimes(1);
+    expect(nt.transport.discardStream).not.toHaveBeenCalled();
     expect(nt.appended.join("")).toContain("hello");
     // Legacy posting path is never touched.
     expect(f.posts).toHaveLength(0);

--- a/packages/bot-slack/src/__tests__/native-stream.test.ts
+++ b/packages/bot-slack/src/__tests__/native-stream.test.ts
@@ -11,7 +11,12 @@ function makeFakeTransport(opts?: {
   failStart?: boolean;
   failStartAfter?: number;
 }) {
-  const messages: { ts: string; appends: string[]; stopped: boolean }[] = [];
+  const messages: {
+    ts: string;
+    appends: string[];
+    stopped: boolean;
+    discarded: boolean;
+  }[] = [];
   let counter = 0;
   const transport: NativeStreamTransport = {
     startStream: vi.fn(async () => {
@@ -26,7 +31,7 @@ function makeFakeTransport(opts?: {
       }
       counter++;
       const ts = `S${counter}`;
-      messages.push({ ts, appends: [], stopped: false });
+      messages.push({ ts, appends: [], stopped: false, discarded: false });
       return ts;
     }),
     appendStream: vi.fn(async (ts: string, md: string) => {
@@ -35,6 +40,10 @@ function makeFakeTransport(opts?: {
     stopStream: vi.fn(async (ts: string) => {
       const m = messages.find((x) => x.ts === ts);
       if (m) m.stopped = true;
+    }),
+    discardStream: vi.fn(async (ts: string) => {
+      const m = messages.find((x) => x.ts === ts);
+      if (m) m.discarded = true;
     }),
   };
   return { transport, messages };
@@ -93,6 +102,82 @@ describe("NativeMessageStream", () => {
     await stream.finish();
     expect(transport.startStream).not.toHaveBeenCalled();
     expect(messages).toHaveLength(0);
+  });
+
+  it("prime() opens the stream eagerly; a later append reuses it (one start)", async () => {
+    const { transport, messages } = makeFakeTransport();
+    const stream = new NativeMessageStream({
+      transport,
+      fallback: makeFakeFallback,
+      minIntervalMs: 0,
+    });
+
+    await stream.prime();
+    expect(transport.startStream).toHaveBeenCalledTimes(1);
+    expect(transport.appendStream).not.toHaveBeenCalled();
+    expect(stream.firstTs).toBe("S1");
+
+    stream.append("hello");
+    await stream.finish();
+
+    // Still exactly one stream — the eager bubble was reused, not reopened.
+    expect(transport.startStream).toHaveBeenCalledTimes(1);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.appends.join("")).toBe("hello");
+    expect(messages[0]!.stopped).toBe(true);
+    expect(messages[0]!.discarded).toBe(false);
+  });
+
+  it("prime() then finish() with no content discards the empty bubble", async () => {
+    const { transport, messages } = makeFakeTransport();
+    const stream = new NativeMessageStream({
+      transport,
+      fallback: makeFakeFallback,
+      minIntervalMs: 0,
+    });
+
+    await stream.prime();
+    await stream.finish();
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.discarded).toBe(true);
+    expect(messages[0]!.stopped).toBe(false);
+  });
+
+  it("prime() falls back to stopStream for an empty bubble when discardStream is absent", async () => {
+    const { transport, messages } = makeFakeTransport();
+    // Strip discardStream — older/partial transports may not implement it.
+    delete (transport as { discardStream?: unknown }).discardStream;
+    const stream = new NativeMessageStream({
+      transport,
+      fallback: makeFakeFallback,
+      minIntervalMs: 0,
+    });
+
+    await stream.prime();
+    await stream.finish();
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.stopped).toBe(true);
+  });
+
+  it("prime() failover to legacy never throws", async () => {
+    const { transport } = makeFakeTransport({ failStart: true });
+    const fallback = makeFakeFallback();
+    const stream = new NativeMessageStream({
+      transport,
+      fallback: () => fallback,
+      minIntervalMs: 0,
+    });
+
+    // Priming a workspace where startStream is unavailable must not throw.
+    await expect(stream.prime()).resolves.toBeUndefined();
+
+    // Subsequent content flows through the legacy fallback.
+    stream.append("via legacy");
+    await stream.finish();
+    expect(fallback.last()).toBe("via legacy");
+    expect(fallback.finished).toBe(true);
   });
 
   it("opens a continuation message when the budget is exceeded", async () => {

--- a/packages/bot-slack/src/adapter.ts
+++ b/packages/bot-slack/src/adapter.ts
@@ -365,6 +365,11 @@ export class SlackAdapter implements PlatformAdapter {
           ts,
         } as unknown as Parameters<WebClient["chat"]["stopStream"]>[0]);
       },
+      // Remove an eagerly-opened streaming bubble that never received content
+      // (a run that produced no text reply) so no empty message is left behind.
+      discardStream: async (ts) => {
+        await this.client.chat.delete({ channel: t.channel, ts });
+      },
     };
   }
 

--- a/packages/bot-slack/src/event-renderer.ts
+++ b/packages/bot-slack/src/event-renderer.ts
@@ -262,7 +262,7 @@ export function createRunRenderer(args: {
     });
 
   // Native chat.startStream transport — raw markdown, no mrkdwn translation.
-  const makeNativeStream = (): TextStream => {
+  const makeNativeStream = (): NativeMessageStream => {
     const ns = args.nativeStreaming!;
     return new NativeMessageStream({
       transport: {
@@ -276,17 +276,44 @@ export function createRunRenderer(args: {
         },
         appendStream: (ts, md) => ns.transport.appendStream(ts, md),
         stopStream: (ts) => ns.transport.stopStream(ts),
+        // Forwarded so an eagerly-primed bubble that never gets content is
+        // deleted rather than finalized as an empty message.
+        ...(ns.transport.discardStream
+          ? { discardStream: (ts: string) => ns.transport.discardStream!(ts) }
+          : {}),
       },
       fallback: makeLegacyStream,
       onStartFailure: ns.onStartFailure,
     });
   };
 
+  // Native channel streaming: the stream opened eagerly at RUN_STARTED, held
+  // here until the first text message adopts it (or RUN_FINISHED discards it).
+  let eagerStream: NativeMessageStream | undefined;
+  // Finalize an un-adopted eager bubble: with no content, finish() deletes the
+  // empty streaming message rather than leaving it open. No-op when there's
+  // none (the common case — a text reply adopted it via ensureStream).
+  const discardEagerStream = async (): Promise<void> => {
+    if (!eagerStream) return;
+    const orphan = eagerStream;
+    eagerStream = undefined;
+    await orphan.finish();
+  };
+
   const ensureStream = (messageId: string): TextStream | undefined => {
     if (finalised.has(messageId)) return undefined;
     let s = streams.get(messageId);
     if (!s) {
-      s = args.nativeStreaming ? makeNativeStream() : makeLegacyStream();
+      // Adopt the eagerly-primed channel stream (opened at RUN_STARTED so Slack
+      // shows its streaming bubble before the first token) for the first text
+      // message, so content continues on the already-open placeholder — no
+      // second `startStream`. Subsequent messages get fresh streams.
+      if (eagerStream) {
+        s = eagerStream;
+        eagerStream = undefined;
+      } else {
+        s = args.nativeStreaming ? makeNativeStream() : makeLegacyStream();
+      }
       streams.set(messageId, s);
     }
     return s;
@@ -314,8 +341,18 @@ export function createRunRenderer(args: {
         // Native status under the composer instead of a placeholder message.
         await setPaneStatus(paneStatus?.thinking || DEFAULT_THINKING_STATUS);
       } else if (nativeNoStatus) {
-        // Native streaming in a channel: no placeholder; the native stream
-        // (and its built-in streaming indicator) is the only surface.
+        // Native streaming in a channel: open the stream eagerly so Slack
+        // renders its streaming bubble immediately — the "pending feedback"
+        // the user sees while the agent reasons / calls tools before the first
+        // token. The first text message adopts this stream (see ensureStream);
+        // a run with no text discards the empty bubble on finish. Priming never
+        // throws (a startStream failure falls over to legacy internally).
+        // Defensive: if a prior iteration's bubble is somehow still un-adopted
+        // (RUN_STARTED without an intervening RUN_FINISHED), discard it first so
+        // we never leak an open, never-stopped stream.
+        await discardEagerStream();
+        eagerStream = makeNativeStream();
+        await eagerStream.prime();
       } else {
         await startThinking();
       }
@@ -325,6 +362,9 @@ export function createRunRenderer(args: {
       // placeholder; otherwise (tool/component/HITL output, or nothing)
       // this removes the leftover "thinking…" bubble.
       await clearThinking();
+      // Native channel mode: if no text message adopted the eagerly-primed
+      // stream, the run produced no reply — discard the empty streaming bubble.
+      await discardEagerStream();
       // In a pane thread, a posted reply auto-clears Slack's status; clear it
       // explicitly when the run produced no visible reply.
       if (paneMode && !postedReply) await clearPaneStatus();
@@ -482,6 +522,9 @@ export function createRunRenderer(args: {
       // the next turn) is the user-visible signal now.
       await clearThinking();
       if (paneMode) await clearPaneStatus();
+      // Native channel mode: an eagerly-primed stream that never got text is an
+      // empty bubble — discard it (the next turn / marker is the signal now).
+      await discardEagerStream();
       // For each in-flight text-message stream, append the interrupted
       // marker and drain. Streams that have no content yet are silently
       // dropped (the bot never posted anything for them).

--- a/packages/bot-slack/src/event-renderer.ts
+++ b/packages/bot-slack/src/event-renderer.ts
@@ -88,6 +88,12 @@ export function createRunRenderer(args: {
   const paneStatus = args.assistantStatus;
   const paneMode = paneStatus !== undefined && target.threadTs !== undefined;
   const paneToolStatus = paneStatus?.toolStatus ?? true;
+  // Native streaming outside the pane (e.g. a channel thread): the reply renders
+  // with Slack's native streaming UI, and Slack has no composer-status surface
+  // here, so we skip the legacy "thinking…" placeholder and `:wrench:` tool rows
+  // entirely and let the native stream speak for itself. (paneMode still wins
+  // when present.)
+  const nativeNoStatus = args.nativeStreaming !== undefined && !paneMode;
 
   const setPaneStatus = async (status: string): Promise<void> => {
     if (!paneMode || !target.threadTs) return;
@@ -307,6 +313,9 @@ export function createRunRenderer(args: {
       if (paneMode) {
         // Native status under the composer instead of a placeholder message.
         await setPaneStatus(paneStatus?.thinking || DEFAULT_THINKING_STATUS);
+      } else if (nativeNoStatus) {
+        // Native streaming in a channel: no placeholder; the native stream
+        // (and its built-in streaming indicator) is the only surface.
       } else {
         await startThinking();
       }
@@ -356,6 +365,9 @@ export function createRunRenderer(args: {
         }
         return;
       }
+      // Native streaming (channel): no `:wrench:` rows — the native stream is
+      // the only surface. Tool calls are still captured below for the run-loop.
+      if (nativeNoStatus) return;
       // Dedup by toolCallId so a tool that re-emits START on resume can't
       // post a second status row.
       if (!showToolStatus) return;
@@ -396,6 +408,8 @@ export function createRunRenderer(args: {
       );
       // Pane threads use live status (set on START); no per-call rows to edit.
       if (paneMode) return;
+      // Native streaming (channel): no rows were posted, nothing to update.
+      if (nativeNoStatus) return;
       if (!showToolStatus) return;
       const ts = toolStatusTs.get(event.toolCallId);
       if (!ts) return;

--- a/packages/bot-slack/src/native-stream.ts
+++ b/packages/bot-slack/src/native-stream.ts
@@ -52,6 +52,12 @@ export interface NativeStreamTransport {
   appendStream(ts: string, markdownText: string): Promise<void>;
   /** `chat.stopStream` — finalize the streamed message at `ts`. */
   stopStream(ts: string): Promise<void>;
+  /**
+   * `chat.delete` — remove a streamed message that was opened eagerly (via
+   * {@link NativeMessageStream.prime}) but never received any content. Optional:
+   * when absent, an empty stream is finalized with `stopStream` instead.
+   */
+  discardStream?(ts: string): Promise<void>;
 }
 
 export interface NativeMessageStreamConfig {
@@ -114,6 +120,24 @@ export class NativeMessageStream implements TextStream {
     return this.firstTsValue;
   }
 
+  /**
+   * Eagerly open the stream before any content, so Slack renders its native
+   * streaming bubble immediately (the "pending feedback" a user sees while the
+   * agent reasons / calls tools before the first token). Idempotent — a no-op
+   * once a message is open or we've failed over to legacy. A `startStream`
+   * failure falls over to legacy exactly like a lazy first flush; the empty
+   * buffer means nothing is posted until real content arrives.
+   */
+  async prime(): Promise<void> {
+    if (this.legacy || this.curTs) return;
+    try {
+      this.curTs = await this.transport.startStream();
+      this.firstTsValue = this.curTs;
+    } catch (err) {
+      this.failOverToLegacy(err, "first");
+    }
+  }
+
   append(fullText: string): void {
     if (this.legacy) {
       this.legacy.append(fullText);
@@ -138,6 +162,17 @@ export class NativeMessageStream implements TextStream {
     }
     // Finalize the streamed message (no-op if we never started one).
     if (this.curTs) {
+      // An eagerly-primed stream that never received content leaves an empty
+      // bubble — discard it (delete) rather than finalize an empty message.
+      // `buffer.length > 0` ⇔ real content arrived (buffer is the full reply).
+      if (this.buffer.length === 0 && this.transport.discardStream) {
+        try {
+          await this.transport.discardStream(this.curTs);
+        } catch (err) {
+          console.error("[native-stream] discardStream failed:", err);
+        }
+        return;
+      }
       try {
         await this.transport.stopStream(this.curTs);
       } catch (err) {


### PR DESCRIPTION
## What

Make the native Slack experience work **everywhere**, not just inside the assistant pane — and show **pending feedback before the first token** in channels, the way Linear's Slack bot does.

When a thread uses native streaming but isn't a pane thread (e.g. the bot is mentioned in a regular channel):
- the legacy `:hourglass: thinking…` placeholder and `:wrench: Calling …` tool rows are gone, **and**
- the native streaming bubble is **opened eagerly at run start** (`chat.startStream`), so Slack renders its streaming indicator immediately — that's the "pending feedback" the user sees while the agent reasons / calls tools before the first token. The reply then continues in that same bubble.

## Why

`assistant.threads.setStatus` (the "is thinking…" composer indicator) is **assistant-pane-only** per Slack's API — there's no equivalent surface in a channel. But `chat.startStream` "creates a placeholder message that updates in real-time" and works in channels with `recipient_user_id` + `recipient_team_id` (both already wired). Opening it eagerly is the native way to show progress in a channel without reintroducing legacy chrome.

## Behavior

In a **channel with native streaming** (this PR): run start opens `chat.startStream` so the streaming bubble appears immediately; the bubble keeps showing through tool calls; the reply adopts that same bubble. **Pane** mode (unchanged) uses `setStatus`. **Legacy / flat DM** (unchanged) uses the `:hourglass:` placeholder + `:wrench:` rows + `chat.update`.

`captureToolCall` still runs in all modes, so the run-loop's tool dispatch is unaffected. Pane mode still wins when both could apply. A run that produces **no** text reply discards the empty eagerly-opened bubble (`chat.delete`) so nothing is left behind. Priming and discarding are degrade-never-throw (a `startStream` failure falls over to the legacy transport).

## Changes

- `packages/bot-slack/src/native-stream.ts` — `NativeMessageStream.prime()` (idempotent eager open, fails over to legacy on error); optional `NativeStreamTransport.discardStream`; `finish()` deletes an empty primed bubble instead of finalizing an empty message.
- `packages/bot-slack/src/event-renderer.ts` — `nativeNoStatus` channel mode: prime an `eagerStream` on `RUN_STARTED`, adopt it for the first text message (no second `startStream`), discard it on `RUN_FINISHED` / `markInterrupted` (and defensively before re-priming) when no reply arrived.
- `packages/bot-slack/src/adapter.ts` — `nativeTransport` provides `discardStream` via `chat.delete`.
- Tests — `native-stream.test.ts` (prime/adopt/discard/failover) and `event-renderer.test.ts` (eager open, reply adopts the bubble, empty run discards it, no legacy chrome, tool calls still captured).

## Verification

- `nx run @copilotkit/bot-slack:test` — 207 passed.
- `nx run @copilotkit/bot-slack:build` — clean.
- Code review (pr-review-toolkit) — no material issues.

**E2E (user-owned):** mention the bot in a regular channel → the native streaming bubble appears immediately (before the first token), then fills in; no `:hourglass:`/`:wrench:` rows. A run that produces no text → no leftover empty bubble. Pane behavior unchanged. *If the empty bubble renders blank rather than a visible loading affordance, the one-line follow-up is to seed `prime()` with an initial `markdown_text` status.*

## Follow-up (release)

Needs a `@copilotkit/bot-slack@0.0.3` publish + `examples/slack` bump + Railway redeploy to reach the deployed bot. `0.0.3` should also fix bot-slack pinning `@copilotkit/bot@0.0.1` exactly → `~0.0.2`.
