### PR TITLE
fix(react-core): resolve renderAndWaitForResponse silent completion on abandonment

### DIFF
--- a/packages/react-core/src/v2/hooks/__tests__/use-human-in-the-loop.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-human-in-the-loop.e2e.test.tsx
@@ -1410,19 +1410,15 @@ describe("HITL Thread Reconnection Bug", () => {
       toggleRemount();
     });
 
-    // After remount, should STILL see executing status
-    // This is the key assertion: executingToolCallIds survives component remounts
-    // because it's tracked at the CopilotKitProvider level
+    // After remount, the unmount should have rejected the promise (abandonment),
+    // so the status becomes Complete (with an error result under the hood)
     await waitFor(() => {
       expect(screen.getByTestId("remount-status").textContent).toBe(
-        ToolCallStatus.Executing,
-      );
-      expect(screen.getByTestId("remount-action").textContent).toBe(
-        "test-action",
+        ToolCallStatus.Complete,
       );
     });
 
-    // The respond button should be present (status is executing)
-    expect(screen.getByTestId("remount-respond")).toBeDefined();
+    // The respond button should not be present (status is complete)
+    expect(screen.queryByTestId("remount-respond")).toBeNull();
   });
 });

--- a/packages/react-core/src/v2/hooks/use-human-in-the-loop.tsx
+++ b/packages/react-core/src/v2/hooks/use-human-in-the-loop.tsx
@@ -12,19 +12,51 @@ export function useHumanInTheLoop<
 >(tool: ReactHumanInTheLoop<T>, deps?: ReadonlyArray<unknown>) {
   const { copilotkit } = useCopilotKit();
   const resolvePromiseRef = useRef<((result: unknown) => void) | null>(null);
+  const rejectPromiseRef = useRef<((error: unknown) => void) | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const respond = useCallback(async (result: unknown) => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
     if (resolvePromiseRef.current) {
       resolvePromiseRef.current(result);
       resolvePromiseRef.current = null;
+      rejectPromiseRef.current = null;
     }
   }, []);
 
-  const handler = useCallback(async () => {
-    return new Promise((resolve) => {
-      resolvePromiseRef.current = resolve;
-    });
-  }, []);
+  const handler = useCallback(
+    async (args: any, options?: { signal?: AbortSignal }) => {
+      return new Promise((resolve, reject) => {
+        resolvePromiseRef.current = resolve;
+        rejectPromiseRef.current = reject;
+
+        if (options?.signal) {
+          const onAbort = () => {
+            if (timeoutRef.current) clearTimeout(timeoutRef.current);
+            if (rejectPromiseRef.current) {
+              rejectPromiseRef.current(new Error("Action aborted by user"));
+              resolvePromiseRef.current = null;
+              rejectPromiseRef.current = null;
+            }
+          };
+          options.signal.addEventListener("abort", onAbort);
+        }
+
+        if (tool.timeout) {
+          timeoutRef.current = setTimeout(() => {
+            if (rejectPromiseRef.current) {
+              rejectPromiseRef.current(
+                new Error(`Action timed out after ${tool.timeout}ms`),
+              );
+              resolvePromiseRef.current = null;
+              rejectPromiseRef.current = null;
+            }
+          }, tool.timeout);
+        }
+      });
+    },
+    [tool.timeout],
+  );
 
   const RenderComponent: ReactToolCallRenderer<T>["render"] = useCallback(
     (props) => {
@@ -86,6 +118,12 @@ export function useHumanInTheLoop<
   // since they can't respond to user interactions anymore
   useEffect(() => {
     return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      if (rejectPromiseRef.current) {
+        rejectPromiseRef.current(new Error("User abandoned the interaction"));
+        resolvePromiseRef.current = null;
+        rejectPromiseRef.current = null;
+      }
       copilotkit.removeHookRenderToolCall(tool.name, tool.agentId);
     };
   }, [copilotkit, tool.name, tool.agentId]);

--- a/packages/react-core/src/v2/types/human-in-the-loop.ts
+++ b/packages/react-core/src/v2/types/human-in-the-loop.ts
@@ -5,6 +5,11 @@ export type ReactHumanInTheLoop<
   T extends Record<string, unknown> = Record<string, unknown>,
 > = Omit<FrontendTool<T>, "handler"> & {
   /**
+   * Optional timeout in milliseconds. If the user does not respond within this time,
+   * the tool call will automatically fail with a timeout error.
+   */
+  timeout?: number;
+  /**
    * Render the human-in-the-loop UI for this tool call.
    *
    * Beyond the tool call's `args`/`status`/`result`, the render props carry


### PR DESCRIPTION
## What does this PR do?

Resolves a bug where `renderAndWaitForResponse` silently completes with an empty result when the user abandons the form/interaction (e.g., closing the tab or navigating away). 

Changes introduced:
- **Component Unmount Signal**: `useHumanInTheLoop` now explicitly rejects its pending promise if the component unmounts, generating an "abandonment" error which is propagated properly to the backend.
- **Backend AbortSignal Integration**: The tool handler now listens to the global `RunHandler` `AbortSignal` and rejects the promise if the agent explicitly aborts the run.
- **Configurable Timeouts**: Added a new optional `timeout` configuration property to `ReactHumanInTheLoop` options, allowing forms to automatically time out and reject the promise if the user fails to respond within a given timeframe.
- **Updated Tests**: Updated the execution context persistence E2E tests in `use-human-in-the-loop.e2e.test.tsx` to align with the new expectation that unmounting the component aborts the pending tool call.

## Related PRs and Issues

- Fixes #5554

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)