### PR TITLE
fix(showcase/aimock): add generate_a2ui d6 fixtures for 8 slugs (Sales Dashboard probe)

### DIFF
--- a/showcase/aimock/d6/ag2/gen-ui-declarative.json
+++ b/showcase/aimock/d6/ag2/gen-ui-declarative.json
@@ -188,6 +188,23 @@
         ]
       },
       "chunkSize": 9999
+    },
+    {
+      "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args). Mirrors LGP gen-ui-declarative.json sales-dashboard outer entry. Closes the production 503 gap where backend hits aimock with tools=[generate_a2ui] for this userMessage (see /tmp/staging-journal-diff.md shape-B).",
+      "match": {
+        "userMessage": "Show me my sales dashboard for this quarter.",
+        "context": "ag2"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_dash_outer_ag2_001",
+            "name": "generate_a2ui",
+            "arguments": "{}"
+          }
+        ]
+      },
+      "chunkSize": 9999
     }
   ]
 }

--- a/showcase/aimock/d6/built-in-agent/gen-ui-declarative.json
+++ b/showcase/aimock/d6/built-in-agent/gen-ui-declarative.json
@@ -161,6 +161,23 @@
       "response": {
         "content": "System health report rendered — API and Database are healthy, Background Workers are degraded."
       }
+    },
+    {
+      "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args). Mirrors LGP gen-ui-declarative.json sales-dashboard outer entry. Closes the production 503 gap where backend hits aimock with tools=[generate_a2ui] for this userMessage (see /tmp/staging-journal-diff.md shape-B).",
+      "match": {
+        "userMessage": "Show me my sales dashboard for this quarter.",
+        "context": "built-in-agent"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_dash_outer_bia_001",
+            "name": "generate_a2ui",
+            "arguments": "{}"
+          }
+        ]
+      },
+      "chunkSize": 9999
     }
   ]
 }

--- a/showcase/aimock/d6/claude-sdk-python/gen-ui-declarative.json
+++ b/showcase/aimock/d6/claude-sdk-python/gen-ui-declarative.json
@@ -113,6 +113,23 @@
       "response": {
         "content": "System health report: API and Database are healthy (99.97% and 99.99% uptime). Background Workers are slightly degraded at 98.2% uptime."
       }
+    },
+    {
+      "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args). Mirrors LGP gen-ui-declarative.json sales-dashboard outer entry. Closes the production 503 gap where backend hits aimock with tools=[generate_a2ui] for this userMessage (see /tmp/staging-journal-diff.md shape-B).",
+      "match": {
+        "userMessage": "Show me my sales dashboard for this quarter.",
+        "context": "claude-sdk-python"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_dash_outer_cspy_001",
+            "name": "generate_a2ui",
+            "arguments": "{}"
+          }
+        ]
+      },
+      "chunkSize": 9999
     }
   ]
 }

--- a/showcase/aimock/d6/claude-sdk-typescript/gen-ui-declarative.json
+++ b/showcase/aimock/d6/claude-sdk-typescript/gen-ui-declarative.json
@@ -118,6 +118,23 @@
         "content": "Status report rendered — API and database are healthy, background workers show degraded performance."
       },
       "chunkSize": 9999
+    },
+    {
+      "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args). Mirrors LGP gen-ui-declarative.json sales-dashboard outer entry. Closes the production 503 gap where backend hits aimock with tools=[generate_a2ui] for this userMessage (see /tmp/staging-journal-diff.md shape-B).",
+      "match": {
+        "userMessage": "Show me my sales dashboard for this quarter.",
+        "context": "claude-sdk-typescript"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_dash_outer_csts_001",
+            "name": "generate_a2ui",
+            "arguments": "{}"
+          }
+        ]
+      },
+      "chunkSize": 9999
     }
   ]
 }

--- a/showcase/aimock/d6/langroid/gen-ui-declarative.json
+++ b/showcase/aimock/d6/langroid/gen-ui-declarative.json
@@ -116,6 +116,23 @@
       "response": {
         "content": "System health report rendered. API and Database are healthy; Background Workers are in a degraded state."
       }
+    },
+    {
+      "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args). Mirrors LGP gen-ui-declarative.json sales-dashboard outer entry. Closes the production 503 gap where backend hits aimock with tools=[generate_a2ui] for this userMessage (see /tmp/staging-journal-diff.md shape-B).",
+      "match": {
+        "userMessage": "Show me my sales dashboard for this quarter.",
+        "context": "langroid"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_dash_outer_langroid_001",
+            "name": "generate_a2ui",
+            "arguments": "{}"
+          }
+        ]
+      },
+      "chunkSize": 9999
     }
   ]
 }

--- a/showcase/aimock/d6/llamaindex/gen-ui-declarative.json
+++ b/showcase/aimock/d6/llamaindex/gen-ui-declarative.json
@@ -116,6 +116,23 @@
       "response": {
         "content": "System health report rendered — API and Database are healthy; Background Workers showing degraded status at 98.2% uptime."
       }
