### PR TITLE
fix(showcase): provision prod digest-pinned + image-drift prod-neutral

### DIFF
--- a/showcase/harness/src/probes/drivers/image-drift.test.ts
+++ b/showcase/harness/src/probes/drivers/image-drift.test.ts
@@ -3,11 +3,10 @@ import { imageDriftDriver } from "./image-drift.js";
 import { logger } from "../../logger.js";
 import type { Logger, ProbeContext } from "../../types/index.js";
 
-// Driver-level tests — the per-service digest comparison matrix lives on
-// the legacy `imageDriftProbe` in ../image-drift.test.ts. This file covers
-// the driver adapter: single-service invocation, GHCR manifest fetch, and
-// the {stale, fresh, 404, auth-fail, transport-fail} matrix each as its
-// own ProbeResult.
+// Driver-level tests for `imageDriftDriver`. This file covers the driver
+// adapter: single-service invocation, GHCR manifest fetch, and the
+// {stale, fresh, 404, auth-fail, transport-fail} matrix each as its own
+// ProbeResult.
 
 function captureLogger(): {
   logger: Logger;
@@ -447,6 +446,145 @@ describe("imageDriftDriver", () => {
     expect(urls[0]).toContain("/showcase-a/manifests/stable");
   });
 
+  // -- Pinned-prod neutrality (fix B2) --------------------------------------
+  //
+  // Prod is INTENTIONALLY pinned behind `:latest` under the pinned-prod /
+  // floating-staging contract. The image-drift probe compares each deployed
+  // digest vs current GHCR `:latest`, so on the production-deployed harness
+  // every service shows "behind :latest" — which is expected, not a defect.
+  // When the deploy environment resolves to production, a digest mismatch
+  // against `:latest` must render GREEN with a `pinnedExpected: true` flag
+  // rather than flipping the service red. Staging behaviour is unchanged.
+  describe("pinned-prod neutrality (fix B2)", () => {
+    function makeCtxEnv(
+      fetchImpl: typeof fetch,
+      env: Record<string, string | undefined>,
+    ): ProbeContext & { fetchImpl: typeof fetch } {
+      return {
+        now: () => new Date("2026-04-20T00:00:00Z"),
+        logger,
+        env,
+        fetchImpl,
+      } as ProbeContext & { fetchImpl: typeof fetch };
+    }
+
+    function staleFetch(): typeof fetch {
+      return scriptedFetch([
+        {
+          status: 200,
+          body: {},
+          headers: { "docker-content-digest": LATEST_DIGEST },
+        },
+      ]).fetchImpl;
+    }
+
+    it("renders green+pinnedExpected when prod (RAILWAY_ENVIRONMENT_NAME) is behind :latest", async () => {
+      const ctx = makeCtxEnv(staleFetch(), {
+        RAILWAY_ENVIRONMENT_NAME: "production",
+      });
+      const r = await imageDriftDriver.run(ctx, {
+        key: "image_drift:showcase-a",
+        name: "showcase-a",
+        imageRef: "ghcr.io/copilotkit/showcase-a:latest",
+        deployedDigest: CURRENT_DIGEST,
+      });
+      // Drift IS detected (currentImage != expectedImage) but prod is
+      // pinned by design, so this is neutral-green, not red.
+      expect(r.state).toBe("green");
+      if ("errorDesc" in r.signal) {
+        throw new Error("expected success-variant signal");
+      }
+      expect(r.signal.isStale).toBe(true);
+      expect(r.signal.pinnedExpected).toBe(true);
+      expect(r.signal.currentImage).toBe(CURRENT_DIGEST);
+      expect(r.signal.expectedImage).toBe(LATEST_DIGEST);
+    });
+
+    it("honours SHOWCASE_ENV=production override", async () => {
+      const ctx = makeCtxEnv(staleFetch(), { SHOWCASE_ENV: "production" });
+      const r = await imageDriftDriver.run(ctx, {
+        key: "image_drift:showcase-a",
+        name: "showcase-a",
+        imageRef: "ghcr.io/copilotkit/showcase-a:latest",
+        deployedDigest: CURRENT_DIGEST,
+      });
+      expect(r.state).toBe("green");
+      if ("errorDesc" in r.signal) {
+        throw new Error("expected success-variant signal");
+      }
+      expect(r.signal.pinnedExpected).toBe(true);
+    });
+
+    it("still flips red on staging drift (env behaviour unchanged)", async () => {
+      const ctx = makeCtxEnv(staleFetch(), {
+        RAILWAY_ENVIRONMENT_NAME: "staging",
+      });
+      const r = await imageDriftDriver.run(ctx, {
+        key: "image_drift:showcase-a",
+        name: "showcase-a",
+        imageRef: "ghcr.io/copilotkit/showcase-a:latest",
+        deployedDigest: CURRENT_DIGEST,
+      });
+      expect(r.state).toBe("red");
+      if ("errorDesc" in r.signal) {
+        throw new Error("expected success-variant signal");
+      }
+      expect(r.signal.isStale).toBe(true);
+      expect(r.signal.pinnedExpected).toBeUndefined();
+    });
+
+    it("still flips red on drift when env is unset (no env name → not prod)", async () => {
+      const ctx = makeCtxEnv(staleFetch(), {});
+      const r = await imageDriftDriver.run(ctx, {
+        key: "image_drift:showcase-a",
+        name: "showcase-a",
+        imageRef: "ghcr.io/copilotkit/showcase-a:latest",
+        deployedDigest: CURRENT_DIGEST,
+      });
+      expect(r.state).toBe("red");
+    });
+
+    it("does NOT neutralize a genuine missing-digest fault in prod", async () => {
+      // currentImage="" is a deploy fault (no digest pinned), NOT
+      // "pinned behind :latest" — keep it red even in prod so a broken
+      // deploy still surfaces.
+      const ctx = makeCtxEnv(staleFetch(), {
+        RAILWAY_ENVIRONMENT_NAME: "production",
+      });
+      const r = await imageDriftDriver.run(ctx, {
+        key: "image_drift:showcase-a",
+        name: "showcase-a",
+        imageRef: "ghcr.io/copilotkit/showcase-a:latest",
+        // no deployedDigest → currentImage stays ""
+      });
+      expect(r.state).toBe("red");
+      if ("errorDesc" in r.signal) {
+        throw new Error("expected success-variant signal");
+      }
+      expect(r.signal.pinnedExpected).toBeUndefined();
+    });
+
+    it("stays green (no pinnedExpected) in prod when prod IS serving :latest", async () => {
+      // Prod happens to match :latest → ordinary green, and we don't
+      // stamp pinnedExpected because there's no drift to excuse.
+      const ctx = makeCtxEnv(staleFetch(), {
+        RAILWAY_ENVIRONMENT_NAME: "production",
+      });
+      const r = await imageDriftDriver.run(ctx, {
+        key: "image_drift:showcase-a",
+        name: "showcase-a",
+        imageRef: "ghcr.io/copilotkit/showcase-a:latest",
+        deployedDigest: LATEST_DIGEST,
+      });
+      expect(r.state).toBe("green");
+      if ("errorDesc" in r.signal) {
+        throw new Error("expected success-variant signal");
+      }
+      expect(r.signal.isStale).toBe(false);
+      expect(r.signal.pinnedExpected).toBeUndefined();
+    });
+  });
+
   it("threads ctx.abortSignal into the GHCR fetch so invoker timeout aborts in-flight", async () => {
     // Regression guard for CR A1: previously the driver called fetchImpl
     // without forwarding the invoker's AbortController signal, so a hung
@@ -479,7 +617,7 @@ describe("imageDriftDriver", () => {
     await imageDriftDriver.run(ctx, {
       key: "image_drift:showcase-a",
       name: "showcase-a",
-      imageRef: `ghcr.io/copilotkit/showcase-a:latest@${CURRENT_DIGEST}`,
+      imageRef: `ghcr.io/copilotkit/showcase-a@${CURRENT_DIGEST}`,
     });
     expect(capturedSignal).toBe(controller.signal);
     expect(capturedSignal?.aborted).toBe(false);
@@ -490,7 +628,7 @@ describe("imageDriftDriver", () => {
     const result = await imageDriftDriver.run(ctx, {
       key: "image_drift:showcase-a",
       name: "showcase-a",
-      imageRef: `ghcr.io/copilotkit/showcase-a:latest@${CURRENT_DIGEST}`,
+      imageRef: `ghcr.io/copilotkit/showcase-a@${CURRENT_DIGEST}`,
     });
     expect(result.state).toBe("error");
     expect((result.signal as { errorDesc: string }).errorDesc).toMatch(

--- a/showcase/harness/src/probes/drivers/image-drift.ts
+++ b/showcase/harness/src/probes/drivers/image-drift.ts
@@ -78,6 +78,18 @@ export type ImageDriftDriverSignal =
        */
       isStale: boolean;
       /**
+       * Set `true` only when the deploy environment is production AND the
+       * service is stale-behind-`:latest` (a real digest mismatch). Under
+       * the pinned-prod / floating-staging contract, prod is INTENTIONALLY
+       * pinned behind `:latest`, so "behind :latest" is expected — not a
+       * defect. When set, the driver renders the result GREEN (neutral)
+       * instead of red, and the flag records WHY the drift was excused.
+       * Absent on staging, on any non-production deploy, on fresh prod
+       * (no drift to excuse), and on genuine faults (missing digest, GHCR
+       * error) which must stay red even in prod.
+       */
+      pinnedExpected?: true;
+      /**
        * Populated only when the GHCR lookup succeeded but the deploy's
        * own `imageRef` lacked a digest — surfaces "no digest pinned on
        * the deploy" without collapsing into the error variant (the
@@ -156,19 +168,46 @@ export const imageDriftDriver: ProbeDriver<
     }
 
     const isStale = currentImage !== "" && currentImage !== expectedImage;
+    // Pinned-prod neutrality: under the pinned-prod / floating-staging
+    // contract, prod is INTENTIONALLY pinned behind `:latest`, so a digest
+    // mismatch against `:latest` is expected on the production-deployed
+    // harness — not a defect. When the deploy env is production AND the
+    // drift is a genuine stale-behind (`isStale`, i.e. both digests
+    // resolved but differ), render GREEN with `pinnedExpected: true`
+    // rather than red. A missing-digest fault (`currentImage === ""`) is
+    // NOT excused — that's a broken deploy, not a pin, so it stays red
+    // even in prod. Staging and unset-env deploys keep the original
+    // red-on-drift behaviour.
+    const pinnedExpected = isStale && isProductionEnv(ctx.env);
     return {
       key: input.key,
-      state: isStale || currentImage === "" ? "red" : "green",
+      state:
+        (isStale && !pinnedExpected) || currentImage === "" ? "red" : "green",
       signal: {
         service: input.name,
         currentImage,
         expectedImage,
         isStale,
+        ...(pinnedExpected ? { pinnedExpected: true as const } : {}),
       },
       observedAt,
     };
   },
 };
+
+/**
+ * Resolve whether the harness deploy environment is production. Mirrors
+ * the orchestrator's `sourceEnv` resolution (`SHOWCASE_ENV` override,
+ * then Railway's injected `RAILWAY_ENVIRONMENT_NAME`) so the driver's
+ * "is this prod?" answer matches the label the alert engine already
+ * stamps on every Slack payload. Case-insensitive exact match on
+ * "production" — "staging", "unknown", and unset all return false, so
+ * the neutralization only ever fires on a genuine prod deploy.
+ */
+function isProductionEnv(env: ProbeContext["env"]): boolean {
+  const name = env.SHOWCASE_ENV ?? env.RAILWAY_ENVIRONMENT_NAME;
+  return typeof name === "string" && name.trim().toLowerCase() === "production";
+}
 
 // Helpers -------------------------------------------------------------------
 

--- a/showcase/scripts/__tests__/deploy-to-railway.digest-pin.test.ts
+++ b/showcase/scripts/__tests__/deploy-to-railway.digest-pin.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for the prod digest-pinning logic in `deploy-to-railway.ts`.
+ *
+ * Contract under test: a freshly provisioned PROD showcase service must be
+ * born pinned to a content digest (`ghcr.io/copilotkit/showcase-<slug>@sha256:...`),
+ * NEVER the mutable `:latest` tag. Staging floats `:latest` by design and is
+ * provisioned by a different script — not exercised here.
+ *
+ * Style note (mirrors provision-starter-fleet / redeploy-env tests): GHCR is
+ * the only impure surface and is dependency-injected as a `GhcrHttp`. We use a
+ * plain recording mock — GHCR is an external registry boundary, not an LLM, so
+ * aimock does not apply. No real network I/O.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  assertProdDigestPinned,
+  buildProdImageRef,
+  ProdPinError,
+  resolveGhcrDigest,
+} from "../deploy-to-railway";
+import type {
+  GhcrHttp,
+  GhcrHttpResponse,
+  ProdInstanceQueryFn,
+} from "../deploy-to-railway";
+
+const DIGEST = "sha256:" + "a".repeat(64);
+
+/**
+ * Build a GhcrHttp mock. `manifestStatus` controls the HEAD on
+ * /manifests/<tag>; `digestHeader` controls the Docker-Content-Digest header
+ * returned on a 2xx. The /token GET always succeeds with a dummy bearer
+ * unless `tokenStatus` overrides it.
+ */
+function makeGhcrHttp(opts: {
+  manifestStatus?: number;
+  digestHeader?: string | null;
+  tokenStatus?: number;
+}): { http: GhcrHttp; calls: { method: string; url: string }[] } {
+  const calls: { method: string; url: string }[] = [];
+  const http: GhcrHttp = {
+    async get(url): Promise<GhcrHttpResponse> {
+      calls.push({ method: "GET", url });
+      const status = opts.tokenStatus ?? 200;
+      return {
+        status,
+        headers: {},
+        body: status < 400 ? JSON.stringify({ token: "dummy-bearer" }) : "",
+      };
+    },
+    async head(url): Promise<GhcrHttpResponse> {
+      calls.push({ method: "HEAD", url });
+      const status = opts.manifestStatus ?? 200;
+      const headers: Record<string, string> = {};
+      const dh = opts.digestHeader === undefined ? DIGEST : opts.digestHeader;
+      if (status < 400 && dh) headers["docker-content-digest"] = dh;
+      return { status, headers, body: "" };
+    },
+  };
+  return { http, calls };
+}
+
+describe("resolveGhcrDigest", () => {
+  it("resolves :latest to its content digest via a manifest HEAD", async () => {
+    const { http, calls } = makeGhcrHttp({});
+    const digest = await resolveGhcrDigest(
+      "showcase-mastra",
+      "latest",
+      http,
+      "pat",
+    );
+    expect(digest).toBe(DIGEST);
+    // Mirrors the Ruby CLI: a /token exchange GET precedes the manifest HEAD.
+    expect(calls[0]).toMatchObject({ method: "GET" });
+    expect(calls[0].url).toContain("/token");
+    expect(calls[1]).toMatchObject({ method: "HEAD" });
+    expect(calls[1].url).toContain(
+      "/v2/copilotkit/showcase-mastra/manifests/latest",
+    );
+  });
+
+  it("throws (fail-loud) when the tag does not exist (404) — no fallback", async () => {
+    const { http } = makeGhcrHttp({ manifestStatus: 404 });
+    await expect(
+      resolveGhcrDigest("showcase-mastra", "latest", http, "pat"),
+    ).rejects.toThrow(/404/);
+  });
+
+  it("throws when GHCR returns a 2xx but no Docker-Content-Digest header", async () => {
+    const { http } = makeGhcrHttp({ digestHeader: null });
+    await expect(
+      resolveGhcrDigest("showcase-mastra", "latest", http, "pat"),
+    ).rejects.toThrow(/Docker-Content-Digest/);
+  });
+
+  it("throws when a supplied token fails the /token exchange (no silent anon downgrade)", async () => {
+    const { http } = makeGhcrHttp({ tokenStatus: 403 });
+    await expect(
+      resolveGhcrDigest("showcase-mastra", "latest", http, "pat"),
+    ).rejects.toThrow(/token exchange failed/);
+  });
+});
+
+describe("buildProdImageRef", () => {
+  it("produces a digest-pinned prod image ref (@sha256:...), NOT the :latest tag", async () => {
+    const ref = await buildProdImageRef("mastra", async () => DIGEST);
+    // The core contract: prod is born pinned, never tracking the mutable tag.
+    expect(ref).toBe(`ghcr.io/copilotkit/showcase-mastra@${DIGEST}`);
+    expect(ref).toMatch(/@sha256:[0-9a-f]{64}$/);
+    expect(ref).not.toContain(":latest");
+  });
+
+  it("fails loud when digest resolution rejects — does NOT fall back to :latest", async () => {
+    await expect(
+      buildProdImageRef("mastra", async () => {
+        throw new Error("GHCR manifest HEAD 404");
+      }),
+    ).rejects.toThrow(/404/);
+  });
+
+  it("rejects a malformed digest rather than pinning prod to it", async () => {
+    await expect(
+      buildProdImageRef("mastra", async () => "sha256:not-a-real-digest"),
+    ).rejects.toThrow(/malformed digest/);
+  });
+
+  it("end-to-end through resolveGhcrDigest yields a pinned ref, never the tag", async () => {
+    const { http } = makeGhcrHttp({});
+    const ref = await buildProdImageRef("mastra", (name) =>
+      resolveGhcrDigest(name, "latest", http, "pat"),
+    );
+    expect(ref).toBe(`ghcr.io/copilotkit/showcase-mastra@${DIGEST}`);
+    expect(ref).not.toContain(":latest");
+  });
+});
+
+/**
+ * Build a fake `ProdInstanceQueryFn` that returns a single showcase service
+ * whose PROD serviceInstance carries `image` as its `source.image`. `image:
+ * null` simulates a service with no configured image source. `serviceName`
+ * and `envId` default to a matching service in the production env so the
+ * tests exercise the digest-shape branch rather than the lookup branches.
+ * `envId` is the `environmentId` the fake serviceInstance is reported under;
+ * supply a value that differs from the env `assertProdDigestPinned` is asked
+ * to verify (its 2nd arg) to drive the env-mismatch lookup branch.
+ */
+function makeProdInstanceQuery(opts: {
+  image: string | null;
+  serviceName?: string;
+  envId?: string;
+}): ProdInstanceQueryFn {
+  const serviceName = opts.serviceName ?? "showcase-mastra";
+  const instanceEnv = opts.envId ?? "prod-env";
+  return async () => ({
+    project: {
+      services: {
+        edges: [
+          {
+            node: {
+              name: serviceName,
+              serviceInstances: {
+                edges: [
+                  {
+                    node: {
+                      environmentId: instanceEnv,
+                      source:
+                        opts.image === null ? null : { image: opts.image },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    },
+  });
+}
+
+describe("assertProdDigestPinned", () => {
+  const PINNED = `ghcr.io/copilotkit/showcase-mastra@${DIGEST}`;
+
+  it("ACCEPTS a valid ghcr.io/copilotkit/<name>@sha256:<64hex> ref", async () => {
+    const query = makeProdInstanceQuery({ image: PINNED });
+    await expect(
+      assertProdDigestPinned("showcase-mastra", "prod-env", query),
+    ).resolves.toBeUndefined();
+  });
+
+  it("REJECTS a :latest tag ref (mutable, unpinned)", async () => {
+    const query = makeProdInstanceQuery({
+      image: "ghcr.io/copilotkit/showcase-mastra:latest",
+    });
+    await expect(
+      assertProdDigestPinned("showcase-mastra", "prod-env", query),
+    ).rejects.toBeInstanceOf(ProdPinError);
+    await expect(
+      assertProdDigestPinned("showcase-mastra", "prod-env", query),
+    ).rejects.toThrow(/not digest-pinned/);
+  });
+
+  it("REJECTS an empty/missing source.image", async () => {
+    const query = makeProdInstanceQuery({ image: null });
+    await expect(
+      assertProdDigestPinned("showcase-mastra", "prod-env", query),
+    ).rejects.toBeInstanceOf(ProdPinError);
+    await expect(
+      assertProdDigestPinned("showcase-mastra", "prod-env", query),
+    ).rejects.toThrow(/no production image source/);
+  });
+
+  it("REJECTS an empty-string source.image", async () => {
+    const query = makeProdInstanceQuery({ image: "" });
+    await expect(
+      assertProdDigestPinned("showcase-mastra", "prod-env", query),
+    ).rejects.toBeInstanceOf(ProdPinError);
+    await expect(
+      assertProdDigestPinned("showcase-mastra", "prod-env", query),
+    ).rejects.toThrow(/no production image source/);
+  });
+
+  it("REJECTS when the service is not found in the project", async () => {
+    const query = makeProdInstanceQuery({
+      image: PINNED,
+      serviceName: "showcase-other",
+    });
+    await expect(
+      assertProdDigestPinned("showcase-mastra", "prod-env", query),
+    ).rejects.toBeInstanceOf(ProdPinError);
+    await expect(
+      assertProdDigestPinned("showcase-mastra", "prod-env", query),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it("REJECTS when the service exists but its instance is in a different env", async () => {
+    // Service IS found, but its only serviceInstance is reported under
+    // `other-env` while the caller asks to verify `prod-env`. The env-match
+    // `.find(...)` returns undefined, so no image resolves and the guard throws.
+    const query = makeProdInstanceQuery({ image: PINNED, envId: "other-env" });
+    await expect(
+      assertProdDigestPinned("showcase-mastra", "prod-env", query),
+    ).rejects.toBeInstanceOf(ProdPinError);
+    await expect(
+      assertProdDigestPinned("showcase-mastra", "prod-env", query),
+    ).rejects.toThrow(/no production image source/);
+  });
+});

--- a/showcase/scripts/deploy-to-railway.ts
+++ b/showcase/scripts/deploy-to-railway.ts
@@ -61,6 +61,195 @@ function getToken(): string {
   }
 }
 
+// ── GHCR digest resolution ─────────────────────────────────────────────
+//
+// Prod services must be born PINNED to a content-addressable digest
+// (`@sha256:...`), never the mutable `:latest` tag — otherwise a freshly
+// provisioned prod service silently tracks `:latest` until a later
+// `bin/railway promote` re-pins it, and in that window a regressed
+// `:latest` flows straight into prod. This mirrors the Ruby promote CLI
+// (`showcase/bin/railway`, class GHCR) so the two stay behaviorally
+// identical.
+//
+// GHCR exposes the OCI Distribution Spec at
+//   https://ghcr.io/v2/<org>/<image>/manifests/<tag>
+// but its manifest endpoint REJECTS a raw GitHub/Actions token sent as
+// `Authorization: Bearer <token>` with HTTP 403 — the token must first be
+// exchanged for a short-lived registry bearer via the /token endpoint. So
+// we ALWAYS hit /token, even when a token is present.
+
+const GHCR_ORG = "copilotkit";
+const GHCR_ACCEPT_MANIFEST = [
+  "application/vnd.oci.image.index.v1+json",
+  "application/vnd.oci.image.manifest.v1+json",
+  "application/vnd.docker.distribution.manifest.list.v2+json",
+  "application/vnd.docker.distribution.manifest.v2+json",
+].join(", ");
+
+/**
+ * Minimal HTTP response shape — only the bits the resolver reads. Injected
+ * so the resolver core is unit-testable without real network I/O.
+ */
+export interface GhcrHttpResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+export interface GhcrHttp {
+  get(url: string, headers: Record<string, string>): Promise<GhcrHttpResponse>;
+  head(url: string, headers: Record<string, string>): Promise<GhcrHttpResponse>;
+}
+
+/**
+ * GHCR bearer (PAT) for manifest reads. Distinct from the Railway token.
+ * Order mirrors the Ruby CLI:
+ *   1. GHCR_TOKEN   — explicit PAT (local dev or CI override).
+ *   2. GITHUB_TOKEN — GitHub Actions automatic token (needs packages:read).
+ * Returns undefined when neither is set (public-package anonymous reads
+ * still succeed via the /token exchange).
+ */
+export function ghcrPat(): string | undefined {
+  const t = (process.env.GHCR_TOKEN || process.env.GITHUB_TOKEN || "").trim();
+  return t || undefined;
+}
+
+/** Flatten a fetch Headers into a plain record keyed BOTH as-sent and
+ * lower-cased, so callers can read `Docker-Content-Digest` case-insensitively
+ * (mirrors the Ruby CLI's dual-keying). */
+function headersToRecord(h: Headers): Record<string, string> {
+  const out: Record<string, string> = {};
+  h.forEach((value, key) => {
+    out[key] = value;
+    out[key.toLowerCase()] = value;
+  });
+  return out;
+}
+
+const realGhcrHttp: GhcrHttp = {
+  async get(url, headers) {
+    const res = await fetch(url, { method: "GET", headers });
+    return {
+      status: res.status,
+      headers: headersToRecord(res.headers),
+      body: await res.text(),
+    };
+  },
+  async head(url, headers) {
+    const res = await fetch(url, { method: "HEAD", headers });
+    return {
+      status: res.status,
+      headers: headersToRecord(res.headers),
+      body: "",
+    };
+  },
+};
+
+/**
+ * Mint the short-lived registry bearer via GHCR's /token exchange. When a
+ * PAT is present we authenticate the exchange with Basic auth
+ * (base64("x-access-token:<pat>")). Throws if a PAT was supplied but the
+ * exchange failed — the caller must NOT silently downgrade to anonymous
+ * (that conflates "no token" with "supplied token failed"). Returns
+ * undefined only when NO PAT was supplied and the package is not
+ * anonymously pullable.
+ */
+async function ghcrBearerFor(
+  name: string,
+  pat: string | undefined,
+  http: GhcrHttp,
+): Promise<string | undefined> {
+  const url = `https://ghcr.io/token?service=ghcr.io&scope=repository:${GHCR_ORG}/${name}:pull`;
+  const headers: Record<string, string> = {};
+  if (pat) {
+    headers.Authorization =
+      "Basic " + Buffer.from(`x-access-token:${pat}`).toString("base64");
+  }
+  const resp = await http.get(url, headers);
+  if (resp.status >= 400) {
+    if (pat) {
+      throw new Error(
+        `GHCR /token exchange failed (${resp.status}) for ${GHCR_ORG}/${name}`,
+      );
+    }
+    return undefined;
+  }
+  let parsed: { token?: string };
+  try {
+    parsed = JSON.parse(resp.body) as { token?: string };
+  } catch (e) {
+    throw new Error(
+      `GHCR /token returned unparseable body for ${GHCR_ORG}/${name}: ${(e as Error).message}`,
+      { cause: e },
+    );
+  }
+  return parsed.token;
+}
+
+/**
+ * Resolve `ghcr.io/copilotkit/<name>:<tag>` to its content digest
+ * (`sha256:...`). Fail-loud: throws on a 404 (the tag does not exist),
+ * on any other >=400, and on a missing Docker-Content-Digest header.
+ * NEVER returns the bare tag as a fallback — that would reintroduce the
+ * mutable-:latest-in-prod bug.
+ */
+export async function resolveGhcrDigest(
+  name: string,
+  tag = "latest",
+  http: GhcrHttp = realGhcrHttp,
+  pat: string | undefined = ghcrPat(),
+): Promise<string> {
+  const bearer = await ghcrBearerFor(name, pat, http);
+  const url = `https://ghcr.io/v2/${GHCR_ORG}/${name}/manifests/${tag}`;
+  const headers: Record<string, string> = { Accept: GHCR_ACCEPT_MANIFEST };
+  if (bearer) headers.Authorization = `Bearer ${bearer}`;
+
+  const resp = await http.head(url, headers);
+  if (resp.status === 404) {
+    throw new Error(
+      `GHCR manifest HEAD 404 for ghcr.io/${GHCR_ORG}/${name}:${tag} — the image tag does not exist; cannot pin prod to a digest. Build & push the image first.`,
+    );
+  }
+  if (resp.status >= 400) {
+    throw new Error(
+      `GHCR manifest HEAD ${resp.status} for ghcr.io/${GHCR_ORG}/${name}:${tag}`,
+    );
+  }
+  const digest =
+    resp.headers["docker-content-digest"] ||
+    resp.headers["Docker-Content-Digest"];
+  if (!digest) {
+    throw new Error(
+      `GHCR did not return Docker-Content-Digest for ghcr.io/${GHCR_ORG}/${name}:${tag}`,
+    );
+  }
+  return digest;
+}
+
+/**
+ * Build the digest-pinned PROD image ref for a slug. Resolves the current
+ * `:latest` digest for `showcase-<slug>` and returns
+ * `ghcr.io/copilotkit/showcase-<slug>@sha256:<digest>`. Fail-loud: any
+ * resolution failure propagates — prod is NEVER born on the bare tag.
+ * Exported for unit testing against an injected resolver.
+ */
+export async function buildProdImageRef(
+  slug: string,
+  resolve: (name: string) => Promise<string> = (name) =>
+    resolveGhcrDigest(name),
+): Promise<string> {
+  const repoName = `showcase-${slug}`;
+  const digest = await resolve(repoName);
+  if (!/^sha256:[0-9a-f]{64}$/.test(digest)) {
+    throw new Error(
+      `GHCR returned a malformed digest for ${repoName}: ${JSON.stringify(
+        digest,
+      )} — refusing to pin prod to a non-canonical digest.`,
+    );
+  }
+  return `ghcr.io/${GHCR_ORG}/${repoName}@${digest}`;
+}
+
 async function railwayGql<T = unknown>(
   query: string,
   variables: Record<string, unknown> = {},
@@ -163,7 +352,6 @@ async function createService(slug: string): Promise<void> {
   }
 
   const serviceName = `showcase-${slug}`;
-  const imagePath = `ghcr.io/copilotkit/showcase-${slug}:latest`;
 
   // Check if already exists
   const existing = await findService(serviceName);
@@ -175,8 +363,35 @@ async function createService(slug: string): Promise<void> {
     return;
   }
 
+  // This script provisions into the PRODUCTION environment
+  // (SHOWCASE.environmentId === PRODUCTION_ENV_ID). The showcase contract is
+  // "prod is PINNED to a digest; staging floats :latest." So resolve the
+  // GHCR digest NOW and pin the source image — a prod service must be born
+  // digest-pinned, never tracking the mutable `:latest` tag. Fail-loud: if
+  // the digest can't be resolved, abort rather than silently provisioning
+  // prod on `:latest` (the regression class that broke ms-agent-dotnet).
+  // Staging provisioning lives elsewhere (provision-starter-fleet.ts) and is
+  // intentionally NOT changed — staging floats by design.
+  let imagePath: string;
+  try {
+    imagePath = await buildProdImageRef(slug);
+  } catch (e) {
+    console.error(
+      `Failed to resolve a GHCR digest for showcase-${slug}: ${(e as Error).message}`,
+    );
+    console.error(
+      "Prod services must be pinned to a content digest (@sha256:...), not the mutable :latest tag.",
+    );
+    console.error(
+      "Ensure the image has been built & pushed to ghcr.io/copilotkit/showcase-" +
+        slug +
+        ":latest, and that GHCR_TOKEN or GITHUB_TOKEN (packages:read) is set, then re-run.",
+    );
+    process.exit(1);
+  }
+
   console.log(`Creating Railway service: ${serviceName}`);
-  console.log(`  Image: ${imagePath}`);
+  console.log(`  Image (digest-pinned): ${imagePath}`);
 
   // 1. Create the service
   const createResult = await railwayGql<ServiceCreateResult>(
@@ -321,6 +536,116 @@ Done! Next steps:
 
 // ── Go live ────────────────────────────────────────────────────────────
 
+const PROD_DIGEST_SHAPE =
+  /^ghcr\.io\/copilotkit\/[a-z0-9-]+@sha256:[0-9a-f]{64}$/;
+
+interface ProdInstanceQuery {
+  project: {
+    services: {
+      edges: Array<{
+        node: {
+          name: string;
+          serviceInstances: {
+            edges: Array<{
+              node: {
+                environmentId: string;
+                source: { image: string | null } | null;
+              };
+            }>;
+          };
+        };
+      }>;
+    };
+  };
+}
+
+/**
+ * Injectable Railway query for the prod serviceInstance image. Mirrors the
+ * `GhcrHttp` DI seam above: production passes the real `railwayGql`-backed
+ * implementation, tests pass a fake returning a canned `ProdInstanceQuery`.
+ * `projectId` is the Railway project to look the service up in.
+ */
+export type ProdInstanceQueryFn = (
+  projectId: string,
+) => Promise<ProdInstanceQuery>;
+
+/** Default prod-instance query: hits Railway via the module-level gql client. */
+const realProdInstanceQuery: ProdInstanceQueryFn = (projectId) =>
+  railwayGql<ProdInstanceQuery>(
+    `query project($id: String!) {
+            project(id: $id) {
+                services {
+                    edges {
+                        node {
+                            name
+                            serviceInstances {
+                                edges { node { environmentId source { image } } }
+                            }
+                        }
+                    }
+                }
+            }
+        }`,
+    { id: projectId },
+  );
+
+/**
+ * Typed error thrown by `assertProdDigestPinned` when the prod image is
+ * missing, unconfigured, or not digest-pinned. The CLI call site (`goLive`)
+ * maps this onto the exit-1 contract — the guard itself stays
+ * process.exit-free so it is unit-testable (mirrors `resolveRailwayToken` /
+ * `getToken`, where exit mapping lives at the call site, not in the core).
+ */
+export class ProdPinError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProdPinError";
+  }
+}
+
+/**
+ * Fail-loud guard: assert the PROD serviceInstance for `serviceName` has a
+ * digest-pinned `source.image` (`@sha256:...`). THROWS a `ProdPinError` if
+ * the service/instance is missing, has no image, or is still on the mutable
+ * `:latest` tag — production behavior (exit 1) is preserved by the caller,
+ * which catches and maps. Railway I/O is injected via `query` so the guard
+ * is unit-testable without network access (mirrors the `GhcrHttp` seam).
+ */
+export async function assertProdDigestPinned(
+  serviceName: string,
+  environmentId: string = SHOWCASE.environmentId,
+  query: ProdInstanceQueryFn = realProdInstanceQuery,
+  projectId: string = SHOWCASE.projectId,
+): Promise<void> {
+  const data = await query(projectId);
+
+  const svc = data.project.services.edges.find(
+    (e) => e.node.name === serviceName,
+  );
+  if (!svc) {
+    throw new ProdPinError(
+      `Cannot verify prod image pin: service ${serviceName} not found in project ${projectId}.`,
+    );
+  }
+  const instance = svc.node.serviceInstances.edges.find(
+    (e) => e.node.environmentId === environmentId,
+  );
+  const image = instance?.node.source?.image ?? null;
+  if (!image) {
+    throw new ProdPinError(
+      `Cannot go live: ${serviceName} has no production image source configured.`,
+    );
+  }
+  if (!PROD_DIGEST_SHAPE.test(image)) {
+    throw new ProdPinError(
+      `Refusing to go live: ${serviceName} prod image is not digest-pinned (got: ${image}).\n` +
+        "Prod must be pinned to ghcr.io/copilotkit/<repo>@sha256:<digest>, not the mutable :latest tag.\n" +
+        `Run \`bin/railway promote ${serviceName.replace(/^showcase-/, "")}\` (or re-provision) to digest-pin prod, then retry --go-live.`,
+    );
+  }
+  console.log(`  Prod image is digest-pinned: ${image}`);
+}
+
 async function goLive(slug: string): Promise<void> {
   const manifestPath = path.join(PACKAGES_DIR, slug, "manifest.yaml");
   if (!fs.existsSync(manifestPath)) {
@@ -334,6 +659,23 @@ async function goLive(slug: string): Promise<void> {
   if (!backendUrl) {
     console.error(`No backend_url in manifest.yaml for ${slug}`);
     process.exit(1);
+  }
+
+  // Guard: prod must be digest-pinned before it goes live. createService now
+  // pins at provisioning time, but a service created before this fix (or
+  // edited by hand) could still be tracking the mutable `:latest` tag.
+  // Going live on `:latest` is exactly the regression class this fix
+  // closes, so refuse it loudly rather than lighting up an unpinned prod.
+  // The guard throws a typed ProdPinError; map it onto the exit-1 contract
+  // HERE so the guard itself stays process.exit-free and unit-testable.
+  try {
+    await assertProdDigestPinned(`showcase-${slug}`);
+  } catch (e) {
+    if (e instanceof ProdPinError) {
+      console.error(e.message);
+      process.exit(1);
+    }
+    throw e;
   }
 
   // Health check


### PR DESCRIPTION
## Summary

Two follow-up fixes that complete the pinned-prod / floating-staging contract for the showcase fleet (the contract enforced by the promote CLI in #5566). Prod services must be digest-pinned (`@sha256`), staging floats `:latest`.

**Fix 1 — `showcase/scripts/deploy-to-railway.ts`: provision prod digest-pinned, not `:latest`.**
Prod services were being *born* on the mutable `:latest` tag, then later pinned only at promote time. Now they are born pinned to a resolved `@sha256` digest at create time, via a new TS GHCR resolver that mirrors the Ruby promote CLI (`/token` exchange → manifest HEAD → `Docker-Content-Digest`). Resolution failure is **fail-loud** (`process.exit(1)`, never a `:latest` fallback). `goLive` asserts the prod `source.image` is digest-pinned (`assertProdDigestPinned`, refactored to be dependency-injectable and to throw a typed `ProdPinError` instead of exiting inline).

**Fix 2 — `showcase/harness/.../image-drift.ts`: stop flagging pinned prod red.**
Under the pinned-prod contract, prod is intentionally digest-pinned behind `:latest`, so the image-drift probe was firing false-red on every prod service. It now renders such prod services **green** (`pinnedExpected`) while a genuinely missing digest stays **red**. Staging behaviour is unchanged.

## Verification

- **Red-green proven locally** for both new test surfaces:
  - `assertProdDigestPinned` guard: RED = 5 tests `assertProdDigestPinned is not a function` (untestable inline-exit) → GREEN = 13 passed after DI refactor; env-mismatch branch: RED = `promise resolved undefined instead of rejecting` → GREEN after wiring the test's env control.
- Suites: `deploy-to-railway.digest-pin.test.ts` **14 passed**; `image-drift.test.ts` **26 passed**. Typecheck (scripts + harness) 0 errors; oxfmt + oxlint clean; harness build green.
- **Empirical 6b against live prod** (settled two reviewer masking-concerns as can't-happen under current config):
  - prod harness `SHOWCASE_ENV` is *unset* (not `""`) and `RAILWAY_ENVIRONMENT_NAME="production"`, so `isProductionEnv()`'s `??` correctly resolves true → the prod-neutral fix **fires** in prod.
  - prod image-drift is discovery-only; all 19 prod `showcase-*` services are digest-pinned and tag-less, so `expectedTag` resolves to `latest` for every prod service → a fixed tag cannot reach prod image-drift (no false-green).

## Review

3-round cr-loop (7 agents/round) converged to zero actionable findings. One fix-introduced test-scaffolding defect (dead `envId` helper option) was caught in the confirmation round and fixed. Remaining reviewer notes are pre-existing issues in untouched goLive/probe code or theoretical-but-can't-happen-under-live-config items, tracked as follow-ups (not in scope for this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)