### PR TITLE
fix(showcase): disjoint catchall userMessages + content-asserting probes (supersedes #5465)

### DIFF
--- a/showcase/aimock/d6/ag2/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/ag2/tool-rendering-custom-catchall.json
@@ -6,21 +6,20 @@
   },
   "fixtures": [
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
+      "_comment": "tool-rendering-custom-catchall — weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
       "match": {
         "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d6_cc_weather_001",
         "context": "ag2"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
+        "content": "Tokyo is 22°C and partly cloudy — rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
+      "_comment": "tool-rendering-custom-catchall — weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
       "match": {
         "userMessage": "Forecast Tokyo through the wildcard renderer",
-        "toolName": "get_weather",
         "context": "ag2"
       },
       "response": {
@@ -34,32 +33,20 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
-      "match": {
-        "userMessage": "Forecast Tokyo through the wildcard renderer",
-        "turnIndex": 0,
-        "context": "ag2"
-      },
-      "response": {
-        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies."
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
+      "_comment": "tool-rendering-custom-catchall — AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d6_cc_stock_001",
         "context": "ag2"
       },
       "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% \u2014 rendered through the custom wildcard catchall."
+        "content": "AAPL is trading at $338.37, down 2.96% — rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
+      "_comment": "tool-rendering-custom-catchall — AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
-        "toolName": "get_stock_price",
         "context": "ag2"
       },
       "response": {
@@ -70,17 +57,6 @@
             "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
-      "match": {
-        "userMessage": "Quote AAPL through the wildcard renderer",
-        "turnIndex": 0,
-        "context": "ag2"
-      },
-      "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
       }
     }
   ]

--- a/showcase/aimock/d6/ag2/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/ag2/tool-rendering-custom-catchall.json
@@ -8,7 +8,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d6_cc_weather_001",
         "context": "ag2"
       },
@@ -19,7 +19,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolName": "get_weather",
         "context": "ag2"
       },
@@ -36,7 +36,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "turnIndex": 0,
         "context": "ag2"
       },
@@ -47,7 +47,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d6_cc_stock_001",
         "context": "ag2"
       },
@@ -58,7 +58,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolName": "get_stock_price",
         "context": "ag2"
       },
@@ -75,7 +75,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "turnIndex": 0,
         "context": "ag2"
       },

--- a/showcase/aimock/d6/agno/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/agno/tool-rendering-custom-catchall.json
@@ -4,24 +4,24 @@
     "sourceFile": "d5-tool-rendering-custom-catchall.ts",
     "created": "2026-05-22",
     "updated": "2026-06-15",
-    "note": "Dropped hasToolResult:false gate on tool-emit fixtures. Reason: the D5 probe runs 'forecast for Tokyo' first, leaving a get_weather tool result in the thread. aimock's hasToolResult is messages.some(m=>m.role==='tool'), so it becomes permanently true on the AAPL turn — hasToolResult:false would never match → no fixture → 30s timeout. The toolCallId-gated narration fixtures still win on iteration 2 (last message is tool with matching id), so the tool-emit fixtures only fire on the first leg of each prompt."
+    "note": "Dropped hasToolResult:false gate on tool-emit fixtures. Reason: the D5 probe runs 'forecast for Tokyo' first, leaving a get_weather tool result in the thread. aimock's hasToolResult is messages.some(m=>m.role==='tool'), so it becomes permanently true on the AAPL turn \u2014 hasToolResult:false would never match \u2192 no fixture \u2192 30s timeout. The toolCallId-gated narration fixtures still win on iteration 2 (last message is tool with matching id), so the tool-emit fixtures only fire on the first leg of each prompt."
   },
   "fixtures": [
     {
       "_comment": "custom-catchall turn 1 follow-up: after get_weather tool result. Keyed by toolCallId. MUST come before the tool-emitting fixture below (first-match-wins).",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d6_agno_cc_weather_001",
         "context": "agno"
       },
       "response": {
-        "content": "Tokyo is 22°C and partly cloudy."
+        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "custom-catchall turn 1: 'weather in Tokyo' — emit get_weather tool call. The custom wildcard renderer fires for this tool because no per-tool renderer is registered. Probe asserts [data-testid='custom-wildcard-card'][data-tool-name='get_weather'] mounts. No hasToolResult gate: matches on userMessage+context alone; the toolCallId narration above wins after the tool result arrives.",
+      "_comment": "custom-catchall turn 1: 'weather in Tokyo' \u2014 emit get_weather tool call. The custom wildcard renderer fires for this tool because no per-tool renderer is registered. Probe asserts [data-testid='custom-wildcard-card'][data-tool-name='get_weather'] mounts. No hasToolResult gate: matches on userMessage+context alone; the toolCallId narration above wins after the tool result arrives.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "context": "agno"
       },
       "response": {
@@ -37,18 +37,18 @@
     {
       "_comment": "custom-catchall turn 2 follow-up: after get_stock_price tool result. Keyed by toolCallId. MUST come before the tool-emitting fixture below.",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d6_agno_cc_stock_001",
         "context": "agno"
       },
       "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
+        "content": "AAPL is trading at $338.37, down 2.96% on the day \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "custom-catchall turn 2: 'What's the current price of AAPL?' — emit get_stock_price tool call. Probe asserts BOTH get_weather and get_stock_price rendered through custom-wildcard-card (cross-tool snapshot). No hasToolResult gate (the Tokyo tool result from turn 1 makes hasToolResult permanently true here).",
+      "_comment": "custom-catchall turn 2: 'What's the current price of AAPL?' \u2014 emit get_stock_price tool call. Probe asserts BOTH get_weather and get_stock_price rendered through custom-wildcard-card (cross-tool snapshot). No hasToolResult gate (the Tokyo tool result from turn 1 makes hasToolResult permanently true here).",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "context": "agno"
       },
       "response": {

--- a/showcase/aimock/d6/built-in-agent/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/built-in-agent/tool-rendering-custom-catchall.json
@@ -6,10 +6,10 @@
   },
   "fixtures": [
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 follow-up narration after get_weather tool result. Scoped via toolCallId (per-leg) so it only matches the weather tool-result turn; ordered BEFORE the tool-emit sibling so first-match-wins picks narration when the tool result is present.",
+      "_comment": "tool-rendering-custom-catchall \u2014 follow-up narration after get_weather tool result. Scoped via turnIndex:1 (assistant-count = 1 means 'one tool-call leg has been emitted; we're now narrating the result'). BIA's TanStack runtime auto-generates tool_call_id at request time, so the older toolCallId pin against a fixture-defined literal never matched on /v1/responses; turnIndex+userMessage is the id-agnostic alternative. Ordered BEFORE the tool-emit sibling so first-match-wins picks narration when the assistant-count gate fires.",
       "match": {
         "userMessage": "Forecast Tokyo through the wildcard renderer",
-        "toolCallId": "call_d6_cc_weather_001",
+        "turnIndex": 1,
         "context": "built-in-agent"
       },
       "response": {
@@ -34,10 +34,10 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 follow-up narration after get_stock_price tool result. Scoped via toolCallId (per-leg) so it only matches the stock tool-result turn; ordered BEFORE the tool-emit sibling so first-match-wins picks narration when the tool result is present.",
+      "_comment": "tool-rendering-custom-catchall \u2014 follow-up narration after get_stock_price tool result. Scoped via turnIndex:3 (assistant-count = 3 means weather-emit + weather-narrate + stock-emit have happened; we're now narrating the AAPL tool result). BIA's TanStack runtime auto-generates tool_call_id at request time, so the older toolCallId pin against a fixture-defined literal never matched on /v1/responses; turnIndex+userMessage is the id-agnostic alternative. Ordered BEFORE the AAPL tool-emit sibling so first-match-wins picks narration once the AAPL assistant-count gate fires.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
-        "toolCallId": "call_d6_cc_stock_001",
+        "turnIndex": 3,
         "context": "built-in-agent"
       },
       "response": {
@@ -45,9 +45,10 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 second prompt 'What's the current price of AAPL?'. Emits get_stock_price tool call to exercise a DIFFERENT tool through the same wildcard renderer. No hasToolResult gate (the Tokyo tool result from the previous prompt makes hasToolResult permanently true here); the toolCallId narration fixture above wins after the stock tool result arrives.",
+      "_comment": "tool-rendering-custom-catchall \u2014 second prompt 'What's the current price of AAPL?'. Emits get_stock_price tool call to exercise a DIFFERENT tool through the same wildcard renderer. turnIndex:2 means exactly two prior assistant turns (Tokyo emit + Tokyo narrate) have happened, the AAPL prompt has just arrived, and no AAPL tool-call has been emitted yet. The narration sibling above (turnIndex:3) fires after this emit produces its assistant tool-call message.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
+        "turnIndex": 2,
         "context": "built-in-agent"
       },
       "response": {

--- a/showcase/aimock/d6/built-in-agent/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/built-in-agent/tool-rendering-custom-catchall.json
@@ -6,20 +6,20 @@
   },
   "fixtures": [
     {
-      "_comment": "tool-rendering-custom-catchall — follow-up narration after get_weather tool result. Scoped via toolCallId (per-leg) so it only matches the weather tool-result turn; ordered BEFORE the tool-emit sibling so first-match-wins picks narration when the tool result is present.",
+      "_comment": "tool-rendering-custom-catchall \u2014 follow-up narration after get_weather tool result. Scoped via toolCallId (per-leg) so it only matches the weather tool-result turn; ordered BEFORE the tool-emit sibling so first-match-wins picks narration when the tool result is present.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d6_cc_weather_001",
         "context": "built-in-agent"
       },
       "response": {
-        "content": "Tokyo is 22°C and partly cloudy — the custom wildcard renderer should show the tool card above."
+        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 the custom wildcard renderer should show the tool card above \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall — first prompt 'weather in Tokyo'. Emits get_weather tool call. The custom wildcard renderer fires for any tool the user doesn't explicitly handle. hasToolResult:false on the tool-emitting fixtures.",
+      "_comment": "tool-rendering-custom-catchall \u2014 first prompt 'weather in Tokyo'. Emits get_weather tool call. The custom wildcard renderer fires for any tool the user doesn't explicitly handle. hasToolResult:false on the tool-emitting fixtures.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "hasToolResult": false,
         "context": "built-in-agent"
       },
@@ -34,20 +34,20 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall — follow-up narration after get_stock_price tool result. Scoped via toolCallId (per-leg) so it only matches the stock tool-result turn; ordered BEFORE the tool-emit sibling so first-match-wins picks narration when the tool result is present.",
+      "_comment": "tool-rendering-custom-catchall \u2014 follow-up narration after get_stock_price tool result. Scoped via toolCallId (per-leg) so it only matches the stock tool-result turn; ordered BEFORE the tool-emit sibling so first-match-wins picks narration when the tool result is present.",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d6_cc_stock_001",
         "context": "built-in-agent"
       },
       "response": {
-        "content": "AAPL is trading at $189.42, up 1.27% — rendered through the custom wildcard catchall renderer."
+        "content": "AAPL is trading at $189.42, up 1.27% \u2014 rendered through the custom wildcard catchall renderer."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall — second prompt 'What's the current price of AAPL?'. Emits get_stock_price tool call to exercise a DIFFERENT tool through the same wildcard renderer.",
+      "_comment": "tool-rendering-custom-catchall \u2014 second prompt 'What's the current price of AAPL?'. Emits get_stock_price tool call to exercise a DIFFERENT tool through the same wildcard renderer.",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "hasToolResult": false,
         "context": "built-in-agent"
       },

--- a/showcase/aimock/d6/built-in-agent/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/built-in-agent/tool-rendering-custom-catchall.json
@@ -45,10 +45,9 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 second prompt 'What's the current price of AAPL?'. Emits get_stock_price tool call to exercise a DIFFERENT tool through the same wildcard renderer.",
+      "_comment": "tool-rendering-custom-catchall \u2014 second prompt 'What's the current price of AAPL?'. Emits get_stock_price tool call to exercise a DIFFERENT tool through the same wildcard renderer. No hasToolResult gate (the Tokyo tool result from the previous prompt makes hasToolResult permanently true here); the toolCallId narration fixture above wins after the stock tool result arrives.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
-        "hasToolResult": false,
         "context": "built-in-agent"
       },
       "response": {

--- a/showcase/aimock/d6/built-in-agent/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/built-in-agent/tool-rendering-custom-catchall.json
@@ -41,7 +41,7 @@
         "context": "built-in-agent"
       },
       "response": {
-        "content": "AAPL is trading at $189.42, up 1.27% \u2014 rendered through the custom wildcard catchall renderer."
+        "content": "AAPL is trading at $338.37, down 2.96% \u2014 rendered through the custom wildcard catchall renderer."
       }
     },
     {
@@ -55,7 +55,7 @@
           {
             "id": "call_d6_cc_stock_001",
             "name": "get_stock_price",
-            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":189.42,\"change_pct\":1.27}"
+            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
           }
         ]
       }

--- a/showcase/aimock/d6/claude-sdk-python/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/claude-sdk-python/tool-rendering-custom-catchall.json
@@ -5,24 +5,24 @@
     "copiedFrom": "langgraph-python",
     "created": "2026-05-22",
     "updated": "2026-06-15",
-    "note": "Dropped the toolName gate on tool-emit fixtures and the no-tool-registered fallback. Reason: when toolName:get_stock_price failed to match (claude-sdk-python backend appears not to forward the tool definition uniformly on the second turn), the userMessage-only fallback returned plain content with no toolCall → no custom-wildcard card → D5 assertion fails with 'missing tool name [get_stock_price]'. Canonical pattern (no gate on tool-emit, toolCallId narration above for first-match-wins) lets the tool call always emit; the toolCallId narration fires on iteration 2 regardless of which tools the backend forwards."
+    "note": "Dropped the toolName gate on tool-emit fixtures and the no-tool-registered fallback. Reason: when toolName:get_stock_price failed to match (claude-sdk-python backend appears not to forward the tool definition uniformly on the second turn), the userMessage-only fallback returned plain content with no toolCall \u2192 no custom-wildcard card \u2192 D5 assertion fails with 'missing tool name [get_stock_price]'. Canonical pattern (no gate on tool-emit, toolCallId narration above for first-match-wins) lets the tool call always emit; the toolCallId narration fires on iteration 2 regardless of which tools the backend forwards."
   },
   "fixtures": [
     {
       "_comment": "custom-catchall: weather in Tokyo follow-up after get_weather tool result. MUST come before the tool-emitting fixture (first-match-wins).",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d5_get_weather_001",
         "context": "claude-sdk-python"
       },
       "response": {
-        "content": "Tokyo is 22°C and partly cloudy — rendered through the custom wildcard catchall."
+        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "custom-catchall: weather in Tokyo first leg — emit get_weather tool call. The custom wildcard renderer fires for this tool. Matches on userMessage+context alone; the toolCallId narration above wins after the tool result arrives.",
+      "_comment": "custom-catchall: weather in Tokyo first leg \u2014 emit get_weather tool call. The custom wildcard renderer fires for this tool. Matches on userMessage+context alone; the toolCallId narration above wins after the tool result arrives.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "context": "claude-sdk-python"
       },
       "response": {
@@ -38,18 +38,18 @@
     {
       "_comment": "custom-catchall: AAPL stock price follow-up after get_stock_price tool result. MUST come before the tool-emitting fixture.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d5_get_stock_price_001",
         "context": "claude-sdk-python"
       },
       "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% — rendered through the custom wildcard catchall."
+        "content": "AAPL is trading at $338.37, down 2.96% \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "custom-catchall: AAPL stock price first leg — emit get_stock_price tool call. No toolName/hasToolResult gate so the tool call emits regardless of which tools the backend forwards on the second turn. The toolCallId narration above wins on iteration 2.",
+      "_comment": "custom-catchall: AAPL stock price first leg \u2014 emit get_stock_price tool call. No toolName/hasToolResult gate so the tool call emits regardless of which tools the backend forwards on the second turn. The toolCallId narration above wins on iteration 2.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "context": "claude-sdk-python"
       },
       "response": {

--- a/showcase/aimock/d6/claude-sdk-typescript/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/claude-sdk-typescript/tool-rendering-custom-catchall.json
@@ -33,23 +33,6 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall pill 1 fallback: weather in Tokyo without toolName gate.",
-      "match": {
-        "userMessage": "Forecast Tokyo through the wildcard renderer",
-        "turnIndex": 0,
-        "context": "claude-sdk-typescript"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_cc_get_weather_001",
-            "name": "get_weather",
-            "arguments": "{\"location\":\"Tokyo\"}"
-          }
-        ]
-      }
-    },
-    {
       "_comment": "tool-rendering-custom-catchall pill 2: AAPL stock price \u2014 follow-up after get_stock_price tool result. Must come before the tool-emitting fixture.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
@@ -74,17 +57,6 @@
             "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall pill 2 fallback: AAPL narration when no tool is wired.",
-      "match": {
-        "userMessage": "Quote AAPL through the wildcard renderer",
-        "turnIndex": 0,
-        "context": "claude-sdk-typescript"
-      },
-      "response": {
-        "content": "AAPL is trading around $338.37, down 2.96% on the day — narration fallback when the get_stock_price tool isn't wired through the custom wildcard catchall."
       }
     }
   ]

--- a/showcase/aimock/d6/claude-sdk-typescript/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/claude-sdk-typescript/tool-rendering-custom-catchall.json
@@ -8,18 +8,18 @@
     {
       "_comment": "tool-rendering-custom-catchall pill 1: weather in Tokyo \u2014 follow-up after get_weather tool result. Must come before the tool-emitting fixture.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d6_cc_get_weather_001",
         "context": "claude-sdk-typescript"
       },
       "response": {
-        "content": "Tokyo is 22 degrees C and partly cloudy. The custom wildcard renderer should display a card for the get_weather tool call."
+        "content": "Tokyo is 22 degrees C and partly cloudy. The custom wildcard renderer should display a card for the get_weather tool call \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
       "_comment": "tool-rendering-custom-catchall pill 1: weather in Tokyo \u2014 first leg: emit get_weather tool call. The custom catchall renderer fires for this tool since no per-tool renderer is registered.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolName": "get_weather",
         "context": "claude-sdk-typescript"
       },
@@ -36,7 +36,7 @@
     {
       "_comment": "tool-rendering-custom-catchall pill 1 fallback: weather in Tokyo without toolName gate.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "turnIndex": 0,
         "context": "claude-sdk-typescript"
       },
@@ -53,18 +53,18 @@
     {
       "_comment": "tool-rendering-custom-catchall pill 2: AAPL stock price \u2014 follow-up after get_stock_price tool result. Must come before the tool-emitting fixture.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d6_cc_get_stock_price_001",
         "context": "claude-sdk-typescript"
       },
       "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day. The custom wildcard renderer should display a card for the get_stock_price tool call."
+        "content": "AAPL is trading at $338.37, down 2.96% on the day. The custom wildcard renderer should display a card for the get_stock_price tool call \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
       "_comment": "tool-rendering-custom-catchall pill 2: AAPL stock price \u2014 first leg: emit get_stock_price tool call.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolName": "get_stock_price",
         "context": "claude-sdk-typescript"
       },
@@ -81,7 +81,7 @@
     {
       "_comment": "tool-rendering-custom-catchall pill 2 fallback: AAPL without toolName gate.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "turnIndex": 0,
         "context": "claude-sdk-typescript"
       },

--- a/showcase/aimock/d6/claude-sdk-typescript/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/claude-sdk-typescript/tool-rendering-custom-catchall.json
@@ -20,7 +20,6 @@
       "_comment": "tool-rendering-custom-catchall pill 1: weather in Tokyo \u2014 first leg: emit get_weather tool call. The custom catchall renderer fires for this tool since no per-tool renderer is registered.",
       "match": {
         "userMessage": "Forecast Tokyo through the wildcard renderer",
-        "toolName": "get_weather",
         "context": "claude-sdk-typescript"
       },
       "response": {
@@ -65,7 +64,6 @@
       "_comment": "tool-rendering-custom-catchall pill 2: AAPL stock price \u2014 first leg: emit get_stock_price tool call.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
-        "toolName": "get_stock_price",
         "context": "claude-sdk-typescript"
       },
       "response": {

--- a/showcase/aimock/d6/claude-sdk-typescript/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/claude-sdk-typescript/tool-rendering-custom-catchall.json
@@ -79,20 +79,14 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall pill 2 fallback: AAPL without toolName gate.",
+      "_comment": "tool-rendering-custom-catchall pill 2 fallback: AAPL narration when no tool is wired.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
         "turnIndex": 0,
         "context": "claude-sdk-typescript"
       },
       "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_cc_get_stock_price_001",
-            "name": "get_stock_price",
-            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
-          }
-        ]
+        "content": "AAPL is trading around $338.37, down 2.96% on the day — narration fallback when the get_stock_price tool isn't wired through the custom wildcard catchall."
       }
     }
   ]

