### PR TITLE
fix(react-core): honor selfManagedAgents in CopilotKit wrapper validation

### DIFF
--- a/packages/react-core/src/components/copilot-provider/__tests__/v1-self-managed-agents-validation.test.tsx
+++ b/packages/react-core/src/components/copilot-provider/__tests__/v1-self-managed-agents-validation.test.tsx
@@ -1,0 +1,51 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { HttpAgent } from "@ag-ui/client";
+import { ConfigurationError } from "@copilotkit/shared";
+import { CopilotKit } from "../copilotkit";
+import type { CopilotKitProps } from "../copilotkit-props";
+
+/**
+ * Regression coverage for #5417. The v1 <CopilotKit> wrapper used to run a
+ * `validateProps` check that threw `ConfigurationError` whenever neither
+ * `runtimeUrl` nor a public key was supplied — without considering local
+ * (self-managed) agents. That rejected the documented self-managed-agent
+ * configuration, even though the underlying v2 CopilotKitProvider accepts it
+ * (its `hasLocalAgents` gate). These tests pin the wrapper to the same gate.
+ */
+describe("v1 <CopilotKit> validateProps → self-managed agents", () => {
+  // Rendering paths that legitimately have no runtime emit a dev-only warning
+  // from the v2 provider; silence it so the test output stays clean.
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  function renderKit(props: Partial<CopilotKitProps>) {
+    return render(<CopilotKit {...props}>child</CopilotKit>);
+  }
+
+  it("throws when no runtimeUrl, key, or local agents are provided", () => {
+    expect(() => renderKit({})).toThrow(ConfigurationError);
+  });
+
+  it("does not throw when selfManagedAgents is provided without a runtimeUrl", () => {
+    const testAgent = new HttpAgent({ url: "http://localhost:8000" });
+    expect(() =>
+      renderKit({ selfManagedAgents: { testAgent }, agent: "testAgent" }),
+    ).not.toThrow();
+  });
+
+  it("does not throw when agents__unsafe_dev_only is provided without a runtimeUrl", () => {
+    const testAgent = new HttpAgent({ url: "http://localhost:8000" });
+    expect(() =>
+      renderKit({ agents__unsafe_dev_only: { testAgent }, agent: "testAgent" }),
+    ).not.toThrow();
+  });
+});

