### PR TITLE
Guard canvas plan auto-continue loops

### DIFF
--- a/examples/canvas/langgraph-python/agent/agent.py
+++ b/examples/canvas/langgraph-python/agent/agent.py
@@ -68,6 +68,7 @@ class AgentState(CopilotKitState):
     planSteps: List[Dict[str, Any]] = []
     currentStepIndex: int = -1
     planStatus: str = ""
+    planContinuationCount: int = 0
 
 
 def summarize_items_for_prompt(state: AgentState) -> str:
@@ -155,6 +156,8 @@ backend_tools = [
 # Extract tool names from backend_tools for comparison
 backend_tool_names = [tool.name for tool in backend_tools]
 
+MAX_AUTOMATIC_PLAN_CONTINUES = 8
+
 # Frontend tool allowlist to keep tool count under API limits and avoid noise
 FRONTEND_TOOL_ALLOWLIST = set(
     [
@@ -195,7 +198,7 @@ FRONTEND_TOOL_ALLOWLIST = set(
 
 async def chat_node(
     state: AgentState, config: RunnableConfig
-) -> Command[Literal["tool_node", "__end__"]]:
+) -> Command[Literal["chat_node", "tool_node", "__end__"]]:
     """
     Standard chat node based on the ReAct design pattern. It handles:
     - The model to use (and binds in CopilotKit actions and the tools defined above)
@@ -278,6 +281,10 @@ async def chat_node(
     plan_steps = state.get("planSteps", []) or []
     current_step_index = state.get("currentStepIndex", -1)
     plan_status = state.get("planStatus", "")
+    try:
+        plan_continue_count = int(state.get("planContinuationCount", 0) or 0)
+    except Exception:
+        plan_continue_count = 0
     field_schema = (
         "FIELD SCHEMA (authoritative):\n"
         "- project.data:\n"
@@ -441,6 +448,9 @@ async def chat_node(
                             "planSteps": state.get("planSteps", []),
                             "currentStepIndex": state.get("currentStepIndex", -1),
                             "planStatus": state.get("planStatus", ""),
+                            "planContinuationCount": state.get(
+                                "planContinuationCount", 0
+                            ),
                         },
                     )
     except Exception:
@@ -615,6 +625,7 @@ async def chat_node(
                 "currentStepIndex": state.get("currentStepIndex", -1),
                 "planStatus": state.get("planStatus", ""),
                 **plan_updates,
+                "planContinuationCount": 0,
                 # guidance for follow-up after tool execution
                 "__last_tool_guidance": "If a deletion tool reports success (deleted:ID), acknowledge deletion even if the item no longer exists afterwards.",
             },
@@ -660,6 +671,7 @@ async def chat_node(
                 "currentStepIndex": state.get("currentStepIndex", -1),
                 "planStatus": state.get("planStatus", ""),
                 **plan_updates,
+                "planContinuationCount": 0,
                 "__last_tool_guidance": (
                     "Frontend tool calls issued. Waiting for client tool results before continuing."
                 ),
@@ -667,6 +679,44 @@ async def chat_node(
         )
 
     if has_remaining and effective_plan_status != "completed":
+        if plan_continue_count >= MAX_AUTOMATIC_PLAN_CONTINUES - 1:
+            failed_steps = []
+            for step in effective_steps:
+                copied_step = dict(step)
+                if copied_step.get("status") not in ("completed", "failed"):
+                    copied_step["status"] = "failed"
+                    copied_step["note"] = (
+                        "Stopped after repeated automatic retries without plan progress."
+                    )
+                failed_steps.append(copied_step)
+
+            return Command(
+                goto=END,
+                update={
+                    "messages": [
+                        AIMessage(
+                            content=(
+                                "I couldn't complete the plan automatically after several retries. "
+                                "The unfinished steps have been marked failed so the workflow can stop cleanly. "
+                                "Please retry with clearer instructions or adjust the plan."
+                            )
+                        )
+                    ],
+                    "items": state.get("items", []),
+                    "globalTitle": state.get("globalTitle", ""),
+                    "globalDescription": state.get("globalDescription", ""),
+                    "itemsCreated": state.get("itemsCreated", 0),
+                    "lastAction": state.get("lastAction", ""),
+                    "planSteps": failed_steps,
+                    "currentStepIndex": plan_updates.get(
+                        "currentStepIndex", current_step_index
+                    ),
+                    "planStatus": "failed",
+                    "planContinuationCount": 0,
+                    "__last_tool_guidance": None,
+                },
+            )
+
         # Auto-continue; include response only if it carries frontend tool calls
         return Command(
             goto="chat_node",
@@ -683,6 +733,7 @@ async def chat_node(
                 "currentStepIndex": state.get("currentStepIndex", -1),
                 "planStatus": state.get("planStatus", ""),
                 **plan_updates,
+                "planContinuationCount": plan_continue_count + 1,
                 "__last_tool_guidance": (
                     "Plan is in progress. Proceed to the next step automatically. "
                     "Update the step status to in_progress, call necessary tools, and mark it completed when done."
@@ -701,6 +752,33 @@ async def chat_node(
         plan_marked_completed = False
 
     if all_steps_completed and not plan_marked_completed:
+        if plan_continue_count >= MAX_AUTOMATIC_PLAN_CONTINUES - 1:
+            return Command(
+                goto=END,
+                update={
+                    "messages": [
+                        AIMessage(
+                            content=(
+                                "All plan steps are complete, so I'm marking the plan completed "
+                                "and ending the automatic follow-up instead of retrying again."
+                            )
+                        )
+                    ],
+                    "items": state.get("items", []),
+                    "globalTitle": state.get("globalTitle", ""),
+                    "globalDescription": state.get("globalDescription", ""),
+                    "itemsCreated": state.get("itemsCreated", 0),
+                    "lastAction": state.get("lastAction", ""),
+                    "planSteps": effective_steps,
+                    "currentStepIndex": plan_updates.get(
+                        "currentStepIndex", current_step_index
+                    ),
+                    "planStatus": "completed",
+                    "planContinuationCount": 0,
+                    "__last_tool_guidance": None,
+                },
+            )
+
         return Command(
             goto="chat_node",
             update={
@@ -715,6 +793,7 @@ async def chat_node(
                 "currentStepIndex": state.get("currentStepIndex", -1),
                 "planStatus": state.get("planStatus", ""),
                 **plan_updates,
+                "planContinuationCount": plan_continue_count + 1,
                 "__last_tool_guidance": (
                     "All steps are completed. Call complete_plan to mark the plan as finished, "
                     "then present a concise summary of outcomes."
@@ -741,6 +820,7 @@ async def chat_node(
             "currentStepIndex": state.get("currentStepIndex", -1),
             "planStatus": state.get("planStatus", ""),
             **plan_updates,
+            "planContinuationCount": 0,
             "__last_tool_guidance": None,
         },
     )

--- a/examples/canvas/langgraph-python/agent/agent.py
+++ b/examples/canvas/langgraph-python/agent/agent.py
@@ -156,7 +156,9 @@ backend_tools = [
 # Extract tool names from backend_tools for comparison
 backend_tool_names = [tool.name for tool in backend_tools]
 
-MAX_AUTOMATIC_PLAN_CONTINUES = 8
+# Keep this below LangGraph's default recursion limit: tool cycles consume two
+# graph steps each (chat_node -> tool_node -> chat_node).
+MAX_AUTOMATIC_PLAN_ITERATIONS = 8
 
 # Frontend tool allowlist to keep tool count under API limits and avoid noise
 FRONTEND_TOOL_ALLOWLIST = set(
@@ -608,7 +610,74 @@ async def chat_node(
     except Exception:
         plan_updates = {}
 
-    # only route to tool node if tool is not in the tools list
+    # 5. If there are remaining steps, auto-continue; otherwise end the graph.
+    try:
+        effective_steps = plan_updates.get("planSteps", plan_steps)
+        effective_plan_status = plan_updates.get("planStatus", plan_status)
+        has_remaining = bool(effective_steps) and any(
+            (s.get("status") not in ("completed", "failed")) for s in effective_steps
+        )
+    except Exception:
+        effective_steps = plan_steps
+        effective_plan_status = plan_status
+        has_remaining = False
+
+    # This is a per-invocation limit, not a consecutive no-tool-call limit.
+    # Backend tools route back through chat_node, so resetting this counter on
+    # every tool call would allow a tool-spinning model to hit LangGraph's
+    # recursion limit before this workflow can terminate cleanly.
+    if (
+        effective_steps
+        and effective_plan_status != "completed"
+        and plan_continue_count >= MAX_AUTOMATIC_PLAN_ITERATIONS - 1
+    ):
+        all_steps_completed = all(
+            step.get("status") == "completed" for step in effective_steps
+        )
+        terminal_plan_status = "completed" if all_steps_completed else "failed"
+        terminal_plan_steps = effective_steps
+        if not all_steps_completed:
+            terminal_plan_steps = []
+            for step in effective_steps:
+                copied_step = dict(step)
+                if copied_step.get("status") not in ("completed", "failed"):
+                    copied_step["status"] = "failed"
+                    copied_step["note"] = (
+                        "Stopped after repeated automatic retries without plan progress."
+                    )
+                terminal_plan_steps.append(copied_step)
+
+        terminal_message = (
+            "All plan steps are complete, so I'm marking the plan completed "
+            "and ending the automatic follow-up instead of retrying again."
+            if all_steps_completed
+            else (
+                "I couldn't complete the plan automatically after several retries. "
+                "The unfinished steps have been marked failed so the workflow can stop cleanly. "
+                "Please retry with clearer instructions or adjust the plan."
+            )
+        )
+
+        return Command(
+            goto=END,
+            update={
+                "messages": [AIMessage(content=terminal_message)],
+                "items": state.get("items", []),
+                "globalTitle": state.get("globalTitle", ""),
+                "globalDescription": state.get("globalDescription", ""),
+                "itemsCreated": state.get("itemsCreated", 0),
+                "lastAction": state.get("lastAction", ""),
+                "planSteps": terminal_plan_steps,
+                "currentStepIndex": plan_updates.get(
+                    "currentStepIndex", current_step_index
+                ),
+                "planStatus": terminal_plan_status,
+                "planContinuationCount": 0,
+                "__last_tool_guidance": None,
+            },
+        )
+
+    # Only route to tool node if the response includes a backend tool call.
     if route_to_tool_node(response):
         print("routing to tool node")
         return Command(
@@ -625,23 +694,11 @@ async def chat_node(
                 "currentStepIndex": state.get("currentStepIndex", -1),
                 "planStatus": state.get("planStatus", ""),
                 **plan_updates,
-                "planContinuationCount": 0,
+                "planContinuationCount": plan_continue_count + 1,
                 # guidance for follow-up after tool execution
                 "__last_tool_guidance": "If a deletion tool reports success (deleted:ID), acknowledge deletion even if the item no longer exists afterwards.",
             },
         )
-
-    # 5. If there are remaining steps, auto-continue; otherwise end the graph.
-    try:
-        effective_steps = plan_updates.get("planSteps", plan_steps)
-        effective_plan_status = plan_updates.get("planStatus", plan_status)
-        has_remaining = bool(effective_steps) and any(
-            (s.get("status") not in ("completed", "failed")) for s in effective_steps
-        )
-    except Exception:
-        effective_steps = plan_steps
-        effective_plan_status = plan_status
-        has_remaining = False
 
     # Determine if this response contains frontend tool calls that must be delivered to the client
     try:
@@ -679,44 +736,6 @@ async def chat_node(
         )
 
     if has_remaining and effective_plan_status != "completed":
-        if plan_continue_count >= MAX_AUTOMATIC_PLAN_CONTINUES - 1:
-            failed_steps = []
-            for step in effective_steps:
-                copied_step = dict(step)
-                if copied_step.get("status") not in ("completed", "failed"):
-                    copied_step["status"] = "failed"
-                    copied_step["note"] = (
-                        "Stopped after repeated automatic retries without plan progress."
-                    )
-                failed_steps.append(copied_step)
-
-            return Command(
-                goto=END,
-                update={
-                    "messages": [
-                        AIMessage(
-                            content=(
-                                "I couldn't complete the plan automatically after several retries. "
-                                "The unfinished steps have been marked failed so the workflow can stop cleanly. "
-                                "Please retry with clearer instructions or adjust the plan."
-                            )
-                        )
-                    ],
-                    "items": state.get("items", []),
-                    "globalTitle": state.get("globalTitle", ""),
-                    "globalDescription": state.get("globalDescription", ""),
-                    "itemsCreated": state.get("itemsCreated", 0),
-                    "lastAction": state.get("lastAction", ""),
-                    "planSteps": failed_steps,
-                    "currentStepIndex": plan_updates.get(
-                        "currentStepIndex", current_step_index
-                    ),
-                    "planStatus": "failed",
-                    "planContinuationCount": 0,
-                    "__last_tool_guidance": None,
-                },
-            )
-
         # Auto-continue; include response only if it carries frontend tool calls
         return Command(
             goto="chat_node",
@@ -752,33 +771,6 @@ async def chat_node(
         plan_marked_completed = False
 
     if all_steps_completed and not plan_marked_completed:
-        if plan_continue_count >= MAX_AUTOMATIC_PLAN_CONTINUES - 1:
-            return Command(
-                goto=END,
-                update={
-                    "messages": [
-                        AIMessage(
-                            content=(
-                                "All plan steps are complete, so I'm marking the plan completed "
-                                "and ending the automatic follow-up instead of retrying again."
-                            )
-                        )
-                    ],
-                    "items": state.get("items", []),
-                    "globalTitle": state.get("globalTitle", ""),
-                    "globalDescription": state.get("globalDescription", ""),
-                    "itemsCreated": state.get("itemsCreated", 0),
-                    "lastAction": state.get("lastAction", ""),
-                    "planSteps": effective_steps,
-                    "currentStepIndex": plan_updates.get(
-                        "currentStepIndex", current_step_index
-                    ),
-                    "planStatus": "completed",
-                    "planContinuationCount": 0,
-                    "__last_tool_guidance": None,
-                },
-            )
-
         return Command(
             goto="chat_node",
             update={


### PR DESCRIPTION
## Summary
Fixes #5606.

This adds a bounded guard around the canvas LangGraph Python example's automatic plan self-loops. If the model keeps re-entering `chat_node` without making tool progress or marking the plan complete, the graph now exits cleanly with a useful assistant message instead of eventually surfacing a LangGraph recursion error.

## Changes
- Track consecutive automatic plan continuations in agent state.
- Reset the counter when backend tool calls or frontend tool calls make progress.
- Mark unfinished plan steps failed after repeated retries so the UI gets a clear terminal state.
- Deterministically mark the plan completed when all steps are already complete but the final completion signal was not emitted.

## Testing
- `python -m py_compile examples/canvas/langgraph-python/agent/agent.py`
- `git diff --check`