--- a/showcase/aimock/d6/claude-sdk-typescript/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/claude-sdk-typescript/tool-rendering-custom-catchall.json
@@ -6,20 +6,21 @@
   },
   "fixtures": [
     {
-      "_comment": "tool-rendering-custom-catchall pill 1: weather in Tokyo \u2014 follow-up after get_weather tool result. Must come before the tool-emitting fixture.",
+      "_comment": "tool-rendering-custom-catchall — follow-up narration after get_weather tool result. Scoped via turnIndex:1 (assistant-count = 1 means 'one tool-call leg has been emitted; we're now narrating the result'). The Anthropic Responses API path auto-generates tool_call_id at request time, so the older toolCallId pin against a fixture-defined literal never matched on /v1/responses; turnIndex+userMessage is the id-agnostic alternative. Ordered BEFORE the tool-emit sibling so first-match-wins picks narration when the assistant-count gate fires.",
       "match": {
         "userMessage": "Forecast Tokyo through the wildcard renderer",
-        "toolCallId": "call_d6_cc_get_weather_001",
+        "turnIndex": 1,
         "context": "claude-sdk-typescript"
       },
       "response": {
-        "content": "Tokyo is 22 degrees C and partly cloudy. The custom wildcard renderer should display a card for the get_weather tool call \u2014 rendered through the custom wildcard catchall."
+        "content": "Tokyo is 22 degrees C and partly cloudy. The custom wildcard renderer should display a card for the get_weather tool call — rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall pill 1: weather in Tokyo \u2014 first leg: emit get_weather tool call. The custom catchall renderer fires for this tool since no per-tool renderer is registered.",
+      "_comment": "tool-rendering-custom-catchall — first prompt 'weather in Tokyo'. Emits get_weather tool call. The custom wildcard renderer fires for any tool the user doesn't explicitly handle. hasToolResult:false on the tool-emitting fixtures.",
       "match": {
         "userMessage": "Forecast Tokyo through the wildcard renderer",
+        "hasToolResult": false,
         "context": "claude-sdk-typescript"
       },
       "response": {
@@ -33,20 +34,21 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall pill 2: AAPL stock price \u2014 follow-up after get_stock_price tool result. Must come before the tool-emitting fixture.",
+      "_comment": "tool-rendering-custom-catchall — follow-up narration after get_stock_price tool result. Scoped via turnIndex:3 (assistant-count = 3 means weather-emit + weather-narrate + stock-emit have happened; we're now narrating the AAPL tool result). The Anthropic Responses API path auto-generates tool_call_id at request time, so the older toolCallId pin against a fixture-defined literal never matched on /v1/responses; turnIndex+userMessage is the id-agnostic alternative. Ordered BEFORE the AAPL tool-emit sibling so first-match-wins picks narration once the AAPL assistant-count gate fires.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
-        "toolCallId": "call_d6_cc_get_stock_price_001",
+        "turnIndex": 3,
         "context": "claude-sdk-typescript"
       },
       "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day. The custom wildcard renderer should display a card for the get_stock_price tool call \u2014 rendered through the custom wildcard catchall."
+        "content": "AAPL is trading at $338.37, down 2.96% on the day. The custom wildcard renderer should display a card for the get_stock_price tool call — rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall pill 2: AAPL stock price \u2014 first leg: emit get_stock_price tool call.",
+      "_comment": "tool-rendering-custom-catchall — second prompt 'What's the current price of AAPL?'. Emits get_stock_price tool call to exercise a DIFFERENT tool through the same wildcard renderer. turnIndex:2 means exactly two prior assistant turns (Tokyo emit + Tokyo narrate) have happened, the AAPL prompt has just arrived, and no AAPL tool-call has been emitted yet. The narration sibling above (turnIndex:3) fires after this emit produces its assistant tool-call message.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
+        "turnIndex": 2,
         "context": "claude-sdk-typescript"
       },
       "response": {

--- a/showcase/aimock/d6/crewai-crews/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/crewai-crews/tool-rendering-custom-catchall.json
@@ -9,17 +9,17 @@
     {
       "_comment": "tool-rendering-custom-catchall sends 'weather in Tokyo' \u2014 first leg emits get_weather tool call. The custom catchall renderer mounts a WeatherCard. toolCallId-keyed follow-up MUST come before the tool-emitting fixture (first-match-wins).",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d5_get_weather_001",
         "context": "crewai-crews"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy."
+        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "hasToolResult": false,
         "context": "crewai-crews"
       },
@@ -36,17 +36,17 @@
     {
       "_comment": "tool-rendering-custom-catchall second pill: 'What's the current price of AAPL?' \u2014 emits get_stock_price tool call, custom catchall renderer mounts a StockCard.",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d5_get_stock_price_001",
         "context": "crewai-crews"
       },
       "response": {
-        "content": "AAPL is trading at $189.42, up 1.27% on the day."
+        "content": "AAPL is trading at $189.42, up 1.27% on the day \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "hasToolResult": false,
         "context": "crewai-crews"
       },

--- a/showcase/aimock/d6/crewai-crews/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/crewai-crews/tool-rendering-custom-catchall.json
@@ -41,7 +41,7 @@
         "context": "crewai-crews"
       },
       "response": {
-        "content": "AAPL is trading at $189.42, up 1.27% on the day \u2014 rendered through the custom wildcard catchall."
+        "content": "AAPL is trading at $338.37, down 2.96% on the day \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
@@ -55,7 +55,7 @@
           {
             "id": "call_d5_get_stock_price_001",
             "name": "get_stock_price",
-            "arguments": "{\"ticker\":\"AAPL\"}"
+            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
           }
         ]
       }

--- a/showcase/aimock/d6/crewai-crews/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/crewai-crews/tool-rendering-custom-catchall.json
@@ -45,9 +45,9 @@
       }
     },
     {
+      "_comment": "tool-rendering-custom-catchall AAPL emit. No hasToolResult gate (the Tokyo tool result from the previous prompt makes hasToolResult permanently true here); the toolCallId narration fixture above wins after the stock tool result arrives.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
-        "hasToolResult": false,
         "context": "crewai-crews"
       },
       "response": {

--- a/showcase/aimock/d6/google-adk/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/google-adk/tool-rendering-custom-catchall.json
@@ -21,7 +21,6 @@
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
       "match": {
         "userMessage": "Forecast Tokyo through the wildcard renderer",
-        "toolName": "get_weather",
         "context": "google-adk"
       },
       "response": {
@@ -32,17 +31,6 @@
             "arguments": "{\"location\":\"Tokyo\"}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
-      "match": {
-        "userMessage": "Forecast Tokyo through the wildcard renderer",
-        "turnIndex": 0,
-        "context": "google-adk"
-      },
-      "response": {
-        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies."
       }
     },
     {
@@ -60,7 +48,6 @@
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
-        "toolName": "get_stock_price",
         "context": "google-adk"
       },
       "response": {
@@ -71,17 +58,6 @@
             "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
-      "match": {
-        "userMessage": "Quote AAPL through the wildcard renderer",
-        "turnIndex": 0,
-        "context": "google-adk"
-      },
-      "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
       }
     },
     {

--- a/showcase/aimock/d6/google-adk/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/google-adk/tool-rendering-custom-catchall.json
@@ -9,7 +9,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d6_cc_google_adk_weather_001",
         "context": "google-adk"
       },
@@ -20,7 +20,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolName": "get_weather",
         "context": "google-adk"
       },
@@ -37,7 +37,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "turnIndex": 0,
         "context": "google-adk"
       },
@@ -48,7 +48,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d6_cc_google_adk_stock_001",
         "context": "google-adk"
       },
@@ -59,7 +59,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolName": "get_stock_price",
         "context": "google-adk"
       },
@@ -76,7 +76,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "turnIndex": 0,
         "context": "google-adk"
       },

--- a/showcase/aimock/d6/langgraph-fastapi/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/langgraph-fastapi/tool-rendering-custom-catchall.json
@@ -8,7 +8,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d6_cc_langgraph_fastapi_weather_001",
         "context": "langgraph-fastapi"
       },
@@ -19,7 +19,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolName": "get_weather",
         "context": "langgraph-fastapi"
       },
@@ -36,7 +36,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "turnIndex": 0,
         "context": "langgraph-fastapi"
       },
@@ -47,7 +47,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d6_cc_langgraph_fastapi_stock_001",
         "context": "langgraph-fastapi"
       },
@@ -58,7 +58,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolName": "get_stock_price",
         "context": "langgraph-fastapi"
       },
@@ -75,7 +75,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "turnIndex": 0,
         "context": "langgraph-fastapi"
       },
@@ -84,7 +84,7 @@
       }
     },
     {
-      "_comment": "custom-catchall — Weather in SF pill. get_weather tool call. Same tools as tool-rendering but the frontend registers a single branded wildcard renderer via useDefaultRenderTool.",
+      "_comment": "custom-catchall \u2014 Weather in SF pill. get_weather tool call. Same tools as tool-rendering but the frontend registers a single branded wildcard renderer via useDefaultRenderTool.",
       "match": {
         "userMessage": "Weather in SF",
         "hasToolResult": false,
@@ -107,11 +107,11 @@
         "context": "langgraph-fastapi"
       },
       "response": {
-        "content": "San Francisco is currently 68°F and sunny with light winds."
+        "content": "San Francisco is currently 68\u00b0F and sunny with light winds."
       }
     },
     {
-      "_comment": "custom-catchall — Find flights pill. search_flights tool call.",
+      "_comment": "custom-catchall \u2014 Find flights pill. search_flights tool call.",
       "match": {
         "userMessage": "Find flights",
         "hasToolResult": false,
@@ -134,11 +134,11 @@
         "context": "langgraph-fastapi"
       },
       "response": {
-        "content": "Three flights found — United UA231 ($348), Delta DL412 ($312), and JetBlue B6722 ($289)."
+        "content": "Three flights found \u2014 United UA231 ($348), Delta DL412 ($312), and JetBlue B6722 ($289)."
       }
     },
     {
-      "_comment": "custom-catchall — Roll a d20 pill. 5 sequential roll_d20 calls chained by toolCallId: [7, 14, 3, 19, 20].",
+      "_comment": "custom-catchall \u2014 Roll a d20 pill. 5 sequential roll_d20 calls chained by toolCallId: [7, 14, 3, 19, 20].",
       "match": {
         "userMessage": "Roll a d20",
         "toolCallId": "call_cc_d20_seq_001",
@@ -209,7 +209,7 @@
         "context": "langgraph-fastapi"
       },
       "response": {
-        "content": "Rolled the d20 five times — landed on 20 on the final roll."
+        "content": "Rolled the d20 five times \u2014 landed on 20 on the final roll."
       }
     },
     {
@@ -230,14 +230,14 @@
       }
     },
     {
-      "_comment": "custom-catchall — Chain tools pill. Emit 3 tool calls in one assistant turn.",
+      "_comment": "custom-catchall \u2014 Chain tools pill. Emit 3 tool calls in one assistant turn.",
       "match": {
         "userMessage": "Chain tools",
         "toolCallId": "call_cc_chain_roll_001",
         "context": "langgraph-fastapi"
       },
       "response": {
-        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
+        "content": "Done \u2014 Tokyo is sunny, three flights found, and the d20 came up 11."
       }
     },
     {
@@ -247,7 +247,7 @@
         "context": "langgraph-fastapi"
       },
       "response": {
-        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
+        "content": "Done \u2014 Tokyo is sunny, three flights found, and the d20 came up 11."
       }
     },
     {
@@ -257,7 +257,7 @@
         "context": "langgraph-fastapi"
       },
       "response": {
-        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
+        "content": "Done \u2014 Tokyo is sunny, three flights found, and the d20 came up 11."
       }
     },
     {

--- a/showcase/aimock/d6/langgraph-fastapi/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/langgraph-fastapi/tool-rendering-custom-catchall.json
@@ -20,7 +20,6 @@
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
       "match": {
         "userMessage": "Forecast Tokyo through the wildcard renderer",
-        "toolName": "get_weather",
         "context": "langgraph-fastapi"
       },
       "response": {
@@ -31,17 +30,6 @@
             "arguments": "{\"location\":\"Tokyo\"}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
-      "match": {
-        "userMessage": "Forecast Tokyo through the wildcard renderer",
-        "turnIndex": 0,
-        "context": "langgraph-fastapi"
-      },
-      "response": {
-        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies."
       }
     },
     {
@@ -59,7 +47,6 @@
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
-        "toolName": "get_stock_price",
         "context": "langgraph-fastapi"
       },
       "response": {
@@ -70,17 +57,6 @@
             "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
-      "match": {
-        "userMessage": "Quote AAPL through the wildcard renderer",
-        "turnIndex": 0,
-        "context": "langgraph-fastapi"
-      },
-      "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
       }
     },
     {

--- a/showcase/aimock/d6/langgraph-python/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/langgraph-python/tool-rendering-custom-catchall.json
@@ -7,6 +7,60 @@
   },
   "fixtures": [
     {
+      "_comment": "d5-tool-rendering-custom-catchall probe — turn 2 narration after get_weather tool result. Scoped via toolCallId (per-leg) so it only matches the weather tool-result turn; ordered BEFORE the tool-emit sibling so first-match-wins picks narration when the tool result is present. Canonical phrase 'rendered through the custom wildcard catchall' is asserted by the probe (LGP-gold disjoint-prompts content guard).",
+      "match": {
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
+        "toolCallId": "call_trcc_get_weather_d5_001",
+        "context": "langgraph-python"
+      },
+      "response": {
+        "content": "Tokyo is 22°C and partly cloudy — the custom wildcard renderer should show the tool card above — rendered through the custom wildcard catchall."
+      }
+    },
+    {
+      "_comment": "d5-tool-rendering-custom-catchall probe — turn 1 emit for get_weather (Tokyo). Disjoint userMessage from the default-catchall probe ('forecast for Tokyo' lowercase) so aimock's substring matcher cannot cross-route between catchall probes. The toolCallId-gated narration above fires after the backend tool result arrives.",
+      "match": {
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
+        "context": "langgraph-python"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_trcc_get_weather_d5_001",
+            "name": "get_weather",
+            "arguments": "{\"location\":\"Tokyo\"}"
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "d5-tool-rendering-custom-catchall probe — turn 2 narration after get_stock_price tool result. Scoped via toolCallId (per-leg). Canonical phrase 'rendered through the custom wildcard catchall' is asserted by the probe; AAPL $338.37/-2.96% matches the canonical payload used across the tool-rendering family.",
+      "match": {
+        "userMessage": "Quote AAPL through the wildcard renderer",
+        "toolCallId": "call_trcc_get_stock_price_d5_001",
+        "context": "langgraph-python"
+      },
+      "response": {
+        "content": "AAPL is trading at $338.37, down 2.96% — rendered through the custom wildcard catchall renderer."
+      }
+    },
+    {
+      "_comment": "d5-tool-rendering-custom-catchall probe — turn 1 emit for get_stock_price (AAPL). Cross-tool pair with get_weather above; the probe asserts both tools render through the SAME custom-wildcard-card testid with distinct data-tool-name values. No hasToolResult gate (the prior turn's tool result makes hasToolResult permanently true here); the toolCallId-gated narration above wins after this tool result arrives.",
+      "match": {
+        "userMessage": "Quote AAPL through the wildcard renderer",
+        "context": "langgraph-python"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_trcc_get_stock_price_d5_001",
+            "name": "get_stock_price",
+            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
+          }
+        ]
+      }
+    },
+    {
       "_comment": "Chain tools — follow-up after all 3 tools ran. Anchored on whichever of the 3 chain toolCallIds appears last in the request (LangGraph's ToolNode preserves tool_calls order). MUST come before the toolCalls-emitting fixture below so iteration 2 of the chain-tools loop hits this branch instead of re-emitting.",
       "match": {
         "userMessage": "Chain a few tools in this single turn",

--- a/showcase/aimock/d6/langgraph-typescript/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/langgraph-typescript/tool-rendering-custom-catchall.json
@@ -22,7 +22,6 @@
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
       "match": {
         "userMessage": "Forecast Tokyo through the wildcard renderer",
-        "toolName": "get_weather",
         "context": "langgraph-typescript"
       },
       "response": {
@@ -33,17 +32,6 @@
             "arguments": "{\"location\":\"Tokyo\"}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
-      "match": {
-        "userMessage": "Forecast Tokyo through the wildcard renderer",
-        "turnIndex": 0,
-        "context": "langgraph-typescript"
-      },
-      "response": {
-        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies."
       }
     },
     {
@@ -61,7 +49,6 @@
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
-        "toolName": "get_stock_price",
         "context": "langgraph-typescript"
       },
       "response": {
@@ -72,17 +59,6 @@
             "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
-      "match": {
-        "userMessage": "Quote AAPL through the wildcard renderer",
-        "turnIndex": 0,
-        "context": "langgraph-typescript"
-      },
-      "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
       }
     },
     {

--- a/showcase/aimock/d6/langgraph-typescript/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/langgraph-typescript/tool-rendering-custom-catchall.json
@@ -10,7 +10,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d6_cc_langgraph_typescript_weather_001",
         "context": "langgraph-typescript"
       },
@@ -21,7 +21,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolName": "get_weather",
         "context": "langgraph-typescript"
       },
@@ -38,7 +38,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "turnIndex": 0,
         "context": "langgraph-typescript"
       },
@@ -49,7 +49,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d6_cc_langgraph_typescript_stock_001",
         "context": "langgraph-typescript"
       },
@@ -60,7 +60,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolName": "get_stock_price",
         "context": "langgraph-typescript"
       },
@@ -77,7 +77,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "turnIndex": 0,
         "context": "langgraph-typescript"
       },

--- a/showcase/aimock/d6/langroid/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/langroid/tool-rendering-custom-catchall.json
@@ -10,18 +10,18 @@
     {
       "_comment": "Custom catchall turn 1 follow-up: after get_weather tool result. Keyed by toolCallId so it only fires on the post-tool leg; ordered before the tool-emit fixture below for first-match-wins.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d6_lr_cc_weather_001",
         "context": "langroid"
       },
       "response": {
-        "content": "Tokyo is 22°C and partly cloudy."
+        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "Custom catchall turn 1: weather in Tokyo — emit get_weather tool call. The custom wildcard renderer fires for this tool. Matches on userMessage+context alone (no hasToolResult gate); the toolCallId narration above wins after the tool result arrives.",
+      "_comment": "Custom catchall turn 1: weather in Tokyo \u2014 emit get_weather tool call. The custom wildcard renderer fires for this tool. Matches on userMessage+context alone (no hasToolResult gate); the toolCallId narration above wins after the tool result arrives.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "context": "langroid"
       },
       "response": {
@@ -37,18 +37,18 @@
     {
       "_comment": "Custom catchall turn 2 follow-up: after get_stock_price tool result. Keyed by toolCallId; must come before the tool-emit fixture below.",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d6_lr_cc_stock_001",
         "context": "langroid"
       },
       "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
+        "content": "AAPL is trading at $338.37, down 2.96% on the day \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "Custom catchall turn 2: AAPL stock price — emit get_stock_price tool call. Both this and get_weather must render through the same custom-wildcard-card testid. No hasToolResult gate (the Tokyo tool result from turn 1 makes hasToolResult permanently true).",
+      "_comment": "Custom catchall turn 2: AAPL stock price \u2014 emit get_stock_price tool call. Both this and get_weather must render through the same custom-wildcard-card testid. No hasToolResult gate (the Tokyo tool result from turn 1 makes hasToolResult permanently true).",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "context": "langroid"
       },
       "response": {

--- a/showcase/aimock/d6/llamaindex/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/llamaindex/tool-rendering-custom-catchall.json
@@ -4,13 +4,13 @@
     "sourceScript": "d5-tool-rendering-custom-catchall.ts",
     "created": "2026-05-22",
     "updated": "2026-06-15",
-    "note": "Dropped hasToolResult:false on tool-emit fixtures — the Tokyo tool result from turn 1 stays in the thread, making hasToolResult permanently true on the AAPL turn → no fixture match → 30s timeout. toolCallId-keyed narration above still wins on iteration 2."
+    "note": "Dropped hasToolResult:false on tool-emit fixtures \u2014 the Tokyo tool result from turn 1 stays in the thread, making hasToolResult permanently true on the AAPL turn \u2192 no fixture match \u2192 30s timeout. toolCallId-keyed narration above still wins on iteration 2."
   },
   "fixtures": [
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up after get_weather tool result. Must come BEFORE the tool-emitting fixture (first-match-wins).",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d6_li_cc_weather_001",
         "context": "llamaindex"
       },
@@ -21,7 +21,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo first leg: emit get_weather tool call. The custom catchall renderer fires for this tool since there's no per-tool renderer registered.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "context": "llamaindex"
       },
       "response": {
@@ -37,7 +37,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up after get_stock_price tool result. Must come BEFORE the tool-emitting fixture.",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d6_li_cc_stock_001",
         "context": "llamaindex"
       },
@@ -48,7 +48,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price first leg: emit get_stock_price tool call. Second prompt in the cross-tool assertion pair.",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "context": "llamaindex"
       },
       "response": {

--- a/showcase/aimock/d6/mastra/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/mastra/tool-rendering-custom-catchall.json
@@ -7,21 +7,20 @@
   },
   "fixtures": [
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
+      "_comment": "tool-rendering-custom-catchall — weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
       "match": {
         "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d6_cc_weather_001",
         "context": "mastra"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
+        "content": "Tokyo is 22°C and partly cloudy — rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
+      "_comment": "tool-rendering-custom-catchall — weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
       "match": {
         "userMessage": "Forecast Tokyo through the wildcard renderer",
-        "toolName": "get_weather",
         "context": "mastra"
       },
       "response": {
@@ -35,32 +34,20 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
-      "match": {
-        "userMessage": "Forecast Tokyo through the wildcard renderer",
-        "turnIndex": 0,
-        "context": "mastra"
-      },
-      "response": {
-        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies."
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
+      "_comment": "tool-rendering-custom-catchall — AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d6_cc_stock_001",
         "context": "mastra"
       },
       "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% \u2014 rendered through the custom wildcard catchall."
+        "content": "AAPL is trading at $338.37, down 2.96% — rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
+      "_comment": "tool-rendering-custom-catchall — AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
-        "toolName": "get_stock_price",
         "context": "mastra"
       },
       "response": {
@@ -71,17 +58,6 @@
             "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
-      "match": {
-        "userMessage": "Quote AAPL through the wildcard renderer",
-        "turnIndex": 0,
-        "context": "mastra"
-      },
-      "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
       }
     }
   ]

