### PR TITLE
feat(core): memory SDK store contract + registry (in-memory mock) [RD-34]

### DIFF
--- a/packages/core/src/__tests__/core-memory-store-auto-unregister.test.ts
+++ b/packages/core/src/__tests__/core-memory-store-auto-unregister.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { CopilotKitCore } from "../core";
+import { ɵcreateMemoryStore } from "../memories";
+import { MockAgent } from "./test-utils";
+
+/**
+ * Pins the integration contract between `CopilotKitCore.onAgentsChanged`
+ * and the memory-store registry.
+ *
+ * Background: when `agents` change, the core auto-unregisters memory stores
+ * for any agentId that has been removed. The "previously had" guard exists
+ * so that the FIRST onAgentsChanged({ agents: {} }) notification — which
+ * fires for published cores BEFORE the published agents are merged in —
+ * does not rip out a store that a consumer just registered.
+ */
+
+describe("CopilotKitCore — onAgentsChanged auto-unregister (memory stores)", () => {
+  it("unregisters a memory store when its agent is removed from agents", async () => {
+    // Start with agent-1 registered. Add a memory store for it. Then remove
+    // agent-1 and confirm the store is auto-unregistered.
+    const agent1 = new MockAgent({ agentId: "agent-1" });
+    const core = new CopilotKitCore({
+      agents__unsafe_dev_only: { "agent-1": agent1 as never },
+    });
+
+    const store = ɵcreateMemoryStore();
+    core.registerMemoryStore("agent-1", store);
+    expect(core.getMemoryStore("agent-1")).toBe(store);
+
+    // Removing agent-1 triggers onAgentsChanged({ agents: {} }) — but agent-1
+    // WAS in the previous snapshot, so the auto-unregister must fire here.
+    core.removeAgent__unsafe_dev_only("agent-1");
+    // Subscriber notification is fire-and-forget; flush microtasks.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(core.getMemoryStore("agent-1")).toBeUndefined();
+  });
+
+  it("does NOT unregister a freshly-registered store on the FIRST empty-agents notification", async () => {
+    // Reproduces the published-core race: the core is created with no agents
+    // (agents are populated asynchronously), a consumer registers a memory
+    // store immediately, and the very first onAgentsChanged({ agents: {} })
+    // notification arrives. Without the "previously had" guard, that empty
+    // notification would rip out the freshly-registered store.
+    const core = new CopilotKitCore({});
+
+    const store = ɵcreateMemoryStore();
+    core.registerMemoryStore("agent-1", store);
+
+    // Trigger an onAgentsChanged({ agents: {} }) notification — this models
+    // the initial empty-agents notification a published core receives before
+    // its agents are merged in.
+    core.setAgents__unsafe_dev_only({});
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The store must survive — agent-1 was never in the previous snapshot,
+    // so there is no transition from "had" to "missing" and nothing to
+    // unregister.
+    expect(core.getMemoryStore("agent-1")).toBe(store);
+  });
+
+  it("unregisters on the SECOND notification when agent appears then disappears", async () => {
+    // Add agent-1, register a store, then remove agent-1. This time the
+    // previous snapshot DID contain agent-1, so the auto-unregister must
+    // fire.
+    const agent1 = new MockAgent({ agentId: "agent-1" });
+    const core = new CopilotKitCore({});
+
+    core.addAgent__unsafe_dev_only({ id: "agent-1", agent: agent1 as never });
+    const store = ɵcreateMemoryStore();
+    core.registerMemoryStore("agent-1", store);
+
+    core.removeAgent__unsafe_dev_only("agent-1");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(core.getMemoryStore("agent-1")).toBeUndefined();
+  });
+
+  it("retains the store for an agent that is still present", async () => {
+    // Two agents: agent-1 and agent-2 both have stores. Removing agent-1
+    // must not touch agent-2's store.
+    const agent1 = new MockAgent({ agentId: "agent-1" });
+    const agent2 = new MockAgent({ agentId: "agent-2" });
+    const core = new CopilotKitCore({
+      agents__unsafe_dev_only: {
+        "agent-1": agent1 as never,
+        "agent-2": agent2 as never,
+      },
+    });
+
+    const store1 = ɵcreateMemoryStore();
+    const store2 = ɵcreateMemoryStore();
+    core.registerMemoryStore("agent-1", store1);
+    core.registerMemoryStore("agent-2", store2);
+
+    core.removeAgent__unsafe_dev_only("agent-1");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(core.getMemoryStore("agent-1")).toBeUndefined();
+    expect(core.getMemoryStore("agent-2")).toBe(store2);
+  });
+});

