### PR TITLE
fix(showcase): standalone promote services (no deps, never gated) — flag docs

### DIFF
--- a/showcase/scripts/__tests__/promote-fleet.bats
+++ b/showcase/scripts/__tests__/promote-fleet.bats
@@ -781,3 +781,54 @@ STUB
   [[ "$output" != *"svc-empty= "* && "$output" != *"svc-empty="$'\n'* ]] \
     || fail "garbage empty-rc entry (svc-empty=) leaked into summary: $output"
 }
+
+# --- NEW: standalone services (`s:` tier marker) -----------------------------
+# A standalone service is promoted UNGATED: it is attempted regardless of any
+# other service's failure (never NOT-ATTEMPTED on an unrelated failure), and its
+# own failure fails the run WITHOUT gating the tiered services.
+
+@test "U4: a standalone (s:) service is promoted even when an unrelated tier-1 service fails" {
+  setup_tier_stub
+  # tier-1 svc-fail fails (gating tier-2 svc-i1 as usual). The standalone
+  # svc-docs (s:) must STILL be attempted and must land in succeeded_csv.
+  run env CLOSURE_PLAN="s:svc-docs,0:svc-a,1:svc-fail,2:svc-i1" bash "$SCRIPT"
+
+  # Standalone attempted DESPITE the unrelated tier-1 failure.
+  [[ "$output" == *"STUB called for: svc-docs"* ]] \
+    || fail "standalone svc-docs must be attempted despite the tier-1 failure: $output"
+  # Normal tier gating is unchanged: tier-2 svc-i1 is still gated.
+  [[ "$output" != *"STUB called for: svc-i1"* ]] \
+    || fail "tier-2 svc-i1 should still be gated by the tier-1 failure: $output"
+  # The run still fails (svc-fail genuinely failed)...
+  [ "$status" -ne 0 ] || fail "expected non-zero exit (svc-fail failed), got $status: $output"
+  # ...but the standalone promoted successfully and is NOT in NOT-ATTEMPTED.
+  run cat "$GITHUB_OUTPUT"
+  [[ "$output" == *"svc-docs"* ]] || fail "standalone svc-docs should be in succeeded_csv: $output"
+}
+
+@test "U4: a standalone (s:) service's OWN failure fails the run but does NOT gate the tiers" {
+  setup_tier_stub
+  # The standalone svc-fail fails. Because a standalone neither gates nor is
+  # gated, EVERY tier must still be attempted, and the run exits non-zero.
+  run env CLOSURE_PLAN="s:svc-fail,0:svc-a,1:svc-h,2:svc-i1" bash "$SCRIPT"
+
+  [[ "$output" == *"STUB called for: svc-fail"* ]] || fail "standalone svc-fail not attempted: $output"
+  # All tiers STILL attempted — the standalone failure must not gate them.
+  [[ "$output" == *"STUB called for: svc-a"* ]] || fail "tier-0 svc-a gated by standalone failure: $output"
+  [[ "$output" == *"STUB called for: svc-h"* ]] || fail "tier-1 svc-h gated by standalone failure: $output"
+  [[ "$output" == *"STUB called for: svc-i1"* ]] || fail "tier-2 svc-i1 gated by standalone failure: $output"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit (standalone svc-fail failed), got $status: $output"
+  # The tiered services were NOT recorded NOT-ATTEMPTED.
+  [[ "$output" != *"NOT-ATTEMPTED"* ]] || fail "a standalone failure must not gate (NOT-ATTEMPTED) any tier: $output"
+}
+
+@test "U4: an all-green plan with a standalone (s:) member promotes everything" {
+  setup_tier_stub
+  run env CLOSURE_PLAN="s:svc-docs,0:svc-a,1:svc-h,2:svc-i1" bash "$SCRIPT"
+  [ "$status" -eq 0 ] || fail "expected exit 0 for an all-green plan, got $status: $output"
+  for s in svc-docs svc-a svc-h svc-i1; do
+    [[ "$output" == *"STUB called for: $s"* ]] || fail "$s not attempted: $output"
+  done
+  run cat "$GITHUB_OUTPUT"
+  [[ "$output" == *"svc-docs"* ]] || fail "standalone svc-docs should be in succeeded_csv: $output"
+}

