### PR TITLE
fix: ignore CopilotKit local state in starters

### DIFF
--- a/showcase/scripts/__tests__/create-integration.test.ts
+++ b/showcase/scripts/__tests__/create-integration.test.ts
@@ -238,7 +238,7 @@ describe("Template Generator", () => {
       path.join(TEST_DIR, ".gitignore"),
       "utf-8",
     );
-    expect(gitignore.split(/\r?\n/)).toContain(".copilotkit");
+    expect(gitignore.split(/\r?\n/)).toContain(".copilotkit/");
   });
 
   it("generates a manifest that passes schema validation", () => {

--- a/showcase/scripts/__tests__/create-integration.test.ts
+++ b/showcase/scripts/__tests__/create-integration.test.ts
@@ -233,6 +233,12 @@ describe("Template Generator", () => {
     for (const file of requiredFiles) {
       expect(fs.existsSync(path.join(TEST_DIR, file))).toBe(true);
     }
+
+    const gitignore = fs.readFileSync(
+      path.join(TEST_DIR, ".gitignore"),
+      "utf-8",
+    );
+    expect(gitignore.split(/\r?\n/)).toContain(".copilotkit");
   });
 
   it("generates a manifest that passes schema validation", () => {

--- a/showcase/scripts/__tests__/extract-starter.test.ts
+++ b/showcase/scripts/__tests__/extract-starter.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { execFileSync } from "child_process";
+import { execOptsFor } from "./test-cleanup";
+import { SCRIPTS_DIR } from "./paths";
+
+describe("extract-starter", () => {
+  it("adds .copilotkit to generated starter .gitignore", () => {
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "starter-"));
+
+    try {
+      execFileSync(
+        "npx",
+        ["tsx", "extract-starter.ts", "langgraph-python", outDir],
+        execOptsFor(SCRIPTS_DIR),
+      );
+
+      const gitignore = fs.readFileSync(
+        path.join(outDir, ".gitignore"),
+        "utf-8",
+      );
+      expect(gitignore.split(/\r?\n/)).toContain(".copilotkit");
+    } finally {
+      fs.rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/showcase/scripts/__tests__/extract-starter.test.ts
+++ b/showcase/scripts/__tests__/extract-starter.test.ts
@@ -7,7 +7,7 @@ import { execOptsFor } from "./test-cleanup";
 import { SCRIPTS_DIR } from "./paths";
 
 describe("extract-starter", () => {
-  it("adds .copilotkit to generated starter .gitignore", () => {
+  it("adds .copilotkit/ to generated starter .gitignore", () => {
     const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "starter-"));
 
     try {
@@ -21,7 +21,7 @@ describe("extract-starter", () => {
         path.join(outDir, ".gitignore"),
         "utf-8",
       );
-      expect(gitignore.split(/\r?\n/)).toContain(".copilotkit");
+      expect(gitignore.split(/\r?\n/)).toContain(".copilotkit/");
     } finally {
       fs.rmSync(outDir, { recursive: true, force: true });
     }

--- a/showcase/scripts/create-integration/index.ts
+++ b/showcase/scripts/create-integration/index.ts
@@ -1562,6 +1562,7 @@ function generateGitignore(): string {
 .next/
 .env.local
 .env
+.copilotkit
 *.pyc
 __pycache__/
 .venv/

--- a/showcase/scripts/create-integration/index.ts
+++ b/showcase/scripts/create-integration/index.ts
@@ -1562,7 +1562,7 @@ function generateGitignore(): string {
 .next/
 .env.local
 .env
-.copilotkit
+.copilotkit/
 *.pyc
 __pycache__/
 .venv/

--- a/showcase/scripts/extract-starter.ts
+++ b/showcase/scripts/extract-starter.ts
@@ -205,6 +205,6 @@ function stripTestDirs(dir: string) {
 }
 stripTestDirs(outDir);
 
-ensureGitignoreEntry(join(outDir, ".gitignore"), ".copilotkit");
+ensureGitignoreEntry(join(outDir, ".gitignore"), ".copilotkit/");
 
 console.log(`Extracted starter for ${slug}: ${outDir}`);

--- a/showcase/scripts/extract-starter.ts
+++ b/showcase/scripts/extract-starter.ts
@@ -158,6 +158,15 @@ function substituteInFile(
   writeFileSync(filePath, content);
 }
 
+function ensureGitignoreEntry(filePath: string, entry: string) {
+  const content = existsSync(filePath) ? readFileSync(filePath, "utf-8") : "";
+  const lines = content.split(/\r?\n/);
+  if (lines.includes(entry)) return;
+
+  const separator = content.length > 0 && !content.endsWith("\n") ? "\n" : "";
+  writeFileSync(filePath, `${content}${separator}${entry}\n`);
+}
+
 // Format slug into a display name: "langgraph-python" -> "Langgraph Python"
 const displayName = slug
   .split("-")
@@ -195,5 +204,7 @@ function stripTestDirs(dir: string) {
   }
 }
 stripTestDirs(outDir);
+
+ensureGitignoreEntry(join(outDir, ".gitignore"), ".copilotkit");
 
 console.log(`Extracted starter for ${slug}: ${outDir}`);


### PR DESCRIPTION
## Summary
- add .copilotkit to newly scaffolded integration .gitignore files
- ensure extracted standalone starters also include .copilotkit in .gitignore
- add regression coverage for scaffolded and extracted starter outputs

## Tests
- pnpm nx run @copilotkit/showcase-scripts:test --skip-nx-cache -- __tests__/extract-starter.test.ts __tests__/create-integration.test.ts
- pnpm exec oxfmt --check showcase/scripts/extract-starter.ts showcase/scripts/create-integration/index.ts showcase/scripts/__tests__/create-integration.test.ts showcase/scripts/__tests__/extract-starter.test.ts