### PR TITLE
refactor(showcase): rename Wired → BE (Agent) across dashboard taxonomies

### DIFF
--- a/showcase/shell-dashboard/src/components/adaptive-stats-bar.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-stats-bar.tsx
@@ -144,7 +144,7 @@ function DepthSection({
   const unsupported = catalog.metadata.unsupported ?? 0;
   return (
     <div className="flex items-center gap-4">
-      <Stat value={wired} label="Wired" colorClass="text-[var(--ok)]" />
+      <Stat value={wired} label="BE (Agent)" colorClass="text-[var(--ok)]" />
       <Stat value={stub} label="Stub" colorClass="text-[var(--amber)]" />
       <Stat
         value={unshipped}
@@ -179,7 +179,7 @@ function DepthSection({
  *
  * Only depths `buildCellModel().achievedDepth` can produce are shown. D0 (wired
  * but no passing rung yet) is rendered so wired-unverified cells stay visible
- * and the row sums to the "Wired" count; the never-reachable D1/D2 rows are
+ * and the row sums to the "BE (Agent)" count; the never-reachable D1/D2 rows are
  * omitted instead of rendering permanent zeros.
  */
 function DepthDistributionSection({

--- a/showcase/shell-dashboard/src/components/cells-view.tsx
+++ b/showcase/shell-dashboard/src/components/cells-view.tsx
@@ -81,8 +81,8 @@ function computeDefaultOpenCategories(
     }
   }
 
-  const totalWired = cells.filter((c) => c.status === "wired").length;
-  if (totalWired === 0) {
+  const totalBeAgent = cells.filter((c) => c.status === "wired").length;
+  if (totalBeAgent === 0) {
     // Open first 2 categories if no wired cells
     return new Set(categories.slice(0, 2).map((c) => c.id));
   }
@@ -94,7 +94,7 @@ function computeDefaultOpenCategories(
 
   const result = new Set<string>();
   let accumulated = 0;
-  const threshold = totalWired * 0.6;
+  const threshold = totalBeAgent * 0.6;
 
   for (const cat of sorted) {
     result.add(cat.id);

--- a/showcase/shell-dashboard/src/components/coverage-bar.tsx
+++ b/showcase/shell-dashboard/src/components/coverage-bar.tsx
@@ -27,7 +27,7 @@ export function CoverageBar({
   const total = wired + stub + unshipped + unsupported;
   if (total === 0) return null;
 
-  const pctWired = (wired / total) * 100;
+  const pctBeAgent = (wired / total) * 100;
   const pctStub = (stub / total) * 100;
   const pctUnsupported = (unsupported / total) * 100;
   // unshipped fills the rest (solid gray background)
@@ -47,11 +47,11 @@ export function CoverageBar({
       className="w-full h-1.5 rounded-full overflow-hidden flex bg-[var(--text-muted)]/20"
       title={titleParts.join(" / ")}
     >
-      {pctWired > 0 && (
+      {pctBeAgent > 0 && (
         <div
           data-testid="coverage-segment-wired"
           className="h-full bg-[var(--ok)]"
-          style={{ width: `${pctWired}%` }}
+          style={{ width: `${pctBeAgent}%` }}
         />
       )}
       {pctStub > 0 && (

--- a/showcase/shell-dashboard/src/components/filter-chips.tsx
+++ b/showcase/shell-dashboard/src/components/filter-chips.tsx
@@ -17,7 +17,7 @@ export interface FilterChipsProps {
 
 const FILTERS: Array<{ id: FilterMode; label: string }> = [
   { id: "all", label: "All" },
-  { id: "wired", label: "Wired" },
+  { id: "wired", label: "BE (Agent)" },
   { id: "gaps", label: "Gaps" },
   { id: "regressions", label: "Regressions" },
   { id: "reference", label: "Reference" },

--- a/showcase/shell-dashboard/src/components/level-strip.test.tsx
+++ b/showcase/shell-dashboard/src/components/level-strip.test.tsx
@@ -61,9 +61,9 @@ describe("LevelStrip", () => {
     );
     const strip = getByTestId("level-strip");
     expect(strip.children).toHaveLength(4);
-    // First letters: U(p), W(ired), C(hats), T(ools)
+    // First letters: U(p), B(E (Agent)), C(hats), T(ools)
     const letters = Array.from(strip.children).map((c) => c.textContent);
-    expect(letters).toEqual(["U", "W", "C", "T"]);
+    expect(letters).toEqual(["U", "B", "C", "T"]);
   });
 
   it("shows green tone when dimension rows are green", () => {
@@ -152,7 +152,7 @@ describe("LevelStrip", () => {
       <LevelStrip integration={integration} liveStatus={live} />,
     );
     const strip = getByTestId("level-strip");
-    const wiredChip = strip.children[1]!;
-    expect(wiredChip.getAttribute("title")).toContain("degraded");
+    const beAgentChip = strip.children[1]!;
+    expect(beAgentChip.getAttribute("title")).toContain("degraded");
   });
 });

--- a/showcase/shell-dashboard/src/components/level-strip.tsx
+++ b/showcase/shell-dashboard/src/components/level-strip.tsx
@@ -1,6 +1,6 @@
 "use client";
 /**
- * Per-integration L1-L4 strip: four badges showing Up / Wired / Chats / Tools.
+ * Per-integration L1-L4 strip: four badges showing Up / BE (Agent) / Chats / Tools.
  * Reads integration-scoped rows from the live-status map.
  *
  * No longer used by Coverage tab (overlay-column-header.tsx).
@@ -8,7 +8,8 @@
  * packages-section.tsx.
  */
 import { ToneChip } from "@/components/badges";
-import { keyFor, type LiveStatusMap, type BadgeTone } from "@/lib/live-status";
+import { keyFor } from "@/lib/live-status";
+import type { LiveStatusMap, BadgeTone } from "@/lib/live-status";
 import { formatTs } from "@/lib/format-ts";
 import type { Integration } from "@/lib/registry";
 
@@ -62,7 +63,7 @@ export function LevelStrip({
 }) {
   const slug = integration.slug;
   const up = resolveBadge(liveStatus, "health", slug, "Up");
-  const wired = resolveBadge(liveStatus, "agent", slug, "Wired");
+  const wired = resolveBadge(liveStatus, "agent", slug, "BE (Agent)");
   const chats = resolveBadge(liveStatus, "chat", slug, "Chats");
 
   // Tools n/a gate: only show real state if integration has tool-rendering demo

--- a/showcase/shell-dashboard/src/components/packages-section.test.tsx
+++ b/showcase/shell-dashboard/src/components/packages-section.test.tsx
@@ -75,6 +75,6 @@ describe("PackagesSection", () => {
       <PackagesSection liveStatus={emptyLiveStatus} connection="live" />,
     );
     const legend = getByTestId("packages-uwct-legend");
-    expect(legend.textContent).toBe("(U=Up, W=Wired, C=Chats, T=Tools)");
+    expect(legend.textContent).toBe("(U=Up, B=BE (Agent), C=Chats, T=Tools)");
   });
 });

--- a/showcase/shell-dashboard/src/components/packages-section.tsx
+++ b/showcase/shell-dashboard/src/components/packages-section.tsx
@@ -4,12 +4,10 @@
  * an achieved-depth column (D0-D4).
  */
 import { useMemo } from "react";
-import { getPackages, type Package } from "@/lib/registry";
-import {
-  keyFor,
-  type ConnectionStatus,
-  type LiveStatusMap,
-} from "@/lib/live-status";
+import { getPackages } from "@/lib/registry";
+import type { Package } from "@/lib/registry";
+import { keyFor } from "@/lib/live-status";
+import type { ConnectionStatus, LiveStatusMap } from "@/lib/live-status";
 import { LevelStrip } from "@/components/level-strip";
 import { DepthChip } from "@/components/depth-chip";
 
@@ -99,7 +97,7 @@ export function PackagesSection({
                   className="ml-2 text-[10px] font-normal normal-case text-[var(--text-muted)]"
                   data-testid="packages-uwct-legend"
                 >
-                  (U=Up, W=Wired, C=Chats, T=Tools)
+                  (U=Up, B=BE (Agent), C=Chats, T=Tools)
                 </span>
               </th>
               <th className="bg-[var(--bg-muted)] px-4 py-2 text-center border-b border-l border-[var(--border)]">

--- a/showcase/shell-dashboard/src/components/parity-view.tsx
+++ b/showcase/shell-dashboard/src/components/parity-view.tsx
@@ -5,12 +5,10 @@
  * Composes: stats bar + parity legend + ParityMatrix.
  */
 import { useMemo } from "react";
-import { ParityBadge, type ParityTier } from "./parity-badge";
-import {
-  ParityMatrix,
-  type IntegrationInfo,
-  type FeatureInfo,
-} from "./parity-matrix";
+import { ParityBadge } from "./parity-badge";
+import type { ParityTier } from "./parity-badge";
+import { ParityMatrix } from "./parity-matrix";
+import type { IntegrationInfo, FeatureInfo } from "./parity-matrix";
 import type { LiveStatusMap, ConnectionStatus } from "@/lib/live-status";
 import type { FeatureCategory } from "@/lib/registry";
 import type { CatalogData } from "@/data/catalog-types";
@@ -82,8 +80,8 @@ function computeDefaultOpenCategories(
     }
   }
 
-  const totalWired = cells.filter((c) => c.status === "wired").length;
-  if (totalWired === 0) {
+  const totalBeAgent = cells.filter((c) => c.status === "wired").length;
+  if (totalBeAgent === 0) {
     return new Set(categories.slice(0, 2).map((c) => c.id));
   }
 
@@ -93,7 +91,7 @@ function computeDefaultOpenCategories(
 
   const result = new Set<string>();
   let accumulated = 0;
-  const threshold = totalWired * 0.6;
+  const threshold = totalBeAgent * 0.6;
 
   for (const cat of sorted) {
     result.add(cat.id);

--- a/showcase/shell-dashboard/src/components/stats-bar.tsx
+++ b/showcase/shell-dashboard/src/components/stats-bar.tsx
@@ -26,7 +26,10 @@ function Stat({
   return (
     <div
       className="flex flex-col items-center"
-      data-testid={`stat-${label.toLowerCase()}`}
+      data-testid={`stat-${label
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/(^-|-$)/g, "")}`}
     >
       <span
         className={`text-2xl font-bold tabular-nums ${colorClass ?? "text-[var(--text)]"}`}

--- a/showcase/shell-dashboard/src/components/stats-bar.tsx
+++ b/showcase/shell-dashboard/src/components/stats-bar.tsx
@@ -51,7 +51,7 @@ export function StatsBar({
 }: StatsBarProps) {
   return (
     <div data-testid="stats-bar" className="flex items-center gap-8 px-4 py-3">
-      <Stat value={wired} label="Wired" colorClass="text-[var(--ok)]" />
+      <Stat value={wired} label="BE (Agent)" colorClass="text-[var(--ok)]" />
       <Stat value={stub} label="Stub" colorClass="text-[var(--amber)]" />
       <Stat
         value={unshipped}


### PR DESCRIPTION
## Summary

Renames the display label \"Wired\" to **\"BE (Agent)\"** across both taxonomies in the showcase dashboard, unifying the two overloaded meanings (live-probe runtime health + catalog integration build state) under one user-visible name. Mirrors the shape of #5473's `E2E (Demo)` → `UI (Frontend)` rename — same atomic, label-only refactor.

## Why

The word \"Wired\" was overloaded across the dashboard:
- The **live-probe L1 row** in `level-strip` rendered \"Wired\" for runtime backend health (the agent is up and responding).
- The **catalog integration-status** column in `stats-bar`/`adaptive-stats-bar`/`coverage-bar`/`filter-chips` rendered \"Wired\" for build state (the integration is built and shipped).

Both refer to the same underlying thing — the backend agent integration — at different lifecycle stages. Calling both **\"BE (Agent)\"** makes the dashboard internally consistent and aligns with the parallel \"UI (Frontend)\" label introduced in #5473.

## Scope

- Visible label flip across `level-strip.tsx`, `packages-section.tsx` legend (incl. `W=Wired` → `B=BE (Agent)` mnemonic), `stats-bar.tsx`, `adaptive-stats-bar.tsx`, `coverage-bar.tsx`, `filter-chips.tsx`.
- Internal counter renames: `pctWired`/`totalWired` → `pctBeAgent`/`totalBeAgent` (`coverage-bar.tsx`, `cells-view.tsx`, `parity-view.tsx`).
- Test assertion + comment updates in `level-strip.test.tsx`, `packages-section.test.tsx`.
- Slugifier fix in `stats-bar.tsx` testid generator — `label.toLowerCase()` on `\"BE (Agent)\"` previously produced `stat-be (agent)` (spaces + parens). Now slugifies to `stat-be-agent`. Incidentally also fixes the pre-existing `stat-max depth` → `stat-max-depth`. Surfaced and fixed during cr-loop Round 1.

## Stable contracts preserved (no behavior change)

- PocketBase row keys `agent:<slug>`
- `LiveDimension` union value `\"agent\"`
- `Status` enum string values `\"wired\" | \"stub\" | \"unshipped\" | \"unsupported\"` (persisted catalog data; only display labels flip)
- Filter chip `id: \"wired\"` (filter state key joining to `cell-matrix.tsx`)
- `catalog.metadata.wired` data field reads
- Harness driver `kind`/emission contracts
- `data-testid=\"coverage-segment-wired\"`

## Commits (4)

- \`ef40bd7c\` live-probe agent dimension Wired → BE (Agent)
- \`bfebac65\` catalog status Wired display → BE (Agent)
- \`f316d055\` rename internal Wired counters to BeAgent
- \`80b526d6\` slugify stats-bar testids (CR fix)

## Verification

- typecheck (\`tsc --noEmit\`): clean
- lint (next build inline): clean
- tests (\`vitest run\`): 1089 pass / 1 skip / 0 fail across 63 files
- build (\`next build\`): clean
- oxfmt: clean
- NUL-byte scan: empty
- cr-loop converged at Round 2 with Procedure 3 audit returning 0 PROMOTE_TO_A items

## Follow-up backlog

Round 1 + Round 2 surfaced ~30 pre-existing structural findings in adjacent code (not subject-scope for this rename). Grouped into 8 follow-up PR subjects: fail-loud sweep, catalog view derivation extraction, derivePackageDepth gate consistency, parity tier counting hardening, coverage-bar tooltip/rounding, cells-view stats useMemo, test hardening, Tailwind opacity-on-CSS-var. None block this rename.