### PR TITLE
include configured headers in inspector /threads requests

### DIFF
--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -2590,7 +2590,7 @@ export class WebInspectorElement extends LitElement {
     store.start();
     store.setContext({
       runtimeUrl: core.runtimeUrl,
-      headers: {},
+      headers: { ...core.headers },
       agentId,
     });
     this._ownedThreadStores.set(agentId, store);


### PR DESCRIPTION
## What does this PR do?

When `enableInspector={true}` is enabled, the web inspector creates its own thread store to list `/threads`. That store was initialised with an empty `headers` object, so the custom headers configured via `<CopilotKit headers={...}>` were never sent on the inspector's `/threads` requests. This caused `403` failures in environments that enforce CSRF or auth checks on those requests.

The fix passes `core.headers` through to the thread store context — the same pattern already used by `useThreads()` (`packages/react-core/src/v2/hooks/use-threads.tsx`):

```ts
store.setContext({
  runtimeUrl: core.runtimeUrl,
  headers: { ...core.headers },  // was: headers: {}
  agentId,
});
```

This is a one-line change in `packages/web-inspector/src/index.ts` (`ensureOwnedThreadStore`).

Fixes #5581

## Related PRs and Issues

- Fixes #5581 — 🐛 Bug: `enableInspector=true` causes `/threads` requests to ignore configured headers
- Follows the same approach as #5300, which fixed headers for `useThreads()` directly

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)