### PR TITLE
fix(release): scope release-workflow concurrency keys by release target (ENT-950)

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -54,12 +54,13 @@ on:
         type: boolean
 
 concurrency:
-  # Serialize repeated dispatches on the same source branch. Cross-branch ref
-  # races are independently prevented by making the canary ref unique per run
-  # (slug + github.run_id, see the slug step below).
-  # Side-effect: repeated dispatches on the same source branch queue behind each
-  # other (cancel-in-progress: false) — even for different scopes.
-  group: canary-publish-${{ github.ref }}
+  # Serialize repeated dispatches on the same source branch FOR THE SAME SCOPE.
+  # Cross-branch ref races are independently prevented by making the canary ref
+  # unique per run (slug + github.run_id, see the slug step below).
+  # The scope is folded into the key so canaries for different scopes (e.g.
+  # `monorepo` vs `angular`) on the same branch run in independent lanes instead
+  # of queuing behind each other (cancel-in-progress: false).
+  group: canary-publish-${{ inputs.scope }}-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -71,7 +71,14 @@ permissions:
   contents: read
 
 concurrency:
-  group: publish-release
+  # Scope the lock to the package being released so a `monorepo` publish and an
+  # `angular` publish run in independent lanes instead of queuing behind each
+  # other. On the manual path `inputs.scope` carries the target; on the merged
+  # release-PR path inputs are empty, but the PR branch is
+  # `release/publish/<scope>/v<version>`, so `github.head_ref` already encodes
+  # the scope. Same-scope runs still serialize (cancel-in-progress: false),
+  # which is what protects the tag push / npm publish.
+  group: publish-release-${{ inputs.scope || github.head_ref || github.ref }}
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -29,7 +29,11 @@ on:
         type: boolean
 
 concurrency:
-  group: release-pr
+  # Scope the lock to the package being released so that, e.g., a `monorepo`
+  # create-pr run and an `angular` create-pr run proceed in independent lanes
+  # instead of queuing behind each other. Same-scope runs still serialize
+  # (cancel-in-progress: false), which is what protects the version bump.
+  group: release-pr-${{ inputs.scope }}
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
## Problem

Releasing `monorepo` was preempted — it sat **queued behind an unrelated `angular` release**. All three scope-aware release workflows use a **target-agnostic** concurrency group, so any two scopes contend for the same lock even though they touch disjoint packages and git tags:

| Workflow | Old `group:` |
|---|---|
| `stable-release.yml` (create PR) | `release-pr` |
| `publish-release.yml` (publish) | `publish-release` |
| `canary.yml` (one-click canary) | `canary-publish-${{ github.ref }}` |

With `cancel-in-progress: false`, the second run doesn't cancel — it queues. `canary.yml` already documented this side-effect ("queue behind each other — even for different scopes").

## Fix

Fold the release target (`inputs.scope`) into each concurrency key:

| Workflow | New `group:` |
|---|---|
| `stable-release.yml` | `release-pr-${{ inputs.scope }}` |
| `publish-release.yml` | `publish-release-${{ inputs.scope \|\| github.head_ref \|\| github.ref }}` |
| `canary.yml` | `canary-publish-${{ inputs.scope }}-${{ github.ref }}` |

- **stable-release** / **canary** are `workflow_dispatch`-only, so `inputs.scope` is always present.
- **publish-release** also fires on merged release PRs (inputs empty there), but the PR branch is `release/publish/<scope>/v<version>`, so `github.head_ref` already encodes the scope — the key stays scope-distinct on both paths.
- **canary** keeps `github.ref` (its original cross-branch-race guard) and *adds* scope.

Net: monorepo / angular / bot* releases run in independent lanes, while **same-scope runs stay serialized** (`cancel-in-progress: false`) — preserving race protection on the version bump, tag push, and npm publish. Tags are already scope-distinct (`v…` vs `angular/v…` vs `bot/v…`).

## Verification

- `scripts/release/verify-release-scope-dropdowns.sh` passes (it checks the `options:` list only — unaffected).
- All three files parse cleanly; `yq` confirms the intended `concurrency.group` values.

Closes ENT-950.

🤖 Generated with [Claude Code](https://claude.com/claude-code)