### PR TITLE
docs: update new frontend quickstarts to be accurate

### DIFF
--- a/showcase/shell-docs/src/content/docs/frontends/angular.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular.mdx
@@ -1,17 +1,17 @@
 ---
 title: Angular
-description: Connect an Angular app to an AG-UI agent with CopilotKit.
+description: Connect an Angular app to Copilot Runtime with CopilotKit.
 icon: "lucide/Triangle"
 hideTOC: true
 ---
 
-`@copilotkit/angular` provides Angular components, directives, and services for CopilotKit. This guide gets you to a working Angular app with a chat UI talking to an [AG-UI](/backend/ag-ui) agent.
+`@copilotkit/angular` provides Angular components, directives, and services for CopilotKit. This guide gets you to a working Angular app with a chat UI backed by a local [Copilot Runtime](/backend/copilot-runtime) and `BuiltInAgent`.
 
-It connects to the agent directly with `HttpAgent`, so there's no CopilotKit runtime to stand up and nothing framework-specific to configure. The same setup works with any AG-UI-compatible agent, whether it's built on LangGraph, CrewAI, Mastra, Pydantic AI, or your own server.
+The runtime runs on your server, keeps model credentials out of the browser, and exposes the `default` agent that `CopilotChat` uses automatically.
 
 ## Prerequisites
 
-- A running AG-UI-compatible agent endpoint. If you don't have one yet, pick a framework under [Integrations](/integrations/langgraph) and follow its agent setup.
+- An OpenAI API key (or another model provider supported by [Model Selection](/model-selection))
 - Angular 19, 20, or 21 (Angular 22 is not supported yet)
 - Node.js 20+
 
@@ -31,22 +31,25 @@ It connects to the agent directly with `HttpAgent`, so there's no CopilotKit run
     <Step>
         ### Install CopilotKit
 
-        Install the Angular package alongside its `@angular/cdk` and `@ag-ui/client` peers:
+        Install the Angular frontend package, `@angular/cdk`, and `@copilotkit/runtime` for your local Copilot Runtime server:
 
         <Tabs groupId="package-manager" items={['npm', 'pnpm', 'yarn']}>
             <Tab value="npm">
                 ```bash
-                npm install @copilotkit/angular @angular/cdk @ag-ui/client
+                npm install @copilotkit/angular @angular/cdk @copilotkit/runtime
+                npm install -D tsx typescript @types/node
                 ```
             </Tab>
             <Tab value="pnpm">
                 ```bash
-                pnpm add @copilotkit/angular @angular/cdk @ag-ui/client
+                pnpm add @copilotkit/angular @angular/cdk @copilotkit/runtime
+                pnpm add -D tsx typescript @types/node
                 ```
             </Tab>
             <Tab value="yarn">
                 ```bash
-                yarn add @copilotkit/angular @angular/cdk @ag-ui/client
+                yarn add @copilotkit/angular @angular/cdk @copilotkit/runtime
+                yarn add -D tsx typescript @types/node
                 ```
             </Tab>
         </Tabs>
@@ -54,6 +57,40 @@ It connects to the agent directly with `HttpAgent`, so there's no CopilotKit run
         <Callout type="info" title="Match @angular/cdk to your Angular version">
           `@angular/cdk` must share your Angular major version. Most package managers resolve this for you, but if you hit a peer-dependency error, pin it explicitly (for example `@angular/cdk@^21`).
         </Callout>
+    </Step>
+    <Step>
+        ### Create the Copilot Runtime
+
+        Add a small Node server that hosts Copilot Runtime at `/api/copilotkit` and registers a `default` built-in agent:
+
+        ```ts title="server.ts"
+        import { createServer } from "node:http";
+        import { BuiltInAgent, CopilotRuntime } from "@copilotkit/runtime/v2";
+        import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
+
+        const runtime = new CopilotRuntime({
+          agents: {
+            default: new BuiltInAgent({
+              model: "openai:gpt-5-mini",
+              prompt: "You are a helpful assistant for an Angular app.",
+            }),
+          },
+        });
+
+        const port = Number(process.env.PORT ?? 8200);
+
+        createServer(
+          createCopilotNodeListener({
+            runtime,
+            basePath: "/api/copilotkit",
+            cors: true,
+          }),
+        ).listen(port, () => {
+          console.log(
+            `Copilot Runtime listening at http://localhost:${port}/api/copilotkit`,
+          );
+        });
+        ```
     </Step>
     <Step>
         ### Import the styles
@@ -65,23 +102,19 @@ It connects to the agent directly with `HttpAgent`, so there's no CopilotKit run
         ```
     </Step>
     <Step>
-        ### Connect to your agent
+        ### Connect to Copilot Runtime
 
-        Register an `HttpAgent` pointing at your agent endpoint under the id `default`, so the chat picks it up automatically.
+        Point `provideCopilotKit` at the runtime endpoint. Because the runtime registers an agent named `default`, the chat picks it up automatically.
 
         ```ts title="src/app/app.config.ts"
         import { ApplicationConfig } from "@angular/core";
         import { provideCopilotKit } from "@copilotkit/angular"; // [!code highlight]
-        import { HttpAgent } from "@ag-ui/client"; // [!code highlight]
 
         export const appConfig: ApplicationConfig = {
           providers: [
-            // [!code highlight:6]
+            // [!code highlight:3]
             provideCopilotKit({
-              selfManagedAgents: {
-                // Point this at your AG-UI-compatible agent endpoint
-                default: new HttpAgent({ url: "http://localhost:8000/" }),
-              },
+              runtimeUrl: "http://localhost:8200/api/copilotkit",
             }),
           ],
         };
@@ -114,19 +147,29 @@ It connects to the agent directly with `HttpAgent`, so there's no CopilotKit run
         </Callout>
     </Step>
     <Step>
-        ### Run the app
+        ### Run the runtime and app
+
+        Start Copilot Runtime in one terminal:
+
+        ```bash
+        export OPENAI_API_KEY=sk-...
+        npx tsx server.ts
+        ```
+
+        Start the Angular app in another terminal:
 
         ```bash
         npm start
         ```
 
-        Open the dev server URL (the Angular CLI prints it, usually `http://localhost:4200`), send a message, and you'll see it stream back from your agent.
+        Open the dev server URL (the Angular CLI prints it, usually `http://localhost:4200`), send a message, and you'll see it stream back through Copilot Runtime.
 
         <Accordions className="mb-4">
             <Accordion title="Troubleshooting">
                 - **Chat renders unstyled**: Make sure you imported `@copilotkit/angular/styles.css` in `src/styles.css`.
