### PR TITLE
Add Inspector Threads locked state for non-Intelligence installs

### DIFF
--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -321,6 +321,7 @@ type ThreadDetailsInternals = {
   _loadingState: boolean;
   _loadingEvents: boolean;
   _panelTplCache: Map<string, { key: readonly unknown[]; tpl: unknown }>;
+  fetchMessages: (threadId: string) => Promise<void>;
   fetchEvents: (threadId: string) => Promise<void>;
   fetchState: (threadId: string) => Promise<void>;
   renderConversation: () => unknown;
@@ -401,6 +402,43 @@ describe("ɵCpkThreadDetails caching", () => {
       await internals.fetchState("t1");
 
       expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("joins thread inspection URLs without double slashes when runtimeUrl has a trailing slash", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = String(input);
+        if (url.endsWith("/messages")) {
+          return new Response(JSON.stringify({ messages: [] }), {
+            status: 200,
+          });
+        }
+        if (url.endsWith("/events")) {
+          return new Response(JSON.stringify({ events: [] }), { status: 200 });
+        }
+        return new Response(JSON.stringify({ state: null }), { status: 200 });
+      });
+    try {
+      const { el, internals } = createThreadDetails();
+      internals.runtimeUrl = "http://localhost:4000/api/";
+      internals.threadInspectionAvailable = true;
+      internals.threadId = "thread one";
+      await el.updateComplete;
+      fetchSpy.mockClear();
+
+      await internals.fetchMessages("thread one");
+      await internals.fetchEvents("thread one");
+      await internals.fetchState("thread one");
+
+      expect(fetchSpy.mock.calls.map((call) => String(call[0]))).toEqual([
+        "http://localhost:4000/api/threads/thread%20one/messages",
+        "http://localhost:4000/api/threads/thread%20one/events",
+        "http://localhost:4000/api/threads/thread%20one/state",
+      ]);
     } finally {
       fetchSpy.mockRestore();
     }
@@ -616,6 +654,7 @@ type HeaderMockCore = {
   agents: Record<string, AbstractAgent>;
   context: Record<string, unknown>;
   properties: Record<string, unknown>;
+  telemetryDisabled: boolean;
   runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus;
   runtimeUrl: string;
   headers: Record<string, string>;
@@ -637,12 +676,15 @@ type HeaderMockCore = {
 function createHeaderMockCore(
   agents: Record<string, AbstractAgent>,
   headers: Record<string, string>,
+  endpointOverrides: Partial<HeaderMockCore["threadEndpoints"]> = {},
+  telemetryDisabled = true,
 ) {
   const subscribers = new Set<CopilotKitCoreSubscriber>();
   const core: HeaderMockCore = {
     agents,
     context: {},
     properties: {},
+    telemetryDisabled,
     runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Connected,
     runtimeUrl: "http://localhost/api",
     headers,
@@ -651,6 +693,7 @@ function createHeaderMockCore(
       inspect: true,
       mutations: true,
       realtimeMetadata: true,
+      ...endpointOverrides,
     },
     subscribe(subscriber: CopilotKitCoreSubscriber) {
       subscribers.add(subscriber);
@@ -693,6 +736,21 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     fetchMock.mock.calls.filter((call) =>
       String(call[0]).includes("/threads?"),
     );
+  const telemetryPosts = () =>
+    fetchMock.mock.calls
+      .filter(
+        (call) =>
+          String(call[0]) === "https://telemetry.copilotkit.ai/ingest" &&
+          (call[1] as RequestInit | undefined)?.method === "POST",
+      )
+      .map((call) => {
+        const body =
+          ((call[1] as RequestInit | undefined)?.body as string) ?? "{}";
+        return JSON.parse(body) as {
+          event: string;
+          properties: Record<string, unknown>;
+        };
+      });
 
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -757,5 +815,161 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     expect(headersOf(threadListCalls().at(-1)!)).toMatchObject({
       "X-CSRF": "2",
     });
+  });
+
+  it("shows the locked Intelligence state when thread listing is unavailable without fetching threads", async () => {
+    const { agent } = createMockAgent("alpha");
+    const harness = createHeaderMockCore(
+      { alpha: agent },
+      { "X-CSRF": "1" },
+      { list: false },
+      true,
+    );
+
+    const inspector = new WebInspectorElement();
+    document.body.appendChild(inspector);
+    inspector.core = harness.core as unknown as WebInspectorElement["core"];
+    harness.emitAgentsChanged();
+
+    const internals = inspector as unknown as {
+      isOpen: boolean;
+      handleMenuSelect: (key: "threads") => void;
+    };
+    internals.isOpen = true;
+    internals.handleMenuSelect("threads");
+    await inspector.updateComplete;
+
+    const text = inspector.shadowRoot?.textContent ?? "";
+    expect(text).toMatch(/Enable Intelligence to inspect Threads\./);
+    expect(text).toContain("Talk to an Engineer");
+    expect(text).toContain("Sign up for Intelligence");
+    const ctaLabels = Array.from(
+      inspector.shadowRoot?.querySelectorAll<HTMLAnchorElement>("a") ?? [],
+    ).map((anchor) => anchor.textContent?.trim());
+    expect(ctaLabels).toEqual([
+      "Talk to an Engineer",
+      "Sign up for Intelligence",
+    ]);
+    expect(text).not.toContain("No threads yet");
+    expect(
+      fetchMock.mock.calls.some((call) => String(call[0]).includes("/threads")),
+    ).toBe(false);
+  });
+
+  it("adds ref and posthog distinct ID attribution to locked-state CTAs", async () => {
+    const { agent } = createMockAgent("alpha");
+    const harness = createHeaderMockCore(
+      { alpha: agent },
+      {},
+      { list: false },
+      false,
+    );
+
+    const inspector = new WebInspectorElement();
+    document.body.appendChild(inspector);
+    inspector.core = harness.core as unknown as WebInspectorElement["core"];
+    harness.emitAgentsChanged();
+
+    const internals = inspector as unknown as {
+      isOpen: boolean;
+      handleMenuSelect: (key: "threads") => void;
+    };
+    internals.isOpen = true;
+    internals.handleMenuSelect("threads");
+    await inspector.updateComplete;
+
+    const signup = inspector.shadowRoot?.querySelector<HTMLAnchorElement>(
+      'a[href^="https://go.copilotkit.ai/intelligence-signup"]',
+    );
+    const engineer = inspector.shadowRoot?.querySelector<HTMLAnchorElement>(
+      'a[href^="https://www.copilotkit.ai/talk-to-an-engineer"]',
+    );
+
+    expect(signup).not.toBeNull();
+    expect(engineer).not.toBeNull();
+
+    const signupUrl = new URL(signup!.href);
+    expect(signupUrl.searchParams.get("ref")).toBe("cpk-inspector");
+    const distinctId = signupUrl.searchParams.get("posthog_distinct_id");
+    expect(distinctId).toMatch(/^[0-9a-f-]{36}$/);
+
+    const engineerUrl = new URL(engineer!.href);
+    expect(engineerUrl.origin).toBe("https://www.copilotkit.ai");
+    expect(engineerUrl.pathname).toBe("/talk-to-an-engineer");
+    expect(engineerUrl.searchParams.get("ref")).toBe("cpk-inspector-threads");
+    expect(engineerUrl.searchParams.get("posthog_distinct_id")).toBe(
+      distinctId,
+    );
+  });
+
+  it("tracks Threads tab clicks through the rendered inspector menu", async () => {
+    const { agent } = createMockAgent("alpha");
+    const harness = createHeaderMockCore(
+      { alpha: agent },
+      {},
+      { list: false },
+      false,
+    );
+
+    const inspector = new WebInspectorElement();
+    document.body.appendChild(inspector);
+    inspector.core = harness.core as unknown as WebInspectorElement["core"];
+    harness.emitAgentsChanged();
+
+    const internals = inspector as unknown as { isOpen: boolean };
+    internals.isOpen = true;
+    inspector.requestUpdate();
+    await inspector.updateComplete;
+
+    const threadsButton = Array.from(
+      inspector.shadowRoot?.querySelectorAll<HTMLButtonElement>("button") ?? [],
+    ).find((button) => button.textContent?.trim() === "Threads");
+    expect(threadsButton, "Threads menu button should render").toBeDefined();
+
+    threadsButton!.click();
+    await inspector.updateComplete;
+    await Promise.resolve();
+
+    const threadsTabClick = telemetryPosts().find(
+      (post) => post.event === "oss.inspector.threads_tab_clicked",
+    );
+    expect(threadsTabClick).toBeDefined();
+    expect(threadsTabClick!.properties).toMatchObject({
+      intelligence_status: "intelligence_not_enabled",
+      thread_service_status: "unavailable",
+      telemetry_disabled: false,
+    });
+    expect(threadsTabClick!.properties.distinct_id).toMatch(/^[0-9a-f-]{36}$/);
+    if (threadsTabClick!.properties.posthog_distinct_id !== undefined) {
+      expect(threadsTabClick!.properties.posthog_distinct_id).toBe(
+        threadsTabClick!.properties.distinct_id,
+      );
+    }
+  });
+
+  it("keeps the enabled empty Threads state when thread listing is available", async () => {
+    const { agent } = createMockAgent("alpha");
+    const harness = createHeaderMockCore({ alpha: agent }, {}, {}, true);
+
+    const inspector = new WebInspectorElement();
+    document.body.appendChild(inspector);
+    inspector.core = harness.core as unknown as WebInspectorElement["core"];
+    harness.emitAgentsChanged();
+
+    const internals = inspector as unknown as {
+      isOpen: boolean;
+      handleMenuSelect: (key: "threads") => void;
+    };
+    internals.isOpen = true;
+    internals.handleMenuSelect("threads");
+    await inspector.updateComplete;
+
+    expect(inspector.shadowRoot?.textContent ?? "").toContain("No threads yet");
+    const engineer = inspector.shadowRoot?.querySelector<HTMLAnchorElement>(
+      'a[href^="https://www.copilotkit.ai/talk-to-an-engineer"]',
+    );
+    expect(engineer?.href).toBe(
+      "https://www.copilotkit.ai/talk-to-an-engineer?ref=cpk-inspector-threads",
+    );
   });
 });

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -63,6 +63,7 @@ import {
   trackThreadsTabClicked,
   trackThreadsTalkToEngineerClicked,
 } from "./lib/telemetry.js";
+import type { InspectorThreadTelemetryProps } from "./lib/telemetry.js";
 
 export type { Anchor } from "./lib/types.js";
 
@@ -2562,9 +2563,9 @@ export class WebInspectorElement extends LitElement {
   }
 
   private getThreadsTelemetryProps(
-    extra: Record<string, unknown> = {},
+    extra: Partial<InspectorThreadTelemetryProps> = {},
     options: { includeUrlAttribution?: boolean } = {},
-  ) {
+  ): InspectorThreadTelemetryProps {
     const distinctId =
       options.includeUrlAttribution && !this.core?.telemetryDisabled
         ? getTelemetryDistinctIdForUrl()

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -50,11 +50,18 @@ import type { PersistedState } from "./lib/persistence.js";
 import {
   TELEMETRY_DOCS_URL,
   ensureTelemetryDistinctId,
+  getRuntimeUrlType,
   getTelemetryDistinctIdForUrl,
   maybeShowDisclosure,
   trackBannerClicked,
   trackBannerViewed,
+  trackTalkToEngineerClicked,
+  trackThreadsEmptyEnabledViewed,
+  trackThreadsEnabledViewed,
+  trackThreadsIntelligenceSignupClicked,
+  trackThreadsLockedViewed,
   trackThreadsTabClicked,
+  trackThreadsTalkToEngineerClicked,
 } from "./lib/telemetry.js";
 
 export type { Anchor } from "./lib/types.js";
@@ -90,6 +97,10 @@ const DEFAULT_WINDOW_SIZE: Size = { width: 840, height: 700 };
 const DOCKED_LEFT_WIDTH = 500; // Sensible width for left dock with collapsed sidebar
 const MAX_AGENT_EVENTS = 200;
 const MAX_TOTAL_EVENTS = 500;
+const INTELLIGENCE_SIGNUP_URL = "https://go.copilotkit.ai/intelligence-signup";
+const TALK_TO_ENGINEER_URL = "https://www.copilotkit.ai/talk-to-an-engineer";
+
+type ThreadServiceStatus = "available" | "unavailable" | "unknown" | "error";
 
 type InspectorAgentEventType =
   | "RUN_STARTED"
@@ -336,9 +347,10 @@ function eventColors(type: string): { bg: string; fg: string } {
     return { bg: "rgba(133,236,206,0.15)", fg: "#189370" };
   if (type.startsWith("STATE"))
     return { bg: "rgba(190,194,255,0.102)", fg: "#5558B2" };
+  if (type === "RUN_ERROR" || type === "ERROR")
+    return { bg: "rgba(250,95,103,0.13)", fg: "#c0333a" };
   if (type.startsWith("RUN_") || type.startsWith("STEP_"))
     return { bg: "rgba(255,172,77,0.2)", fg: "#996300" };
-  if (type === "ERROR") return { bg: "rgba(250,95,103,0.13)", fg: "#c0333a" };
   return { bg: "#F7F7F9", fg: "#838389" };
 }
 
@@ -1472,7 +1484,7 @@ export class ɵCpkThreadDetails extends LitElement {
     }
     try {
       const res = await fetch(
-        `${this.runtimeUrl}/threads/${encodeURIComponent(threadId)}/messages`,
+        this.getThreadInspectionUrl(threadId, "messages"),
         { headers: { ...this.headers }, signal: controller.signal },
       );
       if (controller.signal.aborted || this.threadId !== threadId) return;
@@ -1507,10 +1519,10 @@ export class ɵCpkThreadDetails extends LitElement {
     this._loadingEvents = true;
     this._eventsError = null;
     try {
-      const res = await fetch(
-        `${this.runtimeUrl}/threads/${encodeURIComponent(threadId)}/events`,
-        { headers: { ...this.headers }, signal: controller.signal },
-      );
+      const res = await fetch(this.getThreadInspectionUrl(threadId, "events"), {
+        headers: { ...this.headers },
+        signal: controller.signal,
+      });
       // Drop results if a newer fetch superseded this one (thread switched
       // mid-flight). Without this, switching A→B can leave thread B's view
       // showing thread A's events when A's request resolves last.
@@ -1554,10 +1566,10 @@ export class ɵCpkThreadDetails extends LitElement {
     this._loadingState = true;
     this._stateError = null;
     try {
-      const res = await fetch(
-        `${this.runtimeUrl}/threads/${encodeURIComponent(threadId)}/state`,
-        { headers: { ...this.headers }, signal: controller.signal },
-      );
+      const res = await fetch(this.getThreadInspectionUrl(threadId, "state"), {
+        headers: { ...this.headers },
+        signal: controller.signal,
+      });
       if (controller.signal.aborted || this.threadId !== threadId) return;
       if (res.status === 501) {
         this._stateNotAvailable = true;
@@ -1581,6 +1593,13 @@ export class ɵCpkThreadDetails extends LitElement {
         this._loadingState = false;
       }
     }
+  }
+
+  private getThreadInspectionUrl(
+    threadId: string,
+    resource: "messages" | "events" | "state",
+  ): string {
+    return `${this.runtimeUrl.replace(/\/+$/, "")}/threads/${encodeURIComponent(threadId)}/${resource}`;
   }
 
   private mapMessages(messages: ApiThreadMessage[]): ConversationItem[] {
@@ -2448,6 +2467,7 @@ export class WebInspectorElement extends LitElement {
   // `${bannerId}:${cta}`) so copy-button retries and accidental multi-clicks
   // don't inflate funnel counts beyond one signal per intent type per banner.
   private clickedBannerIds: Set<string> = new Set();
+  private viewedThreadsTelemetryStates: Set<string> = new Set();
 
   get core(): CopilotKitCore | null {
     return this._core;
@@ -2529,7 +2549,54 @@ export class WebInspectorElement extends LitElement {
     ];
   }
 
+  private getThreadServiceStatus(): ThreadServiceStatus {
+    if (!this._core) return "unknown";
+    if (!this._core.threadEndpoints) return "unknown";
+    return this._core.threadEndpoints?.list === false
+      ? "unavailable"
+      : "available";
+  }
+
+  private areThreadEndpointsAvailable(): boolean {
+    return this.getThreadServiceStatus() !== "unavailable";
+  }
+
+  private getThreadsTelemetryProps(
+    extra: Record<string, unknown> = {},
+    options: { includeUrlAttribution?: boolean } = {},
+  ) {
+    const distinctId =
+      options.includeUrlAttribution && !this.core?.telemetryDisabled
+        ? getTelemetryDistinctIdForUrl()
+        : null;
+    const threadServiceStatus = this.getThreadServiceStatus();
+    return {
+      posthog_distinct_id: distinctId ?? undefined,
+      intelligence_status:
+        threadServiceStatus === "available"
+          ? "intelligence_enabled"
+          : threadServiceStatus === "unavailable"
+            ? "intelligence_not_enabled"
+            : "unknown",
+      thread_service_status: threadServiceStatus,
+      license_status: this.core?.licenseStatus ?? undefined,
+      runtime_mode: this.core?.runtimeMode ?? undefined,
+      runtime_url_type: getRuntimeUrlType(this.core?.runtimeUrl),
+      telemetry_disabled: this.core?.telemetryDisabled ?? false,
+      ...extra,
+    };
+  }
+
+  private getIntelligenceSignupUrl(): string {
+    return this.appendRefParam(INTELLIGENCE_SIGNUP_URL, "cpk-inspector");
+  }
+
+  private getTalkToEngineerUrl(): string {
+    return this.appendRefParam(TALK_TO_ENGINEER_URL, "cpk-inspector-threads");
+  }
+
   private subscribeToThreadStore(agentId: string, store: ɵThreadStore): void {
+    if (!this.areThreadEndpointsAvailable()) return;
     if (this._threadStoreSubscriptions.has(agentId)) return;
     const threadsSub = store.select(ɵselectThreads).subscribe((threads) => {
       this._threadsByAgent.set(agentId, threads as ɵThread[]);
@@ -2589,7 +2656,7 @@ export class WebInspectorElement extends LitElement {
     if (this.core?.getThreadStore(agentId)) return;
     const core = this.core;
     if (!core?.runtimeUrl) return;
-    if (core.threadEndpoints?.list === false) return;
+    if (!this.areThreadEndpointsAvailable()) return;
 
     const store = ɵcreateThreadStore({ fetch: globalThis.fetch });
     store.start();
@@ -2628,6 +2695,7 @@ export class WebInspectorElement extends LitElement {
       store.setContext({
         runtimeUrl: core.runtimeUrl,
         headers: { ...headers },
+        wsUrl: core.intelligence?.wsUrl,
         agentId,
       });
     }
@@ -2663,7 +2731,7 @@ export class WebInspectorElement extends LitElement {
             maybeShowDisclosure();
           }
           this.flushPendingBannerViewed();
-          if (core.threadEndpoints?.list !== false) {
+          if (this.areThreadEndpointsAvailable()) {
             for (const agentId of this._ownedThreadStores.keys()) {
               this.refreshOwnedThreadStore(agentId);
             }
@@ -2714,6 +2782,14 @@ export class WebInspectorElement extends LitElement {
 
     this.coreUnsubscribe = core.subscribe(this.coreSubscriber).unsubscribe;
     this.processAgentsChanged(core.agents);
+
+    if (core.runtimeConnectionStatus === "connected") {
+      if (!core.telemetryDisabled) {
+        ensureTelemetryDistinctId();
+        maybeShowDisclosure();
+      }
+      this.flushPendingBannerViewed();
+    }
 
     // Subscribe to any already-registered thread stores. `getThreadStores` was
     // added in the same release as this inspector; guard so consumers still on
@@ -3409,6 +3485,10 @@ ${argsString}</pre
     const base =
       "font-mono text-[10px] font-medium inline-flex items-center rounded-sm px-1.5 py-0.5 border";
 
+    if (type === "RUN_ERROR") {
+      return `${base} bg-rose-50 text-rose-700 border-rose-200`;
+    }
+
     if (type.startsWith("RUN_")) {
       return `${base} bg-blue-50 text-blue-700 border-blue-200`;
     }
@@ -3431,10 +3511,6 @@ ${argsString}</pre
 
     if (type.startsWith("MESSAGES")) {
       return `${base} bg-sky-50 text-sky-700 border-sky-200`;
-    }
-
-    if (type === "RUN_ERROR") {
-      return `${base} bg-rose-50 text-rose-700 border-rose-200`;
     }
 
     return `${base} bg-gray-100 text-gray-600 border-gray-200`;
@@ -5796,6 +5872,45 @@ ${argsString}</pre
     });
   }
 
+  private handleTalkToEngineerClick = (): void => {
+    if (this.core?.telemetryDisabled) return;
+    trackTalkToEngineerClicked(
+      this.getThreadsTelemetryProps(
+        {
+          cta: "talk_to_engineer",
+          cta_surface: "threads_header",
+        },
+        { includeUrlAttribution: true },
+      ),
+    );
+  };
+
+  private handleThreadsIntelligenceSignupClick = (): void => {
+    if (this.core?.telemetryDisabled) return;
+    trackThreadsIntelligenceSignupClicked(
+      this.getThreadsTelemetryProps(
+        {
+          cta: "signup",
+          cta_surface: "threads_locked",
+        },
+        { includeUrlAttribution: true },
+      ),
+    );
+  };
+
+  private handleThreadsTalkToEngineerClick = (): void => {
+    if (this.core?.telemetryDisabled) return;
+    trackThreadsTalkToEngineerClicked(
+      this.getThreadsTelemetryProps(
+        {
+          cta: "talk_to_engineer",
+          cta_surface: "threads_locked",
+        },
+        { includeUrlAttribution: true },
+      ),
+    );
+  };
+
   private handleThreadDividerPointerDown = (event: PointerEvent) => {
     this.threadDividerResizing = true;
     this.threadDividerPointerId = event.pointerId;
@@ -5828,7 +5943,326 @@ ${argsString}</pre
     this.threadDividerResizing = false;
   };
 
+  private trackThreadsViewStateOnce(
+    state: "locked" | "empty_enabled" | "enabled",
+    threadCount: number,
+  ): void {
+    if (this.core?.telemetryDisabled) return;
+    const key = `${state}:${this.getThreadServiceStatus()}`;
+    if (this.viewedThreadsTelemetryStates.has(key)) return;
+    this.viewedThreadsTelemetryStates.add(key);
+    const props = this.getThreadsTelemetryProps({ thread_count: threadCount });
+    if (state === "locked") {
+      trackThreadsLockedViewed(props);
+    } else if (state === "empty_enabled") {
+      trackThreadsEmptyEnabledViewed(props);
+    } else {
+      trackThreadsEnabledViewed(props);
+    }
+  }
+
+  private renderThreadsLockedBackgroundMockup() {
+    const threadRows = [
+      { width: 74, accent: true },
+      { width: 92 },
+      { width: 68 },
+      { width: 84 },
+      { width: 58 },
+      { width: 76 },
+    ];
+
+    return html`
+      <div
+        aria-hidden="true"
+        style="
+          position: absolute;
+          inset: 0;
+          display: grid;
+          grid-template-columns: minmax(180px, 28%) 1fr;
+          overflow: hidden;
+          opacity: 0.58;
+          pointer-events: none;
+        "
+      >
+        <div
+          style="
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            padding: 28px 24px;
+            border-right: 1px solid #dbdbe5;
+            background: #fafafa;
+          "
+        >
+          ${threadRows.map(
+            (row) => html`
+              <div
+                style="
+                  padding: 12px;
+                  border-radius: 8px;
+                  background: ${row.accent ? "#eee6fe" : "#ffffff"};
+                  box-shadow: inset 0 0 0 1px #eeeef4;
+                "
+              >
+                <div
+                  style="
+                    height: 8px;
+                    width: ${row.width}%;
+                    border-radius: 99px;
+                    background: ${row.accent ? "#a984f5" : "#d7d7df"};
+                  "
+                ></div>
+                <div
+                  style="
+                    height: 6px;
+                    width: 88%;
+                    margin-top: 10px;
+                    border-radius: 99px;
+                    background: #e3e3eb;
+                  "
+                ></div>
+                <div
+                  style="
+                    height: 6px;
+                    width: 62%;
+                    margin-top: 7px;
+                    border-radius: 99px;
+                    background: #e8e8ef;
+                  "
+                ></div>
+              </div>
+            `,
+          )}
+        </div>
+        <div
+          style="
+            min-width: 0;
+            padding: 42px 48px;
+            background: #ffffff;
+          "
+        >
+          <div
+            style="
+              height: 10px;
+              width: 180px;
+              border-radius: 99px;
+              background: #d7d7df;
+            "
+          ></div>
+          <div
+            style="
+              height: 8px;
+              width: min(520px, 58%);
+              margin-top: 28px;
+              border-radius: 99px;
+              background: #e3e3eb;
+            "
+          ></div>
+          <div
+            style="
+              height: 8px;
+              width: min(430px, 48%);
+              margin-top: 12px;
+              border-radius: 99px;
+              background: #e8e8ef;
+            "
+          ></div>
+          <div
+            style="
+              display: grid;
+              grid-template-columns: repeat(2, minmax(0, 1fr));
+              gap: 16px;
+              max-width: 620px;
+              margin-top: 30px;
+            "
+          >
+            <div
+              style="
+                height: 116px;
+                border-radius: 8px;
+                background: #f5f5f8;
+                box-shadow: inset 0 0 0 1px #eeeef4;
+              "
+            ></div>
+            <div
+              style="
+                height: 116px;
+                border-radius: 8px;
+                background: #f5f5f8;
+                box-shadow: inset 0 0 0 1px #eeeef4;
+              "
+            ></div>
+          </div>
+          <div
+            style="
+              height: 10px;
+              width: min(680px, 74%);
+              margin-top: 34px;
+              border-radius: 99px;
+              background: #e3e3eb;
+            "
+          ></div>
+          <div
+            style="
+              height: 10px;
+              width: min(560px, 60%);
+              margin-top: 14px;
+              border-radius: 99px;
+              background: #e8e8ef;
+            "
+          ></div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderThreadsLockedView() {
+    this.trackThreadsViewStateOnce("locked", 0);
+    return html`
+      <div
+        style="
+          position: relative;
+          height: 100%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 32px;
+          overflow: hidden;
+          background: #ffffff;
+        "
+      >
+        ${this.renderThreadsLockedBackgroundMockup()}
+        <div
+          aria-hidden="true"
+          style="
+            position: absolute;
+            inset: 0;
+            pointer-events: none;
+            background:
+              radial-gradient(circle at center, rgba(255,255,255,0.9) 0, rgba(255,255,255,0.78) 24%, rgba(255,255,255,0.34) 48%, rgba(255,255,255,0.56) 100%);
+          "
+        ></div>
+        <div
+          style="
+            position: relative;
+            z-index: 1;
+            max-width: 440px;
+            text-align: center;
+            color: #57575b;
+          "
+        >
+          <div
+            aria-hidden="true"
+            style="
+              margin: 0 auto 18px;
+              display: flex;
+              justify-content: center;
+            "
+          >
+            <div
+              style="
+                display: flex;
+                height: 44px;
+                width: 44px;
+                align-items: center;
+                justify-content: center;
+                border: 1px solid #dfd6fb;
+                border-radius: 8px;
+                background: #eee6fe;
+                color: #57575b;
+                box-shadow: 0 8px 18px rgba(87, 87, 91, 0.14);
+              "
+            >
+              ${this.renderIcon("Lock")}
+            </div>
+          </div>
+          <h2
+            style="
+              margin: 0 0 8px;
+              font-size: 16px;
+              line-height: 1.35;
+              font-weight: 600;
+              color: #010507;
+            "
+          >
+            Enable Intelligence to inspect Threads.
+          </h2>
+          <p
+            style="
+              margin: 0 auto 18px;
+              max-width: 380px;
+              font-size: 13px;
+              line-height: 1.55;
+              color: #57575b;
+            "
+          >
+            Persist conversations and inspect saved thread history from the
+            Inspector.
+          </p>
+          <div
+            style="
+              display: flex;
+              flex-wrap: wrap;
+              justify-content: center;
+              gap: 8px;
+            "
+          >
+            <a
+              href=${this.getTalkToEngineerUrl()}
+              target="_blank"
+              rel="noopener"
+              style="
+                display: inline-flex;
+                min-height: 34px;
+                align-items: center;
+                justify-content: center;
+                gap: 6px;
+                border-radius: 6px;
+                background: #010507;
+                padding: 8px 12px;
+                font-size: 12px;
+                font-weight: 600;
+                color: #ffffff;
+                text-decoration: none;
+              "
+              @click=${this.handleThreadsTalkToEngineerClick}
+            >
+              Talk to an Engineer
+            </a>
+            <a
+              href=${this.getIntelligenceSignupUrl()}
+              target="_blank"
+              rel="noopener"
+              style="
+                display: inline-flex;
+                min-height: 34px;
+                align-items: center;
+                justify-content: center;
+                gap: 6px;
+                border-radius: 6px;
+                border: 1px solid #dbdbe5;
+                background: #ffffff;
+                padding: 8px 12px;
+                font-size: 12px;
+                font-weight: 600;
+                color: #57575b;
+                text-decoration: none;
+              "
+              @click=${this.handleThreadsIntelligenceSignupClick}
+            >
+              Sign up for Intelligence
+            </a>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
   private renderThreadsView() {
+    if (!this.areThreadEndpointsAvailable()) {
+      return this.renderThreadsLockedView();
+    }
+
     const displayThreads =
       this.selectedContext === "all-agents"
         ? this._threads
@@ -5852,91 +6286,110 @@ ${argsString}</pre
         ? (displayThreads.find((t) => t.id === this.selectedThreadId) ?? null)
         : null;
 
+    if (!threadsErrorMessage) {
+      this.trackThreadsViewStateOnce(
+        displayThreads.length === 0 ? "empty_enabled" : "enabled",
+        displayThreads.length,
+      );
+    }
+
     return html`
-      <div style="display:flex;height:100%;overflow:hidden;">
-        <!-- Left sidebar: thread list -->
+      <div style="display:flex;height:100%;overflow:hidden;flex-direction:column;">
         <div
-          style="width:${this.threadListWidth}px;flex-shrink:0;overflow:hidden;display:flex;flex-direction:column;border-right:1px solid #DBDBE5;"
+          style="display:flex;align-items:center;justify-content:flex-end;border-bottom:1px solid #DBDBE5;background:#ffffff;padding:8px 12px;flex-shrink:0;"
         >
-          <cpk-thread-list
-            style="height:100%;"
-            .threads=${displayThreads}
-            .selectedThreadId=${this.selectedThreadId}
-            .errorMessage=${threadsErrorMessage}
-            @threadSelected=${(e: CustomEvent<string>) => {
-              this.selectedThreadId = e.detail;
-              this.requestUpdate();
-            }}
-          ></cpk-thread-list>
+          <a
+            href=${this.getTalkToEngineerUrl()}
+            target="_blank"
+            rel="noopener"
+            style="display:inline-flex;align-items:center;gap:6px;border-radius:6px;border:1px solid #dbdbe5;background:#ffffff;padding:7px 10px;font-size:12px;font-weight:600;color:#57575b;text-decoration:none;"
+            @click=${this.handleTalkToEngineerClick}
+          >
+            Talk to an Engineer
+          </a>
         </div>
+        <div style="display:flex;min-height:0;flex:1;overflow:hidden;">
+          <!-- Left sidebar: thread list -->
+          <div
+            style="width:${this.threadListWidth}px;flex-shrink:0;overflow:hidden;display:flex;flex-direction:column;border-right:1px solid #DBDBE5;"
+          >
+            <cpk-thread-list
+              style="height:100%;"
+              .threads=${displayThreads}
+              .selectedThreadId=${this.selectedThreadId}
+              .errorMessage=${threadsErrorMessage}
+              @threadSelected=${(e: CustomEvent<string>) => {
+                this.selectedThreadId = e.detail;
+                this.requestUpdate();
+              }}
+            ></cpk-thread-list>
+          </div>
 
-        <!-- Resize divider -->
-        <div
-          style="width:4px;flex-shrink:0;cursor:col-resize;background:transparent;position:relative;z-index:1;"
-          @pointerdown=${this.handleThreadDividerPointerDown}
-          @pointermove=${this.handleThreadDividerPointerMove}
-          @pointerup=${this.handleThreadDividerPointerUp}
-          @pointercancel=${this.handleThreadDividerPointerUp}
-        ></div>
+          <!-- Resize divider -->
+          <div
+            style="width:4px;flex-shrink:0;cursor:col-resize;background:transparent;position:relative;z-index:1;"
+            @pointerdown=${this.handleThreadDividerPointerDown}
+            @pointermove=${this.handleThreadDividerPointerMove}
+            @pointerup=${this.handleThreadDividerPointerUp}
+            @pointercancel=${this.handleThreadDividerPointerUp}
+          ></div>
 
-        <!-- Center + right: thread details or empty state -->
-        <div style="flex:1;min-width:0;overflow:hidden;display:flex;">
-          ${
-            this.selectedThreadId
-              ? html`<cpk-thread-details
-                  style="flex:1;min-width:0;"
-                  .threadId=${this.selectedThreadId}
-                  .thread=${selectedThread}
-                  .runtimeUrl=${this._core?.runtimeUrl ?? ""}
-                  .headers=${this._core?.headers ?? {}}
-                  .threadInspectionAvailable=${
-                    this._core?.threadEndpoints?.inspect !== false
-                  }
-                  .liveMessageVersion=${
-                    this.selectedThreadId
-                      ? (this.liveMessageVersion.get(this.selectedThreadId) ??
-                        0)
-                      : 0
-                  }
-                  .agentStateInput=${
-                    selectedThread
-                      ? this.getLatestStateForAgent(selectedThread.agentId)
-                      : null
-                  }
-                  .agentEventsInput=${
-                    selectedThread
-                      ? (this.agentEvents.get(selectedThread.agentId) ?? [])
-                      : []
-                  }
-                ></cpk-thread-details>`
-              : html`
-                  <div
-                    style="
-                      flex: 1;
-                      display: flex;
-                      flex-direction: column;
-                      align-items: center;
-                      justify-content: center;
-                      gap: 8px;
-                      color: #838389;
-                    "
-                  >
-                    <svg
-                      width="32"
-                      height="32"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="#c0c0c8"
-                      stroke-width="1.5"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
+          <!-- Center + right: thread details or empty state -->
+          <div style="flex:1;min-width:0;overflow:hidden;display:flex;">
+            ${
+              selectedThread
+                ? html`<cpk-thread-details
+                    style="flex:1;min-width:0;"
+                    .threadId=${selectedThread.id}
+                    .thread=${selectedThread}
+                    .runtimeUrl=${this._core?.runtimeUrl ?? ""}
+                    .headers=${this._core?.headers ?? {}}
+                    .threadInspectionAvailable=${
+                      this._core?.threadEndpoints?.inspect !== false
+                    }
+                    .liveMessageVersion=${
+                      this.liveMessageVersion.get(selectedThread.id) ?? 0
+                    }
+                    .agentStateInput=${this.getLatestStateForAgent(
+                      selectedThread.agentId,
+                    )}
+                    .agentEventsInput=${
+                      this.agentEvents.get(selectedThread.agentId) ?? []
+                    }
+                  ></cpk-thread-details>`
+                : html`
+                    <div
+                      style="
+                        flex: 1;
+                        display: flex;
+                        flex-direction: column;
+                        align-items: center;
+                        justify-content: center;
+                        gap: 8px;
+                        color: #838389;
+                      "
                     >
-                      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-                    </svg>
-                    <span style="font-size: 13px">${displayThreads.length === 0 ? "No threads yet" : "Select a thread to inspect"}</span>
-                  </div>
-                `
-          }
+                      <svg
+                        width="32"
+                        height="32"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="#c0c0c8"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+                      </svg>
+                      <span style="font-size: 13px">${
+                        displayThreads.length === 0
+                          ? "No threads yet"
+                          : "Select a thread to inspect"
+                      }</span>
+                    </div>
+                  `
+            }
+          </div>
         </div>
       </div>
     `;
@@ -6608,8 +7061,8 @@ ${prettyEvent}</pre
     }
 
     if (key === "threads") {
-      if (this.selectedMenu !== "threads" && !this.core?.telemetryDisabled) {
-        trackThreadsTabClicked();
+      if (previousMenu !== "threads" && !this.core?.telemetryDisabled) {
+        trackThreadsTabClicked(this.getThreadsTelemetryProps());
       }
       this.autoSelectLatestThread();
     }
@@ -7289,6 +7742,22 @@ ${prettyEvent}</pre
                           }
                         </button>
                       </div>
+                      <pre
+                        style="
+                          margin: 0;
+                          max-height: 180px;
+                          overflow: auto;
+                          white-space: pre-wrap;
+                          word-break: break-word;
+                          border-radius: 6px;
+                          border: 1px solid #eeeef4;
+                          background: #f7f7f9;
+                          padding: 10px;
+                          font-size: 11px;
+                          line-height: 1.5;
+                          color: #2d2d30;
+                        "
+                      >${this.formatContextValue(context.value)}</pre>
                     `
                     : html`
                         <div class="flex items-center justify-center py-4 text-xs text-gray-500">
@@ -7637,10 +8106,15 @@ ${prettyEvent}</pre
   ): Promise<string | null> {
     const renderer = new marked.Renderer();
     renderer.link = (href, title, text) => {
-      const safeHref = this.escapeHtmlAttr(this.appendRefParam(href ?? ""));
+      const safeHref = this.escapeHtmlAttr(
+        this.isSafeAnnouncementHref(href ?? "")
+          ? this.appendRefParam(href ?? "")
+          : "#",
+      );
       const titleAttr = title ? ` title="${this.escapeHtmlAttr(title)}"` : "";
       return `<a href="${safeHref}" target="_blank" rel="noopener"${titleAttr}>${text}</a>`;
     };
+    renderer.html = (html) => escapeHtml(html);
     renderer.code = (code, lang) => {
       const safeLang = (lang ?? "").replace(/[^a-z0-9-]/gi, "");
       const langClass = safeLang ? ` class="language-${safeLang}"` : "";
@@ -7649,6 +8123,24 @@ ${prettyEvent}</pre
       return `<div class="announcement-code"><pre><code${langClass}>${escaped}</code></pre><div class="announcement-code__copy-shield"><button type="button" class="announcement-code__copy" data-copy="${encoded}" aria-label="Copy code">Copy</button></div></div>`;
     };
     return marked.parse(markdown, { renderer, async: false });
+  }
+
+  private isSafeAnnouncementHref(href: string): boolean {
+    try {
+      const url = new URL(
+        href,
+        typeof window !== "undefined"
+          ? window.location.href
+          : "https://copilotkit.ai",
+      );
+      return (
+        url.protocol === "http:" ||
+        url.protocol === "https:" ||
+        url.protocol === "mailto:"
+      );
+    } catch {
+      return false;
+    }
   }
 
   private copyResetTimeouts = new WeakMap<HTMLButtonElement, number>();
@@ -7715,8 +8207,9 @@ ${prettyEvent}</pre
     }
   };
 
-  private appendRefParam(href: string): string {
+  private appendRefParam(href: string, ref = "cpk-inspector"): string {
     try {
+      const isRootRelative = href.startsWith("/") && !href.startsWith("//");
       const url = new URL(
         href,
         typeof window !== "undefined"
@@ -7724,7 +8217,7 @@ ${prettyEvent}</pre
           : "https://copilotkit.ai",
       );
       if (!url.searchParams.has("ref")) {
-        url.searchParams.append("ref", "cpk-inspector");
+        url.searchParams.append("ref", ref);
       }
       // Propagate the inspector's anonymous distinct-ID so the website /
       // Ops API can call posthog.alias(...) on signup-flow landing and
@@ -7733,17 +8226,26 @@ ${prettyEvent}</pre
       // suppresses cross-domain ID leaks too.
       if (
         !url.searchParams.has("posthog_distinct_id") &&
-        !this.core?.telemetryDisabled
+        !this.core?.telemetryDisabled &&
+        this.isCopilotKitDestination(url)
       ) {
         const distinctId = getTelemetryDistinctIdForUrl();
         if (distinctId) {
           url.searchParams.append("posthog_distinct_id", distinctId);
         }
       }
+      if (isRootRelative) {
+        return `${url.pathname}${url.search}${url.hash}`;
+      }
       return url.toString();
     } catch {
       return href;
     }
+  }
+
+  private isCopilotKitDestination(url: URL): boolean {
+    const hostname = url.hostname.toLowerCase();
+    return hostname === "copilotkit.ai" || hostname.endsWith(".copilotkit.ai");
   }
 
   private escapeHtmlAttr(value: string): string {

--- a/packages/web-inspector/src/lib/__tests__/telemetry.test.ts
+++ b/packages/web-inspector/src/lib/__tests__/telemetry.test.ts
@@ -1,16 +1,26 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MockInstance } from "vitest";
 
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import {
   TELEMETRY_DOCS_URL,
   TELEMETRY_EVENTS,
   TELEMETRY_INGEST_URL,
+  getRuntimeUrlType,
   getTelemetryDistinctIdForUrl,
   maybeShowDisclosure,
   track,
   trackBannerClicked,
   trackBannerViewed,
+  trackTalkToEngineerClicked,
+  trackThreadsEmptyEnabledViewed,
+  trackThreadsEnabledViewed,
+  trackThreadsIntelligenceSignupClicked,
+  trackThreadsLockedViewed,
   trackThreadsTabClicked,
+  trackThreadsTalkToEngineerClicked,
 } from "../telemetry.js";
 import {
   _resetTelemetryPersistenceForTesting,
@@ -26,6 +36,9 @@ import {
 // what would have been sent without making real HTTP requests.
 let fetchMock: MockInstance<typeof fetch>;
 let consoleInfoSpy: MockInstance<typeof console.info>;
+const webInspectorPackage = JSON.parse(
+  readFileSync(resolve(process.cwd(), "package.json"), "utf8"),
+) as { version: string };
 
 beforeEach(() => {
   // Each test starts from a clean localStorage so distinct-ID + opt-out
@@ -83,10 +96,12 @@ describe("track()", () => {
     // package is top-level object, not a string inside properties
     expect(body.package).toEqual({ name: "@copilotkit/web-inspector" });
     expect(body.properties).not.toHaveProperty("package");
+    expect(body.properties).not.toHaveProperty("package_name");
+    expect(body.properties).not.toHaveProperty("inspector_distinct_id");
     expect(typeof body.ts).toBe("number");
   });
 
-  it("sends regardless of localStorage opt-out — callers gate on core.telemetryDisabled", async () => {
+  it("short-circuits when localStorage opt-out is set", async () => {
     setTelemetryOptOut(true);
     expect(isTelemetryOptedOut()).toBe(true);
 
@@ -96,9 +111,20 @@ describe("track()", () => {
     });
     await Promise.resolve();
 
-    // track() no longer short-circuits on localStorage; opt-out is enforced
-    // at the call site via core.telemetryDisabled before track*() is invoked.
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("swallows unserializable properties before dispatching", async () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(() => track(TELEMETRY_EVENTS.bannerClicked, circular)).not.toThrow();
+    expect(() =>
+      track(TELEMETRY_EVENTS.bannerClicked, { value: 1n }),
+    ).not.toThrow();
+    await Promise.resolve();
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("swallows fetch failures (telemetry is best-effort)", async () => {
@@ -170,17 +196,131 @@ describe("typed helpers", () => {
     expect(body.properties.cta).toBe("body");
   });
 
-  it("trackThreadsTabClicked sends no caller-supplied properties", async () => {
-    trackThreadsTabClicked();
+  it("trackThreadsTabClicked sends thread metadata without content", async () => {
+    trackThreadsTabClicked({
+      intelligence_status: "intelligence_not_enabled",
+      thread_service_status: "unavailable",
+      runtime_mode: "sse",
+      runtime_url_type: "localhost",
+      license_status: "none",
+      telemetry_disabled: false,
+    });
     await Promise.resolve();
     const [, init] = fetchMock.mock.calls[0]!;
     const body = JSON.parse((init?.body as string) ?? "{}") as {
       event: string;
       properties: Record<string, unknown>;
+      package: { name: string; version?: string };
     };
     expect(body.event).toBe(TELEMETRY_EVENTS.threadsTabClicked);
-    // Only distinct_id should be in properties (no caller keys)
-    expect(Object.keys(body.properties)).toEqual(["distinct_id"]);
+    expect(body.properties).toMatchObject({
+      intelligence_status: "intelligence_not_enabled",
+      thread_service_status: "unavailable",
+      runtime_mode: "sse",
+      runtime_url_type: "localhost",
+      license_status: "none",
+      telemetry_disabled: false,
+      package_name: "@copilotkit/web-inspector",
+      package_version: webInspectorPackage.version,
+    });
+    expect(body.properties).toHaveProperty("inspector_distinct_id");
+    expect(body.properties.inspector_distinct_id).toBe(
+      body.properties.distinct_id,
+    );
+    expect(body.package).toEqual({
+      name: "@copilotkit/web-inspector",
+      version: webInspectorPackage.version,
+    });
+  });
+
+  it("sends required threads CTA and viewed events", async () => {
+    trackThreadsLockedViewed({
+      intelligence_status: "intelligence_not_enabled",
+      thread_service_status: "unavailable",
+    });
+    trackThreadsIntelligenceSignupClicked({
+      cta: "signup",
+      cta_surface: "threads_locked",
+      posthog_distinct_id: "abc-123",
+    });
+    trackThreadsTalkToEngineerClicked({
+      cta: "talk_to_engineer",
+      cta_surface: "threads_locked",
+      posthog_distinct_id: "abc-123",
+    });
+    trackTalkToEngineerClicked({
+      cta: "talk_to_engineer",
+      cta_surface: "threads_header",
+      posthog_distinct_id: "abc-123",
+    });
+    trackThreadsEmptyEnabledViewed({
+      intelligence_status: "intelligence_enabled",
+      thread_service_status: "available",
+      thread_count: 0,
+    });
+    trackThreadsEnabledViewed({
+      intelligence_status: "intelligence_enabled",
+      thread_service_status: "available",
+      thread_count: 2,
+    });
+
+    await Promise.resolve();
+
+    const payloads = fetchMock.mock.calls.map(([, init]) => {
+      return JSON.parse((init?.body as string) ?? "{}") as {
+        event: string;
+        properties: Record<string, unknown>;
+      };
+    });
+    const events = payloads.map((payload) => payload.event);
+    expect(events).toEqual([
+      TELEMETRY_EVENTS.threadsLockedViewed,
+      TELEMETRY_EVENTS.threadsIntelligenceSignupClicked,
+      TELEMETRY_EVENTS.threadsTalkToEngineerClicked,
+      TELEMETRY_EVENTS.talkToEngineerClicked,
+      TELEMETRY_EVENTS.threadsEmptyEnabledViewed,
+      TELEMETRY_EVENTS.threadsEnabledViewed,
+    ]);
+    expect(payloads[0]!.properties).toMatchObject({
+      intelligence_status: "intelligence_not_enabled",
+      thread_service_status: "unavailable",
+    });
+    expect(payloads[1]!.properties).toMatchObject({
+      cta: "signup",
+      cta_surface: "threads_locked",
+      posthog_distinct_id: "abc-123",
+    });
+    expect(payloads[2]!.properties).toMatchObject({
+      cta: "talk_to_engineer",
+      cta_surface: "threads_locked",
+      posthog_distinct_id: "abc-123",
+    });
+    expect(payloads[3]!.properties).toMatchObject({
+      cta: "talk_to_engineer",
+      cta_surface: "threads_header",
+      posthog_distinct_id: "abc-123",
+    });
+    expect(payloads[4]!.properties).toMatchObject({
+      intelligence_status: "intelligence_enabled",
+      thread_service_status: "available",
+      thread_count: 0,
+    });
+    expect(payloads[5]!.properties).toMatchObject({
+      intelligence_status: "intelligence_enabled",
+      thread_service_status: "available",
+      thread_count: 2,
+    });
+  });
+});
+
+// ─── Safe URL classification ────────────────────────────────────────────────
+
+describe("getRuntimeUrlType()", () => {
+  it("classifies runtime URLs without exposing origins", () => {
+    expect(getRuntimeUrlType(undefined)).toBe("missing");
+    expect(getRuntimeUrlType("/api/copilotkit")).toBe("relative");
+    expect(getRuntimeUrlType("http://localhost:4000")).toBe("localhost");
+    expect(getRuntimeUrlType("https://example.com/api")).toBe("remote");
   });
 });
 

--- a/packages/web-inspector/src/lib/telemetry.ts
+++ b/packages/web-inspector/src/lib/telemetry.ts
@@ -1,6 +1,5 @@
-// Inspector-side anonymous telemetry. Three V1 events fire from index.ts —
-// `oss.inspector.banner_viewed`, `oss.inspector.banner_clicked`, and
-// `oss.inspector.threads_tab_clicked`. POSTs directly from the browser
+// Inspector-side anonymous telemetry. V1 events fire from index.ts for
+// banner and thread-inspection interactions. POSTs directly from the browser
 // to the CopilotKit telemetry sink at `telemetry.copilotkit.ai/ingest`,
 // where a Lambda fan-out forwards events to PostHog / Reo / Scarf.
 //
@@ -31,6 +30,14 @@ export const TELEMETRY_EVENTS = {
   bannerViewed: "oss.inspector.banner_viewed",
   bannerClicked: "oss.inspector.banner_clicked",
   threadsTabClicked: "oss.inspector.threads_tab_clicked",
+  threadsLockedViewed: "oss.inspector.threads_locked_viewed",
+  threadsIntelligenceSignupClicked:
+    "oss.inspector.threads_intelligence_signup_clicked",
+  threadsTalkToEngineerClicked:
+    "oss.inspector.threads_talk_to_engineer_clicked",
+  talkToEngineerClicked: "oss.inspector.talk_to_engineer_clicked",
+  threadsEmptyEnabledViewed: "oss.inspector.threads_empty_enabled_viewed",
+  threadsEnabledViewed: "oss.inspector.threads_enabled_viewed",
 } as const;
 
 export type TelemetryEvent =
@@ -47,10 +54,62 @@ export const TELEMETRY_INGEST_URL = "https://telemetry.copilotkit.ai/ingest";
 export const TELEMETRY_DOCS_URL = "https://docs.copilotkit.ai/telemetry";
 
 const PACKAGE_NAME = "@copilotkit/web-inspector";
+const PACKAGE_VERSION = "1.61.1";
 
 // 3-second cap so a slow gateway can't hang the host app. Matches the
 // runtime's existing scarf-client convention.
 const FETCH_TIMEOUT_MS = 3000;
+
+function isThreadsTelemetryEvent(event: TelemetryEvent): boolean {
+  return (
+    event === TELEMETRY_EVENTS.threadsTabClicked ||
+    event === TELEMETRY_EVENTS.threadsLockedViewed ||
+    event === TELEMETRY_EVENTS.threadsIntelligenceSignupClicked ||
+    event === TELEMETRY_EVENTS.threadsTalkToEngineerClicked ||
+    event === TELEMETRY_EVENTS.talkToEngineerClicked ||
+    event === TELEMETRY_EVENTS.threadsEmptyEnabledViewed ||
+    event === TELEMETRY_EVENTS.threadsEnabledViewed
+  );
+}
+
+export type RuntimeUrlType =
+  | "missing"
+  | "relative"
+  | "localhost"
+  | "same_origin"
+  | "remote"
+  | "invalid";
+
+export function getRuntimeUrlType(
+  runtimeUrl: string | undefined,
+): RuntimeUrlType {
+  if (!runtimeUrl) return "missing";
+  if (runtimeUrl.startsWith("/") && !runtimeUrl.startsWith("//")) {
+    return "relative";
+  }
+
+  try {
+    const baseHref =
+      typeof window !== "undefined"
+        ? window.location.href
+        : "https://copilotkit.ai";
+    const url = new URL(runtimeUrl, baseHref);
+    const baseUrl = new URL(baseHref);
+    const hostname = url.hostname.toLowerCase();
+
+    if (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "[::1]"
+    ) {
+      return "localhost";
+    }
+
+    return url.origin === baseUrl.origin ? "same_origin" : "remote";
+  } catch {
+    return "invalid";
+  }
+}
 
 /**
  * Fire-and-forget telemetry send. Returns synchronously; the network
@@ -64,16 +123,34 @@ export function track(
   event: TelemetryEvent,
   properties: Record<string, unknown> = {},
 ): void {
+  if (isTelemetryOptedOut()) return;
+
   const distinctId = getOrCreateTelemetryDistinctId();
-  const body = JSON.stringify({
-    event,
-    properties: {
-      ...properties,
-      distinct_id: distinctId,
-    },
-    package: { name: PACKAGE_NAME },
-    ts: Math.floor(Date.now() / 1000),
-  });
+  const threadsProperties = isThreadsTelemetryEvent(event)
+    ? {
+        package_name: PACKAGE_NAME,
+        package_version: PACKAGE_VERSION,
+        inspector_distinct_id: distinctId,
+      }
+    : {};
+  let body: string;
+  try {
+    body = JSON.stringify({
+      event,
+      properties: {
+        ...properties,
+        ...threadsProperties,
+        distinct_id: distinctId,
+      },
+      package: {
+        name: PACKAGE_NAME,
+        ...(isThreadsTelemetryEvent(event) ? { version: PACKAGE_VERSION } : {}),
+      },
+      ts: Math.floor(Date.now() / 1000),
+    });
+  } catch {
+    return;
+  }
 
   void postBestEffort(TELEMETRY_INGEST_URL, body, distinctId);
 }
@@ -97,8 +174,75 @@ export function trackBannerClicked(props: {
   track(TELEMETRY_EVENTS.bannerClicked, props);
 }
 
-export function trackThreadsTabClicked(): void {
-  track(TELEMETRY_EVENTS.threadsTabClicked);
+type InspectorThreadTelemetryProps = {
+  package_name?: typeof PACKAGE_NAME;
+  package_version?: typeof PACKAGE_VERSION;
+  inspector_distinct_id?: string;
+  posthog_distinct_id?: string;
+  intelligence_status?:
+    | "intelligence_not_enabled"
+    | "intelligence_enabled"
+    | "unknown";
+  thread_service_status?: "unavailable" | "available" | "unknown" | "error";
+  license_status?:
+    | "valid"
+    | "none"
+    | "expired"
+    | "expiring"
+    | "invalid"
+    | "unknown";
+  runtime_mode?: "sse" | "intelligence";
+  runtime_url_type?: RuntimeUrlType;
+  cta_surface?:
+    | "threads_locked"
+    | "threads_header"
+    | "threads_empty"
+    | "threads_populated";
+  cta?: "signup" | "talk_to_engineer";
+  telemetry_disabled?: boolean;
+  thread_count?: number;
+};
+
+export function trackThreadsTabClicked(
+  props: InspectorThreadTelemetryProps = {},
+): void {
+  track(TELEMETRY_EVENTS.threadsTabClicked, props);
+}
+
+export function trackThreadsLockedViewed(
+  props: InspectorThreadTelemetryProps,
+): void {
+  track(TELEMETRY_EVENTS.threadsLockedViewed, props);
+}
+
+export function trackThreadsIntelligenceSignupClicked(
+  props: InspectorThreadTelemetryProps,
+): void {
+  track(TELEMETRY_EVENTS.threadsIntelligenceSignupClicked, props);
+}
+
+export function trackThreadsTalkToEngineerClicked(
+  props: InspectorThreadTelemetryProps,
+): void {
+  track(TELEMETRY_EVENTS.threadsTalkToEngineerClicked, props);
+}
+
+export function trackTalkToEngineerClicked(
+  props: InspectorThreadTelemetryProps,
+): void {
+  track(TELEMETRY_EVENTS.talkToEngineerClicked, props);
+}
+
+export function trackThreadsEmptyEnabledViewed(
+  props: InspectorThreadTelemetryProps,
+): void {
+  track(TELEMETRY_EVENTS.threadsEmptyEnabledViewed, props);
+}
+
+export function trackThreadsEnabledViewed(
+  props: InspectorThreadTelemetryProps,
+): void {
+  track(TELEMETRY_EVENTS.threadsEnabledViewed, props);
 }
 
 /**

--- a/packages/web-inspector/src/lib/telemetry.ts
+++ b/packages/web-inspector/src/lib/telemetry.ts
@@ -174,7 +174,7 @@ export function trackBannerClicked(props: {
   track(TELEMETRY_EVENTS.bannerClicked, props);
 }
 
-type InspectorThreadTelemetryProps = {
+export type InspectorThreadTelemetryProps = {
   package_name?: typeof PACKAGE_NAME;
   package_version?: typeof PACKAGE_VERSION;
   inspector_distinct_id?: string;

--- a/packages/web-inspector/src/lib/telemetry.ts
+++ b/packages/web-inspector/src/lib/telemetry.ts
@@ -21,11 +21,11 @@ import {
   isTelemetryOptedOut,
   markTelemetryDisclosureShown,
 } from "./persistence.js";
+import packageJson from "../../package.json" with { type: "json" };
 
 // V1 funnel events. Namespaced `oss.inspector.*` so the lambda's
-// event-type allowlist (oss-path-to-production) can gate them
-// server-side. Adding a new event here requires a corresponding
-// allowlist entry on the lambda or events will be rejected.
+// owned-prefix gate (oss-path-to-production) can accept them server-side
+// without a per-event sink deploy.
 export const TELEMETRY_EVENTS = {
   bannerViewed: "oss.inspector.banner_viewed",
   bannerClicked: "oss.inspector.banner_clicked",
@@ -54,7 +54,7 @@ export const TELEMETRY_INGEST_URL = "https://telemetry.copilotkit.ai/ingest";
 export const TELEMETRY_DOCS_URL = "https://docs.copilotkit.ai/telemetry";
 
 const PACKAGE_NAME = "@copilotkit/web-inspector";
-const PACKAGE_VERSION = "1.61.1";
+const PACKAGE_VERSION = packageJson.version;
 
 // 3-second cap so a slow gateway can't hang the host app. Matches the
 // runtime's existing scarf-client convention.
@@ -176,7 +176,7 @@ export function trackBannerClicked(props: {
 
 export type InspectorThreadTelemetryProps = {
   package_name?: typeof PACKAGE_NAME;
-  package_version?: typeof PACKAGE_VERSION;
+  package_version?: string;
   inspector_distinct_id?: string;
   posthog_distinct_id?: string;
   intelligence_status?:


### PR DESCRIPTION
## Summary
- Adds the Inspector Threads locked state for non-Intelligence installs with a faded full-background thread mockup, updated headline, CTA order/styling, and production Talk to an Engineer destination.
- Adds Threads telemetry events and metadata for tab click, locked/enabled/empty views, and CTA clicks, including package/runtime/status fields that can be derived safely.
- Hardens adjacent inspector paths found during review: telemetry opt-out and serialization safety, preserved realtime wsUrl on header refresh, unknown thread endpoint status handling, stale selected-thread rendering, announcement HTML/link safety, RUN_ERROR styling, context value rendering, and thread-detail URL joining for trailing-slash runtime URLs.

## Telemetry notes
Implemented derivable/safe fields: package_name, package_version, inspector_distinct_id, posthog_distinct_id for attributed CTA URLs, intelligence_status, thread_service_status, runtime_url_type, runtime_mode, license_status, telemetry_disabled, cta, cta_surface, and thread_count.

Telemetry sink allowlist checked: `CopilotKit/oss-path-to-production` already accepts the owned `oss.inspector.*` namespace via its prefix gate, so no sink source allowlist change is required. Added https://github.com/CopilotKit/oss-path-to-production/pull/173 to pin the new Inspector Threads event names in ingest tests. The package/version metadata now reads from `packages/web-inspector/package.json` instead of a hardcoded version string.

Not implemented because they are not currently available from safe public inspector state:
- has_public_license_key: no explicit public boolean is exposed; deriving from headers/config could imply token state.
- cta_variant: current UI has no variant state to distinguish.

## Validation
- NX_TUI=false pnpm nx run @copilotkit/web-inspector:check-types --skip-nx-cache
- NX_TUI=false pnpm nx run @copilotkit/web-inspector:test --skip-nx-cache (43 tests passed)
- NX_TUI=false pnpm nx run @copilotkit/web-inspector:build --skip-nx-cache
- NX_TUI=false pnpm nx run @copilotkit/core:check-types --skip-nx-cache
- git diff --check
- Telemetry sink validation in https://github.com/CopilotKit/oss-path-to-production/pull/173: `pnpm test -- telemetry-sink-ingest.test.ts` and `pnpm build`
- 7-agent code review pass, followed by 3-agent focused confirmation pass with no remaining findings in scope
- Pre-commit package matrix hit an unrelated @copilotkit/react-core:test timeout in `A2UIMessageRenderer.test.tsx` during amend; targeted web-inspector checks above passed

## Screenshot
![Inspector Threads locked state](https://gist.githubusercontent.com/samjulien/98d0569b33990b4cf740aa14e1790614/raw/b344397d6e326e9102c4e3d90ba1a9772710e42d/inspector-threads-locked-live.svg)

