### PR TITLE
docs: add Codex docs editing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ AI agent framework with three layers: **Frontend** (React/Angular/Vanilla) → *
 - **Worktrees** — always work in a git worktree for isolation. See [Git & PRs](.claude/docs/git.md) for the full workflow.
 - **Commit as you go** — every meaningful unit of work gets its own commit, pushed immediately. Don't let untracked files accumulate across a session. Tests belong in the commit that introduces the code being tested. Full rules in [Git & PRs](.claude/docs/git.md#commit-early-and-often-in-logical-chunks).
 - **Draft PR up front** — the moment a new branch has one commit, push it and open a **draft PR**. Don't wait until "ready" — unmerged-and-unpushed work is invisible. Flip the PR from draft to ready (`gh pr ready <pr#>`) only when the developer says so. See [Git & PRs](.claude/docs/git.md#open-a-draft-pr-up-front).
+- **Documentation lives in shell-docs** — author CopilotKit docs in `showcase/shell-docs/src/content/`. The top-level `docs/` folder is retired; never edit it for live documentation. AG-UI protocol docs are authored upstream in `ag-ui-protocol/ag-ui`, not directly in this repo. See [Documentation](.claude/docs/documentation.md).
 
 ## Private Agent Instructions
 
@@ -41,9 +42,29 @@ The team maintains shared AI agent skills at [CopilotKit/internal-skills](https:
 
 If you need a skill and don't have the plugin installed, clone the repo and read the relevant `skills/<name>/SKILL.md` directly.
 
+## Documentation Editing
+
+Before editing anything that looks like product docs, read [Documentation](.claude/docs/documentation.md) and the local README for the docs area you are touching. The live docs source is **not** the retired top-level `docs/` app.
+
+- **CopilotKit product docs** live under `showcase/shell-docs/src/content/`:
+  - Guides, how-tos, and concepts: `showcase/shell-docs/src/content/docs/`
+  - API reference: `showcase/shell-docs/src/content/reference/`
+  - Shared MDX snippets: `showcase/shell-docs/src/content/snippets/`
+  - Framework overview pages: `showcase/shell-docs/src/content/framework-overviews/`
+- When adding or moving a guide page under `showcase/shell-docs/src/content/docs/`, update that section's `meta.json` so the page appears in navigation.
+- The v2 API reference under `showcase/shell-docs/src/content/reference/{components,hooks,sdk}/` does **not** use `meta.json`; navigation is generated from page frontmatter. Only `reference/v1/` uses `meta.json`.
+- For framework docs, check the framework's `docs_mode` in `showcase/integrations/<slug>/manifest.yaml` and confirm the docs folder with `getDocsFolder()` in `showcase/shell-docs/src/lib/registry.ts`.
+- For showcase-driven frameworks (`docs_mode: generated`), update the showcase source of truth: manifests, demos, feature coverage, source regions, registry inputs, shared/root MDX, and sparse framework overrides. Do not hand-edit generated files under `showcase/shell-docs/src/data/frameworks/`.
+- For authored frameworks (`docs_mode: authored`), edit `showcase/shell-docs/src/content/docs/integrations/<docsFolder>/` and its `meta.json`.
+- For snippets, edit `showcase/shell-docs/src/content/snippets/`; snippets can feed root docs, authored framework pages, and showcase-driven framework pages.
+- **AG-UI protocol docs** are canonical upstream in `ag-ui-protocol/ag-ui`. The `showcase/shell-docs/src/content/ag-ui/` tree is a downstream mirror; change AG-UI upstream first, then sync the mirror back.
+- **Do not author in top-level `docs/`**. `docs/content/docs/` and the retired Next app no longer publish to `docs.copilotkit.ai`, and `showcase/scripts/sync-docs-from-main.ts` is legacy.
+- To run shell-docs locally, follow `showcase/shell-docs/README.md` and use the shell-docs npm commands.
+
 ## Reference (read when relevant to your task)
 
 - [Architecture & Packages](.claude/docs/architecture.md) — V2/V1 package roles, request lifecycle, core concepts (AG-UI, ProxiedAgent, AgentRunner, tools, context, multi-agent)
 - [Hook Development](.claude/docs/hooks.md) — checklist for creating new hooks (docs, tests, JSDoc)
 - [Workflow & Process](.claude/docs/workflow.md) — when to plan, when to fix autonomously, verification, self-improvement loop, this should be your default mindset when working on any task
 - [Git & PRs](.claude/docs/git.md) — worktree workflow, branching, creating PRs
+- [Documentation](.claude/docs/documentation.md) — where to author docs (CopilotKit → shell-docs; AG-UI → upstream); `docs/` is retired


### PR DESCRIPTION
## Summary
- add Codex-facing guidance for where CopilotKit docs are authored
- call out shell-docs, framework docs modes, reference nav, snippets, AG-UI upstream docs, and retired top-level docs
- clarify shell-docs local work should use the shell-docs npm commands

## Verification
- lefthook pre-commit hooks passed during commit
- commit-msg hook passed