### PR TITLE
feat(showcase): fix --isolate slot picker (pinning, port probe, slot 0 reservation, bin/showcase slots)

### DIFF
--- a/showcase/TESTING.md
+++ b/showcase/TESTING.md
@@ -104,12 +104,7 @@ showcase-iso<N>-aimock` + DOM/probe text):
    `--isolate` slots cold-start aimock from the volume mount, so the first
    post-edit run picks up the change automatically; warm-slot reuse will not.
 
-8. **`--isolate` slot collisions with foreign Docker projects.** The slot registry
-   only knows about `showcase-*` compose projects. If a sibling project (e.g.,
-   `ag2mm-*`) owns the same host ports for the auto-picked slot, health checks
-   cross to the wrong containers and results misroute. Either pre-reserve the
-   conflicting slot dirs in `~/.local/state/copilotkit/showcase/slots/` or tear
-   down the foreign stack first.
+8. **`--isolate` slot pinning and conflict detection.** Pin a specific slot with `SHOWCASE_ISO_SLOT=<N>` (1-45; slot 0 is reserved for the base stack) — the picker uses exactly that slot or fails loudly. The auto-picker now port-probes every candidate via `lsof` before committing, so foreign-Docker (`ag2mm-*`) and host-process (macOS AirPlay on 5000) conflicts are detected pre-`docker compose up`. Run `bin/showcase slots` to inspect all 46 slots across DIR / PID / LIVE / PORTS / OFFSET (and PROJECT) — same code path the picker uses. The `LIVE` column reports `live` / `stale` / `inconclusive` and folds the live-pid and live-containers checks into one axis.
 
 9. **Cell-color flip claims MUST be empirically value-tested via the
    production-equivalent control-plane path** on ≥3 candidate cells before merge.
@@ -122,6 +117,12 @@ showcase-iso<N>-aimock` + DOM/probe text):
    (or `--d5 --isolate` for single-pill e2e). DO NOT use `--direct` for
    value-test — it bypasses the queue/worker pipeline staging actually runs and
    has misled investigations in the past.
+
+   Pick `<N>` by first running `bin/showcase slots` (or `bin/showcase slots --free --brief` for a machine-readable list) and choosing a row whose `DIR` is `absent`, `LIVE` is not `live`, and `PORTS` is not `held`, then pass `SHOWCASE_ISO_SLOT=<N>` to your test invocation:
+
+   ```
+   SHOWCASE_ISO_SLOT=<N> bin/showcase test <slug>:<feature> --d6 --isolate
+   ```
 
 10. **No fixture rewrite from real-LLM record/replay.** The canonical-phrase probe
     is anti-record/replay-against-real-LLM by construction: a real LLM won't emit

--- a/showcase/docker-compose.local.yml
+++ b/showcase/docker-compose.local.yml
@@ -182,7 +182,7 @@ services:
       - POCKETBASE_URL=http://localhost:8090
       - SHOWCASE_LOCAL=1
     ports:
-      - "3200:10000"
+      - "3210:10000"
     depends_on:
       pocketbase:
         condition: service_healthy

--- a/showcase/harness/src/cli/config.ts
+++ b/showcase/harness/src/cli/config.ts
@@ -53,8 +53,8 @@ export function loadConfig(): LocalConfig {
     // When --isolate offsets the aimock host port, honor env overrides so the
     // harness's host-side references point at the per-project aimock.
     aimockUrl: process.env.AIMOCK_URL_LOCAL || "http://localhost:4010",
-    dashboardUrl: process.env.DASHBOARD_URL_LOCAL || "http://localhost:3200",
-    dashboardPort: Number(process.env.DASHBOARD_PORT_LOCAL) || 3200,
+    dashboardUrl: process.env.DASHBOARD_URL_LOCAL || "http://localhost:3210",
+    dashboardPort: Number(process.env.DASHBOARD_PORT_LOCAL) || 3210,
   };
 }
 

--- a/showcase/harness/src/cli/control-plane-run.test.ts
+++ b/showcase/harness/src/cli/control-plane-run.test.ts
@@ -104,8 +104,8 @@ import {
   expectedKeys,
   dedupeScopes,
   runViaControlPlane,
-  type SlugScope,
 } from "./control-plane-run.js";
+import type { SlugScope } from "./control-plane-run.js";
 
 const SILENT_LOGGER: Logger = {
   debug: () => {},
@@ -124,8 +124,8 @@ const STUB_CONFIG: LocalConfig = {
     password: "showcase-local-dev",
   },
   aimockUrl: "http://localhost:4010",
-  dashboardUrl: "http://localhost:3200",
-  dashboardPort: 3200,
+  dashboardUrl: "http://localhost:3210",
+  dashboardPort: 3210,
 };
 
 // Replace process.env.LOCAL_SERVICES_JSON across tests so `buildLocalServicesJson`

--- a/showcase/harness/src/cli/doctor.ts
+++ b/showcase/harness/src/cli/doctor.ts
@@ -22,7 +22,7 @@ const _INFRA_OFFSET = Number(process.env.SHOWCASE_INFRA_PORT_OFFSET) || 0;
 const INFRA_PORTS: Record<string, number> = {
   aimock: 4010 + _INFRA_OFFSET,
   pocketbase: 8090 + _INFRA_OFFSET,
-  dashboard: 3200 + _INFRA_OFFSET,
+  dashboard: 3210 + _INFRA_OFFSET,
 };
 
 // ---------------------------------------------------------------------------

--- a/showcase/harness/src/cli/lifecycle.ts
+++ b/showcase/harness/src/cli/lifecycle.ts
@@ -30,13 +30,13 @@ const PORTS_FILE =
  *
  * Honor SHOWCASE_INFRA_PORT_OFFSET (set by --isolate) so health checks hit
  * the offset host ports of the isolated stack instead of the default
- * project's :4010/:8090/:3200 (which would silently report "healthy"
+ * project's :4010/:8090/:3210 (which would silently report "healthy"
  * against the WRONG containers). */
 const _INFRA_OFFSET = Number(process.env.SHOWCASE_INFRA_PORT_OFFSET) || 0;
 const INFRA_PORTS: Record<string, number> = {
   aimock: 4010 + _INFRA_OFFSET,
   pocketbase: 8090 + _INFRA_OFFSET,
-  dashboard: 3200 + _INFRA_OFFSET,
+  dashboard: 3210 + _INFRA_OFFSET,
 };
 
 /** Health-check endpoint overrides per service type. */

--- a/showcase/scripts/__tests__/isolate.bats
+++ b/showcase/scripts/__tests__/isolate.bats
@@ -112,10 +112,55 @@ esac
 exit 0
 STUB
   chmod +x "$STUB_DIR/docker"
+
+  # ── Fake lsof on PATH ──────────────────────────────────────────────────────
+  # apply_isolation's port-conflict probe (and cmd-doctor.sh) shell out to
+  # `lsof -i :<port> -sTCP:LISTEN -P -n`. Real lsof on the dev box reports
+  # whatever happens to be listening, which is both non-deterministic and
+  # non-hermetic. The stub drives held-port reporting from $LSOF_HOLD_PORTS
+  # (comma-separated): ports in the list emit the standard lsof header + a
+  # single LISTEN row and exit 0; ports not in the list exit 1 with empty
+  # stdout, mirroring real lsof's no-match semantics. Every invocation is
+  # appended to $LSOF_LOG so tests can assert which ports got probed.
+  cat > "$STUB_DIR/lsof" <<'STUB'
+#!/usr/bin/env bash
+# Record every invocation so tests can assert WHICH ports were probed.
+echo "lsof $*" >> "${LSOF_LOG:-/dev/null}"
+# Extract the port from `-i :<port>`. cmd-doctor.sh and _common.sh both invoke
+# `lsof -i :<port> -sTCP:LISTEN -P -n`, so the port arg is the one following
+# `-i`, with a leading colon. Other args (-sTCP:LISTEN, -P, -n) are tolerated
+# and ignored — the stub does not care about protocol/numeric flags.
+port=""
+while [ $# -gt 0 ]; do
+  if [ "$1" = "-i" ] && [[ "${2:-}" =~ ^:([0-9]+)$ ]]; then
+    port="${BASH_REMATCH[1]}"
+    break
+  fi
+  shift
+done
+[ -n "$port" ] || exit 1
+# Check $LSOF_HOLD_PORTS (comma-separated). Pad with commas so a port doesn't
+# substring-match a longer port (e.g. "341" vs "3410").
+case ",${LSOF_HOLD_PORTS:-}," in
+  *",${port},"*)
+    echo "COMMAND     PID  USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME"
+    echo "${LSOF_HOLD_COMMAND:-Python}     12345  user   5u   IPv4 0x0000000000000000      0t0  TCP 127.0.0.1:${port} (LISTEN)"
+    exit 0 ;;
+  *) exit 1 ;;
+esac
+STUB
+  chmod +x "$STUB_DIR/lsof"
+
   PATH="$STUB_DIR:$PATH"
 
   # Invocation log for the docker stub (one line per call, "$*"-joined args).
   export DOCKER_LOG="$BATS_TEST_TMPDIR/docker-invocations.log"
+
+  # Invocation log + held-port config for the lsof stub. Per-test tmpdir, so
+  # each test sees an empty log at start — no cross-test contamination.
+  export LSOF_LOG="$BATS_TEST_TMPDIR/lsof-invocations.log"
+  export LSOF_HOLD_PORTS=""
+  export LSOF_HOLD_COMMAND="Python"
 
   # ── Fake SHOWCASE_ROOT with the two files apply_isolation rewrites ──────────
   export SHOWCASE_ROOT_OVERRIDE="$BATS_TEST_TMPDIR/root"
