### PR TITLE
docs: add Vue quick start guide

### DIFF
--- a/showcase/shell-docs/src/content/docs/meta.json
+++ b/showcase/shell-docs/src/content/docs/meta.json
@@ -50,6 +50,7 @@
     "slack",
     "microsoft-teams",
     "react-native",
+    "vue",
     "---Other---",
     "...(other)",
     {

--- a/showcase/shell-docs/src/content/docs/vue.mdx
+++ b/showcase/shell-docs/src/content/docs/vue.mdx
@@ -1,0 +1,118 @@
+---
+title: Vue
+description: Connect a Vue app to an AG-UI agent with CopilotKit.
+icon: "lucide/Component"
+hideTOC: true
+---
+
+`@copilotkit/vue` provides Vue 3 components and composables for CopilotKit. This guide gets you to a working Vue app with a chat UI talking to an [AG-UI](/backend/ag-ui) agent.
+
+It connects to the agent directly with `HttpAgent`, so there's no CopilotKit runtime to stand up and nothing framework-specific to configure. The same setup works with any AG-UI-compatible agent, whether it's built on LangGraph, CrewAI, Mastra, Pydantic AI, or your own server.
+
+## Prerequisites
+
+- A running AG-UI-compatible agent endpoint. If you don't have one yet, pick a framework under [Integrations](/integrations/langgraph) and follow its agent setup.
+- Vue 3.3+
+- Node.js 18+
+
+## Getting started
+
+<Steps>
+    <Step>
+        ### Create your Vue app
+
+        If you don't have one already:
+
+        ```bash
+        npm create vue@latest my-copilot-app
+        cd my-copilot-app
+        npm install
+        ```
+    </Step>
+    <Step>
+        ### Install CopilotKit
+
+        <Tabs groupId="package-manager" items={['npm', 'pnpm', 'yarn']}>
+            <Tab value="npm">
+                ```bash
+                npm install @copilotkit/vue
+                ```
+            </Tab>
+            <Tab value="pnpm">
+                ```bash
+                pnpm add @copilotkit/vue
+                ```
+            </Tab>
+            <Tab value="yarn">
+                ```bash
+                yarn add @copilotkit/vue
+                ```
+            </Tab>
+        </Tabs>
+    </Step>
+    <Step>
+        ### Import the styles
+
+        Import the package stylesheet once in your app entry. It's self-contained, so the chat renders without any other CSS.
+
+        ```ts title="src/main.ts"
+        import { createApp } from "vue";
+        import App from "./App.vue";
+        import "@copilotkit/vue/styles.css"; // [!code highlight]
+
+        createApp(App).mount("#app");
+        ```
+    </Step>
+    <Step>
+        ### Connect to your agent
+
+        Create an `HttpAgent` pointing at your agent endpoint, hand it to `CopilotKitProvider`, and drop in `CopilotChat`. Register the agent under the id `default` so the chat picks it up automatically.
+
+        ```vue title="src/App.vue"
+        <script setup lang="ts">
+        import { CopilotKitProvider, CopilotChat, HttpAgent } from "@copilotkit/vue/v2"; // [!code highlight]
+
+        // Point this at your AG-UI-compatible agent endpoint
+        const agent = new HttpAgent({ url: "http://localhost:8000/" }); // [!code highlight]
+        </script>
+
+        <template>
+          <!-- [!code highlight:5] -->
+          <CopilotKitProvider :self-managed-agents="{ default: agent }">
+            <div style="height: 100vh">
+              <CopilotChat />
+            </div>
+          </CopilotKitProvider>
+        </template>
+        ```
+
+        <Callout type="info" title="Pick your chat layout">
+          `CopilotChat` is a full-height chat. Swap it for `CopilotSidebar` (a collapsible side panel) or `CopilotPopup` (a floating widget) for a different layout. They take the same props.
+        </Callout>
+    </Step>
+    <Step>
+        ### Run the app
+
+        ```bash
+        npm run dev
+        ```
+
+        Open the dev server URL (Vite prints it, usually `http://localhost:5173`), send a message, and you'll see it stream back from your agent.
+
+        <Accordions className="mb-4">
+            <Accordion title="Troubleshooting">
+                - **Chat renders unstyled**: Make sure you imported `@copilotkit/vue/styles.css` in your app entry.
+                - **No response from the agent**: Confirm the `url` points at a reachable AG-UI endpoint and that the agent is running. Check the browser network tab for the request.
+                - **CORS errors**: A browser-direct connection needs the agent endpoint to allow your app's origin. Enable CORS on the agent, or put it behind the [CopilotKit runtime](/backend/copilot-runtime).
+            </Accordion>
+        </Accordions>
+    </Step>
+</Steps>
+
+## Where to go next
+
+- [Self-managed agents](/backend/self-managed-agents): securing the connection, the dev-only registration variant, and combining with a runtime.
+- [Connect AG-UI agents](/backend/ag-ui): the `HttpAgent` interface and the AG-UI protocol.
+- [Integrations](/integrations/langgraph): set up the agent itself on LangGraph, CrewAI, Mastra, and other frameworks.
+
+The composables (`useAgent`, `useFrontendTool`, `useHumanInTheLoop`, and more) mirror the React SDK. See the [`@copilotkit/vue` README](https://github.com/CopilotKit/CopilotKit/tree/main/packages/vue) for the full API, slot-based customization, and Nuxt SSR setup.


### PR DESCRIPTION
## Vue quick start guide

Adds a minimal getting-started guide for `@copilotkit/vue` under **Platforms**, matching the existing React Native guide. It connects a Vue app directly to an AG-UI agent with `HttpAgent`, so there is no runtime to stand up and nothing framework-specific to configure. The same setup works with any AG-UI agent, and agent-side setup links out to Integrations.

### New page

![Vue quickstart page: nav entry, intro, prerequisites](https://raw.githubusercontent.com/CopilotKit/CopilotKit/assets/vue-quickstart-screenshots/.pr-assets/vue-quickstart/page-top.png)

![Connect to your agent step with code sample](https://raw.githubusercontent.com/CopilotKit/CopilotKit/assets/vue-quickstart-screenshots/.pr-assets/vue-quickstart/connect-step.png)

### Changes

- `showcase/shell-docs/src/content/docs/vue.mdx` (new): five steps from `npm create vue` to a working chat connected to an agent, plus a troubleshooting accordion and next-steps links.
- `meta.json`: adds `vue` to the Platforms nav after `react-native`.

### Verification

- `pnpm build` of shell-docs passes: TypeScript clean, all static pages generated, no errors.
- Built a throwaway Vue app from this guide verbatim. `vite build` and `vue-tsc` resolve every import from `@copilotkit/vue/v2` (installed via the published `@copilotkit/vue`), the chat renders, and a message round-trips to a local AG-UI agent and streams back.