--- a/showcase/scripts/__tests__/resolve-promote-targets.bats
+++ b/showcase/scripts/__tests__/resolve-promote-targets.bats
@@ -181,3 +181,79 @@ run_resolve() {
   [[ "$output" == *"0:aimock"* ]] || fail "closure_plan missing tier-annotated tier-0 entry: $output"
   [[ "$output" == *"2:agent-a"* ]] || fail "closure_plan missing tier-annotated tier-2 entry: $output"
 }
+
+# --- NEW: standalone services (no deps, never gated) -------------------------
+# A standalone leaf (e.g. `docs`) depends on nothing and gates on nothing: a
+# request for ONLY standalone services must resolve to a closure of just those
+# services (NO Tier-1 control plane pulled in), and each standalone member is
+# emitted with the `s:` marker so the fleet driver promotes it ungated.
+
+# Fixture variant: the normal tier-gated fleet PLUS a standalone leaf `docs`.
+_gen_with_standalone() {
+  cat > "$GENERATED" <<'JSON'
+{
+  "closure": {
+    "services": [
+      { "name": "aimock", "tier": 0 },
+      { "name": "harness", "tier": 1 },
+      { "name": "dashboard", "tier": 1 },
+      { "name": "agent-a", "tier": 2 },
+      { "name": "docs", "tier": 2, "standalone": true }
+    ],
+    "skipped": []
+  },
+  "services": [
+    { "name": "aimock", "dispatchName": "showcase-aimock", "probe": { "prod": true }, "promoteTier": 0 },
+    { "name": "harness", "dispatchName": "showcase-harness", "probe": { "prod": true }, "promoteTier": 1 },
+    { "name": "dashboard", "dispatchName": "shell-dashboard", "probe": { "prod": true }, "promoteTier": 1 },
+    { "name": "agent-a", "dispatchName": "a", "probe": { "prod": true }, "promoteTier": 2, "runtimeDeps": ["aimock"] },
+    { "name": "docs", "dispatchName": "shell-docs", "probe": { "prod": true }, "promoteTier": 2, "standalone": true }
+  ]
+}
+JSON
+}
+
+@test "standalone-only request resolves to a closure of JUST itself (no Tier-1 pulled in)" {
+  _gen_with_standalone
+  run_resolve "docs"
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status: $output"
+  run grep '^closure_csv=' "$GITHUB_OUTPUT"
+  [ "$output" = "closure_csv=docs" ] \
+    || fail "standalone closure must be docs ONLY (no harness/dashboard): $output"
+}
+
+@test "standalone request resolves via dispatch_name (shell-docs) too" {
+  _gen_with_standalone
+  run_resolve "shell-docs"
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status: $output"
+  run grep '^closure_csv=' "$GITHUB_OUTPUT"
+  [ "$output" = "closure_csv=docs" ] \
+    || fail "shell-docs must resolve to a docs-only closure: $output"
+}
+
+@test "standalone member is emitted with the s: marker in closure_plan" {
+  _gen_with_standalone
+  run_resolve "docs"
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status: $output"
+  run grep '^closure_plan=' "$GITHUB_OUTPUT"
+  [ "$output" = "closure_plan=s:docs" ] \
+    || fail "standalone must emit the s:docs marker (not a numeric tier): $output"
+}
+
+@test "a normal request still pulls Tier-1 and excludes the unrelated standalone leaf" {
+  _gen_with_standalone
+  run_resolve "agent-a"
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status: $output"
+  run grep '^closure_csv=' "$GITHUB_OUTPUT"
+  [[ "$output" == *"harness"* ]] || fail "non-standalone request must still pull Tier-1 harness: $output"
+  [[ "$output" != *"docs"* ]] || fail "agent-a closure must NOT include the unrelated standalone docs: $output"
+}
+
+@test "all closure_plan marks the standalone member s: and keeps the rest tier-annotated" {
+  _gen_with_standalone
+  run_resolve "all"
+  [ "$status" -eq 0 ] || fail "expected exit 0, got $status: $output"
+  run grep '^closure_plan=' "$GITHUB_OUTPUT"
+  [[ "$output" == *"s:docs"* ]] || fail "all plan must mark docs standalone (s:docs): $output"
+  [[ "$output" == *"1:harness"* ]] || fail "all plan must keep harness tier-annotated: $output"
+}

