### PR TITLE
refactor(showcase): rename cell-badge RT → BE (parallel to E2E → UI in #5473)

### DIFF
--- a/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.lazy-signal.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.lazy-signal.test.tsx
@@ -345,7 +345,7 @@ describe("CellDrilldown — lazy signal fetch (real PocketBase SDK)", () => {
     );
 
     const healthBadge = getByTestId("drilldown-badge-health");
-    // The e2e row's label-derived testid: `RT (Round Trip)` now belongs to
+    // The e2e row's label-derived testid: `BE (Round Trip)` now belongs to
     // the D4 row (whose fixtures here have no chat/tools data), so the e2e
     // row must be selected via its renamed `UI (Frontend)` label.
     const e2eBadge = getByTestId("drilldown-badge-ui--frontend-");

--- a/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
@@ -68,8 +68,8 @@ describe("CellDrilldown", () => {
     expect(getByTestId("cell-drilldown")).toBeDefined();
     expect(getByText("Parity (Reference)")).toBeDefined();
     expect(getByText("CV (Conversation)")).toBeDefined();
-    // `RT (Round Trip)` is now the D4 (chat+tools round-trip) row …
-    expect(getByText("RT (Round Trip)")).toBeDefined();
+    // `BE (Round Trip)` is now the D4 (chat+tools round-trip) row …
+    expect(getByText("BE (Round Trip)")).toBeDefined();
     // … and the e2e row carries the renamed `UI (Frontend)` label
     // (was `E2E (Demo)` — taxonomy cleanup).
     expect(getByText("UI (Frontend)")).toBeDefined();
@@ -81,7 +81,7 @@ describe("CellDrilldown", () => {
     expect(queryByText("Smoke")).toBeNull();
   });
 
-  it("renders a red RT (Round Trip) row for a red D4 fold while the service line stays green (headline drilldown-parity bug)", () => {
+  it("renders a red BE (Round Trip) row for a red D4 fold while the service line stays green (headline drilldown-parity bug)", () => {
     // The dimension that turns the pill red (D4: red tools round-trip) must
     // be VISIBLE in the popup. Pre-fix the popup had no D4 row at all, so a
     // pill-red cell showed nothing non-green to explain itself.
@@ -101,9 +101,9 @@ describe("CellDrilldown", () => {
         onClose={() => {}}
       />,
     );
-    // The d4 row owns the `RT (Round Trip)` label (and so its derived testid).
-    const rtBadge = getByTestId("drilldown-badge-rt--round-trip-");
-    expect(rtBadge.textContent).toContain("RT (Round Trip)");
+    // The d4 row owns the `BE (Round Trip)` label (and so its derived testid).
+    const rtBadge = getByTestId("drilldown-badge-be--round-trip-");
+    expect(rtBadge.textContent).toContain("BE (Round Trip)");
     expect(rtBadge.textContent).toContain("✗");
     // The service-scoped line (health + e2e) is still green — honest scope.
     expect(getByText("green")).toBeDefined();
@@ -119,7 +119,7 @@ describe("CellDrilldown", () => {
     ).toBe("red");
   });
 
-  it("renders strikethrough n/a on the RT (Round Trip) row when chat/tools rows are absent", () => {
+  it("renders strikethrough n/a on the BE (Round Trip) row when chat/tools rows are absent", () => {
     const live = mapOf([
       row("health:lgp", "health", "green", { ...FRESH }),
       row("e2e:lgp/agentic-chat", "e2e", "green", { ...FRESH }),
@@ -134,8 +134,8 @@ describe("CellDrilldown", () => {
         onClose={() => {}}
       />,
     );
-    const rtBadge = getByTestId("drilldown-badge-rt--round-trip-");
-    expect(rtBadge.textContent).toContain("RT (Round Trip)");
+    const rtBadge = getByTestId("drilldown-badge-be--round-trip-");
+    expect(rtBadge.textContent).toContain("BE (Round Trip)");
     expect(rtBadge.textContent).toContain("n/a");
     expect(rtBadge.querySelector(".line-through")).not.toBeNull();
   });
@@ -155,7 +155,7 @@ describe("CellDrilldown", () => {
     expect(queryByText("Rollup")).toBeNull();
   });
 
-  it("renames the e2e label to UI (Frontend); exactly ONE row is labelled RT (Round Trip)", () => {
+  it("renames the e2e label to UI (Frontend); exactly ONE row is labelled BE (Round Trip)", () => {
     const live = mapOf([
       row("e2e:lgp/agentic-chat", "e2e", "green", { ...FRESH }),
       row("chat:lgp", "chat", "green", { ...FRESH }),
@@ -174,10 +174,10 @@ describe("CellDrilldown", () => {
     // E2E (Demo) was renamed to UI (Frontend); the underlying `e2e:<slug>/<feature>`
     // probe key is preserved on PocketBase for backward compatibility.
     expect(getByText("UI (Frontend)")).toBeDefined();
-    expect(getAllByText("RT (Round Trip)").length).toBe(1);
+    expect(getAllByText("BE (Round Trip)").length).toBe(1);
   });
 
-  it("shows fail count and extracted Error field on a red RT (Round Trip) / D4 row", () => {
+  it("shows fail count and extracted Error field on a red BE (Round Trip) / D4 row", () => {
     const live = mapOf([
       row("chat:lgp", "chat", "green", { ...FRESH }),
       row("tools:lgp", "tools", "red", {
@@ -197,7 +197,7 @@ describe("CellDrilldown", () => {
         onClose={() => {}}
       />,
     );
-    const rtBadge = getByTestId("drilldown-badge-rt--round-trip-");
+    const rtBadge = getByTestId("drilldown-badge-be--round-trip-");
     expect(within(rtBadge).getByTestId("fail-count").textContent).toBe("3");
     expect(within(rtBadge).getByTestId("signal-field-error").textContent).toBe(
       "boom",

--- a/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
@@ -21,7 +21,7 @@
  *
  * Covered:
  *   (1) per-depth single-key pass→green/fail→red/missing→(no badge) for
- *       API(d3)/RT(d4)/CV(d5)/D6, asserted as RENDERED badge tone+glyph.
+ *       API(d3)/BE(d4)/CV(d5)/D6, asserted as RENDERED badge tone+glyph.
  *   (2) D6 enum fan-out rollup — beautiful-chat 5-key all-pass/any-fail/
  *       all-missing/partial → documented chip color; the 1:1 + rename
  *       mappings (headless-complete, chat-customization-css, gen-ui-tool-based).
@@ -203,13 +203,13 @@ const CHIP_CLASS: Record<ChipColor, string> = {
 //     asserted as the RENDERED badge tone class + glyph.
 // ===========================================================================
 
-describe("(1) per-depth badge rendering — UI/RT/CV/D6", () => {
+describe("(1) per-depth badge rendering — UI/BE/CV/D6", () => {
   // agentic-chat is 1:1 mapped (CATALOG_TO_D5_KEY["agentic-chat"] =
   // ["agentic-chat"]) so each depth is a single key, isolating one badge.
   const FEATURE = "agentic-chat";
 
   interface DepthCase {
-    badge: "UI" | "RT" | "CV" | "D6";
+    badge: "UI" | "BE" | "CV" | "D6";
     /** rows that set THIS depth's state; gate rows added automatically. */
     rows: StatusRow[];
     expectStatus: TestStatus;
@@ -231,9 +231,9 @@ describe("(1) per-depth badge rendering — UI/RT/CV/D6", () => {
       rows: [row(keyFor("e2e", SLUG, FEATURE), "e2e", "red")],
       expectStatus: "red",
     },
-    // RT (d4) — chat/tools; green requires gate green first
+    // BE (d4) — chat/tools; green requires gate green first
     {
-      badge: "RT",
+      badge: "BE",
       rows: [
         row(keyFor("e2e", SLUG, FEATURE), "e2e", "green"),
         row(keyFor("chat", SLUG), "chat", "green"),
@@ -241,7 +241,7 @@ describe("(1) per-depth badge rendering — UI/RT/CV/D6", () => {
       expectStatus: "green",
     },
     {
-      badge: "RT",
+      badge: "BE",
       rows: [
         row(keyFor("e2e", SLUG, FEATURE), "e2e", "green"),
         row(keyFor("chat", SLUG), "chat", "red"),
@@ -290,7 +290,7 @@ describe("(1) per-depth badge rendering — UI/RT/CV/D6", () => {
     it(`${c.badge} ${c.expectStatus} → tone ${BADGE_RENDER[c.expectStatus ?? "null"].tone}, glyph ${BADGE_RENDER[c.expectStatus ?? "null"].glyph}`, () => {
       const live = mapOf(c.rows);
       const { container } = renderCell(live, FEATURE, ["health"]);
-      // Find the badge by its leading label text (E2E/RT/CV/D6).
+      // Find the badge by its leading label text (UI/BE/CV/D6).
       const labels = Array.from(container.querySelectorAll("span")).filter(
         (s) => s.textContent === c.badge,
       );
@@ -305,12 +305,12 @@ describe("(1) per-depth badge rendering — UI/RT/CV/D6", () => {
     });
   }
 
-  it("missing depth → no badge rendered (RT absent when chat/tools missing)", () => {
-    // Only e2e present → d4 (RT) does not exist → no RT badge.
+  it("missing depth → no badge rendered (BE absent when chat/tools missing)", () => {
+    // Only e2e present → d4 (BE) does not exist → no BE badge.
     const live = mapOf([row(keyFor("e2e", SLUG, FEATURE), "e2e", "green")]);
     const { container } = renderCell(live, FEATURE, ["health"]);
     const rtLabels = Array.from(container.querySelectorAll("span")).filter(
-      (s) => s.textContent === "RT",
+      (s) => s.textContent === "BE",
     );
     expect(rtLabels.length).toBe(0);
   });

--- a/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
@@ -446,7 +446,7 @@ describe("Overlay selector integration — real UI components", () => {
   // -------------------------------------------------------------------------
   // 9. Testing-kind features: CV badges hidden
   // -------------------------------------------------------------------------
-  it("testing-kind feature with health: CV badges hidden, API/RT still shown", () => {
+  it("testing-kind feature with health: CV badges hidden, API/BE still shown", () => {
     const ctx = makeTestingCtx();
     const { getByTestId, getByText, queryByText } = render(
       <ComposedCell ctx={ctx} overlays={overlaySet("health")} />,
@@ -455,7 +455,7 @@ describe("Overlay selector integration — real UI components", () => {
     // Health layer present
     expect(getByTestId("health-layer")).toBeInTheDocument();
 
-    // API and RT badges still visible for testing-kind
+    // API and BE badges still visible for testing-kind
     expect(getByText("API")).toBeInTheDocument();
     expect(getByText("UI")).toBeInTheDocument();
 

--- a/showcase/shell-dashboard/src/components/__tests__/unified-cell.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/unified-cell.test.tsx
@@ -225,7 +225,7 @@ describe("UnifiedCell", () => {
 
       // No badges rendered
       expect(queryByTestId("mock-badge-UI")).not.toBeInTheDocument();
-      expect(queryByTestId("mock-badge-RT")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-BE")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
 
       // No layer divs rendered
@@ -298,11 +298,11 @@ describe("UnifiedCell", () => {
 
   // ── Test 3: Only shows badges for test levels that exist ──────────
   describe("badge existence filtering", () => {
-    it("shows E2E badge when D3 exists but hides RT badge when D4 is missing", () => {
+    it("shows E2E badge when D3 exists but hides BE badge when D4 is missing", () => {
       const ctx = makeCtx();
       const model = makeModel({
         d3: makeLevel(true, "green"),
-        d4: makeLevel(false), // D4 missing -- no RT badge
+        d4: makeLevel(false), // D4 missing -- no BE badge
         d5: makeLevel(true, "red"),
       });
       const { getByTestId, queryByTestId } = render(
@@ -311,8 +311,8 @@ describe("UnifiedCell", () => {
 
       // E2E badge present (D3 exists)
       expect(getByTestId("mock-badge-UI")).toBeInTheDocument();
-      // RT badge absent (D4 does not exist)
-      expect(queryByTestId("mock-badge-RT")).not.toBeInTheDocument();
+      // BE badge absent (D4 does not exist)
+      expect(queryByTestId("mock-badge-BE")).not.toBeInTheDocument();
       // CV badge present (D5 exists)
       expect(getByTestId("mock-badge-CV")).toBeInTheDocument();
     });
@@ -329,7 +329,7 @@ describe("UnifiedCell", () => {
       );
 
       expect(queryByTestId("mock-badge-UI")).not.toBeInTheDocument();
-      expect(queryByTestId("mock-badge-RT")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-BE")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
     });
 
@@ -345,14 +345,14 @@ describe("UnifiedCell", () => {
       );
 
       expect(queryByTestId("mock-badge-UI")).not.toBeInTheDocument();
-      expect(getByTestId("mock-badge-RT")).toBeInTheDocument();
+      expect(getByTestId("mock-badge-BE")).toBeInTheDocument();
       expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
     });
   });
 
   // ── Test 4: Shows all three badges when all levels exist ──────────
   describe("all badges visible", () => {
-    it("shows E2E, RT, and CV badges when all three levels exist", () => {
+    it("shows E2E, BE, and CV badges when all three levels exist", () => {
       const ctx = makeCtx();
       const model = makeModel({
         d3: makeLevel(true, "green"),
@@ -367,7 +367,7 @@ describe("UnifiedCell", () => {
       expect(e2eBadge).toBeInTheDocument();
       expect(e2eBadge.getAttribute("data-tone")).toBe("green");
 
-      const rtBadge = getByTestId("mock-badge-RT");
+      const rtBadge = getByTestId("mock-badge-BE");
       expect(rtBadge).toBeInTheDocument();
       expect(rtBadge.getAttribute("data-tone")).toBe("amber");
 
@@ -392,7 +392,7 @@ describe("UnifiedCell", () => {
 
       expect(queryByTestId("health-layer")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-UI")).not.toBeInTheDocument();
-      expect(queryByTestId("mock-badge-RT")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-BE")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
     });
 

--- a/showcase/shell-dashboard/src/components/adaptive-legend.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-legend.tsx
@@ -66,7 +66,7 @@ function HealthLegend() {
       </LegendItem>
       <LegendItem>
         <span className="font-semibold text-[var(--text-secondary)]">D4</span>
-        Round Trip (RT): single message, full-stack response verification
+        Round Trip (BE): single message, full-stack response verification
       </LegendItem>
       <LegendItem>
         <span className="font-semibold text-[var(--text-secondary)]">D5</span>

--- a/showcase/shell-dashboard/src/components/cell-drilldown.tsx
+++ b/showcase/shell-dashboard/src/components/cell-drilldown.tsx
@@ -3,7 +3,7 @@
  * CellDrilldown — popover panel showing per-badge dimension detail for a
  * single (integration, feature) cell.
  *
- * Renders all relevant badge dimensions (d6/Parity, d5/CV, d4/RT,
+ * Renders all relevant badge dimensions (d6/Parity, d5/CV, d4/BE,
  * e2e/UI, d2/API, health) with tone, label, and — for red/amber badges —
  * failure metadata presented as readable key-value pairs with the full
  * signal collapsible for debugging.
@@ -40,7 +40,7 @@ export interface CellDrilldownProps {
 
 /**
  * Dimension metadata for display ordering (descending depth). Labels follow
- * the legend's canonical taxonomy (adaptive-legend.tsx): D4 = "RT (Round
+ * the legend's canonical taxonomy (adaptive-legend.tsx): D4 = "BE (Round
  * Trip)" (chat+tools round-trip), D3/e2e = "UI (Frontend)" (the demo page
  * renders in a browser). BadgeRow derives its data-testid from the label,
  * so labels must stay unique across rows.
@@ -56,7 +56,7 @@ const DIMENSIONS: Array<{
 }> = [
   { key: "d6", label: "Parity (Reference)" },
   { key: "d5", label: "CV (Conversation)" },
-  { key: "d4", label: "RT (Round Trip)" },
+  { key: "d4", label: "BE (Round Trip)" },
   { key: "e2e", label: "UI (Frontend)" },
   { key: "d2", label: "API (Agent)" },
   { key: "health", label: "Health" },

--- a/showcase/shell-dashboard/src/components/cell-pieces.signal-degrade.test.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.signal-degrade.test.tsx
@@ -121,8 +121,8 @@ function degradedHealthRowNoSignal(): StatusRow {
 
 function rtTitle(container: HTMLElement): string | null {
   // The e2e badge — taxonomy cleanup renamed it from the crossed "RT" label
-  // to "UI" (formerly "E2E"; the grid's RT name now belongs to the D4
-  // chat/tools badge in unified-cell).
+  // to "UI" (formerly "E2E"; the grid's BE name (formerly RT) now belongs to
+  // the D4 chat/tools badge in unified-cell).
   const span = Array.from(container.querySelectorAll("span[title]")).find(
     (s) => s.querySelector("span:first-child")?.textContent?.trim() === "UI",
   );

--- a/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
@@ -5,7 +5,7 @@
  *   - CP5: missing-state tooltip distinguishes opt-out vs absent
  *   - CP7: error-state docs link is clickable when href is present
  *   - CP8: CV badges hidden for testing-kind features
- *   - docs-only kind hides ALL badges (API, RT, CV)
+ *   - docs-only kind hides ALL badges (API, BE, CV)
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent, waitFor } from "@testing-library/react";

--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -137,7 +137,7 @@ function DepthLayer({
 }
 
 /**
- * Render the Health layer: RT, CV, FP badge chips via CellStatus.
+ * Render the Health layer: BE, CV, FP badge chips via CellStatus.
  */
 function HealthLayer({ ctx }: { ctx: CellContext }) {
   return (

--- a/showcase/shell-dashboard/src/components/unified-cell.tsx
+++ b/showcase/shell-dashboard/src/components/unified-cell.tsx
@@ -226,10 +226,10 @@ function HealthLayer({ model }: { model: CellModel }) {
       className="flex items-center justify-center gap-2.5"
     >
       {/* Legend-correct names: D3 = UI (frontend renders in a browser; the
-          "API" name belongs to the D2 agent badge), D4 = RT (chat/tools
+          "API" name belongs to the D2 agent badge), D4 = BE (chat/tools
           round-trip). */}
       <TestBadge name="UI" level={model.d3} />
-      <TestBadge name="RT" level={model.d4} />
+      <TestBadge name="BE" level={model.d4} />
       <TestBadge name="CV" level={model.d5} />
       {/*
         D6 is the TOP of the verification ladder, so its badge must reflect the
@@ -240,7 +240,7 @@ function HealthLayer({ model }: { model: CellModel }) {
             is genuinely FAILING — D3/D4 non-green or a mapped D5 red/amber):
             render a VISIBLE not-achieved indicator ("—", gray) — NOT the
             no-data "?" (which the real Badge hides → the badge would vanish).
-            The actual lower-rung failure is already shown by the CV/API/RT
+            The actual lower-rung failure is already shown by the CV/API/BE
             badges.
           - NO-DATA (d6 does not exist, OR d6Effective null only because the
             ladder is unverified/no-data — e.g. empty live map → D5 mapped but
@@ -248,7 +248,7 @@ function HealthLayer({ model }: { model: CellModel }) {
             badge. A no-data ladder is NOT a failure, so it shows nothing.
           - LADDER INTACT (d6Effective non-null): pass d6Effective through so a
             genuine D6 red/amber/green renders per-dimension.
-        API/RT/CV stay per-dimension (diagnostic); only D6 is gated. See
+        API/BE/CV stay per-dimension (diagnostic); only D6 is gated. See
         `d6Effective` in cell-model.ts.
       */}
       {(() => {

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -63,7 +63,7 @@ export interface CellModel {
    * D5 is red/amber/no-data), the raw D6 result is meaningless as a top-of-ladder
    * claim, so this collapses to `null` (blocked/not-achieved — rendered gray/—,
    * NOT a false green and NOT a false red; the actual lower-rung failure is
-   * already shown by the CV/API/RT badges). When the ladder IS intact through D5,
+   * already shown by the CV/API/BE badges). When the ladder IS intact through D5,
    * the raw D6 status passes through (a genuine D6 red still surfaces as red).
    *
    * D5-UNMAPPED EXCEPTION (`!d5.exists`): when D5 is not mapped for this feature
@@ -939,7 +939,7 @@ export function buildCellModel(
   // meaningful when the ladder through D5 is intact. This reuses the SAME
   // ladder predicates the chip uses above (`d1d4GateFails`, `d5.status`) so the
   // badge/stat never contradict the chip:
-  //   gate fails              → null (blocked; API/RT badge shows the failure)
+  //   gate fails              → null (blocked; API/BE badge shows the failure)
   //   D4 no-data (status null)→ null (ladder UNVERIFIED at D4 — the
   //                             missing-chat collapse; same blocked outcome
   //                             as a failing gate, but the chip shows gray)

--- a/showcase/shell-dashboard/src/lib/page-stats.ts
+++ b/showcase/shell-dashboard/src/lib/page-stats.ts
@@ -219,7 +219,7 @@ export function computeDepthDistribution(
  * green D6 row would otherwise overstate as "D6 green" — collapses to `null`
  * (blocked) and is counted as `gray`, NOT green. This makes the headline D6
  * count agree with the matrix's per-cell D6 badge (which renders the same
- * `d6Effective`) and the chip; the standalone CV/API/RT badges still show the
+ * `d6Effective`) and the chip; the standalone CV/API/BE badges still show the
  * raw per-dimension failure.
  *
  * Buckets stay coherent with the badge tone mapping:


### PR DESCRIPTION
## Summary

Renames the per-cell health badge from **`RT`** to **`BE`** in the showcase dashboard cell grid. Mirrors PR #5473's `E2E → UI` shape exactly — a follow-up to PR #5498 which renamed the L1 row label / catalog stats display ("Wired" → "BE (Agent)") but missed the per-cell badge code, which is what the user actually asked for.

## Why

PR #5498 unified the long-form display label "Wired" → "BE (Agent)" across the L1 row in `level-strip`, the legend in `packages-section`, and the catalog status display in `stats-bar`/`adaptive-stats-bar`/`coverage-bar`/`filter-chips`. But the per-cell badge grid (D3=`UI`, D4=`RT`, D5=`CV`, D6=`D6`) still showed `RT ✓` because that label lives in `unified-cell.tsx`'s `HealthLayer` component — outside #5498's diff.

PR #5473 set the exact precedent: when relabeling `E2E (Demo)` → `UI (Frontend)`, both the long form AND the 2-char cell badge code (`name="E2E"` → `name="UI"`) flipped. This PR applies the same shape: the long form `BE (Agent)` already exists (from #5498); now the 2-char cell badge code flips `RT` → `BE`.

## Scope

13 files, +51/-51 lines:

**Visible label flips (sources, 6 files):**
- `unified-cell.tsx` — `<TestBadge name="RT" level={model.d4} />` → `name="BE"`, legend comment `"D4 = RT"` → `"D4 = BE"`, doc-comment refs `CV/API/RT` → `CV/API/BE`
- `cell-drilldown.tsx` — `{ key: "d4", label: "RT (Round Trip)" }` → `"BE (Round Trip)"`, doc-comments updated
- `adaptive-legend.tsx` — `"Round Trip (RT)"` → `"Round Trip (BE)"`
- `composed-cell.tsx`, `lib/cell-model.ts`, `lib/page-stats.ts` — comment references

**Test updates (7 files):**
- `cell-pieces.test.tsx`, `cell-pieces.signal-degrade.test.tsx`
- `__tests__/cell-drilldown.lazy-signal.test.tsx`, `__tests__/cell-drilldown.test.tsx`
- `__tests__/dashboard-color-matrix.test.tsx`, `__tests__/overlay-selector-integration.test.tsx`, `__tests__/unified-cell.test.tsx`
- Updates: `mock-badge-RT` → `mock-badge-BE`, `drilldown-badge-rt-…` → `drilldown-badge-be-…`, `"RT (Round Trip)"` → `"BE (Round Trip)"`, `"RT"` literal assertions → `"BE"`

## Stable contracts preserved (no behavior change)

- `level={model.d4}` — D4 dimension level identifier
- `dimensionKey={keyFor("e2e", …)}` (where applicable) and other persisted dimension codes
- Probe registry keys `d4` / `chat` / `tools`
- All PocketBase row keys, LiveDimension union values, Status enum string values

Only the visible `name` string flips.

## Remaining "RT" references (intentional)

2 historical-commentary references in `cell-pieces.signal-degrade.test.tsx` lines 123–124 documenting the rename lineage (`RT → UI → BE`). Not visible UI strings or test assertions.

## Verification

- typecheck (`tsc --noEmit`): clean
- tests (`vitest run`): 1089 passed / 1 skipped / 0 failed across 63 files
- build (`next build`): clean
- oxfmt `--check`: all 13 files correctly formatted
- NUL-byte scan: empty

## Related

- PR #5473 — original `E2E → UI` taxonomy rename (template)
- PR #5498 — `"Wired" → "BE (Agent)"` L1 row + catalog stats (which missed this cell-badge rename)