### PR TITLE
fix: replace Unix-only commands with cross-platform Node.js equivalents

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build": "ng-packagr -p ng-package.json && npm run build:css",
-    "build:css": "tailwindcss -i ./src/styles/globals.css -o ./src/styles/generated.css && node scripts/scope-preflight.mjs ./src/styles/generated.css && mkdir -p ./dist && cp ./src/styles/generated.css ./dist/styles.css",
+    "build:css": "tailwindcss -i ./src/styles/globals.css -o ./src/styles/generated.css && node scripts/scope-preflight.mjs ./src/styles/generated.css && node -e \"fs.mkdirSync('./dist',{recursive:true})\" && node -e \"fs.cpSync('./src/styles/generated.css','./dist/styles.css')\"",
     "dev": "concurrently \"ng-packagr -p ng-package.json --watch\" \"npm run dev:css\"",
     "dev:css": "tailwindcss -i ./src/styles/globals.css -o ./src/styles/generated.css --watch",
     "check-types": "tsc --noEmit",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -70,7 +70,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "check-types": "tsc --noEmit",
-    "generate-graphql-schema": "rm -rf __snapshots__ && ts-node --transpile-only ./scripts/generate-gql-schema.ts",
+    "generate-graphql-schema": "node -e \"fs.rmSync('__snapshots__',{recursive:true,force:true})\" && ts-node --transpile-only ./scripts/generate-gql-schema.ts",
     "link:global": "pnpm link --global",
     "unlink:global": "pnpm unlink --global",
     "publint": "publint .",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -63,7 +63,7 @@
   "scripts": {
     "build": "vite build && pnpm build:css && pnpm build:types",
     "build:css": "npx @tailwindcss/cli -i ./src/styles/globals.css -o ./dist/styles.css -m && node scripts/scope-preflight.mjs ./dist/styles.css",
-    "build:types": "vue-tsc -p tsconfig.json --declaration --emitDeclarationOnly --outDir dist --skipLibCheck && cp ./dist/index.d.ts ./dist/index.d.mts && cp ./dist/index.d.ts ./dist/index.d.cts && cp ./dist/v2/index.d.ts ./dist/v2/index.d.mts && cp ./dist/v2/index.d.ts ./dist/v2/index.d.cts",
+    "build:types": "vue-tsc -p tsconfig.json --declaration --emitDeclarationOnly --outDir dist --skipLibCheck && node -e \"fs.cpSync('./dist/index.d.ts','./dist/index.d.mts')\" && node -e \"fs.cpSync('./dist/index.d.ts','./dist/index.d.cts')\" && node -e \"fs.cpSync('./dist/v2/index.d.ts','./dist/v2/index.d.mts')\" && node -e \"fs.cpSync('./dist/v2/index.d.ts','./dist/v2/index.d.cts')\"",
     "dev:css": "npx @tailwindcss/cli -i ./src/styles/globals.css -o ./dist/styles.css --watch --minify",
     "dev": "concurrently \"pnpm dev:css\" \"vite build --watch\"",
     "test": "vitest run",
@@ -74,7 +74,7 @@
     "check-types": "vue-tsc --noEmit",
     "publint": "publint .",
     "attw": "attw --pack . --profile node16 --exclude-entrypoints ./styles.css --ignore-rules internal-resolution-error",
-    "clean": "rm -rf dist"
+    "clean": "node -e \"fs.rmSync('dist',{recursive:true,force:true})\""
   },
   "dependencies": {
     "@a2ui/web_core": "0.9.0",


### PR DESCRIPTION
Fixes #5601

Replaces `rm -rf`, `mkdir -p`, and `cp` shell commands with Node.js inline scripts (`fs.rmSync`, `fs.mkdirSync`, `fs.cpSync`) for Windows compatibility.

## Changes
- **packages/runtime**: generate-graphql-schema -- `rm -rf __snapshots__` to node inline
- **packages/vue**: build:types -- `cp` commands to `node -e fs.cpSync(...)`
- **packages/vue**: clean -- `rm -rf dist` to `node -e fs.rmSync(...)`
- **packages/angular**: build:css -- `mkdir -p` and `cp` to Node.js equivalents
