### PR TITLE
fix(showcase): promote pins staging's running digest + verify serving + drift alarm

### DIFF
--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -215,6 +215,11 @@ jobs:
       # prod verification to exactly this set so a single failed service can't
       # red the verification of the services that did promote.
       succeeded_csv: ${{ steps.promote.outputs.succeeded_csv }}
+      # Aggregated staging-drift payload: non-empty when any promoted service's
+      # staging RUNNING digest differed from the current GHCR :latest (i.e.
+      # staging was NOT serving :latest). Folded into the Slack notify payload
+      # so operators see "what shipped to prod is not current :latest".
+      staging_drift: ${{ steps.promote.outputs.staging_drift }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -384,6 +389,10 @@ jobs:
           PROD_STATUS: ${{ needs.verify-prod.outputs.status }}
           CSV: ${{ needs.resolve-targets.outputs.services_csv }}
           INPUT: ${{ inputs.service }}
+          # Aggregated staging-drift payload from the promote job (empty when no
+          # service drifted). Surfaced in BOTH Slack payloads below so a drifted
+          # promote is loud even on a successful run.
+          DRIFT: ${{ needs.promote.outputs.staging_drift }}
         run: |
           set -euo pipefail
           # Displayed verify-prod value for the Slack line. The job `result` is
@@ -418,11 +427,23 @@ jobs:
           else
             STATE="failure"; ICON=":x:"
           fi
+          # Human-facing drift suffix for the Slack message. Empty string when
+          # there is no drift (renders as nothing); otherwise a loud prefix line
+          # naming the drifted services + digests. MUST be single-line (no
+          # embedded LF) so it survives the GITHUB_OUTPUT key=value contract: a
+          # newline anywhere in $DRIFT (upstream free-form text) would otherwise
+          # split the value across lines and corrupt/inject the whole output map.
+          # We ENFORCE that here via `tr -d '\n'` rather than trusting upstream.
+          DRIFT_LINE=""
+          if [ -n "${DRIFT:-}" ]; then
+            DRIFT_LINE="$(printf '%s' ":warning: STAGING DRIFT — prod pinned to staging's RUNNING digest, NOT current :latest — $DRIFT" | tr -d '\n')"
+          fi
           {
             echo "state=$STATE"
             echo "icon=$ICON"
             echo "csv=$CSV"
             echo "prod_display=$PROD_DISPLAY"
+            echo "drift_line=$DRIFT_LINE"
           } >> "$GITHUB_OUTPUT"
       - name: Post to #oss-alerts
         if: steps.state.outputs.state == 'failure' && inputs.service != '__select_a_service__' && env.SLACK_WEBHOOK != ''
@@ -438,7 +459,7 @@ jobs:
           payload: |
             {
               "text": ${{ toJSON(format(
-                '{0} *Showcase Promote Failed*{9}Services: `{1}`{9}resolve-targets={2} pre-staging={3} promote={4} verify-prod={5}{9}<{6}/{7}/actions/runs/{8}|View run>',
+                '{0} *Showcase Promote Failed*{9}Services: `{1}`{9}resolve-targets={2} pre-staging={3} promote={4} verify-prod={5}{10}{9}<{6}/{7}/actions/runs/{8}|View run>',
                 steps.state.outputs.icon,
                 steps.state.outputs.csv,
                 needs.resolve-targets.result,
@@ -448,7 +469,8 @@ jobs:
                 github.server_url,
                 github.repository,
                 github.run_id,
-                fromJSON('"\n"')
+                fromJSON('"\n"'),
+                steps.state.outputs.drift_line != '' && format('{0}{1}', fromJSON('"\n"'), steps.state.outputs.drift_line) || ''
               )) }}
             }
       - name: Post to #team-showcase
@@ -462,25 +484,38 @@ jobs:
           payload: |
             {
               "text": ${{ toJSON(format(
-                '{0} *Showcase Promoted to Prod*{5}Services: `{1}`{5}<{2}/{3}/actions/runs/{4}|View run>',
+                '{0} *Showcase Promoted to Prod*{5}Services: `{1}`{6}{5}<{2}/{3}/actions/runs/{4}|View run>',
                 steps.state.outputs.icon,
                 steps.state.outputs.csv,
                 github.server_url,
                 github.repository,
                 github.run_id,
-                fromJSON('"\n"')
+                fromJSON('"\n"'),
+                steps.state.outputs.drift_line != '' && format('{0}{1}', fromJSON('"\n"'), steps.state.outputs.drift_line) || ''
               )) }}
             }
       - name: Log (no Slack — webhook unset)
         if: steps.state.outputs.state == 'failure' && inputs.service != '__select_a_service__' && env.SLACK_WEBHOOK == ''
         env:
           CSV: ${{ steps.state.outputs.csv }}
+          DRIFT_LINE: ${{ steps.state.outputs.drift_line }}
         run: |
           echo "::warning::Showcase promote failed for '$CSV' but SLACK_WEBHOOK_OSS_ALERTS is not set; no Slack notification sent."
+          # Preserve the staging-drift signal on the webhook-unset path (it would
+          # otherwise only survive in the promote job's step summary, not here).
+          if [ -n "$DRIFT_LINE" ]; then
+            echo "::warning::$DRIFT_LINE"
+          fi
       - name: Log (no Slack — team-showcase webhook unset)
         if: steps.state.outputs.state == 'success' && inputs.service != '__select_a_service__' && env.SLACK_WEBHOOK_TS == ''
         env:
           CSV: ${{ steps.state.outputs.csv }}
           ICON: ${{ steps.state.outputs.icon }}
+          DRIFT_LINE: ${{ steps.state.outputs.drift_line }}
         run: |
           echo "::notice::$ICON Showcase promoted to prod for '$CSV' but SLACK_WEBHOOK_TEAM_SHOWCASE is not set; no #team-showcase notification sent."
+          # Preserve the staging-drift signal on the webhook-unset path (it would
+          # otherwise only survive in the promote job's step summary, not here).
+          if [ -n "$DRIFT_LINE" ]; then
+            echo "::warning::$DRIFT_LINE"
+          fi

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -513,10 +513,15 @@ module Railway
     #   * Service has NO `serviceInstances` field. To get an instance's
     #     image/startCommand/etc. for a given env, use
     #     `serviceInstance(serviceId, environmentId)` directly.
-    #   * `serviceInstanceDeployV2` takes (serviceId, environmentId, commitSha)
-    #     ONLY — no `image` arg. To pin a service to a specific image, use
+    #   * `serviceInstanceDeployV2(serviceId, environmentId, commitSha?)` returns
+    #     the NEW deployment id (String!). `commitSha` is optional. To pin a
+    #     service to a specific image, use
     #     `serviceInstanceUpdate(serviceId, environmentId, input: { source: { image } })`
-    #     followed by `serviceInstanceRedeploy`.
+    #     followed by `serviceInstanceDeployV2` — which spawns a NEW deployment
+    #     that PULLS the just-updated `source.image`. Do NOT use
+    #     `serviceInstanceRedeploy(serviceId, environmentId)` for this: it replays
+    #     the EXISTING deployment's snapshot (its OLD image), so the freshly
+    #     pinned `source.image` never reaches the running container (bug #2).
     #   * `Environment.variables` returns an `EnvironmentVariablesConnection`
     #     whose edges include `node.serviceId` — we filter by service id to get
     #     per-service env-key sets.
@@ -739,13 +744,16 @@ module Railway
     end
 
     # restore — given a snapshot YAML, force-redeploy each service to its
-    # captured digest via serviceInstanceUpdate(source.image) + redeploy.
+    # captured digest via serviceInstanceUpdate(source.image) + deploy.
     #
-    # Railway's `serviceInstanceDeployV2` mutation does NOT accept an `image`
-    # arg — its signature is (serviceId, environmentId, commitSha). To pin a
-    # service to a specific image digest we must:
+    # To pin a service to a specific image digest we must:
     #   1. update the service instance's source.image to the desired ref
-    #   2. trigger a redeploy
+    #   2. spawn a NEW deployment via serviceInstanceDeployV2 that PULLS the
+    #      just-updated source.image.
+    #
+    # NOTE: serviceInstanceRedeploy is deliberately NOT used here — it replays
+    # the existing deployment's snapshot (its OLD image), so the freshly pinned
+    # source.image never reaches the running container (bug #2).
     class RestoreCommand < BaseCommand
         UPDATE_IMAGE_MUTATION = <<~GQL
             mutation UpdateImage($serviceId: String!, $envId: String!, $image: String!) {
@@ -757,20 +765,24 @@ module Railway
             }
         GQL
 
-        REDEPLOY_MUTATION = <<~GQL
-            mutation Redeploy($serviceId: String!, $envId: String!) {
-                serviceInstanceRedeploy(
+        # serviceInstanceDeployV2 spawns a NEW deployment that pulls the current
+        # source.image (just advanced by UPDATE_IMAGE_MUTATION) and returns the
+        # new deployment id (String!). This is what actually activates the pin.
+        DEPLOY_V2_MUTATION = <<~GQL
+            mutation DeployV2($serviceId: String!, $envId: String!) {
+                serviceInstanceDeployV2(
                     serviceId: $serviceId
                     environmentId: $envId
                 )
             }
         GQL
 
-        # Helper used by RestoreCommand, PinCommand, PromoteCommand: pin then redeploy.
+        # Helper used by RestoreCommand, PinCommand: pin then deploy a NEW
+        # deployment that pulls the updated source.image.
         def self.pin_and_redeploy(gql, service_id:, env_id:, image:)
             gql.query(UPDATE_IMAGE_MUTATION,
                 serviceId: service_id, envId: env_id, image: image)
-            gql.query(REDEPLOY_MUTATION,
+            gql.query(DEPLOY_V2_MUTATION,
                 serviceId: service_id, envId: env_id)
         end
 
@@ -1031,6 +1043,7 @@ module Railway
                     id
                     source { image }
                     updatedAt
+                    latestDeployment { id status meta }
                 }
             }
         GQL
@@ -1038,10 +1051,37 @@ module Railway
         RETRY_COUNT     = 3
         RETRY_DELAY_SEC = 10
 
+        # Serving-digest verification (bug #2): after the NEW deployment is
+        # spawned via serviceInstanceDeployV2, poll latestDeployment until it
+        # reaches SUCCESS and confirm its meta.imageDigest == the pinned digest.
+        # The new deployment must pull + boot the image, which takes longer than
+        # the config-level recheck, so this poll is wider than RETRY_COUNT.
+        SERVING_RETRY_COUNT     = 30
+        SERVING_RETRY_DELAY_SEC = 10
+        DEPLOY_FAILURE_STATUSES = %w[FAILED CRASHED REMOVED].freeze
+
+        # Normalize a Railway deployment `meta` (sometimes a JSON string) and
+        # extract its imageDigest (a `sha256:<hex>` value), or nil.
+        def self.serving_digest_from_deployment(deployment)
+            return nil unless deployment.is_a?(Hash)
+            meta = deployment["meta"]
+            meta = (JSON.parse(meta) rescue meta) if meta.is_a?(String)
+            return nil unless meta.is_a?(Hash)
+            digest = meta["imageDigest"]
+            if (digest.nil? || digest.to_s.empty?) && meta["image"].to_s.include?("@sha256:")
+                digest = meta["image"].to_s.split("@", 2).last
+            end
+            digest = nil if digest.is_a?(String) && digest.empty?
+            digest
+        end
+
         # Pin + verify: confirms the boolean mutation result AND re-queries
         # serviceInstance to confirm BOTH source.image advanced to the new
         # digest AND updatedAt strictly advanced past the pre-mutation value.
-        # 3 retries 10s apart absorb Railway's eventual consistency.
+        # 3 retries 10s apart absorb Railway's eventual consistency. THEN
+        # verifies the NEW deployment spawned by serviceInstanceDeployV2 reaches
+        # SUCCESS and SERVES the pinned digest (bug #2 — config advancing is not
+        # enough; the running container must actually pull the pinned image).
         # `sleeper:` is injected for tests.
         def self.pin_and_verify(gql, service_id:, env_id:, image:, sleeper: ->(n) { sleep(n) })
             # Upfront guard: this method's contract is to pin a DIGEST-form
@@ -1071,19 +1111,25 @@ module Railway
                     "P5: serviceInstanceUpdate returned #{updated.inspect} (expected true) for #{service_id} -> #{image}"
             end
 
-            # Symmetric assertion: serviceInstanceUpdate has already advanced
-            # source.image+updatedAt, so a failed redeploy could otherwise
-            # sneak through verification. Require truthy redeploy result.
-            redeployed = gql.query(RestoreCommand::REDEPLOY_MUTATION,
+            # Spawn a NEW deployment that PULLS the just-updated source.image.
+            # serviceInstanceDeployV2 returns the new deployment id (String!).
+            # serviceInstanceRedeploy is deliberately NOT used: it replays the
+            # existing deployment's snapshot (its OLD image), so the freshly
+            # pinned source.image would never reach the running container
+            # (bug #2 — config advanced but prod kept serving the stale digest).
+            deployed = gql.query(RestoreCommand::DEPLOY_V2_MUTATION,
                 serviceId: service_id, envId: env_id)
-            unless redeployed && redeployed["serviceInstanceRedeploy"]
+            new_deployment_id = deployed && deployed["serviceInstanceDeployV2"]
+            unless new_deployment_id.is_a?(String) && !new_deployment_id.empty?
                 raise MutationError,
-                    "P5: serviceInstanceRedeploy returned #{redeployed.inspect} (expected truthy) for #{service_id} -> #{image}"
+                    "P5: serviceInstanceDeployV2 returned #{deployed.inspect} " \
+                    "(expected a new deployment id String) for #{service_id} -> #{image}"
             end
 
             expected_digest = image.include?("@") ? image.split("@", 2).last : nil
             last_seen_image = nil
             last_seen_ts    = nil
+            config_inst     = nil
 
             RETRY_COUNT.times do |i|
                 data = gql.query(SERVICE_INSTANCE_RECHECK_QUERY,
@@ -1102,15 +1148,100 @@ module Railway
                 # fell back to digest-equality alone — the exact weakness this
                 # gate was added to prevent.
                 ts_ok    = actual_ts && (pre_update_ts.nil? || actual_ts > pre_update_ts)
-                return inst if image_ok && ts_ok
+                if image_ok && ts_ok
+                    config_inst = inst
+                    break
+                end
 
                 sleeper.call(RETRY_DELAY_SEC) if i < RETRY_COUNT - 1
             end
 
+            unless config_inst
+                raise MutationError,
+                    "P5: re-query did not observe image advance to #{image} AND updatedAt > #{pre_update_ts.inspect} " \
+                    "after #{RETRY_COUNT} retries (last seen image=#{last_seen_image.inspect}, " \
+                    "updatedAt=#{last_seen_ts.inspect}). Refusing to declare promote successful."
+            end
+
+            # Bug #2 SERVING-digest gate: config (source.image) advancing is NOT
+            # proof the running container actually pulled the pinned image. Poll
+            # latestDeployment until the NEW deployment (#{new_deployment_id})
+            # reaches SUCCESS, then assert its meta.imageDigest == the pinned
+            # digest. Fail loud if it crashes, never converges, or serves a
+            # different digest — promote must NOT report success while prod
+            # serves a stale image.
+            verify_serving_digest!(gql,
+                service_id: service_id, env_id: env_id, image: image,
+                expected_digest: expected_digest, new_deployment_id: new_deployment_id,
+                sleeper: sleeper)
+
+            config_inst
+        end
+
+        # Poll the production serviceInstance.latestDeployment until it reaches
+        # SUCCESS and SERVES the pinned digest. Raises MutationError on a failed
+        # deploy status, on a SUCCESS deployment serving the wrong digest, or if
+        # the new deployment never converges within the retry budget.
+        def self.verify_serving_digest!(gql, service_id:, env_id:, image:,
+                                        expected_digest:, new_deployment_id:,
+                                        sleeper: ->(n) { sleep(n) })
+            last_status = nil
+            last_serving = nil
+
+            SERVING_RETRY_COUNT.times do |i|
+                data = gql.query(SERVICE_INSTANCE_RECHECK_QUERY,
+                    serviceId: service_id, envId: env_id)
+                inst   = data && data["serviceInstance"]
+                deploy = inst && inst["latestDeployment"]
+                status = deploy && deploy["status"]
+                last_status = status
+
+                # A failed/crashed/removed latest deployment can never serve the
+                # pin — fail loud immediately rather than burn the full budget.
+                # But only hard-fail when the terminal deployment is the NEW one
+                # we triggered. Right after DeployV2 spawns new_deployment_id,
+                # latestDeployment may still briefly point to the OLD deployment,
+                # whose status flips to REMOVED/terminal as it's superseded
+                # (Railway eventual consistency). An ungated raise here would
+                # FALSELY abort a valid promote, misreporting the old
+                # deployment's teardown as the new deployment failing. If it's a
+                # stale old deployment, keep polling — the loop will see the new
+                # deployment become latest and converge.
+                if DEPLOY_FAILURE_STATUSES.include?(status) &&
+                        deploy && deploy["id"] == new_deployment_id
+                    raise MutationError,
+                        "P5: new deployment #{new_deployment_id} for #{service_id} -> #{image} reached " \
+                        "terminal status #{status.inspect}. Refusing to declare promote successful — " \
+                        "prod is NOT serving the pinned digest."
+                end
+
+                if status == "SUCCESS"
+                    serving = serving_digest_from_deployment(deploy)
+                    last_serving = serving
+                    if serving == expected_digest
+                        return inst
+                    end
+                    # SUCCESS but serving a different digest: only acceptable if
+                    # this is still the OLD deployment (Railway eventual
+                    # consistency — the new deployment id hasn't become
+                    # latestDeployment yet). Keep polling. If the NEW deployment
+                    # itself succeeded with the wrong digest, that's a hard fail.
+                    if deploy && deploy["id"] == new_deployment_id
+                        raise MutationError,
+                            "P5: new deployment #{new_deployment_id} for #{service_id} succeeded but SERVES " \
+                            "#{serving.inspect}, expected #{expected_digest.inspect}. Refusing to declare " \
+                            "promote successful — prod is serving a stale image."
+                    end
+                end
+
+                sleeper.call(SERVING_RETRY_DELAY_SEC) if i < SERVING_RETRY_COUNT - 1
+            end
+
             raise MutationError,
-                "P5: re-query did not observe image advance to #{image} AND updatedAt > #{pre_update_ts.inspect} " \
-                "after #{RETRY_COUNT} retries (last seen image=#{last_seen_image.inspect}, " \
-                "updatedAt=#{last_seen_ts.inspect}). Refusing to declare promote successful."
+                "P5: prod did not converge to SERVING the pinned digest #{expected_digest.inspect} for " \
+                "#{service_id} -> #{image} after #{SERVING_RETRY_COUNT} retries " \
+                "(last deploy status=#{last_status.inspect}, last serving digest=#{last_serving.inspect}). " \
+                "Refusing to declare promote successful — prod may be serving a stale image."
         end
 
         def default_options
@@ -1345,6 +1476,12 @@ module Railway
                 puts "[--confirm-divergence set] proceeding past #{warns.size} WARN finding(s)."
             end
 
+            # Surface staging drift LOUDLY (stdout block + Slack payload) right
+            # before the promote proceeds. Drift is NOT a refuse — promote pins
+            # staging's RUNNING digest regardless — but someone must know that
+            # what shipped to prod is not the current :latest.
+            emit_staging_drift_warnings
+
             Railway.confirm_destructive!(
                 env_label: "production",
                 action: "promote",
@@ -1361,9 +1498,20 @@ module Railway
         # a tag would defeat the entire pipeline invariant — and verify-railway-
         # image-refs PROD_SHAPE would later REFUSE.
         #
+        # CONTRACT (the whole point of promote): pin prod to WHAT STAGING IS
+        # ACTUALLY SERVING RIGHT NOW — staging's RUNNING resolved digest — NOT
+        # whatever `:latest` currently points to in GHCR. The staging tag is
+        # mutable, so a build that pushed a new `:latest` AFTER staging last
+        # deployed makes `resolve_digest(:latest)` return a digest staging
+        # never validated. We instead read the digest the staging deployment
+        # is running from Railway's `latestDeployment.meta.imageDigest` (the
+        # same field image-drift.ts uses as the deployed/running digest), and
+        # pin THAT. If that digest != current `:latest`, the caller emits a
+        # LOUD drift warning but still promotes the running digest.
+        #
         # Returns the canonical `<ghcr.io/org/name>@sha256:<digest>` ref.
-        # Returns nil if the staging tag cannot be resolved (e.g. GHCR 404 /
-        # auth failed); the caller MUST refuse rather than pin a tag.
+        # Returns nil if staging's running digest cannot be resolved; the
+        # caller MUST refuse rather than pin a tag.
         def resolved_prod_image(svc)
             # --digest override: when the operator supplied an explicit ref AND
             # we are restricted to a single service, use that ref verbatim. The
@@ -1378,14 +1526,59 @@ module Railway
             return nil if image.nil? || image.empty?
             return image if image.include?("@sha256:")  # already pinned
 
-            digest = ghcr.resolve_digest(image)
-            return nil if digest.nil?
+            # Pin to staging's RUNNING digest (what I see in staging), not
+            # resolve_digest(:latest). Falls back to nil so check_p1 REFUSEs
+            # rather than pinning a mutable tag.
+            running = staging_running_digest(svc)
+            return nil if running.nil?
 
-            # Strip the tag (`:latest`) and append the digest. parse_image_ref
-            # returns the structured parts; rebuild the canonical pinned ref.
+            # Strip the tag (`:latest`) and append the running digest.
+            # parse_image_ref returns the structured parts; rebuild the
+            # canonical pinned ref.
             parts = ghcr.parse_image_ref(image)
             registry = parts[:registry] || "ghcr.io"
-            "#{registry}/#{parts[:org]}/#{parts[:name]}@#{digest}"
+            "#{registry}/#{parts[:org]}/#{parts[:name]}@#{running}"
+        end
+
+        # The digest the staging deployment is ACTUALLY RUNNING right now.
+        #
+        # Mechanism mirrored from showcase/harness/src/probes/drivers/
+        # image-drift.ts: Railway stores tag-only refs in
+        # `serviceInstance.source.image` (e.g. `…:latest`), so the running
+        # digest is NOT recoverable from the snapshot's `image`/`digest`
+        # fields. The real running digest lives on the latest SUCCESS
+        # deployment's `meta.imageDigest` (a `sha256:…` value). We read the
+        # newest SUCCESS staging deployment and return that digest.
+        #
+        # Returns the `sha256:<hex>` digest string, or nil if no SUCCESS
+        # deployment / no imageDigest is available (caller REFUSEs).
+        #
+        # Memoized per service-id so P1 (resolve) and the drift check don't
+        # double-query Railway for the same service.
+        def staging_running_digest(svc)
+            sid = svc["service_id"]
+            return nil if sid.nil?
+            @staging_running_digests ||= {}
+            return @staging_running_digests[sid] if @staging_running_digests.key?(sid)
+
+            deployments = fetch_latest_staging_deployments(sid)
+            latest = (deployments || []).find { |d| d["status"] == "SUCCESS" }
+            digest = nil
+            if latest
+                meta = latest["meta"]
+                meta = (JSON.parse(meta) rescue meta) if meta.is_a?(String)
+                if meta.is_a?(Hash)
+                    # Prefer meta.imageDigest (the resolved running digest).
+                    # Fall back to a digest embedded in meta.image only if it
+                    # happens to be digest-pinned (rare for staging).
+                    digest = meta["imageDigest"]
+                    if (digest.nil? || digest.empty?) && meta["image"].to_s.include?("@sha256:")
+                        digest = meta["image"].to_s.split("@", 2).last
+                    end
+                    digest = nil if digest.is_a?(String) && digest.empty?
+                end
+            end
+            @staging_running_digests[sid] = digest
         end
 
         # P1 — every staging digest about to be promoted must exist in GHCR.
@@ -1403,6 +1596,11 @@ module Railway
             # second preflight against a different snapshot must not carry
             # stale A-era refs into a B-era promote.
             @promote_refs = {}
+            # Drift records accumulated this preflight: each is a Hash
+            # { name:, running:, latest: } where the staging RUNNING digest
+            # differs from the current GHCR :latest digest. Surfaced loudly on
+            # stdout and pushed to the Slack notify payload (GITHUB_OUTPUT).
+            @staging_drift = []
             (staging["services"] || []).each do |svc|
                 image = svc["image"] || svc["image_tag"]
                 if image.nil? || image.empty?
@@ -1433,6 +1631,15 @@ module Railway
                         # Record the verified ref for use by execute_promotion
                         # — guarantees pin parity with what P1 verified.
                         @promote_refs[svc["name"]] = resolved
+                        # DRIFT CHECK: `resolved` pins staging's RUNNING digest
+                        # (the contract). Compare it to what `:latest` points
+                        # to RIGHT NOW in GHCR. If they differ, staging is NOT
+                        # serving `:latest` — promote STILL proceeds with the
+                        # running digest, but we record the drift so it can be
+                        # surfaced loudly (stdout block + Slack payload). A
+                        # nil/identical current :latest (or a non-tag staging
+                        # image) means no drift signal.
+                        detect_staging_drift(svc, resolved)
                     when :missing
                         findings << "REFUSE: P1 (#{svc['name']}): #{resolved} not found in GHCR " \
                                     "(digest may have been garbage-collected; staging build may not have pushed)."
@@ -1445,6 +1652,99 @@ module Railway
                 end
             end
             findings
+        end
+
+        # Compare the digest we are about to pin (`resolved`, = staging's
+        # RUNNING digest) against what the staging `:latest` tag points to in
+        # GHCR RIGHT NOW. When they differ, staging is NOT serving the current
+        # `:latest` — record it so emit_staging_drift_warnings can surface it
+        # loudly. Does NOT add a finding (promote PROCEEDS with the running
+        # digest — that is the contract); a drift is a visible warning, not a
+        # refuse. Best-effort: a GHCR error resolving `:latest` is swallowed so
+        # it never blocks a promote whose running digest already verified.
+        def detect_staging_drift(svc, resolved)
+            # --digest override: when the operator deliberately pinned an
+            # explicit digest for this single service (see resolved_prod_image
+            # ~L1511, mirrored by P2's race-skip ~L1775), `resolved` is the
+            # operator's CHOSEN override digest — NOT staging's running digest.
+            # "Drift from :latest" is meaningless there (the operator made the
+            # choice on purpose), and reporting the override as the running
+            # digest is a spurious/misleading signal. Skip drift detection,
+            # reusing P2's exact override-detection mechanism.
+            return if options[:digest] && options[:service] && svc["name"] == options[:service]
+
+            tag_image = svc["image"] || svc["image_tag"]
+            # Only meaningful when staging tracks a mutable tag (the normal
+            # case). A digest-pinned staging image has no "current :latest" to
+            # drift from.
+            return if tag_image.nil? || tag_image.include?("@sha256:")
+
+            running_digest = resolved.include?("@") ? resolved.split("@", 2).last : nil
+            return if running_digest.nil?
+
+            begin
+                current_latest = ghcr.resolve_digest(tag_image)
+            rescue StandardError => e
+                # Fail loud: the drift check is diagnostic (the pin already uses
+                # staging's verified RUNNING digest, so the promote PROCEEDS),
+                # but the operator must not mistake a check failure for "no
+                # drift". Surface the failure instead of silently swallowing it.
+                warn "WARN: staging drift check failed for #{svc['name']}: #{e.message} — " \
+                     "could not compare against current :latest"
+                return
+            end
+            return if current_latest.nil?
+            return if current_latest == running_digest
+
+            (@staging_drift ||= []) << {
+                name:    svc["name"],
+                running: running_digest,
+                latest:  current_latest,
+            }
+        end
+
+        # Short 12-char digest for human-readable warnings (`sha256:` stripped).
+        def short_digest(d)
+            return "(none)" if d.nil? || d.empty?
+            d.sub(/^sha256:/, "")[0, 12]
+        end
+
+        # Emit the LOUD staging-drift warning to stdout (a bordered block) AND
+        # push a drift flag/line to the Slack notify payload via GITHUB_OUTPUT.
+        # Called from run_with_preflight_only after preflight, before the
+        # destructive-confirm — so it is the last thing an operator sees before
+        # the promote proceeds with the (drifted) running digest.
+        #
+        # No-op when @staging_drift is empty (staging == :latest, the common
+        # case) — preserves existing behavior for the non-drift path.
+        def emit_staging_drift_warnings
+            drift = @staging_drift || []
+            return if drift.empty?
+
+            border = "=" * 72
+            puts border
+            puts "⚠️  STAGING DRIFT — staging is NOT serving the current :latest image"
+            puts border
+            drift.each do |d|
+                puts "  #{d[:name]}: staging RUNNING #{short_digest(d[:running])} " \
+                     "!= current :latest #{short_digest(d[:latest])}"
+            end
+            puts
+            puts "  Promote PROCEEDS pinning prod to staging's RUNNING digest (what you"
+            puts "  see in staging). Someone should investigate WHY staging is behind"
+            puts "  :latest (a newer build pushed :latest after staging last deployed,"
+            puts "  a failed/in-flight staging deploy, or a manual pin)."
+            puts border
+
+            # Machine-readable marker for the CI wrapper. promote-fleet.sh greps
+            # stdout for `STAGING_DRIFT_MARKER:` lines, aggregates them across the
+            # fleet loop, and writes ONE `staging_drift=` to $GITHUB_OUTPUT (a
+            # per-child append would collide — GitHub keeps only the last value).
+            # The workflow notify job then folds it into the Slack payload.
+            line = drift.map { |d|
+                "#{d[:name]}(running=#{short_digest(d[:running])},latest=#{short_digest(d[:latest])})"
+            }.join(", ")
+            puts "STAGING_DRIFT_MARKER: #{line}"
         end
 
         # P2 — for each staging service we are promoting, the most recent
@@ -1472,8 +1772,28 @@ module Railway
                 meta = latest["meta"]
                 meta = (JSON.parse(meta) rescue meta) if meta.is_a?(String)
                 if meta.is_a?(Hash)
-                    deployed_image = meta["image"].to_s
-                    deployed_digest = deployed_image.include?("@") ? deployed_image.split("@", 2).last : nil
+                    # The running digest lives in meta.imageDigest (a `sha256:…`
+                    # value) — staging refs are tag-form (`…:latest`), so
+                    # meta.image has no `@sha256:` and reading it would make
+                    # deployed_digest perpetually nil (dead guard). Mirror
+                    # staging_running_digest: prefer meta.imageDigest, fall back
+                    # to meta.image's `@sha256:` split only if pinned, normalize
+                    # empty→nil. Keep apples-to-apples with promote_digest, which
+                    # is the bare `sha256:…` form (split on `@`).
+                    deployed_digest = meta["imageDigest"]
+                    if (deployed_digest.nil? || deployed_digest.empty?) && meta["image"].to_s.include?("@sha256:")
+                        deployed_digest = meta["image"].to_s.split("@", 2).last
+                    end
+                    deployed_digest = nil if deployed_digest.is_a?(String) && deployed_digest.empty?
+                    # --digest override: when the operator deliberately pinned an
+                    # explicit digest for this single service (see
+                    # resolved_prod_image ~L1511), @promote_refs holds the
+                    # operator's chosen digest, which legitimately differs from
+                    # staging's running digest. Skip the race comparison — the
+                    # operator made the choice on purpose; comparing would emit a
+                    # spurious REFUSE for the exact case --digest exists to support.
+                    digest_override =
+                        options[:digest] && options[:service] && svc["name"] == options[:service]
                     # Compare against the digest P1 resolved+verified (recorded
                     # in @promote_refs), NOT svc["digest"] — staging images are
                     # tag-form, so svc["digest"] is nil and the race-check would
@@ -1482,7 +1802,7 @@ module Railway
                     # REFUSEd this service and we skip the race comparison.
                     promote_ref = (@promote_refs || {})[svc["name"]]
                     promote_digest = promote_ref && promote_ref.include?("@sha256:") ? promote_ref.split("@", 2).last : nil
-                    if promote_digest && deployed_digest && deployed_digest != promote_digest
+                    if !digest_override && promote_digest && deployed_digest && deployed_digest != promote_digest
                         findings << "REFUSE: P2 (#{svc['name']}): in-flight race — latest staging deployment is " \
                                     "#{deployed_digest} but P1 resolved #{promote_digest}. Re-snapshot and retry."
                     end
@@ -1729,7 +2049,7 @@ module Railway
                     warn "PARTIAL PROMOTION: already pinned #{already_pinned.inspect}; " \
                          "FAILED on #{svc['name']}: #{e.class}: #{e.message}. " \
                          "Production is in a mixed state — note that serviceInstanceUpdate " \
-                         "runs BEFORE serviceInstanceRedeploy, so #{svc['name']}'s prod " \
+                         "runs BEFORE serviceInstanceDeployV2, so #{svc['name']}'s prod " \
                          "source.image may already be partially advanced on Railway's side. " \
                          "Run 'bin/railway rollback-commit' against the prior snapshot to revert, " \
                          "or re-run promote to retry."

--- a/showcase/bin/spec/test_promote_cr_fixes.rb
+++ b/showcase/bin/spec/test_promote_cr_fixes.rb
@@ -80,6 +80,15 @@ class PromoteCRFixesTest < Minitest::Test
         # must reflect ONLY snapshot B's services — no stale A entries.
         cmd = Railway::PromoteCommand.new([])
         cmd.instance_variable_set(:@ghcr, PassGHCR.new)
+        # resolved_prod_image now pins staging's RUNNING digest (meta.imageDigest
+        # from the latest SUCCESS deployment), not resolve_digest(:latest). Stub
+        # the deployment lookup so a digest is resolvable for each tag-form svc.
+        cmd.define_singleton_method(:fetch_latest_staging_deployments) do |svc_id|
+            name = svc_id.sub("svc-stg-", "")
+            [{ "id" => "d", "status" => "SUCCESS",
+               "meta" => { "image" => "ghcr.io/copilotkit/#{name}:latest",
+                           "imageDigest" => "sha256:running_#{name}" } }]
+        end
 
         snapshot_a = { "services" => [make_svc("alpha", image: "ghcr.io/copilotkit/alpha:latest")] }
         snapshot_b = { "services" => [make_svc("beta",  image: "ghcr.io/copilotkit/beta:latest")] }
@@ -189,7 +198,7 @@ class PromoteCRFixesTest < Minitest::Test
         fake_gql = Object.new
         fake_gql.define_singleton_method(:query) do |q, vars = {}|
             recorded << [q, vars]
-            { "serviceInstanceUpdate" => true, "serviceInstanceRedeploy" => true }
+            { "serviceInstanceUpdate" => true, "serviceInstanceDeployV2" => "dep-new" }
         end
         cmd.instance_variable_set(:@gql, fake_gql)
         cmd.instance_variable_set(:@promote_refs, {
@@ -228,13 +237,17 @@ class PromoteCRFixesTest < Minitest::Test
                 raise Railway::GraphQL::Error, "boom on update #2" if call_count == 2
                 pinned_ref = vars[:image]
                 { "serviceInstanceUpdate" => true }
-            elsif q.include?("serviceInstanceRedeploy")
-                { "serviceInstanceRedeploy" => true }
+            elsif q.include?("serviceInstanceDeployV2")
+                { "serviceInstanceDeployV2" => "dep-new" }
             elsif q.include?("ServiceInstanceRecheck")
                 if pinned_ref
                     { "serviceInstance" => { "id" => "i",
                                               "source" => { "image" => pinned_ref },
-                                              "updatedAt" => "2026-05-29T00:00:01Z" } }
+                                              "updatedAt" => "2026-05-29T00:00:01Z",
+                                              "latestDeployment" => {
+                                                  "id" => "dep-new", "status" => "SUCCESS",
+                                                  "meta" => { "imageDigest" => (pinned_ref.include?("@") ? pinned_ref.split("@", 2).last : nil) },
+                                              } } }
                 else
                     { "serviceInstance" => { "id" => "i",
                                               "source" => { "image" => "ghcr.io/copilotkit/x@sha256:OLD" },
@@ -307,6 +320,14 @@ class PromoteCRFixesTest < Minitest::Test
         # continue and the service must get a per-service REFUSE.
         cmd = Railway::PromoteCommand.new([])
         cmd.instance_variable_set(:@ghcr, ArgumentErrorGHCR.new)
+        # Stub the running-digest lookup so resolved_prod_image succeeds and the
+        # flow reaches manifest_exists (which raises the ArgumentError under test).
+        cmd.define_singleton_method(:fetch_latest_staging_deployments) do |svc_id|
+            name = svc_id.sub("svc-stg-", "")
+            [{ "id" => "d", "status" => "SUCCESS",
+               "meta" => { "image" => "ghcr.io/copilotkit/#{name}:latest",
+                           "imageDigest" => "sha256:running_#{name}" } }]
+        end
         staging = { "services" => [
             make_svc("a", image: "ghcr.io/copilotkit/a:latest"),
             make_svc("b", image: "ghcr.io/copilotkit/b:latest"),
@@ -350,8 +371,8 @@ class PromoteCRFixesTest < Minitest::Test
             if q.include?("serviceInstanceUpdate")
                 pinned = vars[:image]
                 { "serviceInstanceUpdate" => true }
-            elsif q.include?("serviceInstanceRedeploy")
-                { "serviceInstanceRedeploy" => true }
+            elsif q.include?("serviceInstanceDeployV2")
+                { "serviceInstanceDeployV2" => "dep-new" }
             elsif q.include?("ServiceInstanceRecheck")
                 if pinned.nil?
                     # Pre-update: brand-new instance — both fields are nil.

--- a/showcase/bin/spec/test_promote_execute.rb
+++ b/showcase/bin/spec/test_promote_execute.rb
@@ -21,8 +21,9 @@ class PromoteExecuteTest < Minitest::Test
             if q.include?("serviceInstanceUpdate")
                 @pinned_image = vars[:image]
                 { "serviceInstanceUpdate" => true }
-            elsif q.include?("serviceInstanceRedeploy")
-                { "serviceInstanceRedeploy" => true }
+            elsif q.include?("serviceInstanceDeployV2")
+                # New deployment spawned; returns the new deployment id.
+                { "serviceInstanceDeployV2" => "dep-new" }
             elsif q.include?("ServiceInstanceRecheck")
                 if @pinned_image.nil?
                     # Pre-update snapshot.
@@ -34,11 +35,19 @@ class PromoteExecuteTest < Minitest::Test
                         },
                     }
                 else
+                    # Post-update: config advanced AND the new deployment
+                    # (dep-new) has SUCCEEDED serving the pinned digest, so both
+                    # the config recheck and the bug-#2 serving gate pass.
+                    pinned_digest = @pinned_image.include?("@") ? @pinned_image.split("@", 2).last : nil
                     {
                         "serviceInstance" => {
                             "id" => "i",
                             "source" => { "image" => @pinned_image },
                             "updatedAt" => "2026-05-29T00:00:01Z",
+                            "latestDeployment" => {
+                                "id" => "dep-new", "status" => "SUCCESS",
+                                "meta" => { "imageDigest" => pinned_digest },
+                            },
                         },
                     }
                 end
@@ -109,15 +118,20 @@ class PromoteExecuteTest < Minitest::Test
         gql = RecordingGQL.new
         cmd.instance_variable_set(:@gql, gql)
         cmd.instance_variable_set(:@ghcr, FakeGHCR.new(resolve_map: resolve_map, exists_set: exists_set))
-        # Skip P2 deployments query — make fetch_latest_staging_deployments return
-        # a SUCCESS deployment whose digest matches whatever we will resolve.
-        # Fall back to a placeholder digest so the fixture is never a malformed
-        # "...@" — the unresolvable-tag test path will REFUSE at P1 before P2
-        # consults this stub, so the placeholder value is benign.
-        resolved_digest = resolve_map.values.first ||
-            (staging_image.include?("@") ? staging_image.split("@", 2).last : "sha256:placeholder")
+        # resolved_prod_image pins staging's RUNNING digest, sourced from the
+        # latest SUCCESS deployment's meta.imageDigest (image-drift.ts mechanism).
+        # Map the staging RUNNING digest from resolve_map (the test's notion of
+        # the resolvable digest) or, for an already-digest-pinned staging image,
+        # the embedded digest. When resolve_map is EMPTY *and* the image is
+        # tag-only, the deployment carries NO imageDigest — modelling the
+        # "no running digest resolvable" REFUSE path (replaces the old
+        # "GHCR :latest unresolvable" REFUSE).
+        running_digest = resolve_map.values.first ||
+            (staging_image.include?("@") ? staging_image.split("@", 2).last : nil)
         cmd.define_singleton_method(:fetch_latest_staging_deployments) do |_svc_id|
-            [{ "id" => "d", "status" => "SUCCESS", "meta" => { "image" => "ghcr.io/copilotkit/x@#{resolved_digest}" } }]
+            meta = { "image" => "ghcr.io/copilotkit/x:latest" }
+            meta["imageDigest"] = running_digest if running_digest
+            [{ "id" => "d", "status" => "SUCCESS", "meta" => meta }]
         end
         cmd.define_singleton_method(:run_staging_probe) { |services:| { ok: true, summary: "" } }
         [cmd, gql]

--- a/showcase/bin/spec/test_promote_fleet_target_invariant.rb
+++ b/showcase/bin/spec/test_promote_fleet_target_invariant.rb
@@ -57,8 +57,8 @@ class PromoteFleetTargetInvariantTest < Minitest::Test
             if q.include?("serviceInstanceUpdate")
                 @pinned_by_service[sid] = vars[:image]
                 { "serviceInstanceUpdate" => true }
-            elsif q.include?("serviceInstanceRedeploy")
-                { "serviceInstanceRedeploy" => true }
+            elsif q.include?("serviceInstanceDeployV2")
+                { "serviceInstanceDeployV2" => "dep-#{sid}" }
             elsif q.include?("ServiceInstanceRecheck")
                 pinned = @pinned_by_service[sid]
                 if pinned.nil?
@@ -71,11 +71,16 @@ class PromoteFleetTargetInvariantTest < Minitest::Test
                     }
                 else
                     @ts_counter += 1
+                    pinned_digest = pinned.include?("@") ? pinned.split("@", 2).last : nil
                     {
                         "serviceInstance" => {
                             "id" => "i",
                             "source" => { "image" => pinned },
                             "updatedAt" => "2026-05-29T00:00:#{format('%02d', @ts_counter)}Z",
+                            "latestDeployment" => {
+                                "id" => "dep-#{sid}", "status" => "SUCCESS",
+                                "meta" => { "imageDigest" => pinned_digest },
+                            },
                         },
                     }
                 end

--- a/showcase/bin/spec/test_promote_p2.rb
+++ b/showcase/bin/spec/test_promote_p2.rb
@@ -103,4 +103,59 @@ class PromoteP2Test < Minitest::Test
         combined = out + err
         refute_match(/REFUSE: P2/, combined)
     end
+
+    def test_refuses_when_running_digest_from_meta_imageDigest_does_not_match
+        # REAL staging shape: the staging ref is TAG-FORM (`…:latest`), so the
+        # running digest is NOT in meta.image (which is also tag-form). It lives
+        # in meta.imageDigest. P1's resolved_prod_image pins staging's running
+        # digest (svc-1 below resolves to sha256:OLD via staging_running_digest),
+        # while the LATEST deployment is now running sha256:NEW — an in-flight
+        # race. Before the fix, deployed_digest read meta.image (no `@`) → nil →
+        # the guard was DEAD and never REFUSEd. Now it reads meta.imageDigest.
+        staging = { "services" => [{
+            "name" => "x", "service_id" => "svc-1",
+            "image" => "ghcr.io/copilotkit/x:latest", "digest" => nil,
+            "env_keys" => [],
+        }] }
+        deps = { "svc-1" => [
+            { "id" => "d2", "status" => "SUCCESS",
+              "meta" => { "image" => "ghcr.io/copilotkit/x:latest", "imageDigest" => "sha256:NEW" },
+              "createdAt" => "2026-05-28T02:00:00Z" },
+            { "id" => "d1", "status" => "SUCCESS",
+              "meta" => { "image" => "ghcr.io/copilotkit/x:latest", "imageDigest" => "sha256:OLD" },
+              "createdAt" => "2026-05-28T01:00:00Z" },
+        ] }
+        # Pin @promote_refs as if P1 resolved the OLDER running digest, so the
+        # latest deployment (sha256:NEW) is a genuine in-flight race.
+        c = cmd_with(staging: staging, deployments: deps)
+        c.instance_variable_set(:@promote_refs, { "x" => "ghcr.io/copilotkit/x@sha256:OLD" })
+        findings = c.send(:check_p2_staging_deployments, staging)
+        combined = findings.join("\n")
+        assert_match(/REFUSE: P2.*in-flight.*sha256:NEW.*sha256:OLD/i, combined)
+    end
+
+    def test_digest_override_skips_p2_race_check
+        # --digest override: operator deliberately pinned an explicit digest for
+        # this single service. @promote_refs then holds the operator's chosen
+        # digest (sha256:CHOSEN), which legitimately differs from staging's
+        # running digest (sha256:NEW). The P2 race comparison MUST be skipped —
+        # otherwise it would emit a spurious REFUSE for the exact case --digest
+        # exists to support.
+        staging = { "services" => [{
+            "name" => "x", "service_id" => "svc-1",
+            "image" => "ghcr.io/copilotkit/x:latest", "digest" => nil,
+            "env_keys" => [],
+        }] }
+        deps = { "svc-1" => [
+            { "id" => "d1", "status" => "SUCCESS",
+              "meta" => { "image" => "ghcr.io/copilotkit/x:latest", "imageDigest" => "sha256:NEW" },
+              "createdAt" => "2026-05-28T01:00:00Z" },
+        ] }
+        c = cmd_with(staging: staging, deployments: deps)
+        c.instance_variable_set(:@options, c.options.merge(digest: "ghcr.io/copilotkit/x@sha256:CHOSEN", service: "x"))
+        c.instance_variable_set(:@promote_refs, { "x" => "ghcr.io/copilotkit/x@sha256:CHOSEN" })
+        findings = c.send(:check_p2_staging_deployments, staging)
+        combined = findings.join("\n")
+        refute_match(/REFUSE: P2/, combined)
+    end
 end

--- a/showcase/bin/spec/test_promote_p5.rb
+++ b/showcase/bin/spec/test_promote_p5.rb
@@ -16,14 +16,38 @@ class PromoteP5Test < Minitest::Test
         end
     end
 
+    NEW_DEPLOY_ID = "dep-new"
+
     # Helper: a "pre-update snapshot" GQL response with a given updatedAt.
     def pre(ts) = { data: { "serviceInstance" => { "id" => "i", "source" => { "image" => "ghcr.io/copilotkit/x@sha256:OLD" }, "updatedAt" => ts } } }
 
-    # Helper: a "post-update re-query" response.
+    # Helper: a "post-update re-query" (config recheck) response.
     def post(image:, ts:) = { data: { "serviceInstance" => { "id" => "i", "source" => { "image" => image }, "updatedAt" => ts } } }
 
+    # Helper: a successful DeployV2 mutation returning a new deployment id.
+    def deploy_ok(id = NEW_DEPLOY_ID) = { data: { "serviceInstanceDeployV2" => id } }
+
+    # Helper: a serving-digest recheck response. The NEW deployment has reached
+    # the given status and serves the given digest. Defaults to the SUCCESS +
+    # pinned-digest happy path.
+    def serving(digest:, status: "SUCCESS", deploy_id: NEW_DEPLOY_ID)
+        {
+            data: {
+                "serviceInstance" => {
+                    "id" => "i",
+                    "source" => { "image" => "ghcr.io/copilotkit/x@#{digest}" },
+                    "updatedAt" => "2026-05-28T03:00:00Z",
+                    "latestDeployment" => {
+                        "id" => deploy_id, "status" => status,
+                        "meta" => { "imageDigest" => digest },
+                    },
+                },
+            },
+        }
+    end
+
     def test_refuses_when_update_returns_false
-        # Order: pre-update snapshot, then update (false) — refuse before redeploy.
+        # Order: pre-update snapshot, then update (false) — refuse before deploy.
         gql = FakeGQL.new([
             pre("2026-05-27T00:00:00Z"),
             { data: { "serviceInstanceUpdate" => false } },
@@ -35,17 +59,88 @@ class PromoteP5Test < Minitest::Test
         end
     end
 
-    def test_verifies_image_AND_updatedAt_advanced_after_update
+    def test_refuses_when_deploy_v2_returns_no_id
+        # serviceInstanceDeployV2 must return a non-empty deployment id String.
         gql = FakeGQL.new([
             pre("2026-05-27T00:00:00Z"),
             { data: { "serviceInstanceUpdate"   => true } },
-            { data: { "serviceInstanceRedeploy" => true } },
+            { data: { "serviceInstanceDeployV2" => nil } },
+        ])
+        assert_raises(Railway::PromoteCommand::MutationError) do
+            Railway::PromoteCommand.pin_and_verify(gql,
+                service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+                sleeper: ->(_n) {})
+        end
+    end
+
+    def test_verifies_image_AND_updatedAt_advanced_then_serving_digest
+        gql = FakeGQL.new([
+            pre("2026-05-27T00:00:00Z"),
+            { data: { "serviceInstanceUpdate" => true } },
+            deploy_ok,
             post(image: "ghcr.io/copilotkit/x@sha256:NEW", ts: "2026-05-28T01:00:00Z"),
+            serving(digest: "sha256:NEW"),
         ])
         Railway::PromoteCommand.pin_and_verify(gql,
             service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
             sleeper: ->(_n) {})
-        assert_equal 4, gql.calls.size
+        assert_equal 5, gql.calls.size
+    end
+
+    def test_refuses_when_new_deployment_serves_wrong_digest
+        # Bug #2: config advanced + DeployV2 spawned, but the NEW deployment
+        # succeeded SERVING a stale digest. Must fail loud.
+        gql = FakeGQL.new([
+            pre("2026-05-27T00:00:00Z"),
+            { data: { "serviceInstanceUpdate" => true } },
+            deploy_ok,
+            post(image: "ghcr.io/copilotkit/x@sha256:NEW", ts: "2026-05-28T01:00:00Z"),
+            serving(digest: "sha256:STALE"),  # new deploy SUCCESS but wrong digest
+        ])
+        err = assert_raises(Railway::PromoteCommand::MutationError) do
+            Railway::PromoteCommand.pin_and_verify(gql,
+                service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+                sleeper: ->(_n) {})
+        end
+        assert_match(/serving a stale image|SERVES/, err.message)
+    end
+
+    def test_refuses_when_new_deployment_crashes
+        gql = FakeGQL.new([
+            pre("2026-05-27T00:00:00Z"),
+            { data: { "serviceInstanceUpdate" => true } },
+            deploy_ok,
+            post(image: "ghcr.io/copilotkit/x@sha256:NEW", ts: "2026-05-28T01:00:00Z"),
+            serving(digest: "sha256:NEW", status: "CRASHED"),
+        ])
+        err = assert_raises(Railway::PromoteCommand::MutationError) do
+            Railway::PromoteCommand.pin_and_verify(gql,
+                service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+                sleeper: ->(_n) {})
+        end
+        assert_match(/terminal status/, err.message)
+    end
+
+    def test_keeps_polling_when_stale_old_deployment_is_terminal
+        # Bug (false-abort): right after DeployV2 spawns new_deployment_id,
+        # latestDeployment may still briefly point to the OLD deployment, whose
+        # status flips to REMOVED as it's superseded. The terminal-status check
+        # must NOT raise on this stale old deployment (deploy.id != new id) — it
+        # must keep polling. On a later poll the NEW deployment becomes latest
+        # with SUCCESS + the pinned digest, so verify_serving_digest! converges.
+        gql = FakeGQL.new([
+            pre("2026-05-27T00:00:00Z"),
+            { data: { "serviceInstanceUpdate" => true } },
+            deploy_ok,
+            post(image: "ghcr.io/copilotkit/x@sha256:NEW", ts: "2026-05-28T01:00:00Z"),
+            # Early poll: OLD deployment is still latest, now being torn down.
+            serving(digest: "sha256:OLD", status: "REMOVED", deploy_id: "dep-old"),
+            # Later poll: NEW deployment is latest, SUCCESS, serving the pin.
+            serving(digest: "sha256:NEW"),
+        ])
+        Railway::PromoteCommand.pin_and_verify(gql,
+            service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+            sleeper: ->(_n) {})
     end
 
     def test_refuses_when_image_advanced_but_updatedAt_did_NOT_advance
@@ -57,7 +152,7 @@ class PromoteP5Test < Minitest::Test
         gql = FakeGQL.new([
             pre(pre_ts),
             { data: { "serviceInstanceUpdate"   => true } },
-            { data: { "serviceInstanceRedeploy" => true } },
+            deploy_ok,
             stale_ts_post, stale_ts_post, stale_ts_post,
         ])
         assert_raises(Railway::PromoteCommand::MutationError) do
@@ -73,7 +168,7 @@ class PromoteP5Test < Minitest::Test
         gql = FakeGQL.new([
             pre("2026-05-27T00:00:00Z"),
             { data: { "serviceInstanceUpdate"   => true } },
-            { data: { "serviceInstanceRedeploy" => true } },
+            deploy_ok,
             stale, stale, stale,
         ])
         assert_raises(Railway::PromoteCommand::MutationError) do
@@ -89,8 +184,9 @@ class PromoteP5Test < Minitest::Test
         gql = FakeGQL.new([
             pre("2026-05-27T00:00:00Z"),
             { data: { "serviceInstanceUpdate"   => true } },
-            { data: { "serviceInstanceRedeploy" => true } },
+            deploy_ok,
             stale, stale, new_ok,
+            serving(digest: "sha256:NEW"),
         ])
         Railway::PromoteCommand.pin_and_verify(gql,
             service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",

--- a/showcase/bin/spec/test_promote_resolve_once.rb
+++ b/showcase/bin/spec/test_promote_resolve_once.rb
@@ -9,8 +9,9 @@ require_relative "spec_helper"
 #   FIX-2: a Railway::GHCR::Error raised mid-loop in P1 produces a per-
 #          service REFUSE finding and the loop continues for remaining
 #          services — earlier findings are NOT discarded.
-#   FIX-3: pin_and_verify asserts the serviceInstanceRedeploy result is
-#          truthy (symmetric with the serviceInstanceUpdate result check).
+#   FIX-3: pin_and_verify asserts the serviceInstanceDeployV2 result is a
+#          non-empty deployment id (symmetric with the serviceInstanceUpdate
+#          result check).
 #   FIX-4: P2 emits a WARN finding when deployment meta is not a Hash, so
 #          the silent skip of the in-flight race-check is visible.
 #   FIX-5: when pin_and_verify raises mid-loop in execute_promotion, a
@@ -69,8 +70,10 @@ class PromoteResolveOnceTest < Minitest::Test
                 @ts_counter += 1
                 @post[sid] = { image: vars[:image], ts: "2026-05-29T00:00:%02dZ" % @ts_counter }
                 { "serviceInstanceUpdate" => true }
-            elsif q.include?("serviceInstanceRedeploy")
-                { "serviceInstanceRedeploy" => @redeploy_result }
+            elsif q.include?("serviceInstanceDeployV2")
+                # @redeploy_result false → return nil id so the DeployV2 guard
+                # fails loud (mirrors the prior redeploy-false fail path).
+                { "serviceInstanceDeployV2" => (@redeploy_result ? "dep-#{sid}" : nil) }
             elsif q.include?("ServiceInstanceRecheck")
                 if (entry = @post[sid])
                     {
@@ -78,6 +81,12 @@ class PromoteResolveOnceTest < Minitest::Test
                             "id" => "i",
                             "source" => { "image" => entry[:image] },
                             "updatedAt" => entry[:ts],
+                            "latestDeployment" => {
+                                "id" => "dep-#{sid}", "status" => "SUCCESS",
+                                "meta" => {
+                                    "imageDigest" => (entry[:image].include?("@") ? entry[:image].split("@", 2).last : nil),
+                                },
+                            },
                         },
                     }
                 else
@@ -198,6 +207,15 @@ class PromoteResolveOnceTest < Minitest::Test
         # that names the service.
         cmd = Railway::PromoteCommand.new([])
         cmd.instance_variable_set(:@ghcr, RaisingOnSecondGHCR.new)
+        # resolved_prod_image now pins staging's RUNNING digest (meta.imageDigest);
+        # stub the deployment lookup so the flow reaches manifest_exists (which
+        # raises on the 2nd service under test).
+        cmd.define_singleton_method(:fetch_latest_staging_deployments) do |svc_id|
+            name = svc_id.sub("svc-stg-", "")
+            [{ "id" => "d", "status" => "SUCCESS",
+               "meta" => { "image" => "ghcr.io/copilotkit/#{name}:latest",
+                           "imageDigest" => "sha256:running_#{name}" } }]
+        end
         staging = {
             "services" => [
                 make_svc("a", image: "ghcr.io/copilotkit/a:latest"),
@@ -214,7 +232,7 @@ class PromoteResolveOnceTest < Minitest::Test
 
     # =================== FIX-3 ===================
 
-    def test_fix3_pin_and_verify_raises_when_redeploy_returns_false
+    def test_fix3_pin_and_verify_raises_when_deploy_returns_no_id
         gql = RecordingGQL.new(redeploy_result: false)
         err = assert_raises(Railway::PromoteCommand::MutationError) do
             Railway::PromoteCommand.pin_and_verify(gql,
@@ -222,8 +240,8 @@ class PromoteResolveOnceTest < Minitest::Test
                 image: "ghcr.io/copilotkit/x@sha256:abc",
                 sleeper: ->(_) {})
         end
-        assert_match(/serviceInstanceRedeploy/i, err.message,
-            "MutationError must reference the redeploy mutation; got: #{err.message}")
+        assert_match(/serviceInstanceDeployV2/i, err.message,
+            "MutationError must reference the deploy mutation; got: #{err.message}")
     end
 
     # =================== FIX-4 ===================

--- a/showcase/bin/spec/test_promote_single_service.rb
+++ b/showcase/bin/spec/test_promote_single_service.rb
@@ -29,8 +29,8 @@ class PromoteSingleServiceTest < Minitest::Test
             if q.include?("serviceInstanceUpdate")
                 @pinned_by_service[sid] = vars[:image]
                 { "serviceInstanceUpdate" => true }
-            elsif q.include?("serviceInstanceRedeploy")
-                { "serviceInstanceRedeploy" => true }
+            elsif q.include?("serviceInstanceDeployV2")
+                { "serviceInstanceDeployV2" => "dep-#{sid}" }
             elsif q.include?("ServiceInstanceRecheck")
                 pinned = @pinned_by_service[sid]
                 if pinned.nil?
@@ -43,11 +43,16 @@ class PromoteSingleServiceTest < Minitest::Test
                     }
                 else
                     @ts_counter += 1
+                    pinned_digest = pinned.include?("@") ? pinned.split("@", 2).last : nil
                     {
                         "serviceInstance" => {
                             "id" => "i",
                             "source" => { "image" => pinned },
                             "updatedAt" => "2026-05-29T00:00:#{format('%02d', @ts_counter)}Z",
+                            "latestDeployment" => {
+                                "id" => "dep-#{sid}", "status" => "SUCCESS",
+                                "meta" => { "imageDigest" => pinned_digest },
+                            },
                         },
                     }
                 end

--- a/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
+++ b/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
@@ -62,8 +62,8 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
             if q.include?("serviceInstanceUpdate")
                 @pinned_by_service[sid] = vars[:image]
                 { "serviceInstanceUpdate" => true }
-            elsif q.include?("serviceInstanceRedeploy")
-                { "serviceInstanceRedeploy" => true }
+            elsif q.include?("serviceInstanceDeployV2")
+                { "serviceInstanceDeployV2" => "dep-#{sid}" }
             elsif q.include?("ServiceInstanceRecheck")
                 pinned = @pinned_by_service[sid]
                 if pinned.nil?
@@ -76,11 +76,16 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
                     }
                 else
                     @ts_counter += 1
+                    pinned_digest = pinned.include?("@") ? pinned.split("@", 2).last : nil
                     {
                         "serviceInstance" => {
                             "id" => "i",
                             "source" => { "image" => pinned },
                             "updatedAt" => "2026-05-29T00:00:#{format('%02d', @ts_counter)}Z",
+                            "latestDeployment" => {
+                                "id" => "dep-#{sid}", "status" => "SUCCESS",
+                                "meta" => { "imageDigest" => pinned_digest },
+                            },
                         },
                     }
                 end

--- a/showcase/bin/spec/test_promote_staging_running_digest.rb
+++ b/showcase/bin/spec/test_promote_staging_running_digest.rb
@@ -1,0 +1,241 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+# Covers the staging-running-digest pin + drift warning:
+#   CASE-A: staging RUNNING digest == current :latest  -> pin it, NO warning.
+#   CASE-B: staging RUNNING digest != current :latest  -> pin the RUNNING
+#           digest (NOT :latest) + emit the loud STAGING DRIFT warning.
+#   CASE-C: resolved_prod_image pins meta.imageDigest, not resolve_digest(tag).
+#   CASE-D: no SUCCESS staging deployment -> resolved_prod_image returns nil
+#           (caller REFUSEs rather than pin a mutable tag).
+class PromoteStagingRunningDigestTest < Minitest::Test
+    # GHCR fake: resolve_digest(:latest-tag) returns a configurable "current
+    # latest" digest; manifest_exists is always :exists. Counts resolve_digest
+    # calls so we can assert the tag is NOT used to pick the prod pin.
+    class FakeGHCR
+        attr_reader :resolve_calls
+
+        def initialize(current_latest:)
+            @current_latest = current_latest
+            @resolve_calls  = Hash.new(0)
+        end
+
+        def resolve_digest(ref)
+            @resolve_calls[ref] += 1
+            return ref.split("@", 2).last if ref.include?("@sha256:")
+            @current_latest
+        end
+
+        def manifest_exists(_ref); :exists; end
+        def parse_image_ref(ref); Railway::GHCR.allocate.parse_image_ref(ref); end
+    end
+
+    # Benign GQL: P2 issues a deployments query; return empty so P2 is a no-op.
+    class FakeGQLEmpty
+        def query(*); { "deployments" => { "edges" => [] } }; end
+    end
+
+    def make_cmd(staging_services:, prod_services: [], current_latest:, running_meta:)
+        cmd = Railway::PromoteCommand.new(["--non-interactive", "--yes", "--confirm-divergence"])
+        cmd.parser.parse!(cmd.argv)
+        cmd.instance_variable_set(:@staging_snapshot, { "services" => staging_services })
+        cmd.instance_variable_set(:@prod_snapshot,    { "services" => prod_services })
+        cmd.instance_variable_set(:@gql,  FakeGQLEmpty.new)
+        cmd.instance_variable_set(:@ghcr, FakeGHCR.new(current_latest: current_latest))
+        # The RUNNING digest source: latest SUCCESS staging deployment's
+        # meta.imageDigest. Keyed implicitly by the single service under test.
+        cmd.define_singleton_method(:fetch_latest_staging_deployments) do |_svc_id|
+            [{ "id" => "d", "status" => "SUCCESS", "meta" => running_meta }]
+        end
+        cmd.define_singleton_method(:run_staging_probe) { |services:| { ok: true, summary: "" } }
+        cmd
+    end
+
+    STG = lambda do |name|
+        {
+            "name" => name, "service_id" => "svc-stg-#{name}",
+            "image" => "ghcr.io/copilotkit/#{name}:latest",
+            "env_keys" => [],
+        }
+    end
+
+    # =================== CASE-C: pins meta.imageDigest, not :latest ===========
+
+    def test_resolved_prod_image_pins_running_digest_not_latest
+        cmd = make_cmd(
+            staging_services: [STG.call("x")],
+            current_latest:   "sha256:261ccdef",  # the WRONG (drifted) :latest
+            running_meta:     { "image" => "ghcr.io/copilotkit/x:latest",
+                                "imageDigest" => "sha256:f9454e79" }, # the RUNNING digest
+        )
+        resolved = cmd.send(:resolved_prod_image, STG.call("x"))
+        assert_equal "ghcr.io/copilotkit/x@sha256:f9454e79", resolved,
+            "must pin staging RUNNING digest (meta.imageDigest), NOT current :latest"
+        # resolve_digest(:latest-tag) must NOT be what picks the prod pin.
+        refute_includes resolved, "261ccdef",
+            "prod pin must not be the current :latest digest"
+    end
+
+    # =================== CASE-D: no SUCCESS deploy -> nil =====================
+
+    def test_resolved_prod_image_nil_when_no_running_digest
+        cmd = make_cmd(
+            staging_services: [STG.call("x")],
+            current_latest:   "sha256:261ccdef",
+            running_meta:     { "image" => "ghcr.io/copilotkit/x:latest" }, # no imageDigest
+        )
+        # Drop the SUCCESS deployment entirely.
+        cmd.define_singleton_method(:fetch_latest_staging_deployments) { |_| [] }
+        assert_nil cmd.send(:resolved_prod_image, STG.call("x")),
+            "must return nil (caller REFUSEs) when no running digest is resolvable"
+    end
+
+    # =================== CASE-A: running == :latest -> no warning ============
+
+    def test_no_drift_warning_when_running_equals_latest
+        same = "sha256:cafebabe"
+        cmd = make_cmd(
+            staging_services: [STG.call("x")],
+            prod_services:    [{ "name" => "x", "service_id" => "svc-prod-x",
+                                 "image" => "ghcr.io/copilotkit/x@sha256:OLD", "env_keys" => [] }],
+            current_latest:   same,
+            running_meta:     { "image" => "ghcr.io/copilotkit/x:latest", "imageDigest" => same },
+        )
+        out, _err = capture_io { cmd.send(:check_p1_ghcr_digests, cmd.instance_variable_get(:@staging_snapshot)) }
+        cmd.send(:emit_staging_drift_warnings)
+        out2, _ = capture_io { cmd.send(:emit_staging_drift_warnings) }
+        refute_match(/STAGING DRIFT/, out + out2,
+            "no drift warning when staging RUNNING == current :latest")
+        # And the pinned ref is still the running digest.
+        assert_equal "ghcr.io/copilotkit/x@sha256:cafebabe",
+            cmd.instance_variable_get(:@promote_refs)["x"]
+    end
+
+    # =================== CASE-B: running != :latest -> warning ===============
+
+    def test_drift_warning_when_running_differs_from_latest
+        cmd = make_cmd(
+            staging_services: [STG.call("ms-agent-dotnet")],
+            prod_services:    [{ "name" => "ms-agent-dotnet", "service_id" => "svc-prod-d",
+                                 "image" => "ghcr.io/copilotkit/ms-agent-dotnet@sha256:OLD", "env_keys" => [] }],
+            current_latest:   "sha256:261ccdef3f9a",  # drifted :latest
+            running_meta:     { "image" => "ghcr.io/copilotkit/ms-agent-dotnet:latest",
+                                "imageDigest" => "sha256:f9454e79fbf5" }, # RUNNING
+        )
+        # Run P1 (populates @promote_refs + @staging_drift) then emit the warning.
+        capture_io { cmd.send(:check_p1_ghcr_digests, cmd.instance_variable_get(:@staging_snapshot)) }
+        out, _err = capture_io { cmd.send(:emit_staging_drift_warnings) }
+
+        assert_match(/STAGING DRIFT/, out, "must emit the loud drift block")
+        assert_match(/ms-agent-dotnet/, out, "must name the drifted service")
+        assert_match(/f9454e79/, out, "must name the staging RUNNING digest")
+        assert_match(/261ccdef/, out, "must name the current :latest digest")
+        # Promote still pins the RUNNING digest (drift is a warning, not a refuse).
+        assert_equal "ghcr.io/copilotkit/ms-agent-dotnet@sha256:f9454e79fbf5",
+            cmd.instance_variable_get(:@promote_refs)["ms-agent-dotnet"],
+            "promote must STILL pin the staging RUNNING digest despite drift"
+    end
+
+    # =================== CASE-F: --digest override -> NO drift signal ========
+
+    # When the operator supplies an explicit --digest for a single service, the
+    # pinned ref is the operator's CHOSEN override (not staging's running
+    # digest), so "drift from :latest" is meaningless. detect_staging_drift must
+    # skip — even when the override digest differs from current :latest — and
+    # emit_staging_drift_warnings must say nothing for it.
+    def test_no_drift_signal_when_digest_override_active
+        override_ref = "ghcr.io/copilotkit/x@sha256:0verr1de00"
+        cmd = make_cmd(
+            staging_services: [STG.call("x")],
+            current_latest:   "sha256:261ccdef",  # differs from the override digest
+            running_meta:     { "image" => "ghcr.io/copilotkit/x:latest",
+                                "imageDigest" => "sha256:f9454e79" },
+        )
+        # Operator pinned an explicit digest for this single service (mirrors the
+        # `run`-time options after `promote x --digest <ref>`).
+        cmd.options[:service] = "x"
+        cmd.options[:digest]  = override_ref
+
+        capture_io { cmd.send(:check_p1_ghcr_digests, cmd.instance_variable_get(:@staging_snapshot)) }
+
+        # No drift entry recorded — the override is a deliberate choice, not drift.
+        assert_empty Array(cmd.instance_variable_get(:@staging_drift)),
+            "a --digest override must NOT be recorded as staging drift"
+
+        # And the loud warning emits nothing for it.
+        out, _ = capture_io { cmd.send(:emit_staging_drift_warnings) }
+        refute_match(/STAGING DRIFT/, out,
+            "a --digest override must not produce a (spurious) drift warning")
+        refute_match(/STAGING_DRIFT_MARKER/, out,
+            "a --digest override must not emit a drift marker")
+
+        # The override digest is what got pinned (verbatim).
+        assert_equal override_ref, cmd.instance_variable_get(:@promote_refs)["x"],
+            "promote must pin the operator's chosen override digest"
+    end
+
+    # =================== CASE-E: GHCR resolve fails -> loud WARN, no abort ====
+
+    # GHCR fake whose tag resolution RAISES (auth/transport failure), but digest
+    # refs (@sha256:...) still resolve — so resolved_prod_image's running-digest
+    # pin succeeds while detect_staging_drift's :latest comparison blows up.
+    class FakeGHCRRaisingTag
+        def resolve_digest(ref)
+            return ref.split("@", 2).last if ref.include?("@sha256:")
+            raise StandardError, "GHCR auth failed (boom)"
+        end
+
+        def manifest_exists(_ref); :exists; end
+        def parse_image_ref(ref); Railway::GHCR.allocate.parse_image_ref(ref); end
+    end
+
+    def test_drift_check_failure_warns_loudly_and_does_not_abort
+        cmd = make_cmd(
+            staging_services: [STG.call("x")],
+            current_latest:   "sha256:unused",
+            running_meta:     { "image" => "ghcr.io/copilotkit/x:latest",
+                                "imageDigest" => "sha256:f9454e79" },
+        )
+        cmd.instance_variable_set(:@ghcr, FakeGHCRRaisingTag.new)
+
+        out, err = capture_io do
+            cmd.send(:check_p1_ghcr_digests, cmd.instance_variable_get(:@staging_snapshot))
+        end
+
+        # Fail loud: the drift-check failure must surface, with the error message.
+        assert_match(/WARN: staging drift check failed for x/, out + err,
+            "must emit a loud WARN when the GHCR :latest resolve fails")
+        assert_match(/GHCR auth failed \(boom\)/, out + err,
+            "WARN must carry the underlying error message")
+
+        # Promote PROCEEDS: the running-digest pin still happened (no abort).
+        assert_equal "ghcr.io/copilotkit/x@sha256:f9454e79",
+            cmd.instance_variable_get(:@promote_refs)["x"],
+            "promote must STILL pin the running digest despite the drift-check failure"
+
+        # No drift entry recorded (the check could not be performed).
+        assert_empty Array(cmd.instance_variable_get(:@staging_drift)),
+            "a check FAILURE must not be recorded as a drift"
+        out2, _ = capture_io { cmd.send(:emit_staging_drift_warnings) }
+        refute_match(/STAGING DRIFT/, out2,
+            "a check failure must not produce a (false) drift warning")
+    end
+
+    # =================== CASE-B (machine marker for Slack payload) ===========
+
+    def test_drift_emits_machine_readable_marker
+        # The bordered block is for humans; promote-fleet.sh greps the
+        # STAGING_DRIFT_MARKER: line and aggregates it into the Slack payload.
+        cmd = make_cmd(
+            staging_services: [STG.call("x")],
+            current_latest:   "sha256:aaaa1111",
+            running_meta:     { "image" => "ghcr.io/copilotkit/x:latest", "imageDigest" => "sha256:bbbb2222" },
+        )
+        capture_io { cmd.send(:check_p1_ghcr_digests, cmd.instance_variable_get(:@staging_snapshot)) }
+        out, _ = capture_io { cmd.send(:emit_staging_drift_warnings) }
+        assert_match(/^STAGING_DRIFT_MARKER: /, out, "must emit a machine-readable drift marker line")
+        assert_match(/running=bbbb2222/, out, "marker must carry the RUNNING digest")
+        assert_match(/latest=aaaa1111/, out, "marker must carry the :latest digest")
+    end
+end

--- a/showcase/bin/spec/test_snapshot_graphql.rb
+++ b/showcase/bin/spec/test_snapshot_graphql.rb
@@ -164,16 +164,25 @@ class SnapshotGraphqlTest < Minitest::Test
         end
     end
 
-    def test_redeploy_mutation_uses_serviceInstanceRedeploy_not_serviceInstanceDeployV2_with_image
-        # serviceInstanceDeployV2 has signature (commitSha, environmentId, serviceId).
-        # It does NOT accept an `image` argument. Pinning must go through
-        # serviceInstanceUpdate (source.image) + serviceInstanceRedeploy.
+    def test_deploy_mutation_uses_serviceInstanceDeployV2_not_redeploy
+        # Bug #2: serviceInstanceRedeploy replays the EXISTING deployment's
+        # snapshot (its OLD image), so a freshly pinned source.image never
+        # reaches the running container. Pinning must go through
+        # serviceInstanceUpdate (source.image) + serviceInstanceDeployV2, which
+        # spawns a NEW deployment that PULLS the updated source.image.
+        #
+        # serviceInstanceDeployV2 has signature (serviceId, environmentId,
+        # commitSha?) and does NOT accept an `image` arg — the image is carried
+        # by the preceding serviceInstanceUpdate.
         refute_match(/serviceInstanceDeployV2\s*\([^)]*\bimage\b/m,
-            Railway::RestoreCommand::UPDATE_IMAGE_MUTATION,
-            "Restore must not call serviceInstanceDeployV2 with image arg.")
+            Railway::RestoreCommand::DEPLOY_V2_MUTATION,
+            "DeployV2 must not be called with an image arg.")
         assert_match(/serviceInstanceUpdate\s*\(/, Railway::RestoreCommand::UPDATE_IMAGE_MUTATION)
         assert_match(/source:\s*\{\s*image:/, Railway::RestoreCommand::UPDATE_IMAGE_MUTATION)
-        assert_match(/serviceInstanceRedeploy\s*\(/, Railway::RestoreCommand::REDEPLOY_MUTATION)
+        assert_match(/serviceInstanceDeployV2\s*\(/, Railway::RestoreCommand::DEPLOY_V2_MUTATION)
+        # The bug-#2 trap: serviceInstanceRedeploy must NOT be the deploy path.
+        refute Railway::RestoreCommand.const_defined?(:REDEPLOY_MUTATION),
+            "serviceInstanceRedeploy must be removed — it replays the old image (bug #2)."
     end
 
     def test_snapshot_v2_captures_healthcheck_region_replicas_restart_policy

--- a/showcase/bin/spec/test_snapshot_ivar_lint.rb
+++ b/showcase/bin/spec/test_snapshot_ivar_lint.rb
@@ -54,33 +54,33 @@ class SnapshotIvarLintTest < Minitest::Test
     #                       prose (do not perform a read)
     ALLOWED_LINES = [
         # `run` — capture full-fleet view before optional narrowing.
-        '1224:@full_staging_snapshot = @staging_snapshot',
-        '1225:@full_prod_snapshot    = @prod_snapshot',
+        '1355:@full_staging_snapshot = @staging_snapshot',
+        '1356:@full_prod_snapshot    = @prod_snapshot',
 
         # Doc comment above narrow_snapshots_to_single_service!.
-        '1233:# Narrow @staging_snapshot and @prod_snapshot to only the named',
+        '1364:# Narrow @staging_snapshot and @prod_snapshot to only the named',
 
         # narrow_snapshots_to_single_service! — the WRITE site.
-        '1241:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1246:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
-        '1247:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1248:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
+        '1372:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1377:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
+        '1378:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1379:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
 
         # Doc comment above capture_snapshots.
-        '1252:# @staging_snapshot / @prod_snapshot directly.',
+        '1383:# @staging_snapshot / @prod_snapshot directly.',
 
         # capture_snapshots — single test-seam assignment site.
-        '1254:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
-        '1255:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
+        '1385:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
+        '1386:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
 
         # Doc comment above the accessor block (explains test seam).
-        '1279:# promote tests stub @staging_snapshot/@prod_snapshot directly',
+        '1410:# promote tests stub @staging_snapshot/@prod_snapshot directly',
 
         # The four accessor bodies — the ONLY sanctioned reads.
-        '1291:@full_staging_snapshot || @staging_snapshot',
-        '1295:@full_prod_snapshot || @prod_snapshot',
-        '1299:@staging_snapshot',
-        '1303:@prod_snapshot',
+        '1422:@full_staging_snapshot || @staging_snapshot',
+        '1426:@full_prod_snapshot || @prod_snapshot',
+        '1430:@staging_snapshot',
+        '1434:@prod_snapshot',
     ].freeze
 
     def setup

--- a/showcase/scripts/__tests__/promote-fleet.bats
+++ b/showcase/scripts/__tests__/promote-fleet.bats
@@ -233,3 +233,78 @@ STUB
   [[ "$output" == *"SUCCEEDED (2): svc-a svc-c"* ]] || fail "whitespace-only token not skipped: $output"
   [[ "$output" == *"Attempted 2 service(s)"* ]] || fail "wrong Attempted count: $output"
 }
+
+@test "aggregates STAGING_DRIFT_MARKER lines into staging_drift output + summary" {
+  # Stub that emits a drift marker for svc-b (staging not serving :latest) while
+  # still SUCCEEDING — drift is a warning surface, not a gate. The script must
+  # scan each promote's stdout, aggregate the markers, write them to
+  # $GITHUB_OUTPUT (staging_drift=...) and surface them in the summary.
+  cat > "$STUB_DIR/railway-drift" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "promote" ] || { echo "expected first arg 'promote', got '$1'" >&2; exit 99; }
+svc="$2"
+echo "STUB called for: $svc"
+if [ "$svc" = "svc-b" ]; then
+  echo "STAGING_DRIFT_MARKER: svc-b(running=f9454e79fbf5,latest=261ccdef3f9a)"
+fi
+exit 0
+STUB
+  chmod +x "$STUB_DIR/railway-drift"
+  export RAILWAY_BIN="$STUB_DIR/railway-drift"
+  run env SERVICES_CSV="svc-a,svc-b,svc-c" bash "$SCRIPT"
+
+  # Drift does not fail the run (every service succeeded).
+  [ "$status" -eq 0 ] || fail "drift must not fail the run, got $status: $output"
+  # Summary surfaces the drift loudly and names the running/latest digests.
+  [[ "$output" == *"STAGING DRIFT (1)"* ]] || fail "missing drift summary block: $output"
+  [[ "$output" == *"running=f9454e79fbf5"* ]] || fail "summary missing RUNNING digest: $output"
+  [[ "$output" == *"latest=261ccdef3f9a"* ]] || fail "summary missing :latest digest: $output"
+
+  # The aggregated payload is exported for the notify job's Slack message.
+  run cat "$GITHUB_OUTPUT"
+  [[ "$output" == *"staging_drift=svc-b(running=f9454e79fbf5,latest=261ccdef3f9a)"* ]] \
+    || fail "missing/wrong staging_drift in GITHUB_OUTPUT: $output"
+}
+
+@test "joins multiple STAGING_DRIFT_MARKER entries with '; ' separator" {
+  # Two services drift. The aggregated staging_drift payload must join the
+  # entries with "; " (semicolon + space), NOT ";" — `${drift[*]}` under
+  # IFS='; ' would only honor the first IFS char and drop the space.
+  cat > "$STUB_DIR/railway-drift2" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "promote" ] || { echo "expected first arg 'promote', got '$1'" >&2; exit 99; }
+svc="$2"
+echo "STUB called for: $svc"
+if [ "$svc" = "svc-a" ]; then
+  echo "STAGING_DRIFT_MARKER: svc-a(running=aaaaaaaaaaaa,latest=bbbbbbbbbbbb)"
+fi
+if [ "$svc" = "svc-c" ]; then
+  echo "STAGING_DRIFT_MARKER: svc-c(running=cccccccccccc,latest=dddddddddddd)"
+fi
+exit 0
+STUB
+  chmod +x "$STUB_DIR/railway-drift2"
+  export RAILWAY_BIN="$STUB_DIR/railway-drift2"
+  run env SERVICES_CSV="svc-a,svc-b,svc-c" bash "$SCRIPT"
+
+  [ "$status" -eq 0 ] || fail "drift must not fail the run, got $status: $output"
+  [[ "$output" == *"STAGING DRIFT (2)"* ]] || fail "missing drift summary block: $output"
+
+  run cat "$GITHUB_OUTPUT"
+  # Both entries present, joined with "; " (NOT ";" — the dropped-space bug).
+  [[ "$output" == *"staging_drift=svc-a(running=aaaaaaaaaaaa,latest=bbbbbbbbbbbb); svc-c(running=cccccccccccc,latest=dddddddddddd)"* ]] \
+    || fail "multi-entry drift not joined with '; ' separator: $output"
+}
+
+@test "no drift markers -> empty staging_drift output, no drift summary" {
+  export RAILWAY_BIN="$STUB_DIR/railway-green"
+  run env SERVICES_CSV="svc-a,svc-b,svc-c" bash "$SCRIPT"
+
+  [ "$status" -eq 0 ] || fail "expected zero exit, got $status: $output"
+  [[ "$output" != *"STAGING DRIFT"* ]] || fail "no drift expected but summary shows one: $output"
+
+  run cat "$GITHUB_OUTPUT"
+  # Key present but empty (the non-drift contract): staging_drift=
+  [[ "$output" == *"staging_drift="* ]] || fail "staging_drift key absent: $output"
+  [[ "$output" != *"staging_drift=svc"* ]] || fail "unexpected drift payload: $output"
+}

--- a/showcase/scripts/promote-fleet.sh
+++ b/showcase/scripts/promote-fleet.sh
@@ -60,6 +60,7 @@ fi
 
 succeeded=()
 failed=()        # "svc=exitcode" entries
+drift=()         # aggregated STAGING_DRIFT_MARKER payloads across the fleet
 
 for svc in "${SVCS[@]}"; do
   # Trim leading/trailing whitespace: `IFS=',' read` does NOT trim, so a CSV
@@ -79,8 +80,20 @@ for svc in "${SVCS[@]}"; do
   fi
 
   echo "==> $RAILWAY_BIN ${args[*]}"
-  "$RAILWAY_BIN" "${args[@]}"
-  rc=$?
+  # Tee the promote output so we (a) still stream it live to the operator/CI
+  # log AND (b) can scan it for the STAGING_DRIFT_MARKER line that bin/railway
+  # emits when staging is NOT serving the current :latest. PIPESTATUS[0] is the
+  # railway exit code (tee always exits 0), so the per-service success/fail
+  # accounting is unaffected by the pipe.
+  out="$("$RAILWAY_BIN" "${args[@]}" 2>&1 | tee /dev/stderr)"
+  rc="${PIPESTATUS[0]}"
+
+  # Collect any drift marker(s) emitted for this service. The marker payload is
+  # everything after "STAGING_DRIFT_MARKER: ". Promote still SUCCEEDS on drift
+  # (it pins staging's running digest) — this is a warning surface, not a gate.
+  while IFS= read -r line; do
+    [ -n "$line" ] && drift+=("$line")
+  done < <(printf '%s\n' "$out" | sed -n 's/^STAGING_DRIFT_MARKER: //p')
 
   if [ "$rc" -eq 0 ]; then
     echo "    OK: $svc"
@@ -121,6 +134,20 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "::error::promote-fleet: failed to write succeeded_csv to \$GITHUB_OUTPUT ('$GITHUB_OUTPUT')." >&2
     exit 1
   fi
+  # Aggregated staging-drift payload (one line, services semicolon-joined) so
+  # the notify job can fold "staging was NOT serving :latest" into the Slack
+  # message. Empty when no service drifted (the common case).
+  staging_drift=""
+  if [ "${#drift[@]}" -gt 0 ]; then
+    # Join with "; " between entries. `${drift[*]}` with IFS='; ' would only use
+    # the FIRST IFS char (';'), dropping the space; build the separator explicitly.
+    printf -v staging_drift '%s; ' "${drift[@]}"
+    staging_drift="${staging_drift%; }"
+  fi
+  if ! echo "staging_drift=$staging_drift" >> "$GITHUB_OUTPUT"; then
+    echo "::error::promote-fleet: failed to write staging_drift to \$GITHUB_OUTPUT ('$GITHUB_OUTPUT')." >&2
+    exit 1
+  fi
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────
@@ -142,6 +169,12 @@ if [ "${#succeeded[@]}" -gt 0 ]; then
   emit "SUCCEEDED (${#succeeded[@]}): ${succeeded[*]}"
 else
   emit "SUCCEEDED (0): (none)"
+fi
+
+if [ "${#drift[@]}" -gt 0 ]; then
+  emit ""
+  emit "⚠️ STAGING DRIFT (${#drift[@]}): staging was NOT serving current :latest for — ${drift[*]}"
+  emit "Promote pinned prod to staging's RUNNING digest (what was seen in staging); investigate the drift."
 fi
 
 if [ "${#failed[@]}" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Fixes two correctness bugs in the showcase staging→prod promote path (`showcase/bin/railway`), discovered + live-validated while promoting the full 19-service cluster.

**Bug #1 — promote pinned the wrong digest.** `resolved_prod_image` re-resolved the mutable `:latest` tag against *current* GHCR instead of pinning the digest staging is actually *running* (`latestDeployment.meta.imageDigest`). When `:latest` drifted after staging deployed, promote pushed an unvalidated (and once, regressed) image to prod. Now pins staging's running digest. Adds a loud `⚠️ STAGING DRIFT` warning (promote stdout + `STAGING_DRIFT_MARKER:` → `promote-fleet.sh` aggregation → both Slack payloads) when staging's running digest ≠ current `:latest`, so the gap is visible without blocking the promote.

**Bug #2 — the pin never activated.** `pin_and_verify` used `serviceInstanceRedeploy`, which replays the *existing* deployment's old image rather than the just-pinned `source.image`. Config showed the new digest while prod kept serving the old one (this is why earlier promotes "succeeded" while prod stayed broken). Switched to `serviceInstanceDeployV2` + a new `verify_serving_digest!` gate that polls the new deployment to SUCCESS and **fails loud** if the running digest ≠ pinned.

Plus CR-round hardening: P2 in-flight race check now reads `meta.imageDigest` (was dead on tag-form staging) and skips on `--digest` override; `detect_staging_drift` fails loud (WARN) on GHCR-resolve failure instead of swallowing; `--digest` override suppresses spurious drift; `drift_line` LF-stripped at the `GITHUB_OUTPUT` boundary; multi-service drift join fixed; fallback-log drift preserved.

## Commits
1. `fix(showcase): pin prod to staging's running digest + loud staging-drift warning`
2. `fix(showcase): activate prod pin via serviceInstanceDeployV2 + verify running==pinned`
3. `fix(showcase): harden promote P2 race check + refresh ivar-lint allowlist`

## Validation
- Live red-green on real Railway: claude-sdk-python prod flipped from stale → pinned digest via the fixed CLI; all 19 cluster services promoted green; 5 previously-degraded backends (ag2, llamaindex, pydantic-ai, ms-agent-python, strands) recovered.
- 15/15 Ruby specs + 15/15 bats green; ruby -c, shellcheck (CI invocation), actionlint clean.
- 3-round cr-loop (7 agents/round) converged to zero bucket-(a).

## Follow-ups (not in this PR)
- Defensive `.to_s.empty?` on `meta.imageDigest` extraction (can't-happen on real Railway).
- Test-quality nits (capture_io scoping, weak bats glob, shared mock fixture).
- Pre-existing verify-prod `succeeded_csv`/`GITHUB_OUTPUT` coupling (graceful-degraded, audited STAY_IN_C).
- `deploy-to-railway.ts` births prod on `:latest` (the root provisioning gap); CLI↔workflow notify equivalence (PR2).

## Test plan
- [ ] CI green on PR HEAD
- [ ] (post-merge) a real `gh workflow run showcase_promote.yml` shows the drift line in the #team-showcase notification when staging is behind :latest