### PR TITLE
docs: add framework-scoped Threads callouts

### DIFF
--- a/showcase/integrations/google-adk/manifest.yaml
+++ b/showcase/integrations/google-adk/manifest.yaml
@@ -72,6 +72,7 @@ not_supported_features:
   - agentic-chat-reasoning
   - tool-rendering-reasoning-chain
 a2ui_pattern: schema-loading
+thread_persistence_pattern: adk-session
 agent_config_pattern: shared-state
 auth_pattern: runtime-onrequest
 demos:

--- a/showcase/integrations/langgraph-fastapi/manifest.yaml
+++ b/showcase/integrations/langgraph-fastapi/manifest.yaml
@@ -72,6 +72,7 @@ features:
   - open-gen-ui-advanced
 a2ui_pattern: schema-loading
 interrupt_pattern: native
+thread_persistence_pattern: langgraph
 agent_config_pattern: shared-state
 auth_pattern: langgraph
 demos:

--- a/showcase/integrations/langgraph-python/manifest.yaml
+++ b/showcase/integrations/langgraph-python/manifest.yaml
@@ -76,6 +76,7 @@ features:
   - agent-config
 a2ui_pattern: schema-loading
 interrupt_pattern: native
+thread_persistence_pattern: langgraph
 agent_config_pattern: shared-state
 auth_pattern: langgraph
 demos:

--- a/showcase/integrations/langgraph-typescript/manifest.yaml
+++ b/showcase/integrations/langgraph-typescript/manifest.yaml
@@ -76,6 +76,7 @@ features:
   - open-gen-ui-advanced
 a2ui_pattern: schema-loading
 interrupt_pattern: native
+thread_persistence_pattern: langgraph
 agent_config_pattern: shared-state
 auth_pattern: langgraph
 demos:

--- a/showcase/shared/manifest.schema.json
+++ b/showcase/shared/manifest.schema.json
@@ -202,6 +202,11 @@
       "enum": ["native", "promise-based", null],
       "description": "Implementation pattern used by this integration for `gen-ui-interrupt` / `interrupt-headless`. Set only when at least one is wired. `native` = framework has a real interrupt primitive (e.g. LangGraph `interrupt()` + `useInterrupt`); `promise-based` = the demo uses `useFrontendTool` with a Promise-based handler. Consumed by docs `<WhenFrameworkHas>`."
     },
