### PR TITLE
fix(examples): bump langgraph-js agent @langchain/core to 1.1.49 (v6 uuid export)

### DIFF
--- a/examples/integrations/langgraph-js/agent/package.json
+++ b/examples/integrations/langgraph-js/agent/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@copilotkit/sdk-js": "1.60.0",
-    "@langchain/core": "1.1.44",
+    "@langchain/core": "1.1.49",
     "@langchain/langgraph": "1.3.0",
     "@langchain/openai": "1.4.4",
     "langchain": "1.3.4"


### PR DESCRIPTION
## Summary

The `smoke-starter (langgraph-js)` CI job is failing on `main` (and on every open PR, e.g. #5457). The agent container crashes on startup:

```
SyntaxError: The requested module '@langchain/core/utils/uuid' does not provide an export named 'v6'
```

## Root cause

- `examples/integrations/langgraph-js/docker/Dockerfile.agent` copies only `package.json` (not the lockfile) and runs `npm install`, so transitive deps resolve fresh at build time.
- `@langchain/langgraph@1.3.0` → `@langchain/langgraph-checkpoint@^1.0.2`.
- Checkpoint `1.1.1` (published 2026-06-12) started importing `v6` and raised its peer to `@langchain/core@^1.1.48`.
- The agent pinned `@langchain/core@1.1.44`, which predates the `v6` export → import crash.

Verified that `@langchain/core@1.1.44` does not export `v6` from `utils/uuid` while `1.1.49` does, and a clean `npm install` with core `1.1.49` dedupes to checkpoint `1.1.1` + core `1.1.49` and imports `v6` successfully.

## Change

Bump `@langchain/core` `1.1.44` → `1.1.49` in the langgraph-js agent. The npm `package-lock.json` is intentionally left untouched — no CI job consumes it (the Docker agent build runs `npm install` against `package.json`, per the Dockerfile's own "Mirrors the user experience" comment).

## Test plan

- [ ] `smoke-starter (langgraph-js)` passes on this PR