### PR TITLE
fix(showcase): un-fence ms-agent-harness-dotnet probing

### DIFF
--- a/showcase/harness/config/probes/d6-all-pills-e2e.yml
+++ b/showcase/harness/config/probes/d6-all-pills-e2e.yml
@@ -65,13 +65,6 @@ discovery:
       - showcase-shell-dashboard
       - showcase-shell-docs
       - showcase-shell-dojo
-      # Harness service for .NET integration testing — not a demo service,
-      # deployed: true in manifest, but NOT probe-wired yet: no aimock fixtures
-      # and it shares the ms-agent-dotnet AsyncLocal bug. Excluded from every
-      # probe AND not rendered on the dashboard (see baseline-types.ts) so an
-      # unprobed service never shows stale red. Remove this exclusion only once
-      # it is fully probe-wired (aimock fixtures + the AsyncLocal fix).
-      - showcase-ms-agent-harness-dotnet
       # Decommissioned starters
       - showcase-starter-ag2
       - showcase-starter-agno

--- a/showcase/harness/config/probes/e2e-deep.yml
+++ b/showcase/harness/config/probes/e2e-deep.yml
@@ -119,13 +119,6 @@ discovery:
       - showcase-shell-dashboard
       - showcase-shell-docs
       - showcase-shell-dojo
-      # Harness service for .NET integration testing — not a demo service,
-      # deployed: true in manifest, but NOT probe-wired yet: no aimock fixtures
-      # and it shares the ms-agent-dotnet AsyncLocal bug. Excluded from every
-      # probe AND not rendered on the dashboard (see baseline-types.ts) so an
-      # unprobed service never shows stale red. Remove this exclusion only once
-      # it is fully probe-wired (aimock fixtures + the AsyncLocal fix).
-      - showcase-ms-agent-harness-dotnet
       # Decommissioned starters — Railway services stopped (PR #4390)
       - showcase-starter-ag2
       - showcase-starter-agno

--- a/showcase/harness/config/probes/e2e-demos.yml
+++ b/showcase/harness/config/probes/e2e-demos.yml
@@ -118,13 +118,6 @@ discovery:
       - showcase-shell-dashboard
       - showcase-shell-docs
       - showcase-shell-dojo
-      # Harness service for .NET integration testing — not a demo service,
-      # deployed: true in manifest, but NOT probe-wired yet: no aimock fixtures
-      # and it shares the ms-agent-dotnet AsyncLocal bug. Excluded from every
-      # probe AND not rendered on the dashboard (see baseline-types.ts) so an
-      # unprobed service never shows stale red. Remove this exclusion only once
-      # it is fully probe-wired (aimock fixtures + the AsyncLocal fix).
-      - showcase-ms-agent-harness-dotnet
       # Decommissioned starters — Railway services stopped (PR #4390)
       - showcase-starter-ag2
       - showcase-starter-agno

--- a/showcase/harness/config/probes/e2e-smoke.yml
+++ b/showcase/harness/config/probes/e2e-smoke.yml
@@ -53,13 +53,6 @@ discovery:
       - showcase-shell-dashboard
       - showcase-shell-docs
       - showcase-shell-dojo
-      # Harness service for .NET integration testing — not a demo service,
-      # deployed: true in manifest, but NOT probe-wired yet: no aimock fixtures
-      # and it shares the ms-agent-dotnet AsyncLocal bug. Excluded from every
-      # probe AND not rendered on the dashboard (see baseline-types.ts) so an
-      # unprobed service never shows stale red. Remove this exclusion only once
-      # it is fully probe-wired (aimock fixtures + the AsyncLocal fix).
-      - showcase-ms-agent-harness-dotnet
       # Decommissioned starters — Railway services stopped (PR #4390)
       - showcase-starter-ag2
       - showcase-starter-agno

--- a/showcase/harness/config/probes/smoke.yml
+++ b/showcase/harness/config/probes/smoke.yml
@@ -73,13 +73,6 @@ discovery:
       - "showcase-shell-dashboard"
       - "showcase-shell-docs"
       - "showcase-shell-dojo"
-      # Harness service for .NET integration testing — not a demo service,
-      # deployed: true in manifest, but NOT probe-wired yet: no aimock fixtures
-      # and it shares the ms-agent-dotnet AsyncLocal bug. Excluded from every
-      # probe AND not rendered on the dashboard (see baseline-types.ts) so an
-      # unprobed service never shows stale red. Remove this exclusion only once
-      # it is fully probe-wired (aimock fixtures + the AsyncLocal fix).
-      - "showcase-ms-agent-harness-dotnet"
       # Decommissioned starters — Railway services stopped, deployments
       # halted (PR #4390). Excluded so probes don't scan dead endpoints.
       - "showcase-starter-ag2"

