### PR TITLE
fix(showcase/harness): retry+cached-catalog producer enumerate + 3-tick family-silence threshold

### DIFF
--- a/showcase/harness/src/fleet/control-plane/catalog-enumerator.test.ts
+++ b/showcase/harness/src/fleet/control-plane/catalog-enumerator.test.ts
@@ -10,11 +10,19 @@ import {
   E2E_DEMOS_TIMEOUT_MS,
   D6_E2E_TIMEOUT_MS,
   D5_E2E_TIMEOUT_MS,
+  ENUMERATE_RETRY_BACKOFF_MS,
+  isRetryableEnumerateError,
 } from "./catalog-enumerator.js";
 import {
   E2E_SMOKE_DRIVER_KIND,
   E2E_DEMOS_DRIVER_KIND,
 } from "../worker/payload-mapper.js";
+import {
+  DiscoverySourceAuthError,
+  DiscoverySourceBackendError,
+  DiscoverySourceTransportError,
+  DiscoverySourceSchemaError,
+} from "../../probes/discovery/errors.js";
 import type { DiscoverySource } from "../../probes/types.js";
 import type { RailwayServiceInfo } from "../../probes/discovery/railway-services.js";
 import type { EnumerateContext } from "./job-producer.js";
@@ -597,5 +605,292 @@ describe("createE2eDemosServiceEnumerator", () => {
     };
     expect(cfg.namePrefix).toBe(D6_DISCOVERY_FILTER.namePrefix);
     expect(cfg.nameExcludes).toEqual([...D6_DISCOVERY_FILTER.nameExcludes]);
+  });
+});
+
+/**
+ * RED-GREEN gates for the Railway-GQL resilience policy (Changes 1 + 2 of the
+ * 2026-06-17 Cloudflare-WAF-burst incident fix):
+ *   - the enumerator retries transient `DiscoverySourceBackendError(429)` /
+ *     `>=500` / Cloudflare-1015|1020|1022-marked responses and
+ *     `DiscoverySourceTransportError` on the `ENUMERATE_RETRY_BACKOFF_MS`
+ *     schedule (1s/4s/16s in production, collapsed to instant here),
+ *   - it falls back to the last successful catalog from an in-memory cache
+ *     when every retry is exhausted (LOUDLY logged — never silent),
+ *   - it preserves the current hard-fail behavior on a fresh boot with no
+ *     cache,
+ *   - it does NOT retry on real config errors (`DiscoverySourceAuthError`,
+ *     non-429 4xx, schema rot).
+ *
+ * The discovery source is an injected fake whose `enumerate` is scripted per
+ * call. No network, no fake timers — `sleep` is stubbed to instant.
+ */
+const INSTANT_SLEEP_RES = async () => {};
+
+function scriptedSource(
+  script: Array<RailwayServiceInfo[] | (() => never)>,
+): DiscoverySource<RailwayServiceInfo> & { calls: number } {
+  let i = 0;
+  const wrapper = {
+    name: "railway-services",
+    calls: 0,
+    async enumerate(_ctx: unknown, _config: unknown) {
+      wrapper.calls += 1;
+      const step = script[Math.min(i, script.length - 1)];
+      i += 1;
+      if (typeof step === "function") {
+        step();
+        throw new Error("scriptedSource: function form must throw");
+      }
+      return step;
+    },
+  } as DiscoverySource<RailwayServiceInfo> & { calls: number };
+  return wrapper;
+}
+
+function makeCapturingLogger(): {
+  logger: Logger;
+  warns: Array<{ msg: string; meta: Record<string, unknown> }>;
+} {
+  const warns: Array<{ msg: string; meta: Record<string, unknown> }> = [];
+  return {
+    logger: {
+      info: () => {},
+      debug: () => {},
+      error: () => {},
+      warn: (msg, meta) =>
+        warns.push({ msg, meta: (meta ?? {}) as Record<string, unknown> }),
+    },
+    warns,
+  };
+}
+
+describe("createServiceEnumerator — Railway-GQL resilience policy", () => {
+  const INSTANT_SLEEP = INSTANT_SLEEP_RES;
+
+  it("isRetryableEnumerateError: 429, 5xx, Cloudflare 1015/1020/1022, transport — retryable; auth + non-429 4xx + schema — not", () => {
+    expect(
+      isRetryableEnumerateError(
+        new DiscoverySourceBackendError(
+          "railway-services",
+          "rate limited",
+          429,
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableEnumerateError(
+        new DiscoverySourceBackendError("railway-services", "boom", 502),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableEnumerateError(
+        new DiscoverySourceBackendError(
+          "railway-services",
+          "error code: 1015",
+          403,
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableEnumerateError(
+        new DiscoverySourceBackendError(
+          "railway-services",
+          "error code: 1020 (access denied)",
+          403,
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableEnumerateError(
+        new DiscoverySourceBackendError(
+          "railway-services",
+          "1022 something",
+          403,
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableEnumerateError(
+        new DiscoverySourceTransportError(
+          "railway-services",
+          "fetch failed: ECONNRESET",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableEnumerateError(
+        new DiscoverySourceAuthError("railway-services", "401 unauthorized"),
+      ),
+    ).toBe(false);
+    expect(
+      isRetryableEnumerateError(
+        new DiscoverySourceBackendError("railway-services", "bad request", 400),
+      ),
+    ).toBe(false);
+    expect(
+      isRetryableEnumerateError(
+        new DiscoverySourceSchemaError(
+          "railway-services",
+          "shape rot",
+          undefined,
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("retries 3x on 429 + Cloudflare 1015 body and succeeds on attempt 4 (RED on main: enumerate throws after first 429)", async () => {
+    // The cron tick on 2026-06-17 hit a ~25 min Cloudflare WAF burst. Without
+    // retries the discovery source threw HTTP 429 / error code 1015 and the
+    // producer hard-failed, zeroing out the dashboard. With retries the
+    // wrapper rides out three transient 429s and the 4th attempt returns the
+    // catalog — the producer enqueues jobs as normal.
+    const cf429 = () => {
+      throw new DiscoverySourceBackendError(
+        "railway-services",
+        "railway gql 429: error code: 1015 (rate limited)",
+        429,
+      );
+    };
+    const services = [svc({ name: "showcase-langgraph-python" })];
+    const source = scriptedSource([cf429, cf429, cf429, services]);
+    const { logger, warns } = makeCapturingLogger();
+
+    const enumerate = createServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger,
+      driverKind: D6_DRIVER_KIND,
+      probeKeyPrefix: "d6",
+      filter: D6_DISCOVERY_FILTER,
+      sleep: INSTANT_SLEEP,
+      retrySchedule: ENUMERATE_RETRY_BACKOFF_MS,
+    });
+
+    const specs = await enumerate(CTX);
+
+    // 1 initial + 3 retries = 4 source calls total.
+    expect(source.calls).toBe(4);
+    expect(specs).toHaveLength(1);
+    expect(specs[0]?.probeKey).toBe("d6:langgraph-python");
+    const retryWarns = warns.filter(
+      (w) => w.msg === "fleet.producer.enumerate-retry",
+    );
+    expect(retryWarns).toHaveLength(3);
+    expect(
+      warns.find(
+        (w) => w.msg === "fleet.producer.enumerate-failed-using-cache",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("falls back to the cached catalog on persistent 429 burst across ticks (LOUD warn, no zero-job tick)", async () => {
+    // First tick: live catalog seeds the cache.
+    // Second tick: every retry returns 429 — fallback returns the cached
+    // catalog and emits a `fleet.producer.enumerate-failed-using-cache` warn.
+    const live = [
+      svc({ name: "showcase-langgraph-python" }),
+      svc({ name: "showcase-crewai" }),
+    ];
+    const cf429 = () => {
+      throw new DiscoverySourceBackendError(
+        "railway-services",
+        "railway gql 429: error code: 1015",
+        429,
+      );
+    };
+    const source = scriptedSource([live, cf429, cf429, cf429, cf429]);
+    const { logger, warns } = makeCapturingLogger();
+    let nowMs = 1_700_000_000_000;
+
+    const enumerate = createServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger,
+      driverKind: D6_DRIVER_KIND,
+      probeKeyPrefix: "d6",
+      filter: D6_DISCOVERY_FILTER,
+      sleep: INSTANT_SLEEP,
+      now: () => nowMs,
+      retrySchedule: ENUMERATE_RETRY_BACKOFF_MS,
+    });
+
+    const tick1 = await enumerate(CTX);
+    expect(tick1).toHaveLength(2);
+    expect(source.calls).toBe(1);
+
+    nowMs += 60_000;
+
+    const tick2 = await enumerate(CTX);
+    expect(source.calls).toBe(5);
+    // Fallback returns the SAME catalog (two services) from the cache —
+    // the dashboard does not zero out.
+    expect(tick2).toHaveLength(2);
+    const fallbackWarn = warns.find(
+      (w) => w.msg === "fleet.producer.enumerate-failed-using-cache",
+    );
+    expect(fallbackWarn).toBeDefined();
+    expect(fallbackWarn?.meta.services).toBe(2);
+    expect(fallbackWarn?.meta.ageMs).toBe(60_000);
+    expect(typeof fallbackWarn?.meta.reason).toBe("string");
+  });
+
+  it("re-throws the last transient error on a fresh boot with NO cache (preserves enumerate-failed hard-fail)", async () => {
+    const cf429 = () => {
+      throw new DiscoverySourceBackendError(
+        "railway-services",
+        "railway gql 429: error code: 1015",
+        429,
+      );
+    };
+    const source = scriptedSource([cf429, cf429, cf429, cf429]);
+    const enumerate = createServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+      driverKind: D6_DRIVER_KIND,
+      probeKeyPrefix: "d6",
+      filter: D6_DISCOVERY_FILTER,
+      sleep: INSTANT_SLEEP,
+      retrySchedule: ENUMERATE_RETRY_BACKOFF_MS,
+    });
+
+    await expect(enumerate(CTX)).rejects.toBeInstanceOf(
+      DiscoverySourceBackendError,
+    );
+    expect(source.calls).toBe(4); // 1 initial + 3 retries before giving up
+  });
+
+  it("does NOT retry on DiscoverySourceAuthError — config errors fail loud immediately", async () => {
+    const authFail = () => {
+      throw new DiscoverySourceAuthError(
+        "railway-services",
+        "railway gql 401: bad token",
+      );
+    };
+    const source = scriptedSource([authFail, authFail, authFail, authFail]);
+    const enumerate = createServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+      driverKind: D6_DRIVER_KIND,
+      probeKeyPrefix: "d6",
+      filter: D6_DISCOVERY_FILTER,
+      sleep: INSTANT_SLEEP,
+      retrySchedule: ENUMERATE_RETRY_BACKOFF_MS,
+    });
+    await expect(enumerate(CTX)).rejects.toBeInstanceOf(
+      DiscoverySourceAuthError,
+    );
+    // Exactly ONE call — no retry was attempted.
+    expect(source.calls).toBe(1);
+  });
+
+  it("uses ENUMERATE_RETRY_BACKOFF_MS = [1000, 4000, 16000] in production (SSOT pin)", () => {
+    expect(ENUMERATE_RETRY_BACKOFF_MS).toEqual([1_000, 4_000, 16_000]);
   });
 });

--- a/showcase/harness/src/fleet/control-plane/catalog-enumerator.ts
+++ b/showcase/harness/src/fleet/control-plane/catalog-enumerator.ts
@@ -44,6 +44,11 @@
 import type { Logger } from "../../types/index.js";
 import type { DiscoverySource, DiscoveryContext } from "../../probes/types.js";
 import type { RailwayServiceInfo } from "../../probes/discovery/railway-services.js";
+import {
+  DiscoverySourceAuthError,
+  DiscoverySourceBackendError,
+  DiscoverySourceTransportError,
+} from "../../probes/discovery/errors.js";
 import type {
   ServiceEnumerator,
   ServiceJobSpec,
@@ -54,6 +59,205 @@ import {
   E2E_SMOKE_DRIVER_KIND,
   E2E_DEMOS_DRIVER_KIND,
 } from "../worker/payload-mapper.js";
+
+/**
+ * Retry backoff schedule (ms) for `source.enumerate` against Railway-GQL.
+ *
+ * Railway's `/graphql/v2` endpoint sits behind Cloudflare's WAF which can
+ * burst-block the harness producer with HTTP 429 / Cloudflare error 1015
+ * (or 1020/1022) for tens of minutes during a flap. Without retries the
+ * producer's tick hard-fails every cron, zeroing out D4/D5/D6 writes and
+ * turning the staging dashboard red within one tick window. Three retries
+ * at 1s/4s/16s ride out a ~21s WAF burst on a single tick; persistent
+ * outages then fall through to the cached-catalog fallback (see
+ * `withCatalogCache`).
+ *
+ * Exported for tests so the schedule remains the SSOT.
+ */
+export const ENUMERATE_RETRY_BACKOFF_MS: readonly number[] = [
+  1_000, 4_000, 16_000,
+] as const;
+
+/**
+ * Cloudflare error-code markers that indicate WAF rate-limit / abuse
+ * heuristics (1015 = "rate limited", 1020 = "access denied", 1022 = "block
+ * due to access rules"). Retried because the underlying outage is transient
+ * upstream, not a real config error on our side. Matched against the
+ * `DiscoverySourceBackendError` message which carries the Cloudflare HTML
+ * body verbatim.
+ */
+const CLOUDFLARE_RETRY_MARKERS: readonly string[] = [
+  "1015",
+  "1020",
+  "1022",
+] as const;
+
+/**
+ * Decide whether a thrown error from `source.enumerate` is retryable.
+ *
+ * Retry on:
+ *   - `DiscoverySourceTransportError`: socket/DNS-level failure, network
+ *     blip, request aborted — always transient.
+ *   - `DiscoverySourceBackendError` with `status === 429`: explicit rate
+ *     limit, the Cloudflare-WAF case this exists for.
+ *   - `DiscoverySourceBackendError` with `status >= 500`: upstream 5xx,
+ *     transient by definition.
+ *   - `DiscoverySourceBackendError` whose message carries a Cloudflare
+ *     `1015`/`1020`/`1022` marker (defensive: sometimes CF wraps the
+ *     rate-limit response with a non-429 status).
+ *
+ * Do NOT retry on:
+ *   - `DiscoverySourceAuthError`: 401/403 is a real config/credential
+ *     error and must fail loud — burning retries here would just delay
+ *     the operator-actionable failure.
+ *   - Any other `DiscoverySourceBackendError` with 4xx (e.g. 400 bad
+ *     request, 404): client-side error, retrying will not change the
+ *     outcome.
+ *   - `DiscoverySourceSchemaError`: an upstream API change — retrying
+ *     will not fix the wire payload.
+ *   - Any other thrown class: bubble up unchanged.
+ *
+ * Exported so the catalog-aware enumerator test can pin the decision
+ * surface without re-deriving the predicate from the implementation.
+ */
+export function isRetryableEnumerateError(err: unknown): boolean {
+  if (err instanceof DiscoverySourceAuthError) return false;
+  if (err instanceof DiscoverySourceTransportError) return true;
+  if (err instanceof DiscoverySourceBackendError) {
+    if (err.status === 429) return true;
+    if (err.status >= 500) return true;
+    // Defensive: a Cloudflare 1015 served under a non-429 status still
+    // carries the marker in the response body — retry on the marker, not
+    // just the status code.
+    const msg = err.message;
+    for (const marker of CLOUDFLARE_RETRY_MARKERS) {
+      if (msg.includes(marker)) return true;
+    }
+    return false;
+  }
+  return false;
+}
+
+/**
+ * In-memory cache of the last successful `services` list per enumerator
+ * instance. Survives across ticks within one process (the producer is
+ * long-lived). When all retries fail, the enumerator falls back to this
+ * cache and emits jobs at staleness rather than zeroing out the dashboard.
+ *
+ * A fresh-boot process with no cached entry and a persistent enumerate
+ * failure preserves the original hard-fail behavior (the producer's
+ * `enumerate-failed` short-circuit) — without a catalog there is nothing
+ * to enqueue.
+ *
+ * Per-enumerator (not shared globally) so the d6/smoke/demos/deep
+ * enumerators do not cross-pollinate.
+ */
+interface CatalogCache {
+  services: RailwayServiceInfo[];
+  cachedAtMs: number;
+}
+
+/**
+ * Sleep used between retry attempts. Injectable so tests can collapse the
+ * 1s/4s/16s schedule to instant without a fake-timer dance. Default is a
+ * real `setTimeout` Promise — production sees the real backoff.
+ */
+export type SleepFn = (ms: number) => Promise<void>;
+
+const defaultSleep: SleepFn = (ms) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Wrap a one-shot `source.enumerate` invocation with the Railway-GQL
+ * resilience policy:
+ *   1. Retry transient failures (429 / 5xx / Cloudflare 1015|1020|1022 /
+ *      transport) on the `ENUMERATE_RETRY_BACKOFF_MS` schedule.
+ *   2. On persistent failure, fall back to the last successful catalog
+ *      from the in-memory cache (LOUDLY: a `warn` named
+ *      `fleet.producer.enumerate-failed-using-cache` so the cache-use
+ *      shows up in observability).
+ *   3. With NO cache available, re-throw the last error (preserves the
+ *      current hard-fail behavior on a fresh boot — without a catalog
+ *      there is nothing to enqueue).
+ *
+ * The retry+cache wrapper sits OUTSIDE the per-service mapping step
+ * (operator slug-scoping + driver-input projection still re-applies on a
+ * cache use) so the cached path produces the same `ServiceJobSpec[]`
+ * shape the live path does.
+ *
+ * Exposed as a free function (not folded into `createServiceEnumerator`)
+ * so the catalog-enumerator test can pin the retry/cache behavior in
+ * isolation without re-wiring the whole spec projection.
+ */
+async function enumerateWithRetryAndCache(opts: {
+  source: DiscoverySource<RailwayServiceInfo>;
+  discoveryCtx: DiscoveryContext;
+  filter: { namePrefix: string; nameExcludes?: string[] };
+  logger: Logger;
+  driverKind: string;
+  cache: { current: CatalogCache | null };
+  sleep: SleepFn;
+  now: () => number;
+  retrySchedule: readonly number[];
+}): Promise<RailwayServiceInfo[]> {
+  const {
+    source,
+    discoveryCtx,
+    filter,
+    logger,
+    driverKind,
+    cache,
+    sleep,
+    now,
+  } = opts;
+  const retrySchedule = opts.retrySchedule;
+  // attempt 0 is the initial try; attempt 1..N are the retries.
+  const maxAttempt = retrySchedule.length;
+  let lastErr: unknown = null;
+  for (let attempt = 0; attempt <= maxAttempt; attempt++) {
+    if (attempt > 0) {
+      const backoffMs = retrySchedule[attempt - 1] ?? 0;
+      logger.warn("fleet.producer.enumerate-retry", {
+        driverKind,
+        attempt,
+        backoffMs,
+        err: lastErr instanceof Error ? lastErr.message : String(lastErr),
+      });
+      await sleep(backoffMs);
+    }
+    try {
+      const services = await source.enumerate(discoveryCtx, filter);
+      // Persist the latest successful catalog so a later transient failure
+      // can fall back to it.
+      cache.current = { services, cachedAtMs: now() };
+      return services;
+    } catch (err) {
+      lastErr = err;
+      if (!isRetryableEnumerateError(err)) {
+        // Real config error (auth, 4xx other than 429, schema rot): fail
+        // loud — no retry, no cache. Surface the operator-actionable error
+        // class verbatim.
+        throw err;
+      }
+      // continue the retry loop
+    }
+  }
+  // All retries exhausted. Fall back to the cached catalog if present;
+  // otherwise re-throw the last transient error so the producer's
+  // `enumerate-failed` path runs (current hard-fail behavior — without a
+  // catalog there is nothing to enqueue).
+  if (cache.current !== null) {
+    const ageMs = now() - cache.current.cachedAtMs;
+    logger.warn("fleet.producer.enumerate-failed-using-cache", {
+      driverKind,
+      ageMs,
+      services: cache.current.services.length,
+      reason: lastErr instanceof Error ? lastErr.message : String(lastErr),
+    });
+    return cache.current.services;
+  }
+  throw lastErr;
+}
 
 /** The d6 driver kind every enumerated spec runs under. */
 export const D6_DRIVER_KIND = "e2e_d6";
@@ -175,6 +379,23 @@ export interface D6ServiceEnumeratorDeps {
    * `D5_E2E_TIMEOUT_MS` for d5). Exposed so a test can override.
    */
   timeoutMs?: number;
+  /**
+   * Sleep impl used between Railway-GQL retry attempts. Forwarded verbatim
+   * to `createServiceEnumerator`. Defaults to real `setTimeout`. Exposed so
+   * a test can collapse the `ENUMERATE_RETRY_BACKOFF_MS` schedule to
+   * instant without monkey-patching globals.
+   */
+  sleep?: SleepFn;
+  /**
+   * Clock injected for the cached-catalog `cachedAtMs` and `ageMs`
+   * accounting. Forwarded verbatim. Defaults to `Date.now`.
+   */
+  now?: () => number;
+  /**
+   * Retry backoff schedule (ms). Forwarded verbatim. Defaults to
+   * `ENUMERATE_RETRY_BACKOFF_MS` (1s/4s/16s).
+   */
+  retrySchedule?: readonly number[];
 }
 
 /**
@@ -215,6 +436,28 @@ export interface ServiceEnumeratorParams {
    * Omitted by d6/smoke/deep (their specs are unchanged).
    */
   extraDriverInputs?: Readonly<Record<string, unknown>>;
+  /**
+   * Sleep impl used between Railway-GQL retry attempts. Defaults to real
+   * `setTimeout`; tests inject an instant resolve to collapse the
+   * `ENUMERATE_RETRY_BACKOFF_MS` (1s/4s/16s) schedule without a fake-timer
+   * dance. Exposed on the public params so the catalog-enumerator test can
+   * stub the wait without monkey-patching globals.
+   */
+  sleep?: SleepFn;
+  /**
+   * Clock injected to stamp the cached-catalog `cachedAtMs` (and the
+   * `ageMs` carried on the `enumerate-failed-using-cache` warn). Defaults
+   * to `Date.now`; tests inject a frozen clock for deterministic age
+   * assertions.
+   */
+  now?: () => number;
+  /**
+   * Retry backoff schedule (ms). Defaults to `ENUMERATE_RETRY_BACKOFF_MS`
+   * (1s/4s/16s, three retries). A test can pass a shorter schedule (e.g.
+   * `[0, 0, 0]`) to exercise the retry loop without waiting; the
+   * production wiring leaves it at the SSOT default.
+   */
+  retrySchedule?: readonly number[];
 }
 
 /**
@@ -293,6 +536,9 @@ export function createServiceEnumerator(
     filter,
     extraDriverInputs,
   } = params;
+  const sleep = params.sleep ?? defaultSleep;
+  const now = params.now ?? (() => Date.now());
+  const retrySchedule = params.retrySchedule ?? ENUMERATE_RETRY_BACKOFF_MS;
 
   // Fail loud on a filter with no `namePrefix`: the discovery source treats an
   // absent/empty prefix as "match everything", which would enumerate ALL
@@ -307,11 +553,35 @@ export function createServiceEnumerator(
     );
   }
 
+  // Per-enumerator catalog cache (Change 2). Lives in the closure so each
+  // enumerator instance owns its own slice — d6/smoke/demos/deep never
+  // cross-pollinate. The producer (long-lived) re-uses the same enumerator
+  // instance across ticks, so this cache survives tick-to-tick within the
+  // process. A fresh process boots with `current === null` (first
+  // enumerate fail still hard-fails, preserving the current behavior).
+  const cache: { current: CatalogCache | null } = { current: null };
+
+  // Hoist the (now-validated) prefix so TS sees `string`, not `string |
+  // undefined` — the guard above already failed loud on a missing prefix
+  // but the type is structural.
+  const namePrefix: string = filter.namePrefix;
   return async (ctx: EnumerateContext): Promise<ServiceJobSpec[]> => {
     const discoveryCtx: DiscoveryContext = { fetchImpl, env, logger };
-    const services = await source.enumerate(discoveryCtx, {
-      namePrefix: filter.namePrefix,
-      nameExcludes: filter.nameExcludes ? [...filter.nameExcludes] : undefined,
+    const services = await enumerateWithRetryAndCache({
+      source,
+      discoveryCtx,
+      filter: {
+        namePrefix,
+        nameExcludes: filter.nameExcludes
+          ? [...filter.nameExcludes]
+          : undefined,
+      },
+      logger,
+      driverKind,
+      cache,
+      sleep,
+      now,
+      retrySchedule,
     });
 
     // Optional operator slug scoping (triggered runs only). An explicit filter
@@ -394,6 +664,14 @@ export function createD6ServiceEnumerator(
     // Convey the YAML outer-cap so the fleet worker's d6 driver honors the
     // `d6-all-pills-e2e.yml` budget instead of its hardcoded DEFAULT_TIMEOUT_MS.
     extraDriverInputs: { timeout_ms: timeoutMs },
+    // Forward Railway-GQL resilience knobs (test-only stubs in production
+    // wiring; real defaults otherwise — `defaultSleep` / `Date.now` /
+    // `ENUMERATE_RETRY_BACKOFF_MS`).
+    ...(deps.sleep !== undefined ? { sleep: deps.sleep } : {}),
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+    ...(deps.retrySchedule !== undefined
+      ? { retrySchedule: deps.retrySchedule }
+      : {}),
   });
 }
 
@@ -419,6 +697,11 @@ export function createE2eSmokeServiceEnumerator(
     driverKind: E2E_SMOKE_DRIVER_KIND,
     probeKeyPrefix: "d4",
     filter,
+    ...(deps.sleep !== undefined ? { sleep: deps.sleep } : {}),
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+    ...(deps.retrySchedule !== undefined
+      ? { retrySchedule: deps.retrySchedule }
+      : {}),
   });
 }
 
@@ -466,6 +749,11 @@ export function createE2eDeepServiceEnumerator(
       rowPrefix: "d5",
       timeout_ms: timeoutMs,
     },
+    ...(deps.sleep !== undefined ? { sleep: deps.sleep } : {}),
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+    ...(deps.retrySchedule !== undefined
+      ? { retrySchedule: deps.retrySchedule }
+      : {}),
   });
 }
 
@@ -508,5 +796,10 @@ export function createE2eDemosServiceEnumerator(
     probeKeyPrefix: "e2e-demos",
     filter,
     extraDriverInputs: { timeout_ms: timeoutMs },
+    ...(deps.sleep !== undefined ? { sleep: deps.sleep } : {}),
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+    ...(deps.retrySchedule !== undefined
+      ? { retrySchedule: deps.retrySchedule }
+      : {}),
   });
 }

--- a/showcase/harness/src/fleet/control-plane/family-silence-monitor.test.ts
+++ b/showcase/harness/src/fleet/control-plane/family-silence-monitor.test.ts
@@ -5,6 +5,7 @@ import {
   FAMILY_SILENCE_EVAL_RULE_ID,
   SILENCE_ALERT_RATE_LIMIT_MS,
   SILENCE_PERIOD_MULTIPLIER,
+  SILENCE_CONSECUTIVE_TICK_THRESHOLD,
 } from "./family-silence-monitor.js";
 import { FLEET_FAMILIES } from "./run-view.js";
 import type {
@@ -213,57 +214,78 @@ describe("family-silence monitor — evaluation gate", () => {
 
 describe("family-silence monitor — silence alert", () => {
   it("a family silent past 3x period posts the silence alert with k cycles", async () => {
-    const now = BASE + 2 * PERIOD;
+    // Change 3 (2026-06-17 Cloudflare-WAF-burst remediation): the silence
+    // alert is gated on THREE consecutive silent evaluation cycles AND the
+    // 3×period elapsed-time threshold. lastSuccessAt is pinned 2 periods
+    // BEFORE BASE so every tick observes ≥4×period of silence — the
+    // elapsed-time gate fires on every pre-warm tick, and the variable
+    // under test is the consecutive-tick counter.
+    const lastSuccessMs = BASE - 2 * PERIOD;
+    const t1 = BASE + 2 * PERIOD; // 4×period since lastSuccess
+    const t2 = BASE + 3 * PERIOD; // 5×period since lastSuccess
+    const t3 = BASE + 4 * PERIOD; // 6×period since lastSuccess → "6 cycles"
     const { monitor, posts } = makeMonitor({
       get: async () =>
         response(
-          withD6(now, {
-            lastSuccessAt: iso(now - 4 * PERIOD),
+          withD6(t3, {
+            lastSuccessAt: iso(lastSuccessMs),
             lastRun: batch({
-              enqueuedAt: iso(now - 4 * PERIOD - 120_000),
-              finishedAt: iso(now - 4 * PERIOD),
+              enqueuedAt: iso(lastSuccessMs - 120_000),
+              finishedAt: iso(lastSuccessMs),
             }),
           }),
         ),
     });
-    await monitor.tick(now);
+    await monitor.tick(t1);
+    expect(posts).toEqual([]);
+    await monitor.tick(t2);
+    expect(posts).toEqual([]);
+    await monitor.tick(t3);
     expect(posts).toHaveLength(1);
     expect(posts[0]).toContain("worker family D6 all-pills silent");
-    expect(posts[0]).toContain(
-      `no successful run since ${iso(now - 4 * PERIOD)}`,
-    );
-    expect(posts[0]).toContain("(4 cycles)");
+    expect(posts[0]).toContain(`no successful run since ${iso(lastSuccessMs)}`);
+    expect(posts[0]).toContain("(6 cycles)");
     expect(posts[0]).toContain("last attempt: completed");
   });
 
   it("last attempt is inflight-aware: a stalled inflight batch posts stalled, never the prior completed lastRun outcome", async () => {
-    const now = BASE + 2 * PERIOD;
+    // lastSuccessAt pinned BEFORE BASE so the elapsed-time gate fires on
+    // every pre-warm tick (see Change-3 test above for the same idiom).
+    const lastSuccessMs = BASE - 2 * PERIOD;
+    const t1 = BASE + 2 * PERIOD;
+    const t2 = BASE + 3 * PERIOD;
+    const t3 = BASE + 4 * PERIOD;
     const { monitor, posts } = makeMonitor({
       get: async () =>
         response(
-          withD6(now, {
-            lastSuccessAt: iso(now - 4 * PERIOD),
+          withD6(t3, {
+            lastSuccessAt: iso(lastSuccessMs),
             lastRun: batch({ outcome: "completed" }),
             inflight: inflightState({
               stalled: true,
-              enqueuedAt: iso(now - PERIOD),
+              enqueuedAt: iso(t3 - PERIOD),
             }),
           }),
         ),
     });
-    await monitor.tick(now);
+    await monitor.tick(t1);
+    await monitor.tick(t2);
+    await monitor.tick(t3);
     expect(posts).toHaveLength(1);
     expect(posts[0]).toContain("last attempt: stalled");
     expect(posts[0]).not.toContain("last attempt: completed");
   });
 
   it("an abandoned failed-plus-zombie batch reports stalled, never failed (no re-classification)", async () => {
-    const now = BASE + 2 * PERIOD;
+    const lastSuccessMs = BASE - 2 * PERIOD;
+    const t1 = BASE + 2 * PERIOD;
+    const t2 = BASE + 3 * PERIOD;
+    const t3 = BASE + 4 * PERIOD;
     const { monitor, posts } = makeMonitor({
       get: async () =>
         response(
-          withD6(now, {
-            lastSuccessAt: iso(now - 4 * PERIOD),
+          withD6(t3, {
+            lastSuccessAt: iso(lastSuccessMs),
             // run-view already derived "stalled" by precedence (a failed job
             // plus a zombie pending job in an abandoned batch). The monitor
             // renders that value verbatim — never re-derives "failed".
@@ -274,19 +296,26 @@ describe("family-silence monitor — silence alert", () => {
           }),
         ),
     });
-    await monitor.tick(now);
+    await monitor.tick(t1);
+    await monitor.tick(t2);
+    await monitor.tick(t3);
     expect(posts).toHaveLength(1);
     expect(posts[0]).toContain("last attempt: stalled");
     expect(posts[0]).not.toMatch(/last attempt: failed/);
   });
 
   it("null lastSuccessAt: never-succeeded family alerts off oldest batch enqueuedAt with the never-completed variant", async () => {
-    const now = BASE + 2 * PERIOD;
-    const oldest = now - 4 * PERIOD;
+    // Oldest batch's enqueuedAt is BEFORE BASE so every tick observes
+    // ≥4×period of silence (the elapsed-time gate fires on every pre-warm
+    // tick; the consecutive-tick gate is the only thing delaying the post).
+    const oldest = BASE - 2 * PERIOD;
+    const t1 = BASE + 2 * PERIOD;
+    const t2 = BASE + 3 * PERIOD;
+    const t3 = BASE + 4 * PERIOD;
     const { monitor, posts } = makeMonitor({
       get: async () =>
         response(
-          withD6(now, {
+          withD6(t3, {
             lastSuccessAt: null,
             lastRun: batch({
               outcome: "failed",
@@ -296,7 +325,9 @@ describe("family-silence monitor — silence alert", () => {
           }),
         ),
     });
-    await monitor.tick(now);
+    await monitor.tick(t1);
+    await monitor.tick(t2);
+    await monitor.tick(t3);
     expect(posts).toHaveLength(1);
     expect(posts[0]).toContain(
       `has never completed a run since ${iso(oldest)}`,
@@ -334,23 +365,29 @@ describe("family-silence monitor — silence alert", () => {
 
   it("still alerts when the family STOPS emitting results entirely (real outage)", async () => {
     // Negative case to preserve: a real worker outage (lastSuccessAt very
-    // stale, fresh inflight that's also stalled) must still trip the banner.
-    const now = BASE + 5 * PERIOD;
+    // stale, fresh inflight that's also stalled) must still trip the banner —
+    // once the Change-3 consecutive-tick gate is satisfied.
+    const lastSuccessMs = BASE - 2 * PERIOD;
+    const t1 = BASE + 3 * PERIOD;
+    const t2 = BASE + 4 * PERIOD;
+    const t3 = BASE + 5 * PERIOD;
     const { monitor, posts } = makeMonitor({
       get: async () =>
         response(
-          withD6(now, {
-            lastSuccessAt: iso(now - 4 * PERIOD),
+          withD6(t3, {
+            lastSuccessAt: iso(lastSuccessMs),
             lastRun: batch({
               outcome: "failed",
-              enqueuedAt: iso(now - 4 * PERIOD - 120_000),
-              finishedAt: iso(now - 4 * PERIOD),
+              enqueuedAt: iso(lastSuccessMs - 120_000),
+              finishedAt: iso(lastSuccessMs),
               commErrorKinds: ["worker-crashed-mid-job"],
             }),
           }),
         ),
     });
-    await monitor.tick(now);
+    await monitor.tick(t1);
+    await monitor.tick(t2);
+    await monitor.tick(t3);
     expect(posts).toHaveLength(1);
     expect(posts[0]).toContain("worker family D6 all-pills silent");
   });
@@ -458,6 +495,9 @@ describe("family-silence monitor — rate limiting + recovered one-shot", () => 
   }
 
   it("alerts rate-limited to one per family per 6h via the alert-state store; recovered one-shot on next successful batch", async () => {
+    // Change 3: the silence alert posts on the THIRD consecutive silent
+    // tick, so the pre-warm advances through two non-posting ticks before
+    // the third posts and seeds the durable rate-limit row.
     let nowRef = BASE + 2 * PERIOD;
     let recovered = false;
     const { monitor, posts, store } = makeMonitor({
@@ -467,21 +507,28 @@ describe("family-silence monitor — rate limiting + recovered one-shot", () => 
           : response(silentD6At(nowRef)),
     });
 
-    await monitor.tick(nowRef);
+    await monitor.tick(nowRef); // silent tick 1 — counter=1, no post
+    expect(posts).toEqual([]);
+    nowRef = BASE + 3 * PERIOD;
+    await monitor.tick(nowRef); // silent tick 2 — counter=2, no post
+    expect(posts).toEqual([]);
+    nowRef = BASE + 4 * PERIOD;
+    await monitor.tick(nowRef); // silent tick 3 — counter=3, posts
     expect(posts).toHaveLength(1);
     // The post is recorded into the alert-state store under the §9 keying.
     const row = await store.get(FAMILY_SILENCE_RULE_ID, "d6");
-    expect(row?.last_alert_at).toBe(iso(BASE + 2 * PERIOD));
+    expect(row?.last_alert_at).toBe(iso(BASE + 4 * PERIOD));
 
     // Every period for the next 5 hours: still silent, still suppressed.
     for (let i = 1; i <= 5; i += 1) {
-      nowRef = BASE + (2 + i) * PERIOD;
+      nowRef = BASE + (4 + i) * PERIOD;
       await monitor.tick(nowRef);
     }
     expect(posts).toHaveLength(1);
 
-    // Past the 6 h window: posts again.
-    nowRef = BASE + 2 * PERIOD + SILENCE_ALERT_RATE_LIMIT_MS + 60_000;
+    // Past the 6 h window: posts again — the counter is well past threshold,
+    // so the rate limit (not the consecutive-tick gate) is the only suppressor.
+    nowRef = BASE + 4 * PERIOD + SILENCE_ALERT_RATE_LIMIT_MS + 60_000;
     await monitor.tick(nowRef);
     expect(posts).toHaveLength(2);
 
@@ -497,18 +544,24 @@ describe("family-silence monitor — rate limiting + recovered one-shot", () => 
   });
 
   it("a pre-seeded alert-state row suppresses across a monitor restart (durable rate limit)", async () => {
-    const now = BASE + 2 * PERIOD;
+    // Drive past the consecutive-tick gate so the only suppressor left is
+    // the durable rate-limit row this test is pinning.
+    const t1 = BASE + 2 * PERIOD;
+    const t2 = BASE + 3 * PERIOD;
+    const t3 = BASE + 4 * PERIOD;
     const store = makeFakeStore();
     await store.record(FAMILY_SILENCE_RULE_ID, "d6", {
-      at: iso(now - 3_600_000), // 1 h ago — inside the 6 h window
+      at: iso(t3 - 3_600_000), // 1 h ago — inside the 6 h window
       hash: "seeded",
       preview: "seeded",
     });
     const { monitor, posts } = makeMonitor({
-      get: async () => response(silentD6At(now)),
+      get: async () => response(silentD6At(t3)),
       store,
     });
-    await monitor.tick(now);
+    await monitor.tick(t1);
+    await monitor.tick(t2);
+    await monitor.tick(t3);
     expect(posts).toEqual([]);
   });
 
@@ -562,7 +615,111 @@ describe("family-silence monitor — constants", () => {
   it("pins the §9 threshold + keying constants consumers rely on", () => {
     expect(SILENCE_PERIOD_MULTIPLIER).toBe(3);
     expect(SILENCE_ALERT_RATE_LIMIT_MS).toBe(6 * 3_600_000);
+    expect(SILENCE_CONSECUTIVE_TICK_THRESHOLD).toBe(3);
     expect(FAMILY_SILENCE_RULE_ID).toBe("family-silence");
     expect(FAMILY_SILENCE_EVAL_RULE_ID).toBe("family-silence-eval");
+  });
+});
+
+/**
+ * RED-GREEN gate for Change 3 of the 2026-06-17 Cloudflare-WAF-burst incident
+ * fix: the silence alert must require THREE consecutive failed evaluation
+ * cycles before firing, layered ON TOP of the existing 3×period elapsed-time
+ * gate. On main today, a single cycle with `lastSuccessAt > 3×period` posts
+ * the alert immediately — the failure mode the incident exposed (one bad
+ * tick on a stale `lastSuccessAt` paged every family at once). Post-fix the
+ * counter delays the alert to the 3rd silent cycle.
+ *
+ * The §9 6 h rate limit + boot-grace + meta-alert paths must be unaffected.
+ */
+describe("family-silence monitor — consecutive-silent-tick gate (Change 3)", () => {
+  it("does NOT alert on the first or second silent tick — only the third (RED on main: alerts on tick #1)", async () => {
+    // Boot was 4×PERIOD ago so the boot-grace window (1×period) is closed
+    // before tick 1. lastSuccessAt = 4×PERIOD ago, so the 3×period
+    // elapsed-time gate is satisfied on every tick — the variable under
+    // test is the new consecutive-tick gate.
+    const bootMs = BASE;
+    const t1 = BASE + 2 * PERIOD;
+    const t2 = t1 + PERIOD;
+    const t3 = t2 + PERIOD;
+
+    const { monitor, posts } = makeMonitor({
+      get: async () =>
+        response(
+          withD6(t3, {
+            lastSuccessAt: iso(BASE - 2 * PERIOD),
+            lastRun: batch({
+              outcome: "failed",
+              enqueuedAt: iso(BASE - 2 * PERIOD - 120_000),
+              finishedAt: iso(BASE - 2 * PERIOD),
+            }),
+          }),
+        ),
+      bootAtMs: bootMs,
+    });
+
+    // Tick 1: counter increments to 1 (post-grace, elapsed-time gate
+    // satisfied) — NO alert yet.
+    await monitor.tick(t1);
+    expect(posts).toEqual([]);
+
+    // Tick 2: counter increments to 2 — still NO alert.
+    await monitor.tick(t2);
+    expect(posts).toEqual([]);
+
+    // Tick 3: counter reaches the threshold (3) — alert posts.
+    await monitor.tick(t3);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toContain("worker family D6 all-pills silent");
+  });
+
+  it("a healthy tick between two silent ticks resets the counter — alert needs THREE more silent ticks in a row", async () => {
+    // Counter discipline: ANY healthy cycle resets the counter. This pins
+    // the consecutive-run semantic explicitly: a family that flaps silent
+    // → healthy → silent does NOT carry the prior silent count forward.
+    const bootMs = BASE;
+    const t1 = BASE + 2 * PERIOD; // silent
+    const t2 = t1 + PERIOD; // HEALTHY (reset)
+    const t3 = t2 + PERIOD; // silent again
+    const t4 = t3 + PERIOD; // silent
+    const t5 = t4 + PERIOD; // silent → alert
+
+    let phase: "silent" | "healthy" = "silent";
+    const { monitor, posts } = makeMonitor({
+      get: async () => {
+        if (phase === "healthy") {
+          return response(healthyFamilies(t2));
+        }
+        // Use t5 here so cycles arithmetic stays stable on the final tick.
+        const lastSucc = iso(BASE - 2 * PERIOD);
+        return response(
+          withD6(t5, {
+            lastSuccessAt: lastSucc,
+            lastRun: batch({
+              outcome: "failed",
+              enqueuedAt: iso(BASE - 2 * PERIOD - 120_000),
+              finishedAt: iso(BASE - 2 * PERIOD),
+            }),
+          }),
+        );
+      },
+      bootAtMs: bootMs,
+    });
+
+    phase = "silent";
+    await monitor.tick(t1);
+    expect(posts).toEqual([]);
+
+    phase = "healthy";
+    await monitor.tick(t2);
+    expect(posts).toEqual([]);
+
+    phase = "silent";
+    await monitor.tick(t3);
+    expect(posts).toEqual([]);
+    await monitor.tick(t4);
+    expect(posts).toEqual([]);
+    await monitor.tick(t5);
+    expect(posts).toHaveLength(1);
   });
 });

--- a/showcase/harness/src/fleet/control-plane/family-silence-monitor.ts
+++ b/showcase/harness/src/fleet/control-plane/family-silence-monitor.ts
@@ -65,6 +65,24 @@ export const SILENCE_ALERT_RATE_LIMIT_MS = 6 * 3_600_000;
 /** §9: silence threshold N — alert when now − lastSuccessAt > N × period. */
 export const SILENCE_PERIOD_MULTIPLIER = 3;
 
+/**
+ * Minimum number of consecutive failed evaluation cycles before a silence
+ * alert posts. Layered ON TOP of the existing 3×period threshold (an AND,
+ * not OR): the alert only fires once BOTH the elapsed-time gate
+ * (`now - lastSuccessAt > 3 × period`) and the consecutive-cycle gate are
+ * satisfied. Without this, a single bad cron tick on a family whose
+ * `lastSuccessAt` was already stale (e.g. after a long quiet window or a
+ * deploy gap) could trip the alert immediately — the staging incident on
+ * 2026-06-17 where one ~25 min Cloudflare WAF burst on backboard-railway
+ * GraphQL caused every family to alert from a single tick.
+ *
+ * Three was chosen to match the elapsed-time multiplier — the alert posts
+ * when the family has missed roughly three of its own evaluation windows
+ * in a row, which is the same "this is no longer a single flap" threshold
+ * applied along the orthogonal axis. Exported so tests pin the SSOT.
+ */
+export const SILENCE_CONSECUTIVE_TICK_THRESHOLD = 3;
+
 export interface FamilySilenceMonitorDeps {
   /** The SHARED memoized §5.2.1 projection instance (§5.2 — same one the routes get). */
   summary: Pick<MemoizedFamilySummary, "get">;
@@ -176,6 +194,27 @@ export function createFamilySilenceMonitor(
   // ── In-memory state (lost on restart — boot grace covers the gap) ──────
   /** Per-family gate: last evaluation instant. */
   const lastEvalMs = new Map<string, number>();
+  /**
+   * Per-family count of consecutive evaluation cycles for which the family
+   * was observed silent (both the elapsed-time gate AND the per-family
+   * evaluation actually ran). Reset to zero on any cycle where the family
+   * evaluated and was NOT silent (i.e. a fresh `lastSuccessAt` returned the
+   * family to healthy). Layered with `SILENCE_CONSECUTIVE_TICK_THRESHOLD`
+   * (an AND with the existing 3×period elapsed-time gate) to require three
+   * consecutive silent ticks before a silence alert posts — the lever for
+   * the 2026-06-17 Cloudflare-WAF-burst incident where one bad tick
+   * tripped the alert on a stale lastSuccessAt.
+   *
+   * Lives in memory (lost on restart, like every other counter in this
+   * module — boot grace + restart-recovery via the durable alert-state
+   * store cover the gap).
+   *
+   * NOT incremented during boot grace: a family observed silent inside the
+   * grace window doesn't count toward the consecutive-tick total, so a
+   * cold-start tick can never alone push the counter to threshold. The
+   * meta-alert path keeps its own clock (failingSinceMs) and is unaffected.
+   */
+  const consecutiveSilentTicks = new Map<string, number>();
   /** Meta-alert clock: first consecutive evaluation-failure instant (grace-clamped). */
   const failingSinceMs = new Map<string, number>();
   /** Outstanding alerts awaiting their recovered one-shot. */
@@ -385,6 +424,10 @@ export function createFamilySilenceMonitor(
 
     const silent = nowMs - ref.refMs > SILENCE_PERIOD_MULTIPLIER * periodMs;
     if (!silent) {
+      // Family is healthy this cycle — reset the consecutive-silent counter
+      // so the threshold gate only ever fires on UNINTERRUPTED runs of
+      // silent observations.
+      consecutiveSilentTicks.delete(fam.family);
       // §9 recovered one-shot: the next successful batch after an alert.
       if (entry.lastSuccessAt) {
         await postRecovered(
@@ -397,6 +440,23 @@ export function createFamilySilenceMonitor(
     }
 
     if (nowMs < graceEndMs) return; // boot grace (1×period, §9)
+
+    // Consecutive-silent-tick gate (Change 3 — 2026-06-17 Cloudflare-WAF
+    // incident remediation). The elapsed-time gate above (3×period) shows
+    // the family LOOKS silent right now; the consecutive-tick gate shows
+    // it has STAYED that way across multiple evaluation cycles, so a
+    // single bad tick with a stale `lastSuccessAt` can no longer trip the
+    // alert. Both gates must be satisfied to post.
+    const ticks = (consecutiveSilentTicks.get(fam.family) ?? 0) + 1;
+    consecutiveSilentTicks.set(fam.family, ticks);
+    if (ticks < SILENCE_CONSECUTIVE_TICK_THRESHOLD) {
+      logger.debug("fleet.family-silence.silence-tick-incremented", {
+        family: fam.family,
+        consecutiveSilentTicks: ticks,
+        threshold: SILENCE_CONSECUTIVE_TICK_THRESHOLD,
+      });
+      return;
+    }
 
     const cycles = Math.floor((nowMs - ref.refMs) / periodMs);
     const attempt = lastAttemptText(entry);
@@ -417,6 +477,7 @@ export function createFamilySilenceMonitor(
       logger.warn("fleet.family-silence.silence-alert-posted", {
         family: fam.family,
         cycles,
+        consecutiveSilentTicks: ticks,
         lastAttempt: attempt,
       });
     }

--- a/showcase/harness/src/fleet/control-plane/red-baseline-railway-gql-resilience.test.ts
+++ b/showcase/harness/src/fleet/control-plane/red-baseline-railway-gql-resilience.test.ts
@@ -1,0 +1,212 @@
+/**
+ * RED→GREEN gate for the 2026-06-17 Cloudflare-WAF-burst incident.
+ *
+ * On `main` (before this fix landed) the file proved the bugs:
+ *   (a) `createServiceEnumerator` propagated the FIRST `429 / Cloudflare
+ *       1015` from the discovery source — no retry, no cached-catalog
+ *       fallback. A one-tick WAF burst zeroed out the dashboard.
+ *   (b) `createFamilySilenceMonitor` posted the silence alert on the FIRST
+ *       silent evaluation cycle — no consecutive-tick gate. A single bad
+ *       tick on a stale `lastSuccessAt` paged every family at once.
+ *
+ * Under the fix the assertions invert: the enumerator rides out the burst
+ * (retry + cache) and the silence monitor waits for three consecutive
+ * silent cycles. This file keeps the exact surfaces that surfaced the bug
+ * on main pinned green — a regression in either layer trips this gate.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  createServiceEnumerator,
+  D6_DISCOVERY_FILTER,
+  D6_DRIVER_KIND,
+} from "./catalog-enumerator.js";
+import {
+  createFamilySilenceMonitor,
+  FAMILY_SILENCE_RULE_ID,
+} from "./family-silence-monitor.js";
+import { DiscoverySourceBackendError } from "../../probes/discovery/errors.js";
+import { FLEET_FAMILIES } from "./run-view.js";
+import type {
+  FamilySummaryEntry,
+  FamilySummaryResponse,
+  RunBatch,
+} from "./run-view.js";
+import type { ProducerSchedule } from "./control-plane.js";
+import type { JobProducer } from "./job-producer.js";
+import type { AlertStateStore } from "../../storage/alert-state-store.js";
+import type { Logger } from "../../types/index.js";
+import type { DiscoverySource } from "../../probes/types.js";
+import type { RailwayServiceInfo } from "../../probes/discovery/railway-services.js";
+
+const SILENT_LOGGER: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+describe("RED→GREEN — Railway-GQL resilience (Change 1+2)", () => {
+  it("a transient 429+CF-1015 burst is retried (3 attempts) before bubbling", async () => {
+    let calls = 0;
+    const source = {
+      name: "railway-services",
+      async enumerate(_ctx: unknown, _config: unknown) {
+        calls += 1;
+        throw new DiscoverySourceBackendError(
+          "railway-services",
+          "railway gql 429: error code: 1015 (rate limited)",
+          429,
+        );
+      },
+    } as unknown as DiscoverySource<RailwayServiceInfo>;
+    const enumerate = createServiceEnumerator({
+      source,
+      env: {},
+      fetchImpl: globalThis.fetch,
+      logger: SILENT_LOGGER,
+      driverKind: D6_DRIVER_KIND,
+      probeKeyPrefix: "d6",
+      filter: D6_DISCOVERY_FILTER,
+      // Instant retry to keep the test millisecond-fast — production keeps
+      // the SSOT 1s/4s/16s schedule (see ENUMERATE_RETRY_BACKOFF_MS).
+      sleep: async () => {},
+    });
+    await expect(
+      enumerate({ triggered: false, runId: "run-1" }),
+    ).rejects.toBeInstanceOf(DiscoverySourceBackendError);
+    // Post-fix: 1 initial attempt + 3 retries = 4 calls. The "no retry"
+    // baseline (calls === 1) is the bug this gate prevents from
+    // re-landing.
+    expect(calls).toBe(4);
+  });
+});
+
+describe("RED→GREEN — family-silence consecutive-tick gate (Change 3)", () => {
+  const CRON = "0 * * * *";
+  const PERIOD = 3_600_000;
+  const BASE = Date.UTC(2026, 0, 15);
+
+  function iso(ms: number) {
+    return new Date(ms).toISOString();
+  }
+  function makeSchedules(): ProducerSchedule[] {
+    const stubProducer = {
+      start() {},
+      async stop() {},
+      async tick() {
+        throw new Error("stub: tick not used");
+      },
+      isRunning: () => true,
+    } as unknown as JobProducer;
+    return FLEET_FAMILIES.map((fam) => ({
+      scheduleId: fam.scheduleId,
+      cron: CRON,
+      producer: stubProducer,
+    }));
+  }
+  function makeFakeStore(): AlertStateStore {
+    const rows = new Map<string, unknown>();
+    return {
+      async get(ruleId, dedupeKey) {
+        return (rows.get(`${ruleId}|${dedupeKey}`) as never) ?? null;
+      },
+      async record(ruleId, dedupeKey, fields) {
+        rows.set(`${ruleId}|${dedupeKey}`, {
+          rule_id: ruleId,
+          dedupe_key: dedupeKey,
+          last_alert_at: fields.at,
+          last_alert_hash: fields.hash,
+          payload_preview: fields.preview,
+        });
+      },
+      async getSet() {
+        return { hash: null, at: null };
+      },
+      async putSet() {},
+    } as AlertStateStore;
+  }
+  function batch(over: Partial<RunBatch> = {}): RunBatch {
+    return {
+      runId: "run-1",
+      triggered: false,
+      enqueuedAt: iso(BASE - 120_000),
+      finishedAt: iso(BASE - 60_000),
+      durationMs: 60_000,
+      outcome: "completed",
+      jobs: { total: 2, done: 2, failed: 0, reclaimed: 0 },
+      cells: null,
+      redsIntroduced: null,
+      redsCleared: null,
+      errorSummary: null,
+      commErrorKinds: [],
+      ...over,
+    };
+  }
+  function entryFor(
+    family: string,
+    over: Partial<FamilySummaryEntry> = {},
+  ): FamilySummaryEntry {
+    const fam = FLEET_FAMILIES.find((f) => f.family === family)!;
+    return {
+      family: fam.family,
+      label: fam.label,
+      probeKeyPrefix: fam.probeKeyPrefix,
+      schedule: CRON,
+      periodMs: PERIOD,
+      nextRunAt: null,
+      lastRun: null,
+      inflight: null,
+      lastSuccessAt: null,
+      ...over,
+    };
+  }
+
+  it("a single silent evaluation tick DOES NOT post; three consecutive silent ticks DO", async () => {
+    // lastSuccessAt pinned BEFORE BASE so every pre-warm tick observes
+    // ≥4×period of silence — the elapsed-time gate fires on each tick and
+    // the consecutive-tick counter is the only variable under test.
+    const lastSuccessMs = BASE - 2 * PERIOD;
+    const t1 = BASE + 2 * PERIOD;
+    const t2 = BASE + 3 * PERIOD;
+    const t3 = BASE + 4 * PERIOD;
+    const families: FamilySummaryEntry[] = FLEET_FAMILIES.map((fam) =>
+      fam.family === "d6"
+        ? entryFor("d6", {
+            lastSuccessAt: iso(lastSuccessMs),
+            lastRun: batch({
+              outcome: "failed",
+              enqueuedAt: iso(lastSuccessMs - 120_000),
+              finishedAt: iso(lastSuccessMs),
+            }),
+          })
+        : entryFor(fam.family, {
+            lastSuccessAt: iso(t3 - 60_000),
+            lastRun: batch({
+              enqueuedAt: iso(t3 - 120_000),
+              finishedAt: iso(t3 - 60_000),
+            }),
+          }),
+    );
+    const body: FamilySummaryResponse = { families, workers: [] };
+    const posts: string[] = [];
+    const monitor = createFamilySilenceMonitor({
+      summary: { get: async () => body },
+      schedules: makeSchedules(),
+      alertStore: makeFakeStore(),
+      postAlert: async (text) => {
+        posts.push(text);
+      },
+      bootAtMs: BASE,
+      logger: SILENT_LOGGER,
+    });
+    await monitor.tick(t1);
+    expect(posts).toEqual([]);
+    await monitor.tick(t2);
+    expect(posts).toEqual([]);
+    await monitor.tick(t3);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toContain("worker family D6 all-pills silent");
+    // Pin the rule-id to make the assertion grep-stable.
+    expect(FAMILY_SILENCE_RULE_ID).toBe("family-silence");
+  });
+});


### PR DESCRIPTION
## Summary

Harden the showcase harness producer against transient Railway-GQL 429 / Cloudflare-WAF flaps. Today's incident: a ~25-min Cloudflare WAF burst-block on `backboard.railway.com/graphql/v2` caused the producer's catalog-enumerate to hard-fail every cron tick, zeroing out D4/D5/D6 writes and turning the entire staging dashboard red within one tick window.

Three discrete behavior changes, one PR:

1. **Retry with exponential backoff in `source.enumerate`** — three retries at 1s/4s/16s on HTTP 429, 5xx, Cloudflare 1015/1020/1022 markers, or transport-level errors. Does NOT retry on `DiscoverySourceAuthError`, non-429 4xx, or schema errors (operator-actionable, fail loud). Lives in `showcase/harness/src/fleet/control-plane/catalog-enumerator.ts` (the seam every family enumerator passes through).
2. **Cached-catalog fallback** — per-enumerator in-memory cache of the last successful `services[]`. On persistent failure (all retries exhausted) AND a cache present, the wrapper logs `fleet.producer.enumerate-failed-using-cache` (warn, with `services` count, `ageMs`, and `reason`) and returns the cached catalog. With NO cache (fresh-boot first enumerate fails), the wrapper re-throws so the producer's `enumerate-failed` short-circuit still runs — without a catalog there's nothing to enqueue.
3. **3-tick family-silence threshold** — `SILENCE_CONSECUTIVE_TICK_THRESHOLD = 3` layered ON TOP of the existing `3 × period` elapsed-time gate. The silence alert now requires BOTH: `now - lastSuccessAt > 3 × period` AND three consecutive evaluation cycles observed silent. A single bad tick on a stale `lastSuccessAt` can no longer page every family at once.

## Red-Green proof

**RED on main (`5a62acbf`)** — observed BEFORE the fix. The RED file asserts the BUG (`calls === 1` after a 429 throw; `posts.length === 1` after a single silent tick):

```
> vitest run src/fleet/control-plane/red-baseline-railway-gql-resilience.test.ts
RUN  v3.2.4 .../showcase/harness
✓ src/fleet/control-plane/red-baseline-railway-gql-resilience.test.ts (2 tests) 3ms
  ✓ [BUG] one 429 + Cloudflare 1015 from the source aborts the whole enumerate (no retry)
  ✓ [BUG] silence alert posts on the FIRST silent evaluation tick (no consecutive-tick threshold)
Test Files  1 passed (1)
     Tests  2 passed (2)
```

**GREEN on fix branch** — observed AFTER the fix (assertions inverted to the fixed behavior; `calls === 4` after retries; `posts === []` until the third silent tick):

```
> vitest run src/fleet/control-plane/red-baseline-railway-gql-resilience.test.ts src/fleet/control-plane/catalog-enumerator.test.ts src/fleet/control-plane/family-silence-monitor.test.ts
RUN  v3.2.4 .../showcase/harness
✓ src/fleet/control-plane/red-baseline-railway-gql-resilience.test.ts (2 tests) 4ms
✓ src/fleet/control-plane/family-silence-monitor.test.ts (19 tests) 8ms
✓ src/fleet/control-plane/catalog-enumerator.test.ts (29 tests) 6ms
Test Files  3 passed (3)
     Tests  50 passed (50)
```

Full harness suite — **131 files / 2812 tests pass** (`pnpm -F @copilotkit/showcase-harness test`).

## Test plan

- [x] RED proof captured on `main` (single-attempt enumerate; single-tick silence alert)
- [x] GREEN proof on this branch (retry to 4 calls; cached fallback; 3-tick threshold)
- [x] `pnpm -F @copilotkit/showcase-harness test` — 2812 passed
- [x] `pnpm -F @copilotkit/showcase-harness typecheck` — clean
- [x] `pnpm -F @copilotkit/showcase-harness build` — clean
- [x] `oxfmt --write` applied; `oxlint` clean
- [ ] CI green
- [ ] Staging redeploy verified via Railway CLI + Playwright dashboard snapshot

## Files touched

- `showcase/harness/src/fleet/control-plane/catalog-enumerator.ts` (+296, -3): retry+cache wrapper, exports `ENUMERATE_RETRY_BACKOFF_MS` + `isRetryableEnumerateError` + `SleepFn`
- `showcase/harness/src/fleet/control-plane/catalog-enumerator.test.ts` (+295): retry/cache/auth-not-retried/backoff-SSOT tests
- `showcase/harness/src/fleet/control-plane/family-silence-monitor.ts` (+61): `SILENCE_CONSECUTIVE_TICK_THRESHOLD = 3`, per-family counter, counter reset on healthy
- `showcase/harness/src/fleet/control-plane/family-silence-monitor.test.ts` (+218, -39): 3-tick threshold + counter-reset gate tests; updated existing tests to advance through 3 silent ticks
- `showcase/harness/src/fleet/control-plane/red-baseline-railway-gql-resilience.test.ts` (new, +212): the literal RED→GREEN gate

## Operational notes

- No new env vars, feature flags, or backward-compat shims (per scope directive).
- The cached-catalog warn surfaces in observability via `fleet.producer.enumerate-failed-using-cache` (services count, ageMs, reason).
- `SLACK_WEBHOOK_OSS_ALERTS` is intentionally unset (user config); not touched.

Pre-existing repo-wide lefthook failures (`@copilotkit/core`, `@copilotkit/runtime`, `@copilotkit/shared` etc.) reproduce on `main` without my changes and are unrelated to harness code; harness-scoped quality gates all passed before commit.