### PR TITLE
fix(showcase/google-adk): all 39 in-matrix D6 cells green — restore post-tool re-invoke loop

### DIFF
--- a/showcase/aimock/d6/google-adk/gen-ui-interrupt.json
+++ b/showcase/aimock/d6/google-adk/gen-ui-interrupt.json
@@ -1,15 +1,26 @@
 {
   "_meta": {
-    "description": "D6 fixtures for google-adk / gen-ui-interrupt. Strategy-B scheduling flow (no LangGraph interrupt()): each pill is a 2-leg round-trip — leg 1 (hasToolResult:false) returns a `schedule_meeting` tool call routed to the frontend useHumanInTheLoop picker; leg 2 (toolCallId after the user picks a slot) returns the confirmation narration. toolCallIds (call_d5_schedule_sales_001 / _alice_001) match the shared d5 contract. Cribbed from the orphaned schedule_meeting entries previously parked in hitl-in-chat.json (that demo uses book_call).",
+    "description": "D6 fixtures for google-adk / gen-ui-interrupt. Strategy-B scheduling flow (no LangGraph interrupt()): each pill is a 2-leg round-trip — an emit leg returns a `schedule_meeting` tool call routed to the frontend useHumanInTheLoop picker; a narration leg (gated on that call's toolCallId) returns the confirmation after the user picks a slot. The narration (toolCallId) leg is ordered BEFORE the emit leg so it wins once the pill's own tool result is the last message, and the emit leg matches on userMessage+toolName only — NOT hasToolResult, which is thread-global and would wrongly fail the second pill once an earlier pill left a tool result in history (the alice pill 503'd that way). toolCallIds (call_d5_schedule_sales_001 / _alice_001) match the shared d5 contract.",
     "sourceFile": "d5-all.json",
     "created": "2026-06-08"
   },
   "fixtures": [
     {
+      "_comment": "sales pill — narration leg: after the user picks a slot, the sales tool result is the last message. Ordered before the emit leg so it wins on the post-pick turn.",
+      "match": {
+        "userMessage": "intro call with the sales team",
+        "toolCallId": "call_d5_schedule_sales_001",
+        "context": "google-adk"
+      },
+      "response": {
+        "content": "Booked: Sales intro call confirmed for the slot you picked."
+      }
+    },
+    {
+      "_comment": "sales pill — emit leg: userMessage+toolName only (no hasToolResult gate). The narration leg above already claims the post-pick turn via toolCallId, so this only fires on the initial request.",
       "match": {
         "userMessage": "intro call with the sales team",
         "toolName": "schedule_meeting",
-        "hasToolResult": false,
         "context": "google-adk"
       },
       "response": {
@@ -36,20 +47,21 @@
       }
     },
     {
+      "_comment": "alice pill — narration leg: gated on the alice tool result's toolCallId. Ordered before the emit leg.",
       "match": {
-        "userMessage": "intro call with the sales team",
-        "toolCallId": "call_d5_schedule_sales_001",
+        "userMessage": "1:1 with Alice",
+        "toolCallId": "call_d5_schedule_alice_001",
         "context": "google-adk"
       },
       "response": {
-        "content": "Booked: Sales intro call confirmed for the slot you picked."
+        "content": "Scheduled: 1:1 with Alice locked in for the slot you picked."
       }
     },
     {
+      "_comment": "alice pill — emit leg: userMessage+toolName only. Previously gated hasToolResult:false, which failed once the sales pill left a tool result in the thread (hasToolResult became true) -> 503 -> time-picker-card never mounted.",
       "match": {
         "userMessage": "1:1 with Alice",
         "toolName": "schedule_meeting",
-        "hasToolResult": false,
         "context": "google-adk"
       },
       "response": {
@@ -73,16 +85,6 @@
             "id": "call_d5_schedule_alice_001"
           }
         ]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "1:1 with Alice",
-        "toolCallId": "call_d5_schedule_alice_001",
-        "context": "google-adk"
-      },
-      "response": {
-        "content": "Scheduled: 1:1 with Alice locked in for the slot you picked."
       }
     }
   ]

