### PR TITLE
docs: correct Enterprise Intelligence docs links

### DIFF
--- a/showcase/shell-docs/src/content/docs/premium/threads-explained.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/threads-explained.mdx
@@ -150,4 +150,3 @@ The trade-off is that replay is more complex than loading a message array. The p
 
 - **Step-by-step guide:** [Threads](/threads) — set up thread management in your app
 - **API reference:** [useThreads](/reference/hooks/useThreads) — parameters, return values, types
-- **Tutorial:** [Build a Multi-Conversation Chat App](/tutorials/multi-conversation-chat) — end-to-end walkthrough building a chat app with thread history

--- a/showcase/shell-docs/src/content/docs/threads.mdx
+++ b/showcase/shell-docs/src/content/docs/threads.mdx
@@ -259,4 +259,3 @@ CopilotKit threads enable persistent, resumable multi-turn conversations. The `u
 
 - **Thread architecture:** [Threads & Persistence Architecture](/premium/threads-explained) — event replay model and WebSocket sync
 - **API reference:** [useThreads](/reference/hooks/useThreads) — parameters, return values, types
-- **Tutorial:** [Build a Multi-Conversation Chat App](/tutorials/multi-conversation-chat) — end-to-end walkthrough building a chat app with thread history

--- a/showcase/shell-docs/src/content/reference/hooks/useThreads.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useThreads.mdx
@@ -142,4 +142,3 @@ function ThreadList() {
 
 - **Thread architecture:** [Threads & Persistence Architecture](/premium/threads-explained) — event replay model and WebSocket sync
 - **Step-by-step guide:** [Threads](/threads) — set up thread management in your app
-- **Tutorial:** [Build a Multi-Conversation Chat App](/tutorials/multi-conversation-chat) — end-to-end walkthrough building a chat app with thread history

--- a/showcase/shell-docs/src/content/reference/react-native/hooks/useThreads.mdx
+++ b/showcase/shell-docs/src/content/reference/react-native/hooks/useThreads.mdx
@@ -158,5 +158,4 @@ function ThreadList() {
 
 - **Thread architecture:** [Threads & Persistence Architecture](/premium/threads-explained) covers the event replay model and WebSocket sync
 - **Step-by-step guide:** [Threads](/threads) walks you through setting up thread management in your app
-- **Tutorial:** [Build a Multi-Conversation Chat App](/tutorials/multi-conversation-chat) is an end-to-end walkthrough building a chat app with thread history
 - **React (V2) reference:** [`useThreads`](/reference/v2/hooks/useThreads), the web `useThreads` this hook mirrors

--- a/showcase/shell-docs/src/content/snippets/shared/premium/overview.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/premium/overview.mdx
@@ -9,7 +9,7 @@ Start here when you are deciding what the platform gives you and where it should
 | Capability | What it gives you | Deeper dive |
 |---|---|---|
 | Durable threads and persistence | Resumable conversations that survive reloads, devices, and browser sessions. | [Threads](/threads) and [Threads & Persistence Architecture](/premium/threads-explained) |
-| Cloud-hosted web app | Projects, project API keys, conversation history, thread inspection, and plan management. | [Cloud-Hosted Enterprise Intelligence](/premium/managed-intelligence-platform) |
+| Cloud-hosted Intelligence features | Projects, project API keys, conversation history, thread inspection, and plan management. | [Cloud-Hosted Enterprise Intelligence](/premium/managed-intelligence-platform) |
 | Premium UI capabilities | Platform-gated UI surfaces such as Fully Headless Chat UI. | [Fully Headless Chat UI](/premium/headless-ui) |
 | Self-hosting | The same platform running inside your own Kubernetes cluster, VPC, or data boundary. | [Self-Hosting Enterprise Intelligence](/premium/self-hosting) |
 

--- a/showcase/shell-docs/src/content/snippets/shared/threads/threads.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/threads/threads.mdx
@@ -153,4 +153,3 @@ CopilotKit threads enable persistent, resumable multi-turn conversations. The `u
 
 - **Thread architecture:** [Threads & Persistence Architecture](/premium/threads-explained) — event replay model and WebSocket sync
 - **API reference:** [useThreads](/reference/hooks/useThreads) — parameters, return values, types
-- **Tutorial:** [Build a Multi-Conversation Chat App](/tutorials/multi-conversation-chat) — end-to-end walkthrough building a chat app with thread history


### PR DESCRIPTION
## Summary
- Rename the overview capability from "Cloud-hosted web app" to "Cloud-hosted Intelligence features".
- Remove the redirecting multi-conversation tutorial link from thread docs, shared thread snippets, and useThreads references.

## Validation
- npm run test (showcase/shell-docs)
- npm run lint (showcase/shell-docs; exits 0 with pre-existing warnings)
- npm run typecheck (showcase/shell-docs)
- npm run build (showcase/shell-docs)
- Manual link sweep for edited MDX confirmed no remaining /tutorials/multi-conversation-chat links