### PR TITLE
test(showcase): bump calculator-fixture integration pin to 19 for ms-agent-harness-dotnet

### DIFF
--- a/showcase/scripts/__tests__/calculator-fixture-routing.test.ts
+++ b/showcase/scripts/__tests__/calculator-fixture-routing.test.ts
@@ -49,8 +49,8 @@ const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const CALC_PILL = "build a modern calculator with standard buttons";
 const GENERIC_PILL = "build a modern calculator";
 // The FULL production pill text, from
-// src/app/demos/beautiful-chat/hooks/use-example-suggestions.tsx in 16 of the
-// 18 integrations — built-in-agent and claude-sdk-python have no calculator
+// src/app/demos/beautiful-chat/hooks/use-example-suggestions.tsx in 17 of the
+// 19 integrations — built-in-agent and claude-sdk-python have no calculator
 // pill; their fixture blocks are mirror-parity entries per the GOTCHAS MIRROR
 // rule, ready for when those demos gain the pill. The fixture matchers above
 // (CALC_PILL / GENERIC_PILL) are SUBSTRINGS of this — the behavioral walk
@@ -164,12 +164,12 @@ function send(
 }
 
 describe("beautiful-chat calculator fixture routing", () => {
-  it("discovers all 18 integration _from-feature-parity.json files", () => {
+  it("discovers all 19 integration _from-feature-parity.json files", () => {
     expect(
       integrations.map((i) => i.slug),
       "integration count changed — new integration added? mirror its " +
         "calculator fixtures from langgraph-python and update this pin",
-    ).toHaveLength(18);
+    ).toHaveLength(19);
   });
 
   for (const { slug, file } of integrations) {


### PR DESCRIPTION
## Summary

Fix-forward for the RED `Showcase: Validate` on `main` introduced by #5569 (MS Agent Harness (.NET) full column).

`showcase/scripts/__tests__/calculator-fixture-routing.test.ts` hard-pins the count of discovered `_from-feature-parity.json` integration fixtures. #5569 legitimately added the 19th integration (`ms-agent-harness-dotnet`) and its calculator fixtures are already mirrored in `showcase/aimock/d6/ms-agent-harness-dotnet/_from-feature-parity.json`. The test's own failure message prescribes the fix: bump the pin.

## Changes

- Bump the discovered-integration pin from 18 → 19 (test name + `toHaveLength`).
- Update the explanatory comment counts (16/18 → 17/19) to match the new integration set. The two pill-less integrations (built-in-agent, claude-sdk-python) are unchanged; `ms-agent-harness-dotnet` carries the full calculator pill, so it joins the 17 with a real pill.

No source/behavior change — pin reflects reality (the harness fixture file exists and passes all per-integration routing/ordering assertions).

## Red → Green proof

RED (original pin=18, glob discovers 19):
```
 FAIL  __tests__/calculator-fixture-routing.test.ts > beautiful-chat calculator fixture routing > discovers all 18 integration _from-feature-parity.json files
AssertionError: integration count changed — new integration added? mirror its calculator fixtures from langgraph-python and update this pin: expected [ 'ag2', 'agno', …(17) ] to have a length of 18 but got 19
- 18
+ 19
 Test Files  1 failed (1)
      Tests  1 failed | 57 skipped (58)
```

GREEN (after pin=19, full file):
```
 Test Files  1 passed (1)
      Tests  58 passed (58)
```

(58 = 19 integrations × 3 per-integration tests + the discovery/pin test.)