@@ -153,6 +198,28 @@ load_common() {
   COMPOSE_FILE="$SHOWCASE_ROOT/docker-compose.local.yml"
   PORTS_FILE="$SHOWCASE_ROOT/shared/local-ports.json"
   COMPOSE_CMD="docker compose -f $COMPOSE_FILE"
+}
+
+# ── Foundation smoke: lsof stub plumbing ────────────────────────────────────
+# Pins the bats lsof stub used by the port-conflict tests: $LSOF_HOLD_PORTS
+# (comma-separated) controls which ports the stub reports as LISTEN'd; every
+# invocation is appended to $LSOF_LOG so callers can assert on what was probed.
+# Kept PERMANENT (test #0) so a silent stub regression — stub off PATH, env
+# vars unexported, log unwritable — fails LOUDLY here instead of corrupting
+# every downstream port-conflict test with vacuous "no listener" results.
+
+@test "lsof stub: emits listener line for held ports, exits 1 for free ports" {
+  # held: stub returns LISTEN row, exit 0
+  LSOF_HOLD_PORTS=3410 run lsof -i :3410 -sTCP:LISTEN -P -n
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Python"*"127.0.0.1:3410"*"(LISTEN)"* ]]
+  # log captured
+  grep -q "lsof -i :3410" "$LSOF_LOG"
+
+  # free: stub exits 1, empty stdout
+  LSOF_HOLD_PORTS="" run lsof -i :9999 -sTCP:LISTEN -P -n
+  [ "$status" -eq 1 ]
+  [ -z "$output" ]
 }
 
 # ── Change 1: runtime state under XDG_STATE_HOME ─────────────────────────────
@@ -200,12 +267,14 @@ load_common() {
 
   export DOCKER_PS_OUTPUT=""
   _claim_isolate_slot
-  # The dead slot 0 is reaped and reclaimed by this run.
-  [ "$ISOLATE_SLOT" = "0" ] || fail "expected to reclaim reaped slot 0, got: $ISOLATE_SLOT"
+  # Slot 0 is reserved for the base stack, so the auto-picker lands on slot 1;
+  # the dead slot 0 is still reaped by the sweep (its ghost project file is
+  # gone), the claim just doesn't land there.
+  [ "$ISOLATE_SLOT" = "1" ] || fail "expected to claim slot 1 (slot 0 reserved), got: $ISOLATE_SLOT"
   # The reap rm -rf'd the ghost slot dir: only apply_isolation (not the claim)
-  # writes a project file, so after a genuine reap+reclaim the ghost project
-  # file must be GONE. (A `run cat`+`!= ghost-proj` check here would pass
-  # vacuously on empty output even if the reap never happened.)
+  # writes a project file, so after a genuine reap the ghost project file must
+  # be GONE. (A `run cat`+`!= ghost-proj` check here would pass vacuously on
+  # empty output even if the reap never happened.)
   [ ! -f "$XDG_STATE_HOME/copilotkit/showcase/slots/0/project" ] \
     || fail "ghost project file survived the reap"
 }
