### PR TITLE
chore: release monorepo v1.61.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "AI agent skills for CopilotKit — setup, develop, integrate, debug, upgrade, and contribute",
-    "version": "1.60.2"
+    "version": "1.61.0"
   },
   "plugins": [
     {
       "name": "copilotkit",
       "source": "./",
       "description": "AI agent skills for CopilotKit — setup, develop, integrate, debug, upgrade, and contribute to CopilotKit projects",
-      "version": "1.60.2",
+      "version": "1.61.0",
       "author": {
         "name": "CopilotKit",
         "url": "https://copilotkit.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "copilotkit",
   "description": "AI agent skills for CopilotKit — setup, develop, integrate, debug, upgrade, and contribute to CopilotKit projects",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "author": {
     "name": "CopilotKit",
     "url": "https://copilotkit.ai"

--- a/packages/a2ui-renderer/package.json
+++ b/packages/a2ui-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/a2ui-renderer",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "private": false,
   "description": "A2UI Renderer for CopilotKit - render A2UI surfaces in React applications",
   "keywords": [

--- a/packages/agentcore-runner/package.json
+++ b/packages/agentcore-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/agentcore-runner",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "description": "AWS Bedrock AgentCore-compatible agent runner for CopilotKit2",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/core",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "description": "Core web utilities for CopilotKit2",
   "repository": {
     "type": "git",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/react-core",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "private": false,
   "keywords": [
     "ai",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/react-native",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "private": false,
   "keywords": [
     "ai",

--- a/packages/react-textarea/package.json
+++ b/packages/react-textarea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/react-textarea",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "private": false,
   "keywords": [
     "ai",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/react-ui",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "private": false,
   "keywords": [
     "ai",

--- a/packages/runtime-client-gql/package.json
+++ b/packages/runtime-client-gql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/runtime-client-gql",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "private": false,
   "keywords": [
     "ai",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/runtime",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "private": false,
   "keywords": [
     "ai",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/sdk-js",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "private": false,
   "keywords": [
     "ai",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/shared",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "private": false,
   "keywords": [
     "ai",

--- a/packages/sqlite-runner/package.json
+++ b/packages/sqlite-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/sqlite-runner",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "description": "SQLite-backed agent runner for CopilotKit2",
   "repository": {
     "type": "git",

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/voice",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "description": "Voice services for CopilotKit (transcription, text-to-speech, etc.)",
   "repository": {
     "type": "git",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/vue",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "private": false,
   "description": "Vue 3 components and composables for CopilotKit",
   "keywords": [

--- a/packages/web-inspector/package.json
+++ b/packages/web-inspector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/web-inspector",
-  "version": "1.60.2",
+  "version": "1.61.0",
   "description": "Lit-based web component for the CopilotKit web inspector",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- bump monorepo package versions to 1.61.0
- keep plugin metadata versions aligned with the runtime package

## Validation
- pnpm check:plugin-skills
- pre-commit hook ran package test, publint, and attw targets