### PR TITLE
fix(bot-slack): resolve HITL waiter in assistant-pane DMs + render-tool message order

### DIFF
--- a/packages/bot-slack/src/event-renderer.ts
+++ b/packages/bot-slack/src/event-renderer.ts
@@ -312,6 +312,19 @@ export function createRunRenderer(args: {
       }
     },
     async onRunFinishedEvent() {
+      // Defensive: finalize any text stream still open at the end of THIS run
+      // so a run's streamed text is fully posted before the run-loop executes
+      // tool handlers (which post out-of-band content like images/cards). In
+      // the common path TEXT_MESSAGE_END already finalized and removed the
+      // stream, so this is usually a no-op.
+      const drains: Promise<void>[] = [];
+      for (const [id, stream] of Array.from(streams.entries())) {
+        drains.push(stream.finish());
+        streams.delete(id);
+        finalised.add(id);
+        buffers.delete(id);
+      }
+      if (drains.length > 0) await Promise.all(drains);
       // If the run produced a streamed reply it already claimed the
       // placeholder; otherwise (tool/component/HITL output, or nothing)
       // this removes the leftover "thinking…" bubble.

--- a/packages/bot-slack/src/interaction.test.ts
+++ b/packages/bot-slack/src/interaction.test.ts
@@ -45,6 +45,23 @@ describe("decodeInteraction", () => {
     expect(evt!.user).toEqual({ id: "U2", name: "bob" });
   });
 
+  it("scopes a THREADED DM (assistant pane) by its thread ts, not DM_SCOPE", () => {
+    // Regression: an assistant-pane DM is threaded, so the ingress path keys
+    // the turn by thread ts. Forcing DM_SCOPE here stranded the HITL waiter and
+    // the run never resumed after a Create/Cancel click.
+    const evt = decodeInteraction({
+      type: "block_actions",
+      user: { id: "U3", name: "Cara" },
+      channel: { id: "D7" },
+      message: { ts: "300.1", thread_ts: "300.0" },
+      actions: [{ action_id: "ck:hitl", value: '{"confirmed":true}' }],
+    });
+    expect(evt!.conversationKey).toBe("D7::300.0");
+    // Replies should go back into the assistant thread.
+    expect(evt!.replyTarget).toEqual({ channel: "D7", threadTs: "300.0" });
+    expect(evt!.value).toEqual({ confirmed: true });
+  });
+
   it("falls back to container fields when message/channel are absent", () => {
     const evt = decodeInteraction({
       type: "block_actions",

--- a/packages/bot-slack/src/interaction.ts
+++ b/packages/bot-slack/src/interaction.ts
@@ -1,5 +1,6 @@
 import type { InteractionEvent } from "@copilotkit/bot";
-import { DM_SCOPE, type ConversationKey, type ReplyTarget } from "./types.js";
+import { DM_SCOPE } from "./types.js";
+import type { ConversationKey, ReplyTarget } from "./types.js";
 
 /**
  * Stable string key shared by ingress (onTurn) and interaction decoding so the
@@ -42,19 +43,27 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
   const channelId = body.channel?.id ?? body.container?.channel_id;
   if (!channelId) return undefined;
 
+  // An EXPLICIT thread ts means the click happened inside a thread — including
+  // an assistant-pane DM, which is threaded even though its channel id starts
+  // with "D". Only fall back to the message's own ts (a thread root) for the
+  // scope, never conflate the two.
+  const explicitThreadTs = body.message?.thread_ts ?? body.container?.thread_ts;
   const threadTs =
-    body.message?.thread_ts ??
-    body.container?.thread_ts ??
-    body.message?.ts ??
-    body.container?.message_ts;
+    explicitThreadTs ?? body.message?.ts ?? body.container?.message_ts;
   const isDm = channelId.startsWith("D");
-  // Scope MUST match what the listener emits per turn: DM_SCOPE for DMs,
-  // the thread ts for threaded conversations.
-  const scope = isDm ? DM_SCOPE : (threadTs ?? "");
+  // Scope MUST match what the listener emits per turn (see assistant.ts /
+  // adapter.ts), or the HITL `awaitChoice` waiter is stranded and the run
+  // never resumes: the thread ts for ANY threaded conversation (assistant-pane
+  // DMs included), and DM_SCOPE only for a genuinely unthreaded DM.
+  const scope = explicitThreadTs
+    ? explicitThreadTs
+    : isDm
+      ? DM_SCOPE
+      : (threadTs ?? "");
   const conversationKey = conversationKeyOf({ channelId, scope });
   const replyTarget: ReplyTarget = {
     channel: channelId,
-    threadTs: isDm ? undefined : threadTs,
+    threadTs: isDm && !explicitThreadTs ? undefined : threadTs,
   };
 
   // Tiny, non-sensitive value: the clicked button's value (or selected option


### PR DESCRIPTION
Two fixes surfaced by exercising the bot's generative-UI / HITL tools end-to-end in Slack.

## 1. HITL never resumed in an assistant-pane DM

An assistant-pane DM is **threaded**, so the ingress path (`assistant.ts`) keys the turn's conversation by **`thread_ts`**. But `decodeInteraction` forced **`DM_SCOPE`** for any `D…` channel. So the HITL `awaitChoice` waiter was registered under `D…::<thread_ts>` while a button click looked it up under `D…::dm` — the waiter was never resolved. Clicking **Create/Cancel** swapped the card UI (the button's `onClick` ran) but the agent run never resumed: no write, no reply.

**Fix:** honor an explicit `thread_ts` as the conversation scope even in DMs (matching ingress); fall back to `DM_SCOPE` only for a genuinely unthreaded DM. + a `decodeInteraction` regression test.

## 2. Render-tool output landed out of order

Defensively finalize any text stream still open at the end of a run (`onRunFinishedEvent`), so a run's streamed text is fully posted before the run-loop executes tool handlers that post out-of-band content (images, cards).

All 200 `@copilotkit/bot-slack` tests pass. Verified live: `confirm_write` now gates a write and resumes on approval; chart/diagram output renders in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)