### PR TITLE
fix(showcase): harden promote-notify alerting + debt cleanup

### DIFF
--- a/.github/workflows/showcase_promote_notify.dry-run.sh
+++ b/.github/workflows/showcase_promote_notify.dry-run.sh
@@ -19,6 +19,39 @@
 # (notify workflow aborts gracefully — we treat that as a non-fatal but
 # distinct exit so callers can assert on it).
 
+# ---------- alert post-and-verify predicate (shared with the workflow) ----------
+# Slack returns HTTP 200 with `{"ok":false,"error":"..."}` on LOGICAL failures
+# (channel_not_found, not_in_channel, ...). A failure-ALERT that is silently
+# dropped pages nobody, so the live workflow MUST surface it. This predicate is
+# the testable core of that surfacing logic: it inspects a captured Slack
+# response and, when the post did NOT succeed, emits a GitHub `::warning::`
+# (matching the workflow's existing `::warning::`/`>&2` idiom) and returns 1.
+#
+# Sourcing this script (e.g. from bats) defines this function without running
+# the dry-run body — see the EXECUTION GUARD just below the function.
+#   $1 = label for the warning (e.g. "thread reply", "#oss-alerts cross-post")
+#   $2 = captured Slack API response body (JSON, or "{}" on transport failure)
+slack_alert_posted_ok() {
+  local label="$1"
+  local resp="$2"
+  local ok
+  ok=$(printf '%s' "$resp" | jq -r '.ok // false' 2>/dev/null || echo false)
+  if [ "$ok" != "true" ]; then
+    local err
+    err=$(printf '%s' "$resp" | jq -r '.error // "unknown"' 2>/dev/null || echo unknown)
+    echo "::warning::Slack ${label} did NOT post (ok=${ok} error=${err}); failure alert may have been dropped" >&2
+    return 1
+  fi
+  return 0
+}
+
+# EXECUTION GUARD: define functions only when sourced. `return` outside a
+# function is legal only in a sourced script (it errors when executed), so the
+# subshell `(return 0 2>/dev/null)` succeeds iff we are being sourced — in which
+# case we `return 0` here and skip the dry-run body below. When executed
+# directly the subshell fails and execution falls through to `set -euo`.
+(return 0 2>/dev/null) && return 0
+
 set -euo pipefail
 
 if [ "${1:-}" = "" ]; then
@@ -79,8 +112,6 @@ elapsed=$(jq -r '(.elapsed_seconds // 0) | tonumber? // 0 | floor' "$R")
 pre_staging=$(jq -r '.pre_staging // "skipped"' "$R")
 abort_reason=$(jq -r '.abort_reason // ""' "$R")
 succeeded_count=$(jq -r '.succeeded | length' "$R")
-# shellcheck disable=SC2034  # retained for parity with workflow (internal logging only)
-failed_count=$(jq -r '.failed | length' "$R")
 
 jq '.failed | sort_by(.service)' "$R" > /tmp/dry-run-failed-sorted.json
 jq '[.[] | select(.category != "truncation-suffix")]' /tmp/dry-run-failed-sorted.json > /tmp/dry-run-failed-render.json
