### PR TITLE
feat(showcase): make starter fleet always-on + verify-deploy starter driver

### DIFF
--- a/showcase/scripts/__tests__/fixtures/railway-envs.golden.json
+++ b/showcase/scripts/__tests__/fixtures/railway-envs.golden.json
@@ -451,7 +451,7 @@
     "staging": {
       "instanceId": "208a160a-0d7d-44b2-a94d-39e13b24e21a",
       "domain": "starter-adk-staging.up.railway.app",
-      "probe": false,
+      "probe": true,
       "driver": "starter",
       "repoName": "starter-adk"
     }
@@ -467,7 +467,7 @@
     "staging": {
       "instanceId": "9944eb97-7f58-47f8-a49d-65603e209609",
       "domain": "starter-agno-staging.up.railway.app",
-      "probe": false,
+      "probe": true,
       "driver": "starter",
       "repoName": "starter-agno"
     }
@@ -483,7 +483,7 @@
     "staging": {
       "instanceId": "820895fb-f65c-4834-a07d-d454035d39c4",
       "domain": "starter-crewai-crews-staging.up.railway.app",
-      "probe": false,
+      "probe": true,
       "driver": "starter",
       "repoName": "starter-crewai-crews"
     }
@@ -499,7 +499,7 @@
     "staging": {
       "instanceId": "5f10e976-e121-48a5-bc18-2619798f2f10",
       "domain": "starter-langgraph-fastapi-staging.up.railway.app",
-      "probe": false,
+      "probe": true,
       "driver": "starter",
       "repoName": "starter-langgraph-fastapi"
     }
@@ -515,7 +515,7 @@
     "staging": {
       "instanceId": "43db83fe-fafb-445b-a19a-51bb086c71b9",
       "domain": "starter-langgraph-js-staging.up.railway.app",
-      "probe": false,
+      "probe": true,
       "driver": "starter",
       "repoName": "starter-langgraph-js"
     }
@@ -531,7 +531,7 @@
     "staging": {
       "instanceId": "58105e79-4020-4692-8749-c1a63ab63f2c",
       "domain": "starter-langgraph-python-staging.up.railway.app",
-      "probe": false,
+      "probe": true,
       "driver": "starter",
       "repoName": "starter-langgraph-python"
     }
@@ -547,7 +547,7 @@
     "staging": {
       "instanceId": "44446803-0505-456a-b0c4-01fe82fb3832",
       "domain": "starter-llamaindex-staging.up.railway.app",
-      "probe": false,
+      "probe": true,
       "driver": "starter",
       "repoName": "starter-llamaindex"
     }
@@ -563,7 +563,7 @@
     "staging": {
       "instanceId": "b246e52d-52d8-4015-bb06-89bd09d54f8f",
       "domain": "starter-mastra-staging.up.railway.app",
-      "probe": false,
+      "probe": true,
       "driver": "starter",
       "repoName": "starter-mastra"
     }
@@ -579,7 +579,7 @@
     "staging": {
       "instanceId": "6684c246-e8fd-45a7-86e4-c529a439976f",
       "domain": "starter-ms-agent-framework-dotnet-staging.up.railway.app",
-      "probe": false,
+      "probe": true,
       "driver": "starter",
       "repoName": "starter-ms-agent-framework-dotnet"
     }
@@ -595,7 +595,7 @@
     "staging": {
       "instanceId": "a162348a-f768-4c3f-815c-f617819f64e6",
       "domain": "starter-ms-agent-framework-python-staging.up.railway.app",
-      "probe": false,
+      "probe": true,
       "driver": "starter",
       "repoName": "starter-ms-agent-framework-python"
     }
@@ -611,7 +611,7 @@
     "staging": {
       "instanceId": "25f4eb93-501a-4e5e-b7cf-343eb08ea613",
       "domain": "starter-pydantic-ai-staging.up.railway.app",
-      "probe": false,
+      "probe": true,
       "driver": "starter",
       "repoName": "starter-pydantic-ai"
     }
@@ -627,7 +627,7 @@
     "staging": {
       "instanceId": "adc24096-584a-4ef3-93de-0bc92d49235c",
       "domain": "starter-strands-python-staging.up.railway.app",
-      "probe": false,
+      "probe": true,
       "driver": "starter",
       "repoName": "starter-strands-python"
     }

