### PR TITLE
fix(cvdiag): backend emitters authenticate as PB writer-role so events actually persist

### DIFF
--- a/showcase/harness/src/cvdiag/index.ts
+++ b/showcase/harness/src/cvdiag/index.ts
@@ -8,3 +8,4 @@
 export * from "./schema.js";
 export * from "./edge-headers.js";
 export * from "./emit.js";
+export * from "./pb-writer-fetch.js";

--- a/showcase/harness/src/cvdiag/pb-writer-fetch.test.ts
+++ b/showcase/harness/src/cvdiag/pb-writer-fetch.test.ts
@@ -1,0 +1,218 @@
+/**
+ * pb-writer-fetch.test.ts — RED→GREEN for the CONCRETE, plain-`fetch`,
+ * WRITER-ROLE PB writer that the TS integration backends inject (the fix for
+ * the type-only-seam defect where backend telemetry never persisted).
+ *
+ * Drives `CvdiagFetchPbWriter` against a LIVE PocketBase, authenticating as the
+ * `cvdiag_api_keys` record with role `writer` (NOT superuser) — exactly the §4
+ * three-key-ACL contract a deployed integration must honor. The superuser token
+ * is used ONLY for the read-back assertion (cvdiag_events list/view is
+ * superuser-only by design).
+ *
+ * Coverage:
+ *   - GREEN: a batch persists to cvdiag_events via writer-role auth.
+ *   - A WRONG writer key degrades to a no-op (zero rows) and NEVER throws
+ *     (best-effort, pure-instrumentation contract).
+ *   - A pre-cached but EXPIRED/invalid token triggers a re-auth on 401 and the
+ *     row still lands.
+ *
+ * Requires a `pocketbase` binary (POCKETBASE_BIN, on PATH, or
+ * /tmp/pb022/pocketbase). SKIPS when absent so CI without the binary stays
+ * green.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { CvdiagFetchPbWriter } from "./pb-writer-fetch.js";
+import type { CvdiagEnvelope } from "./schema.js";
+
+const PB_BIN = resolvePbBinary();
+const PORT = 8095;
+const BASE = `http://127.0.0.1:${PORT}`;
+const ADMIN_EMAIL = "cvdiag-fetch-e2e@test.local";
+const ADMIN_PASS = "cvdiagfetche2epass123";
+
+// Seeded by migration 1779990200 (role `writer`). NON-SECRET bootstrap
+// defaults — what a deployed integration authenticates as (NOT a superuser).
+const WRITER_IDENTITY = "cvdiag-writer@keys.local";
+const WRITER_PASSWORD = "cvdiagwriterpass123";
+
+const REPO_PB_DIR = resolve(__dirname, "../../../pocketbase");
+const MIGRATIONS_DIR = join(REPO_PB_DIR, "pb_migrations");
+const HOOKS_DIR = join(REPO_PB_DIR, "pb_hooks");
+
+function resolvePbBinary(): string | null {
+  const explicit = process.env.POCKETBASE_BIN;
+  if (explicit && existsSync(explicit)) return explicit;
+  const probe = spawnSync("which", ["pocketbase"], { encoding: "utf8" });
+  if (probe.status === 0 && probe.stdout.trim()) return probe.stdout.trim();
+  if (existsSync("/tmp/pb022/pocketbase")) return "/tmp/pb022/pocketbase";
+  return null;
+}
+
+async function waitForHealth(timeoutMs = 15_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const r = await fetch(`${BASE}/api/health`);
+      if (r.ok) return;
+    } catch {
+      /* not up yet */
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error("PocketBase did not become healthy in time");
+}
+
+async function adminToken(): Promise<string> {
+  const r = await fetch(`${BASE}/api/admins/auth-with-password`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ identity: ADMIN_EMAIL, password: ADMIN_PASS }),
+  });
+  if (!r.ok) throw new Error(`admin auth: ${r.status} ${await r.text()}`);
+  const body = (await r.json()) as { token: string };
+  return body.token;
+}
+
+async function countRows(testId: string): Promise<number> {
+  const tok = await adminToken();
+  const list = await fetch(
+    `${BASE}/api/collections/cvdiag_events/records?filter=${encodeURIComponent(
+      `test_id="${testId}"`,
+    )}`,
+    { headers: { authorization: tok } },
+  );
+  const body = (await list.json()) as { totalItems: number };
+  return body.totalItems;
+}
+
+let counter = 0;
+function makeEnvelope(slug: string): CvdiagEnvelope {
+  // A fresh UUIDv7-shaped id per call so cases don't collide.
+  const n = (++counter).toString(16).padStart(12, "0");
+  const id = `01900000-0000-7000-8000-${n}`;
+  return {
+    schema_version: 1,
+    test_id: id,
+    trace_id: id,
+    span_id: "0123456789abcdef",
+    parent_span_id: null,
+    layer: "backend",
+    boundary: "backend.agent.enter",
+    slug,
+    demo: slug,
+    ts: new Date().toISOString(),
+    mono_ns: 1,
+    duration_ms: null,
+    outcome: "info",
+    edge_headers: {
+      "cf-ray": null,
+      "cf-mitigated": null,
+      "cf-cache-status": null,
+      "x-railway-edge": null,
+      "x-railway-request-id": null,
+      "x-hikari-trace": null,
+      "retry-after": null,
+      via: null,
+      server: null,
+    },
+    metadata: { agent_name: "default", model_id: "gpt-4" },
+  };
+}
+
+let pb: ChildProcess | undefined;
+let dataDir: string | undefined;
+
+const describeMaybe = PB_BIN ? describe : describe.skip;
+
+describeMaybe("CvdiagFetchPbWriter — live PocketBase, WRITER-role auth", () => {
+  beforeAll(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "pb-cvdiag-fetch-"));
+    const mig = spawnSync(
+      PB_BIN as string,
+      ["migrate", "up", `--dir=${dataDir}`, `--migrationsDir=${MIGRATIONS_DIR}`],
+      { encoding: "utf8" },
+    );
+    if (mig.status !== 0) {
+      throw new Error(`pb migrate up failed: ${mig.stderr || mig.stdout}`);
+    }
+    const admin = spawnSync(
+      PB_BIN as string,
+      ["admin", "create", ADMIN_EMAIL, ADMIN_PASS, `--dir=${dataDir}`],
+      { encoding: "utf8" },
+    );
+    if (admin.status !== 0) {
+      throw new Error(`pb admin create failed: ${admin.stderr || admin.stdout}`);
+    }
+    pb = spawn(
+      PB_BIN as string,
+      [
+        "serve",
+        `--http=127.0.0.1:${PORT}`,
+        `--dir=${dataDir}`,
+        `--migrationsDir=${MIGRATIONS_DIR}`,
+        `--hooksDir=${HOOKS_DIR}`,
+      ],
+      { stdio: "ignore" },
+    );
+    await waitForHealth();
+  }, 30_000);
+
+  afterAll(() => {
+    if (pb) pb.kill("SIGKILL");
+    if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("persists a batch to cvdiag_events authenticating as the writer role", async () => {
+    const writer = new CvdiagFetchPbWriter({
+      baseUrl: BASE,
+      writerKey: WRITER_PASSWORD,
+      writerIdentity: WRITER_IDENTITY,
+    });
+    const env = makeEnvelope("fetch-writer-green");
+    await writer.writeBatch([env]);
+    expect(await countRows(env.test_id)).toBe(1);
+  }, 30_000);
+
+  it("degrades to a no-op (never throws) on a WRONG writer key", async () => {
+    const writer = new CvdiagFetchPbWriter({
+      baseUrl: BASE,
+      writerKey: "wrong-password-xxxxxxxx",
+      writerIdentity: WRITER_IDENTITY,
+    });
+    const env = makeEnvelope("fetch-writer-badkey");
+    // Must resolve (never reject) — best-effort pure instrumentation.
+    await expect(writer.writeBatch([env])).resolves.toBeUndefined();
+    // And nothing persisted (auth failed → no Bearer token → bailed).
+    expect(await countRows(env.test_id)).toBe(0);
+  }, 30_000);
+
+  it("re-auths on a stale cached token and the row still lands", async () => {
+    const writer = new CvdiagFetchPbWriter({
+      baseUrl: BASE,
+      writerKey: WRITER_PASSWORD,
+      writerIdentity: WRITER_IDENTITY,
+    });
+    // Poison the cached token so the first CREATE is rejected (PB treats an
+    // unverifiable token as anonymous → createRule denies → 400, NOT 401), and
+    // the writer must re-auth + retry to recover.
+    (writer as unknown as { token: string | null }).token =
+      "stale.invalid.token";
+    const env = makeEnvelope("fetch-writer-reauth");
+    await writer.writeBatch([env]);
+    expect(await countRows(env.test_id)).toBe(1);
+  }, 30_000);
+
+  it("empty batch is a no-op (no auth attempt)", async () => {
+    const writer = new CvdiagFetchPbWriter({
+      baseUrl: BASE,
+      writerKey: WRITER_PASSWORD,
+      writerIdentity: WRITER_IDENTITY,
+    });
+    await expect(writer.writeBatch([])).resolves.toBeUndefined();
+  }, 30_000);
+});

