### PR TITLE
docs(shell-docs): normalize quickstart CTAs

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/a2a/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/a2a/quickstart.mdx
@@ -13,14 +13,6 @@ hideTOC: true
   surface="docs_a2a_quickstart"
 />
 
-<OpsPlatformCTA
-  variant="card"
-  title="Ship A2A to production"
-  body="Add persistent threads, observability, and the inspector with the Enterprise Intelligence Platform."
-  ctaLabel="Create a free account"
-  surface="docs_a2a_quickstart"
-/>
-
 ## Prerequisites
 
 Before you begin, you'll need the following:

--- a/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
@@ -4,6 +4,15 @@ description: Turn your ADK Agents into an agent-native application in 10 minutes
 icon: "lucide/Play"
 hideTOC: true
 ---
+
+<OpsPlatformCTA
+  variant="card"
+  title="Ship ADK to production"
+  body="Add persistent threads, observability, and the inspector with the Enterprise Intelligence Platform."
+  ctaLabel="Create a free account"
+  surface="docs_adk_quickstart"
+/>
+
 ## Prerequisites
 
 Before you begin, you'll need the following:

--- a/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
@@ -5,6 +5,14 @@ icon: "lucide/Play"
 hideTOC: true
 ---
 
+<OpsPlatformCTA
+  variant="card"
+  title="Ship Agno to production"
+  body="Add persistent threads, observability, and the inspector with the Enterprise Intelligence Platform."
+  ctaLabel="Create a free account"
+  surface="docs_agno_quickstart"
+/>
+
 ## Prerequisites
 
 Before you begin, you'll need the following:

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
@@ -4,6 +4,15 @@ description: Turn your Strands agent into an agent-native application in 10 minu
 icon: "lucide/Play"
 hideTOC: true
 ---
+
+<OpsPlatformCTA
+  variant="card"
+  title="Ship AWS Strands to production"
+  body="Add persistent threads, observability, and the inspector with the Enterprise Intelligence Platform."
+  ctaLabel="Create a free account"
+  surface="docs_aws_strands_quickstart"
+/>
+
 ## Prerequisites
 
 Before you begin, you'll need the following:

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/quickstart.mdx
@@ -13,14 +13,6 @@ hideTOC: true
   surface="docs_crewai_flows_quickstart"
 />
 
-<OpsPlatformCTA
-  variant="card"
-  title="Ship CrewAI Flows to production"
-  body="Add persistent threads, observability, and the inspector with the Enterprise Intelligence Platform."
-  ctaLabel="Create a free account"
-  surface="docs_crewai_flows_quickstart"
-/>
-
 ## Prerequisites
 
 Before you begin, you must have a [CrewAI Flow](https://docs.crewai.com/guides/flows/first-flow) deployed on [CrewAI Enterprise](https://docs.crewai.com/enterprise/introduction). If you're looking for a sample flows, check out this [example agentic chat implementation](https://github.com/suhasdeshpande/agentic_chat).

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/prebuilt-components.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/prebuilt-components.mdx
@@ -18,13 +18,6 @@ CopilotKit ships three prebuilt chat components that connect directly to your La
   one of these set up.
 </Callout>
 
-<OpsPlatformCTA
-  variant="inline"
-  title="Want users to resume conversations across sessions?"
-  body="Persistent threads ship with the Enterprise Intelligence Platform. Try it for free."
-  surface="docs_langgraph_prebuilt_components"
-/>
-
 <IframeSwitcher
   id="agentic-chat-example"
   exampleUrl="https://feature-viewer.copilotkit.ai/langgraph/feature/agentic_chat?sidebar=false&chatDefaultOpen=false"

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -4,6 +4,15 @@ description: Turn your LangGraph agent into an agent-native application in 10 mi
 icon: "lucide/Play"
 hideTOC: true
 ---
+
+<OpsPlatformCTA
+  variant="card"
+  title="Ship LangGraph to production"
+  body="Add persistent threads, observability, and the inspector with the Enterprise Intelligence Platform."
+  ctaLabel="Create a free account"
+  surface="docs_langgraph_quickstart"
+/>
+
 ## Prerequisites
 
 Before you begin, you'll need the following:

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
@@ -4,6 +4,15 @@ description: Turn your LlamaIndex Agents into an agent-native application in 10 
 icon: "lucide/Play"
 hideTOC: true
 ---
+
+<OpsPlatformCTA
+  variant="card"
+  title="Ship LlamaIndex to production"
+  body="Add persistent threads, observability, and the inspector with the Enterprise Intelligence Platform."
+  ctaLabel="Create a free account"
+  surface="docs_llamaindex_quickstart"
+/>
+
 ## Prerequisites
 
 Before you begin, you'll need the following:

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
@@ -27,6 +27,14 @@ import {
 } from "lucide-react";
 import CopilotUI from "@/snippets/copilot-ui.mdx";
 
+<OpsPlatformCTA
+  variant="card"
+  title="Ship Mastra to production"
+  body="Add persistent threads, observability, and the inspector with the Enterprise Intelligence Platform."
+  ctaLabel="Create a free account"
+  surface="docs_mastra_quickstart"
+/>
+
 ## Prerequisites
 
 Before you begin, you'll need the following:

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -4,6 +4,15 @@ description: Turn your Microsoft Agent Framework agent into an agent-native appl
 icon: "lucide/Play"
 hideTOC: true
 ---
+
+<OpsPlatformCTA
+  variant="card"
+  title="Ship Microsoft Agent Framework to production"
+  body="Add persistent threads, observability, and the inspector with the Enterprise Intelligence Platform."
+  ctaLabel="Create a free account"
+  surface="docs_microsoft_agent_framework_quickstart"
+/>
+
 ## Prerequisites
 
 Before you begin, you'll need the following:

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -5,6 +5,13 @@ icon: "lucide/Play"
 hideTOC: true
 ---
 
+<OpsPlatformCTA
+  variant="card"
+  title="Ship Pydantic AI to production"
+  body="Add persistent threads, observability, and the inspector with the Enterprise Intelligence Platform."
+  ctaLabel="Create a free account"
+  surface="docs_pydantic_ai_quickstart"
+/>
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- remove duplicated OpsPlatformCTA blocks from A2A, CrewAI Flows, and LangGraph prebuilt components docs
- add missing production CTA cards to integration quickstarts that only had the inline signup step
- audit shell-docs CTA usage so each integration quickstart has exactly one OpsPlatformCTA and no duplicate CTA blocks remain

## Verification
- npm run test (showcase/shell-docs)
- npm run typecheck (showcase/shell-docs)
- npm run lint (showcase/shell-docs; existing warnings only)
- npm run build (showcase/shell-docs; existing Next/Turbopack warning only)
- duplicate CTA scanner: no duplicate CTA blocks found
- quickstart CTA scanner: every integration quickstart has exactly one OpsPlatformCTA