--- a/showcase/integrations/google-adk/entrypoint.sh
+++ b/showcase/integrations/google-adk/entrypoint.sh
@@ -12,19 +12,20 @@ trap cleanup EXIT
 # exits, by which point the container is already gone.
 export PYTHONUNBUFFERED=1
 
-# Disable Google ADK's progressive SSE streaming feature. With it enabled,
-# Gemini 3.1 Flash-Lite occasionally returns a stream whose final event is flagged
-# `partial`, which the ADK flow aborts with a "The last event is partial"
-# warning — the backend then emits no TOOL_CALL_* or TEXT_MESSAGE_* events,
-# so the tool-rendering UI is stranded and L4 smoke tests intermittently fail.
-# With it OFF the ADK falls back to simple text accumulation and always
-# produces a coherent final response.
-#
-# This env var is belt-and-suspenders with `simple_after_model_modifier` in
-# `src/agents/main.py`, which carries an in-callback partial-event guard. The
-# env var is the primary (operator-level, ADK-wide) workaround; the callback
-# guard runs regardless. Both layers are intentional.
-export ADK_DISABLE_PROGRESSIVE_SSE_STREAMING=1
+# NOTE: ADK_DISABLE_PROGRESSIVE_SSE_STREAMING was previously exported here to
+# dodge an intermittent "The last event is partial" abort on the tool-rendering
+# demos. But disabling progressive streaming ALSO suppresses ADK's
+# post-backend-tool LLM re-invocation: after a backend function tool (or a
+# sub-agent delegation) returns, ADK's non-progressive aggregation path ends the
+# agentic loop instead of re-invoking the model with the tool result appended.
+# That broke every demo that needs a second turn after a tool result — the
+# subagents chain (research -> writing -> critique), tool-rendering-reasoning-chain
+# (AAPL -> MSFT), shared-state-read-write's confirmation, the custom-catchall
+# narration, and headless-complete's per-turn completion. The partial-event
+# abort it guarded against is already handled in-callback by `stop_on_terminal_text`
+# (shared by every registered agent), so progressive streaming is left ON.
+# (Do not re-add this flag without a per-agent feature override that keeps
+# progressive streaming ON for the backend-tool / sub-agent chain agents.)
 
 echo "========================================="
 echo "[entrypoint] Starting showcase package: google-adk"

--- a/showcase/integrations/google-adk/manifest.yaml
+++ b/showcase/integrations/google-adk/manifest.yaml
@@ -71,7 +71,6 @@ not_supported_features:
   - interrupt-headless
   - reasoning-default-render
   - agentic-chat-reasoning
-  - tool-rendering-reasoning-chain
 a2ui_pattern: schema-loading
 agent_config_pattern: shared-state
 auth_pattern: runtime-onrequest