--- a/showcase/scripts/emit-railway-envs-json.ts
+++ b/showcase/scripts/emit-railway-envs-json.ts
@@ -82,6 +82,11 @@ interface Emitted {
     // Cross-service env-var references the Stage-2 Ruby preflight (U5)
     // ASSERTS. OMITTED when the SSOT entry declares none.
     serviceRefs?: { key: string; target: string }[];
+    // Standalone leaf (no deps, never gated). OMITTED unless true so normal
+    // tier-gated services keep the frozen shape. Read by the resolve-targets jq
+    // (closure: skip Tier-1 union for an all-standalone request) + the fleet
+    // driver (promote ungated, never NOT-ATTEMPTED on an unrelated failure).
+    standalone?: boolean;
   }>;
   // --- Top-level promote-closure plan (ADDITIVE, U2). The tier-ordered
   // closure for the FULL fleet (`all`), computed via `computePromoteClosure`.
@@ -168,6 +173,8 @@ function projectServiceToLegacyJson(
     ...(entry.serviceRefs !== undefined
       ? { serviceRefs: entry.serviceRefs }
       : {}),
+    // Standalone leaf: emitted only when true (keeps the leaf default shape).
+    ...(entry.standalone === true ? { standalone: true } : {}),
   };
 }
 

--- a/showcase/scripts/promote-fleet.sh
+++ b/showcase/scripts/promote-fleet.sh
@@ -315,11 +315,13 @@ if [ -n "${CLOSURE_PLAN:-}" ]; then
   tier0=()
   tier1=()
   tier2=()
+  standalone_svcs=()   # `s:`-marked services: promoted UNGATED (never gate / gated)
   IFS=',' read -ra PLAN_TOKENS <<< "$CLOSURE_PLAN"
   for tok in "${PLAN_TOKENS[@]}"; do
     tok="$(trim "$tok")"
     [ -n "$tok" ] || continue
-    # Split `tier:name`; the tier is the part before the FIRST colon.
+    # Split `tier:name`; the tier is the part before the FIRST colon. A
+    # standalone service carries the `s` marker instead of a numeric tier.
     tier="${tok%%:*}"
     svc="$(trim "${tok#*:}")"
     [ -n "$svc" ] || continue
@@ -327,8 +329,9 @@ if [ -n "${CLOSURE_PLAN:-}" ]; then
       0) tier0+=("$svc") ;;
       1) tier1+=("$svc") ;;
       2) tier2+=("$svc") ;;
+      s) standalone_svcs+=("$svc") ;;
       *)
-        echo "::error::promote-fleet: CLOSURE_PLAN token '$tok' has an unknown tier '$tier' (expected 0, 1, or 2)." >&2
+        echo "::error::promote-fleet: CLOSURE_PLAN token '$tok' has an unknown tier '$tier' (expected 0, 1, 2, or s)." >&2
         exit 1
         ;;
     esac
@@ -339,6 +342,13 @@ if [ -n "${CLOSURE_PLAN:-}" ]; then
   # under `set -u` on bash 3.2 (an empty tier expands to a single empty arg,
   # which promote_tier skips via promote_one's no-op on "" — see below).
   gated=0
+  tier_had_failure=0
+  # Standalone services FIRST and ALWAYS ungated. Their failures still land in
+  # failed[] (so the run exits non-zero), but we deliberately do NOT fold their
+  # tier_had_failure into `gated`: a standalone leaf neither gates a dependent
+  # nor is gated by an unrelated failure. The reset below ensures a standalone
+  # failure cannot leak into tier 0's gating decision.
+  promote_tier 0 "${standalone_svcs[@]:-}"
   tier_had_failure=0
   promote_tier "$gated" "${tier0[@]:-}"
   [ "$tier_had_failure" -ne 0 ] && gated=1

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -73,7 +73,8 @@
         "prod": true,
         "driver": "docs"
       },
