### PR TITLE
fix(showcase/harness): break fleet control-plane import cycle crashing the harness on boot (regression from #5616)

### DIFF
--- a/showcase/harness/src/fleet/control-plane/control-plane.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.ts
@@ -57,21 +57,27 @@ import type { ResultConsumer } from "./result-consumer.js";
 import type { ResultAggregator } from "./result-aggregator.js";
 import type { FleetHealthMonitor } from "./fleet-health.js";
 
-/** Scheduler entry id the producer's tick registers under. */
-export const FLEET_PRODUCER_SCHEDULE_ID = "fleet-job-producer";
-
 /**
- * Scheduler entry ids for the three non-d6 browser-family producers. Homed
- * HERE (beside `FLEET_PRODUCER_SCHEDULE_ID`) rather than in `orchestrator.ts`
- * so the §5.1 family registry (`run-view.ts`, inside `fleet/control-plane/`)
- * can import all four ids from one cycle-free home — `orchestrator.ts` already
- * imports from this module, so the registry importing FROM orchestrator would
- * close an import cycle. The cron constants stay in `orchestrator.ts` (the
- * registry deliberately carries no cron literals; resolution is runtime).
+ * Producer scheduler-entry ids now live in the cycle-free leaf module
+ * `schedule-ids.ts` (NO imports back into this module / `run-view.ts` /
+ * `job-producer.ts`). They are re-exported here to preserve this module's
+ * public export surface — `http/fleet-runs.ts`, `orchestrator.ts`, and the
+ * tests import the ids from `control-plane.js`. Homing the VALUES in a leaf
+ * removes the eval-time dependency that put `FLEET_FAMILIES` (run-view) in the
+ * TDZ for `FLEET_PRODUCER_SCHEDULE_ID` under one cycle load order, which
+ * crash-looped the harness on boot.
  */
-export const FLEET_PRODUCER_SMOKE_SCHEDULE_ID = "fleet-producer-e2e-smoke";
-export const FLEET_PRODUCER_DEMOS_SCHEDULE_ID = "fleet-producer-e2e-demos";
-export const FLEET_PRODUCER_DEEP_SCHEDULE_ID = "fleet-producer-e2e-deep";
+export {
+  FLEET_PRODUCER_DEEP_SCHEDULE_ID,
+  FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
+  FLEET_PRODUCER_SCHEDULE_ID,
+  FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
+} from "./schedule-ids.js";
+// Local binding for this module's own runtime use of the d6 id (the
+// degenerate single-schedule fallback in `createControlPlane`). The `export {
+// ... } from` above re-exports the values but does NOT bind them into this
+// module's scope, so an explicit import is required for the in-body reference.
+import { FLEET_PRODUCER_SCHEDULE_ID } from "./schedule-ids.js";
 
 /**
  * Cron cadence the producer runs on by default. Hourly at :40 mirrors the

--- a/showcase/harness/src/fleet/control-plane/import-cycle-tdz.test.ts
+++ b/showcase/harness/src/fleet/control-plane/import-cycle-tdz.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression guard for the fleet control-plane import cycle TDZ crash.
+ *
+ * The cycle is control-plane → job-producer → run-view → control-plane. The
+ * §5.1 family registry (`run-view.ts`'s top-level `FLEET_FAMILIES` literal)
+ * reads the producer schedule ids at MODULE-EVAL time. When those ids lived in
+ * `control-plane.ts` (inside the cycle), one load order — entering the graph
+ * via `control-plane.js` FIRST, exactly as `http/fleet-runs.ts` does —
+ * evaluated `FLEET_FAMILIES` before `control-plane.ts` finished its top-level
+ * assignments, throwing `ReferenceError: Cannot access
+ * 'FLEET_PRODUCER_SCHEDULE_ID' before initialization` and crash-looping the
+ * harness on boot. The fix homes the ids in the cycle-free leaf
+ * `schedule-ids.ts`, so the literal can never read them in the TDZ.
+ *
+ * These tests reproduce the exact boot load order with a fresh module registry
+ * (so the dynamic import actually re-evaluates the graph) and assert the
+ * module graph loads without throwing, and that the ids are wired through.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("fleet control-plane import cycle (TDZ regression)", () => {
+  beforeEach(() => {
+    // Force a fresh module registry so each dynamic import re-evaluates the
+    // module graph from scratch — otherwise a prior import would have already
+    // initialized the constants and masked the eval-time ordering.
+    vi.resetModules();
+  });
+
+  it("loads the graph entering via control-plane.js FIRST (the fleet-runs / boot order) without a TDZ ReferenceError", async () => {
+    // Importing control-plane.js first triggers its transitive
+    // job-producer → run-view evaluation, which is where the FLEET_FAMILIES
+    // literal used to hit the dead zone. No throw == cycle broken.
+    await expect(import("./control-plane.js")).resolves.toBeDefined();
+    await expect(import("./run-view.js")).resolves.toBeDefined();
+  });
+
+  it("loads the graph entering via run-view.js first without a TDZ ReferenceError", async () => {
+    await expect(import("./run-view.js")).resolves.toBeDefined();
+    await expect(import("./control-plane.js")).resolves.toBeDefined();
+  });
+
+  it("wires the schedule ids through both the leaf and control-plane re-export", async () => {
+    const leaf = await import("./schedule-ids.js");
+    const cp = await import("./control-plane.js");
+    const rv = await import("./run-view.js");
+
+    expect(leaf.FLEET_PRODUCER_SCHEDULE_ID).toBe("fleet-job-producer");
+    // control-plane re-exports the leaf values (its public surface is unchanged).
+    expect(cp.FLEET_PRODUCER_SCHEDULE_ID).toBe(leaf.FLEET_PRODUCER_SCHEDULE_ID);
+    expect(cp.FLEET_PRODUCER_SMOKE_SCHEDULE_ID).toBe(
+      leaf.FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
+    );
+    expect(cp.FLEET_PRODUCER_DEMOS_SCHEDULE_ID).toBe(
+      leaf.FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
+    );
+    expect(cp.FLEET_PRODUCER_DEEP_SCHEDULE_ID).toBe(
+      leaf.FLEET_PRODUCER_DEEP_SCHEDULE_ID,
+    );
+    // The §5.1 family registry read the (now leaf-homed) ids at eval time.
+    const d6 = rv.FLEET_FAMILIES.find((f) => f.family === "d6");
+    expect(d6?.scheduleId).toBe(leaf.FLEET_PRODUCER_SCHEDULE_ID);
+  });
+});

--- a/showcase/harness/src/fleet/control-plane/run-view.ts
+++ b/showcase/harness/src/fleet/control-plane/run-view.ts
@@ -39,12 +39,19 @@ import {
 import { PROBE_JOBS_COLLECTION } from "../queue-client.js";
 import { PROBE_RUNS_COLLECTION } from "../../probes/run-history.js";
 import type { ProbeRunSummary } from "../../probes/run-history.js";
+// Import the schedule ids from the cycle-free LEAF module — NOT from
+// `control-plane.js`. The top-level `FLEET_FAMILIES` literal below reads these
+// at MODULE-EVAL time; `control-plane.ts` sits inside the
+// control-plane → job-producer → run-view → control-plane cycle, so importing
+// the ids from it left them in the TDZ under one cycle load order (the harness
+// crash-looped on boot). The leaf has no edges back into the cycle, so the ids
+// are always fully initialized before this literal evaluates.
 import {
   FLEET_PRODUCER_DEEP_SCHEDULE_ID,
   FLEET_PRODUCER_DEMOS_SCHEDULE_ID,
   FLEET_PRODUCER_SCHEDULE_ID,
   FLEET_PRODUCER_SMOKE_SCHEDULE_ID,
-} from "./control-plane.js";
+} from "./schedule-ids.js";
 import type { ProducerSchedule } from "./control-plane.js";
 
 // ───────────────────────────────────────────────────────────────────────

--- a/showcase/harness/src/fleet/control-plane/schedule-ids.ts
+++ b/showcase/harness/src/fleet/control-plane/schedule-ids.ts
@@ -1,0 +1,32 @@
+/**
+ * Producer scheduler-entry ids — a LEAF module with NO imports back into
+ * `control-plane.ts` / `run-view.ts` / `job-producer.ts`.
+ *
+ * These four ids are consumed at MODULE-EVAL time by the §5.1 family registry
+ * (`run-view.ts`'s top-level `FLEET_FAMILIES` literal) and by the on-demand
+ * trigger route (`http/fleet-runs.ts`), while `control-plane.ts` itself sits
+ * inside the same `control-plane → job-producer → run-view → control-plane`
+ * import cycle. Homing the ids HERE — in a leaf with no edges back into that
+ * cycle — guarantees they are fully initialized regardless of the cycle's
+ * load order, so no consumer can hit them in the temporal dead zone.
+ *
+ * (Previously these lived in `control-plane.ts`; under one load order the
+ * `FLEET_FAMILIES` literal evaluated before `control-plane.ts` finished its
+ * top-level assignments, throwing `ReferenceError: Cannot access
+ * 'FLEET_PRODUCER_SCHEDULE_ID' before initialization` and crash-looping the
+ * harness on boot. A leaf module removes the eval-time dependency entirely.)
+ */
+
+/** Scheduler entry id the d6 producer's tick registers under. */
+export const FLEET_PRODUCER_SCHEDULE_ID = "fleet-job-producer";
+
+/**
+ * Scheduler entry ids for the three non-d6 browser-family producers. The §5.1
+ * family registry (`run-view.ts`) and the on-demand trigger route import all
+ * four ids from this cycle-free home. The cron constants stay in
+ * `orchestrator.ts` (the registry deliberately carries no cron literals;
+ * resolution is runtime).
+ */
+export const FLEET_PRODUCER_SMOKE_SCHEDULE_ID = "fleet-producer-e2e-smoke";
+export const FLEET_PRODUCER_DEMOS_SCHEDULE_ID = "fleet-producer-e2e-demos";
+export const FLEET_PRODUCER_DEEP_SCHEDULE_ID = "fleet-producer-e2e-deep";


### PR DESCRIPTION
## Hotfix — staging harness was crash-looping

PR #5616's on-demand-trigger code (`http/fleet-runs.ts`) imports `control-plane.js` first, whose transitive load (`control-plane → job-producer → run-view → control-plane`) evaluated `run-view.ts`'s top-level `FLEET_FAMILIES` literal **before** `control-plane.ts` finished assigning `FLEET_PRODUCER_SCHEDULE_ID` (+3 sibling schedule-id constants) → `ReferenceError: Cannot access 'FLEET_PRODUCER_SCHEDULE_ID' before initialization` → the harness never bound its port (staging harness down; workers stuck on the stale digest).

The cycle was latent (prior load order happened to init the constants first); the trigger change shifted load order and exposed it.

## Fix
New leaf module `fleet/control-plane/schedule-ids.ts` (zero imports) holds the four `SCHEDULE_ID` constants. `control-plane.ts` re-exports them (public surface unchanged); `run-view.ts` imports them from the leaf instead of from `control-plane.js`. No eval-time edge into the cycle → no TDZ.

## Verification (real boot — not just tsc; tsc passed while it crashed at runtime)
- **RED** on main: `import('./dist/http/fleet-runs.js')` and `import('./dist/orchestrator.js')` both threw the exact ReferenceError.
- **GREEN**: all four load orders (fleet-runs, orchestrator entrypoint, control-plane, run-view) import clean; `FLEET_FAMILIES` builds with 4 entries.
- New regression guard `import-cycle-tdz.test.ts` (3 tests) asserts the module graph imports without throwing.
- Fleet control-plane suite 347/347; broader fleet + fleet-runs + orchestrator 814/814; `tsc --noEmit` clean (one pre-existing unrelated `glob` env error, untouched).

## Note
CI's build-check compiles the harness image but never boots the fleet control-plane, so this slipped through green. The new import test is a boot-time regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)