### PR TITLE
feat(react-core): expose toolCallId & agentId on HITL render props

### DIFF
--- a/docs/content/docs/reference/v2/hooks/useHumanInTheLoop.mdx
+++ b/docs/content/docs/reference/v2/hooks/useHumanInTheLoop.mdx
@@ -54,6 +54,12 @@ function useHumanInTheLoop<T extends Record<string, unknown>>(
     - `args: T` -- the original arguments
     - `respond: undefined` -- no longer available
     - `result: string` -- the serialized result
+
+    **In every status the component also receives attribution props:**
+    - `name: string` -- the tool name.
+    - `description: string` -- the tool description.
+    - `toolCallId: string` -- the AG-UI tool-call id, unique per interrupt. Use it as the key to correlate this interrupt with runtime (sub)agent attribution -- e.g. the `agentId` reported by `onToolExecutionStart` -- so you can label and route the interrupt to the agent that raised it.
+    - `agentId?: string` -- the agent this tool was **registered** to, or `undefined` for an unscoped tool. This is the static registration scope; it is not necessarily the runtime (sub)agent that raised the interrupt. For runtime attribution, correlate `toolCallId` instead.
   </PropertyReference>
 
   <PropertyReference name="available" type='"enabled" | "disabled" | "remote"' default='"enabled"'>

--- a/packages/react-core/src/v2/hooks/__tests__/use-human-in-the-loop.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-human-in-the-loop.e2e.test.tsx
@@ -2,11 +2,11 @@ import React, { useEffect, useState } from "react";
 import { screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { z } from "zod";
 import { useHumanInTheLoop } from "../use-human-in-the-loop";
-import { ReactHumanInTheLoop } from "../../types";
+import type { ReactHumanInTheLoop } from "../../types";
 import { ToolCallStatus } from "@copilotkit/core";
 import { CopilotChat } from "../../components/chat/CopilotChat";
 import CopilotChatToolCallsView from "../../components/chat/CopilotChatToolCallsView";
-import { AssistantMessage, Message } from "@ag-ui/core";
+import type { AssistantMessage, Message } from "@ag-ui/core";
 import {
   MockStepwiseAgent,
   MockReconnectableAgent,
@@ -702,6 +702,155 @@ describe("useHumanInTheLoop E2E - HITL Tool Rendering", () => {
         const el = screen.getByTestId("dependency-hitl-render");
         expect(el.textContent).toContain("(v1)");
       });
+    });
+  });
+
+  describe("HITL attribution (toolCallId + agentId)", () => {
+    it("exposes toolCallId and the registered agentId to the render props", async () => {
+      const agent = new MockStepwiseAgent();
+      let renderedToolCallId: string | undefined;
+      let renderedAgentId: string | undefined;
+
+      const AttributionHITLComponent: React.FC = () => {
+        const hitlTool: ReactHumanInTheLoop<{ action: string }> = {
+          name: "scopedApprovalTool",
+          description: "Scoped approval",
+          agentId: "research-agent",
+          parameters: z.object({ action: z.string() }),
+          render: ({ toolCallId, agentId, status, args }) => {
+            renderedToolCallId = toolCallId;
+            renderedAgentId = agentId;
+            return (
+              <div data-testid="attr-hitl">
+                <div data-testid="attr-tool-call-id">{toolCallId}</div>
+                <div data-testid="attr-agent-id">{agentId ?? "none"}</div>
+                <div data-testid="attr-status">{status}</div>
+                <div data-testid="attr-action">{args.action ?? ""}</div>
+              </div>
+            );
+          },
+        };
+
+        useHumanInTheLoop(hitlTool);
+        return null;
+      };
+
+      renderWithCopilotKit({
+        agent,
+        children: (
+          <>
+            <AttributionHITLComponent />
+            <div style={{ height: 400 }}>
+              <CopilotChat welcomeScreen={false} />
+            </div>
+          </>
+        ),
+      });
+
+      const input = await screen.findByRole("textbox");
+      fireEvent.change(input, { target: { value: "Need approval" } });
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+      await waitFor(() => {
+        expect(screen.getByText("Need approval")).toBeDefined();
+      });
+
+      const messageId = testId("msg");
+      const toolCallId = testId("tc");
+
+      agent.emit(runStartedEvent());
+      agent.emit(
+        toolCallChunkEvent({
+          toolCallId,
+          toolCallName: "scopedApprovalTool",
+          parentMessageId: messageId,
+          delta: JSON.stringify({ action: "delete" }),
+        }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("attr-tool-call-id").textContent).toBe(
+          toolCallId,
+        );
+        expect(screen.getByTestId("attr-agent-id").textContent).toBe(
+          "research-agent",
+        );
+      });
+
+      // The same attribution must reach the render callback directly so apps
+      // can correlate/resume the interrupt against the right (sub)agent.
+      expect(renderedToolCallId).toBe(toolCallId);
+      expect(renderedAgentId).toBe("research-agent");
+
+      agent.emit(runFinishedEvent());
+      agent.complete();
+    });
+
+    it("leaves agentId undefined for an unscoped HITL tool", async () => {
+      const agent = new MockStepwiseAgent();
+
+      const UnscopedHITLComponent: React.FC = () => {
+        const hitlTool: ReactHumanInTheLoop<{ action: string }> = {
+          name: "unscopedApprovalTool",
+          description: "Unscoped approval",
+          parameters: z.object({ action: z.string() }),
+          render: ({ toolCallId, agentId, args }) => (
+            <div data-testid="unscoped-hitl">
+              <div data-testid="unscoped-tool-call-id">{toolCallId}</div>
+              <div data-testid="unscoped-agent-id">{agentId ?? "none"}</div>
+              <div data-testid="unscoped-action">{args.action ?? ""}</div>
+            </div>
+          ),
+        };
+
+        useHumanInTheLoop(hitlTool);
+        return null;
+      };
+
+      renderWithCopilotKit({
+        agent,
+        children: (
+          <>
+            <UnscopedHITLComponent />
+            <div style={{ height: 400 }}>
+              <CopilotChat welcomeScreen={false} />
+            </div>
+          </>
+        ),
+      });
+
+      const input = await screen.findByRole("textbox");
+      fireEvent.change(input, { target: { value: "Need approval" } });
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+      await waitFor(() => {
+        expect(screen.getByText("Need approval")).toBeDefined();
+      });
+
+      const messageId = testId("msg");
+      const toolCallId = testId("tc");
+
+      agent.emit(runStartedEvent());
+      agent.emit(
+        toolCallChunkEvent({
+          toolCallId,
+          toolCallName: "unscopedApprovalTool",
+          parentMessageId: messageId,
+          delta: JSON.stringify({ action: "archive" }),
+        }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("unscoped-tool-call-id").textContent).toBe(
+          toolCallId,
+        );
+        expect(screen.getByTestId("unscoped-agent-id").textContent).toBe(
+          "none",
+        );
+      });
+
+      agent.emit(runFinishedEvent());
+      agent.complete();
     });
   });
 });