--- a/showcase/integrations/google-adk/src/agents/headless_complete_agent.py
+++ b/showcase/integrations/google-adk/src/agents/headless_complete_agent.py
@@ -7,16 +7,20 @@ ADK: three mock backend tools (`get_weather`, `get_stock_price`,
 rules so the LLM picks the matching tool per pill.
 
 The frontend also registers a `highlight_note` *frontend* tool via
-`useComponent`, which the LLM may emit a tool_call for; that call flows
-through the AG-UI tool surface and is executed in the browser (no
-backend Python is required for that one, so it's not in the tools list
-here — same shape as langgraph-python).
+`useComponent`, executed in the browser. Unlike langgraph-python (where
+CopilotKit auto-injects frontend tools into the graph), ADK only exposes
+and routes frontend-registered tools when the agent includes
+`AGUIToolset()` in its `tools` list. Without it the model emits a
+`highlight_note` call that the backend tool registry rejects ("Tool
+'highlight_note' not found"), aborting the run — so `AGUIToolset()` is
+required here alongside the three backend tools.
 """
 
 from __future__ import annotations
 
 from google.adk.agents import LlmAgent
 from google.adk.tools import ToolContext
+from ag_ui_adk import AGUIToolset
 
 from agents.shared_chat import get_model, stop_on_terminal_text
 
@@ -104,6 +108,6 @@ headless_complete_agent = LlmAgent(
     name="HeadlessCompleteAgent",
     model=get_model(),
     instruction=_INSTRUCTION,
-    tools=[get_weather, get_stock_price, get_revenue_chart],
+    tools=[get_weather, get_stock_price, get_revenue_chart, AGUIToolset()],
     after_model_callback=stop_on_terminal_text,
 )


### PR DESCRIPTION
## What

Fixes the 6 remaining red D6 cells for the **google-adk** showcase integration, bringing it to **39/39 on the D6 matrix** (under aimock replay, reproduced across two independent full-matrix runs, no in-matrix regression). See the scope/caveats section before reading this as "fully done."

## Root cause + changes

**1. `entrypoint.sh` — remove `ADK_DISABLE_PROGRESSIVE_SSE_STREAMING=1` (the big one).**
A/B tested in-container: with the flag set, ADK's non-progressive aggregation path ends the agentic loop after the first tool round — no post-tool LLM re-invoke. That broke every demo needing a second turn after a tool result:
- `subagents` (research → writing → critique never chained past research)
- `tool-rendering-reasoning-chain` (AAPL → MSFT)
- `shared-state-read-write` (the post-`set_notes` confirmation text)
- `tool-rendering-custom-catchall` (the post-tool narration)

The flag was added to dodge an intermittent "last event is partial" abort on tool-rendering; the in-callback `stop_on_terminal_text` guard (shared by every agent) is intended to cover that. See caveat 1 — that guard's sufficiency is verified under aimock only, not against real Gemini.

**2. `manifest.yaml` — un-skip-list `tool-rendering-reasoning-chain`.** It was marked `not_supported` (vacuous-green) only because of the loop gap; it passes now.

**3. `headless_complete_agent.py` — add `AGUIToolset()`.** Removing the flag unmasked a pre-existing gap: the frontend `highlight_note` tool was never injected/routed, so turn 3 dispatched it server-side and the backend registry rejected it (`Tool 'highlight_note' not found`). langgraph-python auto-injects frontend tools; ADK needs `AGUIToolset()` in the agent's `tools` list (every other frontend-tool google-adk agent has it).

**4. `aimock/d6/google-adk/gen-ui-interrupt.json` — re-key.** The alice pill 503'd: its emit leg was gated `hasToolResult:false`, but the earlier sales pill leaves a tool result in the thread (thread-global). Re-ordered each pill's narration (`toolCallId`) leg before its emit leg and dropped the `hasToolResult` gate, mirroring the reasoning-chain fixture pattern.

## Verification

`showcase test google-adk --d6 --isolate` (full per-pill matrix), run twice on separate isolated stacks:
- Both: `passed=39, failed=0, total=39, state=green`.
- The 6 previously-red cells all pass: shared-state-write, tool-rendering-custom-catchall, subagents, tool-rendering-reasoning-chain, gen-ui-interrupt (sales + alice), gen-ui-headless-complete.
- No regression: all previously-passing cells (incl. all `tool-rendering*` and A2UI: gen-ui-declarative, gen-ui-a2ui-fixed, beautiful-chat) stay green.

## Scope and caveats (read before merging)

1. **The flag removal is verified under aimock only, NOT against real Gemini.** `ADK_DISABLE_PROGRESSIVE_SSE_STREAMING=1` was originally added for a *real-Gemini intermittent* "last event is partial" abort. D6 is deterministic aimock replay and cannot reproduce that intermittent condition, so the "0 partial-aborts" result does not prove the `stop_on_terminal_text` guard is sufficient against real Gemini. There is a real (unmeasured) risk this re-introduces the partial-abort on real-LLM tool-rendering runs. Recommend a real-Gemini smoke of the tool-rendering demos before relying on this in a real-LLM context.
2. **"39/39" is the in-matrix set, not every feature.** Three features remain `not_supported` and are excluded from the matrix (not fixed): `interrupt-headless`, `reasoning-default-render`, `agentic-chat-reasoning`.
3. **Local verification only.** D6 is not CI-gated for google-adk; evidence is two isolate runs on one machine, not an independent CI signal.