--- a/showcase/scripts/__tests__/provision-starter-fleet.test.ts
+++ b/showcase/scripts/__tests__/provision-starter-fleet.test.ts
@@ -442,7 +442,7 @@ describe("provisionStarterFleet — create path", () => {
     }
   });
 
-  it("sets sleepApplication:true + healthcheck '/' + region us-west1 on the staging instance", async () => {
+  it("sets sleepApplication:false (always-on) + healthcheck '/' + region us-west1 on the staging instance", async () => {
     const { gql, calls } = makeMockGql();
     await provisionStarterFleet({
       gql,
@@ -460,7 +460,7 @@ describe("provisionStarterFleet — create path", () => {
       expect(u.variables.environmentId).toBe(STAGING_ENV_ID);
       expect(u.variables.environmentId).not.toBe(PRODUCTION_ENV_ID);
       const input = u.variables.input as Record<string, unknown>;
-      expect(input.sleepApplication).toBe(true);
+      expect(input.sleepApplication).toBe(false);
       expect(input.healthcheckPath).toBe(STARTER_HEALTHCHECK_PATH);
       expect(input.healthcheckPath).toBe("/");
       expect(input.region).toBe(STARTER_REGION);

--- a/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
@@ -38,6 +38,8 @@ import { probeAimock } from "../verify-deploy.drivers.aimock";
 import { probePocketbase } from "../verify-deploy.drivers.pocketbase";
 import { probeWebhooks } from "../verify-deploy.drivers.webhooks";
 import { probeAgent } from "../verify-deploy.drivers.agent";
+import { probeStarter } from "../verify-deploy.drivers.starter";
+import { runDriver } from "../verify-deploy.drivers";
 
 const TOKEN = "tok_test_abcdef";
 
@@ -692,6 +694,17 @@ const DRIVER_CASES: DriverCase[] = [
     enumLiteral: "agent",
     expectedHealthPath: "/api/health",
   },
+  {
+    // The starter-template container fleet (`starter-<slug>`). Starters
+    // EXPOSE only the Next.js frontend (port 3000) which serves `/` and
+    // `/api/copilotkit` but NO `/api/health` — so the baseline driver
+    // healthchecks `/`, exactly like the Next.js shells.
+    label: "starter",
+    driver: probeStarter,
+    service: "starter-adk",
+    enumLiteral: "starter",
+    expectedHealthPath: "/",
+  },
 ];
 
 describe.each(DRIVER_CASES)(
@@ -817,6 +830,43 @@ describe.each(DRIVER_CASES)(
     });
   },
 );
+
+describe("runDriver dispatch: starter is a real baseline driver, not a fail-loud stub", () => {
+  it("routes a driver:'starter' target through the baseline probe (ok on a healthy starter)", async () => {
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("/graphql/v2")) return gqlDeploymentResponse("SUCCESS");
+      return Promise.resolve(mkResponse({ status: 200 }));
+    });
+    await withGlobalSeam(fetchImpl, TOKEN, async () => {
+      const out = await runDriver({
+        name: "starter-adk",
+        host: asHost(domainFor("starter-adk", "staging")),
+        driver: "starter",
+      });
+      expect(out.ok).toBe(true);
+      if (out.ok === false) {
+        // The legacy stub returned this exact phrasing — assert it's gone.
+        expect(out.error).not.toMatch(/is not handled by verify-deploy/);
+      }
+    });
+  });
+
+  it("still fails for a genuinely-down starter (CRASHED deployment)", async () => {
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("/graphql/v2")) return gqlDeploymentResponse("CRASHED");
+      return Promise.resolve(mkResponse({ status: 200 }));
+    });
+    await withGlobalSeam(fetchImpl, TOKEN, async () => {
+      const out = await runDriver({
+        name: "starter-adk",
+        host: asHost(domainFor("starter-adk", "staging")),
+        driver: "starter",
+      });
+      expect(out.ok).toBe(false);
+      if (out.ok === false) expect(out.error).toMatch(/CRASHED/);
+    });
+  });
+});
 
 describe("probeDashboard runtime-config sentinel guard", () => {
   // Build the dashboard `/` HTML carrying the root-layout injection

--- a/showcase/scripts/provision-starter-fleet.ts
+++ b/showcase/scripts/provision-starter-fleet.ts
@@ -3,7 +3,7 @@
  * provision-starter-fleet.ts — Committed, reproducible Railway provisioner
  * for the "starter container fleet" in the showcase STAGING environment.
  *
- * Creates (or idempotently updates) one sleepable Railway service per
+ * Creates (or idempotently updates) one always-on Railway service per
  * starter template, pulling the per-starter image from GHCR:
  *
  *   service name : starter-<slug>          (RAW starter slug, e.g.
@@ -11,7 +11,8 @@
  *                                            remapped dashboard column slug)
  *   image        : ghcr.io/copilotkit/starter-<slug>:latest
  *   env          : STAGING ONLY (railway-envs STAGING_ENV_ID)
- *   sleep        : sleepApplication = true (the whole point — sleepable)
+ *   sleep        : sleepApplication = false (always-on, so the starters are
+ *                  staging-probed like every other managed showcase service)
  *   healthcheck  : "/"  (the starters' single deployable image EXPOSEs 3000
  *                  running the Next.js frontend; the frontend serves "/" and
  *                  "/api/copilotkit" but has NO "/api/health" route — that
@@ -217,7 +218,8 @@ interface ServiceInstanceRedeployResult {
  * registryCredentials) is applied. Same precedent as serviceInstanceRedeploy
  * (redeploy-env.ts / bin/railway treat the scalar as a bare boolean). A
  * `false`/`null` return means the config was NOT applied — e.g. the service
- * would run WITHOUT sleep — so it must be asserted, never discarded.
+ * would run WITHOUT the intended always-on/healthcheck config — so it must be
+ * asserted, never discarded.
  */
 interface ServiceInstanceUpdateResult {
   serviceInstanceUpdate: boolean | null;
@@ -450,7 +452,7 @@ export interface ProvisionSummary {
  *   - create the service (source.image = GHCR ref) if it does not exist,
  *     otherwise reuse the existing service id (UPDATE path);
  *   - serviceInstanceUpdate against the STAGING env with
- *     sleepApplication: true + healthcheckPath + region + (optional) GHCR
+ *     sleepApplication: false + healthcheckPath + region + (optional) GHCR
  *     registryCredentials — applied on BOTH the create and update paths so a
  *     re-run converges drifted settings;
  *   - serviceInstanceRedeploy so the pinned image ACTUALLY RUNS. A
@@ -572,7 +574,7 @@ export async function provisionStarterFleet(
     // drifted existing service converges back to the canonical GHCR ref.
     const instanceInput: Record<string, unknown> = {
       source: { image: target.image },
-      sleepApplication: true,
+      sleepApplication: false,
       healthcheckPath: STARTER_HEALTHCHECK_PATH,
       region: STARTER_REGION,
     };
@@ -602,8 +604,9 @@ export async function provisionStarterFleet(
       );
       // serviceInstanceUpdate returns Boolean! — a `false`/`null` return means
       // sleepApplication/healthcheck/image/creds were NOT applied (the service
-      // would run WITHOUT sleep) while the script reports success. Assert the
-      // result and only log "configured ..." AFTER it is verified.
+      // would run WITHOUT the intended always-on/healthcheck config) while the
+      // script reports success. Assert the result and only log "configured ..."
+      // AFTER it is verified.
       assertMutationOk(
         updated,
         (r) => r.serviceInstanceUpdate,
@@ -612,7 +615,7 @@ export async function provisionStarterFleet(
         serviceId,
       );
       log(
-        `  configured sleep=true, healthcheck=${STARTER_HEALTHCHECK_PATH}, region=${STARTER_REGION}${
+        `  configured sleep=false, healthcheck=${STARTER_HEALTHCHECK_PATH}, region=${STARTER_REGION}${
           registryCredentials ? ", registry creds" : ""
         }`,
       );
@@ -871,7 +874,7 @@ async function main(): Promise<void> {
   }
 
   console.log(
-    `Provisioning ${targets.length} sleepable starter-* services in STAGING (env ${STAGING_ENV_ID})${
+    `Provisioning ${targets.length} always-on starter-* services in STAGING (env ${STAGING_ENV_ID})${
       dryRun ? " [DRY RUN]" : ""
     }\n`,
   );

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -719,7 +719,7 @@
         "prod": "starter-adk-production.up.railway.app"
       },
       "probe": {
-        "staging": false,
+        "staging": true,
         "prod": true,
         "driver": "starter"
       },
@@ -745,7 +745,7 @@
         "prod": "starter-agno-production.up.railway.app"
       },
       "probe": {
-        "staging": false,
+        "staging": true,
         "prod": true,
         "driver": "starter"
       },
@@ -771,7 +771,7 @@
         "prod": "starter-crewai-crews-production.up.railway.app"
       },
       "probe": {
-        "staging": false,
+        "staging": true,
         "prod": true,
         "driver": "starter"
       },
@@ -797,7 +797,7 @@
         "prod": "starter-langgraph-fastapi-production.up.railway.app"
       },
       "probe": {
-        "staging": false,
+        "staging": true,
         "prod": true,
         "driver": "starter"
       },
@@ -823,7 +823,7 @@
         "prod": "starter-langgraph-js-production.up.railway.app"
       },
       "probe": {
-        "staging": false,
+        "staging": true,
         "prod": true,
         "driver": "starter"
       },
@@ -849,7 +849,7 @@
         "prod": "starter-langgraph-python-production.up.railway.app"
       },
       "probe": {
-        "staging": false,
+        "staging": true,
         "prod": true,
         "driver": "starter"
       },
@@ -875,7 +875,7 @@
         "prod": "starter-llamaindex-production.up.railway.app"
       },
       "probe": {
-        "staging": false,
+        "staging": true,
         "prod": true,
         "driver": "starter"
       },
@@ -901,7 +901,7 @@
         "prod": "starter-mastra-production.up.railway.app"
       },
       "probe": {
-        "staging": false,
+        "staging": true,
         "prod": true,
         "driver": "starter"
       },
