### PR TITLE
feat(showcase): support --isolate=<N> CLI form as sugar over SHOWCASE_ISO_SLOT

### DIFF
--- a/showcase/TESTING.md
+++ b/showcase/TESTING.md
@@ -104,7 +104,7 @@ showcase-iso<N>-aimock` + DOM/probe text):
    `--isolate` slots cold-start aimock from the volume mount, so the first
    post-edit run picks up the change automatically; warm-slot reuse will not.
 
-8. **`--isolate` slot pinning and conflict detection.** Pin a specific slot with `SHOWCASE_ISO_SLOT=<N>` (1-45; slot 0 is reserved for the base stack) — the picker uses exactly that slot or fails loudly. The auto-picker now port-probes every candidate via `lsof` before committing, so foreign-Docker (`ag2mm-*`) and host-process (macOS AirPlay on 5000) conflicts are detected pre-`docker compose up`. Run `bin/showcase slots` to inspect all 46 slots across DIR / PID / LIVE / PORTS / OFFSET (and PROJECT) — same code path the picker uses. The `LIVE` column reports `live` / `stale` / `inconclusive` and folds the live-pid and live-containers checks into one axis.
+8. **`--isolate` slot pinning and conflict detection.** Pin a specific slot with `SHOWCASE_ISO_SLOT=<N>` (1-45; slot 0 is reserved for the base stack), or use the equivalent CLI sugar `--isolate=<N>` — the picker uses exactly that slot or fails loudly. The auto-picker now port-probes every candidate via `lsof` before committing, so foreign-Docker (`ag2mm-*`) and host-process (macOS AirPlay on 5000) conflicts are detected pre-`docker compose up`. Run `bin/showcase slots` to inspect all 46 slots across DIR / PID / LIVE / PORTS / OFFSET (and PROJECT) — same code path the picker uses. The `LIVE` column reports `live` / `stale` / `inconclusive` and folds the live-pid and live-containers checks into one axis.
 
 9. **Cell-color flip claims MUST be empirically value-tested via the
    production-equivalent control-plane path** on ≥3 candidate cells before merge.
@@ -118,10 +118,12 @@ showcase-iso<N>-aimock` + DOM/probe text):
    value-test — it bypasses the queue/worker pipeline staging actually runs and
    has misled investigations in the past.
 
-   Pick `<N>` by first running `bin/showcase slots` (or `bin/showcase slots --free --brief` for a machine-readable list) and choosing a row whose `DIR` is `absent`, `LIVE` is not `live`, and `PORTS` is not `held`, then pass `SHOWCASE_ISO_SLOT=<N>` to your test invocation:
+   Pick `<N>` by first running `bin/showcase slots` (or `bin/showcase slots --free --brief` for a machine-readable list) and choosing a row whose `DIR` is `absent`, `LIVE` is not `live`, and `PORTS` is not `held`, then pin the slot via either form (both are equivalent):
 
    ```
    SHOWCASE_ISO_SLOT=<N> bin/showcase test <slug>:<feature> --d6 --isolate
+   # — or, equivalently —
+   bin/showcase test <slug>:<feature> --d6 --isolate=<N>
    ```
 
 10. **No fixture rewrite from real-LLM record/replay.** The canonical-phrase probe

--- a/showcase/scripts/__tests__/isolate.bats
+++ b/showcase/scripts/__tests__/isolate.bats
@@ -1856,3 +1856,122 @@ FIXTURE
   [[ "$state" == *"|?|"* ]] \
     || fail "_slot_state did not degrade to ports='?' when lsof was unavailable: $state"
 }
