### PR TITLE
perf(showcase): within-tier parallel fan-out for promote-fleet so service=all fits the timeout

### DIFF
--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -194,7 +194,13 @@ jobs:
     # mirrors the verify-prod gate idiom below.
     if: ${{ !cancelled() && needs.resolve-targets.result == 'success' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # promote-fleet.sh now fans out promotes WITHIN a tier (PROMOTE_FANOUT, cap
+    # 5) instead of running the whole fleet serially. Even so, the largest tier
+    # (~30 integration leaves) at cap 5 with bin/railway's ~300s/service
+    # verify_serving_digest! is ~6 batches * ~5 min ≈ 30 min, so 20 min cancelled
+    # a `service=all` promote mid-fleet. 35 min leaves headroom above the
+    # worst-case tier without masking a genuinely stuck promote.
+    timeout-minutes: 35
     environment: railway
     permissions:
       contents: read
@@ -236,6 +242,14 @@ jobs:
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Tier-ordered closure plan (U4): promote-fleet.sh prefers CLOSURE_PLAN
+          # over SERVICES_CSV, promoting BY TIER (0->1->2) with dependent-tier
+          # gating AND within-tier parallel fan-out (PROMOTE_FANOUT). A serial
+          # `service=all` fleet overran the job timeout; tiered fan-out cuts the
+          # wall-clock so the whole fleet completes inside timeout-minutes.
+          CLOSURE_PLAN: ${{ needs.resolve-targets.outputs.closure_plan }}
+          # Retained as the backward-compat fallback: promote-fleet.sh uses this
+          # ONLY when CLOSURE_PLAN is empty (e.g. an older resolve step).
           SERVICES_CSV: ${{ needs.resolve-targets.outputs.services_csv }}
           DIGEST: ${{ inputs.digest }}
         run: |

--- a/showcase/scripts/__tests__/promote-fleet.bats
+++ b/showcase/scripts/__tests__/promote-fleet.bats
@@ -484,3 +484,300 @@ STUB
   run cat "$GITHUB_OUTPUT"
   [[ "$output" == *"succeeded_csv=svc-a,svc-h"* ]] || fail "wrong succeeded_csv (whitespace token skipped): $output"
 }
+
+# ── Within-tier parallel fan-out ────────────────────────────────────────────
+#
+# A full `service=all` promote is dominated by bin/railway's serial
+# verify_serving_digest! (~300s/service). Running every promote in a tier
+# strictly one-after-another overruns the job timeout mid-fleet. promote-fleet
+# now backgrounds `promote_one` WITHIN a tier up to a bounded concurrency cap
+# (PROMOTE_FANOUT, default 5), drains all PIDs at the end of the tier (the tier
+# BARRIER), then reaps each service's result back into the aggregate. Cross-tier
+# ordering + dependent-tier gating + best-effort + the final exit-nonzero-iff-any
+# -failed semantics are all preserved.
+#
+# These tests exercise the REAL surface: bats shells out to the real
+# promote-fleet.sh with a RAILWAY_BIN stub. The tier is encoded as the FIRST
+# dash-separated field of the service name (e.g. `t0-a` is a tier-0 service) so
+# the stub — which only receives `promote <svc>` — can record it without the
+# script forwarding the tier.
+#
+# DETERMINISTIC CONCURRENCY PROOF (no wall-clock-sleep race).
+# An earlier version slept a fixed 0.4s in each stub invocation and asserted the
+# observed peak overlap was >= 2. That is timing-fragile: on a loaded CI host a
+# backgrounded promote's spawn latency can approach the sleep, so the second
+# invocation starts only AFTER the first already returned — peak reads 1 and the
+# test FALSE-REDs "ran serially". (We were bitten by exactly this flake.)
+#
+# The rewrite proves parallelism by ACTUAL SIMULTANEITY via a RENDEZVOUS BARRIER,
+# independent of any sleep-vs-spawn-latency race:
+#   * Each stub invocation atomically REGISTERS itself in a shared `running/`
+#     directory by creating a uniquely-named file (each writes only its OWN
+#     file — no shared-file append, so there is NO torn-write / atomicity risk).
+#   * It then BLOCKS, polling the live count of `running/` entries, until that
+#     count reaches BARRIER_TARGET (= min(cap, n_ready), the max simultaneity the
+#     launcher can actually reach) OR a generous timeout elapses.
+#   * While blocking it records the peak live count it ever observed to its own
+#     `peak.<svc>` file, then DEREGISTERS (removes its file) and exits.
+# When the launcher CAN reach the cap, exactly BARRIER_TARGET invocations are
+# provably alive together (they all release only once the target is met), so the
+# recorded peak == BARRIER_TARGET DETERMINISTICALLY — no dependence on sleep.
+# A genuinely-serial (broken) launcher never has >1 invocation alive, so the
+# barrier is never met: each invocation blocks until the TIMEOUT, then exits one
+# at a time and the recorded peak stays 1 → the `peak>=cap` assertion still goes
+# RED on a serial run (RED-on-serial preserved), and the timeout guarantees the
+# run TERMINATES rather than deadlocking.
+#
+# Tests that only need start/end ORDERING (the cross-tier barrier) still record a
+# per-event start/end file (one file per event — again no shared-file append) and
+# read epoch.ns timestamps back from those files.
+
+# BARRIER_TIMEOUT_SECS — generous upper bound a stub invocation waits at the
+# rendezvous before giving up (so a serial launcher terminates + REDs, never
+# hangs). Comfortably longer than any real launch latency; short enough that a
+# broken-serial run still finishes the bats test quickly.
+BARRIER_TIMEOUT_SECS=10
+
+# setup_timeline_stub <barrier_target> [fail_svc] — install a RAILWAY_BIN that,
+# for each `promote <svc>`:
+#   1. writes a per-event `start.<svc>` file (epoch.ns + tier) under $EVENTS_DIR,
+#   2. registers itself in $RUNNING_DIR (atomic: creates its own unique file),
+#   3. blocks at the rendezvous until $RUNNING_DIR holds <barrier_target> entries
+#      OR BARRIER_TIMEOUT_SECS elapses, recording the peak live count it saw to
+#      $PEAKS_DIR/peak.<svc>,
+#   4. deregisters, writes a per-event `end.<svc>` file, then exits 0 (or exit 7
+#      if <svc> == <fail_svc>, AFTER recording everything so the failing svc is
+#      still observable).
+# All recording is via one-file-per-event writes (no shared-file appends), so the
+# measurement is race-free. Pass barrier_target = min(PROMOTE_FANOUT, n_ready).
+setup_timeline_stub() {
+  local barrier_target="$1"
+  local fail_svc="${2:-}"
+  export EVENTS_DIR="$BATS_TEST_TMPDIR/events"
+  export RUNNING_DIR="$BATS_TEST_TMPDIR/running"
+  export PEAKS_DIR="$BATS_TEST_TMPDIR/peaks"
+  rm -rf "$EVENTS_DIR" "$RUNNING_DIR" "$PEAKS_DIR"
+  mkdir -p "$EVENTS_DIR" "$RUNNING_DIR" "$PEAKS_DIR"
+  cat > "$STUB_DIR/railway-timeline" <<STUB
+#!/usr/bin/env bash
+[ "\$1" = "promote" ] || { echo "expected first arg 'promote', got '\$1'" >&2; exit 99; }
+svc="\$2"
+tier="\${svc%%-*}"   # leading t<N> field encodes the tier
+echo "STUB called for: \$svc"
+
+# (1) per-event start file (its OWN file — no shared append).
+printf '%s %s\n' "\$(date +%s.%N)" "\$tier" > "$EVENTS_DIR/start.\$svc"
+
+# (2) register at the rendezvous: create our own unique membership file.
+printf '%s' "\$\$" > "$RUNNING_DIR/\$svc"
+
+# (3) block until BARRIER_TARGET are simultaneously alive OR timeout; track the
+#     peak live count we observe. Count = number of membership files in
+#     \$RUNNING_DIR, computed by globbing into the positional params (no \`ls\`
+#     parsing — robust + shellcheck-clean) and reading \$#.
+target=$barrier_target
+deadline=\$(( \$(date +%s) + $BARRIER_TIMEOUT_SECS ))
+peak=0
+while :; do
+  set -- "$RUNNING_DIR"/*
+  if [ "\$1" = "$RUNNING_DIR/*" ] && [ ! -e "\$1" ]; then
+    live=0   # glob did not match (empty dir)
+  else
+    live=\$#
+  fi
+  [ "\$live" -gt "\$peak" ] && peak=\$live
+  [ "\$live" -ge "\$target" ] && break
+  [ "\$(date +%s)" -ge "\$deadline" ] && break
+  sleep 0.02
+done
+printf '%s' "\$peak" > "$PEAKS_DIR/peak.\$svc"
+
+# (4) deregister, record end, exit.
+rm -f "$RUNNING_DIR/\$svc"
+printf '%s %s\n' "\$(date +%s.%N)" "\$tier" > "$EVENTS_DIR/end.\$svc"
+if [ "\$svc" = "$fail_svc" ]; then exit 7; fi
+exit 0
+STUB
+  chmod +x "$STUB_DIR/railway-timeline"
+  export RAILWAY_BIN="$STUB_DIR/railway-timeline"
+}
+
+# max_concurrency — print the peak number of simultaneously-alive stub
+# invocations, read DETERMINISTICALLY from the per-invocation peak files the
+# rendezvous barrier recorded (each invocation logged the max live count it ever
+# saw). The fleet-wide peak is the max across those readings. No timestamp
+# sweep, no sleep dependence: when the launcher reaches the cap, every concurrent
+# invocation observes (and records) that count before any releases.
+max_concurrency() {
+  local p max=0
+  for f in "$PEAKS_DIR"/peak.*; do
+    [ -f "$f" ] || continue
+    p="$(cat "$f")"
+    [ "$p" -gt "$max" ] && max="$p"
+  done
+  printf '%s' "$max"
+}
+
+@test "fan-out: within a tier, promotes run concurrently but never exceed PROMOTE_FANOUT" {
+  # 6 tier-0 services, cap 3. The rendezvous barrier makes the proof
+  # deterministic: with cap 3 and 6 ready, exactly 3 promotes are provably alive
+  # together (they only release once 3 have rendezvoused), so the recorded peak
+  # is EXACTLY 3 — independent of any sleep. peak must REACH the cap (proves
+  # parallelism, not still-serial) and never EXCEED it (proves the bound holds).
+  setup_timeline_stub 3   # BARRIER_TARGET = min(PROMOTE_FANOUT=3, ready=6) = 3
+  run env PROMOTE_FANOUT=3 \
+    CLOSURE_PLAN="0:t0-a,0:t0-b,0:t0-c,0:t0-d,0:t0-e,0:t0-f" \
+    bash "$SCRIPT"
+
+  [ "$status" -eq 0 ] || fail "expected zero exit on all-green fan-out, got $status: $output"
+  # Every service attempted.
+  for s in t0-a t0-b t0-c t0-d t0-e t0-f; do
+    [[ "$output" == *"STUB called for: $s"* ]] || fail "$s not attempted: $output"
+  done
+
+  local peak
+  peak="$(max_concurrency)"
+  # Bound enforced: never more than PROMOTE_FANOUT in flight at once.
+  [ "$peak" -le 3 ] || fail "peak concurrency $peak exceeded PROMOTE_FANOUT=3 (peaks: $(cat "$PEAKS_DIR"/peak.* 2>/dev/null))"
+  # Parallelism actually happened. With the barrier this is deterministic: a
+  # still-serial launcher never gets >1 invocation alive, never meets the
+  # rendezvous, and each invocation times out with a recorded peak of 1 — so this
+  # assertion goes RED on a serial run (RED-on-serial preserved) with no flake.
+  [ "$peak" -ge 2 ] || fail "peak concurrency $peak < 2 — promotes ran serially, not in parallel (peaks: $(cat "$PEAKS_DIR"/peak.* 2>/dev/null))"
+}
+
+@test "fan-out: tier barrier — no tier-1 start precedes any tier-0 end" {
+  # Cross-tier MUST stay strictly serial: the tier-0 drain (barrier) completes
+  # before any tier-1 promote launches. A naive fan-out that backgrounds across
+  # tier boundaries would let a tier-1 start race ahead of a tier-0 end — this
+  # asserts it does not. BARRIER_TARGET=2 is reachable WITHIN each tier (tier-0
+  # has 3 ready, tier-1 has 2), so neither tier deadlocks; the rendezvous holds
+  # each tier's promotes alive together long enough that a cross-tier leak (a
+  # tier-1 start before a tier-0 end) would be plainly visible in the ordering.
+  setup_timeline_stub 2
+  run env PROMOTE_FANOUT=5 \
+    CLOSURE_PLAN="0:t0-a,0:t0-b,0:t0-c,1:t1-g,1:t1-h" \
+    bash "$SCRIPT"
+
+  [ "$status" -eq 0 ] || fail "expected zero exit, got $status: $output"
+
+  # Latest tier-0 `end` timestamp (from per-event end.<svc> files; field 2 is the
+  # tier, field 1 is the epoch.ns).
+  local last_t0_end
+  last_t0_end="$(cat "$EVENTS_DIR"/end.t0-* 2>/dev/null | awk '{ print $1 }' | sort -g | tail -1)"
+  # Earliest tier-1 `start` timestamp.
+  local first_t1_start
+  first_t1_start="$(cat "$EVENTS_DIR"/start.t1-* 2>/dev/null | awk '{ print $1 }' | sort -g | head -1)"
+
+  [ -n "$last_t0_end" ] || fail "no tier-0 end markers: $(ls "$EVENTS_DIR")"
+  [ -n "$first_t1_start" ] || fail "no tier-1 start markers: $(ls "$EVENTS_DIR")"
+
+  # Barrier: every tier-1 start happens at or after the last tier-0 end.
+  # awk numeric compare (timestamps are epoch.ns floats). Boundary-inclusive
+  # (>=): a tier-1 start tying the last tier-0 end on a coarse clock is valid;
+  # only a start STRICTLY before a tier-0 end (b < a) is a real violation.
+  awk -v a="$last_t0_end" -v b="$first_t1_start" 'BEGIN { exit !(b >= a) }' \
+    || fail "tier barrier violated: tier-1 start $first_t1_start did not follow tier-0 end $last_t0_end (events: $(ls "$EVENTS_DIR"))"
+}
+
+@test "fan-out: a failing tier-0 svc does not abort its siblings; run exits nonzero and reports the failure" {
+  # Best-effort within the (parallel) tier must survive: when one tier-0 service
+  # exits 7, every OTHER tier-0 service still launches + runs to completion, the
+  # final exit is nonzero, and the summary lists the failed svc as `<svc>=7`.
+  # The failing svc records its start/barrier/end markers BEFORE exiting 7, so it
+  # still participates in the rendezvous (BARRIER_TARGET=4 = min(cap 5, ready 4)).
+  setup_timeline_stub 4 "t0-b"
+  run env PROMOTE_FANOUT=5 \
+    CLOSURE_PLAN="0:t0-a,0:t0-b,0:t0-c,0:t0-d" \
+    bash "$SCRIPT"
+
+  # All four tier-0 services launched despite t0-b failing.
+  for s in t0-a t0-b t0-c t0-d; do
+    [[ "$output" == *"STUB called for: $s"* ]] || fail "$s not attempted (best-effort broken): $output"
+    [ -f "$EVENTS_DIR/start.$s" ] || fail "$s has no start marker (did not actually launch): $(ls "$EVENTS_DIR")"
+  done
+
+  # Non-zero aggregate exit because t0-b failed.
+  [ "$status" -ne 0 ] || fail "expected non-zero exit on a failed svc, got $status: $output"
+  # Summary classifies t0-b as failed with its exit code.
+  [[ "$output" == *"t0-b=7"* ]] || fail "failed svc t0-b=7 not reported in summary: $output"
+  # The greens are reported succeeded.
+  run cat "$GITHUB_OUTPUT"
+  [[ "$output" == *"succeeded_csv="* ]] || fail "missing succeeded_csv: $output"
+  [[ "$output" == *"t0-a"* && "$output" == *"t0-c"* && "$output" == *"t0-d"* ]] \
+    || fail "green siblings missing from succeeded_csv: $output"
+  [[ "$output" != *"t0-b"* ]] || fail "failed t0-b leaked into succeeded_csv: $output"
+}
+
+@test "fan-out: PROMOTE_FANOUT override is honored (cap 2 holds peak <= 2)" {
+  # Lowering the cap to 2 must hold the peak concurrency to 2 even with 6 ready
+  # services — proves the env override actually drives the launcher bound. With
+  # BARRIER_TARGET=2 the rendezvous deterministically reaches exactly 2 (if the
+  # launcher honors the override); if it ignored the cap and ran all 6, peak
+  # would exceed 2; if it ran serially, peak would stay 1 and the >=2 assertion
+  # REDs. Either way the override is proven without any sleep dependence.
+  setup_timeline_stub 2   # BARRIER_TARGET = min(PROMOTE_FANOUT=2, ready=6) = 2
+  run env PROMOTE_FANOUT=2 \
+    CLOSURE_PLAN="0:t0-a,0:t0-b,0:t0-c,0:t0-d,0:t0-e,0:t0-f" \
+    bash "$SCRIPT"
+
+  [ "$status" -eq 0 ] || fail "expected zero exit, got $status: $output"
+  local peak
+  peak="$(max_concurrency)"
+  [ "$peak" -le 2 ] || fail "PROMOTE_FANOUT=2 not honored: peak concurrency $peak > 2 (peaks: $(cat "$PEAKS_DIR"/peak.* 2>/dev/null))"
+  [ "$peak" -ge 2 ] || fail "cap-2 run never reached concurrency 2 — not parallel (peaks: $(cat "$PEAKS_DIR"/peak.* 2>/dev/null))"
+}
+
+@test "fan-out: a PRESENT-but-EMPTY .rc (crash/disk-full mid-write) is treated as failed, not parsed as garbage" {
+  # The backgrounded promote_one subshell can be killed (or the disk fill) AFTER
+  # its <slot>.rc file exists but BEFORE the exit code is written — leaving a
+  # PRESENT-but-EMPTY .rc. reap_tier's `-f` check passes (the file exists), so the
+  # missing-file guard does NOT fire; if reap_tier then trusts the empty contents,
+  # `[ "$rc" -eq 0 ]` runs on rc="" and bash errors with "integer expression
+  # expected", and the svc gets recorded as a garbage `<svc>=` (empty rc). This
+  # asserts the empty/non-numeric rc is validated and folded as a real failure.
+  #
+  # We drive it with a stub that locates the script's scratch dir, pre-writes an
+  # EMPTY <svc>.rc, then kill -9's its parent (the promote_one subshell) so the
+  # script never overwrites the empty .rc with a real exit code.
+  cat > "$STUB_DIR/railway-emptyrc" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "promote" ] || { echo "expected first arg 'promote', got '$1'" >&2; exit 99; }
+svc="$2"
+echo "STUB called for: $svc"
+# Locate promote_one's scratch dir (the sole promote-fleet.* under TMPDIR) and
+# pre-seed an EMPTY .rc for this service, mimicking a write that began but never
+# completed (crash/disk-full). svc names here carry no '/', so the slot == svc.
+work="$(ls -d "${TMPDIR:-/tmp}"/promote-fleet.* 2>/dev/null | tail -1)"
+if [ -n "$work" ] && [ -d "$work" ]; then
+  : > "$work/$svc.rc"
+fi
+# Kill the promote_one subshell so it dies BEFORE writing the real rc, leaving
+# the present-but-empty .rc behind. The stub runs inside promote_one's command
+# substitution: $PPID is that cmd-subst subshell; its parent (grandparent of the
+# stub) is the backgrounded promote_one subshell itself — kill THAT so line 179's
+# `echo "$rc" > <slot>.rc` never overwrites the empty file. -9 so no trap rewrites it.
+gp="$(ps -o ppid= -p "$PPID" 2>/dev/null | tr -d ' ')"
+[ -n "$gp" ] && kill -9 "$gp" 2>/dev/null
+kill -9 "$PPID" 2>/dev/null
+exit 0
+STUB
+  chmod +x "$STUB_DIR/railway-emptyrc"
+  export RAILWAY_BIN="$STUB_DIR/railway-emptyrc"
+
+  run env SERVICES_CSV="svc-empty" bash "$SCRIPT"
+
+  # (1) the run exits NONZERO — a lost/garbled result must never read as success.
+  [ "$status" -ne 0 ] || fail "expected non-zero exit on empty .rc, got $status: $output"
+
+  # (2) the bash `[` integer-comparison error must NOT leak (the symptom of an
+  #     unvalidated empty rc reaching `[ "$rc" -eq 0 ]`).
+  [[ "$output" != *"integer expression expected"* ]] \
+    || fail "empty rc leaked into integer comparison: $output"
+
+  # (3) the service is recorded as a real failure (rc coerced to 1), NOT a garbage
+  #     empty `svc-empty=` entry.
+  [[ "$output" == *"svc-empty=1"* ]] || fail "empty-rc svc not recorded as svc-empty=1: $output"
+  [[ "$output" != *"svc-empty= "* && "$output" != *"svc-empty="$'\n'* ]] \
+    || fail "garbage empty-rc entry (svc-empty=) leaked into summary: $output"
+}

--- a/showcase/scripts/promote-fleet.sh
+++ b/showcase/scripts/promote-fleet.sh
@@ -58,6 +58,34 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SHOWCASE_DIR="$(dirname "$HERE")"
 RAILWAY_BIN="${RAILWAY_BIN:-$SHOWCASE_DIR/bin/railway}"
 
+# Within-tier parallel fan-out cap. bin/railway promote is dominated by a
+# serial verify_serving_digest! (~300s/service), so a fully-serial fleet
+# overruns the job timeout mid-fleet. We background promote_one WITHIN a tier up
+# to PROMOTE_FANOUT concurrent processes, drain at the tier boundary (the
+# BARRIER), then reap each service's result. CROSS-tier ordering and
+# dependent-tier gating stay strictly serial. Cap chosen to stay well under
+# Railway API rate limits while cutting wall-clock to ~tier-size/cap * 300s.
+PROMOTE_FANOUT="${PROMOTE_FANOUT:-5}"
+if ! [ "$PROMOTE_FANOUT" -ge 1 ] 2>/dev/null; then
+  echo "::error::promote-fleet: PROMOTE_FANOUT='$PROMOTE_FANOUT' is not a positive integer." >&2
+  exit 1
+fi
+
+# Per-service result scratch dir. Backgrounded promote_one processes run in
+# SUBSHELLS, so their appends to succeeded[]/failed[]/drift[] would be lost; each
+# instead writes its outcome to files here (<svc>.rc / <svc>.drift / <svc>.log),
+# which the parent reap phase reads back into the aggregate arrays IN INPUT
+# ORDER. Cleaned up on exit.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/promote-fleet.XXXXXX")"
+# Invoked indirectly via the EXIT trap below, not by name. shellcheck flags this
+# differently across versions: 0.9.0 (the ubuntu-24.04 CI runner) emits SC2317
+# ("command appears unreachable") on the body, while 0.10.0+ emits SC2329
+# ("function never invoked") on the definition. Disable both so the directive is
+# clean on every shellcheck the fleet runs (local + CI).
+# shellcheck disable=SC2317,SC2329
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
 # ── Input mode resolution ───────────────────────────────────────────────────
 # Two input shapes:
 #   * CLOSURE_PLAN — tier-annotated `tier:name,tier:name,...` (U3 output). When
@@ -95,45 +123,181 @@ trim() {
   printf '%s' "$s"
 }
 
-# promote_one <svc> -> promote a single service best-effort, recording it into
-# succeeded[]/failed[] and aggregating any STAGING_DRIFT_MARKER into drift[].
-# Returns the railway exit code (0 = pinned). This is the EXACT per-service body
-# the flat loop used before tiering was added — preserved byte-for-byte so the
-# behavior (trim handled by caller, args, PIPESTATUS rc capture, drift scan,
-# OK/::error:: lines) is identical on both paths.
+# svc_slot <svc> -> echo a filesystem-safe scratch key for <svc>. Service names
+# are simple DNS-ish labels (e.g. showcase-ag2), but defensively replace any
+# `/` so a stray name can never escape $WORK.
+svc_slot() {
+  printf '%s' "${1//\//_}"
+}
+
+# promote_one <svc> -> promote a single service best-effort. Writes its outcome
+# to the $WORK scratch dir instead of mutating arrays, so it is safe to run in a
+# BACKGROUNDED subshell (where array appends would be lost):
+#   $WORK/<svc>.rc    the railway exit code (0 = pinned)
+#   $WORK/<svc>.log   the full captured promote output (streamed contiguously by
+#                     the reap phase, prefixed [<svc>], so interleaved parallel
+#                     output stays readable)
+#   $WORK/<svc>.drift one STAGING_DRIFT_MARKER payload per line (absent if none)
+# Returns the railway exit code. The per-service BEHAVIOR (args, PIPESTATUS rc
+# capture, drift scan, OK/::error:: lines) is preserved exactly; only the result
+# SINK changed from arrays to files so the parent can reap them in input order.
 promote_one() {
   local svc="$1"
-  local args out rc line
+  local slot args out rc line
+  slot="$(svc_slot "$svc")"
 
   args=(promote "$svc" --yes --non-interactive)
   if [ -n "${DIGEST:-}" ]; then
     args+=(--digest "$DIGEST")
   fi
 
-  echo "==> $RAILWAY_BIN ${args[*]}"
-  # Tee the promote output so we (a) still stream it live to the operator/CI
-  # log AND (b) can scan it for the STAGING_DRIFT_MARKER line that bin/railway
-  # emits when staging is NOT serving the current :latest. PIPESTATUS[0] is the
-  # railway exit code (tee always exits 0), so the per-service success/fail
-  # accounting is unaffected by the pipe.
-  out="$("$RAILWAY_BIN" "${args[@]}" 2>&1 | tee /dev/stderr)"
-  rc="${PIPESTATUS[0]}"
+  # Capture this service's full output into its own log file. We do NOT tee to
+  # the live terminal here: under fan-out, N services stream at once and their
+  # lines would interleave illegibly. The reap phase emits each <svc>.log
+  # CONTIGUOUSLY (prefixed [<svc>]) after the tier drains, preserving the
+  # readable per-service block the serial path produced. PIPESTATUS[0] is the
+  # railway exit code (the redirect/sed in the drift scan never runs in the same
+  # pipe, so rc is the railway rc directly).
+  out="$("$RAILWAY_BIN" "${args[@]}" 2>&1)"
+  rc=$?
+
+  {
+    echo "==> $RAILWAY_BIN ${args[*]}"
+    printf '%s\n' "$out"
+    if [ "$rc" -eq 0 ]; then
+      echo "    OK: $svc"
+    else
+      echo "::error::promote failed for '$svc' (exit $rc)"
+    fi
+  } > "$WORK/$slot.log"
 
   # Collect any drift marker(s) emitted for this service. The marker payload is
   # everything after "STAGING_DRIFT_MARKER: ". Promote still SUCCEEDS on drift
   # (it pins staging's running digest) — this is a warning surface, not a gate.
-  while IFS= read -r line; do
-    [ -n "$line" ] && drift+=("$line")
-  done < <(printf '%s\n' "$out" | sed -n 's/^STAGING_DRIFT_MARKER: //p')
+  printf '%s\n' "$out" | sed -n 's/^STAGING_DRIFT_MARKER: //p' > "$WORK/$slot.drift"
 
-  if [ "$rc" -eq 0 ]; then
-    echo "    OK: $svc"
-    succeeded+=("$svc")
-  else
-    echo "::error::promote failed for '$svc' (exit $rc)"
-    failed+=("$svc=$rc")
-  fi
+  echo "$rc" > "$WORK/$slot.rc"
   return "$rc"
+}
+
+# promote_tier <gated> <svc...> — promote every service in one tier best-effort
+# (unless <gated> is 1, in which case the tier is gated out by an earlier-tier
+# failure and its services are recorded NOT-ATTEMPTED). Sets the GLOBAL
+# `tier_had_failure` to 1 if this tier itself had a promote failure (so the
+# caller can gate the NEXT tier), else 0. Best-effort within the tier is
+# preserved: every member is attempted even after a sibling fails.
+#
+# WITHIN-TIER PARALLELISM: services in a non-gated tier are promoted with
+# bounded concurrency (PROMOTE_FANOUT). promote_one runs in a backgrounded
+# SUBSHELL writing its result to $WORK/<svc>.rc/.drift/.log; when the in-flight
+# count reaches the cap we `wait` the oldest PID (bash 3.2-safe — NO `wait -n`,
+# NO `declare -n`). After launching all members we drain every remaining PID:
+# that drain is the TIER BARRIER. reap_tier then folds the per-service files
+# into the aggregate arrays IN INPUT ORDER, preserving the serial path's
+# ordering, drift aggregation, and best-effort + nonzero-iff-any-failed
+# semantics. CROSS-tier ordering stays serial (the caller reaps before the next
+# tier launches). The flat (SERVICES_CSV) path reuses this as a single ungated
+# tier so it benefits from the same fan-out.
+promote_tier() {
+  local gated_in="$1"; shift
+  local svc pid
+  local launched=()    # service names launched this tier, IN INPUT ORDER
+  local pids=()        # background PIDs, parallel-indexed with launched[]
+  local inflight=0
+  tier_had_failure=0
+  for svc in "$@"; do
+    # Skip the empty arg an empty tier yields via `${arr[@]:-}` on bash 3.2
+    # (and any blank that slipped through). A blank is never a real service.
+    [ -n "$svc" ] || continue
+    if [ "$gated_in" -ne 0 ]; then
+      not_attempted+=("$svc")
+      continue
+    fi
+    # Throttle: once PROMOTE_FANOUT promotes are in flight, block on the OLDEST
+    # outstanding PID before launching the next. Plain `wait <pid>` is bash
+    # 3.2-safe; `wait -n` (4.3+) is deliberately avoided. This is a simple
+    # oldest-first drain, not a true "any-finished" reaper, but it bounds peak
+    # concurrency to the cap exactly while keeping the launch order stable.
+    if [ "$inflight" -ge "$PROMOTE_FANOUT" ]; then
+      local oldest_idx=$(( ${#pids[@]} - inflight ))
+      wait "${pids[$oldest_idx]}"
+      inflight=$(( inflight - 1 ))
+    fi
+    # Background promote_one in a subshell. Its array appends would be lost, but
+    # it writes <svc>.rc/.drift/.log to $WORK which reap_tier reads back.
+    promote_one "$svc" &
+    pids+=("$!")
+    launched+=("$svc")
+    inflight=$(( inflight + 1 ))
+  done
+
+  # TIER BARRIER: drain every remaining in-flight promote before reaping or
+  # advancing to the next tier. Wait on ALL launched PIDs (already-reaped ones
+  # return immediately — harmless).
+  for pid in "${pids[@]:-}"; do
+    [ -n "$pid" ] && wait "$pid"
+  done
+
+  reap_tier "${launched[@]:-}"
+}
+
+# reap_tier <svc...> — fold each launched service's $WORK result files into the
+# aggregate arrays IN THE GIVEN (input) ORDER, so succeeded[]/failed[]/drift[]
+# match the serial path's ordering regardless of completion order. Emits each
+# service's captured log CONTIGUOUSLY, prefixed `[<svc>]`, then OK/::error::
+# accounting identical to the old inline path. Sets tier_had_failure on any
+# nonzero rc.
+reap_tier() {
+  local svc slot rc line
+  for svc in "$@"; do
+    [ -n "$svc" ] || continue
+    slot="$(svc_slot "$svc")"
+
+    # Emit this service's full captured output as one contiguous block so a
+    # parallel tier's logs stay readable (prefixed with the service name).
+    if [ -f "$WORK/$slot.log" ]; then
+      while IFS= read -r line; do
+        echo "[$svc] $line"
+      done < "$WORK/$slot.log"
+    fi
+
+    # Aggregate drift markers (one payload per line; file may be empty/absent).
+    if [ -s "$WORK/$slot.drift" ]; then
+      while IFS= read -r line; do
+        [ -n "$line" ] && drift+=("$line")
+      done < "$WORK/$slot.drift"
+    fi
+
+    # Exit code: a MISSING .rc means the backgrounded promote_one died before
+    # writing it (crash/kill) — treat that as a failure rather than silently
+    # dropping the service, so a lost promote never reads as a phantom success.
+    if [ -f "$WORK/$slot.rc" ]; then
+      rc="$(cat "$WORK/$slot.rc")"
+      # A PRESENT but EMPTY-or-NON-NUMERIC .rc means the promote subshell was
+      # killed (or the disk filled) mid-write — the file exists but its exit code
+      # never landed. Without this guard `rc` could be "" or garbage, and the
+      # `[ "$rc" -eq 0 ]` below would error ("integer expression expected") and
+      # mis-record the service as a phantom `<svc>=` (empty rc). Coerce any
+      # non-integer rc to a failure, mirroring the missing-file branch. The
+      # `case` glob is bash-3.2-safe (no `[[ =~ ]]`, matching the file's style).
+      case "$rc" in
+        ''|*[!0-9-]*)
+          rc=1
+          echo "::error::promote-fleet: malformed result recorded for '$svc' (promote process died mid-write, leaving an empty or non-numeric exit code); treating as failed."
+          ;;
+      esac
+    else
+      rc=1
+      echo "::error::promote-fleet: no result recorded for '$svc' (promote process died before writing its exit code); treating as failed."
+    fi
+
+    if [ "$rc" -eq 0 ]; then
+      succeeded+=("$svc")
+    else
+      failed+=("$svc=$rc")
+      tier_had_failure=1
+    fi
+  done
 }
 
 if [ -n "${CLOSURE_PLAN:-}" ]; then
@@ -170,38 +334,6 @@ if [ -n "${CLOSURE_PLAN:-}" ]; then
     esac
   done
 
-  # promote_tier <gated> <svc...> — promote every service in one tier
-  # best-effort (unless <gated> is 1, in which case the tier is gated out by an
-  # earlier-tier failure and its services are recorded NOT-ATTEMPTED). Sets the
-  # GLOBAL `tier_had_failure` to 1 if this tier itself had a promote failure (so
-  # the caller can gate the NEXT tier), else 0. Best-effort within the tier is
-  # preserved: every member is attempted even after a sibling fails.
-  #
-  # NB: this MUST run in the current shell (NOT a `$(...)` command substitution)
-  # — promote_one appends to the succeeded[]/failed[]/drift[] arrays, and those
-  # mutations would be lost in a subshell. We communicate the tier result via a
-  # global rather than stdout for the same reason.
-  promote_tier() {
-    local gated_in="$1"; shift
-    local svc
-    tier_had_failure=0
-    for svc in "$@"; do
-      # Skip the empty arg an empty tier yields via `${arr[@]:-}` on bash 3.2
-      # (and any blank that slipped through). A blank is never a real service.
-      [ -n "$svc" ] || continue
-      if [ "$gated_in" -ne 0 ]; then
-        not_attempted+=("$svc")
-        continue
-      fi
-      # promote_one returns the railway rc; under `set -uo pipefail` (no -e) a
-      # non-zero return does NOT abort, so per-service best-effort within the
-      # tier is preserved.
-      if ! promote_one "$svc"; then
-        tier_had_failure=1
-      fi
-    done
-  }
-
   # Promote in strict tier order (0 -> 1 -> 2), gating each tier's dependents on
   # ANY earlier-tier failure. `${arr[@]:-}` keeps the empty-array expansion safe
   # under `set -u` on bash 3.2 (an empty tier expands to a single empty arg,
@@ -216,7 +348,11 @@ if [ -n "${CLOSURE_PLAN:-}" ]; then
 else
   # ── Flat leaf path (legacy / backward-compat) ──────────────────────────────
   # No tier gating: every service attempted best-effort, identical to the
-  # pre-U4 behavior. not_attempted[] stays empty on this path.
+  # pre-U4 behavior. not_attempted[] stays empty on this path. We route the
+  # trimmed leaf set through promote_tier as a single UNGATED tier (gated=0) so
+  # the flat path gets the same bounded fan-out as a closure tier — best-effort,
+  # input-order aggregation, and drift handling are all preserved by reap_tier.
+  flat_svcs=()
   IFS=',' read -ra SVCS <<< "$SERVICES_CSV"
   for svc in "${SVCS[@]}"; do
     # Trim BEFORE the empty-check so a whitespace-only token is also skipped.
@@ -224,8 +360,10 @@ else
     # Guard against empty tokens from a stray/trailing comma (or a
     # whitespace-only token) in the CSV.
     [ -n "$svc" ] || continue
-    promote_one "$svc" || true
+    flat_svcs+=("$svc")
   done
+  tier_had_failure=0
+  promote_tier 0 "${flat_svcs[@]:-}"
 fi
 
 # Guard against input that parsed to ONLY empty/whitespace tokens (e.g. ",,"


### PR DESCRIPTION
## Summary

A full `service=all` promote ran **fully serially** and exceeded the promote job's 20-minute `timeout-minutes`, getting cancelled mid-fleet (silent partial promotion). This adds **within-tier parallel fan-out** so `all` completes in budget.

## Changes

- **`promote-fleet.sh`** — within a tier, `promote_one` is backgrounded up to `PROMOTE_FANOUT` (default 5) via a **bash-3.2-safe** PID-array bounded launcher (plain `wait <pid>`, no `wait -n`/`declare -n`). Per-service results go to temp files (`$WORK/<svc>.rc/.drift/.log`) and `reap_tier` repatriates them into `succeeded[]`/`failed[]`/`drift[]` (subshell-safe — backgrounded children can't mutate parent arrays). **Tier boundaries are hard barriers** (all PIDs drained before the next tier); cross-tier stays serial. A present-but-empty/non-numeric `.rc` (crash/disk-full mid-write) is treated as a clean failure, not parsed as garbage.
- **`showcase_promote.yml`** — wires `CLOSURE_PLAN` into the promote step (was flat `SERVICES_CSV`) so the fan-out is tier-aware; bumps the promote job `timeout-minutes` **20 → 35**.
- **`promote-fleet.bats`** — new fan-out tests with a **deterministic rendezvous-barrier** concurrency proof (no wall-clock sleep race; RED-on-serial preserved via timeout), tier-barrier boundary-inclusive (`>=`), and the empty-`.rc`-as-failure case.
- `SC2317,SC2329` shellcheck disable for the trap-only `cleanup()` (ubuntu-24.04 CI ships shellcheck 0.9.0).

## Test plan

- [x] bats **27/27** (file) / **108/108** (dir) green
- [x] shellcheck clean on local 0.11.0 **and** pinned CI 0.9.0
- [x] actionlint clean on the workflow
- [x] within-tier concurrency ≤ cap and reaches cap; tier barrier holds; one failure doesn't abort its tier + run exits nonzero