@@ -927,7 +927,7 @@
         "prod": "starter-ms-agent-framework-dotnet-production.up.railway.app"
       },
       "probe": {
-        "staging": false,
+        "staging": true,
         "prod": true,
         "driver": "starter"
       },
@@ -953,7 +953,7 @@
         "prod": "starter-ms-agent-framework-python-production.up.railway.app"
       },
       "probe": {
-        "staging": false,
+        "staging": true,
         "prod": true,
         "driver": "starter"
       },
@@ -979,7 +979,7 @@
         "prod": "starter-pydantic-ai-production.up.railway.app"
       },
       "probe": {
-        "staging": false,
+        "staging": true,
         "prod": true,
         "driver": "starter"
       },
@@ -1005,7 +1005,7 @@
         "prod": "starter-strands-python-production.up.railway.app"
       },
       "probe": {
-        "staging": false,
+        "staging": true,
         "prod": true,
         "driver": "starter"
       },

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -1230,20 +1230,20 @@ describe("starter-* fleet SSOT entries (S1: promote-closure inclusion)", () => {
     }
   });
 
-  it("every starter exists in BOTH envs with prod probe enabled", () => {
+  it("every starter exists in BOTH envs with prod AND staging probe enabled (always-on)", () => {
     for (const key of STARTER_KEYS) {
       const entry = SERVICES[key];
       expect(Object.keys(entry.environments).sort()).toEqual([
         "prod",
         "staging",
       ]);
-      // prod is probed (they ARE in prod); staging probe deferred to S3
-      // (the starter-smoke axis, not the verify-deploy matrix).
+      // Starters are always-on + staging-probed like every other managed
+      // showcase service: both envs are probed by the verify-deploy baseline
+      // driver (resolve-verify-matrix filters on probe.staging===true, so a
+      // probed starter now enters the staging matrix). The starter-smoke axis
+      // ALSO covers them — orthogonal to the baseline liveness probe here.
       expect(probeEnabled(key, "prod"), `${key} prod probe`).toBe(true);
-      // staging probe OFF — starters never enter the verify-deploy staging
-      // matrix (resolve-verify-matrix filters on probe.staging===true); the
-      // starter-smoke axis owns staging verification (S3).
-      expect(probeEnabled(key, "staging"), `${key} staging probe`).toBe(false);
+      expect(probeEnabled(key, "staging"), `${key} staging probe`).toBe(true);
     }
   });
 

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -115,13 +115,15 @@ export function resolveEnv(name: string): { env: EnvName; envId: string } {
  * - "agent" — generic agent backend (the showcase-* integration services);
  *   feature-level fixture call into the integration's /api endpoint.
  * - "starter" — the starter-template container fleet (`starter-<slug>`).
- *   These are NOT verified by the verify-deploy feature-driver matrix: they
- *   are probed by the harness `starter_smoke` axis (railway-services source,
- *   namePrefix "starter-", writing `starter:<column-slug>/<level>` rows).
- *   verify-deploy.drivers.ts carries a fail-loud placeholder `case "starter"`
- *   purely to satisfy the exhaustive switch; the equivalence gate (S3) reads
- *   this driver to route a starter to the starter-smoke axis. Starters set
- *   staging probe OFF so they never enter the verify-deploy staging matrix.
+ *   Verified by the verify-deploy baseline driver (deployment-SUCCESS +
+ *   HTTP 200 on `/`) in `verify-deploy.drivers.starter.ts`, exactly like the
+ *   Next.js shells — the starters EXPOSE only their Next.js frontend (serving
+ *   `/` + `/api/copilotkit`, NO `/api/health`), so `/` is the only correct
+ *   healthcheck. Starters are always-on + staging-probed, so they enter the
+ *   verify-deploy staging matrix like every other managed showcase service.
+ *   (They are ALSO covered by the harness `starter_smoke` axis — railway-
+ *   services source, namePrefix "starter-", writing `starter:<column-slug>/
+ *   <level>` rows — which is orthogonal to the baseline liveness probe here.)
  */
 export type ProbeDriver =
   | "shell"
@@ -1168,17 +1170,17 @@ export const SERVICES: Record<
   //   - bin/railway lint-prod now COVERS these prod services (asserts they are
   //                        @sha256-pinned).
   //
-  // probeDriver "starter": the starters are verified by the harness
-  // `starter_smoke` axis, NOT the verify-deploy feature-driver matrix. The
-  // `starter_smoke` probe auto-discovers `starter-*` services (railway-services
-  // source, namePrefix "starter-") and writes `starter:<column-slug>/<level>`
-  // rows. prod probe ON (they ARE in prod); staging probe OFF so they do NOT
-  // enter the verify-deploy staging matrix (resolve-verify-matrix filters on
-  // probe.staging===true). The "starter" ProbeDriver is the S3 CONTRACT field:
-  // S3 wires the equivalence gate to READ this driver and route these entries
-  // to the starter-smoke axis (verify-deploy.drivers.ts has a placeholder
-  // `case "starter"` that fails loud if dispatched, since verify-deploy is not
-  // the starter verification path).
+  // probeDriver "starter": the starters are verified by the verify-deploy
+  // baseline driver (deployment-SUCCESS + HTTP 200 on `/`) in
+  // verify-deploy.drivers.starter.ts, exactly like the Next.js shells. They
+  // are always-on + staging-probed (prod probe ON and staging probe ON), so
+  // resolve-verify-matrix routes them through the verify-deploy staging matrix
+  // (which filters on probe.staging===true) like every other managed showcase
+  // service. The starters are ALSO auto-discovered by the harness
+  // `starter_smoke` axis (railway-services source, namePrefix "starter-",
+  // writing `starter:<column-slug>/<level>` rows) — orthogonal to the baseline
+  // liveness probe here. The "starter" ProbeDriver is the contract field the
+  // dispatch switch keys on to route a starter target to probeStarter.
   //
   // runtimeDeps/serviceRefs mirror the showcase-* agents: each starter routes
   // its LLM traffic at the env-local aimock (tier-0), so a cluster promote
@@ -1202,7 +1204,7 @@ export const SERVICES: Record<
       staging: {
         instanceId: "208a160a-0d7d-44b2-a94d-39e13b24e21a",
         domain: "starter-adk-staging.up.railway.app",
-        probe: false,
+        probe: true,
       },
     },
   },
@@ -1224,7 +1226,7 @@ export const SERVICES: Record<
       staging: {
         instanceId: "9944eb97-7f58-47f8-a49d-65603e209609",
         domain: "starter-agno-staging.up.railway.app",
-        probe: false,
+        probe: true,
       },
     },
   },
