### PR TITLE
fix(showcase): record pydantic-ai generate_a2ui D6 fixture (staging 503 flap)

### DIFF
--- a/showcase/aimock/d6/pydantic-ai/gen-ui-declarative.json
+++ b/showcase/aimock/d6/pydantic-ai/gen-ui-declarative.json
@@ -50,6 +50,18 @@
       }
     },
     {
+      "_comment": "sales-dashboard hero pill — outer agent emits generate_a2ui (no args). Mirrors LGP gen-ui-declarative.json sales-dashboard outer entry. Closes the staging pydantic-ai D-chat 503 (no_fixture_match) where the backend hits aimock with tools=[generate_a2ui] for this userMessage under x-aimock-context: pydantic-ai (ms-agent-dotnet already had the equivalent).",
+      "match": {
+        "userMessage": "Show me my sales dashboard for this quarter.",
+        "hasToolResult": false,
+        "context": "pydantic-ai"
+      },
+      "response": {
+        "content": "Here is your sales dashboard for this quarter.",
+        "toolCalls": [{ "name": "generate_a2ui", "arguments": {} }]
+      }
+    },
+    {
       "_comment": "_design_a2ui_surface — KPI dashboard pill (pydantic-ai secondary tool name).",
       "match": {
         "userMessage": "KPI dashboard",
@@ -212,6 +224,109 @@
                   "component": "StatusBadge",
                   "text": "Workers: degraded",
                   "variant": "warning"
+                }
+              ],
+              "data": {}
+            }
+          }
+        ]
+      }
+    },
+    {
+      "_comment": "_design_a2ui_surface — sales-dashboard hero pill. Component payload mirrors LGP gen-ui-declarative.json sales-dashboard surface (KPI metrics row + revenue-by-region pie + monthly-revenue bar), adapted to the pydantic-ai _design_a2ui_surface convention.",
+      "match": {
+        "userMessage": "Show me my sales dashboard for this quarter.",
+        "toolName": "_design_a2ui_surface",
+        "context": "pydantic-ai"
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "_design_a2ui_surface",
+            "arguments": {
+              "surfaceId": "declarative-surface",
+              "catalogId": "declarative-gen-ui-catalog",
+              "components": [
+                {
+                  "id": "root",
+                  "component": "Column",
+                  "gap": 16,
+                  "children": ["kpi-row", "charts-row"]
+                },
+                {
+                  "id": "kpi-row",
+                  "component": "Row",
+                  "gap": 16,
+                  "children": [
+                    "metric-revenue",
+                    "metric-new-customers",
+                    "metric-win-rate",
+                    "metric-deal-size"
+                  ]
+                },
+                {
+                  "id": "metric-revenue",
+                  "component": "Metric",
+                  "label": "Quarterly Revenue",
+                  "value": "$4.2M",
+                  "trend": "up",
+                  "trendValue": "+12% QoQ"
+                },
+                {
+                  "id": "metric-new-customers",
+                  "component": "Metric",
+                  "label": "New Customers",
+                  "value": "186",
+                  "trend": "up",
+                  "trendValue": "+8%"
+                },
+                {
+                  "id": "metric-win-rate",
+                  "component": "Metric",
+                  "label": "Win Rate",
+                  "value": "31%",
+                  "trend": "down",
+                  "trendValue": "-2 pts"
+                },
+                {
+                  "id": "metric-deal-size",
+                  "component": "Metric",
+                  "label": "Avg Deal Size",
+                  "value": "$22.6k",
+                  "trend": "up",
+                  "trendValue": "+5%"
+                },
+                {
+                  "id": "charts-row",
+                  "component": "Row",
+                  "gap": 16,
+                  "children": ["region-pie", "monthly-bar"]
+                },
+                {
+                  "id": "region-pie",
+                  "component": "PieChart",
+                  "title": "Revenue by Region",
+                  "description": "Quarter revenue split across North America, EMEA, APAC, and LATAM.",
+                  "data": [
+                    { "label": "North America", "value": 1900000 },
+                    { "label": "EMEA", "value": 1300000 },
+                    { "label": "APAC", "value": 720000 },
+                    { "label": "LATAM", "value": 280000 }
+                  ]
+                },
+                {
+                  "id": "monthly-bar",
+                  "component": "BarChart",
+                  "title": "Monthly Revenue",
+                  "description": "Revenue trend from Jan through Jun.",
+                  "data": [
+                    { "label": "Jan", "value": 1210000 },
+                    { "label": "Feb", "value": 1340000 },
+                    { "label": "Mar", "value": 1650000 },
+                    { "label": "Apr", "value": 1380000 },
+                    { "label": "May", "value": 1420000 },
+                    { "label": "Jun", "value": 1400000 }
+                  ]
                 }
               ],
               "data": {}


### PR DESCRIPTION
## Summary
- The pydantic-ai `generate_a2ui` declarative D6 turn was missing an aimock fixture, producing HTTP 503 `no_fixture_match` on staging (pydantic-ai 503 vs ms-agent-dotnet 200 for the same turn) — a source of dashboard flapping.
- Adds the canonical mirror fixtures (outer `generate_a2ui` + matching inner `_design_a2ui_surface`) to `showcase/aimock/d6/pydantic-ai/gen-ui-declarative.json`. These are deterministic canonical mirrors matching the langgraph-python convention — **not** a non-deterministic real-LLM recording — preserving the mandatory LGP 1:1 parity.

## Red-green proof
- **RED:** exact failing request (`POST /v1/responses`, gpt-4.1, "Show me my sales dashboard for this quarter.", tools=[`generate_a2ui`], header `x-aimock-context: pydantic-ai`, strict) against the pre-fix fixture set → **HTTP 503 `no_fixture_match`** (reproduces staging exactly; confirmed live on staging too).
- **GREEN:** same request against the new set → **HTTP 200** SSE emitting the `generate_a2ui` tool call; the inner `_design_a2ui_surface` turn also returns 200 with the dashboard surface.
- Independently re-verified. `validate-on-load` clean (no fixture shadowing); existing pydantic-ai D6 turns (KPI/pie/bar/status) still match identically — no regression.

## Notes
- No credentials in the committed fixture — the OpenAI key was never even resolved (canonical mirror, not a recording). Credential scan of the diff + full blob: zero matches.

## Test plan
- [ ] CI green
- [ ] After deploy, confirm the `generate_a2ui` declarative D6 cell flips red→green on staging