### PR TITLE
feat(core,react-core): add unarchiveThread to v2 thread store + useThreads

### DIFF
--- a/packages/core/src/__tests__/core-thread-store-auto-unregister.test.ts
+++ b/packages/core/src/__tests__/core-thread-store-auto-unregister.test.ts
@@ -25,6 +25,7 @@ function makeStore(id = "store"): ɵThreadStore & { __testId: string } {
     fetchNextPage: vi.fn(),
     renameThread: vi.fn(),
     archiveThread: vi.fn(),
+    unarchiveThread: vi.fn(),
     deleteThread: vi.fn(),
     getState: vi.fn(),
     select: vi.fn(),

--- a/packages/core/src/__tests__/thread-store-registry.test.ts
+++ b/packages/core/src/__tests__/thread-store-registry.test.ts
@@ -54,6 +54,7 @@ function makeStore(id = "store-a"): ɵThreadStore & { __testId: string } {
     fetchNextPage: vi.fn(),
     renameThread: vi.fn(),
     archiveThread: vi.fn(),
+    unarchiveThread: vi.fn(),
     deleteThread: vi.fn(),
     getState: vi.fn(),
     select: vi.fn(),

--- a/packages/core/src/__tests__/threads.test.ts
+++ b/packages/core/src/__tests__/threads.test.ts
@@ -367,6 +367,53 @@ describe("thread store", () => {
     });
   });
 
+  it("unarchives a thread via a PATCH with archived:false", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          threads: sampleThreads,
+          joinCode: "jc-1",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          joinToken: "jt-1",
+        }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const store = ɵcreateThreadStore(createEnvironment(fetchMock));
+    stores.push(store);
+    store.start();
+    store.setContext({
+      runtimeUrl: "https://runtime.example.com",
+      headers: { Authorization: "Bearer token" },
+      wsUrl: "ws://localhost:4000/client",
+      agentId: "agent-1",
+    });
+
+    await flushEffects();
+
+    await store.unarchiveThread("thread-2");
+
+    const unarchiveCall = getFetchCall(fetchMock, 2);
+    expect(unarchiveCall[0]).toBe(
+      "https://runtime.example.com/threads/thread-2",
+    );
+    expect(unarchiveCall[1]).toMatchObject({ method: "PATCH" });
+    expect(JSON.parse(unarchiveCall[1].body)).toMatchObject({
+      agentId: "agent-1",
+      archived: false,
+    });
+  });
+
   it("stores fetch failures in error state", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,

--- a/packages/core/src/threads.ts
+++ b/packages/core/src/threads.ts
@@ -143,6 +143,7 @@ const threadAdapterEvents = createActionGroup("Thread Adapter", {
     name: string;
   }>(),
   archiveRequested: props<{ requestId: string; threadId: string }>(),
+  unarchiveRequested: props<{ requestId: string; threadId: string }>(),
   deleteRequested: props<{ requestId: string; threadId: string }>(),
 });
 
@@ -400,6 +401,7 @@ interface ThreadStore {
   fetchNextPage(): void;
   renameThread(threadId: string, name: string): Promise<void>;
   archiveThread(threadId: string): Promise<void>;
+  unarchiveThread(threadId: string): Promise<void>;
   deleteThread(threadId: string): Promise<void>;
   getState(): ThreadState;
   select: Store<ThreadState>["select"];
@@ -880,6 +882,7 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
         ofType(
           threadAdapterEvents.renameRequested,
           threadAdapterEvents.archiveRequested,
+          threadAdapterEvents.unarchiveRequested,
           threadAdapterEvents.deleteRequested,
         ),
         withLatestFrom(state$),
@@ -923,6 +926,18 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
             });
           }
 