@@ -1246,7 +1248,7 @@ export const SERVICES: Record<
       staging: {
         instanceId: "820895fb-f65c-4834-a07d-d454035d39c4",
         domain: "starter-crewai-crews-staging.up.railway.app",
-        probe: false,
+        probe: true,
       },
     },
   },
@@ -1268,7 +1270,7 @@ export const SERVICES: Record<
       staging: {
         instanceId: "5f10e976-e121-48a5-bc18-2619798f2f10",
         domain: "starter-langgraph-fastapi-staging.up.railway.app",
-        probe: false,
+        probe: true,
       },
     },
   },
@@ -1290,7 +1292,7 @@ export const SERVICES: Record<
       staging: {
         instanceId: "43db83fe-fafb-445b-a19a-51bb086c71b9",
         domain: "starter-langgraph-js-staging.up.railway.app",
-        probe: false,
+        probe: true,
       },
     },
   },
@@ -1312,7 +1314,7 @@ export const SERVICES: Record<
       staging: {
         instanceId: "58105e79-4020-4692-8749-c1a63ab63f2c",
         domain: "starter-langgraph-python-staging.up.railway.app",
-        probe: false,
+        probe: true,
       },
     },
   },
@@ -1334,7 +1336,7 @@ export const SERVICES: Record<
       staging: {
         instanceId: "44446803-0505-456a-b0c4-01fe82fb3832",
         domain: "starter-llamaindex-staging.up.railway.app",
-        probe: false,
+        probe: true,
       },
     },
   },
