### PR TITLE
fix(cvdiag): complete cross-layer flap attribution (probe↔backend test_id join, failure classifier, on-demand trigger)

### DIFF
--- a/showcase/harness/src/cvdiag/emit.test.ts
+++ b/showcase/harness/src/cvdiag/emit.test.ts
@@ -27,6 +27,7 @@ import {
   QUEUE_CAP,
   SLUG_FALLBACK,
   boundEntryFields,
+  mintTestId,
 } from "./emit.js";
 import type { CvdiagPbWriter } from "./emit.js";
 import type { CvdiagEmitArgs } from "./emit.js";
@@ -781,7 +782,11 @@ describe("cvdiag emit — entry bound applied end-to-end (slug never violates co
     expect(isValidTestId(env!.test_id)).toBe(true);
   });
 
-  it("an invalid testId override is re-minted and trace_id mirrors it", () => {
+  it("a non-UUIDv7 testId override is ADOPTED as the cross-layer join key (not re-minted); trace_id still mirrors it", () => {
+    // CHANGED CONTRACT (cross-layer join fix): a non-UUIDv7 `testId` is the
+    // probe's per-run id forwarded as `x-test-id`. It is ADOPTED verbatim
+    // (sanitized) as the join key — NOT replaced by a fresh mint, which would
+    // break probe↔backend correlation. With no `traceId`, trace_id mirrors it.
     const emitter = new CvdiagEmitter({ env: { NODE_ENV: "test" } });
     const env = emitter.emit({
       layer: "probe",
@@ -790,6 +795,27 @@ describe("cvdiag emit — entry bound applied end-to-end (slug never violates co
       demo: "chat",
       outcome: "info",
       testId: "not-a-uuidv7",
+      metadata: { message_index: 0, char_count: 3, demo: "chat" },
+    });
+    expect(env).not.toBeNull();
+    // Adopted verbatim (charset-clean already) — NOT a minted UUIDv7.
+    expect(env!.test_id).toBe("not-a-uuidv7");
+    expect(isValidTestId(env!.test_id)).toBe(false);
+    expect(env!.trace_id).toBe(env!.test_id);
+  });
+
+  it("a fully-unsanitizable testId override falls back to a minted UUIDv7", () => {
+    // When the inbound id has NO surviving charset chars (whitespace / control
+    // only), there is no usable join key → mint a fresh UUIDv7 so the row is
+    // still well-formed (the join is simply unavailable for that request).
+    const emitter = new CvdiagEmitter({ env: { NODE_ENV: "test" } });
+    const env = emitter.emit({
+      layer: "probe",
+      boundary: "probe.message.send",
+      slug: "langgraph-python",
+      demo: "chat",
+      outcome: "info",
+      testId: "  \n\t  ",
       metadata: { message_index: 0, char_count: 3, demo: "chat" },
     });
     expect(env).not.toBeNull();
@@ -1017,5 +1043,124 @@ describe("CvdiagEmitter — DEBUG prod fail-closed (safe-env allow-list, §6)", 
       () =>
         new CvdiagEmitter({ debug: true, env: { SHOWCASE_ENV: "staging" } }),
     ).toThrow(/CVDIAG_DEBUG_ALLOW_LIST is required/);
+  });
+});
+
+/**
+ * Cross-layer JOIN-KEY adoption (spec §5 `test_id` = the single id that joins
+ * one run's rows across all layers). The backend receives the probe's per-run
+ * `x-test-id` (e.g. `d4-<slug>-<runId>` — NOT a UUIDv7) and MUST stamp it as
+ * the envelope `test_id` so probe↔backend rows join on the same key. The
+ * backend's OWN per-request id is the `trace_id`/`span_id` (per-request), which
+ * is decoupled from `test_id` on the adoption path.
+ *
+ * RED before the fix:
+ *   - a non-UUIDv7 `testId` override was DROPPED by `boundEntryFields` and a
+ *     fresh random UUIDv7 was minted → backend `test_id` ≠ the probe's id →
+ *     join impossible.
+ *   - `trace_id` was hard-mirrored to `test_id`, so there was no way to carry a
+ *     distinct backend per-request id.
+ */
+describe("CvdiagEmitter cross-layer test_id adoption + trace_id decoupling", () => {
+  const mkEmitter = (): {
+    emitter: CvdiagEmitter;
+    captured: CvdiagEnvelope[];
+  } => {
+    const captured: CvdiagEnvelope[] = [];
+    // Verbose tier so backend.request.ingress / llm.call.start (default:false)
+    // pass the §6 tier matrix and the adoption assertion is not masked by the
+    // tier filter.
+    const emitter = new CvdiagEmitter({
+      layer: "backend",
+      verbose: true,
+      env: { NODE_ENV: "test" },
+      pbWriter: {
+        async writeBatch(events) {
+          captured.push(...events);
+        },
+      },
+    });
+    return { emitter, captured };
+  };
+
+  it("adopts a non-UUIDv7 inbound testId as the envelope test_id (the cross-layer join key)", () => {
+    const { emitter } = mkEmitter();
+    const inbound = "d4-langgraph-typescript-run42";
+    const env = emitter.emit({
+      layer: "backend",
+      boundary: "backend.request.ingress",
+      slug: "langgraph-typescript",
+      demo: "langgraph-typescript",
+      outcome: "info",
+      testId: inbound,
+      metadata: { method: "POST", path: "/api", content_length: 2 },
+    });
+    expect(env).not.toBeNull();
+    // The inbound id is adopted verbatim (sanitized) — NOT replaced by a mint.
+    expect(env!.test_id).toBe(inbound);
+  });
+
+  it("keeps trace_id decoupled from test_id when a distinct traceId is supplied", () => {
+    const { emitter } = mkEmitter();
+    const inbound = "d6-mastra-abc";
+    const backendTrace = mintTestId(); // backend's own per-request UUIDv7
+    const env = emitter.emit({
+      layer: "backend",
+      boundary: "backend.agent.enter",
+      slug: "mastra",
+      demo: "mastra",
+      outcome: "info",
+      testId: inbound,
+      traceId: backendTrace,
+      metadata: { agent_name: "default", model_id: "x" },
+    });
+    expect(env).not.toBeNull();
+    // test_id = the cross-layer join key (probe's id); trace_id = backend's own.
+    expect(env!.test_id).toBe(inbound);
+    expect(env!.trace_id).toBe(backendTrace);
+    expect(env!.trace_id).not.toBe(env!.test_id);
+  });
+
+  it("still mirrors trace_id to test_id when no traceId is supplied (back-compat: probe path)", () => {
+    const { emitter } = mkEmitter();
+    const probeUuid = mintTestId();
+    const env = emitter.emit({
+      layer: "probe",
+      boundary: "probe.message.send",
+      slug: "langgraph-typescript",
+      demo: "chat",
+      outcome: "info",
+      testId: probeUuid,
+      metadata: { message_index: 0, char_count: 1, demo: "chat" },
+    });
+    expect(env).not.toBeNull();
+    expect(env!.test_id).toBe(probeUuid);
+    // Probe passes no traceId → trace_id mirrors test_id (existing invariant).
+    expect(env!.trace_id).toBe(probeUuid);
+  });
+
+  it("sanitizes a malformed/oversize inbound testId rather than dropping it", () => {
+    const { emitter } = mkEmitter();
+    // Control chars + whitespace + over-length: must be bounded to a safe
+    // free-text key (never dropped → minted, which would break the join).
+    const dirty = `  d4-evil\n${"z".repeat(300)}   `;
+    const env = emitter.emit({
+      layer: "backend",
+      boundary: "backend.request.ingress",
+      slug: "built-in-agent",
+      demo: "built-in-agent",
+      outcome: "info",
+      testId: dirty,
+      metadata: { method: "POST", path: "/", content_length: 0 },
+    });
+    expect(env).not.toBeNull();
+    // No control chars / newlines / NULs leaked into the join key.
+    expect(env!.test_id).not.toMatch(/[\s ]/);
+    // Bounded length (≤128) and non-empty.
+    expect(env!.test_id.length).toBeGreaterThan(0);
+    expect(env!.test_id.length).toBeLessThanOrEqual(128);
+    // Derived deterministically from the dirty input prefix (so probe+backend
+    // applying the SAME sanitizer land on the SAME join key).
+    expect(env!.test_id.startsWith("d4-evil")).toBe(true);
   });
 });

--- a/showcase/harness/src/cvdiag/emit.ts
+++ b/showcase/harness/src/cvdiag/emit.ts
@@ -92,6 +92,36 @@ export const SLUG_FALLBACK = "unknown";
 const SLUG_MAX_LEN = 64;
 /** 16-hex lowercase span-id shape (spec §5 `span_id` / `parent_span_id`). */
 const SPAN_ID_REGEX = /^[0-9a-f]{16}$/;
+/**
+ * Max length (chars) of a sanitized free-text cross-layer join key adopted from
+ * an inbound `x-test-id` header. The probe's per-run id (`d4-<slug>-<runId>` /
+ * `d6-<slug>-<runId>`) is well under this; the cap defends against an
+ * unbounded/hostile header value while keeping the key usable as a PB filter.
+ */
+const JOIN_TEST_ID_MAX_LEN = 128;
+
+/**
+ * Sanitize an inbound, non-UUIDv7 `x-test-id` into a SAFE, DETERMINISTIC
+ * free-text cross-layer join key (spec §5 `test_id`). The transform is pure and
+ * deterministic so the probe and the backend, applying it to the SAME inbound
+ * header, derive the SAME join key:
+ *   1. lowercase + trim surrounding whitespace,
+ *   2. drop EVERYTHING except `[a-z0-9._-]` (strips whitespace, control chars,
+ *      NUL, and any injection-prone punctuation — the key is used verbatim in a
+ *      PB filter string),
+ *   3. cap to `JOIN_TEST_ID_MAX_LEN`.
+ * Returns `null` when nothing survives (→ caller mints a fresh UUIDv7). A value
+ * that is ALREADY a valid UUIDv7 is handled by the caller before this is
+ * reached, so this only ever runs on genuinely non-UUIDv7 inputs.
+ */
+export function sanitizeJoinTestId(raw: string): string | null {
+  const cleaned = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, "")
+    .slice(0, JOIN_TEST_ID_MAX_LEN);
+  return cleaned.length > 0 ? cleaned : null;
+}
 
 /** In-memory queue cap (spec §7 R5-F5). */
 export const QUEUE_CAP = 5000;
@@ -141,8 +171,31 @@ export interface CvdiagEmitArgs {
   metadata?: Record<string, unknown>;
   durationMs?: number | null;
   parentSpanId?: string | null;
-  /** Override test_id (e.g. probe.start mints one and threads it through). */
+  /**
+   * Override the envelope `test_id` — the CROSS-LAYER JOIN KEY (spec §5: the
+   * single id that joins one run's rows across probe / backend / aimock). Two
+   * shapes are honored:
+   *   - a valid UUIDv7 (e.g. probe.start mints one and threads it through), OR
+   *   - a probe-minted per-run id forwarded as the inbound `x-test-id` header
+   *     (e.g. `d4-<slug>-<runId>` — NOT a UUIDv7). The backend MUST adopt this
+   *     verbatim (sanitized to a safe free-text key) so its rows JOIN the
+   *     probe's rows. PB stores `test_id` as free text, so a non-UUIDv7 join
+   *     key is valid at the storage layer — the cross-layer correlation is the
+   *     whole point.
+   * An absent / empty / unsanitizable value falls back to a freshly minted
+   * UUIDv7.
+   */
   testId?: string;
+  /**
+   * Override the envelope `trace_id` — the emitter's OWN PER-REQUEST id
+   * (spec §5: trace/span are per-request, test_id is the shared run id). The
+   * backend mints a fresh UUIDv7 per request and passes it here so `trace_id`
+   * stays decoupled from an ADOPTED cross-layer `test_id`. When omitted,
+   * `trace_id` mirrors `test_id` (the historical probe-path invariant). Honored
+   * only when it is a valid UUIDv7 or 16-hex span id; otherwise it falls back
+   * to mirroring `test_id`.
+   */
+  traceId?: string;
 }
 
 /**
@@ -258,8 +311,18 @@ export interface BoundEntryFields {
   slug: string;
   demo: string;
   parentSpanId: string | null;
-  /** A valid UUIDv7 override to honor, or undefined to mint fresh. */
+  /**
+   * The cross-layer join key to honor, or undefined to mint a fresh UUIDv7.
+   * Either a valid UUIDv7 (passed through unchanged) OR a sanitized non-UUIDv7
+   * inbound `x-test-id` adopted verbatim so backend rows JOIN the probe's.
+   */
   testId: string | undefined;
+  /**
+   * The emitter's OWN per-request id (a valid UUIDv7 or 16-hex span id) to use
+   * as `trace_id`, or undefined to mirror `test_id` (historical probe-path
+   * invariant). Decouples `trace_id` from an ADOPTED non-UUIDv7 `test_id`.
+   */
+  traceId: string | undefined;
   /** True iff any field was sanitized/bounded (diagnostic; does NOT set _truncated). */
   boundedAny: boolean;
 }
@@ -307,14 +370,32 @@ export function boundEntryFields(args: CvdiagEmitArgs): BoundEntryFields {
     boundedAny = true;
   }
 
-  // testId override → honor only if a valid UUIDv7; else undefined (mint fresh).
+  // testId override → the CROSS-LAYER JOIN KEY (spec §5). Honor a valid UUIDv7
+  // verbatim. For a non-UUIDv7 inbound id (the probe's `d4-/d6-<slug>-<runId>`
+  // forwarded as `x-test-id`), ADOPT it via the deterministic sanitizer so the
+  // backend's rows join the probe's — PB stores `test_id` as free text, so a
+  // non-UUIDv7 join key is valid at storage. Only an absent / empty /
+  // fully-stripped value falls through to a freshly minted UUIDv7.
   let testId: string | undefined = args.testId;
   if (testId !== undefined && !isValidTestId(testId)) {
-    testId = undefined;
+    const adopted = sanitizeJoinTestId(testId);
+    if (adopted === null || adopted !== testId) boundedAny = true;
+    testId = adopted ?? undefined;
+  }
+
+  // traceId override → the emitter's OWN per-request id. Honor a valid UUIDv7
+  // or 16-hex span id; anything else falls through to mirroring `test_id`.
+  let traceId: string | undefined = args.traceId;
+  if (
+    traceId !== undefined &&
+    !isValidTestId(traceId) &&
+    !SPAN_ID_REGEX.test(traceId)
+  ) {
+    traceId = undefined;
     boundedAny = true;
   }
 
