### PR TITLE
feat(showcase): on-demand prod-vs-staging reconcile tool (reconcile-prod CLI + manual workflow)

### DIFF
--- a/.github/workflows/showcase_reconcile.yml
+++ b/.github/workflows/showcase_reconcile.yml
@@ -1,0 +1,147 @@
+name: "Showcase: Reconcile prod vs staging (drift gate)"
+
+# Lever 1 of the promote-reliability hardening plan: proactively detect when a
+# prod showcase column has drifted STALE vs a green staging, so drift is alerted
+# automatically instead of discovered by eyeballing a dead column.
+#
+# The showcase deploy model: staging tracks a mutable `:latest` tag and is
+# continuously rebuilt; prod is pinned to an immutable `@sha256:` digest and
+# advances only on an explicit promote. So prod can silently fall BEHIND a green
+# staging. This scheduled gate compares, per prod-eligible service
+# (probe.prod == true), the prod SERVING digest against the staging RUNNING
+# digest, reds the run on any stale service, and alerts #oss-alerts with the
+# stale-column list.
+#
+# Read-only: runs `bin/railway reconcile-prod`, which performs NO promotes /
+# mutations. The post-promote convergence step (verifying prod == staging right
+# after a promote) is a deferred fast-follow — this workflow is the standalone
+# scheduled drift detector.
+
+on:
+  schedule:
+    # Daily at 14:00 UTC (mid-morning US Eastern) — a once-a-day drift sweep is
+    # enough; promote is the corrective action and is human-triggered.
+    - cron: "0 14 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: showcase-reconcile-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  reconcile:
+    name: Reconcile prod vs staging
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: railway
+    env:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+    outputs:
+      state: ${{ steps.gate.outputs.state }}
+      stale_line: ${{ steps.gate.outputs.stale_line }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
+        with:
+          ruby-version: "3.2"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+
+      - name: Regenerate SSOT JSON
+        # bin/railway reads showcase/scripts/railway-envs.generated.json to
+        # derive the prod-eligible (probe.prod) set; it is never committed, so
+        # regenerate it here. Skip the oxfmt-canonical pass (repo-root oxfmt is
+        # not installed by this scripts-scoped `npm ci`), mirroring the promote
+        # workflow's resolve/promote jobs.
+        working-directory: showcase/scripts
+        env:
+          EMIT_SKIP_OXFMT: "1"
+        run: |
+          npm ci
+          npx tsx emit-railway-envs-json.ts
+
+      - name: Reconcile gate
+        id: gate
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Path the gate writes machine-readable JSON to, for the Slack builder.
+          RECONCILE_JSON: ${{ github.workspace }}/reconcile.json
+        run: |
+          set -uo pipefail
+          if [ -z "${RAILWAY_TOKEN:-}" ]; then
+            echo "::error::RAILWAY_TOKEN secret not configured; cannot run the reconcile gate."
+            echo "state=error" >> "$GITHUB_OUTPUT"
+            echo "stale_line=" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          # Run the gate. reconcile-prod-gate.sh exits 1 on a stale service and
+          # 2 on a hard error; either is a step failure. Capture rc explicitly
+          # so we can derive the Slack state + stale-column list before exiting.
+          rc=0
+          RAILWAY_BIN="showcase/bin/railway" \
+            showcase/scripts/reconcile-prod-gate.sh || rc=$?
+
+          # Derive a single-line stale-column list from the machine JSON for the
+          # Slack payload (key=value GITHUB_OUTPUT contract forbids embedded
+          # newlines, so this MUST be one line). Empty when nothing is stale or
+          # the JSON could not be produced.
+          STALE_LINE=""
+          if [ -s "${RECONCILE_JSON:-}" ]; then
+            STALE_LINE="$(ruby -rjson -e '
+              data = JSON.parse(File.read(ENV["RECONCILE_JSON"])) rescue {}
+              stale = (data["services"] || []).select { |s| s["status"] == "stale" }
+              names = stale.map { |s| s["name"] }
+              print names.empty? ? "" : "Stale columns: #{names.join(", ")}"
+            ' 2>/dev/null | tr -d '\n')"
+          fi
+
+          if [ "$rc" -eq 0 ]; then
+            echo "state=clean" >> "$GITHUB_OUTPUT"
+          elif [ "$rc" -eq 1 ]; then
+            echo "state=stale" >> "$GITHUB_OUTPUT"
+          else
+            echo "state=error" >> "$GITHUB_OUTPUT"
+          fi
+          echo "stale_line=$STALE_LINE" >> "$GITHUB_OUTPUT"
+          exit "$rc"
+
+      - name: Post to #oss-alerts (stale drift)
+        # Only alert on a stale verdict (drift we can prove). A hard error reds
+        # the run via the gate step's non-zero exit but does not page Slack — it
+        # is surfaced in the run log + step summary.
+        if: always() && steps.gate.outputs.state == 'stale' && env.SLACK_WEBHOOK != ''
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          webhook-type: incoming-webhook
+          # Newlines via fromJSON('"\n"') (a real LF char), NOT a literal '\n':
+          # GitHub Actions expression string literals do not interpret backslash
+          # escapes, so a literal '\n' would survive toJSON as the two chars \\n
+          # and Slack would render it verbatim. (Same idiom as showcase_promote.yml.)
+          payload: |
+            {
+              "text": ${{ toJSON(format(
+                ':warning: *Showcase prod drift detected*{3}Prod has fallen BEHIND a green staging — re-promote the stale column(s).{3}{1}{3}<{0}/{2}/actions/runs/{4}|View run>',
+                github.server_url,
+                steps.gate.outputs.stale_line,
+                github.repository,
+                fromJSON('"\n"'),
+                github.run_id
+              )) }}
+            }
+
+      - name: Log (no Slack — webhook unset)
+        if: always() && steps.gate.outputs.state == 'stale' && env.SLACK_WEBHOOK == ''
+        run: |
+          echo "::warning::Prod drift detected (${{ steps.gate.outputs.stale_line }}) but SLACK_WEBHOOK_OSS_ALERTS is not set; no Slack notification sent."

--- a/.github/workflows/showcase_reconcile.yml
+++ b/.github/workflows/showcase_reconcile.yml
@@ -1,27 +1,21 @@
-name: "Showcase: Reconcile prod vs staging (drift gate)"
+name: "Showcase: Reconcile prod vs staging (on-demand drift check)"
 
-# Lever 1 of the promote-reliability hardening plan: proactively detect when a
-# prod showcase column has drifted STALE vs a green staging, so drift is alerted
-# automatically instead of discovered by eyeballing a dead column.
+# On-demand prod-vs-staging reconciliation. The showcase deploy model: staging
+# tracks a mutable `:latest` tag and is continuously rebuilt; prod is pinned to
+# an immutable `@sha256:` digest and advances only on an explicit promote. So
+# prod can sit BEHIND a green staging — which is OFTEN INTENTIONAL (changes are
+# batched and promoted deliberately), so a recurring drift alert would be noise.
 #
-# The showcase deploy model: staging tracks a mutable `:latest` tag and is
-# continuously rebuilt; prod is pinned to an immutable `@sha256:` digest and
-# advances only on an explicit promote. So prod can silently fall BEHIND a green
-# staging. This scheduled gate compares, per prod-eligible service
-# (probe.prod == true), the prod SERVING digest against the staging RUNNING
-# digest, reds the run on any stale service, and alerts #oss-alerts with the
-# stale-column list.
+# This workflow is therefore MANUAL ONLY (workflow_dispatch). There is no
+# schedule and no unsolicited Slack alert. A maintainer runs it from the Actions
+# tab to answer "is prod caught up with staging right now?"; the per-service
+# reconcile table is rendered into the GH step summary, and the run exits
+# nonzero when a column is stale so the drift is visibly flagged on the run.
 #
 # Read-only: runs `bin/railway reconcile-prod`, which performs NO promotes /
-# mutations. The post-promote convergence step (verifying prod == staging right
-# after a promote) is a deferred fast-follow — this workflow is the standalone
-# scheduled drift detector.
+# mutations.
 
 on:
-  schedule:
-    # Daily at 14:00 UTC (mid-morning US Eastern) — a once-a-day drift sweep is
-    # enough; promote is the corrective action and is human-triggered.
-    - cron: "0 14 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -37,11 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: railway
-    env:
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
-    outputs:
-      state: ${{ steps.gate.outputs.state }}
-      stale_line: ${{ steps.gate.outputs.stale_line }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -75,73 +64,27 @@ jobs:
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Path the gate writes machine-readable JSON to, for the Slack builder.
+          # Path the gate writes machine-readable JSON to (uploaded as an
+          # artifact below). Cheap to keep — handy for a maintainer inspecting a
+          # manual run, but no Slack/alert consumer.
           RECONCILE_JSON: ${{ github.workspace }}/reconcile.json
         run: |
           set -uo pipefail
           if [ -z "${RAILWAY_TOKEN:-}" ]; then
             echo "::error::RAILWAY_TOKEN secret not configured; cannot run the reconcile gate."
-            echo "state=error" >> "$GITHUB_OUTPUT"
-            echo "stale_line=" >> "$GITHUB_OUTPUT"
             exit 1
           fi
-          # Run the gate. reconcile-prod-gate.sh exits 1 on a stale service and
-          # 2 on a hard error; either is a step failure. Capture rc explicitly
-          # so we can derive the Slack state + stale-column list before exiting.
-          rc=0
+          # Run the gate. reconcile-prod-gate.sh surfaces the per-service table
+          # into the GH step summary and exits 1 on a stale service / 2 on a hard
+          # error — either reds the run so a manual run visibly flags drift.
           RAILWAY_BIN="showcase/bin/railway" \
-            showcase/scripts/reconcile-prod-gate.sh || rc=$?
+            showcase/scripts/reconcile-prod-gate.sh
 
-          # Derive a single-line stale-column list from the machine JSON for the
-          # Slack payload (key=value GITHUB_OUTPUT contract forbids embedded
-          # newlines, so this MUST be one line). Empty when nothing is stale or
-          # the JSON could not be produced.
-          STALE_LINE=""
-          if [ -s "${RECONCILE_JSON:-}" ]; then
-            STALE_LINE="$(ruby -rjson -e '
-              data = JSON.parse(File.read(ENV["RECONCILE_JSON"])) rescue {}
-              stale = (data["services"] || []).select { |s| s["status"] == "stale" }
-              names = stale.map { |s| s["name"] }
-              print names.empty? ? "" : "Stale columns: #{names.join(", ")}"
-            ' 2>/dev/null | tr -d '\n')"
-          fi
-
-          if [ "$rc" -eq 0 ]; then
-            echo "state=clean" >> "$GITHUB_OUTPUT"
-          elif [ "$rc" -eq 1 ]; then
-            echo "state=stale" >> "$GITHUB_OUTPUT"
-          else
-            echo "state=error" >> "$GITHUB_OUTPUT"
-          fi
-          echo "stale_line=$STALE_LINE" >> "$GITHUB_OUTPUT"
-          exit "$rc"
-
-      - name: Post to #oss-alerts (stale drift)
-        # Only alert on a stale verdict (drift we can prove). A hard error reds
-        # the run via the gate step's non-zero exit but does not page Slack — it
-        # is surfaced in the run log + step summary.
-        if: always() && steps.gate.outputs.state == 'stale' && env.SLACK_WEBHOOK != ''
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+      - name: Upload reconcile JSON
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
-          webhook-type: incoming-webhook
-          # Newlines via fromJSON('"\n"') (a real LF char), NOT a literal '\n':
-          # GitHub Actions expression string literals do not interpret backslash
-          # escapes, so a literal '\n' would survive toJSON as the two chars \\n
-          # and Slack would render it verbatim. (Same idiom as showcase_promote.yml.)
-          payload: |
-            {
-              "text": ${{ toJSON(format(
-                ':warning: *Showcase prod drift detected*{3}Prod has fallen BEHIND a green staging — re-promote the stale column(s).{3}{1}{3}<{0}/{2}/actions/runs/{4}|View run>',
-                github.server_url,
-                steps.gate.outputs.stale_line,
-                github.repository,
-                fromJSON('"\n"'),
-                github.run_id
-              )) }}
-            }
-
-      - name: Log (no Slack — webhook unset)
-        if: always() && steps.gate.outputs.state == 'stale' && env.SLACK_WEBHOOK == ''
-        run: |
-          echo "::warning::Prod drift detected (${{ steps.gate.outputs.stale_line }}) but SLACK_WEBHOOK_OSS_ALERTS is not set; no Slack notification sent."
+          name: reconcile-json
+          path: reconcile.json
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/showcase_validate.yml
+++ b/.github/workflows/showcase_validate.yml
@@ -565,7 +565,7 @@ jobs:
 
       - name: Shellcheck promote workflow scripts
         # shellcheck is preinstalled on ubuntu-latest.
-        run: shellcheck showcase/scripts/promote-fleet.sh showcase/scripts/verify-prod-display.sh
+        run: shellcheck showcase/scripts/promote-fleet.sh showcase/scripts/verify-prod-display.sh showcase/scripts/reconcile-prod-gate.sh
 
       - name: Run bats suite
         run: bats showcase/scripts/__tests__/

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -2554,6 +2554,213 @@ module Railway
         end
     end
 
+    # reconcile-prod — detect prod columns that have drifted STALE vs a green
+    # staging (Lever 1 of the promote-reliability hardening plan).
+    #
+    # The showcase deploy model: staging tracks a mutable `:latest` tag and is
+    # continuously rebuilt; prod is pinned to an immutable `@sha256:` digest and
+    # only advances on an explicit promote. So prod can silently fall BEHIND a
+    # green staging — a dead/stale prod column that today is only noticed by
+    # eyeballing it. This gate compares, per prod-eligible service, the prod
+    # SERVING digest against the staging RUNNING digest and reds the run when
+    # any service is stale, so drift is alerted automatically.
+    #
+    # For each prod-eligible (`probe.prod == true`, the same set
+    # resolve-promote-targets.sh promotes) service:
+    #   prod serving digest    = the `@sha256:` prod is pinned to (LintProd
+    #                            path — SnapshotCommand.build_snapshot(prod)).
+    #   staging running digest  = staging's latest SUCCESS deployment
+    #                            meta.imageDigest (reuses
+    #                            PromoteCommand#staging_running_digest).
+    #
+    # Classification:
+    #   green  — prod == staging (in sync).
+    #   stale  — prod != staging AND staging running digest IS resolvable
+    #            (prod has drifted behind a green staging — what we alert on).
+    #   gray   — staging running digest not resolvable (no SUCCESS deploy / no
+    #            imageDigest), OR the service has no prod snapshot entry yet.
+    #            Informational, NOT stale — we cannot prove drift.
+    #
+    # Exit codes: 0 = no stale, 1 = at least one stale, 2 = hard error.
+    # Read-only — performs NO promotes / mutations.
+    class ReconcileProdCommand < BaseCommand
+        STATUS_GREEN = "green"
+        STATUS_STALE = "stale"
+        STATUS_GRAY  = "gray"
+
+        def initialize(argv)
+            super
+            @json = false
+        end
+
+        def parser
+            OptionParser.new do |o|
+                o.banner = <<~BANNER
+                    Usage: bin/railway reconcile-prod [--json]
+
+                      Detect production services whose serving digest has drifted
+                      STALE vs a green staging. For every prod-eligible service
+                      (probe.prod == true) compares the prod SERVING digest
+                      (immutable @sha256:) against the staging RUNNING digest
+                      (staging's latest SUCCESS deployment). Classifies each:
+
+                        green   prod digest == staging running digest (in sync)
+                        stale   prod != staging AND staging IS resolvable
+                                (prod drifted behind a green staging)
+                        gray    staging running digest not resolvable, or the
+                                service has no prod snapshot entry yet
+                                (informational — NOT stale)
+
+                      Exits 1 iff any service is STALE. Read-only: NO promotes.
+
+                      --json   Emit machine-readable JSON instead of a table:
+                                 {services:[{name,prod,staging,status}],
+                                  green:N, stale:N, gray:N, timestamp:"ISO8601"}
+                BANNER
+                o.on("--json", "Emit machine-readable JSON") { @json = true }
+                o.on("-h", "--help") { puts o; exit 0 }
+            end
+        end
+
+        def run
+            parser.parse!(argv)
+            rows = classify_all
+
+            if @json
+                stale = rows.count { |r| r["status"] == STATUS_STALE }
+                green = rows.count { |r| r["status"] == STATUS_GREEN }
+                gray  = rows.count { |r| r["status"] == STATUS_GRAY }
+                puts JSON.generate(
+                    "services"  => rows,
+                    "green"     => green,
+                    "stale"     => stale,
+                    "gray"      => gray,
+                    "timestamp" => Time.now.utc.iso8601,
+                )
+                return run_classification(rows)
+            end
+
+            print_table(rows)
+            run_classification(rows)
+        end
+
+        # Classify every prod-eligible service. Returns an array of
+        # { "name", "service_id", "prod", "staging", "status" } hashes, sorted
+        # by name. `prod`/`staging` are the `sha256:...` digests (or nil).
+        def classify_all
+            prod_by_sid = prod_digests_by_service_id
+            eligible_services.map do |elig|
+                sid  = elig["service_id"]
+                name = elig["name"]
+                prod_digest = prod_by_sid[sid]
+                staging_digest = staging_running_digest_for(elig)
+                {
+                    "name"       => name,
+                    "service_id" => sid,
+                    "prod"       => prod_digest,
+                    "staging"    => staging_digest,
+                    "status"     => classify(prod_digest, staging_digest),
+                }
+            end.sort_by { |r| r["name"].to_s }
+        end
+
+        # green  — prod present AND staging present AND equal.
+        # stale  — prod present AND staging present AND different.
+        # gray   — staging unresolvable, OR prod absent (can't prove drift).
+        def classify(prod_digest, staging_digest)
+            return STATUS_GRAY if staging_digest.nil? || staging_digest.empty?
+            return STATUS_GRAY if prod_digest.nil? || prod_digest.empty?
+            prod_digest == staging_digest ? STATUS_GREEN : STATUS_STALE
+        end
+
+        # Exit-code contract: 1 iff any service is stale, else 0.
+        def run_classification(rows)
+            rows.any? { |r| r["status"] == STATUS_STALE } ? 1 : 0
+        end
+
+        private
+
+        # prod serving digest per service_id, from the prod snapshot (the same
+        # LintProd path). Prefer the parsed `digest` field; fall back to parsing
+        # `@sha256:` out of the image ref (prod is always digest-pinned).
+        def prod_digests_by_service_id
+            snap = build_prod_snapshot
+            (snap["services"] || []).each_with_object({}) do |svc, acc|
+                sid = svc["service_id"]
+                next if sid.nil?
+                digest = svc["digest"]
+                if (digest.nil? || digest.empty?)
+                    image = svc["image"].to_s
+                    digest = image.split("@", 2).last if image.include?("@sha256:")
+                end
+                acc[sid] = digest unless digest.nil? || digest.empty?
+            end
+        end
+
+        # The prod snapshot — same source LintProdCommand reads. Isolated into a
+        # method so tests can inject a fixture.
+        def build_prod_snapshot
+            SnapshotCommand.new(["--env", "production", "--dry-run"])
+                .build_snapshot(PRODUCTION_ENV_ID)
+        end
+
+        # The prod-eligible service set: every SSOT service with
+        # `probe.prod == true` (the set resolve-promote-targets.sh promotes).
+        # Each element is { "name" =>, "service_id" => } — service_id is the
+        # SSOT `serviceId`, which equals the snapshot `service_id` (same project
+        # service node across envs), so it correlates prod ⇆ staging.
+        def eligible_services
+            SSOT_DATA.fetch("services")
+                .select { |s| s.dig("probe", "prod") == true }
+                .map { |s| { "name" => s.fetch("name"), "service_id" => s["serviceId"] } }
+        end
+
+        # The staging RUNNING digest for a prod-eligible service. Reuses
+        # PromoteCommand#staging_running_digest (latest SUCCESS staging
+        # deployment meta.imageDigest) — the same source the promote pin uses —
+        # so the comparator and the promote agree on "what staging is serving".
+        # Shares this command's GraphQL client so we don't double-auth.
+        def staging_running_digest_for(svc)
+            promote_helper.send(:staging_running_digest, svc)
+        end
+
+        # A PromoteCommand instance used purely as a library for its
+        # staging-digest resolution. Shares our gql client. NEVER runs a
+        # promote — we only call its read-only digest resolver.
+        def promote_helper
+            @promote_helper ||= begin
+                p = PromoteCommand.new(["--non-interactive"])
+                p.instance_variable_set(:@gql, gql)
+                p
+            end
+        end
+
+        def short(d)
+            return "(none)" if d.nil? || d.to_s.empty?
+            d.to_s.sub(/^sha256:/, "")[0, 12]
+        end
+
+        def print_table(rows)
+            name_w = ([4] + rows.map { |r| r["name"].to_s.length }).max
+            puts format("%-#{name_w}s  %-6s  %-12s  %-12s", "NAME", "STATUS", "PROD", "STAGING")
+            rows.each do |r|
+                puts format("%-#{name_w}s  %-6s  %-12s  %-12s",
+                    r["name"], r["status"], short(r["prod"]), short(r["staging"]))
+            end
+            stale = rows.count { |r| r["status"] == STATUS_STALE }
+            green = rows.count { |r| r["status"] == STATUS_GREEN }
+            gray  = rows.count { |r| r["status"] == STATUS_GRAY }
+            puts ""
+            puts "Summary: #{green} green, #{stale} stale, #{gray} gray (#{rows.size} prod-eligible)."
+            if stale.positive?
+                names = rows.select { |r| r["status"] == STATUS_STALE }.map { |r| r["name"] }
+                puts "STALE: prod has drifted behind green staging for: #{names.join(', ')}."
+            else
+                puts "OK: no production service is stale vs staging."
+            end
+        end
+    end
+
     # ── Dispatcher ─────────────────────────────────────────────────────────────
 
     SUBCOMMANDS = {
@@ -2566,6 +2773,7 @@ module Railway
         "env-diff"         => EnvDiffCommand,
         "resolve-digest"   => ResolveDigestCommand,
         "lint-prod"        => LintProdCommand,
+        "reconcile-prod"   => ReconcileProdCommand,
     }.freeze
 
     def self.usage
@@ -2582,6 +2790,7 @@ module Railway
               env-diff          Diff two envs; exit 1 if drift.
               resolve-digest    Resolve an image tag to its GHCR digest.
               lint-prod         CI gate: fail if any prod service is not digest-pinned.
+              reconcile-prod    Drift gate: fail if any prod service is stale vs staging.
 
             Run any subcommand with --help for full flag list.
 

--- a/showcase/bin/spec/test_reconcile_prod.rb
+++ b/showcase/bin/spec/test_reconcile_prod.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+# Covers `bin/railway reconcile-prod` — the prod-vs-staging drift comparator
+# (Lever 1 of the promote-reliability hardening plan).
+#
+# Contract: for every prod-eligible (`probe.prod == true`) service, compare the
+# prod SERVING digest (the immutable `@sha256:` prod is pinned to) against the
+# staging RUNNING digest (staging's latest SUCCESS deployment's
+# meta.imageDigest — the same source PromoteCommand#staging_running_digest
+# reads). Classify each service:
+#
+#   green  — prod digest == staging running digest (in sync).
+#   stale  — prod digest != staging running digest AND staging IS resolvable
+#            (prod has drifted behind a green staging — the thing we alert on).
+#   gray   — staging running digest not resolvable (no SUCCESS deploy / no
+#            imageDigest) — informational, NOT stale (we can't prove drift).
+#
+# Exit code contract (the whole point of the gate):
+#   exit 0  — no `stale` services (all green, or only green+gray).
+#   exit 1  — at least one `stale` service (prod drifted behind green staging).
+#
+# Read-only: NO promotes / mutations. --json emits machine output.
+#
+# The test injects fakes the same way the promote suite does
+# (test_promote_staging_running_digest.rb): instance_variable_set the prod +
+# staging snapshots and a fake that resolves the staging running digest.
+class ReconcileProdTest < Minitest::Test
+    # Build a ReconcileProdCommand with injected prod + staging snapshots and a
+    # per-service staging-running-digest map (sid => "sha256:..." or nil).
+    #
+    # `eligible` is the list of SSOT-eligible service descriptors the command
+    # iterates: each is { "name" =>, "service_id" => }. We inject it directly so
+    # the test does not depend on the real generated SSOT JSON.
+    def make_cmd(eligible:, prod_services:, running_by_sid:, argv: [])
+        cmd = Railway::ReconcileProdCommand.new(argv)
+        cmd.parser.parse!(cmd.argv)
+        # Inject the prod snapshot the comparator reads (LintProd path).
+        cmd.define_singleton_method(:build_prod_snapshot) do
+            { "services" => prod_services }
+        end
+        # Inject the prod-eligible service set (normally derived from the SSOT
+        # generated.json by probe.prod == true).
+        cmd.define_singleton_method(:eligible_services) { eligible }
+        # Inject the staging running digest lookup (normally
+        # PromoteCommand#staging_running_digest reading Railway deployments).
+        cmd.define_singleton_method(:staging_running_digest_for) do |svc|
+            running_by_sid[svc["service_id"]]
+        end
+        cmd
+    end
+
+    PROD = lambda do |name, sid, digest|
+        # A prod snapshot service is pinned to an immutable digest:
+        # image = ghcr.io/org/name@sha256:..., digest = sha256:...
+        {
+            "name"       => name,
+            "service_id" => sid,
+            "image"      => "ghcr.io/copilotkit/#{name}@#{digest}",
+            "digest"     => digest,
+        }
+    end
+
+    ELIG = lambda do |name, sid|
+        { "name" => name, "service_id" => sid }
+    end
+
+    # ===================== RED-anchor: STALE => exit 1 ========================
+    # Prod is pinned to digest A; staging is RUNNING green digest B. prod !=
+    # staging-green => STALE. The comparator MUST classify it stale and exit 1.
+    def test_stale_when_prod_differs_from_green_staging
+        cmd = make_cmd(
+            eligible:       [ELIG.call("shell", "sid-shell")],
+            prod_services:  [PROD.call("shell", "sid-shell", "sha256:aaaa1111")],
+            running_by_sid: { "sid-shell" => "sha256:bbbb2222" }, # green staging, DIFFERENT
+        )
+        rows = cmd.classify_all
+        row = rows.find { |r| r["name"] == "shell" }
+        assert_equal "stale", row["status"],
+            "prod digest != staging green digest must classify STALE"
+        assert_equal 1, cmd.run_classification(rows),
+            "any stale service must exit non-zero (1)"
+    end
+
+    # ===================== GREEN => exit 0 ====================================
+    def test_green_when_prod_matches_staging
+        cmd = make_cmd(
+            eligible:       [ELIG.call("shell", "sid-shell"),
+                             ELIG.call("docs", "sid-docs")],
+            prod_services:  [PROD.call("shell", "sid-shell", "sha256:aaaa1111"),
+                             PROD.call("docs", "sid-docs", "sha256:cccc3333")],
+            running_by_sid: { "sid-shell" => "sha256:aaaa1111",
+                              "sid-docs"  => "sha256:cccc3333" },
+        )
+        rows = cmd.classify_all
+        assert(rows.all? { |r| r["status"] == "green" },
+            "all matching => all green, got #{rows.map { |r| r['status'] }.inspect}")
+        assert_equal 0, cmd.run_classification(rows),
+            "no stale service => exit 0"
+    end
+
+    # ===================== GRAY (staging not green) => exit 0 =================
+    # Staging has no resolvable running digest (nil). That is NOT drift we can
+    # prove — classify gray (informational), NOT stale. Must NOT red the run.
+    def test_gray_when_staging_not_resolvable
+        cmd = make_cmd(
+            eligible:       [ELIG.call("shell", "sid-shell")],
+            prod_services:  [PROD.call("shell", "sid-shell", "sha256:aaaa1111")],
+            running_by_sid: { "sid-shell" => nil }, # staging not green/resolvable
+        )
+        rows = cmd.classify_all
+        row = rows.find { |r| r["name"] == "shell" }
+        assert_equal "gray", row["status"],
+            "unresolvable staging digest must be gray, not stale"
+        assert_equal 0, cmd.run_classification(rows),
+            "gray (not stale) must NOT red the run"
+    end
+
+    # ===================== mixed: one stale among green/gray => exit 1 ========
+    def test_mixed_with_one_stale_exits_nonzero
+        cmd = make_cmd(
+            eligible:       [ELIG.call("shell", "sid-shell"),
+                             ELIG.call("docs", "sid-docs"),
+                             ELIG.call("dojo", "sid-dojo")],
+            prod_services:  [PROD.call("shell", "sid-shell", "sha256:aaaa1111"),
+                             PROD.call("docs", "sid-docs", "sha256:cccc3333"),
+                             PROD.call("dojo", "sid-dojo", "sha256:dddd4444")],
+            running_by_sid: { "sid-shell" => "sha256:aaaa1111",   # green
+                              "sid-docs"  => "sha256:9999ffff",   # STALE
+                              "sid-dojo"  => nil },                # gray
+        )
+        rows = cmd.classify_all
+        by_name = rows.each_with_object({}) { |r, h| h[r["name"]] = r["status"] }
+        assert_equal "green", by_name["shell"]
+        assert_equal "stale", by_name["docs"]
+        assert_equal "gray",  by_name["dojo"]
+        assert_equal 1, cmd.run_classification(rows),
+            "one stale among green/gray => exit 1"
+    end
+
+    # ===================== --json machine output =============================
+    def test_json_output_shape
+        cmd = make_cmd(
+            eligible:       [ELIG.call("shell", "sid-shell")],
+            prod_services:  [PROD.call("shell", "sid-shell", "sha256:aaaa1111")],
+            running_by_sid: { "sid-shell" => "sha256:bbbb2222" },
+            argv:           ["--json"],
+        )
+        out, = capture_io { cmd.run }
+        payload = JSON.parse(out)
+        assert_equal 1, payload["stale"], "stale count surfaced in JSON"
+        svc = payload["services"].find { |s| s["name"] == "shell" }
+        assert_equal "stale", svc["status"]
+        assert_equal "sha256:aaaa1111", svc["prod"]
+        assert_equal "sha256:bbbb2222", svc["staging"]
+    end
+
+    # ===================== run() end-to-end exit code =========================
+    def test_run_exits_nonzero_on_stale
+        cmd = make_cmd(
+            eligible:       [ELIG.call("shell", "sid-shell")],
+            prod_services:  [PROD.call("shell", "sid-shell", "sha256:aaaa1111")],
+            running_by_sid: { "sid-shell" => "sha256:bbbb2222" },
+        )
+        rc = nil
+        capture_io { rc = cmd.run }
+        assert_equal 1, rc, "run() must exit 1 when a service is stale"
+    end
+
+    def test_run_exits_zero_when_all_green
+        cmd = make_cmd(
+            eligible:       [ELIG.call("shell", "sid-shell")],
+            prod_services:  [PROD.call("shell", "sid-shell", "sha256:aaaa1111")],
+            running_by_sid: { "sid-shell" => "sha256:aaaa1111" },
+        )
+        rc = nil
+        capture_io { rc = cmd.run }
+        assert_equal 0, rc, "run() must exit 0 when all services green"
+    end
+
+    # ===================== prod service missing from snapshot =================
+    # A prod-eligible service that has NO prod snapshot entry (never deployed to
+    # prod) has no prod digest to compare. It must NOT be classified stale
+    # (we can't prove drift) — classify gray (informational).
+    def test_missing_prod_service_is_gray_not_stale
+        cmd = make_cmd(
+            eligible:       [ELIG.call("newsvc", "sid-new")],
+            prod_services:  [], # newsvc not in prod yet
+            running_by_sid: { "sid-new" => "sha256:bbbb2222" },
+        )
+        rows = cmd.classify_all
+        row = rows.find { |r| r["name"] == "newsvc" }
+        assert_equal "gray", row["status"],
+            "prod-eligible service absent from prod snapshot must be gray, not stale"
+        assert_equal 0, cmd.run_classification(rows)
+    end
+
+    # The dispatcher must register the subcommand.
+    def test_subcommand_registered
+        assert Railway::SUBCOMMANDS.key?("reconcile-prod"),
+            "reconcile-prod must be registered in the dispatcher"
+        assert_equal Railway::ReconcileProdCommand,
+            Railway::SUBCOMMANDS["reconcile-prod"]
+    end
+end

--- a/showcase/scripts/__tests__/reconcile-prod-gate.bats
+++ b/showcase/scripts/__tests__/reconcile-prod-gate.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+# Tests for reconcile-prod-gate.sh — the scheduled prod-vs-staging drift gate
+# (Lever 1 of the promote-reliability hardening plan).
+#
+# Core invariant under test: a STALE prod service (its serving digest has
+# drifted BEHIND a green staging) must be caught LOUD — the gate exits non-zero
+# so the scheduled run goes red and the workflow alerts #oss-alerts. A fleet
+# with no stale service passes (exit 0); a hard error (exit 2) is never
+# swallowed.
+#
+# The gate is a thin wrapper around `bin/railway reconcile-prod`, whose
+# exit-code contract IS the assertion: exit 1 on a stale service, exit 0 when
+# none stale (all green, or only green+gray), exit 2 on a hard error. The real
+# `bin/railway` is replaced via RAILWAY_BIN, pointed at a stub mimicking those
+# exit codes. The gate's job is to (a) invoke `reconcile-prod` with the right
+# subcommand and (b) FAIL the step (propagate the non-zero) on a stale service
+# — never swallow it.
+#
+# NB on assertion gating: bats does NOT run test bodies under `set -e`. Only the
+# FINAL command decides pass/fail, so every non-final assertion is written
+# `[[ ... ]] || fail "msg"` to force a hard failure with a diagnostic.
+
+# fail <msg> — print the message to the bats failure stream and abort the test.
+fail() {
+  echo "$1" >&2
+  return 1
+}
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../reconcile-prod-gate.sh"
+  [ -x "$SCRIPT" ] || fail "reconcile-prod-gate.sh missing or not executable at $SCRIPT"
+  STUB_DIR="$BATS_TEST_TMPDIR/stub"
+  mkdir -p "$STUB_DIR"
+
+  # Stale stub: mimics `bin/railway reconcile-prod` finding a prod service that
+  # has drifted behind a green staging — prints a table + STALE line and exits
+  # 1 (the reconcile-prod findings contract). Also asserts the gate invokes it
+  # with the `reconcile-prod` subcommand, so an arg-order regression is caught.
+  cat > "$STUB_DIR/railway-stale" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "reconcile-prod" ] || { echo "expected first arg 'reconcile-prod', got '$1'" >&2; exit 99; }
+echo "NAME   STATUS  PROD          STAGING"
+echo "shell  stale   aaaa1111      bbbb2222"
+echo ""
+echo "Summary: 0 green, 1 stale, 0 gray (1 prod-eligible)."
+echo "STALE: prod has drifted behind green staging for: shell."
+exit 1
+STUB
+  chmod +x "$STUB_DIR/railway-stale"
+
+  # In-sync stub: no service stale — exits 0.
+  cat > "$STUB_DIR/railway-green" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "reconcile-prod" ] || { echo "expected first arg 'reconcile-prod', got '$1'" >&2; exit 99; }
+echo "Summary: 39 green, 0 stale, 0 gray (39 prod-eligible)."
+echo "OK: no production service is stale vs staging."
+exit 0
+STUB
+  chmod +x "$STUB_DIR/railway-green"
+
+  # Error stub: reconcile-prod hit a hard error (auth/GraphQL) — exits 2. The
+  # gate must treat a non-zero (incl. 2) as a hard failure, never a pass.
+  cat > "$STUB_DIR/railway-error" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "reconcile-prod" ] || { echo "expected first arg 'reconcile-prod', got '$1'" >&2; exit 99; }
+echo "graphql error: boom" >&2
+exit 2
+STUB
+  chmod +x "$STUB_DIR/railway-error"
+}
+
+@test "stale prod service -> gate fails loud (non-zero, finding surfaced)" {
+  run env RAILWAY_BIN="$STUB_DIR/railway-stale" bash "$SCRIPT"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit on a stale prod service, got $status"
+  [[ "$output" == *"STALE"* ]] || fail "stale finding not surfaced: $output"
+  [[ "$output" == *"shell"* ]] || fail "stale service name not surfaced: $output"
+}
+
+@test "no stale service -> gate passes (exit 0)" {
+  run env RAILWAY_BIN="$STUB_DIR/railway-green" bash "$SCRIPT"
+  [ "$status" -eq 0 ] || fail "expected exit 0 when no service stale, got $status ($output)"
+  [[ "$output" == *"no production service has drifted stale"* ]] || fail "OK line not surfaced: $output"
+}
+
+@test "reconcile-prod hard error (exit 2) -> gate fails (never swallowed)" {
+  run env RAILWAY_BIN="$STUB_DIR/railway-error" bash "$SCRIPT"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit on a reconcile-prod hard error, got $status"
+}
+
+@test "missing/non-executable RAILWAY_BIN -> fails loud (not a vacuous pass)" {
+  run env RAILWAY_BIN="$STUB_DIR/does-not-exist" bash "$SCRIPT"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit when RAILWAY_BIN is missing, got $status"
+  [[ "$output" == *"missing or not executable"* ]] || fail "missing-binary error not surfaced: $output"
+}
+
+@test "RECONCILE_JSON writes machine output without changing the verdict" {
+  # The JSON capture is a best-effort SECOND invocation; its presence must not
+  # change the gate verdict. With the green stub the gate still exits 0, and
+  # the JSON file is created from the stub's stdout.
+  JSON_OUT="$BATS_TEST_TMPDIR/reconcile.json"
+  run env RAILWAY_BIN="$STUB_DIR/railway-green" RECONCILE_JSON="$JSON_OUT" bash "$SCRIPT"
+  [ "$status" -eq 0 ] || fail "expected exit 0 with green stub + RECONCILE_JSON, got $status ($output)"
+  [ -f "$JSON_OUT" ] || fail "RECONCILE_JSON file not written"
+}
+
+@test "the scheduled workflow wires the gate in" {
+  # Guard against the gate being orphaned (script present + tested, but never
+  # invoked by the reconcile workflow). Assert the workflow actually calls
+  # reconcile-prod-gate.sh.
+  WF="$BATS_TEST_DIRNAME/../../../.github/workflows/showcase_reconcile.yml"
+  [ -f "$WF" ] || fail "reconcile workflow missing at $WF"
+  grep -q "reconcile-prod-gate.sh" "$WF" || fail "showcase_reconcile.yml does not invoke reconcile-prod-gate.sh"
+}