--- a/showcase/harness/src/cvdiag/pb-writer-fetch.test.ts
+++ b/showcase/harness/src/cvdiag/pb-writer-fetch.test.ts
@@ -134,7 +134,12 @@ describeMaybe("CvdiagFetchPbWriter — live PocketBase, WRITER-role auth", () =>
     dataDir = mkdtempSync(join(tmpdir(), "pb-cvdiag-fetch-"));
     const mig = spawnSync(
       PB_BIN as string,
-      ["migrate", "up", `--dir=${dataDir}`, `--migrationsDir=${MIGRATIONS_DIR}`],
+      [
+        "migrate",
+        "up",
+        `--dir=${dataDir}`,
+        `--migrationsDir=${MIGRATIONS_DIR}`,
+      ],
       { encoding: "utf8" },
     );
     if (mig.status !== 0) {
@@ -146,7 +151,9 @@ describeMaybe("CvdiagFetchPbWriter — live PocketBase, WRITER-role auth", () =>
       { encoding: "utf8" },
     );
     if (admin.status !== 0) {
-      throw new Error(`pb admin create failed: ${admin.stderr || admin.stdout}`);
+      throw new Error(
+        `pb admin create failed: ${admin.stderr || admin.stdout}`,
+      );
     }
     pb = spawn(
       PB_BIN as string,

--- a/showcase/harness/src/cvdiag/pb-writer-fetch.ts
+++ b/showcase/harness/src/cvdiag/pb-writer-fetch.ts
@@ -134,7 +134,8 @@ export class CvdiagFetchPbWriter {
     this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
     this.writerKey = opts.writerKey;
     this.writerIdentity = opts.writerIdentity ?? DEFAULT_WRITER_IDENTITY;
-    this.fetchImpl = opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+    this.fetchImpl =
+      opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
     this.timeoutMs = opts.timeoutMs ?? 5000;
   }
 
@@ -239,7 +240,11 @@ export class CvdiagFetchPbWriter {
     }
     if (!res.ok) {
       const body = await safeText(res);
-      this.warn("auth", `auth failed status=${res.status} ${body}`, this.writerIdentity);
+      this.warn(
+        "auth",
+        `auth failed status=${res.status} ${body}`,
+        this.writerIdentity,
+      );
       return false;
     }
     // Read the FULL body — the auth token is ~600 chars, so the warn-path
@@ -259,7 +264,11 @@ export class CvdiagFetchPbWriter {
       return false;
     }
     if (typeof token !== "string" || token.length === 0) {
-      this.warn("auth", "auth returned empty/non-string token", this.writerIdentity);
+      this.warn(
+        "auth",
+        "auth returned empty/non-string token",
+        this.writerIdentity,
+      );
       return false;
     }
     this.token = token;
@@ -280,8 +289,7 @@ export class CvdiagFetchPbWriter {
       "content-type": "application/json",
     };
     if (bearer !== undefined) headers["authorization"] = `Bearer ${bearer}`;
-    const controller =
-      this.timeoutMs > 0 ? new AbortController() : undefined;
+    const controller = this.timeoutMs > 0 ? new AbortController() : undefined;
     const timer =
       controller !== undefined
         ? setTimeout(() => controller.abort(), this.timeoutMs)

--- a/showcase/harness/src/cvdiag/pb-writer-fetch.ts
+++ b/showcase/harness/src/cvdiag/pb-writer-fetch.ts
@@ -1,0 +1,357 @@
+/**
+ * pb-writer-fetch.ts — the CONCRETE `CvdiagPbWriter` for the TS INTEGRATION
+ * backends (plan unit L1-E wiring). This is the writer that actually persists
+ * `CvdiagEmitter.flush()` batches into the `cvdiag_events` PocketBase
+ * collection from inside a deployed Next.js route handler.
+ *
+ * WHY a second writer (and not harness/src/cvdiag/pb-writer.ts): that writer is
+ * HARNESS/probe-side — it wraps the harness `PbClient` and authenticates as a
+ * SUPERUSER (storage/pb-client.ts `/api/collections/_superusers/auth-with-
+ * password`). Superuser auth is BOTH wrong for an integration (an integration
+ * must never hold superuser credentials) AND unbundlable: `PbClient` drags the
+ * harness storage/logging tree, which has no resolution inside a standalone
+ * integration's Next.js build context (the `bin/showcase cvdiag-stage-ts` COPY
+ * staging only ships the leaf cvdiag sources). The result of that mismatch was
+ * the production defect this module fixes: `withCvdiagBackend` constructed a
+ * `CvdiagEmitter` with NO `pbWriter`, so `flush()` was a permanent no-op and
+ * ZERO backend telemetry ever persisted.
+ *
+ * CONTRACT (flap-observability spec §4 three-key ACL): authenticate as the
+ * `cvdiag_api_keys` record with role `writer` (NOT superuser). The
+ * `cvdiag_events` createRule requires exactly that
+ * (`@request.auth.collectionName = "cvdiag_api_keys" && @request.auth.role =
+ * "writer"`). This writer:
+ *   1. POSTs `/api/collections/cvdiag_api_keys/auth-with-password` with
+ *      `{ identity: CVDIAG_WRITER_IDENTITY, password: CVDIAG_WRITER_KEY }` →
+ *      a Bearer token.
+ *   2. POSTs each event to `/api/collections/cvdiag_events/records` with
+ *      `Authorization: Bearer <token>`.
+ *   3. Caches the token and RE-AUTHs once on a 401 (token expiry / rotation).
+ *
+ * Implemented with plain `fetch` ONLY — the pocketbase SDK is deliberately NOT
+ * pulled in, because it does not bundle cleanly into the integrations'
+ * standalone `next build` (this is the exact build surface that bit the seam
+ * before). `fetch` is global in Node 18+ and in the Next.js runtime.
+ *
+ * BEST-EFFORT / NEVER-THROW: this mirrors the emitter's pure-instrumentation
+ * contract (emit.ts §7 R5-F8) and `pb-writer.ts`. Every failure — an auth
+ * rejection, a wrong key, a PB hiccup, an ACL 403, a network error — is
+ * SWALLOWED and surfaced as a single `CVDIAG`-tagged `console.warn`. The
+ * `writeBatch` promise RESOLVES whether every, some, or no rows persisted; it
+ * NEVER rejects into `CvdiagEmitter.flush()` (which itself swallows). A CVDIAG
+ * write failure must NEVER block, throw into, or false-red the boundary it
+ * observes.
+ */
+
+import type { CvdiagEnvelope } from "./schema.js";
+
+/** The `cvdiag_events` collection name (mirrors migration 1779990200). */
+const CVDIAG_EVENTS_COLLECTION = "cvdiag_events";
+/** The auth collection holding the role-keyed identities (migration 1779990200). */
+const CVDIAG_API_KEYS_COLLECTION = "cvdiag_api_keys";
+/**
+ * Default writer identity seeded by the migration. The PASSWORD is supplied via
+ * `CVDIAG_WRITER_KEY` (never defaulted — a missing key means "no writer wired").
+ * The identity rarely changes, so it defaults to the seeded value but can be
+ * overridden via `CVDIAG_WRITER_IDENTITY` for a rotated/renamed record.
+ */
+const DEFAULT_WRITER_IDENTITY = "cvdiag-writer@keys.local";
+
+/** Minimal `fetch` shape (injectable for tests; defaults to the global). */
+export type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+}>;
+
+export interface CvdiagFetchPbWriterOptions {
+  /** PocketBase base URL, e.g. `https://pb.internal` (no trailing slash). */
+  baseUrl: string;
+  /** Writer-role password (`CVDIAG_WRITER_KEY`). Required. */
+  writerKey: string;
+  /** Writer-role identity; defaults to the migration-seeded value. */
+  writerIdentity?: string;
+  /** Injected fetch (tests); defaults to the global `fetch`. */
+  fetchImpl?: FetchLike;
+  /** Per-request timeout in ms (default 5000). 0/undefined disables it. */
+  timeoutMs?: number;
+}
+
+/**
+ * Build the canonical `cvdiag_events` row from a `CvdiagEnvelope`. The envelope
+ * and the PB row share the same 15 persisted fields; the two optional
+ * diagnostic flags (`_metadata_dropped`, `_truncated`) are NOT columns, so —
+ * mirroring `pb-writer.ts` `toEventRecord` — they are folded into the
+ * `metadata` JSON bag (when set) so they stay queryable. A fresh `metadata`
+ * object is built so the caller's envelope is never mutated.
+ */
+function toEventRecord(envelope: CvdiagEnvelope): Record<string, unknown> {
+  const metadata: Record<string, unknown> = { ...envelope.metadata };
+  if (envelope._metadata_dropped) metadata._metadata_dropped = true;
+  if (envelope._truncated) metadata._truncated = true;
+  return {
+    schema_version: envelope.schema_version,
+    test_id: envelope.test_id,
+    trace_id: envelope.trace_id,
+    span_id: envelope.span_id,
+    parent_span_id: envelope.parent_span_id,
+    layer: envelope.layer,
+    boundary: envelope.boundary,
+    slug: envelope.slug,
+    demo: envelope.demo,
+    ts: envelope.ts,
+    mono_ns: envelope.mono_ns,
+    duration_ms: envelope.duration_ms,
+    outcome: envelope.outcome,
+    edge_headers: { ...envelope.edge_headers },
+    metadata,
+  };
+}
+
+/**
+ * A concrete, plain-`fetch`, WRITER-ROLE PB writer satisfying the emitter's
+ * `CvdiagPbWriter` seam (`writeBatch(events) => Promise<void>`, never rejects).
+ */
+export class CvdiagFetchPbWriter {
+  private readonly baseUrl: string;
+  private readonly writerKey: string;
+  private readonly writerIdentity: string;
+  private readonly fetchImpl: FetchLike;
+  private readonly timeoutMs: number;
+  /** Cached Bearer token; null until first auth (or after a 401 reset). */
+  private token: string | null = null;
+
+  constructor(opts: CvdiagFetchPbWriterOptions) {
+    // Strip a trailing slash so URL joins are unambiguous.
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
+    this.writerKey = opts.writerKey;
+    this.writerIdentity = opts.writerIdentity ?? DEFAULT_WRITER_IDENTITY;
+    this.fetchImpl = opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+    this.timeoutMs = opts.timeoutMs ?? 5000;
+  }
+
+  /**
+   * Persist a batch of envelopes, CREATE-only, best-effort. Auths lazily on the
+   * first event, re-auths once on a per-event 401, and NEVER rejects. A
+   * per-event failure degrades to a `CVDIAG`-tagged warn; the batch is never
+   * aborted on one bad row.
+   */
+  async writeBatch(events: CvdiagEnvelope[]): Promise<void> {
+    if (events.length === 0) return;
+    // Authenticate once up front. If auth fails, every event below would 401 —
+    // so warn once and bail rather than spamming a warn per event.
+    if (this.token === null) {
+      const ok = await this.ensureAuth();
+      if (!ok) return;
+    }
+    for (const envelope of events) {
+      try {
+        await this.createOne(toEventRecord(envelope), envelope);
+      } catch (err) {
+        // `createOne` is itself never-throw; this guard covers a mapping throw
+        // on a malformed envelope so one bad row can't abort the rest.
+        this.warn(envelope.boundary, String(err), envelope.test_id);
+      }
+    }
+  }
+
+  /**
+   * CREATE one row. We always hold a cached token here (writeBatch auths up
+   * front). On ANY non-ok status with a cached token we re-auth ONCE and retry
+   * the same row, because an expired/rotated/invalid PB auth-record token does
+   * NOT surface as a clean 401 on this CREATE path — PocketBase silently treats
+   * an unverifiable token as ANONYMOUS, and the `cvdiag_events` createRule
+   * (writer-role required) then rejects the anonymous request as 400 (verified
+   * against PB 0.22.21). So keying the re-auth on 401 alone would never recover
+   * a stale token. A genuine bad-row 400 simply retries once (harmless, fails
+   * again, warns once). Never throws.
+   */
+  private async createOne(
+    record: Record<string, unknown>,
+    envelope: CvdiagEnvelope,
+  ): Promise<void> {
+    const url = `${this.baseUrl}/api/collections/${CVDIAG_EVENTS_COLLECTION}/records`;
+    const body = JSON.stringify(record);
+
+    const res = await this.post(url, body, this.token ?? undefined);
+    if (res === null) {
+      this.warn(envelope.boundary, "transport error", envelope.test_id);
+      return;
+    }
+    if (res.ok) return;
+
+    // Non-ok with a cached token → assume the token is stale/invalid (PB hides
+    // auth expiry behind a createRule-anonymous 400). Re-auth ONCE and retry.
+    this.token = null;
+    const ok = await this.ensureAuth();
+    if (!ok) {
+      this.warn(
+        envelope.boundary,
+        `create failed status=${res.status} (re-auth failed)`,
+        envelope.test_id,
+      );
+      return;
+    }
+    const retry = await this.post(url, body, this.token ?? undefined);
+    if (retry !== null && retry.ok) return;
+    if (retry === null) {
+      this.warn(
+        envelope.boundary,
+        "create failed after re-auth: transport error",
+        envelope.test_id,
+      );
+      return;
+    }
+    const retryBody = await safeText(retry);
+    this.warn(
+      envelope.boundary,
+      `create failed after re-auth status=${retry.status} ${retryBody}`,
+      envelope.test_id,
+    );
+  }
+
+  /**
+   * Auth-with-password as the WRITER ROLE against the `cvdiag_api_keys` auth
+   * collection. Caches the Bearer token on success; returns false (warns) on
+   * any failure. Never throws.
+   */
+  private async ensureAuth(): Promise<boolean> {
+    if (this.token !== null) return true;
+    const res = await this.post(
+      `${this.baseUrl}/api/collections/${CVDIAG_API_KEYS_COLLECTION}/auth-with-password`,
+      JSON.stringify({
+        identity: this.writerIdentity,
+        password: this.writerKey,
+      }),
+      undefined,
+    );
+    if (res === null) {
+      this.warn("auth", "transport error", this.writerIdentity);
+      return false;
+    }
+    if (!res.ok) {
+      const body = await safeText(res);
+      this.warn("auth", `auth failed status=${res.status} ${body}`, this.writerIdentity);
+      return false;
+    }
+    // Read the FULL body — the auth token is ~600 chars, so the warn-path
+    // `safeText` (which 256-char clamps) would corrupt valid JSON.
+    let text: string;
+    try {
+      text = await res.text();
+    } catch {
+      this.warn("auth", "auth body read failed", this.writerIdentity);
+      return false;
+    }
+    let token: unknown;
+    try {
+      token = (JSON.parse(text) as { token?: unknown }).token;
+    } catch {
+      this.warn("auth", "auth response was not JSON", this.writerIdentity);
+      return false;
+    }
+    if (typeof token !== "string" || token.length === 0) {
+      this.warn("auth", "auth returned empty/non-string token", this.writerIdentity);
+      return false;
+    }
+    this.token = token;
+    return true;
+  }
+
+  /**
+   * POST helper. Returns the response, or null on a transport/abort error (so
+   * callers branch on a single null sentinel + an HTTP status). Applies an
+   * optional per-request timeout via AbortController. Never throws.
+   */
+  private async post(
+    url: string,
+    body: string,
+    bearer: string | undefined,
+  ): Promise<{ ok: boolean; status: number; text(): Promise<string> } | null> {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+    };
+    if (bearer !== undefined) headers["authorization"] = `Bearer ${bearer}`;
+    const controller =
+      this.timeoutMs > 0 ? new AbortController() : undefined;
+    const timer =
+      controller !== undefined
+        ? setTimeout(() => controller.abort(), this.timeoutMs)
+        : undefined;
+    try {
+      return await this.fetchImpl(url, {
+        method: "POST",
+        headers,
+        body,
+        signal: controller?.signal,
+      });
+    } catch {
+      return null;
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+
+  /** Single CVDIAG-tagged warn for any swallowed failure (greppable anchor). */
+  private warn(boundary: string, error: string, testId: string): void {
+    console.warn(
+      `CVDIAG pb-writer-fetch write failed test_id=${testId} ` +
+        `boundary=${boundary} error=${error}`,
+    );
+  }
+}
+
+/**
+ * Construct a `CvdiagFetchPbWriter` from the environment, or return `undefined`
+ * when CVDIAG PB persistence is NOT configured. The wiring contract for
+ * `withCvdiagBackend`: build + inject the writer ONLY when `CVDIAG_PB_URL` is
+ * set (and a `CVDIAG_WRITER_KEY` is present). When `CVDIAG_PB_URL` is absent the
+ * emitter is left with NO `pbWriter` — exactly the current stdout-only behavior
+ * — so a deployment without a PocketBase target is unchanged. Never throws.
+ */
+export function createCvdiagFetchPbWriterFromEnv(
+  env: Record<string, string | undefined> = process.env as Record<
+    string,
+    string | undefined
+  >,
+): CvdiagFetchPbWriter | undefined {
+  const baseUrl = env.CVDIAG_PB_URL?.trim();
+  if (baseUrl === undefined || baseUrl === "") return undefined;
+  const writerKey = env.CVDIAG_WRITER_KEY?.trim();
+  if (writerKey === undefined || writerKey === "") {
+    // PB URL set but no writer key → cannot authenticate. Warn once and leave
+    // the emitter writer-less (stdout-only) rather than injecting a writer that
+    // 401-drops every event.
+    console.warn(
+      "CVDIAG pb-writer-fetch: CVDIAG_PB_URL is set but CVDIAG_WRITER_KEY is " +
+        "empty/unset — no PB writer wired (events stay stdout-only).",
+    );
+    return undefined;
+  }
+  const writerIdentity = env.CVDIAG_WRITER_IDENTITY?.trim();
+  return new CvdiagFetchPbWriter({
+    baseUrl,
+    writerKey,
+    writerIdentity:
+      writerIdentity !== undefined && writerIdentity !== ""
+        ? writerIdentity
+        : undefined,
+  });
+}
+
+/** Read a Response body without throwing (used in warn paths). */
+async function safeText(res: { text(): Promise<string> }): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 256);
+  } catch {
+    return "";
+  }
+}

--- a/showcase/integrations/_shared/cvdiag_pb_writer.py
+++ b/showcase/integrations/_shared/cvdiag_pb_writer.py
@@ -11,6 +11,22 @@ Contract (spec §7 — pure instrumentation, never blocks the observed boundary)
     returns immediately; nothing is flushed). This keeps local/unit runs free
     of network side effects.
 
