### PR TITLE
docs(frontends): improve picker and language for non-react frontends

### DIFF
--- a/showcase/scripts/generate-search-index.ts
+++ b/showcase/scripts/generate-search-index.ts
@@ -36,6 +36,17 @@ interface SearchEntry {
   href: string;
 }
 
+const FRONTEND_SEARCH_PAGES = [
+  { id: "vue", name: "Vue", guidanceTitle: "Docs status" },
+  { id: "react-native", name: "React Native", guidanceTitle: "Docs status" },
+  { id: "slack", name: "Slack", guidanceTitle: "About early access" },
+  { id: "teams", name: "Teams", guidanceTitle: "About early access" },
+] as const;
+
+const FRONTEND_NAMES = new Map(
+  FRONTEND_SEARCH_PAGES.map((frontend) => [frontend.id, frontend.name]),
+);
+
 // Derive a human-readable section breadcrumb from a relative path.
 // e.g. "concepts/middleware" → "Concepts"
 //      "sdk/js/client/middleware" → "JS SDK › @ag-ui/client"
@@ -146,6 +157,45 @@ function scanMdxDir(
 
   walk(dir, "");
   return entries;
+}
+
+function normalizeDocsSearchEntry(entry: SearchEntry): SearchEntry[] {
+  const frontendPrefix = "/docs/frontends/";
+  if (!entry.href.startsWith(frontendPrefix)) return [entry];
+
+  const slugPath = entry.href.slice(frontendPrefix.length);
+  if (slugPath === "using-these-docs") {
+    return FRONTEND_SEARCH_PAGES.filter(
+      (frontend) => frontend.guidanceTitle === "About early access",
+    ).map((frontend) => ({
+      ...entry,
+      title: `${frontend.name}: ${frontend.guidanceTitle}`,
+      section: "Frontends",
+      href: `/${frontend.id}/using-these-docs`,
+    }));
+  }
+
+  if (slugPath === "docs-status") {
+    return FRONTEND_SEARCH_PAGES.filter(
+      (frontend) => frontend.guidanceTitle === "Docs status",
+    ).map((frontend) => ({
+      ...entry,
+      title: `${frontend.name}: ${frontend.guidanceTitle}`,
+      section: "Frontends",
+      href: `/${frontend.id}/using-these-docs`,
+    }));
+  }
+
+  const [frontend, ...tail] = slugPath.split("/").filter(Boolean);
+  if (!frontend || !FRONTEND_NAMES.has(frontend)) return [];
+
+  return [
+    {
+      ...entry,
+      section: "Frontends",
+      href: tail.length > 0 ? `/${frontend}/${tail.join("/")}` : `/${frontend}`,
+    },
+  ];
 }
 
 function main() {
@@ -282,7 +332,9 @@ function main() {
   // CopilotKit Docs
   const docsDir = path.join(CONTENT_ROOT, "content", "docs");
   if (fs.existsSync(docsDir)) {
-    const docsEntries = scanMdxDir(docsDir, "/docs", "page");
+    const docsEntries = scanMdxDir(docsDir, "/docs", "page").flatMap(
+      normalizeDocsSearchEntry,
+    );
     entries.push(...docsEntries);
     console.log(`  Docs: ${docsEntries.length} entries`);
     scanDirsPresent.push(docsDir);

--- a/showcase/shell-docs/README.md
+++ b/showcase/shell-docs/README.md
@@ -95,7 +95,7 @@ reference content and still be universal across frontends.
 Use the `frontend` field in page frontmatter or `meta.json` when a root doc should appear in
 non-React frontend docs:
 
-- `universal` — render the same page under `/frontends/<frontend>/...`.
+- `universal` — render the same page under `/<frontend>/...`.
 - `frontend-variant` — render only when a matching page exists under
   `src/content/docs/frontends/<frontend>/...`.
 - `hide` — omit the page from frontend-scoped docs.

--- a/showcase/shell-docs/package-lock.json
+++ b/showcase/shell-docs/package-lock.json
@@ -22,6 +22,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-ga4": "^2.1.0",
+        "react-icons": "^5.6.0",
         "remark-gfm": "^4.0.0",
         "tailwind-merge": "^3.6.0",
         "yaml": "^2.7.0"
@@ -6614,6 +6615,15 @@
       "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
       "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==",
       "license": "MIT"
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",

--- a/showcase/shell-docs/package.json
+++ b/showcase/shell-docs/package.json
@@ -28,6 +28,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-ga4": "^2.1.0",
+    "react-icons": "^5.6.0",
     "remark-gfm": "^4.0.0",
     "tailwind-merge": "^3.6.0",
     "yaml": "^2.7.0"

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/__tests__/framework-root-shell-layout.test.ts
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/__tests__/framework-root-shell-layout.test.ts
@@ -17,4 +17,67 @@ describe("FrameworkRootShell layout", () => {
     );
     expect(shellSource).not.toContain("pt-2 pb-6 md:pt-3 xl:pt-4");
   });
+
+  it("parses frontend routes before resolving frontend content slugs", () => {
+    expect(pageSource).toContain("parseFrontendRoutePath");
+    expect(pageSource).toContain("activeBackendFramework");
+    expect(pageSource).toContain(
+      "frameworkOverride={activeBackendFramework}",
+    );
+  });
+
+  it("redirects retired frontend URL shapes instead of rendering them", () => {
+    expect(pageSource).toContain('if (framework === "frontends")');
+    expect(pageSource).toContain("legacyFrontendPathRedirect(");
+    expect(pageSource).toContain(
+      "const frontendRedirect = legacyFrontendPathRedirect(",
+    );
+  });
+
+  it("renders backend docs when a frontend route includes a backend slug", () => {
+    expect(pageSource).toContain("scopedFramework = activeBackendFramework");
+    expect(pageSource).toContain("scopedSlugHrefPrefix = frontendRoutePath(");
+    expect(pageSource).toContain("frameworkOverride={scopedFramework}");
+    expect(pageSource).toContain(
+      'slugHrefPrefix={scopedSlugHrefPrefix ?? `/${scopedFramework}`}',
+    );
+    expect(pageSource).toContain(
+      "preferIndexMdx={Boolean(scopedSlugHrefPrefix)}",
+    );
+  });
+
+  it("keeps frontend root pages available under frontend/backend routes", () => {
+    const frontendRootIndex = pageSource.indexOf(
+      "if (!activeFrontendSlugPath) {\n      return (\n        <FrontendQuickstartDocsPage",
+    );
+    const backendScopingIndex = pageSource.indexOf(
+      "if (activeBackendFramework) {\n      scopedFramework = activeBackendFramework",
+    );
+
+    expect(frontendRootIndex).toBeGreaterThan(-1);
+    expect(backendScopingIndex).toBeGreaterThan(-1);
+    expect(frontendRootIndex).toBeLessThan(backendScopingIndex);
+  });
+
+  it("keeps frontend guidance pages available under frontend/backend routes", () => {
+    const guidanceIndex = pageSource.indexOf(
+      "if (isFrontendGuidanceSlug(activeFrontendSlugPath))",
+    );
+    const backendScopingIndex = pageSource.indexOf(
+      "if (activeBackendFramework) {\n      scopedFramework = activeBackendFramework",
+    );
+
+    expect(guidanceIndex).toBeGreaterThan(-1);
+    expect(backendScopingIndex).toBeGreaterThan(-1);
+    expect(guidanceIndex).toBeLessThan(backendScopingIndex);
+    expect(pageSource).toContain("<FrontendGuidanceDocsPage");
+  });
+
+  it("uses backend metadata for frontend routes that include a backend slug", () => {
+    expect(pageSource).toContain("frameworkMetadata(");
+    expect(pageSource).toMatch(
+      /frameworkMetadata\(\s*activeBackendFramework,\s*activeFrontendSlugPath/s,
+    );
+    expect(pageSource).toContain("scopedRoutePath(");
+  });
 });

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/__tests__/framework-root-shell-layout.test.ts
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/__tests__/framework-root-shell-layout.test.ts
@@ -32,6 +32,12 @@ describe("FrameworkRootShell layout", () => {
     );
   });
 
