### PR TITLE
chore: prepare angular package release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -103,7 +103,8 @@ jobs:
             SCOPE="$INPUT_SCOPE"
           else
             # Branch format: release/publish/<scope>/v<version>
-            SCOPE=$(echo "$PR_HEAD_REF" | sed 's|release/publish/\([^/]*\)/v.*|\1|')
+            SCOPE="${PR_HEAD_REF#release/publish/}"
+            SCOPE="${SCOPE%%/v*}"
           fi
           MODE="${INPUT_MODE:-stable}"
           echo "scope=$SCOPE" >> "$GITHUB_OUTPUT"
@@ -206,7 +207,8 @@ jobs:
             SCOPE="$INPUT_SCOPE"
           else
             # Branch format: release/publish/<scope>/v<version>
-            SCOPE=$(echo "$PR_HEAD_REF" | sed 's|release/publish/\([^/]*\)/v.*|\1|')
+            SCOPE="${PR_HEAD_REF#release/publish/}"
+            SCOPE="${SCOPE%%/v*}"
           fi
           if [ -z "$SCOPE" ]; then
             echo "::error::Failed to resolve scope (input=$INPUT_SCOPE, ref=$PR_HEAD_REF)"
@@ -249,9 +251,11 @@ jobs:
       - name: Dry-run notice
         if: ${{ inputs.dry-run == true }}
         run: |
-          echo "## Dry Run" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "DRY RUN — skipping publish step. Scope: ${{ steps.meta.outputs.scope }}, mode: ${{ steps.meta.outputs.mode }}." >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Dry Run"
+            echo ""
+            echo "DRY RUN — skipping publish step. Scope: ${{ steps.meta.outputs.scope }}, mode: ${{ steps.meta.outputs.mode }}."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Publish to npm
         id: publish
@@ -315,7 +319,7 @@ jobs:
           fi
           git tag -a "$TAG" -m "Release ${SCOPE} ${VERSION}"
           git push origin "$TAG"
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
         id: tag
 
       - name: Create GitHub Release

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,7 +2,7 @@
 #
 # Single npm OIDC entry point for both stable releases and prerelease canaries.
 # npm trusted publisher records for the 15 @copilotkit/* monorepo packages plus
-# @copilotkitnext/angular are registered against THIS workflow file. Matching
+# @copilotkit/angular are registered against THIS workflow file. Matching
 # happens on the OIDC token's `workflow_ref` claim, which is always
 # publish-release.yml when this workflow is the entry point.
 #
@@ -750,7 +750,7 @@ jobs:
           set -euo pipefail
           case "$SCOPE" in
             angular)
-              NPM_URL="https://www.npmjs.com/package/@copilotkitnext/angular"
+              NPM_URL="https://www.npmjs.com/package/@copilotkit/angular"
               ;;
             *)
               NPM_URL="https://www.npmjs.com/org/copilotkit"

--- a/examples/v2/angular/demo/package.json
+++ b/examples/v2/angular/demo/package.json
@@ -29,7 +29,7 @@
     "@copilotkit/core": "workspace:*",
     "@copilotkit/shared": "workspace:*",
     "@copilotkit/web-inspector": "workspace:*",
-    "@copilotkitnext/angular": "workspace:*",
+    "@copilotkit/angular": "workspace:*",
     "@jetbrains/websandbox": "^1.1.3",
     "@tanstack/pacer": "^0.20.1",
     "clsx": "^2.1.1",

--- a/examples/v2/angular/demo/src/app/app.config.ts
+++ b/examples/v2/angular/demo/src/app/app.config.ts
@@ -5,7 +5,7 @@ import { provideRouter } from "@angular/router";
 import {
   provideCopilotKit,
   provideCopilotChatLabels,
-} from "@copilotkitnext/angular";
+} from "@copilotkit/angular";
 import { WildcardToolRenderComponent } from "./components/wildcard-tool-render.component";
 import { a2uiDemoSandboxFunctions } from "./routes/a2ui/a2ui-demo-sandbox-functions";
 import { routes } from "./app.routes";

--- a/examples/v2/angular/demo/src/app/components/demo-web-inspector.component.ts
+++ b/examples/v2/angular/demo/src/app/components/demo-web-inspector.component.ts
@@ -1,5 +1,5 @@
 import { afterNextRender, Component, DestroyRef, inject } from "@angular/core";
-import { CopilotKit } from "@copilotkitnext/angular";
+import { CopilotKit } from "@copilotkit/angular";
 import { WEB_INSPECTOR_TAG } from "@copilotkit/web-inspector";
 import type { WebInspectorElement } from "@copilotkit/web-inspector";
 

