### PR TITLE
docs: fix CrewAI Flows quickstart init command

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/quickstart.mdx
@@ -63,7 +63,7 @@ Before you begin, you must have a [CrewAI Flow](https://docs.crewai.com/guides/f
             </Accordions>
 
             ```bash
-            npx copilotkit@latest init -m CrewAI --crew-type Flows
+            npx copilotkit@latest init --framework flows
             ```
         </Step>
         <Step>


### PR DESCRIPTION
## Summary
- Update the CrewAI Flows quickstart init command to use the CLI-supported framework flag.

## Verification
- Ran shell-docs predev generation as part of local dev server startup.
- Opened http://localhost:3004/crewai-crews/quickstart and verified the rendered page snapshot contains: `npx copilotkit@latest init --framework flows`.
- Commit hook passed: check-binaries, test-and-check-packages, commitlint.