+Authentication (see the 1779990200_create_cvdiag_events.js migration):
+  The ``cvdiag_events`` createRule requires the caller to authenticate as a
+  ``cvdiag_api_keys`` auth record whose ``role`` is ``"writer"`` —
+
+    @request.auth.collectionName = "cvdiag_api_keys" && @request.auth.role = "writer"
+
+  PocketBase has NO notion of a bespoke header, so a header-only request is
+  UNAUTHENTICATED and the CREATE 4xxs (the createRule evaluates false). The
+  writer therefore POSTs ``/api/collections/cvdiag_api_keys/auth-with-password``
+  with the fixed writer identity (``cvdiag-writer@keys.local`` — overridable via
+  ``CVDIAG_WRITER_IDENTITY``) and ``CVDIAG_WRITER_KEY`` as the PASSWORD, caches
+  the returned token, and sends ``Authorization: Bearer <token>`` on the CREATE.
+  A 401 (token expiry / bad creds) clears the cached token and triggers a single
+  re-auth + retry. Auth failure stays best-effort: it degrades to a no-op + the
+  one-shot ``CVDIAG pb-write-failed`` warn — it NEVER crashes the daemon.
+
 Plan unit: L0-C.
 """
 
@@ -21,6 +37,7 @@ import logging
 import os
 import queue
 import threading
+import urllib.error
 import urllib.request
 from typing import Any, Optional
 
@@ -32,6 +49,12 @@ FLUSH_WINDOW_S = 1.0
 QUEUE_CAP = 5000
 # Per-flush HTTP timeout so a hung PB never wedges the worker thread.
 HTTP_TIMEOUT_S = 5.0
+# Auth collection + fixed default identity of the seeded writer record. The
+# migration seeds email ``cvdiag-writer@keys.local`` with role ``writer``;
+# CVDIAG_WRITER_KEY is that record's PASSWORD. The identity is overridable for
+# environments that rotate the writer email, but defaults to the seeded value.
+WRITER_AUTH_COLLECTION = "cvdiag_api_keys"
+DEFAULT_WRITER_IDENTITY = "cvdiag-writer@keys.local"
 
 
 class CvdiagPbWriter:
@@ -45,6 +68,7 @@ class CvdiagPbWriter:
         pb_url: Optional[str] = None,
         writer_key: Optional[str] = None,
         *,
+        writer_identity: Optional[str] = None,
         flush_window_s: float = FLUSH_WINDOW_S,
     ) -> None:
         self._pb_url = pb_url if pb_url is not None else os.environ.get("CVDIAG_PB_URL")
@@ -53,12 +77,21 @@ class CvdiagPbWriter:
             if writer_key is not None
             else os.environ.get("CVDIAG_WRITER_KEY")
         )
+        self._writer_identity = (
+            writer_identity
+            if writer_identity is not None
+            else os.environ.get("CVDIAG_WRITER_IDENTITY", DEFAULT_WRITER_IDENTITY)
+        )
         self._flush_window_s = flush_window_s
         self._queue: "queue.Queue[dict[str, Any]]" = queue.Queue(maxsize=QUEUE_CAP)
         self._logged_failure = False
         self._started = False
         self._lock = threading.Lock()
         self._worker: Optional[threading.Thread] = None
+        # Cached auth-with-password token. Only the single daemon worker thread
+        # touches this (auth + CREATE both run inside ``_run``), so no lock is
+        # needed. ``None`` means "not authenticated yet / cleared after a 401".
+        self._auth_token: Optional[str] = None
 
     @property
     def enabled(self) -> bool:
@@ -125,29 +158,88 @@ class CvdiagPbWriter:
                 except Exception as err:  # noqa: BLE001 - daemon must survive
                     self._log_failure(err)
 
+    def _authenticate(self) -> Optional[str]:
+        """Auth-with-password as the writer role; return + cache the token.
+
+        Returns the cached token if present, else POSTs the writer identity +
+        ``CVDIAG_WRITER_KEY`` (the writer record PASSWORD) to the
+        ``cvdiag_api_keys`` auth-with-password endpoint and caches the token.
+        Returns ``None`` on any failure (bad creds, unreachable PB, malformed
+        response) — the caller degrades to a no-op. NEVER raises.
+        """
+        if self._auth_token:
+            return self._auth_token
+        url = self._pb_url
+        if not url or not self._writer_key:
+            return None
+        endpoint = (
+            url.rstrip("/")
+            + f"/api/collections/{WRITER_AUTH_COLLECTION}/auth-with-password"
+        )
+        body = json.dumps(
+            {"identity": self._writer_identity, "password": self._writer_key}
+        ).encode("utf-8")
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+        token = payload.get("token")
+        if not token:
+            return None
+        self._auth_token = token
+        return token
+
     def _post(self, envelope: dict[str, Any]) -> None:
         url = self._pb_url
         if not url:
             return
         endpoint = url.rstrip("/") + "/api/collections/cvdiag_events/records"
         # Never-propagate: a single bad record (e.g. a non-JSON-serializable
-        # envelope that makes ``json.dumps`` raise ``TypeError``) must be
-        # logged/dropped, NOT allowed to escape and kill the drain daemon.
-        # This mirrors the TS pb-writer ``writeBatch`` contract — one bad row
-        # degrades to a warn; the batch (and the worker) survives.
+        # envelope that makes ``json.dumps`` raise ``TypeError``) or an auth
+        # failure must be logged/dropped, NOT allowed to escape and kill the
+        # drain daemon. This mirrors the TS pb-writer ``writeBatch`` contract —
+        # one bad row / a failed auth degrades to a warn; the worker survives.
         try:
             body = json.dumps(envelope).encode("utf-8")
-            req = urllib.request.Request(
-                endpoint,
-                data=body,
-                method="POST",
-                headers={"Content-Type": "application/json"},
-            )
-            if self._writer_key:
-                req.add_header("X-Cvdiag-Writer-Key", self._writer_key)
-            urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S).close()
+            # Authenticate as the writer-role record (createRule requires it).
+            # On a 401 (token expiry / stale token) clear the cache and re-auth
+            # once before giving up — but never loop.
+            self._create_with_auth(endpoint, body, allow_reauth=True)
         except Exception as err:  # noqa: BLE001 - instrumentation must never throw
             self._log_failure(err)
+
+    def _create_with_auth(
+        self, endpoint: str, body: bytes, *, allow_reauth: bool
+    ) -> None:
+        """POST the CREATE with a Bearer token; re-auth once on a 401."""
+        token = self._authenticate()
+        if not token:
+            # Auth failed (bad/missing writer key, unreachable PB). Degrade to a
+            # no-op + the one-shot warn — never crash the daemon.
+            self._log_failure(RuntimeError("CVDIAG writer auth failed"))
+            return
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {token}",
+            },
+        )
+        try:
+            urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S).close()
+        except urllib.error.HTTPError as err:
+            # 401 → token expired / revoked. Clear the cache and re-auth ONCE.
+            if err.code == 401 and allow_reauth:
+                self._auth_token = None
+                self._create_with_auth(endpoint, body, allow_reauth=False)
+                return
+            raise
 
     def _log_failure(self, err: Exception) -> None:
         # Log the first failure at WARNING; subsequent ones at DEBUG to avoid

--- a/showcase/integrations/_shared/tests/test_cvdiag_writer_live_pb.py
+++ b/showcase/integrations/_shared/tests/test_cvdiag_writer_live_pb.py
@@ -1,0 +1,244 @@
+"""test_cvdiag_writer_live_pb.py — live-PocketBase auth proof for the Python
+CVDIAG PB writer.
+
+Boots an ACTUAL PocketBase 0.22 server using the EXACT production migrations
+(showcase/pocketbase/pb_migrations), which create ``cvdiag_events`` + the
+``cvdiag_api_keys`` auth collection + the seeded role-keyed records (writer /
+purge / migration). It then drives the real ``CvdiagPbWriter`` against that
+server and asserts the CREATE-only ACL is satisfied **as the writer role**.
+
+WHY WRITER-ROLE (not superuser): the PB superuser bypasses ALL collection
+rules, so a writer that never authenticates would still "succeed" if probed as
+a superuser — that is exactly how the original defect (the inert
+``X-Cvdiag-Writer-Key`` header) escaped review. The createRule
+
+    @request.auth.collectionName = "cvdiag_api_keys" && @request.auth.role = "writer"
+
+is only satisfiable by authenticating as the seeded writer record and sending
+``Authorization: Bearer <token>``. We therefore drive the writer with the
+writer record's PASSWORD as ``CVDIAG_WRITER_KEY`` and verify the row lands by
+querying ``cvdiag_events`` AS THE SUPERUSER (read-only, rule-bypassing) — the
+write path under test is never superuser.
+
+Requires a ``pocketbase`` binary: set ``POCKETBASE_BIN`` to its path, put it on
+PATH, or drop it at ``/tmp/pb022/pocketbase``. The suite SKIPS (does not fail)
+when no binary is available so CI without the binary stays green.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from _shared.cvdiag_pb_writer import CvdiagPbWriter
+
+# These mirror the seed records created by the cvdiag_api_keys migration
+# (showcase/pocketbase/pb_migrations/1779990200_create_cvdiag_events.js).
+WRITER_EMAIL = "cvdiag-writer@keys.local"
+WRITER_PASS = "cvdiagwriterpass123"
+
+# A superuser used ONLY to read rows back (rule-bypassing read); never the
+# write path under test.
+ADMIN_EMAIL = "cvdiag-py-acl@test.local"
+ADMIN_PASS = "cvdiagpyaclpass123"
+
+# showcase/integrations/_shared/tests/ → repo root → showcase/pocketbase
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_MIGRATIONS_DIR = _REPO_ROOT / "showcase" / "pocketbase" / "pb_migrations"
+
+
+def _resolve_pb_binary() -> Optional[str]:
+    explicit = os.environ.get("POCKETBASE_BIN")
+    if explicit and Path(explicit).is_file():
+        return explicit
+    on_path = shutil.which("pocketbase")
+    if on_path:
+        return on_path
+    if Path("/tmp/pb022/pocketbase").is_file():
+        return "/tmp/pb022/pocketbase"
+    return None
+
+
+_PB_BIN = _resolve_pb_binary()
+
+pytestmark = pytest.mark.skipif(
+    _PB_BIN is None,
+    reason="no pocketbase binary (set POCKETBASE_BIN, PATH, or /tmp/pb022/pocketbase)",
+)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_health(base: str, timeout_s: float = 15.0) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(f"{base}/api/health", timeout=1.0) as r:
+                if r.status == 200:
+                    return
+        except (urllib.error.URLError, OSError):
+            pass
+        time.sleep(0.2)
+    raise RuntimeError("PocketBase did not become healthy in time")
+
+
+def _admin_token(base: str) -> str:
+    body = json.dumps({"identity": ADMIN_EMAIL, "password": ADMIN_PASS}).encode()
+    req = urllib.request.Request(
+        f"{base}/api/admins/auth-with-password",
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=5.0) as r:
+        return json.loads(r.read())["token"]
+
+
+def _count_events(base: str, test_id: str) -> int:
+    """Count cvdiag_events rows for one test_id, reading AS SUPERUSER."""
+    tok = _admin_token(base)
+    flt = urllib.parse.quote(f'test_id="{test_id}"')
+    req = urllib.request.Request(
+        f"{base}/api/collections/cvdiag_events/records?filter={flt}",
+        headers={"Authorization": tok},
+    )
+    with urllib.request.urlopen(req, timeout=5.0) as r:
+        return json.loads(r.read())["totalItems"]
+
+
+@pytest.fixture(scope="module")
+def live_pb():
+    """Boot a real PB with the production migrations; yield its base URL."""
+    data_dir = tempfile.mkdtemp(prefix="pb-cvdiag-py-")
+    try:
+        mig = subprocess.run(
+            [
+                _PB_BIN,
+                "migrate",
+                "up",
+                f"--dir={data_dir}",
+                f"--migrationsDir={_MIGRATIONS_DIR}",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if mig.returncode != 0:
+            raise RuntimeError(f"pb migrate up failed: {mig.stderr or mig.stdout}")
+        admin = subprocess.run(
+            [_PB_BIN, "admin", "create", ADMIN_EMAIL, ADMIN_PASS, f"--dir={data_dir}"],
+            capture_output=True,
+            text=True,
+        )
+        if admin.returncode != 0:
+            raise RuntimeError(
+                f"pb admin create failed: {admin.stderr or admin.stdout}"
+            )
+        port = _free_port()
+        base = f"http://127.0.0.1:{port}"
+        proc = subprocess.Popen(
+            [
+                _PB_BIN,
+                "serve",
+                f"--http=127.0.0.1:{port}",
+                f"--dir={data_dir}",
+                f"--migrationsDir={_MIGRATIONS_DIR}",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        try:
+            _wait_for_health(base)
+            yield base
+        finally:
+            proc.kill()
+            proc.wait(timeout=5)
+    finally:
+        shutil.rmtree(data_dir, ignore_errors=True)
+
+
+def _flush_one(writer: CvdiagPbWriter, envelope: dict) -> None:
+    """Enqueue one envelope and let the daemon drain it (flush window 0.05s)."""
+    writer.enqueue(envelope)
+    # Give the worker a few flush windows to drain + POST + (re-)auth.
+    time.sleep(1.0)
+
+
+def _event(test_id: str) -> dict:
+    return {
+        "schema_version": 1,
+        "test_id": test_id,
+        "trace_id": test_id,
+        "span_id": "0000000000000001",
+        "parent_span_id": None,
+        "layer": "backend",
+        "boundary": "backend.handle",
+        "slug": "langgraph-python",
+        "demo": "chat",
+        "ts": "2026-06-18T00:00:00.000Z",
+        "mono_ns": 1,
+        "duration_ms": None,
+        "outcome": "ok",
+        "edge_headers": {},
+        "metadata": {"src": "live-pb-test"},
+    }
+
+
+def test_writer_authenticates_as_writer_role_and_persists(live_pb):
+    """GREEN: the writer auth-with-passwords as the writer role → CREATE 201 →
+    the row is present in cvdiag_events (read back as superuser).
+
+    This is the fix for the inert ``X-Cvdiag-Writer-Key`` header: without
+    auth-with-password → Bearer the CREATE 403s under the writer createRule.
+    """
+    test_id = "0190a0c0-0000-7000-8000-00000000a001"
+    # Pre-condition: no row yet.
+    assert _count_events(live_pb, test_id) == 0
+
+    writer = CvdiagPbWriter(
+        pb_url=live_pb,
+        writer_key=WRITER_PASS,  # CVDIAG_WRITER_KEY == the writer record password
+        flush_window_s=0.05,
+    )
+    _flush_one(writer, _event(test_id))
+
+    # The CREATE went through the CREATE-only writer rule → row present.
+    assert _count_events(live_pb, test_id) == 1
+
+
+def test_writer_with_wrong_password_degrades_to_noop(live_pb):
+    """A WRONG password must degrade to a no-op (auth fails, CREATE 401/403)
+    WITHOUT crashing the daemon — never-throw preserved.
+    """
+    test_id = "0190a0c0-0000-7000-8000-00000000a002"
+    assert _count_events(live_pb, test_id) == 0
+
+    writer = CvdiagPbWriter(
+        pb_url=live_pb,
+        writer_key="totally-wrong-password",
+        flush_window_s=0.05,
+    )
+    _flush_one(writer, _event(test_id))
+
+    # No row landed (auth failed) AND the daemon survived (no crash).
+    assert _count_events(live_pb, test_id) == 0
+    worker = writer._worker
+    assert worker is not None and worker.is_alive(), (
+        "daemon must survive an auth failure (never-throw)"
+    )

--- a/showcase/integrations/_shared/tests/test_cvdiag_writer_live_pb.py
+++ b/showcase/integrations/_shared/tests/test_cvdiag_writer_live_pb.py
@@ -125,11 +125,15 @@ def _count_events(base: str, test_id: str) -> int:
 @pytest.fixture(scope="module")
 def live_pb():
     """Boot a real PB with the production migrations; yield its base URL."""
+    # skipif(_PB_BIN is None) guarantees a binary at runtime; narrow to a
+    # concrete str so subprocess calls don't take a `str | None` arg.
+    pb_bin = _PB_BIN
+    assert pb_bin is not None
     data_dir = tempfile.mkdtemp(prefix="pb-cvdiag-py-")
     try:
         mig = subprocess.run(
             [
-                _PB_BIN,
+                pb_bin,
                 "migrate",
                 "up",
                 f"--dir={data_dir}",
@@ -141,7 +145,7 @@ def live_pb():
         if mig.returncode != 0:
             raise RuntimeError(f"pb migrate up failed: {mig.stderr or mig.stdout}")
         admin = subprocess.run(
-            [_PB_BIN, "admin", "create", ADMIN_EMAIL, ADMIN_PASS, f"--dir={data_dir}"],
+            [pb_bin, "admin", "create", ADMIN_EMAIL, ADMIN_PASS, f"--dir={data_dir}"],
             capture_output=True,
             text=True,
         )
@@ -153,7 +157,7 @@ def live_pb():
         base = f"http://127.0.0.1:{port}"
         proc = subprocess.Popen(
             [
-                _PB_BIN,
+                pb_bin,
                 "serve",
                 f"--http=127.0.0.1:{port}",
                 f"--dir={data_dir}",

--- a/showcase/integrations/_shared/ts/cvdiag-emitter.ts
+++ b/showcase/integrations/_shared/ts/cvdiag-emitter.ts
@@ -127,3 +127,14 @@ export type {
   CvdiagEmitterOptions,
   CvdiagEmitArgs,
 } from "../../../harness/src/cvdiag/emit.js";
+
+// ── Concrete writer-role PB writer (plain fetch; auth-with-password→Bearer) ──
+export {
+  CvdiagFetchPbWriter,
+  createCvdiagFetchPbWriterFromEnv,
+} from "../../../harness/src/cvdiag/pb-writer-fetch.js";
+
+export type {
+  FetchLike,
+  CvdiagFetchPbWriterOptions,
+} from "../../../harness/src/cvdiag/pb-writer-fetch.js";

--- a/showcase/integrations/built-in-agent/src/cvdiag-backend-persist.e2e.test.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag-backend-persist.e2e.test.ts
@@ -1,0 +1,259 @@
+/**
+ * cvdiag-backend-persist.e2e.test.ts — feature-level RED→GREEN for the
+ * production defect: the TS integration backends never persist telemetry
+ * because `withCvdiagBackend` constructs a `CvdiagEmitter` with NO concrete
+ * `pbWriter`, so flush is a no-op and zero rows ever land in `cvdiag_events`.
+ *
+ * This drives the REAL public `withCvdiagBackend` wrapper against a LIVE
+ * PocketBase, authenticating as the WRITER ROLE (`cvdiag_api_keys`, role
+ * `writer`) — NOT a superuser — exactly as a deployed integration would. The
+ * superuser token is used ONLY for the read-back assertion (the collection's
+ * list/view rules are superuser-only by design).
+ *
+ * RED (pre-fix): with `CVDIAG_PB_URL` set but no concrete writer wired into
+ * `withCvdiagBackend`, the emitter's `pbWriter` is undefined → flush no-ops →
+ * cvdiag_events has ZERO rows for the request's test_id.
+ *
+ * GREEN (post-fix): `withCvdiagBackend` constructs the concrete writer-role PB
+ * writer when `CVDIAG_PB_URL` is set, auth-with-passwords as `writer`, and the
+ * backend boundaries persist. A WRONG `CVDIAG_WRITER_KEY` degrades to a no-op
+ * (best-effort, never-throw) — the request still succeeds, zero rows land.
+ *
+ * Requires a `pocketbase` binary (POCKETBASE_BIN, or on PATH, or
+ * /tmp/pb022/pocketbase). SKIPS when absent so CI without the binary stays
+ * green.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { withCvdiagBackend } from "@/cvdiag-backend";
+
+const PB_BIN = resolvePbBinary();
+const PORT = 8097;
+const BASE = `http://127.0.0.1:${PORT}`;
+const ADMIN_EMAIL = "cvdiag-bia-e2e@test.local";
+const ADMIN_PASS = "cvdiagbiae2epass123";
+
+// Seeded by migration 1779990200: a `cvdiag_api_keys` record with role
+// `writer`. These NON-SECRET bootstrap defaults are what a deployed
+// integration authenticates as (NOT a superuser).
+const WRITER_IDENTITY = "cvdiag-writer@keys.local";
+const WRITER_PASSWORD = "cvdiagwriterpass123";
+
+// harness/pocketbase holds the canonical migrations (the integration build
+// context has none of its own); resolve them off the monorepo root.
+const REPO_PB_DIR = resolve(__dirname, "../../../pocketbase");
+const MIGRATIONS_DIR = join(REPO_PB_DIR, "pb_migrations");
+const HOOKS_DIR = join(REPO_PB_DIR, "pb_hooks");
+
+function resolvePbBinary(): string | null {
+  const explicit = process.env.POCKETBASE_BIN;
+  if (explicit && existsSync(explicit)) return explicit;
+  const probe = spawnSync("which", ["pocketbase"], { encoding: "utf8" });
+  if (probe.status === 0 && probe.stdout.trim()) return probe.stdout.trim();
+  if (existsSync("/tmp/pb022/pocketbase")) return "/tmp/pb022/pocketbase";
+  return null;
+}
+
+async function waitForHealth(timeoutMs = 15_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const r = await fetch(`${BASE}/api/health`);
+      if (r.ok) return;
+    } catch {
+      /* not up yet */
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error("PocketBase did not become healthy in time");
+}
+
+async function adminToken(): Promise<string> {
+  const r = await fetch(`${BASE}/api/admins/auth-with-password`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ identity: ADMIN_EMAIL, password: ADMIN_PASS }),
+  });
+  if (!r.ok) throw new Error(`admin auth: ${r.status} ${await r.text()}`);
+  const body = (await r.json()) as { token: string };
+  return body.token;
+}
+
+async function countRows(testId: string): Promise<number> {
+  const tok = await adminToken();
+  const list = await fetch(
+    `${BASE}/api/collections/cvdiag_events/records?filter=${encodeURIComponent(
+      `test_id="${testId}"`,
+    )}`,
+    { headers: { authorization: tok } },
+  );
+  const body = (await list.json()) as { totalItems: number };
+  return body.totalItems;
+}
+
+/** A streaming handler that stamps a known test_id into a response header so
+ * the test can correlate the persisted rows. The backend wrapper mints its
+ * OWN test_id per request, so instead we read it back from the first persisted
+ * row by slug — but to keep the assertion deterministic we count rows by the
+ * UNIQUE slug used per case. */
+function streamingHandler(): (req: Request) => Promise<Response> {
+  return async () => {
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("data: hi\n\n"));
+        controller.close();
+      },
+    });
+    return new Response(body, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+  };
+}
+
+async function countRowsBySlug(slug: string): Promise<number> {
+  const tok = await adminToken();
+  const list = await fetch(
+    `${BASE}/api/collections/cvdiag_events/records?perPage=200&filter=${encodeURIComponent(
+      `slug="${slug}"`,
+    )}`,
+    { headers: { authorization: tok } },
+  );
+  const body = (await list.json()) as { totalItems: number };
+  return body.totalItems;
+}
+
+/** Drive one wrapped request to completion, fully draining the body so the
+ * stream-close terminals + background flush fire. */
+async function driveRequest(slug: string, env: NodeJS.ProcessEnv): Promise<void> {
+  const saved = { ...process.env };
+  Object.assign(process.env, env);
+  try {
+    const wrapped = withCvdiagBackend(streamingHandler(), {
+      slug,
+      agentName: "default",
+      provider: "openai",
+    });
+    const req = new Request("https://example.test/api/copilotkit", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    const res = await wrapped(req);
+    // Fully drain the body so the monitored stream closes → terminals emit.
+    await res.text();
+  } finally {
+    // Restore env so cases don't leak into each other.
+    for (const k of Object.keys(env)) delete process.env[k];
+    Object.assign(process.env, saved);
+  }
+  // Allow the background flush window (FLUSH_WINDOW_MS=1000) to drain.
+  await new Promise((r) => setTimeout(r, 1500));
+}
+
+let pb: ChildProcess | undefined;
+let dataDir: string | undefined;
+
+const describeMaybe = PB_BIN ? describe : describe.skip;
+
+describeMaybe(
+  "cvdiag backend emit→persist seam — live PocketBase, WRITER-role auth",
+  () => {
+    beforeAll(async () => {
+      dataDir = mkdtempSync(join(tmpdir(), "pb-cvdiag-bia-e2e-"));
+      const mig = spawnSync(
+        PB_BIN as string,
+        [
+          "migrate",
+          "up",
+          `--dir=${dataDir}`,
+          `--migrationsDir=${MIGRATIONS_DIR}`,
+        ],
+        { encoding: "utf8" },
+      );
+      if (mig.status !== 0) {
+        throw new Error(`pb migrate up failed: ${mig.stderr || mig.stdout}`);
+      }
+      const admin = spawnSync(
+        PB_BIN as string,
+        ["admin", "create", ADMIN_EMAIL, ADMIN_PASS, `--dir=${dataDir}`],
+        { encoding: "utf8" },
+      );
+      if (admin.status !== 0) {
+        throw new Error(
+          `pb admin create failed: ${admin.stderr || admin.stdout}`,
+        );
+      }
+      pb = spawn(
+        PB_BIN as string,
+        [
+          "serve",
+          `--http=127.0.0.1:${PORT}`,
+          `--dir=${dataDir}`,
+          `--migrationsDir=${MIGRATIONS_DIR}`,
+          `--hooksDir=${HOOKS_DIR}`,
+        ],
+        { stdio: "ignore" },
+      );
+      await waitForHealth();
+    }, 30_000);
+
+    afterAll(() => {
+      if (pb) pb.kill("SIGKILL");
+      if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+    });
+
+    it("persists backend boundaries to cvdiag_events when CVDIAG_PB_URL is set (writer-role auth)", async () => {
+      const slug = "bia-persist-green";
+      await driveRequest(slug, {
+        CVDIAG_BACKEND_EMITTER: "1",
+        CVDIAG_PB_URL: BASE,
+        CVDIAG_WRITER_KEY: WRITER_PASSWORD,
+        SHOWCASE_ENV: "test",
+        NODE_ENV: "test",
+      } as NodeJS.ProcessEnv);
+
+      // GREEN: rows persisted via writer-role auth-with-password.
+      const rows = await countRowsBySlug(slug);
+      expect(rows).toBeGreaterThan(0);
+    }, 30_000);
+
+    it("is a no-op when CVDIAG_PB_URL is unset (stdout-only, current behavior)", async () => {
+      const slug = "bia-persist-nourl";
+      await driveRequest(slug, {
+        CVDIAG_BACKEND_EMITTER: "1",
+        SHOWCASE_ENV: "test",
+        NODE_ENV: "test",
+      } as NodeJS.ProcessEnv);
+
+      // No CVDIAG_PB_URL → no writer injected → zero rows (pre-fix behavior
+      // preserved for the no-PB deployment).
+      const rows = await countRowsBySlug(slug);
+      expect(rows).toBe(0);
+    }, 30_000);
+
+    it("degrades to a no-op (never throws) on a WRONG writer key", async () => {
+      const slug = "bia-persist-badkey";
+      // A wrong password must NOT throw into the wrapped handler; the request
+      // succeeds and zero rows persist (best-effort, never-throw contract).
+      await expect(
+        driveRequest(slug, {
+          CVDIAG_BACKEND_EMITTER: "1",
+          CVDIAG_PB_URL: BASE,
+          CVDIAG_WRITER_KEY: "wrong-password-xxxxxxxx",
+          SHOWCASE_ENV: "test",
+          NODE_ENV: "test",
+        } as NodeJS.ProcessEnv),
+      ).resolves.toBeUndefined();
+
+      const rows = await countRowsBySlug(slug);
+      expect(rows).toBe(0);
+    }, 30_000);
+  },
+);

--- a/showcase/integrations/built-in-agent/src/cvdiag-backend-persist.e2e.test.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag-backend-persist.e2e.test.ts
@@ -131,7 +131,10 @@ async function countRowsBySlug(slug: string): Promise<number> {
 
 /** Drive one wrapped request to completion, fully draining the body so the
  * stream-close terminals + background flush fire. */
-async function driveRequest(slug: string, env: NodeJS.ProcessEnv): Promise<void> {
+async function driveRequest(
+  slug: string,
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
   const saved = { ...process.env };
   Object.assign(process.env, env);
   try {

--- a/showcase/integrations/built-in-agent/src/cvdiag-backend.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag-backend.ts
@@ -37,12 +37,17 @@
  */
 
 import {
+  createCvdiagFetchPbWriterFromEnv,
   CvdiagEmitter,
   filterEdgeHeaders,
   mintTestId,
   scrubSecrets,
 } from "@/cvdiag/cvdiag-emitter";
-import type { CvdiagEnvelope, CvdiagOutcome } from "@/cvdiag/cvdiag-emitter";
+import type {
+  CvdiagEnvelope,
+  CvdiagOutcome,
+  CvdiagPbWriter,
+} from "@/cvdiag/cvdiag-emitter";
 
 /**
  * Web-standard route handler shape. Generic over the request type so a Next.js
@@ -129,9 +134,19 @@ export function withCvdiagBackend<Req extends Request>(
   const modelId = opts.modelId ?? "unknown";
   const heartbeatMs = opts.heartbeatMs ?? 10_000;
 
+  // Construct the concrete writer-role PB writer ONCE (env is read once at
+  // wrapper setup). Returns undefined when CVDIAG_PB_URL is unset — in which
+  // case the emitter is left writer-less (current stdout-only behavior). This
+  // is the fix for the type-only-seam defect: without an injected pbWriter the
+  // emitter's flush was a permanent no-op and ZERO backend events persisted.
+  // A test-injected emitter (opts.emitter) brings its own writer seam.
+  const pbWriter: CvdiagPbWriter | undefined =
+    opts.emitter !== undefined ? undefined : createCvdiagFetchPbWriterFromEnv();
+
   return async (req: Req): Promise<Response> => {
     const emitter =
-      opts.emitter ?? new CvdiagEmitter({ layer: "backend", autoFlush: true });
+      opts.emitter ??
+      new CvdiagEmitter({ layer: "backend", autoFlush: true, pbWriter });
     const testId = mintTestId();
     const startedAt = Date.now();
     const path = requestPath(req);

--- a/showcase/integrations/built-in-agent/src/cvdiag/cvdiag-emitter.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag/cvdiag-emitter.ts
@@ -7,9 +7,10 @@
  * This is the FLATTENED form of `showcase/integrations/_shared/ts/cvdiag-emitter.ts`:
  * the shared barrel re-exports from `../../../harness/src/cvdiag/*`, which has
  * no resolution inside a standalone integration's Docker build context. The
- * stage command copies the three L0-A sources (schema.ts, edge-headers.ts,
- * emit.ts) next to this file and rewrites the re-export specifiers to the
- * co-located `./*.js` copies so `next build` bundles a self-contained emitter.
+ * stage command copies the L0-A sources (scrub.ts, schema.ts, edge-headers.ts,
+ * emit.ts, pb-writer-fetch.ts) next to this file and rewrites the re-export
+ * specifiers to the co-located `./*.js` copies so `next build` bundles a
+ * self-contained emitter + concrete writer-role PB writer.
  */
 
 // ── Schema (types, enums, validators, UUIDv7 regex) ─────────────────────────
@@ -79,3 +80,14 @@ export type {
   CvdiagEmitterOptions,
   CvdiagEmitArgs,
 } from "./emit.js";
+
+// ── Concrete writer-role PB writer (plain fetch; auth-with-password→Bearer) ──
+export {
+  CvdiagFetchPbWriter,
+  createCvdiagFetchPbWriterFromEnv,
+} from "./pb-writer-fetch.js";
+
+export type {
+  FetchLike,
+  CvdiagFetchPbWriterOptions,
+} from "./pb-writer-fetch.js";

--- a/showcase/integrations/built-in-agent/src/cvdiag/pb-writer-fetch.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag/pb-writer-fetch.ts
@@ -134,7 +134,8 @@ export class CvdiagFetchPbWriter {
     this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
     this.writerKey = opts.writerKey;
     this.writerIdentity = opts.writerIdentity ?? DEFAULT_WRITER_IDENTITY;
-    this.fetchImpl = opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+    this.fetchImpl =
+      opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
     this.timeoutMs = opts.timeoutMs ?? 5000;
   }
 
@@ -239,7 +240,11 @@ export class CvdiagFetchPbWriter {
     }
     if (!res.ok) {
       const body = await safeText(res);
-      this.warn("auth", `auth failed status=${res.status} ${body}`, this.writerIdentity);
+      this.warn(
+        "auth",
+        `auth failed status=${res.status} ${body}`,
+        this.writerIdentity,
+      );
       return false;
     }
     // Read the FULL body — the auth token is ~600 chars, so the warn-path
@@ -259,7 +264,11 @@ export class CvdiagFetchPbWriter {
       return false;
     }
     if (typeof token !== "string" || token.length === 0) {
-      this.warn("auth", "auth returned empty/non-string token", this.writerIdentity);
+      this.warn(
+        "auth",
+        "auth returned empty/non-string token",
+        this.writerIdentity,
+      );
       return false;
     }
     this.token = token;
@@ -280,8 +289,7 @@ export class CvdiagFetchPbWriter {
       "content-type": "application/json",
     };
     if (bearer !== undefined) headers["authorization"] = `Bearer ${bearer}`;
-    const controller =
-      this.timeoutMs > 0 ? new AbortController() : undefined;
+    const controller = this.timeoutMs > 0 ? new AbortController() : undefined;
     const timer =
       controller !== undefined
         ? setTimeout(() => controller.abort(), this.timeoutMs)

--- a/showcase/integrations/built-in-agent/src/cvdiag/pb-writer-fetch.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag/pb-writer-fetch.ts
@@ -1,0 +1,357 @@
+/**
+ * pb-writer-fetch.ts — the CONCRETE `CvdiagPbWriter` for the TS INTEGRATION
+ * backends (plan unit L1-E wiring). This is the writer that actually persists
+ * `CvdiagEmitter.flush()` batches into the `cvdiag_events` PocketBase
+ * collection from inside a deployed Next.js route handler.
+ *
+ * WHY a second writer (and not harness/src/cvdiag/pb-writer.ts): that writer is
+ * HARNESS/probe-side — it wraps the harness `PbClient` and authenticates as a
+ * SUPERUSER (storage/pb-client.ts `/api/collections/_superusers/auth-with-
+ * password`). Superuser auth is BOTH wrong for an integration (an integration
+ * must never hold superuser credentials) AND unbundlable: `PbClient` drags the
+ * harness storage/logging tree, which has no resolution inside a standalone
+ * integration's Next.js build context (the `bin/showcase cvdiag-stage-ts` COPY
+ * staging only ships the leaf cvdiag sources). The result of that mismatch was
+ * the production defect this module fixes: `withCvdiagBackend` constructed a
+ * `CvdiagEmitter` with NO `pbWriter`, so `flush()` was a permanent no-op and
+ * ZERO backend telemetry ever persisted.
+ *
+ * CONTRACT (flap-observability spec §4 three-key ACL): authenticate as the
+ * `cvdiag_api_keys` record with role `writer` (NOT superuser). The
+ * `cvdiag_events` createRule requires exactly that
+ * (`@request.auth.collectionName = "cvdiag_api_keys" && @request.auth.role =
+ * "writer"`). This writer:
+ *   1. POSTs `/api/collections/cvdiag_api_keys/auth-with-password` with
+ *      `{ identity: CVDIAG_WRITER_IDENTITY, password: CVDIAG_WRITER_KEY }` →
+ *      a Bearer token.
+ *   2. POSTs each event to `/api/collections/cvdiag_events/records` with
+ *      `Authorization: Bearer <token>`.
+ *   3. Caches the token and RE-AUTHs once on a 401 (token expiry / rotation).
+ *
+ * Implemented with plain `fetch` ONLY — the pocketbase SDK is deliberately NOT
+ * pulled in, because it does not bundle cleanly into the integrations'
+ * standalone `next build` (this is the exact build surface that bit the seam
+ * before). `fetch` is global in Node 18+ and in the Next.js runtime.
+ *
+ * BEST-EFFORT / NEVER-THROW: this mirrors the emitter's pure-instrumentation
+ * contract (emit.ts §7 R5-F8) and `pb-writer.ts`. Every failure — an auth
+ * rejection, a wrong key, a PB hiccup, an ACL 403, a network error — is
+ * SWALLOWED and surfaced as a single `CVDIAG`-tagged `console.warn`. The
+ * `writeBatch` promise RESOLVES whether every, some, or no rows persisted; it
+ * NEVER rejects into `CvdiagEmitter.flush()` (which itself swallows). A CVDIAG
+ * write failure must NEVER block, throw into, or false-red the boundary it
+ * observes.
+ */
+
+import type { CvdiagEnvelope } from "./schema.js";
+
+/** The `cvdiag_events` collection name (mirrors migration 1779990200). */
+const CVDIAG_EVENTS_COLLECTION = "cvdiag_events";
+/** The auth collection holding the role-keyed identities (migration 1779990200). */
+const CVDIAG_API_KEYS_COLLECTION = "cvdiag_api_keys";
+/**
+ * Default writer identity seeded by the migration. The PASSWORD is supplied via
+ * `CVDIAG_WRITER_KEY` (never defaulted — a missing key means "no writer wired").
+ * The identity rarely changes, so it defaults to the seeded value but can be
+ * overridden via `CVDIAG_WRITER_IDENTITY` for a rotated/renamed record.
+ */
+const DEFAULT_WRITER_IDENTITY = "cvdiag-writer@keys.local";
+
+/** Minimal `fetch` shape (injectable for tests; defaults to the global). */
+export type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+}>;
+
+export interface CvdiagFetchPbWriterOptions {
+  /** PocketBase base URL, e.g. `https://pb.internal` (no trailing slash). */
+  baseUrl: string;
+  /** Writer-role password (`CVDIAG_WRITER_KEY`). Required. */
+  writerKey: string;
+  /** Writer-role identity; defaults to the migration-seeded value. */
+  writerIdentity?: string;
+  /** Injected fetch (tests); defaults to the global `fetch`. */
+  fetchImpl?: FetchLike;
+  /** Per-request timeout in ms (default 5000). 0/undefined disables it. */
+  timeoutMs?: number;
+}
+
+/**
+ * Build the canonical `cvdiag_events` row from a `CvdiagEnvelope`. The envelope
+ * and the PB row share the same 15 persisted fields; the two optional
+ * diagnostic flags (`_metadata_dropped`, `_truncated`) are NOT columns, so —
+ * mirroring `pb-writer.ts` `toEventRecord` — they are folded into the
+ * `metadata` JSON bag (when set) so they stay queryable. A fresh `metadata`
+ * object is built so the caller's envelope is never mutated.
+ */
+function toEventRecord(envelope: CvdiagEnvelope): Record<string, unknown> {
+  const metadata: Record<string, unknown> = { ...envelope.metadata };
+  if (envelope._metadata_dropped) metadata._metadata_dropped = true;
+  if (envelope._truncated) metadata._truncated = true;
+  return {
+    schema_version: envelope.schema_version,
+    test_id: envelope.test_id,
+    trace_id: envelope.trace_id,
+    span_id: envelope.span_id,
+    parent_span_id: envelope.parent_span_id,
+    layer: envelope.layer,
+    boundary: envelope.boundary,
+    slug: envelope.slug,
+    demo: envelope.demo,
+    ts: envelope.ts,
+    mono_ns: envelope.mono_ns,
+    duration_ms: envelope.duration_ms,
+    outcome: envelope.outcome,
+    edge_headers: { ...envelope.edge_headers },
+    metadata,
+  };
+}
+
+/**
+ * A concrete, plain-`fetch`, WRITER-ROLE PB writer satisfying the emitter's
+ * `CvdiagPbWriter` seam (`writeBatch(events) => Promise<void>`, never rejects).
+ */
+export class CvdiagFetchPbWriter {
+  private readonly baseUrl: string;
+  private readonly writerKey: string;
+  private readonly writerIdentity: string;
+  private readonly fetchImpl: FetchLike;
+  private readonly timeoutMs: number;
+  /** Cached Bearer token; null until first auth (or after a 401 reset). */
+  private token: string | null = null;
+
+  constructor(opts: CvdiagFetchPbWriterOptions) {
+    // Strip a trailing slash so URL joins are unambiguous.
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
+    this.writerKey = opts.writerKey;
+    this.writerIdentity = opts.writerIdentity ?? DEFAULT_WRITER_IDENTITY;
+    this.fetchImpl = opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+    this.timeoutMs = opts.timeoutMs ?? 5000;
+  }
+
+  /**
+   * Persist a batch of envelopes, CREATE-only, best-effort. Auths lazily on the
+   * first event, re-auths once on a per-event 401, and NEVER rejects. A
+   * per-event failure degrades to a `CVDIAG`-tagged warn; the batch is never
+   * aborted on one bad row.
+   */
+  async writeBatch(events: CvdiagEnvelope[]): Promise<void> {
+    if (events.length === 0) return;
+    // Authenticate once up front. If auth fails, every event below would 401 —
+    // so warn once and bail rather than spamming a warn per event.
+    if (this.token === null) {
+      const ok = await this.ensureAuth();
+      if (!ok) return;
+    }
+    for (const envelope of events) {
+      try {
+        await this.createOne(toEventRecord(envelope), envelope);
+      } catch (err) {
+        // `createOne` is itself never-throw; this guard covers a mapping throw
+        // on a malformed envelope so one bad row can't abort the rest.
+        this.warn(envelope.boundary, String(err), envelope.test_id);
+      }
+    }
+  }
+
+  /**
+   * CREATE one row. We always hold a cached token here (writeBatch auths up
+   * front). On ANY non-ok status with a cached token we re-auth ONCE and retry
+   * the same row, because an expired/rotated/invalid PB auth-record token does
+   * NOT surface as a clean 401 on this CREATE path — PocketBase silently treats
+   * an unverifiable token as ANONYMOUS, and the `cvdiag_events` createRule
+   * (writer-role required) then rejects the anonymous request as 400 (verified
+   * against PB 0.22.21). So keying the re-auth on 401 alone would never recover
+   * a stale token. A genuine bad-row 400 simply retries once (harmless, fails
+   * again, warns once). Never throws.
+   */
+  private async createOne(
+    record: Record<string, unknown>,
+    envelope: CvdiagEnvelope,
+  ): Promise<void> {
+    const url = `${this.baseUrl}/api/collections/${CVDIAG_EVENTS_COLLECTION}/records`;
+    const body = JSON.stringify(record);
+
+    const res = await this.post(url, body, this.token ?? undefined);
+    if (res === null) {
+      this.warn(envelope.boundary, "transport error", envelope.test_id);
+      return;
+    }
+    if (res.ok) return;
+
+    // Non-ok with a cached token → assume the token is stale/invalid (PB hides
+    // auth expiry behind a createRule-anonymous 400). Re-auth ONCE and retry.
+    this.token = null;
+    const ok = await this.ensureAuth();
+    if (!ok) {
+      this.warn(
+        envelope.boundary,
+        `create failed status=${res.status} (re-auth failed)`,
+        envelope.test_id,
+      );
+      return;
+    }
+    const retry = await this.post(url, body, this.token ?? undefined);
+    if (retry !== null && retry.ok) return;
+    if (retry === null) {
+      this.warn(
+        envelope.boundary,
+        "create failed after re-auth: transport error",
+        envelope.test_id,
+      );
+      return;
+    }
+    const retryBody = await safeText(retry);
+    this.warn(
+      envelope.boundary,
+      `create failed after re-auth status=${retry.status} ${retryBody}`,
+      envelope.test_id,
+    );
+  }
+
+  /**
+   * Auth-with-password as the WRITER ROLE against the `cvdiag_api_keys` auth
+   * collection. Caches the Bearer token on success; returns false (warns) on
+   * any failure. Never throws.
+   */
+  private async ensureAuth(): Promise<boolean> {
+    if (this.token !== null) return true;
+    const res = await this.post(
+      `${this.baseUrl}/api/collections/${CVDIAG_API_KEYS_COLLECTION}/auth-with-password`,
+      JSON.stringify({
+        identity: this.writerIdentity,
+        password: this.writerKey,
+      }),
+      undefined,
+    );
+    if (res === null) {
+      this.warn("auth", "transport error", this.writerIdentity);
+      return false;
+    }
+    if (!res.ok) {
+      const body = await safeText(res);
+      this.warn("auth", `auth failed status=${res.status} ${body}`, this.writerIdentity);
+      return false;
+    }
+    // Read the FULL body — the auth token is ~600 chars, so the warn-path
+    // `safeText` (which 256-char clamps) would corrupt valid JSON.
+    let text: string;
+    try {
+      text = await res.text();
+    } catch {
+      this.warn("auth", "auth body read failed", this.writerIdentity);
+      return false;
+    }
+    let token: unknown;
+    try {
+      token = (JSON.parse(text) as { token?: unknown }).token;
+    } catch {
+      this.warn("auth", "auth response was not JSON", this.writerIdentity);
+      return false;
+    }
+    if (typeof token !== "string" || token.length === 0) {
+      this.warn("auth", "auth returned empty/non-string token", this.writerIdentity);
+      return false;
+    }
+    this.token = token;
+    return true;
+  }
+
+  /**
+   * POST helper. Returns the response, or null on a transport/abort error (so
+   * callers branch on a single null sentinel + an HTTP status). Applies an
+   * optional per-request timeout via AbortController. Never throws.
+   */
+  private async post(
+    url: string,
+    body: string,
+    bearer: string | undefined,
+  ): Promise<{ ok: boolean; status: number; text(): Promise<string> } | null> {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+    };
+    if (bearer !== undefined) headers["authorization"] = `Bearer ${bearer}`;
+    const controller =
+      this.timeoutMs > 0 ? new AbortController() : undefined;
+    const timer =
+      controller !== undefined
+        ? setTimeout(() => controller.abort(), this.timeoutMs)
+        : undefined;
+    try {
+      return await this.fetchImpl(url, {
+        method: "POST",
+        headers,
+        body,
+        signal: controller?.signal,
+      });
+    } catch {
+      return null;
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+
+  /** Single CVDIAG-tagged warn for any swallowed failure (greppable anchor). */
+  private warn(boundary: string, error: string, testId: string): void {
+    console.warn(
+      `CVDIAG pb-writer-fetch write failed test_id=${testId} ` +
+        `boundary=${boundary} error=${error}`,
+    );
+  }
+}
+
+/**
+ * Construct a `CvdiagFetchPbWriter` from the environment, or return `undefined`
+ * when CVDIAG PB persistence is NOT configured. The wiring contract for
+ * `withCvdiagBackend`: build + inject the writer ONLY when `CVDIAG_PB_URL` is
+ * set (and a `CVDIAG_WRITER_KEY` is present). When `CVDIAG_PB_URL` is absent the
+ * emitter is left with NO `pbWriter` — exactly the current stdout-only behavior
+ * — so a deployment without a PocketBase target is unchanged. Never throws.
+ */
+export function createCvdiagFetchPbWriterFromEnv(
+  env: Record<string, string | undefined> = process.env as Record<
+    string,
+    string | undefined
+  >,
+): CvdiagFetchPbWriter | undefined {
+  const baseUrl = env.CVDIAG_PB_URL?.trim();
+  if (baseUrl === undefined || baseUrl === "") return undefined;
+  const writerKey = env.CVDIAG_WRITER_KEY?.trim();
+  if (writerKey === undefined || writerKey === "") {
+    // PB URL set but no writer key → cannot authenticate. Warn once and leave
+    // the emitter writer-less (stdout-only) rather than injecting a writer that
+    // 401-drops every event.
+    console.warn(
+      "CVDIAG pb-writer-fetch: CVDIAG_PB_URL is set but CVDIAG_WRITER_KEY is " +
+        "empty/unset — no PB writer wired (events stay stdout-only).",
+    );
+    return undefined;
+  }
+  const writerIdentity = env.CVDIAG_WRITER_IDENTITY?.trim();
+  return new CvdiagFetchPbWriter({
+    baseUrl,
+    writerKey,
+    writerIdentity:
+      writerIdentity !== undefined && writerIdentity !== ""
+        ? writerIdentity
+        : undefined,
+  });
+}
+
+/** Read a Response body without throwing (used in warn paths). */
+async function safeText(res: { text(): Promise<string> }): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 256);
+  } catch {
+    return "";
+  }
+}

--- a/showcase/integrations/built-in-agent/vitest.config.ts
+++ b/showcase/integrations/built-in-agent/vitest.config.ts
@@ -10,7 +10,13 @@ export default defineConfig({
     // broader suite is Playwright e2e (`test:e2e`); this config scopes vitest
     // to the co-located cvdiag unit tests so they run without the Next.js
     // build toolchain.
-    include: ["src/cvdiag-backend.test.ts"],
+    include: [
+      "src/cvdiag-backend.test.ts",
+      "src/cvdiag-backend-persist.e2e.test.ts",
+    ],
+    // The live-PB e2e seam needs room to boot PocketBase + drain flush windows.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     environment: "node",
   },
   resolve: {

--- a/showcase/integrations/claude-sdk-typescript/src/cvdiag-backend.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/cvdiag-backend.ts
@@ -37,12 +37,17 @@
  */
 
 import {
+  createCvdiagFetchPbWriterFromEnv,
   CvdiagEmitter,
   filterEdgeHeaders,
   mintTestId,
   scrubSecrets,
 } from "@/cvdiag/cvdiag-emitter";
-import type { CvdiagEnvelope, CvdiagOutcome } from "@/cvdiag/cvdiag-emitter";
+import type {
+  CvdiagEnvelope,
+  CvdiagOutcome,
+  CvdiagPbWriter,
+} from "@/cvdiag/cvdiag-emitter";
 
 /**
  * Web-standard route handler shape. Generic over the request type so a Next.js
@@ -129,9 +134,19 @@ export function withCvdiagBackend<Req extends Request>(
   const modelId = opts.modelId ?? "unknown";
   const heartbeatMs = opts.heartbeatMs ?? 10_000;
 
+  // Construct the concrete writer-role PB writer ONCE (env is read once at
+  // wrapper setup). Returns undefined when CVDIAG_PB_URL is unset — in which
+  // case the emitter is left writer-less (current stdout-only behavior). This
+  // is the fix for the type-only-seam defect: without an injected pbWriter the
+  // emitter's flush was a permanent no-op and ZERO backend events persisted.
+  // A test-injected emitter (opts.emitter) brings its own writer seam.
+  const pbWriter: CvdiagPbWriter | undefined =
+    opts.emitter !== undefined ? undefined : createCvdiagFetchPbWriterFromEnv();
+
   return async (req: Req): Promise<Response> => {
     const emitter =
-      opts.emitter ?? new CvdiagEmitter({ layer: "backend", autoFlush: true });
+      opts.emitter ??
+      new CvdiagEmitter({ layer: "backend", autoFlush: true, pbWriter });
     const testId = mintTestId();
     const startedAt = Date.now();
     const path = requestPath(req);

--- a/showcase/integrations/claude-sdk-typescript/src/cvdiag/cvdiag-emitter.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/cvdiag/cvdiag-emitter.ts
@@ -7,9 +7,10 @@
  * This is the FLATTENED form of `showcase/integrations/_shared/ts/cvdiag-emitter.ts`:
  * the shared barrel re-exports from `../../../harness/src/cvdiag/*`, which has
  * no resolution inside a standalone integration's Docker build context. The
- * stage command copies the three L0-A sources (schema.ts, edge-headers.ts,
- * emit.ts) next to this file and rewrites the re-export specifiers to the
- * co-located `./*.js` copies so `next build` bundles a self-contained emitter.
+ * stage command copies the L0-A sources (scrub.ts, schema.ts, edge-headers.ts,
+ * emit.ts, pb-writer-fetch.ts) next to this file and rewrites the re-export
+ * specifiers to the co-located `./*.js` copies so `next build` bundles a
+ * self-contained emitter + concrete writer-role PB writer.
  */
 
 // ── Schema (types, enums, validators, UUIDv7 regex) ─────────────────────────
@@ -79,3 +80,14 @@ export type {
   CvdiagEmitterOptions,
   CvdiagEmitArgs,
 } from "./emit.js";
+
+// ── Concrete writer-role PB writer (plain fetch; auth-with-password→Bearer) ──
+export {
+  CvdiagFetchPbWriter,
+  createCvdiagFetchPbWriterFromEnv,
+} from "./pb-writer-fetch.js";
+
+export type {
+  FetchLike,
+  CvdiagFetchPbWriterOptions,
+} from "./pb-writer-fetch.js";

--- a/showcase/integrations/claude-sdk-typescript/src/cvdiag/pb-writer-fetch.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/cvdiag/pb-writer-fetch.ts
@@ -134,7 +134,8 @@ export class CvdiagFetchPbWriter {
     this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
     this.writerKey = opts.writerKey;
     this.writerIdentity = opts.writerIdentity ?? DEFAULT_WRITER_IDENTITY;
-    this.fetchImpl = opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+    this.fetchImpl =
+      opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
     this.timeoutMs = opts.timeoutMs ?? 5000;
   }
 
@@ -239,7 +240,11 @@ export class CvdiagFetchPbWriter {
     }
     if (!res.ok) {
       const body = await safeText(res);
-      this.warn("auth", `auth failed status=${res.status} ${body}`, this.writerIdentity);
+      this.warn(
+        "auth",
+        `auth failed status=${res.status} ${body}`,
+        this.writerIdentity,
+      );
       return false;
     }
     // Read the FULL body — the auth token is ~600 chars, so the warn-path
@@ -259,7 +264,11 @@ export class CvdiagFetchPbWriter {
       return false;
     }
     if (typeof token !== "string" || token.length === 0) {
-      this.warn("auth", "auth returned empty/non-string token", this.writerIdentity);
+      this.warn(
+        "auth",
+        "auth returned empty/non-string token",
+        this.writerIdentity,
+      );
       return false;
     }
     this.token = token;
@@ -280,8 +289,7 @@ export class CvdiagFetchPbWriter {
       "content-type": "application/json",
     };
     if (bearer !== undefined) headers["authorization"] = `Bearer ${bearer}`;
-    const controller =
-      this.timeoutMs > 0 ? new AbortController() : undefined;
+    const controller = this.timeoutMs > 0 ? new AbortController() : undefined;
     const timer =
       controller !== undefined
         ? setTimeout(() => controller.abort(), this.timeoutMs)

--- a/showcase/integrations/claude-sdk-typescript/src/cvdiag/pb-writer-fetch.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/cvdiag/pb-writer-fetch.ts
@@ -1,0 +1,357 @@
+/**
+ * pb-writer-fetch.ts — the CONCRETE `CvdiagPbWriter` for the TS INTEGRATION
+ * backends (plan unit L1-E wiring). This is the writer that actually persists
+ * `CvdiagEmitter.flush()` batches into the `cvdiag_events` PocketBase
+ * collection from inside a deployed Next.js route handler.
+ *
+ * WHY a second writer (and not harness/src/cvdiag/pb-writer.ts): that writer is
+ * HARNESS/probe-side — it wraps the harness `PbClient` and authenticates as a
+ * SUPERUSER (storage/pb-client.ts `/api/collections/_superusers/auth-with-
+ * password`). Superuser auth is BOTH wrong for an integration (an integration
+ * must never hold superuser credentials) AND unbundlable: `PbClient` drags the
+ * harness storage/logging tree, which has no resolution inside a standalone
+ * integration's Next.js build context (the `bin/showcase cvdiag-stage-ts` COPY
+ * staging only ships the leaf cvdiag sources). The result of that mismatch was
+ * the production defect this module fixes: `withCvdiagBackend` constructed a
+ * `CvdiagEmitter` with NO `pbWriter`, so `flush()` was a permanent no-op and
+ * ZERO backend telemetry ever persisted.
+ *
+ * CONTRACT (flap-observability spec §4 three-key ACL): authenticate as the
+ * `cvdiag_api_keys` record with role `writer` (NOT superuser). The
+ * `cvdiag_events` createRule requires exactly that
+ * (`@request.auth.collectionName = "cvdiag_api_keys" && @request.auth.role =
+ * "writer"`). This writer:
+ *   1. POSTs `/api/collections/cvdiag_api_keys/auth-with-password` with
+ *      `{ identity: CVDIAG_WRITER_IDENTITY, password: CVDIAG_WRITER_KEY }` →
+ *      a Bearer token.
+ *   2. POSTs each event to `/api/collections/cvdiag_events/records` with
+ *      `Authorization: Bearer <token>`.
+ *   3. Caches the token and RE-AUTHs once on a 401 (token expiry / rotation).
+ *
+ * Implemented with plain `fetch` ONLY — the pocketbase SDK is deliberately NOT
+ * pulled in, because it does not bundle cleanly into the integrations'
+ * standalone `next build` (this is the exact build surface that bit the seam
+ * before). `fetch` is global in Node 18+ and in the Next.js runtime.
+ *
+ * BEST-EFFORT / NEVER-THROW: this mirrors the emitter's pure-instrumentation
+ * contract (emit.ts §7 R5-F8) and `pb-writer.ts`. Every failure — an auth
+ * rejection, a wrong key, a PB hiccup, an ACL 403, a network error — is
+ * SWALLOWED and surfaced as a single `CVDIAG`-tagged `console.warn`. The
+ * `writeBatch` promise RESOLVES whether every, some, or no rows persisted; it
+ * NEVER rejects into `CvdiagEmitter.flush()` (which itself swallows). A CVDIAG
+ * write failure must NEVER block, throw into, or false-red the boundary it
+ * observes.
+ */
+
+import type { CvdiagEnvelope } from "./schema.js";
+
+/** The `cvdiag_events` collection name (mirrors migration 1779990200). */
+const CVDIAG_EVENTS_COLLECTION = "cvdiag_events";
+/** The auth collection holding the role-keyed identities (migration 1779990200). */
+const CVDIAG_API_KEYS_COLLECTION = "cvdiag_api_keys";
+/**
+ * Default writer identity seeded by the migration. The PASSWORD is supplied via
+ * `CVDIAG_WRITER_KEY` (never defaulted — a missing key means "no writer wired").
+ * The identity rarely changes, so it defaults to the seeded value but can be
+ * overridden via `CVDIAG_WRITER_IDENTITY` for a rotated/renamed record.
+ */
+const DEFAULT_WRITER_IDENTITY = "cvdiag-writer@keys.local";
+
+/** Minimal `fetch` shape (injectable for tests; defaults to the global). */
+export type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+}>;
+
+export interface CvdiagFetchPbWriterOptions {
+  /** PocketBase base URL, e.g. `https://pb.internal` (no trailing slash). */
+  baseUrl: string;
+  /** Writer-role password (`CVDIAG_WRITER_KEY`). Required. */
+  writerKey: string;
+  /** Writer-role identity; defaults to the migration-seeded value. */
+  writerIdentity?: string;
+  /** Injected fetch (tests); defaults to the global `fetch`. */
+  fetchImpl?: FetchLike;
+  /** Per-request timeout in ms (default 5000). 0/undefined disables it. */
+  timeoutMs?: number;
+}
+
+/**
+ * Build the canonical `cvdiag_events` row from a `CvdiagEnvelope`. The envelope
+ * and the PB row share the same 15 persisted fields; the two optional
+ * diagnostic flags (`_metadata_dropped`, `_truncated`) are NOT columns, so —
+ * mirroring `pb-writer.ts` `toEventRecord` — they are folded into the
+ * `metadata` JSON bag (when set) so they stay queryable. A fresh `metadata`
+ * object is built so the caller's envelope is never mutated.
+ */
+function toEventRecord(envelope: CvdiagEnvelope): Record<string, unknown> {
+  const metadata: Record<string, unknown> = { ...envelope.metadata };
+  if (envelope._metadata_dropped) metadata._metadata_dropped = true;
+  if (envelope._truncated) metadata._truncated = true;
+  return {
+    schema_version: envelope.schema_version,
+    test_id: envelope.test_id,
+    trace_id: envelope.trace_id,
+    span_id: envelope.span_id,
+    parent_span_id: envelope.parent_span_id,
+    layer: envelope.layer,
+    boundary: envelope.boundary,
+    slug: envelope.slug,
+    demo: envelope.demo,
+    ts: envelope.ts,
+    mono_ns: envelope.mono_ns,
+    duration_ms: envelope.duration_ms,
+    outcome: envelope.outcome,
+    edge_headers: { ...envelope.edge_headers },
+    metadata,
+  };
+}
+
+/**
+ * A concrete, plain-`fetch`, WRITER-ROLE PB writer satisfying the emitter's
+ * `CvdiagPbWriter` seam (`writeBatch(events) => Promise<void>`, never rejects).
+ */
+export class CvdiagFetchPbWriter {
+  private readonly baseUrl: string;
+  private readonly writerKey: string;
+  private readonly writerIdentity: string;
+  private readonly fetchImpl: FetchLike;
+  private readonly timeoutMs: number;
+  /** Cached Bearer token; null until first auth (or after a 401 reset). */
+  private token: string | null = null;
+
+  constructor(opts: CvdiagFetchPbWriterOptions) {
+    // Strip a trailing slash so URL joins are unambiguous.
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
+    this.writerKey = opts.writerKey;
+    this.writerIdentity = opts.writerIdentity ?? DEFAULT_WRITER_IDENTITY;
+    this.fetchImpl = opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+    this.timeoutMs = opts.timeoutMs ?? 5000;
+  }
+
+  /**
+   * Persist a batch of envelopes, CREATE-only, best-effort. Auths lazily on the
+   * first event, re-auths once on a per-event 401, and NEVER rejects. A
+   * per-event failure degrades to a `CVDIAG`-tagged warn; the batch is never
+   * aborted on one bad row.
+   */
+  async writeBatch(events: CvdiagEnvelope[]): Promise<void> {
+    if (events.length === 0) return;
+    // Authenticate once up front. If auth fails, every event below would 401 —
+    // so warn once and bail rather than spamming a warn per event.
+    if (this.token === null) {
+      const ok = await this.ensureAuth();
+      if (!ok) return;
+    }
+    for (const envelope of events) {
+      try {
+        await this.createOne(toEventRecord(envelope), envelope);
+      } catch (err) {
+        // `createOne` is itself never-throw; this guard covers a mapping throw
+        // on a malformed envelope so one bad row can't abort the rest.
+        this.warn(envelope.boundary, String(err), envelope.test_id);
+      }
+    }
+  }
+
+  /**
+   * CREATE one row. We always hold a cached token here (writeBatch auths up
+   * front). On ANY non-ok status with a cached token we re-auth ONCE and retry
+   * the same row, because an expired/rotated/invalid PB auth-record token does
+   * NOT surface as a clean 401 on this CREATE path — PocketBase silently treats
+   * an unverifiable token as ANONYMOUS, and the `cvdiag_events` createRule
+   * (writer-role required) then rejects the anonymous request as 400 (verified
+   * against PB 0.22.21). So keying the re-auth on 401 alone would never recover
+   * a stale token. A genuine bad-row 400 simply retries once (harmless, fails
+   * again, warns once). Never throws.
+   */
+  private async createOne(
+    record: Record<string, unknown>,
+    envelope: CvdiagEnvelope,
+  ): Promise<void> {
+    const url = `${this.baseUrl}/api/collections/${CVDIAG_EVENTS_COLLECTION}/records`;
+    const body = JSON.stringify(record);
+
+    const res = await this.post(url, body, this.token ?? undefined);
+    if (res === null) {
+      this.warn(envelope.boundary, "transport error", envelope.test_id);
+      return;
+    }
+    if (res.ok) return;
+
+    // Non-ok with a cached token → assume the token is stale/invalid (PB hides
+    // auth expiry behind a createRule-anonymous 400). Re-auth ONCE and retry.
+    this.token = null;
+    const ok = await this.ensureAuth();
+    if (!ok) {
+      this.warn(
+        envelope.boundary,
+        `create failed status=${res.status} (re-auth failed)`,
+        envelope.test_id,
+      );
+      return;
+    }
+    const retry = await this.post(url, body, this.token ?? undefined);
+    if (retry !== null && retry.ok) return;
+    if (retry === null) {
+      this.warn(
+        envelope.boundary,
+        "create failed after re-auth: transport error",
+        envelope.test_id,
+      );
+      return;
+    }
+    const retryBody = await safeText(retry);
+    this.warn(
+      envelope.boundary,
+      `create failed after re-auth status=${retry.status} ${retryBody}`,
+      envelope.test_id,
+    );
+  }
+
+  /**
+   * Auth-with-password as the WRITER ROLE against the `cvdiag_api_keys` auth
+   * collection. Caches the Bearer token on success; returns false (warns) on
+   * any failure. Never throws.
+   */
+  private async ensureAuth(): Promise<boolean> {
+    if (this.token !== null) return true;
+    const res = await this.post(
+      `${this.baseUrl}/api/collections/${CVDIAG_API_KEYS_COLLECTION}/auth-with-password`,
+      JSON.stringify({
+        identity: this.writerIdentity,
+        password: this.writerKey,
+      }),
+      undefined,
+    );
+    if (res === null) {
+      this.warn("auth", "transport error", this.writerIdentity);
+      return false;
+    }
+    if (!res.ok) {
+      const body = await safeText(res);
+      this.warn("auth", `auth failed status=${res.status} ${body}`, this.writerIdentity);
+      return false;
+    }
+    // Read the FULL body — the auth token is ~600 chars, so the warn-path
+    // `safeText` (which 256-char clamps) would corrupt valid JSON.
+    let text: string;
+    try {
+      text = await res.text();
+    } catch {
+      this.warn("auth", "auth body read failed", this.writerIdentity);
+      return false;
+    }
+    let token: unknown;
+    try {
+      token = (JSON.parse(text) as { token?: unknown }).token;
+    } catch {
+      this.warn("auth", "auth response was not JSON", this.writerIdentity);
+      return false;
+    }
+    if (typeof token !== "string" || token.length === 0) {
+      this.warn("auth", "auth returned empty/non-string token", this.writerIdentity);
+      return false;
+    }
+    this.token = token;
+    return true;
+  }
+
+  /**
+   * POST helper. Returns the response, or null on a transport/abort error (so
+   * callers branch on a single null sentinel + an HTTP status). Applies an
+   * optional per-request timeout via AbortController. Never throws.
+   */
+  private async post(
+    url: string,
+    body: string,
+    bearer: string | undefined,
+  ): Promise<{ ok: boolean; status: number; text(): Promise<string> } | null> {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+    };
+    if (bearer !== undefined) headers["authorization"] = `Bearer ${bearer}`;
+    const controller =
+      this.timeoutMs > 0 ? new AbortController() : undefined;
+    const timer =
+      controller !== undefined
+        ? setTimeout(() => controller.abort(), this.timeoutMs)
+        : undefined;
+    try {
+      return await this.fetchImpl(url, {
+        method: "POST",
+        headers,
+        body,
+        signal: controller?.signal,
+      });
+    } catch {
+      return null;
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+
+  /** Single CVDIAG-tagged warn for any swallowed failure (greppable anchor). */
+  private warn(boundary: string, error: string, testId: string): void {
+    console.warn(
+      `CVDIAG pb-writer-fetch write failed test_id=${testId} ` +
+        `boundary=${boundary} error=${error}`,
+    );
+  }
+}
+
+/**
+ * Construct a `CvdiagFetchPbWriter` from the environment, or return `undefined`
+ * when CVDIAG PB persistence is NOT configured. The wiring contract for
+ * `withCvdiagBackend`: build + inject the writer ONLY when `CVDIAG_PB_URL` is
+ * set (and a `CVDIAG_WRITER_KEY` is present). When `CVDIAG_PB_URL` is absent the
+ * emitter is left with NO `pbWriter` — exactly the current stdout-only behavior
+ * — so a deployment without a PocketBase target is unchanged. Never throws.
+ */
+export function createCvdiagFetchPbWriterFromEnv(
+  env: Record<string, string | undefined> = process.env as Record<
+    string,
+    string | undefined
+  >,
+): CvdiagFetchPbWriter | undefined {
+  const baseUrl = env.CVDIAG_PB_URL?.trim();
+  if (baseUrl === undefined || baseUrl === "") return undefined;
+  const writerKey = env.CVDIAG_WRITER_KEY?.trim();
+  if (writerKey === undefined || writerKey === "") {
+    // PB URL set but no writer key → cannot authenticate. Warn once and leave
+    // the emitter writer-less (stdout-only) rather than injecting a writer that
+    // 401-drops every event.
+    console.warn(
+      "CVDIAG pb-writer-fetch: CVDIAG_PB_URL is set but CVDIAG_WRITER_KEY is " +
+        "empty/unset — no PB writer wired (events stay stdout-only).",
+    );
+    return undefined;
+  }
+  const writerIdentity = env.CVDIAG_WRITER_IDENTITY?.trim();
+  return new CvdiagFetchPbWriter({
+    baseUrl,
+    writerKey,
+    writerIdentity:
+      writerIdentity !== undefined && writerIdentity !== ""
+        ? writerIdentity
+        : undefined,
+  });
+}
+
+/** Read a Response body without throwing (used in warn paths). */
+async function safeText(res: { text(): Promise<string> }): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 256);
+  } catch {
+    return "";
+  }
+}

--- a/showcase/integrations/langgraph-typescript/src/cvdiag-backend.ts
+++ b/showcase/integrations/langgraph-typescript/src/cvdiag-backend.ts
@@ -37,12 +37,17 @@
  */
 
 import {
+  createCvdiagFetchPbWriterFromEnv,
   CvdiagEmitter,
   filterEdgeHeaders,
   mintTestId,
   scrubSecrets,
 } from "@/cvdiag/cvdiag-emitter";
-import type { CvdiagEnvelope, CvdiagOutcome } from "@/cvdiag/cvdiag-emitter";
+import type {
+  CvdiagEnvelope,
+  CvdiagOutcome,
+  CvdiagPbWriter,
+} from "@/cvdiag/cvdiag-emitter";
 
 /**
  * Web-standard route handler shape. Generic over the request type so a Next.js
@@ -129,9 +134,19 @@ export function withCvdiagBackend<Req extends Request>(
   const modelId = opts.modelId ?? "unknown";
   const heartbeatMs = opts.heartbeatMs ?? 10_000;
 
+  // Construct the concrete writer-role PB writer ONCE (env is read once at
+  // wrapper setup). Returns undefined when CVDIAG_PB_URL is unset — in which
+  // case the emitter is left writer-less (current stdout-only behavior). This
+  // is the fix for the type-only-seam defect: without an injected pbWriter the
+  // emitter's flush was a permanent no-op and ZERO backend events persisted.
+  // A test-injected emitter (opts.emitter) brings its own writer seam.
+  const pbWriter: CvdiagPbWriter | undefined =
+    opts.emitter !== undefined ? undefined : createCvdiagFetchPbWriterFromEnv();
+
   return async (req: Req): Promise<Response> => {
     const emitter =
-      opts.emitter ?? new CvdiagEmitter({ layer: "backend", autoFlush: true });
+      opts.emitter ??
+      new CvdiagEmitter({ layer: "backend", autoFlush: true, pbWriter });
     const testId = mintTestId();
     const startedAt = Date.now();
     const path = requestPath(req);

--- a/showcase/integrations/langgraph-typescript/src/cvdiag/cvdiag-emitter.ts
+++ b/showcase/integrations/langgraph-typescript/src/cvdiag/cvdiag-emitter.ts
@@ -7,9 +7,10 @@
  * This is the FLATTENED form of `showcase/integrations/_shared/ts/cvdiag-emitter.ts`:
  * the shared barrel re-exports from `../../../harness/src/cvdiag/*`, which has
  * no resolution inside a standalone integration's Docker build context. The
- * stage command copies the three L0-A sources (schema.ts, edge-headers.ts,
- * emit.ts) next to this file and rewrites the re-export specifiers to the
- * co-located `./*.js` copies so `next build` bundles a self-contained emitter.
+ * stage command copies the L0-A sources (scrub.ts, schema.ts, edge-headers.ts,
+ * emit.ts, pb-writer-fetch.ts) next to this file and rewrites the re-export
+ * specifiers to the co-located `./*.js` copies so `next build` bundles a
+ * self-contained emitter + concrete writer-role PB writer.
  */
 
 // ── Schema (types, enums, validators, UUIDv7 regex) ─────────────────────────
@@ -79,3 +80,14 @@ export type {
   CvdiagEmitterOptions,
   CvdiagEmitArgs,
 } from "./emit.js";
+
+// ── Concrete writer-role PB writer (plain fetch; auth-with-password→Bearer) ──
+export {
+  CvdiagFetchPbWriter,
+  createCvdiagFetchPbWriterFromEnv,
+} from "./pb-writer-fetch.js";
+
+export type {
+  FetchLike,
+  CvdiagFetchPbWriterOptions,
+} from "./pb-writer-fetch.js";

--- a/showcase/integrations/langgraph-typescript/src/cvdiag/pb-writer-fetch.ts
+++ b/showcase/integrations/langgraph-typescript/src/cvdiag/pb-writer-fetch.ts
@@ -134,7 +134,8 @@ export class CvdiagFetchPbWriter {
     this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
     this.writerKey = opts.writerKey;
     this.writerIdentity = opts.writerIdentity ?? DEFAULT_WRITER_IDENTITY;
-    this.fetchImpl = opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+    this.fetchImpl =
+      opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
     this.timeoutMs = opts.timeoutMs ?? 5000;
   }
 
@@ -239,7 +240,11 @@ export class CvdiagFetchPbWriter {
     }
     if (!res.ok) {
       const body = await safeText(res);
-      this.warn("auth", `auth failed status=${res.status} ${body}`, this.writerIdentity);
+      this.warn(
+        "auth",
+        `auth failed status=${res.status} ${body}`,
+        this.writerIdentity,
+      );
       return false;
     }
     // Read the FULL body — the auth token is ~600 chars, so the warn-path
@@ -259,7 +264,11 @@ export class CvdiagFetchPbWriter {
       return false;
     }
     if (typeof token !== "string" || token.length === 0) {
-      this.warn("auth", "auth returned empty/non-string token", this.writerIdentity);
+      this.warn(
+        "auth",
+        "auth returned empty/non-string token",
+        this.writerIdentity,
+      );
       return false;
     }
     this.token = token;
@@ -280,8 +289,7 @@ export class CvdiagFetchPbWriter {
       "content-type": "application/json",
     };
     if (bearer !== undefined) headers["authorization"] = `Bearer ${bearer}`;
-    const controller =
-      this.timeoutMs > 0 ? new AbortController() : undefined;
+    const controller = this.timeoutMs > 0 ? new AbortController() : undefined;
     const timer =
       controller !== undefined
         ? setTimeout(() => controller.abort(), this.timeoutMs)

--- a/showcase/integrations/langgraph-typescript/src/cvdiag/pb-writer-fetch.ts
+++ b/showcase/integrations/langgraph-typescript/src/cvdiag/pb-writer-fetch.ts
@@ -1,0 +1,357 @@
+/**
+ * pb-writer-fetch.ts — the CONCRETE `CvdiagPbWriter` for the TS INTEGRATION
+ * backends (plan unit L1-E wiring). This is the writer that actually persists
+ * `CvdiagEmitter.flush()` batches into the `cvdiag_events` PocketBase
+ * collection from inside a deployed Next.js route handler.
+ *
+ * WHY a second writer (and not harness/src/cvdiag/pb-writer.ts): that writer is
+ * HARNESS/probe-side — it wraps the harness `PbClient` and authenticates as a
+ * SUPERUSER (storage/pb-client.ts `/api/collections/_superusers/auth-with-
+ * password`). Superuser auth is BOTH wrong for an integration (an integration
+ * must never hold superuser credentials) AND unbundlable: `PbClient` drags the
+ * harness storage/logging tree, which has no resolution inside a standalone
+ * integration's Next.js build context (the `bin/showcase cvdiag-stage-ts` COPY
+ * staging only ships the leaf cvdiag sources). The result of that mismatch was
+ * the production defect this module fixes: `withCvdiagBackend` constructed a
+ * `CvdiagEmitter` with NO `pbWriter`, so `flush()` was a permanent no-op and
+ * ZERO backend telemetry ever persisted.
+ *
+ * CONTRACT (flap-observability spec §4 three-key ACL): authenticate as the
+ * `cvdiag_api_keys` record with role `writer` (NOT superuser). The
+ * `cvdiag_events` createRule requires exactly that
+ * (`@request.auth.collectionName = "cvdiag_api_keys" && @request.auth.role =
+ * "writer"`). This writer:
+ *   1. POSTs `/api/collections/cvdiag_api_keys/auth-with-password` with
+ *      `{ identity: CVDIAG_WRITER_IDENTITY, password: CVDIAG_WRITER_KEY }` →
+ *      a Bearer token.
+ *   2. POSTs each event to `/api/collections/cvdiag_events/records` with
+ *      `Authorization: Bearer <token>`.
+ *   3. Caches the token and RE-AUTHs once on a 401 (token expiry / rotation).
+ *
+ * Implemented with plain `fetch` ONLY — the pocketbase SDK is deliberately NOT
+ * pulled in, because it does not bundle cleanly into the integrations'
+ * standalone `next build` (this is the exact build surface that bit the seam
+ * before). `fetch` is global in Node 18+ and in the Next.js runtime.
+ *
+ * BEST-EFFORT / NEVER-THROW: this mirrors the emitter's pure-instrumentation
+ * contract (emit.ts §7 R5-F8) and `pb-writer.ts`. Every failure — an auth
+ * rejection, a wrong key, a PB hiccup, an ACL 403, a network error — is
+ * SWALLOWED and surfaced as a single `CVDIAG`-tagged `console.warn`. The
+ * `writeBatch` promise RESOLVES whether every, some, or no rows persisted; it
+ * NEVER rejects into `CvdiagEmitter.flush()` (which itself swallows). A CVDIAG
+ * write failure must NEVER block, throw into, or false-red the boundary it
+ * observes.
+ */
+
+import type { CvdiagEnvelope } from "./schema.js";
+
+/** The `cvdiag_events` collection name (mirrors migration 1779990200). */
+const CVDIAG_EVENTS_COLLECTION = "cvdiag_events";
+/** The auth collection holding the role-keyed identities (migration 1779990200). */
+const CVDIAG_API_KEYS_COLLECTION = "cvdiag_api_keys";
+/**
+ * Default writer identity seeded by the migration. The PASSWORD is supplied via
+ * `CVDIAG_WRITER_KEY` (never defaulted — a missing key means "no writer wired").
+ * The identity rarely changes, so it defaults to the seeded value but can be
+ * overridden via `CVDIAG_WRITER_IDENTITY` for a rotated/renamed record.
+ */
+const DEFAULT_WRITER_IDENTITY = "cvdiag-writer@keys.local";
+
+/** Minimal `fetch` shape (injectable for tests; defaults to the global). */
+export type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+}>;
+
+export interface CvdiagFetchPbWriterOptions {
+  /** PocketBase base URL, e.g. `https://pb.internal` (no trailing slash). */
+  baseUrl: string;
+  /** Writer-role password (`CVDIAG_WRITER_KEY`). Required. */
+  writerKey: string;
+  /** Writer-role identity; defaults to the migration-seeded value. */
+  writerIdentity?: string;
+  /** Injected fetch (tests); defaults to the global `fetch`. */
+  fetchImpl?: FetchLike;
+  /** Per-request timeout in ms (default 5000). 0/undefined disables it. */
+  timeoutMs?: number;
+}
+
+/**
+ * Build the canonical `cvdiag_events` row from a `CvdiagEnvelope`. The envelope
+ * and the PB row share the same 15 persisted fields; the two optional
+ * diagnostic flags (`_metadata_dropped`, `_truncated`) are NOT columns, so —
+ * mirroring `pb-writer.ts` `toEventRecord` — they are folded into the
+ * `metadata` JSON bag (when set) so they stay queryable. A fresh `metadata`
+ * object is built so the caller's envelope is never mutated.
+ */
+function toEventRecord(envelope: CvdiagEnvelope): Record<string, unknown> {
+  const metadata: Record<string, unknown> = { ...envelope.metadata };
+  if (envelope._metadata_dropped) metadata._metadata_dropped = true;
+  if (envelope._truncated) metadata._truncated = true;
+  return {
+    schema_version: envelope.schema_version,
+    test_id: envelope.test_id,
+    trace_id: envelope.trace_id,
+    span_id: envelope.span_id,
+    parent_span_id: envelope.parent_span_id,
+    layer: envelope.layer,
+    boundary: envelope.boundary,
+    slug: envelope.slug,
+    demo: envelope.demo,
+    ts: envelope.ts,
+    mono_ns: envelope.mono_ns,
+    duration_ms: envelope.duration_ms,
+    outcome: envelope.outcome,
+    edge_headers: { ...envelope.edge_headers },
+    metadata,
+  };
+}
+
+/**
+ * A concrete, plain-`fetch`, WRITER-ROLE PB writer satisfying the emitter's
+ * `CvdiagPbWriter` seam (`writeBatch(events) => Promise<void>`, never rejects).
+ */
+export class CvdiagFetchPbWriter {
+  private readonly baseUrl: string;
+  private readonly writerKey: string;
+  private readonly writerIdentity: string;
+  private readonly fetchImpl: FetchLike;
+  private readonly timeoutMs: number;
+  /** Cached Bearer token; null until first auth (or after a 401 reset). */
+  private token: string | null = null;
+
+  constructor(opts: CvdiagFetchPbWriterOptions) {
+    // Strip a trailing slash so URL joins are unambiguous.
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
+    this.writerKey = opts.writerKey;
+    this.writerIdentity = opts.writerIdentity ?? DEFAULT_WRITER_IDENTITY;
+    this.fetchImpl = opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+    this.timeoutMs = opts.timeoutMs ?? 5000;
+  }
+
+  /**
+   * Persist a batch of envelopes, CREATE-only, best-effort. Auths lazily on the
+   * first event, re-auths once on a per-event 401, and NEVER rejects. A
+   * per-event failure degrades to a `CVDIAG`-tagged warn; the batch is never
+   * aborted on one bad row.
+   */
+  async writeBatch(events: CvdiagEnvelope[]): Promise<void> {
+    if (events.length === 0) return;
+    // Authenticate once up front. If auth fails, every event below would 401 —
+    // so warn once and bail rather than spamming a warn per event.
+    if (this.token === null) {
+      const ok = await this.ensureAuth();
+      if (!ok) return;
+    }
+    for (const envelope of events) {
+      try {
+        await this.createOne(toEventRecord(envelope), envelope);
+      } catch (err) {
+        // `createOne` is itself never-throw; this guard covers a mapping throw
+        // on a malformed envelope so one bad row can't abort the rest.
+        this.warn(envelope.boundary, String(err), envelope.test_id);
+      }
+    }
+  }
+
+  /**
+   * CREATE one row. We always hold a cached token here (writeBatch auths up
+   * front). On ANY non-ok status with a cached token we re-auth ONCE and retry
+   * the same row, because an expired/rotated/invalid PB auth-record token does
+   * NOT surface as a clean 401 on this CREATE path — PocketBase silently treats
+   * an unverifiable token as ANONYMOUS, and the `cvdiag_events` createRule
+   * (writer-role required) then rejects the anonymous request as 400 (verified
+   * against PB 0.22.21). So keying the re-auth on 401 alone would never recover
+   * a stale token. A genuine bad-row 400 simply retries once (harmless, fails
+   * again, warns once). Never throws.
+   */
+  private async createOne(
+    record: Record<string, unknown>,
+    envelope: CvdiagEnvelope,
+  ): Promise<void> {
+    const url = `${this.baseUrl}/api/collections/${CVDIAG_EVENTS_COLLECTION}/records`;
+    const body = JSON.stringify(record);
+
+    const res = await this.post(url, body, this.token ?? undefined);
+    if (res === null) {
+      this.warn(envelope.boundary, "transport error", envelope.test_id);
+      return;
+    }
+    if (res.ok) return;
+
+    // Non-ok with a cached token → assume the token is stale/invalid (PB hides
+    // auth expiry behind a createRule-anonymous 400). Re-auth ONCE and retry.
+    this.token = null;
+    const ok = await this.ensureAuth();
+    if (!ok) {
+      this.warn(
+        envelope.boundary,
+        `create failed status=${res.status} (re-auth failed)`,
+        envelope.test_id,
+      );
+      return;
+    }
+    const retry = await this.post(url, body, this.token ?? undefined);
+    if (retry !== null && retry.ok) return;
+    if (retry === null) {
+      this.warn(
+        envelope.boundary,
+        "create failed after re-auth: transport error",
+        envelope.test_id,
+      );
+      return;
+    }
+    const retryBody = await safeText(retry);
+    this.warn(
+      envelope.boundary,
+      `create failed after re-auth status=${retry.status} ${retryBody}`,
+      envelope.test_id,
+    );
+  }
+
+  /**
+   * Auth-with-password as the WRITER ROLE against the `cvdiag_api_keys` auth
+   * collection. Caches the Bearer token on success; returns false (warns) on
+   * any failure. Never throws.
+   */
+  private async ensureAuth(): Promise<boolean> {
+    if (this.token !== null) return true;
+    const res = await this.post(
+      `${this.baseUrl}/api/collections/${CVDIAG_API_KEYS_COLLECTION}/auth-with-password`,
+      JSON.stringify({
+        identity: this.writerIdentity,
+        password: this.writerKey,
+      }),
+      undefined,
+    );
+    if (res === null) {
+      this.warn("auth", "transport error", this.writerIdentity);
+      return false;
+    }
+    if (!res.ok) {
+      const body = await safeText(res);
+      this.warn("auth", `auth failed status=${res.status} ${body}`, this.writerIdentity);
+      return false;
+    }
+    // Read the FULL body — the auth token is ~600 chars, so the warn-path
+    // `safeText` (which 256-char clamps) would corrupt valid JSON.
+    let text: string;
+    try {
+      text = await res.text();
+    } catch {
+      this.warn("auth", "auth body read failed", this.writerIdentity);
+      return false;
+    }
+    let token: unknown;
+    try {
+      token = (JSON.parse(text) as { token?: unknown }).token;
+    } catch {
+      this.warn("auth", "auth response was not JSON", this.writerIdentity);
+      return false;
+    }
+    if (typeof token !== "string" || token.length === 0) {
+      this.warn("auth", "auth returned empty/non-string token", this.writerIdentity);
+      return false;
+    }
+    this.token = token;
+    return true;
+  }
+
+  /**
+   * POST helper. Returns the response, or null on a transport/abort error (so
+   * callers branch on a single null sentinel + an HTTP status). Applies an
+   * optional per-request timeout via AbortController. Never throws.
+   */
+  private async post(
+    url: string,
+    body: string,
+    bearer: string | undefined,
+  ): Promise<{ ok: boolean; status: number; text(): Promise<string> } | null> {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+    };
+    if (bearer !== undefined) headers["authorization"] = `Bearer ${bearer}`;
+    const controller =
+      this.timeoutMs > 0 ? new AbortController() : undefined;
+    const timer =
+      controller !== undefined
+        ? setTimeout(() => controller.abort(), this.timeoutMs)
+        : undefined;
+    try {
+      return await this.fetchImpl(url, {
+        method: "POST",
+        headers,
+        body,
+        signal: controller?.signal,
+      });
+    } catch {
+      return null;
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+
+  /** Single CVDIAG-tagged warn for any swallowed failure (greppable anchor). */
+  private warn(boundary: string, error: string, testId: string): void {
+    console.warn(
+      `CVDIAG pb-writer-fetch write failed test_id=${testId} ` +
+        `boundary=${boundary} error=${error}`,
+    );
+  }
+}
+
+/**
+ * Construct a `CvdiagFetchPbWriter` from the environment, or return `undefined`
+ * when CVDIAG PB persistence is NOT configured. The wiring contract for
+ * `withCvdiagBackend`: build + inject the writer ONLY when `CVDIAG_PB_URL` is
+ * set (and a `CVDIAG_WRITER_KEY` is present). When `CVDIAG_PB_URL` is absent the
+ * emitter is left with NO `pbWriter` — exactly the current stdout-only behavior
+ * — so a deployment without a PocketBase target is unchanged. Never throws.
+ */
+export function createCvdiagFetchPbWriterFromEnv(
+  env: Record<string, string | undefined> = process.env as Record<
+    string,
+    string | undefined
+  >,
+): CvdiagFetchPbWriter | undefined {
+  const baseUrl = env.CVDIAG_PB_URL?.trim();
+  if (baseUrl === undefined || baseUrl === "") return undefined;
+  const writerKey = env.CVDIAG_WRITER_KEY?.trim();
+  if (writerKey === undefined || writerKey === "") {
+    // PB URL set but no writer key → cannot authenticate. Warn once and leave
+    // the emitter writer-less (stdout-only) rather than injecting a writer that
+    // 401-drops every event.
+    console.warn(
+      "CVDIAG pb-writer-fetch: CVDIAG_PB_URL is set but CVDIAG_WRITER_KEY is " +
+        "empty/unset — no PB writer wired (events stay stdout-only).",
+    );
+    return undefined;
+  }
+  const writerIdentity = env.CVDIAG_WRITER_IDENTITY?.trim();
+  return new CvdiagFetchPbWriter({
+    baseUrl,
+    writerKey,
+    writerIdentity:
+      writerIdentity !== undefined && writerIdentity !== ""
+        ? writerIdentity
+        : undefined,
+  });
+}
+
+/** Read a Response body without throwing (used in warn paths). */
+async function safeText(res: { text(): Promise<string> }): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 256);
+  } catch {
+    return "";
+  }
+}