--- a/showcase/harness/src/fleet/control-plane/catalog-enumerator.ts
+++ b/showcase/harness/src/fleet/control-plane/catalog-enumerator.ts
@@ -319,13 +319,6 @@ export const D6_DISCOVERY_FILTER = {
     "showcase-shell-dashboard",
     "showcase-shell-docs",
     "showcase-shell-dojo",
-    // Harness service for .NET integration testing — deployed: true in its
-    // manifest but NOT probe-wired yet (no aimock fixtures; shares the
-    // ms-agent-dotnet AsyncLocal bug). Excluded from every probe AND not
-    // rendered on the dashboard (see shell-dashboard baseline-types.ts) so an
-    // unprobed service never shows stale red. Re-include only once it is fully
-    // probe-wired.
-    "showcase-ms-agent-harness-dotnet",
     // Decommissioned starters.
     "showcase-starter-ag2",
     "showcase-starter-agno",

--- a/showcase/harness/src/probes/aimock-wiring.test.ts
+++ b/showcase/harness/src/probes/aimock-wiring.test.ts
@@ -144,8 +144,11 @@ describe("aimock-wiring probe", () => {
     expect(r.signal.wiredCount).toBe(0);
   });
 
-  it("excludes bare-named ms-agent-harness-dotnet (non-LLM infra)", async () => {
-    const r = await aimockWiringProbe.run(
+  it("checks ms-agent-harness-dotnet for aimock wiring (no longer excluded)", async () => {
+    // The column is now fully probe-wired (d6/d4 aimock fixtures shipped via
+    // PR #5569), so it is an LLM caller and must route through aimock like any
+    // other partner. Unwired → red; wired (base URL present) → green.
+    const unwired = await aimockWiringProbe.run(
       {
         aimockUrl: AIMOCK_URL,
         listServices: async () => [{ name: "ms-agent-harness-dotnet" }],
@@ -153,8 +156,20 @@ describe("aimock-wiring probe", () => {
       },
       ctx,
     );
-    expect(r.state).toBe("green");
-    expect(r.signal.unwired).toEqual([]);
+    expect(unwired.state).toBe("red");
+    expect(unwired.signal.unwired).toEqual(["ms-agent-harness-dotnet"]);
+
+    const wired = await aimockWiringProbe.run(
+      {
+        aimockUrl: AIMOCK_URL,
+        listServices: async () => [{ name: "ms-agent-harness-dotnet" }],
+        getServiceEnv: async () => ({ ANTHROPIC_BASE_URL: AIMOCK_URL }),
+      },
+      ctx,
+    );
+    expect(wired.state).toBe("green");
+    expect(wired.signal.unwired).toEqual([]);
+    expect(wired.signal.wiredCount).toBe(1);
   });
 
   it("does NOT false-exclude services that merely share a prefix with infra names", async () => {

--- a/showcase/harness/src/probes/aimock-wiring.ts
+++ b/showcase/harness/src/probes/aimock-wiring.ts
@@ -74,7 +74,6 @@ const EXCLUDE_SERVICES: ReadonlySet<string> = new Set([
   "showcase-pocketbase",
   "showcase-harness",
   "showcase-webhooks",
-  "showcase-ms-agent-harness-dotnet",
   "showcase-starter-ag2",
   "showcase-starter-agno",
   "showcase-starter-claude-sdk-python",

--- a/showcase/shell-dashboard/src/lib/__tests__/baseline-types.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/baseline-types.test.ts
@@ -181,8 +181,8 @@ describe("FEATURE_CATEGORIES", () => {
 /*  BASELINE_PARTNERS                                                  */
 /* ------------------------------------------------------------------ */
 describe("BASELINE_PARTNERS", () => {
-  it("has exactly 25 partners", () => {
-    expect(BASELINE_PARTNERS).toHaveLength(25);
+  it("has exactly 26 partners", () => {
+    expect(BASELINE_PARTNERS).toHaveLength(26);
   });
 
   it("each partner has name and slug", () => {
@@ -199,16 +199,13 @@ describe("BASELINE_PARTNERS", () => {
     expect(new Set(slugs).size).toBe(slugs.length);
   });
 
-  // Fix C: ms-agent-harness-dotnet is deployed but NOT probe-wired (excluded
-  // from EVERY probe — d5/d6/e2e-smoke/e2e-demos/smoke/aimock-wiring). Rendering
-  // its column would produce cells with no fresh probe data → perpetual stale
-  // red in both the Baseline and Live-status dimensions. RENDERING must stay
-  // consistent with PROBING: an unprobed service contributes no rendered cells.
-  // Do NOT re-add it here until it is fully probe-wired (deploy + aimock
-  // fixtures + probe inclusion + the ms-agent-dotnet AsyncLocal fix).
-  it("does not render the unprobed ms-agent-harness-dotnet partner column", () => {
+  // ms-agent-harness-dotnet is now fully probe-wired: the column shipped
+  // (PR #5569) with d6/d4 aimock fixtures and is included in EVERY harness probe
+  // (d5/d6/e2e-smoke/e2e-demos/smoke/aimock-wiring). RENDERING stays consistent
+  // with PROBING — it contributes rendered cells backed by fresh probe data.
+  it("renders the probe-wired ms-agent-harness-dotnet partner column", () => {
     const slugs = BASELINE_PARTNERS.map((p) => p.slug);
-    expect(slugs).not.toContain("ms-agent-harness-dotnet");
+    expect(slugs).toContain("ms-agent-harness-dotnet");
   });
 });
 

--- a/showcase/shell-dashboard/src/lib/baseline-types.ts
+++ b/showcase/shell-dashboard/src/lib/baseline-types.ts
@@ -287,14 +287,12 @@ export const BASELINE_PARTNERS: readonly { name: string; slug: string }[] = [
   { name: "Google ADK", slug: "google-adk" },
   { name: "MS Agent Framework (Python)", slug: "ms-agent-python" },
   { name: "MS Agent Framework (.NET)", slug: "ms-agent-dotnet" },
-  // ms-agent-harness-dotnet is intentionally NOT rendered. It is deployed but
-  // NOT probe-wired: it is excluded from EVERY harness probe (d5, d6, e2e-smoke,
-  // e2e-demos, smoke, aimock-wiring) because it has no aimock fixtures and shares
-  // the ms-agent-dotnet AsyncLocal bug. Rendering its column would produce cells
-  // with no fresh probe data → perpetual stale red in both the Baseline and
-  // Live-status dimensions. RENDERING must stay consistent with PROBING. Re-add
-  // this entry (and the sort-order.ts slot) only once it is fully probe-wired:
-  // deploy + aimock fixtures + inclusion in the probe configs + the AsyncLocal fix.
+  // ms-agent-harness-dotnet is now fully probe-wired: the column shipped
+  // (PR #5569) with d6/d4 aimock fixtures, and it is included in EVERY harness
+  // probe (d5, d6, e2e-smoke, e2e-demos, smoke, aimock-wiring). RENDERING stays
+  // consistent with PROBING — it contributes rendered cells backed by fresh
+  // probe data. Sorts via the 6.5 slot in sort-order.ts (after ms-agent-dotnet).
+  { name: "MS Agent Harness (.NET)", slug: "ms-agent-harness-dotnet" },
   { name: "Strands", slug: "strands" },
   { name: "Mastra", slug: "mastra" },
   { name: "CrewAI", slug: "crewai-crews" },

--- a/showcase/shell-dashboard/src/lib/sort-order.ts
+++ b/showcase/shell-dashboard/src/lib/sort-order.ts
@@ -14,10 +14,8 @@ export const sortOrder: Record<string, number> = {
   "maf-python": 5,
   "ms-agent-dotnet": 6,
   "maf-dotnet": 6,
-  // ms-agent-harness-dotnet is NOT a rendered partner column (deployed but not
-  // probe-wired — see the note in baseline-types.ts BASELINE_PARTNERS). The 6.5
-  // slot is retained so the column sorts correctly if/when it is fully
-  // probe-wired and re-added to BASELINE_PARTNERS.
+  // ms-agent-harness-dotnet is a rendered partner column (see BASELINE_PARTNERS
+  // in baseline-types.ts). The 6.5 slot sorts it right after ms-agent-dotnet.
   "ms-agent-harness-dotnet": 6.5,
   strands: 7,
   mastra: 8,


### PR DESCRIPTION
## Summary
Un-fences the `ms-agent-harness-dotnet` showcase column from per-cell probe enumeration. The exclude was a placeholder added 2026-06-07 (commit f0edcd5d) before the column existed; the column shipped (PR #5569) and its d6/d4 aimock fixtures landed today (e10df0b4), so the fence is stale. Removed the slug from all 8 SSOT exclude sites (catalog-enumerator.ts nameExcludes, 5 probe YAMLs, aimock-wiring.ts, baseline-types.ts) + updated 3 stale comments/tests.

## Red-green proof (local, real control-plane surface)
- **RED** (origin/main): `enumerated services: [langgraph-python, ms-agent-dotnet]` — slug present-in-nameExcludes:true → **0 d6 cells**.
- **GREEN (enumeration)**: after the edits, `enumerated services: [..., ms-agent-harness-dotnet]` → slug enumerates (via the real `railwayServicesSource.enumerate` + real `D6_DISCOVERY_FILTER`).
- **GREEN (value-test)**: live local control-plane D6 stack (aimock fixtures) → **35 passed, 1 failed, 3 skipped, 3 incapable**.
- The single fail (`gen-ui-declarative` / sales-dashboard pie+bar charts not rendering) is **at parity with the gold-standard sibling**: PocketBase `d6:ms-agent-dotnet/gen-ui-declarative` is RED with the byte-identical error (fail_count 92, since 2026-06-15) and is the sibling's sole tolerated `1✗`. Shared sales-dashboard chart gap in the ms-agent-dotnet family — not a regression from the AsHarnessAgent port. Harness lands 35✓/1✗, matching the sibling.

## Test plan
- [ ] CI green
- [ ] After deploy, staging dashboard shows ms-agent-harness-dotnet cells populating (BE✓, D6 filling) on the next probe tick