### PR TITLE
fix(showcase): resolve oxfmt for promote SSOT generation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3723,6 +3723,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
+      oxfmt:
+        specifier: ^0.36.0
+        version: 0.36.0
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@22.19.11)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))

--- a/showcase/scripts/emit-railway-envs-json.test.ts
+++ b/showcase/scripts/emit-railway-envs-json.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,7 +8,18 @@ import { SERVICES, computePromoteClosure } from "./railway-envs";
 
 const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
 const EMITTER = resolve(SCRIPTS_DIR, "emit-railway-envs-json.ts");
-const OXFMT = resolve(SCRIPTS_DIR, "..", "..", "node_modules", ".bin", "oxfmt");
+const OXFMT_CANDIDATES = [
+  resolve(SCRIPTS_DIR, "..", "..", "node_modules", ".bin", "oxfmt"),
+  resolve(SCRIPTS_DIR, "node_modules", ".bin", "oxfmt"),
+];
+
+function resolveOxfmt(): string {
+  const bin = OXFMT_CANDIDATES.find((candidate) => existsSync(candidate));
+  if (!bin) {
+    throw new Error(`oxfmt binary not found: ${OXFMT_CANDIDATES.join(", ")}`);
+  }
+  return bin;
+}
 
 /**
  * Emit the JSON to a hermetic temp path and parse it. The emitter is the
@@ -169,7 +180,9 @@ describe("emit-railway-envs-json oxfmt-canonical output", () => {
       // ...then assert oxfmt considers the result already-canonical. RED on
       // the pre-fix emitter (multi-line arrays → "Format issues found"),
       // GREEN once the emitter routes output through oxfmt.
-      const res = spawnSync(OXFMT, ["--check", out], { encoding: "utf8" });
+      const res = spawnSync(resolveOxfmt(), ["--check", out], {
+        encoding: "utf8",
+      });
       expect(res.status).toBe(0);
     } finally {
       rmSync(dir, { recursive: true, force: true });
@@ -180,7 +193,9 @@ describe("emit-railway-envs-json oxfmt-canonical output", () => {
     // The in-repo artifact must stay oxfmt-canonical so the CI auto-format
     // bot never fires on it.
     const committed = resolve(SCRIPTS_DIR, "railway-envs.generated.json");
-    const res = spawnSync(OXFMT, ["--check", committed], { encoding: "utf8" });
+    const res = spawnSync(resolveOxfmt(), ["--check", committed], {
+      encoding: "utf8",
+    });
     expect(res.status).toBe(0);
   });
 });

--- a/showcase/scripts/emit-railway-envs-json.ts
+++ b/showcase/scripts/emit-railway-envs-json.ts
@@ -23,6 +23,7 @@
 
 import { execFileSync } from "node:child_process";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -186,14 +187,21 @@ function buildPayload(): Emitted {
  * path AND the `--check` comparison through oxfmt makes on-disk ==
  * emitter-oxfmt-output == oxfmt-canonical, so both checks pass with no bot.
  */