--- a/showcase/integrations/mastra/src/cvdiag-backend.ts
+++ b/showcase/integrations/mastra/src/cvdiag-backend.ts
@@ -37,12 +37,17 @@
  */
 
 import {
+  createCvdiagFetchPbWriterFromEnv,
   CvdiagEmitter,
   filterEdgeHeaders,
   mintTestId,
   scrubSecrets,
 } from "@/cvdiag/cvdiag-emitter";
-import type { CvdiagEnvelope, CvdiagOutcome } from "@/cvdiag/cvdiag-emitter";
+import type {
+  CvdiagEnvelope,
+  CvdiagOutcome,
+  CvdiagPbWriter,
+} from "@/cvdiag/cvdiag-emitter";
 
 /**
  * Web-standard route handler shape. Generic over the request type so a Next.js
@@ -129,9 +134,19 @@ export function withCvdiagBackend<Req extends Request>(
   const modelId = opts.modelId ?? "unknown";
   const heartbeatMs = opts.heartbeatMs ?? 10_000;
 
+  // Construct the concrete writer-role PB writer ONCE (env is read once at
+  // wrapper setup). Returns undefined when CVDIAG_PB_URL is unset — in which
+  // case the emitter is left writer-less (current stdout-only behavior). This
+  // is the fix for the type-only-seam defect: without an injected pbWriter the
+  // emitter's flush was a permanent no-op and ZERO backend events persisted.
+  // A test-injected emitter (opts.emitter) brings its own writer seam.
+  const pbWriter: CvdiagPbWriter | undefined =
+    opts.emitter !== undefined ? undefined : createCvdiagFetchPbWriterFromEnv();
+
   return async (req: Req): Promise<Response> => {
     const emitter =
-      opts.emitter ?? new CvdiagEmitter({ layer: "backend", autoFlush: true });
+      opts.emitter ??
+      new CvdiagEmitter({ layer: "backend", autoFlush: true, pbWriter });
     const testId = mintTestId();
     const startedAt = Date.now();
     const path = requestPath(req);

--- a/showcase/integrations/mastra/src/cvdiag/cvdiag-emitter.ts
+++ b/showcase/integrations/mastra/src/cvdiag/cvdiag-emitter.ts
@@ -7,9 +7,10 @@
  * This is the FLATTENED form of `showcase/integrations/_shared/ts/cvdiag-emitter.ts`:
  * the shared barrel re-exports from `../../../harness/src/cvdiag/*`, which has
  * no resolution inside a standalone integration's Docker build context. The
- * stage command copies the three L0-A sources (schema.ts, edge-headers.ts,
- * emit.ts) next to this file and rewrites the re-export specifiers to the
- * co-located `./*.js` copies so `next build` bundles a self-contained emitter.
+ * stage command copies the L0-A sources (scrub.ts, schema.ts, edge-headers.ts,
+ * emit.ts, pb-writer-fetch.ts) next to this file and rewrites the re-export
+ * specifiers to the co-located `./*.js` copies so `next build` bundles a
+ * self-contained emitter + concrete writer-role PB writer.
  */
 
 // ── Schema (types, enums, validators, UUIDv7 regex) ─────────────────────────
