### PR TITLE
feat(runtime): add url field to ImageMessageInput

### DIFF
--- a/packages/runtime/src/graphql/inputs/message.input.ts
+++ b/packages/runtime/src/graphql/inputs/message.input.ts
@@ -29,7 +29,7 @@ export class ActionExecutionMessageInput {
     nullable: true,
     deprecationReason: "This field will be removed in a future version",
   })
-  scope?: String;
+  scope?: string;
 }
 
 @InputType()
@@ -76,11 +76,14 @@ export class AgentStateMessageInput {
 
 @InputType()
 export class ImageMessageInput {
-  @Field(() => String)
-  format: string;
+  @Field(() => String, { nullable: true })
+  format?: string;
 
-  @Field(() => String)
-  bytes: string;
+  @Field(() => String, { nullable: true })
+  bytes?: string;
+
+  @Field(() => String, { nullable: true })
+  url?: string;
 
   @Field(() => String, { nullable: true })
   parentMessageId?: string;

--- a/packages/runtime/src/graphql/message-conversion/agui-to-gql.ts
+++ b/packages/runtime/src/graphql/message-conversion/agui-to-gql.ts
@@ -30,14 +30,15 @@ function hasImageProperty(
     return false;
   }
 
-  const image: { format?: string; bytes?: string } | undefined =
-    "image" in message ? message.image : undefined;
+  const image: { format?: string; bytes?: string; url?: string } | undefined =
+    "image" in message ? (message as any).image : undefined;
   if (image === undefined) {
     return false;
   }
 
-  const isMalformed = image.format === undefined || image.bytes === undefined;
-  if (isMalformed) {
+  const hasBase64 = image.format !== undefined && image.bytes !== undefined;
+  const hasUrl = image.url !== undefined;
+  if (!hasBase64 && !hasUrl) {
     return false;
   }
 
@@ -384,8 +385,9 @@ export function aguiMessageWithImageToGQLMessage(
 
   return new gql.ImageMessage({
     id: message.id,
-    format: message.image.format,
-    bytes: message.image.bytes,
+    format: (message.image as any).format,
+    bytes: (message.image as any).bytes,
+    url: (message.image as any).url,
     role: roleValue,
   });
 }

--- a/packages/runtime/src/graphql/message-conversion/gql-to-agui.ts
+++ b/packages/runtime/src/graphql/message-conversion/gql-to-agui.ts
@@ -102,7 +102,7 @@ export function gqlActionExecutionMessageToAGUIMessage(
       if (typeof props?.result === "string") {
         try {
           props.result = JSON.parse(props.result);
-        } catch (e) {
+        } catch {
           /* do nothing */
         }
       }
@@ -111,7 +111,7 @@ export function gqlActionExecutionMessageToAGUIMessage(
       if (typeof actionResult === "string") {
         try {
           actionResult = JSON.parse(actionResult);
-        } catch (e) {
+        } catch {
           /* do nothing */
         }
       }
@@ -263,8 +263,21 @@ export function gqlResultMessageToAGUIMessage(
 export function gqlImageMessageToAGUIMessage(
   message: gql.ImageMessage,
 ): agui.Message {
-  // Validate image format
-  if (!validateImageFormat(message.format)) {
+  // Determine the role based on the message role
+  const role = message.role === gql.Role.assistant ? "assistant" : "user";
+
+  if (message.url) {
+    const imageMessage: agui.Message = {
+      id: message.id,
+      role,
+      content: "",
+      image: { url: message.url } as any,
+    };
+    return imageMessage;
+  }
+
+  // Validate image format for base64 path
+  if (!validateImageFormat(message.format ?? "")) {
     throw new Error(
       `Invalid image format: ${message.format}. Supported formats are: ${VALID_IMAGE_FORMATS.join(", ")}`,
     );
@@ -279,16 +292,12 @@ export function gqlImageMessageToAGUIMessage(
     throw new Error("Image bytes must be a non-empty string");
   }
 
-  // Determine the role based on the message role
-  const role = message.role === gql.Role.assistant ? "assistant" : "user";
-
-  // Create the image message with proper typing
   const imageMessage: agui.Message = {
     id: message.id,
     role,
     content: "",
     image: {
-      format: message.format,
+      format: message.format!,
       bytes: message.bytes,
     },
   };

--- a/packages/runtime/src/graphql/message-conversion/roundtrip-conversion.test.ts
+++ b/packages/runtime/src/graphql/message-conversion/roundtrip-conversion.test.ts
@@ -220,6 +220,20 @@ describe("roundtrip message conversion", () => {
     expect((aguiUserMsgs2[0] as any).image.bytes).toBe("userbase64data");
   });
 
+  test("image message GQL -> AGUI using URL", () => {
+    const gqlMsg = new gql.ImageMessage({
+      id: "img-url-1",
+      url: "https://example.com/image.png",
+      role: gql.Role.user,
+    });
+    const aguiMsgs = gqlToAGUI(gqlMsg);
+    expect(aguiMsgs[0].id).toBe("img-url-1");
+    expect(aguiMsgs[0].role).toBe("user");
+    expect((aguiMsgs[0] as any).image.url).toBe(
+      "https://example.com/image.png",
+    );
+  });
+
   test("wild card action roundtrip conversion", () => {
     const mockRender = vi.fn(
       (props) => `Wildcard rendered: ${props.args.test}`,

--- a/packages/runtime/src/graphql/types/converted/index.ts
+++ b/packages/runtime/src/graphql/types/converted/index.ts
@@ -135,7 +135,7 @@ export class ResultMessage extends Message implements ResultMessageInput {
         return { result: JSON.stringify(parsed) };
       }
       return { result };
-    } catch (e) {
+    } catch {
       return { result };
     }
   }
@@ -176,8 +176,9 @@ export class AgentStateMessage
 
 export class ImageMessage extends Message implements ImageMessageInput {
   type: MessageType = "ImageMessage";
-  format: string;
-  bytes: string;
+  format?: string;
+  bytes?: string;
+  url?: string;
   role: MessageRole;
   parentMessageId?: string;
 }

--- a/packages/runtime/src/service-adapters/anthropic/utils.ts
+++ b/packages/runtime/src/service-adapters/anthropic/utils.ts
@@ -1,6 +1,6 @@
-import { Anthropic } from "@anthropic-ai/sdk";
-import { ActionInput } from "../../graphql/inputs/action.input";
-import { Message } from "../../graphql/types/converted";
+import type { Anthropic } from "@anthropic-ai/sdk";
+import type { ActionInput } from "../../graphql/inputs/action.input";
+import type { Message } from "../../graphql/types/converted";
 
 export function limitMessagesToTokenCount(
   messages: any[],
@@ -161,6 +161,21 @@ export function convertMessageToAnthropicMessage(
       };
     }
   } else if (message.isImageMessage()) {
+    if (message.url) {
+      return {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "url",
+              url: message.url,
+            },
+          },
+        ],
+      };
+    }
+
     let mediaType: "image/jpeg" | "image/png" | "image/webp" | "image/gif";
     switch (message.format) {
       case "jpeg":

--- a/packages/runtime/src/service-adapters/conversion.ts
+++ b/packages/runtime/src/service-adapters/conversion.ts
@@ -1,12 +1,12 @@
+import type { Message } from "../graphql/types/converted";
 import {
   ActionExecutionMessage,
-  Message,
   ResultMessage,
   TextMessage,
   AgentStateMessage,
   ImageMessage,
 } from "../graphql/types/converted";
-import { MessageInput } from "../graphql/inputs/message.input";
+import type { MessageInput } from "../graphql/inputs/message.input";
 import { plainToInstance } from "class-transformer";
 import { tryMap, safeParseToolArgs } from "@copilotkit/shared";
 
@@ -29,6 +29,7 @@ export function convertGqlInputToMessages(
         role: message.imageMessage.role,
         bytes: message.imageMessage.bytes,
         format: message.imageMessage.format,
+        url: message.imageMessage.url,
         parentMessageId: message.imageMessage.parentMessageId,
       });
     } else if (message.actionExecutionMessage) {

--- a/packages/runtime/src/service-adapters/openai/utils.ts
+++ b/packages/runtime/src/service-adapters/openai/utils.ts
@@ -261,13 +261,16 @@ export function convertMessageToOpenAIMessage(
       content: message.content,
     } satisfies UsedMessageParams;
   } else if (message.isImageMessage()) {
+    const imageUrl = message.url
+      ? message.url
+      : `data:image/${message.format};base64,${message.bytes}`;
     return {
       role: "user",
       content: [
         {
           type: "image_url",
           image_url: {
-            url: `data:image/${message.format};base64,${message.bytes}`,
+            url: imageUrl,
           },
         },
       ],


### PR DESCRIPTION
## Summary

Adds `url` field to `ImageMessageInput` so images can be sent by URL instead of requiring base64 `bytes` + `format`.

**Before:** `imageMessage` only accepted `{ format, bytes }` — every image had to be base64-encoded by the client before sending.

**After:** `imageMessage` accepts `{ url }` as an alternative:

```graphql
mutation {
  generateCopilotResponse(data: {
    messages: [{
      id: img-1
      imageMessage: {
        role: user
        url: https://example.com/diagram.png
      }
    }]
  }) { ... }
}
```

Both OpenAI and Anthropic service adapters route URL images through the native URL source type (no base64 encoding needed):

- **OpenAI**: `{ type: image_url, image_url: { url } }`
- **Anthropic**: `{ type: image, source: { type: url, url } }`

## Files changed

- `packages/runtime/src/graphql/inputs/message.input.ts` — add `url?: string`, make `format`/`bytes` nullable
- `packages/runtime/src/graphql/types/converted/index.ts` — add `url?: string` to `ImageMessage`
- `packages/runtime/src/service-adapters/conversion.ts` — pass `url` through conversion
- `packages/runtime/src/service-adapters/openai/utils.ts` — use URL directly when present
- `packages/runtime/src/service-adapters/anthropic/utils.ts` — use Anthropic URL source when present
- `packages/runtime/src/graphql/message-conversion/agui-to-gql.ts` — accept url-only image messages
- `packages/runtime/src/graphql/message-conversion/gql-to-agui.ts` — pass url through; skip format validation for url-only path
- `packages/runtime/src/graphql/message-conversion/roundtrip-conversion.test.ts` — add URL roundtrip test

## Test plan

- 1528 tests pass (1527 existing + 1 new URL roundtrip test)
- Build passes (tsdown, no errors)
- Lint passes (0 new warnings, 0 errors)

Closes #1967