### PR TITLE
fix(showcase/harness): reliable data-copilot-running turn-done signal (kill probe false-red flaps)

### DIFF
--- a/showcase/harness/src/probes/helpers/conversation-runner.test.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.test.ts
@@ -6,8 +6,14 @@ import {
   waitForContentAndSend,
   readErrorBanner,
   AssistantErroredError,
+  waitForTurnComplete,
+  TurnNotCompleteError,
 } from "./conversation-runner.js";
-import type { ConversationTurn, Page } from "./conversation-runner.js";
+import type {
+  ConversationTurn,
+  Page,
+  CopilotRunningState,
+} from "./conversation-runner.js";
 
 /**
  * Unit tests for the D5 conversation runner helper. Page is a structural
@@ -72,6 +78,20 @@ interface PageScript {
   // re-paints fresh after the reload, so the 2nd settle re-snapshots a clean
   // baseline and fast-fails again — #5142 stays intact across the retry).
   reloadReplaysQueues?: boolean;
+  // Scripted generator for the CopilotKit v2 run-lifecycle summary
+  // (`window.__hk_copilotRunning`) that `waitForTurnComplete` reads as its
+  // PRIMARY done-signal. Called once per `__hk_copilotRunning` evaluate; the
+  // generator owns its own poll-to-poll progression (e.g. attribute absent →
+  // running true → running false). When omitted, the fake returns the
+  // "attribute absent" shape so the gate falls back to the SSE counter —
+  // every pre-existing count-driven test keeps its original semantics.
+  copilotRunning?: () => {
+    attrPresent: boolean;
+    runningNow: boolean | null;
+    sawRunningTrue: boolean;
+    runStartCount: number;
+    lastStoppedAtMs: number;
+  };
 }
 
 /**
@@ -126,6 +146,20 @@ function wrapEvaluateForUserMessages(
     // branch.
     if (body.includes("__hk_runsFinished")) {
       return latestCount as never;
+    }
+    // CopilotKit v2 run-lifecycle summary (`__hk_copilotRunning`) — the
+    // PRIMARY done-signal. These user-message helpers never simulate the
+    // chat-view attribute, so return the "attribute absent" shape; the gate
+    // then falls back to the synthesised SSE counter above (unchanged
+    // semantics for every test routed through this helper).
+    if (body.includes("__hk_copilotRunning")) {
+      return {
+        attrPresent: false,
+        runningNow: null,
+        sawRunningTrue: false,
+        runStartCount: 0,
+        lastStoppedAtMs: 0,
+      } as never;
     }
     // Atomic cascade-state read (`readCascadeState`): returns BOTH the
     // count and the indexed text from the SAME cascade tier in ONE
@@ -285,6 +319,24 @@ function makePage(script: PageScript = {}): Page {
       // whenever the corresponding bubble exists in the DOM.
       if (fnBody.includes("__hk_runsFinished")) {
         return latestCount as never;
+      }
+      // CopilotKit v2 run-lifecycle summary (`__hk_copilotRunning`). The
+      // post-fix `waitForTurnComplete` reads this as its PRIMARY done-signal.
+      // Tests opt in by scripting `copilotRunning` (a generator keyed to the
+      // running-attribute state); when unscripted we return the
+      // "attribute absent" shape so the gate falls back to the SSE counter —
+      // exactly the behaviour every pre-existing count-based test relies on.
+      if (fnBody.includes("__hk_copilotRunning")) {
+        if (script.copilotRunning) {
+          return script.copilotRunning() as never;
+        }
+        return {
+          attrPresent: false,
+          runningNow: null,
+          sawRunningTrue: false,
+          runStartCount: 0,
+          lastStoppedAtMs: 0,
+        } as never;
       }
       // Error-banner visibility probe references "copilot-error-banner".
       // Routed before the message-count branches so it gets its own
@@ -1385,6 +1437,15 @@ describe("runConversation", () => {
         if (body.includes("__hk_runsFinished")) {
           return assistantCount as never;
         }
+        if (body.includes("__hk_copilotRunning")) {
+          return {
+            attrPresent: false,
+            runningNow: null,
+            sawRunningTrue: false,
+            runStartCount: 0,
+            lastStoppedAtMs: 0,
+          } as never;
+        }
         if (
           body.includes("querySelectorAll") &&
           body.includes("textContent") &&
@@ -1853,6 +1914,18 @@ describe("runConversation", () => {
         if (fn.toString().includes("__hk_runsFinished")) {
           return (evalCount === 0 ? 0 : 2) as never;
         }
+        // This bare-document fake never renders the v2 chat-view attribute
+        // — return the "attribute absent" shape so `waitForTurnComplete`
+        // routes to the SSE-counter fallback above (unchanged semantics).
+        if (fn.toString().includes("__hk_copilotRunning")) {
+          return {
+            attrPresent: false,
+            runningNow: null,
+            sawRunningTrue: false,
+            runStartCount: 0,
+            lastStoppedAtMs: 0,
+          } as never;
+        }
         // Patch globalThis.document with our fake for the duration
         // of the evaluate call. The selector-fn closes over
         // globalThis at runtime, mirroring the browser-side execution.
@@ -1959,6 +2032,17 @@ describe("runConversation", () => {
         // poll has at least 2 RUN_FINISHED equivalents.
         if (fn.toString().includes("__hk_runsFinished")) {
           return (evalCount === 0 ? 1 : 2) as never;
+        }
+        // Bare-document fake — no v2 chat-view attribute; return absent so
+        // the gate uses the SSE-counter fallback (unchanged semantics).
+        if (fn.toString().includes("__hk_copilotRunning")) {
+          return {
+            attrPresent: false,
+            runningNow: null,
+            sawRunningTrue: false,
+            runStartCount: 0,
+            lastStoppedAtMs: 0,
+          } as never;
         }
         // Patch document + getComputedStyle so the error-banner probe
         // runs its real "no banner" path (see the narrowing test above).
@@ -2232,6 +2316,17 @@ describe("runConversation surface-mount completion (completeOnMount)", () => {
         const body = fn.toString();
         // SSE counter: caught up only after the run (post-send).
         if (body.includes("__hk_runsFinished")) return (sent ? 1 : 0) as never;
+        // Surface-mount fake — no v2 chat-view attribute; return absent so
+        // the done-signal falls back to the SSE counter above.
+        if (body.includes("__hk_copilotRunning")) {
+          return {
+            attrPresent: false,
+            runningNow: null,
+            sawRunningTrue: false,
+            runStartCount: 0,
+            lastStoppedAtMs: 0,
+          } as never;
+        }
         // No error banner.
         if (body.includes("copilot-error-banner")) {
           return { state: "absent" } as never;
@@ -2776,5 +2871,1226 @@ describe("readErrorBanner shape handling", () => {
     if (result.state === "visible") {
       expect(result.text).toBe("boom");
     }
+  });
+});
+
+// ============================================================
+// waitForTurnComplete — data-copilot-running PRIMARY done-signal
+// (false-red kill) + done-signal-missing backstop (no false-green)
+// ============================================================
+//
+// BIDIRECTIONAL red-green safety proof for the turn-done-signal fix:
+//
+//   (1) FALSE-RED KILLED: a healthy turn where the SSE fetch-counter NEVER
+//       increments (the fragile signal the flap blames) but the
+//       `data-copilot-running` attribute goes true→false and the bubble is
+//       stable+non-empty → completes GREEN via the DOM transition.
+//   (2) REAL BREAK STILL RED (no false-green): the silent multi-step hang —
+//       bubble #1 paints + text settles but running stays stuck `true` (or
+//       clears without a stop edge for this turn) and the SSE counter never
+//       catches up → REDS via the `done-signal-missing` backstop.
+//   (2b) MULTI-STEP INTERMEDIATE FALSE: running toggles
+//       false→true→false→true→… between sub-runs → does NOT complete on the
+//       first (intermediate) false; only the final stop completes.
+//   (3) HEADLESS FALLBACK: attribute absent → completes via the SSE counter.
+//
+// These build a fake `page` whose `evaluate` dispatches the THREE reads
+// `waitForTurnComplete` makes per poll — `__hk_runsFinished` (SSE counter),
+// `__hk_copilotRunning` (run-lifecycle summary), and the atomic cascade
+// `{ count, text }` — each from a per-poll script array (last value repeats
+// so a "settled tail" models trivially). REAL timers; tiny settle window.
+/** Pull element `i` from `arr`, clamping to the last (steady-state tail). */
+function clampAt<T>(arr: T[], i: number): T {
+  if (arr.length === 0) throw new Error("empty script array");
+  return arr[Math.min(i, arr.length - 1)]!;
+}
+
+describe("waitForTurnComplete — data-copilot-running done-signal", () => {
+  const at = clampAt;
+
+  /**
+   * Build a fake Page that scripts the three per-poll reads independently.
+   * `poll` counts cascade reads (the once-per-iteration anchor); SSE +
+   * running reads sample the SAME poll index so all three advance together.
+   */
+  function makeRunSignalPage(script: {
+    sse: number[];
+    running: CopilotRunningState[];
+    cascade: Array<{ count: number; text: string | null }>;
+  }): Page {
+    let cascadePoll = 0;
+    return {
+      async waitForSelector() {},
+      async fill() {},
+      async press() {},
+      async evaluate(fn: () => unknown) {
+        const body = fn.toString();
+        if (body.includes("copilot-user-message")) return 1 as never;
+        if (body.includes("__hk_runsFinished")) {
+          return at(script.sse, cascadePoll) as never;
+        }
+        if (body.includes("__hk_copilotRunning")) {
+          return at(script.running, cascadePoll) as never;
+        }
+        if (body.includes("copilot-error-banner")) {
+          return { state: "absent" } as never;
+        }
+        // Atomic cascade read — the once-per-poll anchor that advances the
+        // shared poll index.
+        if (
+          body.includes("querySelectorAll") &&
+          body.includes("textContent") &&
+          body.includes("{ count")
+        ) {
+          const v = at(script.cascade, cascadePoll);
+          cascadePoll += 1;
+          return v as never;
+        }
+        // countAssistantMessages (post-loop classifier) — return the last
+        // cascade count.
+        return at(script.cascade, cascadePoll).count as never;
+      },
+    };
+  }
+
+  /**
+   * Surface-mount variant of `makeRunSignalPage`. Scripts the THREE per-poll
+   * reads (sse / running / cascade) PLUS a per-poll surface-mounted boolean,
+   * and returns a `{ page, surfaceReady }` pair. `waitForTurnComplete` calls
+   * `surfaceReady(page)` EXACTLY ONCE per loop iteration, so we key the
+   * surface script off an INDEPENDENT call counter rather than the page's
+   * cascade-poll index (the loop reads surface AFTER the cascade read, which
+   * already advanced the cascade index — keying off call ordinals keeps
+   * `surface[i]` aligned to the i-th loop iteration without an off-by-one).
+   * This lets the surface-mount completion path be exercised against scripted
+   * run-lifecycle toggles — the exact shape the F4 quiescence fix governs.
+   */
+  function makeSurfaceRunSignalPage(script: {
+    sse: number[];
+    running: CopilotRunningState[];
+    cascade: Array<{ count: number; text: string | null }>;
+    surface: boolean[];
+  }): { page: Page; surfaceReady: (page: Page) => Promise<boolean> } {
+    let cascadePoll = 0;
+    const page: Page = {
+      async waitForSelector() {},
+      async fill() {},
+      async press() {},
+      async evaluate(fn: () => unknown) {
+        const body = fn.toString();
+        if (body.includes("copilot-user-message")) return 1 as never;
+        if (body.includes("__hk_runsFinished")) {
+          return at(script.sse, cascadePoll) as never;
+        }
+        if (body.includes("__hk_copilotRunning")) {
+          return at(script.running, cascadePoll) as never;
+        }
+        if (body.includes("copilot-error-banner")) {
+          return { state: "absent" } as never;
+        }
+        if (
+          body.includes("querySelectorAll") &&
+          body.includes("textContent") &&
+          body.includes("{ count")
+        ) {
+          const v = at(script.cascade, cascadePoll);
+          cascadePoll += 1;
+          return v as never;
+        }
+        return at(script.cascade, cascadePoll).count as never;
+      },
+    };
+    let surfaceCall = 0;
+    const surfaceReady = async (): Promise<boolean> => {
+      const v = at(script.surface, surfaceCall);
+      surfaceCall += 1;
+      return v;
+    };
+    return { page, surfaceReady };
+  }
+
+  const runningAbsent: CopilotRunningState = {
+    attrPresent: false,
+    runningNow: null,
+    sawRunningTrue: false,
+    runStartCount: 0,
+    lastStoppedAtMs: 0,
+  };
+  const runningStarted: CopilotRunningState = {
+    attrPresent: true,
+    runningNow: true,
+    sawRunningTrue: true,
+    runStartCount: 1,
+    lastStoppedAtMs: 0,
+  };
+  const runningStopped: CopilotRunningState = {
+    attrPresent: true,
+    runningNow: false,
+    sawRunningTrue: true,
+    runStartCount: 1,
+    lastStoppedAtMs: 1,
+  };
+
+  it("(1) FALSE-RED KILLED: SSE counter never increments but data-copilot-running goes true→false → completes GREEN via DOM signal", async () => {
+    // The fragile fetch-counter NEVER catches up (stays 0 — the exact flap
+    // condition). The ONLY done-signal is the DOM transition. A bubble with
+    // stable non-empty text + the true→false edge must complete GREEN.
+    const page = makeRunSignalPage({
+      sse: [0], // counter never increments — the false-red trigger
+      running: [
+        runningAbsent, // baseline read (turn entry)
+        runningStarted, // run in flight
+        runningStopped, // RUN_FINISHED → true→false transition
+        runningStopped,
+        runningStopped,
+      ],
+      cascade: [
+        { count: 1, text: "hello there" },
+        { count: 1, text: "hello there" },
+        { count: 1, text: "hello there" }, // text stable + non-empty
+      ],
+    });
+    const result = await waitForTurnComplete({
+      page,
+      turnIndex: 1,
+      settleMs: 30,
+      timeoutMs: 5_000,
+      maxTurnDurationMs: 2_000,
+      baselineCount: 0,
+    });
+    expect(result.text).toBe("hello there");
+  });
+
+  it("(1-fast) FAST-TURN FALSE-RED KILLED: RUN_STARTED fires BEFORE the baseline read; pre-send baselineRunStartCount threaded via opts lets the true→false transition complete GREEN", async () => {
+    // F2 regression guard. The PRIMARY done-signal gates on
+    // `runStartCount > baselineRunStartCount`. If the run-start baseline is
+    // captured INSIDE waitForTurnComplete (after the message was sent), a fast
+    // agent that fires RUN_STARTED between the send and that read makes the
+    // baseline already-incremented (runStartCount=1), so
+    // `1 > 1` can NEVER hold → the PRIMARY DOM signal is DEAD and the turn
+    // must fall back to the SSE counter (which here never catches up) → it
+    // reds via the done-signal-missing backstop. The fix captures the
+    // run-start baseline at the CALL SITE BEFORE sendTurnMessage (runStartCount
+    // = 0, before the agent started) and threads it via
+    // `opts.baselineRunStartCount`. With the pre-send baseline of 0, the
+    // observed runStartCount=1 satisfies `1 > 0` → the true→false transition
+    // completes GREEN. The SSE counter stays 0 throughout, proving completion
+    // is driven SOLELY by the DOM transition.
+    const page = makeRunSignalPage({
+      sse: [0], // fragile counter never catches up — DOM signal is the only path
+      running: [
+        // Baseline read (turn entry) ALREADY shows a started run: the fast
+        // agent fired RUN_STARTED before this read could run. runStartCount=1.
+        runningStarted,
+        runningStarted, // run in flight
+        runningStopped, // RUN_FINISHED → true→false transition (runStartCount=1)
+        runningStopped,
+        runningStopped,
+      ],
+      cascade: [
+        { count: 1, text: "fast reply" },
+        { count: 1, text: "fast reply" },
+        { count: 1, text: "fast reply" }, // text stable + non-empty
+      ],
+    });
+    const result = await waitForTurnComplete({
+      page,
+      turnIndex: 1,
+      settleMs: 30,
+      timeoutMs: 5_000,
+      maxTurnDurationMs: 2_000,
+      baselineCount: 0,
+      // The TRUE pre-send baseline (captured at the call site before the agent
+      // started). On UNMODIFIED source this opt does not exist and the
+      // in-function read captures runStartCount=1 → primary signal dies → the
+      // turn reds via the backstop. With the fix, this 0 makes `1 > 0` hold.
+      baselineRunStartCount: 0,
+    });
+    expect(result.text).toBe("fast reply");
+  });
+
+  it("(2) REAL BREAK STILL RED: silent multi-step hang (bubble painted + text settled, running STUCK TRUE, SSE never catches up) → done-signal-missing at the HARD timeout", async () => {
+    // Bubble #1 paints, text settles, but the run NEVER finishes: running
+    // stays `true` forever AND the SSE counter never catches up. DOM+text
+    // hold, yet there is NO trustworthy done-signal → must RED (NOT green on
+    // DOM+text alone).
+    //
+    // NOTE (F4): the `done-signal-missing` BACKSTOP is now gated on
+    // `runningNow !== true` — it must never red a turn that is still
+    // legitimately running. A run STUCK `true` therefore no longer reds at
+    // `maxTurnDurationMs`; it reds at the HARD `timeoutMs` via the post-loop
+    // classifier instead (still `done-signal-missing`: attrPresent + a bubble
+    // + no stop edge for this turn). The backstop's job is the
+    // painted-and-settled-but-finished-signal-missing case where the run is
+    // NOT currently running — see (2-stopped) below. We use a small
+    // `timeoutMs` so the hard-ceiling red fires fast in-test.
+    const page = makeRunSignalPage({
+      sse: [0], // never catches up
+      running: [
+        runningAbsent, // baseline
+        runningStarted, // stuck running forever (no stop edge ever)
+      ],
+      cascade: [{ count: 1, text: "partial answer..." }],
+    });
+    await expect(
+      waitForTurnComplete({
+        page,
+        turnIndex: 1,
+        settleMs: 30,
+        timeoutMs: 400, // hard ceiling — the stuck-true hang reds here
+        maxTurnDurationMs: 200, // backstop is suppressed while runningNow===true
+        baselineCount: 0,
+      }),
+    ).rejects.toMatchObject({
+      name: "TurnNotCompleteError",
+      reason: "done-signal-missing",
+    });
+  });
+
+  it("(2-stopped) BACKSTOP STILL REDS: silent hang where the run has STOPPED (runningNow=false) but the done-signal never confirms → done-signal-missing backstop fires before the hard ceiling", async () => {
+    // The backstop's legitimate job after the F4 runningNow guard: a turn
+    // whose bubble painted + text settled and whose run is NOT currently
+    // running, yet no trustworthy done-signal ever confirms. Here the DOM
+    // attribute is present and `runningNow` is false, BUT no run ever started
+    // THIS turn (runStartCount stays at the baseline 0), so `sawStopThisTurn`
+    // never holds → no stayed-stopped quiescence → `doneSignalOk` stays false.
+    // With the run not running, the backstop must RED it at
+    // `maxTurnDurationMs` (well before the hard `timeoutMs`), proving the
+    // runningNow guard did not neuter the backstop for genuinely-stopped
+    // hangs.
+    const stoppedNoRunThisTurn: CopilotRunningState = {
+      attrPresent: true,
+      runningNow: false,
+      sawRunningTrue: true,
+      runStartCount: 0, // NOT > baseline (0) → sawStopThisTurn never holds
+      lastStoppedAtMs: 1,
+    };
+    const page = makeRunSignalPage({
+      sse: [0], // never catches up
+      running: [runningAbsent, stoppedNoRunThisTurn],
+      cascade: [{ count: 1, text: "partial answer..." }],
+    });
+    await expect(
+      waitForTurnComplete({
+        page,
+        turnIndex: 1,
+        settleMs: 30,
+        timeoutMs: 5_000,
+        maxTurnDurationMs: 300, // backstop fires well before the hard ceiling
+        baselineCount: 0,
+      }),
+    ).rejects.toMatchObject({
+      name: "TurnNotCompleteError",
+      reason: "done-signal-missing",
+    });
+  });
+
+  it("(2-empty) REAL BREAK STILL RED: empty/never-rendered bubble → dom-missing (never completes)", async () => {
+    // No new bubble for this turn (count never exceeds baseline). The run
+    // even reports a stop, but with nothing rendered the turn is a failure,
+    // classified dom-missing.
+    const page = makeRunSignalPage({
+      sse: [1],
+      running: [runningAbsent, runningStopped],
+      cascade: [{ count: 0, text: null }],
+    });
+    await expect(
+      waitForTurnComplete({
+        page,
+        turnIndex: 1,
+        settleMs: 30,
+        timeoutMs: 800,
+        maxTurnDurationMs: 800,
+        baselineCount: 0,
+      }),
+    ).rejects.toMatchObject({
+      name: "TurnNotCompleteError",
+      reason: "dom-missing",
+    });
+  });
+
+  it("(2b) MULTI-STEP INTERMEDIATE FALSE: running false→true→false→true→false does NOT complete on the intermediate false; only the final stop completes", async () => {
+    // A multi-step turn: sub-run 1 starts (true), finishes (false), sub-run 2
+    // starts (true), finishes (false). The gate must NOT complete on the
+    // INTERMEDIATE false (runStartCount=1, a new run about to start) — it
+    // completes only on the final stop. We model the "new run started after
+    // the first stop" by bumping runStartCount on the re-start; the
+    // intermediate-false poll has runningNow=false but is immediately
+    // followed by a re-start, and crucially the FINAL stop has
+    // runStartCount=2 with runningNow=false.
+    const intermediateStop: CopilotRunningState = {
+      attrPresent: true,
+      runningNow: false,
+      sawRunningTrue: true,
+      runStartCount: 1,
+      lastStoppedAtMs: 1,
+    };
+    const restarted: CopilotRunningState = {
+      attrPresent: true,
+      runningNow: true,
+      sawRunningTrue: true,
+      runStartCount: 2,
+      lastStoppedAtMs: 1,
+    };
+    const finalStop: CopilotRunningState = {
+      attrPresent: true,
+      runningNow: false,
+      sawRunningTrue: true,
+      runStartCount: 2,
+      lastStoppedAtMs: 2,
+    };
+    // SSE counter never catches up so completion is driven SOLELY by the DOM
+    // transition — proving the gate waits for the FINAL stop.
+    const page = makeRunSignalPage({
+      sse: [0],
+      running: [
+        runningAbsent, // baseline (runStartCount=0)
+        runningStarted, // sub-run 1 running
+        intermediateStop, // sub-run 1 done — but more work coming
+        restarted, // sub-run 2 running
+        finalStop, // sub-run 2 done — THIS is the real completion
+        finalStop,
+        finalStop,
+      ],
+      cascade: [
+        { count: 1, text: "step 1 output" },
+        { count: 2, text: "step 1 output" },
+        { count: 2, text: "final answer" },
+        { count: 2, text: "final answer" },
+        { count: 2, text: "final answer" }, // stable on the final stop
+      ],
+    });
+    const result = await waitForTurnComplete({
+      page,
+      turnIndex: 1,
+      settleMs: 30,
+      timeoutMs: 5_000,
+      maxTurnDurationMs: 4_000,
+      baselineCount: 0,
+    });
+    // Completed on the FINAL answer, not the intermediate step-1 text.
+    expect(result.text).toBe("final answer");
+  });
+
+  it("(2c) MULTI-STEP SSE OR-TRIGGER MUST NOT FALSE-GREEN: DOM signal present, sub-run 2 already RUNNING (no stop edge this poll) but SSE counter caught up at the intermediate stop + intermediate text settled → must NOT complete early; only the final stop completes", async () => {
+    // The cardinal false-GREEN this branch kills. On a multi-step turn the
+    // page-side RUN_FINISHED fetch-counter increments once per SUB-RUN, so
+    // after sub-run 1 finishes `runsFinished` already reaches 1 ≥ turnIndex 1
+    // → `sseOk` is true for the REST of the turn. With the old
+    // `doneSignalOk = domSignalAvailable ? sawStopThisTurn || sseOk : sseOk`,
+    // the `|| sseOk` disjunct lets that stale counter SOLELY satisfy the
+    // done-signal even when the trustworthy DOM transition says "a new run is
+    // in flight" (sub-run 2 already RUNNING → `sawStopThisTurn` false). If the
+    // intermediate bubble's text also momentarily settles, the gate completes
+    // EARLY on the intermediate answer — defeating the multi-step safety. The
+    // fix makes the DOM transition the SOLE done-signal whenever it's
+    // available, so the gate waits for the FINAL stop.
+    //
+    // Modelled poll-by-poll (note `makeRunSignalPage` advances its shared poll
+    // index only on the cascade read, and the pre-loop baseline read consumes
+    // `running[0]` WITHOUT advancing — so loop poll i reads running[i],
+    // sse[i], cascade[i], with poll 0 re-reading running[0]):
+    //   baseline + poll 0 : sub-run 1 running (sse 0)
+    //   poll 1            : sub-run 1 still running, intermediate text appears
+    //   poll 2 (THE TRAP) : sub-run 2 ALREADY RESTARTED — runningNow=true,
+    //                       runStartCount=2, BUT sse has caught up to 1
+    //                       (sub-run 1's RUN_FINISHED already counted), the
+    //                       intermediate bubble exists, and its text has been
+    //                       stable for settleMs. sawStopThisTurn is FALSE here
+    //                       (runningNow=true), so the ONLY thing that could
+    //                       complete this poll is the stale `|| sseOk`.
+    //   poll 3+           : sub-run 2 finishes — the REAL final stop.
+    const subRun1Running: CopilotRunningState = {
+      attrPresent: true,
+      runningNow: true,
+      sawRunningTrue: true,
+      runStartCount: 1,
+      lastStoppedAtMs: 0,
+    };
+    // Sub-run 2 is ALREADY running again by the time we poll after sub-run 1's
+    // RUN_FINISHED bumped the SSE counter — so this poll has NO stop edge
+    // (runningNow=true) yet sseOk is true. This is the poll that false-greens
+    // under the old OR-trigger.
+    const subRun2RunningWithSseCaughtUp: CopilotRunningState = {
+      attrPresent: true,
+      runningNow: true,
+      sawRunningTrue: true,
+      runStartCount: 2,
+      lastStoppedAtMs: 1,
+    };
+    const finalStop: CopilotRunningState = {
+      attrPresent: true,
+      runningNow: false,
+      sawRunningTrue: true,
+      runStartCount: 2,
+      lastStoppedAtMs: 2,
+    };
+    const page = makeRunSignalPage({
+      // SSE catches up to 1 at poll 2 (sub-run 1's RUN_FINISHED is now
+      // counted) and STAYS there — the stale counter the old `|| sseOk`
+      // would trust.
+      sse: [0, 0, 1, 1, 1, 1, 1],
+      running: [
+        runningAbsent, // baseline + poll 0 (runStartCount=0 → no sawStop)
+        subRun1Running, // poll 1: sub-run 1 in flight
+        subRun2RunningWithSseCaughtUp, // poll 2: THE TRAP — sub-run 2 running, sse=1, text settled
+        finalStop, // poll 3: sub-run 2 done — the REAL completion
+        finalStop,
+        finalStop,
+        finalStop,
+      ],
+      cascade: [
+        // Intermediate bubble appears at poll 1 with "intermediate answer" and
+        // is identical at poll 2 — so by poll 2 it has been stable for the full
+        // poll cadence (>= settleMs=10), arming domOk + thirdOk at the EXACT
+        // poll where the stale sseOk would trigger.
+        { count: 2, text: null }, // poll 0: no bubble text yet
+        { count: 2, text: "intermediate answer" }, // poll 1: intermediate text appears
+        { count: 2, text: "intermediate answer" }, // poll 2: settled — THE TRAP poll
+        { count: 2, text: "final answer" }, // poll 3: final text arrives
+        { count: 2, text: "final answer" },
+        { count: 2, text: "final answer" }, // stable on the final stop
+      ],
+    });
+    const result = await waitForTurnComplete({
+      page,
+      turnIndex: 1,
+      settleMs: 10,
+      timeoutMs: 5_000,
+      maxTurnDurationMs: 4_000,
+      baselineCount: 0,
+    });
+    // Must complete on the FINAL answer, never the intermediate one. Under the
+    // old OR-trigger this returned "intermediate answer" (false-GREEN).
+    expect(result.text).toBe("final answer");
+  });
+
+  it("(3) HEADLESS FALLBACK: attribute absent → completes via the SSE counter", async () => {
+    // A headless bring-your-own-UI demo never renders CopilotChatView, so
+    // `data-copilot-running` is absent (attrPresent=false). The done-signal
+    // falls back to the SSE counter, which catches up → completes GREEN.
+    const page = makeRunSignalPage({
+      sse: [0, 1, 1], // counter catches up by poll 2
+      running: [runningAbsent], // attribute never present
+      cascade: [
+        { count: 1, text: "headless reply" },
+        { count: 1, text: "headless reply" },
+        { count: 1, text: "headless reply" },
+      ],
+    });
+    const result = await waitForTurnComplete({
+      page,
+      turnIndex: 1,
+      settleMs: 30,
+      timeoutMs: 5_000,
+      maxTurnDurationMs: 2_000,
+      baselineCount: 0,
+    });
+    expect(result.text).toBe("headless reply");
+  });
+
+  it("(3-red) HEADLESS REAL BREAK: attribute absent AND SSE counter never catches up → sse-missing at the HARD timeout (NOT early via the backstop)", async () => {
+    // Headless demo whose run never finishes: no DOM signal AND the SSE
+    // counter never catches up, but a bubble painted + settled. The early
+    // `done-signal-missing` backstop is gated on `attrPresent === true` (F5):
+    // a headless turn has NO authoritative signal that can be "missing", so it
+    // is NOT redded early at `maxTurnDurationMs`. A genuinely-stuck headless
+    // turn still REDS — at the HARD `timeoutMs` via the post-loop classifier,
+    // classified `sse-missing` (the SSE counter is the headless done-signal and
+    // it never caught up). Tiny `timeoutMs` so the hard-ceiling path is fast.
+    const page = makeRunSignalPage({
+      sse: [0], // never catches up
+      running: [runningAbsent],
+      cascade: [{ count: 1, text: "stuck headless" }],
+    });
+    await expect(
+      waitForTurnComplete({
+        page,
+        turnIndex: 1,
+        settleMs: 30,
+        timeoutMs: 300,
+        maxTurnDurationMs: 100,
+        baselineCount: 0,
+      }),
+    ).rejects.toMatchObject({
+      name: "TurnNotCompleteError",
+      reason: "sse-missing",
+    });
+  });
+
+  it("(F3) SURFACE-READ ATOMICITY: `surfaceReady(page)` is evaluated AT MOST ONCE per poll (no wasted/non-atomic double DOM round-trip)", async () => {
+    // Regression for the duplicated per-poll `surfaceReady(page)` read. The
+    // buggy gate evaluated the live surface DOM state TWICE on any poll where
+    // the done-signal + DOM held but the surface had NOT yet mounted: once
+    // for the main-completion conjunct `thirdOk`
+    // (`doneSignalOk && domOk && await surfaceReady(page)` → false, so the
+    // completion `if` is skipped) and AGAIN for the backstop conjunct
+    // `thirdConjunctHeld` (`await surfaceReady(page)`), discarding the second
+    // result. That doubled the per-poll surface `page.evaluate` round-trips
+    // and made the two conjuncts read DIFFERENT live values if the surface
+    // mounted between the two reads (a latent disagreement hazard).
+    //
+    // RED PROOF: a counting `surfaceReady` records how many times it is
+    // invoked PER POLL (correlated to the once-per-poll cascade read via the
+    // shared `cascadePoll` the fake exposes through the script tail). On the
+    // first poll the done-signal (SSE counter) + DOM hold but the surface is
+    // NOT mounted, so the UNMODIFIED two-read source invokes `surfaceReady`
+    // TWICE that poll; the surface mounts on the next poll and completes.
+    // With the single-read fix every poll invokes `surfaceReady` AT MOST
+    // ONCE. We assert the per-poll maximum is 1 — FAILS on the two-read
+    // source (records 2 on the first poll), PASSES after the fix.
+    //
+    // `runStoppedThisTurn` keeps the DOM run-attribute present and reports a
+    // completed stop transition for THIS turn (`sawRunningTrue` + a started
+    // run + `runningNow === false`), so the DOM done-signal — the SOLE
+    // done-signal when the attribute is present — is satisfied from poll 1.
+    // That makes `doneSignalOk` TRUE from poll 1, which is exactly the
+    // condition that gates the FIRST (`thirdOk`) surface read on.
+    // Surface-not-yet-mounted on poll 1 then forces the SECOND (backstop)
+    // read on the buggy two-read source. (Note: a DOM transition is used here
+    // rather than the SSE counter because when the run attribute is present
+    // the SSE counter is no longer an OR-trigger for the done-signal.)
+    const runStoppedThisTurn: CopilotRunningState = {
+      attrPresent: true,
+      runningNow: false,
+      sawRunningTrue: true, // saw running then stopped → DOM done-signal fires
+      runStartCount: 1, // > baseline (0) → a run started THIS turn
+      lastStoppedAtMs: 0,
+    };
+    // A self-contained fake whose cascade read (the once-per-poll anchor)
+    // bumps a shared `pollIndex`. `surfaceReady` records the `pollIndex` of
+    // every invocation, so we can deterministically count how many times the
+    // gate read the surface WITHIN a single poll — no timers, no races.
+    let pollIndex = 0;
+    const surfaceCallsByPoll: number[] = []; // surfaceCallsByPoll[p] = reads on poll p
+    let mounted = false;
+    const sse = 1; // headless fallback only; irrelevant here (DOM signal present)
+    const cascade = { count: 1, text: "surface turn" as string | null };
+    const page: Page = {
+      async waitForSelector() {},
+      async fill() {},
+      async press() {},
+      async evaluate(fn: () => unknown) {
+        const body = fn.toString();
+        if (body.includes("copilot-user-message")) return 1 as never;
+        if (body.includes("__hk_runsFinished")) return sse as never;
+        if (body.includes("__hk_copilotRunning"))
+          return runStoppedThisTurn as never;
+        if (body.includes("copilot-error-banner"))
+          return { state: "absent" } as never;
+        if (
+          body.includes("querySelectorAll") &&
+          body.includes("textContent") &&
+          body.includes("{ count")
+        ) {
+          // Once-per-poll anchor: advance the poll index. The surface mounts
+          // starting on poll 2 so poll 1 stays unmounted (forcing the buggy
+          // second read), and poll 2 completes via the main conjunct.
+          pollIndex += 1;
+          if (pollIndex >= 2) mounted = true;
+          return cascade as never;
+        }
+        return cascade.count as never;
+      },
+    };
+    const surfaceReady = async (): Promise<boolean> => {
+      surfaceCallsByPoll[pollIndex] = (surfaceCallsByPoll[pollIndex] ?? 0) + 1;
+      return mounted;
+    };
+    const result = await waitForTurnComplete({
+      page,
+      turnIndex: 1,
+      settleMs: 10,
+      timeoutMs: 5_000,
+      maxTurnDurationMs: 5_000,
+      baselineCount: 0,
+      // Pre-send run-start baseline of 0 so the fake's runStartCount=1 clears
+      // it (`1 > 0`) and the DOM stop transition — the SOLE done-signal when
+      // the run attribute is present — fires from poll 1.
+      baselineRunStartCount: 0,
+      pollIntervalMs: 5,
+      surfaceReady,
+    });
+    expect(result.text).toBe("surface turn");
+    // The defect: the buggy source reads the surface TWICE on the poll where
+    // the done-signal holds but the surface is unmounted (poll 1). The fix
+    // reads it AT MOST ONCE per poll. (Index 0 is the pre-loop baseline-read
+    // window before the first cascade advance; surfaceReady is never called
+    // there, so the meaningful counts live at index >= 1.)
+    const perPollCounts = Array.from(surfaceCallsByPoll, (n) => n ?? 0);
+    const maxCallsInAnyPoll = Math.max(0, ...perPollCounts);
+    expect(maxCallsInAnyPoll).toBeLessThanOrEqual(1);
+    // Sanity: the surface WAS read (the test actually exercised the path).
+    expect(perPollCounts.reduce((a, b) => a + b, 0)).toBeGreaterThan(0);
+  });
+
+  // ==========================================================
+  // F4 — surface-mount STAYED-STOPPED quiescence (close BOTH the
+  // false-GREEN on a transient intermediate stop AND the false-RED
+  // backstop on a still-running gen-UI turn)
+  // ==========================================================
+
+  it("(F4-1) FALSE-GREEN KILLED: a MULTI-STEP completeOnMount turn does NOT complete on a transient INTERMEDIATE stop (surface mounted early); it completes only after the FINAL stop STAYS stopped", async () => {
+    // The cardinal false-green for the surface path. On a multi-step
+    // `completeOnMount` turn the render surface can mount during an EARLY
+    // sub-run. At the FIRST intermediate stop between sub-runs the old gate
+    // saw: sawStopThisTurn (a momentary runningNow=false edge), domOk (a
+    // bubble exists), surfaceMounted (surface already rendered) →
+    // `thirdOk = doneSignalOk && domOk && surfaceMounted` true → it RETURNED
+    // EARLY, before the final sub-run ran. The probe reported the turn
+    // complete when it wasn't.
+    //
+    // The fix requires the stop to have STAYED stopped (no newer run-start
+    // for the settle window) before completion can fire — so the transient
+    // intermediate stop cannot green the turn. NOTE the page-fake convention:
+    // the pre-loop baseline-run-start read consumes running[0] WITHOUT
+    // advancing the shared poll index, so loop iteration `i` reads
+    // running[i] / cascade[i] / surface[i] and running[0] is BOTH the baseline
+    // AND iteration 0 (so real run states begin at index 1). We model:
+    //   i1 sub-run 1 running, surface not yet mounted
+    //   i2 sub-run 1 running, surface MOUNTS (early gen-UI paint)
+    //   i3 INTERMEDIATE stop (runningNow=false, runStartCount=1) — THE TRAP:
+    //      surface mounted, bubble present (count=1), momentary stop edge
+    //   i4 sub-run 2 RE-STARTS (runningNow=true, runStartCount=2), count→2
+    //   i5 FINAL stop (runningNow=false, runStartCount=2)
+    //   i6 FINAL stop holds → quiescence satisfied → completes here
+    //
+    // bubbleIndex discriminates: a false-green at the intermediate stop
+    // returns count=1 → bubbleIndex 0; the correct completion at the final
+    // stop has count=2 → bubbleIndex 1. On UNMODIFIED source this returns
+    // bubbleIndex 0 (early); after the fix it returns bubbleIndex 1.
+    const intermediateStop: CopilotRunningState = {
+      attrPresent: true,
+      runningNow: false,
+      sawRunningTrue: true,
+      runStartCount: 1,
+      lastStoppedAtMs: 1,
+    };
+    const restarted: CopilotRunningState = {
+      attrPresent: true,
+      runningNow: true,
+      sawRunningTrue: true,
+      runStartCount: 2,
+      lastStoppedAtMs: 1,
+    };
+    const finalStop: CopilotRunningState = {
+      attrPresent: true,
+      runningNow: false,
+      sawRunningTrue: true,
+      runStartCount: 2,
+      lastStoppedAtMs: 2,
+    };
+    const { page, surfaceReady } = makeSurfaceRunSignalPage({
+      sse: [0], // DOM transition is the SOLE done-signal here
+      running: [
+        runningAbsent, // baseline + i0 (runStartCount=0 → no sawStop)
+        runningStarted, // i1: sub-run 1 running
+        runningStarted, // i2: still running, surface mounts this poll
+        intermediateStop, // i3: THE TRAP — intermediate stop, surface mounted
+        restarted, // i4: sub-run 2 running again (count→2)
+        finalStop, // i5: final stop
+        finalStop, // i6: final stop holds → quiescent
+        finalStop,
+      ],
+      cascade: [
+        { count: 1, text: null }, // i0
+        { count: 1, text: null }, // i1
+        { count: 1, text: null }, // i2
+        { count: 1, text: null }, // i3 (intermediate bubble — count=1)
+        { count: 2, text: null }, // i4 (sub-run 2's bubble appears — count=2)
+        { count: 2, text: null }, // i5 (final bubble)
+        { count: 2, text: null }, // i6
+        { count: 2, text: null },
+      ],
+      surface: [
+        false, // i0: surface not mounted yet
+        false, // i1: still not mounted
+        true, // i2: surface MOUNTS during sub-run 1
+        true, // i3: still mounted (THE TRAP poll)
+        true, // i4
+        true, // i5
+        true, // i6
+        true,
+      ],
+    });
+    const result = await waitForTurnComplete({
+      page,
+      turnIndex: 1,
+      settleMs: 15,
+      timeoutMs: 5_000,
+      maxTurnDurationMs: 4_000,
+      baselineCount: 0,
+      baselineRunStartCount: 0,
+      pollIntervalMs: 5,
+      surfaceReady,
+    });
+    // Completed on the FINAL bubble (count=2 → bubbleIndex 1), NOT the
+    // intermediate stop's bubble (count=1 → bubbleIndex 0). On unmodified
+    // source this is 0 (false-green at the intermediate stop).
+    expect(result.bubbleIndex).toBe(1);
+  });
+
+  it("(F4-2) FALSE-RED KILLED: a completeOnMount turn whose surface mounts WHILE the run is still going does NOT throw done-signal-missing while running (backstop gated on runningNow !== true)", async () => {
+    // The false-red symptom. A gen-UI turn paints its surface early and the
+    // run is STILL going (runningNow=true). The `done-signal-missing`
+    // backstop fires once `maxTurnDurationMs` elapses with DOM + the third
+    // conjunct (surface) held but no confirmed done-signal — and the OLD
+    // backstop had NO `runningNow` guard, so it RED a turn that was simply
+    // still legitimately running (its stop edge lands after
+    // `maxTurnDurationMs` but before `timeoutMs`).
+    //
+    // We hold the run RUNNING (runningNow=true) past `maxTurnDurationMs` with
+    // the surface mounted + bubble present, then let it stop and stay
+    // stopped. The fixed backstop must NOT fire while runningNow===true, so
+    // the turn completes GREEN on the eventual quiescent stop instead of
+    // throwing. On UNMODIFIED source the backstop throws done-signal-missing
+    // around `maxTurnDurationMs` while the run is still in flight.
+    const finalStop: CopilotRunningState = {
+      attrPresent: true,
+      runningNow: false,
+      sawRunningTrue: true,
+      runStartCount: 1,
+      lastStoppedAtMs: 1,
+    };
+    // maxTurnDurationMs=40 with pollIntervalMs=5 → the backstop window
+    // (~8 polls) elapses while the run is still running (the long
+    // runningStarted tail), so the OLD unguarded backstop reds mid-run.
+    const { page, surfaceReady } = makeSurfaceRunSignalPage({
+      sse: [0], // SSE never catches up; DOM transition is the sole done-signal
+      running: [
+        runningAbsent, // baseline
+        // Run stays RUNNING for many polls past maxTurnDurationMs (40ms /
+        // 5ms ≈ 8 polls); keep it running well beyond that, THEN stop.
+        runningStarted, // i0
+        runningStarted, // i1
+        runningStarted, // i2
+        runningStarted, // i3
+        runningStarted, // i4
+        runningStarted, // i5
+        runningStarted, // i6
+        runningStarted, // i7
+        runningStarted, // i8
+        runningStarted, // i9
+        runningStarted, // i10
+        finalStop, // i11: run finally stops
+        finalStop, // i12: stays stopped → quiescent → completes
+        finalStop,
+      ],
+      cascade: Array.from({ length: 15 }, () => ({
+        count: 1,
+        text: null as string | null,
+      })),
+      surface: Array.from({ length: 15 }, () => true), // surface mounted from i0
+    });
+    // Must NOT reject. On unmodified source this REJECTS (done-signal-missing
+    // backstop fires while runningNow===true).
+    const result = await waitForTurnComplete({
+      page,
+      turnIndex: 1,
+      settleMs: 15,
+      timeoutMs: 5_000,
+      maxTurnDurationMs: 40, // << timeoutMs, fires well before the hard ceiling
+      baselineCount: 0,
+      baselineRunStartCount: 0,
+      pollIntervalMs: 5,
+      surfaceReady,
+    });
+    expect(result.bubbleIndex).toBe(0);
+  });
+
+  it("(F4-3a) REGRESSION: a SINGLE-run completeOnMount happy path still completes once the surface mounts and the stop STAYS stopped", async () => {
+    // Guards against the quiescence gate over-tightening: a normal single-run
+    // gen-UI turn (run starts, stops once, stays stopped; surface mounts)
+    // MUST still complete after the surface mounts + the stop persists.
+    const { page, surfaceReady } = makeSurfaceRunSignalPage({
+      sse: [0],
+      running: [
+        runningAbsent, // baseline
+        runningStarted, // i0: running
+        runningStopped, // i1: stop (runStartCount=1)
+        runningStopped, // i2: stays stopped → quiescent
+        runningStopped,
+        runningStopped,
+      ],
+      cascade: [
+        { count: 1, text: null },
+        { count: 1, text: null },
+        { count: 1, text: null },
+        { count: 1, text: null },
+      ],
+      surface: [false, true, true, true, true, true], // surface mounts at i1
+    });
+    const result = await waitForTurnComplete({
+      page,
+      turnIndex: 1,
+      settleMs: 15,
+      timeoutMs: 5_000,
+      maxTurnDurationMs: 4_000,
+      baselineCount: 0,
+      baselineRunStartCount: 0,
+      pollIntervalMs: 5,
+      surfaceReady,
+    });
+    expect(result.bubbleIndex).toBe(0);
+  });
+
+  it("(F4-3b) REGRESSION: a genuine HEADLESS surface hang (bubble + surface mounted, runningNow=null, done-signal never confirmed) REDS as sse-missing at the HARD timeout (NOT early via the backstop)", async () => {
+    // A painted + surface-mounted-but-finished-signal-missing case on the
+    // HEADLESS path (attribute absent → no DOM transition; SSE counter never
+    // catches up). The early `done-signal-missing` backstop is gated on
+    // `attrPresent === true` (F5), so a headless turn is NOT redded early at
+    // `maxTurnDurationMs` — it would be a false-red on a merely-lagging SSE
+    // counter. A GENUINELY-stuck headless turn still REDS, at the HARD
+    // `timeoutMs` via the post-loop classifier, classified `sse-missing`. (The
+    // DOM-present equivalent of this surface hang is covered by F4-3c below,
+    // which keeps the early `done-signal-missing` backstop behaviour.)
+    const { page, surfaceReady } = makeSurfaceRunSignalPage({
+      sse: [0], // never catches up
+      running: [runningAbsent], // attribute absent → runningNow null (not true)
+      cascade: [{ count: 1, text: null }],
+      surface: [true], // surface mounted the whole time
+    });
+    await expect(
+      waitForTurnComplete({
+        page,
+        turnIndex: 1,
+        settleMs: 15,
+        timeoutMs: 200, // tiny hard ceiling so the timeout path is fast
+        maxTurnDurationMs: 60, // would have fired here on the old (ungated) backstop
+        baselineCount: 0,
+        baselineRunStartCount: 0,
+        pollIntervalMs: 5,
+        surfaceReady,
+      }),
+    ).rejects.toMatchObject({
+      name: "TurnNotCompleteError",
+      reason: "sse-missing",
+    });
+  });
+
+  it("(F4-3c) REGRESSION: a genuine DOM-PRESENT surface hang (bubble + surface mounted, runningNow=false, done-signal never confirmed) still REDS EARLY via the done-signal-missing backstop", async () => {
+    // The early backstop's preserved DOM-present job: a turn whose DOM signal
+    // IS available (attribute present, run stopped: runningNow=false) but where
+    // no run ever started for this turn (runStartCount stays at the baseline),
+    // so the trustworthy `data-copilot-running` true→false transition never
+    // fires. The surface mounted + a bubble exists, yet the done-signal is
+    // genuinely MISSING. Because the DOM signal is available, the early
+    // backstop fires at `maxTurnDurationMs` (well before the hard ceiling),
+    // classified `done-signal-missing`. This is the DOM-present counterpart to
+    // the headless F4-3b case and proves the F5 gate did NOT neuter the early
+    // backstop for the path where it is legitimate.
+    const stoppedNoStart: CopilotRunningState = {
+      attrPresent: true,
+      runningNow: false,
+      sawRunningTrue: false, // no run ever started this turn → no transition
+      runStartCount: 0, // equals baseline → sawStopThisTurn never holds
+      lastStoppedAtMs: 0,
+    };
+    const { page, surfaceReady } = makeSurfaceRunSignalPage({
+      sse: [0], // never catches up (and is not consulted on the DOM path)
+      running: [stoppedNoStart],
+      cascade: [{ count: 1, text: null }],
+      surface: [true], // surface mounted the whole time
+    });
+    await expect(
+      waitForTurnComplete({
+        page,
+        turnIndex: 1,
+        settleMs: 15,
+        timeoutMs: 5_000,
+        maxTurnDurationMs: 60, // backstop fires well before the hard ceiling
+        baselineCount: 0,
+        baselineRunStartCount: 0,
+        pollIntervalMs: 5,
+        surfaceReady,
+      }),
+    ).rejects.toMatchObject({
+      name: "TurnNotCompleteError",
+      reason: "done-signal-missing",
+    });
+  });
+
+  // ==========================================================================
+  // F5 — HEADLESS EARLY-BACKSTOP GATE + systematic backstop/completion matrix
+  // ==========================================================================
+  //
+  // F5 false-red: a HEADLESS turn (attrPresent=false, runningNow=null) whose
+  // bubble paints + text settles by `maxTurnDurationMs` but whose ONLY signal
+  // — the fragile SSE fetch-counter — lags, catching up only AFTER
+  // `maxTurnDurationMs` (≈0.6×timeoutMs) yet BEFORE the hard `timeoutMs`. On
+  // the OLD (ungated) backstop this false-RED at `maxTurnDurationMs` as
+  // `done-signal-missing`. The fix gates the early backstop on
+  // `attrPresent === true`, so the headless turn uses the FULL `timeoutMs` for
+  // its only signal and completes GREEN when the counter catches up.
+  //
+  // The matrix below covers, for BOTH the DOM path (attrPresent=true) and the
+  // HEADLESS path (attrPresent=false):
+  //   completes-normally          → GREEN
+  //   lagging-but-recovers        → GREEN (done-signal/SSE confirms after
+  //                                  maxTurnDurationMs but before timeoutMs;
+  //                                  NOT early-redded) — the F5 case headless
+  //   genuine-hang                → RED with the correct reason
+  //                                  (done-signal-missing for DOM at the early
+  //                                  backstop; sse-missing for headless at the
+  //                                  hard timeout)
+  // crossed with the third conjunct being text-stability (default) vs
+  // surface-mount (completeOnMount) where applicable. Reuses the existing
+  // `makeRunSignalPage` / `makeSurfaceRunSignalPage` page-fakes.
+
+  // -- F5 PRIMARY: the headless lagging-but-recovers false-red kill ----------
+
+  it("(F5) HEADLESS LAGGING-BUT-RECOVERS (text path): SSE counter catches up AFTER maxTurnDurationMs but BEFORE timeoutMs → completes GREEN, NOT early-redded", async () => {
+    // The exact F5 false-red. pollIntervalMs=20, maxTurnDurationMs=100 (≈5
+    // polls), timeoutMs=2000. A painted + settled headless bubble whose SSE
+    // counter stays 0 well past maxTurnDurationMs (polls 0..7) then flips to 1
+    // at poll 8 (~160ms elapsed > 100ms maxTurnDurationMs, << 2000ms timeout).
+    // On the OLD ungated backstop this RED at ~100ms as done-signal-missing
+    // (domOk + textOk held, !doneSignalOk, runningNow=null!==true,
+    // stopStableSince=null). The F5 gate (attrPresent===true) keeps the early
+    // backstop OFF for headless, so the turn waits and completes GREEN.
+    const page = makeRunSignalPage({
+      sse: [0, 0, 0, 0, 0, 0, 0, 0, 1, 1], // catches up at poll 8
+      running: [runningAbsent], // headless: attribute absent → runningNow null
+      cascade: [{ count: 1, text: "lagging headless reply" }], // settled tail
+    });
+    const result = await waitForTurnComplete({
+      page,
+      turnIndex: 1,
+      settleMs: 30,
+      timeoutMs: 2_000,
+      maxTurnDurationMs: 100, // early backstop window the lag crosses
+      baselineCount: 0,
+      pollIntervalMs: 20,
+    });
+    expect(result.text).toBe("lagging headless reply");
+  });
+
+  it("(F5-surface) HEADLESS LAGGING-BUT-RECOVERS (surface-mount path): surface mounted + SSE catches up after maxTurnDurationMs but before timeoutMs → completes GREEN", async () => {
+    // The surface-mount (completeOnMount) headless variant of F5: a text-empty
+    // A2UI-shape headless turn whose render surface mounts immediately but
+    // whose SSE counter lags past maxTurnDurationMs. Must complete GREEN once
+    // the counter catches up, not red early.
+    const { page, surfaceReady } = makeSurfaceRunSignalPage({
+      sse: [0, 0, 0, 0, 0, 0, 0, 0, 1, 1], // catches up at poll 8
+      running: [runningAbsent], // headless
+      cascade: [{ count: 1, text: null }], // text-empty A2UI shape
+      surface: [true], // surface mounted the whole time
+    });
+    const result = await waitForTurnComplete({
+      page,
+      turnIndex: 1,
+      settleMs: 30,
+      timeoutMs: 2_000,
+      maxTurnDurationMs: 100,
+      baselineCount: 0,
+      pollIntervalMs: 20,
+      surfaceReady,
+    });
+    expect(result.bubbleIndex).toBe(0);
+  });
+
+  // -- MATRIX: DOM path (attrPresent=true) -----------------------------------
+
+  it("(matrix DOM/text/completes) done-signal confirms promptly → GREEN", async () => {
+    // DOM signal present, run goes true→false and STAYS stopped, text settles
+    // → completes well before maxTurnDurationMs.
+    const page = makeRunSignalPage({
+      sse: [0], // SSE never consulted on the DOM path
+      running: [runningStarted, runningStopped],
+      cascade: [
+        { count: 1, text: "dom reply" },
+        { count: 1, text: "dom reply" },
+      ],
+    });
+    const result = await waitForTurnComplete({
+      page,
+      turnIndex: 1,
+      settleMs: 30,
+      timeoutMs: 2_000,
+      maxTurnDurationMs: 1_500,
+      baselineCount: 0,
+      baselineRunStartCount: 0,
+    });
+    expect(result.text).toBe("dom reply");
+  });
+
+  it("(matrix DOM/text/lagging-recovers) stop edge arrives AFTER maxTurnDurationMs but BEFORE timeoutMs → GREEN (arming guard defers the backstop)", async () => {
+    // DOM signal present; the run stays RUNNING past maxTurnDurationMs then
+    // stops + stays stopped before the hard timeout. The early backstop must
+    // NOT red while running (runningNow guard) nor on the first stopped poll
+    // (arming guard) — the turn completes GREEN once quiescence holds.
+    const page = makeRunSignalPage({
+      // runningNow=true for polls 0..6 (past maxTurnDurationMs=100 @ 20ms),
+      // then stops at poll 7 and stays stopped.
+      sse: [0],
+      running: [
+        runningStarted,
+        runningStarted,
+        runningStarted,
+        runningStarted,
+        runningStarted,
+        runningStarted,
+        runningStarted,
+        runningStopped,
+      ],
+      cascade: [{ count: 1, text: "dom lagging reply" }],
+    });
+    const result = await waitForTurnComplete({
+      page,
+      turnIndex: 1,
+      settleMs: 30,
+      timeoutMs: 2_000,
+      maxTurnDurationMs: 100,
+      baselineCount: 0,
+      baselineRunStartCount: 0,
+      pollIntervalMs: 20,
+    });
+    expect(result.text).toBe("dom lagging reply");
+  });
+
+  it("(matrix DOM/text/genuine-hang) bubble painted + text settled, run STOPPED but never started for this turn (no transition) → done-signal-missing EARLY at the backstop", async () => {
+    // DOM signal present (attrPresent=true) but no run ever started this turn
+    // (runStartCount stays at baseline, sawRunningTrue=false), so the
+    // true→false transition never fires. domOk + textOk hold, runningNow=false
+    // (not true), stopStableSince stays null (sawStopThisTurn false). The early
+    // backstop fires at maxTurnDurationMs → done-signal-missing.
+    const stoppedNoStart: CopilotRunningState = {
+      attrPresent: true,
+      runningNow: false,
+      sawRunningTrue: false,
+      runStartCount: 0,
+      lastStoppedAtMs: 0,
+    };
+    const page = makeRunSignalPage({
+      sse: [0],
+      running: [stoppedNoStart],
+      cascade: [{ count: 1, text: "dom stuck reply" }],
+    });
+    await expect(
+      waitForTurnComplete({
+        page,
+        turnIndex: 1,
+        settleMs: 30,
+        timeoutMs: 5_000,
+        maxTurnDurationMs: 100, // early backstop fires well before the ceiling
+        baselineCount: 0,
+        baselineRunStartCount: 0,
+        pollIntervalMs: 20,
+      }),
+    ).rejects.toMatchObject({
+      name: "TurnNotCompleteError",
+      reason: "done-signal-missing",
+    });
+  });
+
+  it("(matrix DOM/surface/genuine-hang) surface mounted + no transition → done-signal-missing EARLY at the backstop", async () => {
+    // Surface-mount third-conjunct counterpart of the DOM genuine-hang: covered
+    // structurally by F4-3c above; this asserts the same outcome through the
+    // surface page-fake to keep the {surface}×{DOM}×{genuine-hang} cell
+    // explicitly present in the matrix.
+    const stoppedNoStart: CopilotRunningState = {
+      attrPresent: true,
+      runningNow: false,
+      sawRunningTrue: false,
+      runStartCount: 0,
+      lastStoppedAtMs: 0,
+    };
+    const { page, surfaceReady } = makeSurfaceRunSignalPage({
+      sse: [0],
+      running: [stoppedNoStart],
+      cascade: [{ count: 1, text: null }],
+      surface: [true],
+    });
+    await expect(
+      waitForTurnComplete({
+        page,
+        turnIndex: 1,
+        settleMs: 15,
+        timeoutMs: 5_000,
+        maxTurnDurationMs: 60,
+        baselineCount: 0,
+        baselineRunStartCount: 0,
+        pollIntervalMs: 5,
+        surfaceReady,
+      }),
+    ).rejects.toMatchObject({
+      name: "TurnNotCompleteError",
+      reason: "done-signal-missing",
+    });
+  });
+
+  // -- MATRIX: HEADLESS path (attrPresent=false) -----------------------------
+
+  it("(matrix headless/text/completes) SSE counter confirms promptly → GREEN", async () => {
+    // Headless completes-normally: SSE catches up well before
+    // maxTurnDurationMs. (Mirrors test (3) with explicit matrix framing.)
+    const page = makeRunSignalPage({
+      sse: [0, 1, 1], // catches up at poll 1
+      running: [runningAbsent],
+      cascade: [{ count: 1, text: "headless prompt reply" }],
+    });
+    const result = await waitForTurnComplete({
+      page,
+      turnIndex: 1,
+      settleMs: 30,
+      timeoutMs: 2_000,
+      maxTurnDurationMs: 1_500,
+      baselineCount: 0,
+    });
+    expect(result.text).toBe("headless prompt reply");
+  });
+
+  // headless/text/lagging-recovers === (F5) above.
+  // headless/surface/lagging-recovers === (F5-surface) above.
+
+  it("(matrix headless/text/genuine-hang) SSE counter NEVER catches up → sse-missing at the HARD timeout (NOT early)", async () => {
+    // Headless genuine-hang on the text path: the early backstop is gated OFF
+    // for headless, so the turn runs to the hard timeout and reds sse-missing.
+    // (Mirrors (3-red) with explicit matrix framing; small timeout for speed.)
+    const page = makeRunSignalPage({
+      sse: [0], // never catches up
+      running: [runningAbsent],
+      cascade: [{ count: 1, text: "headless stuck" }],
+    });
+    await expect(
+      waitForTurnComplete({
+        page,
+        turnIndex: 1,
+        settleMs: 30,
+        timeoutMs: 300, // hard ceiling reached fast
+        maxTurnDurationMs: 100, // would have fired here on the old backstop
+        baselineCount: 0,
+      }),
+    ).rejects.toMatchObject({
+      name: "TurnNotCompleteError",
+      reason: "sse-missing",
+    });
+  });
+
+  it("(matrix headless/surface/genuine-hang) surface mounted + SSE NEVER catches up → sse-missing at the HARD timeout (NOT early)", async () => {
+    // Headless genuine-hang on the surface-mount path. (Mirrors (F4-3b) with
+    // explicit matrix framing.)
+    const { page, surfaceReady } = makeSurfaceRunSignalPage({
+      sse: [0],
+      running: [runningAbsent],
+      cascade: [{ count: 1, text: null }],
+      surface: [true],
+    });
+    await expect(
+      waitForTurnComplete({
+        page,
+        turnIndex: 1,
+        settleMs: 15,
+        timeoutMs: 200,
+        maxTurnDurationMs: 60,
+        baselineCount: 0,
+        baselineRunStartCount: 0,
+        pollIntervalMs: 5,
+        surfaceReady,
+      }),
+    ).rejects.toMatchObject({
+      name: "TurnNotCompleteError",
+      reason: "sse-missing",
+    });
   });
 });