-      "promoteTier": 2
+      "promoteTier": 2,
+      "standalone": true
     },
     {
       "name": "dojo",
@@ -1065,7 +1066,8 @@
       },
       {
         "name": "docs",
-        "tier": 2
+        "tier": 2,
+        "standalone": true
       },
       {
         "name": "dojo",

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -1116,6 +1116,37 @@ describe("computePromoteClosure", () => {
     expect(a).toEqual(b);
     expect(JSON.stringify(SERVICES)).toBe(before);
   });
+
+  // --- Standalone services (no deps, never gated) -------------------------
+  it("a standalone-only request (docs) promotes ONLY itself — no Tier-1 control plane", () => {
+    const plan = computePromoteClosure(["docs"]);
+    const names = plan.services.map((s) => s.name);
+    // The whole point: requesting docs must NOT drag in harness/dashboard.
+    expect(names).toEqual(["docs"]);
+    expect(names).not.toContain("harness");
+    expect(names).not.toContain("dashboard");
+    expect(plan.services.find((s) => s.name === "docs")?.standalone).toBe(true);
+  });
+
+  it("resolves the standalone leaf via dispatch_name (shell-docs) too", () => {
+    const plan = computePromoteClosure(["shell-docs"]);
+    expect(plan.services.map((s) => s.name)).toEqual(["docs"]);
+  });
+
+  it("the full-fleet (all) closure marks docs standalone AND still pulls Tier-1 for the rest", () => {
+    const plan = computePromoteClosure(Object.keys(SERVICES));
+    expect(plan.services.find((s) => s.name === "docs")?.standalone).toBe(true);
+    // The non-standalone fleet still gets the Tier-1 control plane.
+    expect(plan.services.map((s) => s.name)).toContain("harness");
+  });
+
+  it("a mixed request (standalone + normal) still pulls in Tier-1", () => {
+    const plan = computePromoteClosure(["docs", "langgraph-python"]);
+    const names = plan.services.map((s) => s.name);
+    expect(names).toContain("harness"); // forced by the non-standalone member
+    expect(names).toContain("docs");
+    expect(plan.services.find((s) => s.name === "docs")?.standalone).toBe(true);
+  });
 });
 
 describe("starter-* fleet SSOT entries (S1: promote-closure inclusion)", () => {

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -257,6 +257,19 @@ export interface ServiceEntry {
    */
   promoteTier?: 0 | 1 | 2;
   /**
+   * STANDALONE service: a leaf that neither depends on anything nor gates on
+   * anything. When set, `computePromoteClosure` (and the resolve-promote-targets
+   * jq mirror) (a) do NOT pull the always-on Tier-1 verification set into a
+   * promote whose REQUESTED set is entirely standalone — so promoting it alone
+   * promotes ONLY itself, not the whole control plane — and (b) the promote
+   * fleet runner attempts it UNGATED and never records it NOT-ATTEMPTED because
+   * an unrelated service failed. Use for self-contained services with no runtime
+   * dependency on the equivalence control plane (e.g. the `docs` shell). A
+   * standalone service must therefore declare no `runtimeDeps`. OPTIONAL;
+   * omitted = false (the normal tier-gated leaf).
+   */
+  standalone?: boolean;
+  /**
    * SSOT keys this service needs PRESENT-AND-CURRENT in the target env for
    * its own promote to be meaningful — the transitive runtime dependencies
    * `computePromoteClosure` pulls into the promote closure. Distinct from
@@ -401,6 +414,12 @@ export const SERVICES: Record<
     gateValidated: true,
     dispatchName: "shell-docs",
     probeDriver: "docs",
+    // Standalone: the docs shell is self-contained — it has no runtime
+    // dependency on the equivalence control plane, so a `docs` promote must
+    // promote ONLY docs (never drag in the Tier-1 harness/aimock set) and must
+    // never be gated by an unrelated service's failure (e.g. a harness P6
+    // env-divergence WARN-refusal must not block docs).
+    standalone: true,
     // Railway service name is `docs`; GHCR repo is `showcase-shell-docs`.
     environments: {
       prod: {
@@ -1682,6 +1701,12 @@ export interface ClosureMember {
   name: string;
   /** Promote tier (0 infra → 1 verification → 2 leaf). */
   tier: 0 | 1 | 2;
+  /**
+   * Standalone service (see {@link ClosureEntry.standalone}): promoted ungated
+   * and never pulls the Tier-1 verification set into its own closure. Only set
+   * (to `true`) on standalone members so the emitted JSON stays minimal.
+   */
+  standalone?: boolean;
 }
 
 /** A member excluded from the promotable set, with an explicit reason. */
@@ -1718,6 +1743,7 @@ type ClosureEntry = {
   runtimeDeps?: string[];
   imageOf?: string;
   gateIgnore?: boolean;
+  standalone?: boolean;
   environments?: Record<string, unknown>;
 };
 
@@ -1774,10 +1800,22 @@ export function computePromoteClosure(
     closure.add(resolveKey(raw));
   }
 
-  // 2) ALWAYS include the full Tier-1 verification set (the control plane +
-  //    dashboard the post-promote re-sweep / equivalence read run against).
-  for (const [key, entry] of Object.entries(services)) {
-    if (tierOf(entry) === 1) closure.add(key);
+  // A promote whose REQUESTED set is ENTIRELY standalone services pulls in NO
+  // Tier-1 verification set: a standalone leaf (e.g. `docs`) is self-contained
+  // and depends on nothing, so promoting it alone must promote ONLY itself, not
+  // the whole control plane. A mixed or `all` request still forces Tier-1 below.
+  const requestedKeys = [...closure];
+  const allStandalone =
+    requestedKeys.length > 0 &&
+    requestedKeys.every((k) => services[k]?.standalone === true);
+
+  // 2) Include the full Tier-1 verification set (the control plane + dashboard
+  //    the post-promote re-sweep / equivalence read run against) — UNLESS the
+  //    request is entirely standalone (a standalone leaf needs no control plane).
+  if (!allStandalone) {
+    for (const [key, entry] of Object.entries(services)) {
+      if (tierOf(entry) === 1) closure.add(key);
+    }
   }
 
   // 3) Transitive runtimeDeps closure (BFS). Every dep must be a real key —
@@ -1822,7 +1860,11 @@ export function computePromoteClosure(
       });
       continue;
     }
-    promotable.push({ name: key, tier: tierOf(entry) });
+    promotable.push({
+      name: key,
+      tier: tierOf(entry),
+      ...(entry.standalone === true ? { standalone: true } : {}),
+    });
   }
 
   // Tier-ordered (0→1→2), stable within a tier on insertion order.

