### PR TITLE
fix(core): preserve agent-level headers instead of overwriting them (#5635)

### DIFF
--- a/packages/core/src/__tests__/core-headers.test.ts
+++ b/packages/core/src/__tests__/core-headers.test.ts
@@ -194,6 +194,30 @@ describe("CopilotKitCore headers", () => {
     });
   });
 
+  it("re-surfaces the agent's own header when the core override is cleared (#5635)", () => {
+    const agent = new HttpAgent({
+      url: "https://runtime.example",
+      headers: { Authorization: "Bearer agent-token" },
+    });
+
+    const core = new CopilotKitCore({
+      runtimeUrl: undefined,
+      headers: { Authorization: "Bearer core-token" },
+      agents__unsafe_dev_only: { default: agent },
+    });
+
+    // Core overrides the agent's own Authorization on conflict.
+    expect(agent.headers).toMatchObject({ Authorization: "Bearer core-token" });
+
+    // Clearing the core override only drops core's value. The agent's own
+    // construction-time header is the merge baseline, so it re-surfaces rather
+    // than being removed — clearing an agent-level header is not possible via
+    // setHeaders by design (see #5635).
+    core.setHeaders({ Authorization: null });
+
+    expect(agent.headers).toEqual({ Authorization: "Bearer agent-token" });
+  });
+
   it("applies updated headers to existing HttpAgent instances", () => {
     const agent = new HttpAgent({ url: "https://runtime.example" });
 

--- a/packages/core/src/__tests__/core-headers.test.ts
+++ b/packages/core/src/__tests__/core-headers.test.ts
@@ -129,6 +129,71 @@ describe("CopilotKitCore headers", () => {
     }
   });
 
+  it("preserves agent-level headers not overridden by core headers (#5635)", () => {
+    const agent = new HttpAgent({
+      url: "https://runtime.example",
+      headers: { Authorization: "Bearer agent-token" },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const core = new CopilotKitCore({
+      runtimeUrl: undefined,
+      // No core-level headers configured at all.
+      agents__unsafe_dev_only: { default: agent },
+    });
+
+    // The agent's own Authorization header must survive registration.
+    expect(agent.headers).toMatchObject({
+      Authorization: "Bearer agent-token",
+    });
+  });
+
+  it("merges core headers over agent-level headers (#5635)", () => {
+    const agent = new HttpAgent({
+      url: "https://runtime.example",
+      headers: {
+        "X-Agent": "agent-value",
+        Authorization: "Bearer agent-token",
+      },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const core = new CopilotKitCore({
+      runtimeUrl: undefined,
+      headers: { Authorization: "Bearer core-token", "X-Core": "core-value" },
+      agents__unsafe_dev_only: { default: agent },
+    });
+
+    // Agent-only header survives, core-only header is added, and the conflicting
+    // Authorization is won by the core (provider-level) value.
+    expect(agent.headers).toEqual({
+      "X-Agent": "agent-value",
+      Authorization: "Bearer core-token",
+      "X-Core": "core-value",
+    });
+  });
+
+  it("retains agent-level headers across setHeaders updates (#5635)", () => {
+    const agent = new HttpAgent({
+      url: "https://runtime.example",
+      headers: { "X-Agent": "agent-value" },
+    });
+
+    const core = new CopilotKitCore({
+      runtimeUrl: undefined,
+      headers: { Authorization: "Bearer initial" },
+      agents__unsafe_dev_only: { default: agent },
+    });
+
+    core.setHeaders({ Authorization: "Bearer updated" });
+
+    // Updating core headers must not wipe the agent's own header.
+    expect(agent.headers).toMatchObject({
+      "X-Agent": "agent-value",
+      Authorization: "Bearer updated",
+    });
+  });
+
   it("applies updated headers to existing HttpAgent instances", () => {
     const agent = new HttpAgent({ url: "https://runtime.example" });
 

--- a/packages/core/src/__tests__/core-headers.test.ts
+++ b/packages/core/src/__tests__/core-headers.test.ts
@@ -218,6 +218,24 @@ describe("CopilotKitCore headers", () => {
     expect(agent.headers).toEqual({ Authorization: "Bearer agent-token" });
   });
 
+  it("keeps the pristine baseline across remove + re-add (no core-header pollution) (#5635)", () => {
+    const agent = new HttpAgent({ url: "https://runtime.example" });
+    const core = new CopilotKitCore({ runtimeUrl: undefined });
+
+    core.addAgent__unsafe_dev_only({ id: "x", agent });
+    core.setHeaders({ Authorization: "Bearer core" });
+    expect(agent.headers).toMatchObject({ Authorization: "Bearer core" });
+
+    // The baseline is captured once (pristine, empty here) and never
+    // re-captured, so removing then re-adding the same instance must not fold
+    // the stale core Authorization into the agent's "own" headers.
+    core.removeAgent__unsafe_dev_only("x");
+    core.setHeaders({});
+    core.addAgent__unsafe_dev_only({ id: "x", agent });
+
+    expect("Authorization" in agent.headers).toBe(false);
+  });
+
   it("applies updated headers to existing HttpAgent instances", () => {
     const agent = new HttpAgent({ url: "https://runtime.example" });
 

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -78,6 +78,15 @@ export class AgentRegistry {
   private _licenseStatus?: RuntimeLicenseStatus;
   private _telemetryDisabled: boolean = false;
 
+  /**
+   * The headers each HttpAgent was constructed with, captured the first time
+   * the agent is seen — before core headers are applied. Core headers are
+   * merged ON TOP of this baseline so that headers configured directly on an
+   * agent (e.g. an `Authorization` for a self-hosted backend) survive
+   * registration instead of being silently replaced. See #5635.
+   */
+  private agentOwnHeaders = new WeakMap<HttpAgent, Record<string, string>>();
+
   constructor(private core: CopilotKitCore) {}
 
   /**
@@ -311,7 +320,15 @@ export class AgentRegistry {
    */
   applyHeadersToAgent(agent: AbstractAgent): void {
     if (agent instanceof HttpAgent) {
+      // Capture the agent's construction-time headers once, before any core
+      // headers overwrite them. On every subsequent apply we rebuild from this
+      // baseline so re-applying core headers (e.g. via setHeaders) never loses
+      // the agent's own headers.
+      if (!this.agentOwnHeaders.has(agent)) {
+        this.agentOwnHeaders.set(agent, { ...agent.headers });
+      }
       agent.headers = {
+        ...this.agentOwnHeaders.get(agent),
         ...(this.core as unknown as CopilotKitCoreFriendsAccess).headers,
       };
     }

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -79,11 +79,14 @@ export class AgentRegistry {
   private _telemetryDisabled: boolean = false;
 
   /**
-   * The headers each HttpAgent was constructed with, captured the first time
-   * the agent is seen — before core headers are applied. Core headers are
-   * merged ON TOP of this baseline so that headers configured directly on an
-   * agent (e.g. an `Authorization` for a self-hosted backend) survive
-   * registration instead of being silently replaced. See #5635.
+   * The headers each HttpAgent was constructed with, captured on the first
+   * `applyHeadersToAgent` call for that agent (which, for agents the registry
+   * owns, happens at registration before any core headers are applied). Core
+   * headers are merged ON TOP of this baseline so that headers configured
+   * directly on an agent (e.g. an `Authorization` for a self-hosted backend)
+   * survive registration instead of being silently replaced. The baseline is
+   * captured once and never re-captured, so a later direct mutation of
+   * `agent.headers` is not folded into it. See #5635.
    */
   private agentOwnHeaders = new WeakMap<HttpAgent, Record<string, string>>();
 
@@ -316,7 +319,10 @@ export class AgentRegistry {
   }
 
   /**
-   * Apply current headers to an agent
+   * Apply current core headers to an agent, merged ON TOP of the agent's own
+   * construction-time headers (the per-agent baseline in `agentOwnHeaders`).
+   * Core wins on a key conflict. Non-`HttpAgent` agents are left untouched
+   * because only `HttpAgent` carries a `headers` field. See #5635.
    */
   applyHeadersToAgent(agent: AbstractAgent): void {
     if (agent instanceof HttpAgent) {

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -309,6 +309,13 @@ export interface CopilotKitCoreFriendsAccess {
   buildFrontendTools(agentId?: string): import("@ag-ui/client").Tool[];
   getContextForAgent(agentId?: string): Context[];
   getAgent(id: string): AbstractAgent | undefined;
+  /**
+   * Re-apply the current core headers to a single agent, merged on top of the
+   * headers the agent was constructed with. The single source of truth for
+   * header application; the run handler uses it so a run never clobbers
+   * per-agent headers (see #5635).
+   */
+  applyHeadersToAgent(agent: AbstractAgent): void;
 
   // References to delegate subsystems
   readonly suggestionEngine: {
@@ -677,8 +684,10 @@ export class CopilotKitCore {
    * ```
    *
    * The resulting header set is also re-applied to every registered
-   * `HttpAgent`-derived agent (replacing its `headers`) and `onHeadersChanged`
-   * subscribers are notified.
+   * `HttpAgent`-derived agent and `onHeadersChanged` subscribers are notified.
+   * These headers are merged ON TOP of any headers the agent was constructed
+   * with, so per-agent headers (e.g. an `Authorization` for a self-hosted
+   * backend) are preserved; on a key conflict the core-level value wins.
    */
   setHeaders(headers: Record<string, string | null | undefined>): void {
     this._headers = normalizeHeaders(headers);
@@ -756,6 +765,18 @@ export class CopilotKitCore {
 
   getAgent(id: string): AbstractAgent | undefined {
     return this.agentRegistry.getAgent(id);
+  }
+
+  /**
+   * Re-apply the current headers to a single agent (delegated to
+   * AgentRegistry). Core headers are merged on top of the agent's own
+   * construction-time headers rather than replacing them, so headers
+   * configured directly on an `HttpAgent` (e.g. an `Authorization` for a
+   * self-hosted backend) survive header updates instead of being silently
+   * dropped (see #5635). On a key conflict the core-level value wins.
+   */
+  applyHeadersToAgent(agent: AbstractAgent): void {
+    this.agentRegistry.applyHeadersToAgent(agent);
   }
 
   /**

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -683,11 +683,19 @@ export class CopilotKitCore {
    * });
    * ```
    *
-   * The resulting header set is also re-applied to every registered
-   * `HttpAgent`-derived agent and `onHeadersChanged` subscribers are notified.
-   * These headers are merged ON TOP of any headers the agent was constructed
-   * with, so per-agent headers (e.g. an `Authorization` for a self-hosted
-   * backend) are preserved; on a key conflict the core-level value wins.
+   * The resulting header set is also re-applied to every agent in the registry
+   * and `onHeadersChanged` subscribers are notified. These headers are merged
+   * ON TOP of the headers each `HttpAgent` was constructed with, so per-agent
+   * headers (e.g. an `Authorization` for a self-hosted backend) are preserved;
+   * on a key conflict the core-level value wins.
+   *
+   * Because the agent's construction-time headers form the merge baseline, this
+   * method can override a per-agent header but cannot REMOVE one: clearing a
+   * core key here only drops the core-level override, after which the agent's
+   * own value (if any) re-surfaces. To change a header an agent was constructed
+   * with, set it at the provider/core level instead of on the agent, or update
+   * it on the agent directly. The clear-on-logout pattern above is for
+   * core-level headers.
    */
   setHeaders(headers: Record<string, string | null | undefined>): void {
     this._headers = normalizeHeaders(headers);
@@ -774,6 +782,12 @@ export class CopilotKitCore {
    * configured directly on an `HttpAgent` (e.g. an `Authorization` for a
    * self-hosted backend) survive header updates instead of being silently
    * dropped (see #5635). On a key conflict the core-level value wins.
+   *
+   * The merge baseline is the agent's headers as captured the first time the
+   * agent is applied (at registration), so the way to change headers
+   * afterwards is `setHeaders` (which re-applies to every agent), not mutating
+   * `agent.headers` directly — a direct mutation is overwritten on the next
+   * re-apply.
    */
   applyHeadersToAgent(agent: AbstractAgent): void {
     this.agentRegistry.applyHeadersToAgent(agent);

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -40,7 +40,11 @@ export interface CopilotKitCoreConfig {
   runtimeTransport?: CopilotRuntimeTransport;
   /** Mapping from agent name to its `AbstractAgent` instance. For development only - production requires CopilotRuntime. */
   agents__unsafe_dev_only?: Record<string, AbstractAgent>;
-  /** Headers appended to every HTTP request made by `CopilotKitCore`. */
+  /**
+   * Headers sent with every runtime request and merged on top of each
+   * `HttpAgent`'s own headers (the core value wins on a key conflict). See
+   * `setHeaders`.
+   */
   headers?: Record<string, string>;
   /** Credentials mode for fetch requests (e.g., "include" for HTTP-only cookies). */
   credentials?: RequestCredentials;

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -6,7 +6,6 @@ import type {
   Tool,
   ToolCall,
 } from "@ag-ui/client";
-import { HttpAgent } from "@ag-ui/client";
 import { randomUUID, logger, schemaToJsonSchema } from "@copilotkit/shared";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import type { CopilotKitCore, CopilotKitCoreFriendsAccess } from "./core";
@@ -240,11 +239,9 @@ export class RunHandler {
         }
       }
 
-      if (agent instanceof HttpAgent) {
-        agent.headers = {
-          ...this._internal.headers,
-        };
-      }
+      // Re-apply core headers (merged on top of the agent's own headers) so a
+      // late header update is picked up without clobbering per-agent headers.
+      this._internal.applyHeadersToAgent(agent);
 
       const runAgentResult = await agent.connectAgent(
         {
@@ -292,11 +289,9 @@ export class RunHandler {
       void this._internal.suggestionEngine.clearSuggestions(agent.agentId);
     }
 
-    if (agent instanceof HttpAgent) {
-      agent.headers = {
-        ...this._internal.headers,
-      };
-    }
+    // Re-apply core headers (merged on top of the agent's own headers) so a
+    // late header update is picked up without clobbering per-agent headers.
+    this._internal.applyHeadersToAgent(agent);
 
     // Detach any active run (e.g. a long-lived connectAgent pipeline) before
     // starting a new run.  We await the detach to ensure the previous pipeline

--- a/packages/react-core/src/__tests__/threadid-propagation.contract.test.tsx
+++ b/packages/react-core/src/__tests__/threadid-propagation.contract.test.tsx
@@ -43,6 +43,7 @@ describe("useAgent → agent.threadId sync from chat configuration", () => {
     runtimeTransport: string;
     headers: Record<string, string>;
     agents: Record<string, AbstractAgent>;
+    applyHeadersToAgent: (agent: AbstractAgent) => void;
     subscribeToAgentWithOptions: (
       agent: AbstractAgent,
       subscriber: any,
@@ -58,6 +59,13 @@ describe("useAgent → agent.threadId sync from chat configuration", () => {
       runtimeTransport: "rest",
       headers: {},
       agents: {},
+      // Faithful to core: merge core headers ON TOP of the agent's own.
+      applyHeadersToAgent: (agent) => {
+        const target = agent as { headers?: Record<string, string> };
+        if (target.headers) {
+          target.headers = { ...target.headers, ...mockCopilotkit.headers };
+        }
+      },
       subscribeToAgentWithOptions: (agent, subscriber) =>
         agent.subscribe(subscriber),
     };

--- a/packages/react-core/src/__tests__/threadid-propagation.contract.test.tsx
+++ b/packages/react-core/src/__tests__/threadid-propagation.contract.test.tsx
@@ -59,7 +59,10 @@ describe("useAgent → agent.threadId sync from chat configuration", () => {
       runtimeTransport: "rest",
       headers: {},
       agents: {},
-      // Faithful to core: merge core headers ON TOP of the agent's own.
+      // Additive stand-in for core's merge (core headers ON TOP of the
+      // agent's own). These tests only assert threadId propagation and never
+      // remove a header, so this approximation is sufficient; it does NOT
+      // model core's frozen construction-time baseline.
       applyHeadersToAgent: (agent) => {
         const target = agent as { headers?: Record<string, string> };
         if (target.headers) {

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent-provider-headers.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent-provider-headers.e2e.test.tsx
@@ -46,7 +46,9 @@ describe("useAgent preserves agent-level headers (#5635)", () => {
     );
 
     await waitFor(() => {
-      expect(agent.headers).toMatchObject({
+      // Exact match: with no provider headers, the agent's own header set is
+      // the complete result (HttpAgent adds no defaults).
+      expect(agent.headers).toEqual({
         Authorization: "Bearer agent-token",
       });
     });

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent-provider-headers.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent-provider-headers.e2e.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { HttpAgent } from "@ag-ui/client";
+import { CopilotKitProvider } from "../../providers/CopilotKitProvider";
+import { useAgent } from "../use-agent";
+
+/**
+ * Regression test for #5635: headers configured directly on an HttpAgent that
+ * is registered via `agents__unsafe_dev_only` must NOT be silently dropped.
+ */
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+function AgentConsumer({ agentId }: { agentId: string }) {
+  useAgent({ agentId });
+  return null;
+}
+
+describe("useAgent preserves agent-level headers (#5635)", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ version: "1.0.0", agents: {} }),
+      text: () => Promise.resolve("{}"),
+    });
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps an agent's own Authorization header when no provider headers are set", async () => {
+    const agent = new HttpAgent({
+      url: "https://backend.example/agent",
+      headers: { Authorization: "Bearer agent-token" },
+    });
+
+    render(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <AgentConsumer agentId="default" />
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => {
+      expect(agent.headers).toMatchObject({
+        Authorization: "Bearer agent-token",
+      });
+    });
+  });
+
+  it("merges provider headers on top of the agent's own headers", async () => {
+    const agent = new HttpAgent({
+      url: "https://backend.example/agent",
+      headers: { "X-Agent": "agent-value", Authorization: "Bearer agent" },
+    });
+
+    render(
+      <CopilotKitProvider
+        agents__unsafe_dev_only={{ default: agent }}
+        headers={{ Authorization: "Bearer provider", "X-Provider": "p" }}
+      >
+        <AgentConsumer agentId="default" />
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => {
+      // Agent-only header survives, provider-only header is added, and the
+      // conflicting Authorization is won by the provider-level value.
+      expect(agent.headers).toMatchObject({
+        "X-Agent": "agent-value",
+        Authorization: "Bearer provider",
+        "X-Provider": "p",
+      });
+    });
+  });
+});

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent-stability.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent-stability.test.tsx
@@ -45,7 +45,10 @@ describe("useAgent stability during runtime connection", () => {
       runtimeTransport: "rest",
       headers: {},
       agents: {},
-      // Faithful to core: merge core headers ON TOP of the agent's own.
+      // Additive stand-in for core's merge (core headers ON TOP of the
+      // agent's own). These tests only assert agent identity / threadId and
+      // never remove a header, so this approximation is sufficient; it does
+      // NOT model core's frozen construction-time baseline.
       applyHeadersToAgent: (agent) => {
         const target = agent as { headers?: Record<string, string> };
         if (target.headers) {

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent-stability.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent-stability.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { AbstractAgent } from "@ag-ui/client";
+import type { AbstractAgent } from "@ag-ui/client";
 import { useCopilotKit } from "../../context";
 import { MockStepwiseAgent } from "../../__tests__/utils/test-helpers";
 import { useAgent } from "../use-agent";
@@ -29,6 +29,7 @@ describe("useAgent stability during runtime connection", () => {
     runtimeTransport: string;
     headers: Record<string, string>;
     agents: Record<string, AbstractAgent>;
+    applyHeadersToAgent: (agent: AbstractAgent) => void;
     subscribeToAgentWithOptions: (
       agent: AbstractAgent,
       subscriber: any,
@@ -44,6 +45,13 @@ describe("useAgent stability during runtime connection", () => {
       runtimeTransport: "rest",
       headers: {},
       agents: {},
+      // Faithful to core: merge core headers ON TOP of the agent's own.
+      applyHeadersToAgent: (agent) => {
+        const target = agent as { headers?: Record<string, string> };
+        if (target.headers) {
+          target.headers = { ...target.headers, ...mockCopilotkit.headers };
+        }
+      },
       subscribeToAgentWithOptions: (agent, subscriber) =>
         agent.subscribe(subscriber),
     };

--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -94,7 +94,7 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
       const cached = provisionalAgentCache.current.get(agentId);
       if (cached) {
         // Update headers on the cached agent in case they changed
-        cached.headers = { ...copilotkit.headers };
+        copilotkit.applyHeadersToAgent(cached);
         return cached;
       }
 
@@ -105,7 +105,7 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
         runtimeMode: "pending",
       });
       // Apply current headers so runs/connects inherit them
-      provisional.headers = { ...copilotkit.headers };
+      copilotkit.applyHeadersToAgent(provisional);
       provisionalAgentCache.current.set(agentId, provisional);
       return provisional;
     }
@@ -121,7 +121,7 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
     ) {
       const cached = provisionalAgentCache.current.get(agentId);
       if (cached) {
-        cached.headers = { ...copilotkit.headers };
+        copilotkit.applyHeadersToAgent(cached);
         return cached;
       }
       const provisional = new ProxiedCopilotRuntimeAgent({
@@ -130,7 +130,7 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
         transport: copilotkit.runtimeTransport,
         runtimeMode: "pending",
       });
-      provisional.headers = { ...copilotkit.headers };
+      copilotkit.applyHeadersToAgent(provisional);
       provisionalAgentCache.current.set(agentId, provisional);
       return provisional;
     }
@@ -218,7 +218,10 @@ export function useAgent({ agentId, updates, throttleMs }: UseAgentProps = {}) {
   // discard intermediate results, but mutations always land).
   useEffect(() => {
     if (agent instanceof HttpAgent) {
-      agent.headers = { ...copilotkit.headers };
+      // Merge core headers on top of the agent's own headers rather than
+      // replacing them, so per-agent headers (e.g. an Authorization for a
+      // self-hosted backend) are preserved (see #5635).
+      copilotkit.applyHeadersToAgent(agent);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agent, JSON.stringify(copilotkit.headers)]);


### PR DESCRIPTION
Fixes #5635.

## What

Headers set directly on an `HttpAgent` registered via `agents__unsafe_dev_only` were silently replaced by the provider headers. Per-agent auth headers (like an `Authorization` for a self-hosted backend) got dropped, causing 401s.

## Why

`AgentRegistry.applyHeadersToAgent` did `agent.headers = { ...core.headers }`, a full overwrite. The run handler and the react-core `useAgent` hook did the same. So an agent built with its own headers lost them on registration, on every `setHeaders`, and before each request.

## Fix

Merge instead of replace. The registry captures each agent's own headers once (in a WeakMap, before the first apply) and rebuilds `{ ...ownHeaders, ...coreHeaders }`. Core wins on key conflicts, which keeps the existing "provider headers are authoritative" and logout/clear behavior. All header application now routes through one method, `CopilotKitCore.applyHeadersToAgent`, so runs never clobber per-agent headers.

Vue and Angular benefit too: they dispatch runs through `core.runAgent` / `connectAgent`, so the merge is re-applied before every request.

## Tests

- core: 3 new cases in `core-headers.test.ts` (preserve, merge, retain-across-setHeaders); existing overwrite and clear tests still pass.
- react-core: new `use-agent-provider-headers.e2e.test.tsx` with a real provider and an HttpAgent that has its own headers.

Verified locally: format, lint, full core + react-core suites, and both builds.