@@ -79,3 +80,14 @@ export type {
   CvdiagEmitterOptions,
   CvdiagEmitArgs,
 } from "./emit.js";
+
+// ── Concrete writer-role PB writer (plain fetch; auth-with-password→Bearer) ──
+export {
+  CvdiagFetchPbWriter,
+  createCvdiagFetchPbWriterFromEnv,
+} from "./pb-writer-fetch.js";
+
+export type {
+  FetchLike,
+  CvdiagFetchPbWriterOptions,
+} from "./pb-writer-fetch.js";

--- a/showcase/integrations/mastra/src/cvdiag/pb-writer-fetch.ts
+++ b/showcase/integrations/mastra/src/cvdiag/pb-writer-fetch.ts
@@ -134,7 +134,8 @@ export class CvdiagFetchPbWriter {
     this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
     this.writerKey = opts.writerKey;
     this.writerIdentity = opts.writerIdentity ?? DEFAULT_WRITER_IDENTITY;
-    this.fetchImpl = opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+    this.fetchImpl =
+      opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
     this.timeoutMs = opts.timeoutMs ?? 5000;
   }
 
@@ -239,7 +240,11 @@ export class CvdiagFetchPbWriter {
     }
     if (!res.ok) {
       const body = await safeText(res);
-      this.warn("auth", `auth failed status=${res.status} ${body}`, this.writerIdentity);
+      this.warn(
+        "auth",
+        `auth failed status=${res.status} ${body}`,
+        this.writerIdentity,
+      );
       return false;
     }
     // Read the FULL body — the auth token is ~600 chars, so the warn-path
