### PR TITLE
fix(examples): route stack analyzer through end node

### DIFF
--- a/examples/canvas/gemini/agent/stack_agent.py
+++ b/examples/canvas/gemini/agent/stack_agent.py
@@ -510,7 +510,7 @@ workflow.add_node("analyze", analyze_with_gemini_node)
 workflow.add_node("end", end_node)
 workflow.add_edge(START, "gather_context")
 workflow.add_edge("gather_context", "analyze")
-workflow.add_edge("analyze", END)
+workflow.add_edge("analyze", "end")
 workflow.set_entry_point("gather_context")
 workflow.set_finish_point("end")
 


### PR DESCRIPTION
## What does this PR do?

Routes the Gemini canvas stack analyzer through its registered `end` node instead of directly to LangGraph's `END` sentinel.

This keeps the workflow wiring consistent with `workflow.set_finish_point("end")` and ensures the cleanup/final state emission in `end_node` is reachable.

## Related PRs and Issues

- Fixes #5605

## Tests

- `python3.12 -m py_compile examples/canvas/gemini/agent/stack_agent.py`
- `python3.12 - <<'PY' ... PY` (AST check that `workflow.add_edge("analyze", "end")` exists and `workflow.add_edge("analyze", END)` does not)
- `. /tmp/oss-pr-pipeline/langgraph-venv/bin/activate && python - <<'PY' ... PY` (LangGraph topology reproduction asserts `analyze -> end -> __end__` and that `end_node` runs)
- `. /tmp/oss-pr-pipeline/langgraph-venv/bin/activate && python - <<'PY' ... PY` (imports `stack_agent.py` with CopilotKit/Gemini stubs and asserts compiled `stack_analysis_graph` edges include `analyze -> end` and not `analyze -> __end__`)
- `git diff --check`

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation (not applicable: example graph wiring bug fix)
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)
