### PR TITLE
fix(showcase): wire promote-notify renderer + 2-line success Slack message

### DIFF
--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -216,6 +216,14 @@ jobs:
       # staging was NOT serving :latest). Folded into the Slack notify payload
       # so operators see "what shipped to prod is not current :latest".
       staging_drift: ${{ steps.promote.outputs.staging_drift }}
+      # Base64-encoded results JSON (schema_version=1) carrying BOTH the
+      # succeeded[] and failed[] sets, consumed by the three-variant Slack
+      # renderer (showcase_promote_notify.yml). promote-fleet.sh is the SSOT
+      # for the result set; the notify job enriches this blob with run-context
+      # (run_id, trigger, operator, elapsed, pre_staging) before dispatch.
+      # Empty when the promote step did not run (the notify job synthesizes a
+      # total-failure blob in that case).
+      results_b64: ${{ steps.promote.outputs.results_b64 }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -453,172 +461,138 @@ jobs:
           showcase/scripts/lint-prod-gate.sh
 
   notify:
-    # Slack #oss-alerts only. Never #engr (engr is sacred — release alerts only).
+    # Single Slack message per run via the three-variant aggregated renderer
+    # (.github/workflows/showcase_promote_notify.yml): success ✅ / partial ⚠️
+    # (per-service Failed bullets, cross-posts #oss-alerts) / total ❌. This job
+    # REPLACES the old inline two-state notify (success/failure-only, which
+    # dumped the full requested CSV and mislabeled a partial promote as a blanket
+    # "Failed [all 39]"). It builds the results JSON (from the promote job's
+    # results_b64, enriched with this run's context) and DISPATCHES the renderer.
+    #
+    # Best-effort promote invariant (do NOT reintroduce a PRE gate):
+    #   resolve-targets              = HARD precondition (must succeed).
+    #   verify-staging-precondition  = ADVISORY only — surfaced in the Slack
+    #                                  payload (`pre_staging`), never gates
+    #                                  promote or run success.
+    #   promote                      = best-effort (exits non-zero iff a
+    #                                  service failed).
+    #   verify-prod                  = verifies the succeeded subset.
     needs: [resolve-targets, verify-staging-precondition, promote, verify-prod]
     if: always()
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
     permissions:
+      # The job's own GITHUB_TOKEN cannot start NEW workflow runs (Actions'
+      # recursion-prevention drops workflow_dispatch events authenticated with
+      # GITHUB_TOKEN), so the renderer dispatch goes through the devops-bot App
+      # token minted below — mirroring canary.yml's cross-workflow dispatch.
       contents: read
-      actions: read
-    env:
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
-      SLACK_WEBHOOK_TS: ${{ secrets.SLACK_WEBHOOK_TEAM_SHOWCASE }}
     steps:
-      # Best-effort promote invariant (do NOT reintroduce a PRE gate below):
-      #   resolve-targets              = HARD precondition (must succeed).
-      #   verify-staging-precondition  = ADVISORY only — surfaced in the Slack
-      #                                  payload (`pre-staging`), never gates
-      #                                  promote or run success. bin/railway
-      #                                  enforces staging-green per-service, so
-      #                                  PRE is a leading indicator, not a gate.
-      #   promote                      = best-effort (exits non-zero iff a
-      #                                  service failed).
-      #   verify-prod                  = verifies the succeeded subset.
-      #   run success                  = PROMOTE == success AND PROD == success.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - name: Compute state
-        id: state
+      - name: Build notify payload
+        id: payload
         env:
+          INPUT: ${{ inputs.service }}
+          # promote-fleet's results JSON (schema_version=1, succeeded[]+failed[]).
+          # Empty when the promote step did not run (upstream abort/skip/cancel).
+          RESULTS_B64: ${{ needs.promote.outputs.results_b64 }}
           RESOLVE: ${{ needs.resolve-targets.result }}
           PRE: ${{ needs.verify-staging-precondition.result }}
           PROMOTE: ${{ needs.promote.result }}
           PROD: ${{ needs.verify-prod.result }}
-          # The verify-prod job's own status output: `success` (prod actually
-          # probed + passed) or `skipped` (nothing promoted, so prod was never
-          # touched). Empty when the job failed/cancelled or never wrote it.
-          PROD_STATUS: ${{ needs.verify-prod.outputs.status }}
-          CSV: ${{ needs.resolve-targets.outputs.services_csv }}
-          INPUT: ${{ inputs.service }}
-          # Aggregated staging-drift payload from the promote job (empty when no
-          # service drifted). Surfaced in BOTH Slack payloads below so a drifted
-          # promote is loud even on a successful run.
-          DRIFT: ${{ needs.promote.outputs.staging_drift }}
+          # Operator identity for the renderer's `operator_mention`. The renderer
+          # prefers a Slack users.lookupByEmail on operator_email; we have no
+          # reliable email for github.actor, so pass the actor as the git-name
+          # fallback (the renderer degrades to it when the email lookup is empty).
+          ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
-          # Displayed verify-prod value for the Slack line. The job `result` is
-          # `success` for BOTH a real pass AND the empty-CSV skip (which exits
-          # 0), so a bare `result` would read `verify-prod=success` even when
-          # prod was never probed. The mapping (prefer the job's `status` output
-          # when it ran cleanly, else fall back to the raw result) lives in the
-          # bats-tested showcase/scripts/verify-prod-display.sh so it can't
-          # drift from its test (see __tests__/verify-prod-display.bats).
-          PROD_DISPLAY="$(PROD="$PROD" PROD_STATUS="$PROD_STATUS" showcase/scripts/verify-prod-display.sh)"
+          # SKIP cases that must NOT post a Slack message (parity with the old
+          # neutral-state arms): a deliberate no-pick abort, or a human cancel.
           if [ "$INPUT" = "__select_a_service__" ]; then
-            # Deliberate no-op abort: a human clicked Run without picking a
-            # service. resolve-targets exits 1 and the downstream jobs skip.
-            # This is NOT a failed promote — emit a neutral state so no red
-            # alert pages #oss-alerts.
-            STATE="aborted"; ICON=":heavy_minus_sign:"
-          elif [ "$PROMOTE" = "success" ] && [ "$PROD" = "success" ]; then
-            # PRE (verify-staging-precondition) is ADVISORY and intentionally
-            # NOT in this gate: bin/railway enforces staging-green per-service,
-            # so a service that was staging-red at precondition time but still
-            # promoted+verified cleanly must not red the run. PRE remains
-            # surfaced in the Slack payload as the `pre-staging` field.
-            STATE="success"; ICON=":white_check_mark:"
-          elif [ "$RESOLVE" = "cancelled" ] || [ "$PRE" = "cancelled" ] || [ "$PROMOTE" = "cancelled" ] || [ "$PROD" = "cancelled" ]; then
-            # A human cancelled the run (e.g. via the Actions UI). This is a
-            # deliberate stop, not a failed promote — emit a neutral state so
-            # no red alert pages #oss-alerts. Cancelling DURING resolve-targets
-            # leaves the three downstream jobs `skipped` (not `cancelled`), so
-            # we must consult RESOLVE here too or the cancel would fall through
-            # to `failure` and fire a false red page.
-            STATE="cancelled"; ICON=":heavy_minus_sign:"
+            echo "::notice::no service selected (deliberate no-op abort); skipping Slack notify."
+            echo "dispatch=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$RESOLVE" = "cancelled" ] || [ "$PRE" = "cancelled" ] || [ "$PROMOTE" = "cancelled" ] || [ "$PROD" = "cancelled" ]; then
+            echo "::notice::run cancelled by a human; skipping Slack notify (no red page)."
+            echo "dispatch=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Map the ADVISORY verify-staging-precondition result onto the
+          # renderer's pre_staging glyph vocabulary (green/amber/red/skipped).
+          case "$PRE" in
+            success) PRE_STAGING="green" ;;
+            failure) PRE_STAGING="amber" ;;   # advisory red → amber (not a gate)
+            *)       PRE_STAGING="skipped" ;;
+          esac
+
+          # 6-char lowercase hex run_id — the renderer's HARD CONTRACT
+          # (^[0-9a-f]{6}$; see its run-name directive). Derive it from this
+          # run's own id so it is stable + greppable, never random.
+          RUN_ID=$(printf '%06x' "$(( GITHUB_RUN_ID % 16777216 ))")
+
+          # Base results JSON: prefer promote-fleet's emitted blob (the SSOT for
+          # succeeded[]/failed[]). When promote never ran (no results_b64), the
+          # run aborted upstream — synthesize a total-failure blob so the
+          # renderer posts the ❌ variant instead of nothing.
+          if [ -n "${RESULTS_B64:-}" ]; then
+            if ! printf '%s' "$RESULTS_B64" | base64 -d > /tmp/results-base.json 2>/dev/null; then
+              echo "::error::failed to decode promote results_b64"
+              exit 1
+            fi
           else
