### PR TITLE
fix(skills): correct copilotkit-upgrade v2 package paths

### DIFF
--- a/skills/copilotkit-upgrade/SKILL.md
+++ b/skills/copilotkit-upgrade/SKILL.md
@@ -37,20 +37,20 @@ Scan the codebase for all v1 imports and API usage:
 
 Key hooks and components to find and replace:
 
-| v1 API                             | v2 Replacement                                       |
-| ---------------------------------- | ---------------------------------------------------- |
-| `useCopilotAction`                 | `useFrontendTool`                                    |
-| `useCopilotReadable`               | `useAgentContext`                                    |
-| `useCopilotChat`                   | `useAgent`                                           |
-| `useCoAgent`                       | `useAgent`                                           |
-| `useCoAgentStateRender`            | `useRenderTool` / `useRenderActivityMessage`         |
+| v1 API                             | v2 Replacement                                             |
+| ---------------------------------- | ---------------------------------------------------------- |
+| `useCopilotAction`                 | `useFrontendTool`                                          |
+| `useCopilotReadable`               | `useAgentContext`                                          |
+| `useCopilotChat`                   | `useAgent`                                                 |
+| `useCoAgent`                       | `useAgent`                                                 |
+| `useCoAgentStateRender`            | `useRenderTool` / `useRenderActivityMessage`               |
 | `useCopilotContext`                | `useCopilotKit` (from `@copilotkit/react-core/v2/context`) |
-| `useLangGraphInterrupt`            | `useInterrupt`                                       |
-| `useCopilotChatSuggestions`        | `useConfigureSuggestions` + `useSuggestions`         |
-| `useCopilotAdditionalInstructions` | `useAgentContext`                                    |
-| `useMakeCopilotDocumentReadable`   | `useAgentContext`                                    |
-| `CopilotKit` (root import)         | `CopilotKit` (from `@copilotkit/react-core/v2`)      |
-| `CopilotTextarea`                  | Removed -- use standard textarea + `useFrontendTool` |
+| `useLangGraphInterrupt`            | `useInterrupt`                                             |
+| `useCopilotChatSuggestions`        | `useConfigureSuggestions` + `useSuggestions`               |
+| `useCopilotAdditionalInstructions` | `useAgentContext`                                          |
+| `useMakeCopilotDocumentReadable`   | `useAgentContext`                                          |
+| `CopilotKit` (root import)         | `CopilotKit` (from `@copilotkit/react-core/v2`)            |
+| `CopilotTextarea`                  | Removed -- use standard textarea + `useFrontendTool`       |
 
 ### 3. Map to v2 Equivalents
 

--- a/skills/copilotkit-upgrade/SKILL.md
+++ b/skills/copilotkit-upgrade/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: copilotkit-upgrade
 description: "Use when migrating a CopilotKit v1 application to v2 -- updating package imports, replacing deprecated hooks and components, switching from GraphQL runtime to AG-UI protocol runtime, and resolving breaking API changes."
-version: 1.0.0
+version: 1.0.1
 ---
 
 # CopilotKit v1 to v2 Migration Skill