--- a/showcase/harness/src/probes/helpers/conversation-runner.ts
+++ b/showcase/harness/src/probes/helpers/conversation-runner.ts
@@ -177,6 +177,31 @@ const SELECTOR_PROBE_TIMEOUT_MS = 5_000;
 const POLL_INTERVAL_MS = 100;
 
 /**
+ * Compute the done-signal backstop ceiling for a turn from its hard
+ * timeout + settle window. The backstop must be:
+ *   - GENEROUSLY above the settle window so a legitimately-slow done-signal
+ *     (a multi-step run whose final RUN_FINISHED lands late, after the text
+ *     has already settled) is NOT cut off prematurely; and
+ *   - comfortably BELOW the hard `timeoutMs` so a genuine
+ *     settled-but-never-finished hang reds at `done-signal-missing` instead
+ *     of burning the full ceiling (and so a future demotion can never
+ *     false-green on DOM+text alone past this point).
+ * Chosen as the larger of "several settle windows" and 60% of the hard
+ * ceiling, clamped to `timeoutMs`. For the defaults (timeout 30s, settle
+ * 1.5s) this is 18s — 12× the settle window, 12s of headroom before the
+ * hard ceiling.
+ */
+function computeMaxTurnDurationMs(
+  turnTimeoutMs: number,
+  settleMs: number,
+): number {
+  return Math.min(
+    turnTimeoutMs,
+    Math.max(settleMs * 4 + POLL_INTERVAL_MS, Math.floor(turnTimeoutMs * 0.6)),
+  );
+}
+
+/**
  * Bounded cold-start retry budget. A showcase can paint a TRANSIENT error
  * banner on the FIRST turn while its agent backend / runtime is still warming
  * up; that banner then clears on its own a beat later. PR #5142's fast-fail
@@ -621,6 +646,19 @@ export async function runConversation(
         page as unknown as PlaywrightPage,
       );
 
+      // Multi-step run-start baseline for the PRIMARY DOM done-signal. Snapshot
+      // the page-side `runStartCount` BEFORE `sendTurnMessage` — SAME ordering
+      // rationale as `baselineCount`: the user message hasn't been submitted
+      // yet, so the agent provably cannot have fired RUN_STARTED for THIS turn,
+      // guaranteeing this baseline reflects only prior-turn runs. Threaded into
+      // `waitForTurnComplete` via `baselineRunStartCount` so the
+      // `runStartCount > baselineRunStartCount` gate stays correct even when a
+      // fast agent fires RUN_STARTED before the settle wait begins (capturing
+      // it inside `waitForTurnComplete`, which runs AFTER the send, would be
+      // racy and could kill the PRIMARY signal on fast turns).
+      const baselineRunStartCount = (await readCopilotRunning(page))
+        .runStartCount;
+
       // Surface-mount completion (opt-in via `turn.completeOnMount`): snapshot
       // the pre-send testid counts so the settle gate can detect a NEW render
       // surface for THIS turn (vs. a leftover from a prior turn). Captured
@@ -706,8 +744,10 @@ export async function runConversation(
           turnIndex: turnNum,
           settleMs,
           timeoutMs: turnTimeoutMs,
+          maxTurnDurationMs: computeMaxTurnDurationMs(turnTimeoutMs, settleMs),
           baselineBannerText,
           baselineCount,
+          baselineRunStartCount,
           surfaceReady,
         });
       } catch (settleErr) {
@@ -812,6 +852,15 @@ export async function runConversation(
           const retryBaselineCount = await countAssistantMessages(
             page as unknown as PlaywrightPage,
           );
+          // Re-snapshot the post-reload run-start baseline BEFORE the
+          // cold-start re-send, mirroring `retryBaselineCount`. page.reload()
+          // tore down the page-side run-lifecycle state, so the live count is
+          // typically 0; capturing it here — before the re-send — keeps the
+          // retry's `runStartCount > baselineRunStartCount` gate measuring the
+          // re-send's NEW run rather than carrying the stale pre-reload
+          // baseline forward.
+          const retryBaselineRunStartCount = (await readCopilotRunning(page))
+            .runStartCount;
           // Re-arm surface-mount completion against the post-reload baseline.
           // page.reload() tore down the DOM, so any prior-turn surface is gone
           // — re-snapshot so the retry's delta gate measures growth from the
@@ -847,16 +896,22 @@ export async function runConversation(
           // this attempt throws again (AssistantErroredError) and the outer
           // catch records the turn failure — #5142 stays intact.
           try {
+            const retryTimeoutMs = Math.max(
+              coldStartRetryMinSettleMs(settleMs),
+              turnDeadline - Date.now(),
+            );
             settleResult = await waitForTurnComplete({
               page,
               turnIndex: turnNum,
               settleMs,
-              timeoutMs: Math.max(
-                coldStartRetryMinSettleMs(settleMs),
-                turnDeadline - Date.now(),
+              timeoutMs: retryTimeoutMs,
+              maxTurnDurationMs: computeMaxTurnDurationMs(
+                retryTimeoutMs,
+                settleMs,
               ),
               baselineBannerText: retryBaselineBannerText,
               baselineCount: retryBaselineCount,
+              baselineRunStartCount: retryBaselineRunStartCount,
               surfaceReady: retrySurfaceReady,
             });
           } catch (retryErr) {
@@ -1539,6 +1594,22 @@ export interface WaitForTurnCompleteOpts {
   settleMs: number;
   /** Hard ceiling. Beyond this we throw `TurnNotCompleteError`. */
   timeoutMs: number;