@@ -259,7 +264,11 @@ export class CvdiagFetchPbWriter {
       return false;
     }
     if (typeof token !== "string" || token.length === 0) {
-      this.warn("auth", "auth returned empty/non-string token", this.writerIdentity);
+      this.warn(
+        "auth",
+        "auth returned empty/non-string token",
+        this.writerIdentity,
+      );
       return false;
     }
     this.token = token;
@@ -280,8 +289,7 @@ export class CvdiagFetchPbWriter {
       "content-type": "application/json",
     };
     if (bearer !== undefined) headers["authorization"] = `Bearer ${bearer}`;
-    const controller =
-      this.timeoutMs > 0 ? new AbortController() : undefined;
+    const controller = this.timeoutMs > 0 ? new AbortController() : undefined;
     const timer =
       controller !== undefined
         ? setTimeout(() => controller.abort(), this.timeoutMs)

--- a/showcase/integrations/mastra/src/cvdiag/pb-writer-fetch.ts
+++ b/showcase/integrations/mastra/src/cvdiag/pb-writer-fetch.ts
@@ -1,0 +1,357 @@
+/**
+ * pb-writer-fetch.ts — the CONCRETE `CvdiagPbWriter` for the TS INTEGRATION
+ * backends (plan unit L1-E wiring). This is the writer that actually persists
+ * `CvdiagEmitter.flush()` batches into the `cvdiag_events` PocketBase
+ * collection from inside a deployed Next.js route handler.
+ *
+ * WHY a second writer (and not harness/src/cvdiag/pb-writer.ts): that writer is
+ * HARNESS/probe-side — it wraps the harness `PbClient` and authenticates as a
+ * SUPERUSER (storage/pb-client.ts `/api/collections/_superusers/auth-with-
+ * password`). Superuser auth is BOTH wrong for an integration (an integration
+ * must never hold superuser credentials) AND unbundlable: `PbClient` drags the
+ * harness storage/logging tree, which has no resolution inside a standalone
+ * integration's Next.js build context (the `bin/showcase cvdiag-stage-ts` COPY
+ * staging only ships the leaf cvdiag sources). The result of that mismatch was
+ * the production defect this module fixes: `withCvdiagBackend` constructed a
+ * `CvdiagEmitter` with NO `pbWriter`, so `flush()` was a permanent no-op and
+ * ZERO backend telemetry ever persisted.
+ *
+ * CONTRACT (flap-observability spec §4 three-key ACL): authenticate as the
+ * `cvdiag_api_keys` record with role `writer` (NOT superuser). The
+ * `cvdiag_events` createRule requires exactly that
+ * (`@request.auth.collectionName = "cvdiag_api_keys" && @request.auth.role =
+ * "writer"`). This writer:
+ *   1. POSTs `/api/collections/cvdiag_api_keys/auth-with-password` with
+ *      `{ identity: CVDIAG_WRITER_IDENTITY, password: CVDIAG_WRITER_KEY }` →
+ *      a Bearer token.
+ *   2. POSTs each event to `/api/collections/cvdiag_events/records` with
+ *      `Authorization: Bearer <token>`.
+ *   3. Caches the token and RE-AUTHs once on a 401 (token expiry / rotation).
+ *
+ * Implemented with plain `fetch` ONLY — the pocketbase SDK is deliberately NOT
+ * pulled in, because it does not bundle cleanly into the integrations'
+ * standalone `next build` (this is the exact build surface that bit the seam
+ * before). `fetch` is global in Node 18+ and in the Next.js runtime.
+ *
+ * BEST-EFFORT / NEVER-THROW: this mirrors the emitter's pure-instrumentation
+ * contract (emit.ts §7 R5-F8) and `pb-writer.ts`. Every failure — an auth
+ * rejection, a wrong key, a PB hiccup, an ACL 403, a network error — is
+ * SWALLOWED and surfaced as a single `CVDIAG`-tagged `console.warn`. The
+ * `writeBatch` promise RESOLVES whether every, some, or no rows persisted; it
+ * NEVER rejects into `CvdiagEmitter.flush()` (which itself swallows). A CVDIAG
+ * write failure must NEVER block, throw into, or false-red the boundary it
+ * observes.
+ */
+
+import type { CvdiagEnvelope } from "./schema.js";
+
+/** The `cvdiag_events` collection name (mirrors migration 1779990200). */
+const CVDIAG_EVENTS_COLLECTION = "cvdiag_events";
+/** The auth collection holding the role-keyed identities (migration 1779990200). */
+const CVDIAG_API_KEYS_COLLECTION = "cvdiag_api_keys";
+/**
+ * Default writer identity seeded by the migration. The PASSWORD is supplied via
+ * `CVDIAG_WRITER_KEY` (never defaulted — a missing key means "no writer wired").
+ * The identity rarely changes, so it defaults to the seeded value but can be
+ * overridden via `CVDIAG_WRITER_IDENTITY` for a rotated/renamed record.
+ */
+const DEFAULT_WRITER_IDENTITY = "cvdiag-writer@keys.local";
+
+/** Minimal `fetch` shape (injectable for tests; defaults to the global). */
+export type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+}>;
+
+export interface CvdiagFetchPbWriterOptions {
+  /** PocketBase base URL, e.g. `https://pb.internal` (no trailing slash). */
+  baseUrl: string;
+  /** Writer-role password (`CVDIAG_WRITER_KEY`). Required. */
+  writerKey: string;
+  /** Writer-role identity; defaults to the migration-seeded value. */
+  writerIdentity?: string;
+  /** Injected fetch (tests); defaults to the global `fetch`. */
+  fetchImpl?: FetchLike;
+  /** Per-request timeout in ms (default 5000). 0/undefined disables it. */
+  timeoutMs?: number;
+}
+
+/**
+ * Build the canonical `cvdiag_events` row from a `CvdiagEnvelope`. The envelope
+ * and the PB row share the same 15 persisted fields; the two optional
+ * diagnostic flags (`_metadata_dropped`, `_truncated`) are NOT columns, so —
+ * mirroring `pb-writer.ts` `toEventRecord` — they are folded into the
+ * `metadata` JSON bag (when set) so they stay queryable. A fresh `metadata`
+ * object is built so the caller's envelope is never mutated.
+ */
+function toEventRecord(envelope: CvdiagEnvelope): Record<string, unknown> {
+  const metadata: Record<string, unknown> = { ...envelope.metadata };
+  if (envelope._metadata_dropped) metadata._metadata_dropped = true;
+  if (envelope._truncated) metadata._truncated = true;
+  return {
+    schema_version: envelope.schema_version,
+    test_id: envelope.test_id,
+    trace_id: envelope.trace_id,
+    span_id: envelope.span_id,
+    parent_span_id: envelope.parent_span_id,
+    layer: envelope.layer,
+    boundary: envelope.boundary,
+    slug: envelope.slug,
+    demo: envelope.demo,
+    ts: envelope.ts,
+    mono_ns: envelope.mono_ns,
+    duration_ms: envelope.duration_ms,
+    outcome: envelope.outcome,
+    edge_headers: { ...envelope.edge_headers },
+    metadata,
+  };
+}
+
+/**
+ * A concrete, plain-`fetch`, WRITER-ROLE PB writer satisfying the emitter's
+ * `CvdiagPbWriter` seam (`writeBatch(events) => Promise<void>`, never rejects).
+ */
+export class CvdiagFetchPbWriter {
+  private readonly baseUrl: string;
+  private readonly writerKey: string;
+  private readonly writerIdentity: string;
+  private readonly fetchImpl: FetchLike;
+  private readonly timeoutMs: number;
+  /** Cached Bearer token; null until first auth (or after a 401 reset). */
+  private token: string | null = null;
+
+  constructor(opts: CvdiagFetchPbWriterOptions) {
+    // Strip a trailing slash so URL joins are unambiguous.
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
+    this.writerKey = opts.writerKey;
+    this.writerIdentity = opts.writerIdentity ?? DEFAULT_WRITER_IDENTITY;
+    this.fetchImpl = opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+    this.timeoutMs = opts.timeoutMs ?? 5000;
+  }
+
+  /**
+   * Persist a batch of envelopes, CREATE-only, best-effort. Auths lazily on the
+   * first event, re-auths once on a per-event 401, and NEVER rejects. A
+   * per-event failure degrades to a `CVDIAG`-tagged warn; the batch is never
+   * aborted on one bad row.
+   */
+  async writeBatch(events: CvdiagEnvelope[]): Promise<void> {
+    if (events.length === 0) return;
+    // Authenticate once up front. If auth fails, every event below would 401 —
+    // so warn once and bail rather than spamming a warn per event.
+    if (this.token === null) {
+      const ok = await this.ensureAuth();
+      if (!ok) return;
+    }
+    for (const envelope of events) {
+      try {
+        await this.createOne(toEventRecord(envelope), envelope);
+      } catch (err) {
+        // `createOne` is itself never-throw; this guard covers a mapping throw
+        // on a malformed envelope so one bad row can't abort the rest.
+        this.warn(envelope.boundary, String(err), envelope.test_id);
+      }
+    }
+  }
+
+  /**
+   * CREATE one row. We always hold a cached token here (writeBatch auths up
+   * front). On ANY non-ok status with a cached token we re-auth ONCE and retry
+   * the same row, because an expired/rotated/invalid PB auth-record token does
+   * NOT surface as a clean 401 on this CREATE path — PocketBase silently treats
+   * an unverifiable token as ANONYMOUS, and the `cvdiag_events` createRule
+   * (writer-role required) then rejects the anonymous request as 400 (verified
+   * against PB 0.22.21). So keying the re-auth on 401 alone would never recover
+   * a stale token. A genuine bad-row 400 simply retries once (harmless, fails
+   * again, warns once). Never throws.
+   */
+  private async createOne(
+    record: Record<string, unknown>,
+    envelope: CvdiagEnvelope,
+  ): Promise<void> {
+    const url = `${this.baseUrl}/api/collections/${CVDIAG_EVENTS_COLLECTION}/records`;
+    const body = JSON.stringify(record);
+
+    const res = await this.post(url, body, this.token ?? undefined);
+    if (res === null) {
+      this.warn(envelope.boundary, "transport error", envelope.test_id);
+      return;
+    }
+    if (res.ok) return;
+
+    // Non-ok with a cached token → assume the token is stale/invalid (PB hides
+    // auth expiry behind a createRule-anonymous 400). Re-auth ONCE and retry.
+    this.token = null;
+    const ok = await this.ensureAuth();
+    if (!ok) {
+      this.warn(
+        envelope.boundary,
+        `create failed status=${res.status} (re-auth failed)`,
+        envelope.test_id,
+      );
+      return;
+    }
+    const retry = await this.post(url, body, this.token ?? undefined);
+    if (retry !== null && retry.ok) return;
+    if (retry === null) {
+      this.warn(
+        envelope.boundary,
+        "create failed after re-auth: transport error",
+        envelope.test_id,
+      );
+      return;
+    }
+    const retryBody = await safeText(retry);
+    this.warn(
+      envelope.boundary,
+      `create failed after re-auth status=${retry.status} ${retryBody}`,
+      envelope.test_id,
+    );
+  }
+
+  /**
+   * Auth-with-password as the WRITER ROLE against the `cvdiag_api_keys` auth
+   * collection. Caches the Bearer token on success; returns false (warns) on
+   * any failure. Never throws.
+   */
+  private async ensureAuth(): Promise<boolean> {
+    if (this.token !== null) return true;
+    const res = await this.post(
+      `${this.baseUrl}/api/collections/${CVDIAG_API_KEYS_COLLECTION}/auth-with-password`,
+      JSON.stringify({
+        identity: this.writerIdentity,
+        password: this.writerKey,
+      }),
+      undefined,
+    );
+    if (res === null) {
+      this.warn("auth", "transport error", this.writerIdentity);
+      return false;
+    }
+    if (!res.ok) {
+      const body = await safeText(res);
+      this.warn("auth", `auth failed status=${res.status} ${body}`, this.writerIdentity);
+      return false;
+    }
+    // Read the FULL body — the auth token is ~600 chars, so the warn-path
+    // `safeText` (which 256-char clamps) would corrupt valid JSON.
+    let text: string;
+    try {
+      text = await res.text();
+    } catch {
+      this.warn("auth", "auth body read failed", this.writerIdentity);
+      return false;
+    }
+    let token: unknown;
+    try {
+      token = (JSON.parse(text) as { token?: unknown }).token;
+    } catch {
+      this.warn("auth", "auth response was not JSON", this.writerIdentity);
+      return false;
+    }
+    if (typeof token !== "string" || token.length === 0) {
+      this.warn("auth", "auth returned empty/non-string token", this.writerIdentity);
+      return false;
+    }
+    this.token = token;
+    return true;
+  }
+
+  /**
+   * POST helper. Returns the response, or null on a transport/abort error (so
+   * callers branch on a single null sentinel + an HTTP status). Applies an
+   * optional per-request timeout via AbortController. Never throws.
+   */
+  private async post(
+    url: string,
+    body: string,
+    bearer: string | undefined,
+  ): Promise<{ ok: boolean; status: number; text(): Promise<string> } | null> {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+    };
+    if (bearer !== undefined) headers["authorization"] = `Bearer ${bearer}`;
+    const controller =
+      this.timeoutMs > 0 ? new AbortController() : undefined;
+    const timer =
+      controller !== undefined
+        ? setTimeout(() => controller.abort(), this.timeoutMs)
+        : undefined;
+    try {
+      return await this.fetchImpl(url, {
+        method: "POST",
+        headers,
+        body,
+        signal: controller?.signal,
+      });
+    } catch {
+      return null;
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+
+  /** Single CVDIAG-tagged warn for any swallowed failure (greppable anchor). */
+  private warn(boundary: string, error: string, testId: string): void {
+    console.warn(
+      `CVDIAG pb-writer-fetch write failed test_id=${testId} ` +
+        `boundary=${boundary} error=${error}`,
+    );
+  }
+}
+
+/**
+ * Construct a `CvdiagFetchPbWriter` from the environment, or return `undefined`
+ * when CVDIAG PB persistence is NOT configured. The wiring contract for
+ * `withCvdiagBackend`: build + inject the writer ONLY when `CVDIAG_PB_URL` is
+ * set (and a `CVDIAG_WRITER_KEY` is present). When `CVDIAG_PB_URL` is absent the
+ * emitter is left with NO `pbWriter` — exactly the current stdout-only behavior
+ * — so a deployment without a PocketBase target is unchanged. Never throws.
+ */
+export function createCvdiagFetchPbWriterFromEnv(
+  env: Record<string, string | undefined> = process.env as Record<
+    string,
+    string | undefined
+  >,
+): CvdiagFetchPbWriter | undefined {
+  const baseUrl = env.CVDIAG_PB_URL?.trim();
+  if (baseUrl === undefined || baseUrl === "") return undefined;
+  const writerKey = env.CVDIAG_WRITER_KEY?.trim();
+  if (writerKey === undefined || writerKey === "") {
+    // PB URL set but no writer key → cannot authenticate. Warn once and leave
+    // the emitter writer-less (stdout-only) rather than injecting a writer that
+    // 401-drops every event.
+    console.warn(
+      "CVDIAG pb-writer-fetch: CVDIAG_PB_URL is set but CVDIAG_WRITER_KEY is " +
+        "empty/unset — no PB writer wired (events stay stdout-only).",
+    );
+    return undefined;
+  }
+  const writerIdentity = env.CVDIAG_WRITER_IDENTITY?.trim();
+  return new CvdiagFetchPbWriter({
+    baseUrl,
+    writerKey,
+    writerIdentity:
+      writerIdentity !== undefined && writerIdentity !== ""
+        ? writerIdentity
+        : undefined,
+  });
+}
+
+/** Read a Response body without throwing (used in warn paths). */
+async function safeText(res: { text(): Promise<string> }): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 256);
+  } catch {
+    return "";
+  }
+}

