### PR TITLE
fix(examples): update threads license command

### DIFF
--- a/examples/integrations/a2a-a2ui/app/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/a2a-a2ui/app/components/threads-drawer/locked-state.tsx
@@ -46,7 +46,9 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>copilotkit license</code>
+            <code className={styles.lockedCommandCode}>
+              npx copilotkit@latest license
+            </code>
           </div>
           <button
             type="button"

--- a/examples/integrations/a2a-middleware/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/a2a-middleware/components/threads-drawer/locked-state.tsx
@@ -46,7 +46,9 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>copilotkit license</code>
+            <code className={styles.lockedCommandCode}>
+              npx copilotkit@latest license
+            </code>
           </div>
           <button
             type="button"

--- a/examples/integrations/adk/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/adk/src/components/threads-drawer/locked-state.tsx
@@ -67,7 +67,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
         <CardFooter className="flex-col items-start gap-3">
           <div className="w-full rounded-[var(--radius)] border border-[var(--border)] bg-[var(--secondary)] px-3 py-2">
             <code className="text-xs whitespace-nowrap text-[var(--secondary-foreground)]">
-              copilotkit license
+              npx copilotkit@latest license
             </code>
           </div>
           <Button

--- a/examples/integrations/agent-spec/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/agent-spec/src/components/threads-drawer/locked-state.tsx
@@ -46,7 +46,9 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>copilotkit license</code>
+            <code className={styles.lockedCommandCode}>
+              npx copilotkit@latest license
+            </code>
           </div>
           <button
             type="button"

--- a/examples/integrations/agentcore/frontend/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/agentcore/frontend/src/components/threads-drawer/locked-state.tsx
@@ -67,7 +67,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
         <CardFooter className="flex-col items-start gap-3">
           <div className="w-full rounded-[var(--radius)] border border-[var(--border)] bg-[var(--secondary)] px-3 py-2">
             <code className="text-xs whitespace-nowrap text-[var(--secondary-foreground)]">
-              copilotkit license
+              npx copilotkit@latest license
             </code>
           </div>
           <Button

--- a/examples/integrations/agno/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/agno/src/components/threads-drawer/locked-state.tsx
@@ -67,7 +67,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
         <CardFooter className="flex-col items-start gap-3">
           <div className="w-full rounded-[var(--radius)] border border-[var(--border)] bg-[var(--secondary)] px-3 py-2">
             <code className="text-xs whitespace-nowrap text-[var(--secondary-foreground)]">
-              copilotkit license
+              npx copilotkit@latest license
             </code>
           </div>
           <Button

--- a/examples/integrations/crewai-crews/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/crewai-crews/src/components/threads-drawer/locked-state.tsx
@@ -46,7 +46,9 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>copilotkit license</code>
+            <code className={styles.lockedCommandCode}>
+              npx copilotkit@latest license
+            </code>
           </div>
           <button
             type="button"

--- a/examples/integrations/crewai-flows/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/crewai-flows/src/components/threads-drawer/locked-state.tsx
@@ -46,7 +46,9 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>copilotkit license</code>
+            <code className={styles.lockedCommandCode}>
+              npx copilotkit@latest license
+            </code>
           </div>
           <button
             type="button"

--- a/examples/integrations/langgraph-fastapi/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/langgraph-fastapi/src/components/threads-drawer/locked-state.tsx
@@ -67,7 +67,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
         <CardFooter className="flex-col items-start gap-3">
           <div className="w-full rounded-[var(--radius)] border border-[var(--border)] bg-[var(--secondary)] px-3 py-2">
             <code className="text-xs whitespace-nowrap text-[var(--secondary-foreground)]">
-              copilotkit license
+              npx copilotkit@latest license
             </code>
           </div>
           <Button