-const OXFMT_BIN = resolve(
-  new URL(".", import.meta.url).pathname,
-  "..",
-  "..",
-  "node_modules",
-  ".bin",
-  "oxfmt",
-);
+const SCRIPT_DIR = new URL(".", import.meta.url).pathname;
+const OXFMT_BIN_CANDIDATES = [
+  resolve(SCRIPT_DIR, "..", "..", "node_modules", ".bin", "oxfmt"),
+  resolve(SCRIPT_DIR, "node_modules", ".bin", "oxfmt"),
+];
+
+function resolveOxfmtBin(): string {
+  if (process.env.OXFMT_BIN) return process.env.OXFMT_BIN;
+  const bin = OXFMT_BIN_CANDIDATES.find((candidate) => existsSync(candidate));
+  if (bin) return bin;
+  throw new Error(
+    `oxfmt binary not found. Checked: ${OXFMT_BIN_CANDIDATES.join(", ")}. ` +
+      "Run the repo install or `npm ci` in showcase/scripts.",
+  );
+}
 
 /**
  * Run the committed oxfmt over a JSON string and return the canonical
@@ -209,7 +217,7 @@ function oxfmtCanonical(json: string, nearDir: string): string {
   const tmpFile = join(tmpDir, "railway-envs.generated.json");
   try {
     writeFileSync(tmpFile, json);
-    execFileSync(OXFMT_BIN, ["--write", tmpFile], { stdio: "pipe" });
+    execFileSync(resolveOxfmtBin(), ["--write", tmpFile], { stdio: "pipe" });
     return readFileSync(tmpFile, "utf8");
   } finally {
     rmSync(tmpDir, { recursive: true, force: true });

--- a/showcase/scripts/package-lock.json
+++ b/showcase/scripts/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "^22.0.0",
         "@types/prompts": "^2.4.9",
         "@vitest/coverage-v8": "^4.1.5",
+        "oxfmt": "^0.36.0",
         "vitest": "^4.1.5"
       }
     },
@@ -631,6 +632,329 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm-eabi": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.36.0.tgz",
+      "integrity": "sha512-Z4yVHJWx/swHHjtr0dXrBZb6LxS+qNz1qdza222mWwPTUK4L790+5i3LTgjx3KYGBzcYpjaiZBw4vOx94dH7MQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm64": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.36.0.tgz",
+      "integrity": "sha512-3ElCJRFNPQl7jexf2CAa9XmAm8eC5JPrIDSjc9jSchkVSFTEqyL0NtZinBB2h1a4i4JgP1oGl/5G5n8YR4FN8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-arm64": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.36.0.tgz",
+      "integrity": "sha512-nak4znWCqIExKhYSY/mz/lWsqWIpdsS7o0+SRzXR1Q0m7GrMcG1UrF1pS7TLGZhhkf7nTfEF7q6oZzJiodRDuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-x64": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.36.0.tgz",
+      "integrity": "sha512-V4GP96thDnpKx6ADnMDnhIXNdtV+Ql9D4HUU+a37VTeVbs5qQSF/s6hhUP1b3xUqU7iRcwh72jUU2Y12rtGHAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-freebsd-x64": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.36.0.tgz",
+      "integrity": "sha512-/xapWCADfI5wrhxpEUjhI9fnw7MV5BUZizVa8e24n3VSK6A3Y1TB/ClOP1tfxNspykFKXp4NBWl6NtDJP3osqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.36.0.tgz",
+      "integrity": "sha512-1lOmv61XMFIH5uNm27620kRRzWt/RK6tdn250BRDoG9W7OXGOQ5UyI1HVT+SFkoOoKztBiinWgi68+NA1MjBVQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.36.0.tgz",
+      "integrity": "sha512-vMH23AskdR1ujUS9sPck2Df9rBVoZUnCVY86jisILzIQ/QQ/yKUTi7tgnIvydPx7TyB/48wsQ5QMr5Knq5p/aw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-gnu": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.36.0.tgz",
+      "integrity": "sha512-Hy1V+zOBHpBiENRx77qrUTt5aPDHeCASRc8K5KwwAHkX2AKP0nV89eL17hsZrE9GmnXFjsNmd80lyf7aRTXsbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-musl": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.36.0.tgz",
+      "integrity": "sha512-SPGLJkOIHSIC6ABUQ5V8NqJpvYhMJueJv26NYqfCnwi/Mn6A61amkpJJ9Suy0Nmvs+OWESJpcebrBUbXPGZyQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.36.0.tgz",
+      "integrity": "sha512-3EuoyB8x9x8ysYJjbEO/M9fkSk72zQKnXCvpZMDHXlnY36/1qMp55Nm0PrCwjGO/1pen5hdOVkz9WmP3nAp2IQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.36.0.tgz",
+      "integrity": "sha512-MpY3itLwpGh8dnywtrZtaZ604T1m715SydCKy0+qTxetv+IHzuA+aO/AGzrlzUNYZZmtWtmDBrChZGibvZxbRQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-musl": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.36.0.tgz",
+      "integrity": "sha512-mmDhe4Vtx+XwQPRPn/V25+APnkApYgZ23q+6GVsNYY98pf3aU0aI3Me96pbRs/AfJ1jIiGC+/6q71FEu8dHcHw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-s390x-gnu": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.36.0.tgz",
+      "integrity": "sha512-AYXhU+DmNWLSnvVwkHM92fuYhogtVHab7UQrPNaDf1sxadugg9gWVmcgJDlIwxJdpk5CVW/TFvwUKwI432zhhA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-gnu": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.36.0.tgz",
+      "integrity": "sha512-H16QhhQ3usoakMleiAAQ2mg0NsBDAdyE9agUgfC8IHHh3jZEbr0rIKwjEqwbOHK5M0EmfhJmr+aGO/MgZPsneA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-musl": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.36.0.tgz",
+      "integrity": "sha512-EFFGkixA39BcmHiCe2ECdrq02D6FCve5ka6ObbvrheXl4V+R0U/E+/uLyVx1X65LW8TA8QQHdnbdDallRekohw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-openharmony-arm64": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.36.0.tgz",
+      "integrity": "sha512-zr/t369wZWFOj1qf06Z5gGNjFymfUNDrxKMmr7FKiDRVI1sNsdKRCuRL4XVjtcptKQ+ao3FfxLN1vrynivmCYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-arm64-msvc": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.36.0.tgz",
+      "integrity": "sha512-FxO7UksTv8h4olzACgrqAXNF6BP329+H322323iDrMB5V/+a1kcAw07fsOsUmqNrb9iJBsCQgH/zqcqp5903ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-ia32-msvc": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.36.0.tgz",
+      "integrity": "sha512-OjoMQ89H01M0oLMfr/CPNH1zi48ZIwxAKObUl57oh7ssUBNDp/2Vjf7E1TQ8M4oj4VFQ/byxl2SmcPNaI2YNDg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-x64-msvc": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.36.0.tgz",
+      "integrity": "sha512-MoyeQ9S36ZTz/4bDhOKJgOBIDROd4dQ5AkT9iezhEaUBxAPdNX9Oq0jD8OSnCj3G4wam/XNxVWKMA52kmzmPtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1945,6 +2269,46 @@
       ],
       "license": "MIT"
     },
+    "node_modules/oxfmt": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.36.0.tgz",
+      "integrity": "sha512-/ejJ+KoSW6J9bcNT9a9UtJSJNWhJ3yOLSBLbkoFHJs/8CZjmaZVZAJe4YgO1KMJlKpNQasrn/G9JQUEZI3p0EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinypool": "2.1.0"
+      },
+      "bin": {
+        "oxfmt": "bin/oxfmt"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxfmt/binding-android-arm-eabi": "0.36.0",
+        "@oxfmt/binding-android-arm64": "0.36.0",
+        "@oxfmt/binding-darwin-arm64": "0.36.0",
+        "@oxfmt/binding-darwin-x64": "0.36.0",
+        "@oxfmt/binding-freebsd-x64": "0.36.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.36.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.36.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.36.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.36.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.36.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.36.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.36.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.36.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.36.0",
+        "@oxfmt/binding-linux-x64-musl": "0.36.0",
+        "@oxfmt/binding-openharmony-arm64": "0.36.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.36.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.36.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.36.0"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -2351,6 +2715,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+      "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/tinyrainbow": {

--- a/showcase/scripts/package.json
+++ b/showcase/scripts/package.json
@@ -32,6 +32,7 @@
     "@types/node": "^22.0.0",
     "@types/prompts": "^2.4.9",
     "@vitest/coverage-v8": "^4.1.5",
+    "oxfmt": "^0.36.0",
     "vitest": "^4.1.5"
   }
 }


### PR DESCRIPTION
## Problem

The Showcase Promote workflow fails in `resolve-targets` before resolving the selected service because `emit-railway-envs-json.ts` hardcodes the root `node_modules/.bin/oxfmt` path, while the workflow only runs `npm ci` inside `showcase/scripts`.

## Why

`showcase/scripts` did not declare `oxfmt`, so the workflow install did not provide the formatter binary the emitter shells out to. This made workflow-dispatch promotes fail before any Railway checks ran.

## Fix

Resolve `oxfmt` from either the repo root install or the `showcase/scripts` install, add `oxfmt` to `showcase/scripts`, and update the focused emitter tests to use the same lookup.