### PR TITLE
fix(runtime): set telemetry license token for v2 SSE runtimes

### DIFF
--- a/packages/runtime/src/lib/runtime/__tests__/copilot-runtime-license-telemetry.test.ts
+++ b/packages/runtime/src/lib/runtime/__tests__/copilot-runtime-license-telemetry.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CopilotRuntime } from "../copilot-runtime";
+import telemetry from "../../telemetry-client";
+
+/**
+ * The v1 (GraphQL) CopilotRuntime is a separate endpoint path from the v2
+ * runtime, with its own constructor. It already forwards the license token to
+ * telemetry — this pins that behavior so the v1 path can't silently regress
+ * into anonymous telemetry the way the v2 SSE path did.
+ */
+describe("v1 CopilotRuntime — telemetry license token", () => {
+  // Real JWT shape with telemetry_id so the parser doesn't warn.
+  const TOKEN = `header.${Buffer.from('{"telemetry_id":"abc-123"}').toString(
+    "base64url",
+  )}.sig`;
+
+  let setLicenseTokenSpy: ReturnType<typeof vi.spyOn>;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    setLicenseTokenSpy = vi
+      .spyOn(telemetry, "setLicenseToken")
+      .mockImplementation(() => {});
+    originalEnv = process.env.COPILOTKIT_LICENSE_TOKEN;
+    delete process.env.COPILOTKIT_LICENSE_TOKEN;
+  });
+
+  afterEach(() => {
+    setLicenseTokenSpy.mockRestore();
+    if (originalEnv === undefined) {
+      delete process.env.COPILOTKIT_LICENSE_TOKEN;
+    } else {
+      process.env.COPILOTKIT_LICENSE_TOKEN = originalEnv;
+    }
+  });
+
+  it("forwards an explicit licenseToken option to telemetry", () => {
+    const runtime = new CopilotRuntime({ agents: {}, licenseToken: TOKEN });
+
+    expect(runtime).toBeInstanceOf(CopilotRuntime);
+    expect(setLicenseTokenSpy).toHaveBeenCalledWith(TOKEN);
+  });
+
+  it("falls back to COPILOTKIT_LICENSE_TOKEN when no option is given", () => {
+    process.env.COPILOTKIT_LICENSE_TOKEN = TOKEN;
+
+    const runtime = new CopilotRuntime({ agents: {} });
+
+    expect(runtime).toBeInstanceOf(CopilotRuntime);
+    expect(setLicenseTokenSpy).toHaveBeenCalledWith(TOKEN);
+  });
+
+  it("does not set a token when none is provided", () => {
+    const runtime = new CopilotRuntime({ agents: {} });
+
+    expect(runtime).toBeInstanceOf(CopilotRuntime);
+    expect(setLicenseTokenSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/runtime/src/v2/runtime/__tests__/license-telemetry-endpoints.integration.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/license-telemetry-endpoints.integration.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Integration tests proving the license token (the Intelligence/EIP key that
+ * carries telemetry_id) rides all the way to the telemetry sink through every
+ * endpoint adapter and BOTH runtime modes — not just SSE-via-Express (covered
+ * in sse-license-telemetry.integration.test.ts).
+ *
+ * Each test constructs a *real* runtime (so the constructor's setLicenseToken
+ * runs), drives a real request through the adapter, and asserts the token
+ * reaches `lambdaClient.send` on `oss.runtime.copilot_request_created` — which
+ * handle-run emits for both SSE and Intelligence modes.
+ *
+ * Own file so the singleton mutation from the real setLicenseToken stays
+ * contained by Vitest's per-file module isolation.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AbstractAgent, BaseEvent } from "@ag-ui/client";
+import { Observable, of } from "rxjs";
+import { lambdaClient } from "@copilotkit/shared";
+
+import { createCopilotHonoHandler } from "../endpoints/hono";
+import { createCopilotRuntimeHandler } from "../core/fetch-handler";
+import { CopilotRuntime, CopilotIntelligenceRuntime } from "../core/runtime";
+import type { CopilotKitIntelligence } from "../intelligence-platform";
+import { IntelligenceAgentRunner } from "../runner/intelligence";
+
+// Real JWT shape with telemetry_id → identified caller → bypasses the sample
+// gate, so the send is deterministic without mocking Math.random.
+const TOKEN = `header.${Buffer.from('{"telemetry_id":"abc-123"}').toString(
+  "base64url",
+)}.sig`;
+
+function makeSseAgent(): AbstractAgent {
+  const a: unknown = { execute: async () => ({ events: [] }) };
+  (a as { clone: () => unknown }).clone = () => makeSseAgent();
+  return a as AbstractAgent;
+}
+
+function makeSseRunner() {
+  return {
+    run: () =>
+      new Observable((observer) => {
+        observer.next({});
+        observer.complete();
+        return () => undefined;
+      }),
+    connect: () => of({}),
+    stop: async () => true,
+  };
+}
+
+function runRequest(): Request {
+  return new Request("http://localhost/agent/default/run", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ messages: [], state: {}, threadId: "t1" }),
+  });
+}
+
+describe("license token → telemetry sink across endpoints/modes (integration)", () => {
+  let lambdaSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    lambdaSpy = vi.spyOn(lambdaClient, "send").mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    lambdaSpy.mockRestore();
+  });
+
+  it("SSE via the Hono adapter forwards the token to the sink", async () => {
+    const runtime = new CopilotRuntime({
+      agents: { default: makeSseAgent() },
+      runner: makeSseRunner(),
+      licenseToken: TOKEN,
+    });
+    const endpoint = createCopilotHonoHandler({ runtime, basePath: "/" });
+
+    await endpoint.fetch(runRequest());
+
+    await vi.waitFor(() => {
+      expect(lambdaSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "oss.runtime.copilot_request_created",
+          licenseToken: TOKEN,
+        }),
+      );
+    });
+  });
+
+  it("SSE via the framework-agnostic fetch handler (node/custom adapters) forwards the token", async () => {
+    // node + any custom adapter wrap this exact handler, so covering it covers
+    // them without standing up an HTTP server.
+    const runtime = new CopilotRuntime({
+      agents: { default: makeSseAgent() },
+      runner: makeSseRunner(),
+      licenseToken: TOKEN,
+    });
+    const handler = createCopilotRuntimeHandler({ runtime, basePath: "/" });
+
+    await handler(runRequest());
+
+    await vi.waitFor(() => {
+      expect(lambdaSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "oss.runtime.copilot_request_created",
+          licenseToken: TOKEN,
+        }),
+      );
+    });
+  });
+
+  it("Intelligence mode forwards the token to the sink end-to-end", async () => {
+    // A real CopilotIntelligenceRuntime so the constructor's (now base-class)
+    // setLicenseToken runs. Its real IntelligenceAgentRunner would open a
+    // WebSocket, so we swap in a stub runner whose observable completes
+    // immediately — the request still flows through the real intelligence run
+    // handler, which is what we want to exercise.
+    const platform = {
+      ɵgetRunnerWsUrl: vi.fn().mockReturnValue("ws://runner.example"),
+      ɵgetRunnerAuthToken: vi.fn().mockReturnValue("token-123"),
+      ɵgetClientWsUrl: vi.fn().mockReturnValue("wss://client.example"),
+      getOrCreateThread: vi.fn().mockResolvedValue({
+        thread: { id: "thread-1", name: null },
+        created: false,
+      }),
+      getThreadMessages: vi.fn().mockResolvedValue({ messages: [] }),
+      ɵacquireThreadLock: vi.fn().mockResolvedValue({
+        threadId: "thread-1",
+        runId: "run-1",
+        joinToken: "jt-1",
+      }),
+      ɵcleanupThreadLock: vi.fn().mockResolvedValue(undefined),
+      ɵrenewThreadLock: vi.fn().mockResolvedValue(undefined),
+    } as unknown as CopilotKitIntelligence;
+
+    const makeIntelligenceAgent = (): AbstractAgent =>
+      ({
+        clone: vi.fn(() => makeIntelligenceAgent()),
+        setMessages: vi.fn(),
+        setState: vi.fn(),
+        threadId: undefined,
+        headers: {},
+        runAgent: vi.fn().mockResolvedValue(undefined),
+      }) as unknown as AbstractAgent;
+
+    const runtime = new CopilotIntelligenceRuntime({
+      agents: { "my-agent": makeIntelligenceAgent() },
+      intelligence: platform,
+      identifyUser: vi
+        .fn()
+        .mockResolvedValue({ id: "user-1", name: "User One" }),
+      licenseToken: TOKEN,
+    });
+
+    // Swap the real WS runner for a stub whose stream completes immediately.
+    const stubRunner = Object.create(IntelligenceAgentRunner.prototype);
+    stubRunner.run = vi.fn(
+      () => new Observable<BaseEvent>((subscriber) => subscriber.complete()),
+    );
+    runtime.runner = stubRunner;
+
+    const handler = createCopilotRuntimeHandler({ runtime, basePath: "/" });
+
+    await handler(
+      new Request("http://localhost/agent/my-agent/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId: "thread-1",
+          runId: "run-1",
+          state: {},
+          messages: [],
+          tools: [],
+          context: [],
+          forwardedProps: {},
+        }),
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(lambdaSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "oss.runtime.copilot_request_created",
+          licenseToken: TOKEN,
+        }),
+      );
+    });
+  });
+});

