### PR TITLE
Route research canvas frontend tool calls

### DIFF
--- a/examples/v1/research-canvas/agents/typescript/src/agent.ts
+++ b/examples/v1/research-canvas/agents/typescript/src/agent.ts
@@ -3,7 +3,7 @@
  * It defines the workflow graph and the entry point for the agent.
  */
 
-import { AIMessage, ToolMessage } from "@langchain/core/messages";
+import { AIMessage } from "@langchain/core/messages";
 import { StateGraph, END } from "@langchain/langgraph";
 import { MemorySaver } from "@langchain/langgraph";
 import { AgentState, AgentStateAnnotation } from "./state";
@@ -36,32 +36,27 @@ export const graph = workflow.compile({
 
 function route(state: AgentState) {
   const messages = state.messages || [];
+  const lastMessage = messages[messages.length - 1];
 
   if (
-    messages.length > 0 &&
-    messages[messages.length - 1].constructor.name === "AIMessageChunk"
+    lastMessage &&
+    ["AIMessage", "AIMessageChunk"].includes(lastMessage.constructor.name)
   ) {
-    const aiMessage = messages[messages.length - 1] as AIMessage;
+    const aiMessage = lastMessage as AIMessage;
+    const toolName = aiMessage.tool_calls?.[0]?.name;
 
-    if (
-      aiMessage.tool_calls &&
-      aiMessage.tool_calls.length > 0 &&
-      aiMessage.tool_calls[0].name === "Search"
-    ) {
+    if (toolName === "Search") {
       return "search_node";
-    } else if (
-      aiMessage.tool_calls &&
-      aiMessage.tool_calls.length > 0 &&
-      aiMessage.tool_calls[0].name === "DeleteResources"
-    ) {
+    } else if (toolName === "DeleteResources") {
       return "delete_node";
+    } else if (toolName) {
+      return "chat_node";
     }
   }
-  if (
-    messages.length > 0 &&
-    messages[messages.length - 1].constructor.name === "ToolMessage"
-  ) {
+
+  if (lastMessage && lastMessage.constructor.name === "ToolMessage") {
     return "chat_node";
   }
+
   return END;
 }


### PR DESCRIPTION
## Summary
Fixes #5607 .

The TypeScript research-canvas graph was ending whenever the model emitted a tool call that was not `Search` or `DeleteResources`. That meant frontend/state tools such as `WriteReport` and `WriteResearchQuestion` could be dropped before the agent handled them.

## Changes
- Extract the first AI tool call name once in the router.
- Keep existing routing for `Search` and `DeleteResources`.
- Route any other tool call back through `chat_node` so write/frontend tool calls are handled instead of falling through to `END`.

## Testing
- `git diff --check`
- TypeScript transpile/syntax check for `agent.ts`