--- a/showcase/aimock/d6/mastra/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/mastra/tool-rendering-custom-catchall.json
@@ -9,7 +9,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d6_cc_weather_001",
         "context": "mastra"
       },
@@ -20,7 +20,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolName": "get_weather",
         "context": "mastra"
       },
@@ -37,7 +37,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "turnIndex": 0,
         "context": "mastra"
       },
@@ -48,7 +48,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d6_cc_stock_001",
         "context": "mastra"
       },
@@ -59,7 +59,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolName": "get_stock_price",
         "context": "mastra"
       },
@@ -76,7 +76,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "turnIndex": 0,
         "context": "mastra"
       },

--- a/showcase/aimock/d6/ms-agent-dotnet/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/ms-agent-dotnet/tool-rendering-custom-catchall.json
@@ -9,7 +9,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up. After get_weather tool result returns, emit narrated content. MUST come before the tool-emitting fixture so iteration 2 hits this branch.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d6_cc_ms_agent_dotnet_weather_001",
         "context": "ms-agent-dotnet"
       },
@@ -20,7 +20,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolName": "get_weather",
         "context": "ms-agent-dotnet"
       },
@@ -37,7 +37,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "turnIndex": 0,
         "context": "ms-agent-dotnet"
       },
@@ -48,7 +48,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up. After get_stock_price tool result returns. MUST come before the tool-emitting fixture.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d6_cc_ms_agent_dotnet_stock_001",
         "context": "ms-agent-dotnet"
       },
@@ -59,7 +59,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolName": "get_stock_price",
         "context": "ms-agent-dotnet"
       },
@@ -76,7 +76,7 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
       "match": {
-        "userMessage": "What's the current price of AAPL?",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "turnIndex": 0,
         "context": "ms-agent-dotnet"
       },
@@ -85,14 +85,14 @@
       }
     },
     {
-      "_comment": "Chain tools — follow-up after all 3 tools ran. Anchored on whichever of the 3 chain toolCallIds appears last in the request (LangGraph's ToolNode preserves tool_calls order). MUST come before the toolCalls-emitting fixture below so iteration 2 of the chain-tools loop hits this branch instead of re-emitting.",
+      "_comment": "Chain tools \u2014 follow-up after all 3 tools ran. Anchored on whichever of the 3 chain toolCallIds appears last in the request (LangGraph's ToolNode preserves tool_calls order). MUST come before the toolCalls-emitting fixture below so iteration 2 of the chain-tools loop hits this branch instead of re-emitting.",
       "match": {
         "userMessage": "Chain a few tools in this single turn",
         "toolCallId": "call_trcc_chain_roll_001",
         "context": "ms-agent-dotnet"
       },
       "response": {
-        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
+        "content": "Done \u2014 Tokyo is sunny, three flights found, and the d20 came up 11."
       }
     },
     {
@@ -102,7 +102,7 @@
         "context": "ms-agent-dotnet"
       },
       "response": {
-        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
+        "content": "Done \u2014 Tokyo is sunny, three flights found, and the d20 came up 11."
       }
     },
     {
@@ -112,11 +112,11 @@
         "context": "ms-agent-dotnet"
       },
       "response": {
-        "content": "Done — Tokyo is sunny, three flights found, and the d20 came up 11."
+        "content": "Done \u2014 Tokyo is sunny, three flights found, and the d20 came up 11."
       }
     },
     {
-      "_comment": "Chain tools — emit 3 tool calls in one assistant turn (get_weather Tokyo + search_flights SFO->Tokyo + roll_d20=11). No turnIndex/hasToolResult gate: in multi-pill demo sessions prior clicks leave tool results AND additional user turns in the thread; the toolCallId fixtures above eat iteration 2 via last-message tool_call_id gating.",
+      "_comment": "Chain tools \u2014 emit 3 tool calls in one assistant turn (get_weather Tokyo + search_flights SFO->Tokyo + roll_d20=11). No turnIndex/hasToolResult gate: in multi-pill demo sessions prior clicks leave tool results AND additional user turns in the thread; the toolCallId fixtures above eat iteration 2 via last-message tool_call_id gating.",
       "match": {
         "userMessage": "Chain a few tools in this single turn",
         "context": "ms-agent-dotnet"
@@ -142,18 +142,18 @@
       }
     },
     {
-      "_comment": "Weather in SF — follow-up content after get_weather tool ran. MUST come before the tool-emitting fixture below (first-match-wins) so iteration 2 of the loop hits this branch instead of re-emitting. toolCallId chain keeps the fixture stateless across multi-pill thread history.",
+      "_comment": "Weather in SF \u2014 follow-up content after get_weather tool ran. MUST come before the tool-emitting fixture below (first-match-wins) so iteration 2 of the loop hits this branch instead of re-emitting. toolCallId chain keeps the fixture stateless across multi-pill thread history.",
       "match": {
         "userMessage": "What's the weather in San Francisco?",
         "toolCallId": "call_trcc_weather_sf_001",
         "context": "ms-agent-dotnet"
       },
       "response": {
-        "content": "San Francisco is currently 68°F and sunny with light winds — rendered through the custom wildcard catchall."
+        "content": "San Francisco is currently 68\u00b0F and sunny with light winds \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "Weather in SF — first turn: emit get_weather tool call with location=San Francisco. The wildcard renderer paints [data-testid='custom-wildcard-card'][data-tool-name='get_weather'] with args containing 'San Francisco'.",
+      "_comment": "Weather in SF \u2014 first turn: emit get_weather tool call with location=San Francisco. The wildcard renderer paints [data-testid='custom-wildcard-card'][data-tool-name='get_weather'] with args containing 'San Francisco'.",
       "match": {
         "userMessage": "What's the weather in San Francisco?",
         "context": "ms-agent-dotnet"
@@ -169,18 +169,18 @@
       }
     },
     {
-      "_comment": "Find flights — follow-up content after search_flights ran. MUST come BEFORE the first-leg fixture below — the matcher is first-match-wins, and the second leg is uniquely identified by `toolCallId` (last message is a tool with this id), so it cannot accidentally swallow the first-leg request (whose last message is the user prompt). The result block of the wildcard card surfaces the tool execution JSON (which already contains 'United', 'Delta', 'JetBlue' from the Python backend); this narration is just to terminate the agent loop.",
+      "_comment": "Find flights \u2014 follow-up content after search_flights ran. MUST come BEFORE the first-leg fixture below \u2014 the matcher is first-match-wins, and the second leg is uniquely identified by `toolCallId` (last message is a tool with this id), so it cannot accidentally swallow the first-leg request (whose last message is the user prompt). The result block of the wildcard card surfaces the tool execution JSON (which already contains 'United', 'Delta', 'JetBlue' from the Python backend); this narration is just to terminate the agent loop.",
       "match": {
         "userMessage": "Find flights from SFO to JFK.",
         "toolCallId": "call_trcc_flights_sfo_jfk_001",
         "context": "ms-agent-dotnet"
       },
       "response": {
-        "content": "Three flights from SFO to JFK — United UA231 at 08:15 ($348), Delta DL412 at 11:20 ($312), and JetBlue B6722 at 17:05 ($289)."
+        "content": "Three flights from SFO to JFK \u2014 United UA231 at 08:15 ($348), Delta DL412 at 11:20 ($312), and JetBlue B6722 at 17:05 ($289)."
       }
     },
     {
-      "_comment": "Find flights — first turn: emit search_flights tool call (SFO -> JFK). Backend executes and returns the 3-flight result list; the wildcard renderer surfaces 'United'/'Delta'/'JetBlue' in the result block.",
+      "_comment": "Find flights \u2014 first turn: emit search_flights tool call (SFO -> JFK). Backend executes and returns the 3-flight result list; the wildcard renderer surfaces 'United'/'Delta'/'JetBlue' in the result block.",
       "match": {
         "userMessage": "Find flights from SFO to JFK.",
         "context": "ms-agent-dotnet"
@@ -196,7 +196,7 @@
       }
     },
     {
-      "_comment": "Roll a d20 — exactly 5 sequential roll_d20 calls returning [7, 14, 3, 19, 20]. Chained by toolCallId so the sequence is stateless across thread history. Specific-toolCallId fixtures MUST come before the userMessage-only fixture below; first-match-wins. The 5th roll has value=20 so the result block of the 5th card surfaces \"value\":20.",
+      "_comment": "Roll a d20 \u2014 exactly 5 sequential roll_d20 calls returning [7, 14, 3, 19, 20]. Chained by toolCallId so the sequence is stateless across thread history. Specific-toolCallId fixtures MUST come before the userMessage-only fixture below; first-match-wins. The 5th roll has value=20 so the result block of the 5th card surfaces \"value\":20.",
       "match": {
         "userMessage": "Roll a 20-sided die.",
         "toolCallId": "call_trcc_d20_seq_001",
@@ -267,11 +267,11 @@
         "context": "ms-agent-dotnet"
       },
       "response": {
-        "content": "Rolled the d20 five times — landed on 20 on the final roll."
+        "content": "Rolled the d20 five times \u2014 landed on 20 on the final roll."
       }
     },
     {
-      "_comment": "First roll. Matches the initial user prompt (no prior d20 tool result in this chain yet). Comes after the toolCallId-chained fixtures above so iterations 2-6 of the loop hit those first. The multi-pill sequential e2e test clicks 'Find flights' first which leaves prior turns in the thread, so a new 'Roll a 20-sided die.' user message is no longer at turnIndex 0 — keep this fixture turnIndex-less. The toolCallId-chained fixtures still take precedence for iterations 2-6 because their last-message gate (role=tool with the chained id) only matches mid-chain — this fixture only matches when last-message.role=user.",
+      "_comment": "First roll. Matches the initial user prompt (no prior d20 tool result in this chain yet). Comes after the toolCallId-chained fixtures above so iterations 2-6 of the loop hit those first. The multi-pill sequential e2e test clicks 'Find flights' first which leaves prior turns in the thread, so a new 'Roll a 20-sided die.' user message is no longer at turnIndex 0 \u2014 keep this fixture turnIndex-less. The toolCallId-chained fixtures still take precedence for iterations 2-6 because their last-message gate (role=tool with the chained id) only matches mid-chain \u2014 this fixture only matches when last-message.role=user.",
       "match": {
         "userMessage": "Roll a 20-sided die.",
         "context": "ms-agent-dotnet"

--- a/showcase/aimock/d6/ms-agent-dotnet/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/ms-agent-dotnet/tool-rendering-custom-catchall.json
@@ -21,7 +21,6 @@
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo (first turn). Emits get_weather tool call. The custom wildcard renderer fires for this tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_weather'].",
       "match": {
         "userMessage": "Forecast Tokyo through the wildcard renderer",
-        "toolName": "get_weather",
         "context": "ms-agent-dotnet"
       },
       "response": {
@@ -32,17 +31,6 @@
             "arguments": "{\"location\":\"Tokyo\"}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo fallback when no get_weather tool registered.",
-      "match": {
-        "userMessage": "Forecast Tokyo through the wildcard renderer",
-        "turnIndex": 0,
-        "context": "ms-agent-dotnet"
-      },
-      "response": {
-        "content": "The weather in Tokyo is currently 22\u00b0C with partly cloudy skies."
       }
     },
     {
@@ -60,7 +48,6 @@
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price (second turn). Emits get_stock_price tool call. The custom wildcard renderer fires for this DIFFERENT tool and renders [data-testid='custom-wildcard-card'][data-tool-name='get_stock_price']. The cross-tool assertion verifies both tool names rendered through the same testid.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
-        "toolName": "get_stock_price",
         "context": "ms-agent-dotnet"
       },
       "response": {
@@ -71,17 +58,6 @@
             "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
           }
         ]
-      }
-    },
-    {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL fallback when no get_stock_price tool registered.",
-      "match": {
-        "userMessage": "Quote AAPL through the wildcard renderer",
-        "turnIndex": 0,
-        "context": "ms-agent-dotnet"
-      },
-      "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
       }
     },
     {

--- a/showcase/aimock/d6/ms-agent-python/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/ms-agent-python/tool-rendering-custom-catchall.json
@@ -41,7 +41,7 @@
         "context": "ms-agent-python"
       },
       "response": {
-        "content": "AAPL is trading at $189.42, up 1.27% on the day \u2014 rendered through the custom wildcard catchall."
+        "content": "AAPL is trading at $338.37, down 2.96% on the day \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
@@ -55,7 +55,7 @@
           {
             "id": "call_d5_get_stock_price_001",
             "name": "get_stock_price",
-            "arguments": "{\"ticker\":\"AAPL\"}"
+            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
           }
         ]
       }

--- a/showcase/aimock/d6/ms-agent-python/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/ms-agent-python/tool-rendering-custom-catchall.json
@@ -45,10 +45,9 @@
       }
     },
     {
-      "_comment": "custom-catchall turn 2: AAPL stock price \u2014 emit get_stock_price tool call. The custom wildcard renderer catches this as the second tool through the same testid.",
+      "_comment": "custom-catchall turn 2: AAPL stock price \u2014 emit get_stock_price tool call. The custom wildcard renderer catches this as the second tool through the same testid. No hasToolResult gate (the Tokyo tool result from turn 1 makes hasToolResult permanently true here); the toolCallId narration fixture above wins after the stock tool result arrives.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
-        "hasToolResult": false,
         "context": "ms-agent-python"
       },
       "response": {

--- a/showcase/aimock/d6/ms-agent-python/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/ms-agent-python/tool-rendering-custom-catchall.json
@@ -8,18 +8,18 @@
     {
       "_comment": "custom-catchall turn 1: weather in Tokyo \u2014 follow-up content after get_weather tool ran. MUST come before tool-emitting fixture (first-match-wins).",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d5_get_weather_001",
         "context": "ms-agent-python"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy."
+        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
       "_comment": "custom-catchall turn 1: weather in Tokyo \u2014 emit get_weather tool call. The custom wildcard renderer will catch this since there is no per-tool renderer registered.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "hasToolResult": false,
         "context": "ms-agent-python"
       },
@@ -36,18 +36,18 @@
     {
       "_comment": "custom-catchall turn 2: AAPL stock price \u2014 follow-up content after get_stock_price tool ran. MUST come before tool-emitting fixture.",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d5_get_stock_price_001",
         "context": "ms-agent-python"
       },
       "response": {
-        "content": "AAPL is trading at $189.42, up 1.27% on the day."
+        "content": "AAPL is trading at $189.42, up 1.27% on the day \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
       "_comment": "custom-catchall turn 2: AAPL stock price \u2014 emit get_stock_price tool call. The custom wildcard renderer catches this as the second tool through the same testid.",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "hasToolResult": false,
         "context": "ms-agent-python"
       },

--- a/showcase/aimock/d6/pydantic-ai/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/pydantic-ai/tool-rendering-custom-catchall.json
@@ -41,7 +41,7 @@
         "context": "pydantic-ai"
       },
       "response": {
-        "content": "AAPL is trading at $189.42, up 1.27% on the day \u2014 rendered through the custom wildcard catchall."
+        "content": "AAPL is trading at $338.37, down 2.96% on the day \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
@@ -55,7 +55,7 @@
           {
             "id": "call_d5_get_stock_price_001",
             "name": "get_stock_price",
-            "arguments": "{\"ticker\":\"AAPL\"}"
+            "arguments": "{\"ticker\":\"AAPL\",\"price_usd\":338.37,\"change_pct\":-2.96}"
           }
         ]
       }

--- a/showcase/aimock/d6/pydantic-ai/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/pydantic-ai/tool-rendering-custom-catchall.json
@@ -8,18 +8,18 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo follow-up after get_weather ran. Keyed on toolCallId so it fires after iteration 1. Must come BEFORE the tool-emitting fixture.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d5_get_weather_001",
         "context": "pydantic-ai"
       },
       "response": {
-        "content": "Tokyo is 22\u00b0C and partly cloudy."
+        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
       "_comment": "tool-rendering-custom-catchall \u2014 weather in Tokyo first leg: emit get_weather tool call. Driven by the probe's first prompt.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "hasToolResult": false,
         "context": "pydantic-ai"
       },
@@ -36,18 +36,18 @@
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price follow-up after get_stock_price ran. Keyed on toolCallId.",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d5_get_stock_price_001",
         "context": "pydantic-ai"
       },
       "response": {
-        "content": "AAPL is trading at $189.42, up 1.27% on the day."
+        "content": "AAPL is trading at $189.42, up 1.27% on the day \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
       "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price first leg: emit get_stock_price tool call. Driven by the probe's second prompt.",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "hasToolResult": false,
         "context": "pydantic-ai"
       },

--- a/showcase/aimock/d6/pydantic-ai/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/pydantic-ai/tool-rendering-custom-catchall.json
@@ -45,10 +45,9 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price first leg: emit get_stock_price tool call. Driven by the probe's second prompt.",
+      "_comment": "tool-rendering-custom-catchall \u2014 AAPL stock price first leg: emit get_stock_price tool call. Driven by the probe's second prompt. No hasToolResult gate (the Tokyo tool result from the first prompt makes hasToolResult permanently true here); the toolCallId narration fixture above wins after the stock tool result arrives.",
       "match": {
         "userMessage": "Quote AAPL through the wildcard renderer",
-        "hasToolResult": false,
         "context": "pydantic-ai"
       },
       "response": {

--- a/showcase/aimock/d6/spring-ai/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/spring-ai/tool-rendering-custom-catchall.json
@@ -6,20 +6,20 @@
   },
   "fixtures": [
     {
-      "_comment": "custom-catchall turn 1 follow-up — after get_weather tool result. Must come before the tool-emitting fixture. Keyed on the actual probe prompt 'weather in Tokyo' (d5-tool-rendering-custom-catchall.ts PROMPT_TOOL_PAIRS[0]); the old key 'check Tokyo weather forecast' never matched anything the probe sends.",
+      "_comment": "custom-catchall turn 1 follow-up \u2014 after get_weather tool result. Must come before the tool-emitting fixture. Keyed on the actual probe prompt 'weather in Tokyo' (d5-tool-rendering-custom-catchall.ts PROMPT_TOOL_PAIRS[0]); the old key 'check Tokyo weather forecast' never matched anything the probe sends.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d5_get_weather_001",
         "context": "spring-ai"
       },
       "response": {
-        "content": "Tokyo is 22°C and partly cloudy."
+        "content": "Tokyo is 22\u00b0C and partly cloudy \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "custom-catchall turn 1 — emit get_weather tool call. The custom wildcard renderer fires for any tool. toolName-gated so agents without get_weather still fall through to tool-rendering.json's content-only fallback; hasToolResult:false keeps this off the post-tool leg.",
+      "_comment": "custom-catchall turn 1 \u2014 emit get_weather tool call. The custom wildcard renderer fires for any tool. toolName-gated so agents without get_weather still fall through to tool-rendering.json's content-only fallback; hasToolResult:false keeps this off the post-tool leg.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolName": "get_weather",
         "hasToolResult": false,
         "context": "spring-ai"
@@ -35,20 +35,20 @@
       }
     },
     {
-      "_comment": "custom-catchall turn 2 follow-up — after get_stock_price tool result. Must come before the tool-emitting fixture.",
+      "_comment": "custom-catchall turn 2 follow-up \u2014 after get_stock_price tool result. Must come before the tool-emitting fixture.",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d5_get_stock_price_cc_001",
         "context": "spring-ai"
       },
       "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
+        "content": "AAPL is trading at $338.37, down 2.96% on the day \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "custom-catchall turn 2 — emit get_stock_price tool call. Both turns render through the same custom-wildcard-card testid with different data-tool-name values. The old hasToolResult:false gate could never match turn 2: turn 1's get_weather tool result is still in the thread (hasToolResult is a whole-thread check), so the request fell through to no-match -> backend RuntimeException -> RUN_ERROR. Deliberately NO turnIndex/hasToolResult gate: spring-ai's MessageListFilter reshapes prior-turn messages, making both counts unreliable (a turnIndex:2 gate also failed live). Loop safety comes from ordering — the toolCallId-gated follow-up above matches the post-tool leg first. This file loads before tool-rendering.json, so this also absorbs that demo's turnIndex:0 AAPL pill leg; that is benign-equivalent (same get_stock_price name, same ticker/price_usd/change_pct argument shape, near-identical follow-up content).",
+      "_comment": "custom-catchall turn 2 \u2014 emit get_stock_price tool call. Both turns render through the same custom-wildcard-card testid with different data-tool-name values. The old hasToolResult:false gate could never match turn 2: turn 1's get_weather tool result is still in the thread (hasToolResult is a whole-thread check), so the request fell through to no-match -> backend RuntimeException -> RUN_ERROR. Deliberately NO turnIndex/hasToolResult gate: spring-ai's MessageListFilter reshapes prior-turn messages, making both counts unreliable (a turnIndex:2 gate also failed live). Loop safety comes from ordering \u2014 the toolCallId-gated follow-up above matches the post-tool leg first. This file loads before tool-rendering.json, so this also absorbs that demo's turnIndex:0 AAPL pill leg; that is benign-equivalent (same get_stock_price name, same ticker/price_usd/change_pct argument shape, near-identical follow-up content).",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolName": "get_stock_price",
         "context": "spring-ai"
       },

