### PR TITLE
feat(harness): complete cvdiag observability on the d5/d6 probe path

### DIFF
--- a/showcase/harness/src/cli/runner.ts
+++ b/showcase/harness/src/cli/runner.ts
@@ -48,6 +48,9 @@ import type { E2eFullBrowser } from "../probes/drivers/d6-all-pills.js";
 import type { StatusWriter } from "../writers/status-writer.js";
 import { runViaControlPlane } from "./control-plane-run.js";
 import type { ControlPlaneLevel } from "./control-plane-run.js";
+import { createPbClient } from "../storage/pb-client.js";
+import { buildCvdiagPersistenceWriter } from "../orchestrator.js";
+import type { CvdiagPbWriter } from "../cvdiag/pb-writer.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -266,6 +269,25 @@ export async function run(
   const pbConfig = options.live ? resolvePbConfig(config) : null;
   const pbWriter = pbConfig ? createPbWriter(pbConfig, logger) : null;
 
+  // CVDIAG event-persistence writer for the local d5/d6 path. When `--live`
+  // (a PB connection is configured), build a writer-role PB client and gate it
+  // through `buildCvdiagPersistenceWriter` (the same assert-collection-exists
+  // degrade-or-inject path the orchestrator uses). When wired, the d6 driver's
+  // per-feature `CvdiagProbeSession` PERSISTS its probe-layer events (probe.exit
+  // etc.) to `cvdiag_events` on flush — so a local `--d5`/`--d6` run is readable
+  // back from PB exactly like staging. Absent (`--live` off, migration missing,
+  // or PB unreachable) → undefined → the emitter's flush is a clean no-op.
+  let cvdiagWriter: CvdiagPbWriter | undefined;
+  if (pbConfig) {
+    const cvdiagPb = createPbClient({
+      url: pbConfig.url,
+      email: pbConfig.email,
+      password: pbConfig.password,
+      logger,
+    });
+    cvdiagWriter = await buildCvdiagPersistenceWriter(cvdiagPb, logger);
+  }
+
   const ctx: ProbeContext = {
     now: () => new Date(),
     logger,
@@ -365,8 +387,10 @@ export async function run(
             close: () => browser.close(),
           };
         },
+        // CVDIAG persistence for the local d5/d6 path (headed).
+        cvdiagPbWriter: cvdiagWriter,
       })
-    : createE2eFullDriver();
+    : createE2eFullDriver({ cvdiagPbWriter: cvdiagWriter });
 
   // -- 9. Run probes --------------------------------------------------------
   const repeatCount = Math.max(1, options.repeat ?? 1);