@@ -91,7 +122,6 @@ truncation_more=$(jq -r '[.[] | select(.category == "truncation-suffix") | .serv
 #   succeeded_count    = raw .succeeded length
 #   failed_real_count  = .failed length minus truncation-suffix sentinels
 #                        (rendered to operators on all display lines)
-#   failed_count       = raw .failed length (internal logging only)
 failed_real_count=$(jq 'length' /tmp/dry-run-failed-render.json)
 
 total_count=$((succeeded_count + failed_real_count))
@@ -252,12 +282,29 @@ emit() {
 emit "#team-showcase" "$init_text"
 emit "#team-showcase (thread_ts=<init_ts>)" "$thread_text"
 
+# Mirror the workflow's post-and-verify exit semantics so the dry-run exercises
+# the SAME fail-loud/warn-only distinction the live .yml does (see the matching
+# slack_alert_posted_ok calls there). No real Slack call happens here, so we
+# feed each predicate a simulated response: a successful post by default (the
+# dry-run convention — see the operator-mention block above), overridable via
+# DRY_RUN_THREAD_RESP / DRY_RUN_OSS_RESP so a test can inject a 200/ok:false
+# drop and assert on the exit code.
+sim_ok='{"ok":true,"ts":"<sim>"}'
+
+# Thread reply: informational, in the promote channel — warn-only (|| true),
+# mirroring the .yml. A dropped summary post must not red the job.
+slack_alert_posted_ok "thread reply" "${DRY_RUN_THREAD_RESP:-$sim_ok}" || true
+
 if [ "$outcome" != "success" ]; then
   case "$outcome" in
     partial) oss_text="⚠️ showcase promote: ${succeeded_count} ✓ · ${failed_real_count} ✗ — thread: <permalink>" ;;
     total)   oss_text="❌ showcase promote aborted: 0 ✓ · ${failed_real_count} ✗ — thread: <permalink>" ;;
   esac
   emit "#oss-alerts" "$oss_text"
+  # Page-the-humans alert: FAIL LOUD, mirroring the .yml. No `|| true` — a
+  # 200/ok:false drop here means nobody is told the promote failed, so the
+  # predicate's non-zero return must abort (set -e) and red the run.
+  slack_alert_posted_ok "#oss-alerts cross-post" "${DRY_RUN_OSS_RESP:-$sim_ok}"
 fi
 
 echo "outcome=${outcome} run_id=${run_id}"

--- a/.github/workflows/showcase_promote_notify.yml
+++ b/.github/workflows/showcase_promote_notify.yml
@@ -109,10 +109,41 @@ jobs:
             rm -f "$resp"
           }
 
+          # Slack returns HTTP 200 with `{"ok":false,"error":"..."}` on LOGICAL
+          # failures (channel_not_found, not_in_channel, ...). slack_api only
+          # surfaces non-2xx HTTP, so a failure-ALERT that posts 200/ok:false
+          # would otherwise be silently dropped — pages nobody. This predicate
+          # checks the captured response and emits a `::warning::` (mirroring the
+          # slack_api non-2xx idiom above) when the post did NOT succeed.
+          #   $1 = label, $2 = captured Slack response body
+          slack_alert_posted_ok() {
+            local label="$1"
+            local resp="$2"
+            local ok
+            ok=$(printf '%s' "$resp" | jq -r '.ok // false' 2>/dev/null || echo false)
+            if [ "$ok" != "true" ]; then
+              local err
+              err=$(printf '%s' "$resp" | jq -r '.error // "unknown"' 2>/dev/null || echo unknown)
+              echo "::warning::Slack ${label} did NOT post (ok=${ok} error=${err}); failure alert may have been dropped" >&2
+              return 1
+            fi
+            return 0
+          }
+
           # ---------- read payload ----------
           R="$RESULTS_PATH"
 
           run_id=$(jq -r '.run_id' "$R")
+          # Validate the BLOB's run_id, not just the RUN_ID input. The decode
+          # step (separate step, no shared shell vars) checks the input; the
+          # CLI/hand-dispatch path renders THIS value into the run-name and the
+          # Slack messages, so it must satisfy the same ^[0-9a-f]{6}$ contract.
+          # Mirrors showcase_promote_notify.dry-run.sh. Hard-fail (exit 1) — a
+          # malformed run_id is a dispatcher-contract violation, not recoverable.
+          if ! printf '%s' "$run_id" | grep -Eq '^[0-9a-f]{6}$'; then
+            echo "::error::run_id '$run_id' does not match ^[0-9a-f]{6}$ (breaks CLI polling contract; see run-name)"
+            exit 1
+          fi
           trigger=$(jq -r '.trigger' "$R")
           operator_email=$(jq -r '.operator_email // ""' "$R")
           operator_git_name=$(jq -r '.operator_git_name // ""' "$R")