-            STATE="failure"; ICON=":x:"
+            jq -nc '{schema_version:1, abort_reason:"fleet-preflight", succeeded:[], failed:[]}' > /tmp/results-base.json
           fi
-          # Human-facing drift suffix for the Slack message. Empty string when
-          # there is no drift (renders as nothing); otherwise a loud prefix line
-          # naming the drifted services + digests. MUST be single-line (no
-          # embedded LF) so it survives the GITHUB_OUTPUT key=value contract: a
-          # newline anywhere in $DRIFT (upstream free-form text) would otherwise
-          # split the value across lines and corrupt/inject the whole output map.
-          # We ENFORCE that here via `tr -d '\n'` rather than trusting upstream.
-          DRIFT_LINE=""
-          if [ -n "${DRIFT:-}" ]; then
-            DRIFT_LINE="$(printf '%s' ":warning: STAGING DRIFT — prod pinned to staging's RUNNING digest, NOT current :latest — $DRIFT" | tr -d '\n')"
-          fi
+
+          # Enrich the base blob with this run's context (run_id, trigger,
+          # operator, elapsed, pre_staging). trigger=workflow (the renderer maps
+          # it to the `showcase_promote.yml` label). elapsed is best-effort 0
+          # here (the workflow does not track wall-clock); the renderer formats
+          # it as "0m 00s".
+          ENRICHED_B64=$(jq -c \
+            --arg run_id "$RUN_ID" \
+            --arg trigger "workflow" \
+            --arg actor "$ACTOR" \
+            --arg pre "$PRE_STAGING" \
+            '. + {run_id:$run_id, trigger:$trigger, operator_git_name:$actor, elapsed_seconds:0, pre_staging:$pre}' \
+            /tmp/results-base.json | base64 | tr -d '\n')
+
           {
-            echo "state=$STATE"
-            echo "icon=$ICON"
-            echo "csv=$CSV"
-            echo "prod_display=$PROD_DISPLAY"
-            echo "drift_line=$DRIFT_LINE"
+            echo "dispatch=1"
+            echo "run_id=$RUN_ID"
+            echo "results_b64=$ENRICHED_B64"
           } >> "$GITHUB_OUTPUT"
