### PR TITLE
fix: sync plugin metadata before release PR creation

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -94,6 +94,10 @@ jobs:
             pnpm tsx scripts/release/prepare-release.ts --bump ${{ inputs.bump }} --scope ${{ inputs.scope }}
           fi
 
+      - name: Sync plugin skills
+        if: inputs.dry_run != true
+        run: pnpm sync:plugin-skills
+
       - name: Generate AI release notes
         if: inputs.dry_run != true
         id: ai_notes


### PR DESCRIPTION
## Summary
- run the plugin metadata sync after release prep updates package versions
- ensure release PR creation commits include aligned plugin metadata

## Root cause
The release PR action commits generated version bumps, which triggers the pre-commit plugin sync check. The workflow updated package versions before committing but did not update plugin metadata first.

## Validation
- bash scripts/release/verify-release-scope-dropdowns.sh
- pre-commit hook

Note: actionlint was not installed locally.