@@ -126,7 +157,6 @@ jobs:
           pre_staging=$(jq -r '.pre_staging // "skipped"' "$R")
           abort_reason=$(jq -r '.abort_reason // ""' "$R")
           succeeded_count=$(jq -r '.succeeded | length' "$R")
-          failed_count=$(jq -r '.failed | length' "$R")
 
           # Comma-separated list of the SUCCEEDED service names, for the ✅
           # success thread reply AND the ⚠️ partial reply's `Promoted:` line.
@@ -151,7 +181,6 @@ jobs:
           #   succeeded_count    = raw .succeeded length
           #   failed_real_count  = .failed length minus truncation-suffix sentinels
           #                        (rendered to operators on all display lines)
-          #   failed_count       = raw .failed length (internal logging only)
           failed_real_count=$(jq 'length' /tmp/failed-render.json)
 
           # Service total = succeeded + real failures (truncation entries
@@ -355,7 +384,7 @@ jobs:
               --arg text "$thread_text" \
               --arg ts "$init_ts" \
               '{channel:$channel, text:$text, thread_ts:$ts}')
-            slack_api chat.postMessage "$thread_body" >/dev/null
+            thread_resp=$(slack_api chat.postMessage "$thread_body")
           else
             # Initiation failed; post the thread text as a top-level
             # message so the operator still gets the summary.
@@ -363,8 +392,11 @@ jobs:
               --arg channel "$TEAM_SHOWCASE_CHANNEL" \
               --arg text "$thread_text" \
               '{channel:$channel, text:$text}')
-            slack_api chat.postMessage "$fallback_body" >/dev/null
+            thread_resp=$(slack_api chat.postMessage "$fallback_body")
           fi
+          # Surface a dropped summary post (200/ok:false). `|| true` keeps the
+          # ::warning:: visible without aborting the cross-post below.
+          slack_alert_posted_ok "thread reply" "$thread_resp" || true
 
           # ---------- cross-post to #oss-alerts on partial/total failure ----------
           if [ "$outcome" != "success" ]; then
@@ -374,8 +406,9 @@ jobs:
               link_suffix="thread: ${permalink}"
             else
               # No Slack permalink available; link to the GitHub Actions run
-              # instead. gha_url is hoisted in the decode-payload section so the
-              # success message and this fallback share the same URL.
+              # instead. gha_url is defined earlier in this render step (where
+              # the payload is read) so the success message and this fallback
+              # share the same URL.
               link_suffix="thread permalink unavailable; see ${gha_url}"
             fi
             case "$outcome" in
@@ -386,7 +419,15 @@ jobs:
               --arg channel "$OSS_ALERTS_CHANNEL" \
               --arg text "$oss_text" \
               '{channel:$channel, text:$text}')
-            slack_api chat.postMessage "$oss_body" >/dev/null
+            oss_resp=$(slack_api chat.postMessage "$oss_body")
+            # This is the page-the-humans alert. A 200/ok:false drop here means
+            # nobody is told the promote failed, so a silently-green renderer job
+            # would hide the dropped page. FAIL LOUD: the ::warning:: alone is
+            # easy to miss, so let the predicate's non-zero return abort this
+            # step (set -e) → the job goes red and the drop is visible. Unlike
+            # the thread reply (informational, in the promote channel), this
+            # alert MUST not be swallowed — so there is no `|| true` here.
+            slack_alert_posted_ok "#oss-alerts cross-post" "$oss_resp"
           fi
 
           echo "notify completed: outcome=${outcome} run_id=${run_id}"

