### PR TITLE
docs(shell-docs): clarify tailored content selectors

### DIFF
--- a/showcase/shell-docs/src/components/react/__tests__/tailored-content.test.tsx
+++ b/showcase/shell-docs/src/components/react/__tests__/tailored-content.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+const navigation = vi.hoisted(() => ({
+  replace: vi.fn(),
+  searchParams: new URLSearchParams("threads-path=cli"),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: navigation.replace }),
+  useSearchParams: () => navigation.searchParams,
+}));
+
+import { TailoredContent, TailoredContentOption } from "../tailored-content";
+
+describe("TailoredContent", () => {
+  it("renders implementation path options as native buttons with a selected affordance", () => {
+    const markup = renderToStaticMarkup(
+      <TailoredContent id="threads-path">
+        <TailoredContentOption
+          id="cli"
+          title="Start with the CLI"
+          description="Bootstrap a new full-stack project pre-configured for threads."
+          icon={<span />}
+        >
+          <p>CLI content</p>
+        </TailoredContentOption>
+        <TailoredContentOption
+          id="manual"
+          title="Add to an existing app"
+          description="Wire threads into a project you already have."
+          icon={<span />}
+        >
+          <p>Manual content</p>
+        </TailoredContentOption>
+      </TailoredContent>,
+    );
+
+    expect(markup.match(/<button/g)?.length).toBe(2);
+    expect(markup).toContain('type="button"');
+    expect(markup).toContain('role="tab"');
+    expect(markup).toContain('aria-selected="true"');
+    expect(markup).toContain('aria-label="Start with the CLI, selected"');
+    expect(markup).toContain("tailored-content-selected-indicator");
+    expect(markup).toContain("CLI content");
+    expect(markup).not.toContain("Manual content");
+  });
+});

--- a/showcase/shell-docs/src/components/react/tailored-content.tsx
+++ b/showcase/shell-docs/src/components/react/tailored-content.tsx
@@ -8,6 +8,7 @@ import React, {
   useMemo,
   useRef,
 } from "react";
+import { Check } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 // Local className-joining helper so this component has no external dep.
@@ -19,7 +20,7 @@ function cn(...values: Array<string | false | null | undefined>): string {
 type TailoredContentOptionProps = {
   title: string;
   description: string;
-  icon: ReactNode;
+  icon?: ReactNode;
   children: ReactNode;
   id: string;
 };
@@ -53,7 +54,7 @@ function TailoredContentInner({
   // All hooks must run unconditionally to satisfy the Rules of Hooks.
   const router = useRouter();
   const searchParams = useSearchParams();
-  const tabRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const warnedKeyRef = useRef<string | null>(null);
 
   // Memoize derived arrays so downstream hook deps have stable identities.
@@ -124,7 +125,10 @@ function TailoredContentInner({
     if (el) el.focus();
   };
 
-  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>, index: number) => {
+  const onKeyDown = (
+    e: React.KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
     switch (e.key) {
       case "Enter":
       case " ":
@@ -165,11 +169,13 @@ function TailoredContentInner({
   };
 
   const itemCn =
-    "shell-docs-radius-surface flex flex-1 cursor-pointer items-center gap-4 overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] p-3 pl-4 shadow-[var(--shadow-control)] transition-colors md:block md:space-y-0.5 md:items-start";
+    "shell-docs-radius-control group relative flex min-h-[5.5rem] flex-1 cursor-pointer items-start gap-3 overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] p-3.5 text-left text-[var(--text)] shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-elevated)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] md:min-h-[6rem]";
   const selectedCn =
-    "selected border-[var(--accent)] bg-[var(--accent-dim)] text-[var(--accent)]";
+    "selected border-[var(--accent)] bg-[var(--accent-dim)] text-[var(--text)]";
   const iconCn =
-    "mb-2 h-8 w-8 text-[var(--text-muted)] opacity-35 transition-colors group-[.selected]:text-[var(--accent)] group-[.selected]:opacity-80";
+    "h-4 w-4 shrink-0 text-[var(--text-muted)] opacity-60 transition-colors group-[.selected]:text-[var(--accent)] group-[.selected]:opacity-90";
+  const indicatorCn =
+    "tailored-content-selected-indicator mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border transition-colors";
 
   const tablistId = `tailored-content-tablist-${id}`;
   const tabId = (optId: string) => `tailored-content-tab-${id}-${optId}`;
@@ -190,7 +196,8 @@ function TailoredContentInner({
           {options.map((option, index) => {
             const isSelected = selectedIndex === index;
             return (
-              <div
+              <button
+                type="button"
                 key={option.props.id}
                 ref={(el) => {
                   tabRefs.current[index] = el;
@@ -201,30 +208,46 @@ function TailoredContentInner({
                 onKeyDown={(e) => onKeyDown(e, index)}
                 role="tab"
                 aria-selected={isSelected}
+                aria-label={`${option.props.title}${
+                  isSelected ? ", selected" : ""
+                }`}
                 aria-controls={panelId(option.props.id)}
                 tabIndex={isSelected ? 0 : -1}
               >
-                <div className="my-0">
-                  {React.isValidElement(option.props.icon) ? (
-                    (() => {
-                      const icon = option.props.icon as IconElement;
-                      return React.cloneElement(icon, {
-                        className: cn(icon.props?.className, iconCn, "my-0"),
-                      });
-                    })()
-                  ) : (
-                    <span className={cn(iconCn, "my-0")} />
+                <span
+                  className={cn(
+                    indicatorCn,
+                    isSelected
+                      ? "border-[var(--accent)] bg-[var(--accent)] text-[var(--primary-foreground)]"
+                      : "border-[var(--border)] bg-[var(--bg-surface)] text-transparent group-hover:border-[var(--accent)] group-hover:bg-[var(--accent-dim)] group-hover:text-[var(--accent)]",
                   )}
-                </div>
-                <div>
-                  <p className="font-semibold text-base">
-                    {option.props.title}
-                  </p>
-                  <p className="text-xs md:text-sm">
+                  aria-hidden="true"
+                >
+                  <Check className="h-3.5 w-3.5" />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="mb-1 flex min-w-0 items-center gap-2">
+                    {React.isValidElement(option.props.icon)
+                      ? (() => {
+                          const icon = option.props.icon as IconElement;
+                          return React.cloneElement(icon, {
+                            className: cn(
+                              icon.props?.className,
+                              iconCn,
+                              "my-0",
+                            ),
+                          });
+                        })()
+                      : null}
+                    <span className="block min-w-0 text-base font-semibold leading-snug">
+                      {option.props.title}
+                    </span>
+                  </span>
+                  <span className="block text-sm leading-relaxed text-[var(--text-secondary)]">
                     {option.props.description}
-                  </p>
-                </div>
-              </div>
+                  </span>
+                </span>
+              </button>
             );
           })}
         </div>


### PR DESCRIPTION
## Summary
- restyle TailoredContent selectors as native segmented path buttons
- add a selected check indicator plus hover/focus affordances
- add a rendering test for button semantics and selected state

## Verification
- pnpm exec oxfmt --check showcase/shell-docs/src/components/react/tailored-content.tsx showcase/shell-docs/src/components/react/__tests__/tailored-content.test.tsx
- npm run lint (showcase/shell-docs; existing warnings only)
- npm run typecheck (showcase/shell-docs)
- npm run test (showcase/shell-docs)
- npm run build (showcase/shell-docs; existing Turbopack NFT trace warning)

## Notes
- Repo-wide pnpm check-format currently fails on unrelated pre-existing files outside this PR; the touched files pass scoped oxfmt check.