### PR TITLE
fix(showcase): honest promote-notify message + durable healthcheckPath tracking

### DIFF
--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -497,6 +497,9 @@ jobs:
       # GITHUB_TOKEN), so the renderer dispatch goes through the devops-bot App
       # token minted below — mirroring canary.yml's cross-workflow dispatch.
       contents: read
+      # actions:read lets the payload step query this run's own metadata
+      # (created_at) to compute real wall-clock elapsed for the Slack message.
+      actions: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -517,6 +520,8 @@ jobs:
           # reliable email for github.actor, so pass the actor as the git-name
           # fallback (the renderer degrades to it when the email lookup is empty).
           ACTOR: ${{ github.actor }}
+          # gh api (run metadata lookup for real wall-clock elapsed) needs a token.
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           # SKIP cases that must NOT post a Slack message (parity with the old
@@ -558,17 +563,37 @@ jobs:
             jq -nc '{schema_version:1, abort_reason:"fleet-preflight", succeeded:[], failed:[]}' > /tmp/results-base.json
           fi
 
+          # Real wall-clock elapsed: this notify job runs last (needs: [...],
+          # if: always()), so (now - run.created_at) is the run's end-to-end
+          # duration. Query this run's own metadata via gh api (actions:read).
+          # Fall back to 0 only if the lookup fails or yields a non-sane value,
+          # in which case the renderer omits the "in {elapsed}" phrasing.
+          ELAPSED=0
+          created_at=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --jq '.created_at' 2>/dev/null || echo "")
+          if [ -n "$created_at" ]; then
+            start_epoch=$(date -u -d "$created_at" +%s 2>/dev/null || echo "")
+            if [ -n "$start_epoch" ]; then
+              now_epoch=$(date -u +%s)
+              delta=$(( now_epoch - start_epoch ))
+              # Guard against clock skew / parse glitches producing a negative.
+              if [ "$delta" -ge 0 ]; then
+                ELAPSED="$delta"
+              fi
+            fi
+          fi
+
           # Enrich the base blob with this run's context (run_id, trigger,
           # operator, elapsed, pre_staging). trigger=workflow (the renderer maps