+    },
+    {
+      "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args). Mirrors LGP gen-ui-declarative.json sales-dashboard outer entry. Closes the production 503 gap where backend hits aimock with tools=[generate_a2ui] for this userMessage (see /tmp/staging-journal-diff.md shape-B).",
+      "match": {
+        "userMessage": "Show me my sales dashboard for this quarter.",
+        "context": "llamaindex"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_dash_outer_llamaindex_001",
+            "name": "generate_a2ui",
+            "arguments": "{}"
+          }
+        ]
+      },
+      "chunkSize": 9999
     }
   ]
 }

--- a/showcase/aimock/d6/ms-agent-dotnet/gen-ui-declarative.json
+++ b/showcase/aimock/d6/ms-agent-dotnet/gen-ui-declarative.json
@@ -184,6 +184,23 @@
         ]
       },
       "chunkSize": 9999
+    },
+    {
+      "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args). Mirrors LGP gen-ui-declarative.json sales-dashboard outer entry. Closes the production 503 gap where backend hits aimock with tools=[generate_a2ui] for this userMessage (see /tmp/staging-journal-diff.md shape-B).",
+      "match": {
+        "userMessage": "Show me my sales dashboard for this quarter.",
+        "context": "ms-agent-dotnet"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_dash_outer_msnet_001",
+            "name": "generate_a2ui",
+            "arguments": "{}"
+          }
+        ]
+      },
+      "chunkSize": 9999
     }
   ]
 }

--- a/showcase/aimock/d6/ms-agent-python/gen-ui-declarative.json
+++ b/showcase/aimock/d6/ms-agent-python/gen-ui-declarative.json
@@ -185,6 +185,23 @@
         ]
       },
       "chunkSize": 9999
+    },
+    {
+      "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args). Mirrors LGP gen-ui-declarative.json sales-dashboard outer entry. Closes the production 503 gap where backend hits aimock with tools=[generate_a2ui] for this userMessage (see /tmp/staging-journal-diff.md shape-B).",
+      "match": {
+        "userMessage": "Show me my sales dashboard for this quarter.",
+        "context": "ms-agent-python"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_d6_decl_dash_outer_mspy_001",
+            "name": "generate_a2ui",
+            "arguments": "{}"
+          }
+        ]
+      },
+      "chunkSize": 9999
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes the production 503 gap on aimock-staging for the **"Show me my sales dashboard for this quarter."** userMessage across 8 non-LGP slugs. Mirrors LGP's `generate_a2ui` outer-emit fixture pattern.

Empirical gap (from `/tmp/staging-journal-diff.md`):

| Shape | Traffic | Status on main | Why |
|---|---|---|---|
| Shape A | model=gpt-4o-mini, no tools key, curl/8.7.1 | 503 | (out of scope) |
| Shape B | model=gpt-4.1, stream=true, tools=[generate_a2ui], AsyncOpenAI/Python | **503** | **No fixture matched** (this PR's target) |

LGP has both `render_a2ui` AND `generate_a2ui` fixtures for this userMessage → stays 200. The 8 slugs below were missing the `generate_a2ui` entry → 503.

## Slugs patched

8 file edits, one entry each in `showcase/aimock/d6/<slug>/gen-ui-declarative.json`:

- llamaindex / built-in-agent / ag2 / langroid / claude-sdk-typescript / claude-sdk-python / ms-agent-dotnet / ms-agent-python

Each entry mirrors LGP's sales-dashboard outer entry — match by `userMessage` + `context: "<slug>"`, response is a `generate_a2ui` toolcall with no args and a per-slug unique toolCallId.

## Red-Green Proof (local aimock against `ghcr.io/copilotkit/aimock:latest`)

Replayed the Shape-B production request body (model=gpt-4.1, stream=true, tools=[generate_a2ui], X-AIMock-Context per slug) against local aimock booted with unmodified `main` fixtures (RED) then this branch's fixtures (GREEN).

**RED (baseline main, all 8 slugs):** `HTTP=404 ERROR=no_fixture_match`
(aimock's 404 `no_fixture_match` is what surfaces as 503 on prod aimock-staging.)

**GREEN (this branch, all 8 slugs):** `HTTP=200 tool=generate_a2ui id=call_d6_decl_dash_outer_<slug>_001`

**LGP regression (baseline → fix branch):** `HTTP=200` (unchanged).

Logs: `/tmp/genfix-RED-baseline.log`, `/tmp/genfix-value-test.log`, `/tmp/genfix-lgp-regression.log`.

## Aimock fixture validation

`pnpm --filter @copilotkit/showcase-scripts test aimock-fixtures` → **737/737 tests pass**.

## Scope

Intentionally narrow per CLAUDE.md "scope PRs to originally-flagged findings":
- Closes Shape-B `tools=[generate_a2ui]` 503s for ONE userMessage.
- Out of scope: Shape-A 503s (no `tools` key, `curl/8.7.1` probe traffic) and other userMessage gaps — separate follow-ups.

## Test plan

- [x] Local aimock RED→GREEN proof across all 8 slugs (Shape-B request body)
- [x] LGP regression check (unchanged)
- [x] Aimock fixture validation suite (737/737)
- [ ] CI green
- [ ] Post-deploy staging replay (8 slugs → 200)