-                - **No response from the agent**: Confirm the `url` points at a reachable AG-UI endpoint and that the agent is running. Check the browser network tab for the request.
-                - **CORS errors**: A browser-direct connection needs the agent endpoint to allow your app's origin. Enable CORS on the agent, or put it behind the [CopilotKit runtime](/backend/copilot-runtime).
+                - **No response from the agent**: Confirm the runtime server is running and `http://localhost:8200/api/copilotkit/info` returns agent information.
+                - **CORS errors**: Keep `cors: true` in `createCopilotNodeListener` for local development, or configure CORS to allow your Angular app's origin in production.
+                - **Model auth errors**: Confirm `OPENAI_API_KEY` is set in the terminal running `npx tsx server.ts`.
                 - **Peer-dependency error on install**: `@angular/cdk` must match your Angular major version. Install the matching major, for example `@angular/cdk@^21` on Angular 21.
                 - **Production build exceeds the bundle budget**: CopilotKit pulls in markdown and syntax-highlighting dependencies, so a fresh app can exceed Angular's default 1 MB budget. Raise `budgets` in `angular.json` if your production build fails on size.
             </Accordion>
@@ -136,8 +179,8 @@ It connects to the agent directly with `HttpAgent`, so there's no CopilotKit run
 
 ## Where to go next
 
-- [Self-managed agents](/backend/self-managed-agents): securing the connection, the dev-only registration variant, and combining with a runtime.
-- [Connect AG-UI agents](/backend/ag-ui): the `HttpAgent` interface and the AG-UI protocol.
-- [Integrations](/integrations/langgraph): set up the agent itself on LangGraph, CrewAI, Mastra, and other frameworks.
+- [Copilot Runtime](/backend/copilot-runtime): runtime setup, auth, middleware, and routing.
+- [Built-in Agent quickstart](/quickstart): configure the in-process agent used in this quickstart.
+- [Integrations](/integrations/langgraph): connect LangGraph, CrewAI, Mastra, and other agents through the runtime.
 
 For headless setups, custom UIs with `injectAgentStore`, and the full component list, see the [`@copilotkit/angular` README](https://github.com/CopilotKit/CopilotKit/tree/main/packages/angular).

--- a/showcase/shell-docs/src/content/docs/frontends/react-native.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/react-native.mdx
@@ -4,11 +4,12 @@ description: Get started with CopilotKit in React Native.
 icon: "lucide/Smartphone"
 hideTOC: true
 ---
-`@copilotkit/react-native` provides a lightweight, headless wrapper around CopilotKit's React hooks for React Native apps. You build the UI — CopilotKit handles the agent communication.
+
+`@copilotkit/react-native` provides a lightweight, headless wrapper around CopilotKit's React hooks for React Native apps. You build the UI, and a [Copilot Runtime](/backend/copilot-runtime) endpoint handles agent communication from your server.
 
 ## Prerequisites
 
-- A CopilotKit runtime endpoint (self-hosted or cloud)
+- An OpenAI API key (or another model provider supported by [Model Selection](/model-selection))
 - React Native 0.70+ (bare CLI or Expo)
 - Node.js 20+
 
@@ -28,20 +29,25 @@ hideTOC: true
     <Step>
         ### Install CopilotKit
 
+        Install the React Native frontend package and `@copilotkit/runtime` for your local Copilot Runtime server:
+
         <Tabs groupId="package-manager" items={['npm', 'pnpm', 'yarn']}>
             <Tab value="npm">
                 ```bash
-                npm install @copilotkit/react-native
+                npm install @copilotkit/react-native @copilotkit/runtime
+                npm install -D tsx typescript @types/node
                 ```
             </Tab>
             <Tab value="pnpm">
                 ```bash
-                pnpm add @copilotkit/react-native
+                pnpm add @copilotkit/react-native @copilotkit/runtime
+                pnpm add -D tsx typescript @types/node
                 ```
             </Tab>
             <Tab value="yarn">
                 ```bash
-                yarn add @copilotkit/react-native
+                yarn add @copilotkit/react-native @copilotkit/runtime
+                yarn add -D tsx typescript @types/node
                 ```
             </Tab>
         </Tabs>
@@ -74,24 +80,66 @@ hideTOC: true
         </Callout>
     </Step>
     <Step>
+        ### Create the Copilot Runtime
+
+        Add a small Node server that hosts Copilot Runtime at `/api/copilotkit` and registers a `default` built-in agent:
+
+        ```ts title="server.ts"
+        import { createServer } from "node:http";
+        import { BuiltInAgent, CopilotRuntime } from "@copilotkit/runtime/v2";
+        import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
+
+        const runtime = new CopilotRuntime({
+          agents: {
+            default: new BuiltInAgent({
+              model: "openai:gpt-5-mini",
+              prompt: "You are a helpful assistant for a React Native app.",
+            }),
+          },
+        });
+
+        const port = Number(process.env.PORT ?? 8200);
+
+        createServer(
+          createCopilotNodeListener({
+            runtime,
+            basePath: "/api/copilotkit",
+            cors: true,
+          }),
+        ).listen(port, () => {
+          console.log(
+            `Copilot Runtime listening at http://localhost:${port}/api/copilotkit`,
+          );
+        });
+        ```
+    </Step>
+    <Step>
         ### Wrap your app with CopilotKitProvider
+
+        Point the provider at the runtime endpoint. Android emulators reach the host machine at `10.0.2.2`; iOS simulators can use `localhost`.
 
         ```tsx title="App.tsx"
         import { CopilotKitProvider } from "@copilotkit/react-native"; // [!code highlight]