@@ -1356,7 +1358,7 @@ export const SERVICES: Record<
       staging: {
         instanceId: "b246e52d-52d8-4015-bb06-89bd09d54f8f",
         domain: "starter-mastra-staging.up.railway.app",
-        probe: false,
+        probe: true,
       },
     },
   },
@@ -1378,7 +1380,7 @@ export const SERVICES: Record<
       staging: {
         instanceId: "6684c246-e8fd-45a7-86e4-c529a439976f",
         domain: "starter-ms-agent-framework-dotnet-staging.up.railway.app",
-        probe: false,
+        probe: true,
       },
     },
   },
@@ -1400,7 +1402,7 @@ export const SERVICES: Record<
       staging: {
         instanceId: "a162348a-f768-4c3f-815c-f617819f64e6",
         domain: "starter-ms-agent-framework-python-staging.up.railway.app",
-        probe: false,
+        probe: true,
       },
     },
   },
@@ -1422,7 +1424,7 @@ export const SERVICES: Record<
       staging: {
         instanceId: "25f4eb93-501a-4e5e-b7cf-343eb08ea613",
         domain: "starter-pydantic-ai-staging.up.railway.app",
-        probe: false,
+        probe: true,
       },
     },
   },
@@ -1444,7 +1446,7 @@ export const SERVICES: Record<
       staging: {
         instanceId: "adc24096-584a-4ef3-93de-0bc92d49235c",
         domain: "starter-strands-python-staging.up.railway.app",
-        probe: false,
+        probe: true,
       },
     },
   },

