### PR TITLE
fix(showcase): skip non-probe-eligible services in staging precondition instead of crashing

### DIFF
--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -176,7 +176,17 @@ jobs:
           # authoritative. CI verify history is a leading indicator only.
           # Run from showcase/scripts (where `npm ci` installed tsx) so npx
           # uses the local install instead of network-fetching it.
-          npx tsx verify-deploy.ts --env staging --services "$SERVICES_CSV"
+          #
+          # --skip-ineligible: SERVICES_CSV is the PROMOTE target set, which
+          # for `service=all` legitimately includes services that are
+          # promotable but NOT staging-probe-eligible (the starter-* fleet
+          # carries probe.staging=false in the SSOT). Those are an expected
+          # state here, not a fault — verify-deploy SKIPS them with a clear
+          # status line and probes only the eligible services, rather than
+          # hard-crashing the whole precondition on the first starter-*. This
+          # flag does NOT relax green for eligible services, nor does it
+          # tolerate an unknown (non-SSOT) name — a typo is still a hard error.
+          npx tsx verify-deploy.ts --env staging --services "$SERVICES_CSV" --skip-ineligible
 
   promote:
     needs: [resolve-targets, verify-staging-precondition]

--- a/showcase/scripts/__tests__/verify-deploy.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.test.ts
@@ -6,6 +6,7 @@ import {
   runVerify,
 } from "../verify-deploy";
 import type { ProbeRunner } from "../verify-deploy";