--- a/packages/react-core/src/v2/hooks/__tests__/use-human-in-the-loop.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-human-in-the-loop.e2e.test.tsx
@@ -794,10 +794,11 @@ describe("useHumanInTheLoop E2E - HITL Tool Rendering", () => {
           name: "unscopedApprovalTool",
           description: "Unscoped approval",
           parameters: z.object({ action: z.string() }),
-          render: ({ toolCallId, agentId, args }) => (
+          render: ({ toolCallId, agentId, status, args }) => (
             <div data-testid="unscoped-hitl">
               <div data-testid="unscoped-tool-call-id">{toolCallId}</div>
               <div data-testid="unscoped-agent-id">{agentId ?? "none"}</div>
+              <div data-testid="unscoped-status">{status}</div>
               <div data-testid="unscoped-action">{args.action ?? ""}</div>
             </div>
           ),
@@ -841,6 +842,9 @@ describe("useHumanInTheLoop E2E - HITL Tool Rendering", () => {
       );
 
       await waitFor(() => {
+        expect(screen.getByTestId("unscoped-status").textContent).toBe(
+          ToolCallStatus.InProgress,
+        );
         expect(screen.getByTestId("unscoped-tool-call-id").textContent).toBe(
           toolCallId,
         );
@@ -851,6 +855,20 @@ describe("useHumanInTheLoop E2E - HITL Tool Rendering", () => {
 
       agent.emit(runFinishedEvent());
       agent.complete();
+
+      // Attribution must survive the status transition: toolCallId stays the
+      // same and agentId stays undefined once the tool reaches Executing.
+      await waitFor(() => {
+        expect(screen.getByTestId("unscoped-status").textContent).toBe(
+          ToolCallStatus.Executing,
+        );
+        expect(screen.getByTestId("unscoped-tool-call-id").textContent).toBe(
+          toolCallId,
+        );
+        expect(screen.getByTestId("unscoped-agent-id").textContent).toBe(
+          "none",
+        );
+      });
     });
   });
 });

--- a/packages/react-core/src/v2/hooks/use-human-in-the-loop.tsx
+++ b/packages/react-core/src/v2/hooks/use-human-in-the-loop.tsx
@@ -29,12 +29,16 @@ export function useHumanInTheLoop<
     (props) => {
       const ToolComponent = tool.render;
 
-      // Enhance props based on current status
+      // Enhance props based on current status.
+      // `props` already carries `toolCallId`; we add the tool's registration
+      // `agentId` so the HITL UI can attribute the interrupt to the correct
+      // (sub)agent.
       if (props.status === "inProgress") {
         const enhancedProps = {
           ...props,
           name: tool.name,
           description: tool.description || "",
+          agentId: tool.agentId,
           respond: undefined,
         };
         return React.createElement(ToolComponent, enhancedProps);
@@ -43,6 +47,7 @@ export function useHumanInTheLoop<
           ...props,
           name: tool.name,
           description: tool.description || "",
+          agentId: tool.agentId,
           respond,
         };
         return React.createElement(ToolComponent, enhancedProps);
@@ -51,6 +56,7 @@ export function useHumanInTheLoop<
           ...props,
           name: tool.name,
           description: tool.description || "",
+          agentId: tool.agentId,
           respond: undefined,
         };
         return React.createElement(ToolComponent, enhancedProps);
@@ -60,7 +66,7 @@ export function useHumanInTheLoop<
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return React.createElement(ToolComponent, props as any);
     },
-    [tool.render, tool.name, tool.description, respond],
+    [tool.render, tool.name, tool.description, tool.agentId, respond],
   );
 
   const frontendTool: ReactFrontendTool<T> = {

--- a/packages/react-core/src/v2/hooks/use-human-in-the-loop.tsx
+++ b/packages/react-core/src/v2/hooks/use-human-in-the-loop.tsx
@@ -2,6 +2,7 @@ import { useCopilotKit } from "../context";
 import type { ReactFrontendTool } from "../types/frontend-tool";
 import type { ReactHumanInTheLoop } from "../types/human-in-the-loop";
 import type { ReactToolCallRenderer } from "../types/react-tool-call-renderer";
+import { ToolCallStatus } from "@copilotkit/core";
 import { useCallback, useEffect, useRef } from "react";
 import React from "react";
 import { useFrontendTool } from "./use-frontend-tool";
@@ -29,11 +30,11 @@ export function useHumanInTheLoop<
     (props) => {
       const ToolComponent = tool.render;
 
-      // Enhance props based on current status.
-      // `props` already carries `toolCallId`; we add the tool's registration
-      // `agentId` so the HITL UI can attribute the interrupt to the correct
-      // (sub)agent.
-      if (props.status === "inProgress") {
+      // Enhance props based on current status. `props` already carries
+      // `toolCallId`; we add the tool's registration `agentId` (and the
+      // normalized `name`/`description`) so the HITL UI always receives the
+      // full attribution contract. `respond` is only live while executing.
+      if (props.status === ToolCallStatus.InProgress) {
         const enhancedProps = {
           ...props,
           name: tool.name,
@@ -42,7 +43,7 @@ export function useHumanInTheLoop<
           respond: undefined,
         };
         return React.createElement(ToolComponent, enhancedProps);
-      } else if (props.status === "executing") {
+      } else if (props.status === ToolCallStatus.Executing) {
         const enhancedProps = {
           ...props,
           name: tool.name,
@@ -51,7 +52,7 @@ export function useHumanInTheLoop<
           respond,
         };
         return React.createElement(ToolComponent, enhancedProps);
-      } else if (props.status === "complete") {
+      } else if (props.status === ToolCallStatus.Complete) {
         const enhancedProps = {
           ...props,
           name: tool.name,
@@ -62,9 +63,19 @@ export function useHumanInTheLoop<
         return React.createElement(ToolComponent, enhancedProps);
       }
 
-      // Fallback - just render with original props
+      // Unreachable today: ToolCallStatus has only the three states handled
+      // above, so `props` narrows to `never` here. Kept defensively — if a new
+      // status is ever added, still surface name/description/agentId so
+      // attribution is not silently dropped. `props` is cast to a record
+      // because a `never` cannot be spread directly.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return React.createElement(ToolComponent, props as any);
+      return React.createElement(ToolComponent, {
+        ...(props as Record<string, unknown>),
+        name: tool.name,
+        description: tool.description || "",
+        agentId: tool.agentId,
+        respond: undefined,
+      } as any);
     },
     [tool.render, tool.name, tool.description, tool.agentId, respond],
   );

--- a/packages/react-core/src/v2/hooks/use-human-in-the-loop.tsx
+++ b/packages/react-core/src/v2/hooks/use-human-in-the-loop.tsx
@@ -30,10 +30,11 @@ export function useHumanInTheLoop<
     (props) => {
       const ToolComponent = tool.render;
 
-      // Enhance props based on current status. `props` already carries
-      // `toolCallId`; we add the tool's registration `agentId` (and the
-      // normalized `name`/`description`) so the HITL UI always receives the
-      // full attribution contract. `respond` is only live while executing.
+      // Build the HITL render props per status. `props` already carries
+      // `toolCallId`; we overwrite `name`/`description` with the tool's
+      // registration values and add the registration `agentId`, so the HITL
+      // render always receives the full prop contract. `respond` is only live
+      // while the tool is executing.
       if (props.status === ToolCallStatus.InProgress) {
         const enhancedProps = {
           ...props,
@@ -63,19 +64,12 @@ export function useHumanInTheLoop<
         return React.createElement(ToolComponent, enhancedProps);
       }
 
-      // Unreachable today: ToolCallStatus has only the three states handled
-      // above, so `props` narrows to `never` here. Kept defensively — if a new
-      // status is ever added, still surface name/description/agentId so
-      // attribution is not silently dropped. `props` is cast to a record
-      // because a `never` cannot be spread directly.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return React.createElement(ToolComponent, {
-        ...(props as Record<string, unknown>),
-        name: tool.name,
-        description: tool.description || "",
-        agentId: tool.agentId,
-        respond: undefined,
-      } as any);
+      // ToolCallStatus has only the three states handled above, so this point
+      // is unreachable and `props` narrows to `never`. The assignment turns a
+      // newly-added status into a compile error here — forcing it to get its
+      // own branch above — instead of silently rendering without `respond`.
+      const exhaustiveCheck: never = props;
+      return exhaustiveCheck;
     },
     [tool.render, tool.name, tool.description, tool.agentId, respond],
   );