+          if (threadAdapterEvents.unarchiveRequested.match(action)) {
+            return createThreadMutationObservable(environment, context, {
+              requestId: action.requestId,
+              method: "PATCH",
+              path: `/threads/${encodeURIComponent(action.threadId)}`,
+              body: {
+                ...commonBody,
+                archived: false,
+              },
+            });
+          }
+
           return createThreadMutationObservable(environment, context, {
             requestId: action.requestId,
             method: "DELETE",
@@ -951,6 +966,7 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
     dispatchAction:
       | ReturnType<typeof threadAdapterEvents.renameRequested>
       | ReturnType<typeof threadAdapterEvents.archiveRequested>
+      | ReturnType<typeof threadAdapterEvents.unarchiveRequested>
       | ReturnType<typeof threadAdapterEvents.deleteRequested>,
   ): Promise<void> {
     const completion$ = merge(
@@ -1020,6 +1036,14 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
     archiveThread(threadId: string): Promise<void> {
       return trackMutation(
         threadAdapterEvents.archiveRequested({
+          requestId: createThreadRequestId(),
+          threadId,
+        }),
+      );
+    },
+    unarchiveThread(threadId: string): Promise<void> {
+      return trackMutation(
+        threadAdapterEvents.unarchiveRequested({
           requestId: createThreadRequestId(),
           threadId,
         }),

--- a/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
@@ -592,6 +592,36 @@ describe("useThreads", () => {
     );
   });
 
+  it("unarchives a thread through the runtime contract", async () => {
+    fetchMock
+      .mockReturnValueOnce(
+        jsonResponse({ threads: sampleThreads, joinCode: "jc-1" }),
+      )
+      .mockReturnValueOnce(jsonResponse({ joinToken: "jt-1" }))
+      .mockReturnValueOnce(jsonResponse({}));
+
+    const { result } = renderHook(() => useThreads(defaultInput));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.unarchiveThread("t-2");
+    });
+
+    const unarchiveCall = fetchMock.mock.calls.find(
+      (args: unknown[]) =>
+        typeof args[0] === "string" &&
+        (args[0] as string).includes("/threads/t-2") &&
+        (args[1] as { method?: string } | undefined)?.method === "PATCH",
+    );
+    expect(unarchiveCall).toBeDefined();
+    expect(
+      JSON.parse((unarchiveCall![1] as { body: string }).body),
+    ).toMatchObject({ agentId: "agent-1", archived: false });
+  });
+
   it("exposes thread-scoped pagination properties", async () => {
     fetchMock
       .mockReturnValueOnce(

--- a/packages/react-core/src/v2/hooks/use-threads.tsx
+++ b/packages/react-core/src/v2/hooks/use-threads.tsx
@@ -105,6 +105,12 @@ export interface UseThreadsResult {
    */
   archiveThread: (threadId: string) => Promise<void>;
   /**
+   * Restore a previously archived thread on the platform.
+   * The thread re-appears in default (non-archived) list results.
+   * Resolves when the server confirms the update; rejects on failure.
+   */
+  unarchiveThread: (threadId: string) => Promise<void>;
+  /**
    * Permanently delete a thread from the platform.
    * This is irreversible. Resolves when the server confirms deletion;
    * rejects on failure.
@@ -137,9 +143,9 @@ function useThreadStoreSelector<T>(
  * current without polling — thread creates, renames, archives, and deletes
  * from any client are reflected immediately.
  *
- * Mutation methods (`renameThread`, `archiveThread`, `deleteThread`) return
- * promises that resolve once the platform confirms the operation and reject
- * with an `Error` on failure.
+ * Mutation methods (`renameThread`, `archiveThread`, `unarchiveThread`,
+ * `deleteThread`) return promises that resolve once the platform confirms the
+ * operation and reject with an `Error` on failure.
  *
  * @param input - Agent identifier and optional list controls.
  * @returns Thread list state and stable mutation callbacks.
@@ -360,6 +366,11 @@ export function useThreads({
     [store, guardMutation],
   );
 
+  const unarchiveThread = useMemo(
+    () => guardMutation((threadId: string) => store.unarchiveThread(threadId)),
+    [store, guardMutation],
+  );
+
   const deleteThread = useMemo(
     () => guardMutation((threadId: string) => store.deleteThread(threadId)),
     [store, guardMutation],
@@ -376,6 +387,7 @@ export function useThreads({
     fetchMoreThreads,
     renameThread,
     archiveThread,
+    unarchiveThread,
     deleteThread,
   };
 }


### PR DESCRIPTION
## Summary

Adds `unarchiveThread(id)` to the v2 thread store (`@copilotkit/core`) and the `useThreads` hook (`@copilotkit/react-core/v2`), restoring an archived thread via the existing generic `PATCH /threads/:id { archived: false }` update path — no new runtime endpoint. Mirrors `archiveThread` across the store and hook.

This is the durable, architecture-independent piece extracted from the threads-drawer effort. The drawer UI itself is being restarted as a framework-agnostic **CopilotDrawer** (Lit web component + React/Angular wrappers) under a separate spec; this hook method stands on its own and is needed regardless.

## Testing

TDD. New core store test (`PATCH … { archived: false }`) and `useThreads` hook test; full suites green (core, react-core).