--- a/packages/react-core/src/components/copilot-provider/__tests__/v1-self-managed-agents-validation.test.tsx
+++ b/packages/react-core/src/components/copilot-provider/__tests__/v1-self-managed-agents-validation.test.tsx
@@ -17,8 +17,9 @@ describe("v1 <CopilotKit> validateProps → self-managed agents", () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
   beforeEach(() => {
     // The v2 provider emits a dev-only "missing runtime" warning on some
-    // keyless renders; silence that expected noise. console.error is spied (not
-    // blanket-silenced) so valid configs can be asserted to log nothing.
+    // keyless renders; silence that expected noise. console.error is spied and
+    // silenced too, so valid configs can be asserted to log nothing while
+    // keeping test output clean.
     vi.spyOn(console, "warn").mockImplementation(() => {});
     errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });

--- a/packages/react-core/src/components/copilot-provider/__tests__/v1-self-managed-agents-validation.test.tsx
+++ b/packages/react-core/src/components/copilot-provider/__tests__/v1-self-managed-agents-validation.test.tsx
@@ -14,38 +14,61 @@ import type { CopilotKitProps } from "../copilotkit-props";
  * (its `hasLocalAgents` gate). These tests pin the wrapper to the same gate.
  */
 describe("v1 <CopilotKit> validateProps → self-managed agents", () => {
-  // Rendering paths that legitimately have no runtime emit a dev-only warning
-  // from the v2 provider; silence it so the test output stays clean.
-  let warnSpy: ReturnType<typeof vi.spyOn>;
   let errorSpy: ReturnType<typeof vi.spyOn>;
   beforeEach(() => {
-    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // The v2 provider emits a dev-only "missing runtime" warning on some
+    // keyless renders; silence that expected noise. console.error is spied (not
+    // blanket-silenced) so valid configs can be asserted to log nothing.
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
   afterEach(() => {
-    warnSpy.mockRestore();
-    errorSpy.mockRestore();
+    vi.restoreAllMocks();
   });
 
   function renderKit(props: Partial<CopilotKitProps>) {
     return render(<CopilotKit {...props}>child</CopilotKit>);
   }
 
+  // A valid configuration must render without throwing AND without surfacing an
+  // unexpected error to the console (which would mean the v2 provider rejected
+  // the config another way).
+  function expectRendersCleanly(props: Partial<CopilotKitProps>) {
+    expect(() => renderKit(props)).not.toThrow();
+    expect(errorSpy).not.toHaveBeenCalled();
+  }
+
   it("throws when no runtimeUrl, key, or local agents are provided", () => {
     expect(() => renderKit({})).toThrow(ConfigurationError);
   });
 
+  it("throws when selfManagedAgents is an empty map", () => {
+    expect(() => renderKit({ selfManagedAgents: {} })).toThrow(
+      ConfigurationError,
+    );
+  });
+
   it("does not throw when selfManagedAgents is provided without a runtimeUrl", () => {
     const testAgent = new HttpAgent({ url: "http://localhost:8000" });
-    expect(() =>
-      renderKit({ selfManagedAgents: { testAgent }, agent: "testAgent" }),
-    ).not.toThrow();
+    expectRendersCleanly({
+      selfManagedAgents: { testAgent },
+      agent: "testAgent",
+    });
   });
 
   it("does not throw when agents__unsafe_dev_only is provided without a runtimeUrl", () => {
     const testAgent = new HttpAgent({ url: "http://localhost:8000" });
-    expect(() =>
-      renderKit({ agents__unsafe_dev_only: { testAgent }, agent: "testAgent" }),
-    ).not.toThrow();
+    expectRendersCleanly({
+      agents__unsafe_dev_only: { testAgent },
+      agent: "testAgent",
+    });
+  });
+
+  it("does not throw on the pre-existing runtimeUrl and publicApiKey paths", () => {
+    expectRendersCleanly({
+      runtimeUrl: "http://localhost:3000/api/copilotkit",
+    });
+    errorSpy.mockClear();
+    expectRendersCleanly({ publicApiKey: "ck_pub_test" });
   });
 });

--- a/packages/react-core/src/components/copilot-provider/__tests__/v1-self-managed-agents-validation.test.tsx
+++ b/packages/react-core/src/components/copilot-provider/__tests__/v1-self-managed-agents-validation.test.tsx
@@ -32,8 +32,10 @@ describe("v1 <CopilotKit> validateProps → self-managed agents", () => {
 
   // A valid configuration must render without throwing AND without surfacing an
   // unexpected error to the console (which would mean the v2 provider rejected
-  // the config another way).
+  // the config another way). Self-contained: clears the spy so callers don't
+  // have to track prior console.error calls.
   function expectRendersCleanly(props: Partial<CopilotKitProps>) {
+    errorSpy.mockClear();
     expect(() => renderKit(props)).not.toThrow();
     expect(errorSpy).not.toHaveBeenCalled();
   }
@@ -64,11 +66,13 @@ describe("v1 <CopilotKit> validateProps → self-managed agents", () => {
     });
   });
 
-  it("does not throw on the pre-existing runtimeUrl and publicApiKey paths", () => {
+  it("does not throw on the pre-existing runtimeUrl path", () => {
     expectRendersCleanly({
       runtimeUrl: "http://localhost:3000/api/copilotkit",
     });
-    errorSpy.mockClear();
+  });
+
+  it("does not throw on the pre-existing publicApiKey path", () => {
     expectRendersCleanly({ publicApiKey: "ck_pub_test" });
   });
 });

--- a/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -14,13 +14,13 @@
  * ```
  */
 
+import type { SetStateAction } from "react";
 import React, {
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
-  SetStateAction,
 } from "react";
 import {
   CopilotChatConfigurationProvider,
@@ -28,43 +28,47 @@ import {
   CopilotKitProvider as CopilotKitV2Provider,
   useCopilotKit,
 } from "../../v2";
-import {
-  CopilotContext,
+import type {
   CopilotApiConfig,
   ChatComponentsCache,
   AgentSession,
   AuthState,
+} from "../../context/copilot-context";
+import {
+  CopilotContext,
   useCopilotContext,
 } from "../../context/copilot-context";
 import useTree from "../../hooks/use-tree";
-import {
+import type {
   CopilotChatSuggestionConfiguration,
   DocumentPointer,
 } from "../../types";
 import { flushSync } from "react-dom";
-import {
-  COPILOT_CLOUD_CHAT_URL,
+import type {
   CopilotCloudConfig,
   FunctionCallHandler,
-  COPILOT_CLOUD_PUBLIC_API_KEY_HEADER,
-  randomUUID,
-  ConfigurationError,
-  MissingPublicApiKeyError,
   CopilotKitError,
   CopilotErrorEvent,
   CopilotErrorHandler,
 } from "@copilotkit/shared";
-import { FrontendAction } from "../../types/frontend-action";
+import {
+  COPILOT_CLOUD_CHAT_URL,
+  COPILOT_CLOUD_PUBLIC_API_KEY_HEADER,
+  randomUUID,
+  ConfigurationError,
+  MissingPublicApiKeyError,
+} from "@copilotkit/shared";
+import type { FrontendAction } from "../../types/frontend-action";
 import useFlatCategoryStore from "../../hooks/use-flat-category-store";
-import { CopilotKitProps } from "./copilotkit-props";
-import { CoagentState } from "../../types/coagent-state";
+import type { CopilotKitProps } from "./copilotkit-props";
+import type { CoagentState } from "../../types/coagent-state";
 import { CopilotMessages, MessagesTapProvider } from "./copilot-messages";
 import { ToastProvider } from "../toast/toast-provider";
 import { getErrorActions, UsageBanner } from "../usage-banner";
 import { shouldShowDevConsole } from "../../utils";
 import { CopilotErrorBoundary } from "../error-boundary/error-boundary";
-import { Agent, ExtensionsInput } from "@copilotkit/runtime-client-gql";
-import {
+import type { Agent, ExtensionsInput } from "@copilotkit/runtime-client-gql";
+import type {
   LangGraphInterruptRender,
   LangGraphInterruptActionSetterArgs,
   QueuedInterruptEvent,
@@ -837,7 +841,17 @@ function validateProps(props: CopilotKitProps): never | void {
   // Check if we have either a runtimeUrl or one of the API keys
   const hasApiKey = props.publicApiKey || props.publicLicenseKey;
 
-  if (!props.runtimeUrl && !hasApiKey) {
+  // Self-managed (and dev-only) agents are instantiated client-side and route
+  // directly to their AG-UI endpoints, so they need neither a runtime nor a
+  // cloud key. Mirror CopilotKitProvider's `hasLocalAgents` gate so the wrapper
+  // doesn't reject a valid self-managed configuration (#5417).
+  const hasLocalAgents =
+    Object.keys({
+      ...props.agents__unsafe_dev_only,
+      ...props.selfManagedAgents,
+    }).length > 0;
+
+  if (!props.runtimeUrl && !hasApiKey && !hasLocalAgents) {
     throw new ConfigurationError(
       "Missing required prop: 'runtimeUrl' or 'publicApiKey' or 'publicLicenseKey'",
     );

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -380,6 +380,22 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   );
   const hasLocalAgents = mergedAgents && Object.keys(mergedAgents).length > 0;
 
+  // `selfManagedAgents` is part of CopilotKit's Enterprise Intelligence offering.
+  // The signal is advisory and client-side only (not enforced): warn — in both
+  // development and production — when it is used without a license key so
+  // production usage is surfaced. `agents__unsafe_dev_only` is the free local-dev
+  // escape hatch and is intentionally NOT gated here.
+  const hasSelfManagedAgents = Object.keys(selfManagedAgents).length > 0;
+  useEffect(() => {
+    if (hasSelfManagedAgents && !resolvedPublicKey) {
+      console.warn(
+        "[CopilotKit] `selfManagedAgents` is part of CopilotKit's Enterprise " +
+          "Intelligence offering. Provide a `publicLicenseKey` for production " +
+          "use — contact the CopilotKit team about licensing.",
+      );
+    }
+  }, [hasSelfManagedAgents, resolvedPublicKey]);
+
   // Resolve headers from function or static object
   const headers =
     typeof headersProp === "function" ? headersProp() : headersProp;

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import type { ReactFrontendTool } from "../../types/frontend-tool";
 import type { ReactHumanInTheLoop } from "../../types/human-in-the-loop";
+import { HttpAgent } from "@ag-ui/client";
 import { CopilotKitProvider, useCopilotKit } from "../CopilotKitProvider";
 
 // Mock console methods
@@ -47,6 +48,49 @@ describe("CopilotKitProvider", () => {
 
       errorSpy.mockRestore();
       consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+  });
+
+  describe("selfManagedAgents license signal", () => {
+    const ENTERPRISE_WARNING = "Enterprise Intelligence";
+
+    it("warns when selfManagedAgents is provided without a license key", () => {
+      const agent = new HttpAgent({ url: "http://localhost:8000" });
+      render(
+        <CopilotKitProvider selfManagedAgents={{ myAgent: agent }}>
+          child
+        </CopilotKitProvider>,
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(ENTERPRISE_WARNING),
+      );
+    });
+
+    it("does not warn when selfManagedAgents is paired with a license key", () => {
+      const agent = new HttpAgent({ url: "http://localhost:8000" });
+      render(
+        <CopilotKitProvider
+          selfManagedAgents={{ myAgent: agent }}
+          publicLicenseKey="ck_lic_test"
+        >
+          child
+        </CopilotKitProvider>,
+      );
+      expect(consoleWarnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining(ENTERPRISE_WARNING),
+      );
+    });
+
+    it("does not warn for the free agents__unsafe_dev_only escape hatch", () => {
+      const agent = new HttpAgent({ url: "http://localhost:8000" });
+      render(
+        <CopilotKitProvider agents__unsafe_dev_only={{ myAgent: agent }}>
+          child
+        </CopilotKitProvider>,
+      );
+      expect(consoleWarnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining(ENTERPRISE_WARNING),
+      );
     });
   });
 

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
@@ -64,6 +64,11 @@ describe("CopilotKitProvider", () => {
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining(ENTERPRISE_WARNING),
       );
+      // selfManagedAgents satisfies hasLocalAgents, so the separate
+      // missing-runtime config warning must NOT fire here.
+      expect(consoleWarnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("Missing required prop"),
+      );
     });
 
     it("does not warn when selfManagedAgents is paired with a license key", () => {

--- a/showcase/shell-docs/src/content/docs/backend/self-managed-agents.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/self-managed-agents.mdx
@@ -18,8 +18,9 @@ AG-UI-compatible backend you own and have already secured:
 
 <Callout type="info" title="Part of Enterprise Intelligence">
   `selfManagedAgents` is part of CopilotKit's [Enterprise
-  Intelligence](/premium/intelligence-platform) offering. Contact the CopilotKit
-  team about licensing for production use.
+  Intelligence](/premium/intelligence-platform) offering. [Talk to an
+  engineer](https://copilotkit.ai/talk-to-an-engineer) about licensing for
+  production use.
 </Callout>
 
 ```tsx

--- a/showcase/shell-docs/src/content/docs/backend/self-managed-agents.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/self-managed-agents.mdx
@@ -16,6 +16,12 @@ for those agents. There are two props for this, and choosing the right one matte
 yourself, for example an [`HttpAgent`](/backend/ag-ui) pointing at an
 AG-UI-compatible backend you own and have already secured:
 
+<Callout type="info" title="Part of Enterprise Intelligence">
+  `selfManagedAgents` is part of CopilotKit's [Enterprise
+  Intelligence](/premium/intelligence-platform) offering. Contact the CopilotKit
+  team about licensing for production use.
+</Callout>
+
 ```tsx
 import { HttpAgent } from "@ag-ui/client";
 import { CopilotKit } from "@copilotkit/react-core/v2";

--- a/showcase/shell-docs/src/content/docs/troubleshooting/error-reference.mdx
+++ b/showcase/shell-docs/src/content/docs/troubleshooting/error-reference.mdx
@@ -26,11 +26,11 @@ Missing required prop: 'runtimeUrl' or 'publicApiKey' or 'publicLicenseKey'
 `console.warn` so local-agent and test setups still run.
 
 <Callout type="info" title="v1 behaves differently">
-  The **v1** `<CopilotKit>` provider throws this error **unconditionally** (in
-  both development and production; there is no dev-only `console.warn` branch),
-  and it does **not** accept `selfManagedAgents`. On v1, satisfy the provider with
-  a `runtimeUrl` or a Copilot Cloud key, or pass agents directly via
-  `agents__unsafe_dev_only` for local development.
+  The **v1** `<CopilotKit>` provider throws this error in **both development and
+  production** when nothing is configured — unlike v2, it has no dev-only
+  `console.warn` branch. Like v2, it accepts local agents: registering
+  `selfManagedAgents` or `agents__unsafe_dev_only` satisfies the check without a
+  `runtimeUrl` or a Copilot Cloud key.
 </Callout>
 
 **Cause:** the provider has no way to reach an agent. You didn't pass a
@@ -47,7 +47,7 @@ didn't register any local agents.
 // Copilot Cloud
 <CopilotKitProvider publicApiKey="ck_pub_...">{children}</CopilotKitProvider>
 
-// Agents you manage yourself (v2 only)
+// Agents you manage yourself (works on both the v1 `<CopilotKit>` wrapper and v2)
 <CopilotKitProvider selfManagedAgents={{ "my-agent": myAgent }}>{children}</CopilotKitProvider>
 ```
 

--- a/showcase/shell-docs/src/content/docs/troubleshooting/error-reference.mdx
+++ b/showcase/shell-docs/src/content/docs/troubleshooting/error-reference.mdx
@@ -47,7 +47,7 @@ didn't register any local agents.
 // Copilot Cloud
 <CopilotKitProvider publicApiKey="ck_pub_...">{children}</CopilotKitProvider>
 
-// Agents you manage yourself (works on both the v1 `<CopilotKit>` wrapper and v2)
+// Agents you manage yourself — the `selfManagedAgents` prop is also accepted by the v1 `<CopilotKit>` wrapper
 <CopilotKitProvider selfManagedAgents={{ "my-agent": myAgent }}>{children}</CopilotKitProvider>
 ```
 

--- a/showcase/shell-docs/src/content/docs/troubleshooting/error-reference.mdx
+++ b/showcase/shell-docs/src/content/docs/troubleshooting/error-reference.mdx
@@ -26,11 +26,11 @@ Missing required prop: 'runtimeUrl' or 'publicApiKey' or 'publicLicenseKey'
 `console.warn` so local-agent and test setups still run.
 
 <Callout type="info" title="v1 behaves differently">
-  The **v1** `<CopilotKit>` provider throws this error in **both development and
-  production** when nothing is configured — unlike v2, it has no dev-only
-  `console.warn` branch. Like v2, it accepts local agents: registering
-  `selfManagedAgents` or `agents__unsafe_dev_only` satisfies the check without a
-  `runtimeUrl` or a Copilot Cloud key.
+  The **v1** `<CopilotKit>` provider throws in **both development and
+  production** when nothing is configured, whereas the v2 `<CopilotKitProvider>`
+  only warns in development. Either way, registering `selfManagedAgents` or
+  `agents__unsafe_dev_only` satisfies the check — no `runtimeUrl` or Copilot
+  Cloud key required.
 </Callout>
 
 **Cause:** the provider has no way to reach an agent. You didn't pass a


### PR DESCRIPTION
## Summary

Fixes #5417. The v1 `<CopilotKit>` wrapper's `validateProps` threw `ConfigurationError: Missing required prop: 'runtimeUrl' or 'publicApiKey' or 'publicLicenseKey'` whenever neither `runtimeUrl` nor a public key was supplied — without considering self-managed agents. This rejected the documented self-managed-agent setup, even though the underlying v2 `CopilotKitProvider` accepts it via its `hasLocalAgents` gate.

- **Fix:** `validateProps` now mirrors the provider's `hasLocalAgents` check, so `selfManagedAgents` and `agents__unsafe_dev_only` satisfy the requirement without a `runtimeUrl` or Cloud key.
- **Test:** new rendering test pins the behavior — still throws when nothing is configured, no longer throws when local agents are supplied.
- **Docs:** the showcase error-reference "v1 behaves differently" callout claimed the wrapper throws unconditionally and rejects `selfManagedAgents` (both now false); corrected, and dropped the "(v2 only)" label on the self-managed example.

## Test plan

- [x] `nx test react-core` — 1284 passing, 0 failing
- [x] New test fails before the fix (red) and passes after (green)
- [x] No new type errors introduced (pre-existing `tsc` noise unchanged vs `main`)