### PR TITLE
feat(showcase): wire dynamic A2UI declarative-gen-ui for strands + strands-typescript

### DIFF
--- a/showcase/aimock/d6/strands-typescript/gen-ui-declarative.json
+++ b/showcase/aimock/d6/strands-typescript/gen-ui-declarative.json
@@ -1,121 +1,189 @@
 {
-  "_meta": {
-    "description": "D6 fixtures for strands / gen-ui-declarative",
-    "sourceFile": "d5-gen-ui-declarative.ts",
-    "created": "2026-05-22"
+ "_meta": {
+  "description": "D6 fixtures for strands-typescript / gen-ui-declarative (A2UI Dynamic Schema)",
+  "_note": "Strands port of langgraph-python's gen-ui-declarative.json. Same two-stage A2UI flow: (1) outer agent emits a no-arg generate_a2ui toolcall [match userMessage+context]; (2) the Strands adapter (runtime injectA2UITool:true) drives a secondary render_a2ui planner [match userMessage+toolName=render_a2ui] that emits the flat A2UI components targeting catalog declarative-gen-ui-catalog; (3) outer agent narrates [match toolCallId]. context=strands-typescript.",
+  "created": "2026-06-11"
+ },
+ "fixtures": [
+  {
+   "_comment": "pill sales-dashboard hero \u2014 inner secondary LLM (middleware-injected render_a2ui) emits the flat A2UI components.",
+   "match": {
+    "userMessage": "Show me my sales dashboard for this quarter.",
+    "toolName": "render_a2ui"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_dash_design_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"sales-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"kpi-row\",\"charts-row\"]},{\"id\":\"kpi-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-revenue\",\"metric-new-customers\",\"metric-win-rate\",\"metric-deal-size\"]},{\"id\":\"metric-revenue\",\"component\":\"Metric\",\"label\":\"Quarterly Revenue\",\"value\":\"$4.2M\",\"trend\":\"up\",\"trendValue\":\"+12% QoQ\"},{\"id\":\"metric-new-customers\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"186\",\"trend\":\"up\",\"trendValue\":\"+8%\"},{\"id\":\"metric-win-rate\",\"component\":\"Metric\",\"label\":\"Win Rate\",\"value\":\"31%\",\"trend\":\"down\",\"trendValue\":\"-2 pts\"},{\"id\":\"metric-deal-size\",\"component\":\"Metric\",\"label\":\"Avg Deal Size\",\"value\":\"$22.6k\",\"trend\":\"up\",\"trendValue\":\"+5%\"},{\"id\":\"charts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"region-pie\",\"monthly-bar\"]},{\"id\":\"region-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by Region\",\"description\":\"Quarter revenue split across North America, EMEA, APAC, and LATAM.\",\"data\":[{\"label\":\"North America\",\"value\":1900000},{\"label\":\"EMEA\",\"value\":1300000},{\"label\":\"APAC\",\"value\":720000},{\"label\":\"LATAM\",\"value\":280000}]},{\"id\":\"monthly-bar\",\"component\":\"BarChart\",\"title\":\"Monthly Revenue\",\"description\":\"Revenue trend from Jan through Jun.\",\"data\":[{\"label\":\"Jan\",\"value\":1210000},{\"label\":\"Feb\",\"value\":1340000},{\"label\":\"Mar\",\"value\":1650000},{\"label\":\"Apr\",\"value\":1380000},{\"label\":\"May\",\"value\":1420000},{\"label\":\"Jun\",\"value\":1400000}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
   },
-  "fixtures": [
-    {
-      "_comment": "gen-ui-declarative kpi-dashboard pill — emit render_a2ui tool call with Card + Metric components. hasToolResult:false ensures this fires on the first leg only.",
-      "match": {
-        "userMessage": "KPI dashboard with 3-4 metrics",
-        "hasToolResult": false,
-        "context": "strands-typescript"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_declarative_kpi_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"Card\",\"props\":{\"title\":\"KPI Dashboard\",\"data-testid\":\"declarative-card\"}},{\"type\":\"Metric\",\"props\":{\"label\":\"Revenue\",\"value\":\"$1.2M\",\"change\":\"+15%\",\"data-testid\":\"declarative-metric\"}},{\"type\":\"Metric\",\"props\":{\"label\":\"Signups\",\"value\":\"3,421\",\"change\":\"+8%\",\"data-testid\":\"declarative-metric\"}},{\"type\":\"Metric\",\"props\":{\"label\":\"Churn\",\"value\":\"2.1%\",\"change\":\"-0.3%\",\"data-testid\":\"declarative-metric\"}}]}"
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative kpi-dashboard pill — follow-up after render_a2ui returns.",
-      "match": {
-        "userMessage": "KPI dashboard with 3-4 metrics",
-        "toolCallId": "call_d6_declarative_kpi_001",
-        "context": "strands-typescript"
-      },
-      "response": {
-        "content": "KPI dashboard rendered above with revenue, signups, and churn metrics."
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative pie-chart pill — emit render_a2ui with PieChart component.",
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "hasToolResult": false,
-        "context": "strands-typescript"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_declarative_pie_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"PieChart\",\"props\":{\"title\":\"Sales by Region\",\"data\":[{\"label\":\"North America\",\"value\":45},{\"label\":\"Europe\",\"value\":30},{\"label\":\"Asia Pacific\",\"value\":20},{\"label\":\"Other\",\"value\":5}],\"data-testid\":\"declarative-pie-chart\"}}]}"
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative pie-chart pill — follow-up.",
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "toolCallId": "call_d6_declarative_pie_001",
-        "context": "strands-typescript"
-      },
-      "response": {
-        "content": "Pie chart rendered — North America leads at 45%, followed by Europe at 30%."
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative bar-chart pill — emit render_a2ui with BarChart component.",
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "hasToolResult": false,
-        "context": "strands-typescript"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_declarative_bar_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"BarChart\",\"props\":{\"title\":\"Quarterly Revenue\",\"data\":[{\"label\":\"Q1\",\"value\":280000},{\"label\":\"Q2\",\"value\":320000},{\"label\":\"Q3\",\"value\":350000},{\"label\":\"Q4\",\"value\":410000}],\"data-testid\":\"declarative-bar-chart\"}}]}"
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative bar-chart pill — follow-up.",
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "toolCallId": "call_d6_declarative_bar_001",
-        "context": "strands-typescript"
-      },
-      "response": {
-        "content": "Bar chart rendered — revenue grew steadily from $280K in Q1 to $410K in Q4."
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative status-report pill — emit render_a2ui with StatusBadge components.",
-      "match": {
-        "userMessage": "status report on system health",
-        "hasToolResult": false,
-        "context": "strands-typescript"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_declarative_status_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"StatusBadge\",\"props\":{\"label\":\"API\",\"status\":\"healthy\",\"data-testid\":\"declarative-status-badge\"}},{\"type\":\"StatusBadge\",\"props\":{\"label\":\"Database\",\"status\":\"healthy\",\"data-testid\":\"declarative-status-badge\"}},{\"type\":\"StatusBadge\",\"props\":{\"label\":\"Background Workers\",\"status\":\"degraded\",\"data-testid\":\"declarative-status-badge\"}}]}"
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative status-report pill — follow-up.",
-      "match": {
-        "userMessage": "status report on system health",
-        "toolCallId": "call_d6_declarative_status_001",
-        "context": "strands-typescript"
-      },
-      "response": {
-        "content": "System health report rendered — API and Database are healthy, Background Workers showing degraded status."
-      }
-    }
-  ]
+  {
+   "_comment": "pill sales-dashboard hero \u2014 outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "strands-typescript",
+    "toolCallId": "call_d6_decl_dash_outer_001"
+   },
+   "response": {
+    "content": "Here's your Q2 sales dashboard."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill sales-dashboard hero \u2014 outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "Show me my sales dashboard for this quarter.",
+    "context": "strands-typescript"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_dash_outer_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill team-performance \u2014 inner secondary LLM (middleware-injected render_a2ui) emits the flat A2UI components.",
+   "match": {
+    "userMessage": "How are our sales reps performing against quota?",
+    "toolName": "render_a2ui"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_team_design_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"rep-quota-performance\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"title\",\"summary\",\"content\"]},{\"id\":\"title\",\"component\":\"Text\",\"text\":\"Sales rep performance vs quota\"},{\"id\":\"summary\",\"component\":\"Text\",\"text\":\"2 of 5 reps are above quota, 1 is near plan, and 2 are below target in Q2.\"},{\"id\":\"content\",\"component\":\"Row\",\"gap\":16,\"children\":[\"table-card\",\"attainment-chart\"]},{\"id\":\"table-card\",\"component\":\"Card\",\"title\":\"Rep attainment table\",\"child\":\"rep-table\"},{\"id\":\"rep-table\",\"component\":\"DataTable\",\"columns\":[{\"key\":\"rep\",\"label\":\"Rep\"},{\"key\":\"attainment\",\"label\":\"Attainment\"},{\"key\":\"pipeline\",\"label\":\"Pipeline\"}],\"rows\":[{\"rep\":\"Dana Whitfield\",\"attainment\":\"124%\",\"pipeline\":\"Leading team; biggest account Meridian Apparel Group has 4 open opps worth $210k\"},{\"rep\":\"Marcus Lee\",\"attainment\":\"108%\",\"pipeline\":\"Above plan\"},{\"rep\":\"Priya Sharma\",\"attainment\":\"97%\",\"pipeline\":\"Near quota\"},{\"rep\":\"Tom Okafor\",\"attainment\":\"88%\",\"pipeline\":\"Below plan\"},{\"rep\":\"Elena Vasquez\",\"attainment\":\"71%\",\"pipeline\":\"Furthest from quota\"}]},{\"id\":\"attainment-chart\",\"component\":\"BarChart\",\"title\":\"Quota attainment by rep\",\"description\":\"Q2 quota attainment percentages for all sales reps.\",\"data\":[{\"label\":\"Dana Whitfield\",\"value\":124},{\"label\":\"Marcus Lee\",\"value\":108},{\"label\":\"Priya Sharma\",\"value\":97},{\"label\":\"Tom Okafor\",\"value\":88},{\"label\":\"Elena Vasquez\",\"value\":71}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill team-performance \u2014 outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "strands-typescript",
+    "toolCallId": "call_d6_decl_team_outer_001"
+   },
+   "response": {
+    "content": "Here's how the team is tracking against quota."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill team-performance \u2014 outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "How are our sales reps performing against quota?",
+    "context": "strands-typescript"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_team_outer_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill at-risk \u2014 inner secondary LLM (middleware-injected render_a2ui) emits the flat A2UI components.",
+   "match": {
+    "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
+    "toolName": "render_a2ui"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_risk_design_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"risk-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"metrics-row\",\"accounts-row\"]},{\"id\":\"metrics-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-arr\",\"metric-accounts\",\"metric-biggest\"]},{\"id\":\"metric-arr\",\"component\":\"Metric\",\"label\":\"ARR at risk\",\"value\":\"$615k\",\"trend\":\"down\",\"trendValue\":\"3 accounts\"},{\"id\":\"metric-accounts\",\"component\":\"Metric\",\"label\":\"Accounts at risk\",\"value\":\"3\",\"trend\":\"neutral\",\"trendValue\":\"This quarter\"},{\"id\":\"metric-biggest\",\"component\":\"Metric\",\"label\":\"Biggest exposure\",\"value\":\"Northwind Retail\",\"trend\":\"down\",\"trendValue\":\"$340k renewal\"},{\"id\":\"accounts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"card-northwind\",\"card-cascadia\",\"card-atlas\"]},{\"id\":\"card-northwind\",\"component\":\"Card\",\"title\":\"Northwind Retail\",\"subtitle\":\"$340k ARR at stake\",\"child\":\"northwind-content\"},{\"id\":\"northwind-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"northwind-badge\",\"northwind-text\"]},{\"id\":\"northwind-badge\",\"component\":\"StatusBadge\",\"text\":\"High severity\",\"variant\":\"error\"},{\"id\":\"northwind-text\",\"component\":\"Text\",\"text\":\"No contact in 6 weeks; next action: exec outreach this week to protect the renewal.\"},{\"id\":\"card-cascadia\",\"component\":\"Card\",\"title\":\"Cascadia Outfitters\",\"subtitle\":\"$180k ARR at stake\",\"child\":\"cascadia-content\"},{\"id\":\"cascadia-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"cascadia-badge\",\"cascadia-text\"]},{\"id\":\"cascadia-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"cascadia-text\",\"component\":\"Text\",\"text\":\"Champion left; next action: rebuild stakeholder map and secure a new sponsor.\"},{\"id\":\"card-atlas\",\"component\":\"Card\",\"title\":\"Atlas Goods\",\"subtitle\":\"$95k ARR at stake\",\"child\":\"atlas-content\"},{\"id\":\"atlas-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"atlas-badge\",\"atlas-text\"]},{\"id\":\"atlas-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"atlas-text\",\"component\":\"Text\",\"text\":\"Legal review is stalled; next action: align procurement and legal on open terms.\"}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill at-risk \u2014 outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "strands-typescript",
+    "toolCallId": "call_d6_decl_risk_outer_001"
+   },
+   "response": {
+    "content": "Three accounts need attention this quarter."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill at-risk \u2014 outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
+    "context": "strands-typescript"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_risk_outer_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill top-account \u2014 inner secondary LLM (middleware-injected render_a2ui) emits the flat A2UI components.",
+   "match": {
+    "userMessage": "Pull up the details on our biggest account.",
+    "toolName": "render_a2ui"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_acct_design_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"biggest-account-details\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Row\",\"gap\":16,\"children\":[\"account-card\",\"revenue-pie\"]},{\"id\":\"account-card\",\"component\":\"Card\",\"title\":\"Meridian Apparel Group\",\"subtitle\":\"Biggest account\",\"child\":\"account-facts\"},{\"id\":\"account-facts\",\"component\":\"Column\",\"gap\":8,\"children\":[\"fact1\",\"fact2\",\"fact3\",\"fact4\",\"fact5\",\"fact6\",\"fact7\"]},{\"id\":\"fact1\",\"component\":\"InfoRow\",\"label\":\"Owner\",\"value\":\"Dana Whitfield\"},{\"id\":\"fact2\",\"component\":\"InfoRow\",\"label\":\"Region\",\"value\":\"North America\"},{\"id\":\"fact3\",\"component\":\"InfoRow\",\"label\":\"ARR\",\"value\":\"$612k\"},{\"id\":\"fact4\",\"component\":\"InfoRow\",\"label\":\"Renewal date\",\"value\":\"Sep 30\"},{\"id\":\"fact5\",\"component\":\"InfoRow\",\"label\":\"Last contact\",\"value\":\"3 days ago\"},{\"id\":\"fact6\",\"component\":\"InfoRow\",\"label\":\"Health\",\"value\":\"Green\"},{\"id\":\"fact7\",\"component\":\"InfoRow\",\"label\":\"Open opportunities\",\"value\":\"4 opportunities worth $210k\"},{\"id\":\"revenue-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by product line\",\"description\":\"Meridian Apparel Group revenue mix across product lines.\",\"data\":[{\"label\":\"Outerwear\",\"value\":260000},{\"label\":\"Footwear\",\"value\":180000},{\"label\":\"Accessories\",\"value\":112000},{\"label\":\"Custom\",\"value\":60000}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill top-account \u2014 outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "strands-typescript",
+    "toolCallId": "call_d6_decl_acct_outer_001"
+   },
+   "response": {
+    "content": "Here's the rundown on Meridian Apparel Group."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill top-account \u2014 outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "Pull up the details on our biggest account.",
+    "context": "strands-typescript"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_acct_outer_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  }
+ ]
 }

--- a/showcase/aimock/d6/strands/gen-ui-declarative.json
+++ b/showcase/aimock/d6/strands/gen-ui-declarative.json
@@ -1,121 +1,189 @@
 {
-  "_meta": {
-    "description": "D6 fixtures for strands / gen-ui-declarative",
-    "sourceFile": "d5-gen-ui-declarative.ts",
-    "created": "2026-05-22"
+ "_meta": {
+  "description": "D6 fixtures for strands / gen-ui-declarative (A2UI Dynamic Schema)",
+  "_note": "Strands port of langgraph-python's gen-ui-declarative.json. Same two-stage A2UI flow: (1) outer agent emits a no-arg generate_a2ui toolcall [match userMessage+context]; (2) the Strands adapter (runtime injectA2UITool:true) drives a secondary render_a2ui planner [match userMessage+toolName=render_a2ui] that emits the flat A2UI components targeting catalog declarative-gen-ui-catalog; (3) outer agent narrates [match toolCallId]. context=strands.",
+  "created": "2026-06-11"
+ },
+ "fixtures": [
+  {
+   "_comment": "pill sales-dashboard hero \u2014 inner secondary LLM (middleware-injected render_a2ui) emits the flat A2UI components.",
+   "match": {
+    "userMessage": "Show me my sales dashboard for this quarter.",
+    "toolName": "render_a2ui"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_dash_design_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"sales-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"kpi-row\",\"charts-row\"]},{\"id\":\"kpi-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-revenue\",\"metric-new-customers\",\"metric-win-rate\",\"metric-deal-size\"]},{\"id\":\"metric-revenue\",\"component\":\"Metric\",\"label\":\"Quarterly Revenue\",\"value\":\"$4.2M\",\"trend\":\"up\",\"trendValue\":\"+12% QoQ\"},{\"id\":\"metric-new-customers\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"186\",\"trend\":\"up\",\"trendValue\":\"+8%\"},{\"id\":\"metric-win-rate\",\"component\":\"Metric\",\"label\":\"Win Rate\",\"value\":\"31%\",\"trend\":\"down\",\"trendValue\":\"-2 pts\"},{\"id\":\"metric-deal-size\",\"component\":\"Metric\",\"label\":\"Avg Deal Size\",\"value\":\"$22.6k\",\"trend\":\"up\",\"trendValue\":\"+5%\"},{\"id\":\"charts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"region-pie\",\"monthly-bar\"]},{\"id\":\"region-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by Region\",\"description\":\"Quarter revenue split across North America, EMEA, APAC, and LATAM.\",\"data\":[{\"label\":\"North America\",\"value\":1900000},{\"label\":\"EMEA\",\"value\":1300000},{\"label\":\"APAC\",\"value\":720000},{\"label\":\"LATAM\",\"value\":280000}]},{\"id\":\"monthly-bar\",\"component\":\"BarChart\",\"title\":\"Monthly Revenue\",\"description\":\"Revenue trend from Jan through Jun.\",\"data\":[{\"label\":\"Jan\",\"value\":1210000},{\"label\":\"Feb\",\"value\":1340000},{\"label\":\"Mar\",\"value\":1650000},{\"label\":\"Apr\",\"value\":1380000},{\"label\":\"May\",\"value\":1420000},{\"label\":\"Jun\",\"value\":1400000}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
   },
-  "fixtures": [
-    {
-      "_comment": "gen-ui-declarative kpi-dashboard pill — emit render_a2ui tool call with Card + Metric components. hasToolResult:false ensures this fires on the first leg only.",
-      "match": {
-        "userMessage": "KPI dashboard with 3-4 metrics",
-        "hasToolResult": false,
-        "context": "strands"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_declarative_kpi_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"Card\",\"props\":{\"title\":\"KPI Dashboard\",\"data-testid\":\"declarative-card\"}},{\"type\":\"Metric\",\"props\":{\"label\":\"Revenue\",\"value\":\"$1.2M\",\"change\":\"+15%\",\"data-testid\":\"declarative-metric\"}},{\"type\":\"Metric\",\"props\":{\"label\":\"Signups\",\"value\":\"3,421\",\"change\":\"+8%\",\"data-testid\":\"declarative-metric\"}},{\"type\":\"Metric\",\"props\":{\"label\":\"Churn\",\"value\":\"2.1%\",\"change\":\"-0.3%\",\"data-testid\":\"declarative-metric\"}}]}"
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative kpi-dashboard pill — follow-up after render_a2ui returns.",
-      "match": {
-        "userMessage": "KPI dashboard with 3-4 metrics",
-        "toolCallId": "call_d6_declarative_kpi_001",
-        "context": "strands"
-      },
-      "response": {
-        "content": "KPI dashboard rendered above with revenue, signups, and churn metrics."
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative pie-chart pill — emit render_a2ui with PieChart component.",
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "hasToolResult": false,
-        "context": "strands"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_declarative_pie_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"PieChart\",\"props\":{\"title\":\"Sales by Region\",\"data\":[{\"label\":\"North America\",\"value\":45},{\"label\":\"Europe\",\"value\":30},{\"label\":\"Asia Pacific\",\"value\":20},{\"label\":\"Other\",\"value\":5}],\"data-testid\":\"declarative-pie-chart\"}}]}"
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative pie-chart pill — follow-up.",
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "toolCallId": "call_d6_declarative_pie_001",
-        "context": "strands"
-      },
-      "response": {
-        "content": "Pie chart rendered — North America leads at 45%, followed by Europe at 30%."
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative bar-chart pill — emit render_a2ui with BarChart component.",
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "hasToolResult": false,
-        "context": "strands"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_declarative_bar_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"BarChart\",\"props\":{\"title\":\"Quarterly Revenue\",\"data\":[{\"label\":\"Q1\",\"value\":280000},{\"label\":\"Q2\",\"value\":320000},{\"label\":\"Q3\",\"value\":350000},{\"label\":\"Q4\",\"value\":410000}],\"data-testid\":\"declarative-bar-chart\"}}]}"
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative bar-chart pill — follow-up.",
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "toolCallId": "call_d6_declarative_bar_001",
-        "context": "strands"
-      },
-      "response": {
-        "content": "Bar chart rendered — revenue grew steadily from $280K in Q1 to $410K in Q4."
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative status-report pill — emit render_a2ui with StatusBadge components.",
-      "match": {
-        "userMessage": "status report on system health",
-        "hasToolResult": false,
-        "context": "strands"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_declarative_status_001",
-            "name": "render_a2ui",
-            "arguments": "{\"components\":[{\"type\":\"StatusBadge\",\"props\":{\"label\":\"API\",\"status\":\"healthy\",\"data-testid\":\"declarative-status-badge\"}},{\"type\":\"StatusBadge\",\"props\":{\"label\":\"Database\",\"status\":\"healthy\",\"data-testid\":\"declarative-status-badge\"}},{\"type\":\"StatusBadge\",\"props\":{\"label\":\"Background Workers\",\"status\":\"degraded\",\"data-testid\":\"declarative-status-badge\"}}]}"
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "gen-ui-declarative status-report pill — follow-up.",
-      "match": {
-        "userMessage": "status report on system health",
-        "toolCallId": "call_d6_declarative_status_001",
-        "context": "strands"
-      },
-      "response": {
-        "content": "System health report rendered — API and Database are healthy, Background Workers showing degraded status."
-      }
-    }
-  ]
+  {
+   "_comment": "pill sales-dashboard hero \u2014 outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "strands",
+    "toolCallId": "call_d6_decl_dash_outer_001"
+   },
+   "response": {
+    "content": "Here's your Q2 sales dashboard."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill sales-dashboard hero \u2014 outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "Show me my sales dashboard for this quarter.",
+    "context": "strands"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_dash_outer_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill team-performance \u2014 inner secondary LLM (middleware-injected render_a2ui) emits the flat A2UI components.",
+   "match": {
+    "userMessage": "How are our sales reps performing against quota?",
+    "toolName": "render_a2ui"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_team_design_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"rep-quota-performance\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"title\",\"summary\",\"content\"]},{\"id\":\"title\",\"component\":\"Text\",\"text\":\"Sales rep performance vs quota\"},{\"id\":\"summary\",\"component\":\"Text\",\"text\":\"2 of 5 reps are above quota, 1 is near plan, and 2 are below target in Q2.\"},{\"id\":\"content\",\"component\":\"Row\",\"gap\":16,\"children\":[\"table-card\",\"attainment-chart\"]},{\"id\":\"table-card\",\"component\":\"Card\",\"title\":\"Rep attainment table\",\"child\":\"rep-table\"},{\"id\":\"rep-table\",\"component\":\"DataTable\",\"columns\":[{\"key\":\"rep\",\"label\":\"Rep\"},{\"key\":\"attainment\",\"label\":\"Attainment\"},{\"key\":\"pipeline\",\"label\":\"Pipeline\"}],\"rows\":[{\"rep\":\"Dana Whitfield\",\"attainment\":\"124%\",\"pipeline\":\"Leading team; biggest account Meridian Apparel Group has 4 open opps worth $210k\"},{\"rep\":\"Marcus Lee\",\"attainment\":\"108%\",\"pipeline\":\"Above plan\"},{\"rep\":\"Priya Sharma\",\"attainment\":\"97%\",\"pipeline\":\"Near quota\"},{\"rep\":\"Tom Okafor\",\"attainment\":\"88%\",\"pipeline\":\"Below plan\"},{\"rep\":\"Elena Vasquez\",\"attainment\":\"71%\",\"pipeline\":\"Furthest from quota\"}]},{\"id\":\"attainment-chart\",\"component\":\"BarChart\",\"title\":\"Quota attainment by rep\",\"description\":\"Q2 quota attainment percentages for all sales reps.\",\"data\":[{\"label\":\"Dana Whitfield\",\"value\":124},{\"label\":\"Marcus Lee\",\"value\":108},{\"label\":\"Priya Sharma\",\"value\":97},{\"label\":\"Tom Okafor\",\"value\":88},{\"label\":\"Elena Vasquez\",\"value\":71}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill team-performance \u2014 outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "strands",
+    "toolCallId": "call_d6_decl_team_outer_001"
+   },
+   "response": {
+    "content": "Here's how the team is tracking against quota."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill team-performance \u2014 outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "How are our sales reps performing against quota?",
+    "context": "strands"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_team_outer_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill at-risk \u2014 inner secondary LLM (middleware-injected render_a2ui) emits the flat A2UI components.",
+   "match": {
+    "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
+    "toolName": "render_a2ui"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_risk_design_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"risk-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"metrics-row\",\"accounts-row\"]},{\"id\":\"metrics-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-arr\",\"metric-accounts\",\"metric-biggest\"]},{\"id\":\"metric-arr\",\"component\":\"Metric\",\"label\":\"ARR at risk\",\"value\":\"$615k\",\"trend\":\"down\",\"trendValue\":\"3 accounts\"},{\"id\":\"metric-accounts\",\"component\":\"Metric\",\"label\":\"Accounts at risk\",\"value\":\"3\",\"trend\":\"neutral\",\"trendValue\":\"This quarter\"},{\"id\":\"metric-biggest\",\"component\":\"Metric\",\"label\":\"Biggest exposure\",\"value\":\"Northwind Retail\",\"trend\":\"down\",\"trendValue\":\"$340k renewal\"},{\"id\":\"accounts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"card-northwind\",\"card-cascadia\",\"card-atlas\"]},{\"id\":\"card-northwind\",\"component\":\"Card\",\"title\":\"Northwind Retail\",\"subtitle\":\"$340k ARR at stake\",\"child\":\"northwind-content\"},{\"id\":\"northwind-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"northwind-badge\",\"northwind-text\"]},{\"id\":\"northwind-badge\",\"component\":\"StatusBadge\",\"text\":\"High severity\",\"variant\":\"error\"},{\"id\":\"northwind-text\",\"component\":\"Text\",\"text\":\"No contact in 6 weeks; next action: exec outreach this week to protect the renewal.\"},{\"id\":\"card-cascadia\",\"component\":\"Card\",\"title\":\"Cascadia Outfitters\",\"subtitle\":\"$180k ARR at stake\",\"child\":\"cascadia-content\"},{\"id\":\"cascadia-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"cascadia-badge\",\"cascadia-text\"]},{\"id\":\"cascadia-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"cascadia-text\",\"component\":\"Text\",\"text\":\"Champion left; next action: rebuild stakeholder map and secure a new sponsor.\"},{\"id\":\"card-atlas\",\"component\":\"Card\",\"title\":\"Atlas Goods\",\"subtitle\":\"$95k ARR at stake\",\"child\":\"atlas-content\"},{\"id\":\"atlas-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"atlas-badge\",\"atlas-text\"]},{\"id\":\"atlas-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"atlas-text\",\"component\":\"Text\",\"text\":\"Legal review is stalled; next action: align procurement and legal on open terms.\"}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill at-risk \u2014 outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "strands",
+    "toolCallId": "call_d6_decl_risk_outer_001"
+   },
+   "response": {
+    "content": "Three accounts need attention this quarter."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill at-risk \u2014 outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
+    "context": "strands"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_risk_outer_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill top-account \u2014 inner secondary LLM (middleware-injected render_a2ui) emits the flat A2UI components.",
+   "match": {
+    "userMessage": "Pull up the details on our biggest account.",
+    "toolName": "render_a2ui"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_acct_design_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"biggest-account-details\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Row\",\"gap\":16,\"children\":[\"account-card\",\"revenue-pie\"]},{\"id\":\"account-card\",\"component\":\"Card\",\"title\":\"Meridian Apparel Group\",\"subtitle\":\"Biggest account\",\"child\":\"account-facts\"},{\"id\":\"account-facts\",\"component\":\"Column\",\"gap\":8,\"children\":[\"fact1\",\"fact2\",\"fact3\",\"fact4\",\"fact5\",\"fact6\",\"fact7\"]},{\"id\":\"fact1\",\"component\":\"InfoRow\",\"label\":\"Owner\",\"value\":\"Dana Whitfield\"},{\"id\":\"fact2\",\"component\":\"InfoRow\",\"label\":\"Region\",\"value\":\"North America\"},{\"id\":\"fact3\",\"component\":\"InfoRow\",\"label\":\"ARR\",\"value\":\"$612k\"},{\"id\":\"fact4\",\"component\":\"InfoRow\",\"label\":\"Renewal date\",\"value\":\"Sep 30\"},{\"id\":\"fact5\",\"component\":\"InfoRow\",\"label\":\"Last contact\",\"value\":\"3 days ago\"},{\"id\":\"fact6\",\"component\":\"InfoRow\",\"label\":\"Health\",\"value\":\"Green\"},{\"id\":\"fact7\",\"component\":\"InfoRow\",\"label\":\"Open opportunities\",\"value\":\"4 opportunities worth $210k\"},{\"id\":\"revenue-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by product line\",\"description\":\"Meridian Apparel Group revenue mix across product lines.\",\"data\":[{\"label\":\"Outerwear\",\"value\":260000},{\"label\":\"Footwear\",\"value\":180000},{\"label\":\"Accessories\",\"value\":112000},{\"label\":\"Custom\",\"value\":60000}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill top-account \u2014 outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "strands",
+    "toolCallId": "call_d6_decl_acct_outer_001"
+   },
+   "response": {
+    "content": "Here's the rundown on Meridian Apparel Group."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill top-account \u2014 outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "Pull up the details on our biggest account.",
+    "context": "strands"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_acct_outer_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  }
+ ]
 }

--- a/showcase/integrations/strands-typescript/src/agent/agent.ts
+++ b/showcase/integrations/strands-typescript/src/agent/agent.ts
@@ -218,3 +218,98 @@ export async function buildA2uiFixedSchemaAgent(): Promise<StrandsAgent> {
       "A2UI surface from a fixed, pre-authored schema (direct backend tool)",
   });
 }
+
+// ---------------------------------------------------------------------------
+// A2UI Dynamic Schema (declarative-gen-ui) — adapter auto-injects generate_a2ui.
+// ---------------------------------------------------------------------------
+//
+// Unlike the fixed-schema demo (which wires a `display_flight` tool returning a
+// pre-authored envelope), the dynamic demo lets the agent *generate* the
+// surface layout on the fly. The Next.js route
+// (app/api/copilotkit-declarative-gen-ui/route.ts) sets
+// `a2ui: { injectA2UITool: true, defaultCatalogId: "declarative-gen-ui-catalog" }`;
+// the runtime forwards the flag, the Strands adapter auto-injects a
+// `generate_a2ui` tool and drives a secondary render planner. The
+// `config.a2ui` block below supplies the catalog id stamped into generated
+// surfaces and the composition guide that teaches the planner the page's
+// catalog. Mirrors the ag-ui dynamic-schema reference example.
+//
+// The compositionGuide MUST describe the catalog the page registers at
+// src/app/demos/declarative-gen-ui/a2ui/{definitions,renderers,catalog}.ts
+// (catalog id `declarative-gen-ui-catalog`): Card / StatusBadge / Metric /
+// InfoRow / PrimaryButton / PieChart / BarChart / DataTable, composed inside
+// the basic catalog's Row / Column / Text (`includeBasicCatalog: true`).
+//
+// Grounding dataset + composition rules are kept in spirit with the frontend
+// `sales-context.ts` (SALES_DATASET + COMPOSITION_RULES) the page registers via
+// `useAgentContext`. The frontend context steers the PRIMARY agent; this
+// compositionGuide is the channel the adapter feeds to the secondary
+// `render_a2ui` planner (it gets `guidelines`, not the frontend App Context),
+// so the planner is self-contained.
+
+const A2UI_DYNAMIC_CATALOG_ID = "declarative-gen-ui-catalog";
+
+const A2UI_DYNAMIC_SALES_DATASET = `Vantage Threads (fictional B2B apparel company) — Q2 sales data. Ground every visual in these numbers; invent only plausible details consistent with them.
+- Quarterly revenue: $4.2M (up 12% QoQ). New customers: 186 (up 8%). Win rate: 31% (down 2pts). Avg deal size: $22.6k (up 5%).
+- Revenue by region: North America $1.9M, EMEA $1.3M, APAC $720k, LATAM $280k.
+- Monthly revenue: Jan $1.21M, Feb $1.34M, Mar $1.65M, Apr $1.38M, May $1.42M, Jun $1.40M.
+- Reps (vs quota): Dana Whitfield 124%, Marcus Lee 108%, Priya Sharma 97%, Tom Okafor 88%, Elena Vasquez 71%.
+- At-risk: total $615k ARR across 3 accounts — Northwind Retail ($340k renewal, no contact 6 weeks; severity high), Cascadia Outfitters ($180k, champion left; severity medium), Atlas Goods ($95k, stalled legal review; severity medium).
+- Biggest account: Meridian Apparel Group — owner Dana Whitfield, region North America, ARR $612k, renewal Sep 30, last contact 3 days ago, health green, 4 open opportunities worth $210k.
+- Meridian revenue by product line: Outerwear $260k, Footwear $180k, Accessories $112k, Custom $60k.`;
+
+const A2UI_DYNAMIC_COMPOSITION_RULES = `Pick A2UI components by the shape of the question — never ask which chart the user wants:
+1. Overall snapshot / "sales dashboard" → a Column (gap 16) whose first child is a Row (gap 16) of 4 Metric tiles (each with trend + trendValue), followed by a Row with a PieChart (revenue by region) next to a BarChart (monthly revenue, all six months Jan-Jun). Do NOT wrap the dashboard in a surrounding Card — the charts carry their own card chrome. Do NOT use StatusBadge, DataTable, or InfoRow here.
+2. Rep / team performance → a Column (gap 16) with a Card containing a DataTable (columns: rep, attainment, pipeline) next to or above a BarChart of quota attainment % per rep — no StatusBadge or InfoRow.
+3. Risk / health checks → a Column (gap 16): first a Row (gap 16) of 3 Metric tiles (ARR at risk $615k trend down, accounts at risk 3, biggest exposure Northwind $340k), then a Row (gap 16) with one compact Card per at-risk account (title = account name, subtitle = ARR at stake) containing a StatusBadge (error for high severity, warning otherwise) above a one-line Text with the reason and the recommended next action — no DataTable or InfoRow.
+4. Single account/entity details → a Row (gap 16) with a Card of InfoRow facts (owner, region, ARR, renewal date, last contact) next to a PieChart of that account's revenue by product line — no DataTable or StatusBadge.
+5. Part-of-whole follow-ups → PieChart; trends or comparisons over time/categories → BarChart.
+Compose generously — a dashboard should feel like a real analytics product, not a single widget.`;
+
+const A2UI_DYNAMIC_COMPOSITION_GUIDE = `${A2UI_DYNAMIC_SALES_DATASET}\n\n${A2UI_DYNAMIC_COMPOSITION_RULES}`;
+
+// Mirrors the langgraph-python demo's a2ui_dynamic.py SYSTEM_PROMPT.
+const A2UI_DYNAMIC_SYSTEM_PROMPT =
+  "You are the embedded sales analyst for Vantage Threads, the fictional " +
+  "B2B apparel company described in your App Context. Answer every " +
+  "business question by calling `generate_a2ui` to draw a rich visual " +
+  "surface, and keep the chat reply to one short sentence.\n\n" +
+  "Ground every number in the sales dataset from App Context — never " +
+  "invent figures that contradict it. Follow the dashboard composition " +
+  "rules from App Context when choosing components: pick the component " +
+  "by the shape of the question (snapshot → composed KPI dashboard with " +
+  "charts; team performance → table; risk → status badges; single " +
+  "account → info rows; part-of-whole → pie; trend/comparison → bar). " +
+  "Never ask the user which chart they want. `generate_a2ui` takes no " +
+  "arguments and handles the rendering automatically. Compose " +
+  "generously — a dashboard should feel like a real analytics product, " +
+  "not a single widget.";
+
+/**
+ * Dedicated agent for the A2UI dynamic-schema demo. Wires NO `generate_a2ui`
+ * tool — the runtime's `injectA2UITool: true` makes the adapter auto-inject it
+ * and drive a secondary render planner to GENERATE the surface.
+ */
+export async function buildA2uiDynamicAgent(): Promise<StrandsAgent> {
+  const strandsAgent = new Agent({
+    // Chat Completions API: the Responses adapter buffers tool-call argument
+    // deltas, which would defeat A2UI's progressive surface streaming.
+    model: await createModel({ openaiApi: "chat" }),
+    systemPrompt: A2UI_DYNAMIC_SYSTEM_PROMPT,
+  });
+
+  const config: StrandsAgentConfig = {
+    a2ui: {
+      defaultCatalogId: A2UI_DYNAMIC_CATALOG_ID,
+      guidelines: { compositionGuide: A2UI_DYNAMIC_COMPOSITION_GUIDE },
+    },
+  };
+
+  return new StrandsAgent({
+    agent: strandsAgent,
+    name: "a2ui_dynamic_schema",
+    description:
+      "Dynamic A2UI surfaces generated on the fly (auto-injected tool)",
+    config,
+  });
+}

--- a/showcase/integrations/strands-typescript/src/agent/server.ts
+++ b/showcase/integrations/strands-typescript/src/agent/server.ts
@@ -22,6 +22,7 @@ import {
   buildByocHashbrownAgent,
   buildByocJsonRenderAgent,
   buildA2uiFixedSchemaAgent,
+  buildA2uiDynamicAgent,
 } from "./agent";
 
 /** Mount an agent at `path` and `path/` so trailing-slash proxies resolve. */
@@ -51,15 +52,15 @@ async function main(): Promise<void> {
   });
   addPing(app, "/ping");
 
-  const [showcase, voice, hashbrown, jsonRender, a2uiFixed] = await Promise.all(
-    [
+  const [showcase, voice, hashbrown, jsonRender, a2uiFixed, a2uiDynamic] =
+    await Promise.all([
       buildShowcaseAgent(),
       buildVoiceAgent(),
       buildByocHashbrownAgent(),
       buildByocJsonRenderAgent(),
       buildA2uiFixedSchemaAgent(),
-    ],
-  );
+      buildA2uiDynamicAgent(),
+    ]);
 
   mountAgent(app, "/voice", voice);
   mountAgent(app, "/byoc-hashbrown", hashbrown);
@@ -68,6 +69,10 @@ async function main(): Promise<void> {
   // (`display_flight`) returning an a2ui_operations envelope; the runtime
   // A2UIMiddleware paints it directly. No generate_a2ui injection.
   mountAgent(app, "/a2ui-fixed-schema", a2uiFixed);
+  // Dynamic-schema A2UI: the dedicated agent wires NO tool — the runtime's
+  // `injectA2UITool: true` makes the adapter auto-inject `generate_a2ui` and
+  // GENERATE the surface, stamped with the page's catalog id.
+  mountAgent(app, "/declarative-gen-ui", a2uiDynamic);
   // Mount the shared agent LAST at the root so the sub-path POST routes are
   // matched first by Express's route table.
   mountAgent(app, "/", showcase);

--- a/showcase/integrations/strands-typescript/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/strands-typescript/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -13,7 +13,12 @@ import { HttpAgent } from "@ag-ui/client";
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
 function createAgent() {
-  return new HttpAgent({ url: `${AGENT_URL}/` });
+  // Dedicated backend agent mounted at /declarative-gen-ui (see
+  // src/agent/server.ts). It wires NO generate_a2ui tool — the runtime's
+  // `injectA2UITool: true` below makes the Strands adapter auto-inject it and
+  // GENERATE the surface layout. Trailing slash so the sub-application's root
+  // route resolves.
+  return new HttpAgent({ url: `${AGENT_URL}/declarative-gen-ui/` });
 }
 
 const a2uiAgent = createAgent();
@@ -30,6 +35,17 @@ export const POST = async (req: NextRequest) => {
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
+        // Enable A2UI tool injection: the runtime injects a `generate_a2ui`
+        // tool and drives a secondary render planner to emit the surface ops,
+        // then the A2UIMiddleware paints them. The Strands adapter auto-injects
+        // the tool when it sees this forwarded flag. Pin the catalog the page
+        // registers so the planner doesn't fall back to the unregistered spec
+        // basic catalog ("Catalog not found"). Mirrors the langgraph-python
+        // declarative-gen-ui route.
+        a2ui: {
+          injectA2UITool: true,
+          defaultCatalogId: "declarative-gen-ui-catalog",
+        },
       }),
     });
     return await handleRequest(req);

--- a/showcase/integrations/strands-typescript/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+++ b/showcase/integrations/strands-typescript/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
@@ -16,6 +16,45 @@ import { z } from "zod";
 import type { CatalogDefinitions } from "@copilotkit/a2ui-renderer";
 
 export const myDefinitions = {
+  // Override the basic catalog's Row/Column so `gap` is honoured — the
+  // built-in versions ignore it, which makes composed dashboards cramped.
+  Row: {
+    description:
+      "Horizontal layout container. Children share the width evenly. Use `gap` (px) to space dashboard tiles.",
+    props: z.object({
+      gap: z.number().optional(),
+      // Enum mirrors the keys the renderer actually maps to CSS. Anything
+      // outside this set silently falls back at render time, so we reject
+      // it at schema-parse time to surface LLM typos early.
+      align: z
+        .enum(["start", "center", "end", "stretch", "baseline"])
+        .optional(),
+      justify: z.enum(["start", "center", "end", "spaceBetween"]).optional(),
+      children: z.array(z.string()),
+    }),
+  },
+
+  Column: {
+    description:
+      "Vertical layout container. Use `gap` (px) to space stacked sections.",
+    props: z.object({
+      gap: z.number().optional(),
+      align: z
+        .enum(["start", "center", "end", "stretch", "baseline"])
+        .optional(),
+      children: z.array(z.string()),
+    }),
+  },
+
+  // Override the basic catalog's Text so it aligns flush with sibling
+  // components (the built-in version carries an 8px outer margin).
+  Text: {
+    description: "A plain text line. Use for short explanations inside cards.",
+    props: z.object({
+      text: z.string(),
+    }),
+  },
+
   Card: {
     description:
       "A titled card container with an optional subtitle and a single child slot. Use it to group related content (metrics, rows, buttons).",
@@ -28,7 +67,7 @@ export const myDefinitions = {
 
   StatusBadge: {
     description:
-      "A small coloured pill communicating the state of something (healthy/degraded/down, online/offline, open/closed). Choose `variant` to match the intent.",
+      "A small coloured pill communicating the state of something (healthy/degraded/at-risk, on-track/behind). Choose `variant` to match the intent.",
     props: z.object({
       text: z.string(),
       variant: z.enum(["success", "warning", "error", "info"]).optional(),
@@ -37,20 +76,43 @@ export const myDefinitions = {
 
   Metric: {
     description:
-      "A key/value KPI display with an optional trend indicator. Ideal for dashboards (e.g. 'Revenue • $12.4k • up').",
+      "A key/value KPI tile with an optional trend indicator and trend delta. Ideal for dashboard KPI rows (e.g. 'Revenue • $4.2M • up 12%').",
     props: z.object({
       label: z.string(),
       value: z.string(),
       trend: z.enum(["up", "down", "neutral"]).optional(),
+      trendValue: z.string().optional(),
     }),
   },
 
   InfoRow: {
     description:
-      "A compact two-column 'label: value' row. Good for stacks of facts inside a Card (owner, region, last updated, etc.).",
+      "A compact two-column 'label: value' row. Good for stacks of facts inside a Card (owner, region, ARR, renewal date, etc.).",
     props: z.object({
       label: z.string(),
       value: z.string(),
+    }),
+  },
+
+  DataTable: {
+    description:
+      "A data table with column headers and rows. Ideal for rankings and per-person/per-item breakdowns (rep performance vs quota, deal lists). Each row's keys MUST appear in `columns[].key`; unknown row keys render as blank cells and indicate model/schema drift.",
+    // NOTE on B12 (row-keys ⊆ columns[].key): we'd normally enforce this
+    // with `z.object(...).refine(...)`, but the host catalog package's
+    // `CatalogComponentDefinition` type requires `props: ZodObject<…>`
+    // (it inspects `.shape` at runtime), and `.refine` returns a
+    // `ZodEffects` that breaks both the `satisfies CatalogDefinitions`
+    // type assertion and the runtime `.shape` access. Until the host
+    // type is broadened, we encode the constraint in the description
+    // above so the LLM sees the rule, and leave hard enforcement to
+    // the rendering pipeline (which already shows the empty cell —
+    // detection is the gap, not behaviour).
+    props: z.object({
+      columns: z.array(z.object({ key: z.string(), label: z.string() })),
+      // Cells may be strings or numbers — the renderer stringifies at
+      // render time, but accepting both lets the LLM emit raw numerics
+      // (e.g. attainment 124) instead of being forced to stringify.
+      rows: z.array(z.record(z.union([z.string(), z.number()]))),
     }),
   },
 
@@ -59,13 +121,18 @@ export const myDefinitions = {
       "A styled primary call-to-action button. Attach an optional `action` that will be dispatched back to the agent when the user clicks it.",
     props: z.object({
       label: z.string(),
-      action: z.any().optional(),
+      // The renderer hands `action` opaquely to the A2UI `dispatch` helper,
+      // which forwards it back to the agent. We don't constrain the shape
+      // (different demos use different action payloads), but `z.unknown()`
+      // is strictly better than `z.any()` here because it forces any
+      // consumer that touches the value to narrow it explicitly.
+      action: z.unknown().optional(),
     }),
   },
 
   PieChart: {
     description:
-      "A pie/donut chart with a brand-coloured legend. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for part-of-whole breakdowns (sales by region, traffic sources, portfolio allocation).",
+      "A pie/donut chart with a brand-coloured legend. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for part-of-whole breakdowns (revenue by region, pipeline by stage).",
     props: z.object({
       title: z.string(),
       description: z.string(),
@@ -80,7 +147,7 @@ export const myDefinitions = {
 
   BarChart: {
     description:
-      "A vertical bar chart built on Recharts. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for comparing series across categories (quarterly revenue, headcount by team, signups per month).",
+      "A vertical bar chart built on Recharts. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for comparing series across categories or time (monthly revenue, signups per month).",
     props: z.object({
       title: z.string(),
       description: z.string(),

--- a/showcase/integrations/strands-typescript/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/strands-typescript/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -3,215 +3,252 @@
 /**
  * A2UI catalog RENDERERS.
  *
- * React implementations for each definition in `./definitions.ts`,
- * styled with the demo's local ShadCN-flavoured primitives in
- * `../_components/`. The assembled catalog (definitions × renderers via
- * `createCatalog`) lives in `./catalog.ts`.
+ * React implementations for each definition in `./definitions.ts`. Visuals
+ * mirror beautiful-chat's sales dashboard renderers
+ * (../../beautiful-chat/declarative-generative-ui/renderers.tsx) so the two
+ * demos read as the same product family — same card chrome, metric
+ * typography, recharts donut/bar styling, and palette. The assembled catalog
+ * (definitions × renderers via `createCatalog`) lives in `./catalog.ts`.
  *
  * Reference:
  *   https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui
  */
-import React, { useRef } from "react";
+import React from "react";
 import {
+  PieChart as RechartsPieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
   BarChart as RechartsBarChart,
   Bar,
   XAxis,
   YAxis,
   Tooltip,
   CartesianGrid,
-  Cell,
-  ResponsiveContainer,
-  Rectangle,
 } from "recharts";
 import type { CatalogRenderers } from "@copilotkit/a2ui-renderer";
+import { TriangleAlert, CircleAlert, CircleCheck, Info } from "lucide-react";
 
 import type { MyDefinitions } from "./definitions";
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-} from "../_components/card";
 import { Badge } from "../_components/badge";
 import { Button } from "../_components/button";
 
-// ─── ShadCN-friendly chart palette ─────────────────────────────────────────
-// Neutral, slightly muted hues that pair with `bg-card` / `--border`
-// (zinc/slate-leaning, akin to ShadCN's chart-{1..5} palette).
-const CHART_COLORS = [
-  "#3F3F46", // zinc-700
-  "#71717A", // zinc-500
-  "#A1A1AA", // zinc-400
-  "#18181B", // zinc-900
-  "#52525B", // zinc-600
-  "#D4D4D8", // zinc-300
-  "#27272A", // zinc-800
-] as const;
-
-const CHART_TOOLTIP_STYLE: React.CSSProperties = {
-  backgroundColor: "var(--card)",
-  border: "1px solid var(--border)",
-  borderRadius: 8,
-  padding: "8px 12px",
-  color: "var(--foreground)",
-  fontSize: 12,
-  boxShadow: "0 4px 12px rgba(0,0,0,0.06)",
+// ─── Theme tokens + palette (mirrors beautiful-chat) ────────────────────────
+const c = {
+  card: "var(--card)",
+  cardFg: "var(--card-foreground)",
+  border: "var(--border)",
+  muted: "var(--muted-foreground)",
+  divider: "color-mix(in srgb, var(--border) 50%, var(--card))",
+  shadow: "0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.04)",
 };
 
-/** Custom SVG donut chart built with <circle> + stroke-dasharray. */
-function DonutChart({
-  data,
-  size = 220,
-  strokeWidth = 36,
+const CHART_COLORS = [
+  "#3b82f6", // blue-500
+  "#8b5cf6", // violet-500
+  "#ec4899", // pink-500
+  "#f59e0b", // amber-500
+  "#10b981", // emerald-500
+  "#6366f1", // indigo-500
+] as const;
+
+/** DashboardCard-style chrome shared by Card and the chart wrappers. */
+function CardShell({
+  title,
+  subtitle,
+  testid,
+  cardId,
+  children,
 }: {
-  data: { label: string; value: number }[];
-  size?: number;
-  strokeWidth?: number;
+  title: string;
+  subtitle?: string;
+  testid?: string;
+  cardId?: string;
+  children?: React.ReactNode;
 }) {
-  const radius = (size - strokeWidth) / 2;
-  const circumference = 2 * Math.PI * radius;
-  const center = size / 2;
-
-  const total = data.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
-
-  let accumulated = 0;
-  const slices = data.map((item, index) => {
-    const val = Number(item.value) || 0;
-    const ratio = total > 0 ? val / total : 0;
-    const arc = ratio * circumference;
-    const startAt = accumulated;
-    accumulated += arc;
-    return {
-      ...item,
-      arc,
-      gap: circumference - arc,
-      dashoffset: -startAt,
-      color: CHART_COLORS[index % CHART_COLORS.length],
-    };
-  });
-
   return (
-    <svg
-      width="100%"
-      viewBox={`0 0 ${size} ${size}`}
+    <div
+      data-testid={testid}
+      data-card-id={cardId}
       style={{
-        display: "block",
-        margin: "0 auto",
-        maxWidth: size,
-        transform: "scaleX(-1)",
+        background: c.card,
+        borderRadius: "12px",
+        border: `1px solid ${c.border}`,
+        padding: "20px",
+        boxShadow: c.shadow,
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px",
+        width: "100%",
+        minWidth: 0,
+        overflow: "hidden",
       }}
     >
-      <circle
-        cx={center}
-        cy={center}
-        r={radius}
-        fill="none"
-        stroke="var(--muted)"
-        strokeWidth={strokeWidth}
-      />
-      {slices.map((slice, i) => (
-        <circle
-          key={i}
-          cx={center}
-          cy={center}
-          r={radius}
-          fill="none"
-          stroke={slice.color}
-          strokeWidth={strokeWidth}
-          strokeDasharray={`${slice.arc} ${slice.gap}`}
-          strokeDashoffset={slice.dashoffset}
-          strokeLinecap="butt"
-          transform={`rotate(-90 ${center} ${center})`}
-        />
-      ))}
-    </svg>
-  );
-}
-
-/** Tracks seen indices so only NEW bars get the fade-in animation. */
-function useSeenIndices() {
-  const seen = useRef(new Set<number>());
-  return {
-    isNew(index: number) {
-      if (seen.current.has(index)) return false;
-      seen.current.add(index);
-      return true;
-    },
-  };
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function AnimatedBar(props: any) {
-  const { isNew, ...rest } = props;
-  return (
-    <g
-      style={
-        isNew
-          ? {
-              animation: "barSlideIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) both",
-            }
-          : undefined
-      }
-    >
-      <Rectangle {...rest} />
-    </g>
+      <div>
+        <div style={{ fontWeight: 600, fontSize: "0.9rem", color: c.cardFg }}>
+          {title}
+        </div>
+        {subtitle && (
+          <div
+            style={{ fontSize: "0.75rem", color: c.muted, marginTop: "2px" }}
+          >
+            {subtitle}
+          </div>
+        )}
+      </div>
+      {children}
+    </div>
   );
 }
 
 // @region[renderers-react]
 export const myRenderers: CatalogRenderers<MyDefinitions> = {
-  Card: ({ props, children }) => (
-    <Card
-      className="w-full min-w-0 overflow-hidden"
-      data-testid="declarative-card"
-    >
-      <CardHeader>
-        <CardTitle>{props.title}</CardTitle>
-        {props.subtitle && <CardDescription>{props.subtitle}</CardDescription>}
-      </CardHeader>
-      {props.child && (
-        <CardContent className="flex flex-col gap-4">
-          {children(props.child)}
-        </CardContent>
-      )}
-    </Card>
+  Row: ({ props, children }) => {
+    const justifyMap: Record<string, string> = {
+      start: "flex-start",
+      center: "center",
+      end: "flex-end",
+      spaceBetween: "space-between",
+    };
+    const items = Array.isArray(props.children) ? props.children : [];
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          gap: `${props.gap ?? 16}px`,
+          alignItems: props.align ?? "stretch",
+          justifyContent: justifyMap[props.justify ?? "start"] ?? "flex-start",
+          flexWrap: "wrap",
+          width: "100%",
+        }}
+      >
+        {items.map((id, i) => (
+          <div key={`${id}-${i}`} style={{ flex: "1 1 0", minWidth: 0 }}>
+            {children(id)}
+          </div>
+        ))}
+      </div>
+    );
+  },
+
+  Column: ({ props, children }) => {
+    const items = Array.isArray(props.children) ? props.children : [];
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: `${props.gap ?? 12}px`,
+          width: "100%",
+        }}
+      >
+        {items.map((id, i) => (
+          <React.Fragment key={`${id}-${i}`}>{children(id)}</React.Fragment>
+        ))}
+      </div>
+    );
+  },
+
+  Text: ({ props }) => (
+    <span style={{ fontSize: "0.85rem", color: c.cardFg, lineHeight: 1.5 }}>
+      {props.text}
+    </span>
   ),
 
-  StatusBadge: ({ props }) => (
-    <Badge
-      variant={props.variant ?? "info"}
-      data-testid="declarative-status-badge"
+  Card: ({ props, children }) => (
+    // `data-testid="declarative-card"` stays shared so existing e2e selectors
+    // still find every card; `data-card-id={props.title}` disambiguates
+    // sibling cards (e.g. the at-risk pill's 3 severity cards) so test
+    // assertions can target a specific card by title.
+    <CardShell
+      title={props.title}
+      subtitle={props.subtitle}
+      testid="declarative-card"
+      cardId={props.title}
     >
-      {props.text}
-    </Badge>
+      {props.child && children(props.child)}
+    </CardShell>
   ),
+
+  StatusBadge: ({ props }) => {
+    const variant = props.variant ?? "info";
+    const Icon = {
+      error: TriangleAlert,
+      warning: CircleAlert,
+      success: CircleCheck,
+      info: Info,
+    }[variant];
+    return (
+      // `alignSelf: flex-start` keeps the pill content-sized — flex parents
+      // (our Column override) default to stretch, which inflates it into a
+      // full-width banner.
+      <Badge
+        variant={variant}
+        style={{ alignSelf: "flex-start" }}
+        data-testid="declarative-status-badge"
+      >
+        <Icon size={12} strokeWidth={2.5} style={{ marginRight: 4 }} />
+        {props.text}
+      </Badge>
+    );
+  },
 
   Metric: ({ props }) => {
-    const trend = props.trend ?? "neutral";
-    const arrow = trend === "up" ? "↑" : trend === "down" ? "↓" : "";
-    const trendClass =
-      trend === "up"
-        ? "text-emerald-600"
-        : trend === "down"
-          ? "text-rose-600"
-          : "text-[var(--foreground)]";
+    const trendColors: Record<string, string> = {
+      up: "#059669",
+      down: "#dc2626",
+      neutral: c.muted,
+    };
+    const trendIcons: Record<string, string> = {
+      up: "↑",
+      down: "↓",
+      neutral: "→",
+    };
     return (
-      // `flex-1 min-w-[120px]` lets a row of Metrics distribute evenly
-      // inside the basic catalog's gap-less Row — 3 metrics in a 600px
-      // card column get ~200px each instead of squishing to content width.
       <div
         data-testid="declarative-metric"
-        className="flex flex-1 min-w-[120px] flex-col gap-1"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "4px",
+          minWidth: "120px",
+        }}
       >
-        <div className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
-          {props.label}
-        </div>
-        <div
-          className={`flex items-baseline gap-1.5 text-2xl font-semibold tabular-nums ${trendClass}`}
+        <span
+          style={{
+            fontSize: "0.75rem",
+            color: c.muted,
+            fontWeight: 500,
+            textTransform: "uppercase",
+            letterSpacing: "0.05em",
+          }}
         >
-          <span>{props.value}</span>
-          {arrow && <span className="text-base">{arrow}</span>}
+          {props.label}
+        </span>
+        <div style={{ display: "flex", alignItems: "baseline", gap: "8px" }}>
+          <span
+            style={{
+              fontSize: "1.5rem",
+              fontWeight: 700,
+              color: c.cardFg,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            {props.value}
+          </span>
+          {props.trend && (
+            <span
+              style={{
+                fontSize: "0.8rem",
+                fontWeight: 500,
+                color: trendColors[props.trend] ?? c.muted,
+              }}
+            >
+              {trendIcons[props.trend]}
+              {props.trendValue ? ` ${props.trendValue}` : ""}
+            </span>
+          )}
         </div>
       </div>
     );
@@ -221,7 +258,10 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     // Divider via `border-b last:border-b-0` so the final row doesn't dangle
     // a trailing line, regardless of whether the agent wraps these in a
     // Column or drops them directly into a Card's child slot.
-    <div className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0">
+    <div
+      data-testid="declarative-info-row"
+      className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0"
+    >
       <span className="text-sm text-[var(--muted-foreground)]">
         {props.label}
       </span>
@@ -230,6 +270,59 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
       </span>
     </div>
   ),
+
+  DataTable: ({ props }) => {
+    const cols = Array.isArray(props.columns) ? props.columns : [];
+    const rows = Array.isArray(props.rows) ? props.rows : [];
+    return (
+      <div
+        data-testid="declarative-data-table"
+        className="w-full overflow-x-auto"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  className="border-b-2 border-[var(--border)] px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => {
+              // Stable row key: prefer the first column's value (primary-key-ish),
+              // suffix with index in case values repeat, fall back to a JSON
+              // stringify of the row when columns is empty. Stable keys prevent
+              // React from re-mounting every row when the agent re-emits a
+              // slightly different table.
+              const pk = cols.length > 0 ? row[cols[0].key] : undefined;
+              const rowKey =
+                pk !== undefined ? `${pk}-${i}` : JSON.stringify(row);
+              return (
+                <tr
+                  key={rowKey}
+                  className="border-b border-[var(--border)] last:border-b-0"
+                >
+                  {cols.map((col) => (
+                    <td
+                      key={col.key}
+                      className="px-3 py-2 tabular-nums text-[var(--foreground)]"
+                    >
+                      {String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
 
   PrimaryButton: ({ props, dispatch }) => (
     <Button
@@ -242,150 +335,114 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
   ),
 
   PieChart: ({ props }) => {
-    const data = props.data ?? [];
-    const safeData = Array.isArray(data) ? data : [];
-    const total = safeData.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
-
+    // Coerce values to numbers — the LLM sometimes emits them as strings.
+    // Use a strict finite check so null/undefined/NaN/non-numeric strings are
+    // surfaced via console.warn rather than silently collapsed to 0 (which
+    // masks schema/data drift). Recharts requires a numeric value to render,
+    // so we fall back to 0 only after logging.
+    const data = (Array.isArray(props.data) ? props.data : []).map((d) => {
+      const raw = (d as { value?: unknown }).value;
+      const n = typeof raw === "number" ? raw : parseFloat(raw as string);
+      let value: number;
+      if (Number.isFinite(n)) {
+        value = n;
+      } else {
+        console.warn("Invalid chart value", {
+          component: "PieChart",
+          key: "value",
+          raw,
+        });
+        value = 0;
+      }
+      return { ...d, value };
+    });
     return (
-      // `flex-1 min-w-0` so multiple charts in a basic-catalog Row
-      // distribute the available width evenly instead of each insisting
-      // on its content size and overflowing.
-      <Card
-        className="w-full flex-1 min-w-0 overflow-hidden"
-        data-testid="declarative-pie-chart"
+      <CardShell
+        title={props.title}
+        subtitle={props.description}
+        testid="declarative-pie-chart"
       >
-        <CardHeader>
-          <CardTitle>{props.title}</CardTitle>
-          <CardDescription>{props.description}</CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          {safeData.length === 0 ? (
-            <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">
-              No data available
-            </div>
-          ) : (
-            <>
-              <DonutChart data={safeData} />
-              <div className="flex flex-col gap-2 pt-2">
-                {safeData.map((item, index) => {
-                  const val = Number(item.value) || 0;
-                  const pct =
-                    total > 0 ? ((val / total) * 100).toFixed(0) : "0";
-                  return (
-                    <div
-                      key={index}
-                      className="flex items-center gap-3 text-sm"
-                    >
-                      <span
-                        className="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
-                        style={{
-                          backgroundColor:
-                            CHART_COLORS[index % CHART_COLORS.length],
-                        }}
-                      />
-                      <span className="flex-1 truncate text-[var(--foreground)]">
-                        {item.label}
-                      </span>
-                      <span className="tabular-nums text-[var(--muted-foreground)]">
-                        {val.toLocaleString()}
-                      </span>
-                      <span className="w-10 text-right tabular-nums text-[var(--muted-foreground)]">
-                        {pct}%
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            </>
-          )}
-        </CardContent>
-      </Card>
+        {data.length === 0 ? (
+          <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">
+            No data available
+          </div>
+        ) : (
+          <div style={{ width: "100%", height: 200 }}>
+            <ResponsiveContainer>
+              <RechartsPieChart>
+                <Pie
+                  data={data}
+                  dataKey="value"
+                  nameKey="label"
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={40}
+                  outerRadius={80}
+                  paddingAngle={2}
+                >
+                  {data.map((_, i) => (
+                    <Cell
+                      key={i}
+                      fill={CHART_COLORS[i % CHART_COLORS.length]}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip />
+              </RechartsPieChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardShell>
     );
   },
 
   BarChart: ({ props }) => {
-    const { isNew } = useSeenIndices();
-    const data = props.data ?? [];
-    const safeData = Array.isArray(data) ? data : [];
-
+    // Coerce values to numbers — the LLM sometimes emits them as strings,
+    // which recharts treats as categorical (unordered Y-axis ticks). Use a
+    // strict finite check so null/undefined/NaN/non-numeric strings are
+    // surfaced via console.warn rather than silently collapsed to 0 (which
+    // masks schema/data drift). Recharts requires a numeric value to render,
+    // so we fall back to 0 only after logging.
+    const data = (Array.isArray(props.data) ? props.data : []).map((d) => {
+      const raw = (d as { value?: unknown }).value;
+      const n = typeof raw === "number" ? raw : parseFloat(raw as string);
+      let value: number;
+      if (Number.isFinite(n)) {
+        value = n;
+      } else {
+        console.warn("Invalid chart value", {
+          component: "BarChart",
+          key: "value",
+          raw,
+        });
+        value = 0;
+      }
+      return { ...d, value };
+    });
     return (
-      <Card
-        className="w-full flex-1 min-w-0 overflow-hidden"
-        data-testid="declarative-bar-chart"
+      <CardShell
+        title={props.title}
+        subtitle={props.description}
+        testid="declarative-bar-chart"
       >
-        {/* Scoped keyframe — no globals.css needed */}
-        <style>{`
-          @keyframes barSlideIn {
-            from { transform: translateY(40px); opacity: 0; }
-            20% { opacity: 1; }
-            to { transform: translateY(0); opacity: 1; }
-          }
-        `}</style>
-        <CardHeader>
-          <CardTitle>{props.title}</CardTitle>
-          <CardDescription>{props.description}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          {safeData.length === 0 ? (
-            <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">
-              No data available
-            </div>
-          ) : (
-            <ResponsiveContainer width="100%" height={260}>
-              <RechartsBarChart
-                data={safeData}
-                margin={{ top: 12, right: 12, bottom: 4, left: -8 }}
-              >
-                <CartesianGrid
-                  strokeDasharray="3 3"
-                  stroke="var(--border)"
-                  vertical={false}
-                />
-                <XAxis
-                  dataKey="label"
-                  tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
-                  stroke="var(--border)"
-                  tickLine={false}
-                  axisLine={false}
-                />
-                <YAxis
-                  tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
-                  stroke="var(--border)"
-                  tickLine={false}
-                  axisLine={false}
-                />
-                <Tooltip
-                  contentStyle={CHART_TOOLTIP_STYLE}
-                  cursor={{ fill: "var(--muted)", opacity: 0.5 }}
-                />
-                <Bar
-                  isAnimationActive={false}
-                  dataKey="value"
-                  radius={[6, 6, 0, 0]}
-                  maxBarSize={48}
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  shape={
-                    ((barProps: any) => (
-                      <AnimatedBar
-                        {...barProps}
-                        isNew={isNew(barProps.index as number)}
-                      />
-                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    )) as any
-                  }
-                >
-                  {safeData.map((_, index) => (
-                    <Cell
-                      key={index}
-                      fill={CHART_COLORS[index % CHART_COLORS.length]}
-                    />
-                  ))}
-                </Bar>
+        {data.length === 0 ? (
+          <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">
+            No data available
+          </div>
+        ) : (
+          <div style={{ width: "100%", height: 200 }}>
+            <ResponsiveContainer>
+              <RechartsBarChart data={data}>
+                <CartesianGrid strokeDasharray="3 3" stroke={c.divider} />
+                <XAxis dataKey="label" tick={{ fontSize: 11, fill: c.muted }} />
+                <YAxis tick={{ fontSize: 11, fill: c.muted }} />
+                <Tooltip />
+                <Bar dataKey="value" fill="#3b82f6" radius={[4, 4, 0, 0]} />
               </RechartsBarChart>
             </ResponsiveContainer>
-          )}
-        </CardContent>
-      </Card>
+          </div>
+        )}
+      </CardShell>
     );
   },
 };

--- a/showcase/integrations/strands-typescript/src/app/demos/declarative-gen-ui/chat.tsx
+++ b/showcase/integrations/strands-typescript/src/app/demos/declarative-gen-ui/chat.tsx
@@ -2,9 +2,11 @@
 
 import { CopilotChat } from "@copilotkit/react-core/v2";
 import { useDeclarativeGenUISuggestions } from "./suggestions";
+import { useSalesAnalystContext } from "./sales-context";
 
 export function Chat() {
   useDeclarativeGenUISuggestions();
+  useSalesAnalystContext();
   return (
     <CopilotChat agentId="declarative-gen-ui" className="h-full rounded-2xl" />
   );

--- a/showcase/integrations/strands-typescript/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/integrations/strands-typescript/src/app/demos/declarative-gen-ui/page.tsx
@@ -11,13 +11,14 @@
  *   2. Pass that catalog to the provider via
  *      `<CopilotKit a2ui={{ catalog: myCatalog }}>`.
  *   3. The dedicated runtime at `/api/copilotkit-declarative-gen-ui` is
- *      configured with `injectA2UITool: false` — the backend agent
- *      (`src/agents/a2ui_dynamic.py`) owns the `generate_a2ui` tool
- *      explicitly, mirroring the working pattern from beautiful-chat and the
- *      canonical `examples/integrations/langgraph-python` reference. The
- *      A2UI middleware still serialises the registered catalog schema into
- *      `copilotkit.context` so the secondary LLM inside `generate_a2ui`
- *      knows which components are available.
+ *      configured with `injectA2UITool: true` + `defaultCatalogId:
+ *      "declarative-gen-ui-catalog"`. The runtime injects a `generate_a2ui`
+ *      tool and drives a secondary render planner to GENERATE the surface;
+ *      the Strands adapter auto-injects the tool on the backend side when it
+ *      sees the forwarded flag (the dedicated backend agent wires no tool
+ *      itself). The A2UI middleware serialises the registered catalog schema
+ *      so the planner knows which components are available. Mirrors the
+ *      canonical `examples/integrations/langgraph-python` reference.
  *
  * Reference:
  *   https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui

--- a/showcase/integrations/strands-typescript/src/app/demos/declarative-gen-ui/sales-context.ts
+++ b/showcase/integrations/strands-typescript/src/app/demos/declarative-gen-ui/sales-context.ts
@@ -1,0 +1,43 @@
+import { useAgentContext } from "@copilotkit/react-core/v2";
+
+// Grounding data + composition rules for the sales-analyst demo persona.
+// Registered as agent context so it reaches both the primary agent (App
+// Context) and the secondary A2UI planner LLM, which serialises frontend
+// context entries into its system instruction.
+//
+// DUPLICATION NOTICE: This file is intentionally byte-duplicated across
+// the langgraph-python and google-adk integrations, per the showcase's
+// per-integration parity convention (no cross-integration imports). The
+// two copies MUST be kept byte-for-byte identical — verify with `diff`
+// after any edit, and update BOTH files in the same commit.
+//
+// TODO(OSS-136): Extract this dataset + composition rules into a shared
+// showcase module so both integrations import a single source of truth
+// instead of relying on manual byte-sync.
+const SALES_DATASET = `Vantage Threads (fictional B2B apparel company) — Q2 sales data. Ground every visual in these numbers; invent only plausible details consistent with them.
+- Quarterly revenue: $4.2M (up 12% QoQ). New customers: 186 (up 8%). Win rate: 31% (down 2pts). Avg deal size: $22.6k (up 5%).
+- Revenue by region: North America $1.9M, EMEA $1.3M, APAC $720k, LATAM $280k.
+- Monthly revenue: Jan $1.21M, Feb $1.34M, Mar $1.65M, Apr $1.38M, May $1.42M, Jun $1.40M.
+- Reps (vs quota): Dana Whitfield 124%, Marcus Lee 108%, Priya Sharma 97%, Tom Okafor 88%, Elena Vasquez 71%.
+- At-risk: total $615k ARR across 3 accounts — Northwind Retail ($340k renewal, no contact 6 weeks; severity high), Cascadia Outfitters ($180k, champion left; severity medium), Atlas Goods ($95k, stalled legal review; severity medium).
+- Biggest account: Meridian Apparel Group — owner Dana Whitfield, region North America, ARR $612k, renewal Sep 30, last contact 3 days ago, health green, 4 open opportunities worth $210k.
+- Meridian revenue by product line: Outerwear $260k, Footwear $180k, Accessories $112k, Custom $60k.`;
+
+const COMPOSITION_RULES = `Pick A2UI components by the shape of the question — never ask which chart the user wants:
+1. Overall snapshot / "sales dashboard" → a Column (gap 16) whose first child is a Row (gap 16) of 4 Metric tiles (each with trend + trendValue), followed by a Row with a PieChart (revenue by region) next to a BarChart (monthly revenue, all six months Jan-Jun). Do NOT wrap the dashboard in a surrounding Card — the charts carry their own card chrome. Do NOT use StatusBadge, DataTable, or InfoRow here.
+2. Rep / team performance → a Column (gap 16) with a Card containing a DataTable (columns: rep, attainment, pipeline) next to or above a BarChart of quota attainment % per rep — no StatusBadge or InfoRow.
+3. Risk / health checks → a Column (gap 16): first a Row (gap 16) of 3 Metric tiles (ARR at risk $615k trend down, accounts at risk 3, biggest exposure Northwind $340k), then a Row (gap 16) with one compact Card per at-risk account (title = account name, subtitle = ARR at stake) containing a StatusBadge (error for high severity, warning otherwise) above a one-line Text with the reason and the recommended next action — no DataTable or InfoRow.
+4. Single account/entity details → a Row (gap 16) with a Card of InfoRow facts (owner, region, ARR, renewal date, last contact) next to a PieChart of that account's revenue by product line — no DataTable or StatusBadge.
+5. Part-of-whole follow-ups → PieChart; trends or comparisons over time/categories → BarChart.
+Compose generously — a dashboard should feel like a real analytics product, not a single widget.`;
+
+export function useSalesAnalystContext() {
+  useAgentContext({
+    description: "Sales dataset for Vantage Threads (the demo company)",
+    value: SALES_DATASET,
+  });
+  useAgentContext({
+    description: "Dashboard composition rules for A2UI surfaces",
+    value: COMPOSITION_RULES,
+  });
+}

--- a/showcase/integrations/strands-typescript/src/app/demos/declarative-gen-ui/suggestions.ts
+++ b/showcase/integrations/strands-typescript/src/app/demos/declarative-gen-ui/suggestions.ts
@@ -1,25 +1,29 @@
 import { useConfigureSuggestions } from "@copilotkit/react-core/v2";
 
+// Pill prompts are natural business questions — chart-type steering lives in
+// the agent's system prompt (src/agents/a2ui_dynamic.py). Each pill maps to a
+// distinct catalog component so the D5 probe
+// (showcase/harness/src/probes/scripts/d5-gen-ui-declarative.ts) can assert a
+// newly-mounted testid per pill. Keep prompts in sync with that probe and with
+// tests/e2e/declarative-gen-ui.spec.ts.
 export function useDeclarativeGenUISuggestions() {
   useConfigureSuggestions({
     suggestions: [
       {
-        title: "Show a KPI dashboard",
-        message:
-          "Show me a quick KPI dashboard with 3-4 metrics (revenue, signups, churn).",
+        title: "Show my sales dashboard",
+        message: "Show me my sales dashboard for this quarter.",
       },
       {
-        title: "Pie chart — sales by region",
-        message: "Show a pie chart of sales by region.",
+        title: "Team performance",
+        message: "How are our sales reps performing against quota?",
       },
       {
-        title: "Bar chart — quarterly revenue",
-        message: "Render a bar chart of quarterly revenue.",
+        title: "Anything at risk?",
+        message: "Are any accounts or pipeline deals at risk this quarter?",
       },
       {
-        title: "Status report",
-        message:
-          "Give me a status report on system health — API, database, and background workers.",
+        title: "Top account details",
+        message: "Pull up the details on our biggest account.",
       },
     ],
     available: "always",

--- a/showcase/integrations/strands/requirements.txt
+++ b/showcase/integrations/strands/requirements.txt
@@ -1,5 +1,5 @@
 ag-ui-protocol==0.1.18
-ag_ui_strands==0.1.9
+ag_ui_strands==0.2.1
 strands-agents[OpenAI]==1.18.0
 strands-agents-tools==0.2.16
 copilotkit==0.1.94

--- a/showcase/integrations/strands/src/agent_server.py
+++ b/showcase/integrations/strands/src/agent_server.py
@@ -131,6 +131,7 @@ from agents.byoc_hashbrown import build_byoc_hashbrown_agent  # noqa: E402  (mus
 from agents.byoc_json_render import build_byoc_json_render_agent  # noqa: E402  (must follow instrumentor patch)
 from agents.voice_agent import build_voice_agent  # noqa: E402  (must follow instrumentor patch)
 from agents.a2ui_fixed import build_a2ui_fixed_schema_agent  # noqa: E402  (must follow instrumentor patch)
+from agents.a2ui_dynamic import build_a2ui_dynamic_agent  # noqa: E402  (must follow instrumentor patch)
 
 load_dotenv()
 
@@ -165,6 +166,15 @@ byoc_json_render_app = create_strands_app(byoc_json_render_agui_agent, "/")
 a2ui_fixed_schema_agui_agent = build_a2ui_fixed_schema_agent()
 a2ui_fixed_schema_app = create_strands_app(a2ui_fixed_schema_agui_agent, "/")
 
+# A2UI dynamic-schema agent (declarative-gen-ui demo): a plain agent with no
+# generate_a2ui tool wired. When the runtime forwards `injectA2UITool: true`,
+# the adapter auto-injects `generate_a2ui` and drives a secondary render
+# planner to GENERATE the surface layout, stamped with the catalog id the page
+# registers (`declarative-gen-ui-catalog`). Mounted as a dedicated agent so the
+# demo no longer relies on the generic "/" agent.
+a2ui_dynamic_agui_agent = build_a2ui_dynamic_agent()
+a2ui_dynamic_app = create_strands_app(a2ui_dynamic_agui_agent, "/")
+
 # Create the FastAPI app from the AG-UI Strands integration
 agent_path = os.getenv("AGENT_PATH", "/")
 app = create_strands_app(agui_agent, agent_path)
@@ -183,6 +193,9 @@ app.mount("/byoc-json-render", byoc_json_render_app)
 # A2UI fixed-schema: the Next.js route proxies to AGENT_URL/a2ui-fixed-schema/
 # (trailing slash) so the sub-application's root route resolves.
 app.mount("/a2ui-fixed-schema", a2ui_fixed_schema_app)
+# A2UI dynamic-schema: the Next.js route proxies to AGENT_URL/declarative-gen-ui/
+# (trailing slash) so the sub-application's root route resolves.
+app.mount("/declarative-gen-ui", a2ui_dynamic_app)
 
 
 # Serve /health via middleware so it short-circuits BEFORE route resolution.

--- a/showcase/integrations/strands/src/agents/a2ui_dynamic.py
+++ b/showcase/integrations/strands/src/agents/a2ui_dynamic.py
@@ -1,0 +1,115 @@
+"""Dedicated Strands agent for the Declarative Generative UI (A2UI — Dynamic
+Schema) demo.
+
+Strands port of the canonical langgraph-python ``a2ui_dynamic`` demo
+(``../../../langgraph-python/src/agents/a2ui_dynamic.py``). Unlike the
+fixed-schema demo (which wires a single ``display_flight`` tool returning a
+pre-authored ``a2ui_operations`` envelope), the dynamic demo lets the agent
+*generate* the surface layout on the fly.
+
+How the generation is wired (no manual tool):
+  - The Next.js runtime route (``app/api/copilotkit-declarative-gen-ui/
+    route.ts``) sets ``a2ui: { injectA2UITool: true, defaultCatalogId:
+    "declarative-gen-ui-catalog" }``.
+  - The CopilotKit runtime forwards that ``injectA2UITool`` flag to this
+    agent, and the Strands adapter auto-injects a ``generate_a2ui`` tool +
+    drives a secondary ``render_a2ui`` planner LLM to emit the surface ops.
+  - The ``StrandsAgentConfig.a2ui`` block below supplies the
+    ``default_catalog_id`` stamped into generated surfaces and the
+    ``composition_guide`` that teaches the planner which components the page's
+    catalog registers. Mirrors the ag-ui dynamic-schema reference example.
+
+The ``composition_guide`` MUST describe the exact catalog the showcase page
+registers at ``src/app/demos/declarative-gen-ui/a2ui/{definitions,renderers,
+catalog}.ts`` (catalog id ``declarative-gen-ui-catalog``): the custom
+components Card / StatusBadge / Metric / InfoRow / PrimaryButton / PieChart /
+BarChart / DataTable, composed inside the basic catalog's Row / Column / Text
+containers (``includeBasicCatalog: true``).
+"""
+
+from __future__ import annotations
+
+from strands import Agent
+from ag_ui_strands import StrandsAgent, StrandsAgentConfig
+
+from agents.agent import _build_model
+
+# Must match the catalog id the page registers via
+# `createCatalog(..., { catalogId: "declarative-gen-ui-catalog" })`. The
+# render planner omits `catalogId` unless told, and the middleware then falls
+# back to the unregistered spec basic catalog ("Catalog not found"). Stamping
+# it here (and in the route's `defaultCatalogId`) pins the right catalog.
+CATALOG_ID = "declarative-gen-ui-catalog"
+
+# Grounding dataset + composition rules for the sales-analyst persona, kept
+# byte-for-byte in spirit with the frontend `sales-context.ts`
+# (SALES_DATASET + COMPOSITION_RULES) that the page registers via
+# `useAgentContext`. The frontend context steers the PRIMARY agent; this
+# `composition_guide` is the channel the Strands adapter feeds to the secondary
+# `render_a2ui` planner (it gets `guidelines`, not the frontend App Context),
+# so the planner is self-contained — it knows both the numbers to ground in and
+# which catalog components to compose.
+SALES_DATASET = """Vantage Threads (fictional B2B apparel company) — Q2 sales data. Ground every visual in these numbers; invent only plausible details consistent with them.
+- Quarterly revenue: $4.2M (up 12% QoQ). New customers: 186 (up 8%). Win rate: 31% (down 2pts). Avg deal size: $22.6k (up 5%).
+- Revenue by region: North America $1.9M, EMEA $1.3M, APAC $720k, LATAM $280k.
+- Monthly revenue: Jan $1.21M, Feb $1.34M, Mar $1.65M, Apr $1.38M, May $1.42M, Jun $1.40M.
+- Reps (vs quota): Dana Whitfield 124%, Marcus Lee 108%, Priya Sharma 97%, Tom Okafor 88%, Elena Vasquez 71%.
+- At-risk: total $615k ARR across 3 accounts — Northwind Retail ($340k renewal, no contact 6 weeks; severity high), Cascadia Outfitters ($180k, champion left; severity medium), Atlas Goods ($95k, stalled legal review; severity medium).
+- Biggest account: Meridian Apparel Group — owner Dana Whitfield, region North America, ARR $612k, renewal Sep 30, last contact 3 days ago, health green, 4 open opportunities worth $210k.
+- Meridian revenue by product line: Outerwear $260k, Footwear $180k, Accessories $112k, Custom $60k."""
+
+COMPOSITION_RULES = """Pick A2UI components by the shape of the question — never ask which chart the user wants:
+1. Overall snapshot / "sales dashboard" → a Column (gap 16) whose first child is a Row (gap 16) of 4 Metric tiles (each with trend + trendValue), followed by a Row with a PieChart (revenue by region) next to a BarChart (monthly revenue, all six months Jan-Jun). Do NOT wrap the dashboard in a surrounding Card — the charts carry their own card chrome. Do NOT use StatusBadge, DataTable, or InfoRow here.
+2. Rep / team performance → a Column (gap 16) with a Card containing a DataTable (columns: rep, attainment, pipeline) next to or above a BarChart of quota attainment % per rep — no StatusBadge or InfoRow.
+3. Risk / health checks → a Column (gap 16): first a Row (gap 16) of 3 Metric tiles (ARR at risk $615k trend down, accounts at risk 3, biggest exposure Northwind $340k), then a Row (gap 16) with one compact Card per at-risk account (title = account name, subtitle = ARR at stake) containing a StatusBadge (error for high severity, warning otherwise) above a one-line Text with the reason and the recommended next action — no DataTable or InfoRow.
+4. Single account/entity details → a Row (gap 16) with a Card of InfoRow facts (owner, region, ARR, renewal date, last contact) next to a PieChart of that account's revenue by product line — no DataTable or StatusBadge.
+5. Part-of-whole follow-ups → PieChart; trends or comparisons over time/categories → BarChart.
+Compose generously — a dashboard should feel like a real analytics product, not a single widget."""
+
+COMPOSITION_GUIDE = SALES_DATASET + "\n\n" + COMPOSITION_RULES
+
+# Mirrors the langgraph-python demo's a2ui_dynamic.py SYSTEM_PROMPT. The
+# dataset + composition rules also reach the primary agent via the frontend
+# `sales-context.ts` App Context.
+SYSTEM_PROMPT = (
+    "You are the embedded sales analyst for Vantage Threads, the fictional "
+    "B2B apparel company described in your App Context. Answer every "
+    "business question by calling `generate_a2ui` to draw a rich visual "
+    "surface, and keep the chat reply to one short sentence.\n"
+    "\n"
+    "Ground every number in the sales dataset from App Context — never "
+    "invent figures that contradict it. Follow the dashboard composition "
+    "rules from App Context when choosing components: pick the component "
+    "by the shape of the question (snapshot → composed KPI dashboard with "
+    "charts; team performance → table; risk → status badges; single "
+    "account → info rows; part-of-whole → pie; trend/comparison → bar). "
+    "Never ask the user which chart they want. `generate_a2ui` takes no "
+    "arguments and handles the rendering automatically. Compose "
+    "generously — a dashboard should feel like a real analytics product, "
+    "not a single widget."
+)
+
+
+def build_a2ui_dynamic_agent() -> StrandsAgent:
+    """Construct the dedicated A2UI dynamic-schema StrandsAgent.
+
+    The ``generate_a2ui`` tool is auto-injected by the adapter when the runtime
+    forwards ``injectA2UITool: true`` — nothing is wired into the Strands
+    agent's ``tools`` list here.
+    """
+    strands_agent = Agent(
+        model=_build_model(),
+        system_prompt=SYSTEM_PROMPT,
+    )
+
+    return StrandsAgent(
+        agent=strands_agent,
+        name="a2ui_dynamic_schema",
+        description="Dynamic A2UI surfaces generated on the fly (auto-injected tool)",
+        config=StrandsAgentConfig(
+            a2ui={
+                "default_catalog_id": CATALOG_ID,
+                "guidelines": {"composition_guide": COMPOSITION_GUIDE},
+            }
+        ),
+    )

--- a/showcase/integrations/strands/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -1,7 +1,8 @@
 // Dedicated runtime for the Declarative Generative UI (A2UI dynamic) demo.
 // Scoped so a2ui options for this cell stay isolated from the shared route.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
   ExperimentalEmptyAdapter,
@@ -12,7 +13,12 @@ import { HttpAgent } from "@ag-ui/client";
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
 function createAgent() {
-  return new HttpAgent({ url: `${AGENT_URL}/` });
+  // Dedicated backend agent mounted at /declarative-gen-ui (see
+  // src/agent_server.py). It wires NO generate_a2ui tool — the runtime's
+  // `injectA2UITool: true` below makes the Strands adapter auto-inject it and
+  // GENERATE the surface layout. Trailing slash so the sub-application's root
+  // route resolves.
+  return new HttpAgent({ url: `${AGENT_URL}/declarative-gen-ui/` });
 }
 
 const a2uiAgent = createAgent();
@@ -29,6 +35,17 @@ export const POST = async (req: NextRequest) => {
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
+        // Enable A2UI tool injection: the runtime injects a `generate_a2ui`
+        // tool and drives a secondary render planner to emit the surface ops,
+        // then the A2UIMiddleware paints them. The Strands adapter auto-injects
+        // the tool when it sees this forwarded flag. Pin the catalog the page
+        // registers so the planner doesn't fall back to the unregistered spec
+        // basic catalog ("Catalog not found"). Mirrors the langgraph-python
+        // declarative-gen-ui route.
+        a2ui: {
+          injectA2UITool: true,
+          defaultCatalogId: "declarative-gen-ui-catalog",
+        },
       }),
     });
     return await handleRequest(req);

--- a/showcase/integrations/strands/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+++ b/showcase/integrations/strands/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
@@ -16,6 +16,45 @@ import { z } from "zod";
 import type { CatalogDefinitions } from "@copilotkit/a2ui-renderer";
 
 export const myDefinitions = {
+  // Override the basic catalog's Row/Column so `gap` is honoured — the
+  // built-in versions ignore it, which makes composed dashboards cramped.
+  Row: {
+    description:
+      "Horizontal layout container. Children share the width evenly. Use `gap` (px) to space dashboard tiles.",
+    props: z.object({
+      gap: z.number().optional(),
+      // Enum mirrors the keys the renderer actually maps to CSS. Anything
+      // outside this set silently falls back at render time, so we reject
+      // it at schema-parse time to surface LLM typos early.
+      align: z
+        .enum(["start", "center", "end", "stretch", "baseline"])
+        .optional(),
+      justify: z.enum(["start", "center", "end", "spaceBetween"]).optional(),
+      children: z.array(z.string()),
+    }),
+  },
+
+  Column: {
+    description:
+      "Vertical layout container. Use `gap` (px) to space stacked sections.",
+    props: z.object({
+      gap: z.number().optional(),
+      align: z
+        .enum(["start", "center", "end", "stretch", "baseline"])
+        .optional(),
+      children: z.array(z.string()),
+    }),
+  },
+
+  // Override the basic catalog's Text so it aligns flush with sibling
+  // components (the built-in version carries an 8px outer margin).
+  Text: {
+    description: "A plain text line. Use for short explanations inside cards.",
+    props: z.object({
+      text: z.string(),
+    }),
+  },
+
   Card: {
     description:
       "A titled card container with an optional subtitle and a single child slot. Use it to group related content (metrics, rows, buttons).",
@@ -28,7 +67,7 @@ export const myDefinitions = {
 
   StatusBadge: {
     description:
-      "A small coloured pill communicating the state of something (healthy/degraded/down, online/offline, open/closed). Choose `variant` to match the intent.",
+      "A small coloured pill communicating the state of something (healthy/degraded/at-risk, on-track/behind). Choose `variant` to match the intent.",
     props: z.object({
       text: z.string(),
       variant: z.enum(["success", "warning", "error", "info"]).optional(),
@@ -37,20 +76,43 @@ export const myDefinitions = {
 
   Metric: {
     description:
-      "A key/value KPI display with an optional trend indicator. Ideal for dashboards (e.g. 'Revenue • $12.4k • up').",
+      "A key/value KPI tile with an optional trend indicator and trend delta. Ideal for dashboard KPI rows (e.g. 'Revenue • $4.2M • up 12%').",
     props: z.object({
       label: z.string(),
       value: z.string(),
       trend: z.enum(["up", "down", "neutral"]).optional(),
+      trendValue: z.string().optional(),
     }),
   },
 
   InfoRow: {
     description:
-      "A compact two-column 'label: value' row. Good for stacks of facts inside a Card (owner, region, last updated, etc.).",
+      "A compact two-column 'label: value' row. Good for stacks of facts inside a Card (owner, region, ARR, renewal date, etc.).",
     props: z.object({
       label: z.string(),
       value: z.string(),
+    }),
+  },
+
+  DataTable: {
+    description:
+      "A data table with column headers and rows. Ideal for rankings and per-person/per-item breakdowns (rep performance vs quota, deal lists). Each row's keys MUST appear in `columns[].key`; unknown row keys render as blank cells and indicate model/schema drift.",
+    // NOTE on B12 (row-keys ⊆ columns[].key): we'd normally enforce this
+    // with `z.object(...).refine(...)`, but the host catalog package's
+    // `CatalogComponentDefinition` type requires `props: ZodObject<…>`
+    // (it inspects `.shape` at runtime), and `.refine` returns a
+    // `ZodEffects` that breaks both the `satisfies CatalogDefinitions`
+    // type assertion and the runtime `.shape` access. Until the host
+    // type is broadened, we encode the constraint in the description
+    // above so the LLM sees the rule, and leave hard enforcement to
+    // the rendering pipeline (which already shows the empty cell —
+    // detection is the gap, not behaviour).
+    props: z.object({
+      columns: z.array(z.object({ key: z.string(), label: z.string() })),
+      // Cells may be strings or numbers — the renderer stringifies at
+      // render time, but accepting both lets the LLM emit raw numerics
+      // (e.g. attainment 124) instead of being forced to stringify.
+      rows: z.array(z.record(z.union([z.string(), z.number()]))),
     }),
   },
 
@@ -59,13 +121,18 @@ export const myDefinitions = {
       "A styled primary call-to-action button. Attach an optional `action` that will be dispatched back to the agent when the user clicks it.",
     props: z.object({
       label: z.string(),
-      action: z.any().optional(),
+      // The renderer hands `action` opaquely to the A2UI `dispatch` helper,
+      // which forwards it back to the agent. We don't constrain the shape
+      // (different demos use different action payloads), but `z.unknown()`
+      // is strictly better than `z.any()` here because it forces any
+      // consumer that touches the value to narrow it explicitly.
+      action: z.unknown().optional(),
     }),
   },
 
   PieChart: {
     description:
-      "A pie/donut chart with a brand-coloured legend. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for part-of-whole breakdowns (sales by region, traffic sources, portfolio allocation).",
+      "A pie/donut chart with a brand-coloured legend. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for part-of-whole breakdowns (revenue by region, pipeline by stage).",
     props: z.object({
       title: z.string(),
       description: z.string(),
@@ -80,7 +147,7 @@ export const myDefinitions = {
 
   BarChart: {
     description:
-      "A vertical bar chart built on Recharts. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for comparing series across categories (quarterly revenue, headcount by team, signups per month).",
+      "A vertical bar chart built on Recharts. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for comparing series across categories or time (monthly revenue, signups per month).",
     props: z.object({
       title: z.string(),
       description: z.string(),

--- a/showcase/integrations/strands/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/strands/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -3,215 +3,252 @@
 /**
  * A2UI catalog RENDERERS.
  *
- * React implementations for each definition in `./definitions.ts`,
- * styled with the demo's local ShadCN-flavoured primitives in
- * `../_components/`. The assembled catalog (definitions × renderers via
- * `createCatalog`) lives in `./catalog.ts`.
+ * React implementations for each definition in `./definitions.ts`. Visuals
+ * mirror beautiful-chat's sales dashboard renderers
+ * (../../beautiful-chat/declarative-generative-ui/renderers.tsx) so the two
+ * demos read as the same product family — same card chrome, metric
+ * typography, recharts donut/bar styling, and palette. The assembled catalog
+ * (definitions × renderers via `createCatalog`) lives in `./catalog.ts`.
  *
  * Reference:
  *   https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui
  */
-import React, { useRef } from "react";
+import React from "react";
 import {
+  PieChart as RechartsPieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
   BarChart as RechartsBarChart,
   Bar,
   XAxis,
   YAxis,
   Tooltip,
   CartesianGrid,
-  Cell,
-  ResponsiveContainer,
-  Rectangle,
 } from "recharts";
 import type { CatalogRenderers } from "@copilotkit/a2ui-renderer";
+import { TriangleAlert, CircleAlert, CircleCheck, Info } from "lucide-react";
 
 import type { MyDefinitions } from "./definitions";
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-} from "../_components/card";
 import { Badge } from "../_components/badge";
 import { Button } from "../_components/button";
 
-// ─── ShadCN-friendly chart palette ─────────────────────────────────────────
-// Neutral, slightly muted hues that pair with `bg-card` / `--border`
-// (zinc/slate-leaning, akin to ShadCN's chart-{1..5} palette).
-const CHART_COLORS = [
-  "#3F3F46", // zinc-700
-  "#71717A", // zinc-500
-  "#A1A1AA", // zinc-400
-  "#18181B", // zinc-900
-  "#52525B", // zinc-600
-  "#D4D4D8", // zinc-300
-  "#27272A", // zinc-800
-] as const;
-
-const CHART_TOOLTIP_STYLE: React.CSSProperties = {
-  backgroundColor: "var(--card)",
-  border: "1px solid var(--border)",
-  borderRadius: 8,
-  padding: "8px 12px",
-  color: "var(--foreground)",
-  fontSize: 12,
-  boxShadow: "0 4px 12px rgba(0,0,0,0.06)",
+// ─── Theme tokens + palette (mirrors beautiful-chat) ────────────────────────
+const c = {
+  card: "var(--card)",
+  cardFg: "var(--card-foreground)",
+  border: "var(--border)",
+  muted: "var(--muted-foreground)",
+  divider: "color-mix(in srgb, var(--border) 50%, var(--card))",
+  shadow: "0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.04)",
 };
 
-/** Custom SVG donut chart built with <circle> + stroke-dasharray. */
-function DonutChart({
-  data,
-  size = 220,
-  strokeWidth = 36,
+const CHART_COLORS = [
+  "#3b82f6", // blue-500
+  "#8b5cf6", // violet-500
+  "#ec4899", // pink-500
+  "#f59e0b", // amber-500
+  "#10b981", // emerald-500
+  "#6366f1", // indigo-500
+] as const;
+
+/** DashboardCard-style chrome shared by Card and the chart wrappers. */
+function CardShell({
+  title,
+  subtitle,
+  testid,
+  cardId,
+  children,
 }: {
-  data: { label: string; value: number }[];
-  size?: number;
-  strokeWidth?: number;
+  title: string;
+  subtitle?: string;
+  testid?: string;
+  cardId?: string;
+  children?: React.ReactNode;
 }) {
-  const radius = (size - strokeWidth) / 2;
-  const circumference = 2 * Math.PI * radius;
-  const center = size / 2;
-
-  const total = data.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
-
-  let accumulated = 0;
-  const slices = data.map((item, index) => {
-    const val = Number(item.value) || 0;
-    const ratio = total > 0 ? val / total : 0;
-    const arc = ratio * circumference;
-    const startAt = accumulated;
-    accumulated += arc;
-    return {
-      ...item,
-      arc,
-      gap: circumference - arc,
-      dashoffset: -startAt,
-      color: CHART_COLORS[index % CHART_COLORS.length],
-    };
-  });
-
   return (
-    <svg
-      width="100%"
-      viewBox={`0 0 ${size} ${size}`}
+    <div
+      data-testid={testid}
+      data-card-id={cardId}
       style={{
-        display: "block",
-        margin: "0 auto",
-        maxWidth: size,
-        transform: "scaleX(-1)",
+        background: c.card,
+        borderRadius: "12px",
+        border: `1px solid ${c.border}`,
+        padding: "20px",
+        boxShadow: c.shadow,
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px",
+        width: "100%",
+        minWidth: 0,
+        overflow: "hidden",
       }}
     >
-      <circle
-        cx={center}
-        cy={center}
-        r={radius}
-        fill="none"
-        stroke="var(--muted)"
-        strokeWidth={strokeWidth}
-      />
-      {slices.map((slice, i) => (
-        <circle
-          key={i}
-          cx={center}
-          cy={center}
-          r={radius}
-          fill="none"
-          stroke={slice.color}
-          strokeWidth={strokeWidth}
-          strokeDasharray={`${slice.arc} ${slice.gap}`}
-          strokeDashoffset={slice.dashoffset}
-          strokeLinecap="butt"
-          transform={`rotate(-90 ${center} ${center})`}
-        />
-      ))}
-    </svg>
-  );
-}
-
-/** Tracks seen indices so only NEW bars get the fade-in animation. */
-function useSeenIndices() {
-  const seen = useRef(new Set<number>());
-  return {
-    isNew(index: number) {
-      if (seen.current.has(index)) return false;
-      seen.current.add(index);
-      return true;
-    },
-  };
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function AnimatedBar(props: any) {
-  const { isNew, ...rest } = props;
-  return (
-    <g
-      style={
-        isNew
-          ? {
-              animation: "barSlideIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) both",
-            }
-          : undefined
-      }
-    >
-      <Rectangle {...rest} />
-    </g>
+      <div>
+        <div style={{ fontWeight: 600, fontSize: "0.9rem", color: c.cardFg }}>
+          {title}
+        </div>
+        {subtitle && (
+          <div
+            style={{ fontSize: "0.75rem", color: c.muted, marginTop: "2px" }}
+          >
+            {subtitle}
+          </div>
+        )}
+      </div>
+      {children}
+    </div>
   );
 }
 
 // @region[renderers-react]
 export const myRenderers: CatalogRenderers<MyDefinitions> = {
-  Card: ({ props, children }) => (
-    <Card
-      className="w-full min-w-0 overflow-hidden"
-      data-testid="declarative-card"
-    >
-      <CardHeader>
-        <CardTitle>{props.title}</CardTitle>
-        {props.subtitle && <CardDescription>{props.subtitle}</CardDescription>}
-      </CardHeader>
-      {props.child && (
-        <CardContent className="flex flex-col gap-4">
-          {children(props.child)}
-        </CardContent>
-      )}
-    </Card>
+  Row: ({ props, children }) => {
+    const justifyMap: Record<string, string> = {
+      start: "flex-start",
+      center: "center",
+      end: "flex-end",
+      spaceBetween: "space-between",
+    };
+    const items = Array.isArray(props.children) ? props.children : [];
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          gap: `${props.gap ?? 16}px`,
+          alignItems: props.align ?? "stretch",
+          justifyContent: justifyMap[props.justify ?? "start"] ?? "flex-start",
+          flexWrap: "wrap",
+          width: "100%",
+        }}
+      >
+        {items.map((id, i) => (
+          <div key={`${id}-${i}`} style={{ flex: "1 1 0", minWidth: 0 }}>
+            {children(id)}
+          </div>
+        ))}
+      </div>
+    );
+  },
+
+  Column: ({ props, children }) => {
+    const items = Array.isArray(props.children) ? props.children : [];
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: `${props.gap ?? 12}px`,
+          width: "100%",
+        }}
+      >
+        {items.map((id, i) => (
+          <React.Fragment key={`${id}-${i}`}>{children(id)}</React.Fragment>
+        ))}
+      </div>
+    );
+  },
+
+  Text: ({ props }) => (
+    <span style={{ fontSize: "0.85rem", color: c.cardFg, lineHeight: 1.5 }}>
+      {props.text}
+    </span>
   ),
 
-  StatusBadge: ({ props }) => (
-    <Badge
-      variant={props.variant ?? "info"}
-      data-testid="declarative-status-badge"
+  Card: ({ props, children }) => (
+    // `data-testid="declarative-card"` stays shared so existing e2e selectors
+    // still find every card; `data-card-id={props.title}` disambiguates
+    // sibling cards (e.g. the at-risk pill's 3 severity cards) so test
+    // assertions can target a specific card by title.
+    <CardShell
+      title={props.title}
+      subtitle={props.subtitle}
+      testid="declarative-card"
+      cardId={props.title}
     >
-      {props.text}
-    </Badge>
+      {props.child && children(props.child)}
+    </CardShell>
   ),
+
+  StatusBadge: ({ props }) => {
+    const variant = props.variant ?? "info";
+    const Icon = {
+      error: TriangleAlert,
+      warning: CircleAlert,
+      success: CircleCheck,
+      info: Info,
+    }[variant];
+    return (
+      // `alignSelf: flex-start` keeps the pill content-sized — flex parents
+      // (our Column override) default to stretch, which inflates it into a
+      // full-width banner.
+      <Badge
+        variant={variant}
+        style={{ alignSelf: "flex-start" }}
+        data-testid="declarative-status-badge"
+      >
+        <Icon size={12} strokeWidth={2.5} style={{ marginRight: 4 }} />
+        {props.text}
+      </Badge>
+    );
+  },
 
   Metric: ({ props }) => {
-    const trend = props.trend ?? "neutral";
-    const arrow = trend === "up" ? "↑" : trend === "down" ? "↓" : "";
-    const trendClass =
-      trend === "up"
-        ? "text-emerald-600"
-        : trend === "down"
-          ? "text-rose-600"
-          : "text-[var(--foreground)]";
+    const trendColors: Record<string, string> = {
+      up: "#059669",
+      down: "#dc2626",
+      neutral: c.muted,
+    };
+    const trendIcons: Record<string, string> = {
+      up: "↑",
+      down: "↓",
+      neutral: "→",
+    };
     return (
-      // `flex-1 min-w-[120px]` lets a row of Metrics distribute evenly
-      // inside the basic catalog's gap-less Row — 3 metrics in a 600px
-      // card column get ~200px each instead of squishing to content width.
       <div
         data-testid="declarative-metric"
-        className="flex flex-1 min-w-[120px] flex-col gap-1"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "4px",
+          minWidth: "120px",
+        }}
       >
-        <div className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
-          {props.label}
-        </div>
-        <div
-          className={`flex items-baseline gap-1.5 text-2xl font-semibold tabular-nums ${trendClass}`}
+        <span
+          style={{
+            fontSize: "0.75rem",
+            color: c.muted,
+            fontWeight: 500,
+            textTransform: "uppercase",
+            letterSpacing: "0.05em",
+          }}
         >
-          <span>{props.value}</span>
-          {arrow && <span className="text-base">{arrow}</span>}
+          {props.label}
+        </span>
+        <div style={{ display: "flex", alignItems: "baseline", gap: "8px" }}>
+          <span
+            style={{
+              fontSize: "1.5rem",
+              fontWeight: 700,
+              color: c.cardFg,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            {props.value}
+          </span>
+          {props.trend && (
+            <span
+              style={{
+                fontSize: "0.8rem",
+                fontWeight: 500,
+                color: trendColors[props.trend] ?? c.muted,
+              }}
+            >
+              {trendIcons[props.trend]}
+              {props.trendValue ? ` ${props.trendValue}` : ""}
+            </span>
+          )}
         </div>
       </div>
     );
@@ -221,7 +258,10 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     // Divider via `border-b last:border-b-0` so the final row doesn't dangle
     // a trailing line, regardless of whether the agent wraps these in a
     // Column or drops them directly into a Card's child slot.
-    <div className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0">
+    <div
+      data-testid="declarative-info-row"
+      className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0"
+    >
       <span className="text-sm text-[var(--muted-foreground)]">
         {props.label}
       </span>
@@ -230,6 +270,59 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
       </span>
     </div>
   ),
+
+  DataTable: ({ props }) => {
+    const cols = Array.isArray(props.columns) ? props.columns : [];
+    const rows = Array.isArray(props.rows) ? props.rows : [];
+    return (
+      <div
+        data-testid="declarative-data-table"
+        className="w-full overflow-x-auto"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  className="border-b-2 border-[var(--border)] px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => {
+              // Stable row key: prefer the first column's value (primary-key-ish),
+              // suffix with index in case values repeat, fall back to a JSON
+              // stringify of the row when columns is empty. Stable keys prevent
+              // React from re-mounting every row when the agent re-emits a
+              // slightly different table.
+              const pk = cols.length > 0 ? row[cols[0].key] : undefined;
+              const rowKey =
+                pk !== undefined ? `${pk}-${i}` : JSON.stringify(row);
+              return (
+                <tr
+                  key={rowKey}
+                  className="border-b border-[var(--border)] last:border-b-0"
+                >
+                  {cols.map((col) => (
+                    <td
+                      key={col.key}
+                      className="px-3 py-2 tabular-nums text-[var(--foreground)]"
+                    >
+                      {String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
 
   PrimaryButton: ({ props, dispatch }) => (
     <Button
@@ -242,150 +335,114 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
   ),
 
   PieChart: ({ props }) => {
-    const data = props.data ?? [];
-    const safeData = Array.isArray(data) ? data : [];
-    const total = safeData.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
-
+    // Coerce values to numbers — the LLM sometimes emits them as strings.
+    // Use a strict finite check so null/undefined/NaN/non-numeric strings are
+    // surfaced via console.warn rather than silently collapsed to 0 (which
+    // masks schema/data drift). Recharts requires a numeric value to render,
+    // so we fall back to 0 only after logging.
+    const data = (Array.isArray(props.data) ? props.data : []).map((d) => {
+      const raw = (d as { value?: unknown }).value;
+      const n = typeof raw === "number" ? raw : parseFloat(raw as string);
+      let value: number;
+      if (Number.isFinite(n)) {
+        value = n;
+      } else {
+        console.warn("Invalid chart value", {
+          component: "PieChart",
+          key: "value",
+          raw,
+        });
+        value = 0;
+      }
+      return { ...d, value };
+    });
     return (
-      // `flex-1 min-w-0` so multiple charts in a basic-catalog Row
-      // distribute the available width evenly instead of each insisting
-      // on its content size and overflowing.
-      <Card
-        className="w-full flex-1 min-w-0 overflow-hidden"
-        data-testid="declarative-pie-chart"
+      <CardShell
+        title={props.title}
+        subtitle={props.description}
+        testid="declarative-pie-chart"
       >
-        <CardHeader>
-          <CardTitle>{props.title}</CardTitle>
-          <CardDescription>{props.description}</CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          {safeData.length === 0 ? (
-            <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">
-              No data available
-            </div>
-          ) : (
-            <>
-              <DonutChart data={safeData} />
-              <div className="flex flex-col gap-2 pt-2">
-                {safeData.map((item, index) => {
-                  const val = Number(item.value) || 0;
-                  const pct =
-                    total > 0 ? ((val / total) * 100).toFixed(0) : "0";
-                  return (
-                    <div
-                      key={index}
-                      className="flex items-center gap-3 text-sm"
-                    >
-                      <span
-                        className="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
-                        style={{
-                          backgroundColor:
-                            CHART_COLORS[index % CHART_COLORS.length],
-                        }}
-                      />
-                      <span className="flex-1 truncate text-[var(--foreground)]">
-                        {item.label}
-                      </span>
-                      <span className="tabular-nums text-[var(--muted-foreground)]">
-                        {val.toLocaleString()}
-                      </span>
-                      <span className="w-10 text-right tabular-nums text-[var(--muted-foreground)]">
-                        {pct}%
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            </>
-          )}
-        </CardContent>
-      </Card>
+        {data.length === 0 ? (
+          <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">
+            No data available
+          </div>
+        ) : (
+          <div style={{ width: "100%", height: 200 }}>
+            <ResponsiveContainer>
+              <RechartsPieChart>
+                <Pie
+                  data={data}
+                  dataKey="value"
+                  nameKey="label"
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={40}
+                  outerRadius={80}
+                  paddingAngle={2}
+                >
+                  {data.map((_, i) => (
+                    <Cell
+                      key={i}
+                      fill={CHART_COLORS[i % CHART_COLORS.length]}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip />
+              </RechartsPieChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardShell>
     );
   },
 
   BarChart: ({ props }) => {
-    const { isNew } = useSeenIndices();
-    const data = props.data ?? [];
-    const safeData = Array.isArray(data) ? data : [];
-
+    // Coerce values to numbers — the LLM sometimes emits them as strings,
+    // which recharts treats as categorical (unordered Y-axis ticks). Use a
+    // strict finite check so null/undefined/NaN/non-numeric strings are
+    // surfaced via console.warn rather than silently collapsed to 0 (which
+    // masks schema/data drift). Recharts requires a numeric value to render,
+    // so we fall back to 0 only after logging.
+    const data = (Array.isArray(props.data) ? props.data : []).map((d) => {
+      const raw = (d as { value?: unknown }).value;
+      const n = typeof raw === "number" ? raw : parseFloat(raw as string);
+      let value: number;
+      if (Number.isFinite(n)) {
+        value = n;
+      } else {
+        console.warn("Invalid chart value", {
+          component: "BarChart",
+          key: "value",
+          raw,
+        });
+        value = 0;
+      }
+      return { ...d, value };
+    });
     return (
-      <Card
-        className="w-full flex-1 min-w-0 overflow-hidden"
-        data-testid="declarative-bar-chart"
+      <CardShell
+        title={props.title}
+        subtitle={props.description}
+        testid="declarative-bar-chart"
       >
-        {/* Scoped keyframe — no globals.css needed */}
-        <style>{`
-          @keyframes barSlideIn {
-            from { transform: translateY(40px); opacity: 0; }
-            20% { opacity: 1; }
-            to { transform: translateY(0); opacity: 1; }
-          }
-        `}</style>
-        <CardHeader>
-          <CardTitle>{props.title}</CardTitle>
-          <CardDescription>{props.description}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          {safeData.length === 0 ? (
-            <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">
-              No data available
-            </div>
-          ) : (
-            <ResponsiveContainer width="100%" height={260}>
-              <RechartsBarChart
-                data={safeData}
-                margin={{ top: 12, right: 12, bottom: 4, left: -8 }}
-              >
-                <CartesianGrid
-                  strokeDasharray="3 3"
-                  stroke="var(--border)"
-                  vertical={false}
-                />
-                <XAxis
-                  dataKey="label"
-                  tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
-                  stroke="var(--border)"
-                  tickLine={false}
-                  axisLine={false}
-                />
-                <YAxis
-                  tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
-                  stroke="var(--border)"
-                  tickLine={false}
-                  axisLine={false}
-                />
-                <Tooltip
-                  contentStyle={CHART_TOOLTIP_STYLE}
-                  cursor={{ fill: "var(--muted)", opacity: 0.5 }}
-                />
-                <Bar
-                  isAnimationActive={false}
-                  dataKey="value"
-                  radius={[6, 6, 0, 0]}
-                  maxBarSize={48}
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  shape={
-                    ((barProps: any) => (
-                      <AnimatedBar
-                        {...barProps}
-                        isNew={isNew(barProps.index as number)}
-                      />
-                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    )) as any
-                  }
-                >
-                  {safeData.map((_, index) => (
-                    <Cell
-                      key={index}
-                      fill={CHART_COLORS[index % CHART_COLORS.length]}
-                    />
-                  ))}
-                </Bar>
+        {data.length === 0 ? (
+          <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">
+            No data available
+          </div>
+        ) : (
+          <div style={{ width: "100%", height: 200 }}>
+            <ResponsiveContainer>
+              <RechartsBarChart data={data}>
+                <CartesianGrid strokeDasharray="3 3" stroke={c.divider} />
+                <XAxis dataKey="label" tick={{ fontSize: 11, fill: c.muted }} />
+                <YAxis tick={{ fontSize: 11, fill: c.muted }} />
+                <Tooltip />
+                <Bar dataKey="value" fill="#3b82f6" radius={[4, 4, 0, 0]} />
               </RechartsBarChart>
             </ResponsiveContainer>
-          )}
-        </CardContent>
-      </Card>
+          </div>
+        )}
+      </CardShell>
     );
   },
 };

--- a/showcase/integrations/strands/src/app/demos/declarative-gen-ui/chat.tsx
+++ b/showcase/integrations/strands/src/app/demos/declarative-gen-ui/chat.tsx
@@ -2,9 +2,11 @@
 
 import { CopilotChat } from "@copilotkit/react-core/v2";
 import { useDeclarativeGenUISuggestions } from "./suggestions";
+import { useSalesAnalystContext } from "./sales-context";
 
 export function Chat() {
   useDeclarativeGenUISuggestions();
+  useSalesAnalystContext();
   return (
     <CopilotChat agentId="declarative-gen-ui" className="h-full rounded-2xl" />
   );

--- a/showcase/integrations/strands/src/app/demos/declarative-gen-ui/page.tsx
+++ b/showcase/integrations/strands/src/app/demos/declarative-gen-ui/page.tsx
@@ -11,13 +11,14 @@
  *   2. Pass that catalog to the provider via
  *      `<CopilotKit a2ui={{ catalog: myCatalog }}>`.
  *   3. The dedicated runtime at `/api/copilotkit-declarative-gen-ui` is
- *      configured with `injectA2UITool: false` — the backend agent
- *      (`src/agents/a2ui_dynamic.py`) owns the `generate_a2ui` tool
- *      explicitly, mirroring the working pattern from beautiful-chat and the
- *      canonical `examples/integrations/langgraph-python` reference. The
- *      A2UI middleware still serialises the registered catalog schema into
- *      `copilotkit.context` so the secondary LLM inside `generate_a2ui`
- *      knows which components are available.
+ *      configured with `injectA2UITool: true` + `defaultCatalogId:
+ *      "declarative-gen-ui-catalog"`. The runtime injects a `generate_a2ui`
+ *      tool and drives a secondary render planner to GENERATE the surface;
+ *      the Strands adapter auto-injects the tool on the backend side when it
+ *      sees the forwarded flag (the dedicated backend agent wires no tool
+ *      itself). The A2UI middleware serialises the registered catalog schema
+ *      so the planner knows which components are available. Mirrors the
+ *      canonical `examples/integrations/langgraph-python` reference.
  *
  * Reference:
  *   https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui

--- a/showcase/integrations/strands/src/app/demos/declarative-gen-ui/sales-context.ts
+++ b/showcase/integrations/strands/src/app/demos/declarative-gen-ui/sales-context.ts
@@ -1,0 +1,43 @@
+import { useAgentContext } from "@copilotkit/react-core/v2";
+
+// Grounding data + composition rules for the sales-analyst demo persona.
+// Registered as agent context so it reaches both the primary agent (App
+// Context) and the secondary A2UI planner LLM, which serialises frontend
+// context entries into its system instruction.
+//
+// DUPLICATION NOTICE: This file is intentionally byte-duplicated across
+// the langgraph-python and google-adk integrations, per the showcase's
+// per-integration parity convention (no cross-integration imports). The
+// two copies MUST be kept byte-for-byte identical — verify with `diff`
+// after any edit, and update BOTH files in the same commit.
+//
+// TODO(OSS-136): Extract this dataset + composition rules into a shared
+// showcase module so both integrations import a single source of truth
+// instead of relying on manual byte-sync.
+const SALES_DATASET = `Vantage Threads (fictional B2B apparel company) — Q2 sales data. Ground every visual in these numbers; invent only plausible details consistent with them.
+- Quarterly revenue: $4.2M (up 12% QoQ). New customers: 186 (up 8%). Win rate: 31% (down 2pts). Avg deal size: $22.6k (up 5%).
+- Revenue by region: North America $1.9M, EMEA $1.3M, APAC $720k, LATAM $280k.
+- Monthly revenue: Jan $1.21M, Feb $1.34M, Mar $1.65M, Apr $1.38M, May $1.42M, Jun $1.40M.
+- Reps (vs quota): Dana Whitfield 124%, Marcus Lee 108%, Priya Sharma 97%, Tom Okafor 88%, Elena Vasquez 71%.
+- At-risk: total $615k ARR across 3 accounts — Northwind Retail ($340k renewal, no contact 6 weeks; severity high), Cascadia Outfitters ($180k, champion left; severity medium), Atlas Goods ($95k, stalled legal review; severity medium).
+- Biggest account: Meridian Apparel Group — owner Dana Whitfield, region North America, ARR $612k, renewal Sep 30, last contact 3 days ago, health green, 4 open opportunities worth $210k.
+- Meridian revenue by product line: Outerwear $260k, Footwear $180k, Accessories $112k, Custom $60k.`;
+
+const COMPOSITION_RULES = `Pick A2UI components by the shape of the question — never ask which chart the user wants:
+1. Overall snapshot / "sales dashboard" → a Column (gap 16) whose first child is a Row (gap 16) of 4 Metric tiles (each with trend + trendValue), followed by a Row with a PieChart (revenue by region) next to a BarChart (monthly revenue, all six months Jan-Jun). Do NOT wrap the dashboard in a surrounding Card — the charts carry their own card chrome. Do NOT use StatusBadge, DataTable, or InfoRow here.
+2. Rep / team performance → a Column (gap 16) with a Card containing a DataTable (columns: rep, attainment, pipeline) next to or above a BarChart of quota attainment % per rep — no StatusBadge or InfoRow.
+3. Risk / health checks → a Column (gap 16): first a Row (gap 16) of 3 Metric tiles (ARR at risk $615k trend down, accounts at risk 3, biggest exposure Northwind $340k), then a Row (gap 16) with one compact Card per at-risk account (title = account name, subtitle = ARR at stake) containing a StatusBadge (error for high severity, warning otherwise) above a one-line Text with the reason and the recommended next action — no DataTable or InfoRow.
+4. Single account/entity details → a Row (gap 16) with a Card of InfoRow facts (owner, region, ARR, renewal date, last contact) next to a PieChart of that account's revenue by product line — no DataTable or StatusBadge.
+5. Part-of-whole follow-ups → PieChart; trends or comparisons over time/categories → BarChart.
+Compose generously — a dashboard should feel like a real analytics product, not a single widget.`;
+
+export function useSalesAnalystContext() {
+  useAgentContext({
+    description: "Sales dataset for Vantage Threads (the demo company)",
+    value: SALES_DATASET,
+  });
+  useAgentContext({
+    description: "Dashboard composition rules for A2UI surfaces",
+    value: COMPOSITION_RULES,
+  });
+}

--- a/showcase/integrations/strands/src/app/demos/declarative-gen-ui/suggestions.ts
+++ b/showcase/integrations/strands/src/app/demos/declarative-gen-ui/suggestions.ts
@@ -1,25 +1,29 @@
 import { useConfigureSuggestions } from "@copilotkit/react-core/v2";
 
+// Pill prompts are natural business questions — chart-type steering lives in
+// the agent's system prompt (src/agents/a2ui_dynamic.py). Each pill maps to a
+// distinct catalog component so the D5 probe
+// (showcase/harness/src/probes/scripts/d5-gen-ui-declarative.ts) can assert a
+// newly-mounted testid per pill. Keep prompts in sync with that probe and with
+// tests/e2e/declarative-gen-ui.spec.ts.
 export function useDeclarativeGenUISuggestions() {
   useConfigureSuggestions({
     suggestions: [
       {
-        title: "Show a KPI dashboard",
-        message:
-          "Show me a quick KPI dashboard with 3-4 metrics (revenue, signups, churn).",
+        title: "Show my sales dashboard",
+        message: "Show me my sales dashboard for this quarter.",
       },
       {
-        title: "Pie chart — sales by region",
-        message: "Show a pie chart of sales by region.",
+        title: "Team performance",
+        message: "How are our sales reps performing against quota?",
       },
       {
-        title: "Bar chart — quarterly revenue",
-        message: "Render a bar chart of quarterly revenue.",
+        title: "Anything at risk?",
+        message: "Are any accounts or pipeline deals at risk this quarter?",
       },
       {
-        title: "Status report",
-        message:
-          "Give me a status report on system health — API, database, and background workers.",
+        title: "Top account details",
+        message: "Pull up the details on our biggest account.",
       },
     ],
     available: "always",


### PR DESCRIPTION
## What

Implements the **Declarative Generative UI (A2UI dynamic schema)** demo for both the **strands** (Python) and **strands-typescript** integrations, bringing the `declarative-gen-ui` cell to 1:1 parity with the canonical `langgraph-python` demo.

Stacked on `claude/xenodochial-turing-4f0ec3` (PR #5632, the strands demo fixes + a2ui-fixed-schema + `@ag-ui/aws-strands@0.2.2`). GitHub retargets to `main` once #5632 merges.

## How the dynamic wiring works

Unlike the fixed-schema sibling (a backend `display_flight` tool returning a pre-authored envelope), the dynamic demo lets the agent **generate** the surface:

- The runtime route sets `a2ui: { injectA2UITool: true, defaultCatalogId: "declarative-gen-ui-catalog" }` (exact option confirmed against `@copilotkit/runtime` + the langgraph-python gold-standard route).
- The CopilotKit runtime forwards `injectA2UITool` to the agent; the Strands adapter auto-injects `generate_a2ui` and drives a secondary `render_a2ui` planner.
- `StrandsAgentConfig.a2ui` supplies `default_catalog_id` + a `composition_guide` (sales dataset + composition rules) so the planner is self-contained (it receives `guidelines`, not the frontend App Context).
- A dedicated backend agent is mounted on the `/declarative-gen-ui` sub-path; the route's `HttpAgent` points there (mirrors the a2ui-fixed-schema pattern).

## Per-file changes (both integrations)

**Backend**
- `strands/src/agents/a2ui_dynamic.py` (new) / `strands-typescript/src/agent/agent.ts` (`buildA2uiDynamicAgent`): plain agent, no tool wired; `a2ui` config with catalog id + composition guide.
- `strands/src/agent_server.py` / `strands-typescript/src/agent/server.ts`: mount the agent at `/declarative-gen-ui`.
- `*/app/api/copilotkit-declarative-gen-ui/route.ts`: `injectA2UITool: true` + `defaultCatalogId`, HttpAgent → sub-path.
- `strands/requirements.txt`: `ag_ui_strands` 0.1.9 → **0.2.1** (A2UI auto-injection config landed in 0.2.0; pulls `ag-ui-a2ui-toolkit` transitively). strands-typescript already on 0.2.2.

**Frontend** (ported from langgraph-python for probe/catalog parity)
- `declarative-gen-ui/{suggestions.ts,chat.tsx,sales-context.ts,a2ui/definitions.ts,a2ui/renderers.tsx}`: sales-analyst pills + catalog incl `DataTable`/`InfoRow`. `page.tsx` keeps the Strands-specific wiring comment.

**Fixtures**
- `showcase/aimock/d6/{strands,strands-typescript}/gen-ui-declarative.json`: authored from the langgraph-python template (3 legs/pill: outer `generate_a2ui`, inner `render_a2ui`, narration).

## Verification (real OpenAI, gpt-4o)

Both integrations paint a **real A2UI surface** (not raw JSON / not plain text): `generate_a2ui Done` + 4 Metric tiles ($4.2M ↑12%, 186 ↑8%, 31% ↓2pts, $22.6k ↑5%) + Revenue-by-Region PieChart + Monthly Revenue BarChart (Jan–Jun) + narration. The painted components match the probe's expected testids and `minCounts` for the sales-dashboard pill.

## gen-ui-declarative D6 status — BLOCKED (not by this change)

The `gen-ui-declarative` D6 cell currently goes red at 0.0s with:

```
page.evaluate: ReferenceError: __name is not defined
```

This fires in the shared harness probe's `page.evaluate` during turn-1 `preFill`, **before any agent call** (page loads, the ported suggestions render, the route returns 200). It is a harness-tooling bug affecting `page.evaluate`-based probes generally, owned separately from this demo work. The fixtures + wiring here are correct, as the real-LLM paint above demonstrates; the cell will go green once the harness `__name` fix lands.