### PR TITLE
fix(generative-ui-playground): valid model id + serverExternalPackages

### DIFF
--- a/examples/showcases/generative-ui-playground/next.config.ts
+++ b/examples/showcases/generative-ui-playground/next.config.ts
@@ -4,6 +4,9 @@ const nextConfig: NextConfig = {
   // Disable React strict mode to prevent double-rendering issues with MCP Apps
   // The MCPAppsActivityRenderer creates duplicate iframes in strict mode
   reactStrictMode: false,
+  // The API routes import @copilotkit/runtime/v2 (server-only); keep it external
+  // so Next.js does not try to bundle it. Base package name covers the /v2 subpath.
+  serverExternalPackages: ["@copilotkit/runtime"],
   // Note: NOT using standalone mode - hono/vercel adapter requires regular next start
 };
 

--- a/examples/showcases/generative-ui-playground/src/app/api/copilotkit-opengenui/[[...slug]]/route.ts
+++ b/examples/showcases/generative-ui-playground/src/app/api/copilotkit-opengenui/[[...slug]]/route.ts
@@ -13,7 +13,7 @@ import {
 } from "@copilotkit/runtime/v2";
 import { handle } from "hono/vercel";
 
-const MODEL = "openai/gpt-5.2";
+const MODEL = "openai/gpt-4o";
 
 const agent = new BuiltInAgent({
   model: MODEL,


### PR DESCRIPTION
## Summary

Two focused, pre-existing fixes in the `generative-ui-playground` example. These were surfaced as out-of-subject bucket-(d) findings during the `@copilotkitnext` → `/v2` migration CR (#5562) and split out into this follow-up.

### 1. Invalid model id in the opengenui route
`src/app/api/copilotkit-opengenui/[[...slug]]/route.ts:16` set `const MODEL = "openai/gpt-5.2"` — a nonexistent model id, so every chat turn errored. Changed to `"openai/gpt-4o"`, the verified-real id used by the sibling `showcase/shell/src/app/api/copilotkit/[[...slug]]/route.ts`.

### 2. Missing `serverExternalPackages` in next.config.ts
`next.config.ts` lacked `serverExternalPackages`, but the example's API routes import `@copilotkit/runtime/v2` (a server-only package). Added `serverExternalPackages: ["@copilotkit/runtime"]` (base package name covers the `/v2` subpath), mirroring `showcase/shell/next.config.ts`.

## Red → Green evidence

**Model id**
- RED: `route.ts:16` was `const MODEL = "openai/gpt-5.2";`; sibling `showcase/shell` route uses `model: "openai/gpt-4o"`.
- GREEN: `route.ts:16` is now `const MODEL = "openai/gpt-4o";`.

**serverExternalPackages**
- RED: `grep -n serverExternalPackages next.config.ts` -> no match (exit 1).
- GREEN: `grep -n serverExternalPackages next.config.ts` -> `9:  serverExternalPackages: ["@copilotkit/runtime"],`.

## Build outcome

`next build` is **blocked by SEPARATE pre-existing module-resolution failures unrelated to these fixes** and NOT addressed here:
- `copilotkit` and `copilotkit-a2ui` routes import `createCopilotEndpoint` from the bare v1 `@copilotkit/runtime`, which does not export it.
- The `copilotkit-opengenui` route (and its client-component chain) imports from `@copilotkitnext/runtime`, which is not a declared dependency of this package and fails with `Module not found: Can't resolve '@copilotkitnext/runtime'`.

Because the build fails at module resolution for these pre-existing imports before compiling the changed lines, a clean end-to-end build cannot be obtained. Both edits are statically correct: the model id matches the verified-real sibling, and `serverExternalPackages` mirrors the working `showcase/shell` config. Fixing the pre-existing `createCopilotEndpoint` / `@copilotkitnext/runtime` import errors is explicitly out of scope for this follow-up.