@@ -15,7 +15,7 @@ This plugin includes an MCP server (`copilotkit-docs`) that provides `search-doc
 
 ## Overview
 
-CopilotKit v2 is a ground-up rewrite built on the AG-UI protocol (`@ag-ui/client` / `@ag-ui/core`). Users continue to install and import `@copilotkit/*` packages -- the v2 changes are exposed through the same package names with updated APIs (new hook names, component names, runtime configuration). The `@copilotkit/*` namespace is an internal implementation detail that users never interact with.
+CopilotKit v2 is a ground-up rewrite built on the AG-UI protocol (`@ag-ui/client` / `@ag-ui/core`). Users continue to install and import `@copilotkit/*` packages -- the v2 changes are exposed through the same package names (under their `/v2` subpaths) with updated APIs (new hook names, component names, runtime configuration). The underlying `@ag-ui/*` packages are an internal implementation detail re-exported through `@copilotkit/react-core/v2`, so users never need to install them directly.
 
 ## Migration Workflow
 
@@ -41,9 +41,10 @@ Key hooks and components to find and replace:
 | ---------------------------------- | ---------------------------------------------------- |
 | `useCopilotAction`                 | `useFrontendTool`                                    |
 | `useCopilotReadable`               | `useAgentContext`                                    |
-| `useCopilotChat`                   | `useAgent` + `useSuggestions`                        |
+| `useCopilotChat`                   | `useAgent`                                           |
 | `useCoAgent`                       | `useAgent`                                           |
-| `useCoAgentStateRender`            | `useRenderToolCall` / `useRenderActivityMessage`     |
+| `useCoAgentStateRender`            | `useRenderTool` / `useRenderActivityMessage`         |
+| `useCopilotContext`                | `useCopilotKit` (from `@copilotkit/react-core/v2/context`) |
 | `useLangGraphInterrupt`            | `useInterrupt`                                       |
 | `useCopilotChatSuggestions`        | `useConfigureSuggestions` + `useSuggestions`         |
 | `useCopilotAdditionalInstructions` | `useAgentContext`                                    |
@@ -57,16 +58,16 @@ Refer to `references/v1-to-v2-migration.md` for detailed before/after code examp
 
 ### 4. Update Package Dependencies
 
-The `@copilotkit/*` package names stay the same. Update to the latest v2 versions:
+The `@copilotkit/*` package names stay the same. v2 does **not** introduce new package names -- the v2 APIs ship from the **`/v2` subpath** of the existing packages (`@copilotkit/react-core/v2`, `@copilotkit/runtime/v2`). There is no `@copilotkit/react` or `@copilotkit/agent` package. Update to the latest v2 versions:
 
 ```
-@copilotkit/react-core        -> @copilotkit/react (consolidated into one package)
-@copilotkit/react-ui           -> @copilotkit/react (consolidated into one package)
+@copilotkit/react-core         -> @copilotkit/react-core (v2 symbols under the /v2 subpath)
+@copilotkit/react-ui           -> chat components move to @copilotkit/react-core/v2; react-ui contributes only styles in v2
 @copilotkit/react-textarea     -> removed (no v2 equivalent)
-@copilotkit/runtime            -> @copilotkit/runtime (same package, new agent-based API)
-@copilotkit/runtime-client-gql -> removed (replaced by AG-UI protocol, re-exported from @copilotkit/react)
+@copilotkit/runtime            -> @copilotkit/runtime (v2 symbols under the /v2 subpath)
+@copilotkit/runtime-client-gql -> removed (replaced by AG-UI protocol; @ag-ui/client types are re-exported from @copilotkit/react-core/v2)
 @copilotkit/shared             -> @copilotkit/shared (same package)
-@copilotkit/sdk-js             -> @copilotkit/agent (new package for agent definitions)
+@copilotkit/sdk-js             -> removed (BuiltInAgent now ships from @copilotkit/runtime/v2)
 ```
 
 ### 5. Update Runtime Configuration
@@ -78,19 +79,24 @@ The v1 `CopilotRuntime` accepted service adapters (OpenAI, Anthropic, LangChain,
 ```ts
 import { CopilotRuntime, OpenAIAdapter } from "@copilotkit/runtime";
 const runtime = new CopilotRuntime({ actions: [...] });
-// used with copilotKitEndpoint() for Next.js, Express, etc.
+// used with framework handlers like copilotRuntimeNextJSAppRouterEndpoint() (Next.js), etc.
 ```
 
 **v2 pattern** (agents + Hono endpoint):
 
 ```ts
-import { CopilotRuntime, createCopilotEndpoint } from "@copilotkit/runtime";
-import { BuiltInAgent } from "@copilotkit/agent";
+import {
+  CopilotRuntime,
+  BuiltInAgent,
+  createCopilotHonoHandler,
+} from "@copilotkit/runtime/v2";
 const runtime = new CopilotRuntime({
-  agents: { myAgent: new BuiltInAgent({ model: "openai:gpt-4o" }) },
+  agents: { myAgent: new BuiltInAgent({ model: "openai/gpt-4o" }) },
 });
-const app = createCopilotEndpoint({ runtime, basePath: "/api/copilotkit" });
+const app = createCopilotHonoHandler({ runtime, basePath: "/api/copilotkit" });
 ```
+
+> Use `createCopilotHonoHandler` (from `@copilotkit/runtime/v2`) as the canonical Hono endpoint factory. `createCopilotEndpoint` is a **deprecated** alias for it -- avoid it in new code. For Express, use `createCopilotExpressHandler` from `@copilotkit/runtime/v2/express` (`createCopilotEndpointExpress` is its deprecated alias).
 
 ### 6. Update Provider
 
@@ -121,18 +127,18 @@ import { CopilotKit } from "@copilotkit/react-core/v2";
 
 ## Quick Reference
 
-| Concept              | v1                                              | v2                                                                         |
-| -------------------- | ----------------------------------------------- | -------------------------------------------------------------------------- |
-| Package scope        | `@copilotkit/*`                                 | `@copilotkit/*` (same scope, updated APIs)                                 |
-| Protocol             | GraphQL                                         | AG-UI (SSE)                                                                |
-| Provider component   | `CopilotKit` (from `@copilotkit/react-core`)    | `CopilotKit` (from `@copilotkit/react-core/v2`)                            |
-| Define frontend tool | `useCopilotAction`                              | `useFrontendTool`                                                          |
-| Share app state      | `useCopilotReadable`                            | `useAgentContext`                                                          |
-| Agent interaction    | `useCoAgent`                                    | `useAgent`                                                                 |
-| Handle interrupts    | `useLangGraphInterrupt`                         | `useInterrupt`                                                             |
-| Render tool calls    | `useCopilotAction({ render })`                  | `useRenderToolCall`                                                        |
-| Chat suggestions     | `useCopilotChatSuggestions`                     | `useConfigureSuggestions`                                                  |
-| Runtime class        | `CopilotRuntime` (adapters)                     | `CopilotRuntime` (agents)                                                  |
-| Endpoint setup       | `copilotKitEndpoint()`                          | `createCopilotEndpoint()`                                                  |
-| Agent definition     | `LangGraphAgent` endpoint                       | `AbstractAgent` / `BuiltInAgent`                                           |
-| Chat components      | `CopilotChat`, `CopilotPopup`, `CopilotSidebar` | `CopilotChat`, `CopilotPopup`, `CopilotSidebar` (from `@copilotkit/react`) |
+| Concept              | v1                                              | v2                                                                                 |
+| -------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Package scope        | `@copilotkit/*`                                 | `@copilotkit/*` (same scope, updated APIs)                                         |
+| Protocol             | GraphQL                                         | AG-UI (SSE)                                                                        |
+| Provider component   | `CopilotKit` (from `@copilotkit/react-core`)    | `CopilotKit` (from `@copilotkit/react-core/v2`)                                    |
+| Define frontend tool | `useCopilotAction`                              | `useFrontendTool`                                                                  |
+| Share app state      | `useCopilotReadable`                            | `useAgentContext`                                                                  |
+| Agent interaction    | `useCoAgent`                                    | `useAgent`                                                                         |
+| Handle interrupts    | `useLangGraphInterrupt`                         | `useInterrupt`                                                                     |
+| Render tool calls    | `useCopilotAction({ render })`                  | `useFrontendTool({ render })` or `useRenderTool` (render-only)                     |
+| Chat suggestions     | `useCopilotChatSuggestions`                     | `useConfigureSuggestions`                                                          |
+| Runtime class        | `CopilotRuntime` (adapters)                     | `CopilotRuntime` (agents, from `@copilotkit/runtime/v2`)                           |
+| Endpoint setup       | `copilotRuntimeNextJSAppRouterEndpoint()`       | `createCopilotHonoHandler()` (`createCopilotEndpoint` is a deprecated alias)       |
+| Agent definition     | `LangGraphAgent` endpoint                       | `AbstractAgent` / `BuiltInAgent` (from `@copilotkit/runtime/v2`)                   |
+| Chat components      | `CopilotChat`, `CopilotPopup`, `CopilotSidebar` | `CopilotChat`, `CopilotPopup`, `CopilotSidebar` (from `@copilotkit/react-core/v2`) |

--- a/skills/copilotkit-upgrade/references/breaking-changes.md
+++ b/skills/copilotkit-upgrade/references/breaking-changes.md
@@ -20,11 +20,11 @@ The v2 API is exposed through the same `@copilotkit/*` packages -- no package na
 
 ### Removed packages
 
-| Package                          | Status                                                                           |
-| -------------------------------- | -------------------------------------------------------------------------------- |
+| Package                          | Status                                                                                                    |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | `@copilotkit/react-textarea`     | No v2 equivalent. The v1 package stays installable; remove it only after migrating off `CopilotTextarea`. |
-| `@copilotkit/runtime-client-gql` | Replaced by `@ag-ui/client` (re-exported from `@copilotkit/react-core/v2`)       |
-| `@copilotkit/sdk-js`             | Removed. `BuiltInAgent` and agent definitions ship from `@copilotkit/runtime/v2` |
+| `@copilotkit/runtime-client-gql` | Replaced by `@ag-ui/client` (re-exported from `@copilotkit/react-core/v2`)                                |
+| `@copilotkit/sdk-js`             | Removed. `BuiltInAgent` and agent definitions ship from `@copilotkit/runtime/v2`                          |
 
 ---
 
@@ -49,20 +49,20 @@ The provider keeps the name `CopilotKit`; the import path changes from the packa
 
 ### Props changes
 
-| v1 Prop        | v2 Status                       | Notes                                                          |
-| -------------- | ------------------------------- | -------------------------------------------------------------- |
-| `runtimeUrl`   | Kept                            | Same behavior                                                  |
-| `headers`      | Kept                            | Same behavior                                                  |
-| `publicApiKey` | Kept (deprecated)               | `publicLicenseKey` is the canonical name                       |
-| `properties`   | Kept                            | Same behavior                                                  |
-| `agents`       | Removed                         | Use `selfManagedAgents` or `agents__unsafe_dev_only`           |
+| v1 Prop        | v2 Status                       | Notes                                                                                                                                                                                            |
+| -------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `runtimeUrl`   | Kept                            | Same behavior                                                                                                                                                                                    |
+| `headers`      | Kept                            | Same behavior                                                                                                                                                                                    |
+| `publicApiKey` | Kept (deprecated)               | `publicLicenseKey` is the canonical name                                                                                                                                                         |
+| `properties`   | Kept                            | Same behavior                                                                                                                                                                                    |
+| `agents`       | Removed                         | Use `selfManagedAgents` or `agents__unsafe_dev_only`                                                                                                                                             |
 | `guardrails_c` | Kept (CopilotCloud only)        | Marked `@internal`/defunct in source, but still wired into the legacy CopilotCloud `restrictToTopic` config when a cloud key (`publicApiKey`) is set; has no effect on the v2 AG-UI runtime path |
-| `children`     | Kept                            | Same behavior                                                  |
-| --             | Added: `credentials`            | `RequestCredentials` for fetch (e.g., `"include"` for cookies) |
-| --             | Added: `selfManagedAgents`      | `Record<string, AbstractAgent>` for client-side agents         |
-| --             | Added: `renderToolCalls`        | `ReactToolCallRenderer[]` for provider-level tool renderers    |
-| --             | Added: `renderActivityMessages` | `ReactActivityMessageRenderer[]` for activity renderers        |
-| --             | Added: `useSingleEndpoint`      | Boolean to use single-route endpoint mode                      |
+| `children`     | Kept                            | Same behavior                                                                                                                                                                                    |
+| --             | Added: `credentials`            | `RequestCredentials` for fetch (e.g., `"include"` for cookies)                                                                                                                                   |
+| --             | Added: `selfManagedAgents`      | `Record<string, AbstractAgent>` for client-side agents                                                                                                                                           |
+| --             | Added: `renderToolCalls`        | `ReactToolCallRenderer[]` for provider-level tool renderers                                                                                                                                      |
+| --             | Added: `renderActivityMessages` | `ReactActivityMessageRenderer[]` for activity renderers                                                                                                                                          |
+| --             | Added: `useSingleEndpoint`      | Boolean to use single-route endpoint mode                                                                                                                                                        |
 
 ### Context hook rename
 
@@ -201,7 +201,7 @@ All service adapters are removed from the runtime:
 | --------------------------- | ------------------------------------------------------------------- |
 | `OpenAIAdapter`             | Use `BuiltInAgent({ model: "openai/gpt-4o" })`                      |
 | `AnthropicAdapter`          | Use `BuiltInAgent({ model: "anthropic/claude-sonnet-4.5" })`        |
-| `GoogleGenerativeAIAdapter` | Use `BuiltInAgent({ model: "google/gemini-2.5-pro" })`             |
+| `GoogleGenerativeAIAdapter` | Use `BuiltInAgent({ model: "google/gemini-2.5-pro" })`              |
 | `LangChainAdapter`          | Use a custom `AbstractAgent` implementation                         |
 | `GroqAdapter`               | Use a custom `AbstractAgent` (pass a Groq `LanguageModel` instance) |
 | `UnifyAdapter`              | Use a custom `AbstractAgent` implementation                         |

--- a/skills/copilotkit-upgrade/references/breaking-changes.md
+++ b/skills/copilotkit-upgrade/references/breaking-changes.md
@@ -10,21 +10,21 @@ v1 split React functionality across three packages:
 - `@copilotkit/react-ui` -- chat components (CopilotChat, CopilotPopup, CopilotSidebar)
 - `@copilotkit/react-textarea` -- CopilotTextarea component
 
-v2 consolidates everything into a single package:
+v2 consolidates the React surface under the **`/v2` subpath of the same `@copilotkit/react-core` package** (there is no `@copilotkit/react` package):
 
-- `@copilotkit/react` -- provider, hooks, types, chat components, AG-UI re-exports
+- `@copilotkit/react-core/v2` -- provider, hooks, types, chat components, and AG-UI re-exports (`@copilotkit/react-core/v2/styles.css` for styles)
 
-### New package scope
+### Same package names, new subpath
 
-The v2 API is exposed through the same `@copilotkit/*` packages. No package name changes are required when upgrading.
+The v2 API is exposed through the same `@copilotkit/*` packages -- no package name changes are required when upgrading. The v2 symbols live under the `/v2` subpath (`@copilotkit/react-core/v2`, `@copilotkit/runtime/v2`, `@copilotkit/runtime/v2/express`).
 
 ### Removed packages
 
-| Package                          | Status                                                             |
-| -------------------------------- | ------------------------------------------------------------------ |
-| `@copilotkit/react-textarea`     | Removed. No v2 equivalent.                                         |
-| `@copilotkit/runtime-client-gql` | Replaced by `@ag-ui/client` (re-exported from `@copilotkit/react`) |
-| `@copilotkit/sdk-js`             | Replaced by `@copilotkit/agent`                                    |
+| Package                          | Status                                                                           |
+| -------------------------------- | -------------------------------------------------------------------------------- |
+| `@copilotkit/react-textarea`     | No v2 equivalent. The v1 package stays installable; remove it only after migrating off `CopilotTextarea`. |
+| `@copilotkit/runtime-client-gql` | Replaced by `@ag-ui/client` (re-exported from `@copilotkit/react-core/v2`)       |
+| `@copilotkit/sdk-js`             | Removed. `BuiltInAgent` and agent definitions ship from `@copilotkit/runtime/v2` |
 
 ---
 
@@ -45,7 +45,7 @@ The most fundamental breaking change is the protocol layer. v1 used a GraphQL-ba
 
 ### Component import path change
 
-The provider keeps the name `CopilotKit`; the import path changes from the package root (`@copilotkit/react-core`, legacy v1) to the `/v2` subpath (`@copilotkit/react-core/v2`). The `/v2` subpath also exports a `CopilotKitProvider` component -- do **not** migrate to it. It is a functionality subset of `CopilotKit`, which is the compatibility bridge across v1 and v2 (its `CopilotKitProps` extends `CopilotKitProviderProps`, so every `CopilotKitProvider` prop works on it).
+The provider keeps the name `CopilotKit`; the import path changes from the package root (`@copilotkit/react-core`, legacy v1) to the `/v2` subpath (`@copilotkit/react-core/v2`). The `/v2` subpath also exports a `CopilotKitProvider` component -- do **not** migrate to it. It is a functionality subset of `CopilotKit`, which is the compatibility bridge across v1 and v2 (its `CopilotKitProps` extends `Omit<CopilotKitProviderProps, "children">` with a narrowed `children` type, so every non-`children` `CopilotKitProvider` prop works on it).
 
 ### Props changes
 
@@ -56,7 +56,7 @@ The provider keeps the name `CopilotKit`; the import path changes from the packa
 | `publicApiKey` | Kept (deprecated)               | `publicLicenseKey` is the canonical name                       |
 | `properties`   | Kept                            | Same behavior                                                  |
 | `agents`       | Removed                         | Use `selfManagedAgents` or `agents__unsafe_dev_only`           |
-| `guardrails_c` | Removed                         | --                                                             |
+| `guardrails_c` | Kept (CopilotCloud only)        | Marked `@internal`/defunct in source, but still wired into the legacy CopilotCloud `restrictToTopic` config when a cloud key (`publicApiKey`) is set; has no effect on the v2 AG-UI runtime path |
 | `children`     | Kept                            | Same behavior                                                  |
 | --             | Added: `credentials`            | `RequestCredentials` for fetch (e.g., `"include"` for cookies) |
 | --             | Added: `selfManagedAgents`      | `Record<string, AbstractAgent>` for client-side agents         |
@@ -66,7 +66,7 @@ The provider keeps the name `CopilotKit`; the import path changes from the packa
 
 ### Context hook rename
 
-`useCopilotContext` is replaced by `useCopilotKit` which returns `{ copilotkit: CopilotKitCoreReact }`.
+`useCopilotContext` is replaced by `useCopilotKit` (imported from `@copilotkit/react-core/v2/context`), which returns `{ copilotkit: CopilotKitCoreReact, executingToolCallIds: ReadonlySet<string> }`.
 
 ---
 
@@ -103,21 +103,23 @@ handler: async (args) => { ... }  // args is typed from the Zod schema
 **Render props change:**
 
 ```ts
-// v1 render status: "inProgress" | "executing" | "complete"
+// v1 render status: the string literals "inProgress" | "executing" | "complete"
 // v1 uses `respond()` callback for interactive actions
 
-// v2 render status: ToolCallStatus.InProgress | ToolCallStatus.Executing | ToolCallStatus.Complete
-// v2 render props: { name, args, status, result }
+// v2 render status: the `ToolCallStatus` enum (ToolCallStatus.InProgress | .Executing | .Complete).
+// Its values ARE those same strings, so `status === "inProgress"` still works;
+// prefer comparing against the enum members.
+// v2 render props: { name, toolCallId, args, status, result }
 ```
 
 **Availability change:**
 
 ```ts
 // v1
-disabled: true; // or available: "disabled"
+disabled: true;
 
-// v2
-available: "disabled" | "enabled";
+// v2 — `available` is a boolean (defaults to true; set false to hide the tool)
+available: false;
 ```
 
 ### useCopilotReadable -> useAgentContext
@@ -162,7 +164,7 @@ AbstractAgent; // AG-UI agent instance with run(), stop(), etc.
 
 - `agentName` -> `agentId`
 - `nodeName` -> removed (use `enabled` predicate to filter)
-- `render` props change: receives `InterruptRenderProps<TValue, TResult>` instead of v1's `{ event, resolve }`
+- `render` props change: v2 receives `InterruptRenderProps<TValue, TResult>` = `{ event, resolve, result }` (still includes `event`/`resolve`, adds `result`)
 - New `renderInChat` prop (default `true`) controls whether interrupt renders inside CopilotChat
 - New `handler` prop for programmatic handling before rendering
 - New `enabled` predicate prop for filtering interrupts
@@ -197,14 +199,14 @@ All service adapters are removed from the runtime:
 
 | Removed Adapter             | v2 Alternative                                                      |
 | --------------------------- | ------------------------------------------------------------------- |
-| `OpenAIAdapter`             | Use `BuiltInAgent({ model: "openai:gpt-4o" })`                      |
-| `AnthropicAdapter`          | Use `BuiltInAgent({ model: "anthropic:claude-sonnet-4-20250514" })` |
-| `GoogleGenerativeAIAdapter` | Use `BuiltInAgent({ model: "google:gemini-pro" })`                  |
+| `OpenAIAdapter`             | Use `BuiltInAgent({ model: "openai/gpt-4o" })`                      |
+| `AnthropicAdapter`          | Use `BuiltInAgent({ model: "anthropic/claude-sonnet-4.5" })`        |
+| `GoogleGenerativeAIAdapter` | Use `BuiltInAgent({ model: "google/gemini-2.5-pro" })`             |
 | `LangChainAdapter`          | Use a custom `AbstractAgent` implementation                         |
-| `GroqAdapter`               | Use `BuiltInAgent` with Groq-compatible model string                |
+| `GroqAdapter`               | Use a custom `AbstractAgent` (pass a Groq `LanguageModel` instance) |
 | `UnifyAdapter`              | Use a custom `AbstractAgent` implementation                         |
 | `OpenAIAssistantAdapter`    | Use a custom `AbstractAgent` implementation                         |
-| `BedrockAdapter`            | Use `BuiltInAgent({ model: "vertex:..." })` or custom agent         |
+| `BedrockAdapter`            | Use a custom `AbstractAgent` implementation                         |
 | `OllamaAdapter`             | Use a custom `AbstractAgent` implementation                         |
 | `EmptyAdapter`              | Not needed                                                          |
 
@@ -239,13 +241,13 @@ new CopilotRuntime({
 
 v1 had built-in integrations for Next.js (App Router, Pages Router), Express, NestJS, and Node HTTP. v2 uses Hono as the standard HTTP layer:
 
-| v1 Integration                            | v2 Replacement                                     |
-| ----------------------------------------- | -------------------------------------------------- |
-| `copilotRuntimeNextJSAppRouterEndpoint`   | `createCopilotEndpoint` (Hono, works with Next.js) |
-| `copilotRuntimeNextJSPagesRouterEndpoint` | `createCopilotEndpoint` (Hono)                     |
-| `CopilotRuntimeNodeExpressEndpoint`       | `createCopilotEndpointExpress`                     |
-| `CopilotRuntimeNestEndpoint`              | Use Hono adapter or Express endpoint               |
-| `CopilotRuntimeNodeHttpEndpoint`          | Use Hono or Express endpoint                       |
+| v1 Integration                            | v2 Replacement                                                   |
+| ----------------------------------------- | ---------------------------------------------------------------- |
+| `copilotRuntimeNextJSAppRouterEndpoint`   | `createCopilotHonoHandler` (Hono, works with Next.js)            |
+| `copilotRuntimeNextJSPagesRouterEndpoint` | `createCopilotHonoHandler` (Hono)                                |
+| `CopilotRuntimeNodeExpressEndpoint`       | `createCopilotExpressHandler` (`@copilotkit/runtime/v2/express`) |
+| `CopilotRuntimeNestEndpoint`              | Use Hono adapter or Express endpoint                             |
+| `CopilotRuntimeNodeHttpEndpoint`          | Use Hono or Express endpoint                                     |
 
 ### Endpoint configuration
 
@@ -259,10 +261,10 @@ export const POST = copilotRuntimeNextJSAppRouterEndpoint({
   endpoint: "/api/copilotkit",
 });
 
-// v2
-import { createCopilotEndpoint } from "@copilotkit/runtime";
+// v2 -- use createCopilotHonoHandler (createCopilotEndpoint is a deprecated alias)
+import { createCopilotHonoHandler } from "@copilotkit/runtime/v2";
 
-const app = createCopilotEndpoint({
+const app = createCopilotHonoHandler({
   runtime,
   basePath: "/api/copilotkit",
   cors: {
@@ -290,12 +292,12 @@ new CopilotRuntime({
 });
 
 // v2 (direct agent instance)
-import { LangGraphAgent } from "@ag-ui/langgraph";
+import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 new CopilotRuntime({
   agents: {
     myAgent: new LangGraphAgent({
-      url: "http://localhost:8000",
+      deploymentUrl: "http://localhost:8000",
       graphId: "my-graph",
     }),
   },

--- a/skills/copilotkit-upgrade/references/deprecation-map.md
+++ b/skills/copilotkit-upgrade/references/deprecation-map.md
@@ -4,111 +4,111 @@ Complete mapping of every deprecated v1 API to its v2 replacement.
 
 ## Hooks
 
-| v1 Hook                            | v1 Package               | v2 Replacement                                   | v2 Package                          | Status                               |
-| ---------------------------------- | ------------------------ | ------------------------------------------------ | ----------------------------------- | ------------------------------------ |
-| `useCopilotAction`                 | `@copilotkit/react-core` | `useFrontendTool`                                | `@copilotkit/react-core/v2`         | Renamed + new parameter format (Zod) |
-| `useCopilotReadable`               | `@copilotkit/react-core` | `useAgentContext`                                | `@copilotkit/react-core/v2`         | Renamed, `parentId` removed          |
-| `useCopilotChat`                   | `@copilotkit/react-core` | `useAgent`                                       | `@copilotkit/react-core/v2`         | Replaced (different API)             |
-| `useCoAgent`                       | `@copilotkit/react-core` | `useAgent`                                       | `@copilotkit/react-core/v2`         | Renamed, different return type       |
-| `useCoAgentStateRender`            | `@copilotkit/react-core` | `useRenderTool` / `useRenderActivityMessage`     | `@copilotkit/react-core/v2`         | Split: render-by-name + activity rendering |
-| `useLangGraphInterrupt`            | `@copilotkit/react-core` | `useInterrupt`                                   | `@copilotkit/react-core/v2`         | Renamed + new API                    |
-| `useCopilotChatSuggestions`        | `@copilotkit/react-core` | `useConfigureSuggestions` + `useSuggestions`     | `@copilotkit/react-core/v2`         | Split into two hooks                 |
-| `useCopilotAdditionalInstructions` | `@copilotkit/react-core` | `useAgentContext`                                | `@copilotkit/react-core/v2`         | Use description/value context        |
-| `useMakeCopilotDocumentReadable`   | `@copilotkit/react-core` | `useAgentContext`                                | `@copilotkit/react-core/v2`         | Pass content directly                |
-| `useCopilotRuntimeClient`          | `@copilotkit/react-core` | `useCopilotKit`                                  | `@copilotkit/react-core/v2/context` | Access core via provider context     |
-| `useCopilotContext`                | `@copilotkit/react-core` | `useCopilotKit`                                  | `@copilotkit/react-core/v2/context` | Returns `{ copilotkit, executingToolCallIds }` |
-| `useCopilotMessagesContext`        | `@copilotkit/react-core` | --                                               | --                                  | Removed (use agent event stream)     |
-| `useCoAgentStateRenders`           | `@copilotkit/react-core` | --                                               | --                                  | Removed (context no longer needed)   |
-| `useCopilotChatInternal`           | `@copilotkit/react-core` | --                                               | --                                  | Internal, removed                    |
-| `useCopilotChatHeadless_c`         | `@copilotkit/react-core` | --                                               | --                                  | Internal, removed                    |
-| `useCopilotAuthenticatedAction_c`  | `@copilotkit/react-core` | --                                               | --                                  | Internal, removed                    |
-| `useFrontendTool`                  | `@copilotkit/react-core` | `useFrontendTool`                                | `@copilotkit/react-core/v2`         | Same name, import path changes       |
-| `useHumanInTheLoop`                | `@copilotkit/react-core` | `useHumanInTheLoop`                              | `@copilotkit/react-core/v2`         | Same name, import path changes       |
-| `useRenderToolCall`                | `@copilotkit/react-core` | `useRenderToolCall`                              | `@copilotkit/react-core/v2`         | Same name, import path changes       |
+| v1 Hook                            | v1 Package               | v2 Replacement                                                | v2 Package                          | Status                                                                        |
+| ---------------------------------- | ------------------------ | ------------------------------------------------------------- | ----------------------------------- | ----------------------------------------------------------------------------- |
+| `useCopilotAction`                 | `@copilotkit/react-core` | `useFrontendTool`                                             | `@copilotkit/react-core/v2`         | Renamed + new parameter format (Zod)                                          |
+| `useCopilotReadable`               | `@copilotkit/react-core` | `useAgentContext`                                             | `@copilotkit/react-core/v2`         | Renamed, `parentId` removed                                                   |
+| `useCopilotChat`                   | `@copilotkit/react-core` | `useAgent`                                                    | `@copilotkit/react-core/v2`         | Replaced (different API)                                                      |
+| `useCoAgent`                       | `@copilotkit/react-core` | `useAgent`                                                    | `@copilotkit/react-core/v2`         | Renamed, different return type                                                |
+| `useCoAgentStateRender`            | `@copilotkit/react-core` | `useRenderTool` / `useRenderActivityMessage`                  | `@copilotkit/react-core/v2`         | Split: render-by-name + activity rendering                                    |
+| `useLangGraphInterrupt`            | `@copilotkit/react-core` | `useInterrupt`                                                | `@copilotkit/react-core/v2`         | Renamed + new API                                                             |
+| `useCopilotChatSuggestions`        | `@copilotkit/react-core` | `useConfigureSuggestions` + `useSuggestions`                  | `@copilotkit/react-core/v2`         | Split into two hooks                                                          |
+| `useCopilotAdditionalInstructions` | `@copilotkit/react-core` | `useAgentContext`                                             | `@copilotkit/react-core/v2`         | Use description/value context                                                 |
+| `useMakeCopilotDocumentReadable`   | `@copilotkit/react-core` | `useAgentContext`                                             | `@copilotkit/react-core/v2`         | Pass content directly                                                         |
+| `useCopilotRuntimeClient`          | `@copilotkit/react-core` | `useCopilotKit`                                               | `@copilotkit/react-core/v2/context` | Access core via provider context                                              |
+| `useCopilotContext`                | `@copilotkit/react-core` | `useCopilotKit`                                               | `@copilotkit/react-core/v2/context` | Returns `{ copilotkit, executingToolCallIds }`                                |
+| `useCopilotMessagesContext`        | `@copilotkit/react-core` | --                                                            | --                                  | Removed (use agent event stream)                                              |
+| `useCoAgentStateRenders`           | `@copilotkit/react-core` | --                                                            | --                                  | Removed (context no longer needed)                                            |
+| `useCopilotChatInternal`           | `@copilotkit/react-core` | --                                                            | --                                  | Internal, removed                                                             |
+| `useCopilotChatHeadless_c`         | `@copilotkit/react-core` | --                                                            | --                                  | Internal, removed                                                             |
+| `useCopilotAuthenticatedAction_c`  | `@copilotkit/react-core` | --                                                            | --                                  | Internal, removed                                                             |
+| `useFrontendTool`                  | `@copilotkit/react-core` | `useFrontendTool`                                             | `@copilotkit/react-core/v2`         | Same name, import path changes                                                |
+| `useHumanInTheLoop`                | `@copilotkit/react-core` | `useHumanInTheLoop`                                           | `@copilotkit/react-core/v2`         | Same name, import path changes                                                |
+| `useRenderToolCall`                | `@copilotkit/react-core` | `useRenderToolCall`                                           | `@copilotkit/react-core/v2`         | Same name, import path changes                                                |
 | `useDefaultTool`                   | `@copilotkit/react-core` | `useDefaultRenderTool` (render) / `useFrontendTool` (handler) | `@copilotkit/react-core/v2`         | Split: v1's catch-all had a handler; v2 `useDefaultRenderTool` is render-only |
-| `useLazyToolRenderer`              | `@copilotkit/react-core` | --                                               | --                                  | Removed                              |
-| `useChatContext` (react-ui)        | `@copilotkit/react-ui`   | `useCopilotChatConfiguration`                    | `@copilotkit/react-core/v2`         | Renamed                              |
+| `useLazyToolRenderer`              | `@copilotkit/react-core` | --                                                            | --                                  | Removed                                                                       |
+| `useChatContext` (react-ui)        | `@copilotkit/react-ui`   | `useCopilotChatConfiguration`                                 | `@copilotkit/react-core/v2`         | Renamed                                                                       |
 
 ## Components
 
-| v1 Component                  | v1 Package                   | v2 Replacement                | v2 Package                  | Status                               |
-| ----------------------------- | ---------------------------- | ----------------------------- | --------------------------- | ------------------------------------ |
-| `CopilotKit`                  | `@copilotkit/react-core`     | `CopilotKit`                  | `@copilotkit/react-core/v2` | Same name, new import path           |
-| `CopilotChat`                 | `@copilotkit/react-ui`       | `CopilotChat`                 | `@copilotkit/react-core/v2` | Same name, new package               |
-| `CopilotPopup`                | `@copilotkit/react-ui`       | `CopilotPopup`                | `@copilotkit/react-core/v2` | Same name, new package               |
-| `CopilotSidebar`              | `@copilotkit/react-ui`       | `CopilotSidebar`              | `@copilotkit/react-core/v2` | Same name, new package               |
-| `CopilotTextarea`             | `@copilotkit/react-textarea` | --                            | --                          | **Removed**                          |
-| `CopilotDevConsole`           | `@copilotkit/react-ui`       | `CopilotKitInspector`         | `@copilotkit/react-core/v2` | Renamed                              |
-| `Markdown`                    | `@copilotkit/react-ui`       | --                            | --                          | Removed -- v2 chat components render markdown internally |
-| `AssistantMessage`            | `@copilotkit/react-ui`       | `CopilotChatAssistantMessage` | `@copilotkit/react-core/v2` | Renamed                              |
-| `UserMessage`                 | `@copilotkit/react-ui`       | `CopilotChatUserMessage`      | `@copilotkit/react-core/v2` | Renamed                              |
-| `ImageRenderer`               | `@copilotkit/react-ui`       | --                            | --                          | Removed                              |
-| `RenderSuggestionsList`       | `@copilotkit/react-ui`       | `CopilotChatSuggestionView`   | `@copilotkit/react-core/v2` | Renamed                              |
-| `RenderSuggestion`            | `@copilotkit/react-ui`       | `CopilotChatSuggestionPill`   | `@copilotkit/react-core/v2` | Renamed                              |
-| `CoAgentStateRendersProvider` | `@copilotkit/react-core`     | --                            | --                          | Removed (no v2 equivalent)           |
+| v1 Component                  | v1 Package                   | v2 Replacement                | v2 Package                  | Status                                                                        |
+| ----------------------------- | ---------------------------- | ----------------------------- | --------------------------- | ----------------------------------------------------------------------------- |
+| `CopilotKit`                  | `@copilotkit/react-core`     | `CopilotKit`                  | `@copilotkit/react-core/v2` | Same name, new import path                                                    |
+| `CopilotChat`                 | `@copilotkit/react-ui`       | `CopilotChat`                 | `@copilotkit/react-core/v2` | Same name, new package                                                        |
+| `CopilotPopup`                | `@copilotkit/react-ui`       | `CopilotPopup`                | `@copilotkit/react-core/v2` | Same name, new package                                                        |
+| `CopilotSidebar`              | `@copilotkit/react-ui`       | `CopilotSidebar`              | `@copilotkit/react-core/v2` | Same name, new package                                                        |
+| `CopilotTextarea`             | `@copilotkit/react-textarea` | --                            | --                          | **Removed**                                                                   |
+| `CopilotDevConsole`           | `@copilotkit/react-ui`       | `CopilotKitInspector`         | `@copilotkit/react-core/v2` | Renamed                                                                       |
+| `Markdown`                    | `@copilotkit/react-ui`       | --                            | --                          | Removed -- v2 chat components render markdown internally                      |
+| `AssistantMessage`            | `@copilotkit/react-ui`       | `CopilotChatAssistantMessage` | `@copilotkit/react-core/v2` | Renamed                                                                       |
+| `UserMessage`                 | `@copilotkit/react-ui`       | `CopilotChatUserMessage`      | `@copilotkit/react-core/v2` | Renamed                                                                       |
+| `ImageRenderer`               | `@copilotkit/react-ui`       | --                            | --                          | Removed                                                                       |
+| `RenderSuggestionsList`       | `@copilotkit/react-ui`       | `CopilotChatSuggestionView`   | `@copilotkit/react-core/v2` | Renamed                                                                       |
+| `RenderSuggestion`            | `@copilotkit/react-ui`       | `CopilotChatSuggestionPill`   | `@copilotkit/react-core/v2` | Renamed                                                                       |
+| `CoAgentStateRendersProvider` | `@copilotkit/react-core`     | --                            | --                          | Removed (no v2 equivalent)                                                    |
 | `ThreadsProvider`             | `@copilotkit/react-core`     | `useThreads`                  | `@copilotkit/react-core/v2` | Provider removed; use the `useThreads` hook for client-side thread management |
 
 > **Note:** `@copilotkit/react-core/v2` also exports a `CopilotKitProvider` component. Do not migrate to it -- it is a functionality subset of `CopilotKit` (from `/v2`), which is the compatibility bridge across v1 and v2.
 
 ## Runtime Classes
 
-| v1 Class/Function              | v1 Package            | v2 Replacement                             | v2 Package               | Status                               |
-| ------------------------------ | --------------------- | ------------------------------------------ | ------------------------ | ------------------------------------ |
-| `CopilotRuntime`               | `@copilotkit/runtime` | `CopilotRuntime`                           | `@copilotkit/runtime/v2` | Same name, different constructor API |
-| `OpenAIAdapter`                | `@copilotkit/runtime` | `BuiltInAgent({ model: "openai/..." })`    | `@copilotkit/runtime/v2` | **Removed**                          |
-| `AnthropicAdapter`             | `@copilotkit/runtime` | `BuiltInAgent({ model: "anthropic/..." })` | `@copilotkit/runtime/v2` | **Removed**                          |
-| `GoogleGenerativeAIAdapter`    | `@copilotkit/runtime` | `BuiltInAgent({ model: "google/..." })`    | `@copilotkit/runtime/v2` | **Removed**                          |
-| `LangChainAdapter`             | `@copilotkit/runtime` | Custom `AbstractAgent`                     | --                       | **Removed**                          |
-| `GroqAdapter`                  | `@copilotkit/runtime` | Custom `AbstractAgent` (Groq `LanguageModel`) | --                    | **Removed**                          |
-| `UnifyAdapter`                 | `@copilotkit/runtime` | Custom `AbstractAgent`                     | --                       | **Removed**                          |
-| `OpenAIAssistantAdapter`       | `@copilotkit/runtime` | Custom `AbstractAgent`                     | --                       | **Removed**                          |
-| `BedrockAdapter`               | `@copilotkit/runtime` | Custom `AbstractAgent`                     | --                       | **Removed**                          |
-| `OllamaAdapter` (experimental) | `@copilotkit/runtime` | Custom `AbstractAgent`                     | --                       | **Removed**                          |
-| `EmptyAdapter`                 | `@copilotkit/runtime` | --                                         | --                       | **Removed**                          |
-| `RemoteChain`                  | `@copilotkit/runtime` | --                                         | --                       | **Removed**                          |
-| `LangGraphAgent`               | `@copilotkit/runtime` | `LangGraphAgent`                           | `@copilotkit/runtime/langgraph` | Moved to the `/langgraph` subpath    |
-| `LangGraphHttpAgent`           | `@copilotkit/runtime` | `LangGraphHttpAgent`                       | `@copilotkit/runtime/langgraph` | Distinct class (not merged into `LangGraphAgent`); moved to the `/langgraph` subpath |
+| v1 Class/Function              | v1 Package            | v2 Replacement                                | v2 Package                      | Status                                                                               |
+| ------------------------------ | --------------------- | --------------------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------ |
+| `CopilotRuntime`               | `@copilotkit/runtime` | `CopilotRuntime`                              | `@copilotkit/runtime/v2`        | Same name, different constructor API                                                 |
+| `OpenAIAdapter`                | `@copilotkit/runtime` | `BuiltInAgent({ model: "openai/..." })`       | `@copilotkit/runtime/v2`        | **Removed**                                                                          |
+| `AnthropicAdapter`             | `@copilotkit/runtime` | `BuiltInAgent({ model: "anthropic/..." })`    | `@copilotkit/runtime/v2`        | **Removed**                                                                          |
+| `GoogleGenerativeAIAdapter`    | `@copilotkit/runtime` | `BuiltInAgent({ model: "google/..." })`       | `@copilotkit/runtime/v2`        | **Removed**                                                                          |
+| `LangChainAdapter`             | `@copilotkit/runtime` | Custom `AbstractAgent`                        | --                              | **Removed**                                                                          |
+| `GroqAdapter`                  | `@copilotkit/runtime` | Custom `AbstractAgent` (Groq `LanguageModel`) | --                              | **Removed**                                                                          |
+| `UnifyAdapter`                 | `@copilotkit/runtime` | Custom `AbstractAgent`                        | --                              | **Removed**                                                                          |
+| `OpenAIAssistantAdapter`       | `@copilotkit/runtime` | Custom `AbstractAgent`                        | --                              | **Removed**                                                                          |
+| `BedrockAdapter`               | `@copilotkit/runtime` | Custom `AbstractAgent`                        | --                              | **Removed**                                                                          |
+| `OllamaAdapter` (experimental) | `@copilotkit/runtime` | Custom `AbstractAgent`                        | --                              | **Removed**                                                                          |
+| `EmptyAdapter`                 | `@copilotkit/runtime` | --                                            | --                              | **Removed**                                                                          |
+| `RemoteChain`                  | `@copilotkit/runtime` | --                                            | --                              | **Removed**                                                                          |
+| `LangGraphAgent`               | `@copilotkit/runtime` | `LangGraphAgent`                              | `@copilotkit/runtime/langgraph` | Moved to the `/langgraph` subpath                                                    |
+| `LangGraphHttpAgent`           | `@copilotkit/runtime` | `LangGraphHttpAgent`                          | `@copilotkit/runtime/langgraph` | Distinct class (not merged into `LangGraphAgent`); moved to the `/langgraph` subpath |
 
 ## Runtime Framework Integrations
 
-| v1 Function                               | v1 Package            | v2 Replacement                | v2 Package                       | Status                                                      |
-| ----------------------------------------- | --------------------- | ----------------------------- | -------------------------------- | ----------------------------------------------------------- |
+| v1 Function                               | v1 Package            | v2 Replacement                | v2 Package                       | Status                                                                |
+| ----------------------------------------- | --------------------- | ----------------------------- | -------------------------------- | --------------------------------------------------------------------- |
 | `copilotRuntimeNextJSAppRouterEndpoint`   | `@copilotkit/runtime` | `createCopilotHonoHandler`    | `@copilotkit/runtime/v2`         | **Removed** (use Hono; `createCopilotEndpoint` is a deprecated alias) |
 | `copilotRuntimeNextJSPagesRouterEndpoint` | `@copilotkit/runtime` | `createCopilotHonoHandler`    | `@copilotkit/runtime/v2`         | **Removed** (use Hono; `createCopilotEndpoint` is a deprecated alias) |
-| `CopilotRuntimeNodeExpressEndpoint`       | `@copilotkit/runtime` | `createCopilotExpressHandler` | `@copilotkit/runtime/v2/express` | Renamed                                                     |
-| `CopilotRuntimeNestEndpoint`              | `@copilotkit/runtime` | `createCopilotHonoHandler`    | `@copilotkit/runtime/v2`         | **Removed** (use Hono)                                      |
-| `CopilotRuntimeNodeHttpEndpoint`          | `@copilotkit/runtime` | `createCopilotHonoHandler`    | `@copilotkit/runtime/v2`         | **Removed** (use Hono)                                      |
+| `CopilotRuntimeNodeExpressEndpoint`       | `@copilotkit/runtime` | `createCopilotExpressHandler` | `@copilotkit/runtime/v2/express` | Renamed                                                               |
+| `CopilotRuntimeNestEndpoint`              | `@copilotkit/runtime` | `createCopilotHonoHandler`    | `@copilotkit/runtime/v2`         | **Removed** (use Hono)                                                |
+| `CopilotRuntimeNodeHttpEndpoint`          | `@copilotkit/runtime` | `createCopilotHonoHandler`    | `@copilotkit/runtime/v2`         | **Removed** (use Hono)                                                |
 
 ## Types
 
-| v1 Type                              | v1 Package               | v2 Replacement                   | v2 Package                   | Status                                                         |
-| ------------------------------------ | ------------------------ | -------------------------------- | ---------------------------- | -------------------------------------------------------------- |
+| v1 Type                              | v1 Package               | v2 Replacement                   | v2 Package                   | Status                                                                           |
+| ------------------------------------ | ------------------------ | -------------------------------- | ---------------------------- | -------------------------------------------------------------------------------- |
 | `CopilotKitProps`                    | `@copilotkit/react-core` | `CopilotKitProps`                | `@copilotkit/react-core/v2`  | Same name, new import path (extends `Omit<CopilotKitProviderProps, "children">`) |
-| `CopilotContextParams`               | `@copilotkit/react-core` | `CopilotKitContextValue`         | `@copilotkit/react-core/v2`  | Renamed                                                        |
-| `FrontendAction`                     | `@copilotkit/react-core` | `ReactFrontendTool`              | `@copilotkit/react-core/v2`  | Renamed + restructured                                         |
-| `ActionRenderProps`                  | `@copilotkit/react-core` | `ReactToolCallRenderer`          | `@copilotkit/react-core/v2`  | Renamed + restructured                                         |
-| `DocumentPointer`                    | `@copilotkit/react-core` | --                               | --                           | **Removed**                                                    |
-| `SystemMessageFunction`              | `@copilotkit/react-core` | --                               | --                           | **Removed**                                                    |
-| `CopilotChatSuggestionConfiguration` | `@copilotkit/react-core` | `Suggestion`                     | `@copilotkit/core`           | Renamed                                                        |
-| `Parameter`                          | `@copilotkit/shared`     | Zod schemas / `StandardSchemaV1` | `zod` / `@copilotkit/shared` | Replaced with schema-based                                     |
-| `CopilotServiceAdapter`              | `@copilotkit/runtime`    | `AbstractAgent`                  | `@ag-ui/client`              | Replaced                                                       |
-| `TextMessageEvents`                  | `@copilotkit/runtime`    | --                               | --                           | **Removed** (@deprecated)                                      |
-| `ToolCallEvents`                     | `@copilotkit/runtime`    | --                               | --                           | **Removed** (@deprecated)                                      |
-| `CustomEventNames`                   | `@copilotkit/runtime`    | --                               | --                           | **Removed** (@deprecated)                                      |
-| `PredictStateTool`                   | `@copilotkit/runtime`    | --                               | --                           | **Removed** (@deprecated)                                      |
+| `CopilotContextParams`               | `@copilotkit/react-core` | `CopilotKitContextValue`         | `@copilotkit/react-core/v2`  | Renamed                                                                          |
+| `FrontendAction`                     | `@copilotkit/react-core` | `ReactFrontendTool`              | `@copilotkit/react-core/v2`  | Renamed + restructured                                                           |
+| `ActionRenderProps`                  | `@copilotkit/react-core` | `ReactToolCallRenderer`          | `@copilotkit/react-core/v2`  | Renamed + restructured                                                           |
+| `DocumentPointer`                    | `@copilotkit/react-core` | --                               | --                           | **Removed**                                                                      |
+| `SystemMessageFunction`              | `@copilotkit/react-core` | --                               | --                           | **Removed**                                                                      |
+| `CopilotChatSuggestionConfiguration` | `@copilotkit/react-core` | `Suggestion`                     | `@copilotkit/core`           | Renamed                                                                          |
+| `Parameter`                          | `@copilotkit/shared`     | Zod schemas / `StandardSchemaV1` | `zod` / `@copilotkit/shared` | Replaced with schema-based                                                       |
+| `CopilotServiceAdapter`              | `@copilotkit/runtime`    | `AbstractAgent`                  | `@ag-ui/client`              | Replaced                                                                         |
+| `TextMessageEvents`                  | `@copilotkit/runtime`    | --                               | --                           | **Removed** (@deprecated)                                                        |
+| `ToolCallEvents`                     | `@copilotkit/runtime`    | --                               | --                           | **Removed** (@deprecated)                                                        |
+| `CustomEventNames`                   | `@copilotkit/runtime`    | --                               | --                           | **Removed** (@deprecated)                                                        |
+| `PredictStateTool`                   | `@copilotkit/runtime`    | --                               | --                           | **Removed** (@deprecated)                                                        |
 
 ## v1 Props Marked @deprecated Within v1
 
 These were already deprecated within v1 itself:
 
-| Location               | Deprecated API                                               | Replacement                                          |
-| ---------------------- | ------------------------------------------------------------ | ---------------------------------------------------- |
-| `FrontendAction`       | `disabled`                                                   | `available: false` (boolean; defaults to `true`)     |
-| `ActionRenderProps`    | `respond()`                                                  | Use `respond` (same, just documented differently)    |
+| Location               | Deprecated API                                               | Replacement                                                                                                                                                   |
+| ---------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FrontendAction`       | `disabled`                                                   | `available: false` (boolean; defaults to `true`)                                                                                                              |
+| `ActionRenderProps`    | `respond()`                                                  | Use `respond` (same, just documented differently)                                                                                                             |
 | `CopilotKitProps`      | `guardrails_c`                                               | `@internal`/defunct in source but still populates the legacy CopilotCloud `restrictToTopic` config when a cloud key is set; no effect on the v2 AG-UI runtime |
-| `CopilotRuntime`       | `onBeforeRequest` / `onAfterRequest`                         | `beforeRequestMiddleware` / `afterRequestMiddleware` |
-| `useCopilotChat`       | `visibleMessages`                                            | Use AG-UI message stream                             |
-| `useCopilotChat`       | `appendMessage`                                              | Use `sendMessage` or agent API                       |
-| Chat component props   | `AssistantMessage` / `UserMessage` / `Messages` render props | `RenderMessage`                                      |
-| `useA2UIStore`         | `useA2UIStore`                                               | `useA2UIContext`                                     |
-| `useA2UIStoreSelector` | `useA2UIStoreSelector`                                       | `useA2UIContext`                                     |
+| `CopilotRuntime`       | `onBeforeRequest` / `onAfterRequest`                         | `beforeRequestMiddleware` / `afterRequestMiddleware`                                                                                                          |
+| `useCopilotChat`       | `visibleMessages`                                            | Use AG-UI message stream                                                                                                                                      |
+| `useCopilotChat`       | `appendMessage`                                              | Use `sendMessage` or agent API                                                                                                                                |
+| Chat component props   | `AssistantMessage` / `UserMessage` / `Messages` render props | `RenderMessage`                                                                                                                                               |
+| `useA2UIStore`         | `useA2UIStore`                                               | `useA2UIContext`                                                                                                                                              |
+| `useA2UIStoreSelector` | `useA2UIStoreSelector`                                       | `useA2UIContext`                                                                                                                                              |

--- a/skills/copilotkit-upgrade/references/deprecation-map.md
+++ b/skills/copilotkit-upgrade/references/deprecation-map.md
@@ -4,89 +4,89 @@ Complete mapping of every deprecated v1 API to its v2 replacement.
 
 ## Hooks
 
-| v1 Hook                            | v1 Package               | v2 Replacement                                   | v2 Package          | Status                               |
-| ---------------------------------- | ------------------------ | ------------------------------------------------ | ------------------- | ------------------------------------ |
-| `useCopilotAction`                 | `@copilotkit/react-core` | `useFrontendTool`                                | `@copilotkit/react` | Renamed + new parameter format (Zod) |
-| `useCopilotReadable`               | `@copilotkit/react-core` | `useAgentContext`                                | `@copilotkit/react` | Renamed, `parentId` removed          |
-| `useCopilotChat`                   | `@copilotkit/react-core` | `useAgent`                                       | `@copilotkit/react` | Replaced (different API)             |
-| `useCoAgent`                       | `@copilotkit/react-core` | `useAgent`                                       | `@copilotkit/react` | Renamed, different return type       |
-| `useCoAgentStateRender`            | `@copilotkit/react-core` | `useRenderToolCall` / `useRenderActivityMessage` | `@copilotkit/react` | Split into two hooks                 |
-| `useLangGraphInterrupt`            | `@copilotkit/react-core` | `useInterrupt`                                   | `@copilotkit/react` | Renamed + new API                    |
-| `useCopilotChatSuggestions`        | `@copilotkit/react-core` | `useConfigureSuggestions` + `useSuggestions`     | `@copilotkit/react` | Split into two hooks                 |
-| `useCopilotAdditionalInstructions` | `@copilotkit/react-core` | `useAgentContext`                                | `@copilotkit/react` | Use description/value context        |
-| `useMakeCopilotDocumentReadable`   | `@copilotkit/react-core` | `useAgentContext`                                | `@copilotkit/react` | Pass content directly                |
-| `useCopilotRuntimeClient`          | `@copilotkit/react-core` | `useCopilotKit`                                  | `@copilotkit/react` | Access core via provider context     |
-| `useCopilotContext`                | `@copilotkit/react-core` | `useCopilotKit`                                  | `@copilotkit/react` | Returns `{ copilotkit }`             |
-| `useCopilotMessagesContext`        | `@copilotkit/react-core` | --                                               | --                  | Removed (use agent event stream)     |
-| `useCoAgentStateRenders`           | `@copilotkit/react-core` | --                                               | --                  | Removed (context no longer needed)   |
-| `useCopilotChatInternal`           | `@copilotkit/react-core` | --                                               | --                  | Internal, removed                    |
-| `useCopilotChatHeadless_c`         | `@copilotkit/react-core` | --                                               | --                  | Internal, removed                    |
-| `useCopilotAuthenticatedAction_c`  | `@copilotkit/react-core` | --                                               | --                  | Internal, removed                    |
-| `useFrontendTool`                  | `@copilotkit/react-core` | `useFrontendTool`                                | `@copilotkit/react` | Same name, import path changes       |
-| `useHumanInTheLoop`                | `@copilotkit/react-core` | `useHumanInTheLoop`                              | `@copilotkit/react` | Same name, import path changes       |
-| `useRenderToolCall`                | `@copilotkit/react-core` | `useRenderToolCall`                              | `@copilotkit/react` | Same name, import path changes       |
-| `useDefaultTool`                   | `@copilotkit/react-core` | `useDefaultRenderTool`                           | `@copilotkit/react` | Renamed                              |
-| `useLazyToolRenderer`              | `@copilotkit/react-core` | --                                               | --                  | Removed                              |
-| `useChatContext` (react-ui)        | `@copilotkit/react-ui`   | `useCopilotChatConfiguration`                    | `@copilotkit/react` | Renamed                              |
+| v1 Hook                            | v1 Package               | v2 Replacement                                   | v2 Package                          | Status                               |
+| ---------------------------------- | ------------------------ | ------------------------------------------------ | ----------------------------------- | ------------------------------------ |
+| `useCopilotAction`                 | `@copilotkit/react-core` | `useFrontendTool`                                | `@copilotkit/react-core/v2`         | Renamed + new parameter format (Zod) |
+| `useCopilotReadable`               | `@copilotkit/react-core` | `useAgentContext`                                | `@copilotkit/react-core/v2`         | Renamed, `parentId` removed          |
+| `useCopilotChat`                   | `@copilotkit/react-core` | `useAgent`                                       | `@copilotkit/react-core/v2`         | Replaced (different API)             |
+| `useCoAgent`                       | `@copilotkit/react-core` | `useAgent`                                       | `@copilotkit/react-core/v2`         | Renamed, different return type       |
+| `useCoAgentStateRender`            | `@copilotkit/react-core` | `useRenderTool` / `useRenderActivityMessage`     | `@copilotkit/react-core/v2`         | Split: render-by-name + activity rendering |
+| `useLangGraphInterrupt`            | `@copilotkit/react-core` | `useInterrupt`                                   | `@copilotkit/react-core/v2`         | Renamed + new API                    |
+| `useCopilotChatSuggestions`        | `@copilotkit/react-core` | `useConfigureSuggestions` + `useSuggestions`     | `@copilotkit/react-core/v2`         | Split into two hooks                 |
+| `useCopilotAdditionalInstructions` | `@copilotkit/react-core` | `useAgentContext`                                | `@copilotkit/react-core/v2`         | Use description/value context        |
+| `useMakeCopilotDocumentReadable`   | `@copilotkit/react-core` | `useAgentContext`                                | `@copilotkit/react-core/v2`         | Pass content directly                |
+| `useCopilotRuntimeClient`          | `@copilotkit/react-core` | `useCopilotKit`                                  | `@copilotkit/react-core/v2/context` | Access core via provider context     |
+| `useCopilotContext`                | `@copilotkit/react-core` | `useCopilotKit`                                  | `@copilotkit/react-core/v2/context` | Returns `{ copilotkit, executingToolCallIds }` |
+| `useCopilotMessagesContext`        | `@copilotkit/react-core` | --                                               | --                                  | Removed (use agent event stream)     |
+| `useCoAgentStateRenders`           | `@copilotkit/react-core` | --                                               | --                                  | Removed (context no longer needed)   |
+| `useCopilotChatInternal`           | `@copilotkit/react-core` | --                                               | --                                  | Internal, removed                    |
+| `useCopilotChatHeadless_c`         | `@copilotkit/react-core` | --                                               | --                                  | Internal, removed                    |
+| `useCopilotAuthenticatedAction_c`  | `@copilotkit/react-core` | --                                               | --                                  | Internal, removed                    |
+| `useFrontendTool`                  | `@copilotkit/react-core` | `useFrontendTool`                                | `@copilotkit/react-core/v2`         | Same name, import path changes       |
+| `useHumanInTheLoop`                | `@copilotkit/react-core` | `useHumanInTheLoop`                              | `@copilotkit/react-core/v2`         | Same name, import path changes       |
+| `useRenderToolCall`                | `@copilotkit/react-core` | `useRenderToolCall`                              | `@copilotkit/react-core/v2`         | Same name, import path changes       |
+| `useDefaultTool`                   | `@copilotkit/react-core` | `useDefaultRenderTool` (render) / `useFrontendTool` (handler) | `@copilotkit/react-core/v2`         | Split: v1's catch-all had a handler; v2 `useDefaultRenderTool` is render-only |
+| `useLazyToolRenderer`              | `@copilotkit/react-core` | --                                               | --                                  | Removed                              |
+| `useChatContext` (react-ui)        | `@copilotkit/react-ui`   | `useCopilotChatConfiguration`                    | `@copilotkit/react-core/v2`         | Renamed                              |
 
 ## Components
 
 | v1 Component                  | v1 Package                   | v2 Replacement                | v2 Package                  | Status                               |
 | ----------------------------- | ---------------------------- | ----------------------------- | --------------------------- | ------------------------------------ |
 | `CopilotKit`                  | `@copilotkit/react-core`     | `CopilotKit`                  | `@copilotkit/react-core/v2` | Same name, new import path           |
-| `CopilotChat`                 | `@copilotkit/react-ui`       | `CopilotChat`                 | `@copilotkit/react`         | Same name, new package               |
-| `CopilotPopup`                | `@copilotkit/react-ui`       | `CopilotPopup`                | `@copilotkit/react`         | Same name, new package               |
-| `CopilotSidebar`              | `@copilotkit/react-ui`       | `CopilotSidebar`              | `@copilotkit/react`         | Same name, new package               |
+| `CopilotChat`                 | `@copilotkit/react-ui`       | `CopilotChat`                 | `@copilotkit/react-core/v2` | Same name, new package               |
+| `CopilotPopup`                | `@copilotkit/react-ui`       | `CopilotPopup`                | `@copilotkit/react-core/v2` | Same name, new package               |
+| `CopilotSidebar`              | `@copilotkit/react-ui`       | `CopilotSidebar`              | `@copilotkit/react-core/v2` | Same name, new package               |
 | `CopilotTextarea`             | `@copilotkit/react-textarea` | --                            | --                          | **Removed**                          |
-| `CopilotDevConsole`           | `@copilotkit/react-ui`       | `CopilotKitInspector`         | `@copilotkit/react`         | Renamed                              |
-| `Markdown`                    | `@copilotkit/react-ui`       | --                            | --                          | Removed (use A2UI renderer)          |
-| `AssistantMessage`            | `@copilotkit/react-ui`       | `CopilotChatAssistantMessage` | `@copilotkit/react`         | Renamed                              |
-| `UserMessage`                 | `@copilotkit/react-ui`       | `CopilotChatUserMessage`      | `@copilotkit/react`         | Renamed                              |
+| `CopilotDevConsole`           | `@copilotkit/react-ui`       | `CopilotKitInspector`         | `@copilotkit/react-core/v2` | Renamed                              |
+| `Markdown`                    | `@copilotkit/react-ui`       | --                            | --                          | Removed -- v2 chat components render markdown internally |
+| `AssistantMessage`            | `@copilotkit/react-ui`       | `CopilotChatAssistantMessage` | `@copilotkit/react-core/v2` | Renamed                              |
+| `UserMessage`                 | `@copilotkit/react-ui`       | `CopilotChatUserMessage`      | `@copilotkit/react-core/v2` | Renamed                              |
 | `ImageRenderer`               | `@copilotkit/react-ui`       | --                            | --                          | Removed                              |
-| `RenderSuggestionsList`       | `@copilotkit/react-ui`       | `CopilotChatSuggestionView`   | `@copilotkit/react`         | Renamed                              |
-| `RenderSuggestion`            | `@copilotkit/react-ui`       | `CopilotChatSuggestionPill`   | `@copilotkit/react`         | Renamed                              |
+| `RenderSuggestionsList`       | `@copilotkit/react-ui`       | `CopilotChatSuggestionView`   | `@copilotkit/react-core/v2` | Renamed                              |
+| `RenderSuggestion`            | `@copilotkit/react-ui`       | `CopilotChatSuggestionPill`   | `@copilotkit/react-core/v2` | Renamed                              |
 | `CoAgentStateRendersProvider` | `@copilotkit/react-core`     | --                            | --                          | Removed (no v2 equivalent)           |
-| `ThreadsProvider`             | `@copilotkit/react-core`     | --                            | --                          | Removed (threads managed by runtime) |
+| `ThreadsProvider`             | `@copilotkit/react-core`     | `useThreads`                  | `@copilotkit/react-core/v2` | Provider removed; use the `useThreads` hook for client-side thread management |
 
 > **Note:** `@copilotkit/react-core/v2` also exports a `CopilotKitProvider` component. Do not migrate to it -- it is a functionality subset of `CopilotKit` (from `/v2`), which is the compatibility bridge across v1 and v2.
 
 ## Runtime Classes
 
-| v1 Class/Function              | v1 Package            | v2 Replacement                             | v2 Package            | Status                               |
-| ------------------------------ | --------------------- | ------------------------------------------ | --------------------- | ------------------------------------ |
-| `CopilotRuntime`               | `@copilotkit/runtime` | `CopilotRuntime`                           | `@copilotkit/runtime` | Same name, different constructor API |
-| `OpenAIAdapter`                | `@copilotkit/runtime` | `BuiltInAgent({ model: "openai:..." })`    | `@copilotkit/agent`   | **Removed**                          |
-| `AnthropicAdapter`             | `@copilotkit/runtime` | `BuiltInAgent({ model: "anthropic:..." })` | `@copilotkit/agent`   | **Removed**                          |
-| `GoogleGenerativeAIAdapter`    | `@copilotkit/runtime` | `BuiltInAgent({ model: "google:..." })`    | `@copilotkit/agent`   | **Removed**                          |
-| `LangChainAdapter`             | `@copilotkit/runtime` | Custom `AbstractAgent`                     | --                    | **Removed**                          |
-| `GroqAdapter`                  | `@copilotkit/runtime` | `BuiltInAgent` with Groq model             | `@copilotkit/agent`   | **Removed**                          |
-| `UnifyAdapter`                 | `@copilotkit/runtime` | Custom `AbstractAgent`                     | --                    | **Removed**                          |
-| `OpenAIAssistantAdapter`       | `@copilotkit/runtime` | Custom `AbstractAgent`                     | --                    | **Removed**                          |
-| `BedrockAdapter`               | `@copilotkit/runtime` | `BuiltInAgent({ model: "vertex:..." })`    | `@copilotkit/agent`   | **Removed**                          |
-| `OllamaAdapter` (experimental) | `@copilotkit/runtime` | Custom `AbstractAgent`                     | --                    | **Removed**                          |
-| `EmptyAdapter`                 | `@copilotkit/runtime` | --                                         | --                    | **Removed**                          |
-| `RemoteChain`                  | `@copilotkit/runtime` | --                                         | --                    | **Removed**                          |
-| `LangGraphAgent`               | `@copilotkit/runtime` | `LangGraphAgent`                           | `@ag-ui/langgraph`    | Moved to AG-UI package               |
-| `LangGraphHttpAgent`           | `@copilotkit/runtime` | `LangGraphAgent`                           | `@ag-ui/langgraph`    | Moved + renamed                      |
+| v1 Class/Function              | v1 Package            | v2 Replacement                             | v2 Package               | Status                               |
+| ------------------------------ | --------------------- | ------------------------------------------ | ------------------------ | ------------------------------------ |
+| `CopilotRuntime`               | `@copilotkit/runtime` | `CopilotRuntime`                           | `@copilotkit/runtime/v2` | Same name, different constructor API |
+| `OpenAIAdapter`                | `@copilotkit/runtime` | `BuiltInAgent({ model: "openai/..." })`    | `@copilotkit/runtime/v2` | **Removed**                          |
+| `AnthropicAdapter`             | `@copilotkit/runtime` | `BuiltInAgent({ model: "anthropic/..." })` | `@copilotkit/runtime/v2` | **Removed**                          |
+| `GoogleGenerativeAIAdapter`    | `@copilotkit/runtime` | `BuiltInAgent({ model: "google/..." })`    | `@copilotkit/runtime/v2` | **Removed**                          |
+| `LangChainAdapter`             | `@copilotkit/runtime` | Custom `AbstractAgent`                     | --                       | **Removed**                          |
+| `GroqAdapter`                  | `@copilotkit/runtime` | Custom `AbstractAgent` (Groq `LanguageModel`) | --                    | **Removed**                          |
+| `UnifyAdapter`                 | `@copilotkit/runtime` | Custom `AbstractAgent`                     | --                       | **Removed**                          |
+| `OpenAIAssistantAdapter`       | `@copilotkit/runtime` | Custom `AbstractAgent`                     | --                       | **Removed**                          |
+| `BedrockAdapter`               | `@copilotkit/runtime` | Custom `AbstractAgent`                     | --                       | **Removed**                          |
+| `OllamaAdapter` (experimental) | `@copilotkit/runtime` | Custom `AbstractAgent`                     | --                       | **Removed**                          |
+| `EmptyAdapter`                 | `@copilotkit/runtime` | --                                         | --                       | **Removed**                          |
+| `RemoteChain`                  | `@copilotkit/runtime` | --                                         | --                       | **Removed**                          |
+| `LangGraphAgent`               | `@copilotkit/runtime` | `LangGraphAgent`                           | `@copilotkit/runtime/langgraph` | Moved to the `/langgraph` subpath    |
+| `LangGraphHttpAgent`           | `@copilotkit/runtime` | `LangGraphHttpAgent`                       | `@copilotkit/runtime/langgraph` | Distinct class (not merged into `LangGraphAgent`); moved to the `/langgraph` subpath |
 
 ## Runtime Framework Integrations
 
-| v1 Function                               | v1 Package            | v2 Replacement                 | v2 Package            | Status                 |
-| ----------------------------------------- | --------------------- | ------------------------------ | --------------------- | ---------------------- |
-| `copilotRuntimeNextJSAppRouterEndpoint`   | `@copilotkit/runtime` | `createCopilotEndpoint`        | `@copilotkit/runtime` | **Removed** (use Hono) |
-| `copilotRuntimeNextJSPagesRouterEndpoint` | `@copilotkit/runtime` | `createCopilotEndpoint`        | `@copilotkit/runtime` | **Removed** (use Hono) |
-| `CopilotRuntimeNodeExpressEndpoint`       | `@copilotkit/runtime` | `createCopilotEndpointExpress` | `@copilotkit/runtime` | Renamed                |
-| `CopilotRuntimeNestEndpoint`              | `@copilotkit/runtime` | `createCopilotEndpoint`        | `@copilotkit/runtime` | **Removed** (use Hono) |
-| `CopilotRuntimeNodeHttpEndpoint`          | `@copilotkit/runtime` | `createCopilotEndpoint`        | `@copilotkit/runtime` | **Removed** (use Hono) |
+| v1 Function                               | v1 Package            | v2 Replacement                | v2 Package                       | Status                                                      |
+| ----------------------------------------- | --------------------- | ----------------------------- | -------------------------------- | ----------------------------------------------------------- |
+| `copilotRuntimeNextJSAppRouterEndpoint`   | `@copilotkit/runtime` | `createCopilotHonoHandler`    | `@copilotkit/runtime/v2`         | **Removed** (use Hono; `createCopilotEndpoint` is a deprecated alias) |
+| `copilotRuntimeNextJSPagesRouterEndpoint` | `@copilotkit/runtime` | `createCopilotHonoHandler`    | `@copilotkit/runtime/v2`         | **Removed** (use Hono; `createCopilotEndpoint` is a deprecated alias) |
+| `CopilotRuntimeNodeExpressEndpoint`       | `@copilotkit/runtime` | `createCopilotExpressHandler` | `@copilotkit/runtime/v2/express` | Renamed                                                     |
+| `CopilotRuntimeNestEndpoint`              | `@copilotkit/runtime` | `createCopilotHonoHandler`    | `@copilotkit/runtime/v2`         | **Removed** (use Hono)                                      |
+| `CopilotRuntimeNodeHttpEndpoint`          | `@copilotkit/runtime` | `createCopilotHonoHandler`    | `@copilotkit/runtime/v2`         | **Removed** (use Hono)                                      |
 
 ## Types
 
 | v1 Type                              | v1 Package               | v2 Replacement                   | v2 Package                   | Status                                                         |
 | ------------------------------------ | ------------------------ | -------------------------------- | ---------------------------- | -------------------------------------------------------------- |
-| `CopilotKitProps`                    | `@copilotkit/react-core` | `CopilotKitProps`                | `@copilotkit/react-core/v2`  | Same name, new import path (extends `CopilotKitProviderProps`) |
-| `CopilotContextParams`               | `@copilotkit/react-core` | `CopilotKitContextValue`         | `@copilotkit/react`          | Renamed                                                        |
-| `FrontendAction`                     | `@copilotkit/react-core` | `ReactFrontendTool`              | `@copilotkit/react`          | Renamed + restructured                                         |
-| `ActionRenderProps`                  | `@copilotkit/react-core` | `ReactToolCallRenderer`          | `@copilotkit/react`          | Renamed + restructured                                         |
+| `CopilotKitProps`                    | `@copilotkit/react-core` | `CopilotKitProps`                | `@copilotkit/react-core/v2`  | Same name, new import path (extends `Omit<CopilotKitProviderProps, "children">`) |
+| `CopilotContextParams`               | `@copilotkit/react-core` | `CopilotKitContextValue`         | `@copilotkit/react-core/v2`  | Renamed                                                        |
+| `FrontendAction`                     | `@copilotkit/react-core` | `ReactFrontendTool`              | `@copilotkit/react-core/v2`  | Renamed + restructured                                         |
+| `ActionRenderProps`                  | `@copilotkit/react-core` | `ReactToolCallRenderer`          | `@copilotkit/react-core/v2`  | Renamed + restructured                                         |
 | `DocumentPointer`                    | `@copilotkit/react-core` | --                               | --                           | **Removed**                                                    |
 | `SystemMessageFunction`              | `@copilotkit/react-core` | --                               | --                           | **Removed**                                                    |
 | `CopilotChatSuggestionConfiguration` | `@copilotkit/react-core` | `Suggestion`                     | `@copilotkit/core`           | Renamed                                                        |
@@ -103,9 +103,9 @@ These were already deprecated within v1 itself:
 
 | Location               | Deprecated API                                               | Replacement                                          |
 | ---------------------- | ------------------------------------------------------------ | ---------------------------------------------------- |
-| `FrontendAction`       | `disabled`                                                   | `available: "disabled"`                              |
+| `FrontendAction`       | `disabled`                                                   | `available: false` (boolean; defaults to `true`)     |
 | `ActionRenderProps`    | `respond()`                                                  | Use `respond` (same, just documented differently)    |
-| `CopilotKitProps`      | `guardrails_c`                                               | Removed in v2                                        |
+| `CopilotKitProps`      | `guardrails_c`                                               | `@internal`/defunct in source but still populates the legacy CopilotCloud `restrictToTopic` config when a cloud key is set; no effect on the v2 AG-UI runtime |
 | `CopilotRuntime`       | `onBeforeRequest` / `onAfterRequest`                         | `beforeRequestMiddleware` / `afterRequestMiddleware` |
 | `useCopilotChat`       | `visibleMessages`                                            | Use AG-UI message stream                             |
 | `useCopilotChat`       | `appendMessage`                                              | Use `sendMessage` or agent API                       |

--- a/skills/copilotkit-upgrade/references/v1-to-v2-migration.md
+++ b/skills/copilotkit-upgrade/references/v1-to-v2-migration.md
@@ -20,15 +20,15 @@ npm install @copilotkit/react-core@latest @copilotkit/runtime@latest @copilotkit
 
 **Package mapping:**
 
-| v1 Package                       | v2 Package                  | Notes                                                                                     |
-| -------------------------------- | --------------------------- | ----------------------------------------------------------------------------------------- |
-| `@copilotkit/react-core`         | `@copilotkit/react-core/v2` | Same package; v2 hooks, provider, types, and chat components live under the `/v2` subpath |
-| `@copilotkit/react-ui`           | `@copilotkit/react-core/v2` | Chat components moved into `react-core/v2`; `react-ui` contributes only styles in v2      |
+| v1 Package                       | v2 Package                  | Notes                                                                                                                                     |
+| -------------------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `@copilotkit/react-core`         | `@copilotkit/react-core/v2` | Same package; v2 hooks, provider, types, and chat components live under the `/v2` subpath                                                 |
+| `@copilotkit/react-ui`           | `@copilotkit/react-core/v2` | Chat components moved into `react-core/v2`; `react-ui` contributes only styles in v2                                                      |
 | `@copilotkit/react-textarea`     | --                          | No v2 equivalent; the v1 `@copilotkit/react-textarea@1.x` package stays installable -- drop it only after migrating off `CopilotTextarea` |
-| `@copilotkit/runtime`            | `@copilotkit/runtime/v2`    | Same package; v2 runtime/agents live under the `/v2` subpath                              |
-| `@copilotkit/runtime-client-gql` | `@ag-ui/client`             | Re-exported by `@copilotkit/react-core/v2`                                                |
-| `@copilotkit/shared`             | `@copilotkit/shared`        | Utility types and constants                                                               |
-| `@copilotkit/sdk-js`             | `@copilotkit/runtime/v2`    | `BuiltInAgent` and agent definitions now ship from `runtime/v2`                           |
+| `@copilotkit/runtime`            | `@copilotkit/runtime/v2`    | Same package; v2 runtime/agents live under the `/v2` subpath                                                                              |
+| `@copilotkit/runtime-client-gql` | `@ag-ui/client`             | Re-exported by `@copilotkit/react-core/v2`                                                                                                |
+| `@copilotkit/shared`             | `@copilotkit/shared`        | Utility types and constants                                                                                                               |
+| `@copilotkit/sdk-js`             | `@copilotkit/runtime/v2`    | `BuiltInAgent` and agent definitions now ship from `runtime/v2`                                                                           |
 
 ### Step 2: Update All Imports
 

--- a/skills/copilotkit-upgrade/references/v1-to-v2-migration.md
+++ b/skills/copilotkit-upgrade/references/v1-to-v2-migration.md
@@ -4,37 +4,40 @@
 
 ### Step 1: Replace Dependencies
 
-Remove v1 packages and install v2 equivalents:
+The `@copilotkit/*` package names are unchanged in v2 -- the v2 APIs ship from the **`/v2` subpath** of the same packages. There is **no** `@copilotkit/react` or `@copilotkit/agent` package; do not install them. You only need to remove the packages that no longer have a v2 surface and upgrade the rest to their latest versions:
 
 ```bash
-# Remove v1
-npm uninstall @copilotkit/react-core @copilotkit/react-ui @copilotkit/react-textarea \
-  @copilotkit/runtime @copilotkit/runtime-client-gql @copilotkit/shared @copilotkit/sdk-js
+# Remove packages with no v2 surface (uninstall @copilotkit/react-textarea only
+# AFTER you have migrated off CopilotTextarea -- the v1 package still exists and
+# stays installable for backward compatibility)
+npm uninstall @copilotkit/runtime-client-gql @copilotkit/sdk-js
 
-# Install v2
-npm install @copilotkit/react @copilotkit/runtime @copilotkit/agent @copilotkit/shared
+# Upgrade the packages you keep to their latest (v2) versions.
+# `hono` is only needed for the Hono endpoint (createCopilotHonoHandler); `zod` is
+# the peer dep used for tool parameter schemas.
+npm install @copilotkit/react-core@latest @copilotkit/runtime@latest @copilotkit/shared@latest zod
 ```
 
 **Package mapping:**
 
-| v1 Package                       | v2 Package            | Notes                                          |
-| -------------------------------- | --------------------- | ---------------------------------------------- |
-| `@copilotkit/react-core`         | `@copilotkit/react`   | Hooks, provider, types merged into one package |
-| `@copilotkit/react-ui`           | `@copilotkit/react`   | Chat components merged into same package       |
-| `@copilotkit/react-textarea`     | --                    | Removed entirely, no v2 equivalent             |
-| `@copilotkit/runtime`            | `@copilotkit/runtime` | New agent-based architecture                   |
-| `@copilotkit/runtime-client-gql` | `@ag-ui/client`       | Re-exported by `@copilotkit/react`             |
-| `@copilotkit/shared`             | `@copilotkit/shared`  | Utility types and constants                    |
-| `@copilotkit/sdk-js`             | `@copilotkit/agent`   | Agent definitions (BuiltInAgent, etc.)         |
+| v1 Package                       | v2 Package                  | Notes                                                                                     |
+| -------------------------------- | --------------------------- | ----------------------------------------------------------------------------------------- |
+| `@copilotkit/react-core`         | `@copilotkit/react-core/v2` | Same package; v2 hooks, provider, types, and chat components live under the `/v2` subpath |
+| `@copilotkit/react-ui`           | `@copilotkit/react-core/v2` | Chat components moved into `react-core/v2`; `react-ui` contributes only styles in v2      |
+| `@copilotkit/react-textarea`     | --                          | No v2 equivalent; the v1 `@copilotkit/react-textarea@1.x` package stays installable -- drop it only after migrating off `CopilotTextarea` |
+| `@copilotkit/runtime`            | `@copilotkit/runtime/v2`    | Same package; v2 runtime/agents live under the `/v2` subpath                              |
+| `@copilotkit/runtime-client-gql` | `@ag-ui/client`             | Re-exported by `@copilotkit/react-core/v2`                                                |
+| `@copilotkit/shared`             | `@copilotkit/shared`        | Utility types and constants                                                               |
+| `@copilotkit/sdk-js`             | `@copilotkit/runtime/v2`    | `BuiltInAgent` and agent definitions now ship from `runtime/v2`                           |
 
 ### Step 2: Update All Imports
 
 Find-and-replace import paths across your codebase:
 
 ```
-@copilotkit/react-core  ->  @copilotkit/react
-@copilotkit/react-ui    ->  @copilotkit/react
-@copilotkit/runtime     ->  @copilotkit/runtime
+@copilotkit/react-core  ->  @copilotkit/react-core/v2
+@copilotkit/react-ui    ->  @copilotkit/react-core/v2   (plus import "@copilotkit/react-core/v2/styles.css")
+@copilotkit/runtime     ->  @copilotkit/runtime/v2      (Express helpers: @copilotkit/runtime/v2/express)
 @copilotkit/shared      ->  @copilotkit/shared
 ```
 
@@ -75,7 +78,7 @@ function App() {
 **Key differences:**
 
 - Same component name; the import path changes from the package root (legacy v1) to the `/v2` subpath
-- The props type keeps the name `CopilotKitProps` (also exported from `/v2`); it extends `CopilotKitProviderProps`, so every `CopilotKitProvider` prop also works on it
+- The props type keeps the name `CopilotKitProps` (also exported from `/v2`); it extends `Omit<CopilotKitProviderProps, "children">` (with a narrowed `children` type), so every non-`children` `CopilotKitProvider` prop also works on it
 - v2 adds `credentials`, `selfManagedAgents`, `renderToolCalls`, `renderActivityMessages` props
 - v2 removes `agents` prop (use `selfManagedAgents` or `agents__unsafe_dev_only` for local dev)
 
@@ -118,7 +121,7 @@ useCopilotAction({
 **v2:**
 
 ```tsx
-import { useFrontendTool } from "@copilotkit/react";
+import { useFrontendTool } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
 useFrontendTool({
@@ -144,8 +147,8 @@ useFrontendTool({
 - Hook renamed from `useCopilotAction` to `useFrontendTool`
 - Parameters use Zod schemas instead of the v1 parameter descriptor array (`{ name, type, required }`)
 - The `handler` receives the full args object directly (not destructured from `{ arg1, arg2 }`)
-- The `render` prop works similarly but uses `ToolCallStatus` enum (`"inProgress"`, `"executing"`, `"complete"`)
-- v2 adds `available` prop (`"enabled"` | `"disabled"`) replacing the v1 `disabled` boolean
+- The `render` prop works similarly but `status` is now a `ToolCallStatus` enum member (`ToolCallStatus.InProgress` / `.Executing` / `.Complete`, whose values are `"inProgress"` / `"executing"` / `"complete"`)
+- v2 replaces the v1 `disabled` boolean with `available` -- also a boolean (defaults to `true`; set `false` to hide the tool)
 - v2 adds `agentId` prop to scope a tool to a specific agent
 
 ### useCopilotReadable -> useAgentContext
@@ -168,7 +171,7 @@ function EmployeeList({ employees }) {
 **v2:**
 
 ```tsx
-import { useAgentContext } from "@copilotkit/react";
+import { useAgentContext } from "@copilotkit/react-core/v2";
 
 function EmployeeList({ employees }) {
   useAgentContext({
@@ -199,7 +202,7 @@ useMakeCopilotDocumentReadable(documentPointer, ["category1"]);
 **v2:**
 
 ```tsx
-import { useAgentContext } from "@copilotkit/react";
+import { useAgentContext } from "@copilotkit/react-core/v2";
 
 useAgentContext({
   description: "Document content for category1",
@@ -211,6 +214,7 @@ useAgentContext({
 
 - No direct `DocumentPointer` equivalent in v2; pass document content directly via `useAgentContext`
 - Categories are not supported; use the `description` field to provide context
+- v1 returned a document `id` (used for `parentId` chaining); `useAgentContext` returns nothing, and hierarchical context via `parentId` is gone -- flatten instead
 
 ### useCoAgent -> useAgent
 
@@ -231,7 +235,7 @@ const { name, state, setState, running, start, stop, run } =
 **v2:**
 
 ```tsx
-import { useAgent } from "@copilotkit/react";
+import { useAgent } from "@copilotkit/react-core/v2";
 
 const agent = useAgent({ agentId: "my-agent" });
 
@@ -247,7 +251,7 @@ const agent = useAgent({ agentId: "my-agent" });
 - v2 returns an `AbstractAgent` instance instead of a destructured state object
 - The `run` / `start` / `stop` API surface differs -- v2 uses AG-UI protocol methods
 
-### useCoAgentStateRender -> useRenderToolCall / useRenderActivityMessage
+### useCoAgentStateRender -> useRenderTool / useRenderActivityMessage
 
 **v1:**
 
@@ -266,27 +270,24 @@ useCoAgentStateRender<YourAgentState>({
 **v2:**
 
 ```tsx
-import { useRenderToolCall } from "@copilotkit/react";
+import { useRenderTool } from "@copilotkit/react-core/v2";
 
-// For tool call rendering:
-useRenderToolCall({
-  toolCall,
-  toolMessage,
-});
-
-// Or for activity messages:
-import { useRenderActivityMessage } from "@copilotkit/react";
-
-useRenderActivityMessage({
-  // renders activity/progress messages from the agent
+// Register a render-only renderer for a tool BY NAME (the declarative successor):
+useRenderTool({
+  name: "basic_agent",
+  render: ({ name, args, status, result }) => (
+    <SearchProgress args={args} status={status} />
+  ),
 });
 ```
 
 **Key differences:**
 
-- `useCoAgentStateRender` is split into `useRenderToolCall` (for tool execution UI) and `useRenderActivityMessage` (for progress/activity rendering)
-- v2 does not have the `nodeName` filtering -- tool rendering is keyed by tool call ID
-- v2 uses AG-UI `ToolCall` and `ToolMessage` types instead of the v1 agent state shape
+- The idiomatic successor is `useRenderTool({ name, render })` -- a declarative, render-only registration keyed by tool **name** (no handler). If you also need execution behavior, use `useFrontendTool`, which accepts both a `handler` and a `render`.
+- For agent progress/activity (not tool calls), use `useRenderActivityMessage()` -- a zero-arg hook returning `{ renderActivityMessage, findRenderer }`.
+- `useRenderToolCall()` is the lower-level imperative hook (zero-arg, returns a `renderToolCall({ toolCall, toolMessage })` function) used internally by the chat views; prefer `useRenderTool` for migration.
+- v2 has no `nodeName` filtering; renderers match by tool name (with an `agentId` tie-break and a `"*"` wildcard fallback).
+- v2 uses AG-UI `ToolCall` / `ToolMessage` types instead of the v1 agent state shape.
 
 ### useLangGraphInterrupt -> useInterrupt
 
@@ -312,7 +313,7 @@ useLangGraphInterrupt({
 **v2:**
 
 ```tsx
-import { useInterrupt } from "@copilotkit/react";
+import { useInterrupt } from "@copilotkit/react-core/v2";
 
 const interruptElement = useInterrupt({
   renderInChat: false, // false = you render it yourself; true = renders in CopilotChat
@@ -343,7 +344,7 @@ return <div>{interruptElement}</div>;
 - v2 adds optional `handler` for programmatic interrupt handling before rendering
 - v2 returns a `React.ReactElement | null` when `renderInChat: false`
 
-### useCopilotChat -> useAgent + useSuggestions
+### useCopilotChat -> useAgent
 
 **v1:**
 
@@ -362,7 +363,7 @@ await appendMessage(
 **v2:**
 
 ```tsx
-import { useAgent } from "@copilotkit/react";
+import { useAgent } from "@copilotkit/react-core/v2";
 
 const agent = useAgent({ agentId: "my-agent" });
 
@@ -392,7 +393,10 @@ useCopilotChatSuggestions({
 **v2:**
 
 ```tsx
-import { useConfigureSuggestions, useSuggestions } from "@copilotkit/react";
+import {
+  useConfigureSuggestions,
+  useSuggestions,
+} from "@copilotkit/react-core/v2";
 
 // Configure suggestion generation:
 useConfigureSuggestions({
@@ -427,7 +431,7 @@ useCopilotAdditionalInstructions({
 **v2:**
 
 ```tsx
-import { useAgentContext } from "@copilotkit/react";
+import { useAgentContext } from "@copilotkit/react-core/v2";
 
 useAgentContext({
   description: "Additional instructions for the agent",
@@ -446,7 +450,7 @@ import { useHumanInTheLoop } from "@copilotkit/react-core";
 **v2:**
 
 ```tsx
-import { useHumanInTheLoop } from "@copilotkit/react";
+import { useHumanInTheLoop } from "@copilotkit/react-core/v2";
 ```
 
 The API is similar -- registers a tool that pauses for user input via a render function with a `respond` callback.
@@ -463,7 +467,7 @@ import {
   OpenAIAdapter,
   GoogleGenerativeAIAdapter,
 } from "@copilotkit/runtime";
-import { copilotKitEndpoint } from "@copilotkit/runtime"; // Next.js App Router
+import { copilotRuntimeNextJSAppRouterEndpoint } from "@copilotkit/runtime"; // Next.js App Router
 
 const serviceAdapter = new OpenAIAdapter({ model: "gpt-4o" });
 const runtime = new CopilotRuntime({
@@ -481,41 +485,54 @@ const runtime = new CopilotRuntime({
 });
 
 // Next.js App Router
-export const POST = copilotKitEndpoint(runtime, serviceAdapter);
+export const POST = copilotRuntimeNextJSAppRouterEndpoint({
+  runtime,
+  serviceAdapter,
+  endpoint: "/api/copilotkit",
+});
 ```
 
 ### v2: AG-UI Agent Pattern
 
 ```ts
-import { CopilotRuntime, createCopilotEndpoint } from "@copilotkit/runtime";
-import { BuiltInAgent } from "@copilotkit/agent";
-import { LangGraphAgent } from "@ag-ui/langgraph";
+import {
+  CopilotRuntime,
+  BuiltInAgent,
+  createCopilotHonoHandler,
+} from "@copilotkit/runtime/v2";
+import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const runtime = new CopilotRuntime({
   agents: {
     default: new BuiltInAgent({
-      model: "openai:gpt-4o",
+      model: "openai/gpt-4o",
       // Frontend tools are registered client-side via useFrontendTool
     }),
     myLangGraphAgent: new LangGraphAgent({
-      url: "http://localhost:8000",
+      deploymentUrl: "http://localhost:8000",
       graphId: "my-graph",
     }),
   },
   // Optional middleware
   a2ui: {}, // A2UI middleware config
   mcpApps: {
-    // MCP Apps middleware
-    servers: [{ transport: { type: "sse", url: "http://localhost:3001/sse" } }],
+    // MCP Apps middleware -- each server config is flat (type + url at the top level)
+    servers: [{ type: "sse", url: "http://localhost:3001/sse" }],
   },
 });
 
-// Hono-based endpoint (works with Next.js, Express, standalone)
-const app = createCopilotEndpoint({
+// Hono-based endpoint. `createCopilotEndpoint` is a deprecated alias for
+// `createCopilotHonoHandler`. For Express, use `createCopilotExpressHandler`
+// from "@copilotkit/runtime/v2/express".
+const app = createCopilotHonoHandler({
   runtime,
   basePath: "/api/copilotkit",
 });
 
+// Standalone Hono: `export default app`.
+// Next.js App Router (app/api/copilotkit/route.ts): export the fetch handler instead:
+//   export const POST = app.fetch;
+//   export const GET = app.fetch;
 export default app;
 ```
 
@@ -524,7 +541,7 @@ export default app;
 - No more service adapters (`OpenAIAdapter`, `LangChainAdapter`, etc.) -- model selection is done inside agents
 - No more `actions` array on the runtime -- frontend tools are registered via `useFrontendTool`, backend tools via agent configuration
 - No more `remoteEndpoints` -- agents are passed directly as `AbstractAgent` instances
-- Endpoint setup uses `createCopilotEndpoint` (Hono) or `createCopilotEndpointExpress` (Express) instead of framework-specific integrations
+- Endpoint setup uses `createCopilotHonoHandler` (Hono, from `@copilotkit/runtime/v2`; also exported as the deprecated alias `createCopilotEndpoint`) or `createCopilotExpressHandler` (Express, from `@copilotkit/runtime/v2/express`) instead of framework-specific integrations
 - v2 runtime supports SSE mode and Intelligence mode (durable threads with realtime events)
 
 ### v2 Runtime Modes
@@ -536,7 +553,7 @@ const runtime = new CopilotRuntime({
 });
 
 // Intelligence Mode (durable threads, realtime, requires CopilotKitIntelligence)
-import { CopilotKitIntelligence } from "@copilotkit/runtime";
+import { CopilotKitIntelligence } from "@copilotkit/runtime/v2";
 
 const runtime = new CopilotRuntime({
   agents: { default: myAgent },
@@ -552,7 +569,7 @@ const runtime = new CopilotRuntime({
 
 ## Chat Component Migration
 
-Chat components have the same names but move to `@copilotkit/react`:
+Chat components have the same names but move to `@copilotkit/react-core/v2`:
 
 **v1:**
 
@@ -567,7 +584,11 @@ import {
 **v2:**
 
 ```tsx
-import { CopilotChat, CopilotPopup, CopilotSidebar } from "@copilotkit/react";
+import {
+  CopilotChat,
+  CopilotPopup,
+  CopilotSidebar,
+} from "@copilotkit/react-core/v2";
 ```
 
 v2 adds new chat sub-components for granular customization:
@@ -602,14 +623,16 @@ v1 used GraphQL-based message types from `@copilotkit/runtime-client-gql`:
 import { TextMessage, MessageRole } from "@copilotkit/runtime-client-gql";
 ```
 
-v2 uses AG-UI protocol types from `@ag-ui/client` (re-exported by `@copilotkit/react`):
+v2 uses AG-UI protocol types from `@ag-ui/client` (re-exported by `@copilotkit/react-core/v2`):
 
 ```tsx
 import {
-  Message,
-  TextMessage,
+  Message, // the message union
+  AssistantMessage, // per-role message types (UserMessage, SystemMessage, ToolMessage, ...)
   ToolCall,
   ToolMessage,
   EventType,
-} from "@copilotkit/react"; // re-exports from @ag-ui/client
+} from "@copilotkit/react-core/v2"; // re-exports from @ag-ui/client
 ```
+
+> v2 has no standalone `TextMessage` type (that was the v1 GraphQL name). Use the `Message` union or the per-role types (`AssistantMessage` / `UserMessage` / ...); streamed text arrives via events such as `TextMessageChunkEvent`.

--- a/skills/copilotkit-upgrade/sources.md
+++ b/skills/copilotkit-upgrade/sources.md
@@ -1,41 +1,51 @@
 # Sources
 
 Files and directories read from CopilotKit/CopilotKit to generate this skill's references.
-Generated: 2026-03-28
+Generated: 2026-06-18 (regenerated against live `main`)
+
+> **Package layout note:** the repo is a flat monorepo -- every package lives directly
+> under `packages/<name>` (there is no `packages/v1/` or `packages/v2/` directory).
+> v2 ships from the **`/v2` subpath of the same packages**: v2 React is
+> `@copilotkit/react-core/v2` (source: `packages/react-core/src/v2/`) and v2 runtime is
+> `@copilotkit/runtime/v2` (source: `packages/runtime/src/v2/`). There is no
+> `@copilotkit/react` or `@copilotkit/agent` package -- `BuiltInAgent` and the v2 agent
+> definitions are re-exported from `@copilotkit/runtime/v2`
+> (source: `packages/runtime/src/agent/`).
 
 ## v1-to-v2-migration.md
 
-- packages/v1/react-core/src/index.ts (v1 hook exports: useCopilotAction, useCopilotReadable, useCoAgent, useLangGraphInterrupt, useCopilotChat, useCopilotChatSuggestions, useCopilotAdditionalInstructions, useMakeCopilotDocumentReadable, CopilotKit provider)
-- packages/v1/react-ui/src/index.ts (v1 component exports: CopilotChat, CopilotPopup, CopilotSidebar)
-- packages/v1/react-textarea/src/index.ts (CopilotTextarea export, confirmed removed in v2)
-- packages/v1/runtime/src/index.ts (v1 runtime exports: CopilotRuntime, OpenAIAdapter, AnthropicAdapter, GoogleGenerativeAIAdapter, LangChainAdapter, copilotRuntimeNextJSAppRouterEndpoint, copilotKitEndpoint)
-- packages/v1/runtime-client-gql/src/index.ts (v1 GraphQL types: TextMessage, MessageRole, ActionExecutionMessage, ResultMessage)
-- packages/v2/react/src/index.ts (v2 hook exports: useFrontendTool, useAgentContext, useAgent, useInterrupt, useSuggestions, useConfigureSuggestions, useRenderToolCall, useRenderActivityMessage, CopilotKit compat provider -- the recommended migration target; CopilotKitProvider is also exported but is a functionality subset)
-- packages/v2/runtime/src/index.ts (v2 runtime exports: CopilotRuntime, createCopilotEndpoint, createCopilotEndpointExpress, CopilotKitIntelligence)
-- packages/v2/agent/src/index.ts (v2 agent exports: BuiltInAgent, defineTool)
-- packages/v2/core/src/ (CopilotKitCore, AG-UI event types, AbstractAgent interface)
+- packages/react-core/src/index.tsx (v1 hook exports: useCopilotAction, useCopilotReadable, useCoAgent, useLangGraphInterrupt, useCopilotChat, useCopilotChatSuggestions, useCopilotAdditionalInstructions, useMakeCopilotDocumentReadable, CopilotKit provider)
+- packages/react-ui/src/components/chat/index.tsx (v1 component exports: CopilotChat, CopilotPopup, CopilotSidebar; CSS-only in v2)
+- packages/react-textarea/src/index.tsx (CopilotTextarea export, confirmed removed in v2)
+- packages/runtime/src/index.ts (v1 runtime exports: CopilotRuntime, OpenAIAdapter, AnthropicAdapter, GoogleGenerativeAIAdapter, LangChainAdapter, copilotRuntimeNextJSAppRouterEndpoint, copilotKitEndpoint)
+- packages/runtime-client-gql/src/index.ts (v1 GraphQL types: TextMessage, MessageRole, ActionExecutionMessage, ResultMessage)
+- packages/react-core/src/v2/index.ts (v2 React exports under `@copilotkit/react-core/v2`: useFrontendTool, useAgentContext, useAgent, useInterrupt, useSuggestions, useConfigureSuggestions, useRenderToolCall, useRenderActivityMessage, useHumanInTheLoop, CopilotKit compat provider -- the recommended migration target; CopilotKitProvider is also exported but is a functionality subset; chat components CopilotChat/CopilotPopup/CopilotSidebar; re-exports `@copilotkit/core` and `@ag-ui/client`)
+- packages/runtime/src/v2/index.ts (v2 runtime exports under `@copilotkit/runtime/v2`: CopilotRuntime, createCopilotHonoHandler [deprecated alias createCopilotEndpoint], CopilotKitIntelligence, InMemoryAgentRunner)
+- packages/runtime/src/v2/runtime/endpoints/express.ts (Express endpoint helper `createCopilotExpressHandler`, exported from `@copilotkit/runtime/v2/express`)
+- packages/runtime/src/agent/index.ts (v2 agent exports re-exported from `@copilotkit/runtime/v2`: BuiltInAgent, defineTool)
+- packages/core/src/ (CopilotKitCore, AG-UI event types, AbstractAgent interface; re-exported by `@copilotkit/react-core/v2`)
 
 ## breaking-changes.md
 
-- packages/v1/react-core/src/ (v1 provider props: CopilotKitProps, parameter descriptor format, FrontendAction type, ActionRenderProps)
-- packages/v1/runtime/src/ (v1 service adapters, CopilotRuntime constructor with actions/remoteEndpoints, framework integration functions)
-- packages/v1/shared/src/ (v1 Parameter type definition)
-- packages/v2/react/src/ (v2 provider props: CopilotKitProviderProps, Zod parameter schemas, useFrontendTool available prop)
-- packages/v2/runtime/src/ (v2 CopilotRuntime constructor with agents/middleware, createCopilotEndpoint Hono-based)
-- packages/v2/core/src/ (AG-UI event types, message types replacing GraphQL types)
-- packages/v2/agent/src/ (BuiltInAgent replacing all service adapters)
+- packages/react-core/src/ (v1 provider props: CopilotKitProps, parameter descriptor format, FrontendAction type, ActionRenderProps)
+- packages/runtime/src/ (v1 service adapters, CopilotRuntime constructor with actions/remoteEndpoints, framework integration functions)
+- packages/shared/src/ (v1 Parameter type definition)
+- packages/react-core/src/v2/ (v2 provider props: CopilotKitProviderProps, Zod parameter schemas, useFrontendTool available prop)
+- packages/runtime/src/v2/ (v2 CopilotRuntime constructor with agents/middleware, createCopilotHonoHandler Hono-based)
+- packages/core/src/ (AG-UI event types, message types replacing GraphQL types)
+- packages/runtime/src/agent/ (BuiltInAgent replacing all service adapters)
 
 ## deprecation-map.md
 
-- packages/v1/react-core/src/index.ts (all v1 hook and component exports)
-- packages/v1/react-ui/src/index.ts (all v1 UI component exports)
-- packages/v1/react-textarea/src/index.ts (CopilotTextarea export)
-- packages/v1/runtime/src/index.ts (all v1 runtime class and function exports)
-- packages/v1/runtime-client-gql/src/index.ts (v1 GraphQL client exports)
-- packages/v1/shared/src/index.ts (v1 shared type exports)
-- packages/v1/sdk-js/src/index.ts (v1 SDK exports)
-- packages/v2/react/src/index.ts (all v2 hook and component exports)
-- packages/v2/runtime/src/index.ts (all v2 runtime exports)
-- packages/v2/agent/src/index.ts (v2 agent exports)
-- packages/v2/core/src/index.ts (v2 core exports)
-- packages/v2/shared/src/index.ts (v2 shared type exports)
+- packages/react-core/src/index.tsx (all v1 hook and component exports)
+- packages/react-ui/src/components/chat/index.tsx (all v1 UI component exports)
+- packages/react-textarea/src/index.tsx (CopilotTextarea export)
+- packages/runtime/src/index.ts (all v1 runtime class and function exports)
+- packages/runtime-client-gql/src/index.ts (v1 GraphQL client exports)
+- packages/shared/src/index.ts (v1 shared type exports)
+- packages/sdk-js/src/index.ts (v1 SDK exports)
+- packages/react-core/src/v2/index.ts (all v2 React hook and component exports)
+- packages/runtime/src/v2/index.ts (all v2 runtime exports)
+- packages/runtime/src/agent/index.ts (v2 agent exports)
+- packages/core/src/index.ts (v2 core exports)
+- packages/shared/src/index.ts (v2 shared type exports)


### PR DESCRIPTION
`copilotkit-upgrade` was the one skill the v2 migration skipped. It routed users to packages that don't exist, so following it produces a non-installable app.

Root cause: the skill was generated against a non-existent `packages/v1/*` / `packages/v2/*` layout. The repo is flat and v2 ships from the `/v2` subpath of the same packages.

## Fix (pure docs)

Corrected every package/import reference across `SKILL.md` plus the three reference files against the live exports maps:

| Phantom in skill | Real target |
| --- | --- |
| `@copilotkit/react` | `@copilotkit/react-core/v2` |
| `@copilotkit/agent` | `@copilotkit/runtime/v2` (`BuiltInAgent`) |
| bare `@copilotkit/runtime` for v2 APIs | `@copilotkit/runtime/v2` |
| `createCopilotEndpointExpress` (doesn't exist) | `createCopilotExpressHandler` (`@copilotkit/runtime/v2/express`) |

Also fixed the install commands and regenerated `sources.md` against the real flat layout.

## Verification

Grep sweep shows zero remaining phantom references, and every v2 symbol the skill now cites was confirmed to exist in the live source barrels.