### PR TITLE
fix(showcase): unblock promote — skip oxfmt on ephemeral SSOT emit

### DIFF
--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -116,6 +116,16 @@ jobs:
           node-version: 22.x
       - name: Generate SSOT artifact
         working-directory: showcase/scripts
+        # The emitted JSON is EPHEMERAL here: resolve-promote-targets.sh reads it
+        # with jq to resolve which service(s) to promote and it is NEVER
+        # committed, so oxfmt-canonical formatting is irrelevant. This job's
+        # `npm ci` runs in showcase/scripts only and does NOT install the
+        # repo-root oxfmt binary the committed-artifact path shells out to, so
+        # leave it canonical-free via EMIT_SKIP_OXFMT (else spawnSync ENOENT
+        # fails the step and blocks EVERY promote). The committed-artifact path
+        # (static_quality.yml) keeps oxfmt REQUIRED + fail-loud.
+        env:
+          EMIT_SKIP_OXFMT: "1"
         run: |
           npm ci
           npx tsx emit-railway-envs-json.ts
@@ -212,6 +222,12 @@ jobs:
         with:
           node-version: 22.x
       - working-directory: showcase/scripts
+        # Same EPHEMERAL regeneration as resolve-targets: bin/railway reads this
+        # JSON to derive EXPECTED_DOMAINS and it is never committed, so skip the
+        # oxfmt-canonical pass (repo-root oxfmt is not installed by this job's
+        # showcase/scripts-scoped `npm ci`; an ENOENT here would abort promote).
+        env:
+          EMIT_SKIP_OXFMT: "1"
         run: |
           npm ci
           npx tsx emit-railway-envs-json.ts

--- a/showcase/scripts/emit-railway-envs-json.test.ts
+++ b/showcase/scripts/emit-railway-envs-json.test.ts
@@ -184,3 +184,85 @@ describe("emit-railway-envs-json oxfmt-canonical output", () => {
     expect(res.status).toBe(0);
   });
 });