--- a/showcase/scripts/__tests__/promote-notify.bats
+++ b/showcase/scripts/__tests__/promote-notify.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+# Tests for the alert post-and-verify predicate shared by
+# .github/workflows/showcase_promote_notify.yml and its dry-run helper.
+#
+# The bug under test: the thread-reply and #oss-alerts cross-post used to pipe
+# the Slack API response to /dev/null. Slack returns HTTP 200 with
+# `{"ok":false,"error":"channel_not_found"}` on LOGICAL failures, so a failed
+# failure-ALERT (the page-the-humans message) was silently dropped — no warning,
+# no non-zero exit. `slack_alert_posted_ok` is the testable predicate that now
+# surfaces such drops via a GitHub `::warning::` and a non-zero return.
+#
+# NB on assertion gating: bats does NOT run test bodies under errexit. Only the
+# FINAL command's status decides pass/fail, so every non-final assertion is
+# written `[[ ... ]] || fail "message"`. The `|| fail` is what forces the hard
+# failure; dropping it turns the assertion into a silent false-green.
+
+fail() {
+  echo "$1" >&2
+  return 1
+}
+
+setup() {
+  # The predicate lives in the workflow's dry-run helper. Source it (the helper
+  # has an EXECUTION GUARD so sourcing defines functions without running the
+  # dry-run body).
+  HELPER="$BATS_TEST_DIRNAME/../../../.github/workflows/showcase_promote_notify.dry-run.sh"
+  [ -f "$HELPER" ] || fail "helper not found: $HELPER"
+  # shellcheck source=/dev/null
+  source "$HELPER"
+}
+
+@test "slack_alert_posted_ok: ok:true response returns 0 and emits no warning" {
+  run slack_alert_posted_ok "#oss-alerts cross-post" '{"ok":true,"ts":"123.456"}'
+  [ "$status" -eq 0 ] || fail "expected status 0 on ok:true, got $status"
+  [[ "$output" != *"::warning::"* ]] || fail "expected NO warning on ok:true, got: $output"
+}
+
+@test "slack_alert_posted_ok: ok:false (channel_not_found) returns non-zero and warns" {
+  # This is the silent-drop the fix surfaces: HTTP 200 but logical failure.
+  run slack_alert_posted_ok "#oss-alerts cross-post" '{"ok":false,"error":"channel_not_found"}'
+  [ "$status" -ne 0 ] || fail "expected non-zero status on ok:false, got $status"
+  [[ "$output" == *"::warning::"* ]] || fail "expected a ::warning:: on ok:false, got: $output"
+  [[ "$output" == *"channel_not_found"* ]] || fail "expected the Slack error in the warning, got: $output"
+  [[ "$output" == *"#oss-alerts cross-post"* ]] || fail "expected the call label in the warning, got: $output"
+}
+
+@test "slack_alert_posted_ok: transport-failure sentinel ({}) returns non-zero and warns" {
+  # slack_api returns "{}" on non-2xx/transport failure; treat that as a drop.
+  run slack_alert_posted_ok "thread reply" '{}'
+  [ "$status" -ne 0 ] || fail "expected non-zero status on empty response, got $status"
+  [[ "$output" == *"::warning::"* ]] || fail "expected a ::warning:: on empty response, got: $output"
+  [[ "$output" == *"thread reply"* ]] || fail "expected the call label in the warning, got: $output"
+}
+
+# ---------- A3: high-value predicate edge cases ----------
+# Each must be treated as a DROPPED page: non-zero return AND a surfaced
+# ::warning::. These exercise the `jq ... || echo false` / `// false` defenses
+# against non-JSON, malformed, and ok-key-absent responses.
+
+@test "slack_alert_posted_ok: curl transport error / non-JSON body returns non-zero and warns" {
+  # slack_api feeds the raw body through on some failure modes; a proxy/5xx page
+  # like '<html>500</html>' is not JSON — jq fails, `.ok` must default to false.
+  run slack_alert_posted_ok "#oss-alerts cross-post" '<html>500</html>'
+  [ "$status" -ne 0 ] || fail "expected non-zero status on non-JSON body, got $status"
+  [[ "$output" == *"::warning::"* ]] || fail "expected a ::warning:: on non-JSON body, got: $output"
+  [[ "$output" == *"#oss-alerts cross-post"* ]] || fail "expected the call label in the warning, got: $output"
+}
+
+@test "slack_alert_posted_ok: malformed JSON returns non-zero and warns" {
+  # A truncated/garbled body that jq cannot parse — must NOT be treated as ok.
+  run slack_alert_posted_ok "#oss-alerts cross-post" '{"ok":tru'
+  [ "$status" -ne 0 ] || fail "expected non-zero status on malformed JSON, got $status"
+  [[ "$output" == *"::warning::"* ]] || fail "expected a ::warning:: on malformed JSON, got: $output"
+}
+
+@test "slack_alert_posted_ok: missing ok key entirely ({}) returns non-zero and warns" {
+  # Valid JSON but no `ok` field — `.ok // false` must default to false.
+  run slack_alert_posted_ok "#oss-alerts cross-post" '{}'
+  [ "$status" -ne 0 ] || fail "expected non-zero status on missing ok key, got $status"
+  [[ "$output" == *"::warning::"* ]] || fail "expected a ::warning:: on missing ok key, got: $output"
+}
+
+@test "slack_alert_posted_ok: ok:null returns non-zero and warns" {
+  # `.ok // false` only defaults on null/absent; an explicit null must NOT pass.
+  run slack_alert_posted_ok "#oss-alerts cross-post" '{"ok":null}'
+  [ "$status" -ne 0 ] || fail "expected non-zero status on ok:null, got $status"
+  [[ "$output" == *"::warning::"* ]] || fail "expected a ::warning:: on ok:null, got: $output"
+}
+
+# ---------- A2: anti-drift parity guard ----------
+# The bats suite sources ONLY the .sh mirror, so a future yml-only edit to
+# slack_alert_posted_ok would drift undetected while bats stayed green. Extract
+# the function body from BOTH files and assert they are byte-identical modulo
+# leading indentation (the .yml carries the step's run-block indent). Drift =>
+# CI failure.
+
+@test "slack_alert_posted_ok: yml and sh mirror definitions are identical (anti-drift)" {
+  local root yml sh
+  root="$BATS_TEST_DIRNAME/../../../.github/workflows"
+  yml="$root/showcase_promote_notify.yml"
+  sh="$root/showcase_promote_notify.dry-run.sh"
+  [ -f "$yml" ] || fail "yml not found: $yml"
+  [ -f "$sh" ]  || fail "sh mirror not found: $sh"
+
+  # Extract `slack_alert_posted_ok() { ... }` (first such block) and strip
+  # leading whitespace so indent differences between the two homes don't count.
+  extract() {
+    awk '/^[[:space:]]*slack_alert_posted_ok\(\) \{/{f=1} f{print} f&&/^[[:space:]]*\}$/{exit}' "$1" \
+      | sed 's/^[[:space:]]*//'
+  }
+  local yml_body sh_body
+  yml_body=$(extract "$yml")
+  sh_body=$(extract "$sh")
+
+  [ -n "$yml_body" ] || fail "could not extract slack_alert_posted_ok from $yml"
+  [ -n "$sh_body" ]  || fail "could not extract slack_alert_posted_ok from $sh"
+
+  [ "$yml_body" = "$sh_body" ] || fail "slack_alert_posted_ok drifted between yml and sh mirror:
+$(diff <(printf '%s\n' "$sh_body") <(printf '%s\n' "$yml_body"))"
+}
+
+# ---------- A1: end-to-end call-site fail-loud/warn-only distinction ----------
+# The predicate above is exercised in isolation, but the BUG the branch fixes is
+# in the CALL-SITE WIRING: the #oss-alerts page-the-humans post is FAIL-LOUD (no
+# `|| true`, so a dropped delivery reds the renderer job) while the thread-reply
+# summary post stays WARN-ONLY (`|| true`). A future re-add of `|| true` to the
+# #oss-alerts call-site would leave the predicate tests green while silently
+# reintroducing the drop. These tests run the dry-run script as a subprocess on a
+# FAILURE outcome (so BOTH posts execute) and inject responses via the
+# DRY_RUN_OSS_RESP / DRY_RUN_THREAD_RESP hooks to lock the per-call-site exit
+# semantics. The `partial` fixture yields outcome=partial → both posts fire.
+
+PARTIAL_FIXTURE() {
+  echo "$BATS_TEST_DIRNAME/../../test-fixtures/promote-notify/partial.json"
+}
+
+@test "call-site: dropped #oss-alerts page (ok:false) reds the job (non-zero exit)" {
+  local fixture
+  fixture="$(PARTIAL_FIXTURE)"
+  [ -f "$fixture" ] || fail "partial fixture not found: $fixture"
+  # OSS page drops, thread reply ok. Fail-loud call-site must propagate non-zero.
+  run env DRY_RUN_OSS_RESP='{"ok":false,"error":"channel_not_found"}' \
+    bash "$HELPER" --file "$fixture"
+  [ "$status" -ne 0 ] || fail "expected non-zero exit when #oss-alerts page is dropped, got $status; output: $output"
+  [[ "$output" == *"::warning::"* ]] || fail "expected a ::warning:: for the dropped page, got: $output"
+  [[ "$output" == *"#oss-alerts cross-post"* ]] || fail "expected the #oss-alerts label in the warning, got: $output"
+}
+
+@test "call-site: dropped thread reply (ok:false) is warn-only (zero exit + warning)" {
+  local fixture
+  fixture="$(PARTIAL_FIXTURE)"
+  [ -f "$fixture" ] || fail "partial fixture not found: $fixture"
+  # Thread reply drops, OSS page ok. Warn-only call-site must NOT red the job.
+  run env DRY_RUN_THREAD_RESP='{"ok":false,"error":"channel_not_found"}' \
+    bash "$HELPER" --file "$fixture"
+  [ "$status" -eq 0 ] || fail "expected zero exit when only the thread reply is dropped, got $status; output: $output"
+  [[ "$output" == *"::warning::"* ]] || fail "expected a ::warning:: for the dropped thread reply, got: $output"
+  [[ "$output" == *"thread reply"* ]] || fail "expected the thread-reply label in the warning, got: $output"
+}
+
+@test "call-site: both posts ok → zero exit, no warning" {
+  local fixture
+  fixture="$(PARTIAL_FIXTURE)"
+  [ -f "$fixture" ] || fail "partial fixture not found: $fixture"
+  # Default sim responses are ok:true for both posts.
+  run bash "$HELPER" --file "$fixture"
+  [ "$status" -eq 0 ] || fail "expected zero exit when both posts succeed, got $status; output: $output"
+  [[ "$output" != *"::warning::"* ]] || fail "expected NO warning when both posts succeed, got: $output"
+  [[ "$output" == *"outcome=partial"* ]] || fail "expected the trailing outcome line (proves the OSS post ran), got: $output"
+}