--- a/showcase/scripts/__tests__/reconcile-prod-gate.bats
+++ b/showcase/scripts/__tests__/reconcile-prod-gate.bats
@@ -65,6 +65,25 @@ echo "graphql error: boom" >&2
 exit 2
 STUB
   chmod +x "$STUB_DIR/railway-error"
+
+  # JSON-error stub: distinguishes the machine-output (`--json`) invocation from
+  # the human-table invocation. The `--json` invocation emits a DISTINCT stderr
+  # diagnostic (`JSON-CAPTURE-DIAG`) and NO stdout payload, then exits 2; the
+  # human-table invocation emits its own line. This isolates the `--json`
+  # capture path so we can assert it (a) preserves ITS stderr diagnostic instead
+  # of routing it to /dev/null and (b) does not write a blank artifact from the
+  # empty stdout.
+  cat > "$STUB_DIR/railway-json-error" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "reconcile-prod" ] || { echo "expected first arg 'reconcile-prod', got '$1'" >&2; exit 99; }
+if [ "$2" = "--json" ]; then
+  echo "graphql error: JSON-CAPTURE-DIAG staging outage" >&2
+  exit 2
+fi
+echo "graphql error: human-table boom" >&2
+exit 2
+STUB
+  chmod +x "$STUB_DIR/railway-json-error"
 }
 
 @test "stale prod service -> gate fails loud (non-zero, finding surfaced)" {
@@ -99,6 +118,26 @@ STUB
   run env RAILWAY_BIN="$STUB_DIR/railway-green" RECONCILE_JSON="$JSON_OUT" bash "$SCRIPT"
   [ "$status" -eq 0 ] || fail "expected exit 0 with green stub + RECONCILE_JSON, got $status ($output)"
   [ -f "$JSON_OUT" ] || fail "RECONCILE_JSON file not written"
+}
+
+@test "RECONCILE_JSON capture preserves the stderr diagnostic on a hard error" {
+  # When the --json capture invocation hits a hard error, its stderr diagnostic
+  # must NOT be swallowed (routed to /dev/null) — a failed probe has to leave a
+  # diagnostic trail in the job log instead of vanishing.
+  JSON_OUT="$BATS_TEST_TMPDIR/reconcile.json"
+  run env RAILWAY_BIN="$STUB_DIR/railway-json-error" RECONCILE_JSON="$JSON_OUT" bash "$SCRIPT"
+  [[ "$output" == *"JSON-CAPTURE-DIAG"* ]] || fail "stderr diagnostic from the --json capture was swallowed: $output"
+}
+
+@test "RECONCILE_JSON does not write a blank artifact when the capture produces nothing" {
+  # When the --json invocation errors and emits no payload, the gate must NOT
+  # leave a blank/empty reconcile.json behind — an empty artifact is uploaded as
+  # if it were a real result. Either no file, or a non-empty file.
+  JSON_OUT="$BATS_TEST_TMPDIR/reconcile.json"
+  run env RAILWAY_BIN="$STUB_DIR/railway-json-error" RECONCILE_JSON="$JSON_OUT" bash "$SCRIPT"
+  if [ -f "$JSON_OUT" ]; then
+    [ -s "$JSON_OUT" ] || fail "wrote a blank reconcile.json artifact (empty file) on a no-payload error"
+  fi
 }
 
 @test "the on-demand workflow wires the gate in" {

--- a/showcase/scripts/__tests__/reconcile-prod-gate.bats
+++ b/showcase/scripts/__tests__/reconcile-prod-gate.bats
@@ -1,12 +1,10 @@
 #!/usr/bin/env bats
-# Tests for reconcile-prod-gate.sh — the scheduled prod-vs-staging drift gate
-# (Lever 1 of the promote-reliability hardening plan).
+# Tests for reconcile-prod-gate.sh — the on-demand prod-vs-staging drift gate.
 #
 # Core invariant under test: a STALE prod service (its serving digest has
 # drifted BEHIND a green staging) must be caught LOUD — the gate exits non-zero
-# so the scheduled run goes red and the workflow alerts #oss-alerts. A fleet
-# with no stale service passes (exit 0); a hard error (exit 2) is never
-# swallowed.
+# so a manual run visibly flags the drift on the run. A fleet with no stale
+# service passes (exit 0); a hard error (exit 2) is never swallowed.
 #
 # The gate is a thin wrapper around `bin/railway reconcile-prod`, whose
 # exit-code contract IS the assertion: exit 1 on a stale service, exit 0 when
@@ -103,7 +101,7 @@ STUB
   [ -f "$JSON_OUT" ] || fail "RECONCILE_JSON file not written"
 }
 