+
+# ── --isolate=<N> arg-parser sugar (cmd-test.sh) ─────────────────────────────
+#
+# The `--isolate=<N>` form is sugar over `SHOWCASE_ISO_SLOT=<N> ... --isolate`:
+# the arg parser in cmd-test.sh sets SHOWCASE_ISO_SLOT from the =<N> suffix and
+# exports it, then the existing picker (_claim_isolate_slot) handles ALL
+# validation. The tests here pin the parser→env→picker pipeline end-to-end by
+# replaying cmd-test.sh's --isolate=* branch verbatim and then invoking the
+# picker (the SAME wiring bin/showcase test would do). No new validation logic
+# exists in the arg parser, so we don't re-test validation here — we prove the
+# arg form drives the existing validation paths pinned above.
+#
+# We replay the parser branch rather than invoking `cmd_test` directly because
+# cmd_test runs heavy work (need_slug, trap restore_isolation, apply_isolation
+# which forks docker/python3) after parsing — orthogonal to what this test
+# pins.
+
+@test "--isolate=<N> arg form exports SHOWCASE_ISO_SLOT and pins the slot through the picker" {
+  load_common
+  # Replay cmd-test.sh's `--isolate=*` branch verbatim, then run the picker.
+  set -- --isolate=9 dummy-slug
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --isolate=*)
+        SHOWCASE_ISO_SLOT="${1#--isolate=}"
+        export SHOWCASE_ISO_SLOT
+        shift
+        ;;
+      *) shift ;;
+    esac
+  done
+  [ "$SHOWCASE_ISO_SLOT" = "9" ] \
+    || fail "--isolate=9 did not export SHOWCASE_ISO_SLOT=9; got: $SHOWCASE_ISO_SLOT"
+
+  # The exported pin drives the picker exactly as the SHOWCASE_ISO_SLOT=9
+  # pinned-path test does (pinned by "SHOWCASE_ISO_SLOT=9 claims slot 9 ..."
+  # above): slot 9 claimed verbatim.
+  _claim_isolate_slot
+  [ "$ISOLATE_SLOT" = "9" ] \
+    || fail "picker did not honor --isolate=9-exported SHOWCASE_ISO_SLOT: got $ISOLATE_SLOT"
+}
+
+@test "--isolate=0 arg form drives the picker's reserved-slot rejection" {
+  # Wiring proof: the arg parser does NO validation of N itself — it relies on
+  # the picker. So --isolate=0 must trip the SAME 'slot 0 is reserved' die
+  # pinned by "SHOWCASE_ISO_SLOT validates input (0, foo, 99 all rejected)"
+  # above. Replay the parser branch, then invoke the picker.
+  load_common
+  set -- --isolate=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --isolate=*)
+        SHOWCASE_ISO_SLOT="${1#--isolate=}"
+        export SHOWCASE_ISO_SLOT
+        shift
+        ;;
+      *) shift ;;
+    esac
+  done
+  [ "$SHOWCASE_ISO_SLOT" = "0" ] || fail "parser did not export 0: got $SHOWCASE_ISO_SLOT"
+
+  run _claim_isolate_slot
+  [ "$status" -ne 0 ] || fail "--isolate=0 unexpectedly succeeded: $output"
+  [[ "$output" == *"slot 0 is reserved"* ]] \
+    || fail "--isolate=0 did not surface the reserved-slot die: $output"
+}
+
+@test "cmd-test.sh --isolate=<N> actually wires the arg through to SHOWCASE_ISO_SLOT" {
+  # Drift guard: the three tests above replay the parser branch verbatim. This
+  # test sources the REAL cmd-test.sh and runs cmd_test end-to-end with a stub
+  # apply_isolation that snapshots SHOWCASE_ISO_SLOT — so if the parser branch
+  # is ever removed or wired differently, this fails LOUDLY.
+  load_common
+
+  local snapshot="$BATS_TEST_TMPDIR/iso-slot-snapshot"
+  local cmd_test_sh="$BATS_TEST_DIRNAME/../cli/cmd-test.sh"
+  [ -f "$cmd_test_sh" ] || fail "cmd-test.sh not found: $cmd_test_sh"
+
+  # Stub apply_isolation: snapshot SHOWCASE_ISO_SLOT, then exit cleanly via
+  # `die` so the rest of cmd_test (which forks docker/etc) never runs.
+  # Stub need_slug to a no-op so the parser path is what's exercised.
+  # Stub everything else cmd_test invokes after the parser to no-ops.
+  run bash -euo pipefail -c "
+    source '$COMMON'
+    source '$cmd_test_sh'
+    apply_isolation() { printf '%s\n' \"\${SHOWCASE_ISO_SLOT:-<unset>}\" > '$snapshot'; exit 0; }
+    need_slug() { :; }
+    info() { :; }
+    run_harness() { :; }
+    cmd_test --isolate=7 dummy-slug
+  "
+  [ "$status" -eq 0 ] || fail "cmd_test --isolate=7 failed: $output"
+  [ -f "$snapshot" ] || fail "stubbed apply_isolation never fired (parser/use_isolate wiring broken)"
+  run cat "$snapshot"
+  [[ "$output" == "7" ]] \
+    || fail "cmd-test.sh did not export SHOWCASE_ISO_SLOT=7 from --isolate=7: got '$output'"
+}
+
+@test "--isolate=99 arg form drives the picker's out-of-range rejection" {
+  # Same wiring proof for the upper bound: ISOLATE_MAX_SLOT=45, so 99 is over.
+  load_common
+  set -- --isolate=99
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --isolate=*)
+        SHOWCASE_ISO_SLOT="${1#--isolate=}"
+        export SHOWCASE_ISO_SLOT
+        shift
+        ;;
+      *) shift ;;
+    esac
+  done
+  [ "$SHOWCASE_ISO_SLOT" = "99" ] || fail "parser did not export 99: got $SHOWCASE_ISO_SLOT"
+
+  run _claim_isolate_slot
+  [ "$status" -ne 0 ] || fail "--isolate=99 unexpectedly succeeded: $output"
+  [[ "$output" == *"exceeds ISOLATE_MAX_SLOT=45"* ]] \
+    || fail "--isolate=99 did not surface the out-of-range die: $output"
+}