--- a/showcase/scripts/resolve-promote-targets.sh
+++ b/showcase/scripts/resolve-promote-targets.sh
@@ -142,16 +142,22 @@ CLOSURE_PLAN_JSON=$(jq -n \
   | ($ordered | map({ key: .name, value: .tier }) | from_entries) as $tierOf
   # name -> runtimeDeps[] from the per-service entries.
   | ($g.services | map({ key: .name, value: (.runtimeDeps // []) }) | from_entries) as $depsOf
+  # name -> standalone? from the per-service entries (mirrors railway-envs.ts
+  # computePromoteClosure). A standalone leaf depends on nothing and gates on
+  # nothing.
+  | ($g.services | map({ key: .name, value: (.standalone // false) }) | from_entries) as $standaloneOf
   # ALL Tier-1 verification services are always part of an equivalence-gated
-  # promote closure (§4.2).
+  # promote closure (§4.2) — UNLESS the request is ENTIRELY standalone services,
+  # in which case the closure is just the requested leaf (no control plane).
   | ($ordered | map(select(.tier == 1) | .name)) as $tier1
+  | (($requested | length) > 0 and ($requested | all(. as $r | $standaloneOf[$r] == true))) as $allStandalone
   # Transitive runtimeDeps walk over the requested set (bounded; the dep graph is
   # shallow — tier-2 -> tier-0/1, tier-1 -> tier-0).
   | def expand(seed):
       reduce range(0; 8) as $_ (seed;
         (. + ([ .[] | ($depsOf[.] // []) ] | add // [])) | unique
       );
-    expand(($requested + $tier1))
+    expand(if $allStandalone then $requested else ($requested + $tier1) end)
   # name -> position in the authoritative closure ordering. We build this as an
   # explicit map rather than using index(name): the jq index builtin on an array
   # of strings does a SUBSEQUENCE search when the argument is a string (e.g.
@@ -164,13 +170,16 @@ CLOSURE_PLAN_JSON=$(jq -n \
   | map(select($tierOf[.] != null))
   | unique
   | sort_by([ $tierOf[.], $posOf[.] ])
-  | map({ name: ., tier: $tierOf[.] })
+  | map({ name: ., tier: $tierOf[.], standalone: ($standaloneOf[.] == true) })
 ')
 
 # closure_csv — tier-ordered SSOT-name CSV.
 CLOSURE_CSV=$(printf '%s' "$CLOSURE_PLAN_JSON" | jq -r 'map(.name) | join(",")')
 # closure_plan — tier-annotated `tier:name` CSV for U4's tier-ordered gating.
-CLOSURE_PLAN=$(printf '%s' "$CLOSURE_PLAN_JSON" | jq -r 'map("\(.tier):\(.name)") | join(",")')
+# A standalone member is emitted with the `s:` marker instead of its numeric
+# tier, so the fleet driver promotes it UNGATED (never gated by, and never
+# gating, another service).
+CLOSURE_PLAN=$(printf '%s' "$CLOSURE_PLAN_JSON" | jq -r 'map(if .standalone then "s:\(.name)" else "\(.tier):\(.name)" end) | join(",")')
 
 # Defense in depth: an empty closure means the SSOT closure block is broken (the
 # requested set always self-includes, and Tier-1 is always present). Fail loud


### PR DESCRIPTION
## Problem

A `shell-docs` promote (live run [27990607860](https://github.com/CopilotKit/CopilotKit/actions/runs/27990607860)) failed even though docs itself was healthy. Requesting `docs` expands the promote **dependency closure** to include the always-on Tier-1 verification set:

```
CLOSURE_PLAN: 0:pocketbase,1:dashboard,1:harness,2:docs
```

`harness` then tripped a **P6 env-divergence WARN-refusal** (`only-in-staging BROWSER_POOL_*`, `only-in-prod NODE_ENV`) and the tier barrier gated `docs` as **NOT-ATTEMPTED**. docs has no runtime dependency on the control plane, so it should never have been coupled to harness.

## Fix

Introduce a declarative **`standalone`** service class — a leaf that **neither depends on anything nor gates on anything** — and flag `docs`:

- **`computePromoteClosure` (railway-envs.ts)** and the **resolve-promote-targets jq mirror** skip the Tier-1 union when the requested set is *entirely* standalone, so a standalone request promotes **only itself** (a mixed / `all` request still forces Tier-1 for the rest).
- Standalone closure members are emitted with an **`s:` plan marker**; **promote-fleet.sh** promotes `s:` services **ungated** — always attempted (never NOT-ATTEMPTED on an unrelated failure), and their own failure fails the run **without** gating the tiers.
- The tier-gating model is unchanged for every non-standalone service.

Net effect: `service=shell-docs` now resolves to a closure of just `docs` (no harness), and docs is never gated in an `all` run.

## Red → Green (real surfaces)

Against `origin/main` (pre-fix) the new tests fail with the exact bug; after the fix they pass:

| suite | RED (origin/main) | GREEN (this PR) |
|---|---|---|
| `railway-envs.test.ts` (computePromoteClosure) | 4 fail — `docs` closure pulls in `harness`/`dashboard`; `.standalone` undefined | 103 pass |
| `resolve-promote-targets.bats` | 4 fail — `closure_csv=harness,dashboard,docs`; `closure_plan=1:harness,1:dashboard,2:docs` | 17 pass |
| `promote-fleet.bats` | 3 fail — `CLOSURE_PLAN token 's:svc-docs' has an unknown tier 's'` | 30 pass |

Other gates: `shellcheck --severity=warning` clean (both scripts); `emit-railway-envs-json.ts --check` → up to date; `tsc -p scripts/tsconfig.json` clean for the changed files.

## Note

Prod `docs` was unblocked out-of-band via a direct `bin/railway promote docs` (single-service, no closure) while this lands; the #team-showcase success notification was posted manually. This PR fixes the *workflow* path so the manual route is no longer needed.