--- a/showcase/scripts/verify-deploy.drivers.starter.ts
+++ b/showcase/scripts/verify-deploy.drivers.starter.ts
@@ -1,0 +1,32 @@
+import type { ProbeTarget } from "./verify-deploy";
+import type { ProbeOutcome } from "./verify-deploy.drivers";
+import { probeBaseline } from "./verify-deploy.drivers.baseline";
+
+/**
+ * Feature-level verifier for the starter-template container fleet
+ * (`starter-<slug>`). Each starter ships a SINGLE deployable image that
+ * EXPOSEs the Next.js frontend on port 3000; that frontend serves `/` and
+ * `/api/copilotkit` but has NO `/api/health` route (the agent's `/health`
+ * lives on the internal agent port 8123, which Railway does not expose). So
+ * `/` is the only correct, reachable healthcheck for the exposed surface —
+ * the same baseline the Next.js shells use, and the same `healthcheckPath`
+ * the provisioner (`provision-starter-fleet.ts`) sets on the Railway
+ * instance config.
+ *
+ * Like every driver this composes on `probeBaseline`, which enforces the
+ * two minimum invariants before any feature-level extension:
+ *   1. Railway deployment-SUCCESS for the resolved env (GraphQL).
+ *   2. HTTP 200 on `https://<host>/`.
+ *
+ * Driver-specific DOM + network-call extensions (e.g. a CopilotKit
+ * round-trip against `/api/copilotkit`) can compose on top of this baseline
+ * once those micro-tasks land; until then this baseline is the agreed
+ * completion bar, and crucially NO driver remains a fail-loud "not handled"
+ * stub.
+ */
+export async function probeStarter(target: ProbeTarget): Promise<ProbeOutcome> {
+  return probeBaseline(target, {
+    driverLabel: "starter",
+    healthcheckPath: "/",
+  });
+}

