### PR TITLE
docs(showcase): fix Deep Agents state streaming schema

### DIFF
--- a/docs/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
+++ b/docs/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
@@ -78,13 +78,13 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
             <Tab value="TypeScript">
                 ```ts title="agent.ts"
                 import { createMiddleware } from "langchain";
-                import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
+                import { copilotkitMiddleware, zodState } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
                 import { z } from "zod";
 
                 export const observedStepsMiddleware = createMiddleware({
                     name: "AgentState",
                     stateSchema: z.object({
-                        observed_steps: z.array(z.string()).default([]), // Array of completed steps
+                        observed_steps: zodState(z.array(z.string()).default([])), // Array of completed steps
                     }),
                 });
 
@@ -358,13 +358,13 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
           <Tab value="TypeScript">
             ```ts title="agent.ts"
             import { createMiddleware } from "langchain";
-            import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
+            import { copilotkitMiddleware, zodState } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
             import { z } from "zod";
 
             export const observedStepsMiddleware = createMiddleware({
                 name: "AgentState",
                 stateSchema: z.object({
-                    observed_steps: z.array(z.string()).default([]),
+                    observed_steps: zodState(z.array(z.string()).default([])),
                 }),
             });
             ```
@@ -424,6 +424,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                     observedStepsMiddleware,
                     copilotkitMiddleware,
                     stateStreamingMiddleware(  // [!code highlight]
+                        // Map the tool's `steps` argument into the `observed_steps` state field.
                         stateItem({ stateKey: "observed_steps", tool: "step_progress_tool", toolArgument: "steps" })  // [!code highlight]
                     ),  // [!code highlight]
                 ],

--- a/docs/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
+++ b/docs/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
@@ -78,13 +78,13 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
             <Tab value="TypeScript">
                 ```ts title="agent.ts"
                 import { createMiddleware } from "langchain";
-                import { copilotkitMiddleware, zodState } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
+                import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
                 import { z } from "zod";
 
                 export const observedStepsMiddleware = createMiddleware({
                     name: "AgentState",
                     stateSchema: z.object({
-                        observed_steps: zodState(z.array(z.string()).default([])), // Array of completed steps
+                        observed_steps: z.array(z.string()).default([]), // Array of completed steps
                     }),
                 });
 
@@ -358,13 +358,13 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
           <Tab value="TypeScript">
             ```ts title="agent.ts"
             import { createMiddleware } from "langchain";
-            import { copilotkitMiddleware, zodState } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
+            import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
             import { z } from "zod";
 
             export const observedStepsMiddleware = createMiddleware({
                 name: "AgentState",
                 stateSchema: z.object({
-                    observed_steps: zodState(z.array(z.string()).default([])),
+                    observed_steps: z.array(z.string()).default([]),
                 }),
             });
             ```
@@ -424,7 +424,6 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                     observedStepsMiddleware,
                     copilotkitMiddleware,
                     stateStreamingMiddleware(  // [!code highlight]
-                        // Map the tool's `steps` argument into the `observed_steps` state field.
                         stateItem({ stateKey: "observed_steps", tool: "step_progress_tool", toolArgument: "steps" })  // [!code highlight]
                     ),  // [!code highlight]
                 ],

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/shared-state/predictive-state-updates.mdx
@@ -68,13 +68,13 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
             <Tab value="TypeScript">
                 ```ts title="agent.ts"
                 import { createMiddleware } from "langchain";
-                import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
+                import { copilotkitMiddleware, zodState } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
                 import { z } from "zod";
 
                 export const observedStepsMiddleware = createMiddleware({
                     name: "AgentState",
                     stateSchema: z.object({
-                        observed_steps: z.array(z.string()).default([]), // Array of completed steps
+                        observed_steps: zodState(z.array(z.string()).default([])), // Array of completed steps
                     }),
                 });
 
@@ -348,13 +348,13 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
           <Tab value="TypeScript">
             ```ts title="agent.ts"
             import { createMiddleware } from "langchain";
-            import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
+            import { copilotkitMiddleware, zodState } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
             import { z } from "zod";
 
             export const observedStepsMiddleware = createMiddleware({
                 name: "AgentState",
                 stateSchema: z.object({
-                    observed_steps: z.array(z.string()).default([]),
+                    observed_steps: zodState(z.array(z.string()).default([])),
                 }),
             });
             ```
@@ -414,6 +414,7 @@ When a node in your LangGraph finishes executing, **its returned state becomes t
                     observedStepsMiddleware,
                     copilotkitMiddleware,
                     stateStreamingMiddleware(  // [!code highlight]
+                        // Map the tool's `steps` argument into the `observed_steps` state field.
                         stateItem({ stateKey: "observed_steps", tool: "step_progress_tool", toolArgument: "steps" })  // [!code highlight]
                     ),  // [!code highlight]
                 ],


### PR DESCRIPTION
## Summary
- wrap the Deep Agents TypeScript `observed_steps` custom state field in `zodState`
- clarify that `step_progress_tool.steps` intentionally maps into the `observed_steps` state field
- move the fix to the publishing Showcase docs source under `showcase/shell-docs`

## Why
The QA report called out a mismatch between `steps` and `observed_steps`. That mapping is intentional via `stateItem`; the actual issue is that the custom state field was declared as plain Zod. In LangGraph JS, fields that are not wrapped with `zodState` can be filtered out of the AG-UI state snapshot, so the tool call can happen while the UI never receives the rendered state.

## Verification
- `pnpm validate:model-names`
- `npm ci --ignore-scripts` in `showcase/shell-docs`
- `npm run build` in `showcase/shell-docs`
- `git diff --check`