+  /**
+   * Done-signal backstop ceiling, SEPARATE from `timeoutMs`. Guards the
+   * "silent multi-step hang" failure mode: a turn renders a non-empty,
+   * text-stable bubble (DOM + TEXT conjuncts satisfied) but NO trustworthy
+   * done-signal ever confirms — neither the `data-copilot-running`
+   * true→false transition NOR the SSE fetch-counter. Without this, such a
+   * turn would otherwise sit DOM+text-stable until the much larger
+   * `timeoutMs` elapses; worse, a future demotion that completed on
+   * DOM+text alone would FALSE-GREEN a real hang. When DOM + TEXT have
+   * held but no done-signal has confirmed within `maxTurnDurationMs`, the
+   * gate throws `TurnNotCompleteError(reason="done-signal-missing")` so
+   * the hang STILL REDS. `undefined` ⇒ no backstop (legacy callers /
+   * unit-test fakes that never exercise the hang path); the runner passes
+   * it explicitly. Must be ≤ `timeoutMs` to fire before the hard ceiling.
+   */
+  maxTurnDurationMs?: number;
   /** Optional poll cadence. Default 100ms — fast enough for fast-replay aimock. */
   pollIntervalMs?: number;
   /**
@@ -1572,6 +1643,29 @@ export interface WaitForTurnCompleteOpts {
    * fakes that script count progressions keyed to turn ordinals.
    */
   baselineCount?: number;
