### PR TITLE
Accept ag_ui (underscore) state key alongside ag-ui in LangGraph

### DIFF
--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -339,7 +339,7 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         BYOC custom catalogs render their own components, not the basic one).
         """
         # AG-UI native path.
-        ag_ui = state.get("ag-ui") or {}
+        ag_ui = state.get("ag-ui") or state.get("ag_ui") or {}
         a2ui_schema = ag_ui.get("a2ui_schema")
         if a2ui_schema:
             catalog_id = None
@@ -385,7 +385,7 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         means no signal at all (off, or no A2UI middleware in the pipeline), in
         which case we do not auto-inject.
         """
-        return (state.get("ag-ui") or {}).get("inject_a2ui_tool")
+        return (state.get("ag-ui") or state.get("ag_ui") or {}).get("inject_a2ui_tool")
 
     def _maybe_build_a2ui_tool(self, request: ModelRequest) -> Any | None:
         """Build a ``generate_a2ui`` tool bound to the agent's own model when

--- a/sdk-python/copilotkit/langgraph_agui_agent.py
+++ b/sdk-python/copilotkit/langgraph_agui_agent.py
@@ -273,7 +273,7 @@ class LangGraphAGUIAgent(LangGraphAgent):
         """Override to add CopilotKit actions to the state"""
         merged_state = super().langgraph_default_merge_state(state, messages, input)
         # Extract tools from the merged state and add them as CopilotKit actions
-        agui_properties = merged_state.get("ag-ui", {}) or merged_state
+        agui_properties = merged_state.get("ag-ui", {}) or merged_state.get("ag_ui", {}) or merged_state
 
         return {
             **merged_state,


### PR DESCRIPTION
## What does this PR do?

LangGraph's JSON-schema validation can rewrite the hyphenated `ag-ui` state key to `ag_ui` (underscore). The CopilotKit LangGraph middleware only read `state["ag-ui"]`, so when the namespace arrived under `ag_ui` it was missed and A2UI components failed to render (no `generate_a2ui` tool injection, no catalog resolution, no `inject_a2ui_tool` flag read).

This adds an `ag_ui` fallback next to every `ag-ui` state read, in the three places identified in #5463:

- `sdk-python/copilotkit/langgraph_agui_agent.py` — `langgraph_default_merge_state` reads agui `tools`/`context`.
- `sdk-python/copilotkit/copilotkit_lg_middleware.py` — `_resolve_a2ui_catalog` reads `a2ui_schema`.
- `sdk-python/copilotkit/copilotkit_lg_middleware.py` — `_a2ui_inject_decision` reads `inject_a2ui_tool`.

The change is backward compatible: when `ag-ui` is present and truthy, behavior is unchanged; the underscore key is only consulted as a fallback.

## Related PRs and Issues

- Fixes #5463

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)