### PR DESCRIPTION
## Summary

Hardening + pre-existing-debt cleanup of the showcase promote-notify Slack renderer (follow-up to #5657, scoped to deferred review items).

**Fail loud on a dropped page-the-humans alert.** The #oss-alerts failure cross-post used to pipe the Slack API response to `/dev/null`, so a `200`/`{"ok":false,"error":"channel_not_found"}` silently dropped the alert that fires when a promote *failed* — on a green job nobody would notice. Both posts now capture the response via a shared `slack_alert_posted_ok` predicate; the #oss-alerts page fails the renderer job loud on a dropped delivery, while the informational thread reply stays warn-only. The predicate is mirrored byte-identically across the live workflow and the dry-run helper.

**Debt cleanup.** Removed a dead `failed_count` var, corrected a misleading `gha_url` comment, and added `^[0-9a-f]{6}$` validation on the decoded blob `run_id` in the render step so a malformed run_id can't reach Slack or the run name.

## Test plan
- [x] `promote-notify.bats` 11/11 — predicate edge cases (non-JSON, malformed, missing/`null` ok), anti-drift parity guard (predicate identical in both files), and call-site tests locking the #oss-alerts fail-loud vs thread warn-only exit semantics
- [x] red→green proven: re-adding `|| true` to the #oss-alerts call-site flips the call-site test red
- [x] shellcheck clean on the dry-run helper