### PR TITLE
fix(showcase): map AG-UI multimodal content to native pydantic-ai types (fix assert_never)

### DIFF
--- a/showcase/integrations/pydantic-ai/src/agents/multimodal_agent.py
+++ b/showcase/integrations/pydantic-ai/src/agents/multimodal_agent.py
@@ -11,35 +11,123 @@ Attachments arrive here after travelling through:
   CopilotChat  →  AG-UI message content parts  →  PydanticAI AG-UI bridge
               →  this agent (PydanticAI messages)
 
-The frontend page at ``src/app/demos/multimodal/page.tsx`` installs the
-same ``onRunInitialized`` shim used in the langgraph-python reference:
-modern ``{ type: "image" | "document", source: {...} }`` parts get
-rewritten to the legacy ``{ type: "binary", mimeType, data | url }``
-shape before the request reaches the runtime. This keeps the on-wire
-format compatible with AG-UI bridges that only understand the legacy
-shape.
+CopilotChat emits modern ``{ type: "image" | "document", source: {...} }``
+parts; the frontend page may additionally rewrite them to the legacy
+``{ type: "binary", mimeType, data | url }`` shape. The PydanticAI AG-UI
+bridge (``pydantic_ai.ag_ui._messages_from_ag_ui``) drops the raw
+``UserMessage.content`` list — a list of AG-UI ``InputContent`` *model
+objects* (``TextInputContent``, ``ImageInputContent``,
+``DocumentInputContent``, ``BinaryInputContent`` …) — straight into
+``UserPromptPart.content`` with NO conversion. PydanticAI's own
+``OpenAIResponsesModel._map_user_prompt`` then ``assert_never``s on those
+AG-UI objects because they are not native PydanticAI content types.
 
-On the Python side we use a ``history_processor`` to preprocess user
-messages before each model call:
+So we normalise EVERY AG-UI content subtype — for BOTH ``data`` (inline
+base64) and ``url`` sources — into the native PydanticAI content types
+``OpenAIResponsesModel._map_user_prompt`` understands:
 
