### PR TITLE
fix: merge agent-specific headers instead of overwriting in applyHeadersToAgent

### DIFF
--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -319,6 +319,7 @@ export class AgentRegistry {
     if (agent instanceof HttpAgent) {
       agent.headers = {
         ...(this.core as unknown as CopilotKitCoreFriendsAccess).headers,
+        ...agent.headers,
       };
     }
   }


### PR DESCRIPTION
Fixes #5635

\pplyHeadersToAgent\ in \packages/core/src/core/agent-registry.ts\ was replacing \gent.headers\ entirely with core headers, silently dropping any headers configured directly on an \HttpAgent\ instance passed to \gents__unsafe_dev_only\.

Now merges agent-specific headers after core headers, so agent headers take precedence.