--- a/packages/react-core/src/v2/types/human-in-the-loop.ts
+++ b/packages/react-core/src/v2/types/human-in-the-loop.ts
@@ -8,13 +8,17 @@ export type ReactHumanInTheLoop<
    * Render the human-in-the-loop UI for this tool call.
    *
    * Beyond the tool call's `args`/`status`/`result`, the render props carry
-   * attribution so the UI can tell which run raised the interrupt:
-   * - `toolCallId` — the AG-UI tool call id. Correlate it with the agent
-   *   attribution from `onToolExecutionStart` (or with per-run attribution
-   *   stamped on the event stream) to render and resume the interrupt against
-   *   the correct (sub)agent.
-   * - `agentId` — the agent this tool was registered for (the tool's own
-   *   `agentId`), or `undefined` when the tool is not agent-scoped.
+   * attribution:
+   * - `toolCallId` — the AG-UI tool call id, unique per interrupt. It is the
+   *   stable key for correlating this interrupt with runtime (sub)agent
+   *   attribution — e.g. the `agentId` reported by `onToolExecutionStart`, or
+   *   per-run attribution stamped on the event stream — so the UI can label
+   *   the interrupt with the agent that actually raised it.
+   * - `agentId` — the agent this tool was *registered* to (the tool's own
+   *   `agentId`), or `undefined` for an unscoped tool. This is the static
+   *   registration scope; it is NOT necessarily the runtime (sub)agent that
+   *   raised the interrupt. For runtime attribution, correlate `toolCallId`
+   *   with the event-stream/`onToolExecutionStart` agent id.
    */
   render: React.ComponentType<
     | {

--- a/packages/react-core/src/v2/types/human-in-the-loop.ts
+++ b/packages/react-core/src/v2/types/human-in-the-loop.ts
@@ -1,13 +1,27 @@
-import { FrontendTool, ToolCallStatus } from "@copilotkit/core";
+import type { FrontendTool, ToolCallStatus } from "@copilotkit/core";
 import React from "react";
 
 export type ReactHumanInTheLoop<
   T extends Record<string, unknown> = Record<string, unknown>,
 > = Omit<FrontendTool<T>, "handler"> & {
+  /**
+   * Render the human-in-the-loop UI for this tool call.
+   *
+   * Beyond the tool call's `args`/`status`/`result`, the render props carry
+   * attribution so the UI can tell which run raised the interrupt:
+   * - `toolCallId` — the AG-UI tool call id. Correlate it with the agent
+   *   attribution from `onToolExecutionStart` (or with per-run attribution
+   *   stamped on the event stream) to render and resume the interrupt against
+   *   the correct (sub)agent.
+   * - `agentId` — the agent this tool was registered for (the tool's own
+   *   `agentId`), or `undefined` when the tool is not agent-scoped.
+   */
   render: React.ComponentType<
     | {
         name: string;
         description: string;
+        toolCallId: string;
+        agentId?: string;
         args: Partial<T>;
         status: ToolCallStatus.InProgress;
         result: undefined;
@@ -16,6 +30,8 @@ export type ReactHumanInTheLoop<
     | {
         name: string;
         description: string;
+        toolCallId: string;
+        agentId?: string;
         args: T;
         status: ToolCallStatus.Executing;
         result: undefined;
@@ -24,6 +40,8 @@ export type ReactHumanInTheLoop<
     | {
         name: string;
         description: string;
+        toolCallId: string;
+        agentId?: string;
         args: T;
         status: ToolCallStatus.Complete;
         result: string;


### PR DESCRIPTION
## Summary

Adds two optional attribution props — `toolCallId` and `agentId` — to the `useHumanInTheLoop` render callback (`ReactHumanInTheLoop`), so a UI can tell **which (sub)agent raised an interrupt** and route/resume it accordingly. This is the front-end piece needed to render and act on human-in-the-loop stops that originate from a subagent (the orchestrator/subagent pattern).

Backward compatible and additive — existing HITL render components are unaffected. No AG-UI protocol change and no runtime change: `toolCallId` already flowed to the renderer at runtime (this surfaces it in the type), and `agentId` is sourced from the tool's own registration.

## What changed

- **`types/human-in-the-loop.ts`** — add `toolCallId: string` and `agentId?: string` to all three render-prop variants, with JSDoc on the static-vs-runtime distinction.
- **`hooks/use-human-in-the-loop.tsx`** — thread `agentId: tool.agentId` into the enhanced props; compare `props.status` against the `ToolCallStatus` enum (was string literals); replace the unreachable `as any` fallback with a compile-time exhaustiveness check.
- **tests** — assert `toolCallId`/`agentId` reach the render props through the real `CopilotChat` pipeline (scoped + unscoped), and that attribution survives the `InProgress → Executing` transition.
- **docs** — document the two new props on the `useHumanInTheLoop` reference page.

## Decision needed from reviewers — `agentId` semantics

`agentId` is the tool's **static registration scope** (`tool.agentId`), which is `undefined` for the default unscoped tool — it is **not** the runtime subagent that raised the interrupt. `toolCallId` is the load-bearing addition: correlate it with `onToolExecutionStart`'s agent id for true runtime attribution. The JSDoc states this explicitly. Options if we want to avoid any ambiguity:
1. **Keep as-is** (documented static scope) — current state.
2. Rename → `registeredAgentId`.
3. Drop `agentId`, ship `toolCallId`-only.

## Follow-ups (separate PR — not in scope here)

These are pre-existing in the HITL `respond`/registration layer (untouched by this diff) and are the deeper work for full subagent HITL:
- **Route `respond` by `toolCallId`** — a single `resolvePromiseRef` can't service concurrent interrupts of the *same* tool (cross-wire/hang). Key resolvers by `toolCallId`.
- **`respond` failure path** — currently a silent no-op when no resolver is pending, and the handler promise has no rejection on unmount/abort.
- **Re-registration on dynamic `agentId` change** — `useFrontendTool`'s registration effect deps omit `agentId`/`render`.

## Verification

- `nx run @copilotkit/react-core:test` — 1281 passing (incl. the new attribution tests).
- `react-core` typecheck clean for the change; `react-core:build` green.
- Reviewed via a 3-round, 7-agent unbiased CR loop; converged with the bucket-(c) promotion audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