-        import { SafeAreaProvider } from "react-native-safe-area-context";
+        import { Platform } from "react-native";
         import { ChatScreen } from "./src/ChatScreen";
+
+        const runtimeUrl =
+          Platform.OS === "android"
+            ? "http://10.0.2.2:8200/api/copilotkit"
+            : "http://localhost:8200/api/copilotkit";
 
         export default function App() {
           return (
-            <SafeAreaProvider>
-              {/* [!code highlight:3] */}
-              <CopilotKitProvider runtimeUrl="https://your-server/api/copilotkit">
-                <ChatScreen />
-              </CopilotKitProvider>
-            </SafeAreaProvider>
+            <CopilotKitProvider runtimeUrl={runtimeUrl}> {/* [!code highlight] */}
+              <ChatScreen />
+            </CopilotKitProvider>
           );
         }
         ```
+
+        <Callout type="info" title="Testing on a physical device">
+          Replace `localhost` or `10.0.2.2` with your development machine's LAN IP address, for example `http://192.168.1.23:8200/api/copilotkit`.
+        </Callout>
     </Step>
     <Step>
         ### Build your chat UI
@@ -120,6 +168,21 @@ hideTOC: true
 
           const messages = agent?.messages ?? [];
           const isLoading = agent?.isRunning ?? false;