--- a/examples/v2/angular/demo/src/app/components/wildcard-tool-render.component.ts
+++ b/examples/v2/angular/demo/src/app/components/wildcard-tool-render.component.ts
@@ -14,7 +14,7 @@ import {
   Wrench,
 } from "lucide-angular";
 
-import type { AngularToolCall, ToolRenderer } from "@copilotkitnext/angular";
+import type { AngularToolCall, ToolRenderer } from "@copilotkit/angular";
 
 type WildcardToolArgs = Record<string, unknown>;
 

--- a/examples/v2/angular/demo/src/app/routes/a2ui/a2ui-demo-input.component.ts
+++ b/examples/v2/angular/demo/src/app/routes/a2ui/a2ui-demo-input.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, input } from "@angular/core";
-import { CopilotChatInput, injectChatState } from "@copilotkitnext/angular";
-import type { ToolsMenuItem } from "@copilotkitnext/angular";
+import { CopilotChatInput, injectChatState } from "@copilotkit/angular";
+import type { ToolsMenuItem } from "@copilotkit/angular";
 
 @Component({
   selector: "a2ui-demo-input",

--- a/examples/v2/angular/demo/src/app/routes/a2ui/a2ui-demo-sandbox-functions.ts
+++ b/examples/v2/angular/demo/src/app/routes/a2ui/a2ui-demo-sandbox-functions.ts
@@ -1,4 +1,4 @@
-import type { SandboxFunction } from "@copilotkitnext/angular";
+import type { SandboxFunction } from "@copilotkit/angular";
 import { z } from "zod";
 
 export type Theme = "light" | "dark";

--- a/examples/v2/angular/demo/src/app/routes/a2ui/a2ui-demo.component.ts
+++ b/examples/v2/angular/demo/src/app/routes/a2ui/a2ui-demo.component.ts
@@ -11,8 +11,8 @@ import {
   connectAgentContext,
   provideCopilotChatLabels,
   registerFrontendTool,
-} from "@copilotkitnext/angular";
-import type { AttachmentsConfig } from "@copilotkitnext/angular";
+} from "@copilotkit/angular";
+import type { AttachmentsConfig } from "@copilotkit/angular";
 import { A2UIDemoInputComponent } from "./a2ui-demo-input.component";
 import { z } from "zod";
 import { bindA2UIDemoThemeHandler } from "./a2ui-demo-sandbox-functions";

--- a/examples/v2/angular/demo/src/app/routes/custom-input/custom-chat-input.component.ts
+++ b/examples/v2/angular/demo/src/app/routes/custom-input/custom-chat-input.component.ts
@@ -6,7 +6,7 @@ import {
 } from "@angular/core";
 
 import { FormsModule } from "@angular/forms";
-import { injectChatState } from "@copilotkitnext/angular";
+import { injectChatState } from "@copilotkit/angular";
 
 @Component({
   selector: "nextgen-custom-input",

--- a/examples/v2/angular/demo/src/app/routes/custom-input/custom-input-chat.component.ts
+++ b/examples/v2/angular/demo/src/app/routes/custom-input/custom-input-chat.component.ts
@@ -4,7 +4,7 @@ import {
   CopilotChatView,
   CopilotChat,
   provideCopilotChatLabels,
-} from "@copilotkitnext/angular";
+} from "@copilotkit/angular";
 import { CustomChatInputComponent } from "./custom-chat-input.component";
 
 @Component({

--- a/examples/v2/angular/demo/src/app/routes/default/default-chat.component.ts
+++ b/examples/v2/angular/demo/src/app/routes/default/default-chat.component.ts
@@ -1,6 +1,6 @@
 import { Component } from "@angular/core";
 
-import { CopilotChat } from "@copilotkitnext/angular";
+import { CopilotChat } from "@copilotkit/angular";
 
 @Component({
   selector: "default-chat",

--- a/examples/v2/angular/demo/src/app/routes/headless/headless-chat.component.ts
+++ b/examples/v2/angular/demo/src/app/routes/headless/headless-chat.component.ts
@@ -13,14 +13,14 @@ import { FormsModule } from "@angular/forms";
 import type {
   HumanInTheLoopToolCall,
   HumanInTheLoopToolRenderer,
-} from "@copilotkitnext/angular";
+} from "@copilotkit/angular";
 import {
   connectAgentContext,
   CopilotKit,
   injectAgentStore,
   registerHumanInTheLoop,
-} from "@copilotkitnext/angular";
-import { RenderToolCalls } from "@copilotkitnext/angular";
+} from "@copilotkit/angular";
+import { RenderToolCalls } from "@copilotkit/angular";
 import { WEB_INSPECTOR_TAG } from "@copilotkit/web-inspector";
 import type { WebInspectorElement } from "@copilotkit/web-inspector";
 import { z } from "zod";

--- a/examples/v2/angular/demo/src/app/routes/ukg-port/co-pilot-port.component.ts
+++ b/examples/v2/angular/demo/src/app/routes/ukg-port/co-pilot-port.component.ts
@@ -1,8 +1,5 @@
 import { ChangeDetectionStrategy, Component } from "@angular/core";
-import {
-  CopilotChatView,
-  provideCopilotChatLabels,
-} from "@copilotkitnext/angular";
+import { CopilotChatView, provideCopilotChatLabels } from "@copilotkit/angular";
 import { CustomChatInputComponent } from "../custom-input/custom-chat-input.component";
 
 @Component({

--- a/examples/v2/angular/demo/tsconfig.json
+++ b/examples/v2/angular/demo/tsconfig.json
@@ -13,8 +13,8 @@
     "emitDecoratorMetadata": true,
     "baseUrl": ".",
     "paths": {
-      "@copilotkitnext/angular": ["../../../../packages/angular/src/index.ts"],
-      "@copilotkitnext/angular/*": ["../../../../packages/angular/src/*"],
+      "@copilotkit/angular": ["../../../../packages/angular/src/index.ts"],
+      "@copilotkit/angular/*": ["../../../../packages/angular/src/*"],
       "@copilotkit/core": ["node_modules/@copilotkit/core"],
       "@copilotkit/shared": ["node_modules/@copilotkit/shared"],
       "@copilotkit/web-inspector": ["node_modules/@copilotkit/web-inspector"],

--- a/examples/v2/angular/storybook/components/custom-input.component.ts
+++ b/examples/v2/angular/storybook/components/custom-input.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { FormsModule } from "@angular/forms";
-import type { ChatState } from "@copilotkitnext/angular";
+import type { ChatState } from "@copilotkit/angular";
 
 @Component({
   selector: "custom-input",

--- a/examples/v2/angular/storybook/package.json
+++ b/examples/v2/angular/storybook/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.6-next.1",
   "private": true,
   "scripts": {
-    "dev": "pnpm --filter @copilotkitnext/angular run build:css && sleep 1 && ng run storybook-angular:storybook",
+    "dev": "pnpm --filter @copilotkit/angular run build:css && sleep 1 && ng run storybook-angular:storybook",
     "build": "ng run storybook-angular:build-storybook",
-    "storybook:dev": "pnpm --filter @copilotkitnext/angular run build:css && sleep 1 && ng run storybook-angular:storybook",
+    "storybook:dev": "pnpm --filter @copilotkit/angular run build:css && sleep 1 && ng run storybook-angular:storybook",
     "storybook:build": "ng run storybook-angular:build-storybook"
   },
   "dependencies": {
@@ -29,7 +29,7 @@
     "@angular/cli": "^21.2.13",
     "@angular/compiler-cli": "^21.2.15",
     "@copilotkit/typescript-config": "workspace:*",
-    "@copilotkitnext/angular": "workspace:*",
+    "@copilotkit/angular": "workspace:*",
     "@storybook/addon-themes": "10.3.6",
     "@storybook/angular": "10.3.6",
     "@tailwindcss/postcss": "^4.1.12",

--- a/examples/v2/angular/storybook/stories/CopilotChatAssistantMessage.stories.ts
+++ b/examples/v2/angular/storybook/stories/CopilotChatAssistantMessage.stories.ts
@@ -6,7 +6,7 @@ import { Component, Input } from "@angular/core";
 import {
   CopilotChatAssistantMessage,
   provideCopilotChatLabels,
-} from "@copilotkitnext/angular";
+} from "@copilotkit/angular";
 import type { AssistantMessage } from "@ag-ui/client";
 
 // Simple default message
@@ -356,7 +356,7 @@ export const Default: Story = {
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatAssistantMessage } from '@copilotkitnext/angular';
+import { CopilotChatAssistantMessage } from '@copilotkit/angular';
 import { AssistantMessage } from '@ag-ui/client';
 
 @Component({
@@ -413,7 +413,7 @@ export const TestAllMarkdownFeatures: Story = {
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatAssistantMessage } from '@copilotkitnext/angular';
+import { CopilotChatAssistantMessage } from '@copilotkit/angular';
 import { AssistantMessage } from '@ag-ui/client';
 
 @Component({
@@ -502,7 +502,7 @@ export const WithToolbarButtons: Story = {
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatAssistantMessage } from '@copilotkitnext/angular';
+import { CopilotChatAssistantMessage } from '@copilotkit/angular';
 import { AssistantMessage } from '@ag-ui/client';
 
 @Component({
@@ -595,7 +595,7 @@ export const WithAdditionalToolbarItems: Story = {
       source: {
         type: "code",
         code: `import { Component, ViewChild, TemplateRef } from '@angular/core';
-import { CopilotChatAssistantMessage } from '@copilotkitnext/angular';
+import { CopilotChatAssistantMessage } from '@copilotkit/angular';
 import { AssistantMessage } from '@ag-ui/client';
 
 @Component({
@@ -678,7 +678,7 @@ export const CodeBlocksWithLanguages: Story = {
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatAssistantMessage } from '@copilotkitnext/angular';
+import { CopilotChatAssistantMessage } from '@copilotkit/angular';
 import { AssistantMessage } from '@ag-ui/client';
 
 @Component({

--- a/examples/v2/angular/storybook/stories/CopilotChatInput.stories.ts
+++ b/examples/v2/angular/storybook/stories/CopilotChatInput.stories.ts
@@ -15,8 +15,8 @@ import {
   CopilotChatInput,
   provideCopilotChatLabels,
   provideCopilotKit,
-} from "@copilotkitnext/angular";
-import type { ToolsMenuItem } from "@copilotkitnext/angular";
+} from "@copilotkit/angular";
+import type { ToolsMenuItem } from "@copilotkit/angular";
 import { CustomSendButtonComponent } from "../components/custom-send-button.component";
 
 @Injectable()
@@ -159,8 +159,8 @@ The CopilotChatInput component provides a feature-rich chat input interface for 
 ## Basic Usage
 
 \`\`\`typescript
-import { CopilotChatInput } from '@copilotkitnext/angular';
-import { provideCopilotChatLabels } from '@copilotkitnext/angular';
+import { CopilotChatInput } from '@copilotkit/angular';
+import { provideCopilotChatLabels } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',
@@ -278,7 +278,7 @@ export const Default: Story = {
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatInput, provideCopilotChatLabels } from '@copilotkitnext/angular';
+import { CopilotChatInput, provideCopilotChatLabels } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',
@@ -396,7 +396,7 @@ toolsMenu: [
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatInput, ToolsMenuItem } from '@copilotkitnext/angular';
+import { CopilotChatInput, ToolsMenuItem } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',
@@ -484,7 +484,7 @@ Emits:
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatInput } from '@copilotkitnext/angular';
+import { CopilotChatInput } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',
@@ -580,7 +580,7 @@ The template receives:
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatInput } from '@copilotkitnext/angular';
+import { CopilotChatInput } from '@copilotkit/angular';
 
 // Custom send button component
 @Component({
@@ -712,7 +712,7 @@ Note: The template is passed as an input property, not as content projection.
       source: {
         type: "code",
         code: `import { Component, ViewChild, TemplateRef } from '@angular/core';
-import { CopilotChatInput } from '@copilotkitnext/angular';
+import { CopilotChatInput } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',
@@ -796,7 +796,7 @@ Useful for:
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatInput } from '@copilotkitnext/angular';
+import { CopilotChatInput } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',
@@ -850,7 +850,7 @@ Features:
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatInput } from '@copilotkitnext/angular';
+import { CopilotChatInput } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',
@@ -976,7 +976,7 @@ This example shows:
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatInput } from '@copilotkitnext/angular';
+import { CopilotChatInput } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',
@@ -1079,7 +1079,7 @@ The most flexible approach - use ng-template to completely control the send butt
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatInput } from '@copilotkitnext/angular';
+import { CopilotChatInput } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',

--- a/examples/v2/angular/storybook/stories/CopilotChatMessageView.stories.ts
+++ b/examples/v2/angular/storybook/stories/CopilotChatMessageView.stories.ts
@@ -7,14 +7,14 @@ import type {
   RenderToolCallConfig,
   ToolRenderer,
   AngularToolCall,
-} from "@copilotkitnext/angular";
+} from "@copilotkit/angular";
 import {
   CopilotChatMessageView,
   CopilotChatMessageViewCursor,
   CopilotKit,
   provideCopilotKit,
   provideCopilotChatLabels,
-} from "@copilotkitnext/angular";
+} from "@copilotkit/angular";
 import { ToolCallStatus } from "@copilotkit/core";
 import { z } from "zod"; // Schema validation
 
@@ -66,7 +66,7 @@ export const Default: Story = {
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatMessageView, Message } from '@copilotkitnext/angular';
+import { CopilotChatMessageView, Message } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',
@@ -220,7 +220,7 @@ export const ShowCursor: Story = {
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatMessageView, Message } from '@copilotkitnext/angular';
+import { CopilotChatMessageView, Message } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',
@@ -598,7 +598,7 @@ import {
   ToolCall, 
   ToolMessage,
   provideCopilotKit
-} from '@copilotkitnext/angular';
+} from '@copilotkit/angular';
 import { ToolCallStatus } from '@copilotkit/core';
 import { z } from 'zod';
 

--- a/examples/v2/angular/storybook/stories/CopilotChatUserMessage.stories.ts
+++ b/examples/v2/angular/storybook/stories/CopilotChatUserMessage.stories.ts
@@ -4,7 +4,7 @@ import { CommonModule } from "@angular/common";
 import {
   CopilotChatUserMessage,
   provideCopilotChatLabels,
-} from "@copilotkitnext/angular";
+} from "@copilotkit/angular";
 import type { UserMessage } from "@ag-ui/client";
 
 // Simple default message
@@ -106,7 +106,7 @@ export const Default: Story = {
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatUserMessage, UserMessage } from '@copilotkitnext/angular';
+import { CopilotChatUserMessage, UserMessage } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',
@@ -146,7 +146,7 @@ export const LongMessage: Story = {
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatUserMessage, UserMessage } from '@copilotkitnext/angular';
+import { CopilotChatUserMessage, UserMessage } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',
@@ -196,7 +196,7 @@ export const WithEditButton: Story = {
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatUserMessage, UserMessage } from '@copilotkitnext/angular';
+import { CopilotChatUserMessage, UserMessage } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',
@@ -238,7 +238,7 @@ export const WithoutEditButton: Story = {
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatUserMessage, UserMessage } from '@copilotkitnext/angular';
+import { CopilotChatUserMessage, UserMessage } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',
@@ -276,7 +276,7 @@ export const CodeRelatedMessage: Story = {
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatUserMessage, UserMessage } from '@copilotkitnext/angular';
+import { CopilotChatUserMessage, UserMessage } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',
@@ -335,7 +335,7 @@ export const ShortQuestion: Story = {
       source: {
         type: "code",
         code: `import { Component } from '@angular/core';
-import { CopilotChatUserMessage, UserMessage } from '@copilotkitnext/angular';
+import { CopilotChatUserMessage, UserMessage } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',
@@ -404,7 +404,7 @@ export const WithAdditionalToolbarItems: Story = {
       source: {
         type: "code",
         code: `import { Component, ViewChild, TemplateRef } from '@angular/core';
-import { CopilotChatUserMessage, UserMessage } from '@copilotkitnext/angular';
+import { CopilotChatUserMessage, UserMessage } from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat',

--- a/examples/v2/angular/storybook/stories/CopilotChatView-Actions.stories.ts
+++ b/examples/v2/angular/storybook/stories/CopilotChatView-Actions.stories.ts
@@ -8,7 +8,7 @@ import {
   CopilotChatInput,
   provideCopilotChatLabels,
   provideCopilotKit,
-} from "@copilotkitnext/angular";
+} from "@copilotkit/angular";
 import type { Message } from "@ag-ui/client";
 
 const meta: Meta<CopilotChatView> = {
@@ -53,7 +53,7 @@ import {
   CopilotChatInput,
   provideCopilotKit,
   provideCopilotChatLabels
-} from '@copilotkitnext/angular';
+} from '@copilotkit/angular';
 import { Message } from '@ag-ui/client';
 
 // Custom disclaimer component

--- a/examples/v2/angular/storybook/stories/CopilotChatView-CSS.stories.ts
+++ b/examples/v2/angular/storybook/stories/CopilotChatView-CSS.stories.ts
@@ -8,7 +8,7 @@ import {
   CopilotChatInput,
   provideCopilotChatLabels,
   provideCopilotKit,
-} from "@copilotkitnext/angular";
+} from "@copilotkit/angular";
 import type { Message } from "@ag-ui/client";
 
 const meta: Meta<CopilotChatView> = {

--- a/examples/v2/angular/storybook/stories/CopilotChatView-Components.stories.ts
+++ b/examples/v2/angular/storybook/stories/CopilotChatView-Components.stories.ts
@@ -10,7 +10,7 @@ import {
   ChatState,
   provideCopilotChatLabels,
   provideCopilotKit,
-} from "@copilotkitnext/angular";
+} from "@copilotkit/angular";
 import type { Message } from "@ag-ui/client";
 import { CustomDisclaimerComponent } from "../components/custom-disclaimer.component";
 import { CustomInputComponent } from "../components/custom-input.component";
@@ -75,7 +75,7 @@ import {
   CopilotChatInput,
   provideCopilotKit,
   provideCopilotChatLabels
-} from '@copilotkitnext/angular';
+} from '@copilotkit/angular';
 import { Message } from '@ag-ui/client';
 
 // Custom disclaimer component
@@ -209,7 +209,7 @@ import {
   ChatState,
   provideCopilotKit,
   provideCopilotChatLabels
-} from '@copilotkitnext/angular';
+} from '@copilotkit/angular';
 import { Message } from '@ag-ui/client';
 
 // Custom input component
@@ -364,7 +364,7 @@ import {
   CopilotChatInput,
   provideCopilotKit,
   provideCopilotChatLabels
-} from '@copilotkitnext/angular';
+} from '@copilotkit/angular';
 import { Message } from '@ag-ui/client';
 
 // Custom scroll button component
@@ -511,7 +511,7 @@ import {
   CopilotChatInput,
   provideCopilotKit,
   provideCopilotChatLabels
-} from '@copilotkitnext/angular';
+} from '@copilotkit/angular';
 import { Message } from '@ag-ui/client';
 
 &#64;Component({
@@ -616,7 +616,7 @@ import {
   ChatState,
   provideCopilotKit,
   provideCopilotChatLabels
-} from '@copilotkitnext/angular';
+} from '@copilotkit/angular';
 import { Message } from '@ag-ui/client';
 
 // Minimal custom input component with service injection

--- a/examples/v2/angular/storybook/stories/CopilotChatView-Templates.stories.ts
+++ b/examples/v2/angular/storybook/stories/CopilotChatView-Templates.stories.ts
@@ -10,7 +10,7 @@ import {
   ChatState,
   provideCopilotChatLabels,
   provideCopilotKit,
-} from "@copilotkitnext/angular";
+} from "@copilotkit/angular";
 import type { Message } from "@ag-ui/client";
 
 @Injectable()

--- a/examples/v2/angular/storybook/stories/CopilotChatView.stories.ts
+++ b/examples/v2/angular/storybook/stories/CopilotChatView.stories.ts
@@ -7,7 +7,7 @@ import {
   CopilotChatInput,
   provideCopilotChatLabels,
   provideCopilotKit,
-} from "@copilotkitnext/angular";
+} from "@copilotkit/angular";
 import type { Message } from "@ag-ui/client";
 
 const meta: Meta<CopilotChatView> = {
@@ -53,7 +53,7 @@ import {
   CopilotChatInput,
   provideCopilotKit,
   provideCopilotChatLabels
-} from '@copilotkitnext/angular';
+} from '@copilotkit/angular';
 import { Message } from '@ag-ui/client';
 
 @Component({
@@ -95,12 +95,12 @@ export class ChatComponent {
 
 1. Install the package:
 \\\`\\\`\\\`bash
-npm install @copilotkitnext/angular
+npm install @copilotkit/angular
 \\\`\\\`\\\`
 
 2. Import and configure in your component:
 \\\`\\\`\\\`typescript
-import { provideCopilotKit } from '@copilotkitnext/angular';
+import { provideCopilotKit } from '@copilotkit/angular';
 
 @Component({
   providers: [provideCopilotKit({})]
@@ -149,12 +149,12 @@ import { provideCopilotKit } from '@copilotkitnext/angular';
 
 1. Install the package:
 \`\`\`bash
-npm install @copilotkitnext/angular
+npm install @copilotkit/angular
 \`\`\`
 
 2. Import and configure in your component:
 \`\`\`typescript
-import { provideCopilotKit } from '@copilotkitnext/angular';
+import { provideCopilotKit } from '@copilotkit/angular';
 
 @Component({
   providers: [provideCopilotKit({})]
@@ -218,7 +218,7 @@ import {
   CopilotChatView,
   provideCopilotKit,
   provideCopilotChatLabels
-} from '@copilotkitnext/angular';
+} from '@copilotkit/angular';
 import { Message } from '@ag-ui/client';
 
 @Component({
@@ -313,7 +313,7 @@ import {
   CopilotChatView,
   provideCopilotKit,
   provideCopilotChatLabels
-} from '@copilotkitnext/angular';
+} from '@copilotkit/angular';
 
 @Component({
   selector: 'app-chat-empty',

--- a/examples/v2/angular/storybook/tsconfig.json
+++ b/examples/v2/angular/storybook/tsconfig.json
@@ -16,8 +16,8 @@
     "useDefineForClassFields": false,
     "baseUrl": ".",
     "paths": {
-      "@copilotkitnext/angular": ["../../../../packages/angular/src/index.ts"],
-      "@copilotkitnext/angular/*": ["../../../../packages/angular/src/*"],
+      "@copilotkit/angular": ["../../../../packages/angular/src/index.ts"],
+      "@copilotkit/angular/*": ["../../../../packages/angular/src/*"],
       "@copilotkit/a2ui-renderer": ["node_modules/@copilotkit/a2ui-renderer"],
       "@copilotkit/a2ui-renderer/web-components": [
         "node_modules/@copilotkit/a2ui-renderer/web-components"

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -6,7 +6,7 @@ Angular bindings for CopilotKit core and AG-UI agents. This package provides ser
 
 ```bash
 # npm
-npm install @copilotkitnext/angular
+npm install @copilotkit/angular
 ```
 
 Peer dependencies you provide in your app:
@@ -14,15 +14,6 @@ Peer dependencies you provide in your app:
 - `@angular/core` and `@angular/common` (19, 20, or 21)
 - `@angular/cdk` (match your Angular major)
 - `rxjs`
-
-> **TypeScript note:** if your build reports `TS7016: Could not find a declaration file for module '@copilotkitnext/angular'`, add a `paths` entry pointing at the bundled types until the package's `exports` map ships a `types` condition:
->
-> ```jsonc
-> // tsconfig.json → compilerOptions
-> "paths": {
->   "@copilotkitnext/angular": ["./node_modules/@copilotkitnext/angular/dist/index.d.ts"]
-> }
-> ```
 
 ## Quick start
 
@@ -32,7 +23,7 @@ Configure runtime and tools in your app config:
 
 ```ts
 import { ApplicationConfig } from "@angular/core";
-import { provideCopilotKit } from "@copilotkitnext/angular";
+import { provideCopilotKit } from "@copilotkit/angular";
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -50,7 +41,7 @@ export const appConfig: ApplicationConfig = {
 ```ts
 import { Component, inject, signal } from "@angular/core";
 import { Message } from "@ag-ui/client";
-import { CopilotKit, injectAgentStore } from "@copilotkitnext/angular";
+import { CopilotKit, injectAgentStore } from "@copilotkit/angular";
 import { randomUUID } from "@copilotkit/shared";
 
 @Component({
@@ -187,7 +178,7 @@ Advanced factory for creating `AgentStore` signals. Most apps should use `inject
 Connect AG-UI context to the runtime (auto-cleanup when the effect is destroyed):
 
 ```ts
-import { connectAgentContext } from "@copilotkitnext/angular";
+import { connectAgentContext } from "@copilotkit/angular";
 
 connectAgentContext({
   description: "User preferences",
@@ -259,7 +250,7 @@ import {
   registerFrontendTool,
   registerRenderToolCall,
   registerHumanInTheLoop,
-} from "@copilotkitnext/angular";
+} from "@copilotkit/angular";
 import { z } from "zod";
 
 registerFrontendTool({

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@copilotkitnext/angular",
-  "version": "1.54.3",
+  "name": "@copilotkit/angular",
+  "version": "0.1.0",
   "description": "Angular library for CopilotKit",
   "license": "MIT",
   "repository": {
@@ -9,12 +9,15 @@
     "directory": "packages/angular"
   },
   "type": "module",
-  "main": "dist/fesm2022/copilotkitnext-angular.mjs",
-  "module": "dist/fesm2022/copilotkitnext-angular.mjs",
-  "types": "dist/types/copilotkitnext-angular.d.ts",
+  "main": "dist/fesm2022/copilotkit-angular.mjs",
+  "module": "dist/fesm2022/copilotkit-angular.mjs",
+  "types": "dist/types/copilotkit-angular.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/fesm2022/copilotkitnext-angular.mjs"
+      "import": {
+        "types": "./dist/types/copilotkit-angular.d.ts",
+        "default": "./dist/fesm2022/copilotkit-angular.mjs"
+      }
     },
     "./styles.css": "./dist/styles.css"
   },

--- a/packages/angular/src/lib/components/chat/copilot-chat-input-defaults.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat-input-defaults.ts
@@ -16,7 +16,7 @@ import { CopilotChatToolsMenu } from "./copilot-chat-tools-menu";
  *
  * @example
  * ```typescript
- * import { CopilotChatInputDefaults } from '@copilotkitnext/angular';
+ * import { CopilotChatInputDefaults } from '@copilotkit/angular';
  *
  * @Component({
  *   template: `

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1141,6 +1141,9 @@ importers:
       '@copilotkit/a2ui-renderer':
         specifier: workspace:*
         version: link:../../../../packages/a2ui-renderer
+      '@copilotkit/angular':
+        specifier: workspace:*
+        version: link:../../../../packages/angular
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../../../../packages/core
@@ -1150,9 +1153,6 @@ importers:
       '@copilotkit/web-inspector':
         specifier: workspace:*
         version: link:../../../../packages/web-inspector
-      '@copilotkitnext/angular':
-        specifier: workspace:*
-        version: link:../../../../packages/angular
       '@jetbrains/websandbox':
         specifier: ^1.1.3
         version: 1.1.3
@@ -1318,12 +1318,12 @@ importers:
       '@angular/compiler-cli':
         specifier: ^21.2.15
         version: 21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3)
+      '@copilotkit/angular':
+        specifier: workspace:*
+        version: link:../../../../packages/angular
       '@copilotkit/typescript-config':
         specifier: workspace:*
         version: link:../../../../packages/typescript-config
-      '@copilotkitnext/angular':
-        specifier: workspace:*
-        version: link:../../../../packages/angular
       '@storybook/addon-themes':
         specifier: 10.3.6
         version: 10.3.6(storybook@10.3.6(@testing-library/dom@10.4.0)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))

--- a/release.config.json
+++ b/release.config.json
@@ -23,8 +23,8 @@
       "sharedVersion": true
     },
     "angular": {
-      "packages": ["@copilotkitnext/angular"],
-      "versionSource": "@copilotkitnext/angular",
+      "packages": ["@copilotkit/angular"],
+      "versionSource": "@copilotkit/angular",
       "sharedVersion": false
     },
     "bot": {

--- a/scripts/release/lib/build-release-notification.test.ts
+++ b/scripts/release/lib/build-release-notification.test.ts
@@ -6,7 +6,7 @@ const RUN_URL = "https://github.com/CopilotKit/CopilotKit/actions/runs/123";
 const RELEASE_URL =
   "https://github.com/CopilotKit/CopilotKit/releases/tag/v1.2.3";
 const NPM_URL = "https://www.npmjs.com/org/copilotkit";
-const ANGULAR_NPM_URL = "https://www.npmjs.com/package/@copilotkitnext/angular";
+const ANGULAR_NPM_URL = "https://www.npmjs.com/package/@copilotkit/angular";
 const PY_URL = "https://pypi.org/project/copilotkit/0.9.0/";
 
 // A neutral baseline where nothing has acted. Each test overrides only the

--- a/scripts/release/lib/versions.test.ts
+++ b/scripts/release/lib/versions.test.ts
@@ -26,8 +26,8 @@ vi.mock("./config.js", async () => {
           sharedVersion: true,
         },
         angular: {
-          packages: ["@copilotkitnext/angular"],
-          versionSource: "@copilotkitnext/angular",
+          packages: ["@copilotkit/angular"],
+          versionSource: "@copilotkit/angular",
           sharedVersion: false,
         },
       },
@@ -40,8 +40,8 @@ vi.mock("./config.js", async () => {
           sharedVersion: true,
         },
         angular: {
-          packages: ["@copilotkitnext/angular"],
-          versionSource: "@copilotkitnext/angular",
+          packages: ["@copilotkit/angular"],
+          versionSource: "@copilotkit/angular",
           sharedVersion: false,
         },
       };


### PR DESCRIPTION
## Summary

- Rename the Angular package from `@copilotkitnext/angular` to `@copilotkit/angular`.
- Reset the Angular package version to `0.1.0` and update package entrypoints for the generated `copilotkit-angular` bundle.
- Update release configuration, release notification tests, docs, lockfile, demo imports, and Storybook references to the new package name.

## Validation

- `pnpm nx run @copilotkit/angular:build`
- `pnpm nx run @copilotkit/angular:check-types --excludeTaskDependencies`
- `pnpm nx run @copilotkit/angular:publint`
- `pnpm nx run @copilotkit/angular:attw`
- `bash scripts/release/verify-release-scope-dropdowns.sh`
- `pnpm exec vitest run --config scripts/release/vitest.config.mts`
- Pre-commit package test/check hook completed successfully.

## Notes

- A full dependency type-check attempt surfaced existing `@copilotkit/core:check-types` errors before Angular ran, so Angular type-checking was rerun directly with dependency tasks excluded.
