### PR TITLE
docs(react-ui): clarify all modalities in attachments prop examples

### DIFF
--- a/packages/react-ui/src/components/chat/Chat.tsx
+++ b/packages/react-ui/src/components/chat/Chat.tsx
@@ -236,16 +236,19 @@ export interface CopilotChatProps {
    * Configuration for file attachments in the chat input.
    * Enables users to attach images, audio, video, and documents.
    *
+   * Supports images, audio, video, and documents. Omit `accept` to allow all
+   * file types (default: `"*\/*"`), or restrict with a MIME filter.
+   *
    * @example
    * ```tsx
    * <CopilotChat
    *   attachments={{
    *     enabled: true,
-   *     accept: "image/*,application/pdf",
+   *     accept: "image/*,audio/*,video/*,application/pdf",
    *     maxSize: 10 * 1024 * 1024, // 10MB
    *     onUpload: async (file) => {
    *       const url = await uploadToS3(file);
-   *       return { url, mimeType: file.type };
+   *       return { type: "url", value: url, mimeType: file.type };
    *     },
    *   }}
    * />

--- a/showcase/shell-docs/src/content/docs/multimodal-attachments.mdx
+++ b/showcase/shell-docs/src/content/docs/multimodal-attachments.mdx
@@ -29,7 +29,9 @@ The `attachments` prop accepts an `AttachmentsConfig` object:
 <CopilotChat
   attachments={{
     enabled: true,
-    accept: "image/*",              // MIME filter (default: "*/*")
+    // Omit `accept` to allow all file types (default: "*/*").
+    // Restrict with a MIME filter if needed:
+    accept: "image/*,audio/*,video/*,application/pdf",
     maxSize: 10 * 1024 * 1024,      // 10MB limit (default: 20MB)
   }}
 />


### PR DESCRIPTION
## Summary

The `attachments` prop supports images, audio, video, and documents — but the JSDoc example in `Chat.tsx` only showed `image/*,application/pdf`, and the docs configuration example used `accept: image/*`, silently teaching users to restrict themselves to images.

**Before (Chat.tsx JSDoc):**
```tsx
accept: image/*,application/pdf,
```

**After:**
```tsx
accept: image/*,audio/*,video/*,application/pdf,
```

The docs configuration example now also clarifies that omitting `accept` defaults to `*/*` (all files), and the shown value includes all four supported modalities.

## Changes

- `packages/react-ui/src/components/chat/Chat.tsx` — updated JSDoc example to show all modalities; added note that default `accept` is `*/*`
- `showcase/shell-docs/src/content/docs/multimodal-attachments.mdx` — updated configuration example to show `image/*,audio/*,video/*,application/pdf` and note that omitting `accept` allows all types