--- a/showcase/harness/src/cvdiag/probe-session.ts
+++ b/showcase/harness/src/cvdiag/probe-session.ts
@@ -1,0 +1,577 @@
+/**
+ * probe-session.ts — shared CVDIAG probe-layer session.
+ *
+ * `CvdiagProbeSession` owns the CVDIAG emit state for ONE probe level (one
+ * `test_id`). It was originally an internal class of the d4 (e2e-smoke) driver;
+ * it is extracted here so the d5/d6 (`d6-all-pills`) probe path can construct
+ * the SAME session and emit the SAME 12 probe-layer boundaries (spec §3
+ * Layer 1) — closing the gap where the flapping d5/d6 path produced NO
+ * `cvdiag_events` `probe.exit` rows and so could not be read back from staging.
+ *
+ * The d4 driver re-imports every symbol here so its behavior is unchanged.
+ *
+ * Pure instrumentation: every method swallows its own errors — a CVDIAG fault
+ * MUST NEVER throw into the probe it observes (spec §7 R5-F8).
+ */
+
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { truncateUtf8 } from "../render/filters.js";
+import type { CvdiagEmitter } from "./emit.js";
+import { mintSpanId } from "./emit.js";
+import { filterEdgeHeaders } from "./edge-headers.js";
+import { scrubSecrets } from "./scrub.js";
+import type {
+  CvdiagFailureClassifier,
+  CvdiagOutcome,
+  ProbeSseEventMeta,
+  TerminationKind,
+} from "./schema.js";
+import { isValidTestId } from "./schema.js";
+import { mintTestId, sanitizeJoinTestId } from "./emit.js";
+
+/**
+ * SSE-event emit sampling target (spec §7 R5-F11): cap probe-side
+ * `probe.sse.event` emits at ≤30/sec regardless of underlying SSE rate. Above
+ * this rate, every Nth event is emitted; below it, every event.
+ */
+const CVDIAG_SSE_SAMPLE_TARGET_PER_SEC = 30;
+/**
+ * Class-(e) carve-out window (spec §7 R2-F19 rule 2): in the N ms immediately
+ * preceding a `probe.exit` with `terminal_outcome=timeout`, EVERY
+ * `probe.sse.event` is emitted regardless of rate, preserving the cross-layer
+ * `sequence_num` join that detects dropped/reordered frontend events.
+ */
+const CVDIAG_PRE_TIMEOUT_WINDOW_MS = 5_000;
+/** `probe.console.error.message_scrubbed` byte cap (spec §5). */
+const CVDIAG_CONSOLE_MSG_CAP_BYTES = 512;
+/** `probe.navigate.complete.url` byte cap (spec §5). */
+const CVDIAG_URL_CAP_BYTES = 256;
+
+/**
+ * Normalized HTTP-response shape the driver reads for `probe.network.response`
+ * and `probe.message.send` edge-header capture. The launcher adapts
+ * Playwright's `Response` onto this minimal surface so the driver stays
+ * decoupled from the Playwright type tree (and fakes can hand one in).
+ */
+export interface CvdiagResponseEvent {
+  url: string;
+  status: number;
+  /** Raw header bag (case-insensitive keys); filtered to the 9-key allow-list. */
+  headers: Record<string, string | null | undefined>;
+  contentLength: number | null;
+  durationMs: number;
+  /** True iff this is the agent-message POST (drives `probe.message.send`). */
+  isMessagePost?: boolean;
+  /**
+   * DEBUG-tier raw-byte capture (L2-C / Phase 2.5) seam: lazily reads the
+   * literal (possibly compressed) response body. Present ONLY when the
+   * launcher wires Playwright's `Response.body()`; absent on fake pages (which
+   * therefore never trigger a raw-byte capture). Best-effort — resolves null
+   * on any read failure so it never throws into the probe.
+   */
+  body?: () => Promise<Buffer | null>;
+}
+
+/** Normalized failed-request shape for `probe.network.error`. */
+export interface CvdiagRequestFailedEvent {
+  url: string;
+  errorClass: string;
+  responseStatus: number | null;
+}
+
+/** Normalized console-message shape for `probe.console.error`. */
+export interface CvdiagConsoleEvent {
+  level: "warning" | "error";
+  /** Raw (un-scrubbed) text; the driver scrubs + caps before emit. */
+  text: string;
+  sourceFile: string | null;
+  lineCol: string | null;
+}
+
+/** Normalized SSE-event shape for `probe.sse.event`. */
+export interface CvdiagSseEvent {
+  eventType: string;
+  payloadSizeBytes: number;
+}
+
+/** Normalized SSE-abort shape for `probe.sse.aborted`. */
+export interface CvdiagSseAbortedEvent {
+  terminationKind: TerminationKind;
+  bytesBeforeAbort: number;
+}
+
+/** A single buffered SSE event awaiting sample/carve-out decision. */
+interface PendingSseEvent {
+  eventType: string;
+  payloadSizeBytes: number;
+  /** Wall-clock ms when observed (for the pre-timeout carve-out window). */
+  atMs: number;
+  /**
+   * The `sequence_num` minted at OBSERVE time (chronological), NOT at emit
+   * time. Every observed SSE event reserves its seq the moment it arrives, so
+   * the carve-out backfill (which emits dropped events on a timeout exit)
+   * carries each event's ORIGINAL chronological seq. Minting a FRESH seq at
+   * backfill time sorted the backfilled (lower-in-time) events AFTER the live
+   * ones — defeating the reorder/drop detection the carve-out exists for. The
+   * seq is reserved here regardless of whether the event is emitted live so a
+   * later backfill can replay it in the original order.
+   */
+  seq: number;
+  /**
+   * True iff this event was ALREADY emitted live (passed the §7 sampling
+   * stride). The timeout carve-out flushes only events that were NOT emitted
+   * live, so a sampled-through event is never emitted twice (no duplicate
+   * `probe.sse.event` rows, no inflated `sse_event_count`).
+   */
+  emittedLive: boolean;
+}
+
+/**
+ * `CvdiagProbeSession` — owns the CVDIAG emit state for ONE probe level (one
+ * `test_id`). It threads the shared `test_id` through all 12 probe-layer
+ * boundaries (spec §3 Layer 1), maintains per-`(test_id, boundary-family)`
+ * `sequence_num` counters (spec §5 R3-F16), mints `span_id`/`parent_span_id`
+ * per emit, applies the §7 SSE-rate sampling + the class-(e) pre-timeout
+ * carve-out, and buffers every emitted envelope to a replay-fallback ndjson
+ * file (spec §4 / §1.5).
+ *
+ * Pure instrumentation: every method swallows its own errors — a CVDIAG fault
+ * MUST NEVER throw into the probe it observes (spec §7 R5-F8).
+ */
+export class CvdiagProbeSession {
+  private readonly emitter: CvdiagEmitter;
+  private readonly testId: string;
+  private readonly slug: string;
+  private readonly demo: string;
+  private readonly bufferDir: string;
+  private readonly startMonoMs: number;
+  /** Root span minted at `probe.start`; parents the per-boundary spans. */
+  private readonly rootSpanId = mintSpanId();
+  /** Per-boundary-family monotonic sequence counters, reset per test_id. */
+  private readonly sequenceByFamily = new Map<string, number>();
+  /** Rolling window of recently-observed SSE events (carve-out support). */
+  private readonly pendingSse: PendingSseEvent[] = [];
+  /** Sampling cursor: emit every Nth event when over the rate target. */
+  private sseSeenInWindow = 0;
+  private sseWindowStartMs = 0;
+  private firstTokenDeltaMs: number | null = null;
+  private sseEmittedCount = 0;
+
+  constructor(opts: {
+    emitter: CvdiagEmitter;
+    testId: string;
+    slug: string;
+    demo: string;
+    bufferDir: string;
+    nowMs: number;
+  }) {
+    this.emitter = opts.emitter;
+    // Resolve ONE stable test_id for the whole session — the CROSS-LAYER JOIN
+    // KEY (spec §5). The probe's X-Test-Id is `d4-<slug>-<runId>` /
+    // `d6-<slug>-<runId>`, NOT a UUIDv7. It is forwarded verbatim as the
+    // `X-Test-Id` request header, and the backend ADOPTS that inbound header as
+    // its OWN cvdiag `test_id`, normalizing it through `sanitizeJoinTestId`. So
+    // the probe MUST record the SAME normalized value — `sanitizeJoinTestId`
+    // applied to the SAME forwarded id — for probe.* rows to JOIN backend.* rows
+    // on `test_id`. Recording a fresh random UUIDv7 here (the pre-fix behavior)
+    // gave probe rows an id the backend never derives, so the join never closed.
+    //
+    // Resolution order (all branches yield ONE stable id threaded through every
+    // emit() + the raw-byte sample, so intra-layer rows stay correlated too):
+    //   1. a value already a valid UUIDv7 → keep it verbatim (legacy callers
+    //      that mint a UUIDv7 up front; `sanitizeJoinTestId` only runs on
+    //      genuinely non-UUIDv7 inputs, matching the emitter/backend contract);
+    //   2. else sanitize the forwarded id the SAME way the backend does — this
+    //      is the join key both sides share;
+    //   3. else (nothing survives sanitization) mint a fresh UUIDv7 fallback so
+    //      every row still carries a valid, stable id.
+    this.testId = isValidTestId(opts.testId)
+      ? opts.testId
+      : (sanitizeJoinTestId(opts.testId) ?? mintTestId());
+    this.slug = opts.slug;
+    this.demo = opts.demo;
+    this.bufferDir = opts.bufferDir;
+    this.startMonoMs = opts.nowMs;
+    this.sseWindowStartMs = opts.nowMs;
+  }
+
+  /**
+   * The resolved, stable session test_id (a valid UUIDv7) that every emitted
+   * `cvdiag_events` row for this level carries. Callers (e.g. the DEBUG-tier
+   * raw-byte capture) MUST use this — not the raw `d4-<slug>-<runId>`
+   * X-Test-Id — so `cvdiag_raw_byte_samples.test_id` joins back to the events.
+   */
+  get resolvedTestId(): string {
+    return this.testId;
+  }
+
+  /**
+   * Next monotonic `sequence_num` for a boundary family (spec §5 R3-F16:
+   * per-`(test_id, layer, boundary-family)`, starting at 0). The session is
+   * already scoped to one `(test_id, layer=probe)`, so we key on the family.
+   */
+  private nextSeq(family: string): number {
+    const cur = this.sequenceByFamily.get(family) ?? 0;
+    this.sequenceByFamily.set(family, cur + 1);
+    return cur;
+  }
+
+  /** Core emit + ndjson-buffer wrapper. Swallows all faults. */
+  private fire(args: {
+    boundary: Parameters<CvdiagEmitter["emit"]>[0]["boundary"];
+    outcome: CvdiagOutcome;
+    metadata?: Record<string, unknown>;
+    edgeHeaders?: ReturnType<typeof filterEdgeHeaders>;
+    durationMs?: number | null;
+  }): void {
+    try {
+      const env = this.emitter.emit({
+        layer: "probe",
+        boundary: args.boundary,
+        slug: this.slug,
+        demo: this.demo,
+        outcome: args.outcome,
+        metadata: args.metadata,
+        edgeHeaders: args.edgeHeaders,
+        durationMs: args.durationMs ?? null,
+        parentSpanId: this.rootSpanId,
+        testId: this.testId,
+      });
+      if (env) void this.buffer(env);
+    } catch {
+      /* pure instrumentation — never throw into the probe */
+    }
+  }
+
+  /** Append one emitted envelope to the replay-fallback ndjson buffer. */
+  private async buffer(env: { ts: string }): Promise<void> {
+    try {
+      const date = env.ts.slice(0, 10); // YYYY-MM-DD
+      const dir = path.join(this.bufferDir, date);
+      await fs.mkdir(dir, { recursive: true });
+      const file = path.join(dir, `${this.testId}.ndjson`);
+      await fs.appendFile(file, `${JSON.stringify(env)}\n`, "utf8");
+    } catch {
+      /* best-effort — a buffer write must never break a probe */
+    }
+  }
+
+  // ── Boundary emitters ─────────────────────────────────────────────────────
+
+  start(url: string, viewport: { width: number; height: number }): void {
+    this.fire({
+      boundary: "probe.start",
+      outcome: "info",
+      metadata: { url: truncateUtf8(url, CVDIAG_URL_CAP_BYTES), viewport },
+    });
+  }
+
+  navigateComplete(
+    url: string,
+    navMs: number | null,
+    httpStatus: number | null,
+  ): void {
+    this.fire({
+      boundary: "probe.navigate.complete",
+      outcome: httpStatus !== null && httpStatus >= 400 ? "err" : "ok",
+      durationMs: navMs,
+      metadata: {
+        url: truncateUtf8(url, CVDIAG_URL_CAP_BYTES),
+        nav_ms: navMs,
+        http_status: httpStatus,
+      },
+    });
+  }
+
+  messageSend(
+    messageIndex: number,
+    charCount: number,
+    edge?: ReturnType<typeof filterEdgeHeaders>,
+  ): void {
+    this.fire({
+      boundary: "probe.message.send",
+      outcome: "ok",
+      edgeHeaders: edge,
+      metadata: {
+        message_index: messageIndex,
+        char_count: charCount,
+        demo: this.demo,
+      },
+    });
+  }
+
+  containerMount(nowMs: number): void {
+    this.fire({
+      boundary: "probe.dom.container.mount",
+      outcome: "ok",
+      metadata: { delta_ms_from_start: Math.max(0, nowMs - this.startMonoMs) },
+    });
+  }
+
+  firstToken(nowMs: number, textLength: number): void {
+    const delta = Math.max(0, nowMs - this.startMonoMs);
+    this.firstTokenDeltaMs = delta;
+    this.fire({
+      boundary: "probe.dom.firsttoken",
+      outcome: "ok",
+      metadata: { delta_ms_from_start: delta, text_length: textLength },
+    });
+  }
+
+  /** Emitted on a terminal exit whose assistant text stayed empty (class (d)). */
+  alternateContent(childTypeHistogram: Record<string, number>): void {
+    this.fire({
+      boundary: "probe.dom.alternate_content",
+      outcome: "info",
+      metadata: { child_type_histogram: childTypeHistogram },
+    });
+  }
+
+  networkResponse(evt: CvdiagResponseEvent): void {
+    this.fire({
+      boundary: "probe.network.response",
+      outcome: evt.status >= 400 ? "err" : "ok",
+      durationMs: evt.durationMs,
+      edgeHeaders: filterEdgeHeaders(evt.headers),
+      metadata: {
+        url: truncateUtf8(evt.url, CVDIAG_URL_CAP_BYTES),
+        status: evt.status,
+        content_length: evt.contentLength,
+        duration_ms: evt.durationMs,
+      },
+    });
+  }
+
+  networkError(evt: CvdiagRequestFailedEvent): void {
+    this.fire({
+      boundary: "probe.network.error",
+      outcome: "err",
+      metadata: {
+        url: truncateUtf8(evt.url, CVDIAG_URL_CAP_BYTES),
+        error_class: evt.errorClass,
+        response_status: evt.responseStatus,
+      },
+    });
+  }
+
+  consoleError(evt: CvdiagConsoleEvent): void {
+    // Scrub secrets BEFORE the byte cap so a truncation can never split a
+    // partially-scrubbed token and leak the tail.
+    const scrubbed = truncateUtf8(
+      scrubSecrets(evt.text),
+      CVDIAG_CONSOLE_MSG_CAP_BYTES,
+    );
+    this.fire({
+      boundary: "probe.console.error",
+      outcome: evt.level === "error" ? "err" : "info",
+      metadata: {
+        level: evt.level,
+        message_scrubbed: scrubbed,
+        source_file: evt.sourceFile,
+        line_col: evt.lineCol,
+      },
+    });
+  }
+
+  /**
+   * Observe one SSE event. Applies §7 rate sampling (≤30 emit/sec); over the
+   * rate, only every Nth event is emitted. ALL observed events are retained in
+   * a rolling pre-timeout window so a subsequent timeout exit can flush the
+   * full unsampled set (class-(e) carve-out, rule 2).
+   */
+  sseEvent(evt: CvdiagSseEvent, nowMs: number): void {
+    // Roll the 1-second sampling window.
+    if (nowMs - this.sseWindowStartMs >= 1000) {
+      this.sseWindowStartMs = nowMs;
+      this.sseSeenInWindow = 0;
+    }
+    this.sseSeenInWindow += 1;
+    // Reserve the chronological `sequence_num` for THIS event at observe time,
+    // regardless of whether it is emitted live or dropped by the §7 sampling
+    // stride. A later timeout carve-out backfills dropped events with this
+    // ORIGINAL seq so the cross-layer join sorts them in true arrival order —
+    // minting a fresh seq at backfill time put them AFTER the live events.
+    const pending: PendingSseEvent = {
+      eventType: evt.eventType,
+      payloadSizeBytes: evt.payloadSizeBytes,
+      atMs: nowMs,
+      seq: this.nextSeq("sse"),
+      emittedLive: false,
+    };
+    this.pendingSse.push(pending);
+    // Trim the rolling window to the carve-out horizon to bound memory.
+    const cutoff = nowMs - CVDIAG_PRE_TIMEOUT_WINDOW_MS;
+    while (this.pendingSse.length > 0 && this.pendingSse[0]!.atMs < cutoff) {
+      this.pendingSse.shift();
+    }
+    // Sampling decision: under target → emit every event; over → every Nth.
+    const overRate = this.sseSeenInWindow > CVDIAG_SSE_SAMPLE_TARGET_PER_SEC;
+    const stride = overRate
+      ? Math.ceil(this.sseSeenInWindow / CVDIAG_SSE_SAMPLE_TARGET_PER_SEC)
+      : 1;
+    if (this.sseSeenInWindow % stride === 0) {
+      this.emitSse(evt.eventType, evt.payloadSizeBytes, pending.seq);
+      // Mark so the timeout carve-out below does NOT re-emit this event (it
+      // was already counted in `sseEmittedCount` and emitted as a row).
+      pending.emittedLive = true;
+    }
+  }
+
+  private emitSse(
+    eventType: string,
+    payloadSizeBytes: number,
+    seq: number,
+  ): void {
+    const metadata: ProbeSseEventMeta = {
+      event_type: eventType,
+      payload_size_bytes: payloadSizeBytes,
+      sequence_num: seq,
+    };
+    this.fire({
+      boundary: "probe.sse.event",
+      outcome: "info",
+      metadata: metadata as unknown as Record<string, unknown>,
+    });
+    this.sseEmittedCount += 1;
+  }
+
+  sseAborted(evt: CvdiagSseAbortedEvent): void {
+    this.fire({
+      boundary: "probe.sse.aborted",
+      outcome: "err",
+      metadata: {
+        termination_kind: evt.terminationKind,
+        bytes_before_abort: evt.bytesBeforeAbort,
+      },
+    });
+  }
+
+  /**
+   * Terminal `probe.exit`. On a `timeout` outcome, first flush the entire
+   * pre-timeout SSE window UNSAMPLED (class-(e) carve-out rule 2) so the
+   * cross-layer `sequence_num` join is complete, THEN emit `probe.exit`.
+   *
+   * `failureClassifier` labels WHY a non-`ok` run failed. When the caller has
+   * the authoritative reason (e.g. `waitForTurnComplete`'s
+   * `TurnNotCompleteError.reason`) it passes it explicitly; otherwise, for a
+   * non-`ok` outcome, this derives a best-effort classifier from the probe's
+   * OWN observed signals (no SSE => `sse-missing`; SSE seen but no DOM
+   * first-token => `dom-missing`; else `text-unstable`) so reds are always
+   * labeled in cvdiag probe data. An `ok` outcome NEVER carries a classifier.
+   */
+  exit(
+    terminalOutcome: CvdiagOutcome,
+    totalDurationMs: number,
+    failureClassifier?: CvdiagFailureClassifier,
+  ): void {
+    if (terminalOutcome === "timeout") {
+      // Flush ONLY events not already emitted live. Re-emitting the full
+      // buffered window (including the already-live-emitted subset) duplicated
+      // `probe.sse.event` rows and inflated `sse_event_count`; the carve-out's
+      // job is to backfill the events the §7 sampling stride DROPPED, not to
+      // re-emit the ones it let through.
+      for (const ev of this.pendingSse) {
+        if (!ev.emittedLive) {
+          // Backfill with the event's ORIGINAL observe-time seq so it sorts in
+          // true chronological order alongside the live-emitted events — a
+          // fresh seq minted here would sort the (earlier) dropped events AFTER
+          // the (later) live ones, defeating the reorder/drop detection.
+          this.emitSse(ev.eventType, ev.payloadSizeBytes, ev.seq);
+        }
+      }
+      this.pendingSse.length = 0;
+    }
+    // Label the failure. An explicit reason (from the caller, e.g.
+    // `waitForTurnComplete`'s reject `reason`) wins; otherwise derive a
+    // best-effort classifier from this probe's own observed signals. `ok`
+    // runs never carry a classifier (greens stay unlabeled).
+    const resolvedClassifier: CvdiagFailureClassifier | undefined =
+      terminalOutcome === "ok"
+        ? undefined
+        : (failureClassifier ?? this.deriveFailureClassifier());
+    this.fire({
+      boundary: "probe.exit",
+      outcome: terminalOutcome,
+      durationMs: totalDurationMs,
+      metadata: {
+        terminal_outcome: terminalOutcome,
+        total_duration_ms: totalDurationMs,
+        sse_event_count: this.sseEmittedCount,
+        first_token_delta_ms: this.firstTokenDeltaMs,
+        // Only present on a non-`ok` outcome (undefined keys are dropped by
+        // the emit-time metadata validator, so greens carry no classifier).
+        ...(resolvedClassifier !== undefined
+          ? { failure_classifier: resolvedClassifier }
+          : {}),
+      },
+    });
+  }
+
+  /**
+   * Best-effort failure classifier from the probe's OWN observed signals,
+   * mirroring `waitForTurnComplete`'s precedence (earliest-missing signal
+   * wins): no SSE event => `sse-missing`; SSE seen but no DOM first-token =>
+   * `dom-missing`; SSE + first-token both seen but the run still failed (the
+   * text never settled / assertion red) => `text-unstable`.
+   */
+  private deriveFailureClassifier(): CvdiagFailureClassifier {
+    if (this.sseEmittedCount === 0) return "sse-missing";
+    if (this.firstTokenDeltaMs === null) return "dom-missing";
+    return "text-unstable";
+  }
+}
+
+/** Default replay-fallback ndjson buffer root (spec §4 `~/.cvdiag/buffer`). */
+export function defaultCvdiagBufferDir(): string {
+  return path.join(os.homedir(), ".cvdiag", "buffer");
+}
+
+/**
+ * Monotonic wall-clock ms for CVDIAG delta computations
+ * (`delta_ms_from_start`, the SSE sampling window, the pre-timeout carve-out).
+ * `performance.now()` is monotonic and immune to wall-clock skew — the right
+ * source for intra-probe durations.
+ */
+export function nowMonoMs(): number {
+  return performance.now();
+}
+
+/**
+ * Set of valid CVDIAG failure classifiers, for the duck-typed
+ * `TurnNotCompleteError.reason` guard below. Kept in sync with the schema's
+ * `CVDIAG_FAILURE_CLASSIFIERS` union (a mismatch is caught by the
+ * `satisfies` assertion).
+ */
+const FAILURE_CLASSIFIER_SET: ReadonlySet<CvdiagFailureClassifier> = new Set([
+  "sse-missing",
+  "dom-missing",
+  "text-unstable",
+  "surface-missing",
+  "selector-mismatch",
+] satisfies CvdiagFailureClassifier[]);
+
+/**
+ * Extract a CVDIAG failure classifier from a thrown error when it is a
+ * `waitForTurnComplete` `TurnNotCompleteError` (duck-typed via its `reason`
+ * field so this module stays decoupled from conversation-runner). Returns
+ * `undefined` for any other throw, leaving the session to derive a best-effort
+ * classifier from its own observed signals.
+ */
+export function turnCompleteReason(
+  err: unknown,
+): CvdiagFailureClassifier | undefined {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    "reason" in err &&
+    typeof (err as { reason: unknown }).reason === "string"
+  ) {
+    const reason = (err as { reason: string }).reason;
+    if (FAILURE_CLASSIFIER_SET.has(reason as CvdiagFailureClassifier)) {
+      return reason as CvdiagFailureClassifier;
+    }
+  }
+  return undefined;
+}