-- ``image/*`` legacy-binary parts are converted to PydanticAI's
-  ``ImageUrl`` content (which ``OpenAIResponsesModel`` forwards as a
-  vision-native ``image_url`` part to GPT-4o).
-- ``application/pdf`` legacy-binary parts are flattened to inline text
-  via ``pypdf`` so the model can read them without needing file-part
-  support — matching the langgraph-python behaviour exactly.
-- Any other part shape passes through unchanged.
+- ``text`` → plain ``str``.
+- ``image`` (data, SUPPORTED subtype) → :class:`pydantic_ai.ImageUrl`
+  wrapping a ``data:`` URI. OpenAI's Responses vision API accepts ONLY
+  PNG/JPEG/GIF/WebP (see :data:`_OPENAI_SUPPORTED_IMAGE_SUBTYPES`), so only
+  those subtypes are emitted as an ``ImageUrl``; the Responses model forwards
+  it verbatim as a vision-native ``input_image`` part. (``ImageUrl`` with a
+  ``data:`` URI and ``BinaryContent`` both deliver inline base64 images
+  identically through ``_map_user_prompt``; we use ``ImageUrl`` to match the
+  langgraph-python reference's data-URI delivery.)
+- ``image`` (data, UNSUPPORTED subtype — ``image/heic`` (the iPhone default!),
+  ``image/svg+xml``, ``image/tiff``, ``image/bmp`` …) → degraded to a
+  descriptive text placeholder (``[Attached image: <mime>]``): the Responses
+  API would REJECT the unsupported subtype (dropping the image / failing the
+  turn), so we degrade exactly like audio/video rather than emit it.
+- ``image`` (url) → :class:`pydantic_ai.ImageUrl` wrapping the http(s)
+  URL when the subtype is supported (or the mime is absent — no ``data:`` URI
+  is built); an UNSUPPORTED present subtype degrades to a placeholder just
+  like the data path, since the provider rejects it regardless of delivery.
+- ``document``/PDF (data) → flattened to inline text via ``pypdf`` so the
+  model can read it without needing file-part support — matching the
+  langgraph-python behaviour exactly.
+- ``document`` (url, PDF) → flattened to a reference placeholder (we
+  cannot extract text from a URL without fetching it); a non-PDF
+  ``document`` (url) carrying a fetchable-document mime →
+  :class:`pydantic_ai.DocumentUrl`. A ``document``/``binary`` (url) carrying an
+  audio/video/image or missing mime is NOT a fetchable document — it degrades
+  to a text placeholder rather than an unconditional ``DocumentUrl`` the
+  Responses mapper would reject.
+- non-image/non-PDF ``binary``/``document`` (data) →
+  :class:`pydantic_ai.BinaryContent` so the model still receives the file.
+- A missing-mime *inline-DATA* image is sniffed for a SUPPORTED concrete image
+  media type from its base64 magic bytes (ONLY PNG/JPEG/GIF/WebP are sniffed as
+  positives — see :func:`_sniff_image_mime`). We must NEVER emit a
+  ``data:image/*;base64`` URI — OpenAI's Responses API rejects the wildcard
+  media type — NOR an unsupported concrete subtype (the sniffer no longer
+  returns TIFF/BMP, since those would also be rejected). If the bytes are not a
+  recognised SUPPORTED image format we degrade to a generic-attachment text
+  placeholder (the langgraph-python reference DROPS such missing-mime parts).
+- A *recoverable-empty* part (a known-modality ``binary`` with no data and no
+  url, or a modern ``image``/``document`` with an empty/absent source) is
+  degraded to a placeholder string rather than dropped or fail-louded — these
+  are expected, recoverable conditions, not unknown shapes.
+- A known-but-unsupported modality (``audio``/``video``) is degraded to a
+  descriptive text placeholder (e.g. ``[Attached audio: <mime>]``): the OpenAI
+  Responses mapper cannot consume audio/video as native content, but a
+  recognised modality is NOT an unknown shape — it degrades, never fail-louds.
+
+For a TRULY-unknown shape (an unrecognised ``type``, a non-content object) we
+**fail loud** — raising a clear ``ValueError`` naming the shape — rather than
+silently passing the object through to ``_map_user_prompt``'s ``assert_never``.
+
+State safety (langgraph-python parity)
+======================================
+The langgraph-python reference scopes its flatten to the *model call* via
+``wrap_model_call`` so the rewrite never persists back into agent state
+(which would render the flattened PDF text / image substitutions verbatim
+in the user's chat bubble).
+
+PydanticAI's ``history_processors`` hook is NOT model-call-scoped for this
+purpose: ``_agent_graph`` writes the processor's *returned* list straight
+back to state with ``ctx.state.message_history[:] = message_history`` (see
+``pydantic_ai._agent_graph`` around the ``_process_message_history`` call).
+So a processor that *returns* flattened content leaks that flattened
+PDF-text / ImageUrl into the UI-visible conversation state — keeping the
+processor "pure" (new objects, originals untouched) protects the ORIGINALS
+but NOT the returned list that gets persisted. (Empirically confirmed by
+``test_model_boundary_flatten_does_not_persist_to_state``.)
+
+We therefore scope the flatten to the *model boundary* — exactly mirroring
+the reference's ``wrap_model_call`` contract — via a thin
+:class:`pydantic_ai.models.wrapper.WrapperModel` subclass
+(:class:`_MultimodalFlattenModel`) whose ``request`` / ``request_stream``
+flatten the OUTGOING ``messages`` list just before delegating to the wrapped
+``OpenAIResponsesModel``. The flatten never touches
+``ctx.state.message_history``, so the persisted (UI-visible) conversation
+keeps the original AG-UI content while only the provider request is
+normalised. No content-flattening ``history_processor`` is registered.
 """
 
 from __future__ import annotations
 
 import base64
+import dataclasses
 import io
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from textwrap import dedent
 from typing import Any
 
-from pydantic_ai import Agent
+from pydantic_ai import Agent, BinaryContent, DocumentUrl, ImageUrl
+from pydantic_ai._run_context import RunContext
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    UserPromptPart,
+)
+from pydantic_ai.models import ModelRequestParameters, StreamedResponse
 from pydantic_ai.models.openai import OpenAIResponsesModel
+from pydantic_ai.models.wrapper import WrapperModel
+from pydantic_ai.settings import ModelSettings
+from pydantic_ai.usage import RequestUsage
 
 
 SYSTEM_PROMPT = dedent(
@@ -52,14 +140,84 @@ SYSTEM_PROMPT = dedent(
     """
 ).strip()
 
+# Used when an attachment arrives without a usable mime type. The model
+# still receives the bytes/URL so it can tell the user what was attached.
+_DEFAULT_MIME = "application/octet-stream"
+
+# The ONLY image subtypes OpenAI's Responses vision API accepts as an
+# ``input_image`` part. Any other subtype (``image/heic`` — the iPhone
+# default! — ``image/svg+xml``, ``image/tiff``, ``image/bmp`` …) is REJECTED
+# by the provider, dropping the image / failing the turn. This is the single
+# source of truth: an image whose subtype is in this set is emitted as an
+# ``ImageUrl``; an image whose subtype is NOT in it degrades to a text
+# placeholder (the same degrade pattern as audio/video). Applied to BOTH the
+# present-mime path and the missing-mime sniff path so neither can ever emit an
+# unsupported ``data:image/*`` URI. Subtypes are compared lower-cased.
+_OPENAI_SUPPORTED_IMAGE_SUBTYPES = frozenset({"png", "jpeg", "gif", "webp"})
+
+
+def _normalize_image_mime(mime: str) -> str:
+    """Normalise an image media type for allow-list comparison.
+
+    Strips RFC-2045 parameters (anything after ``;``) and surrounding
+    whitespace, lower-cases, and aliases the non-canonical-but-ubiquitous
+    ``image/jpg`` → ``image/jpeg`` so a real JPEG is not dropped. The result is
+    a bare ``type/subtype`` (or the empty string for a blank input) suitable for
+    both the ``image/`` prefix test and the subtype membership test. This is the
+    single normalisation used everywhere a mime is compared to the allow-list.
+    """
+    low = mime.split(";", 1)[0].strip().lower()
+    if low == "image/jpg":
+        return "image/jpeg"
+    return low
+
+
+def _is_supported_image_mime(mime: str) -> bool:
+    """Return ``True`` iff ``mime`` is an OpenAI-supported image media type.
+
+    Accepts only ``image/<subtype>`` where ``<subtype>`` is one of the
+    Responses-vision-supported formats (PNG/JPEG/GIF/WebP); a non-image mime or
+    an unsupported image subtype (HEIC/SVG/TIFF/BMP …) returns ``False``. The
+    mime is normalised first (parameters/whitespace stripped, ``image/jpg``
+    aliased to ``image/jpeg``) so a supported image carrying a parameter or a
+    non-canonical subtype is not wrongly degraded.
+    """
+    low = _normalize_image_mime(mime)
+    if not low.startswith("image/"):
+        return False
+    subtype = low[len("image/") :]
+    return subtype in _OPENAI_SUPPORTED_IMAGE_SUBTYPES
+
+
+def _looks_like_fetchable_document(mime: str) -> bool:
+    """Return ``True`` iff a ``url``-source ``other`` attachment may be emitted
+    as a :class:`pydantic_ai.DocumentUrl` the model can fetch as a file part.
+
+    The ``other`` branch is reached only for non-image, non-PDF mimes, so this
+    gate excludes the modalities the OpenAI Responses file-part mapper cannot
+    consume — audio, video, and (defensively) image — as well as a
+    missing/blank/octet-stream mime, all of which degrade to a placeholder
+    instead of an unconditional ``DocumentUrl`` the provider would reject. Any
+    other present, concrete mime (text/*, application/* office docs, …) is
+    treated as a fetchable document.
+    """
+    low = mime.split(";", 1)[0].strip().lower()
+    if not low or low == _DEFAULT_MIME:
+        return False
+    if low.startswith(("audio/", "video/", "image/")):
+        return False
+    return True
+
 
 def _extract_pdf_text(b64: str) -> str:
     """Decode an inline-base64 PDF and extract its text.
 
     Returns an empty string if decoding or extraction fails — callers
-    must treat the extracted text as best-effort. Any exception here is
-    logged and swallowed so one malformed attachment does not tank the
-    whole user turn.
+    must treat the extracted text as best-effort. A malformed *payload*
+    is an expected, recoverable condition (one bad attachment must not
+    tank the whole user turn), so it is logged and degraded to ``""``;
+    this is NOT the fail-loud path, which is reserved for unknown
+    *content shapes* in :func:`_rewrite_part_for_model`.
     """
     try:
         raw = base64.b64decode(b64, validate=False)
@@ -85,89 +243,413 @@ def _extract_pdf_text(b64: str) -> str:
         return ""
 
 
-def _classify_binary_part(part: Any) -> tuple[str, str, str] | None:
-    """Inspect an AG-UI content part and return ``(kind, mime, payload)``.
+def _part_to_dict(part: Any) -> Any:
+    """Normalise an AG-UI content part to a plain ``dict``.
 
-    ``kind`` is one of ``"image"``, ``"pdf"``, ``"other"``. Returns
-    ``None`` if the part is not an attachment we recognise.
+    AG-UI ``InputContent`` is a Pydantic model, so ``model_dump()`` gives
+    us ``{"type": ..., "text"/"source": ...}`` with ``snake_case`` keys
+    (e.g. ``mime_type``). Already-dict parts (legacy on-wire shape
+    rewritten by the frontend shim) pass through unchanged. A non-model,
+    non-dict part (e.g. a bare ``str`` already-native content) is returned
+    as-is for the caller to classify.
 
-    Handles both shapes that can arrive at the agent:
-
-    - Legacy binary: ``{"type": "binary", "mimeType": "...",
-      "data": "<base64>"}`` or ``"url": "..."``.
-    - Modern source: ``{"type": "image" | "document",
-      "source": {"type": "data", "value": "<base64>", "mimeType": "..."}}``.
+    A ``model_dump()`` that *raises* is NOT swallowed: a mapping failure
+    here would otherwise silently re-enable the downstream ``assert_never``,
+    so we let it surface (fail-loud) — this is integration/AI-adjacent code.
     """
+    if isinstance(part, dict):
+        return part
+    dump = getattr(part, "model_dump", None)
+    if callable(dump):
+        return dump()
+    return part
+
+
+def _source_payload(source: Any) -> tuple[str, str, str] | None:
+    """Extract ``(scheme, value, mime)`` from an AG-UI content source dict.
+
+    ``scheme`` is ``"data"`` (inline base64 in ``value``) or ``"url"``
+    (a fetchable reference in ``value``). Handles both ``camelCase``
+    (``mimeType``) and ``snake_case`` (``mime_type``) keys, since the
+    source can arrive either from the frontend on-wire shape or from
+    ``model_dump()`` of an AG-UI object. Returns ``None`` if the source
+    is not a recognised ``data``/``url`` source with a string value.
+    """
+    if not isinstance(source, dict):
+        return None
+    scheme = source.get("type")
+    if scheme not in ("data", "url"):
+        return None
+    value = source.get("value")
+    if not isinstance(value, str) or not value:
+        return None
+    mime = source.get("mimeType") or source.get("mime_type") or ""
+    if not isinstance(mime, str):
+        mime = ""
+    return (scheme, value, mime)
+
+
+def _classify_content_part(part: Any) -> tuple[str, str, str, str] | None:
+    """Inspect an AG-UI content part and return ``(kind, scheme, mime, value)``.
+
+    ``kind`` is one of ``"image"``, ``"pdf"``, ``"other"``, or the special
+    ``"empty"`` (a recognised-modality attachment carrying no usable
+    data/url/source — a recoverable-empty case the caller degrades to a
+    placeholder rather than fail-louding). ``scheme`` is ``"data"`` (``value``
+    is inline base64) or ``"url"`` (``value`` is a fetchable URL); for
+    ``"empty"`` both ``scheme`` and ``value`` are ``""``.
+
+    Returns ``None`` ONLY if the part is not an attachment shape we recognise
+    at all (plain text, already-native content, a genuinely unknown ``type``) —
+    the caller fail-louds on that. A recognised-but-empty attachment is NOT
+    ``None``; it is ``("empty", "", mime, "")``.
+
+    Handles every shape that can arrive at the agent:
+
+    - Legacy binary: ``{"type": "binary", "mimeType"/"mime_type": "...",
+      "data": "<base64>"}`` (data scheme) or ``"url": "..."`` (url scheme).
+    - Modern source: ``{"type": "image" | "document",
+      "source": {"type": "data" | "url", "value": "...", "mimeType": "..."}}``.
+
+    A part whose modality is recognised but whose mime is missing keeps an
+    empty mime for an image (so the caller sniffs / degrades) and the canonical
+    mime for a pdf, so it is never dropped.
+    """
+    part = _part_to_dict(part)
     if not isinstance(part, dict):
         return None
     part_type = part.get("type")
 
     if part_type == "binary":
-        mime = part.get("mimeType") or ""
+        mime = part.get("mimeType") or part.get("mime_type") or ""
+        if not isinstance(mime, str):
+            mime = ""
         data = part.get("data")
-        if isinstance(data, str) and mime:
-            if mime.startswith("image/"):
-                return ("image", mime, data)
-            if "pdf" in mime.lower():
-                return ("pdf", mime, data)
-            return ("other", mime, data)
+        url = part.get("url")
+        kind, mime = _kind_for(mime, default="other")
+        if isinstance(data, str) and data:
+            return (kind, "data", mime, data)
+        if isinstance(url, str) and url:
+            return (kind, "url", mime, url)
+        # Known-modality binary with no data and no url: recoverable-empty.
+        return ("empty", "", mime, "")
 
     if part_type in ("image", "document"):
-        source = part.get("source")
-        if isinstance(source, dict) and source.get("type") == "data":
-            value = source.get("value")
-            mime = source.get("mimeType", "")
-            if isinstance(value, str) and isinstance(mime, str) and mime:
-                if mime.startswith("image/"):
-                    return ("image", mime, value)
-                if "pdf" in mime.lower():
-                    return ("pdf", mime, value)
-                return ("other", mime, value)
+        # The part type tells us the modality even when mime/source is absent.
+        default_kind = "image" if part_type == "image" else "pdf"
+        payload = _source_payload(part.get("source"))
+        if payload is None:
+            # Modern image/document with an empty/absent source:
+            # recoverable-empty, not an unknown shape.
+            return ("empty", "", "", "")
+        scheme, value, mime = payload
+        kind, mime = _kind_for(mime, default=default_kind)
+        return (kind, scheme, mime, value)
+
+    if part_type in ("audio", "video"):
+        # Known AG-UI modalities the OpenAI Responses mapper cannot consume as
+        # native vision/file content. Degrade to a text placeholder (consistent
+        # with the other unsupported-binary degradation) rather than fail-loud:
+        # a recognised modality is NOT an unknown shape. ``kind`` carries the
+        # modality so the caller can build a descriptive placeholder; an
+        # empty/absent source degrades just the same.
+        payload = _source_payload(part.get("source"))
+        mime = payload[2] if payload is not None else ""
+        return (part_type, "", mime, "")
 
     return None
 
 
-def _rewrite_part_for_model(part: Any) -> Any:
-    """Rewrite a single content part into a model-friendly shape.
+def _sniff_image_mime(raw: bytes) -> str | None:
+    """Sniff an OpenAI-SUPPORTED image media type from a decoded byte payload.
 
-    - Image binary parts → OpenAI-style ``image_url`` dict with a
-      ``data:`` URL embedded. ``OpenAIResponsesModel`` passes this
-      through natively, matching GPT-4o's vision input format.
-    - PDF binary parts → text part prefixed with ``[Attached document]``
-      and the extracted body; falls back to a structured placeholder if
-      extraction failed.
-    - Everything else → unchanged.
+    Returns a concrete ``image/<fmt>`` media type for the OpenAI-Responses-
+    SUPPORTED web image formats ONLY (PNG/JPEG/GIF/WebP — see
+    :data:`_OPENAI_SUPPORTED_IMAGE_SUBTYPES`), or ``None`` if the bytes are not
+    a recognised SUPPORTED image. Formats OpenAI rejects (TIFF/BMP/HEIC/…) are
+    deliberately NOT sniffed as positives: emitting a ``data:image/tiff`` URI
+    would fail the turn, so an unsupported-format payload returns ``None`` here
+    and the caller degrades it to a text placeholder — never an ``ImageUrl``.
     """
-    classified = _classify_binary_part(part)
-    if classified is None:
+    if raw.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if raw.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if raw[:6] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    if raw[:4] == b"RIFF" and raw[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def _kind_for(mime: str, *, default: str) -> tuple[str, str]:
+    """Map a mime type to a ``kind`` and the (possibly-empty) mime to use.
+
+    Returns ``(kind, mime)``. When ``mime`` is present we route on it. When
+    ``mime`` is MISSING we fall back to the modality the part ``type`` implied
+    but DO NOT synthesise a fake concrete mime: an image returns ``("image",
+    "")`` so the caller can sniff a concrete type from the bytes (never emit
+    ``image/*``); a pdf gets the canonical ``application/pdf``; everything else
+    is treated as a generic attachment.
+    """
+    if mime:
+        low = mime.lower()
+        if low.startswith("image/"):
+            return ("image", mime)
+        if "pdf" in low:
+            return ("pdf", mime)
+        return ("other", mime)
+    # Missing mime — fall back on the modality the part type implied. For an
+    # image we return an EMPTY mime (never "image/*") so the caller sniffs a
+    # concrete media type from the payload or degrades to a placeholder.
+    if default == "image":
+        return ("image", "")
+    if default == "pdf":
+        return ("pdf", "application/pdf")
+    return ("other", _DEFAULT_MIME)
+
+
+def _text_of(part: Any) -> str | None:
+    """Return the text of a text content part, or ``None``.
+
+    Recognises the AG-UI ``TextInputContent`` model object and the
+    equivalent ``{"type": "text", "text": "..."}`` dict. PydanticAI's
+    ``_map_user_prompt`` only accepts a plain ``str`` for text content,
+    so text parts must be flattened to ``str``.
+    """
+    part = _part_to_dict(part)
+    if isinstance(part, dict) and part.get("type") == "text":
+        text = part.get("text")
+        if isinstance(text, str):
+            return text
+    return None
+
+
+# Native PydanticAI content types that ``_map_user_prompt`` already maps.
+# These pass through the rewrite untouched. Note the rewrite as a WHOLE is
+# NOT a round-trip-idempotent transform — e.g. PDF (data) → extracted ``str``
+# is a one-way flatten (the original PDF bytes are not recoverable). What this
+# pass-through guarantees is only that re-applying the rewrite to its OWN
+# already-native output is a stable fixpoint (a ``str``/``ImageUrl`` stays
+# itself), so running the model-boundary flatten over partially-native content
+# is safe.
+_NATIVE_CONTENT = (str, ImageUrl, BinaryContent, DocumentUrl)
+
+
+def _rewrite_part_for_model(part: Any) -> Any:
+    """Rewrite a single content part into a native PydanticAI content type.
+
+    ``OpenAIResponsesModel._map_user_prompt`` only maps the native content
+    types (``str``, ``ImageUrl``, ``BinaryContent``, ``DocumentUrl`` …) and
+    ``assert_never``s on anything else — including AG-UI ``InputContent``
+    model objects *and* raw OpenAI-style dicts. So we always emit native
+    types here, for BOTH inline-``data`` and ``url`` sources:
+
+    - Text → plain ``str``.
+    - Image (data, SUPPORTED subtype) → ``ImageUrl`` wrapping a
+      ``data:<concrete-mime>`` URI. Only the OpenAI-supported subtypes
+      (PNG/JPEG/GIF/WebP — :data:`_OPENAI_SUPPORTED_IMAGE_SUBTYPES`) are
+      emitted; a missing mime is sniffed from the magic bytes (never
+      ``image/*``, never an unsupported subtype), and an unsniffable payload
+      degrades to a placeholder ``str``.
+    - Image (data, UNSUPPORTED subtype — heic/svg/tiff/bmp/…) → degraded to a
+      ``[Attached image: <mime>]`` placeholder ``str``: OpenAI's Responses API
+      rejects the subtype, so emitting it would fail the turn (same degrade
+      pattern as audio/video).
+    - Image (url) → ``ImageUrl`` wrapping the URL when the subtype is supported
+      or the mime is absent (no ``data:`` URI is built); an UNSUPPORTED present
+      subtype degrades to a placeholder, since the provider rejects it
+      regardless of data-vs-url delivery.
+    - PDF (data) → ``str`` (extracted text, or a placeholder if unreadable).
+    - PDF (url) → ``str`` reference placeholder (no fetch).
+    - other (data) → ``BinaryContent`` so the model still gets the bytes; an
+      unsupported image subtype (``binary.is_image`` true) and any
+      non-image/non-document binary are logged and degraded to a placeholder
+      ``str`` (the supported-type gate lives at this emission choke point).
+    - other (url) → ``DocumentUrl`` ONLY for a fetchable-document mime; an
+      audio/video/image or missing-mime url degrades to a placeholder ``str``
+      rather than an unconditional ``DocumentUrl`` the mapper would reject.
+    - A recoverable-empty attachment (``kind == "empty"``) → degraded to a
+      placeholder ``str`` — NOT fail-louded.
+    - A known-but-unsupported modality (``audio``/``video``) → degraded to a
+      descriptive placeholder ``str`` (e.g. ``[Attached audio: audio/mpeg]``).
+      The OpenAI Responses mapper cannot consume audio/video natively, but a
+      recognised modality is NOT an unknown shape — it degrades, NOT fail-louds.
+    - Already-native content (``str`` / ``ImageUrl`` / ``BinaryContent`` /
+      ``DocumentUrl``) → unchanged (a stable fixpoint, so re-applying the
+      flatten over its own output is safe; this is NOT a claim that the
+      attachment→native transform round-trips).
+    - A genuinely unknown shape (unrecognised ``type`` / non-content object) →
+      **fail loud**: raise a ``ValueError`` naming the shape, NEVER silently
+      pass it through to the downstream ``assert_never``.
+    """
+    # Already-native content (a stable fixpoint of the flatten) — leave as-is.
+    if isinstance(part, _NATIVE_CONTENT):
         return part
-    kind, mime, payload = classified
-    if kind == "image":
-        return {
-            "type": "image_url",
-            "image_url": {"url": f"data:{mime};base64,{payload}"},
-        }
-    if kind == "pdf":
-        text = _extract_pdf_text(payload)
-        if not text:
-            return {
-                "type": "text",
-                "text": "[Attached document: PDF could not be read.]",
-            }
-        return {"type": "text", "text": f"[Attached document]\n{text}"}
-    # Unrecognized mime — stringify metadata so the model can at least
-    # tell the user what was attached.
-    return {
-        "type": "text",
-        "text": f"[Attached file of type {mime}]",
-    }
+
+    text = _text_of(part)
+    if text is not None:
+        return text
+
+    classified = _classify_content_part(part)
+    if classified is not None:
+        kind, scheme, mime, value = classified
+        if kind == "empty":
+            # Recognised modality, but no usable data/url/source. Degrade to a
+            # placeholder so one empty attachment doesn't tank the turn. Preserve
+            # a KNOWN mime in the placeholder (consistent with the unsupported-
+            # image and non-image-binary degrades) so the model can still tell
+            # the user what was attached; only a truly-unknown mime is omitted.
+            print(
+                "[multimodal_agent] empty attachment "
+                f"(mime={mime or 'unknown'!r}) — degraded to placeholder",
+            )
+            if mime:
+                return f"[Attached file ({mime}) could not be read.]"
+            return "[Attached file could not be read.]"
+        if kind in ("audio", "video"):
+            # Known-but-unsupported modality: the OpenAI Responses mapper cannot
+            # consume audio/video as native content. Degrade to a descriptive
+            # placeholder (consistent with the non-image/non-document binary
+            # path) so the model can tell the user what was attached, rather
+            # than fail-louding a recognised modality.
+            print(
+                f"[multimodal_agent] {kind} attachment "
+                f"(mime={mime or 'unknown'!r}) — degraded to placeholder",
+            )
+            label = mime or kind
+            return f"[Attached {kind}: {label}]"
+        if kind == "image":
+            if scheme == "data":
+                concrete = mime
+                if concrete:
+                    # Present mime: only the OpenAI-supported subtypes
+                    # (PNG/JPEG/GIF/WebP) may be emitted as an ImageUrl. An
+                    # unsupported subtype (image/heic, image/svg+xml, …) would
+                    # be REJECTED by the Responses API — degrade to a text
+                    # placeholder (same pattern as audio/video) so the turn
+                    # proceeds and the model can tell the user what was sent.
+                    if not _is_supported_image_mime(concrete):
+                        print(
+                            "[multimodal_agent] unsupported image subtype "
+                            f"(mime={concrete!r}) — degraded to placeholder",
+                        )
+                        return f"[Attached image: {concrete}]"
+                    # Supported subtype — emit the NORMALISED canonical mime in
+                    # the data URI (strips RFC-2045 params/whitespace; aliases
+                    # image/jpg → image/jpeg) so OpenAI receives a clean,
+                    # allow-listed media type rather than the raw header value.
+                    concrete = _normalize_image_mime(concrete)
+                else:
+                    # Missing mime: NEVER emit "data:image/*" (OpenAI rejects
+                    # the wildcard). Sniff a SUPPORTED concrete type from the
+                    # bytes; an unsupported/unrecognised payload sniffs to
+                    # ``None`` and degrades (the reference drops such parts).
+                    try:
+                        raw = base64.b64decode(value, validate=False)
+                    except Exception as exc:
+                        print(
+                            "[multimodal_agent] missing-mime image base64 "
+                            f"decode failed: {exc} — degraded to placeholder",
+                        )
+                        return "[Attached image could not be read.]"
+                    sniffed = _sniff_image_mime(raw)
+                    if sniffed is None:
+                        print(
+                            "[multimodal_agent] missing-mime image not a "
+                            "supported format — degraded to placeholder",
+                        )
+                        return "[Attached image could not be read.]"
+                    concrete = sniffed
+                return ImageUrl(url=f"data:{concrete};base64,{value}")
+            # URL-source image: an unsupported subtype is REJECTED by the
+            # provider just the same, so apply the allow-list here too. A
+            # missing mime on a URL source is harmless (no data: URI is built),
+            # so an empty mime still passes through as an ImageUrl.
+            if mime and not _is_supported_image_mime(mime):
+                print(
+                    "[multimodal_agent] unsupported image subtype "
+                    f"(mime={mime!r}) — degraded to placeholder",
+                )
+                return f"[Attached image: {mime}]"
+            return ImageUrl(url=value)
+        if kind == "pdf":
+            if scheme == "data":
+                extracted = _extract_pdf_text(value)
+                if not extracted:
+                    return "[Attached document: PDF could not be read.]"
+                return f"[Attached document]\n{extracted}"
+            # URL-source PDF: we cannot extract text without fetching it;
+            # hand the model a reference so it can tell the user.
+            return f"[Attached document: {value}]"
+        # Non-image / non-PDF attachment ("other"). This is the SINGLE native-
+        # type EMISSION CHOKE POINT for BinaryContent / DocumentUrl, so the
+        # supported-type gate + degrade live here (not per content-branch): no
+        # unsupported image subtype and no audio/video/other-non-document mime
+        # is ever emitted as a native type the OpenAI mapper would reject.
+        if scheme == "data":
+            try:
+                raw = base64.b64decode(value, validate=False)
+            except Exception as exc:
+                raise ValueError(
+                    f"multimodal_agent: failed to decode inline base64 for "
+                    f"attachment of type {mime!r}: {exc}"
+                ) from exc
+            binary = BinaryContent(data=raw, media_type=mime or _DEFAULT_MIME)
+            # CHOKE POINT: an image binary whose subtype is NOT in the allow-list
+            # (HEIC/SVG/TIFF/BMP — ``binary.is_image`` is true for ANY image/*)
+            # must degrade, NOT be emitted as a rejected image binary. This makes
+            # the allow-list genuinely single-source regardless of how a part is
+            # routed to the "other" branch.
+            if binary.is_image and not _is_supported_image_mime(binary.media_type):
+                print(
+                    "[multimodal_agent] unsupported image binary "
+                    f"(mime={binary.media_type!r}) — degraded to placeholder",
+                )
+                return f"[Attached image: {binary.media_type}]"
+            # The OpenAI Responses model can only map image/document binary
+            # content; for anything else (incl. a missing-mime octet-stream)
+            # hand the model a descriptive string so it can tell the user
+            # what was attached instead of crashing the mapper. Log the drop
+            # so it stays triageable, consistent with the other degradations.
+            if binary.is_image or binary.is_document:
+                return binary
+            print(
+                "[multimodal_agent] non-image/non-document binary "
+                f"(mime={mime or 'unknown'!r}) — degraded to placeholder",
+            )
+            return f"[Attached file of type {mime or 'unknown'}]"
+        # URL-source "other": CHOKE POINT for DocumentUrl. Only emit a fetchable
+        # DocumentUrl for a mime the Responses model can actually consume as a
+        # file part (a real document); audio/video and other non-document mimes
+        # (and an unsupported image subtype that somehow reached here) degrade to
+        # a placeholder rather than an unconditional DocumentUrl the mapper /
+        # provider would reject and fail the turn.
+        if not _looks_like_fetchable_document(mime):
+            print(
+                "[multimodal_agent] non-document url attachment "
+                f"(mime={mime or 'unknown'!r}) — degraded to placeholder",
+            )
+            return f"[Attached file of type {mime or 'unknown'}]"
+        return DocumentUrl(url=value)
+
+    # Genuinely unknown shape — fail loud rather than feed the downstream
+    # ``assert_never``. Name the shape so the failure is triageable.
+    shape = type(part).__name__
+    preview = part if isinstance(part, dict) else repr(part)
+    raise ValueError(
+        "multimodal_agent: unrecognised content part of type "
+        f"{shape!r} — cannot normalise to a native PydanticAI content type "
+        f"(would crash OpenAIResponsesModel._map_user_prompt's assert_never). "
+        f"Part: {preview!r}"
+    )
 
 
 def _rewrite_message_content(content: Any) -> Any:
     """Rewrite the ``content`` field of a single message.
 
     User messages carry lists of content parts; we walk the list and
-    rewrite any binary/image/document parts in place. String-only
+    rewrite every part to a native PydanticAI content type. String-only
     content (assistant replies, system prompts) passes through.
     """
     if not isinstance(content, list):
@@ -175,45 +657,161 @@ def _rewrite_message_content(content: Any) -> Any:
     return [_rewrite_part_for_model(part) for part in content]
 
 
-def _rewrite_history(messages: list[Any]) -> list[Any]:
-    """History processor: flatten attachments before each model call.
+def _flatten_messages_for_model(messages: list[ModelMessage]) -> list[ModelMessage]:
+    """Flatten AG-UI attachment content to native PydanticAI content types.
 
-    Receives the PydanticAI ``ModelMessage`` list. Only ``request``
-    (user) messages carry attachments in practice; we defensively walk
-    every message and rewrite any ``content`` field that is a list of
-    parts. Idempotent: re-running on the already-rewritten list is a
-    no-op.
+    Receives the PydanticAI ``ModelMessage`` list bound for the provider and
+    returns a NEW list in which every ``UserPromptPart`` whose content is a
+    list has had each part normalised to a native content type
+    (``str`` / ``ImageUrl`` / ``BinaryContent`` / ``DocumentUrl``).
+
+    This function is **pure**: it never mutates the incoming message or part
+    objects. It is called at the MODEL BOUNDARY (see
+    :class:`_MultimodalFlattenModel`), NOT as a ``history_processor`` — the
+    history-processor hook persists its return to ``ctx.state.message_history``
+    (the UI-visible conversation), which would leak the flattened PDF text /
+    ImageUrl substitutions into the user's chat bubble. Scoping the flatten to
+    the outgoing request mirrors the langgraph-python reference's
+    ``wrap_model_call`` contract.
+
+    A ``UserPromptPart`` whose rewrite is a no-op (content unchanged) is left
+    as the ORIGINAL object — we never rebuild on a no-op. Only ``ModelRequest``
+    messages carry user attachments; every other message kind passes through by
+    reference unchanged.
     """
-    rewritten: list[Any] = []
+    rewritten: list[ModelMessage] = []
     for message in messages:
-        # PydanticAI message objects expose parts on ``.parts``; each
-        # part has a ``.content`` attribute (for UserPromptPart etc.).
-        # We patch the ``.content`` in-place on a shallow copy rather
-        # than constructing a new PydanticAI message, because PydanticAI
-        # preserves message identity across runs for caching.
-        parts = getattr(message, "parts", None)
-        if not parts:
+        if not isinstance(message, ModelRequest):
             rewritten.append(message)
             continue
-        for part in parts:
+
+        new_parts: list[Any] = []
+        changed = False
+        for part in message.parts:
             content = getattr(part, "content", None)
-            if isinstance(content, list):
+            if isinstance(part, UserPromptPart) and isinstance(content, list):
                 new_content = _rewrite_message_content(content)
-                if new_content is not content:
-                    try:
-                        part.content = new_content  # type: ignore[attr-defined]
-                    except Exception:
-                        # Immutable part — skip; preserves original
-                        # behaviour without crashing the run.
-                        pass
-        rewritten.append(message)
+                # Detect a genuine no-op by IDENTITY, element-wise, not by
+                # structural ``==``. The original list holds AG-UI ``InputContent``
+                # model objects while a rewrite produces native types
+                # (str/ImageUrl/BinaryContent/DocumentUrl); comparing those
+                # heterogeneous pairs with ``==`` is fragile — a custom ``__eq__``
+                # could raise on the hot model-boundary path, or a liberal
+                # ``__eq__`` could false-positive and keep an un-flattened object
+                # (re-enabling the downstream ``assert_never``). A real no-op
+                # leaves every element the SAME object (a native fixpoint); a
+                # flatten always builds new objects. ``is`` cannot raise and
+                # cannot false-positive across an AG-UI→native conversion.
+                if len(new_content) == len(content) and all(
+                    n is o for n, o in zip(new_content, content)
+                ):
+                    # No-op rewrite — keep the original part object as-is.
+                    new_parts.append(part)
+                    continue
+                # Field-complete copy: preserve every UserPromptPart field
+                # (timestamp, part_kind, …) and only swap content.
+                new_parts.append(dataclasses.replace(part, content=new_content))
+                changed = True
+            else:
+                new_parts.append(part)
+
+        if not changed:
+            # Nothing in this request needed rewriting — keep it as-is.
+            rewritten.append(message)
+            continue
+
+        rewritten.append(dataclasses.replace(message, parts=new_parts))
     return rewritten
 
 
+class _MultimodalFlattenModel(WrapperModel):
+    """Wraps a model to flatten AG-UI attachment content at the model boundary.
+
+    The AG-UI bridge drops raw ``InputContent`` objects into
+    ``UserPromptPart.content``; we normalise them to native PydanticAI content
+    types in the OUTGOING request only, just before delegating to the wrapped
+    model. Because this happens at the request boundary — not via a
+    ``history_processor`` — the flatten never persists into
+    ``ctx.state.message_history``, so the UI-visible conversation keeps the
+    original AG-UI content (mirrors the langgraph-python ``wrap_model_call``).
+
+    Every model-call path FLATTENS before delegating: ``request``
+    (non-streaming), ``request_stream`` (streaming), AND ``count_tokens`` (the
+    ahead-of-request token count ``_agent_graph`` runs when
+    ``UsageLimits.count_tokens_before_request`` is set). The goal is uniform:
+    no path ever feeds raw AG-UI content to the wrapped model's prompt mapper /
+    ``assert_never``. (The ``count_tokens`` override flattens-then-delegates to
+    keep that invariant; it does NOT make ahead-of-request token counting
+    functional — the wrapped ``OpenAIResponsesModel`` raises
+    ``NotImplementedError`` for it. See ``count_tokens`` below.)
+    """
+
+    async def request(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+    ) -> ModelResponse:
+        return await self.wrapped.request(
+            _flatten_messages_for_model(messages),
+            model_settings,
+            model_request_parameters,
+        )
+
+    async def count_tokens(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+    ) -> RequestUsage:
+        """Flatten AG-UI content before delegating the token-count call.
+
+        ``_agent_graph`` calls ``count_tokens(message_history, ...)`` with the
+        UN-flattened history when ``UsageLimits.count_tokens_before_request`` is
+        set, so the raw AG-UI ``InputContent`` objects would otherwise reach the
+        wrapped model's prompt mapper (and its ``assert_never``) on this path —
+        exactly the crash the ``request`` flatten guards against. We mirror
+        ``request`` here so NO model-call path (request, stream, or token count)
+        ever feeds raw AG-UI content to a prompt mapper. The flatten is pure, so
+        (like ``request``) it never persists into ``ctx.state.message_history``.
+
+        NOTE: this override does NOT make ahead-of-request token counting
+        *work* — ``OpenAIResponsesModel`` (the wrapped model) does not support
+        it and its ``count_tokens`` raises ``NotImplementedError``. The override's
+        sole job is to guarantee no un-flattened AG-UI content reaches a prompt
+        mapper IF this path is ever exercised; it does not enable the feature.
+        """
+        return await self.wrapped.count_tokens(
+            _flatten_messages_for_model(messages),
+            model_settings,
+            model_request_parameters,
+        )
+
+    @asynccontextmanager
+    async def request_stream(
+        self,
+        messages: list[ModelMessage],
+        model_settings: ModelSettings | None,
+        model_request_parameters: ModelRequestParameters,
+        run_context: RunContext[Any] | None = None,
+    ) -> AsyncIterator[StreamedResponse]:
+        async with self.wrapped.request_stream(
+            _flatten_messages_for_model(messages),
+            model_settings,
+            model_request_parameters,
+            run_context,
+        ) as response_stream:
+            yield response_stream
+
+
+# Vision-capable model (``gpt-4o`` consumes image content natively), wrapped so
+# the AG-UI attachment flatten is scoped to the model call and never persists
+# into UI-visible state. (The gpt-4o vs gpt-5.4 choice mirrors the
+# langgraph-python reference's intent but stays on gpt-4o here to keep the
+# recorded aimock fixtures stable.)
 agent = Agent(
-    model=OpenAIResponsesModel("gpt-4o"),
+    model=_MultimodalFlattenModel(OpenAIResponsesModel("gpt-4o")),
     system_prompt=SYSTEM_PROMPT,
-    history_processors=[_rewrite_history],
 )
 
 

--- a/showcase/integrations/pydantic-ai/tests/python/test_multimodal_content_mapping.py
+++ b/showcase/integrations/pydantic-ai/tests/python/test_multimodal_content_mapping.py
@@ -1,0 +1,1321 @@
+"""Red→green tests for the multimodal agent's AG-UI content mapping.
+
+Exercises the REAL failure surface end-to-end:
+
+    AG-UI ``UserMessage(content=[TextInputContent, ImageInputContent, ...])``
+      → ``pydantic_ai.ag_ui._messages_from_ag_ui``      (the AG-UI bridge)
+      → ``multimodal_agent._flatten_messages_for_model`` (model-boundary flatten)
+      → ``OpenAIResponsesModel._map_user_prompt``        (lib mapping)
+
+The bug: the PydanticAI AG-UI bridge drops the raw ``UserMessage.content``
+list — a list of AG-UI ``InputContent`` *model objects* — straight into
+``UserPromptPart.content`` with no conversion, and ``_map_user_prompt`` then
+``assert_never``s on those AG-UI objects. The model-boundary flatten
+(``_flatten_messages_for_model``, invoked by the ``_MultimodalFlattenModel``
+wrapper) must normalise each part to a native PydanticAI content type
+(``str`` / ``ImageUrl`` / ``BinaryContent`` / ``DocumentUrl`` / extracted-PDF
+text) before the model maps it — for BOTH inline-``data`` and ``url`` sources —
+and **fail loud** on a genuinely unknown shape rather than feed the downstream
+``assert_never``.
+
+RED before the original rework: ``_map_user_prompt`` raises
+``AssertionError("Expected code to be unreachable, but got: <AG-UI object>")``
+for url-source content. Earlier rounds wired the flatten as a
+``history_processor``, whose return PydanticAI persists to
+``ctx.state.message_history`` — leaking the flattened content into UI-visible
+state.
+GREEN after: every content subtype maps to OpenAI ``input_text`` /
+``input_image`` / ``input_file`` content parts with no ``assert_never``; the
+flatten is scoped to the model call (no ``history_processor``), so the persisted
+conversation keeps the original AG-UI content; a missing-mime inline-DATA image
+never produces a ``data:image/*`` URI; recoverable-empty attachments degrade to
+placeholders; and a genuinely unknown shape raises a clear ``ValueError``.
+
+These tests are plain ``def`` functions driving coroutines via
+``asyncio.run`` (mirroring the sibling ``test_cvdiag_boundaries.py``
+convention) so they actually execute their assertions in a clean env —
+``pytest-asyncio`` is NOT a dependency, so ``@pytest.mark.asyncio`` tests
+would be collected-but-never-awaited (a vacuous pass). They need the real
+``pydantic_ai`` + ``ag_ui`` runtime deps and an ``OPENAI_API_KEY`` (module-level
+``Agent`` construction reads it; no network call is made — only the pure
+mapping is exercised). They skip cleanly when those deps are unavailable so the
+lightweight CVDIAG lane is unaffected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+# A 1x1 transparent PNG, base64.
+_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4"
+    "2mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+)
+
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-multimodal-mapping")
+
+ag_core = pytest.importorskip("ag_ui.core")
+pydantic_ag_ui = pytest.importorskip("pydantic_ai.ag_ui")
+pydantic_openai = pytest.importorskip("pydantic_ai.models.openai")
+
+from pydantic_ai import BinaryContent, ImageUrl  # noqa: E402
+from pydantic_ai.messages import ModelResponse, UserPromptPart  # noqa: E402
+from pydantic_ai.models import ModelRequestParameters  # noqa: E402
+
+from agents.multimodal_agent import (  # noqa: E402
+    _flatten_messages_for_model,
+    _rewrite_part_for_model,
+)
+
+UserMessage = ag_core.UserMessage
+TextInputContent = ag_core.TextInputContent
+ImageInputContent = ag_core.ImageInputContent
+AudioInputContent = ag_core.AudioInputContent
+VideoInputContent = ag_core.VideoInputContent
+DocumentInputContent = ag_core.DocumentInputContent
+BinaryInputContent = ag_core.BinaryInputContent
+InputContentDataSource = ag_core.InputContentDataSource
+InputContentUrlSource = ag_core.InputContentUrlSource
+_messages_from_ag_ui = pydantic_ag_ui._messages_from_ag_ui
+OpenAIResponsesModel = pydantic_openai.OpenAIResponsesModel
+
+
+def _user_prompt_part(model_messages):
+    for mm in model_messages:
+        for part in getattr(mm, "parts", []):
+            if isinstance(part, UserPromptPart):
+                return part
+    raise AssertionError("no UserPromptPart produced by the AG-UI bridge")
+
+
+async def _bridge_and_map(user_message: UserMessage):
+    """Run the full real surface and return ``(rewritten_part, mapped, orig_part)``.
+
+    ``orig_part`` is the UserPromptPart the AG-UI bridge produced *before* the
+    model-boundary flatten ran — used to assert the flatten never mutates the
+    state/UI-backing objects.
+    """
+    bridged = _messages_from_ag_ui([user_message])
+    orig_part = _user_prompt_part(bridged)
+    orig_snapshot = (
+        list(orig_part.content)
+        if isinstance(orig_part.content, list)
+        else orig_part.content
+    )
+    model_messages = _flatten_messages_for_model(bridged)
+    part = _user_prompt_part(model_messages)
+    model = OpenAIResponsesModel("gpt-4o")
+    mapped = await model._map_user_prompt(part)
+    return part, mapped, orig_part, orig_snapshot
+
+
+def _content_types(mapped):
+    content = mapped["content"]
+    if isinstance(content, str):
+        return ["__str__"]
+    return [p.get("type") for p in content]
+
+
+# ---------------------------------------------------------------------------
+# Data-source (inline base64) regressions — must keep working.
+# ---------------------------------------------------------------------------
+
+
+def test_multimodal_text_plus_image_maps_without_assert_never():
+    """Text + inline-image message maps to input_text + input_image, and the
+    user's literal prompt text survives alongside the attachment."""
+
+    async def run():
+        um = UserMessage(
+            id="m1",
+            role="user",
+            content=[
+                TextInputContent(type="text", text="describe the sample image"),
+                ImageInputContent(
+                    type="image",
+                    source=InputContentDataSource(
+                        type="data", value=_PNG_B64, mime_type="image/png"
+                    ),
+                ),
+            ],
+        )
+        part, mapped, _orig, _snap = await _bridge_and_map(um)
+
+        # Our history_processor must have produced native PydanticAI types.
+        assert isinstance(part.content, list)
+        assert any(isinstance(c, str) for c in part.content)
+        assert any(isinstance(c, ImageUrl) for c in part.content)
+
+        # The lib maps them with no ``assert_never``.
+        types = _content_types(mapped)
+        assert "input_text" in types
+        assert "input_image" in types
+
+        # The user's literal prompt text survives verbatim.
+        texts = [
+            p.get("text") for p in mapped["content"] if p.get("type") == "input_text"
+        ]
+        assert "describe the sample image" in texts
+
+    asyncio.run(run())
+
+
+def test_plain_text_user_message_passes_through():
+    """A non-multimodal ``str`` message is untouched and maps fine."""
+
+    async def run():
+        um = UserMessage(id="m2", role="user", content="hello there")
+        part, mapped, _orig, _snap = await _bridge_and_map(um)
+        assert part.content == "hello there"
+        assert mapped["content"] == "hello there"
+
+    asyncio.run(run())
+
+
+def test_pdf_document_data_flattened_to_text():
+    """An unreadable inline PDF document part degrades to a placeholder string,
+    and the sibling prompt text survives."""
+
+    async def run():
+        um = UserMessage(
+            id="m3",
+            role="user",
+            content=[
+                TextInputContent(type="text", text="summarize this"),
+                DocumentInputContent(
+                    type="document",
+                    source=InputContentDataSource(
+                        type="data",
+                        value="bm90YXBkZg==",  # "notapdf" — not a real PDF
+                        mime_type="application/pdf",
+                    ),
+                ),
+            ],
+        )
+        part, mapped, _orig, _snap = await _bridge_and_map(um)
+
+        assert isinstance(part.content, list)
+        assert all(isinstance(c, str) for c in part.content)
+        texts = [
+            p.get("text") for p in mapped["content"] if p.get("type") == "input_text"
+        ]
+        assert "summarize this" in texts  # prompt text survives
+        assert any("could not be read" in (t or "") for t in texts)
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# URL-source coverage — the A1 incompleteness that crashed with assert_never.
+# ---------------------------------------------------------------------------
+
+
+def test_url_source_image_maps_to_image_url():
+    """A url-source image (modern ``InputContentUrlSource``) maps to an
+    ``ImageUrl`` and an ``input_image`` part — RED before the rework
+    (``assert_never``), GREEN after."""
+
+    async def run():
+        um = UserMessage(
+            id="u1",
+            role="user",
+            content=[
+                TextInputContent(type="text", text="what is in this picture"),
+                ImageInputContent(
+                    type="image",
+                    source=InputContentUrlSource(
+                        type="url",
+                        value="https://example.com/cat.png",
+                        mime_type="image/png",
+                    ),
+                ),
+            ],
+        )
+        part, mapped, _orig, _snap = await _bridge_and_map(um)
+        assert any(isinstance(c, ImageUrl) for c in part.content)
+        img = next(c for c in part.content if isinstance(c, ImageUrl))
+        assert img.url == "https://example.com/cat.png"
+        types = _content_types(mapped)
+        assert "input_text" in types
+        assert "input_image" in types
+
+    asyncio.run(run())
+
+
+def test_url_carrying_binary_maps_to_image_url():
+    """A legacy ``binary`` part carrying a ``url`` (not ``data``) maps to an
+    ``ImageUrl`` — RED before the rework (``assert_never``), GREEN after."""
+
+    async def run():
+        um = UserMessage(
+            id="u2",
+            role="user",
+            content=[
+                BinaryInputContent(
+                    type="binary",
+                    mime_type="image/png",
+                    url="https://example.com/cat.png",
+                ),
+            ],
+        )
+        part, mapped, _orig, _snap = await _bridge_and_map(um)
+        assert any(isinstance(c, ImageUrl) for c in part.content)
+        assert "input_image" in _content_types(mapped)
+
+    asyncio.run(run())
+
+
+def test_missing_mime_image_not_dropped():
+    """A modern image part whose source omits ``mime_type`` is classified by its
+    part ``type`` and still produces an ``ImageUrl`` — never silently dropped."""
+
+    async def run():
+        um = UserMessage(
+            id="u3",
+            role="user",
+            content=[
+                ImageInputContent(
+                    type="image",
+                    source=InputContentUrlSource(
+                        type="url",
+                        value="https://example.com/no-mime",
+                        mime_type=None,
+                    ),
+                ),
+            ],
+        )
+        part, mapped, _orig, _snap = await _bridge_and_map(um)
+        assert any(isinstance(c, ImageUrl) for c in part.content)
+        assert "input_image" in _content_types(mapped)
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# State purity — the A3 leak (in-place mutation persisted to chat state).
+# ---------------------------------------------------------------------------
+
+
+def test_model_boundary_flatten_does_not_mutate_input():
+    """The model-boundary flatten must NOT mutate the AG-UI-derived (UI-backing)
+    message objects — it builds NEW objects so the rewrite stays scoped to the
+    outgoing request and never touches the list PydanticAI persists to
+    ``ctx.state.message_history``.
+
+    RED before the original rework: the flatten mutated ``part.content`` in
+    place, so the flattened ImageUrl/text leaked back into the original
+    objects PydanticAI persists to state.
+    """
+
+    async def run():
+        um = UserMessage(
+            id="s1",
+            role="user",
+            content=[
+                TextInputContent(type="text", text="hi"),
+                ImageInputContent(
+                    type="image",
+                    source=InputContentDataSource(
+                        type="data", value=_PNG_B64, mime_type="image/png"
+                    ),
+                ),
+            ],
+        )
+        part, _mapped, orig_part, orig_snapshot = await _bridge_and_map(um)
+
+        # The rewritten part is native content...
+        assert any(isinstance(c, ImageUrl) for c in part.content)
+        # ...but the original (state/UI-backing) part is untouched: still the
+        # raw AG-UI InputContent objects, and a NEW part object.
+        assert orig_part.content == orig_snapshot
+        assert orig_part is not part
+        assert all(type(o).__name__.endswith("InputContent") for o in orig_part.content)
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud on unknown shapes — the A2 swallow that re-enabled assert_never.
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_object_shape_fails_loud():
+    """A genuinely unknown content object raises a clear ``ValueError`` naming
+    the shape — never silent pass-through to the downstream ``assert_never``."""
+
+    class _Mystery:
+        pass
+
+    with pytest.raises(ValueError) as exc:
+        _rewrite_part_for_model(_Mystery())
+    assert "unrecognised content part" in str(exc.value)
+    assert "_Mystery" in str(exc.value)
+
+
+def test_unknown_dict_shape_fails_loud():
+    """An unknown dict-shaped part also fails loud rather than passing through."""
+
+    with pytest.raises(ValueError) as exc:
+        _rewrite_part_for_model({"type": "mystery", "foo": 1})
+    assert "unrecognised content part" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# A1' — missing-mime inline-DATA image must NEVER produce a "data:image/*" URI
+# (OpenAI's Responses API rejects the wildcard media type → image dropped /
+# turn fails). The reference DROPS missing-mime parts; we sniff a concrete
+# image type from the base64 magic bytes when we can, else degrade to a
+# generic-attachment text placeholder.
+# ---------------------------------------------------------------------------
+
+
+def test_missing_mime_data_image_sniffs_concrete_type_never_wildcard():
+    """A modern image part with inline DATA but no mime must map to an ImageUrl
+    whose data URI carries a CONCRETE media type sniffed from the PNG magic
+    bytes — NEVER ``data:image/*;base64`` (which OpenAI rejects).
+
+    RED before the fix: ``_kind_for`` returns ``image/*`` for a missing-mime
+    image, so the data URI is ``data:image/*;base64,...`` (invalid).
+    GREEN after: the URI carries ``image/png``.
+    """
+    out = _rewrite_part_for_model(
+        ImageInputContent(
+            type="image",
+            source=InputContentDataSource(type="data", value=_PNG_B64, mime_type=""),
+        )
+    )
+    assert isinstance(out, ImageUrl)
+    assert "image/*" not in out.url
+    assert out.url == f"data:image/png;base64,{_PNG_B64}"
+
+
+def test_missing_mime_unsniffable_data_image_degrades_to_placeholder():
+    """A missing-mime inline-DATA image whose bytes are NOT a recognisable
+    image format must NOT emit a ``data:image/*`` URI; it degrades to a
+    generic-attachment text placeholder (reference DROPS such parts).
+
+    RED before the fix: produces ``ImageUrl("data:image/*;base64,...")``.
+    GREEN after: a ``str`` placeholder, no invalid wildcard URI.
+    """
+    # "notanimage" base64 — no PNG/JPEG/GIF/WebP magic.
+    out = _rewrite_part_for_model(
+        ImageInputContent(
+            type="image",
+            source=InputContentDataSource(
+                type="data", value="bm90YW5pbWFnZQ==", mime_type=""
+            ),
+        )
+    )
+    assert isinstance(out, str)
+    assert "image/*" not in out
+    assert "[Attached" in out
+
+
+def test_missing_mime_data_image_full_surface_maps_to_input_image():
+    """End-to-end: a missing-mime inline-DATA PNG must still map to an
+    ``input_image`` (sniffed concrete type) through the real model mapper —
+    NEVER an invalid wildcard data URI that OpenAI would reject."""
+
+    async def run():
+        um = UserMessage(
+            id="mm1",
+            role="user",
+            content=[
+                ImageInputContent(
+                    type="image",
+                    source=InputContentDataSource(
+                        type="data", value=_PNG_B64, mime_type=""
+                    ),
+                ),
+            ],
+        )
+        part, mapped, _orig, _snap = await _bridge_and_map(um)
+        imgs = [c for c in part.content if isinstance(c, ImageUrl)]
+        assert imgs, "missing-mime DATA image should still produce an ImageUrl"
+        assert all("image/*" not in c.url for c in imgs)
+        assert "input_image" in _content_types(mapped)
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud OVERREACH — recoverable-empty cases must degrade, NOT raise.
+# Only a GENUINELY-unknown shape fails loud.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_payload_legacy_binary_degrades_not_raises():
+    """A legacy ``binary`` part with a known mime but NO data and NO url is a
+    recoverable-empty case per the taxonomy — it must degrade (placeholder /
+    skip), NOT raise the fail-loud ValueError.
+
+    RED before the fix: ``_classify_content_part`` returns ``None`` and the
+    part falls through to the fail-loud ``ValueError``.
+    GREEN after: returns a degraded text placeholder, no raise.
+    """
+    out = _rewrite_part_for_model({"type": "binary", "mimeType": "image/png"})
+    assert isinstance(out, str)
+    assert "[Attached" in out
+
+
+def test_empty_source_modern_image_degrades_not_raises():
+    """A modern ``image`` part with an empty/absent source is recoverable-empty
+    and must degrade gracefully, NOT raise."""
+    out = _rewrite_part_for_model({"type": "image", "source": {}})
+    assert isinstance(out, str)
+    assert "[Attached" in out
+
+
+def test_empty_source_modern_document_degrades_not_raises():
+    """A modern ``document`` part with no usable source degrades, NOT raises."""
+    out = _rewrite_part_for_model({"type": "document"})
+    assert isinstance(out, str)
+    assert "[Attached" in out
+
+
+def test_genuinely_unknown_shape_still_fails_loud_after_overreach_fix():
+    """The overreach fix must NOT weaken the fail-loud on a TRULY-unknown shape:
+    a dict whose ``type`` is unrecognised still raises a clear ValueError."""
+    with pytest.raises(ValueError) as exc:
+        _rewrite_part_for_model({"type": "totally-bogus", "x": 1})
+    assert "unrecognised content part" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# A3' — the flatten MUST NOT persist into ctx.state.message_history (UI state).
+# pydantic_ai._agent_graph writes the history_processor's RETURNED list back to
+# state (``ctx.state.message_history[:] = message_history``), so a processor
+# that RETURNS flattened content leaks it into the UI-visible conversation —
+# even if the original objects are untouched. The fix scopes the flatten to the
+# model boundary (a WrapperModel) so the persisted history keeps the ORIGINAL
+# AG-UI content while only the outgoing provider request is flattened.
+# ---------------------------------------------------------------------------
+
+
+def test_agent_uses_no_content_flattening_history_processor():
+    """The agent must NOT carry a history_processor that flattens content,
+    because pydantic_ai persists the processor's return to
+    ``ctx.state.message_history`` (the UI-visible state).
+
+    This asserts the load-bearing INVARIANT — no registered processor flattens
+    raw AG-UI content — by RUNNING every registered processor over a real
+    bridged history and proving the result still holds raw AG-UI objects. It
+    inspects only the agent's actual registered processors, so it stays robust
+    regardless of any internal helper names.
+
+    RED before the fix: the flatten was registered as a history_processor, so a
+    processor returns flattened content (ImageUrl/str) → UI leak.
+    GREEN after: no content-flattening processor is registered (the flatten
+    happens at the model boundary instead), so the processed history is
+    unchanged raw AG-UI content.
+    """
+    from agents.multimodal_agent import agent
+
+    um = UserMessage(
+        id="proc1",
+        role="user",
+        content=[
+            TextInputContent(type="text", text="hi"),
+            ImageInputContent(
+                type="image",
+                source=InputContentDataSource(
+                    type="data", value=_PNG_B64, mime_type="image/png"
+                ),
+            ),
+        ],
+    )
+    history = _messages_from_ag_ui([um])
+
+    processed = list(history)
+    for proc in list(getattr(agent, "history_processors", []) or []):
+        processed = proc(processed)
+
+    part = _user_prompt_part(processed)
+    assert isinstance(part.content, list)
+    assert all(type(c).__name__.endswith("InputContent") for c in part.content), (
+        "a registered history_processor flattened content — its return is "
+        "persisted to ctx.state.message_history and would leak the flattened "
+        f"PDF/image content into UI state: {[type(c).__name__ for c in part.content]}"
+    )
+
+
+def test_model_boundary_flatten_does_not_persist_to_state():
+    """EMPIRICAL A3' leak proof, driven through the REAL model-boundary wrapper.
+
+    The previous version of this test looped over ``agent.history_processors``
+    — which is empty — so its loop never ran and it passed trivially (a
+    tautology). This version instead drives the load-bearing surface: the
+    ``_MultimodalFlattenModel`` wrapper that actually flattens the outgoing
+    request. We hand the wrapper a captured ``state_history`` (exactly the list
+    ``_agent_graph`` keeps as ``ctx.state.message_history``), let the wrapper's
+    model-boundary flatten run, and assert the state-backing list STILL holds
+    the ORIGINAL raw AG-UI content objects — proving the flatten is scoped to
+    the outgoing request and never persists into UI-visible state.
+
+    This is non-tautological: a captured ``RecordingModel`` confirms the
+    wrapper's delegate actually RECEIVED flattened (native) content (so the
+    flatten really ran), while the asserted state list is unchanged.
+
+    RED (a regression where the wrapper mutated/persisted its input, or a
+    re-introduced history_processor): the state list would hold ImageUrl/str.
+    GREEN: state keeps raw AG-UI objects; the wrapped model saw native content.
+    """
+    from pydantic_ai.usage import RequestUsage
+
+    from agents.multimodal_agent import _MultimodalFlattenModel
+
+    class RecordingModel(OpenAIResponsesModel):
+        """Captures the messages the wrapper forwards, without a network call."""
+
+        def __init__(self):
+            super().__init__("gpt-4o")
+            self.seen_request = None
+            self.seen_count_tokens = None
+
+        async def request(self, messages, model_settings, model_request_parameters):
+            self.seen_request = messages
+            return ModelResponse(parts=[])
+
+        async def count_tokens(
+            self, messages, model_settings, model_request_parameters
+        ):
+            self.seen_count_tokens = messages
+            return RequestUsage()
+
+    um = UserMessage(
+        id="leak1",
+        role="user",
+        content=[
+            TextInputContent(type="text", text="hi"),
+            ImageInputContent(
+                type="image",
+                source=InputContentDataSource(
+                    type="data", value=_PNG_B64, mime_type="image/png"
+                ),
+            ),
+        ],
+    )
+    state_history = _messages_from_ag_ui([um])
+    orig_part = _user_prompt_part(state_history)
+    orig_snapshot = list(orig_part.content)
+
+    rec = RecordingModel()
+    wrapper = _MultimodalFlattenModel(rec)
+    params = ModelRequestParameters()
+
+    async def run():
+        await wrapper.request(state_history, None, params)
+        await wrapper.count_tokens(state_history, None, params)
+
+    asyncio.run(run())
+
+    # The wrapped model actually received FLATTENED (native) content on BOTH
+    # the request and the count_tokens path — proves the flatten really ran.
+    for seen in (rec.seen_request, rec.seen_count_tokens):
+        assert seen is not None
+        seen_part = _user_prompt_part(seen)
+        assert any(isinstance(c, ImageUrl) for c in seen_part.content), (
+            "wrapped model did not receive flattened content: "
+            f"{[type(c).__name__ for c in seen_part.content]}"
+        )
+
+    # ...yet the state-backing history is UNCHANGED — still raw AG-UI objects,
+    # same identity, same content (no persistence/leak into UI state).
+    assert _user_prompt_part(state_history) is orig_part
+    assert orig_part.content == orig_snapshot
+    assert all(type(c).__name__.endswith("InputContent") for c in orig_part.content), (
+        "model-boundary flatten leaked into state: "
+        f"{[type(c).__name__ for c in orig_part.content]}"
+    )
+
+
+def test_model_wrapper_flattens_outgoing_request():
+    """The model boundary MUST flatten AG-UI content before the provider call.
+
+    The wrapper-model approach (the A3' fix) flattens the outgoing messages
+    just before the wrapped model's request. We exercise the wrapper's flatten
+    on a UserPromptPart carrying raw AG-UI content and assert it produces native
+    PydanticAI content (so the provider never sees an AG-UI object), while the
+    INPUT list is left untouched (model-boundary scope, no state mutation).
+    """
+    from agents.multimodal_agent import _flatten_messages_for_model
+
+    bridged = _messages_from_ag_ui(
+        [
+            UserMessage(
+                id="w1",
+                role="user",
+                content=[
+                    TextInputContent(type="text", text="describe"),
+                    ImageInputContent(
+                        type="image",
+                        source=InputContentDataSource(
+                            type="data", value=_PNG_B64, mime_type="image/png"
+                        ),
+                    ),
+                ],
+            )
+        ]
+    )
+    orig_part = _user_prompt_part(bridged)
+    orig_types = [type(c).__name__ for c in orig_part.content]
+
+    flattened = _flatten_messages_for_model(bridged)
+    fpart = _user_prompt_part(flattened)
+    assert any(isinstance(c, ImageUrl) for c in fpart.content)
+    assert any(isinstance(c, str) for c in fpart.content)
+
+    # The input messages are untouched (no state mutation at the boundary).
+    assert [type(c).__name__ for c in orig_part.content] == orig_types
+    assert all(type(c).__name__.endswith("InputContent") for c in orig_part.content)
+
+
+# ---------------------------------------------------------------------------
+# count_tokens path — the model-call path _agent_graph runs when
+# UsageLimits.count_tokens_before_request is set. It passes the UN-flattened
+# message_history, so without a wrapper count_tokens override the raw AG-UI
+# InputContent reaches the wrapped model's prompt mapper (assert_never), OR the
+# call never delegates at all (base Model.count_tokens raises NotImplementedError
+# regardless of the wrapped model). The wrapper must flatten + delegate.
+# ---------------------------------------------------------------------------
+
+
+def test_count_tokens_path_does_not_reach_assert_never_on_raw_ag_ui():
+    """RED before the override: the wrapper has NO ``count_tokens``, so it
+    resolves to base ``Model.count_tokens`` — which NEVER delegates to the
+    wrapped model and raises ``NotImplementedError`` (the count_tokens path is
+    entirely uncovered). Even where a wrapped model DOES implement count_tokens
+    by mapping the prompt, the raw AG-UI objects would reach its ``assert_never``.
+
+    GREEN after: the wrapper overrides ``count_tokens`` to flatten the outgoing
+    messages and delegate — so a wrapped model that maps the prompt during
+    count_tokens (exactly the OpenAI Responses ``_map_user_prompt`` surface)
+    receives NATIVE content and never hits ``assert_never``.
+    """
+
+    from pydantic_ai.usage import RequestUsage
+
+    from agents.multimodal_agent import _MultimodalFlattenModel
+
+    mapper_model = OpenAIResponsesModel("gpt-4o")
+
+    class CountingModel(OpenAIResponsesModel):
+        """A wrapped model whose count_tokens maps the prompt — the real
+        ``OpenAIResponsesModel._map_user_prompt`` surface that ``assert_never``s
+        on non-native content. This is the path ``_agent_graph`` drives."""
+
+        def __init__(self):
+            super().__init__("gpt-4o")
+            self.mapped_types = None
+
+        async def count_tokens(
+            self, messages, model_settings, model_request_parameters
+        ):
+            part = _user_prompt_part(messages)
+            mapped = await mapper_model._map_user_prompt(part)
+            self.mapped_types = _content_types(mapped)
+            return RequestUsage()
+
+    um = UserMessage(
+        id="ct1",
+        role="user",
+        content=[
+            TextInputContent(type="text", text="how many tokens"),
+            ImageInputContent(
+                type="image",
+                source=InputContentDataSource(
+                    type="data", value=_PNG_B64, mime_type="image/png"
+                ),
+            ),
+        ],
+    )
+    messages = _messages_from_ag_ui([um])
+
+    counting = CountingModel()
+    wrapper = _MultimodalFlattenModel(counting)
+    params = ModelRequestParameters()
+
+    async def run():
+        # RED: without the override this resolves to base Model.count_tokens →
+        # NotImplementedError (path uncovered). With a delegating-but-unflattened
+        # path, _map_user_prompt would assert_never on the raw AG-UI image.
+        await wrapper.count_tokens(messages, None, params)
+
+    asyncio.run(run())
+
+    # GREEN: the prompt mapped cleanly to native input parts — no assert_never.
+    assert counting.mapped_types is not None
+    assert "input_text" in counting.mapped_types
+    assert "input_image" in counting.mapped_types
+
+
+# ---------------------------------------------------------------------------
+# Audio / video — KNOWN-but-unsupported modalities must DEGRADE to a text
+# placeholder (consistent with non-image/non-document binary), NOT fail-loud.
+# Fail-loud stays reserved for GENUINELY-unknown shapes.
+# ---------------------------------------------------------------------------
+
+
+def test_audio_data_input_degrades_to_placeholder_not_raises():
+    """A valid inline-DATA ``AudioInputContent`` degrades to a text placeholder,
+    NOT a fail-loud ValueError.
+
+    RED before the fix: ``audio`` is not a recognised attachment ``type`` in
+    ``_classify_content_part``, so it falls through to the fail-loud
+    ``ValueError``.
+    GREEN after: it degrades to ``[Attached audio: <mime>]`` and the turn
+    proceeds.
+    """
+    out = _rewrite_part_for_model(
+        AudioInputContent(
+            type="audio",
+            source=InputContentDataSource(
+                type="data", value="AAAA", mime_type="audio/mpeg"
+            ),
+        )
+    )
+    assert isinstance(out, str)
+    assert "[Attached audio" in out
+
+
+def test_video_url_input_degrades_to_placeholder_not_raises():
+    """A valid url-source ``VideoInputContent`` degrades to a placeholder, NOT
+    a fail-loud ValueError."""
+    out = _rewrite_part_for_model(
+        VideoInputContent(
+            type="video",
+            source=InputContentUrlSource(
+                type="url", value="https://example.com/v.mp4", mime_type="video/mp4"
+            ),
+        )
+    )
+    assert isinstance(out, str)
+    assert "[Attached video" in out
+
+
+def test_audio_dict_with_empty_source_degrades_not_raises():
+    """A modern ``audio`` part with no usable source still degrades (recognised
+    modality), NOT fail-loud."""
+    out = _rewrite_part_for_model({"type": "audio"})
+    assert isinstance(out, str)
+    assert "[Attached audio" in out
+
+
+def test_audio_video_message_maps_through_full_surface_without_assert_never():
+    """End-to-end: a message mixing text + audio + video maps through the real
+    model mapper with NO ``assert_never`` — audio/video become text placeholders
+    and the user's prompt text survives."""
+
+    async def run():
+        um = UserMessage(
+            id="av1",
+            role="user",
+            content=[
+                TextInputContent(type="text", text="what is in these clips"),
+                AudioInputContent(
+                    type="audio",
+                    source=InputContentDataSource(
+                        type="data", value="AAAA", mime_type="audio/mpeg"
+                    ),
+                ),
+                VideoInputContent(
+                    type="video",
+                    source=InputContentUrlSource(
+                        type="url",
+                        value="https://example.com/v.mp4",
+                        mime_type="video/mp4",
+                    ),
+                ),
+            ],
+        )
+        part, mapped, _orig, _snap = await _bridge_and_map(um)
+        assert all(isinstance(c, str) for c in part.content)
+        types = _content_types(mapped)
+        assert "input_text" in types
+        texts = [
+            p.get("text") for p in mapped["content"] if p.get("type") == "input_text"
+        ]
+        assert "what is in these clips" in texts
+        assert any("Attached audio" in (t or "") for t in texts)
+        assert any("Attached video" in (t or "") for t in texts)
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Unsupported IMAGE SUBTYPES — OpenAI's Responses vision API only supports
+# PNG / JPEG / GIF / WebP. A present-mime image whose subtype is anything else
+# (image/heic — the iPhone default! — image/svg+xml, image/tiff, image/bmp …)
+# must NEVER be emitted as a ``data:image/<subtype>;base64`` ImageUrl: the
+# Responses API rejects the unsupported subtype → the image is dropped / the
+# turn fails. It must DEGRADE to a text placeholder (same pattern as the
+# audio/video degrade). The allow-list applies to BOTH the present-mime image
+# path AND the missing-mime sniff path (so a sniffed tiff/bmp also degrades).
+# ---------------------------------------------------------------------------
+
+
+def test_present_mime_heic_image_degrades_not_image_url():
+    """A present-mime ``image/heic`` part (iPhone default) must degrade to a
+    text placeholder — OpenAI's Responses vision API rejects HEIC.
+
+    RED before the fix: routed to ``kind="image"`` on the ``image/`` prefix and
+    emitted as ``ImageUrl("data:image/heic;base64,...")`` (OpenAI rejects).
+    GREEN after: a ``str`` placeholder naming the mime; no ``data:image/heic``.
+    """
+    out = _rewrite_part_for_model(
+        ImageInputContent(
+            type="image",
+            source=InputContentDataSource(
+                type="data", value=_PNG_B64, mime_type="image/heic"
+            ),
+        )
+    )
+    assert isinstance(out, str)
+    assert "[Attached image" in out
+    assert "image/heic" in out
+
+
+def test_present_mime_svg_image_degrades_not_image_url():
+    """A present-mime ``image/svg+xml`` part degrades to a placeholder — SVG is
+    not a supported Responses vision subtype."""
+    out = _rewrite_part_for_model(
+        ImageInputContent(
+            type="image",
+            source=InputContentDataSource(
+                type="data", value=_PNG_B64, mime_type="image/svg+xml"
+            ),
+        )
+    )
+    assert isinstance(out, str)
+    assert "[Attached image" in out
+    assert "image/svg+xml" in out
+
+
+def test_present_mime_unsupported_image_url_source_degrades():
+    """An unsupported image subtype delivered via a URL source ALSO degrades —
+    OpenAI would reject the ``image/heic`` regardless of data-vs-url delivery."""
+    out = _rewrite_part_for_model(
+        ImageInputContent(
+            type="image",
+            source=InputContentUrlSource(
+                type="url",
+                value="https://example.com/photo.heic",
+                mime_type="image/heic",
+            ),
+        )
+    )
+    assert isinstance(out, str)
+    assert "[Attached image" in out
+    assert "image/heic" in out
+
+
+def test_sniffed_tiff_missing_mime_image_degrades_not_image_url():
+    """A missing-mime inline-DATA image whose magic bytes sniff as TIFF must
+    degrade — TIFF is recognisable but NOT a supported Responses subtype, so it
+    must NOT be emitted as ``data:image/tiff``.
+
+    RED before the fix: ``_sniff_image_mime`` returns ``image/tiff`` and the
+    part is emitted as ``ImageUrl("data:image/tiff;base64,...")``.
+    GREEN after: degrades to a placeholder ``str``; no ``data:image/tiff``.
+    """
+    import base64 as _b64
+
+    tiff_b64 = _b64.b64encode(b"II*\x00" + b"\x00" * 20).decode()
+    out = _rewrite_part_for_model(
+        ImageInputContent(
+            type="image",
+            source=InputContentDataSource(type="data", value=tiff_b64, mime_type=""),
+        )
+    )
+    assert isinstance(out, str)
+    assert "image/tiff" not in out
+    assert "data:image" not in out
+    assert "[Attached image" in out
+
+
+def test_sniffed_bmp_missing_mime_image_degrades_not_image_url():
+    """A missing-mime inline-DATA image whose magic bytes sniff as BMP also
+    degrades — BMP is not a supported Responses subtype."""
+    import base64 as _b64
+
+    bmp_b64 = _b64.b64encode(b"BM" + b"\x00" * 20).decode()
+    out = _rewrite_part_for_model(
+        ImageInputContent(
+            type="image",
+            source=InputContentDataSource(type="data", value=bmp_b64, mime_type=""),
+        )
+    )
+    assert isinstance(out, str)
+    assert "data:image" not in out
+    assert "[Attached image" in out
+
+
+def test_supported_image_subtypes_still_image_url_present_mime():
+    """The four supported subtypes (PNG/JPEG/GIF/WebP) still emit an ImageUrl
+    when delivered with a present mime — the allow-list must not over-degrade."""
+    for subtype in ("png", "jpeg", "gif", "webp"):
+        out = _rewrite_part_for_model(
+            ImageInputContent(
+                type="image",
+                source=InputContentDataSource(
+                    type="data", value=_PNG_B64, mime_type=f"image/{subtype}"
+                ),
+            )
+        )
+        assert isinstance(out, ImageUrl), f"image/{subtype} should map to ImageUrl"
+        assert out.url == f"data:image/{subtype};base64,{_PNG_B64}"
+
+
+def test_supported_image_subtype_url_source_still_image_url():
+    """A supported-subtype URL-source image still maps to an ImageUrl."""
+    out = _rewrite_part_for_model(
+        ImageInputContent(
+            type="image",
+            source=InputContentUrlSource(
+                type="url", value="https://example.com/cat.png", mime_type="image/png"
+            ),
+        )
+    )
+    assert isinstance(out, ImageUrl)
+    assert out.url == "https://example.com/cat.png"
+
+
+def test_heic_image_maps_through_full_surface_as_text_not_image():
+    """End-to-end: a present-mime HEIC image maps through the real model mapper
+    as an ``input_text`` placeholder — never an unsupported ``input_image``."""
+
+    async def run():
+        um = UserMessage(
+            id="heic1",
+            role="user",
+            content=[
+                TextInputContent(type="text", text="describe this photo"),
+                ImageInputContent(
+                    type="image",
+                    source=InputContentDataSource(
+                        type="data", value=_PNG_B64, mime_type="image/heic"
+                    ),
+                ),
+            ],
+        )
+        part, mapped, _orig, _snap = await _bridge_and_map(um)
+        # No ImageUrl produced for the HEIC part; it degraded to a str.
+        assert not any(isinstance(c, ImageUrl) for c in part.content)
+        types = _content_types(mapped)
+        assert "input_text" in types
+        assert "input_image" not in types
+        texts = [
+            p.get("text") for p in mapped["content"] if p.get("type") == "input_text"
+        ]
+        assert "describe this photo" in texts
+        assert any("Attached image" in (t or "") for t in texts)
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Empty-but-known-mime attachment must preserve the mime in the placeholder
+# (consistent with the legacy-binary empty path), not discard it.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_known_mime_image_preserves_mime_in_placeholder():
+    """A modern ``image`` part whose source is empty but whose modality is known
+    degrades to a placeholder that names the modality — and a legacy binary with
+    a known mime but no payload preserves that mime."""
+    # Legacy binary with a known mime but no data/url: mime preserved.
+    out = _rewrite_part_for_model({"type": "binary", "mimeType": "image/png"})
+    assert isinstance(out, str)
+    assert "image/png" in out
+
+
+# ---------------------------------------------------------------------------
+# request_stream override — the streaming model-call path must flatten the
+# outgoing messages before delegating to the wrapped model (mirror the
+# request / count_tokens wrapper coverage).
+# ---------------------------------------------------------------------------
+
+
+def test_request_stream_flattens_outgoing_messages():
+    """The wrapper's ``request_stream`` override MUST flatten AG-UI content
+    before delegating, so the wrapped model's streaming path never sees raw
+    AG-UI ``InputContent`` (which would crash ``_map_user_prompt``).
+
+    RED if the override forwarded raw messages: the wrapped model would receive
+    AG-UI objects on the stream path.
+    GREEN: the wrapped model's ``request_stream`` receives flattened native
+    content, and the input state list is left untouched.
+    """
+    from contextlib import asynccontextmanager
+
+    from agents.multimodal_agent import _MultimodalFlattenModel
+
+    class StreamRecordingModel(OpenAIResponsesModel):
+        """Captures the messages the wrapper forwards on the stream path."""
+
+        def __init__(self):
+            super().__init__("gpt-4o")
+            self.seen_stream = None
+
+        @asynccontextmanager
+        async def request_stream(
+            self,
+            messages,
+            model_settings,
+            model_request_parameters,
+            run_context=None,
+        ):
+            self.seen_stream = messages
+            yield object()  # a stand-in StreamedResponse; never iterated here
+
+    um = UserMessage(
+        id="stream1",
+        role="user",
+        content=[
+            TextInputContent(type="text", text="stream this"),
+            ImageInputContent(
+                type="image",
+                source=InputContentDataSource(
+                    type="data", value=_PNG_B64, mime_type="image/png"
+                ),
+            ),
+        ],
+    )
+    state_history = _messages_from_ag_ui([um])
+    orig_part = _user_prompt_part(state_history)
+    orig_snapshot = list(orig_part.content)
+
+    rec = StreamRecordingModel()
+    wrapper = _MultimodalFlattenModel(rec)
+    params = ModelRequestParameters()
+
+    async def run():
+        async with wrapper.request_stream(state_history, None, params, None):
+            pass
+
+    asyncio.run(run())
+
+    # The wrapped model's stream path received FLATTENED native content.
+    assert rec.seen_stream is not None
+    seen_part = _user_prompt_part(rec.seen_stream)
+    assert any(isinstance(c, ImageUrl) for c in seen_part.content), (
+        "wrapped model's request_stream did not receive flattened content: "
+        f"{[type(c).__name__ for c in seen_part.content]}"
+    )
+    assert any(isinstance(c, str) for c in seen_part.content)
+
+    # ...and the state-backing history is unchanged (no leak into UI state).
+    assert _user_prompt_part(state_history) is orig_part
+    assert orig_part.content == orig_snapshot
+    assert all(type(c).__name__.endswith("InputContent") for c in orig_part.content)
+
+
+# ---------------------------------------------------------------------------
+# Unit-level flatten behaviour (no model required).
+# ---------------------------------------------------------------------------
+
+
+def test_text_input_content_object_flattens_to_str():
+    """``_rewrite_part_for_model`` flattens an AG-UI text object to ``str``."""
+    out = _rewrite_part_for_model(TextInputContent(type="text", text="hi"))
+    assert out == "hi"
+
+
+def test_image_input_content_object_flattens_to_image_url():
+    """``_rewrite_part_for_model`` flattens an inline AG-UI image to ImageUrl."""
+    out = _rewrite_part_for_model(
+        ImageInputContent(
+            type="image",
+            source=InputContentDataSource(
+                type="data", value=_PNG_B64, mime_type="image/png"
+            ),
+        )
+    )
+    assert isinstance(out, ImageUrl)
+    assert out.url == f"data:image/png;base64,{_PNG_B64}"
+
+
+def test_legacy_binary_dict_still_handled():
+    """Frontend legacy on-wire dict shape still maps to ImageUrl."""
+    out = _rewrite_part_for_model(
+        {"type": "binary", "mimeType": "image/png", "data": _PNG_B64}
+    )
+    assert isinstance(out, ImageUrl)
+    assert out.url == f"data:image/png;base64,{_PNG_B64}"
+
+
+def test_native_content_passes_through_unchanged():
+    """Already-native content (idempotency) passes through untouched."""
+    iu = ImageUrl(url="https://example.com/x.png")
+    assert _rewrite_part_for_model(iu) is iu
+    assert _rewrite_part_for_model("already a string") == "already a string"
+
+
+# ---------------------------------------------------------------------------
+# R8 — consolidated type-gating at the EMISSION CHOKE POINT.
+#
+# These three tests close a CR-round-7 cluster whose shared root cause is that
+# the OpenAI supported-type gate + degrade lived only on the ``image`` content
+# branch (and the mime allow-list under-accepted parameterised / non-canonical
+# mimes). After R8 the supported-type check + degrade happen at the SINGLE
+# native-type emission choke point, and mime normalisation strips RFC-2045
+# parameters / whitespace and aliases ``image/jpg`` → ``image/jpeg``.
+# ---------------------------------------------------------------------------
+
+
+def test_jpg_alias_data_image_forwarded_as_image_url():
+    """GAP (a) — ``image/jpg`` (non-canonical but ubiquitous) inline-DATA image
+    must be FORWARDED as a supported JPEG ``ImageUrl``, not degraded.
+
+    RED before R8: the subtype ``"jpg"`` is not in the allow-list, so
+    ``_is_supported_image_mime("image/jpg")`` returns ``False`` and the image is
+    degraded to a ``[Attached image: image/jpg]`` placeholder — a real JPEG
+    silently never reaches the vision model.
+    GREEN after R8: ``image/jpg`` is aliased to ``image/jpeg`` before the
+    membership test, so it emits an ``ImageUrl``.
+    """
+    out = _rewrite_part_for_model(
+        ImageInputContent(
+            type="image",
+            source=InputContentDataSource(
+                type="data", value=_PNG_B64, mime_type="image/jpg"
+            ),
+        )
+    )
+    assert isinstance(out, ImageUrl), "image/jpg should forward as a JPEG ImageUrl"
+    assert out.url.startswith("data:image/jpeg;base64,"), (
+        f"image/jpg should normalise to canonical image/jpeg in the data URI, "
+        f"got {out.url!r}"
+    )
+
+
+def test_parameterised_supported_mime_data_image_forwarded():
+    """GAP (c) — a SUPPORTED image whose mime carries an RFC-2045 parameter or
+    stray whitespace (e.g. ``image/jpeg; charset=binary``) must be FORWARDED as
+    an ``ImageUrl``, not degraded.
+
+    RED before R8: ``_is_supported_image_mime`` takes the verbatim remainder
+    after ``image/`` as the subtype (``"jpeg; charset=binary"``), which is not in
+    the allow-list, so the image is degraded.
+    GREEN after R8: the mime is normalised (split on ``;`` + strip) before the
+    membership test, so it emits an ``ImageUrl``.
+    """
+    out = _rewrite_part_for_model(
+        ImageInputContent(
+            type="image",
+            source=InputContentDataSource(
+                type="data", value=_PNG_B64, mime_type="image/jpeg; charset=binary"
+            ),
+        )
+    )
+    assert isinstance(out, ImageUrl), (
+        "parameterised image/jpeg should forward as an ImageUrl"
+    )
+    assert out.url.startswith("data:image/jpeg;base64,"), (
+        f"parameterised mime should normalise to bare image/jpeg in the data "
+        f"URI, got {out.url!r}"
+    )
+
+
+def test_url_document_media_mime_degrades_not_document_url():
+    """GAP (b) — a ``document`` (or legacy ``binary``) URL source carrying a
+    non-PDF / media (audio/video) mime must DEGRADE to a text placeholder, NOT
+    be emitted as an unconditional ``DocumentUrl`` the OpenAI mapper may reject.
+
+    RED before R8: ``_kind_for("audio/mpeg", default=...)`` returns
+    ``("other", "audio/mpeg")`` and the ``"other"`` URL branch returns
+    ``DocumentUrl(url=value)`` unconditionally — no mime gate at all.
+    GREEN after R8: the supported-type gate at the emission choke point degrades
+    a non-fetchable-document URL to a ``[Attached ...]`` placeholder.
+    """
+    from pydantic_ai import DocumentUrl
+
+    # Legacy binary carrying an audio mime with a url source.
+    out = _rewrite_part_for_model(
+        {
+            "type": "binary",
+            "mimeType": "audio/mpeg",
+            "url": "https://example.com/voice.mp3",
+        }
+    )
+    assert not isinstance(out, DocumentUrl), (
+        "an audio url must NOT be emitted as a DocumentUrl"
+    )
+    assert isinstance(out, str)
+    assert "[Attached" in out
+
+    # Modern document part carrying a video mime with a url source.
+    out2 = _rewrite_part_for_model(
+        DocumentInputContent(
+            type="document",
+            source=InputContentUrlSource(
+                type="url",
+                value="https://example.com/clip.mp4",
+                mime_type="video/mp4",
+            ),
+        )
+    )
+    assert not isinstance(out2, DocumentUrl), (
+        "a video url document must NOT be emitted as a DocumentUrl"
+    )
+    assert isinstance(out2, str)
+    assert "[Attached" in out2
+
+
+def test_url_real_document_still_document_url():
+    """The supported-type gate must NOT over-degrade a genuine non-PDF document
+    URL the model CAN fetch (e.g. a plain-text or office document): it still
+    emits a ``DocumentUrl`` so the model can fetch it."""
+    from pydantic_ai import DocumentUrl
+
+    out = _rewrite_part_for_model(
+        DocumentInputContent(
+            type="document",
+            source=InputContentUrlSource(
+                type="url",
+                value="https://example.com/report.docx",
+                mime_type=(
+                    "application/vnd.openxmlformats-officedocument."
+                    "wordprocessingml.document"
+                ),
+            ),
+        )
+    )
+    assert isinstance(out, DocumentUrl), (
+        "a fetchable document url should still emit a DocumentUrl"
+    )
+    assert out.url == "https://example.com/report.docx"
+
+
+def test_unsupported_image_binary_data_degrades_at_choke_point():
+    """GAP (b/F3) — an unsupported image subtype that reaches the ``other`` DATA
+    branch as a ``BinaryContent`` (``binary.is_image`` true, e.g. HEIC) must
+    DEGRADE at the emission choke point, not be emitted as a rejected image
+    binary.
+
+    Exercises the choke-point gate directly via a legacy binary dict whose mime
+    is an unsupported image subtype but is NOT routed through the ``image`` kind
+    (it is — so to hit the ``other`` BinaryContent path we rely on the choke
+    point catching ``binary.is_image`` for an unsupported subtype). With the
+    consolidated gate, NO unsupported image subtype is ever emitted as a native
+    image, regardless of routing.
+    """
+    # A heic data binary: even if a future routing change sent it to the
+    # BinaryContent path, the choke point must degrade it (not emit a rejected
+    # image binary). Today it routes via kind=="image" and degrades there; the
+    # assertion is the invariant: never a native image type for heic.
+    out = _rewrite_part_for_model(
+        {
+            "type": "binary",
+            "mimeType": "image/heic",
+            "data": _PNG_B64,
+        }
+    )
+    assert not isinstance(out, (ImageUrl, BinaryContent)), (
+        "an unsupported image subtype must never be emitted as a native image"
+    )
+    assert isinstance(out, str)
+    assert "[Attached image" in out


### PR DESCRIPTION
## Summary
The pydantic-ai showcase integration crashed with `assert_never` in pydantic-ai's `_map_user_prompt` whenever AG-UI multimodal `InputContent` (images / documents / binary, data: and url: sources) reached the model — AG-UI content types were never normalized to the native pydantic-ai types (`str` / `ImageUrl` / `BinaryContent` / `DocumentUrl`) the mapper requires.

## What changed
- **`_MultimodalFlattenModel(WrapperModel)`** normalizes content at the **model-call boundary** (overriding `request` / `request_stream` / `count_tokens`) — deliberately NOT a `history_processor`, because that hook persists its return into `message_history` and would leak flattened content back to the UI.
- **Supported-type gating + degrade centralized at the single native-type emission choke point** (instead of scattered per-content-branch): unsupported image subtypes (HEIC/SVG/TIFF/BMP), audio/video, and non-fetchable url attachments degrade to a text placeholder rather than emitting a native type the OpenAI Responses vision API rejects (which would fail the turn).
- **Mime normalized once** — strips RFC-2045 params/whitespace, lowercases, and aliases the common non-canonical `image/jpg` → `image/jpeg` before the allow-list (png/jpeg/gif/webp) test, so real JPEGs are no longer silently dropped.
- Identity-based (`is`) no-op detection replaces fragile structural `==`.

## Why it matters
Unblocks multimodal turns in the pydantic-ai showcase integration; eliminates the `assert_never` crash and stops valid `image/jpg` JPEGs and url-borne documents from being silently mishandled.

## Testing
- **43 unit tests** (clean pinned venv, pydantic-ai 1.0.18), red-green proven per gap: `image/jpg` forwarded as a supported JPEG; url-media / non-PDF-doc degrade instead of emitting an unconditional `DocumentUrl`; parameterized mime forwarded; state-leak guard (`request_stream` forwards flattened, not raw); `count_tokens` override; `assert_never` provably unreachable (all flatten paths return a native type or raise).
- 9 rounds of code review (7 agents/round) to a clean confirmation round (zero blocking findings).

## Test plan
- [ ] CI green