### PR TITLE
docs(angular): add @copilotkit/angular reference documentation

### DIFF
--- a/showcase/shell-docs/src/app/reference/page.tsx
+++ b/showcase/shell-docs/src/app/reference/page.tsx
@@ -55,6 +55,12 @@ const SDK_CHOICES: { name: string; description: string; href: string }[] = [
     href: referenceVersionHref("vue"),
   },
   {
+    name: "Angular",
+    description:
+      "Components, services, and functions for building CopilotKit into an Angular app.",
+    href: referenceVersionHref("angular"),
+  },
+  {
     name: "Core (TypeScript)",
     description:
       "The framework-agnostic @copilotkit/core client — runs anywhere JavaScript runs.",

--- a/showcase/shell-docs/src/components/reference-version-selector.tsx
+++ b/showcase/shell-docs/src/components/reference-version-selector.tsx
@@ -19,6 +19,7 @@ const VERSION_LABELS: Record<ReferenceVersion, string> = {
   v1: "React (V1)",
   "react-native": "React Native",
   vue: "Vue",
+  angular: "Angular",
   core: "Core (TypeScript)",
   bot: "Bots",
 };

--- a/showcase/shell-docs/src/content/reference/angular/components/CopilotChat.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/components/CopilotChat.mdx
@@ -1,0 +1,83 @@
+---
+title: "CopilotChat"
+description: "Angular standalone component that wires an agent to the chat UI, the @copilotkit/angular equivalent of React's CopilotChat"
+---
+
+## Overview
+
+`CopilotChat` is the all-in-one chat component. It wires an agent into [`CopilotChatView`](/reference/angular/components/CopilotChatView) so you get a working chat interface with one selector. It resolves the agent through [`injectAgentStore`](/reference/angular/functions/injectAgentStore), subscribes to that agent's messages and running state, manages suggestions, tracks the input value, handles audio transcription, wires file attachments, and clears the input after each message is sent.
+
+This is the Angular equivalent of React's `<CopilotChat>`. Where React composes the agent wiring in the component, Angular `CopilotChat` extends the internal `ChatState` and provides itself as the `ChatState` for the view and input beneath it. You usually only need to point it at an agent.
+
+For the layout without the agent wiring, use [`CopilotChatView`](/reference/angular/components/CopilotChatView) directly.
+
+## Usage
+
+`CopilotChat` is a standalone component with the selector `copilot-chat`. Import the class into your component's `imports` array and use the element in the template. The chat reads its configuration from [`provideCopilotKit`](/reference/angular/functions/provideCopilotKit), so the provider must be in scope.
+
+```ts title="src/app/app.component.ts"
+import { Component } from "@angular/core";
+import { CopilotChat } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-root",
+  standalone: true,
+  imports: [CopilotChat],
+  template: `<copilot-chat />`,
+})
+export class AppComponent {}
+```
+
+Remember to import the stylesheet once in your global styles:
+
+```css title="src/styles.css"
+@import "@copilotkit/angular/styles.css";
+```
+
+## Inputs
+
+<PropertyReference name="agentId" type="string">
+  ID of the agent to connect. Must match an agent configured in [`provideCopilotKit`](/reference/angular/functions/provideCopilotKit). When omitted, the default agent is used.
+</PropertyReference>
+
+<PropertyReference name="threadId" type="string">
+  ID of the conversation thread. Pass a specific thread id to resume an existing conversation. When omitted, a thread id is minted locally and the agent connects on first run. Setting an explicit `threadId` also makes the chat attempt to connect to (resume) that thread on the agent.
+</PropertyReference>
+
+<PropertyReference name="attachments" type="AttachmentsConfig">
+  Configuration for file attachments. Bound through the `attachments` alias (the underlying input is `attachmentsConfig`). When `enabled` is true, the add-file action and drag-and-drop are turned on and the chat manages the attachment queue automatically.
+</PropertyReference>
+
+<PropertyReference name="inputComponent" type="Type<any>">
+  A custom Angular component class to render in place of the default [`CopilotChatInput`](/reference/angular/components/CopilotChatInput). Forwarded to the underlying [`CopilotChatView`](/reference/angular/components/CopilotChatView).
+</PropertyReference>
+
+## Outputs
+
+`CopilotChat` does not declare its own outputs. It handles message submission, suggestion selection, and transcription internally through the `ChatState` it provides to the input and view. To observe lower-level interactions, render a custom input via `inputComponent` (or use [`CopilotChatInput`](/reference/angular/components/CopilotChatInput) directly), which exposes outputs such as `submitMessage` and the transcription events.
+
+## Customization
+
+`CopilotChat` keeps the layout simple and delegates slot customization to the view it renders. Swap the input area with the `inputComponent` input, or compose the layout yourself with [`CopilotChatView`](/reference/angular/components/CopilotChatView), which exposes the full set of slot inputs and content-projection templates (message view, scroll view, feather, disclaimer, input container, and the input toolbar buttons).
+
+To customize the text strings (input placeholder, welcome message, toolbar labels, disclaimer), provide labels through [`provideCopilotChatLabels`](/reference/angular/functions/provideCopilotChatLabels). The chat reads them through `injectChatLabels` internally.
+
+## Related
+
+<Cards>
+  <Card
+    title="CopilotChatView"
+    description="The layout-only chat view used internally. Use it when you manage messages and handlers yourself."
+    href="/reference/angular/components/CopilotChatView"
+  />
+  <Card
+    title="CopilotChatInput"
+    description="The input area: textarea, send button, tools menu, file upload, and transcription."
+    href="/reference/angular/components/CopilotChatInput"
+  />
+  <Card
+    title="provideCopilotKit"
+    description="Configures the runtime connection and agents that CopilotChat reads from."
+    href="/reference/angular/functions/provideCopilotKit"
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/components/CopilotChatAssistantMessage.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/components/CopilotChatAssistantMessage.mdx
@@ -1,0 +1,216 @@
+---
+title: "CopilotChatAssistantMessage"
+description: "Angular standalone component that renders a single assistant message with markdown content, tool calls, and a toolbar of copy, thumbs, read-aloud, and regenerate actions."
+---
+
+## Overview
+
+`CopilotChatAssistantMessage` renders one assistant message. It shows the message content through a markdown renderer, renders any tool calls attached to the message, and shows a toolbar with copy, thumbs up/down, read-aloud, and regenerate actions. It mirrors React's `CopilotChatAssistantMessage`.
+
+The toolbar appears only when the message has non-empty text content. The copy button always renders; the thumbs up and thumbs down buttons render when you provide a custom slot for them or when a thumbs handler is available from a surrounding [`CopilotChatView`](/reference/angular/components/CopilotChatView). The read-aloud and regenerate buttons render only when you provide a custom slot for them.
+
+The component is standalone and uses `OnPush` change detection. Reactive inputs are Angular [signals](https://angular.dev/guide/signals).
+
+## Usage
+
+Import the component class and use its `copilot-chat-assistant-message` selector. The `message` input is required.
+
+```ts title="src/app/assistant.component.ts"
+import { Component, signal } from "@angular/core";
+import { CopilotChatAssistantMessage } from "@copilotkit/angular";
+import type { AssistantMessage } from "@ag-ui/client";
+
+@Component({
+  selector: "app-assistant",
+  standalone: true,
+  imports: [CopilotChatAssistantMessage],
+  template: `
+    <copilot-chat-assistant-message
+      [message]="message()"
+      (thumbsUp)="onThumbsUp($event)"
+      (regenerate)="onRegenerate($event)"
+    />
+  `,
+})
+export class AssistantComponent {
+  message = signal<AssistantMessage>({
+    id: "1",
+    role: "assistant",
+    content: "Hello, how can I help?",
+  });
+
+  onThumbsUp(event: { message: AssistantMessage }) {
+    console.log("liked", event.message.id);
+  }
+
+  onRegenerate(event: { message: AssistantMessage }) {
+    console.log("regenerate", event.message.id);
+  }
+}
+```
+
+## Inputs
+
+<PropertyReference name="message" type="AssistantMessage" required>
+  The assistant message to render. Its `content` is passed to the markdown renderer and its `toolCalls` drive the tool calls view.
+</PropertyReference>
+
+<PropertyReference name="messages" type="Message[]" default="[]">
+  The surrounding message list. Forwarded to the tool calls view so a tool render can read prior context.
+</PropertyReference>
+
+<PropertyReference name="agentId" type="string">
+  ID of the agent that produced the message. Forwarded to the tool calls view for resolving the matching tool renderer.
+</PropertyReference>
+
+<PropertyReference name="isLoading" type="boolean" default="false">
+  Whether the agent is currently streaming. Forwarded to the tool calls view.
+</PropertyReference>
+
+<PropertyReference name="toolbarVisible" type="boolean" default="true">
+  Whether the toolbar may be shown. Even when `true`, the toolbar only renders if the message has non-empty text content.
+</PropertyReference>
+
+<PropertyReference name="additionalToolbarItems" type="TemplateRef<any>">
+  A template appended to the end of the default toolbar, after the built-in buttons.
+</PropertyReference>
+
+<PropertyReference name="inputClass" type="string">
+  Extra CSS classes merged onto the message container.
+</PropertyReference>
+
+### Slot class inputs
+
+Each of these passes extra CSS classes to the corresponding default sub-component.
+
+<PropertyReference name="markdownRendererClass" type="string">
+  Classes for the default markdown renderer.
+</PropertyReference>
+
+<PropertyReference name="toolbarClass" type="string">
+  Classes for the default toolbar.
+</PropertyReference>
+
+<PropertyReference name="copyButtonClass" type="string">
+  Classes for the default copy button.
+</PropertyReference>
+
+<PropertyReference name="thumbsUpButtonClass" type="string">
+  Classes for the default thumbs-up button.
+</PropertyReference>
+
+<PropertyReference name="thumbsDownButtonClass" type="string">
+  Classes for the default thumbs-down button.
+</PropertyReference>
+
+<PropertyReference name="readAloudButtonClass" type="string">
+  Classes for the default read-aloud button.
+</PropertyReference>
+
+<PropertyReference name="regenerateButtonClass" type="string">
+  Classes for the default regenerate button.
+</PropertyReference>
+
+<PropertyReference name="toolCallsViewClass" type="string">
+  Classes for the default tool calls view.
+</PropertyReference>
+
+### Slot component inputs
+
+Each of these replaces the corresponding default sub-component with a component class of your own. Content-projection templates (see below) take precedence over these.
+
+<PropertyReference name="markdownRendererComponent" type="Type<any>">
+  Replaces the default markdown renderer.
+</PropertyReference>
+
+<PropertyReference name="toolbarComponent" type="Type<any>">
+  Replaces the default toolbar.
+</PropertyReference>
+
+<PropertyReference name="copyButtonComponent" type="Type<any>">
+  Replaces the default copy button.
+</PropertyReference>
+
+<PropertyReference name="thumbsUpButtonComponent" type="Type<any>">
+  Replaces the default thumbs-up button.
+</PropertyReference>
+
+<PropertyReference name="thumbsDownButtonComponent" type="Type<any>">
+  Replaces the default thumbs-down button.
+</PropertyReference>
+
+<PropertyReference name="readAloudButtonComponent" type="Type<any>">
+  Replaces the default read-aloud button.
+</PropertyReference>
+
+<PropertyReference name="regenerateButtonComponent" type="Type<any>">
+  Replaces the default regenerate button.
+</PropertyReference>
+
+<PropertyReference name="toolCallsViewComponent" type="Type<any>">
+  Replaces the default tool calls view.
+</PropertyReference>
+
+## Outputs
+
+<PropertyReference name="thumbsUp" type="CopilotChatAssistantMessageOnThumbsUpProps">
+  Emitted when the thumbs-up button is clicked. The payload is `{ message: AssistantMessage }`.
+</PropertyReference>
+
+<PropertyReference name="thumbsDown" type="CopilotChatAssistantMessageOnThumbsDownProps">
+  Emitted when the thumbs-down button is clicked. The payload is `{ message: AssistantMessage }`.
+</PropertyReference>
+
+<PropertyReference name="readAloud" type="CopilotChatAssistantMessageOnReadAloudProps">
+  Emitted when the read-aloud button is clicked. The payload is `{ message: AssistantMessage }`.
+</PropertyReference>
+
+<PropertyReference name="regenerate" type="CopilotChatAssistantMessageOnRegenerateProps">
+  Emitted when the regenerate button is clicked. The payload is `{ message: AssistantMessage }`.
+</PropertyReference>
+
+## Slots and content projection
+
+You can override any piece of the message by projecting a named template. A projected template takes precedence over the matching `*Component` input. Each template receives a typed context object.
+
+| Template name | Context type | Replaces |
+| --- | --- | --- |
+| `markdownRenderer` | `AssistantMessageMarkdownRendererContext` (`{ content: string }`) | The markdown content renderer |
+| `toolbar` | `AssistantMessageToolbarContext` (`{ children?: any }`) | The whole toolbar |
+| `copyButton` | `AssistantMessageCopyButtonContext` (`{ content?: string }`) | The copy button |
+| `thumbsUpButton` | `ThumbsUpButtonContext` (empty; click via outputs) | The thumbs-up button |
+| `thumbsDownButton` | `ThumbsDownButtonContext` (empty; click via outputs) | The thumbs-down button |
+| `readAloudButton` | `ReadAloudButtonContext` (empty; click via outputs) | The read-aloud button |
+| `regenerateButton` | `RegenerateButtonContext` (empty; click via outputs) | The regenerate button |
+| `toolCallsView` | `any` | The tool calls view |
+
+```html title="src/app/assistant.component.html"
+<copilot-chat-assistant-message [message]="message()">
+  <ng-template #markdownRenderer let-content="content">
+    <article class="my-markdown">{{ content }}</article>
+  </ng-template>
+</copilot-chat-assistant-message>
+```
+
+## Related
+
+<Cards>
+  <Card
+    title="CopilotChatMessageView"
+    description="Renders a list of messages, routing each to assistant, user, reasoning, or activity rendering."
+    href="/reference/angular/components/CopilotChatMessageView"
+    icon={<LinkIcon />}
+  />
+  <Card
+    title="CopilotChatUserMessage"
+    description="Renders a single user message with copy, edit, and branch navigation."
+    href="/reference/angular/components/CopilotChatUserMessage"
+    icon={<LinkIcon />}
+  />
+  <Card
+    title="CopilotChatView"
+    description="The full chat layout: scroll container, message view, and input."
+    href="/reference/angular/components/CopilotChatView"
+    icon={<LinkIcon />}
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/components/CopilotChatInput.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/components/CopilotChatInput.mdx
@@ -1,0 +1,237 @@
+---
+title: "CopilotChatInput"
+description: "Angular standalone component for the chat input area: textarea, send button, tools menu, file upload, and audio transcription, the @copilotkit/angular equivalent of React's CopilotChatInput"
+---
+
+## Overview
+
+`CopilotChatInput` is the input area of the chat. It renders the textarea, the send button, an optional tools menu, an add-file button, and the audio transcription controls. It has three modes: `"input"` (the default textarea), `"transcribe"` (records audio and shows transcription controls), and `"processing"` (disables the textarea and send button while the agent runs).
+
+This is the Angular equivalent of React's `<CopilotChatInput>`. When rendered inside [`CopilotChat`](/reference/angular/components/CopilotChat) or [`CopilotChatView`](/reference/angular/components/CopilotChatView), it reads the surrounding `ChatState` (through `injectChatState`) and wires submission, value changes, transcription, and file uploads to it automatically. Its outputs fire in addition to that built-in behavior, so you can observe interactions without disabling them.
+
+## Usage
+
+`CopilotChatInput` is a standalone component with the selector `copilot-chat-input`. Import the class into your component's `imports` array and use the element in the template.
+
+```ts title="src/app/chat.component.ts"
+import { Component } from "@angular/core";
+import { CopilotChatInput } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-chat",
+  standalone: true,
+  imports: [CopilotChatInput],
+  template: `
+    <copilot-chat-input
+      [autoFocus]="true"
+      (submitMessage)="onSubmit($event)"
+    />
+  `,
+})
+export class ChatComponent {
+  onSubmit(value: string) {
+    console.log("user submitted:", value);
+  }
+}
+```
+
+## Inputs
+
+### Behavior inputs
+
+<PropertyReference name="mode" type='"input" | "transcribe" | "processing"'>
+  Initial input mode. The component manages transitions between these modes during audio transcription. When omitted, the input starts in `"input"` mode.
+</PropertyReference>
+
+<PropertyReference name="toolsMenu" type='(ToolsMenuItem | "-")[]'>
+  Items for the input's tools menu. Each `ToolsMenuItem` has a `label` and either an `action` callback or nested `items`. Use the string `"-"` for a separator. When empty, the tools menu is hidden unless the add-file action is available.
+</PropertyReference>
+
+<PropertyReference name="autoFocus" type="boolean" default="true">
+  Whether the textarea focuses automatically after the view initializes. Defaults to `true` when omitted.
+</PropertyReference>
+
+<PropertyReference name="value" type="string">
+  Controlled value for the textarea. When provided, it takes precedence over the value held in the surrounding `ChatState`.
+</PropertyReference>
+
+<PropertyReference name="inputClass" type="string">
+  Class applied to the internal input wrapper. Prefer the host `class` for styling the component itself.
+</PropertyReference>
+
+<PropertyReference name="additionalToolbarItems" type="TemplateRef<any>">
+  A template rendered after the leading toolbar items, for adding your own controls to the toolbar.
+</PropertyReference>
+
+### Textarea inputs
+
+<PropertyReference name="textAreaClass" type="string">
+  Class applied to the default textarea.
+</PropertyReference>
+
+<PropertyReference name="textAreaMaxRows" type="number">
+  Maximum number of rows the textarea grows to before scrolling.
+</PropertyReference>
+
+<PropertyReference name="textAreaPlaceholder" type="string">
+  Placeholder text for the textarea.
+</PropertyReference>
+
+### Slot override inputs
+
+Each interactive piece can be replaced with a component class (`*Component`) and styled with a class (`*Class`). Templates for the same slots are read from content projection (see Slots below).
+
+<PropertyReference name="sendButtonComponent" type="Type<any>">
+  Component class for the send button. Style the default with `sendButtonClass`.
+</PropertyReference>
+
+<PropertyReference name="toolbarComponent" type="Type<any>">
+  Component class for the toolbar. Style the default with `toolbarClass`.
+</PropertyReference>
+
+<PropertyReference name="textAreaComponent" type="Type<any>">
+  Component class for the textarea.
+</PropertyReference>
+
+<PropertyReference name="audioRecorderComponent" type="Type<any>">
+  Component class for the audio recorder shown in transcribe mode. Style the default with `audioRecorderClass`.
+</PropertyReference>
+
+<PropertyReference name="startTranscribeButtonComponent" type="Type<any>">
+  Component class for the start-transcribe button. Style the default with `startTranscribeButtonClass`.
+</PropertyReference>
+
+<PropertyReference name="cancelTranscribeButtonComponent" type="Type<any>">
+  Component class for the cancel-transcribe button. Style the default with `cancelTranscribeButtonClass`.
+</PropertyReference>
+
+<PropertyReference name="finishTranscribeButtonComponent" type="Type<any>">
+  Component class for the finish-transcribe button. Style the default with `finishTranscribeButtonClass`.
+</PropertyReference>
+
+<PropertyReference name="addFileButtonComponent" type="Type<any>">
+  Component class for the add-file button. Style the default with `addFileButtonClass`.
+</PropertyReference>
+
+<PropertyReference name="toolsButtonComponent" type="Type<any>">
+  Component class for the tools menu button. Style the default with `toolsButtonClass`.
+</PropertyReference>
+
+## Outputs
+
+These events fire in addition to the input's built-in handling, so you can observe interactions without replacing default behavior.
+
+<PropertyReference name="submitMessage" type="string">
+  Emitted with the trimmed message text when the user sends a message (Enter without Shift, or the send button).
+</PropertyReference>
+
+<PropertyReference name="valueChange" type="string">
+  Emitted whenever the textarea value changes.
+</PropertyReference>
+
+<PropertyReference name="startTranscribe" type="void">
+  Emitted when audio transcription starts (the input switches to transcribe mode).
+</PropertyReference>
+
+<PropertyReference name="cancelTranscribe" type="void">
+  Emitted when audio transcription is cancelled (the input returns to input mode).
+</PropertyReference>
+
+<PropertyReference name="finishTranscribe" type="void">
+  Emitted when audio transcription finishes (the input returns to input mode).
+</PropertyReference>
+
+<PropertyReference name="finishTranscribeWithAudio" type="Blob">
+  Emitted with the recorded audio blob when transcription finishes with a recording. The blob is also handed to the surrounding `ChatState` for transcription.
+</PropertyReference>
+
+<PropertyReference name="addFile" type="void">
+  Emitted when the add-file action is triggered. Only active when attachments are enabled in the surrounding chat.
+</PropertyReference>
+
+## Slots
+
+For deep customization, provide named `<ng-template>` elements inside `<copilot-chat-input>`. Each is read with `contentChild` and takes precedence over the corresponding `*Component` input. The send button and toolbar templates receive a typed context.
+
+<PropertyReference name="sendButton" type="TemplateRef<SendButtonContext>">
+  Custom send button. Context: `send: () => void`, `disabled: boolean`, `value: string`.
+</PropertyReference>
+
+<PropertyReference name="toolbar" type="TemplateRef<ToolbarContext>">
+  Custom toolbar. Context: `mode: CopilotChatInputMode`, `value: string`.
+</PropertyReference>
+
+<PropertyReference name="textArea" type="TemplateRef<any>">
+  Custom textarea.
+</PropertyReference>
+
+<PropertyReference name="audioRecorder" type="TemplateRef<any>">
+  Custom audio recorder for transcribe mode.
+</PropertyReference>
+
+<PropertyReference name="startTranscribeButton" type="TemplateRef<any>">
+  Custom start-transcribe button.
+</PropertyReference>
+
+<PropertyReference name="cancelTranscribeButton" type="TemplateRef<any>">
+  Custom cancel-transcribe button.
+</PropertyReference>
+
+<PropertyReference name="finishTranscribeButton" type="TemplateRef<any>">
+  Custom finish-transcribe button.
+</PropertyReference>
+
+<PropertyReference name="addFileButton" type="TemplateRef<any>">
+  Custom add-file button.
+</PropertyReference>
+
+<PropertyReference name="toolsButton" type="TemplateRef<any>">
+  Custom tools menu button.
+</PropertyReference>
+
+### Tools menu example
+
+```ts title="src/app/chat.component.ts"
+import { Component } from "@angular/core";
+import { CopilotChatInput } from "@copilotkit/angular";
+import type { ToolsMenuItem } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-chat",
+  standalone: true,
+  imports: [CopilotChatInput],
+  template: `
+    <copilot-chat-input [toolsMenu]="toolsMenu" />
+  `,
+})
+export class ChatComponent {
+  toolsMenu: (ToolsMenuItem | "-")[] = [
+    { label: "Summarize", action: () => this.summarize() },
+    "-",
+    { label: "Translate", action: () => this.translate() },
+  ];
+
+  summarize() {}
+  translate() {}
+}
+```
+
+## Related
+
+<Cards>
+  <Card
+    title="CopilotChat"
+    description="The all-in-one component that wires an agent and renders this input through the chat view."
+    href="/reference/angular/components/CopilotChat"
+  />
+  <Card
+    title="CopilotChatView"
+    description="The layout-only chat view that renders this input by default."
+    href="/reference/angular/components/CopilotChatView"
+  />
+  <Card
+    title="provideCopilotKit"
+    description="Configures the runtime connection and agents that power the chat."
+    href="/reference/angular/functions/provideCopilotKit"
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/components/CopilotChatMessageView.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/components/CopilotChatMessageView.mdx
@@ -1,0 +1,200 @@
+---
+title: "CopilotChatMessageView"
+description: "Angular standalone component that renders a list of chat messages, routing each message to assistant, user, reasoning, or activity rendering with slot customization."
+---
+
+## Overview
+
+`CopilotChatMessageView` renders an array of messages and routes each one to the correct renderer based on its `role`: assistant messages go to [`CopilotChatAssistantMessage`](/reference/angular/components/CopilotChatAssistantMessage), user messages to [`CopilotChatUserMessage`](/reference/angular/components/CopilotChatUserMessage), reasoning messages to the reasoning renderer, and activity messages to any registered activity renderer. It optionally renders a typing cursor at the end of the list while the agent is streaming.
+
+This is the message-list layer used internally by [`CopilotChatView`](/reference/angular/components/CopilotChatView). It mirrors React's `CopilotChatMessageView`. Use it directly when you manage your own `messages` array and want only the list rendering without the surrounding scroll container and input.
+
+The component is standalone and uses `OnPush` change detection. Reactive inputs are Angular [signals](https://angular.dev/guide/signals).
+
+## Usage
+
+Import the component class and use its `copilot-chat-message-view` selector in your template.
+
+```ts title="src/app/messages.component.ts"
+import { Component, signal } from "@angular/core";
+import { CopilotChatMessageView } from "@copilotkit/angular";
+import type { Message } from "@ag-ui/core";
+
+@Component({
+  selector: "app-messages",
+  standalone: true,
+  imports: [CopilotChatMessageView],
+  template: `
+    <copilot-chat-message-view
+      [messages]="messages()"
+      [showCursor]="isLoading()"
+      [isLoading]="isLoading()"
+    />
+  `,
+})
+export class MessagesComponent {
+  messages = signal<Message[]>([]);
+  isLoading = signal(false);
+}
+```
+
+## Inputs
+
+<PropertyReference name="messages" type="Message[]" default="[]">
+  The messages to render. Each entry is routed by its `role` (`assistant`, `user`, `reasoning`, or `activity`). Entries with any other role are skipped.
+</PropertyReference>
+
+<PropertyReference name="showCursor" type="boolean" default="false">
+  Whether to show the typing cursor at the end of the list. The cursor is suppressed when the last message is a reasoning message.
+</PropertyReference>
+
+<PropertyReference name="isLoading" type="boolean" default="false">
+  Whether the agent is currently streaming. Forwarded to assistant, reasoning, and activity renderers so they can show in-progress state.
+</PropertyReference>
+
+<PropertyReference name="inputClass" type="string">
+  Extra CSS classes merged onto the default list container (`flex flex-col`).
+</PropertyReference>
+
+<PropertyReference name="agentId" type="string">
+  ID of the agent whose messages are being rendered. Used to resolve the matching activity-message renderer and the agent instance passed to it.
+</PropertyReference>
+
+### Assistant message slot inputs
+
+<PropertyReference name="assistantMessageComponent" type="Type<any>">
+  A component class to render each assistant message in place of the default [`CopilotChatAssistantMessage`](/reference/angular/components/CopilotChatAssistantMessage).
+</PropertyReference>
+
+<PropertyReference name="assistantMessageTemplate" type="TemplateRef<any>">
+  A template to render each assistant message. Takes precedence over `assistantMessageComponent` when both are set.
+</PropertyReference>
+
+<PropertyReference name="assistantMessageClass" type="string">
+  Extra CSS classes forwarded to each assistant message renderer.
+</PropertyReference>
+
+### User message slot inputs
+
+<PropertyReference name="userMessageComponent" type="Type<any>">
+  A component class to render each user message in place of the default [`CopilotChatUserMessage`](/reference/angular/components/CopilotChatUserMessage).
+</PropertyReference>
+
+<PropertyReference name="userMessageTemplate" type="TemplateRef<any>">
+  A template to render each user message. Takes precedence over `userMessageComponent` when both are set.
+</PropertyReference>
+
+<PropertyReference name="userMessageClass" type="string">
+  Extra CSS classes forwarded to each user message renderer.
+</PropertyReference>
+
+### Cursor slot inputs
+
+<PropertyReference name="cursorComponent" type="Type<any>">
+  A component class to render the typing cursor in place of the default cursor.
+</PropertyReference>
+
+<PropertyReference name="cursorTemplate" type="TemplateRef<any>">
+  A template to render the typing cursor. Takes precedence over `cursorComponent` when both are set.
+</PropertyReference>
+
+<PropertyReference name="cursorClass" type="string">
+  Extra CSS classes forwarded to the cursor renderer.
+</PropertyReference>
+
+## Outputs
+
+These bubble up from the per-message child components so you can observe toolbar interactions from the list level. Each payload is `{ message: Message }`.
+
+<PropertyReference name="assistantMessageThumbsUp" type="{ message: Message }">
+  Emitted when the thumbs-up action is triggered on an assistant message.
+</PropertyReference>
+
+<PropertyReference name="assistantMessageThumbsDown" type="{ message: Message }">
+  Emitted when the thumbs-down action is triggered on an assistant message.
+</PropertyReference>
+
+<PropertyReference name="assistantMessageReadAloud" type="{ message: Message }">
+  Emitted when the read-aloud action is triggered on an assistant message.
+</PropertyReference>
+
+<PropertyReference name="assistantMessageRegenerate" type="{ message: Message }">
+  Emitted when the regenerate action is triggered on an assistant message.
+</PropertyReference>
+
+<PropertyReference name="userMessageCopy" type="{ message: Message }">
+  Emitted when a user message is copied.
+</PropertyReference>
+
+<PropertyReference name="userMessageEdit" type="{ message: Message }">
+  Emitted when a user message edit action is triggered.
+</PropertyReference>
+
+## Custom layout
+
+For full control over how the list is laid out, project a template named `customLayout`. It receives a context object with the current `messages`, the `isLoading` and `showCursor` flags, and `messageElements` (the messages filtered to the renderable roles). When this template is present, the default list rendering is replaced entirely.
+
+```html title="src/app/messages.component.html"
+<copilot-chat-message-view [messages]="messages()" [showCursor]="isLoading()">
+  <ng-template #customLayout let-messages="messages" let-showCursor="showCursor">
+    <div class="my-list">
+      @for (message of messages; track message.id) {
+        <div class="my-row">{{ message.content }}</div>
+      }
+      @if (showCursor) {
+        <span class="my-cursor">...</span>
+      }
+    </div>
+  </ng-template>
+</copilot-chat-message-view>
+```
+
+## Customizing message rendering
+
+To swap out how a whole role is rendered without rebuilding the layout, pass a slot input. The slot accepts either a component class or a template, with the template taking precedence.
+
+```ts title="src/app/messages.component.ts"
+import { Component, signal } from "@angular/core";
+import { CopilotChatMessageView } from "@copilotkit/angular";
+import { MyAssistantMessage } from "./my-assistant-message.component";
+import type { Message } from "@ag-ui/core";
+
+@Component({
+  selector: "app-messages",
+  standalone: true,
+  imports: [CopilotChatMessageView],
+  template: `
+    <copilot-chat-message-view
+      [messages]="messages()"
+      [assistantMessageComponent]="assistantMessage"
+    />
+  `,
+})
+export class MessagesComponent {
+  messages = signal<Message[]>([]);
+  protected readonly assistantMessage = MyAssistantMessage;
+}
+```
+
+## Related
+
+<Cards>
+  <Card
+    title="CopilotChatAssistantMessage"
+    description="Renders a single assistant message with markdown content, a toolbar, and tool calls."
+    href="/reference/angular/components/CopilotChatAssistantMessage"
+    icon={<LinkIcon />}
+  />
+  <Card
+    title="CopilotChatUserMessage"
+    description="Renders a single user message with copy, edit, and branch navigation."
+    href="/reference/angular/components/CopilotChatUserMessage"
+    icon={<LinkIcon />}
+  />
+  <Card
+    title="CopilotChatView"
+    description="The full chat layout: scroll container, message view, and input."
+    href="/reference/angular/components/CopilotChatView"
+    icon={<LinkIcon />}
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/components/CopilotChatUserMessage.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/components/CopilotChatUserMessage.mdx
@@ -1,0 +1,168 @@
+---
+title: "CopilotChatUserMessage"
+description: "Angular standalone component that renders a single user message with attachments, copy and edit actions, and branch navigation."
+---
+
+## Overview
+
+`CopilotChatUserMessage` renders one user message. It shows any image or file attachments, renders the message text through a renderer, and shows a toolbar with copy and edit actions. When the message belongs to a set of regenerated branches, a branch navigation control lets you step between them. It mirrors React's `CopilotChatUserMessage`.
+
+The copy and edit buttons always render. The branch navigation control renders only when `numberOfBranches` is greater than 1.
+
+The component is standalone and uses `OnPush` change detection. Reactive inputs are Angular [signals](https://angular.dev/guide/signals).
+
+## Usage
+
+Import the component class and use its `copilot-chat-user-message` selector.
+
+```ts title="src/app/user-message.component.ts"
+import { Component, signal } from "@angular/core";
+import { CopilotChatUserMessage } from "@copilotkit/angular";
+import type { UserMessage } from "@ag-ui/core";
+
+@Component({
+  selector: "app-user-message",
+  standalone: true,
+  imports: [CopilotChatUserMessage],
+  template: `
+    <copilot-chat-user-message
+      [message]="message()"
+      (editMessage)="onEdit($event)"
+    />
+  `,
+})
+export class UserMessageComponent {
+  message = signal<UserMessage>({
+    id: "1",
+    role: "user",
+    content: "What is the weather today?",
+  });
+
+  onEdit(event: { message: UserMessage }) {
+    console.log("edit", event.message.id);
+  }
+}
+```
+
+## Inputs
+
+<PropertyReference name="message" type="UserMessage">
+  The user message to render. Its content is flattened to text for the renderer, and any media parts are shown as attachments above it.
+</PropertyReference>
+
+<PropertyReference name="branchIndex" type="number" default="0">
+  Zero-based index of the currently shown branch. Used by the branch navigation control.
+</PropertyReference>
+
+<PropertyReference name="numberOfBranches" type="number" default="1">
+  Total number of regenerated branches for this message. Branch navigation renders only when this is greater than 1.
+</PropertyReference>
+
+<PropertyReference name="additionalToolbarItems" type="TemplateRef<any>">
+  A template prepended to the default toolbar, before the copy and edit buttons.
+</PropertyReference>
+
+<PropertyReference name="inputClass" type="string">
+  Extra CSS classes merged onto the message container.
+</PropertyReference>
+
+### Slot class inputs
+
+Each of these passes extra CSS classes to the corresponding default sub-component.
+
+<PropertyReference name="messageRendererClass" type="string">
+  Classes for the default message renderer.
+</PropertyReference>
+
+<PropertyReference name="toolbarClass" type="string">
+  Classes for the default toolbar.
+</PropertyReference>
+
+<PropertyReference name="copyButtonClass" type="string">
+  Classes for the default copy button.
+</PropertyReference>
+
+<PropertyReference name="editButtonClass" type="string">
+  Classes for the default edit button.
+</PropertyReference>
+
+<PropertyReference name="branchNavigationClass" type="string">
+  Classes for the default branch navigation control.
+</PropertyReference>
+
+### Slot component inputs
+
+Each of these replaces the corresponding default sub-component with a component class of your own. Content-projection templates (see below) take precedence over these.
+
+<PropertyReference name="messageRendererComponent" type="Type<any>">
+  Replaces the default message renderer.
+</PropertyReference>
+
+<PropertyReference name="toolbarComponent" type="Type<any>">
+  Replaces the default toolbar.
+</PropertyReference>
+
+<PropertyReference name="copyButtonComponent" type="Type<any>">
+  Replaces the default copy button.
+</PropertyReference>
+
+<PropertyReference name="editButtonComponent" type="Type<any>">
+  Replaces the default edit button.
+</PropertyReference>
+
+<PropertyReference name="branchNavigationComponent" type="Type<any>">
+  Replaces the default branch navigation control.
+</PropertyReference>
+
+## Outputs
+
+<PropertyReference name="editMessage" type="CopilotChatUserMessageOnEditMessageProps">
+  Emitted when the edit button is clicked. The payload is `{ message: UserMessage }`.
+</PropertyReference>
+
+<PropertyReference name="switchToBranch" type="CopilotChatUserMessageOnSwitchToBranchProps">
+  Emitted when a different branch is selected through the branch navigation control. The payload is `{ message: UserMessage; branchIndex: number; numberOfBranches: number }`.
+</PropertyReference>
+
+## Slots and content projection
+
+You can override any piece of the message by projecting a named template. A projected template takes precedence over the matching `*Component` input. Each template receives a typed context object.
+
+| Template name | Context type | Replaces |
+| --- | --- | --- |
+| `messageRenderer` | `MessageRendererContext` (`{ content: string }`) | The message text renderer |
+| `toolbar` | `UserMessageToolbarContext` (`{ children?: any }`) | The whole toolbar |
+| `copyButton` | `CopyButtonContext` (`{ content?: string; copied?: boolean }`) | The copy button |
+| `editButton` | `EditButtonContext` (empty; click via outputs) | The edit button |
+| `branchNavigation` | `BranchNavigationContext` (`{ currentBranch, numberOfBranches, onSwitchToBranch?, message }`) | The branch navigation control |
+
+```html title="src/app/user-message.component.html"
+<copilot-chat-user-message [message]="message()">
+  <ng-template #messageRenderer let-content="content">
+    <p class="my-user-text">{{ content }}</p>
+  </ng-template>
+</copilot-chat-user-message>
+```
+
+## Related
+
+<Cards>
+  <Card
+    title="CopilotChatMessageView"
+    description="Renders a list of messages, routing each to assistant, user, reasoning, or activity rendering."
+    href="/reference/angular/components/CopilotChatMessageView"
+    icon={<LinkIcon />}
+  />
+  <Card
+    title="CopilotChatAssistantMessage"
+    description="Renders a single assistant message with markdown content, a toolbar, and tool calls."
+    href="/reference/angular/components/CopilotChatAssistantMessage"
+    icon={<LinkIcon />}
+  />
+  <Card
+    title="CopilotChatView"
+    description="The full chat layout: scroll container, message view, and input."
+    href="/reference/angular/components/CopilotChatView"
+    icon={<LinkIcon />}
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/components/CopilotChatView.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/components/CopilotChatView.mdx
@@ -1,0 +1,265 @@
+---
+title: "CopilotChatView"
+description: "Angular standalone component that renders the chat layout (message feed and input) without agent wiring, the @copilotkit/angular equivalent of React's CopilotChatView"
+---
+
+## Overview
+
+`CopilotChatView` is the layout-only chat view. It renders the message feed, the input container, the feather effect, the disclaimer, the suggestion pills, and a welcome screen when there are no messages. It does not wire an agent on its own. You pass it `messages` and read interaction handlers from the surrounding `ChatState`.
+
+This is the Angular equivalent of React's `<CopilotChatView>`. Contrast it with [`CopilotChat`](/reference/angular/components/CopilotChat): `CopilotChat` wires the agent (resolving messages, running state, suggestions, and submission) and renders `CopilotChatView` underneath, while `CopilotChatView` is presentational. Use it directly when you manage messages and handlers yourself, or when you need deep control over the layout and its slots.
+
+Almost every visual piece is a slot. Each slot accepts either a component class (`*Component`) or an Angular template (`*Template`), plus an optional class string (`*Class`).
+
+## Usage
+
+`CopilotChatView` is a standalone component with the selector `copilot-chat-view`. Import the class into your component's `imports` array and use the element in the template.
+
+```ts title="src/app/chat.component.ts"
+import { Component, signal } from "@angular/core";
+import { CopilotChatView } from "@copilotkit/angular";
+import type { Message } from "@ag-ui/client";
+
+@Component({
+  selector: "app-chat",
+  standalone: true,
+  imports: [CopilotChatView],
+  template: `
+    <copilot-chat-view [messages]="messages()" [autoScroll]="true" />
+  `,
+})
+export class ChatComponent {
+  messages = signal<Message[]>([]);
+}
+```
+
+## Inputs
+
+### Core inputs
+
+<PropertyReference name="messages" type="Message[]" default="[]">
+  The messages to render in the feed. When empty (and no explicit thread is selected), the welcome screen is shown instead.
+</PropertyReference>
+
+<PropertyReference name="agentId" type="string">
+  ID of the agent whose messages are being rendered. Forwarded to the scroll view for per-agent rendering.
+</PropertyReference>
+
+<PropertyReference name="autoScroll" type="boolean" default="true">
+  Whether the feed sticks to the bottom as new messages stream in.
+</PropertyReference>
+
+<PropertyReference name="showCursor" type="boolean" default="false">
+  Whether to show a streaming cursor at the end of the feed while the agent is responding.
+</PropertyReference>
+
+<PropertyReference name="hasExplicitThreadId" type="boolean" default="false">
+  Whether an explicit thread id was provided. When true, the welcome screen is suppressed even with no messages (the conversation is being resumed).
+</PropertyReference>
+
+### Slot inputs
+
+Each visual region exposes a component override, a template override, and a class. The template takes precedence over the component when both are set.
+
+<PropertyReference name="messageViewComponent" type="Type<any>">
+  Component class to render the message list. Pair with `messageViewClass` to style it, or use `messageViewTemplate` for a template.
+</PropertyReference>
+
+<PropertyReference name="messageViewTemplate" type="TemplateRef<any>">
+  Template to render the message list.
+</PropertyReference>
+
+<PropertyReference name="messageViewClass" type="string">
+  Class applied to the message list.
+</PropertyReference>
+
+<PropertyReference name="scrollViewComponent" type="Type<any>">
+  Component class for the scrolling container around the message list.
+</PropertyReference>
+
+<PropertyReference name="scrollViewTemplate" type="TemplateRef<any>">
+  Template for the scrolling container.
+</PropertyReference>
+
+<PropertyReference name="scrollViewClass" type="string">
+  Class applied to the scrolling container.
+</PropertyReference>
+
+<PropertyReference name="scrollToBottomButtonComponent" type="Type<any>">
+  Component class for the scroll-to-bottom button.
+</PropertyReference>
+
+<PropertyReference name="scrollToBottomButtonTemplate" type="TemplateRef<any>">
+  Template for the scroll-to-bottom button.
+</PropertyReference>
+
+<PropertyReference name="scrollToBottomButtonClass" type="string">
+  Class applied to the scroll-to-bottom button.
+</PropertyReference>
+
+<PropertyReference name="inputComponent" type="Type<any>">
+  Component class for the chat input. Defaults to [`CopilotChatInput`](/reference/angular/components/CopilotChatInput).
+</PropertyReference>
+
+<PropertyReference name="inputTemplate" type="TemplateRef<any>">
+  Template for the chat input.
+</PropertyReference>
+
+<PropertyReference name="inputContainerComponent" type="Type<any>">
+  Component class for the container that wraps the input and disclaimer.
+</PropertyReference>
+
+<PropertyReference name="inputContainerTemplate" type="TemplateRef<any>">
+  Template for the input container.
+</PropertyReference>
+
+<PropertyReference name="inputContainerClass" type="string">
+  Class applied to the input container.
+</PropertyReference>
+
+<PropertyReference name="featherComponent" type="Type<any>">
+  Component class for the feather (fade) effect above the input.
+</PropertyReference>
+
+<PropertyReference name="featherTemplate" type="TemplateRef<any>">
+  Template for the feather effect.
+</PropertyReference>
+
+<PropertyReference name="featherClass" type="string">
+  Class applied to the feather effect.
+</PropertyReference>
+
+<PropertyReference name="disclaimerComponent" type="Type<any>">
+  Component class for the disclaimer shown beneath the input.
+</PropertyReference>
+
+<PropertyReference name="disclaimerTemplate" type="TemplateRef<any>">
+  Template for the disclaimer.
+</PropertyReference>
+
+<PropertyReference name="disclaimerClass" type="string">
+  Class applied to the disclaimer.
+</PropertyReference>
+
+<PropertyReference name="disclaimerText" type="string">
+  Text content for the disclaimer.
+</PropertyReference>
+
+## Outputs
+
+`CopilotChatView` bubbles message-level interaction events from the message feed. Each payload is an object with the relevant `message`.
+
+<PropertyReference name="assistantMessageThumbsUp" type="{ message: Message }">
+  Emitted when the thumbs-up action is triggered on an assistant message.
+</PropertyReference>
+
+<PropertyReference name="assistantMessageThumbsDown" type="{ message: Message }">
+  Emitted when the thumbs-down action is triggered on an assistant message.
+</PropertyReference>
+
+<PropertyReference name="assistantMessageReadAloud" type="{ message: Message }">
+  Emitted when the read-aloud action is triggered on an assistant message.
+</PropertyReference>
+
+<PropertyReference name="assistantMessageRegenerate" type="{ message: Message }">
+  Emitted when the regenerate action is triggered on an assistant message.
+</PropertyReference>
+
+<PropertyReference name="userMessageCopy" type="{ message: Message }">
+  Emitted when the copy action is triggered on a user message.
+</PropertyReference>
+
+<PropertyReference name="userMessageEdit" type="{ message: Message }">
+  Emitted when the edit action is triggered on a user message.
+</PropertyReference>
+
+## Content projection
+
+Beyond the slot inputs, `CopilotChatView` reads named templates from content projection (via `@ContentChild`) for deep customization. Provide them as `<ng-template>` elements with the matching reference variable inside `<copilot-chat-view>`.
+
+<PropertyReference name="customLayout" type="TemplateRef<CopilotChatViewLayoutContext>">
+  Replaces the entire default layout (render-prop pattern). Receives a context object with the resolved slots: `messageView`, `input`, `scrollView`, `scrollToBottomButton`, `feather`, `inputContainer`, and `disclaimer`.
+</PropertyReference>
+
+<PropertyReference name="sendButton" type="TemplateRef<any>">
+  Custom send button passed down to the input.
+</PropertyReference>
+
+<PropertyReference name="toolbar" type="TemplateRef<any>">
+  Custom input toolbar.
+</PropertyReference>
+
+<PropertyReference name="textArea" type="TemplateRef<any>">
+  Custom textarea for the input.
+</PropertyReference>
+
+<PropertyReference name="audioRecorder" type="TemplateRef<any>">
+  Custom audio recorder for transcription mode.
+</PropertyReference>
+
+<PropertyReference name="assistantMessageMarkdownRenderer" type="TemplateRef<any>">
+  Custom markdown renderer for assistant messages.
+</PropertyReference>
+
+<PropertyReference name="thumbsUpButton" type="TemplateRef<any>">
+  Custom thumbs-up button on assistant messages.
+</PropertyReference>
+
+<PropertyReference name="thumbsDownButton" type="TemplateRef<any>">
+  Custom thumbs-down button on assistant messages.
+</PropertyReference>
+
+<PropertyReference name="readAloudButton" type="TemplateRef<any>">
+  Custom read-aloud button on assistant messages.
+</PropertyReference>
+
+<PropertyReference name="regenerateButton" type="TemplateRef<any>">
+  Custom regenerate button on assistant messages.
+</PropertyReference>
+
+### Custom layout example
+
+```ts title="src/app/chat.component.ts"
+import { Component, signal } from "@angular/core";
+import { CopilotChatView } from "@copilotkit/angular";
+import type { Message } from "@ag-ui/client";
+
+@Component({
+  selector: "app-chat",
+  standalone: true,
+  imports: [CopilotChatView],
+  template: `
+    <copilot-chat-view [messages]="messages()">
+      <ng-template #customLayout let-ctx>
+        <div class="my-layout">
+          <ng-container [ngTemplateOutlet]="ctx.messageView" />
+          <ng-container [ngTemplateOutlet]="ctx.input" />
+        </div>
+      </ng-template>
+    </copilot-chat-view>
+  `,
+})
+export class ChatComponent {
+  messages = signal<Message[]>([]);
+}
+```
+
+## Related
+
+<Cards>
+  <Card
+    title="CopilotChat"
+    description="The all-in-one component that wires an agent and renders this view."
+    href="/reference/angular/components/CopilotChat"
+  />
+  <Card
+    title="CopilotChatInput"
+    description="The default input rendered inside the view: textarea, send, tools menu, file upload, and transcription."
+    href="/reference/angular/components/CopilotChatInput"
+  />
+  <Card
+    title="provideCopilotKit"
+    description="Configures the runtime connection and agents that power the chat."
+    href="/reference/angular/functions/provideCopilotKit"
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/directives/CopilotKitAgentContext.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/directives/CopilotKitAgentContext.mdx
@@ -1,0 +1,118 @@
+---
+title: "CopilotKitAgentContext"
+description: "Angular standalone directive that shares application state with the agent as context from a template for @copilotkit/angular."
+---
+
+## Overview
+
+`CopilotKitAgentContext` is a standalone Angular directive that shares a piece of [context](https://docs.ag-ui.com/concepts/context) with the agent from your template. Apply it to any element. It adds the context when the element initializes, updates it when its inputs change, and removes it when the element is destroyed.
+
+You can supply the context either as a single object via the directive selector input, or as separate `description` and `value` inputs. The context object takes precedence when both are provided.
+
+This is the template-based equivalent of the [`connectAgentContext`](/reference/angular/functions/connectAgentContext) function, which mirrors React's `useAgentContext()`.
+
+## Import
+
+The directive is standalone. Import the class into your component's `imports` array, then use the `copilotkitAgentContext` attribute selector in the template.
+
+```ts title="src/app/profile.component.ts"
+import { Component } from "@angular/core";
+import { CopilotKitAgentContext } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-profile",
+  standalone: true,
+  imports: [CopilotKitAgentContext],
+  template: `
+    <div copilotkitAgentContext
+         description="User profile"
+         [value]="profile">
+    </div>
+  `,
+})
+export class ProfileComponent {
+  profile = { name: "Ada", plan: "pro" };
+}
+```
+
+## Selector
+
+```
+[copilotkitAgentContext]
+```
+
+It is an attribute directive, so apply it to any element.
+
+## Inputs
+
+<PropertyReference name="copilotkitAgentContext" type="Context">
+  A complete context object containing both `description` and `value`. This is the directive's selector input (`[copilotkitAgentContext]="..."`). When provided, it takes precedence over the separate `description` and `value` inputs. A `Context` has the shape `{ description: string; value: string }`.
+</PropertyReference>
+
+<PropertyReference name="description" type="string">
+  A human-readable description of what this context represents. Used to build the context object when the `copilotkitAgentContext` object input is not provided. The context is only registered when both `description` and `value` are set.
+</PropertyReference>
+
+<PropertyReference name="value" type="any">
+  The context value. Used together with `description` to build the context object when the `copilotkitAgentContext` object input is not provided. The context is only registered when both `description` and `value` are set.
+</PropertyReference>
+
+## Usage
+
+### Separate inputs
+
+```html
+<div copilotkitAgentContext
+     description="User preferences"
+     [value]="userSettings">
+</div>
+```
+
+### Context object
+
+Pass a complete `{ description, value }` object through the selector input.
+
+```html
+<div [copilotkitAgentContext]="contextObject"></div>
+```
+
+### Dynamic values
+
+The directive re-registers the context whenever its inputs change, so binding a dynamic value keeps the agent in sync.
+
+```html
+<div copilotkitAgentContext
+     description="Form state"
+     [value]="formData$ | async">
+</div>
+```
+
+## Behavior
+
+- **Adds on init.** The context is registered with the agent in `ngOnInit`.
+- **Updates on change.** When `copilotkitAgentContext`, `description`, or `value` change, the directive removes the previous context and adds the new one. The first change is handled by init, so it is not double-registered.
+- **Removes on destroy.** The context is removed when the host element is destroyed.
+- **Object input precedence.** When the `copilotkitAgentContext` object input is set, it is used and the separate `description` and `value` inputs are ignored. Otherwise, the context is built from `description` and `value`, and is only registered when both are set.
+
+## Related
+
+<Cards>
+  <Card
+    title="connectAgentContext"
+    description="Share context with the agent from a function instead of a template."
+    href="/reference/angular/functions/connectAgentContext"
+    icon={<LinkIcon />}
+  />
+  <Card
+    title="injectAgentStore"
+    description="Subscribe to an agent and read its messages, state, and run status."
+    href="/reference/angular/functions/injectAgentStore"
+    icon={<LinkIcon />}
+  />
+  <Card
+    title="CopilotKit service"
+    description="The central handle on agents, tools, and the runtime connection."
+    href="/reference/angular/services/CopilotKit"
+    icon={<LinkIcon />}
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/functions/connectAgentContext.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/connectAgentContext.mdx
@@ -1,0 +1,158 @@
+---
+title: "connectAgentContext"
+description: "Angular function that adds reactive context for the agent and cleans it up automatically for @copilotkit/angular."
+---
+
+## Overview
+
+`connectAgentContext` registers a piece of [context](https://docs.ag-ui.com/concepts/context) with the agent so the agent can read your application state. It accepts a static `Context` object or a `Signal<Context>`. When you pass a signal, the registered context updates reactively as the signal changes, and the previous context is removed and the new one added.
+
+The registration is wrapped in an Angular `effect`, so the context is cleaned up automatically when the owning component or service is destroyed.
+
+This is the function-based equivalent of React's `useAgentContext()`. For a template-driven alternative, use the [`CopilotKitAgentContext`](/reference/angular/directives/CopilotKitAgentContext) directive.
+
+<Callout type="warn">
+  Call this from an Angular injection context (a constructor or a field initializer). If you cannot, pass an `injector` in the config. If neither is available, it throws.
+</Callout>
+
+## Signature
+
+```ts
+import { connectAgentContext } from "@copilotkit/angular";
+import type { Signal, Injector } from "@angular/core";
+import type { Context } from "@ag-ui/client";
+
+interface ConnectAgentContextConfig {
+  injector?: Injector;
+}
+
+function connectAgentContext(
+  context: Context | Signal<Context>,
+  config?: ConnectAgentContextConfig,
+): void;
+```
+
+## Parameters
+
+<PropertyReference name="context" type="Context | Signal<Context>" required>
+  The context to share with the agent, or a signal of it. A `Context` is an object with the following fields. When you pass a `Signal<Context>`, the context re-registers whenever the signal value changes.
+
+  <PropertyReference name="description" type="string" required>
+    A human-readable description of what this context represents, for example `"User preferences"`.
+  </PropertyReference>
+
+  <PropertyReference name="value" type="string" required>
+    The context value. Stringify non-string values (for example with `JSON.stringify`) before passing them.
+  </PropertyReference>
+</PropertyReference>
+
+<PropertyReference name="config" type="ConnectAgentContextConfig">
+  Optional configuration.
+
+  <PropertyReference name="injector" type="Injector">
+    An explicit `Injector` to use when `connectAgentContext` is called outside an injection context. When omitted, the ambient injector is used. The injector also scopes the internal `effect`, so cleanup runs when that injector is destroyed.
+  </PropertyReference>
+</PropertyReference>
+
+## Usage
+
+### Static context
+
+```ts title="src/app/preferences.component.ts"
+import { Component } from "@angular/core";
+import { connectAgentContext } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-preferences",
+  standalone: true,
+  template: `<!-- ... -->`,
+})
+export class PreferencesComponent {
+  constructor() {
+    connectAgentContext({
+      description: "User preferences",
+      value: JSON.stringify({ theme: "dark", locale: "en-US" }),
+    });
+  }
+}
+```
+
+### Reactive context with a signal
+
+Pass a `Signal<Context>` so the agent always sees the current value.
+
+```ts title="src/app/cart.component.ts"
+import { Component, computed, signal } from "@angular/core";
+import { connectAgentContext } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-cart",
+  standalone: true,
+  template: `<button (click)="add()">Add item</button>`,
+})
+export class CartComponent {
+  readonly items = signal<string[]>([]);
+
+  // Re-registers with the agent whenever the cart changes.
+  readonly cartContext = connectAgentContext(
+    computed(() => ({
+      description: "Current shopping cart",
+      value: JSON.stringify(this.items()),
+    })),
+  );
+
+  add() {
+    this.items.update((items) => [...items, "Item"]);
+  }
+}
+```
+
+### Passing an explicit injector
+
+When you call `connectAgentContext` outside an injection context, pass an `injector`.
+
+```ts title="src/app/late-context.service.ts"
+import { inject, Injectable, Injector } from "@angular/core";
+import { connectAgentContext } from "@copilotkit/angular";
+
+@Injectable({ providedIn: "root" })
+export class LateContextService {
+  private readonly injector = inject(Injector);
+
+  register(value: string) {
+    connectAgentContext(
+      { description: "Late context", value },
+      { injector: this.injector },
+    );
+  }
+}
+```
+
+## Behavior
+
+- **Reactive updates.** When given a `Signal<Context>`, the context is removed and re-added whenever the signal value changes, so the agent always sees the current value.
+- **Automatic cleanup.** Registration runs inside an Angular `effect`; the context is removed when the effect is torn down, which happens when the owning component, service, or injector is destroyed.
+- **Injection context required.** Throws if called outside an injection context without an `injector` in the config.
+
+## Related
+
+<Cards>
+  <Card
+    title="CopilotKitAgentContext directive"
+    description="Share context with the agent from a template instead of a function."
+    href="/reference/angular/directives/CopilotKitAgentContext"
+    icon={<LinkIcon />}
+  />
+  <Card
+    title="injectAgentStore"
+    description="Subscribe to an agent and read its messages, state, and run status."
+    href="/reference/angular/functions/injectAgentStore"
+    icon={<LinkIcon />}
+  />
+  <Card
+    title="CopilotKit service"
+    description="The central handle on agents, tools, and the runtime connection."
+    href="/reference/angular/services/CopilotKit"
+    icon={<LinkIcon />}
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/functions/injectAgentStore.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/injectAgentStore.mdx
@@ -1,0 +1,158 @@
+---
+title: "injectAgentStore"
+description: "Angular function that subscribes to an AG-UI agent and returns a signal of reactive agent state (messages, state, isRunning) for @copilotkit/angular."
+---
+
+## Overview
+
+`injectAgentStore` subscribes to an [AG-UI agent](https://docs.ag-ui.com/sdk/js/client/abstract-agent) and returns an Angular `Signal<AgentStore>`. The `AgentStore` exposes the agent instance plus its reactive state (messages, shared state, and run status) as Angular signals, so your component re-renders automatically when the agent changes.
+
+Read the store by calling the outer signal, then read each member by calling its signal: `store().messages()`, `store().isRunning()`, `store().state()`. The `agent` member is the plain AG-UI instance (not a signal), so you read it directly: `store().agent`.
+
+This is the Angular equivalent of React's `useAgent()`. Call it from an injection context (a constructor or a field initializer). The subscription is torn down automatically when the owning component or service is destroyed.
+
+<Callout type="warn">
+  Resolution of the agent is lazy and reactive. If no agent can be resolved for the given `agentId` after the runtime has synced (for example, the id does not match any agent reported by your runtime `/info` or registered via `agents__unsafe_dev_only`), reading the store signal throws an error listing the known agents.
+</Callout>
+
+## Signature
+
+```ts
+import { injectAgentStore } from "@copilotkit/angular";
+import type { Signal } from "@angular/core";
+
+function injectAgentStore(
+  agentId: string | Signal<string | undefined>,
+): Signal<AgentStore>;
+```
+
+## Parameters
+
+<PropertyReference name="agentId" type="string | Signal<string | undefined>" required>
+  ID of the agent to subscribe to. Pass a plain string for a fixed agent, or a `Signal<string | undefined>` to switch agents reactively. When the resolved id is empty or `undefined`, the default agent id is used. The returned signal re-resolves whenever this id, the available agents, or the runtime connection status change.
+</PropertyReference>
+
+## Return Value
+
+<PropertyReference name="store" type="Signal<AgentStore>">
+  An Angular signal holding the current `AgentStore`. Calling it (`store()`) returns the live `AgentStore` instance, recomputing when the agent is re-resolved. Reading it also throws if the agent cannot be resolved (see the callout above).
+
+  The `AgentStore` exposes the following members:
+
+  <PropertyReference name="agent" type="AbstractAgent">
+    The underlying AG-UI agent instance. This is a plain reference, not a signal, so read it directly as `store().agent`. Use it to call agent methods such as `runAgent`, `setState`, `addMessage`, and `abortRun`. See the [AbstractAgent documentation](https://docs.ag-ui.com/sdk/js/client/abstract-agent) for the full interface.
+  </PropertyReference>
+
+  <PropertyReference name="messages" type="Signal<Message[]>">
+    A readonly signal of the agent's conversation messages. Read it with `store().messages()`. Each entry is an AG-UI `Message` with fields such as `id`, `role` (`"user" | "assistant" | "system" | "tool" | "developer"`), and `content`. Updates whenever the agent's messages change.
+  </PropertyReference>
+
+  <PropertyReference name="state" type="Signal<unknown>">
+    A readonly signal of the agent's shared state object, synchronized between your app and the agent. Read it with `store().state()`. It is `undefined` until the agent reports state. Cast or type it as needed for your agent's state shape.
+  </PropertyReference>
+
+  <PropertyReference name="isRunning" type="Signal<boolean>">
+    A readonly signal indicating whether the agent is currently executing. Read it with `store().isRunning()`. It becomes `true` when a run is initialized and `false` when the run finalizes, fails, or reports a protocol-level run error.
+  </PropertyReference>
+</PropertyReference>
+
+## Usage
+
+### Basic usage
+
+```ts title="src/app/agent-status.component.ts"
+import { Component } from "@angular/core";
+import { injectAgentStore } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-agent-status",
+  standalone: true,
+  template: `
+    <div>Messages: {{ store().messages().length }}</div>
+    <div>Running: {{ store().isRunning() ? "Yes" : "No" }}</div>
+  `,
+})
+export class AgentStatusComponent {
+  readonly store = injectAgentStore("default");
+}
+```
+
+### Reading and updating shared state
+
+Read the state via the signal, and write it through the agent instance.
+
+```ts title="src/app/theme-panel.component.ts"
+import { Component } from "@angular/core";
+import { injectAgentStore } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-theme-panel",
+  standalone: true,
+  template: `
+    <pre>{{ store().state() | json }}</pre>
+    <button (click)="setDark()">Dark theme</button>
+  `,
+})
+export class ThemePanelComponent {
+  readonly store = injectAgentStore("default");
+
+  setDark() {
+    const agent = this.store().agent;
+    agent.setState({ ...(agent.state as object), theme: "dark" });
+  }
+}
+```
+
+### Switching agents reactively
+
+Pass a signal so the store re-resolves when the selected agent id changes.
+
+```ts title="src/app/multi-agent.component.ts"
+import { Component, signal } from "@angular/core";
+import { injectAgentStore } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-multi-agent",
+  standalone: true,
+  template: `
+    <button (click)="agentId.set('support')">Support</button>
+    <button (click)="agentId.set('sales')">Sales</button>
+    <div>Active: {{ store().agent.agentId }}</div>
+    <div>Messages: {{ store().messages().length }}</div>
+  `,
+})
+export class MultiAgentComponent {
+  readonly agentId = signal<string | undefined>("support");
+  readonly store = injectAgentStore(this.agentId);
+}
+```
+
+## Behavior
+
+- **Reactive resolution.** The returned signal recomputes when the `agentId`, the set of available agents, the runtime connection status, the runtime URL or transport, or the request headers change.
+- **Provisional agents.** When a runtime is configured but not yet connected, a provisional proxied runtime agent is created and cached so the store has something to render before the runtime syncs.
+- **Automatic cleanup.** The agent subscription is unsubscribed when the owning component or service is destroyed. Switching to a new agent tears down the previous store's subscription first.
+- **Error on missing agent.** If no agent resolves after the runtime has synced, reading the store signal throws an error that lists the known agent ids.
+
+## Related
+
+<Cards>
+  <Card
+    title="connectAgentContext"
+    description="Share application state with the agent reactively from a function."
+    href="/reference/angular/functions/connectAgentContext"
+    icon={<LinkIcon />}
+  />
+  <Card
+    title="CopilotKit service"
+    description="The central handle on agents, tools, and the runtime connection."
+    href="/reference/angular/services/CopilotKit"
+    icon={<LinkIcon />}
+  />
+  <Card
+    title="AG-UI AbstractAgent"
+    description="Full agent interface: methods, messages, state, and subscriptions."
+    href="https://docs.ag-ui.com/sdk/js/client/abstract-agent"
+    icon={<LinkIcon />}
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/functions/injectChatLabels.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/injectChatLabels.mdx
@@ -1,0 +1,55 @@
+---
+title: "injectChatLabels"
+description: "Angular function that returns the CopilotKit chat labels, with provided overrides merged over the defaults"
+---
+
+## Overview
+
+`injectChatLabels` returns the full set of [`CopilotChatLabels`](/reference/angular/functions/provideCopilotChatLabels#parameters) in scope: any labels you provided through [`provideCopilotChatLabels`](/reference/angular/functions/provideCopilotChatLabels) merged over `COPILOT_CHAT_DEFAULT_LABELS`. If no labels were provided, it returns the defaults unchanged.
+
+It reads the `COPILOT_CHAT_LABELS` injection token (optionally), so it must run inside an Angular injection context (a constructor, a field initializer, or a factory). The prebuilt chat components call it internally; use it directly when you build your own chat UI and want the same configurable strings.
+
+## Signature
+
+```ts
+import { injectChatLabels } from "@copilotkit/angular";
+
+function injectChatLabels(): CopilotChatLabels;
+```
+
+## Return Value
+
+Returns a complete `CopilotChatLabels` object. Because the value is the merge of your overrides over the defaults, every field is always present (never `undefined`).
+
+## Usage
+
+Call it from an injection context and read the labels you need.
+
+```ts title="src/app/my-chat.component.ts"
+import { Component } from "@angular/core";
+import { injectChatLabels } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-my-chat",
+  standalone: true,
+  template: `<input [placeholder]="labels.chatInputPlaceholder" />`,
+})
+export class MyChatComponent {
+  protected readonly labels = injectChatLabels();
+}
+```
+
+## Related
+
+<Cards>
+  <Card
+    title="provideCopilotChatLabels"
+    description="Provide the label overrides that this function merges over the defaults."
+    href="/reference/angular/functions/provideCopilotChatLabels"
+  />
+  <Card
+    title="CopilotChat"
+    description="The prebuilt chat component that uses these labels internally."
+    href="/reference/angular/components/CopilotChat"
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/functions/injectCopilotKitConfig.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/injectCopilotKitConfig.mdx
@@ -1,0 +1,55 @@
+---
+title: "injectCopilotKitConfig"
+description: "Angular function that reads the CopilotKitConfig provided through provideCopilotKit from the current injection context"
+---
+
+## Overview
+
+`injectCopilotKitConfig` returns the [`CopilotKitConfig`](/reference/angular/functions/provideCopilotKit#parameters) that you registered with [`provideCopilotKit`](/reference/angular/functions/provideCopilotKit). It reads the value bound to the `COPILOT_KIT_CONFIG` injection token, so it must run inside an Angular injection context (a constructor, a field initializer, or a factory).
+
+Most applications do not call this directly. The [`CopilotKit`](/reference/angular/services/CopilotKit) service uses it internally to build its core. Reach for it when you need to read the raw config you provided, for example to read your own `properties` or `runtimeUrl`.
+
+## Signature
+
+```ts
+import { injectCopilotKitConfig } from "@copilotkit/angular";
+
+function injectCopilotKitConfig(): CopilotKitConfig;
+```
+
+## Return Value
+
+Returns the `CopilotKitConfig` bound to the `COPILOT_KIT_CONFIG` token. Note that the `headers` field reflects the merged headers computed by `provideCopilotKit`, which may include the `X-CopilotCloud-Public-Api-Key` header derived from your `licenseKey`.
+
+## Usage
+
+Call it from an injection context, such as a service constructor or a component field initializer.
+
+```ts title="src/app/runtime-info.service.ts"
+import { Injectable } from "@angular/core";
+import { injectCopilotKitConfig } from "@copilotkit/angular";
+
+@Injectable({ providedIn: "root" })
+export class RuntimeInfoService {
+  private readonly config = injectCopilotKitConfig();
+
+  get runtimeUrl(): string | undefined {
+    return this.config.runtimeUrl;
+  }
+}
+```
+
+## Related
+
+<Cards>
+  <Card
+    title="provideCopilotKit"
+    description="Register the CopilotKitConfig that this function reads back."
+    href="/reference/angular/functions/provideCopilotKit"
+  />
+  <Card
+    title="CopilotKit"
+    description="The service that consumes the configuration and exposes runtime state as signals."
+    href="/reference/angular/services/CopilotKit"
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/functions/provideCopilotChatLabels.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/provideCopilotChatLabels.mdx
@@ -1,0 +1,125 @@
+---
+title: "provideCopilotChatLabels"
+description: "Angular provider that overrides the default text labels used by the CopilotKit chat components"
+---
+
+## Overview
+
+`provideCopilotChatLabels` returns an Angular [`Provider`](https://angular.dev/guide/di/dependency-injection-providers) that customizes the text labels used throughout the prebuilt chat components, such as the input placeholder, toolbar button labels, the disclaimer text, and the welcome message. You pass a partial set of labels and they are merged over the defaults, so you only override the strings you want to change.
+
+Add it to an application or component `providers` array. Components read the merged labels through [`injectChatLabels`](/reference/angular/functions/injectChatLabels). This mirrors React's chat label configuration via `useCopilotChatConfiguration`.
+
+The full set of defaults lives in `COPILOT_CHAT_DEFAULT_LABELS`. Any field you omit falls back to its default value.
+
+## Signature
+
+```ts
+import { provideCopilotChatLabels } from "@copilotkit/angular";
+import type { Provider } from "@angular/core";
+
+function provideCopilotChatLabels(
+  config: Partial<CopilotChatLabels>,
+): Provider;
+```
+
+## Parameters
+
+<PropertyReference name="config" type="Partial<CopilotChatLabels>" required>
+  A partial set of label overrides. Provided fields are merged over
+  `COPILOT_CHAT_DEFAULT_LABELS`; omitted fields keep their defaults.
+
+  <PropertyReference name="chatInputPlaceholder" type="string" default="Type a message...">
+    Placeholder text for the chat input.
+  </PropertyReference>
+  <PropertyReference name="chatInputToolbarStartTranscribeButtonLabel" type="string" default="Transcribe">
+    Label for the start-transcription button.
+  </PropertyReference>
+  <PropertyReference name="chatInputToolbarCancelTranscribeButtonLabel" type="string" default="Cancel">
+    Label for the cancel-transcription button.
+  </PropertyReference>
+  <PropertyReference name="chatInputToolbarFinishTranscribeButtonLabel" type="string" default="Finish">
+    Label for the finish-transcription button.
+  </PropertyReference>
+  <PropertyReference name="chatInputToolbarAddButtonLabel" type="string" default="Add photos or files">
+    Label for the add-attachment button.
+  </PropertyReference>
+  <PropertyReference name="chatInputToolbarToolsButtonLabel" type="string" default="Tools">
+    Label for the tools button.
+  </PropertyReference>
+  <PropertyReference name="assistantMessageToolbarCopyCodeLabel" type="string" default="Copy">
+    Label for the copy-code action on an assistant message.
+  </PropertyReference>
+  <PropertyReference name="assistantMessageToolbarCopyCodeCopiedLabel" type="string" default="Copied">
+    Label shown after code is copied from an assistant message.
+  </PropertyReference>
+  <PropertyReference name="assistantMessageToolbarCopyMessageLabel" type="string" default="Copy">
+    Label for the copy-message action on an assistant message.
+  </PropertyReference>
+  <PropertyReference name="assistantMessageToolbarThumbsUpLabel" type="string" default="Good response">
+    Label for the thumbs-up action.
+  </PropertyReference>
+  <PropertyReference name="assistantMessageToolbarThumbsDownLabel" type="string" default="Bad response">
+    Label for the thumbs-down action.
+  </PropertyReference>
+  <PropertyReference name="assistantMessageToolbarReadAloudLabel" type="string" default="Read aloud">
+    Label for the read-aloud action.
+  </PropertyReference>
+  <PropertyReference name="assistantMessageToolbarRegenerateLabel" type="string" default="Regenerate">
+    Label for the regenerate action.
+  </PropertyReference>
+  <PropertyReference name="userMessageToolbarCopyMessageLabel" type="string" default="Copy">
+    Label for the copy-message action on a user message.
+  </PropertyReference>
+  <PropertyReference name="userMessageToolbarEditMessageLabel" type="string" default="Edit">
+    Label for the edit-message action on a user message.
+  </PropertyReference>
+  <PropertyReference name="chatDisclaimerText" type="string" default="AI can make mistakes. Please verify important information.">
+    Disclaimer text shown beneath the chat.
+  </PropertyReference>
+  <PropertyReference name="welcomeMessageText" type="string" default="How can I help you today?">
+    The welcome message shown before the conversation starts.
+  </PropertyReference>
+</PropertyReference>
+
+## Return Value
+
+Returns an Angular `Provider` that binds the merged labels to the `COPILOT_CHAT_LABELS` injection token.
+
+## Usage
+
+Override a few labels in your application config. Everything you do not list keeps its default.
+
+```ts title="src/app/app.config.ts"
+import { ApplicationConfig } from "@angular/core";
+import {
+  provideCopilotKit,
+  provideCopilotChatLabels,
+} from "@copilotkit/angular";
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideCopilotKit({ runtimeUrl: "/api/copilotkit" }),
+    provideCopilotChatLabels({
+      chatInputPlaceholder: "Ask me anything...",
+      welcomeMessageText: "Welcome! What can I help you build?",
+    }),
+  ],
+};
+```
+
+You can also scope labels to part of your app by adding the provider to a feature component's `providers` array instead of the application config.
+
+## Related
+
+<Cards>
+  <Card
+    title="injectChatLabels"
+    description="Read the merged chat labels from within an injection context."
+    href="/reference/angular/functions/injectChatLabels"
+  />
+  <Card
+    title="CopilotChat"
+    description="The prebuilt chat component whose text these labels customize."
+    href="/reference/angular/components/CopilotChat"
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/functions/provideCopilotKit.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/provideCopilotKit.mdx
@@ -1,0 +1,242 @@
+---
+title: "provideCopilotKit"
+description: "Angular provider that configures CopilotKit through dependency injection: runtime URL, agents, tools, headers, and more"
+---
+
+## Overview
+
+`provideCopilotKit` is the primary setup entry point for `@copilotkit/angular`. It returns an Angular [`Provider`](https://angular.dev/guide/di/dependency-injection-providers) that you add to your application (or component) `providers` array. The provider stores your [`CopilotKitConfig`](#parameters) behind the `COPILOT_KIT_CONFIG` injection token, where the [`CopilotKit`](/reference/angular/services/CopilotKit) service and every CopilotKit function reads it.
+
+This is the Angular equivalent of React's `<CopilotKit>` provider. Because Angular configures CopilotKit through dependency injection rather than a wrapper component, you register it once in `app.config.ts` (or in a feature component's `providers`) and everything below it in the injector tree can connect to your runtime and agents.
+
+You typically configure the connection one of two ways: point at a CopilotKit runtime with `runtimeUrl`, or connect directly to one or more AG-UI agents with `selfManagedAgents`.
+
+## Signature
+
+```ts
+import { provideCopilotKit } from "@copilotkit/angular";
+import type { Provider } from "@angular/core";
+
+function provideCopilotKit(config: CopilotKitConfig): Provider;
+```
+
+## Parameters
+
+<PropertyReference name="config" type="CopilotKitConfig" required>
+  The CopilotKit configuration object.
+
+  <PropertyReference name="runtimeUrl" type="string">
+    The URL of your CopilotKit runtime endpoint. Set this to route agent
+    traffic through a runtime (for example a Next.js, Express, or Hono backend).
+  </PropertyReference>
+
+  <PropertyReference name="headers" type="Record<string, string>">
+    Extra HTTP headers sent with every runtime request, for example an
+    `Authorization` header. If you pass a `licenseKey`, a
+    `X-CopilotCloud-Public-Api-Key` header is merged in automatically unless you
+    already set one here.
+  </PropertyReference>
+
+  <PropertyReference name="licenseKey" type="string">
+    Your CopilotCloud license key (a `ck_pub_...` value). When present and valid
+    it is sent as the `X-CopilotCloud-Public-Api-Key` header and removes the
+    license watermark. An absent or malformed key logs a one-time console
+    warning.
+  </PropertyReference>
+
+  <PropertyReference name="properties" type="Record<string, unknown>">
+    Arbitrary key/value properties forwarded to the runtime with each request.
+    Use this for request-scoped metadata such as a user id or tenant.
+  </PropertyReference>
+
+  <PropertyReference name="agents" type="Record<string, AbstractAgent>">
+    A map of agent id to AG-UI agent instance. Use this to register agents
+    directly in the client. These are merged with `selfManagedAgents` when the
+    underlying core is constructed.
+  </PropertyReference>
+
+  <PropertyReference name="selfManagedAgents" type="Record<string, AbstractAgent>">
+    A map of agent id to AG-UI agent instance that connect directly to an agent
+    endpoint without a CopilotKit runtime. Provide an `@ag-ui/client` agent such
+    as `HttpAgent` here to talk to an agent server directly.
+  </PropertyReference>
+
+  <PropertyReference name="tools" type="ClientTool[]">
+    Client tools registered at startup. Each `ClientTool` is a frontend tool
+    definition without a `handler`, plus an optional `renderer` component. When
+    a tool supplies both a `renderer` and `parameters`, its renderer is
+    registered as a tool call renderer automatically.
+  </PropertyReference>
+
+  <PropertyReference name="renderToolCalls" type="RenderToolCallConfig[]">
+    Renderers for tool calls. Each entry maps a tool `name` and a `args`
+    [Standard Schema](https://standardschema.dev) to a `component` that
+    visualizes the call. Optional `agentId` scopes the renderer to one agent and
+    `passAgent` exposes the agent to the renderer.
+  </PropertyReference>
+
+  <PropertyReference name="renderActivityMessages" type="RenderActivityMessageConfig[]">
+    Renderers for agent activity messages. Each entry maps an `activityType` and
+    a `content` schema to a `component`. Optional `agentId` scopes the renderer
+    to one agent.
+  </PropertyReference>
+
+  <PropertyReference name="suggestionsConfig" type="SuggestionsConfig[]">
+    Suggestion configurations. Each entry is either a dynamic config
+    (`instructions` plus optional `minSuggestions`, `maxSuggestions`,
+    `available`, `providerAgentId`, `consumerAgentId`) or a static config (an
+    explicit `suggestions` array plus optional `available` and
+    `consumerAgentId`).
+  </PropertyReference>
+
+  <PropertyReference name="frontendTools" type="FrontendToolConfig[]">
+    Client-side tools registered at startup, each with a `name`, `description`,
+    `parameters` schema, async `handler`, and optional `component` renderer,
+    `followUp`, and `agentId`. Handlers run inside the root injection context,
+    so they can use `inject()`. Prefer
+    [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool)
+    for tools scoped to a component.
+  </PropertyReference>
+
+  <PropertyReference name="humanInTheLoop" type="HumanInTheLoopConfig[]">
+    Human-in-the-loop tools registered at startup. Each entry has a `name`,
+    `description`, `parameters` schema, a `component` renderer that collects the
+    user's response, and an optional `agentId`. Prefer
+    [`registerHumanInTheLoop`](/reference/angular/functions/registerHumanInTheLoop)
+    for tools scoped to a component.
+  </PropertyReference>
+
+  <PropertyReference name="a2ui" type="A2UIConfig">
+    Configuration for A2UI (agent-to-UI declarative surfaces).
+
+    <PropertyReference name="theme" type="Theme">
+      The A2UI theme used to style rendered surfaces.
+    </PropertyReference>
+    <PropertyReference name="catalog" type="Catalog<LitComponentImplementation>">
+      A catalog of custom components the agent may render.
+    </PropertyReference>
+    <PropertyReference name="loadingComponent" type="() => LitRenderable">
+      A function returning the element shown while a surface is loading.
+    </PropertyReference>
+    <PropertyReference name="includeSchema" type="boolean" default="true">
+      Whether to send the catalog component schemas to the agent as context. Set
+      to `false` to omit the schema context.
+    </PropertyReference>
+  </PropertyReference>
+
+  <PropertyReference name="openGenerativeUI" type="OpenGenerativeUIConfig">
+    Configuration for open generative UI (the `generateSandboxedUi` tool).
+    Providing this object enables the feature.
+
+    <PropertyReference name="sandboxFunctions" type="SandboxFunction[]">
+      Functions the sandboxed UI can call back into the host application via
+      `Websandbox.connection.remote.<functionName>(args)`. Each has a `name`,
+      `description`, `parameters` schema, and a `handler`.
+    </PropertyReference>
+    <PropertyReference name="designSkill" type="string">
+      Design guidelines passed to the agent for generated UI. Defaults to the
+      built-in shadcn-inspired design skill.
+    </PropertyReference>
+  </PropertyReference>
+</PropertyReference>
+
+## Return Value
+
+Returns an Angular `Provider` that binds your (header-augmented) config to the `COPILOT_KIT_CONFIG` injection token. Add it to a `providers` array.
+
+## Usage
+
+### Connect through a runtime
+
+Point `runtimeUrl` at your CopilotKit runtime endpoint and register the provider in your application config.
+
+```ts title="src/app/app.config.ts"
+import { ApplicationConfig } from "@angular/core";
+import { provideCopilotKit } from "@copilotkit/angular";
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideCopilotKit({
+      runtimeUrl: "/api/copilotkit",
+      headers: {
+        Authorization: "Bearer <token>",
+      },
+      properties: {
+        userId: "user_123",
+      },
+    }),
+  ],
+};
+```
+
+### Connect directly to an AG-UI agent
+
+To talk to an agent server without a CopilotKit runtime, pass `selfManagedAgents` with an `@ag-ui/client` agent such as `HttpAgent`.
+
+```ts title="src/app/app.config.ts"
+import { ApplicationConfig } from "@angular/core";
+import { provideCopilotKit } from "@copilotkit/angular";
+import { HttpAgent } from "@ag-ui/client";
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideCopilotKit({
+      selfManagedAgents: {
+        default: new HttpAgent({ url: "http://localhost:8000/" }),
+      },
+    }),
+  ],
+};
+```
+
+### Register startup tools
+
+Pass `frontendTools` to register client tools when the application starts. Their handlers run inside the root injection context, so they can use `inject()`.
+
+```ts title="src/app/app.config.ts"
+import { ApplicationConfig } from "@angular/core";
+import { provideCopilotKit } from "@copilotkit/angular";
+import { z } from "zod";
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideCopilotKit({
+      runtimeUrl: "/api/copilotkit",
+      frontendTools: [
+        {
+          name: "sayHello",
+          description: "Greet the user by name",
+          parameters: z.object({ name: z.string() }),
+          handler: async ({ name }) => `Hello, ${name}!`,
+        },
+      ],
+    }),
+  ],
+};
+```
+
+## Behavior
+
+- The provided config is bound to the `COPILOT_KIT_CONFIG` injection token. Read it with [`injectCopilotKitConfig`](/reference/angular/functions/injectCopilotKitConfig).
+- If `licenseKey` (or an `X-CopilotCloud-Public-Api-Key` header) is missing or malformed, a one-time license watermark warning is logged to the console.
+- `agents` and `selfManagedAgents` are merged together when the underlying core is created, so an id present in both resolves to the `selfManagedAgents` entry.
+
+## Related
+
+<Cards>
+  <Card
+    title="injectCopilotKitConfig"
+    description="Read the CopilotKitConfig you provided here from within an injection context."
+    href="/reference/angular/functions/injectCopilotKitConfig"
+  />
+  <Card
+    title="CopilotKit"
+    description="The service that consumes this configuration and exposes agents, tools, and runtime state."
+    href="/reference/angular/services/CopilotKit"
+  />
+  <Card
+    title="CopilotChat"
+    description="The prebuilt chat component to drop into a template once the provider is registered."
+    href="/reference/angular/components/CopilotChat"
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/functions/registerFrontendTool.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/registerFrontendTool.mdx
@@ -1,0 +1,270 @@
+---
+title: "registerFrontendTool"
+description: "Angular function for registering a client-side frontend tool with CopilotKit, with an optional Angular renderer component, that runs in the browser when an agent calls it"
+---
+
+## Overview
+
+`registerFrontendTool` registers a client-side tool with CopilotKit. When the agent decides to call the tool, the provided `handler` function executes in the browser, and the value it resolves to is surfaced back to the agent as the tool result. Optionally, you can supply a `component` (a standalone Angular component) to render custom UI in the chat that shows the tool call's progress and result.
+
+You call `registerFrontendTool` inside an Angular injection context (a component or service constructor, or a field initializer). The tool registers immediately, and CopilotKit removes it automatically when the owning component or service is destroyed. Parameter schemas are defined with a [Standard Schema](https://standardschema.dev) such as a [Zod](https://zod.dev) object, which is used for both validation and type inference of the handler's arguments.
+
+This is the Angular equivalent of React's `useFrontendTool()`. The handler runs inside the same injector that registered the tool, so it can call `inject()` to reach your other Angular services.
+
+<Callout type="info">
+  Import from the package root, `@copilotkit/angular`. There is no `/v2`
+  subpath. `registerFrontendTool` must run in an injection context that has
+  [`provideCopilotKit`](/reference/angular/functions/provideCopilotKit) in
+  scope.
+</Callout>
+
+## Signature
+
+```ts
+import { registerFrontendTool } from "@copilotkit/angular";
+
+function registerFrontendTool<Args extends Record<string, unknown>>(
+  frontendTool: FrontendToolConfig<Args>,
+): void;
+```
+
+## Parameters
+
+<PropertyReference name="frontendTool" type="FrontendToolConfig<Args>" required>
+  The tool definition object.
+
+  <PropertyReference name="name" type="string" required>
+    A unique name for the tool. The agent references this name when it decides
+    to call the tool. Registering another tool with the same name (for the same
+    `agentId`) adds a second registration, so use distinct names per tool.
+  </PropertyReference>
+
+  <PropertyReference name="description" type="string" required>
+    A natural-language description that tells the agent what the tool does and
+    when to use it.
+  </PropertyReference>
+
+  <PropertyReference name="parameters" type="StandardSchemaV1<unknown, Args>" required>
+    A [Standard Schema](https://standardschema.dev) (for example a Zod object)
+    that defines the tool's input parameters. The schema drives both validation
+    and the type inference of the `handler` arguments. For a tool that takes no
+    parameters, pass an empty object schema such as `z.object({})`.
+  </PropertyReference>
+
+  <PropertyReference
+    name="handler"
+    type="(args: Args, context: FrontendToolHandlerContext) => Promise<unknown>"
+    required
+  >
+    An async function that runs when the agent calls the tool. It receives the
+    validated, typed `args` and a `context` object, and runs inside the
+    injection context that registered the tool, so you can call `inject()`
+    inside it. The resolved value is returned to the agent as the tool result.
+
+    <PropertyReference name="context.toolCall" type="ToolCall">
+      The raw AG-UI tool call metadata, including the tool call `id`.
+    </PropertyReference>
+
+    <PropertyReference name="context.agent" type="AbstractAgent">
+      The agent instance that invoked the tool.
+    </PropertyReference>
+
+    <PropertyReference name="context.signal" type="AbortSignal">
+      An `AbortSignal` that is aborted when the user stops the agent. Long
+      running handlers can check `signal.aborted` or pass `signal` to `fetch`
+      to cancel cooperatively.
+    </PropertyReference>
+  </PropertyReference>
+
+  <PropertyReference name="component" type="Type<ToolRenderer<Args>>">
+    An optional standalone Angular component class used to visualize the tool
+    call in the chat. CopilotKit instantiates it and binds a `toolCall` signal
+    input that exposes the streaming `args`, the `status`, and the `result`. See
+    [`registerRenderToolCall`](/reference/angular/functions/registerRenderToolCall)
+    for the full `ToolRenderer` and `AngularToolCall` shapes.
+  </PropertyReference>
+
+  <PropertyReference name="followUp" type="boolean">
+    Whether the agent should automatically continue the run after the tool
+    result is returned.
+  </PropertyReference>
+
+  <PropertyReference name="agentId" type="string">
+    Optional agent scope. When set, the tool is only offered to the agent with
+    this id. Cleanup on destroy is scoped to the same `agentId`.
+  </PropertyReference>
+</PropertyReference>
+
+## Return Value
+
+`registerFrontendTool` returns `void`. It performs the registration as a side effect and wires up automatic cleanup.
+
+## Behavior
+
+- **Immediate registration.** The tool is added to CopilotKit as soon as the function runs, so call it during construction or field initialization, not inside an event handler.
+- **Runs in the injection context.** The `handler` is invoked with `runInInjectionContext` using the injector that registered the tool, so `inject()` works inside it.
+- **Automatic cleanup.** CopilotKit removes the tool when the owning component or service is destroyed, using the same `name` and `agentId` you registered with. There is no manual unregister step.
+- **Optional renderer.** When you pass a `component`, it is registered alongside the tool so the chat can render the tool call's progress and result.
+
+## Usage
+
+### Basic tool with a Zod schema and async handler
+
+Register the tool in the component constructor. The handler reads and writes a local signal, then returns a string result for the agent.
+
+```ts title="src/app/todo.component.ts"
+import { Component, signal } from "@angular/core";
+import { z } from "zod";
+import { registerFrontendTool } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-todo",
+  standalone: true,
+  template: `
+    <ul>
+      @for (todo of todos(); track todo) {
+        <li>{{ todo }}</li>
+      }
+    </ul>
+  `,
+})
+export class TodoComponent {
+  readonly todos = signal<string[]>([]);
+
+  constructor() {
+    registerFrontendTool({
+      name: "addTodo",
+      description: "Add a new item to the user's todo list",
+      parameters: z.object({
+        text: z.string().describe("The todo item text"),
+        priority: z.enum(["low", "medium", "high"]).describe("Priority level"),
+      }),
+      handler: async ({ text, priority }) => {
+        this.todos.update((current) => [...current, text]);
+        return `Added "${text}" with ${priority} priority`;
+      },
+    });
+  }
+}
+```
+
+Because the handler runs in the injection context, you can call `inject()` for a service instead of capturing it from the component:
+
+```ts title="src/app/weather.component.ts"
+import { Component, inject } from "@angular/core";
+import { z } from "zod";
+import { registerFrontendTool } from "@copilotkit/angular";
+import { WeatherService } from "./weather.service";
+
+@Component({
+  selector: "app-weather",
+  standalone: true,
+  template: ``,
+})
+export class WeatherComponent {
+  constructor() {
+    registerFrontendTool({
+      name: "getWeather",
+      description: "Fetch weather information for a city",
+      parameters: z.object({
+        city: z.string().describe("City name"),
+        units: z.enum(["celsius", "fahrenheit"]).default("celsius"),
+      }),
+      handler: async ({ city, units }, { signal }) => {
+        const weather = inject(WeatherService);
+        const result = await weather.fetch(city, units, { signal });
+        return JSON.stringify(result);
+      },
+    });
+  }
+}
+```
+
+### Tool with a custom Angular renderer component
+
+Pass a standalone component as `component` to visualize the tool call in chat. The renderer implements `ToolRenderer<Args>`, so it exposes a `toolCall` signal input that carries the `status`, the (possibly partial) `args`, and the `result`.
+
+```ts title="src/app/weather-tool-view.component.ts"
+import { Component, input } from "@angular/core";
+import { AngularToolCall, ToolRenderer } from "@copilotkit/angular";
+
+type WeatherArgs = { city: string; units: "celsius" | "fahrenheit" };
+
+@Component({
+  selector: "app-weather-tool-view",
+  standalone: true,
+  template: `
+    @let call = toolCall();
+    @if (call.status === "in-progress") {
+      <div class="animate-pulse">Fetching weather for {{ call.args.city }}...</div>
+    } @else if (call.status === "complete") {
+      @let data = parse(call.result);
+      <div class="rounded border p-4">
+        <h3>{{ data.city }}</h3>
+        <p>{{ data.temperature }} {{ data.units }}</p>
+        <p>{{ data.conditions }}</p>
+      </div>
+    }
+  `,
+})
+export class WeatherToolViewComponent implements ToolRenderer<WeatherArgs> {
+  readonly toolCall = input.required<AngularToolCall<WeatherArgs>>();
+
+  protected parse(result: string) {
+    return JSON.parse(result);
+  }
+}
+```
+
+Register the tool with that component:
+
+```ts title="src/app/weather.component.ts"
+import { Component, inject } from "@angular/core";
+import { z } from "zod";
+import { registerFrontendTool } from "@copilotkit/angular";
+import { WeatherService } from "./weather.service";
+import { WeatherToolViewComponent } from "./weather-tool-view.component";
+
+@Component({
+  selector: "app-weather",
+  standalone: true,
+  template: ``,
+})
+export class WeatherComponent {
+  constructor() {
+    registerFrontendTool({
+      name: "getWeather",
+      description: "Fetch and display weather information for a city",
+      parameters: z.object({
+        city: z.string().describe("City name"),
+        units: z.enum(["celsius", "fahrenheit"]).default("celsius"),
+      }),
+      handler: async ({ city, units }, { signal }) => {
+        const result = await inject(WeatherService).fetch(city, units, { signal });
+        return JSON.stringify(result);
+      },
+      component: WeatherToolViewComponent,
+    });
+  }
+}
+```
+
+## Related
+
+<Cards>
+  <Card
+    title="registerRenderToolCall"
+    description="Register a renderer for a tool call (including server-side and agentic tools) with full access to status and results."
+    href="/reference/angular/functions/registerRenderToolCall"
+  />
+  <Card
+    title="registerHumanInTheLoop"
+    description="Register a tool that pauses the agent and waits for the user to respond from a rendered component."
+    href="/reference/angular/functions/registerHumanInTheLoop"
+  />
+  <Card
+    title="CopilotKit service"
+    description="The central service that holds agents, tools, and the runtime connection."
+    href="/reference/angular/services/CopilotKit"
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/functions/registerHumanInTheLoop.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/registerHumanInTheLoop.mdx
@@ -1,0 +1,196 @@
+---
+title: "registerHumanInTheLoop"
+description: "Angular function for registering a human-in-the-loop tool with CopilotKit that pauses the agent and resumes it when the user responds from a rendered component"
+---
+
+## Overview
+
+`registerHumanInTheLoop` registers a tool that pauses the agent and waits for human input. When the agent calls the tool, CopilotKit renders the `component` you provide and suspends the agent run. The component collects a decision from the user (for example a confirm or reject choice) and calls `respond(result)`. That call resolves the tool, surfaces the result back to the agent, and lets the run continue.
+
+You call `registerHumanInTheLoop` inside an Angular injection context (a component or service constructor, or a field initializer). The tool registers immediately, and CopilotKit removes it automatically when the owning component or service is destroyed.
+
+This is the Angular equivalent of React's `useHumanInTheLoop()`. Unlike [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool), you do not write a `handler`. The handler is supplied internally and simply awaits the user's `respond` call, so the rendered component drives when the agent resumes.
+
+<Callout type="info">
+  Import from the package root, `@copilotkit/angular`. There is no `/v2`
+  subpath. `registerHumanInTheLoop` must run in an injection context that has
+  [`provideCopilotKit`](/reference/angular/functions/provideCopilotKit) in
+  scope.
+</Callout>
+
+## Signature
+
+```ts
+import { registerHumanInTheLoop } from "@copilotkit/angular";
+
+function registerHumanInTheLoop<Args extends Record<string, unknown>>(
+  humanInTheLoop: HumanInTheLoopConfig<Args>,
+): void;
+```
+
+## Parameters
+
+<PropertyReference name="humanInTheLoop" type="HumanInTheLoopConfig<Args>" required>
+  The tool definition object.
+
+  <PropertyReference name="name" type="string" required>
+    A unique name for the tool. The agent references this name when it decides
+    to call the tool.
+  </PropertyReference>
+
+  <PropertyReference name="description" type="string" required>
+    A natural-language description that tells the agent what the tool does and
+    when to use it.
+  </PropertyReference>
+
+  <PropertyReference name="parameters" type="StandardSchemaV1<unknown, Args>" required>
+    A [Standard Schema](https://standardschema.dev) (for example a Zod object)
+    that defines the tool's input parameters. The schema drives both validation
+    and the type inference of the `args` exposed to your component. For a tool
+    that takes no parameters, pass an empty object schema such as
+    `z.object({})`.
+  </PropertyReference>
+
+  <PropertyReference name="component" type="Type<HumanInTheLoopToolRenderer<Args>>" required>
+    The standalone Angular component class to render while the agent waits.
+    CopilotKit instantiates it and binds a `toolCall` signal input whose value
+    carries the `args`, the `status`, the `result`, and the `respond` callback.
+  </PropertyReference>
+
+  <PropertyReference name="agentId" type="string">
+    Optional agent scope. When set, the tool is only offered to the agent with
+    this id. Cleanup on destroy is scoped to the same `agentId`.
+  </PropertyReference>
+</PropertyReference>
+
+## Return Value
+
+`registerHumanInTheLoop` returns `void`. It registers the tool as a side effect and wires up automatic cleanup.
+
+## The renderer component
+
+Your `component` implements the `HumanInTheLoopToolRenderer<Args>` interface. It exposes a single `toolCall` signal input, so declare it with Angular's `input()`:
+
+```ts
+import { Signal } from "@angular/core";
+
+interface HumanInTheLoopToolRenderer<Args extends Record<string, unknown>> {
+  toolCall: Signal<HumanInTheLoopToolCall<Args>>;
+}
+```
+
+### HumanInTheLoopToolCall
+
+`toolCall()` returns a discriminated union keyed on `status`. Every variant carries a `respond` callback:
+
+```ts
+type HumanInTheLoopToolCall<Args extends Record<string, unknown>> =
+  | {
+      name?: string;
+      args: Partial<Args>; // streaming, may be incomplete
+      status: "in-progress";
+      result: undefined;
+      respond: (result: unknown) => void;
+    }
+  | {
+      name?: string;
+      args: Args; // fully parsed
+      status: "executing";
+      result: undefined;
+      respond: (result: unknown) => void;
+    }
+  | {
+      name?: string;
+      args: Args; // fully parsed
+      status: "complete";
+      result: string; // the value you passed to respond
+      respond: (result: unknown) => void;
+    };
+```
+
+The `respond(result)` callback is how your component resumes the agent. Calling it resolves the underlying tool handler with the value you pass, and that value becomes the tool result the agent sees. While the agent waits, `status` is `executing` (or `in-progress` while the arguments are still streaming). After you call `respond`, the tool call resolves and `status` becomes `complete` with `result` set to the value you sent.
+
+## Usage
+
+### A confirmation dialog
+
+This component renders a confirm and a reject button. Each calls `respond` with a different value, which resumes the agent with that decision.
+
+```ts title="src/app/confirm-dialog.component.ts"
+import { Component, computed, input } from "@angular/core";
+import { HumanInTheLoopToolCall, HumanInTheLoopToolRenderer } from "@copilotkit/angular";
+
+type ConfirmArgs = { message: string };
+
+@Component({
+  selector: "app-confirm-dialog",
+  standalone: true,
+  template: `
+    @let call = toolCall();
+    @if (call.status === "complete") {
+      <div class="text-sm opacity-70">You chose: {{ call.result }}</div>
+    } @else {
+      <div class="rounded border p-4">
+        <p>{{ message() }}</p>
+        <div class="mt-3 flex gap-2">
+          <button type="button" (click)="call.respond('confirmed')">Confirm</button>
+          <button type="button" (click)="call.respond('rejected')">Reject</button>
+        </div>
+      </div>
+    }
+  `,
+})
+export class ConfirmDialogComponent implements HumanInTheLoopToolRenderer<ConfirmArgs> {
+  readonly toolCall = input.required<HumanInTheLoopToolCall<ConfirmArgs>>();
+  readonly message = computed(() => this.toolCall().args.message ?? "Are you sure?");
+}
+```
+
+Register the tool with that component:
+
+```ts title="src/app/chat.component.ts"
+import { Component } from "@angular/core";
+import { z } from "zod";
+import { registerHumanInTheLoop } from "@copilotkit/angular";
+import { ConfirmDialogComponent } from "./confirm-dialog.component";
+
+@Component({
+  selector: "app-chat",
+  standalone: true,
+  template: ``,
+})
+export class ChatComponent {
+  constructor() {
+    registerHumanInTheLoop({
+      name: "confirmAction",
+      description: "Ask the user to confirm before performing a sensitive action",
+      parameters: z.object({
+        message: z.string().describe("The confirmation question to show the user"),
+      }),
+      component: ConfirmDialogComponent,
+    });
+  }
+}
+```
+
+When the agent calls `confirmAction`, the dialog appears in the chat and the run pauses. As soon as the user clicks a button, `respond` resumes the agent with `"confirmed"` or `"rejected"`, and the tool call moves to `status: "complete"`.
+
+## Related
+
+<Cards>
+  <Card
+    title="registerFrontendTool"
+    description="Register a client-side tool with an async handler and an optional renderer component."
+    href="/reference/angular/functions/registerFrontendTool"
+  />
+  <Card
+    title="registerRenderToolCall"
+    description="Register a renderer for a tool call with access to streaming status and results, without a handler."
+    href="/reference/angular/functions/registerRenderToolCall"
+  />
+  <Card
+    title="CopilotKit service"
+    description="The central service that holds agents, tools, and the runtime connection."
+    href="/reference/angular/services/CopilotKit"
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/functions/registerRenderToolCall.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/registerRenderToolCall.mdx
@@ -1,0 +1,224 @@
+---
+title: "registerRenderToolCall"
+description: "Angular function for registering a renderer component for a tool call with CopilotKit, with access to streaming arguments, status, and result"
+---
+
+## Overview
+
+`registerRenderToolCall` registers a renderer for a tool call. It does not run a handler. It tells CopilotKit which standalone Angular component to render whenever a tool call with a matching `name` appears in the conversation. Use it to visualize tool calls that execute somewhere other than the browser, for example a server-side tool or an agentic (long-running) tool, where you only want to show progress and results in the chat.
+
+You call `registerRenderToolCall` inside an Angular injection context (a component or service constructor, or a field initializer). The renderer registers immediately, and CopilotKit removes it automatically when the owning component or service is destroyed.
+
+This is the Angular equivalent of React's `useRenderTool()` / `useRenderToolCall()`. If you want to both run a browser handler and render UI, use [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool) with its `component` field instead.
+
+<Callout type="info">
+  Import from the package root, `@copilotkit/angular`. There is no `/v2`
+  subpath. `registerRenderToolCall` must run in an injection context that has
+  [`provideCopilotKit`](/reference/angular/functions/provideCopilotKit) in
+  scope.
+</Callout>
+
+## Signature
+
+```ts
+import { registerRenderToolCall } from "@copilotkit/angular";
+
+function registerRenderToolCall<Args extends Record<string, unknown>>(
+  renderToolCall: RenderToolCallConfig<Args>,
+): void;
+```
+
+## Parameters
+
+<PropertyReference name="renderToolCall" type="RenderToolCallConfig<Args>" required>
+  The renderer definition object.
+
+  <PropertyReference name="name" type="string" required>
+    The name of the tool call to render. Use the literal `"*"` to register a
+    catch-all renderer that handles any tool call that has no more specific
+    renderer registered.
+  </PropertyReference>
+
+  <PropertyReference name="args" type="StandardSchemaV1<unknown, Args>" required>
+    A [Standard Schema](https://standardschema.dev) (for example a Zod object)
+    that describes the tool call arguments. It is used to type the `args`
+    exposed to your component.
+  </PropertyReference>
+
+  <PropertyReference name="component" type="Type<ToolRenderer<Args>>" required>
+    The standalone Angular component class to render for this tool call.
+    CopilotKit instantiates it and binds a `toolCall` signal input.
+  </PropertyReference>
+
+  <PropertyReference name="agentId" type="string">
+    Optional agent scope. When set, the renderer only applies to tool calls
+    emitted by the agent with this id. When omitted, the renderer applies across
+    agents.
+  </PropertyReference>
+
+  <PropertyReference name="passAgent" type="boolean" default="false">
+    When `true`, CopilotKit also binds an `agent` signal input on the component
+    with the agent instance that emitted the tool call. Leave it `false` (the
+    default) if your renderer does not need the agent.
+  </PropertyReference>
+</PropertyReference>
+
+## Return Value
+
+`registerRenderToolCall` returns `void`. It registers the renderer as a side effect and wires up automatic cleanup.
+
+## The renderer component
+
+Your `component` implements the `ToolRenderer<Args>` interface. CopilotKit binds the inputs by name, so declare them with Angular's `input()`:
+
+```ts
+import { Signal } from "@angular/core";
+import { AbstractAgent } from "@ag-ui/client";
+
+interface ToolRenderer<Args extends Record<string, unknown>> {
+  // Required: the current state of the tool call.
+  toolCall: Signal<AngularToolCall<Args>>;
+  // Bound only when the config sets passAgent: true.
+  agent?: Signal<AbstractAgent | undefined>;
+}
+```
+
+### AngularToolCall
+
+`toolCall()` returns a discriminated union keyed on `status`. The shape of `args` and `result` depends on the status:
+
+```ts
+type AngularToolCall<Args extends Record<string, unknown>> =
+  | {
+      name?: string;
+      args: Partial<Args>; // streaming, may be incomplete
+      status: "in-progress";
+      result: undefined;
+    }
+  | {
+      name?: string;
+      args: Args; // fully parsed
+      status: "executing";
+      result: undefined;
+    }
+  | {
+      name?: string;
+      args: Args; // fully parsed
+      status: "complete";
+      result: string; // the tool result, as a string
+    };
+```
+
+- **`in-progress`** means the arguments are still streaming in, so `args` is `Partial<Args>` and `result` is `undefined`.
+- **`executing`** means the arguments have fully arrived and the tool is running, so `args` is the complete `Args` and `result` is still `undefined`.
+- **`complete`** means the tool finished, so `args` is complete and `result` holds the string result.
+
+## Usage
+
+### A renderer component for a server-side tool
+
+This renderer shows a spinner while the tool runs and then renders the result. It narrows on `status` so the template only reads `result` once it is available.
+
+```ts title="src/app/search-tool-view.component.ts"
+import { Component, input } from "@angular/core";
+import { AngularToolCall, ToolRenderer } from "@copilotkit/angular";
+
+type SearchArgs = { query: string };
+
+@Component({
+  selector: "app-search-tool-view",
+  standalone: true,
+  template: `
+    @let call = toolCall();
+    @switch (call.status) {
+      @case ("in-progress") {
+        <div class="text-sm opacity-70">Preparing search...</div>
+      }
+      @case ("executing") {
+        <div class="text-sm opacity-70">Searching for "{{ call.args.query }}"...</div>
+      }
+      @case ("complete") {
+        <pre class="rounded border p-3 text-sm">{{ call.result }}</pre>
+      }
+    }
+  `,
+})
+export class SearchToolViewComponent implements ToolRenderer<SearchArgs> {
+  readonly toolCall = input.required<AngularToolCall<SearchArgs>>();
+}
+```
+
+Register it for the tool name your agent emits:
+
+```ts title="src/app/chat.component.ts"
+import { Component } from "@angular/core";
+import { z } from "zod";
+import { registerRenderToolCall } from "@copilotkit/angular";
+import { SearchToolViewComponent } from "./search-tool-view.component";
+
+@Component({
+  selector: "app-chat",
+  standalone: true,
+  template: ``,
+})
+export class ChatComponent {
+  constructor() {
+    registerRenderToolCall({
+      name: "searchDocuments",
+      args: z.object({ query: z.string() }),
+      component: SearchToolViewComponent,
+    });
+  }
+}
+```
+
+### Receiving the agent instance
+
+Set `passAgent: true` to have CopilotKit bind the `agent` signal input as well. Declare it on the component as an optional `input()`.
+
+```ts title="src/app/handoff-tool-view.component.ts"
+import { Component, input } from "@angular/core";
+import { AbstractAgent } from "@ag-ui/client";
+import { AngularToolCall, ToolRenderer } from "@copilotkit/angular";
+
+type HandoffArgs = { target: string };
+
+@Component({
+  selector: "app-handoff-tool-view",
+  standalone: true,
+  template: `<div>Handing off to {{ toolCall().args.target }}</div>`,
+})
+export class HandoffToolViewComponent implements ToolRenderer<HandoffArgs> {
+  readonly toolCall = input.required<AngularToolCall<HandoffArgs>>();
+  readonly agent = input<AbstractAgent | undefined>();
+}
+```
+
+```ts title="src/app/chat.component.ts"
+registerRenderToolCall({
+  name: "handoff",
+  args: z.object({ target: z.string() }),
+  component: HandoffToolViewComponent,
+  passAgent: true,
+});
+```
+
+## Related
+
+<Cards>
+  <Card
+    title="registerFrontendTool"
+    description="Register a client-side tool with an async handler and an optional renderer component."
+    href="/reference/angular/functions/registerFrontendTool"
+  />
+  <Card
+    title="registerHumanInTheLoop"
+    description="Register a tool that pauses the agent and waits for the user to respond from a rendered component."
+    href="/reference/angular/functions/registerHumanInTheLoop"
+  />
+  <Card
+    title="CopilotKit service"
+    description="The central service that holds agents, tools, and the runtime connection."
+    href="/reference/angular/services/CopilotKit"
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/index.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/index.mdx
@@ -1,0 +1,125 @@
+---
+title: "Angular"
+description: "API reference for @copilotkit/angular: the CopilotKit providers, prebuilt chat components, services, and functions for building CopilotKit into an Angular app."
+---
+
+`@copilotkit/angular` brings CopilotKit to Angular. It ships a set of [providers](/reference/angular/functions/provideCopilotKit), prebuilt chat components, a `CopilotKit` service, and standalone functions that mirror the React SDK. Everything is built on the [AG-UI](https://docs.ag-ui.com) agent protocol.
+
+<Callout type="info">
+  The package targets Angular 19, 20, and 21, and ships as standalone
+  components and providers. Import everything from the package root,
+  `@copilotkit/angular`. There is no `/v2` subpath.
+</Callout>
+
+## Installation
+
+```sh
+npm install @copilotkit/angular @angular/cdk
+```
+
+`@angular/cdk` and `rxjs` are peer dependencies. If your agent connects directly over AG-UI, also install `@ag-ui/client`.
+
+## Styling
+
+When using the prebuilt UI components, import the stylesheet once in your global styles. It is self-contained, so the chat renders without any other CSS.
+
+```css title="src/styles.css"
+@import "@copilotkit/angular/styles.css";
+```
+
+## Provider setup
+
+CopilotKit is configured through Angular's dependency injection rather than a wrapper component. Add [`provideCopilotKit`](/reference/angular/functions/provideCopilotKit) to your application providers and configure the runtime connection there. Every component, service, and function reads this configuration through the injector, so they must be used within an application (or component) that has the provider in scope.
+
+```ts title="src/app/app.config.ts"
+import { ApplicationConfig } from "@angular/core";
+import { provideCopilotKit } from "@copilotkit/angular";
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideCopilotKit({
+      runtimeUrl: "/api/copilotkit",
+    }),
+  ],
+};
+```
+
+To connect directly to an AG-UI agent without a runtime, pass `selfManagedAgents` instead of `runtimeUrl`:
+
+```ts title="src/app/app.config.ts"
+import { ApplicationConfig } from "@angular/core";
+import { provideCopilotKit } from "@copilotkit/angular";
+import { HttpAgent } from "@ag-ui/client";
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideCopilotKit({
+      selfManagedAgents: {
+        default: new HttpAgent({ url: "http://localhost:8000/" }),
+      },
+    }),
+  ],
+};
+```
+
+Then drop the chat into a standalone component's template:
+
+```ts title="src/app/app.component.ts"
+import { Component } from "@angular/core";
+import { CopilotChat } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-root",
+  standalone: true,
+  imports: [CopilotChat],
+  template: `<copilot-chat />`,
+})
+export class AppComponent {}
+```
+
+## Angular conventions
+
+A few patterns recur across this reference and differ from the React SDK:
+
+- **Setup is a provider, not a component.** Where the React SDK wraps your app in `<CopilotKit>`, the Angular SDK registers [`provideCopilotKit`](/reference/angular/functions/provideCopilotKit) in your application or component providers.
+- **State is exposed as signals.** Where React hooks return values that trigger re-renders, the Angular SDK exposes Angular [signals](https://angular.dev/guide/signals). Read them by calling the signal, for example `agentStore().messages()`.
+- **Functions run in an injection context.** Functions such as [`injectAgentStore`](/reference/angular/functions/injectAgentStore), [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool), and [`connectAgentContext`](/reference/angular/functions/connectAgentContext) use Angular's `inject()` under the hood. Call them from a constructor, a field initializer, or another injection context. They clean themselves up when the owning component or service is destroyed.
+- **Components are standalone.** Import the component class into your `imports` array and use its element selector in the template, for example `<copilot-chat>` for [`CopilotChat`](/reference/angular/components/CopilotChat).
+- **Templates and directives replace render props.** Where the React SDK uses render props or `children`, the Angular components accept Angular templates and content projection for the same customization.
+
+## API Reference
+
+<Callout type="info">
+  Looking for tool rendering? Start with
+  [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool),
+  [`registerRenderToolCall`](/reference/angular/functions/registerRenderToolCall),
+  and
+  [`registerHumanInTheLoop`](/reference/angular/functions/registerHumanInTheLoop).
+</Callout>
+
+<Cards>
+  <Card
+    title="UI Components"
+    description="Prebuilt chat components: CopilotChat, CopilotChatView, CopilotChatInput, and the message components."
+    href="/reference/angular/components/CopilotChat"
+    icon={<LinkIcon />}
+  />
+  <Card
+    title="Functions"
+    description="Setup providers and injectable functions for agents, tools, context, and chat labels."
+    href="/reference/angular/functions/provideCopilotKit"
+    icon={<LinkIcon />}
+  />
+  <Card
+    title="Services"
+    description="The CopilotKit service: the central handle on agents, tools, runtime connection, and suggestions."
+    href="/reference/angular/services/CopilotKit"
+    icon={<LinkIcon />}
+  />
+  <Card
+    title="Directives"
+    description="The CopilotKitAgentContext directive for sharing application state with the agent from a template."
+    href="/reference/angular/directives/CopilotKitAgentContext"
+    icon={<LinkIcon />}
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/services/CopilotKit.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/services/CopilotKit.mdx
@@ -1,0 +1,238 @@
+---
+title: "CopilotKit"
+description: "The root Angular service that exposes CopilotKit agents, tools, runtime state, and suggestions as signals"
+---
+
+## Overview
+
+`CopilotKit` is the central injectable service for `@copilotkit/angular`. It is `providedIn: "root"`, so a single instance is shared across your application. It builds and owns the underlying `CopilotKitCore` from the [`CopilotKitConfig`](/reference/angular/functions/provideCopilotKit#parameters) you registered with [`provideCopilotKit`](/reference/angular/functions/provideCopilotKit), exposes reactive runtime state as Angular [signals](https://angular.dev/guide/signals), and provides methods to register tools, manage suggestions, and update the runtime connection.
+
+This is the Angular equivalent of React's `useCopilotKit()`. In most apps you do not call its methods directly. The injectable functions such as [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool), [`registerRenderToolCall`](/reference/angular/functions/registerRenderToolCall), and [`registerHumanInTheLoop`](/reference/angular/functions/registerHumanInTheLoop) wrap it and add automatic cleanup. Inject the service when you need direct access to its signals or the `core` instance.
+
+## Accessing the service
+
+Inject it from any injection context, for example a component or service.
+
+```ts title="src/app/status.component.ts"
+import { Component, inject } from "@angular/core";
+import { CopilotKit } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-status",
+  standalone: true,
+  template: `<p>Status: {{ copilotKit.runtimeConnectionStatus() }}</p>`,
+})
+export class StatusComponent {
+  protected readonly copilotKit = inject(CopilotKit);
+}
+```
+
+## Signals
+
+All reactive state is exposed as read-only Angular signals. Read a signal by calling it, for example `copilotKit.agents()`.
+
+<PropertyReference name="agents" type="Signal<Record<string, AbstractAgent>>">
+  The agents currently registered, keyed by agent id. Updated when the core's
+  agents change.
+</PropertyReference>
+
+<PropertyReference name="runtimeConnectionStatus" type="Signal<CopilotKitCoreRuntimeConnectionStatus>">
+  The current runtime connection status: `Disconnected`, `Connecting`,
+  `Connected`, or `Error`.
+</PropertyReference>
+
+<PropertyReference name="runtimeUrl" type="Signal<string | undefined>">
+  The current runtime URL, or `undefined` when none is configured.
+</PropertyReference>
+
+<PropertyReference name="runtimeTransport" type="Signal<CopilotRuntimeTransport>">
+  The active runtime transport: `"rest"`, `"single"`, or `"auto"`. Defaults to
+  `"auto"`.
+</PropertyReference>
+
+<PropertyReference name="headers" type="Signal<Record<string, string>>">
+  The HTTP headers currently sent with runtime requests.
+</PropertyReference>
+
+<PropertyReference name="suggestionsByAgent" type="Signal<Record<string, CopilotKitCoreGetSuggestionsResult>>">
+  Suggestions keyed by agent id. Each value is
+  `{ suggestions: Suggestion[]; isLoading: boolean }`.
+</PropertyReference>
+
+<PropertyReference name="toolCallRenderConfigs" type="Signal<RenderToolCallConfig[]>">
+  All registered tool call renderers, including built-in renderers (for example
+  A2UI).
+</PropertyReference>
+
+<PropertyReference name="clientToolCallRenderConfigs" type="Signal<FrontendToolConfig[]>">
+  All registered client (frontend) tools, including built-in tools (for example
+  the open generative UI tool when enabled).
+</PropertyReference>
+
+<PropertyReference name="humanInTheLoopToolRenderConfigs" type="Signal<HumanInTheLoopConfig[]>">
+  All registered human-in-the-loop tool configs.
+</PropertyReference>
+
+<PropertyReference name="activityMessageRenderConfigs" type="Signal<RenderActivityMessageConfig[]>">
+  All registered activity message renderers, including built-in renderers.
+</PropertyReference>
+
+## Properties
+
+<PropertyReference name="core" type="CopilotKitCore">
+  The underlying `CopilotKitCore` instance from `@copilotkit/core`. Use it for
+  lower-level operations that the service does not wrap, such as adding context
+  or subscribing to core events.
+</PropertyReference>
+
+## Methods
+
+<PropertyReference name="addFrontendTool" type="(tool: FrontendToolConfig & { injector: Injector }) => void">
+  Register a client-side tool. The handler is rebound to run inside the provided
+  `injector`, so it can use `inject()`. Prefer
+  [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool),
+  which supplies the injector and removes the tool on destroy.
+</PropertyReference>
+
+<PropertyReference name="addRenderToolCall" type="(renderConfig: RenderToolCallConfig) => void">
+  Register a renderer for a tool call. Prefer
+  [`registerRenderToolCall`](/reference/angular/functions/registerRenderToolCall)
+  for automatic cleanup.
+</PropertyReference>
+
+<PropertyReference name="addRenderActivityMessage" type="(renderConfig: RenderActivityMessageConfig) => void">
+  Register a renderer for an agent activity message type.
+</PropertyReference>
+
+<PropertyReference name="addHumanInTheLoop" type="(humanInTheLoopTool: HumanInTheLoopConfig) => void">
+  Register a human-in-the-loop tool. The tool pauses the run until the user
+  responds. Prefer
+  [`registerHumanInTheLoop`](/reference/angular/functions/registerHumanInTheLoop)
+  for automatic cleanup.
+</PropertyReference>
+
+<PropertyReference name="addSuggestionsConfig" type="(config: SuggestionsConfig) => string">
+  Add a suggestions configuration and return its id.
+</PropertyReference>
+
+<PropertyReference name="removeSuggestionsConfig" type="(id: string) => void">
+  Remove a previously added suggestions configuration by id.
+</PropertyReference>
+
+<PropertyReference name="getSuggestions" type="(agentId: string) => CopilotKitCoreGetSuggestionsResult">
+  Return the current suggestions for an agent as
+  `{ suggestions, isLoading }`. Reads from `suggestionsByAgent` first, falling
+  back to the core.
+</PropertyReference>
+
+<PropertyReference name="reloadSuggestions" type="(agentId: string) => void">
+  Regenerate the suggestions for an agent.
+</PropertyReference>
+
+<PropertyReference name="clearSuggestions" type="(agentId: string) => void">
+  Clear the current suggestions for an agent.
+</PropertyReference>
+
+<PropertyReference name="removeTool" type="(toolName: string, agentId?: string) => void">
+  Remove a tool by name (optionally scoped to an `agentId`) and drop its
+  matching client tool, human-in-the-loop, and tool call render configs.
+</PropertyReference>
+
+<PropertyReference name="getAgent" type="(agentId: string) => AbstractAgent | undefined">
+  Return the agent registered under `agentId`, or `undefined`.
+</PropertyReference>
+
+<PropertyReference name="updateRuntime" type="(options) => void">
+  Update the runtime connection at runtime. `options` may include `runtimeUrl`,
+  `runtimeTransport`, `headers`, `properties`, `agents`, and
+  `selfManagedAgents`. Only the fields you pass are applied; `runtimeUrl`,
+  `runtimeTransport`, and `headers` also update the corresponding signals.
+</PropertyReference>
+
+## Usage
+
+### Read agents and connection status in a template
+
+```ts title="src/app/agents-panel.component.ts"
+import { Component, inject } from "@angular/core";
+import { CopilotKit } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-agents-panel",
+  standalone: true,
+  template: `
+    <p>Status: {{ copilotKit.runtimeConnectionStatus() }}</p>
+    <ul>
+      @for (id of agentIds(); track id) {
+        <li>{{ id }}</li>
+      }
+    </ul>
+  `,
+})
+export class AgentsPanelComponent {
+  protected readonly copilotKit = inject(CopilotKit);
+  protected readonly agentIds = () => Object.keys(this.copilotKit.agents());
+}
+```
+
+### Switch the runtime URL at runtime
+
+```ts title="src/app/runtime-switcher.component.ts"
+import { Component, inject } from "@angular/core";
+import { CopilotKit } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-runtime-switcher",
+  standalone: true,
+  template: `<button (click)="useStaging()">Use staging</button>`,
+})
+export class RuntimeSwitcherComponent {
+  private readonly copilotKit = inject(CopilotKit);
+
+  protected useStaging(): void {
+    this.copilotKit.updateRuntime({
+      runtimeUrl: "https://staging.example.com/api/copilotkit",
+    });
+  }
+}
+```
+
+### Reload suggestions for an agent
+
+```ts title="src/app/suggestions.component.ts"
+import { Component, inject } from "@angular/core";
+import { CopilotKit } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-suggestions",
+  standalone: true,
+  template: `<button (click)="refresh()">Refresh suggestions</button>`,
+})
+export class SuggestionsComponent {
+  private readonly copilotKit = inject(CopilotKit);
+
+  protected refresh(): void {
+    this.copilotKit.reloadSuggestions("default");
+  }
+}
+```
+
+## Related
+
+<Cards>
+  <Card
+    title="provideCopilotKit"
+    description="Register the configuration that this service reads to build its core."
+    href="/reference/angular/functions/provideCopilotKit"
+  />
+  <Card
+    title="registerFrontendTool"
+    description="Register a client-side tool from a component, with automatic cleanup on destroy."
+    href="/reference/angular/functions/registerFrontendTool"
+  />
+  <Card
+    title="injectAgentStore"
+    description="Subscribe to a single agent's reactive state (messages, running status, and more)."
+    href="/reference/angular/functions/injectAgentStore"
+  />
+</Cards>

--- a/showcase/shell-docs/src/lib/reference-items.ts
+++ b/showcase/shell-docs/src/lib/reference-items.ts
@@ -31,6 +31,7 @@ export const REFERENCE_VERSIONS = [
   "v1",
   "react-native",
   "vue",
+  "angular",
   "core",
   "bot",
 ] as const;
@@ -43,6 +44,8 @@ export const REFERENCE_CATEGORIES = [
   "Components",
   "Hooks",
   "Functions",
+  "Services",
+  "Directives",
   "Classes",
   "Types",
   "Enums",
@@ -56,6 +59,8 @@ type ReferenceSubdir =
   | "components"
   | "hooks"
   | "functions"
+  | "services"
+  | "directives"
   | "classes"
   | "types"
   | "enums"
@@ -68,6 +73,7 @@ const VERSION_SUBDIRS: Record<ReferenceVersion, ReferenceSubdir[]> = {
   v1: ["components", "hooks", "classes", "sdk"],
   "react-native": ["components", "hooks"],
   vue: ["components", "hooks"],
+  angular: ["components", "functions", "services", "directives"],
   core: ["classes", "types", "enums"],
   bot: ["components", "functions", "classes", "types", "slack", "discord"],
 };
@@ -76,6 +82,8 @@ const CATEGORY_BY_SUBDIR: Record<ReferenceSubdir, ReferenceCategory> = {
   components: "Components",
   hooks: "Hooks",
   functions: "Functions",
+  services: "Services",
+  directives: "Directives",
   classes: "Classes",
   types: "Types",
   enums: "Enums",


### PR DESCRIPTION
Adds an **Angular** SDK section to the reference docs (closes OSS-251), mirroring the React and Vue references. Documents every exported function, service, directive, and component of `@copilotkit/angular`, authored against the actual source.

**18 pages**, plus reference infra: registers `angular` and adds `Services` + `Directives` categories for Angular's DI + signals model.

- **Functions:** `provideCopilotKit`, `injectCopilotKitConfig`, `provideCopilotChatLabels`, `injectChatLabels`, `injectAgentStore`, `connectAgentContext`, `registerFrontendTool`, `registerRenderToolCall`, `registerHumanInTheLoop`
- **Services:** `CopilotKit` · **Directives:** `CopilotKitAgentContext`
- **Components:** `CopilotChat`, `CopilotChatView`, `CopilotChatInput`, `CopilotChatMessageView`, `CopilotChatAssistantMessage`, `CopilotChatUserMessage`

Verified: renders locally, all cross-links resolve, surfaces in `llms.txt`/`llms-full.txt`, existing SDKs unaffected. Uses the correct `@copilotkit/angular` name (top-level imports, no `/v2`). Companion to the Angular quickstart (OSS-252, #5583).

### Screenshots

Reference overview, now with an Angular SDK card:

![Reference overview](https://raw.githubusercontent.com/CopilotKit/CopilotKit/austin/oss-251-angular-reference-screenshots/pr-assets/oss-251/reference-overview.png)

Angular landing page (sidebar grouped into Components / Functions / Services / Directives):

![Angular reference index](https://raw.githubusercontent.com/CopilotKit/CopilotKit/austin/oss-251-angular-reference-screenshots/pr-assets/oss-251/angular-index.png)

`provideCopilotKit` (a representative function page):

![provideCopilotKit](https://raw.githubusercontent.com/CopilotKit/CopilotKit/austin/oss-251-angular-reference-screenshots/pr-assets/oss-251/provideCopilotKit.png)

<details>
<summary>More pages</summary>

`registerFrontendTool`:

![registerFrontendTool](https://raw.githubusercontent.com/CopilotKit/CopilotKit/austin/oss-251-angular-reference-screenshots/pr-assets/oss-251/registerFrontendTool.png)

`CopilotChat` component:

![CopilotChat](https://raw.githubusercontent.com/CopilotKit/CopilotKit/austin/oss-251-angular-reference-screenshots/pr-assets/oss-251/CopilotChat.png)

</details>

<sub>Screenshots live on branch `austin/oss-251-angular-reference-screenshots` to keep this PR's diff docs-only.</sub>