+import { SERVICES, probeEnabled } from "../railway-envs";
 
 describe("verify-deploy argv parsing", () => {
   it("requires --env", () => {
@@ -40,6 +41,22 @@ describe("verify-deploy argv parsing", () => {
     expect(() => parseArgs(["--env=staging", "--services", ",,"])).toThrow(
       /--services requires a CSV value/,
     );
+  });
+
+  it("defaults skipIneligible to false (strict mode)", () => {
+    const parsed = parseArgs(["--env", "staging"]);
+    expect(parsed.skipIneligible).toBeFalsy();
+  });
+
+  it("accepts --skip-ineligible (opt-in skip of probe.staging=false services)", () => {
+    const parsed = parseArgs([
+      "--env",
+      "staging",
+      "--services",
+      "docs",
+      "--skip-ineligible",
+    ]);
+    expect(parsed.skipIneligible).toBe(true);
   });
 
   it("rejects bare trailing --env (no following value)", () => {
@@ -105,6 +122,51 @@ describe("resolveProbeTargets", () => {
     // than "not probe-eligible". The two paths must be distinguished.
     expect(() =>
       resolveProbeTargets({ env: "staging", services: ["totally-fake"] }),
+    ).toThrow(/unknown service/i);
+  });
+
+  it("REFUSES a non-probe-eligible service by default (strict mode for explicit probes)", () => {
+    // Find a real SSOT service whose probe.staging===false (e.g. a
+    // starter-*). The default (strict) path must still throw the
+    // distinct "not probe-eligible" error — an operator who explicitly
+    // typed a single non-eligible service deserves a hard refusal.
+    const ineligible = Object.keys(SERVICES).find(
+      (n) => SERVICES[n] !== undefined && !probeEnabled(n, "staging"),
+    );
+    expect(ineligible).toBeDefined();
+    expect(() =>
+      resolveProbeTargets({ env: "staging", services: [ineligible as string] }),
+    ).toThrow(/not probe-eligible/i);
+  });
+
+  it("SKIPS non-probe-eligible services (skipIneligible) instead of crashing, keeping eligible ones", () => {
+    // The promote precondition probes the FULL promote set (service=all),
+    // which legitimately includes non-probe-eligible starters
+    // (probe.staging=false). Those must be SKIPPED, not crash the run.
+    const ineligible = Object.keys(SERVICES).find(
+      (n) => SERVICES[n] !== undefined && !probeEnabled(n, "staging"),
+    );
+    expect(ineligible).toBeDefined();
+    // "docs" is probe.staging=true — must survive the skip filter.
+    const targets = resolveProbeTargets({
+      env: "staging",
+      services: ["docs", ineligible as string],
+      skipIneligible: true,
+    });
+    const names = targets.map((t) => t.name);
+    expect(names).toContain("docs");
+    expect(names).not.toContain(ineligible);
+  });
+
+  it("still REFUSES an unknown service even with skipIneligible (typo is a real error, not a skip)", () => {
+    // skipIneligible only relaxes the probe.staging=false case; a name
+    // that is not in the SSOT at all is still a hard error.
+    expect(() =>
+      resolveProbeTargets({
+        env: "staging",
+        services: ["docs", "totally-fake"],
+        skipIneligible: true,
+      }),
     ).toThrow(/unknown service/i);
   });
 
@@ -244,6 +306,31 @@ describe("runVerify driver dispatch", () => {
       services: ["docs"],
       runner: async () => ({ ok: true }),
     });
+    expect(summary.exitCode).toBe(0);
+  });
+
+  it("with skipIneligible, exits 0 probing only eligible services when the set mixes in non-eligible ones", async () => {
+    // Mirrors the promote precondition `service=all` shape: a
+    // probe-eligible service (docs) mixed with a probe.staging=false
+    // service (a starter-*). The eligible one is probed normally; the
+    // ineligible one is skipped — no crash, exit 0 when greens pass.
+    const ineligible = Object.keys(SERVICES).find(
+      (n) => SERVICES[n] !== undefined && !probeEnabled(n, "staging"),
+    );
+    expect(ineligible).toBeDefined();
+    const calls: string[] = [];
+    const runner: ProbeRunner = async (target) => {
+      calls.push(target.name);
+      return { ok: true };
+    };
+    const summary = await runVerify({
+      env: "staging",
+      services: ["docs", ineligible as string],
+      skipIneligible: true,
+      runner,
+    });
+    expect(calls).toContain("docs");
+    expect(calls).not.toContain(ineligible);
     expect(summary.exitCode).toBe(0);
   });
 

--- a/showcase/scripts/verify-deploy.ts
+++ b/showcase/scripts/verify-deploy.ts
@@ -28,11 +28,21 @@ import type { EnvName, ProbeDriver } from "./railway-envs";
 export interface ParsedArgs {
   env: EnvName;
   services?: string[];
+  /**
+   * Opt-in: when a `--services` filter names a service that exists in the
+   * SSOT but is NOT probe-eligible for `--env` (`probe.<env>=false`), SKIP
+   * it with a clear status line instead of throwing. Off by default so an
+   * explicit single-service probe still hard-refuses a non-eligible name;
+   * the promote staging precondition (which probes the FULL promote set,
+   * legitimately mixing in non-eligible starters) passes this flag.
+   */
+  skipIneligible?: boolean;
 }
 
 export function parseArgs(argv: string[]): ParsedArgs {
   let envRaw: string | undefined;
   let services: string[] | undefined;
+  let skipIneligible = false;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--env") {
@@ -78,6 +88,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       if (services.length === 0) {
         throw new Error("--services requires a CSV value");
       }
+    } else if (a === "--skip-ineligible") {
+      skipIneligible = true;
     } else {
       throw new Error(`Unknown argument: ${a}`);
     }
@@ -86,7 +98,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
     throw new Error("--env is required (staging|prod)");
   }
   const { env } = resolveEnv(envRaw);
-  return services === undefined ? { env } : { env, services };
+  const base: ParsedArgs = { env, skipIneligible };
+  return services === undefined ? base : { ...base, services };
 }
 
 /**
@@ -208,6 +221,14 @@ export interface ResolveOpts {
   env: EnvName;
   services?: string[];
   /**
+   * When true, a `--services` entry that is in the SSOT but not
+   * probe-eligible for `env` (`probe.<env>=false`) is SKIPPED (with a
+   * status line) rather than throwing. Unknown (non-SSOT) names are STILL
+   * a hard error — a typo is a real fault, not a legitimate skip. See
+   * `ParsedArgs.skipIneligible`.
+   */
+  skipIneligible?: boolean;
+  /**
    * Test seam: shallow-merge a partial entry over the SSOT before resolve.
    * `domains` is keyed by env name (matches the open `EnvName`); callers
    * supply at least the env under test.
@@ -222,6 +243,15 @@ export function resolveProbeTargets(opts: ResolveOpts): ProbeTarget[] {
   // filtering — a typo (`docss`) or a name that's not probe-eligible
   // for the target env must surface as a clear, distinct error, not a
   // silent zero-targets vacuous green.
+  //
+  // EXCEPTION (opts.skipIneligible): the promote staging precondition
+  // probes the FULL promote set (service=all), which legitimately mixes
+  // in services that are promotable but NOT probe-eligible for staging
+  // (the starter-* fleet carries probe.staging=false in the SSOT). For
+  // that caller a non-eligible service is an expected state, not a fault,
+  // so SKIP it (with a clear status line) instead of crashing the gate.
+  // An UNKNOWN (non-SSOT) name stays a hard error on BOTH paths — a typo
+  // is a real fault, never a legitimate skip.
   if (filter) {
     for (const name of filter) {
       const entry = SERVICES[name];
@@ -231,6 +261,12 @@ export function resolveProbeTargets(opts: ResolveOpts): ProbeTarget[] {
         );
       }
       if (!probeEnabled(name, opts.env)) {
+        if (opts.skipIneligible) {
+          process.stdout.write(
+            `  ${name.padEnd(36)} (skipped — not probe-eligible for ${opts.env}, probe.${opts.env}=false)\n`,
+          );
+          continue;
+        }
         throw new Error(
           `service "${name}" is not probe-eligible for env "${opts.env}" (probe.${opts.env}=false in SSOT)`,
         );
@@ -267,6 +303,8 @@ export function resolveProbeTargets(opts: ResolveOpts): ProbeTarget[] {
 export interface VerifyOpts {
   env: EnvName;
   services?: string[];
+  /** See `ResolveOpts.skipIneligible` — forwarded to resolveProbeTargets. */
+  skipIneligible?: boolean;
   runner?: ProbeRunner;
 }
 
@@ -281,6 +319,7 @@ export async function runVerify(opts: VerifyOpts): Promise<VerifySummary> {
   const targets = resolveProbeTargets({
     env: opts.env,
     services: opts.services,
+    skipIneligible: opts.skipIneligible,
   });
   const runner = opts.runner ?? runDriver;
   const passed: Array<{ name: string }> = [];


### PR DESCRIPTION
## Summary

A `service=all` promote runs `verify-staging-precondition` → `verify-deploy.ts --env staging --services <all>`, which **hard-crashes** (exit 2) the moment it's handed a service with `probe.staging=false` (`resolveProbeTargets` throws `not probe-eligible`). That failed the whole-fleet precondition. This adds an opt-in `--skip-ineligible` flag (wired into the `verify-staging-precondition` step **only**) that skips a non-probe-eligible service with a clear status line instead of throwing; eligible services are still probed normally, and an explicit single-service probe / unknown name still hard-fails (strict default preserved; `verify-prod` untouched).

After #5641 (starters always-on), the only remaining `probe.staging=false` services are **`harness-workers`** and **`harness-legacy`** — empirically confirmed to still crash a `service=all` precondition, so this fix is still needed (the starters that originally triggered it are now eligible and probed normally).

## Verification
- Red-green (vitest, real surface): a service list containing `harness-workers` crashes WITHOUT the flag, and is SKIPPED (`harness-workers (skipped — not probe-eligible for staging, probe.staging=false)`) WITH it.
- verify-deploy suite: 124/124 pass. `tsc --noEmit` clean on changed files. `actionlint` on the workflow: exit 0.

## Test plan
- [x] vitest verify-deploy suite green (124)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)