+  it("canonicalizes React guidance routes to the React root", () => {
+    expect(pageSource).toContain(
+      'return frontendPathForBackend("react", slugPath);',
+    );
+  });
+
   it("renders backend docs when a frontend route includes a backend slug", () => {
     expect(pageSource).toContain("scopedFramework = activeBackendFramework");
     expect(pageSource).toContain("scopedSlugHrefPrefix = frontendRoutePath(");

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/__tests__/framework-root-shell-layout.test.ts
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/__tests__/framework-root-shell-layout.test.ts
@@ -21,9 +21,7 @@ describe("FrameworkRootShell layout", () => {
   it("parses frontend routes before resolving frontend content slugs", () => {
     expect(pageSource).toContain("parseFrontendRoutePath");
     expect(pageSource).toContain("activeBackendFramework");
-    expect(pageSource).toContain(
-      "frameworkOverride={activeBackendFramework}",
-    );
+    expect(pageSource).toContain("frameworkOverride={activeBackendFramework}");
   });
 
   it("redirects retired frontend URL shapes instead of rendering them", () => {
@@ -39,7 +37,7 @@ describe("FrameworkRootShell layout", () => {
     expect(pageSource).toContain("scopedSlugHrefPrefix = frontendRoutePath(");
     expect(pageSource).toContain("frameworkOverride={scopedFramework}");
     expect(pageSource).toContain(
-      'slugHrefPrefix={scopedSlugHrefPrefix ?? `/${scopedFramework}`}',
+      "slugHrefPrefix={scopedSlugHrefPrefix ?? `/${scopedFramework}`}",
     );
     expect(pageSource).toContain(
       "preferIndexMdx={Boolean(scopedSlugHrefPrefix)}",

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -179,7 +179,7 @@ function frontendMetadata(
             activeBackendFramework,
           )
         : frontendRoutePath(frontend, slugPath, activeBackendFramework),
-    });
+  });
 }
 
 function frameworkMetadata(
@@ -926,10 +926,7 @@ async function FrameworkRootPage({
       }
     }
     return (
-      <FrameworkRootShell
-        navTree={navTree}
-        slugHrefPrefix={slugHrefPrefix}
-      >
+      <FrameworkRootShell navTree={navTree} slugHrefPrefix={slugHrefPrefix}>
         <FrameworkOverview
           data={overview}
           currentFramework={framework}

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -104,7 +104,7 @@ function isFrontendRootSlug(slugPath: string): boolean {
 }
 
 function reactRootPath(slugPath: string): string {
-  return slugPath ? `/${slugPath}` : "/";
+  return frontendPathForBackend("react", slugPath);
 }
 
 function scopedRoutePath(slugHrefPrefix: string, slugPath: string): string {

--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -37,6 +37,19 @@ import type { MdxFrameworkOverviewProps } from "@/components/content/landing-pag
 import { FrameworkSetup } from "@/lib/setup-concept";
 import { frameworkOverviews } from "@/data/frameworks";
 import { docsComponents } from "@/lib/mdx-registry";
+import { resolveFrontendDocPage } from "@/lib/frontend-doc-policy";
+import {
+  getFrontendGuidanceContentSlug,
+  getFrontendContentSlug,
+  getFrontendQuickstartNavTree,
+} from "@/lib/frontend-page-content";
+import type { FrontendPageId } from "@/lib/frontend-page-content";
+import {
+  frontendPathForBackend,
+  getFrontendOption,
+  isFrontendId,
+  parseFrontendRoutePath,
+} from "@/lib/frontend-options";
 import { transformerMeta } from "@/lib/rehype-code-meta";
 import {
   CONTENT_DIR,
@@ -70,33 +83,116 @@ function hasDocsOnlyFrameworkContent(framework: string): boolean {
   );
 }
 
-// Per-framework self-canonical: /<framework>/<slug> declares itself
-// canonical (NOT the bare /<slug>) so search engines index each
-// framework variant at its own URL. When the URL's first segment
-// doesn't match a registered integration, the route falls through to
-// UnscopedDocsPage but the canonical still points at the same URL —
-// the page's identity is defined by its URL, not the resolution
-// strategy used to render it.
-//
-// Title and description come from the resolved MDX frontmatter (with
-// the same per-framework override resolution the page render uses) so
-// every variant emits its own social card and SEO description rather
-// than inheriting the layout's generic site-wide values.
-export async function generateMetadata({
-  params,
-}: {
-  params: Promise<{ framework: string; slug?: string[] }>;
-}): Promise<Metadata> {
-  const { framework, slug } = await params;
-  const slugTail = slug && slug.length > 0 ? `/${slug.join("/")}` : "";
-  const canonicalPath = `/${framework}${slugTail}`;
+function isFrontendPageId(value: string): value is FrontendPageId {
+  return isFrontendId(value) && value !== "react";
+}
+
+function frontendRoutePath(
+  frontend: FrontendPageId,
+  slugPath: string,
+  activeBackendFramework: string | null = null,
+): string {
+  return frontendPathForBackend(frontend, slugPath, activeBackendFramework);
+}
+
+function isFrontendGuidanceSlug(slugPath: string): boolean {
+  return slugPath === "using-these-docs";
+}
+
+function isFrontendRootSlug(slugPath: string): boolean {
+  return !slugPath || slugPath === "quickstart";
+}
+
+function reactRootPath(slugPath: string): string {
+  return slugPath ? `/${slugPath}` : "/";
+}
+
+function scopedRoutePath(slugHrefPrefix: string, slugPath: string): string {
+  const prefix = slugHrefPrefix.replace(/\/+$/, "");
+  const normalizedSlugPath = slugPath.split("/").filter(Boolean).join("/");
+  if (!normalizedSlugPath) return prefix || "/";
+  return `${prefix}/${normalizedSlugPath}`;
+}
+
+function legacyFrontendPathRedirect(
+  activeBackendFramework: string,
+  slugPath: string,
+): string | null {
+  const [frontendsSegment, frontend, ...tail] = slugPath
+    .split("/")
+    .filter(Boolean);
+  if (frontendsSegment !== "frontends" || !isFrontendId(frontend)) {
+    return null;
+  }
+
+  return frontendPathForBackend(
+    frontend,
+    tail.join("/"),
+    activeBackendFramework,
+  );
+}
+
+function frontendMetadata(
+  frontend: FrontendPageId,
+  slugPath: string,
+  activeBackendFramework: string | null = null,
+): Metadata {
+  if (!slugPath || slugPath === "quickstart") {
+    const contentSlug = getFrontendContentSlug(frontend);
+    const doc = loadDoc(contentSlug);
+    const option = getFrontendOption(frontend);
+
+    return buildDocMetadata({
+      title: `${doc?.fm.title ?? option.name} quickstart`,
+      description: doc?.fm.description,
+      canonicalPath: frontendRoutePath(frontend, "", activeBackendFramework),
+    });
+  }
+
+  if (slugPath === "using-these-docs") {
+    const doc = loadDoc(getFrontendGuidanceContentSlug(frontend));
+    const option = getFrontendOption(frontend);
+
+    return buildDocMetadata({
+      title: `${option.name}: ${doc?.fm.title ?? "using these docs"}`,
+      description: doc?.fm.description,
+      canonicalPath: frontendRoutePath(
+        frontend,
+        slugPath,
+        activeBackendFramework,
+      ),
+    });
+  }
+
+  const resolution = resolveFrontendDocPage(frontend, slugPath);
+  const doc =
+    resolution.status === "found" ? loadDoc(resolution.contentSlugPath) : null;
+
+  return buildDocMetadata({
+    title: doc?.fm.title ?? slugPath,
+    description: doc?.fm.description,
+    canonicalPath:
+      resolution.status === "found"
+        ? frontendRoutePath(
+            frontend,
+            resolution.slugPath,
+            activeBackendFramework,
+          )
+        : frontendRoutePath(frontend, slugPath, activeBackendFramework),
+    });
+}
+
+function frameworkMetadata(
+  framework: string,
+  slugPath: string,
+  canonicalPath = slugPath ? `/${framework}/${slugPath}` : `/${framework}`,
+): Metadata {
   // Try to read frontmatter for the resolved page. Mirror the page's
   // own content-resolution order (authored vs generated, per-framework
   // override vs root) cheaply: best-effort only; if nothing resolves,
   // the helper falls back to the framework slug as a humanised title.
   let title: string | undefined;
   let description: string | undefined;
-  const slugPath = slug?.join("/") ?? "";
   const integration = getIntegration(framework);
   const isDocsOnlyFramework =
     !integration && hasDocsOnlyFrameworkContent(framework);
@@ -104,7 +200,10 @@ export async function generateMetadata({
     // Root-surface URL. The BIA-authored page wins when one exists —
     // mirror UnscopedDocsPage's resolution so the metadata matches the
     // content the route serves.
-    const unscopedPath = [framework, ...(slug ?? [])].join("/");
+    const unscopedPath = [
+      framework,
+      ...slugPath.split("/").filter(Boolean),
+    ].join("/");
     const doc =
       loadDoc(
         `integrations/${getDocsFolder(ROOT_FRAMEWORK)}/${unscopedPath}`,
@@ -133,6 +232,7 @@ export async function generateMetadata({
       framework;
     description = indexDoc?.fm.description ?? overview?.subheader;
   }
+
   // Per-page OG route lives at /og/<slug>/og.png — see
   // src/app/og/[...slug]/route.tsx. Each framework variant gets its own
   // image because the slug is framework-scoped.
@@ -143,6 +243,86 @@ export async function generateMetadata({
     canonicalPath,
     ogPath,
   });
+}
+
+// Per-framework self-canonical: /<framework>/<slug> declares itself
+// canonical (NOT the bare /<slug>) so search engines index each
+// framework variant at its own URL. When the URL's first segment
+// doesn't match a registered integration, the route falls through to
+// UnscopedDocsPage but the canonical still points at the same URL —
+// the page's identity is defined by its URL, not the resolution
+// strategy used to render it.
+//
+// Title and description come from the resolved MDX frontmatter (with
+// the same per-framework override resolution the page render uses) so
+// every variant emits its own social card and SEO description rather
+// than inheriting the layout's generic site-wide values.
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ framework: string; slug?: string[] }>;
+}): Promise<Metadata> {
+  const { framework, slug } = await params;
+  const slugPath = slug?.join("/") ?? "";
+
+  if (framework === "react") {
+    const canonicalPath = reactRootPath(slugPath);
+    const doc = slugPath
+      ? (loadDoc(`integrations/${getDocsFolder(ROOT_FRAMEWORK)}/${slugPath}`) ??
+        loadDoc(slugPath))
+      : null;
+
+    return buildDocMetadata({
+      title: doc?.fm.title ?? (slugPath || "CopilotKit docs"),
+      description: doc?.fm.description,
+      canonicalPath,
+      ogPath: `/og${canonicalPath}/og.png`,
+    });
+  }
+
+  if (isFrontendPageId(framework)) {
+    const frontendRoute = parseFrontendRoutePath(
+      `/${[framework, ...(slug ?? [])].join("/")}`,
+      getIntegrations().map((integration) => integration.slug),
+    );
+    const activeBackendFramework =
+      frontendRoute?.backend === ROOT_FRAMEWORK
+        ? null
+        : (frontendRoute?.backend ?? null);
+    const activeFrontendSlugPath = frontendRoute?.slugPath ?? slugPath;
+    if (isFrontendGuidanceSlug(activeFrontendSlugPath)) {
+      return frontendMetadata(
+        framework,
+        activeFrontendSlugPath,
+        activeBackendFramework,
+      );
+    }
+
+    if (isFrontendRootSlug(activeFrontendSlugPath)) {
+      return frontendMetadata(framework, "", activeBackendFramework);
+    }
+
+    if (activeBackendFramework) {
+      const slugHrefPrefix = frontendRoutePath(
+        framework,
+        "",
+        activeBackendFramework,
+      );
+      return frameworkMetadata(
+        activeBackendFramework,
+        activeFrontendSlugPath,
+        scopedRoutePath(slugHrefPrefix, activeFrontendSlugPath),
+      );
+    }
+
+    return frontendMetadata(
+      framework,
+      activeFrontendSlugPath,
+      activeBackendFramework,
+    );
+  }
+
+  return frameworkMetadata(framework, slugPath);
 }
 
 export async function generateStaticParams() {
@@ -196,6 +376,101 @@ export default async function FrameworkScopedDocsPage({
     notFound();
   }
 
+  const frontendSlugPath = slug?.join("/") ?? "";
+  if (framework === "frontends") {
+    const [frontend, ...tail] = slug ?? [];
+    if (isFrontendId(frontend)) {
+      redirect(frontendPathForBackend(frontend, tail.join("/")));
+    }
+
+    redirect(frontendSlugPath ? `/${frontendSlugPath}` : "/");
+  }
+
+  if (framework === "react") {
+    redirect(reactRootPath(frontendSlugPath));
+  }
+
+  let scopedFramework = framework;
+  let scopedSlug = slug;
+  let scopedSlugHrefPrefix: string | null = null;
+  let activeFrontendPage: FrontendPageId | null = null;
+
+  if (isFrontendPageId(framework)) {
+    activeFrontendPage = framework;
+    const frontendRoute = parseFrontendRoutePath(
+      `/${[framework, ...(slug ?? [])].join("/")}`,
+      getIntegrations().map((integration) => integration.slug),
+    );
+    const activeBackendFramework = frontendRoute?.backend ?? null;
+    const activeFrontendSlugPath = frontendRoute?.slugPath ?? frontendSlugPath;
+
+    if (activeBackendFramework === ROOT_FRAMEWORK) {
+      redirect(frontendRoutePath(framework, activeFrontendSlugPath));
+    }
+
+    if (
+      activeBackendFramework &&
+      getDocsMode(activeBackendFramework) === "hidden"
+    ) {
+      notFound();
+    }
+
+    if (!activeFrontendSlugPath) {
+      return (
+        <FrontendQuickstartDocsPage
+          frontend={framework}
+          activeBackendFramework={activeBackendFramework}
+        />
+      );
+    }
+
+    if (activeFrontendSlugPath === "quickstart") {
+      redirect(frontendRoutePath(framework, "", activeBackendFramework));
+    }
+
+    if (isFrontendGuidanceSlug(activeFrontendSlugPath)) {
+      return (
+        <FrontendGuidanceDocsPage
+          frontend={framework}
+          activeBackendFramework={activeBackendFramework}
+        />
+      );
+    }
+
+    if (activeBackendFramework) {
+      scopedFramework = activeBackendFramework;
+      scopedSlug = activeFrontendSlugPath
+        ? activeFrontendSlugPath.split("/").filter(Boolean)
+        : undefined;
+      scopedSlugHrefPrefix = frontendRoutePath(
+        framework,
+        "",
+        activeBackendFramework,
+      );
+    } else {
+      const resolution = resolveFrontendDocPage(
+        framework,
+        activeFrontendSlugPath,
+      );
+      if (resolution.status === "not-found") notFound();
+
+      return (
+        <DocsPageView
+          slugPath={resolution.slugPath}
+          contentSlugPath={resolution.contentSlugPath}
+          slugHrefPrefix={frontendRoutePath(
+            framework,
+            "",
+            activeBackendFramework,
+          )}
+          frameworkOverride={activeBackendFramework}
+          navTree={getFrontendQuickstartNavTree(framework)}
+          sidebarBannerSlot={<FrontendSidebarBanner frontend={framework} />}
+        />
+      );
+    }
+  }
+
   // Validate the framework slug against the registry.
   // If not a registered integration, treat the URL as an unscoped doc path.
   // This is necessary because Next.js routes /quickstart here (dynamic segment
@@ -206,11 +481,11 @@ export default async function FrameworkScopedDocsPage({
   // but no demo package in `showcase/integrations/`, so they're absent from
   // the registry. Recognize them by slug so the framework-root page (Tier 1
   // FrameworkOverview / Tier 2 MDX index) can still render.
-  const integration = getIntegration(framework);
+  const integration = getIntegration(scopedFramework);
   const isDocsOnlyFramework =
-    !integration && hasDocsOnlyFrameworkContent(framework);
+    !integration && hasDocsOnlyFrameworkContent(scopedFramework);
   if (!integration && !isDocsOnlyFramework) {
-    const unscopedPath = [framework, ...(slug ?? [])].join("/");
+    const unscopedPath = [scopedFramework, ...(scopedSlug ?? [])].join("/");
     return <UnscopedDocsPage slugPath={unscopedPath} />;
   }
 
@@ -219,11 +494,16 @@ export default async function FrameworkScopedDocsPage({
   // 404 is the right answer; the unscoped fallback above would still
   // show the user the agnostic docs under their framework slug, which
   // misleadingly implies the framework has docs.
-  if (integration && getDocsMode(framework) === "hidden") {
+  if (integration && getDocsMode(scopedFramework) === "hidden") {
     notFound();
   }
 
-  const slugPath = slug?.join("/") ?? "";
+  const slugPath = scopedSlug?.join("/") ?? "";
+  const frontendRedirect = legacyFrontendPathRedirect(
+    scopedFramework,
+    slugPath,
+  );
+  if (frontendRedirect) redirect(frontendRedirect);
 
   // No slug → framework landing page. Three-tier resolution:
   //   1. Data-driven `FrameworkOverview` when a record exists in
@@ -234,7 +514,13 @@ export default async function FrameworkScopedDocsPage({
   //      have either a data record OR an index.mdx after Phase 2; a
   //      missing entry is an authoring error worth surfacing.
   if (!slugPath) {
-    return <FrameworkRootPage framework={framework} />;
+    return (
+      <FrameworkRootPage
+        framework={scopedFramework}
+        preferIndexMdx={Boolean(scopedSlugHrefPrefix)}
+        slugHrefPrefix={scopedSlugHrefPrefix ?? `/${scopedFramework}`}
+      />
+    );
   }
 
   // `/<framework>/unselected/<path>` is incoherent — a framework IS
@@ -243,7 +529,11 @@ export default async function FrameworkScopedDocsPage({
   // same underlying content, just with Snippets resolved against the
   // selected framework's cells).
   if (slugPath.startsWith("unselected/")) {
-    redirect(`/${framework}/${slugPath.slice("unselected/".length)}`);
+    redirect(
+      `${scopedSlugHrefPrefix ?? `/${scopedFramework}`}/${slugPath.slice(
+        "unselected/".length,
+      )}`,
+    );
   }
 
   // Content resolution:
@@ -265,12 +555,12 @@ export default async function FrameworkScopedDocsPage({
   // python → `microsoft-agent-framework/`, plus legacy renames for
   // google-adk → `adk/` and strands → `aws-strands/`. Resolve the URL
   // slug to its docs folder before touching disk.
-  const docsFolder = getDocsFolder(framework);
-  const docsMode = getDocsMode(framework);
+  const docsFolder = getDocsFolder(scopedFramework);
+  const docsMode = getDocsMode(scopedFramework);
   const frameworkName =
     integration?.name ??
-    frameworkOverviews[framework]?.frameworkName ??
-    framework;
+    frameworkOverviews[scopedFramework]?.frameworkName ??
+    scopedFramework;
 
   let contentSlugPath: string = slugPath;
   let doc: ReturnType<typeof loadDoc> = null;
@@ -317,7 +607,7 @@ export default async function FrameworkScopedDocsPage({
   const navTree: NavNode[] =
     docsMode === "authored"
       ? buildFrameworkOnlyNav(docsFolder)
-      : buildFrameworkNav(docsFolder, frameworkName, framework);
+      : buildFrameworkNav(docsFolder, frameworkName, scopedFramework);
 
   if (!doc) {
     // No root MDX and no override for this framework. If the topic
@@ -339,7 +629,9 @@ export default async function FrameworkScopedDocsPage({
           availableIn={availableIn}
           navTree={navTree}
           frameworkName={frameworkName}
-          frameworkSlug={framework}
+          frameworkSlug={scopedFramework}
+          slugHrefPrefix={scopedSlugHrefPrefix ?? `/${scopedFramework}`}
+          activeFrontendPage={activeFrontendPage}
         />
       );
     }
@@ -352,7 +644,7 @@ export default async function FrameworkScopedDocsPage({
   const missingCell =
     integration &&
     doc.fm.defaultCell &&
-    !frameworkHasCellFor(framework, doc.fm.defaultCell);
+    !frameworkHasCellFor(scopedFramework, doc.fm.defaultCell);
   const alternativeFrameworks = doc.fm.defaultCell
     ? findFrameworksWithCell(
         doc.fm.defaultCell,
@@ -377,7 +669,9 @@ export default async function FrameworkScopedDocsPage({
               const alt = getIntegration(altSlug);
               if (!alt) return null;
               const name = alt.name;
-              const href = `/${altSlug}/${slugPath}`;
+              const href = activeFrontendPage
+                ? frontendRoutePath(activeFrontendPage, slugPath, altSlug)
+                : `/${altSlug}/${slugPath}`;
               return (
                 <React.Fragment key={altSlug}>
                   {i > 0 && ", "}
@@ -401,12 +695,69 @@ export default async function FrameworkScopedDocsPage({
     <DocsPageView
       slugPath={slugPath}
       contentSlugPath={contentSlugPath}
-      slugHrefPrefix={`/${framework}`}
-      frameworkOverride={framework}
-      navTree={navTree}
+      slugHrefPrefix={scopedSlugHrefPrefix ?? `/${scopedFramework}`}
+      frameworkOverride={scopedFramework}
+      navTree={
+        activeFrontendPage
+          ? getFrontendQuickstartNavTree(activeFrontendPage)
+          : navTree
+      }
       bannerSlot={banner}
+      sidebarBannerSlot={
+        activeFrontendPage ? (
+          <FrontendSidebarBanner frontend={activeFrontendPage} />
+        ) : undefined
+      }
     />
   );
+}
+
+function FrontendQuickstartDocsPage({
+  frontend,
+  activeBackendFramework,
+}: {
+  frontend: FrontendPageId;
+  activeBackendFramework?: string | null;
+}) {
+  const contentSlug = getFrontendContentSlug(frontend);
+  if (!loadDoc(contentSlug)) notFound();
+
+  return (
+    <DocsPageView
+      slugPath=""
+      contentSlugPath={contentSlug}
+      slugHrefPrefix={frontendRoutePath(frontend, "", activeBackendFramework)}
+      frameworkOverride={activeBackendFramework}
+      navTree={getFrontendQuickstartNavTree(frontend)}
+      sidebarBannerSlot={<FrontendSidebarBanner frontend={frontend} />}
+    />
+  );
+}
+
+function FrontendGuidanceDocsPage({
+  frontend,
+  activeBackendFramework,
+}: {
+  frontend: FrontendPageId;
+  activeBackendFramework?: string | null;
+}) {
+  const contentSlug = getFrontendGuidanceContentSlug(frontend);
+  if (!loadDoc(contentSlug)) notFound();
+
+  return (
+    <DocsPageView
+      slugPath="using-these-docs"
+      contentSlugPath={contentSlug}
+      slugHrefPrefix={frontendRoutePath(frontend, "", activeBackendFramework)}
+      frameworkOverride={activeBackendFramework}
+      navTree={getFrontendQuickstartNavTree(frontend)}
+      sidebarBannerSlot={<FrontendSidebarBanner frontend={frontend} />}
+    />
+  );
+}
+
+function FrontendSidebarBanner(_props: { frontend: FrontendPageId }) {
+  return <SidebarFrameworkSelector />;
 }
 
 // ---------------------------------------------------------------------------
@@ -434,7 +785,15 @@ const FRAMEWORK_OVERVIEW_MDX_DIR = path.join(
   "src/content/framework-overviews",
 );
 
-async function FrameworkRootPage({ framework }: { framework: string }) {
+async function FrameworkRootPage({
+  framework,
+  preferIndexMdx = false,
+  slugHrefPrefix = `/${framework}`,
+}: {
+  framework: string;
+  preferIndexMdx?: boolean;
+  slugHrefPrefix?: string;
+}) {
   // Some frameworks are docs-only — they have a `frameworkOverviews`
   // entry and an `integrations/<slug>/` content folder, but no demo
   // package in `showcase/integrations/`, so `getIntegration()` returns
@@ -459,6 +818,21 @@ async function FrameworkRootPage({ framework }: { framework: string }) {
     docsMode === "authored"
       ? buildFrameworkOnlyNav(docsFolder)
       : buildFrameworkNav(docsFolder, integrationName, framework);
+
+  const indexContentPath = `integrations/${docsFolder}/index`;
+  const indexDoc = loadDoc(indexContentPath);
+
+  if (preferIndexMdx && indexDoc) {
+    return (
+      <DocsPageView
+        slugPath=""
+        contentSlugPath={indexContentPath}
+        slugHrefPrefix={slugHrefPrefix}
+        frameworkOverride={framework}
+        navTree={navTree}
+      />
+    );
+  }
 
   // Tier 1: data-driven FrameworkOverview. ONLY for `generated` mode —
   // `authored` frameworks skip straight to Tier 2 so their ported
@@ -552,7 +926,10 @@ async function FrameworkRootPage({ framework }: { framework: string }) {
       }
     }
     return (
-      <FrameworkRootShell framework={framework} navTree={navTree}>
+      <FrameworkRootShell
+        navTree={navTree}
+        slugHrefPrefix={slugHrefPrefix}
+      >
         <FrameworkOverview
           data={overview}
           currentFramework={framework}
@@ -568,13 +945,12 @@ async function FrameworkRootPage({ framework }: { framework: string }) {
   // `slugPath=""` keeps active-link logic pointing at the framework
   // root (the new `"index"`→`""` rewrite in buildFrameworkOverridesNav
   // matches this).
-  const indexContentPath = `integrations/${docsFolder}/index`;
-  if (loadDoc(indexContentPath)) {
+  if (indexDoc) {
     return (
       <DocsPageView
         slugPath=""
         contentSlugPath={indexContentPath}
-        slugHrefPrefix={`/${framework}`}
+        slugHrefPrefix={slugHrefPrefix}
         frameworkOverride={framework}
         navTree={navTree}
       />
@@ -591,17 +967,15 @@ async function FrameworkRootPage({ framework }: { framework: string }) {
  * `DocsPageView` directly.
  */
 function FrameworkRootShell({
-  framework,
   navTree,
+  slugHrefPrefix,
   children,
 }: {
-  framework: string;
   navTree: NavNode[];
+  slugHrefPrefix: string;
   children: React.ReactNode;
 }) {
-  // slugHrefPrefix is `/<framework>` so every sidebar link resolves
-  // inside the framework scope.
-  const pageTree = navTreeToPageTree(navTree, `/${framework}`);
+  const pageTree = navTreeToPageTree(navTree, slugHrefPrefix);
   return (
     <ShellDocsLayout tree={pageTree} banner={<SidebarFrameworkSelector />}>
       <DocsPage
@@ -635,17 +1009,33 @@ function NotAvailableForFrameworkPage({
   navTree,
   frameworkName,
   frameworkSlug,
+  slugHrefPrefix = `/${frameworkSlug}`,
+  activeFrontendPage = null,
 }: {
   slugPath: string;
   availableIn: string[];
   navTree: NavNode[];
   frameworkName: string;
   frameworkSlug: string;
+  slugHrefPrefix?: string;
+  activeFrontendPage?: FrontendPageId | null;
 }) {
   const title = humanizeSlug(slugPath);
-  const pageTree = navTreeToPageTree(navTree, `/${frameworkSlug}`);
+  const sidebarNavTree = activeFrontendPage
+    ? getFrontendQuickstartNavTree(activeFrontendPage)
+    : navTree;
+  const pageTree = navTreeToPageTree(sidebarNavTree, slugHrefPrefix);
   return (
-    <ShellDocsLayout tree={pageTree} banner={<SidebarFrameworkSelector />}>
+    <ShellDocsLayout
+      tree={pageTree}
+      banner={
+        activeFrontendPage ? (
+          <FrontendSidebarBanner frontend={activeFrontendPage} />
+        ) : (
+          <SidebarFrameworkSelector />
+        )
+      }
+    >
       <DocsPage
         toc={[]}
         tableOfContent={{ enabled: false }}
@@ -672,10 +1062,13 @@ function NotAvailableForFrameworkPage({
               {availableIn.map((slug) => {
                 const alt = getIntegration(slug);
                 if (!alt) return null;
+                const href = activeFrontendPage
+                  ? frontendRoutePath(activeFrontendPage, slugPath, slug)
+                  : `/${slug}/${slugPath}`;
                 return (
                   <li key={slug}>
                     <Link
-                      href={`/${slug}/${slugPath}`}
+                      href={href}
                       className="text-sm text-[var(--accent)] hover:underline"
                     >
                       {alt.name}
@@ -688,7 +1081,7 @@ function NotAvailableForFrameworkPage({
           <p className="text-[13px] text-[var(--text-muted)]">
             Or return to{" "}
             <Link
-              href={`/${frameworkSlug}`}
+              href={slugHrefPrefix}
               className="text-[var(--accent)] hover:underline"
             >
               the {frameworkName} docs

--- a/showcase/shell-docs/src/app/frontends/[frontend]/[...slug]/page.test.ts
+++ b/showcase/shell-docs/src/app/frontends/[frontend]/[...slug]/page.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { redirect } from "next/navigation";
+
+const navigation = vi.hoisted(() => ({
+  redirect: vi.fn((path: string) => {
+    throw new Error(`NEXT_REDIRECT:${path}`);
+  }),
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: navigation.redirect,
+  notFound: navigation.notFound,
+}));
+
+import FrontendDocPage from "./page";
+
+const redirectMock = vi.mocked(redirect);
+
+function callFrontendDocPage(frontend: string, slug: string[]) {
+  return FrontendDocPage({
+    params: Promise.resolve({ frontend, slug }),
+  });
+}
+
+describe("legacy frontend docs route", () => {
+  it("canonicalizes React guidance docs to the React root", async () => {
+    await expect(
+      callFrontendDocPage("react", ["using-these-docs"]),
+    ).rejects.toThrow("NEXT_REDIRECT:/");
+
+    expect(redirectMock).toHaveBeenCalledWith("/");
+  });
+});

--- a/showcase/shell-docs/src/app/frontends/[frontend]/[...slug]/page.tsx
+++ b/showcase/shell-docs/src/app/frontends/[frontend]/[...slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
-import { isFrontendId } from "@/lib/frontend-options";
+import { frontendPathForBackend, isFrontendId } from "@/lib/frontend-options";
 import { loadDoc } from "@/lib/docs-render";
 import { resolveFrontendDocPage } from "@/lib/frontend-doc-policy";
 import { buildDocMetadata } from "@/lib/seo-metadata";
@@ -53,7 +53,9 @@ export default async function FrontendDocPage({
   const { frontend } = resolvedParams;
   if (!isFrontendId(frontend)) notFound();
   const slugPath = slugPathFromParams(resolvedParams);
-  if (frontend === "react") redirect(slugPath ? `/${slugPath}` : "/");
+  if (frontend === "react") {
+    redirect(frontendPathForBackend("react", slugPath));
+  }
 
   if (slugPath === "quickstart") redirect(`/${frontend}`);
   if (slugPath === "using-these-docs") {

--- a/showcase/shell-docs/src/app/frontends/[frontend]/[...slug]/page.tsx
+++ b/showcase/shell-docs/src/app/frontends/[frontend]/[...slug]/page.tsx
@@ -1,7 +1,5 @@
 import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
-import { DocsPageView } from "@/components/docs-page-view";
-import { getFrontendQuickstartNavTree } from "@/lib/frontend-page-content";
 import { isFrontendId } from "@/lib/frontend-options";
 import { loadDoc } from "@/lib/docs-render";
 import { resolveFrontendDocPage } from "@/lib/frontend-doc-policy";
@@ -28,7 +26,7 @@ export async function generateMetadata({
   if (!isFrontendId(frontend) || frontend === "react") {
     return buildDocMetadata({
       title: "Frontend docs",
-      canonicalPath: "/frontends",
+      canonicalPath: "/",
     });
   }
 
@@ -42,7 +40,7 @@ export async function generateMetadata({
     canonicalPath:
       resolution.status === "found"
         ? resolution.canonicalPath
-        : `/frontends/${frontend}/${slugPath}`,
+        : `/${frontend}/${slugPath}`,
   });
 }
 
@@ -54,23 +52,13 @@ export default async function FrontendDocPage({
   const resolvedParams = await params;
   const { frontend } = resolvedParams;
   if (!isFrontendId(frontend)) notFound();
-  if (frontend === "react") redirect("/");
-
   const slugPath = slugPathFromParams(resolvedParams);
-  if (slugPath === "quickstart") redirect(`/frontends/${frontend}`);
+  if (frontend === "react") redirect(slugPath ? `/${slugPath}` : "/");
+
+  if (slugPath === "quickstart") redirect(`/${frontend}`);
   if (slugPath === "using-these-docs") {
-    redirect(`/frontends/${frontend}/using-these-docs`);
+    redirect(`/${frontend}/using-these-docs`);
   }
 
-  const resolution = resolveFrontendDocPage(frontend, slugPath);
-  if (resolution.status === "not-found") notFound();
-
-  return (
-    <DocsPageView
-      slugPath={resolution.slugPath}
-      contentSlugPath={resolution.contentSlugPath}
-      slugHrefPrefix={`/frontends/${frontend}`}
-      navTree={getFrontendQuickstartNavTree(frontend)}
-    />
-  );
+  redirect(`/${frontend}/${slugPath}`);
 }

--- a/showcase/shell-docs/src/app/frontends/[frontend]/page.tsx
+++ b/showcase/shell-docs/src/app/frontends/[frontend]/page.tsx
@@ -1,10 +1,8 @@
 import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
-import { DocsPageView } from "@/components/docs-page-view";
 import {
   FRONTEND_PAGE_IDS,
   getFrontendContentSlug,
-  getFrontendQuickstartNavTree,
 } from "@/lib/frontend-page-content";
 import { getFrontendOption, isFrontendId } from "@/lib/frontend-options";
 import { loadDoc } from "@/lib/docs-render";
@@ -23,7 +21,7 @@ export async function generateMetadata({
   if (!isFrontendId(frontend) || frontend === "react") {
     return buildDocMetadata({
       title: "Frontend quickstart",
-      canonicalPath: "/frontends",
+      canonicalPath: "/",
     });
   }
 
@@ -34,7 +32,7 @@ export async function generateMetadata({
   return buildDocMetadata({
     title: `${doc?.fm.title ?? option.name} quickstart`,
     description: doc?.fm.description,
-    canonicalPath: `/frontends/${frontend}`,
+    canonicalPath: `/${frontend}`,
   });
 }
 
@@ -47,15 +45,5 @@ export default async function FrontendQuickstartPage({
   if (!isFrontendId(frontend)) notFound();
   if (frontend === "react") redirect("/");
 
-  const contentSlug = getFrontendContentSlug(frontend);
-  if (!loadDoc(contentSlug)) notFound();
-
-  return (
-    <DocsPageView
-      slugPath=""
-      contentSlugPath={contentSlug}
-      slugHrefPrefix={`/frontends/${frontend}`}
-      navTree={getFrontendQuickstartNavTree(frontend)}
-    />
-  );
+  redirect(`/${frontend}`);
 }

--- a/showcase/shell-docs/src/app/frontends/[frontend]/using-these-docs/page.tsx
+++ b/showcase/shell-docs/src/app/frontends/[frontend]/using-these-docs/page.tsx
@@ -1,10 +1,8 @@
 import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
-import { DocsPageView } from "@/components/docs-page-view";
 import {
-  FRONTEND_GUIDANCE_CONTENT_SLUG,
   FRONTEND_PAGE_IDS,
-  getFrontendQuickstartNavTree,
+  getFrontendGuidanceContentSlug,
 } from "@/lib/frontend-page-content";
 import { getFrontendOption, isFrontendId } from "@/lib/frontend-options";
 import { loadDoc } from "@/lib/docs-render";
@@ -23,17 +21,17 @@ export async function generateMetadata({
   if (!isFrontendId(frontend) || frontend === "react") {
     return buildDocMetadata({
       title: "Using these frontend docs",
-      canonicalPath: "/frontends",
+      canonicalPath: "/",
     });
   }
 
-  const doc = loadDoc(FRONTEND_GUIDANCE_CONTENT_SLUG);
+  const doc = loadDoc(getFrontendGuidanceContentSlug(frontend));
   const option = getFrontendOption(frontend);
 
   return buildDocMetadata({
     title: `${option.name}: ${doc?.fm.title ?? "using these docs"}`,
     description: doc?.fm.description,
-    canonicalPath: `/frontends/${frontend}/using-these-docs`,
+    canonicalPath: `/${frontend}/using-these-docs`,
   });
 }
 
@@ -46,14 +44,5 @@ export default async function FrontendGuidancePage({
   if (!isFrontendId(frontend)) notFound();
   if (frontend === "react") redirect("/");
 
-  if (!loadDoc(FRONTEND_GUIDANCE_CONTENT_SLUG)) notFound();
-
-  return (
-    <DocsPageView
-      slugPath="using-these-docs"
-      contentSlugPath={FRONTEND_GUIDANCE_CONTENT_SLUG}
-      slugHrefPrefix={`/frontends/${frontend}`}
-      navTree={getFrontendQuickstartNavTree(frontend)}
-    />
-  );
+  redirect(`/${frontend}/using-these-docs`);
 }

--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -260,12 +260,44 @@
   padding: 4px;
 }
 
+.shell-docs-picker-group-selected {
+  background: color-mix(in oklch, var(--accent-dim) 34%, transparent);
+}
+
+.shell-docs-picker-group-bordered {
+  border: 1px solid var(--nav-control-border);
+}
+
 .dark .shell-docs-picker-group {
+  background: color-mix(in oklch, var(--accent) 9%, transparent);
+}
+
+.dark .shell-docs-picker-group-selected {
   background: color-mix(in oklch, var(--accent) 9%, transparent);
 }
 
 .shell-docs-picker-row {
   border-radius: var(--shell-docs-radius-control);
+}
+
+.shell-docs-picker-row-divided {
+  position: relative;
+}
+
+.shell-docs-picker-row-divided::before {
+  content: "";
+  position: absolute;
+  top: -1px;
+  right: 8px;
+  left: 8px;
+  height: 1px;
+  background: var(--nav-control-border);
+  pointer-events: none;
+}
+
+.shell-docs-picker-menu {
+  box-shadow: 0 18px 42px -18px rgba(1, 5, 7, 0.18);
+  clip-path: inset(0 -48px -48px -48px);
 }
 
 .shell-docs-picker-icon-chip {
@@ -578,6 +610,154 @@
 .shell-docs-sidebar p:has(.shell-docs-react-docs-proxy) svg {
   color: color-mix(in srgb, var(--accent) 55%, var(--text-muted)) !important;
   opacity: 0.65;
+}
+
+.shell-docs-sidebar p:has(.shell-docs-frontend-docs-upcoming) {
+  display: block !important;
+  padding: 0 0.5rem !important;
+  margin: 1.75rem 0 0.25rem !important;
+}
+
+.shell-docs-frontend-docs-upcoming {
+  position: relative;
+  display: flex;
+  min-height: max(36rem, calc(100dvh - 27rem));
+  flex-direction: column;
+  padding: 0;
+  cursor: default;
+  user-select: none;
+}
+
+.shell-docs-frontend-docs-upcoming-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  line-height: inherit;
+}
+
+.shell-docs-frontend-docs-upcoming-header svg {
+  width: 16px !important;
+  height: 16px !important;
+  flex: 0 0 auto;
+  color: var(--accent) !important;
+}
+
+.shell-docs-frontend-docs-upcoming-title {
+  min-width: 0;
+  overflow: hidden;
+  color: inherit;
+  font: inherit;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shell-docs-frontend-docs-upcoming-copy {
+  display: block;
+  margin-top: 0.5rem;
+  max-width: 16.5rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  color: color-mix(in oklch, var(--text-muted) 78%, transparent);
+  text-transform: none;
+  user-select: text;
+}
+
+.shell-docs-frontend-docs-upcoming-link {
+  color: color-mix(in oklch, var(--accent) 86%, var(--text));
+  font-weight: 650;
+  text-decoration: none;
+  pointer-events: auto;
+}
+
+.shell-docs-frontend-docs-upcoming-link:hover {
+  text-decoration: underline;
+  text-underline-offset: 0.125rem;
+}
+
+.shell-docs-frontend-docs-upcoming-stack {
+  display: grid;
+  flex: 1 1 auto;
+  min-height: 0;
+  grid-template-rows: repeat(8, minmax(2.875rem, 1fr));
+  gap: 0.375rem;
+  margin-top: 0.875rem;
+  padding-bottom: 0.75rem;
+  -webkit-mask-image: linear-gradient(to bottom, #000 82%, transparent);
+  mask-image: linear-gradient(to bottom, #000 82%, transparent);
+  pointer-events: none;
+}
+
+.shell-docs-frontend-docs-upcoming-sheet {
+  position: relative;
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.375rem;
+  overflow: hidden;
+  border: 1px solid color-mix(in oklch, var(--border) 52%, transparent);
+  border-radius: var(--shell-docs-radius-control);
+  background: color-mix(in oklch, var(--accent-dim) 15%, transparent);
+  padding: 0.625rem 0.875rem;
+  box-shadow: none;
+  opacity: 0.76;
+}
+
+.shell-docs-frontend-docs-upcoming-sheet::before,
+.shell-docs-frontend-docs-upcoming-sheet::after {
+  content: "";
+  position: absolute;
+}
+
+.shell-docs-frontend-docs-upcoming-sheet::before {
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in oklch, var(--bg-surface) 28%, transparent),
+    transparent
+  );
+  opacity: 0.34;
+}
+
+.shell-docs-frontend-docs-upcoming-sheet::after {
+  display: none;
+}
+
+.shell-docs-frontend-docs-upcoming-sheet:nth-child(2n) {
+  opacity: 0.66;
+}
+
+.shell-docs-frontend-docs-upcoming-sheet:nth-child(3n) {
+  opacity: 0.56;
+}
+
+.shell-docs-frontend-docs-upcoming-sheet-line {
+  position: relative;
+  display: block;
+  height: 0.375rem;
+  border-radius: 9999px;
+  background: color-mix(in oklch, var(--text-faint) 19%, transparent);
+}
+
+.shell-docs-frontend-docs-upcoming-sheet-line-long {
+  width: 78%;
+}
+
+.shell-docs-frontend-docs-upcoming-sheet-line-medium {
+  width: 60%;
+}
+
+.shell-docs-frontend-docs-upcoming-sheet-line-short {
+  width: 42%;
+}
+
+.dark .shell-docs-frontend-docs-upcoming-sheet {
+  background: color-mix(in oklch, var(--accent) 8%, transparent);
 }
 
 /* Fumadocs CodeBlock chrome — force a single tokenized surface throughout.

--- a/showcase/shell-docs/src/app/llms-mdx/[[...slug]]/route.test.ts
+++ b/showcase/shell-docs/src/app/llms-mdx/[[...slug]]/route.test.ts
@@ -17,20 +17,48 @@ vi.mock("@/lib/frontend-doc-policy", () => ({
 vi.mock("@/lib/frontend-page-content", () => ({
   FRONTEND_GUIDANCE_CONTENT_SLUG: "frontends/using-these-docs",
   getFrontendContentSlug: vi.fn((id: string) => `frontends/${id}`),
+  getFrontendGuidanceContentSlug: vi.fn((id: string) =>
+    id === "slack" || id === "teams"
+      ? "frontends/using-these-docs"
+      : "frontends/docs-status",
+  ),
 }));
 
 vi.mock("@/lib/frontend-options", () => ({
   isFrontendId: vi.fn((value: string | undefined) =>
     ["react", "vue", "react-native", "slack", "teams"].includes(value ?? ""),
   ),
+  parseFrontendRoutePath: vi.fn(
+    (pathname: string, backendFrameworkSlugs: readonly string[] = []) => {
+      const [first, ...rest] = pathname.split("/").filter(Boolean);
+      if (!["vue", "react-native", "slack", "teams"].includes(first ?? "")) {
+        return null;
+      }
+      const [maybeBackend, ...tail] = rest;
+      const backend =
+        maybeBackend && backendFrameworkSlugs.includes(maybeBackend)
+          ? maybeBackend
+          : null;
+      return {
+        frontend: first,
+        backend,
+        slugPath: backend ? tail.join("/") : rest.join("/"),
+      };
+    },
+  ),
 }));
 
 vi.mock("@/lib/registry", () => ({
   getDocsFolder: vi.fn((slug: string) =>
-    slug === "langgraph-python" ? "langgraph" : slug,
+    slug === "langgraph-python" || slug === "langgraph-typescript"
+      ? "langgraph"
+      : slug,
   ),
   getDocsMode: vi.fn(() => "generated"),
-  getIntegrations: vi.fn(() => [{ slug: "langgraph-python" }]),
+  getIntegrations: vi.fn(() => [
+    { slug: "langgraph-python" },
+    { slug: "langgraph-typescript" },
+  ]),
   ROOT_FRAMEWORK: "built-in-agent",
 }));
 
@@ -67,11 +95,14 @@ describe("llms-mdx route", () => {
       (id: string) => `frontends/${id}`,
     );
     getDocsFolderMock.mockImplementation((slug: string) =>
-      slug === "langgraph-python" ? "langgraph" : slug,
+      slug === "langgraph-python" || slug === "langgraph-typescript"
+        ? "langgraph"
+        : slug,
     );
     getDocsModeMock.mockReturnValue("generated");
     getIntegrationsMock.mockReturnValue([
       { slug: "langgraph-python" } as never,
+      { slug: "langgraph-typescript" } as never,
     ]);
     renderPageToLlmTextMock.mockReturnValue("rendered markdown");
   });
@@ -132,18 +163,51 @@ describe("llms-mdx route", () => {
         : null,
     );
 
-    const response = await callLlmsMdxRoute(["frontends", "slack"]);
+    const response = await callLlmsMdxRoute(["slack"]);
 
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toBe("rendered markdown");
     expect(loadDocMock).toHaveBeenCalledWith("frontends/slack");
     expect(renderPageToLlmTextMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "frontends/slack",
+        url: "slack",
         filePath: "frontends/slack.mdx",
         loadSlug: "frontends/slack",
       }),
       { framework: undefined },
+    );
+  });
+
+  it("serves frontend quickstart markdown under two-axis frontend/backend root URLs", async () => {
+    resolveFrontendDocPageMock.mockReturnValue({ status: "not-found" });
+    loadDocMock.mockImplementation((slug: string) =>
+      slug === "frontends/vue"
+        ? {
+            source: "",
+            filePath: "frontends/vue.mdx",
+            fm: {
+              title: "Vue Quickstart",
+              description: "Vue frontend docs.",
+            },
+          }
+        : null,
+    );
+
+    const response = await callLlmsMdxRoute(["vue", "langgraph-python"]);
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("rendered markdown");
+    expect(loadDocMock).toHaveBeenCalledWith("frontends/vue");
+    expect(loadDocMock).not.toHaveBeenCalledWith("index");
+    expect(loadDocMock).not.toHaveBeenCalledWith("integrations/langgraph/index");
+    expect(renderPageToLlmTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "vue/langgraph-python",
+        filePath: "frontends/vue.mdx",
+        loadSlug: "frontends/vue",
+        framework: "langgraph-python",
+      }),
+      { framework: "langgraph-python" },
     );
   });
 
@@ -154,29 +218,63 @@ describe("llms-mdx route", () => {
             source: "",
             filePath: "frontends/using-these-docs.mdx",
             fm: {
-              title: "Using these docs",
+              title: "About early access",
               description: "How to read frontend docs.",
             },
           }
         : null,
     );
 
-    const response = await callLlmsMdxRoute([
-      "frontends",
-      "slack",
-      "using-these-docs",
-    ]);
+    const response = await callLlmsMdxRoute(["slack", "using-these-docs"]);
 
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toBe("rendered markdown");
     expect(loadDocMock).toHaveBeenCalledWith("frontends/using-these-docs");
     expect(renderPageToLlmTextMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "frontends/slack/using-these-docs",
+        url: "slack/using-these-docs",
         filePath: "frontends/using-these-docs.mdx",
         loadSlug: "frontends/using-these-docs",
       }),
       { framework: undefined },
+    );
+  });
+
+  it("serves frontend guidance markdown under two-axis frontend/backend URLs", async () => {
+    loadDocMock.mockImplementation((slug: string) =>
+      slug === "frontends/docs-status"
+        ? {
+            source: "",
+            filePath: "frontends/docs-status.mdx",
+            fm: {
+              title: "Docs status",
+              description: "What to expect while frontend docs catch up.",
+            },
+          }
+        : null,
+    );
+
+    const response = await callLlmsMdxRoute([
+      "react-native",
+      "langgraph-typescript",
+      "using-these-docs",
+    ]);
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("rendered markdown");
+    expect(loadDocMock).toHaveBeenCalledWith("frontends/docs-status");
+    expect(loadDocMock).not.toHaveBeenCalledWith("using-these-docs");
+    expect(loadDocMock).not.toHaveBeenCalledWith(
+      "integrations/langgraph/using-these-docs",
+    );
+    expect(renderPageToLlmTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "react-native/langgraph-typescript/using-these-docs",
+        filePath: "frontends/docs-status.mdx",
+        loadSlug: "frontends/docs-status",
+        framework: "langgraph-typescript",
+      }),
+      { framework: "langgraph-typescript" },
     );
   });
 
@@ -202,7 +300,6 @@ describe("llms-mdx route", () => {
     );
 
     const response = await callLlmsMdxRoute([
-      "frontends",
       "slack",
       "concepts",
       "architecture",
@@ -217,7 +314,7 @@ describe("llms-mdx route", () => {
     expect(loadDocMock).toHaveBeenCalledWith("concepts/architecture");
     expect(renderPageToLlmTextMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "frontends/slack/concepts/architecture",
+        url: "slack/concepts/architecture",
         filePath: "concepts/architecture.mdx",
         loadSlug: "concepts/architecture",
       }),

--- a/showcase/shell-docs/src/app/llms-mdx/[[...slug]]/route.test.ts
+++ b/showcase/shell-docs/src/app/llms-mdx/[[...slug]]/route.test.ts
@@ -199,7 +199,9 @@ describe("llms-mdx route", () => {
     await expect(response.text()).resolves.toBe("rendered markdown");
     expect(loadDocMock).toHaveBeenCalledWith("frontends/vue");
     expect(loadDocMock).not.toHaveBeenCalledWith("index");
-    expect(loadDocMock).not.toHaveBeenCalledWith("integrations/langgraph/index");
+    expect(loadDocMock).not.toHaveBeenCalledWith(
+      "integrations/langgraph/index",
+    );
     expect(renderPageToLlmTextMock).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "vue/langgraph-python",

--- a/showcase/shell-docs/src/app/llms-mdx/[[...slug]]/route.ts
+++ b/showcase/shell-docs/src/app/llms-mdx/[[...slug]]/route.ts
@@ -157,13 +157,10 @@ function resolvePage(slug: string[]): ResolvedPage | null {
       );
     }
 
-    const contentSlug =
-      (() => {
-        const resolution = resolveFrontendDocPage(frontend, frontendRest);
-        return resolution.status === "found"
-          ? resolution.contentSlugPath
-          : null;
-      })();
+    const contentSlug = (() => {
+      const resolution = resolveFrontendDocPage(frontend, frontendRest);
+      return resolution.status === "found" ? resolution.contentSlugPath : null;
+    })();
 
     if (!contentSlug) return null;
     const doc = loadDoc(contentSlug);

--- a/showcase/shell-docs/src/app/llms-mdx/[[...slug]]/route.ts
+++ b/showcase/shell-docs/src/app/llms-mdx/[[...slug]]/route.ts
@@ -4,10 +4,11 @@ import { AG_UI_CONTENT_DIR } from "@/lib/sitemap-helpers";
 import { loadDoc } from "@/lib/docs-render";
 import { resolveFrontendDocPage } from "@/lib/frontend-doc-policy";
 import {
-  FRONTEND_GUIDANCE_CONTENT_SLUG,
   getFrontendContentSlug,
+  getFrontendGuidanceContentSlug,
 } from "@/lib/frontend-page-content";
-import { isFrontendId } from "@/lib/frontend-options";
+import { isFrontendId, parseFrontendRoutePath } from "@/lib/frontend-options";
+import type { FrontendId } from "@/lib/frontend-options";
 import {
   getDocsFolder,
   getDocsMode,
@@ -40,7 +41,7 @@ import matter from "gray-matter";
 //     blockquote so the title survives.
 //
 // URL resolution mirrors what `app/[framework]/[[...slug]]/page.tsx` does:
-//   - Frontend-scoped URLs reuse the same `/frontends/<frontend>` content
+//   - Frontend-scoped URLs reuse the same `/<frontend>` content
 //     resolution as the live frontend pages.
 //   - When the first segment is a known integration slug, we try
 //     `integrations/<docsFolder>/<rest>.mdx` first (or root depending on
@@ -82,29 +83,87 @@ interface ResolvedPage {
   framework?: string;
 }
 
+type FrontendPageId = Exclude<FrontendId, "react">;
+
+function isFrontendGuidanceSlug(slugPath: string): boolean {
+  return slugPath === "using-these-docs";
+}
+
+function isFrontendRootSlug(slugPath: string): boolean {
+  return !slugPath || slugPath === "quickstart";
+}
+
 function resolvePage(slug: string[]): ResolvedPage | null {
   const first = slug[0]!;
   const rest = slug.slice(1).join("/");
   const url = slug.join("/");
 
-  // /frontends/<frontend>[/<slug>].md → the same MDX rendered by the
+  // /<frontend>[/<slug>].md → the same MDX rendered by the
   // frontend-scoped docs pages.
-  if (first === "frontends") {
-    const frontend = slug[1];
-    if (!isFrontendId(frontend) || frontend === "react") return null;
+  if (isFrontendId(first)) {
+    if (first === "react") return null;
 
-    const frontendRest = slug.slice(2).join("/");
+    const frontend = first as FrontendPageId;
+    const frontendRoute = parseFrontendRoutePath(
+      `/${slug.join("/")}`,
+      getIntegrations().map((integration) => integration.slug),
+    );
+    const frontendRest = frontendRoute?.slugPath ?? rest;
+    const activeBackendFramework =
+      frontendRoute?.backend === ROOT_FRAMEWORK
+        ? undefined
+        : (frontendRoute?.backend ?? undefined);
+    if (isFrontendGuidanceSlug(frontendRest)) {
+      const contentSlug = getFrontendGuidanceContentSlug(frontend);
+      const doc = loadDoc(contentSlug);
+      if (!doc) return null;
+
+      return {
+        page: {
+          url,
+          title: doc.fm.title,
+          description: doc.fm.description,
+          filePath: doc.filePath,
+          loadSlug: contentSlug,
+          framework: activeBackendFramework,
+        },
+        framework: activeBackendFramework,
+      };
+    }
+
+    if (isFrontendRootSlug(frontendRest)) {
+      const contentSlug = getFrontendContentSlug(frontend);
+      const doc = loadDoc(contentSlug);
+      if (!doc) return null;
+
+      return {
+        page: {
+          url,
+          title: doc.fm.title,
+          description: doc.fm.description,
+          filePath: doc.filePath,
+          loadSlug: contentSlug,
+          framework: activeBackendFramework,
+        },
+        framework: activeBackendFramework,
+      };
+    }
+
+    if (activeBackendFramework) {
+      return resolveFrameworkScopedPage(
+        activeBackendFramework,
+        frontendRest || "index",
+        url,
+      );
+    }
+
     const contentSlug =
-      frontendRest === ""
-        ? getFrontendContentSlug(frontend)
-        : frontendRest === "using-these-docs"
-          ? FRONTEND_GUIDANCE_CONTENT_SLUG
-          : (() => {
-              const resolution = resolveFrontendDocPage(frontend, frontendRest);
-              return resolution.status === "found"
-                ? resolution.contentSlugPath
-                : null;
-            })();
+      (() => {
+        const resolution = resolveFrontendDocPage(frontend, frontendRest);
+        return resolution.status === "found"
+          ? resolution.contentSlugPath
+          : null;
+      })();
 
     if (!contentSlug) return null;
     const doc = loadDoc(contentSlug);
@@ -117,7 +176,9 @@ function resolvePage(slug: string[]): ResolvedPage | null {
         description: doc.fm.description,
         filePath: doc.filePath,
         loadSlug: contentSlug,
+        framework: activeBackendFramework,
       },
+      framework: activeBackendFramework,
     };
   }
 
@@ -160,37 +221,7 @@ function resolvePage(slug: string[]): ResolvedPage | null {
   // Framework-scoped URL: first segment is an integration slug.
   const frameworkSlugs = new Set(getIntegrations().map((i) => i.slug));
   if (frameworkSlugs.has(first)) {
-    const docsFolder = getDocsFolder(first);
-    const docsMode = getDocsMode(first);
-    const tail = rest || "index";
-    const rootSlugPath = tail;
-    const frameworkSlugPath = `integrations/${docsFolder}/${tail}`;
-
-    // `authored` frameworks own their entire IA — try the per-framework
-    // tree first. `generated` is the inverse — root wins, framework
-    // tree is the override, except quickstart where the root file is
-    // only a routing shim and the page route prefers framework content.
-    const candidateOrder =
-      docsMode === "authored" || tail === "quickstart"
-        ? [frameworkSlugPath, rootSlugPath]
-        : [rootSlugPath, frameworkSlugPath];
-
-    for (const candidate of candidateOrder) {
-      const doc = loadDoc(candidate);
-      if (!doc) continue;
-      return {
-        page: {
-          url,
-          title: doc.fm.title,
-          description: doc.fm.description,
-          filePath: doc.filePath,
-          loadSlug: candidate,
-          framework: first,
-        },
-        framework: first,
-      };
-    }
-    return null;
+    return resolveFrameworkScopedPage(first, rest || "index", url);
   }
 
   // Bare unscoped doc. The root surface serves ROOT_FRAMEWORK's
@@ -213,6 +244,43 @@ function resolvePage(slug: string[]): ResolvedPage | null {
         framework: isOverride ? ROOT_FRAMEWORK : undefined,
       },
       framework: isOverride ? ROOT_FRAMEWORK : undefined,
+    };
+  }
+  return null;
+}
+
+function resolveFrameworkScopedPage(
+  framework: string,
+  tail: string,
+  url: string,
+): ResolvedPage | null {
+  const docsFolder = getDocsFolder(framework);
+  const docsMode = getDocsMode(framework);
+  const rootSlugPath = tail;
+  const frameworkSlugPath = `integrations/${docsFolder}/${tail}`;
+
+  // `authored` frameworks own their entire IA — try the per-framework
+  // tree first. `generated` is the inverse — root wins, framework
+  // tree is the override, except quickstart where the root file is
+  // only a routing shim and the page route prefers framework content.
+  const candidateOrder =
+    docsMode === "authored" || tail === "quickstart"
+      ? [frameworkSlugPath, rootSlugPath]
+      : [rootSlugPath, frameworkSlugPath];
+
+  for (const candidate of candidateOrder) {
+    const doc = loadDoc(candidate);
+    if (!doc) continue;
+    return {
+      page: {
+        url,
+        title: doc.fm.title,
+        description: doc.fm.description,
+        filePath: doc.filePath,
+        loadSlug: candidate,
+        framework,
+      },
+      framework,
     };
   }
   return null;

--- a/showcase/shell-docs/src/app/sitemap.ts
+++ b/showcase/shell-docs/src/app/sitemap.ts
@@ -24,6 +24,12 @@ import {
   getReferencePages,
   resolveLastModified,
 } from "@/lib/sitemap-helpers";
+import {
+  FRONTEND_PAGE_IDS,
+  getFrontendContentSlug,
+  getFrontendGuidanceContentSlug,
+} from "@/lib/frontend-page-content";
+import { loadDoc } from "@/lib/docs-render";
 import { getDocsFolder, getIntegrations, ROOT_FRAMEWORK } from "@/lib/registry";
 
 // Force-dynamic so the sitemap is regenerated per request and reads
@@ -116,6 +122,30 @@ export default function sitemap(): MetadataRoute.Sitemap {
       url: `${baseUrl}/${slug}`,
       lastModified: resolveLastModified(filePath),
     });
+  }
+
+  // Frontend quickstarts. The source MDX lives under
+  // content/docs/frontends/*, but those files are not served as
+  // /frontends/* docs anymore; they canonicalize to /<frontend>.
+  for (const frontend of FRONTEND_PAGE_IDS) {
+    const doc = loadDoc(getFrontendContentSlug(frontend));
+    if (doc) {
+      entries.push({
+        url: `${baseUrl}/${frontend}`,
+        lastModified: resolveLastModified(doc.filePath),
+      });
+    }
+  }
+
+  // Status/guidance page, emitted once per non-React frontend.
+  for (const frontend of FRONTEND_PAGE_IDS) {
+    const doc = loadDoc(getFrontendGuidanceContentSlug(frontend));
+    if (doc) {
+      entries.push({
+        url: `${baseUrl}/${frontend}/using-these-docs`,
+        lastModified: resolveLastModified(doc.filePath),
+      });
+    }
   }
 
   // 4. Reference docs.

--- a/showcase/shell-docs/src/components/__tests__/framework-selector.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/framework-selector.test.tsx
@@ -86,8 +86,7 @@ describe("FrameworkSelector", () => {
     expect(
       markup.match(
         /shell-docs-picker-group shell-docs-picker-group-selected shell-docs-picker-group-bordered/g,
-      )
-        ?.length,
+      )?.length,
     ).toBe(1);
     expect(markup).not.toContain("shell-docs-picker-row-selected");
     expect(markup).not.toContain("shell-docs-nav-link-active");

--- a/showcase/shell-docs/src/components/__tests__/framework-selector.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/framework-selector.test.tsx
@@ -1,4 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
+import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 
 const navigation = vi.hoisted(() => ({
@@ -80,7 +81,17 @@ describe("FrameworkSelector", () => {
     expect(backendIndex).toBeGreaterThanOrEqual(0);
     expect(frontendIndex).toBeLessThan(backendIndex);
     expect(markup).toContain("React");
+    expect(markup).not.toContain("Early access");
     expect(markup).toContain("CopilotKit");
+    expect(
+      markup.match(
+        /shell-docs-picker-group shell-docs-picker-group-selected shell-docs-picker-group-bordered/g,
+      )
+        ?.length,
+    ).toBe(1);
+    expect(markup).not.toContain("shell-docs-picker-row-selected");
+    expect(markup).not.toContain("shell-docs-nav-link-active");
+    expect(markup.match(/shell-docs-picker-row-divided/g)?.length).toBe(1);
     expect(markup.match(/<button/g)?.length).toBe(2);
     expect(markup).not.toContain("Choose your stack");
     expect(markup).not.toContain("Current stack");
@@ -97,7 +108,7 @@ describe("FrameworkSelector", () => {
   });
 
   it("reflects the frontend selected by the URL", () => {
-    navigation.pathname = "/frontends/vue";
+    navigation.pathname = "/vue";
 
     const markup = renderToStaticMarkup(
       <FrameworkSelector
@@ -109,6 +120,70 @@ describe("FrameworkSelector", () => {
 
     expect(markup).toContain("Frontend");
     expect(markup).toContain("Vue");
+    expect(markup).not.toContain("Early access");
+    expect(markup).not.toContain("px-1 py-0 text-[8px]");
+    expect(markup).not.toContain("leading-[10px]");
+    expect(markup).toContain("mt-0.5 flex min-w-0 items-center gap-2");
     expect(markup).not.toContain("React Native");
+  });
+
+  it("keeps the early access badge for Slack and Teams only", () => {
+    navigation.pathname = "/slack";
+
+    const markup = renderToStaticMarkup(
+      <FrameworkSelector
+        options={options}
+        categoryOrder={[]}
+        variant="sidebar"
+      />,
+    );
+
+    expect(markup).toContain("Slack");
+    expect(markup).toContain("Early access");
+    expect(markup).toContain("px-1 py-0 text-[8px]");
+    expect(markup).toContain("leading-[10px]");
+    expect(markup).toContain("self-center");
+  });
+
+  it("uses a picker menu shadow that does not bleed upward", () => {
+    const componentSource = readFileSync(
+      new URL("../framework-selector.tsx", import.meta.url),
+      "utf8",
+    );
+    const cssSource = readFileSync(
+      new URL("../../app/globals.css", import.meta.url),
+      "utf8",
+    );
+
+    expect(componentSource).toContain("shell-docs-picker-menu");
+    expect(componentSource).not.toContain("shadow-[var(--shadow-panel)]");
+    expect(cssSource).toContain(".shell-docs-picker-menu");
+    expect(cssSource).toContain("clip-path: inset(0 -48px -48px -48px)");
+  });
+
+  it("keeps the picker fill subtler than active navigation", () => {
+    const cssSource = readFileSync(
+      new URL("../../app/globals.css", import.meta.url),
+      "utf8",
+    );
+
+    expect(cssSource).toContain(`.shell-docs-picker-group-selected {
+  background: color-mix(in oklch, var(--accent-dim) 34%, transparent);
+}`);
+    expect(cssSource).not.toContain(`.shell-docs-picker-group-selected {
+  background: color-mix(in oklch, var(--accent) 13%, transparent);
+}`);
+  });
+
+  it("routes backend selections even from frontend docs routes", () => {
+    const componentSource = readFileSync(
+      new URL("../framework-selector.tsx", import.meta.url),
+      "utf8",
+    );
+
+    expect(componentSource).not.toContain("if (!urlFrontend)");
+    expect(componentSource).toContain(
+      "router.replace(\n      backendPathForCurrentPath(",
+    );
   });
 });

--- a/showcase/shell-docs/src/components/__tests__/frontend-logo.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/frontend-logo.test.tsx
@@ -1,0 +1,27 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { FrontendLogo } from "../frontend-logo";
+
+describe("FrontendLogo", () => {
+  it("renders brand logo paths from icon libraries", () => {
+    expect(renderToStaticMarkup(<FrontendLogo icon="react" />)).toContain(
+      "M14.23 12.004",
+    );
+    expect(renderToStaticMarkup(<FrontendLogo icon="vue" />)).toContain(
+      "M24,1.61H14.06L12,5.16",
+    );
+    const slackMarkup = renderToStaticMarkup(<FrontendLogo icon="slack" />);
+    expect(slackMarkup).toContain("M5.042 15.165a2.528");
+    expect(slackMarkup).toContain('fill="#36C5F0"');
+    expect(slackMarkup).toContain('fill="#2EB67D"');
+    expect(slackMarkup).toContain('fill="#ECB22E"');
+    expect(slackMarkup).toContain('fill="#E01E5A"');
+    expect(renderToStaticMarkup(<FrontendLogo icon="teams" />)).toContain(
+      "M18.581 11.513h3.413",
+    );
+    expect(
+      renderToStaticMarkup(<FrontendLogo icon="react-native" />),
+    ).toContain("M6.357 9c-2.637");
+  });
+});

--- a/showcase/shell-docs/src/components/docs-tabs.tsx
+++ b/showcase/shell-docs/src/components/docs-tabs.tsx
@@ -65,7 +65,9 @@ type TabChildProps = {
   title?: unknown;
 };
 
-function deriveItemsFromChildren(children: React.ReactNode): string[] | undefined {
+function deriveItemsFromChildren(
+  children: React.ReactNode,
+): string[] | undefined {
   const items = React.Children.toArray(children)
     .map((child) => {
       if (!React.isValidElement<TabChildProps>(child)) {
@@ -73,9 +75,7 @@ function deriveItemsFromChildren(children: React.ReactNode): string[] | undefine
       }
 
       const value = child.props.value ?? child.props.title;
-      return typeof value === "string" && value.length > 0
-        ? value
-        : undefined;
+      return typeof value === "string" && value.length > 0 ? value : undefined;
     })
     .filter((value): value is string => Boolean(value));
 

--- a/showcase/shell-docs/src/components/docs-tabs.tsx
+++ b/showcase/shell-docs/src/components/docs-tabs.tsx
@@ -60,19 +60,48 @@ interface ExtendedTabsProps extends Omit<FumadocsTabsProps, "defaultValue"> {
   persist?: boolean;
 }
 
+type TabChildProps = {
+  value?: unknown;
+  title?: unknown;
+};
+
+function deriveItemsFromChildren(children: React.ReactNode): string[] | undefined {
+  const items = React.Children.toArray(children)
+    .map((child) => {
+      if (!React.isValidElement<TabChildProps>(child)) {
+        return undefined;
+      }
+
+      const value = child.props.value ?? child.props.title;
+      return typeof value === "string" && value.length > 0
+        ? value
+        : undefined;
+    })
+    .filter((value): value is string => Boolean(value));
+
+  return items.length > 0 ? items : undefined;
+}
+
 export function Tabs({
   default: defaultProp,
   defaultValue,
   groupId: _groupId,
   persist: _persist,
+  items: itemsProp,
+  children,
   ...rest
 }: ExtendedTabsProps) {
-  const resolvedDefault = defaultValue ?? defaultProp;
+  const items = itemsProp ?? deriveItemsFromChildren(children);
+  const resolvedDefault = defaultValue ?? defaultProp ?? items?.[0];
+
   return (
     <FumadocsTabs
       {...rest}
+      items={items}
       defaultValue={resolvedDefault ? escapeValue(resolvedDefault) : undefined}
-    />
+    >
+      {children}
+    </FumadocsTabs>
   );
 }
 

--- a/showcase/shell-docs/src/components/framework-provider.tsx
+++ b/showcase/shell-docs/src/components/framework-provider.tsx
@@ -31,6 +31,7 @@ import React, {
   useState,
 } from "react";
 import { usePathname } from "next/navigation";
+import { backendFromPathname } from "@/lib/frontend-options";
 
 export interface FrameworkContextValue {
   /**
@@ -121,9 +122,7 @@ export function FrameworkProvider({
 }) {
   const pathname = usePathname() ?? "";
   const urlFramework = useMemo(() => {
-    const first = pathname.split("/").filter(Boolean)[0];
-    if (first && knownFrameworks.includes(first)) return first;
-    return null;
+    return backendFromPathname(pathname, knownFrameworks);
   }, [pathname, knownFrameworks]);
 
   const [stored, setStored] = useState<string | null>(null);

--- a/showcase/shell-docs/src/components/framework-selector.tsx
+++ b/showcase/shell-docs/src/components/framework-selector.tsx
@@ -13,8 +13,10 @@ import { FrameworkLogo } from "./icons/framework-icons";
 import { compareByDisplayOrder } from "@/lib/framework-order";
 import {
   FRONTEND_OPTIONS,
+  backendPathForCurrentPath,
   frontendFromPathname,
-  frontendPathFor,
+  frontendPathForCurrentPath,
+  isFrontendEarlyAccess,
 } from "@/lib/frontend-options";
 import type { FrontendId } from "@/lib/frontend-options";
 
@@ -54,6 +56,14 @@ function SelectorAffordance({ active }: { active: boolean }) {
         }`}
         strokeWidth={2}
       />
+    </span>
+  );
+}
+
+function FrontendEarlyAccessBadge() {
+  return (
+    <span className="shell-docs-radius-control inline-flex shrink-0 self-center border border-[var(--border)] bg-[var(--bg-elevated)] px-1 py-0 text-[8px] font-semibold leading-[10px] text-[var(--text-muted)]">
+      Early access
     </span>
   );
 }
@@ -106,8 +116,14 @@ export function FrameworkSelector({
     FRONTEND_OPTIONS[0];
 
   function selectFrontend(id: FrontendId) {
-    if (id !== effectiveFrontendId || pathname.startsWith("/frontends/")) {
-      router.replace(frontendPathFor(id));
+    if (id !== effectiveFrontendId) {
+      router.replace(
+        frontendPathForCurrentPath(
+          id,
+          pathname,
+          options.map((option) => option.slug),
+        ),
+      );
     }
     setOpenMenu(null);
   }
@@ -125,9 +141,14 @@ export function FrameworkSelector({
     } catch {
       // Swallow - analytics is fire-and-forget.
     }
-    if (!pathname.startsWith("/frontends/")) {
-      router.replace(slug === DEFAULT_FRAMEWORK ? "/" : `/${slug}`);
-    }
+    router.replace(
+      backendPathForCurrentPath(
+        slug,
+        pathname,
+        options.map((option) => option.slug),
+        DEFAULT_FRAMEWORK,
+      ),
+    );
     setOpenMenu(null);
   }
 
@@ -214,7 +235,7 @@ export function FrameworkSelector({
     >
       {isSidebar ? (
         <>
-          <div className="shell-docs-picker-group space-y-0.5">
+          <div className="shell-docs-picker-group shell-docs-picker-group-selected shell-docs-picker-group-bordered space-y-0.5">
             <button
               type="button"
               onClick={() =>
@@ -223,11 +244,7 @@ export function FrameworkSelector({
               aria-haspopup="listbox"
               aria-expanded={openMenu === "frontend"}
               aria-label="Choose frontend"
-              className={`shell-docs-picker-row group flex min-h-[52px] w-full cursor-pointer items-center gap-2.5 px-2 py-1.5 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] ${
-                openMenu === "frontend"
-                  ? "bg-[var(--bg-surface)] shadow-[var(--shadow-control)]"
-                  : "hover:bg-[var(--bg-surface)]"
-              }`}
+              className="shell-docs-picker-row group flex min-h-[52px] w-full cursor-pointer items-center gap-2.5 px-2 py-1.5 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
             >
               <span
                 className="shell-docs-picker-icon-chip flex h-8 w-8 shrink-0 items-center justify-center"
@@ -239,8 +256,11 @@ export function FrameworkSelector({
                 <span className="block text-[11px] font-medium leading-tight text-[var(--text-muted)]">
                   Frontend
                 </span>
-                <span className="mt-0.5 block truncate text-[13px] font-semibold leading-tight text-[var(--text)]">
-                  {selectedFrontend.name}
+                <span className="mt-0.5 flex min-w-0 items-center gap-2 text-[13px] font-semibold leading-tight text-[var(--text)]">
+                  <span className="truncate">{selectedFrontend.name}</span>
+                  {isFrontendEarlyAccess(selectedFrontend.id) && (
+                    <FrontendEarlyAccessBadge />
+                  )}
                 </span>
               </span>
               <SelectorAffordance active={openMenu === "frontend"} />
@@ -254,11 +274,7 @@ export function FrameworkSelector({
               aria-haspopup="listbox"
               aria-expanded={openMenu === "backend"}
               aria-label="Choose agent backend"
-              className={`shell-docs-picker-row group flex min-h-[52px] w-full cursor-pointer items-center gap-2.5 px-2 py-1.5 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] ${
-                openMenu === "backend"
-                  ? "bg-[var(--bg-surface)] shadow-[var(--shadow-control)]"
-                  : "hover:bg-[var(--bg-surface)]"
-              }`}
+              className="shell-docs-picker-row shell-docs-picker-row-divided group flex min-h-[52px] w-full cursor-pointer items-center gap-2.5 px-2 py-1.5 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
             >
               <span
                 className="shell-docs-picker-icon-chip flex h-8 w-8 shrink-0 items-center justify-center"
@@ -297,7 +313,7 @@ export function FrameworkSelector({
             <div
               role="listbox"
               aria-label="Choose frontend"
-              className="shell-docs-radius-surface absolute left-0 right-0 top-full z-50 mt-1 border border-[var(--border)] bg-[var(--bg-surface)] p-2 shadow-[var(--shadow-panel)]"
+              className="shell-docs-radius-surface shell-docs-picker-menu absolute left-0 right-0 top-full z-50 mt-1 border border-[var(--border)] bg-[var(--bg-surface)] p-2"
             >
               {FRONTEND_OPTIONS.map((option) => {
                 const isActive = option.id === selectedFrontend.id;
@@ -320,8 +336,11 @@ export function FrameworkSelector({
                     >
                       <FrontendLogo icon={option.icon} size={17} />
                     </span>
-                    <span className="flex-1 truncate text-left font-medium">
-                      {option.name}
+                    <span className="flex min-w-0 flex-1 items-center gap-2 text-left font-medium">
+                      <span className="truncate">{option.name}</span>
+                      {isFrontendEarlyAccess(option.id) && (
+                        <FrontendEarlyAccessBadge />
+                      )}
                     </span>
                   </button>
                 );
@@ -333,7 +352,7 @@ export function FrameworkSelector({
             <div
               role="listbox"
               aria-label="Choose agent backend"
-              className="shell-docs-radius-surface absolute left-0 top-full z-50 mt-1 max-h-[60vh] w-[320px] max-w-[calc(100vw-2rem)] overflow-y-auto border border-[var(--border)] bg-[var(--bg-surface)] p-2 shadow-[var(--shadow-panel)]"
+              className="shell-docs-radius-surface shell-docs-picker-menu absolute left-0 top-full z-50 mt-1 max-h-[60vh] w-[320px] max-w-[calc(100vw-2rem)] overflow-y-auto border border-[var(--border)] bg-[var(--bg-surface)] p-2"
             >
               {backendOptions(
                 true,
@@ -376,7 +395,7 @@ export function FrameworkSelector({
           {openMenu === "backend" && (
             <div
               role="listbox"
-              className="shell-docs-radius-surface absolute left-0 top-full z-50 mt-1 max-h-[70vh] w-[340px] overflow-y-auto border border-[var(--border)] bg-[var(--bg-surface)] p-2 shadow-[var(--shadow-panel)]"
+              className="shell-docs-radius-surface shell-docs-picker-menu absolute left-0 top-full z-50 mt-1 max-h-[70vh] w-[340px] overflow-y-auto border border-[var(--border)] bg-[var(--bg-surface)] p-2"
             >
               {backendOptions(
                 false,

--- a/showcase/shell-docs/src/components/frontend-logo.tsx
+++ b/showcase/shell-docs/src/components/frontend-logo.tsx
@@ -70,16 +70,14 @@ function SlackColorLogo({
   );
 }
 
-const FRONTEND_ICONS: Record<
-  FrontendIcon,
-  { Icon: BrandIcon; color: string }
-> = {
-  react: { Icon: SiReact, color: "#61DAFB" },
-  vue: { Icon: SiVuedotjs, color: "#4FC08D" },
-  "react-native": { Icon: TbBrandReactNative, color: "#61DAFB" },
-  slack: { Icon: SlackColorLogo, color: "currentColor" },
-  teams: { Icon: BiLogoMicrosoftTeams, color: "#6264A7" },
-};
+const FRONTEND_ICONS: Record<FrontendIcon, { Icon: BrandIcon; color: string }> =
+  {
+    react: { Icon: SiReact, color: "#61DAFB" },
+    vue: { Icon: SiVuedotjs, color: "#4FC08D" },
+    "react-native": { Icon: TbBrandReactNative, color: "#61DAFB" },
+    slack: { Icon: SlackColorLogo, color: "currentColor" },
+    teams: { Icon: BiLogoMicrosoftTeams, color: "#6264A7" },
+  };
 
 export function FrontendLogo({
   icon,

--- a/showcase/shell-docs/src/components/frontend-logo.tsx
+++ b/showcase/shell-docs/src/components/frontend-logo.tsx
@@ -1,19 +1,84 @@
 import type { FrontendIcon } from "@/lib/frontend-options";
-import {
-  Code,
-  Component,
-  MessageSquare,
-  Smartphone,
-  Users,
-} from "lucide-react";
-import type { LucideIcon } from "lucide-react";
+import type React from "react";
+import { BiLogoMicrosoftTeams } from "react-icons/bi";
+import { SiReact, SiVuedotjs } from "react-icons/si";
+import { TbBrandReactNative } from "react-icons/tb";
 
-const FRONTEND_ICONS: Record<FrontendIcon, LucideIcon> = {
-  react: Component,
-  vue: Code,
-  "react-native": Smartphone,
-  slack: MessageSquare,
-  teams: Users,
+type BrandIcon = React.ComponentType<{
+  "aria-hidden"?: boolean;
+  className?: string;
+  color?: string;
+  focusable?: boolean | "false";
+  size?: number | string;
+  title?: string;
+}>;
+
+function SlackColorLogo({
+  className,
+  size = 18,
+}: {
+  "aria-hidden"?: boolean;
+  className?: string;
+  focusable?: boolean | "false";
+  size?: number | string;
+  title?: string;
+}) {
+  return (
+    <svg
+      aria-hidden={true}
+      className={className}
+      focusable={false}
+      height={size}
+      role="img"
+      viewBox="0 0 24 24"
+      width={size}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fill="#E01E5A"
+        d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52z"
+      />
+      <path
+        fill="#E01E5A"
+        d="M6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313z"
+      />
+      <path
+        fill="#36C5F0"
+        d="M8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834z"
+      />
+      <path
+        fill="#36C5F0"
+        d="M8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312z"
+      />
+      <path
+        fill="#2EB67D"
+        d="M18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834z"
+      />
+      <path
+        fill="#2EB67D"
+        d="M17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312z"
+      />
+      <path
+        fill="#ECB22E"
+        d="M15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52z"
+      />
+      <path
+        fill="#ECB22E"
+        d="M15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"
+      />
+    </svg>
+  );
+}
+
+const FRONTEND_ICONS: Record<
+  FrontendIcon,
+  { Icon: BrandIcon; color: string }
+> = {
+  react: { Icon: SiReact, color: "#61DAFB" },
+  vue: { Icon: SiVuedotjs, color: "#4FC08D" },
+  "react-native": { Icon: TbBrandReactNative, color: "#61DAFB" },
+  slack: { Icon: SlackColorLogo, color: "currentColor" },
+  teams: { Icon: BiLogoMicrosoftTeams, color: "#6264A7" },
 };
 
 export function FrontendLogo({
@@ -25,13 +90,15 @@ export function FrontendLogo({
   size?: number;
   className?: string;
 }) {
-  const Icon = FRONTEND_ICONS[icon];
+  const { Icon, color } = FRONTEND_ICONS[icon];
   return (
     <Icon
-      aria-hidden="true"
+      aria-hidden={true}
       className={className}
+      color={color}
+      focusable={false}
       size={size}
-      strokeWidth={2}
+      title=""
     />
   );
 }

--- a/showcase/shell-docs/src/components/search-modal.tsx
+++ b/showcase/shell-docs/src/components/search-modal.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { ArrowRight, Check, ChevronDown, Search, X } from "lucide-react";
 import searchIndex from "@/data/search-index.json";
 import { DEFAULT_FRAMEWORK, useFramework } from "./framework-provider";
+import { frontendFromPathname } from "@/lib/frontend-options";
 import { FrameworkLogo } from "./icons/framework-icons";
 import { compareByDisplayOrder } from "@/lib/framework-order";
 import type { Registry } from "@/lib/registry";
@@ -162,6 +163,8 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const selectedIndexRef = useRef(0);
   const router = useRouter();
+  const pathname = usePathname() ?? "";
+  const activeFrontend = frontendFromPathname(pathname);
 
   // Keep a ref in sync with selectedIndex so the Enter handler never reads
   // a stale closure value (reset-on-input + key-handler race).
@@ -309,7 +312,11 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
         docsGroups.set(integrationDoc.topic || "overview", {
           topic: integrationDoc.topic,
           entry: p,
-          href: frameworkDocsHref(selectedOption.slug, integrationDoc.topic),
+          href: frameworkDocsHref(
+            selectedOption.slug,
+            integrationDoc.topic,
+            activeFrontend,
+          ),
           frameworkCount: options.length,
         });
         continue;
@@ -324,7 +331,11 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
           docsGroups.set(docsTopic, {
             topic: docsTopic,
             entry: p,
-            href: normalizeHref(p.href, shellHost),
+            href: frameworkDocsHref(
+              selectedFramework,
+              docsTopic,
+              activeFrontend,
+            ),
           });
         }
         continue;
@@ -393,7 +404,14 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
     return dedupeResults(items)
       .sort((a, b) => scoreResult(a, q) - scoreResult(b, q))
       .slice(0, 12);
-  }, [query, registryData, selectedFramework, frameworkOptions, shellHost]);
+  }, [
+    query,
+    registryData,
+    selectedFramework,
+    frameworkOptions,
+    shellHost,
+    activeFrontend,
+  ]);
 
   useEffect(() => {
     setSelectedIndex((idx) =>

--- a/showcase/shell-docs/src/components/sidebar-react-docs-notice.tsx
+++ b/showcase/shell-docs/src/components/sidebar-react-docs-notice.tsx
@@ -28,7 +28,7 @@ function toRelativeHref(href: string): string {
 }
 
 function guidanceHref(frontendId: FrontendId): string {
-  return `/frontends/${frontendId}/using-these-docs`;
+  return `/${frontendId}/using-these-docs`;
 }
 
 function normalizeLabel(label: string): string {

--- a/showcase/shell-docs/src/content/docs/frontends/docs-status.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/docs-status.mdx
@@ -1,10 +1,10 @@
 ---
-title: About early access
+title: Docs status
 description: What to expect while this frontend's full guide set is being written.
 hideTOC: true
 ---
 
-This frontend is currently in early access. Its quickstart and reference guides are ready, and the full guide set is being written.
+This frontend is feature complete, but the docs are still catching up. Its quickstart and reference guides are ready with more guides on the way.
 
 Use these docs in three layers:
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/doctest.json
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/doctest.json
@@ -1,0 +1,14 @@
+{
+  "python": {
+    "deps": [
+      "ag-ui-langgraph",
+      "copilotkit",
+      "fastapi",
+      "langchain-core",
+      "langchain-openai",
+      "langgraph",
+      "python-dotenv",
+      "uvicorn"
+    ]
+  }
+}

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -128,7 +128,7 @@ Before you begin, you'll need the following:
               Add LangGraph and the required AG-UI packages to your project:
 
               ```bash
-              uv add langgraph copilotkit langchain-openai langchain-core dotenv
+              uv add langgraph copilotkit langchain-openai langchain-core python-dotenv
               ```
           </Step>
           <Step>

--- a/showcase/shell-docs/src/content/reference/bot/functions/createBot.mdx
+++ b/showcase/shell-docs/src/content/reference/bot/functions/createBot.mdx
@@ -7,7 +7,7 @@ description: "Create a bot: wire platform adapters to an AG-UI agent, register t
 
 `createBot` is the entry point of `@copilotkit/bot`. It wires one or more platform adapters to an AG-UI agent and returns a `Bot` — the surface for registering turn handlers, interaction handlers, interrupt handlers, slash commands, and tools, plus `start()` / `stop()` lifecycle control.
 
-For a complete walkthrough, see the [Slack quickstart](/frontends/slack).
+For a complete walkthrough, see the [Slack quickstart](/slack).
 
 ## Signature
 
@@ -123,4 +123,4 @@ await bot.start();
 - [defineBotTool](/reference/bot/functions/defineBotTool) — tools the agent can call
 - [defineBotCommand](/reference/bot/functions/defineBotCommand) — slash commands
 - [ActionStore](/reference/bot/types/ActionStore) — action binding and durability
-- [Slack quickstart](/frontends/slack) — zero to a working bot
+- [Slack quickstart](/slack) — zero to a working bot

--- a/showcase/shell-docs/src/content/reference/bot/functions/defineBotCommand.mdx
+++ b/showcase/shell-docs/src/content/reference/bot/functions/defineBotCommand.mdx
@@ -85,7 +85,7 @@ A slash command's text is never posted to the channel, so it isn't in the histor
 
 ## Behavior
 
-- **Declare commands with the platform** — platforms only deliver commands they know about. On Slack, every command must **also** be declared in the app configuration (the manifest's `slash_commands` section, or "Slash Commands" in the app settings); an undeclared command is silently dropped, even over Socket Mode. See the [Slack quickstart](/frontends/slack).
+- **Declare commands with the platform** — platforms only deliver commands they know about. On Slack, every command must **also** be declared in the app configuration (the manifest's `slash_commands` section, or "Slash Commands" in the app settings); an undeclared command is silently dropped, even over Socket Mode. See the [Slack quickstart](/slack).
 - **Matching is case-insensitive** and ignores the leading slash; commands delivered by the platform but not registered on the bot are ignored.
 - **Up-front registration** — on `start()`, declared commands are forwarded to adapters that implement `registerCommands` (e.g. a Discord-style application-command API); adapters without it, including Slack, are skipped.
 

--- a/showcase/shell-docs/src/content/reference/bot/index.mdx
+++ b/showcase/shell-docs/src/content/reference/bot/index.mdx
@@ -19,7 +19,7 @@ pnpm add @copilotkit/bot @copilotkit/bot-ui @copilotkit/bot-discord
 ```
 
 <Callout type="info">
-  New to the stack? Start with the [Slack quickstart](/frontends/slack) — zero to a working bot, then come back here for the API surface.
+  New to the stack? Start with the [Slack quickstart](/slack) — zero to a working bot, then come back here for the API surface.
 </Callout>
 
 ## Setup
@@ -72,5 +72,5 @@ A turn flows through three stages. The adapter normalizes a platform event into 
 
 ## Related
 
-- [Slack quickstart](/frontends/slack) — create the Slack app, install, and run your first bot
+- [Slack quickstart](/slack) — create the Slack app, install, and run your first bot
 - [On-call triage example](https://github.com/CopilotKit/CopilotKit/tree/main/examples/slack) — a full bot over Linear + Notion MCP with HITL and slash commands

--- a/showcase/shell-docs/src/content/reference/bot/slack/SanitizingHttpAgent.mdx
+++ b/showcase/shell-docs/src/content/reference/bot/slack/SanitizingHttpAgent.mdx
@@ -7,7 +7,7 @@ description: "An HttpAgent that tolerates the AG-UI event streams real agent bac
 
 `SanitizingHttpAgent` is an `HttpAgent` (from `@ag-ui/client`) that tolerates the event streams real agent backends emit. The stock `HttpAgent` re-validates every streamed event against a strict schema, and a single rejected event aborts the entire run — some backends (notably LangGraph) legitimately emit events that fail it, e.g. a `TOOL_CALL_START` with a `null` `parentMessageId`, which is exactly the shape that carries interrupts. This class parses the same SSE stream but coerces the known nullable-string fields instead, so interrupts and human-in-the-loop work over HTTP.
 
-This is the agent class to use when the bot connects to a **remote AG-UI backend** — the bot-process/runtime-process split shown in the [Slack quickstart](/frontends/slack) and used by the [triage example](https://github.com/CopilotKit/CopilotKit/tree/main/examples/slack).
+This is the agent class to use when the bot connects to a **remote AG-UI backend** — the bot-process/runtime-process split shown in the [Slack quickstart](/slack) and used by the [triage example](https://github.com/CopilotKit/CopilotKit/tree/main/examples/slack).
 
 ## Signature
 
@@ -46,4 +46,4 @@ const bot = createBot({
 
 - [createBot](/reference/bot/functions/createBot) — the `agent` factory option
 - [slack()](/reference/bot/slack) — the adapter this ships with
-- [Slack quickstart](/frontends/slack) — the split-process setup this enables
+- [Slack quickstart](/slack) — the split-process setup this enables

--- a/showcase/shell-docs/src/content/reference/bot/slack/index.mdx
+++ b/showcase/shell-docs/src/content/reference/bot/slack/index.mdx
@@ -7,7 +7,7 @@ description: "The Slack platform adapter factory — Socket Mode ingress via Bol
 
 `slack(opts)` returns a `SlackAdapter` — the Slack implementation of the engine's `PlatformAdapter` boundary. It handles ingress via Bolt (Socket Mode by default), renders the JSX vocabulary to Block Kit within Slack's per-element budgets, streams agent replies via throttled `chat.update`, and decodes interactions to opaque action ids. `@copilotkit/bot-slack` is the only package in the stack that talks to Slack.
 
-For app creation, tokens, and first run, see the [Slack quickstart](/frontends/slack).
+For app creation, tokens, and first run, see the [Slack quickstart](/slack).
 
 ## Signature
 
@@ -122,4 +122,4 @@ The underlying Bolt `App` is constructed with `deferInitialization` — construc
 - [markdownToMrkdwn](/reference/bot/slack/markdownToMrkdwn) — the Markdown → mrkdwn translation
 - [defaultSlackTools](/reference/bot/slack/defaultSlackTools) / [defaultSlackContext](/reference/bot/slack/defaultSlackContext) — the shipped built-ins
 - [SanitizingHttpAgent](/reference/bot/slack/SanitizingHttpAgent) — connecting to a remote AG-UI backend
-- [Slack quickstart](/frontends/slack) — app manifest, tokens, first run
+- [Slack quickstart](/slack) — app manifest, tokens, first run

--- a/showcase/shell-docs/src/content/reference/react-native/index.mdx
+++ b/showcase/shell-docs/src/content/reference/react-native/index.mdx
@@ -89,5 +89,5 @@ The root also exports two prebuilt chrome components: [`CopilotSidebar`](/refere
 
 ## Related
 
-- [React Native quickstart](/frontends/react-native): create an app, install, and connect your first agent
+- [React Native quickstart](/react-native): create an app, install, and connect your first agent
 - [React (V2) reference](/reference/v2): the web SDK, where the re-exported hooks behave identically

--- a/showcase/shell-docs/src/lib/__tests__/docs-link-rewrite.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-link-rewrite.test.ts
@@ -25,6 +25,20 @@ describe("resolveDocsHref", () => {
     ).toBe("/mastra/quickstart#install");
   });
 
+  it("scopes links under frontend and framework when both axes are selected", () => {
+    const options = {
+      slugHrefPrefix: "/vue/langgraph-python",
+      frameworkOverride: "langgraph-python",
+    };
+
+    expect(resolveDocsHref("/generative-ui/tool-rendering", options)).toBe(
+      "/vue/langgraph-python/generative-ui/tool-rendering",
+    );
+    expect(resolveDocsHref("/langgraph-python/quickstart", options)).toBe(
+      "/vue/langgraph-python/quickstart",
+    );
+  });
+
   it("does not scope cross-framework or reserved-route links", () => {
     const options = {
       slugHrefPrefix: "/mastra",

--- a/showcase/shell-docs/src/lib/__tests__/frontend-options.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/frontend-options.test.ts
@@ -1,19 +1,29 @@
+import React from "react";
 import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
 
 import {
   FRONTEND_OPTIONS,
+  backendFromPathname,
+  backendPathForCurrentPath,
   frontendFromPathname,
   frontendPathFor,
+  frontendPathForCurrentPath,
   getFrontendOption,
+  isFrontendEarlyAccess,
   isFrontendId,
+  parseFrontendRoutePath,
 } from "../frontend-options";
 import {
+  FRONTEND_DOCS_STATUS_CONTENT_SLUG,
   FRONTEND_GUIDANCE_CONTENT_SLUG,
   FRONTEND_PAGE_IDS,
   getFrontendContentSlug,
+  getFrontendGuidanceContentSlug,
+  getFrontendGuidanceTitle,
   getFrontendReferenceSlug,
-  getFrontendUsingTheseDocsPath,
   getFrontendQuickstartNavTree,
+  getFrontendUsingTheseDocsPath,
 } from "../frontend-page-content";
 import { loadDoc } from "../docs-render";
 import type { NavNode } from "../docs-render";
@@ -44,14 +54,112 @@ function collectPageUrls(tree: PageTree.Root): string[] {
   return urls;
 }
 
+function renderNavNameToMarkup(name: React.ReactNode): string {
+  return renderToStaticMarkup(React.createElement(React.Fragment, null, name));
+}
+
 describe("frontend options", () => {
   it("keeps React as the full docs surface and routes other frontends to their guides", () => {
     expect(frontendPathFor("react")).toBe("/");
-    expect(frontendPathFor("vue")).toBe("/frontends/vue");
-    expect(frontendPathFor("react-native")).toBe("/frontends/react-native");
-    expect(frontendFromPathname("/frontends/vue")).toBe("vue");
-    expect(frontendFromPathname("/frontends/react")).toBeNull();
+    expect(frontendPathFor("vue")).toBe("/vue");
+    expect(frontendPathFor("react-native")).toBe("/react-native");
+    expect(frontendPathFor("react", "concepts/architecture")).toBe(
+      "/concepts/architecture",
+    );
+    expect(frontendPathFor("slack", "concepts/architecture")).toBe(
+      "/slack/concepts/architecture",
+    );
+    expect(frontendPathFor("react", "quickstart")).toBe("/");
+    expect(frontendPathFor("react", "using-these-docs")).toBe("/");
+    expect(frontendFromPathname("/vue")).toBe("vue");
+    expect(frontendFromPathname("/vue/concepts/architecture")).toBe("vue");
+    expect(frontendFromPathname("/react")).toBeNull();
+    expect(frontendFromPathname("/frontends/vue")).toBeNull();
     expect(frontendFromPathname("/langgraph-python/quickstart")).toBeNull();
+  });
+
+  it("maps picker selections across frontend URL shapes", () => {
+    const backendSlugs = ["built-in-agent", "langgraph-python", "mastra"];
+
+    expect(
+      frontendPathForCurrentPath("slack", "/vue/concepts/architecture"),
+    ).toBe("/slack/concepts/architecture");
+    expect(
+      frontendPathForCurrentPath("react", "/slack/concepts/architecture"),
+    ).toBe("/concepts/architecture");
+    expect(frontendPathForCurrentPath("teams", "/quickstart")).toBe("/teams");
+    expect(
+      frontendPathForCurrentPath(
+        "slack",
+        "/langgraph-python/quickstart",
+        backendSlugs,
+      ),
+    ).toBe("/slack/langgraph-python");
+    expect(
+      frontendPathForCurrentPath(
+        "slack",
+        "/vue/langgraph-python/concepts/architecture",
+        backendSlugs,
+      ),
+    ).toBe("/slack/langgraph-python/concepts/architecture");
+    expect(
+      frontendPathForCurrentPath(
+        "react",
+        "/vue/langgraph-python/concepts/architecture",
+        backendSlugs,
+      ),
+    ).toBe("/langgraph-python/concepts/architecture");
+  });
+
+  it("parses and builds two-axis frontend/backend routes", () => {
+    const backendSlugs = ["built-in-agent", "langgraph-python", "mastra"];
+
+    expect(
+      parseFrontendRoutePath(
+        "/vue/langgraph-python/concepts/architecture",
+        backendSlugs,
+      ),
+    ).toEqual({
+      frontend: "vue",
+      backend: "langgraph-python",
+      slugPath: "concepts/architecture",
+    });
+    expect(parseFrontendRoutePath("/vue/using-these-docs", backendSlugs))
+      .toEqual({
+        frontend: "vue",
+        backend: null,
+        slugPath: "using-these-docs",
+      });
+    expect(backendFromPathname("/vue/langgraph-python", backendSlugs)).toBe(
+      "langgraph-python",
+    );
+    expect(backendFromPathname("/langgraph-python", backendSlugs)).toBe(
+      "langgraph-python",
+    );
+    expect(
+      backendPathForCurrentPath(
+        "langgraph-python",
+        "/vue",
+        backendSlugs,
+        "built-in-agent",
+      ),
+    ).toBe("/vue/langgraph-python");
+    expect(
+      backendPathForCurrentPath(
+        "mastra",
+        "/vue/langgraph-python/concepts/architecture",
+        backendSlugs,
+        "built-in-agent",
+      ),
+    ).toBe("/vue/mastra/concepts/architecture");
+    expect(
+      backendPathForCurrentPath(
+        "built-in-agent",
+        "/vue/langgraph-python",
+        backendSlugs,
+        "built-in-agent",
+      ),
+    ).toBe("/vue");
   });
 
   it("maps every non-React frontend to an MDX guide page", () => {
@@ -65,13 +173,29 @@ describe("frontend options", () => {
       expect(getFrontendOption(id).name).toBeTruthy();
       expect(getFrontendContentSlug(id)).toBe(`frontends/${id}`);
       expect(getFrontendUsingTheseDocsPath(id)).toBe(
-        `/frontends/${id}/using-these-docs`,
+        `/${id}/using-these-docs`,
       );
       expect(loadDoc(getFrontendContentSlug(id))?.fm.title).toBeTruthy();
     }
+    expect(isFrontendEarlyAccess("vue")).toBe(false);
+    expect(isFrontendEarlyAccess("react-native")).toBe(false);
+    expect(isFrontendEarlyAccess("slack")).toBe(true);
+    expect(isFrontendEarlyAccess("teams")).toBe(true);
     expect(loadDoc(FRONTEND_GUIDANCE_CONTENT_SLUG)?.fm.title).toBe(
-      "Using these docs",
+      "About early access",
     );
+    expect(loadDoc(FRONTEND_DOCS_STATUS_CONTENT_SLUG)?.fm.title).toBe(
+      "Docs status",
+    );
+    expect(getFrontendGuidanceContentSlug("vue")).toBe(
+      FRONTEND_DOCS_STATUS_CONTENT_SLUG,
+    );
+    expect(getFrontendGuidanceContentSlug("slack")).toBe(
+      FRONTEND_GUIDANCE_CONTENT_SLUG,
+    );
+    expect(getFrontendGuidanceTitle("vue")).toBe("Docs status");
+    expect(getFrontendGuidanceTitle("slack")).toBe("About early access");
+    expect(isFrontendEarlyAccess("react")).toBe(false);
   });
 
   it("routes frontend sidebars to the most specific reference docs available", () => {
@@ -83,63 +207,10 @@ describe("frontend options", () => {
     expect(getFrontendReferenceSlug("teams")).toBe("reference");
   });
 
-  it("keeps non-React frontend sidebars focused before proxying React docs", () => {
+  it("keeps non-React frontend sidebars limited to quickstart and reference links", () => {
     const navTree = getFrontendQuickstartNavTree("slack");
     const flattenedNavTree = flattenNavTree(navTree);
 
-    expect(navTree.slice(0, 3)).toEqual([
-      { type: "section", title: "Getting Started", icon: "lucide/Rocket" },
-      { type: "page", title: "Quickstart", slug: "" },
-      {
-        type: "page",
-        title: "Using these docs 🏗️",
-        slug: "using-these-docs",
-        icon: "lucide/Wrench",
-      },
-    ]);
-
-    expect(flattenedNavTree).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: "section",
-          title: "Concepts",
-        }),
-        expect.objectContaining({
-          type: "page",
-          title: "Architecture",
-          slug: "concepts/architecture",
-        }),
-      ]),
-    );
-
-    expect(
-      flattenedNavTree.find(
-        (node) => node.type === "section" && node.title === "Concepts",
-      )?.variant,
-    ).toBeUndefined();
-    expect(
-      flattenedNavTree.find(
-        (node) => node.type === "page" && node.slug === "concepts/architecture",
-      )?.variant,
-    ).toBeUndefined();
-    expect(
-      flattenedNavTree.find(
-        (node) => node.type === "page" && node.slug === "concepts/which-hook",
-      ),
-    ).toBeUndefined();
-
-    expect(navTree).toEqual(
-      expect.arrayContaining([
-        { type: "section", title: "More to explore", icon: "lucide/BookOpen" },
-        {
-          type: "page",
-          title: "Reference docs",
-          slug: "reference/bot",
-          href: "/reference/bot",
-        },
-      ]),
-    );
-
     expect(flattenedNavTree).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -155,98 +226,46 @@ describe("frontend options", () => {
       ]),
     );
 
-    expect(navTree).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: "section",
-          title: "React docs",
-        }),
-      ]),
-    );
-
-    expect(flattenNavTree(navTree)).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: "page",
-          title: "React docs for deeper examples",
-        }),
-      ]),
-    );
-
     expect(flattenedNavTree).not.toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          variant: "shadow-note",
-        }),
-        expect.objectContaining({
-          variant: "shadow",
-        }),
-        expect.objectContaining({
-          variant: "shadow-divider",
-        }),
-      ]),
-    );
-
-    expect(
-      flattenedNavTree.find(
-        (node) =>
-          node.variant === "react-docs-proxy" &&
-          node.type === "section" &&
-          /^(get|getting) started$/i.test(node.title),
-      ),
-    ).toBeUndefined();
-
-    const proxiedPageTitles = flattenedNavTree
-      .filter(
-        (node) => node.type === "page" && node.variant === "react-docs-proxy",
-      )
-      .map((node) => node.title);
-    expect(proxiedPageTitles).not.toEqual(
-      expect.arrayContaining([
-        "Introduction",
-        "Quickstart",
-        "Build with agents",
-        "Architecture",
-        "Generative UI Overview",
-        "Which Hook for Which Job",
-      ]),
-    );
-
-    expect(flattenedNavTree).toEqual(
-      expect.arrayContaining([
-        { type: "section", title: "More to explore", icon: "lucide/BookOpen" },
-        expect.objectContaining({
-          type: "page",
-          title: "Prebuilt Components",
-          variant: "react-docs-proxy",
-          href: "/prebuilt-components",
-        }),
-        expect.objectContaining({
-          type: "group",
-          variant: "react-docs-proxy",
-        }),
+        expect.objectContaining({ variant: "react-docs-proxy" }),
       ]),
     );
 
     const pageUrls = collectPageUrls(
-      navTreeToPageTree(navTree, "/frontends/slack"),
+      navTreeToPageTree(navTree, "/slack"),
     );
-    expect(pageUrls).toEqual(
-      expect.arrayContaining([
-        "/frontends/slack",
-        "/frontends/slack/using-these-docs",
-        "/frontends/slack/concepts/architecture",
-        "/frontends/slack/agentic-protocols",
-        "/frontends/slack/agentic-protocols/ag-ui",
-        "/reference/bot",
-        "/prebuilt-components",
-      ]),
-    );
+    expect(pageUrls).toEqual([
+      "/slack",
+      "/slack/using-these-docs",
+      "/reference/bot",
+    ]);
     expect(pageUrls).not.toEqual(
       expect.arrayContaining([
         "/concepts/architecture",
-        "/frontends/slack/concepts/which-hook",
-        "/frontends/slack/prebuilt-components",
+        "/slack/concepts/architecture",
+        "/slack/concepts/which-hook",
+        "/slack/prebuilt-components",
+        "/prebuilt-components",
+      ]),
+    );
+
+    expect(getFrontendQuickstartNavTree("vue")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "section",
+          variant: "frontend-docs-upcoming",
+          frontendDocsStatus: "feature-complete",
+        }),
+      ]),
+    );
+    expect(getFrontendQuickstartNavTree("slack")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "section",
+          variant: "frontend-docs-upcoming",
+          frontendDocsStatus: "early-access",
+        }),
       ]),
     );
 
@@ -255,8 +274,43 @@ describe("frontend options", () => {
         status: "found",
         slugPath: "agentic-protocols",
         contentSlugPath: "agentic-protocols",
-        canonicalPath: "/agentic-protocols",
+        canonicalPath: "/slack/agentic-protocols",
       }),
+    );
+  });
+
+  it("renders frontend docs status copy by frontend availability", () => {
+    const vueTree = navTreeToPageTree(
+      getFrontendQuickstartNavTree("vue"),
+      "/vue",
+    );
+    const slackTree = navTreeToPageTree(
+      getFrontendQuickstartNavTree("slack"),
+      "/slack",
+    );
+
+    const vueUpcoming = vueTree.children.find(
+      (node) =>
+        node.type === "separator" &&
+        renderNavNameToMarkup(node.name).includes("Guides coming soon"),
+    );
+    const slackUpcoming = slackTree.children.find(
+      (node) =>
+        node.type === "separator" &&
+        renderNavNameToMarkup(node.name).includes("Guides coming soon"),
+    );
+
+    expect(renderNavNameToMarkup(vueUpcoming?.name)).toContain(
+      "Vue is feature complete, but the docs are still catching up. The ",
+    );
+    expect(renderNavNameToMarkup(vueUpcoming?.name)).toContain(
+      " guides are ready with more guides on the way.",
+    );
+    expect(renderNavNameToMarkup(slackUpcoming?.name)).toContain(
+      "Slack is currently in early access. The ",
+    );
+    expect(renderNavNameToMarkup(slackUpcoming?.name)).toContain(
+      " guides are ready; more are on the way after early access.",
     );
   });
 });

--- a/showcase/shell-docs/src/lib/__tests__/frontend-options.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/frontend-options.test.ts
@@ -124,12 +124,13 @@ describe("frontend options", () => {
       backend: "langgraph-python",
       slugPath: "concepts/architecture",
     });
-    expect(parseFrontendRoutePath("/vue/using-these-docs", backendSlugs))
-      .toEqual({
-        frontend: "vue",
-        backend: null,
-        slugPath: "using-these-docs",
-      });
+    expect(
+      parseFrontendRoutePath("/vue/using-these-docs", backendSlugs),
+    ).toEqual({
+      frontend: "vue",
+      backend: null,
+      slugPath: "using-these-docs",
+    });
     expect(backendFromPathname("/vue/langgraph-python", backendSlugs)).toBe(
       "langgraph-python",
     );
@@ -172,9 +173,7 @@ describe("frontend options", () => {
       expect(isFrontendId(id)).toBe(true);
       expect(getFrontendOption(id).name).toBeTruthy();
       expect(getFrontendContentSlug(id)).toBe(`frontends/${id}`);
-      expect(getFrontendUsingTheseDocsPath(id)).toBe(
-        `/${id}/using-these-docs`,
-      );
+      expect(getFrontendUsingTheseDocsPath(id)).toBe(`/${id}/using-these-docs`);
       expect(loadDoc(getFrontendContentSlug(id))?.fm.title).toBeTruthy();
     }
     expect(isFrontendEarlyAccess("vue")).toBe(false);
@@ -232,9 +231,7 @@ describe("frontend options", () => {
       ]),
     );
 
-    const pageUrls = collectPageUrls(
-      navTreeToPageTree(navTree, "/slack"),
-    );
+    const pageUrls = collectPageUrls(navTreeToPageTree(navTree, "/slack"));
     expect(pageUrls).toEqual([
       "/slack",
       "/slack/using-these-docs",

--- a/showcase/shell-docs/src/lib/__tests__/search-hrefs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/search-hrefs.test.ts
@@ -22,9 +22,9 @@ describe("search href helpers", () => {
     expect(frameworkDocsHref("built-in-agent", "quickstart", "vue")).toBe(
       "/vue",
     );
-    expect(
-      frameworkDocsHref("langgraph-python", "quickstart", "vue"),
-    ).toBe("/vue/langgraph-python");
+    expect(frameworkDocsHref("langgraph-python", "quickstart", "vue")).toBe(
+      "/vue/langgraph-python",
+    );
     expect(
       frameworkDocsHref("mastra", "concepts/architecture", "react-native"),
     ).toBe("/react-native/mastra/concepts/architecture");
@@ -59,10 +59,7 @@ describe("search href helpers", () => {
       ),
     ).toBe("/react-native/using-these-docs");
     expect(
-      normalizeHref(
-        "/docs/frontends/using-these-docs",
-        "https://shell.test",
-      ),
+      normalizeHref("/docs/frontends/using-these-docs", "https://shell.test"),
     ).toBe("/vue/using-these-docs");
     expect(
       normalizeHref("/docs/frontends/docs-status", "https://shell.test"),

--- a/showcase/shell-docs/src/lib/__tests__/search-hrefs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/search-hrefs.test.ts
@@ -17,6 +17,19 @@ describe("search href helpers", () => {
     );
   });
 
+  it("preserves the active frontend when building framework search results", () => {
+    expect(frameworkDocsHref("built-in-agent", "", "vue")).toBe("/vue");
+    expect(frameworkDocsHref("built-in-agent", "quickstart", "vue")).toBe(
+      "/vue",
+    );
+    expect(
+      frameworkDocsHref("langgraph-python", "quickstart", "vue"),
+    ).toBe("/vue/langgraph-python");
+    expect(
+      frameworkDocsHref("mastra", "concepts/architecture", "react-native"),
+    ).toBe("/react-native/mastra/concepts/architecture");
+  });
+
   it("normalizes built-in-agent docs index hrefs to root URLs", () => {
     expect(normalizeHref("/docs/built-in-agent", "https://shell.test")).toBe(
       "/",
@@ -36,6 +49,24 @@ describe("search href helpers", () => {
     expect(normalizeHref("/docs/quickstart", "https://shell.test")).toBe(
       "/quickstart",
     );
+    expect(normalizeHref("/docs/frontends/vue", "https://shell.test")).toBe(
+      "/vue",
+    );
+    expect(
+      normalizeHref(
+        "/docs/frontends/react-native/using-these-docs",
+        "https://shell.test",
+      ),
+    ).toBe("/react-native/using-these-docs");
+    expect(
+      normalizeHref(
+        "/docs/frontends/using-these-docs",
+        "https://shell.test",
+      ),
+    ).toBe("/vue/using-these-docs");
+    expect(
+      normalizeHref("/docs/frontends/docs-status", "https://shell.test"),
+    ).toBe("/vue/using-these-docs");
     expect(normalizeHref("/integrations", "https://shell.test")).toBe(
       "https://shell.test/integrations",
     );
@@ -44,6 +75,7 @@ describe("search href helpers", () => {
   it("parses docs href categories", () => {
     expect(parseDocsHref("/docs/quickstart")).toBe("quickstart");
     expect(parseDocsHref("/docs/integrations/mastra/quickstart")).toBeNull();
+    expect(parseDocsHref("/docs/frontends/vue")).toBeNull();
     expect(
       parseIntegrationDocsHref("/docs/integrations/mastra/quickstart"),
     ).toEqual({ folder: "mastra", topic: "quickstart" });

--- a/showcase/shell-docs/src/lib/__tests__/seo-redirects.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/seo-redirects.test.ts
@@ -51,14 +51,14 @@ describe("seoRedirects", () => {
           destination: "/",
         },
         {
-          id: "FE-vue",
-          source: "/vue",
-          destination: "/frontends/vue",
+          id: "FE-frontends-wild",
+          source: "/frontends/:path*",
+          destination: "/:path*",
         },
         {
           id: "FE-teams",
           source: "/microsoft-teams",
-          destination: "/frontends/teams",
+          destination: "/teams",
         },
       ]),
     );
@@ -138,6 +138,9 @@ describe("seoRedirects", () => {
     expect(matchesSeoRedirectSource("/generative-ui/tool-rendering")).toBe(
       false,
     );
+    expect(matchesSeoRedirectSource("/vue")).toBe(false);
+    expect(matchesSeoRedirectSource("/slack")).toBe(false);
+    expect(matchesSeoRedirectSource("/react-native")).toBe(false);
     expect(matchesSeoRedirectSource("/custom-look-and-feel/slots")).toBe(false);
   });
 });

--- a/showcase/shell-docs/src/lib/docs-link-rewrite.ts
+++ b/showcase/shell-docs/src/lib/docs-link-rewrite.ts
@@ -28,6 +28,15 @@ function stripPathPrefix(href: string, prefix: string): string | null {
   return null;
 }
 
+function joinPrefixedPath(prefix: string, suffix: string): string {
+  if (!prefix) return suffix;
+  if (suffix === "/") return prefix;
+  if (suffix.startsWith("/?") || suffix.startsWith("/#")) {
+    return `${prefix}${suffix.slice(1)}`;
+  }
+  return `${prefix}${suffix}`;
+}
+
 /**
  * Keep authored MDX links inside the active docs surface.
  *
@@ -72,13 +81,16 @@ export function resolveDocsHref(
     return sameFrameworkPath ?? href;
   }
 
+  if (sameFrameworkPath !== null) {
+    return joinPrefixedPath(slugHrefPrefix, sameFrameworkPath);
+  }
+
   if (
-    sameFrameworkPath === null &&
     !targetsAnotherFramework &&
     !targetsReservedRoute &&
     !targetsRedirectAlias
   ) {
-    return `/${linkRewriteFramework}${href}`;
+    return joinPrefixedPath(slugHrefPrefix, href);
   }
 
   return href;

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -28,7 +28,11 @@ export {
 // Nav tree types
 // ---------------------------------------------------------------------------
 
-export type NavNodeVariant = "react-docs-proxy";
+export type NavNodeVariant =
+  | "react-docs-proxy"
+  | "frontend-docs-upcoming";
+
+export type FrontendDocsStatus = "feature-complete" | "early-access";
 
 export type NavNode =
   | {
@@ -44,6 +48,9 @@ export type NavNode =
       title: string;
       icon?: string;
       variant?: NavNodeVariant;
+      quickstartHref?: string;
+      referenceHref?: string;
+      frontendDocsStatus?: FrontendDocsStatus;
     }
   | {
       type: "group";

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -28,9 +28,7 @@ export {
 // Nav tree types
 // ---------------------------------------------------------------------------
 
-export type NavNodeVariant =
-  | "react-docs-proxy"
-  | "frontend-docs-upcoming";
+export type NavNodeVariant = "react-docs-proxy" | "frontend-docs-upcoming";
 
 export type FrontendDocsStatus = "feature-complete" | "early-access";
 

--- a/showcase/shell-docs/src/lib/frontend-doc-policy.ts
+++ b/showcase/shell-docs/src/lib/frontend-doc-policy.ts
@@ -125,7 +125,7 @@ export function resolveFrontendDocPage(
         status: "found",
         slugPath,
         contentSlugPath: variantContentSlug,
-        canonicalPath: `/frontends/${frontend}/${slugPath}`,
+        canonicalPath: `/${frontend}/${slugPath}`,
         policy,
       };
     }
@@ -137,7 +137,7 @@ export function resolveFrontendDocPage(
       status: "found",
       slugPath,
       contentSlugPath: slugPath,
-      canonicalPath: `/${slugPath}`,
+      canonicalPath: `/${frontend}/${slugPath}`,
       policy,
     };
   }
@@ -147,7 +147,7 @@ export function resolveFrontendDocPage(
       status: "found",
       slugPath,
       contentSlugPath: variantContentSlug,
-      canonicalPath: `/frontends/${frontend}/${slugPath}`,
+      canonicalPath: `/${frontend}/${slugPath}`,
       policy: { kind: "frontend-variant", fallback: "hide" },
     };
   }

--- a/showcase/shell-docs/src/lib/frontend-options.ts
+++ b/showcase/shell-docs/src/lib/frontend-options.ts
@@ -59,10 +59,7 @@ export function isFrontendEarlyAccess(id: FrontendId): boolean {
 }
 
 function normalizeSlugPath(slugPath: string): string {
-  return slugPath
-    .split("/")
-    .filter(Boolean)
-    .join("/");
+  return slugPath.split("/").filter(Boolean).join("/");
 }
 
 export function frontendPathFor(id: FrontendId, slugPath = ""): string {

--- a/showcase/shell-docs/src/lib/frontend-options.ts
+++ b/showcase/shell-docs/src/lib/frontend-options.ts
@@ -54,13 +54,141 @@ export function getFrontendOption(id: FrontendId): FrontendOption {
   return FRONTEND_OPTIONS.find((option) => option.id === id)!;
 }
 
-export function frontendPathFor(id: FrontendId): string {
-  return id === "react" ? "/" : `/frontends/${id}`;
+export function isFrontendEarlyAccess(id: FrontendId): boolean {
+  return id === "slack" || id === "teams";
 }
 
-export function frontendFromPathname(pathname: string): FrontendId | null {
-  const [first, second] = pathname.split("/").filter(Boolean);
-  if (first !== "frontends") return null;
-  if (!isFrontendId(second) || second === "react") return null;
-  return second;
+function normalizeSlugPath(slugPath: string): string {
+  return slugPath
+    .split("/")
+    .filter(Boolean)
+    .join("/");
+}
+
+export function frontendPathFor(id: FrontendId, slugPath = ""): string {
+  const normalizedSlugPath = normalizeSlugPath(slugPath);
+  return frontendPathForBackend(id, normalizedSlugPath, null);
+}
+
+export function frontendPathForBackend(
+  id: FrontendId,
+  slugPath = "",
+  backendFrameworkSlug: string | null = null,
+): string {
+  const normalizedSlugPath = normalizeSlugPath(slugPath);
+  const basePath =
+    id === "react"
+      ? backendFrameworkSlug
+        ? `/${backendFrameworkSlug}`
+        : ""
+      : backendFrameworkSlug
+        ? `/${id}/${backendFrameworkSlug}`
+        : `/${id}`;
+
+  if (
+    normalizedSlugPath === "" ||
+    normalizedSlugPath === "quickstart" ||
+    (id === "react" && normalizedSlugPath === "using-these-docs")
+  ) {
+    return basePath || "/";
+  }
+
+  return basePath
+    ? `${basePath}/${normalizedSlugPath}`
+    : `/${normalizedSlugPath}`;
+}
+
+export function frontendFromPathname(
+  pathname: string,
+): Exclude<FrontendId, "react"> | null {
+  const [first] = pathname.split("/").filter(Boolean);
+  if (!isFrontendId(first) || first === "react") return null;
+  return first;
+}
+
+export interface FrontendRoutePath {
+  frontend: Exclude<FrontendId, "react">;
+  backend: string | null;
+  slugPath: string;
+}
+
+function pathnameSegments(pathname: string): string[] {
+  return pathname.split("/").filter(Boolean);
+}
+
+export function parseFrontendRoutePath(
+  pathname: string,
+  backendFrameworkSlugs: readonly string[] = [],
+): FrontendRoutePath | null {
+  const [first, ...rest] = pathnameSegments(pathname);
+  if (!isFrontendId(first) || first === "react") return null;
+
+  const [maybeBackend, ...tail] = rest;
+  const backend =
+    maybeBackend && backendFrameworkSlugs.includes(maybeBackend)
+      ? maybeBackend
+      : null;
+
+  return {
+    frontend: first,
+    backend,
+    slugPath: backend ? tail.join("/") : rest.join("/"),
+  };
+}
+
+export function backendFromPathname(
+  pathname: string,
+  backendFrameworkSlugs: readonly string[] = [],
+): string | null {
+  const frontendRoute = parseFrontendRoutePath(pathname, backendFrameworkSlugs);
+  if (frontendRoute) return frontendRoute.backend;
+
+  const [first] = pathnameSegments(pathname);
+  return first && backendFrameworkSlugs.includes(first) ? first : null;
+}
+
+export function frontendPathForCurrentPath(
+  id: FrontendId,
+  pathname: string,
+  backendFrameworkSlugs: readonly string[] = [],
+): string {
+  const frontendRoute = parseFrontendRoutePath(pathname, backendFrameworkSlugs);
+  if (frontendRoute) {
+    return frontendPathForBackend(
+      id,
+      frontendRoute.slugPath,
+      frontendRoute.backend,
+    );
+  }
+
+  const [first = "", ...rest] = pathnameSegments(pathname);
+  if (backendFrameworkSlugs.includes(first)) {
+    return frontendPathForBackend(id, rest.join("/"), first);
+  }
+
+  return frontendPathFor(id, [first, ...rest].join("/"));
+}
+
+export function backendPathForCurrentPath(
+  slug: string,
+  pathname: string,
+  backendFrameworkSlugs: readonly string[] = [],
+  defaultFrameworkSlug: string,
+): string {
+  const backend = slug === defaultFrameworkSlug ? null : slug;
+  const frontendRoute = parseFrontendRoutePath(pathname, backendFrameworkSlugs);
+  if (frontendRoute) {
+    return frontendPathForBackend(
+      frontendRoute.frontend,
+      frontendRoute.slugPath,
+      backend,
+    );
+  }
+
+  const [first = "", ...rest] = pathnameSegments(pathname);
+  if (backendFrameworkSlugs.includes(first)) {
+    return frontendPathForBackend("react", rest.join("/"), backend);
+  }
+
+  return frontendPathForBackend("react", [first, ...rest].join("/"), backend);
 }

--- a/showcase/shell-docs/src/lib/frontend-page-content.ts
+++ b/showcase/shell-docs/src/lib/frontend-page-content.ts
@@ -1,11 +1,6 @@
-import { FRONTEND_OPTIONS } from "./frontend-options";
+import { FRONTEND_OPTIONS, isFrontendEarlyAccess } from "./frontend-options";
 import type { FrontendId } from "./frontend-options";
-import { buildRootSurfaceNav } from "./docs-render";
 import type { NavNode } from "./docs-render";
-import {
-  isFrontendFirstClassDoc,
-  isFrontendOwnedDoc,
-} from "./frontend-doc-policy";
 
 export type FrontendPageId = Exclude<FrontendId, "react">;
 
@@ -18,9 +13,20 @@ export function getFrontendContentSlug(id: FrontendPageId): string {
 }
 
 export const FRONTEND_GUIDANCE_CONTENT_SLUG = "frontends/using-these-docs";
+export const FRONTEND_DOCS_STATUS_CONTENT_SLUG = "frontends/docs-status";
+
+export function getFrontendGuidanceContentSlug(id: FrontendPageId): string {
+  return isFrontendEarlyAccess(id)
+    ? FRONTEND_GUIDANCE_CONTENT_SLUG
+    : FRONTEND_DOCS_STATUS_CONTENT_SLUG;
+}
+
+export function getFrontendGuidanceTitle(id: FrontendPageId): string {
+  return isFrontendEarlyAccess(id) ? "About early access" : "Docs status";
+}
 
 export function getFrontendUsingTheseDocsPath(id: FrontendPageId): string {
-  return `/frontends/${id}/using-these-docs`;
+  return `/${id}/using-these-docs`;
 }
 
 const FRONTEND_REFERENCE_SLUGS = {
@@ -34,153 +40,35 @@ export function getFrontendReferenceSlug(id: FrontendPageId): string {
   return FRONTEND_REFERENCE_SLUGS[id];
 }
 
-function asReactDocsProxyNode(node: NavNode): NavNode {
-  if (node.type === "group") {
-    return {
-      ...node,
-      variant: "react-docs-proxy",
-      children: node.children.map(asReactDocsProxyNode),
-    };
-  }
-
-  if (node.type === "page") {
-    return { ...node, href: `/${node.slug}`, variant: "react-docs-proxy" };
-  }
-
-  return { ...node, variant: "react-docs-proxy" };
-}
-
-function isGettingStartedSection(node: NavNode): boolean {
-  return (
-    node.type === "section" &&
-    /^(get|getting) started$/i.test(node.title.trim())
-  );
-}
-
-function withoutRootSections(
-  nodes: NavNode[],
-  isRemovedSection: (node: NavNode) => boolean,
-): NavNode[] {
-  const nextNodes: NavNode[] = [];
-
-  for (let index = 0; index < nodes.length; ) {
-    const node = nodes[index];
-
-    if (node.type === "section" && isRemovedSection(node)) {
-      index += 1;
-      while (index < nodes.length && nodes[index].type !== "section") {
-        index += 1;
-      }
-      continue;
-    }
-
-    nextNodes.push(node);
-    index += 1;
-  }
-
-  return nextNodes;
-}
-
-function rootSurfaceNav(): NavNode[] {
-  return buildRootSurfaceNav("built-in-agent");
-}
-
-function filterFrontendOwnedNode(
-  node: NavNode,
-  id: FrontendPageId,
-): NavNode | null {
-  if (node.type === "page") {
-    return isFrontendFirstClassDoc(id, node.slug) ? node : null;
-  }
-
-  if (node.type === "group") {
-    const children = node.children
-      .map((child) => filterFrontendOwnedNode(child, id))
-      .filter((child): child is NavNode => child !== null);
-    return children.length > 0 ? { ...node, children } : null;
-  }
-
-  return node;
-}
-
-function getFrontendOwnedNavTree(id: FrontendPageId): NavNode[] {
-  const nextNodes: NavNode[] = [];
-  let pendingSection: NavNode | null = null;
-
-  for (const node of rootSurfaceNav()) {
-    if (node.type === "section") {
-      pendingSection = node;
-      continue;
-    }
-
-    const filteredNode = filterFrontendOwnedNode(node, id);
-    if (!filteredNode) continue;
-
-    if (pendingSection) {
-      nextNodes.push(pendingSection);
-      pendingSection = null;
-    }
-    nextNodes.push(filteredNode);
-  }
-
-  return nextNodes;
-}
-
-function dropEmptySections(nodes: NavNode[]): NavNode[] {
-  return nodes.filter((node, index) => {
-    if (node.type !== "section") return true;
-
-    const nextNode = nodes[index + 1];
-    return nextNode !== undefined && nextNode.type !== "section";
-  });
-}
-
-function filterReactParallelsNode(node: NavNode): NavNode | null {
-  if (node.type === "page") {
-    return isFrontendOwnedDoc(node.slug) ? null : asReactDocsProxyNode(node);
-  }
-
-  if (node.type === "group") {
-    const children = node.children
-      .map(filterReactParallelsNode)
-      .filter((child): child is NavNode => child !== null);
-    return children.length > 0
-      ? asReactDocsProxyNode({ ...node, children })
-      : null;
-  }
-
-  return asReactDocsProxyNode(node);
-}
-
-function getReactParallelsNavTree(): NavNode[] {
-  const filtered = withoutRootSections(
-    rootSurfaceNav(),
-    isGettingStartedSection,
-  )
-    .map(filterReactParallelsNode)
-    .filter((node): node is NavNode => node !== null);
-
-  return dropEmptySections(filtered);
-}
-
 export function getFrontendQuickstartNavTree(id: FrontendPageId): NavNode[] {
+  const frontendName =
+    FRONTEND_OPTIONS.find((option) => option.id === id)?.name ?? id;
+
   return [
     { type: "section", title: "Getting Started", icon: "lucide/Rocket" },
     { type: "page", title: "Quickstart", slug: "" },
     {
       type: "page",
-      title: "Using these docs 🏗️",
+      title: getFrontendGuidanceTitle(id),
       slug: "using-these-docs",
       icon: "lucide/Wrench",
     },
-    ...getFrontendOwnedNavTree(id),
-    { type: "section", title: "More to explore", icon: "lucide/BookOpen" },
     {
       type: "page",
       title: "Reference docs",
       slug: getFrontendReferenceSlug(id),
       href: `/${getFrontendReferenceSlug(id)}`,
     },
-    ...getReactParallelsNavTree(),
+    {
+      type: "section",
+      title: frontendName,
+      icon: "lucide/RefreshCw",
+      variant: "frontend-docs-upcoming",
+      quickstartHref: `/${id}`,
+      referenceHref: `/${getFrontendReferenceSlug(id)}`,
+      frontendDocsStatus: isFrontendEarlyAccess(id)
+        ? "early-access"
+        : "feature-complete",
+    },
   ];
 }

--- a/showcase/shell-docs/src/lib/page-tree-bridge.ts
+++ b/showcase/shell-docs/src/lib/page-tree-bridge.ts
@@ -132,9 +132,7 @@ function renderNavName(
   }
 
   const className =
-    variant === "react-docs-proxy"
-      ? "shell-docs-react-docs-proxy"
-      : undefined;
+    variant === "react-docs-proxy" ? "shell-docs-react-docs-proxy" : undefined;
 
   if (!className && !icon) return title;
 

--- a/showcase/shell-docs/src/lib/page-tree-bridge.ts
+++ b/showcase/shell-docs/src/lib/page-tree-bridge.ts
@@ -24,6 +24,17 @@ import type * as PageTree from "fumadocs-core/page-tree";
 import type { NavNode } from "@/lib/docs-render";
 import { resolveSidebarIcon } from "@/lib/sidebar-icon";
 
+const frontendUpcomingSkeletonCards = [
+  ["long", "medium", "short"],
+  ["medium", "long"],
+  ["short", "long", "medium"],
+  ["long", "short"],
+  ["medium", "short"],
+  ["short", "medium", "long"],
+  ["long", "medium"],
+  ["medium", "short"],
+] as const;
+
 function buildUrl(prefix: string, slug: string): string {
   // `prefix` is one of "/docs", "/<framework>", or "" (root). Normalize
   // trailing/leading slashes so `/${prefix}/${slug}` never doubles up.
@@ -37,11 +48,93 @@ function renderNavName(
   title: string,
   variant: NavNode["variant"],
   icon?: React.ReactNode,
+  links?: {
+    quickstartHref?: string;
+    referenceHref?: string;
+    frontendDocsStatus?: "feature-complete" | "early-access";
+  },
 ): React.ReactNode {
   const isReactDocsProxy = variant === "react-docs-proxy";
-  const className = isReactDocsProxy
-    ? "shell-docs-react-docs-proxy"
-    : undefined;
+  if (variant === "frontend-docs-upcoming") {
+    const frontendDocsStatus = links?.frontendDocsStatus ?? "early-access";
+    const ariaLabel =
+      frontendDocsStatus === "feature-complete"
+        ? `${title} guides are coming soon. ${title} is feature complete, but the docs are still catching up. The quickstart and reference guides are ready with more guides on the way.`
+        : `${title} guides are coming soon. ${title} is currently in early access. The quickstart and reference guides are ready; more are on the way after early access.`;
+
+    return React.createElement(
+      "span",
+      {
+        className: "shell-docs-frontend-docs-upcoming",
+        role: "note",
+        "aria-label": ariaLabel,
+      },
+      React.createElement(
+        "span",
+        { className: "shell-docs-frontend-docs-upcoming-header" },
+        icon,
+        React.createElement(
+          "span",
+          { className: "shell-docs-frontend-docs-upcoming-title" },
+          "Guides coming soon...",
+        ),
+      ),
+      React.createElement(
+        "span",
+        { className: "shell-docs-frontend-docs-upcoming-copy" },
+        frontendDocsStatus === "feature-complete"
+          ? `${title} is feature complete, but the docs are still catching up. The `
+          : `${title} is currently in early access. The `,
+        React.createElement(
+          "a",
+          {
+            className: "shell-docs-frontend-docs-upcoming-link",
+            href: links?.quickstartHref ?? "#",
+          },
+          "quickstart",
+        ),
+        " and ",
+        React.createElement(
+          "a",
+          {
+            className: "shell-docs-frontend-docs-upcoming-link",
+            href: links?.referenceHref ?? "#",
+          },
+          "reference",
+        ),
+        frontendDocsStatus === "feature-complete"
+          ? " guides are ready with more guides on the way."
+          : " guides are ready; more are on the way after early access.",
+      ),
+      React.createElement(
+        "span",
+        {
+          className: "shell-docs-frontend-docs-upcoming-stack",
+          "aria-hidden": "true",
+        },
+        frontendUpcomingSkeletonCards.map((lines, cardIndex) =>
+          React.createElement(
+            "span",
+            {
+              key: `card-${cardIndex}`,
+              className: "shell-docs-frontend-docs-upcoming-sheet",
+            },
+            lines.map((line, lineIndex) =>
+              React.createElement("span", {
+                key: `line-${lineIndex}`,
+                className: `shell-docs-frontend-docs-upcoming-sheet-line shell-docs-frontend-docs-upcoming-sheet-line-${line}`,
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  const className =
+    variant === "react-docs-proxy"
+      ? "shell-docs-react-docs-proxy"
+      : undefined;
 
   if (!className && !icon) return title;
 
@@ -89,7 +182,11 @@ export function navNodeToPageTreeNodes(
     // `inline-flex items-center gap-2` styling still aligns the SVG
     // and label exactly as it would have with the prop split.
     const icon = resolveSidebarIcon(node.icon);
-    const name = renderNavName(node.title, node.variant, icon);
+    const name = renderNavName(node.title, node.variant, icon, {
+      quickstartHref: node.quickstartHref,
+      referenceHref: node.referenceHref,
+      frontendDocsStatus: node.frontendDocsStatus,
+    });
     return [{ type: "separator", name }];
   }
   if (node.type === "page") {

--- a/showcase/shell-docs/src/lib/search-hrefs.ts
+++ b/showcase/shell-docs/src/lib/search-hrefs.ts
@@ -1,4 +1,9 @@
+import { frontendPathForBackend } from "@/lib/frontend-options";
+import type { FrontendId } from "@/lib/frontend-options";
+
 const ROOT_FRAMEWORK = "built-in-agent";
+const FRONTEND_IDS = new Set(["vue", "react-native", "slack", "teams"]);
+type FrontendPageId = Exclude<FrontendId, "react">;
 
 export function parseIntegrationDocsHref(
   href: string,
@@ -14,10 +19,23 @@ export function parseIntegrationDocsHref(
 export function parseDocsHref(href: string): string | null {
   if (!href.startsWith("/docs/")) return null;
   if (href.startsWith("/docs/integrations/")) return null;
+  if (href.startsWith("/docs/frontends/")) return null;
   return href.slice("/docs/".length);
 }
 
-export function frameworkDocsHref(framework: string, topic: string): string {
+export function frameworkDocsHref(
+  framework: string,
+  topic: string,
+  frontend?: FrontendPageId | null,
+): string {
+  if (frontend) {
+    return frontendPathForBackend(
+      frontend,
+      topic,
+      framework === ROOT_FRAMEWORK ? null : framework,
+    );
+  }
+
   if (framework === ROOT_FRAMEWORK) {
     return topic ? `/${topic}` : "/";
   }
@@ -27,6 +45,25 @@ export function frameworkDocsHref(framework: string, topic: string): string {
 export function normalizeHref(href: string, shellHost: string): string {
   if (href === "/integrations" || href === "/matrix") {
     return `${shellHost}${href}`;
+  }
+
+  const frontendDocsPrefix = "/docs/frontends/";
+  if (href.startsWith(frontendDocsPrefix)) {
+    const [frontend, ...tail] = href
+      .slice(frontendDocsPrefix.length)
+      .split("/")
+      .filter(Boolean);
+
+    // Regenerated indexes expand shared frontend guidance once per frontend.
+    // This only protects users with a stale index from landing on 404.
+    if (frontend === "using-these-docs" || frontend === "docs-status") {
+      return "/vue/using-these-docs";
+    }
+    if (FRONTEND_IDS.has(frontend)) {
+      return tail.length > 0
+        ? `/${frontend}/${tail.join("/")}`
+        : `/${frontend}`;
+    }
   }
 
   const rootDocsPrefix = `/docs/${ROOT_FRAMEWORK}`;

--- a/showcase/shell-docs/src/lib/seo-redirects.ts
+++ b/showcase/shell-docs/src/lib/seo-redirects.ts
@@ -690,24 +690,34 @@ const MOVED_ROOT_REDIRECTS: RedirectEntry[] = [
 
 const FRONTEND_PLATFORM_REDIRECTS: RedirectEntry[] = [
   {
-    id: "FE-vue",
-    source: "/vue",
-    destination: "/frontends/vue",
+    id: "FE-frontends",
+    source: "/frontends",
+    destination: "/",
   },
   {
-    id: "FE-slack",
-    source: "/slack",
-    destination: "/frontends/slack",
+    id: "FE-frontends-react",
+    source: "/frontends/react",
+    destination: "/",
+  },
+  {
+    id: "FE-frontends-react-wild",
+    source: "/frontends/react/:path*",
+    destination: "/:path*",
+  },
+  {
+    id: "FE-frontends-wild",
+    source: "/frontends/:path*",
+    destination: "/:path*",
   },
   {
     id: "FE-teams",
     source: "/microsoft-teams",
-    destination: "/frontends/teams",
+    destination: "/teams",
   },
   {
-    id: "FE-react-native",
-    source: "/react-native",
-    destination: "/frontends/react-native",
+    id: "FE-teams-wild",
+    source: "/microsoft-teams/:path*",
+    destination: "/teams/:path*",
   },
 ];
 

--- a/showcase/shell-docs/src/lib/sitemap-helpers.ts
+++ b/showcase/shell-docs/src/lib/sitemap-helpers.ts
@@ -139,8 +139,10 @@ export function resolveLastModified(absFilePath: string): Date {
  * root URL is emitted only once by the caller.
  */
 export function getBareDocsPages(): MdxEntry[] {
-  return walkMdx(DOCS_CONTENT_DIR, new Set(["frontends", "integrations"]))
-    .filter((e) => e.slug.length > 0);
+  return walkMdx(
+    DOCS_CONTENT_DIR,
+    new Set(["frontends", "integrations"]),
+  ).filter((e) => e.slug.length > 0);
 }
 
 /**

--- a/showcase/shell-docs/src/lib/sitemap-helpers.ts
+++ b/showcase/shell-docs/src/lib/sitemap-helpers.ts
@@ -139,9 +139,8 @@ export function resolveLastModified(absFilePath: string): Date {
  * root URL is emitted only once by the caller.
  */
 export function getBareDocsPages(): MdxEntry[] {
-  return walkMdx(DOCS_CONTENT_DIR, new Set(["integrations"])).filter(
-    (e) => e.slug.length > 0,
-  );
+  return walkMdx(DOCS_CONTENT_DIR, new Set(["frontends", "integrations"]))
+    .filter((e) => e.slug.length > 0);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix frontend selection, logo, and docs navigation behavior in shell docs
- Update link rewriting, search href generation, SEO redirects, and sitemap handling for frontend docs paths
- Refresh related docs pages and tests across framework and frontend routes

## Testing
- Added and updated unit tests for frontend options, link rewriting, search hrefs, SEO redirects, and framework shell layout
- Added route-level coverage for the llms-mdx endpoint