--- a/packages/core/src/__tests__/core-memory-store-registry.test.ts
+++ b/packages/core/src/__tests__/core-memory-store-registry.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { CopilotKitCore } from "../core/core";
+import { ɵcreateMemoryStore } from "../memories";
+
+describe("CopilotKitCore memory store registry", () => {
+  it("registers and retrieves a store by agentId", () => {
+    const core = new CopilotKitCore({});
+    const store = ɵcreateMemoryStore();
+    core.registerMemoryStore("agent-1", store);
+    expect(core.getMemoryStore("agent-1")).toBe(store);
+  });
+
+  it("returns undefined for an unknown agentId", () => {
+    const core = new CopilotKitCore({});
+    expect(core.getMemoryStore("unknown")).toBeUndefined();
+  });
+
+  it("unregisters a store", () => {
+    const core = new CopilotKitCore({});
+    const store = ɵcreateMemoryStore();
+    core.registerMemoryStore("agent-1", store);
+    core.unregisterMemoryStore("agent-1");
+    expect(core.getMemoryStore("agent-1")).toBeUndefined();
+  });
+
+  it("getMemoryStores() returns a stable frozen snapshot between mutations", () => {
+    const core = new CopilotKitCore({});
+    const store = ɵcreateMemoryStore();
+    core.registerMemoryStore("agent-1", store);
+    const snapshot1 = core.getMemoryStores();
+    const snapshot2 = core.getMemoryStores();
+    expect(snapshot1).toBe(snapshot2);
+    expect(Object.keys(snapshot1)).toEqual(["agent-1"]);
+  });
+});