+  /**
+   * Pre-turn baseline of the page-side run-start count (`runStartCount` from
+   * `data-copilot-running`'s lifecycle summary). Captured by the runner at the
+   * CALL SITE — BEFORE `sendTurnMessage` — mirroring `baselineCount`'s
+   * ordering: the user message hasn't been submitted yet, so the agent
+   * provably cannot have fired RUN_STARTED for THIS turn. The PRIMARY DOM
+   * done-signal gates on `runStartCount > baselineRunStartCount` to confirm "a
+   * NEW run started THIS turn and then stopped".
+   *
+   * Why pre-send matters: capturing the baseline INSIDE `waitForTurnComplete`
+   * (which the runner only calls AFTER `sendTurnMessage`) is RACY — a fast
+   * agent that fires RUN_STARTED between the send and the in-function read
+   * leaves the baseline already-incremented, so `runStartCount >
+   * baselineRunStartCount` can NEVER hold → the PRIMARY DOM signal is DEAD on
+   * fast turns and the turn falls back to the fragile SSE counter (or
+   * false-reds via the done-signal-missing backstop). Threading the pre-send
+   * baseline here closes that race.
+   *
+   * When omitted (unit-test fakes / any caller that doesn't snapshot
+   * pre-send), the function falls back to reading the baseline at turn entry —
+   * the legacy behaviour — so no existing caller breaks.
+   */
+  baselineRunStartCount?: number;
   /**
    * Surface-mount completion predicate (OPT-IN — set only by the runner
    * when the turn carries `completeOnMount`). When provided, the third
@@ -1617,6 +1711,7 @@ export class TurnNotCompleteError extends Error {
       | "sse-missing"
       | "dom-missing"
       | "text-unstable"
+      | "done-signal-missing"
       | "surface-missing",
     readonly turnIndex: number,
     readonly observedAtMs: number,
@@ -1642,6 +1737,88 @@ async function readRunsFinished(page: Page): Promise<number> {
     );
   } catch {
     return 0;
+  }
+}
+
+/**
+ * Edge-accurate summary of CopilotKit v2's `data-copilot-running`
+ * attribute, latched page-side by the MutationObserver
+ * `attachSseInterceptor` installs (`window.__hk_copilotRunning`). This is
+ * the PRIMARY turn-done signal — transport-independent (driven by the
+ * agent run lifecycle RUN_STARTED/RUN_FINISHED, not a fetch monkeypatch).
+ *
+ * - `attrPresent`     — the `[data-testid="copilot-chat"]` element bearing
+ *                       `data-copilot-running` has been seen. `false` ⇒
+ *                       this demo doesn't render `CopilotChatView` (a
+ *                       headless bring-your-own-UI demo); the gate falls
+ *                       back to the SSE counter.
+ * - `runningNow`      — live attribute value; `null` when never observed.
+ * - `sawRunningTrue`  — latched once the attribute EVER went `true`. The
+ *                       primary done-signal gates on the TRANSITION
+ *                       (saw-true-then-stopped), never on a bare `false`
+ *                       (which is also the never-started baseline).
+ * - `runStartCount`   — count of false→true edges. A multi-step turn
+ *                       toggles between sub-runs; the gate uses a snapshot
+ *                       of this taken at turn start to detect a NEW run
+ *                       beginning after a stop (⇒ not yet complete).
+ * - `lastStoppedAtMs` — wall-clock ms of the most recent true→false edge.
+ */
+export interface CopilotRunningState {
+  attrPresent: boolean;
+  runningNow: boolean | null;
+  sawRunningTrue: boolean;
+  runStartCount: number;
+  lastStoppedAtMs: number;
+}
+
+/**
+ * Read the page-side `__hk_copilotRunning` lifecycle summary. Returns the
+ * "attribute absent / never observed" shape if the global hasn't been
+ * seeded (pre-navigation, or a page where `attachSseInterceptor` never
+ * ran) or if the `evaluate` itself throws — both are equivalent to "no
+ * trustworthy DOM run-signal available" from the gate's vantage, which
+ * routes it to the SSE-counter fallback.
+ */
+async function readCopilotRunning(page: Page): Promise<CopilotRunningState> {
+  const absent: CopilotRunningState = {
+    attrPresent: false,
+    runningNow: null,
+    sawRunningTrue: false,
+    runStartCount: 0,
+    lastStoppedAtMs: 0,
+  };
+  try {
+    const raw = await page.evaluate(
+      () =>
+        (
+          globalThis as unknown as {
+            __hk_copilotRunning?: {
+              attrPresent?: boolean;
+              runningNow?: boolean | null;
+              sawRunningTrue?: boolean;
+              runStartCount?: number;
+              lastStoppedAtMs?: number;
+            };
+          }
+        ).__hk_copilotRunning ?? null,
+    );
+    if (raw === null || typeof raw !== "object") return absent;
+    return {
+      attrPresent: raw.attrPresent === true,
+      runningNow:
+        raw.runningNow === true
+          ? true
+          : raw.runningNow === false
+            ? false
+            : null,
+      sawRunningTrue: raw.sawRunningTrue === true,
+      runStartCount:
+        typeof raw.runStartCount === "number" ? raw.runStartCount : 0,
+      lastStoppedAtMs:
+        typeof raw.lastStoppedAtMs === "number" ? raw.lastStoppedAtMs : 0,
+    };
+  } catch {
+    return absent;
   }
 }
 