--- a/showcase/scripts/verify-deploy.drivers.ts
+++ b/showcase/scripts/verify-deploy.drivers.ts
@@ -58,21 +58,16 @@ export async function runDriver(target: ProbeTarget): Promise<ProbeOutcome> {
           target,
         );
       case "starter":
-        // The starter-template fleet (`starter-<slug>`) is NOT verified by the
-        // verify-deploy feature-driver matrix — it is probed by the harness
-        // `starter_smoke` axis. This case exists ONLY to satisfy the exhaustive
-        // switch (the `never` guard below) now that "starter" is a ProbeDriver.
-        // Starters set staging probe OFF, so resolve-verify-matrix never routes
-        // one here; if a starter is ever dispatched to verify-deploy that is a
-        // wiring bug, so fail loud rather than silently pass. S3 wires the
-        // equivalence gate to route a "starter"-driver service to starter-smoke.
-        return {
-          ok: false,
-          error:
-            `driver "starter" is not handled by verify-deploy (service ` +
-            `"${target.name}"): the starter fleet is verified by the harness ` +
-            `starter_smoke axis, not the verify-deploy matrix`,
-        };
+        // The starter-template fleet (`starter-<slug>`) is verified by the
+        // verify-deploy baseline driver (deployment-SUCCESS + HTTP 200 on
+        // `/`), exactly like the Next.js shells — the starters EXPOSE only
+        // their Next.js frontend (serving `/` + `/api/copilotkit`, NO
+        // `/api/health`), so `/` is the only correct healthcheck. Starters
+        // are always-on + staging-probed, so resolve-verify-matrix routes
+        // them here like every other managed showcase service.
+        return (await import("./verify-deploy.drivers.starter")).probeStarter(
+          target,
+        );
       default: {
         const exhaustive: never = target.driver;
         return { ok: false, error: `unknown driver: ${String(exhaustive)}` };


### PR DESCRIPTION
## Summary

The 12 `starter-*` services were deliberately `sleepApplication=true` (sleepable), `probe.staging=false` (held out of the verify-deploy staging matrix). That class-difference is the root of three recurring symptoms: the `service=all` promote false-fails them (SLEEPING / no running-digest), the deployed-starter smoke test 404s a cold container, and they're excluded from staging validation. Decision: **bring them into the normal managed-fleet flow — always-on + staging-probed.**

- **`verify-deploy.drivers.starter.ts` (new)** — real `probeStarter` baseline driver (deployment SUCCESS + HTTP 200 on `/`, mirroring `probeShell`); replaces the fail-loud `case "starter"` stub.
- **`railway-envs.ts`** — `staging.probe: false→true` for all 12 starters (prod already true); stale "staging probe OFF" comments rewritten. `railway-envs.generated.json` regenerated (in-sync via `--check`).
- **`provision-starter-fleet.ts`** — `sleepApplication: true→false` + comments/logs; test updated.

## ⚠️ Deploy ordering (must hold)
This PR flips `probe.staging=true`, which routes starters into the staging matrix. It must **not** merge until the live services are flipped always-on, or a `service=all` promote would probe still-sleeping starters and fail. Sequence: **(1) live-flip 24 instances `sleepApplication=false` + redeploy (12 staging + 12 prod), (2) verify awake + serving `/`, (3) merge this PR.**

## Verification
- Red-green: starter driver (stub→probe `/`), SSOT golden (probe.staging true), provisioner (sleep false) — all RED→GREEN.
- `showcase/scripts`: 2092 tests pass; `tsc --noEmit` clean on changed files.

## Test plan
- [x] vitest suites green (2092)
- [ ] CR
- [ ] live 24-instance always-on flip + redeploy (staging + prod)
- [ ] CI green
- [ ] post-flip: `service=all` dry-run shows starters pass staging probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)