### PR TITLE
fix: route frontend tool calls (WriteReport, WriteResearchQuestion) to chat_node in research-canvas TS agent

### DIFF
--- a/examples/v1/research-canvas/agents/typescript/src/agent.ts
+++ b/examples/v1/research-canvas/agents/typescript/src/agent.ts
@@ -43,18 +43,13 @@ function route(state: AgentState) {
   ) {
     const aiMessage = messages[messages.length - 1] as AIMessage;
 
-    if (
-      aiMessage.tool_calls &&
-      aiMessage.tool_calls.length > 0 &&
-      aiMessage.tool_calls[0].name === "Search"
-    ) {
+    const toolName = aiMessage.tool_calls?.[0]?.name;
+    if (toolName === "Search") {
       return "search_node";
-    } else if (
-      aiMessage.tool_calls &&
-      aiMessage.tool_calls.length > 0 &&
-      aiMessage.tool_calls[0].name === "DeleteResources"
-    ) {
+    } else if (toolName === "DeleteResources") {
       return "delete_node";
+    } else if (toolName) {
+      return "chat_node";
     }
   }
   if (


### PR DESCRIPTION
Fixes #5607

The \oute()\ function in the research-canvas TypeScript agent only recognized \Search\ and \DeleteResources\ tool calls. Frontend CopilotKit actions (\WriteReport\, \WriteResearchQuestion\, etc.) would fall through to \eturn END\, silently dropping them.

Now routes any unrecognized tool call back to \chat_node\ so the AG-UI channel can pick up frontend actions.