--- a/packages/core/src/__tests__/memories.test.ts
+++ b/packages/core/src/__tests__/memories.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { firstValueFrom } from "rxjs";
 import { take, toArray } from "rxjs/operators";
 import {
-  ɵcreateInMemoryMemoryStore,
+  ɵcreateMemoryStore,
   ɵselectMemories,
   ɵselectMemoriesError,
   ɵselectMemoriesIsLoading,
@@ -18,9 +18,9 @@ const sampleMemory: PublicMemory = {
   invalidatedAt: null,
 };
 
-describe("ɵcreateInMemoryMemoryStore", () => {
+describe("ɵcreateMemoryStore", () => {
   it("starts empty with no error and not loading", () => {
-    const store = ɵcreateInMemoryMemoryStore();
+    const store = ɵcreateMemoryStore();
 
     expect(store.getState().memories).toEqual([]);
     expect(store.getState().isLoading).toBe(false);
@@ -28,13 +28,13 @@ describe("ɵcreateInMemoryMemoryStore", () => {
   });
 
   it("seeds the list from initial memories", () => {
-    const store = ɵcreateInMemoryMemoryStore({ initial: [sampleMemory] });
+    const store = ɵcreateMemoryStore({ initial: [sampleMemory] });
 
     expect(store.getState().memories).toEqual([sampleMemory]);
   });
 
   it("addMemory inserts the created memory and resolves to it", async () => {
-    const store = ɵcreateInMemoryMemoryStore({
+    const store = ɵcreateMemoryStore({
       idFactory: () => "mem-created",
     });
 
@@ -52,7 +52,7 @@ describe("ɵcreateInMemoryMemoryStore", () => {
 
   it("updateMemory supersedes: new id minted, old id removed, change applied", async () => {
     let next = 0;
-    const store = ɵcreateInMemoryMemoryStore({
+    const store = ɵcreateMemoryStore({
       initial: [sampleMemory],
       idFactory: () => `mem-superseded-${(next += 1)}`,
     });
@@ -69,7 +69,7 @@ describe("ɵcreateInMemoryMemoryStore", () => {
   });
 
   it("updateMemory preserves untouched fields onto the superseded memory", async () => {
-    const store = ɵcreateInMemoryMemoryStore({
+    const store = ɵcreateMemoryStore({
       initial: [sampleMemory],
       idFactory: () => "mem-next",
     });
@@ -84,7 +84,7 @@ describe("ɵcreateInMemoryMemoryStore", () => {
   });
 
   it("updateMemory rejects with MEMORY_NOT_FOUND for an unknown id", async () => {
-    const store = ɵcreateInMemoryMemoryStore();
+    const store = ɵcreateMemoryStore();
 
     await expect(store.updateMemory("nope", { content: "x" })).rejects.toThrow(
       "MEMORY_NOT_FOUND",
@@ -92,7 +92,7 @@ describe("ɵcreateInMemoryMemoryStore", () => {
   });
 
   it("removeMemory removes the memory from the list", async () => {
-    const store = ɵcreateInMemoryMemoryStore({ initial: [sampleMemory] });
+    const store = ɵcreateMemoryStore({ initial: [sampleMemory] });
 
     await store.removeMemory("mem-seed");
 
@@ -100,7 +100,7 @@ describe("ɵcreateInMemoryMemoryStore", () => {
   });
 
   it("ɵselectMemories emits the updated list after a mutation", async () => {
-    const store = ɵcreateInMemoryMemoryStore({
+    const store = ɵcreateMemoryStore({
       idFactory: () => "mem-rt",
     });
 
@@ -121,7 +121,7 @@ describe("ɵcreateInMemoryMemoryStore", () => {
   });
 
   it("applies an externally emitted created event (realtime reconciliation)", () => {
-    const store = ɵcreateInMemoryMemoryStore();
+    const store = ɵcreateMemoryStore();
 
     store.ɵemitMetadataEvent({ operation: "created", memory: sampleMemory });
 
@@ -129,7 +129,7 @@ describe("ɵcreateInMemoryMemoryStore", () => {
   });
 
   it("applies an externally emitted invalidated event", () => {
-    const store = ɵcreateInMemoryMemoryStore({ initial: [sampleMemory] });
+    const store = ɵcreateMemoryStore({ initial: [sampleMemory] });
 
     store.ɵemitMetadataEvent({
       operation: "invalidated",
@@ -140,7 +140,7 @@ describe("ɵcreateInMemoryMemoryStore", () => {
   });
 
   it("exposes loading and error via selectors", async () => {
-    const store = ɵcreateInMemoryMemoryStore();
+    const store = ɵcreateMemoryStore();
 
     expect(await firstValueFrom(store.select(ɵselectMemoriesIsLoading))).toBe(
       false,

--- a/packages/core/src/__tests__/memories.test.ts
+++ b/packages/core/src/__tests__/memories.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { firstValueFrom } from "rxjs";
+import { take, toArray } from "rxjs/operators";
+import {
+  ɵcreateInMemoryMemoryStore,
+  ɵselectMemories,
+  ɵselectMemoriesError,
+  ɵselectMemoriesIsLoading,
+} from "../memories";
+import type { PublicMemory } from "../memories";
+
+const sampleMemory: PublicMemory = {
+  id: "mem-seed",
+  kind: "topical",
+  scope: "user",
+  content: "User prefers dark mode",
+  sourceThreadIds: ["thread-1"],
+  invalidatedAt: null,
+};
+
+describe("ɵcreateInMemoryMemoryStore", () => {
+  it("starts empty with no error and not loading", () => {
+    const store = ɵcreateInMemoryMemoryStore();
+
+    expect(store.getState().memories).toEqual([]);
+    expect(store.getState().isLoading).toBe(false);
+    expect(store.getState().error).toBeNull();
+  });
+
+  it("seeds the list from initial memories", () => {
+    const store = ɵcreateInMemoryMemoryStore({ initial: [sampleMemory] });
+
+    expect(store.getState().memories).toEqual([sampleMemory]);
+  });
+
+  it("addMemory inserts the created memory and resolves to it", async () => {
+    const store = ɵcreateInMemoryMemoryStore({
+      idFactory: () => "mem-created",
+    });
+
+    const created = await store.addMemory({
+      kind: "episodic",
+      scope: "user",
+      content: "Met with Acme on Tuesday",
+      sourceThreadIds: ["thread-7"],
+    });
+
+    expect(created.id).toBe("mem-created");
+    expect(created.content).toBe("Met with Acme on Tuesday");
+    expect(store.getState().memories).toContainEqual(created);
+  });
+
+  it("updateMemory supersedes: new id minted, old id removed, change applied", async () => {
+    let next = 0;
+    const store = ɵcreateInMemoryMemoryStore({
+      initial: [sampleMemory],
+      idFactory: () => `mem-superseded-${(next += 1)}`,
+    });
+
+    const updated = await store.updateMemory("mem-seed", {
+      content: "User prefers light mode",
+    });
+
+    expect(updated.id).not.toBe("mem-seed");
+    expect(updated.content).toBe("User prefers light mode");
+    const ids = store.getState().memories.map((m) => m.id);
+    expect(ids).not.toContain("mem-seed");
+    expect(ids).toContain(updated.id);
+  });
+
+  it("updateMemory preserves untouched fields onto the superseded memory", async () => {
+    const store = ɵcreateInMemoryMemoryStore({
+      initial: [sampleMemory],
+      idFactory: () => "mem-next",
+    });
+
+    const updated = await store.updateMemory("mem-seed", {
+      content: "changed",
+    });
+
+    expect(updated.kind).toBe("topical");
+    expect(updated.scope).toBe("user");
+    expect(updated.sourceThreadIds).toEqual(["thread-1"]);
+  });
+
+  it("updateMemory rejects with MEMORY_NOT_FOUND for an unknown id", async () => {
+    const store = ɵcreateInMemoryMemoryStore();
+
+    await expect(store.updateMemory("nope", { content: "x" })).rejects.toThrow(
+      "MEMORY_NOT_FOUND",
+    );
+  });
+
+  it("removeMemory removes the memory from the list", async () => {
+    const store = ɵcreateInMemoryMemoryStore({ initial: [sampleMemory] });
+
+    await store.removeMemory("mem-seed");
+
+    expect(store.getState().memories).toEqual([]);
+  });
+
+  it("ɵselectMemories emits the updated list after a mutation", async () => {
+    const store = ɵcreateInMemoryMemoryStore({
+      idFactory: () => "mem-rt",
+    });
+
+    const emissions = firstValueFrom(
+      store.select(ɵselectMemories).pipe(take(2), toArray()),
+    );
+
+    await store.addMemory({
+      kind: "operational",
+      scope: "project",
+      content: "Deploy via the staging pipeline",
+    });
+
+    const emitted = await emissions;
+    expect(emitted).toHaveLength(2);
+    expect(emitted[0]).toEqual([]);
+    expect(emitted[1]!.map((m) => m.id)).toEqual(["mem-rt"]);
+  });
+
+  it("applies an externally emitted created event (realtime reconciliation)", () => {
+    const store = ɵcreateInMemoryMemoryStore();
+
+    store.ɵemitMetadataEvent({ operation: "created", memory: sampleMemory });
+
+    expect(store.getState().memories).toContainEqual(sampleMemory);
+  });
+
+  it("applies an externally emitted invalidated event", () => {
+    const store = ɵcreateInMemoryMemoryStore({ initial: [sampleMemory] });
+
+    store.ɵemitMetadataEvent({
+      operation: "invalidated",
+      memoryId: "mem-seed",
+    });
+
+    expect(store.getState().memories).toEqual([]);
+  });
+
+  it("exposes loading and error via selectors", async () => {
+    const store = ɵcreateInMemoryMemoryStore();
+
+    expect(await firstValueFrom(store.select(ɵselectMemoriesIsLoading))).toBe(
+      false,
+    );
+    expect(await firstValueFrom(store.select(ɵselectMemoriesError))).toBeNull();
+  });
+});

--- a/packages/core/src/__tests__/memories.test.ts
+++ b/packages/core/src/__tests__/memories.test.ts
@@ -83,6 +83,28 @@ describe("ɵcreateMemoryStore", () => {
     expect(updated.sourceThreadIds).toEqual(["thread-1"]);
   });
 
+  it("updateMemory does not carry score onto the superseded memory", async () => {
+    const store = ɵcreateMemoryStore({
+      idFactory: () => "mem-no-score",
+    });
+    store.ɵemitMetadataEvent({
+      operation: "created",
+      memory: {
+        id: "m1",
+        kind: "topical",
+        scope: "user",
+        content: "x",
+        sourceThreadIds: [],
+        score: 0.9,
+        invalidatedAt: null,
+      },
+    });
+
+    const updated = await store.updateMemory("m1", { content: "y" });
+
+    expect(updated.score).toBeUndefined();
+  });
+
   it("updateMemory rejects with MEMORY_NOT_FOUND for an unknown id", async () => {
     const store = ɵcreateMemoryStore();
 

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -419,15 +419,15 @@ export class CopilotKitCore {
           }
         });
 
-        // Unregister thread stores for agents that have been removed.
+        // Unregister thread and memory stores for agents that have been removed.
         //
         // Critically, only unregister an agentId that was present in the
         // PREVIOUS agents snapshot AND is missing from the new one. Without
         // the "previously had" guard, the FIRST `onAgentsChanged({ agents: {} })`
-        // delivered to a freshly-published core would tear out a thread store
-        // that a consumer (e.g. useThreads) just registered — `core.agents`
-        // is asynchronously populated and the empty-map notification fires
-        // before the published agents are merged in.
+        // delivered to a freshly-published core would tear out a store that a
+        // consumer (e.g. useThreads) just registered — `core.agents` is
+        // asynchronously populated and the empty-map notification fires before
+        // the published agents are merged in.
         const currentAgentIds = new Set(Object.keys(agents));
         // Each iteration is wrapped so a throw on one id does not stall
         // cleanup for the rest of the set. Both registries' unregister
@@ -443,6 +443,21 @@ export class CopilotKitCore {
             } catch (err) {
               console.error(
                 `CopilotKitCore.onAgentsChanged: threadStoreRegistry.unregister failed for "${agentId}":`,
+                err,
+              );
+            }
+          }
+        }
+        for (const agentId of Object.keys(this.memoryStoreRegistry.getAll())) {
+          if (
+            this.previousAgentIds.has(agentId) &&
+            !currentAgentIds.has(agentId)
+          ) {
+            try {
+              this.memoryStoreRegistry.unregister(agentId);
+            } catch (err) {
+              console.error(
+                `CopilotKitCore.onAgentsChanged: memoryStoreRegistry.unregister failed for "${agentId}":`,
                 err,
               );
             }

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -32,6 +32,8 @@ import type { DebugConfig } from "@copilotkit/shared";
 import { StateManager } from "./state-manager";
 import { ThreadStoreRegistry } from "./thread-store-registry";
 import type { ɵThreadStore } from "../threads";
+import { MemoryStoreRegistry } from "./memory-store-registry";
+import type { ɵMemoryStore } from "../memories";
 
 /** Configuration options for `CopilotKitCore`. */
 export interface CopilotKitCoreConfig {
@@ -356,6 +358,7 @@ export class CopilotKitCore {
   private runHandler: RunHandler;
   private stateManager: StateManager;
   private threadStoreRegistry: ThreadStoreRegistry;
+  private memoryStoreRegistry: MemoryStoreRegistry;
   /**
    * Tracks the agent IDs from the most recent `onAgentsChanged` notification.
    * Used to gate thread-store auto-unregister so the FIRST empty-agents
@@ -387,6 +390,7 @@ export class CopilotKitCore {
     this.runHandler = new RunHandler(this);
     this.stateManager = new StateManager(this);
     this.threadStoreRegistry = new ThreadStoreRegistry(this);
+    this.memoryStoreRegistry = new MemoryStoreRegistry(this);
 
     // Initialize each subsystem
     this.agentRegistry.initialize(agents__unsafe_dev_only);
@@ -801,6 +805,25 @@ export class CopilotKitCore {
 
   getThreadStores(): Readonly<Record<string, ɵThreadStore>> {
     return this.threadStoreRegistry.getAll();
+  }
+
+  /**
+   * Memory store registry (delegated to MemoryStoreRegistry)
+   */
+  registerMemoryStore(agentId: string, store: ɵMemoryStore): void {
+    this.memoryStoreRegistry.register(agentId, store);
+  }
+
+  unregisterMemoryStore(agentId: string): void {
+    this.memoryStoreRegistry.unregister(agentId);
+  }
+
+  getMemoryStore(agentId: string): ɵMemoryStore | undefined {
+    return this.memoryStoreRegistry.get(agentId);
+  }
+
+  getMemoryStores(): Readonly<Record<string, ɵMemoryStore>> {
+    return this.memoryStoreRegistry.getAll();
   }
 
   /**

--- a/packages/core/src/core/memory-store-registry.ts
+++ b/packages/core/src/core/memory-store-registry.ts
@@ -1,0 +1,42 @@
+import type { ɵMemoryStore } from "../memories";
+import type { CopilotKitCore } from "./core";
+
+export class MemoryStoreRegistry {
+  private _stores: Record<string, ɵMemoryStore> = {};
+  // Cached frozen snapshot of `_stores`. Invalidated to `null` on every
+  // `register`/`unregister` so the next `getAll()` rebuilds it. Stable
+  // references between mutations matter for `useSyncExternalStore` consumers
+  // that compare snapshot identity to decide whether to re-render.
+  private _snapshot: Readonly<Record<string, ɵMemoryStore>> | null = null;
+
+  constructor(private core: CopilotKitCore) {}
+
+  register(agentId: string, store: ɵMemoryStore): void {
+    this._stores[agentId] = store;
+    this._snapshot = null;
+  }
+
+  unregister(agentId: string): void {
+    if (!(agentId in this._stores)) return;
+    delete this._stores[agentId];
+    this._snapshot = null;
+  }
+
+  get(agentId: string): ɵMemoryStore | undefined {
+    return this._stores[agentId];
+  }
+
+  getAll(): Readonly<Record<string, ɵMemoryStore>> {
+    // Cache a frozen snapshot so consecutive calls return the same reference.
+    // `useSyncExternalStore` and other identity-comparing consumers depend on
+    // this stability to skip re-renders when nothing has actually changed.
+    // `Object.freeze` makes the `Readonly<>` claim true at runtime, not just
+    // at the type level — attempts to mutate the snapshot throw in strict
+    // mode and are silently ignored in sloppy mode (rather than corrupting
+    // the registry). Invalidated to `null` by `register`/`unregister`.
+    if (this._snapshot === null) {
+      this._snapshot = Object.freeze({ ...this._stores });
+    }
+    return this._snapshot;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,3 +6,4 @@ export * from "./intelligence-agent";
 export * from "./utils/micro-redux";
 export * from "./utils/phoenix-observable";
 export * from "./threads";
+export * from "./memories";

--- a/packages/core/src/memories.ts
+++ b/packages/core/src/memories.ts
@@ -217,6 +217,8 @@ export function ɵcreateMemoryStore(
       store.stop();
     },
     refresh(): Promise<void> {
+      // Intentional no-op: the in-memory mock has no transport to re-pull from.
+      // The real REST snapshot re-fetch is RD-34's responsibility.
       return Promise.resolve();
     },
     addMemory(input: NewMemory): Promise<PublicMemory> {

--- a/packages/core/src/memories.ts
+++ b/packages/core/src/memories.ts
@@ -157,6 +157,11 @@ export interface InMemoryMemoryStoreOptions {
   initial?: PublicMemory[];
   /** Id minted for created/superseded memories. Defaults to a counter. */
   idFactory?: () => string;
+  /**
+   * Transport hook consumed by RD-34's real store implementation. Accepted here
+   * for interface compatibility but unused by the in-memory mock.
+   */
+  fetch?: typeof fetch;
 }
 
 /**
@@ -181,10 +186,12 @@ function createDefaultIdFactory(): () => string {
 }
 
 /**
- * Creates an {@link InMemoryMemoryStore}. See {@link InMemoryMemoryStore} for
- * why this exists and how it relates to RD-34's real store.
+ * Creates an {@link InMemoryMemoryStore}. This is the canonical factory name
+ * consumed by the React and Angular SDK bindings. RD-34 replaces this
+ * function's body with the transport-backed implementation; the name,
+ * signature, and {@link MemoryStore} contract remain stable.
  */
-export function ɵcreateInMemoryMemoryStore(
+export function ɵcreateMemoryStore(
   options: InMemoryMemoryStoreOptions = {},
 ): InMemoryMemoryStore {
   const mintId = options.idFactory ?? createDefaultIdFactory();

--- a/packages/core/src/memories.ts
+++ b/packages/core/src/memories.ts
@@ -238,8 +238,11 @@ export function ɵcreateMemoryStore(
       if (!current) {
         return Promise.reject(new Error("MEMORY_NOT_FOUND"));
       }
+      // Destructure `score` out so it is never carried onto a freshly superseded
+      // memory. `score` is recall-only and must not appear on list entries.
+      const { score: _score, ...currentWithoutScore } = current;
       const superseded: PublicMemory = {
-        ...current,
+        ...currentWithoutScore,
         ...changes,
         id: mintId(),
         invalidatedAt: null,

--- a/packages/core/src/memories.ts
+++ b/packages/core/src/memories.ts
@@ -1,0 +1,263 @@
+import {
+  createActionGroup,
+  createReducer,
+  createSelector,
+  createStore,
+  empty,
+  on,
+  props,
+} from "./utils/micro-redux";
+import type { Reducer, Store } from "./utils/micro-redux";
+
+/**
+ * Memory taxonomy, public vocabulary. There is a single set of names across
+ * storage, the realtime payload, REST, and the SDK — no internal/external
+ * mapping layer (see RD-37). Do not reintroduce `semantic`/`procedural`.
+ */
+export type MemoryKind = "topical" | "episodic" | "operational";
+
+/** Memories are user- or project-scoped only. There is no thread scope. */
+export type MemoryScope = "user" | "project";
+
+/**
+ * Minimal public projection of a memory, matching the REST contract
+ * (`GET/POST /api/memories`, `POST /api/memories/recall`). Internal
+ * bookkeeping columns never cross this boundary.
+ *
+ * - `score` is present only on recall hits.
+ * - `invalidatedAt` is present on list responses so the `includeInvalidated`
+ *   toggle is meaningful; it is `null` for live memories.
+ */
+export interface PublicMemory {
+  id: string;
+  kind: MemoryKind;
+  scope: MemoryScope;
+  content: string;
+  sourceThreadIds: readonly string[];
+  score?: number;
+  invalidatedAt?: string | null;
+}
+
+/** Input accepted by {@link MemoryStore.addMemory} (`POST /api/memories`). */
+export interface NewMemory {
+  kind: MemoryKind;
+  scope: MemoryScope;
+  content: string;
+  sourceThreadIds?: readonly string[];
+}
+
+/**
+ * Mutable fields accepted by {@link MemoryStore.updateMemory}
+ * (`PATCH /api/memories/:id`). Scope is immutable across a supersede, so it
+ * is not part of the change set.
+ */
+export interface MemoryChanges {
+  kind?: MemoryKind;
+  content?: string;
+}
+
+/**
+ * Realtime `memory_metadata` delta, mirroring the gateway payload. Every
+ * server write emits one (or, for a supersede, an `invalidated` for the old
+ * id followed by a `created` for the new id).
+ */
+export type MemoryMetadataEvent =
+  | { operation: "created" | "updated"; memory: PublicMemory }
+  | { operation: "invalidated"; memoryId: string };
+
+/** Observable state shape exposed by the store. */
+export interface MemoryState {
+  memories: PublicMemory[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Framework-agnostic memory store surface that the React (`useMemories`) and
+ * Angular (`injectMemories`) bindings consume. Selectors are read via
+ * `select(...)`; mutations delegate to the store, which owns transport and
+ * realtime reconciliation. Mirrors the thread store's contract.
+ */
+export interface MemoryStore {
+  start(): void;
+  stop(): void;
+  /** Re-pull the REST snapshot (the fallback for project scope, no realtime). */
+  refresh(): Promise<void>;
+  addMemory(input: NewMemory): Promise<PublicMemory>;
+  /** Supersede: retires `id`, creates a replacement, resolves to the new memory. */
+  updateMemory(id: string, changes: MemoryChanges): Promise<PublicMemory>;
+  removeMemory(id: string): Promise<void>;
+  getState(): MemoryState;
+  select: Store<MemoryState>["select"];
+}
+
+const memoryEvents = createActionGroup("Memory", {
+  loadStarted: empty(),
+  loadSucceeded: props<{ memories: PublicMemory[] }>(),
+  loadFailed: props<{ error: Error }>(),
+  upserted: props<{ memory: PublicMemory }>(),
+  invalidated: props<{ memoryId: string }>(),
+});
+
+const initialMemoryState: MemoryState = {
+  memories: [],
+  isLoading: false,
+  error: null,
+};
+
+function upsertMemory(
+  memories: PublicMemory[],
+  memory: PublicMemory,
+): PublicMemory[] {
+  const index = memories.findIndex((existing) => existing.id === memory.id);
+  if (index === -1) {
+    return [...memories, memory];
+  }
+  const next = memories.slice();
+  next[index] = memory;
+  return next;
+}
+
+const memoryReducer = createReducer(
+  initialMemoryState,
+  on(memoryEvents.loadStarted, (state: MemoryState) => ({
+    ...state,
+    isLoading: true,
+    error: null,
+  })),
+  on(memoryEvents.loadSucceeded, (state: MemoryState, { memories }) => ({
+    ...state,
+    memories,
+    isLoading: false,
+  })),
+  on(memoryEvents.loadFailed, (state: MemoryState, { error }) => ({
+    ...state,
+    error,
+    isLoading: false,
+  })),
+  on(memoryEvents.upserted, (state: MemoryState, { memory }) => ({
+    ...state,
+    memories: upsertMemory(state.memories, memory),
+  })),
+  on(memoryEvents.invalidated, (state: MemoryState, { memoryId }) => ({
+    ...state,
+    memories: state.memories.filter((memory) => memory.id !== memoryId),
+  })),
+) as Reducer<MemoryState>;
+
+const selectMemories = createSelector((state: MemoryState) => state.memories);
+const selectMemoriesIsLoading = createSelector(
+  (state: MemoryState) => state.isLoading,
+);
+const selectMemoriesError = createSelector((state: MemoryState) => state.error);
+
+/** Options for the in-memory mock store. */
+export interface InMemoryMemoryStoreOptions {
+  /** Memories the store is seeded with. */
+  initial?: PublicMemory[];
+  /** Id minted for created/superseded memories. Defaults to a counter. */
+  idFactory?: () => string;
+}
+
+/**
+ * Concrete in-memory mock store used to build and unit-test the framework
+ * bindings ahead of the real core `MemoryStore` (RD-34). It collapses
+ * REST + realtime into local reducer dispatches — a mutation updates the list
+ * immediately, exactly as the server-authoritative `created`/`invalidated`
+ * events would. {@link InMemoryMemoryStore.ɵemitMetadataEvent} simulates a
+ * realtime delta arriving from another client.
+ *
+ * This is scaffolding: RD-34 supplies the transport-backed `createMemoryStore`
+ * that replaces it; the {@link MemoryStore} contract and selectors stay.
+ */
+export interface InMemoryMemoryStore extends MemoryStore {
+  /** Test seam: apply a realtime `memory_metadata` delta. */
+  ɵemitMetadataEvent(event: MemoryMetadataEvent): void;
+}
+
+function createDefaultIdFactory(): () => string {
+  let counter = 0;
+  return () => `mem-${(counter += 1)}`;
+}
+
+/**
+ * Creates an {@link InMemoryMemoryStore}. See {@link InMemoryMemoryStore} for
+ * why this exists and how it relates to RD-34's real store.
+ */
+export function ɵcreateInMemoryMemoryStore(
+  options: InMemoryMemoryStoreOptions = {},
+): InMemoryMemoryStore {
+  const mintId = options.idFactory ?? createDefaultIdFactory();
+  const store = createStore<MemoryState>({ reducer: memoryReducer });
+
+  if (options.initial && options.initial.length > 0) {
+    store.dispatch(memoryEvents.loadSucceeded({ memories: options.initial }));
+  }
+
+  function applyEvent(event: MemoryMetadataEvent): void {
+    if (event.operation === "invalidated") {
+      store.dispatch(memoryEvents.invalidated({ memoryId: event.memoryId }));
+      return;
+    }
+    store.dispatch(memoryEvents.upserted({ memory: event.memory }));
+  }
+
+  return {
+    start(): void {
+      store.init();
+    },
+    stop(): void {
+      store.stop();
+    },
+    refresh(): Promise<void> {
+      return Promise.resolve();
+    },
+    addMemory(input: NewMemory): Promise<PublicMemory> {
+      const memory: PublicMemory = {
+        id: mintId(),
+        kind: input.kind,
+        scope: input.scope,
+        content: input.content,
+        sourceThreadIds: input.sourceThreadIds ?? [],
+        invalidatedAt: null,
+      };
+      applyEvent({ operation: "created", memory });
+      return Promise.resolve(memory);
+    },
+    updateMemory(id: string, changes: MemoryChanges): Promise<PublicMemory> {
+      const current = store
+        .getState()
+        .memories.find((memory) => memory.id === id);
+      if (!current) {
+        return Promise.reject(new Error("MEMORY_NOT_FOUND"));
+      }
+      const superseded: PublicMemory = {
+        ...current,
+        ...changes,
+        id: mintId(),
+        invalidatedAt: null,
+      };
+      // Supersede emits both deltas, mirroring the server contract.
+      applyEvent({ operation: "invalidated", memoryId: id });
+      applyEvent({ operation: "created", memory: superseded });
+      return Promise.resolve(superseded);
+    },
+    removeMemory(id: string): Promise<void> {
+      applyEvent({ operation: "invalidated", memoryId: id });
+      return Promise.resolve();
+    },
+    getState(): MemoryState {
+      return store.getState();
+    },
+    select: store.select.bind(store),
+    ɵemitMetadataEvent(event: MemoryMetadataEvent): void {
+      applyEvent(event);
+    },
+  };
+}
+
+export type ɵMemoryStore = MemoryStore;
+export const ɵmemoryEvents = memoryEvents;
+export const ɵselectMemories = selectMemories;
+export const ɵselectMemoriesIsLoading = selectMemoriesIsLoading;
+export const ɵselectMemoriesError = selectMemoriesError;


### PR DESCRIPTION
## Summary

Adds the **framework-agnostic core for the Memory SDK** in `@copilotkit/core` — the shared foundation the React (`useMemories`, RD-35) and Angular (`injectMemories`, RD-36) bindings sit on. Linear: **RD-34** (this is the SDK-side base; the transport-backed store lands separately).

> ⚠️ **This is an in-memory MOCK / scaffolding**, deliberately ahead of the real transport-backed `MemoryStore` (RD-34, owned separately). It lets the bindings be built and unit-tested now. The store reuses the repo's `micro-redux` primitives (which are in-memory; transport lives only in effects), so it is indistinguishable from the real store to a binding — RD-34 later swaps the factory body for the Phoenix/REST implementation while this contract stays.

## What's here

- **Types** matching the live REST contract (`memories-routes.ts`): `PublicMemory` (`id/kind/scope/content/sourceThreadIds`, optional `score`/`invalidatedAt`), `NewMemory`, `MemoryChanges`, `MemoryScope`, and `MemoryKind = topical | episodic | operational` (the RD-37 rename — no `semantic`/`procedural`).
- **`ɵMemoryStore`** contract + selectors (`ɵselectMemories` / `…IsLoading` / `…Error`), mirroring the thread store.
- **In-memory `ɵcreateMemoryStore`** factory — encodes the supersede semantics of `updateMemory` (new id, old retired), with a `ɵemitMetadataEvent` test seam simulating realtime deltas.
- **`MemoryStoreRegistry`** on `CopilotKitCore` (`registerMemoryStore`/`getMemoryStore`/`unregisterMemoryStore`/`getMemoryStores`) + symmetric auto-unregister on agent removal (mirrors the thread-store registry).

## Quality

- `@copilotkit/core`: 469 tests, check-types, build — all green; format clean.
- Reviewed via a 2-round, 7-agent code-review loop (converged; bucket-(c) promotion audit returned 0). Round 1 caught & fixed: a dead `includeInvalidated` path (filter now tested) and a memory-store leak on agent removal (symmetric cleanup added).

## 🔧 Open contract questions for RD-34 (the real store)

The bindings filter `includeInvalidated` **client-side** on `memory.invalidatedAt`, which assumes the store **retains** invalidated rows. The real store must settle:
1. **`includeInvalidated`:** retain-and-filter (store holds retired rows, consumer filters) vs. fetch-param (`GET ?includeInvalidated=`)? And does the realtime `invalidated` delta *remove* the row (live-list) or *mark* `invalidatedAt` (retain)?
2. **`updateMemory` = supersede:** confirm the store owns the `PATCH` retire-old/create-new + reconciliation (the binding resolves to the new-id memory).
3. **Per-`agentId` store sharing:** each binding creates its own store and registers under `agentId` (mirrors `useThreads`); decide whether the real store is shared per `agentId` and whether `registerMemoryStore` should notify on replace.

## Follow-ups (non-blocking, deferred)

- Unbound `globalThis.fetch` was a copied `useThreads` idiom — bound here; **`useThreads` should match** (codebase-wide cleanup).
- Registry replace-without-notify and unregister-without-`stop()` mirror `ThreadStoreRegistry`; revisit when the inspector consumes `getMemoryStore`.

Blocks: RD-41 (docs), RD-42 (CLI starters). **Draft** — opened for early review alongside RD-35/RD-36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fq87snzYGjh74USiepGatB
