### PR TITLE
feat(runtime): add DockerModelRunnerAdapter for local LLM via Docker Model Runner

### DIFF
--- a/packages/runtime/src/service-adapters/docker/docker-model-runner-adapter.ts
+++ b/packages/runtime/src/service-adapters/docker/docker-model-runner-adapter.ts
@@ -1,0 +1,71 @@
+/**
+ * Copilot Runtime adapter for Docker Model Runner.
+ *
+ * Docker Model Runner exposes an OpenAI-compatible API for locally running
+ * AI models via Docker Desktop. See https://docs.docker.com/ai/model-runner/
+ *
+ * ## Example
+ *
+ * ```ts
+ * import { CopilotRuntime, DockerModelRunnerAdapter } from "@copilotkit/runtime";
+ *
+ * const copilotKit = new CopilotRuntime();
+ *
+ * return new DockerModelRunnerAdapter({ model: "ai/llama3.2" });
+ * ```
+ *
+ * ## Example with custom base URL
+ *
+ * ```ts
+ * import { CopilotRuntime, DockerModelRunnerAdapter } from "@copilotkit/runtime";
+ *
+ * const copilotKit = new CopilotRuntime();
+ *
+ * return new DockerModelRunnerAdapter({
+ *   model: "ai/mistral",
+ *   baseUrl: "http://model-runner.docker.internal/engines/llama.cpp/v1",
+ * });
+ * ```
+ */
+import Openai from "openai";
+import { OpenAIAdapter } from "../openai/openai-adapter";
+import type { OpenAIAdapterParams } from "../openai/openai-adapter";
+
+const DEFAULT_BASE_URL = "http://localhost:12434/engines/llama.cpp/v1";
+const DEFAULT_MODEL = "ai/llama3.2";
+
+export interface DockerModelRunnerAdapterParams extends Omit<
+  OpenAIAdapterParams,
+  "openai"
+> {
+  /**
+   * The base URL of the Docker Model Runner API endpoint.
+   * Defaults to `http://localhost:12434/engines/llama.cpp/v1`.
+   * Can also be set via the `DOCKER_MODEL_RUNNER_BASE_URL` environment variable.
+   */
+  baseUrl?: string;
+}
+
+export class DockerModelRunnerAdapter extends OpenAIAdapter {
+  public override get name() {
+    return "DockerModelRunnerAdapter";
+  }
+
+  constructor(params?: DockerModelRunnerAdapterParams) {
+    const baseUrl =
+      params?.baseUrl ??
+      process.env["DOCKER_MODEL_RUNNER_BASE_URL"] ??
+      DEFAULT_BASE_URL;
+
+    const openai = new Openai({
+      baseURL: baseUrl,
+      apiKey: "docker",
+    });
+
+    super({
+      ...params,
+      openai,
+      model: params?.model ?? DEFAULT_MODEL,
+    });
+  }
+}

--- a/packages/runtime/src/service-adapters/index.ts
+++ b/packages/runtime/src/service-adapters/index.ts
@@ -16,3 +16,4 @@ export * from "./anthropic/anthropic-adapter";
 export * from "./experimental/ollama/ollama-adapter";
 export * from "./bedrock/bedrock-adapter";
 export * from "./empty/empty-adapter";
+export * from "./docker/docker-model-runner-adapter";


### PR DESCRIPTION
## Summary

Adds `DockerModelRunnerAdapter` -- a new service adapter that connects CopilotKit to [Docker Model Runner](https://docs.docker.com/ai/model-runner/), which provides an OpenAI-compatible API for running AI models locally via Docker Desktop.

Because Docker Model Runner is OpenAI-compatible, the adapter composes with `OpenAIAdapter` and only overrides the base URL and default model -- no streaming or tool-call logic is duplicated.

**Before:** users had to manually construct an `OpenAIAdapter` with a custom `baseURL` and figure out the right endpoint.

**After:**

```ts
import { CopilotRuntime, DockerModelRunnerAdapter } from @copilotkit/runtime;

const copilotKit = new CopilotRuntime();
return new DockerModelRunnerAdapter({ model: ai/llama3.2 });
```

Custom base URL (e.g. from inside a Docker container):

```ts
return new DockerModelRunnerAdapter({
  model: ai/mistral,
  baseUrl: http://model-runner.docker.internal/engines/llama.cpp/v1,
});
```

The endpoint can also be set via the `DOCKER_MODEL_RUNNER_BASE_URL` environment variable.

## Changes

- `packages/runtime/src/service-adapters/docker/docker-model-runner-adapter.ts` - new adapter
- `packages/runtime/src/service-adapters/index.ts` - exports `DockerModelRunnerAdapter`

## Test plan

- Build passes (tsdown, no errors)
- Lint passes (oxlint 0 warnings, 0 errors)
- Manual: start Docker Desktop with Model Runner enabled, instantiate `new DockerModelRunnerAdapter({ model: ai/llama3.2 })`, confirm chat completions stream correctly

Closes #2530