### PR TITLE
fix(showcase): declarative-gen-ui D6 completes on surface-mount, not text-stability

### DIFF
--- a/showcase/harness/src/probes/helpers/conversation-runner.test.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.test.ts
@@ -2187,6 +2187,209 @@ describe("runConversation", () => {
   });
 });
 
+describe("runConversation surface-mount completion (completeOnMount)", () => {
+  /**
+   * Purpose-built fake modelling the A2UI-declarative completion shape:
+   * the run FINISHES and a new assistant bubble appears, but the bubble's
+   * scoped TEXT is ALWAYS EMPTY (the demo emits a `render_a2ui` surface,
+   * not assistant prose) — so the default text-stability conjunct can
+   * never converge. A configurable set of render-surface testids mounts
+   * (or never mounts, for the integrity/red case).
+   *
+   * Routes `page.evaluate` by inspecting the closure body, mirroring
+   * `makePage`'s dispatch but with two key differences:
+   *   - the cascade-state read always returns non-empty `count` with
+   *     `text: ""` (empty → text-stability impossible), and
+   *   - the `readTestIdCounts` closure (body has `data-testid` + builds an
+   *     `out` map, no `{ count`) returns the scripted per-testid counts.
+   */
+  function makeSurfacePage(opts: {
+    /** Per-testid count returned AFTER the surface "mounts". */
+    mounted: Record<string, number>;
+    /**
+     * Polls before the surface mounts — until then `readTestIdCounts`
+     * returns all-zero. Default 1 (mounts almost immediately). Set high
+     * (or never-mounting via `neverMount`) to model a broken render.
+     */
+    mountAfterPolls?: number;
+    /** When true the surface NEVER mounts (integrity/red case). */
+    neverMount?: boolean;
+  }): Page {
+    const mountAfter = opts.mountAfterPolls ?? 1;
+    let surfacePolls = 0;
+    // Track whether the user message has been submitted. Before send the
+    // assistant-bubble count is 0 (the pre-send `baselineCount` snapshot);
+    // after the Enter press a new bubble exists (count=1) so the gate's
+    // `count > baselineCount` (domOk) conjunct holds for THIS turn.
+    let sent = false;
+    return {
+      async waitForSelector() {},
+      async fill() {},
+      async press() {
+        sent = true;
+      },
+      async evaluate(fn: () => unknown) {
+        const body = fn.toString();
+        // SSE counter: caught up only after the run (post-send).
+        if (body.includes("__hk_runsFinished")) return (sent ? 1 : 0) as never;
+        // No error banner.
+        if (body.includes("copilot-error-banner")) {
+          return { state: "absent" } as never;
+        }
+        // User-message read: monotonic so fillAndVerifySend succeeds fast.
+        if (body.includes("copilot-user-message")) {
+          return 1 as never;
+        }
+        // Cascade-state read (`readCascadeStateLast`): builds `{ count, text }`.
+        // Route FIRST among the querySelectorAll branches — its closure ALSO
+        // references the `copilot-assistant-message` tier selector, so it
+        // must win before the count branch. A NEW bubble exists (count=1) but
+        // its scoped TEXT is ALWAYS EMPTY — text-stability can never hold.
+        if (
+          body.includes("querySelectorAll") &&
+          body.includes("textContent") &&
+          body.includes("{ count")
+        ) {
+          return { count: sent ? 1 : 0, text: "" } as never;
+        }
+        // countAssistantMessages (baseline snapshot + final-read
+        // classification): references the canonical assistant testid but does
+        // NOT build `{ count`. Returns a NUMBER — 0 before send (baseline), 1
+        // after (a new bubble exists for this turn).
+        if (body.includes("copilot-assistant-message")) {
+          return (sent ? 1 : 0) as never;
+        }
+        // readTestIdCounts: references data-testid + querySelectorAll, builds
+        // an `out` map, no `{ count`, no `copilot-assistant-message`. This is
+        // the surface-mount poll.
+        if (body.includes("data-testid") && body.includes("querySelectorAll")) {
+          surfacePolls += 1;
+          const ready = !opts.neverMount && surfacePolls >= mountAfter;
+          return (ready ? opts.mounted : {}) as never;
+        }
+        // Fallback: treat any other querySelectorAll read as 1 bubble.
+        if (body.includes("querySelectorAll")) return 1 as never;
+        return 0 as never;
+      },
+    };
+  }
+
+  it("GREEN: completes a text-empty A2UI turn once the render surface mounts (no text-stability)", async () => {
+    // The run finished + a new bubble exists, text is empty forever, but
+    // the declarative dashboard testids mount → the turn completes and the
+    // assertion runs. Without `completeOnMount` this same shape would time
+    // out as `text-unstable`.
+    const page = makeSurfacePage({
+      mounted: {
+        "declarative-metric": 4,
+        "declarative-pie-chart": 1,
+        "declarative-bar-chart": 1,
+      },
+      mountAfterPolls: 2,
+    });
+    let assertionRan = false;
+    const result = await runConversation(
+      page,
+      [
+        {
+          input: "Show me my sales dashboard for this quarter.",
+          completeOnMount: {
+            testIds: [
+              "declarative-metric",
+              "declarative-pie-chart",
+              "declarative-bar-chart",
+            ],
+            minNewMounts: 1,
+          },
+          assertions: async () => {
+            assertionRan = true;
+          },
+        },
+      ],
+      { assistantSettleMs: 50 },
+    );
+    expect(result.failure_turn).toBeUndefined();
+    expect(result.turns_completed).toBe(1);
+    expect(assertionRan).toBe(true);
+  }, 20_000);
+
+  it("INTEGRITY (red): the SAME turn FAILS surface-missing when the surface never mounts", async () => {
+    // Broken render: run finishes, a new bubble appears, text is empty —
+    // but NO declarative testids ever mount. The surface-mount completion
+    // must NOT pass; the turn must fail. This proves the fixed gate stays
+    // RED when the feature does not render (it is not "always green now").
+    const page = makeSurfacePage({
+      mounted: {},
+      neverMount: true,
+    });
+    let assertionRan = false;
+    const result = await runConversation(
+      page,
+      [
+        {
+          input: "Show me my sales dashboard for this quarter.",
+          // Short timeout so the never-mount case fails fast in-test.
+          responseTimeoutMs: 1_200,
+          completeOnMount: {
+            testIds: [
+              "declarative-metric",
+              "declarative-pie-chart",
+              "declarative-bar-chart",
+            ],
+            minNewMounts: 1,
+          },
+          assertions: async () => {
+            assertionRan = true;
+          },
+        },
+      ],
+      { assistantSettleMs: 50 },
+    );
+    expect(result.failure_turn).toBe(1);
+    expect(result.error).toContain("surface-missing");
+    // The assertion (real render check) must NOT have run — the gate threw
+    // before it.
+    expect(assertionRan).toBe(false);
+  }, 20_000);
+
+  it("INTEGRITY (red): fails surface-missing when only a LEFTOVER surface is present (no new mount)", async () => {
+    // The expected testids ARE present but were all already in the
+    // pre-send baseline (leftover from a prior turn) — zero newly mounted.
+    // The delta gate (`minNewMounts: 1`) must reject this so a stale
+    // surface cannot satisfy completion. The fake returns the same counts
+    // on the pre-send baseline read AND every poll, so `newlyMounted` is 0.
+    const leftover = {
+      "declarative-metric": 4,
+      "declarative-pie-chart": 1,
+      "declarative-bar-chart": 1,
+    };
+    const page = makeSurfacePage({
+      mounted: leftover,
+      mountAfterPolls: 1, // present from the very first read (incl. baseline)
+    });
+    const result = await runConversation(
+      page,
+      [
+        {
+          input: "Show me my sales dashboard for this quarter.",
+          responseTimeoutMs: 1_200,
+          completeOnMount: {
+            testIds: [
+              "declarative-metric",
+              "declarative-pie-chart",
+              "declarative-bar-chart",
+            ],
+            minNewMounts: 1,
+          },
+        },
+      ],
+      { assistantSettleMs: 50 },
+    );
+    expect(result.failure_turn).toBe(1);
+    expect(result.error).toContain("surface-missing");
+  }, 20_000);
+});
+
 describe("fillAndVerifySend", () => {
   it("succeeds on first attempt when user message appears immediately", async () => {
     const recorded = { fills: [] as string[], presses: [] as string[] };

--- a/showcase/harness/src/probes/helpers/conversation-runner.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.ts
@@ -365,6 +365,45 @@ export interface ConversationTurn {
    * to settle within this budget fails with `error: "timeout: ..."`.
    */
   responseTimeoutMs?: number;
+  /**
+   * Surface-mount completion criterion (OPT-IN). When set, this turn is
+   * considered complete on `run-finished + a new assistant bubble + the
+   * named render-surface testids mounting` — INSTEAD OF requiring the
+   * assistant TEXT bubble to stabilise for `settleMs`.
+   *
+   * This exists for tool-rendered / declarative-A2UI demos whose
+   * MEANINGFUL output is a RENDERED SURFACE, not assistant prose. In the
+   * canonical case (`langgraph-python` `declarative-gen-ui`, which uses
+   * `a2ui.injectA2UITool: true` → a secondary `render_a2ui` call), the
+   * dashboard paints and the run FINISHES, but no assistant text bubble is
+   * ever emitted, so the text-stability conjunct can never converge and the
+   * turn would otherwise time out with `reason=text-unstable` BEFORE the
+   * turn's `assertions` (the real render check) ever runs.
+   *
+   * Semantics (see `waitForTurnComplete`): the text-stability conjunct is
+   * REPLACED — not relaxed — by a surface-mount conjunct for THIS turn. The
+   * SSE-run-finished and new-bubble (`count > baselineCount`) conjuncts
+   * STILL apply, so this never declares completion before the run actually
+   * finished or before a new assistant bubble appeared — it only swaps WHAT
+   * the third signal is (rendered surface vs. stable text).
+   *
+   *   - `testIds`: every render-surface testid that MUST be present in the
+   *     DOM for the surface to count as mounted (conjunctive — `every`).
+   *   - `minNewMounts`: minimum number of testids (from `testIds`) that must
+   *     be NEWLY mounted vs. the pre-send baseline (default 1). The runner
+   *     snapshots each testid's count BEFORE sending the turn so a leftover
+   *     surface from a prior turn cannot satisfy completion on its own — at
+   *     least `minNewMounts` of the expected testids must have grown.
+   *
+   * Turns that DO NOT set `completeOnMount` are unaffected: the third
+   * conjunct remains text-stability exactly as before (text-based demos —
+   * agentic-chat, tool-rendering, HITL, etc. — keep their existing settle
+   * semantics). This is a per-turn opt-in, not a global mode change.
+   */
+  completeOnMount?: {
+    testIds: readonly string[];
+    minNewMounts?: number;
+  };
 }
 
 export interface ConversationResult {
@@ -582,6 +621,30 @@ export async function runConversation(
         page as unknown as PlaywrightPage,
       );
 
+      // Surface-mount completion (opt-in via `turn.completeOnMount`): snapshot
+      // the pre-send testid counts so the settle gate can detect a NEW render
+      // surface for THIS turn (vs. a leftover from a prior turn). Captured
+      // BEFORE `sendTurnMessage` — same ordering rationale as `baselineCount`:
+      // the user message hasn't been submitted yet, so nothing this turn could
+      // have mounted. `null` when the turn opts out → the gate keeps requiring
+      // text-stability (unchanged for every text-based demo).
+      let surfaceReady: ((page: Page) => Promise<boolean>) | null = null;
+      if (turn.completeOnMount) {
+        const baselineTestIds = await readTestIdCounts(
+          page,
+          turn.completeOnMount.testIds,
+        );
+        surfaceReady = buildSurfaceReady(turn.completeOnMount, baselineTestIds);
+        console.debug(
+          `[conversation-runner] turn ${turnNum}/${total} — surface-mount completion armed`,
+          {
+            testIds: turn.completeOnMount.testIds,
+            minNewMounts: turn.completeOnMount.minNewMounts ?? 1,
+            baselineTestIds,
+          },
+        );
+      }
+
       await sendTurnMessage();
 
       console.debug(
@@ -645,6 +708,7 @@ export async function runConversation(
           timeoutMs: turnTimeoutMs,
           baselineBannerText,
           baselineCount,
+          surfaceReady,
         });
       } catch (settleErr) {
         // Translate a turn-incomplete failure observed alongside a
@@ -748,6 +812,22 @@ export async function runConversation(
           const retryBaselineCount = await countAssistantMessages(
             page as unknown as PlaywrightPage,
           );
+          // Re-arm surface-mount completion against the post-reload baseline.
+          // page.reload() tore down the DOM, so any prior-turn surface is gone
+          // — re-snapshot so the retry's delta gate measures growth from the
+          // fresh (typically empty) state rather than the stale pre-reload one.
+          let retrySurfaceReady: ((page: Page) => Promise<boolean>) | null =
+            null;
+          if (turn.completeOnMount) {
+            const retryBaselineTestIds = await readTestIdCounts(
+              page,
+              turn.completeOnMount.testIds,
+            );
+            retrySurfaceReady = buildSurfaceReady(
+              turn.completeOnMount,
+              retryBaselineTestIds,
+            );
+          }
           await fillAndVerifySend(page, chatInputSelector, turn.input);
           // Re-snapshot the post-reload baseline banner. The page DOM was
           // torn down + repainted, so any banner now visible is the
@@ -777,6 +857,7 @@ export async function runConversation(
               ),
               baselineBannerText: retryBaselineBannerText,
               baselineCount: retryBaselineCount,
+              surfaceReady: retrySurfaceReady,
             });
           } catch (retryErr) {
             if (retryErr instanceof BannerVisibleError) {
@@ -965,6 +1046,102 @@ export async function readUserMessageCount(page: Page): Promise<number> {
     );
     return 0;
   }
+}
+
+/**
+ * Read the current DOM count of each `[data-testid="<id>"]` selector in
+ * ONE browser-side round-trip. Used by the surface-mount completion path
+ * (`ConversationTurn.completeOnMount`) to snapshot the pre-send baseline
+ * and to poll whether the expected render surface has mounted.
+ *
+ * Returns a `{ [testId]: count }` map. On any read error every requested
+ * testid maps to 0 (same resilience strategy as `countAssistantMessages`
+ * / `readUserMessageCount`) so a transient `page.evaluate` hiccup reads as
+ * "surface not mounted yet" rather than throwing out of the settle loop.
+ *
+ * The selectors are passed as an arg into the browser closure (the real
+ * Playwright `Page.evaluate` is variadic — the runner's structural `Page`
+ * threads the second arg through `arguments`), so the reader stays generic
+ * and the caller (a probe script) owns which testids constitute its
+ * surface.
+ */
+export async function readTestIdCounts(
+  page: Page,
+  testIds: readonly string[],
+): Promise<Record<string, number>> {
+  const ids = [...testIds];
+  try {
+    // The selector list is BAKED INTO the closure source via JSON.stringify
+    // rather than passed as a `page.evaluate(fn, arg)` argument. The harness
+    // worker's `page.evaluate` arg-passing does NOT reliably round-trip the
+    // second argument to the browser side (the arg arrives `undefined`), so a
+    // captured-arg closure silently reads an empty selector list and reports
+    // every testid as absent — exactly the `baselineTestIds: {}` failure that
+    // made the A2UI-declarative surface look unmounted. Inlining the literals
+    // matches the established zero-arg convention (`_genuine-shared.ts`'s
+    // `clickByJs`, `d5-gen-ui-declarative.ts`'s `readDeclarativeTestIds`).
+    const code = `
+      (() => {
+        const ids = ${JSON.stringify(ids)};
+        const out = {};
+        for (const id of ids) {
+          out[id] = document.querySelectorAll('[data-testid="' + id + '"]').length;
+        }
+        return out;
+      })()
+    `;
+    const fn = new Function(`return ${code.trim()};`) as () => Record<
+      string,
+      number
+    >;
+    return await page.evaluate(fn);
+  } catch (readErr) {
+    // CVDIAG: surface the previously-silent testid read error. Polled in
+    // the settle loop, so routed through console.debug (still greppable)
+    // to avoid flooding warn-level logs on a transient per-poll hiccup.
+    // Control flow is unchanged — the caller reads "all zero" and keeps
+    // polling.
+    console.debug(
+      formatCvdiag({
+        component: "conversation-runner",
+        boundary: "inbound",
+        status: "error",
+        error: `testid-count read failed: ${errorMessage(readErr).slice(0, 120)}`,
+      }),
+    );
+    const zero: Record<string, number> = {};
+    for (const id of ids) zero[id] = 0;
+    return zero;
+  }
+}
+
+/**
+ * Build a surface-mount completion predicate from a turn's
+ * `completeOnMount` spec and the pre-send baseline testid counts. The
+ * returned predicate resolves `true` once ALL `testIds` are present in the
+ * DOM AND at least `minNewMounts` of them have grown vs. the baseline.
+ *
+ * The "newly mounted" delta gate mirrors the declarative assertion's own
+ * leftover guard: A2UI render nodes accumulate across turns, so an
+ * absolute-presence check would let a turn complete on a prior turn's
+ * leftover surface. Requiring `minNewMounts` of the expected testids to
+ * grow guarantees THIS turn actually painted something.
+ */
+function buildSurfaceReady(
+  spec: { testIds: readonly string[]; minNewMounts?: number },
+  baseline: Record<string, number>,
+): (page: Page) => Promise<boolean> {
+  const ids = [...spec.testIds];
+  const minNewMounts = spec.minNewMounts ?? 1;
+  return async (page: Page): Promise<boolean> => {
+    const current = await readTestIdCounts(page, ids);
+    const allPresent = ids.every((id) => (current[id] ?? 0) > 0);
+    if (!allPresent) return false;
+    const newlyMounted = ids.filter(
+      (id) => (current[id] ?? 0) > (baseline[id] ?? 0),
+    ).length;
+    return newlyMounted >= minNewMounts;
+  };
 }
 
 /**
@@ -1395,6 +1572,27 @@ export interface WaitForTurnCompleteOpts {
    * fakes that script count progressions keyed to turn ordinals.
    */
   baselineCount?: number;
+  /**
+   * Surface-mount completion predicate (OPT-IN — set only by the runner
+   * when the turn carries `completeOnMount`). When provided, the third
+   * settle conjunct is REPLACED: instead of requiring the bubble's TEXT to
+   * be non-empty and stable for `settleMs`, the gate completes once
+   * `surfaceReady(page)` resolves `true` (the expected render surface has
+   * mounted). The SSE-run-finished and new-bubble (`count > baselineCount`)
+   * conjuncts STILL apply, so completion never precedes the run finishing
+   * or a new assistant bubble appearing — only the THIRD signal changes
+   * from "stable text" to "rendered surface".
+   *
+   * `null` / omitted → the text-stability conjunct is used unchanged. This
+   * is how every text-based demo keeps its existing settle semantics — only
+   * a turn that opts in via `completeOnMount` ever sees this predicate.
+   *
+   * Failure classification: when `surfaceReady` is set and the gate times
+   * out, the post-loop reason is `surface-missing` (the surface-mount
+   * analogue of `text-unstable`) so the operator sees the render surface,
+   * not the absent text, was the unmet signal.
+   */
+  surfaceReady?: ((page: Page) => Promise<boolean>) | null;
 }
 
 /** Result of a successful `waitForTurnComplete`. */
@@ -1415,7 +1613,11 @@ export interface WaitForTurnCompleteResult {
  */
 export class TurnNotCompleteError extends Error {
   constructor(
-    readonly reason: "sse-missing" | "dom-missing" | "text-unstable",
+    readonly reason:
+      | "sse-missing"
+      | "dom-missing"
+      | "text-unstable"
+      | "surface-missing",
     readonly turnIndex: number,
     readonly observedAtMs: number,
     message: string,
@@ -1469,6 +1671,7 @@ export async function waitForTurnComplete(
 ): Promise<WaitForTurnCompleteResult> {
   const { page, turnIndex, settleMs, timeoutMs } = opts;
   const baselineBannerText = opts.baselineBannerText ?? null;
+  const surfaceReady = opts.surfaceReady ?? null;
   const pollIntervalMs = opts.pollIntervalMs ?? POLL_INTERVAL_MS;
   // Defect-2 sentinel: per-turn baseline count of assistant bubbles already
   // in the DOM BEFORE this turn submitted. The gate requires
@@ -1525,11 +1728,23 @@ export async function waitForTurnComplete(
     const domOk = count > baselineCount;
     const textOk =
       text !== null && text.trim().length > 0 && now - lastChangeAt >= settleMs;
-    if (sseOk && domOk && textOk) {
+    // Third conjunct: text-stability by default, OR surface-mount when the
+    // turn opted in via `completeOnMount` (surfaceReady != null). The
+    // surface-mount path is checked ONLY once SSE + DOM hold, so completion
+    // still requires the run to have finished and a new assistant bubble to
+    // exist — we only swap WHAT the third signal is (rendered surface vs.
+    // stable text). This is what makes the tool-rendered A2UI-declarative
+    // demo (no assistant text bubble ever stabilises) complete on its
+    // rendered dashboard instead of timing out as `text-unstable`.
+    const thirdOk =
+      surfaceReady !== null
+        ? sseOk && domOk && (await surfaceReady(page))
+        : textOk;
+    if (sseOk && domOk && thirdOk) {
       // bubbleIndex returned = last bubble in the matched tier at the
       // moment of return, so callers consuming the assertions ctx see the
-      // same bubble whose text settled the gate.
-      return { bubbleIndex: count - 1, text: text! };
+      // same bubble whose text settled (or whose turn's surface mounted).
+      return { bubbleIndex: count - 1, text: text ?? "" };
     }
     // Pre-conjunct banner fast-fail guard. We ONLY fire fast-fail when the
     // assistant hasn't yet produced a response for THIS turn (domOk =
@@ -1581,12 +1796,19 @@ export async function waitForTurnComplete(
   // "we didn't see it in time", which the final read reproduces faithfully.
   const runsFinishedFinal = await readRunsFinished(page);
   const countFinal = await countAssistantMessages(pwPage);
+  // Precedence: blame the earliest signal that hadn't arrived. The third
+  // signal differs by completion mode: `surface-missing` when the turn
+  // opted into surface-mount completion (`surfaceReady` set), else the
+  // historical `text-unstable`. SSE/DOM precedence is identical for both
+  // modes (those two conjuncts are shared).
   const reason: TurnNotCompleteError["reason"] =
     runsFinishedFinal < turnIndex
       ? "sse-missing"
       : countFinal <= baselineCount
         ? "dom-missing"
-        : "text-unstable";
+        : surfaceReady !== null
+          ? "surface-missing"
+          : "text-unstable";
   throw new TurnNotCompleteError(
     reason,
     turnIndex,

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-declarative.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-declarative.ts
@@ -331,6 +331,30 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
       },
       captured: false,
     };
+    // Surface-mount completion: this demo wires `a2ui.injectA2UITool: true`,
+    // so the agent's response is a secondary `render_a2ui` call that paints
+    // the declarative dashboard — NO assistant text bubble is ever emitted.
+    // The conversation runner's default text-stability settle can therefore
+    // never converge for this turn and would time out as `text-unstable`
+    // BEFORE the per-pill `assertions` (the real render-mount check) ever
+    // runs. Opting into `completeOnMount` swaps the runner's third settle
+    // conjunct from "assistant text stabilised" to "the expected render
+    // surface mounted", so the turn completes on `run-finished + new bubble +
+    // surface painted` and the assertion gets to verify the catalog testids.
+    //
+    // The surface testids are the union of the pill's conjunctive
+    // `expectedTestIds` and any `minCounts` keys (the full set the assertion
+    // checks), so the runner-level gate and the assertion agree on what
+    // "mounted" means. The runner's delta gate (`minNewMounts: 1`) only needs
+    // to confirm SOMETHING painted for THIS turn — the assertion still
+    // enforces the strict per-pill composition + per-testid `minCounts`
+    // deltas, so this does not weaken the genuine render check.
+    const surfaceTestIds = Array.from(
+      new Set<string>([
+        ...expectedTestIds,
+        ...(minCounts ? Object.keys(minCounts) : []),
+      ]),
+    );
     return {
       input: prompt,
       preFill: buildBaselineCapture(baselineRef),
@@ -341,6 +365,10 @@ export function buildTurns(_ctx: D5BuildContext): ConversationTurn[] {
         minCounts,
       ),
       responseTimeoutMs: DECLARATIVE_RESPONSE_TIMEOUT_MS,
+      completeOnMount: {
+        testIds: surfaceTestIds,
+        minNewMounts: 1,
+      },
     };
   });
 }


### PR DESCRIPTION
> **DRAFT / WIP — not reviewed, not ready to merge.** Checkpoint per request. The mandatory 7-agent cr-loop + CI-green gate runs before this leaves draft. LGP and ADK ship together in this PR.

## Problem (a false-D6 in both directions)
Declarative A2UI demos wire `a2ui.injectA2UITool: true`, so the response is a rendered `render_a2ui` surface with **no assistant text bubble**. The D6 conversation-runner's turn-completion gate required the assistant **text** to stabilize — so on a working declarative demo the run finished and the dashboard painted, but text never settled → `waitForTurnComplete` timed out (`reason=text-unstable`) **before the render assertion ran**.

Result: `langgraph-python:declarative-gen-ui` (the gold standard) reported **false-RED while rendering correctly** (all 4 pills verified live on staging), while `google-adk` reported **false-GREEN**.

## Fix
Opt-in `ConversationTurn.completeOnMount` (set only by `d5-gen-ui-declarative.ts`). For those turns the text-stability completion conjunct is **replaced** by a surface-mount predicate: run-finished (sseOk) + a new assistant bubble + the expected declarative testids **newly mounting**. A non-rendering surface now yields a new `surface-missing` failure reason (truthful RED). Text-based demos are byte-for-byte unchanged (opt-in, per-turn).

## Proof (both directions, live D6)
- RED (before): `text-unstable` timeout; dashboard text painted.
- GREEN (after): passes in ~5s; `buildDeclarativeAssertion` actually runs and verifies testids mount for all 4 pills.
- INTEGRITY: forced a broken render (renamed testids) → test goes **red** (`surface-missing`). Not "always green now."
- Unit: 89/89 + 3 new (green-on-mount, red-on-surface-missing).

## Scope: LGP + ADK (ship together) — both truthful GREEN
- **LGP** gold-standard cell: false-RED → truthful GREEN (all 4 pills assert).
- **ADK** realignment: **test-only, complete.** The shared-script fix auto-applies; verified all 4 ADK pills truthfully GREEN (each surface mounts from baseline 0 via surface-mount completion). Prior false-green closed; **no ADK backend gap**.

## Out of scope (someone else's problem)
This shared-script change re-evaluates **every** declarative-gen-ui cell truthfully. Integrations beyond LGP/ADK that don't actually render will flip to **truthful RED** — e.g. `langgraph-typescript` pill 2 (team-performance `declarative-data-table` doesn't mount). Those are real per-demo render gaps for their owners; **not fixed here.**

## Follow-up (not in this PR)
The `render_a2ui` call returns a ~5.9 MB SSE for a ~2 KB surface (LGT worse) — a separate runtime amplification concern in the `injectA2UITool:true` middleware path.

## Before ready/merge
- [x] ADK empirical verdict — all 4 pills truthful GREEN, realignment test-only, no backend gap
- [ ] mandatory cr-loop → zero findings
- [ ] CI green