-      - name: Post to #oss-alerts
-        if: steps.state.outputs.state == 'failure' && inputs.service != '__select_a_service__' && env.SLACK_WEBHOOK != ''
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+      - name: Mint devops-bot token
+        id: app-token
+        if: steps.payload.outputs.dispatch == '1'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
-          webhook-type: incoming-webhook
-          # Newlines are injected via fromJSON('"\n"') (a real LF char), NOT a
-          # literal '\n' in the template: GitHub Actions expression string
-          # literals do not interpret backslash escapes, so a literal '\n' would
-          # survive toJSON as the two chars \\n and Slack would render it
-          # verbatim as "\n" instead of a line break.
-          payload: |
-            {
-              "text": ${{ toJSON(format(
-                '{0} *Showcase Promote Failed*{9}Services: `{1}`{9}resolve-targets={2} pre-staging={3} promote={4} verify-prod={5}{10}{9}<{6}/{7}/actions/runs/{8}|View run>',
-                steps.state.outputs.icon,
-                steps.state.outputs.csv,
-                needs.resolve-targets.result,
-                needs.verify-staging-precondition.result,
-                needs.promote.result,
-                steps.state.outputs.prod_display,
-                github.server_url,
-                github.repository,
-                github.run_id,
-                fromJSON('"\n"'),
-                steps.state.outputs.drift_line != '' && format('{0}{1}', fromJSON('"\n"'), steps.state.outputs.drift_line) || ''
-              )) }}
-            }
-      - name: Post to #team-showcase
-        if: steps.state.outputs.state == 'success' && inputs.service != '__select_a_service__' && env.SLACK_WEBHOOK_TS != ''
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_TEAM_SHOWCASE }}
-          webhook-type: incoming-webhook
-          # Newlines via fromJSON('"\n"') (real LF), not a literal '\n' — see the
-          # #oss-alerts step above for why a literal '\n' renders verbatim.
-          payload: |
-            {
-              "text": ${{ toJSON(format(
-                '{0} *Showcase Promoted to Prod*{5}Services: `{1}`{6}{5}<{2}/{3}/actions/runs/{4}|View run>',
-                steps.state.outputs.icon,
-                steps.state.outputs.csv,
-                github.server_url,
-                github.repository,
-                github.run_id,
-                fromJSON('"\n"'),
-                steps.state.outputs.drift_line != '' && format('{0}{1}', fromJSON('"\n"'), steps.state.outputs.drift_line) || ''
-              )) }}
-            }
-      - name: Log (no Slack — webhook unset)
-        if: steps.state.outputs.state == 'failure' && inputs.service != '__select_a_service__' && env.SLACK_WEBHOOK == ''
+          app-id: 1108748
+          private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
+          # actions=write is the ONLY scope needed: dispatch the sibling renderer
+          # workflow. The default GITHUB_TOKEN cannot start new workflow runs.
+          permission-actions: write
+      - name: Dispatch showcase_promote_notify.yml
+        if: steps.payload.outputs.dispatch == '1'
         env:
