### PR TITLE
fix(web-inspector): handle empty tool result content

### DIFF
--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -411,6 +411,19 @@ type ThreadDetailsInternals = {
   timelineItemsFromEvents: (
     events: Array<Record<string, unknown>>,
   ) => Array<Record<string, unknown>>;
+  mapMessages: (
+    messages: Array<{
+      id: string;
+      role: string;
+      content?: string | null;
+      toolCallId?: string | null;
+      toolCalls?: Array<{
+        id: string;
+        name: string;
+        args: string;
+      }>;
+    }>,
+  ) => Array<Record<string, unknown>>;
 };
 
 function createThreadDetails(): {
@@ -453,7 +466,6 @@ function createDeferred<T>(): {
   });
   return { promise, resolve, reject };
 }
-
 describe("ɵCpkThreadDetails caching", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -748,6 +760,57 @@ describe("ɵCpkThreadDetails caching", () => {
 
     expect(internals.renderState()).not.toBe(stateA);
     expect(internals.renderEvents()).not.toBe(eventsA);
+  });
+
+  it("maps empty tool arguments and results as empty objects", () => {
+    const { internals } = createThreadDetails();
+
+    const items = internals.mapMessages([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          {
+            id: "call-empty",
+            name: "lookupUser",
+            args: "",
+          },
+          {
+            id: "call-whitespace",
+            name: "lookupOrder",
+            args: "   ",
+          },
+        ],
+      },
+      {
+        id: "tool-empty",
+        role: "tool",
+        toolCallId: "call-empty",
+        content: "",
+      },
+      {
+        id: "tool-whitespace",
+        role: "tool",
+        toolCallId: "call-whitespace",
+        content: "   ",
+      },
+    ]);
+
+    expect(items).toMatchObject([
+      {
+        type: "tool_call",
+        toolCallId: "call-empty",
+        arguments: {},
+        result: {},
+      },
+      {
+        type: "tool_call",
+        toolCallId: "call-whitespace",
+        arguments: {},
+        result: {},
+      },
+    ]);
   });
 });
 

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -2327,10 +2327,10 @@ export class CpkThreadInspector extends LitElement {
             let args: Record<string, unknown> = {};
             if (typeof tc.args === "string") {
               try {
-                args = JSON.parse(tc.args) as Record<string, unknown>;
+                args = this.parseToolCallContent(tc.args);
               } catch (err) {
-                // Inspector is a debugging surface — surface malformed payloads
-                // instead of silently substituting `{}`.
+                // Empty content is normalized to `{}` for both tool arguments
+                // and results. The inspector still surfaces malformed JSON.
                 console.error(
                   "[CopilotKit Inspector] Failed to parse tool-call arguments",
                   { toolCallId: tc.id, raw: tc.args, error: err },
@@ -2372,10 +2372,7 @@ export class CpkThreadInspector extends LitElement {
         const tc = toolCallMap.get(msg.toolCallId);
         if (tc) {
           try {
-            tc.result = JSON.parse(msg.content ?? "{}") as Record<
-              string,
-              unknown
-            >;
+            tc.result = this.parseToolCallContent(msg.content);
           } catch (err) {
             // See the comment on the assistant tool-call args parse above —
             // same rationale, same sentinel shape so the renderer can treat
@@ -2390,6 +2387,17 @@ export class CpkThreadInspector extends LitElement {
       }
     }
     return items;
+  }
+
+  private parseToolCallContent(
+    content: string | null | undefined,
+  ): Record<string, unknown> {
+    const normalizedContent = content?.trim();
+    if (!normalizedContent) {
+      return {};
+    }
+
+    return JSON.parse(normalizedContent) as Record<string, unknown>;
   }
 
   private mapApiEvents(events: ThreadDebuggerEvent[]): ApiAgentEvent[] {


### PR DESCRIPTION
## Summary

Fixes the web inspector crash when historical tool result messages have empty `content`.

Some stored thread tool-result messages can have `content: ""`. The inspector previously parsed tool result content with `JSON.parse(msg.content ?? "{}")`, which still passes the empty string into `JSON.parse` and throws `Unexpected end of JSON input`.

## Changes

-> Treat empty and whitespace-only tool result content as an empty result object
-> Keep malformed non-empty result content flowing through the existing parse-error fallback
-> Add regression coverage for empty and whitespace-only tool result messages in the thread conversation mapper

## Testing

-> `pnpm exec oxlint packages/web-inspector/src/index.ts packages/web-inspector/src/__tests__/web-inspector.spec.ts`
-> `pnpm -C packages/web-inspector exec vitest run src/__tests__/web-inspector.spec.ts --pool=threads --testNamePattern "maps empty tool result content" --reporter=verbose`

## Notes

-> `pnpm nx show project @copilotkit/web-inspector --json` timed out locally
-> `pnpm -C packages/web-inspector run check-types` is currently blocked by existing package-level TypeScript errors around explicit `.js` import extensions and one unrelated existing error

## Related Issue

Closes #5598 