@@ -1701,9 +1878,58 @@ export async function waitForTurnComplete(
   // stale text) resets the counter — the banner is not a fresh error.
   let consecutiveBannerDiffersFromBaseline = 0;
   let lastBannerText = "";
+  // Done-signal backstop ceiling. Defaults to `timeoutMs` (no early
+  // backstop) when the caller doesn't opt in. Clamped to `timeoutMs` so a
+  // misconfigured larger value can never push the backstop past the hard
+  // ceiling. See `WaitForTurnCompleteOpts.maxTurnDurationMs`.
+  const maxTurnDurationMs = Math.min(
+    opts.maxTurnDurationMs ?? timeoutMs,
+    timeoutMs,
+  );
+  // Multi-step toggle baseline: the page-side run-start count captured BEFORE
+  // this turn submitted. A multi-step turn fires RUN_STARTED/RUN_FINISHED per
+  // sub-run, toggling `data-copilot-running` false→true→false→true→…. By
+  // comparing the LIVE `runStartCount` against this baseline we detect "a
+  // NEW run started after the last stop" and refuse to complete on an
+  // INTERMEDIATE false — completion requires running to have STOPPED and
+  // STAYED stopped (no newer start) for the settle window.
+  //
+  // PREFER the caller's pre-send snapshot (`opts.baselineRunStartCount`). The
+  // runner captures it BEFORE `sendTurnMessage` (mirroring `baselineCount`) so
+  // a fast agent that fires RUN_STARTED before this function even runs cannot
+  // poison the baseline. Falling back to an in-function read here would be
+  // RACY on fast turns — the agent may already have started, making
+  // `runStartCount > baselineRunStartCount` impossible and killing the PRIMARY
+  // DOM signal. The in-function read is retained ONLY as the fallback for
+  // callers (unit-test fakes) that don't pass the opt.
+  const baselineRunStartCount =
+    opts.baselineRunStartCount ??
+    (await readCopilotRunning(page)).runStartCount;
+  // STAYED-STOPPED quiescence tracking (the temporal guard the comments
+  // promise and the gate must actually enforce). A bare `runningNow === false`
+  // edge (`sawStopThisTurn`) is INSTANTANEOUS — true at ANY stop edge,
+  // including the transient INTERMEDIATE stop between two sub-runs of a
+  // multi-step turn. Completing on that edge false-greens the turn before its
+  // final sub-run. We therefore require the stop to have PERSISTED — the same
+  // `runStartCount` observed `runningNow === false` continuously for at least
+  // `settleMs` (mirroring the text path's stability window) with NO newer
+  // run-start. A new run-start (a later false→true edge bumping
+  // `runStartCount`) resets this window, so an intermediate stop can never
+  // satisfy it; only the FINAL stop that STAYS stopped does.
+  //   - `stopStableSince`         : wall-clock ms the current stop edge was
+  //                                 first observed (`null` when not stopped).
+  //   - `stopStableRunStartCount` : the `runStartCount` value that stop edge
+  //                                 belongs to; a change resets the window
+  //                                 (a newer run started since).
+  let stopStableSince: number | null = null;
+  let stopStableRunStartCount = -1;
+  // Records the last time we had NOT yet observed a trustworthy done-signal
+  // while DOM+TEXT were satisfied — drives the `done-signal-missing`
+  // backstop. `null` until DOM+TEXT first hold.
   const pwPage = page as unknown as PlaywrightPage;
   while (Date.now() - startedAt < timeoutMs) {
     const runsFinished = await readRunsFinished(page);
+    const running = await readCopilotRunning(page);
     // Atomic single-evaluate read: `readCascadeStateLast` returns BOTH the
     // count and the text of the LAST bubble in the matched cascade tier in
     // ONE browser-side round-trip. The "last bubble" semantics is the
@@ -1720,7 +1946,78 @@ export async function waitForTurnComplete(
       lastText = text;
       lastChangeAt = now;
     }
+    // SSE fetch-counter signal (the legacy conjunct). FRAGILE: it relies on
+    // the page-side fetch wrapper matching the runtime URL pattern + install
+    // ordering + transport, which misses on variance → healthy demos
+    // false-red. Retained as the FALLBACK done-signal for HEADLESS demos
+    // (which never render `CopilotChatView`, so `data-copilot-running` is
+    // absent), and as a SECONDARY confirmation alongside the DOM signal.
     const sseOk = runsFinished >= turnIndex;
+    // PRIMARY done-signal edge — the `data-copilot-running` true→false
+    // TRANSITION. Trustworthy ONLY when the attribute is present
+    // (`attrPresent`); it is driven directly by the agent run lifecycle
+    // (RUN_STARTED → true, RUN_FINISHED → false) and is transport-
+    // independent (no fetch monkeypatch). We gate on the TRANSITION
+    // (saw-running-then-stopped), NOT a bare `runningNow === false`, because
+    // `false` is also the never-started baseline. Multi-step safety: we
+    // additionally require that at least one run started THIS turn —
+    // `runningNow === false` AND `sawRunningTrue` AND
+    // `runStartCount > baselineRunStartCount` — so the latest edge for this
+    // turn is a STOP. A subsequent false→true edge bumps `runStartCount` and
+    // flips `runningNow` back to true, so this EDGE predicate goes false again
+    // on an intermediate stop. CRUCIAL: this is only the INSTANTANEOUS edge —
+    // it is true at ANY `runningNow===false` poll, including the transient
+    // intermediate stop between sub-runs. Completion is NOT allowed to fire on
+    // the bare edge; it requires the STAYED-STOPPED quiescence below.
+    const sawStopThisTurn =
+      running.sawRunningTrue &&
+      running.runStartCount > baselineRunStartCount &&
+      running.runningNow === false;
+    // STAYED-STOPPED quiescence bookkeeping. Track that the stop has PERSISTED
+    // for `settleMs` on the SAME `runStartCount` (no newer run started). A new
+    // run-start (`runStartCount` changed) or a non-stop poll resets the
+    // window, so an intermediate stop — immediately followed by a re-start
+    // that bumps `runStartCount` — can never accumulate the window; only the
+    // FINAL stop that stays stopped does. This is the temporal guard the
+    // `data-copilot-running` done-signal needs so completion cannot fire on a
+    // transient intermediate edge (mirroring the text path's `settleMs`).
+    if (sawStopThisTurn) {
+      if (running.runStartCount !== stopStableRunStartCount) {
+        // First poll of a (new) stop edge for this run generation: arm the
+        // window. A bumped `runStartCount` here means a newer run started and
+        // then stopped — a DIFFERENT stop edge — so we re-arm from `now`.
+        stopStableSince = now;
+        stopStableRunStartCount = running.runStartCount;
+      }
+    } else {
+      // Not stopped this poll (still running, re-started, or never started):
+      // disarm — a stop must be CONTINUOUS across the settle window.
+      stopStableSince = null;
+      stopStableRunStartCount = -1;
+    }
+    const stopQuiescent =
+      sawStopThisTurn &&
+      stopStableSince !== null &&
+      now - stopStableSince >= settleMs;
+    const domSignalAvailable = running.attrPresent;
+    // The DONE-signal. When the trustworthy DOM signal is AVAILABLE it is the
+    // SOLE done-signal: the `data-copilot-running` true→false transition that
+    // has STAYED stopped for the settle window (`stopQuiescent`) — and ONLY
+    // that. Requiring quiescence (not the bare `sawStopThisTurn` edge) is what
+    // prevents completion on a transient INTERMEDIATE stop between sub-runs —
+    // the false-green the surface-mount path (which has no text-stability
+    // window of its own) was exposed to. The fragile SSE fetch-counter must
+    // NOT be able to satisfy the done-signal here, because on a MULTI-STEP
+    // turn `sseOk = runsFinished >= turnIndex` goes true after the FIRST
+    // sub-run's RUN_FINISHED and STAYS true for the rest of the turn — so an
+    // `|| sseOk` disjunct would let that stale counter SOLELY drive completion
+    // on an INTERMEDIATE stop (a new sub-run still to come). SSE is the
+    // FALLBACK done-signal ONLY when the DOM signal is unavailable (headless
+    // demos never render `CopilotChatView`, so `data-copilot-running` is
+    // absent) — never an OR-trigger alongside a present DOM signal. (The SSE
+    // counter is monotonic per turn and the headless path has no run-start
+    // generations to distinguish, so it carries no transient-edge hazard.)
+    const doneSignalOk = domSignalAvailable ? stopQuiescent : sseOk;
     // Defect-2 protection: a new bubble has appeared for THIS turn — not
     // just "any bubble exists". `count > baselineCount` rejects a leftover
     // bubble from a prior turn while accepting multi-step turns where >1
@@ -1730,21 +2027,124 @@ export async function waitForTurnComplete(
       text !== null && text.trim().length > 0 && now - lastChangeAt >= settleMs;
     // Third conjunct: text-stability by default, OR surface-mount when the
     // turn opted in via `completeOnMount` (surfaceReady != null). The
-    // surface-mount path is checked ONLY once SSE + DOM hold, so completion
-    // still requires the run to have finished and a new assistant bubble to
-    // exist — we only swap WHAT the third signal is (rendered surface vs.
-    // stable text). This is what makes the tool-rendered A2UI-declarative
-    // demo (no assistant text bubble ever stabilises) complete on its
-    // rendered dashboard instead of timing out as `text-unstable`.
+    // surface-mount path is checked ONLY once the done-signal + DOM hold, so
+    // completion still requires the run to have finished and a new assistant
+    // bubble to exist — we only swap WHAT the third signal is (rendered
+    // surface vs. stable text). This is what makes the tool-rendered
+    // A2UI-declarative demo (no assistant text bubble ever stabilises)
+    // complete on its rendered dashboard instead of timing out.
+    // ATOMICITY + EFFICIENCY: read the live surface state AT MOST ONCE per
+    // poll and reuse the single value for BOTH the main-completion conjunct
+    // (`thirdOk`) and the `done-signal-missing` backstop conjunct
+    // (`thirdConjunctHeld`) below. Previously `surfaceReady(page)` — a real
+    // `page.evaluate` DOM round-trip — was read once for `thirdOk` (gated on
+    // `doneSignalOk && domOk` via short-circuit) AND again for
+    // `thirdConjunctHeld`, so a poll where the done-signal + DOM held but the
+    // surface had NOT yet mounted paid TWO round-trips and discarded the
+    // second. The two reads
+    // were also NON-ATOMIC: a surface that mounts BETWEEN them makes the two
+    // conjuncts observe DIFFERENT live values within one iteration — a latent
+    // disagreement hazard. A single read removes the wasted round-trip and
+    // guarantees `thirdOk` and `thirdConjunctHeld` agree on the same value.
+    // `null` (text-path) skips the read entirely.
+    const surfaceMounted =
+      surfaceReady !== null ? await surfaceReady(page) : false;
     const thirdOk =
-      surfaceReady !== null
-        ? sseOk && domOk && (await surfaceReady(page))
-        : textOk;
-    if (sseOk && domOk && thirdOk) {
+      surfaceReady !== null ? doneSignalOk && domOk && surfaceMounted : textOk;
+    if (doneSignalOk && domOk && thirdOk) {
       // bubbleIndex returned = last bubble in the matched tier at the
       // moment of return, so callers consuming the assertions ctx see the
       // same bubble whose text settled (or whose turn's surface mounted).
       return { bubbleIndex: count - 1, text: text ?? "" };
+    }
+    // DONE-SIGNAL BACKSTOP — catches the silent multi-step hang and REDS
+    // it EARLY (at `maxTurnDurationMs`, well before the hard `timeoutMs`).
+    // GATED on the trustworthy DOM signal being AVAILABLE (`domSignalAvailable`
+    // / `attrPresent === true`) — see the DOM-SIGNAL GATE note below. When the
+    // DOM signal is present and DOM + the third conjunct (text-stable /
+    // surface-mounted) have held but the done-signal has NOT confirmed
+    // (`!doneSignalOk` — the `data-copilot-running` true→false transition never
+    // STAYED stopped) by `maxTurnDurationMs`, the bubble is painted and settled
+    // yet the run never finished → throw RED rather than waiting out the full
+    // `timeoutMs` (and rather than EVER false-greening on DOM+text alone). The
+    // log/error below dumps BOTH raw counters for diagnosis. Classified
+    // `done-signal-missing` so the operator sees the missing completion, not
+    // the (present) text/surface. HEADLESS turns (`attrPresent === false`) are
+    // NOT eligible for this early backstop — they have no authoritative signal
+    // that can be "missing" and their lagging SSE counter must be allowed the
+    // full `timeoutMs`; a genuinely-stuck headless turn reds at the hard
+    // ceiling as `sse-missing` via the post-loop classifier. Reuses the single
+    // per-poll `surfaceMounted` read (see ATOMICITY note above) so this
+    // backstop conjunct and `thirdOk` agree on the same live surface value.
+    //
+    // RUNNING GUARD (`running.runningNow !== true`): the backstop must NEVER
+    // red a turn that is still LEGITIMATELY running. A gen-UI turn can paint
+    // its surface early while the run is still going; its stop edge may simply
+    // land after `maxTurnDurationMs` but before the hard `timeoutMs`. Without
+    // this guard such a turn false-REDS the moment `maxTurnDurationMs` elapses
+    // even though it is healthily in flight. The backstop's job is the
+    // painted-and-settled-but-finished-signal-MISSING case, where the run is
+    // NOT currently running (`runningNow` is false, or absent → `null`). A
+    // genuinely hung run whose `runningNow` is stuck `true` still reds — at
+    // the hard `timeoutMs` via the post-loop classifier, not here.
+    //
+    // ARMING-STOP GUARD (`stopStableSince === null`): once a stop edge has
+    // been observed it is ARMING toward quiescence — the very next poll(s) may
+    // satisfy the `settleMs` STAYED-STOPPED window and COMPLETE the turn. If
+    // `maxTurnDurationMs` happens to have already elapsed while the run was
+    // still in flight, the run's stop edge lands AFTER the backstop deadline;
+    // without this guard the backstop would red on the FIRST stopped poll,
+    // before the quiescence window (`settleMs`) could be satisfied — racing
+    // the legitimate completion it would otherwise produce one poll later. We
+    // therefore defer the backstop while a stop edge is arming. A genuine hang
+    // never arms a stop (`sawStopThisTurn` stays false → `stopStableSince`
+    // stays `null`), so the backstop still reds it.
+    //
+    // DOM-SIGNAL GATE (`domSignalAvailable` / `running.attrPresent === true`):
+    // the EARLY (`maxTurnDurationMs`) backstop applies ONLY when the
+    // trustworthy DOM run-signal is AVAILABLE. With the DOM signal present,
+    // `!doneSignalOk` means the `data-copilot-running` true→false transition we
+    // SHOULD have seen has not arrived — a meaningful "the run lifecycle says
+    // there should be a transition but there isn't" hang signal — so redding
+    // early (rather than waiting out the full `timeoutMs`) is correct. For
+    // HEADLESS turns (`attrPresent === false`: no `CopilotChatView`, so
+    // `data-copilot-running` is absent) there is NO authoritative done-signal
+    // that can be "missing"; the SOLE signal is the fragile SSE fetch-counter,
+    // which the comments above document as prone to LAGGING. Early-redding a
+    // healthy-but-lagging headless turn at `maxTurnDurationMs` (≈0.6×timeoutMs)
+    // is a FALSE-RED on the exact fragile-SSE mode this PR exists to eliminate
+    // — origin/main (no backstop) let such a turn run to the full timeout, by
+    // which point the counter usually catches up (→ green). Both of the guards
+    // above are INERT for headless (`runningNow` is `null`, never `true`;
+    // `sawRunningTrue` is false so `stopStableSince` stays `null`), so without
+    // this gate the early backstop would fire on every painted+settled headless
+    // turn whose SSE counter merely lagged. A GENUINELY-stuck headless turn
+    // (counter never catches up) still REDS — at the hard `timeoutMs` via the
+    // post-loop classifier as `sse-missing`, exactly as origin/main did.
+    const thirdConjunctHeld = surfaceReady !== null ? surfaceMounted : textOk;
+    if (
+      domSignalAvailable &&
+      !doneSignalOk &&
+      running.runningNow !== true &&
+      stopStableSince === null &&
+      domOk &&
+      thirdConjunctHeld &&
+      now - startedAt >= maxTurnDurationMs
+    ) {
+      console.warn(
+        formatCvdiag({
+          component: "conversation-runner",
+          boundary: "inbound",
+          status: "error",
+          error: `done-signal-missing backstop: turn ${turnIndex} bubble painted + settled but neither data-copilot-running transition nor SSE counter confirmed within ${maxTurnDurationMs}ms (attrPresent=${running.attrPresent}, runningNow=${String(running.runningNow)}, sawRunningTrue=${running.sawRunningTrue}, runStartCount=${running.runStartCount}, baselineRunStartCount=${baselineRunStartCount}, runsFinished=${runsFinished})`,
+        }),
+      );
+      throw new TurnNotCompleteError(
+        "done-signal-missing",
+        turnIndex,
+        now - startedAt,
+        `waitForTurnComplete: turn ${turnIndex} bubble settled but no done-signal (data-copilot-running transition or SSE counter) confirmed within maxTurnDurationMs=${maxTurnDurationMs}ms (reason=done-signal-missing, attrPresent=${running.attrPresent}, runningNow=${String(running.runningNow)}, runStartCount=${running.runStartCount}, runsFinished=${runsFinished}, count=${count})`,
+      );
     }
     // Pre-conjunct banner fast-fail guard. We ONLY fire fast-fail when the
     // assistant hasn't yet produced a response for THIS turn (domOk =
@@ -1795,24 +2195,62 @@ export async function waitForTurnComplete(
   // exactly between the last poll and the deadline should classify as
   // "we didn't see it in time", which the final read reproduces faithfully.
   const runsFinishedFinal = await readRunsFinished(page);
+  const runningFinal = await readCopilotRunning(page);
   const countFinal = await countAssistantMessages(pwPage);
-  // Precedence: blame the earliest signal that hadn't arrived. The third
-  // signal differs by completion mode: `surface-missing` when the turn
-  // opted into surface-mount completion (`surfaceReady` set), else the
-  // historical `text-unstable`. SSE/DOM precedence is identical for both
-  // modes (those two conjuncts are shared).
-  const reason: TurnNotCompleteError["reason"] =
-    runsFinishedFinal < turnIndex
+  // Recompute the loop's done-signal predicate at the final read so the
+  // classifier agrees with the gate: with the DOM signal available the
+  // done-signal is SOLELY "saw a stop THIS turn" (the trustworthy DOM
+  // transition); the fragile SSE counter is NOT an OR-trigger here (it would
+  // false-green an intermediate multi-step stop — see the loop predicate).
+  // Headless (DOM signal absent) falls back to the SSE counter alone.
+  const sawStopFinal =
+    runningFinal.sawRunningTrue &&
+    runningFinal.runStartCount > baselineRunStartCount &&
+    runningFinal.runningNow === false;
+  const doneSignalOkFinal = runningFinal.attrPresent
+    ? sawStopFinal
+    : runsFinishedFinal >= turnIndex;
+  const domOkFinal = countFinal > baselineCount;
+  // Precedence: blame the earliest signal that hadn't arrived. The blamed
+  // reason differs by whether the trustworthy DOM run-signal was available.
+  //
+  //   1. No new bubble for this turn (`!domOkFinal`):
+  //        - HEADLESS (attribute absent): the legacy SSE-counter conjunct is
+  //          the only done-signal; if it never caught up, blame `sse-missing`
+  //          (preserves the pre-fix headless classification + operator
+  //          log-greps); otherwise `dom-missing`.
+  //        - DOM-signal present: `dom-missing` (nothing rendered).
+  //   2. A bubble rendered (`domOkFinal`) but the done-signal never confirmed
+  //      (`!doneSignalOkFinal`):
+  //        - DOM-signal present: `done-signal-missing` — the
+  //          `data-copilot-running` true→false transition never fired (the
+  //          SOLE done-signal when the DOM signal is available). This is the
+  //          silent-hang case the backstop reds. The SSE counter is NOT
+  //          consulted here: with the DOM signal present a bare missing SSE
+  //          counter is never blamed as `sse-missing` (that WAS the false-red),
+  //          and a PRESENT-but-stale SSE counter must not green an
+  //          intermediate multi-step stop — both fold into the DOM-transition
+  //          decision, classified `done-signal-missing`.
+  //        - HEADLESS: the SSE counter is the sole done-signal; a missing one
+  //          stays `sse-missing` (legacy semantics — the headless path has no
+  //          DOM transition to fold into `done-signal-missing`).
+  //   3. The done-signal DID confirm but the third conjunct never settled →
+  //      `surface-missing` (surface-mount mode) / `text-unstable`.
+  const reason: TurnNotCompleteError["reason"] = !domOkFinal
+    ? !runningFinal.attrPresent && runsFinishedFinal < turnIndex
       ? "sse-missing"
-      : countFinal <= baselineCount
-        ? "dom-missing"
-        : surfaceReady !== null
-          ? "surface-missing"
-          : "text-unstable";
+      : "dom-missing"
+    : !doneSignalOkFinal
+      ? runningFinal.attrPresent
+        ? "done-signal-missing"
+        : "sse-missing"
+      : surfaceReady !== null
+        ? "surface-missing"
+        : "text-unstable";
   throw new TurnNotCompleteError(
     reason,
     turnIndex,
     Date.now() - startedAt,
-    `waitForTurnComplete: turn ${turnIndex} did not complete within ${timeoutMs}ms (reason=${reason}, runsFinished=${runsFinishedFinal}, count=${countFinal})`,
+    `waitForTurnComplete: turn ${turnIndex} did not complete within ${timeoutMs}ms (reason=${reason}, runsFinished=${runsFinishedFinal}, count=${countFinal}, attrPresent=${runningFinal.attrPresent}, runningNow=${String(runningFinal.runningNow)}, runStartCount=${runningFinal.runStartCount})`,
   );
 }

--- a/showcase/harness/src/probes/helpers/sse-interceptor.ts
+++ b/showcase/harness/src/probes/helpers/sse-interceptor.ts
@@ -629,6 +629,142 @@ function buildPageSideCounterScript(endpointPattern: string | RegExp): string {
 }
 
 /**
+ * Build the page-side init script that observes CopilotKit v2's
+ * `data-copilot-running` attribute and latches the run lifecycle into
+ * `window.__hk_copilotRunning` for `waitForTurnComplete`'s PRIMARY
+ * done-signal.
+ *
+ * Why a page-side MutationObserver rather than a per-poll
+ * `getAttribute` read: CopilotKit v2 renders
+ * `data-copilot-running="true|false"` on `[data-testid="copilot-chat"]`
+ * driven by the agent run lifecycle (RUN_STARTED → true, RUN_FINISHED →
+ * false). On fast aimock replays the `true` window can be shorter than
+ * `waitForTurnComplete`'s 100ms poll cadence, so a sampling read could
+ * miss the `true` entirely and never observe the true→false transition.
+ * A MutationObserver installed at document_start latches every
+ * transition the moment it happens, so the SUT reads an
+ * EDGE-ACCURATE summary regardless of poll timing:
+ *
+ *   - `attrPresent`     — true once the `[data-testid="copilot-chat"]`
+ *                         element bearing `data-copilot-running` has been
+ *                         seen in the DOM. Distinguishes the v2-chat case
+ *                         (attribute present → DOM signal is trustworthy)
+ *                         from the HEADLESS case (bring-your-own-UI demos
+ *                         like `headless-simple` never render
+ *                         `CopilotChatView`, so the attribute is absent
+ *                         and the gate must fall back to the SSE counter).
+ *   - `runningNow`      — the LIVE value of the attribute (true while a
+ *                         run is in flight). `null` when never observed.
+ *   - `sawRunningTrue`  — latched once the attribute has EVER gone "true".
+ *                         The PRIMARY done-signal gates on the TRANSITION
+ *                         (saw-true-then-stopped), NOT on a bare
+ *                         `=== "false"` — because "false" is also the
+ *                         never-started baseline state, which must not be
+ *                         mistaken for a completed turn.
+ *   - `runStartCount`   — count of false→true edges (RUN_STARTED). A
+ *                         multi-step turn toggles false→true→false→true→…
+ *                         between sub-runs, so the gate uses this to
+ *                         reject completion on an INTERMEDIATE false (a
+ *                         new run started after the last stop).
+ *   - `lastStoppedAtMs` — wall-clock ms of the most recent true→false
+ *                         edge (RUN_FINISHED). `0` when never stopped.
+ *                         The gate requires the stop to have STAYED
+ *                         stopped (no newer start) for the settle window.
+ *
+ * Idempotent (sentinel `__hk_runObserverInstalled`) and self-contained —
+ * same string-IIFE rationale as `buildPageSideCounterScript`: a
+ * function-form `addInitScript` payload can pick up tsx-injected helper
+ * symbols the page context cannot resolve, silently no-op'ing at
+ * document_start.
+ */
+function buildCopilotRunningObserverScript(): string {
+  return `
+    (function() {
+      var g = globalThis;
+      if (g.__hk_runObserverInstalled === true) return;
+      g.__hk_runObserverInstalled = true;
+      if (!g.__hk_copilotRunning) {
+        g.__hk_copilotRunning = {
+          attrPresent: false,
+          runningNow: null,
+          sawRunningTrue: false,
+          runStartCount: 0,
+          lastStoppedAtMs: 0
+        };
+      }
+      var SEL = '[data-testid="copilot-chat"]';
+      var ATTR = 'data-copilot-running';
+      function readAttr() {
+        try {
+          var doc = g.document;
+          if (!doc || typeof doc.querySelector !== 'function') return undefined;
+          var el = doc.querySelector(SEL);
+          if (!el || typeof el.getAttribute !== 'function') return undefined;
+          var raw = el.getAttribute(ATTR);
+          if (raw === null) return undefined;
+          return raw === 'true';
+        } catch (_) {
+          return undefined;
+        }
+      }
+      function record(val) {
+        // val: true | false | undefined (attribute absent)
+        var st = g.__hk_copilotRunning;
+        if (val === undefined) return; // attribute not present on this read
+        st.attrPresent = true;
+        var prev = st.runningNow;
+        if (val === true) {
+          // false/null -> true edge = a (sub-)run started.
+          if (prev !== true) {
+            st.runStartCount = (st.runStartCount | 0) + 1;
+          }
+          st.sawRunningTrue = true;
+          st.runningNow = true;
+        } else {
+          // -> false. Record a stop edge only when we were running (or
+          // had ever run) so the never-started baseline 'false' does not
+          // stamp a bogus lastStoppedAtMs.
+          if (prev === true) {
+            st.lastStoppedAtMs = Date.now();
+          }
+          st.runningNow = false;
+        }
+      }
+      function scan() {
+        record(readAttr());
+      }
+      // Prime once in case the element + attribute already exist at
+      // observer-install time (e.g. addInitScript ran but the chat view
+      // hydrated before our first mutation callback).
+      scan();
+      try {
+        var mo = new MutationObserver(function() { scan(); });
+        // Observe the whole subtree: the chat element may not exist yet
+        // at document_start (React mounts it later), and once it does we
+        // need attribute mutations on it. Observing document with
+        // subtree + attribute filter catches both the initial mount and
+        // every subsequent data-copilot-running flip.
+        var target = g.document && g.document.documentElement
+          ? g.document.documentElement
+          : g.document;
+        if (target && mo && typeof mo.observe === 'function') {
+          mo.observe(target, {
+            subtree: true,
+            childList: true,
+            attributes: true,
+            attributeFilter: [ATTR]
+          });
+        }
+      } catch (_) {
+        // MutationObserver unavailable (ancient/headless shell) — the
+        // primed scan above still seeds whatever was present at install,
+        // and waitForTurnComplete's per-poll read falls back gracefully.
+      }
+    })();
+  `;
+}
+
+/**
  * Attach a CDP-based SSE interceptor to a Playwright page.
  *
  * The handler returned by `stop()` detaches all CDP listeners, fetches
@@ -697,6 +833,17 @@ export async function attachSseInterceptor(
   // `SseCapture.raw_event_count` at `stop()`-time for the parity
   // engine, and stays the authoritative end-of-run count.
   await page.addInitScript(buildPageSideCounterScript(endpointPattern));
+
+  // Page-side run-lifecycle observer: latch CopilotKit v2's
+  // `data-copilot-running` attribute transitions into
+  // `window.__hk_copilotRunning` so `waitForTurnComplete` has a
+  // TRANSPORT-INDEPENDENT (no fetch-monkeypatch) PRIMARY done-signal.
+  // Rides the SAME page lifecycle as the SSE counter above so the two
+  // signals are always co-present (the gate prefers the DOM signal when
+  // `attrPresent` and falls back to the fetch counter when absent —
+  // headless bring-your-own-UI demos). Idempotent on the page side via
+  // its own `__hk_runObserverInstalled` sentinel.
+  await page.addInitScript(buildCopilotRunningObserverScript());
 
   // Newer Playwright versions expose `page.context().newCDPSession(page)`;
   // older ones only `browserContext.newCDPSession`. Both APIs return the

--- a/showcase/harness/test/integration/wait-for-turn-complete.test.ts
+++ b/showcase/harness/test/integration/wait-for-turn-complete.test.ts
@@ -71,23 +71,27 @@ interface ScriptStep {
  */
 function makeScriptedPage(script: ScriptStep[]) {
   let tickIdx = 0;
-  let evalsInTick = 0;
   const currentStep = (): ScriptStep =>
     script[Math.min(tickIdx, script.length - 1)];
   return {
     async evaluate(fn: unknown, arg?: unknown): Promise<unknown> {
       const body = String(fn);
       const step = currentStep();
-      evalsInTick += 1;
-      // Every 2 evals advances one script step (sse + cascade state).
-      // Post-r4f2 (commit 6a98baef1) the runner uses the atomic
-      // `readCascadeState` helper so each poll makes TWO evaluates,
-      // not three.
-      if (evalsInTick >= 2) {
-        evalsInTick = 0;
-        tickIdx += 1;
-      }
       if (body.includes("__hk_runsFinished")) return step.runsFinished;
+      // CopilotKit v2 run-lifecycle summary (`__hk_copilotRunning`) — the
+      // PRIMARY done-signal. These mechanism scripts model the legacy
+      // SSE-counter world (no chat-view attribute), so return the
+      // "attribute absent" shape; the gate falls back to the SSE counter,
+      // preserving the exact pre-fix conjunct semantics these tests assert.
+      if (body.includes("__hk_copilotRunning")) {
+        return {
+          attrPresent: false,
+          runningNow: null,
+          sawRunningTrue: false,
+          runStartCount: 0,
+          lastStoppedAtMs: 0,
+        };
+      }
       // Atomic cascade-state read (`readCascadeState`): returns BOTH the
       // count and the indexed text from the SAME cascade tier in ONE
       // round-trip. The distinguishing substring is the literal `{ count`
@@ -98,14 +102,21 @@ function makeScriptedPage(script: ScriptStep[]) {
         body.includes("textContent") &&
         body.includes("{ count")
       ) {
+        // The atomic cascade read is the once-per-poll anchor — advance the
+        // script tick HERE (rather than counting raw evaluates) so the
+        // script stays 1:1 with poll iterations regardless of how many
+        // auxiliary reads (`__hk_runsFinished`, `__hk_copilotRunning`) the
+        // primitive makes per poll. This is robust to the done-signal
+        // overhaul adding a third per-poll read.
         const idx = (arg as number | undefined) ?? 0;
-        if (idx < 0 || idx >= step.count) {
-          return { count: step.count, text: null };
-        }
-        // Only index 0 has populated text in our scripts; mirror the
-        // null-when-out-of-range behaviour of the production cascade.
-        const text = idx === 0 ? step.text : null;
-        return { count: step.count, text };
+        const result =
+          idx < 0 || idx >= step.count
+            ? { count: step.count, text: null }
+            : // Only index 0 has populated text in our scripts; mirror the
+              // null-when-out-of-range behaviour of the production cascade.
+              { count: step.count, text: idx === 0 ? step.text : null };
+        tickIdx += 1;
+        return result;
       }
       // Count-only re-read (`countAssistantMessages`): used by the
       // final-classification path AFTER the polling loop times out.


### PR DESCRIPTION
## Summary

Makes the showcase harness probe's turn-done signal **reliable**, killing the dominant class of dashboard false-red flaps without ever hiding a real failure.

`waitForTurnComplete` previously relied on a fragile SSE fetch-counter conjunct that false-reds healthy demos whenever the page-side fetch wrapper missed the runtime URL/transport. This change makes the **`data-copilot-running` DOM attribute** (driven directly by the agent run lifecycle, `RUN_STARTED`→true / `RUN_FINISHED`→false, transport-independent) the **PRIMARY** done-signal, with the SSE counter demoted to a **headless-only fallback** (headless demos never render `CopilotChatView`, so the attribute is absent).

Design (all three preserved — no false-green, no false-red, hangs still red):
- **Primary signal** = the `data-copilot-running` true→false **transition** with a **stayed-stopped quiescence window** (a stop must persist on the same run-start count for `settleMs`; a new sub-run resets it) — so it cannot complete on an intermediate stop in a multi-step turn.
- **SSE counter** = headless fallback only; never an OR-trigger when the DOM signal is present.
- **`done-signal-missing` backstop** (gated on `attrPresent===true` + `runningNow!==true`) reds a genuine painted-but-never-finished DOM turn before the hard timeout; headless turns use their full timeout for their only signal.

## How it was reviewed

A full 4-round `cr-loop` (7 unbiased agents/round + confirmation rounds + a Procedure-3 promotion audit) caught and fixed **5 distinct correctness defects** in the implementation before merge:
- **F1** — SSE OR-trigger could complete a multi-step turn early on an intermediate stop (false-GREEN), in both the loop and the post-loop classifier.
- **F2** — the run-start baseline was captured *after* the message send, killing the primary signal on fast turns (false-RED).
- **F3** — non-atomic double `surfaceReady` read per poll (latent hazard + wasted round-trip).
- **F4** — the surface-mount (`completeOnMount`) path had no quiescence window (false-GREEN on intermediate stop + false-RED on a still-running gen-UI turn).
- **F5** — the early backstop false-redded slow-but-healthy **headless** turns (now gated on the DOM signal).

Bidirectional red-green tests for F1–F5 plus a systematic `{DOM, headless} × {completes, lagging-recovers, genuine-hang} × {text, surface}` completion/backstop matrix. Full harness unit suite: **3173 passed / 18 skipped / 0 failed**; `tsc --noEmit` clean; lint 0 errors; build clean.

## Known follow-ups (NOT in this PR — pre-existing / non-blocking)

- **Theoretical edge (not reachable on real or realistically-streamed turns):** if a run completed within a single synchronous microtask (zero-duration), the page-side MutationObserver could miss the true edge while `attrPresent===true` → false-red. Real LLM turns and aimock realistic-streaming hold the attribute true across many event-loop ticks, so the observer reliably latches it. A naive "re-add SSE fallback for DOM-present" fix would reintroduce F1's multi-step false-green, so it's intentionally not done here.
- **Recommended quick follow-up (latency only, no wrong verdict):** capture `baselineBannerText` pre-`sendTurnMessage` (mirroring the run-start/count baselines) so a fast-erroring cold-start turn fast-fails (#5142) instead of burning the full timeout.
- **Pre-existing sse-interceptor capture/counter internals** (none load-bearing for the new done-signal; verified STAY_IN_C by the Procedure-3 audit): page-side counter soft-nav/multi-capture reset, `__hk_fetchWrapped` pattern reuse + hardcoded fallback, g/y-flag stateful RegExp, TextDecoder end-of-stream flush, bare-catch reader-error swallow, framenav payload discard/TOCTOU, CDP-wallTime-vs-Date.now TTFT, addInitScript/close-listener re-registration accumulation.

## Test plan

- [x] `pnpm test` (harness) — 3173 passed / 18 skipped / 0 failed
- [x] `tsc --noEmit` exit 0, lint 0 errors, build exit 0
- [ ] Verify on staging that auth / prebuilt-sidebar / claude-sdk-tools (and other previously-flapping cells) stop false-redding while genuinely-broken cells stay red

Please review the replay/primary-signal approach. Not auto-merging.