-          CSV: ${{ steps.state.outputs.csv }}
-          DRIFT_LINE: ${{ steps.state.outputs.drift_line }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RESULTS_B64: ${{ steps.payload.outputs.results_b64 }}
+          RUN_ID: ${{ steps.payload.outputs.run_id }}
         run: |
-          echo "::warning::Showcase promote failed for '$CSV' but SLACK_WEBHOOK_OSS_ALERTS is not set; no Slack notification sent."
-          # Preserve the staging-drift signal on the webhook-unset path (it would
-          # otherwise only survive in the promote job's step summary, not here).
-          if [ -n "$DRIFT_LINE" ]; then
-            echo "::warning::$DRIFT_LINE"
-          fi
-      - name: Log (no Slack — team-showcase webhook unset)
-        if: steps.state.outputs.state == 'success' && inputs.service != '__select_a_service__' && env.SLACK_WEBHOOK_TS == ''
-        env:
-          CSV: ${{ steps.state.outputs.csv }}
-          ICON: ${{ steps.state.outputs.icon }}
-          DRIFT_LINE: ${{ steps.state.outputs.drift_line }}
-        run: |
-          echo "::notice::$ICON Showcase promoted to prod for '$CSV' but SLACK_WEBHOOK_TEAM_SHOWCASE is not set; no #team-showcase notification sent."
-          # Preserve the staging-drift signal on the webhook-unset path (it would
-          # otherwise only survive in the promote job's step summary, not here).
-          if [ -n "$DRIFT_LINE" ]; then
-            echo "::warning::$DRIFT_LINE"
-          fi
+          set -euo pipefail
+          # Dispatch the three-variant renderer. It owns ALL Slack posting
+          # (#team-showcase init + thread, #oss-alerts cross-post on
+          # partial/total). Pass trigger=workflow + the 6-hex run_id (which is
+          # also the renderer's run-name for the CLI's gh-run-list polling
+          # contract). Dispatched on the default branch (no --ref) so the
+          # renderer's reviewed main-branch definition runs.
+          gh workflow run showcase_promote_notify.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            -f results="$RESULTS_B64" \
+            -f trigger=workflow \
+            -f run_id="$RUN_ID"
+          echo "dispatched showcase_promote_notify.yml (run_id=$RUN_ID)"

--- a/.github/workflows/showcase_promote_notify.dry-run.sh
+++ b/.github/workflows/showcase_promote_notify.dry-run.sh
@@ -90,6 +90,16 @@ failed_real_count=$(jq 'length' /tmp/dry-run-failed-render.json)
 
 total_count=$((succeeded_count + failed_real_count))
 
+# Comma-separated list of the SUCCEEDED service names, for the ✅ success
+# thread reply. The runtime blob emits .succeeded[] as {service} objects (see
+# promote-fleet.sh); tolerate bare strings too (hand-written fixtures use them).
+succeeded_csv=$(jq -r '[.succeeded[] | if type == "object" then .service else . end] | join(", ")' "$R")
+
+# GitHub Actions run URL — used by the success message's inline "View run" link.
+# In CI GITHUB_REPOSITORY/GITHUB_RUN_ID are set; in a bare dry-run they may not
+# be, so fall back to a stable placeholder so the rendered shape still matches.
+gha_url="https://github.com/${GITHUB_REPOSITORY:-CopilotKit/CopilotKit}/actions/runs/${GITHUB_RUN_ID:-<run_id>}"
+
 fmt_elapsed() {
   local total="$1"
   local m=$((total / 60))
@@ -170,8 +180,8 @@ ${fail_bullets}"
   fi
 elif [ "$failed_real_count" -eq 0 ]; then
   outcome="success"
-  thread_text="✅ *Done in ${elapsed_str}* — ${succeeded_count} ✓ · 0 ✗
-verify-prod: ✓ all green"
+  thread_text="✅ *Showcase Promoted to Prod* — ${succeeded_count} ✓  ·  <${gha_url}|View run>
+Services: ${succeeded_csv}"
 elif [ "$succeeded_count" -gt 0 ] && [ "$failed_real_count" -gt 0 ]; then
   outcome="partial"
   thread_text="⚠️ *Done in ${elapsed_str}* — ${succeeded_count} ✓ · ${failed_real_count} ✗

--- a/.github/workflows/showcase_promote_notify.yml
+++ b/.github/workflows/showcase_promote_notify.yml
@@ -122,6 +122,16 @@ jobs:
           succeeded_count=$(jq -r '.succeeded | length' "$R")
           failed_count=$(jq -r '.failed | length' "$R")
 
+          # Comma-separated list of the SUCCEEDED service names, for the ✅
+          # success thread reply. The runtime blob emits .succeeded[] as
+          # {service} objects (see promote-fleet.sh); tolerate bare strings too.
+          succeeded_csv=$(jq -r '[.succeeded[] | if type == "object" then .service else . end] | join(", ")' "$R")
+
+          # GitHub Actions run URL — used by the success message's inline
+          # "View run" link AND by the cross-post branch's permalink fallback.
+          # Computed once here so both render the SAME url.
+          gha_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
           # Sort failed alphabetically by service and split off the
           # truncation-suffix sentinel (if any) so it renders as a
           # trailing "+ K more" line instead of a bullet.
@@ -272,8 +282,8 @@ jobs:
             fi
           elif [ "$failed_real_count" -eq 0 ]; then
             outcome="success"
-            thread_text="✅ *Done in ${elapsed_str}* — ${succeeded_count} ✓ · 0 ✗
-          verify-prod: ✓ all green"
+            thread_text="✅ *Showcase Promoted to Prod* — ${succeeded_count} ✓  ·  <${gha_url}|View run>
+          Services: ${succeeded_csv}"
           elif [ "$succeeded_count" -gt 0 ] && [ "$failed_real_count" -gt 0 ]; then
             outcome="partial"
             thread_text="⚠️ *Done in ${elapsed_str}* — ${succeeded_count} ✓ · ${failed_real_count} ✗
@@ -325,8 +335,9 @@ jobs:
             if [ -n "$permalink" ]; then
               link_suffix="thread: ${permalink}"
             else
-              # No Slack permalink available; link to the GitHub Actions run instead.
-              gha_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+              # No Slack permalink available; link to the GitHub Actions run
+              # instead. gha_url is hoisted in the decode-payload section so the
+              # success message and this fallback share the same URL.
               link_suffix="thread permalink unavailable; see ${gha_url}"
             fi
             case "$outcome" in

--- a/showcase/scripts/__tests__/promote-fleet.bats
+++ b/showcase/scripts/__tests__/promote-fleet.bats
@@ -309,6 +309,82 @@ STUB
   [[ "$output" != *"staging_drift=svc"* ]] || fail "unexpected drift payload: $output"
 }
 
+# ── results JSON for the three-variant Slack renderer ───────────────────────
+#
+# promote-fleet emits a base64-encoded `results` blob (schema_version=1)
+# consumed by .github/workflows/showcase_promote_notify.yml. The renderer is
+# the SSOT for the schema; these tests assert promote-fleet emits a blob that
+# matches it: valid base64 → valid JSON, schema_version=1, BOTH succeeded[] and
+# failed[] present, succeeded[] entries are `{service}` objects, and failed[]
+# entries are `{service, exit, category}` with the real exit code. The
+# end-to-end RED-GREEN proof (decode → pipe through the dry-run harness →
+# rendered ⚠️ partial / ✅ success / ❌ total message) lives outside bats.
+
+# decode_results_b64 — read results_b64 from $GITHUB_OUTPUT and decode it to
+# stdout as JSON, failing the test loudly if the key is absent or the value is
+# not valid base64/JSON. Mirrors the renderer's decode step.
+decode_results_b64() {
+  local b64
+  b64=$(grep '^results_b64=' "$GITHUB_OUTPUT" | head -1 | cut -d= -f2-)
+  [ -n "$b64" ] || fail "results_b64 key absent from GITHUB_OUTPUT: $(cat "$GITHUB_OUTPUT")"
+  printf '%s' "$b64" | base64 -d 2>/dev/null || fail "results_b64 is not valid base64: $b64"
+}
+
+@test "emits results JSON (schema_version=1) with both succeeded[] and failed[] on a partial promote" {
+  # Mixed run: svc-a/svc-c succeed, svc-b fails (exit 7). The emitted blob must
+  # carry the partial outcome the renderer turns into the ⚠️ partial message.
+  run env SERVICES_CSV="svc-a,svc-b,svc-c" bash "$SCRIPT"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit on partial, got $status: $output"
+
+  # Decode → valid JSON with schema_version=1.
+  json=$(decode_results_b64)
+  echo "$json" | jq -e '.schema_version == 1' >/dev/null \
+    || fail "schema_version != 1: $json"
+
+  # succeeded[] = the two that pinned, as {service} objects (renderer reads
+  # length only, but we emit objects for symmetry/future use).
+  [ "$(echo "$json" | jq -r '.succeeded | length')" = "2" ] \
+    || fail "succeeded[] should have 2 entries: $json"
+  echo "$json" | jq -e '[.succeeded[].service] | sort == ["svc-a","svc-c"]' >/dev/null \
+    || fail "succeeded[] services wrong: $json"
+
+  # failed[] = svc-b with its REAL exit code (7) + the default category. The
+  # renderer renders "• `svc-b` — exit 7 (promote-failed)".
+  [ "$(echo "$json" | jq -r '.failed | length')" = "1" ] \
+    || fail "failed[] should have exactly 1 entry: $json"
+  echo "$json" | jq -e '.failed[0] == {service:"svc-b", exit:7, category:"promote-failed"}' >/dev/null \
+    || fail "failed[0] does not match {svc-b, exit 7, promote-failed}: $json"
+
+  # The failed service must NOT leak into succeeded[].
+  echo "$json" | jq -e '[.succeeded[].service] | index("svc-b") == null' >/dev/null \
+    || fail "failed svc-b leaked into succeeded[]: $json"
+}
+
+@test "emits results JSON with empty failed[] on an all-green promote" {
+  export RAILWAY_BIN="$STUB_DIR/railway-green"
+  run env SERVICES_CSV="svc-a,svc-b,svc-c" bash "$SCRIPT"
+  [ "$status" -eq 0 ] || fail "expected zero exit, got $status: $output"
+
+  json=$(decode_results_b64)
+  echo "$json" | jq -e '.schema_version == 1' >/dev/null || fail "schema_version != 1: $json"
+  [ "$(echo "$json" | jq -r '.succeeded | length')" = "3" ] || fail "succeeded[] should have 3: $json"
+  # Empty failed[] → the renderer's ✅ success variant.
+  echo "$json" | jq -e '.failed == []' >/dev/null || fail "failed[] should be empty on all-green: $json"
+}
+
+@test "emits results JSON with empty succeeded[] on an all-fail promote (total variant)" {
+  # Every service fails → succeeded[]=[], failed[] non-empty → the renderer's
+  # ❌ total-failure variant (succeeded==0 && failed>0 defensive branch).
+  run env SERVICES_CSV="svc-b" bash "$SCRIPT"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit, got $status: $output"
+
+  json=$(decode_results_b64)
+  echo "$json" | jq -e '.schema_version == 1' >/dev/null || fail "schema_version != 1: $json"
+  echo "$json" | jq -e '.succeeded == []' >/dev/null || fail "succeeded[] should be empty on all-fail: $json"
+  [ "$(echo "$json" | jq -r '.failed | length')" = "1" ] || fail "failed[] should have 1: $json"
+  echo "$json" | jq -e '.failed[0].exit == 7' >/dev/null || fail "failed exit code wrong: $json"
+}
+
 # ── U4: tier-ordered closure promote with dependent-tier gating ─────────────
 #
 # When CLOSURE_PLAN (tier-annotated `tier:name,tier:name,...` from U3's

--- a/showcase/scripts/promote-fleet.sh
+++ b/showcase/scripts/promote-fleet.sh
@@ -130,6 +130,32 @@ svc_slot() {
   printf '%s' "${1//\//_}"
 }
 
+# failed_set_to_json <svc=rc>... -> emit the failed[] array consumed by the
+# showcase_promote_notify.yml renderer: one object per entry, each
+# `{service, exit, category}`. promote-fleet tracks only `svc=exitcode` (no
+# failure taxonomy), so every entry gets the default category "promote-failed".
+# The renderer renders these as "• `<service>` — exit <exit> (<category>)".
+# Kept as a top-level function (not an inline `case` inside `$( )`) because a
+# `case` glob ending in `)` inside command substitution trips the bash parser
+# on some versions ("syntax error near unexpected token `;;'").
+failed_set_to_json() {
+  local entry svc rc
+  for entry in "$@"; do
+    [ -n "$entry" ] || continue
+    # Split on the LAST '=' so the exit code is always the trailing field even
+    # if a service name (defensively) contained '='.
+    svc="${entry%=*}"
+    rc="${entry##*=}"
+    # Coerce a non-numeric / empty rc to 1 so the jq --argjson below always
+    # gets a valid integer (a malformed entry must not crash the JSON build).
+    case "$rc" in
+      ''|*[!0-9-]*) rc=1 ;;
+    esac
+    jq -nc --arg s "$svc" --argjson e "$rc" \
+      '{service: $s, exit: $e, category: "promote-failed"}'
+  done | jq -sc '.'
+}
+
 # promote_one <svc> -> promote a single service best-effort. Writes its outcome
 # to the $WORK scratch dir instead of mutating arrays, so it is safe to run in a
 # BACKGROUNDED subshell (where array appends would be lost):