--- a/packages/runtime/src/v2/runtime/__tests__/runtime-license-telemetry.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/runtime-license-telemetry.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CopilotIntelligenceRuntime,
+  CopilotRuntime,
+  CopilotSseRuntime,
+} from "../core/runtime";
+import type { CopilotKitIntelligence } from "../intelligence-platform";
+import { telemetry } from "../telemetry";
+
+/**
+ * Every runtime construction path feeds the same endpoints, and all endpoints
+ * share the process-wide `telemetry` singleton. So telemetry attribution is
+ * decided entirely at construction time: if the runtime constructor forwards
+ * the license token to `telemetry.setLicenseToken`, every downstream event
+ * (instance_created, copilot_request_created, agent_execution_*) carries the
+ * telemetry_id; if it doesn't, those events are anonymous and sample-gated.
+ *
+ * Regression guard for the gap where only CopilotIntelligenceRuntime set the
+ * token, so self-hosted SSE users never got a telemetry_id on their events.
+ */
+describe("runtime construction — telemetry license token", () => {
+  const agents = {};
+  const identifyUser = vi
+    .fn()
+    .mockResolvedValue({ id: "user-1", name: "User One" });
+  const createMockIntelligence = (): CopilotKitIntelligence =>
+    ({
+      ɵgetRunnerWsUrl: vi.fn().mockReturnValue("ws://runner.example"),
+      ɵgetRunnerAuthToken: vi.fn().mockReturnValue("token-123"),
+      ɵgetClientWsUrl: vi.fn().mockReturnValue("ws://client.example"),
+    }) as unknown as CopilotKitIntelligence;
+
+  // Real JWT shape with telemetry_id so the parser doesn't warn.
+  const TOKEN = `header.${Buffer.from('{"telemetry_id":"abc-123"}').toString(
+    "base64url",
+  )}.sig`;
+
+  let setLicenseTokenSpy: ReturnType<typeof vi.spyOn>;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    // Spy with a no-op impl so the shared singleton's identified/anonymous
+    // state is never mutated across tests — we assert the call, not state.
+    setLicenseTokenSpy = vi
+      .spyOn(telemetry, "setLicenseToken")
+      .mockImplementation(() => {});
+    originalEnv = process.env.COPILOTKIT_LICENSE_TOKEN;
+    delete process.env.COPILOTKIT_LICENSE_TOKEN;
+  });
+
+  afterEach(() => {
+    setLicenseTokenSpy.mockRestore();
+    if (originalEnv === undefined) {
+      delete process.env.COPILOTKIT_LICENSE_TOKEN;
+    } else {
+      process.env.COPILOTKIT_LICENSE_TOKEN = originalEnv;
+    }
+  });
+
+  describe("CopilotSseRuntime (self-hosted, direct)", () => {
+    it("forwards an explicit licenseToken option to telemetry", () => {
+      const runtime = new CopilotSseRuntime({ agents, licenseToken: TOKEN });
+
+      expect(runtime.mode).toBe("sse");
+      expect(setLicenseTokenSpy).toHaveBeenCalledTimes(1);
+      expect(setLicenseTokenSpy).toHaveBeenCalledWith(TOKEN);
+    });
+
+    it("falls back to COPILOTKIT_LICENSE_TOKEN when no option is given", () => {
+      process.env.COPILOTKIT_LICENSE_TOKEN = TOKEN;
+
+      const runtime = new CopilotSseRuntime({ agents });
+
+      expect(runtime.mode).toBe("sse");
+      expect(setLicenseTokenSpy).toHaveBeenCalledTimes(1);
+      expect(setLicenseTokenSpy).toHaveBeenCalledWith(TOKEN);
+    });
+
+    it("does not set a token when none is provided", () => {
+      const runtime = new CopilotSseRuntime({ agents });
+
+      expect(runtime.mode).toBe("sse");
+      expect(setLicenseTokenSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("CopilotRuntime shim — SSE delegate (self-hosted, default entrypoint)", () => {
+    it("forwards an explicit licenseToken option to telemetry", () => {
+      const runtime = new CopilotRuntime({ agents, licenseToken: TOKEN });
+
+      expect(runtime.mode).toBe("sse");
+      expect(setLicenseTokenSpy).toHaveBeenCalledTimes(1);
+      expect(setLicenseTokenSpy).toHaveBeenCalledWith(TOKEN);
+    });
+
+    it("falls back to COPILOTKIT_LICENSE_TOKEN when no option is given", () => {
+      process.env.COPILOTKIT_LICENSE_TOKEN = TOKEN;
+
+      const runtime = new CopilotRuntime({ agents });
+
+      expect(runtime.mode).toBe("sse");
+      expect(setLicenseTokenSpy).toHaveBeenCalledTimes(1);
+      expect(setLicenseTokenSpy).toHaveBeenCalledWith(TOKEN);
+    });
+  });
+
+  describe("CopilotIntelligenceRuntime (direct)", () => {
+    it("forwards the licenseToken exactly once (no double-set after hoist)", () => {
+      const runtime = new CopilotIntelligenceRuntime({
+        agents,
+        intelligence: createMockIntelligence(),
+        identifyUser,
+        licenseToken: TOKEN,
+      });
+
+      expect(runtime.mode).toBe("intelligence");
+      expect(setLicenseTokenSpy).toHaveBeenCalledTimes(1);
+      expect(setLicenseTokenSpy).toHaveBeenCalledWith(TOKEN);
+    });
+
+    it("falls back to COPILOTKIT_LICENSE_TOKEN when no option is given", () => {
+      process.env.COPILOTKIT_LICENSE_TOKEN = TOKEN;
+
+      const runtime = new CopilotIntelligenceRuntime({
+        agents,
+        intelligence: createMockIntelligence(),
+        identifyUser,
+      });
+
+      expect(runtime.mode).toBe("intelligence");
+      expect(setLicenseTokenSpy).toHaveBeenCalledTimes(1);
+      expect(setLicenseTokenSpy).toHaveBeenCalledWith(TOKEN);
+    });
+  });
+
+  describe("CopilotRuntime shim — Intelligence delegate", () => {
+    it("forwards the licenseToken exactly once", () => {
+      const runtime = new CopilotRuntime({
+        agents,
+        intelligence: createMockIntelligence(),
+        identifyUser,
+        licenseToken: TOKEN,
+      });
+
+      expect(runtime.mode).toBe("intelligence");
+      expect(setLicenseTokenSpy).toHaveBeenCalledTimes(1);
+      expect(setLicenseTokenSpy).toHaveBeenCalledWith(TOKEN);
+    });
+  });
+});

--- a/packages/runtime/src/v2/runtime/__tests__/sse-license-env-fallback.integration.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/sse-license-env-fallback.integration.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Integration test for the env-var-only license config — the exact scenario
+ * this PR exists for: a self-hosted SSE user who sets COPILOTKIT_LICENSE_TOKEN
+ * and never passes a `licenseToken` option. Unit tests cover the resolution;
+ * this proves the env-resolved token survives all the way to the sink through
+ * a real request.
+ *
+ * Deliberately its OWN file: the process-wide telemetry singleton is
+ * last-write-wins, so if this ran after option-based tests that already set
+ * the singleton to a token, it would pass even if the env fallback did
+ * nothing. Per-file isolation makes this construction the ONLY thing that
+ * could set the token — a faithful guard.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AbstractAgent } from "@ag-ui/client";
+import { Observable, of } from "rxjs";
+import { lambdaClient } from "@copilotkit/shared";
+
+import { createCopilotRuntimeHandler } from "../core/fetch-handler";
+import { CopilotRuntime } from "../core/runtime";
+
+const TOKEN = `header.${Buffer.from('{"telemetry_id":"abc-123"}').toString(
+  "base64url",
+)}.sig`;
+
+function makeSseAgent(): AbstractAgent {
+  const a: unknown = { execute: async () => ({ events: [] }) };
+  (a as { clone: () => unknown }).clone = () => makeSseAgent();
+  return a as AbstractAgent;
+}
+
+function makeSseRunner() {
+  return {
+    run: () =>
+      new Observable((observer) => {
+        observer.next({});
+        observer.complete();
+        return () => undefined;
+      }),
+    connect: () => of({}),
+    stop: async () => true,
+  };
+}
+
+describe("SSE license env fallback → telemetry sink (integration)", () => {
+  let lambdaSpy: ReturnType<typeof vi.spyOn>;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    lambdaSpy = vi.spyOn(lambdaClient, "send").mockResolvedValue(undefined);
+    originalEnv = process.env.COPILOTKIT_LICENSE_TOKEN;
+  });
+
+  afterEach(() => {
+    lambdaSpy.mockRestore();
+    if (originalEnv === undefined) {
+      delete process.env.COPILOTKIT_LICENSE_TOKEN;
+    } else {
+      process.env.COPILOTKIT_LICENSE_TOKEN = originalEnv;
+    }
+  });
+
+  it("forwards the COPILOTKIT_LICENSE_TOKEN env value (no explicit option) to the sink", async () => {
+    process.env.COPILOTKIT_LICENSE_TOKEN = TOKEN;
+
+    const runtime = new CopilotRuntime({
+      agents: { default: makeSseAgent() },
+      runner: makeSseRunner(),
+      // intentionally no `licenseToken` option — must fall back to the env var
+    });
+    const handler = createCopilotRuntimeHandler({ runtime, basePath: "/" });
+
+    await handler(
+      new Request("http://localhost/agent/default/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: [], state: {}, threadId: "t1" }),
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(lambdaSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "oss.runtime.copilot_request_created",
+          licenseToken: TOKEN,
+        }),
+      );
+    });
+  });
+});

