### PR TITLE
fix(showcase): built-in-agent shared-state demo now re-renders on UI writes

### DIFF
--- a/showcase/integrations/built-in-agent/src/app/demos/shared-state-read-write/page.tsx
+++ b/showcase/integrations/built-in-agent/src/app/demos/shared-state-read-write/page.tsx
@@ -43,7 +43,7 @@ function Demo() {
 
   useEffect(() => {
     if (!agent.state || Object.keys(agent.state).length === 0) {
-      agent.state = { ...defaultRecipe } as unknown as typeof agent.state;
+      agent.setState({ ...defaultRecipe } as unknown as typeof agent.state);
     }
   }, [agent]);
 
@@ -55,10 +55,10 @@ function Demo() {
   // @region[set-state]
   // @region[use-agent-write]
   function setTitle(next: string) {
-    agent.state = {
+    agent.setState({
       ...(agent.state as object),
       title: next,
-    } as unknown as typeof agent.state;
+    } as unknown as typeof agent.state);
   }
   // @endregion[use-agent-write]
   // @endregion[set-state]


### PR DESCRIPTION
## Summary

The built-in-agent `shared-state-read-write` demo wrote agent state via **direct property assignment** (`agent.state = {...}`). That sets the value but does **not** fire `onStateChanged`, so components subscribed via `useAgent` never re-render off a UI write. Switched the seed + title write to **`agent.setState(...)`**, which updates state *and* notifies subscribers.

This was the lone divergence: every other framework demo — including the `langgraph-python` gold standard — already uses `agent.setState(...)`, and `docs/shared-state.mdx` documents writes going through `setState`.

```diff
-    agent.state = { ...defaultRecipe } as unknown as typeof agent.state;
+    agent.setState({ ...defaultRecipe } as unknown as typeof agent.state);
...
-    agent.state = { ...(agent.state as object), title: next } as unknown as typeof agent.state;
+    agent.setState({ ...(agent.state as object), title: next } as unknown as typeof agent.state);
```

## Why

`@ag-ui/client`'s `AbstractAgent.setState()` both assigns `this.state` and notifies all subscribers (`onStateChanged`), which is what drives the `useAgent` re-render. Direct `agent.state = {...}` is a plain property write — it skips the notification, so any component relying on the hook to reflect the change silently goes stale.

## Test plan

- `showcase/bin/showcase test built-in-agent --d5 --verbose --cycle --isolate` → green after rebuild from the changed source.
- lefthook pre-commit (lint-fix, package checks) + commitlint pass.

## Follow-up (not in this PR)

The built-in-agent demo is recipe-shaped (title/ingredients/steps) while the other read-write demos are preferences/notes + `DemoLayout`. Per the showcase 1:1 convention it should mirror `langgraph-python` — larger change (+ fixture realignment), flagging separately.