--- a/showcase/aimock/d6/spring-ai/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/spring-ai/tool-rendering-custom-catchall.json
@@ -17,11 +17,10 @@
       }
     },
     {
-      "_comment": "custom-catchall turn 1 \u2014 emit get_weather tool call. The custom wildcard renderer fires for any tool. toolName-gated so agents without get_weather still fall through to tool-rendering.json's content-only fallback; hasToolResult:false keeps this off the post-tool leg.",
+      "_comment": "custom-catchall turn 1 \u2014 emit get_weather tool call. The custom wildcard renderer fires for any tool. toolName-gated so agents without get_weather still fall through to tool-rendering.json's content-only fallback. No hasToolResult gate (LGP-gold parity): the toolCallId-gated follow-up above matches the post-tool leg first via first-match-wins ordering.",
       "match": {
         "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolName": "get_weather",
-        "hasToolResult": false,
         "context": "spring-ai"
       },
       "response": {

--- a/showcase/aimock/d6/strands/tool-rendering-custom-catchall.json
+++ b/showcase/aimock/d6/strands/tool-rendering-custom-catchall.json
@@ -8,20 +8,20 @@
   },
   "fixtures": [
     {
-      "_comment": "tool-rendering-custom-catchall — weather follow-up after tool result. MUST come before the tool-emitting fixture (first-match-wins).",
+      "_comment": "tool-rendering-custom-catchall \u2014 weather follow-up after tool result. MUST come before the tool-emitting fixture (first-match-wins).",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "toolCallId": "call_d6_custom_catchall_weather_001",
         "context": "strands"
       },
       "response": {
-        "content": "Tokyo is 22°C and partly cloudy with a gentle easterly breeze."
+        "content": "Tokyo is 22\u00b0C and partly cloudy with a gentle easterly breeze \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall — 'weather in Tokyo' first turn. Emits get_weather tool call. The custom wildcard renderer fires for ANY tool the integration didn't register a per-tool renderer for, rendering [data-testid='custom-wildcard-card'][data-tool-name='get_weather']. Matches on userMessage+context alone; toolCallId narration above wins after the tool result arrives.",
+      "_comment": "tool-rendering-custom-catchall \u2014 'weather in Tokyo' first turn. Emits get_weather tool call. The custom wildcard renderer fires for ANY tool the integration didn't register a per-tool renderer for, rendering [data-testid='custom-wildcard-card'][data-tool-name='get_weather']. Matches on userMessage+context alone; toolCallId narration above wins after the tool result arrives.",
       "match": {
-        "userMessage": "forecast for Tokyo",
+        "userMessage": "Forecast Tokyo through the wildcard renderer",
         "context": "strands"
       },
       "response": {
@@ -35,20 +35,20 @@
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall — stock follow-up after tool result. MUST come before the tool-emitting fixture.",
+      "_comment": "tool-rendering-custom-catchall \u2014 stock follow-up after tool result. MUST come before the tool-emitting fixture.",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "toolCallId": "call_d6_custom_catchall_stock_001",
         "context": "strands"
       },
       "response": {
-        "content": "AAPL is trading at $338.37, down 2.96% on the day."
+        "content": "AAPL is trading at $338.37, down 2.96% on the day \u2014 rendered through the custom wildcard catchall."
       }
     },
     {
-      "_comment": "tool-rendering-custom-catchall — 'AAPL stock price' second turn. Emits get_stock_price tool call. The custom wildcard renderer fires again with [data-tool-name='get_stock_price']. The cross-tool assertion verifies BOTH tool names rendered through the same custom-wildcard-card testid. No hasToolResult gate (the Tokyo tool result from turn 1 makes hasToolResult permanently true).",
+      "_comment": "tool-rendering-custom-catchall \u2014 'AAPL stock price' second turn. Emits get_stock_price tool call. The custom wildcard renderer fires again with [data-tool-name='get_stock_price']. The cross-tool assertion verifies BOTH tool names rendered through the same custom-wildcard-card testid. No hasToolResult gate (the Tokyo tool result from turn 1 makes hasToolResult permanently true).",
       "match": {
-        "userMessage": "current price of AAPL",
+        "userMessage": "Quote AAPL through the wildcard renderer",
         "context": "strands"
       },
       "response": {

--- a/showcase/bin/showcase
+++ b/showcase/bin/showcase
@@ -96,18 +96,43 @@ cmd_up() {
   fi
 
   info "Launching fleet topology: control-plane + ${pool_count} worker(s) + PocketBase + demos + aimock (HARNESS_POOL_COUNT=${pool_count})"
-  # Scope `--build` to the targeted slug(s) when provided. Without a positional
-  # service filter, `up -d --build` rebuilds EVERY service in every active
-  # profile (infra + slug profiles), which serializes BuildKit and stalls
-  # concurrent `--isolate` runs (issue #5495, A21). When no slugs are given
-  # (infra-only bring-up), the blanket `--build` is preserved so first-time
-  # bootstrap still builds whatever infra services are missing.
+  # Two-call strategy to preserve A21's BuildKit-contention fix (target-only
+  # rebuild) WITHOUT regressing infra startup that A21 inadvertently dropped
+  # (A21b, issue #5495).
+  #
+  # docker compose semantics: positional service names after `up` restrict
+  # WHICH services start to the named ones + their `depends_on` chain — not
+  # just which ones get `--build`-rebuilt. So a single
+  # `up -d --build <slug>` only brings up the slug + its depends_on (aimock),
+  # leaving the rest of the infra profile (pocketbase/dashboard/harness/
+  # harness-pool-worker) down. Under `--isolate` with a sibling stack on the
+  # same host ports, health checks then cross onto foreign containers and
+  # cells silently misroute → 0.0s red.
+  #
+  # Fix: when slugs are present, emit TWO compose calls:
+  #   1. <profiles> up -d (no --build, no positional services) — start all
+  #      services in the active profiles using cached images.
+  #   2. <profiles> up -d --build <slug...> — force-rebuild ONLY the named
+  #      services and ensure they're up. Other services from call (1) are
+  #      no-ops.
+  # When no slugs are present (infra-only bring-up), keep the single blanket
+  # `--build` call so first-time bootstrap still builds missing images.
   #
   # bash 3.2 (macOS default) errors on `${arr[@]}` for an EMPTY array under
   # `set -u`; the `${arr[@]+...}` guard expands to nothing when unset/empty.
-  $compose_cmd --profile infra ${profile_args[@]+"${profile_args[@]}"} up -d --build \
-    --scale harness-pool-worker="$pool_count" ${passthrough_args[@]+"${passthrough_args[@]}"} \
-    ${build_targets[@]+"${build_targets[@]}"}
+  if [[ ${#build_targets[@]} -gt 0 ]]; then
+    # Call 1: bring up ALL services in active profiles, no build.
+    $compose_cmd --profile infra ${profile_args[@]+"${profile_args[@]}"} up -d \
+      --scale harness-pool-worker="$pool_count" ${passthrough_args[@]+"${passthrough_args[@]}"}
+    # Call 2: rebuild ONLY the targeted slug(s) and ensure they're up.
+    $compose_cmd --profile infra ${profile_args[@]+"${profile_args[@]}"} up -d --build \
+      --scale harness-pool-worker="$pool_count" ${passthrough_args[@]+"${passthrough_args[@]}"} \
+      "${build_targets[@]}"
+  else
+    # Infra-only: single call with blanket --build for first-time bootstrap.
+    $compose_cmd --profile infra up -d --build \
+      --scale harness-pool-worker="$pool_count" ${passthrough_args[@]+"${passthrough_args[@]}"}
+  fi
 }
 
 cmd_down() {

--- a/showcase/bin/showcase
+++ b/showcase/bin/showcase
@@ -67,12 +67,14 @@ cmd_up() {
   local pool_count="${HARNESS_POOL_COUNT:-1}"
   export HARNESS_POOL_COUNT="$pool_count"
 
-  # Split args: bare slugs → `--profile <slug>`; flags (-*) → pass through.
-  # `--dev` is intercepted (not passed to compose): it layers the dev overlay
-  # (docker-compose.dev.yml) which bind-mounts integration source + overrides
-  # the run command to a hot-reload entrypoint — fast iteration without an
-  # image rebuild. The built-image mode (no --dev) stays the faithful default.
+  # Split args: bare slugs → `--profile <slug>` + build target; flags (-*) →
+  # pass through. `--dev` is intercepted (not passed to compose): it layers
+  # the dev overlay (docker-compose.dev.yml) which bind-mounts integration
+  # source + overrides the run command to a hot-reload entrypoint — fast
+  # iteration without an image rebuild. The built-image mode (no --dev) stays
+  # the faithful default.
   local profile_args=()
+  local build_targets=()
   local passthrough_args=()
   local dev_mode=false
   local arg
@@ -83,6 +85,7 @@ cmd_up() {
       passthrough_args+=("$arg")
     else
       profile_args+=(--profile "$arg")
+      build_targets+=("$arg")
     fi
   done
 
@@ -93,10 +96,18 @@ cmd_up() {
   fi
 
   info "Launching fleet topology: control-plane + ${pool_count} worker(s) + PocketBase + demos + aimock (HARNESS_POOL_COUNT=${pool_count})"
+  # Scope `--build` to the targeted slug(s) when provided. Without a positional
+  # service filter, `up -d --build` rebuilds EVERY service in every active
+  # profile (infra + slug profiles), which serializes BuildKit and stalls
+  # concurrent `--isolate` runs (issue #5495, A21). When no slugs are given
+  # (infra-only bring-up), the blanket `--build` is preserved so first-time
+  # bootstrap still builds whatever infra services are missing.
+  #
   # bash 3.2 (macOS default) errors on `${arr[@]}` for an EMPTY array under
   # `set -u`; the `${arr[@]+...}` guard expands to nothing when unset/empty.
   $compose_cmd --profile infra ${profile_args[@]+"${profile_args[@]}"} up -d --build \
-    --scale harness-pool-worker="$pool_count" ${passthrough_args[@]+"${passthrough_args[@]}"}
+    --scale harness-pool-worker="$pool_count" ${passthrough_args[@]+"${passthrough_args[@]}"} \
+    ${build_targets[@]+"${build_targets[@]}"}
 }
 
 cmd_down() {

--- a/showcase/harness/src/cli/control-plane-run.test.ts
+++ b/showcase/harness/src/cli/control-plane-run.test.ts
@@ -60,9 +60,10 @@ const {
   createFleetQueueClientMock: vi.fn(() => ({}) as unknown),
   createE2eDeepEnumMock: vi.fn(() => async () => []),
   createServiceEnumMock: vi.fn(() => async () => []),
-  demosForSlugMock: vi.fn(
-    (slug: string): string[] => [`${slug}-demo-a`, `${slug}-demo-b`],
-  ),
+  demosForSlugMock: vi.fn((slug: string): string[] => [
+    `${slug}-demo-a`,
+    `${slug}-demo-b`,
+  ]),
 }));
 
 vi.mock("../fleet/control-plane/job-producer.js", () => ({

--- a/showcase/harness/src/cli/control-plane-run.test.ts
+++ b/showcase/harness/src/cli/control-plane-run.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Unit tests for the cli/control-plane-run module — A18's per-demo scoping
+ * helpers (`buildLocalServicesJson`, `expectedKeys`, `dedupeScopes`) and the
+ * `runViaControlPlane` orchestrator's error-surfacing behavior.
+ *
+ * The heavy fleet/queue/pb modules are mocked at import time so we can
+ * exercise `runViaControlPlane`'s deduplication threading, scope-label error
+ * messages, and partial-enqueue failure handling WITHOUT spinning up real
+ * PocketBase / queue infrastructure.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { LocalConfig } from "./config.js";
+import type { TestTarget } from "./targets.js";
+import type { Logger } from "../types/index.js";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — every dependency that opens a socket / shells out / reaches
+// for the disk is replaced with a vi.fn we can introspect from the tests.
+// ---------------------------------------------------------------------------
+const {
+  tickResultRef,
+  createJobProducerMock,
+  createPbClientMock,
+  createJobClaimClientMock,
+  createFleetQueueClientMock,
+  createE2eDeepEnumMock,
+  createServiceEnumMock,
+  demosForSlugMock,
+} = vi.hoisted(() => ({
+  // A mutable ref the producer mock returns from `tick()` so per-test we can
+  // simulate enqueue success / partial failure / total failure.
+  tickResultRef: {
+    current: {
+      runId: "test-run-1",
+      enqueued: 1,
+      enqueueFailures: 0,
+      truncatedByStop: 0,
+      skippedForBacklog: 0,
+      backlogGateFailedOpen: 0,
+      sweptExpired: false,
+      sweepFailed: false,
+      reclaimed: 0,
+      enumerateFailed: false,
+    } as {
+      runId: string;
+      enqueued: number;
+      enqueueFailures: number;
+      truncatedByStop: number;
+      skippedForBacklog: number;
+      backlogGateFailedOpen: number;
+      sweptExpired: boolean;
+      sweepFailed: boolean;
+      reclaimed: number;
+      enumerateFailed: boolean;
+    },
+  },
+  createJobProducerMock: vi.fn(),
+  createPbClientMock: vi.fn(() => ({}) as unknown),
+  createJobClaimClientMock: vi.fn(() => ({}) as unknown),
+  createFleetQueueClientMock: vi.fn(() => ({}) as unknown),
+  createE2eDeepEnumMock: vi.fn(() => async () => []),
+  createServiceEnumMock: vi.fn(() => async () => []),
+  demosForSlugMock: vi.fn(
+    (slug: string): string[] => [`${slug}-demo-a`, `${slug}-demo-b`],
+  ),
+}));
+
+vi.mock("../fleet/control-plane/job-producer.js", () => ({
+  createJobProducer: createJobProducerMock,
+}));
+vi.mock("../storage/pb-client.js", () => ({
+  createPbClient: createPbClientMock,
+}));
+vi.mock("../fleet/job-claim.js", () => ({
+  createJobClaimClient: createJobClaimClientMock,
+}));
+vi.mock("../fleet/queue-client.js", () => ({
+  createFleetQueueClient: createFleetQueueClientMock,
+}));
+vi.mock("../fleet/control-plane/catalog-enumerator.js", () => ({
+  createE2eDeepServiceEnumerator: createE2eDeepEnumMock,
+  createServiceEnumerator: createServiceEnumMock,
+  D6_DRIVER_KIND: "d6",
+}));
+vi.mock("../probes/discovery/railway-services.js", () => ({
+  railwayServicesSource: () => async () => ({ ok: true, items: [] }),
+}));
+
+// `demosForSlug` reads the manifest from disk — mock so tests don't need a
+// real integration tree on disk.
+vi.mock("./targets.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./targets.js")>("./targets.js");
+  return {
+    ...actual,
+    demosForSlug: (slug: string, _config: LocalConfig) =>
+      demosForSlugMock(slug),
+  };
+});
+
+import {
+  buildLocalServicesJson,
+  expectedKeys,
+  dedupeScopes,
+  runViaControlPlane,
+  type SlugScope,
+} from "./control-plane-run.js";
+
+const SILENT_LOGGER: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+const STUB_CONFIG: LocalConfig = {
+  showcaseDir: "/tmp/showcase",
+  composeFile: "/tmp/docker-compose.local.yml",
+  localPorts: {},
+  pocketbase: {
+    url: "http://localhost:8090",
+    email: "admin@example.com",
+    password: "showcase-local-dev",
+  },
+  aimockUrl: "http://localhost:4010",
+  dashboardUrl: "http://localhost:3200",
+  dashboardPort: 3200,
+};
+
+// Replace process.env.LOCAL_SERVICES_JSON across tests so `buildLocalServicesJson`
+// always falls through to the synthesis branch.
+const origEnv = { ...process.env };
+beforeEach(() => {
+  delete process.env.LOCAL_SERVICES_JSON;
+  createJobProducerMock.mockReset();
+  createJobProducerMock.mockReturnValue({
+    start: vi.fn(),
+    stop: vi.fn(async () => {}),
+    tick: vi.fn(async () => tickResultRef.current),
+  });
+  // Reset the tick payload to the default (single successful enqueue).
+  tickResultRef.current = {
+    runId: "test-run-1",
+    enqueued: 1,
+    enqueueFailures: 0,
+    truncatedByStop: 0,
+    skippedForBacklog: 0,
+    backlogGateFailedOpen: 0,
+    sweptExpired: false,
+    sweepFailed: false,
+    reclaimed: 0,
+    enumerateFailed: false,
+  };
+});
+afterEach(() => {
+  // Restore env between tests so a stray set doesn't bleed across.
+  process.env = { ...origEnv };
+});
+
+// ---------------------------------------------------------------------------
+// buildLocalServicesJson
+// ---------------------------------------------------------------------------
+describe("buildLocalServicesJson", () => {
+  it("d5 no demo → demos:[agentic-chat] regardless of manifest", () => {
+    const scopes: SlugScope[] = [{ slug: "langgraph-python" }];
+    const out = JSON.parse(
+      buildLocalServicesJson(scopes, "d5", STUB_CONFIG),
+    ) as Array<{ name: string; publicUrl: string; demos: string[] }>;
+    expect(out).toEqual([
+      {
+        name: "showcase-langgraph-python",
+        publicUrl: "http://langgraph-python:10000",
+        demos: ["agentic-chat"],
+      },
+    ]);
+  });
+
+  it("d5 with demo → demos:[<demo>] (overrides the level default)", () => {
+    const scopes: SlugScope[] = [
+      { slug: "built-in-agent", demo: "tool-rendering" },
+    ];
+    const out = JSON.parse(
+      buildLocalServicesJson(scopes, "d5", STUB_CONFIG),
+    ) as Array<{ demos: string[] }>;
+    expect(out[0].demos).toEqual(["tool-rendering"]);
+  });
+
+  it("d6 no demo → demos:[full demo set] via demosForSlug", () => {
+    demosForSlugMock.mockReturnValueOnce(["agentic-chat", "tool-rendering"]);
+    const scopes: SlugScope[] = [{ slug: "langgraph-python" }];
+    const out = JSON.parse(
+      buildLocalServicesJson(scopes, "d6", STUB_CONFIG),
+    ) as Array<{ demos: string[] }>;
+    expect(out[0].demos).toEqual(["agentic-chat", "tool-rendering"]);
+  });
+
+  it("d6 with demo → demos:[<demo>] (per-demo scoping)", () => {
+    const scopes: SlugScope[] = [
+      { slug: "built-in-agent", demo: "tool-rendering" },
+    ];
+    const out = JSON.parse(
+      buildLocalServicesJson(scopes, "d6", STUB_CONFIG),
+    ) as Array<{ demos: string[] }>;
+    expect(out[0].demos).toEqual(["tool-rendering"]);
+  });
+
+  it("honors LOCAL_SERVICES_JSON env override verbatim", () => {
+    process.env.LOCAL_SERVICES_JSON = '[{"name":"showcase-from-env"}]';
+    const scopes: SlugScope[] = [{ slug: "ignored" }];
+    expect(buildLocalServicesJson(scopes, "d5", STUB_CONFIG)).toBe(
+      '[{"name":"showcase-from-env"}]',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// expectedKeys
+// ---------------------------------------------------------------------------
+describe("expectedKeys", () => {
+  it("d5 no demo → aggregate + agentic-chat side row", () => {
+    expect(expectedKeys("d5", "langgraph-python")).toEqual([
+      "d5-single-pill-e2e:langgraph-python",
+      "d5:langgraph-python/agentic-chat",
+    ]);
+  });
+
+  it("d5 with demo → per-featureType side row only", () => {
+    // `tool-rendering` maps 1:1 to feature `tool-rendering`.
+    expect(expectedKeys("d5", "built-in-agent", "tool-rendering")).toEqual([
+      "d5:built-in-agent/tool-rendering",
+    ]);
+  });
+
+  it("d6 no demo → per-service aggregate", () => {
+    expect(expectedKeys("d6", "langgraph-python")).toEqual([
+      "d6:langgraph-python",
+    ]);
+  });
+
+  it("d6 with demo → per-featureType side row (not the aggregate)", () => {
+    expect(expectedKeys("d6", "built-in-agent", "tool-rendering")).toEqual([
+      "d6:built-in-agent/tool-rendering",
+    ]);
+  });
+
+  it("with demo → expands one demo into multiple featureTypes when the registry splits it", () => {
+    // `beautiful-chat` maps to 5 featureTypes in REGISTRY_TO_D5.
+    const keys = expectedKeys("d6", "langgraph-python", "beautiful-chat");
+    expect(keys).toContain("d6:langgraph-python/beautiful-chat-toggle-theme");
+    expect(keys).toContain("d6:langgraph-python/beautiful-chat-pie-chart");
+    expect(keys.length).toBe(5);
+  });
+
+  it("throws on unmappable demo so the run cannot hang to timeout", () => {
+    expect(() =>
+      expectedKeys("d5", "langgraph-python", "no-such-demo"),
+    ).toThrow(/does not map to any D5 featureType/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dedupeScopes
+// ---------------------------------------------------------------------------
+describe("dedupeScopes", () => {
+  it("collapses repeated bare-slug targets into one scope", () => {
+    const targets: TestTarget[] = [
+      { slug: "a", level: "d5" },
+      { slug: "a", level: "d5" },
+    ];
+    expect(dedupeScopes(targets)).toEqual([{ slug: "a", demo: undefined }]);
+  });
+
+  it("keeps the bare slug AND a per-demo scope for the same slug distinct", () => {
+    const targets: TestTarget[] = [
+      { slug: "built-in-agent", level: "d6" },
+      { slug: "built-in-agent", demo: "tool-rendering", level: "d6" },
+    ];
+    const scopes = dedupeScopes(targets);
+    expect(scopes).toEqual([
+      { slug: "built-in-agent", demo: undefined },
+      { slug: "built-in-agent", demo: "tool-rendering" },
+    ]);
+  });
+
+  it("collapses repeated identical (slug, demo) pairs", () => {
+    const targets: TestTarget[] = [
+      { slug: "x", demo: "d", level: "d6" },
+      { slug: "x", demo: "d", level: "d6" },
+    ];
+    expect(dedupeScopes(targets)).toEqual([{ slug: "x", demo: "d" }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runViaControlPlane — error surfacing
+// ---------------------------------------------------------------------------
+describe("runViaControlPlane error surfacing", () => {
+  it("0 enqueued → throws with the per-demo scope label, not the bare slug", async () => {
+    tickResultRef.current = { ...tickResultRef.current, enqueued: 0 };
+    const targets: TestTarget[] = [
+      { slug: "built-in-agent", demo: "tool-rendering", level: "d5" },
+    ];
+    await expect(
+      runViaControlPlane(
+        targets,
+        { level: "d5", timeoutMs: 1, pollIntervalMs: 1 },
+        STUB_CONFIG,
+        SILENT_LOGGER,
+      ),
+    ).rejects.toThrow(/built-in-agent:tool-rendering/);
+  });
+
+  it("0 enqueued with empty targets → guards the double-space gap (uses placeholder label)", async () => {
+    tickResultRef.current = { ...tickResultRef.current, enqueued: 0 };
+    await expect(
+      runViaControlPlane(
+        [],
+        { level: "d5", timeoutMs: 1, pollIntervalMs: 1 },
+        STUB_CONFIG,
+        SILENT_LOGGER,
+      ),
+    ).rejects.toThrow(/\(no targets\)/);
+  });
+
+  it("partial enqueue failure → aborts before poll (does not silently proceed)", async () => {
+    tickResultRef.current = {
+      ...tickResultRef.current,
+      enqueued: 1,
+      enqueueFailures: 2,
+    };
+    const targets: TestTarget[] = [{ slug: "a", level: "d5" }];
+    await expect(
+      runViaControlPlane(
+        targets,
+        { level: "d5", timeoutMs: 1, pollIntervalMs: 1 },
+        STUB_CONFIG,
+        SILENT_LOGGER,
+      ),
+    ).rejects.toThrow(/2 failure\(s\)/);
+  });
+});

--- a/showcase/harness/src/cli/control-plane-run.ts
+++ b/showcase/harness/src/cli/control-plane-run.ts
@@ -118,10 +118,37 @@ function resolvePbCreds(config: LocalConfig): {
  * `<slug>:<demo>` (explicit per-demo scoping); when absent, the level's
  * default semantics apply (d5 = representative `agentic-chat`; d6 = full
  * demo set).
+ *
+ * Exported for unit-test coverage (`control-plane-run.test.ts`) — internal
+ * callers should keep using {@link runViaControlPlane}.
  */
-interface SlugScope {
+export interface SlugScope {
   slug: string;
   demo?: string;
+}
+
+/**
+ * Deduplicate `(slug, demo)` pairs from the operator-supplied targets. An
+ * explicit `slug:demo` is kept distinct from a bare slug for the same slug,
+ * so `built-in-agent built-in-agent:tool-rendering` enqueues both the
+ * default representative AND the scoped per-demo job. Mirrors the pre-A18
+ * `[...new Set(slugs)]` shape for the bare-slug case.
+ *
+ * Exported for unit-test coverage.
+ */
+export function dedupeScopes(targets: TestTarget[]): SlugScope[] {
+  const scopes: SlugScope[] = [];
+  const seen = new Set<string>();
+  for (const t of targets) {
+    // Use NUL escape as separator so a slug containing the separator
+    // could never collide; identifiers are ASCII so this is unreachable
+    // in practice but cheap insurance against future slug shapes.
+    const key = `${t.slug}\x00${t.demo ?? ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    scopes.push({ slug: t.slug, demo: t.demo });
+  }
+  return scopes;
 }
 
 /**
@@ -141,7 +168,7 @@ interface SlugScope {
  *     like-staging overlay; d6 needs the slug's full demo set so the
  *     all-pills driver exercises every cell.
  */
-function buildLocalServicesJson(
+export function buildLocalServicesJson(
   scopes: SlugScope[],
   level: ControlPlaneLevel,
   config: LocalConfig,
@@ -228,7 +255,7 @@ function buildEnumerator(
  *     feature outside the closed D5 set), throw — the run would otherwise
  *     enqueue but never produce a matching side row, hanging until timeout.
  */
-function expectedKeys(
+export function expectedKeys(
   level: ControlPlaneLevel,
   slug: string,
   demo?: string,
@@ -385,19 +412,18 @@ export async function runViaControlPlane(
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
 
-  // Deduplicate (slug, demo) pairs. The default (demo === undefined) path
-  // collapses repeated bare slugs to one record (matching the pre-A18
-  // `[...new Set(slugs)]`); an explicit `slug:demo` keeps the demo distinct,
-  // so a run like `built-in-agent built-in-agent:tool-rendering` enqueues
-  // both the default representative and the scoped per-demo job.
-  const scopes: SlugScope[] = [];
-  const seen = new Set<string>();
-  for (const t of targets) {
-    const key = `${t.slug} ${t.demo ?? ""}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    scopes.push({ slug: t.slug, demo: t.demo });
-  }
+  // Deduplicate (slug, demo) pairs via the standalone helper (see
+  // `dedupeScopes`): default-scoped repeats collapse to one record; an
+  // explicit `slug:demo` is kept distinct from the bare slug for the same
+  // slug, so `built-in-agent built-in-agent:tool-rendering` enqueues both
+  // the default representative and the scoped per-demo job.
+  const scopes = dedupeScopes(targets);
+  // The slug-only set is intentionally re-deduped here even though
+  // `dedupeScopes` already collapses bare-slug repeats: a caller passing
+  // multiple per-demo scopes for the same slug (e.g. `slug:a slug:b`) is
+  // preserved by `dedupeScopes` but should reduce to a single discovery
+  // filter entry - `buildEnumerator`'s narrow wants the slug SET, not
+  // the (slug, demo) set.
   const slugs = [...new Set(scopes.map((s) => s.slug))];
 
   const creds = resolvePbCreds(config);
@@ -457,9 +483,11 @@ export async function runViaControlPlane(
   // -- Fire one operator-triggered tick → enqueue onto probe_jobs -----------
   producer.start();
   let enqueued = 0;
+  let enqueueFailures = 0;
   try {
     const tick = await producer.tick({ triggered: true });
     enqueued = tick.enqueued;
+    enqueueFailures = tick.enqueueFailures ?? 0;
     console.log(
       `  \x1b[2mEnqueued ${tick.enqueued} job(s) (runId ${tick.runId})\x1b[0m`,
     );
@@ -472,9 +500,26 @@ export async function runViaControlPlane(
     await producer.stop();
   }
 
+  // Use the demo-aware label so a per-demo zero-enqueue surfaces the qualifier
+  // (`<slug>:<demo>`) instead of just the slug; guard the empty-targets edge
+  // case so the error doesn't render with a double-space gap.
+  const failureLabel = scopeLabel.length > 0 ? scopeLabel : "(no targets)";
   if (enqueued === 0) {
     throw new Error(
-      `control-plane enqueued 0 jobs for ${slugs.join(", ")} — check LOCAL_SERVICES_JSON / discovery filter`,
+      `control-plane enqueued 0 jobs for ${failureLabel} — check LOCAL_SERVICES_JSON / discovery filter`,
+    );
+  }
+
+  // Finding 3: partial enqueue failures used to be logged-only, so the run
+  // would proceed and silently report green if the surviving jobs happened to
+  // pass. Treat any enqueue failure as fatal — the operator asked for N jobs
+  // and only M < N reached the queue; the remainder will never report a cell
+  // and the poll loop would hang to timeout (or, worse on partial coverage,
+  // mask a real failure).
+  if (enqueueFailures > 0) {
+    throw new Error(
+      `control-plane enqueue had ${enqueueFailures} failure(s) for ${failureLabel} — ` +
+        `partial enqueue would mask missing cells; aborting before poll`,
     );
   }
 

--- a/showcase/harness/src/cli/control-plane-run.ts
+++ b/showcase/harness/src/cli/control-plane-run.ts
@@ -50,6 +50,7 @@ import type { LocalConfig } from "./config.js";
 import type { TestTarget } from "./targets.js";
 import type { TerminalResult } from "./results.js";
 import { demosForSlug } from "./targets.js";
+import { demosToFeatureTypes } from "../probes/helpers/d5-feature-mapping.js";
 
 /** The two fleet levels this runner can drive. */
 export type ControlPlaneLevel = "d5" | "d6";
@@ -112,17 +113,36 @@ function resolvePbCreds(config: LocalConfig): {
 }
 
 /**
+ * A per-slug scoping record used by {@link buildLocalServicesJson} and
+ * {@link expectedKeys}. `demo` is set ONLY when the caller typed
+ * `<slug>:<demo>` (explicit per-demo scoping); when absent, the level's
+ * default semantics apply (d5 = representative `agentic-chat`; d6 = full
+ * demo set).
+ */
+interface SlugScope {
+  slug: string;
+  demo?: string;
+}
+
+/**
  * Build the `LOCAL_SERVICES_JSON` discovery roster the enumerator reads. If
  * the env already supplies it (the control-plane container's value), reuse it
  * verbatim; otherwise synthesize the canonical local record per requested
  * slug, matching the compose overlay shape exactly.
  *
- * `level` controls the demo set: d5 ("take-one") only needs the representative
- * demo (`agentic-chat`), mirroring the like-staging overlay; d6 needs the
- * slug's full demo set so the all-pills driver exercises every cell.
+ * Per-slug demo scoping:
+ *   - When the caller explicitly typed `<slug>:<demo>`, this synthesizes
+ *     `demos: [<demo>]` regardless of level — the worker will route only
+ *     that demo through the d5/d6 driver, mirroring the legacy direct path's
+ *     `target.demo` semantics (`buildDeepInputs`/`buildFullInputs` in
+ *     `targets.ts`).
+ *   - When `demo` is absent, level controls the demo set: d5 ("take-one")
+ *     only needs the representative demo (`agentic-chat`), mirroring the
+ *     like-staging overlay; d6 needs the slug's full demo set so the
+ *     all-pills driver exercises every cell.
  */
 function buildLocalServicesJson(
-  slugs: string[],
+  scopes: SlugScope[],
   level: ControlPlaneLevel,
   config: LocalConfig,
 ): string {
@@ -130,10 +150,14 @@ function buildLocalServicesJson(
   if (fromEnv && fromEnv.trim().length > 0) {
     return fromEnv;
   }
-  const records = slugs.map((slug) => ({
+  const records = scopes.map(({ slug, demo }) => ({
     name: `showcase-${slug}`,
     publicUrl: `http://${slug}:10000`,
-    demos: level === "d5" ? ["agentic-chat"] : demosForSlug(slug, config),
+    demos: demo
+      ? [demo]
+      : level === "d5"
+        ? ["agentic-chat"]
+        : demosForSlug(slug, config),
   }));
   return JSON.stringify(records);
 }
@@ -183,12 +207,43 @@ function buildEnumerator(
 
 /**
  * The dashboard status keys a run is expected to terminate, derived from the
- * level + slug. d5 emits the aggregate `d5-single-pill-e2e:<slug>` plus the
- * per-feature `d5:<slug>/<featureType>` side rows; the representative demo is
- * `agentic-chat`, so we wait on `d5:<slug>/agentic-chat`. d6 emits the
- * per-service `d6:<slug>` cell.
+ * level + slug (+ optional demo scoping).
+ *
+ * Default (`demo` absent) semantics — UNCHANGED from the pre-A18 behavior:
+ *   - d5 emits the aggregate `d5-single-pill-e2e:<slug>` plus the per-feature
+ *     `d5:<slug>/<featureType>` side rows; the representative demo is
+ *     `agentic-chat`, so we wait on `d5:<slug>/agentic-chat`.
+ *   - d6 emits the per-service aggregate `d6:<slug>` cell.
+ *
+ * Per-demo scoping (`demo` set — operator typed `<slug>:<demo>`):
+ *   - The worker emits side rows keyed by FEATURE TYPE, not demo ID. We
+ *     translate the demo ID into its featureType(s) via the same
+ *     `REGISTRY_TO_D5` mapping the d6 driver uses (`demosToFeatureTypes`),
+ *     and wait on each resulting `<level>:<slug>/<featureType>` side row.
+ *     The default-scope key (e.g. `d5:<slug>/agentic-chat` or the d6
+ *     aggregate) is INTENTIONALLY OMITTED — the run is scoped to the demo,
+ *     so substituting agentic-chat or waiting on the full-sweep aggregate
+ *     would be the same false-positive bug A18 fixes.
+ *   - If the demo ID does not map to any featureType (e.g. a registry
+ *     feature outside the closed D5 set), throw — the run would otherwise
+ *     enqueue but never produce a matching side row, hanging until timeout.
  */
-function expectedKeys(level: ControlPlaneLevel, slug: string): string[] {
+function expectedKeys(
+  level: ControlPlaneLevel,
+  slug: string,
+  demo?: string,
+): string[] {
+  if (demo) {
+    const featureTypes = demosToFeatureTypes([demo]);
+    if (featureTypes.length === 0) {
+      throw new Error(
+        `control-plane ${level}: demo "${demo}" does not map to any D5 featureType ` +
+          `(no entry in REGISTRY_TO_D5). The worker would not emit a matching ` +
+          `side row — refusing to enqueue a run that cannot terminate.`,
+      );
+    }
+    return featureTypes.map((ft) => `${level}:${slug}/${ft}`);
+  }
   if (level === "d5") {
     return [`d5-single-pill-e2e:${slug}`, `d5:${slug}/agentic-chat`];
   }
@@ -329,24 +384,44 @@ export async function runViaControlPlane(
   const { level } = options;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-  const slugs = [...new Set(targets.map((t) => t.slug))];
+
+  // Deduplicate (slug, demo) pairs. The default (demo === undefined) path
+  // collapses repeated bare slugs to one record (matching the pre-A18
+  // `[...new Set(slugs)]`); an explicit `slug:demo` keeps the demo distinct,
+  // so a run like `built-in-agent built-in-agent:tool-rendering` enqueues
+  // both the default representative and the scoped per-demo job.
+  const scopes: SlugScope[] = [];
+  const seen = new Set<string>();
+  for (const t of targets) {
+    const key = `${t.slug} ${t.demo ?? ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    scopes.push({ slug: t.slug, demo: t.demo });
+  }
+  const slugs = [...new Set(scopes.map((s) => s.slug))];
 
   const creds = resolvePbCreds(config);
 
   // Build the discovery env the enumerator reads — the SAME static-injection
   // seam staging's control-plane container uses.
-  const localServicesJson = buildLocalServicesJson(slugs, level, config);
+  const localServicesJson = buildLocalServicesJson(scopes, level, config);
   const env: Record<string, string | undefined> = {
     ...process.env,
     LOCAL_SERVICES_JSON: localServicesJson,
   };
 
+  // Display the per-scope label so an operator sees the demo qualifier
+  // (`<slug>:<demo>`) on the CLI banner, mirroring how the legacy direct path
+  // labels a per-demo run.
+  const scopeLabel = scopes
+    .map((s) => (s.demo ? `${s.slug}:${s.demo}` : s.slug))
+    .join(", ");
   console.log(
-    `\n  \x1b[36mControl-plane ${level.toUpperCase()} run:\x1b[0m ${slugs.join(", ")}`,
+    `\n  \x1b[36mControl-plane ${level.toUpperCase()} run:\x1b[0m ${scopeLabel}`,
   );
   logger.info("cli.control-plane.start", {
     level,
-    slugs,
+    scopes,
     pbUrl: creds.url,
   });
 
@@ -404,7 +479,11 @@ export async function runViaControlPlane(
   }
 
   // -- Wait for the worker fleet to drain + the aggregator to write cells ---
-  const allKeys = slugs.flatMap((slug) => expectedKeys(level, slug));
+  // Iterate scopes (NOT bare slugs) so per-demo runs wait on per-cell keys
+  // (`<level>:<slug>/<featureType>`) instead of the default-scope key.
+  const allKeys = scopes.flatMap(({ slug, demo }) =>
+    expectedKeys(level, slug, demo),
+  );
   console.log(
     `  \x1b[2mWaiting for worker fleet to produce cells: ${allKeys.join(", ")}\x1b[0m`,
   );

--- a/showcase/harness/src/cli/lifecycle.test.ts
+++ b/showcase/harness/src/cli/lifecycle.test.ts
@@ -101,7 +101,7 @@ describe("rebuild() — targeted slugs", () => {
   });
 });
 
-describe("up() — scoped --build (A21)", () => {
+describe("up() — two-call infra-start + scoped --build (A21b)", () => {
   // Stub healthCheck transitively by making fetch unreachable but compose succeed.
   // up() throws on unhealthy services, so we mock the health-check path via
   // network fetch failing — but the IMPORTANT assertion is the compose argv
@@ -118,13 +118,20 @@ describe("up() — scoped --build (A21)", () => {
   });
 
   /**
-   * The compose argv shape we want:
-   *   [--profile infra --profile <slug>... up -d --build <slug>...]
+   * The two-call shape we want when slugs are provided:
+   *   Call 1: [--profile infra --profile <slug>... up -d]
+   *     (no --build, no positional services — brings up ALL services in
+   *     active profiles using cached images)
+   *   Call 2: [--profile infra --profile <slug>... up -d --build <slug>...]
+   *     (rebuilds ONLY the named services; others are no-ops)
    *
-   * Without slug positionals AFTER `--build`, compose rebuilds EVERY service
-   * in every active profile (infra + slug profiles). With slug positionals,
-   * compose rebuilds ONLY the named services and uses cached images for
-   * everything else — that is the A21 fix.
+   * Background: docker compose positional service names after `up` restrict
+   * WHICH services start (not just which get rebuilt). A21's single-call
+   * `up -d --build <slug>` therefore prevented infra services without an
+   * explicit `depends_on` from the slug from starting at all — health checks
+   * crossed onto sibling stack containers and cells silently misrouted (0.0s
+   * red). A21b splits into two calls to keep target-only rebuild while
+   * restoring the full infra startup.
    *
    * `--profile <name>` arguments do NOT scope the build target on their own;
    * docker compose only treats positional args after `up` as the service
@@ -151,39 +158,66 @@ describe("up() — scoped --build (A21)", () => {
     return out;
   }
 
-  it("scopes --build to the targeted slug (does NOT rebuild infra services)", async () => {
+  /** Pull the `--profile <name>` set from a compose argv. */
+  function profilesIn(argv: string[]): string[] {
+    const out: string[] = [];
+    for (let i = 0; i < argv.length - 1; i++) {
+      if (argv[i] === "--profile") out.push(argv[i + 1]);
+    }
+    return out.sort();
+  }
+
+  it("emits TWO compose calls when slugs provided: infra-up then target-build", async () => {
     await up(["langgraph-python"]);
 
-    const upCall = composeCalls().find(
-      (argv) => argv.includes("up") && argv.includes("--build"),
-    );
-    expect(upCall).toBeDefined();
-    // The slug must appear as a positional AFTER `up` so compose treats it as
-    // the build target filter — not merely as a `--profile <slug>` argument
-    // (profiles don't scope --build).
-    expect(positionalsAfterUp(upCall!)).toEqual(["langgraph-python"]);
+    const upCalls = composeCalls().filter((argv) => argv.includes("up"));
+    expect(upCalls.length).toBe(2);
+
+    // Call 1: no --build, no positional services.
+    const [call1, call2] = upCalls;
+    expect(call1).not.toContain("--build");
+    expect(positionalsAfterUp(call1)).toEqual([]);
+
+    // Call 2: --build present, slug as positional after `up`.
+    expect(call2).toContain("--build");
+    expect(positionalsAfterUp(call2)).toEqual(["langgraph-python"]);
   });
 
-  it("with no slugs (infra-only), --build remains blanket (first-time bootstrap)", async () => {
+  it("with no slugs (infra-only), emits a SINGLE blanket --build call", async () => {
     await up([]);
 
-    const upCall = composeCalls().find(
-      (argv) => argv.includes("up") && argv.includes("--build"),
-    );
-    expect(upCall).toBeDefined();
+    const upCalls = composeCalls().filter((argv) => argv.includes("up"));
+    expect(upCalls.length).toBe(1);
+    const [call] = upCalls;
+    expect(call).toContain("--build");
     // No slug positional after `up`: compose builds whatever is missing in the
     // infra profile (cached images skipped, fresh ones built). This preserves
     // first-time bootstrap behaviour when no infra images exist yet.
-    expect(positionalsAfterUp(upCall!)).toEqual([]);
+    expect(positionalsAfterUp(call)).toEqual([]);
   });
 
-  it("multi-slug: scopes --build to ALL targeted slugs", async () => {
+  it("multi-slug: scopes --build to ALL targeted slugs (call 2)", async () => {
     await up(["a", "b"]);
 
-    const upCall = composeCalls().find(
-      (argv) => argv.includes("up") && argv.includes("--build"),
-    );
-    expect(upCall).toBeDefined();
-    expect(positionalsAfterUp(upCall!).sort()).toEqual(["a", "b"]);
+    const upCalls = composeCalls().filter((argv) => argv.includes("up"));
+    expect(upCalls.length).toBe(2);
+    const [, call2] = upCalls;
+    expect(call2).toContain("--build");
+    expect(positionalsAfterUp(call2).sort()).toEqual(["a", "b"]);
+  });
+
+  it("both calls use IDENTICAL profile flags (no profile drift)", async () => {
+    await up(["langgraph-python"]);
+
+    const upCalls = composeCalls().filter((argv) => argv.includes("up"));
+    expect(upCalls.length).toBe(2);
+    const [call1, call2] = upCalls;
+    // Same --profile set in both calls so services across calls agree on
+    // which profiles are "active" — drift here would mean call 1 brings up a
+    // service that call 2 doesn't know about (or vice versa).
+    expect(profilesIn(call1)).toEqual(profilesIn(call2));
+    // And the slug's profile is actually present.
+    expect(profilesIn(call1)).toContain("infra");
+    expect(profilesIn(call1)).toContain("langgraph-python");
   });
 });

--- a/showcase/harness/src/cli/lifecycle.test.ts
+++ b/showcase/harness/src/cli/lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks — vi.hoisted() runs before vi.mock factories so the spies
@@ -19,15 +19,23 @@ vi.mock("node:child_process", () => ({
 
 vi.mock("node:fs", () => {
   // stageSharedModules() short-circuits when INTEGRATIONS_DIR is absent.
+  // readFileSync is consulted by loadPortsFile() to map slugs → host ports
+  // for health checks; provide stub ports for any slug the up() tests use.
   const api = {
     existsSync: (...args: unknown[]) => existsSyncMock(...args),
     readdirSync: vi.fn(() => []),
-    readFileSync: vi.fn(() => "{}"),
+    readFileSync: vi.fn(() =>
+      JSON.stringify({
+        "langgraph-python": 10001,
+        a: 10002,
+        b: 10003,
+      }),
+    ),
   };
   return { default: api, ...api };
 });
 
-import { rebuild } from "./lifecycle.js";
+import { rebuild, up } from "./lifecycle.js";
 
 /** Pull out the compose argv (after the `-f <file>` prefix) for each call. */
 function composeCalls(): string[][] {
@@ -90,5 +98,92 @@ describe("rebuild() — targeted slugs", () => {
     );
     expect(recreateCall).toContain("a");
     expect(recreateCall).toContain("b");
+  });
+});
+
+describe("up() — scoped --build (A21)", () => {
+  // Stub healthCheck transitively by making fetch unreachable but compose succeed.
+  // up() throws on unhealthy services, so we mock the health-check path via
+  // network fetch failing — but the IMPORTANT assertion is the compose argv
+  // captured by composeCalls() BEFORE health checks run.
+  // To avoid up() throwing before we can assert, mock fetch globally to resolve OK.
+  const _origFetch = globalThis.fetch;
+  beforeEach(() => {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, status: 200 } as Response),
+    ) as unknown as typeof fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = _origFetch;
+  });
+
+  /**
+   * The compose argv shape we want:
+   *   [--profile infra --profile <slug>... up -d --build <slug>...]
+   *
+   * Without slug positionals AFTER `--build`, compose rebuilds EVERY service
+   * in every active profile (infra + slug profiles). With slug positionals,
+   * compose rebuilds ONLY the named services and uses cached images for
+   * everything else — that is the A21 fix.
+   *
+   * `--profile <name>` arguments do NOT scope the build target on their own;
+   * docker compose only treats positional args after `up` as the service
+   * filter for `--build`. So the test asserts the slug appears AFTER the `up`
+   * keyword (as a positional), not merely anywhere in the argv.
+   */
+  function positionalsAfterUp(argv: string[]): string[] {
+    const upIdx = argv.indexOf("up");
+    if (upIdx < 0) return [];
+    const out: string[] = [];
+    for (let i = upIdx + 1; i < argv.length; i++) {
+      const tok = argv[i];
+      // Skip flags and their values. `-d`/`--build` take no value; `--progress`
+      // takes a value. Keep it simple — the only flags we emit here are
+      // `-d`, `--build`, `--progress plain`.
+      if (tok === "-d" || tok === "--build") continue;
+      if (tok === "--progress") {
+        i++; // skip the value
+        continue;
+      }
+      if (tok.startsWith("-")) continue;
+      out.push(tok);
+    }
+    return out;
+  }
+
+  it("scopes --build to the targeted slug (does NOT rebuild infra services)", async () => {
+    await up(["langgraph-python"]);
+
+    const upCall = composeCalls().find(
+      (argv) => argv.includes("up") && argv.includes("--build"),
+    );
+    expect(upCall).toBeDefined();
+    // The slug must appear as a positional AFTER `up` so compose treats it as
+    // the build target filter — not merely as a `--profile <slug>` argument
+    // (profiles don't scope --build).
+    expect(positionalsAfterUp(upCall!)).toEqual(["langgraph-python"]);
+  });
+
+  it("with no slugs (infra-only), --build remains blanket (first-time bootstrap)", async () => {
+    await up([]);
+
+    const upCall = composeCalls().find(
+      (argv) => argv.includes("up") && argv.includes("--build"),
+    );
+    expect(upCall).toBeDefined();
+    // No slug positional after `up`: compose builds whatever is missing in the
+    // infra profile (cached images skipped, fresh ones built). This preserves
+    // first-time bootstrap behaviour when no infra images exist yet.
+    expect(positionalsAfterUp(upCall!)).toEqual([]);
+  });
+
+  it("multi-slug: scopes --build to ALL targeted slugs", async () => {
+    await up(["a", "b"]);
+
+    const upCall = composeCalls().find(
+      (argv) => argv.includes("up") && argv.includes("--build"),
+    );
+    expect(upCall).toBeDefined();
+    expect(positionalsAfterUp(upCall!).sort()).toEqual(["a", "b"]);
   });
 });

--- a/showcase/harness/src/cli/lifecycle.ts
+++ b/showcase/harness/src/cli/lifecycle.ts
@@ -294,14 +294,7 @@ export async function up(
       // Call 1: bring up all services (no build, cached images).
       compose(...profileArgs, "up", "-d", ...verboseFlag);
       // Call 2: rebuild target slug(s) and ensure they're up.
-      compose(
-        ...profileArgs,
-        "up",
-        "-d",
-        "--build",
-        ...verboseFlag,
-        ...slugs,
-      );
+      compose(...profileArgs, "up", "-d", "--build", ...verboseFlag, ...slugs);
     } else {
       // Infra-only: single call with blanket --build for first-time bootstrap.
       compose(...profileArgs, "up", "-d", "--build", ...verboseFlag);

--- a/showcase/harness/src/cli/lifecycle.ts
+++ b/showcase/harness/src/cli/lifecycle.ts
@@ -265,30 +265,47 @@ export async function up(
     }
 
     const verboseFlag = opts?.verbose ? ["--progress", "plain"] : [];
-    // Scope `--build` to the targeted slug(s) when provided. Without a
-    // positional service filter, `up -d --build` rebuilds EVERY service in
-    // every active profile (infra + slug profiles), which serializes BuildKit
-    // and stalls concurrent `--isolate` runs — slot N's full-stack rebuild
-    // contends with slot M's rebuild on the same daemon (issue #5495, A21).
+    // Two-call strategy to preserve A21's BuildKit-contention fix (target-only
+    // rebuild) WITHOUT regressing the infra startup that A21 inadvertently
+    // dropped (A21b, issue #5495).
     //
-    // With positional slugs after `up`, compose only rebuilds the named
-    // services; everything else uses cached images and falls through to plain
-    // start. First-time bootstrap (no infra images) still works because
-    // compose builds missing images automatically — `--build` only FORCES a
-    // rebuild of services that already have an image. For a forced full
-    // rebuild, callers should use `rebuild()` (the `--rebuild` flag path).
-    const buildTargets = slugs.length > 0 ? slugs : [];
-    const args = [
-      ...profileArgs,
-      "up",
-      "-d",
-      "--build",
-      ...verboseFlag,
-      ...buildTargets,
-    ];
-
+    // docker compose semantics: positional service names after `up` restrict
+    // WHICH services start to the named ones + their `depends_on` chain — not
+    // just which ones get `--build`-rebuilt. A21 passed the target slug as a
+    // positional after `up -d --build`, which (correctly) scoped the rebuild
+    // to the slug but (incorrectly) prevented infra services without an
+    // explicit `depends_on` from the target (pocketbase, dashboard, harness,
+    // harness-pool-worker) from coming up. Under `--isolate` with a sibling
+    // stack holding the same host ports, health checks then crossed onto the
+    // foreign containers and the cell silently misrouted → 0.0s red.
+    //
+    // Fix: split into two calls when slugs is non-empty.
+    //   1. compose <profiles> up -d              — start ALL services in the
+    //      active profiles using cached images. No `--build`, no positional
+    //      services. Brings up the full infra profile + the slug's profile.
+    //   2. compose <profiles> up -d --build <slug...>
+    //      Force-rebuild ONLY the named services and ensure they're up. Other
+    //      services already running from call (1) are no-ops.
+    //
+    // When slugs is empty (infra-only bring-up), keep the single blanket call
+    // so first-time bootstrap still builds whatever infra images are missing.
     log.info("starting services", { slugs: slugs.length ? slugs : ["infra"] });
-    compose(...args);
+    if (slugs.length > 0) {
+      // Call 1: bring up all services (no build, cached images).
+      compose(...profileArgs, "up", "-d", ...verboseFlag);
+      // Call 2: rebuild target slug(s) and ensure they're up.
+      compose(
+        ...profileArgs,
+        "up",
+        "-d",
+        "--build",
+        ...verboseFlag,
+        ...slugs,
+      );
+    } else {
+      // Infra-only: single call with blanket --build for first-time bootstrap.
+      compose(...profileArgs, "up", "-d", "--build", ...verboseFlag);
+    }
 
     // Determine which services to health-check
     const servicesToCheck =

--- a/showcase/harness/src/cli/lifecycle.ts
+++ b/showcase/harness/src/cli/lifecycle.ts
@@ -265,7 +265,27 @@ export async function up(
     }
 
     const verboseFlag = opts?.verbose ? ["--progress", "plain"] : [];
-    const args = [...profileArgs, "up", "-d", "--build", ...verboseFlag];
+    // Scope `--build` to the targeted slug(s) when provided. Without a
+    // positional service filter, `up -d --build` rebuilds EVERY service in
+    // every active profile (infra + slug profiles), which serializes BuildKit
+    // and stalls concurrent `--isolate` runs — slot N's full-stack rebuild
+    // contends with slot M's rebuild on the same daemon (issue #5495, A21).
+    //
+    // With positional slugs after `up`, compose only rebuilds the named
+    // services; everything else uses cached images and falls through to plain
+    // start. First-time bootstrap (no infra images) still works because
+    // compose builds missing images automatically — `--build` only FORCES a
+    // rebuild of services that already have an image. For a forced full
+    // rebuild, callers should use `rebuild()` (the `--rebuild` flag path).
+    const buildTargets = slugs.length > 0 ? slugs : [];
+    const args = [
+      ...profileArgs,
+      "up",
+      "-d",
+      "--build",
+      ...verboseFlag,
+      ...buildTargets,
+    ];
 
     log.info("starting services", { slugs: slugs.length ? slugs : ["infra"] });
     compose(...args);

--- a/showcase/harness/src/cli/lifecycle.ts
+++ b/showcase/harness/src/cli/lifecycle.ts
@@ -290,13 +290,23 @@ export async function up(
     // When slugs is empty (infra-only bring-up), keep the single blanket call
     // so first-time bootstrap still builds whatever infra images are missing.
     log.info("starting services", { slugs: slugs.length ? slugs : ["infra"] });
+    // Track which compose call most recently ran so a downstream health
+    // failure can name the call that touched the unhealthy service. Without
+    // this, an operator seeing "Health check failed for: <slug>" cannot tell
+    // whether infra-up (call 1) crossed onto a foreign container or whether
+    // the target's rebuild (call 2) produced a broken image.
+    let lastComposeCall: string;
     if (slugs.length > 0) {
       // Call 1: bring up all services (no build, cached images).
+      lastComposeCall = "call 1 (infra-up: profiles up -d, no build)";
       compose(...profileArgs, "up", "-d", ...verboseFlag);
       // Call 2: rebuild target slug(s) and ensure they're up.
+      lastComposeCall =
+        "call 2 (target rebuild: profiles up -d --build <slug>...)";
       compose(...profileArgs, "up", "-d", "--build", ...verboseFlag, ...slugs);
     } else {
       // Infra-only: single call with blanket --build for first-time bootstrap.
+      lastComposeCall = "infra-only (profiles up -d --build, no slugs)";
       compose(...profileArgs, "up", "-d", "--build", ...verboseFlag);
     }
 
@@ -313,7 +323,7 @@ export async function up(
 
     if (unhealthy.length > 0) {
       throw new Error(
-        `Health check failed for: ${unhealthy.join(", ")}. Check logs with: showcase logs <slug>`,
+        `Health check failed for: ${unhealthy.join(", ")} after ${lastComposeCall}. Check logs with: showcase logs <slug>`,
       );
     }
 

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-custom-catchall.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-custom-catchall.test.ts
@@ -302,11 +302,10 @@ describe("D5 tool-rendering-custom-catchall — requireContentPhrase branch (reg
         }) as R,
     };
     await expect(
-      mod.assertCustomCatchall(
-        page,
-        ["get_weather", "get_stock_price"],
-        { requireContentPhrase: true, timeoutMs: 30 },
-      ),
+      mod.assertCustomCatchall(page, ["get_weather", "get_stock_price"], {
+        requireContentPhrase: true,
+        timeoutMs: 30,
+      }),
     ).rejects.toThrow(/custom-catchall content phrase/);
   });
 });

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-custom-catchall.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-custom-catchall.test.ts
@@ -24,7 +24,7 @@ describe("D5 tool-rendering-custom-catchall — registration", () => {
 
   it("references the tool-rendering fixture", () => {
     const script = getD5Script("tool-rendering-custom-catchall");
-    expect(script?.fixtureFile).toBe("tool-rendering.json");
+    expect(script?.fixtureFile).toBe("tool-rendering-custom-catchall.json");
   });
 
   it("registers preNavigateRoute pointing at the canonical route", () => {

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-custom-catchall.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-custom-catchall.test.ts
@@ -3,8 +3,8 @@ import {
   D5_REGISTRY,
   __clearD5RegistryForTesting,
   getD5Script,
-  type D5BuildContext,
 } from "../helpers/d5-registry.js";
+import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { Page } from "../helpers/conversation-runner.js";
 
 let scriptModule: typeof import("./d5-tool-rendering-custom-catchall.js");
@@ -52,8 +52,13 @@ describe("D5 tool-rendering-custom-catchall — buildTurns", () => {
     };
     const turns = scriptModule.buildTurns(ctx);
     expect(turns).toHaveLength(2);
-    expect(turns[0]!.input).toBe("forecast for Tokyo");
-    expect(turns[1]!.input).toBe("What's the current price of AAPL?");
+    // LGP-gold disjoint-prompts pattern (supersedes #5465): both
+    // prompts must be unique substrings that no default-catchall
+    // fixture matcher can satisfy. See PROMPT_TOOL_PAIRS comment.
+    expect(turns[0]!.input).toBe(
+      "Forecast Tokyo through the wildcard renderer",
+    );
+    expect(turns[1]!.input).toBe("Quote AAPL through the wildcard renderer");
     expect(typeof turns[0]!.assertions).toBe("function");
     expect(typeof turns[1]!.assertions).toBe("function");
   });
@@ -136,10 +141,15 @@ describe("D5 tool-rendering-custom-catchall — exported constants", () => {
     expect(mod.CUSTOM_CATCHALL_TESTID).toBe("custom-wildcard-card");
     expect(mod.PROMPT_TOOL_PAIRS).toHaveLength(2);
     expect(mod.PROMPT_TOOL_PAIRS[0].tool).toBe("get_weather");
-    expect(mod.PROMPT_TOOL_PAIRS[0].prompt).toBe("forecast for Tokyo");
+    expect(mod.PROMPT_TOOL_PAIRS[0].prompt).toBe(
+      "Forecast Tokyo through the wildcard renderer",
+    );
     expect(mod.PROMPT_TOOL_PAIRS[1].tool).toBe("get_stock_price");
     expect(mod.PROMPT_TOOL_PAIRS[1].prompt).toBe(
-      "What's the current price of AAPL?",
+      "Quote AAPL through the wildcard renderer",
+    );
+    expect(mod.CUSTOM_CATCHALL_CONTENT_PHRASE).toBe(
+      "rendered through the custom wildcard catchall",
     );
   });
 });

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-custom-catchall.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-custom-catchall.test.ts
@@ -153,3 +153,160 @@ describe("D5 tool-rendering-custom-catchall — exported constants", () => {
     );
   });
 });
+
+// Regression test for PR #5495 A11 fix (CR Finding 2). The A11 fix
+// inlined the leak-phrase needle as a JS literal inside the
+// `page.evaluate()` closure body because the `page.evaluate(fn, arg)`
+// second-arg form does NOT propagate the arg into the browser-side
+// closure (empirically verified during A11 RED-GREEN). Without that
+// inline, `customContentPhrasePresent` stays `false` forever and the
+// LGP-gold disjoint-prompts content guard becomes dead code — and
+// because the fake `Page` in `makePageReturning` never executes the
+// closure, reverting the inline-needle fix would NOT be caught by any
+// other test. This test captures the closure source and asserts the
+// inline-needle invariant directly.
+describe("D5 tool-rendering-custom-catchall — inline-needle invariant (regression)", () => {
+  function findEvaluateCallSource(fnSource: string): string {
+    // Locate the `page.evaluate(` call and capture the closure source
+    // we hand to it. We use a substring scan rather than a regex because
+    // the closure body contains characters (parens, braces, quotes)
+    // that would force a full balanced-paren parser to match cleanly.
+    const idx = fnSource.indexOf("page.evaluate(");
+    expect(idx).toBeGreaterThanOrEqual(0);
+    return fnSource.slice(idx);
+  }
+
+  it("probeCustomCatchall inlines the leak phrase as a string literal", async () => {
+    const mod = await import("./d5-tool-rendering-custom-catchall.js");
+    const src = mod.probeCustomCatchall.toString();
+    const evalCall = findEvaluateCallSource(src);
+    // The canonical phrase must appear as a literal inside the closure
+    // body. We assert via the exported constant so a renamed/relocated
+    // constant still tracks correctly.
+    expect(evalCall).toContain(mod.CUSTOM_CATCHALL_CONTENT_PHRASE);
+  });
+
+  it("probeCustomCatchall does NOT pass the needle via a page.evaluate second-arg", async () => {
+    const mod = await import("./d5-tool-rendering-custom-catchall.js");
+    const src = mod.probeCustomCatchall.toString();
+    // The historical broken form declared a parameter on the closure:
+    //   page.evaluate((expectedPhrase?: string) => { ... }, phrase)
+    // The fixed form takes no parameters. Asserting on these patterns
+    // would re-fail immediately if the fix were reverted.
+    expect(src).not.toMatch(/page\.evaluate\(\s*\(\s*expectedPhrase/);
+    expect(src).not.toMatch(/page\.evaluate\(\s*\(\s*expectedLeakPhrase/);
+    // Defensive: the literal needle inside the closure must NOT be
+    // sourced from a captured outer-scope binding (e.g.
+    // `const leakPhrase = CUSTOM_CATCHALL_CONTENT_PHRASE;` outside the
+    // closure followed by passing it as an arg). The arg-form's call
+    // signature was `page.evaluate(fn, leakPhrase)` — assert no second
+    // arg is passed to evaluate.
+    //
+    // The closure used in `probeCustomCatchall` is the LAST `(...) =>`
+    // before the trailing `)` of `page.evaluate(...)`. We match the
+    // tail of the function source to assert the evaluate call closes
+    // with `})` and not `}, <something>)`.
+    const tail = src.slice(-200);
+    // The closure ends with `});` (no second arg) — not `}, x);` or
+    // `}, "...")`.
+    expect(tail).toMatch(/\}\s*\)\s*;?\s*\}?\s*$/);
+    expect(tail).not.toMatch(/\},\s*[A-Za-z_$"]/);
+  });
+});
+
+// Regression test for PR #5495 A7 fix (CR Finding 3). The A7 fix
+// added the `requireContentPhrase` knob to `validateCustomCatchall`
+// (and threaded it through `assertCustomCatchall`). The existing
+// tests omitted the third arg and so always exercised the default
+// `false` branch — the new leak-detection branch was untested. This
+// suite covers the `true` branch end-to-end.
+describe("D5 tool-rendering-custom-catchall — requireContentPhrase branch (regression)", () => {
+  it("passes when both tool names AND the content phrase are present", async () => {
+    const mod = await import("./d5-tool-rendering-custom-catchall.js");
+    const result = mod.validateCustomCatchall(
+      {
+        toolNames: ["get_weather", "get_stock_price"],
+        containerCount: 2,
+        customContentPhrasePresent: true,
+      },
+      ["get_weather", "get_stock_price"],
+      true,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("fails when the content phrase is absent and the flag is true", async () => {
+    const mod = await import("./d5-tool-rendering-custom-catchall.js");
+    const result = mod.validateCustomCatchall(
+      {
+        toolNames: ["get_weather", "get_stock_price"],
+        containerCount: 2,
+        customContentPhrasePresent: false,
+      },
+      ["get_weather", "get_stock_price"],
+      true,
+    );
+    expect(result).not.toBeNull();
+    expect(result).toMatch(/custom-catchall content phrase/);
+    expect(result).toMatch(/leaked default-catchall fixture/);
+    // The canonical phrase must appear in the error message.
+    expect(result).toContain(mod.CUSTOM_CATCHALL_CONTENT_PHRASE);
+  });
+
+  it("fails when customContentPhrasePresent is undefined and flag is true", async () => {
+    const mod = await import("./d5-tool-rendering-custom-catchall.js");
+    // Pre-A7 fixtures predating the field — absence must be treated as
+    // false by the validator (documented behavior).
+    const result = mod.validateCustomCatchall(
+      {
+        toolNames: ["get_weather", "get_stock_price"],
+        containerCount: 2,
+      },
+      ["get_weather", "get_stock_price"],
+      true,
+    );
+    expect(result).not.toBeNull();
+    expect(result).toMatch(/custom-catchall content phrase/);
+  });
+
+  it("passes when phrase absent BUT requireContentPhrase is false (default)", async () => {
+    const mod = await import("./d5-tool-rendering-custom-catchall.js");
+    // Confirms the default-branch behavior is preserved: when the flag
+    // is false, an absent phrase is NOT a failure.
+    const result = mod.validateCustomCatchall(
+      {
+        toolNames: ["get_weather", "get_stock_price"],
+        containerCount: 2,
+        customContentPhrasePresent: false,
+      },
+      ["get_weather", "get_stock_price"],
+      false,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("assertCustomCatchall plumbs requireContentPhrase through to the validator", async () => {
+    const mod = await import("./d5-tool-rendering-custom-catchall.js");
+    // Fake page that returns containers + tool names but NO content
+    // phrase. With `requireContentPhrase: true`, the assert must throw
+    // with the canonical-phrase error message.
+    const page: Page = {
+      waitForSelector: async () => undefined,
+      fill: async () => undefined,
+      press: async () => undefined,
+      evaluate: async <R>(_fn: () => R): Promise<R> =>
+        ({
+          toolNames: ["get_weather", "get_stock_price"],
+          containerCount: 2,
+          customContentPhrasePresent: false,
+        }) as R,
+    };
+    await expect(
+      mod.assertCustomCatchall(
+        page,
+        ["get_weather", "get_stock_price"],
+        { requireContentPhrase: true, timeoutMs: 30 },
+      ),
+    ).rejects.toThrow(/custom-catchall content phrase/);
+  });
+});

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-custom-catchall.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-custom-catchall.ts
@@ -108,24 +108,68 @@ export interface CustomCatchallProbe {
 export async function probeCustomCatchall(
   page: Page,
 ): Promise<CustomCatchallProbe> {
-  const phrase = CUSTOM_CATCHALL_CONTENT_PHRASE;
-  return await page.evaluate((expectedPhrase?: string) => {
-    const needle = expectedPhrase ?? "";
-    const win = globalThis as unknown as {
-      document: {
-        querySelectorAll(sel: string): ArrayLike<{
-          getAttribute(name: string): string | null;
-          textContent: string | null;
-        }>;
-        body: { textContent?: string | null };
-      };
-    };
-    const containers = win.document.querySelectorAll(
+  // ROOT CAUSE (PR #5495 A11): the prior implementation passed the
+  // content phrase into the browser-side closure via the
+  // `page.evaluate(fn, arg)` second-arg form:
+  //
+  //     return await page.evaluate((expectedPhrase?: string) => {
+  //       const needle = expectedPhrase ?? "";
+  //       if (needle) { /* … cascade scan … */ }
+  //       ...
+  //     }, phrase);
+  //
+  // Empirically (verified via in-closure return diagnostics during the
+  // A11 RED-GREEN proof on `langgraph-python:tool-rendering-custom-catchall`),
+  // `expectedPhrase` arrives as `undefined` inside the closure — the arg
+  // is NOT propagated through the harness's compiled `page.evaluate` call
+  // path. With `needle === ""`, the `if (needle)` guard skipped the entire
+  // cascade and `customContentPhrasePresent` stayed `false` forever, even
+  // though `bubble.textContent` / `body.textContent` / `body.innerText`
+  // all contained the canonical phrase at the SAME moment.
+  //
+  // Why this affects ONLY this probe: `findAssistantBubbleAt` and
+  // `readCascadeStateLast` pass a `number` (bubble index) via the same
+  // mechanism and work correctly — verified by the conversation runner's
+  // `settled text` log reading bubble idx=3's prose successfully. The
+  // bubble-index path being green vs the string-arg path being undef
+  // hints at a serialization-layer behavior we did not fully nail down
+  // (Playwright + tsc + the harness build chain). The defensive fix
+  // sidesteps the question entirely by inlining the needle as a JS
+  // literal inside the closure — no `page.evaluate(fn, arg)` second-arg
+  // dependency at all.
+  //
+  // The needle is the canonical content phrase exported above as
+  // `CUSTOM_CATCHALL_CONTENT_PHRASE`. Keep these two in lock-step.
+  return await page.evaluate(() => {
+    const needle = "rendered through the custom wildcard catchall";
+    // Re-establish minimal DOM shape locally — package tsconfig excludes the
+    // `dom` lib. Same pattern used in `findAssistantBubbleAt`.
+    interface DomElement {
+      readonly textContent: string | null;
+      getAttribute(name: string): string | null;
+      querySelector(sel: string): DomElement | null;
+      querySelectorAll(sel: string): DomNodeList;
+    }
+    interface DomNodeList {
+      readonly length: number;
+      item(idx: number): DomElement | null;
+    }
+    const doc = (
+      globalThis as unknown as {
+        document: {
+          querySelectorAll(sel: string): DomNodeList;
+          body: {
+            textContent?: string | null;
+          } | null;
+        };
+      }
+    ).document;
+    const containers = doc.querySelectorAll(
       '[data-testid="custom-wildcard-card"]',
     );
     const names = new Set<string>();
     for (let i = 0; i < containers.length; i++) {
-      const n = containers[i]!.getAttribute("data-tool-name");
+      const n = containers.item(i)?.getAttribute("data-tool-name");
       if (n) names.add(n);
     }
     // Scan the assistant-message bubbles for the custom-catchall content
@@ -140,37 +184,35 @@ export async function probeCustomCatchall(
     // shells that don't carry the canonical `copilot-assistant-message`
     // testid.
     let customContentPhrasePresent = false;
-    if (needle) {
-      const tiers = [
-        '[data-testid="copilot-assistant-message"]',
-        '[role="article"][data-message-role="assistant"]',
-        '[role="article"]:not([data-message-role="user"])',
-        '[data-message-role="assistant"]',
-      ];
-      for (const sel of tiers) {
-        const bubbles = win.document.querySelectorAll(sel);
-        for (let i = 0; i < bubbles.length; i++) {
-          const t = bubbles[i]!.textContent ?? "";
-          if (t.includes(needle)) {
-            customContentPhrasePresent = true;
-            break;
-          }
+    const tiers = [
+      '[data-testid="copilot-assistant-message"]',
+      '[role="article"][data-message-role="assistant"]',
+      '[role="article"]:not([data-message-role="user"])',
+      '[data-message-role="assistant"]',
+    ];
+    for (const sel of tiers) {
+      const bubbles = doc.querySelectorAll(sel);
+      for (let i = 0; i < bubbles.length; i++) {
+        const t = bubbles.item(i)?.textContent ?? "";
+        if (t.includes(needle)) {
+          customContentPhrasePresent = true;
+          break;
         }
-        if (customContentPhrasePresent) break;
       }
-      // Last-resort: scan the document body's textContent (full DOM).
-      if (!customContentPhrasePresent) {
-        const body = win.document.body;
-        const bodyText = (body.textContent ?? "") as string;
-        customContentPhrasePresent = bodyText.includes(needle);
-      }
+      if (customContentPhrasePresent) break;
+    }
+    // Last-resort: scan the document body's textContent (full DOM).
+    if (!customContentPhrasePresent) {
+      const body = doc.body;
+      const bodyText = (body?.textContent ?? "") as string;
+      customContentPhrasePresent = bodyText.includes(needle);
     }
     return {
       toolNames: Array.from(names),
       containerCount: containers.length,
       customContentPhrasePresent,
     };
-  }, phrase);
+  });
 }
 
 /**

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-custom-catchall.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-custom-catchall.ts
@@ -318,7 +318,7 @@ export function preNavigateRoute(): string {
 
 registerD5Script({
   featureTypes: ["tool-rendering-custom-catchall"],
-  fixtureFile: "tool-rendering.json",
+  fixtureFile: "tool-rendering-custom-catchall.json",
   buildTurns,
   preNavigateRoute,
 });

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-custom-catchall.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-custom-catchall.ts
@@ -30,10 +30,8 @@
  * convention.
  */
 
-import {
-  registerD5Script,
-  type D5BuildContext,
-} from "../helpers/d5-registry.js";
+import { registerD5Script } from "../helpers/d5-registry.js";
+import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
 
 /** Testid the custom wildcard component renders for every tool call. */
@@ -47,11 +45,38 @@ export const CUSTOM_CATCHALL_TESTID = "custom-wildcard-card";
  * `get_weather` and `get_stock_price` are the canonical pair used
  * across the tool-rendering family (matches `tool-rendering.json` and
  * `gen-ui-headless-complete.json` patterns).
+ *
+ * **LGP-gold disjoint-prompts pattern** — these prompts MUST stay
+ * disjoint from `d5-tool-rendering-default-catchall.ts`'s prompts so
+ * aimock's `userMessage` substring matcher cannot cross-route a
+ * default-catchall request to a custom-catchall fixture (or vice
+ * versa) regardless of fixture file sort order. Supersedes PR #5465
+ * which attempted to remove the `toolName` discriminator without
+ * adding a replacement (cross-fixture leakage). See
+ * `/tmp/cross-fixture-leak-investigation.md` for the full root-cause
+ * trail.
  */
 export const PROMPT_TOOL_PAIRS = [
-  { prompt: "forecast for Tokyo", tool: "get_weather" },
-  { prompt: "What's the current price of AAPL?", tool: "get_stock_price" },
+  {
+    prompt: "Forecast Tokyo through the wildcard renderer",
+    tool: "get_weather",
+  },
+  {
+    prompt: "Quote AAPL through the wildcard renderer",
+    tool: "get_stock_price",
+  },
 ] as const;
+
+/**
+ * Page text content the custom wildcard renderer's follow-up
+ * fixtures emit. Asserted by the probe so a cross-fixture leak (a
+ * default-catchall fixture servicing a custom-catchall request) is
+ * caught at the content layer — testid-only assertions cannot catch
+ * it because the `[data-testid="custom-wildcard-card"]` wrapper
+ * mounts identically regardless of which file's content arrived.
+ */
+export const CUSTOM_CATCHALL_CONTENT_PHRASE =
+  "rendered through the custom wildcard catchall";
 
 const POLL_TIMEOUT_MS = 15_000;
 const POLL_INTERVAL_MS = 250;
@@ -67,17 +92,32 @@ export interface CustomCatchallProbe {
   toolNames: string[];
   /** Total number of custom-catchall containers in the DOM. */
   containerCount: number;
+  /**
+   * True when at least one assistant message bubble on the page
+   * contains the custom-catchall content phrase
+   * (`CUSTOM_CATCHALL_CONTENT_PHRASE`). False when the wildcard card
+   * mounted but the narrating content came from the WRONG fixture
+   * file (cross-fixture leak — exactly the failure mode that
+   * motivated PR #5465 and its follow-up). Optional so existing
+   * test fixtures predating the field still type-check; absence is
+   * treated as `false` by the validator.
+   */
+  customContentPhrasePresent?: boolean;
 }
 
 export async function probeCustomCatchall(
   page: Page,
 ): Promise<CustomCatchallProbe> {
-  return await page.evaluate(() => {
+  const phrase = CUSTOM_CATCHALL_CONTENT_PHRASE;
+  return await page.evaluate((expectedPhrase?: string) => {
+    const needle = expectedPhrase ?? "";
     const win = globalThis as unknown as {
       document: {
         querySelectorAll(sel: string): ArrayLike<{
           getAttribute(name: string): string | null;
+          textContent: string | null;
         }>;
+        body: { textContent?: string | null };
       };
     };
     const containers = win.document.querySelectorAll(
@@ -88,25 +128,69 @@ export async function probeCustomCatchall(
       const n = containers[i]!.getAttribute("data-tool-name");
       if (n) names.add(n);
     }
+    // Scan the assistant-message bubbles for the custom-catchall content
+    // phrase. Uses `textContent` rather than `body.innerText` because
+    // `innerText` excludes off-viewport text on long chat threads — the
+    // latest narration bubble can be below the visible scrollport and
+    // silently elided. `textContent` returns the full DOM-attached text
+    // regardless of viewport state.
+    //
+    // The selector cascade matches `countAssistantMessages` in
+    // `helpers/assistant-message-count.ts` so probes pick up bubbles for
+    // shells that don't carry the canonical `copilot-assistant-message`
+    // testid.
+    let customContentPhrasePresent = false;
+    if (needle) {
+      const tiers = [
+        '[data-testid="copilot-assistant-message"]',
+        '[role="article"][data-message-role="assistant"]',
+        '[role="article"]:not([data-message-role="user"])',
+        '[data-message-role="assistant"]',
+      ];
+      for (const sel of tiers) {
+        const bubbles = win.document.querySelectorAll(sel);
+        for (let i = 0; i < bubbles.length; i++) {
+          const t = bubbles[i]!.textContent ?? "";
+          if (t.includes(needle)) {
+            customContentPhrasePresent = true;
+            break;
+          }
+        }
+        if (customContentPhrasePresent) break;
+      }
+      // Last-resort: scan the document body's textContent (full DOM).
+      if (!customContentPhrasePresent) {
+        const body = win.document.body;
+        const bodyText = (body.textContent ?? "") as string;
+        customContentPhrasePresent = bodyText.includes(needle);
+      }
+    }
     return {
       toolNames: Array.from(names),
       containerCount: containers.length,
+      customContentPhrasePresent,
     };
-  });
+  }, phrase);
 }
 
 /**
  * Validate that BOTH expected tool names rendered through the SAME
- * custom-catchall testid. Returns null when the cross-tool snapshot
- * holds, or a human-readable error string on the first failing check.
+ * custom-catchall testid AND that the rendered narration came from
+ * the custom-catchall fixture (not a leaked default-catchall fixture).
+ * Returns null when the cross-tool + content snapshot holds, or a
+ * human-readable error string on the first failing check.
  *
  * The checks are ordered from "no rendering at all" → "partial
- * rendering" → "wrong tools rendered" so the operator's first error
- * message is the most informative one.
+ * rendering" → "wrong tools rendered" → "wrong narration content"
+ * so the operator's first error message is the most informative
+ * one. The content check (when `requireContentPhrase` is true) is
+ * the LGP-gold disjoint-prompts guard — it catches a cross-fixture
+ * leak that the testid + tool-name checks structurally cannot.
  */
 export function validateCustomCatchall(
   snap: CustomCatchallProbe,
   expectedToolNames: readonly string[],
+  requireContentPhrase: boolean = false,
 ): string | null {
   if (snap.containerCount === 0) {
     return (
@@ -124,21 +208,43 @@ export function validateCustomCatchall(
       `observed: [${snap.toolNames.join(", ") || "(none)"}]`
     );
   }
+  if (requireContentPhrase && !snap.customContentPhrasePresent) {
+    return (
+      `tool-rendering-custom-catchall: custom wildcard rendered ` +
+      `[${snap.toolNames.join(", ")}] but the page body does not include ` +
+      `the custom-catchall content phrase ${JSON.stringify(CUSTOM_CATCHALL_CONTENT_PHRASE)} — ` +
+      "narration may have come from a leaked default-catchall fixture"
+    );
+  }
   return null;
 }
 
 export async function assertCustomCatchall(
   page: Page,
   expectedToolNames: readonly string[],
-  timeoutMs: number = POLL_TIMEOUT_MS,
+  optionsOrTimeoutMs:
+    | number
+    | { requireContentPhrase?: boolean; timeoutMs?: number } = {},
 ): Promise<void> {
+  // Accept legacy `(page, expected, timeoutMs)` signature alongside the new
+  // options-object form so callers in this repo (e.g. existing tests under
+  // `d5-tool-rendering-custom-catchall.test.ts`) keep compiling.
+  const options =
+    typeof optionsOrTimeoutMs === "number"
+      ? { timeoutMs: optionsOrTimeoutMs }
+      : optionsOrTimeoutMs;
+  const { requireContentPhrase = false, timeoutMs = POLL_TIMEOUT_MS } = options;
   const deadline = Date.now() + timeoutMs;
   let lastError: string | null = null;
   let pollCount = 0;
   while (Date.now() < deadline) {
     const snap = await probeCustomCatchall(page);
     pollCount++;
-    lastError = validateCustomCatchall(snap, expectedToolNames);
+    lastError = validateCustomCatchall(
+      snap,
+      expectedToolNames,
+      requireContentPhrase,
+    );
     if (lastError === null) {
       console.debug(
         "[d5-tool-rendering-custom-catchall] cross-tool signature passed",
@@ -180,8 +286,28 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
     {
       input: PROMPT_TOOL_PAIRS[1].prompt,
       // After the second turn, BOTH tool calls must have rendered
-      // through the same custom-catchall testid.
-      assertions: (page: Page) => assertCustomCatchall(page, allExpected),
+      // through the same custom-catchall testid AND the assistant's
+      // narration content (passed in via `ctx.text` — the turn-scoped
+      // bubble text resolved by the conversation runner's settle path)
+      // must include the custom-catchall content phrase. The narration
+      // content check proves the response came from the custom-catchall
+      // fixture rather than a leaked default-catchall fixture
+      // (LGP-gold disjoint-prompts guard). We use `ctx.text` instead
+      // of a probe-side DOM read so the check is cascade-consistent
+      // with the rest of the harness (turn-indexed, defect-2 safe —
+      // see `d5-gen-ui-custom.ts` for the same pattern).
+      assertions: async (page, ctx) => {
+        await assertCustomCatchall(page, allExpected);
+        const phrase = CUSTOM_CATCHALL_CONTENT_PHRASE;
+        if (!ctx.text.includes(phrase)) {
+          throw new Error(
+            "tool-rendering-custom-catchall: narration content does not " +
+              `include the custom-catchall content phrase ${JSON.stringify(phrase)} — ` +
+              `narration may have come from a leaked default-catchall fixture. ` +
+              `Observed text: ${JSON.stringify(ctx.text.slice(0, 200))}`,
+          );
+        }
+      },
     },
   ];
 }

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-custom-catchall.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-custom-catchall.ts
@@ -297,7 +297,10 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
       // with the rest of the harness (turn-indexed, defect-2 safe —
       // see `d5-gen-ui-custom.ts` for the same pattern).
       assertions: async (page, ctx) => {
-        await assertCustomCatchall(page, allExpected);
+        await assertCustomCatchall(page, allExpected, {
+          requireContentPhrase: true,
+          timeoutMs: POLL_TIMEOUT_MS,
+        });
         const phrase = CUSTOM_CATCHALL_CONTENT_PHRASE;
         if (!ctx.text.includes(phrase)) {
           throw new Error(

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-default-catchall.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-default-catchall.test.ts
@@ -142,3 +142,89 @@ describe("D5 tool-rendering-default-catchall — exported constants", () => {
     expect(mod.STATUS_PILL_TESTID).toBe("copilot-tool-render-status");
   });
 });
+
+// Regression test for PR #5495 A25a fix (CR Finding 1). The default
+// catchall probe historically used the broken
+// `page.evaluate((arg?: string) => { ... }, leakPhrase)` arg-passing
+// pattern. Empirically, `arg` arrives as `undefined` inside the
+// browser-side closure, so `if (needle)` guarded the entire leak-detection
+// cascade as dead code and `customLeakPhrasePresent` stayed `false`
+// forever — making `validateDefaultCatchall`'s leak branch dead code
+// too. The A25a fix mirrors the A11 sibling probe's pattern by
+// inlining the needle as a JS literal in the closure body. This test
+// asserts the invariant directly via the function source so a
+// revert would re-fail.
+describe("D5 tool-rendering-default-catchall — inline-needle invariant (regression)", () => {
+  function findEvaluateCallSource(fnSource: string): string {
+    const idx = fnSource.indexOf("page.evaluate(");
+    expect(idx).toBeGreaterThanOrEqual(0);
+    return fnSource.slice(idx);
+  }
+
+  it("probeDefaultCatchall inlines the leak phrase as a string literal", async () => {
+    const mod = await import("./d5-tool-rendering-default-catchall.js");
+    const src = mod.probeDefaultCatchall.toString();
+    const evalCall = findEvaluateCallSource(src);
+    expect(evalCall).toContain(mod.CUSTOM_CATCHALL_LEAK_PHRASE);
+  });
+
+  it("probeDefaultCatchall does NOT pass the needle via a page.evaluate second-arg", async () => {
+    const mod = await import("./d5-tool-rendering-default-catchall.js");
+    const src = mod.probeDefaultCatchall.toString();
+    // The historical broken form had a parameter on the closure:
+    //   page.evaluate((expectedLeakPhrase?: string) => { ... }, leakPhrase)
+    // The fixed form takes no parameters.
+    expect(src).not.toMatch(/page\.evaluate\(\s*\(\s*expectedLeakPhrase/);
+    expect(src).not.toMatch(/page\.evaluate\(\s*\(\s*expectedPhrase/);
+    // The call must not have a second arg — the closure should close
+    // with `})` not `}, x)`.
+    const tail = src.slice(-200);
+    expect(tail).toMatch(/\}\s*\)\s*;?\s*\}?\s*$/);
+    expect(tail).not.toMatch(/\},\s*[A-Za-z_$"]/);
+  });
+});
+
+// Coverage for the leak-detection branch of validateDefaultCatchall.
+// The branch was added to detect cross-fixture leaks from the
+// custom-catchall fixture into a default-catchall request. Without
+// this coverage, reverting the leak check would not be caught by
+// any other test.
+describe("D5 tool-rendering-default-catchall — customLeakPhrasePresent branch (regression)", () => {
+  it("fails when leak phrase is present in the snapshot", async () => {
+    const mod = await import("./d5-tool-rendering-default-catchall.js");
+    const err = mod.validateDefaultCatchall({
+      containerWithToolName: true,
+      statusPillPresent: true,
+      observedToolNames: ["get_weather"],
+      customLeakPhrasePresent: true,
+    });
+    expect(err).not.toBeNull();
+    expect(err).toMatch(/custom-catchall/);
+    expect(err).toMatch(/leaked/);
+    expect(err).toContain(mod.CUSTOM_CATCHALL_LEAK_PHRASE);
+  });
+
+  it("passes when leak phrase is absent (false)", async () => {
+    const mod = await import("./d5-tool-rendering-default-catchall.js");
+    expect(
+      mod.validateDefaultCatchall({
+        containerWithToolName: true,
+        statusPillPresent: true,
+        observedToolNames: ["get_weather"],
+        customLeakPhrasePresent: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("passes when leak phrase is undefined (absence == false)", async () => {
+    const mod = await import("./d5-tool-rendering-default-catchall.js");
+    expect(
+      mod.validateDefaultCatchall({
+        containerWithToolName: true,
+        statusPillPresent: true,
+        observedToolNames: ["get_weather"],
+        // customLeakPhrasePresent omitted — treated as false.
+      }),
+    ).toBeNull();
+  });
+});

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-default-catchall.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-default-catchall.test.ts
@@ -24,7 +24,7 @@ describe("D5 tool-rendering-default-catchall — registration", () => {
 
   it("references the tool-rendering fixture", () => {
     const script = getD5Script("tool-rendering-default-catchall");
-    expect(script?.fixtureFile).toBe("tool-rendering.json");
+    expect(script?.fixtureFile).toBe("tool-rendering-default-catchall.json");
   });
 
   it("registers preNavigateRoute pointing at the canonical demo route", () => {

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-default-catchall.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-default-catchall.ts
@@ -32,10 +32,8 @@
  * convention.
  */
 
-import {
-  registerD5Script,
-  type D5BuildContext,
-} from "../helpers/d5-registry.js";
+import { registerD5Script } from "../helpers/d5-registry.js";
+import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
 
 /**
@@ -62,6 +60,18 @@ export const CATCHALL_CONTAINER_TESTID = "copilot-tool-render";
  */
 export const STATUS_PILL_TESTID = "copilot-tool-render-status";
 
+/**
+ * The narration phrase the CUSTOM-catchall fixtures emit (see
+ * `d5-tool-rendering-custom-catchall.ts`). The default-catchall page
+ * must NEVER include this phrase — its presence indicates a
+ * cross-fixture leak (e.g. PR #5465's toolName-strip mistake or a
+ * latent `userMessage` collision between the two fixture files). The
+ * negative assertion below catches that regression at the content
+ * layer, which the testid + tool-name asserts structurally cannot.
+ */
+export const CUSTOM_CATCHALL_LEAK_PHRASE =
+  "rendered through the custom wildcard catchall";
+
 /** Total time we'll poll for the renderer to settle, in ms. */
 const POLL_TIMEOUT_MS = 15_000;
 const POLL_INTERVAL_MS = 250;
@@ -74,12 +84,22 @@ export interface DefaultCatchallProbe {
   statusPillPresent: boolean;
   /** Diagnostic: the data-tool-name values found on rendered containers. */
   observedToolNames: string[];
+  /**
+   * True when the page body contains the custom-catchall content
+   * phrase (`CUSTOM_CATCHALL_LEAK_PHRASE`). On the default-catchall
+   * page this MUST be false; true indicates a cross-fixture leak.
+   * Optional so existing test fixtures predating the field still
+   * type-check; absence is treated as `false` by the validator.
+   */
+  customLeakPhrasePresent?: boolean;
 }
 
 export async function probeDefaultCatchall(
   page: Page,
 ): Promise<DefaultCatchallProbe> {
-  return await page.evaluate(() => {
+  const leakPhrase = CUSTOM_CATCHALL_LEAK_PHRASE;
+  return await page.evaluate((expectedLeakPhrase?: string) => {
+    const needle = expectedLeakPhrase ?? "";
     const win = globalThis as unknown as {
       document: {
         querySelectorAll(sel: string): ArrayLike<{
@@ -88,6 +108,7 @@ export async function probeDefaultCatchall(
           textContent: string | null;
         }>;
         querySelector(sel: string): unknown;
+        body: { textContent?: string | null };
       };
     };
 
@@ -138,8 +159,36 @@ export async function probeDefaultCatchall(
       }
     }
 
-    return { containerWithToolName, statusPillPresent, observedToolNames };
-  });
+    // Scan assistant-message bubbles for the custom-catchall leak phrase.
+    // We use `textContent` over `innerText` so off-viewport bubbles in a
+    // scrolled chat still register; otherwise a leaked bubble below the
+    // fold could escape the leak check entirely.
+    let customLeakPhrasePresent = false;
+    if (needle) {
+      const bubbles = win.document.querySelectorAll(
+        '[data-testid="copilot-assistant-message"]',
+      );
+      for (let i = 0; i < bubbles.length; i++) {
+        const t = bubbles[i]!.textContent ?? "";
+        if (t.includes(needle)) {
+          customLeakPhrasePresent = true;
+          break;
+        }
+      }
+      if (!customLeakPhrasePresent) {
+        const body = win.document.body;
+        const bodyText = (body.textContent ?? "") as string;
+        customLeakPhrasePresent = bodyText.includes(needle);
+      }
+    }
+
+    return {
+      containerWithToolName,
+      statusPillPresent,
+      observedToolNames,
+      customLeakPhrasePresent,
+    };
+  }, leakPhrase);
 }
 
 /** Validate a snapshot against the built-in catchall contract. */
@@ -159,6 +208,14 @@ export function validateDefaultCatchall(
     return (
       "tool-rendering-default-catchall: container present but no status pill " +
       `([data-testid="${STATUS_PILL_TESTID}"]) — built-in renderer regressed`
+    );
+  }
+  if (snap.customLeakPhrasePresent) {
+    return (
+      "tool-rendering-default-catchall: page body contains the custom-catchall " +
+      `narration phrase ${JSON.stringify(CUSTOM_CATCHALL_LEAK_PHRASE)} — ` +
+      "a custom-catchall fixture leaked into the default-catchall request " +
+      "(see d5-tool-rendering-custom-catchall.ts for the LGP-gold disjoint-prompts pattern)"
     );
   }
   return null;
@@ -200,11 +257,24 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
   return [
     {
       input: "forecast for Tokyo",
-      // Wrapped so the assertions callback ignores the Phase-4 `ctx`
-      // argument: `assertDefaultCatchall` takes `(page, timeoutMs?)`, not
-      // `(page, ctx)`, and ctx is irrelevant to the default-catchall probe.
-      assertions: async (page) => {
+      // After the testid + tool-name checks pass, also assert the
+      // assistant narration content (the bubble text resolved by the
+      // conversation runner) does NOT contain the custom-catchall leak
+      // phrase. This catches the cross-fixture leak that the testid
+      // checks structurally cannot — see the
+      // `d5-tool-rendering-custom-catchall.ts` companion probe and PR
+      // #5465's failure mode for context.
+      assertions: async (page, ctx) => {
         await assertDefaultCatchall(page);
+        if (ctx.text.includes(CUSTOM_CATCHALL_LEAK_PHRASE)) {
+          throw new Error(
+            "tool-rendering-default-catchall: narration content contains " +
+              `the custom-catchall leak phrase ${JSON.stringify(CUSTOM_CATCHALL_LEAK_PHRASE)} — ` +
+              "a custom-catchall fixture leaked into the default-catchall " +
+              "request (LGP-gold disjoint-prompts pattern violated). " +
+              `Observed text: ${JSON.stringify(ctx.text.slice(0, 200))}`,
+          );
+        }
       },
     },
   ];

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-default-catchall.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-default-catchall.ts
@@ -97,9 +97,33 @@ export interface DefaultCatchallProbe {
 export async function probeDefaultCatchall(
   page: Page,
 ): Promise<DefaultCatchallProbe> {
-  const leakPhrase = CUSTOM_CATCHALL_LEAK_PHRASE;
-  return await page.evaluate((expectedLeakPhrase?: string) => {
-    const needle = expectedLeakPhrase ?? "";
+  // ROOT CAUSE (PR #5495 A11, then A25a): the prior implementation passed the
+  // leak phrase into the browser-side closure via the `page.evaluate(fn, arg)`
+  // second-arg form:
+  //
+  //     const leakPhrase = CUSTOM_CATCHALL_LEAK_PHRASE;
+  //     return await page.evaluate((expectedLeakPhrase?: string) => {
+  //       const needle = expectedLeakPhrase ?? "";
+  //       if (needle) { /* … cascade scan … */ }
+  //       ...
+  //     }, leakPhrase);
+  //
+  // Empirically (verified during the A11 RED-GREEN proof on the SIBLING
+  // `tool-rendering-custom-catchall` probe), `expectedLeakPhrase` arrives as
+  // `undefined` inside the browser-side closure — the arg is NOT propagated
+  // through the harness's compiled `page.evaluate` call path. With
+  // `needle === ""`, the `if (needle)` guard skipped the entire leak-detection
+  // cascade and `customLeakPhrasePresent` stayed `false` forever, even when
+  // the canonical phrase WAS in the DOM — making `validateDefaultCatchall`'s
+  // leak branch (the check at the end of `validateDefaultCatchall`) dead
+  // code. The defensive fix mirrors the sibling probe by inlining the needle
+  // as a JS string literal inside the closure — no `page.evaluate(fn, arg)`
+  // second-arg dependency at all.
+  //
+  // The needle is the canonical leak phrase exported above as
+  // `CUSTOM_CATCHALL_LEAK_PHRASE`. Keep these two in lock-step.
+  return await page.evaluate(() => {
+    const needle = "rendered through the custom wildcard catchall";
     const win = globalThis as unknown as {
       document: {
         querySelectorAll(sel: string): ArrayLike<{
@@ -164,22 +188,20 @@ export async function probeDefaultCatchall(
     // scrolled chat still register; otherwise a leaked bubble below the
     // fold could escape the leak check entirely.
     let customLeakPhrasePresent = false;
-    if (needle) {
-      const bubbles = win.document.querySelectorAll(
-        '[data-testid="copilot-assistant-message"]',
-      );
-      for (let i = 0; i < bubbles.length; i++) {
-        const t = bubbles[i]!.textContent ?? "";
-        if (t.includes(needle)) {
-          customLeakPhrasePresent = true;
-          break;
-        }
+    const bubbles = win.document.querySelectorAll(
+      '[data-testid="copilot-assistant-message"]',
+    );
+    for (let i = 0; i < bubbles.length; i++) {
+      const t = bubbles[i]!.textContent ?? "";
+      if (t.includes(needle)) {
+        customLeakPhrasePresent = true;
+        break;
       }
-      if (!customLeakPhrasePresent) {
-        const body = win.document.body;
-        const bodyText = (body.textContent ?? "") as string;
-        customLeakPhrasePresent = bodyText.includes(needle);
-      }
+    }
+    if (!customLeakPhrasePresent) {
+      const body = win.document.body;
+      const bodyText = (body.textContent ?? "") as string;
+      customLeakPhrasePresent = bodyText.includes(needle);
     }
 
     return {
@@ -188,7 +210,7 @@ export async function probeDefaultCatchall(
       observedToolNames,
       customLeakPhrasePresent,
     };
-  }, leakPhrase);
+  });
 }
 
 /** Validate a snapshot against the built-in catchall contract. */

--- a/showcase/harness/src/probes/scripts/d5-tool-rendering-default-catchall.ts
+++ b/showcase/harness/src/probes/scripts/d5-tool-rendering-default-catchall.ts
@@ -293,7 +293,7 @@ export function preNavigateRoute(): string {
 
 registerD5Script({
   featureTypes: ["tool-rendering-default-catchall"],
-  fixtureFile: "tool-rendering.json",
+  fixtureFile: "tool-rendering-default-catchall.json",
   buildTurns,
   preNavigateRoute,
 });

--- a/showcase/integrations/crewai-crews/src/agents/tool_rendering.py
+++ b/showcase/integrations/crewai-crews/src/agents/tool_rendering.py
@@ -69,15 +69,85 @@ GET_WEATHER_TOOL = {
 }
 
 
+GET_STOCK_PRICE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_stock_price",
+        "description": (
+            "Get a mock current price for a stock ticker.  Always call "
+            "this tool when the user asks about a stock price or quote. "
+            "Pass the ticker symbol verbatim (e.g. 'AAPL')."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "ticker": {
+                    "type": "string",
+                    "description": "The stock ticker symbol (e.g. 'AAPL').",
+                },
+                "price_usd": {
+                    "type": "number",
+                    "description": (
+                        "Optional deterministic price to echo back. When "
+                        "omitted, a mock price is returned."
+                    ),
+                },
+                "change_pct": {
+                    "type": "number",
+                    "description": (
+                        "Optional deterministic percent-change to echo back. "
+                        "When omitted, a mock change is returned."
+                    ),
+                },
+            },
+            "required": ["ticker"],
+        },
+    },
+}
+
+
+def get_stock_price_impl(
+    ticker: str,
+    price_usd: float | None = None,
+    change_pct: float | None = None,
+) -> dict:
+    """Return mock stock quote for the given ticker.
+
+    Mirrors the LangGraph-Python `get_stock_price` tool shape so the
+    aimock fixtures and `d5-tool-rendering-custom-catchall` probe see
+    identical tool-result payloads across integrations. When
+    `price_usd`/`change_pct` are supplied (e.g. by the aimock fixture
+    "Quote AAPL through the wildcard renderer"), they're echoed back
+    verbatim for deterministic assertions.
+    """
+    import random as _random
+
+    rng = _random.Random(ticker.lower())
+    return {
+        "ticker": ticker.upper(),
+        "price_usd": (
+            round(float(price_usd), 2)
+            if price_usd is not None
+            else round(100 + rng.randint(0, 400) + rng.randint(0, 99) / 100, 2)
+        ),
+        "change_pct": (
+            round(float(change_pct), 2)
+            if change_pct is not None
+            else round(rng.choice([-1, 1]) * (rng.randint(0, 300) / 100), 2)
+        ),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Flow
 # ---------------------------------------------------------------------------
 
 _SYSTEM_PROMPT = (
-    "You are a helpful, concise weather assistant.  When the user asks "
-    "about weather for a location, call the `get_weather` tool with the "
-    "location.  After receiving the tool result, summarise the weather "
-    "in a short sentence."
+    "You are a helpful, concise assistant.  When the user asks about "
+    "weather for a location, call the `get_weather` tool.  When the "
+    "user asks about a stock price or quote, call the `get_stock_price` "
+    "tool with the ticker symbol.  After receiving any tool result, "
+    "summarise it in a short sentence."
 )
 
 # Maximum LLM round-trips per user turn (prevents infinite loops).
@@ -95,10 +165,11 @@ class ToolRenderingFlow(Flow[ToolRenderingState]):
             "id": str(uuid.uuid4()) + "-system",
         }
 
-        # Frontend-registered actions + our backend get_weather tool.
+        # Frontend-registered actions + our backend get_weather / get_stock_price tools.
         tools = [
             *self.state.copilotkit.actions,
             GET_WEATHER_TOOL,
+            GET_STOCK_PRICE_TOOL,
         ]
 
         for _iteration in range(_MAX_ITERATIONS):
@@ -139,6 +210,24 @@ class ToolRenderingFlow(Flow[ToolRenderingState]):
                         {
                             "role": "tool",
                             "content": result_str,
+                            "tool_call_id": tool_call_id,
+                        }
+                    )
+                elif tool_name == "get_stock_price":
+                    try:
+                        args = json.loads(tool_call["function"]["arguments"] or "{}")
+                    except json.JSONDecodeError:
+                        args = {}
+                    ticker = args.get("ticker", "UNKNOWN")
+                    price_usd = args.get("price_usd")
+                    change_pct = args.get("change_pct")
+                    stock_result = get_stock_price_impl(
+                        ticker, price_usd=price_usd, change_pct=change_pct
+                    )
+                    self.state.messages.append(
+                        {
+                            "role": "tool",
+                            "content": json.dumps(stock_result),
                             "tool_call_id": tool_call_id,
                         }
                     )

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit/route.ts
@@ -48,7 +48,6 @@ const agentNames = [
   "agent-config",
   // Tool rendering variants
   "tool-rendering-default-catchall",
-  "tool-rendering-custom-catchall",
   "tool-rendering-reasoning-chain",
   // HITL
   "hitl-in-chat",
@@ -94,6 +93,15 @@ agents["interrupt-headless"] = createAgent("/interrupt-adapted");
 // per-tool state mutations to the AG-UI bridge — same architectural
 // reason as shared-state-read-write and subagents.
 agents["gen-ui-agent"] = createAgent("/gen-ui-agent");
+// tool-rendering-custom-catchall routes to a dedicated CrewAI Flow
+// backend (`/tool-rendering`, src/agents/tool_rendering.py) that emits
+// AG-UI TOOL_CALL_* events for `get_weather` / `get_stock_price`. The
+// shared `LatestAiDevelopment` ChatWithCrewFlow on "/" runs backend
+// tools internally without emitting tool-call events, so the frontend's
+// custom wildcard renderer (`useDefaultRenderTool`) would never paint
+// the `[data-testid="custom-wildcard-card"]` shell that the
+// `d5-tool-rendering-custom-catchall` probe asserts on.
+agents["tool-rendering-custom-catchall"] = createAgent("/tool-rendering");
 agents["default"] = createAgent();
 
 console.log(


### PR DESCRIPTION
## Summary

Restores **all 4 D5 custom-catchall cells** (LGP, crewai-crews, built-in-agent, claude-sdk-typescript) to green via the production-equivalent control-plane pipeline, plus 4 harness honesty fixes that turn `--isolate` and `:demo` invocations into apples-to-apples staging mirrors.

**Cells GREEN locally (verified post-CR via `bin/showcase test <slug>:tool-rendering-custom-catchall --d5 --isolate`):**
- `langgraph-python` ✓
- `crewai-crews` ✓
- `built-in-agent` ✓
- `claude-sdk-typescript` ✓

## Harness honesty fixes (the load-bearing ones)

1. **A11 — probe-scan inline-needle.** `page.evaluate(fn, arg)` was passing `undefined` to the browser closure → `customContentPhrasePresent` was permanently false fleet-wide, masking every other failure mode. Fix: inline the canonical phrase literal in the closure. A25a propagated the same fix to `d5-tool-rendering-default-catchall.ts` (still had the broken pattern).
2. **A18 — control-plane honors `:demo`.** `bin/showcase test <slug>:<demo> --d5/--d6 --isolate` previously ignored the demo qualifier (d5 hardcoded to `agentic-chat`; d6 aggregate-only). Now per-demo scoping flows through `buildLocalServicesJson` + `expectedKeys`. Eliminates a class of silent false-positive PASS.
3. **A21 + A21b — `--isolate` rebuild scope.** A21 scoped `--build` to target slug (BuildKit contention unblock); A21b corrected an A21 regression where positional-after-`up` restricted which services started. Result: two-call compose split — `compose --profile infra up -d` (no build, uses cached images), then `compose --profile infra --profile <slug> up -d --build <slug>` (rebuild target only). Cold-build ~30s–2 min instead of 10+ min full-stack rebuild.

## Cell fixes

- **A14 (crewai-crews)**: backend defect — `tool-rendering-custom-catchall` agentId routed to shared `LatestAiDevelopment` flow at `/` with no `get_weather`/`get_stock_price` handlers; tool-loop never closed. Added `get_stock_price_impl`, re-routed agentId to `/tool-rendering`.
- **A19b (built-in-agent)** + **A20 (claude-sdk-typescript)**: backend ID-rewrite (TanStack `fc_*`, Anthropic `toolu_*`) broke `toolCallId`-gated narration fixtures. Swapped to `turnIndex` discriminator (backend-id-invariant). `response.content` (canonical phrase) preserved verbatim.
- **A10 (langgraph-python)**: parent commit \`9491b8934\` disjoined the d5 probe userMessages but didn't add matching LGP-gold fixture entries. Added 4 entries (turn-1 emit + turn-2 narration for Tokyo + AAPL).
- **A1-A9 (R1+R2 fixture hygiene)**: cleanups to dead `turnIndex:0` fallbacks, `hasToolResult:false` gates, AAPL value drift, csdkts copy-paste bug — pre-A11 era.

## Test coverage (A25 round, addresses post-A21b CR findings)

- A11 inline-needle invariant (regression test — fails if the fix is reverted)
- A7 `requireContentPhrase=true` branch end-to-end
- A18 `buildLocalServicesJson` + `expectedKeys` + `dedupeScopes` + `runViaControlPlane` error surfacing (17 new tests in \`control-plane-run.test.ts\`)
- A21+A21b two-call compose argv contract (lifecycle.test.ts, 7 tests)

Full harness vitest suite: **2790/2790 pass**. Typecheck clean. oxfmt clean.

## Test plan
- [x] Local control-plane (`--d5 --isolate`) on all 4 cells — GREEN
- [x] LGP regression check across every fix-round — GREEN throughout
- [x] vitest harness suite (2790 tests) — GREEN
- [x] tsc --noEmit — clean
- [x] oxfmt --check — clean
- [x] Pre-push quality + 7-agent cr-loop + 3-slot post-A25 confirmation round — converged ZERO blockers
- [ ] CI gates (gh pr checks 5495) on push — to be observed

## Notes for reviewers
Docs PR (\`docs/showcase-sop-tiering\`, off main) sequences AFTER this one — it documents the new CLI semantics (\`:demo\` scoping, \`--isolate\` rebuild scope) introduced here.