### PR TITLE
fix(core): preserve runtime agent instance across re-connection

### DIFF
--- a/packages/core/src/__tests__/agent-registry-preserve-instance.test.ts
+++ b/packages/core/src/__tests__/agent-registry-preserve-instance.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CopilotKitCore } from "../core";
+import { waitForCondition } from "./test-utils";
+
+/**
+ * Regression: a second `updateRuntimeConnection` (triggered by an `/info`
+ * re-settle or a config/transport change while the runtime URL is unchanged)
+ * MUST preserve the already-registered runtime agent instance — its identity,
+ * its accumulated `messages`, and its `threadId`.
+ *
+ * Before the fix, `updateRuntimeConnection` unconditionally rebuilt the
+ * `remoteAgents` map with a fresh `ProxiedCopilotRuntimeAgent` for every id,
+ * discarding the live instance. On the showcase auth demo (lazy `<CopilotKit>`
+ * mount + `headers {}→{Authorization}` in one batch), this rebuild landed
+ * after run-1 had rendered the assistant message, so the `use-agent` memo
+ * re-handed `CopilotChat` a NEW empty instance → the assistant bubble
+ * disappeared → `assistantMsgCount=0` → `dom-missing` flap (~21%).
+ */
+describe("CopilotKitCore runtime re-connection preserves agent instance", () => {
+  const originalFetch = global.fetch;
+  const originalWindow = (global as unknown as { window?: unknown }).window;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    (global as unknown as { window?: unknown }).window = {};
+  });
+
+  afterEach(() => {
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      delete (global as typeof globalThis & { fetch?: typeof fetch }).fetch;
+    }
+    if (originalWindow === undefined) {
+      delete (global as unknown as { window?: unknown }).window;
+    } else {
+      (global as unknown as { window?: unknown }).window = originalWindow;
+    }
+  });
+
+  it("reuses the existing remote agent instance and preserves its messages/threadId across re-connection", async () => {
+    const runtimeUrl = "https://runtime.example";
+    const info = {
+      version: "1.0.0",
+      agents: { default: { description: "assistant", capabilities: {} } },
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue(info),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    // Initial connect (explicit REST transport → deterministic, no auto-detect).
+    const core = new CopilotKitCore({ runtimeUrl, runtimeTransport: "rest" });
+    await waitForCondition(() => core.getAgent("default") !== undefined);
+
+    const firstInstance = core.getAgent("default")!;
+
+    // Simulate run-1: the agent accumulates an assistant message + a threadId,
+    // exactly as it would after the first conversation turn renders.
+    const assistantMessage = {
+      id: "assistant-1",
+      role: "assistant" as const,
+      content: "Hello from run-1",
+    };
+    firstInstance.setMessages([assistantMessage]);
+    firstInstance.threadId = "thread-run-1";
+
+    // Trigger a SECOND updateRuntimeConnection with the runtime URL unchanged —
+    // the way an /info re-settle / config change re-runs it. Changing the
+    // requested transport mode is the public-API path that re-runs the
+    // connection without tearing down the runtime URL.
+    core.setRuntimeTransport("single");
+    await waitForCondition(() => fetchMock.mock.calls.length >= 2);
+    // Let the rebuild settle.
+    await new Promise((r) => setTimeout(r, 30));
+
+    const secondInstance = core.getAgent("default")!;
+
+    // Identity preserved — the SAME live instance, not a fresh empty one.
+    expect(secondInstance).toBe(firstInstance);
+
+    // Messages + threadId preserved.
+    expect(secondInstance.messages).toHaveLength(1);
+    expect(secondInstance.messages[0]?.id).toBe("assistant-1");
+    expect(secondInstance.threadId).toBe("thread-run-1");
+  });
+});

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -400,6 +400,27 @@ export class AgentRegistry {
       const agents: Record<string, AbstractAgent> = Object.fromEntries(
         Object.entries(runtimeInfo.agents).map(
           ([id, { description, capabilities }]) => {
+            // Reuse the already-registered instance for ids that are still
+            // present. A re-connection (an /info re-settle, a header/config or
+            // transport change) re-runs this method, but the runtime agent for
+            // a given id is the SAME logical agent — minting a fresh instance
+            // would discard its accumulated `messages`/`threadId` and its live
+            // subscriptions. Downstream (e.g. the `use-agent` memo) keys on the
+            // instance identity returned by `getAgent(id)`, so replacing it
+            // unmounts an already-rendered conversation. Only re-apply what the
+            // registry owns (headers + credentials) in place; the proxy
+            // re-resolves its own runtime mode/intelligence via `/info`.
+            const existing = Object.prototype.hasOwnProperty.call(
+              this.remoteAgents,
+              id,
+            )
+              ? this.remoteAgents[id]
+              : undefined;
+            if (existing instanceof ProxiedCopilotRuntimeAgent) {
+              this.applyHeadersToAgent(existing);
+              this.applyCredentialsToAgent(existing);
+              return [id, existing];
+            }
             const agent = new ProxiedCopilotRuntimeAgent({
               runtimeUrl: this.runtimeUrl,
               agentId: id, // Runtime agents always have their ID set correctly
@@ -417,6 +438,9 @@ export class AgentRegistry {
         ),
       );
 
+      // Reassign the full set: ids present in `runtimeInfo.agents` are carried
+      // over (reused or freshly minted above); ids no longer advertised are
+      // dropped because they are absent from this rebuilt map.
       this.remoteAgents = agents;
       this._agents = { ...this.localAgents, ...this.remoteAgents };
       this._runtimeConnectionStatus =


### PR DESCRIPTION
## Problem (real product bug, not a test artifact)
A CopilotKit v2 app that **lazily mounts `<CopilotKit>` and/or changes `headers` while a run is starting** can lose its first assistant message: the assistant turn streams in, the run finishes, but the chat shows nothing (welcome screen never clears, no bubble). Surfaced as the showcase `auth` demo flapping `dom-missing` (~21% on staging; SSE finished + HTTP 200 + `assistantMsgCount=0`).

## Root cause (triple-confirmed: live data + source trace + ~100% local repro)
`AgentRegistry.updateRuntimeConnection()` rebuilds `remoteAgents` by constructing **brand-new `ProxiedCopilotRuntimeAgent` instances** for every advertised id and wholesale-replacing the map on **every `/info` handshake / reconnect / header change**. When that re-connection resolves *while a run is in flight* (e.g. sign-in mounts `<CopilotKit>`, its `/info` lands ~300ms before/around the first turn), the run streams into the **old (now orphaned) instance** while `useAgent(id)` re-binds the UI to the **new empty instance** → the rendered conversation is dropped. The page-side run counter still increments (it counted the orphaned run), so nothing else notices. It's a timing race, hence intermittent.

## Fix
In `updateRuntimeConnection()`'s rebuild loop: **reuse the already-registered instance** for an id that is still advertised (re-applying only registry-owned headers + credentials in place), instead of minting a new one. New ids still get a fresh instance; ids no longer advertised are still dropped; the disconnect/no-runtime and Error paths are unchanged (they still clear). This preserves the in-flight run's `messages`/`threadId`/subscriptions and the UI binding across re-connection — for every app, not just the showcase.

## Verification (red-green on the real registry)
- New test `agent-registry-preserve-instance.test.ts` drives the real `CopilotKitCore`/`AgentRegistry`: connect → mutate the live instance (messages + threadId) → trigger a 2nd `updateRuntimeConnection` → assert `getAgent(id)` is the **same instance** with state preserved.
  - **RED** on `main`: instance replaced, `messages:[]`, fresh threadId.
  - **GREEN** with fix.
- `@copilotkit/core` full suite: **447/447 pass**; `nx build @copilotkit/core` clean; react-core v2 `use-agent` tests 6/6.

## Blast radius
`packages/core` (CopilotKitCore) — affects every v2 app. Surgical (+24 lines), but core: please review the reconcile semantics. Real-surface confirmation (showcase `auth` flap-rate → ~0 post-deploy) follows the harness/core redeploy.

## Not in this PR
The separate `subagents`/`gen-ui-agent` 60s-timeout flap has a different signature (`assistantMsgCount>0` — messages *did* render) and a distinct cause; tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)