--- a/showcase/scripts/cli/cmd-cvdiag-stage-ts.sh
+++ b/showcase/scripts/cli/cmd-cvdiag-stage-ts.sh
@@ -54,6 +54,7 @@ _CVDIAG_L0A_SOURCES=(
   "schema.ts"
   "edge-headers.ts"
   "emit.ts"
+  "pb-writer-fetch.ts"
 )
 
 usage_cvdiag_stage_ts() {
@@ -70,7 +71,8 @@ Options:
 
 Staged into each of: langgraph-typescript, claude-sdk-typescript, mastra,
 built-in-agent (under src/cvdiag/):
-  schema.ts, edge-headers.ts, emit.ts   (verbatim from harness/src/cvdiag/)
+  scrub.ts, schema.ts, edge-headers.ts, emit.ts, pb-writer-fetch.ts
+                                        (verbatim from harness/src/cvdiag/)
   cvdiag-emitter.ts                     (flattened barrel: re-exports the
                                          co-located copies, not ../../../harness)
 HELP
@@ -91,9 +93,10 @@ _cvdiag_emit_flattened_barrel() {
  * This is the FLATTENED form of `showcase/integrations/_shared/ts/cvdiag-emitter.ts`:
  * the shared barrel re-exports from `../../../harness/src/cvdiag/*`, which has
  * no resolution inside a standalone integration's Docker build context. The
- * stage command copies the three L0-A sources (schema.ts, edge-headers.ts,
- * emit.ts) next to this file and rewrites the re-export specifiers to the
- * co-located `./*.js` copies so `next build` bundles a self-contained emitter.
+ * stage command copies the L0-A sources (scrub.ts, schema.ts, edge-headers.ts,
+ * emit.ts, pb-writer-fetch.ts) next to this file and rewrites the re-export
+ * specifiers to the co-located `./*.js` copies so `next build` bundles a
+ * self-contained emitter + concrete writer-role PB writer.
  */
 
 // ── Schema (types, enums, validators, UUIDv7 regex) ─────────────────────────
@@ -163,6 +166,17 @@ export type {
   CvdiagEmitterOptions,
   CvdiagEmitArgs,
 } from "./emit.js";
+
+// ── Concrete writer-role PB writer (plain fetch; auth-with-password→Bearer) ──
+export {
+  CvdiagFetchPbWriter,
+  createCvdiagFetchPbWriterFromEnv,
+} from "./pb-writer-fetch.js";
+
+export type {
+  FetchLike,
+  CvdiagFetchPbWriterOptions,
+} from "./pb-writer-fetch.js";
 BARREL
 }
 


### PR DESCRIPTION
## What

Fixes a production defect in the cvdiag observability subsystem (#5591): **backend emitters never persisted to PocketBase.** The `cvdiag_events` createRule requires an authenticated `cvdiag_api_keys` record with `role="writer"`, but:
- The **Python** writer sent a custom `X-Cvdiag-Writer-Key` header and never authenticated → every CREATE 403'd and was silently dropped by the never-throw daemon.
- The **TS** backends had a *type-only* PB-writer seam — the concrete writer lived in `harness/` and was never bundled into the deployed Next.js runtime → `pbWriter` undefined → flush was a no-op.

So backend boundaries (`request.ingress`, `llm.call.*`, `sse.*`, `error.caught`) emitted to stdout but never reached the DB. (The probe/harness side already persists — it auths as superuser.)

**Why #5591's CR didn't catch it:** the M2 persistence tests authenticated as **superuser**, which the migration itself notes bypasses *all* collection rules — so the real writer-role auth path was never exercised.

## Fix
- **Python** (`cvdiag_pb_writer.py`): `auth-with-password` against `cvdiag_api_keys` (identity `cvdiag-writer@keys.local`, password = `CVDIAG_WRITER_KEY`) → cache Bearer token → `Authorization: Bearer` on CREATE; re-auth on token expiry; auth failure degrades to no-op (never-throw). Identity overridable via `CVDIAG_WRITER_IDENTITY`.
- **TS** (`harness/src/cvdiag/pb-writer-fetch.ts`, staged into the 4 integrations): a plain-`fetch` writer-role writer (no SDK, bundles cleanly in Next), injected by `withCvdiagBackend` only when `CVDIAG_PB_URL` is set.

The writer credential already exists — the migration seeds the `writer` record — so no provisioning needed.

## Verification (against a LIVE PocketBase, authenticating as the writer role — not superuser)
- Python: live-PB writer-role test — header-only → **0 rows**; after fix → **row persists**; wrong password → **0 rows, daemon alive**. `_shared` pytest 16/16.
- TS: live-PB writer-role tests — 0 rows → rows persist; stale-token re-auth lands; wrong-key/no-url no-op. harness cvdiag vitest 255/255. Real Docker `next build` of built-in-agent succeeds (writer bundles).
- `cvdiag-stage-ts --check` in-sync.

## Follow-up (not in this PR)
Java/.NET backends have the same auth gap; they're not the flap-heavy integrations and will be fixed before enabling their columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)