### PR TITLE
fix(examples): suppress browser-extension hydration warning on <body> across integration demos

### DIFF
--- a/examples/integrations/_parity/manifest.json
+++ b/examples/integrations/_parity/manifest.json
@@ -136,7 +136,7 @@
         "next.config.ts"
       ],
       "packageJsonOverrides": {
-        "scripts.dev:agent": "./scripts/run-agent.sh || scripts\\\\run-agent.bat",
+        "scripts.dev:agent": "./scripts/run-agent.sh || scripts\\run-agent.bat",
         "scripts.install:agent": "cd agent && npm install"
       }
     },
@@ -175,8 +175,8 @@
         "scripts/**"
       ],
       "packageJsonOverrides": {
-        "scripts.dev:agent": "./scripts/run-agent.sh || scripts\\\\run-agent.bat",
-        "scripts.install:agent": "./scripts/setup-agent.sh || scripts\\\\setup-agent.bat"
+        "scripts.dev:agent": "./scripts/run-agent.sh || scripts\\run-agent.bat",
+        "scripts.install:agent": "./scripts/setup-agent.sh || scripts\\setup-agent.bat"
       }
     }
   }

--- a/examples/integrations/adk/src/app/layout.tsx
+++ b/examples/integrations/adk/src/app/layout.tsx
@@ -16,12 +16,16 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={"antialiased"}>
+      {/*
+        suppressHydrationWarning: browser extensions (e.g. Grammarly) inject
+        attributes like data-gr-ext-installed onto <body> before React hydrates,
+        which would otherwise surface as a hydration mismatch on first load.
+        This only relaxes the check for <body>'s own attributes (one level deep);
+        everything rendered inside <body> is still fully hydration-checked.
+      */}
+      <body className={"antialiased"} suppressHydrationWarning>
         {/* Force REST transport so runtime-info + threads both hit the multi-route endpoint (auto-detect races the lazily-compiled API route in next dev). */}
