### PR TITLE
fix(shell-docs): align callout accent colors to brand

### DIFF
--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -56,6 +56,9 @@
   --warning-dim: color-mix(in oklch, var(--warning) 10%, transparent);
   --warning-border: color-mix(in oklch, var(--warning) 46%, var(--border));
   --warning-text: color-mix(in oklch, var(--warning) 70%, var(--text));
+  /* Brand mint, backs --color-fd-success. mint/800 for contrast on the
+   * white callout card; the dark theme lifts this to mint/400. */
+  --success: #189370;
   --window-control-close: #ff5f57;
   --window-control-minimize: #ffbd2e;
   --window-control-zoom: #28c840;
@@ -806,6 +809,23 @@ figure.shiki > div:first-child[class*="border-b"] {
   --color-fd-ring: var(--accent);
 }
 
+/* Callout / admonition accents (consumed by the fumadocs `<Callout>` via
+ * `var(--color-fd-info|warning|success)`). Fumadocs' preset ships generic
+ * blue/amber/green for these, which read as off-brand against the
+ * purple-anchored docs theme. Remap them to existing brand tokens: info ->
+ * brand accent (purple), warning -> the docs `--warning` orange already used
+ * by `.shell-docs-warning-surface`, success -> brand mint. These MUST be plain
+ * `:root` custom properties, not `@theme` tokens — Tailwind v4 tree-shakes
+ * theme variables that no utility class references, and the Callout reads
+ * these only through inline `var()`. The source tokens are theme-aware, so a
+ * single `:root` definition covers light and dark. `error` is intentionally
+ * left to `--destructive` (set by fumadocs' shadcn.css). */
+:root {
+  --color-fd-info: var(--accent);
+  --color-fd-warning: var(--warning);
+  --color-fd-success: var(--success);
+}
+
 :root {
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
@@ -928,6 +948,9 @@ figure.shiki > div:first-child[class*="border-b"] {
   --warning-dim: color-mix(in oklch, var(--warning) 14%, transparent);
   --warning-border: color-mix(in oklch, var(--warning) 48%, var(--border));
   --warning-text: color-mix(in oklch, var(--warning) 72%, var(--text));
+  /* Brand mint/400 — brighter than the light-mode mint/800 so the success
+   * accent reads on the dark callout card. */
+  --success: #85ecce;
   --blue: #6ba6e8;
   --violet: var(--accent);
   --violet-light: var(--accent-light);


### PR DESCRIPTION
## What

Docs `<Callout>` accents (the icon + left bar) were rendering in fumadocs' generic blue/amber/green instead of the CopilotKit palette. Remap them to brand tokens:

- **info** → brand accent (purple)
- **warning** → the docs `--warning` orange
- **success** → brand mint (new `--success` token)
- **error** → unchanged (already `--destructive`)

Theme-aware across light and dark.

## Before / After

|  | Before | After |
|---|:---:|:---:|
| **Light** | ![before light](https://raw.githubusercontent.com/CopilotKit/CopilotKit/callout-brand-screenshots/pr-assets/callout-brand/before-light.png) | ![after light](https://raw.githubusercontent.com/CopilotKit/CopilotKit/callout-brand-screenshots/pr-assets/callout-brand/after-light.png) |
| **Dark** | ![before dark](https://raw.githubusercontent.com/CopilotKit/CopilotKit/callout-brand-screenshots/pr-assets/callout-brand/before-dark.png) | ![after dark](https://raw.githubusercontent.com/CopilotKit/CopilotKit/callout-brand-screenshots/pr-assets/callout-brand/after-dark.png) |

## Note

These must be plain `:root` custom properties, not `@theme` tokens: Tailwind v4 tree-shakes theme variables that no utility class references, and the Callout reads `--color-fd-info|warning|success` only through inline `var()`.
