### PR TITLE
feat(angular): injectMemories binding [RD-36]

### DIFF
--- a/packages/angular/src/lib/memories.spec.ts
+++ b/packages/angular/src/lib/memories.spec.ts
@@ -1,0 +1,250 @@
+import { Component, signal } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+import { CopilotKitCoreRuntimeConnectionStatus } from "@copilotkit/core";
+import { CopilotKit } from "./copilotkit";
+import { injectMemories, type MemoriesController } from "./memories";
+
+const AGENT_ID = "agent-1";
+const RUNTIME_URL = "https://runtime.example.com";
+const WS_URL = "wss://gw.example.com/client";
+
+type WireMemory = {
+  id: string;
+  kind: "topical";
+  scope: "user";
+  content: string;
+  sourceThreadIds: string[];
+  invalidatedAt: string | null;
+};
+
+function wireMemory(id: string, content = `content-${id}`): WireMemory {
+  return {
+    id,
+    kind: "topical",
+    scope: "user",
+    content,
+    sourceThreadIds: [],
+    invalidatedAt: null,
+  };
+}
+
+/**
+ * Stub of the Angular `CopilotKit` service exposing the surface
+ * `injectMemories` touches: writable runtime signals (so the internal
+ * `effect()` can be driven to `Connected`) and a `core` carrying the
+ * memory-store registry plus the `intelligence` runtime info (its `wsUrl`
+ * is required in the memory store's context).
+ */
+class CopilotKitStub {
+  readonly #runtimeConnectionStatus =
+    signal<CopilotKitCoreRuntimeConnectionStatus>(
+      CopilotKitCoreRuntimeConnectionStatus.Connected,
+    );
+  readonly #runtimeUrl = signal<string | undefined>(RUNTIME_URL);
+  readonly #headers = signal<Record<string, string>>({});
+
+  runtimeConnectionStatus = this.#runtimeConnectionStatus.asReadonly();
+  runtimeUrl = this.#runtimeUrl.asReadonly();
+  headers = this.#headers.asReadonly();
+
+  registeredStore: unknown;
+
+  core = {
+    intelligence: { wsUrl: WS_URL },
+    registerMemoryStore: vi.fn((_agentId: string, store: unknown) => {
+      this.registeredStore = store;
+    }),
+    unregisterMemoryStore: vi.fn(),
+  };
+
+  setRuntimeUrl(value: string | undefined) {
+    this.#runtimeUrl.set(value);
+  }
+
+  setRuntimeConnectionStatus(value: CopilotKitCoreRuntimeConnectionStatus) {
+    this.#runtimeConnectionStatus.set(value);
+  }
+}
+
+@Component({ standalone: true, template: "" })
+class MemoriesHost {
+  controller: MemoriesController = injectMemories({ agentId: AGENT_ID });
+}
+
+async function setup(): Promise<{
+  stub: CopilotKitStub;
+  fixture: ReturnType<typeof TestBed.createComponent<MemoriesHost>>;
+  controller: MemoriesController;
+}> {
+  const stub = new CopilotKitStub();
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    providers: [{ provide: CopilotKit, useValue: stub }],
+  });
+
+  const fixture = TestBed.createComponent(MemoriesHost);
+  fixture.detectChanges();
+  await fixture.whenStable();
+
+  return { stub, fixture, controller: fixture.componentInstance.controller };
+}
+
+/** Runs change detection then drains microtasks so signals settle. */
+async function flush(
+  fixture: ReturnType<typeof TestBed.createComponent<MemoriesHost>>,
+): Promise<void> {
+  fixture.detectChanges();
+  await fixture.whenStable();
+}
+
+type FetchResponse = {
+  ok: boolean;
+  status?: number;
+  json?: () => Promise<unknown>;
+};
+
+/**
+ * Routes the store's fetches by URL + method. Setting the context fires two
+ * concurrent calls — the REST snapshot `GET /memories` and the realtime
+ * `POST /memories/subscribe` (for socket join credentials). Routing by
+ * request (rather than `mockResolvedValueOnce` ordering) keeps the subscribe
+ * call from perturbing the snapshot/mutation assertions. `subscribe` always
+ * resolves to benign join credentials; the binding spec only exercises the
+ * REST + selector-forwarding surface (channel realtime is covered by core's
+ * `memory.test.ts`).
+ */
+function routedFetch(handlers: {
+  snapshot: FetchResponse;
+  mutation?: FetchResponse;
+}): Mock {
+  return vi.fn((url: string, init?: { method?: string }) => {
+    const method = init?.method ?? "GET";
+    if (url.endsWith("/memories/subscribe")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ joinToken: "jt-1", joinCode: "jc-1" }),
+      });
+    }
+    if (url.endsWith("/memories") && method === "GET") {
+      return Promise.resolve(handlers.snapshot);
+    }
+    // Any mutation (POST /memories, PATCH|DELETE /memories/:id).
+    return Promise.resolve(handlers.mutation ?? { ok: true });
+  });
+}
+
+describe("injectMemories", () => {
+  let fetchMock: Mock;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("loads the snapshot on mount", async () => {
+    fetchMock = routedFetch({
+      snapshot: {
+        ok: true,
+        json: async () => ({ memories: [wireMemory("m1"), wireMemory("m2")] }),
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { stub, fixture, controller } = await setup();
+    await flush(fixture);
+
+    expect(controller.memories().map((m) => m.id)).toEqual(["m1", "m2"]);
+    expect(controller.isLoading()).toBe(false);
+    expect(controller.error()).toBeNull();
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${RUNTIME_URL}/memories`,
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(stub.registeredStore).toBeDefined();
+  });
+
+  it("addMemory POSTs and resolves to the created memory, adding it to the list", async () => {
+    fetchMock = routedFetch({
+      snapshot: { ok: true, json: async () => ({ memories: [] }) },
+      mutation: {
+        ok: true,
+        json: async () => ({ ...wireMemory("m1", "hi"), absorbed: false }),
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fixture, controller } = await setup();
+    await flush(fixture);
+    expect(controller.isLoading()).toBe(false);
+
+    const created = await controller.addMemory({
+      content: "hi",
+      kind: "topical",
+    });
+    await flush(fixture);
+
+    expect(created.id).toBe("m1");
+    expect(controller.memories().map((m) => m.id)).toEqual(["m1"]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${RUNTIME_URL}/memories`,
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("updateMemory supersedes: resolves to the new id and the list shows it (old id gone)", async () => {
+    fetchMock = routedFetch({
+      snapshot: {
+        ok: true,
+        json: async () => ({ memories: [wireMemory("m1", "old")] }),
+      },
+      mutation: {
+        ok: true,
+        json: async () => ({ ...wireMemory("m2", "new"), retiredId: "m1" }),
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fixture, controller } = await setup();
+    await flush(fixture);
+    expect(controller.memories().map((m) => m.id)).toEqual(["m1"]);
+
+    const updated = await controller.updateMemory("m1", {
+      content: "new",
+      kind: "topical",
+    });
+    await flush(fixture);
+
+    expect(updated.id).toBe("m2");
+    expect(controller.memories().map((m) => m.id)).toEqual(["m2"]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${RUNTIME_URL}/memories/m1`,
+      expect.objectContaining({ method: "PATCH" }),
+    );
+  });
+
+  it("removeMemory DELETEs and removes the memory from the list", async () => {
+    fetchMock = routedFetch({
+      snapshot: {
+        ok: true,
+        json: async () => ({ memories: [wireMemory("m1")] }),
+      },
+      mutation: { ok: true },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fixture, controller } = await setup();
+    await flush(fixture);
+    expect(controller.memories().map((m) => m.id)).toEqual(["m1"]);
+
+    await controller.removeMemory("m1");
+    await flush(fixture);
+
+    expect(controller.memories()).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${RUNTIME_URL}/memories/m1`,
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+});

--- a/packages/angular/src/lib/memories.ts
+++ b/packages/angular/src/lib/memories.ts
@@ -1,0 +1,172 @@
+import { DestroyRef, effect, inject, Signal } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
+import {
+  ɵcreateMemoryStore,
+  ɵselectMemories,
+  ɵselectMemoriesError,
+  ɵselectMemoriesIsLoading,
+  CopilotKitCoreRuntimeConnectionStatus,
+} from "@copilotkit/core";
+import type { ɵMemory, ɵMemoryChanges, ɵNewMemory } from "@copilotkit/core";
+import { CopilotKit } from "./copilotkit";
+
+/**
+ * Configuration for the {@link injectMemories} function.
+ *
+ * Memory operations are scoped to the runtime-authenticated user and the
+ * provided agent.
+ */
+export interface InjectMemoriesParams {
+  /** The ID of the agent whose memories to list and manage. */
+  agentId: string;
+}
+
+/**
+ * Return value of {@link injectMemories}.
+ *
+ * The `memories` signal is the server-authoritative list for the current
+ * user/agent pair. It is hydrated from a REST snapshot and kept current by
+ * realtime `memory_metadata` deltas pushed over the memory store's own
+ * channel. Mutations resolve once the platform confirms the operation and
+ * reject with an `Error` on failure.
+ */
+export interface MemoriesController {
+  /**
+   * Memories for the current user/agent pair. Updated in realtime when the
+   * platform pushes `memory_metadata` events over the memory store's channel.
+   */
+  memories: Signal<ɵMemory[]>;
+  /**
+   * `true` while the initial memory snapshot is being fetched. Subsequent
+   * realtime updates do not re-enter the loading state.
+   */
+  isLoading: Signal<boolean>;
+  /**
+   * The most recent error from fetching memories or a mutation, or `null`
+   * when there is no error.
+   */
+  error: Signal<Error | null>;
+  /**
+   * Re-fetch the memory snapshot from the platform.
+   */
+  refresh: () => Promise<void>;
+  /**
+   * Create a memory. Resolves to the stored memory; rejects on failure.
+   */
+  addMemory: (input: ɵNewMemory) => Promise<ɵMemory>;
+  /**
+   * Supersede a memory: the old memory is retired and a new one is created.
+   * Resolves to the new memory (its `id` differs from the supplied `id`);
+   * rejects on failure.
+   */
+  updateMemory: (id: string, changes: ɵMemoryChanges) => Promise<ɵMemory>;
+  /**
+   * Retire a memory (non-lossy delete). Resolves when the server confirms;
+   * rejects on failure.
+   */
+  removeMemory: (id: string) => Promise<void>;
+}
+
+/**
+ * Angular injection function for listing and managing platform memories.
+ *
+ * On creation the binding fetches the memory snapshot for the
+ * runtime-authenticated user and the given `agentId`, then exposes the live
+ * list plus stable `addMemory` / `updateMemory` / `removeMemory` / `refresh`
+ * callbacks. Mutations are server-authoritative: each resolves once the
+ * platform confirms the operation and rejects with an `Error` on failure.
+ *
+ * Realtime updates: the memory store opens its own channel and works
+ * standalone — it does not depend on the thread feature being mounted.
+ * Realtime `memory_metadata` deltas flow automatically once the binding's
+ * `setContext` connects (i.e. the runtime is `Connected`).
+ *
+ * Must be called inside an injection context (component constructor, `inject`
+ * callback, or `TestBed.runInInjectionContext`).
+ *
+ * @param params - Agent identifier.
+ * @returns Signals for memory state and stable mutation callbacks.
+ *
+ * @example
+ * ```ts
+ * import { injectMemories } from "@copilotkit/angular";
+ *
+ * @Component({ ... })
+ * class MemoryList {
+ *   readonly #m = injectMemories({ agentId: "agent-1" });
+ *   memories = this.#m.memories;
+ *   isLoading = this.#m.isLoading;
+ *
+ *   remove(id: string) { this.#m.removeMemory(id); }
+ * }
+ * ```
+ */
+export function injectMemories({
+  agentId,
+}: InjectMemoriesParams): MemoriesController {
+  const copilotkit = inject(CopilotKit);
+  const destroyRef = inject(DestroyRef);
+
+  const store = ɵcreateMemoryStore({
+    fetch: globalThis.fetch.bind(globalThis),
+  });
+
+  copilotkit.core.registerMemoryStore(agentId, store);
+  store.start();
+
+  // Mirror useThreads: defer setting the context until the runtime reports
+  // Connected, since the memory store is session-guarded and does nothing
+  // until `setContext` is called. Waiting for `Connected` also means `/info`
+  // has landed, so `intelligence.wsUrl` (the realtime gateway the memory store
+  // opens its own channel on) is populated. When `runtimeUrl` or `wsUrl` is
+  // absent (or the runtime is not Connected) we clear the context so a
+  // previous user's snapshot cannot linger.
+  effect(() => {
+    const runtimeUrl = copilotkit.runtimeUrl();
+    const runtimeStatus = copilotkit.runtimeConnectionStatus();
+    const wsUrl = copilotkit.core.intelligence?.wsUrl;
+
+    if (
+      !runtimeUrl ||
+      !wsUrl ||
+      runtimeStatus !== CopilotKitCoreRuntimeConnectionStatus.Connected
+    ) {
+      store.setContext(null);
+      return;
+    }
+
+    store.setContext({
+      runtimeUrl,
+      wsUrl,
+      headers: { ...copilotkit.headers() },
+    });
+  });
+
+  destroyRef.onDestroy(() => {
+    store.stop();
+    copilotkit.core.unregisterMemoryStore(agentId);
+  });
+
+  const initialState = store.getState();
+
+  const memories = toSignal(store.select(ɵselectMemories), {
+    initialValue: ɵselectMemories(initialState),
+  });
+  const isLoading = toSignal(store.select(ɵselectMemoriesIsLoading), {
+    initialValue: ɵselectMemoriesIsLoading(initialState),
+  });
+  const error = toSignal(store.select(ɵselectMemoriesError), {
+    initialValue: ɵselectMemoriesError(initialState),
+  });
+
+  return {
+    memories,
+    isLoading,
+    error,
+    refresh: () => store.refresh(),
+    addMemory: (input: ɵNewMemory) => store.addMemory(input),
+    updateMemory: (id: string, changes: ɵMemoryChanges) =>
+      store.updateMemory(id, changes),
+    removeMemory: (id: string) => store.removeMemory(id),
+  };
+}

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -12,6 +12,7 @@ export * from "./lib/scroll-position";
 export * from "./lib/resize-observer";
 export * from "./lib/utils";
 export * from "./lib/agent-context";
+export * from "./lib/memories";
 export type {
   Attachment,
   AttachmentModality,


### PR DESCRIPTION
## Summary

The **Angular binding** for the Memory SDK — `injectMemories` in `@copilotkit/angular`. Linear: **RD-36**.

> **Built on markus's final core** (`mme/memory-core`, RD-34) — **stacked on `mme/memory-core`**. Angular analog of the React `useMemories` (#5669).

A thin RxJS→signal adapter over the core `MemoryStore`; no transport logic here.

## Surface

```ts
const memories = injectMemories({ agentId });
// template: @for (m of memories.memories(); track m.id) { ... }
```

- Params are just **`{ agentId }`**.
- `memories` / `isLoading` / `error` as **signals** via `toSignal`; mutations as promise-returning methods using `ɵMemory` / `ɵNewMemory` / `ɵMemoryChanges`.
- `updateMemory` resolves to the **superseded (new-id)** memory — `track m.id`.
- An `effect()` calls `setContext({ runtimeUrl, headers, wsUrl })` once the runtime is Connected; `DestroyRef.onDestroy` → stop + unregister.

## Realtime

Memory **opens its own `user_meta:memories` channel** (via `/memories/subscribe`) — no thread-feature dependency. Live deltas flow automatically once the runtime connects (`wsUrl` sourced from `core.intelligence.wsUrl`). REST + mutations + realtime work standalone.

## Quality
- `@copilotkit/angular`: `injectMemories` spec passes (load / add / supersede-new-id / remove); lib types clean.
- Stack `check-types` CI may be red on the `@copilotkit/core` dependency (markus's pre-existing test-mock fixes) — **not from this PR.** A pre-existing unrelated `a2ui-activity-renderer.spec.ts` failure also exists on the base — not ours.

**Draft.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fq87snzYGjh74USiepGatB