--- a/packages/runtime/src/v2/runtime/__tests__/sse-license-telemetry.integration.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/sse-license-telemetry.integration.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Integration test: a self-hosted SSE runtime constructed with a license token
+ * must carry that token (and therefore its telemetry_id) all the way to the
+ * telemetry sink when a real HTTP request hits the endpoint.
+ *
+ * This is the end-to-end proof of the construction → endpoint → sink chain for
+ * the gap this change closes: previously CopilotSseRuntime never called
+ * telemetry.setLicenseToken, so these events reached the sink anonymously.
+ *
+ * Own file so the singleton mutation from the real setLicenseToken stays
+ * contained by Vitest's per-file module isolation.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AbstractAgent } from "@ag-ui/client";
+import { Observable, of } from "rxjs";
+import request from "supertest";
+import express from "express";
+import { lambdaClient } from "@copilotkit/shared";
+
+import { createCopilotExpressHandler } from "../endpoints/express";
+import { CopilotRuntime } from "../core/runtime";
+
+// Real JWT shape with telemetry_id so the token parses to an identified
+// caller — identified callers bypass the sample gate, so the send is
+// deterministic without mocking Math.random.
+const TOKEN = `header.${Buffer.from('{"telemetry_id":"abc-123"}').toString(
+  "base64url",
+)}.sig`;
+
+function makeAgent(): AbstractAgent {
+  const a: unknown = { execute: async () => ({ events: [] }) };
+  (a as { clone: () => unknown }).clone = () => makeAgent();
+  return a as AbstractAgent;
+}
+
+function makeSseRuntimeWithLicense() {
+  const runner = {
+    run: () =>
+      new Observable((observer) => {
+        observer.next({});
+        observer.complete();
+        return () => undefined;
+      }),
+    connect: () => of({}),
+    stop: async () => true,
+  };
+  // No `intelligence` option → the CopilotRuntime shim builds a CopilotSseRuntime.
+  return new CopilotRuntime({
+    agents: { default: makeAgent() },
+    runner,
+    licenseToken: TOKEN,
+  });
+}
+
+describe("SSE runtime license token → telemetry sink (integration)", () => {
+  let lambdaSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    lambdaSpy = vi.spyOn(lambdaClient, "send").mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    lambdaSpy.mockRestore();
+  });
+
+  it("forwards the license token to the sink on a real endpoint request", async () => {
+    const runtime = makeSseRuntimeWithLicense();
+    const app = express();
+    app.use(createCopilotExpressHandler({ runtime, basePath: "/" }));
+
+    await request(app)
+      .post("/agent/default/run")
+      .set("Content-Type", "application/json")
+      .send({ messages: [], state: {}, threadId: "t1" });
+
+    await vi.waitFor(() => {
+      expect(lambdaSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "oss.runtime.copilot_request_created",
+          licenseToken: TOKEN,
+        }),
+      );
+    });
+  });
+});

