### PR TITLE
fix(showcase): include 12 starters in promote dropdown + regression guard

### DIFF
--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -59,6 +59,18 @@ on:
           - showcase-harness
           - showcase-pocketbase
           - spring-ai
+          - starter-adk
+          - starter-agno
+          - starter-crewai-crews
+          - starter-langgraph-fastapi
+          - starter-langgraph-js
+          - starter-langgraph-python
+          - starter-llamaindex
+          - starter-mastra
+          - starter-ms-agent-framework-dotnet
+          - starter-ms-agent-framework-python
+          - starter-pydantic-ai
+          - starter-strands-python
           - strands
           - webhooks
         # <<< END GENERATED service options

--- a/showcase/scripts/__tests__/sync-promote-service-options.test.ts
+++ b/showcase/scripts/__tests__/sync-promote-service-options.test.ts
@@ -14,6 +14,53 @@ import type { ServiceEntry } from "../railway-envs";
 
 const SCRIPT = resolve(__dirname, "..", "sync-promote-service-options.ts");
 
+// The REAL, committed workflow file that GitHub validates the `service`
+// workflow_dispatch choice against server-side. `gh workflow run` is rejected
+// with HTTP 422 ("Provided value '<svc>' ... not in the list of allowed
+// values") whenever a chosen value is absent from THIS file on the default
+// branch — so the durable regression test below asserts against the committed
+// file, not just the in-memory generator output.
+const COMMITTED_WORKFLOW = resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  ".github",
+  "workflows",
+  "showcase_promote.yml",
+);
+
+/**
+ * The full set of services that MUST appear in the promote dropdown. This is
+ * the regression guard's allowlist: if a future generator change (or a botched
+ * SSOT edit) drops ANY of these, both the generator-output and committed-file
+ * assertions below fail LOUDLY in CI.
+ *
+ * `shell-docs` is called out by name on purpose: it is promoted regularly by a
+ * teammate, and the explicit worry is that a future pinning/generator
+ * regression must NEVER silently strip it from the dropdown. The 12 `starter-*`
+ * services are listed because they were historically OMITTED (the committed
+ * dropdown was never regenerated after they joined the SSOT), which caused the
+ * HTTP 422 rejection this regression test exists to prevent recurring.
+ */
+const REQUIRED_PROMOTE_TARGETS = [
+  // The teammate-critical target — guarded by name, never just by count.
+  "shell-docs",
+  // The 12 starter-* container fleet (the previously-omitted set).
+  "starter-adk",
+  "starter-agno",
+  "starter-crewai-crews",
+  "starter-langgraph-fastapi",
+  "starter-langgraph-js",
+  "starter-langgraph-python",
+  "starter-llamaindex",
+  "starter-mastra",
+  "starter-ms-agent-framework-dotnet",
+  "starter-ms-agent-framework-python",
+  "starter-pydantic-ai",
+  "starter-strands-python",
+] as const;
+
 /**
  * Build a synthetic env-map `ServiceEntry` for computeOptionTokens tests.
  * Only the fields the generator reads matter (`environments.prod.probe` +
@@ -569,5 +616,72 @@ describe("sync-promote-service-options", () => {
     expect(tokens[1]).toBe("all");
     expect(tokens.filter((t) => t === SENTINEL)).toHaveLength(1);
     expect(tokens.filter((t) => t === "all")).toHaveLength(1);
+  });
+});
+
+describe("promote dropdown regression guard (shell-docs + starters must stay listed)", () => {
+  // The whole set the dropdown must currently expose, computed from the SSOT.
+  // Used as the "no previously-listed target is dropped" oracle: every token
+  // the generator currently emits (minus the two reserved literals) MUST
+  // survive in both the generator output and the committed workflow file.
+  const expectedTokens = computeOptionTokens(SERVICES);
+  const expectedRealTargets = expectedTokens.filter(
+    (t) => t !== SENTINEL && t !== "all",
+  );
+
+  it("generator output contains shell-docs AND all 12 starters by name", () => {
+    const tokens = computeOptionTokens(SERVICES);
+    // Assert MEMBERSHIP by name (not just a count) so a regression that swaps
+    // one target for another is still caught.
+    for (const required of REQUIRED_PROMOTE_TARGETS) {
+      expect(
+        tokens,
+        `promote dropdown (generator output) must contain "${required}" — ` +
+          `it is a required promote target and must never be dropped`,
+      ).toContain(required);
+    }
+  });
+
+  it("the COMMITTED showcase_promote.yml choice list contains shell-docs AND all 12 starters", () => {
+    // This is the file GitHub validates the choice enum against server-side.
+    // If shell-docs or any starter is absent here, `gh workflow run
+    // showcase_promote.yml -f service=<svc>` is rejected with HTTP 422 even
+    // though the SSOT lists the service. Asserting the COMMITTED file (not
+    // just the in-memory generator output) is what makes this guard real:
+    // it fails if the dropdown is ever left un-regenerated after an SSOT change.
+    const doc = parseYaml(readFileSync(COMMITTED_WORKFLOW, "utf8"));
+    const options: string[] = doc.on.workflow_dispatch.inputs.service.options;
+
+    for (const required of REQUIRED_PROMOTE_TARGETS) {
+      expect(
+        options,
+        `committed showcase_promote.yml service dropdown must contain ` +
+          `"${required}" (GitHub validates the choice enum against this file; ` +
+          `a missing value yields HTTP 422 on dispatch)`,
+      ).toContain(required);
+    }
+  });
+
+  it("the committed dropdown is the EXACT union — drops no previously-listed target", () => {
+    // The committed file must equal the generator's full output, guaranteeing
+    // the fix is purely additive: every service the generator emits (the union
+    // of shell-docs, the starters, and every pre-existing target) is present,
+    // in order, with nothing removed.
+    const doc = parseYaml(readFileSync(COMMITTED_WORKFLOW, "utf8"));
+    const options: string[] = doc.on.workflow_dispatch.inputs.service.options;
+
+    // Nothing the generator currently emits may be missing from the committed
+    // file — this is the "never drop an existing target" invariant.
+    for (const target of expectedRealTargets) {
+      expect(
+        options,
+        `committed dropdown dropped previously-listed promote target ` +
+          `"${target}"`,
+      ).toContain(target);
+    }
+
+    // And the committed list is byte-for-byte the generator's output, so the
+    // dropdown can never silently drift from the SSOT in either direction.
+    expect(options).toEqual(expectedTokens);
   });
 });

--- a/showcase/scripts/sync-promote-service-options.ts
+++ b/showcase/scripts/sync-promote-service-options.ts
@@ -68,16 +68,30 @@ import { SERVICES } from "./railway-envs";
 import type { ServiceEntry } from "./railway-envs";
 
 /**
- * Whether an entry is prod-promotable: it declares a `prod` env whose probe
- * is enabled (`probe` defaults to true when omitted). Operates on the passed
- * entry (NOT the global SSOT) so `computeOptionTokens` can be exercised with
- * an injected synthetic services map in tests. Mirrors the workflow resolve
- * step's `select(.probe.prod == true)` against the emitted JSON.
+ * Whether an entry is prod-promotable: it declares a prod environment whose
+ * probe is enabled (`probe` defaults to true when omitted). Operates on the
+ * passed entry (NOT the global SSOT) so `computeOptionTokens` can be exercised
+ * with an injected synthetic services map in tests.
+ *
+ * Recognizes the single canonical eligibility shape: the env-map schema used by
+ * `railway-envs.ts` (`SERVICES`), where per-env config lives under
+ * `environments.prod.probe`. This is the TS SSOT shape every current service
+ * (including the 12 starters) carries, and it is the ONLY shape the generator
+ * reads — the generator imports the TS SSOT, never the generated JSON.
+ *
+ * This predicate is equivalent to the workflow resolve step's
+ * `select(.probe.prod == true)`: that step runs against the EMITTED JSON whose
+ * flat `probe.prod` is derived solely from this same `environments.prod.probe`
+ * (see `emit-railway-envs-json.ts`). So an entry is promotable here iff resolve
+ * would accept it, keeping the dropdown and the resolve step in lockstep.
  */
 function isProdPromotable(entry: Pick<ServiceEntry, "environments">): boolean {
-  const prod = entry.environments?.prod;
-  if (!prod) return false;
-  return prod.probe ?? true;
+  // Env-map schema — environments.prod.probe (defaults true when omitted).
+  const envMapProd = entry.environments?.prod;
+  if (envMapProd) {
+    if ((envMapProd.probe ?? true) === true) return true;
+  }
+  return false;
 }
 
 /** Selecting this option aborts the promote run (rejected by resolve step). */