--- a/showcase/scripts/cli/cmd-test.sh
+++ b/showcase/scripts/cli/cmd-test.sh
@@ -28,6 +28,8 @@ Options:
   --cycle          On failure, auto-dump aimock logs from the test window
   --isolate [name] Run in an isolated compose project with offset ports
                    (default name: showcase-iso<slot>). Allows parallel test runs.
+  --isolate=<N>    Sugar form: pin the isolation slot to N (equivalent to
+                   prefixing SHOWCASE_ISO_SLOT=<N>). 1≤N≤ISOLATE_MAX_SLOT.
 
 Examples:
   showcase test mastra --d6 --verbose         # D6 probes (full matrix) with verbose output
@@ -37,6 +39,7 @@ Examples:
   showcase test mastra --d5 --headed          # watch the browser
   showcase test agno --d5 --isolate           # isolated run (auto-named)
   showcase test agno --d5 --isolate d5verify  # isolated with explicit name
+  showcase test agno --d5 --isolate=9         # pin to slot 9 (equiv: SHOWCASE_ISO_SLOT=9 ... --isolate)
 HELP
 }
 
@@ -83,6 +86,15 @@ cmd_test() {
             :
           fi
         fi
+        ;;
+      --isolate=*)
+        # Sugar form: --isolate=<N> pins the slot by exporting SHOWCASE_ISO_SLOT.
+        # The picker (_claim_isolate_slot in _common.sh) handles all validation
+        # (positive integer, 1≤N≤ISOLATE_MAX_SLOT, slot 0 reserved, port probe).
+        use_isolate=true
+        SHOWCASE_ISO_SLOT="${1#--isolate=}"
+        export SHOWCASE_ISO_SLOT
+        shift
         ;;
       --repeat)
         shift


### PR DESCRIPTION
## Summary

Follow-up to #5543. Adds `--isolate=<N>` CLI form so users don't need to set `SHOWCASE_ISO_SLOT=<N>` as an env var prefix.

## Before

```
SHOWCASE_ISO_SLOT=9 bin/showcase test agno --d5 --isolate
```

## After (both forms work)

```
bin/showcase test agno --d5 --isolate=9
# OR
SHOWCASE_ISO_SLOT=9 bin/showcase test agno --d5 --isolate
```

## Implementation

~10 lines in `showcase/scripts/cli/cmd-test.sh` arg parser: a new `--isolate=*` case sets `use_isolate=true` and exports `SHOWCASE_ISO_SLOT=<N>`. The existing picker (`_claim_isolate_slot` in `_common.sh`) handles all validation, slot-0 rejection, port-probe, liveness, etc. — no logic duplication.

Help text in `cmd-test.sh` and the existing `SHOWCASE_ISO_SLOT` references in `showcase/TESTING.md` now show both forms as equivalent.

## Tests

Four new bats tests in `showcase/scripts/__tests__/isolate.bats`:

- `--isolate=<N> arg form exports SHOWCASE_ISO_SLOT and pins the slot through the picker` — replays the parser branch, verifies env export + picker pinning.
- `--isolate=0 arg form drives the picker's reserved-slot rejection` — proves `--isolate=0` flows through the same `slot 0 is reserved` die as the env-var form.
- `--isolate=99 arg form drives the picker's out-of-range rejection` — proves `--isolate=99` flows through the same `exceeds ISOLATE_MAX_SLOT=45` die as the env-var form.
- `cmd-test.sh --isolate=<N> actually wires the arg through to SHOWCASE_ISO_SLOT` — drift guard that sources the REAL `cmd-test.sh`, stubs `apply_isolation`, and snapshots `SHOWCASE_ISO_SLOT` to catch any future regression of the parser branch.

All 58 bats tests in `isolate.bats` pass locally (54 pre-existing + 4 new).

## Docs

`showcase/TESTING.md` items 8 and 9 updated to show both forms. Repo-wide grep confirmed TESTING.md is the only doc that references `SHOWCASE_ISO_SLOT`.

## Test plan

- [x] `bats showcase/scripts/__tests__/isolate.bats` → 58/58 green
- [x] `--isolate=9` → `SHOWCASE_ISO_SLOT` exported, slot 9 claimed
- [x] `--isolate=0` → picker dies "slot 0 is reserved"
- [x] `--isolate=99` → picker dies "exceeds ISOLATE_MAX_SLOT=45"
- [x] `shellcheck showcase/scripts/cli/cmd-test.sh` → no new warnings (only the pre-existing SC2034 on `CMD_TEST_DESC`, consumed by dispatcher parallel arrays)
- [x] `oxfmt --check showcase/` → clean