@@ -428,6 +454,55 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
   fi
   if ! echo "staging_drift=$staging_drift" >> "$GITHUB_OUTPUT"; then
     echo "::error::promote-fleet: failed to write staging_drift to \$GITHUB_OUTPUT ('$GITHUB_OUTPUT')." >&2
+    exit 1
+  fi
+
+  # ── results JSON for the three-variant Slack renderer ──────────────────────
+  # Build the base64-encoded `results` blob consumed by
+  # .github/workflows/showcase_promote_notify.yml (schema_version=1). That
+  # renderer is the SSOT for the schema; the canonical fields it decodes are:
+  #   .schema_version  must equal "1" (else the renderer aborts gracefully)
+  #   .succeeded[]     succeeded-set; the renderer reads `.succeeded | length`
+  #                    only (count), never per-entry fields — we emit objects
+  #                    `{service}` for symmetry with failed[] / future use.
+  #   .failed[]        each `{service, exit, category}` — the renderer renders
+  #                    "• `<service>` — exit <exit> (<category>)" bullets and
+  #                    uses `category == "truncation-suffix"` as a sentinel.
+  #   .abort_reason    "fleet-preflight" | "per-service" | "" — drives the
+  #                    total-abort branch + *Reason:* line. promote-fleet has
+  #                    no preflight/abort concept of its own (bin/railway owns
+  #                    §7 preflight), so we leave it "" and let the renderer's
+  #                    succeeded==0 && failed>0 defensive branch render the
+  #                    total-failure variant.
+  # CATEGORY CAVEAT: promote-fleet only tracks `svc=exitcode` (no failure
+  # taxonomy), so every failed entry gets the sane default category
+  # "promote-failed". A richer taxonomy would live upstream in bin/railway.
+  #
+  # The run-context fields the renderer also reads — run_id, trigger,
+  # operator_email/git_name, elapsed_seconds, pre_staging — are NOT known here
+  # (they are properties of the dispatching RUN, not the promote loop). The
+  # workflow that dispatches the renderer merges those into this blob; see
+  # showcase_promote.yml's "Build notify payload" step. We still emit a valid
+  # schema_version=1 blob with succeeded[]/failed[] so promote-fleet is the
+  # SSOT for the result set and the bats suite can assert it directly.
+  succeeded_json="[]"
+  if [ "${#succeeded[@]}" -gt 0 ]; then
+    succeeded_json=$(printf '%s\n' "${succeeded[@]}" | jq -R '{service: .}' | jq -sc '.')
+  fi
+  failed_json="[]"
+  if [ "${#failed[@]}" -gt 0 ]; then
+    failed_json=$(failed_set_to_json "${failed[@]}")
+  fi
+  results_json=$(jq -nc \
+    --argjson succeeded "$succeeded_json" \
+    --argjson failed "$failed_json" \
+    '{schema_version: 1, abort_reason: "", succeeded: $succeeded, failed: $failed}')
+  # base64-encode (single line; the renderer's `base64 -d` tolerates wrapping
+  # but a single line keeps the GITHUB_OUTPUT key=value contract trivially
+  # intact — no embedded newline to corrupt the output map).
+  results_b64=$(printf '%s' "$results_json" | base64 | tr -d '\n')
+  if ! echo "results_b64=$results_b64" >> "$GITHUB_OUTPUT"; then
+    echo "::error::promote-fleet: failed to write results_b64 to \$GITHUB_OUTPUT ('$GITHUB_OUTPUT')." >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary

