### PR TITLE
feat(showcase): dependency/env/verification-complete cluster promote

### DIFF
--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -15,7 +15,10 @@ name: "Showcase: Promote (staging → prod)"
 #                                     spec §7 hardening (P1..P6).
 #   3. verify-prod                  → verify-deploy.ts --env prod for the
 #                                     target service(s). Feature-level probes,
-#                                     not naked 200.
+#                                     not naked 200. Then the prod equivalence
+#                                     re-sweep gate (§6.2) and the pinned-ness
+#                                     gate (lint-prod, §8.2 — every prod service
+#                                     must be on an immutable @sha256: digest).
 #   4. notify                       → Slack #oss-alerts on any red. Never #engr.
 #                                     success → #team-showcase.
 
@@ -82,7 +85,16 @@ jobs:
     permissions:
       contents: read
     outputs:
+      # Leaf-set CSV — the BACKWARD-COMPAT promote target the promote job still
+      # drives off (Phase 1 behavior is unchanged).
       services_csv: ${{ steps.resolve.outputs.services_csv }}
+      # Tier-ordered promote closure (requested ∪ transitive runtimeDeps ∪
+      # Tier-1 verification, §4.2). Phase 1 SURFACES it (operators see the
+      # closure in the step summary) but the actual promote still uses
+      # services_csv; U4 enforces tier ordering / dependent-gating off these.
+      closure_csv: ${{ steps.resolve.outputs.closure_csv }}
+      # Machine-readable `tier:name` form of the closure for U4 to consume.
+      closure_plan: ${{ steps.resolve.outputs.closure_plan }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -97,64 +109,20 @@ jobs:
           npx tsx emit-railway-envs-json.ts
       - name: Resolve target service set
         id: resolve
+        # Resolution + the tiered-closure derivation live in the bats-tested
+        # showcase/scripts/resolve-promote-targets.sh so they can't drift from
+        # their test (see __tests__/resolve-promote-targets.bats), mirroring how
+        # promote-fleet.sh / verify-prod-display.sh were extracted from this same
+        # workflow. The script preserves the existing guards (--digest+all
+        # reject, empty-`all` fail-loud, unknown/ambiguous/not-prod-eligible) and
+        # emits services_csv (leaf, backward-compat) + closure_csv/closure_plan
+        # (tiered closure) into $GITHUB_OUTPUT, plus the closure plan + skips into
+        # $GITHUB_STEP_SUMMARY.
         env:
           INPUT: ${{ inputs.service }}
           DIGEST: ${{ inputs.digest }}
-        run: |
-          set -euo pipefail
-          GENERATED="showcase/scripts/railway-envs.generated.json"
-          if [ "$INPUT" = "__select_a_service__" ]; then
-            echo "::error::No service selected. Re-run and pick a service (or 'all') from the dropdown."
-            exit 1
-          fi
-          if [ "$INPUT" = "all" ]; then
-            # A single digest identifies at most one service's image, so a
-            # fleet-wide promote pinned to one digest is always wrong. The
-            # per-service promote loop would slip past bin/railway's own
-            # --digest guard (each call passes a positional service), so reject
-            # the combination loud and early here.
-            if [ -n "${DIGEST:-}" ]; then
-              echo "::error::--digest cannot be combined with 'all' (a single digest is meaningless across multiple services); pick one service."
-              exit 1
-            fi
-            CSV=$(jq -r '.services[] | select(.probe.prod == true) | .name' "$GENERATED" | sort -u | tr '\n' ',' | sed 's/,$//')
-            # Fail loud if 'all' resolved to nothing (e.g. an SSOT regression
-            # dropped every probe.prod entry). An empty CSV would otherwise
-            # propagate downstream with exit 0; mirror the single-service
-            # branch's fail-loud style.
-            if [ -z "$CSV" ]; then
-              echo "::error::'all' resolved to zero prod-eligible services"
-              exit 1
-            fi
-          else
-            # Capture the FULL match set (no `head` — that would silently mask
-            # an ambiguous match, and piping jq into head under pipefail can
-            # SIGPIPE jq and abort with no ::error:: annotation). Then count
-            # and branch fail-loud.
-            # Independently enforce prod-eligibility here: the dropdown
-            # advertises a prod-eligible set, but a stale/edited dropdown could
-            # offer a probe.prod:false service. Filtering on probe.prod == true
-            # ensures the single-service path never promotes a non-eligible
-            # service to prod, matching the `all` branch's gate.
-            MATCHES=$(jq -r --arg s "$INPUT" '
-              .services[]
-              | select(.name == $s or .dispatchName == $s)
-              | select(.probe.prod == true)
-              | .name
-            ' "$GENERATED")
-            # `grep -c` on empty input exits 1 under set -e; guard with || true.
-            COUNT=$(printf '%s' "$MATCHES" | grep -c . || true)
-            if [ "$COUNT" -eq 0 ]; then
-              echo "::error::Unknown or not prod-eligible service '$INPUT' (not an SSOT key/dispatch_name, or probe.prod is not true)"
-              exit 1
-            elif [ "$COUNT" -gt 1 ]; then
-              LIST=$(printf '%s' "$MATCHES" | tr '\n' ',' | sed 's/,$//')
-              echo "::error::Ambiguous service '$INPUT' matches multiple SSOT entries: $LIST"
-              exit 1
-            fi
-            CSV="$MATCHES"
-          fi
-          echo "services_csv=$CSV" >> "$GITHUB_OUTPUT"
+          GENERATED: showcase/scripts/railway-envs.generated.json
+        run: showcase/scripts/resolve-promote-targets.sh
 
   verify-staging-precondition:
     needs: [resolve-targets]
@@ -348,6 +316,99 @@ jobs:
           npx tsx verify-deploy.ts --env prod --services "$SERVICES_CSV"
           # Prod was actually probed and passed.
           echo "status=success" >> "$GITHUB_OUTPUT"
+      # ── Prod equivalence gate (UNIT U10, spec §6.2) ──────────────────────
+      # After the closure pins (promote job) AND the per-service prod probe
+      # (above), re-sweep the promoted integration closure on the PROD control
+      # plane (prod harness scheduler + prod harness-workers, or scheduler
+      # INLINE fallback when workers are unprovisioned — §4.4) and run U9's
+      # equivalence gate over the FRESH prod rows vs current staging. Promote
+      # success flips to the equivalence definition (fail only on
+      # staging-green / prod-not-green, gray/stale excluded, one-directional).
+      #
+      # GATED ON CONFIGURATION: the equivalence gate needs prod + staging
+      # PocketBase creds and the prod Railway environment id. Those are an
+      # out-of-PR operational prerequisite (§8.1) — until the secrets are wired
+      # the step ANNOTATES "not configured" and is a no-op, so this job's
+      # existing per-service prod verification (above) remains the gate. Once
+      # configured, a gate FAILURE fails the step (and the run).
+      # Install the pnpm workspace ONLY when the equivalence gate is configured
+      # (the gate step's enqueue dynamically imports the harness producer graph,
+      # which lives in the pnpm workspace — `npm ci` in showcase/scripts alone
+      # does not resolve it). `--ignore-scripts` skips postinstall/Playwright
+      # browser downloads: the host only ENQUEUES + POLLS prod PocketBase; the
+      # prod harness-workers own the browser. Gated on the same config check as
+      # the gate step so the no-op (unconfigured) path stays cheap.
+      - name: Set up pnpm (equivalence gate only)
+        if: ${{ steps.verify.outputs.status == 'success' && vars.SHOWCASE_PROD_POCKETBASE_URL != '' && vars.SHOWCASE_STAGING_POCKETBASE_URL != '' && vars.SHOWCASE_RAILWAY_ENV_ID_PROD != '' }}
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - name: pnpm install (equivalence gate only)
+        if: ${{ steps.verify.outputs.status == 'success' && vars.SHOWCASE_PROD_POCKETBASE_URL != '' && vars.SHOWCASE_STAGING_POCKETBASE_URL != '' && vars.SHOWCASE_RAILWAY_ENV_ID_PROD != '' }}
+        run: pnpm install --ignore-scripts
+      - name: Prod equivalence re-sweep gate
+        if: ${{ steps.verify.outputs.status == 'success' }}
+        working-directory: showcase/scripts
+        env:
+          # The promoted closure subset that ACTUALLY pinned (best-effort) —
+          # the set to re-sweep + compare. Same scope as the prod probe above.
+          PROMOTED_CLOSURE_CSV: ${{ needs.promote.outputs.succeeded_csv }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.SHOWCASE_RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT_ID_PROD: ${{ vars.SHOWCASE_RAILWAY_ENV_ID_PROD }}
+          PROD_POCKETBASE_URL: ${{ vars.SHOWCASE_PROD_POCKETBASE_URL }}
+          PROD_POCKETBASE_SUPERUSER_EMAIL: ${{ secrets.SHOWCASE_PROD_POCKETBASE_SUPERUSER_EMAIL }}
+          PROD_POCKETBASE_SUPERUSER_PASSWORD: ${{ secrets.SHOWCASE_PROD_POCKETBASE_SUPERUSER_PASSWORD }}
+          STAGING_POCKETBASE_URL: ${{ vars.SHOWCASE_STAGING_POCKETBASE_URL }}
+          STAGING_POCKETBASE_SUPERUSER_EMAIL: ${{ secrets.SHOWCASE_STAGING_POCKETBASE_SUPERUSER_EMAIL }}
+          STAGING_POCKETBASE_SUPERUSER_PASSWORD: ${{ secrets.SHOWCASE_STAGING_POCKETBASE_SUPERUSER_PASSWORD }}
+          # §4.4 annotation: flip to "false" once prod harness-workers are
+          # provisioned-but-degraded is the default-true full-throughput path.
+          PROD_HARNESS_WORKERS_PROVISIONED: ${{ vars.SHOWCASE_PROD_HARNESS_WORKERS_PROVISIONED }}
+        run: |
+          set -euo pipefail
+          # OUT-OF-PR PREREQ GATE: the equivalence gate is inert until the prod
+          # + staging PocketBase + prod Railway env-id config is wired (§8.1).
+          # Absence is NOT a failure — the per-service prod probe above already
+          # gated the run; this step just annotates that the equivalence gate
+          # was skipped for lack of configuration.
+          if [ -z "${PROD_POCKETBASE_URL:-}" ] || [ -z "${STAGING_POCKETBASE_URL:-}" ] || [ -z "${RAILWAY_ENVIRONMENT_ID_PROD:-}" ]; then
+            echo "::notice::Prod equivalence gate not configured (prod/staging PocketBase + prod Railway env-id absent) — skipping the re-sweep gate. This is the §8.1 out-of-PR prerequisite; the per-service prod probe remains the gate."
+            exit 0
+          fi
+          if [ -z "${PROMOTED_CLOSURE_CSV:-}" ]; then
+            echo "::notice::no promoted closure to re-sweep — equivalence gate vacuously passes."
+            exit 0
+          fi
+          # A gate FAILURE (a genuine staging-green / prod-not-green regression)
+          # or a re-sweep timeout (REFUSE) exits non-zero → fails this step and
+          # the run, exactly like the per-service probe above. `pnpm exec` (not
+          # `npx`) so the dynamically-imported harness producer graph resolves
+          # through the workspace node_modules the install step above created.
+          pnpm exec tsx verify-prod-resweep.ts
+      # ── Prod pinned-ness gate (UNIT U12, spec §8.2) ──────────────────────
+      # COMPLEMENTS the equivalence gate above — it asserts PINNED-NESS, not
+      # equivalence. After the promote pins the closure and prod is verified
+      # healthy + equivalent, assert that EVERY prod service is on an immutable
+      # `@sha256:` digest, not a mutable `:latest` tag. A born-on-:latest prod
+      # service (deploy-to-railway.ts provisions an unpinned source.image, spec
+      # R-E) can be healthy AND equivalent while still floating on a mutable tag
+      # — a latent rollback/repro hazard the other gates do not catch. The gate
+      # logic lives in the bats-tested showcase/scripts/lint-prod-gate.sh (a thin
+      # `bin/railway lint-prod` wrapper) so it can't drift from its test (see
+      # __tests__/lint-prod-gate.bats). Runs whenever prod was actually probed
+      # (same `status == 'success'` guard as the equivalence gate); a non-zero
+      # exit (an unpinned prod service, or a hard lint-prod error) fails the step
+      # and the run. No `--exit-zero`: an unpinned prod service must red the run.
+      - name: Prod pinned-ness gate (lint-prod)
+        if: ${{ steps.verify.outputs.status == 'success' }}
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_TOKEN is not set"
+            exit 1
+          fi
+          showcase/scripts/lint-prod-gate.sh
 
   notify:
     # Slack #oss-alerts only. Never #engr (engr is sacred — release alerts only).

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -580,6 +580,43 @@ module Railway
         }
     GQL
 
+    # Per-(service,env) variable VALUES. The snapshot path (above) deliberately
+    # captures KEYS ONLY so snapshots stay safe to commit. The U5 promote
+    # preflight, by contrast, must compare a FEW specific VALUES (a serviceRef
+    # host assertion, a prod-specific-key shape assertion, a replicate-class
+    # copy) — so it reads values transiently at runtime, never persisting them.
+    # `variables(serviceId)` scopes to a single service so we do not pull the
+    # whole env's secret surface. Sealed values come back as nil (Railway will
+    # not return a sealed value), which the callers treat as "unreadable" and
+    # never copy.
+    # Railway's top-level `variables(projectId, environmentId, serviceId)`
+    # returns a JSON scalar (a flat `{ "NAME" => "value", ... }` map) — NOT a
+    # connection. (`Environment.variables` IS a connection but its node carries
+    # no `value`, which is why the snapshot path reads keys only.)
+    SERVICE_VARIABLES_QUERY = <<~GQL
+        query EnvServiceVariables($projectId: String!, $serviceId: String!, $envId: String!) {
+            variables(projectId: $projectId, serviceId: $serviceId, environmentId: $envId)
+        }
+    GQL
+
+    # Upsert a single environment variable VALUE for a (service,env). This is
+    # the variable*Upsert family (NOT serviceInstanceUpdate(source.image), which
+    # only sets the image). Used ONLY by U5's opt-in replicate-class env-write;
+    # the default replicate set is empty, so this fires for no key today.
+    VARIABLE_UPSERT_MUTATION = <<~GQL
+        mutation VariableUpsert($serviceId: String!, $envId: String!, $name: String!, $value: String!) {
+            variableUpsert(
+                input: {
+                    projectId: "#{PROJECT_ID}"
+                    serviceId: $serviceId
+                    environmentId: $envId
+                    name: $name
+                    value: $value
+                }
+            )
+        }
+    GQL
+
     # ── Subcommands ────────────────────────────────────────────────────────────
 
     class BaseCommand
@@ -1452,6 +1489,19 @@ module Railway
             findings.concat(check_critical_env_key_parity(target_staging, target_prod))
             findings.concat(check_expected_prod_domains(fleet_prod))
 
+            # U5 (spec §5): env + service-ref + resource preflight (Stage 2).
+            # §5.2 service-ref assertion (REFUSE), §5.3.2 prod-specific-key
+            # assertion (REFUSE; NEVER copies), §5.4 resource/concurrency
+            # divergence (WARN; detect-only). Replicate-class env-write (§5.3.1)
+            # is opt-in per service via the SSOT `replicateKeys` field and is
+            # empty for every service today, so it fires for nothing.
+            findings.concat(check_service_refs(target_staging, target_prod))
+            findings.concat(assert_prod_specific_keys(target_staging, target_prod,
+                prod_specific_keys: ssot_prod_specific_keys(target_staging)))
+            findings.concat(replicate_env_keys(target_staging, target_prod,
+                replicate_keys: ssot_replicate_keys(target_staging)))
+            findings.concat(check_resource_divergence(target_staging, target_prod))
+
             # Mandatory parity-NOTE that env var VALUES are not compared.
             puts "NOTE: env var VALUES are not compared between staging and prod " \
                  "(intentional — staging and prod hold different secrets/URLs). " \
@@ -1964,11 +2014,15 @@ module Railway
             #   - target in staging but not prod (the silent-rc=0 footgun:
             #     narrowed prod would skip the absent target with no mutation);
             #   - target in prod but not staging (the mirror case).
-            # Unrelated services that exist in only one env (harness-workers,
-            # starter-* demos staging-only; a deprecated prod-only service) are
-            # legitimately single-env and are not this promote's concern, so we
-            # scope BOTH arms to the target. Full-fleet promotes (target nil)
-            # retain full-strictness parity on both arms — there, any env-shape
+            # Unrelated services that exist in only one env (e.g. the
+            # staging-only harness-workers pool worker, or a deprecated
+            # prod-only service) are legitimately single-env and are not this
+            # promote's concern, so we scope BOTH arms to the target.
+            # (NOTE: the 12 starter-<slug> demos are NO LONGER staging-only —
+            # S2 brought them under the SSOT in BOTH envs, so they are normal
+            # dual-env services that satisfy parity on their own; they are not
+            # an exemption case here.) Full-fleet promotes (target nil) retain
+            # full-strictness parity on both arms — there, any env-shape
             # asymmetry across the whole fleet is a genuine REFUSE.
             if target
                 staging_only = staging_only & [target]
@@ -1986,6 +2040,203 @@ module Railway
                 next unless pmatch
                 missing = (CRITICAL_ENV_KEYS & (svc["env_keys"] || [])) - (pmatch["env_keys"] || [])
                 findings << "REFUSE: #{svc['name']}: critical env keys missing in prod: #{missing.join(', ')}" unless missing.empty?
+            end
+            findings
+        end
+
+        # ── U5 (spec §5): env + service-ref + resource preflight (Stage 2) ──
+        #
+        # Concurrency env-var keys that are a RESOURCE/scaling knob rather than a
+        # functional contract — divergence is DETECT-and-WARN, never REFUSE
+        # (§5.4). Sourced as a literal set; add knobs here as they appear.
+        CONCURRENCY_ENV_KEYS = %w[BROWSER_POOL_SIZE].freeze
+
+        # Per-service SSOT entry (the generated.json closure record) by name.
+        def ssot_service(name)
+            (Railway::SSOT_DATA["services"] || []).find { |s| s["name"] == name }
+        end
+
+        # Union of per-service `replicateKeys` declared in the SSOT for the
+        # services being promoted (§5.3.1). EMPTY for every service today — the
+        # replicate-class env-write mechanism is opt-in and copies nothing until
+        # a key is explicitly declared.
+        def ssot_replicate_keys(staging)
+            (staging["services"] || []).flat_map do |svc|
+                (ssot_service(svc["name"]) || {})["replicateKeys"] || []
+            end.uniq
+        end
+
+        # Union of per-service `prodSpecificKeys` declared in the SSOT for the
+        # services being promoted (§5.3.2). These are ASSERTED present in prod,
+        # NEVER copied. EMPTY for every service today.
+        def ssot_prod_specific_keys(staging)
+            (staging["services"] || []).flat_map do |svc|
+                (ssot_service(svc["name"]) || {})["prodSpecificKeys"] || []
+            end.uniq
+        end
+
+        # The env-LOCAL host the target service serves in `env` (the `domains`
+        # value from the SSOT). `env` is "prod" or "staging".
+        def ssot_target_host(target_name, env)
+            entry = ssot_service(target_name)
+            entry && entry.dig("domains", env)
+        end
+
+        # Read a single (service,env) variable VALUE transiently (never
+        # persisted). Returns nil for an absent or sealed (unreadable) variable
+        # — callers MUST treat nil as "not present", never as a value to copy.
+        def read_service_var(service_id, env_id, name)
+            data = gql.query(SERVICE_VARIABLES_QUERY,
+                projectId: PROJECT_ID, serviceId: service_id, envId: env_id)
+            vars = data && data["variables"]
+            return nil unless vars.is_a?(Hash)
+            v = vars[name]
+            (v.nil? || v.to_s.empty?) ? nil : v
+        end
+
+        # §5.2 service-ref assertion (REFUSE). For each promote target carrying
+        # `serviceRefs` in the SSOT, assert its PROD env var (e.g.
+        # OPENAI_BASE_URL / ANTHROPIC_BASE_URL) points at the env-LOCAL target
+        # host (prod->prod aimock). A prod ref resolving to the STAGING target
+        # host (or a foreign host) is the `ms-agent-dotnet` cross-env leak class
+        # => REFUSE. This is an ASSERTION; it NEVER writes/copies.
+        def check_service_refs(staging, prod)
+            findings = []
+            (staging["services"] || []).each do |svc|
+                name = svc["name"]
+                pmatch = Railway.find_service(prod, name)
+                next unless pmatch
+                refs = (ssot_service(name) || {})["serviceRefs"] || []
+                refs.each do |ref|
+                    key    = ref["key"]
+                    target = ref["target"]
+                    next if key.nil? || target.nil?
+                    prod_host = ssot_target_host(target, "prod")
+                    if prod_host.nil?
+                        findings << "REFUSE: §5.2 (#{name}): serviceRef #{key} -> #{target} has no prod host in SSOT"
+                        next
+                    end
+                    actual = read_service_var(pmatch["service_id"], PRODUCTION_ENV_ID, key)
+                    if actual.nil?
+                        findings << "REFUSE: §5.2 (#{name}): prod #{key} is unset/unreadable " \
+                                    "(expected to point at #{target}'s prod host #{prod_host})"
+                        next
+                    end
+                    # Compare on HOST only — the env var may be a full URL.
+                    unless actual.to_s.include?(prod_host)
+                        findings << "REFUSE: §5.2 (#{name}): prod #{key}=#{actual.inspect} does NOT point at " \
+                                    "#{target}'s env-LOCAL prod host #{prod_host.inspect} " \
+                                    "(cross-env service-ref leak — the ms-agent-dotnet class)"
+                    end
+                end
+            end
+            findings
+        end
+
+        # §5.3.1 replicate-class env-write (NEW capability). For declared
+        # replicate keys ONLY, copy staging's VALUE -> prod via the
+        # variable*Upsert family (NOT serviceInstanceUpdate(source.image)),
+        # verified by re-read. The default replicate set is EMPTY — the
+        # mechanism is opt-in per key and fires for nothing today (R-A:
+        # replicating a misclassified prod-specific key would clobber prod).
+        def replicate_env_keys(staging, prod, replicate_keys: [])
+            findings = []
+            keys = (replicate_keys || []).uniq
+            return findings if keys.empty?
+            (staging["services"] || []).each do |svc|
+                name = svc["name"]
+                pmatch = Railway.find_service(prod, name)
+                next unless pmatch
+                keys.each do |key|
+                    staging_val = read_service_var(svc["service_id"], STAGING_ENV_ID, key)
+                    if staging_val.nil?
+                        findings << "WARN: §5.3.1 (#{name}): replicate key #{key} is unset/unreadable in staging; skipping"
+                        next
+                    end
+                    prod_val = read_service_var(pmatch["service_id"], PRODUCTION_ENV_ID, key)
+                    if prod_val == staging_val
+                        findings << "replicate §5.3.1 (#{name}): #{key} already in sync"
+                        next
+                    end
+                    if options[:dry_run]
+                        findings << "replicate §5.3.1 (#{name}): [dry-run] would upsert #{key} (staging->prod)"
+                        next
+                    end
+                    gql.query(VARIABLE_UPSERT_MUTATION,
+                        serviceId: pmatch["service_id"], envId: PRODUCTION_ENV_ID,
+                        name: key, value: staging_val)
+                    # Verify-by-re-read: the upsert must be observable on prod.
+                    reread = read_service_var(pmatch["service_id"], PRODUCTION_ENV_ID, key)
+                    if reread == staging_val
+                        findings << "replicate §5.3.1 (#{name}): upserted #{key} (staging->prod), re-read OK"
+                    else
+                        findings << "REFUSE: §5.3.1 (#{name}): re-read after upsert of #{key} " \
+                                    "did not observe staging value (got #{reread.inspect})"
+                    end
+                end
+            end
+            findings
+        end
+
+        # §5.3.2/§5.3.3 assert prod-specific keys present + prod-shaped (NEVER
+        # copy) and assert secret KEY presence (never value). A prod-specific
+        # key (e.g. a domain like NEXT_PUBLIC_POCKETBASE_URL) MUST be ASSERTED,
+        # never written — copying staging's value would point prod at staging's
+        # datastore (R-A, the highest-blast capability in this PR). This method
+        # issues NO mutations by construction.
+        def assert_prod_specific_keys(staging, prod, prod_specific_keys: [])
+            findings = []
+            keys = (prod_specific_keys || []).uniq
+            return findings if keys.empty?
+            (staging["services"] || []).each do |svc|
+                name = svc["name"]
+                pmatch = Railway.find_service(prod, name)
+                next unless pmatch
+                keys.each do |key|
+                    prod_val = read_service_var(pmatch["service_id"], PRODUCTION_ENV_ID, key)
+                    if prod_val.nil?
+                        findings << "REFUSE: §5.3.2 (#{name}): prod-specific key #{key} is missing in prod " \
+                                    "(assert-only; NEVER copied from staging)"
+                    end
+                end
+            end
+            findings
+        end
+
+        # §5.4 concurrency DETECT-and-WARN. Declared concurrency env vars (e.g.
+        # BROWSER_POOL_SIZE) join the existing WARN-class divergence set
+        # (region/replicas/restartPolicy already WARN in check_p6_parity).
+        # DETECT ONLY — never auto-set.
+        #
+        # NOTE: a limitOverride (CPU/memory cap) WARN was specified here but is
+        # NOT implementable: Railway's GraphQL schema exposes NO readable limit
+        # field on ServiceInstance (verified by introspection 2026-06 — the only
+        # related types are the write-only `serviceInstanceLimitsUpdate` mutation
+        # taking ServiceInstanceLimitsUpdateInput{memoryGB,vCPUs}; the
+        # ServiceInstanceLimit type is an opaque scalar with no readable fields).
+        # Because build_snapshot cannot capture the cap, a divergence comparison
+        # would always be nil==nil and the WARN could never fire — it was dead
+        # code masked by a hand-injected test fixture. Dropped rather than
+        # shipped dead. Re-add only if Railway adds a readable limit field to
+        # ServiceInstance (then wire it into SERVICE_INSTANCE_QUERY + the
+        # snapshot hash, and re-add a WARN here).
+        def check_resource_divergence(staging, prod)
+            findings = []
+            (staging["services"] || []).each do |svc|
+                name = svc["name"]
+                pmatch = Railway.find_service(prod, name)
+                next unless pmatch
+
+                # WARN — concurrency env-var key presence (e.g. BROWSER_POOL_SIZE).
+                staging_keys = svc["env_keys"] || []
+                prod_keys    = pmatch["env_keys"] || []
+                CONCURRENCY_ENV_KEYS.each do |ck|
+                    if staging_keys.include?(ck) != prod_keys.include?(ck)
+                        findings << "WARN: §5.4 (#{name}): concurrency env key #{ck} presence diverges " \
+                                    "(staging=#{staging_keys.include?(ck)} prod=#{prod_keys.include?(ck)}) " \
+                                    "[detect-only]"
+                    end
+                end
             end
             findings
         end

--- a/showcase/bin/spec/test_lint_prod_covers_starters.rb
+++ b/showcase/bin/spec/test_lint_prod_covers_starters.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+# bin/railway lint-prod — the starter-* fleet is UNDER the gate (S2).
+#
+# Background: S1 folded the 12 starter-<slug> services into the railway-envs
+# SSOT but kept them gate-INERT (gateIgnore:true / ciBuilt:false / probeDriver
+# "shell"), and verify-railway-image-refs.ts + this CLI's promote parity scope
+# carved them out as "decoupled / staging-only". S2 reverses that fence: the
+# starters are now full dual-env, gateValidated, ciBuilt SSOT entries that must
+# receive the SAME pinned-prod treatment as a showcase-* agent.
+#
+# lint-prod asserts every PROD service is pinned to an immutable @sha256
+# digest. It reads the FULL live prod snapshot with NO per-service skip, so its
+# coverage is exactly "every service live in prod". The point of S2 is that the
+# 12 starters — which ARE live in prod — are within that coverage: a starter
+# floating on a mutable :latest tag in prod is DRIFT and lint-prod must flag it.
+#
+# Red-green for THIS change:
+#   - The 12 starter names are derived from the SSOT (railway-envs.generated.json
+#     STARTER_PROD_SERVICES below) — under S1 the starters were modeled as
+#     staging-only / gate-exempt, so a "lint-prod covers starters" assertion had
+#     no SSOT basis (the prod set excluded them). After S2 the SSOT places all
+#     12 in prod, and lint-prod flags each mutable-tag starter as drift.
+#   - Regression: a digest-PINNED starter in prod is NOT flagged (the gate
+#     accepts the canonical shape), exactly like any showcase-* service.
+
+require_relative "spec_helper"
+require "stringio"
+
+class LintProdCoversStartersTest < Minitest::Test
+    # The 12 starter Railway service names, derived from the SSOT
+    # (railway-envs.generated.json) rather than re-hardcoded here, so this test
+    # moves with the SSOT and can never silently drift from it.
+    STARTER_PROD_SERVICES = Railway::SSOT_DATA
+        .fetch("services")
+        .select { |s| s.fetch("name").start_with?("starter-") }
+        .map { |s| s.fetch("name") }
+        .sort
+        .freeze
+
+    # A couple of showcase services kept in the fixture so the starter coverage
+    # is exercised ALONGSIDE the existing fleet (not in isolation).
+    SHOWCASE_SAMPLE = %w[showcase-mastra aimock].freeze
+
+    # Install a fake prod snapshot onto SnapshotCommand#build_snapshot for the
+    # duration of the block. LintProdCommand#run constructs its OWN
+    # SnapshotCommand internally, so we stub at the class level (the only seam),
+    # restoring the original method in `ensure`.
+    def with_prod_snapshot(services)
+        snapshot = { "services" => services }
+        original = Railway::SnapshotCommand.instance_method(:build_snapshot)
+        Railway::SnapshotCommand.send(:define_method, :build_snapshot) do |_env_id|
+            snapshot
+        end
+        yield
+    ensure
+        Railway::SnapshotCommand.send(:define_method, :build_snapshot, original)
+    end
+
+    def starter_svc(name, image:)
+        { "name" => name, "service_id" => "prod-#{name}", "image" => image }
+    end
+
+    # Red-green anchor (S2 source change, as Ruby sees it): the generated.json
+    # that bin/railway reads via SSOT_DATA now marks all 12 starters
+    # ciBuilt:true + gateValidated:true. Under S1 these were false (gate-inert);
+    # S2 flips them — this is the exact byte-level change lint-prod's "starters
+    # are gate-covered" guarantee rests on. RED before S2 (false), GREEN after.
+    def test_ssot_marks_all_starters_ci_built_and_gate_validated
+        starters = Railway::SSOT_DATA.fetch("services")
+            .select { |s| s.fetch("name").start_with?("starter-") }
+        assert_equal 12, starters.length
+
+        starters.each do |s|
+            name = s.fetch("name")
+            assert_equal true, s["ciBuilt"],
+                "#{name} must be ciBuilt (built by showcase_build.yml build-starters)"
+            assert_equal true, s["gateValidated"],
+                "#{name} must be gateValidated (image-ref gate validates its shape)"
+            assert_equal name, s["dispatchName"],
+                "#{name} dispatchName must equal its SSOT key (starter dispatch value)"
+            # No repoNameOverride: service name === GHCR repo name.
+            assert_nil s["repoNameOverride"],
+                "#{name} must carry no repoNameOverride (name === GHCR repo)"
+            assert_equal "starter", s.dig("probe", "driver"),
+                "#{name} probe driver must be the S3 'starter' axis contract"
+        end
+    end
+
+    # GREEN (post-S2): the 12 starters sit in prod on a mutable :latest tag.
+    # lint-prod must COVER them — i.e. flag every one as not-digest-pinned drift.
+    def test_lint_prod_flags_mutable_tag_starters_in_prod
+        # Sanity: the SSOT actually carries the full 12-starter prod fleet.
+        assert_equal 12, STARTER_PROD_SERVICES.length,
+            "expected 12 starter-* prod services in the SSOT; got " \
+            "#{STARTER_PROD_SERVICES.inspect}"
+
+        services =
+            SHOWCASE_SAMPLE.map { |n| starter_svc(n, image: "ghcr.io/copilotkit/#{n}@sha256:abc") } +
+            STARTER_PROD_SERVICES.map { |n| starter_svc(n, image: "ghcr.io/copilotkit/#{n}:latest") }
+
+        rc = nil
+        out = nil
+        with_prod_snapshot(services) do
+            cmd = Railway::LintProdCommand.new([])
+            out, _ = capture_io { rc = cmd.run }
+        end
+
+        refute_equal 0, rc,
+            "lint-prod must FAIL when prod starters float on :latest (they are " \
+            "now gate-covered); got rc=#{rc.inspect}\nout=#{out}"
+
+        # Every one of the 12 starters must be named in the drift report —
+        # proving lint-prod's coverage INCLUDES the starter fleet, not just the
+        # showcase services.
+        STARTER_PROD_SERVICES.each do |name|
+            assert_match(/#{Regexp.escape(name)}: not digest-pinned/, out,
+                "lint-prod must flag mutable-tag starter #{name} as drift")
+        end
+        assert_match(/DRIFT: 12 production service\(s\) not digest-pinned/, out,
+            "exactly the 12 starters should be flagged (showcase sample is pinned)")
+    end
+
+    # Regression: a digest-PINNED starter in prod is accepted, exactly like any
+    # showcase-* service. (Confirms the coverage is the CANONICAL shape check,
+    # not a blanket starter REFUSE.)
+    def test_lint_prod_accepts_digest_pinned_starters
+        services =
+            (SHOWCASE_SAMPLE + STARTER_PROD_SERVICES).map do |n|
+                starter_svc(n, image: "ghcr.io/copilotkit/#{n}@sha256:#{'a' * 64}")
+            end
+
+        rc = nil
+        out = nil
+        with_prod_snapshot(services) do
+            cmd = Railway::LintProdCommand.new([])
+            out, _ = capture_io { rc = cmd.run }
+        end
+
+        assert_equal 0, rc,
+            "lint-prod must PASS when every prod service (starters included) is " \
+            "digest-pinned; got rc=#{rc.inspect}\nout=#{out}"
+        assert_match(/OK: all production services digest-pinned/, out)
+    end
+end

--- a/showcase/bin/spec/test_promote_u5_env_serviceref.rb
+++ b/showcase/bin/spec/test_promote_u5_env_serviceref.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+# U5 (spec §5) — Ruby env + service-ref + resource preflight (Stage 2).
+#
+#   §5.2 service-ref assertion (REFUSE): each promote target carrying
+#        `serviceRefs` must have its prod env var (e.g. OPENAI_BASE_URL) point at
+#        the env-LOCAL target host (prod->prod aimock). A prod ref pointing at
+#        the STAGING target host => REFUSE (the ms-agent-dotnet class). ASSERT,
+#        never copy.
+#   §5.3.1 replicate-class env-write (NEW capability): for declared replicate
+#        keys, copy staging->prod value via the variable*Upsert family, verified
+#        by re-read. Default replicate set is EMPTY (opt-in per service); the
+#        MECHANISM + assertion path lands even with no opt-in keys.
+#   §5.3.2/5.3.3 assert prod-specific keys present + prod-shaped (NEVER copy);
+#        assert secret KEY presence (never value).
+#   §5.4 concurrency DETECT-and-WARN: concurrency env vars (e.g.
+#        BROWSER_POOL_SIZE) join the WARN-class divergence set
+#        (region/replicas/restartPolicy already WARN). DETECT ONLY — never set.
+#        (A limitOverride CPU/memory-cap WARN was dropped: Railway exposes no
+#        readable limit field on ServiceInstance, so it was unimplementable
+#        dead code — see test_snapshot_graphql.rb regression guard.)
+#
+# RISK R-A (HIGH — env clobber): a prod-specific key (e.g. a domain like
+# NEXT_PUBLIC_POCKETBASE_URL) must be ASSERTED, NEVER written/copied. The
+# fourth test below proves no upsert is issued for a prod-specific mismatch.
+class PromoteU5EnvServiceRefTest < Minitest::Test
+    # A fake gql that records every mutation issued and answers variable reads
+    # from an in-memory per-(serviceId,envId) value map. Tests seed values and
+    # assert on @mutations to prove "asserted, never copied".
+    class FakeGql
+        attr_reader :mutations
+
+        # values: { [service_id, env_id] => { "KEY" => "value", ... } }
+        def initialize(values: {})
+            @values = values
+            @mutations = []
+        end
+
+        def query(query, variables = {})
+            if query.include?("variableUpsert") || query.include?("variableCollectionUpsert")
+                @mutations << { kind: :upsert, variables: variables }
+                sid = variables[:serviceId] || variables["serviceId"]
+                eid = variables[:envId] || variables["environmentId"] || variables["envId"]
+                name = variables[:name] || variables["name"]
+                val  = variables[:value] || variables["value"]
+                (@values[[sid, eid]] ||= {})[name] = val if name
+                return { "variableUpsert" => true }
+            end
+
+            if query.include?("query EnvServiceVariables")
+                sid = variables[:serviceId] || variables["serviceId"]
+                eid = variables[:envId] || variables["environmentId"] || variables["envId"]
+                # Railway returns a flat JSON scalar map { "NAME" => "value" }.
+                return { "variables" => (@values[[sid, eid]] || {}) }
+            end
+
+            @mutations << { kind: :other, query: query, variables: variables }
+            {}
+        end
+    end
+
+    def cmd
+        c = Railway::PromoteCommand.new(["--non-interactive", "--yes"])
+        c.parser.parse!(c.argv)
+        c
+    end
+
+    PROD_ENV = Railway::PRODUCTION_ENV_ID
+    STG_ENV  = Railway::STAGING_ENV_ID
+
+    # ── §5.2 service-ref assertion (REFUSE) ─────────────────────────────────
+
+    def test_serviceref_prod_pointing_at_staging_aimock_refuses
+        # showcase-ag2 carries serviceRefs:[{key:OPENAI_BASE_URL,target:aimock}].
+        # aimock prod host = showcase-aimock-production.up.railway.app.
+        c = cmd
+        c.instance_variable_set(:@gql, FakeGql.new(values: {
+            ["ag2-prod", PROD_ENV] => {
+                # WRONG: prod points at the STAGING aimock host.
+                "OPENAI_BASE_URL" => "https://aimock-staging.up.railway.app",
+            },
+        }))
+        staging = { "services" => [{ "name" => "showcase-ag2", "service_id" => "ag2-stg" }] }
+        prod    = { "services" => [{ "name" => "showcase-ag2", "service_id" => "ag2-prod" }] }
+        findings = c.check_service_refs(staging, prod)
+        assert(findings.any? { |f| f.start_with?("REFUSE") && f =~ /OPENAI_BASE_URL/ },
+               "expected REFUSE for prod serviceRef pointing at staging host, got #{findings.inspect}")
+        assert(c.instance_variable_get(:@gql).mutations.none? { |m| m[:kind] == :upsert },
+               "service-ref check must ASSERT, never upsert")
+    end
+
+    def test_serviceref_prod_pointing_at_prod_aimock_passes
+        c = cmd
+        c.instance_variable_set(:@gql, FakeGql.new(values: {
+            ["ag2-prod", PROD_ENV] => {
+                "OPENAI_BASE_URL" => "https://showcase-aimock-production.up.railway.app",
+            },
+        }))
+        staging = { "services" => [{ "name" => "showcase-ag2", "service_id" => "ag2-stg" }] }
+        prod    = { "services" => [{ "name" => "showcase-ag2", "service_id" => "ag2-prod" }] }
+        findings = c.check_service_refs(staging, prod)
+        assert_empty findings.select { |f| f.start_with?("REFUSE") },
+                     "prod->prod aimock ref must not REFUSE, got #{findings.inspect}"
+    end
+
+    # ── §5.3.1 replicate-class env-write (NEW capability) ───────────────────
+
+    def test_replicate_key_value_diff_upserts_and_reread_green
+        # Inject a replicate set (default is EMPTY) so the mechanism is exercised.
+        c = cmd
+        fake = FakeGql.new(values: {
+            ["x-stg", STG_ENV]  => { "FEATURE_FLAG" => "on" },
+            ["x-prod", PROD_ENV] => { "FEATURE_FLAG" => "off" },
+        })
+        c.instance_variable_set(:@gql, fake)
+        staging = { "services" => [{ "name" => "x", "service_id" => "x-stg" }] }
+        prod    = { "services" => [{ "name" => "x", "service_id" => "x-prod" }] }
+        findings = c.replicate_env_keys(staging, prod, replicate_keys: %w[FEATURE_FLAG])
+        # mechanism issued the upsert to prod with staging's value
+        upserts = fake.mutations.select { |m| m[:kind] == :upsert }
+        assert_equal 1, upserts.size, "expected exactly one upsert, got #{fake.mutations.inspect}"
+        up = upserts.first[:variables]
+        assert_equal "FEATURE_FLAG", (up[:name] || up["name"])
+        assert_equal "on", (up[:value] || up["value"])
+        assert_equal PROD_ENV, (up[:envId] || up["environmentId"] || up["envId"])
+        # re-read confirms prod now carries staging's value (verified-by-re-read)
+        assert(findings.any? { |f| f =~ /replicat/i && f =~ /FEATURE_FLAG/ },
+               "expected a replicate report line, got #{findings.inspect}")
+        refute(findings.any? { |f| f.start_with?("REFUSE") }, "replicate must not REFUSE on success")
+    end
+
+    def test_default_replicate_set_is_empty_no_writes
+        c = cmd
+        fake = FakeGql.new(values: {
+            ["x-stg", STG_ENV]  => { "FEATURE_FLAG" => "on" },
+            ["x-prod", PROD_ENV] => { "FEATURE_FLAG" => "off" },
+        })
+        c.instance_variable_set(:@gql, fake)
+        staging = { "services" => [{ "name" => "x", "service_id" => "x-stg" }] }
+        prod    = { "services" => [{ "name" => "x", "service_id" => "x-prod" }] }
+        # default (no replicate_keys argument) => empty set => no writes
+        c.replicate_env_keys(staging, prod)
+        assert(fake.mutations.none? { |m| m[:kind] == :upsert },
+               "default replicate set must be EMPTY (no upserts), got #{fake.mutations.inspect}")
+    end
+
+    # ── R-A (HIGH): prod-specific key ASSERTED, NEVER written ───────────────
+
+    def test_prod_specific_key_mismatch_refuses_and_never_writes
+        c = cmd
+        fake = FakeGql.new(values: {
+            ["dash-stg", STG_ENV]  => { "NEXT_PUBLIC_POCKETBASE_URL" => "https://pb.staging.copilotkit.ai" },
+            # prod MISSING the prod-specific key entirely => mismatch.
+            ["dash-prod", PROD_ENV] => {},
+        })
+        c.instance_variable_set(:@gql, fake)
+        staging = { "services" => [{ "name" => "dashboard", "service_id" => "dash-stg" }] }
+        prod    = { "services" => [{ "name" => "dashboard", "service_id" => "dash-prod" }] }
+        findings = c.assert_prod_specific_keys(staging, prod, prod_specific_keys: %w[NEXT_PUBLIC_POCKETBASE_URL])
+        assert(findings.any? { |f| f.start_with?("REFUSE") && f =~ /NEXT_PUBLIC_POCKETBASE_URL/ },
+               "expected REFUSE for missing prod-specific key, got #{findings.inspect}")
+        # CRITICAL R-A: no upsert/write issued for the prod-specific key.
+        assert(fake.mutations.none? { |m| m[:kind] == :upsert },
+               "prod-specific key must be ASSERTED, NEVER copied/written, got #{fake.mutations.inspect}")
+    end
+
+    # ── §5.4 resource/concurrency DETECT-and-WARN (never REFUSE) ────────────
+
+    # NOTE: a limitOverride (CPU/memory cap) divergence WARN was originally
+    # specified for check_resource_divergence, but Railway's GraphQL schema
+    # exposes no readable limit field on ServiceInstance (verified by
+    # introspection — the only related surface is the write-only
+    # serviceInstanceLimitsUpdate mutation). build_snapshot therefore cannot
+    # capture the cap, so the WARN was dead code and has been dropped. See
+    # test_snapshot_graphql.rb#test_limit_override_warn_is_unimplementable_via_real_snapshot
+    # for the regression guard proving it through the real snapshot path.
+
+    def test_concurrency_env_divergence_warns_not_refuses
+        c = cmd
+        staging = { "services" => [svc("x", "x-stg", "env_keys" => %w[BROWSER_POOL_SIZE])] }
+        prod    = { "services" => [svc("x", "x-prod", "env_keys" => [])] }
+        findings = c.check_resource_divergence(staging, prod)
+        assert(findings.any? { |f| f.start_with?("WARN") && f =~ /BROWSER_POOL_SIZE/ },
+               "expected WARN for concurrency env divergence, got #{findings.inspect}")
+        assert(findings.none? { |f| f.start_with?("REFUSE") })
+    end
+
+    private
+
+    def svc(name, sid, over = {})
+        { "name" => name, "service_id" => sid }.merge(over)
+    end
+end

--- a/showcase/bin/spec/test_snapshot_graphql.rb
+++ b/showcase/bin/spec/test_snapshot_graphql.rb
@@ -82,6 +82,57 @@ class SnapshotGraphqlTest < Minitest::Test
         }
     end
 
+    def test_limit_override_warn_is_unimplementable_via_real_snapshot
+        # Regression guard for the DROPPED limitOverride WARN. A
+        # limitOverride (CPU/memory cap) divergence WARN was originally
+        # specified for check_resource_divergence, but it was dead code: it
+        # compared snapshot["limit_override"] values that build_snapshot never
+        # captures, because Railway's GraphQL ServiceInstance type exposes NO
+        # readable limit field (verified by introspection 2026-06 — the only
+        # related surface is the write-only serviceInstanceLimitsUpdate mutation
+        # taking ServiceInstanceLimitsUpdateInput{memoryGB,vCPUs}; the
+        # ServiceInstanceLimit type is an opaque scalar with no readable fields).
+        #
+        # This guard drives a divergence through the REAL capture path
+        # (build_snapshot) — even injecting a hypothetical limit into the fake
+        # serviceInstance response — and asserts: (a) build_snapshot drops it
+        # (no limit_override key survives), and (b) check_resource_divergence
+        # emits NO limitOverride WARN. If Railway ever adds a readable limit
+        # field and someone wires it through SERVICE_INSTANCE_QUERY + the
+        # snapshot hash, this guard flips and signals the WARN can be re-added.
+        build = lambda do |limit|
+            fake = FakeGQL.new(
+                "ProjectServices" => {
+                    "project" => { "id" => Railway::PROJECT_ID, "name" => "showcase",
+                        "services" => { "edges" => [{ "node" => { "id" => "svc-x", "name" => "x" } }] } },
+                },
+                "EnvVariables" => { "environment" => { "id" => "e", "name" => "n",
+                    "variables" => { "edges" => [] } } },
+                "ServiceInstance" => service_instance_response(
+                    image: "ghcr.io/copilotkit/x@sha256:cafef00d",
+                ).tap { |r| r["serviceInstance"]["serviceLimitOverride"] = limit },
+            )
+            cmd = Railway::SnapshotCommand.new(["--env", "production", "--dry-run"])
+            cmd.instance_variable_set(:@gql, fake)
+            cmd.build_snapshot(Railway::PRODUCTION_ENV_ID)
+        end
+        staging = build.call("memoryGB" => 4.0, "vCPUs" => 2.0)
+        prod    = build.call("memoryGB" => 1.0, "vCPUs" => 1.0)
+
+        # (a) the real snapshot path captures no limit field at all.
+        staging["services"].each { |s| assert_nil s["limit_override"] }
+        prod["services"].each    { |s| assert_nil s["limit_override"] }
+
+        # (b) consequently the dropped WARN cannot (and does not) fire.
+        c = Railway::PromoteCommand.new(["--non-interactive", "--yes"])
+        c.parser.parse!(c.argv)
+        findings = c.check_resource_divergence(staging, prod)
+        assert(findings.none? { |f| f =~ /limitOverride/i },
+            "limitOverride WARN was dropped as unimplementable dead code; it must " \
+            "not reappear unless build_snapshot genuinely captures a limit field — " \
+            "got #{findings.inspect}")
+    end
+
     def test_build_snapshot_uses_corrected_field_names_and_produces_pinned_entries
         fake = FakeGQL.new(
             "ProjectServices" => services_list_response,

--- a/showcase/bin/spec/test_snapshot_ivar_lint.rb
+++ b/showcase/bin/spec/test_snapshot_ivar_lint.rb
@@ -54,33 +54,33 @@ class SnapshotIvarLintTest < Minitest::Test
     #                       prose (do not perform a read)
     ALLOWED_LINES = [
         # `run` — capture full-fleet view before optional narrowing.
-        '1355:@full_staging_snapshot = @staging_snapshot',
-        '1356:@full_prod_snapshot    = @prod_snapshot',
+        '1392:@full_staging_snapshot = @staging_snapshot',
+        '1393:@full_prod_snapshot    = @prod_snapshot',
 
         # Doc comment above narrow_snapshots_to_single_service!.
-        '1364:# Narrow @staging_snapshot and @prod_snapshot to only the named',
+        '1401:# Narrow @staging_snapshot and @prod_snapshot to only the named',
 
         # narrow_snapshots_to_single_service! — the WRITE site.
-        '1372:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1377:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
-        '1378:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1379:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
+        '1409:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1414:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
+        '1415:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1416:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
 
         # Doc comment above capture_snapshots.
-        '1383:# @staging_snapshot / @prod_snapshot directly.',
+        '1420:# @staging_snapshot / @prod_snapshot directly.',
 
         # capture_snapshots — single test-seam assignment site.
-        '1385:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
-        '1386:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
+        '1422:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
+        '1423:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
 
         # Doc comment above the accessor block (explains test seam).
-        '1410:# promote tests stub @staging_snapshot/@prod_snapshot directly',
+        '1447:# promote tests stub @staging_snapshot/@prod_snapshot directly',
 
         # The four accessor bodies — the ONLY sanctioned reads.
-        '1422:@full_staging_snapshot || @staging_snapshot',
-        '1426:@full_prod_snapshot || @prod_snapshot',
-        '1430:@staging_snapshot',
-        '1434:@prod_snapshot',
+        '1459:@full_staging_snapshot || @staging_snapshot',
+        '1463:@full_prod_snapshot || @prod_snapshot',
+        '1467:@staging_snapshot',
+        '1471:@prod_snapshot',
     ].freeze
 
     def setup

--- a/showcase/harness/config/probes/cross-env-pin-drift.yml
+++ b/showcase/harness/config/probes/cross-env-pin-drift.yml
@@ -1,0 +1,53 @@
+# Probe: cross-env-pin-drift (plan U11 / spec §7.3)
+#
+# Weekly CROSS-ENV pin-drift check (U6's `pin_drift_cross_env` driver).
+# For each prod-pinned `showcase-*` service it reads BOTH envs' running
+# digests and asserts prod is RUNNING the digest it was LAST PROMOTED to
+# (its pinned `@sha256:` ref) AND that the digest is still present in GHCR
+# — distinct from `image-drift` (one env vs GHCR `:latest`), which the Ops
+# surface uses for STAGING only. The Ops surface routes PROD services HERE
+# (see src/probes/ops-drift-routing.ts) so pinned prod is VERIFIED, not
+# suppressed-to-green via image-drift's `pinnedExpected`.
+#
+# Discovery `cross-env-pin-drift` delegates the `showcase-*` roster + image
+# refs to railway-services, then stamps the prod/staging env-ids onto every
+# record. The driver itself runs the two-env project query.
+#
+# Schedule: Monday 10:00 UTC — same weekly cadence as the `pin-drift`
+# validate-pins ratchet (`pin-drift.yml`) and the weekly CI ratchet in
+# `.github/workflows/showcase_validate.yml`, so the in-cluster cross-env
+# tick lines up with the existing weekly drift cadence. timeout_ms is
+# generous enough for the two-env project query plus one GHCR manifest
+# GET per service on a cold TCP stack. max_concurrency=4 matches
+# image-drift's GHCR pool size.
+kind: pin_drift_cross_env
+id: pin-drift-cross-env-weekly
+schedule: "0 10 * * 1"
+timeout_ms: 30000
+max_concurrency: 4
+discovery:
+  source: cross-env-pin-drift
+  filter:
+    namePrefix: "showcase-"
+    nameExcludes:
+      # Decommissioned starters — Railway services stopped (PR #4390).
+      # Mirrors image-drift.yml's exclusion list (the cross-env probe
+      # enumerates the same railway-services roster).
+      - "showcase-starter-ag2"
+      - "showcase-starter-agno"
+      - "showcase-starter-claude-sdk-python"
+      - "showcase-starter-claude-sdk-typescript"
+      - "showcase-starter-crewai-crews"
+      - "showcase-starter-google-adk"
+      - "showcase-starter-langgraph-fastapi"
+      - "showcase-starter-langgraph-python"
+      - "showcase-starter-langgraph-typescript"
+      - "showcase-starter-langroid"
+      - "showcase-starter-llamaindex"
+      - "showcase-starter-mastra"
+      - "showcase-starter-ms-agent-dotnet"
+      - "showcase-starter-ms-agent-python"
+      - "showcase-starter-pydantic-ai"
+      - "showcase-starter-spring-ai"
+      - "showcase-starter-strands"
+  key_template: "pin_drift_cross_env:${name}"

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -2552,6 +2552,7 @@ describe("orchestrator.registerAllProbeDrivers (post-#4292 hotfix guard)", () =>
         "e2e_smoke",
         "image_drift",
         "pin_drift",
+        "pin_drift_cross_env",
         "qa",
         "redirect_decommission",
         "smoke",
@@ -4399,8 +4400,8 @@ describe("orchestrator runControlPlane REQ-B worker-self-report wiring (aggregat
 /**
  * In-process HTTP-only probe families on the fleet control-plane.
  *
- * The control-plane runs the 8 HTTP-only probe families (smoke, starter_smoke,
- * image_drift, qa, aimock_wiring, version_drift, pin_drift,
+ * The control-plane runs the 9 HTTP-only probe families (smoke, starter_smoke,
+ * image_drift, pin_drift_cross_env, qa, aimock_wiring, version_drift, pin_drift,
  * redirect_decommission) IN-PROCESS, alongside the d6 producer. These tests
  * pin that behavior:
  *
@@ -5224,7 +5225,7 @@ describe("orchestrator runControlPlane in-process HTTP probes", () => {
 // BROWSER_KINDS — or an HTTP driver whose kind overlaps a browser kind — would
 // silently drop a family from the in-process schedule.
 describe("orchestrator.registerHttpProbeDrivers / BROWSER_KINDS partition (drift-lock)", () => {
-  it("registers exactly the 8 HTTP-only kinds (no browser kinds)", async () => {
+  it("registers exactly the 9 HTTP-only kinds (no browser kinds)", async () => {
     const orchMod = await import("./orchestrator.js");
     const registry = createProbeRegistry();
     orchMod.registerHttpProbeDrivers(registry);
@@ -5234,6 +5235,9 @@ describe("orchestrator.registerHttpProbeDrivers / BROWSER_KINDS partition (drift
         "aimock_wiring",
         "image_drift",
         "pin_drift",
+        // U11: cross-env pin-drift is HTTP-only (Railway GraphQL + GHCR
+        // manifest GET; no browser), so it joins the control-plane HTTP set.
+        "pin_drift_cross_env",
         "qa",
         "redirect_decommission",
         "smoke",

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -40,6 +40,7 @@ import { aimockWiringDriver } from "./probes/drivers/aimock-wiring.js";
 import { pinDriftDriver } from "./probes/drivers/pin-drift.js";
 import { livenessDriver } from "./probes/drivers/d2-liveness.js";
 import { imageDriftDriver } from "./probes/drivers/image-drift.js";
+import { crossEnvPinDriftDriver } from "./probes/drivers/cross-env-pin-drift.js";
 import { versionDriftDriver } from "./probes/drivers/version-drift.js";
 import { redirectDecommissionDriver } from "./probes/drivers/redirect-decommission.js";
 import {
@@ -64,6 +65,7 @@ import { writeDiagEvent } from "./storage/diag-sink.js";
 import { qaDriver } from "./probes/drivers/qa.js";
 import { starterSmokeDriver } from "./probes/drivers/starter-smoke.js";
 import { railwayServicesSource } from "./probes/discovery/railway-services.js";
+import { crossEnvPinDriftDiscoverySource } from "./probes/discovery/cross-env-pin-drift-discovery.js";
 import { pnpmPackagesDiscoverySource } from "./probes/discovery/pnpm-packages.js";
 import { withCache } from "./probes/discovery/caching-source.js";
 import { DiscoveryAuthTracker } from "./probes/discovery/auth-tracker.js";
@@ -757,6 +759,12 @@ export async function boot(opts: BootOptions = {}): Promise<{
       authTracker,
     }),
   );
+  // Cross-env pin-drift discovery (U11): delegates the showcase-* roster to
+  // railway-services then stamps the prod/staging env-ids. Registered
+  // un-cached — its sole consumer is the weekly `pin_drift_cross_env` probe,
+  // so the per-tick re-enumeration cost is negligible and a stale cache
+  // would only hide a freshly-promoted digest.
+  discoveryRegistry.register(crossEnvPinDriftDiscoverySource);
   discoveryRegistry.register(pnpmPackagesDiscoverySource);
   const probeConfigDir =
     opts.configDir !== undefined
@@ -1422,6 +1430,7 @@ export function registerHttpProbeDrivers(
   // `"smoke"`) — there is no separate "smoke" driver export.
   probeRegistry.register(livenessDriver);
   probeRegistry.register(imageDriftDriver);
+  probeRegistry.register(crossEnvPinDriftDriver);
   probeRegistry.register(versionDriftDriver);
   probeRegistry.register(redirectDecommissionDriver);
   probeRegistry.register(qaDriver);
@@ -1597,6 +1606,7 @@ export function registerAllProbeDrivers(
   probeRegistry.register(pinDriftDriver);
   probeRegistry.register(livenessDriver);
   probeRegistry.register(imageDriftDriver);
+  probeRegistry.register(crossEnvPinDriftDriver);
   probeRegistry.register(versionDriftDriver);
   probeRegistry.register(redirectDecommissionDriver);
 
@@ -2905,7 +2915,7 @@ export async function runControlPlane(
 
   // ---- In-process HTTP-only probe families ----
   //
-  // The control-plane runs the 8 HTTP-only probe families IN-PROCESS by
+  // The control-plane runs the 9 HTTP-only probe families IN-PROCESS by
   // lifting the legacy boot() probe-loader machinery: an HTTP-only
   // `probeRegistry` (no browser drivers), a `createProbeLoader` scoped to the
   // HTTP `kind`s via `includeKind` (browser `e2e_*` YAMLs are SKIPPED, not

--- a/showcase/harness/src/probes/discovery/cross-env-pin-drift-discovery.test.ts
+++ b/showcase/harness/src/probes/discovery/cross-env-pin-drift-discovery.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  crossEnvPinDriftDiscoverySource,
+  imageRepoFromRef,
+} from "./cross-env-pin-drift-discovery.js";
+import { railwayServicesSource } from "./railway-services.js";
+import type { DiscoveryContext } from "../types.js";
+import type { Logger } from "../../types/index.js";
+
+const DEFAULT_PROD_ENV_ID = "b14919f4-6417-429f-848d-c6ae2201e04f";
+const DEFAULT_STAGING_ENV_ID = "8edfef02-ea09-4a20-8689-261f21cc2849";
+
+function noopLogger(): Logger {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+}
+
+function ctx(env: Record<string, string | undefined>): DiscoveryContext {
+  return {
+    fetchImpl: (() => {
+      throw new Error("fetch should not be called — railway path is mocked");
+    }) as unknown as typeof fetch,
+    logger: noopLogger(),
+    env,
+  };
+}
+
+describe("imageRepoFromRef — strip tag/digest to the bare GHCR repo", () => {
+  it("strips a :tag", () => {
+    expect(imageRepoFromRef("ghcr.io/copilotkit/showcase-x:latest")).toBe(
+      "ghcr.io/copilotkit/showcase-x",
+    );
+  });
+  it("strips an @sha256 digest", () => {
+    expect(imageRepoFromRef("ghcr.io/copilotkit/showcase-x@sha256:abc")).toBe(
+      "ghcr.io/copilotkit/showcase-x",
+    );
+  });
+  it("strips both tag and digest", () => {
+    expect(
+      imageRepoFromRef("ghcr.io/copilotkit/showcase-x:latest@sha256:abc"),
+    ).toBe("ghcr.io/copilotkit/showcase-x");
+  });
+  it("returns a bare repo unchanged", () => {
+    expect(imageRepoFromRef("ghcr.io/copilotkit/showcase-x")).toBe(
+      "ghcr.io/copilotkit/showcase-x",
+    );
+  });
+  it("returns empty string for an empty ref", () => {
+    expect(imageRepoFromRef("")).toBe("");
+  });
+});
+
+describe("crossEnvPinDriftDiscoverySource — stamps prod/staging env-ids per service", () => {
+  it("uses the SSOT default env-ids and derives imageRepo per service", async () => {
+    vi.spyOn(railwayServicesSource, "enumerate").mockResolvedValueOnce([
+      {
+        name: "showcase-langgraph-python",
+        imageRef: "ghcr.io/copilotkit/showcase-langgraph-python:latest",
+        publicUrl: "https://x",
+        env: {},
+        shape: "package",
+        deployedDigest: "",
+        demos: [],
+        notSupportedFeatures: [],
+        deployedAt: "",
+      },
+    ] as never);
+
+    const records = await crossEnvPinDriftDiscoverySource.enumerate(ctx({}), {
+      namePrefix: "showcase-",
+    });
+
+    expect(records).toEqual([
+      {
+        name: "showcase-langgraph-python",
+        imageRepo: "ghcr.io/copilotkit/showcase-langgraph-python",
+        prodEnvId: DEFAULT_PROD_ENV_ID,
+        stagingEnvId: DEFAULT_STAGING_ENV_ID,
+      },
+    ]);
+  });
+
+  it("honors RAILWAY_PROD/STAGING_ENVIRONMENT_ID overrides", async () => {
+    vi.spyOn(railwayServicesSource, "enumerate").mockResolvedValueOnce([
+      {
+        name: "showcase-x",
+        imageRef: "ghcr.io/copilotkit/showcase-x:latest",
+        publicUrl: "https://x",
+        env: {},
+        shape: "package",
+        deployedDigest: "",
+        demos: [],
+        notSupportedFeatures: [],
+        deployedAt: "",
+      },
+    ] as never);
+
+    const records = await crossEnvPinDriftDiscoverySource.enumerate(
+      ctx({
+        RAILWAY_PROD_ENVIRONMENT_ID: "prod-override",
+        RAILWAY_STAGING_ENVIRONMENT_ID: "staging-override",
+      }),
+      {},
+    );
+
+    expect(records[0]).toMatchObject({
+      name: "showcase-x",
+      prodEnvId: "prod-override",
+      stagingEnvId: "staging-override",
+    });
+  });
+
+  it("propagates a railway-services enumeration throw (single keyed error tile)", async () => {
+    vi.spyOn(railwayServicesSource, "enumerate").mockRejectedValueOnce(
+      new Error("railway down"),
+    );
+    await expect(
+      crossEnvPinDriftDiscoverySource.enumerate(ctx({}), {}),
+    ).rejects.toThrow("railway down");
+  });
+});

--- a/showcase/harness/src/probes/discovery/cross-env-pin-drift-discovery.ts
+++ b/showcase/harness/src/probes/discovery/cross-env-pin-drift-discovery.ts
@@ -1,0 +1,112 @@
+import { z } from "zod";
+import type { DiscoveryContext, DiscoverySource } from "../types.js";
+import { railwayServicesSource } from "./railway-services.js";
+
+/**
+ * Discovery source for the CROSS-ENV pin-drift probe (plan U11 / spec
+ * §7.3). Wiring layer between `railway-services` (which enumerates the
+ * `showcase-*` service roster for ONE env) and the `pin_drift_cross_env`
+ * driver (U6), which needs, per service:
+ *
+ *   - `name`        — the Railway service name (from railway-services).
+ *   - `imageRepo`   — the GHCR repo (no tag/digest) the pinned digest is
+ *                     looked up in; derived from the service's `imageRef`.
+ *   - `prodEnvId`   — the pinned side (asserted against).
+ *   - `stagingEnvId`— the floating side (reporting only; the driver reads
+ *                     it for the prod/staging digest pair in one signal).
+ *
+ * `railway-services` is SINGLE-ENV (`RAILWAY_ENVIRONMENT_ID` from
+ * ctx.env) — so we enumerate it ONCE to get the service roster + image
+ * refs, then stamp the prod/staging env-ids onto every record. The driver
+ * itself runs a two-env project query (it filters prod + staging
+ * client-side from the single project query), so no second discovery pass
+ * is needed here.
+ *
+ * `rootDir: src` forbids importing `showcase/scripts/railway-envs.ts`
+ * (the env-id SSOT), so the env-ids are read from `ctx.env` with the SSOT
+ * values mirrored as the default. The mirror is kept in lockstep with
+ * `showcase/scripts/railway-envs.ts` (PRODUCTION_ENV_ID / STAGING_ENV_ID);
+ * the env-var override (`RAILWAY_PROD_ENVIRONMENT_ID` /
+ * `RAILWAY_STAGING_ENVIRONMENT_ID`) lets staging/CI point at a different
+ * project without a code change.
+ */
+
+/**
+ * SSOT mirror of `showcase/scripts/railway-envs.ts` — kept in lockstep.
+ * `rootDir: src` forbids the cross-package import, so these are mirrored
+ * here and overridable via env so a non-prod project (CI) can re-point.
+ */
+const DEFAULT_PROD_ENV_ID = "b14919f4-6417-429f-848d-c6ae2201e04f";
+const DEFAULT_STAGING_ENV_ID = "8edfef02-ea09-4a20-8689-261f21cc2849";
+
+/**
+ * Filter block mirrors railway-services' (namePrefix + nameExcludes) since
+ * we delegate enumeration to it. `.passthrough()` so the YAML filter flows
+ * straight through to the delegate without re-declaring each field.
+ */
+const ConfigSchema = z
+  .object({
+    namePrefix: z.string().optional(),
+    nameExcludes: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+/** Per-service record handed to the `pin_drift_cross_env` driver. */
+export interface CrossEnvPinDriftRecord {
+  name: string;
+  imageRepo: string;
+  prodEnvId: string;
+  stagingEnvId: string;
+}
+
+/**
+ * Strip the `:tag` and/or `@sha256:…` suffix off an `imageRef` to get the
+ * bare GHCR repository (`ghcr.io/<org>/<name>`). Mirrors the right-to-left
+ * parse in `image-drift.ts:parseImageRef` (digest first, then the LAST `:`
+ * in the final path segment so a `registry:5000/...` port isn't mistaken
+ * for a tag). Returns "" for an empty ref so the driver surfaces a
+ * deterministic GHCR-lookup error rather than guessing a repo.
+ */
+export function imageRepoFromRef(imageRef: string): string {
+  if (!imageRef) return "";
+  const atIdx = imageRef.lastIndexOf("@");
+  const withoutDigest = atIdx !== -1 ? imageRef.slice(0, atIdx) : imageRef;
+  const slashIdx = withoutDigest.lastIndexOf("/");
+  const lastSegment =
+    slashIdx === -1 ? withoutDigest : withoutDigest.slice(slashIdx + 1);
+  const colonIdx = lastSegment.indexOf(":");
+  if (colonIdx === -1) return withoutDigest;
+  return (
+    (slashIdx === -1 ? "" : withoutDigest.slice(0, slashIdx + 1)) +
+    lastSegment.slice(0, colonIdx)
+  );
+}
+
+export const crossEnvPinDriftDiscoverySource: DiscoverySource<CrossEnvPinDriftRecord> =
+  {
+    name: "cross-env-pin-drift",
+    configSchema: ConfigSchema,
+    async enumerate(
+      ctx: DiscoveryContext,
+      rawConfig,
+    ): Promise<CrossEnvPinDriftRecord[]> {
+      const prodEnvId =
+        ctx.env.RAILWAY_PROD_ENVIRONMENT_ID ?? DEFAULT_PROD_ENV_ID;
+      const stagingEnvId =
+        ctx.env.RAILWAY_STAGING_ENVIRONMENT_ID ?? DEFAULT_STAGING_ENV_ID;
+
+      // Delegate the service-roster enumeration to railway-services (it
+      // already applies the namePrefix/nameExcludes filter, the
+      // LOCAL_SERVICES_JSON seam, and the auth/transport/schema error
+      // taxonomy). A throw here propagates to the invoker as a single
+      // keyed discovery-error tile — same as any other source.
+      const services = await railwayServicesSource.enumerate(ctx, rawConfig);
+
+      return services.map((svc) => ({
+        name: svc.name,
+        imageRepo: imageRepoFromRef(svc.imageRef),
+        prodEnvId,
+        stagingEnvId,
+      }));
+    },
+  };

--- a/showcase/harness/src/probes/drivers/cross-env-pin-drift.test.ts
+++ b/showcase/harness/src/probes/drivers/cross-env-pin-drift.test.ts
@@ -1,0 +1,535 @@
+import { describe, it, expect } from "vitest";
+import { crossEnvPinDriftDriver } from "./cross-env-pin-drift.js";
+import type { Logger, ProbeContext } from "../../types/index.js";
+
+// Driver-level tests for `crossEnvPinDriftDriver`. Unlike `image-drift`
+// (one env's running digest vs GHCR `:latest`) and `pin-drift` (the
+// validate-pins ratchet), this driver is CROSS-ENV: for each prod-pinned
+// service it reads
+//   - prod's PINNED ref            (serviceInstances[prod].source.image, `@sha256:…`)
+//   - prod's RUNNING digest        (serviceInstances[prod].latestDeployment.meta.imageDigest)
+//   - the GHCR presence of the pinned digest (manifest GET)
+//   - staging's running digest     (reporting only; the floating side)
+// and asserts prod is RUNNING what it was LAST PROMOTED to (pinned) AND
+// that the pinned digest is still present in GHCR — NOT "matches :latest".
+
+const PROD_ENV_ID = "b14919f4-6417-429f-848d-c6ae2201e04f";
+const STAGING_ENV_ID = "8edfef02-ea09-4a20-8689-261f21cc2849";
+
+const PINNED_DIGEST =
+  "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+const DRIFTED_DIGEST =
+  "sha256:2222222222222222222222222222222222222222222222222222222222222222";
+const STAGING_DIGEST =
+  "sha256:3333333333333333333333333333333333333333333333333333333333333333";
+
+function captureLogger(): {
+  logger: Logger;
+  warnCalls: { msg: string; meta?: Record<string, unknown> }[];
+  errorCalls: { msg: string; meta?: Record<string, unknown> }[];
+} {
+  const warnCalls: { msg: string; meta?: Record<string, unknown> }[] = [];
+  const errorCalls: { msg: string; meta?: Record<string, unknown> }[] = [];
+  const captured: Logger = {
+    debug: () => {},
+    info: () => {},
+    warn: (msg, meta) => warnCalls.push({ msg, meta }),
+    error: (msg, meta) => errorCalls.push({ msg, meta }),
+  };
+  return { logger: captured, warnCalls, errorCalls };
+}
+
+interface InstanceSpec {
+  environmentId: string;
+  image: string | null;
+  /** Running digest published in latestDeployment.meta.imageDigest. */
+  runningDigest?: string | null;
+}
+
+/**
+ * Build a Railway project GraphQL response carrying one service with the
+ * supplied per-env instances. Mirrors the shape `railway-services`
+ * discovery parses (`project.services.edges[].node.serviceInstances`).
+ */
+function railwayProjectResponse(
+  serviceName: string,
+  instances: InstanceSpec[],
+) {
+  return {
+    data: {
+      project: {
+        services: {
+          edges: [
+            {
+              node: {
+                id: "svc-1",
+                name: serviceName,
+                serviceInstances: {
+                  edges: instances.map((inst) => ({
+                    node: {
+                      environmentId: inst.environmentId,
+                      source: { image: inst.image },
+                      domains: { serviceDomains: [] },
+                      latestDeployment:
+                        inst.runningDigest === undefined
+                          ? null
+                          : {
+                              meta:
+                                inst.runningDigest === null
+                                  ? null
+                                  : { imageDigest: inst.runningDigest },
+                            },
+                    },
+                  })),
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+interface ResponseSpec {
+  status: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+  throws?: Error;
+}
+
+/**
+ * Scripted fetch: serves Railway (POST) and GHCR (GET) round-trips from a
+ * queue in order. Queue exhaustion throws so a test asking for more
+ * round-trips than scripted fails loud. Records both the request URLs AND
+ * the per-call `init` (so tests can assert on the headers the driver
+ * attaches, e.g. the GHCR `Authorization` bearer).
+ */
+function scriptedFetch(queue: ResponseSpec[]): {
+  fetchImpl: typeof fetch;
+  urls: string[];
+  inits: (RequestInit | undefined)[];
+} {
+  const urls: string[] = [];
+  const inits: (RequestInit | undefined)[] = [];
+  let idx = 0;
+  const fetchImpl: typeof fetch = async (url, init) => {
+    urls.push(typeof url === "string" ? url : url.toString());
+    inits.push(init);
+    const entry = queue[idx++];
+    if (!entry) throw new Error("scriptedFetch: queue exhausted");
+    if (entry.throws) throw entry.throws;
+    const body =
+      typeof entry.body === "string"
+        ? entry.body
+        : JSON.stringify(entry.body ?? {});
+    return new Response(body, {
+      status: entry.status,
+      headers: entry.headers ?? { "content-type": "application/json" },
+    });
+  };
+  return { fetchImpl, urls, inits };
+}
+
+/**
+ * Read a single header value off a recorded `init.headers` regardless of
+ * the shape the caller used (plain record, array of tuples, or `Headers`).
+ * Returns undefined when the header is absent.
+ */
+function headerValue(
+  init: RequestInit | undefined,
+  name: string,
+): string | undefined {
+  const h = init?.headers;
+  if (!h) return undefined;
+  if (h instanceof Headers) return h.get(name) ?? undefined;
+  if (Array.isArray(h)) {
+    const match = h.find(([k]) => k.toLowerCase() === name.toLowerCase());
+    return match?.[1];
+  }
+  const rec = h as Record<string, string>;
+  const key = Object.keys(rec).find(
+    (k) => k.toLowerCase() === name.toLowerCase(),
+  );
+  return key ? rec[key] : undefined;
+}
+
+function makeCtx(
+  fetchImpl: typeof fetch,
+  loggerOverride?: Logger,
+  envOverride?: Record<string, string | undefined>,
+): ProbeContext & { fetchImpl: typeof fetch } {
+  return {
+    now: () => new Date("2026-06-19T00:00:00Z"),
+    logger: loggerOverride ?? captureLogger().logger,
+    env: envOverride ?? {
+      RAILWAY_TOKEN: "rwtok",
+      RAILWAY_PROJECT_ID: "proj-1",
+    },
+    fetchImpl,
+  } as ProbeContext & { fetchImpl: typeof fetch };
+}
+
+function ghcrPresent(digest: string): ResponseSpec {
+  return {
+    status: 200,
+    headers: {
+      "docker-content-digest": digest,
+      "content-type": "application/vnd.oci.image.manifest.v1+json",
+    },
+  };
+}
+
+const baseInput = {
+  key: "pin_drift_cross_env:showcase-langgraph-python",
+  name: "showcase-langgraph-python",
+  imageRepo: "ghcr.io/copilotkit/showcase-langgraph-python",
+  prodEnvId: PROD_ENV_ID,
+  stagingEnvId: STAGING_ENV_ID,
+};
+
+describe("crossEnvPinDriftDriver", () => {
+  it("exposes a stable kind string", () => {
+    expect(typeof crossEnvPinDriftDriver.kind).toBe("string");
+    expect(crossEnvPinDriftDriver.kind.length).toBeGreaterThan(0);
+  });
+
+  it("inputSchema requires key, name, imageRepo, and prodEnvId", () => {
+    expect(
+      crossEnvPinDriftDriver.inputSchema.safeParse(baseInput).success,
+    ).toBe(true);
+    expect(
+      crossEnvPinDriftDriver.inputSchema.safeParse({
+        key: baseInput.key,
+        name: baseInput.name,
+        imageRepo: baseInput.imageRepo,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("GREEN: prod running digest equals last-promoted (pinned) digest and digest present in GHCR", async () => {
+    const { fetchImpl } = scriptedFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse(baseInput.name, [
+          {
+            environmentId: PROD_ENV_ID,
+            image: `${baseInput.imageRepo}@${PINNED_DIGEST}`,
+            runningDigest: PINNED_DIGEST,
+          },
+          {
+            environmentId: STAGING_ENV_ID,
+            image: `${baseInput.imageRepo}:latest`,
+            runningDigest: STAGING_DIGEST,
+          },
+        ]),
+      },
+      ghcrPresent(PINNED_DIGEST),
+    ]);
+    const ctx = makeCtx(fetchImpl);
+    const r = await crossEnvPinDriftDriver.run(ctx, baseInput);
+    expect(r.state).toBe("green");
+    expect(r.key).toBe(baseInput.key);
+    const signal = r.signal as Record<string, unknown>;
+    expect(signal.status).toBe("stable");
+    expect(signal.prodPinnedDigest).toBe(PINNED_DIGEST);
+    expect(signal.prodRunningDigest).toBe(PINNED_DIGEST);
+    expect(signal.stagingRunningDigest).toBe(STAGING_DIGEST);
+    expect(signal.ghcrPresent).toBe(true);
+  });
+
+  it("RED (regressed): prod running digest drifted off the pinned/last-promoted digest", async () => {
+    const { fetchImpl } = scriptedFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse(baseInput.name, [
+          {
+            environmentId: PROD_ENV_ID,
+            image: `${baseInput.imageRepo}@${PINNED_DIGEST}`,
+            runningDigest: DRIFTED_DIGEST,
+          },
+          {
+            environmentId: STAGING_ENV_ID,
+            image: `${baseInput.imageRepo}:latest`,
+            runningDigest: STAGING_DIGEST,
+          },
+        ]),
+      },
+      ghcrPresent(PINNED_DIGEST),
+    ]);
+    const ctx = makeCtx(fetchImpl);
+    const r = await crossEnvPinDriftDriver.run(ctx, baseInput);
+    expect(r.state).toBe("red");
+    const signal = r.signal as Record<string, unknown>;
+    expect(signal.status).toBe("regressed");
+    expect(signal.prodPinnedDigest).toBe(PINNED_DIGEST);
+    expect(signal.prodRunningDigest).toBe(DRIFTED_DIGEST);
+  });
+
+  it("RED (alarm): the last-promoted (pinned) digest has been GC'd from GHCR", async () => {
+    const { fetchImpl } = scriptedFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse(baseInput.name, [
+          {
+            environmentId: PROD_ENV_ID,
+            image: `${baseInput.imageRepo}@${PINNED_DIGEST}`,
+            runningDigest: PINNED_DIGEST,
+          },
+          {
+            environmentId: STAGING_ENV_ID,
+            image: `${baseInput.imageRepo}:latest`,
+            runningDigest: STAGING_DIGEST,
+          },
+        ]),
+      },
+      // GHCR 404 — the pinned digest was garbage-collected.
+      { status: 404, body: { errors: [{ code: "MANIFEST_UNKNOWN" }] } },
+    ]);
+    const ctx = makeCtx(fetchImpl);
+    const r = await crossEnvPinDriftDriver.run(ctx, baseInput);
+    expect(r.state).toBe("red");
+    const signal = r.signal as Record<string, unknown>;
+    expect(signal.status).toBe("ghcr-missing");
+    expect(signal.ghcrPresent).toBe(false);
+  });
+
+  it("RED: prod instance is not pinned (still on :latest)", async () => {
+    const { fetchImpl } = scriptedFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse(baseInput.name, [
+          {
+            environmentId: PROD_ENV_ID,
+            image: `${baseInput.imageRepo}:latest`,
+            runningDigest: PINNED_DIGEST,
+          },
+        ]),
+      },
+    ]);
+    const ctx = makeCtx(fetchImpl);
+    const r = await crossEnvPinDriftDriver.run(ctx, baseInput);
+    expect(r.state).toBe("red");
+    const signal = r.signal as Record<string, unknown>;
+    expect(signal.status).toBe("unpinned");
+  });
+
+  it("error: prod service has no instance in the prod env", async () => {
+    const { fetchImpl } = scriptedFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse(baseInput.name, [
+          {
+            environmentId: STAGING_ENV_ID,
+            image: `${baseInput.imageRepo}:latest`,
+            runningDigest: STAGING_DIGEST,
+          },
+        ]),
+      },
+    ]);
+    const ctx = makeCtx(fetchImpl);
+    const r = await crossEnvPinDriftDriver.run(ctx, baseInput);
+    expect(r.state).toBe("error");
+    const signal = r.signal as Record<string, unknown>;
+    expect(typeof signal.errorDesc).toBe("string");
+  });
+
+  it("error: Railway auth failure surfaces as a keyed error result", async () => {
+    const { fetchImpl } = scriptedFetch([
+      { status: 401, body: "unauthorized" },
+    ]);
+    const ctx = makeCtx(fetchImpl);
+    const r = await crossEnvPinDriftDriver.run(ctx, baseInput);
+    expect(r.state).toBe("error");
+    const signal = r.signal as Record<string, unknown>;
+    expect(typeof signal.errorDesc).toBe("string");
+  });
+
+  it("error: missing Railway credentials in env", async () => {
+    const { fetchImpl } = scriptedFetch([]);
+    const ctx = makeCtx(fetchImpl, undefined, {});
+    const r = await crossEnvPinDriftDriver.run(ctx, baseInput);
+    expect(r.state).toBe("error");
+  });
+
+  it("error: Railway returns project: null", async () => {
+    const { fetchImpl } = scriptedFetch([
+      { status: 200, body: { data: { project: null } } },
+    ]);
+    const ctx = makeCtx(fetchImpl);
+    const r = await crossEnvPinDriftDriver.run(ctx, baseInput);
+    expect(r.state).toBe("error");
+    const signal = r.signal as Record<string, unknown>;
+    expect(String(signal.errorDesc)).toContain("returned null");
+  });
+
+  it("error: Railway response fails the project schema", async () => {
+    const { fetchImpl } = scriptedFetch([
+      { status: 200, body: { data: { project: { services: "nope" } } } },
+    ]);
+    const ctx = makeCtx(fetchImpl);
+    const r = await crossEnvPinDriftDriver.run(ctx, baseInput);
+    expect(r.state).toBe("error");
+    const signal = r.signal as Record<string, unknown>;
+    expect(String(signal.errorDesc)).toContain("did not match expected shape");
+  });
+
+  it("error: requested service is absent from the railway project", async () => {
+    const { fetchImpl } = scriptedFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse("showcase-some-other-service", [
+          {
+            environmentId: PROD_ENV_ID,
+            image: `${baseInput.imageRepo}@${PINNED_DIGEST}`,
+            runningDigest: PINNED_DIGEST,
+          },
+        ]),
+      },
+    ]);
+    const ctx = makeCtx(fetchImpl);
+    const r = await crossEnvPinDriftDriver.run(ctx, baseInput);
+    expect(r.state).toBe("error");
+    const signal = r.signal as Record<string, unknown>;
+    expect(String(signal.errorDesc)).toContain("not found");
+  });
+
+  it("GREEN with no staging env id: staging digest reported as empty", async () => {
+    const { fetchImpl } = scriptedFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse(baseInput.name, [
+          {
+            environmentId: PROD_ENV_ID,
+            image: `${baseInput.imageRepo}@${PINNED_DIGEST}`,
+            runningDigest: PINNED_DIGEST,
+          },
+        ]),
+      },
+      ghcrPresent(PINNED_DIGEST),
+    ]);
+    const ctx = makeCtx(fetchImpl);
+    const { stagingEnvId: _omit, ...prodOnlyInput } = baseInput;
+    const r = await crossEnvPinDriftDriver.run(ctx, prodOnlyInput);
+    expect(r.state).toBe("green");
+    const signal = r.signal as Record<string, unknown>;
+    expect(signal.stagingRunningDigest).toBe("");
+  });
+
+  it("error: GHCR returns 401 auth failure on the pinned-digest lookup", async () => {
+    const { fetchImpl } = scriptedFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse(baseInput.name, [
+          {
+            environmentId: PROD_ENV_ID,
+            image: `${baseInput.imageRepo}@${PINNED_DIGEST}`,
+            runningDigest: PINNED_DIGEST,
+          },
+        ]),
+      },
+      { status: 401, body: "unauthorized" },
+    ]);
+    const ctx = makeCtx(fetchImpl);
+    const r = await crossEnvPinDriftDriver.run(ctx, baseInput);
+    expect(r.state).toBe("error");
+    const signal = r.signal as Record<string, unknown>;
+    expect(String(signal.errorDesc)).toContain("ghcr lookup failed");
+  });
+
+  it("error: GHCR returns a 500 on the pinned-digest lookup", async () => {
+    const { fetchImpl } = scriptedFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse(baseInput.name, [
+          {
+            environmentId: PROD_ENV_ID,
+            image: `${baseInput.imageRepo}@${PINNED_DIGEST}`,
+            runningDigest: PINNED_DIGEST,
+          },
+        ]),
+      },
+      { status: 500, body: "boom" },
+    ]);
+    const ctx = makeCtx(fetchImpl);
+    const r = await crossEnvPinDriftDriver.run(ctx, baseInput);
+    expect(r.state).toBe("error");
+    const signal = r.signal as Record<string, unknown>;
+    expect(String(signal.errorDesc)).toContain("ghcr manifest lookup 500");
+  });
+
+  it("error: GHCR fetch throws (transport failure) on the pinned-digest lookup", async () => {
+    const { fetchImpl } = scriptedFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse(baseInput.name, [
+          {
+            environmentId: PROD_ENV_ID,
+            image: `${baseInput.imageRepo}@${PINNED_DIGEST}`,
+            runningDigest: PINNED_DIGEST,
+          },
+        ]),
+      },
+      { status: 0, throws: new Error("ECONNREFUSED") },
+    ]);
+    const ctx = makeCtx(fetchImpl);
+    const r = await crossEnvPinDriftDriver.run(ctx, baseInput);
+    expect(r.state).toBe("error");
+    const signal = r.signal as Record<string, unknown>;
+    expect(String(signal.errorDesc)).toContain("ghcr fetch failed");
+  });
+
+  it("attaches GHCR Authorization header when GHCR_TOKEN is present", async () => {
+    const { fetchImpl, urls, inits } = scriptedFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse(baseInput.name, [
+          {
+            environmentId: PROD_ENV_ID,
+            image: `${baseInput.imageRepo}@${PINNED_DIGEST}`,
+            runningDigest: PINNED_DIGEST,
+          },
+        ]),
+      },
+      ghcrPresent(PINNED_DIGEST),
+    ]);
+    const ctx = makeCtx(fetchImpl, undefined, {
+      RAILWAY_TOKEN: "rwtok",
+      RAILWAY_PROJECT_ID: "proj-1",
+      GHCR_TOKEN: "ghp_test",
+    });
+    const r = await crossEnvPinDriftDriver.run(ctx, baseInput);
+    expect(r.state).toBe("green");
+    // The second round-trip targets the GHCR manifest endpoint for the
+    // pinned digest.
+    expect(urls[1]).toContain(
+      "ghcr.io/v2/copilotkit/showcase-langgraph-python",
+    );
+    expect(urls[1]).toContain(encodeURIComponent(PINNED_DIGEST));
+    // …and it MUST carry the GHCR bearer derived from GHCR_TOKEN. This is
+    // the load-bearing assertion: if the driver ever drops the header the
+    // test fails (the URL alone can't catch that regression).
+    expect(headerValue(inits[1], "Authorization")).toBe("Bearer ghp_test");
+  });
+
+  it("omits the GHCR Authorization header when GHCR_TOKEN is absent", async () => {
+    const { fetchImpl, inits } = scriptedFetch([
+      {
+        status: 200,
+        body: railwayProjectResponse(baseInput.name, [
+          {
+            environmentId: PROD_ENV_ID,
+            image: `${baseInput.imageRepo}@${PINNED_DIGEST}`,
+            runningDigest: PINNED_DIGEST,
+          },
+        ]),
+      },
+      ghcrPresent(PINNED_DIGEST),
+    ]);
+    // makeCtx's default env has no GHCR_TOKEN.
+    const ctx = makeCtx(fetchImpl);
+    const r = await crossEnvPinDriftDriver.run(ctx, baseInput);
+    expect(r.state).toBe("green");
+    expect(headerValue(inits[1], "Authorization")).toBeUndefined();
+  });
+});

--- a/showcase/harness/src/probes/drivers/cross-env-pin-drift.ts
+++ b/showcase/harness/src/probes/drivers/cross-env-pin-drift.ts
@@ -1,0 +1,455 @@
+import { z } from "zod";
+import type { ProbeDriver } from "../types.js";
+import type { ProbeResult } from "../../types/index.js";
+import { makeGql } from "../discovery/railway-services.js";
+import {
+  DiscoverySourceAuthError,
+  DiscoverySourceBackendError,
+  DiscoverySourceTransportError,
+} from "../discovery/errors.js";
+
+/**
+ * CROSS-ENV pin-drift driver.
+ *
+ * This is the genuinely-new prod drift signal, distinct from the two
+ * pre-existing probes it is frequently confused with:
+ *
+ *   - `pin-drift-core.ts` / `drivers/pin-drift.ts` is the validate-pins
+ *     RATCHET — a fail-baseline hash comparison of the source-tree pin
+ *     set. It is NOT cross-environment and never reads a running deploy.
+ *   - `drivers/image-drift.ts` compares ONE env's running digest against
+ *     the GHCR `:latest` tag. The merged false-red fix there only
+ *     SUPPRESSED reds on pinned prod (`pinnedExpected`) — it does NOT
+ *     verify prod is running what it was promoted to.
+ *
+ * The real prod drift question is CROSS-ENV: for each prod-pinned
+ * service, is prod actually RUNNING the digest it was LAST PROMOTED to,
+ * and is that digest still present in the registry? Under the
+ * pinned-prod / floating-staging contract, prod's `source.image` is an
+ * immutable `@sha256:<digest>` ref (set by `bin/railway promote`) — that
+ * IS the last-promoted digest. So this driver, per service:
+ *
+ *   1. Reads prod's PINNED ref from `serviceInstances[prod].source.image`
+ *      (the last-promoted digest) and asserts it carries an `@sha256:`.
+ *      An unpinned prod (`:latest`) is `status: "unpinned"` → red.
+ *   2. Reads prod's RUNNING digest from
+ *      `serviceInstances[prod].latestDeployment.meta.imageDigest` and
+ *      asserts it equals the pinned digest. A mismatch means prod is
+ *      running something other than what it was promoted to →
+ *      `status: "regressed"` → red. (Distinct from image-drift's
+ *      "behind :latest", which is EXPECTED on pinned prod.)
+ *   3. GETs the pinned digest manifest from GHCR and asserts it is still
+ *      present. A garbage-collected last-promoted digest means prod
+ *      cannot be re-pulled / rolled forward cleanly →
+ *      `status: "ghcr-missing"` → red (alarm).
+ *
+ * Staging's running digest is read for REPORTING ONLY (the floating
+ * side) — it never drives the assertion. Surfacing it lets operators see
+ * the prod/staging digest pair in one signal.
+ *
+ * Cross-package note: `tsc rootDir: src` forbids importing
+ * `showcase/scripts/*`, so the Railway GraphQL plumbing is reused from
+ * the SAME package (`discovery/railway-services.ts`'s exported `makeGql`)
+ * rather than from the scripts tree. The two-env read is the project
+ * query (which already returns every env's instances) filtered to the
+ * prod + staging env-ids supplied per input — no second round-trip and
+ * no second discovery pass.
+ */
+
+/** Probe `kind` literal. Wiring onto the schedule/Ops surface is U11. */
+export const CROSS_ENV_PIN_DRIFT_KIND = "pin_drift_cross_env";
+
+const crossEnvPinDriftInputSchema = z.object({
+  /** Probe row key, e.g. `pin_drift_cross_env:showcase-langgraph-python`. */
+  key: z.string().min(1),
+  /** Railway service name (matches `railway-services` discovery `name`). */
+  name: z.string().min(1),
+  /**
+   * GHCR repository for the service image, e.g.
+   * `ghcr.io/copilotkit/showcase-langgraph-python`. Used to look up the
+   * pinned digest's manifest. Supplied by the wiring layer rather than
+   * parsed from the prod ref so a malformed prod ref still produces a
+   * deterministic GHCR lookup target for the error message.
+   */
+  imageRepo: z.string().min(1),
+  /** Railway production environment id (the pinned side). */
+  prodEnvId: z.string().min(1),
+  /**
+   * Railway staging environment id (the floating side). Optional —
+   * staging is reporting-only and absent on prod-only services.
+   */
+  stagingEnvId: z.string().min(1).optional(),
+});
+
+type CrossEnvPinDriftInput = z.infer<typeof crossEnvPinDriftInputSchema>;
+
+export type CrossEnvPinDriftStatus =
+  | "stable"
+  | "regressed"
+  | "unpinned"
+  | "ghcr-missing";
+
+/**
+ * Discriminated-union signal — success carries the full digest tuple +
+ * status; error carries only `errorDesc`. Callers discriminate on the
+ * presence of `errorDesc`.
+ */
+export type CrossEnvPinDriftSignal =
+  | {
+      service: string;
+      status: CrossEnvPinDriftStatus;
+      /** Last-promoted (pinned) digest from prod `source.image`. Empty when unpinned. */
+      prodPinnedDigest: string;
+      /** Running digest from prod `latestDeployment.meta.imageDigest`. */
+      prodRunningDigest: string;
+      /** Running digest on staging (reporting only). Empty when staging absent / undeployed. */
+      stagingRunningDigest: string;
+      /** Whether the pinned digest is still present in GHCR. */
+      ghcrPresent: boolean;
+      errorDesc?: undefined;
+    }
+  | { errorDesc: string };
+
+interface InstanceView {
+  pinnedDigest: string;
+  runningDigest: string;
+  rawImage: string;
+}
+
+// GraphQL response shape (subset of the project query). Kept minimal —
+// only the fields this driver reads.
+const ProjectSchema = z.object({
+  project: z
+    .object({
+      services: z.object({
+        edges: z.array(
+          z.object({
+            node: z.object({
+              name: z.string(),
+              serviceInstances: z.object({
+                edges: z.array(
+                  z.object({
+                    node: z.object({
+                      environmentId: z.string(),
+                      source: z
+                        .object({ image: z.string().nullable() })
+                        .nullable(),
+                      latestDeployment: z
+                        .object({
+                          meta: z.record(z.unknown()).nullable().optional(),
+                        })
+                        .nullable()
+                        .optional(),
+                    }),
+                  }),
+                ),
+              }),
+            }),
+          }),
+        ),
+      }),
+    })
+    .nullable(),
+});
+
+/**
+ * Parse a service-instance node into pinned + running digests. The
+ * pinned digest is the `@sha256:…` from `source.image` (empty when the
+ * ref is tag-only / unpinned); the running digest is
+ * `latestDeployment.meta.imageDigest`.
+ */
+function readInstance(node: {
+  source: { image: string | null } | null;
+  latestDeployment?: { meta?: Record<string, unknown> | null } | null;
+}): InstanceView {
+  const rawImage = node.source?.image ?? "";
+  const atIdx = rawImage.lastIndexOf("@");
+  const pinnedDigest = atIdx !== -1 ? rawImage.slice(atIdx + 1) : "";
+  const rawRunning = node.latestDeployment?.meta?.["imageDigest"];
+  const runningDigest = typeof rawRunning === "string" ? rawRunning : "";
+  return { pinnedDigest, runningDigest, rawImage };
+}
+
+export const crossEnvPinDriftDriver: ProbeDriver<
+  CrossEnvPinDriftInput,
+  CrossEnvPinDriftSignal
+> = {
+  kind: CROSS_ENV_PIN_DRIFT_KIND,
+  inputSchema: crossEnvPinDriftInputSchema,
+  async run(ctx, input): Promise<ProbeResult<CrossEnvPinDriftSignal>> {
+    const observedAt = ctx.now().toISOString();
+    const error = (errorDesc: string): ProbeResult<CrossEnvPinDriftSignal> => ({
+      key: input.key,
+      state: "error",
+      signal: { errorDesc },
+      observedAt,
+    });
+
+    const token = ctx.env.RAILWAY_TOKEN;
+    const projectId = ctx.env.RAILWAY_PROJECT_ID;
+    if (!token || !projectId) {
+      ctx.logger.warn("driver.cross-env-pin-drift.missing-creds", {
+        service: input.name,
+      });
+      return error(
+        "RAILWAY_TOKEN and RAILWAY_PROJECT_ID must both be set for the cross-env pin-drift probe",
+      );
+    }
+
+    const fetchImpl = ctx.fetchImpl ?? globalThis.fetch;
+    const gql = makeGql({
+      fetchImpl,
+      token,
+      sourceName: "cross-env-pin-drift",
+      abortSignal: ctx.abortSignal,
+      logger: ctx.logger,
+    });
+
+    // Single project query returning every env's instances; we filter to
+    // prod + staging client-side (same pattern as railway-services).
+    let projectData: unknown;
+    try {
+      const result = await gql<unknown>(
+        `query crossEnvPinDrift($id: String!) {
+          project(id: $id) {
+            services {
+              edges { node {
+                name
+                serviceInstances {
+                  edges { node {
+                    environmentId
+                    source { image }
+                    latestDeployment { meta }
+                  } }
+                }
+              } }
+            }
+          }
+        }`,
+        { id: projectId },
+      );
+      projectData = result.data;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // `makeGql` throws the discovery error taxonomy
+      // (DiscoverySource{Auth,Transport,Backend,Schema}Error) on
+      // auth/transport/HTTP/body faults, plus a bare Error on anything
+      // unforeseen. All of them collapse to one keyed `state:"error"`
+      // result so a Railway fault is a single actionable line in the
+      // writer log rather than an uncaught crash that takes down the
+      // probe tick. `errClass` records WHICH taxonomy class fired so an
+      // operator can tell a 401 from a DNS blip without parsing the
+      // message string.
+      const errClass =
+        err instanceof DiscoverySourceAuthError ||
+        err instanceof DiscoverySourceTransportError ||
+        err instanceof DiscoverySourceBackendError
+          ? err.name
+          : "unknown";
+      ctx.logger.warn("driver.cross-env-pin-drift.railway-failed", {
+        service: input.name,
+        errClass,
+        err: message,
+      });
+      return error(`railway query failed: ${message}`);
+    }
+
+    const parsed = ProjectSchema.safeParse(projectData);
+    if (!parsed.success) {
+      return error(
+        `railway project response did not match expected shape: ${parsed.error.message}`,
+      );
+    }
+    if (parsed.data.project === null) {
+      return error(
+        `railway project ${projectId} returned null — check RAILWAY_PROJECT_ID and token access`,
+      );
+    }
+
+    const svc = parsed.data.project.services.edges.find(
+      (e) => e.node.name === input.name,
+    );
+    if (!svc) {
+      return error(`service ${input.name} not found in railway project`);
+    }
+
+    const prodNode = svc.node.serviceInstances.edges.find(
+      (e) => e.node.environmentId === input.prodEnvId,
+    )?.node;
+    if (!prodNode) {
+      return error(
+        `service ${input.name} has no instance in prod env ${input.prodEnvId}`,
+      );
+    }
+    const prod = readInstance(prodNode);
+
+    const stagingNode = input.stagingEnvId
+      ? svc.node.serviceInstances.edges.find(
+          (e) => e.node.environmentId === input.stagingEnvId,
+        )?.node
+      : undefined;
+    const stagingRunningDigest = stagingNode
+      ? readInstance(stagingNode).runningDigest
+      : "";
+
+    // (1) Prod must be pinned to an `@sha256:` digest — that pinned ref
+    // IS the last-promoted digest under the promote contract.
+    if (prod.pinnedDigest === "" || !prod.pinnedDigest.startsWith("sha256:")) {
+      ctx.logger.warn("driver.cross-env-pin-drift.unpinned", {
+        service: input.name,
+        image: prod.rawImage,
+      });
+      return {
+        key: input.key,
+        state: "red",
+        signal: {
+          service: input.name,
+          status: "unpinned",
+          prodPinnedDigest: prod.pinnedDigest,
+          prodRunningDigest: prod.runningDigest,
+          stagingRunningDigest,
+          ghcrPresent: false,
+        },
+        observedAt,
+      };
+    }
+
+    // (2) Prod must be RUNNING the pinned/last-promoted digest. A
+    // running digest that differs (or is absent) means prod drifted off
+    // what it was promoted to. An absent running digest is treated as a
+    // mismatch (we cannot prove prod is running the pin), staying red.
+    if (prod.runningDigest !== prod.pinnedDigest) {
+      ctx.logger.warn("driver.cross-env-pin-drift.regressed", {
+        service: input.name,
+        pinned: prod.pinnedDigest,
+        running: prod.runningDigest,
+      });
+      return {
+        key: input.key,
+        state: "red",
+        signal: {
+          service: input.name,
+          status: "regressed",
+          prodPinnedDigest: prod.pinnedDigest,
+          prodRunningDigest: prod.runningDigest,
+          stagingRunningDigest,
+          ghcrPresent: false,
+        },
+        observedAt,
+      };
+    }
+
+    // (3) The last-promoted digest must still exist in GHCR so prod can
+    // be re-pulled / rolled forward. A GC'd digest is an alarm even
+    // though prod is currently running it (the local image survives, but
+    // a re-pull would fail).
+    let ghcrPresent: boolean;
+    try {
+      ghcrPresent = await ghcrDigestPresent(fetchImpl, {
+        repository: input.imageRepo,
+        reference: prod.pinnedDigest,
+        token: ctx.env.GHCR_TOKEN,
+        signal: ctx.abortSignal,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.logger.warn("driver.cross-env-pin-drift.ghcr-error", {
+        service: input.name,
+        err: message,
+      });
+      return error(`ghcr lookup failed: ${message}`);
+    }
+
+    if (!ghcrPresent) {
+      ctx.logger.warn("driver.cross-env-pin-drift.ghcr-missing", {
+        service: input.name,
+        digest: prod.pinnedDigest,
+      });
+      return {
+        key: input.key,
+        state: "red",
+        signal: {
+          service: input.name,
+          status: "ghcr-missing",
+          prodPinnedDigest: prod.pinnedDigest,
+          prodRunningDigest: prod.runningDigest,
+          stagingRunningDigest,
+          ghcrPresent: false,
+        },
+        observedAt,
+      };
+    }
+
+    return {
+      key: input.key,
+      state: "green",
+      signal: {
+        service: input.name,
+        status: "stable",
+        prodPinnedDigest: prod.pinnedDigest,
+        prodRunningDigest: prod.runningDigest,
+        stagingRunningDigest,
+        ghcrPresent: true,
+      },
+      observedAt,
+    };
+  },
+};
+
+// Helpers -------------------------------------------------------------------
+
+/**
+ * GET the GHCR manifest endpoint for `<repository>@<digest>` and return
+ * whether it is present. A 200 means present; a 404 means GC'd (returns
+ * false, NOT an error — a missing pinned digest is a probe signal, not a
+ * transport fault). Auth failures and other non-2xx/non-404 statuses, and
+ * transport rejections, throw so the driver surfaces them as an error
+ * result rather than a false "missing".
+ *
+ * Mirrors `image-drift.ts`'s `fetchGhcrDigest` request shape (Accept
+ * header advertising OCI + Docker v2 media types) but answers a
+ * presence question instead of returning the digest header — the
+ * reference here IS the digest.
+ */
+async function ghcrDigestPresent(
+  fetchImpl: typeof fetch,
+  opts: {
+    repository: string;
+    reference: string;
+    token?: string;
+    signal?: AbortSignal;
+  },
+): Promise<boolean> {
+  const path = opts.repository.replace(/^ghcr\.io\//, "");
+  const url = `https://ghcr.io/v2/${path}/manifests/${encodeURIComponent(opts.reference)}`;
+  const headers: Record<string, string> = {
+    Accept: [
+      "application/vnd.oci.image.manifest.v1+json",
+      "application/vnd.oci.image.index.v1+json",
+      "application/vnd.docker.distribution.manifest.v2+json",
+      "application/vnd.docker.distribution.manifest.list.v2+json",
+    ].join(", "),
+  };
+  if (opts.token) {
+    headers.Authorization = `Bearer ${opts.token}`;
+  }
+  let res: Response;
+  try {
+    res = await fetchImpl(url, { method: "GET", headers, signal: opts.signal });
+  } catch (err) {
+    throw new Error(
+      `ghcr fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+  if (res.status === 404) return false;
+  if (res.status === 401 || res.status === 403) {
+    throw new Error(
+      `ghcr auth failed: ${res.status} ${res.statusText || ""}`.trim(),
+    );
+  }
+  if (!res.ok) {
+    throw new Error(`ghcr manifest lookup ${res.status}`);
+  }
+  return true;
+}

--- a/showcase/harness/src/probes/loader/probe-loader.test.ts
+++ b/showcase/harness/src/probes/loader/probe-loader.test.ts
@@ -418,6 +418,7 @@ describe("createProbeLoader against the real shipped config set", () => {
     // (it does not enumerate), so stub sources matching the real names are
     // sufficient to exercise the load-time invariant without Railway/pnpm.
     discoveryRegistry.register(mkSource("railway-services"));
+    discoveryRegistry.register(mkSource("cross-env-pin-drift"));
     discoveryRegistry.register(mkSource("pnpm-packages"));
 
     const bus = mkBus();

--- a/showcase/harness/src/probes/ops-drift-routing.test.ts
+++ b/showcase/harness/src/probes/ops-drift-routing.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  selectDriftProbeKind,
+  OPS_PROD_DRIFT_KIND,
+  OPS_STAGING_DRIFT_KIND,
+} from "./ops-drift-routing.js";
+
+/**
+ * Ops-surface drift routing (plan U11 / spec §7.3).
+ *
+ * The Ops surface must use the CROSS-ENV pin-drift probe
+ * (`pin_drift_cross_env`, U6's driver) as the authoritative drift signal
+ * for PROD services, and the `:latest`-drift probe (`image_drift`) only
+ * for STAGING. Before this routing the Ops surface treated pinned prod as
+ * `:latest`-drift — image-drift's `pinnedExpected` neutralization renders
+ * prod GREEN by SUPPRESSING the signal rather than verifying prod is
+ * running what it was promoted to. These tests pin the routing so a future
+ * edit that re-points prod at `:latest`-drift (the lie) fails CI.
+ */
+describe("selectDriftProbeKind — prod→cross-env-pin-drift, staging→:latest-drift", () => {
+  it("routes a production env to the CROSS-ENV pin-drift kind", () => {
+    expect(selectDriftProbeKind({ SHOWCASE_ENV: "production" })).toBe(
+      "pin_drift_cross_env",
+    );
+  });
+
+  it("routes a staging env to the :latest image-drift kind", () => {
+    expect(selectDriftProbeKind({ SHOWCASE_ENV: "staging" })).toBe(
+      "image_drift",
+    );
+  });
+
+  it("resolves prod from Railway's injected RAILWAY_ENVIRONMENT_NAME", () => {
+    expect(
+      selectDriftProbeKind({ RAILWAY_ENVIRONMENT_NAME: "production" }),
+    ).toBe("pin_drift_cross_env");
+  });
+
+  it("resolves staging from Railway's injected RAILWAY_ENVIRONMENT_NAME", () => {
+    expect(selectDriftProbeKind({ RAILWAY_ENVIRONMENT_NAME: "staging" })).toBe(
+      "image_drift",
+    );
+  });
+
+  it("prefers the explicit SHOWCASE_ENV override over RAILWAY_ENVIRONMENT_NAME", () => {
+    // A prod harness deployed with an explicit staging override must route
+    // as staging — the override wins, mirroring image-drift's isProductionEnv.
+    expect(
+      selectDriftProbeKind({
+        SHOWCASE_ENV: "staging",
+        RAILWAY_ENVIRONMENT_NAME: "production",
+      }),
+    ).toBe("image_drift");
+  });
+
+  it("is case-insensitive on the env-name match (Production → prod routing)", () => {
+    expect(selectDriftProbeKind({ SHOWCASE_ENV: "Production" })).toBe(
+      "pin_drift_cross_env",
+    );
+  });
+
+  it("defaults a non-production env (unknown / unset) to :latest-drift", () => {
+    // Only a genuine production label routes to cross-env pin-drift; an
+    // unset or unrecognised env is NOT prod, so it falls to the staging
+    // `:latest`-drift path (never the prod cross-env path on a guess).
+    expect(selectDriftProbeKind({})).toBe("image_drift");
+    expect(selectDriftProbeKind({ SHOWCASE_ENV: "unknown" })).toBe(
+      "image_drift",
+    );
+  });
+
+  it("exposes the two routed kinds as named constants matching the driver kinds", () => {
+    expect(OPS_PROD_DRIFT_KIND).toBe("pin_drift_cross_env");
+    expect(OPS_STAGING_DRIFT_KIND).toBe("image_drift");
+  });
+});

--- a/showcase/harness/src/probes/ops-drift-routing.ts
+++ b/showcase/harness/src/probes/ops-drift-routing.ts
@@ -1,0 +1,70 @@
+import { CROSS_ENV_PIN_DRIFT_KIND } from "./drivers/cross-env-pin-drift.js";
+
+/**
+ * Ops-surface drift routing (plan U11 / spec §7.3).
+ *
+ * There are TWO drift signals the Ops surface can show per service, and
+ * they answer DIFFERENT questions:
+ *
+ *   - `image_drift` ("`:latest`-drift") compares ONE env's running digest
+ *     against the GHCR `:latest` tag. That is the right question for
+ *     STAGING, which floats `:latest` by contract — a staging deploy
+ *     behind `:latest` is genuine drift. But on PROD (intentionally
+ *     PINNED to a digest) "behind :latest" is EXPECTED, so image-drift
+ *     neutralizes it to GREEN via `pinnedExpected`. That neutralization
+ *     does not VERIFY prod — it merely SUPPRESSES the signal, so the Ops
+ *     surface effectively lies about pinned prod (always green, even if
+ *     prod drifted off its last-promoted digest or that digest was GC'd).
+ *   - `pin_drift_cross_env` (U6's CROSS-ENV pin-drift) is the real prod
+ *     signal: it asserts prod is RUNNING the digest it was LAST PROMOTED
+ *     to AND that the digest is still present in GHCR — NOT "matches
+ *     :latest".
+ *
+ * So the Ops surface routes by the harness's deploy environment:
+ *   PROD    → `pin_drift_cross_env`   (verify the pin)
+ *   STAGING → `image_drift`           (verify floating `:latest`)
+ *
+ * The env resolution mirrors `image-drift.ts`'s `isProductionEnv` exactly
+ * (explicit `SHOWCASE_ENV` override, then Railway's injected
+ * `RAILWAY_ENVIRONMENT_NAME`, case-insensitive exact-match on
+ * "production") so the routing and the driver agree on "is this prod?".
+ * Only a genuine production label routes to the cross-env path — "staging",
+ * "unknown", and unset all fall to `image_drift` so a missing env var can
+ * never silently route prod-verification onto a guess.
+ */
+
+/** Probe kind the Ops surface uses for PROD drift — U6's cross-env probe. */
+export const OPS_PROD_DRIFT_KIND = CROSS_ENV_PIN_DRIFT_KIND;
+
+/** Probe kind the Ops surface uses for STAGING drift — `:latest`-drift. */
+export const OPS_STAGING_DRIFT_KIND = "image_drift" as const;
+
+export type OpsDriftKind =
+  | typeof OPS_PROD_DRIFT_KIND
+  | typeof OPS_STAGING_DRIFT_KIND;
+
+/**
+ * Resolve whether the harness deploy environment is production. Mirrors
+ * `image-drift.ts:isProductionEnv` (and the orchestrator's `sourceEnv`
+ * resolution): explicit `SHOWCASE_ENV` override wins, then Railway's
+ * injected `RAILWAY_ENVIRONMENT_NAME`. Case-insensitive exact match on
+ * "production" — "staging", "unknown", and unset all return false.
+ */
+function isProductionEnv(
+  env: Readonly<Record<string, string | undefined>>,
+): boolean {
+  const name = env.SHOWCASE_ENV ?? env.RAILWAY_ENVIRONMENT_NAME;
+  return typeof name === "string" && name.trim().toLowerCase() === "production";
+}
+
+/**
+ * Select the authoritative drift probe kind for the Ops surface given the
+ * harness's environment: PROD → cross-env pin-drift, everything else →
+ * `:latest` image-drift. See the module docstring for why the prod path
+ * must NOT use image-drift (the `pinnedExpected` lie).
+ */
+export function selectDriftProbeKind(
+  env: Readonly<Record<string, string | undefined>>,
+): OpsDriftKind {
+  return isProductionEnv(env) ? OPS_PROD_DRIFT_KIND : OPS_STAGING_DRIFT_KIND;
+}

--- a/showcase/harness/src/types/index.ts
+++ b/showcase/harness/src/types/index.ts
@@ -51,6 +51,15 @@ export const DIMENSIONS = [
   "image_drift",
   "e2e_smoke",
   "pin_drift",
+  // CROSS-ENV pin-drift (U6/U11, spec §7.3). The `pin_drift_cross_env`
+  // driver reads BOTH prod (pinned) and staging (floating) running digests
+  // and asserts prod is RUNNING the digest it was LAST PROMOTED to AND that
+  // the digest is still present in GHCR — distinct from `image_drift`
+  // (one env vs GHCR `:latest`) and `pin_drift` (the validate-pins ratchet).
+  // The Ops surface routes PROD services here and STAGING to `image_drift`
+  // (see probes/ops-drift-routing.ts). Closed-enum slot so its YAML
+  // (`config/probes/cross-env-pin-drift.yml`) and rule keys validate at load.
+  "pin_drift_cross_env",
   "version_drift",
   "redirect_decommission",
   "deploy",

--- a/showcase/scripts/__tests__/emit-railway-envs-json.test.ts
+++ b/showcase/scripts/__tests__/emit-railway-envs-json.test.ts
@@ -25,7 +25,7 @@ describe("emit-railway-envs-json", () => {
     expect(json.projectId).toBe("6f8c6bff-a80d-4f8f-b78d-50b32bcf4479");
     expect(json.envIds.staging).toBe("8edfef02-ea09-4a20-8689-261f21cc2849");
     expect(json.envIds.prod).toBe("b14919f4-6417-429f-848d-c6ae2201e04f");
-    expect(json.services.length).toBe(29);
+    expect(json.services.length).toBe(41);
     const docs = json.services.find((s: { name: string }) => s.name === "docs");
     expect(docs.domains.staging).toBe("docs.staging.copilotkit.ai");
     expect(docs.domains.prod).toBe("docs.copilotkit.ai");

--- a/showcase/scripts/__tests__/fixtures/railway-envs.golden.json
+++ b/showcase/scripts/__tests__/fixtures/railway-envs.golden.json
@@ -440,6 +440,198 @@
       "repoName": "showcase-strands"
     }
   },
+  "starter-adk": {
+    "prod": {
+      "instanceId": "cb23cae4-9555-4ddd-8a62-f1aa1ff72c67",
+      "domain": "starter-adk-production.up.railway.app",
+      "probe": true,
+      "driver": "starter",
+      "repoName": "starter-adk"
+    },
+    "staging": {
+      "instanceId": "208a160a-0d7d-44b2-a94d-39e13b24e21a",
+      "domain": "starter-adk-staging.up.railway.app",
+      "probe": false,
+      "driver": "starter",
+      "repoName": "starter-adk"
+    }
+  },
+  "starter-agno": {
+    "prod": {
+      "instanceId": "2f58513b-5fe4-4b09-a28f-93d4caa277b5",
+      "domain": "starter-agno-production.up.railway.app",
+      "probe": true,
+      "driver": "starter",
+      "repoName": "starter-agno"
+    },
+    "staging": {
+      "instanceId": "9944eb97-7f58-47f8-a49d-65603e209609",
+      "domain": "starter-agno-staging.up.railway.app",
+      "probe": false,
+      "driver": "starter",
+      "repoName": "starter-agno"
+    }
+  },
+  "starter-crewai-crews": {
+    "prod": {
+      "instanceId": "1a3e24cb-0752-45c8-b4a2-0c6096899875",
+      "domain": "starter-crewai-crews-production.up.railway.app",
+      "probe": true,
+      "driver": "starter",
+      "repoName": "starter-crewai-crews"
+    },
+    "staging": {
+      "instanceId": "820895fb-f65c-4834-a07d-d454035d39c4",
+      "domain": "starter-crewai-crews-staging.up.railway.app",
+      "probe": false,
+      "driver": "starter",
+      "repoName": "starter-crewai-crews"
+    }
+  },
+  "starter-langgraph-fastapi": {
+    "prod": {
+      "instanceId": "0679bc18-e9af-40c6-bc17-0b5eb2cd7bec",
+      "domain": "starter-langgraph-fastapi-production.up.railway.app",
+      "probe": true,
+      "driver": "starter",
+      "repoName": "starter-langgraph-fastapi"
+    },
+    "staging": {
+      "instanceId": "5f10e976-e121-48a5-bc18-2619798f2f10",
+      "domain": "starter-langgraph-fastapi-staging.up.railway.app",
+      "probe": false,
+      "driver": "starter",
+      "repoName": "starter-langgraph-fastapi"
+    }
+  },
+  "starter-langgraph-js": {
+    "prod": {
+      "instanceId": "50a2205b-8768-4765-b7a1-21941c105051",
+      "domain": "starter-langgraph-js-production.up.railway.app",
+      "probe": true,
+      "driver": "starter",
+      "repoName": "starter-langgraph-js"
+    },
+    "staging": {
+      "instanceId": "43db83fe-fafb-445b-a19a-51bb086c71b9",
+      "domain": "starter-langgraph-js-staging.up.railway.app",
+      "probe": false,
+      "driver": "starter",
+      "repoName": "starter-langgraph-js"
+    }
+  },
+  "starter-langgraph-python": {
+    "prod": {
+      "instanceId": "24dad599-576a-4154-a621-c3af40629a8f",
+      "domain": "starter-langgraph-python-production.up.railway.app",
+      "probe": true,
+      "driver": "starter",
+      "repoName": "starter-langgraph-python"
+    },
+    "staging": {
+      "instanceId": "58105e79-4020-4692-8749-c1a63ab63f2c",
+      "domain": "starter-langgraph-python-staging.up.railway.app",
+      "probe": false,
+      "driver": "starter",
+      "repoName": "starter-langgraph-python"
+    }
+  },
+  "starter-llamaindex": {
+    "prod": {
+      "instanceId": "c119f40b-dc71-4734-9716-c1085754b085",
+      "domain": "starter-llamaindex-production.up.railway.app",
+      "probe": true,
+      "driver": "starter",
+      "repoName": "starter-llamaindex"
+    },
+    "staging": {
+      "instanceId": "44446803-0505-456a-b0c4-01fe82fb3832",
+      "domain": "starter-llamaindex-staging.up.railway.app",
+      "probe": false,
+      "driver": "starter",
+      "repoName": "starter-llamaindex"
+    }
+  },
+  "starter-mastra": {
+    "prod": {
+      "instanceId": "c6fba6d8-8dde-442b-948f-560bf25fa2f1",
+      "domain": "starter-mastra-production.up.railway.app",
+      "probe": true,
+      "driver": "starter",
+      "repoName": "starter-mastra"
+    },
+    "staging": {
+      "instanceId": "b246e52d-52d8-4015-bb06-89bd09d54f8f",
+      "domain": "starter-mastra-staging.up.railway.app",
+      "probe": false,
+      "driver": "starter",
+      "repoName": "starter-mastra"
+    }
+  },
+  "starter-ms-agent-framework-dotnet": {
+    "prod": {
+      "instanceId": "993237a4-9ee7-47b2-a5be-267e247c1409",
+      "domain": "starter-ms-agent-framework-dotnet-production.up.railway.app",
+      "probe": true,
+      "driver": "starter",
+      "repoName": "starter-ms-agent-framework-dotnet"
+    },
+    "staging": {
+      "instanceId": "6684c246-e8fd-45a7-86e4-c529a439976f",
+      "domain": "starter-ms-agent-framework-dotnet-staging.up.railway.app",
+      "probe": false,
+      "driver": "starter",
+      "repoName": "starter-ms-agent-framework-dotnet"
+    }
+  },
+  "starter-ms-agent-framework-python": {
+    "prod": {
+      "instanceId": "aa934881-340a-4fb7-8b39-9cb0a6f372b2",
+      "domain": "starter-ms-agent-framework-python-production.up.railway.app",
+      "probe": true,
+      "driver": "starter",
+      "repoName": "starter-ms-agent-framework-python"
+    },
+    "staging": {
+      "instanceId": "a162348a-f768-4c3f-815c-f617819f64e6",
+      "domain": "starter-ms-agent-framework-python-staging.up.railway.app",
+      "probe": false,
+      "driver": "starter",
+      "repoName": "starter-ms-agent-framework-python"
+    }
+  },
+  "starter-pydantic-ai": {
+    "prod": {
+      "instanceId": "74ce36fe-0b8f-446e-8e06-0b6496b6e829",
+      "domain": "starter-pydantic-ai-production.up.railway.app",
+      "probe": true,
+      "driver": "starter",
+      "repoName": "starter-pydantic-ai"
+    },
+    "staging": {
+      "instanceId": "25f4eb93-501a-4e5e-b7cf-343eb08ea613",
+      "domain": "starter-pydantic-ai-staging.up.railway.app",
+      "probe": false,
+      "driver": "starter",
+      "repoName": "starter-pydantic-ai"
+    }
+  },
+  "starter-strands-python": {
+    "prod": {
+      "instanceId": "4af440e0-ba05-48a5-b922-5b96a033891a",
+      "domain": "starter-strands-python-production.up.railway.app",
+      "probe": true,
+      "driver": "starter",
+      "repoName": "starter-strands-python"
+    },
+    "staging": {
+      "instanceId": "adc24096-584a-4ef3-93de-0bc92d49235c",
+      "domain": "starter-strands-python-staging.up.railway.app",
+      "probe": false,
+      "driver": "starter",
+      "repoName": "starter-strands-python"
+    }
+  },
   "webhooks": {
     "prod": {
       "instanceId": "d82ef5b4-3bfd-462e-9436-3d5dbca8681a",

--- a/showcase/scripts/__tests__/lint-prod-gate.bats
+++ b/showcase/scripts/__tests__/lint-prod-gate.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+# Tests for lint-prod-gate.sh — the post-promote pinned-ness gate extracted from
+# .github/workflows/showcase_promote.yml (UNIT U12, spec §8.2).
+#
+# Core invariant under test: after a promote, EVERY prod service must be pinned
+# to an immutable `@sha256:` digest. A born-on-`:latest` service (the
+# deploy-to-railway.ts unpinned-source case, spec R-E) must be caught LOUD — the
+# gate exits non-zero so the verify-prod job (and the run) goes red. A
+# fully-pinned fleet passes (exit 0).
+#
+# The gate is a thin wrapper around `bin/railway lint-prod`, whose exit-code
+# contract IS the assertion: exit 1 on findings (an unpinned prod service), exit
+# 0 when all pinned, exit 2 on a hard error. The real `bin/railway` is replaced
+# on PATH-independent terms via RAILWAY_BIN, pointed at a stub that mimics those
+# exit codes. The gate's job is to (a) invoke `lint-prod` with the right
+# subcommand and (b) FAIL the step (propagate the non-zero) when lint-prod finds
+# an unpinned service — never swallow it.
+#
+# NB on assertion gating: bats does NOT run test bodies under `set -e`. Only the
+# FINAL command decides pass/fail, so every non-final assertion is written
+# `[[ ... ]] || fail "msg"` to force a hard failure with a diagnostic. A bare
+# `[[ ... ]]` on a non-final line is a silent no-op (false-green).
+
+# fail <msg> — print the message to the bats failure stream and abort the test.
+fail() {
+  echo "$1" >&2
+  return 1
+}
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../lint-prod-gate.sh"
+  [ -x "$SCRIPT" ] || fail "lint-prod-gate.sh missing or not executable at $SCRIPT"
+  STUB_DIR="$BATS_TEST_TMPDIR/stub"
+  mkdir -p "$STUB_DIR"
+
+  # Unpinned stub: mimics `bin/railway lint-prod` finding a born-on-:latest prod
+  # service — prints a finding and exits 1 (the lint-prod findings contract).
+  # Also asserts the gate invokes it with the `lint-prod` subcommand, so an
+  # arg-order regression in the wrapper is caught.
+  cat > "$STUB_DIR/railway-unpinned" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "lint-prod" ] || { echo "expected first arg 'lint-prod', got '$1'" >&2; exit 99; }
+echo "deploy-to-railway: not digest-pinned (image=ghcr.io/copilotkit/showcase-x:latest)"
+echo "DRIFT: 1 production service(s) not digest-pinned."
+exit 1
+STUB
+  chmod +x "$STUB_DIR/railway-unpinned"
+
+  # Pinned stub: every prod service on an @sha256: digest — exits 0.
+  cat > "$STUB_DIR/railway-pinned" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "lint-prod" ] || { echo "expected first arg 'lint-prod', got '$1'" >&2; exit 99; }
+echo "OK: all production services digest-pinned."
+exit 0
+STUB
+  chmod +x "$STUB_DIR/railway-pinned"
+
+  # Error stub: lint-prod hit a hard error (auth/GraphQL) — exits 2. The gate
+  # must treat a non-zero (incl. 2) as a hard failure, never a pass.
+  cat > "$STUB_DIR/railway-error" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "lint-prod" ] || { echo "expected first arg 'lint-prod', got '$1'" >&2; exit 99; }
+echo "graphql error: boom" >&2
+exit 2
+STUB
+  chmod +x "$STUB_DIR/railway-error"
+}
+
+@test "unpinned prod service -> gate fails loud (non-zero, finding surfaced)" {
+  run env RAILWAY_BIN="$STUB_DIR/railway-unpinned" bash "$SCRIPT"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit on unpinned prod service, got $status"
+  [[ "$output" == *"not digest-pinned"* ]] || fail "finding not surfaced: $output"
+}
+
+@test "fully-pinned fleet -> gate passes (exit 0)" {
+  run env RAILWAY_BIN="$STUB_DIR/railway-pinned" bash "$SCRIPT"
+  [ "$status" -eq 0 ] || fail "expected exit 0 on a fully-pinned fleet, got $status ($output)"
+  [[ "$output" == *"all production services digest-pinned"* ]] || fail "OK line not surfaced: $output"
+}
+
+@test "lint-prod hard error (exit 2) -> gate fails (never swallowed)" {
+  run env RAILWAY_BIN="$STUB_DIR/railway-error" bash "$SCRIPT"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit on a lint-prod hard error, got $status"
+}
+
+@test "missing/non-executable RAILWAY_BIN -> fails loud (not a vacuous pass)" {
+  run env RAILWAY_BIN="$STUB_DIR/does-not-exist" bash "$SCRIPT"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit when RAILWAY_BIN is missing, got $status"
+  [[ "$output" == *"missing or not executable"* ]] || fail "missing-binary error not surfaced: $output"
+}
+
+@test "the workflow wires the gate into the verify-prod job" {
+  # Guard against the gate being orphaned (script present + tested, but never
+  # invoked by the promote workflow). Assert the verify-prod job actually calls
+  # lint-prod-gate.sh as a post-promote step.
+  WF="$BATS_TEST_DIRNAME/../../../.github/workflows/showcase_promote.yml"
+  [ -f "$WF" ] || fail "promote workflow missing at $WF"
+  grep -q "lint-prod-gate.sh" "$WF" || fail "showcase_promote.yml does not invoke lint-prod-gate.sh"
+}

--- a/showcase/scripts/__tests__/promote-fleet.bats
+++ b/showcase/scripts/__tests__/promote-fleet.bats
@@ -308,3 +308,179 @@ STUB
   [[ "$output" == *"staging_drift="* ]] || fail "staging_drift key absent: $output"
   [[ "$output" != *"staging_drift=svc"* ]] || fail "unexpected drift payload: $output"
 }
+
+# ── U4: tier-ordered closure promote with dependent-tier gating ─────────────
+#
+# When CLOSURE_PLAN (tier-annotated `tier:name,tier:name,...` from U3's
+# resolve-promote-targets.sh) is supplied, promote-fleet iterates the closure
+# BY TIER (0->1->2). The existing per-service best-effort loop is preserved
+# WITHIN a tier, but a tier GATES its dependents: if ANY tier-0 service fails
+# pin+verify, tiers 1 and 2 do NOT promote (a stale aimock/harness under fresh
+# integrations = non-equivalent prod); a tier-1 failure blocks tier-2. Blocked
+# tiers are reported NOT-ATTEMPTED (distinct from FAILED) so the operator can
+# re-run (spec R-B). succeeded_csv = the actually-pinned closure subset.
+
+# A per-tier stub: tier-0 = aimock(svc-a)/pocketbase(svc-b); tier-1 =
+# harness(svc-h); tier-2 = integrations(svc-i1,svc-i2). svc-fail always fails.
+setup_tier_stub() {
+  cat > "$STUB_DIR/railway-tier" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "promote" ] || { echo "expected first arg 'promote', got '$1'" >&2; exit 99; }
+svc="$2"
+echo "STUB called for: $svc"
+case "$svc" in
+  svc-fail) exit 7 ;;
+  *)        exit 0 ;;
+esac
+STUB
+  chmod +x "$STUB_DIR/railway-tier"
+  export RAILWAY_BIN="$STUB_DIR/railway-tier"
+}
+
+@test "U4: tier-0 failure HALTS tiers 1 and 2 (reported NOT-ATTEMPTED, not failed)" {
+  setup_tier_stub
+  # tier-0: svc-fail (fails) + svc-a (ok); tier-1: svc-h; tier-2: svc-i1,svc-i2.
+  run env CLOSURE_PLAN="0:svc-fail,0:svc-a,1:svc-h,2:svc-i1,2:svc-i2" bash "$SCRIPT"
+
+  # tier-0 members ARE attempted (best-effort within the failing tier).
+  [[ "$output" == *"STUB called for: svc-fail"* ]] || fail "tier-0 svc-fail not attempted: $output"
+  [[ "$output" == *"STUB called for: svc-a"* ]] || fail "tier-0 svc-a not attempted: $output"
+
+  # tiers 1 and 2 are NOT attempted — the tier-0 failure gated them.
+  [[ "$output" != *"STUB called for: svc-h"* ]] || fail "tier-1 svc-h should NOT have been attempted after tier-0 failure: $output"
+  [[ "$output" != *"STUB called for: svc-i1"* ]] || fail "tier-2 svc-i1 should NOT have been attempted after tier-0 failure: $output"
+  [[ "$output" != *"STUB called for: svc-i2"* ]] || fail "tier-2 svc-i2 should NOT have been attempted after tier-0 failure: $output"
+
+  # Non-zero aggregate exit (a tier-0 service failed).
+  [ "$status" -ne 0 ] || fail "expected non-zero exit on tier-0 failure, got $status: $output"
+
+  # Blocked tiers reported as NOT-ATTEMPTED — distinct from FAILED so the
+  # operator knows they can re-run them once tier-0 is healthy.
+  [[ "$output" == *"NOT-ATTEMPTED"* ]] || fail "expected a NOT-ATTEMPTED report for gated tiers: $output"
+  [[ "$output" == *"svc-h"* ]] || fail "gated svc-h should be named in NOT-ATTEMPTED: $output"
+  [[ "$output" == *"svc-i1"* ]] || fail "gated svc-i1 should be named in NOT-ATTEMPTED: $output"
+  [[ "$output" == *"svc-i2"* ]] || fail "gated svc-i2 should be named in NOT-ATTEMPTED: $output"
+
+  # succeeded_csv = actually-pinned subset (only svc-a; NOT the gated tiers,
+  # NOT the failed svc-fail).
+  run cat "$GITHUB_OUTPUT"
+  [[ "$output" == *"succeeded_csv=svc-a"* ]] || fail "succeeded_csv should be exactly the pinned subset (svc-a): $output"
+  [[ "$output" != *"svc-h"* ]] || fail "gated svc-h must not leak into succeeded_csv: $output"
+  [[ "$output" != *"svc-fail"* ]] || fail "failed svc-fail must not leak into succeeded_csv: $output"
+}
+
+@test "U4: tier-1 failure blocks tier-2 (tier-0 still promoted)" {
+  setup_tier_stub
+  # tier-0: svc-a (ok); tier-1: svc-fail (fails); tier-2: svc-i1.
+  run env CLOSURE_PLAN="0:svc-a,1:svc-fail,2:svc-i1" bash "$SCRIPT"
+
+  # tier-0 + tier-1 attempted.
+  [[ "$output" == *"STUB called for: svc-a"* ]] || fail "tier-0 svc-a not attempted: $output"
+  [[ "$output" == *"STUB called for: svc-fail"* ]] || fail "tier-1 svc-fail not attempted: $output"
+  # tier-2 NOT attempted (gated by the tier-1 failure).
+  [[ "$output" != *"STUB called for: svc-i1"* ]] || fail "tier-2 svc-i1 should NOT have been attempted after tier-1 failure: $output"
+
+  [ "$status" -ne 0 ] || fail "expected non-zero exit on tier-1 failure, got $status: $output"
+  [[ "$output" == *"NOT-ATTEMPTED"* ]] || fail "expected NOT-ATTEMPTED report for gated tier-2: $output"
+  [[ "$output" == *"svc-i1"* ]] || fail "gated svc-i1 should be named in NOT-ATTEMPTED: $output"
+
+  # tier-0 svc-a DID pin even though tier-1 later failed.
+  run cat "$GITHUB_OUTPUT"
+  [[ "$output" == *"succeeded_csv=svc-a"* ]] || fail "tier-0 svc-a should be in succeeded_csv: $output"
+}
+
+@test "U4: all-green closure promotes every tier in order (0 before 1 before 2)" {
+  setup_tier_stub
+  run env CLOSURE_PLAN="0:svc-a,0:svc-b,1:svc-h,2:svc-i1,2:svc-i2" bash "$SCRIPT"
+
+  [ "$status" -eq 0 ] || fail "expected zero exit on all-green closure, got $status: $output"
+
+  # Every service attempted.
+  for s in svc-a svc-b svc-h svc-i1 svc-i2; do
+    [[ "$output" == *"STUB called for: $s"* ]] || fail "$s not attempted: $output"
+  done
+
+  # Tier ordering: tier-0 services appear BEFORE tier-1, which appears BEFORE
+  # tier-2. Use the byte offset of each STUB line in $output to assert order.
+  a_pos="${output%%STUB called for: svc-a*}"
+  h_pos="${output%%STUB called for: svc-h*}"
+  i1_pos="${output%%STUB called for: svc-i1*}"
+  [ "${#a_pos}" -lt "${#h_pos}" ] || fail "tier-0 svc-a must promote BEFORE tier-1 svc-h: $output"
+  [ "${#h_pos}" -lt "${#i1_pos}" ] || fail "tier-1 svc-h must promote BEFORE tier-2 svc-i1: $output"
+
+  # All five exported as the succeeded set, in tier order.
+  run cat "$GITHUB_OUTPUT"
+  [[ "$output" == *"succeeded_csv=svc-a,svc-b,svc-h,svc-i1,svc-i2"* ]] || fail "wrong succeeded_csv: $output"
+}
+
+@test "U4: a tier-2 (leaf) failure does NOT gate anything; best-effort within the leaf tier" {
+  setup_tier_stub
+  # tier-0 ok, tier-1 ok, tier-2: svc-fail (fails) + svc-i1 (ok). The leaf tier
+  # has no dependents, so svc-i1 must STILL be attempted after svc-fail fails
+  # (the existing best-effort-within-a-tier behavior).
+  run env CLOSURE_PLAN="0:svc-a,1:svc-h,2:svc-fail,2:svc-i1" bash "$SCRIPT"
+
+  [[ "$output" == *"STUB called for: svc-fail"* ]] || fail "tier-2 svc-fail not attempted: $output"
+  [[ "$output" == *"STUB called for: svc-i1"* ]] || fail "tier-2 svc-i1 not attempted after a sibling failed (best-effort): $output"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit (a service failed), got $status: $output"
+
+  run cat "$GITHUB_OUTPUT"
+  # svc-i1 pinned despite its sibling failing; svc-fail not in succeeded_csv.
+  [[ "$output" == *"succeeded_csv=svc-a,svc-h,svc-i1"* ]] || fail "wrong succeeded_csv (leaf best-effort): $output"
+}
+
+@test "U4: --digest override still works on the single-service closure path" {
+  # R-B: the single-service --digest escape path must survive the tier path.
+  cat > "$STUB_DIR/railway-tier-digest" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "promote" ] || { echo "expected first arg 'promote', got '$1'" >&2; exit 99; }
+echo "ARGS: $*"
+[[ "$*" == *"--digest sha256:deadbeef"* ]] || { echo "missing digest" >&2; exit 9; }
+exit 0
+STUB
+  chmod +x "$STUB_DIR/railway-tier-digest"
+  export RAILWAY_BIN="$STUB_DIR/railway-tier-digest"
+
+  run env CLOSURE_PLAN="2:svc-a" DIGEST="sha256:deadbeef" bash "$SCRIPT"
+
+  [ "$status" -eq 0 ] || fail "expected zero exit, got $status: $output"
+  [[ "$output" == *"ARGS: "*"--digest sha256:deadbeef"* ]] || fail "digest not forwarded on closure path: $output"
+}
+
+@test "U4: STAGING_DRIFT_MARKER aggregation works on the tier path too" {
+  cat > "$STUB_DIR/railway-tier-drift" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "promote" ] || { echo "expected first arg 'promote', got '$1'" >&2; exit 99; }
+svc="$2"
+echo "STUB called for: $svc"
+if [ "$svc" = "svc-h" ]; then
+  echo "STAGING_DRIFT_MARKER: svc-h(running=f9454e79fbf5,latest=261ccdef3f9a)"
+fi
+exit 0
+STUB
+  chmod +x "$STUB_DIR/railway-tier-drift"
+  export RAILWAY_BIN="$STUB_DIR/railway-tier-drift"
+
+  run env CLOSURE_PLAN="0:svc-a,1:svc-h,2:svc-i1" bash "$SCRIPT"
+
+  [ "$status" -eq 0 ] || fail "drift must not fail the run, got $status: $output"
+  [[ "$output" == *"STAGING DRIFT (1)"* ]] || fail "missing drift summary block on tier path: $output"
+
+  run cat "$GITHUB_OUTPUT"
+  [[ "$output" == *"staging_drift=svc-h(running=f9454e79fbf5,latest=261ccdef3f9a)"* ]] \
+    || fail "missing/wrong staging_drift on tier path: $output"
+}
+
+@test "U4: closure plan with empty/whitespace tokens within a tier skips them" {
+  setup_tier_stub
+  # A stray comma / whitespace token inside the tier-annotated plan must be
+  # skipped exactly like the flat-CSV path (preserve trim + empty-token skip).
+  run env CLOSURE_PLAN="0:svc-a,0: ,1:svc-h" bash "$SCRIPT"
+
+  [ "$status" -eq 0 ] || fail "expected zero exit, got $status: $output"
+  [[ "$output" == *"STUB called for: svc-a"* ]] || fail "svc-a not attempted: $output"
+  [[ "$output" == *"STUB called for: svc-h"* ]] || fail "svc-h not attempted: $output"
+
+  run cat "$GITHUB_OUTPUT"
+  [[ "$output" == *"succeeded_csv=svc-a,svc-h"* ]] || fail "wrong succeeded_csv (whitespace token skipped): $output"
+}

--- a/showcase/scripts/__tests__/resolve-promote-targets.bats
+++ b/showcase/scripts/__tests__/resolve-promote-targets.bats
@@ -1,0 +1,183 @@
+#!/usr/bin/env bats
+# Tests for resolve-promote-targets.sh — the resolve-targets logic extracted from
+# .github/workflows/showcase_promote.yml so the closure derivation + the existing
+# guards are unit-testable (mirrors how verify-prod-display.sh / promote-fleet.sh
+# were extracted from the same workflow).
+#
+# U3 (spec §8.3 Phase 1, BACKWARD-COMPAT). The script MUST:
+#   1. Resolve INPUT (SSOT key / dispatch_name / 'all') into services_csv —
+#      the EXISTING leaf-set CSV used by the actual promote (unchanged behavior).
+#   2. Compute the tiered promote CLOSURE from the generated JSON's `closure`
+#      block (transitive runtimeDeps ∪ Tier-1 verification, tier-ordered 0→1→2)
+#      and EMIT it into $GITHUB_STEP_SUMMARY so operators SEE the closure (§4.5),
+#      WITHOUT changing the leaf-set promote (U4 enforces tier ordering later).
+#   3. Emit a tier-annotated `closure_csv` output for U4 to consume.
+#   4. PRESERVE the existing guards: the --digest+all reject, the empty-CSV
+#      fail-loud, the ambiguous/unknown-service guard.
+#
+# Inputs (env): INPUT (workflow_dispatch service), DIGEST (optional), GENERATED
+# (path to railway-envs.generated.json). Outputs are appended to $GITHUB_OUTPUT
+# and $GITHUB_STEP_SUMMARY (both pointed at temp files by setup()).
+#
+# NB on assertion gating: bats does NOT run test bodies under `set -e`. Only the
+# FINAL command decides pass/fail, so every non-final assertion is written
+# `[[ ... ]] || fail "msg"` to force a hard failure with a diagnostic.
+
+fail() {
+  echo "$1" >&2
+  return 1
+}
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../resolve-promote-targets.sh"
+  [ -f "$SCRIPT" ] || fail "resolve-promote-targets.sh missing at $SCRIPT"
+
+  export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/github_output"
+  export GITHUB_STEP_SUMMARY="$BATS_TEST_TMPDIR/github_step_summary"
+  : > "$GITHUB_OUTPUT"
+  : > "$GITHUB_STEP_SUMMARY"
+
+  # A small, self-contained fixture so the test does not depend on the live SSOT
+  # (which churns as integrations come and go). Two tier-2 agents both depend on
+  # tier-0 `aimock`; `dashboard` is tier-1 and depends on tier-0 `pocketbase` +
+  # tier-1 `harness`. `legacy` has probe.prod:false (must never resolve as a
+  # leaf). The `closure.services` array is the tier-ordered full-fleet closure
+  # (as U2 emits it); the per-service entries carry promoteTier/runtimeDeps.
+  GEN="$BATS_TEST_TMPDIR/generated.json"
+  cat > "$GEN" <<'JSON'
+{
+  "closure": {
+    "services": [
+      { "name": "aimock", "tier": 0 },
+      { "name": "pocketbase", "tier": 0 },
+      { "name": "harness", "tier": 1 },
+      { "name": "dashboard", "tier": 1 },
+      { "name": "agent-a", "tier": 2 },
+      { "name": "agent-b", "tier": 2 }
+    ],
+    "skipped": [
+      { "name": "harness-workers", "reason": "no \"prod\" environment in the SSOT" }
+    ]
+  },
+  "services": [
+    { "name": "aimock", "dispatchName": "showcase-aimock", "probe": { "prod": true }, "promoteTier": 0 },
+    { "name": "pocketbase", "dispatchName": "showcase-pocketbase", "probe": { "prod": true }, "promoteTier": 0 },
+    { "name": "harness", "dispatchName": "showcase-harness", "probe": { "prod": true }, "promoteTier": 1 },
+    { "name": "dashboard", "dispatchName": "shell-dashboard", "probe": { "prod": true }, "promoteTier": 1, "runtimeDeps": ["pocketbase", "harness"] },
+    { "name": "agent-a", "dispatchName": "a", "probe": { "prod": true }, "promoteTier": 2, "runtimeDeps": ["aimock"], "serviceRefs": [ { "key": "OPENAI_BASE_URL", "target": "aimock" } ] },
+    { "name": "agent-b", "dispatchName": "b", "probe": { "prod": true }, "promoteTier": 2, "runtimeDeps": ["aimock"] },
+    { "name": "legacy", "dispatchName": "legacy", "probe": { "prod": false }, "promoteTier": 2 }
+  ]
+}
+JSON
+  export GENERATED="$GEN"
+}
+
+run_resolve() {
+  # run_resolve <INPUT> [DIGEST]
+  INPUT="$1" DIGEST="${2:-}" GENERATED="$GENERATED" run bash "$SCRIPT"
+}
+
+# --- existing leaf-set behavior (backward-compat, must be unchanged) ---------
+
+@test "single service by SSOT name -> leaf services_csv is just that service" {
+  run_resolve "agent-a"
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status: $output"
+  run grep '^services_csv=' "$GITHUB_OUTPUT"
+  [ "$output" = "services_csv=agent-a" ] || fail "leaf services_csv changed: $output"
+}
+
+@test "single service by dispatch_name -> leaf services_csv is the SSOT name" {
+  run_resolve "a"
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status: $output"
+  run grep '^services_csv=' "$GITHUB_OUTPUT"
+  [ "$output" = "services_csv=agent-a" ] || fail "dispatch_name did not map to SSOT name: $output"
+}
+
+@test "all -> leaf services_csv is every prod-eligible service (legacy excluded)" {
+  run_resolve "all"
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status: $output"
+  run grep '^services_csv=' "$GITHUB_OUTPUT"
+  # All prod-eligible SSOT names, sorted (the existing `sort -u` behavior).
+  [ "$output" = "services_csv=agent-a,agent-b,aimock,dashboard,harness,pocketbase" ] \
+    || fail "all leaf CSV wrong (legacy must be excluded): $output"
+}
+
+# --- preserved guards --------------------------------------------------------
+
+@test "--digest + all is rejected loud" {
+  run_resolve "all" "sha256:deadbeef"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit on --digest+all, got $status"
+  [[ "$output" == *"::error::"* ]] || fail "expected ::error:: on --digest+all: $output"
+}
+
+@test "unknown service is rejected loud" {
+  run_resolve "does-not-exist"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit on unknown service, got $status"
+  [[ "$output" == *"::error::"* ]] || fail "expected ::error:: on unknown service: $output"
+}
+
+@test "not-prod-eligible service is rejected loud" {
+  run_resolve "legacy"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit on non-prod-eligible service, got $status"
+  [[ "$output" == *"::error::"* ]] || fail "expected ::error:: on non-prod-eligible service: $output"
+}
+
+@test "the placeholder selection aborts loud" {
+  run_resolve "__select_a_service__"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit on placeholder, got $status"
+  [[ "$output" == *"::error::"* ]] || fail "expected ::error:: on placeholder: $output"
+}
+
+# --- NEW: tiered closure computation + surfacing (U3) -------------------------
+
+@test "single tier-2 service closure pulls its tier-0 dep + ALL tier-1 verification, tier-ordered" {
+  run_resolve "agent-a"
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status: $output"
+  run grep '^closure_csv=' "$GITHUB_OUTPUT"
+  # agent-a (t2) -> aimock (t0, its runtimeDep) + harness,dashboard (t1, always
+  # included for an equivalence-gated promote) + dashboard's transitive deps
+  # pocketbase (t0) + harness (t1) + agent-a (t2). Tier-ordered (0→1→2), and
+  # WITHIN a tier the closure block's listing order (harness BEFORE dashboard).
+  [ "$output" = "closure_csv=aimock,pocketbase,harness,dashboard,agent-a" ] \
+    || fail "closure_csv wrong shape/order: $output"
+}
+
+@test "closure plan is surfaced into the step summary, tier-labeled" {
+  run_resolve "agent-a"
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status: $output"
+  run cat "$GITHUB_STEP_SUMMARY"
+  [[ "$output" == *"Promote closure"* ]] || fail "summary missing closure heading: $output"
+  [[ "$output" == *"aimock"* ]] || fail "summary missing tier-0 dep aimock: $output"
+  [[ "$output" == *"agent-a"* ]] || fail "summary missing requested service: $output"
+  # The summary must show the TIER for each member so the operator sees ordering.
+  [[ "$output" == *"tier 0"* || "$output" == *"Tier 0"* || "$output" == *"t0"* ]] \
+    || fail "summary missing tier labels: $output"
+}
+
+@test "all -> closure_csv equals the full tier-ordered closure" {
+  run_resolve "all"
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status: $output"
+  run grep '^closure_csv=' "$GITHUB_OUTPUT"
+  # The whole fleet, in the closure block's tier order (0,0,1,1,2,2).
+  [ "$output" = "closure_csv=aimock,pocketbase,harness,dashboard,agent-a,agent-b" ] \
+    || fail "all closure_csv wrong: $output"
+}
+
+@test "skipped (no-prod-env) members are surfaced in the summary, never silent" {
+  run_resolve "all"
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status: $output"
+  run cat "$GITHUB_STEP_SUMMARY"
+  [[ "$output" == *"harness-workers"* ]] || fail "summary did not surface skipped member: $output"
+  [[ "$output" == *"skip"* || "$output" == *"Skip"* ]] || fail "summary missing skip reason label: $output"
+}
+
+@test "tier-annotated closure_plan output is emitted for U4 to consume" {
+  run_resolve "agent-a"
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status: $output"
+  # A machine-readable tier-annotated plan (tier:name pairs) for U4's gating.
+  run grep '^closure_plan=' "$GITHUB_OUTPUT"
+  [ "$status" -eq 0 ] || fail "closure_plan output missing"
+  [[ "$output" == *"0:aimock"* ]] || fail "closure_plan missing tier-annotated tier-0 entry: $output"
+  [[ "$output" == *"2:agent-a"* ]] || fail "closure_plan missing tier-annotated tier-2 entry: $output"
+}

--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -28,10 +28,14 @@ describe("ServiceEntry gateIgnore field", () => {
     // `harness-legacy` fleet-migration bridge (runs a pinned out-of-band
     // digest, not the canonical :latest/@sha256 shape). See their SSOT
     // entries in railway-envs.ts for the rationale.
+    // S2: the 12 starter-<slug> services are NO LONGER gate-ignored — they
+    // are fully gate-managed (gateValidated, no gateIgnore), so they fall
+    // into the default-falsy branch below exactly like every showcase-* agent.
     const GATE_IGNORED = new Set(["harness-workers", "harness-legacy"]);
+    const isGateIgnored = (name: string): boolean => GATE_IGNORED.has(name);
     for (const [name, entry] of Object.entries(SERVICES)) {
       const gi = (entry as ServiceEntry).gateIgnore;
-      if (GATE_IGNORED.has(name)) {
+      if (isGateIgnored(name)) {
         expect(gi, `${name} gateIgnore`).toBe(true);
         continue;
       }
@@ -65,16 +69,27 @@ describe("findUntrackedServices (Railway -> SSOT direction)", () => {
     expect(findUntrackedServices(railway)).toEqual(["alpha-svc", "zeta-svc"]);
   });
 
-  it("does NOT flag a `starter-*` live service that is absent from the SSOT", () => {
-    // The starter container fleet (starter-<slug>) is auto-discovered by
-    // the starter_smoke probe (railway-services source, namePrefix
-    // "starter-") and is intentionally DECOUPLED from this 27-service
-    // SSOT. Provisioning a starter-* service must NOT trip the
-    // Railway->SSOT drift gate (which previously SKIPPED the build).
+  it("tolerates the 12 SSOT-managed starters via the normal SSOT-membership branch (S2)", () => {
+    // S2: starter-langgraph-python / starter-mastra are now SSOT entries, so
+    // they are tolerated by the `if (entry) continue` SSOT-membership branch
+    // exactly like every other tracked service — NOT by the starter carve-out.
     const railway = new Set<string>([
       "showcase-mastra", // tracked
-      "starter-langgraph-python", // starter fleet, decoupled — tolerated
-      "starter-mastra", // starter fleet, decoupled — tolerated
+      "starter-langgraph-python", // SSOT-managed starter (S2) — tracked
+      "starter-mastra", // SSOT-managed starter (S2) — tracked
+    ]);
+    expect(findUntrackedServices(railway)).toEqual([]);
+  });
+
+  it("tolerates a NON-SSOT `starter-*` live service via the narrow carve-out", () => {
+    // The narrowed carve-out only covers a stray/in-flight starter that is
+    // NOT (yet) in the SSOT — e.g. a brand-new starter slug provisioned ahead
+    // of its SSOT entry. `starter-experimental-xyz` has no SSOT entry, so it
+    // falls past the SSOT-membership branch into isStarterFleetService() and
+    // is tolerated (the starter_smoke probe auto-discovers it by prefix).
+    const railway = new Set<string>([
+      "showcase-mastra", // tracked
+      "starter-experimental-xyz", // non-SSOT starter — narrow carve-out
     ]);
     expect(findUntrackedServices(railway)).toEqual([]);
   });
@@ -85,7 +100,7 @@ describe("findUntrackedServices (Railway -> SSOT direction)", () => {
     // even when a tolerated starter-* service is present alongside it.
     const railway = new Set<string>([
       "showcase-mastra", // tracked
-      "starter-mastra", // starter fleet — tolerated
+      "starter-mastra", // SSOT-managed starter — tolerated
       "showcase-rogue-untracked", // real drift — must be flagged
     ]);
     expect(findUntrackedServices(railway)).toEqual([
@@ -141,17 +156,20 @@ describe("isStarterFleetService predicate", () => {
   });
 });
 
-describe("findMissingServices — starter fleet is never required", () => {
-  it("does not require any `starter-*` service (none are in the SSOT)", () => {
-    // Starter services are decoupled from the SSOT, so they are never
-    // gateValidated SSOT entries and findMissingServices never demands
-    // them. A present-set containing only a starter service must still
-    // report the real gateValidated services as missing — and never the
-    // starter itself.
+describe("findMissingServices — starter fleet IS required (S2)", () => {
+  it("requires the 12 SSOT-managed `starter-*` services like any tracked service", () => {
+    // S2 reversed the S1 decoupling: starters are gateValidated SSOT entries,
+    // so findMissingServices DEMANDS them when absent from Railway, exactly
+    // like a showcase-* agent. A present-set containing only starter-mastra
+    // must therefore still report starter-langgraph-python (and the showcase
+    // fleet) as missing — proving the carve-out is gone.
     const present = new Set<string>(["starter-mastra"]);
     const missing = findMissingServices("prod", present);
+    // starter-mastra is present → not missing; the other starters ARE.
     expect(missing).not.toContain("starter-mastra");
-    // Sanity: the tracked fleet is still required when absent.
+    expect(missing).toContain("starter-langgraph-python");
+    expect(missing).toContain("starter-adk");
+    // Sanity: the showcase fleet is still required when absent.
     expect(missing).toContain("showcase-mastra");
   });
 });
@@ -240,21 +258,21 @@ describe("WS-C: all gate-managed services gateValidated, with correct overrides"
     ["harness", "showcase-harness"],
   ] as const;
 
-  it("has 29 services in the SSOT", () => {
-    expect(Object.keys(SERVICES)).toHaveLength(29);
+  it("has 41 services in the SSOT (29 showcase/infra + 12 starter-*)", () => {
+    expect(Object.keys(SERVICES)).toHaveLength(41);
   });
 
   it("marks every gate-managed service gateValidated (no Phase-2 holdouts)", () => {
-    // Two intentional gateValidated:false entries: the staging-only
-    // `harness-workers` (gateIgnore:true — no public domain) and the
-    // interim `harness-legacy` fleet-migration bridge (gateIgnore:true — runs
-    // a pinned out-of-band digest). Every OTHER service must be
-    // gateValidated:true.
+    // Intentional gateValidated:false entries: the staging-only
+    // `harness-workers` (gateIgnore:true — no public domain) and the interim
+    // `harness-legacy` fleet-migration bridge (gateIgnore:true — runs a
+    // pinned out-of-band digest). S2 brought the 12 starter-<slug> services
+    // UNDER the gate (gateValidated:true), so they are no longer holdouts —
+    // every OTHER service, starters included, must be gateValidated:true.
     const GATE_IGNORED = new Set(["harness-workers", "harness-legacy"]);
+    const isGateIgnored = (name: string): boolean => GATE_IGNORED.has(name);
     const unvalidated = Object.entries(SERVICES)
-      .filter(
-        ([name, entry]) => !entry.gateValidated && !GATE_IGNORED.has(name),
-      )
+      .filter(([name, entry]) => !entry.gateValidated && !isGateIgnored(name))
       .map(([name]) => name);
     expect(unvalidated).toEqual([]);
   });
@@ -272,13 +290,20 @@ describe("WS-C: all gate-managed services gateValidated, with correct overrides"
     });
   }
 
-  it("findMissingServices treats all 27 as gateValidated targets", () => {
-    // With nothing "present", every gateValidated service should
-    // appear in the missing set; after C.3 that means all 27.
+  it("findMissingServices treats all 39 gateValidated services as targets (27 showcase/infra + 12 starters)", () => {
+    // With nothing "present", every gateValidated service should appear in
+    // the missing set. After S2 brought the 12 starter-<slug> services under
+    // the gate (gateValidated:true, dual-env), that means all 39 — the 27
+    // showcase/infra gateValidated services plus the 12 starters. (The two
+    // gateIgnore entries, harness-workers + harness-legacy, are NOT
+    // gateValidated and so are not required here.)
     const missingProd = findMissingServices("prod", new Set<string>());
     const missingStaging = findMissingServices("staging", new Set<string>());
-    expect(missingProd).toHaveLength(27);
-    expect(missingStaging).toHaveLength(27);
+    expect(missingProd).toHaveLength(39);
+    expect(missingStaging).toHaveLength(39);
+    // The 12 starters are now demanded in BOTH envs.
+    expect(missingProd).toContain("starter-adk");
+    expect(missingStaging).toContain("starter-mastra");
   });
 });
 

--- a/showcase/scripts/emit-railway-envs-json.test.ts
+++ b/showcase/scripts/emit-railway-envs-json.test.ts
@@ -1,0 +1,186 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { SERVICES, computePromoteClosure } from "./railway-envs";
+
+const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
+const EMITTER = resolve(SCRIPTS_DIR, "emit-railway-envs-json.ts");
+const OXFMT = resolve(SCRIPTS_DIR, "..", "..", "node_modules", ".bin", "oxfmt");
+
+/**
+ * Emit the JSON to a hermetic temp path and parse it. The emitter is the
+ * single source of the artifact shape, so the test drives the real emitter
+ * (via `--out=`) rather than reconstructing the payload.
+ */
+function emitToTemp(): {
+  parsed: Record<string, unknown>;
+  raw: string;
+  cleanup: () => void;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "emit-railway-envs-"));
+  const out = join(dir, "railway-envs.generated.json");
+  execFileSync("npx", ["tsx", EMITTER, `--out=${out}`], {
+    cwd: SCRIPTS_DIR,
+    stdio: "pipe",
+  });
+  const raw = readFileSync(out, "utf8");
+  return {
+    parsed: JSON.parse(raw) as Record<string, unknown>,
+    raw,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("emit-railway-envs-json closure block", () => {
+  let parsed: Record<string, unknown>;
+  let cleanup: () => void;
+
+  beforeAll(() => {
+    const r = emitToTemp();
+    parsed = r.parsed;
+    cleanup = r.cleanup;
+  });
+
+  afterAll(() => cleanup?.());
+
+  it("emits a top-level `closure` block matching computePromoteClosure(all)", () => {
+    const expected = computePromoteClosure(Object.keys(SERVICES));
+    expect(parsed.closure).toBeDefined();
+    const closure = parsed.closure as {
+      services: { name: string; tier: number }[];
+      skipped: { name: string; reason: string }[];
+    };
+    expect(closure.services).toEqual(expected.services);
+    expect(closure.skipped).toEqual(expected.skipped);
+  });
+
+  it("closure.services is tier-ordered (0 → 1 → 2, non-decreasing)", () => {
+    const closure = parsed.closure as {
+      services: { name: string; tier: number }[];
+    };
+    const tiers = closure.services.map((s) => s.tier);
+    const sorted = [...tiers].sort((a, b) => a - b);
+    expect(tiers).toEqual(sorted);
+  });
+
+  it("emits per-service promoteTier / runtimeDeps / serviceRefs from the SSOT", () => {
+    const services = parsed.services as Array<{
+      name: string;
+      promoteTier: number;
+      runtimeDeps?: string[];
+      serviceRefs?: { key: string; target: string }[];
+    }>;
+
+    // aimock is declared tier 0 in the SSOT.
+    const aimock = services.find((s) => s.name === "aimock");
+    expect(aimock?.promoteTier).toBe(0);
+
+    // An agent integration carries runtimeDeps:["aimock"] + an OPENAI_BASE_URL
+    // serviceRef → aimock. Names are SSOT keys (e.g. "showcase-ag2"), not
+    // dispatch_names.
+    const agent = services.find((s) => s.name === "showcase-ag2");
+    expect(agent?.runtimeDeps).toEqual(["aimock"]);
+    expect(agent?.serviceRefs).toEqual([
+      { key: "OPENAI_BASE_URL", target: "aimock" },
+    ]);
+
+    // promoteTier is always present (defaults to 2 for a leaf integration).
+    expect(agent?.promoteTier).toBe(2);
+  });
+});
+
+describe("emit-railway-envs-json legacy shape preservation (golden)", () => {
+  it("keeps the committed per-service legacy keys BYTE-IDENTICAL", () => {
+    const { parsed, cleanup } = emitToTemp();
+    try {
+      const committed = JSON.parse(
+        readFileSync(
+          resolve(SCRIPTS_DIR, "railway-envs.generated.json"),
+          "utf8",
+        ),
+      ) as { services: Array<Record<string, unknown>> };
+      const emitted = parsed as unknown as {
+        services: Array<Record<string, unknown>>;
+      };
+
+      // The set of frozen legacy keys must be a SUBSET of every emitted
+      // service, with byte-identical values — new keys (promoteTier/
+      // runtimeDeps/serviceRefs) are additive only.
+      const LEGACY_KEYS = [
+        "name",
+        "serviceId",
+        "prodInstanceId",
+        "stagingInstanceId",
+        "ciBuilt",
+        "gateValidated",
+        "dispatchName",
+        "repoNameOverride",
+        "domains",
+        "probe",
+      ];
+      const projectLegacy = (s: Record<string, unknown>) => {
+        const out: Record<string, unknown> = {};
+        for (const k of LEGACY_KEYS) {
+          if (Object.hasOwn(s, k)) out[k] = s[k];
+        }
+        return out;
+      };
+
+      const byNameCommitted = new Map(
+        committed.services.map((s) => [s.name as string, projectLegacy(s)]),
+      );
+      for (const s of emitted.services) {
+        const legacy = projectLegacy(s);
+        expect(byNameCommitted.get(s.name as string)).toEqual(legacy);
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("the committed railway-envs.generated.json is up to date (emit --check passes)", () => {
+    // GREEN gate: after regen, the in-repo artifact equals the emitter output.
+    execFileSync("npx", ["tsx", EMITTER, "--check"], {
+      cwd: SCRIPTS_DIR,
+      stdio: "pipe",
+    });
+  });
+});
+
+describe("emit-railway-envs-json oxfmt-canonical output", () => {
+  // CI's static_quality.yml formats this artifact with oxfmt and auto-commits
+  // any drift. If the emitter produced raw `JSON.stringify(_, null, 2)` (with
+  // multi-line arrays), `oxfmt --check` would fail forever (oxfmt wants
+  // compact arrays) while `emit --check` (a raw string compare) would fail the
+  // moment we oxfmt-fixed the file — the two checks conflict. The emitter
+  // routes its output through oxfmt so both pass simultaneously, with no bot.
+  it("emitter output passes oxfmt --check (no auto-format drift)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "emit-railway-envs-oxfmt-"));
+    const out = join(dir, "railway-envs.generated.json");
+    try {
+      // Emit via the real emitter into a hermetic path...
+      execFileSync("npx", ["tsx", EMITTER, `--out=${out}`], {
+        cwd: SCRIPTS_DIR,
+        stdio: "pipe",
+      });
+      // ...then assert oxfmt considers the result already-canonical. RED on
+      // the pre-fix emitter (multi-line arrays → "Format issues found"),
+      // GREEN once the emitter routes output through oxfmt.
+      const res = spawnSync(OXFMT, ["--check", out], { encoding: "utf8" });
+      expect(res.status).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("the committed railway-envs.generated.json passes oxfmt --check", () => {
+    // The in-repo artifact must stay oxfmt-canonical so the CI auto-format
+    // bot never fires on it.
+    const committed = resolve(SCRIPTS_DIR, "railway-envs.generated.json");
+    const res = spawnSync(OXFMT, ["--check", committed], { encoding: "utf8" });
+    expect(res.status).toBe(0);
+  });
+});

--- a/showcase/scripts/emit-railway-envs-json.ts
+++ b/showcase/scripts/emit-railway-envs-json.ts
@@ -21,14 +21,23 @@
  *                      writes). Defaults to the canonical tracked artifact.
  */
 
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import {
   PRODUCTION_ENV_ID,
   PROJECT_ID,
   SERVICES,
   STAGING_ENV_ID,
+  computePromoteClosure,
 } from "./railway-envs";
+import type { ClosurePlan } from "./railway-envs";
 
 const DEFAULT_OUTPUT_PATH = resolve(
   new URL(".", import.meta.url).pathname,
@@ -49,7 +58,26 @@ interface Emitted {
     repoNameOverride?: { prod?: string; staging?: string };
     domains: { staging: string; prod: string };
     probe: { staging: boolean; prod: boolean; driver: string };
+    // --- Promote-closure fields (ADDITIVE, U2). Appended AFTER the frozen
+    // legacy keys above so the Ruby/jq legacy shape stays byte-identical. ---
+    // Effective promote tier (declared `promoteTier`, default 2). ALWAYS
+    // emitted so the Ruby CLI + workflow jq never have to recompute the
+    // default. 0 = shared infra, 1 = verification control plane, 2 = leaf.
+    promoteTier: 0 | 1 | 2;
+    // SSOT keys this service needs present-and-current to be meaningful.
+    // OMITTED when the SSOT entry declares none (matches the leaf default).
+    runtimeDeps?: string[];
+    // Cross-service env-var references the Stage-2 Ruby preflight (U5)
+    // ASSERTS. OMITTED when the SSOT entry declares none.
+    serviceRefs?: { key: string; target: string }[];
   }>;
+  // --- Top-level promote-closure plan (ADDITIVE, U2). The tier-ordered
+  // closure for the FULL fleet (`all`), computed via `computePromoteClosure`.
+  // Consumed by the workflow's resolve-targets jq (U3) + the fleet driver
+  // (U4) so the tiered plan is a single source of truth read from the JSON
+  // rather than recomputed in bash. Per-service `closure` for a NAMED subset
+  // is recomputed by the consumer from the per-service fields above. ---
+  closure: ClosurePlan;
 }
 
 /**
@@ -116,6 +144,18 @@ function projectServiceToLegacyJson(
       prod: prodEnv ? (prodEnv.probe ?? true) : false,
       driver: entry.probeDriver,
     },
+    // --- Promote-closure fields, appended AFTER `probe` so every legacy key
+    // keeps its frozen serialization position (the golden contract). ---
+    // Default to the leaf tier 2 when omitted, matching `computePromoteClosure`.
+    promoteTier: entry.promoteTier ?? 2,
+    // Omit the key entirely when the SSOT declares none, so the leaf default
+    // (no deps / no refs) does not add empty arrays to every leaf service.
+    ...(entry.runtimeDeps !== undefined
+      ? { runtimeDeps: entry.runtimeDeps }
+      : {}),
+    ...(entry.serviceRefs !== undefined
+      ? { serviceRefs: entry.serviceRefs }
+      : {}),
   };
 }
 
@@ -123,15 +163,62 @@ function buildPayload(): Emitted {
   const services: Emitted["services"] = Object.entries(SERVICES)
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([name, entry]) => projectServiceToLegacyJson(name, entry));
+  // The full-fleet (`all`) closure: tier-ordered promotable services + the
+  // skipped-with-reason members. `computePromoteClosure` is the SSOT for the
+  // tiering; emitting it here keeps the workflow jq + fleet driver from
+  // re-implementing the closure math in bash.
+  const closure = computePromoteClosure(Object.keys(SERVICES));
   return {
     projectId: PROJECT_ID,
     envIds: { staging: STAGING_ENV_ID, prod: PRODUCTION_ENV_ID },
     services,
+    closure,
   };
 }
 
-function serialize(payload: Emitted): string {
-  return JSON.stringify(payload, null, 2) + "\n";
+/**
+ * The repo-root oxfmt binary. CI's `static_quality.yml` formats this
+ * artifact with oxfmt and auto-commits any drift, so the emitter must
+ * produce oxfmt-CANONICAL output — otherwise `oxfmt --check` (CI) and
+ * `emit --check` (this script's raw string compare) conflict forever:
+ * oxfmt wants compact arrays (`["pocketbase","harness"]`), the raw
+ * `JSON.stringify(_, null, 2)` emits multi-line ones. Routing the write
+ * path AND the `--check` comparison through oxfmt makes on-disk ==
+ * emitter-oxfmt-output == oxfmt-canonical, so both checks pass with no bot.
+ */
+const OXFMT_BIN = resolve(
+  new URL(".", import.meta.url).pathname,
+  "..",
+  "..",
+  "node_modules",
+  ".bin",
+  "oxfmt",
+);
+
+/**
+ * Run the committed oxfmt over a JSON string and return the canonical
+ * formatting. We shell out to the SAME binary CI uses (rather than the
+ * programmatic API, which would not auto-discover the repo `.oxfmtrc.json`)
+ * so the emitter's output is byte-identical to what CI's `oxfmt --check`
+ * accepts. The temp file is created NEXT TO the final artifact's directory
+ * so oxfmt resolves the same `.oxfmtrc.json` (printWidth: 80) it would for
+ * the real file — config discovery walks up from the file path.
+ */
+function oxfmtCanonical(json: string, nearDir: string): string {
+  const tmpDir = mkdtempSync(join(nearDir, ".emit-oxfmt-"));
+  const tmpFile = join(tmpDir, "railway-envs.generated.json");
+  try {
+    writeFileSync(tmpFile, json);
+    execFileSync(OXFMT_BIN, ["--write", tmpFile], { stdio: "pipe" });
+    return readFileSync(tmpFile, "utf8");
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function serialize(payload: Emitted, nearDir: string): string {
+  const raw = JSON.stringify(payload, null, 2) + "\n";
+  return oxfmtCanonical(raw, nearDir);
 }
 
 function parseOutPath(args: string[]): string {
@@ -144,8 +231,14 @@ function main(): void {
   const args = process.argv.slice(2);
   const check = args.includes("--check");
   const outputPath = parseOutPath(args);
+  const outputDir = dirname(outputPath);
   const payload = buildPayload();
-  const next = serialize(payload);
+  // The oxfmt temp file is created inside `outputDir` so config discovery
+  // resolves the same `.oxfmtrc.json` the real artifact would. Ensure the
+  // directory exists before serializing (the write path also recreates it
+  // below; this covers `--check` against a not-yet-created --out dir).
+  mkdirSync(outputDir, { recursive: true });
+  const next = serialize(payload, outputDir);
 
   if (check) {
     let current = "";
@@ -177,7 +270,8 @@ function main(): void {
     return;
   }
 
-  mkdirSync(dirname(outputPath), { recursive: true });
+  // outputDir already created above (so the oxfmt temp file could resolve
+  // the repo `.oxfmtrc.json`); just write the canonical artifact.
   writeFileSync(outputPath, next);
   process.stdout.write(`wrote ${outputPath}\n`);
 }

--- a/showcase/scripts/equivalence-gate.test.ts
+++ b/showcase/scripts/equivalence-gate.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect } from "vitest";
+import {
+  runEquivalenceGate,
+  type EquivalenceGateInput,
+  type GateCell,
+} from "./equivalence-gate";
+import type {
+  LiveStatusMap,
+  StatusRow,
+} from "../shell-dashboard/src/lib/live-status";
+import { keyFor } from "../shell-dashboard/src/lib/live-status";
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+const NOW = Date.parse("2026-06-19T12:00:00.000Z");
+// The re-sweep was triggered 10 minutes before "now" — any prod row observed
+// before this instant is pre-trigger (stale for the gate's §6.4 freshness
+// rule) and must be excluded.
+const RESWEEP_TRIGGER_AT = Date.parse("2026-06-19T11:50:00.000Z");
+const FRESH_AT = "2026-06-19T11:55:00.000Z"; // post-trigger
+const PRE_TRIGGER_AT = "2026-06-19T11:40:00.000Z"; // before re-sweep trigger
+
+function row(
+  dimension: string,
+  slug: string,
+  featureId: string | undefined,
+  state: StatusRow["state"],
+  opts: { observedAt?: string; signal?: unknown } = {},
+): [string, StatusRow] {
+  const key = keyFor(dimension, slug, featureId);
+  const observed = opts.observedAt ?? FRESH_AT;
+  return [
+    key,
+    {
+      id: `${key}#id`,
+      key,
+      dimension,
+      state,
+      signal: opts.signal ?? null,
+      observed_at: observed,
+      transitioned_at: observed,
+      fail_count: state === "red" ? 1 : 0,
+      first_failure_at: state === "red" ? observed : null,
+    },
+  ];
+}
+
+/**
+ * Build a LiveStatusMap that yields a chosen ChipColor for a single
+ * (slug, featureId) cell. We drive `buildCellModel` through the SAME row
+ * shapes the dashboard derives from so the gate reuses the real derivation:
+ *   - "green": fresh-green D3 e2e + fresh-green chat (D4) + fresh-green d5/d6
+ *     for the mapped featureType → ladder intact → green chip.
+ *   - "amber": fresh-green e2e + chat + d5 but a fresh-RED d6 → ladder intact
+ *     to D5, D6 not green → chip amber (cell-model §"D5 green + D6 red/amber
+ *     /missing → amber"). amber is NOT-green, so staging-green/prod-amber is a
+ *     gate mismatch.
+ *   - "red": fresh-red e2e row → gate fails red.
+ *   - "driver-error": red e2e row whose signal carries `errorClass:"driver-error"`
+ *     → U7 folds to gray.
+ *   - "stale-red": red e2e row observed BEFORE the re-sweep trigger → §6.4
+ *     freshness excludes it (gray).
+ */
+type ColorKind = "green" | "amber" | "red" | "driver-error";
+
+// featureId chosen so it is NOT in CATALOG_TO_D5_KEY → D5/D6 unmapped, so a
+// fresh green chat+e2e with a D5-unmapped feature renders... not green (the
+// chip needs a mapped green D5 for green). To get a clean green we instead use
+// a feature WITH a D5 mapping. Pick a real catalog featureType key.
+const MAPPED_FEATURE = "agentic-chat"; // present in CATALOG_TO_D5_KEY
+
+function cellMap(
+  slug: string,
+  color: ColorKind,
+  opts: { observedAt?: string } = {},
+): LiveStatusMap {
+  const observed = opts.observedAt ?? FRESH_AT;
+  const m: LiveStatusMap = new Map();
+  if (color === "green" || color === "amber") {
+    // Intact ladder up to D5: e2e green, chat green (D4), d5 green for the
+    // mapped featureType. D6 decides green vs amber — green for "green", red
+    // for "amber" (cell-model: D5 green + D6 not-green → amber chip).
+    m.set(
+      ...row("e2e", slug, MAPPED_FEATURE, "green", { observedAt: observed }),
+    );
+    m.set(...row("chat", slug, undefined, "green", { observedAt: observed }));
+    m.set(
+      ...row("d5", slug, MAPPED_FEATURE, "green", { observedAt: observed }),
+    );
+    m.set(
+      ...row("d6", slug, MAPPED_FEATURE, color === "green" ? "green" : "red", {
+        observedAt: observed,
+      }),
+    );
+    return m;
+  }
+  // red / driver-error: a genuine red e2e row drives the chip red. We still
+  // emit a green chat so the D1-D4 gate is exercised (e2e red dominates).
+  const signal =
+    color === "driver-error" ? { errorClass: "driver-error" } : undefined;
+  m.set(
+    ...row("e2e", slug, MAPPED_FEATURE, "red", {
+      observedAt: observed,
+      signal,
+    }),
+  );
+  m.set(...row("chat", slug, undefined, "green", { observedAt: observed }));
+  return m;
+}
+
+function gateInput(
+  cells: GateCell[],
+  staging: LiveStatusMap,
+  prod: LiveStatusMap,
+): EquivalenceGateInput {
+  return {
+    cells,
+    stagingRows: staging,
+    prodRows: prod,
+    reSweepTriggerAt: RESWEEP_TRIGGER_AT,
+    now: NOW,
+  };
+}
+
+const CELL: GateCell = {
+  slug: "demo",
+  featureId: MAPPED_FEATURE,
+  isSupported: true,
+  isWired: true,
+};
+
+/** The 4 starter smoke levels, mirroring STARTER_LEVELS. */
+const STARTER_LEVELS = ["health", "agent", "chat", "interaction"] as const;
+
+/**
+ * A STARTER-axis cell, keyed by its dashboard COLUMN slug. The equivalence
+ * gate must resolve its ChipColor from the `starter:<col>/<level>` rows, NOT
+ * the agent feature ladder.
+ */
+const STARTER_CELL: GateCell = {
+  slug: "google-adk",
+  featureId: "starter",
+  isSupported: true,
+  isWired: true,
+  probeAxis: "starter",
+};
+
+/**
+ * Build a LiveStatusMap that yields a chosen ChipColor for a starter cell by
+ * setting all four `starter:<col>/<level>` rows to a uniform state:
+ *   - "green": every level fresh-green → green chip.
+ *   - "red":   one level red (the rest green) → red chip.
+ */
+function starterCellMap(
+  columnSlug: string,
+  color: "green" | "red",
+  opts: { observedAt?: string } = {},
+): LiveStatusMap {
+  const observed = opts.observedAt ?? FRESH_AT;
+  const m: LiveStatusMap = new Map();
+  STARTER_LEVELS.forEach((level, i) => {
+    const state =
+      color === "red" && i === STARTER_LEVELS.length - 1 ? "red" : "green";
+    m.set(
+      ...row("starter", columnSlug, level, state, { observedAt: observed }),
+    );
+  });
+  return m;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("runEquivalenceGate", () => {
+  it("FAILS on staging-green / prod-red(genuine)", () => {
+    const result = runEquivalenceGate(
+      gateInput([CELL], cellMap("demo", "green"), cellMap("demo", "red")),
+    );
+    expect(result.passed).toBe(false);
+    expect(result.mismatches).toHaveLength(1);
+    expect(result.mismatches[0]).toMatchObject({
+      slug: "demo",
+      featureId: MAPPED_FEATURE,
+      stagingChip: "green",
+      prodChip: "red",
+    });
+    // The mismatch must surface in the summary text for the workflow/Slack.
+    expect(result.summary).toContain("demo");
+  });
+
+  it("FAILS a STARTER-axis cell green-on-staging / red-on-prod (resolved on the starter-smoke axis)", () => {
+    // The starter cell's ChipColor must be derived from `starter:<col>/<level>`
+    // rows — NOT the agent e2e/d5/d6 ladder. Staging green + prod red on the
+    // starter axis is a real prod regression → gate FAILS.
+    const result = runEquivalenceGate(
+      gateInput(
+        [STARTER_CELL],
+        starterCellMap("google-adk", "green"),
+        starterCellMap("google-adk", "red"),
+      ),
+    );
+    expect(result.passed).toBe(false);
+    expect(result.mismatches).toHaveLength(1);
+    expect(result.mismatches[0]).toMatchObject({
+      slug: "google-adk",
+      stagingChip: "green",
+      prodChip: "red",
+      mismatch: true,
+      excluded: false,
+    });
+  });
+
+  it("EXCLUDES a STARTER-axis cell with a stale prod observation (pre-trigger)", () => {
+    // The starter cell's prod rows all predate the re-sweep trigger → §6.4
+    // freshness folds the prod chip to gray → excluded → PASS (no false fail).
+    const result = runEquivalenceGate(
+      gateInput(
+        [STARTER_CELL],
+        starterCellMap("google-adk", "green"),
+        starterCellMap("google-adk", "red", { observedAt: PRE_TRIGGER_AT }),
+      ),
+    );
+    expect(result.passed).toBe(true);
+    const cmp = result.comparisons.find((c) => c.slug === "google-adk");
+    expect(cmp?.excluded).toBe(true);
+    expect(cmp?.excludedReason).toBe("stale-prod");
+  });
+
+  it("FAILS on staging-green / prod-amber (amber is not-green → regression)", () => {
+    // §6.3: `amber` = not-green. A cell green on staging but amber on prod is a
+    // prod regression — the promote degraded a fully-green cell to partial. This
+    // exercises the `prodChip !== "green"` mismatch branch via amber (NOT red),
+    // so a refactor to "only red is a regression" would be caught here.
+    const result = runEquivalenceGate(
+      gateInput([CELL], cellMap("demo", "green"), cellMap("demo", "amber")),
+    );
+    expect(result.passed).toBe(false);
+    expect(result.mismatches).toHaveLength(1);
+    expect(result.mismatches[0]).toMatchObject({
+      slug: "demo",
+      featureId: MAPPED_FEATURE,
+      stagingChip: "green",
+      prodChip: "amber",
+      mismatch: true,
+      excluded: false,
+    });
+    // The comparison for the cell is recorded as a real, non-excluded mismatch.
+    const cmp = result.comparisons.find((c) => c.slug === "demo");
+    expect(cmp?.prodChip).toBe("amber");
+    expect(cmp?.excluded).toBe(false);
+    expect(result.summary).toContain("demo");
+  });
+
+  it("PASSES on staging-green / prod-gray(driver-error) — excluded", () => {
+    const result = runEquivalenceGate(
+      gateInput(
+        [CELL],
+        cellMap("demo", "green"),
+        cellMap("demo", "driver-error"),
+      ),
+    );
+    expect(result.passed).toBe(true);
+    expect(result.mismatches).toHaveLength(0);
+    // prod folded to gray via U7 → excluded from the gate.
+    const cmp = result.comparisons.find((c) => c.slug === "demo");
+    expect(cmp?.prodChip).toBe("gray");
+    expect(cmp?.excluded).toBe(true);
+  });
+
+  it("PASSES when prod is GREENER than staging (one-directional)", () => {
+    // staging red, prod green → prod is greener → not a regression → PASS.
+    const result = runEquivalenceGate(
+      gateInput([CELL], cellMap("demo", "red"), cellMap("demo", "green")),
+    );
+    expect(result.passed).toBe(true);
+    expect(result.mismatches).toHaveLength(0);
+  });
+
+  it("EXCLUDES a stale prod row (observed before the re-sweep trigger)", () => {
+    // staging green, prod red BUT the prod row predates the re-sweep trigger →
+    // §6.4 freshness folds it to gray/excluded → PASS.
+    const result = runEquivalenceGate(
+      gateInput(
+        [CELL],
+        cellMap("demo", "green"),
+        cellMap("demo", "red", { observedAt: PRE_TRIGGER_AT }),
+      ),
+    );
+    expect(result.passed).toBe(true);
+    expect(result.mismatches).toHaveLength(0);
+    const cmp = result.comparisons.find((c) => c.slug === "demo");
+    expect(cmp?.excluded).toBe(true);
+    expect(cmp?.excludedReason).toBe("stale-prod");
+  });
+
+  it("PASSES when both sides are green (equivalent)", () => {
+    const result = runEquivalenceGate(
+      gateInput([CELL], cellMap("demo", "green"), cellMap("demo", "green")),
+    );
+    expect(result.passed).toBe(true);
+    expect(result.mismatches).toHaveLength(0);
+  });
+
+  it("EXCLUDES a cell that is gray on STAGING (no staging-green claim to honor)", () => {
+    // staging driver-error→gray, prod red. Gate fires ONLY on staging-green, so
+    // a gray-staging cell is excluded regardless of prod.
+    const result = runEquivalenceGate(
+      gateInput(
+        [CELL],
+        cellMap("demo", "driver-error"),
+        cellMap("demo", "red"),
+      ),
+    );
+    expect(result.passed).toBe(true);
+    expect(result.mismatches).toHaveLength(0);
+    const cmp = result.comparisons.find((c) => c.slug === "demo");
+    expect(cmp?.excluded).toBe(true);
+  });
+
+  it("reports every cell in comparisons and aggregates multiple mismatches", () => {
+    const cellA: GateCell = { ...CELL, slug: "a" };
+    const cellB: GateCell = { ...CELL, slug: "b" };
+    const staging: LiveStatusMap = new Map([
+      ...cellMap("a", "green"),
+      ...cellMap("b", "green"),
+    ]);
+    const prod: LiveStatusMap = new Map([
+      ...cellMap("a", "red"),
+      ...cellMap("b", "green"),
+    ]);
+    const result = runEquivalenceGate(gateInput([cellA, cellB], staging, prod));
+    expect(result.passed).toBe(false);
+    expect(result.comparisons).toHaveLength(2);
+    expect(result.mismatches.map((m) => m.slug)).toEqual(["a"]);
+  });
+});

--- a/showcase/scripts/equivalence-gate.ts
+++ b/showcase/scripts/equivalence-gate.ts
@@ -1,0 +1,280 @@
+/**
+ * Prod ↔ Staging equivalence gate (UNIT U9, spec §6.3/§6.4).
+ *
+ * After a cluster promote re-pins prod and a fresh prod re-sweep lands (U10),
+ * this gate decides whether prod is "equivalent enough" to staging to call the
+ * promote a success. It does NOT re-implement any colour derivation — it reuses
+ * the dashboard's `buildCellModel` (the SINGLE source of truth for the
+ * presentation `ChipColor`) against BOTH PocketBase instances and compares on
+ * the resolved `ChipColor` (green | amber | red | gray), never the lower-level
+ * `State`.
+ *
+ * ── OQ-5 decision: IMPORT, not mirror ────────────────────────────────────
+ * `showcase/shell-dashboard` is intentionally OUTSIDE the pnpm workspace (npm),
+ * while `showcase/scripts` is in it. But ChipColor derivation must have ONE
+ * source of truth — duplicating `buildCellModel`'s ~300-line ladder/U7/U8 logic
+ * here would be a guaranteed-to-drift second copy of the very thing the gate
+ * exists to honor. So we import it by RELATIVE PATH
+ * (`../shell-dashboard/src/lib/cell-model`). This is the lower-blast option and
+ * is already an established pattern in this directory:
+ * `redirect-decommission-core.test.ts` imports `../shell/src/lib/seo-redirects`
+ * the same way. The dashboard lib subtree we pull in
+ * (`cell-model → live-status → staleness → format-ts`) has ZERO React/Next/`@/`
+ * dependencies — it is a pure-TS subtree — so the import resolves cleanly under
+ * tsx / vitest / tsc (`moduleResolution: bundler`, extensionless) without
+ * dragging the dashboard into the pnpm graph or the gate into npm. tsc on
+ * `scripts/tsconfig.json` (`include: ["*.ts", …]`) follows the relative import
+ * and typechecks the subtree with `skipLibCheck`. No tsconfig `paths` mapping
+ * and no mirror+parity-test were needed.
+ *
+ * ── Gate rules (spec §6.3) ────────────────────────────────────────────────
+ *   - FAIL only on a cell that is `green` on STAGING and NOT-`green` on PROD,
+ *     EXCLUDING any cell `gray` on EITHER side. Driver-error / abort (U7) and
+ *     stale rows (U8 / §6.4) fold to `gray`, so they drop out — this is what
+ *     fixes the 418-false-fail.
+ *   - ONE-DIRECTIONAL (§1.1): prod GREENER than staging PASSES (the ~81-vs-~99
+ *     asymmetry is the point, not a defect). We only flag staging-green →
+ *     prod-not-green regressions.
+ *   - `amber` = not-green (a staging-green / prod-amber cell IS a mismatch).
+ *
+ * ── Freshness (spec §6.4) ─────────────────────────────────────────────────
+ * `buildCellModel`'s U8 stale-fold uses each row family's staleness WINDOW
+ * relative to `now`. The gate needs a STRICTER, promote-scoped freshness: ANY
+ * prod cell whose newest contributing row predates the RE-SWEEP TRIGGER instant
+ * is treated as gray/excluded — a row from before the re-sweep is not evidence
+ * about the just-promoted prod, regardless of whether it is within its family
+ * window. So we additionally exclude a prod cell when none of its contributing
+ * rows was observed at/after `reSweepTriggerAt`. (Staging is NOT held to the
+ * re-sweep freshness — only prod was just re-swept.)
+ */
+
+import {
+  buildCellModel,
+  type ChipColor,
+  type CellModelInput,
+} from "../shell-dashboard/src/lib/cell-model";
+import {
+  keyFor,
+  CATALOG_TO_D5_KEY,
+  STARTER_LEVELS,
+  type LiveStatusMap,
+} from "../shell-dashboard/src/lib/live-status";
+
+/** A single (integration, feature) cell to compare across envs. */
+export type GateCell = CellModelInput;
+
+/** Why a cell was excluded from the gate verdict. */
+export type ExclusionReason =
+  /** The cell is `gray` on staging (no green claim to honor). */
+  | "gray-staging"
+  /** The cell folded to `gray` on prod (driver-error / abort / U8 stale). */
+  | "gray-prod"
+  /** Every prod row for the cell predates the re-sweep trigger (§6.4). */
+  | "stale-prod"
+  /** The cell is unsupported / not-wired (no comparable verification). */
+  | "unsupported";
+
+export interface CellComparison {
+  slug: string;
+  featureId: string;
+  /** Resolved staging ChipColor (`buildCellModel`). */
+  stagingChip: ChipColor;
+  /**
+   * Resolved prod ChipColor, AFTER the §6.4 re-sweep-freshness fold (a
+   * pre-trigger prod cell reads `gray` here even if `buildCellModel` would
+   * have rendered another colour).
+   */
+  prodChip: ChipColor;
+  /** True when the cell does not count toward the gate verdict. */
+  excluded: boolean;
+  /** Populated iff `excluded` — the dominant reason. */
+  excludedReason?: ExclusionReason;
+  /**
+   * True when this cell is a GATE MISMATCH (staging-green, prod-not-green,
+   * neither side gray, fresh prod). A mismatch fails the gate.
+   */
+  mismatch: boolean;
+}
+
+export interface EquivalenceGateInput {
+  /** The cells to compare. The caller (U10) enumerates the promoted closure. */
+  cells: GateCell[];
+  /** Status rows read from the STAGING PocketBase. */
+  stagingRows: LiveStatusMap;
+  /** Status rows read from the PROD PocketBase. */
+  prodRows: LiveStatusMap;
+  /**
+   * Epoch ms of the re-sweep trigger. A prod cell whose newest contributing
+   * row predates this instant is excluded as stale (§6.4).
+   */
+  reSweepTriggerAt: number;
+  /** `now` for the underlying `buildCellModel` staleness folds. Defaults to `Date.now()`. */
+  now?: number;
+}
+
+export interface EquivalenceGateResult {
+  /** True when no cell is a mismatch (the promote is equivalence-clean). */
+  passed: boolean;
+  /** Every cell's comparison, in input order. */
+  comparisons: CellComparison[];
+  /** Just the mismatching cells (the gate-failing subset), in input order. */
+  mismatches: CellComparison[];
+  /** A human-readable summary for `$GITHUB_STEP_SUMMARY` + Slack. */
+  summary: string;
+}
+
+/**
+ * The maximum prod-row `observed_at`, in epoch ms, across EVERY row a cell
+ * derives from — or `null` when the cell has no contributing rows (no-data;
+ * nothing to date). Mirrors the keyspace `buildCellModel`'s resolvers and
+ * `computeCellFreshness` fan out over (e2e, chat/tools, the D5/D6 per-cell
+ * family, health) so the gate's freshness verdict cannot diverge from what the
+ * chip was derived from. An unparseable `observed_at` cannot establish recency
+ * and is skipped (it can never beat the trigger), failing safe toward
+ * "excluded as stale".
+ */
+function newestProdObservation(
+  rows: LiveStatusMap,
+  cell: GateCell,
+): number | null {
+  const { slug, featureId } = cell;
+  // STARTER axis: a starter cell derives ONLY from its `starter:<col>/<level>`
+  // rows (`buildCellModel`'s `resolveStarterChip` reads exactly these), so its
+  // §6.4 freshness must be dated off the SAME keys — NOT the agent
+  // e2e/chat/tools/health + d5/d6 keyspace, which a starter never writes.
+  const keys: string[] =
+    cell.probeAxis === "starter"
+      ? STARTER_LEVELS.map((level) => keyFor("starter", slug, level))
+      : [
+          keyFor("e2e", slug, featureId),
+          keyFor("chat", slug),
+          keyFor("tools", slug),
+          keyFor("health", slug),
+        ];
+  if (cell.probeAxis !== "starter") {
+    const familyKeys = CATALOG_TO_D5_KEY[featureId];
+    if (familyKeys) {
+      for (const ft of familyKeys) {
+        keys.push(keyFor("d5", slug, ft));
+        keys.push(keyFor("d6", slug, ft));
+      }
+    }
+  }
+
+  let newest: number | null = null;
+  for (const key of keys) {
+    const row = rows.get(key);
+    if (!row) continue;
+    const observedMs = Date.parse(row.observed_at);
+    if (Number.isNaN(observedMs)) continue;
+    if (newest === null || observedMs > newest) newest = observedMs;
+  }
+  return newest;
+}
+
+/**
+ * Compare one cell across envs and produce its `CellComparison`.
+ *
+ * Exclusion precedence (a cell can satisfy several at once — we record the
+ * FIRST that applies, but any one is enough to exclude):
+ *   1. unsupported / not-wired      — no comparable verification on either env.
+ *   2. gray on staging              — no green claim to honor (gate fires only
+ *                                     on staging-green).
+ *   3. stale prod (§6.4)            — every prod row predates the re-sweep.
+ *   4. gray on prod (U7/U8)         — driver-error/abort/stale → not a product
+ *                                     red.
+ * A cell is a MISMATCH only when it is NOT excluded, staging is `green`, and
+ * prod is not `green`.
+ */
+function compareCell(
+  input: EquivalenceGateInput,
+  cell: GateCell,
+  now: number,
+): CellComparison {
+  const staging = buildCellModel(input.stagingRows, cell, now);
+  const prodModel = buildCellModel(input.prodRows, cell, now);
+
+  const stagingChip = staging.chipColor;
+
+  // §6.4 re-sweep freshness: a prod cell with contributing rows but NONE at or
+  // after the trigger is stale-excluded → its effective prod chip is gray.
+  const newestProd = newestProdObservation(input.prodRows, cell);
+  const prodIsStaleForGate =
+    newestProd !== null && newestProd < input.reSweepTriggerAt;
+  const prodChip: ChipColor = prodIsStaleForGate ? "gray" : prodModel.chipColor;
+
+  let excluded = false;
+  let excludedReason: ExclusionReason | undefined;
+
+  if (!cell.isSupported || !cell.isWired) {
+    excluded = true;
+    excludedReason = "unsupported";
+  } else if (stagingChip === "gray") {
+    excluded = true;
+    excludedReason = "gray-staging";
+  } else if (prodIsStaleForGate) {
+    excluded = true;
+    excludedReason = "stale-prod";
+  } else if (prodChip === "gray") {
+    excluded = true;
+    excludedReason = "gray-prod";
+  }
+
+  const mismatch = !excluded && stagingChip === "green" && prodChip !== "green";
+
+  return {
+    slug: cell.slug,
+    featureId: cell.featureId,
+    stagingChip,
+    prodChip,
+    excluded,
+    ...(excludedReason ? { excludedReason } : {}),
+    mismatch,
+  };
+}
+
+/** Build the workflow-summary / Slack text for a result. */
+function buildSummary(
+  comparisons: CellComparison[],
+  mismatches: CellComparison[],
+): string {
+  const total = comparisons.length;
+  const excluded = comparisons.filter((c) => c.excluded).length;
+  const compared = total - excluded;
+  if (mismatches.length === 0) {
+    return (
+      `Equivalence gate PASSED — ${compared} compared, ${excluded} excluded ` +
+      `(gray/stale/unsupported), 0 prod regressions across ${total} cells.`
+    );
+  }
+  const lines = mismatches
+    .map(
+      (m) =>
+        `  - ${m.slug}/${m.featureId}: staging=${m.stagingChip} prod=${m.prodChip}`,
+    )
+    .join("\n");
+  return (
+    `Equivalence gate FAILED — ${mismatches.length} prod regression(s) ` +
+    `(staging green, prod not green) of ${compared} compared ` +
+    `(${excluded} excluded):\n${lines}`
+  );
+}
+
+/**
+ * Run the prod ↔ staging equivalence gate over `cells`. Pure: no I/O, no
+ * mutation of the input maps. The caller reads both PocketBase instances and
+ * supplies the rows + cell list.
+ */
+export function runEquivalenceGate(
+  input: EquivalenceGateInput,
+): EquivalenceGateResult {
+  const now = input.now ?? Date.now();
+  const comparisons = input.cells.map((cell) => compareCell(input, cell, now));
+  const mismatches = comparisons.filter((c) => c.mismatch);
+  return {
+    passed: mismatches.length === 0,
+    comparisons,
+    mismatches,
+    summary: buildSummary(comparisons, mismatches),
+  };
+}

--- a/showcase/scripts/lint-prod-gate.sh
+++ b/showcase/scripts/lint-prod-gate.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# lint-prod-gate.sh — post-promote gate: assert EVERY prod service is pinned to
+# an immutable `@sha256:` digest.
+#
+# Extracted from .github/workflows/showcase_promote.yml (UNIT U12, spec §8.2) so
+# the gate is unit-testable (see __tests__/lint-prod-gate.bats), mirroring how
+# promote-fleet.sh / verify-prod-display.sh / resolve-promote-targets.sh were
+# pulled out of this same workflow.
+#
+# Why a SEPARATE gate (it complements, not duplicates, the equivalence gate):
+#   * verify-prod's per-service probe (verify-deploy.ts) asserts the prod service
+#     is HEALTHY.
+#   * U10's equivalence re-sweep asserts prod is FUNCTIONALLY EQUIVALENT to
+#     staging.
+#   * Neither asserts PINNED-NESS. A born-on-`:latest` prod service
+#     (deploy-to-railway.ts provisions an unpinned source.image, spec R-E) can be
+#     healthy AND functionally equivalent while still floating on a mutable tag —
+#     a latent rollback/repro hazard. This gate asserts every prod service is on
+#     an immutable digest, catching such a service LOUD post-promote.
+#
+# It is a thin wrapper around `bin/railway lint-prod`, whose exit-code contract
+# IS the gate: exit 0 = all prod services digest-pinned, exit 1 = at least one
+# unpinned (findings), exit 2 = hard error (auth/GraphQL). Any non-zero fails the
+# step (and the run) — we deliberately do NOT pass --exit-zero (advisory mode):
+# an unpinned prod service must red the run, not just print a warning.
+#
+# Usage:
+#   RAILWAY_TOKEN=... scripts/lint-prod-gate.sh
+#
+# Env:
+#   RAILWAY_TOKEN  (required by bin/railway lint-prod to read the prod snapshot;
+#                  this wrapper does not consult it directly — bin/railway does).
+#   RAILWAY_BIN    (optional) path to the railway CLI (default: sibling
+#                  ../bin/railway). Overridable for testing.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHOWCASE_DIR="$(dirname "$HERE")"
+RAILWAY_BIN="${RAILWAY_BIN:-$SHOWCASE_DIR/bin/railway}"
+
+# Validate the railway CLI up front. Without this, a missing/non-executable
+# binary makes the lint-prod invocation fail with 126/127 — fail loud with a
+# clear message instead of a cryptic exec error. `-x` covers an absolute path;
+# `command -v` covers RAILWAY_BIN being a bare PATH command name.
+if [ ! -x "$RAILWAY_BIN" ] && ! command -v "$RAILWAY_BIN" >/dev/null 2>&1; then
+  echo "::error::lint-prod-gate: RAILWAY_BIN '$RAILWAY_BIN' is missing or not executable; cannot run the pinned-ness gate." >&2
+  exit 1
+fi
+
+echo "==> $RAILWAY_BIN lint-prod"
+# Run the gate. lint-prod exits 1 on findings (an unpinned prod service) and 2 on
+# a hard error; either is a step failure. We capture the rc explicitly (rather
+# than relying on `set -e`, which is intentionally off) so the failure message
+# below is precise about which service(s) tripped — lint-prod already prints the
+# per-service findings to stdout, which CI surfaces.
+"$RAILWAY_BIN" lint-prod
+rc=$?
+
+if [ "$rc" -eq 0 ]; then
+  echo "OK: every production service is digest-pinned (@sha256:)."
+  exit 0
+fi
+
+echo "::error::lint-prod-gate: production is NOT fully digest-pinned (bin/railway lint-prod exit $rc). A born-on-:latest prod service (spec R-E) floats on a mutable tag — re-pin it via 'bin/railway promote <svc>' or 'bin/railway pin <svc> <digest>'." >&2
+exit "$rc"

--- a/showcase/scripts/promote-fleet.sh
+++ b/showcase/scripts/promote-fleet.sh
@@ -18,14 +18,30 @@
 #     them. Exit zero only when every attempted service succeeded.
 #
 # Usage:
+#   # legacy flat leaf set (backward-compat):
 #   SERVICES_CSV="a,b,c" [DIGEST=ref] scripts/promote-fleet.sh
+#   # tier-ordered closure (U4 — preferred for `all`/equivalence-gated promotes):
+#   CLOSURE_PLAN="0:aimock,1:harness,2:langgraph-python" [DIGEST=ref] scripts/promote-fleet.sh
 #
 # Env:
-#   SERVICES_CSV  (required)  comma-separated service names to promote.
+#   CLOSURE_PLAN  (optional)  tier-annotated `tier:name,tier:name,...` plan from
+#                             U3's resolve-promote-targets.sh (the `closure_plan`
+#                             output). When set, the fleet is promoted BY TIER
+#                             (0->1->2) and a tier GATES its dependents: if ANY
+#                             service in a tier fails pin+verify, every LATER
+#                             tier is NOT promoted (reported NOT-ATTEMPTED, not
+#                             FAILED — so the operator can re-run once the
+#                             failing tier is healthy, spec R-B). Within a tier
+#                             the existing per-service best-effort loop is
+#                             preserved exactly. Takes precedence over
+#                             SERVICES_CSV when both are set.
+#   SERVICES_CSV  (optional*) comma-separated service names to promote, flat /
+#                             best-effort with NO tier gating (the legacy leaf
+#                             path). Required when CLOSURE_PLAN is unset.
 #   DIGEST        (optional)  digest override; forwarded as `--digest <ref>`.
 #                             Upstream resolve-targets already rejects
 #                             --digest + 'all', so a populated DIGEST here
-#                             always pairs with a single-service CSV.
+#                             always pairs with a single-service set.
 #   RAILWAY_BIN   (optional)  path to the railway CLI (default: sibling
 #                             ../bin/railway). Overridable for testing.
 #
@@ -42,12 +58,17 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SHOWCASE_DIR="$(dirname "$HERE")"
 RAILWAY_BIN="${RAILWAY_BIN:-$SHOWCASE_DIR/bin/railway}"
 
-if [ -z "${SERVICES_CSV:-}" ]; then
-  echo "::error::promote-fleet: SERVICES_CSV is empty; nothing to promote." >&2
+# ── Input mode resolution ───────────────────────────────────────────────────
+# Two input shapes:
+#   * CLOSURE_PLAN — tier-annotated `tier:name,tier:name,...` (U3 output). When
+#     present, the fleet is promoted BY TIER with dependent-tier gating.
+#   * SERVICES_CSV — flat comma-separated leaf set (legacy / backward-compat),
+#     best-effort with NO tier gating.
+# CLOSURE_PLAN takes precedence when both are set.
+if [ -z "${CLOSURE_PLAN:-}" ] && [ -z "${SERVICES_CSV:-}" ]; then
+  echo "::error::promote-fleet: neither CLOSURE_PLAN nor SERVICES_CSV is set; nothing to promote." >&2
   exit 1
 fi
-
-IFS=',' read -ra SVCS <<< "$SERVICES_CSV"
 
 # Validate the railway CLI up front. Without this, a missing/non-executable
 # binary makes EVERY iteration fail with 126/127, misattributing a single
@@ -58,21 +79,31 @@ if [ ! -x "$RAILWAY_BIN" ] && ! command -v "$RAILWAY_BIN" >/dev/null 2>&1; then
   exit 1
 fi
 
-succeeded=()
-failed=()        # "svc=exitcode" entries
-drift=()         # aggregated STAGING_DRIFT_MARKER payloads across the fleet
+succeeded=()       # service names that actually pinned (the closure subset)
+failed=()          # "svc=exitcode" entries
+not_attempted=()   # services in tiers gated out by an earlier-tier failure
+drift=()           # aggregated STAGING_DRIFT_MARKER payloads across the fleet
 
-for svc in "${SVCS[@]}"; do
-  # Trim leading/trailing whitespace: `IFS=',' read` does NOT trim, so a CSV
-  # like "svc-a, svc-c" yields a literal " svc-c" (leading space) that would be
-  # promoted as a bogus service name. Trim BEFORE the empty-check so a
-  # whitespace-only token is also correctly skipped.
-  svc="${svc#"${svc%%[![:space:]]*}"}"   # strip leading whitespace
-  svc="${svc%"${svc##*[![:space:]]}"}"   # strip trailing whitespace
+# trim <var-of-string> -> echoes the string with leading/trailing whitespace
+# stripped. `IFS=',' read` does NOT trim, so a token like " svc-c" (leading
+# space) would be promoted as a bogus service name; strip it consistently on
+# both the flat and the tiered paths.
+trim() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"   # strip leading whitespace
+  s="${s%"${s##*[![:space:]]}"}"   # strip trailing whitespace
+  printf '%s' "$s"
+}
 
-  # Guard against empty tokens from a stray/trailing comma (or a whitespace-only
-  # token) in the CSV.
-  [ -n "$svc" ] || continue
+# promote_one <svc> -> promote a single service best-effort, recording it into
+# succeeded[]/failed[] and aggregating any STAGING_DRIFT_MARKER into drift[].
+# Returns the railway exit code (0 = pinned). This is the EXACT per-service body
+# the flat loop used before tiering was added — preserved byte-for-byte so the
+# behavior (trim handled by caller, args, PIPESTATUS rc capture, drift scan,
+# OK/::error:: lines) is identical on both paths.
+promote_one() {
+  local svc="$1"
+  local args out rc line
 
   args=(promote "$svc" --yes --non-interactive)
   if [ -n "${DIGEST:-}" ]; then
@@ -102,16 +133,119 @@ for svc in "${SVCS[@]}"; do
     echo "::error::promote failed for '$svc' (exit $rc)"
     failed+=("$svc=$rc")
   fi
-done
+  return "$rc"
+}
 
-# Guard against a non-empty CSV that parsed to ONLY empty/whitespace tokens
-# (e.g. ",," or " , "). Such input passes the SERVICES_CSV empty-check, skips
-# every token in the loop, and would otherwise exit 0 claiming "All services
-# promoted successfully" — a silent no-op false success. If zero services were
-# actually attempted, fail loud.
+if [ -n "${CLOSURE_PLAN:-}" ]; then
+  # ── Tier-ordered closure path (U4) ──────────────────────────────────────────
+  # Parse `tier:name` tokens into per-tier service lists, then promote tier 0,
+  # then 1, then 2. A tier GATES its dependents: once any tier records a
+  # failure, every LATER tier is NOT attempted — its services are recorded as
+  # not_attempted[] (distinct from failed[]) so the operator can re-run them
+  # once the failing tier is healthy (spec R-B). A stale aimock/harness under
+  # fresh integrations is a non-equivalent prod, so the leaf tiers must not pin.
+  # Three per-tier service lists. NB we deliberately AVOID bash 4.3 `declare -n`
+  # namerefs here: CI runs on ubuntu bash 5 but contributors/maintainers run the
+  # bats suite on macOS system bash 3.2, which lacks namerefs. Iterate each tier
+  # array explicitly so the script stays portable to bash 3.2.
+  tier0=()
+  tier1=()
+  tier2=()
+  IFS=',' read -ra PLAN_TOKENS <<< "$CLOSURE_PLAN"
+  for tok in "${PLAN_TOKENS[@]}"; do
+    tok="$(trim "$tok")"
+    [ -n "$tok" ] || continue
+    # Split `tier:name`; the tier is the part before the FIRST colon.
+    tier="${tok%%:*}"
+    svc="$(trim "${tok#*:}")"
+    [ -n "$svc" ] || continue
+    case "$tier" in
+      0) tier0+=("$svc") ;;
+      1) tier1+=("$svc") ;;
+      2) tier2+=("$svc") ;;
+      *)
+        echo "::error::promote-fleet: CLOSURE_PLAN token '$tok' has an unknown tier '$tier' (expected 0, 1, or 2)." >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  # promote_tier <gated> <svc...> — promote every service in one tier
+  # best-effort (unless <gated> is 1, in which case the tier is gated out by an
+  # earlier-tier failure and its services are recorded NOT-ATTEMPTED). Sets the
+  # GLOBAL `tier_had_failure` to 1 if this tier itself had a promote failure (so
+  # the caller can gate the NEXT tier), else 0. Best-effort within the tier is
+  # preserved: every member is attempted even after a sibling fails.
+  #
+  # NB: this MUST run in the current shell (NOT a `$(...)` command substitution)
+  # — promote_one appends to the succeeded[]/failed[]/drift[] arrays, and those
+  # mutations would be lost in a subshell. We communicate the tier result via a
+  # global rather than stdout for the same reason.
+  promote_tier() {
+    local gated_in="$1"; shift
+    local svc
+    tier_had_failure=0
+    for svc in "$@"; do
+      # Skip the empty arg an empty tier yields via `${arr[@]:-}` on bash 3.2
+      # (and any blank that slipped through). A blank is never a real service.
+      [ -n "$svc" ] || continue
+      if [ "$gated_in" -ne 0 ]; then
+        not_attempted+=("$svc")
+        continue
+      fi
+      # promote_one returns the railway rc; under `set -uo pipefail` (no -e) a
+      # non-zero return does NOT abort, so per-service best-effort within the
+      # tier is preserved.
+      if ! promote_one "$svc"; then
+        tier_had_failure=1
+      fi
+    done
+  }
+
+  # Promote in strict tier order (0 -> 1 -> 2), gating each tier's dependents on
+  # ANY earlier-tier failure. `${arr[@]:-}` keeps the empty-array expansion safe
+  # under `set -u` on bash 3.2 (an empty tier expands to a single empty arg,
+  # which promote_tier skips via promote_one's no-op on "" — see below).
+  gated=0
+  tier_had_failure=0
+  promote_tier "$gated" "${tier0[@]:-}"
+  [ "$tier_had_failure" -ne 0 ] && gated=1
+  promote_tier "$gated" "${tier1[@]:-}"
+  [ "$tier_had_failure" -ne 0 ] && gated=1
+  promote_tier "$gated" "${tier2[@]:-}"
+else
+  # ── Flat leaf path (legacy / backward-compat) ──────────────────────────────
+  # No tier gating: every service attempted best-effort, identical to the
+  # pre-U4 behavior. not_attempted[] stays empty on this path.
+  IFS=',' read -ra SVCS <<< "$SERVICES_CSV"
+  for svc in "${SVCS[@]}"; do
+    # Trim BEFORE the empty-check so a whitespace-only token is also skipped.
+    svc="$(trim "$svc")"
+    # Guard against empty tokens from a stray/trailing comma (or a
+    # whitespace-only token) in the CSV.
+    [ -n "$svc" ] || continue
+    promote_one "$svc" || true
+  done
+fi
+
+# Guard against input that parsed to ONLY empty/whitespace tokens (e.g. ",,"
+# or " , ", or a CLOSURE_PLAN of all blank tokens). Such input passes the
+# upfront empty-check, skips every token in the loop, and would otherwise exit 0
+# claiming "All services promoted successfully" — a silent no-op false success.
+# If zero services were actually attempted, fail loud.
+#
+# NOTE: not_attempted[] (tiers gated out by an earlier-tier failure) is NOT an
+# "attempt" — those services were deliberately NOT promoted. But a gated run
+# ALWAYS has at least one failed[] entry (the tier failure that triggered the
+# gate), so `attempted` is non-zero there; this guard only trips on genuinely
+# empty input.
 attempted=$(( ${#succeeded[@]} + ${#failed[@]} ))
 if [ "$attempted" -eq 0 ]; then
-  echo "::error::promote-fleet: SERVICES_CSV contained no usable service names (only empty/whitespace tokens); nothing was promoted." >&2
+  if [ -n "${CLOSURE_PLAN:-}" ]; then
+    echo "::error::promote-fleet: CLOSURE_PLAN contained no usable service names (only empty/whitespace tokens); nothing was promoted." >&2
+  else
+    echo "::error::promote-fleet: SERVICES_CSV contained no usable service names (only empty/whitespace tokens); nothing was promoted." >&2
+  fi
   exit 1
 fi
 
@@ -161,9 +295,13 @@ emit() {
 }
 
 emit "## Promote fleet summary"
-# Report services ACTUALLY attempted (succeeded + failed), not the raw CSV
+# Report services ACTUALLY attempted (succeeded + failed), not the raw input
 # token count — which would over-count empty/whitespace tokens skipped above.
-emit "Attempted ${attempted} service(s) from SERVICES_CSV."
+if [ -n "${CLOSURE_PLAN:-}" ]; then
+  emit "Attempted ${attempted} service(s) from CLOSURE_PLAN (tier-ordered)."
+else
+  emit "Attempted ${attempted} service(s) from SERVICES_CSV."
+fi
 
 if [ "${#succeeded[@]}" -gt 0 ]; then
   emit "SUCCEEDED (${#succeeded[@]}): ${succeeded[*]}"
@@ -175,6 +313,16 @@ if [ "${#drift[@]}" -gt 0 ]; then
   emit ""
   emit "⚠️ STAGING DRIFT (${#drift[@]}): staging was NOT serving current :latest for — ${drift[*]}"
   emit "Promote pinned prod to staging's RUNNING digest (what was seen in staging); investigate the drift."
+fi
+
+# NOT-ATTEMPTED: services in tiers gated out by an earlier-tier failure. These
+# are DISTINCT from FAILED — the services were never promoted (so prod was left
+# untouched), and the operator can re-run them once the failing tier is healthy
+# (spec R-B). Only populated on the tier-ordered CLOSURE_PLAN path.
+if [ "${#not_attempted[@]}" -gt 0 ]; then
+  emit ""
+  emit "NOT-ATTEMPTED (${#not_attempted[@]}): ${not_attempted[*]}"
+  emit "These tiers were gated by an earlier-tier failure and NOT promoted; re-run once the failing tier is healthy."
 fi
 
 if [ "${#failed[@]}" -gt 0 ]; then

--- a/showcase/scripts/provision-starter-fleet.ts
+++ b/showcase/scripts/provision-starter-fleet.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env npx tsx
 /**
  * provision-starter-fleet.ts — Committed, reproducible Railway provisioner
- * for the SSOT-decoupled "starter container fleet" in the showcase STAGING
- * environment.
+ * for the "starter container fleet" in the showcase STAGING environment.
  *
  * Creates (or idempotently updates) one sleepable Railway service per
  * starter template, pulling the per-starter image from GHCR:
@@ -26,18 +25,32 @@
  *   domain       : a generated Railway domain per service (serviceDomainCreate)
  *
  * The 12 starter slugs are the keys of STARTER_TO_COLUMN in
- * showcase/harness/src/probes/helpers/starter-mapping.ts — the single source
- * of truth shared with the smoke matrix (showcase/tests/e2e/starter-smoke.spec.ts)
- * and the CI build matrix (.github/workflows/showcase_build.yml). This script
- * derives its target list from that SSOT so the fleet can never drift from the
- * matrix.
+ * showcase/harness/src/probes/helpers/starter-mapping.ts. That list is NOT
+ * literally shared with the smoke matrix (showcase/tests/e2e/starter-smoke.spec.ts)
+ * or the CI build matrix (.github/workflows/showcase_build.yml) — those are
+ * INDEPENDENT lists. The drift test
+ * (showcase/harness/src/probes/helpers/starter-mapping-drift.test.ts) keeps
+ * STARTER_TO_COLUMN in lockstep with the smoke matrix + the on-disk column set
+ * ONLY (it does NOT check showcase_build.yml — the CI build matrix is independent
+ * and not covered by that test). This script derives its target list from
+ * STARTER_TO_COLUMN, so the drift-synced map keeps the fleet aligned with the
+ * smoke/column set.
  *
- * The fleet is intentionally DECOUPLED from the 27-service railway-envs SSOT:
- * starter-* services are auto-discovered at runtime by the starter_smoke probe
- * (railway-services source, namePrefix "starter-") and are NOT added to
- * SERVICES. PR #5254 already made verify-railway-image-refs.ts tolerate
- * starter-* names in BOTH drift directions, so provisioning these services
- * does NOT trip the CI image-ref gate / skip the showcase build.
+ * SSOT relationship (S2): the 12 starter-<slug> services are now FULL
+ * railway-envs SSOT entries (SERVICES in showcase/scripts/railway-envs.ts),
+ * gateValidated + ciBuilt exactly like a showcase-* agent. This script is NOT
+ * a competing source of truth: it is the STAGING PROVISIONER, deriving its 12
+ * targets from STARTER_TO_COLUMN (the canonical starter-slug map; the smoke
+ * matrix and CI build matrix are INDEPENDENT lists, per the note above). The railway-envs SSOT owns the
+ * image-ref gate + the cluster-promote closure (prod @sha256 pinning); this
+ * script owns idempotent staging service creation. They are complementary, not
+ * double-managing — the slug set is the single shared input, so they cannot
+ * drift. The starter_smoke probe still auto-discovers starter-* services at
+ * runtime (railway-services source, namePrefix "starter-") for verification.
+ *
+ * NOTE: prod pinning + image-ref drift for starters is handled by the
+ * railway-envs gate (verify-railway-image-refs.ts) and bin/railway lint-prod,
+ * NOT by this staging-only provisioner.
  *
  * IDEMPOTENT: a starter-* service that already exists in staging is UPDATED
  * (instance settings re-applied; a domain created only if none exists, and an

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -25,7 +25,8 @@
         "staging": true,
         "prod": true,
         "driver": "aimock"
-      }
+      },
+      "promoteTier": 0
     },
     {
       "name": "dashboard",
@@ -47,7 +48,9 @@
         "staging": true,
         "prod": true,
         "driver": "dashboard"
-      }
+      },
+      "promoteTier": 1,
+      "runtimeDeps": ["pocketbase", "harness"]
     },
     {
       "name": "docs",
@@ -69,7 +72,8 @@
         "staging": true,
         "prod": true,
         "driver": "docs"
-      }
+      },
+      "promoteTier": 2
     },
     {
       "name": "dojo",
@@ -91,7 +95,8 @@
         "staging": true,
         "prod": true,
         "driver": "dojo"
-      }
+      },
+      "promoteTier": 2
     },
     {
       "name": "harness",
@@ -113,7 +118,8 @@
         "staging": true,
         "prod": true,
         "driver": "harness"
-      }
+      },
+      "promoteTier": 1
     },
     {
       "name": "harness-legacy",
@@ -134,7 +140,8 @@
         "staging": false,
         "prod": false,
         "driver": "harness"
-      }
+      },
+      "promoteTier": 2
     },
     {
       "name": "harness-workers",
@@ -155,7 +162,8 @@
         "staging": false,
         "prod": false,
         "driver": "harness"
-      }
+      },
+      "promoteTier": 1
     },
     {
       "name": "pocketbase",
@@ -177,7 +185,8 @@
         "staging": true,
         "prod": true,
         "driver": "pocketbase"
-      }
+      },
+      "promoteTier": 0
     },
     {
       "name": "shell",
@@ -199,7 +208,8 @@
         "staging": true,
         "prod": true,
         "driver": "shell"
-      }
+      },
+      "promoteTier": 2
     },
     {
       "name": "showcase-ag2",
@@ -217,7 +227,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-agno",
@@ -235,7 +253,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-built-in-agent",
@@ -253,7 +279,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-claude-sdk-python",
@@ -271,7 +305,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-claude-sdk-typescript",
@@ -289,7 +331,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-crewai-crews",
@@ -307,7 +357,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-google-adk",
@@ -325,7 +383,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-langgraph-fastapi",
@@ -343,7 +409,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-langgraph-python",
@@ -361,7 +435,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-langgraph-typescript",
@@ -379,7 +461,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-langroid",
@@ -397,7 +487,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-llamaindex",
@@ -415,7 +513,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-mastra",
@@ -433,7 +539,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-ms-agent-dotnet",
@@ -451,7 +565,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-ms-agent-harness-dotnet",
@@ -469,7 +591,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-ms-agent-python",
@@ -487,7 +617,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-pydantic-ai",
@@ -505,7 +643,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-spring-ai",
@@ -523,7 +669,15 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "showcase-strands",
@@ -541,7 +695,327 @@
         "staging": true,
         "prod": true,
         "driver": "agent"
-      }
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
+    },
+    {
+      "name": "starter-adk",
+      "serviceId": "37691009-c0b2-4af7-8960-9f0b3f0a6be3",
+      "prodInstanceId": "cb23cae4-9555-4ddd-8a62-f1aa1ff72c67",
+      "stagingInstanceId": "208a160a-0d7d-44b2-a94d-39e13b24e21a",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "starter-adk",
+      "domains": {
+        "staging": "starter-adk-staging.up.railway.app",
+        "prod": "starter-adk-production.up.railway.app"
+      },
+      "probe": {
+        "staging": false,
+        "prod": true,
+        "driver": "starter"
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
+    },
+    {
+      "name": "starter-agno",
+      "serviceId": "5ab3c37e-18a5-44e5-8329-26243dd98da8",
+      "prodInstanceId": "2f58513b-5fe4-4b09-a28f-93d4caa277b5",
+      "stagingInstanceId": "9944eb97-7f58-47f8-a49d-65603e209609",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "starter-agno",
+      "domains": {
+        "staging": "starter-agno-staging.up.railway.app",
+        "prod": "starter-agno-production.up.railway.app"
+      },
+      "probe": {
+        "staging": false,
+        "prod": true,
+        "driver": "starter"
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
+    },
+    {
+      "name": "starter-crewai-crews",
+      "serviceId": "2a9a4230-e6cd-4c1d-92a5-36e5c624371a",
+      "prodInstanceId": "1a3e24cb-0752-45c8-b4a2-0c6096899875",
+      "stagingInstanceId": "820895fb-f65c-4834-a07d-d454035d39c4",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "starter-crewai-crews",
+      "domains": {
+        "staging": "starter-crewai-crews-staging.up.railway.app",
+        "prod": "starter-crewai-crews-production.up.railway.app"
+      },
+      "probe": {
+        "staging": false,
+        "prod": true,
+        "driver": "starter"
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
+    },
+    {
+      "name": "starter-langgraph-fastapi",
+      "serviceId": "6ae57213-52ea-4fea-b4a0-7bc304cbc80e",
+      "prodInstanceId": "0679bc18-e9af-40c6-bc17-0b5eb2cd7bec",
+      "stagingInstanceId": "5f10e976-e121-48a5-bc18-2619798f2f10",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "starter-langgraph-fastapi",
+      "domains": {
+        "staging": "starter-langgraph-fastapi-staging.up.railway.app",
+        "prod": "starter-langgraph-fastapi-production.up.railway.app"
+      },
+      "probe": {
+        "staging": false,
+        "prod": true,
+        "driver": "starter"
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
+    },
+    {
+      "name": "starter-langgraph-js",
+      "serviceId": "d044c3e5-bb27-4d5e-a2bf-e3b382981372",
+      "prodInstanceId": "50a2205b-8768-4765-b7a1-21941c105051",
+      "stagingInstanceId": "43db83fe-fafb-445b-a19a-51bb086c71b9",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "starter-langgraph-js",
+      "domains": {
+        "staging": "starter-langgraph-js-staging.up.railway.app",
+        "prod": "starter-langgraph-js-production.up.railway.app"
+      },
+      "probe": {
+        "staging": false,
+        "prod": true,
+        "driver": "starter"
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
+    },
+    {
+      "name": "starter-langgraph-python",
+      "serviceId": "10dca514-7c8f-4a32-9708-9f29a944da36",
+      "prodInstanceId": "24dad599-576a-4154-a621-c3af40629a8f",
+      "stagingInstanceId": "58105e79-4020-4692-8749-c1a63ab63f2c",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "starter-langgraph-python",
+      "domains": {
+        "staging": "starter-langgraph-python-staging.up.railway.app",
+        "prod": "starter-langgraph-python-production.up.railway.app"
+      },
+      "probe": {
+        "staging": false,
+        "prod": true,
+        "driver": "starter"
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
+    },
+    {
+      "name": "starter-llamaindex",
+      "serviceId": "3255b27f-ea84-44b7-b587-b1687b409363",
+      "prodInstanceId": "c119f40b-dc71-4734-9716-c1085754b085",
+      "stagingInstanceId": "44446803-0505-456a-b0c4-01fe82fb3832",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "starter-llamaindex",
+      "domains": {
+        "staging": "starter-llamaindex-staging.up.railway.app",
+        "prod": "starter-llamaindex-production.up.railway.app"
+      },
+      "probe": {
+        "staging": false,
+        "prod": true,
+        "driver": "starter"
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
+    },
+    {
+      "name": "starter-mastra",
+      "serviceId": "6548403e-3fee-4443-9d59-d8b041a3d43a",
+      "prodInstanceId": "c6fba6d8-8dde-442b-948f-560bf25fa2f1",
+      "stagingInstanceId": "b246e52d-52d8-4015-bb06-89bd09d54f8f",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "starter-mastra",
+      "domains": {
+        "staging": "starter-mastra-staging.up.railway.app",
+        "prod": "starter-mastra-production.up.railway.app"
+      },
+      "probe": {
+        "staging": false,
+        "prod": true,
+        "driver": "starter"
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
+    },
+    {
+      "name": "starter-ms-agent-framework-dotnet",
+      "serviceId": "1b4c5296-97f6-463d-90af-6e04d7919957",
+      "prodInstanceId": "993237a4-9ee7-47b2-a5be-267e247c1409",
+      "stagingInstanceId": "6684c246-e8fd-45a7-86e4-c529a439976f",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "starter-ms-agent-framework-dotnet",
+      "domains": {
+        "staging": "starter-ms-agent-framework-dotnet-staging.up.railway.app",
+        "prod": "starter-ms-agent-framework-dotnet-production.up.railway.app"
+      },
+      "probe": {
+        "staging": false,
+        "prod": true,
+        "driver": "starter"
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
+    },
+    {
+      "name": "starter-ms-agent-framework-python",
+      "serviceId": "225d0a06-d1cd-4b82-ae9c-2d1e8ecbaf86",
+      "prodInstanceId": "aa934881-340a-4fb7-8b39-9cb0a6f372b2",
+      "stagingInstanceId": "a162348a-f768-4c3f-815c-f617819f64e6",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "starter-ms-agent-framework-python",
+      "domains": {
+        "staging": "starter-ms-agent-framework-python-staging.up.railway.app",
+        "prod": "starter-ms-agent-framework-python-production.up.railway.app"
+      },
+      "probe": {
+        "staging": false,
+        "prod": true,
+        "driver": "starter"
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
+    },
+    {
+      "name": "starter-pydantic-ai",
+      "serviceId": "c01d0d24-af88-4631-8a9a-23cffef2b36a",
+      "prodInstanceId": "74ce36fe-0b8f-446e-8e06-0b6496b6e829",
+      "stagingInstanceId": "25f4eb93-501a-4e5e-b7cf-343eb08ea613",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "starter-pydantic-ai",
+      "domains": {
+        "staging": "starter-pydantic-ai-staging.up.railway.app",
+        "prod": "starter-pydantic-ai-production.up.railway.app"
+      },
+      "probe": {
+        "staging": false,
+        "prod": true,
+        "driver": "starter"
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
+    },
+    {
+      "name": "starter-strands-python",
+      "serviceId": "321735ab-c14d-4e45-a1c2-e47f2b29d774",
+      "prodInstanceId": "4af440e0-ba05-48a5-b922-5b96a033891a",
+      "stagingInstanceId": "adc24096-584a-4ef3-93de-0bc92d49235c",
+      "ciBuilt": true,
+      "gateValidated": true,
+      "dispatchName": "starter-strands-python",
+      "domains": {
+        "staging": "starter-strands-python-staging.up.railway.app",
+        "prod": "starter-strands-python-production.up.railway.app"
+      },
+      "probe": {
+        "staging": false,
+        "prod": true,
+        "driver": "starter"
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ]
     },
     {
       "name": "webhooks",
@@ -563,7 +1037,174 @@
         "staging": true,
         "prod": true,
         "driver": "webhooks"
-      }
+      },
+      "promoteTier": 0
     }
-  ]
+  ],
+  "closure": {
+    "services": [
+      {
+        "name": "aimock",
+        "tier": 0
+      },
+      {
+        "name": "pocketbase",
+        "tier": 0
+      },
+      {
+        "name": "webhooks",
+        "tier": 0
+      },
+      {
+        "name": "dashboard",
+        "tier": 1
+      },
+      {
+        "name": "harness",
+        "tier": 1
+      },
+      {
+        "name": "docs",
+        "tier": 2
+      },
+      {
+        "name": "dojo",
+        "tier": 2
+      },
+      {
+        "name": "shell",
+        "tier": 2
+      },
+      {
+        "name": "showcase-ag2",
+        "tier": 2
+      },
+      {
+        "name": "showcase-agno",
+        "tier": 2
+      },
+      {
+        "name": "showcase-built-in-agent",
+        "tier": 2
+      },
+      {
+        "name": "showcase-claude-sdk-python",
+        "tier": 2
+      },
+      {
+        "name": "showcase-claude-sdk-typescript",
+        "tier": 2
+      },
+      {
+        "name": "showcase-crewai-crews",
+        "tier": 2
+      },
+      {
+        "name": "showcase-google-adk",
+        "tier": 2
+      },
+      {
+        "name": "showcase-langgraph-fastapi",
+        "tier": 2
+      },
+      {
+        "name": "showcase-langgraph-python",
+        "tier": 2
+      },
+      {
+        "name": "showcase-langgraph-typescript",
+        "tier": 2
+      },
+      {
+        "name": "showcase-langroid",
+        "tier": 2
+      },
+      {
+        "name": "showcase-llamaindex",
+        "tier": 2
+      },
+      {
+        "name": "showcase-mastra",
+        "tier": 2
+      },
+      {
+        "name": "showcase-ms-agent-dotnet",
+        "tier": 2
+      },
+      {
+        "name": "showcase-ms-agent-harness-dotnet",
+        "tier": 2
+      },
+      {
+        "name": "showcase-ms-agent-python",
+        "tier": 2
+      },
+      {
+        "name": "showcase-pydantic-ai",
+        "tier": 2
+      },
+      {
+        "name": "showcase-spring-ai",
+        "tier": 2
+      },
+      {
+        "name": "showcase-strands",
+        "tier": 2
+      },
+      {
+        "name": "starter-adk",
+        "tier": 2
+      },
+      {
+        "name": "starter-agno",
+        "tier": 2
+      },
+      {
+        "name": "starter-crewai-crews",
+        "tier": 2
+      },
+      {
+        "name": "starter-langgraph-fastapi",
+        "tier": 2
+      },
+      {
+        "name": "starter-langgraph-js",
+        "tier": 2
+      },
+      {
+        "name": "starter-langgraph-python",
+        "tier": 2
+      },
+      {
+        "name": "starter-llamaindex",
+        "tier": 2
+      },
+      {
+        "name": "starter-mastra",
+        "tier": 2
+      },
+      {
+        "name": "starter-ms-agent-framework-dotnet",
+        "tier": 2
+      },
+      {
+        "name": "starter-ms-agent-framework-python",
+        "tier": 2
+      },
+      {
+        "name": "starter-pydantic-ai",
+        "tier": 2
+      },
+      {
+        "name": "starter-strands-python",
+        "tier": 2
+      }
+    ],
+    "skipped": [
+      {
+        "name": "harness-workers",
+        "reason": "no \"prod\" environment in the SSOT — cannot be promoted (it exists in: staging)."
+      }
+    ]
+  }
 }

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -9,10 +9,12 @@ import {
   PROJECT_ID,
   SERVICES,
   STAGING_ENV_ID,
+  assertClosureValid,
   assertDispatchNamesUnique,
   assertEnvRegistryConsistent,
   assertImageConsumersValid,
   assertServiceAndInstanceIdsUnique,
+  computePromoteClosure,
   domainFor,
   envsFor,
   instanceIdFor,
@@ -22,7 +24,11 @@ import {
   resolveEnv,
   serviceForDispatchName,
 } from "./railway-envs";
-import type { EnvironmentConfig, ProbeDriver } from "./railway-envs";
+import type {
+  ClosurePlan,
+  EnvironmentConfig,
+  ProbeDriver,
+} from "./railway-envs";
 
 describe("railway-envs SSOT", () => {
   it("exposes the canonical project id", () => {
@@ -100,9 +106,9 @@ describe("railway-envs SSOT", () => {
     expect(ENV_IDS.staging).toBe(STAGING_ENV_ID);
   });
 
-  it("contains exactly 29 services", () => {
+  it("contains exactly 41 services (29 showcase/infra + 12 starter-*)", () => {
     const names = listServiceNames();
-    expect(names.length).toBe(29);
+    expect(names.length).toBe(41);
   });
 
   it("contains the expected canonical services", () => {
@@ -174,8 +180,11 @@ describe("railway-envs SSOT", () => {
     );
   });
 
-  it("CI_BUILT_SERVICES contains exactly 26 services (incl. pocketbase) and excludes webhooks", () => {
-    expect(CI_BUILT_SERVICES.size).toBe(26);
+  it("CI_BUILT_SERVICES contains exactly 38 services (incl. pocketbase + 12 starters) and excludes webhooks", () => {
+    // 26 showcase/infra CI-built + 12 starter-<slug> (S2 brought them under
+    // the gate; they ARE built+pushed by showcase_build.yml's `build-starters`
+    // job to ghcr.io/copilotkit/starter-<slug>:latest).
+    expect(CI_BUILT_SERVICES.size).toBe(38);
     // pocketbase is now CI-built (showcase_build.yml `pocketbase` slot,
     // gated to showcase/pocketbase/** changes).
     expect(CI_BUILT_SERVICES.has("pocketbase")).toBe(true);
@@ -185,6 +194,9 @@ describe("railway-envs SSOT", () => {
     expect(CI_BUILT_SERVICES.has("showcase-mastra")).toBe(true);
     expect(CI_BUILT_SERVICES.has("aimock")).toBe(true);
     expect(CI_BUILT_SERVICES.has("dashboard")).toBe(true);
+    // S2: starters are now CI-built.
+    expect(CI_BUILT_SERVICES.has("starter-adk")).toBe(true);
+    expect(CI_BUILT_SERVICES.has("starter-mastra")).toBe(true);
   });
 
   it("pocketbase and webhooks have per-env GHCR repo-name overrides", () => {
@@ -327,7 +339,24 @@ describe("railway-envs SSOT", () => {
     // "showcase-pocketbase" slot is gated to showcase/pocketbase/**) and
     // so is included here; only webhooks remains non-CI-built (released by
     // the showcase-eval-webhook repo) and thus excluded from this check.
-    const yamlSet = new Set(dispatchNames);
+    //
+    // S2: the 12 starter-<slug> services are CI-built by the SEPARATE
+    // `build-starters` job, whose matrix uses `"image":"starter-<slug>"`
+    // keys (NOT `"dispatch_name":"…"`). Their dispatchName === the SSOT key
+    // === the starter matrix `.image` === the workflow_dispatch choice value
+    // (`- starter-<slug>`). So the reverse-direction membership set must also
+    // include the starter matrix `image` values; otherwise the now-CI-built
+    // starters would spuriously fail this check.
+    const starterImageRegex = /"image"\s*:\s*"(starter-[^"]+)"/g;
+    const starterImages: string[] = [];
+    for (const match of yaml.matchAll(starterImageRegex)) {
+      starterImages.push(match[1]);
+    }
+    expect(
+      starterImages.length,
+      "no starter `image` entries found in showcase_build.yml — the build-starters matrix moved or its key shape changed",
+    ).toBeGreaterThanOrEqual(12);
+    const yamlSet = new Set([...dispatchNames, ...starterImages]);
     for (const name of CI_BUILT_SERVICES) {
       const entry = SERVICES[name];
       expect(
@@ -336,7 +365,7 @@ describe("railway-envs SSOT", () => {
       ).toBeDefined();
       expect(
         yamlSet.has(entry.dispatchName as string),
-        `CI-built service "${name}" (dispatchName="${entry.dispatchName}") has no matching entry in showcase_build.yml ALL_SERVICES matrix`,
+        `CI-built service "${name}" (dispatchName="${entry.dispatchName}") has no matching entry in showcase_build.yml (ALL_SERVICES dispatch_name or build-starters image)`,
       ).toBe(true);
     }
   });
@@ -816,6 +845,7 @@ describe("railway-envs SSOT — domains + probe", () => {
       "docs",
       "dashboard",
       "agent",
+      "starter",
     ];
     for (const [name, entry] of Object.entries(SERVICES)) {
       // probeDriver is hoisted to the entry (env-independent).
@@ -938,5 +968,313 @@ describe("railway-envs SSOT — domains + probe", () => {
       repoName: "showcase-example",
     };
     expect(sample.probe).toBe(false);
+  });
+});
+
+describe("promote-tier SSOT fields", () => {
+  it("tags the tier-0 infra services with promoteTier 0", () => {
+    for (const key of ["aimock", "pocketbase", "webhooks"]) {
+      expect(SERVICES[key].promoteTier).toBe(0);
+    }
+  });
+
+  it("tags the tier-1 verification services with promoteTier 1", () => {
+    for (const key of ["harness", "harness-workers", "dashboard"]) {
+      expect(SERVICES[key].promoteTier).toBe(1);
+    }
+  });
+
+  it("leaves integrations + shells at the default tier 2 (omitted)", () => {
+    // Default-2-when-omitted contract: integrations and shells carry no
+    // explicit promoteTier.
+    for (const key of [
+      "showcase-langgraph-python",
+      "showcase-mastra",
+      "shell",
+      "docs",
+      "dojo",
+    ]) {
+      expect(SERVICES[key].promoteTier).toBeUndefined();
+    }
+  });
+
+  it("declares runtimeDeps: every agent service needs a current aimock", () => {
+    for (const [key, entry] of Object.entries(SERVICES)) {
+      if (entry.probeDriver !== "agent") continue;
+      expect(entry.runtimeDeps).toContain("aimock");
+    }
+  });
+
+  it("declares the dashboard's runtimeDeps on pocketbase + harness", () => {
+    expect(SERVICES.dashboard.runtimeDeps).toEqual(
+      expect.arrayContaining(["pocketbase", "harness"]),
+    );
+  });
+
+  it("declares serviceRefs from each agent at aimock (OPENAI_BASE_URL)", () => {
+    const lgp = SERVICES["showcase-langgraph-python"];
+    expect(lgp.serviceRefs).toEqual(
+      expect.arrayContaining([{ key: "OPENAI_BASE_URL", target: "aimock" }]),
+    );
+  });
+
+  it("every runtimeDeps / serviceRefs target is an existing SSOT key", () => {
+    for (const entry of Object.values(SERVICES)) {
+      for (const dep of entry.runtimeDeps ?? []) {
+        expect(Object.hasOwn(SERVICES, dep)).toBe(true);
+      }
+      for (const ref of entry.serviceRefs ?? []) {
+        expect(Object.hasOwn(SERVICES, ref.target)).toBe(true);
+      }
+    }
+  });
+});
+
+describe("computePromoteClosure", () => {
+  it("returns aimock(t0) + harness/workers/dashboard(t1) + langgraph-python(t2) in tier order", () => {
+    const plan: ClosurePlan = computePromoteClosure(["langgraph-python"]);
+    const names = plan.services.map((s) => s.name);
+    // Tier order: 0 before 1 before 2.
+    const tiers = plan.services.map((s) => s.tier);
+    const sorted = [...tiers].sort((a, b) => a - b);
+    expect(tiers).toEqual(sorted);
+
+    // Tier-0 runtime dep (aimock) pulled in for an agent service.
+    expect(names).toContain("aimock");
+    expect(plan.services.find((s) => s.name === "aimock")?.tier).toBe(0);
+
+    // Tier-1 verification set ALWAYS included.
+    expect(names).toContain("harness");
+    expect(names).toContain("dashboard");
+    for (const t1 of ["harness", "dashboard"]) {
+      expect(plan.services.find((s) => s.name === t1)?.tier).toBe(1);
+    }
+
+    // The requested integration (resolved from its dispatch_name) at tier 2.
+    expect(names).toContain("showcase-langgraph-python");
+    expect(
+      plan.services.find((s) => s.name === "showcase-langgraph-python")?.tier,
+    ).toBe(2);
+
+    // aimock (t0) precedes harness (t1) precedes the integration (t2).
+    expect(names.indexOf("aimock")).toBeLessThan(names.indexOf("harness"));
+    expect(names.indexOf("harness")).toBeLessThan(
+      names.indexOf("showcase-langgraph-python"),
+    );
+  });
+
+  it("resolves an SSOT key directly as well as a dispatch_name", () => {
+    const viaKey = computePromoteClosure(["showcase-langgraph-python"]);
+    const viaDispatch = computePromoteClosure(["langgraph-python"]);
+    expect(viaKey.services.map((s) => s.name).sort()).toEqual(
+      viaDispatch.services.map((s) => s.name).sort(),
+    );
+  });
+
+  it("always includes the full Tier-1 verification set even for a tier-0-only request", () => {
+    const plan = computePromoteClosure(["pocketbase"]);
+    const names = plan.services.map((s) => s.name);
+    expect(names).toEqual(
+      expect.arrayContaining(
+        ["harness", "harness-workers", "dashboard"].filter(
+          (k) => k !== "harness-workers",
+        ),
+      ),
+    );
+    // harness + dashboard are prod-promotable Tier-1 and present:
+    expect(names).toContain("harness");
+    expect(names).toContain("dashboard");
+  });
+
+  it("skips a prod-less member (harness-workers) with an explicit reason, never silently", () => {
+    const plan = computePromoteClosure(["langgraph-python"]);
+    const promotableNames = plan.services.map((s) => s.name);
+    // harness-workers has no `prod` env today → excluded from the promotable
+    // list...
+    expect(promotableNames).not.toContain("harness-workers");
+    // ...but recorded with an explicit reason (never silent).
+    const skipped = plan.skipped.find((s) => s.name === "harness-workers");
+    expect(skipped).toBeDefined();
+    expect(skipped?.reason).toMatch(/prod/i);
+  });
+
+  it("excludes harness-legacy (gateIgnore, pinned out-of-band)", () => {
+    const plan = computePromoteClosure(["langgraph-python"]);
+    expect(plan.services.map((s) => s.name)).not.toContain("harness-legacy");
+  });
+
+  it("throws on an unknown requested service (fail loud)", () => {
+    expect(() => computePromoteClosure(["does-not-exist"])).toThrow(
+      /unknown|not an SSOT key/i,
+    );
+  });
+
+  it("is pure — repeated calls return equal plans and do not mutate SERVICES", () => {
+    const before = JSON.stringify(SERVICES);
+    const a = computePromoteClosure(["langgraph-python"]);
+    const b = computePromoteClosure(["langgraph-python"]);
+    expect(a).toEqual(b);
+    expect(JSON.stringify(SERVICES)).toBe(before);
+  });
+});
+
+describe("starter-* fleet SSOT entries (S1: promote-closure inclusion)", () => {
+  // The 12 starter-<slug> services GHCR-named ghcr.io/copilotkit/starter-<slug>.
+  // Folded into the cluster-promote SSOT at tier 2 so they receive the same
+  // dependency-/env-/verification-complete + pinned-prod treatment as the
+  // showcase-* demos. The Railway service name (and SSOT key) is the RAW
+  // starter slug prefixed with `starter-` — the keys of STARTER_TO_COLUMN.
+  const STARTER_KEYS = [
+    "starter-adk",
+    "starter-agno",
+    "starter-crewai-crews",
+    "starter-langgraph-fastapi",
+    "starter-langgraph-js",
+    "starter-langgraph-python",
+    "starter-llamaindex",
+    "starter-mastra",
+    "starter-ms-agent-framework-dotnet",
+    "starter-ms-agent-framework-python",
+    "starter-pydantic-ai",
+    "starter-strands-python",
+  ] as const;
+
+  it("registers all 12 starter-* services in the SSOT", () => {
+    for (const key of STARTER_KEYS) {
+      expect(Object.hasOwn(SERVICES, key), `${key} missing from SERVICES`).toBe(
+        true,
+      );
+    }
+  });
+
+  it("every starter carries promoteTier 2, runtimeDeps [aimock] + OPENAI_BASE_URL serviceRef", () => {
+    for (const key of STARTER_KEYS) {
+      const entry = SERVICES[key];
+      expect(entry.promoteTier, `${key}.promoteTier`).toBe(2);
+      expect(entry.runtimeDeps, `${key}.runtimeDeps`).toEqual(["aimock"]);
+      expect(entry.serviceRefs, `${key}.serviceRefs`).toEqual([
+        { key: "OPENAI_BASE_URL", target: "aimock" },
+      ]);
+    }
+  });
+
+  it("every starter is fully gate-managed: ciBuilt, gateValidated, no gateIgnore, dispatchName === key, probeDriver 'starter'", () => {
+    // S2 reverses the S1 fence: starters are now treated exactly like a
+    // showcase-* agent. They ARE built+pushed by showcase_build.yml's
+    // `build-starters` job (ghcr.io/copilotkit/starter-<slug>:latest), so
+    // ciBuilt:true; the image-ref gate validates their canonical shape
+    // (prod @sha256, staging :latest) in both drift directions, so
+    // gateValidated:true and NO gateIgnore. dispatchName === the SSOT key
+    // (the starter workflow_dispatch choice value is the bare starter-<slug>;
+    // assertDispatchNamesUnique permits a dispatchName equal to its own key).
+    // probeDriver "starter" is the S3 contract: the equivalence gate routes
+    // these to the harness starter_smoke axis.
+    for (const key of STARTER_KEYS) {
+      const entry = SERVICES[key];
+      expect(entry.ciBuilt, `${key}.ciBuilt`).toBe(true);
+      expect(
+        entry.gateIgnore === undefined || entry.gateIgnore === false,
+        `${key}.gateIgnore`,
+      ).toBe(true);
+      expect(entry.gateValidated, `${key}.gateValidated`).toBe(true);
+      expect(entry.dispatchName, `${key}.dispatchName`).toBe(key);
+      expect(entry.probeDriver, `${key}.probeDriver`).toBe("starter");
+    }
+  });
+
+  it("no starter carries a repoName override (service name === GHCR repo name)", () => {
+    // The Railway service name (starter-<slug>) already equals the GHCR repo
+    // name, so the gate's default ghcr.io/copilotkit/<serviceName> resolves
+    // correctly with no per-env override — mirroring how showcase-* agents
+    // (whose names match their GHCR repos) carry no repoName.
+    for (const key of STARTER_KEYS) {
+      const entry = SERVICES[key];
+      expect(entry.environments.prod.repoName, `${key} prod repoName`).toBe(
+        undefined,
+      );
+      expect(
+        entry.environments.staging.repoName,
+        `${key} staging repoName`,
+      ).toBe(undefined);
+    }
+  });
+
+  it("every starter exists in BOTH envs with prod probe enabled", () => {
+    for (const key of STARTER_KEYS) {
+      const entry = SERVICES[key];
+      expect(Object.keys(entry.environments).sort()).toEqual([
+        "prod",
+        "staging",
+      ]);
+      // prod is probed (they ARE in prod); staging probe deferred to S3
+      // (the starter-smoke axis, not the verify-deploy matrix).
+      expect(probeEnabled(key, "prod"), `${key} prod probe`).toBe(true);
+      // staging probe OFF — starters never enter the verify-deploy staging
+      // matrix (resolve-verify-matrix filters on probe.staging===true); the
+      // starter-smoke axis owns staging verification (S3).
+      expect(probeEnabled(key, "staging"), `${key} staging probe`).toBe(false);
+    }
+  });
+
+  it("the full-fleet promote closure includes all 12 starters at tier 2", () => {
+    // `all` is not itself an SSOT key/dispatchName; the fleet closure is
+    // computed over every SSOT key — mirroring emit-railway-envs-json.ts,
+    // which builds the top-level `closure` as computePromoteClosure(keys).
+    const fleet = computePromoteClosure(Object.keys(SERVICES));
+    const tier2 = new Set(
+      fleet.services.filter((s) => s.tier === 2).map((s) => s.name),
+    );
+    for (const key of STARTER_KEYS) {
+      expect(
+        tier2.has(key),
+        `${key} should be tier-2 in the fleet closure`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("assertClosureValid", () => {
+  it("passes for the real SSOT (a normal closure with a full Tier-1 set)", () => {
+    expect(() => assertClosureValid(["langgraph-python"])).not.toThrow();
+  });
+
+  it("throws when the SSOT carries no Tier-1 verification services", () => {
+    const noTier1 = {
+      aimock: { promoteTier: 0, environments: { prod: {}, staging: {} } },
+      "showcase-x": {
+        environments: { prod: {}, staging: {} },
+        runtimeDeps: ["aimock"],
+      },
+    } as unknown as typeof SERVICES;
+    expect(() => assertClosureValid(["showcase-x"], noTier1)).toThrow(
+      /tier-1|tier 1/i,
+    );
+  });
+
+  it("throws when a member's runtimeDeps names a missing SSOT key", () => {
+    const danglingDep = {
+      aimock: { promoteTier: 0, environments: { prod: {}, staging: {} } },
+      harness: { promoteTier: 1, environments: { prod: {}, staging: {} } },
+      dashboard: { promoteTier: 1, environments: { prod: {}, staging: {} } },
+      "showcase-x": {
+        environments: { prod: {}, staging: {} },
+        runtimeDeps: ["ghost"],
+      },
+    } as unknown as typeof SERVICES;
+    expect(() => assertClosureValid(["showcase-x"], danglingDep)).toThrow(
+      /ghost|not an SSOT key|missing/i,
+    );
+  });
+
+  it("throws when the computed closure has no promotable services", () => {
+    // A Tier-1 service exists (so the missing-Tier-1 clause passes), but it
+    // is the ONLY entry and it has no prod env → every closure member is
+    // skipped-with-reason and `services` is empty. Refuse to promote nothing.
+    const allProdless = {
+      harness: { promoteTier: 1, environments: { staging: {} } },
+    } as unknown as typeof SERVICES;
+    expect(() => assertClosureValid(["harness"], allProdless)).toThrow(
+      /empty|promote nothing/i,
+    );
   });
 });

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -114,6 +114,14 @@ export function resolveEnv(name: string): { env: EnvName; envId: string } {
  * - "webhooks" — synthetic event POST and downstream confirmation.
  * - "agent" — generic agent backend (the showcase-* integration services);
  *   feature-level fixture call into the integration's /api endpoint.
+ * - "starter" — the starter-template container fleet (`starter-<slug>`).
+ *   These are NOT verified by the verify-deploy feature-driver matrix: they
+ *   are probed by the harness `starter_smoke` axis (railway-services source,
+ *   namePrefix "starter-", writing `starter:<column-slug>/<level>` rows).
+ *   verify-deploy.drivers.ts carries a fail-loud placeholder `case "starter"`
+ *   purely to satisfy the exhaustive switch; the equivalence gate (S3) reads
+ *   this driver to route a starter to the starter-smoke axis. Starters set
+ *   staging probe OFF so they never enter the verify-deploy staging matrix.
  */
 export type ProbeDriver =
   | "shell"
@@ -125,7 +133,8 @@ export type ProbeDriver =
   | "dojo"
   | "docs"
   | "dashboard"
-  | "agent";
+  | "agent"
+  | "starter";
 
 /**
  * Per-env configuration for a service. One of these lives under each key of
@@ -232,6 +241,45 @@ export interface ServiceEntry {
    */
   gateIgnore?: boolean;
   /**
+   * Promote ordering tier for the equivalence-gated cluster promote
+   * (`computePromoteClosure`). Lower tiers pin+verify BEFORE higher tiers,
+   * and a tier gates its dependents (a stale aimock/harness under fresh
+   * integrations = a non-equivalent prod):
+   *   - 0 — shared infra the whole cluster runs against (`aimock`,
+   *     `pocketbase`, `webhooks`);
+   *   - 1 — the verification control plane + dashboard
+   *     (`harness`, `harness-workers`, `dashboard`), ALWAYS pulled into an
+   *     equivalence-gated promote so the post-promote re-sweep + dashboard
+   *     read run against the just-promoted harness/PB;
+   *   - 2 — integrations and shells (the leaf set an operator names).
+   * OPTIONAL: defaults to 2 when omitted (the leaf default). This field is
+   * promote-only — it does NOT affect the staging redeploy scope.
+   */
+  promoteTier?: 0 | 1 | 2;
+  /**
+   * SSOT keys this service needs PRESENT-AND-CURRENT in the target env for
+   * its own promote to be meaningful — the transitive runtime dependencies
+   * `computePromoteClosure` pulls into the promote closure. Distinct from
+   * `imageOf` (image-sharing for the redeploy scope): `runtimeDeps` models
+   * "this service talks to that service at runtime", e.g. each `agent`
+   * integration → `["aimock"]` (it routes LLM traffic at the env-local
+   * aimock) and the `dashboard` → `["pocketbase","harness"]` (it reads the
+   * PB rows the harness writes). OPTIONAL; omitted = no runtime deps. Every
+   * entry must be an existing SSOT key (enforced by `assertClosureValid`).
+   */
+  runtimeDeps?: string[];
+  /**
+   * Cross-service env-var references this service carries in the target env
+   * — an env var (`key`) whose VALUE must point at another SSOT service's
+   * (`target`) env-LOCAL host (prod→prod, staging→staging). e.g. an agent's
+   * `OPENAI_BASE_URL` must resolve to the env's own aimock, never the other
+   * env's. The Stage-2 Ruby preflight (U5) ASSERTS these (REFUSE on
+   * mismatch — the `ms-agent-dotnet` cross-env class); it never copies a
+   * value. OPTIONAL; omitted = no service refs. Every `target` must be an
+   * existing SSOT key (enforced by `assertClosureValid`).
+   */
+  serviceRefs?: { key: string; target: string }[];
+  /**
    * Ruby/jq-BOUNDARY COMPATIBILITY SHIM — read ONLY by
    * `emit-railway-envs-json.ts`, never by any TS accessor.
    *
@@ -293,6 +341,9 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "showcase-aimock",
     probeDriver: "aimock",
+    // Tier-0 shared infra: every agent integration routes its LLM traffic at
+    // the env-local aimock, so aimock pins+verifies before any tier-1/2.
+    promoteTier: 0,
     // Aimock runs the `showcase-aimock` wrapper image in BOTH envs.
     // The wrapper (built from `showcase/aimock/Dockerfile`) bakes the
     // showcase fixture tree into base aimock and is the permanent,
@@ -321,6 +372,11 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "shell-dashboard",
     probeDriver: "dashboard",
+    // Tier-1 verification surface: the dashboard reads the PB rows the
+    // harness writes, so an equivalence-gated promote always pulls it in.
+    promoteTier: 1,
+    // Runtime deps: it reads pocketbase rows produced by the harness sweep.
+    runtimeDeps: ["pocketbase", "harness"],
     // Railway service name is `dashboard`; GHCR repo is
     // `showcase-shell-dashboard`. Same override for both envs:
     // staging :latest, prod @sha256 — uniform across all services.
@@ -389,6 +445,9 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "showcase-harness",
     probeDriver: "harness",
+    // Tier-1 verification control plane: the post-promote re-sweep runs on
+    // the just-promoted harness, so it pins+verifies before tier-2.
+    promoteTier: 1,
     // Railway service name is `harness`; GHCR repo is `showcase-harness`.
     // ciBuilt: true, gateValidated: true — uniform with the rest of
     // the CI-built integrations now that WS-C has flipped the five.
@@ -436,6 +495,10 @@ export const SERVICES: Record<
     gateValidated: false,
     gateIgnore: true,
     probeDriver: "harness",
+    // Tier-1 verification fleet. STAGING-ONLY today (no prod env below), so
+    // computePromoteClosure records it as skipped-with-reason rather than
+    // promoting it; the tier survives for when a prod worker is provisioned.
+    promoteTier: 1,
     // The worker runs the SAME `showcase-harness` GHCR image that the
     // existing `harness` (control-plane) service runs — it is NOT a
     // separately-built image. The single `showcase-harness` build slot in
@@ -540,6 +603,9 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "showcase-pocketbase",
     probeDriver: "pocketbase",
+    // Tier-0 shared infra: the verification control plane (harness) writes
+    // its sweep rows here, so PB pins+verifies before tier-1.
+    promoteTier: 0,
     environments: {
       prod: {
         instanceId: "1ee376e2-13f2-4464-801e-d0aa0bf76532",
@@ -583,6 +649,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "ag2",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "de571c97-03fd-486b-8a54-9767a4a53f95",
@@ -602,6 +674,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "agno",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "026d12fb-2844-42af-8f92-b47bc8a06bc8",
@@ -621,6 +699,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "built-in-agent",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "40018ef7-1ed1-4979-b80c-9c2d957b6d88",
@@ -640,6 +724,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "claude-sdk-python",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "bb18caaf-9a3e-4fdd-85ec-562fd82a3a89",
@@ -659,6 +749,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "claude-sdk-typescript",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "bee425e4-9661-4a88-8888-922b8cd4b61d",
@@ -678,6 +774,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "crewai-crews",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "3dab0cc3-cab1-4579-b772-947268088514",
@@ -697,6 +799,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "google-adk",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "7b2da5db-87d2-40ad-a3d9-b2d7a5485a22",
@@ -716,6 +824,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "langgraph-fastapi",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "105b7e01-acd0-48e2-9a09-541e2103e8d2",
@@ -735,6 +849,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "langgraph-python",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "aec504f7-63d7-4ea6-9d50-601b00d2ae80",
@@ -754,6 +874,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "langgraph-typescript",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "f53e9fdc-7c3e-4dfd-9fa8-d7241fd55bb8",
@@ -773,6 +899,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "langroid",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "6b5e20b5-8f8e-4ec3-9288-7a41122e42e5",
@@ -792,6 +924,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "llamaindex",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "b778856e-9f90-4136-9415-fb2b41173f8d",
@@ -811,6 +949,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "mastra",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "eaeddd9c-8b75-426f-b033-0fd935cbf6ef",
@@ -830,6 +974,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "ms-agent-dotnet",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "93ca0edf-7b59-4de4-b1fd-3412bb07bc6a",
@@ -849,6 +999,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "ms-agent-harness-dotnet",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "8f91ebc6-95c0-4433-b1f7-657ff49c2d59",
@@ -868,6 +1024,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "ms-agent-python",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "323ed911-4d28-45ab-8fc0-7d151828b938",
@@ -887,6 +1049,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "pydantic-ai",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "192cd647-6824-4f01-937a-1da675d83805",
@@ -906,6 +1074,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "spring-ai",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "2fbf1db2-5e51-44c9-983c-3f2242d95c61",
@@ -925,6 +1099,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "strands",
     probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
+    // at the env-local aimock, so a cluster promote pulls aimock (tier-0)
+    // into the closure. The OPENAI_BASE_URL service-ref is ASSERTED prod→prod
+    // by the Stage-2 Ruby preflight (never copied).
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
       prod: {
         instanceId: "2123c71b-9385-443c-a1c3-bcf4b1669eeb",
@@ -938,12 +1118,326 @@ export const SERVICES: Record<
       },
     },
   },
+  // ───────────────────────── starter-* container fleet ─────────────────────
+  // The 12 starter-template containers (ghcr.io/copilotkit/starter-<slug>),
+  // live in BOTH staging and prod. Folded into the cluster-promote SSOT (S1)
+  // and brought UNDER THE GATE (S2) so they receive the SAME
+  // dependency-/env-/verification-complete + pinned-prod treatment as the
+  // showcase-* demos — one whole cluster, no carve-out. The SSOT key === the
+  // Railway service name === `starter-<RAW starter slug>`, where the RAW slug
+  // is a BARE key of STARTER_TO_COLUMN (e.g. `adk`, so the SSOT key is
+  // `starter-adk`) in harness/src/probes/helpers/starter-mapping.ts — NOT the
+  // remapped dashboard column slug.
+  //
+  // S2 SCOPE — these entries are now FULLY gate-managed, identical to a
+  // showcase-* agent:
+  //   - ciBuilt:true     → built+pushed by showcase_build.yml's `build-starters`
+  //                        job to `ghcr.io/copilotkit/starter-<slug>:latest`
+  //                        (the starter matrix `.image` === `starter-<slug>` ===
+  //                        this SSOT key). In the CI_BUILT_SERVICES redeploy
+  //                        scope. `dispatchName` === the SSOT key because the
+  //                        starter workflow_dispatch choice value is the bare
+  //                        `starter-<slug>` (assertDispatchNamesUnique permits a
+  //                        dispatchName equal to its OWN key).
+  //   - gateValidated:true / gateIgnore unset → verify-railway-image-refs.ts
+  //                        validates the canonical image shape (prod @sha256,
+  //                        staging :latest) and BOTH drift directions, exactly
+  //                        like showcase-*. No `repoName` override: the Railway
+  //                        service name already equals the GHCR repo name
+  //                        (`starter-<slug>`), so the gate's default
+  //                        `ghcr.io/copilotkit/<serviceName>` is correct.
+  //   - bin/railway lint-prod now COVERS these prod services (asserts they are
+  //                        @sha256-pinned).
+  //
+  // probeDriver "starter": the starters are verified by the harness
+  // `starter_smoke` axis, NOT the verify-deploy feature-driver matrix. The
+  // `starter_smoke` probe auto-discovers `starter-*` services (railway-services
+  // source, namePrefix "starter-") and writes `starter:<column-slug>/<level>`
+  // rows. prod probe ON (they ARE in prod); staging probe OFF so they do NOT
+  // enter the verify-deploy staging matrix (resolve-verify-matrix filters on
+  // probe.staging===true). The "starter" ProbeDriver is the S3 CONTRACT field:
+  // S3 wires the equivalence gate to READ this driver and route these entries
+  // to the starter-smoke axis (verify-deploy.drivers.ts has a placeholder
+  // `case "starter"` that fails loud if dispatched, since verify-deploy is not
+  // the starter verification path).
+  //
+  // runtimeDeps/serviceRefs mirror the showcase-* agents: each starter routes
+  // its LLM traffic at the env-local aimock (tier-0), so a cluster promote
+  // pulls aimock into the closure and the OPENAI_BASE_URL ref is ASSERTED
+  // prod→prod by the Stage-2 Ruby preflight (never copied).
+  "starter-adk": {
+    serviceId: "37691009-c0b2-4af7-8960-9f0b3f0a6be3",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "starter-adk",
+    probeDriver: "starter",
+    promoteTier: 2,
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    environments: {
+      prod: {
+        instanceId: "cb23cae4-9555-4ddd-8a62-f1aa1ff72c67",
+        domain: "starter-adk-production.up.railway.app",
+        probe: true,
+      },
+      staging: {
+        instanceId: "208a160a-0d7d-44b2-a94d-39e13b24e21a",
+        domain: "starter-adk-staging.up.railway.app",
+        probe: false,
+      },
+    },
+  },
+  "starter-agno": {
+    serviceId: "5ab3c37e-18a5-44e5-8329-26243dd98da8",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "starter-agno",
+    probeDriver: "starter",
+    promoteTier: 2,
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    environments: {
+      prod: {
+        instanceId: "2f58513b-5fe4-4b09-a28f-93d4caa277b5",
+        domain: "starter-agno-production.up.railway.app",
+        probe: true,
+      },
+      staging: {
+        instanceId: "9944eb97-7f58-47f8-a49d-65603e209609",
+        domain: "starter-agno-staging.up.railway.app",
+        probe: false,
+      },
+    },
+  },
+  "starter-crewai-crews": {
+    serviceId: "2a9a4230-e6cd-4c1d-92a5-36e5c624371a",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "starter-crewai-crews",
+    probeDriver: "starter",
+    promoteTier: 2,
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    environments: {
+      prod: {
+        instanceId: "1a3e24cb-0752-45c8-b4a2-0c6096899875",
+        domain: "starter-crewai-crews-production.up.railway.app",
+        probe: true,
+      },
+      staging: {
+        instanceId: "820895fb-f65c-4834-a07d-d454035d39c4",
+        domain: "starter-crewai-crews-staging.up.railway.app",
+        probe: false,
+      },
+    },
+  },
+  "starter-langgraph-fastapi": {
+    serviceId: "6ae57213-52ea-4fea-b4a0-7bc304cbc80e",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "starter-langgraph-fastapi",
+    probeDriver: "starter",
+    promoteTier: 2,
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    environments: {
+      prod: {
+        instanceId: "0679bc18-e9af-40c6-bc17-0b5eb2cd7bec",
+        domain: "starter-langgraph-fastapi-production.up.railway.app",
+        probe: true,
+      },
+      staging: {
+        instanceId: "5f10e976-e121-48a5-bc18-2619798f2f10",
+        domain: "starter-langgraph-fastapi-staging.up.railway.app",
+        probe: false,
+      },
+    },
+  },
+  "starter-langgraph-js": {
+    serviceId: "d044c3e5-bb27-4d5e-a2bf-e3b382981372",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "starter-langgraph-js",
+    probeDriver: "starter",
+    promoteTier: 2,
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    environments: {
+      prod: {
+        instanceId: "50a2205b-8768-4765-b7a1-21941c105051",
+        domain: "starter-langgraph-js-production.up.railway.app",
+        probe: true,
+      },
+      staging: {
+        instanceId: "43db83fe-fafb-445b-a19a-51bb086c71b9",
+        domain: "starter-langgraph-js-staging.up.railway.app",
+        probe: false,
+      },
+    },
+  },
+  "starter-langgraph-python": {
+    serviceId: "10dca514-7c8f-4a32-9708-9f29a944da36",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "starter-langgraph-python",
+    probeDriver: "starter",
+    promoteTier: 2,
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    environments: {
+      prod: {
+        instanceId: "24dad599-576a-4154-a621-c3af40629a8f",
+        domain: "starter-langgraph-python-production.up.railway.app",
+        probe: true,
+      },
+      staging: {
+        instanceId: "58105e79-4020-4692-8749-c1a63ab63f2c",
+        domain: "starter-langgraph-python-staging.up.railway.app",
+        probe: false,
+      },
+    },
+  },
+  "starter-llamaindex": {
+    serviceId: "3255b27f-ea84-44b7-b587-b1687b409363",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "starter-llamaindex",
+    probeDriver: "starter",
+    promoteTier: 2,
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    environments: {
+      prod: {
+        instanceId: "c119f40b-dc71-4734-9716-c1085754b085",
+        domain: "starter-llamaindex-production.up.railway.app",
+        probe: true,
+      },
+      staging: {
+        instanceId: "44446803-0505-456a-b0c4-01fe82fb3832",
+        domain: "starter-llamaindex-staging.up.railway.app",
+        probe: false,
+      },
+    },
+  },
+  "starter-mastra": {
+    serviceId: "6548403e-3fee-4443-9d59-d8b041a3d43a",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "starter-mastra",
+    probeDriver: "starter",
+    promoteTier: 2,
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    environments: {
+      prod: {
+        instanceId: "c6fba6d8-8dde-442b-948f-560bf25fa2f1",
+        domain: "starter-mastra-production.up.railway.app",
+        probe: true,
+      },
+      staging: {
+        instanceId: "b246e52d-52d8-4015-bb06-89bd09d54f8f",
+        domain: "starter-mastra-staging.up.railway.app",
+        probe: false,
+      },
+    },
+  },
+  "starter-ms-agent-framework-dotnet": {
+    serviceId: "1b4c5296-97f6-463d-90af-6e04d7919957",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "starter-ms-agent-framework-dotnet",
+    probeDriver: "starter",
+    promoteTier: 2,
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    environments: {
+      prod: {
+        instanceId: "993237a4-9ee7-47b2-a5be-267e247c1409",
+        domain: "starter-ms-agent-framework-dotnet-production.up.railway.app",
+        probe: true,
+      },
+      staging: {
+        instanceId: "6684c246-e8fd-45a7-86e4-c529a439976f",
+        domain: "starter-ms-agent-framework-dotnet-staging.up.railway.app",
+        probe: false,
+      },
+    },
+  },
+  "starter-ms-agent-framework-python": {
+    serviceId: "225d0a06-d1cd-4b82-ae9c-2d1e8ecbaf86",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "starter-ms-agent-framework-python",
+    probeDriver: "starter",
+    promoteTier: 2,
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    environments: {
+      prod: {
+        instanceId: "aa934881-340a-4fb7-8b39-9cb0a6f372b2",
+        domain: "starter-ms-agent-framework-python-production.up.railway.app",
+        probe: true,
+      },
+      staging: {
+        instanceId: "a162348a-f768-4c3f-815c-f617819f64e6",
+        domain: "starter-ms-agent-framework-python-staging.up.railway.app",
+        probe: false,
+      },
+    },
+  },
+  "starter-pydantic-ai": {
+    serviceId: "c01d0d24-af88-4631-8a9a-23cffef2b36a",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "starter-pydantic-ai",
+    probeDriver: "starter",
+    promoteTier: 2,
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    environments: {
+      prod: {
+        instanceId: "74ce36fe-0b8f-446e-8e06-0b6496b6e829",
+        domain: "starter-pydantic-ai-production.up.railway.app",
+        probe: true,
+      },
+      staging: {
+        instanceId: "25f4eb93-501a-4e5e-b7cf-343eb08ea613",
+        domain: "starter-pydantic-ai-staging.up.railway.app",
+        probe: false,
+      },
+    },
+  },
+  "starter-strands-python": {
+    serviceId: "321735ab-c14d-4e45-a1c2-e47f2b29d774",
+    ciBuilt: true,
+    gateValidated: true,
+    dispatchName: "starter-strands-python",
+    probeDriver: "starter",
+    promoteTier: 2,
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    environments: {
+      prod: {
+        instanceId: "4af440e0-ba05-48a5-b922-5b96a033891a",
+        domain: "starter-strands-python-production.up.railway.app",
+        probe: true,
+      },
+      staging: {
+        instanceId: "adc24096-584a-4ef3-93de-0bc92d49235c",
+        domain: "starter-strands-python-staging.up.railway.app",
+        probe: false,
+      },
+    },
+  },
   webhooks: {
     serviceId: "ba6acc13-7585-41fe-a5ee-585b34a58fcd",
     ciBuilt: false,
     gateValidated: true,
     dispatchName: "webhooks",
     probeDriver: "webhooks",
+    // Tier-0 shared infra (eval webhook relay): grouped with the other
+    // cluster-wide infra so it settles before tier-1/2 promote.
+    promoteTier: 0,
     // webhooks is a first-party ghcr.io/copilotkit/ image, but its
     // GHCR repo name is `showcase-eval-webhook` (NOT `webhooks`), and
     // it is built by a separate release workflow — not showcase_build.yml.
@@ -1180,6 +1674,242 @@ export function serviceForDispatchName(
     if (entry.dispatchName === dispatchName) return name;
   }
   return undefined;
+}
+
+/** One promotable member of a {@link ClosurePlan}, carrying its tier. */
+export interface ClosureMember {
+  /** Canonical SSOT key. */
+  name: string;
+  /** Promote tier (0 infra → 1 verification → 2 leaf). */
+  tier: 0 | 1 | 2;
+}
+
+/** A member excluded from the promotable set, with an explicit reason. */
+export interface ClosureSkip {
+  /** Canonical SSOT key. */
+  name: string;
+  /** Human-readable reason this member is not promoted (never silent). */
+  reason: string;
+}
+
+/**
+ * The tier-ordered promote plan computed by {@link computePromoteClosure}:
+ * the `services` an equivalence-gated promote should pin+verify (tier 0→1→2)
+ * plus the `skipped` members that were pulled into the closure but cannot be
+ * promoted today (e.g. a member with no `prod` env), each with an explicit
+ * reason so the exclusion is visible (§4.3 — never silent).
+ */
+export interface ClosurePlan {
+  /** Tier-ordered (0→1→2) list of promotable services. */
+  services: ClosureMember[];
+  /** Closure members excluded from `services`, each with a reason. */
+  skipped: ClosureSkip[];
+}
+
+/**
+ * The promote tiers, lowest-first. The promote loop (U4) iterates the
+ * closure in this order; a tier gates its dependents.
+ */
+const PROMOTE_TIERS: readonly (0 | 1 | 2)[] = [0, 1, 2];
+
+/** Structural view of a {@link ServiceEntry} the closure math needs. */
+type ClosureEntry = {
+  promoteTier?: 0 | 1 | 2;
+  runtimeDeps?: string[];
+  imageOf?: string;
+  gateIgnore?: boolean;
+  environments?: Record<string, unknown>;
+};
+
+/** The effective tier of an entry: declared `promoteTier`, default 2. */
+function tierOf(entry: ClosureEntry): 0 | 1 | 2 {
+  return entry.promoteTier ?? 2;
+}
+
+/**
+ * Compute the tier-ordered promote closure for `requested` (SSOT keys OR
+ * `showcase_build.yml` dispatch_names — resolved the same way
+ * `resolveTargetServices` does). PURE: reads the SSOT, returns a plan, never
+ * mutates anything.
+ *
+ * The closure is (§4.2):
+ *   requested
+ *     ∪ transitive `runtimeDeps` (each member's runtime deps, recursively)
+ *     ∪ the FULL Tier-1 verification set (ALWAYS — an equivalence-gated
+ *       promote re-sweeps on the just-promoted harness and reads via the
+ *       dashboard, so the control plane must itself be current)
+ *     ∪ explicit `imageOf` consumers of any member.
+ *
+ * NOTE the promote path does NOT inherit the staging-redeploy `imageOf`
+ * EXPANSION wholesale — it pulls a consumer in only because that consumer
+ * runs a closure member's image and would otherwise run a stale image after
+ * the member is pinned (§4.2). `harness-legacy` (`gateIgnore`, pinned
+ * out-of-band) is excluded entirely (§4.3). A member whose `environments`
+ * omits `prod` (e.g. `harness-workers` today, §4.4) cannot be promoted and is
+ * recorded in `skipped` with a reason rather than silently dropped (§4.3).
+ *
+ * Throws (fail loud) on a requested name that resolves to no SSOT entry.
+ *
+ * Accepts an injected map for testing; defaults to the real SERVICES map.
+ */
+export function computePromoteClosure(
+  requested: string[],
+  services: Record<string, ClosureEntry & { dispatchName?: string }> = SERVICES,
+): ClosurePlan {
+  // 1) Resolve requested names → SSOT keys (own-key first, then dispatchName),
+  //    mirroring resolveTargetServices. Fail loud on an unknown name.
+  const closure = new Set<string>();
+  const resolveKey = (raw: string): string => {
+    const name = raw.trim();
+    if (Object.hasOwn(services, name)) return name;
+    for (const [key, entry] of Object.entries(services)) {
+      if (entry.dispatchName === name) return key;
+    }
+    throw new Error(
+      `computePromoteClosure: unknown service "${raw}" — not an SSOT key or dispatch_name in railway-envs.ts.`,
+    );
+  };
+  for (const raw of requested) {
+    if (raw.trim() === "") continue;
+    closure.add(resolveKey(raw));
+  }
+
+  // 2) ALWAYS include the full Tier-1 verification set (the control plane +
+  //    dashboard the post-promote re-sweep / equivalence read run against).
+  for (const [key, entry] of Object.entries(services)) {
+    if (tierOf(entry) === 1) closure.add(key);
+  }
+
+  // 3) Transitive runtimeDeps closure (BFS). Every dep must be a real key —
+  //    a dangling dep is caught by assertClosureValid, but guard here too so
+  //    the pure function never dereferences a non-entry.
+  const queue = [...closure];
+  while (queue.length > 0) {
+    const key = queue.shift() as string;
+    const entry = Object.hasOwn(services, key) ? services[key] : undefined;
+    if (entry === undefined) continue;
+    for (const dep of entry.runtimeDeps ?? []) {
+      if (!closure.has(dep) && Object.hasOwn(services, dep)) {
+        closure.add(dep);
+        queue.push(dep);
+      }
+    }
+  }
+
+  // 4) Explicit imageOf consumers of any closure member (pull, do not inherit
+  //    the staging-redeploy env-aware expansion wholesale — §4.2).
+  for (const [consumer, entry] of Object.entries(services)) {
+    const target = entry.imageOf;
+    if (target !== undefined && closure.has(target)) closure.add(consumer);
+  }
+
+  // 5) Partition into promotable (tier-ordered) vs skipped-with-reason.
+  const promotable: ClosureMember[] = [];
+  const skipped: ClosureSkip[] = [];
+  for (const key of closure) {
+    const entry = services[key];
+    // harness-legacy class: pinned out-of-band, gateIgnore → excluded
+    // entirely (not even reported as skipped — it is deliberately untracked).
+    if (entry.gateIgnore === true && key === "harness-legacy") continue;
+    // No prod env → cannot be promoted (the staging-only worker today).
+    const envs = entry.environments ?? {};
+    if (!Object.hasOwn(envs, "prod")) {
+      skipped.push({
+        name: key,
+        reason: `no "prod" environment in the SSOT — cannot be promoted (it exists in: ${
+          Object.keys(envs).sort().join(", ") || "no environments"
+        }).`,
+      });
+      continue;
+    }
+    promotable.push({ name: key, tier: tierOf(entry) });
+  }
+
+  // Tier-ordered (0→1→2), stable within a tier on insertion order.
+  const services_ordered: ClosureMember[] = [];
+  for (const tier of PROMOTE_TIERS) {
+    for (const m of promotable) {
+      if (m.tier === tier) services_ordered.push(m);
+    }
+  }
+
+  return { services: services_ordered, skipped };
+}
+
+/**
+ * Throw on SSOT load (or in a test with injected input) if the promote
+ * closure is malformed (§4.5), MIRRORING `assertImageConsumersValid`:
+ *   - a member's `runtimeDeps` / `serviceRefs.target` names a non-existent
+ *     SSOT key (a dangling dep would silently never be promoted);
+ *   - the SSOT carries NO Tier-1 verification service (an equivalence-gated
+ *     promote with no control plane to re-sweep on is meaningless);
+ *   - the computed closure is EMPTY (refusing to silently promote nothing).
+ *
+ * `requested` defaults to the full set of declared dispatch_names so the
+ * module-load check exercises the real, fully-populated closure. Accepts an
+ * injected map for testing; defaults to the real SERVICES map.
+ */
+export function assertClosureValid(
+  requested: string[] = Object.keys(SERVICES),
+  services: Record<string, ClosureEntry & { dispatchName?: string }> = SERVICES,
+): void {
+  const problems: string[] = [];
+
+  // Dangling runtimeDeps / serviceRefs targets.
+  for (const [key, entry] of Object.entries(services)) {
+    for (const dep of entry.runtimeDeps ?? []) {
+      if (!Object.hasOwn(services, dep)) {
+        problems.push(
+          `  - runtimeDeps "${dep}" on "${key}" is not an SSOT key in SERVICES`,
+        );
+      }
+    }
+    const refs = (entry as { serviceRefs?: { target: string }[] }).serviceRefs;
+    for (const ref of refs ?? []) {
+      if (!Object.hasOwn(services, ref.target)) {
+        problems.push(
+          `  - serviceRefs target "${ref.target}" on "${key}" is not an SSOT key in SERVICES`,
+        );
+      }
+    }
+  }
+
+  // The SSOT must declare at least one Tier-1 verification service.
+  const hasTier1 = Object.values(services).some((e) => tierOf(e) === 1);
+  if (!hasTier1) {
+    problems.push(
+      `  - no Tier-1 verification service (promoteTier:1) in SERVICES — an equivalence-gated promote has no control plane to re-sweep on`,
+    );
+  }
+
+  // The computed closure must be non-empty. Skip this clause when the
+  // dangling-dep / missing-Tier-1 problems above already fired, since
+  // computePromoteClosure would throw on an unknown requested name before we
+  // could surface the curated message.
+  if (problems.length === 0) {
+    let plan: ClosurePlan | undefined;
+    try {
+      plan = computePromoteClosure(requested, services);
+    } catch (err) {
+      problems.push(`  - computePromoteClosure threw: ${String(err)}`);
+    }
+    if (plan !== undefined && plan.services.length === 0) {
+      problems.push(
+        `  - the computed promote closure is EMPTY — refusing to silently promote nothing`,
+      );
+    }
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `railway-envs promote-closure invariant violated:\n${problems.join(
+        "\n",
+      )}\n` +
+        `Fix: every runtimeDeps / serviceRefs target must be an existing ` +
+        `SSOT key, the SSOT must declare at least one Tier-1 (promoteTier:1) ` +
+        `service, and the computed closure must be non-empty.`,
+    );
+  }
 }
 
 /**
@@ -1490,3 +2220,4 @@ assertDispatchNamesUnique();
 assertImageConsumersValid();
 assertEnvRegistryConsistent();
 assertServiceAndInstanceIdsUnique();
+assertClosureValid();

--- a/showcase/scripts/redeploy-env.test.ts
+++ b/showcase/scripts/redeploy-env.test.ts
@@ -48,7 +48,7 @@ describe("runRedeploy", () => {
     summary += s + "\n";
   };
 
-  it("default staging scope = 26 CI-built services + their imageOf consumers (harness-workers)", async () => {
+  it("default staging scope = 38 CI-built services + their imageOf consumers (harness-workers)", async () => {
     const seenNames: string[] = [];
     const redeploy = vi.fn(async (serviceId: string) => {
       // Reverse-lookup the SSOT name from serviceId so the test can
@@ -68,11 +68,16 @@ describe("runRedeploy", () => {
     });
 
     expect(result.exitCode).toBe(0);
-    expect(result.attempted).toBe(27);
-    expect(result.succeeded).toBe(27);
-    expect(redeploy).toHaveBeenCalledTimes(27);
+    // 38 CI-built (26 showcase/infra + 12 starters, S2) + harness-workers
+    // (imageOf consumer of showcase-harness) = 39.
+    expect(result.attempted).toBe(39);
+    expect(result.succeeded).toBe(39);
+    expect(redeploy).toHaveBeenCalledTimes(39);
     // pocketbase is now CI-built, so it IS in the default redeploy scope.
     expect(seenNames).toContain("pocketbase");
+    // S2: starters are CI-built, so they JOIN the default redeploy scope.
+    expect(seenNames).toContain("starter-adk");
+    expect(seenNames).toContain("starter-mastra");
     // harness-workers runs the shared showcase-harness image (imageOf:
     // "harness") and must follow the scheduler into the staging scope.
     expect(seenNames).toContain("harness-workers");
@@ -133,8 +138,9 @@ describe("runRedeploy", () => {
   });
 
   it("default prod scope does NOT include the staging-only harness-workers", async () => {
-    // imageOf expansion is env-aware: harness-workers has no prod env, so
-    // prod behavior is unchanged (26 CI-built services, no worker).
+    // imageOf expansion is env-aware: harness-workers has no prod env, so it
+    // never joins the prod scope. The prod default = the 38 CI-built services
+    // (26 showcase/infra + 12 starters, S2), no worker.
     const seenNames: string[] = [];
     const redeploy = vi.fn(async (serviceId: string) => {
       const name = Object.entries(SERVICES).find(
@@ -148,8 +154,10 @@ describe("runRedeploy", () => {
       redeploy,
       appendSummary,
     });
-    expect(result.attempted).toBe(26);
+    expect(result.attempted).toBe(38);
     expect(seenNames).not.toContain("harness-workers");
+    // S2: starters ARE in the default prod scope (CI-built, dual-env).
+    expect(seenNames).toContain("starter-adk");
   });
 
   it("default whole-env staging redeploy NEVER bounces webhooks (out-of-band)", async () => {
@@ -554,9 +562,12 @@ describe("resolveTargetServices", () => {
 
   it("returns the CI_BUILT_SERVICES set sorted when given undefined", () => {
     const resolved = resolveTargetServices(undefined);
-    expect(resolved.length).toBe(26);
+    // 26 showcase/infra CI-built + 12 starters (S2) = 38.
+    expect(resolved.length).toBe(38);
     // pocketbase is now CI-built and part of the default scope.
     expect(resolved).toContain("pocketbase");
+    // S2: starters are CI-built and part of the default scope.
+    expect(resolved).toContain("starter-adk");
     // webhooks remains out-of-band.
     expect(resolved).not.toContain("webhooks");
   });

--- a/showcase/scripts/resolve-promote-targets.sh
+++ b/showcase/scripts/resolve-promote-targets.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# resolve-promote-targets.sh — resolve the workflow_dispatch `service` input into
+# the canonical promote target sets consumed by the downstream jobs.
+#
+# Extracted from .github/workflows/showcase_promote.yml so the resolution +
+# closure derivation are unit-testable (see __tests__/resolve-promote-targets.bats),
+# mirroring how verify-prod-display.sh / promote-fleet.sh were extracted from the
+# same workflow.
+#
+# This is the U3 (spec §8.3 Phase 1, BACKWARD-COMPAT) surface. It does THREE
+# things and changes NO promote behavior:
+#
+#   1. services_csv — the EXISTING leaf-set CSV the actual promote loop consumes.
+#      For a single service this is just that service's SSOT name; for `all` it
+#      is every prod-eligible (`probe.prod == true`) SSOT name, sorted (the prior
+#      inline behavior, byte-for-byte). U4 still drives the real promote off this.
+#
+#   2. closure_csv / closure_plan — the TIERED promote closure computed from the
+#      generated JSON's `closure` block: the requested set ∪ transitive
+#      runtimeDeps ∪ ALL Tier-1 verification services (always included for an
+#      equivalence-gated promote, §4.2), ordered by tier (0→1→2) using the
+#      `closure.services` array's authoritative ordering. `closure_csv` is the
+#      tier-ordered SSOT-name CSV; `closure_plan` is the machine-readable
+#      `tier:name` form U4 consumes to enforce tier ordering / dependent-gating.
+#      Phase 1 EMITS these but does NOT promote off them — U4 does that later.
+#
+#   3. A human-readable closure plan + the skipped (no-prod-env) members into
+#      $GITHUB_STEP_SUMMARY so the operator SEES the closure and any skips (§4.3,
+#      §4.5) before/while the promote runs — skips are never silent.
+#
+# Preserved guards (unchanged from the inline version):
+#   * the __select_a_service__ placeholder abort,
+#   * the --digest + 'all' reject (a single digest is meaningless fleet-wide),
+#   * the empty-`all` fail-loud (an SSOT regression dropping every prod entry),
+#   * the unknown / ambiguous / not-prod-eligible single-service guard.
+#
+# Inputs (env):
+#   INPUT      (required)  the workflow_dispatch `service` value (SSOT key,
+#                          dispatch_name, or 'all').
+#   DIGEST     (optional)  the workflow_dispatch `digest` override.
+#   GENERATED  (optional)  path to railway-envs.generated.json
+#                          (default: showcase/scripts/railway-envs.generated.json,
+#                          resolved relative to this script).
+#
+# Outputs (appended to $GITHUB_OUTPUT):
+#   services_csv   leaf-set CSV (backward-compat promote target).
+#   closure_csv    tier-ordered closure SSOT-name CSV.
+#   closure_plan   tier-annotated `tier:name` CSV for U4.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INPUT="${INPUT:-}"
+DIGEST="${DIGEST:-}"
+GENERATED="${GENERATED:-$SCRIPT_DIR/railway-envs.generated.json}"
+
+if [ ! -f "$GENERATED" ]; then
+  echo "::error::generated SSOT artifact not found at '$GENERATED'"
+  exit 1
+fi
+
+# --- guard: deliberate no-op abort (human ran without picking a service) -----
+if [ "$INPUT" = "__select_a_service__" ] || [ -z "$INPUT" ]; then
+  echo "::error::No service selected. Re-run and pick a service (or 'all') from the dropdown."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Leaf-set services_csv (BACKWARD-COMPAT — identical to the prior inline path)
+# ---------------------------------------------------------------------------
+if [ "$INPUT" = "all" ]; then
+  # A single digest identifies at most one service's image, so a fleet-wide
+  # promote pinned to one digest is always wrong. Reject loud and early (the
+  # per-service promote loop would otherwise slip past bin/railway's own
+  # --digest guard, which only sees one positional service at a time).
+  if [ -n "$DIGEST" ]; then
+    echo "::error::--digest cannot be combined with 'all' (a single digest is meaningless across multiple services); pick one service."
+    exit 1
+  fi
+  CSV=$(jq -r '.services[] | select(.probe.prod == true) | .name' "$GENERATED" | sort -u | tr '\n' ',' | sed 's/,$//')
+  # Fail loud if 'all' resolved to nothing (e.g. an SSOT regression dropped every
+  # probe.prod entry). An empty CSV would otherwise propagate downstream with
+  # exit 0; mirror the single-service branch's fail-loud style.
+  if [ -z "$CSV" ]; then
+    echo "::error::'all' resolved to zero prod-eligible services"
+    exit 1
+  fi
+  # The requested SSOT set for closure computation = the full prod-eligible leaf
+  # set (newline-delimited).
+  REQUESTED=$(printf '%s' "$CSV" | tr ',' '\n')
+else
+  # Capture the FULL match set (no `head` — that would silently mask an ambiguous
+  # match, and piping jq into head under pipefail can SIGPIPE jq and abort with no
+  # ::error:: annotation). Then count and branch fail-loud. Enforce prod-
+  # eligibility here too: a stale/edited dropdown could offer a probe.prod:false
+  # service, and the single-service path must never promote a non-eligible
+  # service to prod (matching the `all` branch's gate).
+  MATCHES=$(jq -r --arg s "$INPUT" '
+    .services[]
+    | select(.name == $s or .dispatchName == $s)
+    | select(.probe.prod == true)
+    | .name
+  ' "$GENERATED")
+  # `grep -c` on empty input exits 1 under set -e; guard with || true.
+  COUNT=$(printf '%s' "$MATCHES" | grep -c . || true)
+  if [ "$COUNT" -eq 0 ]; then
+    echo "::error::Unknown or not prod-eligible service '$INPUT' (not an SSOT key/dispatch_name, or probe.prod is not true)"
+    exit 1
+  elif [ "$COUNT" -gt 1 ]; then
+    LIST=$(printf '%s' "$MATCHES" | tr '\n' ',' | sed 's/,$//')
+    echo "::error::Ambiguous service '$INPUT' matches multiple SSOT entries: $LIST"
+    exit 1
+  fi
+  CSV="$MATCHES"
+  REQUESTED="$MATCHES"
+fi
+
+echo "services_csv=$CSV" >> "$GITHUB_OUTPUT"
+
+# ---------------------------------------------------------------------------
+# 2. Tiered promote CLOSURE (computed from the generated `closure` block).
+# ---------------------------------------------------------------------------
+# Closure = requested ∪ transitive runtimeDeps ∪ ALL Tier-1 verification
+# services (always included for an equivalence-gated promote, §4.2), restricted
+# to the closure block's members and emitted in the closure block's tier order.
+#
+# The closure block (U1/U2) is the authoritative tier-ordered full-fleet plan:
+#   .closure.services = [ { name, tier }, ... ]  (already 0→1→2 ordered)
+#   .closure.skipped  = [ { name, reason }, ... ] (no-prod-env members, §4.3)
+# Per-service runtimeDeps live on .services[].runtimeDeps.
+#
+# We do the transitive-closure walk in jq so the ordering + dedup match the SSOT
+# emitter exactly (no bash set bookkeeping). REQUESTED is passed as a newline list.
+REQUESTED_JSON=$(printf '%s\n' "$REQUESTED" | jq -R . | jq -s 'map(select(length > 0))')
+
+CLOSURE_PLAN_JSON=$(jq -n \
+  --slurpfile gen "$GENERATED" \
+  --argjson requested "$REQUESTED_JSON" '
+  ($gen[0]) as $g
+  # name -> tier from the authoritative closure ordering.
+  | ($g.closure.services) as $ordered
+  | ($ordered | map({ key: .name, value: .tier }) | from_entries) as $tierOf
+  # name -> runtimeDeps[] from the per-service entries.
+  | ($g.services | map({ key: .name, value: (.runtimeDeps // []) }) | from_entries) as $depsOf
+  # ALL Tier-1 verification services are always part of an equivalence-gated
+  # promote closure (§4.2).
+  | ($ordered | map(select(.tier == 1) | .name)) as $tier1
+  # Transitive runtimeDeps walk over the requested set (bounded; the dep graph is
+  # shallow — tier-2 -> tier-0/1, tier-1 -> tier-0).
+  | def expand(seed):
+      reduce range(0; 8) as $_ (seed;
+        (. + ([ .[] | ($depsOf[.] // []) ] | add // [])) | unique
+      );
+    expand(($requested + $tier1))
+  # name -> position in the authoritative closure ordering. We build this as an
+  # explicit map rather than using index(name): the jq index builtin on an array
+  # of strings does a SUBSEQUENCE search when the argument is a string (e.g.
+  # ["harness","dashboard"] | index("dashboard") returns 0, not 1), which would
+  # scramble within-tier ordering. A position map is unambiguous.
+  | ($ordered | to_entries | map({ key: .value.name, value: .key }) | from_entries) as $posOf
+  # Keep only members that exist in the closure ordering (drop anything without a
+  # known tier — e.g. a runtimeDep that is itself not promotable), then sort by
+  # the closure tier order, and within a tier preserve the closure listing order.
+  | map(select($tierOf[.] != null))
+  | unique
+  | sort_by([ $tierOf[.], $posOf[.] ])
+  | map({ name: ., tier: $tierOf[.] })
+')
+
+# closure_csv — tier-ordered SSOT-name CSV.
+CLOSURE_CSV=$(printf '%s' "$CLOSURE_PLAN_JSON" | jq -r 'map(.name) | join(",")')
+# closure_plan — tier-annotated `tier:name` CSV for U4's tier-ordered gating.
+CLOSURE_PLAN=$(printf '%s' "$CLOSURE_PLAN_JSON" | jq -r 'map("\(.tier):\(.name)") | join(",")')
+
+# Defense in depth: an empty closure means the SSOT closure block is broken (the
+# requested set always self-includes, and Tier-1 is always present). Fail loud
+# rather than emit a vacuous plan downstream.
+if [ -z "$CLOSURE_CSV" ]; then
+  echo "::error::promote closure resolved to zero services — the SSOT closure block is empty or malformed"
+  exit 1
+fi
+
+{
+  echo "closure_csv=$CLOSURE_CSV"
+  echo "closure_plan=$CLOSURE_PLAN"
+} >> "$GITHUB_OUTPUT"
+
+# ---------------------------------------------------------------------------
+# 3. Surface the closure plan + skips into the step summary (operators SEE it).
+# ---------------------------------------------------------------------------
+# Phase-1 note for the operator: the closure is INFORMATIONAL here; the actual
+# promote still runs the leaf set (services_csv). U4 will enforce tier ordering
+# and dependent-gating off this same closure.
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### Promote closure (\`$INPUT\`)"
+    echo ""
+    echo "**Leaf promote set** (Phase 1 — what actually promotes now): \`$CSV\`"
+    echo ""
+    echo "**Tiered closure** (transitive deps ∪ Tier-1 verification — surfaced for the equivalence gate; U4 promotes by tier):"
+    echo ""
+    echo "| order | tier | service |"
+    echo "| ----- | ---- | ------- |"
+    printf '%s' "$CLOSURE_PLAN_JSON" \
+      | jq -r 'to_entries[] | "| \(.key + 1) | tier \(.value.tier) | `\(.value.name)` |"'
+    echo ""
+    # Skipped members (no prod env, §4.3) — NEVER silent.
+    SKIPPED_COUNT=$(jq -r '(.closure.skipped // []) | length' "$GENERATED")
+    if [ "$SKIPPED_COUNT" -gt 0 ]; then
+      echo "**Skipped** (no \`prod\` environment in the SSOT — cannot be promoted):"
+      echo ""
+      jq -r '(.closure.skipped // [])[] | "- `\(.name)` — \(.reason)"' "$GENERATED"
+      echo ""
+    fi
+  } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/showcase/scripts/verify-deploy.drivers.ts
+++ b/showcase/scripts/verify-deploy.drivers.ts
@@ -57,6 +57,22 @@ export async function runDriver(target: ProbeTarget): Promise<ProbeOutcome> {
         return (await import("./verify-deploy.drivers.agent")).probeAgent(
           target,
         );
+      case "starter":
+        // The starter-template fleet (`starter-<slug>`) is NOT verified by the
+        // verify-deploy feature-driver matrix — it is probed by the harness
+        // `starter_smoke` axis. This case exists ONLY to satisfy the exhaustive
+        // switch (the `never` guard below) now that "starter" is a ProbeDriver.
+        // Starters set staging probe OFF, so resolve-verify-matrix never routes
+        // one here; if a starter is ever dispatched to verify-deploy that is a
+        // wiring bug, so fail loud rather than silently pass. S3 wires the
+        // equivalence gate to route a "starter"-driver service to starter-smoke.
+        return {
+          ok: false,
+          error:
+            `driver "starter" is not handled by verify-deploy (service ` +
+            `"${target.name}"): the starter fleet is verified by the harness ` +
+            `starter_smoke axis, not the verify-deploy matrix`,
+        };
       default: {
         const exhaustive: never = target.driver;
         return { ok: false, error: `unknown driver: ${String(exhaustive)}` };

--- a/showcase/scripts/verify-prod-resweep.test.ts
+++ b/showcase/scripts/verify-prod-resweep.test.ts
@@ -1,0 +1,599 @@
+import { describe, it, expect } from "vitest";
+import {
+  enqueueProdResweep,
+  pollProdFreshness,
+  runVerifyProdResweep,
+  freshnessKeysForCell,
+  cellsFromClosureCsv,
+  partitionCellsByAxis,
+  createRealProdControlPlane,
+} from "./verify-prod-resweep";
+import type {
+  ProdResweepDeps,
+  FakeProdControlPlane,
+} from "./verify-prod-resweep";
+import type {
+  LiveStatusMap,
+  StatusRow,
+} from "../shell-dashboard/src/lib/live-status";
+import { keyFor } from "../shell-dashboard/src/lib/live-status";
+import type { GateCell } from "./equivalence-gate";
+
+// ---------------------------------------------------------------------------
+// Fake prod control-plane
+//
+// The real prod path enqueues a triggered tick against the prod harness
+// producer (→ probe_jobs in prod PB), the prod harness-workers claim + run the
+// jobs, and the result-aggregator writes fresh `status` rows. We model that as
+// a clock-driven fake: `enqueue` records the trigger time; the worker fleet
+// (modeled by `advanceWorkers`) writes post-trigger rows into the prod map
+// after a configurable lag; the poller reads the prod map.
+// ---------------------------------------------------------------------------
+
+const NOW0 = Date.parse("2026-06-19T12:00:00.000Z");
+
+function row(
+  dimension: string,
+  slug: string,
+  featureId: string | undefined,
+  state: StatusRow["state"],
+  observedAtMs: number,
+  signal: unknown = null,
+): [string, StatusRow] {
+  const key = keyFor(dimension, slug, featureId);
+  const observed = new Date(observedAtMs).toISOString();
+  return [
+    key,
+    {
+      id: `${key}#id`,
+      key,
+      dimension,
+      state,
+      signal,
+      observed_at: observed,
+      transitioned_at: observed,
+      fail_count: state === "red" ? 1 : 0,
+      first_failure_at: state === "red" ? observed : null,
+    },
+  ];
+}
+
+const MAPPED_FEATURE = "agentic-chat"; // present in CATALOG_TO_D5_KEY
+
+/** Build a green-ladder cell map at a given observed_at (ms). */
+function greenCellMap(slug: string, observedAtMs: number): LiveStatusMap {
+  const m: LiveStatusMap = new Map();
+  m.set(...row("e2e", slug, MAPPED_FEATURE, "green", observedAtMs));
+  m.set(...row("chat", slug, undefined, "green", observedAtMs));
+  m.set(...row("d5", slug, MAPPED_FEATURE, "green", observedAtMs));
+  m.set(...row("d6", slug, MAPPED_FEATURE, "green", observedAtMs));
+  return m;
+}
+
+function redCellMap(slug: string, observedAtMs: number): LiveStatusMap {
+  const m: LiveStatusMap = new Map();
+  m.set(...row("e2e", slug, MAPPED_FEATURE, "red", observedAtMs));
+  m.set(...row("chat", slug, undefined, "green", observedAtMs));
+  return m;
+}
+
+function mergeMaps(...maps: LiveStatusMap[]): LiveStatusMap {
+  const out: LiveStatusMap = new Map();
+  for (const m of maps) for (const [k, v] of m) out.set(k, v);
+  return out;
+}
+
+const CELL = (slug: string): GateCell => ({
+  slug,
+  featureId: MAPPED_FEATURE,
+  isSupported: true,
+  isWired: true,
+});
+
+/**
+ * A controllable fake prod control-plane. `enqueue` records the trigger and
+ * how many jobs went on the queue. `runWorkers(atMs, builder)` simulates the
+ * worker fleet draining the queue and writing fresh status rows (the
+ * aggregator output) at `atMs` — call it to land post-trigger rows.
+ */
+function makeFake(opts: {
+  enqueued?: number;
+  enqueueFailures?: number;
+  workersProvisioned?: boolean;
+}): FakeProdControlPlane & {
+  prod: LiveStatusMap;
+  runWorkers: (atMs: number, mapBuilder: () => LiveStatusMap) => void;
+  triggerAt: number | null;
+} {
+  const prod: LiveStatusMap = new Map();
+  let triggerAt: number | null = null;
+  return {
+    prod,
+    triggerAt,
+    enqueue: async (atMs: number) => {
+      triggerAt = atMs;
+      return {
+        triggerAt: atMs,
+        enqueued: opts.enqueued ?? 3,
+        enqueueFailures: opts.enqueueFailures ?? 0,
+        workersProvisioned: opts.workersProvisioned ?? true,
+      };
+    },
+    readProdStatus: async () => new Map(prod),
+    runWorkers(atMs, mapBuilder) {
+      for (const [k, v] of mapBuilder()) prod.set(k, v);
+      void atMs;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// cellsFromClosureCsv — closure-CSV (U4 succeeded_csv) → gate cells
+//
+// The closure CSV carries SSOT `.name` values: integrations are
+// `showcase-<slug>` (prefixed); infra/shell services are bare names
+// (`aimock`, `dashboard`, `docs`, `dojo`, `webhooks`, `pocketbase`,
+// `harness`). The derived cell must (1) strip the `showcase-` prefix to the
+// harness slug the enqueue discovery + keyFor use, (2) carry only catalogued
+// integrations (infra/shells excluded), and (3) stamp the slug's
+// representative catalog feature.
+// ---------------------------------------------------------------------------
+
+describe("cellsFromClosureCsv", () => {
+  it("derives integration cells with the showcase- prefix STRIPPED and infra/shells excluded", () => {
+    const cells = cellsFromClosureCsv(
+      "showcase-langgraph-python,aimock,pocketbase,dashboard,docs,harness",
+    );
+    // Only the one real integration becomes a cell; every infra/shell token
+    // (aimock/pocketbase/dashboard/docs/harness) is dropped.
+    expect(cells).toHaveLength(1);
+    const cell = cells[0]!;
+    // Slug is the HARNESS slug (prefix stripped) — NOT the raw closure token
+    // `showcase-langgraph-python`, which would never match keyFor / the
+    // enqueue discovery's serviceSlug.
+    expect(cell.slug).toBe("langgraph-python");
+    // featureId is the slug's representative catalog feature (present in
+    // CATALOG_TO_D5_KEY), NOT a phantom.
+    expect(cell.featureId).toBe(MAPPED_FEATURE);
+  });
+
+  it("excludes a showcase-prefixed but non-probe-wired service (ms-agent-harness-dotnet)", () => {
+    const cells = cellsFromClosureCsv(
+      "showcase-langgraph-python,showcase-ms-agent-harness-dotnet",
+    );
+    expect(cells.map((c) => c.slug)).toEqual(["langgraph-python"]);
+  });
+
+  it("derives multiple integration cells, each prefix-stripped", () => {
+    const cells = cellsFromClosureCsv(
+      "showcase-langgraph-python,showcase-mastra,webhooks,dojo",
+    );
+    expect(cells.map((c) => c.slug).sort()).toEqual([
+      "langgraph-python",
+      "mastra",
+    ]);
+  });
+
+  it("routes a starter-* token to the STARTER axis (column slug + probeAxis), NOT a phantom agentic-chat cell", () => {
+    // A closure carrying BOTH a showcase-* integration and a starter-* slug.
+    // The integration stays on the feature (agent) axis; the starter must be
+    // emitted on the STARTER axis: slug remapped to its dashboard COLUMN slug
+    // (STARTER_TO_COLUMN), probeAxis "starter", and NOT a second agentic-chat
+    // cell.
+    const cells = cellsFromClosureCsv("showcase-langgraph-python,starter-adk");
+
+    const integration = cells.find((c) => c.slug === "langgraph-python");
+    expect(integration).toBeDefined();
+    expect(integration!.featureId).toBe(MAPPED_FEATURE);
+    expect(integration!.probeAxis ?? "agent").toBe("agent");
+
+    // `starter-adk` → STARTER_TO_COLUMN["adk"] === "google-adk".
+    const starter = cells.find((c) => c.probeAxis === "starter");
+    expect(starter).toBeDefined();
+    expect(starter!.slug).toBe("google-adk");
+    // The starter cell must NOT masquerade as an agentic-chat feature cell.
+    expect(starter!.featureId).not.toBe(MAPPED_FEATURE);
+
+    // Exactly two cells, and exactly ONE of them is a starter — no phantom
+    // duplicate agentic-chat cell for the starter.
+    expect(cells).toHaveLength(2);
+    expect(cells.filter((c) => c.featureId === MAPPED_FEATURE)).toHaveLength(1);
+  });
+
+  it("maps a direct-slug starter-* token (slug === column slug)", () => {
+    // `langgraph-python` is a DIRECT starter mapping (starter slug === column
+    // slug), distinct from the `showcase-langgraph-python` integration token.
+    const cells = cellsFromClosureCsv("starter-langgraph-python");
+    expect(cells).toHaveLength(1);
+    expect(cells[0]!.slug).toBe("langgraph-python");
+    expect(cells[0]!.probeAxis).toBe("starter");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// freshnessKeysForCell
+// ---------------------------------------------------------------------------
+
+describe("freshnessKeysForCell", () => {
+  it("enumerates the e2e/chat/tools/health + d5/d6 family keys for a cell", () => {
+    const keys = freshnessKeysForCell(CELL("langgraph-python"));
+    expect(keys).toContain(keyFor("e2e", "langgraph-python", MAPPED_FEATURE));
+    expect(keys).toContain(keyFor("chat", "langgraph-python"));
+    expect(keys).toContain(keyFor("d6", "langgraph-python", MAPPED_FEATURE));
+  });
+
+  it("enumerates the starter:<col>/<level> keys for a STARTER-axis cell", () => {
+    const keys = freshnessKeysForCell({
+      slug: "google-adk",
+      featureId: "starter",
+      isSupported: true,
+      isWired: true,
+      probeAxis: "starter",
+    });
+    // Starter axis: the 4 per-level rows, NOT the agent e2e/chat/d5/d6 keys.
+    expect(keys).toContain(keyFor("starter", "google-adk", "health"));
+    expect(keys).toContain(keyFor("starter", "google-adk", "interaction"));
+    expect(keys).not.toContain(keyFor("e2e", "google-adk", MAPPED_FEATURE));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enqueueProdResweep
+// ---------------------------------------------------------------------------
+
+describe("enqueueProdResweep", () => {
+  it("fires the triggered enqueue against prod and returns the trigger instant", async () => {
+    const fake = makeFake({ enqueued: 3 });
+    const deps: ProdResweepDeps = {
+      controlPlane: fake,
+      cells: [CELL("a"), CELL("b"), CELL("c")],
+      readStagingStatus: async () => new Map(),
+      now: () => NOW0,
+      sleep: async () => {},
+    };
+    const res = await enqueueProdResweep(deps);
+    expect(res.triggerAt).toBe(NOW0);
+    expect(res.enqueued).toBe(3);
+    expect(res.workersProvisioned).toBe(true);
+  });
+
+  it("REFUSES when zero jobs are enqueued (nothing will ever land)", async () => {
+    const fake = makeFake({ enqueued: 0 });
+    const deps: ProdResweepDeps = {
+      controlPlane: fake,
+      cells: [CELL("a")],
+      readStagingStatus: async () => new Map(),
+      now: () => NOW0,
+      sleep: async () => {},
+    };
+    await expect(enqueueProdResweep(deps)).rejects.toThrow(/enqueued 0 jobs/i);
+  });
+
+  it("REFUSES on partial enqueue failure (the missing cells never report)", async () => {
+    const fake = makeFake({ enqueued: 2, enqueueFailures: 1 });
+    const deps: ProdResweepDeps = {
+      controlPlane: fake,
+      cells: [CELL("a"), CELL("b"), CELL("c")],
+      readStagingStatus: async () => new Map(),
+      now: () => NOW0,
+      sleep: async () => {},
+    };
+    await expect(enqueueProdResweep(deps)).rejects.toThrow(/enqueue failure/i);
+  });
+
+  it("annotates fallback (inline) mode when prod workers are unprovisioned", async () => {
+    const fake = makeFake({ enqueued: 3, workersProvisioned: false });
+    const deps: ProdResweepDeps = {
+      controlPlane: fake,
+      cells: [CELL("a")],
+      readStagingStatus: async () => new Map(),
+      now: () => NOW0,
+      sleep: async () => {},
+    };
+    const res = await enqueueProdResweep(deps);
+    expect(res.workersProvisioned).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pollProdFreshness
+// ---------------------------------------------------------------------------
+
+describe("pollProdFreshness", () => {
+  it("waits until every promoted cell has a post-trigger row, then returns", async () => {
+    const fake = makeFake({ enqueued: 2 });
+    const triggerAt = NOW0;
+    // The worker fleet lands fresh rows on the 2nd poll tick.
+    let tick = 0;
+    const clock = { t: NOW0 + 1_000 };
+    const deps: ProdResweepDeps = {
+      controlPlane: fake,
+      cells: [CELL("a"), CELL("b")],
+      readStagingStatus: async () => new Map(),
+      now: () => clock.t,
+      sleep: async (ms) => {
+        clock.t += ms;
+        tick += 1;
+        if (tick === 2) {
+          // Workers drain on the 2nd sleep: write fresh post-trigger rows.
+          fake.runWorkers(clock.t, () =>
+            mergeMaps(
+              greenCellMap("a", triggerAt + 5_000),
+              greenCellMap("b", triggerAt + 5_000),
+            ),
+          );
+        }
+      },
+    };
+    const prodRows = await pollProdFreshness(deps, {
+      triggerAt,
+      timeoutMs: 20 * 60_000,
+      pollIntervalMs: 5_000,
+    });
+    // Every cell now has a contributing row at/after the trigger.
+    expect(prodRows.get(keyFor("e2e", "a", MAPPED_FEATURE))?.state).toBe(
+      "green",
+    );
+    expect(prodRows.get(keyFor("e2e", "b", MAPPED_FEATURE))?.state).toBe(
+      "green",
+    );
+  });
+
+  it("REFUSES with 'did not complete' on timeout when rows never post-date the trigger", async () => {
+    const fake = makeFake({ enqueued: 1 });
+    const triggerAt = NOW0;
+    // Pre-existing STALE row from before the trigger — never refreshed.
+    for (const [k, v] of greenCellMap("a", triggerAt - 60_000)) {
+      fake.prod.set(k, v);
+    }
+    const clock = { t: NOW0 + 1_000 };
+    const deps: ProdResweepDeps = {
+      controlPlane: fake,
+      cells: [CELL("a")],
+      readStagingStatus: async () => new Map(),
+      now: () => clock.t,
+      sleep: async (ms) => {
+        clock.t += ms;
+      },
+    };
+    await expect(
+      pollProdFreshness(deps, {
+        triggerAt,
+        timeoutMs: 20 * 60_000,
+        pollIntervalMs: 5_000,
+      }),
+    ).rejects.toThrow(/re-sweep did not complete/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runVerifyProdResweep — the full enqueue → poll → equivalence-gate path
+// ---------------------------------------------------------------------------
+
+describe("runVerifyProdResweep", () => {
+  it("PASSES when fresh prod equals staging (both green) after the re-sweep", async () => {
+    const fake = makeFake({ enqueued: 1 });
+    const clock = { t: NOW0 + 1_000 };
+    let tick = 0;
+    const deps: ProdResweepDeps = {
+      controlPlane: fake,
+      cells: [CELL("a")],
+      readStagingStatus: async () => greenCellMap("a", NOW0),
+      now: () => clock.t,
+      sleep: async (ms) => {
+        clock.t += ms;
+        tick += 1;
+        if (tick === 1) {
+          fake.runWorkers(clock.t, () => greenCellMap("a", NOW0 + 5_000));
+        }
+      },
+    };
+    const result = await runVerifyProdResweep(deps);
+    expect(result.gate.passed).toBe(true);
+    // The trigger watermark is the clock reading AT enqueue (NOW0 + 1_000),
+    // not the test's NOW0 constant.
+    expect(result.triggerAt).toBe(NOW0 + 1_000);
+  });
+
+  it("FAILS the gate on a genuine prod regression (staging green, fresh prod red)", async () => {
+    const fake = makeFake({ enqueued: 1 });
+    const clock = { t: NOW0 + 1_000 };
+    let tick = 0;
+    const deps: ProdResweepDeps = {
+      controlPlane: fake,
+      cells: [CELL("a")],
+      readStagingStatus: async () => greenCellMap("a", NOW0),
+      now: () => clock.t,
+      sleep: async (ms) => {
+        clock.t += ms;
+        tick += 1;
+        if (tick === 1) {
+          // Fresh post-trigger prod row, but RED → genuine regression.
+          fake.runWorkers(clock.t, () => redCellMap("a", NOW0 + 5_000));
+        }
+      },
+    };
+    const result = await runVerifyProdResweep(deps);
+    expect(result.gate.passed).toBe(false);
+    expect(result.gate.mismatches).toHaveLength(1);
+  });
+
+  it("REFUSES (timeout) before consulting the gate when the re-sweep never lands", async () => {
+    const fake = makeFake({ enqueued: 1 });
+    const clock = { t: NOW0 + 1_000 };
+    const deps: ProdResweepDeps = {
+      controlPlane: fake,
+      cells: [CELL("a")],
+      readStagingStatus: async () => greenCellMap("a", NOW0),
+      now: () => clock.t,
+      sleep: async (ms) => {
+        clock.t += ms;
+      },
+    };
+    await expect(runVerifyProdResweep(deps)).rejects.toThrow(
+      /re-sweep did not complete/i,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// partitionCellsByAxis — split the promoted closure into the two enqueue axes
+//
+// The REAL prod enqueue must drive BOTH probe families: the AGENT-axis cells
+// (showcase-* integrations) go through the d6 producer→queue tick, while the
+// STARTER-axis cells (starter-* containers) are probed on the `starter_smoke`
+// CRON matrix. The two have DIFFERENT trigger surfaces + DIFFERENT keyspaces,
+// so the enqueue must partition the closure and fire the correct tick per axis.
+// A starter cell carries the dashboard COLUMN slug; the starter_smoke trigger
+// filter is keyed by the discovery service name (`starter_smoke:starter-<raw>`),
+// so the partition must reverse-map column→raw via STARTER_TO_COLUMN.
+// ---------------------------------------------------------------------------
+
+const STARTER_CELL = (columnSlug: string): GateCell => ({
+  slug: columnSlug,
+  featureId: "starter",
+  isSupported: true,
+  isWired: true,
+  probeAxis: "starter",
+});
+
+describe("partitionCellsByAxis", () => {
+  it("separates agent (showcase-*) slugs from starter trigger keys", () => {
+    const { agentSlugs, starterTriggerKeys } = partitionCellsByAxis([
+      CELL("langgraph-python"),
+      CELL("mastra"),
+      // google-adk is the COLUMN slug; its starter raw slug is `adk`.
+      STARTER_CELL("google-adk"),
+    ]);
+    expect(agentSlugs.sort()).toEqual(["langgraph-python", "mastra"]);
+    // Starter trigger key uses the discovery service name (raw slug), NOT the
+    // column slug, and NOT a d6 keyspace.
+    expect(starterTriggerKeys).toEqual(["starter_smoke:starter-adk"]);
+  });
+
+  it("reverse-maps a DIRECT starter mapping (column slug === raw slug)", () => {
+    // langgraph-python is a direct mapping (raw === column).
+    const { agentSlugs, starterTriggerKeys } = partitionCellsByAxis([
+      STARTER_CELL("langgraph-python"),
+    ]);
+    expect(agentSlugs).toEqual([]);
+    expect(starterTriggerKeys).toEqual([
+      "starter_smoke:starter-langgraph-python",
+    ]);
+  });
+
+  it("reverse-maps a DRIFT starter mapping (column slug !== raw slug)", () => {
+    // strands column slug maps from the `strands-python` raw starter slug.
+    const { starterTriggerKeys } = partitionCellsByAxis([
+      STARTER_CELL("strands"),
+    ]);
+    expect(starterTriggerKeys).toEqual([
+      "starter_smoke:starter-strands-python",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createRealProdControlPlane — axis-split real enqueue (injected seams)
+//
+// The real enqueue is the bug surface the CR flagged: a starter-inclusive
+// promote's enqueue must (a) enumerate the prod starter service and fire a
+// starter_smoke tick (NOT a d6 tick — d6 discovery EXCLUDES starters), and
+// (b) the freshness poll must then wait on `starter:<col>/<level>` keys (which
+// the starter_smoke probe produces), NOT the agent e2e/d6 keys. Before the
+// fix, starter cells were dropped by the showcase- discovery filter and a d6
+// tick was fired, so the `starter:<col>/<level>` rows the freshness poll waits
+// on were NEVER produced → 20-min timeout → REFUSE.
+//
+// We exercise the real factory with INJECTED enqueue seams (no Railway, no
+// harness graph, no HTTP): the seams record which axis was driven with which
+// slugs/keys, so the test proves the split fires a starter_smoke tick for the
+// starter cell and a d6 tick for the agent cell.
+// ---------------------------------------------------------------------------
+
+describe("createRealProdControlPlane axis split", () => {
+  const prodPb = { url: "http://pb", email: "e", password: "p" };
+  const prodRailwayEnv = {
+    token: "rw",
+    projectId: "proj",
+    environmentId: "env",
+  };
+
+  it("fires a starter_smoke tick for starter cells and a d6 tick for agent cells", async () => {
+    const calls: {
+      agentSlugs?: string[];
+      starterTriggerKeys?: string[];
+    } = {};
+    const cp = createRealProdControlPlane({
+      cells: [CELL("langgraph-python"), STARTER_CELL("google-adk")],
+      prodPb,
+      prodRailwayEnv,
+      workersProvisioned: true,
+      // Injected seams — record the axis-routed payloads instead of touching
+      // Railway / the harness producer / the prod harness HTTP trigger.
+      agentEnqueue: async (slugs) => {
+        calls.agentSlugs = slugs;
+        return { enqueued: slugs.length, enqueueFailures: 0 };
+      },
+      starterEnqueue: async (triggerKeys) => {
+        calls.starterTriggerKeys = triggerKeys;
+        return { enqueued: triggerKeys.length, enqueueFailures: 0 };
+      },
+    });
+
+    const res = await cp.enqueue(NOW0);
+
+    // Agent axis: the showcase integration goes through the d6 producer tick.
+    expect(calls.agentSlugs).toEqual(["langgraph-python"]);
+    // Starter axis: the starter container is triggered on starter_smoke, keyed
+    // by its discovery service name (raw slug), NOT a d6 keyspace.
+    expect(calls.starterTriggerKeys).toEqual(["starter_smoke:starter-adk"]);
+    // Both jobs counted toward the enqueue total.
+    expect(res.enqueued).toBe(2);
+    expect(res.enqueueFailures).toBe(0);
+    expect(res.triggerAt).toBe(NOW0);
+  });
+
+  it("does NOT fire a d6 tick when the closure is starter-only", async () => {
+    let agentCalled = false;
+    let starterKeys: string[] = [];
+    const cp = createRealProdControlPlane({
+      cells: [STARTER_CELL("google-adk")],
+      prodPb,
+      prodRailwayEnv,
+      workersProvisioned: true,
+      agentEnqueue: async (slugs) => {
+        agentCalled = true;
+        return { enqueued: slugs.length, enqueueFailures: 0 };
+      },
+      starterEnqueue: async (triggerKeys) => {
+        starterKeys = triggerKeys;
+        return { enqueued: triggerKeys.length, enqueueFailures: 0 };
+      },
+    });
+
+    const res = await cp.enqueue(NOW0);
+
+    // A starter-only closure must NOT drive the d6 producer at all (no agent
+    // cells → no showcase-* discovery tick).
+    expect(agentCalled).toBe(false);
+    expect(starterKeys).toEqual(["starter_smoke:starter-adk"]);
+    expect(res.enqueued).toBe(1);
+  });
+
+  it("freshness keys the poll waits on for a starter cell are starter:<col>/<level>, matching what starter_smoke produces", () => {
+    // The enqueue fires starter_smoke (above); the freshness poll must then
+    // consult the SAME keyspace starter_smoke writes — `starter:<col>/<level>`,
+    // NOT the agent e2e/d6 family. This closes the loop the CR flagged: enqueue
+    // axis ↔ freshness keyspace must agree, else the poll times out.
+    const keys = freshnessKeysForCell(STARTER_CELL("google-adk"));
+    expect(keys).toEqual([
+      keyFor("starter", "google-adk", "health"),
+      keyFor("starter", "google-adk", "agent"),
+      keyFor("starter", "google-adk", "chat"),
+      keyFor("starter", "google-adk", "interaction"),
+    ]);
+    // It must NOT consult the d6 keyspace the (wrong) d6 tick would produce.
+    expect(keys).not.toContain(keyFor("d6", "google-adk", MAPPED_FEATURE));
+  });
+});

--- a/showcase/scripts/verify-prod-resweep.ts
+++ b/showcase/scripts/verify-prod-resweep.ts
@@ -1,0 +1,1087 @@
+/**
+ * Prod re-sweep enqueue + freshness wait + equivalence gate (UNIT U10, spec §6.2).
+ *
+ * ── WHAT THIS DOES ────────────────────────────────────────────────────────
+ * After a cluster promote has re-pinned the closure on prod (U4's
+ * `promote-fleet.sh` ran in the `promote` job), the verification of "did prod
+ * actually come up equivalent to staging?" cannot trust the FROZEN prod status
+ * rows: they describe the pre-promote prod. So this module:
+ *
+ *   1. ENQUEUE — fires a fresh D-level sweep on the PROD control plane (prod
+ *      harness scheduler/producer → prod `probe_jobs` queue → prod
+ *      harness-workers → result-aggregator), scoped to the promoted Tier-2
+ *      integration closure. This is NOT a new probe path — it is one
+ *      operator-TRIGGERED producer tick against prod, the SAME
+ *      producer→queue→worker wiring `bin/showcase test --d5/--d6` drives
+ *      locally (`runViaControlPlane` / `createJobProducer`). The CLI host only
+ *      enqueues + polls; the prod workers run the drivers inside the prod
+ *      network.
+ *
+ *   2. POLL — waits until EVERY promoted cell has at least one contributing
+ *      prod `status` row whose `observed_at` post-dates the re-sweep TRIGGER
+ *      instant, or a 20-minute timeout → REFUSE "re-sweep did not complete".
+ *      A pre-trigger row is the pre-promote prod and is not evidence about the
+ *      just-promoted prod (mirrors equivalence-gate §6.4 freshness).
+ *
+ *   3. GATE — runs U9's `runEquivalenceGate` over the freshly-swept prod rows
+ *      vs the current staging rows. Promote success flips to the equivalence
+ *      definition: FAIL only on a cell green-on-staging / not-green-on-prod,
+ *      gray/stale excluded, one-directional (prod greener passes).
+ *
+ * ── FALLBACK (spec §4.4 / §8.1) ───────────────────────────────────────────
+ * Prod `harness-workers` is an out-of-PR operational prerequisite. Until it is
+ * provisioned, the prod scheduler runs the probes INLINE (degraded throughput
+ * but functional). The enqueue layer reports `workersProvisioned`; this gate
+ * ANNOTATES fallback mode in its result/summary and does NOT block on it — the
+ * provisioning decision is a maintainer prereq, not a code unit.
+ *
+ * ── TESTABILITY ───────────────────────────────────────────────────────────
+ * The orchestration (enqueue → poll-for-freshness → gate) is pure over an
+ * injected `ProdControlPlane` (enqueue + read-prod-status) + injected
+ * `readStagingStatus` + clock + sleep, so the whole path is unit-tested against
+ * a FAKE prod control-plane (no Railway, no PocketBase). The CLI entrypoint at
+ * the bottom wires the REAL prod control-plane (`createRealProdControlPlane`,
+ * dynamically importing the harness producer/queue wiring) and the prod/staging
+ * PocketBase readers.
+ */
+
+import { runEquivalenceGate } from "./equivalence-gate";
+import type { EquivalenceGateResult, GateCell } from "./equivalence-gate";
+import {
+  keyFor,
+  CATALOG_TO_D5_KEY,
+  STARTER_LEVELS,
+} from "../shell-dashboard/src/lib/live-status";
+import type {
+  LiveStatusMap,
+  StatusRow,
+} from "../shell-dashboard/src/lib/live-status";
+import { STARTER_TO_COLUMN } from "../harness/src/probes/helpers/starter-mapping";
+
+/** Default re-sweep ceiling (spec §6.2): 20 minutes → REFUSE on timeout. */
+export const DEFAULT_RESWEEP_TIMEOUT_MS = 20 * 60_000;
+/** How often to re-read prod PocketBase for post-trigger freshness. */
+export const DEFAULT_RESWEEP_POLL_INTERVAL_MS = 15_000;
+
+/** Outcome of the prod enqueue tick. */
+export interface ProdEnqueueResult {
+  /** Epoch ms the re-sweep was triggered (the freshness watermark). */
+  triggerAt: number;
+  /** Number of per-cell jobs that reached the prod queue. */
+  enqueued: number;
+  /** Number of jobs that FAILED to enqueue (any > 0 = REFUSE). */
+  enqueueFailures: number;
+  /**
+   * False when prod `harness-workers` is unprovisioned and the scheduler is
+   * running probes inline (degraded fallback, §4.4). Annotated, never blocked.
+   */
+  workersProvisioned: boolean;
+}
+
+/**
+ * The prod control-plane seam. Production wires this to the harness
+ * producer/queue (enqueue) + a prod PocketBase reader (readProdStatus); tests
+ * inject a fake.
+ */
+export interface ProdControlPlane {
+  /**
+   * Fire ONE operator-triggered producer tick against PROD, scoped to the
+   * promoted closure, returning the trigger instant + enqueue accounting.
+   * `atMs` is the caller's clock reading for the trigger watermark.
+   */
+  enqueue(atMs: number): Promise<ProdEnqueueResult>;
+  /** Read the current prod `status` rows into a LiveStatusMap. */
+  readProdStatus(): Promise<LiveStatusMap>;
+}
+
+/** Test alias — a fake that satisfies {@link ProdControlPlane}. */
+export type FakeProdControlPlane = ProdControlPlane;
+
+/**
+ * The per-axis enqueue accounting a real enqueue seam returns. The real prod
+ * enqueue fans out over TWO axes (agent d6 producer tick + starter_smoke
+ * trigger); each seam reports how many jobs landed and how many failed, and
+ * {@link createRealProdControlPlane} sums them into the {@link ProdEnqueueResult}.
+ */
+export interface EnqueueAxisResult {
+  enqueued: number;
+  enqueueFailures: number;
+}
+
+/**
+ * The AGENT-axis enqueue seam: fire a TRIGGERED d6 producer tick scoped to the
+ * given harness slugs against prod. Defaults to the real harness
+ * producer→queue wiring; tests inject a fake.
+ */
+export type AgentEnqueueFn = (
+  agentSlugs: string[],
+  atMs: number,
+) => Promise<EnqueueAxisResult>;
+
+/**
+ * The STARTER-axis enqueue seam: TRIGGER the prod `starter_smoke` CRON probe,
+ * scoped to the given `starter_smoke:starter-<rawSlug>` filter keys. Defaults
+ * to an HTTP POST to the prod harness `/api/probes/starter_smoke/trigger`
+ * endpoint; tests inject a fake.
+ */
+export type StarterEnqueueFn = (
+  starterTriggerKeys: string[],
+  atMs: number,
+) => Promise<EnqueueAxisResult>;
+
+/** Injected dependencies for the prod re-sweep + gate. */
+export interface ProdResweepDeps {
+  /** The prod control-plane (enqueue + read prod status). */
+  controlPlane: ProdControlPlane;
+  /** The promoted closure as gate cells (caller enumerates from U3/U4 output). */
+  cells: GateCell[];
+  /** Read the current staging `status` rows into a LiveStatusMap. */
+  readStagingStatus(): Promise<LiveStatusMap>;
+  /** Epoch-ms clock. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Sleep helper (ms). Defaults to a real `setTimeout` wait. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/** Polling tunables for {@link pollProdFreshness}. */
+export interface FreshnessPollOptions {
+  /** The re-sweep trigger watermark (epoch ms); rows must post-date it. */
+  triggerAt: number;
+  /** Ceiling before REFUSE. Default {@link DEFAULT_RESWEEP_TIMEOUT_MS}. */
+  timeoutMs?: number;
+  /** Re-read cadence. Default {@link DEFAULT_RESWEEP_POLL_INTERVAL_MS}. */
+  pollIntervalMs?: number;
+}
+
+/** The full result of a verify-prod re-sweep + equivalence gate. */
+export interface VerifyProdResweepResult {
+  /** When the re-sweep was triggered (epoch ms). */
+  triggerAt: number;
+  /** Whether prod workers were provisioned (false = inline fallback, §4.4). */
+  workersProvisioned: boolean;
+  /** The equivalence-gate verdict over the FRESH prod vs staging rows. */
+  gate: EquivalenceGateResult;
+  /** A human-readable summary for `$GITHUB_STEP_SUMMARY` + Slack. */
+  summary: string;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Enumerate the prod `status` keys a single cell derives from. A cell is
+ * considered FRESH iff at least one of these keys has a post-trigger row. This
+ * mirrors the keyspace `equivalence-gate.newestProdObservation` /
+ * `buildCellModel`'s resolvers fan out over (e2e, chat/tools, health, and the
+ * per-cell d5/d6 family) so the freshness verdict cannot diverge from the rows
+ * the chip is derived from.
+ */
+export function freshnessKeysForCell(cell: GateCell): string[] {
+  const { slug, featureId } = cell;
+  // STARTER axis: a starter cell is probed on the `starter_smoke` matrix, whose
+  // rows are keyed `starter:<columnSlug>/<level>`. It never writes the agent
+  // e2e/chat/tools/health + d5/d6 rows, so freshness must consult ITS keyspace
+  // — mirroring `equivalence-gate.newestProdObservation` and the rows
+  // `buildCellModel`'s `resolveStarterChip` derives from.
+  if (cell.probeAxis === "starter") {
+    return STARTER_LEVELS.map((level) => keyFor("starter", slug, level));
+  }
+  const keys: string[] = [
+    keyFor("e2e", slug, featureId),
+    keyFor("chat", slug),
+    keyFor("tools", slug),
+    keyFor("health", slug),
+  ];
+  const familyKeys = CATALOG_TO_D5_KEY[featureId];
+  if (familyKeys) {
+    for (const ft of familyKeys) {
+      keys.push(keyFor("d5", slug, ft));
+      keys.push(keyFor("d6", slug, ft));
+    }
+  }
+  return keys;
+}
+
+/**
+ * The newest prod `observed_at` (epoch ms) across every key a cell derives
+ * from, or `null` when the cell has NO contributing prod row at all. An
+ * unparseable `observed_at` cannot establish recency and is skipped (it can
+ * never beat the trigger), failing safe toward "not fresh".
+ */
+function newestObservation(rows: LiveStatusMap, cell: GateCell): number | null {
+  let newest: number | null = null;
+  for (const key of freshnessKeysForCell(cell)) {
+    const r = rows.get(key);
+    if (!r) continue;
+    const ms = Date.parse(r.observed_at);
+    if (Number.isNaN(ms)) continue;
+    if (newest === null || ms > newest) newest = ms;
+  }
+  return newest;
+}
+
+/** True iff the cell has at least one contributing row at/after `triggerAt`. */
+function cellIsFresh(
+  rows: LiveStatusMap,
+  cell: GateCell,
+  triggerAt: number,
+): boolean {
+  const newest = newestObservation(rows, cell);
+  return newest !== null && newest >= triggerAt;
+}
+
+/**
+ * Fire the prod re-sweep enqueue and validate the tick landed jobs for the
+ * WHOLE closure. REFUSES (throws) on a zero-enqueue or any partial enqueue
+ * failure — a cell whose job never reached the prod queue would never produce
+ * a fresh row, so the freshness poll could only ever time out (or, worse, a
+ * surviving subset could mask the missing cells). Mirrors the CLI
+ * control-plane's fail-loud enqueue guards (`runViaControlPlane`).
+ */
+export async function enqueueProdResweep(
+  deps: ProdResweepDeps,
+): Promise<ProdEnqueueResult> {
+  const now = deps.now ?? Date.now;
+  const res = await deps.controlPlane.enqueue(now());
+  if (res.enqueued === 0) {
+    throw new Error(
+      "prod re-sweep enqueued 0 jobs — no cell would ever produce a fresh row; " +
+        "refusing before the freshness poll (check the promoted closure / prod discovery)",
+    );
+  }
+  if (res.enqueueFailures > 0) {
+    throw new Error(
+      `prod re-sweep had ${res.enqueueFailures} enqueue failure(s) — the missing ` +
+        "cells will never report a fresh row; refusing before the freshness poll",
+    );
+  }
+  return res;
+}
+
+/**
+ * Poll prod PocketBase until EVERY promoted cell has a contributing row whose
+ * `observed_at` post-dates `triggerAt`, then return the prod LiveStatusMap.
+ * Throws "re-sweep did not complete" on timeout (spec §6.2 REFUSE).
+ */
+export async function pollProdFreshness(
+  deps: ProdResweepDeps,
+  opts: FreshnessPollOptions,
+): Promise<LiveStatusMap> {
+  const now = deps.now ?? Date.now;
+  const sleep = deps.sleep ?? defaultSleep;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_RESWEEP_TIMEOUT_MS;
+  const pollIntervalMs =
+    opts.pollIntervalMs ?? DEFAULT_RESWEEP_POLL_INTERVAL_MS;
+  const deadline = now() + timeoutMs;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const prodRows = await deps.controlPlane.readProdStatus();
+    const stale = deps.cells.filter(
+      (cell) => !cellIsFresh(prodRows, cell, opts.triggerAt),
+    );
+    if (stale.length === 0) {
+      return prodRows;
+    }
+    if (now() >= deadline) {
+      const label = stale.map((c) => `${c.slug}/${c.featureId}`).join(", ");
+      throw new Error(
+        `re-sweep did not complete: ${stale.length} of ${deps.cells.length} ` +
+          `promoted cell(s) had no prod row post-dating the trigger within ` +
+          `${Math.round(timeoutMs / 60_000)}m: ${label}`,
+      );
+    }
+    await sleep(pollIntervalMs);
+  }
+}
+
+/**
+ * Build the workflow-summary / Slack text. Prefixes the equivalence-gate
+ * summary with the re-sweep mode banner (fallback annotation, §4.4).
+ */
+function buildSummary(
+  res: ProdEnqueueResult,
+  gate: EquivalenceGateResult,
+): string {
+  const mode = res.workersProvisioned
+    ? "prod harness-workers (full throughput)"
+    : "scheduler INLINE fallback — prod harness-workers unprovisioned (§4.4, degraded throughput)";
+  return (
+    `Prod re-sweep mode: ${mode}.\n` +
+    `Triggered ${res.enqueued} job(s) at ${new Date(res.triggerAt).toISOString()}.\n` +
+    gate.summary
+  );
+}
+
+/**
+ * Full verify-prod re-sweep: enqueue a fresh prod sweep over the promoted
+ * closure, wait for every cell to report a post-trigger row (or REFUSE on
+ * timeout), then run U9's equivalence gate over the FRESH prod vs current
+ * staging rows. Returns the gate verdict + fallback annotation.
+ */
+export async function runVerifyProdResweep(
+  deps: ProdResweepDeps,
+  opts: Partial<FreshnessPollOptions> = {},
+): Promise<VerifyProdResweepResult> {
+  const now = deps.now ?? Date.now;
+  const enqueueRes = await enqueueProdResweep(deps);
+
+  const prodRows = await pollProdFreshness(deps, {
+    triggerAt: enqueueRes.triggerAt,
+    timeoutMs: opts.timeoutMs,
+    pollIntervalMs: opts.pollIntervalMs,
+  });
+
+  const stagingRows = await deps.readStagingStatus();
+
+  const gate = runEquivalenceGate({
+    cells: deps.cells,
+    stagingRows,
+    prodRows,
+    reSweepTriggerAt: enqueueRes.triggerAt,
+    now: now(),
+  });
+
+  return {
+    triggerAt: enqueueRes.triggerAt,
+    workersProvisioned: enqueueRes.workersProvisioned,
+    gate,
+    summary: buildSummary(enqueueRes, gate),
+  };
+}
+
+// Re-export the gate row shape so callers building maps have one import site.
+export type { StatusRow };
+
+// ===========================================================================
+// REAL prod control-plane wiring + CLI entrypoint
+//
+// Everything above is pure over the injected `ProdControlPlane` + readers and
+// is what the unit tests exercise against a FAKE prod control-plane. Below is
+// the production wiring the `verify-prod` workflow job invokes
+// (`npx tsx verify-prod-resweep.ts`). It is intentionally thin — all the
+// orchestration logic lives in the pure core above.
+// ===========================================================================
+
+import { resolve as resolvePath } from "node:path";
+import type { Logger } from "../harness/src/types/index";
+
+// The prod ENQUEUE reuses the harness producer→queue wiring (the SAME path
+// `runViaControlPlane` drives — spec §6.2, not a new probe path). That import
+// graph is heavy (croner / playwright / zod, ~28 harness files), so it is
+// loaded via a DYNAMIC `import()` INSIDE the enqueue call rather than at module
+// top: the pure orchestration core, the unit tests (which inject a FAKE control
+// plane), and the config-absent no-op path never pay for — or even need — the
+// harness graph. Only a real prod enqueue (where the harness package is
+// installed alongside) materializes it. The relative `../harness/src/...`
+// specifiers mirror the established cross-package pattern in
+// `provision-starter-fleet.ts`.
+type HarnessProducerWiring = {
+  createJobProducer: typeof import("../harness/src/fleet/control-plane/job-producer").createJobProducer;
+  createServiceEnumerator: typeof import("../harness/src/fleet/control-plane/catalog-enumerator").createServiceEnumerator;
+  D6_DRIVER_KIND: string;
+  FLEET_FAMILIES: typeof import("../harness/src/fleet/control-plane/run-view").FLEET_FAMILIES;
+  createFleetQueueClient: typeof import("../harness/src/fleet/queue-client").createFleetQueueClient;
+  createPbClient: typeof import("../harness/src/storage/pb-client").createPbClient;
+  createJobClaimClient: typeof import("../harness/src/fleet/job-claim").createJobClaimClient;
+  railwayServicesSource: typeof import("../harness/src/probes/discovery/railway-services").railwayServicesSource;
+};
+
+async function loadHarnessProducerWiring(): Promise<HarnessProducerWiring> {
+  const [
+    jobProducer,
+    catalogEnumerator,
+    runView,
+    queueClient,
+    pbClient,
+    jobClaim,
+    discovery,
+  ] = await Promise.all([
+    import("../harness/src/fleet/control-plane/job-producer"),
+    import("../harness/src/fleet/control-plane/catalog-enumerator"),
+    import("../harness/src/fleet/control-plane/run-view"),
+    import("../harness/src/fleet/queue-client"),
+    import("../harness/src/storage/pb-client"),
+    import("../harness/src/fleet/job-claim"),
+    import("../harness/src/probes/discovery/railway-services"),
+  ]);
+  return {
+    createJobProducer: jobProducer.createJobProducer,
+    createServiceEnumerator: catalogEnumerator.createServiceEnumerator,
+    D6_DRIVER_KIND: catalogEnumerator.D6_DRIVER_KIND,
+    FLEET_FAMILIES: runView.FLEET_FAMILIES,
+    createFleetQueueClient: queueClient.createFleetQueueClient,
+    createPbClient: pbClient.createPbClient,
+    createJobClaimClient: jobClaim.createJobClaimClient,
+    railwayServicesSource: discovery.railwayServicesSource,
+  };
+}
+
+/** PocketBase superuser creds + base URL for one env's status reader. */
+interface PbCreds {
+  url: string;
+  email: string;
+  password: string;
+}
+
+/**
+ * Read one env's `status` collection into a LiveStatusMap via the PocketBase
+ * REST API. Mirrors the dashboard's bulk fetch — full rows (signal included,
+ * which `buildCellModel`/U7 needs to read `errorClass`/`errorDesc`), paged.
+ * Fails loud on an auth or read error: a silent empty map would make the
+ * equivalence gate vacuously pass.
+ */
+async function readPbStatus(creds: PbCreds): Promise<LiveStatusMap> {
+  const token = await pbAuth(creds);
+  const map: LiveStatusMap = new Map();
+  let page = 1;
+  // PB caps perPage at 500; page until totalPages is exhausted.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const qs = new URLSearchParams({
+      page: String(page),
+      perPage: "500",
+      sort: "-updated",
+    });
+    const res = await fetch(
+      `${creds.url}/api/collections/status/records?${qs.toString()}`,
+      { headers: { Authorization: token } },
+    );
+    if (!res.ok) {
+      throw new Error(
+        `PocketBase status read failed at ${creds.url}: ${res.status}`,
+      );
+    }
+    const body = (await res.json()) as {
+      items: StatusRow[];
+      totalPages: number;
+    };
+    for (const item of body.items) {
+      // Keep the NEWEST row per key (sorted -updated → first wins).
+      if (!map.has(item.key)) map.set(item.key, item);
+    }
+    if (page >= body.totalPages || body.items.length === 0) break;
+    page += 1;
+  }
+  return map;
+}
+
+async function pbAuth(creds: PbCreds): Promise<string> {
+  // PB ≤0.22 uses /api/admins; 0.23+ uses /api/collections/_superusers
+  // (mirror control-plane-run.ts + pb-client).
+  for (const path of [
+    "/api/collections/_superusers/auth-with-password",
+    "/api/admins/auth-with-password",
+  ]) {
+    const res = await fetch(`${creds.url}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ identity: creds.email, password: creds.password }),
+    });
+    if (res.ok) {
+      const b = (await res.json()) as { token?: string };
+      if (b.token) return b.token;
+    }
+  }
+  throw new Error(`PocketBase admin auth failed at ${creds.url}`);
+}
+
+/** Resolve a required env var or fail loud. */
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v || v.trim().length === 0) {
+    throw new Error(`${name} is not set — required for the prod re-sweep`);
+  }
+  return v.trim();
+}
+
+/** Minimal stderr logger for the prod producer wiring (CLI context). */
+function createCliLogger(): Logger {
+  const emit =
+    (level: string) =>
+    (msg: string, meta?: Record<string, unknown>): void => {
+      const tail = meta ? ` ${JSON.stringify(meta)}` : "";
+      console.error(`[verify-prod-resweep] ${level} ${msg}${tail}`);
+    };
+  return {
+    info: emit("info"),
+    warn: emit("warn"),
+    error: emit("error"),
+    debug: () => {},
+  };
+}
+
+/** Resolve the §5.1 registry family id for the d6 level (fail loud on rename). */
+function d6Family(families: HarnessProducerWiring["FLEET_FAMILIES"]): string {
+  const entry = families.find((f) => f.family === "d6");
+  if (!entry) {
+    throw new Error(
+      'no FLEET_FAMILIES entry for "d6" — the prod re-sweep must stamp a §5.1 registry family',
+    );
+  }
+  return entry.family;
+}
+
+/**
+ * The default AGENT-axis enqueue: a TRIGGERED d6 producer tick scoped to the
+ * promoted harness slugs against PROD. REUSES the EXISTING producer→queue→worker
+ * path verbatim — the SAME `createJobProducer` + `createFleetQueueClient` +
+ * `producer.tick({ triggered: true })` wiring `runViaControlPlane`
+ * (`harness/src/cli/control-plane-run.ts`) drives for `bin/showcase test --d6`,
+ * only pointed at the PROD PocketBase + PROD Railway environment (no
+ * `LOCAL_SERVICES_JSON` → real prod discovery). We do NOT re-implement the
+ * producer (that would be a drift-prone second copy) and we do NOT invent a new
+ * probe path (spec §6.2 / ambiguity #4): a TRIGGERED d6 tick is exactly the
+ * operator-trigger seam the producer already exposes (`EnumerateContext.triggered`).
+ *
+ * The host only ENQUEUES + POLLS prod PB. The prod `harness-workers` claim the
+ * `probe_jobs` and run the drivers inside the prod network. When prod
+ * `harness-workers` is unprovisioned (§4.4), the prod scheduler drains the
+ * queue INLINE (degraded throughput, still functional) — the enqueue path is
+ * identical; we annotate `workersProvisioned: false`.
+ *
+ * Discovery is scoped to the promoted slugs by a post-enumerate filter: the
+ * prod Railway roster is `showcase-<slug>`, so we keep the `showcase-` prefix
+ * then drop every discovered service whose slug is NOT in the promoted set
+ * (mirrors `runViaControlPlane`'s per-slug narrowing).
+ *
+ * A starter-only closure yields ZERO agent slugs — this seam is a no-op then
+ * (we never spin up the heavy producer graph), so the d6 path is not driven for
+ * a closure that has nothing on the agent axis.
+ */
+function makeAgentEnqueue(args: {
+  prodPb: PbCreds;
+  prodRailwayEnv: {
+    token: string;
+    projectId: string;
+    environmentId: string;
+  };
+  logger: Logger;
+}): AgentEnqueueFn {
+  // The prod discovery env the enumerator reads (NO LOCAL_SERVICES_JSON → the
+  // railway-services source queries the prod Railway environment).
+  const discoveryEnv: Record<string, string | undefined> = {
+    ...process.env,
+    LOCAL_SERVICES_JSON: undefined,
+    RAILWAY_TOKEN: args.prodRailwayEnv.token,
+    RAILWAY_PROJECT_ID: args.prodRailwayEnv.projectId,
+    RAILWAY_ENVIRONMENT_ID: args.prodRailwayEnv.environmentId,
+  };
+  return async (agentSlugs: string[]): Promise<EnqueueAxisResult> => {
+    // No agent-axis cells (e.g. a starter-only closure) → nothing to enqueue
+    // on the d6 path; skip the heavy harness producer graph entirely.
+    if (agentSlugs.length === 0) {
+      return { enqueued: 0, enqueueFailures: 0 };
+    }
+    // `agentSlugs` are the HARNESS slugs (the `showcase-` prefix stripped — see
+    // cellsFromClosureCsv), the SAME normalization the discovery enumerator's
+    // `serviceSlug` (= `deriveSlug(name)`) produces, so `requested.has(serviceSlug)`
+    // below matches the promoted integrations and enqueues one job per cell.
+    const requested = new Set(agentSlugs);
+    // Materialize the heavy harness producer graph only now (real enqueue).
+    const w = await loadHarnessProducerWiring();
+    const pb = w.createPbClient({
+      url: args.prodPb.url,
+      email: args.prodPb.email,
+      password: args.prodPb.password,
+      logger: args.logger,
+    });
+    const claim = w.createJobClaimClient({
+      url: args.prodPb.url,
+      email: args.prodPb.email,
+      password: args.prodPb.password,
+      logger: args.logger,
+    });
+    const queue = w.createFleetQueueClient({ pb, claim, logger: args.logger });
+    const enumerate = w.createServiceEnumerator({
+      source: w.railwayServicesSource,
+      env: discoveryEnv,
+      fetchImpl: globalThis.fetch,
+      logger: args.logger,
+      driverKind: w.D6_DRIVER_KIND,
+      probeKeyPrefix: "d6",
+      // Narrow the prod roster to the promoted slugs only: keep the
+      // `showcase-` prefix, then exclude every discovered service whose
+      // slug is not in the promoted set. Discovery applies `nameExcludes`
+      // after `namePrefix`, so a precomputed exclusion list cannot drop a
+      // slug we want; we instead post-filter the enumerated specs below.
+      filter: { namePrefix: "showcase-", nameExcludes: [] as string[] },
+    });
+    const producer = w.createJobProducer({
+      queue,
+      // Wrap the enumerator to drop any spec whose slug was NOT promoted —
+      // a TRIGGERED tick over the whole roster would re-sweep unrelated
+      // integrations and inflate the freshness wait.
+      enumerate: async (ctx) => {
+        const all = await enumerate(ctx);
+        return all.filter((s) => requested.has(s.serviceSlug));
+      },
+      logger: args.logger,
+      family: d6Family(w.FLEET_FAMILIES),
+    });
+
+    producer.start();
+    try {
+      const tick = await producer.tick({
+        triggered: true,
+        filter: { slugs: agentSlugs },
+      });
+      return {
+        enqueued: tick.enqueued,
+        enqueueFailures: tick.enqueueFailures ?? 0,
+      };
+    } finally {
+      await producer.stop();
+    }
+  };
+}
+
+/**
+ * The default STARTER-axis enqueue: TRIGGER the prod `starter_smoke` CRON probe,
+ * scoped to the promoted starters' `starter_smoke:starter-<rawSlug>` keys. The
+ * starter_smoke probe is NOT a control-plane producer family (the d6 discovery
+ * filter EXCLUDES `starter-*` services), so it never flows through the
+ * `createJobProducer` path. Its operator-trigger seam is the prod harness
+ * `POST /api/probes/starter_smoke/trigger` route (`harness/src/http/probes.ts`),
+ * which accepts a `{ filter: { slugs } }` body and narrows the probe's
+ * discovered targets to the post-`key_template` keys before fan-out. Triggering
+ * it makes the prod starter_smoke driver re-probe ONLY the promoted starters and
+ * write fresh `starter:<col>/<level>` rows — exactly the keys
+ * {@link freshnessKeysForCell} waits on for a starter cell.
+ *
+ * A closure with no starter cells yields ZERO trigger keys — this seam is then a
+ * no-op (no trigger POST), mirroring the agent seam's empty-slug short-circuit.
+ */
+function makeStarterEnqueue(args: {
+  prodHarnessBaseUrl: string;
+  prodHarnessTriggerToken: string;
+  logger: Logger;
+}): StarterEnqueueFn {
+  return async (starterTriggerKeys: string[]): Promise<EnqueueAxisResult> => {
+    if (starterTriggerKeys.length === 0) {
+      return { enqueued: 0, enqueueFailures: 0 };
+    }
+    const url = `${args.prodHarnessBaseUrl.replace(/\/$/, "")}/api/probes/${STARTER_SMOKE_PROBE_ID}/trigger`;
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${args.prodHarnessTriggerToken}`,
+        },
+        body: JSON.stringify({ filter: { slugs: starterTriggerKeys } }),
+      });
+    } catch (err) {
+      // A transport failure means the starter_smoke tick never fired — fail
+      // loud so the enqueue REFUSES rather than the freshness poll timing out
+      // 20 minutes later with a confusing "starter never reported" message.
+      throw new Error(
+        `prod starter_smoke trigger POST failed (${url}): ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+    if (!res.ok) {
+      throw new Error(
+        `prod starter_smoke trigger returned ${res.status} at ${url} — ` +
+          "the starter cells will never report a fresh row; refusing before the freshness poll",
+      );
+    }
+    args.logger.info("verify-prod-resweep.starter-trigger", {
+      keys: starterTriggerKeys,
+    });
+    // One starter_smoke tick covers every requested starter target; count one
+    // enqueued job per filter key so the caller's zero-enqueue guard treats a
+    // starter-only closure as a real enqueue.
+    return { enqueued: starterTriggerKeys.length, enqueueFailures: 0 };
+  };
+}
+
+/**
+ * Build the REAL prod control-plane. The enqueue fans out over BOTH probe axes
+ * in the promoted closure ({@link partitionCellsByAxis}): the AGENT-axis cells
+ * (showcase-* integrations) through a TRIGGERED d6 producer tick, and the
+ * STARTER-axis cells (starter-* containers) through a `starter_smoke` CRON-probe
+ * trigger. Each axis writes a DIFFERENT keyspace
+ * (`d5/d6/e2e/chat/tools/health` vs `starter:<col>/<level>`), so driving only
+ * the d6 tick would leave a starter cell's freshness poll waiting forever on
+ * `starter:<col>/<level>` rows that were never produced — the bug this split
+ * fixes.
+ *
+ * The two enqueue seams are injectable (`agentEnqueue` / `starterEnqueue`),
+ * defaulting to the real harness producer + the real prod harness HTTP trigger,
+ * so the axis-split routing is unit-testable without Railway / the harness graph
+ * / a live prod harness.
+ */
+export function createRealProdControlPlane(args: {
+  cells: GateCell[];
+  prodPb: PbCreds;
+  prodRailwayEnv: {
+    token: string;
+    projectId: string;
+    environmentId: string;
+  };
+  workersProvisioned: boolean;
+  /** Override the AGENT-axis (d6 producer) enqueue — tests inject a fake. */
+  agentEnqueue?: AgentEnqueueFn;
+  /** Override the STARTER-axis (starter_smoke trigger) enqueue — tests inject a fake. */
+  starterEnqueue?: StarterEnqueueFn;
+  /** Prod harness base URL for the default starter_smoke trigger seam. */
+  prodHarnessBaseUrl?: string;
+  /** Bearer token for the default starter_smoke trigger seam. */
+  prodHarnessTriggerToken?: string;
+}): ProdControlPlane {
+  const logger = createCliLogger();
+  const { agentSlugs, starterTriggerKeys } = partitionCellsByAxis(args.cells);
+
+  const agentEnqueue =
+    args.agentEnqueue ??
+    makeAgentEnqueue({
+      prodPb: args.prodPb,
+      prodRailwayEnv: args.prodRailwayEnv,
+      logger,
+    });
+  const starterEnqueue =
+    args.starterEnqueue ??
+    (() => {
+      // Only the DEFAULT starter seam needs the prod harness URL + token. When
+      // the closure has no starter cells, no default is required (no trigger).
+      if (starterTriggerKeys.length === 0) {
+        return async (): Promise<EnqueueAxisResult> => ({
+          enqueued: 0,
+          enqueueFailures: 0,
+        });
+      }
+      if (
+        args.prodHarnessBaseUrl === undefined ||
+        args.prodHarnessTriggerToken === undefined
+      ) {
+        throw new Error(
+          "verify-prod-resweep: the promoted closure includes starter cells but " +
+            "prodHarnessBaseUrl / prodHarnessTriggerToken were not supplied — " +
+            "cannot trigger the prod starter_smoke probe.",
+        );
+      }
+      return makeStarterEnqueue({
+        prodHarnessBaseUrl: args.prodHarnessBaseUrl,
+        prodHarnessTriggerToken: args.prodHarnessTriggerToken,
+        logger,
+      });
+    })();
+
+  return {
+    async enqueue(atMs: number): Promise<ProdEnqueueResult> {
+      // Drive ONLY the axes the promoted closure actually populates — a
+      // starter-only closure must not touch the d6 producer, and an agent-only
+      // closure must not POST the starter_smoke trigger. An empty axis
+      // contributes nothing to the enqueue accounting.
+      const empty: EnqueueAxisResult = { enqueued: 0, enqueueFailures: 0 };
+      const [agentRes, starterRes] = await Promise.all([
+        agentSlugs.length > 0 ? agentEnqueue(agentSlugs, atMs) : empty,
+        starterTriggerKeys.length > 0
+          ? starterEnqueue(starterTriggerKeys, atMs)
+          : empty,
+      ]);
+      return {
+        triggerAt: atMs,
+        enqueued: agentRes.enqueued + starterRes.enqueued,
+        enqueueFailures: agentRes.enqueueFailures + starterRes.enqueueFailures,
+        workersProvisioned: args.workersProvisioned,
+      };
+    },
+    async readProdStatus(): Promise<LiveStatusMap> {
+      return readPbStatus(args.prodPb);
+    },
+  };
+}
+
+/**
+ * The representative catalog feature stamped on every promoted integration
+ * cell. `agentic-chat` is the universal baseline feature every showcase
+ * integration ships (the d5/d6 take-one) and the default-scope cell the
+ * dashboard derives. It MUST be a catalogued feature; the module-load
+ * assertion below fails loud if a `CATALOG_TO_D5_KEY` refactor ever drops it.
+ */
+const REPRESENTATIVE_FEATURE = "agentic-chat";
+
+// Fail loud at load if the representative feature is no longer catalogued —
+// otherwise `freshnessKeysForCell` would silently lose the d5/d6 family keys
+// (`CATALOG_TO_D5_KEY[featureId]` undefined) and the freshness poll would only
+// ever consult the integration-level keys, weakening the gate.
+if (!CATALOG_TO_D5_KEY[REPRESENTATIVE_FEATURE]) {
+  throw new Error(
+    `verify-prod-resweep: representative feature "${REPRESENTATIVE_FEATURE}" ` +
+      "is not present in CATALOG_TO_D5_KEY — the cell derivation cannot stamp " +
+      "a catalogued feature; update REPRESENTATIVE_FEATURE.",
+  );
+}
+
+/**
+ * Strip the `showcase-` prefix from an SSOT service name to derive the HARNESS
+ * SLUG — the key the enqueue discovery's `serviceSlug` and `keyFor(...)` use.
+ * Mirrors discovery's `deriveSlugFromServiceName` / the catalog-enumerator's
+ * `deriveSlug` (the import would drag the heavy harness producer graph this
+ * module loads lazily, so the one-line normalization is re-stated here). Bare
+ * names (infra/shells) pass through unchanged.
+ */
+function deriveSlug(name: string): string {
+  return name.startsWith("showcase-") ? name.slice("showcase-".length) : name;
+}
+
+/**
+ * `showcase-`-prefixed SSOT names that are NOT probe-wired integration cells.
+ * Mirrors the non-starter `showcase-*` exclusions in the catalog-enumerator's
+ * `D6_DISCOVERY_FILTER.nameExcludes` (the SSOT for which `showcase-*` services
+ * the d6 sweep skips): `showcase-ms-agent-harness-dotnet` is `deployed: true`
+ * but unprobed, so the enqueue discovery never emits a d6 row for it — a cell
+ * for it could only ever time out the freshness poll. Importing the enumerator
+ * constant directly would drag the heavy harness graph this module loads
+ * lazily, so the single non-integration `showcase-*` name is re-stated here.
+ */
+const NON_INTEGRATION_SHOWCASE_NAMES = new Set([
+  "showcase-ms-agent-harness-dotnet",
+]);
+
+/**
+ * Parse the promoted closure CSV (U4's `succeeded_csv`) into gate cells. The
+ * CSV carries SSOT `.name` values: integrations are `showcase-<slug>`
+ * (prefixed), while infra/shell services are bare names (`aimock`,
+ * `dashboard`, `docs`, `dojo`, `webhooks`, `pocketbase`, `harness`). Each
+ * promoted INTEGRATION maps to its representative cell:
+ *   - the `slug` is the HARNESS slug (the `showcase-` prefix STRIPPED), so it
+ *     matches both `keyFor(...)` (the freshness keyspace) and the enqueue
+ *     discovery's `serviceSlug` (= `deriveSlug(name)`). Emitting the raw
+ *     prefixed token here would match neither (zero enqueue + freshness
+ *     timeout → REFUSE).
+ *   - the `featureId` is the representative catalog feature
+ *     ({@link REPRESENTATIVE_FEATURE}), validated against `CATALOG_TO_D5_KEY`.
+ *
+ * Membership is a POSITIVE "is this a catalogued integration?" test rather than
+ * a hand-maintained infra blocklist (robust to infra name drift): a token is
+ * an integration iff it is `showcase-`-prefixed, is not a known unprobed
+ * `showcase-*` service, and its representative feature is catalogued. Infra and
+ * shell services carry bare names, so they fail the prefix test and are
+ * excluded automatically.
+ *
+ * STARTER axis (tier-2 `starter-*` closure members): a `starter-<rawSlug>`
+ * token is a starter-template container, probed on the `starter_smoke` matrix —
+ * NOT the agent feature ladder. It is emitted as a `probeAxis: "starter"` cell
+ * whose `slug` is the DASHBOARD COLUMN slug (`STARTER_TO_COLUMN[rawSlug]`), so
+ * the equivalence gate / freshness poll resolve it from the
+ * `starter:<columnSlug>/<level>` rows. A starter is never stamped with the
+ * representative `agentic-chat` feature.
+ */
+/**
+ * The featureId label stamped on a STARTER-axis cell. The starter axis is NOT
+ * feature-scoped (its rows are keyed `starter:<columnSlug>/<level>`, not by a
+ * catalog feature), so this is a non-catalogued LABEL — deliberately NOT
+ * {@link REPRESENTATIVE_FEATURE}, so a starter never resolves through (or is
+ * emitted as) a phantom `agentic-chat` cell. `buildCellModel` /
+ * `freshnessKeysForCell` / `newestProdObservation` all route off
+ * `probeAxis === "starter"`, never this label.
+ */
+const STARTER_FEATURE_LABEL = "starter";
+
+/**
+ * The `starter_smoke` CRON probe id (`showcase/harness/config/probes/starter_smoke.yml`).
+ * The prod re-sweep TRIGGERS this probe (operator-trigger seam) for the
+ * starter-axis cells — it is NOT a control-plane producer family, so it never
+ * flows through the d6 `createJobProducer` path.
+ */
+export const STARTER_SMOKE_PROBE_ID = "starter_smoke";
+
+/**
+ * The starter-fleet Railway service-name prefix (`starter-<rawSlug>`). The
+ * `starter_smoke` probe's `key_template` is `starter_smoke:${name}`, so the
+ * per-target slug a `scheduler.trigger(... filter.slugs)` invocation matches is
+ * the POST-key_template key `starter_smoke:starter-<rawSlug>` (see
+ * `probe-invoker.ts` — the filter compares against `ResolvedInput.key`).
+ */
+const STARTER_SERVICE_PREFIX = "starter-";
+
+/**
+ * Reverse of STARTER_TO_COLUMN: dashboard COLUMN slug → starter RAW slug (the
+ * `starter-<rawSlug>` Railway service-name slug the starter_smoke discovery
+ * enumerates). `cellsFromClosureCsv` stores the COLUMN slug on a starter cell
+ * (so the equivalence gate / freshness poll resolve the `starter:<col>/<level>`
+ * rows), but the starter_smoke TRIGGER filter is keyed by the SERVICE name, so
+ * the enqueue must map back. STARTER_TO_COLUMN is injective in practice (each
+ * column has exactly one raw starter), so the reverse is unambiguous; built
+ * once at module load.
+ */
+const COLUMN_TO_STARTER_RAW: Readonly<Record<string, string>> = (() => {
+  const out: Record<string, string> = {};
+  for (const [rawSlug, columnSlug] of Object.entries(STARTER_TO_COLUMN)) {
+    out[columnSlug] = rawSlug;
+  }
+  return out;
+})();
+
+/**
+ * The two enqueue axes a promoted closure fans out over. The real prod enqueue
+ * must drive BOTH: the AGENT-axis cells through the d6 producer→queue tick, and
+ * the STARTER-axis cells through a `starter_smoke` CRON-probe trigger. They have
+ * different trigger surfaces AND different keyspaces (`d5/d6/e2e/...` vs
+ * `starter:<col>/<level>`), so a single d6 tick can NEVER produce the rows a
+ * starter cell's freshness poll waits on.
+ */
+export interface AxisPartition {
+  /** Harness slugs (showcase- prefix stripped) for the d6 producer tick. */
+  agentSlugs: string[];
+  /**
+   * `starter_smoke:starter-<rawSlug>` trigger-filter keys for the starter_smoke
+   * CRON-probe trigger (the POST-key_template keys `probe-invoker` matches).
+   */
+  starterTriggerKeys: string[];
+}
+
+/**
+ * Split the promoted closure cells into the AGENT and STARTER enqueue axes.
+ * Agent cells contribute their harness slug to the d6 producer tick; starter
+ * cells (column slug) are reverse-mapped to their `starter-<rawSlug>` service
+ * name and emitted as `starter_smoke:starter-<rawSlug>` trigger-filter keys. A
+ * starter cell whose column slug has no reverse mapping is dropped (it could
+ * only ever time out the freshness poll) — symmetric with `cellsFromClosureCsv`
+ * dropping an unmapped starter on the way in.
+ */
+export function partitionCellsByAxis(cells: GateCell[]): AxisPartition {
+  const agentSlugs: string[] = [];
+  const starterTriggerKeys: string[] = [];
+  for (const cell of cells) {
+    if (cell.probeAxis === "starter") {
+      const rawSlug = COLUMN_TO_STARTER_RAW[cell.slug];
+      if (rawSlug === undefined) continue;
+      starterTriggerKeys.push(
+        `${STARTER_SMOKE_PROBE_ID}:${STARTER_SERVICE_PREFIX}${rawSlug}`,
+      );
+      continue;
+    }
+    agentSlugs.push(cell.slug);
+  }
+  return { agentSlugs, starterTriggerKeys };
+}
+
+export function cellsFromClosureCsv(csv: string): GateCell[] {
+  const cells: GateCell[] = [];
+  for (const token of csv.split(",").map((s) => s.trim())) {
+    if (token.length === 0) continue;
+    // ── STARTER axis: `starter-<rawSlug>` closure tokens. The raw slug is a
+    //    key of STARTER_TO_COLUMN (the starter-smoke matrix slug); remap it to
+    //    the dashboard COLUMN slug so the cell is keyed the way starter_smoke
+    //    rows are (`starter:<columnSlug>/<level>`). A starter NOT in the map
+    //    has no smoke column and is dropped (it could only ever time out the
+    //    freshness poll), mirroring the showcase-* unprobed exclusion. ──
+    if (token.startsWith("starter-")) {
+      const rawSlug = token.slice("starter-".length);
+      const columnSlug = STARTER_TO_COLUMN[rawSlug];
+      if (columnSlug === undefined) continue;
+      cells.push({
+        slug: columnSlug,
+        featureId: STARTER_FEATURE_LABEL,
+        isSupported: true,
+        isWired: true,
+        probeAxis: "starter",
+      });
+      continue;
+    }
+    // Positive integration gate: infra/shell names are bare (no `showcase-`),
+    // so the prefix requirement alone drops them.
+    if (!token.startsWith("showcase-")) continue;
+    if (NON_INTEGRATION_SHOWCASE_NAMES.has(token)) continue;
+    cells.push({
+      slug: deriveSlug(token),
+      featureId: REPRESENTATIVE_FEATURE,
+      isSupported: true,
+      isWired: true,
+    });
+  }
+  return cells;
+}
+
+/** CLI entry: wire the real prod control-plane + readers, run, exit non-zero on REFUSE/FAIL. */
+async function main(): Promise<void> {
+  const closureCsv = requireEnv("PROMOTED_CLOSURE_CSV");
+  const cells = cellsFromClosureCsv(closureCsv);
+  if (cells.length === 0) {
+    console.log(
+      "::notice::no promoted integration cells in PROMOTED_CLOSURE_CSV — " +
+        "nothing to re-sweep; equivalence gate vacuously passes.",
+    );
+    return;
+  }
+
+  const prodPb: PbCreds = {
+    url: requireEnv("PROD_POCKETBASE_URL"),
+    email: requireEnv("PROD_POCKETBASE_SUPERUSER_EMAIL"),
+    password: requireEnv("PROD_POCKETBASE_SUPERUSER_PASSWORD"),
+  };
+  const stagingPb: PbCreds = {
+    url: requireEnv("STAGING_POCKETBASE_URL"),
+    email: requireEnv("STAGING_POCKETBASE_SUPERUSER_EMAIL"),
+    password: requireEnv("STAGING_POCKETBASE_SUPERUSER_PASSWORD"),
+  };
+  // §4.4 fallback annotation: the operator/CI declares whether prod
+  // harness-workers are provisioned. Default true; an explicit "false" flips
+  // the gate into inline-fallback annotation (still functional).
+  const workersProvisioned =
+    (process.env.PROD_HARNESS_WORKERS_PROVISIONED ?? "true").toLowerCase() !==
+    "false";
+
+  // The STARTER-axis enqueue triggers the prod `starter_smoke` CRON probe over
+  // HTTP. Only require its base URL + trigger token when the closure actually
+  // contains starter cells — an agent-only promote never touches the route.
+  const hasStarterCells = cells.some((c) => c.probeAxis === "starter");
+
+  const controlPlane = createRealProdControlPlane({
+    cells,
+    prodPb,
+    prodRailwayEnv: {
+      token: requireEnv("RAILWAY_TOKEN"),
+      projectId: requireEnv("RAILWAY_PROJECT_ID"),
+      environmentId: requireEnv("RAILWAY_ENVIRONMENT_ID_PROD"),
+    },
+    workersProvisioned,
+    ...(hasStarterCells
+      ? {
+          prodHarnessBaseUrl: requireEnv("PROD_HARNESS_BASE_URL"),
+          prodHarnessTriggerToken: requireEnv("PROD_HARNESS_TRIGGER_TOKEN"),
+        }
+      : {}),
+  });
+
+  const result = await runVerifyProdResweep({
+    controlPlane,
+    cells,
+    readStagingStatus: () => readPbStatus(stagingPb),
+  });
+
+  // Surface the verdict to the workflow summary + logs.
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+  const block = `## Prod equivalence gate\n\n\`\`\`\n${result.summary}\n\`\`\`\n`;
+  if (summaryFile) {
+    const { appendFile } = await import("node:fs/promises");
+    await appendFile(summaryFile, block);
+  }
+  console.log(result.summary);
+
+  if (!result.gate.passed) {
+    console.error(
+      `::error::Equivalence gate FAILED — ${result.gate.mismatches.length} prod regression(s).`,
+    );
+    process.exit(1);
+  }
+}
+
+// Run main only when invoked directly (not when imported by the test).
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  resolvePath(process.argv[1]) === resolvePath(import.meta.filename);
+if (invokedDirectly) {
+  main().catch((err: unknown) => {
+    console.error(
+      `::error::prod re-sweep refused: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  });
+}

--- a/showcase/scripts/verify-railway-image-refs.ts
+++ b/showcase/scripts/verify-railway-image-refs.ts
@@ -60,15 +60,18 @@ const STARTER_FLEET_PREFIX = "starter-";
  * True iff `name` is a starter-container-fleet Railway service
  * (`starter-<slug>`).
  *
- * The starter fleet is DECOUPLED from this 27-service SSOT: each
- * `starter-*` service is AUTO-DISCOVERED at runtime by the `starter_smoke`
- * probe via the `railway-services` discovery source filtered on
- * `namePrefix: "starter-"` — it is never read from `railway-envs.ts`.
- * Therefore the SSOT⨉Railway drift checks below MUST exclude these
- * services: a provisioned `starter-*` service is neither required-in-SSOT
- * (findMissingServices) nor flagged-as-untracked (findUntrackedServices).
- * Without this carve-out, provisioning a starter service trips the
- * Railway→SSOT drift gate and SKIPS the showcase build.
+ * S2: the 12 known starter-<slug> services are now FULLY SSOT-managed and
+ * `gateValidated` in `railway-envs.ts` — they are validated and required in
+ * both drift directions exactly like a showcase-* agent, with NO carve-out.
+ * This predicate is retained for a single NARROW purpose: tolerating a
+ * stray/in-flight `starter-<slug>` live service that is provisioned ahead of
+ * (or absent from) its SSOT entry. `findUntrackedServices` consults it ONLY
+ * after the SSOT-membership check, so an SSOT-managed starter never reaches
+ * this carve-out. It does NOT exempt any SSOT starter from the gate.
+ *
+ * The `starter_smoke` probe still auto-discovers `starter-*` services at
+ * runtime (railway-services source, `namePrefix: "starter-"`), independent of
+ * this gate — that is the verification axis for the fleet (S3).
  *
  * NOTE: this matches the `starter-` prefix only — the decommissioned
  * `showcase-starter-*` services use the `showcase-` prefix and are NOT
@@ -225,11 +228,12 @@ export function findMissingServices(
 ): string[] {
   const missing: string[] = [];
   for (const [name, entry] of Object.entries(SERVICES)) {
-    // Starter-fleet services are SSOT-decoupled (see
-    // isStarterFleetService) — never require them in the SSOT→Railway
-    // direction. Defense-in-depth: SERVICES never contains a starter-*
-    // key today, so this is a guard against a future stray entry.
-    if (isStarterFleetService(name)) continue;
+    // S2: the 12 starter-<slug> services are now SSOT-managed +
+    // gateValidated, exactly like a showcase-* agent — no starter carve-out
+    // here. They are REQUIRED in the SSOT→Railway direction in any env they
+    // declare. The `!entry.gateValidated` guard below is the single gate
+    // membership filter; a starter that is gateValidated:true is demanded
+    // just like every other tracked service.
     if (!entry.gateValidated) continue;
     // Only require the service in an env it actually DECLARES. A service
     // that does not exist in `env` (a single-env worker) is not "missing"
@@ -261,17 +265,20 @@ export function findUntrackedServices(
 ): string[] {
   const untracked: string[] = [];
   for (const name of railwayServiceNames) {
-    // Starter-fleet services (starter-<slug>) are SSOT-decoupled and
-    // auto-discovered by the starter_smoke probe (see
-    // isStarterFleetService) — a provisioned starter-* service is NOT
-    // drift, so never flag it as untracked. This is the carve-out that
-    // lets the 12 starter services be provisioned without skipping the
-    // showcase build.
-    if (isStarterFleetService(name)) continue;
     const entry = SERVICES[name];
     // Any SSOT entry — gateIgnored or not — is known/accounted-for in
-    // the Railway->SSOT direction. Only absence from the SSOT counts.
+    // the Railway->SSOT direction. Only absence from the SSOT counts. The
+    // 12 starter-<slug> services are now SSOT entries (S2), so they take
+    // this branch and are tolerated exactly like every other tracked
+    // service — no special-case skip.
     if (entry) continue;
+    // Narrow carve-out for a starter-* live service that is NOT (yet) in the
+    // SSOT. The 12 known starters are SSOT-managed above; this only tolerates
+    // a stray/in-flight `starter-<slug>` provisioned ahead of its SSOT entry
+    // (the starter_smoke probe auto-discovers it by namePrefix "starter-").
+    // It does NOT exempt any SSOT-managed starter from drift — those are
+    // handled by the `if (entry) continue` branch and ARE gate-validated.
+    if (isStarterFleetService(name)) continue;
     untracked.push(name);
   }
   return untracked.sort();

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.driver-error-render.test.tsx
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.driver-error-render.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * U7 REAL-SURFACE PROOF (spec §7.1).
+ *
+ * The unit suite in `cell-model.test.ts` proves the gray-fold logic against
+ * hand-built rows. This file closes the spec's real-surface requirement: it
+ * loads PB status rows shaped EXACTLY as the harness drivers persist them
+ * (`fixtures/driver-error-rows.json`, captured from the d6-all-pills /
+ * d4-chat-roundtrip write shapes — see that file's `_fixture` provenance),
+ * runs them through the real `buildCellModel`, and RENDERS the resulting chip
+ * via the real `DepthChip` component (the same `chipColor={model.chipColor}`
+ * prop `unified-cell.tsx` passes). The DOM assertion confirms the rows that
+ * carry a `driver-error`/`abort` infra signal actually paint GRAY, while a
+ * genuine `selector-timeout` assertion failure still paints the danger RED —
+ * proving the fold is visible end-to-end at the render surface, not just in a
+ * unit return value.
+ */
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { buildCellModel, E2E_STALE_AFTER_MS } from "../cell-model";
+import type { StatusRow, LiveStatusMap } from "../live-status";
+import { DepthChip } from "@/components/depth-chip";
+import fixture from "./fixtures/driver-error-rows.json";
+
+// The gray no-data fill (chipColorToClass → "gray") and the danger red fill
+// (→ "red"), straight from depth-chip.tsx. Asserting on these class fragments
+// is asserting on the painted colour an operator sees.
+const GRAY_FILL = "bg-[var(--text-muted)]/20";
+const RED_FILL = "bg-[var(--danger)]";
+
+function mapOf(rows: StatusRow[]): LiveStatusMap {
+  const m: LiveStatusMap = new Map();
+  for (const r of rows) m.set(r.key, r);
+  return m;
+}
+
+const wired = {
+  slug: "agno",
+  featureId: "agentic-chat",
+  isSupported: true,
+  isWired: true,
+};
+
+// The captured fixture rows are observed at 2026-06-19T08:00:00Z. The U7
+// render proofs are about the INFRA fold (driver-error/abort → gray) and the
+// masks-real-red guard — both INDEPENDENT of staleness. Pin `now` to just
+// after the rows' `observed_at` so the U8 matrix-staleness fold (which would
+// otherwise fold ANY row to gray once it ages past the e2e window relative to
+// the wall clock) never confounds the U7 colour under test. The U8 staleness
+// behaviour gets its own real-surface proof below.
+const FIXTURE_FRESH_NOW = Date.parse("2026-06-19T08:01:00.000Z");
+
+function renderChipForAt(rows: StatusRow[], now?: number): HTMLElement {
+  const model = buildCellModel(mapOf(rows), wired, now);
+  const { getByTestId } = render(
+    <DepthChip
+      chipColor={model.chipColor}
+      depth={model.achievedDepth}
+      status="wired"
+      unreachable={model.surfaceState === "unreachable"}
+      pending={model.surfaceState === "pending"}
+    />,
+  );
+  return getByTestId("depth-chip");
+}
+
+function renderChipFor(rows: StatusRow[]): HTMLElement {
+  // Pin to a `now` just after the fixtures' `observed_at` so the U7 colour
+  // under test is isolated from the U8 staleness fold (see FIXTURE_FRESH_NOW).
+  return renderChipForAt(rows, FIXTURE_FRESH_NOW);
+}
+
+describe("U7 real-surface proof: driver-error/abort rows render gray", () => {
+  it("a real per-cell d6 driver-error row (errorClass) paints GRAY, not red", () => {
+    const chip = renderChipFor([fixture.d6DriverErrorRow as StatusRow]);
+    expect(chip.className).toContain(GRAY_FILL);
+    expect(chip.className).not.toContain(RED_FILL);
+  });
+
+  it("a real D4 chat driver-error row (errorDesc only) paints GRAY, not red", () => {
+    const chip = renderChipFor([fixture.d4DriverErrorRow as StatusRow]);
+    expect(chip.className).toContain(GRAY_FILL);
+    expect(chip.className).not.toContain(RED_FILL);
+  });
+
+  it("a real abort row paints GRAY, not red", () => {
+    const chip = renderChipFor([fixture.abortRow as StatusRow]);
+    expect(chip.className).toContain(GRAY_FILL);
+    expect(chip.className).not.toContain(RED_FILL);
+  });
+
+  it("a genuine selector-timeout assertion failure STILL paints RED (masks-real-red guard)", () => {
+    const chip = renderChipFor([
+      fixture.genuineSelectorTimeoutRow as StatusRow,
+    ]);
+    expect(chip.className).toContain(RED_FILL);
+    expect(chip.className).not.toContain(GRAY_FILL);
+  });
+});
+
+/**
+ * U8 REAL-SURFACE PROOF (spec §7.2 / §6.4).
+ *
+ * Reuses the SAME genuine `selector-timeout` row the harness persists — a real
+ * ran-and-failed assertion that U7 deliberately keeps RED. The two assertions
+ * below render that one real row through `buildCellModel` → `DepthChip` at two
+ * different `now` values, proving the matrix-staleness fold is visible at the
+ * render surface (not just in a unit return value): FRESH → danger RED; the
+ * same row past the e2e re-sweep window → no-data GRAY ("re-sweep pending").
+ */
+describe("U8 real-surface proof: a stale red row renders gray", () => {
+  // The captured fixture rows are observed at 2026-06-19T08:00:00Z.
+  const ROW_OBSERVED_MS = Date.parse("2026-06-19T08:00:00.000Z");
+  const FRESH_NOW = ROW_OBSERVED_MS + 60 * 1000; // 1 min later — fresh
+  const STALE_NOW = ROW_OBSERVED_MS + E2E_STALE_AFTER_MS + 60 * 60 * 1000; // past window
+
+  it("the real selector-timeout row paints RED while FRESH", () => {
+    const chip = renderChipForAt(
+      [fixture.genuineSelectorTimeoutRow as StatusRow],
+      FRESH_NOW,
+    );
+    expect(chip.className).toContain(RED_FILL);
+    expect(chip.className).not.toContain(GRAY_FILL);
+  });
+
+  it("the SAME row paints GRAY once stale past the re-sweep window (U8)", () => {
+    const chip = renderChipForAt(
+      [fixture.genuineSelectorTimeoutRow as StatusRow],
+      STALE_NOW,
+    );
+    expect(chip.className).toContain(GRAY_FILL);
+    expect(chip.className).not.toContain(RED_FILL);
+  });
+});

--- a/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/__tests__/cell-model.test.ts
@@ -2356,4 +2356,283 @@ describe("buildCellModel", () => {
       });
     });
   });
+
+  // ── U7: harness driver-error/abort INFRA reds fold to gray (§7.1) ────
+  //
+  // The harness writes an `errorClass`/`errorDesc` literal into the failing
+  // row's `signal` blob. Two of those literals are genuine INFRA failures (a
+  // driver threw, or the run was aborted by worker drain) rather than a probe
+  // that RAN and failed its functional assertion: `driver-error` and `abort`.
+  // The dashboard must fold a cell whose red is attributable ONLY to an infra
+  // signal to the existing `gray` ChipColor (no-data), so an infra blip does
+  // not masquerade as a genuine product red. Reads BOTH `signal.errorClass`
+  // AND `signal.errorDesc` — D4 writes `driver-error` into `errorDesc`, never
+  // `errorClass`. A probe that ran and failed a functional assertion (no infra
+  // class in either field) STAYS red — that is the masks-real-red guard.
+  describe("driver-error/abort infra fold (U7, §7.1)", () => {
+    it("folds a D3 red carrying signal.errorClass:'driver-error' to gray", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "red", {
+          signal: { errorClass: "driver-error", errorDesc: "boom" },
+        }),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.chipColor).toBe("gray");
+    });
+
+    it("folds a D4 red carrying signal.errorDesc:'driver-error' (the D4 shape) to gray", () => {
+      // D4 (d4-chat-roundtrip.ts) writes driver-error into errorDesc, NOT
+      // errorClass — an errorClass-only read would leave this RED.
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "red", {
+          signal: { errorDesc: "driver-error" },
+        }),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.chipColor).toBe("gray");
+    });
+
+    it("folds a D3 red carrying signal.errorClass:'abort' to gray", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "red", {
+          signal: { errorClass: "abort", errorDesc: "aborted before start" },
+        }),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.chipColor).toBe("gray");
+    });
+
+    it("folds a D5 red carrying signal.errorClass:'driver-error' to gray", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("tools", "agno"), "tools", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "red", {
+          signal: { errorClass: "driver-error" },
+        }),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.chipColor).toBe("gray");
+    });
+
+    it("KEEPS a real assertion failure RED — errorClass:'selector-timeout' (no infra class)", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "red", {
+          signal: { errorClass: "selector-timeout", errorDesc: "no match" },
+        }),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.chipColor).toBe("red");
+    });
+
+    it("KEEPS a real assertion failure RED — feature-timeout (a ran-and-failed signal)", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("tools", "agno"), "tools", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "red", {
+          signal: { errorClass: "feature-timeout" },
+        }),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.chipColor).toBe("red");
+    });
+
+    it("KEEPS a red with no signal at all RED (bare red row)", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "red"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.chipColor).toBe("red");
+    });
+
+    it("KEEPS red when one contributing red is infra but another is a genuine assertion fail", () => {
+      // D3 infra (driver-error) + D5 genuine (selector-timeout): the genuine
+      // red must NOT be masked by the infra blip on a sibling rung.
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "red", {
+          signal: { errorClass: "driver-error" },
+        }),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "red", {
+          signal: { errorClass: "selector-timeout" },
+        }),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.chipColor).toBe("red");
+    });
+
+    it("does not disturb a genuinely green cell (no infra signal present)", () => {
+      const live = mapOf([
+        row(keyFor("e2e", "agno", "agentic-chat"), "e2e", "green"),
+        row(keyFor("chat", "agno"), "chat", "green"),
+        row(keyFor("tools", "agno"), "tools", "green"),
+        row(keyFor("d5", "agno", "agentic-chat"), "d5", "green"),
+        row(keyFor("d6", "agno", "agentic-chat"), "d6", "green"),
+      ]);
+      const model = buildCellModel(live, wiredInput("agno", "agentic-chat"));
+      expect(model.chipColor).toBe("green");
+    });
+  });
+
+  // ── U8: stale cell → gray on the matrix (§7.2 / §6.4) ───────────────
+  // The per-depth resolvers only downgrade stale GREEN → amber and let a
+  // stale RED pass straight through (frozen-historical). That is correct for
+  // the depth LADDER, but for the MATRIX presentation a cell whose freshest
+  // observation predates the re-sweep freshness window is "re-sweep pending"
+  // — its frozen colour (red INCLUDED) is no longer a live claim, so the chip
+  // must render gray, not its stale historical state. The cell is stale only
+  // when EVERY contributing row is stale relative to its own family window;
+  // one fresh row means the cell was recently swept and keeps its colour.
+  // This is the SAME treatment U9's equivalence gate applies (excludes stale
+  // prod rows). Composes with U7: a stale driver-error cell is gray either
+  // way; the masks-real-red guard is unaffected because a fresh red stays red.
+  describe("stale cell → gray on matrix (U8, §7.2)", () => {
+    const NOW = Date.parse("2026-05-30T12:00:00Z");
+
+    function rowAtAge(
+      key: string,
+      dimension: string,
+      ageMs: number,
+      state: State = "green",
+      overrides: Partial<StatusRow> = {},
+    ) {
+      const observedAt = new Date(NOW - ageMs).toISOString();
+      return row(key, dimension, state, {
+        observed_at: observedAt,
+        transitioned_at: observedAt,
+        ...overrides,
+      });
+    }
+
+    // Past the e2e window — the freshest matrix cadence (6h). A row this old
+    // is unambiguously stale for every family window.
+    const STALE = E2E_STALE_AFTER_MS + 60 * 60 * 1000;
+    const FRESH = 60 * 1000;
+
+    it("folds a stale RED cell to gray (re-sweep pending), not red", () => {
+      // A genuine red (no infra class) that is also STALE. Under the depth
+      // resolvers this stays red; U8 must fold the matrix chip to gray.
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", STALE, "red"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      // The depth resolver still reports the frozen red (ladder unchanged)…
+      expect(model.d3?.status).toBe("red");
+      // …but the MATRIX chip is gray: stale, re-sweep pending.
+      expect(model.chipColor).toBe("gray");
+    });
+
+    it("leaves a FRESH red cell red (only stale folds)", () => {
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "red"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.chipColor).toBe("red");
+    });
+
+    it("does NOT mark a cell stale when one contributing row is fresh", () => {
+      // Stale red e2e but a FRESH chat row → the cell was swept recently, so
+      // it is NOT re-sweep-pending; the frozen red still surfaces as red.
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", STALE, "red"),
+        rowAtAge(keyFor("chat", "agno"), "chat", FRESH, "green"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.chipColor).toBe("red");
+    });
+
+    it("surfaces the observed_at age so operators see staleness", () => {
+      const ageMs = STALE;
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", ageMs, "red"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.isStaleCell).toBe(true);
+      // Age is the gap between `now` and the freshest contributing row's
+      // observed_at (the e2e row here).
+      expect(model.observedAtAgeMs).toBe(ageMs);
+    });
+
+    it("reports a non-stale cell's age and isStaleCell=false", () => {
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "red"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.isStaleCell).toBe(false);
+      expect(model.observedAtAgeMs).toBe(FRESH);
+    });
+
+    it("REGRESSION: a fresh driver-error cell still folds to gray (U7 intact)", () => {
+      // U7's infra fold must keep working alongside U8: a FRESH driver-error
+      // row is gray because of U7 (infra), independent of staleness.
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", FRESH, "red", {
+          signal: { errorClass: "driver-error" },
+        }),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.isStaleCell).toBe(false);
+      expect(model.chipColor).toBe("gray");
+    });
+
+    it("a no-data cell (no rows) is not stale and has null age", () => {
+      // No contributing rows → no-data gray already; staleness is undefined,
+      // not "stale" (there is no observation to be stale).
+      const live = mapOf([]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.isStaleCell).toBe(false);
+      expect(model.observedAtAgeMs).toBeNull();
+      expect(model.chipColor).toBe("gray");
+    });
+
+    it("folds a stale GREEN-derived cell to gray too (any colour, not just red)", () => {
+      // Every contributing row stale-green. The depth resolvers downgrade the
+      // stale greens to amber (so the chip would otherwise be amber/red); U8
+      // then folds the stale matrix cell to gray — re-sweep pending applies to
+      // any colour, the cell simply hasn't been observed recently.
+      const live = mapOf([
+        rowAtAge(keyFor("e2e", "agno", "agentic-chat"), "e2e", STALE, "green"),
+        rowAtAge(keyFor("chat", "agno"), "chat", STALE, "green"),
+        rowAtAge(keyFor("d5", "agno", "agentic-chat"), "d5", STALE, "green"),
+        rowAtAge(keyFor("d6", "agno", "agentic-chat"), "d6", STALE, "green"),
+      ]);
+      const model = buildCellModel(
+        live,
+        wiredInput("agno", "agentic-chat"),
+        NOW,
+      );
+      expect(model.isStaleCell).toBe(true);
+      expect(model.chipColor).toBe("gray");
+    });
+  });
 });

--- a/showcase/shell-dashboard/src/lib/__tests__/fixtures/driver-error-rows.json
+++ b/showcase/shell-dashboard/src/lib/__tests__/fixtures/driver-error-rows.json
@@ -1,0 +1,79 @@
+{
+  "_fixture": {
+    "description": "Real-surface PB status rows carrying harness INFRA signals (U7, spec §7.1). Captured from the harness driver write shapes: the per-cell d6 RED row signal is the exact object built at showcase/harness/src/probes/drivers/d6-all-pills.ts:1362-1377 (errorClass + errorDesc top-level on the signal blob, alongside slug/featureType/url/diagnostics); the D4 chat RED row carries driver-error in errorDesc ONLY (errorClass unset) per d4-chat-roundtrip.ts:915. The genuine-failure row (selector-timeout) is included to prove a ran-and-failed assertion STAYS red. shell-dashboard had no captured driver-error PB fixture before this file; these rows are persisted exactly as the harness writer emits them (showcase/harness/src/probes/drivers/d6-all-pills.ts:2211 writes result.signal straight onto the row).",
+    "source_drivers": [
+      "showcase/harness/src/probes/drivers/d6-all-pills.ts:1362 (per-cell d6 red side row)",
+      "showcase/harness/src/probes/drivers/d6-all-pills.ts:1783 (driver-error errorClass catch)",
+      "showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts:915 (D4 driver-error in errorDesc)"
+    ]
+  },
+  "d6DriverErrorRow": {
+    "id": "rec_d6_driver_error",
+    "key": "d6:agno/agentic-chat",
+    "dimension": "d6",
+    "state": "red",
+    "signal": {
+      "slug": "agno",
+      "featureType": "agentic-chat",
+      "backendUrl": "http://agno:8000",
+      "url": "http://shell:3000/agno/agentic-chat",
+      "fixtureFile": "agno-agentic-chat.json",
+      "turns_completed": 0,
+      "total_turns": 4,
+      "errorDesc": "page.goto: net::ERR_CONNECTION_REFUSED at http://shell:3000/agno/agentic-chat",
+      "errorClass": "driver-error",
+      "diagnostics": { "consoleErrors": [], "screenshot": null }
+    },
+    "observed_at": "2026-06-19T08:00:00.000Z",
+    "transitioned_at": "2026-06-19T08:00:00.000Z",
+    "fail_count": 1,
+    "first_failure_at": "2026-06-19T08:00:00.000Z"
+  },
+  "d4DriverErrorRow": {
+    "id": "rec_d4_driver_error",
+    "key": "chat:agno",
+    "dimension": "chat",
+    "state": "red",
+    "signal": {
+      "slug": "agno",
+      "level": "L3",
+      "errorDesc": "driver-error"
+    },
+    "observed_at": "2026-06-19T08:00:00.000Z",
+    "transitioned_at": "2026-06-19T08:00:00.000Z",
+    "fail_count": 1,
+    "first_failure_at": "2026-06-19T08:00:00.000Z"
+  },
+  "abortRow": {
+    "id": "rec_d6_abort",
+    "key": "d6:agno/agentic-chat",
+    "dimension": "d6",
+    "state": "red",
+    "signal": {
+      "slug": "agno",
+      "featureType": "agentic-chat",
+      "errorClass": "abort",
+      "errorDesc": "aborted before start"
+    },
+    "observed_at": "2026-06-19T08:00:00.000Z",
+    "transitioned_at": "2026-06-19T08:00:00.000Z",
+    "fail_count": 1,
+    "first_failure_at": "2026-06-19T08:00:00.000Z"
+  },
+  "genuineSelectorTimeoutRow": {
+    "id": "rec_d6_selector_timeout",
+    "key": "d6:agno/agentic-chat",
+    "dimension": "d6",
+    "state": "red",
+    "signal": {
+      "slug": "agno",
+      "featureType": "agentic-chat",
+      "errorClass": "selector-timeout",
+      "errorDesc": "waiting for selector [data-testid=\"assistant-message\"] timed out after 30000ms"
+    },
+    "observed_at": "2026-06-19T08:00:00.000Z",
+    "transitioned_at": "2026-06-19T08:00:00.000Z",
+    "fail_count": 1,
+    "first_failure_at": "2026-06-19T08:00:00.000Z"
+  }
+}

--- a/showcase/shell-dashboard/src/lib/cell-model.test.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.test.ts
@@ -234,3 +234,118 @@ describe("buildCellModel — comm-error overlay precedence", () => {
     expect(model.surfaceState).toBe("unreachable");
   });
 });
+
+describe("buildCellModel — starter axis (probeAxis: 'starter')", () => {
+  const COL = "google-adk";
+  const STARTER_LEVELS = ["health", "agent", "chat", "interaction"] as const;
+  const STARTER_CELL = {
+    slug: COL,
+    featureId: "starter",
+    isSupported: true,
+    isWired: true,
+    probeAxis: "starter",
+  } as const;
+
+  function starterMap(
+    states: Partial<Record<(typeof STARTER_LEVELS)[number], State>>,
+    observedAt?: string,
+  ): LiveStatusMap {
+    const live: LiveStatusMap = new Map();
+    for (const level of STARTER_LEVELS) {
+      const st = states[level];
+      if (st === undefined) continue;
+      const key = keyFor("starter", COL, level);
+      live.set(key, row(key, st, observedAt ? { observedAt } : {}));
+    }
+    return live;
+  }
+
+  it("derives GREEN when every starter level is fresh-green", () => {
+    const live = starterMap({
+      health: "green",
+      agent: "green",
+      chat: "green",
+      interaction: "green",
+    });
+    const model = buildCellModel(live, STARTER_CELL, NOW);
+    expect(model.chipColor).toBe("green");
+    // It must NOT consult the agent ladder — d3/d4/d5/d6 are not the source.
+    expect(model.supported).toBe(true);
+  });
+
+  it("derives RED when any starter level is red", () => {
+    const live = starterMap({
+      health: "green",
+      agent: "green",
+      chat: "green",
+      interaction: "red",
+    });
+    const model = buildCellModel(live, STARTER_CELL, NOW);
+    expect(model.chipColor).toBe("red");
+  });
+
+  it("derives GRAY when a starter level row is missing (unverified)", () => {
+    const live = starterMap({
+      health: "green",
+      agent: "green",
+      chat: "green",
+      // interaction missing
+    });
+    const model = buildCellModel(live, STARTER_CELL, NOW);
+    expect(model.chipColor).toBe("gray");
+  });
+
+  it("does NOT resolve a starter cell from agent e2e/d5/d6 rows", () => {
+    // Only agent-axis rows present; no starter rows → starter cell is no-data.
+    const live: LiveStatusMap = new Map();
+    live.set(
+      keyFor("e2e", COL, "agentic-chat"),
+      row(keyFor("e2e", COL, "agentic-chat"), "green"),
+    );
+    const model = buildCellModel(live, STARTER_CELL, NOW);
+    expect(model.chipColor).toBe("gray");
+  });
+
+  // A starter row past STARTER_STALE_AFTER_MS (2.5h). 3h before NOW is stale,
+  // while the helper's default observed_at (30s before NOW) is fresh.
+  const STALE_OBSERVED = "2026-06-04T09:00:00.000Z";
+
+  it("derives AMBER (degraded fold) when all levels green but one is STALE", () => {
+    // health/agent/chat fresh-green; interaction green but past the starter
+    // staleness window → per-row stale-green→degraded fold → not-all-fresh →
+    // amber. A SINGLE stale-green level can't be credited green, but it isn't a
+    // red and the cell isn't wholly stale (3 fresh rows), so the matrix-stale
+    // gray fold does NOT apply.
+    const live: LiveStatusMap = new Map();
+    for (const level of ["health", "agent", "chat"] as const) {
+      const key = keyFor("starter", COL, level);
+      live.set(key, row(key, "green"));
+    }
+    const staleKey = keyFor("starter", COL, "interaction");
+    live.set(staleKey, row(staleKey, "green", { observedAt: STALE_OBSERVED }));
+
+    const model = buildCellModel(live, STARTER_CELL, NOW);
+    expect(model.chipColor).toBe("amber");
+    // One fresh row keeps the cell off the matrix-stale gray fold.
+    expect(model.isStaleCell).toBe(false);
+  });
+
+  it("derives GRAY with isStaleCell when ALL contributing rows are stale", () => {
+    // Every level present and green but ALL past the matrix window → the U8
+    // matrix-staleness fold collapses any colour to gray and flags the cell
+    // stale ("re-sweep pending"). starterMap applies the one stale timestamp to
+    // all four rows.
+    const live = starterMap(
+      {
+        health: "green",
+        agent: "green",
+        chat: "green",
+        interaction: "green",
+      },
+      STALE_OBSERVED,
+    );
+    const model = buildCellModel(live, STARTER_CELL, NOW);
+    expect(model.chipColor).toBe("gray");
+    expect(model.isStaleCell).toBe(true);
+  });
+});

--- a/showcase/shell-dashboard/src/lib/cell-model.ts
+++ b/showcase/shell-dashboard/src/lib/cell-model.ts
@@ -19,11 +19,14 @@ import {
   CATALOG_TO_D5_KEY,
   commErrorFromStatusSignal,
   FLEET_COMM_AGGREGATE_DIMENSIONS,
+  STARTER_LEVELS,
 } from "./live-status";
+import type { StarterLevel } from "./live-status";
 import {
   E2E_STALE_AFTER_MS,
   D4_STALE_AFTER_MS,
   LIVENESS_STALE_AFTER_MS,
+  STARTER_STALE_AFTER_MS,
   isStale,
 } from "./staleness";
 
@@ -42,6 +45,58 @@ export {
 
 export type TestStatus = "green" | "red" | "amber" | null;
 export type ChipColor = "green" | "amber" | "red" | "gray";
+
+/**
+ * INFRA error classes that fold a red cell to gray (U7, spec §7.1).
+ *
+ * The harness writes an `errorClass`/`errorDesc` literal onto a failing row's
+ * `signal` blob. Two of those literals mean the probe NEVER produced a real
+ * functional result — the run was infra-broken, not product-broken:
+ *   - `driver-error` — the Playwright driver threw before/while exercising the
+ *     feature (`d6-all-pills.ts` non-abort catch; `d4-chat-roundtrip.ts` writes
+ *     it into `errorDesc`, NOT `errorClass`).
+ *   - `abort` — the run was aborted by worker drain / shutdown
+ *     (`abortSignal.aborted` branch in the same drivers).
+ * A cell whose red is attributable ONLY to one of these folds to the existing
+ * `gray` ChipColor (no-data) instead of `red`, so an infra blip never
+ * masquerades as a genuine product red on the matrix.
+ *
+ * CONSERVATIVE BY DESIGN (masks-real-red guard, spec R-C / ambiguity #3): the
+ * set is EXACTLY these two. Every other emitted class — `feature-timeout`,
+ * `missing-script`, `selector-timeout`, `conversation-error`, `goto-error`,
+ * `transport-error`, `launcher-error`, `interceptor-attach-error`,
+ * `interceptor-stop-error`, `promise-rejected`, `smoke-failed`, … — is a
+ * probe that RAN and failed, so it STAYS red. Widening this set risks hiding a
+ * genuine failure; never add a class without re-grounding it against the
+ * harness drivers. (`comm-error` / `pool-acquire-timeout` are NOT errorClass
+ * values — they are the REQ-B comm-error overlay and an Error message
+ * respectively — so they will never match here and are deliberately excluded.)
+ */
+export const INFRA_ERROR_CLASSES: ReadonlySet<string> = new Set([
+  "driver-error",
+  "abort",
+]);
+
+/**
+ * Does a status row's `signal` blob carry an INFRA error class in EITHER
+ * `errorClass` or `errorDesc`? Reading both fields is mandatory: D4
+ * (`d4-chat-roundtrip.ts`) writes `driver-error` into `errorDesc` and leaves
+ * `errorClass` unset, so an `errorClass`-only read would leave D4 driver-error
+ * reds RED. `signal` is typed `unknown` (the PB blob), so guard the shape
+ * before reading — a non-object / array / null signal carries no infra class.
+ */
+function signalHasInfraErrorClass(signal: unknown): boolean {
+  if (signal === null || typeof signal !== "object" || Array.isArray(signal)) {
+    return false;
+  }
+  const blob = signal as Record<string, unknown>;
+  const errorClass = blob.errorClass;
+  const errorDesc = blob.errorDesc;
+  return (
+    (typeof errorClass === "string" && INFRA_ERROR_CLASSES.has(errorClass)) ||
+    (typeof errorDesc === "string" && INFRA_ERROR_CLASSES.has(errorDesc))
+  );
+}
 
 export interface TestLevel {
   exists: boolean;
@@ -121,6 +176,26 @@ export interface CellModel {
    *     through; only green/gray becomes "pending").
    */
   surfaceState: FleetSurfaceState;
+  /**
+   * U8 (§7.2 / §6.4) — is the cell STALE on the matrix? A cell is stale when
+   * EVERY row that contributes to its rendering has an `observed_at` older than
+   * that row's own family staleness window (so a single fresh row means the
+   * cell was recently swept and is NOT stale). Distinct from the per-depth
+   * stale-green→amber downgrade in the resolvers: this is a MATRIX-level recency
+   * flag that folds ANY stale colour — red INCLUDED — to gray ("re-sweep
+   * pending"), because a frozen historical state is no longer a live claim. The
+   * same treatment U9's equivalence gate applies (a stale prod row is excluded).
+   * `false` for an unsupported/not-wired/no-data cell — there is no observation
+   * to be stale.
+   */
+  isStaleCell: boolean;
+  /**
+   * U8 — age in milliseconds of the cell's FRESHEST contributing observation
+   * (`now - max(observed_at)` across the rows the chip derives from). Surfaces
+   * staleness to operators ("last swept N ago"). `null` when the cell has no
+   * contributing rows (no-data) — there is no observation to age.
+   */
+  observedAtAgeMs: number | null;
 }
 
 export interface CellModelInput {
@@ -128,6 +203,20 @@ export interface CellModelInput {
   featureId: string;
   isSupported: boolean;
   isWired: boolean;
+  /**
+   * Which VERIFICATION AXIS this cell is probed on. Defaults to `"agent"` —
+   * the showcase-* integration feature ladder (D3 e2e / D4 chat-tools / D5 / D6,
+   * keyed `<dim>:<slug>/<featureId>`). A `"starter"` cell is a starter-template
+   * container fleet member (`starter-<slug>`): it is NOT probed on the agent
+   * feature ladder at all but on the `starter_smoke` matrix, whose rows are
+   * keyed `starter:<column-slug>/<level>` (level ∈ STARTER_LEVELS). For a
+   * starter cell `slug` is the DASHBOARD COLUMN slug (the value side of
+   * `STARTER_TO_COLUMN`) and `featureId` is a label only (the starter axis is
+   * not feature-scoped). `buildCellModel` routes a starter cell to
+   * `resolveStarterChip` instead of the agent ladder, so a starter is never
+   * resolved from — or emitted as — a phantom `agentic-chat` cell.
+   */
+  probeAxis?: "agent" | "starter";
 }
 
 // ---------------------------------------------------------------------------
@@ -747,6 +836,163 @@ function decodeCellCommError(
   return winner;
 }
 
+/**
+ * Decide whether a cell's RED is attributable ONLY to harness infra signals
+ * (`driver-error`/`abort` in `signal.errorClass` or `signal.errorDesc`) and so
+ * should fold to gray (U7, spec §7.1).
+ *
+ * Scans EVERY row the chip's red can derive from — the D3 (e2e) row, the D4
+ * chat/tools rows, and the D5/D6 per-cell families (mapped through
+ * `CATALOG_TO_D5_KEY`, the same keyspace the resolvers fan out over). A row
+ * "contributes red" when its persisted `state` ranks at or above `red` (rank
+ * fold, NOT literal "red" equality — an out-of-vocabulary runtime state such
+ * as `"error"` ranks ABOVE red and must still count, mirroring `rankOfState`).
+ *
+ * Returns true ONLY when there is at least one contributing red row AND EVERY
+ * contributing red row carries an infra class. If ANY contributing red row is
+ * NOT infra-classed (a genuine ran-and-failed assertion), this returns false
+ * and the cell STAYS red — the masks-real-red guard (spec R-C). The resolvers
+ * fold each family to a single worst row, so a family could hide a genuine red
+ * behind an infra winner (or vice-versa); scanning the raw rows here — not the
+ * resolved winners — is what makes the guard conservative.
+ *
+ * Staleness is NOT applied here: a stale GREEN row never contributes red, and
+ * a red row's infra-ness does not age out (the signal classifies WHY the probe
+ * failed, independent of when). The chip already computed `red`, so the only
+ * question is whether that red is infra-only.
+ */
+function redIsPurelyInfra(
+  live: LiveStatusMap,
+  slug: string,
+  featureId: string,
+): boolean {
+  const familyKeys = CATALOG_TO_D5_KEY[featureId];
+  const keys: string[] = [
+    keyFor("e2e", slug, featureId),
+    keyFor("chat", slug),
+    keyFor("tools", slug),
+  ];
+  if (familyKeys) {
+    for (const ft of familyKeys) {
+      keys.push(keyFor("d5", slug, ft));
+      keys.push(keyFor("d6", slug, ft));
+    }
+  }
+
+  let sawContributingRed = false;
+  for (const key of keys) {
+    const row = live.get(key);
+    if (!row) continue;
+    // A row contributes red when its state ranks at/above red — rank-based so
+    // an out-of-vocabulary "error" state (ranked above red by the A2
+    // machinery) is still treated as a failing contributor, not swallowed.
+    if (rankOfState(row.state) < STATE_RANK.red) continue;
+    if (!signalHasInfraErrorClass(row.signal)) {
+      // A genuine ran-and-failed red — never fold it away.
+      return false;
+    }
+    sawContributingRed = true;
+  }
+  return sawContributingRed;
+}
+
+/**
+ * Result of the U8 matrix-freshness scan.
+ *   - `freshestAgeMs` — age in ms of the cell's FRESHEST contributing
+ *     observation (`now - max(observed_at)`), or `null` when the cell has no
+ *     contributing rows (no-data; nothing to age).
+ *   - `isStale` — true when at least one row contributes AND every contributing
+ *     row is older than its own family staleness window. A single fresh row
+ *     (relative to ITS window) means the cell was recently swept → not stale.
+ */
+interface CellFreshness {
+  freshestAgeMs: number | null;
+  isStale: boolean;
+}
+
+/**
+ * Compute the cell's MATRIX freshness (U8, spec §7.2/§6.4).
+ *
+ * Scans EVERY row the cell renders from — the D3 (e2e) row, the D4 chat/tools
+ * rows, the D5/D6 per-cell families (mapped through `CATALOG_TO_D5_KEY`, the
+ * same keyspace the resolvers fan out over), and the D1/D2 `health` row — and
+ * asks two things per row: how old is it, and is it stale relative to ITS OWN
+ * family window? Windows differ by cadence (e2e/d5/d6 = `E2E_STALE_AFTER_MS`
+ * (6h), chat/tools = `D4_STALE_AFTER_MS` (1h), health = `LIVENESS_STALE_AFTER_MS`
+ * (45m)) — mirroring `decodeCellCommError`'s per-family staleness so a
+ * fast-cadence row (health) does not wrongly mark a cell stale when its slower
+ * e2e row is legitimately a couple hours old, and vice-versa.
+ *
+ * A cell is STALE only when it has at least one contributing row AND every
+ * contributing row is past its window — i.e. the cell has not been swept on
+ * ANY cadence within that cadence's tolerance. One fresh row keeps the cell
+ * fresh (it was recently observed). The freshest age is `now - max(observed_at)`
+ * across all contributing rows, surfaced so operators see "last swept N ago".
+ *
+ * An unparseable `observed_at` is treated as NOT fresh for the freshest-age
+ * pick (it cannot establish recency) but IS treated as stale for the all-stale
+ * verdict — a row with no trustworthy timestamp cannot vouch that the cell was
+ * recently swept. This fails safe toward "re-sweep pending" (gray) rather than
+ * trusting a corrupt timestamp to paint a frozen colour as live.
+ */
+function computeCellFreshness(
+  live: LiveStatusMap,
+  slug: string,
+  featureId: string,
+  now: number,
+): CellFreshness {
+  const familyKeys = CATALOG_TO_D5_KEY[featureId];
+  const candidates: Array<{ key: string; staleAfterMs: number }> = [
+    { key: keyFor("e2e", slug, featureId), staleAfterMs: E2E_STALE_AFTER_MS },
+    { key: keyFor("chat", slug), staleAfterMs: D4_STALE_AFTER_MS },
+    { key: keyFor("tools", slug), staleAfterMs: D4_STALE_AFTER_MS },
+    { key: keyFor("health", slug), staleAfterMs: LIVENESS_STALE_AFTER_MS },
+  ];
+  if (familyKeys) {
+    for (const ft of familyKeys) {
+      candidates.push({
+        key: keyFor("d5", slug, ft),
+        staleAfterMs: E2E_STALE_AFTER_MS,
+      });
+      candidates.push({
+        key: keyFor("d6", slug, ft),
+        staleAfterMs: E2E_STALE_AFTER_MS,
+      });
+    }
+  }
+
+  let freshestAgeMs: number | null = null;
+  let sawContributingRow = false;
+  let allStale = true;
+  for (const { key, staleAfterMs } of candidates) {
+    const row = live.get(key);
+    if (!row) continue;
+    sawContributingRow = true;
+    // Reuse the shared `isStale` primitive with this row's family window. An
+    // unparseable timestamp reads as NOT stale there (staleness is a positive
+    // signal) — but for the all-stale verdict a row with no trustworthy
+    // timestamp must not vouch for recency, so treat unparseable as stale.
+    const observedMs = Date.parse(row.observed_at);
+    const rowStale = Number.isNaN(observedMs)
+      ? true
+      : isStale(row, now, staleAfterMs);
+    if (!rowStale) allStale = false;
+    // Freshest age: smallest non-negative `now - observed_at`. Skip an
+    // unparseable timestamp — it cannot establish recency.
+    if (!Number.isNaN(observedMs)) {
+      const ageMs = now - observedMs;
+      if (freshestAgeMs === null || ageMs < freshestAgeMs) {
+        freshestAgeMs = ageMs;
+      }
+    }
+  }
+
+  return {
+    freshestAgeMs,
+    isStale: sawContributingRow && allStale,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -772,7 +1018,135 @@ const UNSUPPORTED: CellModel = Object.freeze({
   chipColor: "gray",
   isRegression: false,
   surfaceState: "gray",
+  isStaleCell: false,
+  observedAtAgeMs: null,
 });
+
+/**
+ * Resolve a STARTER cell's `ChipColor` + matrix-freshness from the four
+ * `starter:<columnSlug>/<level>` rows the `starter_smoke` driver emits (level ∈
+ * {@link STARTER_LEVELS}). A starter is NOT probed on the agent feature ladder,
+ * so this is its OWN derivation — disjoint from the D3/D4/D5/D6 resolvers.
+ *
+ * The fold mirrors the agent ladder's philosophy so the equivalence gate stays
+ * apples-to-apples on whichever axis a cell lives on:
+ *   - per-row stale-green → degraded BEFORE the worst-state fold (the starter
+ *     uses `STARTER_STALE_AFTER_MS`), so a frozen-green level can't mask a
+ *     fresh sibling;
+ *   - STRICT on missing rows: a level with no row makes the family unverified
+ *     and collapses a green/degraded fold to no-data (`gray`) — a present RED
+ *     still dominates no-data (rank-based, so an out-of-vocab state ranked
+ *     above red still surfaces);
+ *   - `green` only when ALL four levels are present AND green-and-fresh;
+ *   - `amber` for a stale-green / degraded fold (not-green, but not a red);
+ *   - the U8 matrix-staleness fold (every contributing row past its window →
+ *     gray) is applied by the caller via the returned `isStale`.
+ */
+function resolveStarterChip(
+  live: LiveStatusMap,
+  columnSlug: string,
+  now: number,
+): { chipColor: ChipColor; isStale: boolean; freshestAgeMs: number | null } {
+  let worstState: State | null = null;
+  let anyMissing = false;
+  let sawRow = false;
+  let allStale = true;
+  let freshestAgeMs: number | null = null;
+
+  for (const level of STARTER_LEVELS as readonly StarterLevel[]) {
+    const row = live.get(keyFor("starter", columnSlug, level)) ?? null;
+    if (!row) {
+      anyMissing = true;
+      continue;
+    }
+    sawRow = true;
+    // U8 matrix-freshness bookkeeping (mirrors computeCellFreshness): an
+    // unparseable timestamp reads as stale for the all-stale verdict but cannot
+    // establish recency for the freshest-age pick.
+    const observedMs = Date.parse(row.observed_at);
+    const rowStale = Number.isNaN(observedMs)
+      ? true
+      : isStale(row, now, STARTER_STALE_AFTER_MS);
+    if (!rowStale) allStale = false;
+    if (!Number.isNaN(observedMs)) {
+      const ageMs = now - observedMs;
+      if (freshestAgeMs === null || ageMs < freshestAgeMs)
+        freshestAgeMs = ageMs;
+    }
+    // Per-row stale-green → degraded downgrade BEFORE the worst-state fold.
+    const eff: State =
+      row.state === "green" && isStale(row, now, STARTER_STALE_AFTER_MS)
+        ? "degraded"
+        : row.state;
+    if (worstState === null || rankOfState(eff) > rankOfState(worstState)) {
+      worstState = eff;
+    }
+  }
+
+  // No starter rows at all → no-data gray (the resting state before the first
+  // smoke tick), matrix-fresh-neutral.
+  if (!sawRow || worstState === null) {
+    return { chipColor: "gray", isStale: false, freshestAgeMs };
+  }
+
+  const matrixStale = sawRow && allStale;
+
+  // STRICT missing-level collapse: a missing level makes the family unverified.
+  // A present red-or-worse still dominates no-data (rank-based); otherwise a
+  // green/degraded fold collapses to gray.
+  let chipColor: ChipColor;
+  if (anyMissing && rankOfState(worstState) < STATE_RANK.red) {
+    chipColor = "gray";
+  } else {
+    const status = foldStateToTestStatus(worstState);
+    chipColor =
+      status === "green" ? "green" : status === "red" ? "red" : "amber";
+  }
+
+  // U8 matrix-staleness fold: a wholly-stale starter cell is "re-sweep pending"
+  // → gray, exactly as the agent ladder folds a stale cell (and as U9's
+  // equivalence gate excludes a stale prod cell).
+  if (matrixStale && chipColor !== "gray") {
+    chipColor = "gray";
+  }
+
+  return { chipColor, isStale: matrixStale, freshestAgeMs };
+}
+
+/**
+ * Build the cell model for a STARTER-axis cell ({@link CellModelInput.probeAxis}
+ * `=== "starter"`). The starter axis has no D3/D4/D5/D6 ladder, so the depth
+ * levels are all `null`/no-data and the `chipColor` comes from
+ * `resolveStarterChip` over the `starter:<columnSlug>/<level>` rows. No
+ * comm-error overlay is decoded (the starter_smoke driver does not ride the
+ * fleet comm-error path), so `surfaceState` mirrors `chipColor`.
+ */
+function buildStarterCellModel(
+  live: LiveStatusMap,
+  columnSlug: string,
+  now: number,
+): CellModel {
+  const { chipColor, isStale, freshestAgeMs } = resolveStarterChip(
+    live,
+    columnSlug,
+    now,
+  );
+  return {
+    supported: true,
+    d3: NOT_WIRED_LEVEL,
+    d4: NOT_WIRED_LEVEL,
+    d5: NOT_WIRED_LEVEL,
+    d6: NOT_WIRED_LEVEL,
+    d6Effective: null,
+    achievedDepth: 0,
+    ceilingDepth: 0,
+    chipColor,
+    isRegression: false,
+    surfaceState: chipColorToSurface(chipColor),
+    isStaleCell: isStale,
+    observedAtAgeMs: freshestAgeMs,
+  };
+}
 
 /**
  * Build the complete cell model for a single (integration, feature) pair.
@@ -793,6 +1167,13 @@ export function buildCellModel(
     return UNSUPPORTED;
   }
 
+  // ── Starter axis: resolve off the starter_smoke matrix, NOT the agent
+  //    feature ladder. A starter's `slug` is its dashboard COLUMN slug. ──
+  if (input.probeAxis === "starter") {
+    if (!isWired) return UNSUPPORTED;
+    return buildStarterCellModel(live, slug, now);
+  }
+
   // ── Not wired (supported but no test harness configured) ──────────
   if (!isWired) {
     return {
@@ -807,6 +1188,8 @@ export function buildCellModel(
       chipColor: "gray",
       isRegression: false,
       surfaceState: "gray",
+      isStaleCell: false,
+      observedAtAgeMs: null,
     };
   }
 
@@ -931,6 +1314,38 @@ export function buildCellModel(
     // Mapped D5 is red or stale-amber → ladder broken at D5. Red wins over
     // any D6 outcome (including a green aggregate).
     chipColor = "red";
+  }
+
+  // ── U7: harness driver-error/abort INFRA fold (§7.1) ──────────────
+  // A cell that is RED purely because its failing rows carry a harness infra
+  // signal (`driver-error`/`abort` in `signal.errorClass` or `signal.errorDesc`)
+  // is folded to the existing `gray` ChipColor (no-data) — an infra blip is not
+  // a genuine product red and must not show as one on the matrix. The fold is
+  // CONSERVATIVE: it fires only when EVERY contributing red row is infra-classed
+  // (see `redIsPurelyInfra`), so a real ran-and-failed assertion — alone or
+  // alongside an infra red on a sibling rung — keeps the cell RED. Applied only
+  // to a red chip; green/amber/gray are untouched, and the masks-real-red guard
+  // (spec R-C) lives entirely in `redIsPurelyInfra`.
+  if (chipColor === "red" && redIsPurelyInfra(live, slug, featureId)) {
+    chipColor = "gray";
+  }
+
+  // ── U8: matrix staleness fold (§7.2 / §6.4) ───────────────────────
+  // The per-depth resolvers only downgrade a stale GREEN to amber and let a
+  // stale RED pass through frozen — correct for the depth LADDER. But on the
+  // MATRIX a cell whose freshest observation predates its re-sweep window is
+  // "re-sweep pending": its frozen colour (red INCLUDED) is no longer a live
+  // claim, so fold ANY non-gray chip to gray. The cell is stale only when
+  // EVERY contributing row is past its own family window (one fresh row keeps
+  // it live — see `computeCellFreshness`), so a fresh red stays red and the
+  // existing "fresh e2e + stale D5" depth cases are untouched. This is the SAME
+  // treatment U9's equivalence gate applies (a stale prod row is excluded).
+  // Runs AFTER U7's infra fold: a stale driver-error cell is already gray, so
+  // the two folds compose without either masking the other.
+  const freshness = computeCellFreshness(live, slug, featureId, now);
+  const isStaleCell = freshness.isStale;
+  if (isStaleCell && chipColor !== "gray") {
+    chipColor = "gray";
   }
 
   // d6Effective — ladder-gated D6 status for the D6 badge + D6 stat.
@@ -1059,5 +1474,7 @@ export function buildCellModel(
     isRegression,
     ...(commError ? { commError } : {}),
     surfaceState,
+    isStaleCell,
+    observedAtAgeMs: freshness.freshestAgeMs,
   };
 }

--- a/showcase/shell-dashboard/src/lib/ops-api.ts
+++ b/showcase/shell-dashboard/src/lib/ops-api.ts
@@ -41,6 +41,13 @@ export type ProbeKind =
   | "health"
   | "image-drift"
   | "pin-drift"
+  // CROSS-ENV pin-drift (U11 / spec §7.3). The harness `/probes` endpoint
+  // emits `cfg.kind` raw, so this arrives over the wire as the underscore
+  // form `pin_drift_cross_env`. The Ops surface routes PROD drift here and
+  // STAGING to `image-drift` (the `:latest`-drift signal) — see the harness
+  // `probes/ops-drift-routing.ts`. Listed so the kind is documented rather
+  // than only matching the `(string & {})` forward-compat fallback.
+  | "pin_drift_cross_env"
   | "aimock-wiring"
   | "qa"
   | "redirect-decommission"


### PR DESCRIPTION
## Summary

Makes showcase cluster promotion **dependency-, env-, and verification-complete** so prod matches staging after a full promote — and folds the **starter template apps into the same cluster** so they get identical treatment. (Design spec: Notion `3843aa38185281629803fd926b793018`.) One PR.

### Engine (the 19 showcase-* integrations + infra)
- **Dependency-complete:** promote-closure SSOT (`promoteTier`/`runtimeDeps`/`serviceRefs`) + pure `computePromoteClosure` (tier-ordered 0→1→2, skip-with-reason, fail-loud `assertClosureValid`); tier-ordered dependency-gated promote (tier-0 failure blocks 1+2 as NOT-ATTEMPTED, `--digest` escape retained); `lint-prod` pinned-ness gate.
- **Env-complete:** Ruby preflight — service-ref assertion (REFUSE on prod→staging host), replicate-class env-write mechanism (opt-in, empty today), prod-specific assert-never-copy (R-A guard); resource detect-and-WARN. (`limitOverride` WARN dropped — Railway exposes no readable limit field, introspection-verified.)
- **Verification-complete:** cross-env pin-drift probe (prod-pinned vs last-promoted digest — the real prod drift signal); dashboard folds harness `driver-error`/`abort` + stale cells to gray (genuine failures stay red — masks-real-red guard verified); prod↔staging equivalence gate (ChipColor compare, gray-excluded, one-directional) fed by a verify-prod re-sweep + freshness wait.

### Starters (the 12 starter-* template apps) — "one whole cluster"
- 12 starter SSOT entries (tier 2, `runtimeDeps:["aimock"]`, `serviceRefs:OPENAI_BASE_URL→aimock`); reversed the 3 decoupling fences (drift whitelist, `lint-prod` exemption, provisioner) so **`lint-prod` now covers starters** (flags any prod `:latest`).
- Equivalence + re-sweep run starters on their **starter-smoke axis** (`probeAxis:"starter"`): enqueue fires `starter_smoke:starter-<slug>` triggers and the gate reads `starter:<col>/<level>` rows — agent axis unchanged.
- **F1 value-tested:** all 12 starters carry prod `OPENAI_BASE_URL`→prod-aimock (mirror showcase-* wiring), so the service-ref assertion does NOT brick the promote.

### Verification
- 4-round 7-agent cr-loop converged to zero actionable findings (caught + fixed a verify-prod always-REFUSE cell-derivation bug, a dead `limitOverride` WARN, and an incomplete starter enqueue axis). Red-green on every unit; cross-env probe proven against live Railway.
- Pre-push CLEAN: oxfmt/oxlint, tsc 0 (scripts/harness/dashboard), suites green (scripts 257, harness 194, dashboard 1118, ruby 160, bats 103), builds 0, actionlint clean.

### Out-of-band prod hotfix (already live)
Prod `aimock` was stale (06-16) and lacked the google-adk `gen-ui-declarative` fixture → prod served a hallucinated dashboard. Promoted prod aimock to staging's digest; **value-tested live** — prod now serves the curated `$4.2M` fixture. This is the exact dependency-incomplete-promote failure the redesign prevents.

### Phase-2 activation (to switch the new guarantees ON — not in this PR)
The tier-closure + verify-prod gate ship **dormant/config-gated** (low blast radius). To activate: (1) wire `CLOSURE_PLAN` into the live promote step (currently feeds the leaf `SERVICES_CSV`); (2) provision prod `harness-workers` + set `SHOWCASE_PROD/STAGING_POCKETBASE_URL`, `SHOWCASE_RAILWAY_ENV_ID_PROD`, `SHOWCASE_RAILWAY_PROJECT_ID`; (3) set `PROD_HARNESS_BASE_URL`/`PROD_HARNESS_TRIGGER_TOKEN` for the starter re-sweep.

### Follow-ups (ledgered, non-blocking)
GHCR token-exchange for harness drivers; closure dual-impl imageOf divergence (latent); discriminated-union type-hardening for GateCell/CellComparison; misc defensive-branch coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)