@@ -294,7 +363,9 @@ load_common() {
 
   run bash -euo pipefail -c "source '$COMMON'; _claim_isolate_slot; echo \"CLAIMED=\$ISOLATE_SLOT\""
   [ "$status" -eq 0 ] || fail "script died under set -euo pipefail on legacy slot: $output"
-  [[ "$output" == *"CLAIMED=0"* ]] || fail "dead legacy slot 0 not reaped/reclaimed: $output"
+  # Slot 0 is reserved for the base stack, so the auto-picker lands on slot 1
+  # even though the dead legacy slot 0 was reaped by the sweep.
+  [[ "$output" == *"CLAIMED=1"* ]] || fail "dead legacy slot 0 not reaped (claim should be 1, slot 0 reserved): $output"
 }
 
 @test "claim does NOT reap a kept-stack slot (owner dead, containers live)" {
@@ -333,7 +404,11 @@ load_common() {
   touch -t 202001010000 "$slots/0"   # mtime far beyond the 2h threshold
 
   _claim_isolate_slot
-  [ "$ISOLATE_SLOT" = "0" ] || fail "empty-pid over-age slot 0 leaked; claimed: $ISOLATE_SLOT"
+  # Slot 0 is reserved for the base stack, so the auto-picker lands on slot 1.
+  # The empty-pid over-age slot 0 was still reaped by the sweep (verified by
+  # the slot dir being gone), the claim just doesn't land there.
+  [ "$ISOLATE_SLOT" = "1" ] || fail "empty-pid over-age slot 0 leaked or claim path broken; claimed: $ISOLATE_SLOT"
+  [ ! -d "$slots/0" ] || fail "empty-pid over-age slot 0 was not reaped"
 }
 
 @test "claim does NOT reap a RECENT project-recorded slot whose pid file is garbage (inconclusive)" {
@@ -372,7 +447,11 @@ load_common() {
 
   export DOCKER_PS_OUTPUT=""
   _claim_isolate_slot
-  [ "$ISOLATE_SLOT" = "0" ] || fail "over-age inconclusive-pid slot 0 leaked; claimed: $ISOLATE_SLOT"
+  # Slot 0 is reserved for the base stack, so the auto-picker lands on slot 1.
+  # The over-age inconclusive-pid slot 0 was still reaped by the sweep
+  # (verified by the ghost project record and orphan run dir being gone), the
+  # claim just doesn't land there.
+  [ "$ISOLATE_SLOT" = "1" ] || fail "over-age inconclusive-pid slot 0 leaked or claim path broken; claimed: $ISOLATE_SLOT"
   [ ! -f "$slots/0/project" ] || fail "ghost project record survived the age-fallback reap"
   [ ! -d "$base/runs/truncated-proj" ] || fail "orphan run dir leaked: $base/runs/truncated-proj"
 }
@@ -391,7 +470,10 @@ load_common() {
 
   export DOCKER_PS_OUTPUT=""   # no live containers → project-stale reap
   _claim_isolate_slot
-  [ "$ISOLATE_SLOT" = "0" ] || fail "expected to reclaim reaped slot 0, got: $ISOLATE_SLOT"
+  # Slot 0 is reserved for the base stack, so the auto-picker lands on slot 1.
+  # The dead slot 0 is still reaped by the sweep (verified by the ghost slot
+  # dir and orphan run dir being gone), the claim just doesn't land there.
+  [ "$ISOLATE_SLOT" = "1" ] || fail "expected slot 1 (slot 0 reserved), got: $ISOLATE_SLOT"
   [ ! -f "$base/slots/0/project" ] || fail "ghost slot 0 was not reaped"
   [ ! -d "$base/runs/ghost-proj" ] || fail "orphan run dir leaked: $base/runs/ghost-proj"
   # The sweep released its own lock on the way out.
@@ -419,7 +501,10 @@ load_common() {
   : > "$DOCKER_LOG"
   docker version
   _claim_isolate_slot
-  [ "$ISOLATE_SLOT" = "0" ] || fail "expected to reclaim reaped slot 0, got: $ISOLATE_SLOT"
+  # Slot 0 is reserved for the base stack, so the auto-picker lands on slot 1.
+  # The dead slot 0 is still reaped by the sweep (verified by the ghost project
+  # record and runs dir being gone), the claim just doesn't land there.
+  [ "$ISOLATE_SLOT" = "1" ] || fail "expected slot 1 (slot 0 reserved), got: $ISOLATE_SLOT"
   [ ! -f "$base/slots/0/project" ] || fail "ghost project record survived the reap"
   [ ! -d "$base/runs/stopped-keeper" ] || fail "runs dir survived the reap"
   # The remnant cleanup ran: a project-labeled compose down carrying --volumes.
@@ -550,8 +635,11 @@ load_common() {
 
   export DOCKER_PS_OUTPUT=""
   _claim_isolate_slot
-  # Takeover happened → the sweep ran → the dead slot 0 was reaped + reclaimed.
-  [ "$ISOLATE_SLOT" = "0" ] \
+  # Takeover happened → the sweep ran → the dead slot 0 was reaped. The
+  # auto-picker lands on slot 1 (slot 0 reserved for the base stack); the
+  # absence of the ghost project record is what proves the sweep ran after the
+  # takeover.
+  [ "$ISOLATE_SLOT" = "1" ] \
     || fail "over-age sweep lock not taken over (sweep skipped); claimed: $ISOLATE_SLOT"
   [ ! -f "$slots/0/project" ] \
     || fail "ghost project record survived — sweep did not run after the takeover"
@@ -639,8 +727,12 @@ load_common() {
   _touch_age 600 "$slots/.sweep.lock"      # over the 60s lock threshold
   export DOCKER_PS_OUTPUT=""
   _claim_isolate_slot
-  # Takeover + sweep ran: the dead slot 0 was reaped and reclaimed.
-  [ "$ISOLATE_SLOT" = "0" ] || fail "plain-file lock wedged the sweep; claimed: $ISOLATE_SLOT"
+  # Takeover + sweep ran: the dead slot 0 was reaped. The auto-picker lands on
+  # slot 1 (slot 0 reserved for the base stack); the absence of slot 0's
+  # project file (asserted below alongside the lock-residue check) is what
+  # proves the sweep ran past the plain-file lock.
+  [ "$ISOLATE_SLOT" = "1" ] || fail "plain-file lock wedged the sweep; claimed: $ISOLATE_SLOT"
+  [ ! -f "$slots/0/project" ] || fail "ghost project record survived — sweep did not run"
   # And nothing lock-shaped was left behind (takeover's own lock released).
   [ ! -e "$slots/.sweep.lock" ] || fail "stale plain-file lock (or its takeover) left behind"
   # No takeover tombstone leaked either (same guarantee the dir-lock variant
@@ -673,7 +765,10 @@ load_common() {
   # assertions below.
   chmod u+w "$slots/.sweep.lock.tomb.99999" 2>/dev/null || true
   [ "$status" -eq 0 ] || fail "claim died under set -e on a failed tombstone rm: $output"
-  [[ "$output" == *"CLAIMED=0"* ]] \
+  # Slot 0 is reserved for the base stack, so the auto-picker lands on slot 1.
+  # What this test really pins is that the claim PROCEEDED past the failed
+  # tombstone rm under set -e — landing on any valid slot is sufficient proof.
+  [[ "$output" == *"CLAIMED=1"* ]] \
     || fail "claim did not proceed past the failed tombstone rm: $output"
 }
 
@@ -702,8 +797,10 @@ load_common() {
   chmod u+w "$slots"/.sweep.lock.tomb.* 2>/dev/null || true
   [ "$status" -eq 0 ] || fail "takeover died under set -e on a failed tombstone rm: $output"
   # The takeover completed despite the failed disposal: fresh lock acquired,
-  # sweep ran, dead slot 0 reaped + reclaimed.
-  [[ "$output" == *"CLAIMED=0"* ]] \
+  # sweep ran, dead slot 0 reaped. The auto-picker lands on slot 1 (slot 0
+  # reserved for the base stack); landing on any valid slot proves the sweep
+  # progressed past the failed tombstone disposal.
+  [[ "$output" == *"CLAIMED=1"* ]] \
     || fail "sweep did not run after the failed tombstone disposal: $output"
 }
 
@@ -750,12 +847,13 @@ load_common() {
   [ -d "$rundir" ]  || fail "kept run dir was removed"
 
   # Survival notice content: project name, the 3 +offset host ports, teardown cmd.
-  # Explicit name 'keepme' on slot 0 -> offset 200: aimock 4210, dashboard 3400,
-  # pocketbase 8290.
+  # Slot 0 is reserved for the base stack, so apply_isolation auto-picks slot 1
+  # (offset (1+1)*200 = 400): aimock 4010+400=4410, dashboard 3210+400=3610,
+  # pocketbase 8090+400=8490.
   [[ "$output" == *"keepme"* ]] || fail "notice missing project name: $output"
-  [[ "$output" == *"4210"* ]] || fail "notice missing aimock host port: $output"
-  [[ "$output" == *"3400"* ]] || fail "notice missing dashboard host port: $output"
-  [[ "$output" == *"8290"* ]] || fail "notice missing pocketbase host port: $output"
+  [[ "$output" == *"4410"* ]] || fail "notice missing aimock host port: $output"
+  [[ "$output" == *"3610"* ]] || fail "notice missing dashboard host port: $output"
+  [[ "$output" == *"8490"* ]] || fail "notice missing pocketbase host port: $output"
   [[ "$output" == *"docker compose -p keepme down"* ]] \
     || fail "notice missing literal teardown command: $output"
 
@@ -1292,7 +1390,8 @@ FIXTURE
   [ "$status" -eq 0 ] || fail "fixture script failed: $output"
 
   # Survival: the run dir and slot must still exist after the trap ran.
-  local slotdir="$XDG_STATE_HOME/copilotkit/showcase/slots/0"
+  # Slot 0 is reserved for the base stack, so apply_isolation auto-picks slot 1.
+  local slotdir="$XDG_STATE_HOME/copilotkit/showcase/slots/1"
   local rundir="$XDG_STATE_HOME/copilotkit/showcase/runs/trapkeep"
   [ -d "$rundir" ]  || fail "kept run dir was torn down by the EXIT trap: $output"
   [ -d "$slotdir" ] || fail "kept slot was released by the EXIT trap: $output"
@@ -1309,4 +1408,451 @@ FIXTURE
   _assert_stub_sentinel_logged
   run grep -E -- "(--project-name|-p) trapkeep down" "$DOCKER_LOG"
   [ "$status" -ne 0 ] || fail "EXIT trap composed the kept stack down: $output"
+}
+
+# ── SHOWCASE_ISO_SLOT pinning ────────────────────────────────────────────────
+#
+# When SHOWCASE_ISO_SLOT is exported the picker pins to that slot instead of
+# auto-selecting the first free one. Three behaviors are pinned here:
+#   1. A free pinned slot is claimed verbatim, even if lower-numbered slots are
+#      occupied — the pin BYPASSES auto-selection, doesn't merely seed it.
+#   2. A pinned slot that is currently LIVE refuses to steal it — the die
+#      message names the liveness state so the user can clear it explicitly.
+#   3. Invalid pin values (reserved slot 0, non-numeric, out-of-range) are
+#      rejected with the appropriate validation message BEFORE any slot is
+#      claimed or reaped.
+
+@test "SHOWCASE_ISO_SLOT=9 claims slot 9 even when 1-3 are pre-occupied" {
+  # Pinning bypass: when slots 1, 2, 3 are all live-occupied (live owning PID),
+  # the auto-picker would land on slot 4; with SHOWCASE_ISO_SLOT=9 set the
+  # picker must skip every lower free slot AND every lower live slot and land
+  # on 9 verbatim. Live PID alone (no project file, no docker containers)
+  # makes _slot_liveness return "live" via signal #2 (owning-PID liveness),
+  # so the sweep leaves the pre-seeded slots intact.
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  local n
+  for n in 1 2 3; do
+    mkdir -p "$slots/$n"
+    echo "$$" > "$slots/$n/pid"   # this bats process — definitely alive
+  done
+
+  export SHOWCASE_ISO_SLOT=9
+  _claim_isolate_slot
+  [ "$ISOLATE_SLOT" = "9" ] \
+    || fail "pinned SHOWCASE_ISO_SLOT=9 did not land on slot 9: got $ISOLATE_SLOT"
+  # Offset formula is (slot + 1) * 200 — slot 9 → 2000.
+  [ "$ISOLATE_PORT_OFFSET" = "2000" ] \
+    || fail "pinned slot 9 port offset wrong: expected 2000, got $ISOLATE_PORT_OFFSET"
+  # Slot 9 actually got claimed on disk and the pid file was written by the
+  # common post-claim block.
+  [ -d "$slots/9" ] || fail "slot 9 dir not created on pin"
+  [ -f "$slots/9/pid" ] || fail "slot 9 pid file not written on pin"
+  # Pre-occupied slots survive — the pin must not steal/reap them.
+  for n in 1 2 3; do
+    [ -d "$slots/$n" ] || fail "pre-occupied slot $n was reaped by the pin"
+  done
+}
+
+@test "SHOWCASE_ISO_SLOT pinned to live slot dies with liveness message" {
+  # Live-pin refusal: a pinned slot that is currently live must NOT be stolen.
+  # Seed slot 9 with a live owning PID (this bats process) so _slot_liveness 9
+  # classifies it as "live" via signal #2 — no docker containers needed.
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/9"
+  echo "$$" > "$slots/9/pid"   # this bats process — _slot_liveness → live
+
+  export SHOWCASE_ISO_SLOT=9
+  run _claim_isolate_slot
+  [ "$status" -ne 0 ] || fail "pin to LIVE slot 9 unexpectedly succeeded: $output"
+  [[ "$output" == *"liveness=live"* ]] \
+    || fail "die message does not mention the live liveness state: $output"
+  # The live slot survives — pin must not touch it.
+  [ -d "$slots/9" ] || fail "live slot 9 was reaped by the refused pin"
+  run cat "$slots/9/pid"
+  [ "$status" -eq 0 ] || fail "live slot 9 pid file vanished after refused pin"
+  [[ "$output" == "$$" ]] || fail "live slot 9 pid file mangled: $output"
+}
+
+@test "SHOWCASE_ISO_SLOT validates input (0, foo, 99 all rejected)" {
+  # Three input-validation branches, one test:
+  #   - SHOWCASE_ISO_SLOT=0 → reserved (slot 0 is the base stack)
+  #   - SHOWCASE_ISO_SLOT=foo → non-numeric
+  #   - SHOWCASE_ISO_SLOT=99 → exceeds ISOLATE_MAX_SLOT (45)
+  # All three must die with a message naming the specific failure mode,
+  # BEFORE any slot is claimed (so the slots dir stays empty across all
+  # three calls).
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+
+  # NB: the regex check runs FIRST, so non-numeric values trip the "positive
+  # integer" branch even if they would also be out-of-range. Order: numeric
+  # regex → >=1 → <=ISOLATE_MAX_SLOT.
+
+  # Reserved slot 0.
+  SHOWCASE_ISO_SLOT=0 run _claim_isolate_slot
+  [ "$status" -ne 0 ] || fail "SHOWCASE_ISO_SLOT=0 unexpectedly succeeded: $output"
+  [[ "$output" == *"slot 0 is reserved"* ]] \
+    || fail "SHOWCASE_ISO_SLOT=0 die message does not say 'slot 0 is reserved': $output"
+
+  # Non-numeric.
+  SHOWCASE_ISO_SLOT=foo run _claim_isolate_slot
+  [ "$status" -ne 0 ] || fail "SHOWCASE_ISO_SLOT=foo unexpectedly succeeded: $output"
+  [[ "$output" == *"positive integer"* ]] \
+    || fail "SHOWCASE_ISO_SLOT=foo die message does not mention 'positive integer': $output"
+
+  # Out of range (ISOLATE_MAX_SLOT=45, so 99 is over).
+  SHOWCASE_ISO_SLOT=99 run _claim_isolate_slot
+  [ "$status" -ne 0 ] || fail "SHOWCASE_ISO_SLOT=99 unexpectedly succeeded: $output"
+  [[ "$output" == *"exceeds ISOLATE_MAX_SLOT=45"* ]] \
+    || fail "SHOWCASE_ISO_SLOT=99 die message does not mention 'exceeds ISOLATE_MAX_SLOT=45': $output"
+
+  # None of the rejected calls claimed a slot — the slots dir contains no
+  # numeric entries (the sweep may have created/removed .sweep.lock-shaped
+  # entries, but no integer slot dirs).
+  if [ -d "$slots" ]; then
+    run bash -c "ls -A '$slots' | grep -E '^[0-9]+\$' || true"
+    [ -z "$output" ] || fail "rejected pins claimed a slot anyway: $output"
+  fi
+}
+
+# ── Port-probe and stale-reap behavior (MT3.2c) ──────────────────────────────
+#
+# Four additional behaviors pinned here:
+#   #4. Pinned-path reap-and-retry: a stale slot at the pinned number is reaped
+#       and the slot dir re-mkdir'd by the picker on the same call.
+#   #5. Post-shift _slot_offset_ports regression: slot 8's dashboard port is
+#       now 5010 (3210 + 1800), NOT 5000 (the pre-shift 3200 + 1800). The
+#       regression test pins both halves: 5010 present, 5000 absent.
+#   #6. Auto-pick port-probe skip: a slot whose dashboard port is held by a
+#       FOREIGN process (not docker) is skipped — the picker rmdirs the
+#       provisional slot dir and advances to the next slot.
+#   #7. Own-project docker-listener filter: a live slot's project sees a
+#       com.docker.* listener on one of its ports as the slot's OWN binding
+#       (treated as free); a non-docker process name on the same port is NOT
+#       filtered (treated as held). This is the port-probe path that lets a
+#       --keep'd stack's own docker-proxy listener not be re-flagged as a
+#       foreign hold.
+
+@test "SHOWCASE_ISO_SLOT pinned-path reaps stale slot and re-claims successfully" {
+  # Stale-reap on pinned: pre-create slot 9 with a project file but NO pid
+  # file — _slot_liveness classifies this as "stale" (has_proj=true,
+  # pid_file_present=false → stale). The pinned branch should reap-and-retry
+  # (rm -rf the slot entry, then mkdir it fresh) and write our pid into the
+  # rebuilt slot via the common post-claim block.
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/9"
+  echo "stale-proj" > "$slots/9/project"   # project recorded, no pid file → stale
+
+  export DOCKER_PS_OUTPUT=""   # no live containers for stale-proj
+  export SHOWCASE_ISO_SLOT=9
+  _claim_isolate_slot
+  [ "$ISOLATE_SLOT" = "9" ] \
+    || fail "pinned stale slot 9 did not re-claim: got $ISOLATE_SLOT"
+  # The reap removed the original slot dir + project file; the common
+  # post-claim block re-mkdir'd it and wrote our pid. Prove BOTH halves:
+  [ -f "$slots/9/pid" ] || fail "post-reap pid file missing on slot 9"
+  run cat "$slots/9/pid"
+  [ "$status" -eq 0 ] || fail "post-reap pid file unreadable on slot 9"
+  [[ "$output" == "$$" ]] \
+    || fail "post-reap pid file does not contain reaper's pid: got $output, expected $$"
+  # The stale project file should be gone (reap rm -rf'd it; the claim does
+  # NOT re-write a project file — only apply_isolation does).
+  [ ! -f "$slots/9/project" ] \
+    || fail "stale project file survived the reap-and-retry: $(cat "$slots/9/project")"
+}
+
+@test "_slot_offset_ports 8 includes 5010 and excludes 5000 (port-shift regression)" {
+  # Pre-shift the dashboard base was 3200, so slot 8 (offset 1800) bound 5000.
+  # Post-shift the dashboard base is 3210, so slot 8 binds 5010. Pin BOTH halves
+  # of the regression: 5010 must be present (the new port emitted by the offset
+  # function), AND 5000 must be absent (a stale assumption that would let a
+  # foreign 5000 binder collide with slot 8 invisibly). One assertion without
+  # the other lets a half-revert (e.g. emitting BOTH 5000 and 5010) slip past.
+  load_common
+  run _slot_offset_ports 8
+  [ "$status" -eq 0 ] || fail "_slot_offset_ports 8 failed: $output"
+  [[ "$output" == *"5010"* ]] \
+    || fail "_slot_offset_ports 8 did not emit dashboard port 5010 (post-shift): $output"
+  ! [[ "$output" == *"5000"* ]] \
+    || fail "_slot_offset_ports 8 still emits pre-shift dashboard port 5000: $output"
+}
+
+@test "auto-pick skips slot 1 when its dashboard port is held by a foreign process" {
+  # Auto-pick port-probe skip: with no SHOWCASE_ISO_SLOT set, the picker walks
+  # 1..ISOLATE_MAX_SLOT. Slot 1's dashboard port (3210 + 400 = 3610) is held
+  # by a non-docker process (Python — not subject to the own-project filter,
+  # which only fires for docker/com.docker process names). The picker must
+  # mkdir slot 1, see the port held, rmdir slot 1, and advance to slot 2.
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  export LSOF_HOLD_PORTS="3610"
+  export LSOF_HOLD_COMMAND="Python"
+
+  _claim_isolate_slot
+  [ "$ISOLATE_SLOT" = "2" ] \
+    || fail "auto-pick did not skip port-held slot 1: claimed $ISOLATE_SLOT"
+  # Slot 1 was rmdir'd after the port probe failed; slot 2 was claimed.
+  [ ! -d "$slots/1" ] \
+    || fail "port-held slot 1 dir survived the picker's rmdir"
+  [ -d "$slots/2" ] || fail "slot 2 was not claimed"
+  [ -f "$slots/2/pid" ] || fail "slot 2 pid file not written"
+}
+
+@test "_slot_ports_free treats own-project docker listeners as free, but not Python" {
+  # Own-project filter (port-probe path): a docker / com.docker listener on a
+  # port owned by a slot whose project is recorded and live is treated as the
+  # slot's OWN binding (returns 0 = "all free"). The same port held by a
+  # non-docker process name is NOT filtered (returns 1 = "held"). This is
+  # what lets a --keep'd stack's own docker-proxy not be re-flagged as a
+  # foreign hold.
+  #
+  # The brief originally proposed exercising this via the pinned-path's
+  # EEXIST branch with a live slot, but that path DIES on a live pin before
+  # reaching the port probe — so the own-project filter is not observable
+  # from _claim_isolate_slot directly. We test _slot_ports_free in isolation,
+  # which is the function that actually implements the filter.
+  #
+  # Pinning slot 8 as live: write the project file + a live pid ($$). Slot 8's
+  # dashboard port post-shift is 3210 + 1800 = 5010.
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/8"
+  echo "iso8-proj" > "$slots/8/project"
+  echo "$$" > "$slots/8/pid"   # _slot_liveness 8 → live (pid live, no containers needed)
+
+  # Case A: docker listener on slot 8's dashboard port → filtered as own-project.
+  export DOCKER_PS_OUTPUT=""   # no docker containers; pid-liveness still wins
+  export LSOF_HOLD_PORTS="5010"
+  export LSOF_HOLD_COMMAND="com.docker.backend"
+  run _slot_ports_free 8
+  [ "$status" -eq 0 ] \
+    || fail "_slot_ports_free 8 should treat com.docker.backend on own port as free, got status=$status output=$output"
+
+  # Case B: same port held by Python (non-docker) → NOT filtered, returns 1.
+  export LSOF_HOLD_COMMAND="Python"
+  run _slot_ports_free 8
+  [ "$status" -ne 0 ] \
+    || fail "_slot_ports_free 8 should treat Python listener on own port as held (foreign), got status=0 output=$output"
+  [[ "$output" == *"Slot 8 port 5010 held by Python"* ]] \
+    || fail "_slot_ports_free 8 did not emit the foreign-hold info line for Python: $output"
+}
+
+# ── Composite tests (MT3.2d): _slot_state axes, bin/showcase slots, concurrent claim ──
+#
+# Three additional behaviors pinned here:
+#   #8.  _slot_state emits one pipe-delimited line carrying ALL 7 axes (slot,
+#        dir, pid, liveness, ports, offset, project) for a populated slot — the
+#        wire format that `bin/showcase slots` parses.
+#   #9.  `bin/showcase slots` enumerates ALL 46 slots (0..ISOLATE_MAX_SLOT=45)
+#        with a header row and the special "showcase (base)" project label for
+#        slot 0 — the table contract the CLI exposes to operators.
+#   #10. Two concurrent `_claim_isolate_slot` invocations land on DISTINCT
+#        slots — atomic mkdir is the synchronization primitive; no two
+#        claimants ever end up owning the same slot.
+
+@test "_slot_state 5 reports all axes for a live populated slot" {
+  # The wire format: one pipe-delimited line of 7 fields, exactly as
+  # cmd-slots.sh's `IFS='|' read -r slot dir pid liveness ports offset project`
+  # consumes them. Seed slot 5 with a project record AND a live owning pid
+  # (this bats process) so _slot_liveness 5 returns "live" via signal #2 — no
+  # docker containers needed. Slot 5's offset is (5+1)*200 = 1200.
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/5"
+  echo "iso5-proj" > "$slots/5/project"
+  echo "$$" > "$slots/5/pid"   # this bats process — _slot_liveness → live
+
+  # No held ports → _slot_ports_free returns 0 → ports="free".
+  export LSOF_HOLD_PORTS=""
+  run _slot_state 5
+  [ "$status" -eq 0 ] || fail "_slot_state 5 failed: $output"
+  # Exactly one output line.
+  [ "${#lines[@]}" -eq 1 ] \
+    || fail "_slot_state emitted ${#lines[@]} lines, expected 1: $output"
+
+  # Parse the 7 pipe-delimited axes. `read -ra fields` on a single line under
+  # IFS='|' gives one field per axis — independent of bats's line-splitting.
+  local -a fields
+  IFS='|' read -ra fields <<< "$output"
+  [ "${#fields[@]}" -eq 7 ] \
+    || fail "_slot_state emitted ${#fields[@]} fields, expected 7 (slot|dir|pid|liveness|ports|offset|project): $output"
+
+  [ "${fields[0]}" = "5" ]          || fail "axis[0] slot wrong: got '${fields[0]}', expected '5'"
+  [ "${fields[1]}" = "present" ]    || fail "axis[1] dir wrong: got '${fields[1]}', expected 'present'"
+  [ "${fields[2]}" = "$$" ]         || fail "axis[2] pid wrong: got '${fields[2]}', expected '$$'"
+  [ "${fields[3]}" = "live" ]       || fail "axis[3] liveness wrong: got '${fields[3]}', expected 'live'"
+  [ "${fields[4]}" = "free" ]       || fail "axis[4] ports wrong: got '${fields[4]}', expected 'free' (no LSOF_HOLD_PORTS)"
+  [ "${fields[5]}" = "1200" ]       || fail "axis[5] offset wrong: got '${fields[5]}', expected '1200' (=(5+1)*200)"
+  [ "${fields[6]}" = "iso5-proj" ]  || fail "axis[6] project wrong: got '${fields[6]}', expected 'iso5-proj'"
+}
+
+@test "bin/showcase slots prints all 46 slots with header and special slot 0 project label" {
+  # End-to-end contract for `showcase slots`: with no slots pre-claimed, the
+  # default fixed-width table emits one header row + 46 data rows (slots
+  # 0..ISOLATE_MAX_SLOT=45), and slot 0's project column shows the special
+  # "showcase (base)" label that cmd-slots.sh injects (the on-disk record is
+  # never set for slot 0 — it's reserved for the base stack).
+  #
+  # XDG_STATE_HOME is already set to the per-test scratch dir by setup(), so
+  # the slots dir starts empty and every row reports dir=absent.
+  # The docker/lsof stubs in $STUB_DIR are on PATH and stay on PATH for the
+  # child shell, so no real docker/lsof is hit; _slot_liveness short-circuits
+  # to "inconclusive" for absent dirs (no docker call).
+
+  # bin/showcase lives at the repo's showcase/bin/showcase, two dirs up from
+  # this test file (scripts/__tests__/ → showcase/, then bin/showcase).
+  run bash "$BATS_TEST_DIRNAME/../../bin/showcase" slots
+  [ "$status" -eq 0 ] || fail "bin/showcase slots failed: $output"
+
+  # ≥47 lines: 1 header + 46 data rows.
+  [ "${#lines[@]}" -ge 47 ] \
+    || fail "bin/showcase slots emitted ${#lines[@]} lines, expected >=47 (1 header + 46 rows): $output"
+
+  # Header: first non-blank line starts with "SLOT" (the fixed-width table's
+  # header row, per cmd-slots.sh: `printf '%-4s ... "SLOT" "DIR" ...`).
+  local first_nonblank=""
+  local line
+  for line in "${lines[@]}"; do
+    if [ -n "${line// /}" ]; then
+      first_nonblank="$line"
+      break
+    fi
+  done
+  [[ "$first_nonblank" == SLOT* ]] \
+    || fail "first non-blank line is not the SLOT header: '$first_nonblank'"
+
+  # Slot 0's special project label "showcase (base)" must appear (cmd-slots.sh
+  # injects it for slot 0 regardless of the on-disk record).
+  [[ "$output" == *"showcase (base)"* ]] \
+    || fail "slot 0 project label 'showcase (base)' missing: $output"
+
+  # Exactly 46 data rows: lines starting with a digit + whitespace (the
+  # printf format opens with %-4s for the slot number, so data rows start
+  # with a digit followed by spaces; the header line starts with "SLOT").
+  local data_rows=0
+  for line in "${lines[@]}"; do
+    if [[ "$line" =~ ^[0-9]+[[:space:]] ]]; then
+      data_rows=$((data_rows + 1))
+    fi
+  done
+  [ "$data_rows" -eq 46 ] \
+    || fail "expected 46 data rows (slots 0..45), got $data_rows: $output"
+}
+
+@test "concurrent _claim_isolate_slot calls claim distinct slots (no double-claim)" {
+  # Atomic-mkdir lock under concurrency: two _claim_isolate_slot invocations
+  # running simultaneously must NEVER both land on the same slot. Bats runs
+  # in a single process so we spawn the two claims as background subshells
+  # (`&`) and wait for both — the atomic-mkdir lock in _claim_isolate_slot
+  # is the synchronization primitive. Slots 1-8 are pre-occupied with live
+  # owning PIDs so the auto-picker is forced to evaluate slots 9 and 10.
+  load_common
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  local n
+  for n in 1 2 3 4 5 6 7 8; do
+    mkdir -p "$slots/$n"
+    echo "$$" > "$slots/$n/pid"   # this bats process — definitely alive
+  done
+
+  # No held ports for any slot's offset range → _slot_ports_free returns 0
+  # for whichever slot the picker probes.
+  export LSOF_HOLD_PORTS=""
+  export DOCKER_PS_OUTPUT=""
+
+  # Spawn two subshell claims concurrently. Each subshell writes its result
+  # (the claimed ISOLATE_SLOT and its own subshell pid) to a file the parent
+  # can read after wait(); ISOLATE_SLOT itself is a variable inside each
+  # subshell and doesn't propagate back to the parent. The filesystem state
+  # under $slots/ is the real source of truth for "did they double-claim".
+  local out1="$BATS_TEST_TMPDIR/claim1.out"
+  local out2="$BATS_TEST_TMPDIR/claim2.out"
+  (
+    _claim_isolate_slot
+    printf 'slot=%s pid=%s\n' "$ISOLATE_SLOT" "$BASHPID" > "$out1"
+  ) &
+  local p1=$!
+  # Tiny stagger so both subshells exist before the second's mkdir loop —
+  # without this the second can finish before the first ever enters the loop,
+  # serializing them (still correct, but doesn't exercise the concurrent path).
+  sleep 0.05
+  (
+    _claim_isolate_slot
+    printf 'slot=%s pid=%s\n' "$ISOLATE_SLOT" "$BASHPID" > "$out2"
+  ) &
+  local p2=$!
+  wait "$p1" || fail "subshell 1 (_claim_isolate_slot) failed"
+  wait "$p2" || fail "subshell 2 (_claim_isolate_slot) failed"
+
+  # Both wrote their result files.
+  [ -f "$out1" ] || fail "subshell 1 did not produce $out1"
+  [ -f "$out2" ] || fail "subshell 2 did not produce $out2"
+
+  # Filesystem proof: BOTH slots 9 AND 10 exist with pid files. The picker
+  # walks 1..ISOLATE_MAX_SLOT, skips the live-occupied 1-8 (each carries
+  # this bats process's pid → liveness=live), and the two concurrent claims
+  # land on the next two free slots.
+  [ -d "$slots/9" ]  || fail "slot 9 was not claimed (no concurrent landing): $(ls -1 "$slots")"
+  [ -d "$slots/10" ] || fail "slot 10 was not claimed (no concurrent landing): $(ls -1 "$slots")"
+  [ -f "$slots/9/pid" ]  || fail "slot 9 has no pid file (claim did not write owner): $(ls -1 "$slots/9")"
+  [ -f "$slots/10/pid" ] || fail "slot 10 has no pid file (claim did not write owner): $(ls -1 "$slots/10")"
+
+  # No double-claim: the two subshells reported DIFFERENT slot numbers in
+  # their own ISOLATE_SLOT — proving they followed disjoint paths through the
+  # auto-pick loop. (The pid files themselves carry $$ — the parent bats PID,
+  # which a subshell inherits unchanged — so identical pid file contents is
+  # NOT evidence of double-claim; the slot-number divergence is.)
+  local result1 result2
+  result1="$(cat "$out1" 2>/dev/null || true)"
+  result2="$(cat "$out2" 2>/dev/null || true)"
+  local slot1 slot2
+  slot1="$(printf '%s' "$result1" | sed -E 's/^slot=([0-9]+).*/\1/')"
+  slot2="$(printf '%s' "$result2" | sed -E 's/^slot=([0-9]+).*/\1/')"
+  [ -n "$slot1" ] || fail "subshell 1 did not record a slot: result1='$result1'"
+  [ -n "$slot2" ] || fail "subshell 2 did not record a slot: result2='$result2'"
+  [ "$slot1" != "$slot2" ] \
+    || fail "subshell 1 and subshell 2 both claimed slot $slot1 (double-claim): result1='$result1' result2='$result2'"
+
+  # Slot-numbers must each be 9 OR 10 (the two slots the auto-picker reaches
+  # after skipping the live-occupied 1-8).
+  case "$slot1" in 9|10) ;; *) fail "subshell 1 claimed unexpected slot $slot1 (expected 9 or 10): $result1" ;; esac
+  case "$slot2" in 9|10) ;; *) fail "subshell 2 claimed unexpected slot $slot2 (expected 9 or 10): $result2" ;; esac
+}
+
+@test "_slot_state emits ports=? when lsof is unavailable" {
+  # Passive-inspector forgiveness: `bin/showcase slots` calls _slot_state for
+  # every present slot, and _slot_state's port-probe goes through
+  # _slot_ports_free — which dies hard when lsof is missing. That die is the
+  # right contract for the picker (--isolate genuinely needs lsof), but it
+  # makes the read-only `slots` table unusable on lsof-less hosts. Fix:
+  # _slot_state short-circuits to ports="?" when lsof is unavailable, leaving
+  # _slot_ports_free's die intact for the picker path.
+  load_common
+  # Seed slot 0 as present so _slot_state takes the probe branch (dir=absent
+  # would leave ports="-" and bypass the lsof check entirely).
+  local slots="$XDG_STATE_HOME/copilotkit/showcase/slots"
+  mkdir -p "$slots/0"
+
+  # Hide the stub lsof by pointing PATH at an empty dir — done AFTER
+  # load_common so the harness's stub wiring is already in place and we are
+  # specifically simulating "lsof not installed".
+  local empty_bin="$BATS_TEST_TMPDIR/no-lsof-bin"
+  mkdir -p "$empty_bin"
+  local saved_path="$PATH"
+  PATH="$empty_bin"
+
+  # _slot_state must not die; the ports field (axis #5, between the 4th and
+  # 5th pipes) must be "?".
+  local state
+  state=$(_slot_state 0)
+  local rc=$?
+
+  PATH="$saved_path"
+
+  [ "$rc" -eq 0 ] || fail "_slot_state 0 failed (rc=$rc) with lsof unavailable: $state"
+  [ -n "$state" ] || fail "_slot_state 0 emitted no output with lsof unavailable"
+  [[ "$state" == *"|?|"* ]] \
+    || fail "_slot_state did not degrade to ports='?' when lsof was unavailable: $state"
 }

--- a/showcase/scripts/cli/_common.sh
+++ b/showcase/scripts/cli/_common.sh
@@ -149,6 +149,8 @@ ISOLATE_STALE_THRESHOLD=7200  # 2 hours in seconds — slot-age fallback
 # disable stale reaping for the full 2-hour SLOT threshold — give the lock its
 # own, much shorter staleness threshold.
 ISOLATE_SWEEP_LOCK_STALE_THRESHOLD=60  # seconds
+# Maximum slot index for --isolate (0 reserved for base stack; 1..N for isolated runs).
+ISOLATE_MAX_SLOT=45
 
 # _file_mtime <path> — epoch mtime of a path, or empty when it cannot be
 # stat'ed (vanished concurrently, permissions). Callers must treat a
@@ -252,9 +254,12 @@ _release_sweep_lock() {
   fi
 }
 
-# Claim an isolation slot using atomic mkdir. Slots start at 0 and increment.
-# Each slot dir contains a "pid" file for stale-detection. The port offset is
-# (slot + 1) * 200, so slot 0 → +200, slot 1 → +400, etc.
+# Claim an isolation slot using atomic mkdir. Slots 1..ISOLATE_MAX_SLOT are
+# usable for --isolate runs; slot 0 is reserved for the base (non-isolate)
+# stack. Each slot dir contains a "pid" file for stale-detection. The port
+# offset is (slot + 1) * 200, so slot 1 → +400, slot 2 → +600, etc. If
+# SHOWCASE_ISO_SLOT is set, the picker pins to that slot; otherwise it
+# auto-picks the first free slot in 1..ISOLATE_MAX_SLOT.
 _claim_isolate_slot() {
   mkdir -p "$ISOLATE_SLOT_DIR"
 
@@ -337,20 +342,140 @@ _claim_isolate_slot() {
     _release_sweep_lock "$sweep_lock"
   fi
 
-  # Claim the first available slot (mkdir is atomic — if it succeeds, we own it)
-  local n=0
-  while true; do
-    if mkdir "$ISOLATE_SLOT_DIR/$n" 2>/dev/null; then
-      ISOLATE_SLOT="$n"
-      echo "$$" > "$ISOLATE_SLOT_DIR/$n/pid"
-      ISOLATE_PORT_OFFSET=$(( (n + 1) * 200 ))
+  if [ -n "${SHOWCASE_ISO_SLOT:-}" ]; then
+    # Pinned path
+    local pinned="$SHOWCASE_ISO_SLOT"
+    [[ "$pinned" =~ ^[0-9]+$ ]] || die "SHOWCASE_ISO_SLOT must be a positive integer, got: $pinned"
+    [ "$pinned" -ge 1 ] || die "slot 0 is reserved for the base stack — use 1-$ISOLATE_MAX_SLOT"
+    [ "$pinned" -le "$ISOLATE_MAX_SLOT" ] || die "SHOWCASE_ISO_SLOT=$pinned exceeds ISOLATE_MAX_SLOT=$ISOLATE_MAX_SLOT"
+
+    local slot_dir="$ISOLATE_SLOT_DIR/$pinned"
+    if mkdir "$slot_dir" 2>/dev/null; then
+      :   # fresh claim, fall through to port probe
+    else
+      # EEXIST: consult liveness
+      local liveness
+      liveness=$(_slot_liveness "$pinned")
+      if [ "$liveness" = "live" ]; then
+        # Identify the live axis for the message
+        local axis="containers/pid"
+        die "Slot $pinned is already in use (liveness=$liveness, $axis) — pick a different SHOWCASE_ISO_SLOT or clear it first"
+      fi
+      # stale or inconclusive: reap and retry once
+      local pinned_entry="$ISOLATE_SLOT_DIR/$pinned"
+      local pinned_proj
+      pinned_proj="$(cat "$pinned_entry/project" 2>/dev/null || true)"
+      _reap_isolate_slot "$pinned_entry" "$pinned_proj" || true
+      mkdir "$slot_dir" 2>/dev/null || die "Slot $pinned could not be reclaimed after reap — check $slot_dir manually"
+    fi
+    # Port-probe
+    if ! _slot_ports_free "$pinned"; then
+      rmdir "$slot_dir" 2>/dev/null || true
+      die "Slot $pinned ports are held by a foreign process — see info messages above; clear conflicts or pick a different SHOWCASE_ISO_SLOT"
+    fi
+    ISOLATE_SLOT="$pinned"
+  else
+    # Auto-pick path: loop 1..ISOLATE_MAX_SLOT (slot 0 reserved)
+    local n=1
+    while [ "$n" -le "$ISOLATE_MAX_SLOT" ]; do
+      local slot_dir="$ISOLATE_SLOT_DIR/$n"
+      if mkdir "$slot_dir" 2>/dev/null; then
+        if _slot_ports_free "$n"; then
+          ISOLATE_SLOT="$n"
+          break
+        else
+          rmdir "$slot_dir" 2>/dev/null || true
+          info "Slot $n ports held, trying next"
+          # Benign race: between our rmdir and the next iteration's mkdir attempt, a concurrent
+          # claimant can mkdir this same slot dir. That's fine — mkdir is the
+          # atomic synchronization point, so only one process can hold a given
+          # slot at a time. The concurrent claimant wins; we advance to n+1 and
+          # no double-claim occurs. Port-probe and ownership-write (pid file) are
+          # also per-slot, so there is no cross-claimant corruption under load.
+        fi
+      fi
+      n=$((n + 1))
+    done
+    [ -n "${ISOLATE_SLOT:-}" ] || die "No isolation slots available (1-$ISOLATE_MAX_SLOT exhausted)"
+  fi
+
+  # Common post-claim
+  echo "$$" > "$ISOLATE_SLOT_DIR/$ISOLATE_SLOT/pid"
+  ISOLATE_PORT_OFFSET=$(( (ISOLATE_SLOT + 1) * 200 ))
+  return 0
+}
+
+# Classify a single isolation slot as live | stale | inconclusive — pure
+# classification, no reaping, no info logging. Shared between
+# _sweep_isolate_slots (which reaps stale slots) and the picker (which avoids
+# binding to live slots). Always prints exactly one word to stdout and exits 0.
+#
+# Signals (in order, matching the sweeper's documented staleness contract):
+#   1. Compose-project liveness — live containers under the slot's recorded
+#      compose project → live. Docker-ps failure → inconclusive (warn and
+#      leave it alone, same as the sweeper).
+#   2. Owning-PID liveness — pid file present + numeric + kill -0 succeeds
+#      → live. Numeric pid but kill -0 fails → stale.
+#   3. Project recorded + no pid file at all → stale (claim writes the pid
+#      file BEFORE the project record, so missing pid means owner state is
+#      genuinely gone).
+#   4. Age fallback — pid check inconclusive (pid file missing on a
+#      project-less legacy slot, OR present-but-empty/non-numeric on any
+#      slot) AND age > ISOLATE_STALE_THRESHOLD → stale.
+#   5. Otherwise → inconclusive (slot dir vanished mid-check, fresh slot
+#      whose pid write hasn't landed yet, etc.).
+_slot_liveness() {
+  local slot="${1:?slot required}"
+  local slot_entry="$ISOLATE_SLOT_DIR/$slot"
+  if [ ! -d "$slot_entry" ]; then
+    printf 'inconclusive\n'
+    return 0
+  fi
+  local slot_proj has_proj=false
+  slot_proj="$(cat "$slot_entry/project" 2>/dev/null || true)"
+  if [ -n "$slot_proj" ]; then
+    has_proj=true
+    local live_containers
+    if ! live_containers="$(docker ps -q --filter "label=com.docker.compose.project=$slot_proj" 2>/dev/null)"; then
+      warn "Cannot verify liveness of slot $slot (docker ps failed) — leaving it alone"
+      printf 'inconclusive\n'
       return 0
     fi
-    n=$((n + 1))
-    if [ "$n" -gt 45 ]; then
-      die "No isolation slots available (0-45 exhausted). Check $ISOLATE_SLOT_DIR/"
+    if [ -n "$live_containers" ]; then
+      printf 'live\n'
+      return 0
     fi
-  done
+  fi
+  local slot_pid_file="$slot_entry/pid"
+  local slot_pid="" pid_file_present=false
+  if [ -f "$slot_pid_file" ]; then
+    pid_file_present=true
+    slot_pid="$(cat "$slot_pid_file" 2>/dev/null || true)"
+  fi
+  if [[ "$slot_pid" =~ ^[0-9]+$ ]]; then
+    if kill -0 "$slot_pid" 2>/dev/null; then
+      printf 'live\n'
+      return 0
+    fi
+    printf 'stale\n'
+    return 0
+  fi
+  if [ "$has_proj" = true ] && [ "$pid_file_present" = false ]; then
+    printf 'stale\n'
+    return 0
+  fi
+  local slot_mtime
+  slot_mtime="$(_file_mtime "$slot_entry")"
+  if [[ "$slot_mtime" =~ ^[0-9]+$ ]]; then
+    local slot_age
+    slot_age=$(( $(date +%s) - slot_mtime ))
+    if [ "$slot_age" -gt "$ISOLATE_STALE_THRESHOLD" ]; then
+      printf 'stale\n'
+      return 0
+    fi
+  fi
+  printf 'inconclusive\n'
+  return 0
 }
 
 # Sweep stale slots. Caller (_claim_isolate_slot) MUST hold .sweep.lock.
@@ -397,22 +522,21 @@ _sweep_isolate_slots() {
     [ -d "$sweep_lock" ] && touch -c "$sweep_lock" 2>/dev/null || true
     local slot_name
     slot_name="$(basename "$slot_entry")"
+    local liveness
+    liveness="$(_slot_liveness "$slot_name")"
+    if [ "$liveness" = "live" ] || [ "$liveness" = "inconclusive" ]; then
+      # `live` → in use (running containers or live owning PID). `inconclusive`
+      # → docker-ps failure (already warned by _slot_liveness), or a slot dir
+      # that vanished mid-check, or a fresh-but-not-yet-aged slot whose pid
+      # write hasn't landed. Either way: leave it alone.
+      continue
+    fi
+    # Stale. Re-derive the evidence to emit the exact reason in the info line
+    # before reaping. The reads here mirror _slot_liveness — kept in the
+    # sweeper so the helper stays purely classifying.
     local slot_proj has_proj=false
     slot_proj="$(cat "$slot_entry/project" 2>/dev/null || true)"
-    if [ -n "$slot_proj" ]; then
-      has_proj=true
-      local live_containers
-      if ! live_containers="$(docker ps -q --filter "label=com.docker.compose.project=$slot_proj" 2>/dev/null)"; then
-        warn "Cannot verify liveness of slot $slot_name (docker ps failed) — leaving it alone"
-        continue
-      fi
-      if [ -n "$live_containers" ]; then
-        # Live containers → in use (covers --keep'd stacks whose owner exited).
-        continue
-      fi
-      # Zero live containers is inconclusive (project file is written before
-      # the containers start) — fall through to the owning-PID check.
-    fi
+    [ -n "$slot_proj" ] && has_proj=true
     local slot_pid_file="$slot_entry/pid"
     local slot_pid="" pid_file_present=false
     if [ -f "$slot_pid_file" ]; then
@@ -420,10 +544,6 @@ _sweep_isolate_slots() {
       slot_pid="$(cat "$slot_pid_file" 2>/dev/null || true)"
     fi
     if [[ "$slot_pid" =~ ^[0-9]+$ ]]; then
-      if kill -0 "$slot_pid" 2>/dev/null; then
-        # Live owning PID always protects the slot.
-        continue
-      fi
       info "Attempting to reclaim stale slot $slot_name (PID $slot_pid dead)"
       _reap_isolate_slot "$slot_entry" "$slot_proj"
       continue
@@ -474,6 +594,151 @@ _release_isolate_slot() {
     rm -rf "$ISOLATE_SLOT_DIR/$ISOLATE_SLOT" 2>/dev/null || true
   fi
   ISOLATE_SLOT=""
+}
+
+# Print every host port that the given isolation slot will bind, one per line.
+# Includes all slug ports from PORTS_FILE and the four infra base ports.
+# Each output port = base + (slot+1)*200.
+_slot_offset_ports() {
+  local slot="${1:?slot required}"
+
+  # Validate: must be a non-negative integer
+  if ! printf '%s' "$slot" | grep -qE '^[0-9]+$'; then
+    die "_slot_offset_ports: slot must be a non-negative integer, got: $slot"
+  fi
+  if [ "$slot" -gt "$ISOLATE_MAX_SLOT" ]; then
+    die "_slot_offset_ports: slot $slot exceeds ISOLATE_MAX_SLOT ($ISOLATE_MAX_SLOT)"
+  fi
+
+  local offset=$(( (slot + 1) * 200 ))
+  local infra_ports=(4010 8090 3210 8081)
+
+  # Slug ports from PORTS_FILE
+  local port_values
+  if command -v jq &>/dev/null; then
+    port_values="$(jq -r 'to_entries[] | .value' "$PORTS_FILE" 2>/dev/null)"
+  else
+    port_values="$(grep -o '"[^"]*"[[:space:]]*:[[:space:]]*[0-9]*' "$PORTS_FILE" | sed 's/.*:[[:space:]]*//')"
+  fi
+
+  while IFS= read -r base; do
+    [ -z "$base" ] && continue
+    printf '%d\n' $(( base + offset ))
+  done <<< "$port_values"
+
+  # Infra ports
+  for base in "${infra_ports[@]}"; do
+    printf '%d\n' $(( base + offset ))
+  done
+}
+
+# _slot_ports_free <slot> — probe every port the slot would bind for non-self
+# listeners. Returns 0 if all ports are free (or only held by this slot's own
+# compose project), 1 if any port is held by a foreign process. Emits one
+# `info` line per held port. Requires lsof (matches cmd-doctor.sh convention).
+_slot_ports_free() {
+  local slot="${1:?slot required}"
+  if ! command -v lsof &>/dev/null; then
+    die "--isolate requires lsof; install it"
+  fi
+
+  local slot_proj=""
+  local slot_proj_file="$ISOLATE_SLOT_DIR/$slot/project"
+  if [ -f "$slot_proj_file" ]; then
+    slot_proj="$(cat "$slot_proj_file" 2>/dev/null || true)"
+  fi
+
+  local liveness=""
+  local any_held=0
+  local port
+  while IFS= read -r port; do
+    [ -z "$port" ] && continue
+    local listeners
+    listeners="$(lsof -i :"$port" -sTCP:LISTEN -P -n 2>/dev/null | tail -n +2 || true)"
+    [ -z "$listeners" ] && continue
+
+    local line
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      local proc_name
+      proc_name="$(printf '%s\n' "$line" | awk '{print $1}')"
+      # Own-project filter: a docker/com.docker listener on a slot whose own
+      # compose project is recorded and live is treated as the slot's own
+      # binding, not a foreign hold.
+      if printf '%s' "$proc_name" | grep -qiE 'docker|com\.docker'; then
+        if [ -n "$slot_proj" ]; then
+          if [ -z "$liveness" ]; then
+            liveness="$(_slot_liveness "$slot")"
+          fi
+          if [ "$liveness" = "live" ]; then
+            continue
+          fi
+        fi
+      fi
+      info "Slot $slot port $port held by $proc_name"
+      any_held=1
+    done <<< "$listeners"
+  done < <(_slot_offset_ports "$slot")
+
+  if [ "$any_held" -eq 0 ]; then
+    return 0
+  fi
+  return 1
+}
+
+# _slot_state <slot> — emit one pipe-delimited line describing the slot:
+#   slot|dir|pid|liveness|ports|offset|project
+# Always exits 0. For an absent slot dir, ports is "-" (no probe) to keep the
+# `bin/showcase slots` table tidy.
+_slot_state() {
+  local slot="${1:?slot required}"
+  local slot_entry="$ISOLATE_SLOT_DIR/$slot"
+
+  local dir="absent"
+  [ -d "$slot_entry" ] && dir="present"
+
+  local pid="-"
+  if [ -f "$slot_entry/pid" ]; then
+    local raw_pid
+    raw_pid="$(cat "$slot_entry/pid" 2>/dev/null || true)"
+    if [[ "$raw_pid" =~ ^[0-9]+$ ]]; then
+      pid="$raw_pid"
+    fi
+  fi
+
+  local project="-"
+  if [ -f "$slot_entry/project" ]; then
+    local raw_proj
+    raw_proj="$(cat "$slot_entry/project" 2>/dev/null || true)"
+    if [ -n "$raw_proj" ]; then
+      project="$raw_proj"
+    fi
+  fi
+
+  local liveness
+  liveness="$(_slot_liveness "$slot")"
+
+  local ports="-"
+  if [ "$dir" = "present" ]; then
+    if ! command -v lsof >/dev/null 2>&1; then
+      ports="?"
+    elif _slot_ports_free "$slot" >/dev/null 2>&1; then
+      ports="free"
+    else
+      ports="held"
+    fi
+  fi
+
+  local offset
+  if [ "$slot" = "0" ]; then
+    offset=0
+  else
+    offset=$(( (slot + 1) * 200 ))
+  fi
+
+  printf '%s|%s|%s|%s|%s|%s|%s\n' \
+    "$slot" "$dir" "$pid" "$liveness" "$ports" "$offset" "$project"
+  return 0
 }
 
 # Contract: callers MUST arm `trap restore_isolation EXIT` BEFORE calling this
@@ -739,7 +1004,7 @@ with open('$tmp_compose', 'w') as f:
   # Export for the TS harness CLI (config.ts / lifecycle.ts honor these).
   # Without SHOWCASE_COMPOSE_FILE the harness hardcodes the default compose
   # path, causing container-name collisions on a second concurrent --isolate.
-  # SHOWCASE_INFRA_PORT_OFFSET shifts the hardcoded :4010/:8090/:3200 health
+  # SHOWCASE_INFRA_PORT_OFFSET shifts the hardcoded :4010/:8090/:3210 health
   # checks onto the isolated stack's offset host ports (otherwise the harness
   # would silently report the DEFAULT-project aimock/pocketbase as healthy).
   export LOCAL_PORTS_FILE="$tmp_ports"
@@ -748,9 +1013,9 @@ with open('$tmp_compose', 'w') as f:
 
   # Offset host-side URLs so any harness code referencing config.aimockUrl /
   # dashboardUrl / pocketbase.url talks to THIS project's instances (not the
-  # default :4010 / :3200 / :8090).
+  # default :4010 / :3210 / :8090).
   local aimock_host_port=$(( 4010 + ISOLATE_PORT_OFFSET ))
-  local dashboard_host_port=$(( 3200 + ISOLATE_PORT_OFFSET ))
+  local dashboard_host_port=$(( 3210 + ISOLATE_PORT_OFFSET ))
   local pocketbase_host_port=$(( 8090 + ISOLATE_PORT_OFFSET ))
   export AIMOCK_URL_LOCAL="http://localhost:${aimock_host_port}"
   export DASHBOARD_URL_LOCAL="http://localhost:${dashboard_host_port}"
@@ -797,7 +1062,7 @@ restore_isolation() {
     # everything needed to reach and later tear down the stack by hand.
     if [ "${ISOLATE_KEEP:-false}" = true ]; then
       local aimock_host_port=$(( 4010 + ISOLATE_PORT_OFFSET ))
-      local dashboard_host_port=$(( 3200 + ISOLATE_PORT_OFFSET ))
+      local dashboard_host_port=$(( 3210 + ISOLATE_PORT_OFFSET ))
       local pocketbase_host_port=$(( 8090 + ISOLATE_PORT_OFFSET ))
       info "Kept isolated group standing: project=$ISOLATE_NAME slot=$ISOLATE_SLOT"
       info "  aimock:     http://localhost:${aimock_host_port}"

--- a/showcase/scripts/cli/cmd-slots.sh
+++ b/showcase/scripts/cli/cmd-slots.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# showcase slots — show isolation slot status
+# Sourced by the main dispatcher; do not execute directly.
+
+CMD_SLOTS_DESC="Show isolation slot status"
+
+usage_slots() {
+  cat <<'HELP'
+Usage: showcase slots [options]
+
+Show the status of all isolation slots (0..ISOLATE_MAX_SLOT).
+
+Options:
+  --json    Emit one JSON object per slot (JSONL format)
+  --free    Filter to slots that are free (unclaimed, no live pid/containers, no held ports)
+  --brief   Output only numeric slot IDs of matching slots, one per line
+
+Flags may be combined: --free --brief  → one integer per line for each free slot
+                       --free --json   → JSONL for free slots only
+
+Notes:
+  Slot 0 is reserved for the base (non-isolate) stack and is never reported as free.
+  Free = dir absent + liveness not live + ports not held.
+HELP
+}
+
+cmd_slots() {
+  local opt_json=false
+  local opt_free=false
+  local opt_brief=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json)   opt_json=true;   shift ;;
+      --free)   opt_free=true;   shift ;;
+      --brief)  opt_brief=true;  shift ;;
+      -h|--help)
+        usage_slots
+        return 0
+        ;;
+      -*)
+        die "Unknown flag: $1 (see 'showcase slots --help')"
+        ;;
+      *)
+        die "Unexpected argument: $1 (see 'showcase slots --help')"
+        ;;
+    esac
+  done
+
+  # Collect all slot records
+  local -a rows=()
+  local n
+  for n in $(seq 0 "$ISOLATE_MAX_SLOT"); do
+    rows+=("$(_slot_state "$n")")
+  done
+
+  # ── Output ────────────────────────────────────────────────────────────────
+
+  if $opt_brief; then
+    # Brief: numeric slot IDs only, one per line
+    for row in "${rows[@]}"; do
+      IFS='|' read -r slot dir pid liveness ports offset project <<< "$row"
+      # Slot 0 is never free (reserved for base stack)
+      if $opt_free; then
+        [ "$slot" = "0" ] && continue
+        # Free = dir absent, liveness not live, ports not held
+        [ "$dir" = "absent" ] && [ "$liveness" != "live" ] && [ "$ports" != "held" ] || continue
+      fi
+      printf '%s\n' "$slot"
+    done
+    return 0
+  fi
+
+  if $opt_json; then
+    # JSONL: one JSON object per slot
+    for row in "${rows[@]}"; do
+      IFS='|' read -r slot dir pid liveness ports offset project <<< "$row"
+      if $opt_free; then
+        [ "$slot" = "0" ] && continue
+        [ "$dir" = "absent" ] && [ "$liveness" != "live" ] && [ "$ports" != "held" ] || continue
+      fi
+      # Slot 0 project label
+      local proj_display="$project"
+      [ "$slot" = "0" ] && proj_display="showcase (base)"
+      jq -nc \
+        --argjson slot    "$slot" \
+        --arg     dir     "$dir" \
+        --arg     pid     "$pid" \
+        --arg     liveness "$liveness" \
+        --arg     ports   "$ports" \
+        --argjson offset  "$offset" \
+        --arg     project "$proj_display" \
+        '{slot: $slot, dir: $dir, pid: $pid, liveness: $liveness, ports: $ports, offset: $offset, project: $project}'
+    done
+    return 0
+  fi
+
+  # Default: fixed-width table
+  # Header: SLOT(4) DIR(7) PID(6) LIVE(12) PORTS(6) OFFSET(6) PROJECT(remainder)
+  printf '%-4s  %-7s  %-6s  %-12s  %-6s  %-6s  %s\n' \
+    "SLOT" "DIR" "PID" "LIVE" "PORTS" "OFFSET" "PROJECT"
+
+  for row in "${rows[@]}"; do
+    IFS='|' read -r slot dir pid liveness ports offset project <<< "$row"
+    if $opt_free; then
+      [ "$slot" = "0" ] && continue
+      [ "$dir" = "absent" ] && [ "$liveness" != "live" ] && [ "$ports" != "held" ] || continue
+    fi
+    # Slot 0 project label
+    local proj_display="$project"
+    [ "$slot" = "0" ] && proj_display="showcase (base)"
+    printf '%-4s  %-7s  %-6s  %-12s  %-6s  %-6s  %s\n' \
+      "$slot" "$dir" "$pid" "$liveness" "$ports" "+$offset" "$proj_display"
+  done
+
+  return 0
+}


### PR DESCRIPTION
## Summary

Fixes the `--isolate` slot picker in `showcase/scripts/cli/_common.sh` and adds a new `bin/showcase slots` inspector subcommand. Resolves five compounding bugs that made multi-agent local testing unreliable.

## Bugs fixed

1. **`SHOWCASE_ISO_SLOT=<N>` env var was ignored.** The picker walked 0→N regardless. Now: validates input (positive integer, `1 ≤ N ≤ 45`, slot 0 rejected as base stack), tries exactly that slot, fails loudly on conflict.
2. **No port-probe before commit.** Picker `mkdir`'d a slot dir without checking whether the slot's host ports were free. A slot whose dir was absent but whose ports were taken (foreign Docker project, host service like macOS AirPlay on 5000) was picked then failed at `docker compose up`. Now: `lsof`-probe every candidate port before committing the claim; rmdir + try next on conflict.
3. **Slot 8 / port 5000 collision on macOS.** Base dashboard port `3200` + slot 8 offset `+1800` = `5000`, permanently bound by macOS Control Center's AirPlay Receiver. Shifted dashboard base port `3200 → 3210` across `docker-compose.local.yml` and `showcase/harness/src/cli/*.ts` so slot 8 → port `5010` (free).
4. **Slot ownership desync across 3+ independent owners.** Picker checked only the dir; sweeper checked dir+pid+containers; neither checked foreign ports. New unified `_slot_state` returns all 4 axes (dir/pid/liveness/ports/offset/project); new `bin/showcase slots` exposes the state via table / `--json` / `--free --brief` filters.
5. **Parallel pre-claim deadlock dissolved** by bugs 1+2+4 — per-session pinning via env var + accurate port-probe + atomic `mkdir` lock self-resolves contention.

## Implementation

- New helpers in `_common.sh`: `_slot_offset_ports`, `_slot_liveness` (extracted from sweeper), `_slot_ports_free` (with own-project docker-listener filter), `_slot_state` (composite axis report).
- Rewritten `_claim_isolate_slot`: pinned-path (validate / try / die loudly) and auto-pick-path (1..MAX_SLOT, rmdir + skip on port-held). Slot 0 reserved with explicit die message.
- `ISOLATE_MAX_SLOT=45` centralized as a constant.
- Dashboard host port shift `3200 → 3210` across 6 files (compose + 4 harness TS + comment updates).
- New `cmd-slots.sh` plugin (auto-discovered by `bin/showcase`): default table, `--json` (JSONL), `--free` (filter to claimable slots), `--brief` (numeric IDs only).

## Tests

**Bats — 54/54 GREEN** in `showcase/scripts/__tests__/isolate.bats`:

- 12 pre-existing tests updated for slot-0-reservation contract (reap-evidence assertions preserved; only slot-number / port-offset expectations updated).
- 11 new tests added:
  - lsof stub + foundation smoke (test #0)
  - Pinning behavior tests #1-3 (success, live-die, validation incl. 0/foo/99)
  - Port-probe tests #4-7 (stale-reap, `_slot_offset_ports 8 → 5010 ≠ 5000`, foreign-process skip, own-project no-skip)
  - Composite tests #8-10 (`_slot_state` 5 axes, `bin/showcase slots` output, concurrent claim distinct slots)
  - lsof-graceful test (#54): `_slot_state emits ports=? when lsof is unavailable`

**Vitest — 17/17 GREEN** in `showcase/harness/src/cli/control-plane-run.test.ts` (port-shift stub consistency).

**Value-test (live local, plan §6 scenarios) — all 3 PASS:**

- **Scenario A:** On the test host Docker was holding slot 9's ports, so the picker correctly REFUSED `SHOWCASE_ISO_SLOT=9` with per-port diagnostics (proving the fail-loud half of the contract). Re-ran with `SHOWCASE_ISO_SLOT=15` (first free slot) and the pin was honored cleanly: `ISOLATE_SLOT=15`, `OFFSET=3200`. Both halves of the pin contract verified.
- **Scenario B:** Slots 1-7 pre-occupied with live pids + Python listener on `127.0.0.1:5010` (slot 8's dashboard port) → picker logged "Slot N ports held" + "trying next" for each conflict, walked past 9..13 (Docker-held), and landed on slot 14 with `OFFSET=3000`. No silent collision.
- **Scenario C:** `bin/showcase slots` matches reality: slot 0 → `OFFSET=+0 PROJECT=showcase (base)`; pre-claimed slot 5 → `DIR=present PID=<pid> LIVE=live PORTS=held OFFSET=+1200 PROJECT=showcase-iso5-test`. `--free --brief` outputs only fully-claimable slot IDs (44 in this run, slot 5 excluded).

## Code review

Full 7-agent cr-loop with `pr-review-toolkit` reviewers (Round 1 + confirmation round). 4 subject-scope load-bearing findings fixed:
- `_reap_isolate_slot` arg shape in pinned-path retry
- `_slot_state` base-stack offset (slot 0 → `+0`, not `+200`)
- TESTING.md item 8/9 column-name accuracy (matches actual `SLOT DIR PID LIVE PORTS OFFSET PROJECT` header)
- `bin/showcase slots` lsof-graceful degradation (inspector reports `PORTS=?` instead of dying when `lsof` is missing)

Plus 1 trivial comment-phrasing fix (race-comment wording). ~50 pre-existing harness/compose findings partitioned out-of-subject and deferred to follow-up PRs (see below). Procedure 3 bucket-(c) promotion audit returned zero PROMOTE_TO_A items — full convergence.

## Follow-up PRs (out-of-subject, separate subjects)

These coherent subjects surfaced during CR but belong to distinct PRs (the diff merely brushed against them for the `3200→3210` shift):

- **d1** — Harness `up()` / `doctor` should health-check `harness-control-plane` (port 8081). `_slot_offset_ports` includes 8081; `INFRA_PORTS` in `doctor.ts` / `lifecycle.ts` does not.
- **d2** — `doctor.ts` port + image diagnostic loud-failure pass (`checkStaleImages`, `checkPorts`, `isPortListening`, `checkDepotInterception` swallow errors).
- **d3** — `lifecycle.ts` error-surfacing pass (broad catches in `loadPortsFile`, `isRunning`, `compose`, `healthCheck`, `diffLogs`, etc.).
- **d4** — `docker-compose.local.yml` healthcheck error visibility (`.catch(() => process.exit(1))` swallows; dashboard `/` returns 307).
- **d5** — `apply_isolation` Python rewriter fail-loud pass (no `re.subn` count checks, hand-rolled YAML demos parser).
- **d6** — Centralize infra port literals (currently duplicated in 4 places).
- **d7** — `lifecycle.ts:11-13` stale `ops/` path comment (file lives at `harness/`).
- **d8** — `cmd_slots --json` `pid` field typing (string vs number) — settle when first JSON consumer appears.

## Test plan

- [x] `bats showcase/scripts/__tests__/isolate.bats` → 54/0
- [x] `pnpm vitest run src/cli/control-plane-run.test.ts` (in `showcase/harness/`) → 17/0
- [x] `pnpm exec tsc --noEmit` (in `showcase/harness/`) → clean
- [x] `oxfmt --check showcase/` → clean
- [x] `docker compose -f showcase/docker-compose.local.yml config` → valid YAML
- [x] Local value-test scenarios A/B/C from plan §6 → PASS