The three-variant promote Slack renderer (`showcase_promote_notify.yml`, merged in #5240-era work) was built and reviewed but **never wired in** — nothing dispatched it, so the showcase promote workflow kept posting its old inline two-state notify (the misleading `❌ Showcase Promote Failed [all 39 services]` even when most promoted). This PR completes the wiring and applies the agreed success-message layout.

- **`promote-fleet.sh`**: emit a base64 `results_b64` payload (schema_version=1, `succeeded[]` + `failed[]` with `service/exit/category`) to `$GITHUB_OUTPUT`, alongside the existing `succeeded_csv`/`staging_drift`.
- **`showcase_promote.yml`**: promote job exports `results_b64`; **removed** the inline two-state notify and replaced it with a job that enriches the blob with run context and dispatches `showcase_promote_notify.yml` via `gh workflow run` (authed with the devops-bot App token, mirroring `canary.yml`). Exactly one Slack message per run.
- **`showcase_promote_notify.yml`** + **dry-run harness**: success message reshaped to the agreed 2 lines — `✅ *Showcase Promoted to Prod* — N ✓  ·  <run|View run>` then `Services: <promoted csv>`. Partial (⚠️) and total (❌) variants unchanged.

## Why it matters

Today's `service=all` promote (25 promoted, 14 legitimately refused) posted a blanket "Failed" listing all 39 services. With this wired, that same run renders a **partial** (`⚠️ N ✓ · M ✗` + per-service Failed bullets, cross-posted to #oss-alerts) — promoted vs refused is finally visible, and a clean run shows the 2-line success.

## Verification

- Dry-run harness rendered for **all three variants** (success/partial/total) — success is the new 2-line form; partial/total byte-identical to the agreed format (regression-guarded).
- bats: promote-fleet 33/33 (incl. 3 new tests asserting the `results_b64` schema), resolve-promote-targets 17/17, verify-prod-display 6/6.
- shellcheck clean; actionlint no new findings.

## Test plan
- [x] dry-run harness: 3 variants render correctly
- [x] bats suites green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)