-        <CopilotKit
-          runtimeUrl="/api/copilotkit"
-          useSingleEndpoint={false}
-        >
+        <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/agent-spec/src/app/layout.tsx
+++ b/examples/integrations/agent-spec/src/app/layout.tsx
@@ -27,7 +27,14 @@ export default function RootLayout({
           href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap"
         />
       </head>
-      <body className={"antialiased"}>
+      {/*
+        suppressHydrationWarning: browser extensions (e.g. Grammarly) inject
+        attributes like data-gr-ext-installed onto <body> before React hydrates,
+        which would otherwise surface as a hydration mismatch on first load.
+        This only relaxes the check for <body>'s own attributes (one level deep);
+        everything rendered inside <body> is still fully hydration-checked.
+      */}
+      <body className={"antialiased"} suppressHydrationWarning>
         <div className="flex h-dvh w-screen flex-col min-h-0 overflow-hidden bg-background">
           {children}
         </div>

--- a/examples/integrations/agno/src/app/layout.tsx
+++ b/examples/integrations/agno/src/app/layout.tsx
@@ -16,12 +16,16 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={"antialiased"}>
+      {/*
+        suppressHydrationWarning: browser extensions (e.g. Grammarly) inject
+        attributes like data-gr-ext-installed onto <body> before React hydrates,
+        which would otherwise surface as a hydration mismatch on first load.
+        This only relaxes the check for <body>'s own attributes (one level deep);
+        everything rendered inside <body> is still fully hydration-checked.
+      */}
+      <body className={"antialiased"} suppressHydrationWarning>
         {/* Force REST transport so runtime-info + threads both hit the multi-route endpoint (auto-detect races the lazily-compiled API route in next dev). */}
-        <CopilotKit
-          runtimeUrl="/api/copilotkit"
-          useSingleEndpoint={false}
-        >
+        <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/crewai-crews/src/app/layout.tsx
+++ b/examples/integrations/crewai-crews/src/app/layout.tsx
@@ -16,7 +16,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={"antialiased"}>
+      {/*
+        suppressHydrationWarning: browser extensions (e.g. Grammarly) inject
+        attributes like data-gr-ext-installed onto <body> before React hydrates,
+        which would otherwise surface as a hydration mismatch on first load.
+        This only relaxes the check for <body>'s own attributes (one level deep);
+        everything rendered inside <body> is still fully hydration-checked.
+      */}
+      <body className={"antialiased"} suppressHydrationWarning>
         {/* Force REST transport so runtime-info + threads both hit the multi-route endpoint (auto-detect races the lazily-compiled API route in next dev). */}
         <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
           {children}

--- a/examples/integrations/crewai-flows/src/app/layout.tsx
+++ b/examples/integrations/crewai-flows/src/app/layout.tsx
@@ -16,12 +16,16 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={"antialiased"}>
+      {/*
+        suppressHydrationWarning: browser extensions (e.g. Grammarly) inject
+        attributes like data-gr-ext-installed onto <body> before React hydrates,
+        which would otherwise surface as a hydration mismatch on first load.
+        This only relaxes the check for <body>'s own attributes (one level deep);
+        everything rendered inside <body> is still fully hydration-checked.
+      */}
+      <body className={"antialiased"} suppressHydrationWarning>
         {/* Force REST transport so runtime-info + threads both hit the multi-route endpoint (auto-detect races the lazily-compiled API route in next dev). */}
-        <CopilotKit
-          runtimeUrl="/api/copilotkit"
-          useSingleEndpoint={false}
-        >
+        <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/langgraph-fastapi/src/app/layout.tsx
+++ b/examples/integrations/langgraph-fastapi/src/app/layout.tsx
@@ -21,7 +21,14 @@ export default function RootLayout({
           href="/copilotkit-logo-mark.svg"
         />
       </head>
-      <body className={`antialiased`}>
+      {/*
+        suppressHydrationWarning: browser extensions (e.g. Grammarly) inject
+        attributes like data-gr-ext-installed onto <body> before React hydrates,
+        which would otherwise surface as a hydration mismatch on first load.
+        This only relaxes the check for <body>'s own attributes (one level deep);
+        everything rendered inside <body> is still fully hydration-checked.
+      */}
+      <body className={`antialiased`} suppressHydrationWarning>
         <ThemeProvider>
           <CopilotKit
             runtimeUrl="/api/copilotkit"

--- a/examples/integrations/langgraph-js/package.json
+++ b/examples/integrations/langgraph-js/package.json
@@ -6,7 +6,7 @@
     "dev": "concurrently \"npm run dev:ui\" \"npm run dev:agent\" --names ui,agent --prefix-colors blue,green --kill-others",
     "dev:debug": "LOG_LEVEL=debug npm run dev",
     "dev:ui": "next dev --turbopack",
-    "dev:agent": "./scripts/run-agent.sh || scripts\\\\run-agent.bat",
+    "dev:agent": "./scripts/run-agent.sh || scripts\\run-agent.bat",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/examples/integrations/langgraph-js/src/app/layout.tsx
+++ b/examples/integrations/langgraph-js/src/app/layout.tsx
@@ -21,7 +21,14 @@ export default function RootLayout({
           href="/copilotkit-logo-mark.svg"
         />
       </head>
-      <body className={`antialiased`}>
+      {/*
+        suppressHydrationWarning: browser extensions (e.g. Grammarly) inject
+        attributes like data-gr-ext-installed onto <body> before React hydrates,
+        which would otherwise surface as a hydration mismatch on first load.
+        This only relaxes the check for <body>'s own attributes (one level deep);
+        everything rendered inside <body> is still fully hydration-checked.
+      */}
+      <body className={`antialiased`} suppressHydrationWarning>
         <ThemeProvider>
           <CopilotKit
             runtimeUrl="/api/copilotkit"

--- a/examples/integrations/langgraph-python/src/app/layout.tsx
+++ b/examples/integrations/langgraph-python/src/app/layout.tsx
@@ -21,7 +21,14 @@ export default function RootLayout({
           href="/copilotkit-logo-mark.svg"
         />
       </head>
-      <body className={`antialiased`}>
+      {/*
+        suppressHydrationWarning: browser extensions (e.g. Grammarly) inject
+        attributes like data-gr-ext-installed onto <body> before React hydrates,
+        which would otherwise surface as a hydration mismatch on first load.
+        This only relaxes the check for <body>'s own attributes (one level deep);
+        everything rendered inside <body> is still fully hydration-checked.
+      */}
+      <body className={`antialiased`} suppressHydrationWarning>
         <ThemeProvider>
           <CopilotKit
             runtimeUrl="/api/copilotkit"

--- a/examples/integrations/llamaindex/src/app/layout.tsx
+++ b/examples/integrations/llamaindex/src/app/layout.tsx
@@ -16,12 +16,16 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={"antialiased"}>
+      {/*
+        suppressHydrationWarning: browser extensions (e.g. Grammarly) inject
+        attributes like data-gr-ext-installed onto <body> before React hydrates,
+        which would otherwise surface as a hydration mismatch on first load.
+        This only relaxes the check for <body>'s own attributes (one level deep);
+        everything rendered inside <body> is still fully hydration-checked.
+      */}
+      <body className={"antialiased"} suppressHydrationWarning>
         {/* Force REST transport so runtime-info + threads both hit the multi-route endpoint (auto-detect races the lazily-compiled API route in next dev). */}
-        <CopilotKit
-          runtimeUrl="/api/copilotkit"
-          useSingleEndpoint={false}
-        >
+        <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/mastra/src/app/layout.tsx
+++ b/examples/integrations/mastra/src/app/layout.tsx
@@ -26,8 +26,16 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      {/*
+        suppressHydrationWarning: browser extensions (e.g. Grammarly) inject
+        attributes like data-gr-ext-installed onto <body> before React hydrates,
+        which would otherwise surface as a hydration mismatch on first load.
+        This only relaxes the check for <body>'s own attributes (one level deep);
+        everything rendered inside <body> is still fully hydration-checked.
+      */}
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        suppressHydrationWarning
       >
         {/* Force REST transport so runtime-info + threads both hit the multi-route endpoint (auto-detect races the lazily-compiled API route in next dev). */}
         <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>

--- a/examples/integrations/ms-agent-framework-dotnet/src/app/layout.tsx
+++ b/examples/integrations/ms-agent-framework-dotnet/src/app/layout.tsx
@@ -16,12 +16,16 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={"antialiased"}>
+      {/*
+        suppressHydrationWarning: browser extensions (e.g. Grammarly) inject
+        attributes like data-gr-ext-installed onto <body> before React hydrates,
+        which would otherwise surface as a hydration mismatch on first load.
+        This only relaxes the check for <body>'s own attributes (one level deep);
+        everything rendered inside <body> is still fully hydration-checked.
+      */}
+      <body className={"antialiased"} suppressHydrationWarning>
         {/* Force REST transport so runtime-info + threads both hit the multi-route endpoint (auto-detect races the lazily-compiled API route in next dev). */}
-        <CopilotKit
-          runtimeUrl="/api/copilotkit"
-          useSingleEndpoint={false}
-        >
+        <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/ms-agent-framework-python/src/app/layout.tsx
+++ b/examples/integrations/ms-agent-framework-python/src/app/layout.tsx
@@ -16,12 +16,16 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={"antialiased"}>
+      {/*
+        suppressHydrationWarning: browser extensions (e.g. Grammarly) inject
+        attributes like data-gr-ext-installed onto <body> before React hydrates,
+        which would otherwise surface as a hydration mismatch on first load.
+        This only relaxes the check for <body>'s own attributes (one level deep);
+        everything rendered inside <body> is still fully hydration-checked.
+      */}
+      <body className={"antialiased"} suppressHydrationWarning>
         {/* Force REST transport so runtime-info + threads both hit the multi-route endpoint (auto-detect races the lazily-compiled API route in next dev). */}
-        <CopilotKit
-          runtimeUrl="/api/copilotkit"
-          useSingleEndpoint={false}
-        >
+        <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/pydantic-ai/src/app/layout.tsx
+++ b/examples/integrations/pydantic-ai/src/app/layout.tsx
@@ -16,12 +16,16 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={"antialiased"}>
+      {/*
+        suppressHydrationWarning: browser extensions (e.g. Grammarly) inject
+        attributes like data-gr-ext-installed onto <body> before React hydrates,
+        which would otherwise surface as a hydration mismatch on first load.
+        This only relaxes the check for <body>'s own attributes (one level deep);
+        everything rendered inside <body> is still fully hydration-checked.
+      */}
+      <body className={"antialiased"} suppressHydrationWarning>
         {/* Force REST transport so runtime-info + threads both hit the multi-route endpoint (auto-detect races the lazily-compiled API route in next dev). */}
-        <CopilotKit
-          runtimeUrl="/api/copilotkit"
-          useSingleEndpoint={false}
-        >
+        <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
           {children}
         </CopilotKit>
       </body>

--- a/examples/integrations/strands-python/src/app/layout.tsx
+++ b/examples/integrations/strands-python/src/app/layout.tsx
@@ -21,7 +21,14 @@ export default function RootLayout({
           href="/copilotkit-logo-mark.svg"
         />
       </head>
-      <body className={`antialiased`}>
+      {/*
+        suppressHydrationWarning: browser extensions (e.g. Grammarly) inject
+        attributes like data-gr-ext-installed onto <body> before React hydrates,
+        which would otherwise surface as a hydration mismatch on first load.
+        This only relaxes the check for <body>'s own attributes (one level deep);
+        everything rendered inside <body> is still fully hydration-checked.
+      */}
+      <body className={`antialiased`} suppressHydrationWarning>
         <ThemeProvider>
           <CopilotKit
             runtimeUrl="/api/copilotkit"


### PR DESCRIPTION
## What

1. Add `suppressHydrationWarning` to `<body>` across **all 14 integration demo templates** (`examples/integrations/*/src/app/layout.tsx`).
2. Fix a pre-existing **double-escaped Windows path** bug in the parity manifest's `packageJsonOverrides`.

## Why (hydration)

**Mike Ryan hit a hydration error on first load of a fresh `langgraph-python` init — caused by his Grammarly browser extension.**

Grammarly (and similar extensions) inject attributes onto `<body>` *before* React hydrates:

```
data-new-gr-c-s-check-loaded="9.98.0"
data-gr-ext-installed=""
```

Those attributes are in the client DOM but absent from the server HTML, so Next.js reports:

> A tree hydrated but some attributes of the server rendered HTML didn't match the client properties.

It's a **false positive** — the app works, and end users (without dev extensions) never see it — but it's a red console error on the first load of our flagship eval/showcase templates, which is a poor first impression.

## Fix (hydration)

`suppressHydrationWarning` on `<body>` is the React/Next.js-recommended escape hatch for this. It is **scoped and one level deep**: it only relaxes the check for `<body>`'s *own* attributes/text — **everything rendered inside `<body>` (the whole app) is still fully hydration-checked** — and `<body>`'s only attribute here is a static `className`, so none of our own markup is masked. An inline comment documents this so a future maintainer who adds dynamic `<body>` attributes knows the check is relaxed.

`agent-spec` already had `suppressHydrationWarning` on `<html>`; the Grammarly attributes land on `<body>`, so it needed the body-level relaxation too (the `<html>` one is a level up and doesn't cover `<body>`'s attributes).

## Commits

1. `b1fa482a7` — north-star (`langgraph-python`) + parity instances (`langgraph-js`, `langgraph-fastapi`, `strands-python`) via `pnpm parity:sync`.
2. `9f9c415d9` — the non-parity templates (not tracked by `_parity/manifest.json`): `adk`, `agno`, `crewai-crews`, `crewai-flows`, `llamaindex`, `mastra`, `ms-agent-framework-dotnet`, `ms-agent-framework-python`, `pydantic-ai`, `agent-spec`. *(The repo's `oxfmt` pre-commit hook also collapsed some multiline `<CopilotKit …>` JSX in these files — standard auto-format on touched files; the only semantic change is the suppression.)*
3. `7d60e49de` — parity manifest path-escaping fix (see below).

## The manifest bug (commit 3)

While syncing I found the `langgraph-js` and `strands-python` `packageJsonOverrides` double-escaped the Windows `.bat` fallback, producing `scripts\\run-agent.bat` (two backslashes) instead of `scripts\run-agent.bat`:

- `langgraph-js/package.json` had already been synced with the broken value.
- `strands-python/package.json` was still correct — and `parity:sync` would have **corrupted** it on the next run (which is what surfaced this).

Fixed the three overrides and re-ran `parity:sync`, which corrects `langgraph-js/package.json` and leaves `strands-python`'s correct value intact.

## Test plan

- [x] `pnpm parity:verify` → 0 errors
- [x] lefthook pre-commit green on all 3 commits (lint + `packages/**` tests + commitlint)
- [x] All 14 templates confirmed to have body-level `suppressHydrationWarning`
- [ ] Reviewer with Grammarly installed: run/`init` a template and confirm no hydration error on first load