-  return { slug, demo, parentSpanId, testId, boundedAny };
+  return { slug, demo, parentSpanId, testId, traceId, boundedAny };
 }
 
 /**
@@ -473,6 +554,11 @@ export class CvdiagEmitter {
     // fallback keeps `trace_id` (its mirror) valid.
     const bound = boundEntryFields(args);
     const testId = bound.testId ?? mintTestId();
+    // `trace_id` is the emitter's OWN per-request id. It MIRRORS `test_id` by
+    // default (probe path: one run = one test_id = one trace_id), but the
+    // backend supplies a distinct per-request UUIDv7 via `traceId` so it stays
+    // decoupled from an ADOPTED cross-layer `test_id` (spec §5).
+    const traceId = bound.traceId ?? testId;
     const isDataPlane = !args.boundary.startsWith(ACCOUNTING_PREFIX);
     let metadata: Record<string, unknown> = {};
     let metadataDropped = false;
@@ -497,7 +583,7 @@ export class CvdiagEmitter {
     const envelope: CvdiagEnvelope = {
       schema_version: SCHEMA_VERSION,
       test_id: testId,
-      trace_id: testId,
+      trace_id: traceId,
       span_id: mintSpanId(),
       parent_span_id: bound.parentSpanId,
       layer: args.layer,
@@ -548,14 +634,16 @@ export class CvdiagEmitter {
    * ONLY the three genuinely-unbounded inputs — the `metadata` bag, the
    * free-text `demo` string, and the free-string `edge_headers` VALUES — and
    * NEVER touches a format-constrained field. It cannot produce a non-16-hex
-   * `span_id`/`parent_span_id`, break the documented `trace_id === test_id`
-   * join, or write a `slug` that violates the PB/codegen contract
+   * `span_id`/`parent_span_id`, alter the `test_id`/`trace_id` join keys (they
+   * are minted/adopted/entry-bound, never clamped), or write a `slug` that
+   * violates the PB/codegen contract
    * `^[a-z][a-z0-9-]{0,63}$`, because those fields are NOT in the clamp set at
    * all. They are bounded by construction:
    *   - `slug`     — entry-bounded to ≤64 pattern-valid chars (`boundEntryFields`)
    *   - `demo`     — entry-bounded to ≤`DEMO_MAX_LEN` (then the only clampable field)
    *   - `parent_span_id` — entry-bounded to 16-hex or `null`
-   *   - `test_id`/`trace_id` — minted UUIDv7 (36 chars), `trace_id === test_id`
+   *   - `test_id` — minted UUIDv7 OR an adopted/sanitized inbound join key
+   *     (≤128 chars); `trace_id` — minted UUIDv7 or a mirror of `test_id`
    *   - `span_id`  — minted 16-hex
    *   - `schema_version` (const int), `layer`/`boundary`/`outcome` (enums),
    *     `ts` (ISO-8601), `mono_ns`/`duration_ms` (numbers)

--- a/showcase/harness/src/cvdiag/schema.json
+++ b/showcase/harness/src/cvdiag/schema.json
@@ -233,7 +233,8 @@
         "terminal_outcome",
         "total_duration_ms",
         "sse_event_count",
-        "first_token_delta_ms"
+        "first_token_delta_ms",
+        "failure_classifier"
       ],
       "backend.request.ingress": ["method", "path", "content_length"],
       "backend.agent.enter": ["agent_name", "model_id"],

--- a/showcase/harness/src/cvdiag/schema.json
+++ b/showcase/harness/src/cvdiag/schema.json
@@ -39,18 +39,11 @@
       "pattern": "^[0-9a-f]{16}$"
     },
     "parent_span_id": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": ["string", "null"]
     },
     "layer": {
       "type": "string",
-      "enum": [
-        "probe",
-        "backend",
-        "aimock"
-      ]
+      "enum": ["probe", "backend", "aimock"]
     },
     "boundary": {
       "type": "string",
@@ -105,19 +98,11 @@
       "type": "integer"
     },
     "duration_ms": {
-      "type": [
-        "integer",
-        "null"
-      ]
+      "type": ["integer", "null"]
     },
     "outcome": {
       "type": "string",
-      "enum": [
-        "ok",
-        "err",
-        "timeout",
-        "info"
-      ]
+      "enum": ["ok", "err", "timeout", "info"]
     },
     "edge_headers": {
       "type": "object",
@@ -135,58 +120,31 @@
       ],
       "properties": {
         "cf-ray": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "cf-mitigated": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "cf-cache-status": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "x-railway-edge": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "x-railway-request-id": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "x-hikari-trace": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "retry-after": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "via": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "server": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       }
     },
@@ -201,17 +159,8 @@
     }
   },
   "$defs": {
-    "layers": [
-      "probe",
-      "backend",
-      "aimock"
-    ],
-    "outcomes": [
-      "ok",
-      "err",
-      "timeout",
-      "info"
-    ],
+    "layers": ["probe", "backend", "aimock"],
+    "outcomes": ["ok", "err", "timeout", "info"],
     "boundaries": [
       "probe.start",
       "probe.navigate.complete",
@@ -259,44 +208,15 @@
       "server"
     ],
     "boundary_metadata_keys": {
-      "probe.start": [
-        "url",
-        "viewport"
-      ],
-      "probe.navigate.complete": [
-        "url",
-        "nav_ms",
-        "http_status"
-      ],
-      "probe.message.send": [
-        "message_index",
-        "char_count",
-        "demo"
-      ],
-      "probe.dom.container.mount": [
-        "delta_ms_from_start"
-      ],
-      "probe.dom.firsttoken": [
-        "delta_ms_from_start",
-        "text_length"
-      ],
-      "probe.dom.alternate_content": [
-        "child_type_histogram"
-      ],
-      "probe.sse.event": [
-        "event_type",
-        "payload_size_bytes",
-        "sequence_num"
-      ],
-      "probe.sse.aborted": [
-        "termination_kind",
-        "bytes_before_abort"
-      ],
-      "probe.network.error": [
-        "url",
-        "error_class",
-        "response_status"
-      ],
+      "probe.start": ["url", "viewport"],
+      "probe.navigate.complete": ["url", "nav_ms", "http_status"],
+      "probe.message.send": ["message_index", "char_count", "demo"],
+      "probe.dom.container.mount": ["delta_ms_from_start"],
+      "probe.dom.firsttoken": ["delta_ms_from_start", "text_length"],
+      "probe.dom.alternate_content": ["child_type_histogram"],
+      "probe.sse.event": ["event_type", "payload_size_bytes", "sequence_num"],
+      "probe.sse.aborted": ["termination_kind", "bytes_before_abort"],
+      "probe.network.error": ["url", "error_class", "response_status"],
       "probe.network.response": [
         "url",
         "status",
@@ -316,23 +236,14 @@
         "first_token_delta_ms",
         "failure_classifier"
       ],
-      "backend.request.ingress": [
-        "method",
-        "path",
-        "content_length"
-      ],
-      "backend.agent.enter": [
-        "agent_name",
-        "model_id"
-      ],
+      "backend.request.ingress": ["method", "path", "content_length"],
+      "backend.agent.enter": ["agent_name", "model_id"],
       "backend.llm.call.start": [
         "provider",
         "model",
         "prompt_token_count_estimate"
       ],
-      "backend.llm.call.heartbeat": [
-        "elapsed_ms_since_start"
-      ],
+      "backend.llm.call.heartbeat": ["elapsed_ms_since_start"],
       "backend.llm.call.response": [
         "provider",
         "model",
@@ -340,22 +251,10 @@
         "latency_ms",
         "error_class"
       ],
-      "backend.sse.first_byte": [
-        "delta_ms_from_ingress"
-      ],
-      "backend.sse.event": [
-        "event_type",
-        "payload_size_bytes",
-        "sequence_num"
-      ],
-      "backend.sse.aborted": [
-        "termination_kind",
-        "bytes_before_abort"
-      ],
-      "backend.agent.exit": [
-        "terminal_outcome",
-        "total_duration_ms"
-      ],
+      "backend.sse.first_byte": ["delta_ms_from_ingress"],
+      "backend.sse.event": ["event_type", "payload_size_bytes", "sequence_num"],
+      "backend.sse.aborted": ["termination_kind", "bytes_before_abort"],
+      "backend.agent.exit": ["terminal_outcome", "total_duration_ms"],
       "backend.response.complete": [
         "http_status",
         "content_length",
@@ -368,27 +267,11 @@
         "stack_brief",
         "truncated"
       ],
-      "aimock.request.ingress": [
-        "path",
-        "content_length",
-        "match_keys"
-      ],
-      "aimock.match.decision": [
-        "fixture_id",
-        "match_score",
-        "reject_reasons"
-      ],
-      "aimock.response.start": [
-        "delta_ms_from_ingress"
-      ],
-      "aimock.sse.chunk": [
-        "chunk_size_bytes",
-        "sequence_num"
-      ],
-      "aimock.response.aborted": [
-        "termination_kind",
-        "bytes_before_abort"
-      ],
+      "aimock.request.ingress": ["path", "content_length", "match_keys"],
+      "aimock.match.decision": ["fixture_id", "match_score", "reject_reasons"],
+      "aimock.response.start": ["delta_ms_from_ingress"],
+      "aimock.sse.chunk": ["chunk_size_bytes", "sequence_num"],
+      "aimock.response.aborted": ["termination_kind", "bytes_before_abort"],
       "aimock.response.complete": [
         "http_status",
         "total_bytes",

--- a/showcase/harness/src/cvdiag/schema.json
+++ b/showcase/harness/src/cvdiag/schema.json
@@ -39,11 +39,18 @@
       "pattern": "^[0-9a-f]{16}$"
     },
     "parent_span_id": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "layer": {
       "type": "string",
-      "enum": ["probe", "backend", "aimock"]
+      "enum": [
+        "probe",
+        "backend",
+        "aimock"
+      ]
     },
     "boundary": {
       "type": "string",
@@ -98,11 +105,19 @@
       "type": "integer"
     },
     "duration_ms": {
-      "type": ["integer", "null"]
+      "type": [
+        "integer",
+        "null"
+      ]
     },
     "outcome": {
       "type": "string",
-      "enum": ["ok", "err", "timeout", "info"]
+      "enum": [
+        "ok",
+        "err",
+        "timeout",
+        "info"
+      ]
     },
     "edge_headers": {
       "type": "object",
@@ -120,31 +135,58 @@
       ],
       "properties": {
         "cf-ray": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "cf-mitigated": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "cf-cache-status": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "x-railway-edge": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "x-railway-request-id": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "x-hikari-trace": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "retry-after": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "via": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "server": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },
@@ -159,8 +201,17 @@
     }
   },
   "$defs": {
-    "layers": ["probe", "backend", "aimock"],
-    "outcomes": ["ok", "err", "timeout", "info"],
+    "layers": [
+      "probe",
+      "backend",
+      "aimock"
+    ],
+    "outcomes": [
+      "ok",
+      "err",
+      "timeout",
+      "info"
+    ],
     "boundaries": [
       "probe.start",
       "probe.navigate.complete",
@@ -208,15 +259,44 @@
       "server"
     ],
     "boundary_metadata_keys": {
-      "probe.start": ["url", "viewport"],
-      "probe.navigate.complete": ["url", "nav_ms", "http_status"],
-      "probe.message.send": ["message_index", "char_count", "demo"],
-      "probe.dom.container.mount": ["delta_ms_from_start"],
-      "probe.dom.firsttoken": ["delta_ms_from_start", "text_length"],
-      "probe.dom.alternate_content": ["child_type_histogram"],
-      "probe.sse.event": ["event_type", "payload_size_bytes", "sequence_num"],
-      "probe.sse.aborted": ["termination_kind", "bytes_before_abort"],
-      "probe.network.error": ["url", "error_class", "response_status"],
+      "probe.start": [
+        "url",
+        "viewport"
+      ],
+      "probe.navigate.complete": [
+        "url",
+        "nav_ms",
+        "http_status"
+      ],
+      "probe.message.send": [
+        "message_index",
+        "char_count",
+        "demo"
+      ],
+      "probe.dom.container.mount": [
+        "delta_ms_from_start"
+      ],
+      "probe.dom.firsttoken": [
+        "delta_ms_from_start",
+        "text_length"
+      ],
+      "probe.dom.alternate_content": [
+        "child_type_histogram"
+      ],
+      "probe.sse.event": [
+        "event_type",
+        "payload_size_bytes",
+        "sequence_num"
+      ],
+      "probe.sse.aborted": [
+        "termination_kind",
+        "bytes_before_abort"
+      ],
+      "probe.network.error": [
+        "url",
+        "error_class",
+        "response_status"
+      ],
       "probe.network.response": [
         "url",
         "status",
@@ -236,14 +316,23 @@
         "first_token_delta_ms",
         "failure_classifier"
       ],
-      "backend.request.ingress": ["method", "path", "content_length"],
-      "backend.agent.enter": ["agent_name", "model_id"],
+      "backend.request.ingress": [
+        "method",
+        "path",
+        "content_length"
+      ],
+      "backend.agent.enter": [
+        "agent_name",
+        "model_id"
+      ],
       "backend.llm.call.start": [
         "provider",
         "model",
         "prompt_token_count_estimate"
       ],
-      "backend.llm.call.heartbeat": ["elapsed_ms_since_start"],
+      "backend.llm.call.heartbeat": [
+        "elapsed_ms_since_start"
+      ],
       "backend.llm.call.response": [
         "provider",
         "model",
@@ -251,10 +340,22 @@
         "latency_ms",
         "error_class"
       ],
-      "backend.sse.first_byte": ["delta_ms_from_ingress"],
-      "backend.sse.event": ["event_type", "payload_size_bytes", "sequence_num"],
-      "backend.sse.aborted": ["termination_kind", "bytes_before_abort"],
-      "backend.agent.exit": ["terminal_outcome", "total_duration_ms"],
+      "backend.sse.first_byte": [
+        "delta_ms_from_ingress"
+      ],
+      "backend.sse.event": [
+        "event_type",
+        "payload_size_bytes",
+        "sequence_num"
+      ],
+      "backend.sse.aborted": [
+        "termination_kind",
+        "bytes_before_abort"
+      ],
+      "backend.agent.exit": [
+        "terminal_outcome",
+        "total_duration_ms"
+      ],
       "backend.response.complete": [
         "http_status",
         "content_length",
@@ -267,11 +368,27 @@
         "stack_brief",
         "truncated"
       ],
-      "aimock.request.ingress": ["path", "content_length", "match_keys"],
-      "aimock.match.decision": ["fixture_id", "match_score", "reject_reasons"],
-      "aimock.response.start": ["delta_ms_from_ingress"],
-      "aimock.sse.chunk": ["chunk_size_bytes", "sequence_num"],
-      "aimock.response.aborted": ["termination_kind", "bytes_before_abort"],
+      "aimock.request.ingress": [
+        "path",
+        "content_length",
+        "match_keys"
+      ],
+      "aimock.match.decision": [
+        "fixture_id",
+        "match_score",
+        "reject_reasons"
+      ],
+      "aimock.response.start": [
+        "delta_ms_from_ingress"
+      ],
+      "aimock.sse.chunk": [
+        "chunk_size_bytes",
+        "sequence_num"
+      ],
+      "aimock.response.aborted": [
+        "termination_kind",
+        "bytes_before_abort"
+      ],
       "aimock.response.complete": [
         "http_status",
         "total_bytes",

--- a/showcase/harness/src/cvdiag/schema.ts
+++ b/showcase/harness/src/cvdiag/schema.ts
@@ -262,11 +262,35 @@ export interface ProbeConsoleErrorMeta {
   source_file: string | null;
   line_col: string | null;
 }
+/**
+ * Why a probe run failed, mirroring `waitForTurnComplete`'s reject `reason`
+ * union (conversation-runner `TurnNotCompleteError.reason`) plus
+ * `selector-mismatch` (a readiness/selector failure the d6 pill flow surfaces).
+ * Stamped on `probe.exit` ONLY when `terminal_outcome` is non-`ok` so reds are
+ * labeled directly in cvdiag probe data instead of being inferred from the
+ * absence of SSE / first-token rows.
+ */
+export const CVDIAG_FAILURE_CLASSIFIERS = [
+  "sse-missing",
+  "dom-missing",
+  "text-unstable",
+  "surface-missing",
+  "selector-mismatch",
+] as const;
+export type CvdiagFailureClassifier =
+  (typeof CVDIAG_FAILURE_CLASSIFIERS)[number];
+
 export interface ProbeExitMeta {
   terminal_outcome: CvdiagOutcome;
   total_duration_ms: number;
   sse_event_count: number;
   first_token_delta_ms: number | null;
+  /**
+   * Present ONLY on a non-`ok` terminal outcome. Classifies which turn-complete
+   * signal was missing (the `waitForTurnComplete` reject reason, or a derived
+   * best-effort classifier from the probe's own observed signals).
+   */
+  failure_classifier?: CvdiagFailureClassifier;
 }
 
 // Layer 2 (backend) ──────────────────────────────────────────────────────────
@@ -491,6 +515,7 @@ export const BOUNDARY_METADATA_KEYS: Record<
     "total_duration_ms",
     "sse_event_count",
     "first_token_delta_ms",
+    "failure_classifier",
   ],
   // backend
   "backend.request.ingress": ["method", "path", "content_length"],