-@test "the scheduled workflow wires the gate in" {
+@test "the on-demand workflow wires the gate in" {
   # Guard against the gate being orphaned (script present + tested, but never
   # invoked by the reconcile workflow). Assert the workflow actually calls
   # reconcile-prod-gate.sh.

--- a/showcase/scripts/reconcile-prod-gate.sh
+++ b/showcase/scripts/reconcile-prod-gate.sh
@@ -58,9 +58,27 @@ fi
 # This is a best-effort SECOND invocation (read-only) — its rc does not decide
 # the gate (the human-table invocation below does); a JSON-write failure must
 # not change the gate verdict.
+#
+# We capture stdout to a temp first (NOT straight to $RECONCILE_JSON) so that:
+#   * the probe's stderr is PRESERVED to the job log (a failed --json capture —
+#     e.g. a staging GraphQL outage — must leave a diagnostic trail, never be
+#     routed to /dev/null and vanish); and
+#   * we only publish a NON-BLANK payload. On a hard error reconcile-prod emits
+#     no stdout, and writing the empty result straight to $RECONCILE_JSON would
+#     upload a blank artifact that looks like a real (empty) reconciliation.
+#     Guard the write so a blank/empty payload is skipped.
 if [ -n "${RECONCILE_JSON:-}" ]; then
   echo "==> $RAILWAY_BIN reconcile-prod --json (machine output -> $RECONCILE_JSON)"
-  "$RAILWAY_BIN" reconcile-prod --json > "$RECONCILE_JSON" 2>/dev/null || true
+  json_tmp="$(mktemp)"
+  # stdout -> temp; stderr -> the job log (preserve the diagnostic). rc is
+  # ignored (best-effort); the human-table invocation below decides the gate.
+  "$RAILWAY_BIN" reconcile-prod --json > "$json_tmp" || true
+  if [ -s "$json_tmp" ]; then
+    cp "$json_tmp" "$RECONCILE_JSON"
+  else
+    echo "reconcile-prod-gate: --json capture produced no payload; skipping blank artifact write to $RECONCILE_JSON." >&2
+  fi
+  rm -f "$json_tmp"
 fi
 
 echo "==> $RAILWAY_BIN reconcile-prod"

--- a/showcase/scripts/reconcile-prod-gate.sh
+++ b/showcase/scripts/reconcile-prod-gate.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# reconcile-prod-gate.sh — scheduled drift gate: assert NO prod service has
-# drifted STALE vs a green staging (Lever 1 of the promote-reliability
-# hardening plan).
+# reconcile-prod-gate.sh — on-demand drift gate: assert NO prod service has
+# drifted STALE vs a green staging.
 #
 # Mirrors lint-prod-gate.sh (a thin wrapper around a `bin/railway` subcommand
 # whose exit-code contract IS the gate), but checks a DIFFERENT invariant:
@@ -13,8 +12,8 @@
 #     is staging=mutable `:latest` (continuously rebuilt), prod=immutable
 #     `@sha256:` (advances only on explicit promote), so prod can silently fall
 #     behind a green staging — a dead/stale prod column that today is only
-#     noticed by eyeballing it. This gate detects that drift automatically so
-#     the scheduled workflow can alert on it.
+#     noticed by eyeballing it. This gate detects that drift on demand so a
+#     manual workflow run can surface it.
 #
 # It is a thin wrapper around `bin/railway reconcile-prod`, whose exit-code
 # contract IS the gate: exit 0 = no service stale (all green, or only
@@ -23,9 +22,8 @@
 # We do NOT pass any advisory flag — a stale prod column must red the run.
 #
 # Output is surfaced into $GITHUB_STEP_SUMMARY (the readable per-service table)
-# AND to stdout (the job log). When run with --json the machine output is also
-# captured to a file the caller (the workflow) reads to build the Slack
-# payload's stale-column list.
+# AND to stdout (the job log). When RECONCILE_JSON is set the machine output is
+# also captured to that file (uploaded as a workflow artifact for inspection).
 #
 # Usage:
 #   RAILWAY_TOKEN=... scripts/reconcile-prod-gate.sh
@@ -39,7 +37,7 @@
 #   RECONCILE_JSON (optional) path to write the machine-readable JSON output to
 #                  (in addition to the human table). When set, the gate also
 #                  invokes `reconcile-prod --json` and writes the result there
-#                  for the workflow's Slack-payload builder.
+#                  (uploaded as a workflow artifact for inspection).
 
 set -uo pipefail
 
@@ -56,7 +54,7 @@ if [ ! -x "$RAILWAY_BIN" ] && ! command -v "$RAILWAY_BIN" >/dev/null 2>&1; then
   exit 1
 fi
 
-# Optionally capture machine-readable JSON for the workflow's Slack builder.
+# Optionally capture machine-readable JSON (uploaded as a workflow artifact).
 # This is a best-effort SECOND invocation (read-only) — its rc does not decide
 # the gate (the human-table invocation below does); a JSON-write failure must
 # not change the gate verdict.

--- a/showcase/scripts/reconcile-prod-gate.sh
+++ b/showcase/scripts/reconcile-prod-gate.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# reconcile-prod-gate.sh — scheduled drift gate: assert NO prod service has
+# drifted STALE vs a green staging (Lever 1 of the promote-reliability
+# hardening plan).
+#
+# Mirrors lint-prod-gate.sh (a thin wrapper around a `bin/railway` subcommand
+# whose exit-code contract IS the gate), but checks a DIFFERENT invariant:
+#
+#   * lint-prod-gate asserts every prod service is PINNED to an immutable
+#     `@sha256:` digest (no born-on-:latest float).
+#   * reconcile-prod-gate asserts no prod service is STALE — i.e. its serving
+#     digest has not drifted BEHIND a green staging. The showcase deploy model
+#     is staging=mutable `:latest` (continuously rebuilt), prod=immutable
+#     `@sha256:` (advances only on explicit promote), so prod can silently fall
+#     behind a green staging — a dead/stale prod column that today is only
+#     noticed by eyeballing it. This gate detects that drift automatically so
+#     the scheduled workflow can alert on it.
+#
+# It is a thin wrapper around `bin/railway reconcile-prod`, whose exit-code
+# contract IS the gate: exit 0 = no service stale (all green, or only
+# green+gray), exit 1 = at least one stale (prod drifted behind green staging),
+# exit 2 = hard error (auth/GraphQL). Any non-zero fails the step (and the run).
+# We do NOT pass any advisory flag — a stale prod column must red the run.
+#
+# Output is surfaced into $GITHUB_STEP_SUMMARY (the readable per-service table)
+# AND to stdout (the job log). When run with --json the machine output is also
+# captured to a file the caller (the workflow) reads to build the Slack
+# payload's stale-column list.
+#
+# Usage:
+#   RAILWAY_TOKEN=... scripts/reconcile-prod-gate.sh
+#
+# Env:
+#   RAILWAY_TOKEN  (required by bin/railway reconcile-prod to read the prod
+#                  snapshot + staging deployments; this wrapper does not consult
+#                  it directly — bin/railway does).
+#   RAILWAY_BIN    (optional) path to the railway CLI (default: sibling
+#                  ../bin/railway). Overridable for testing.
+#   RECONCILE_JSON (optional) path to write the machine-readable JSON output to
+#                  (in addition to the human table). When set, the gate also
+#                  invokes `reconcile-prod --json` and writes the result there
+#                  for the workflow's Slack-payload builder.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHOWCASE_DIR="$(dirname "$HERE")"
+RAILWAY_BIN="${RAILWAY_BIN:-$SHOWCASE_DIR/bin/railway}"
+
+# Validate the railway CLI up front. Without this, a missing/non-executable
+# binary makes the reconcile-prod invocation fail with 126/127 — fail loud with
+# a clear message instead of a cryptic exec error. `-x` covers an absolute
+# path; `command -v` covers RAILWAY_BIN being a bare PATH command name.
+if [ ! -x "$RAILWAY_BIN" ] && ! command -v "$RAILWAY_BIN" >/dev/null 2>&1; then
+  echo "::error::reconcile-prod-gate: RAILWAY_BIN '$RAILWAY_BIN' is missing or not executable; cannot run the drift gate." >&2
+  exit 1
+fi
+
+# Optionally capture machine-readable JSON for the workflow's Slack builder.
+# This is a best-effort SECOND invocation (read-only) — its rc does not decide
+# the gate (the human-table invocation below does); a JSON-write failure must
+# not change the gate verdict.
+if [ -n "${RECONCILE_JSON:-}" ]; then
+  echo "==> $RAILWAY_BIN reconcile-prod --json (machine output -> $RECONCILE_JSON)"
+  "$RAILWAY_BIN" reconcile-prod --json > "$RECONCILE_JSON" 2>/dev/null || true
+fi
+
+echo "==> $RAILWAY_BIN reconcile-prod"
+# Run the gate and capture its readable output so we can mirror it to the GH
+# step summary AND surface it on stdout. reconcile-prod exits 1 on a stale
+# service and 2 on a hard error; either is a step failure. We capture rc
+# explicitly (set -e is intentionally off) so the failure message below is
+# precise about the verdict.
+OUT="$("$RAILWAY_BIN" reconcile-prod 2>&1)"
+rc=$?
+
+# Mirror the table to the job log.
+printf '%s\n' "$OUT"
+
+# Surface the table into the GH step summary (when running under Actions).
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### Prod ⇆ staging reconciliation"
+    echo ""
+    echo '```'
+    printf '%s\n' "$OUT"
+    echo '```'
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [ "$rc" -eq 0 ]; then
+  echo "OK: no production service has drifted stale vs staging."
+  exit 0
+fi
+
+echo "::error::reconcile-prod-gate: at least one production service is STALE vs a green staging (bin/railway reconcile-prod exit $rc). Prod has fallen behind staging — promote it via 'bin/railway promote <svc>' (or investigate if staging is the wrong reference)." >&2
+exit "$rc"


### PR DESCRIPTION
## Summary

An **on-demand** tool to answer "is prod caught up with staging right now?". The showcase deploy model is **staging = mutable `:latest`** (continuously rebuilt) and **prod = immutable `@sha256:`** (advances only on an explicit promote), so a prod column can sit **behind** a green staging.

**There is no scheduled drift alert — by design.** Prod lagging staging is **often intentional**: changes are batched and promoted deliberately, so a recurring "N columns stale" alert would be pure noise. This tool is therefore manual-only: a maintainer runs it when they want to check, and it tells them the current state.

- **`bin/railway reconcile-prod`** — for every prod-eligible (`probe.prod == true`) service, compares the **prod serving digest** (the `@sha256:` from `SnapshotCommand.build_snapshot(PRODUCTION_ENV_ID)`) against the **staging running digest** (reuses `PromoteCommand#staging_running_digest`, the same source the promote pin uses). Classifies each:
  - `green` — prod == staging (in sync)
  - `stale` — prod != staging **and** staging is resolvable (prod is behind a green staging)
  - `gray` — staging running digest not resolvable, or the service has no prod snapshot entry yet — informational, **not** stale
  - Prints a readable per-service table + summary; **exits nonzero iff any service is stale**; `--json` for machine output. **Read-only — no promotes/mutations.**
- **`showcase/scripts/reconcile-prod-gate.sh`** — wrapper mirroring `lint-prod-gate.sh`: surfaces the table into `$GITHUB_STEP_SUMMARY`, optionally captures `--json` to `RECONCILE_JSON`, and propagates the exit-code verdict (never swallows a non-zero).
- **`.github/workflows/showcase_reconcile.yml`** — **`workflow_dispatch` only** (no cron). Regenerates the SSOT JSON (`EMIT_SKIP_OXFMT=1`, same as the promote workflow's resolve/promote jobs), runs the gate with the Railway/GHCR auth env, renders the reconcile table to the **GH step summary**, and uploads the `--json` as a `reconcile-json` artifact. **No Slack.** The run exits nonzero on a stale column so a manual run visibly flags drift. `timeout-minutes: 10`.
- **Tests** — Ruby minitest (`test_reconcile_prod.rb`: classification + exit-code + `--json` shape + dispatcher registration) and a bats gate test (`reconcile-prod-gate.bats`). Wired the gate script into the `showcase_validate.yml` shellcheck list.

### What changed from the original scheduled-alert design

The first cut of this PR shipped a daily cron + auto-post to #oss-alerts on any stale column. Per owner feedback, that was reshaped to on-demand only: the `schedule:` trigger and the Slack-on-stale step were removed (intentional/deliberate staleness is not a bug, so an unsolicited recurring alert is noise). The CLI command, the gate wrapper, and all tests are unchanged.

## Gates

- `ruby showcase/bin/spec/test_reconcile_prod.rb` → **9 runs, 20 assertions, 0 failures**
- `bats showcase/scripts/__tests__/reconcile-prod-gate.bats` → **6 ok**
- `shellcheck -s bash showcase/scripts/reconcile-prod-gate.sh` → **clean**
- `actionlint .github/workflows/showcase_reconcile.yml` → **clean** (the pre-existing `depot-ubuntu-24.04-4` custom-runner-label warning is on `showcase_validate.yml`, predates this PR — my only change there is one line in the shellcheck list)

## Test plan

- [ ] CI green (Ruby suite, bats suite, actionlint/shellcheck, commitlint)
- [ ] Optional: read-only `workflow_dispatch` run of `showcase_reconcile.yml` to confirm it runs against live prod/staging (safe — no mutations)