### PR TITLE
chore(examples): quiet :wrench: tool rows in the slack bot (cards make them redundant)

### DIFF
--- a/examples/slack/app/index.ts
+++ b/examples/slack/app/index.ts
@@ -43,6 +43,12 @@ async function main() {
       slack({
         botToken: required("SLACK_BOT_TOKEN"),
         appToken: required("SLACK_APP_TOKEN"),
+        // This bot answers with rich Block Kit cards (issue lists, tables,
+        // diagrams) via render tools, so per-tool `:wrench: Calling …` rows are
+        // redundant noise next to the card. Suppress them — the "thinking…"
+        // placeholder covers pre-answer feedback, and text replies stream
+        // natively (Slack's streaming UI). Drop this to see per-tool rows.
+        showToolStatus: false,
         // Assistant-pane behavior is ON by default; this just customizes it.
         // The greeting + chips show when a user opens the pane (matching the
         // app manifest's `assistant_view`); native streaming + status need no


### PR DESCRIPTION
## What

Set `showToolStatus: false` on the Slack adapter in the `examples/slack` bot.

## Why

The triage bot answers with rich **Block Kit cards** (issue lists, tables, diagrams, status/incident cards) rendered via tools. The per-tool `:wrench: Calling …` → `:white_check_mark:` status rows are redundant noise sitting right next to the card they precede (e.g. a `:wrench: Calling issue_list…` row immediately above the issue-list card).

With this off, a channel turn shows just the `:hourglass: thinking…` placeholder during the work, then the card. **Text** replies still stream natively (Slack's streaming UI / "purple flash"), exactly like the assistant pane.

## Scope

**Example-only — no SDK change.** Native streaming and the `thinking…` placeholder already work in channel threads on `main`; this only quiets the tool rows for this card-heavy example. `showToolStatus` is an existing `slack()` adapter option.

## Verifying locally

Run the example (`pnpm notion-mcp`, `pnpm run runtime`, `pnpm run start`) and @mention the bot in a channel:
- "what are the open CPK issues this cycle?" → `:hourglass: thinking…` → issue-list card, **no** `:wrench:` rows.
- "what can you do?" → reply streams with Slack's native streaming UI.

## Note

Supersedes the experiments in #5488 (closed): that PR tried to replace the placeholder with an eagerly-opened native stream, which left an undeletable empty "Thinking…" bubble for card answers (`chat.delete` → `cant_delete_message`). The native streaming on `main` was already correct; the only real gap was the noisy tool rows, which this addresses.
