### PR TITLE
fix(showcase): recover ag2 + llamaindex staging from crash-loops

### DIFF
--- a/showcase/aimock/d6/ag2/gen-ui-declarative.json
+++ b/showcase/aimock/d6/ag2/gen-ui-declarative.json
@@ -1,210 +1,189 @@
 {
-  "_meta": {
-    "description": "D6 fixtures for ag2 / gen-ui-declarative (A2UI Dynamic Schema)",
-    "_note": "Agent uses a two-stage A2UI pattern (src/agents/a2ui_dynamic.py): (1) outer agent has only one tool, `generate_a2ui` (no args). (2) `generate_a2ui` internally invokes a secondary LLM bound to `render_a2ui` with `tool_choice` forced. The inner call's user message is threaded from the OUTER conversation's latest user prompt (see _latest_user_message() in a2ui_dynamic.py) so each pill's inner-call body is byte-distinct. (3) After the tool returns, the outer agent emits a one-sentence narration. Fixtures cover three LLM calls per pill: (a) outer turn 1 → emit generate_a2ui toolcall; (b) inner secondary call (tools=[render_a2ui], tool_choice forced) → emit render_a2ui toolcall with the flat catalog components; (c) outer turn 2 (post tool result) → narration. The inner call is discriminated by `toolName: 'render_a2ui'` (each call carries its bound tools=[render_a2ui]). Inner-call mirrors MUST be ordered BEFORE the outer generate_a2ui fixtures so first-match-wins routes the inner-call traffic to them.",
-    "created": "2026-05-28"
+ "_meta": {
+  "description": "D6 fixtures for ag2 / gen-ui-declarative (A2UI Dynamic Schema)",
+  "_note": "Mirrors langgraph-python gen-ui-declarative.json 1:1 (same 4 sales-context pills, same render_a2ui component trees). ag2 backend is the dedicated a2ui_dynamic.py agent mounted at /declarative-gen-ui (the route points HttpAgent at ${AGENT_URL}/declarative-gen-ui/, injectA2UITool:false). Two-stage pattern: (1) outer agent emits no-arg generate_a2ui toolcall (matched by userMessage+context=ag2); (2) the agent body runs its own secondary render_a2ui LLM call (matched by userMessage+toolName=render_a2ui) and wraps the result in an a2ui_operations container; (3) outer agent emits a one-sentence narration (matched by toolCallId). The outer generate_a2ui handler takes NO arguments — a required context param caused empty-args {} pydantic rejection + a retry hot loop.",
+  "created": "2026-06-23"
+ },
+ "fixtures": [
+  {
+   "_comment": "pill sales-dashboard hero — inner secondary LLM (middleware-injected render_a2ui) emits the flat A2UI components.",
+   "match": {
+    "userMessage": "Show me my sales dashboard for this quarter.",
+    "toolName": "render_a2ui"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_dash_design_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"sales-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"kpi-row\",\"charts-row\"]},{\"id\":\"kpi-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-revenue\",\"metric-new-customers\",\"metric-win-rate\",\"metric-deal-size\"]},{\"id\":\"metric-revenue\",\"component\":\"Metric\",\"label\":\"Quarterly Revenue\",\"value\":\"$4.2M\",\"trend\":\"up\",\"trendValue\":\"+12% QoQ\"},{\"id\":\"metric-new-customers\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"186\",\"trend\":\"up\",\"trendValue\":\"+8%\"},{\"id\":\"metric-win-rate\",\"component\":\"Metric\",\"label\":\"Win Rate\",\"value\":\"31%\",\"trend\":\"down\",\"trendValue\":\"-2 pts\"},{\"id\":\"metric-deal-size\",\"component\":\"Metric\",\"label\":\"Avg Deal Size\",\"value\":\"$22.6k\",\"trend\":\"up\",\"trendValue\":\"+5%\"},{\"id\":\"charts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"region-pie\",\"monthly-bar\"]},{\"id\":\"region-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by Region\",\"description\":\"Quarter revenue split across North America, EMEA, APAC, and LATAM.\",\"data\":[{\"label\":\"North America\",\"value\":1900000},{\"label\":\"EMEA\",\"value\":1300000},{\"label\":\"APAC\",\"value\":720000},{\"label\":\"LATAM\",\"value\":280000}]},{\"id\":\"monthly-bar\",\"component\":\"BarChart\",\"title\":\"Monthly Revenue\",\"description\":\"Revenue trend from Jan through Jun.\",\"data\":[{\"label\":\"Jan\",\"value\":1210000},{\"label\":\"Feb\",\"value\":1340000},{\"label\":\"Mar\",\"value\":1650000},{\"label\":\"Apr\",\"value\":1380000},{\"label\":\"May\",\"value\":1420000},{\"label\":\"Jun\",\"value\":1400000}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
   },
-  "fixtures": [
-    {
-      "_comment": "pill 1 KPI — inner secondary LLM (tools=[render_a2ui], tool_choice forced) emits the flat A2UI components. Discriminated by toolName so it wins over the outer generate_a2ui fixture whose userMessage matches the same prompt.",
-      "match": {
-        "userMessage": "Show me a quick KPI dashboard",
-        "toolName": "render_a2ui",
-        "context": "ag2"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_kpi_design_001",
-            "name": "render_a2ui",
-            "arguments": "{\"surfaceId\":\"kpi-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Card\",\"title\":\"KPI Dashboard\",\"subtitle\":\"Last 30 days\",\"child\":\"metrics-col\"},{\"id\":\"metrics-col\",\"component\":\"Column\",\"children\":[\"m-rev\",\"m-sign\",\"m-churn\",\"m-mrr\"],\"gap\":12},{\"id\":\"m-rev\",\"component\":\"Metric\",\"label\":\"Revenue\",\"value\":\"$1.2M\",\"trend\":\"up\"},{\"id\":\"m-sign\",\"component\":\"Metric\",\"label\":\"Signups\",\"value\":\"8,420\",\"trend\":\"up\"},{\"id\":\"m-churn\",\"component\":\"Metric\",\"label\":\"Churn\",\"value\":\"2.1%\",\"trend\":\"down\"},{\"id\":\"m-mrr\",\"component\":\"Metric\",\"label\":\"MRR\",\"value\":\"$98K\",\"trend\":\"up\"}]}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 2 pie chart — inner secondary LLM emits PieChart catalog component.",
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "toolName": "render_a2ui",
-        "context": "ag2"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_pie_design_001",
-            "name": "render_a2ui",
-            "arguments": "{\"surfaceId\":\"sales-pie\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"PieChart\",\"title\":\"Sales by Region\",\"description\":\"Regional sales distribution\",\"data\":[{\"label\":\"North America\",\"value\":45},{\"label\":\"Europe\",\"value\":28},{\"label\":\"Asia-Pacific\",\"value\":18},{\"label\":\"Other\",\"value\":9}]}]}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 3 bar chart — inner secondary LLM emits BarChart catalog component.",
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "toolName": "render_a2ui",
-        "context": "ag2"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_bar_design_001",
-            "name": "render_a2ui",
-            "arguments": "{\"surfaceId\":\"quarterly-rev\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"BarChart\",\"title\":\"Quarterly Revenue\",\"description\":\"Revenue by quarter\",\"data\":[{\"label\":\"Q1\",\"value\":280000},{\"label\":\"Q2\",\"value\":310000},{\"label\":\"Q3\",\"value\":295000},{\"label\":\"Q4\",\"value\":340000}]}]}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 4 status report — inner secondary LLM emits StatusBadges grouped in a root Column.",
-      "match": {
-        "userMessage": "status report on system health",
-        "toolName": "render_a2ui",
-        "context": "ag2"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_status_design_001",
-            "name": "render_a2ui",
-            "arguments": "{\"surfaceId\":\"sys-status\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Card\",\"title\":\"System health\",\"subtitle\":\"All services\",\"child\":\"badges-col\"},{\"id\":\"badges-col\",\"component\":\"Column\",\"children\":[\"sb-api\",\"sb-db\",\"sb-bg\"],\"gap\":8},{\"id\":\"sb-api\",\"component\":\"StatusBadge\",\"text\":\"API: healthy (p99 42ms)\",\"variant\":\"success\"},{\"id\":\"sb-db\",\"component\":\"StatusBadge\",\"text\":\"Database: healthy (replication lag 0.2s)\",\"variant\":\"success\"},{\"id\":\"sb-bg\",\"component\":\"StatusBadge\",\"text\":\"Background Workers: degraded (queue depth 1247)\",\"variant\":\"warning\"}]}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 1 KPI — outer agent narration after generate_a2ui returns.",
-      "match": {
-        "context": "ag2",
-        "toolCallId": "call_d6_decl_kpi_outer_001"
-      },
-      "response": {
-        "content": "KPI dashboard rendered."
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 1 KPI — outer agent emits generate_a2ui (no args).",
-      "match": {
-        "userMessage": "Show me a quick KPI dashboard",
-        "context": "ag2"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_kpi_outer_001",
-            "name": "generate_a2ui",
-            "arguments": "{}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 2 pie chart — outer agent narration.",
-      "match": {
-        "context": "ag2",
-        "toolCallId": "call_d6_decl_pie_outer_001"
-      },
-      "response": {
-        "content": "Pie chart rendered."
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 2 pie chart — outer agent emits generate_a2ui.",
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "context": "ag2"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_pie_outer_001",
-            "name": "generate_a2ui",
-            "arguments": "{}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 3 bar chart — outer agent narration.",
-      "match": {
-        "context": "ag2",
-        "toolCallId": "call_d6_decl_bar_outer_001"
-      },
-      "response": {
-        "content": "Bar chart rendered."
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 3 bar chart — outer agent emits generate_a2ui.",
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "context": "ag2"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_bar_outer_001",
-            "name": "generate_a2ui",
-            "arguments": "{}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 4 status report — outer agent narration.",
-      "match": {
-        "context": "ag2",
-        "toolCallId": "call_d6_decl_status_outer_001"
-      },
-      "response": {
-        "content": "System health status rendered."
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill 4 status report — outer agent emits generate_a2ui.",
-      "match": {
-        "userMessage": "status report on system health",
-        "context": "ag2"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_status_outer_001",
-            "name": "generate_a2ui",
-            "arguments": "{}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    },
-    {
-      "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args). Mirrors LGP gen-ui-declarative.json sales-dashboard outer entry. Closes the production 503 gap where backend hits aimock with tools=[generate_a2ui] for this userMessage (see /tmp/staging-journal-diff.md shape-B).",
-      "match": {
-        "userMessage": "Show me my sales dashboard for this quarter.",
-        "context": "ag2"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "id": "call_d6_decl_dash_outer_ag2_001",
-            "name": "generate_a2ui",
-            "arguments": "{}"
-          }
-        ]
-      },
-      "chunkSize": 9999
-    }
-  ]
+  {
+   "_comment": "pill sales-dashboard hero — outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "ag2",
+    "toolCallId": "call_d6_decl_dash_outer_ag2_001"
+   },
+   "response": {
+    "content": "Here's your Q2 sales dashboard."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "Show me my sales dashboard for this quarter.",
+    "context": "ag2"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_dash_outer_ag2_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill team-performance — inner secondary LLM (middleware-injected render_a2ui) emits the flat A2UI components.",
+   "match": {
+    "userMessage": "How are our sales reps performing against quota?",
+    "toolName": "render_a2ui"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_team_design_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"rep-quota-performance\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"title\",\"summary\",\"content\"]},{\"id\":\"title\",\"component\":\"Text\",\"text\":\"Sales rep performance vs quota\"},{\"id\":\"summary\",\"component\":\"Text\",\"text\":\"2 of 5 reps are above quota, 1 is near plan, and 2 are below target in Q2.\"},{\"id\":\"content\",\"component\":\"Row\",\"gap\":16,\"children\":[\"table-card\",\"attainment-chart\"]},{\"id\":\"table-card\",\"component\":\"Card\",\"title\":\"Rep attainment table\",\"child\":\"rep-table\"},{\"id\":\"rep-table\",\"component\":\"DataTable\",\"columns\":[{\"key\":\"rep\",\"label\":\"Rep\"},{\"key\":\"attainment\",\"label\":\"Attainment\"},{\"key\":\"pipeline\",\"label\":\"Pipeline\"}],\"rows\":[{\"rep\":\"Dana Whitfield\",\"attainment\":\"124%\",\"pipeline\":\"Leading team; biggest account Meridian Apparel Group has 4 open opps worth $210k\"},{\"rep\":\"Marcus Lee\",\"attainment\":\"108%\",\"pipeline\":\"Above plan\"},{\"rep\":\"Priya Sharma\",\"attainment\":\"97%\",\"pipeline\":\"Near quota\"},{\"rep\":\"Tom Okafor\",\"attainment\":\"88%\",\"pipeline\":\"Below plan\"},{\"rep\":\"Elena Vasquez\",\"attainment\":\"71%\",\"pipeline\":\"Furthest from quota\"}]},{\"id\":\"attainment-chart\",\"component\":\"BarChart\",\"title\":\"Quota attainment by rep\",\"description\":\"Q2 quota attainment percentages for all sales reps.\",\"data\":[{\"label\":\"Dana Whitfield\",\"value\":124},{\"label\":\"Marcus Lee\",\"value\":108},{\"label\":\"Priya Sharma\",\"value\":97},{\"label\":\"Tom Okafor\",\"value\":88},{\"label\":\"Elena Vasquez\",\"value\":71}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill team-performance — outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "ag2",
+    "toolCallId": "call_d6_decl_team_outer_ag2_001"
+   },
+   "response": {
+    "content": "Here's how the team is tracking against quota."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill team-performance — outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "How are our sales reps performing against quota?",
+    "context": "ag2"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_team_outer_ag2_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill at-risk — inner secondary LLM (middleware-injected render_a2ui) emits the flat A2UI components.",
+   "match": {
+    "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
+    "toolName": "render_a2ui"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_risk_design_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"risk-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"metrics-row\",\"accounts-row\"]},{\"id\":\"metrics-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-arr\",\"metric-accounts\",\"metric-biggest\"]},{\"id\":\"metric-arr\",\"component\":\"Metric\",\"label\":\"ARR at risk\",\"value\":\"$615k\",\"trend\":\"down\",\"trendValue\":\"3 accounts\"},{\"id\":\"metric-accounts\",\"component\":\"Metric\",\"label\":\"Accounts at risk\",\"value\":\"3\",\"trend\":\"neutral\",\"trendValue\":\"This quarter\"},{\"id\":\"metric-biggest\",\"component\":\"Metric\",\"label\":\"Biggest exposure\",\"value\":\"Northwind Retail\",\"trend\":\"down\",\"trendValue\":\"$340k renewal\"},{\"id\":\"accounts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"card-northwind\",\"card-cascadia\",\"card-atlas\"]},{\"id\":\"card-northwind\",\"component\":\"Card\",\"title\":\"Northwind Retail\",\"subtitle\":\"$340k ARR at stake\",\"child\":\"northwind-content\"},{\"id\":\"northwind-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"northwind-badge\",\"northwind-text\"]},{\"id\":\"northwind-badge\",\"component\":\"StatusBadge\",\"text\":\"High severity\",\"variant\":\"error\"},{\"id\":\"northwind-text\",\"component\":\"Text\",\"text\":\"No contact in 6 weeks; next action: exec outreach this week to protect the renewal.\"},{\"id\":\"card-cascadia\",\"component\":\"Card\",\"title\":\"Cascadia Outfitters\",\"subtitle\":\"$180k ARR at stake\",\"child\":\"cascadia-content\"},{\"id\":\"cascadia-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"cascadia-badge\",\"cascadia-text\"]},{\"id\":\"cascadia-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"cascadia-text\",\"component\":\"Text\",\"text\":\"Champion left; next action: rebuild stakeholder map and secure a new sponsor.\"},{\"id\":\"card-atlas\",\"component\":\"Card\",\"title\":\"Atlas Goods\",\"subtitle\":\"$95k ARR at stake\",\"child\":\"atlas-content\"},{\"id\":\"atlas-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"atlas-badge\",\"atlas-text\"]},{\"id\":\"atlas-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"atlas-text\",\"component\":\"Text\",\"text\":\"Legal review is stalled; next action: align procurement and legal on open terms.\"}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill at-risk — outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "ag2",
+    "toolCallId": "call_d6_decl_risk_outer_ag2_001"
+   },
+   "response": {
+    "content": "Three accounts need attention this quarter."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill at-risk — outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
+    "context": "ag2"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_risk_outer_ag2_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill top-account — inner secondary LLM (middleware-injected render_a2ui) emits the flat A2UI components.",
+   "match": {
+    "userMessage": "Pull up the details on our biggest account.",
+    "toolName": "render_a2ui"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_acct_design_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"biggest-account-details\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Row\",\"gap\":16,\"children\":[\"account-card\",\"revenue-pie\"]},{\"id\":\"account-card\",\"component\":\"Card\",\"title\":\"Meridian Apparel Group\",\"subtitle\":\"Biggest account\",\"child\":\"account-facts\"},{\"id\":\"account-facts\",\"component\":\"Column\",\"gap\":8,\"children\":[\"fact1\",\"fact2\",\"fact3\",\"fact4\",\"fact5\",\"fact6\",\"fact7\"]},{\"id\":\"fact1\",\"component\":\"InfoRow\",\"label\":\"Owner\",\"value\":\"Dana Whitfield\"},{\"id\":\"fact2\",\"component\":\"InfoRow\",\"label\":\"Region\",\"value\":\"North America\"},{\"id\":\"fact3\",\"component\":\"InfoRow\",\"label\":\"ARR\",\"value\":\"$612k\"},{\"id\":\"fact4\",\"component\":\"InfoRow\",\"label\":\"Renewal date\",\"value\":\"Sep 30\"},{\"id\":\"fact5\",\"component\":\"InfoRow\",\"label\":\"Last contact\",\"value\":\"3 days ago\"},{\"id\":\"fact6\",\"component\":\"InfoRow\",\"label\":\"Health\",\"value\":\"Green\"},{\"id\":\"fact7\",\"component\":\"InfoRow\",\"label\":\"Open opportunities\",\"value\":\"4 opportunities worth $210k\"},{\"id\":\"revenue-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by product line\",\"description\":\"Meridian Apparel Group revenue mix across product lines.\",\"data\":[{\"label\":\"Outerwear\",\"value\":260000},{\"label\":\"Footwear\",\"value\":180000},{\"label\":\"Accessories\",\"value\":112000},{\"label\":\"Custom\",\"value\":60000}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill top-account — outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "ag2",
+    "toolCallId": "call_d6_decl_acct_outer_ag2_001"
+   },
+   "response": {
+    "content": "Here's the rundown on Meridian Apparel Group."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill top-account — outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "Pull up the details on our biggest account.",
+    "context": "ag2"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_acct_outer_ag2_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  }
+ ]
 }

--- a/showcase/integrations/ag2/src/agents/a2ui_dynamic.py
+++ b/showcase/integrations/ag2/src/agents/a2ui_dynamic.py
@@ -16,12 +16,14 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Annotated
+from typing import cast
 
 import openai
 from autogen import ConversableAgent, LLMConfig
-from autogen.ag_ui import AGUIStream
+from autogen.ag_ui import AGUIStream  # type: ignore[import-not-found]  # runtime-only submodule (ag2[ag-ui] extra); not present in static type stubs
 from fastapi import FastAPI
+from openai.types.chat import ChatCompletionFunctionToolParam
+from openai.types.shared_params import FunctionDefinition
 
 from tools import (
     build_a2ui_operations_from_tool_call,
@@ -51,18 +53,24 @@ SYSTEM_PROMPT = (
     "`PieChart` for part-of-whole breakdowns (sales by region, traffic "
     "sources, portfolio allocation) and `BarChart` for comparisons across "
     "categories (quarterly revenue, headcount by team, signups per month). "
-    "`generate_a2ui` takes a single `context` argument summarising the "
-    "conversation. Keep chat replies to one short sentence; let the UI do "
+    "`generate_a2ui` takes no arguments and handles the rendering "
+    "automatically. Keep chat replies to one short sentence; let the UI do "
     "the talking."
 )
 
 
-async def generate_a2ui(
-    context: Annotated[
-        str, "Conversation context summary the secondary LLM should design UI from"
-    ],
-) -> str:
+async def generate_a2ui() -> str:
     """Generate dynamic A2UI components based on the conversation.
+
+    Takes NO arguments. The outer agent calls this tool with empty
+    arguments (``{}``); the per-request user prompt is read from the
+    ``RequestUserMessageMiddleware`` ContextVar (see ``_request_context``)
+    rather than threaded through a tool parameter. This mirrors the
+    langgraph-python sibling, whose ``generate_a2ui`` also takes no args
+    (``a2ui_dynamic.py``), and keeps the tool schema aligned with the D6
+    fixtures, which emit ``generate_a2ui`` with ``arguments="{}"``. A
+    required ``context`` parameter here would make pydantic reject every
+    empty-args call and drive the outer agent into a retry hot loop.
 
     A secondary LLM designs the UI schema and data using the `render_a2ui`
     tool schema. The result is returned as an `a2ui_operations` container
@@ -85,6 +93,13 @@ async def generate_a2ui(
     user_prompt = get_latest_user_message() or (
         "Generate a dynamic A2UI dashboard based on the conversation."
     )
+    # The inner-call system message is constant; per-pill distinctness comes
+    # from ``user_prompt`` above (the outer conversation's latest user
+    # message, captured per-request). Previously this was the outer agent's
+    # ``context`` tool argument, but the outer agent calls ``generate_a2ui``
+    # with empty args ``{}`` (see the no-arg signature + the D6 fixtures),
+    # so a required ``context`` param only produced a pydantic hot loop.
+    inner_system_prompt = "Generate a useful dashboard UI."
     # A13: forward inbound x-* headers via extra_headers as a defense in depth
     # alongside the global httpx hook (see _header_forwarding.py). The hook
     # patches httpx at module load, but extra_headers makes the intent
@@ -96,15 +111,18 @@ async def generate_a2ui(
             messages=[
                 {
                     "role": "system",
-                    "content": context or "Generate a useful dashboard UI.",
+                    "content": inner_system_prompt,
                 },
                 {"role": "user", "content": user_prompt},
             ],
             tools=[
-                {
-                    "type": "function",
-                    "function": RENDER_A2UI_TOOL_SCHEMA,
-                }
+                ChatCompletionFunctionToolParam(
+                    type="function",
+                    # RENDER_A2UI_TOOL_SCHEMA is an untyped dict literal that
+                    # conforms to the OpenAI FunctionDefinition TypedDict shape;
+                    # cast so the type checker accepts it (no runtime change).
+                    function=cast(FunctionDefinition, RENDER_A2UI_TOOL_SCHEMA),
+                )
             ],
             tool_choice={"type": "function", "function": {"name": "render_a2ui"}},
             extra_headers=forwarded or None,
@@ -127,8 +145,21 @@ async def generate_a2ui(
         logger.warning("generate_a2ui: secondary LLM produced no render_a2ui tool call")
         return json.dumps({"error": "LLM did not call render_a2ui"})
 
+    # tool_calls is a union of function- and custom-tool calls; only the
+    # function variant carries `.function`. `tool_choice` above forces the
+    # `render_a2ui` FUNCTION tool, so the first call is always the function
+    # variant at runtime — narrow on `.type` to make that explicit to the type
+    # checker (and degrade gracefully to the same error shape if it ever isn't).
+    first_call = choice.message.tool_calls[0]
+    if first_call.type != "function":
+        logger.warning(
+            "generate_a2ui: secondary LLM returned non-function tool call type=%s",
+            first_call.type,
+        )
+        return json.dumps({"error": "LLM did not call render_a2ui"})
+
     try:
-        args = json.loads(choice.message.tool_calls[0].function.arguments)
+        args = json.loads(first_call.function.arguments)
         result = build_a2ui_operations_from_tool_call(args)
         return json.dumps(result)
     except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:

--- a/showcase/integrations/ag2/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/ag2/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -1,12 +1,17 @@
 // Dedicated runtime for the Declarative Generative UI (A2UI — Dynamic Schema)
-// cell. Mirrors the working claude-sdk-typescript reference pattern: the
-// backend is the default pass-through ConversableAgent, and the runtime
-// auto-injects the `render_a2ui` tool (injectA2UITool defaults to true).
-// The A2UI middleware serialises the registered client catalog into
-// `copilotkit.context` and detects `a2ui_operations` in the tool result,
-// streaming rendered surfaces to the frontend.
+// cell. The backend is the dedicated `a2ui_dynamic.py` agent mounted at
+// `/declarative-gen-ui` (NOT the root catch-all `agent.py`): it owns the
+// `generate_a2ui` tool explicitly and runs its own secondary `render_a2ui`
+// LLM pass, returning an `a2ui_operations` container that the A2UI
+// middleware detects and streams to the frontend. This mirrors the sibling
+// dedicated routes (`/a2ui-fixed-schema/`, `/beautiful-chat/`, etc.) which
+// all point at their named mount, and matches the D6 fixtures + PARITY_NOTES.
+//
+// `injectA2UITool: false` — the agent already owns `generate_a2ui`, so the
+// runtime must NOT double-bind a second injected A2UI tool over it.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
   ExperimentalEmptyAdapter,
@@ -18,10 +23,22 @@ const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
 const runtime = new CopilotRuntime({
   // @ts-ignore -- see main route.ts
-  agents: { "declarative-gen-ui": new HttpAgent({ url: `${AGENT_URL}/` }) },
-  // `injectA2UITool` defaults to true — the runtime injects the A2UI tool
-  // and the default ConversableAgent receives it via AG-UI, matching the
-  // working claude-sdk-typescript reference pattern.
+  agents: {
+    "declarative-gen-ui": new HttpAgent({
+      url: `${AGENT_URL}/declarative-gen-ui/`,
+    }),
+  },
+  a2ui: {
+    // The dedicated agent owns `generate_a2ui` and produces the
+    // `a2ui_operations` container itself; do not inject a second A2UI tool.
+    injectA2UITool: false,
+    // Pin the catalog the page registers (mirrors the sibling
+    // `/copilotkit-beautiful-chat` and `/copilotkit-a2ui-fixed-schema`
+    // routes). The agent's emitted ops already carry this catalogId, but
+    // pinning it guards against any op that omits it falling back to the
+    // unregistered basic catalog ("Catalog not found" → surface never mounts).
+    defaultCatalogId: "declarative-gen-ui-catalog",
+  },
 });
 
 export const POST = async (req: NextRequest) => {

--- a/showcase/integrations/ag2/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
+++ b/showcase/integrations/ag2/src/app/demos/declarative-gen-ui/a2ui/definitions.ts
@@ -16,6 +16,45 @@ import { z } from "zod";
 import type { CatalogDefinitions } from "@copilotkit/a2ui-renderer";
 
 export const myDefinitions = {
+  // Override the basic catalog's Row/Column so `gap` is honoured — the
+  // built-in versions ignore it, which makes composed dashboards cramped.
+  Row: {
+    description:
+      "Horizontal layout container. Children share the width evenly. Use `gap` (px) to space dashboard tiles.",
+    props: z.object({
+      gap: z.number().optional(),
+      // Enum mirrors the keys the renderer actually maps to CSS. Anything
+      // outside this set silently falls back at render time, so we reject
+      // it at schema-parse time to surface LLM typos early.
+      align: z
+        .enum(["start", "center", "end", "stretch", "baseline"])
+        .optional(),
+      justify: z.enum(["start", "center", "end", "spaceBetween"]).optional(),
+      children: z.array(z.string()),
+    }),
+  },
+
+  Column: {
+    description:
+      "Vertical layout container. Use `gap` (px) to space stacked sections.",
+    props: z.object({
+      gap: z.number().optional(),
+      align: z
+        .enum(["start", "center", "end", "stretch", "baseline"])
+        .optional(),
+      children: z.array(z.string()),
+    }),
+  },
+
+  // Override the basic catalog's Text so it aligns flush with sibling
+  // components (the built-in version carries an 8px outer margin).
+  Text: {
+    description: "A plain text line. Use for short explanations inside cards.",
+    props: z.object({
+      text: z.string(),
+    }),
+  },
+
   Card: {
     description:
       "A titled card container with an optional subtitle and a single child slot. Use it to group related content (metrics, rows, buttons).",
@@ -28,7 +67,7 @@ export const myDefinitions = {
 
   StatusBadge: {
     description:
-      "A small coloured pill communicating the state of something (healthy/degraded/down, online/offline, open/closed). Choose `variant` to match the intent.",
+      "A small coloured pill communicating the state of something (healthy/degraded/at-risk, on-track/behind). Choose `variant` to match the intent.",
     props: z.object({
       text: z.string(),
       variant: z.enum(["success", "warning", "error", "info"]).optional(),
@@ -37,20 +76,43 @@ export const myDefinitions = {
 
   Metric: {
     description:
-      "A key/value KPI display with an optional trend indicator. Ideal for dashboards (e.g. 'Revenue • $12.4k • up').",
+      "A key/value KPI tile with an optional trend indicator and trend delta. Ideal for dashboard KPI rows (e.g. 'Revenue • $4.2M • up 12%').",
     props: z.object({
       label: z.string(),
       value: z.string(),
       trend: z.enum(["up", "down", "neutral"]).optional(),
+      trendValue: z.string().optional(),
     }),
   },
 
   InfoRow: {
     description:
-      "A compact two-column 'label: value' row. Good for stacks of facts inside a Card (owner, region, last updated, etc.).",
+      "A compact two-column 'label: value' row. Good for stacks of facts inside a Card (owner, region, ARR, renewal date, etc.).",
     props: z.object({
       label: z.string(),
       value: z.string(),
+    }),
+  },
+
+  DataTable: {
+    description:
+      "A data table with column headers and rows. Ideal for rankings and per-person/per-item breakdowns (rep performance vs quota, deal lists). Each row's keys MUST appear in `columns[].key`; unknown row keys render as blank cells and indicate model/schema drift.",
+    // NOTE on B12 (row-keys ⊆ columns[].key): we'd normally enforce this
+    // with `z.object(...).refine(...)`, but the host catalog package's
+    // `CatalogComponentDefinition` type requires `props: ZodObject<…>`
+    // (it inspects `.shape` at runtime), and `.refine` returns a
+    // `ZodEffects` that breaks both the `satisfies CatalogDefinitions`
+    // type assertion and the runtime `.shape` access. Until the host
+    // type is broadened, we encode the constraint in the description
+    // above so the LLM sees the rule, and leave hard enforcement to
+    // the rendering pipeline (which already shows the empty cell —
+    // detection is the gap, not behaviour).
+    props: z.object({
+      columns: z.array(z.object({ key: z.string(), label: z.string() })),
+      // Cells may be strings or numbers — the renderer stringifies at
+      // render time, but accepting both lets the LLM emit raw numerics
+      // (e.g. attainment 124) instead of being forced to stringify.
+      rows: z.array(z.record(z.union([z.string(), z.number()]))),
     }),
   },
 
@@ -59,13 +121,18 @@ export const myDefinitions = {
       "A styled primary call-to-action button. Attach an optional `action` that will be dispatched back to the agent when the user clicks it.",
     props: z.object({
       label: z.string(),
-      action: z.any().optional(),
+      // The renderer hands `action` opaquely to the A2UI `dispatch` helper,
+      // which forwards it back to the agent. We don't constrain the shape
+      // (different demos use different action payloads), but `z.unknown()`
+      // is strictly better than `z.any()` here because it forces any
+      // consumer that touches the value to narrow it explicitly.
+      action: z.unknown().optional(),
     }),
   },
 
   PieChart: {
     description:
-      "A pie/donut chart with a brand-coloured legend. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for part-of-whole breakdowns (sales by region, traffic sources, portfolio allocation).",
+      "A pie/donut chart with a brand-coloured legend. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for part-of-whole breakdowns (revenue by region, pipeline by stage).",
     props: z.object({
       title: z.string(),
       description: z.string(),
@@ -80,7 +147,7 @@ export const myDefinitions = {
 
   BarChart: {
     description:
-      "A vertical bar chart built on Recharts. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for comparing series across categories (quarterly revenue, headcount by team, signups per month).",
+      "A vertical bar chart built on Recharts. Provide `title`, `description`, and `data` as an array of `{ label, value }` objects. Great for comparing series across categories or time (monthly revenue, signups per month).",
     props: z.object({
       title: z.string(),
       description: z.string(),

--- a/showcase/integrations/ag2/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
+++ b/showcase/integrations/ag2/src/app/demos/declarative-gen-ui/a2ui/renderers.tsx
@@ -3,215 +3,252 @@
 /**
  * A2UI catalog RENDERERS.
  *
- * React implementations for each definition in `./definitions.ts`,
- * styled with the demo's local ShadCN-flavoured primitives in
- * `../_components/`. The assembled catalog (definitions × renderers via
- * `createCatalog`) lives in `./catalog.ts`.
+ * React implementations for each definition in `./definitions.ts`. Visuals
+ * mirror beautiful-chat's sales dashboard renderers
+ * (../../beautiful-chat/declarative-generative-ui/renderers.tsx) so the two
+ * demos read as the same product family — same card chrome, metric
+ * typography, recharts donut/bar styling, and palette. The assembled catalog
+ * (definitions × renderers via `createCatalog`) lives in `./catalog.ts`.
  *
  * Reference:
  *   https://docs.copilotkit.ai/integrations/langgraph/generative-ui/a2ui
  */
-import React, { useRef } from "react";
+import React from "react";
 import {
+  PieChart as RechartsPieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
   BarChart as RechartsBarChart,
   Bar,
   XAxis,
   YAxis,
   Tooltip,
   CartesianGrid,
-  Cell,
-  ResponsiveContainer,
-  Rectangle,
 } from "recharts";
 import type { CatalogRenderers } from "@copilotkit/a2ui-renderer";
+import { TriangleAlert, CircleAlert, CircleCheck, Info } from "lucide-react";
 
 import type { MyDefinitions } from "./definitions";
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-} from "../_components/card";
 import { Badge } from "../_components/badge";
 import { Button } from "../_components/button";
 
-// ─── ShadCN-friendly chart palette ─────────────────────────────────────────
-// Neutral, slightly muted hues that pair with `bg-card` / `--border`
-// (zinc/slate-leaning, akin to ShadCN's chart-{1..5} palette).
-const CHART_COLORS = [
-  "#3F3F46", // zinc-700
-  "#71717A", // zinc-500
-  "#A1A1AA", // zinc-400
-  "#18181B", // zinc-900
-  "#52525B", // zinc-600
-  "#D4D4D8", // zinc-300
-  "#27272A", // zinc-800
-] as const;
-
-const CHART_TOOLTIP_STYLE: React.CSSProperties = {
-  backgroundColor: "var(--card)",
-  border: "1px solid var(--border)",
-  borderRadius: 8,
-  padding: "8px 12px",
-  color: "var(--foreground)",
-  fontSize: 12,
-  boxShadow: "0 4px 12px rgba(0,0,0,0.06)",
+// ─── Theme tokens + palette (mirrors beautiful-chat) ────────────────────────
+const c = {
+  card: "var(--card)",
+  cardFg: "var(--card-foreground)",
+  border: "var(--border)",
+  muted: "var(--muted-foreground)",
+  divider: "color-mix(in srgb, var(--border) 50%, var(--card))",
+  shadow: "0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.04)",
 };
 
-/** Custom SVG donut chart built with <circle> + stroke-dasharray. */
-function DonutChart({
-  data,
-  size = 220,
-  strokeWidth = 36,
+const CHART_COLORS = [
+  "#3b82f6", // blue-500
+  "#8b5cf6", // violet-500
+  "#ec4899", // pink-500
+  "#f59e0b", // amber-500
+  "#10b981", // emerald-500
+  "#6366f1", // indigo-500
+] as const;
+
+/** DashboardCard-style chrome shared by Card and the chart wrappers. */
+function CardShell({
+  title,
+  subtitle,
+  testid,
+  cardId,
+  children,
 }: {
-  data: { label: string; value: number }[];
-  size?: number;
-  strokeWidth?: number;
+  title: string;
+  subtitle?: string;
+  testid?: string;
+  cardId?: string;
+  children?: React.ReactNode;
 }) {
-  const radius = (size - strokeWidth) / 2;
-  const circumference = 2 * Math.PI * radius;
-  const center = size / 2;
-
-  const total = data.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
-
-  let accumulated = 0;
-  const slices = data.map((item, index) => {
-    const val = Number(item.value) || 0;
-    const ratio = total > 0 ? val / total : 0;
-    const arc = ratio * circumference;
-    const startAt = accumulated;
-    accumulated += arc;
-    return {
-      ...item,
-      arc,
-      gap: circumference - arc,
-      dashoffset: -startAt,
-      color: CHART_COLORS[index % CHART_COLORS.length],
-    };
-  });
-
   return (
-    <svg
-      width="100%"
-      viewBox={`0 0 ${size} ${size}`}
+    <div
+      data-testid={testid}
+      data-card-id={cardId}
       style={{
-        display: "block",
-        margin: "0 auto",
-        maxWidth: size,
-        transform: "scaleX(-1)",
+        background: c.card,
+        borderRadius: "12px",
+        border: `1px solid ${c.border}`,
+        padding: "20px",
+        boxShadow: c.shadow,
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px",
+        width: "100%",
+        minWidth: 0,
+        overflow: "hidden",
       }}
     >
-      <circle
-        cx={center}
-        cy={center}
-        r={radius}
-        fill="none"
-        stroke="var(--muted)"
-        strokeWidth={strokeWidth}
-      />
-      {slices.map((slice, i) => (
-        <circle
-          key={i}
-          cx={center}
-          cy={center}
-          r={radius}
-          fill="none"
-          stroke={slice.color}
-          strokeWidth={strokeWidth}
-          strokeDasharray={`${slice.arc} ${slice.gap}`}
-          strokeDashoffset={slice.dashoffset}
-          strokeLinecap="butt"
-          transform={`rotate(-90 ${center} ${center})`}
-        />
-      ))}
-    </svg>
-  );
-}
-
-/** Tracks seen indices so only NEW bars get the fade-in animation. */
-function useSeenIndices() {
-  const seen = useRef(new Set<number>());
-  return {
-    isNew(index: number) {
-      if (seen.current.has(index)) return false;
-      seen.current.add(index);
-      return true;
-    },
-  };
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function AnimatedBar(props: any) {
-  const { isNew, ...rest } = props;
-  return (
-    <g
-      style={
-        isNew
-          ? {
-              animation: "barSlideIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) both",
-            }
-          : undefined
-      }
-    >
-      <Rectangle {...rest} />
-    </g>
+      <div>
+        <div style={{ fontWeight: 600, fontSize: "0.9rem", color: c.cardFg }}>
+          {title}
+        </div>
+        {subtitle && (
+          <div
+            style={{ fontSize: "0.75rem", color: c.muted, marginTop: "2px" }}
+          >
+            {subtitle}
+          </div>
+        )}
+      </div>
+      {children}
+    </div>
   );
 }
 
 // @region[renderers-react]
 export const myRenderers: CatalogRenderers<MyDefinitions> = {
-  Card: ({ props, children }) => (
-    <Card
-      className="w-full min-w-0 overflow-hidden"
-      data-testid="declarative-card"
-    >
-      <CardHeader>
-        <CardTitle>{props.title}</CardTitle>
-        {props.subtitle && <CardDescription>{props.subtitle}</CardDescription>}
-      </CardHeader>
-      {props.child && (
-        <CardContent className="flex flex-col gap-4">
-          {children(props.child)}
-        </CardContent>
-      )}
-    </Card>
+  Row: ({ props, children }) => {
+    const justifyMap: Record<string, string> = {
+      start: "flex-start",
+      center: "center",
+      end: "flex-end",
+      spaceBetween: "space-between",
+    };
+    const items = Array.isArray(props.children) ? props.children : [];
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          gap: `${props.gap ?? 16}px`,
+          alignItems: props.align ?? "stretch",
+          justifyContent: justifyMap[props.justify ?? "start"] ?? "flex-start",
+          flexWrap: "wrap",
+          width: "100%",
+        }}
+      >
+        {items.map((id, i) => (
+          <div key={`${id}-${i}`} style={{ flex: "1 1 0", minWidth: 0 }}>
+            {children(id)}
+          </div>
+        ))}
+      </div>
+    );
+  },
+
+  Column: ({ props, children }) => {
+    const items = Array.isArray(props.children) ? props.children : [];
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: `${props.gap ?? 12}px`,
+          width: "100%",
+        }}
+      >
+        {items.map((id, i) => (
+          <React.Fragment key={`${id}-${i}`}>{children(id)}</React.Fragment>
+        ))}
+      </div>
+    );
+  },
+
+  Text: ({ props }) => (
+    <span style={{ fontSize: "0.85rem", color: c.cardFg, lineHeight: 1.5 }}>
+      {props.text}
+    </span>
   ),
 
-  StatusBadge: ({ props }) => (
-    <Badge
-      variant={props.variant ?? "info"}
-      data-testid="declarative-status-badge"
+  Card: ({ props, children }) => (
+    // `data-testid="declarative-card"` stays shared so existing e2e selectors
+    // still find every card; `data-card-id={props.title}` disambiguates
+    // sibling cards (e.g. the at-risk pill's 3 severity cards) so test
+    // assertions can target a specific card by title.
+    <CardShell
+      title={props.title}
+      subtitle={props.subtitle}
+      testid="declarative-card"
+      cardId={props.title}
     >
-      {props.text}
-    </Badge>
+      {props.child && children(props.child)}
+    </CardShell>
   ),
+
+  StatusBadge: ({ props }) => {
+    const variant = props.variant ?? "info";
+    const Icon = {
+      error: TriangleAlert,
+      warning: CircleAlert,
+      success: CircleCheck,
+      info: Info,
+    }[variant];
+    return (
+      // `alignSelf: flex-start` keeps the pill content-sized — flex parents
+      // (our Column override) default to stretch, which inflates it into a
+      // full-width banner.
+      <Badge
+        variant={variant}
+        style={{ alignSelf: "flex-start" }}
+        data-testid="declarative-status-badge"
+      >
+        <Icon size={12} strokeWidth={2.5} style={{ marginRight: 4 }} />
+        {props.text}
+      </Badge>
+    );
+  },
 
   Metric: ({ props }) => {
-    const trend = props.trend ?? "neutral";
-    const arrow = trend === "up" ? "↑" : trend === "down" ? "↓" : "";
-    const trendClass =
-      trend === "up"
-        ? "text-emerald-600"
-        : trend === "down"
-          ? "text-rose-600"
-          : "text-[var(--foreground)]";
+    const trendColors: Record<string, string> = {
+      up: "#059669",
+      down: "#dc2626",
+      neutral: c.muted,
+    };
+    const trendIcons: Record<string, string> = {
+      up: "↑",
+      down: "↓",
+      neutral: "→",
+    };
     return (
-      // `flex-1 min-w-[120px]` lets a row of Metrics distribute evenly
-      // inside the basic catalog's gap-less Row — 3 metrics in a 600px
-      // card column get ~200px each instead of squishing to content width.
       <div
         data-testid="declarative-metric"
-        className="flex flex-1 min-w-[120px] flex-col gap-1"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "4px",
+          minWidth: "120px",
+        }}
       >
-        <div className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]">
-          {props.label}
-        </div>
-        <div
-          className={`flex items-baseline gap-1.5 text-2xl font-semibold tabular-nums ${trendClass}`}
+        <span
+          style={{
+            fontSize: "0.75rem",
+            color: c.muted,
+            fontWeight: 500,
+            textTransform: "uppercase",
+            letterSpacing: "0.05em",
+          }}
         >
-          <span>{props.value}</span>
-          {arrow && <span className="text-base">{arrow}</span>}
+          {props.label}
+        </span>
+        <div style={{ display: "flex", alignItems: "baseline", gap: "8px" }}>
+          <span
+            style={{
+              fontSize: "1.5rem",
+              fontWeight: 700,
+              color: c.cardFg,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            {props.value}
+          </span>
+          {props.trend && (
+            <span
+              style={{
+                fontSize: "0.8rem",
+                fontWeight: 500,
+                color: trendColors[props.trend] ?? c.muted,
+              }}
+            >
+              {trendIcons[props.trend]}
+              {props.trendValue ? ` ${props.trendValue}` : ""}
+            </span>
+          )}
         </div>
       </div>
     );
@@ -221,7 +258,10 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
     // Divider via `border-b last:border-b-0` so the final row doesn't dangle
     // a trailing line, regardless of whether the agent wraps these in a
     // Column or drops them directly into a Card's child slot.
-    <div className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0">
+    <div
+      data-testid="declarative-info-row"
+      className="flex items-baseline justify-between gap-4 py-2 border-b border-[var(--border)] last:border-b-0 last:pb-0 first:pt-0"
+    >
       <span className="text-sm text-[var(--muted-foreground)]">
         {props.label}
       </span>
@@ -230,6 +270,59 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
       </span>
     </div>
   ),
+
+  DataTable: ({ props }) => {
+    const cols = Array.isArray(props.columns) ? props.columns : [];
+    const rows = Array.isArray(props.rows) ? props.rows : [];
+    return (
+      <div
+        data-testid="declarative-data-table"
+        className="w-full overflow-x-auto"
+      >
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  className="border-b-2 border-[var(--border)] px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => {
+              // Stable row key: prefer the first column's value (primary-key-ish),
+              // suffix with index in case values repeat, fall back to a JSON
+              // stringify of the row when columns is empty. Stable keys prevent
+              // React from re-mounting every row when the agent re-emits a
+              // slightly different table.
+              const pk = cols.length > 0 ? row[cols[0].key] : undefined;
+              const rowKey =
+                pk !== undefined ? `${pk}-${i}` : JSON.stringify(row);
+              return (
+                <tr
+                  key={rowKey}
+                  className="border-b border-[var(--border)] last:border-b-0"
+                >
+                  {cols.map((col) => (
+                    <td
+                      key={col.key}
+                      className="px-3 py-2 tabular-nums text-[var(--foreground)]"
+                    >
+                      {String(row[col.key] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  },
 
   PrimaryButton: ({ props, dispatch }) => (
     <Button
@@ -242,150 +335,114 @@ export const myRenderers: CatalogRenderers<MyDefinitions> = {
   ),
 
   PieChart: ({ props }) => {
-    const data = props.data ?? [];
-    const safeData = Array.isArray(data) ? data : [];
-    const total = safeData.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
-
+    // Coerce values to numbers — the LLM sometimes emits them as strings.
+    // Use a strict finite check so null/undefined/NaN/non-numeric strings are
+    // surfaced via console.warn rather than silently collapsed to 0 (which
+    // masks schema/data drift). Recharts requires a numeric value to render,
+    // so we fall back to 0 only after logging.
+    const data = (Array.isArray(props.data) ? props.data : []).map((d) => {
+      const raw = (d as { value?: unknown }).value;
+      const n = typeof raw === "number" ? raw : parseFloat(raw as string);
+      let value: number;
+      if (Number.isFinite(n)) {
+        value = n;
+      } else {
+        console.warn("Invalid chart value", {
+          component: "PieChart",
+          key: "value",
+          raw,
+        });
+        value = 0;
+      }
+      return { ...d, value };
+    });
     return (
-      // `flex-1 min-w-0` so multiple charts in a basic-catalog Row
-      // distribute the available width evenly instead of each insisting
-      // on its content size and overflowing.
-      <Card
-        className="w-full flex-1 min-w-0 overflow-hidden"
-        data-testid="declarative-pie-chart"
+      <CardShell
+        title={props.title}
+        subtitle={props.description}
+        testid="declarative-pie-chart"
       >
-        <CardHeader>
-          <CardTitle>{props.title}</CardTitle>
-          <CardDescription>{props.description}</CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          {safeData.length === 0 ? (
-            <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">
-              No data available
-            </div>
-          ) : (
-            <>
-              <DonutChart data={safeData} />
-              <div className="flex flex-col gap-2 pt-2">
-                {safeData.map((item, index) => {
-                  const val = Number(item.value) || 0;
-                  const pct =
-                    total > 0 ? ((val / total) * 100).toFixed(0) : "0";
-                  return (
-                    <div
-                      key={index}
-                      className="flex items-center gap-3 text-sm"
-                    >
-                      <span
-                        className="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
-                        style={{
-                          backgroundColor:
-                            CHART_COLORS[index % CHART_COLORS.length],
-                        }}
-                      />
-                      <span className="flex-1 truncate text-[var(--foreground)]">
-                        {item.label}
-                      </span>
-                      <span className="tabular-nums text-[var(--muted-foreground)]">
-                        {val.toLocaleString()}
-                      </span>
-                      <span className="w-10 text-right tabular-nums text-[var(--muted-foreground)]">
-                        {pct}%
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            </>
-          )}
-        </CardContent>
-      </Card>
+        {data.length === 0 ? (
+          <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">
+            No data available
+          </div>
+        ) : (
+          <div style={{ width: "100%", height: 200 }}>
+            <ResponsiveContainer>
+              <RechartsPieChart>
+                <Pie
+                  data={data}
+                  dataKey="value"
+                  nameKey="label"
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={40}
+                  outerRadius={80}
+                  paddingAngle={2}
+                >
+                  {data.map((_, i) => (
+                    <Cell
+                      key={i}
+                      fill={CHART_COLORS[i % CHART_COLORS.length]}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip />
+              </RechartsPieChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardShell>
     );
   },
 
   BarChart: ({ props }) => {
-    const { isNew } = useSeenIndices();
-    const data = props.data ?? [];
-    const safeData = Array.isArray(data) ? data : [];
-
+    // Coerce values to numbers — the LLM sometimes emits them as strings,
+    // which recharts treats as categorical (unordered Y-axis ticks). Use a
+    // strict finite check so null/undefined/NaN/non-numeric strings are
+    // surfaced via console.warn rather than silently collapsed to 0 (which
+    // masks schema/data drift). Recharts requires a numeric value to render,
+    // so we fall back to 0 only after logging.
+    const data = (Array.isArray(props.data) ? props.data : []).map((d) => {
+      const raw = (d as { value?: unknown }).value;
+      const n = typeof raw === "number" ? raw : parseFloat(raw as string);
+      let value: number;
+      if (Number.isFinite(n)) {
+        value = n;
+      } else {
+        console.warn("Invalid chart value", {
+          component: "BarChart",
+          key: "value",
+          raw,
+        });
+        value = 0;
+      }
+      return { ...d, value };
+    });
     return (
-      <Card
-        className="w-full flex-1 min-w-0 overflow-hidden"
-        data-testid="declarative-bar-chart"
+      <CardShell
+        title={props.title}
+        subtitle={props.description}
+        testid="declarative-bar-chart"
       >
-        {/* Scoped keyframe — no globals.css needed */}
-        <style>{`
-          @keyframes barSlideIn {
-            from { transform: translateY(40px); opacity: 0; }
-            20% { opacity: 1; }
-            to { transform: translateY(0); opacity: 1; }
-          }
-        `}</style>
-        <CardHeader>
-          <CardTitle>{props.title}</CardTitle>
-          <CardDescription>{props.description}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          {safeData.length === 0 ? (
-            <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">
-              No data available
-            </div>
-          ) : (
-            <ResponsiveContainer width="100%" height={260}>
-              <RechartsBarChart
-                data={safeData}
-                margin={{ top: 12, right: 12, bottom: 4, left: -8 }}
-              >
-                <CartesianGrid
-                  strokeDasharray="3 3"
-                  stroke="var(--border)"
-                  vertical={false}
-                />
-                <XAxis
-                  dataKey="label"
-                  tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
-                  stroke="var(--border)"
-                  tickLine={false}
-                  axisLine={false}
-                />
-                <YAxis
-                  tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
-                  stroke="var(--border)"
-                  tickLine={false}
-                  axisLine={false}
-                />
-                <Tooltip
-                  contentStyle={CHART_TOOLTIP_STYLE}
-                  cursor={{ fill: "var(--muted)", opacity: 0.5 }}
-                />
-                <Bar
-                  isAnimationActive={false}
-                  dataKey="value"
-                  radius={[6, 6, 0, 0]}
-                  maxBarSize={48}
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  shape={
-                    ((barProps: any) => (
-                      <AnimatedBar
-                        {...barProps}
-                        isNew={isNew(barProps.index as number)}
-                      />
-                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    )) as any
-                  }
-                >
-                  {safeData.map((_, index) => (
-                    <Cell
-                      key={index}
-                      fill={CHART_COLORS[index % CHART_COLORS.length]}
-                    />
-                  ))}
-                </Bar>
+        {data.length === 0 ? (
+          <div className="py-8 text-center text-sm text-[var(--muted-foreground)]">
+            No data available
+          </div>
+        ) : (
+          <div style={{ width: "100%", height: 200 }}>
+            <ResponsiveContainer>
+              <RechartsBarChart data={data}>
+                <CartesianGrid strokeDasharray="3 3" stroke={c.divider} />
+                <XAxis dataKey="label" tick={{ fontSize: 11, fill: c.muted }} />
+                <YAxis tick={{ fontSize: 11, fill: c.muted }} />
+                <Tooltip />
+                <Bar dataKey="value" fill="#3b82f6" radius={[4, 4, 0, 0]} />
               </RechartsBarChart>
             </ResponsiveContainer>
-          )}
-        </CardContent>
-      </Card>
+          </div>
+        )}
+      </CardShell>
     );
   },
 };

--- a/showcase/integrations/llamaindex/src/agents/_request_tools.py
+++ b/showcase/integrations/llamaindex/src/agents/_request_tools.py
@@ -1,0 +1,395 @@
+"""Forward CopilotKit request-time frontend tools to the LlamaIndex AG-UI LLM.
+
+WHY THIS EXISTS
+---------------
+The llama-index AG-UI adapter (``llama_index.protocols.ag_ui``) builds the
+tool list it hands to the LLM from ONLY the *static* ``frontend_tools`` /
+``backend_tools`` passed at router-construction time (see
+``AGUIChatWorkflow.chat`` -> ``tools = list(self.frontend_tools.values()) +
+list(self.backend_tools.values())``). It never reads ``RunAgentInput.tools``,
+the per-request tool list CopilotKit injects from the page's
+``useFrontendTool`` / ``useHumanInTheLoop`` / ``useComponent`` hooks.
+
+Every other working integration (LangGraph, ag2, ...) forwards the request's
+injected tools to the model automatically — the gold-standard
+``langgraph-python`` does it inside the framework runtime. LlamaIndex does not,
+so any showcase demo whose page registers a tool the sub-router was constructed
+WITHOUT (e.g. ``beautiful-chat`` injects ``toggleTheme`` / ``pieChart`` /
+``barChart`` / ``scheduleTime`` but its router was built with
+``frontend_tools=[]``) produces a request whose tool list differs from the
+recorded aimock fixture. aimock 404s (``no_fixture_match``), the adapter raises
+``openai.NotFoundError`` and emits ``RUN_ERROR`` instead of ``RUN_FINISHED`` →
+the harness reports ``sse-missing``.
+
+THE FIX
+-------
+A mixin that, at the start of the ``chat`` step, converts each
+``RunAgentInput.tools`` entry into a no-op ``FunctionTool`` whose OpenAI wire
+schema is *byte-faithful* to the schema the frontend injected, and merges them
+into ``self.frontend_tools`` BEFORE the parent ``chat`` builds its tool list.
+Because the merged tools land in ``self.frontend_tools``, every existing
+``in self.frontend_tools`` classification in the adapter (tool-call routing,
+``aggregate_tool_calls`` -> ``StopEvent``) treats them correctly as
+frontend-resolved tools: their calls stream back to the client and are never
+executed server-side. CopilotKit resolves the real result on the page.
+
+A fresh workflow is constructed per request (``AGUIWorkflowRouter.run`` ->
+``await self.workflow_factory()``), so mutating ``self.frontend_tools`` per
+request is safe and never leaks across runs.
+
+Statically-declared tools always win over an injected tool of the same name
+(so a router that intentionally declares a backend tool keeps its server-side
+implementation).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, Dict, List, Optional, Union, cast
+
+from ag_ui.core import RunAgentInput
+from fastapi import APIRouter
+from llama_index.core.llms import ChatMessage, ChatResponse, MessageRole, TextBlock
+from llama_index.core.llms.function_calling import FunctionCallingLLM
+from llama_index.core.tools import BaseTool, FunctionTool, ToolMetadata
+from llama_index.core.workflow import Context, step
+
+# StopEvent is re-exported by llama_index.core.workflow.events, but pyright flags
+# that as a private re-export (reportPrivateImportUsage). Import from the public
+# `workflows.events` module instead — verified to be the SAME class object.
+from workflows.events import StopEvent
+from llama_index.protocols.ag_ui.agent import (
+    AGUIChatWorkflow,
+    DEFAULT_STATE_PROMPT,
+    InputEvent,
+    LoopEvent,
+    ToolCallEvent,
+)
+from llama_index.protocols.ag_ui.events import (
+    StateSnapshotWorkflowEvent,
+    TextMessageChunkWorkflowEvent,
+    ToolCallChunkWorkflowEvent,
+)
+from llama_index.protocols.ag_ui.router import get_ag_ui_workflow_router
+from llama_index.protocols.ag_ui.utils import (
+    ag_ui_message_to_llama_index_message,
+    timestamp,
+)
+
+
+class _RawSchemaToolMetadata(ToolMetadata):
+    """ToolMetadata that returns a verbatim, frontend-supplied JSON schema.
+
+    The adapter serializes a tool to the OpenAI wire format via
+    ``ToolMetadata.to_openai_tool`` -> ``get_parameters_dict``, which normally
+    derives the schema from a pydantic ``fn_schema``. Round-tripping the
+    injected JSON schema through a generated pydantic model can subtly reshape
+    it (added ``title`` keys, reordered ``required``, ``$defs`` rewrites), which
+    would diverge from the recorded aimock fixture. We instead carry the exact
+    schema the page injected and hand it back unchanged.
+    """
+
+    def __init__(self, raw_parameters: Optional[Dict[str, Any]], **kwargs: Any):
+        super().__init__(**kwargs)
+        # Stored on the instance dict (ToolMetadata is a dataclass; this is an
+        # extra, non-field attribute used only by get_parameters_dict below).
+        object.__setattr__(self, "_raw_parameters", raw_parameters)
+
+    def get_parameters_dict(self) -> dict:
+        raw = getattr(self, "_raw_parameters", None)
+        if raw is None:
+            # Tool injected with no parameters schema — present an empty object
+            # so the LLM sees a zero-arg tool (matches a ``z.object({})`` page
+            # registration like beautiful-chat's ``toggleTheme``).
+            return {"type": "object", "properties": {}}
+        return raw
+
+
+def _noop_stub(**kwargs: Any) -> str:
+    """No-op sync body for a frontend-resolved tool.
+
+    The adapter sends a ``ToolCallEvent`` for frontend tools too, which routes
+    through ``handle_tool_call`` -> ``tool.acall(**kwargs)``. The real result is
+    produced on the client and streamed back; this body is never the source of
+    truth. ``aggregate_tool_calls`` then returns a ``StopEvent`` (the call was
+    classified as frontend), so the frontend resolves the actual result.
+    """
+    return ""
+
+
+async def _noop_stub_async(**kwargs: Any) -> str:
+    """Async counterpart of ``_noop_stub`` for the ``acall`` path."""
+    return ""
+
+
+def request_tools_to_frontend_tools(
+    input_data: RunAgentInput,
+) -> Dict[str, BaseTool]:
+    """Convert ``RunAgentInput.tools`` into a name -> stub-tool mapping.
+
+    Built via ``FunctionTool.from_defaults`` with an explicit ``tool_metadata``
+    so the OpenAI wire schema is the verbatim, frontend-supplied JSON schema
+    (no pydantic round-trip reshaping that would diverge from the recorded
+    aimock fixture), while reusing the battle-tested ``FunctionTool`` for the
+    ``acall`` path.
+    """
+    result: Dict[str, BaseTool] = {}
+    for tool in input_data.tools or []:
+        metadata = _RawSchemaToolMetadata(
+            raw_parameters=tool.parameters,
+            name=tool.name,
+            description=tool.description or tool.name,
+            fn_schema=None,
+        )
+        result[tool.name] = FunctionTool.from_defaults(
+            fn=_noop_stub,
+            async_fn=_noop_stub_async,
+            tool_metadata=metadata,
+        )
+    return result
+
+
+def _fix_tool_messages_copy(chat_history: List[ChatMessage]) -> None:
+    """Re-role tool-result messages the upstream converter mis-roles as ``user``.
+
+    ``ag_ui_message_to_llama_index_message`` converts AG-UI ``ToolMessage`` to
+    ``ChatMessage(role="user")`` (an upstream hack). The OpenAI SDK needs
+    ``role="tool"`` to emit a proper tool-result message; aimock's
+    ``hasToolResult`` matcher (``messages.some(role === "tool")``) likewise only
+    sees the second-leg fixture when the role is ``tool``. Without this, a
+    frontend tool's follow-up turn (``toggleTheme`` / ``scheduleTime``) sends
+    the result as ``user`` → ``hasToolResult:false`` → the ``hasToolResult:true``
+    fixture never matches → 404 → run error.
+
+    Operates on a SHALLOW-copied list: it REPLACES affected entries with re-roled
+    clones (rather than mutating the shared ``ChatMessage`` objects), so the
+    caller's original ``chat_history`` — which also feeds ``_snapshot_messages``
+    / the stored history and thus the client's rendered ``useComponent``
+    surfaces — is left untouched.
+    """
+    for i, msg in enumerate(chat_history):
+        if msg.role.value == "user" and "tool_call_id" in msg.additional_kwargs:
+            chat_history[i] = ChatMessage(
+                role=MessageRole.TOOL,
+                content=msg.content,
+                additional_kwargs=dict(msg.additional_kwargs),
+            )
+
+
+class RequestAwareAGUIChatWorkflow(AGUIChatWorkflow):
+    """Upstream ``AGUIChatWorkflow`` + request-time frontend-tool forwarding,
+    re-implementing ``chat`` with three targeted, empirically-validated changes.
+
+    The single workflow ``make_request_aware_router`` builds. Design rationale,
+    earned on the D5 beautiful-chat 5-cell suite (toggle / pie / bar / flights /
+    schedule):
+
+    - The bug: the llama-index AG-UI adapter never forwards
+      ``RunAgentInput.tools`` to the LLM, so page-injected tools are invisible →
+      the recorded fixture's tool call can't be satisfied → RUN_ERROR →
+      ``sse-missing``.
+
+    This ``chat`` is the upstream ``AGUIChatWorkflow.chat`` body with exactly
+    three additions, each tied to a concrete failure mode (and NOTHING else —
+    no stable ``id`` / ``parent_message_id`` regrouping like
+    ``FixedAGUIChatWorkflow``, which breaks ``useComponent`` rendering):
+
+      0. Request-tool forwarding: merge ``RunAgentInput.tools`` into
+         ``self.frontend_tools`` so the LLM sees page-injected tools.
+      1. FIX 3 (tool-result re-roling) applied ONLY to the LLM-bound message
+         copy: AG-UI tool results are mis-roled ``role="user"`` upstream; the
+         OpenAI request (and aimock's ``hasToolResult`` matcher) need
+         ``role="tool"`` so the ``hasToolResult:true`` second-leg fixture matches
+         (``toggleTheme`` / ``scheduleTime`` follow-up turns). We re-role a COPY,
+         leaving the stored history / MESSAGES_SNAPSHOT untouched.
+      2. Frontend tool calls are NOT re-emitted as TOOL_CALL_CHUNK events: the
+         (bare, un-stripped) MESSAGES_SNAPSHOT already carries them via
+         ``ag_ui_tool_calls``, and emitting the chunk too double-delivers the
+         arguments — for an args-bearing frontend tool (``scheduleTime``) the
+         doubled args concatenate (``{...}{...}``) and the client raises
+         ``tool_argument_parse_failed``. The snapshot path alone both renders
+         ``useComponent`` surfaces (``pieChart`` / ``barChart``) AND drives the
+         HITL / frontend-tool flows. Backend tool calls DO still emit the chunk
+         (their server-side execution loop depends on it).
+
+    Empirical matrix that pins each choice:
+    bare-snapshot + emit-frontend-chunk → pie/bar/toggle/flights pass, schedule
+    fails (dup args); stripping the snapshot tool calls instead → schedule
+    passes but pie/bar break. Dropping the frontend chunk (this design) keeps the
+    snapshot for rendering AND removes the dup → all five pass.
+    """
+
+    @step
+    async def chat(
+        self, ctx: Context, ev: InputEvent | LoopEvent
+    ) -> Optional[Union[StopEvent, ToolCallEvent]]:
+        if isinstance(ev, InputEvent):
+            # ADD 0: forward page-injected tools so the LLM can see/call them.
+            # A fresh workflow is built per request, so mutating frontend_tools
+            # is safe.
+            injected = request_tools_to_frontend_tools(ev.input_data)
+            for name, tool in injected.items():
+                # Statically declared tools (frontend or backend) win.
+                if name in self.frontend_tools or name in self.backend_tools:
+                    continue
+                self.frontend_tools[name] = tool
+
+            ag_ui_messages = ev.input_data.messages
+            chat_history = [
+                ag_ui_message_to_llama_index_message(m) for m in ag_ui_messages
+            ]
+
+            state = ev.input_data.state
+            if isinstance(state, dict):
+                state.pop("messages", None)
+            elif isinstance(state, str):
+                state = json.loads(state)
+                state.pop("messages", None)
+            else:
+                state = self.initial_state.copy()
+
+            await ctx.store.set("state", state)
+            ctx.write_event_to_stream(StateSnapshotWorkflowEvent(snapshot=state))
+
+            if state:
+                for msg in chat_history[::-1]:
+                    if msg.role.value == "user":
+                        msg.content = DEFAULT_STATE_PROMPT.format(
+                            state=str(state), user_input=msg.content
+                        )
+                        break
+
+            if self.system_prompt:
+                if chat_history[0].role.value == "system":
+                    chat_history[0].blocks.append(TextBlock(text=self.system_prompt))
+                else:
+                    chat_history.insert(
+                        0, ChatMessage(role="system", content=self.system_prompt)
+                    )
+
+            await ctx.store.set("chat_history", chat_history)
+        else:
+            chat_history = await ctx.store.get("chat_history")
+
+        tools = list(self.frontend_tools.values())
+        tools.extend(list(self.backend_tools.values()))
+
+        # ADD 1: FIX 3 on the LLM-bound copy only (re-role tool results -> tool)
+        # so the OpenAI request / aimock `hasToolResult` matcher sees a proper
+        # tool-result message. We do NOT mutate `chat_history` itself — it feeds
+        # the (bare) snapshot and stored history that drive client rendering.
+        llm_chat_history = list(chat_history)
+        _fix_tool_messages_copy(llm_chat_history)
+
+        # `self.llm` is declared `LLM` by the base, but upstream's __init__
+        # asserts `isinstance(self.llm, FunctionCallingLLM)`; the tool-calling
+        # methods below (astream_chat_with_tools / get_tool_calls_from_response)
+        # live on FunctionCallingLLM. Cast so the runtime-guaranteed type is
+        # visible to the type checker (no behavior change).
+        llm = cast(FunctionCallingLLM, self.llm)
+
+        resp_gen = await llm.astream_chat_with_tools(
+            tools=tools,
+            chat_history=llm_chat_history,
+            allow_parallel_tool_calls=True,
+        )
+
+        resp_id = str(uuid.uuid4())
+        resp = ChatResponse(message=ChatMessage(role="assistant", content=""))
+        async for resp in resp_gen:
+            if resp.delta:
+                ctx.write_event_to_stream(
+                    TextMessageChunkWorkflowEvent(
+                        role="assistant",
+                        delta=resp.delta,
+                        timestamp=timestamp(),
+                        message_id=resp_id,
+                    )
+                )
+
+        # Bare snapshot (inherited): keeps `ag_ui_tool_calls` so useComponent /
+        # HITL / frontend tools render from the MESSAGES_SNAPSHOT.
+        chat_history.append(resp.message)
+        self._snapshot_messages(ctx, [*chat_history])
+        await ctx.store.set("chat_history", chat_history)
+
+        tool_calls = llm.get_tool_calls_from_response(resp, error_on_no_tool_call=False)
+        if tool_calls:
+            await ctx.store.set("num_tool_calls", len(tool_calls))
+            frontend_tool_calls = [
+                tc for tc in tool_calls if tc.tool_name in self.frontend_tools
+            ]
+            backend_tool_calls = [
+                tc for tc in tool_calls if tc.tool_name in self.backend_tools
+            ]
+
+            # Backend tools: emit chunk AND dispatch (server-side execution loop
+            # consumes the ToolCallEvent and loops back).
+            for tool_call in backend_tool_calls:
+                ctx.send_event(
+                    ToolCallEvent(
+                        tool_call_id=tool_call.tool_id,
+                        tool_name=tool_call.tool_name,
+                        tool_kwargs=tool_call.tool_kwargs,
+                    )
+                )
+                ctx.write_event_to_stream(
+                    ToolCallChunkWorkflowEvent(
+                        tool_call_id=tool_call.tool_id,
+                        tool_call_name=tool_call.tool_name,
+                        delta=json.dumps(tool_call.tool_kwargs),
+                    )
+                )
+
+            # ADD 2: frontend tools — dispatch the ToolCallEvent (so the
+            # workflow tracks completion / loops correctly) but do NOT emit the
+            # TOOL_CALL_CHUNK: the bare snapshot's `ag_ui_tool_calls` already
+            # delivers the call to the client. Emitting both doubles the
+            # arguments (`{...}{...}`) and breaks args-bearing tools.
+            for tool_call in frontend_tool_calls:
+                ctx.send_event(
+                    ToolCallEvent(
+                        tool_call_id=tool_call.tool_id,
+                        tool_name=tool_call.tool_name,
+                        tool_kwargs=tool_call.tool_kwargs,
+                    )
+                )
+
+            return None
+
+        return StopEvent()
+
+
+def make_request_aware_router(
+    *,
+    llm: FunctionCallingLLM,
+    frontend_tools: Optional[List[Any]] = None,
+    backend_tools: Optional[List[Any]] = None,
+    system_prompt: Optional[str] = None,
+    initial_state: Optional[Dict[str, Any]] = None,
+    timeout: Optional[float] = 120,
+) -> APIRouter:
+    """Drop-in for ``get_ag_ui_workflow_router(llm=..., ...)`` that also forwards
+    request-time injected frontend tools to the LLM.
+
+    Use this instead of the upstream router for any demo whose page registers
+    tools/components via React hooks (``useFrontendTool`` / ``useComponent`` /
+    ``useHumanInTheLoop``) that the router does not statically declare. The
+    underlying workflow forwards those injected tools to the LLM (the core
+    sse-missing fix) and dedups duplicate snapshot tool calls so zero-arg
+    frontend tools (``toggleTheme``) don't break, while preserving the bare
+    adapter's ``useComponent`` rendering path (``pieChart`` / ``barChart``).
+    """
+
+    async def _factory():
+        return RequestAwareAGUIChatWorkflow(
+            llm=llm,
+            frontend_tools=frontend_tools or [],
+            backend_tools=backend_tools or [],
+            system_prompt=system_prompt,
+            initial_state=initial_state or {},
+            timeout=timeout,
+        )
+
+    return get_ag_ui_workflow_router(workflow_factory=_factory)

--- a/showcase/integrations/llamaindex/src/agents/beautiful_chat_agent.py
+++ b/showcase/integrations/llamaindex/src/agents/beautiful_chat_agent.py
@@ -22,9 +22,9 @@ import os
 from typing import Annotated
 
 from llama_index.llms.openai import OpenAI
-from llama_index.protocols.ag_ui.router import get_ag_ui_workflow_router
 
-from tools import get_weather_impl
+from agents._request_tools import make_request_aware_router
+from tools import get_weather_impl, search_flights_impl
 
 
 async def get_weather(
@@ -34,6 +34,22 @@ async def get_weather(
     return json.dumps(get_weather_impl(location))
 
 
+async def search_flights(
+    flights: Annotated[
+        list,
+        "List of flight objects to search and display as rich cards. "
+        "Return exactly 2 flights.",
+    ],
+) -> str:
+    """Search for flights and display the results as rich A2UI cards.
+
+    Each flight must have: airline, airlineLogo, flightNumber, origin,
+    destination, date, departureTime, arrivalTime, duration, status,
+    statusColor, price, currency.
+    """
+    return json.dumps(search_flights_impl(flights))
+
+
 SYSTEM_PROMPT = """You are a polished, friendly demo assistant powering the
 "Beautiful Chat" showcase. You are deliberately concise — keep answers to
 1-2 sentences when possible.
@@ -41,19 +57,36 @@ SYSTEM_PROMPT = """You are a polished, friendly demo assistant powering the
 You can:
 - Chat naturally with the user
 - Get weather for a location via the get_weather tool
+- Search flights and display rich flight cards via the search_flights tool
+- Render charts the page provides (pieChart / barChart frontend components)
+- Toggle the app theme via the toggleTheme frontend tool
+- Schedule a meeting with the user via the scheduleTime frontend tool
+  (human-in-the-loop time picker)
 
-Be warm, pithy, and helpful. Avoid filler — let the chat surface itself
-do the talking."""
+When asked to search or show flights, always call search_flights with exactly
+two flights. Be warm, pithy, and helpful. Avoid filler — let the chat surface
+itself do the talking."""
 
 
 _openai_kwargs = {}
 if os.environ.get("OPENAI_BASE_URL"):
     _openai_kwargs["api_base"] = os.environ["OPENAI_BASE_URL"]
 
-beautiful_chat_router = get_ag_ui_workflow_router(
+# The page registers frontend tools/components at request time via React hooks
+# (toggleTheme, pieChart, barChart, scheduleTime — see
+# src/app/demos/beautiful-chat/hooks/use-generative-ui-examples.tsx). The
+# request-aware router forwards those injected tools to the LLM so the request
+# shape matches the recorded aimock fixture; without it the LLM never sees the
+# injected tools, the request 404s in aimock, and the run emits RUN_ERROR
+# (sse-missing) instead of RUN_FINISHED. See agents/_request_tools.py.
+beautiful_chat_router = make_request_aware_router(
     llm=OpenAI(model="gpt-4o-mini", **_openai_kwargs),
     frontend_tools=[],
-    backend_tools=[get_weather],
+    # search_flights is a backend tool the page's "Search Flights" pill exercises
+    # (mirrors langgraph-python/beautiful_chat.py). The page-injected frontend
+    # tools (toggleTheme, pieChart, barChart, scheduleTime) are forwarded at
+    # request time by make_request_aware_router. See agents/_request_tools.py.
+    backend_tools=[get_weather, search_flights],
     system_prompt=SYSTEM_PROMPT,
     initial_state={},
 )

--- a/showcase/integrations/llamaindex/src/agents/mcp_apps_agent.py
+++ b/showcase/integrations/llamaindex/src/agents/mcp_apps_agent.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 import os
 
 from llama_index.llms.openai import OpenAI
-from llama_index.protocols.ag_ui.router import get_ag_ui_workflow_router
+
+from agents._request_tools import make_request_aware_router
 
 
 SYSTEM_PROMPT = """\
@@ -57,7 +58,12 @@ _openai_kwargs = {}
 if os.environ.get("OPENAI_BASE_URL"):
     _openai_kwargs["api_base"] = os.environ["OPENAI_BASE_URL"]
 
-mcp_apps_router = get_ag_ui_workflow_router(
+# The MCP Apps middleware injects the remote MCP server's tools (e.g.
+# create_view) into the request at runtime. The request-aware router forwards
+# those injected tools to the LLM so the request matches the recorded aimock
+# fixture; otherwise the run 404s in aimock and emits RUN_ERROR (sse-missing).
+# See agents/_request_tools.py.
+mcp_apps_router = make_request_aware_router(
     llm=OpenAI(model="gpt-4o-mini", **_openai_kwargs),
     frontend_tools=[],
     backend_tools=[],

--- a/showcase/integrations/llamaindex/src/agents/open_gen_ui_advanced_agent.py
+++ b/showcase/integrations/llamaindex/src/agents/open_gen_ui_advanced_agent.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 import os
 
 from llama_index.llms.openai import OpenAI
-from llama_index.protocols.ag_ui.router import get_ag_ui_workflow_router
+
+from agents._request_tools import make_request_aware_router
 
 
 SYSTEM_PROMPT = """You are a UI-generating assistant for the Open Generative UI (Advanced) demo.
@@ -52,7 +53,12 @@ _openai_kwargs = {}
 if os.environ.get("OPENAI_BASE_URL"):
     _openai_kwargs["api_base"] = os.environ["OPENAI_BASE_URL"]
 
-open_gen_ui_advanced_router = get_ag_ui_workflow_router(
+# The runtime injects the `generateSandboxedUi` frontend tool (plus the page's
+# registered sandbox functions) at request time. The request-aware router
+# forwards them to the LLM so the request matches the recorded aimock fixture;
+# otherwise the run 404s in aimock and emits RUN_ERROR (sse-missing). See
+# agents/_request_tools.py.
+open_gen_ui_advanced_router = make_request_aware_router(
     llm=OpenAI(model="gpt-4.1", **_openai_kwargs),
     frontend_tools=[],
     backend_tools=[],

--- a/showcase/integrations/llamaindex/src/agents/open_gen_ui_agent.py
+++ b/showcase/integrations/llamaindex/src/agents/open_gen_ui_agent.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 import os
 
 from llama_index.llms.openai import OpenAI
-from llama_index.protocols.ag_ui.router import get_ag_ui_workflow_router
+
+from agents._request_tools import make_request_aware_router
 
 
 SYSTEM_PROMPT = """You are a UI-generating assistant for an Open Generative UI demo
@@ -52,7 +53,11 @@ _openai_kwargs = {}
 if os.environ.get("OPENAI_BASE_URL"):
     _openai_kwargs["api_base"] = os.environ["OPENAI_BASE_URL"]
 
-open_gen_ui_router = get_ag_ui_workflow_router(
+# The runtime's OpenGenerativeUIMiddleware injects the `generateSandboxedUi`
+# frontend tool at request time. The request-aware router forwards it to the
+# LLM so the request matches the recorded aimock fixture; otherwise the run
+# 404s in aimock and emits RUN_ERROR (sse-missing). See agents/_request_tools.py.
+open_gen_ui_router = make_request_aware_router(
     llm=OpenAI(model="gpt-4.1", **_openai_kwargs),
     frontend_tools=[],
     backend_tools=[],


### PR DESCRIPTION
## Summary

Both the **AG2** and **LlamaIndex** showcase integrations were 100% red on the staging matrix (every cell `BE ×`, 0 green all day). Root cause was **not** per-cell logic — each framework's Next.js frontend was crash-looping under matrix load, driven by an agent-side hot loop. This PR fixes both root-cause loops.

### LlamaIndex — `sse-missing` (commit forwarding request-time tools)
- **Root cause:** the llama-index AG-UI adapter never forwarded `RunAgentInput.tools`, so page-injected tools (`toggleTheme`, `pieChart`, `barChart`, `scheduleTime`, MCP, `generateSandboxedUi`) were invisible to the LLM → `RUN_ERROR` (404 `no_fixture_match` → `openai.NotFoundError`) → no `RUN_FINISHED` → `sse-missing`. The retry storm OOM-crashed the frontend (Node fatal, `next-server` v15.5.18).
- **Fix:** new `RequestAwareAGUIChatWorkflow` (`_request_tools.py`) that forwards request tools, re-roles the tool-result on an LLM-bound copy only, and skips duplicate frontend-tool chunk emission (bare snapshot already carries them). Applied to beautiful_chat / mcp_apps / open_gen_ui / open_gen_ui_advanced routers; added the `search_flights` backend tool to beautiful_chat for langgraph-python parity.
- **Red→green:** beautiful-chat **0/5 → 5/5** (toggle-theme, schedule-meeting, search-flights, pie-chart, bar-chart), freshly re-confirmed via `--d6 --rebuild`; `mcp-apps` red→green.

### AG2 — `generate_a2ui` empty-arg validation loop
- **Root cause:** the declarative route pointed `HttpAgent` at the root catch-all agent instead of the dedicated `/declarative-gen-ui` mount, and `generate_a2ui` required a `context` arg the model emits as `{}` → pydantic `context Field required` → infinite retry. **630 loop iterations** observed; the flood starved the ag2 frontend (502s).
- **Fix:** dedicated mount + `injectA2UITool:false` + no-arg `generate_a2ui` (matches langgraph-python / google-adk) + regenerated aimock fixture to 4-pill parity + ported the stale ag2 renderers/definitions.
- **Red→green:** **630 → 0** validation errors, `runsFinished=1`, clean `generate_a2ui → TOOL_CALL_RESULT → RUN_FINISHED`.

## Known remaining (pre-existing, separate, NOT regressions)
- **ag2 `gen-ui-declarative`:** run completes but the a2ui surface components don't paint (autogen↔AG-UI bridge `TOOL_CALL_RESULT` → A2UIMiddleware surface-conversion gap). Tracked separately.
- **llamaindex `open-gen-ui`:** `sse-missing` resolved; residual sandboxed-UI iframe render gap is **pre-existing** (red since 2026-06-01, fc=509 — predates this crash).

## Test plan
- [x] LlamaIndex beautiful-chat `--d6 --rebuild`: 5/5 green (fresh, isolated)
- [x] LlamaIndex mcp-apps: red→green
- [x] AG2 declarative hot-loop: 630→0 validation errors, runsFinished=1
- [x] Pyright clean on both integrations (verified in-Docker with real deps)
- [x] oxfmt clean
- [ ] Post-deploy: re-run D6 matrix on staging to confirm ag2 + llamaindex column recovery

## Deploy note
Staging is **image-sourced, main-only** (the "Showcase: Build & Push" workflow builds GHCR images and redeploys on push to `main`). This branch will NOT auto-deploy. To validate on staging before merge: `gh workflow run showcase_build.yml --ref fix/llamaindex-sse-request-tools -f service=ag2` (and `service=llamaindex`).