### PR DESCRIPTION
## Summary

Fixes the showcase promote dropdown so the 12 `starter-*` services are dispatchable. The committed `.github/workflows/showcase_promote.yml` `service` choice list was never regenerated after the starters landed in the SSOT, so `gh workflow run showcase_promote.yml -f service=starter-*` was rejected by GitHub with `HTTP 422: not in the list of allowed values` (GitHub validates the `choice` enum server-side against the default branch). This left main's "Showcase: Build & Push" red via `verify-railway-image-refs`.

## Changes

- Regenerated `showcase_promote.yml` — the `service` dropdown now includes all 12 starters plus `shell-docs` and every previously-listed target (nothing dropped). 41 options total.
- `isProdPromotable` reads the canonical env-map shape (`environments.prod.probe`), equivalent to the workflow resolve predicate (`select(.probe.prod==true)` against the emitted JSON).
- Added a durable regression test asserting `shell-docs` AND all 12 starters are present in both the generator output and the committed dropdown, so a future generator regression can't silently drop a promote target.

## Test plan

- [x] `--check` exits 0 (committed dropdown in sync with SSOT)
- [x] vitest 24/24 pass; regression guard asserts shell-docs + 12 starters
- [x] every emitted token resolves to exactly one prod-eligible service under the real resolve predicate
- [x] oxfmt/oxlint/typecheck clean on the diff