### PR TITLE
feat(react-core): useMemories hook [RD-35]

### DIFF
--- a/packages/react-core/src/v2/hooks/__tests__/use-memories.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-memories.test.tsx
@@ -1,0 +1,201 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+import { useCopilotKit } from "../../context";
+import { CopilotKitCoreRuntimeConnectionStatus } from "@copilotkit/core";
+import { useMemories } from "../use-memories";
+
+vi.mock("../../context", () => ({
+  useCopilotKit: vi.fn(),
+}));
+
+const mockUseCopilotKit = useCopilotKit as ReturnType<typeof vi.fn>;
+
+const AGENT_ID = "agent-1";
+const RUNTIME_URL = "https://runtime.example.com";
+
+type WireMemory = {
+  id: string;
+  kind: "topical";
+  scope: "user";
+  content: string;
+  sourceThreadIds: string[];
+  invalidatedAt: string | null;
+};
+
+function wireMemory(id: string, content = `content-${id}`): WireMemory {
+  return {
+    id,
+    kind: "topical",
+    scope: "user",
+    content,
+    sourceThreadIds: [],
+    invalidatedAt: null,
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+/**
+ * Builds a fetch mock that routes by URL + method. The store always POSTs
+ * `/memories/subscribe` for realtime join credentials on `setContext`, so the
+ * mock must answer that endpoint alongside the snapshot GET and the mutation
+ * call. The phoenix socket never connects under jsdom; that path is covered by
+ * core's `memory.test.ts`. `onMutation` returns the body for the create /
+ * supersede / retire request (or `undefined` for a bodyless DELETE).
+ */
+function makeFetchMock(
+  snapshot: WireMemory[],
+  onMutation?: (url: string, method: string) => unknown,
+): Mock {
+  return vi.fn((input: string, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    if (url === `${RUNTIME_URL}/memories` && method === "GET") {
+      return Promise.resolve(jsonResponse({ memories: snapshot }));
+    }
+    if (url === `${RUNTIME_URL}/memories/subscribe` && method === "POST") {
+      return Promise.resolve(
+        jsonResponse({ joinToken: "tok", joinCode: "code" }),
+      );
+    }
+    const body = onMutation?.(url, method);
+    return Promise.resolve(
+      method === "DELETE" ? ({ ok: true } as Response) : jsonResponse(body),
+    );
+  });
+}
+
+let registeredStore: unknown;
+let fetchMock: Mock;
+
+function setupCopilotKit(): void {
+  registeredStore = undefined;
+
+  mockUseCopilotKit.mockReturnValue({
+    copilotkit: {
+      runtimeUrl: RUNTIME_URL,
+      headers: {},
+      intelligence: { wsUrl: "wss://gw.example.com/client" },
+      runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Connected,
+      registerMemoryStore: vi.fn((_agentId: string, store: unknown) => {
+        registeredStore = store;
+      }),
+      unregisterMemoryStore: vi.fn(),
+    },
+    executingToolCallIds: new Set(),
+  });
+}
+
+describe("useMemories", () => {
+  beforeEach(() => {
+    setupCopilotKit();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("loads the snapshot on mount", async () => {
+    fetchMock = makeFetchMock([wireMemory("m1"), wireMemory("m2")]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useMemories({ agentId: AGENT_ID }));
+
+    await waitFor(() => {
+      expect(result.current.memories.map((m) => m.id)).toEqual(["m1", "m2"]);
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${RUNTIME_URL}/memories`,
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(registeredStore).toBeDefined();
+  });
+
+  it("addMemory POSTs and resolves to the created memory, adding it to the list", async () => {
+    fetchMock = makeFetchMock([], () => ({
+      ...wireMemory("m1", "hi"),
+      absorbed: false,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useMemories({ agentId: AGENT_ID }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let created: { id: string } | undefined;
+    await act(async () => {
+      created = await result.current.addMemory({
+        content: "hi",
+        kind: "topical",
+      });
+    });
+
+    expect(created?.id).toBe("m1");
+    await waitFor(() => {
+      expect(result.current.memories.map((m) => m.id)).toEqual(["m1"]);
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${RUNTIME_URL}/memories`,
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("updateMemory supersedes: resolves to the new id and the list shows it (old id gone)", async () => {
+    fetchMock = makeFetchMock([wireMemory("m1", "old")], () => ({
+      ...wireMemory("m2", "new"),
+      retiredId: "m1",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useMemories({ agentId: AGENT_ID }));
+    await waitFor(() =>
+      expect(result.current.memories.map((m) => m.id)).toEqual(["m1"]),
+    );
+
+    let updated: { id: string } | undefined;
+    await act(async () => {
+      updated = await result.current.updateMemory("m1", {
+        content: "new",
+        kind: "topical",
+      });
+    });
+
+    expect(updated?.id).toBe("m2");
+    await waitFor(() => {
+      expect(result.current.memories.map((m) => m.id)).toEqual(["m2"]);
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${RUNTIME_URL}/memories/m1`,
+      expect.objectContaining({ method: "PATCH" }),
+    );
+  });
+
+  it("removeMemory DELETEs and removes the memory from the list", async () => {
+    fetchMock = makeFetchMock([wireMemory("m1")]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useMemories({ agentId: AGENT_ID }));
+    await waitFor(() =>
+      expect(result.current.memories.map((m) => m.id)).toEqual(["m1"]),
+    );
+
+    await act(async () => {
+      await result.current.removeMemory("m1");
+    });
+
+    await waitFor(() => expect(result.current.memories).toEqual([]));
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${RUNTIME_URL}/memories/m1`,
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+});

--- a/packages/react-core/src/v2/hooks/index.ts
+++ b/packages/react-core/src/v2/hooks/index.ts
@@ -17,6 +17,8 @@ export { useInterrupt } from "./use-interrupt";
 export type { UseInterruptConfig } from "./use-interrupt";
 export { useThreads } from "./use-threads";
 export type { Thread, UseThreadsInput, UseThreadsResult } from "./use-threads";
+export { useMemories } from "./use-memories";
+export type { UseMemoriesInput, UseMemoriesResult } from "./use-memories";
 export { useLearnFromUserAction } from "./use-learn-from-user-action";
 export type {
   LearnFromUserActionInput,

--- a/packages/react-core/src/v2/hooks/use-memories.tsx
+++ b/packages/react-core/src/v2/hooks/use-memories.tsx
@@ -1,0 +1,234 @@
+import { useCopilotKit } from "../context";
+import {
+  CopilotKitCoreRuntimeConnectionStatus,
+  ɵcreateMemoryStore,
+  ɵselectMemories,
+  ɵselectMemoriesError,
+  ɵselectMemoriesIsLoading,
+} from "@copilotkit/core";
+import type {
+  ɵMemory,
+  ɵMemoryChanges,
+  ɵMemoryRuntimeContext,
+  ɵMemoryStore,
+  ɵNewMemory,
+} from "@copilotkit/core";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+/**
+ * Configuration for the {@link useMemories} hook.
+ *
+ * Memory operations are scoped to the runtime-authenticated user (v1 surfaces
+ * user-scoped memories only) and the provided agent.
+ */
+export interface UseMemoriesInput {
+  /** The ID of the agent whose memories to list and manage. */
+  agentId: string;
+}
+
+/**
+ * Return value of the {@link useMemories} hook.
+ *
+ * The `memories` array is the server-authoritative list for the current
+ * user/agent pair. It is hydrated from a REST snapshot and kept current by
+ * realtime `memory_metadata` deltas from the store's own channel. Mutations
+ * resolve once the platform confirms the operation and reject with an `Error`
+ * on failure.
+ */
+export interface UseMemoriesResult {
+  /**
+   * Memories for the current user/agent pair, newest first. Updated in
+   * realtime when the platform pushes `memory_metadata` events.
+   */
+  memories: ɵMemory[];
+  /**
+   * `true` while the initial memory snapshot is being fetched. Subsequent
+   * realtime updates do not re-enter the loading state.
+   */
+  isLoading: boolean;
+  /**
+   * The most recent error from fetching memories or executing a mutation, or
+   * `null` when there is no error. Reset to `null` on the next successful
+   * fetch.
+   */
+  error: Error | null;
+  /**
+   * Re-fetch the memory snapshot from the platform. Resolves once the re-pull
+   * settles; rejects if it fails or the store is torn down mid-flight.
+   */
+  refresh: () => Promise<void>;
+  /**
+   * Create a memory. Resolves to the stored memory (server-authoritative);
+   * rejects on failure.
+   */
+  addMemory: (input: ɵNewMemory) => Promise<ɵMemory>;
+  /**
+   * Supersede a memory: the old memory is retired and a new one is created.
+   * Resolves to the new memory (its `id` differs from `id`); rejects on
+   * failure.
+   */
+  updateMemory: (id: string, changes: ɵMemoryChanges) => Promise<ɵMemory>;
+  /**
+   * Retire a memory (non-lossy delete). Resolves when the server confirms;
+   * rejects on failure.
+   */
+  removeMemory: (id: string) => Promise<void>;
+}
+
+function useMemoryStoreSelector<T>(
+  store: ɵMemoryStore,
+  selector: (state: ReturnType<ɵMemoryStore["getState"]>) => T,
+): T {
+  return useSyncExternalStore(
+    useCallback(
+      (onStoreChange) => {
+        const subscription = store.select(selector).subscribe(onStoreChange);
+        return () => subscription.unsubscribe();
+      },
+      [store, selector],
+    ),
+    () => selector(store.getState()),
+  );
+}
+
+/**
+ * React hook for listing and managing platform memories.
+ *
+ * On mount the hook fetches the memory snapshot for the runtime-authenticated
+ * user and the given `agentId`, then exposes the live list plus stable
+ * `addMemory` / `updateMemory` / `removeMemory` / `refresh` callbacks. Mutations
+ * are server-authoritative: each resolves once the platform confirms the
+ * operation and rejects with an `Error` on failure.
+ *
+ * Realtime updates are automatic: the memory store opens its own
+ * `user_meta:memories:<joinCode>` channel and applies `memory_metadata` deltas
+ * to the list as soon as the runtime is connected (i.e. once `setContext` has
+ * wired up the runtime URL and headers). No other feature needs to be mounted —
+ * memory works standalone. You can still call `refresh()` to re-pull the REST
+ * snapshot on demand.
+ *
+ * @param input - Agent identifier.
+ * @returns Memory list state and stable mutation callbacks.
+ *
+ * @example
+ * ```tsx
+ * import { useMemories } from "@copilotkit/react-core";
+ *
+ * function MemoryList() {
+ *   const { memories, isLoading, addMemory, removeMemory } = useMemories({
+ *     agentId: "agent-1",
+ *   });
+ *
+ *   if (isLoading) return <p>Loading…</p>;
+ *
+ *   return (
+ *     <ul>
+ *       {memories.map((m) => (
+ *         <li key={m.id}>
+ *           {m.content}
+ *           <button onClick={() => removeMemory(m.id)}>Delete</button>
+ *         </li>
+ *       ))}
+ *     </ul>
+ *   );
+ * }
+ * ```
+ */
+export function useMemories({ agentId }: UseMemoriesInput): UseMemoriesResult {
+  const { copilotkit } = useCopilotKit();
+
+  const [store] = useState(() =>
+    ɵcreateMemoryStore({ fetch: globalThis.fetch.bind(globalThis) }),
+  );
+
+  const memories = useMemoryStoreSelector(store, ɵselectMemories);
+  const isLoading = useMemoryStoreSelector(store, ɵselectMemoriesIsLoading);
+  const error = useMemoryStoreSelector(store, ɵselectMemoriesError);
+
+  const headersKey = useMemo(() => {
+    return JSON.stringify(
+      Object.entries(copilotkit.headers ?? {}).sort(([left], [right]) =>
+        left.localeCompare(right),
+      ),
+    );
+  }, [copilotkit.headers]);
+  const runtimeStatus = copilotkit.runtimeConnectionStatus;
+
+  useEffect(() => {
+    store.start();
+    return () => {
+      store.stop();
+    };
+  }, [store]);
+
+  useEffect(() => {
+    copilotkit.registerMemoryStore(agentId, store);
+    return () => {
+      copilotkit.unregisterMemoryStore(agentId);
+    };
+  }, [copilotkit, agentId, store]);
+
+  const wsUrl = copilotkit.intelligence?.wsUrl;
+
+  // Mirror useThreads: defer setting the context until the runtime reports
+  // Connected, since the memory store is session-guarded and does nothing
+  // until `setContext` is called. The store opens its OWN realtime channel
+  // (`user_meta:memories:<joinCode>`) from this context, so it needs the
+  // gateway `wsUrl` alongside the runtime URL and headers. `wsUrl` only lands
+  // once `/info` resolves, so we wait for it to avoid dispatching a context
+  // with an undefined socket URL. When `runtimeUrl` is absent (or the runtime
+  // isn't Connected) we clear the context so a previous user's snapshot can't
+  // linger.
+  useEffect(() => {
+    if (
+      !copilotkit.runtimeUrl ||
+      runtimeStatus !== CopilotKitCoreRuntimeConnectionStatus.Connected
+    ) {
+      store.setContext(null);
+      return;
+    }
+
+    // Wait for `/info` to land so the context carries a real gateway URL and
+    // we don't re-dispatch once it resolves.
+    if (!wsUrl) {
+      return;
+    }
+
+    const context: ɵMemoryRuntimeContext = {
+      runtimeUrl: copilotkit.runtimeUrl,
+      wsUrl,
+      headers: { ...copilotkit.headers },
+    };
+    store.setContext(context);
+  }, [store, copilotkit.runtimeUrl, runtimeStatus, headersKey, wsUrl, agentId]);
+
+  const refresh = useCallback(() => store.refresh(), [store]);
+  const addMemory = useCallback(
+    (input: ɵNewMemory) => store.addMemory(input),
+    [store],
+  );
+  const updateMemory = useCallback(
+    (id: string, changes: ɵMemoryChanges) => store.updateMemory(id, changes),
+    [store],
+  );
+  const removeMemory = useCallback(
+    (id: string) => store.removeMemory(id),
+    [store],
+  );
+
+  return {
+    memories,
+    isLoading,
+    error,
+    refresh,
+    addMemory,
+    updateMemory,
+    removeMemory,
+  };
+}


### PR DESCRIPTION
## Summary

The **React binding** for the Memory SDK — `useMemories` in `@copilotkit/react-core`. Linear: **RD-35**.

> **Built on markus's final core** (`mme/memory-core`, RD-34) — **stacked on `mme/memory-core`**. Merge after the core lands.

A thin adapter over the core `MemoryStore`, mirroring `useThreads` — no transport logic here.

## Surface

```ts
const { memories, isLoading, error, refresh,
        addMemory, updateMemory, removeMemory } =
  useMemories({ agentId });
```

- Params are just **`{ agentId }`** (scope/includeInvalidated removed — v1 surfaces user scope; invalidated handling is server-side).
- List via `useSyncExternalStore` over the core selectors; types are the real `ɵMemory` / `ɵNewMemory` / `ɵMemoryChanges`.
- `updateMemory` resolves to the **superseded (new-id)** memory — key lists on `memory.id`.
- Stable `useCallback` mutations; `setContext({ runtimeUrl, headers, wsUrl })` once the runtime is Connected.

## Realtime

The memory store **opens its own `user_meta:memories` channel** (via `/memories/subscribe`) — it does **not** depend on the thread feature. Live `memory_metadata` deltas flow automatically once the runtime connects (the binding sources `wsUrl` from `intelligence.wsUrl`, same gateway). REST + mutations + realtime all work standalone.

## Quality
- `@copilotkit/react-core`: 1312 tests incl. `useMemories` coverage (load / add / supersede-new-id / remove). Hook types clean.
- Stack `check-types` CI may be red on the `@copilotkit/core` dependency until markus's pre-existing test-mock type fixes land — **not from this PR.**

**Draft.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fq87snzYGjh74USiepGatB