-          # it to the `showcase_promote.yml` label). elapsed is best-effort 0
-          # here (the workflow does not track wall-clock); the renderer formats
-          # it as "0m 00s".
+          # it to the `showcase_promote.yml` label). elapsed_seconds is the real
+          # wall-clock computed above; the renderer formats it as "Nm SSs".
           ENRICHED_B64=$(jq -c \
             --arg run_id "$RUN_ID" \
             --arg trigger "workflow" \
             --arg actor "$ACTOR" \
             --arg pre "$PRE_STAGING" \
-            '. + {run_id:$run_id, trigger:$trigger, operator_git_name:$actor, elapsed_seconds:0, pre_staging:$pre}' \
+            --argjson elapsed "$ELAPSED" \
+            '. + {run_id:$run_id, trigger:$trigger, operator_git_name:$actor, elapsed_seconds:$elapsed, pre_staging:$pre}' \
             /tmp/results-base.json | base64 | tr -d '\n')
 
           {

--- a/.github/workflows/showcase_promote_notify.dry-run.sh
+++ b/.github/workflows/showcase_promote_notify.dry-run.sh
@@ -69,7 +69,13 @@ fi
 trigger=$(jq -r '.trigger' "$R")
 operator_email=$(jq -r '.operator_email // ""' "$R")
 operator_git_name=$(jq -r '.operator_git_name // ""' "$R")
-elapsed=$(jq -r '.elapsed_seconds // 0' "$R")
+# Coerce to an integer up front: elapsed_seconds may arrive as a float (e.g.
+# 5.2) OR as a JSON STRING (e.g. "5.2"). `floor` on a string raises jq error 5
+# ("number required") which, under `set -euo pipefail`, aborts the whole render
+# step so NO Slack message posts. `tonumber?` parses numeric strings and
+# swallows non-numeric input (-> 0); `floor` then yields the integer Bash
+# `[ -gt ]`/`$(( ))` need.
+elapsed=$(jq -r '(.elapsed_seconds // 0) | tonumber? // 0 | floor' "$R")
 pre_staging=$(jq -r '.pre_staging // "skipped"' "$R")
 abort_reason=$(jq -r '.abort_reason // ""' "$R")
 succeeded_count=$(jq -r '.succeeded | length' "$R")
@@ -91,22 +97,44 @@ failed_real_count=$(jq 'length' /tmp/dry-run-failed-render.json)
 total_count=$((succeeded_count + failed_real_count))
 
 # Comma-separated list of the SUCCEEDED service names, for the ✅ success
-# thread reply. The runtime blob emits .succeeded[] as {service} objects (see
-# promote-fleet.sh); tolerate bare strings too (hand-written fixtures use them).
+# thread reply AND the ⚠️ partial reply's `Promoted:` line. The runtime blob
+# emits .succeeded[] as {service} objects (see promote-fleet.sh); tolerate bare
+# strings too (hand-written fixtures use them).
 succeeded_csv=$(jq -r '[.succeeded[] | if type == "object" then .service else . end] | join(", ")' "$R")
+
+# Names of every ATTEMPTED service (succeeded + real failures), for the init
+# post. For `service=all` this is the drifted subset resolve-targets selected;
+# for a scoped/single-service dispatch it is exactly what was requested. Either
+# way it is the set we ATTEMPTED — we do not claim the rest was already current.
+# Sorted for a stable, legible list; the truncation-suffix sentinel is excluded
+# via /tmp/dry-run-failed-render.json.
+attempted_csv=$(jq -rs '
+  (.[0] | [.succeeded[] | if type == "object" then .service else . end])
+  + (.[1] | [.[].service])
+  | sort | join(", ")
+' "$R" /tmp/dry-run-failed-render.json)
 
 # GitHub Actions run URL — used by the success message's inline "View run" link.
 # In CI GITHUB_REPOSITORY/GITHUB_RUN_ID are set; in a bare dry-run they may not
 # be, so fall back to a stable placeholder so the rendered shape still matches.
 gha_url="https://github.com/${GITHUB_REPOSITORY:-CopilotKit/CopilotKit}/actions/runs/${GITHUB_RUN_ID:-<run_id>}"
 
+# elapsed is the real wall-clock seconds the dispatcher measured
+# (showcase_promote.yml computes now - run.created_at). When it is a positive
+# value we render " in Nm SSs"; when it is 0 (dispatcher could not measure it,
+# or a hand-dispatch passed nothing) we OMIT the phrase entirely rather than
+# print a meaningless "in 0m 00s".
 fmt_elapsed() {
   local total="$1"
   local m=$((total / 60))
   local s=$((total % 60))
   printf '%dm %02ds' "$m" "$s"
 }
-elapsed_str=$(fmt_elapsed "$elapsed")
+if [ "$elapsed" -gt 0 ] 2>/dev/null; then
+  elapsed_phrase=" in $(fmt_elapsed "$elapsed")"
+else
+  elapsed_phrase=""
+fi
 
 # operator mention: dry-run simulates a successful Slack lookup; falls back to git name then "unknown" if no email present.
 if [ -n "$operator_email" ]; then
@@ -133,7 +161,18 @@ else
   trigger_label='`showcase_promote.yml`'
 fi
 
-init_text="🚂 *Promoting showcase → prod* (${total_count} services)
+# Name the services being promoted this run. We name only what was ATTEMPTED
+# — accurate whether the dispatch was `service=all` (the drifted subset) or a
+# single service. We do NOT claim the rest of the fleet was "already current":
+# for a scoped/single-service dispatch that is false (it conflates "attempted"
+# with "drifted"). Fall back to a bare count when the attempted set is empty
+# (e.g. a fleet-preflight abort that touched zero services).
+if [ -n "$attempted_csv" ]; then
+  init_headline="🚂 *Promoting showcase → prod* (${total_count}): ${attempted_csv}"
+else
+  init_headline="🚂 *Promoting showcase → prod* (${total_count})"
+fi
+init_text="${init_headline}
 operator ${operator_mention} · trigger ${trigger_label} · run \`${run_id}\`
 ${pre_staging_line}"
 
@@ -166,13 +205,11 @@ if [ -n "$abort_reason" ] && [ "$succeeded_count" -eq 0 ]; then
   if [ "$failed_real_count" -eq 0 ]; then
     # Fleet-preflight abort with zero services touched: no bullets to
     # render, so omit the *Failed:* heading entirely.
-    thread_text="❌ *Aborted in ${elapsed_str}* — 0 ✓ · 0 ✗
-verify-prod: not run
+    thread_text="❌ *Aborted${elapsed_phrase}* — 0 ✓ · 0 ✗
 ${pre_staging_line}
 ${reason_line}"
   else
-    thread_text="❌ *Aborted in ${elapsed_str}* — 0 ✓ · ${failed_real_count} ✗
-verify-prod: not run
+    thread_text="❌ *Aborted${elapsed_phrase}* — 0 ✓ · ${failed_real_count} ✗
 ${pre_staging_line}
 ${reason_line}
 *Failed:*
@@ -184,8 +221,8 @@ elif [ "$failed_real_count" -eq 0 ]; then
 Services: ${succeeded_csv}"
 elif [ "$succeeded_count" -gt 0 ] && [ "$failed_real_count" -gt 0 ]; then
   outcome="partial"
-  thread_text="⚠️ *Done in ${elapsed_str}* — ${succeeded_count} ✓ · ${failed_real_count} ✗
-verify-prod: ✓ on succeeded · n/a on failed
+  thread_text="⚠️ *Done${elapsed_phrase}* — ${succeeded_count} ✓ · ${failed_real_count} ✗
+*Promoted:* ${succeeded_csv}
 *Failed:*
 ${fail_bullets}"
 else
@@ -197,8 +234,7 @@ else
     per-service)     reason_line="*Reason:* all services individually refused" ;;
     *)               reason_line="*Reason:* aborted" ;;
   esac
-  thread_text="❌ *Aborted in ${elapsed_str}* — 0 ✓ · ${failed_real_count} ✗
-verify-prod: not run
+  thread_text="❌ *Aborted${elapsed_phrase}* — 0 ✓ · ${failed_real_count} ✗
 ${pre_staging_line}
 ${reason_line}
 *Failed:*

--- a/.github/workflows/showcase_promote_notify.yml
+++ b/.github/workflows/showcase_promote_notify.yml
@@ -116,15 +116,22 @@ jobs:
           trigger=$(jq -r '.trigger' "$R")
           operator_email=$(jq -r '.operator_email // ""' "$R")
           operator_git_name=$(jq -r '.operator_git_name // ""' "$R")
-          elapsed=$(jq -r '.elapsed_seconds // 0' "$R")
+          # Coerce to an integer up front: elapsed_seconds may arrive as a float
+          # (e.g. 5.2) OR as a JSON STRING (e.g. "5.2"). `floor` on a string
+          # raises jq error 5 ("number required") which, under `set -euo
+          # pipefail`, aborts the whole render step so NO Slack message posts.
+          # `tonumber?` parses numeric strings and swallows non-numeric input
+          # (-> 0); `floor` then yields the integer Bash `[ -gt ]`/`$(( ))` need.
+          elapsed=$(jq -r '(.elapsed_seconds // 0) | tonumber? // 0 | floor' "$R")
           pre_staging=$(jq -r '.pre_staging // "skipped"' "$R")
           abort_reason=$(jq -r '.abort_reason // ""' "$R")
           succeeded_count=$(jq -r '.succeeded | length' "$R")
           failed_count=$(jq -r '.failed | length' "$R")
 
           # Comma-separated list of the SUCCEEDED service names, for the ✅
-          # success thread reply. The runtime blob emits .succeeded[] as
-          # {service} objects (see promote-fleet.sh); tolerate bare strings too.
+          # success thread reply AND the ⚠️ partial reply's `Promoted:` line.
+          # The runtime blob emits .succeeded[] as {service} objects (see
+          # promote-fleet.sh); tolerate bare strings too.
           succeeded_csv=$(jq -r '[.succeeded[] | if type == "object" then .service else . end] | join(", ")' "$R")
 
           # GitHub Actions run URL — used by the success message's inline
@@ -151,14 +158,36 @@ jobs:
           # are not real services).
           total_count=$((succeeded_count + failed_real_count))
 
+          # Names of every ATTEMPTED service (succeeded + real failures), for
+          # the init post. For `service=all` this is the drifted subset
+          # resolve-targets selected; for a scoped/single-service dispatch it is
+          # exactly what was requested. Either way it is the set we ATTEMPTED —
+          # we do not claim the rest was already current. Sorted for a stable,
+          # legible list; the truncation-suffix sentinel (not a real service) is
+          # excluded via /tmp/failed-render.json.
+          attempted_csv=$(jq -rs '
+            (.[0] | [.succeeded[] | if type == "object" then .service else . end])
+            + (.[1] | [.[].service])
+            | sort | join(", ")
+          ' "$R" /tmp/failed-render.json)
+
           # ---------- format elapsed seconds ----------
+          # elapsed is the real wall-clock seconds the dispatcher measured
+          # (showcase_promote.yml computes now - run.created_at). When it is a
+          # positive value we render " in Nm SSs"; when it is 0 (dispatcher
+          # could not measure it, or a hand-dispatch passed nothing) we OMIT the
+          # phrase entirely rather than print a meaningless "in 0m 00s".
           fmt_elapsed() {
             local total="$1"
             local m=$((total / 60))
             local s=$((total % 60))
             printf '%dm %02ds' "$m" "$s"
           }
-          elapsed_str=$(fmt_elapsed "$elapsed")
+          if [ "$elapsed" -gt 0 ] 2>/dev/null; then
+            elapsed_phrase=" in $(fmt_elapsed "$elapsed")"
+          else
+            elapsed_phrase=""
+          fi
 
           # ---------- resolve operator mention ----------
           operator_mention=""
@@ -203,7 +232,19 @@ jobs:
           fi
 
           # ---------- initiation post ----------
-          init_text="🚂 *Promoting showcase → prod* (${total_count} services)
+          # Name the services being promoted this run. We name only what was
+          # ATTEMPTED — accurate whether the dispatch was `service=all` (the
+          # drifted subset) or a single service. We do NOT claim the rest of
+          # the fleet was "already current": for a scoped/single-service
+          # dispatch that is false (it conflates "attempted" with "drifted").
+          # Fall back to a bare count when the attempted set is empty (e.g. a
+          # fleet-preflight abort that touched zero services).
+          if [ -n "$attempted_csv" ]; then
+            init_headline="🚂 *Promoting showcase → prod* (${total_count}): ${attempted_csv}"
+          else
+            init_headline="🚂 *Promoting showcase → prod* (${total_count})"
+          fi
+          init_text="${init_headline}
           operator ${operator_mention} · trigger ${trigger_label} · run \`${run_id}\`
           ${pre_staging_line}"
           # Strip leading whitespace introduced by the heredoc-style indent above.
@@ -268,13 +309,11 @@ jobs:
             if [ "$failed_real_count" -eq 0 ]; then
               # Fleet-preflight abort with zero services touched: no
               # bullets to render, so omit the *Failed:* heading entirely.
-              thread_text="❌ *Aborted in ${elapsed_str}* — 0 ✓ · 0 ✗
-          verify-prod: not run
+              thread_text="❌ *Aborted${elapsed_phrase}* — 0 ✓ · 0 ✗
           ${pre_staging_line}
           ${reason_line}"
             else
-              thread_text="❌ *Aborted in ${elapsed_str}* — 0 ✓ · ${failed_real_count} ✗
-          verify-prod: not run
+              thread_text="❌ *Aborted${elapsed_phrase}* — 0 ✓ · ${failed_real_count} ✗
           ${pre_staging_line}
           ${reason_line}
           *Failed:*
@@ -286,8 +325,8 @@ jobs:
           Services: ${succeeded_csv}"
           elif [ "$succeeded_count" -gt 0 ] && [ "$failed_real_count" -gt 0 ]; then
             outcome="partial"
-            thread_text="⚠️ *Done in ${elapsed_str}* — ${succeeded_count} ✓ · ${failed_real_count} ✗
-          verify-prod: ✓ on succeeded · n/a on failed
+            thread_text="⚠️ *Done${elapsed_phrase}* — ${succeeded_count} ✓ · ${failed_real_count} ✗
+          *Promoted:* ${succeeded_csv}
           *Failed:*
           ${fail_bullets}"
           else
@@ -299,8 +338,7 @@ jobs:
               per-service)     reason_line="*Reason:* all services individually refused" ;;
               *)               reason_line="*Reason:* aborted" ;;
             esac
-            thread_text="❌ *Aborted in ${elapsed_str}* — 0 ✓ · ${failed_real_count} ✗
-          verify-prod: not run
+            thread_text="❌ *Aborted${elapsed_phrase}* — 0 ✓ · ${failed_real_count} ✗
           ${pre_staging_line}
           ${reason_line}
           *Failed:*

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -802,6 +802,28 @@ module Railway
             }
         GQL
 
+        # Variant of UPDATE_IMAGE_MUTATION that ALSO re-asserts the SSOT
+        # healthcheckPath alongside source.image. Railway's
+        # ServiceInstanceUpdateInput accepts healthcheckPath next to source (see
+        # deploy-to-railway.ts / provision-starter-fleet.ts, which set it via the
+        # same mutation), and treats an absent input key as "leave as-is" — so a
+        # partial update of {source, healthcheckPath} is safe.
+        #
+        # CRITICAL: this variant is used ONLY when the SSOT declares a path for
+        # the target service+env. When the SSOT has NO path (a live-null
+        # service), the caller uses the plain UPDATE_IMAGE_MUTATION above so the
+        # `healthcheckPath` key is OMITTED entirely — we MUST NOT send
+        # `healthcheckPath: null`, which would actively CLEAR it on Railway.
+        UPDATE_IMAGE_AND_HEALTHCHECK_MUTATION = <<~GQL
+            mutation UpdateImage($serviceId: String!, $envId: String!, $image: String!, $healthcheckPath: String!) {
+                serviceInstanceUpdate(
+                    serviceId: $serviceId
+                    environmentId: $envId
+                    input: { source: { image: $image }, healthcheckPath: $healthcheckPath }
+                )
+            }
+        GQL
+
         # serviceInstanceDeployV2 spawns a NEW deployment that pulls the current
         # source.image (just advanced by UPDATE_IMAGE_MUTATION) and returns the
         # new deployment id (String!). This is what actually activates the pin.
@@ -1120,7 +1142,16 @@ module Railway
         # SUCCESS and SERVES the pinned digest (bug #2 — config advancing is not
         # enough; the running container must actually pull the pinned image).
         # `sleeper:` is injected for tests.
-        def self.pin_and_verify(gql, service_id:, env_id:, image:, sleeper: ->(n) { sleep(n) })
+        #
+        # `healthcheck_path:` — the SSOT-declared HTTP healthcheck path for this
+        # service+env, or nil when the SSOT tracks NONE. When present, the pin
+        # mutation RE-ASSERTS it alongside source.image so a prod instance whose
+        # healthcheckPath silently went null (the aimock incident) self-heals to
+        # the tracked value on the next promote. When nil, the plain
+        # image-only mutation is used and the `healthcheckPath` key is OMITTED
+        # entirely — we NEVER send `healthcheckPath: null` (which would actively
+        # CLEAR it). This is the durable lever the SSOT-tracking change adds.
+        def self.pin_and_verify(gql, service_id:, env_id:, image:, healthcheck_path: nil, sleeper: ->(n) { sleep(n) })
             # Upfront guard: this method's contract is to pin a DIGEST-form
             # image. Pre-fix, a stray tag ref would fall through to retries
             # (since expected_digest stayed nil and image_ok was always false)
@@ -1141,8 +1172,18 @@ module Railway
             pre_inst = pre_data && pre_data["serviceInstance"]
             pre_update_ts = pre_inst && pre_inst["updatedAt"]
 
-            updated = gql.query(RestoreCommand::UPDATE_IMAGE_MUTATION,
-                serviceId: service_id, envId: env_id, image: image)
+            # Re-assert the SSOT healthcheckPath alongside source.image ONLY when
+            # the SSOT declares one. A nil/empty path uses the image-only
+            # mutation so the healthcheckPath key is OMITTED (never sent as
+            # null, which would clear it) — a live-null service stays null.
+            if healthcheck_path.nil? || healthcheck_path.to_s.empty?
+                updated = gql.query(RestoreCommand::UPDATE_IMAGE_MUTATION,
+                    serviceId: service_id, envId: env_id, image: image)
+            else
+                updated = gql.query(RestoreCommand::UPDATE_IMAGE_AND_HEALTHCHECK_MUTATION,
+                    serviceId: service_id, envId: env_id, image: image,
+                    healthcheckPath: healthcheck_path)
+            end
             unless updated && updated["serviceInstanceUpdate"] == true
                 raise MutationError,
                     "P5: serviceInstanceUpdate returned #{updated.inspect} (expected true) for #{service_id} -> #{image}"
@@ -1721,8 +1762,10 @@ module Railway
         # `:latest` — record it so emit_staging_drift_warnings can surface it
         # loudly. Does NOT add a finding (promote PROCEEDS with the running
         # digest — that is the contract); a drift is a visible warning, not a
-        # refuse. Best-effort: a GHCR error resolving `:latest` is swallowed so
-        # it never blocks a promote whose running digest already verified.
+        # refuse. Best-effort: a GHCR error resolving `:latest` is surfaced as a
+        # WARN (never blocks) so a promote whose running digest already verified
+        # proceeds, while the operator is not misled into reading a check
+        # failure as "no drift".
         def detect_staging_drift(svc, resolved)
             # --digest override: when the operator deliberately pinned an
             # explicit digest for this single service (see resolved_prod_image
@@ -2304,10 +2347,18 @@ module Railway
                     next
                 end
                 begin
+                    # Re-assert the SSOT-tracked prod healthcheckPath on every
+                    # promote (the durable fix: a prod instance whose path
+                    # silently went null self-heals). Read it from the generated
+                    # SSOT record; nil when the service tracks none (live-null) —
+                    # pin_and_verify then OMITS the field rather than clearing it.
+                    ssot_healthcheck = (ssot_service(svc["name"]) || {})
+                        .dig("healthcheckPath", "prod")
                     PromoteCommand.pin_and_verify(gql,
                         service_id: pmatch["service_id"],
                         env_id: PRODUCTION_ENV_ID,
-                        image: image)
+                        image: image,
+                        healthcheck_path: ssot_healthcheck)
                     puts "promoted #{svc['name']} -> #{image}"
                     already_pinned << svc["name"]
                 # Broadened rescue: a transient GraphQL or network error

--- a/showcase/bin/spec/test_promote_healthcheck_reassert.rb
+++ b/showcase/bin/spec/test_promote_healthcheck_reassert.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+# Re-assertion of the SSOT healthcheckPath on the promote pin (the durable fix
+# for the aimock silent-null incident). pin_and_verify must:
+#   - INCLUDE healthcheckPath in the serviceInstanceUpdate input when the SSOT
+#     declares a path for the service+env (e.g. aimock -> /health), and
+#   - OMIT it entirely (never send `healthcheckPath: null`) when the SSOT tracks
+#     none (a live-null service like docs), so a null-live service is never
+#     accidentally cleared OR set to a wrong path.
+class PromoteHealthcheckReassertTest < Minitest::Test
+    class FakeGQL
+        def initialize(plan); @plan = plan; @calls = []; end
+        attr_reader :calls
+
+        def query(q, vars = {})
+            @calls << [q, vars]
+            step = @plan.shift
+            raise "fake exhausted at call ##{@calls.size}: #{q[0, 40]}" unless step
+            raise step[:raise] if step[:raise]
+            step[:data]
+        end
+    end
+
+    NEW_DEPLOY_ID = "dep-new"
+
+    def pre(ts) = { data: { "serviceInstance" => { "id" => "i", "source" => { "image" => "ghcr.io/copilotkit/x@sha256:OLD" }, "updatedAt" => ts } } }
+    def post(image:, ts:) = { data: { "serviceInstance" => { "id" => "i", "source" => { "image" => image }, "updatedAt" => ts } } }
+    def deploy_ok(id = NEW_DEPLOY_ID) = { data: { "serviceInstanceDeployV2" => id } }
+
+    def serving(digest:, status: "SUCCESS", deploy_id: NEW_DEPLOY_ID)
+        {
+            data: {
+                "serviceInstance" => {
+                    "id" => "i",
+                    "source" => { "image" => "ghcr.io/copilotkit/x@#{digest}" },
+                    "updatedAt" => "2026-05-28T03:00:00Z",
+                    "latestDeployment" => {
+                        "id" => deploy_id, "status" => status,
+                        "meta" => { "imageDigest" => digest },
+                    },
+                },
+            },
+        }
+    end
+
+    def happy_plan
+        [
+            pre("2026-05-27T00:00:00Z"),
+            { data: { "serviceInstanceUpdate" => true } },
+            deploy_ok,
+            post(image: "ghcr.io/copilotkit/x@sha256:NEW", ts: "2026-05-28T01:00:00Z"),
+            serving(digest: "sha256:NEW"),
+        ]
+    end
+
+    # The serviceInstanceUpdate is always the 2nd GQL call (after the pre-update
+    # snapshot). Returns [query_string, vars] for that call.
+    def update_call(gql) = gql.calls[1]
+
+    def test_includes_healthcheck_path_when_ssot_declares_one
+        gql = FakeGQL.new(happy_plan)
+        Railway::PromoteCommand.pin_and_verify(gql,
+            service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+            healthcheck_path: "/health", sleeper: ->(_n) {})
+
+        query, vars = update_call(gql)
+        # The mutation must DECLARE + USE $healthcheckPath in the input, and the
+        # vars must carry the SSOT value.
+        assert_match(/\$healthcheckPath:\s*String/, query,
+            "update mutation should declare a healthcheckPath variable")
+        assert_match(/healthcheckPath:\s*\$healthcheckPath/, query,
+            "update mutation input should set healthcheckPath")
+        assert_equal "/health", vars[:healthcheckPath],
+            "update vars should carry the SSOT healthcheckPath"
+    end
+
+    def test_omits_healthcheck_path_when_ssot_has_none
+        gql = FakeGQL.new(happy_plan)
+        # nil healthcheck_path == a live-null service (e.g. docs).
+        Railway::PromoteCommand.pin_and_verify(gql,
+            service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+            healthcheck_path: nil, sleeper: ->(_n) {})
+
+        query, vars = update_call(gql)
+        # The image-only mutation must be used: NO healthcheckPath anywhere — we
+        # must NEVER send `healthcheckPath: null`, which would clear it.
+        refute_match(/healthcheckPath/, query,
+            "image-only mutation must not mention healthcheckPath")
+        refute vars.key?(:healthcheckPath),
+            "update vars must omit healthcheckPath for a live-null service"
+    end
+
+    def test_empty_string_path_is_treated_as_omitted
+        gql = FakeGQL.new(happy_plan)
+        Railway::PromoteCommand.pin_and_verify(gql,
+            service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+            healthcheck_path: "", sleeper: ->(_n) {})
+
+        query, vars = update_call(gql)
+        refute_match(/healthcheckPath/, query)
+        refute vars.key?(:healthcheckPath)
+    end
+end

--- a/showcase/bin/spec/test_snapshot_ivar_lint.rb
+++ b/showcase/bin/spec/test_snapshot_ivar_lint.rb
@@ -54,33 +54,33 @@ class SnapshotIvarLintTest < Minitest::Test
     #                       prose (do not perform a read)
     ALLOWED_LINES = [
         # `run` — capture full-fleet view before optional narrowing.
-        '1394:@full_staging_snapshot = @staging_snapshot',
-        '1395:@full_prod_snapshot    = @prod_snapshot',
+        '1435:@full_staging_snapshot = @staging_snapshot',
+        '1436:@full_prod_snapshot    = @prod_snapshot',
 
         # Doc comment above narrow_snapshots_to_single_service!.
-        '1403:# Narrow @staging_snapshot and @prod_snapshot to only the named',
+        '1444:# Narrow @staging_snapshot and @prod_snapshot to only the named',
 
         # narrow_snapshots_to_single_service! — the WRITE site.
-        '1411:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1416:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
-        '1417:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1418:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
+        '1452:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1457:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
+        '1458:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1459:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
 
         # Doc comment above capture_snapshots.
-        '1422:# @staging_snapshot / @prod_snapshot directly.',
+        '1463:# @staging_snapshot / @prod_snapshot directly.',
 
         # capture_snapshots — single test-seam assignment site.
-        '1424:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
-        '1425:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
+        '1465:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
+        '1466:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
 
         # Doc comment above the accessor block (explains test seam).
-        '1449:# promote tests stub @staging_snapshot/@prod_snapshot directly',
+        '1490:# promote tests stub @staging_snapshot/@prod_snapshot directly',
 
         # The four accessor bodies — the ONLY sanctioned reads.
-        '1461:@full_staging_snapshot || @staging_snapshot',
-        '1465:@full_prod_snapshot || @prod_snapshot',
-        '1469:@staging_snapshot',
-        '1473:@prod_snapshot',
+        '1502:@full_staging_snapshot || @staging_snapshot',
+        '1506:@full_prod_snapshot || @prod_snapshot',
+        '1510:@staging_snapshot',
+        '1514:@prod_snapshot',
     ].freeze
 
     def setup

--- a/showcase/scripts/__tests__/deploy-to-railway.healthcheck.test.ts
+++ b/showcase/scripts/__tests__/deploy-to-railway.healthcheck.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for healthcheck-path resolution during provisioning in
+ * `deploy-to-railway.ts` (`resolveProvisionHealthcheck`).
+ *
+ * Contract under test: `healthcheckPathFor` returns undefined for TWO distinct
+ * reasons, and conflating them wedges deploys:
+ *
+ *   1. The service is NOT tracked in the SSOT at all (brand-new/unknown
+ *      service this script is onboarding) → fall back to the agent-class
+ *      default `/api/health`.
+ *   2. The service IS tracked but deliberately has a null/omitted
+ *      healthcheckPath (dashboard, docs, dojo, webhooks, pocketbase) → it has
+ *      no HTTP health endpoint, so the healthcheck MUST be omitted. Forcing
+ *      `/api/health` onto it yields a 404 that wedges the deploy (the bug this
+ *      test guards against).
+ *
+ * Pure SSOT lookups — no network I/O, no aimock (no LLM surface here).
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolveProvisionHealthcheck } from "../deploy-to-railway";
+
+describe("resolveProvisionHealthcheck", () => {
+  it("OMITS the healthcheck for a TRACKED service with a null healthcheckPath (docs)", () => {
+    // RED before fix: `healthcheckPathFor("docs") ?? "/api/health"` wrongly
+    // returned "/api/health" for this tracked-null service.
+    expect(resolveProvisionHealthcheck("docs")).toEqual({ kind: "omit" });
+  });
+
+  it("OMITS the healthcheck for other tracked-null services (dashboard, dojo, webhooks, pocketbase)", () => {
+    for (const svc of ["dashboard", "dojo", "webhooks", "pocketbase"]) {
+      expect(resolveProvisionHealthcheck(svc)).toEqual({ kind: "omit" });
+    }
+  });
+
+  it("SETS the SSOT healthcheckPath verbatim for a tracked service that defines one (aimock → /health)", () => {
+    expect(resolveProvisionHealthcheck("aimock")).toEqual({
+      kind: "set",
+      path: "/health",
+    });
+  });
+
+  it("SETS /api/health for a tracked agent service (showcase-langgraph-python)", () => {
+    expect(resolveProvisionHealthcheck("showcase-langgraph-python")).toEqual({
+      kind: "set",
+      path: "/api/health",
+    });
+  });
+
+  it("FALLS BACK to /api/health for an UNTRACKED brand-new service", () => {
+    expect(resolveProvisionHealthcheck("totally-new-unknown-service")).toEqual({
+      kind: "set",
+      path: "/api/health",
+    });
+  });
+
+  it("does NOT treat inherited Object.prototype keys as tracked services", () => {
+    // Own-property semantics: "constructor"/"toString" are not SSOT members,
+    // so they take the untracked fallback rather than resolving to a prototype.
+    for (const key of ["constructor", "toString", "hasOwnProperty"]) {
+      expect(resolveProvisionHealthcheck(key)).toEqual({
+        kind: "set",
+        path: "/api/health",
+      });
+    }
+  });
+});

--- a/showcase/scripts/deploy-to-railway.ts
+++ b/showcase/scripts/deploy-to-railway.ts
@@ -20,7 +20,12 @@ import yaml from "yaml";
 import { fileURLToPath } from "url";
 import { RAILWAY_GRAPHQL_ENDPOINT } from "./lib/railway-graphql";
 import { RailwayTokenError, resolveRailwayToken } from "./lib/railway-token";
-import { PROJECT_ID, PRODUCTION_ENV_ID } from "./railway-envs";
+import {
+  PROJECT_ID,
+  PRODUCTION_ENV_ID,
+  healthcheckPathFor,
+  isTrackedService,
+} from "./railway-envs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -32,6 +37,41 @@ const SHOWCASE = {
   projectId: PROJECT_ID,
   environmentId: PRODUCTION_ENV_ID,
 };
+
+/**
+ * Resolve the healthcheck path to apply to a Railway service instance during
+ * provisioning, disambiguating the two reasons {@link healthcheckPathFor}
+ * returns undefined:
+ *
+ *   - `{ kind: "set", path }`     — a tracked service with an explicit SSOT
+ *                                   healthcheckPath (e.g. aimock → `/health`,
+ *                                   agents → `/api/health`). Apply that path.
+ *   - `{ kind: "omit" }`          — a TRACKED service that deliberately has a
+ *                                   null/omitted healthcheckPath (dashboard,
+ *                                   docs, dojo, webhooks, pocketbase). These
+ *                                   have no HTTP health endpoint; forcing
+ *                                   `/api/health` 404s and wedges the deploy.
+ *                                   Set NO healthcheck (Railway default).
+ *   - `{ kind: "set", path: "/api/health" }` for an UNTRACKED service — a
+ *                                   brand-new/unknown service this script is
+ *                                   onboarding takes the agent-class default.
+ *
+ * Pure (SSOT lookup only) so both createService and goLive share one source
+ * of truth and it is unit-testable without network I/O.
+ */
+export function resolveProvisionHealthcheck(
+  serviceName: string,
+): { kind: "set"; path: string } | { kind: "omit" } {
+  if (!isTrackedService(serviceName)) {
+    // Not in the SSOT at all — agent-class default for a new service.
+    return { kind: "set", path: "/api/health" };
+  }
+  const trackedPath = healthcheckPathFor(serviceName, "prod");
+  // Tracked-null → omit the healthcheck (no HTTP health endpoint).
+  return trackedPath === undefined
+    ? { kind: "omit" }
+    : { kind: "set", path: trackedPath };
+}
 
 /**
  * Resolve the Railway bearer token for this run. Wraps the shared
@@ -421,10 +461,21 @@ async function createService(slug: string): Promise<void> {
     );
   }
 
+  // Resolve the healthcheck path from the SSOT (railway-envs.ts) so this
+  // onboarding script does not become a SECOND untracked source of truth (the
+  // failure mode behind the aimock silent-null incident). `serviceName` is the
+  // canonical SSOT key (`showcase-<slug>`) and SHOWCASE.environmentId is
+  // PRODUCTION_ENV_ID, so we resolve the prod value. The shared resolver
+  // distinguishes a tracked-null service (omit the healthcheck) from an
+  // untracked new service (agent-class `/api/health` default) — forcing
+  // `/api/health` onto a tracked-null service 404s and wedges the deploy.
   const instanceInput: Record<string, unknown> = {
-    healthcheckPath: "/api/health",
     region: "us-west1",
   };
+  const hc = resolveProvisionHealthcheck(serviceName);
+  if (hc.kind === "set") {
+    instanceInput.healthcheckPath = hc.path;
+  }
   if (githubToken) {
     // GHCR registry username: read from env (GHCR_USERNAME preferred, then
     // GITHUB_ACTOR for CI contexts). Fail loud rather than baking a
@@ -678,19 +729,34 @@ async function goLive(slug: string): Promise<void> {
     throw e;
   }
 
-  // Health check
-  const healthUrl = `${backendUrl}/api/health`;
-  console.log(`Checking health: ${healthUrl}`);
-  try {
-    const res = await fetch(healthUrl, { signal: AbortSignal.timeout(10000) });
-    if (!res.ok) {
-      console.error(`Health check failed: ${res.status}`);
+  // Health check — resolve the path from the SSOT (railway-envs.ts) via the
+  // SAME shared resolver as createService so this does not become a SECOND
+  // source of truth. A tracked-null service (dashboard, docs, dojo, webhooks,
+  // pocketbase) has no HTTP health endpoint; probing `/api/health` would 404
+  // and (via process.exit below) wedge the deploy — so SKIP the HTTP check
+  // entirely for those.
+  const ssotKey = `showcase-${slug}`;
+  const hc = resolveProvisionHealthcheck(ssotKey);
+  if (hc.kind === "omit") {
+    console.log(
+      `  Skipping HTTP health check — ${ssotKey} has no healthcheckPath in the SSOT (tracked-null service).`,
+    );
+  } else {
+    const healthUrl = `${backendUrl}${hc.path}`;
+    console.log(`Checking health: ${healthUrl}`);
+    try {
+      const res = await fetch(healthUrl, {
+        signal: AbortSignal.timeout(10000),
+      });
+      if (!res.ok) {
+        console.error(`Health check failed: ${res.status}`);
+        process.exit(1);
+      }
+      console.log(`  Healthy!`);
+    } catch (e: unknown) {
+      console.error(`  Not reachable: ${(e as Error).message}`);
       process.exit(1);
     }
-    console.log(`  Healthy!`);
-  } catch (e: unknown) {
-    console.error(`  Not reachable: ${(e as Error).message}`);
-    process.exit(1);
   }
 
   // Update manifest: deployed: true

--- a/showcase/scripts/emit-railway-envs-json.test.ts
+++ b/showcase/scripts/emit-railway-envs-json.test.ts
@@ -90,6 +90,41 @@ describe("emit-railway-envs-json closure block", () => {
     // promoteTier is always present (defaults to 2 for a leaf integration).
     expect(agent?.promoteTier).toBe(2);
   });
+
+  it("emits per-env healthcheckPath when the SSOT declares one, omits it for live-null services", () => {
+    const services = parsed.services as Array<{
+      name: string;
+      healthcheckPath?: { prod?: string; staging?: string };
+    }>;
+
+    // aimock declares /health in BOTH envs (the repaired incident service).
+    const aimock = services.find((s) => s.name === "aimock");
+    expect(aimock?.healthcheckPath).toEqual({
+      prod: "/health",
+      staging: "/health",
+    });
+
+    // An agent integration is /api/health in both envs.
+    const agent = services.find((s) => s.name === "showcase-ag2");
+    expect(agent?.healthcheckPath).toEqual({
+      prod: "/api/health",
+      staging: "/api/health",
+    });
+
+    // shell is the Next.js shell that probes `/` (NOT the live-null docs/dojo).
+    const shell = services.find((s) => s.name === "shell");
+    expect(shell?.healthcheckPath).toEqual({ prod: "/", staging: "/" });
+
+    // docs is live-null in BOTH envs → the healthcheckPath key is OMITTED
+    // entirely (never `/`), so the pin omits the mutation field.
+    const docs = services.find((s) => s.name === "docs");
+    expect(docs?.healthcheckPath).toBeUndefined();
+
+    // harness-legacy is /health in staging, OMITTED in prod (per-env asymmetry).
+    const legacy = services.find((s) => s.name === "harness-legacy");
+    expect(legacy?.healthcheckPath).toEqual({ staging: "/health" });
+    expect(legacy?.healthcheckPath?.prod).toBeUndefined();
+  });
 });
 
 describe("emit-railway-envs-json legacy shape preservation (golden)", () => {
@@ -191,10 +226,13 @@ describe("emit-railway-envs-json EMIT_SKIP_OXFMT ephemeral opt-out", () => {
   // and that job's `npm ci` does not install the repo-root oxfmt binary the
   // committed path shells out to. EMIT_SKIP_OXFMT=1 lets those jobs skip the
   // oxfmt-canonical pass so a missing binary no longer ENOENT-aborts EVERY
-  // promote. We force the oxfmt binary to resolve to a path that does NOT exist
-  // (PATH-independent: the emitter shells out to an absolute repo-root path) by
-  // running with EMIT_SKIP_OXFMT unset vs set and asserting the failure flips.
-  function emitWithSkip(skip: boolean): {
+  // promote. These tests assert the OPT-OUT behavior directly: with
+  // EMIT_SKIP_OXFMT=1 the emitter SUCCEEDS without invoking oxfmt and returns
+  // the raw JSON.stringify form. (The DEFAULT, oxfmt-required path is covered
+  // by the "oxfmt-canonical output" golden tests above; we do not assert a
+  // failure here because whether oxfmt is installed varies by checkout, which
+  // would make a `skip=false` failure assertion non-deterministic.)
+  function emitWithSkip(): {
     status: number | null;
     stderr: string;
     out: string;
@@ -202,19 +240,7 @@ describe("emit-railway-envs-json EMIT_SKIP_OXFMT ephemeral opt-out", () => {
   } {
     const dir = mkdtempSync(join(tmpdir(), "emit-railway-envs-skip-"));
     const out = join(dir, "railway-envs.generated.json");
-    // Point OXFMT discovery at a binary that cannot exist so the default
-    // (oxfmt-required) path fails loud, isolating the env-var behavior from
-    // whether the repo-root oxfmt happens to be installed in this checkout.
-    const env = {
-      ...process.env,
-      // The emitter resolves OXFMT_BIN from import.meta.url, so we cannot
-      // redirect it via PATH; instead we rely on the natural CI condition the
-      // bug hits — oxfmt absent at the repo-root path. To make this test
-      // deterministic regardless of local install state we set EMIT_SKIP_OXFMT
-      // and assert the run SUCCEEDS, then (separately) that the committed-path
-      // golden tests above continue to require oxfmt.
-      ...(skip ? { EMIT_SKIP_OXFMT: "1" } : {}),
-    };
+    const env = { ...process.env, EMIT_SKIP_OXFMT: "1" };
     const res = spawnSync("npx", ["tsx", EMITTER, `--out=${out}`], {
       cwd: SCRIPTS_DIR,
       stdio: "pipe",
@@ -230,7 +256,7 @@ describe("emit-railway-envs-json EMIT_SKIP_OXFMT ephemeral opt-out", () => {
   }
 
   it("EMIT_SKIP_OXFMT=1 emits valid JSON (no oxfmt invocation required)", () => {
-    const r = emitWithSkip(true);
+    const r = emitWithSkip();
     try {
       expect(r.status).toBe(0);
       // The emitted artifact parses and carries the shape downstream consumers
@@ -253,7 +279,7 @@ describe("emit-railway-envs-json EMIT_SKIP_OXFMT ephemeral opt-out", () => {
     // arrays (oxfmt would collapse short arrays onto one line). We assert at
     // least one multi-line array marker exists, proving oxfmt was NOT run — the
     // exact divergence the committed path canonicalizes away.
-    const r = emitWithSkip(true);
+    const r = emitWithSkip();
     try {
       expect(r.status).toBe(0);
       const raw = readFileSync(r.out, "utf8");

--- a/showcase/scripts/emit-railway-envs-json.ts
+++ b/showcase/scripts/emit-railway-envs-json.ts
@@ -87,6 +87,14 @@ interface Emitted {
     // (closure: skip Tier-1 union for an all-standalone request) + the fleet
     // driver (promote ungated, never NOT-ATTEMPTED on an unrelated failure).
     standalone?: boolean;
+    // Per-env Railway HTTP healthcheck path (ADDITIVE). Read by the Ruby
+    // promote pin to RE-ASSERT the tracked path on every promote (the durable
+    // fix for the aimock silent-null incident). Each env key is emitted ONLY
+    // when the SSOT declares a healthcheckPath for that env — a live-null
+    // service omits the key (and the pin omits the mutation field, never
+    // sending `null`). The whole `healthcheckPath` object is omitted when
+    // NEITHER env declares one, so live-null services keep the frozen shape.
+    healthcheckPath?: { prod?: string; staging?: string };
   }>;
   // --- Top-level promote-closure plan (ADDITIVE, U2). The tier-ordered
   // closure for the FULL fleet (`all`), computed via `computePromoteClosure`.
@@ -143,6 +151,24 @@ function projectServiceToLegacyJson(
   const prodDomain = prodEnv?.domain ?? compatDomains?.prod ?? "";
   const stagingDomain = stagingEnv?.domain ?? compatDomains?.staging ?? "";
 
+  // Per-env healthcheckPath: mirror the per-env-flat ({prod, staging}) legacy
+  // shape used by domains/repoNameOverride. Each env key is conditionally
+  // spread (omitted when the EnvironmentConfig omits it), and the whole object
+  // is included ONLY when at least one env declares a path — a live-null
+  // service (both envs omit) keeps the frozen shape with NO healthcheckPath
+  // key, exactly like repoNameOverride.
+  const prodHealthcheck = prodEnv?.healthcheckPath;
+  const stagingHealthcheck = stagingEnv?.healthcheckPath;
+  const healthcheckPath =
+    prodHealthcheck !== undefined || stagingHealthcheck !== undefined
+      ? {
+          ...(prodHealthcheck !== undefined ? { prod: prodHealthcheck } : {}),
+          ...(stagingHealthcheck !== undefined
+            ? { staging: stagingHealthcheck }
+            : {}),
+        }
+      : undefined;
+
   return {
     name,
     serviceId: entry.serviceId,
@@ -175,6 +201,10 @@ function projectServiceToLegacyJson(
       : {}),
     // Standalone leaf: emitted only when true (keeps the leaf default shape).
     ...(entry.standalone === true ? { standalone: true } : {}),
+    // Per-env healthcheckPath, appended AFTER the legacy keys (additive). The
+    // golden test projects only LEGACY_KEYS so this stays byte-safe; omitted
+    // entirely for live-null services so their frozen shape is preserved.
+    ...(healthcheckPath !== undefined ? { healthcheckPath } : {}),
   };
 }
 

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -26,7 +26,11 @@
         "prod": true,
         "driver": "aimock"
       },
-      "promoteTier": 0
+      "promoteTier": 0,
+      "healthcheckPath": {
+        "prod": "/health",
+        "staging": "/health"
+      }
     },
     {
       "name": "dashboard",
@@ -120,7 +124,11 @@
         "prod": true,
         "driver": "harness"
       },
-      "promoteTier": 1
+      "promoteTier": 1,
+      "healthcheckPath": {
+        "prod": "/health",
+        "staging": "/health"
+      }
     },
     {
       "name": "harness-legacy",
@@ -142,7 +150,10 @@
         "prod": false,
         "driver": "harness"
       },
-      "promoteTier": 2
+      "promoteTier": 2,
+      "healthcheckPath": {
+        "staging": "/health"
+      }
     },
     {
       "name": "harness-workers",
@@ -164,7 +175,10 @@
         "prod": false,
         "driver": "harness"
       },
-      "promoteTier": 1
+      "promoteTier": 1,
+      "healthcheckPath": {
+        "staging": "/health"
+      }
     },
     {
       "name": "pocketbase",
@@ -210,7 +224,11 @@
         "prod": true,
         "driver": "shell"
       },
-      "promoteTier": 2
+      "promoteTier": 2,
+      "healthcheckPath": {
+        "prod": "/",
+        "staging": "/"
+      }
     },
     {
       "name": "showcase-ag2",
@@ -236,7 +254,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-agno",
@@ -262,7 +284,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-built-in-agent",
@@ -288,7 +314,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-claude-sdk-python",
@@ -314,7 +344,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-claude-sdk-typescript",
@@ -340,7 +374,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-crewai-crews",
@@ -366,7 +404,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-google-adk",
@@ -392,7 +434,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-langgraph-fastapi",
@@ -418,7 +464,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-langgraph-python",
@@ -444,7 +494,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-langgraph-typescript",
@@ -470,7 +524,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-langroid",
@@ -496,7 +554,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-llamaindex",
@@ -522,7 +584,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-mastra",
@@ -548,7 +614,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-ms-agent-dotnet",
@@ -574,7 +644,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-ms-agent-harness-dotnet",
@@ -600,7 +674,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-ms-agent-python",
@@ -626,7 +704,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-pydantic-ai",
@@ -652,7 +734,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-spring-ai",
@@ -678,7 +764,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "showcase-strands",
@@ -704,7 +794,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/api/health",
+        "staging": "/api/health"
+      }
     },
     {
       "name": "starter-adk",
@@ -730,7 +824,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/",
+        "staging": "/"
+      }
     },
     {
       "name": "starter-agno",
@@ -756,7 +854,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/",
+        "staging": "/"
+      }
     },
     {
       "name": "starter-crewai-crews",
@@ -782,7 +884,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/",
+        "staging": "/"
+      }
     },
     {
       "name": "starter-langgraph-fastapi",
@@ -808,7 +914,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/",
+        "staging": "/"
+      }
     },
     {
       "name": "starter-langgraph-js",
@@ -834,7 +944,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/",
+        "staging": "/"
+      }
     },
     {
       "name": "starter-langgraph-python",
@@ -860,7 +974,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/",
+        "staging": "/"
+      }
     },
     {
       "name": "starter-llamaindex",
@@ -886,7 +1004,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/",
+        "staging": "/"
+      }
     },
     {
       "name": "starter-mastra",
@@ -912,7 +1034,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/",
+        "staging": "/"
+      }
     },
     {
       "name": "starter-ms-agent-framework-dotnet",
@@ -938,7 +1064,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/",
+        "staging": "/"
+      }
     },
     {
       "name": "starter-ms-agent-framework-python",
@@ -964,7 +1094,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/",
+        "staging": "/"
+      }
     },
     {
       "name": "starter-pydantic-ai",
@@ -990,7 +1124,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/",
+        "staging": "/"
+      }
     },
     {
       "name": "starter-strands-python",
@@ -1016,7 +1154,11 @@
           "key": "OPENAI_BASE_URL",
           "target": "aimock"
         }
-      ]
+      ],
+      "healthcheckPath": {
+        "prod": "/",
+        "staging": "/"
+      }
     },
     {
       "name": "webhooks",

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -17,6 +17,7 @@ import {
   computePromoteClosure,
   domainFor,
   envsFor,
+  healthcheckPathFor,
   instanceIdFor,
   listServiceNames,
   probeEnabled,
@@ -142,6 +143,40 @@ describe("railway-envs SSOT", () => {
         ).toMatch(uuid);
       }
     }
+  });
+
+  it("every declared healthcheckPath is a non-empty `/`-prefixed string", () => {
+    // A wrong healthcheckPath 404s and WEDGES the deploy forever, so the
+    // schema guards the shape: when present it MUST be a non-empty path
+    // starting with `/`. Absence is legal (live-null → omit / do not assert).
+    for (const [name, entry] of Object.entries(SERVICES)) {
+      for (const [env, cfg] of Object.entries(entry.environments)) {
+        if (cfg.healthcheckPath === undefined) continue;
+        expect(
+          cfg.healthcheckPath,
+          `${name}.environments.${env}.healthcheckPath`,
+        ).toMatch(/^\/\S*$/);
+      }
+    }
+  });
+
+  it("healthcheckPathFor returns the tracked value / undefined", () => {
+    // Tracked: aimock /health (the repaired incident service).
+    expect(healthcheckPathFor("aimock", "prod")).toBe("/health");
+    expect(healthcheckPathFor("aimock", "staging")).toBe("/health");
+    // Agent integration: /api/health.
+    expect(healthcheckPathFor("showcase-ag2", "prod")).toBe("/api/health");
+    // Next.js shell: `/`.
+    expect(healthcheckPathFor("shell", "prod")).toBe("/");
+    // Live-null service: undefined (do not assert).
+    expect(healthcheckPathFor("docs", "prod")).toBeUndefined();
+    expect(healthcheckPathFor("dashboard", "staging")).toBeUndefined();
+    // Per-env asymmetry: harness-legacy staging /health, prod undefined.
+    expect(healthcheckPathFor("harness-legacy", "staging")).toBe("/health");
+    expect(healthcheckPathFor("harness-legacy", "prod")).toBeUndefined();
+    // Unknown service / undeclared env → undefined (never throws).
+    expect(healthcheckPathFor("nope", "prod")).toBeUndefined();
+    expect(healthcheckPathFor("harness-workers", "prod")).toBeUndefined();
   });
 
   it("instance IDs differ across a service's envs", () => {

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -154,6 +154,16 @@ export type ProbeDriver =
  * - `repoName` — GHCR repo-name override for this env. OPTIONAL. When unset,
  *   the gate expects `ghcr.io/copilotkit/<serviceName>:<tag>`; when set, it
  *   uses `ghcr.io/copilotkit/<repoName>:<tag>` for THIS env only.
+ * - `healthcheckPath` — Railway HTTP healthcheck path for this env (the path
+ *   Railway probes to mark a deploy healthy). OPTIONAL; OMITTED ⇒ "do not
+ *   assert" (Railway default / null — TCP-port liveness, no HTTP path). This
+ *   is the SSOT the promote pin re-asserts on every promote so a prod
+ *   instance whose healthcheckPath silently went null (the aimock incident)
+ *   self-heals to the tracked value. MUST encode the LIVE Railway value
+ *   verbatim per env — a wrong path 404s and WEDGES the deploy forever. A
+ *   live-null service OMITS this field entirely; it is NEVER written as `/`
+ *   or `/api/health` (and the pin mutation OMITS the key when absent rather
+ *   than sending `null`, which would actively CLEAR it).
  */
 export interface EnvironmentConfig {
   /** env-scoped Railway serviceInstance ID. */
@@ -164,6 +174,11 @@ export interface EnvironmentConfig {
   probe?: boolean;
   /** Per-env GHCR repo-name override. Defaults to the service name. */
   repoName?: string;
+  /**
+   * Railway HTTP healthcheck path for this env. OPTIONAL; omitted ⇒ do not
+   * assert (Railway default / null). Encode the LIVE value verbatim.
+   */
+  healthcheckPath?: string;
 }
 
 export interface ServiceEntry {
@@ -369,12 +384,14 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "5801d8be-5ad9-4eff-9c9c-7be61d9a023e",
+        healthcheckPath: "/health",
         domain: "showcase-aimock-production.up.railway.app",
         probe: true,
         repoName: "showcase-aimock",
       },
       staging: {
         instanceId: "9f260dfd-d9d4-43e9-98fe-49696f87fe50",
+        healthcheckPath: "/health",
         domain: "aimock-staging.up.railway.app",
         probe: true,
         repoName: "showcase-aimock",
@@ -475,12 +492,14 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "05fbcdf2-8a50-4b71-b4f6-c92c4b17e626",
+        healthcheckPath: "/health",
         domain: "showcase-harness-production.up.railway.app",
         probe: true,
         repoName: "showcase-harness",
       },
       staging: {
         instanceId: "0811f68f-fac4-440e-a350-3a7ca5855b80",
+        healthcheckPath: "/health",
         domain: "harness-staging-2ee4.up.railway.app",
         probe: true,
         repoName: "showcase-harness",
@@ -538,6 +557,7 @@ export const SERVICES: Record<
     environments: {
       staging: {
         instanceId: "362c1e37-5f40-45f2-ac7b-0e5adac565f8",
+        healthcheckPath: "/health",
         probe: false,
         repoName: "showcase-harness",
       },
@@ -596,6 +616,7 @@ export const SERVICES: Record<
       },
       staging: {
         instanceId: "ed184024-fdfa-4b6f-bb51-37d6648e0beb",
+        healthcheckPath: "/health",
         probe: false,
         repoName: "showcase-harness",
       },
@@ -652,12 +673,14 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "01614ccf-e109-4b30-b41b-7c5551c0a34c",
+        healthcheckPath: "/",
         domain: "showcase.copilotkit.ai",
         probe: true,
         repoName: "showcase-shell",
       },
       staging: {
         instanceId: "25b7de41-188c-4f2e-ac07-538212eaeb91",
+        healthcheckPath: "/",
         domain: "showcase.staging.copilotkit.ai",
         probe: true,
         repoName: "showcase-shell",
@@ -679,11 +702,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "de571c97-03fd-486b-8a54-9767a4a53f95",
+        healthcheckPath: "/api/health",
         domain: "showcase-ag2-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "ecaf81b3-93a8-4862-92b6-04a016b634ed",
+        healthcheckPath: "/api/health",
         domain: "showcase-ag2-staging.up.railway.app",
         probe: true,
       },
@@ -704,11 +729,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "026d12fb-2844-42af-8f92-b47bc8a06bc8",
+        healthcheckPath: "/api/health",
         domain: "showcase-agno-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "68964ab6-75ca-4095-a64a-52cacfb684f5",
+        healthcheckPath: "/api/health",
         domain: "showcase-agno-staging.up.railway.app",
         probe: true,
       },
@@ -729,11 +756,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "40018ef7-1ed1-4979-b80c-9c2d957b6d88",
+        healthcheckPath: "/api/health",
         domain: "showcase-built-in-agent-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "b89ae7b3-01cc-4ed4-aca6-23aaa63cd59e",
+        healthcheckPath: "/api/health",
         domain: "showcase-built-in-agent-staging.up.railway.app",
         probe: true,
       },
@@ -754,11 +783,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "bb18caaf-9a3e-4fdd-85ec-562fd82a3a89",
+        healthcheckPath: "/api/health",
         domain: "showcase-claude-sdk-python-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "1ef25aec-5fbd-40b9-8685-57c2681bd45d",
+        healthcheckPath: "/api/health",
         domain: "showcase-claude-sdk-python-staging.up.railway.app",
         probe: true,
       },
@@ -779,11 +810,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "bee425e4-9661-4a88-8888-922b8cd4b61d",
+        healthcheckPath: "/api/health",
         domain: "showcase-claude-sdk-typescript-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "92305747-2f55-4122-aad4-882e989558ab",
+        healthcheckPath: "/api/health",
         domain: "showcase-claude-sdk-typescript-staging.up.railway.app",
         probe: true,
       },
@@ -804,11 +837,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "3dab0cc3-cab1-4579-b772-947268088514",
+        healthcheckPath: "/api/health",
         domain: "showcase-crewai-crews-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "88c2a14f-435b-499e-a811-ee4f4be18fd8",
+        healthcheckPath: "/api/health",
         domain: "showcase-crewai-crews-staging.up.railway.app",
         probe: true,
       },
@@ -829,11 +864,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "7b2da5db-87d2-40ad-a3d9-b2d7a5485a22",
+        healthcheckPath: "/api/health",
         domain: "showcase-google-adk-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "7efe2fa0-fa78-4585-bc4c-6d39c326e6d1",
+        healthcheckPath: "/api/health",
         domain: "showcase-google-adk-staging.up.railway.app",
         probe: true,
       },
@@ -854,11 +891,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "105b7e01-acd0-48e2-9a09-541e2103e8d2",
+        healthcheckPath: "/api/health",
         domain: "showcase-langgraph-fastapi-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "7899afe0-141b-4217-8dbb-5907813231dc",
+        healthcheckPath: "/api/health",
         domain: "showcase-langgraph-fastapi-staging.up.railway.app",
         probe: true,
       },
@@ -879,11 +918,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "aec504f7-63d7-4ea6-9d50-601b00d2ae80",
+        healthcheckPath: "/api/health",
         domain: "showcase-langgraph-python-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "04d29664-a776-4670-9db3-b1d18bce1669",
+        healthcheckPath: "/api/health",
         domain: "showcase-langgraph-python-staging.up.railway.app",
         probe: true,
       },
@@ -904,11 +945,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "f53e9fdc-7c3e-4dfd-9fa8-d7241fd55bb8",
+        healthcheckPath: "/api/health",
         domain: "showcase-langgraph-typescript-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "481ab37f-da8a-4015-bd88-2b28d9eb261a",
+        healthcheckPath: "/api/health",
         domain: "showcase-langgraph-typescript-staging.up.railway.app",
         probe: true,
       },
@@ -929,11 +972,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "6b5e20b5-8f8e-4ec3-9288-7a41122e42e5",
+        healthcheckPath: "/api/health",
         domain: "showcase-langroid-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "a213f7d9-2117-4944-988b-05e68d819dd5",
+        healthcheckPath: "/api/health",
         domain: "showcase-langroid-staging.up.railway.app",
         probe: true,
       },
@@ -954,11 +999,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "b778856e-9f90-4136-9415-fb2b41173f8d",
+        healthcheckPath: "/api/health",
         domain: "showcase-llamaindex-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "17899ea7-355c-43f2-a152-28cb0b7fa864",
+        healthcheckPath: "/api/health",
         domain: "showcase-llamaindex-staging.up.railway.app",
         probe: true,
       },
@@ -979,11 +1026,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "eaeddd9c-8b75-426f-b033-0fd935cbf6ef",
+        healthcheckPath: "/api/health",
         domain: "showcase-mastra-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "eec22411-aab5-47a1-8f5b-d097e233d7f8",
+        healthcheckPath: "/api/health",
         domain: "showcase-mastra-staging.up.railway.app",
         probe: true,
       },
@@ -1004,11 +1053,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "93ca0edf-7b59-4de4-b1fd-3412bb07bc6a",
+        healthcheckPath: "/api/health",
         domain: "showcase-ms-agent-dotnet-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "9826bc58-c472-41e6-b050-29249d4b2a52",
+        healthcheckPath: "/api/health",
         domain: "showcase-ms-agent-dotnet-staging.up.railway.app",
         probe: true,
       },
@@ -1029,11 +1080,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "8f91ebc6-95c0-4433-b1f7-657ff49c2d59",
+        healthcheckPath: "/api/health",
         domain: "showcase-ms-agent-harness-dotnet-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "6b0fe181-9156-4a40-9e44-90befe09833a",
+        healthcheckPath: "/api/health",
         domain: "showcase-ms-agent-harness-dotnet-staging.up.railway.app",
         probe: true,
       },
@@ -1054,11 +1107,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "323ed911-4d28-45ab-8fc0-7d151828b938",
+        healthcheckPath: "/api/health",
         domain: "showcase-ms-agent-python-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "741725ce-5fa1-4327-aff5-53dcc000c29c",
+        healthcheckPath: "/api/health",
         domain: "showcase-ms-agent-python-staging.up.railway.app",
         probe: true,
       },
@@ -1079,11 +1134,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "192cd647-6824-4f01-937a-1da675d83805",
+        healthcheckPath: "/api/health",
         domain: "showcase-pydantic-ai-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "6edf5ca5-6a56-4d28-92c3-2a3360c735db",
+        healthcheckPath: "/api/health",
         domain: "showcase-pydantic-ai-staging.up.railway.app",
         probe: true,
       },
@@ -1104,11 +1161,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "2fbf1db2-5e51-44c9-983c-3f2242d95c61",
+        healthcheckPath: "/api/health",
         domain: "showcase-spring-ai-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "189ac76f-bd77-45c0-9c45-3853dae763cc",
+        healthcheckPath: "/api/health",
         domain: "showcase-spring-ai-staging.up.railway.app",
         probe: true,
       },
@@ -1129,11 +1188,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "2123c71b-9385-443c-a1c3-bcf4b1669eeb",
+        healthcheckPath: "/api/health",
         domain: "showcase-strands-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "f8a9d2ed-50ec-4f06-85d6-230baced8471",
+        healthcheckPath: "/api/health",
         domain: "showcase-strands-staging.up.railway.app",
         probe: true,
       },
@@ -1198,11 +1259,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "cb23cae4-9555-4ddd-8a62-f1aa1ff72c67",
+        healthcheckPath: "/",
         domain: "starter-adk-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "208a160a-0d7d-44b2-a94d-39e13b24e21a",
+        healthcheckPath: "/",
         domain: "starter-adk-staging.up.railway.app",
         probe: true,
       },
@@ -1220,11 +1283,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "2f58513b-5fe4-4b09-a28f-93d4caa277b5",
+        healthcheckPath: "/",
         domain: "starter-agno-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "9944eb97-7f58-47f8-a49d-65603e209609",
+        healthcheckPath: "/",
         domain: "starter-agno-staging.up.railway.app",
         probe: true,
       },
@@ -1242,11 +1307,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "1a3e24cb-0752-45c8-b4a2-0c6096899875",
+        healthcheckPath: "/",
         domain: "starter-crewai-crews-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "820895fb-f65c-4834-a07d-d454035d39c4",
+        healthcheckPath: "/",
         domain: "starter-crewai-crews-staging.up.railway.app",
         probe: true,
       },
@@ -1264,11 +1331,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "0679bc18-e9af-40c6-bc17-0b5eb2cd7bec",
+        healthcheckPath: "/",
         domain: "starter-langgraph-fastapi-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "5f10e976-e121-48a5-bc18-2619798f2f10",
+        healthcheckPath: "/",
         domain: "starter-langgraph-fastapi-staging.up.railway.app",
         probe: true,
       },
@@ -1286,11 +1355,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "50a2205b-8768-4765-b7a1-21941c105051",
+        healthcheckPath: "/",
         domain: "starter-langgraph-js-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "43db83fe-fafb-445b-a19a-51bb086c71b9",
+        healthcheckPath: "/",
         domain: "starter-langgraph-js-staging.up.railway.app",
         probe: true,
       },
@@ -1308,11 +1379,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "24dad599-576a-4154-a621-c3af40629a8f",
+        healthcheckPath: "/",
         domain: "starter-langgraph-python-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "58105e79-4020-4692-8749-c1a63ab63f2c",
+        healthcheckPath: "/",
         domain: "starter-langgraph-python-staging.up.railway.app",
         probe: true,
       },
@@ -1330,11 +1403,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "c119f40b-dc71-4734-9716-c1085754b085",
+        healthcheckPath: "/",
         domain: "starter-llamaindex-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "44446803-0505-456a-b0c4-01fe82fb3832",
+        healthcheckPath: "/",
         domain: "starter-llamaindex-staging.up.railway.app",
         probe: true,
       },
@@ -1352,11 +1427,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "c6fba6d8-8dde-442b-948f-560bf25fa2f1",
+        healthcheckPath: "/",
         domain: "starter-mastra-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "b246e52d-52d8-4015-bb06-89bd09d54f8f",
+        healthcheckPath: "/",
         domain: "starter-mastra-staging.up.railway.app",
         probe: true,
       },
@@ -1374,11 +1451,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "993237a4-9ee7-47b2-a5be-267e247c1409",
+        healthcheckPath: "/",
         domain: "starter-ms-agent-framework-dotnet-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "6684c246-e8fd-45a7-86e4-c529a439976f",
+        healthcheckPath: "/",
         domain: "starter-ms-agent-framework-dotnet-staging.up.railway.app",
         probe: true,
       },
@@ -1396,11 +1475,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "aa934881-340a-4fb7-8b39-9cb0a6f372b2",
+        healthcheckPath: "/",
         domain: "starter-ms-agent-framework-python-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "a162348a-f768-4c3f-815c-f617819f64e6",
+        healthcheckPath: "/",
         domain: "starter-ms-agent-framework-python-staging.up.railway.app",
         probe: true,
       },
@@ -1418,11 +1499,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "74ce36fe-0b8f-446e-8e06-0b6496b6e829",
+        healthcheckPath: "/",
         domain: "starter-pydantic-ai-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "25f4eb93-501a-4e5e-b7cf-343eb08ea613",
+        healthcheckPath: "/",
         domain: "starter-pydantic-ai-staging.up.railway.app",
         probe: true,
       },
@@ -1440,11 +1523,13 @@ export const SERVICES: Record<
     environments: {
       prod: {
         instanceId: "4af440e0-ba05-48a5-b922-5b96a033891a",
+        healthcheckPath: "/",
         domain: "starter-strands-python-production.up.railway.app",
         probe: true,
       },
       staging: {
         instanceId: "adc24096-584a-4ef3-93de-0bc92d49235c",
+        healthcheckPath: "/",
         domain: "starter-strands-python-staging.up.railway.app",
         probe: true,
       },
@@ -1677,6 +1762,42 @@ export function probeEnabled(serviceName: string, env: EnvName): boolean {
   const envCfg = findEnvCfg(entry, env);
   if (envCfg === undefined) return false;
   return envCfg.probe ?? true;
+}
+
+/**
+ * Resolve the Railway HTTP healthcheck path for a (serviceName, env) pair, or
+ * `undefined` when none is tracked. Returns undefined (rather than throwing)
+ * on unknown service AND on an undeclared env — mirroring `probeEnabled` —
+ * because absence is LEGAL and semantically meaningful: it means "leave the
+ * Railway default (null); do not assert any path." Callers MUST treat
+ * undefined as "omit the field" (never coerce to a literal path) — the promote
+ * pin sends `healthcheckPath` to Railway only when this returns a value, so a
+ * live-null service is never accidentally cleared OR set to a wrong path.
+ */
+export function healthcheckPathFor(
+  serviceName: string,
+  env: EnvName,
+): string | undefined {
+  const entry = findEntry(serviceName);
+  if (entry === undefined) return undefined;
+  const envCfg = findEnvCfg(entry, env);
+  if (envCfg === undefined) return undefined;
+  return envCfg.healthcheckPath;
+}
+
+/**
+ * Whether `serviceName` is a tracked SSOT entry. Uses the same own-property
+ * semantics as {@link findEntry} (so inherited Object.prototype keys are NOT
+ * counted as members). Callers need this to disambiguate the two reasons
+ * {@link healthcheckPathFor} returns undefined: a service that is NOT in the
+ * SSOT at all (brand-new/unknown) versus a TRACKED service that deliberately
+ * has a null/omitted healthcheckPath (dashboard, docs, dojo, webhooks,
+ * pocketbase). The former may take an agent-class default; the latter must
+ * NOT have a healthcheck forced onto it (doing so wedges the deploy — the
+ * `/api/health` 404 incident).
+ */
+export function isTrackedService(serviceName: string): boolean {
+  return findEntry(serviceName) !== undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Two related fixes to the showcase promote pipeline:

**Promote-notify Slack message — say what actually happened.** Previously a partial promote rendered a message that read as if *everything* failed, with no indication of which services promoted vs. failed. Now the message:
- announces `🚂 Promoting showcase → prod (N): <names>` with a legible count
- on a partial/failed outcome leads with `Promoted:` / `Failed:` (one header each, then bullets) so you can see exactly which services succeeded and which didn't
- reports real wall-clock elapsed (integer-coerced; degrades to omitting the phrase if metadata is unparseable)
- drops the constant `verify-prod:` legend line that preceded the meaningful data

**Durable healthcheckPath tracking — stop the silent prod drift.** The promote pin path and the provisioning path could leave a service's Railway `healthcheckPath` diverged from intent (this is what left aimock answering on the wrong path in prod). Now:
- `healthcheckPath` is tracked per-service/per-env in the SSOT (`railway-envs`)
- the promote pin re-asserts it (omit-when-absent — never sends `null`)
- `deploy-to-railway` provisioning routes through `isTrackedService` / `resolveProvisionHealthcheck`, so a tracked-null service correctly *omits* the healthcheck while an untracked one keeps the `/api/health` default

## Test plan
- [x] `test_promote_healthcheck_reassert.rb` — pin re-asserts SSOT healthcheck, omits when absent, never null (3 runs / 11 assertions)
- [x] `deploy-to-railway.healthcheck.test.ts` + `railway-envs.test.ts` + `emit-railway-envs-json.test.ts` (121 tests)
- [x] snapshot-ivar lint green (2 runs / 32 assertions)
- [x] notify renderer dry-run mirrors success / partial / total-failure shapes