### PR TITLE
feat(qa): notify Slack when QA PRs merge

### DIFF
--- a/.github/workflows/qa_merge-notify.yml
+++ b/.github/workflows/qa_merge-notify.yml
@@ -1,0 +1,33 @@
+name: qa / merge notify
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: qa-merge-notify-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    env:
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      TEAM_OSS_CHANNEL_ID: ${{ vars.TEAM_OSS_CHANNEL_ID }}
+    steps:
+      - name: Checkout merged code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Notify QA and OSS channels
+        run: node scripts/qa-merge-notifier.mjs

--- a/scripts/__tests__/qa-merge-notifier.test.mjs
+++ b/scripts/__tests__/qa-merge-notifier.test.mjs
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildQaThreadMessage,
+  buildTeamOssMessage,
+  extractLinearIdentifier,
+  extractSlackPermalink,
+  notifyMergedQaPr,
+  parseSlackPermalink,
+} from "../qa-merge-notifier.mjs";
+
+describe("qa merge notifier", () => {
+  it("extracts a FAC issue identifier from the merged PR branch before title/body", () => {
+    const issue = extractLinearIdentifier({
+      head: { ref: "docs/FAC-77-state-streaming-schema" },
+      title: "docs: unrelated FAC-12 mention",
+      body: "Closes FAC-13",
+    });
+
+    expect(issue).toBe("FAC-77");
+  });
+
+  it("extracts the original Slack permalink from Linear attachments or description", () => {
+    const fromAttachment = extractSlackPermalink({
+      description: "",
+      attachments: {
+        nodes: [
+          {
+            title: "PR",
+            url: "https://github.com/CopilotKit/CopilotKit/pull/5556",
+          },
+          {
+            title: "Original Slack post (#collab-qa)",
+            url: "https://copilotkit.slack.com/archives/C08GG122URL/p1781797100757009",
+          },
+        ],
+      },
+    });
+
+    const fromDescription = extractSlackPermalink({
+      description:
+        "Original QA Slack report: [https://copilotkit.slack.com/archives/C08GG122URL/p1781797100757009](<https://copilotkit.slack.com/archives/C08GG122URL/p1781797100757009>)",
+      attachments: { nodes: [] },
+    });
+
+    expect(fromAttachment).toBe(
+      "https://copilotkit.slack.com/archives/C08GG122URL/p1781797100757009",
+    );
+    expect(fromDescription).toBe(
+      "https://copilotkit.slack.com/archives/C08GG122URL/p1781797100757009",
+    );
+  });
+
+  it("turns a Slack permalink into a channel and thread timestamp", () => {
+    expect(
+      parseSlackPermalink(
+        "https://copilotkit.slack.com/archives/C08GG122URL/p1781797100757009",
+      ),
+    ).toEqual({
+      channel: "C08GG122URL",
+      threadTs: "1781797100.757009",
+    });
+  });
+
+  it("renders QA and internal Slack messages with different link detail", () => {
+    const issue = {
+      identifier: "FAC-77",
+      title: "Deep Agents TS state streaming example has step schema mismatch",
+      url: "https://linear.app/copilotkit/issue/FAC-77/example",
+    };
+    const pr = {
+      number: 5556,
+      html_url: "https://github.com/CopilotKit/CopilotKit/pull/5556",
+      title: "docs(showcase): fix Deep Agents state streaming schema",
+    };
+
+    expect(buildQaThreadMessage(issue)).toBe(
+      "This has been fixed and merged. It will go out with the next release. Reference: FAC-77.",
+    );
+    expect(buildTeamOssMessage(issue, pr)).toBe(
+      "Merged from QA: FAC-77 - Deep Agents TS state streaming example has step schema mismatch. PR: https://github.com/CopilotKit/CopilotKit/pull/5556. This will go out with the next release.",
+    );
+  });
+
+  it("posts to the original QA thread and team OSS channel for merged FAC PRs", async () => {
+    const calls = [];
+    const fetchFn = async (url, init) => {
+      calls.push({ url, body: JSON.parse(init.body) });
+
+      if (url === "https://api.linear.app/graphql") {
+        return Response.json({
+          data: {
+            issue: {
+              identifier: "FAC-77",
+              title:
+                "Deep Agents TS state streaming example has step schema mismatch",
+              url: "https://linear.app/copilotkit/issue/FAC-77/example",
+              description: "",
+              attachments: {
+                nodes: [
+                  {
+                    title: "Original Slack post (#collab-qa)",
+                    url: "https://copilotkit.slack.com/archives/C08GG122URL/p1781797100757009",
+                  },
+                ],
+              },
+            },
+          },
+        });
+      }
+
+      return Response.json({ ok: true });
+    };
+
+    const result = await notifyMergedQaPr({
+      fetchFn,
+      log: { info() {}, warn() {} },
+      env: {
+        LINEAR_API_KEY: "linear-token",
+        SLACK_BOT_TOKEN: "slack-token",
+        TEAM_OSS_CHANNEL_ID: "C_TEAM_OSS",
+      },
+      event: {
+        pull_request: {
+          merged: true,
+          head: { ref: "docs/FAC-77-state-streaming-schema" },
+          title: "docs(showcase): fix Deep Agents state streaming schema",
+          body: "",
+          html_url: "https://github.com/CopilotKit/CopilotKit/pull/5556",
+          number: 5556,
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      status: "notified",
+      identifier: "FAC-77",
+      qaThreadPosted: true,
+      teamOssPosted: true,
+    });
+    expect(calls).toHaveLength(3);
+    expect(calls[1].body).toMatchObject({
+      channel: "C08GG122URL",
+      thread_ts: "1781797100.757009",
+      text: "This has been fixed and merged. It will go out with the next release. Reference: FAC-77.",
+    });
+    expect(calls[2].body).toMatchObject({
+      channel: "C_TEAM_OSS",
+      text: "Merged from QA: FAC-77 - Deep Agents TS state streaming example has step schema mismatch. PR: https://github.com/CopilotKit/CopilotKit/pull/5556. This will go out with the next release.",
+    });
+  });
+});

--- a/scripts/qa-merge-notifier.mjs
+++ b/scripts/qa-merge-notifier.mjs
@@ -1,0 +1,261 @@
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const FAC_IDENTIFIER_PATTERN = /\bFAC-\d+\b/i;
+const SLACK_PERMALINK_PATTERN =
+  /https:\/\/[A-Za-z0-9.-]+\.slack\.com\/archives\/[A-Z0-9]+\/p\d+/;
+
+export function extractLinearIdentifier(pr) {
+  const candidates = [pr?.head?.ref, pr?.title, pr?.body];
+
+  for (const candidate of candidates) {
+    const match = candidate?.match?.(FAC_IDENTIFIER_PATTERN);
+    if (match) {
+      return match[0].toUpperCase();
+    }
+  }
+
+  return null;
+}
+
+export function extractSlackPermalink(issue) {
+  const attachmentUrls =
+    issue?.attachments?.nodes?.map((attachment) => attachment?.url) ?? [];
+  const candidates = [...attachmentUrls, issue?.description];
+
+  for (const candidate of candidates) {
+    const match = candidate?.match?.(SLACK_PERMALINK_PATTERN);
+    if (match) {
+      return match[0];
+    }
+  }
+
+  return null;
+}
+
+export function parseSlackPermalink(permalink) {
+  const match = permalink.match(
+    /\/archives\/(?<channel>[A-Z0-9]+)\/p(?<rawTs>\d+)/,
+  );
+  if (
+    !match?.groups?.channel ||
+    !match.groups.rawTs ||
+    match.groups.rawTs.length <= 10
+  ) {
+    return null;
+  }
+
+  const { channel, rawTs } = match.groups;
+  return {
+    channel,
+    threadTs: `${rawTs.slice(0, 10)}.${rawTs.slice(10)}`,
+  };
+}
+
+export function buildQaThreadMessage(issue) {
+  return `This has been fixed and merged. It will go out with the next release. Reference: ${issue.identifier}.`;
+}
+
+export function buildTeamOssMessage(issue, pr) {
+  return `Merged from QA: ${issue.identifier} - ${issue.title}. PR: ${pr.html_url}. This will go out with the next release.`;
+}
+
+async function fetchLinearIssue(identifier, { fetchFn, linearApiKey }) {
+  const response = await fetchFn("https://api.linear.app/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: linearApiKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query: `
+        query QaMergeNotifierIssue($id: String!) {
+          issue(id: $id) {
+            identifier
+            title
+            url
+            description
+            attachments {
+              nodes {
+                title
+                url
+              }
+            }
+          }
+        }
+      `,
+      variables: { id: identifier },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Linear API returned HTTP ${response.status}`);
+  }
+
+  const payload = await response.json();
+  if (payload.errors?.length) {
+    throw new Error(
+      `Linear API error: ${payload.errors.map((error) => error.message).join("; ")}`,
+    );
+  }
+
+  return payload.data?.issue ?? null;
+}
+
+async function postSlackMessage({
+  fetchFn,
+  slackBotToken,
+  channel,
+  text,
+  threadTs,
+}) {
+  const response = await fetchFn("https://slack.com/api/chat.postMessage", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${slackBotToken}`,
+      "Content-Type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({
+      channel,
+      text,
+      ...(threadTs ? { thread_ts: threadTs } : {}),
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Slack API returned HTTP ${response.status}`);
+  }
+
+  const payload = await response.json();
+  if (!payload.ok) {
+    throw new Error(`Slack API error: ${payload.error ?? "unknown_error"}`);
+  }
+
+  return payload;
+}
+
+export async function notifyMergedQaPr({
+  event,
+  env = process.env,
+  fetchFn = globalThis.fetch,
+  log = console,
+} = {}) {
+  const pr = event?.pull_request;
+
+  if (!pr?.merged) {
+    log.info("PR was closed without merging; skipping QA merge notification.");
+    return { status: "skipped", reason: "not_merged" };
+  }
+
+  const identifier = extractLinearIdentifier(pr);
+  if (!identifier) {
+    log.info(
+      "Merged PR does not reference a FAC issue; skipping QA merge notification.",
+    );
+    return { status: "skipped", reason: "no_fac_issue" };
+  }
+
+  if (!env.LINEAR_API_KEY) {
+    log.warn("LINEAR_API_KEY is not set; cannot look up the QA Linear issue.");
+    return { status: "skipped", reason: "missing_linear_api_key", identifier };
+  }
+
+  if (!env.SLACK_BOT_TOKEN) {
+    log.warn(
+      "SLACK_BOT_TOKEN is not set; cannot post Slack merge notifications.",
+    );
+    return { status: "skipped", reason: "missing_slack_bot_token", identifier };
+  }
+
+  let issue;
+  try {
+    issue = await fetchLinearIssue(identifier, {
+      fetchFn,
+      linearApiKey: env.LINEAR_API_KEY,
+    });
+  } catch (error) {
+    log.warn(`Could not look up ${identifier} in Linear: ${error.message}`);
+    return { status: "skipped", reason: "linear_lookup_failed", identifier };
+  }
+
+  if (!issue) {
+    log.info(
+      `Linear issue ${identifier} was not found; skipping QA merge notification.`,
+    );
+    return { status: "skipped", reason: "linear_issue_not_found", identifier };
+  }
+
+  const results = {
+    status: "notified",
+    identifier,
+    qaThreadPosted: false,
+    teamOssPosted: false,
+  };
+
+  const permalink = extractSlackPermalink(issue);
+  const slackThread = permalink ? parseSlackPermalink(permalink) : null;
+
+  if (slackThread) {
+    try {
+      await postSlackMessage({
+        fetchFn,
+        slackBotToken: env.SLACK_BOT_TOKEN,
+        channel: slackThread.channel,
+        threadTs: slackThread.threadTs,
+        text: buildQaThreadMessage(issue),
+      });
+      results.qaThreadPosted = true;
+    } catch (error) {
+      log.warn(
+        `Could not post QA thread notification for ${identifier}: ${error.message}`,
+      );
+    }
+  } else {
+    log.warn(
+      `No usable Slack permalink found on ${identifier}; skipping QA thread reply.`,
+    );
+  }
+
+  if (env.TEAM_OSS_CHANNEL_ID) {
+    try {
+      await postSlackMessage({
+        fetchFn,
+        slackBotToken: env.SLACK_BOT_TOKEN,
+        channel: env.TEAM_OSS_CHANNEL_ID,
+        text: buildTeamOssMessage(issue, pr),
+      });
+      results.teamOssPosted = true;
+    } catch (error) {
+      log.warn(
+        `Could not post #team-oss notification for ${identifier}: ${error.message}`,
+      );
+    }
+  } else {
+    log.warn(
+      "TEAM_OSS_CHANNEL_ID is not set; skipping #team-oss merge notification.",
+    );
+  }
+
+  return results;
+}
+
+export async function main({
+  env = process.env,
+  fetchFn = globalThis.fetch,
+  log = console,
+} = {}) {
+  if (!env.GITHUB_EVENT_PATH) {
+    log.warn("GITHUB_EVENT_PATH is not set; skipping QA merge notification.");
+    return { status: "skipped", reason: "missing_event_path" };
+  }
+
+  const event = JSON.parse(await readFile(env.GITHUB_EVENT_PATH, "utf8"));
+  return notifyMergedQaPr({ event, env, fetchFn, log });
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add a merged-PR GitHub Action for QA pipeline notifications
- detect linked `FAC-...` issues, fetch the Linear issue, and find the original Slack permalink
- reply in the original QA Slack thread with merge status, and post the PR-linked internal note to `#team-oss`

## Behavior
- QA thread message: status-only, no PR link dependency for external QA
- `#team-oss` message: includes the Linear identifier, issue title, and PR URL
- non-QA PRs, missing FAC identifiers, missing Slack permalinks, or missing config no-op with warnings instead of failing unrelated merges

## Required config
- `LINEAR_API_KEY` secret
- `SLACK_BOT_TOKEN` secret
- `TEAM_OSS_CHANNEL_ID` GitHub Actions variable for `#team-oss`

## Verification
- `pnpm exec vitest run scripts/__tests__/qa-merge-notifier.test.mjs`
- `pnpm exec oxfmt --check scripts/qa-merge-notifier.mjs scripts/__tests__/qa-merge-notifier.test.mjs .github/workflows/qa_merge-notify.yml`
- `pnpm exec oxlint scripts/qa-merge-notifier.mjs scripts/__tests__/qa-merge-notifier.test.mjs`
- `node --check scripts/qa-merge-notifier.mjs`

Note: `zizmor` and `actionlint` were not installed locally, so workflow-specific validation is left to CI.