### PR TITLE
Refactor shell docs quickstart routing and sidebar behavior

### DIFF
--- a/showcase/shell-docs/next.config.ts
+++ b/showcase/shell-docs/next.config.ts
@@ -221,6 +221,11 @@ const nextConfig: NextConfig = {
         destination: "/:path*",
         permanent: true,
       },
+      {
+        source: "/:framework/quickstart",
+        destination: "/:framework/quickstart/react",
+        permanent: true,
+      },
       // troubleshooting/migrate-to-* in unselected → existing
       // /migrate/* canonical (already redirected at the
       // /troubleshooting/migrate-to-* level).

--- a/showcase/shell-docs/next.config.ts
+++ b/showcase/shell-docs/next.config.ts
@@ -84,6 +84,11 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
       {
+        source: "/quickstart",
+        destination: "/react",
+        permanent: true,
+      },
+      {
         source: "/frontend-actions",
         destination: "/frontend-tools",
         permanent: true,
@@ -123,7 +128,7 @@ const nextConfig: NextConfig = {
       },
       {
         source: "/unselected/quickstart",
-        destination: "/quickstart",
+        destination: "/react",
         permanent: true,
       },
       {

--- a/showcase/shell-docs/package-lock.json
+++ b/showcase/shell-docs/package-lock.json
@@ -22,6 +22,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-ga4": "^2.1.0",
+        "react-icons": "^5.6.0",
         "remark-gfm": "^4.0.0",
         "tailwind-merge": "^3.6.0",
         "yaml": "^2.7.0"
@@ -6629,6 +6630,15 @@
       "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
       "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==",
       "license": "MIT"
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",

--- a/showcase/shell-docs/package.json
+++ b/showcase/shell-docs/package.json
@@ -28,6 +28,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-ga4": "^2.1.0",
+    "react-icons": "^5.6.0",
     "remark-gfm": "^4.0.0",
     "tailwind-merge": "^3.6.0",
     "yaml": "^2.7.0"

--- a/showcase/shell-docs/src/app/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[[...slug]]/page.tsx
@@ -22,6 +22,10 @@ import {
   buildRootSurfaceNav,
   loadDoc,
 } from "@/lib/docs-render";
+import {
+  frontendQuickstartContentSlugPath,
+  frontendQuickstartHref,
+} from "@/lib/frontend-quickstarts";
 import { compareByDisplayOrder } from "@/lib/framework-order";
 import { navTreeToPageTree } from "@/lib/page-tree-bridge";
 import {
@@ -75,10 +79,11 @@ export async function generateMetadata({
   }
   // Root URLs serve the BIA-authored page when one exists (see
   // UnscopedDocsPage) — mirror that resolution for metadata.
+  const contentSlugPath = frontendQuickstartContentSlugPath(slugPath);
   const doc =
     loadDoc(
-      `integrations/${getDocsFolder(HOME_DEFAULT_FRAMEWORK)}/${slugPath}`,
-    ) ?? loadDoc(slugPath);
+      `integrations/${getDocsFolder(HOME_DEFAULT_FRAMEWORK)}/${contentSlugPath}`,
+    ) ?? loadDoc(contentSlugPath);
   return buildDocMetadata({
     title: doc?.fm.title ?? slugPath,
     description: doc?.fm.description,
@@ -120,10 +125,7 @@ function DocsOverview() {
       slug: i.slug,
       name: i.slug === HOME_DEFAULT_FRAMEWORK ? "CopilotKit (Default)" : i.name,
       logo: i.logo ?? null,
-      href:
-        i.slug === HOME_DEFAULT_FRAMEWORK
-          ? "/quickstart"
-          : `/${i.slug}/quickstart`,
+      href: frontendQuickstartHref(i.slug, "react"),
     }));
   return (
     <ShellDocsLayout tree={pageTree} banner={<SidebarFrameworkSelector />}>

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.test.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.test.tsx
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { redirectMock } = vi.hoisted(() => ({
+  redirectMock: vi.fn((href: string) => {
+    throw new Error(`NEXT_REDIRECT:${href}`);
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+  redirect: redirectMock,
+}));
+
+import FrameworkScopedDocsPage from "./page";
+
+describe("FrameworkScopedDocsPage", () => {
+  beforeEach(() => {
+    redirectMock.mockClear();
+  });
+
+  it("redirects framework quickstart shims to the scoped React quickstart", async () => {
+    await expect(
+      FrameworkScopedDocsPage({
+        params: Promise.resolve({
+          framework: "langgraph-python",
+          slug: ["quickstart"],
+        }),
+      }),
+    ).rejects.toThrow("NEXT_REDIRECT:/langgraph-python/quickstart/react");
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      "/langgraph-python/quickstart/react",
+    );
+  });
+});

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -240,6 +240,14 @@ export default async function FrameworkScopedDocsPage({
     return <FrameworkRootPage framework={framework} />;
   }
 
+  if (slugPath === "quickstart") {
+    redirect(
+      framework === ROOT_FRAMEWORK
+        ? "/react"
+        : `/${framework}/quickstart/react`,
+    );
+  }
+
   // `/<framework>/unselected/<path>` is incoherent — a framework IS
   // selected, so the URL should never assert the "unselected" state
   // alongside. Collapse to the framework-scoped path (which serves the

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -107,8 +107,7 @@ export async function generateMetadata({
     // mirror UnscopedDocsPage's resolution so the metadata matches the
     // content the route serves.
     const unscopedPath = [framework, ...(slug ?? [])].join("/");
-    const unscopedContentPath =
-      frontendQuickstartContentSlugPath(unscopedPath);
+    const unscopedContentPath = frontendQuickstartContentSlugPath(unscopedPath);
     const doc =
       loadDoc(
         `integrations/${getDocsFolder(ROOT_FRAMEWORK)}/${unscopedContentPath}`,
@@ -275,8 +274,7 @@ export default async function FrameworkScopedDocsPage({
     integration?.name ??
     frameworkOverviews[framework]?.frameworkName ??
     framework;
-  const requestedContentSlugPath =
-    frontendQuickstartContentSlugPath(slugPath);
+  const requestedContentSlugPath = frontendQuickstartContentSlugPath(slugPath);
 
   let contentSlugPath: string = requestedContentSlugPath;
   let doc: ReturnType<typeof loadDoc> = null;

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -46,6 +46,7 @@ import {
   findFrameworksWithPage,
   loadDoc,
 } from "@/lib/docs-render";
+import { frontendQuickstartContentSlugPath } from "@/lib/frontend-quickstarts";
 import type { NavNode } from "@/lib/docs-render";
 import {
   getDocsFolder,
@@ -97,6 +98,7 @@ export async function generateMetadata({
   let title: string | undefined;
   let description: string | undefined;
   const slugPath = slug?.join("/") ?? "";
+  const contentSlugPath = frontendQuickstartContentSlugPath(slugPath);
   const integration = getIntegration(framework);
   const isDocsOnlyFramework =
     !integration && hasDocsOnlyFrameworkContent(framework);
@@ -105,18 +107,20 @@ export async function generateMetadata({
     // mirror UnscopedDocsPage's resolution so the metadata matches the
     // content the route serves.
     const unscopedPath = [framework, ...(slug ?? [])].join("/");
+    const unscopedContentPath =
+      frontendQuickstartContentSlugPath(unscopedPath);
     const doc =
       loadDoc(
-        `integrations/${getDocsFolder(ROOT_FRAMEWORK)}/${unscopedPath}`,
-      ) ?? loadDoc(unscopedPath);
+        `integrations/${getDocsFolder(ROOT_FRAMEWORK)}/${unscopedContentPath}`,
+      ) ?? loadDoc(unscopedContentPath);
     title = doc?.fm.title ?? humanizeSlug(unscopedPath);
     description = doc?.fm.description;
   } else if (slugPath) {
     const docsFolder = getDocsFolder(framework);
     const frameworkScopedDoc = loadDoc(
-      `integrations/${docsFolder}/${slugPath}`,
+      `integrations/${docsFolder}/${contentSlugPath}`,
     );
-    const doc = frameworkScopedDoc ?? loadDoc(slugPath);
+    const doc = frameworkScopedDoc ?? loadDoc(contentSlugPath);
     if (doc) {
       title = doc.fm.title;
       description = doc.fm.description;
@@ -271,8 +275,10 @@ export default async function FrameworkScopedDocsPage({
     integration?.name ??
     frameworkOverviews[framework]?.frameworkName ??
     framework;
+  const requestedContentSlugPath =
+    frontendQuickstartContentSlugPath(slugPath);
 
-  let contentSlugPath: string = slugPath;
+  let contentSlugPath: string = requestedContentSlugPath;
   let doc: ReturnType<typeof loadDoc> = null;
 
   // Content resolution order depends on docs_mode:
@@ -287,24 +293,24 @@ export default async function FrameworkScopedDocsPage({
   //   generated — root MDX wins (Model 1, current behavior); the
   //               per-framework tree is a sparse override layer.
   if (docsMode === "authored") {
-    const frameworkPath = `integrations/${docsFolder}/${slugPath}`;
+    const frameworkPath = `integrations/${docsFolder}/${requestedContentSlugPath}`;
     doc = loadDoc(frameworkPath);
     if (doc) contentSlugPath = frameworkPath;
-    if (!doc) doc = loadDoc(slugPath);
+    if (!doc) doc = loadDoc(requestedContentSlugPath);
   } else {
     // `/quickstart` at the root is a routing shim — it exists only so
     // the sidebar's Quickstart entry has a backing page. Real quickstart
     // content lives per-framework at `integrations/<framework>/quickstart.mdx`,
     // so for framework-scoped URLs the override always wins over the shim.
-    if (slugPath === "quickstart") {
-      const overridePath = `integrations/${docsFolder}/${slugPath}`;
+    if (requestedContentSlugPath === "quickstart") {
+      const overridePath = `integrations/${docsFolder}/${requestedContentSlugPath}`;
       doc = loadDoc(overridePath);
       if (doc) contentSlugPath = overridePath;
     }
     if (!doc) {
-      doc = loadDoc(slugPath);
+      doc = loadDoc(requestedContentSlugPath);
       if (!doc) {
-        const fallbackPath = `integrations/${docsFolder}/${slugPath}`;
+        const fallbackPath = `integrations/${docsFolder}/${requestedContentSlugPath}`;
         doc = loadDoc(fallbackPath);
         if (doc) contentSlugPath = fallbackPath;
       }

--- a/showcase/shell-docs/src/app/llms-mdx/[[...slug]]/route.ts
+++ b/showcase/shell-docs/src/app/llms-mdx/[[...slug]]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import path from "path";
 import { AG_UI_CONTENT_DIR } from "@/lib/sitemap-helpers";
 import { loadDoc } from "@/lib/docs-render";
+import { frontendQuickstartContentSlugPath } from "@/lib/frontend-quickstarts";
 import {
   getDocsFolder,
   getDocsMode,
@@ -121,15 +122,16 @@ function resolvePage(slug: string[]): ResolvedPage | null {
     const docsFolder = getDocsFolder(first);
     const docsMode = getDocsMode(first);
     const tail = rest || "index";
-    const rootSlugPath = tail;
-    const frameworkSlugPath = `integrations/${docsFolder}/${tail}`;
+    const contentTail = frontendQuickstartContentSlugPath(tail);
+    const rootSlugPath = contentTail;
+    const frameworkSlugPath = `integrations/${docsFolder}/${contentTail}`;
 
     // `authored` frameworks own their entire IA — try the per-framework
     // tree first. `generated` is the inverse — root wins, framework
     // tree is the override, except quickstart where the root file is
     // only a routing shim and the page route prefers framework content.
     const candidateOrder =
-      docsMode === "authored" || tail === "quickstart"
+      docsMode === "authored" || contentTail === "quickstart"
         ? [frameworkSlugPath, rootSlugPath]
         : [rootSlugPath, frameworkSlugPath];
 
@@ -154,9 +156,12 @@ function resolvePage(slug: string[]): ResolvedPage | null {
   // Bare unscoped doc. The root surface serves ROOT_FRAMEWORK's
   // authored page when one exists (mirrors UnscopedDocsPage), so the
   // `.md` variant must resolve the same MDX the page renders.
-  const rootOverride = `integrations/${getDocsFolder(ROOT_FRAMEWORK)}/${url}`;
+  const contentUrl = frontendQuickstartContentSlugPath(url);
+  const rootOverride = `integrations/${getDocsFolder(ROOT_FRAMEWORK)}/${contentUrl}`;
   const candidates =
-    getDocsMode(ROOT_FRAMEWORK) === "authored" ? [rootOverride, url] : [url];
+    getDocsMode(ROOT_FRAMEWORK) === "authored"
+      ? [rootOverride, contentUrl]
+      : [contentUrl];
   for (const candidate of candidates) {
     const doc = loadDoc(candidate);
     if (!doc) continue;

--- a/showcase/shell-docs/src/app/og/[...slug]/route.tsx
+++ b/showcase/shell-docs/src/app/og/[...slug]/route.tsx
@@ -5,6 +5,7 @@ import type { NextRequest } from "next/server";
 import { notFound } from "next/navigation";
 import { ImageResponse } from "next/og";
 import { loadDoc } from "@/lib/docs-render";
+import { frontendQuickstartContentSlugPath } from "@/lib/frontend-quickstarts";
 import { getDocsFolder, getIntegration, ROOT_FRAMEWORK } from "@/lib/registry";
 
 // Per-page Open Graph image route — emits a 1200x630-ish PNG used by
@@ -89,15 +90,18 @@ export async function GET(
     //      that name in the docs root (built-in-agent.mdx) — the
     //      existing behavior preserved here so prior callers keep
     //      working.
+    const contentSlugPath = frontendQuickstartContentSlugPath(slugPath);
     let doc = slugPath
-      ? (loadDoc(`integrations/${getDocsFolder(ROOT_FRAMEWORK)}/${slugPath}`) ??
-        loadDoc(slugPath))
+      ? (loadDoc(
+          `integrations/${getDocsFolder(ROOT_FRAMEWORK)}/${contentSlugPath}`,
+        ) ?? loadDoc(contentSlugPath))
       : null;
     if (!doc && slugParts.length >= 2) {
       const [framework, ...rest] = slugParts;
       if (getIntegration(framework)) {
         const docsFolder = getDocsFolder(framework);
-        doc = loadDoc(`integrations/${docsFolder}/${rest.join("/")}`);
+        const contentRest = frontendQuickstartContentSlugPath(rest.join("/"));
+        doc = loadDoc(`integrations/${docsFolder}/${contentRest}`);
       }
     }
     if (!doc) notFound();

--- a/showcase/shell-docs/src/components/__tests__/frontend-quickstart-selector.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/frontend-quickstart-selector.test.tsx
@@ -1,0 +1,35 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/react",
+  useRouter: () => ({ replace: vi.fn() }),
+}));
+
+vi.mock("../framework-provider", () => ({
+  useFramework: () => ({
+    effectiveFramework: "built-in-agent",
+    framework: null,
+  }),
+}));
+
+import { FrontendQuickstartSelector } from "../frontend-quickstart-selector";
+
+describe("FrontendQuickstartSelector", () => {
+  it("labels the selected frontend picker as a frontend quickstart", () => {
+    const markup = renderToStaticMarkup(<FrontendQuickstartSelector />);
+
+    expect(markup).toContain("Frontend Quickstart");
+    expect(markup).not.toContain("App frontend quickstart");
+  });
+
+  it("uses the same sidebar selector sizing and selected surface as the backend picker", () => {
+    const markup = renderToStaticMarkup(<FrontendQuickstartSelector />);
+
+    expect(markup).toContain("h-12");
+    expect(markup).toContain("bg-[var(--accent-dim)]");
+    expect(markup).toContain("border-[var(--nav-control-border)]");
+    expect(markup).toContain("hover:bg-[var(--accent-light)]");
+    expect(markup).toContain("h-8 w-8 shrink-0");
+  });
+});

--- a/showcase/shell-docs/src/components/__tests__/hero-quickstart-dropdown.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/hero-quickstart-dropdown.test.tsx
@@ -1,0 +1,33 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../framework-provider", () => ({
+  useFramework: () => ({
+    setStoredFramework: vi.fn(),
+  }),
+}));
+
+import { HeroQuickstartDropdown } from "../hero-quickstart-dropdown";
+
+describe("HeroQuickstartDropdown", () => {
+  it("uses the accent CTA treatment for the quickstart trigger", () => {
+    const markup = renderToStaticMarkup(
+      <HeroQuickstartDropdown
+        options={[
+          {
+            slug: "built-in-agent",
+            name: "CopilotKit's Built-in Agent",
+            href: "/react",
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("border-[var(--accent)]");
+    expect(markup).toContain("bg-[var(--accent)]");
+    expect(markup).toContain("text-[var(--primary-foreground)]");
+    expect(markup).toContain("hover:bg-[var(--accent-strong)]");
+    expect(markup).not.toContain("bg-[#000000]");
+    expect(markup).not.toContain("hover:bg-[#1f1f1f]");
+  });
+});

--- a/showcase/shell-docs/src/components/frontend-quickstart-selector.tsx
+++ b/showcase/shell-docs/src/components/frontend-quickstart-selector.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { ChevronDown } from "lucide-react";
+import { useFramework } from "./framework-provider";
+import { FrontendLogo } from "./icons/frontend-icons";
+import type { FrontendQuickstartSlug } from "@/lib/frontend-quickstarts";
+import {
+  FRONTEND_QUICKSTARTS,
+  frontendQuickstartHref,
+  selectedFrontendQuickstart,
+} from "@/lib/frontend-quickstarts";
+import {
+  consumeSidebarFolderOpenOnce,
+  FRONTEND_QUICKSTART_FOLDER_LABEL,
+  requestSidebarFolderOpenOnce,
+} from "@/lib/sidebar-folder-state";
+
+function slugPathFromPathname(pathname: string, framework: string | null) {
+  const segments = pathname.split("/").filter(Boolean);
+  return (framework ? segments.slice(1) : segments).join("/");
+}
+
+export function FrontendQuickstartSelector() {
+  const router = useRouter();
+  const pathname = usePathname() ?? "";
+  const { framework, effectiveFramework } = useFramework();
+  const [open, setOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const slugPath = slugPathFromPathname(pathname, framework);
+  const activeSlug = selectedFrontendQuickstart(slugPath) ?? "react";
+  const active =
+    FRONTEND_QUICKSTARTS.find((frontend) => frontend.slug === activeSlug) ??
+    FRONTEND_QUICKSTARTS[0];
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target instanceof Node ? e.target : null;
+      if (!target) return;
+      if (
+        panelRef.current?.contains(target) ||
+        buttonRef.current?.contains(target)
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  function selectFrontend(slug: FrontendQuickstartSlug) {
+    const href = frontendQuickstartHref(effectiveFramework, slug);
+    requestSidebarFolderOpenOnce(FRONTEND_QUICKSTART_FOLDER_LABEL);
+    router.replace(href);
+    if (href === pathname) {
+      consumeSidebarFolderOpenOnce(FRONTEND_QUICKSTART_FOLDER_LABEL);
+    }
+    setOpen(false);
+  }
+
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="shell-docs-radius-control flex h-12 w-full cursor-pointer items-center gap-2 border border-[var(--nav-control-border)] bg-[var(--accent-dim)] p-1.5 text-[13px] font-medium text-[var(--text)] shadow-[var(--shadow-control)] transition-colors hover:border-[var(--nav-control-border-hover)] hover:bg-[var(--accent-light)]"
+      >
+        <span
+          className="shell-docs-picker-icon-chip h-8 w-8 shrink-0"
+          aria-hidden="true"
+        >
+          <FrontendLogo slug={active.iconKey} width={16} height={16} />
+        </span>
+        <span className="min-w-0 flex-1 text-left">
+          <span className="block truncate leading-tight">{active.label}</span>
+          <span className="mt-0.5 block text-[9px] leading-tight text-[var(--text-faint)]">
+            Frontend Quickstart
+          </span>
+        </span>
+        <ChevronDown
+          aria-hidden="true"
+          className="mr-0.5 h-3.5 w-3.5 shrink-0 text-[var(--text-muted)]"
+          strokeWidth={2}
+        />
+      </button>
+
+      {open && (
+        <div
+          ref={panelRef}
+          role="listbox"
+          className="shell-docs-radius-surface absolute left-0 right-0 top-full z-50 mt-1 border border-[var(--border)] bg-[var(--bg-surface)] p-2 shadow-[var(--shadow-panel)]"
+        >
+          {FRONTEND_QUICKSTARTS.map((frontend) => {
+            const isActive = frontend.slug === active.slug;
+            return (
+              <button
+                key={frontend.slug}
+                type="button"
+                onClick={() => selectFrontend(frontend.slug)}
+                className={`shell-docs-radius-control flex w-full cursor-pointer items-center gap-2 px-2 py-1.5 text-[13px] transition-colors ${
+                  isActive
+                    ? "bg-[var(--accent-dim)] text-[var(--accent)]"
+                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]"
+                }`}
+              >
+                <span className="shrink-0" aria-hidden="true">
+                  <FrontendLogo
+                    slug={frontend.iconKey}
+                    width={16}
+                    height={16}
+                  />
+                </span>
+                <span className="flex-1 truncate text-left">
+                  {frontend.label}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/showcase/shell-docs/src/components/icons/__tests__/frontend-icons.test.tsx
+++ b/showcase/shell-docs/src/components/icons/__tests__/frontend-icons.test.tsx
@@ -19,16 +19,12 @@ describe("FrontendLogo", () => {
     for (const markup of rendered) {
       expect(markup).toContain("<svg");
     }
-    expect(rendered.join("\n")).toContain("data-frontend-icon=\"slack\"");
+    expect(rendered.join("\n")).toContain('data-frontend-icon="slack"');
     expect(rendered.join("\n")).toContain(
-      "data-frontend-icon=\"microsoft-teams\"",
+      'data-frontend-icon="microsoft-teams"',
     );
-    expect(rendered.join("\n")).toContain(
-      "data-icon-library=\"react-icons/si\"",
-    );
-    expect(rendered.join("\n")).toContain(
-      "data-icon-library=\"react-icons/tb\"",
-    );
+    expect(rendered.join("\n")).toContain('data-icon-library="react-icons/si"');
+    expect(rendered.join("\n")).toContain('data-icon-library="react-icons/tb"');
   });
 
   it("uses icon library packages instead of inline logo paths", () => {

--- a/showcase/shell-docs/src/components/icons/__tests__/frontend-icons.test.tsx
+++ b/showcase/shell-docs/src/components/icons/__tests__/frontend-icons.test.tsx
@@ -1,0 +1,47 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import fs from "fs";
+import path from "path";
+
+import { FrontendLogo } from "../frontend-icons";
+
+describe("FrontendLogo", () => {
+  it("renders brand marks for every frontend quickstart surface", () => {
+    const rendered = [
+      "react",
+      "vue",
+      "react-native",
+      "slack",
+      "microsoft-teams",
+    ].map((slug) => renderToStaticMarkup(<FrontendLogo slug={slug} />));
+
+    expect(rendered).toHaveLength(5);
+    for (const markup of rendered) {
+      expect(markup).toContain("<svg");
+    }
+    expect(rendered.join("\n")).toContain("data-frontend-icon=\"slack\"");
+    expect(rendered.join("\n")).toContain(
+      "data-frontend-icon=\"microsoft-teams\"",
+    );
+    expect(rendered.join("\n")).toContain(
+      "data-icon-library=\"react-icons/si\"",
+    );
+    expect(rendered.join("\n")).toContain(
+      "data-icon-library=\"react-icons/tb\"",
+    );
+  });
+
+  it("uses icon library packages instead of inline logo paths", () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, "../frontend-icons.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain('from "react-icons/si"');
+    expect(source).toContain('from "react-icons/tb"');
+    expect(source).not.toContain("<path");
+    expect(source).not.toContain("<ellipse");
+    expect(source).not.toContain("<circle");
+    expect(source).not.toContain("<rect");
+  });
+});

--- a/showcase/shell-docs/src/components/icons/frontend-icons.tsx
+++ b/showcase/shell-docs/src/components/icons/frontend-icons.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { SiReact, SiSlack, SiVuedotjs } from "react-icons/si";
+import { TbBrandReactNative, TbBrandTeams } from "react-icons/tb";
+
+interface FrontendIconProps {
+  className?: string;
+  width?: number;
+  height?: number;
+}
+
+interface FrontendLogoProps extends FrontendIconProps {
+  slug: string;
+}
+
+const FRONTEND_ICONS = {
+  react: {
+    icon: SiReact,
+    library: "react-icons/si",
+  },
+  vue: {
+    icon: SiVuedotjs,
+    library: "react-icons/si",
+  },
+  "react-native": {
+    icon: TbBrandReactNative,
+    library: "react-icons/tb",
+  },
+  slack: {
+    icon: SiSlack,
+    library: "react-icons/si",
+  },
+  "microsoft-teams": {
+    icon: TbBrandTeams,
+    library: "react-icons/tb",
+  },
+} as const;
+
+export function FrontendLogo({
+  slug,
+  className,
+  width = 20,
+  height = 20,
+}: FrontendLogoProps) {
+  const item = FRONTEND_ICONS[slug as keyof typeof FRONTEND_ICONS];
+  if (!item) {
+    return (
+      <span
+        aria-hidden="true"
+        className={className}
+        style={{ width, height, display: "inline-block" }}
+      />
+    );
+  }
+
+  const Icon = item.icon;
+  return (
+    <span
+      aria-hidden="true"
+      className={className}
+      data-frontend-icon={slug}
+      data-icon-library={item.library}
+      style={{ width, height, display: "inline-flex" }}
+    >
+      <Icon fontSize={Math.max(width, height)} />
+    </span>
+  );
+}

--- a/showcase/shell-docs/src/components/sidebar-folder-state-preserver.tsx
+++ b/showcase/shell-docs/src/components/sidebar-folder-state-preserver.tsx
@@ -12,10 +12,14 @@
 // This component:
 //   1. On mount and on every URL change, marks the current folder panels
 //      so Fumadocs's mount-time collapsible animation is suppressed.
-//   2. Reads the saved map from localStorage and, for every folder
-//      trigger whose current `data-state` differs from the saved value,
-//      clicks the trigger to restore the saved state.
-//   3. Attaches a delegated `click` listener on `#nd-sidebar` that
+//   2. Opens any folder containing the selected page for the current
+//      route. For other folders, reads the saved map from localStorage
+//      and clicks triggers whose current `data-state` differs from the
+//      saved value.
+//   3. Consumes one-shot folder-open requests from other controls, like
+//      the frontend quickstart picker, without overwriting saved user
+//      preferences.
+//   4. Attaches a delegated `click` listener on `#nd-sidebar` that
 //      records each folder's new `data-state` (read on the next
 //      animation frame, after Radix has updated it) into the map.
 //
@@ -36,38 +40,16 @@
 
 import { useEffect, useLayoutEffect } from "react";
 import { usePathname } from "next/navigation";
+import {
+  consumeSidebarFolderOpenOnce,
+  readSidebarFolderState,
+  resolveSidebarFolderDesiredState,
+  SIDEBAR_FOLDER_OPEN_REQUEST_EVENT,
+  sidebarHrefMatchesPathname,
+  writeSidebarFolderState,
+} from "@/lib/sidebar-folder-state";
 
-const STORAGE_KEY = "shell-docs-sidebar-folders";
 const SKIP_INITIAL_ANIMATION_ATTR = "data-shell-docs-skip-initial-animation";
-
-type FolderStateMap = Record<string, "open" | "closed">;
-
-function readStateMap(): FolderStateMap {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as unknown;
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as FolderStateMap;
-    }
-  } catch (err) {
-    // Corrupted JSON, SecurityError (third-party iframe / privacy
-    // mode), or quota — log so a user reporting "my folders keep
-    // resetting" can diagnose, then start fresh below.
-    console.warn("[sidebar-folder-state-preserver] failed to read state", err);
-  }
-  return {};
-}
-
-function writeStateMap(map: FolderStateMap) {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
-  } catch (err) {
-    // Same rationale as the read side — non-critical state, but log so
-    // a quota / access error doesn't silently swallow the failure.
-    console.warn("[sidebar-folder-state-preserver] failed to write state", err);
-  }
-}
 
 // Fumadocs folder triggers are <button>s that toggle a sibling
 // Collapsible. They carry `data-state="open" | "closed"` and an
@@ -102,6 +84,40 @@ function enableFolderAnimation(trigger: HTMLButtonElement) {
   findFolderContent(trigger)?.removeAttribute(SKIP_INITIAL_ANIMATION_ATTR);
 }
 
+function folderContainsSelectedPage(
+  trigger: HTMLButtonElement,
+  pathname: string,
+) {
+  const content = findFolderContent(trigger);
+  if (!content) return false;
+  const origin = window.location.origin;
+  return Array.from(content.querySelectorAll<HTMLAnchorElement>("a[href]"))
+    .map((link) => link.getAttribute("href"))
+    .some((href) =>
+      href ? sidebarHrefMatchesPathname(href, pathname, origin) : false,
+    );
+}
+
+function clickWithoutPersisting(trigger: HTMLButtonElement) {
+  // Mark BEFORE dispatching so the delegated click handler that fires
+  // synchronously on `.click()` sees the marker and skips recording.
+  // Cleared on the next rAF — by then any genuine user-initiated click
+  // will have a fresh, unmarked event.
+  syntheticClicks.add(trigger);
+  trigger.click();
+  requestAnimationFrame(() => syntheticClicks.delete(trigger));
+}
+
+function openFolderByKey(key: string) {
+  const triggers = findFolderTriggers();
+  for (const trigger of triggers) {
+    if (folderKey(trigger) !== key) continue;
+    if (trigger.getAttribute("data-state") !== "open") {
+      clickWithoutPersisting(trigger);
+    }
+  }
+}
+
 // Triggers we just synthetically clicked during a restore pass. The
 // delegated click handler skips these so a restore-driven click doesn't
 // get recorded back into localStorage — without this guard a Radix
@@ -120,23 +136,21 @@ export function SidebarFolderStatePreserver() {
     // classes so route-mounted open folders do not animate on every
     // page navigation. Real user clicks remove the marker below, so
     // interactive open/close still animates normally.
-    const saved = readStateMap();
+    const saved = readSidebarFolderState();
     const triggers = findFolderTriggers();
     markInitialFolderAnimations(triggers);
     for (const trigger of triggers) {
       const key = folderKey(trigger);
       if (!key) continue;
-      const desired = saved[key];
+      const desired = resolveSidebarFolderDesiredState({
+        containsSelectedPage: folderContainsSelectedPage(trigger, pathname),
+        openOnceRequested: consumeSidebarFolderOpenOnce(key),
+        savedState: saved[key],
+      });
       if (desired === undefined) continue;
       const current = trigger.getAttribute("data-state");
       if (current !== desired) {
-        // Mark BEFORE dispatching so the delegated click handler that
-        // fires synchronously on `.click()` sees the marker and skips
-        // recording. Cleared on the next rAF — by then any genuine
-        // user-initiated click will have a fresh, unmarked event.
-        syntheticClicks.add(trigger);
-        trigger.click();
-        requestAnimationFrame(() => syntheticClicks.delete(trigger));
+        clickWithoutPersisting(trigger);
       }
     }
   }, [pathname]);
@@ -168,16 +182,27 @@ export function SidebarFolderStatePreserver() {
       requestAnimationFrame(() => {
         const state = trigger.getAttribute("data-state");
         if (state !== "open" && state !== "closed") return;
-        const map = readStateMap();
+        const map = readSidebarFolderState();
         if (map[key] === state) return;
         map[key] = state;
-        writeStateMap(map);
+        writeSidebarFolderState(map);
       });
     };
 
+    const onOpenRequest = (event: Event) => {
+      const detail = (event as CustomEvent<{ folder?: unknown }>).detail;
+      if (typeof detail?.folder !== "string") return;
+      openFolderByKey(detail.folder);
+    };
+
     sidebar.addEventListener("click", onClick);
+    window.addEventListener(SIDEBAR_FOLDER_OPEN_REQUEST_EVENT, onOpenRequest);
     return () => {
       sidebar.removeEventListener("click", onClick);
+      window.removeEventListener(
+        SIDEBAR_FOLDER_OPEN_REQUEST_EVENT,
+        onOpenRequest,
+      );
     };
   }, []);
 

--- a/showcase/shell-docs/src/components/sidebar-framework-selector.tsx
+++ b/showcase/shell-docs/src/components/sidebar-framework-selector.tsx
@@ -9,6 +9,7 @@
 
 import React from "react";
 import { FrameworkSelector } from "./framework-selector";
+import { FrontendQuickstartSelector } from "./frontend-quickstart-selector";
 import { getCategoryLabel, getDocsMode, getIntegrations } from "@/lib/registry";
 import { FRAMEWORK_CATEGORY_ORDER } from "@/lib/docs-render";
 
@@ -47,14 +48,15 @@ export function SidebarFrameworkSelector() {
 
   return (
     // The sidebar column itself is already fixed within the docs layout, so
-    // this selector can stay in normal flow. Keeping it non-sticky avoids a
-    // raised layer overlapping the first selected sidebar item at scroll-top.
-    <div>
+    // these selectors can stay in normal flow. Keeping them non-sticky avoids
+    // a raised layer overlapping the first selected sidebar item at scroll-top.
+    <div className="flex flex-col gap-2">
       <FrameworkSelector
         options={options}
         categoryOrder={categoryOrder}
         variant="sidebar"
       />
+      <FrontendQuickstartSelector />
     </div>
   );
 }

--- a/showcase/shell-docs/src/components/unscoped-docs-page.tsx
+++ b/showcase/shell-docs/src/components/unscoped-docs-page.tsx
@@ -22,6 +22,7 @@ import React from "react";
 import { notFound } from "next/navigation";
 import { DocsPageView } from "@/components/docs-page-view";
 import { buildRootSurfaceNav, loadDoc } from "@/lib/docs-render";
+import { frontendQuickstartContentSlugPath } from "@/lib/frontend-quickstarts";
 import { getDocsFolder, getDocsMode, ROOT_FRAMEWORK } from "@/lib/registry";
 
 export async function UnscopedDocsPage({ slugPath }: { slugPath: string }) {
@@ -35,10 +36,11 @@ export async function UnscopedDocsPage({ slugPath }: { slugPath: string }) {
   // sections), so navigating between BIA and agnostic pages never swaps it.
   const docsFolder = getDocsFolder(ROOT_FRAMEWORK);
   const navTree = buildRootSurfaceNav(docsFolder);
+  const contentSlugPath = frontendQuickstartContentSlugPath(slugPath);
 
   // BIA-authored page for this slug → render it BIA-scoped at the root
   // URL: BIA snippet resolution, root-relative hrefs.
-  const overridePath = `integrations/${docsFolder}/${slugPath}`;
+  const overridePath = `integrations/${docsFolder}/${contentSlugPath}`;
   if (getDocsMode(ROOT_FRAMEWORK) === "authored" && loadDoc(overridePath)) {
     return (
       <DocsPageView
@@ -51,7 +53,7 @@ export async function UnscopedDocsPage({ slugPath }: { slugPath: string }) {
     );
   }
 
-  const doc = loadDoc(slugPath);
+  const doc = loadDoc(contentSlugPath);
   if (!doc) notFound();
 
   // Agnostic page. Feature pages (those declaring a snippet cell) used to
@@ -63,6 +65,7 @@ export async function UnscopedDocsPage({ slugPath }: { slugPath: string }) {
   return (
     <DocsPageView
       slugPath={slugPath}
+      contentSlugPath={contentSlugPath}
       slugHrefPrefix=""
       frameworkOverride={doc.fm.defaultCell ? ROOT_FRAMEWORK : undefined}
       navTree={navTree}

--- a/showcase/shell-docs/src/content/docs/meta.json
+++ b/showcase/shell-docs/src/content/docs/meta.json
@@ -46,11 +46,6 @@
     "threads",
     "---Deploy---",
     "...deploy",
-    "---Platforms---",
-    "slack",
-    "microsoft-teams",
-    "react-native",
-    "vue",
     "---Other---",
     "...(other)",
     {

--- a/showcase/shell-docs/src/content/docs/microsoft-teams.mdx
+++ b/showcase/shell-docs/src/content/docs/microsoft-teams.mdx
@@ -10,6 +10,10 @@ import { Callout } from "fumadocs-ui/components/callout";
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
+<Callout type="info" title="Guide content in progress">
+  Feature parity is here, but this guide content is still in progress. After the quickstart, use the [reference docs](/reference) to go deeper or ask an agent using our [CopilotKit skills](/build-with-agents).
+</Callout>
+
 ## What you will build
 
 By the end of this guide, you will have a small Node app that can answer Microsoft Teams messages

--- a/showcase/shell-docs/src/content/docs/react-native.mdx
+++ b/showcase/shell-docs/src/content/docs/react-native.mdx
@@ -4,6 +4,11 @@ description: Get started with CopilotKit in React Native.
 icon: "lucide/Smartphone"
 hideTOC: true
 ---
+
+<Callout type="info" title="Guide content in progress">
+  Feature parity is here, but this guide content is still in progress. After the quickstart, use the [reference docs](/reference) to go deeper or ask an agent using our [CopilotKit skills](/build-with-agents).
+</Callout>
+
 `@copilotkit/react-native` provides a lightweight, headless wrapper around CopilotKit's React hooks for React Native apps. You build the UI — CopilotKit handles the agent communication.
 
 ## Prerequisites

--- a/showcase/shell-docs/src/content/docs/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/slack.mdx
@@ -6,6 +6,10 @@ hideTOC: true
 earlyAccess: slack
 ---
 
+<Callout type="info" title="Guide content in progress">
+  Feature parity is here, but this guide content is still in progress. After the quickstart, use the [reference docs](/reference) to go deeper or ask an agent using our [CopilotKit skills](/build-with-agents).
+</Callout>
+
 This guide takes you from zero to a Slack bot you can @-mention in a channel, then adds an interactive button card. You write handlers in TypeScript, the agent's replies stream into the thread, and rich messages are JSX that the adapter renders to Block Kit (Slack's message-UI format). No public URL needed.
 
 ## Prerequisites

--- a/showcase/shell-docs/src/content/docs/vue.mdx
+++ b/showcase/shell-docs/src/content/docs/vue.mdx
@@ -5,6 +5,10 @@ icon: "lucide/Component"
 hideTOC: true
 ---
 
+<Callout type="info" title="Guide content in progress">
+  Feature parity is here, but this guide content is still in progress. After the quickstart, use the [reference docs](/reference) to go deeper or ask an agent using our [CopilotKit skills](/build-with-agents).
+</Callout>
+
 `@copilotkit/vue` provides Vue 3 components and composables for CopilotKit. This guide gets you to a working Vue app with a chat UI talking to an [AG-UI](/backend/ag-ui) agent.
 
 It connects to the agent directly with `HttpAgent`, so there's no CopilotKit runtime to stand up and nothing framework-specific to configure. The same setup works with any AG-UI-compatible agent, whether it's built on LangGraph, CrewAI, Mastra, Pydantic AI, or your own server.

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -48,6 +48,12 @@ function hasSectionPage(navTree: NavNode[], section: string, page: string) {
   return false;
 }
 
+function hasSection(navTree: NavNode[], section: string) {
+  return navTree.some(
+    (node) => node.type === "section" && node.title === section,
+  );
+}
+
 function sectionPages(navTree: NavNode[], section: string): string[] {
   const pages: string[] = [];
   let inSection = false;
@@ -60,6 +66,20 @@ function sectionPages(navTree: NavNode[], section: string): string[] {
     if (node.type === "page") pages.push(node.title);
   }
   return pages;
+}
+
+function findGroup(navTree: NavNode[], title: string): Extract<
+  NavNode,
+  { type: "group" }
+> | null {
+  for (const node of navTree) {
+    if (node.type === "group") {
+      if (node.title === title) return node;
+      const child = findGroup(node.children, title);
+      if (child) return child;
+    }
+  }
+  return null;
 }
 
 function collectMdxFiles(dir: string): string[] {
@@ -235,20 +255,98 @@ describe("framework nav", () => {
     expect(teams?.hideTOC).toBe(true);
   });
 
-  it("includes the shared React Native platform guide in generated framework nav", () => {
+  it("groups frontend SDKs under Quickstart in generated framework nav", () => {
     const navTree = buildFrameworkNav(
       "langgraph",
       "LangGraph (Python)",
       "langgraph-python",
     );
 
-    expect(hasSectionPage(navTree, "Platforms", "React Native")).toBe(true);
+    const quickstart = findGroup(navTree, "Quickstart");
+
+    expect(quickstart?.children).toEqual([
+      {
+        type: "page",
+        title: "React",
+        slug: "react",
+        icon: "frontend/react",
+      },
+      {
+        type: "page",
+        title: "Vue",
+        slug: "vue",
+        icon: "frontend/vue",
+      },
+      {
+        type: "page",
+        title: "React Native",
+        slug: "react-native",
+        icon: "frontend/react-native",
+      },
+      {
+        type: "page",
+        title: "Slack",
+        slug: "slack",
+        icon: "frontend/slack",
+      },
+      {
+        type: "page",
+        title: "Microsoft Teams",
+        slug: "microsoft-teams",
+        icon: "frontend/microsoft-teams",
+      },
+    ]);
+    expect(hasSectionPage(navTree, "Platforms", "React Native")).toBe(false);
+    expect(hasSectionPage(navTree, "Platforms", "Slack")).toBe(false);
+    expect(hasSectionPage(navTree, "Platforms", "Microsoft Teams")).toBe(
+      false,
+    );
+    expect(hasSection(navTree, "Platforms")).toBe(false);
   });
 
-  it("includes the shared React Native platform guide in authored framework nav", () => {
+  it("groups frontend SDKs under Quickstart in authored framework nav", () => {
     const navTree = buildFrameworkOnlyNav("built-in-agent");
 
-    expect(hasSectionPage(navTree, "Platforms", "React Native")).toBe(true);
+    const quickstart = findGroup(navTree, "Quickstart");
+
+    expect(quickstart?.children).toEqual([
+      {
+        type: "page",
+        title: "React",
+        slug: "react",
+        icon: "frontend/react",
+      },
+      {
+        type: "page",
+        title: "Vue",
+        slug: "vue",
+        icon: "frontend/vue",
+      },
+      {
+        type: "page",
+        title: "React Native",
+        slug: "react-native",
+        icon: "frontend/react-native",
+      },
+      {
+        type: "page",
+        title: "Slack",
+        slug: "slack",
+        icon: "frontend/slack",
+      },
+      {
+        type: "page",
+        title: "Microsoft Teams",
+        slug: "microsoft-teams",
+        icon: "frontend/microsoft-teams",
+      },
+    ]);
+    expect(hasSectionPage(navTree, "Platforms", "React Native")).toBe(false);
+    expect(hasSectionPage(navTree, "Platforms", "Slack")).toBe(false);
+    expect(hasSectionPage(navTree, "Platforms", "Microsoft Teams")).toBe(
+      false,
+    );
+    expect(hasSection(navTree, "Platforms")).toBe(false);
   });
 
   it("uses the generated Intelligence Platform section for authored framework nav", () => {

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -68,10 +68,10 @@ function sectionPages(navTree: NavNode[], section: string): string[] {
   return pages;
 }
 
-function findGroup(navTree: NavNode[], title: string): Extract<
-  NavNode,
-  { type: "group" }
-> | null {
+function findGroup(
+  navTree: NavNode[],
+  title: string,
+): Extract<NavNode, { type: "group" }> | null {
   for (const node of navTree) {
     if (node.type === "group") {
       if (node.title === title) return node;
@@ -298,9 +298,7 @@ describe("framework nav", () => {
     ]);
     expect(hasSectionPage(navTree, "Platforms", "React Native")).toBe(false);
     expect(hasSectionPage(navTree, "Platforms", "Slack")).toBe(false);
-    expect(hasSectionPage(navTree, "Platforms", "Microsoft Teams")).toBe(
-      false,
-    );
+    expect(hasSectionPage(navTree, "Platforms", "Microsoft Teams")).toBe(false);
     expect(hasSection(navTree, "Platforms")).toBe(false);
   });
 
@@ -343,9 +341,7 @@ describe("framework nav", () => {
     ]);
     expect(hasSectionPage(navTree, "Platforms", "React Native")).toBe(false);
     expect(hasSectionPage(navTree, "Platforms", "Slack")).toBe(false);
-    expect(hasSectionPage(navTree, "Platforms", "Microsoft Teams")).toBe(
-      false,
-    );
+    expect(hasSectionPage(navTree, "Platforms", "Microsoft Teams")).toBe(false);
     expect(hasSection(navTree, "Platforms")).toBe(false);
   });
 

--- a/showcase/shell-docs/src/lib/__tests__/frontend-quickstarts.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/frontend-quickstarts.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  FRONTEND_QUICKSTARTS,
+  frontendQuickstartContentSlugPath,
+  frontendQuickstartHref,
+  selectedFrontendQuickstart,
+} from "../frontend-quickstarts";
+
+const CONTENT_DOCS_DIR = path.join(process.cwd(), "src/content/docs");
+const GUIDE_PROGRESS_CALLOUT_COPY =
+  "Feature parity is here, but this guide content is still in progress.";
+
+describe("frontend quickstart routing", () => {
+  it("routes root frontend choices to top-level frontend slugs", () => {
+    expect(frontendQuickstartHref(null, "react")).toBe("/react");
+    expect(frontendQuickstartHref("built-in-agent", "vue")).toBe("/vue");
+    expect(frontendQuickstartHref("built-in-agent", "react-native")).toBe(
+      "/react-native",
+    );
+    expect(frontendQuickstartHref("built-in-agent", "slack")).toBe("/slack");
+    expect(frontendQuickstartHref("built-in-agent", "microsoft-teams")).toBe(
+      "/microsoft-teams",
+    );
+  });
+
+  it("routes backend-scoped frontend choices to frontend slugs under the backend", () => {
+    expect(frontendQuickstartHref("langgraph-python", "react")).toBe(
+      "/langgraph-python/react",
+    );
+    expect(frontendQuickstartHref("langgraph-python", "vue")).toBe(
+      "/langgraph-python/vue",
+    );
+    expect(frontendQuickstartHref("langgraph-python", "react-native")).toBe(
+      "/langgraph-python/react-native",
+    );
+    expect(frontendQuickstartHref("langgraph-python", "slack")).toBe(
+      "/langgraph-python/slack",
+    );
+    expect(frontendQuickstartHref("langgraph-python", "microsoft-teams")).toBe(
+      "/langgraph-python/microsoft-teams",
+    );
+  });
+
+  it("aliases frontend routes to the existing MDX sources", () => {
+    expect(frontendQuickstartContentSlugPath("react")).toBe("quickstart");
+    expect(frontendQuickstartContentSlugPath("vue")).toBe("vue");
+    expect(frontendQuickstartContentSlugPath("react-native")).toBe(
+      "react-native",
+    );
+    expect(frontendQuickstartContentSlugPath("slack")).toBe("slack");
+    expect(frontendQuickstartContentSlugPath("microsoft-teams")).toBe(
+      "microsoft-teams",
+    );
+    expect(frontendQuickstartContentSlugPath("quickstart/react")).toBe(
+      "quickstart",
+    );
+    expect(frontendQuickstartContentSlugPath("quickstart/vue")).toBe("vue");
+    expect(frontendQuickstartContentSlugPath("quickstart/react-native")).toBe(
+      "react-native",
+    );
+    expect(frontendQuickstartContentSlugPath("quickstart/slack")).toBe(
+      "slack",
+    );
+    expect(
+      frontendQuickstartContentSlugPath("quickstart/microsoft-teams"),
+    ).toBe("microsoft-teams");
+  });
+
+  it("recognizes both new quickstart routes and legacy frontend routes", () => {
+    expect(selectedFrontendQuickstart("react")).toBe("react");
+    expect(selectedFrontendQuickstart("vue")).toBe("vue");
+    expect(selectedFrontendQuickstart("react-native")).toBe("react-native");
+    expect(selectedFrontendQuickstart("slack")).toBe("slack");
+    expect(selectedFrontendQuickstart("microsoft-teams")).toBe(
+      "microsoft-teams",
+    );
+    expect(selectedFrontendQuickstart("quickstart")).toBe("react");
+    expect(selectedFrontendQuickstart("quickstart/react")).toBe("react");
+    expect(selectedFrontendQuickstart("quickstart/vue")).toBe("vue");
+    expect(selectedFrontendQuickstart("quickstart/react-native")).toBe(
+      "react-native",
+    );
+    expect(selectedFrontendQuickstart("quickstart/slack")).toBe("slack");
+    expect(selectedFrontendQuickstart("quickstart/microsoft-teams")).toBe(
+      "microsoft-teams",
+    );
+  });
+
+  it("defines branded icon keys for every frontend option", () => {
+    expect(
+      FRONTEND_QUICKSTARTS.map(({ slug, label, iconKey }) => ({
+        slug,
+        label,
+        iconKey,
+      })),
+    ).toEqual([
+      {
+        slug: "react",
+        label: "React",
+        iconKey: "react",
+      },
+      { slug: "vue", label: "Vue", iconKey: "vue" },
+      {
+        slug: "react-native",
+        label: "React Native",
+        iconKey: "react-native",
+      },
+      { slug: "slack", label: "Slack", iconKey: "slack" },
+      {
+        slug: "microsoft-teams",
+        label: "Microsoft Teams",
+        iconKey: "microsoft-teams",
+      },
+    ]);
+  });
+
+  it("adds guide progress callouts only to non-react frontend quickstarts", () => {
+    for (const quickstart of FRONTEND_QUICKSTARTS) {
+      const filePath = path.join(
+        CONTENT_DOCS_DIR,
+        `${quickstart.sourceSlugPath}.mdx`,
+      );
+      const content = fs.readFileSync(filePath, "utf8");
+
+      if (quickstart.slug === "react") {
+        expect(content).not.toContain(GUIDE_PROGRESS_CALLOUT_COPY);
+      } else {
+        expect(content).toContain(GUIDE_PROGRESS_CALLOUT_COPY);
+      }
+    }
+  });
+});

--- a/showcase/shell-docs/src/lib/__tests__/frontend-quickstarts.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/frontend-quickstarts.test.ts
@@ -61,9 +61,7 @@ describe("frontend quickstart routing", () => {
     expect(frontendQuickstartContentSlugPath("quickstart/react-native")).toBe(
       "react-native",
     );
-    expect(frontendQuickstartContentSlugPath("quickstart/slack")).toBe(
-      "slack",
-    );
+    expect(frontendQuickstartContentSlugPath("quickstart/slack")).toBe("slack");
     expect(
       frontendQuickstartContentSlugPath("quickstart/microsoft-teams"),
     ).toBe("microsoft-teams");

--- a/showcase/shell-docs/src/lib/__tests__/next-config-redirects.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/next-config-redirects.test.ts
@@ -56,4 +56,27 @@ describe("next.config redirects", () => {
       ]),
     );
   });
+
+  it("redirects the root quickstart shim to the React quickstart slug", async () => {
+    vi.stubEnv("NEXT_PUBLIC_BASE_URL", "http://localhost:3003");
+    vi.stubEnv("NEXT_PUBLIC_SHELL_URL", "http://localhost:3000");
+
+    const nextConfig = (await import("../../../next.config")).default;
+    const redirects = await nextConfig.redirects?.();
+
+    expect(redirects).toEqual(
+      expect.arrayContaining([
+        {
+          source: "/quickstart",
+          destination: "/react",
+          permanent: true,
+        },
+        {
+          source: "/unselected/quickstart",
+          destination: "/react",
+          permanent: true,
+        },
+      ]),
+    );
+  });
 });

--- a/showcase/shell-docs/src/lib/__tests__/next-config-redirects.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/next-config-redirects.test.ts
@@ -79,4 +79,22 @@ describe("next.config redirects", () => {
       ]),
     );
   });
+
+  it("redirects framework quickstart shims to the scoped React quickstart slug", async () => {
+    vi.stubEnv("NEXT_PUBLIC_BASE_URL", "http://localhost:3003");
+    vi.stubEnv("NEXT_PUBLIC_SHELL_URL", "http://localhost:3000");
+
+    const nextConfig = (await import("../../../next.config")).default;
+    const redirects = await nextConfig.redirects?.();
+
+    expect(redirects).toEqual(
+      expect.arrayContaining([
+        {
+          source: "/:framework/quickstart",
+          destination: "/:framework/quickstart/react",
+          permanent: true,
+        },
+      ]),
+    );
+  });
 });

--- a/showcase/shell-docs/src/lib/__tests__/sidebar-folder-state.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/sidebar-folder-state.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  consumeSidebarFolderOpenOnce,
+  FRONTEND_QUICKSTART_FOLDER_LABEL,
+  requestSidebarFolderOpenOnce,
+  resolveSidebarFolderDesiredState,
+  sidebarHrefMatchesPathname,
+  SIDEBAR_FOLDER_OPEN_ONCE_STORAGE_KEY,
+  SIDEBAR_FOLDER_STATE_STORAGE_KEY,
+} from "../sidebar-folder-state";
+
+class MemoryStorage {
+  private readonly items = new Map<string, string>();
+
+  getItem(key: string) {
+    return this.items.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string) {
+    this.items.set(key, value);
+  }
+
+  removeItem(key: string) {
+    this.items.delete(key);
+  }
+}
+
+describe("sidebar folder state", () => {
+  it("opens a folder that contains the selected page even when the saved preference is closed", () => {
+    expect(
+      resolveSidebarFolderDesiredState({
+        containsSelectedPage: true,
+        openOnceRequested: false,
+        savedState: "closed",
+      }),
+    ).toBe("open");
+  });
+
+  it("matches sidebar links to the selected pathname without query strings or trailing slash differences", () => {
+    expect(
+      sidebarHrefMatchesPathname(
+        "/langgraph-python/react-native?tab=start#install",
+        "/langgraph-python/react-native/",
+        "http://localhost:3003",
+      ),
+    ).toBe(true);
+  });
+
+  it("consumes frontend quickstart open requests once without changing saved folder preferences", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      SIDEBAR_FOLDER_STATE_STORAGE_KEY,
+      JSON.stringify({ [FRONTEND_QUICKSTART_FOLDER_LABEL]: "closed" }),
+    );
+
+    requestSidebarFolderOpenOnce(FRONTEND_QUICKSTART_FOLDER_LABEL, storage);
+
+    expect(storage.getItem(SIDEBAR_FOLDER_OPEN_ONCE_STORAGE_KEY)).toBe(
+      FRONTEND_QUICKSTART_FOLDER_LABEL,
+    );
+    expect(
+      consumeSidebarFolderOpenOnce(FRONTEND_QUICKSTART_FOLDER_LABEL, storage),
+    ).toBe(true);
+    expect(
+      consumeSidebarFolderOpenOnce(FRONTEND_QUICKSTART_FOLDER_LABEL, storage),
+    ).toBe(false);
+    expect(storage.getItem(SIDEBAR_FOLDER_STATE_STORAGE_KEY)).toBe(
+      JSON.stringify({ [FRONTEND_QUICKSTART_FOLDER_LABEL]: "closed" }),
+    );
+  });
+});

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -11,6 +11,7 @@ import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
 import { resolveWithinDir } from "./safe-fs";
+import { FRONTEND_QUICKSTARTS } from "./frontend-quickstarts";
 import { getDocsMode } from "./registry";
 import { isRouteGroupSegment } from "./route-groups";
 
@@ -607,7 +608,9 @@ export function buildFrameworkOnlyNav(
     return node;
   };
   return dropEmptySections(
-    appendSharedRootSections(nodes.map(rewrite), sharedSections),
+    withFrontendQuickstartNav(
+      appendSharedRootSections(nodes.map(rewrite), sharedSections),
+    ),
   );
 }
 
@@ -627,7 +630,7 @@ export function buildRootSurfaceNav(folder: string): NavNode[] {
   return buildFrameworkOnlyNav(folder, ROOT_SURFACE_SECTIONS);
 }
 
-const SHARED_ROOT_SECTIONS = ["Intelligence Platform", "Platforms"];
+const SHARED_ROOT_SECTIONS = ["Intelligence Platform"];
 
 // Sections pulled from the root `meta.json` into the Built-in Agent
 // sidebar when it serves the ROOT surface (see `buildRootSurfaceNav`).
@@ -640,15 +643,13 @@ const SHARED_ROOT_SECTIONS = ["Intelligence Platform", "Platforms"];
 //
 // Each title slots into a matching empty `---Section---` placeholder in
 // BIA's `meta.json` when present (so position is author-controlled),
-// otherwise the section appends at the end. "Intelligence Platform" and
-// "Platforms" stay in the list so the root surface keeps the generated
-// Intelligence Platform IA and shared platform guides.
+// otherwise the section appends at the end. "Intelligence Platform" stays in
+// the list so the root surface keeps the generated Intelligence Platform IA.
 const ROOT_SURFACE_SECTIONS = [
   "Concepts",
   "Runtime",
   "Intelligence Platform",
   "Deploy",
-  "Platforms",
   "Other",
 ];
 
@@ -669,6 +670,60 @@ function dropEmptySections(navTree: NavNode[]): NavNode[] {
     // next section boundary.
     return next !== undefined && next.type !== "section";
   });
+}
+
+function frontendQuickstartGroup(): NavNode {
+  return {
+    type: "group",
+    title: "Quickstart",
+    slug: "quickstart",
+    defaultOpen: true,
+    children: FRONTEND_QUICKSTARTS.map((frontend) => ({
+      type: "page",
+      title: frontend.label,
+      slug: frontend.slug,
+      icon: `frontend/${frontend.iconKey}`,
+    })),
+  };
+}
+
+function withFrontendQuickstartNav(navTree: NavNode[]): NavNode[] {
+  let replacedQuickstart = false;
+
+  const rewrite = (node: NavNode): NavNode | null => {
+    if (node.type === "page") {
+      if (node.slug === "quickstart") {
+        replacedQuickstart = true;
+        return frontendQuickstartGroup();
+      }
+      if (
+        node.slug === "vue" ||
+        node.slug === "react-native" ||
+        node.slug === "slack" ||
+        node.slug === "microsoft-teams"
+      ) {
+        return null;
+      }
+      return node;
+    }
+
+    if (node.type === "group") {
+      const children = node.children
+        .map(rewrite)
+        .filter((child): child is NavNode => child !== null);
+      return children.length > 0 ? { ...node, children } : null;
+    }
+
+    return node;
+  };
+
+  const rewritten = navTree
+    .map(rewrite)
+    .filter((node): node is NavNode => node !== null);
+
+  return replacedQuickstart
+    ? rewritten
+    : [frontendQuickstartGroup(), ...rewritten];
 }
 
 function sectionRange(
@@ -886,7 +941,7 @@ export function buildFrameworkNav(
   frameworkSlug: string,
 ): NavNode[] {
   return mergeFrameworkNav(
-    buildNavTree(CONTENT_DIR),
+    withFrontendQuickstartNav(buildNavTree(CONTENT_DIR)),
     buildFrameworkOverridesNav(docsFolder),
     frameworkName,
     frameworkSectionIcon(frameworkSlug),

--- a/showcase/shell-docs/src/lib/frontend-quickstarts.ts
+++ b/showcase/shell-docs/src/lib/frontend-quickstarts.ts
@@ -1,0 +1,87 @@
+export const ROOT_QUICKSTART_FRAMEWORK = "built-in-agent";
+
+export const FRONTEND_QUICKSTARTS = [
+  {
+    slug: "react",
+    label: "React",
+    shortLabel: "React",
+    iconKey: "react",
+    sourceSlugPath: "quickstart",
+  },
+  {
+    slug: "vue",
+    label: "Vue",
+    shortLabel: "Vue",
+    iconKey: "vue",
+    sourceSlugPath: "vue",
+  },
+  {
+    slug: "react-native",
+    label: "React Native",
+    shortLabel: "Native",
+    iconKey: "react-native",
+    sourceSlugPath: "react-native",
+  },
+  {
+    slug: "slack",
+    label: "Slack",
+    shortLabel: "Slack",
+    iconKey: "slack",
+    sourceSlugPath: "slack",
+  },
+  {
+    slug: "microsoft-teams",
+    label: "Microsoft Teams",
+    shortLabel: "Teams",
+    iconKey: "microsoft-teams",
+    sourceSlugPath: "microsoft-teams",
+  },
+] as const;
+
+export type FrontendQuickstartSlug =
+  (typeof FRONTEND_QUICKSTARTS)[number]["slug"];
+
+const FRONTEND_QUICKSTART_SLUGS = new Set<string>(
+  FRONTEND_QUICKSTARTS.map((frontend) => frontend.slug),
+);
+const FRONTEND_QUICKSTART_BY_SLUG = new Map(
+  FRONTEND_QUICKSTARTS.map((frontend) => [frontend.slug, frontend]),
+);
+
+export function isFrontendQuickstartSlug(
+  slug: string | null | undefined,
+): slug is FrontendQuickstartSlug {
+  return Boolean(slug && FRONTEND_QUICKSTART_SLUGS.has(slug));
+}
+
+export function selectedFrontendQuickstart(
+  slugPath: string,
+): FrontendQuickstartSlug | null {
+  const normalized = slugPath.replace(/^\/+|\/+$/g, "");
+  if (normalized === "quickstart") return "react";
+  if (isFrontendQuickstartSlug(normalized)) {
+    return normalized;
+  }
+
+  const match = normalized.match(/^quickstart\/([^/]+)$/);
+  if (!match) return null;
+  const slug = match[1];
+  return isFrontendQuickstartSlug(slug) ? slug : null;
+}
+
+export function frontendQuickstartContentSlugPath(slugPath: string): string {
+  const selected = selectedFrontendQuickstart(slugPath);
+  if (!selected) return slugPath;
+
+  const quickstart = FRONTEND_QUICKSTART_BY_SLUG.get(selected);
+  return quickstart?.sourceSlugPath ?? slugPath;
+}
+
+export function frontendQuickstartHref(
+  framework: string | null | undefined,
+  frontend: FrontendQuickstartSlug,
+): string {
+  const prefix =
+    framework && framework !== ROOT_QUICKSTART_FRAMEWORK ? `/${framework}` : "";
+  return `${prefix}/${frontend}`;
+}

--- a/showcase/shell-docs/src/lib/sidebar-folder-state.ts
+++ b/showcase/shell-docs/src/lib/sidebar-folder-state.ts
@@ -1,0 +1,138 @@
+export const SIDEBAR_FOLDER_STATE_STORAGE_KEY =
+  "shell-docs-sidebar-folders";
+export const SIDEBAR_FOLDER_OPEN_ONCE_STORAGE_KEY =
+  "shell-docs-sidebar-open-once";
+export const SIDEBAR_FOLDER_OPEN_REQUEST_EVENT =
+  "shell-docs:sidebar-folder-open-request";
+export const FRONTEND_QUICKSTART_FOLDER_LABEL = "Quickstart";
+
+export type FolderStateMap = Record<string, "open" | "closed">;
+
+export interface SidebarFolderDesiredStateInput {
+  containsSelectedPage: boolean;
+  openOnceRequested: boolean;
+  savedState: "open" | "closed" | undefined;
+}
+
+export interface SidebarFolderStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+function localFolderStorage(): SidebarFolderStorage | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage;
+}
+
+function sessionFolderStorage(): SidebarFolderStorage | null {
+  if (typeof window === "undefined") return null;
+  return window.sessionStorage;
+}
+
+function eventTarget(): Window | null {
+  if (typeof window === "undefined") return null;
+  return window;
+}
+
+export function readSidebarFolderState(
+  storage: SidebarFolderStorage | null = localFolderStorage(),
+): FolderStateMap {
+  try {
+    const raw = storage?.getItem(SIDEBAR_FOLDER_STATE_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as FolderStateMap;
+    }
+  } catch (err) {
+    console.warn("[sidebar-folder-state-preserver] failed to read state", err);
+  }
+  return {};
+}
+
+export function writeSidebarFolderState(
+  map: FolderStateMap,
+  storage: SidebarFolderStorage | null = localFolderStorage(),
+) {
+  try {
+    storage?.setItem(SIDEBAR_FOLDER_STATE_STORAGE_KEY, JSON.stringify(map));
+  } catch (err) {
+    console.warn("[sidebar-folder-state-preserver] failed to write state", err);
+  }
+}
+
+export function resolveSidebarFolderDesiredState({
+  containsSelectedPage,
+  openOnceRequested,
+  savedState,
+}: SidebarFolderDesiredStateInput): "open" | "closed" | undefined {
+  if (containsSelectedPage || openOnceRequested) return "open";
+  return savedState;
+}
+
+function normalizePathname(pathname: string): string {
+  if (pathname === "/") return pathname;
+  return pathname.replace(/\/+$/, "");
+}
+
+export function sidebarHrefMatchesPathname(
+  href: string,
+  pathname: string,
+  origin = "http://localhost",
+): boolean {
+  if (!href || href.startsWith("#")) return false;
+
+  try {
+    const base = new URL(origin);
+    const hrefUrl = new URL(href, base);
+    const currentUrl = new URL(pathname, base);
+    if (hrefUrl.origin !== base.origin) return false;
+    return (
+      normalizePathname(hrefUrl.pathname) ===
+      normalizePathname(currentUrl.pathname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function requestSidebarFolderOpenOnce(
+  folder: string,
+  storage: SidebarFolderStorage | null = sessionFolderStorage(),
+  target: Window | null = eventTarget(),
+) {
+  try {
+    storage?.setItem(SIDEBAR_FOLDER_OPEN_ONCE_STORAGE_KEY, folder);
+  } catch (err) {
+    console.warn(
+      "[sidebar-folder-state-preserver] failed to write open request",
+      err,
+    );
+  }
+
+  target?.dispatchEvent(
+    new CustomEvent(SIDEBAR_FOLDER_OPEN_REQUEST_EVENT, {
+      detail: { folder },
+    }),
+  );
+}
+
+export function consumeSidebarFolderOpenOnce(
+  folder: string,
+  storage: SidebarFolderStorage | null = sessionFolderStorage(),
+): boolean {
+  try {
+    if (storage?.getItem(SIDEBAR_FOLDER_OPEN_ONCE_STORAGE_KEY) !== folder) {
+      return false;
+    }
+    storage.removeItem(SIDEBAR_FOLDER_OPEN_ONCE_STORAGE_KEY);
+    return true;
+  } catch (err) {
+    console.warn(
+      "[sidebar-folder-state-preserver] failed to read open request",
+      err,
+    );
+    return false;
+  }
+}

--- a/showcase/shell-docs/src/lib/sidebar-folder-state.ts
+++ b/showcase/shell-docs/src/lib/sidebar-folder-state.ts
@@ -1,5 +1,4 @@
-export const SIDEBAR_FOLDER_STATE_STORAGE_KEY =
-  "shell-docs-sidebar-folders";
+export const SIDEBAR_FOLDER_STATE_STORAGE_KEY = "shell-docs-sidebar-folders";
 export const SIDEBAR_FOLDER_OPEN_ONCE_STORAGE_KEY =
   "shell-docs-sidebar-open-once";
 export const SIDEBAR_FOLDER_OPEN_REQUEST_EVENT =


### PR DESCRIPTION
## Summary
- Move frontend quickstart pages into a dedicated quickstart group in the docs nav
- Route `/quickstart` and related unscoped redirects to React
- Update metadata, OG/LLMS routes, and sidebar state handling to resolve the new quickstart paths consistently
- Add frontend quickstart selector UI and supporting icon/tests

## Testing
- Added and updated unit tests for nav generation, redirects, quickstart resolution, sidebar folder state, and selector rendering
- Not run (not requested)