### PR TITLE
docs: add Angular quick-start guide

### DIFF
--- a/showcase/scripts/generate-search-index.ts
+++ b/showcase/scripts/generate-search-index.ts
@@ -39,6 +39,7 @@ interface SearchEntry {
 const FRONTEND_SEARCH_PAGES = [
   { id: "vue", name: "Vue", guidanceTitle: "Docs status" },
   { id: "react-native", name: "React Native", guidanceTitle: "Docs status" },
+  { id: "angular", name: "Angular", guidanceTitle: "Docs status" },
   { id: "slack", name: "Slack", guidanceTitle: "About early access" },
   { id: "teams", name: "Teams", guidanceTitle: "About early access" },
 ] as const;

--- a/showcase/shell-docs/src/components/frontend-logo.tsx
+++ b/showcase/shell-docs/src/components/frontend-logo.tsx
@@ -1,7 +1,7 @@
 import type { FrontendIcon } from "@/lib/frontend-options";
 import type React from "react";
 import { BiLogoMicrosoftTeams } from "react-icons/bi";
-import { SiReact, SiVuedotjs } from "react-icons/si";
+import { SiAngular, SiReact, SiVuedotjs } from "react-icons/si";
 import { TbBrandReactNative } from "react-icons/tb";
 
 type BrandIcon = React.ComponentType<{
@@ -75,6 +75,7 @@ const FRONTEND_ICONS: Record<FrontendIcon, { Icon: BrandIcon; color: string }> =
     react: { Icon: SiReact, color: "#61DAFB" },
     vue: { Icon: SiVuedotjs, color: "#4FC08D" },
     "react-native": { Icon: TbBrandReactNative, color: "#61DAFB" },
+    angular: { Icon: SiAngular, color: "#DD0031" },
     slack: { Icon: SlackColorLogo, color: "currentColor" },
     teams: { Icon: BiLogoMicrosoftTeams, color: "#6264A7" },
   };

--- a/showcase/shell-docs/src/content/docs/frontends/angular.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular.mdx
@@ -1,0 +1,143 @@
+---
+title: Angular
+description: Connect an Angular app to an AG-UI agent with CopilotKit.
+icon: "lucide/Triangle"
+hideTOC: true
+---
+
+`@copilotkit/angular` provides Angular components, directives, and services for CopilotKit. This guide gets you to a working Angular app with a chat UI talking to an [AG-UI](/backend/ag-ui) agent.
+
+It connects to the agent directly with `HttpAgent`, so there's no CopilotKit runtime to stand up and nothing framework-specific to configure. The same setup works with any AG-UI-compatible agent, whether it's built on LangGraph, CrewAI, Mastra, Pydantic AI, or your own server.
+
+## Prerequisites
+
+- A running AG-UI-compatible agent endpoint. If you don't have one yet, pick a framework under [Integrations](/integrations/langgraph) and follow its agent setup.
+- Angular 19, 20, or 21 (Angular 22 is not supported yet)
+- Node.js 20+
+
+## Getting started
+
+<Steps>
+    <Step>
+        ### Create your Angular app
+
+        If you don't have one already. The package supports Angular up to 21, so pin the CLI to a supported major rather than `@latest`:
+
+        ```bash
+        npx @angular/cli@21 new my-copilot-app
+        cd my-copilot-app
+        ```
+    </Step>
+    <Step>
+        ### Install CopilotKit
+
+        Install the Angular package alongside its `@angular/cdk` and `@ag-ui/client` peers:
+
+        <Tabs groupId="package-manager" items={['npm', 'pnpm', 'yarn']}>
+            <Tab value="npm">
+                ```bash
+                npm install @copilotkit/angular @angular/cdk @ag-ui/client
+                ```
+            </Tab>
+            <Tab value="pnpm">
+                ```bash
+                pnpm add @copilotkit/angular @angular/cdk @ag-ui/client
+                ```
+            </Tab>
+            <Tab value="yarn">
+                ```bash
+                yarn add @copilotkit/angular @angular/cdk @ag-ui/client
+                ```
+            </Tab>
+        </Tabs>
+
+        <Callout type="info" title="Match @angular/cdk to your Angular version">
+          `@angular/cdk` must share your Angular major version. Most package managers resolve this for you, but if you hit a peer-dependency error, pin it explicitly (for example `@angular/cdk@^21`).
+        </Callout>
+    </Step>
+    <Step>
+        ### Import the styles
+
+        Add the package stylesheet to your global styles. It's self-contained, so the chat renders without any other CSS.
+
+        ```css title="src/styles.css"
+        @import "@copilotkit/angular/styles.css"; /* [!code highlight] */
+        ```
+    </Step>
+    <Step>
+        ### Connect to your agent
+
+        Register an `HttpAgent` pointing at your agent endpoint under the id `default`, so the chat picks it up automatically.
+
+        ```ts title="src/app/app.config.ts"
+        import { ApplicationConfig } from "@angular/core";
+        import { provideCopilotKit } from "@copilotkit/angular"; // [!code highlight]
+        import { HttpAgent } from "@ag-ui/client"; // [!code highlight]
+
+        export const appConfig: ApplicationConfig = {
+          providers: [
+            // [!code highlight:6]
+            provideCopilotKit({
+              selfManagedAgents: {
+                // Point this at your AG-UI-compatible agent endpoint
+                default: new HttpAgent({ url: "http://localhost:8000/" }),
+              },
+            }),
+          ],
+        };
+        ```
+    </Step>
+    <Step>
+        ### Add the chat UI
+
+        Import the `CopilotChat` component into your root component and drop it into the template.
+
+        ```ts title="src/app/app.ts"
+        import { Component } from "@angular/core";
+        import { CopilotChat } from "@copilotkit/angular"; // [!code highlight]
+
+        @Component({
+          selector: "app-root",
+          imports: [CopilotChat], // [!code highlight]
+          template: `
+            <!-- [!code highlight:3] -->
+            <div style="height: 100vh">
+              <copilot-chat />
+            </div>
+          `,
+        })
+        export class App {}
+        ```
+
+        <Callout type="info" title="Older Angular projects">
+          Angular 19 names the root component `app.component.ts` with class `AppComponent`. Add the same imports and template there.
+        </Callout>
+    </Step>
+    <Step>
+        ### Run the app
+
+        ```bash
+        npm start
+        ```
+
+        Open the dev server URL (the Angular CLI prints it, usually `http://localhost:4200`), send a message, and you'll see it stream back from your agent.
+
+        <Accordions className="mb-4">
+            <Accordion title="Troubleshooting">
+                - **Chat renders unstyled**: Make sure you imported `@copilotkit/angular/styles.css` in `src/styles.css`.
+                - **No response from the agent**: Confirm the `url` points at a reachable AG-UI endpoint and that the agent is running. Check the browser network tab for the request.
+                - **CORS errors**: A browser-direct connection needs the agent endpoint to allow your app's origin. Enable CORS on the agent, or put it behind the [CopilotKit runtime](/backend/copilot-runtime).
+                - **Peer-dependency error on install**: `@angular/cdk` must match your Angular major version. Install the matching major, for example `@angular/cdk@^21` on Angular 21.
+                - **Production build exceeds the bundle budget**: CopilotKit pulls in markdown and syntax-highlighting dependencies, so a fresh app can exceed Angular's default 1 MB budget. Raise `budgets` in `angular.json` if your production build fails on size.
+            </Accordion>
+        </Accordions>
+    </Step>
+</Steps>
+
+## Where to go next
+
+- [Self-managed agents](/backend/self-managed-agents): securing the connection, the dev-only registration variant, and combining with a runtime.
+- [Connect AG-UI agents](/backend/ag-ui): the `HttpAgent` interface and the AG-UI protocol.
+- [Integrations](/integrations/langgraph): set up the agent itself on LangGraph, CrewAI, Mastra, and other frameworks.
+
+For headless setups, custom UIs with `injectAgentStore`, and the full component list, see the [`@copilotkit/angular` README](https://github.com/CopilotKit/CopilotKit/tree/main/packages/angular).

--- a/showcase/shell-docs/src/lib/frontend-options.ts
+++ b/showcase/shell-docs/src/lib/frontend-options.ts
@@ -1,4 +1,10 @@
-export type FrontendId = "react" | "vue" | "react-native" | "slack" | "teams";
+export type FrontendId =
+  | "react"
+  | "vue"
+  | "react-native"
+  | "angular"
+  | "slack"
+  | "teams";
 
 export type FrontendIcon = FrontendId;
 
@@ -27,6 +33,12 @@ export const FRONTEND_OPTIONS: readonly FrontendOption[] = [
     name: "React Native",
     icon: "react-native",
     summary: "Mobile bindings for React Native and Expo apps.",
+  },
+  {
+    id: "angular",
+    name: "Angular",
+    icon: "angular",
+    summary: "Angular components, directives, and services.",
   },
   {
     id: "slack",

--- a/showcase/shell-docs/src/lib/frontend-page-content.ts
+++ b/showcase/shell-docs/src/lib/frontend-page-content.ts
@@ -32,6 +32,7 @@ export function getFrontendUsingTheseDocsPath(id: FrontendPageId): string {
 const FRONTEND_REFERENCE_SLUGS = {
   vue: "reference",
   "react-native": "reference/react-native",
+  angular: "reference",
   slack: "reference/bot",
   teams: "reference",
 } satisfies Record<FrontendPageId, string>;

--- a/showcase/shell-docs/src/lib/search-hrefs.ts
+++ b/showcase/shell-docs/src/lib/search-hrefs.ts
@@ -2,7 +2,13 @@ import { frontendPathForBackend } from "@/lib/frontend-options";
 import type { FrontendId } from "@/lib/frontend-options";
 
 const ROOT_FRAMEWORK = "built-in-agent";
-const FRONTEND_IDS = new Set(["vue", "react-native", "slack", "teams"]);
+const FRONTEND_IDS = new Set([
+  "vue",
+  "react-native",
+  "angular",
+  "slack",
+  "teams",
+]);
 type FrontendPageId = Exclude<FrontendId, "react">;
 
 export function parseIntegrationDocsHref(


### PR DESCRIPTION
Adds a minimal Angular quick-start guide and wires Angular into the docs **frontend picker** introduced in #5586. Connects directly to an AG-UI agent via `HttpAgent`, no runtime required.

Closes [OSS-252](https://linear.app/copilotkit/issue/OSS-252/add-angular-quick-start-guide).

### Angular in the frontend picker

![Angular in the docs frontend picker](https://raw.githubusercontent.com/CopilotKit/CopilotKit/assets/oss-252-angular-quickstart/pr-assets/oss-252/angular-frontend-picker.png)

- Guide lives at `content/docs/frontends/angular.mdx`, served at `/angular` like the other frontends
- Registered `angular` in `frontend-options` (+ `SiAngular` logo), `search-hrefs`, the search-index pages, and the typed reference-slug record
- Not flagged early access (parity with Vue / React Native)

### Verified end-to-end

Built a fresh Angular 21 app, followed the guide verbatim, and got a live streamed reply. shell-docs typecheck and the frontend unit tests (8/8) pass.

![Working chat in a generated Angular app](https://raw.githubusercontent.com/CopilotKit/CopilotKit/assets/oss-252-angular-quickstart/pr-assets/oss-252/angular-quickstart-verified.png)

Key specifics from that validation: install **`@copilotkit/angular`** (the deprecated `@copilotkitnext/angular` is renamed), no TS7016 workaround needed (the package ships types), and pin `@angular/cli@21` since `@latest` (v22) is outside the `19-21` peer range.

> Reference-docs link points at `/reference` for now; it should switch to `/reference/angular` once the Angular reference PR (#5585) lands.
> The in-repo package is still `@copilotkitnext/angular`; the `@copilotkit/angular` rename only landed on npm 2026-06-18. Renaming in source is a separate follow-up.

_Screenshots live on the `assets/oss-252-angular-quickstart` branch to keep this diff scoped._