### PR TITLE
fix(runtime): support full tool lifecycle in BuiltInAgent TanStack factory mode

### DIFF
--- a/packages/runtime/src/agent/__tests__/converter-tanstack-input.test.ts
+++ b/packages/runtime/src/agent/__tests__/converter-tanstack-input.test.ts
@@ -130,6 +130,84 @@ describe("convertInputToTanStackAI", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Client tools (frontend-provided tools → TanStack client tools)
+  // -------------------------------------------------------------------------
+  describe("client tools", () => {
+    it("converts input.tools to TanStack client tools (no executor)", () => {
+      const params = {
+        type: "object" as const,
+        properties: { issues: { type: "array" as const } },
+        required: ["issues"],
+      };
+      const input = createDefaultInput({
+        tools: [
+          {
+            name: "issue_list",
+            description: "Render a list of issues",
+            parameters: params,
+          },
+        ],
+      });
+
+      const { tools } = convertInputToTanStackAI(input);
+
+      expect(tools).toHaveLength(1);
+      expect(tools[0]).toEqual({
+        __toolSide: "client",
+        name: "issue_list",
+        description: "Render a list of issues",
+        inputSchema: params,
+      });
+      // Client tools must NOT carry an executor — TanStack pauses and hands
+      // the call back to the AG-UI client instead of running it.
+      expect("execute" in tools[0]).toBe(false);
+    });
+
+    it("returns an empty tools array when input has no tools", () => {
+      const { tools } = convertInputToTanStackAI(createDefaultInput());
+      expect(tools).toEqual([]);
+    });
+
+    it("closes open objects (additionalProperties → false) for OpenAI compatibility", () => {
+      const input = createDefaultInput({
+        tools: [
+          {
+            name: "render_chart",
+            description: "Render a chart",
+            parameters: {
+              type: "object",
+              properties: {
+                // z.record(z.string(), z.any()) → additionalProperties: {}
+                options: { type: "object", additionalProperties: {} },
+                data: {
+                  type: "array",
+                  // .passthrough() → additionalProperties: true on items
+                  items: {
+                    type: "object",
+                    properties: { v: { type: "number" } },
+                    additionalProperties: true,
+                  },
+                },
+              },
+              additionalProperties: false,
+            },
+          },
+        ],
+      });
+
+      const { tools } = convertInputToTanStackAI(input);
+      const schema = tools[0].inputSchema as Record<string, any>;
+
+      expect(schema.properties.options.additionalProperties).toBe(false);
+      expect(schema.properties.data.items.additionalProperties).toBe(false);
+      // Nested defined properties are preserved.
+      expect(schema.properties.data.items.properties.v).toEqual({
+        type: "number",
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Context injection
   // -------------------------------------------------------------------------
   describe("context injection", () => {

--- a/packages/runtime/src/agent/__tests__/converter-tanstack.test.ts
+++ b/packages/runtime/src/agent/__tests__/converter-tanstack.test.ts
@@ -4,6 +4,7 @@ import {
   createAgent,
   createDefaultInput,
   collectEvents,
+  collectEventsIncludingErrors,
   expectLifecycleWrapped,
   expectEventSequence,
   eventField,
@@ -316,6 +317,99 @@ describe("TanStack AI converter (via Agent)", () => {
       expect(eventField<string>(textEvent, "delta")).toBe(largeDelta);
       expect(eventField<string>(textEvent, "delta").length).toBe(100_000);
     });
+  });
+});
+
+describe("TanStack AI converter — multi-turn agent loop", () => {
+  // chat() emits a RUN_STARTED / RUN_FINISHED pair PER model turn and executes
+  // server-side tools (MCP / provider tools) itself between turns. The run
+  // lifecycle is owned by the Agent wrapper, so per-turn markers must be
+  // dropped and every turn's content converted — a regression here truncated
+  // the run at the first tool turn, dropping the tool result and final answer.
+
+  it("does NOT truncate at a per-turn RUN_FINISHED — tool result + final text still convert", async () => {
+    const agent = createAgent("tanstack", [
+      // Turn 1: model emits a tool call, then the turn finishes.
+      tanstackToolCallStart("tc-1", "list_issues"),
+      tanstackToolCallArgs("tc-1", '{"team":"CPK"}'),
+      tanstackToolCallEnd("tc-1"),
+      { type: "RUN_FINISHED" },
+      // Between turns: chat() executes the MCP tool itself.
+      tanstackToolCallResult("tc-1", { issues: [] }),
+      // Turn 2: model produces the final answer.
+      { type: "RUN_STARTED" },
+      tanstackTextChunk("No open issues."),
+      { type: "RUN_FINISHED" },
+    ]);
+    const events = await collectEvents(agent.run(createDefaultInput()));
+
+    expectLifecycleWrapped(events);
+    expectEventSequence(events, [
+      EventType.RUN_STARTED,
+      EventType.TOOL_CALL_START,
+      EventType.TOOL_CALL_ARGS,
+      EventType.TOOL_CALL_END,
+      EventType.TOOL_CALL_RESULT,
+      EventType.TEXT_MESSAGE_CHUNK,
+      EventType.RUN_FINISHED,
+    ]);
+
+    // Exactly one RUN_FINISHED — the outer wrapper's, not TanStack's per-turn ones.
+    expect(
+      events.filter((e) => e.type === EventType.RUN_FINISHED),
+    ).toHaveLength(1);
+    // The final answer survived the per-turn RUN_FINISHED.
+    const textEvent = events.find(
+      (e) => e.type === EventType.TEXT_MESSAGE_CHUNK,
+    )!;
+    expect(eventField<string>(textEvent, "delta")).toBe("No open issues.");
+  });
+
+  it("de-duplicates a tool call re-announced after execution", async () => {
+    const agent = createAgent("tanstack", [
+      tanstackToolCallStart("tc-1", "search"),
+      tanstackToolCallEnd("tc-1"),
+      { type: "RUN_FINISHED" },
+      tanstackToolCallResult("tc-1", { ok: true }),
+      // chat() re-announces the same call when it re-prompts — must be dropped.
+      tanstackToolCallStart("tc-1", "search"),
+      tanstackToolCallArgs("tc-1", '{"q":"x"}'),
+      tanstackToolCallEnd("tc-1"),
+      { type: "RUN_STARTED" },
+      tanstackTextChunk("done"),
+    ]);
+    const events = await collectEvents(agent.run(createDefaultInput()));
+
+    expectLifecycleWrapped(events);
+    expectEventSequence(events, [
+      EventType.RUN_STARTED,
+      EventType.TOOL_CALL_START,
+      EventType.TOOL_CALL_END,
+      EventType.TOOL_CALL_RESULT,
+      EventType.TEXT_MESSAGE_CHUNK,
+      EventType.RUN_FINISHED,
+    ]);
+  });
+
+  it("surfaces a RUN_ERROR chunk as a terminal RUN_ERROR event", async () => {
+    const agent = createAgent("tanstack", [
+      tanstackTextChunk("partial"),
+      { type: "RUN_ERROR", message: "provider 400" },
+      // Anything after the error must never be converted.
+      tanstackTextChunk("should not appear"),
+    ]);
+    const { events, errored } = await collectEventsIncludingErrors(
+      agent.run(createDefaultInput()),
+    );
+
+    expect(errored).toBe(true);
+    const errorEvent = events.find((e) => e.type === EventType.RUN_ERROR)!;
+    expect(errorEvent).toBeDefined();
+    expect(eventField<string>(errorEvent, "message")).toBe("provider 400");
+    // The post-error text chunk was not emitted.
+    const texts = events.filter((e) => e.type === EventType.TEXT_MESSAGE_CHUNK);
+    expect(texts).toHaveLength(1);
+    expect(eventField<string>(texts[0], "delta")).toBe("partial");
   });
 });
 

--- a/packages/runtime/src/agent/converters/tanstack.ts
+++ b/packages/runtime/src/agent/converters/tanstack.ts
@@ -1,6 +1,5 @@
-import {
+import type {
   BaseEvent,
-  EventType,
   RunAgentInput,
   Message,
   TextMessageChunkEvent,
@@ -16,6 +15,7 @@ import {
   ReasoningMessageEndEvent,
   ReasoningEndEvent,
 } from "@ag-ui/client";
+import { EventType } from "@ag-ui/client";
 import { randomUUID } from "@copilotkit/shared";
 
 type ContentPartSource =
@@ -54,6 +54,24 @@ export interface TanStackChatMessage {
 }
 
 /**
+ * A TanStack AI client-side tool, derived from a frontend-provided AG-UI tool.
+ *
+ * Shaped to match `@tanstack/ai`'s `ClientTool` (`__toolSide: "client"`, no
+ * `execute`): the model may CALL it, but TanStack does not run it — it pauses
+ * the run and hands the call back to the AG-UI client (the CopilotKit frontend
+ * / bot) to execute, mirroring CopilotKit's client-tool round-trip. `chat()`
+ * accepts a JSON Schema directly as `inputSchema`, so the AG-UI tool's
+ * `parameters` pass through unchanged.
+ */
+export interface TanStackClientTool {
+  __toolSide: "client";
+  name: string;
+  description: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  inputSchema: any;
+}
+
+/**
  * Result of converting RunAgentInput to TanStack AI format.
  */
 export interface TanStackInputResult {
@@ -61,6 +79,14 @@ export interface TanStackInputResult {
   messages: TanStackChatMessage[];
   /** System prompts extracted from system/developer messages, context, and state */
   systemPrompts: string[];
+  /**
+   * Client-side tools derived from `input.tools` (the frontend-provided tools
+   * the CopilotKit client forwards on every run). Pass these into `chat()`
+   * alongside any server/provider tools so the model can call the frontend's
+   * generative-UI and human-in-the-loop tools; TanStack pauses the run on a
+   * client-tool call and the client executes it.
+   */
+  tools: TanStackClientTool[];
 }
 
 /**
@@ -153,6 +179,62 @@ function convertUserContent(
 }
 
 /**
+ * Recursively normalizes a frontend tool's JSON Schema so OpenAI accepts it as
+ * a function-tool schema.
+ *
+ * Frontend tools are often authored with permissive Zod (`z.any()`,
+ * `z.record(...)`, `.passthrough()`), which serialize to open objects —
+ * `additionalProperties: {}` (an empty sub-schema) or `additionalProperties:
+ * true`. OpenAI rejects both: strict mode requires `additionalProperties:
+ * false`, and an empty `{}` sub-schema fails base validation ("schema must
+ * have a 'type' key"). The classic (Vercel AI SDK) path sanitized these
+ * implicitly via a Zod round-trip; the TanStack path forwards the raw schema,
+ * so we close open objects here to match. (Models can't supply free-form extra
+ * keys either way — same as the classic path.)
+ */
+function sanitizeClientToolSchema(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    return schema.map(sanitizeClientToolSchema);
+  }
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+  const node: Record<string, unknown> = {
+    ...(schema as Record<string, unknown>),
+  };
+
+  // Any `additionalProperties` (empty `{}`, `true`, or a sub-schema) becomes
+  // `false` — the only form OpenAI accepts for strict function tools.
+  if ("additionalProperties" in node) {
+    node.additionalProperties = false;
+  }
+
+  if (node.properties && typeof node.properties === "object") {
+    const props: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(
+      node.properties as Record<string, unknown>,
+    )) {
+      props[key] = sanitizeClientToolSchema(value);
+    }
+    node.properties = props;
+  }
+
+  if ("items" in node) {
+    node.items = sanitizeClientToolSchema(node.items);
+  }
+
+  for (const combinator of ["anyOf", "allOf", "oneOf"] as const) {
+    if (Array.isArray(node[combinator])) {
+      node[combinator] = (node[combinator] as unknown[]).map(
+        sanitizeClientToolSchema,
+      );
+    }
+  }
+
+  return node;
+}
+
+/**
  * Converts a RunAgentInput into the format expected by TanStack AI's `chat()`.
  *
  * - Keeps only user/assistant/tool messages (activity, reasoning, and other roles are also excluded)
@@ -221,7 +303,17 @@ export function convertInputToTanStackAI(
     );
   }
 
-  return { messages, systemPrompts };
+  // Frontend-provided tools become client-side TanStack tools (no executor):
+  // the model can call them, TanStack pauses the run, and the AG-UI client
+  // executes them and resumes — the CopilotKit client-tool round-trip.
+  const tools: TanStackClientTool[] = (input.tools ?? []).map((t) => ({
+    __toolSide: "client",
+    name: t.name,
+    description: t.description,
+    inputSchema: sanitizeClientToolSchema(t.parameters),
+  }));
+
+  return { messages, systemPrompts, tools };
 }
 
 /**
@@ -266,14 +358,22 @@ export async function* convertTanStackStream(
     }
   }
 
-  // TanStack's chat() engine runs a multi-turn agent loop: after the model
-  // returns tool calls, the engine tries to execute them and re-prompt. This
-  // produces a second round of TOOL_CALL_START / TOOL_CALL_END events that
-  // duplicate the ones from the first streaming pass. The CopilotKit runtime
-  // handles tool execution externally (via the frontend SDK), so we must stop
-  // converting events once the TanStack adapter signals the first turn is
-  // complete with RUN_FINISHED.
-  let runFinished = false;
+  // TanStack's chat() engine runs a multi-turn agent loop and emits a
+  // RUN_STARTED / RUN_FINISHED pair PER model turn — not once for the whole
+  // run. When it executes a tool itself (an MCP server tool or a provider tool
+  // like web_search), it does so between turns and streams a TOOL_CALL_RESULT
+  // followed by the next turn's text. The overall run lifecycle is owned by the
+  // Agent wrapper (it emits exactly one outer RUN_STARTED / RUN_FINISHED), so
+  // we drop TanStack's per-turn lifecycle markers and convert every content
+  // event across all turns. (A previous version stopped converting at the first
+  // RUN_FINISHED — that truncated the run at the first tool turn and silently
+  // dropped both the tool result and the model's final answer.)
+  //
+  // chat() can re-announce a tool call when it re-prompts after executing it,
+  // so START / END are de-duplicated by toolCallId to avoid emitting a pair
+  // twice (which would violate the ag-ui verify middleware).
+  const startedToolCalls = new Set<string>();
+  const endedToolCalls = new Set<string>();
 
   for await (const chunk of stream) {
     if (abortSignal.aborted) break;
@@ -281,14 +381,19 @@ export async function* convertTanStackStream(
     const raw = chunk as Record<string, unknown>;
     const type = raw.type as string;
 
-    // Stop converting after the first RUN_FINISHED — any subsequent events
-    // come from TanStack's internal tool-execution loop and would produce
-    // duplicate TOOL_CALL_END events that violate the ag-ui verify middleware.
-    if (type === "RUN_FINISHED") {
-      runFinished = true;
+    // Per-turn lifecycle markers are owned by the Agent wrapper, not forwarded.
+    if (type === "RUN_STARTED" || type === "RUN_FINISHED") {
       continue;
     }
-    if (runFinished) continue;
+
+    // Surface engine errors instead of dropping them: throw so the Agent
+    // wrapper emits a terminal RUN_ERROR. Without this a failed run (e.g. a
+    // provider 4xx) would finish empty with no indication of what went wrong.
+    if (type === "RUN_ERROR") {
+      throw new Error(
+        typeof raw.message === "string" ? raw.message : "TanStack AI run error",
+      );
+    }
 
     if (type === "TEXT_MESSAGE_CONTENT" && raw.delta != null) {
       yield* closeReasoningIfOpen();
@@ -300,16 +405,22 @@ export async function* convertTanStackStream(
       };
       yield textEvent;
     } else if (type === "TOOL_CALL_START") {
+      const toolCallId = raw.toolCallId as string;
+      if (startedToolCalls.has(toolCallId)) continue;
+      startedToolCalls.add(toolCallId);
       yield* closeReasoningIfOpen();
-      toolNamesById.set(raw.toolCallId as string, raw.toolCallName as string);
+      toolNamesById.set(toolCallId, raw.toolCallName as string);
       const startEvent: ToolCallStartEvent = {
         type: EventType.TOOL_CALL_START,
         parentMessageId: messageId,
-        toolCallId: raw.toolCallId as string,
+        toolCallId,
         toolCallName: raw.toolCallName as string,
       };
       yield startEvent;
     } else if (type === "TOOL_CALL_ARGS") {
+      // Drop args re-announced after the call has ended (the re-prompt pass);
+      // forwarding them would corrupt the already-closed call's accumulated args.
+      if (endedToolCalls.has(raw.toolCallId as string)) continue;
       yield* closeReasoningIfOpen();
       const argsEvent: ToolCallArgsEvent = {
         type: EventType.TOOL_CALL_ARGS,
@@ -318,10 +429,13 @@ export async function* convertTanStackStream(
       };
       yield argsEvent;
     } else if (type === "TOOL_CALL_END") {
+      const toolCallId = raw.toolCallId as string;
+      if (endedToolCalls.has(toolCallId)) continue;
+      endedToolCalls.add(toolCallId);
       yield* closeReasoningIfOpen();
       const endEvent: ToolCallEndEvent = {
         type: EventType.TOOL_CALL_END,
-        toolCallId: raw.toolCallId as string,
+        toolCallId,
       };
       yield endEvent;
     } else if (type === "TOOL_CALL_RESULT") {


### PR DESCRIPTION
## Problem

`BuiltInAgent`'s TanStack factory mode (`type: "tanstack"`) was unusable with server-executed tools. The stream converter (`convertTanStackStream`) stopped converting at the **first per-turn `RUN_FINISHED`**, assuming tools are always executed client-side and re-prompted. But `chat()` executes MCP-server and provider tools **itself** across multiple turns — so the `TOOL_CALL_RESULT` and the model's final answer were dropped, and MCP-backed turns returned **nothing**. It also couldn't surface frontend (generative-UI / HITL) tools at all in factory mode.

## Fix

- **`convertTanStackStream`**: drop TanStack's per-turn `RUN_STARTED`/`RUN_FINISHED` (the `Agent` wrapper owns the single outer pair) and convert **every** turn's events; dedupe tool `START`/`END` by id (chat() re-announces a call when it re-prompts); surface `RUN_ERROR` by throwing instead of silently dropping it.
- **`convertInputToTanStackAI`**: return `input.tools` as TanStack **client-side** tools so the frontend's generative-UI / HITL tools work in factory mode, and **sanitize** their JSON Schema (recursively close open objects → `additionalProperties: false`) so OpenAI accepts them — mirroring what the classic (Vercel AI SDK) path did implicitly via its Zod round-trip.

## Tests

Adds coverage to the converter + input-converter suites: multi-turn (no truncation at per-turn `RUN_FINISHED`), tool-call dedup, `RUN_ERROR` surfacing, client-tool conversion, and schema sanitizing. Full `@copilotkit/runtime` suite green.

Verified end-to-end against a live Slack bot (`examples/slack`): web search + Linear/Notion MCP + generative-UI cards + HITL all work through factory mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)