--- a/showcase/harness/src/cvdiag/probe-session.ts
+++ b/showcase/harness/src/cvdiag/probe-session.ts
@@ -28,7 +28,7 @@ import type {
   ProbeSseEventMeta,
   TerminationKind,
 } from "./schema.js";
-import { isValidTestId } from "./schema.js";
+import { CVDIAG_FAILURE_CLASSIFIERS, isValidTestId } from "./schema.js";
 import { mintTestId, sanitizeJoinTestId } from "./emit.js";
 
 /**
@@ -540,17 +540,14 @@ export function nowMonoMs(): number {
 
 /**
  * Set of valid CVDIAG failure classifiers, for the duck-typed
- * `TurnNotCompleteError.reason` guard below. Kept in sync with the schema's
- * `CVDIAG_FAILURE_CLASSIFIERS` union (a mismatch is caught by the
- * `satisfies` assertion).
+ * `TurnNotCompleteError.reason` guard below AND for the d6 driver's
+ * conversation-error `reason=<classifier>` breadcrumb parse. Derived from the
+ * schema's canonical `CVDIAG_FAILURE_CLASSIFIERS` const so the allow-list can
+ * NEVER drift from the `CvdiagFailureClassifier` union — adding a classifier
+ * to the schema array automatically widens every membership check.
  */