--- a/examples/integrations/langgraph-js/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/langgraph-js/src/components/threads-drawer/locked-state.tsx
@@ -67,7 +67,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
         <CardFooter className="flex-col items-start gap-3">
           <div className="w-full rounded-[var(--radius)] border border-[var(--border)] bg-[var(--secondary)] px-3 py-2">
             <code className="text-xs whitespace-nowrap text-[var(--secondary-foreground)]">
-              copilotkit license
+              npx copilotkit@latest license
             </code>
           </div>
           <Button

--- a/examples/integrations/langgraph-python/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/langgraph-python/src/components/threads-drawer/locked-state.tsx
@@ -67,7 +67,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
         <CardFooter className="flex-col items-start gap-3">
           <div className="w-full rounded-[var(--radius)] border border-[var(--border)] bg-[var(--secondary)] px-3 py-2">
             <code className="text-xs whitespace-nowrap text-[var(--secondary-foreground)]">
-              copilotkit license
+              npx copilotkit@latest license
             </code>
           </div>
           <Button

--- a/examples/integrations/llamaindex/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/llamaindex/src/components/threads-drawer/locked-state.tsx
@@ -46,7 +46,9 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>copilotkit license</code>
+            <code className={styles.lockedCommandCode}>
+              npx copilotkit@latest license
+            </code>
           </div>
           <button
             type="button"

--- a/examples/integrations/mastra/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/mastra/src/components/threads-drawer/locked-state.tsx
@@ -46,7 +46,9 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>copilotkit license</code>
+            <code className={styles.lockedCommandCode}>
+              npx copilotkit@latest license
+            </code>
           </div>
           <button
             type="button"

--- a/examples/integrations/mcp-apps/app/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/mcp-apps/app/components/threads-drawer/locked-state.tsx
@@ -46,7 +46,9 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>copilotkit license</code>
+            <code className={styles.lockedCommandCode}>
+              npx copilotkit@latest license
+            </code>
           </div>
           <button
             type="button"

--- a/examples/integrations/ms-agent-framework-dotnet/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/ms-agent-framework-dotnet/src/components/threads-drawer/locked-state.tsx
@@ -46,7 +46,9 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>copilotkit license</code>
+            <code className={styles.lockedCommandCode}>
+              npx copilotkit@latest license
+            </code>
           </div>
           <button
             type="button"

--- a/examples/integrations/ms-agent-framework-python/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/ms-agent-framework-python/src/components/threads-drawer/locked-state.tsx
@@ -46,7 +46,9 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>copilotkit license</code>
+            <code className={styles.lockedCommandCode}>
+              npx copilotkit@latest license
+            </code>
           </div>
           <button
             type="button"

--- a/examples/integrations/pydantic-ai/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/pydantic-ai/src/components/threads-drawer/locked-state.tsx
@@ -46,7 +46,9 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
             Add it to your project with:
           </p>
           <div className={styles.lockedCommand}>
-            <code className={styles.lockedCommandCode}>copilotkit license</code>
+            <code className={styles.lockedCommandCode}>
+              npx copilotkit@latest license
+            </code>
           </div>
           <button
             type="button"

--- a/examples/integrations/strands-python/src/components/threads-drawer/locked-state.tsx
+++ b/examples/integrations/strands-python/src/components/threads-drawer/locked-state.tsx
@@ -67,7 +67,7 @@ export function ThreadsPanelGate({ children }: { children: React.ReactNode }) {
         <CardFooter className="flex-col items-start gap-3">
           <div className="w-full rounded-[var(--radius)] border border-[var(--border)] bg-[var(--secondary)] px-3 py-2">
             <code className="text-xs whitespace-nowrap text-[var(--secondary-foreground)]">
-              copilotkit license
+              npx copilotkit@latest license
             </code>
           </div>
           <Button


### PR DESCRIPTION
## Summary
- Update locked Threads drawer copy in integration examples to use `npx copilotkit@latest license`
- Keep the command consistent across the example variants that render the licensed feature panel

## Validation
- Pre-commit hooks ran lint/check package hooks successfully
- Verified integration examples no longer render the stale `copilotkit license` command