+          const chatMessages = messages.flatMap((message) => {
+            if (
+              (message.role === "user" || message.role === "assistant") &&
+              typeof message.content === "string" &&
+              message.content.length > 0
+            ) {
+              return [
+                {
+                  id: message.id,
+                  content: message.content,
+                },
+              ];
+            }
+            return [];
+          });
 
           const handleSend = useCallback(async () => {
             const text = inputText.trim();
@@ -141,9 +204,7 @@ hideTOC: true
             >
               <FlatList
                 ref={flatListRef}
-                data={messages.filter(
-                  (m) => m.role === "user" || (m.role === "assistant" && m.content),
-                )}
+                data={chatMessages}
                 renderItem={({ item }) => (
                   <View style={{ padding: 12, maxWidth: "80%" }}>
                     <Text>{item.content}</Text>
@@ -171,11 +232,20 @@ hideTOC: true
         ```
 
         <Callout type="info" title="Headless by design">
-          `@copilotkit/react-native` is headless — it provides hooks, not UI components. You have full control over your chat interface using standard React Native components.
+          `@copilotkit/react-native` is headless. It provides hooks, not UI components. You have full control over your chat interface using standard React Native components.
         </Callout>
     </Step>
     <Step>
-        ### Run the app
+        ### Run the runtime and app
+
+        Start Copilot Runtime in one terminal:
+
+        ```bash
+        export OPENAI_API_KEY=sk-...
+        npx tsx server.ts
+        ```
+
+        Run the React Native app in another terminal:
 
         <Tabs groupId="platform" items={['iOS', 'Android']}>
             <Tab value="iOS">
@@ -193,19 +263,20 @@ hideTOC: true
     <Step>
         ### Start chatting!
 
-        Your React Native app is now connected to CopilotKit. Hooks from the web SDK work identically:
+        Your React Native app is now connected to Copilot Runtime. Hooks from the web SDK work identically:
 
-        - `useAgent` — connect to an agent and manage messages
-        - `useFrontendTool` — let the agent call functions in your app
-        - `useHumanInTheLoop` — add approval flows for agent actions
-        - `useCopilotKit` — access the CopilotKit instance directly
+        - `useAgent` - connect to an agent and manage messages
+        - `useFrontendTool` - let the agent call functions in your app
+        - `useHumanInTheLoop` - add approval flows for agent actions
+        - `useCopilotKit` - access the CopilotKit instance directly
 
         <Accordions className="mb-4">
             <Accordion title="Troubleshooting">
-                - **Metro can't resolve modules**: Clear the cache with `npx react-native start --reset-cache`
-                - **Streaming not working**: Make sure polyfills are imported before any CopilotKit code in your entry point
-                - **Existing polyfill conflicts**: Use the granular imports instead of the barrel `polyfills` import
-                - Make sure the runtime endpoint URL is reachable from your device/emulator (use your machine's IP, not `localhost`, for physical devices)
+                - **Metro can't resolve modules**: Clear the cache with `npx react-native start --reset-cache`.
+                - **Streaming not working**: Make sure polyfills are imported before any CopilotKit code in your entry point.
+                - **No response from the runtime**: Confirm the runtime server is running, `http://localhost:8200/api/copilotkit/info` returns the `default` agent, and the device can reach `runtimeUrl`. For physical devices, use your machine's LAN IP instead of `localhost`.
+                - **Model auth errors**: Confirm `OPENAI_API_KEY` is set in the terminal running `npx tsx server.ts`.
+                - **Existing polyfill conflicts**: Use the granular imports instead of the barrel `polyfills` import.
             </Accordion>
         </Accordions>
     </Step>
@@ -215,12 +286,13 @@ hideTOC: true
 
 | Export | Description |
 |--------|-------------|
-| `CopilotKitProvider` | Lightweight provider — no DOM, CSS, or web framework deps |
+| `CopilotKitProvider` | Lightweight provider that points React Native at Copilot Runtime |
 | `useAgent`, `useFrontendTool`, etc. | Re-exported hooks from `@copilotkit/react-core` |
 | `@copilotkit/react-native/polyfills` | ReadableStream, TextEncoder, crypto, DOMException, location |
+| `@copilotkit/runtime` | Server-side runtime used to host your `default` agent |
 
 ## Known limitations
 
-- **No pre-built UI components** — you build the chat interface with React Native components
-- **Markdown rendering** — assistant messages with markdown render as plain text; bring your own renderer (e.g. `react-native-markdown-display`)
-- **Voice** — `@copilotkit/voice` has not been adapted for React Native yet
+- **No pre-built UI components** - you build the chat interface with React Native components
+- **Markdown rendering** - assistant messages with markdown render as plain text; bring your own renderer (e.g. `react-native-markdown-display`)
+- **Voice** - `@copilotkit/voice` has not been adapted for React Native yet

--- a/showcase/shell-docs/src/content/docs/frontends/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/slack.mdx
@@ -1,18 +1,18 @@
 ---
 title: Slack
-description: Build an AI Slack bot with CopilotKit — createBot, the Slack adapter over Socket Mode, agent runs with thread.runAgent, and interactive JSX messages rendered as Block Kit.
+description: Build an AI Slack bot with CopilotKit, Copilot Runtime, createBot, the Slack adapter over Socket Mode, and interactive JSX messages rendered as Block Kit.
 icon: "lucide/Slack"
 hideTOC: true
 earlyAccess: slack
 ---
 
-This guide takes you from zero to a Slack bot you can @-mention in a channel, then adds an interactive button card. You write handlers in TypeScript, the agent's replies stream into the thread, and rich messages are JSX that the adapter renders to Block Kit (Slack's message-UI format). No public URL needed.
+This guide takes you from zero to a Slack bot you can @-mention in a channel, then adds an interactive button card. You write handlers in TypeScript, Copilot Runtime hosts the agent, and rich messages are JSX that the adapter renders to Block Kit (Slack's message-UI format). No public URL needed.
 
 ## Prerequisites
 
 - Node.js 20+
 - A Slack workspace where you can install apps
-- An OpenAI API key (or Anthropic/Google — any model the [built-in agent](/build-with-agents) supports)
+- An OpenAI API key (or Anthropic/Google — any model supported by [Model Selection](/model-selection))
 
 ## Getting started
 
@@ -51,7 +51,7 @@ This guide takes you from zero to a Slack bot you can @-mention in a channel, th
         npm init -y && npm pkg set type=module
         ```
 
-        Install the bot packages, plus `@copilotkit/runtime` for the in-process agent and `tsx` to run TypeScript directly:
+        Install the bot packages, plus `@copilotkit/runtime` for Copilot Runtime and `tsx` to run TypeScript directly:
 
         <Tabs groupId="package-manager" items={['npm', 'pnpm', 'yarn']}>
             <Tab value="npm">
@@ -98,29 +98,39 @@ This guide takes you from zero to a Slack bot you can @-mention in a channel, th
         </Callout>
     </Step>
     <Step>
-        ### Write the bot
+        ### Set up Copilot Runtime and the bot
 
-        The smallest working bot is `createBot` + the Slack adapter + one `onMention` handler that runs the agent. For the quickstart, the agent — CopilotKit's `BuiltInAgent` — runs inside the same process, served on a local port the bot connects to, so one command starts everything:
+        The smallest working bot is `createBot` + the Slack adapter + one `onMention` handler that runs the agent. For the quickstart, Copilot Runtime runs in the same process as the Slack bot, serves a `BuiltInAgent` on a local port, and the bot connects to that runtime URL:
 
         ```tsx title="bot.tsx"
         import { createServer } from "node:http";
         import { createBot } from "@copilotkit/bot";
         import { slack, SanitizingHttpAgent } from "@copilotkit/bot-slack"; // [!code highlight]
-        import { BuiltInAgent, CopilotSseRuntime } from "@copilotkit/runtime/v2";
+        import { BuiltInAgent, CopilotRuntime } from "@copilotkit/runtime/v2";
         import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
-        // The agent — runs in-process for the quickstart.
-        const runtime = new CopilotSseRuntime({
+        const agentId = "assistant";
+        const runtimePort = Number(process.env.RUNTIME_PORT ?? 8200);
+        const runtimeUrl = `http://localhost:${runtimePort}/api/copilotkit`;
+
+        // Copilot Runtime: hosts the assistant agent.
+        const runtime = new CopilotRuntime({
           agents: {
-            assistant: new BuiltInAgent({
-              model: "openai/gpt-5.4", // reads OPENAI_API_KEY
+            [agentId]: new BuiltInAgent({
+              model: process.env.OPENAI_MODEL ?? "openai:gpt-5-mini",
               prompt: "You are a helpful Slack assistant. Keep replies short.",
             }),
           },
         });
         createServer(
-          createCopilotNodeListener({ runtime, basePath: "/api/copilotkit" }),
-        ).listen(8200);
+          createCopilotNodeListener({
+            runtime,
+            basePath: "/api/copilotkit",
+            cors: true,
+          }),
+        ).listen(runtimePort, () => {
+          console.log(`Copilot Runtime listening at ${runtimeUrl}`);
+        });
 
         // The bot: the Slack adapter + one handler.
         const bot = createBot({
@@ -134,7 +144,7 @@ This guide takes you from zero to a Slack bot you can @-mention in a channel, th
           // One agent connection per Slack conversation.
           agent: (threadId) => {
             const agent = new SanitizingHttpAgent({
-              url: "http://localhost:8200/api/copilotkit/agent/assistant/run",
+              url: `${runtimeUrl}/agent/${encodeURIComponent(agentId)}/run`,
             });
             agent.threadId = threadId;
             return agent;
@@ -162,7 +172,7 @@ This guide takes you from zero to a Slack bot you can @-mention in a channel, th
         npx tsx bot.tsx
         ```
 
-        You should see `⚡ Bot connected over Socket Mode` in the terminal. Now **invite the bot** to a channel and mention it — the bot's name comes from the manifest (if autocomplete can't find it, check **App Home** → *Default username*):
+        You should see `Copilot Runtime listening at http://localhost:8200/api/copilotkit` and `⚡ Bot connected over Socket Mode` in the terminal. Now **invite the bot** to a channel and mention it — the bot's name comes from the manifest (if autocomplete can't find it, check **App Home** → *Default username*):
 
         ```
         /invite @YourBot
@@ -174,6 +184,7 @@ This guide takes you from zero to a Slack bot you can @-mention in a channel, th
                 - **Mentioning the bot does nothing** — `app_mention` only fires in channels the bot is a **member** of: `/invite` it first. Also check the process is running and both tokens are set.
                 - **`@`-autocomplete doesn't find the bot** — search by the bot user's *Default username* (visible under **App Home**), not the app's display name. Identity changes only propagate when you **reinstall** the app; in stubborn cases a full uninstall → reinstall is needed, which **rotates the `xoxb-` token** — update your env when it does.
                 - **`bot.start()` fails with an auth error** — the `xoxb-` token is wrong or was rotated by a reinstall; copy the current one from OAuth & Permissions.
+                - **The bot connects but never replies** — confirm `OPENAI_API_KEY` is set and `http://localhost:8200/api/copilotkit/info` returns the `assistant` agent.
                 - **Slash command does nothing** — the command isn't declared in the Slack app config (see the last step), or the process isn't running.
             </Accordion>
         </Accordions>
@@ -244,17 +255,21 @@ This guide takes you from zero to a Slack bot you can @-mention in a channel, th
 
 ## Split the bot and the agent
 
-The bot and its agent talk over [AG-UI](https://docs.ag-ui.com) — an open protocol for agent ↔ frontend communication — so they don't have to share a process. The production shape is two services joined by a URL: move the `CopilotSseRuntime` block into its own process (or use any existing AG-UI endpoint — a deployed CopilotKit runtime, LangGraph, …) and point the bot at it via env, exactly how the full [on-call triage example](https://github.com/CopilotKit/CopilotKit/tree/main/examples/slack) is wired:
+The bot and its agent talk over [AG-UI](https://docs.ag-ui.com) through Copilot Runtime, so they don't have to share a process. The production shape is two services joined by a URL: move the `CopilotRuntime` block into its own process (or use a deployed Copilot Runtime) and point the bot at it via env, exactly how the full [on-call triage example](https://github.com/CopilotKit/CopilotKit/tree/main/examples/slack) is wired:
 
 ```tsx title="bot.tsx"
+const runtimeUrl = process.env.COPILOT_RUNTIME_URL!;
+
 agent: (threadId) => {
-  const agent = new SanitizingHttpAgent({ url: process.env.AGENT_URL! }); // [!code highlight]
+  const agent = new SanitizingHttpAgent({
+    url: `${runtimeUrl}/agent/assistant/run`, // [!code highlight]
+  });
   agent.threadId = threadId;
   return agent;
 },
 ```
 
-[`SanitizingHttpAgent`](/reference/bot/slack/SanitizingHttpAgent) is an `HttpAgent` that tolerates the event streams real agent backends emit — use it over the stock `HttpAgent` when connecting to a remote runtime.
+[`SanitizingHttpAgent`](/reference/bot/slack/SanitizingHttpAgent) is an `HttpAgent` that tolerates the event streams real agent backends emit — use it over the stock `HttpAgent` when connecting a Slack bot to Copilot Runtime.
 
 ## Known limitations (v1)
 

--- a/showcase/shell-docs/src/content/docs/frontends/teams.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/teams.mdx
@@ -1,6 +1,6 @@
 ---
 title: Microsoft Teams
-description: Build a Microsoft Teams bot with CopilotKit from an empty Node project.
+description: Build a Microsoft Teams bot with CopilotKit and Copilot Runtime from an empty Node project.
 hideTOC: true
 earlyAccess: teams
 ---
@@ -13,16 +13,16 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 ## What you will build
 
 By the end of this guide, you will have a small Node app that can answer Microsoft Teams messages
-with a CopilotKit agent. You will test it locally first with Teams DevTools, then optionally expose
+through Copilot Runtime. You will test it locally first with Teams DevTools, then optionally expose
 the same bot through Azure Bot Service and sideload it into Microsoft Teams.
 
 `@copilotkit/bot-teams` handles the Teams-specific work: receiving Teams activities, rendering
 Adaptive Cards, streaming updates, and running the local DevTools bridge. Your app provides the
-CopilotKit runtime, agent configuration, Microsoft credentials, tunnel, and Teams manifest.
+Copilot Runtime, agent configuration, Microsoft credentials, tunnel, and Teams manifest.
 
 | Process | Port | Purpose |
 | --- | --- | --- |
-| CopilotKit runtime | 8200 | Runs a `BuiltInAgent` and exposes `/api/copilotkit` |
+| Copilot Runtime | 8200 | Runs a `BuiltInAgent` and exposes `/api/copilotkit` |
 | Teams bot | 3978 | Receives Teams activities at `POST /api/messages` |
 | Teams DevTools | 3979 | Local browser UI for testing Teams messages without a Teams account |
 
@@ -48,7 +48,7 @@ For sideloading into Microsoft Teams:
 
 ### Create the Node project
 
-Start with a new Node project and install the CopilotKit runtime, core package, and Teams bridge:
+Start with a new Node project and install Copilot Runtime, the core package, and the Teams bridge:
 
 <Tabs items={["npm", "pnpm", "yarn"]}>
   <Tab value="npm">
@@ -57,8 +57,7 @@ Start with a new Node project and install the CopilotKit runtime, core package, 
     mkdir copilotkit-teams-bot
     cd copilotkit-teams-bot
     npm init -y
-    npm pkg set type=module
-    npm install @copilotkit/bot-teams @copilotkit/core @copilotkit/runtime
+    npm install @copilotkit/bot-teams@0.0.1 @copilotkit/core@1.59.1 @copilotkit/runtime
     npm install -D tsx typescript @types/node
     ```
 
@@ -69,8 +68,7 @@ Start with a new Node project and install the CopilotKit runtime, core package, 
     mkdir copilotkit-teams-bot
     cd copilotkit-teams-bot
     pnpm init
-    pnpm pkg set type=module
-    pnpm add @copilotkit/bot-teams @copilotkit/core @copilotkit/runtime
+    pnpm add @copilotkit/bot-teams@0.0.1 @copilotkit/core@1.59.1 @copilotkit/runtime
     pnpm add -D tsx typescript @types/node
     ```
 
@@ -82,13 +80,18 @@ Start with a new Node project and install the CopilotKit runtime, core package, 
     cd copilotkit-teams-bot
     yarn init -y
     yarn config set nodeLinker node-modules
-    npm pkg set type=module
-    yarn add @copilotkit/bot-teams @copilotkit/core @copilotkit/runtime
+    yarn add @copilotkit/bot-teams@0.0.1 @copilotkit/core@1.59.1 @copilotkit/runtime
     yarn add -D tsx typescript @types/node
     ```
 
   </Tab>
 </Tabs>
+
+<Callout type="info" title="Why these versions are pinned">
+  The Teams bridge is early access. `@copilotkit/bot-teams@0.0.1` expects
+  `@copilotkit/core@1.59.1`, so the quickstart pins that pair to keep
+  `CopilotKitCore` types aligned.
+</Callout>
 
 </Step>
 
@@ -115,15 +118,15 @@ Create `tsconfig.json`:
 
 <Step>
 
-### Add the CopilotKit runtime and Teams bot
+### Add Copilot Runtime and the Teams bot
 
-Create `bot.ts`. This single file starts both the CopilotKit runtime and the Teams-facing bot:
+Create `bot.cts`. This single file starts both Copilot Runtime and the Teams-facing bot:
 
-```ts title="bot.ts"
+```ts title="bot.cts"
 import { createServer } from "node:http";
-import { CopilotKitCore, ProxiedCopilotRuntimeAgent } from "@copilotkit/core";
+import { CopilotKitCore } from "@copilotkit/core";
 import { createTeamsAgentBot } from "@copilotkit/bot-teams/bot";
-import { BuiltInAgent, CopilotSseRuntime } from "@copilotkit/runtime/v2";
+import { BuiltInAgent, CopilotRuntime } from "@copilotkit/runtime/v2";
 import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
 
 const agentId = "assistant";
@@ -131,10 +134,10 @@ const runtimePort = Number(process.env.RUNTIME_PORT ?? 8200);
 const botPort = Number(process.env.PORT ?? 3978);
 const runtimeUrl = `http://localhost:${runtimePort}/api/copilotkit`;
 
-const runtime = new CopilotSseRuntime({
+const runtime = new CopilotRuntime({
   agents: {
     [agentId]: new BuiltInAgent({
-      model: process.env.OPENAI_MODEL ?? "openai/gpt-4o-mini",
+      model: process.env.OPENAI_MODEL ?? "openai:gpt-5-mini",
       prompt:
         "You are a helpful Microsoft Teams assistant. Keep replies concise and useful.",
     }),
@@ -145,32 +148,36 @@ createServer(
   createCopilotNodeListener({
     runtime,
     basePath: "/api/copilotkit",
+    cors: true,
   }),
 ).listen(runtimePort, () => {
-  console.log(`CopilotKit runtime listening at ${runtimeUrl}`);
+  console.log(`Copilot Runtime listening at ${runtimeUrl}`);
 });
 
 const core = new CopilotKitCore({ runtimeUrl });
 core.setDefaultThrottleMs(1000);
-core.addAgent__unsafe_dev_only({
-  id: agentId,
-  agent: new ProxiedCopilotRuntimeAgent({
-    agentId,
-    runtimeAgentId: agentId,
-    runtimeUrl,
-  }),
-});
-
-const bot = createTeamsAgentBot({
-  core,
+core.registerProxiedAgent({
   agentId,
-  approvalTimeoutMs: 5 * 60 * 1000,
-  reviewerName: "Reviewer",
+  runtimeAgentId: agentId,
 });
 
-await bot.start(botPort);
-console.log(`Teams bot listening at http://localhost:${botPort}/api/messages`);
-console.log(`Teams DevTools available at http://localhost:${botPort + 1}/devtools`);
+async function main() {
+  const bot = createTeamsAgentBot({
+    core,
+    agentId,
+    approvalTimeoutMs: 5 * 60 * 1000,
+    reviewerName: "Reviewer",
+  });
+
+  await bot.start(botPort);
+  console.log(`Teams bot listening at http://localhost:${botPort}/api/messages`);
+  console.log(`Teams DevTools available at http://localhost:${botPort + 1}/devtools`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
 ```
 
 Your project should now look like this:
@@ -179,7 +186,7 @@ Your project should now look like this:
 copilotkit-teams-bot/
   package.json
   tsconfig.json
-  bot.ts
+  bot.cts
 ```
 
 </Step>
@@ -195,7 +202,7 @@ Set your OpenAI key and start the bot:
 
     ```bash
     export OPENAI_API_KEY=sk-...
-    npx tsx bot.ts
+    npx tsx bot.cts
     ```
 
   </Tab>
@@ -203,7 +210,7 @@ Set your OpenAI key and start the bot:
 
     ```powershell
     $env:OPENAI_API_KEY="sk-..."
-    npx tsx bot.ts
+    npx tsx bot.cts
     ```
 
   </Tab>
@@ -216,7 +223,7 @@ Hello from Teams
 ```
 
 <Callout type="success" title="Local verification">
-  If you receive a response card in DevTools, the CopilotKit runtime and Teams bot are working
+  If you receive a response card in DevTools, Copilot Runtime and the Teams bot are working
   locally.
 </Callout>
 
@@ -226,7 +233,7 @@ Hello from Teams
 ## Sideload into Microsoft Teams
 
 The local DevTools path does not require Microsoft credentials. The real Teams client does. Keep the
-same `bot.ts`; add a tunnel, a Microsoft app registration, an Azure Bot resource, and a Teams app
+same `bot.cts`; add a tunnel, a Microsoft app registration, an Azure Bot resource, and a Teams app
 manifest.
 
 <Steps>
@@ -277,7 +284,7 @@ Run the bot with those credentials:
     export CLIENT_ID=<application-client-id>
     export CLIENT_SECRET=<client-secret-value>
     export TENANT_ID=<directory-tenant-id>
-    npx tsx bot.ts
+    npx tsx bot.cts
     ```
 
   </Tab>
@@ -288,7 +295,7 @@ Run the bot with those credentials:
     $env:CLIENT_ID="<application-client-id>"
     $env:CLIENT_SECRET="<client-secret-value>"
     $env:TENANT_ID="<directory-tenant-id>"
-    npx tsx bot.ts
+    npx tsx bot.cts
     ```
 
   </Tab>
@@ -387,8 +394,8 @@ You should receive the same response you saw in DevTools.
 
 <Accordions type="single" collapsible>
   <Accordion title="DevTools opens but messages do not answer">
-    Confirm `OPENAI_API_KEY` is set in the terminal running `npx tsx bot.ts`, and check that
-    `http://localhost:8200/api/copilotkit` is not blocked by another process.
+    Confirm `OPENAI_API_KEY` is set in the terminal running `npx tsx bot.cts`, and check that
+    `http://localhost:8200/api/copilotkit/info` returns the `assistant` agent.
   </Accordion>
   <Accordion title="Teams says the bot cannot be reached">
     Confirm the Azure Bot messaging endpoint is exactly `https://<your-tunnel-host>/api/messages`,
@@ -404,6 +411,6 @@ You should receive the same response you saw in DevTools.
   </Accordion>
   <Accordion title="Port 3978 or 8200 is already in use">
     Stop the process using that port, or set `PORT` and `RUNTIME_PORT` before running
-    `npx tsx bot.ts`.
+    `npx tsx bot.cts`.
   </Accordion>
 </Accordions>

--- a/showcase/shell-docs/src/content/docs/frontends/vue.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/vue.mdx
@@ -1,19 +1,19 @@
 ---
 title: Vue
-description: Connect a Vue app to an AG-UI agent with CopilotKit.
+description: Connect a Vue app to Copilot Runtime with CopilotKit.
 icon: "lucide/Component"
 hideTOC: true
 ---
 
-`@copilotkit/vue` provides Vue 3 components and composables for CopilotKit. This guide gets you to a working Vue app with a chat UI talking to an [AG-UI](/backend/ag-ui) agent.
+`@copilotkit/vue` provides Vue 3 components and composables for CopilotKit. This guide gets you to a working Vue app with a chat UI backed by a local [Copilot Runtime](/backend/copilot-runtime) and `BuiltInAgent`.
 
-It connects to the agent directly with `HttpAgent`, so there's no CopilotKit runtime to stand up and nothing framework-specific to configure. The same setup works with any AG-UI-compatible agent, whether it's built on LangGraph, CrewAI, Mastra, Pydantic AI, or your own server.
+The runtime runs on your server, keeps model credentials out of the browser, and exposes the `default` agent that `CopilotChat` uses automatically.
 
 ## Prerequisites
 
-- A running AG-UI-compatible agent endpoint. If you don't have one yet, pick a framework under [Integrations](/integrations/langgraph) and follow its agent setup.
+- An OpenAI API key (or another model provider supported by [Model Selection](/model-selection))
 - Vue 3.3+
-- Node.js 18+
+- Node.js 20+
 
 ## Getting started
 
@@ -32,23 +32,62 @@ It connects to the agent directly with `HttpAgent`, so there's no CopilotKit run
     <Step>
         ### Install CopilotKit
 
+        Install the Vue frontend package and `@copilotkit/runtime` for your local Copilot Runtime server:
+
         <Tabs groupId="package-manager" items={['npm', 'pnpm', 'yarn']}>
             <Tab value="npm">
                 ```bash
-                npm install @copilotkit/vue
+                npm install @copilotkit/vue @copilotkit/runtime
+                npm install -D tsx typescript @types/node
                 ```
             </Tab>
             <Tab value="pnpm">
                 ```bash
-                pnpm add @copilotkit/vue
+                pnpm add @copilotkit/vue @copilotkit/runtime
+                pnpm add -D tsx typescript @types/node
                 ```
             </Tab>
             <Tab value="yarn">
                 ```bash
-                yarn add @copilotkit/vue
+                yarn add @copilotkit/vue @copilotkit/runtime
+                yarn add -D tsx typescript @types/node
                 ```
             </Tab>
         </Tabs>
+    </Step>
+    <Step>
+        ### Create the Copilot Runtime
+
+        Add a small Node server that hosts Copilot Runtime at `/api/copilotkit` and registers a `default` built-in agent:
+
+        ```ts title="server.ts"
+        import { createServer } from "node:http";
+        import { BuiltInAgent, CopilotRuntime } from "@copilotkit/runtime/v2";
+        import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
+
+        const runtime = new CopilotRuntime({
+          agents: {
+            default: new BuiltInAgent({
+              model: "openai:gpt-5-mini",
+              prompt: "You are a helpful assistant for a Vue app.",
+            }),
+          },
+        });
+
+        const port = Number(process.env.PORT ?? 8200);
+
+        createServer(
+          createCopilotNodeListener({
+            runtime,
+            basePath: "/api/copilotkit",
+            cors: true,
+          }),
+        ).listen(port, () => {
+          console.log(
+            `Copilot Runtime listening at http://localhost:${port}/api/copilotkit`,
+          );
+        });
+        ```
     </Step>
     <Step>
         ### Import the styles
@@ -64,21 +103,18 @@ It connects to the agent directly with `HttpAgent`, so there's no CopilotKit run
         ```
     </Step>
     <Step>
-        ### Connect to your agent
+        ### Connect to Copilot Runtime
 
-        Create an `HttpAgent` pointing at your agent endpoint, hand it to `CopilotKitProvider`, and drop in `CopilotChat`. Register the agent under the id `default` so the chat picks it up automatically.
+        Point `CopilotKitProvider` at the runtime endpoint and drop in `CopilotChat`. Because the runtime registers an agent named `default`, the chat picks it up automatically.
 
         ```vue title="src/App.vue"
         <script setup lang="ts">
-        import { CopilotKitProvider, CopilotChat, HttpAgent } from "@copilotkit/vue/v2"; // [!code highlight]
-
-        // Point this at your AG-UI-compatible agent endpoint
-        const agent = new HttpAgent({ url: "http://localhost:8000/" }); // [!code highlight]
+        import { CopilotKitProvider, CopilotChat } from "@copilotkit/vue/v2"; // [!code highlight]
         </script>
 
         <template>
           <!-- [!code highlight:5] -->
-          <CopilotKitProvider :self-managed-agents="{ default: agent }">
+          <CopilotKitProvider runtime-url="http://localhost:8200/api/copilotkit">
             <div style="height: 100vh">
               <CopilotChat />
             </div>
@@ -91,19 +127,29 @@ It connects to the agent directly with `HttpAgent`, so there's no CopilotKit run
         </Callout>
     </Step>
     <Step>
-        ### Run the app
+        ### Run the runtime and app
+
+        Start Copilot Runtime in one terminal:
+
+        ```bash
+        export OPENAI_API_KEY=sk-...
+        npx tsx server.ts
+        ```
+
+        Start the Vue app in another terminal:
 
         ```bash
         npm run dev
         ```
 
-        Open the dev server URL (Vite prints it, usually `http://localhost:5173`), send a message, and you'll see it stream back from your agent.
+        Open the dev server URL (Vite prints it, usually `http://localhost:5173`), send a message, and you'll see it stream back through Copilot Runtime.
 
         <Accordions className="mb-4">
             <Accordion title="Troubleshooting">
                 - **Chat renders unstyled**: Make sure you imported `@copilotkit/vue/styles.css` in your app entry.
-                - **No response from the agent**: Confirm the `url` points at a reachable AG-UI endpoint and that the agent is running. Check the browser network tab for the request.
-                - **CORS errors**: A browser-direct connection needs the agent endpoint to allow your app's origin. Enable CORS on the agent, or put it behind the [CopilotKit runtime](/backend/copilot-runtime).
+                - **No response from the agent**: Confirm the runtime server is running and `http://localhost:8200/api/copilotkit/info` returns agent information.
+                - **CORS errors**: Keep `cors: true` in `createCopilotNodeListener` for local development, or configure CORS to allow your Vue app's origin in production.
+                - **Model auth errors**: Confirm `OPENAI_API_KEY` is set in the terminal running `npx tsx server.ts`.
             </Accordion>
         </Accordions>
     </Step>
@@ -111,8 +157,8 @@ It connects to the agent directly with `HttpAgent`, so there's no CopilotKit run
 
 ## Where to go next
 
-- [Self-managed agents](/backend/self-managed-agents): securing the connection, the dev-only registration variant, and combining with a runtime.
-- [Connect AG-UI agents](/backend/ag-ui): the `HttpAgent` interface and the AG-UI protocol.
-- [Integrations](/integrations/langgraph): set up the agent itself on LangGraph, CrewAI, Mastra, and other frameworks.
+- [Copilot Runtime](/backend/copilot-runtime): runtime setup, auth, middleware, and routing.
+- [Built-in Agent quickstart](/quickstart): configure the in-process agent used in this quickstart.
+- [Integrations](/integrations/langgraph): connect LangGraph, CrewAI, Mastra, and other agents through the runtime.
 
 The composables (`useAgent`, `useFrontendTool`, `useHumanInTheLoop`, and more) mirror the React SDK. See the [`@copilotkit/vue` README](https://github.com/CopilotKit/CopilotKit/tree/main/packages/vue) for the full API, slot-based customization, and Nuxt SSR setup.


### PR DESCRIPTION
## Summary
- Rework Angular, React Native, Vue, Slack, and Teams frontend docs to center on Copilot Runtime instead of direct AG-UI agent endpoints
- Add local runtime setup examples, package install updates, and troubleshooting guidance for runtime auth and connectivity
- Update language, prerequisites, and next-step links to match the new runtime-based quickstarts

## Testing
- Not run (not requested)