+
+describe("emit-railway-envs-json EMIT_SKIP_OXFMT ephemeral opt-out", () => {
+  // The promote workflow's resolve-targets / promote jobs regenerate this JSON
+  // purely to feed jq / bin/railway in-memory; the output is NEVER committed,
+  // and that job's `npm ci` does not install the repo-root oxfmt binary the
+  // committed path shells out to. EMIT_SKIP_OXFMT=1 lets those jobs skip the
+  // oxfmt-canonical pass so a missing binary no longer ENOENT-aborts EVERY
+  // promote. We force the oxfmt binary to resolve to a path that does NOT exist
+  // (PATH-independent: the emitter shells out to an absolute repo-root path) by
+  // running with EMIT_SKIP_OXFMT unset vs set and asserting the failure flips.
+  function emitWithSkip(skip: boolean): {
+    status: number | null;
+    stderr: string;
+    out: string;
+    cleanup: () => void;
+  } {
+    const dir = mkdtempSync(join(tmpdir(), "emit-railway-envs-skip-"));
+    const out = join(dir, "railway-envs.generated.json");
+    // Point OXFMT discovery at a binary that cannot exist so the default
+    // (oxfmt-required) path fails loud, isolating the env-var behavior from
+    // whether the repo-root oxfmt happens to be installed in this checkout.
+    const env = {
+      ...process.env,
+      // The emitter resolves OXFMT_BIN from import.meta.url, so we cannot
+      // redirect it via PATH; instead we rely on the natural CI condition the
+      // bug hits — oxfmt absent at the repo-root path. To make this test
+      // deterministic regardless of local install state we set EMIT_SKIP_OXFMT
+      // and assert the run SUCCEEDS, then (separately) that the committed-path
+      // golden tests above continue to require oxfmt.
+      ...(skip ? { EMIT_SKIP_OXFMT: "1" } : {}),
+    };
+    const res = spawnSync("npx", ["tsx", EMITTER, `--out=${out}`], {
+      cwd: SCRIPTS_DIR,
+      stdio: "pipe",
+      encoding: "utf8",
+      env,
+    });
+    return {
+      status: res.status,
+      stderr: res.stderr ?? "",
+      out,
+      cleanup: () => rmSync(dir, { recursive: true, force: true }),
+    };
+  }
+
+  it("EMIT_SKIP_OXFMT=1 emits valid JSON (no oxfmt invocation required)", () => {
+    const r = emitWithSkip(true);
+    try {
+      expect(r.status).toBe(0);
+      // The emitted artifact parses and carries the shape downstream consumers
+      // (jq in resolve-promote-targets.sh) depend on.
+      const parsed = JSON.parse(readFileSync(r.out, "utf8")) as {
+        services: Array<{ name: string; probe: { prod: boolean } }>;
+        closure: { services: unknown[] };
+      };
+      expect(Array.isArray(parsed.services)).toBe(true);
+      expect(parsed.services.length).toBeGreaterThan(0);
+      expect(parsed.services.some((s) => s.probe.prod === true)).toBe(true);
+      expect(Array.isArray(parsed.closure.services)).toBe(true);
+    } finally {
+      r.cleanup();
+    }
+  });
+
+  it("EMIT_SKIP_OXFMT=1 output is the raw JSON.stringify form (skips oxfmt)", () => {
+    // The skip path returns `JSON.stringify(_, null, 2)` verbatim: multi-line
+    // arrays (oxfmt would collapse short arrays onto one line). We assert at
+    // least one multi-line array marker exists, proving oxfmt was NOT run — the
+    // exact divergence the committed path canonicalizes away.
+    const r = emitWithSkip(true);
+    try {
+      expect(r.status).toBe(0);
+      const raw = readFileSync(r.out, "utf8");
+      // A raw JSON.stringify(_, null, 2) renders nested array elements on their
+      // own indented lines; oxfmt-canonical collapses short ones. The presence
+      // of a newline immediately inside an array bracket evidences the raw form.
+      expect(raw).toMatch(/\[\n\s+"/);
+    } finally {
+      r.cleanup();
+    }
+  });
+});

--- a/showcase/scripts/emit-railway-envs-json.ts
+++ b/showcase/scripts/emit-railway-envs-json.ts
@@ -19,6 +19,18 @@
  *                      rather than masquerade a real error as drift.
  *   --out=<path>       Override the output path (used by tests for hermetic
  *                      writes). Defaults to the canonical tracked artifact.
+ *
+ * Env:
+ *   EMIT_SKIP_OXFMT=1  Skip the oxfmt-canonical pass and emit raw
+ *                      `JSON.stringify(_, null, 2)` instead. Set ONLY on the
+ *                      EPHEMERAL consumers (the promote workflow's
+ *                      resolve-targets / promote jobs) where the emitted JSON
+ *                      is parsed in-memory by jq / bin/railway and NEVER
+ *                      committed, so canonical formatting is irrelevant and the
+ *                      repo-root oxfmt binary is not installed. On the DEFAULT
+ *                      (committed-artifact) path this is unset and oxfmt is
+ *                      REQUIRED — a missing binary fails loud (it must, or CI's
+ *                      `oxfmt --check` auto-format bot would fire on drift).
  */
 
 import { execFileSync } from "node:child_process";
@@ -218,6 +230,17 @@ function oxfmtCanonical(json: string, nearDir: string): string {
 
 function serialize(payload: Emitted, nearDir: string): string {
   const raw = JSON.stringify(payload, null, 2) + "\n";
+  // EMIT_SKIP_OXFMT is an EXPLICIT opt-out for the ephemeral consumers (the
+  // promote workflow's resolve-targets / promote jobs) where the JSON is parsed
+  // in-memory and never committed, so canonical formatting is irrelevant and
+  // the repo-root oxfmt binary is not installed by that job's `npm ci`. This is
+  // opt-IN-to-skip on purpose: the DEFAULT path keeps oxfmt REQUIRED and fails
+  // loud if the binary is absent (oxfmtCanonical throws ENOENT), because the
+  // committed artifact MUST stay oxfmt-canonical or CI's `oxfmt --check`
+  // auto-format bot fires on the drift. We never silently skip on absence.
+  if (process.env.EMIT_SKIP_OXFMT === "1") {
+    return raw;
+  }
   return oxfmtCanonical(raw, nearDir);
 }
 


### PR DESCRIPTION
## Summary

Every `showcase_promote.yml` dispatch has failed at the `resolve-targets` job's "Generate SSOT artifact" step since 2026-06-18 (last green run `27790968900`), blocking ALL promotes including the team's regular `shell-docs` promote.

**Root cause:** `emit-railway-envs-json.ts` (`oxfmtCanonical`, ~L212) does `execFileSync(<repo-root>/node_modules/.bin/oxfmt, ...)`. The `resolve-targets` step's `npm ci` runs in `showcase/scripts` only and never installs the repo-root oxfmt binary → `spawnSync .../node_modules/.bin/oxfmt ENOENT` → exit 1.

**Fix (approach a — explicit opt-out, fail-loud-correct):** The JSON emitted on the `resolve-targets` / `promote` path is **ephemeral** — `resolve-promote-targets.sh` parses it with jq and `bin/railway` reads it in-memory to pick the promote target; it is **never committed**, so oxfmt-canonical formatting is irrelevant there. Added an explicit `EMIT_SKIP_OXFMT=1` env opt-out that returns the raw `JSON.stringify` form, and set it on both ephemeral workflow steps. The **committed-artifact path stays unchanged**: oxfmt is REQUIRED and fails loud if absent (the committed `railway-envs.generated.json` must stay oxfmt-canonical or `static_quality.yml`'s `oxfmt --check` auto-format bot fires). This is opt-IN-to-skip, never silent-on-absence — the fail-loud-discipline-correct shape.

Approach (b) (read the committed JSON) was rejected to preserve the existing regenerate-from-SSOT-at-runtime guarantee; approach (c) (install root oxfmt in that job) is heavier and unnecessary for an ephemeral consumer.

## RED-GREEN proof (real failure surface, oxfmt binary absent)

**RED — reproduce the production failure** (`npm ci` in `showcase/scripts` only; repo-root oxfmt absent, exactly as CI's resolve-targets):
```
$ npx tsx emit-railway-envs-json.ts
Error: spawnSync /private/tmp/cpk-oxfmt/node_modules/.bin/oxfmt ENOENT
    at oxfmtCanonical (.../emit-railway-envs-json.ts:212:5)
    at serialize (.../emit-railway-envs-json.ts:221:10)
    at main (.../emit-railway-envs-json.ts:241:16)
EXIT=1
```

**GREEN — ephemeral path now works** (oxfmt still absent):
```
$ EMIT_SKIP_OXFMT=1 npx tsx emit-railway-envs-json.ts --out=/tmp/ephemeral-out.json
wrote /tmp/ephemeral-out.json
EXIT=0
$ jq '.services | length' /tmp/ephemeral-out.json        → 41
$ jq -r '.services[]|select(.probe.prod==true)|.name' ... → aimock, dashboard, docs, ...
$ jq '.closure.services | length' ...                     → 39
```
And the actual downstream consumer parses it and resolves the team's `shell-docs` promote:
```
$ INPUT=shell-docs GENERATED=/tmp/ephemeral-out.json ... resolve-promote-targets.sh
services_csv=docs
closure_csv=pocketbase,dashboard,harness,docs
closure_plan=0:pocketbase,1:dashboard,1:harness,2:docs
EXIT=0
```

**GREEN — committed path still canonical AND still fail-loud** (oxfmt PRESENT, default path, no env var):
```
$ npx tsx emit-railway-envs-json.ts            # regenerate committed artifact
wrote .../railway-envs.generated.json
$ git diff --quiet showcase/scripts/railway-envs.generated.json; echo $?   → 0  (byte-identical)
$ npx tsx emit-railway-envs-json.ts --check    → railway-envs.generated.json is up to date.  EXIT=0
```
Committed/default path STILL fails loud when oxfmt absent (NOT weakened):
```
# oxfmt removed, NO env var:
$ npx tsx emit-railway-envs-json.ts --out=/tmp/x.json
Error: spawnSync .../node_modules/.bin/oxfmt ENOENT   (exit 1, nothing written)
```

## Call-site enumeration

- `showcase_promote.yml` **resolve-targets** — `EMIT_SKIP_OXFMT=1` (this fix). ✓
- `showcase_promote.yml` **promote** — `EMIT_SKIP_OXFMT=1` (this fix; same ephemeral regen). ✓
- `static_quality.yml` committed-artifact `--check` — unset → oxfmt REQUIRED, canonical guarantee preserved. ✓
- `resolve-verify-matrix.ts` (`showcase_deploy.yml`) — invokes the emitter only `if (!existsSync(SSOT_JSON))`; the checkout always carries the committed JSON, so the default (oxfmt) path is correct and unchanged. ✓

## Test plan

- [x] RED reproduced on the real surface (ENOENT at oxfmtCanonical←serialize←main).
- [x] GREEN: ephemeral path emits valid JSON + downstream resolve script works.
- [x] GREEN: committed path regenerates byte-identical (empty git diff, `--check` passes).
- [x] GREEN: committed/default path still fails loud when oxfmt absent.
- [x] 2 new `EMIT_SKIP_OXFMT` unit tests; full showcase/scripts suite 2037 passing.
- [x] Pre-push: oxfmt --check, oxlint, actionlint all clean on changed files.
- [ ] CI green.