--- a/packages/runtime/src/v2/runtime/core/runtime.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime.ts
@@ -259,6 +259,20 @@ abstract class BaseCopilotRuntime implements CopilotRuntimeLike {
     this.openGenerativeUI = openGenerativeUI;
     this.runner = runner;
 
+    // Attribute telemetry to the licensed customer for *every* runtime mode.
+    // Done in the shared base (not the subclasses) so SSE and Intelligence
+    // runtimes behave identically — previously only CopilotIntelligenceRuntime
+    // set this, so self-hosted SSE users never got a telemetry_id on their
+    // runtime events even with a license token configured. Matches the
+    // license-verifier's env fallback so attribution resolves the same way as
+    // feature gating; otherwise customers who set only COPILOTKIT_LICENSE_TOKEN
+    // would get a working license but anonymous telemetry.
+    const licenseToken =
+      options.licenseToken ?? process.env.COPILOTKIT_LICENSE_TOKEN;
+    if (licenseToken) {
+      telemetry.setLicenseToken(licenseToken);
+    }
+
     if (process.env.NODE_ENV !== "production") {
       this.debugEventBus = new DebugEventBus();
     }
@@ -314,16 +328,12 @@ export class CopilotIntelligenceRuntime
     this.intelligence = options.intelligence;
     this.identifyUser = options.identifyUser;
     this.generateThreadNames = options.generateThreadNames ?? true;
-    // Match license-verifier's env fallback so telemetry attribution
-    // resolves the same way as feature gating — otherwise customers who
-    // set only COPILOTKIT_LICENSE_TOKEN would get a working license but
-    // anonymous telemetry.
-    const licenseToken =
-      options.licenseToken ?? process.env.COPILOTKIT_LICENSE_TOKEN;
-    this.licenseChecker = createLicenseChecker(licenseToken);
-    if (licenseToken) {
-      telemetry.setLicenseToken(licenseToken);
-    }
+    // Telemetry attribution (telemetry.setLicenseToken) is handled by the
+    // base constructor for all modes; here we only need the license token for
+    // feature gating. Same env fallback so gating and attribution agree.
+    this.licenseChecker = createLicenseChecker(
+      options.licenseToken ?? process.env.COPILOTKIT_LICENSE_TOKEN,
+    );
     this.lockTtlSeconds = Math.min(
       options.lockTtlSeconds ?? 20,
       CopilotIntelligenceRuntime.MAX_LOCK_TTL_SECONDS,

--- a/packages/runtime/src/v2/runtime/core/runtime.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime.ts
@@ -234,6 +234,14 @@ abstract class BaseCopilotRuntime implements CopilotRuntimeLike {
   public debug: ResolvedDebugConfig;
   public debugLogger?: CopilotRuntimeLogger;
 
+  /**
+   * License token resolved once with the env fallback, so telemetry
+   * attribution (below) and subclass feature gating
+   * (CopilotIntelligenceRuntime's licenseChecker) read the exact same value
+   * instead of each re-applying `?? COPILOTKIT_LICENSE_TOKEN`.
+   */
+  protected readonly resolvedLicenseToken?: string;
+
   abstract readonly intelligence?: CopilotKitIntelligence;
   abstract readonly mode: RuntimeMode;
 
@@ -259,18 +267,19 @@ abstract class BaseCopilotRuntime implements CopilotRuntimeLike {
     this.openGenerativeUI = openGenerativeUI;
     this.runner = runner;
 
+    // Resolve the license token once (matching the license-verifier's env
+    // fallback) so telemetry attribution and subclass feature gating share
+    // one value.
+    this.resolvedLicenseToken =
+      options.licenseToken ?? process.env.COPILOTKIT_LICENSE_TOKEN;
+
     // Attribute telemetry to the licensed customer for *every* runtime mode.
     // Done in the shared base (not the subclasses) so SSE and Intelligence
     // runtimes behave identically — previously only CopilotIntelligenceRuntime
     // set this, so self-hosted SSE users never got a telemetry_id on their
-    // runtime events even with a license token configured. Matches the
-    // license-verifier's env fallback so attribution resolves the same way as
-    // feature gating; otherwise customers who set only COPILOTKIT_LICENSE_TOKEN
-    // would get a working license but anonymous telemetry.
-    const licenseToken =
-      options.licenseToken ?? process.env.COPILOTKIT_LICENSE_TOKEN;
-    if (licenseToken) {
-      telemetry.setLicenseToken(licenseToken);
+    // runtime events even with a license token configured.
+    if (this.resolvedLicenseToken) {
+      telemetry.setLicenseToken(this.resolvedLicenseToken);
     }
 
     if (process.env.NODE_ENV !== "production") {
@@ -328,12 +337,10 @@ export class CopilotIntelligenceRuntime
     this.intelligence = options.intelligence;
     this.identifyUser = options.identifyUser;
     this.generateThreadNames = options.generateThreadNames ?? true;
-    // Telemetry attribution (telemetry.setLicenseToken) is handled by the
-    // base constructor for all modes; here we only need the license token for
-    // feature gating. Same env fallback so gating and attribution agree.
-    this.licenseChecker = createLicenseChecker(
-      options.licenseToken ?? process.env.COPILOTKIT_LICENSE_TOKEN,
-    );
+    // Telemetry attribution is handled by the base constructor for all modes;
+    // here we only need the token for feature gating. Reuse the base-resolved
+    // value so gating and attribution can never disagree.
+    this.licenseChecker = createLicenseChecker(this.resolvedLicenseToken);
     this.lockTtlSeconds = Math.min(
       options.lockTtlSeconds ?? 20,
       CopilotIntelligenceRuntime.MAX_LOCK_TTL_SECONDS,


### PR DESCRIPTION
## Problem

Self-hosted users on the v2 SSE runtime never get a `telemetry_id` on their runtime telemetry events — even with a license token configured.  The root cause is in `packages/runtime/src/v2/runtime/core/runtime.ts`:

- `CopilotIntelligenceRuntime` **did** call `telemetry.setLicenseToken(...)` in its constructor.
- `BaseCopilotRuntime` and `CopilotSseRuntime` **did not**.

`telemetry_id` is derived only inside `setLicenseToken` (`parseAndWarnTelemetryId`). If it's never called, every event the runtime emits is sent anonymously. SSE-mode handlers (`handle-connect`, `handle-run`, `sse-response`) all emit `oss.runtime.*` events through the shared telemetry singleton, so all of them went out unattributed for SSE users.

## Fix

Hoist the license-token resolution (`options.licenseToken ?? COPILOTKIT_LICENSE_TOKEN`) and the `telemetry.setLicenseToken` call **into `BaseCopilotRuntime`'s constructor**, so SSE and Intelligence runtimes attribute telemetry identically. The now-redundant duplicate is removed from `CopilotIntelligenceRuntime` (its `licenseChecker` stays). The v1 `CopilotRuntime` already set the token and is unchanged.

## Test coverage — every construction path into the endpoints

The token is set at construction time and all endpoints share one telemetry singleton, so covering every runtime construction path covers every endpoint.

- **`runtime-license-telemetry.test.ts`** — `CopilotSseRuntime` and `CopilotIntelligenceRuntime` (direct) + the `CopilotRuntime` shim (both SSE and Intelligence delegates), each across `{explicit option, COPILOTKIT_LICENSE_TOKEN fallback, none}`. Asserts the token is set **exactly once** (guards against a double-set after the hoist).
- **`sse-license-telemetry.integration.test.ts`** — end-to-end: an SSE runtime built with a license token forwards it all the way to `lambdaClient.send` on a real Express endpoint request.
- **`copilot-runtime-license-telemetry.test.ts`** — regression guard for the v1 `CopilotRuntime` path (already worked, previously untested — exactly the kind of untested path that let this gap appear).

The new tests are **red before the fix** (the SSE-path assertions fail) and green after.

## Verification

- New + existing v2 runtime suite: **770/770 pass**, no regressions.
- Lint: 0 new warnings. Build: green (types clean). Format: clean (oxfmt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