--- a/showcase/harness/src/cvdiag/schema.ts
+++ b/showcase/harness/src/cvdiag/schema.ts
@@ -367,9 +367,21 @@ export interface AimockResponseCompleteMeta {
 export interface CvdiagEnvelope {
   /** const 1 in v1. */
   schema_version: typeof SCHEMA_VERSION;
-  /** UUIDv7, normalized lowercase hyphenated. */
+  /**
+   * The CROSS-LAYER JOIN KEY: the single id that joins one run's rows across
+   * probe / backend / aimock (spec §5). Normally a UUIDv7 (the probe mints one
+   * and threads it through). On the BACKEND adoption path it is the probe's
+   * per-run id forwarded as the inbound `x-test-id` (sanitized free text, e.g.
+   * `d4-<slug>-<runId>`) so backend rows join the probe's — PB stores this
+   * column as free text, so a non-UUIDv7 join key is valid at storage.
+   */
   test_id: string;
-  /** Equals `test_id` for join compatibility. */
+  /**
+   * The emitter's OWN PER-REQUEST id. MIRRORS `test_id` by default (probe path:
+   * one run = one test_id = one trace_id). The backend supplies a distinct
+   * per-request UUIDv7 so `trace_id` stays decoupled from an ADOPTED
+   * cross-layer `test_id`.
+   */
   trace_id: string;
   /** 16-hex, unique per emit. */
   span_id: string;

--- a/showcase/harness/src/http/fleet-runs.test.ts
+++ b/showcase/harness/src/http/fleet-runs.test.ts
@@ -16,7 +16,11 @@ import { describe, expect, it } from "vitest";
 import type { ListOpts, ListResult, PbClient } from "../storage/pb-client.js";
 import type { Logger } from "../types/index.js";
 import type { JobStatus } from "../fleet/job-claim.js";
-import type { JobProducer } from "../fleet/control-plane/job-producer.js";
+import type {
+  JobProducer,
+  TickOptions,
+  TickResult,
+} from "../fleet/control-plane/job-producer.js";
 import {
   FLEET_PRODUCER_DEEP_SCHEDULE_ID,
   FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
@@ -847,5 +851,174 @@ describe("createLruTtlMemo", () => {
     ).rejects.toThrow("boom");
     const z = await memo.get("z", async () => 7);
     expect(z).toBe(7);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// POST /api/runs/:family/trigger — on-demand fleet/D6 probe trigger
+// ───────────────────────────────────────────────────────────────────────
+
+const TRIGGER_TOKEN = "ops-secret-token";
+
+/** A producer that RECORDS its tick calls so a route test can assert the
+ *  enqueue path fired with the right (triggered + filter) options. */
+function recordingProducer(): {
+  producer: JobProducer;
+  ticks: TickOptions[];
+} {
+  const ticks: TickOptions[] = [];
+  const producer: JobProducer = {
+    start: () => {},
+    stop: async () => {},
+    isRunning: () => true,
+    tick: async (opts?: TickOptions): Promise<TickResult> => {
+      ticks.push(opts ?? {});
+      return {
+        runId: "frun_test_1",
+        // Two services enumerated + enqueued for this triggered run.
+        enqueued: 2,
+        enqueueFailures: 0,
+        skippedForBacklog: 0,
+        backlogGateFailedOpen: 0,
+        truncatedByStop: 0,
+        sweptExpired: false,
+        sweepFailed: false,
+        reclaimed: 0,
+        enumerateFailed: false,
+      };
+    },
+  };
+  return { producer, ticks };
+}
+
+/**
+ * Build an app whose four schedules each carry a RECORDING producer, plus the
+ * token-gated trigger route. Returns the per-family recorders so a test can
+ * assert which family's producer ticked.
+ */
+function makeTriggerApp(opts?: { withToken?: boolean; now?: () => number }): {
+  app: Hono;
+  ticksByFamily: Map<string, TickOptions[]>;
+} {
+  const app = new Hono();
+  const now = opts?.now ?? (() => NOW_MS);
+  const ticksByFamily = new Map<string, TickOptions[]>();
+  // family → scheduleId via the SCHEDULE_ID constants directly (not
+  // `fam.scheduleId`, which can be the import-cycle's undefined snapshot
+  // depending on module load order — see the route's familyToScheduleId).
+  const familyToScheduleId: Record<string, string> = {
+    d6: FLEET_PRODUCER_SCHEDULE_ID,
+    d5: FLEET_PRODUCER_DEEP_SCHEDULE_ID,
+    "e2e-demos": FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
+    "e2e-smoke": FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
+  };
+  const schedules: ProducerSchedule[] = FLEET_FAMILIES.map((fam) => {
+    const { producer, ticks } = recordingProducer();
+    ticksByFamily.set(fam.family, ticks);
+    const scheduleId = familyToScheduleId[fam.family];
+    const cron =
+      scheduleId === FLEET_PRODUCER_SCHEDULE_ID ? "40 * * * *" : "0 * * * *";
+    return { scheduleId, cron, producer };
+  });
+  const rv: RunViewDeps = {
+    pb: makeFakePb({}).pb,
+    scheduler: { nextRunAt: () => null },
+    schedules,
+    workerStaleAfterMs: 180_000,
+    logger: noopLogger,
+    now,
+  };
+  registerFleetRunsRoutes(app, {
+    summary: createMemoizedFamilySummary(rv),
+    pb: rv.pb,
+    schedules,
+    scheduler: rv.scheduler,
+    workerStaleAfterMs: rv.workerStaleAfterMs,
+    logger: noopLogger,
+    now,
+    ...(opts?.withToken === false ? {} : { triggerToken: TRIGGER_TOKEN }),
+  });
+  return { app, ticksByFamily };
+}
+
+describe("POST /api/runs/:family/trigger", () => {
+  it("401s without a valid bearer token", async () => {
+    const { app, ticksByFamily } = makeTriggerApp();
+    const noAuth = await app.request("/api/runs/d6/trigger", {
+      method: "POST",
+    });
+    expect(noAuth.status).toBe(401);
+    const wrong = await app.request("/api/runs/d6/trigger", {
+      method: "POST",
+      headers: { Authorization: "Bearer nope" },
+    });
+    expect(wrong.status).toBe(401);
+    // No producer ticked on a rejected trigger.
+    expect(ticksByFamily.get("d6")).toEqual([]);
+  });
+
+  it("fires the D6 producer's triggered tick and reports the enqueue", async () => {
+    const { app, ticksByFamily } = makeTriggerApp();
+    const res = await app.request("/api/runs/d6/trigger", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${TRIGGER_TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      family: string;
+      runId: string;
+      enqueued: number;
+    };
+    expect(body.family).toBe("d6");
+    expect(body.runId).toBe("frun_test_1");
+    expect(body.enqueued).toBe(2);
+    // The D6 producer ticked exactly once, as an OPERATOR-triggered run.
+    const ticks = ticksByFamily.get("d6") ?? [];
+    expect(ticks.length).toBe(1);
+    expect(ticks[0].triggered).toBe(true);
+    // Sibling families were not touched.
+    expect(ticksByFamily.get("e2e-smoke")).toEqual([]);
+  });
+
+  it("fires the correct producer for a non-D6 fleet family", async () => {
+    const { app, ticksByFamily } = makeTriggerApp();
+    const res = await app.request("/api/runs/e2e-smoke/trigger", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${TRIGGER_TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+    expect((ticksByFamily.get("e2e-smoke") ?? []).length).toBe(1);
+    expect(ticksByFamily.get("d6")).toEqual([]);
+  });
+
+  it("forwards a slug/featureType filter to the producer tick", async () => {
+    const { app, ticksByFamily } = makeTriggerApp();
+    const res = await app.request("/api/runs/d6/trigger", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${TRIGGER_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        filter: { slugs: ["langgraph-python"], featureTypes: ["d6"] },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const ticks = ticksByFamily.get("d6") ?? [];
+    expect(ticks.length).toBe(1);
+    expect(ticks[0].triggered).toBe(true);
+    expect(ticks[0].filter).toEqual({
+      slugs: ["langgraph-python"],
+      featureTypes: ["d6"],
+    });
+  });
+
+  it("404s for an unknown family", async () => {
+    const { app } = makeTriggerApp();
+    const res = await app.request("/api/runs/not-a-family/trigger", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${TRIGGER_TOKEN}` },
+    });
+    expect(res.status).toBe(404);
   });
 });

--- a/showcase/harness/src/http/fleet-runs.ts
+++ b/showcase/harness/src/http/fleet-runs.ts
@@ -21,6 +21,8 @@
  */
 
 import type { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { bearerAuth } from "./auth.js";
 import type { Logger } from "../types/index.js";
 import type { Scheduler } from "../scheduler/scheduler.js";
 import type { PbClient } from "../storage/pb-client.js";
@@ -29,6 +31,12 @@ import { isPoolCommErrorKind } from "../fleet/contracts.js";
 import { PROBE_JOBS_COLLECTION } from "../fleet/queue-client.js";
 import { PROBE_RUNS_COLLECTION } from "../probes/run-history.js";
 import type { ProducerSchedule } from "../fleet/control-plane/control-plane.js";
+import {
+  FLEET_PRODUCER_DEEP_SCHEDULE_ID,
+  FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
+  FLEET_PRODUCER_SCHEDULE_ID,
+  FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
+} from "../fleet/control-plane/control-plane.js";
 import {
   FLEET_FAMILIES,
   RUN_FETCH_MAX_PAGES,
@@ -79,7 +87,32 @@ export interface FleetRunsRouteDeps {
   workerStaleAfterMs: number;
   logger: Logger;
   now?: () => number;
+  /**
+   * Bearer token gating the on-demand `POST /api/runs/:family/trigger` route.
+   * When supplied (the CP role always supplies `OPS_TRIGGER_TOKEN`), the
+   * trigger route is mounted and `bearerAuth` enforces it; construction is
+   * fail-loud (MissingAuthTokenError) on an empty token. When OMITTED, the
+   * three read-only GET routes mount exactly as before but the mutating
+   * trigger route is NOT registered (older worker/test wiring that never
+   * triggers fleet runs). This is the ONE token-coupled fleet-runs route —
+   * the §5.2 GETs stay unconditionally mounted.
+   */
+  triggerToken?: string;
 }
+
+/**
+ * Window during which a successful fleet-trigger blocks any further trigger
+ * for the same family. Mirrors `/api/probes` `TRIGGER_RATE_LIMIT_MS` so an
+ * operator can't accidentally fan a family out twice in quick succession.
+ * In-memory per process — sufficient for the single CP instance.
+ */
+export const FLEET_TRIGGER_RATE_LIMIT_MS = 5 * 60 * 1000;
+
+/**
+ * Hard ceiling on the fleet-trigger POST body — operators only ever send a
+ * small slug/featureType filter. Mirrors `/api/probes` `TRIGGER_BODY_LIMIT_BYTES`.
+ */
+export const FLEET_TRIGGER_BODY_LIMIT_BYTES = 16 * 1024;
 
 // ───────────────────────────────────────────────────────────────────────
 // Response DTOs
@@ -661,4 +694,189 @@ export function registerFleetRunsRoutes(
       });
     }
   });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // POST /api/runs/:family/trigger — ON-DEMAND fleet/D6 probe trigger
+  //
+  // The §5.2 GETs are read-only; the fleet/D6 (and the other browser-family)
+  // probes are dispatched via the control-plane producer → queue → worker
+  // path and so were NOT manually fireable. This route closes that gap: it
+  // resolves the family to its registered producer (via FLEET_FAMILIES →
+  // scheduleId → schedules) and runs an OPERATOR-triggered tick
+  // (`tick({ triggered: true, filter })`), which enqueues one per-service job
+  // through the SAME job-producer path a cron tick uses — it does NOT
+  // reimplement the worker. Combined with `/api/probes/:id/trigger` (the
+  // in-process registered probes), EVERY probe is now on-demand triggerable.
+  //
+  // Mounted ONLY when `triggerToken` is supplied (mirrors `/api/probes`); the
+  // bearer gate is constructed up-front so a missing token fails loud at boot
+  // rather than exposing an unauthenticated trigger.
+  // ─────────────────────────────────────────────────────────────────────
+  if (deps.triggerToken !== undefined) {
+    const auth = bearerAuth({ expectedToken: deps.triggerToken });
+    const triggerBodyLimit = bodyLimit({
+      maxSize: FLEET_TRIGGER_BODY_LIMIT_BYTES,
+      onError: (c) =>
+        c.json({ error: "payload_too_large" } as const, 413) as unknown as
+          | Response
+          | Promise<Response>,
+    });
+    // Per-family last-trigger timestamp for the rate-limit window.
+    const lastTriggerAt = new Map<string, number>();
+    // family → scheduleId. Mirrors the FLEET_FAMILIES registry's family↔
+    // scheduleId join, but reads the scheduleId from the constants DIRECTLY
+    // rather than `fam.scheduleId`: `FLEET_FAMILIES` and the SCHEDULE_ID
+    // constants live in a documented import cycle (run-view ⇄ control-plane),
+    // so depending on module load order `fam.scheduleId` can be the cycle's
+    // undefined snapshot — the constants themselves (plain string literals
+    // with no cycle dependency) are always defined. Keyed off the registry's
+    // `family` ids so adding a family is still a one-line registry change.
+    const familyToScheduleId: Record<string, string> = {
+      d6: FLEET_PRODUCER_SCHEDULE_ID,
+      d5: FLEET_PRODUCER_DEEP_SCHEDULE_ID,
+      "e2e-demos": FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
+      "e2e-smoke": FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
+    };
+    // family → producer schedule, joined via the injected schedules. A family
+    // whose scheduleId has no schedule entry is unfireable here (404) — same
+    // UX as an unknown family.
+    const scheduleById = new Map(deps.schedules.map((s) => [s.scheduleId, s]));
+    const producerByFamily = new Map<string, ProducerSchedule>();
+    for (const fam of FLEET_FAMILIES) {
+      const scheduleId = familyToScheduleId[fam.family];
+      const sched = scheduleId ? scheduleById.get(scheduleId) : undefined;
+      if (sched) producerByFamily.set(fam.family, sched);
+    }
+
+    app.post("/api/runs/:family/trigger", auth, triggerBodyLimit, async (c) => {
+      c.header("Cache-Control", "no-cache");
+      const family = c.req.param("family");
+      const sched = producerByFamily.get(family);
+      if (!sched) {
+        return c.json({ error: "not_found" }, 404);
+      }
+
+      // Read + validate the body BEFORE stamping the rate-limit window so a
+      // malformed filter never burns the operator's hold (mirrors /api/probes).
+      let raw: string;
+      try {
+        raw = await c.req.text();
+      } catch (err) {
+        if (err instanceof Error && err.name === "BodyLimitError") {
+          return c.json({ error: "payload_too_large" }, 413);
+        }
+        return c.json({ error: "invalid_body" }, 400);
+      }
+      if (Buffer.byteLength(raw, "utf8") > FLEET_TRIGGER_BODY_LIMIT_BYTES) {
+        return c.json({ error: "payload_too_large" }, 413);
+      }
+
+      // Optional operator filter — `slugs` (string[]) scopes which services
+      // enumerate; `featureTypes` (non-empty string[]) narrows cells. Both
+      // forwarded verbatim to the producer's TickOptions.filter.
+      let filter: { slugs?: string[]; featureTypes?: string[] } | undefined;
+      if (raw.length > 0) {
+        let parsed: { filter?: { slugs?: unknown; featureTypes?: unknown } };
+        try {
+          parsed = JSON.parse(raw) as {
+            filter?: { slugs?: unknown; featureTypes?: unknown };
+          };
+        } catch {
+          return c.json({ error: "invalid_json" }, 400);
+        }
+        if (parsed && typeof parsed === "object" && parsed.filter) {
+          const slugs = (parsed.filter as { slugs?: unknown }).slugs;
+          let outSlugs: string[] | undefined;
+          if (slugs !== undefined) {
+            if (
+              !Array.isArray(slugs) ||
+              !slugs.every((s): s is string => typeof s === "string")
+            ) {
+              return c.json({ error: "invalid_filter" }, 400);
+            }
+            outSlugs = slugs;
+          }
+          const featureTypes = (parsed.filter as { featureTypes?: unknown })
+            .featureTypes;
+          let outFeatureTypes: string[] | undefined;
+          if (featureTypes !== undefined) {
+            if (
+              !Array.isArray(featureTypes) ||
+              featureTypes.length === 0 ||
+              !featureTypes.every(
+                (s): s is string => typeof s === "string" && s.length > 0,
+              )
+            ) {
+              return c.json(
+                {
+                  error: "invalid_filter",
+                  message: "featureTypes must be a non-empty array of strings",
+                },
+                400,
+              );
+            }
+            outFeatureTypes = featureTypes;
+          }
+          if (outSlugs !== undefined || outFeatureTypes !== undefined) {
+            filter = {
+              ...(outSlugs !== undefined ? { slugs: outSlugs } : {}),
+              ...(outFeatureTypes !== undefined
+                ? { featureTypes: outFeatureTypes }
+                : {}),
+            };
+          }
+        }
+      }
+
+      // Stamp the rate-limit window AFTER validation passes, with a CAS
+      // rollback on failure so a concurrent trigger's stamp survives.
+      const last = lastTriggerAt.get(family);
+      const t = now();
+      if (last !== undefined && t - last < FLEET_TRIGGER_RATE_LIMIT_MS) {
+        return c.json(
+          {
+            error: "rate_limited",
+            retryAfterMs: FLEET_TRIGGER_RATE_LIMIT_MS - (t - last),
+          },
+          429,
+        );
+      }
+      lastTriggerAt.set(family, t);
+      const rollbackRateLimit = (): void => {
+        if (lastTriggerAt.get(family) !== t) return;
+        if (last === undefined) lastTriggerAt.delete(family);
+        else lastTriggerAt.set(family, last);
+      };
+
+      try {
+        // Operator-triggered tick: bypasses the producer's backlog gate and
+        // enqueues one per-service job through the existing producer path. A
+        // filter is TRIGGER-ONLY (the producer ignores filters on scheduled
+        // ticks); forwarding it under `triggered: true` is the supported scope.
+        const result = await sched.producer.tick({
+          triggered: true,
+          ...(filter !== undefined ? { filter } : {}),
+        });
+        return c.json({
+          family,
+          runId: result.runId,
+          enqueued: result.enqueued,
+          enqueueFailures: result.enqueueFailures,
+          skippedForBacklog: result.skippedForBacklog,
+          scope: filter?.slugs ?? null,
+          featureTypesScope: filter?.featureTypes ?? null,
+        });
+      } catch (err) {
+        // A producer tick never rejects by contract, but guard anyway: roll
+        // back the rate-limit stamp so a transient failure doesn't lock the
+        // operator out of the window for the next 5 minutes.
+        rollbackRateLimit();
+        deps.logger.error("fleet-runs.trigger-failed", {
+          family,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return c.json({ family, error: "trigger_failed" }, 500);
+      }
+    });
+  }
 }

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -3302,6 +3302,14 @@ export async function runControlPlane(
     // role — `summary` is the §5.2 shared memo instance the §9 monitor also
     // reads, so a dashboard poll and a monitor evaluation inside the same TTL
     // share one PB fan-out.
+    //
+    // On-demand fleet/D6 trigger: when an OPS_TRIGGER_TOKEN is configured
+    // (the same token gating /api/probes), `triggerToken` mounts the mutating
+    // POST /api/runs/:family/trigger route so EVERY fleet/D6 probe is
+    // on-demand fireable — it enqueues an operator-triggered run through the
+    // producer this CP already owns. The three GETs stay unconditionally
+    // mounted regardless; only the trigger route is token-gated (and skipped
+    // when the token is unset, mirroring probesDeps).
     fleetRuns: {
       summary: familySummary,
       pb,
@@ -3309,6 +3317,7 @@ export async function runControlPlane(
       scheduler,
       workerStaleAfterMs,
       logger,
+      ...(triggerToken ? { triggerToken } : {}),
     },
     // §9 compensating control: stamp the monitor's last evaluation cycle into
     // /health so an external poll can detect a wedged monitor.

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -747,6 +747,7 @@ describe("e2eChatToolsDriver module export", () => {
 // specific boundaries.
 
 import { CvdiagEmitter } from "../../cvdiag/index.js";
+import { sanitizeJoinTestId } from "../../cvdiag/emit.js";
 import type { CvdiagEnvelope } from "../../cvdiag/index.js";
 import type { CvdiagPbWriter } from "../../cvdiag/pb-writer.js";
 import type {
@@ -1106,14 +1107,21 @@ describe("d4 CVDIAG probe instrumentation (L1-A)", () => {
 
     // A raw-byte sample was captured.
     expect(rawByteSamples.length).toBeGreaterThan(0);
-    // Every emitted event for this level shares ONE test_id (the minted UUIDv7).
+    // Every emitted event for this level shares ONE stable session test_id.
     const eventIds = new Set(captured.map((e) => e.test_id));
     expect(eventIds.size).toBe(1);
     const eventTestId = [...eventIds][0]!;
-    // The raw-byte sample carries the SAME test_id → the join resolves.
+    // The raw-byte sample carries the SAME test_id → the intra-layer
+    // raw-byte ↔ events join resolves.
     expect(rawByteSamples[0]!.test_id).toBe(eventTestId);
-    // And it is NOT the raw d4-<slug>-<runId> X-Test-Id (the pre-fix value).
-    expect(rawByteSamples[0]!.test_id).not.toMatch(/^d4-/);
+    // leg-3: the shared session test_id is the backend-adopted/sanitized
+    // forwarded X-Test-Id — `sanitizeJoinTestId("d4-foo-<runId>")` — NOT a fresh
+    // random UUIDv7. This is the value the backend derives from the same inbound
+    // header, so the cross-layer probe↔backend join now also closes. The
+    // sanitizer preserves the `d4-` prefix (it is `[a-z0-9._-]`), so the
+    // resolved id is the forwarded id, lowercased.
+    expect(eventTestId).toMatch(/^d4-foo-/);
+    expect(eventTestId).toBe(sanitizeJoinTestId(eventTestId));
   });
 });
 
@@ -1766,5 +1774,75 @@ describe("d4 A/B internal routing (Phase 8)", () => {
     // RED (pre-fix): one lone edge orphan was collected. GREEN: nothing —
     // no internal sibling means no half-pair is emitted.
     expect(collected).toEqual([]);
+  });
+});
+
+describe("d4 CVDIAG cross-layer join: probe adopts the forwarded X-Test-Id", () => {
+  function bufDir(): string {
+    return mkdtempSync(join(tmpdir(), "cvdiag-test-"));
+  }
+
+  // ── leg 3: probe records the SAME forwarded X-Test-Id the backend adopts ───
+  it("probe cvdiag test_id == sanitizeJoinTestId(forwarded X-Test-Id), NOT a fresh UUIDv7, so probe↔backend rows join", async () => {
+    // The probe forwards a per-run id (`d6-<slug>-<runId>` / `d4-<slug>-<runId>`)
+    // as the `X-Test-Id` request header. The backend (this branch) ADOPTS that
+    // inbound header verbatim, normalizing it via `sanitizeJoinTestId`, as its
+    // cvdiag `test_id` — the cross-layer join key (spec §5).
+    //
+    // RED (pre-fix): `CvdiagProbeSession` re-minted a RANDOM UUIDv7 for its own
+    // cvdiag `test_id` (the forwarded id is not a UUIDv7, so the constructor's
+    // `isValidTestId(opts.testId) ? opts.testId : mintTestId()` fell through to
+    // a fresh mint). Result: probe.* rows carried a UUIDv7 that NEVER equals the
+    // backend's adopted/sanitized id → the join did not close.
+    //
+    // GREEN (post-fix): the session records `sanitizeJoinTestId(forwardedId)` —
+    // the EXACT value the backend derives from the same inbound header — so both
+    // sides share one `test_id`.
+    const forwarded = "d6-built-in-agent-run-ABC";
+    // The value the BACKEND adopts from the same inbound header. Mirroring the
+    // backend's sanitize here makes the cross-layer match provable from the
+    // probe side alone.
+    const backendAdopted = sanitizeJoinTestId(forwarded);
+    expect(backendAdopted).not.toBeNull();
+
+    const writer = new CaptureWriter();
+    const emitter = new CvdiagEmitter({
+      verbose: true,
+      env: {},
+      layer: "probe",
+      pbWriter: writer,
+    });
+    const session = new CvdiagProbeSession({
+      emitter,
+      // The forwarded X-Test-Id — exactly what the driver passes to both the
+      // request header AND this session (see runLevel: testId is the per-level
+      // X-Test-Id, and the same value is set as the `X-Test-Id` request header).
+      testId: forwarded,
+      slug: "built-in",
+      demo: "agentic-chat",
+      bufferDir: bufDir(),
+      nowMs: 0,
+    });
+    // Drive an open/close pair so at least two probe.* rows are emitted.
+    session.start("https://x.example.com/demos/agentic-chat", {
+      width: 1280,
+      height: 720,
+    });
+    session.exit("ok", 1);
+    await emitter.flush();
+
+    const rows = writer.events;
+    expect(rows.length).toBeGreaterThan(0);
+    // EVERY probe.* row carries the SAME test_id (the session's resolved id).
+    const ids = new Set(rows.map((e) => e.test_id));
+    expect(ids.size).toBe(1);
+    const probeTestId = [...ids][0]!;
+    // The crux: the probe's cvdiag test_id is the backend-adopted/sanitized
+    // forwarded id — NOT a fresh random UUIDv7 — so the cross-layer join closes.
+    expect(probeTestId).toBe(backendAdopted);
+    // And the session's resolvedTestId (used by raw-byte samples) agrees, so the
+    // intra-layer raw-byte↔events join is preserved while the cross-layer join
+    // now also closes.
+    expect(session.resolvedTestId).toBe(backendAdopted);
   });
 });

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -940,6 +940,65 @@ describe("d4 CVDIAG probe instrumentation (L1-A)", () => {
     expect(alt[0]!.metadata.child_type_histogram).toEqual({ pre: 1, code: 2 });
   });
 
+  it("labels a failed run (empty SSE, no first-token) on probe.exit with outcome=err + failure_classifier=sse-missing", async () => {
+    // RED (pre-fix): a run that produces NO SSE events and NO first-token
+    // (empty assistant text) still emits `probe.exit` with `terminal_outcome=ok`
+    // and no failure classifier — so reds are indistinguishable from greens in
+    // cvdiag probe data. GREEN: the same run emits `outcome=err` AND a
+    // `failure_classifier=sse-missing` (no SSE => earliest-missing signal) in
+    // metadata, so the red is labeled at the probe.exit boundary.
+    const { emitter, writer } = makeCvdiagEmitter();
+    await runWith(
+      // No `sseEvents`, empty assistant text => no probe.dom.firsttoken,
+      // sse_event_count=0 => the run actually failed.
+      { assistantText: "", alternateHistogram: { div: 1 } },
+      emitter,
+    );
+    const exit = byBoundary(writer, "probe.exit");
+    expect(exit.length).toBe(1);
+    expect(exit[0]!.outcome).toBe("err");
+    expect(exit[0]!.metadata.terminal_outcome).toBe("err");
+    expect(exit[0]!.metadata.failure_classifier).toBe("sse-missing");
+  });
+
+  it("keeps a passing run on probe.exit at outcome=ok with no failure_classifier", async () => {
+    // GREEN-CONTROL: a clean run (assistant text present, an SSE run-finished
+    // event) stays `terminal_outcome=ok` and carries NO failure classifier.
+    const { emitter, writer } = makeCvdiagEmitter();
+    await runWith(
+      {
+        assistantText: "Hello there",
+        sseEvents: [{ eventType: "RUN_FINISHED", payloadSizeBytes: 10 }],
+      },
+      emitter,
+    );
+    const exit = byBoundary(writer, "probe.exit");
+    expect(exit.length).toBe(1);
+    expect(exit[0]!.outcome).toBe("ok");
+    expect(exit[0]!.metadata.terminal_outcome).toBe("ok");
+    expect(exit[0]!.metadata.failure_classifier).toBeUndefined();
+  });
+
+  it("classifies a run that streamed SSE but never rendered a DOM bubble as failure_classifier=dom-missing", async () => {
+    // RED (pre-fix): SSE arrived but no assistant bubble ever rendered (empty
+    // text, no first-token) — still `terminal_outcome=ok`. GREEN: `outcome=err`
+    // with `failure_classifier=dom-missing` (SSE present => not sse-missing;
+    // no first-token => DOM never produced a token).
+    const { emitter, writer } = makeCvdiagEmitter();
+    await runWith(
+      {
+        assistantText: "",
+        alternateHistogram: { div: 1 },
+        sseEvents: [{ eventType: "RUN_FINISHED", payloadSizeBytes: 10 }],
+      },
+      emitter,
+    );
+    const exit = byBoundary(writer, "probe.exit");
+    expect(exit.length).toBe(1);
+    expect(exit[0]!.outcome).toBe("err");
+    expect(exit[0]!.metadata.failure_classifier).toBe("dom-missing");
+  });
+
   it("captures a browser console.error in probe.console.error", async () => {
     const { emitter, writer } = makeCvdiagEmitter();
     await runWith(

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -19,6 +19,7 @@ import {
 } from "../../cvdiag/index.js";
 import type {
   CvdiagEnvelope,
+  CvdiagFailureClassifier,
   CvdiagOutcome,
   ProbeSseEventMeta,
   TerminationKind,
@@ -776,8 +777,20 @@ export class CvdiagProbeSession {
    * Terminal `probe.exit`. On a `timeout` outcome, first flush the entire
    * pre-timeout SSE window UNSAMPLED (class-(e) carve-out rule 2) so the
    * cross-layer `sequence_num` join is complete, THEN emit `probe.exit`.
+   *
+   * `failureClassifier` labels WHY a non-`ok` run failed. When the caller has
+   * the authoritative reason (e.g. `waitForTurnComplete`'s
+   * `TurnNotCompleteError.reason`) it passes it explicitly; otherwise, for a
+   * non-`ok` outcome, this derives a best-effort classifier from the probe's
+   * OWN observed signals (no SSE => `sse-missing`; SSE seen but no DOM
+   * first-token => `dom-missing`; else `text-unstable`) so reds are always
+   * labeled in cvdiag probe data. An `ok` outcome NEVER carries a classifier.
    */
-  exit(terminalOutcome: CvdiagOutcome, totalDurationMs: number): void {
+  exit(
+    terminalOutcome: CvdiagOutcome,
+    totalDurationMs: number,
+    failureClassifier?: CvdiagFailureClassifier,
+  ): void {
     if (terminalOutcome === "timeout") {
       // Flush ONLY events not already emitted live. Re-emitting the full
       // buffered window (including the already-live-emitted subset) duplicated
@@ -795,6 +808,14 @@ export class CvdiagProbeSession {
       }
       this.pendingSse.length = 0;
     }
+    // Label the failure. An explicit reason (from the caller, e.g.
+    // `waitForTurnComplete`'s reject `reason`) wins; otherwise derive a
+    // best-effort classifier from this probe's own observed signals. `ok`
+    // runs never carry a classifier (greens stay unlabeled).
+    const resolvedClassifier: CvdiagFailureClassifier | undefined =
+      terminalOutcome === "ok"
+        ? undefined
+        : (failureClassifier ?? this.deriveFailureClassifier());
     this.fire({
       boundary: "probe.exit",
       outcome: terminalOutcome,
@@ -804,8 +825,26 @@ export class CvdiagProbeSession {
         total_duration_ms: totalDurationMs,
         sse_event_count: this.sseEmittedCount,
         first_token_delta_ms: this.firstTokenDeltaMs,
+        // Only present on a non-`ok` outcome (undefined keys are dropped by
+        // the emit-time metadata validator, so greens carry no classifier).
+        ...(resolvedClassifier !== undefined
+          ? { failure_classifier: resolvedClassifier }
+          : {}),
       },
     });
+  }
+
+  /**
+   * Best-effort failure classifier from the probe's OWN observed signals,
+   * mirroring `waitForTurnComplete`'s precedence (earliest-missing signal
+   * wins): no SSE event => `sse-missing`; SSE seen but no DOM first-token =>
+   * `dom-missing`; SSE + first-token both seen but the run still failed (the
+   * text never settled / assertion red) => `text-unstable`.
+   */
+  private deriveFailureClassifier(): CvdiagFailureClassifier {
+    if (this.sseEmittedCount === 0) return "sse-missing";
+    if (this.firstTokenDeltaMs === null) return "dom-missing";
+    return "text-unstable";
   }
 }
 
@@ -2050,10 +2089,19 @@ async function runLevel(opts: {
     }
 
     const assertion = assertResponse(responseText);
-    // probe.exit (ok path) — a clean completion regardless of the assertion
-    // verdict (red on a missing-vocab/empty response is still a clean run; the
-    // terminal_outcome reflects probe MECHANICS, not the green/red assertion).
-    cvdiagExit(cvdiag, "ok");
+    // probe.exit (completion path). A missing-VOCAB response is still a clean
+    // MECHANICAL run (real response present) → `terminal_outcome=ok`, reflecting
+    // probe mechanics not the green/red vocab assertion. But a run that produced
+    // NOTHING — no SSE event AND no DOM first-token (`cvdiagResponseEmpty`) — is
+    // a genuine probe FAILURE (e.g. a first-token timeout with sse_event_count=0)
+    // that previously mislabeled itself `ok`, making reds indistinguishable from
+    // greens in cvdiag. Label it `err` with the derived failure classifier so the
+    // red is identifiable directly from probe.exit.
+    if (cvdiagResponseEmpty) {
+      cvdiagExit(cvdiag, "err");
+    } else {
+      cvdiagExit(cvdiag, "ok");
+    }
     cvdiagExited = true;
     return {
       result: {
@@ -2075,8 +2123,16 @@ async function runLevel(opts: {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     // probe.exit (error path) — `timeout` when the level aborted (the driver's
-    // hard-timeout / external abort fired), else `err`.
-    cvdiagExit(cvdiag, abortSignal.aborted ? "timeout" : "err");
+    // hard-timeout / external abort fired), else `err`. When the throw is a
+    // `waitForTurnComplete` `TurnNotCompleteError` (duck-typed via its `reason`
+    // field so this module stays decoupled from conversation-runner), thread the
+    // authoritative reject reason as the failure classifier; otherwise `exit`
+    // derives one from the probe's own observed signals.
+    cvdiagExit(
+      cvdiag,
+      abortSignal.aborted ? "timeout" : "err",
+      turnCompleteReason(err),
+    );
     cvdiagExited = true;
     return {
       result: {
@@ -2120,9 +2176,50 @@ async function runLevel(opts: {
   function cvdiagExit(
     session: CvdiagProbeSession | undefined,
     outcome: CvdiagOutcome,
+    failureClassifier?: CvdiagFailureClassifier,
   ): void {
-    session?.exit(outcome, Math.round(nowMonoMs() - cvdiagStartMs));
+    session?.exit(
+      outcome,
+      Math.round(nowMonoMs() - cvdiagStartMs),
+      failureClassifier,
+    );
   }
+}
+
+/**
+ * Set of valid CVDIAG failure classifiers, for the duck-typed
+ * `TurnNotCompleteError.reason` guard below. Kept in sync with the schema's
+ * `CVDIAG_FAILURE_CLASSIFIERS` union (a mismatch is caught by the
+ * `satisfies` assertion).
+ */
+const FAILURE_CLASSIFIER_SET: ReadonlySet<CvdiagFailureClassifier> = new Set([
+  "sse-missing",
+  "dom-missing",
+  "text-unstable",
+  "surface-missing",
+  "selector-mismatch",
+] satisfies CvdiagFailureClassifier[]);
+
+/**
+ * Extract a CVDIAG failure classifier from a thrown error when it is a
+ * `waitForTurnComplete` `TurnNotCompleteError` (duck-typed via its `reason`
+ * field so this driver stays decoupled from conversation-runner). Returns
+ * `undefined` for any other throw, leaving the session to derive a best-effort
+ * classifier from its own observed signals.
+ */
+function turnCompleteReason(err: unknown): CvdiagFailureClassifier | undefined {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    "reason" in err &&
+    typeof (err as { reason: unknown }).reason === "string"
+  ) {
+    const reason = (err as { reason: string }).reason;
+    if (FAILURE_CLASSIFIER_SET.has(reason as CvdiagFailureClassifier)) {
+      return reason as CvdiagFailureClassifier;
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -34,7 +34,11 @@ import {
   sanitizeTestId,
 } from "../../cvdiag/ab-hmac.js";
 import type { AbOutcomeRecord } from "../../cvdiag/ab-report.js";
-import { mintSpanId as mintAbPairId, mintTestId } from "../../cvdiag/emit.js";
+import {
+  mintSpanId as mintAbPairId,
+  mintTestId,
+  sanitizeJoinTestId,
+} from "../../cvdiag/emit.js";
 import { isValidTestId } from "../../cvdiag/schema.js";
 
 /**
@@ -488,15 +492,28 @@ export class CvdiagProbeSession {
     nowMs: number;
   }) {
     this.emitter = opts.emitter;
-    // Resolve ONE stable test_id for the whole session. The probe's X-Test-Id
-    // is `d4-<slug>-<runId>`, NOT a UUIDv7 — if we threaded that raw value into
-    // every emit(), the emitter's entry-bounding would drop it and mint a
-    // FRESH random UUIDv7 PER CALL, so each boundary row would carry a
-    // different test_id and the per-run correlation (and the
-    // cvdiag_raw_byte_samples ↔ cvdiag_events join) would break. Mint the
-    // UUIDv7 ONCE here and thread the SAME value through every emit + the
-    // raw-byte sample so all rows for this level share one test_id.
-    this.testId = isValidTestId(opts.testId) ? opts.testId : mintTestId();
+    // Resolve ONE stable test_id for the whole session — the CROSS-LAYER JOIN
+    // KEY (spec §5). The probe's X-Test-Id is `d4-<slug>-<runId>` /
+    // `d6-<slug>-<runId>`, NOT a UUIDv7. It is forwarded verbatim as the
+    // `X-Test-Id` request header, and the backend ADOPTS that inbound header as
+    // its OWN cvdiag `test_id`, normalizing it through `sanitizeJoinTestId`. So
+    // the probe MUST record the SAME normalized value — `sanitizeJoinTestId`
+    // applied to the SAME forwarded id — for probe.* rows to JOIN backend.* rows
+    // on `test_id`. Recording a fresh random UUIDv7 here (the pre-fix behavior)
+    // gave probe rows an id the backend never derives, so the join never closed.
+    //
+    // Resolution order (all branches yield ONE stable id threaded through every
+    // emit() + the raw-byte sample, so intra-layer rows stay correlated too):
+    //   1. a value already a valid UUIDv7 → keep it verbatim (legacy callers
+    //      that mint a UUIDv7 up front; `sanitizeJoinTestId` only runs on
+    //      genuinely non-UUIDv7 inputs, matching the emitter/backend contract);
+    //   2. else sanitize the forwarded id the SAME way the backend does — this
+    //      is the join key both sides share;
+    //   3. else (nothing survives sanitization) mint a fresh UUIDv7 fallback so
+    //      every row still carries a valid, stable id.
+    this.testId = isValidTestId(opts.testId)
+      ? opts.testId
+      : (sanitizeJoinTestId(opts.testId) ?? mintTestId());
     this.slug = opts.slug;
     this.demo = opts.demo;
     this.bufferDir = opts.bufferDir;
@@ -1685,8 +1702,10 @@ async function runLevel(opts: {
 
   // CVDIAG session for THIS level (one test_id). The probe-layer test_id is
   // the per-level X-Test-Id so harness↔backend↔aimock correlate on the same
-  // key. The CvdiagEmitter normalizes/validates; if the X-Test-Id is not a
-  // UUIDv7 the emitter mints one rather than emitting an invalid envelope.
+  // key. The forwarded X-Test-Id (`d4-/d6-<slug>-<runId>`) is not a UUIDv7, so
+  // the session records `sanitizeJoinTestId(X-Test-Id)` — the SAME value the
+  // backend adopts from the same inbound header — making probe.* rows JOIN
+  // backend.* rows on `test_id` (spec §5).
   const cvdiag =
     cvdiagEmitter !== undefined
       ? new CvdiagProbeSession({

--- a/showcase/integrations/built-in-agent/src/cvdiag-backend-persist.e2e.test.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag-backend-persist.e2e.test.ts
@@ -356,7 +356,9 @@ describeMaybe(
         NODE_ENV: "test",
       } as NodeJS.ProcessEnv);
 
-      const boundaries = new Set((await rowsBySlug(slug)).map((r) => r.boundary));
+      const boundaries = new Set(
+        (await rowsBySlug(slug)).map((r) => r.boundary),
+      );
       // gap #2: the boundaries needed to discriminate slow-first-token from a
       // true stall are all present.
       for (const expected of [

--- a/showcase/integrations/built-in-agent/src/cvdiag-backend-persist.e2e.test.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag-backend-persist.e2e.test.ts
@@ -129,6 +129,60 @@ async function countRowsBySlug(slug: string): Promise<number> {
   return body.totalItems;
 }
 
+interface CvdiagRow {
+  test_id: string;
+  trace_id: string;
+  boundary: string;
+}
+
+/** Fetch every persisted row for a slug (for the join-key assertions). */
+async function rowsBySlug(slug: string): Promise<CvdiagRow[]> {
+  const tok = await adminToken();
+  const list = await fetch(
+    `${BASE}/api/collections/cvdiag_events/records?perPage=200&filter=${encodeURIComponent(
+      `slug="${slug}"`,
+    )}`,
+    { headers: { authorization: tok } },
+  );
+  const body = (await list.json()) as { items: CvdiagRow[] };
+  return body.items;
+}
+
+/**
+ * Drive one wrapped request carrying an inbound probe `x-test-id` header (the
+ * cross-layer join key) to completion. Mirrors `driveRequest` but stamps the
+ * header so the persisted rows can be asserted to JOIN on it.
+ */
+async function driveRequestWithTestId(
+  slug: string,
+  inboundTestId: string,
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  const saved = { ...process.env };
+  Object.assign(process.env, env);
+  try {
+    const wrapped = withCvdiagBackend(streamingHandler(), {
+      slug,
+      agentName: "default",
+      provider: "openai",
+    });
+    const req = new Request("https://example.test/api/copilotkit", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-test-id": inboundTestId,
+      },
+      body: "{}",
+    });
+    const res = await wrapped(req);
+    await res.text();
+  } finally {
+    for (const k of Object.keys(env)) delete process.env[k];
+    Object.assign(process.env, saved);
+  }
+  await new Promise((r) => setTimeout(r, 1500));
+}
+
 /** Drive one wrapped request to completion, fully draining the body so the
  * stream-close terminals + background flush fire. */
 async function driveRequest(
@@ -257,6 +311,62 @@ describeMaybe(
 
       const rows = await countRowsBySlug(slug);
       expect(rows).toBe(0);
+    }, 30_000);
+
+    it("adopts the inbound x-test-id as test_id so backend rows JOIN the probe (trace_id stays per-request)", async () => {
+      const slug = "bia-persist-join";
+      // The probe forwards a per-run id (NOT a UUIDv7) as x-test-id.
+      const inboundTestId = "d4-built-in-agent-run-7f3a";
+      await driveRequestWithTestId(slug, inboundTestId, {
+        CVDIAG_BACKEND_EMITTER: "1",
+        CVDIAG_PB_URL: BASE,
+        CVDIAG_WRITER_KEY: WRITER_PASSWORD,
+        SHOWCASE_ENV: "test",
+        NODE_ENV: "test",
+      } as NodeJS.ProcessEnv);
+
+      const rows = await rowsBySlug(slug);
+      expect(rows.length).toBeGreaterThan(0);
+
+      // GREEN gap #1: EVERY backend row carries the inbound id as test_id (the
+      // cross-layer join key) — NOT a minted UUIDv7. Pre-fix this was a fresh
+      // random UUIDv7 per request → probe↔backend rows shared zero test_ids.
+      for (const row of rows) {
+        expect(row.test_id).toBe(inboundTestId);
+      }
+      // The backend's OWN per-request id is the trace_id — a valid UUIDv7,
+      // DISTINCT from the adopted (non-UUIDv7) test_id.
+      const traceIds = new Set(rows.map((r) => r.trace_id));
+      for (const traceId of traceIds) {
+        expect(traceId).not.toBe(inboundTestId);
+        expect(traceId).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+        );
+      }
+    }, 30_000);
+
+    it("persists the slow-first-token boundaries (request.ingress / sse.first_byte / llm.call.*) at verbose tier", async () => {
+      const slug = "bia-persist-boundaries";
+      await driveRequestWithTestId(slug, "d6-built-in-agent-bset", {
+        CVDIAG_BACKEND_EMITTER: "1",
+        CVDIAG_PB_URL: BASE,
+        CVDIAG_WRITER_KEY: WRITER_PASSWORD,
+        CVDIAG_VERBOSE: "1",
+        SHOWCASE_ENV: "test",
+        NODE_ENV: "test",
+      } as NodeJS.ProcessEnv);
+
+      const boundaries = new Set((await rowsBySlug(slug)).map((r) => r.boundary));
+      // gap #2: the boundaries needed to discriminate slow-first-token from a
+      // true stall are all present.
+      for (const expected of [
+        "backend.request.ingress",
+        "backend.sse.first_byte",
+        "backend.llm.call.start",
+        "backend.llm.call.response",
+      ]) {
+        expect(boundaries.has(expected)).toBe(true);
+      }
     }, 30_000);
   },
 );

--- a/showcase/integrations/built-in-agent/src/cvdiag-backend.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag-backend.ts
@@ -104,6 +104,25 @@ function contentLength(headers: Headers): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+/**
+ * Read the inbound probe `x-test-id` — the CROSS-LAYER JOIN KEY (spec §5). The
+ * probe mints a per-run id (`d4-/d6-<slug>-<runId>`) and prefix-forwards it on
+ * every request; the backend MUST adopt it as the envelope `test_id` so its
+ * rows JOIN the probe's rows. Returns the trimmed header value, or undefined
+ * when absent/blank (→ the emitter mints a fresh UUIDv7). The emitter
+ * sanitizes/validates the value, so we forward it as-is here.
+ */
+function inboundTestId(headers: Headers): string | undefined {
+  try {
+    const raw = headers.get("x-test-id");
+    if (raw === null) return undefined;
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Snapshot the allow-listed edge headers off a header bag. */
 function edgeHeadersFrom(
   headers: Headers,
@@ -147,7 +166,14 @@ export function withCvdiagBackend<Req extends Request>(
     const emitter =
       opts.emitter ??
       new CvdiagEmitter({ layer: "backend", autoFlush: true, pbWriter });
-    const testId = mintTestId();
+    // CROSS-LAYER JOIN (spec §5): adopt the inbound probe `x-test-id` as the
+    // envelope `test_id` so backend rows join the probe's rows on the SAME run
+    // key. When the header is absent, the emitter mints a fresh UUIDv7. The
+    // backend's OWN per-request id is a freshly minted UUIDv7 passed as
+    // `traceId` — kept DISTINCT from an adopted (non-UUIDv7) `test_id` so
+    // trace/span stay per-request (NOT the shared run id).
+    const testId = inboundTestId(req.headers);
+    const traceId = mintTestId();
     const startedAt = Date.now();
     const path = requestPath(req);
     const edgeHeaders = safeEdgeHeaders(req);
@@ -165,6 +191,7 @@ export function withCvdiagBackend<Req extends Request>(
         demo: opts.slug,
         outcome,
         testId,
+        traceId,
         edgeHeaders,
         metadata,
         durationMs,

--- a/showcase/integrations/built-in-agent/src/cvdiag/emit.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag/emit.ts
@@ -92,6 +92,36 @@ export const SLUG_FALLBACK = "unknown";
 const SLUG_MAX_LEN = 64;
 /** 16-hex lowercase span-id shape (spec §5 `span_id` / `parent_span_id`). */
 const SPAN_ID_REGEX = /^[0-9a-f]{16}$/;
+/**
+ * Max length (chars) of a sanitized free-text cross-layer join key adopted from
+ * an inbound `x-test-id` header. The probe's per-run id (`d4-<slug>-<runId>` /
+ * `d6-<slug>-<runId>`) is well under this; the cap defends against an
+ * unbounded/hostile header value while keeping the key usable as a PB filter.
+ */
+const JOIN_TEST_ID_MAX_LEN = 128;
+
+/**
+ * Sanitize an inbound, non-UUIDv7 `x-test-id` into a SAFE, DETERMINISTIC
+ * free-text cross-layer join key (spec §5 `test_id`). The transform is pure and
+ * deterministic so the probe and the backend, applying it to the SAME inbound
+ * header, derive the SAME join key:
+ *   1. lowercase + trim surrounding whitespace,
+ *   2. drop EVERYTHING except `[a-z0-9._-]` (strips whitespace, control chars,
+ *      NUL, and any injection-prone punctuation — the key is used verbatim in a
+ *      PB filter string),
+ *   3. cap to `JOIN_TEST_ID_MAX_LEN`.
+ * Returns `null` when nothing survives (→ caller mints a fresh UUIDv7). A value
+ * that is ALREADY a valid UUIDv7 is handled by the caller before this is
+ * reached, so this only ever runs on genuinely non-UUIDv7 inputs.
+ */
+export function sanitizeJoinTestId(raw: string): string | null {
+  const cleaned = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, "")
+    .slice(0, JOIN_TEST_ID_MAX_LEN);
+  return cleaned.length > 0 ? cleaned : null;
+}
 
 /** In-memory queue cap (spec §7 R5-F5). */
 export const QUEUE_CAP = 5000;
@@ -141,8 +171,31 @@ export interface CvdiagEmitArgs {
   metadata?: Record<string, unknown>;
   durationMs?: number | null;
   parentSpanId?: string | null;
-  /** Override test_id (e.g. probe.start mints one and threads it through). */
+  /**
+   * Override the envelope `test_id` — the CROSS-LAYER JOIN KEY (spec §5: the
+   * single id that joins one run's rows across probe / backend / aimock). Two
+   * shapes are honored:
+   *   - a valid UUIDv7 (e.g. probe.start mints one and threads it through), OR
+   *   - a probe-minted per-run id forwarded as the inbound `x-test-id` header
+   *     (e.g. `d4-<slug>-<runId>` — NOT a UUIDv7). The backend MUST adopt this
+   *     verbatim (sanitized to a safe free-text key) so its rows JOIN the
+   *     probe's rows. PB stores `test_id` as free text, so a non-UUIDv7 join
+   *     key is valid at the storage layer — the cross-layer correlation is the
+   *     whole point.
+   * An absent / empty / unsanitizable value falls back to a freshly minted
+   * UUIDv7.
+   */
   testId?: string;
+  /**
+   * Override the envelope `trace_id` — the emitter's OWN PER-REQUEST id
+   * (spec §5: trace/span are per-request, test_id is the shared run id). The
+   * backend mints a fresh UUIDv7 per request and passes it here so `trace_id`
+   * stays decoupled from an ADOPTED cross-layer `test_id`. When omitted,
+   * `trace_id` mirrors `test_id` (the historical probe-path invariant). Honored
+   * only when it is a valid UUIDv7 or 16-hex span id; otherwise it falls back
+   * to mirroring `test_id`.
+   */
+  traceId?: string;
 }
 
 /**
@@ -258,8 +311,18 @@ export interface BoundEntryFields {
   slug: string;
   demo: string;
   parentSpanId: string | null;
-  /** A valid UUIDv7 override to honor, or undefined to mint fresh. */
+  /**
+   * The cross-layer join key to honor, or undefined to mint a fresh UUIDv7.
+   * Either a valid UUIDv7 (passed through unchanged) OR a sanitized non-UUIDv7
+   * inbound `x-test-id` adopted verbatim so backend rows JOIN the probe's.
+   */
   testId: string | undefined;
+  /**
+   * The emitter's OWN per-request id (a valid UUIDv7 or 16-hex span id) to use
+   * as `trace_id`, or undefined to mirror `test_id` (historical probe-path
+   * invariant). Decouples `trace_id` from an ADOPTED non-UUIDv7 `test_id`.
+   */
+  traceId: string | undefined;
   /** True iff any field was sanitized/bounded (diagnostic; does NOT set _truncated). */
   boundedAny: boolean;
 }
@@ -307,14 +370,32 @@ export function boundEntryFields(args: CvdiagEmitArgs): BoundEntryFields {
     boundedAny = true;
   }
 
-  // testId override → honor only if a valid UUIDv7; else undefined (mint fresh).
+  // testId override → the CROSS-LAYER JOIN KEY (spec §5). Honor a valid UUIDv7
+  // verbatim. For a non-UUIDv7 inbound id (the probe's `d4-/d6-<slug>-<runId>`
+  // forwarded as `x-test-id`), ADOPT it via the deterministic sanitizer so the
+  // backend's rows join the probe's — PB stores `test_id` as free text, so a
+  // non-UUIDv7 join key is valid at storage. Only an absent / empty /
+  // fully-stripped value falls through to a freshly minted UUIDv7.
   let testId: string | undefined = args.testId;
   if (testId !== undefined && !isValidTestId(testId)) {
-    testId = undefined;
+    const adopted = sanitizeJoinTestId(testId);
+    if (adopted === null || adopted !== testId) boundedAny = true;
+    testId = adopted ?? undefined;
+  }
+
+  // traceId override → the emitter's OWN per-request id. Honor a valid UUIDv7
+  // or 16-hex span id; anything else falls through to mirroring `test_id`.
+  let traceId: string | undefined = args.traceId;
+  if (
+    traceId !== undefined &&
+    !isValidTestId(traceId) &&
+    !SPAN_ID_REGEX.test(traceId)
+  ) {
+    traceId = undefined;
     boundedAny = true;
   }
 
-  return { slug, demo, parentSpanId, testId, boundedAny };
+  return { slug, demo, parentSpanId, testId, traceId, boundedAny };
 }
 
 /**
@@ -473,6 +554,11 @@ export class CvdiagEmitter {
     // fallback keeps `trace_id` (its mirror) valid.
     const bound = boundEntryFields(args);
     const testId = bound.testId ?? mintTestId();
+    // `trace_id` is the emitter's OWN per-request id. It MIRRORS `test_id` by
+    // default (probe path: one run = one test_id = one trace_id), but the
+    // backend supplies a distinct per-request UUIDv7 via `traceId` so it stays
+    // decoupled from an ADOPTED cross-layer `test_id` (spec §5).
+    const traceId = bound.traceId ?? testId;
     const isDataPlane = !args.boundary.startsWith(ACCOUNTING_PREFIX);
     let metadata: Record<string, unknown> = {};
     let metadataDropped = false;
@@ -497,7 +583,7 @@ export class CvdiagEmitter {
     const envelope: CvdiagEnvelope = {
       schema_version: SCHEMA_VERSION,
       test_id: testId,
-      trace_id: testId,
+      trace_id: traceId,
       span_id: mintSpanId(),
       parent_span_id: bound.parentSpanId,
       layer: args.layer,
@@ -548,14 +634,16 @@ export class CvdiagEmitter {
    * ONLY the three genuinely-unbounded inputs — the `metadata` bag, the
    * free-text `demo` string, and the free-string `edge_headers` VALUES — and
    * NEVER touches a format-constrained field. It cannot produce a non-16-hex
-   * `span_id`/`parent_span_id`, break the documented `trace_id === test_id`
-   * join, or write a `slug` that violates the PB/codegen contract
+   * `span_id`/`parent_span_id`, alter the `test_id`/`trace_id` join keys (they
+   * are minted/adopted/entry-bound, never clamped), or write a `slug` that
+   * violates the PB/codegen contract
    * `^[a-z][a-z0-9-]{0,63}$`, because those fields are NOT in the clamp set at
    * all. They are bounded by construction:
    *   - `slug`     — entry-bounded to ≤64 pattern-valid chars (`boundEntryFields`)
    *   - `demo`     — entry-bounded to ≤`DEMO_MAX_LEN` (then the only clampable field)
    *   - `parent_span_id` — entry-bounded to 16-hex or `null`
-   *   - `test_id`/`trace_id` — minted UUIDv7 (36 chars), `trace_id === test_id`
+   *   - `test_id` — minted UUIDv7 OR an adopted/sanitized inbound join key
+   *     (≤128 chars); `trace_id` — minted UUIDv7 or a mirror of `test_id`
    *   - `span_id`  — minted 16-hex
    *   - `schema_version` (const int), `layer`/`boundary`/`outcome` (enums),
    *     `ts` (ISO-8601), `mono_ns`/`duration_ms` (numbers)

--- a/showcase/integrations/built-in-agent/src/cvdiag/schema.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag/schema.ts
@@ -262,11 +262,35 @@ export interface ProbeConsoleErrorMeta {
   source_file: string | null;
   line_col: string | null;
 }
+/**
+ * Why a probe run failed, mirroring `waitForTurnComplete`'s reject `reason`
+ * union (conversation-runner `TurnNotCompleteError.reason`) plus
+ * `selector-mismatch` (a readiness/selector failure the d6 pill flow surfaces).
+ * Stamped on `probe.exit` ONLY when `terminal_outcome` is non-`ok` so reds are
+ * labeled directly in cvdiag probe data instead of being inferred from the
+ * absence of SSE / first-token rows.
+ */
+export const CVDIAG_FAILURE_CLASSIFIERS = [
+  "sse-missing",
+  "dom-missing",
+  "text-unstable",
+  "surface-missing",
+  "selector-mismatch",
+] as const;
+export type CvdiagFailureClassifier =
+  (typeof CVDIAG_FAILURE_CLASSIFIERS)[number];
+
 export interface ProbeExitMeta {
   terminal_outcome: CvdiagOutcome;
   total_duration_ms: number;
   sse_event_count: number;
   first_token_delta_ms: number | null;
+  /**
+   * Present ONLY on a non-`ok` terminal outcome. Classifies which turn-complete
+   * signal was missing (the `waitForTurnComplete` reject reason, or a derived
+   * best-effort classifier from the probe's own observed signals).
+   */
+  failure_classifier?: CvdiagFailureClassifier;
 }
 
 // Layer 2 (backend) ──────────────────────────────────────────────────────────
@@ -491,6 +515,7 @@ export const BOUNDARY_METADATA_KEYS: Record<
     "total_duration_ms",
     "sse_event_count",
     "first_token_delta_ms",
+    "failure_classifier",
   ],
   // backend
   "backend.request.ingress": ["method", "path", "content_length"],

--- a/showcase/integrations/built-in-agent/src/cvdiag/schema.ts
+++ b/showcase/integrations/built-in-agent/src/cvdiag/schema.ts
@@ -367,9 +367,21 @@ export interface AimockResponseCompleteMeta {
 export interface CvdiagEnvelope {
   /** const 1 in v1. */
   schema_version: typeof SCHEMA_VERSION;
-  /** UUIDv7, normalized lowercase hyphenated. */
+  /**
+   * The CROSS-LAYER JOIN KEY: the single id that joins one run's rows across
+   * probe / backend / aimock (spec §5). Normally a UUIDv7 (the probe mints one
+   * and threads it through). On the BACKEND adoption path it is the probe's
+   * per-run id forwarded as the inbound `x-test-id` (sanitized free text, e.g.
+   * `d4-<slug>-<runId>`) so backend rows join the probe's — PB stores this
+   * column as free text, so a non-UUIDv7 join key is valid at storage.
+   */
   test_id: string;
-  /** Equals `test_id` for join compatibility. */
+  /**
+   * The emitter's OWN PER-REQUEST id. MIRRORS `test_id` by default (probe path:
+   * one run = one test_id = one trace_id). The backend supplies a distinct
+   * per-request UUIDv7 so `trace_id` stays decoupled from an ADOPTED
+   * cross-layer `test_id`.
+   */
   trace_id: string;
   /** 16-hex, unique per emit. */
   span_id: string;

--- a/showcase/integrations/claude-sdk-typescript/src/cvdiag-backend.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/cvdiag-backend.ts
@@ -104,6 +104,25 @@ function contentLength(headers: Headers): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+/**
+ * Read the inbound probe `x-test-id` — the CROSS-LAYER JOIN KEY (spec §5). The
+ * probe mints a per-run id (`d4-/d6-<slug>-<runId>`) and prefix-forwards it on
+ * every request; the backend MUST adopt it as the envelope `test_id` so its
+ * rows JOIN the probe's rows. Returns the trimmed header value, or undefined
+ * when absent/blank (→ the emitter mints a fresh UUIDv7). The emitter
+ * sanitizes/validates the value, so we forward it as-is here.
+ */
+function inboundTestId(headers: Headers): string | undefined {
+  try {
+    const raw = headers.get("x-test-id");
+    if (raw === null) return undefined;
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Snapshot the allow-listed edge headers off a header bag. */
 function edgeHeadersFrom(
   headers: Headers,
@@ -147,7 +166,14 @@ export function withCvdiagBackend<Req extends Request>(
     const emitter =
       opts.emitter ??
       new CvdiagEmitter({ layer: "backend", autoFlush: true, pbWriter });
-    const testId = mintTestId();
+    // CROSS-LAYER JOIN (spec §5): adopt the inbound probe `x-test-id` as the
+    // envelope `test_id` so backend rows join the probe's rows on the SAME run
+    // key. When the header is absent, the emitter mints a fresh UUIDv7. The
+    // backend's OWN per-request id is a freshly minted UUIDv7 passed as
+    // `traceId` — kept DISTINCT from an adopted (non-UUIDv7) `test_id` so
+    // trace/span stay per-request (NOT the shared run id).
+    const testId = inboundTestId(req.headers);
+    const traceId = mintTestId();
     const startedAt = Date.now();
     const path = requestPath(req);
     const edgeHeaders = safeEdgeHeaders(req);
@@ -165,6 +191,7 @@ export function withCvdiagBackend<Req extends Request>(
         demo: opts.slug,
         outcome,
         testId,
+        traceId,
         edgeHeaders,
         metadata,
         durationMs,

--- a/showcase/integrations/claude-sdk-typescript/src/cvdiag/emit.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/cvdiag/emit.ts
@@ -92,6 +92,36 @@ export const SLUG_FALLBACK = "unknown";
 const SLUG_MAX_LEN = 64;
 /** 16-hex lowercase span-id shape (spec §5 `span_id` / `parent_span_id`). */
 const SPAN_ID_REGEX = /^[0-9a-f]{16}$/;
+/**
+ * Max length (chars) of a sanitized free-text cross-layer join key adopted from
+ * an inbound `x-test-id` header. The probe's per-run id (`d4-<slug>-<runId>` /
+ * `d6-<slug>-<runId>`) is well under this; the cap defends against an
+ * unbounded/hostile header value while keeping the key usable as a PB filter.
+ */
+const JOIN_TEST_ID_MAX_LEN = 128;
+
+/**
+ * Sanitize an inbound, non-UUIDv7 `x-test-id` into a SAFE, DETERMINISTIC
+ * free-text cross-layer join key (spec §5 `test_id`). The transform is pure and
+ * deterministic so the probe and the backend, applying it to the SAME inbound
+ * header, derive the SAME join key:
+ *   1. lowercase + trim surrounding whitespace,
+ *   2. drop EVERYTHING except `[a-z0-9._-]` (strips whitespace, control chars,
+ *      NUL, and any injection-prone punctuation — the key is used verbatim in a
+ *      PB filter string),
+ *   3. cap to `JOIN_TEST_ID_MAX_LEN`.
+ * Returns `null` when nothing survives (→ caller mints a fresh UUIDv7). A value
+ * that is ALREADY a valid UUIDv7 is handled by the caller before this is
+ * reached, so this only ever runs on genuinely non-UUIDv7 inputs.
+ */
+export function sanitizeJoinTestId(raw: string): string | null {
+  const cleaned = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, "")
+    .slice(0, JOIN_TEST_ID_MAX_LEN);
+  return cleaned.length > 0 ? cleaned : null;
+}
 
 /** In-memory queue cap (spec §7 R5-F5). */
 export const QUEUE_CAP = 5000;
@@ -141,8 +171,31 @@ export interface CvdiagEmitArgs {
   metadata?: Record<string, unknown>;
   durationMs?: number | null;
   parentSpanId?: string | null;
-  /** Override test_id (e.g. probe.start mints one and threads it through). */
+  /**
+   * Override the envelope `test_id` — the CROSS-LAYER JOIN KEY (spec §5: the
+   * single id that joins one run's rows across probe / backend / aimock). Two
+   * shapes are honored:
+   *   - a valid UUIDv7 (e.g. probe.start mints one and threads it through), OR
+   *   - a probe-minted per-run id forwarded as the inbound `x-test-id` header
+   *     (e.g. `d4-<slug>-<runId>` — NOT a UUIDv7). The backend MUST adopt this
+   *     verbatim (sanitized to a safe free-text key) so its rows JOIN the
+   *     probe's rows. PB stores `test_id` as free text, so a non-UUIDv7 join
+   *     key is valid at the storage layer — the cross-layer correlation is the
+   *     whole point.
+   * An absent / empty / unsanitizable value falls back to a freshly minted
+   * UUIDv7.
+   */
   testId?: string;
+  /**
+   * Override the envelope `trace_id` — the emitter's OWN PER-REQUEST id
+   * (spec §5: trace/span are per-request, test_id is the shared run id). The
+   * backend mints a fresh UUIDv7 per request and passes it here so `trace_id`
+   * stays decoupled from an ADOPTED cross-layer `test_id`. When omitted,
+   * `trace_id` mirrors `test_id` (the historical probe-path invariant). Honored
+   * only when it is a valid UUIDv7 or 16-hex span id; otherwise it falls back
+   * to mirroring `test_id`.
+   */
+  traceId?: string;
 }
 
 /**
@@ -258,8 +311,18 @@ export interface BoundEntryFields {
   slug: string;
   demo: string;
   parentSpanId: string | null;
-  /** A valid UUIDv7 override to honor, or undefined to mint fresh. */
+  /**
+   * The cross-layer join key to honor, or undefined to mint a fresh UUIDv7.
+   * Either a valid UUIDv7 (passed through unchanged) OR a sanitized non-UUIDv7
+   * inbound `x-test-id` adopted verbatim so backend rows JOIN the probe's.
+   */
   testId: string | undefined;
+  /**
+   * The emitter's OWN per-request id (a valid UUIDv7 or 16-hex span id) to use
+   * as `trace_id`, or undefined to mirror `test_id` (historical probe-path
+   * invariant). Decouples `trace_id` from an ADOPTED non-UUIDv7 `test_id`.
+   */
+  traceId: string | undefined;
   /** True iff any field was sanitized/bounded (diagnostic; does NOT set _truncated). */
   boundedAny: boolean;
 }
@@ -307,14 +370,32 @@ export function boundEntryFields(args: CvdiagEmitArgs): BoundEntryFields {
     boundedAny = true;
   }
 
-  // testId override → honor only if a valid UUIDv7; else undefined (mint fresh).
+  // testId override → the CROSS-LAYER JOIN KEY (spec §5). Honor a valid UUIDv7
+  // verbatim. For a non-UUIDv7 inbound id (the probe's `d4-/d6-<slug>-<runId>`
+  // forwarded as `x-test-id`), ADOPT it via the deterministic sanitizer so the
+  // backend's rows join the probe's — PB stores `test_id` as free text, so a
+  // non-UUIDv7 join key is valid at storage. Only an absent / empty /
+  // fully-stripped value falls through to a freshly minted UUIDv7.
   let testId: string | undefined = args.testId;
   if (testId !== undefined && !isValidTestId(testId)) {
-    testId = undefined;
+    const adopted = sanitizeJoinTestId(testId);
+    if (adopted === null || adopted !== testId) boundedAny = true;
+    testId = adopted ?? undefined;
+  }
+
+  // traceId override → the emitter's OWN per-request id. Honor a valid UUIDv7
+  // or 16-hex span id; anything else falls through to mirroring `test_id`.
+  let traceId: string | undefined = args.traceId;
+  if (
+    traceId !== undefined &&
+    !isValidTestId(traceId) &&
+    !SPAN_ID_REGEX.test(traceId)
+  ) {
+    traceId = undefined;
     boundedAny = true;
   }
 
-  return { slug, demo, parentSpanId, testId, boundedAny };
+  return { slug, demo, parentSpanId, testId, traceId, boundedAny };
 }
 
 /**
@@ -473,6 +554,11 @@ export class CvdiagEmitter {
     // fallback keeps `trace_id` (its mirror) valid.
     const bound = boundEntryFields(args);
     const testId = bound.testId ?? mintTestId();
+    // `trace_id` is the emitter's OWN per-request id. It MIRRORS `test_id` by
+    // default (probe path: one run = one test_id = one trace_id), but the
+    // backend supplies a distinct per-request UUIDv7 via `traceId` so it stays
+    // decoupled from an ADOPTED cross-layer `test_id` (spec §5).
+    const traceId = bound.traceId ?? testId;
     const isDataPlane = !args.boundary.startsWith(ACCOUNTING_PREFIX);
     let metadata: Record<string, unknown> = {};
     let metadataDropped = false;
@@ -497,7 +583,7 @@ export class CvdiagEmitter {
     const envelope: CvdiagEnvelope = {
       schema_version: SCHEMA_VERSION,
       test_id: testId,
-      trace_id: testId,
+      trace_id: traceId,
       span_id: mintSpanId(),
       parent_span_id: bound.parentSpanId,
       layer: args.layer,
@@ -548,14 +634,16 @@ export class CvdiagEmitter {
    * ONLY the three genuinely-unbounded inputs — the `metadata` bag, the
    * free-text `demo` string, and the free-string `edge_headers` VALUES — and
    * NEVER touches a format-constrained field. It cannot produce a non-16-hex
-   * `span_id`/`parent_span_id`, break the documented `trace_id === test_id`
-   * join, or write a `slug` that violates the PB/codegen contract
+   * `span_id`/`parent_span_id`, alter the `test_id`/`trace_id` join keys (they
+   * are minted/adopted/entry-bound, never clamped), or write a `slug` that
+   * violates the PB/codegen contract
    * `^[a-z][a-z0-9-]{0,63}$`, because those fields are NOT in the clamp set at
    * all. They are bounded by construction:
    *   - `slug`     — entry-bounded to ≤64 pattern-valid chars (`boundEntryFields`)
    *   - `demo`     — entry-bounded to ≤`DEMO_MAX_LEN` (then the only clampable field)
    *   - `parent_span_id` — entry-bounded to 16-hex or `null`
-   *   - `test_id`/`trace_id` — minted UUIDv7 (36 chars), `trace_id === test_id`
+   *   - `test_id` — minted UUIDv7 OR an adopted/sanitized inbound join key
+   *     (≤128 chars); `trace_id` — minted UUIDv7 or a mirror of `test_id`
    *   - `span_id`  — minted 16-hex
    *   - `schema_version` (const int), `layer`/`boundary`/`outcome` (enums),
    *     `ts` (ISO-8601), `mono_ns`/`duration_ms` (numbers)

--- a/showcase/integrations/claude-sdk-typescript/src/cvdiag/schema.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/cvdiag/schema.ts
@@ -262,11 +262,35 @@ export interface ProbeConsoleErrorMeta {
   source_file: string | null;
   line_col: string | null;
 }
+/**
+ * Why a probe run failed, mirroring `waitForTurnComplete`'s reject `reason`
+ * union (conversation-runner `TurnNotCompleteError.reason`) plus
+ * `selector-mismatch` (a readiness/selector failure the d6 pill flow surfaces).
+ * Stamped on `probe.exit` ONLY when `terminal_outcome` is non-`ok` so reds are
+ * labeled directly in cvdiag probe data instead of being inferred from the
+ * absence of SSE / first-token rows.
+ */
+export const CVDIAG_FAILURE_CLASSIFIERS = [
+  "sse-missing",
+  "dom-missing",
+  "text-unstable",
+  "surface-missing",
+  "selector-mismatch",
+] as const;
+export type CvdiagFailureClassifier =
+  (typeof CVDIAG_FAILURE_CLASSIFIERS)[number];
+
 export interface ProbeExitMeta {
   terminal_outcome: CvdiagOutcome;
   total_duration_ms: number;
   sse_event_count: number;
   first_token_delta_ms: number | null;
+  /**
+   * Present ONLY on a non-`ok` terminal outcome. Classifies which turn-complete
+   * signal was missing (the `waitForTurnComplete` reject reason, or a derived
+   * best-effort classifier from the probe's own observed signals).
+   */
+  failure_classifier?: CvdiagFailureClassifier;
 }
 
 // Layer 2 (backend) ──────────────────────────────────────────────────────────
@@ -491,6 +515,7 @@ export const BOUNDARY_METADATA_KEYS: Record<
     "total_duration_ms",
     "sse_event_count",
     "first_token_delta_ms",
+    "failure_classifier",
   ],
   // backend
   "backend.request.ingress": ["method", "path", "content_length"],

--- a/showcase/integrations/claude-sdk-typescript/src/cvdiag/schema.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/cvdiag/schema.ts
@@ -367,9 +367,21 @@ export interface AimockResponseCompleteMeta {
 export interface CvdiagEnvelope {
   /** const 1 in v1. */
   schema_version: typeof SCHEMA_VERSION;
-  /** UUIDv7, normalized lowercase hyphenated. */
+  /**
+   * The CROSS-LAYER JOIN KEY: the single id that joins one run's rows across
+   * probe / backend / aimock (spec §5). Normally a UUIDv7 (the probe mints one
+   * and threads it through). On the BACKEND adoption path it is the probe's
+   * per-run id forwarded as the inbound `x-test-id` (sanitized free text, e.g.
+   * `d4-<slug>-<runId>`) so backend rows join the probe's — PB stores this
+   * column as free text, so a non-UUIDv7 join key is valid at storage.
+   */
   test_id: string;
-  /** Equals `test_id` for join compatibility. */
+  /**
+   * The emitter's OWN PER-REQUEST id. MIRRORS `test_id` by default (probe path:
+   * one run = one test_id = one trace_id). The backend supplies a distinct
+   * per-request UUIDv7 so `trace_id` stays decoupled from an ADOPTED
+   * cross-layer `test_id`.
+   */
   trace_id: string;
   /** 16-hex, unique per emit. */
   span_id: string;

--- a/showcase/integrations/langgraph-typescript/src/cvdiag-backend.ts
+++ b/showcase/integrations/langgraph-typescript/src/cvdiag-backend.ts
@@ -104,6 +104,25 @@ function contentLength(headers: Headers): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+/**
+ * Read the inbound probe `x-test-id` — the CROSS-LAYER JOIN KEY (spec §5). The
+ * probe mints a per-run id (`d4-/d6-<slug>-<runId>`) and prefix-forwards it on
+ * every request; the backend MUST adopt it as the envelope `test_id` so its
+ * rows JOIN the probe's rows. Returns the trimmed header value, or undefined
+ * when absent/blank (→ the emitter mints a fresh UUIDv7). The emitter
+ * sanitizes/validates the value, so we forward it as-is here.
+ */
+function inboundTestId(headers: Headers): string | undefined {
+  try {
+    const raw = headers.get("x-test-id");
+    if (raw === null) return undefined;
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Snapshot the allow-listed edge headers off a header bag. */
 function edgeHeadersFrom(
   headers: Headers,
@@ -147,7 +166,14 @@ export function withCvdiagBackend<Req extends Request>(
     const emitter =
       opts.emitter ??
       new CvdiagEmitter({ layer: "backend", autoFlush: true, pbWriter });
-    const testId = mintTestId();
+    // CROSS-LAYER JOIN (spec §5): adopt the inbound probe `x-test-id` as the
+    // envelope `test_id` so backend rows join the probe's rows on the SAME run
+    // key. When the header is absent, the emitter mints a fresh UUIDv7. The
+    // backend's OWN per-request id is a freshly minted UUIDv7 passed as
+    // `traceId` — kept DISTINCT from an adopted (non-UUIDv7) `test_id` so
+    // trace/span stay per-request (NOT the shared run id).
+    const testId = inboundTestId(req.headers);
+    const traceId = mintTestId();
     const startedAt = Date.now();
     const path = requestPath(req);
     const edgeHeaders = safeEdgeHeaders(req);
@@ -165,6 +191,7 @@ export function withCvdiagBackend<Req extends Request>(
         demo: opts.slug,
         outcome,
         testId,
+        traceId,
         edgeHeaders,
         metadata,
         durationMs,

--- a/showcase/integrations/langgraph-typescript/src/cvdiag/emit.ts
+++ b/showcase/integrations/langgraph-typescript/src/cvdiag/emit.ts
@@ -92,6 +92,36 @@ export const SLUG_FALLBACK = "unknown";
 const SLUG_MAX_LEN = 64;
 /** 16-hex lowercase span-id shape (spec §5 `span_id` / `parent_span_id`). */
 const SPAN_ID_REGEX = /^[0-9a-f]{16}$/;
+/**
+ * Max length (chars) of a sanitized free-text cross-layer join key adopted from
+ * an inbound `x-test-id` header. The probe's per-run id (`d4-<slug>-<runId>` /
+ * `d6-<slug>-<runId>`) is well under this; the cap defends against an
+ * unbounded/hostile header value while keeping the key usable as a PB filter.
+ */
+const JOIN_TEST_ID_MAX_LEN = 128;
+
+/**
+ * Sanitize an inbound, non-UUIDv7 `x-test-id` into a SAFE, DETERMINISTIC
+ * free-text cross-layer join key (spec §5 `test_id`). The transform is pure and
+ * deterministic so the probe and the backend, applying it to the SAME inbound
+ * header, derive the SAME join key:
+ *   1. lowercase + trim surrounding whitespace,
+ *   2. drop EVERYTHING except `[a-z0-9._-]` (strips whitespace, control chars,
+ *      NUL, and any injection-prone punctuation — the key is used verbatim in a
+ *      PB filter string),
+ *   3. cap to `JOIN_TEST_ID_MAX_LEN`.
+ * Returns `null` when nothing survives (→ caller mints a fresh UUIDv7). A value
+ * that is ALREADY a valid UUIDv7 is handled by the caller before this is
+ * reached, so this only ever runs on genuinely non-UUIDv7 inputs.
+ */
+export function sanitizeJoinTestId(raw: string): string | null {
+  const cleaned = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, "")
+    .slice(0, JOIN_TEST_ID_MAX_LEN);
+  return cleaned.length > 0 ? cleaned : null;
+}
 
 /** In-memory queue cap (spec §7 R5-F5). */
 export const QUEUE_CAP = 5000;
@@ -141,8 +171,31 @@ export interface CvdiagEmitArgs {
   metadata?: Record<string, unknown>;
   durationMs?: number | null;
   parentSpanId?: string | null;
-  /** Override test_id (e.g. probe.start mints one and threads it through). */
+  /**
+   * Override the envelope `test_id` — the CROSS-LAYER JOIN KEY (spec §5: the
+   * single id that joins one run's rows across probe / backend / aimock). Two
+   * shapes are honored:
+   *   - a valid UUIDv7 (e.g. probe.start mints one and threads it through), OR
+   *   - a probe-minted per-run id forwarded as the inbound `x-test-id` header
+   *     (e.g. `d4-<slug>-<runId>` — NOT a UUIDv7). The backend MUST adopt this
+   *     verbatim (sanitized to a safe free-text key) so its rows JOIN the
+   *     probe's rows. PB stores `test_id` as free text, so a non-UUIDv7 join
+   *     key is valid at the storage layer — the cross-layer correlation is the
+   *     whole point.
+   * An absent / empty / unsanitizable value falls back to a freshly minted
+   * UUIDv7.
+   */
   testId?: string;
+  /**
+   * Override the envelope `trace_id` — the emitter's OWN PER-REQUEST id
+   * (spec §5: trace/span are per-request, test_id is the shared run id). The
+   * backend mints a fresh UUIDv7 per request and passes it here so `trace_id`
+   * stays decoupled from an ADOPTED cross-layer `test_id`. When omitted,
+   * `trace_id` mirrors `test_id` (the historical probe-path invariant). Honored
+   * only when it is a valid UUIDv7 or 16-hex span id; otherwise it falls back
+   * to mirroring `test_id`.
+   */
+  traceId?: string;
 }
 
 /**
@@ -258,8 +311,18 @@ export interface BoundEntryFields {
   slug: string;
   demo: string;
   parentSpanId: string | null;
-  /** A valid UUIDv7 override to honor, or undefined to mint fresh. */
+  /**
+   * The cross-layer join key to honor, or undefined to mint a fresh UUIDv7.
+   * Either a valid UUIDv7 (passed through unchanged) OR a sanitized non-UUIDv7
+   * inbound `x-test-id` adopted verbatim so backend rows JOIN the probe's.
+   */
   testId: string | undefined;
+  /**
+   * The emitter's OWN per-request id (a valid UUIDv7 or 16-hex span id) to use
+   * as `trace_id`, or undefined to mirror `test_id` (historical probe-path
+   * invariant). Decouples `trace_id` from an ADOPTED non-UUIDv7 `test_id`.
+   */
+  traceId: string | undefined;
   /** True iff any field was sanitized/bounded (diagnostic; does NOT set _truncated). */
   boundedAny: boolean;
 }
@@ -307,14 +370,32 @@ export function boundEntryFields(args: CvdiagEmitArgs): BoundEntryFields {
     boundedAny = true;
   }
 
-  // testId override → honor only if a valid UUIDv7; else undefined (mint fresh).
+  // testId override → the CROSS-LAYER JOIN KEY (spec §5). Honor a valid UUIDv7
+  // verbatim. For a non-UUIDv7 inbound id (the probe's `d4-/d6-<slug>-<runId>`
+  // forwarded as `x-test-id`), ADOPT it via the deterministic sanitizer so the
+  // backend's rows join the probe's — PB stores `test_id` as free text, so a
+  // non-UUIDv7 join key is valid at storage. Only an absent / empty /
+  // fully-stripped value falls through to a freshly minted UUIDv7.
   let testId: string | undefined = args.testId;
   if (testId !== undefined && !isValidTestId(testId)) {
-    testId = undefined;
+    const adopted = sanitizeJoinTestId(testId);
+    if (adopted === null || adopted !== testId) boundedAny = true;
+    testId = adopted ?? undefined;
+  }
+
+  // traceId override → the emitter's OWN per-request id. Honor a valid UUIDv7
+  // or 16-hex span id; anything else falls through to mirroring `test_id`.
+  let traceId: string | undefined = args.traceId;
+  if (
+    traceId !== undefined &&
+    !isValidTestId(traceId) &&
+    !SPAN_ID_REGEX.test(traceId)
+  ) {
+    traceId = undefined;
     boundedAny = true;
   }
 
-  return { slug, demo, parentSpanId, testId, boundedAny };
+  return { slug, demo, parentSpanId, testId, traceId, boundedAny };
 }
 
 /**
@@ -473,6 +554,11 @@ export class CvdiagEmitter {
     // fallback keeps `trace_id` (its mirror) valid.
     const bound = boundEntryFields(args);
     const testId = bound.testId ?? mintTestId();
+    // `trace_id` is the emitter's OWN per-request id. It MIRRORS `test_id` by
+    // default (probe path: one run = one test_id = one trace_id), but the
+    // backend supplies a distinct per-request UUIDv7 via `traceId` so it stays
+    // decoupled from an ADOPTED cross-layer `test_id` (spec §5).
+    const traceId = bound.traceId ?? testId;
     const isDataPlane = !args.boundary.startsWith(ACCOUNTING_PREFIX);
     let metadata: Record<string, unknown> = {};
     let metadataDropped = false;
@@ -497,7 +583,7 @@ export class CvdiagEmitter {
     const envelope: CvdiagEnvelope = {
       schema_version: SCHEMA_VERSION,
       test_id: testId,
-      trace_id: testId,
+      trace_id: traceId,
       span_id: mintSpanId(),
       parent_span_id: bound.parentSpanId,
       layer: args.layer,
@@ -548,14 +634,16 @@ export class CvdiagEmitter {
    * ONLY the three genuinely-unbounded inputs — the `metadata` bag, the
    * free-text `demo` string, and the free-string `edge_headers` VALUES — and
    * NEVER touches a format-constrained field. It cannot produce a non-16-hex
-   * `span_id`/`parent_span_id`, break the documented `trace_id === test_id`
-   * join, or write a `slug` that violates the PB/codegen contract
+   * `span_id`/`parent_span_id`, alter the `test_id`/`trace_id` join keys (they
+   * are minted/adopted/entry-bound, never clamped), or write a `slug` that
+   * violates the PB/codegen contract
    * `^[a-z][a-z0-9-]{0,63}$`, because those fields are NOT in the clamp set at
    * all. They are bounded by construction:
    *   - `slug`     — entry-bounded to ≤64 pattern-valid chars (`boundEntryFields`)
    *   - `demo`     — entry-bounded to ≤`DEMO_MAX_LEN` (then the only clampable field)
    *   - `parent_span_id` — entry-bounded to 16-hex or `null`
-   *   - `test_id`/`trace_id` — minted UUIDv7 (36 chars), `trace_id === test_id`
+   *   - `test_id` — minted UUIDv7 OR an adopted/sanitized inbound join key
+   *     (≤128 chars); `trace_id` — minted UUIDv7 or a mirror of `test_id`
    *   - `span_id`  — minted 16-hex
    *   - `schema_version` (const int), `layer`/`boundary`/`outcome` (enums),
    *     `ts` (ISO-8601), `mono_ns`/`duration_ms` (numbers)

--- a/showcase/integrations/langgraph-typescript/src/cvdiag/schema.ts
+++ b/showcase/integrations/langgraph-typescript/src/cvdiag/schema.ts
@@ -262,11 +262,35 @@ export interface ProbeConsoleErrorMeta {
   source_file: string | null;
   line_col: string | null;
 }
+/**
+ * Why a probe run failed, mirroring `waitForTurnComplete`'s reject `reason`
+ * union (conversation-runner `TurnNotCompleteError.reason`) plus
+ * `selector-mismatch` (a readiness/selector failure the d6 pill flow surfaces).
+ * Stamped on `probe.exit` ONLY when `terminal_outcome` is non-`ok` so reds are
+ * labeled directly in cvdiag probe data instead of being inferred from the
+ * absence of SSE / first-token rows.
+ */
+export const CVDIAG_FAILURE_CLASSIFIERS = [
+  "sse-missing",
+  "dom-missing",
+  "text-unstable",
+  "surface-missing",
+  "selector-mismatch",
+] as const;
+export type CvdiagFailureClassifier =
+  (typeof CVDIAG_FAILURE_CLASSIFIERS)[number];
+
 export interface ProbeExitMeta {
   terminal_outcome: CvdiagOutcome;
   total_duration_ms: number;
   sse_event_count: number;
   first_token_delta_ms: number | null;
+  /**
+   * Present ONLY on a non-`ok` terminal outcome. Classifies which turn-complete
+   * signal was missing (the `waitForTurnComplete` reject reason, or a derived
+   * best-effort classifier from the probe's own observed signals).
+   */
+  failure_classifier?: CvdiagFailureClassifier;
 }
 
 // Layer 2 (backend) ──────────────────────────────────────────────────────────
@@ -491,6 +515,7 @@ export const BOUNDARY_METADATA_KEYS: Record<
     "total_duration_ms",
     "sse_event_count",
     "first_token_delta_ms",
+    "failure_classifier",
   ],
   // backend
   "backend.request.ingress": ["method", "path", "content_length"],

--- a/showcase/integrations/langgraph-typescript/src/cvdiag/schema.ts
+++ b/showcase/integrations/langgraph-typescript/src/cvdiag/schema.ts
@@ -367,9 +367,21 @@ export interface AimockResponseCompleteMeta {
 export interface CvdiagEnvelope {
   /** const 1 in v1. */
   schema_version: typeof SCHEMA_VERSION;
-  /** UUIDv7, normalized lowercase hyphenated. */
+  /**
+   * The CROSS-LAYER JOIN KEY: the single id that joins one run's rows across
+   * probe / backend / aimock (spec §5). Normally a UUIDv7 (the probe mints one
+   * and threads it through). On the BACKEND adoption path it is the probe's
+   * per-run id forwarded as the inbound `x-test-id` (sanitized free text, e.g.
+   * `d4-<slug>-<runId>`) so backend rows join the probe's — PB stores this
+   * column as free text, so a non-UUIDv7 join key is valid at storage.
+   */
   test_id: string;
-  /** Equals `test_id` for join compatibility. */
+  /**
+   * The emitter's OWN PER-REQUEST id. MIRRORS `test_id` by default (probe path:
+   * one run = one test_id = one trace_id). The backend supplies a distinct
+   * per-request UUIDv7 so `trace_id` stays decoupled from an ADOPTED
+   * cross-layer `test_id`.
+   */
   trace_id: string;
   /** 16-hex, unique per emit. */
   span_id: string;

--- a/showcase/integrations/mastra/src/cvdiag-backend.ts
+++ b/showcase/integrations/mastra/src/cvdiag-backend.ts
@@ -104,6 +104,25 @@ function contentLength(headers: Headers): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+/**
+ * Read the inbound probe `x-test-id` — the CROSS-LAYER JOIN KEY (spec §5). The
+ * probe mints a per-run id (`d4-/d6-<slug>-<runId>`) and prefix-forwards it on
+ * every request; the backend MUST adopt it as the envelope `test_id` so its
+ * rows JOIN the probe's rows. Returns the trimmed header value, or undefined
+ * when absent/blank (→ the emitter mints a fresh UUIDv7). The emitter
+ * sanitizes/validates the value, so we forward it as-is here.
+ */
+function inboundTestId(headers: Headers): string | undefined {
+  try {
+    const raw = headers.get("x-test-id");
+    if (raw === null) return undefined;
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Snapshot the allow-listed edge headers off a header bag. */
 function edgeHeadersFrom(
   headers: Headers,
@@ -147,7 +166,14 @@ export function withCvdiagBackend<Req extends Request>(
     const emitter =
       opts.emitter ??
       new CvdiagEmitter({ layer: "backend", autoFlush: true, pbWriter });
-    const testId = mintTestId();
+    // CROSS-LAYER JOIN (spec §5): adopt the inbound probe `x-test-id` as the
+    // envelope `test_id` so backend rows join the probe's rows on the SAME run
+    // key. When the header is absent, the emitter mints a fresh UUIDv7. The
+    // backend's OWN per-request id is a freshly minted UUIDv7 passed as
+    // `traceId` — kept DISTINCT from an adopted (non-UUIDv7) `test_id` so
+    // trace/span stay per-request (NOT the shared run id).
+    const testId = inboundTestId(req.headers);
+    const traceId = mintTestId();
     const startedAt = Date.now();
     const path = requestPath(req);
     const edgeHeaders = safeEdgeHeaders(req);
@@ -165,6 +191,7 @@ export function withCvdiagBackend<Req extends Request>(
         demo: opts.slug,
         outcome,
         testId,
+        traceId,
         edgeHeaders,
         metadata,
         durationMs,

--- a/showcase/integrations/mastra/src/cvdiag/emit.ts
+++ b/showcase/integrations/mastra/src/cvdiag/emit.ts
@@ -92,6 +92,36 @@ export const SLUG_FALLBACK = "unknown";
 const SLUG_MAX_LEN = 64;
 /** 16-hex lowercase span-id shape (spec §5 `span_id` / `parent_span_id`). */
 const SPAN_ID_REGEX = /^[0-9a-f]{16}$/;
+/**
+ * Max length (chars) of a sanitized free-text cross-layer join key adopted from
+ * an inbound `x-test-id` header. The probe's per-run id (`d4-<slug>-<runId>` /
+ * `d6-<slug>-<runId>`) is well under this; the cap defends against an
+ * unbounded/hostile header value while keeping the key usable as a PB filter.
+ */
+const JOIN_TEST_ID_MAX_LEN = 128;
+
+/**
+ * Sanitize an inbound, non-UUIDv7 `x-test-id` into a SAFE, DETERMINISTIC
+ * free-text cross-layer join key (spec §5 `test_id`). The transform is pure and
+ * deterministic so the probe and the backend, applying it to the SAME inbound
+ * header, derive the SAME join key:
+ *   1. lowercase + trim surrounding whitespace,
+ *   2. drop EVERYTHING except `[a-z0-9._-]` (strips whitespace, control chars,
+ *      NUL, and any injection-prone punctuation — the key is used verbatim in a
+ *      PB filter string),
+ *   3. cap to `JOIN_TEST_ID_MAX_LEN`.
+ * Returns `null` when nothing survives (→ caller mints a fresh UUIDv7). A value
+ * that is ALREADY a valid UUIDv7 is handled by the caller before this is
+ * reached, so this only ever runs on genuinely non-UUIDv7 inputs.
+ */
+export function sanitizeJoinTestId(raw: string): string | null {
+  const cleaned = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, "")
+    .slice(0, JOIN_TEST_ID_MAX_LEN);
+  return cleaned.length > 0 ? cleaned : null;
+}
 
 /** In-memory queue cap (spec §7 R5-F5). */
 export const QUEUE_CAP = 5000;
@@ -141,8 +171,31 @@ export interface CvdiagEmitArgs {
   metadata?: Record<string, unknown>;
   durationMs?: number | null;
   parentSpanId?: string | null;
-  /** Override test_id (e.g. probe.start mints one and threads it through). */
+  /**
+   * Override the envelope `test_id` — the CROSS-LAYER JOIN KEY (spec §5: the
+   * single id that joins one run's rows across probe / backend / aimock). Two
+   * shapes are honored:
+   *   - a valid UUIDv7 (e.g. probe.start mints one and threads it through), OR
+   *   - a probe-minted per-run id forwarded as the inbound `x-test-id` header
+   *     (e.g. `d4-<slug>-<runId>` — NOT a UUIDv7). The backend MUST adopt this
+   *     verbatim (sanitized to a safe free-text key) so its rows JOIN the
+   *     probe's rows. PB stores `test_id` as free text, so a non-UUIDv7 join
+   *     key is valid at the storage layer — the cross-layer correlation is the
+   *     whole point.
+   * An absent / empty / unsanitizable value falls back to a freshly minted
+   * UUIDv7.
+   */
   testId?: string;
+  /**
+   * Override the envelope `trace_id` — the emitter's OWN PER-REQUEST id
+   * (spec §5: trace/span are per-request, test_id is the shared run id). The
+   * backend mints a fresh UUIDv7 per request and passes it here so `trace_id`
+   * stays decoupled from an ADOPTED cross-layer `test_id`. When omitted,
+   * `trace_id` mirrors `test_id` (the historical probe-path invariant). Honored
+   * only when it is a valid UUIDv7 or 16-hex span id; otherwise it falls back
+   * to mirroring `test_id`.
+   */
+  traceId?: string;
 }
 
 /**
@@ -258,8 +311,18 @@ export interface BoundEntryFields {
   slug: string;
   demo: string;
   parentSpanId: string | null;
-  /** A valid UUIDv7 override to honor, or undefined to mint fresh. */
+  /**
+   * The cross-layer join key to honor, or undefined to mint a fresh UUIDv7.
+   * Either a valid UUIDv7 (passed through unchanged) OR a sanitized non-UUIDv7
+   * inbound `x-test-id` adopted verbatim so backend rows JOIN the probe's.
+   */
   testId: string | undefined;
+  /**
+   * The emitter's OWN per-request id (a valid UUIDv7 or 16-hex span id) to use
+   * as `trace_id`, or undefined to mirror `test_id` (historical probe-path
+   * invariant). Decouples `trace_id` from an ADOPTED non-UUIDv7 `test_id`.
+   */
+  traceId: string | undefined;
   /** True iff any field was sanitized/bounded (diagnostic; does NOT set _truncated). */
   boundedAny: boolean;
 }
@@ -307,14 +370,32 @@ export function boundEntryFields(args: CvdiagEmitArgs): BoundEntryFields {
     boundedAny = true;
   }
 
-  // testId override → honor only if a valid UUIDv7; else undefined (mint fresh).
+  // testId override → the CROSS-LAYER JOIN KEY (spec §5). Honor a valid UUIDv7
+  // verbatim. For a non-UUIDv7 inbound id (the probe's `d4-/d6-<slug>-<runId>`
+  // forwarded as `x-test-id`), ADOPT it via the deterministic sanitizer so the
+  // backend's rows join the probe's — PB stores `test_id` as free text, so a
+  // non-UUIDv7 join key is valid at storage. Only an absent / empty /
+  // fully-stripped value falls through to a freshly minted UUIDv7.
   let testId: string | undefined = args.testId;
   if (testId !== undefined && !isValidTestId(testId)) {
-    testId = undefined;
+    const adopted = sanitizeJoinTestId(testId);
+    if (adopted === null || adopted !== testId) boundedAny = true;
+    testId = adopted ?? undefined;
+  }
+
+  // traceId override → the emitter's OWN per-request id. Honor a valid UUIDv7
+  // or 16-hex span id; anything else falls through to mirroring `test_id`.
+  let traceId: string | undefined = args.traceId;
+  if (
+    traceId !== undefined &&
+    !isValidTestId(traceId) &&
+    !SPAN_ID_REGEX.test(traceId)
+  ) {
+    traceId = undefined;
     boundedAny = true;
   }
 
-  return { slug, demo, parentSpanId, testId, boundedAny };
+  return { slug, demo, parentSpanId, testId, traceId, boundedAny };
 }
 
 /**
@@ -473,6 +554,11 @@ export class CvdiagEmitter {
     // fallback keeps `trace_id` (its mirror) valid.
     const bound = boundEntryFields(args);
     const testId = bound.testId ?? mintTestId();
+    // `trace_id` is the emitter's OWN per-request id. It MIRRORS `test_id` by
+    // default (probe path: one run = one test_id = one trace_id), but the
+    // backend supplies a distinct per-request UUIDv7 via `traceId` so it stays
+    // decoupled from an ADOPTED cross-layer `test_id` (spec §5).
+    const traceId = bound.traceId ?? testId;
     const isDataPlane = !args.boundary.startsWith(ACCOUNTING_PREFIX);
     let metadata: Record<string, unknown> = {};
     let metadataDropped = false;
@@ -497,7 +583,7 @@ export class CvdiagEmitter {
     const envelope: CvdiagEnvelope = {
       schema_version: SCHEMA_VERSION,
       test_id: testId,
-      trace_id: testId,
+      trace_id: traceId,
       span_id: mintSpanId(),
       parent_span_id: bound.parentSpanId,
       layer: args.layer,
@@ -548,14 +634,16 @@ export class CvdiagEmitter {
    * ONLY the three genuinely-unbounded inputs — the `metadata` bag, the
    * free-text `demo` string, and the free-string `edge_headers` VALUES — and
    * NEVER touches a format-constrained field. It cannot produce a non-16-hex
-   * `span_id`/`parent_span_id`, break the documented `trace_id === test_id`
-   * join, or write a `slug` that violates the PB/codegen contract
+   * `span_id`/`parent_span_id`, alter the `test_id`/`trace_id` join keys (they
+   * are minted/adopted/entry-bound, never clamped), or write a `slug` that
+   * violates the PB/codegen contract
    * `^[a-z][a-z0-9-]{0,63}$`, because those fields are NOT in the clamp set at
    * all. They are bounded by construction:
    *   - `slug`     — entry-bounded to ≤64 pattern-valid chars (`boundEntryFields`)
    *   - `demo`     — entry-bounded to ≤`DEMO_MAX_LEN` (then the only clampable field)
    *   - `parent_span_id` — entry-bounded to 16-hex or `null`
-   *   - `test_id`/`trace_id` — minted UUIDv7 (36 chars), `trace_id === test_id`
+   *   - `test_id` — minted UUIDv7 OR an adopted/sanitized inbound join key
+   *     (≤128 chars); `trace_id` — minted UUIDv7 or a mirror of `test_id`
    *   - `span_id`  — minted 16-hex
    *   - `schema_version` (const int), `layer`/`boundary`/`outcome` (enums),
    *     `ts` (ISO-8601), `mono_ns`/`duration_ms` (numbers)

--- a/showcase/integrations/mastra/src/cvdiag/schema.ts
+++ b/showcase/integrations/mastra/src/cvdiag/schema.ts
@@ -262,11 +262,35 @@ export interface ProbeConsoleErrorMeta {
   source_file: string | null;
   line_col: string | null;
 }
+/**
+ * Why a probe run failed, mirroring `waitForTurnComplete`'s reject `reason`
+ * union (conversation-runner `TurnNotCompleteError.reason`) plus
+ * `selector-mismatch` (a readiness/selector failure the d6 pill flow surfaces).
+ * Stamped on `probe.exit` ONLY when `terminal_outcome` is non-`ok` so reds are
+ * labeled directly in cvdiag probe data instead of being inferred from the
+ * absence of SSE / first-token rows.
+ */
+export const CVDIAG_FAILURE_CLASSIFIERS = [
+  "sse-missing",
+  "dom-missing",
+  "text-unstable",
+  "surface-missing",
+  "selector-mismatch",
+] as const;
+export type CvdiagFailureClassifier =
+  (typeof CVDIAG_FAILURE_CLASSIFIERS)[number];
+
 export interface ProbeExitMeta {
   terminal_outcome: CvdiagOutcome;
   total_duration_ms: number;
   sse_event_count: number;
   first_token_delta_ms: number | null;
+  /**
+   * Present ONLY on a non-`ok` terminal outcome. Classifies which turn-complete
+   * signal was missing (the `waitForTurnComplete` reject reason, or a derived
+   * best-effort classifier from the probe's own observed signals).
+   */
+  failure_classifier?: CvdiagFailureClassifier;
 }
 
 // Layer 2 (backend) ──────────────────────────────────────────────────────────
@@ -491,6 +515,7 @@ export const BOUNDARY_METADATA_KEYS: Record<
     "total_duration_ms",
     "sse_event_count",
     "first_token_delta_ms",
+    "failure_classifier",
   ],
   // backend
   "backend.request.ingress": ["method", "path", "content_length"],

--- a/showcase/integrations/mastra/src/cvdiag/schema.ts
+++ b/showcase/integrations/mastra/src/cvdiag/schema.ts
@@ -367,9 +367,21 @@ export interface AimockResponseCompleteMeta {
 export interface CvdiagEnvelope {
   /** const 1 in v1. */
   schema_version: typeof SCHEMA_VERSION;
-  /** UUIDv7, normalized lowercase hyphenated. */
+  /**
+   * The CROSS-LAYER JOIN KEY: the single id that joins one run's rows across
+   * probe / backend / aimock (spec §5). Normally a UUIDv7 (the probe mints one
+   * and threads it through). On the BACKEND adoption path it is the probe's
+   * per-run id forwarded as the inbound `x-test-id` (sanitized free text, e.g.
+   * `d4-<slug>-<runId>`) so backend rows join the probe's — PB stores this
+   * column as free text, so a non-UUIDv7 join key is valid at storage.
+   */
   test_id: string;
-  /** Equals `test_id` for join compatibility. */
+  /**
+   * The emitter's OWN PER-REQUEST id. MIRRORS `test_id` by default (probe path:
+   * one run = one test_id = one trace_id). The backend supplies a distinct
+   * per-request UUIDv7 so `trace_id` stays decoupled from an ADOPTED
+   * cross-layer `test_id`.
+   */
   trace_id: string;
   /** 16-hex, unique per emit. */
   span_id: string;


### PR DESCRIPTION
## What

Completes the cvdiag observability subsystem so a single flapping showcase run is **fully attributable end-to-end** — and makes every probe reproducible on demand. Four fixes, all proven against the real surface (live PocketBase writer-role, real `next` build, driver vitest):

1. **Cross-layer `test_id` join (the keystone).** Both sides were using different ids: the backend minted its own UUIDv7, and the probe re-minted a random UUIDv7 when its forwarded `X-Test-Id` (`d6-<slug>-<runId>`) wasn't a UUIDv7. Now both run the same `sanitizeJoinTestId` over the forwarded id → probe.* and backend.* rows for one run **share `test_id`** (the join key per `schema.ts`); each side keeps its own `trace_id`/`span`.
2. **Probe failure classifier.** `probe.exit` now stamps `outcome=err` + `failure_classifier` (`sse-missing`/`dom-missing`/`text-unstable`) from `waitForTurnComplete`'s reason, instead of `outcome=ok` on every run — so reds are labeled, not inferred.
3. **Backend boundaries.** (Confirmed already on main — full 11-boundary set incl `request.ingress`/`sse.first_byte`/`llm.call.*`.)
4. **On-demand trigger for EVERY probe.** New `POST /api/runs/:family/trigger` (OPS-token-gated, rate-limited) fires any fleet/D6 probe via the existing job-producer enqueue; in-process probes keep their route. No more waiting on the hourly cron to reproduce a flap.

## Why

cvdiag was live and persisting, but couldn't yet say "backend stall vs frontend race" for a single red because probe and backend rows couldn't be joined, reds weren't labeled, and D6 wasn't on-demand reproducible. These close those gaps.

## Verification
- harness `tsc --noEmit` clean · cvdiag + drivers vitest **665 passed / 31 files** (join + classifier + boundary + trigger together) · 4 fix-test files 151 passed
- codegen `--check` + `cvdiag-stage-ts --check` in-sync (schema.json + 4 staged copies regenerated, not hand-merged)
- real Docker `next build` of built-in-agent succeeded (backend boundary + writer code bundles)
- live-PB writer-role RED→GREEN for the join; driver RED→GREEN for the classifier; enqueue-assertion RED→GREEN for the trigger

## Follow-ups (not in this PR)
- Python dual-process (:8123) backend→PB shipping gap (python integrations emit zero backend rows despite the auth fix)
- liveness-probe 400 noise → `outcome=info` + plumb real `model_id`
- Java/.NET backend writer-role auth
- break the run-view⇄control-plane import cycle the trigger routes around

🤖 Generated with [Claude Code](https://claude.com/claude-code)