### PR TITLE
refactor(showcase): rename CV→1P + normalize API (HTTP) / BE (Agent) labels

### DIFF
--- a/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.lazy-signal.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.lazy-signal.test.tsx
@@ -345,7 +345,7 @@ describe("CellDrilldown — lazy signal fetch (real PocketBase SDK)", () => {
     );
 
     const healthBadge = getByTestId("drilldown-badge-health");
-    // The e2e row's label-derived testid: `BE (Round Trip)` now belongs to
+    // The e2e row's label-derived testid: `BE (Agent)` now belongs to
     // the D4 row (whose fixtures here have no chat/tools data), so the e2e
     // row must be selected via its renamed `UI (Frontend)` label.
     const e2eBadge = getByTestId("drilldown-badge-ui--frontend-");

--- a/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
@@ -68,12 +68,12 @@ describe("CellDrilldown", () => {
     expect(getByTestId("cell-drilldown")).toBeDefined();
     expect(getByText("Parity (Reference)")).toBeDefined();
     expect(getByText("1P (Single Pill)")).toBeDefined();
-    // `BE (Round Trip)` is now the D4 (chat+tools round-trip) row …
-    expect(getByText("BE (Round Trip)")).toBeDefined();
+    // `BE (Agent)` is now the D4 (chat+tools round-trip) row …
+    expect(getByText("BE (Agent)")).toBeDefined();
     // … and the e2e row carries the renamed `UI (Frontend)` label
     // (was `E2E (Demo)` — taxonomy cleanup).
     expect(getByText("UI (Frontend)")).toBeDefined();
-    expect(getByText("API (Agent)")).toBeDefined();
+    expect(getByText("API (HTTP)")).toBeDefined();
     expect(getByText("Health")).toBeDefined();
     // The "Smoke" row was dropped: the /smoke endpoint had the same contract
     // as /health on the same service (pure redundancy) and is no longer
@@ -81,7 +81,7 @@ describe("CellDrilldown", () => {
     expect(queryByText("Smoke")).toBeNull();
   });
 
-  it("renders a red BE (Round Trip) row for a red D4 fold while the service line stays green (headline drilldown-parity bug)", () => {
+  it("renders a red BE (Agent) row for a red D4 fold while the service line stays green (headline drilldown-parity bug)", () => {
     // The dimension that turns the pill red (D4: red tools round-trip) must
     // be VISIBLE in the popup. Pre-fix the popup had no D4 row at all, so a
     // pill-red cell showed nothing non-green to explain itself.
@@ -101,9 +101,9 @@ describe("CellDrilldown", () => {
         onClose={() => {}}
       />,
     );
-    // The d4 row owns the `BE (Round Trip)` label (and so its derived testid).
-    const rtBadge = getByTestId("drilldown-badge-be--round-trip-");
-    expect(rtBadge.textContent).toContain("BE (Round Trip)");
+    // The d4 row owns the `BE (Agent)` label (and so its derived testid).
+    const rtBadge = getByTestId("drilldown-badge-be--agent-");
+    expect(rtBadge.textContent).toContain("BE (Agent)");
     expect(rtBadge.textContent).toContain("✗");
     // The service-scoped line (health + e2e) is still green — honest scope.
     expect(getByText("green")).toBeDefined();
@@ -119,7 +119,7 @@ describe("CellDrilldown", () => {
     ).toBe("red");
   });
 
-  it("renders strikethrough n/a on the BE (Round Trip) row when chat/tools rows are absent", () => {
+  it("renders strikethrough n/a on the BE (Agent) row when chat/tools rows are absent", () => {
     const live = mapOf([
       row("health:lgp", "health", "green", { ...FRESH }),
       row("e2e:lgp/agentic-chat", "e2e", "green", { ...FRESH }),
@@ -134,8 +134,8 @@ describe("CellDrilldown", () => {
         onClose={() => {}}
       />,
     );
-    const rtBadge = getByTestId("drilldown-badge-be--round-trip-");
-    expect(rtBadge.textContent).toContain("BE (Round Trip)");
+    const rtBadge = getByTestId("drilldown-badge-be--agent-");
+    expect(rtBadge.textContent).toContain("BE (Agent)");
     expect(rtBadge.textContent).toContain("n/a");
     expect(rtBadge.querySelector(".line-through")).not.toBeNull();
   });
@@ -155,7 +155,7 @@ describe("CellDrilldown", () => {
     expect(queryByText("Rollup")).toBeNull();
   });
 
-  it("renames the e2e label to UI (Frontend); exactly ONE row is labelled BE (Round Trip)", () => {
+  it("renames the e2e label to UI (Frontend); exactly ONE row is labelled BE (Agent)", () => {
     const live = mapOf([
       row("e2e:lgp/agentic-chat", "e2e", "green", { ...FRESH }),
       row("chat:lgp", "chat", "green", { ...FRESH }),
@@ -174,10 +174,10 @@ describe("CellDrilldown", () => {
     // E2E (Demo) was renamed to UI (Frontend); the underlying `e2e:<slug>/<feature>`
     // probe key is preserved on PocketBase for backward compatibility.
     expect(getByText("UI (Frontend)")).toBeDefined();
-    expect(getAllByText("BE (Round Trip)").length).toBe(1);
+    expect(getAllByText("BE (Agent)").length).toBe(1);
   });
 
-  it("shows fail count and extracted Error field on a red BE (Round Trip) / D4 row", () => {
+  it("shows fail count and extracted Error field on a red BE (Agent) / D4 row", () => {
     const live = mapOf([
       row("chat:lgp", "chat", "green", { ...FRESH }),
       row("tools:lgp", "tools", "red", {
@@ -197,7 +197,7 @@ describe("CellDrilldown", () => {
         onClose={() => {}}
       />,
     );
-    const rtBadge = getByTestId("drilldown-badge-be--round-trip-");
+    const rtBadge = getByTestId("drilldown-badge-be--agent-");
     expect(within(rtBadge).getByTestId("fail-count").textContent).toBe("3");
     expect(within(rtBadge).getByTestId("signal-field-error").textContent).toBe(
       "boom",

--- a/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/cell-drilldown.test.tsx
@@ -67,7 +67,7 @@ describe("CellDrilldown", () => {
     );
     expect(getByTestId("cell-drilldown")).toBeDefined();
     expect(getByText("Parity (Reference)")).toBeDefined();
-    expect(getByText("CV (Conversation)")).toBeDefined();
+    expect(getByText("1P (Single Pill)")).toBeDefined();
     // `BE (Round Trip)` is now the D4 (chat+tools round-trip) row …
     expect(getByText("BE (Round Trip)")).toBeDefined();
     // … and the e2e row carries the renamed `UI (Frontend)` label

--- a/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/dashboard-color-matrix.test.tsx
@@ -21,7 +21,7 @@
  *
  * Covered:
  *   (1) per-depth single-key pass→green/fail→red/missing→(no badge) for
- *       API(d3)/BE(d4)/CV(d5)/D6, asserted as RENDERED badge tone+glyph.
+ *       API(d3)/BE(d4)/1P(d5)/D6, asserted as RENDERED badge tone+glyph.
  *   (2) D6 enum fan-out rollup — beautiful-chat 5-key all-pass/any-fail/
  *       all-missing/partial → documented chip color; the 1:1 + rename
  *       mappings (headless-complete, chat-customization-css, gen-ui-tool-based).
@@ -203,13 +203,13 @@ const CHIP_CLASS: Record<ChipColor, string> = {
 //     asserted as the RENDERED badge tone class + glyph.
 // ===========================================================================
 
-describe("(1) per-depth badge rendering — UI/BE/CV/D6", () => {
+describe("(1) per-depth badge rendering — UI/BE/1P/D6", () => {
   // agentic-chat is 1:1 mapped (CATALOG_TO_D5_KEY["agentic-chat"] =
   // ["agentic-chat"]) so each depth is a single key, isolating one badge.
   const FEATURE = "agentic-chat";
 
   interface DepthCase {
-    badge: "UI" | "BE" | "CV" | "D6";
+    badge: "UI" | "BE" | "1P" | "D6";
     /** rows that set THIS depth's state; gate rows added automatically. */
     rows: StatusRow[];
     expectStatus: TestStatus;
@@ -248,9 +248,9 @@ describe("(1) per-depth badge rendering — UI/BE/CV/D6", () => {
       ],
       expectStatus: "red",
     },
-    // CV (d5) — single enum key (agentic-chat→agentic-chat)
+    // 1P (d5) — single enum key (agentic-chat→agentic-chat)
     {
-      badge: "CV",
+      badge: "1P",
       rows: [
         ...gateGreen(FEATURE),
         row(keyFor("d5", SLUG, FEATURE), "d5", "green"),
@@ -258,7 +258,7 @@ describe("(1) per-depth badge rendering — UI/BE/CV/D6", () => {
       expectStatus: "green",
     },
     {
-      badge: "CV",
+      badge: "1P",
       rows: [
         ...gateGreen(FEATURE),
         row(keyFor("d5", SLUG, FEATURE), "d5", "red"),
@@ -290,7 +290,7 @@ describe("(1) per-depth badge rendering — UI/BE/CV/D6", () => {
     it(`${c.badge} ${c.expectStatus} → tone ${BADGE_RENDER[c.expectStatus ?? "null"].tone}, glyph ${BADGE_RENDER[c.expectStatus ?? "null"].glyph}`, () => {
       const live = mapOf(c.rows);
       const { container } = renderCell(live, FEATURE, ["health"]);
-      // Find the badge by its leading label text (UI/BE/CV/D6).
+      // Find the badge by its leading label text (UI/BE/1P/D6).
       const labels = Array.from(container.querySelectorAll("span")).filter(
         (s) => s.textContent === c.badge,
       );
@@ -316,15 +316,15 @@ describe("(1) per-depth badge rendering — UI/BE/CV/D6", () => {
   });
 
   it("no-data depth (mapped, unemitted) → no badge (glyph '?' → Badge null)", () => {
-    // Gate green, D5 mapped but unemitted → d5.status null → CV glyph "?"
-    // → Badge returns null. The CV badge must NOT render.
+    // Gate green, D5 mapped but unemitted → d5.status null → 1P glyph "?"
+    // → Badge returns null. The 1P badge must NOT render.
     const live = mapOf(gateGreen(FEATURE));
     const model = wiredModel(live, FEATURE);
     expect(model.d5?.exists).toBe(true);
     expect(model.d5?.status).toBeNull();
     const { container } = renderCell(live, FEATURE, ["health"]);
     const cvLabels = Array.from(container.querySelectorAll("span")).filter(
-      (s) => s.textContent === "CV",
+      (s) => s.textContent === "1P",
     );
     expect(cvLabels.length).toBe(0);
   });

--- a/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
+++ b/showcase/shell-dashboard/src/components/__tests__/depth-utils.test.ts
@@ -227,7 +227,7 @@ describe("deriveDepth", () => {
 
   // ── isRegression now compares against maxPossible, not historical max_depth ──
 
-  it("isRegression is true when achieved < maxPossible (D5 mapping exists, CV red)", () => {
+  it("isRegression is true when achieved < maxPossible (D5 mapping exists, 1P red)", () => {
     // "agentic-chat" has D5 mapping → maxPossible=6, achieved=4 → regression
     const c = cell("lgp", "agentic-chat", "wired", 4);
     const live = mapOf([
@@ -601,7 +601,7 @@ describe("deriveDepth", () => {
       expect(result.isRegression).toBe(false);
     });
 
-    it("(b) D5 mapping exists, CV red → achieved=4, maxPossible=6, chip=AMBER territory", () => {
+    it("(b) D5 mapping exists, 1P red → achieved=4, maxPossible=6, chip=AMBER territory", () => {
       const c = cell("lgp", "agentic-chat");
       const live = mapOf([
         row("health:lgp", "health", "green"),
@@ -616,7 +616,7 @@ describe("deriveDepth", () => {
       expect(result.isRegression).toBe(true);
     });
 
-    it("(c) D5 mapping exists, CV no data → achieved=4, maxPossible=6, chip=AMBER territory", () => {
+    it("(c) D5 mapping exists, 1P no data → achieved=4, maxPossible=6, chip=AMBER territory", () => {
       const c = cell("lgp", "agentic-chat");
       const live = mapOf([
         row("health:lgp", "health", "green"),

--- a/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/overlay-selector-integration.test.tsx
@@ -207,10 +207,10 @@ describe("Overlay selector integration — real UI components", () => {
     expect(queryByTestId("depth-chip")).not.toBeInTheDocument();
     expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
 
-    // No health badges (API, UI, CV)
+    // No health badges (API, UI, 1P)
     expect(queryByText("API")).not.toBeInTheDocument();
     expect(queryByText("UI")).not.toBeInTheDocument();
-    expect(queryByText("CV")).not.toBeInTheDocument();
+    expect(queryByText("1P")).not.toBeInTheDocument();
 
     // No docs indicators
     expect(queryByText("docs-og")).not.toBeInTheDocument();
@@ -250,9 +250,9 @@ describe("Overlay selector integration — real UI components", () => {
   // -------------------------------------------------------------------------
   // 3. Health only — the critical case (no docs indicators must appear)
   // -------------------------------------------------------------------------
-  it("health only: API/UI/CV badges visible, NO docs indicators", () => {
+  it("health only: API/UI/1P badges visible, NO docs indicators", () => {
     // `agentic-chat` is a real CATALOG_TO_D5_KEY entry, so its d5 row resolves
-    // green and the CV badge renders. An UNMAPPED feature's CV badge is gray
+    // green and the 1P badge renders. An UNMAPPED feature's 1P badge is gray
     // "?" and hidden by design (resolveD5Row returns null for unmapped
     // features, matching resolveD5 / isD5Green) — "don't show tests that
     // don't exist".
@@ -274,7 +274,7 @@ describe("Overlay selector integration — real UI components", () => {
     expect(getByTestId("health-layer")).toBeInTheDocument();
     expect(getByText("API")).toBeInTheDocument();
     expect(getByText("UI")).toBeInTheDocument();
-    expect(getByText("CV")).toBeInTheDocument();
+    expect(getByText("1P")).toBeInTheDocument();
 
     // No docs indicators — this is the critical regression test for B2's fix
     expect(queryByText("docs-og")).not.toBeInTheDocument();
@@ -338,8 +338,8 @@ describe("Overlay selector integration — real UI components", () => {
   // 6. Health + Docs — both badges AND docs indicators visible
   // -------------------------------------------------------------------------
   it("health + docs: badges AND docs indicators both visible", () => {
-    // `agentic-chat` is a real CATALOG_TO_D5_KEY entry so the CV badge has a
-    // resolved (green) d5 row to render; an unmapped feature's CV badge is
+    // `agentic-chat` is a real CATALOG_TO_D5_KEY entry so the 1P badge has a
+    // resolved (green) d5 row to render; an unmapped feature's 1P badge is
     // hidden by design. The docs-status mock also covers `agentic-chat`, so
     // the docs-og / docs-shell indicators still resolve.
     const ctx = makeCtx({
@@ -360,7 +360,7 @@ describe("Overlay selector integration — real UI components", () => {
     expect(getByTestId("health-layer")).toBeInTheDocument();
     expect(getByText("API")).toBeInTheDocument();
     expect(getByText("UI")).toBeInTheDocument();
-    expect(getByText("CV")).toBeInTheDocument();
+    expect(getByText("1P")).toBeInTheDocument();
 
     // Docs layer
     expect(getByTestId("docs-layer")).toBeInTheDocument();
@@ -444,9 +444,9 @@ describe("Overlay selector integration — real UI components", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 9. Testing-kind features: CV badges hidden
+  // 9. Testing-kind features: 1P badges hidden
   // -------------------------------------------------------------------------
-  it("testing-kind feature with health: CV badges hidden, API/BE still shown", () => {
+  it("testing-kind feature with health: 1P badges hidden, API/BE still shown", () => {
     const ctx = makeTestingCtx();
     const { getByTestId, getByText, queryByText } = render(
       <ComposedCell ctx={ctx} overlays={overlaySet("health")} />,
@@ -459,8 +459,8 @@ describe("Overlay selector integration — real UI components", () => {
     expect(getByText("API")).toBeInTheDocument();
     expect(getByText("UI")).toBeInTheDocument();
 
-    // CV hidden for testing-kind features (CellStatus hides them)
-    expect(queryByText("CV")).not.toBeInTheDocument();
+    // 1P hidden for testing-kind features (CellStatus hides them)
+    expect(queryByText("1P")).not.toBeInTheDocument();
   });
 
   // -------------------------------------------------------------------------

--- a/showcase/shell-dashboard/src/components/__tests__/unified-cell.test.tsx
+++ b/showcase/shell-dashboard/src/components/__tests__/unified-cell.test.tsx
@@ -226,7 +226,7 @@ describe("UnifiedCell", () => {
       // No badges rendered
       expect(queryByTestId("mock-badge-UI")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-BE")).not.toBeInTheDocument();
-      expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-1P")).not.toBeInTheDocument();
 
       // No layer divs rendered
       expect(queryByTestId("depth-layer")).not.toBeInTheDocument();
@@ -313,8 +313,8 @@ describe("UnifiedCell", () => {
       expect(getByTestId("mock-badge-UI")).toBeInTheDocument();
       // BE badge absent (D4 does not exist)
       expect(queryByTestId("mock-badge-BE")).not.toBeInTheDocument();
-      // CV badge present (D5 exists)
-      expect(getByTestId("mock-badge-CV")).toBeInTheDocument();
+      // 1P badge present (D5 exists)
+      expect(getByTestId("mock-badge-1P")).toBeInTheDocument();
     });
 
     it("hides all badges when no test levels exist", () => {
@@ -330,7 +330,7 @@ describe("UnifiedCell", () => {
 
       expect(queryByTestId("mock-badge-UI")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-BE")).not.toBeInTheDocument();
-      expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-1P")).not.toBeInTheDocument();
     });
 
     it("hides badge when level is null", () => {
@@ -346,13 +346,13 @@ describe("UnifiedCell", () => {
 
       expect(queryByTestId("mock-badge-UI")).not.toBeInTheDocument();
       expect(getByTestId("mock-badge-BE")).toBeInTheDocument();
-      expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-1P")).not.toBeInTheDocument();
     });
   });
 
   // ── Test 4: Shows all three badges when all levels exist ──────────
   describe("all badges visible", () => {
-    it("shows E2E, BE, and CV badges when all three levels exist", () => {
+    it("shows E2E, BE, and 1P badges when all three levels exist", () => {
       const ctx = makeCtx();
       const model = makeModel({
         d3: makeLevel(true, "green"),
@@ -371,7 +371,7 @@ describe("UnifiedCell", () => {
       expect(rtBadge).toBeInTheDocument();
       expect(rtBadge.getAttribute("data-tone")).toBe("amber");
 
-      const cvBadge = getByTestId("mock-badge-CV");
+      const cvBadge = getByTestId("mock-badge-1P");
       expect(cvBadge).toBeInTheDocument();
       expect(cvBadge.getAttribute("data-tone")).toBe("red");
     });
@@ -393,7 +393,7 @@ describe("UnifiedCell", () => {
       expect(queryByTestId("health-layer")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-UI")).not.toBeInTheDocument();
       expect(queryByTestId("mock-badge-BE")).not.toBeInTheDocument();
-      expect(queryByTestId("mock-badge-CV")).not.toBeInTheDocument();
+      expect(queryByTestId("mock-badge-1P")).not.toBeInTheDocument();
     });
 
     // ── Test 6: Hides depth chip when depth overlay is not active ───
@@ -459,7 +459,7 @@ describe("UnifiedCell", () => {
       // Raw D6 dimension is green, but D5 is red so the ladder is broken
       // below D6 → d6Effective null. The D6 badge must render a real, VISIBLE
       // not-achieved indicator ("—", gray) — NOT a "?" that the real Badge
-      // hides, and never green; CV stays per-dimension red (diagnostic).
+      // hides, and never green; 1P stays per-dimension red (diagnostic).
       const model = makeModel({
         d3: makeLevel(true, "green"),
         d4: makeLevel(true, "green"),
@@ -482,8 +482,8 @@ describe("UnifiedCell", () => {
       expect(d6Badge.getAttribute("data-tone")).not.toBe("green");
       expect(d6Badge.textContent).toContain("—");
 
-      // CV badge still shows the real per-dimension D5 failure (red).
-      expect(getByTestId("mock-badge-CV").getAttribute("data-tone")).toBe(
+      // 1P badge still shows the real per-dimension D5 failure (red).
+      expect(getByTestId("mock-badge-1P").getAttribute("data-tone")).toBe(
         "red",
       );
     });

--- a/showcase/shell-dashboard/src/components/adaptive-legend.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-legend.tsx
@@ -70,8 +70,8 @@ function HealthLegend() {
       </LegendItem>
       <LegendItem>
         <span className="font-semibold text-[var(--text-secondary)]">D5</span>
-        Conversation (CV): multi-turn scripted dialogue with tool calls and
-        content assertions
+        Single Pill (1P): one scripted conversation from the canonical aimock
+        fixture set; D6 runs all pills
       </LegendItem>
       <LegendItem>
         <span className="font-semibold text-[var(--text-secondary)]">D6</span>
@@ -94,7 +94,7 @@ function HealthLegend() {
         <span className="text-[var(--ok)]">D5</span>/
         <span className="text-[var(--amber)]">D5</span>/
         <span className="text-[var(--danger)]">D5</span>
-        conversation check (green pass / amber stale / red fail)
+        single-pill check (green pass / amber stale / red fail)
       </LegendItem>
       <LegendItem>
         <span className="text-[var(--ok)]">D6</span>/

--- a/showcase/shell-dashboard/src/components/adaptive-legend.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-legend.tsx
@@ -58,7 +58,7 @@ function HealthLegend() {
       </LegendItem>
       <LegendItem>
         <span className="font-semibold text-[var(--text-secondary)]">D2</span>
-        API: responds to a basic CopilotKit API call
+        API (HTTP): backend service is up and HTTP-reachable
       </LegendItem>
       <LegendItem>
         <span className="font-semibold text-[var(--text-secondary)]">D3</span>
@@ -66,7 +66,8 @@ function HealthLegend() {
       </LegendItem>
       <LegendItem>
         <span className="font-semibold text-[var(--text-secondary)]">D4</span>
-        Round Trip (BE): single message, full-stack response verification
+        BE (Agent): single message round-trip — agent processes a chat message
+        end-to-end
       </LegendItem>
       <LegendItem>
         <span className="font-semibold text-[var(--text-secondary)]">D5</span>

--- a/showcase/shell-dashboard/src/components/adaptive-stats-bar.tsx
+++ b/showcase/shell-dashboard/src/components/adaptive-stats-bar.tsx
@@ -144,7 +144,7 @@ function DepthSection({
   const unsupported = catalog.metadata.unsupported ?? 0;
   return (
     <div className="flex items-center gap-4">
-      <Stat value={wired} label="BE (Agent)" colorClass="text-[var(--ok)]" />
+      <Stat value={wired} label="API (HTTP)" colorClass="text-[var(--ok)]" />
       <Stat value={stub} label="Stub" colorClass="text-[var(--amber)]" />
       <Stat
         value={unshipped}
@@ -179,7 +179,7 @@ function DepthSection({
  *
  * Only depths `buildCellModel().achievedDepth` can produce are shown. D0 (wired
  * but no passing rung yet) is rendered so wired-unverified cells stay visible
- * and the row sums to the "BE (Agent)" count; the never-reachable D1/D2 rows are
+ * and the row sums to the "API (HTTP)" count; the never-reachable D1/D2 rows are
  * omitted instead of rendering permanent zeros.
  */
 function DepthDistributionSection({

--- a/showcase/shell-dashboard/src/components/cell-drilldown.tsx
+++ b/showcase/shell-dashboard/src/components/cell-drilldown.tsx
@@ -3,8 +3,8 @@
  * CellDrilldown — popover panel showing per-badge dimension detail for a
  * single (integration, feature) cell.
  *
- * Renders all relevant badge dimensions (d6/Parity, d5/1P, d4/BE,
- * e2e/UI, d2/API, health) with tone, label, and — for red/amber badges —
+ * Renders all relevant badge dimensions (d6/Parity, d5/1P, d4/BE (Agent),
+ * e2e/UI, d2/API (HTTP), health) with tone, label, and — for red/amber badges —
  * failure metadata presented as readable key-value pairs with the full
  * signal collapsible for debugging.
  *
@@ -40,10 +40,11 @@ export interface CellDrilldownProps {
 
 /**
  * Dimension metadata for display ordering (descending depth). Labels follow
- * the legend's canonical taxonomy (adaptive-legend.tsx): D4 = "BE (Round
- * Trip)" (chat+tools round-trip), D3/e2e = "UI (Frontend)" (the demo page
- * renders in a browser). BadgeRow derives its data-testid from the label,
- * so labels must stay unique across rows.
+ * the legend's canonical taxonomy (adaptive-legend.tsx): D4 = "BE (Agent)"
+ * (single chat message round-trip — agent processes a message end-to-end),
+ * D3/e2e = "UI (Frontend)" (the demo page renders in a browser), D2 =
+ * "API (HTTP)" (backend service is up and HTTP-reachable). BadgeRow derives
+ * its data-testid from the label, so labels must stay unique across rows.
  *
  * The `smoke` row was dropped — the smoke endpoint was redundant with
  * /health on the same service and is no longer probed. `CellState.smoke`
@@ -56,9 +57,9 @@ const DIMENSIONS: Array<{
 }> = [
   { key: "d6", label: "Parity (Reference)" },
   { key: "d5", label: "1P (Single Pill)" },
-  { key: "d4", label: "BE (Round Trip)" },
+  { key: "d4", label: "BE (Agent)" },
   { key: "e2e", label: "UI (Frontend)" },
-  { key: "d2", label: "API (Agent)" },
+  { key: "d2", label: "API (HTTP)" },
   { key: "health", label: "Health" },
 ];
 

--- a/showcase/shell-dashboard/src/components/cell-drilldown.tsx
+++ b/showcase/shell-dashboard/src/components/cell-drilldown.tsx
@@ -3,7 +3,7 @@
  * CellDrilldown — popover panel showing per-badge dimension detail for a
  * single (integration, feature) cell.
  *
- * Renders all relevant badge dimensions (d6/Parity, d5/CV, d4/BE,
+ * Renders all relevant badge dimensions (d6/Parity, d5/1P, d4/BE,
  * e2e/UI, d2/API, health) with tone, label, and — for red/amber badges —
  * failure metadata presented as readable key-value pairs with the full
  * signal collapsible for debugging.
@@ -55,7 +55,7 @@ const DIMENSIONS: Array<{
   label: string;
 }> = [
   { key: "d6", label: "Parity (Reference)" },
-  { key: "d5", label: "CV (Conversation)" },
+  { key: "d5", label: "1P (Single Pill)" },
   { key: "d4", label: "BE (Round Trip)" },
   { key: "e2e", label: "UI (Frontend)" },
   { key: "d2", label: "API (Agent)" },

--- a/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.test.tsx
@@ -4,8 +4,8 @@
  *   - CP2: transitionLine discriminates `first` and `error` transitions
  *   - CP5: missing-state tooltip distinguishes opt-out vs absent
  *   - CP7: error-state docs link is clickable when href is present
- *   - CP8: CV badges hidden for testing-kind features
- *   - docs-only kind hides ALL badges (API, BE, CV)
+ *   - CP8: 1P badges hidden for testing-kind features
+ *   - docs-only kind hides ALL badges (API, BE, 1P)
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent, waitFor } from "@testing-library/react";
@@ -104,7 +104,7 @@ function redE2eRow(): StatusRow {
  * A FRESH green D5 (conversation) row for `test/agentic-chat`, keyed exactly
  * as `CellStatus` looks it up (`d5:<slug>/<featureId>`). `observed_at` is
  * `now` so the stale-green downgrade window (E2E_STALE_AFTER_MS) does NOT fire
- * — the CV badge resolves to a real green label and therefore RENDERS (a "?"
+ * — the 1P badge resolves to a real green label and therefore RENDERS (a "?"
  * label would make `Badge` return null, which is exactly the tautology the CP8
  * test must avoid).
  */
@@ -342,30 +342,30 @@ describe("urlsFor: trailing-slash normalization (SSR placeholder leak)", () => {
   });
 });
 
-describe("CP8: CV badges hidden for testing-kind features", () => {
-  it("renders CV for a primary feature but hides it for a testing-kind feature (same green D5 row)", () => {
-    // Non-tautological setup: a FRESH green D5 row is present, so the CV badge
+describe("CP8: 1P badges hidden for testing-kind features", () => {
+  it("renders 1P for a primary feature but hides it for a testing-kind feature (same green D5 row)", () => {
+    // Non-tautological setup: a FRESH green D5 row is present, so the 1P badge
     // resolves to a real (non-"?") label and WOULD render for a `primary`
-    // feature. If CP8 regressed, the testing-kind cell would also render "CV".
+    // feature. If CP8 regressed, the testing-kind cell would also render "1P".
     const liveStatus = new Map([
       [greenD5Row().key, greenD5Row()],
     ]) as LiveStatusMap;
 
-    // Control: a primary feature with the same row DOES render "CV".
+    // Control: a primary feature with the same row DOES render "1P".
     const primary = render(
       <CellStatus
         ctx={makeCtx({ feature: makeFeature({ kind: "primary" }), liveStatus })}
       />,
     );
-    expect(primary.container.textContent ?? "").toContain("CV");
+    expect(primary.container.textContent ?? "").toContain("1P");
 
-    // Subject: a testing-kind feature with the SAME green D5 row hides "CV".
+    // Subject: a testing-kind feature with the SAME green D5 row hides "1P".
     const testing = render(
       <CellStatus
         ctx={makeCtx({ feature: makeFeature({ kind: "testing" }), liveStatus })}
       />,
     );
-    expect(testing.container.textContent ?? "").not.toContain("CV");
+    expect(testing.container.textContent ?? "").not.toContain("1P");
   });
 
   it("renders badge container for primary features (badges null for '?' labels)", () => {
@@ -402,7 +402,7 @@ describe("docs-only kind hides ALL badges", () => {
     const text = container.textContent ?? "";
     expect(text).not.toContain("API");
     expect(text).not.toContain("UI");
-    expect(text).not.toContain("CV");
+    expect(text).not.toContain("1P");
   });
 });
 

--- a/showcase/shell-dashboard/src/components/cell-pieces.tsx
+++ b/showcase/shell-dashboard/src/components/cell-pieces.tsx
@@ -340,7 +340,7 @@ function formatTransitionLine(row: {
 }
 
 /**
- * Shared status row: API / UI / CV badges (D2 API / D3 UI / D5 Conversation).
+ * Shared status row: API / UI / 1P badges (D2 API / D3 UI / D5 Single Pill).
  * QA and HealthDot removed in Phase 3 (3.3 + 3.4). L1 health now in strip.
  * Smoke per-cell badge removed — integration-scoped smoke lives in the strip.
  * Docs rendering removed — handled exclusively by DocsLayer in ComposedCell,
@@ -384,23 +384,23 @@ export function CellStatus({ ctx }: { ctx: CellContext }) {
         dimensionKey={keyFor("e2e", ctx.integration.slug, ctx.feature.id)}
       />
       {/*
-        CP8: CV producers (`e2e-deep`) only emit rows for primary features
-        per spec; testing-kind features never get a CV row, so the badge
+        CP8: 1P producers (`e2e-deep`) only emit rows for primary features
+        per spec; testing-kind features never get a 1P row, so the badge
         would render a perpetual gray "?" that adds noise without
         information. Hide for `isTesting` so operators only see badges
         backed by real data.
 
-        CP9: CV badges intentionally have no `href` — there is no
+        CP9: 1P badges intentionally have no `href` — there is no
         per-feature drilldown URL convention in shell-dashboard today.
         When a drilldown route exists (e.g. a per-(slug, feature) D5 run
         history page), wire the URL through `keyFor` here.
-        TODO(showcase-dashboard): CV drilldown URL — see
+        TODO(showcase-dashboard): 1P drilldown URL — see
         docs/spec §5.6 follow-up.
       */}
       {!isTesting && (
         <>
           <LiveBadge
-            name="CV"
+            name="1P"
             badge={cell.d5}
             dimensionKey={keyFor("d5", ctx.integration.slug, ctx.feature.id)}
           />

--- a/showcase/shell-dashboard/src/components/composed-cell.tsx
+++ b/showcase/shell-dashboard/src/components/composed-cell.tsx
@@ -137,7 +137,7 @@ function DepthLayer({
 }
 
 /**
- * Render the Health layer: BE, CV, FP badge chips via CellStatus.
+ * Render the Health layer: BE, 1P, FP badge chips via CellStatus.
  */
 function HealthLayer({ ctx }: { ctx: CellContext }) {
   return (

--- a/showcase/shell-dashboard/src/components/depth-utils.ts
+++ b/showcase/shell-dashboard/src/components/depth-utils.ts
@@ -113,7 +113,7 @@ function isD4Green(live: LiveStatusMap, slug: string, now: number): boolean {
  * Check whether all D5 PB rows for a given (slug, catalogFeatureId) are green
  * AND fresh. Returns false if the feature has no D5 mapping or any mapped row
  * is missing/non-green/stale. The staleness gate mirrors `cell-model.ts` so a
- * frozen-green CV row from a stalled driver no longer credits D5.
+ * frozen-green 1P row from a stalled driver no longer credits D5.
  */
 function isD5Green(
   live: LiveStatusMap,
@@ -122,9 +122,9 @@ function isD5Green(
   now: number,
 ): boolean {
   const d5Keys = CATALOG_TO_D5_KEY[featureId];
-  // No D5 mapping = no CV test exists for this feature = cannot be D5.
+  // No D5 mapping = no 1P test exists for this feature = cannot be D5.
   // Previously fell back to a direct key lookup which could resolve true
-  // from stale/shared PB rows, granting D5 to cells without CV tests.
+  // from stale/shared PB rows, granting D5 to cells without 1P tests.
   if (!d5Keys || d5Keys.length === 0) {
     return false;
   }

--- a/showcase/shell-dashboard/src/components/filter-chips.tsx
+++ b/showcase/shell-dashboard/src/components/filter-chips.tsx
@@ -17,7 +17,7 @@ export interface FilterChipsProps {
 
 const FILTERS: Array<{ id: FilterMode; label: string }> = [
   { id: "all", label: "All" },
-  { id: "wired", label: "BE (Agent)" },
+  { id: "wired", label: "API (HTTP)" },
   { id: "gaps", label: "Gaps" },
   { id: "regressions", label: "Regressions" },
   { id: "reference", label: "Reference" },

--- a/showcase/shell-dashboard/src/components/level-strip.test.tsx
+++ b/showcase/shell-dashboard/src/components/level-strip.test.tsx
@@ -61,9 +61,9 @@ describe("LevelStrip", () => {
     );
     const strip = getByTestId("level-strip");
     expect(strip.children).toHaveLength(4);
-    // First letters: U(p), B(E (Agent)), C(hats), T(ools)
+    // First letters: U(p), A(PI (HTTP)), C(hats), T(ools)
     const letters = Array.from(strip.children).map((c) => c.textContent);
-    expect(letters).toEqual(["U", "B", "C", "T"]);
+    expect(letters).toEqual(["U", "A", "C", "T"]);
   });
 
   it("shows green tone when dimension rows are green", () => {
@@ -152,7 +152,7 @@ describe("LevelStrip", () => {
       <LevelStrip integration={integration} liveStatus={live} />,
     );
     const strip = getByTestId("level-strip");
-    const beAgentChip = strip.children[1]!;
-    expect(beAgentChip.getAttribute("title")).toContain("degraded");
+    const apiHttpChip = strip.children[1]!;
+    expect(apiHttpChip.getAttribute("title")).toContain("degraded");
   });
 });

--- a/showcase/shell-dashboard/src/components/level-strip.tsx
+++ b/showcase/shell-dashboard/src/components/level-strip.tsx
@@ -1,6 +1,6 @@
 "use client";
 /**
- * Per-integration L1-L4 strip: four badges showing Up / BE (Agent) / Chats / Tools.
+ * Per-integration L1-L4 strip: four badges showing Up / API (HTTP) / Chats / Tools.
  * Reads integration-scoped rows from the live-status map.
  *
  * No longer used by Coverage tab (overlay-column-header.tsx).
@@ -63,7 +63,7 @@ export function LevelStrip({
 }) {
   const slug = integration.slug;
   const up = resolveBadge(liveStatus, "health", slug, "Up");
-  const wired = resolveBadge(liveStatus, "agent", slug, "BE (Agent)");
+  const wired = resolveBadge(liveStatus, "agent", slug, "API (HTTP)");
   const chats = resolveBadge(liveStatus, "chat", slug, "Chats");
 
   // Tools n/a gate: only show real state if integration has tool-rendering demo

--- a/showcase/shell-dashboard/src/components/packages-section.test.tsx
+++ b/showcase/shell-dashboard/src/components/packages-section.test.tsx
@@ -75,6 +75,6 @@ describe("PackagesSection", () => {
       <PackagesSection liveStatus={emptyLiveStatus} connection="live" />,
     );
     const legend = getByTestId("packages-uwct-legend");
-    expect(legend.textContent).toBe("(U=Up, B=BE (Agent), C=Chats, T=Tools)");
+    expect(legend.textContent).toBe("(U=Up, A=API (HTTP), C=Chats, T=Tools)");
   });
 });

--- a/showcase/shell-dashboard/src/components/packages-section.tsx
+++ b/showcase/shell-dashboard/src/components/packages-section.tsx
@@ -97,7 +97,7 @@ export function PackagesSection({
                   className="ml-2 text-[10px] font-normal normal-case text-[var(--text-muted)]"
                   data-testid="packages-uwct-legend"
                 >
-                  (U=Up, B=BE (Agent), C=Chats, T=Tools)
+                  (U=Up, A=API (HTTP), C=Chats, T=Tools)
                 </span>
               </th>
               <th className="bg-[var(--bg-muted)] px-4 py-2 text-center border-b border-l border-[var(--border)]">

--- a/showcase/shell-dashboard/src/components/stats-bar.tsx
+++ b/showcase/shell-dashboard/src/components/stats-bar.tsx
@@ -54,7 +54,7 @@ export function StatsBar({
 }: StatsBarProps) {
   return (
     <div data-testid="stats-bar" className="flex items-center gap-8 px-4 py-3">
-      <Stat value={wired} label="BE (Agent)" colorClass="text-[var(--ok)]" />
+      <Stat value={wired} label="API (HTTP)" colorClass="text-[var(--ok)]" />
       <Stat value={stub} label="Stub" colorClass="text-[var(--amber)]" />
       <Stat
         value={unshipped}

--- a/showcase/shell-dashboard/src/components/unified-cell.tsx
+++ b/showcase/shell-dashboard/src/components/unified-cell.tsx
@@ -230,7 +230,7 @@ function HealthLayer({ model }: { model: CellModel }) {
           round-trip). */}
       <TestBadge name="UI" level={model.d3} />
       <TestBadge name="BE" level={model.d4} />
-      <TestBadge name="CV" level={model.d5} />
+      <TestBadge name="1P" level={model.d5} />
       {/*
         D6 is the TOP of the verification ladder, so its badge must reflect the
         LADDER-GATED status (`model.d6Effective`), NOT the raw per-dimension
@@ -240,7 +240,7 @@ function HealthLayer({ model }: { model: CellModel }) {
             is genuinely FAILING — D3/D4 non-green or a mapped D5 red/amber):
             render a VISIBLE not-achieved indicator ("—", gray) — NOT the
             no-data "?" (which the real Badge hides → the badge would vanish).
-            The actual lower-rung failure is already shown by the CV/API/BE
+            The actual lower-rung failure is already shown by the 1P/API/BE
             badges.
           - NO-DATA (d6 does not exist, OR d6Effective null only because the
             ladder is unverified/no-data — e.g. empty live map → D5 mapped but
@@ -248,7 +248,7 @@ function HealthLayer({ model }: { model: CellModel }) {
             badge. A no-data ladder is NOT a failure, so it shows nothing.
           - LADDER INTACT (d6Effective non-null): pass d6Effective through so a
             genuine D6 red/amber/green renders per-dimension.
-        API/BE/CV stay per-dimension (diagnostic); only D6 is gated. See
+        API/BE/1P stay per-dimension (diagnostic); only D6 is gated. See
         `d6Effective` in cell-model.ts.
       */}
       {(() => {

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -1771,7 +1771,7 @@ describe("buildCellModel", () => {
       // The exact bug: D5 red but D6 emitted green in isolation. The raw
       // per-dimension d6.status is green, but the top-of-ladder claim is
       // broken below D6, so d6Effective must NOT be green (and not a false
-      // red — the CV badge already shows the D5 failure).
+      // red — the 1P badge already shows the D5 failure).
       const live = mapOf([
         row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
         row(keyFor("chat", "agno"), "chat", "green"),

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -63,7 +63,7 @@ export interface CellModel {
    * D5 is red/amber/no-data), the raw D6 result is meaningless as a top-of-ladder
    * claim, so this collapses to `null` (blocked/not-achieved — rendered gray/—,
    * NOT a false green and NOT a false red; the actual lower-rung failure is
-   * already shown by the CV/API/BE badges). When the ladder IS intact through D5,
+   * already shown by the 1P/API/BE badges). When the ladder IS intact through D5,
    * the raw D6 status passes through (a genuine D6 red still surfaces as red).
    *
    * D5-UNMAPPED EXCEPTION (`!d5.exists`): when D5 is not mapped for this feature
@@ -954,7 +954,7 @@ export function buildCellModel(
   //                             genuine D6 red/amber/green passes through)
   //   D5 red/amber/null       → null (ladder BROKEN/unverified below D6 → the
   //                             D6 claim is not-achieved/blocked; never a false
-  //                             green and never a false red — the CV badge
+  //                             green and never a false red — the 1P badge
   //                             already shows the real lower-rung failure)
   let d6Effective: TestStatus;
   if (d1d4GateFails || d4NoData || d1d4Absent) {

--- a/showcase/shell-dashboard/src/lib/live-status.test.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.test.ts
@@ -965,13 +965,13 @@ describe("resolveCell — post-Phase 3 (rollup uses health + e2e only)", () => {
 
   // ── unmapped feature: no direct-key fallback (mirrors cell-model.ts
   //    resolveD5 / depth-utils.ts isD5Green) ──
-  // A feature NOT in CATALOG_TO_D5_KEY has no CV test, so its D5 badge must
+  // A feature NOT in CATALOG_TO_D5_KEY has no 1P test, so its D5 badge must
   // be gray "?" even when a direct `d5:<slug>/<featureId>` row exists in the
   // map. Pre-fix, resolveD5Row fell back to the direct key and rendered the
   // row's tone (green), contradicting the coverage chip (resolveD5 returns
   // exists:false) and deriveDepth (isD5Green returns false). The fallback was
   // removed from isD5Green because it "could resolve true from stale/shared
-  // PB rows, granting D5 to cells without CV tests" — resolveD5Row must match.
+  // PB rows, granting D5 to cells without 1P tests" — resolveD5Row must match.
   it("d5 unmapped feature: present direct-key row does NOT render green (matches chip)", () => {
     // `some-unmapped-feature` is intentionally absent from CATALOG_TO_D5_KEY.
     const live = mapOf([row("d5:agno/some-unmapped-feature", "d5", "green")]);

--- a/showcase/shell-dashboard/src/lib/live-status.ts
+++ b/showcase/shell-dashboard/src/lib/live-status.ts
@@ -534,13 +534,13 @@ export function resolveD5Row(
   now: number = Date.now(),
 ): StatusRow | null {
   const d5Keys = CATALOG_TO_D5_KEY[featureId];
-  // Unmapped / empty-map feature: no CV test exists, so return null (gray
+  // Unmapped / empty-map feature: no 1P test exists, so return null (gray
   // no-data badge) to match cell-model.ts `resolveD5` (returns exists:false)
   // and depth-utils.ts `isD5Green` (returns false). There is NO direct-key
   // fallback — a feature with real D5 coverage must be in CATALOG_TO_D5_KEY.
   // A direct `d5:<slug>/<featureId>` fallback was removed because it could
   // resolve a green badge from a stale/shared PB row, granting D5 to a cell
-  // the chip and depth derivation both treat as having no CV test, so the
+  // the chip and depth derivation both treat as having no 1P test, so the
   // badge and chip would visibly contradict each other.
   if (!d5Keys || d5Keys.length === 0) {
     return null;

--- a/showcase/shell-dashboard/src/lib/page-stats.ts
+++ b/showcase/shell-dashboard/src/lib/page-stats.ts
@@ -219,7 +219,7 @@ export function computeDepthDistribution(
  * green D6 row would otherwise overstate as "D6 green" — collapses to `null`
  * (blocked) and is counted as `gray`, NOT green. This makes the headline D6
  * count agree with the matrix's per-cell D6 badge (which renders the same
- * `d6Effective`) and the chip; the standalone CV/API/BE badges still show the
+ * `d6Effective`) and the chip; the standalone 1P/API/BE badges still show the
  * raw per-dimension failure.
  *
  * Buckets stay coherent with the badge tone mapping:


### PR DESCRIPTION
## Summary

Two related taxonomy-hygiene commits cleaning up the dashboard cell/legend labels. Follows on from #5473 (E2E→UI), #5498 (Wired→BE (Agent) L1 + catalog), #5503 (RT→BE cell badge).

### Commit 1 — `CV → 1P` cell-badge rename

The per-cell badge code `CV` (Conversation) becomes `1P` (Single Pill). Clearer scope framing:
- D5 driver is literally `d5-single-pill.ts` (one scripted conversation)
- D6 driver is `d6-all-pills.ts` (full pill suite + parity vs reference)

`CV` ("Conversation") was opaque — `1P` reads as "1 pill out of N" and pairs naturally with `D6` (all pills). Scope ladder now: `API → UI → BE → 1P → D6`.

### Commit 2 — `API (HTTP)` / `BE (Agent)` long-form normalization

Resolves a label collision introduced by #5498. Previously:
- L1 row D2 (agent-liveness) was labeled `BE (Agent)`
- Per-cell D2 badge was labeled `API (Agent)`
- Per-cell D4 badge (chat round-trip) was labeled `BE (Round Trip)`

So `BE (Agent)` (D2 L1) and `API (Agent)` (D2 per-cell) described the SAME concept under two different names, while `BE (Round Trip)` (D4) shared the "BE" prefix with `BE (Agent)` (D2) for DIFFERENT concepts. Now normalized by **layer**, not subject:

| Dimension | Old labels | New label |
|---|---|---|
| **D2** (transport / Railway liveness) | "BE (Agent)" L1 + "API (Agent)" per-cell | **`API (HTTP)`** everywhere |
| **D4** (agent chat round-trip) | "BE (Round Trip)" per-cell | **`BE (Agent)`** |

Reads cleanly: API = is the transport up; BE = can the agent process a chat message. Both probes test "the agent" — the parens distinguish what's actually being checked.

## Scope

28 files total (17 + 11), 114 insertions, 112 deletions. Pure label/comment rename. Touches:
- Source: `unified-cell`, `cell-pieces`, `cell-drilldown`, `adaptive-legend`, `adaptive-stats-bar`, `stats-bar`, `filter-chips`, `packages-section`, `level-strip`, `composed-cell`, `depth-utils`, `cell-model`, `live-status`, `page-stats`
- Tests: matching test files for assertion + comment updates
- Mnemonic legend: `(U=Up, B=BE (Agent), C=Chats, T=Tools)` → `(U=Up, A=API (HTTP), C=Chats, T=Tools)`

## Stable contracts preserved (no behavior change)

- All `keyFor(...)` dimension keys (`"agent"`, `"d2"`, `"d4"`, `"d5"`, `"e2e"`)
- Filter chip `id: "wired"` (filter state key)
- `LiveDimension` union string values
- `Status` enum string values (`"wired" | "stub" | …`)
- Internal variable names (`wired`, `pctBeAgent`, `totalBeAgent`, etc.) — intentionally not renamed to avoid scope creep
- Driver names, probe registry keys, PocketBase keys, harness API contracts

## Verification

- typecheck: clean
- tests: 1089 pass / 1 skip / 0 fail across 63 files
- build: clean
- oxfmt `--check`: clean across all 25 changed files
- NUL-byte scan: empty
- No remaining stale labels — `rg '"API \(Agent\)"|"BE \(Round Trip\)"'` empty; `"BE (Agent)"` only appears at D4 sites

## Related

- #5473 — `E2E → UI` (original taxonomy refactor; cell-badge template)
- #5498 — `Wired → BE (Agent)` L1 + catalog (introduced the label collision this PR resolves)
- #5503 — `RT → BE` cell badge (set the cell-badge naming pattern this PR mirrors)