### PR TITLE
fix(showcase/aimock): add ag2 Excalidraw create_view d6 fixture

### DIFF
--- a/showcase/aimock/d6/ag2/mcp-apps.json
+++ b/showcase/aimock/d6/ag2/mcp-apps.json
@@ -16,6 +16,26 @@
       }
     },
     {
+      "_comment": "D5 mcp-apps probe — verbatim probe prompt drives a real `create_view` MCP tool call so the runtime's MCP Apps middleware fetches the UI resource and mounts the iframe. Mirrored from showcase/aimock/d6/langgraph-python/tool-rendering-reasoning-chain.json (the LGP gold-standard entry) — ag2 was the only integration missing this turn-1 fixture, so strict-mode staging returned 503 for ag2 + this prompt + create_view while all other integrations matched.",
+      "match": {
+        "userMessage": "Open Excalidraw and sketch a system diagram",
+        "toolName": "create_view",
+        "context": "ag2"
+      },
+      "response": {
+        "reasoning": "The user wants a sketch of a client/server/database architecture. I'll call create_view once with three labelled rectangles connected by arrows and a title, framed by a cameraUpdate.",
+        "content": "Sketching a client → server → database diagram in Excalidraw.",
+        "toolCalls": [
+          {
+            "id": "call_d5_mcp_apps_create_view_001",
+            "name": "create_view",
+            "arguments": "{\"elements\":[{\"id\":\"title\",\"type\":\"text\",\"x\":260,\"y\":40,\"text\":\"System Diagram\",\"fontSize\":24},{\"id\":\"client\",\"type\":\"rectangle\",\"x\":80,\"y\":160,\"width\":160,\"height\":70,\"label\":{\"text\":\"Client\",\"fontSize\":18}},{\"id\":\"server\",\"type\":\"rectangle\",\"x\":320,\"y\":160,\"width\":160,\"height\":70,\"label\":{\"text\":\"Server\",\"fontSize\":18}},{\"id\":\"database\",\"type\":\"rectangle\",\"x\":560,\"y\":160,\"width\":160,\"height\":70,\"label\":{\"text\":\"Database\",\"fontSize\":18}},{\"id\":\"a1\",\"type\":\"arrow\",\"x\":240,\"y\":195,\"endX\":320,\"endY\":195},{\"id\":\"a2\",\"type\":\"arrow\",\"x\":480,\"y\":195,\"endX\":560,\"endY\":195},{\"id\":\"camera\",\"type\":\"cameraUpdate\",\"x\":40,\"y\":0,\"width\":800,\"height\":600}]}"
+          }
+        ]
+      },
+      "chunkSize": 9999
+    },
+    {
       "_comment": "D5 mcp-apps suggestion pill #1 (\"Draw a flowchart\"). Sends the verbatim suggestion message \"Use Excalidraw to draw a simple flowchart with three steps.\" The distinctive substring \"draw a simple flowchart\" prevents collision with feature-parity.json's generic `{userMessage: \"steps\"}` fixture, which would otherwise absorb the prompt and return a tool-call-free planning blurb (breaking the iframe). Turn 1 emits `create_view` with three-step flowchart elements so the MCP middleware fetches the Excalidraw UI resource and mounts the iframe; turn 2 (after the tool result) emits the deterministic narration.",
       "match": {
         "userMessage": "draw a simple flowchart",


### PR DESCRIPTION
## The gap

Staging strict-mode replay against `aimock-staging.up.railway.app` confirmed
**ag2** was the only integration missing a fixture for:

- `userMessage: "Open Excalidraw and sketch a system diagram..."`
- `toolName: "create_view"`
- `context: "ag2"`

All 11 other contexts that share this userMessage (`langgraph-python`,
`google-adk`, `ms-agent-{dotnet,python}`, `strands`, `llamaindex`,
`built-in-agent`, `claude-sdk-{typescript,python}`, `langroid`, `mastra`)
return 200 with `tools=[create_view]` declared. Only `ag2` returns
`{"code":"no_fixture_match"}`.

Evidence: a staging-only audit on the originating workstation
(`/tmp/aimock-staging-fixture-verify.md`).

## The fix

One fixture entry added to `showcase/aimock/d6/ag2/mcp-apps.json`,
mirroring the LGP gold-standard at
`showcase/aimock/d6/langgraph-python/tool-rendering-reasoning-chain.json`
(same fixture id `call_d5_mcp_apps_create_view_001`, same arguments payload,
same `chunkSize: 9999`). The entry sits next to the existing
`hasToolResult: true` turn-2 sibling for the same userMessage.

## Red-green proof

**RED (pre-fix, against staging):**
```
$ curl -sS -X POST https://aimock-staging.up.railway.app/v1/chat/completions \
    -H "X-AIMock-Context: ag2" -H "X-AIMock-Strict: true" \
    -H "Content-Type: application/json" \
    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Open Excalidraw and sketch a system diagram..."}],"tools":[{"type":"function","function":{"name":"create_view","parameters":{"type":"object","properties":{}}}}]}'

{"error":{"message":"Strict mode: no fixture matched","type":"invalid_request_error","param":null,"code":"no_fixture_match"}}
```

**GREEN (post-fix, against local iso9 aimock with the new fixture mounted):**
```
$ curl -sS -X POST http://localhost:6010/v1/chat/completions \
    -H "X-AIMock-Context: ag2" -H "X-AIMock-Strict: true" \
    -H "Content-Type: application/json" \
    -d '{ ...same payload... }'

200 OK
content: "Sketching a client → server → database diagram in Excalidraw."
tool_calls[0].id: "call_d5_mcp_apps_create_view_001"
tool_calls[0].function.name: "create_view"
```

Local aimock `/__aimock/journal` confirms the match keys:
```
status=200 fixture={"userMessage":"Open Excalidraw and sketch a system diagram","toolName":"create_view","context":"ag2"}
```

**LGP regression check:** the same probe with
`X-AIMock-Context: langgraph-python` against the local iso9 aimock returns 200
with the same canonical tool_call payload — LGP unaffected.

## Scope

Intentionally narrow per "scope PRs to the originally-flagged findings". This
PR closes ONLY the one genuine fixture gap identified by the staging
verification audit. The 9 other 503s in that audit (sales-dashboard across 9
slugs + google-adk Excalidraw) are NOT fixture gaps — staging replays show
those fixtures DO load and DO match when `tools=[create_view]` is declared.
The 503s come from the backend omitting the tool name from the outbound
`/v1/chat/completions` request's `tools` array, a separate effort.

## Post-merge verification

After `showcase_deploy` rebuilds `aimock-staging`, the same staging probe
above will be re-run; it must return 200 (not 503).