### PR TITLE
Preserve quickstart CTA styling in shell docs reference pages

### DIFF
--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -339,6 +339,12 @@
   text-decoration: none;
 }
 
+.reference-content a.shell-docs-primary-cta,
+.reference-content a.shell-docs-primary-cta:hover {
+  color: var(--primary-foreground);
+  text-decoration: none;
+}
+
 .reference-content a.shell-docs-cta-accent,
 .reference-content a.shell-docs-cta-accent:hover,
 .reference-content .shell-docs-cta-accent {

--- a/showcase/shell-docs/src/components/__tests__/hero-start-commands.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/hero-start-commands.test.tsx
@@ -5,6 +5,10 @@ const heroStartCommandsSource = readFileSync(
   new URL("../hero-start-commands.tsx", import.meta.url),
   "utf8",
 );
+const globalsCss = readFileSync(
+  new URL("../../app/globals.css", import.meta.url),
+  "utf8",
+);
 
 // `hero_command_copied` fires alongside the global <CopyTracker>'s
 // `cli_command_copied` for the same copy. The sibling records
@@ -29,5 +33,15 @@ describe("hero_command_copied analytics", () => {
 
   it("guards the location read for SSR, mirroring the CopyTracker sibling", () => {
     expect(heroStartCommandsSource).toContain('typeof window !== "undefined"');
+  });
+});
+
+describe("hero quickstart CTA styling", () => {
+  it("opts the primary quickstart link out of prose link colors", () => {
+    expect(heroStartCommandsSource).toContain("shell-docs-primary-cta");
+    expect(globalsCss).toContain(
+      ".reference-content a.shell-docs-primary-cta",
+    );
+    expect(globalsCss).toContain("color: var(--primary-foreground);");
   });
 });

--- a/showcase/shell-docs/src/components/content/landing-pages/__tests__/framework-overview.test.tsx
+++ b/showcase/shell-docs/src/components/content/landing-pages/__tests__/framework-overview.test.tsx
@@ -31,6 +31,7 @@ describe("FrameworkOverview", () => {
     expect(markup).toContain('aria-controls="hero-cli-commands"');
     expect(markup).toContain("border-[var(--accent)]");
     expect(markup).toContain("bg-[var(--accent)]");
+    expect(markup).toContain("shell-docs-primary-cta");
     expect(markup).toContain("text-[var(--primary-foreground)]");
   });
 

--- a/showcase/shell-docs/src/components/hero-start-commands.tsx
+++ b/showcase/shell-docs/src/components/hero-start-commands.tsx
@@ -247,7 +247,7 @@ export function QuickstartLinkButton({ href }: { href: string }) {
   return (
     <Link
       href={href}
-      className="shell-docs-radius-control group inline-flex h-11 w-full items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--primary-foreground)] no-underline shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--accent-strong)] sm:w-fit"
+      className="shell-docs-primary-cta shell-docs-radius-control group inline-flex h-11 w-full items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--primary-foreground)] no-underline shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--accent-strong)] sm:w-fit"
     >
       Quickstart
       <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />


### PR DESCRIPTION
## Summary
- Add a dedicated `shell-docs-primary-cta` style for the hero quickstart link so it keeps the primary CTA color inside reference content.
- Cover the new class usage in the hero and framework overview tests.

## Testing
- Updated unit tests to verify the quickstart CTA class and the matching global CSS override.
- Updated unit tests to verify the framework overview markup includes the primary CTA class.