-const FAILURE_CLASSIFIER_SET: ReadonlySet<CvdiagFailureClassifier> = new Set([
-  "sse-missing",
-  "dom-missing",
-  "text-unstable",
-  "surface-missing",
-  "selector-mismatch",
-] satisfies CvdiagFailureClassifier[]);
+export const FAILURE_CLASSIFIER_SET: ReadonlySet<CvdiagFailureClassifier> =
+  new Set(CVDIAG_FAILURE_CLASSIFIERS);
 
 /**
  * Extract a CVDIAG failure classifier from a thrown error when it is a

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -1455,6 +1455,11 @@ export function buildPooledBrowserDrivers(
     d6: createE2eFullDriver({
       launcher: createPooledE2eFullLauncher(pool, log),
       diagPb,
+      // Same CVDIAG event-persistence writer the smoke driver uses: the d5/d6
+      // probe path now constructs a `CvdiagProbeSession` per feature and emits
+      // probe-layer boundaries (probe.exit etc.) that PERSIST to `cvdiag_events`
+      // on flush, so the flapping d5/d6 runs are readable from staging.
+      cvdiagPbWriter: cvdiagWriter,
     }),
   };
 }

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -1,5 +1,4 @@
 import { promises as fs } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { z } from "zod";
 import { truncateUtf8 } from "../../render/filters.js";
@@ -11,19 +10,24 @@ import type { BrowserPool } from "../helpers/browser-pool.js";
 import type { ProbeDriver } from "../types.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
 import { mintRunId } from "../helpers/cv-diag.js";
-import {
-  CvdiagEmitter,
-  filterEdgeHeaders,
-  mintSpanId,
-  scrubSecrets,
-} from "../../cvdiag/index.js";
+import { CvdiagEmitter, filterEdgeHeaders } from "../../cvdiag/index.js";
 import type {
-  CvdiagEnvelope,
   CvdiagFailureClassifier,
   CvdiagOutcome,
-  ProbeSseEventMeta,
-  TerminationKind,
 } from "../../cvdiag/index.js";
+import {
+  CvdiagProbeSession,
+  defaultCvdiagBufferDir,
+  nowMonoMs,
+  turnCompleteReason,
+} from "../../cvdiag/probe-session.js";
+import type {
+  CvdiagConsoleEvent,
+  CvdiagRequestFailedEvent,
+  CvdiagResponseEvent,
+  CvdiagSseAbortedEvent,
+  CvdiagSseEvent,
+} from "../../cvdiag/probe-session.js";
 import {
   captureRawBytes,
   parseDebugAllowList,
@@ -35,12 +39,24 @@ import {
   sanitizeTestId,
 } from "../../cvdiag/ab-hmac.js";
 import type { AbOutcomeRecord } from "../../cvdiag/ab-report.js";
-import {
-  mintSpanId as mintAbPairId,
-  mintTestId,
-  sanitizeJoinTestId,
-} from "../../cvdiag/emit.js";
-import { isValidTestId } from "../../cvdiag/schema.js";
+import { mintSpanId as mintAbPairId, mintTestId } from "../../cvdiag/emit.js";
+
+// Re-export the shared `CvdiagProbeSession` so existing importers (the d4
+// tests) keep resolving it from `./d4-chat-roundtrip.js`. The class now lives
+// in `../../cvdiag/probe-session.js` (shared with the d5/d6 probe path).
+export { CvdiagProbeSession } from "../../cvdiag/probe-session.js";
+
+// Re-export the shared CVDIAG event-source shapes so existing importers
+// (this driver's `E2ePage` seams, the d4 tests) keep resolving them from
+// `./d4-chat-roundtrip.js`. The definitions now live in
+// `../../cvdiag/probe-session.js` (shared with the d5/d6 probe path).
+export type {
+  CvdiagConsoleEvent,
+  CvdiagRequestFailedEvent,
+  CvdiagResponseEvent,
+  CvdiagSseAbortedEvent,
+  CvdiagSseEvent,
+} from "../../cvdiag/probe-session.js";
 
 /**
  * e2e-smoke driver — L3 (chat round-trip) and L4 (tool rendering) coverage
@@ -207,58 +223,13 @@ export interface E2ePage {
   onSseAborted?(handler: (evt: CvdiagSseAbortedEvent) => void): void;
 }
 
-/**
- * Normalized HTTP-response shape the driver reads for `probe.network.response`
- * and `probe.message.send` edge-header capture. The launcher adapts
- * Playwright's `Response` onto this minimal surface so the driver stays
- * decoupled from the Playwright type tree (and fakes can hand one in).
- */
-export interface CvdiagResponseEvent {
-  url: string;
-  status: number;
-  /** Raw header bag (case-insensitive keys); filtered to the 9-key allow-list. */
-  headers: Record<string, string | null | undefined>;
-  contentLength: number | null;
-  durationMs: number;
-  /** True iff this is the agent-message POST (drives `probe.message.send`). */
-  isMessagePost?: boolean;
-  /**
-   * DEBUG-tier raw-byte capture (L2-C / Phase 2.5) seam: lazily reads the
-   * literal (possibly compressed) response body. Present ONLY when the
-   * launcher wires Playwright's `Response.body()`; absent on fake pages (which
-   * therefore never trigger a raw-byte capture). Best-effort — resolves null
-   * on any read failure so it never throws into the probe.
-   */
-  body?: () => Promise<Buffer | null>;
-}
-
-/** Normalized failed-request shape for `probe.network.error`. */
-export interface CvdiagRequestFailedEvent {
-  url: string;
-  errorClass: string;
-  responseStatus: number | null;
-}
-
-/** Normalized console-message shape for `probe.console.error`. */
-export interface CvdiagConsoleEvent {
-  level: "warning" | "error";
-  /** Raw (un-scrubbed) text; the driver scrubs + caps before emit. */
-  text: string;
-  sourceFile: string | null;
-  lineCol: string | null;
-}
-
-/** Normalized SSE-event shape for `probe.sse.event`. */
-export interface CvdiagSseEvent {
-  eventType: string;
-  payloadSizeBytes: number;
-}
-
-/** Normalized SSE-abort shape for `probe.sse.aborted`. */
-export interface CvdiagSseAbortedEvent {
-  terminationKind: TerminationKind;
-  bytesBeforeAbort: number;
-}
+// The normalized CVDIAG event-source shapes (`CvdiagResponseEvent`,
+// `CvdiagRequestFailedEvent`, `CvdiagConsoleEvent`, `CvdiagSseEvent`,
+// `CvdiagSseAbortedEvent`) and the `CvdiagProbeSession` they feed now live in
+// the shared `../../cvdiag/probe-session.js` module so the d5/d6 probe path
+// (`d6-all-pills`) can construct the SAME session. They are re-exported below
+// (`export type { ... }`) so existing importers (this driver's page surface,
+// the d4 tests) keep resolving them from `./d4-chat-roundtrip.js` unchanged.
 
 export interface E2eBrowserContext {
   newPage(): Promise<E2ePage>;
@@ -362,26 +333,6 @@ export interface E2eSmokeDriverDeps {
 }
 
 /**
- * SSE-event emit sampling target (spec §7 R5-F11): cap probe-side
- * `probe.sse.event` emits at ≤30/sec regardless of underlying SSE rate. Above
- * this rate, every Nth event is emitted; below it, every event.
- */
-const CVDIAG_SSE_SAMPLE_TARGET_PER_SEC = 30;
-/**
- * Class-(e) carve-out window (spec §7 R2-F19 rule 2): in the N ms immediately
- * preceding a `probe.exit` with `terminal_outcome=timeout`, EVERY
- * `probe.sse.event` is emitted regardless of rate, preserving the cross-layer
- * `sequence_num` join that detects dropped/reordered frontend events. Because
- * `probe.exit` is terminal (the future is unknown at emit time), the driver
- * buffers the last `CVDIAG_PRE_TIMEOUT_WINDOW_MS` of SSE events and flushes the
- * full unsampled set on a timeout exit.
- */
-const CVDIAG_PRE_TIMEOUT_WINDOW_MS = 5_000;
-/** `probe.console.error.message_scrubbed` byte cap (spec §5). */
-const CVDIAG_CONSOLE_MSG_CAP_BYTES = 512;
-/** `probe.navigate.complete.url` byte cap (spec §5). */
-const CVDIAG_URL_CAP_BYTES = 256;
-/**
  * Hard cap on outstanding (un-responded) request-start timestamps tracked per
  * URL by `wirePlaywrightPage`'s FIFO timing queue. A pooled page is long-lived
  * and a CopilotKit demo holds a PERSISTENT agent SSE stream that never returns
@@ -427,441 +378,10 @@ function isAgentMessagePost(method: string, url: string): boolean {
 const DEFAULT_TIMEOUT_MS = 3 * 60 * 1000;
 const DEFAULT_PAGE_TIMEOUT_MS = 60 * 1000;
 
-/** A single buffered SSE event awaiting sample/carve-out decision. */
-interface PendingSseEvent {
-  eventType: string;
-  payloadSizeBytes: number;
-  /** Wall-clock ms when observed (for the pre-timeout carve-out window). */
-  atMs: number;
-  /**
-   * The `sequence_num` minted at OBSERVE time (chronological), NOT at emit
-   * time. Every observed SSE event reserves its seq the moment it arrives, so
-   * the carve-out backfill (which emits dropped events on a timeout exit)
-   * carries each event's ORIGINAL chronological seq. Minting a FRESH seq at
-   * backfill time sorted the backfilled (lower-in-time) events AFTER the live
-   * ones — defeating the reorder/drop detection the carve-out exists for. The
-   * seq is reserved here regardless of whether the event is emitted live so a
-   * later backfill can replay it in the original order.
-   */
-  seq: number;
-  /**
-   * True iff this event was ALREADY emitted live (passed the §7 sampling
-   * stride). The timeout carve-out flushes only events that were NOT emitted
-   * live, so a sampled-through event is never emitted twice (no duplicate
-   * `probe.sse.event` rows, no inflated `sse_event_count`).
-   */
-  emittedLive: boolean;
-}
-
-/**
- * `CvdiagProbeSession` — owns the CVDIAG emit state for ONE probe level (one
- * `test_id`). It threads the shared `test_id` through all 12 probe-layer
- * boundaries (spec §3 Layer 1), maintains per-`(test_id, boundary-family)`
- * `sequence_num` counters (spec §5 R3-F16), mints `span_id`/`parent_span_id`
- * per emit, applies the §7 SSE-rate sampling + the class-(e) pre-timeout
- * carve-out, and buffers every emitted envelope to a replay-fallback ndjson
- * file (spec §4 / §1.5).
- *
- * Pure instrumentation: every method swallows its own errors — a CVDIAG fault
- * MUST NEVER throw into the probe it observes (spec §7 R5-F8).
- */
-export class CvdiagProbeSession {
-  private readonly emitter: CvdiagEmitter;
-  private readonly testId: string;
-  private readonly slug: string;
-  private readonly demo: string;
-  private readonly bufferDir: string;
-  private readonly startMonoMs: number;
-  /** Root span minted at `probe.start`; parents the per-boundary spans. */
-  private readonly rootSpanId = mintSpanId();
-  /** Per-boundary-family monotonic sequence counters, reset per test_id. */
-  private readonly sequenceByFamily = new Map<string, number>();
-  /** Rolling window of recently-observed SSE events (carve-out support). */
-  private readonly pendingSse: PendingSseEvent[] = [];
-  /** Sampling cursor: emit every Nth event when over the rate target. */
-  private sseSeenInWindow = 0;
-  private sseWindowStartMs = 0;
-  private firstTokenDeltaMs: number | null = null;
-  private sseEmittedCount = 0;
-
-  constructor(opts: {
-    emitter: CvdiagEmitter;
-    testId: string;
-    slug: string;
-    demo: string;
-    bufferDir: string;
-    nowMs: number;
-  }) {
-    this.emitter = opts.emitter;
-    // Resolve ONE stable test_id for the whole session — the CROSS-LAYER JOIN
-    // KEY (spec §5). The probe's X-Test-Id is `d4-<slug>-<runId>` /
-    // `d6-<slug>-<runId>`, NOT a UUIDv7. It is forwarded verbatim as the
-    // `X-Test-Id` request header, and the backend ADOPTS that inbound header as
-    // its OWN cvdiag `test_id`, normalizing it through `sanitizeJoinTestId`. So
-    // the probe MUST record the SAME normalized value — `sanitizeJoinTestId`
-    // applied to the SAME forwarded id — for probe.* rows to JOIN backend.* rows
-    // on `test_id`. Recording a fresh random UUIDv7 here (the pre-fix behavior)
-    // gave probe rows an id the backend never derives, so the join never closed.
-    //
-    // Resolution order (all branches yield ONE stable id threaded through every
-    // emit() + the raw-byte sample, so intra-layer rows stay correlated too):
-    //   1. a value already a valid UUIDv7 → keep it verbatim (legacy callers
-    //      that mint a UUIDv7 up front; `sanitizeJoinTestId` only runs on
-    //      genuinely non-UUIDv7 inputs, matching the emitter/backend contract);
-    //   2. else sanitize the forwarded id the SAME way the backend does — this
-    //      is the join key both sides share;
-    //   3. else (nothing survives sanitization) mint a fresh UUIDv7 fallback so
-    //      every row still carries a valid, stable id.
-    this.testId = isValidTestId(opts.testId)
-      ? opts.testId
-      : (sanitizeJoinTestId(opts.testId) ?? mintTestId());
-    this.slug = opts.slug;
-    this.demo = opts.demo;
-    this.bufferDir = opts.bufferDir;
-    this.startMonoMs = opts.nowMs;
-    this.sseWindowStartMs = opts.nowMs;
-  }
-
-  /**
-   * The resolved, stable session test_id (a valid UUIDv7) that every emitted
-   * `cvdiag_events` row for this level carries. Callers (e.g. the DEBUG-tier
-   * raw-byte capture) MUST use this — not the raw `d4-<slug>-<runId>`
-   * X-Test-Id — so `cvdiag_raw_byte_samples.test_id` joins back to the events.
-   */
-  get resolvedTestId(): string {
-    return this.testId;
-  }
-
-  /**
-   * Next monotonic `sequence_num` for a boundary family (spec §5 R3-F16:
-   * per-`(test_id, layer, boundary-family)`, starting at 0). The session is
-   * already scoped to one `(test_id, layer=probe)`, so we key on the family.
-   */
-  private nextSeq(family: string): number {
-    const cur = this.sequenceByFamily.get(family) ?? 0;
-    this.sequenceByFamily.set(family, cur + 1);
-    return cur;
-  }
-
-  /** Core emit + ndjson-buffer wrapper. Swallows all faults. */
-  private fire(args: {
-    boundary: Parameters<CvdiagEmitter["emit"]>[0]["boundary"];
-    outcome: CvdiagOutcome;
-    metadata?: Record<string, unknown>;
-    edgeHeaders?: ReturnType<typeof filterEdgeHeaders>;
-    durationMs?: number | null;
-  }): void {
-    try {
-      const env = this.emitter.emit({
-        layer: "probe",
-        boundary: args.boundary,
-        slug: this.slug,
-        demo: this.demo,
-        outcome: args.outcome,
-        metadata: args.metadata,
-        edgeHeaders: args.edgeHeaders,
-        durationMs: args.durationMs ?? null,
-        parentSpanId: this.rootSpanId,
-        testId: this.testId,
-      });
-      if (env) void this.buffer(env);
-    } catch {
-      /* pure instrumentation — never throw into the probe */
-    }
-  }
-
-  /** Append one emitted envelope to the replay-fallback ndjson buffer. */
-  private async buffer(env: CvdiagEnvelope): Promise<void> {
-    try {
-      const date = env.ts.slice(0, 10); // YYYY-MM-DD
-      const dir = path.join(this.bufferDir, date);
-      await fs.mkdir(dir, { recursive: true });
-      const file = path.join(dir, `${this.testId}.ndjson`);
-      await fs.appendFile(file, `${JSON.stringify(env)}\n`, "utf8");
-    } catch {
-      /* best-effort — a buffer write must never break a probe */
-    }
-  }
-
-  // ── Boundary emitters ─────────────────────────────────────────────────────
-
-  start(url: string, viewport: { width: number; height: number }): void {
-    this.fire({
-      boundary: "probe.start",
-      outcome: "info",
-      metadata: { url: truncateUtf8(url, CVDIAG_URL_CAP_BYTES), viewport },
-    });
-  }
-
-  navigateComplete(
-    url: string,
-    navMs: number | null,
-    httpStatus: number | null,
-  ): void {
-    this.fire({
-      boundary: "probe.navigate.complete",
-      outcome: httpStatus !== null && httpStatus >= 400 ? "err" : "ok",
-      durationMs: navMs,
-      metadata: {
-        url: truncateUtf8(url, CVDIAG_URL_CAP_BYTES),
-        nav_ms: navMs,
-        http_status: httpStatus,
-      },
-    });
-  }
-
-  messageSend(
-    messageIndex: number,
-    charCount: number,
-    edge?: ReturnType<typeof filterEdgeHeaders>,
-  ): void {
-    this.fire({
-      boundary: "probe.message.send",
-      outcome: "ok",
-      edgeHeaders: edge,
-      metadata: {
-        message_index: messageIndex,
-        char_count: charCount,
-        demo: this.demo,
-      },
-    });
-  }
-
-  containerMount(nowMs: number): void {
-    this.fire({
-      boundary: "probe.dom.container.mount",
-      outcome: "ok",
-      metadata: { delta_ms_from_start: Math.max(0, nowMs - this.startMonoMs) },
-    });
-  }
-
-  firstToken(nowMs: number, textLength: number): void {
-    const delta = Math.max(0, nowMs - this.startMonoMs);
-    this.firstTokenDeltaMs = delta;
-    this.fire({
-      boundary: "probe.dom.firsttoken",
-      outcome: "ok",
-      metadata: { delta_ms_from_start: delta, text_length: textLength },
-    });
-  }
-
-  /** Emitted on a terminal exit whose assistant text stayed empty (class (d)). */
-  alternateContent(childTypeHistogram: Record<string, number>): void {
-    this.fire({
-      boundary: "probe.dom.alternate_content",
-      outcome: "info",
-      metadata: { child_type_histogram: childTypeHistogram },
-    });
-  }
-
-  networkResponse(evt: CvdiagResponseEvent): void {
-    this.fire({
-      boundary: "probe.network.response",
-      outcome: evt.status >= 400 ? "err" : "ok",
-      durationMs: evt.durationMs,
-      edgeHeaders: filterEdgeHeaders(evt.headers),
-      metadata: {
-        url: truncateUtf8(evt.url, CVDIAG_URL_CAP_BYTES),
-        status: evt.status,
-        content_length: evt.contentLength,
-        duration_ms: evt.durationMs,
-      },
-    });
-  }
-
-  networkError(evt: CvdiagRequestFailedEvent): void {
-    this.fire({
-      boundary: "probe.network.error",
-      outcome: "err",
-      metadata: {
-        url: truncateUtf8(evt.url, CVDIAG_URL_CAP_BYTES),
-        error_class: evt.errorClass,
-        response_status: evt.responseStatus,
-      },
-    });
-  }
-
-  consoleError(evt: CvdiagConsoleEvent): void {
-    // Scrub secrets BEFORE the byte cap so a truncation can never split a
-    // partially-scrubbed token and leak the tail.
-    const scrubbed = truncateUtf8(
-      scrubSecrets(evt.text),
-      CVDIAG_CONSOLE_MSG_CAP_BYTES,
-    );
-    this.fire({
-      boundary: "probe.console.error",
-      outcome: evt.level === "error" ? "err" : "info",
-      metadata: {
-        level: evt.level,
-        message_scrubbed: scrubbed,
-        source_file: evt.sourceFile,
-        line_col: evt.lineCol,
-      },
-    });
-  }
-
-  /**
-   * Observe one SSE event. Applies §7 rate sampling (≤30 emit/sec); over the
-   * rate, only every Nth event is emitted. ALL observed events are retained in
-   * a rolling pre-timeout window so a subsequent timeout exit can flush the
-   * full unsampled set (class-(e) carve-out, rule 2).
-   */
-  sseEvent(evt: CvdiagSseEvent, nowMs: number): void {
-    // Roll the 1-second sampling window.
-    if (nowMs - this.sseWindowStartMs >= 1000) {
-      this.sseWindowStartMs = nowMs;
-      this.sseSeenInWindow = 0;
-    }
-    this.sseSeenInWindow += 1;
-    // Reserve the chronological `sequence_num` for THIS event at observe time,
-    // regardless of whether it is emitted live or dropped by the §7 sampling
-    // stride. A later timeout carve-out backfills dropped events with this
-    // ORIGINAL seq so the cross-layer join sorts them in true arrival order —
-    // minting a fresh seq at backfill time put them AFTER the live events.
-    const pending: PendingSseEvent = {
-      eventType: evt.eventType,
-      payloadSizeBytes: evt.payloadSizeBytes,
-      atMs: nowMs,
-      seq: this.nextSeq("sse"),
-      emittedLive: false,
-    };
-    this.pendingSse.push(pending);
-    // Trim the rolling window to the carve-out horizon to bound memory.
-    const cutoff = nowMs - CVDIAG_PRE_TIMEOUT_WINDOW_MS;
-    while (this.pendingSse.length > 0 && this.pendingSse[0]!.atMs < cutoff) {
-      this.pendingSse.shift();
-    }
-    // Sampling decision: under target → emit every event; over → every Nth.
-    const overRate = this.sseSeenInWindow > CVDIAG_SSE_SAMPLE_TARGET_PER_SEC;
-    const stride = overRate
-      ? Math.ceil(this.sseSeenInWindow / CVDIAG_SSE_SAMPLE_TARGET_PER_SEC)
-      : 1;
-    if (this.sseSeenInWindow % stride === 0) {
-      this.emitSse(evt.eventType, evt.payloadSizeBytes, pending.seq);
-      // Mark so the timeout carve-out below does NOT re-emit this event (it
-      // was already counted in `sseEmittedCount` and emitted as a row).
-      pending.emittedLive = true;
-    }
-  }
-
-  private emitSse(
-    eventType: string,
-    payloadSizeBytes: number,
-    seq: number,
-  ): void {
-    const metadata: ProbeSseEventMeta = {
-      event_type: eventType,
-      payload_size_bytes: payloadSizeBytes,
-      sequence_num: seq,
-    };
-    this.fire({
-      boundary: "probe.sse.event",
-      outcome: "info",
-      metadata: metadata as unknown as Record<string, unknown>,
-    });
-    this.sseEmittedCount += 1;
-  }
-
-  sseAborted(evt: CvdiagSseAbortedEvent): void {
-    this.fire({
-      boundary: "probe.sse.aborted",
-      outcome: "err",
-      metadata: {
-        termination_kind: evt.terminationKind,
-        bytes_before_abort: evt.bytesBeforeAbort,
-      },
-    });
-  }
-
-  /**
-   * Terminal `probe.exit`. On a `timeout` outcome, first flush the entire
-   * pre-timeout SSE window UNSAMPLED (class-(e) carve-out rule 2) so the
-   * cross-layer `sequence_num` join is complete, THEN emit `probe.exit`.
-   *
-   * `failureClassifier` labels WHY a non-`ok` run failed. When the caller has
-   * the authoritative reason (e.g. `waitForTurnComplete`'s
-   * `TurnNotCompleteError.reason`) it passes it explicitly; otherwise, for a
-   * non-`ok` outcome, this derives a best-effort classifier from the probe's
-   * OWN observed signals (no SSE => `sse-missing`; SSE seen but no DOM
-   * first-token => `dom-missing`; else `text-unstable`) so reds are always
-   * labeled in cvdiag probe data. An `ok` outcome NEVER carries a classifier.
-   */
-  exit(
-    terminalOutcome: CvdiagOutcome,
-    totalDurationMs: number,
-    failureClassifier?: CvdiagFailureClassifier,
-  ): void {
-    if (terminalOutcome === "timeout") {
-      // Flush ONLY events not already emitted live. Re-emitting the full
-      // buffered window (including the already-live-emitted subset) duplicated
-      // `probe.sse.event` rows and inflated `sse_event_count`; the carve-out's
-      // job is to backfill the events the §7 sampling stride DROPPED, not to
-      // re-emit the ones it let through.
-      for (const ev of this.pendingSse) {
-        if (!ev.emittedLive) {
-          // Backfill with the event's ORIGINAL observe-time seq so it sorts in
-          // true chronological order alongside the live-emitted events — a
-          // fresh seq minted here would sort the (earlier) dropped events AFTER
-          // the (later) live ones, defeating the reorder/drop detection.
-          this.emitSse(ev.eventType, ev.payloadSizeBytes, ev.seq);
-        }
-      }
-      this.pendingSse.length = 0;
-    }
-    // Label the failure. An explicit reason (from the caller, e.g.
-    // `waitForTurnComplete`'s reject `reason`) wins; otherwise derive a
-    // best-effort classifier from this probe's own observed signals. `ok`
-    // runs never carry a classifier (greens stay unlabeled).
-    const resolvedClassifier: CvdiagFailureClassifier | undefined =
-      terminalOutcome === "ok"
-        ? undefined
-        : (failureClassifier ?? this.deriveFailureClassifier());
-    this.fire({
-      boundary: "probe.exit",
-      outcome: terminalOutcome,
-      durationMs: totalDurationMs,
-      metadata: {
-        terminal_outcome: terminalOutcome,
-        total_duration_ms: totalDurationMs,
-        sse_event_count: this.sseEmittedCount,
-        first_token_delta_ms: this.firstTokenDeltaMs,
-        // Only present on a non-`ok` outcome (undefined keys are dropped by
-        // the emit-time metadata validator, so greens carry no classifier).
-        ...(resolvedClassifier !== undefined
-          ? { failure_classifier: resolvedClassifier }
-          : {}),
-      },
-    });
-  }
-
-  /**
-   * Best-effort failure classifier from the probe's OWN observed signals,
-   * mirroring `waitForTurnComplete`'s precedence (earliest-missing signal
-   * wins): no SSE event => `sse-missing`; SSE seen but no DOM first-token =>
-   * `dom-missing`; SSE + first-token both seen but the run still failed (the
-   * text never settled / assertion red) => `text-unstable`.
-   */
-  private deriveFailureClassifier(): CvdiagFailureClassifier {
-    if (this.sseEmittedCount === 0) return "sse-missing";
-    if (this.firstTokenDeltaMs === null) return "dom-missing";
-    return "text-unstable";
-  }
-}
-
-/** Default replay-fallback ndjson buffer root (spec §4 `~/.cvdiag/buffer`). */
-function defaultCvdiagBufferDir(): string {
-  return path.join(os.homedir(), ".cvdiag", "buffer");
-}
-
-/**
- * Monotonic wall-clock ms for CVDIAG delta computations
- * (`delta_ms_from_start`, the SSE sampling window, the pre-timeout carve-out).
- * `performance.now()` is monotonic and immune to wall-clock skew — the right
- * source for intra-probe durations.
- */
-function nowMonoMs(): number {
-  return performance.now();
-}
+// `PendingSseEvent`, `CvdiagProbeSession`, `defaultCvdiagBufferDir`, and
+// `nowMonoMs` were extracted to `../../cvdiag/probe-session.js` so the d5/d6
+// probe path can reuse the SAME probe-layer session. They are imported at the
+// top of this file; behavior here is unchanged.
 
 /**
  * Weather vocabulary the L4 response must include — mirrors the
@@ -2186,41 +1706,9 @@ async function runLevel(opts: {
   }
 }
 
-/**
- * Set of valid CVDIAG failure classifiers, for the duck-typed
- * `TurnNotCompleteError.reason` guard below. Kept in sync with the schema's
- * `CVDIAG_FAILURE_CLASSIFIERS` union (a mismatch is caught by the
- * `satisfies` assertion).
- */
-const FAILURE_CLASSIFIER_SET: ReadonlySet<CvdiagFailureClassifier> = new Set([
-  "sse-missing",
-  "dom-missing",
-  "text-unstable",
-  "surface-missing",
-  "selector-mismatch",
-] satisfies CvdiagFailureClassifier[]);
-
-/**
- * Extract a CVDIAG failure classifier from a thrown error when it is a
- * `waitForTurnComplete` `TurnNotCompleteError` (duck-typed via its `reason`
- * field so this driver stays decoupled from conversation-runner). Returns
- * `undefined` for any other throw, leaving the session to derive a best-effort
- * classifier from its own observed signals.
- */
-function turnCompleteReason(err: unknown): CvdiagFailureClassifier | undefined {
-  if (
-    typeof err === "object" &&
-    err !== null &&
-    "reason" in err &&
-    typeof (err as { reason: unknown }).reason === "string"
-  ) {
-    const reason = (err as { reason: string }).reason;
-    if (FAILURE_CLASSIFIER_SET.has(reason as CvdiagFailureClassifier)) {
-      return reason as CvdiagFailureClassifier;
-    }
-  }
-  return undefined;
-}
+// `FAILURE_CLASSIFIER_SET` and `turnCompleteReason` were extracted to
+// `../../cvdiag/probe-session.js` (imported at the top of this file) so the
+// d5/d6 probe path can reuse the same thrown-error → failure-classifier guard.
 
 /**
  * Read the child-element type histogram of the LAST assistant-message

--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -7,8 +7,10 @@ import {
   e2eFullDriver,
   FEATURE_CONCURRENCY_D6,
   openGuardedContext,
+  parseFailureClassifier,
   Semaphore,
 } from "./d6-all-pills.js";
+import { CVDIAG_FAILURE_CLASSIFIERS } from "../../cvdiag/index.js";
 import type { GuardableBrowser } from "./d6-all-pills.js";
 import type {
   E2eFullAggregateSignal,
@@ -169,16 +171,20 @@ function noopScriptLoader() {
 
 function makeScript(
   featureTypes: string[],
-  opts?: { preNavigateRoute?: string },
+  opts?: {
+    preNavigateRoute?: string;
+    turns?: ReturnType<D5Script["buildTurns"]>;
+  },
 ): D5Script {
   return {
     featureTypes: featureTypes as D5Script["featureTypes"],
     fixtureFile: "test-fixture.json",
-    buildTurns: () => [
-      {
-        input: "hello",
-      },
-    ],
+    buildTurns: () =>
+      opts?.turns ?? [
+        {
+          input: "hello",
+        },
+      ],
     preNavigateRoute: opts?.preNavigateRoute
       ? () => opts.preNavigateRoute!
       : undefined,
@@ -1575,5 +1581,279 @@ describe("e2e-full per-feature retry signal isolation", () => {
         expect(sig.errorDesc).not.toContain("600000");
       }
     }, 20_000);
+  });
+});
+
+// ── D6 CVDIAG probe instrumentation (probe-session) ─────────────────────────
+//
+// The d5/d6 probe path (`d6-all-pills`) now constructs the SAME
+// `CvdiagProbeSession` the d4 driver uses, emitting probe-layer boundaries
+// (notably `probe.exit` with `terminal_outcome` + `failure_classifier`) so the
+// flapping d5/d6 runs are readable from `cvdiag_events`. These tests inject a
+// VERBOSE-tier emitter wired to a capturing PB writer and assert the emitted
+// envelopes directly — mirroring the d4 CVDIAG tests.
+
+import { CvdiagEmitter } from "../../cvdiag/index.js";
+import type { CvdiagEnvelope } from "../../cvdiag/index.js";
+
+/** Capturing PB writer: records every flushed envelope for assertion. */
+class D6CaptureWriter {
+  events: CvdiagEnvelope[] = [];
+  async writeBatch(events: CvdiagEnvelope[]): Promise<void> {
+    this.events.push(...events);
+  }
+}
+
+/** Build a VERBOSE-tier emitter wired to a capturing PB writer. */
+function makeD6CvdiagEmitter(): {
+  emitter: CvdiagEmitter;
+  writer: D6CaptureWriter;
+} {
+  const writer = new D6CaptureWriter();
+  const emitter = new CvdiagEmitter({
+    verbose: true,
+    env: {},
+    layer: "probe",
+    pbWriter: writer,
+  });
+  return { emitter, writer };
+}
+
+function byD6Boundary(
+  writer: D6CaptureWriter,
+  boundary: string,
+): CvdiagEnvelope[] {
+  return writer.events.filter((e) => e.boundary === boundary);
+}
+
+describe("d6 CVDIAG probe instrumentation (probe-session)", () => {
+  beforeEach(() => {
+    __clearD5RegistryForTesting();
+  });
+
+  it("emits exactly one probe.exit with terminal_outcome=ok for a passing feature", async () => {
+    // RED (pre-change): runFeature constructed NO CvdiagProbeSession, so an
+    // injected VERBOSE emitter received ZERO `probe.exit` rows on the d5/d6
+    // path. GREEN: a passing feature emits exactly one `probe.exit` with
+    // `terminal_outcome=ok` and no failure classifier.
+    registerD5Script(makeScript(["agentic-chat"]));
+    const { emitter, writer } = makeD6CvdiagEmitter();
+
+    const driver = createE2eFullDriver({
+      launcher: async () => makeBrowser(),
+      scriptLoader: noopScriptLoader(),
+      cvdiagEmitter: emitter,
+    });
+    const result = await driver.run(makeCtx(), {
+      key: "d6:showcase-test-slug",
+      backendUrl: "https://test.example.com",
+      features: ["agentic-chat"],
+    });
+    await emitter.flush();
+
+    expect(result.state).toBe("green");
+    const exit = byD6Boundary(writer, "probe.exit");
+    expect(exit.length).toBe(1);
+    expect(exit[0]!.outcome).toBe("ok");
+    expect(exit[0]!.metadata.terminal_outcome).toBe("ok");
+    expect(exit[0]!.metadata.failure_classifier).toBeUndefined();
+  });
+
+  it("emits a probe.start before navigation for a passing feature", async () => {
+    registerD5Script(makeScript(["agentic-chat"]));
+    const { emitter, writer } = makeD6CvdiagEmitter();
+
+    const driver = createE2eFullDriver({
+      launcher: async () => makeBrowser(),
+      scriptLoader: noopScriptLoader(),
+      cvdiagEmitter: emitter,
+    });
+    await driver.run(makeCtx(), {
+      key: "d6:showcase-test-slug",
+      backendUrl: "https://test.example.com",
+      features: ["agentic-chat"],
+    });
+    await emitter.flush();
+
+    const start = byD6Boundary(writer, "probe.start");
+    expect(start.length).toBe(1);
+  });
+
+  it("labels a failed feature (goto error) on probe.exit with outcome=err + a failure_classifier", async () => {
+    // RED (pre-change): a failing feature emitted no probe.exit at all on the
+    // d5/d6 path, so reds were invisible in cvdiag. GREEN: the feature emits a
+    // single `probe.exit` with `outcome=err` AND a `failure_classifier`
+    // (derived: no SSE observed by the probe-session => `sse-missing`).
+    registerD5Script(makeScript(["agentic-chat"]));
+    const { emitter, writer } = makeD6CvdiagEmitter();
+
+    const driver = createE2eFullDriver({
+      launcher: async () =>
+        makeBrowser({ pageScript: { throwOnGoto: new Error("nav boom") } }),
+      scriptLoader: noopScriptLoader(),
+      cvdiagEmitter: emitter,
+    });
+    const result = await driver.run(makeCtx(), {
+      key: "d6:showcase-test-slug",
+      backendUrl: "https://test.example.com",
+      features: ["agentic-chat"],
+    });
+    await emitter.flush();
+
+    expect(result.state).toBe("red");
+    const exit = byD6Boundary(writer, "probe.exit");
+    expect(exit.length).toBe(1);
+    expect(exit[0]!.outcome).toBe("err");
+    expect(exit[0]!.metadata.terminal_outcome).toBe("err");
+    expect(exit[0]!.metadata.failure_classifier).toBeDefined();
+  });
+
+  it("never emits CVDIAG rows when no emitter is injected (instrumentation off)", async () => {
+    // Control: a missing emitter is a clean no-op — the probe path is
+    // unchanged and still greens.
+    registerD5Script(makeScript(["agentic-chat"]));
+    const driver = createE2eFullDriver({
+      launcher: async () => makeBrowser(),
+      scriptLoader: noopScriptLoader(),
+    });
+    const result = await driver.run(makeCtx(), {
+      key: "d6:showcase-test-slug",
+      backendUrl: "https://test.example.com",
+      features: ["agentic-chat"],
+    });
+    expect(result.state).toBe("green");
+  });
+
+  it("does not throw the cvdiag char-count out of the probe path on a non-string turn input (cvdiag isolation)", async () => {
+    // RED (pre-change): the cvdiag message-send char count was computed
+    // UNGUARDED in the probe's main path BEFORE `runConversation`, via
+    // `turns.reduce((n, t) => n + [...t.input].length, 0)`. A turn whose
+    // `input` is null/undefined/non-string makes the spread throw
+    // `t.input is not iterable`, which escapes runFeature and REDs the probe
+    // with THAT cvdiag error. cvdiag instrumentation must NEVER compute-or-
+    // throw into the probe path. GREEN (post-change): the per-turn length
+    // coerces a non-string `input` to 0, so the cvdiag spread no longer
+    // throws — the probe never fails with the cvdiag `is not iterable`
+    // error (the conversation-runner separately rejects a non-string input
+    // on its own merits, which is correct probe behavior, NOT a cvdiag
+    // concern).
+    registerD5Script(
+      makeScript(["agentic-chat"], {
+        // A malformed turn (e.g. a buggy script producing a non-string input).
+        // Typed `string`, so cast to exercise the runtime defect the cvdiag
+        // spread would have thrown on.
+        turns: [{ input: undefined as unknown as string }],
+      }),
+    );
+    const { emitter } = makeD6CvdiagEmitter();
+
+    const driver = createE2eFullDriver({
+      launcher: async () => makeBrowser(),
+      scriptLoader: noopScriptLoader(),
+      cvdiagEmitter: emitter,
+    });
+    const result = await driver.run(makeCtx(), {
+      key: "d6:showcase-test-slug",
+      backendUrl: "https://test.example.com",
+      features: ["agentic-chat"],
+    });
+    await emitter.flush();
+
+    // The cvdiag char-count spread no longer throws into the probe path: the
+    // feature's failure (if any) is the conversation-runner's own non-string
+    // rejection, never the cvdiag `t.input is not iterable` throw.
+    const signal = result.signal as E2eFullAggregateSignal;
+    expect(signal.failureSummary ?? "").not.toContain("is not iterable");
+  });
+
+  it("computes no char count and emits nothing when the emitter is absent (cvdiag no-op)", async () => {
+    // The char-count reduction lives INSIDE the `if (cvdiag)` guard, so with
+    // no emitter the reduction is never evaluated and cvdiag is a clean no-op
+    // — a normal valid-string feature still greens and (the control already
+    // covered) emits zero CVDIAG rows. This pins the guard: the computation
+    // must not run on the emitter-absent path.
+    registerD5Script(
+      makeScript(["agentic-chat"], { turns: [{ input: "hi" }] }),
+    );
+    const driver = createE2eFullDriver({
+      launcher: async () => makeBrowser(),
+      scriptLoader: noopScriptLoader(),
+    });
+    const result = await driver.run(makeCtx(), {
+      key: "d6:showcase-test-slug",
+      backendUrl: "https://test.example.com",
+      features: ["agentic-chat"],
+    });
+    expect(result.state).toBe("green");
+  });
+
+  it("records the cvdiag message-send char count for valid turns (computation intact under the guard)", async () => {
+    // Post-change the char count moved INSIDE `if (cvdiag)`. This pins that
+    // the normal path still records one `probe.message.send` whose char count
+    // is the Unicode code-point total across the (valid string) turns —
+    // "hello" (5) + "world!" (6) = 11.
+    registerD5Script(
+      makeScript(["agentic-chat"], {
+        turns: [{ input: "hello" }, { input: "world!" }],
+      }),
+    );
+    const { emitter, writer } = makeD6CvdiagEmitter();
+
+    const driver = createE2eFullDriver({
+      launcher: async () => makeBrowser(),
+      scriptLoader: noopScriptLoader(),
+      cvdiagEmitter: emitter,
+    });
+    const result = await driver.run(makeCtx(), {
+      key: "d6:showcase-test-slug",
+      backendUrl: "https://test.example.com",
+      features: ["agentic-chat"],
+    });
+    await emitter.flush();
+
+    expect(result.state).toBe("green");
+    const sends = byD6Boundary(writer, "probe.message.send");
+    expect(sends.length).toBe(1);
+    expect(sends[0]!.metadata.char_count).toBe(11);
+  });
+});
+
+describe("parseFailureClassifier (conversation-error breadcrumb)", () => {
+  it("accepts selector-mismatch (regression: was dropped by a stale 4-member allow-list)", () => {
+    // RED before fix: parseFailureClassifier validated against a hardcoded
+    // {dom-missing, text-unstable, sse-missing, surface-missing} subset that
+    // omitted `selector-mismatch`, so a `reason=selector-mismatch` breadcrumb
+    // returned undefined → fell through to the derived `sse-missing` classifier
+    // → the cell was mislabeled. The allow-list now derives from the canonical
+    // CVDIAG_FAILURE_CLASSIFIERS, so the breadcrumb survives.
+    expect(
+      parseFailureClassifier(
+        "turn 0 failed: reason=selector-mismatch — pill never matched",
+      ),
+    ).toBe("selector-mismatch");
+  });
+
+  it("accepts every canonical CVDIAG_FAILURE_CLASSIFIERS member (no drift)", () => {
+    for (const classifier of CVDIAG_FAILURE_CLASSIFIERS) {
+      expect(
+        parseFailureClassifier(`turn 0 failed: reason=${classifier}`),
+      ).toBe(classifier);
+    }
+  });
+
+  it("strips trailing punctuation from the breadcrumb", () => {
+    expect(
+      parseFailureClassifier("turn 0 failed: reason=selector-mismatch,"),
+    ).toBe("selector-mismatch");
+  });
+
+  it("returns undefined for an unrecognized reason or a missing breadcrumb", () => {
+    expect(
+      parseFailureClassifier("turn 0 failed: reason=bogus"),
+    ).toBeUndefined();
+    expect(
+      parseFailureClassifier("turn 0 failed: no breadcrumb"),
+    ).toBeUndefined();
+    expect(parseFailureClassifier(undefined)).toBeUndefined();
   });
 });

--- a/showcase/harness/src/probes/drivers/d6-all-pills.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.ts
@@ -34,6 +34,16 @@ import {
 } from "../helpers/cv-diag.js";
 import { writeDiagEvent } from "../../storage/diag-sink.js";
 import type { DiagSinkClient } from "../../storage/diag-sink.js";
+import { CvdiagEmitter } from "../../cvdiag/index.js";
+import {
+  CvdiagProbeSession,
+  defaultCvdiagBufferDir,
+  FAILURE_CLASSIFIER_SET,
+  nowMonoMs,
+  turnCompleteReason,
+} from "../../cvdiag/probe-session.js";
+import type { CvdiagFailureClassifier } from "../../cvdiag/index.js";
+import type { CvdiagPbWriter } from "../../cvdiag/pb-writer.js";
 import type { ProbeDriver } from "../types.js";
 import type { Logger, ProbeContext, ProbeResult } from "../../types/index.js";
 import type { BrowserPool } from "../helpers/browser-pool.js";
@@ -261,6 +271,35 @@ export interface E2eFullDriverDeps {
    * swallowed by `writeDiagEvent` and can never break a probe.
    */
   diagPb?: DiagSinkClient;
+  /**
+   * CVDIAG flap-observability emitter (spec §3 Layer 1). When provided (or
+   * constructed from `ctx.env` on first use), each feature run constructs a
+   * `CvdiagProbeSession` and emits the probe-layer boundaries — notably
+   * `probe.exit` carrying `terminal_outcome` + `failure_classifier` — so the
+   * flapping d5/d6 runs are readable from `cvdiag_events`. This is the SAME
+   * session the d4 driver uses (extracted to `cvdiag/probe-session.ts`).
+   * Injectable so unit tests can supply a VERBOSE emitter with a captured
+   * PB-writer seam and assert envelopes without a live PB. CVDIAG is pure
+   * instrumentation — a missing or failing emitter NEVER changes a probe's
+   * red/green outcome.
+   */
+  cvdiagEmitter?: CvdiagEmitter;
+  /**
+   * CVDIAG event-persistence writer. When provided, the driver injects it into
+   * the `CvdiagEmitter` it constructs so the queued probe-layer events PERSIST
+   * to the `cvdiag_events` collection on flush (the emit→persist seam). The
+   * fleet worker / CLI constructs one from a writer-role PB connection; absent
+   * → events emit to the queue but the durable write is a no-op. Never
+   * load-bearing: a write failure can't break a probe.
+   */
+  cvdiagPbWriter?: CvdiagPbWriter;
+  /**
+   * Root directory for the per-test replay-fallback ndjson buffer
+   * (`<dir>/<date>/<test-id>.ndjson`). Defaults to `~/.cvdiag/buffer`.
+   * Injectable so tests buffer into a tmpdir. Best-effort: a write failure is
+   * swallowed and never breaks a probe.
+   */
+  cvdiagBufferDir?: string;
   /**
    * Factory for the per-`run()` correlation id (`runId`). Defaults to
    * `mintRunId` (`crypto.randomUUID()`). Injectable ONLY so unit tests can
@@ -729,6 +768,11 @@ export function createE2eFullDriver(
   const representatives = deps.representatives ?? D5_REPRESENTATIVES;
   const diagPb = deps.diagPb;
   const idFactory = deps.idFactory ?? mintRunId;
+  // CVDIAG probe-session deps (best-effort). The emitter may be injected (tests)
+  // or constructed once per `run()` from `ctx.env`; the PB writer + buffer dir
+  // are resolved here so the per-feature sessions persist + buffer.
+  const cvdiagPbWriter = deps.cvdiagPbWriter;
+  const cvdiagBufferDir = deps.cvdiagBufferDir ?? defaultCvdiagBufferDir();
 
   return {
     kind: "e2e_d6",
@@ -776,6 +820,34 @@ export function createE2eFullDriver(
       // probe matches against. Used for the best-effort post-run journal
       // join; absent → the join is skipped (logged as status=error).
       const aimockBaseUrl = ctx.env.AIMOCK_URL ?? ctx.env.AIMOCK_URL_LOCAL;
+
+      // CVDIAG probe-session emitter (spec §3 Layer 1). Injected for tests;
+      // otherwise constructed once per `run()` from the probe's env so the
+      // resolved verbosity tier honors CVDIAG_VERBOSE / CVDIAG_DEBUG. The PB
+      // writer (when wired) makes the queued probe-layer events PERSIST to
+      // `cvdiag_events` on the run-level flush below. Construction is wrapped so
+      // a fail-closed DEBUG guard throw can never break the probe — CVDIAG is
+      // pure instrumentation. This is the SAME session the d4 driver
+      // constructs (extracted to `cvdiag/probe-session.ts`); the d5/d6 path was
+      // previously the ONLY probe family that did NOT emit these boundaries,
+      // which is exactly why the flapping d5/d6 runs were unreadable from
+      // `cvdiag_events`.
+      let cvdiagEmitter: CvdiagEmitter | undefined = deps.cvdiagEmitter;
+      if (cvdiagEmitter === undefined) {
+        try {
+          cvdiagEmitter = new CvdiagEmitter({
+            env: ctx.env,
+            layer: "probe",
+            pbWriter: cvdiagPbWriter,
+          });
+        } catch (err) {
+          ctx.logger.warn("probe.e2e-full.cvdiag-init-failed", {
+            slug,
+            err: err instanceof Error ? err.message : String(err),
+          });
+          cvdiagEmitter = undefined;
+        }
+      }
 
       // Resolve the feature list. ALL features, not one-per-type.
       const featuresFromInput = input.features ?? [];
@@ -1235,6 +1307,12 @@ export function createE2eFullDriver(
                 // inbound-boundary line at header injection.
                 runId,
                 cvComponent,
+                // CVDIAG probe-session: the emitter (when present) + buffer dir
+                // let runFeature construct a `CvdiagProbeSession` per feature
+                // and emit the probe-layer boundaries (probe.start / navigate /
+                // message.send / firstToken / exit) for THIS d5/d6 cell.
+                cvdiagEmitter,
+                cvdiagBufferDir,
               });
               inFlightRunFeatures.push(runFeaturePromise);
               try {
@@ -1516,6 +1594,18 @@ export function createE2eFullDriver(
         if (externalAbort) {
           externalAbort.removeEventListener("abort", onExternalAbort);
         }
+        // Drain the CVDIAG emitter's queued probe-layer events to PB before
+        // returning. `flush()` is best-effort (no-op when no `pbWriter` was
+        // injected, and never throws into the probe), so this can run
+        // unconditionally and can NEVER change the probe's red/green outcome.
+        try {
+          await cvdiagEmitter?.flush();
+        } catch (err) {
+          ctx.logger.warn("probe.e2e-full.cvdiag-flush-failed", {
+            slug,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
         if (browser) {
           try {
             await browser.close();
@@ -1550,6 +1640,14 @@ async function runFeature(opts: {
   runId: string;
   /** CVDIAG component tag (`harness-d5` | `harness-d6`). */
   cvComponent: string;
+  /**
+   * CVDIAG probe-session emitter for THIS feature cell. Absent → no
+   * probe-layer emission (instrumentation off). Same session as the d4 driver
+   * (extracted to `cvdiag/probe-session.ts`).
+   */
+  cvdiagEmitter?: CvdiagEmitter;
+  /** Replay-fallback ndjson buffer root for this cell's CVDIAG session. */
+  cvdiagBufferDir?: string;
 }): Promise<
   | { ok: true; conversation: ConversationResult }
   | {
@@ -1564,7 +1662,7 @@ async function runFeature(opts: {
     browser,
     url,
     slug,
-    featureType: _featureType,
+    featureType,
     pageTimeoutMs,
     script,
     buildCtx,
@@ -1572,8 +1670,49 @@ async function runFeature(opts: {
     logger,
     runId,
     cvComponent,
+    cvdiagEmitter,
+    cvdiagBufferDir,
   } = opts;
+
+  const testId = buildE2eTestId(slug, runId);
+  // CVDIAG probe-session for THIS feature cell (one test_id). The session
+  // records `sanitizeJoinTestId(X-Test-Id)` — the SAME value the backend adopts
+  // from the inbound `X-Test-Id` header (injected on the browser context below)
+  // — so probe.* rows JOIN backend.* rows on `test_id`. Absent emitter → no-op.
+  const cvdiag =
+    cvdiagEmitter !== undefined
+      ? new CvdiagProbeSession({
+          emitter: cvdiagEmitter,
+          testId,
+          slug,
+          demo: featureType,
+          bufferDir: cvdiagBufferDir ?? defaultCvdiagBufferDir(),
+          nowMs: nowMonoMs(),
+        })
+      : undefined;
+  // Terminal-exit tracking: `probe.exit` fires EXACTLY ONCE per feature across
+  // the success / catch / finally paths (mirrors d4's `cvdiagExited` guard).
+  const cvdiagStartMs = nowMonoMs();
+  let cvdiagExited = false;
+  const cvdiagExit = (
+    outcome: Parameters<CvdiagProbeSession["exit"]>[0],
+    failureClassifier?: CvdiagFailureClassifier,
+  ): void => {
+    if (cvdiagExited) return;
+    cvdiagExited = true;
+    cvdiag?.exit(
+      outcome,
+      Math.round(nowMonoMs() - cvdiagStartMs),
+      failureClassifier,
+    );
+  };
+
   if (abortSignal.aborted) {
+    // Balance the session: emit start+exit even on the abort-before-start
+    // early return so the test_id always carries an open/close pair (mirrors
+    // d4). `timeout` outcome — the cell was aborted before it could run.
+    cvdiag?.start(url, { width: 1280, height: 720 });
+    cvdiagExit("timeout");
     return {
       ok: false,
       errorClass: "abort",
@@ -1583,7 +1722,6 @@ async function runFeature(opts: {
 
   let context: E2eFullBrowserContext | undefined;
   let page: E2eFullPage | undefined;
-  const testId = buildE2eTestId(slug, runId);
   try {
     // D6 sets per-feature context headers: X-AIMock-Context and X-Test-Id.
     //
@@ -1627,18 +1765,32 @@ async function runFeature(opts: {
       slug: buildCtx.integrationSlug,
     });
 
+    // CVDIAG probe.start — record entry for THIS cell's test_id.
+    cvdiag?.start(url, { width: 1280, height: 720 });
+
+    const navStartMs = nowMonoMs();
     try {
       await page.goto(url, {
         waitUntil: "load",
         timeout: pageTimeoutMs,
       });
       logger.debug("probe.e2e-full.runFeature.navigation-complete", { url });
+      // CVDIAG probe.navigate.complete — nav timing (the d6 launcher's goto
+      // resolves void, so HTTP status is unavailable here → null).
+      cvdiag?.navigateComplete(url, Math.round(nowMonoMs() - navStartMs), null);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       logger.debug("probe.e2e-full.runFeature.navigation-failed", {
         url,
         error: msg,
       });
+      // CVDIAG probe.exit — a goto failure is a probe FAILURE. `surface-missing`
+      // (the page never loaded → the chat surface never appeared); on an abort
+      // the outcome is `timeout`.
+      cvdiagExit(
+        abortSignal.aborted ? "timeout" : "err",
+        abortSignal.aborted ? undefined : "surface-missing",
+      );
       return {
         ok: false,
         errorClass: "goto-error",
@@ -1719,6 +1871,25 @@ async function runFeature(opts: {
       slug: buildCtx.integrationSlug,
       bubbleRaceMessagesOverride: turnsOverride !== undefined,
     });
+
+    // CVDIAG probe.message.send — record the first turn send with the total
+    // input char count (Unicode code points across all turns). The d6 launcher
+    // exposes no message-POST response seam, so edge headers are unavailable
+    // here (passed undefined); the boundary still records the send.
+    //
+    // cvdiag instrumentation must NEVER compute-or-throw into the probe path:
+    // the char count is computed ONLY when the session exists (no-op when the
+    // emitter is absent), and each turn's length coerces non-string/missing
+    // `input` to 0 (`[...t.input]` would throw on null/undefined/non-string,
+    // which would RED an otherwise-green probe).
+    if (cvdiag) {
+      const totalInputChars = turns.reduce(
+        (n, t) => n + (typeof t.input === "string" ? [...t.input].length : 0),
+        0,
+      );
+      cvdiag.messageSend(0, totalInputChars);
+    }
+
     const conversation = await runConversation(page, turns);
 
     if (conversation.failure_turn !== undefined) {
@@ -1756,6 +1927,17 @@ async function runFeature(opts: {
           ).slice(0, 200),
         }),
       );
+      // CVDIAG probe.exit — the conversation failed. Parse the turn-runner's
+      // `reason=<classifier>` breadcrumb out of `conversation.error` so the
+      // probe.exit row carries the authoritative failure classifier; otherwise
+      // the session derives a best-effort one from its own observed signals
+      // (no SSE seam wired in d6 → typically `sse-missing`). A drain/timeout
+      // abort maps to `timeout`.
+      const conversationClassifier = parseFailureClassifier(conversation.error);
+      cvdiagExit(
+        abortSignal.aborted ? "timeout" : "err",
+        abortSignal.aborted ? undefined : conversationClassifier,
+      );
       return {
         ok: false,
         errorClass: "conversation-error",
@@ -1774,10 +1956,29 @@ async function runFeature(opts: {
       turnsCompleted: conversation.turns_completed,
       turnDurations: conversation.turn_durations_ms,
     });
+    // CVDIAG probe.dom.firsttoken — best-effort: the d6 path has no per-token
+    // DOM seam, so approximate first-token latency from the FIRST turn's
+    // wall-clock duration (the time the first assistant turn took to settle).
+    // Gives the ok-path a non-null `first_token_delta_ms` and prevents the
+    // derived classifier from ever labeling a green as `dom-missing`.
+    const firstTurnMs = conversation.turn_durations_ms[0];
+    if (firstTurnMs !== undefined) {
+      cvdiag?.firstToken(cvdiagStartMs + firstTurnMs, 1);
+    }
+    // CVDIAG probe.exit — clean completion.
+    cvdiagExit("ok");
     return { ok: true, conversation };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     const diagnostics = page ? await captureDiagnostics(page) : undefined;
+    // CVDIAG probe.exit (error path) — `timeout` when this attempt aborted
+    // (the driver's outer / per-feature timeout fired), else `err`. A
+    // `TurnNotCompleteError` carries its authoritative `reason` as the
+    // classifier; otherwise the session derives one from its observed signals.
+    cvdiagExit(
+      abortSignal.aborted ? "timeout" : "err",
+      abortSignal.aborted ? undefined : turnCompleteReason(err),
+    );
     return {
       ok: false,
       errorClass: abortSignal.aborted ? "abort" : "driver-error",
@@ -1785,6 +1986,12 @@ async function runFeature(opts: {
       diagnostics,
     };
   } finally {
+    // Defense in depth: if neither the success nor the error path emitted a
+    // probe.exit (an unexpected control-flow gap), emit it here so probe.exit
+    // fires EXACTLY ONCE per feature on every path.
+    if (!cvdiagExited) {
+      cvdiagExit(abortSignal.aborted ? "timeout" : "err");
+    }
     if (page) {
       try {
         await page.close();
@@ -1800,6 +2007,33 @@ async function runFeature(opts: {
       }
     }
   }
+}
+
+/**
+ * Parse a CVDIAG failure classifier out of a conversation-runner error string.
+ * `waitForTurnComplete` rejections embed a `reason=<classifier>` breadcrumb in
+ * the thrown message (e.g. `turn 0 failed: reason=dom-missing — ...`). When the
+ * breadcrumb names one of the canonical flap classifiers, return it so the
+ * `probe.exit` row carries the authoritative reason instead of the session's
+ * best-effort derivation. Returns `undefined` for any message without a
+ * recognizable breadcrumb (the session then derives from its own signals).
+ *
+ * Validates against the shared `FAILURE_CLASSIFIER_SET` (derived from the
+ * schema's canonical `CVDIAG_FAILURE_CLASSIFIERS`) — never a hand-maintained
+ * subset — so a newly-added classifier (e.g. `selector-mismatch`) can never be
+ * silently dropped here and mislabeled by the derived classifier.
+ */
+export function parseFailureClassifier(
+  error: string | undefined,
+): CvdiagFailureClassifier | undefined {
+  if (typeof error !== "string") return undefined;
+  const m = /reason=(\S+)/.exec(error);
+  if (!m) return undefined;
+  // Strip trailing punctuation the breadcrumb may carry (e.g. `reason=dom-missing,`).
+  const reason = m[1]!.replace(/[.,;:)\]]+$/, "");
+  return FAILURE_CLASSIFIER_SET.has(reason as CvdiagFailureClassifier)
+    ? (reason as CvdiagFailureClassifier)
+    : undefined;
 }
 
 /**


### PR DESCRIPTION
## What
Completes the cvdiag flap-observability instrument so **d5/d6/e2e probe runs are readable from `cvdiag_events`** — previously only the d4 driver emitted probe-layer rows, leaving the d5/d6 path (where the dashboard flaps live) a blind spot.

- Extract `CvdiagProbeSession` (+ event shapes, constants, `turnCompleteReason`) from `d4-chat-roundtrip.ts` into shared `cvdiag/probe-session.ts`; d4 re-imports (behavior-preserving).
- Wire `CvdiagProbeSession` into `d6-all-pills.ts::runFeature`: emit `probe.start/navigate.complete/message.send/firstToken` + an exactly-once guarded `probe.exit` carrying `terminal_outcome` + `failure_classifier`, and close the probe↔backend `test_id` join (X-Test-Id already injected).
- Thread `cvdiagPbWriter` through `orchestrator.ts` (fleet worker) + `cli/runner.ts` (`--live`) so probe events persist to `cvdiag_events`.

## Why
The d5/d6 probe path emitted **zero `probe.exit` rows** (verified: 2 days of cvdiag retention = 100% `d4-`, zero d5), so a flapping d5 cell (e.g. `dom-missing` reds) could not be diagnosed from staging data. This closes that gap.

## Verification
- Local red-green on the real surface (`langgraph-typescript --d5`): `probe.exit` rows **0 → 38** (terminal_outcome + failure_classifier populated).
- Full harness suite: **3167/3167 passing**; tsc/oxlint/oxfmt/build clean.

## Code review (2-round cr-loop, 7 agents/round, converged + Procedure 3 clean)
- **A1** — `messageSend` char-count ran unguarded in the probe path; a non-string input could throw and red a green probe. Fixed: computation moved inside the `if (cvdiag)` guard + non-string coerced. (red-green)
- **A2** — `parseFailureClassifier` used a stale hardcoded 4-member allow-list omitting `selector-mismatch`; reconciled both membership checks to the canonical `FAILURE_CLASSIFIER_SET` (derived from `CVDIAG_FAILURE_CLASSIFIERS`). (red-green)

## Follow-ups (not in this PR)
- `--headed` CLI launcher lacks the `goto`-wrap that installs the SSE interceptor, so cvdiag (newly wired into `--headed`) mislabels `failure_classifier` there; the supported fleet/`--direct` path is correct. (dev-path quality)
- d6 feature-concurrency: 4 concurrent features share `test_id` `d6-<slug>-<runId>`; per-feature reads work via `demo=featureType`, but the §5 sequence_num join + replay buffer would benefit from per-feature keying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)