+    "thread_persistence_pattern": {
+      "type": ["string", "null"],
+      "enum": ["langgraph", "adk-session", null],
+      "description": "Framework-specific thread persistence/interoperability pattern. Set only when docs need to explain how CopilotKit Enterprise Intelligence Platform threads can be aligned with an external framework's own run/session identifiers. `langgraph` = explicit CopilotKit thread IDs are forwarded as AG-UI thread IDs and can be aligned with LangGraph checkpoint/thread IDs when the backend accepts them; `adk-session` = CopilotKit thread IDs may be mapped to ADK session IDs, while ADK durability depends on the configured ADK session service. Consumed by docs `<WhenFrameworkHas>`."
+    },
     "agent_config_pattern": {
       "type": ["string", "null"],
       "enum": ["shared-state", "runtime-properties", null],

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -304,7 +304,12 @@ export async function DocsPageView({
                         WhenFrameworkHas: (props: Record<string, unknown>) => (
                           <WhenFrameworkHas
                             {...(props as {
-                              flag: "a2ui_pattern" | "interrupt_pattern";
+                              flag:
+                                | "a2ui_pattern"
+                                | "interrupt_pattern"
+                                | "thread_persistence_pattern"
+                                | "agent_config_pattern"
+                                | "auth_pattern";
                               equals?: string;
                               absent?: boolean;
                               framework?: string;

--- a/showcase/shell-docs/src/components/when-framework-has.tsx
+++ b/showcase/shell-docs/src/components/when-framework-has.tsx
@@ -36,7 +36,12 @@ import { getIntegration } from "@/lib/registry";
  * `lib/registry.ts` and the manifest schema in
  * `showcase/shared/manifest.schema.json`.
  */
-type SupportedFlag = "a2ui_pattern" | "interrupt_pattern";
+type SupportedFlag =
+  | "a2ui_pattern"
+  | "interrupt_pattern"
+  | "thread_persistence_pattern"
+  | "agent_config_pattern"
+  | "auth_pattern";
 
 interface WhenFrameworkHasProps {
   /** Manifest field to read (e.g. `"a2ui_pattern"`). */

--- a/showcase/shell-docs/src/content/docs/threads.mdx
+++ b/showcase/shell-docs/src/content/docs/threads.mdx
@@ -6,7 +6,7 @@ doc_type: how-to
 ---
 ## What is this?
 
-CopilotKit threads enable persistent, resumable multi-turn conversations. The `useThreads` hook lists, creates, renames, archives, and deletes threads with realtime synchronization via WebSocket. Threads work with any agent framework — the Enterprise Intelligence Platform stores conversation history server-side, so users can close their browser and pick up where they left off. Thread metadata updates (renames, archives, new threads) are pushed to all connected clients in realtime without polling.
+CopilotKit threads enable persistent, resumable multi-turn conversations. The `useThreads` hook lists, creates, renames, archives, and deletes Enterprise Intelligence Platform threads with realtime synchronization via WebSocket. Threads work with any agent framework — the Enterprise Intelligence Platform stores conversation history server-side, so users can close their browser and pick up where they left off. It does not list or mutate native LangGraph, ADK, or other framework stores unless your backend explicitly bridges those systems. Thread metadata updates (renames, archives, new threads) appear on connected clients without polling.
 
 <OpsPlatformCTA
   variant="inline"
@@ -222,6 +222,18 @@ CopilotKit threads enable persistent, resumable multi-turn conversations. The `u
         ```
 
         When `threadId` changes, the chat component automatically loads the selected thread's history and reconnects to the agent's stream. If the agent is still running on that thread, the chat picks up the live stream.
+
+        <WhenFrameworkHas flag="thread_persistence_pattern" equals="langgraph">
+          <Callout type="info" title="LangGraph persistence">
+            When you pass an explicit CopilotKit `threadId`, CopilotKit forwards it to your backend as the AG-UI `threadId`. A LangGraph backend can use that value directly, or map it to its own checkpoint/thread identifier, when you implement that mapping. LangGraph Platform thread IDs must be UUIDs. CopilotKit `useThreads` manages Enterprise Intelligence Platform thread records; rename, archive, and delete operations do not update LangGraph stores unless your backend adds that bridge.
+          </Callout>
+        </WhenFrameworkHas>
+
+        <WhenFrameworkHas flag="thread_persistence_pattern" equals="adk-session">
+          <Callout type="info" title="ADK sessions">
+            When you pass an explicit CopilotKit `threadId`, CopilotKit forwards it to your backend as the AG-UI `threadId`. An ADK backend can map that value to an ADK session ID, but the current showcase uses in-memory ADK services, so those sessions are not durable by default. Durable ADK session persistence requires configuring a separate ADK session service. CopilotKit `useThreads` manages Enterprise Intelligence Platform thread records, not ADK's native session store.
+          </Callout>
+        </WhenFrameworkHas>
       </Step>
 
       <Step>

--- a/showcase/shell-docs/src/content/snippets/shared/threads/threads.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/threads/threads.mdx
@@ -2,7 +2,7 @@ import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
 ## What is this?
 
-CopilotKit threads enable persistent, resumable multi-turn conversations. The `useThreads` hook lists, creates, renames, archives, and deletes threads with realtime synchronization via WebSocket. Threads work with any agent framework — the Enterprise Intelligence Platform stores conversation history server-side, so users can close their browser and pick up where they left off. Thread metadata updates (renames, archives, new threads) are pushed to all connected clients in realtime without polling.
+CopilotKit threads enable persistent, resumable multi-turn conversations. The `useThreads` hook lists, creates, renames, archives, and deletes Enterprise Intelligence Platform threads with realtime synchronization via WebSocket. Threads work with any agent framework — the Enterprise Intelligence Platform stores conversation history server-side, so users can close their browser and pick up where they left off. It does not list or mutate native LangGraph, ADK, or other framework stores unless your backend explicitly bridges those systems. Thread metadata updates (renames, archives, new threads) appear on connected clients without polling.
 
 <OpsPlatformCTA
   variant="inline"
@@ -218,6 +218,18 @@ CopilotKit threads enable persistent, resumable multi-turn conversations. The `u
         ```
 
         When `threadId` changes, the chat component automatically loads the selected thread's history and reconnects to the agent's stream. If the agent is still running on that thread, the chat picks up the live stream.
+
+        <WhenFrameworkHas flag="thread_persistence_pattern" equals="langgraph">
+          <Callout type="info" title="LangGraph persistence">
+            When you pass an explicit CopilotKit `threadId`, CopilotKit forwards it to your backend as the AG-UI `threadId`. A LangGraph backend can use that value directly, or map it to its own checkpoint/thread identifier, when you implement that mapping. LangGraph Platform thread IDs must be UUIDs. CopilotKit `useThreads` manages Enterprise Intelligence Platform thread records; rename, archive, and delete operations do not update LangGraph stores unless your backend adds that bridge.
+          </Callout>
+        </WhenFrameworkHas>
+
+        <WhenFrameworkHas flag="thread_persistence_pattern" equals="adk-session">
+          <Callout type="info" title="ADK sessions">
+            When you pass an explicit CopilotKit `threadId`, CopilotKit forwards it to your backend as the AG-UI `threadId`. An ADK backend can map that value to an ADK session ID, but the current showcase uses in-memory ADK services, so those sessions are not durable by default. Durable ADK session persistence requires configuring a separate ADK session service. CopilotKit `useThreads` manages Enterprise Intelligence Platform thread records, not ADK's native session store.
+          </Callout>
+        </WhenFrameworkHas>
       </Step>
 
       <Step>

--- a/showcase/shell-docs/src/lib/registry.ts
+++ b/showcase/shell-docs/src/lib/registry.ts
@@ -76,6 +76,26 @@ export interface Integration {
    *   handler (ms-agent-python, ms-agent-dotnet).
    */
   interrupt_pattern?: "native" | "promise-based" | null;
+  /**
+   * Framework-specific pattern for aligning Enterprise Intelligence
+   * Platform threads with an external framework's own persistence/session
+   * identifiers.
+   *
+   * - `langgraph`: explicit CopilotKit thread IDs are forwarded as AG-UI
+   *   `threadId` and can be aligned with LangGraph checkpoint/thread IDs
+   *   when the backend accepts them.
+   * - `adk-session`: CopilotKit thread IDs may be mapped to ADK session
+   *   IDs; ADK durability still depends on the configured ADK session
+   *   service.
+   */
+  thread_persistence_pattern?: "langgraph" | "adk-session" | null;
+  agent_config_pattern?: "shared-state" | "runtime-properties" | null;
+  auth_pattern?:
+    | "langgraph"
+    | "ag2-context-variables"
+    | "microsoft-agent-framework"
+    | "runtime-onrequest"
+    | null;
   sort_order?: number;
   managed_platform?: { name: string; url: string };
   animated_preview_url?: string | null;


### PR DESCRIPTION
## Summary

- Adds a `thread_persistence_pattern` manifest flag so shared docs can render selected-framework Threads guidance.
- Marks LangGraph Python, LangGraph TypeScript, LangGraph FastAPI, and Google ADK with the appropriate thread persistence pattern.
- Extends `WhenFrameworkHas` support so the shared Threads guide can show LangGraph-only and ADK-only callouts.
- Clarifies that `useThreads` manages Enterprise Intelligence Platform thread records, not native framework stores.
- Adds framework-selected callouts to the root/shared Threads guide without adding a third setup path.

## Notes

The new callouts intentionally avoid claiming external store listing, lifecycle sync, migration/import tooling, or durable ADK sessions by default. Those remain product/runtime follow-ups tracked separately.

## Validation

- `git diff --check`
- `npm run pretypecheck` in `showcase/shell-docs`
- `npm run lint` in `showcase/shell-docs` (passes with existing warnings)
- `npm run typecheck` in `showcase/shell-docs`
- `npm run build` in `showcase/shell-docs` (passes with existing Turbopack/NFT warning)
- Local route smoke checks:
  - `/threads` hides framework callouts
  - `/langgraph-python/threads` shows LangGraph callout only
  - `/langgraph-typescript/threads` shows LangGraph callout only
  - `/langgraph-fastapi/threads` shows LangGraph callout only
  - `/google-adk/threads` shows ADK callout only
