### PR TITLE
fix(runtime): log anonymous telemetry disclosure once per process

### DIFF
--- a/.changeset/runtime-telemetry-disclosure-once-per-process.md
+++ b/.changeset/runtime-telemetry-disclosure-once-per-process.md
@@ -1,0 +1,9 @@
+---
+"@copilotkit/runtime": patch
+---
+
+fix(runtime): log the anonymous telemetry disclosure once per process
+
+The runtime's "anonymous telemetry enabled — see …/telemetry to opt out" disclosure is meant to print at most once per process, but its once-guard lived in a module-level variable. That guard is reborn whenever the module is re-evaluated, so in `next dev` — which compiles each API route in its own module context — the line re-fired on every route compile, and the V1 `CopilotRuntime` + lazy V2 `CopilotRuntimeVNext` constructors logged it twice on a single runtime build.
+
+The guard now lives on a `Symbol.for`-keyed `globalThis` slot, which is shared across module re-evaluations and across the ESM/CJS package copies, so the disclosure prints exactly once per process. Production behavior is unchanged except that the occasional double-line is collapsed to one.

--- a/packages/runtime/src/lib/__tests__/telemetry-disclosure.test.ts
+++ b/packages/runtime/src/lib/__tests__/telemetry-disclosure.test.ts
@@ -1,12 +1,5 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
 
 import {
   _resetRuntimeTelemetryDisclosureForTesting,
@@ -39,6 +32,23 @@ describe("logRuntimeTelemetryDisclosure", () => {
     const [message] = consoleInfoSpy.mock.calls[0]!;
     expect(message).toMatch(/anonymous telemetry/i);
     expect(message).toMatch(/COPILOTKIT_TELEMETRY_DISABLED/);
+  });
+
+  it("logs once even when the module is re-evaluated", async () => {
+    // Next.js dev compiles each API route in its own module context, so the
+    // module-level once-guard is reborn per route and the disclosure used to
+    // re-fire on every route compile. The guard must survive module
+    // re-evaluation within a single process.
+    vi.resetModules();
+    const first = await import("../telemetry-disclosure");
+    first.logRuntimeTelemetryDisclosure();
+
+    vi.resetModules();
+    const second = await import("../telemetry-disclosure");
+    second.logRuntimeTelemetryDisclosure();
+
+    expect(second).not.toBe(first);
+    expect(consoleInfoSpy).toHaveBeenCalledTimes(1);
   });
 
   it("does not log when COPILOTKIT_TELEMETRY_DISABLED is set", () => {

--- a/packages/runtime/src/lib/telemetry-disclosure.ts
+++ b/packages/runtime/src/lib/telemetry-disclosure.ts
@@ -11,6 +11,13 @@
 // Fires at most once per process — runtime instances may be constructed
 // multiple times (tests, hot-reload), but the disclosure is informational
 // and a single line is enough.
+//
+// The once-guard lives on `globalThis`, not a module-level variable,
+// because "once per process" must survive module re-evaluation. Next.js
+// dev compiles each API route in its own module context, and the runtime
+// ships as both ESM and CJS builds, so a module-scoped flag is reborn per
+// route compile / per package copy and the disclosure re-fires on every
+// one. A single global slot is shared across all of them.
 
 // Canonical telemetry docs page on main.
 // Mirror constant: packages/web-inspector/src/lib/telemetry.ts
@@ -26,7 +33,18 @@ function isTelemetryDisabled(): boolean {
   );
 }
 
-let disclosureLogged = false;
+// Process-wide once-guard slot. A global-registry symbol (`Symbol.for`)
+// resolves to the same key across every copy of this module — ESM/CJS
+// builds and Next.js per-route module contexts alike — so the flag is
+// genuinely shared process-wide.
+const DISCLOSURE_GUARD = Symbol.for(
+  "copilotkit.runtime.telemetryDisclosureLogged",
+);
+
+// `Symbol.for` is typed as `symbol` (not `unique symbol`), so it can't be a
+// computed property name; a symbol index signature is the valid way to read
+// and write the slot off `globalThis`.
+type DisclosureGlobal = Record<symbol, boolean | undefined>;
 
 /**
  * Logs a one-line console.info about anonymous telemetry on runtime
@@ -36,9 +54,10 @@ let disclosureLogged = false;
  * Idempotent — safe to call from multiple constructor paths.
  */
 export function logRuntimeTelemetryDisclosure(): void {
-  if (disclosureLogged) return;
+  const guard = globalThis as unknown as DisclosureGlobal;
+  if (guard[DISCLOSURE_GUARD]) return;
   if (isTelemetryDisabled()) return;
-  disclosureLogged = true;
+  guard[DISCLOSURE_GUARD] = true;
   // eslint-disable-next-line no-console
   console.info(
     `[CopilotKit Runtime] anonymous telemetry enabled — see ${TELEMETRY_DOCS_URL} to opt out (set COPILOTKIT_TELEMETRY_DISABLED=true).`,
@@ -49,5 +68,5 @@ export function logRuntimeTelemetryDisclosure(): void {
 // test cases. Not part of the public package surface — used by the runtime
 // disclosure tests.
 export function _resetRuntimeTelemetryDisclosureForTesting(): void {
-  disclosureLogged = false;
+  (globalThis as unknown as DisclosureGlobal)[DISCLOSURE_GUARD] = false;
 }


### PR DESCRIPTION
## What & why

The runtime's anonymous-telemetry disclosure (`[CopilotKit Runtime] anonymous telemetry enabled — see …/telemetry to opt out`) is documented to print **at most once per process**, but it spams the console in `next dev`:

```
[ui] [CopilotKit Runtime] anonymous telemetry enabled — see https://docs.copilotkit.ai/telemetry to opt out (set COPILOTKIT_TELEMETRY_DISABLED=true).
[ui] [CopilotKit Runtime] anonymous telemetry enabled — see https://docs.copilotkit.ai/telemetry to opt out (set COPILOTKIT_TELEMETRY_DISABLED=true).
[ui]  GET /api/copilotkit/info 200 …
...
[ui] [CopilotKit Runtime] anonymous telemetry enabled — see …  ← again after each route
```

### Root cause

The once-guard was a **module-level** `let disclosureLogged`, which doesn't survive module re-evaluation:

1. **Next.js dev** compiles each API route in its own module context, so `telemetry-disclosure` is re-evaluated per route and the guard is reborn `false` → the line re-fires on every route compile.
2. The V1 `CopilotRuntime` constructor **and** the lazily-built V2 `CopilotRuntimeVNext` base constructor both call it → a single runtime build logs it twice (the `2×` burst right after `GET /`).

This is **dev-only spam**. Production evaluates each module once per process, so it already fires ~once (with a possible cosmetic double-line).

## The fix

Move the once-guard to a `Symbol.for`-keyed `globalThis` slot. A global-registry symbol resolves to the same key across module re-evaluations and across the ESM/CJS package copies, so the disclosure fires **exactly once per process**. Production behavior is unchanged except the occasional double-line collapses to one. The disclosure itself is untouched.

## Tests

Added a regression test that re-evaluates the module (`vi.resetModules()`) and asserts a single log. It fails red against the old guard (`expected … 1 times, but got 2 times`) and passes with the fix. All 4 disclosure tests pass; `@copilotkit/runtime` test target green.

Patch changeset included.

Linear: ENT-965

🤖 Generated with [Claude Code](https://claude.com/claude-code)
