### PR TITLE
feat(angular): Add injectThreads shared thread store API

### DIFF
--- a/packages/angular/src/lib/copilotkit.ts
+++ b/packages/angular/src/lib/copilotkit.ts
@@ -6,6 +6,8 @@ import {
   CopilotRuntimeTransport,
   type CopilotKitCoreGetSuggestionsResult,
   type SuggestionsConfig,
+  type IntelligenceRuntimeInfo,
+  type ThreadEndpointRuntimeInfo,
 } from "@copilotkit/core";
 import {
   Injectable,
@@ -78,6 +80,14 @@ export class CopilotKit {
   readonly runtimeTransport = this.#runtimeTransport.asReadonly();
   readonly #headers = signal<Record<string, string>>({});
   readonly headers = this.#headers.asReadonly();
+  readonly #intelligence = signal<IntelligenceRuntimeInfo | undefined>(
+    undefined,
+  );
+  readonly intelligence = this.#intelligence.asReadonly();
+  readonly #threadEndpoints = signal<ThreadEndpointRuntimeInfo | undefined>(
+    undefined,
+  );
+  readonly threadEndpoints = this.#threadEndpoints.asReadonly();
   readonly #suggestionsByAgent = signal<
     Record<string, CopilotKitCoreGetSuggestionsResult>
   >({});
@@ -146,6 +156,8 @@ export class CopilotKit {
     this.#runtimeUrl.set(this.core.runtimeUrl);
     this.#runtimeTransport.set(this.core.runtimeTransport);
     this.#headers.set(this.core.headers);
+    this.#intelligence.set(this.core.intelligence);
+    this.#threadEndpoints.set(this.core.threadEndpoints);
     this.#config.renderToolCalls?.forEach((renderConfig) => {
       this.addRenderToolCall(renderConfig);
     });
@@ -178,6 +190,8 @@ export class CopilotKit {
       },
       onRuntimeConnectionStatusChanged: ({ status }) => {
         this.#runtimeConnectionStatus.set(status);
+        this.#intelligence.set(this.core.intelligence);
+        this.#threadEndpoints.set(this.core.threadEndpoints);
         this.#syncBuiltInActivityMessageRenderers();
         this.#syncBuiltInOpenGenerativeUI();
       },

--- a/packages/angular/src/lib/threads.spec.ts
+++ b/packages/angular/src/lib/threads.spec.ts
@@ -1,0 +1,294 @@
+import { Component, signal } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import {
+  CopilotKitCoreRuntimeConnectionStatus,
+  type ThreadEndpointRuntimeInfo,
+} from "@copilotkit/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CopilotKit } from "./copilotkit";
+import { injectThreads } from "./threads";
+import type { InjectThreadsResult } from "./threads";
+
+interface FetchCall {
+  input: RequestInfo | URL;
+  init?: RequestInit;
+}
+
+type QueuedFetch = typeof fetch & {
+  calls: FetchCall[];
+  enqueue(body: unknown | Promise<unknown>, status?: number): void;
+};
+
+const supportedThreadEndpoints: ThreadEndpointRuntimeInfo = {
+  list: true,
+  inspect: true,
+  mutations: true,
+  realtimeMetadata: true,
+};
+
+const sampleThreads = [
+  {
+    id: "thread-1",
+    organizationId: "org-1",
+    agentId: "agent-1",
+    createdById: "user-1",
+    name: "Thread One",
+    archived: false,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+];
+
+const ignoreDeferredResolution = (): void => {};
+
+class CopilotKitThreadsStub {
+  readonly #runtimeConnectionStatus = signal(
+    CopilotKitCoreRuntimeConnectionStatus.Connected,
+  );
+  readonly #runtimeUrl = signal<string | undefined>(
+    "https://runtime.example.com",
+  );
+  readonly #headers = signal<Record<string, string>>({
+    Authorization: "Bearer token",
+  });
+  readonly #intelligence = signal<{ wsUrl: string } | undefined>(undefined);
+  readonly #threadEndpoints = signal<ThreadEndpointRuntimeInfo | undefined>(
+    supportedThreadEndpoints,
+  );
+
+  readonly runtimeConnectionStatus = this.#runtimeConnectionStatus.asReadonly();
+  readonly runtimeUrl = this.#runtimeUrl.asReadonly();
+  readonly headers = this.#headers.asReadonly();
+  readonly intelligence = this.#intelligence.asReadonly();
+  readonly threadEndpoints = this.#threadEndpoints.asReadonly();
+  readonly core = {
+    registerThreadStore: vi.fn(),
+    unregisterThreadStore: vi.fn(),
+  };
+
+  setRuntimeUrl(runtimeUrl: string | undefined): void {
+    this.#runtimeUrl.set(runtimeUrl);
+  }
+}
+
+function createQueuedFetch(): QueuedFetch {
+  const calls: FetchCall[] = [];
+  const queue: Array<{ body: unknown | Promise<unknown>; status: number }> = [];
+  const fetchImpl = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    calls.push({ input, init });
+    const next = queue.shift() ?? { body: {}, status: 200 };
+    const body = await next.body;
+    return new Response(JSON.stringify(body), {
+      status: next.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  return Object.assign(fetchImpl, {
+    calls,
+    enqueue(body: unknown | Promise<unknown>, status = 200): void {
+      queue.push({ body, status });
+    },
+  });
+}
+
+function deferredFetchBody() {
+  let resolve: (body: unknown) => void = ignoreDeferredResolution;
+  const promise = new Promise<unknown>((resolver) => {
+    resolve = resolver;
+  });
+  return { promise, resolve };
+}
+
+async function waitForCondition(assertion: () => void): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+  throw lastError;
+}
+
+describe("injectThreads", () => {
+  let copilotKit: CopilotKitThreadsStub;
+  let fetchMock: QueuedFetch;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    fetchMock = createQueuedFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    copilotKit = new CopilotKitThreadsStub();
+    TestBed.configureTestingModule({
+      providers: [{ provide: CopilotKit, useValue: copilotKit }],
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches static input threads and exposes Angular signals", async () => {
+    fetchMock.enqueue({ threads: sampleThreads });
+
+    @Component({
+      standalone: true,
+      template: "",
+    })
+    class HostComponent {
+      readonly threads = injectThreads({ agentId: "agent-1" });
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    const result = fixture.componentInstance.threads;
+
+    expect(typeof result.threads).toBe("function");
+    expect(typeof result.isLoading).toBe("function");
+    expect(typeof result.error).toBe("function");
+
+    await waitForCondition(() => {
+      expect(result.isLoading()).toBe(false);
+      expect(result.threads()).toHaveLength(1);
+    });
+
+    expect(fetchMock.calls[0]?.input).toBe(
+      "https://runtime.example.com/threads?agentId=agent-1",
+    );
+    expect(result.threads()[0]).toEqual({
+      id: "thread-1",
+      agentId: "agent-1",
+      name: "Thread One",
+      archived: false,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    });
+  });
+
+  it("resets immediately and refetches when signal inputs change", async () => {
+    const secondFetch = deferredFetchBody();
+    fetchMock.enqueue({ threads: sampleThreads });
+    fetchMock.enqueue(secondFetch.promise);
+    const agentId = signal<string | undefined>("agent-1");
+
+    @Component({
+      standalone: true,
+      template: "",
+    })
+    class HostComponent {
+      readonly threads = injectThreads({ agentId });
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    const result = fixture.componentInstance.threads;
+
+    await waitForCondition(() => {
+      expect(result.threads().map((thread) => thread.id)).toEqual(["thread-1"]);
+    });
+
+    agentId.set("agent-2");
+
+    await waitForCondition(() => {
+      expect(result.isLoading()).toBe(true);
+      expect(result.threads()).toEqual([]);
+    });
+
+    secondFetch.resolve({
+      threads: [{ ...sampleThreads[0], id: "thread-2", agentId: "agent-2" }],
+    });
+
+    await waitForCondition(() => {
+      expect(result.isLoading()).toBe(false);
+      expect(result.threads().map((thread) => thread.id)).toEqual(["thread-2"]);
+    });
+  });
+
+  it("forwards mutation methods to the shared store and returns promises", async () => {
+    fetchMock.enqueue({ threads: sampleThreads });
+    fetchMock.enqueue({});
+
+    @Component({
+      standalone: true,
+      template: "",
+    })
+    class HostComponent {
+      readonly threads = injectThreads({ agentId: "agent-1" });
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    const result = fixture.componentInstance.threads;
+
+    await waitForCondition(() => {
+      expect(result.threads()).toHaveLength(1);
+    });
+
+    await result.renameThread("thread-1", "Renamed");
+
+    const renameCall = fetchMock.calls.find(
+      (call) =>
+        call.input === "https://runtime.example.com/threads/thread-1" &&
+        call.init?.method === "PATCH",
+    );
+    expect(renameCall).toBeDefined();
+    expect(renameCall?.init?.body).toBe(
+      JSON.stringify({ agentId: "agent-1", name: "Renamed" }),
+    );
+  });
+
+  it("unregisters and stops the store when the injection context is destroyed", async () => {
+    fetchMock.enqueue({ threads: sampleThreads });
+
+    @Component({
+      standalone: true,
+      template: "",
+    })
+    class HostComponent {
+      readonly threads: InjectThreadsResult = injectThreads({
+        agentId: "agent-1",
+      });
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+
+    await waitForCondition(() => {
+      expect(copilotKit.core.registerThreadStore).toHaveBeenCalledWith(
+        "agent-1",
+        expect.objectContaining({ stop: expect.any(Function) }),
+      );
+    });
+
+    fixture.destroy();
+
+    expect(copilotKit.core.unregisterThreadStore).toHaveBeenCalledWith(
+      "agent-1",
+    );
+  });
+
+  it("surfaces Enterprise Intelligence configuration errors visibly", async () => {
+    copilotKit.setRuntimeUrl(undefined);
+
+    @Component({
+      standalone: true,
+      template: "",
+    })
+    class HostComponent {
+      readonly threads = injectThreads({ agentId: "agent-1" });
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    const result = fixture.componentInstance.threads;
+
+    await waitForCondition(() => {
+      expect(result.isLoading()).toBe(false);
+      expect(result.threads()).toEqual([]);
+      expect(result.error()?.message).toBe("Runtime URL is not configured");
+    });
+    expect(fetchMock.calls).toHaveLength(0);
+  });
+});

--- a/packages/angular/src/lib/threads.spec.ts
+++ b/packages/angular/src/lib/threads.spec.ts
@@ -69,6 +69,18 @@ class CopilotKitThreadsStub {
   setRuntimeUrl(runtimeUrl: string | undefined): void {
     this.#runtimeUrl.set(runtimeUrl);
   }
+
+  setRuntimeConnectionStatus(
+    runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus,
+  ): void {
+    this.#runtimeConnectionStatus.set(runtimeConnectionStatus);
+  }
+
+  setThreadEndpoints(
+    threadEndpoints: ThreadEndpointRuntimeInfo | undefined,
+  ): void {
+    this.#threadEndpoints.set(threadEndpoints);
+  }
 }
 
 function createQueuedFetch(): QueuedFetch {
@@ -290,5 +302,67 @@ describe("injectThreads", () => {
       expect(result.error()?.message).toBe("Runtime URL is not configured");
     });
     expect(fetchMock.calls).toHaveLength(0);
+  });
+
+  it("surfaces runtime info failures with a configured runtime URL visibly", async () => {
+    copilotKit.setRuntimeConnectionStatus(
+      CopilotKitCoreRuntimeConnectionStatus.Error,
+    );
+
+    @Component({
+      standalone: true,
+      template: "",
+    })
+    class HostComponent {
+      readonly threads = injectThreads({ agentId: "agent-1" });
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    const result = fixture.componentInstance.threads;
+
+    await waitForCondition(() => {
+      expect(result.isLoading()).toBe(false);
+      expect(result.threads()).toEqual([]);
+      expect(result.error()?.message).toBe(
+        "CopilotKit runtime info is unavailable",
+      );
+    });
+    expect(fetchMock.calls).toHaveLength(0);
+  });
+
+  it("does not refetch or reset threads for mutation-only endpoint capability changes", async () => {
+    fetchMock.enqueue({ threads: sampleThreads });
+
+    @Component({
+      standalone: true,
+      template: "",
+    })
+    class HostComponent {
+      readonly threads = injectThreads({ agentId: "agent-1" });
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    const result = fixture.componentInstance.threads;
+
+    await waitForCondition(() => {
+      expect(result.threads()).toHaveLength(1);
+    });
+
+    copilotKit.setThreadEndpoints({
+      list: true,
+      inspect: true,
+      mutations: false,
+      realtimeMetadata: true,
+    });
+    fixture.detectChanges();
+
+    await waitForCondition(() => {
+      expect(fetchMock.calls).toHaveLength(1);
+      expect(result.threads()).toHaveLength(1);
+    });
+
+    await expect(result.renameThread("thread-1", "Renamed")).rejects.toThrow(
+      "Thread mutations are not available on this CopilotKit runtime",
+    );
   });
 });

--- a/packages/angular/src/lib/threads.spec.ts
+++ b/packages/angular/src/lib/threads.spec.ts
@@ -115,6 +115,10 @@ function deferredFetchBody() {
   return { promise, resolve };
 }
 
+function threadIds(result: InjectThreadsResult): string[] {
+  return result.threads().map((thread) => thread.id);
+}
+
 async function waitForCondition(assertion: () => void): Promise<void> {
   let lastError: unknown;
   for (let attempt = 0; attempt < 30; attempt += 1) {
@@ -327,8 +331,62 @@ describe("injectThreads", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(result.isLoading()).toBe(false);
-    expect(result.threads().map((thread) => thread.id)).toEqual(["thread-1"]);
+    expect(threadIds(result)).toEqual(["thread-1"]);
     expect(fetchMock.calls).toHaveLength(1);
+  });
+
+  it("clears fetched threads without refetching when inputs change during transient reconnects", async () => {
+    fetchMock.enqueue({ threads: sampleThreads });
+    fetchMock.enqueue({
+      threads: [{ ...sampleThreads[0], id: "thread-2", archived: true }],
+    });
+    const includeArchived = signal<boolean | undefined>(false);
+
+    @Component({
+      standalone: true,
+      template: "",
+    })
+    class HostComponent {
+      readonly threads = injectThreads({
+        agentId: "agent-1",
+        includeArchived,
+      });
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    const result = fixture.componentInstance.threads;
+
+    await waitForCondition(() => {
+      expect(result.isLoading()).toBe(false);
+      expect(threadIds(result)).toEqual(["thread-1"]);
+    });
+
+    copilotKit.setRuntimeConnectionStatus(
+      CopilotKitCoreRuntimeConnectionStatus.Connecting,
+    );
+    fixture.detectChanges();
+
+    includeArchived.set(true);
+    fixture.detectChanges();
+
+    await waitForCondition(() => {
+      expect(result.threads()).toEqual([]);
+      expect(result.isLoading()).toBe(true);
+    });
+    expect(fetchMock.calls).toHaveLength(1);
+
+    copilotKit.setRuntimeConnectionStatus(
+      CopilotKitCoreRuntimeConnectionStatus.Connected,
+    );
+    fixture.detectChanges();
+
+    await waitForCondition(() => {
+      expect(result.isLoading()).toBe(false);
+      expect(threadIds(result)).toEqual(["thread-2"]);
+    });
+    expect(fetchMock.calls[1]?.input).toBe(
+      "https://runtime.example.com/threads?agentId=agent-1&includeArchived=true",
+    );
   });
 
   it("unregisters and stops the store when the injection context is destroyed", async () => {

--- a/packages/angular/src/lib/threads.spec.ts
+++ b/packages/angular/src/lib/threads.spec.ts
@@ -224,6 +224,7 @@ describe("injectThreads", () => {
   it("forwards mutation methods to the shared store and returns promises", async () => {
     fetchMock.enqueue({ threads: sampleThreads });
     fetchMock.enqueue({});
+    fetchMock.enqueue({});
 
     @Component({
       standalone: true,
@@ -251,6 +252,83 @@ describe("injectThreads", () => {
     expect(renameCall?.init?.body).toBe(
       JSON.stringify({ agentId: "agent-1", name: "Renamed" }),
     );
+
+    await result.unarchiveThread("thread-1");
+
+    const unarchiveCall = fetchMock.calls.find(
+      (call) =>
+        call.input === "https://runtime.example.com/threads/thread-1" &&
+        call.init?.method === "PATCH" &&
+        call.init.body ===
+          JSON.stringify({ agentId: "agent-1", archived: false }),
+    );
+    expect(unarchiveCall).toBeDefined();
+  });
+
+  it("shows loading before the runtime connects without fetching threads", async () => {
+    copilotKit.setRuntimeConnectionStatus(
+      CopilotKitCoreRuntimeConnectionStatus.Connecting,
+    );
+    fetchMock.enqueue({ threads: sampleThreads });
+
+    @Component({
+      standalone: true,
+      template: "",
+    })
+    class HostComponent {
+      readonly threads = injectThreads({ agentId: "agent-1" });
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    const result = fixture.componentInstance.threads;
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fetchMock.calls).toHaveLength(0);
+    expect(result.isLoading()).toBe(true);
+    expect(result.threads()).toEqual([]);
+
+    copilotKit.setRuntimeConnectionStatus(
+      CopilotKitCoreRuntimeConnectionStatus.Connected,
+    );
+    fixture.detectChanges();
+
+    await waitForCondition(() => {
+      expect(result.isLoading()).toBe(false);
+      expect(result.threads()).toHaveLength(1);
+    });
+    expect(fetchMock.calls).toHaveLength(1);
+  });
+
+  it("preserves fetched threads during transient runtime reconnects", async () => {
+    fetchMock.enqueue({ threads: sampleThreads });
+
+    @Component({
+      standalone: true,
+      template: "",
+    })
+    class HostComponent {
+      readonly threads = injectThreads({ agentId: "agent-1" });
+    }
+
+    const fixture = TestBed.createComponent(HostComponent);
+    const result = fixture.componentInstance.threads;
+
+    await waitForCondition(() => {
+      expect(result.isLoading()).toBe(false);
+      expect(result.threads().map((thread) => thread.id)).toEqual(["thread-1"]);
+    });
+
+    copilotKit.setRuntimeConnectionStatus(
+      CopilotKitCoreRuntimeConnectionStatus.Connecting,
+    );
+    fixture.detectChanges();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(result.isLoading()).toBe(false);
+    expect(result.threads().map((thread) => thread.id)).toEqual(["thread-1"]);
+    expect(fetchMock.calls).toHaveLength(1);
   });
 
   it("unregisters and stops the store when the injection context is destroyed", async () => {

--- a/packages/angular/src/lib/threads.ts
+++ b/packages/angular/src/lib/threads.ts
@@ -51,6 +51,14 @@ type StaticSignalValue = string | boolean | number | undefined;
 
 const EMPTY_HEADERS: Record<string, string> = {};
 
+interface ThreadListInputIdentity {
+  agentId: string;
+  runtimeUrl: string | undefined;
+  headers: Record<string, string>;
+  includeArchived: boolean | undefined;
+  limit: number | undefined;
+}
+
 function toInputSignal<T extends StaticSignalValue>(
   value: T | Signal<T>,
 ): Signal<T> {
@@ -79,6 +87,19 @@ function toPublicThread({
     updatedAt,
     ...(lastRunAt !== undefined ? { lastRunAt } : {}),
   };
+}
+
+function hasSameThreadListInputIdentity(
+  context: ɵThreadRuntimeContext,
+  identity: ThreadListInputIdentity,
+): boolean {
+  return (
+    context.agentId === identity.agentId &&
+    context.runtimeUrl === identity.runtimeUrl &&
+    context.headers === identity.headers &&
+    context.includeArchived === identity.includeArchived &&
+    context.limit === identity.limit
+  );
 }
 
 function bindSelector<T>(
@@ -185,12 +206,30 @@ export function injectThreads(input: InjectThreadsInput): InjectThreadsResult {
 
     const runtimeUrl = copilotKit.runtimeUrl();
     const runtimeConnectionStatus = copilotKit.runtimeConnectionStatus();
+    const resolvedHeaders = copilotKit.headers() ?? EMPTY_HEADERS;
+    const resolvedIncludeArchived = includeArchived();
+    const resolvedLimit = limit();
+
     if (
       runtimeUrl &&
       runtimeConnectionStatus !==
         CopilotKitCoreRuntimeConnectionStatus.Connected &&
       runtimeConnectionStatus !== CopilotKitCoreRuntimeConnectionStatus.Error
     ) {
+      if (
+        lastContext &&
+        !hasSameThreadListInputIdentity(lastContext, {
+          agentId: resolvedAgentId,
+          runtimeUrl,
+          headers: resolvedHeaders,
+          includeArchived: resolvedIncludeArchived,
+          limit: resolvedLimit,
+        })
+      ) {
+        store.setContext(null);
+        hasDispatchedContext.set(false);
+        lastContext = null;
+      }
       return;
     }
 
@@ -201,10 +240,10 @@ export function injectThreads(input: InjectThreadsInput): InjectThreadsResult {
     const context = resolveContext(
       resolvedAgentId,
       isRuntimeConnected ? runtimeUrl : undefined,
-      copilotKit.headers() ?? EMPTY_HEADERS,
+      resolvedHeaders,
       isRuntimeConnected ? copilotKit.intelligence()?.wsUrl : undefined,
-      includeArchived(),
-      limit(),
+      resolvedIncludeArchived,
+      resolvedLimit,
       copilotKit.threadEndpoints(),
       runtimeConnectionStatus,
     );

--- a/packages/angular/src/lib/threads.ts
+++ b/packages/angular/src/lib/threads.ts
@@ -1,0 +1,229 @@
+import type { Signal } from "@angular/core";
+import { DestroyRef, computed, effect, inject, signal } from "@angular/core";
+import {
+  CopilotKitCoreRuntimeConnectionStatus,
+  ɵcreateThreadStore,
+  ɵselectHasNextPage,
+  ɵselectIsFetchingNextPage,
+  ɵselectThreads,
+  ɵselectThreadsError,
+  ɵselectThreadsIsLoading,
+} from "@copilotkit/core";
+import type {
+  ThreadEndpointRuntimeInfo,
+  ɵThread,
+  ɵThreadRuntimeContext,
+  ɵThreadStore,
+} from "@copilotkit/core";
+import type { Subscription } from "rxjs";
+import { CopilotKit } from "./copilotkit";
+
+export interface InjectThreadsInput {
+  agentId: string | Signal<string | undefined>;
+  includeArchived?: boolean | Signal<boolean | undefined>;
+  limit?: number | Signal<number | undefined>;
+}
+
+export interface Thread {
+  id: string;
+  agentId: string;
+  name: string | null;
+  archived: boolean;
+  createdAt: string;
+  updatedAt: string;
+  lastRunAt?: string;
+}
+
+export interface InjectThreadsResult {
+  threads: Signal<Thread[]>;
+  isLoading: Signal<boolean>;
+  error: Signal<Error | null>;
+  hasMoreThreads: Signal<boolean>;
+  isFetchingMoreThreads: Signal<boolean>;
+  fetchMoreThreads: () => void;
+  renameThread: (threadId: string, name: string) => Promise<void>;
+  archiveThread: (threadId: string) => Promise<void>;
+  deleteThread: (threadId: string) => Promise<void>;
+}
+
+type StaticSignalValue = string | boolean | number | undefined;
+
+const EMPTY_HEADERS: Record<string, string> = {};
+
+function toInputSignal<T extends StaticSignalValue>(
+  value: T | Signal<T>,
+): Signal<T> {
+  if (typeof value === "function") {
+    return value;
+  }
+
+  return computed(() => value);
+}
+
+function sameThreadEndpoints(
+  left: ThreadEndpointRuntimeInfo | undefined,
+  right: ThreadEndpointRuntimeInfo | undefined,
+): boolean {
+  return (
+    left?.list === right?.list &&
+    left?.inspect === right?.inspect &&
+    left?.mutations === right?.mutations &&
+    left?.realtimeMetadata === right?.realtimeMetadata
+  );
+}
+
+function toPublicThread({
+  id,
+  agentId,
+  name,
+  archived,
+  createdAt,
+  updatedAt,
+  lastRunAt,
+}: ɵThread): Thread {
+  return {
+    id,
+    agentId,
+    name,
+    archived,
+    createdAt,
+    updatedAt,
+    ...(lastRunAt !== undefined ? { lastRunAt } : {}),
+  };
+}
+
+function bindSelector<T>(
+  store: ɵThreadStore,
+  selector: (state: ReturnType<ɵThreadStore["getState"]>) => T,
+  destroyRef: DestroyRef,
+): Signal<T> {
+  const value = signal(selector(store.getState()));
+  const subscription: Subscription = store
+    .select(selector)
+    .subscribe((next) => {
+      value.set(next);
+    });
+  destroyRef.onDestroy(() => {
+    subscription.unsubscribe();
+  });
+  return value.asReadonly();
+}
+
+export function injectThreads(input: InjectThreadsInput): InjectThreadsResult {
+  const copilotKit = inject(CopilotKit);
+  const destroyRef = inject(DestroyRef);
+  const agentId = toInputSignal(input.agentId);
+  const includeArchived = toInputSignal(input.includeArchived);
+  const limit = toInputSignal(input.limit);
+  const store = ɵcreateThreadStore({ fetch: globalThis.fetch });
+
+  store.start();
+  destroyRef.onDestroy(() => {
+    store.stop();
+  });
+
+  const coreThreads = bindSelector(store, ɵselectThreads, destroyRef);
+  const threads = computed(() => coreThreads().map(toPublicThread));
+  const isLoading = bindSelector(store, ɵselectThreadsIsLoading, destroyRef);
+  const error = bindSelector(store, ɵselectThreadsError, destroyRef);
+  const hasMoreThreads = bindSelector(store, ɵselectHasNextPage, destroyRef);
+  const isFetchingMoreThreads = bindSelector(
+    store,
+    ɵselectIsFetchingNextPage,
+    destroyRef,
+  );
+
+  let lastContext: ɵThreadRuntimeContext | null = null;
+
+  const resolveContext = (
+    resolvedAgentId: string,
+    runtimeUrl: string | undefined,
+    headers: Record<string, string>,
+    wsUrl: string | undefined,
+    resolvedIncludeArchived: boolean | undefined,
+    resolvedLimit: number | undefined,
+    threadEndpoints: ThreadEndpointRuntimeInfo | undefined,
+  ): ɵThreadRuntimeContext => {
+    if (
+      lastContext &&
+      lastContext.agentId === resolvedAgentId &&
+      lastContext.runtimeUrl === runtimeUrl &&
+      lastContext.headers === headers &&
+      lastContext.wsUrl === wsUrl &&
+      lastContext.includeArchived === resolvedIncludeArchived &&
+      lastContext.limit === resolvedLimit &&
+      sameThreadEndpoints(lastContext.threadEndpoints, threadEndpoints)
+    ) {
+      return lastContext;
+    }
+
+    lastContext = {
+      agentId: resolvedAgentId,
+      runtimeUrl,
+      headers,
+      wsUrl,
+      includeArchived: resolvedIncludeArchived,
+      limit: resolvedLimit,
+      threadEndpoints,
+    };
+    return lastContext;
+  };
+
+  effect(() => {
+    const resolvedAgentId = agentId();
+    if (!resolvedAgentId) {
+      store.setContext(null);
+      return;
+    }
+
+    const runtimeUrl = copilotKit.runtimeUrl();
+    const runtimeConnectionStatus = copilotKit.runtimeConnectionStatus();
+    if (
+      runtimeUrl &&
+      runtimeConnectionStatus !==
+        CopilotKitCoreRuntimeConnectionStatus.Connected
+    ) {
+      store.setContext(null);
+      return;
+    }
+
+    store.setContext(
+      resolveContext(
+        resolvedAgentId,
+        runtimeUrl,
+        copilotKit.headers() ?? EMPTY_HEADERS,
+        copilotKit.intelligence()?.wsUrl,
+        includeArchived(),
+        limit(),
+        copilotKit.threadEndpoints(),
+      ),
+    );
+  });
+
+  effect((onCleanup) => {
+    const resolvedAgentId = agentId();
+    if (!resolvedAgentId) {
+      return;
+    }
+
+    copilotKit.core.registerThreadStore(resolvedAgentId, store);
+    onCleanup(() => {
+      copilotKit.core.unregisterThreadStore(resolvedAgentId);
+    });
+  });
+
+  return {
+    threads,
+    isLoading,
+    error,
+    hasMoreThreads,
+    isFetchingMoreThreads,
+    fetchMoreThreads: () => {
+      store.fetchNextPage();
+    },
+    renameThread: (threadId: string, name: string) =>
+      store.renameThread(threadId, name),
+    archiveThread: (threadId: string) => store.archiveThread(threadId),
+    deleteThread: (threadId: string) => store.deleteThread(threadId),
+  };
+}

--- a/packages/angular/src/lib/threads.ts
+++ b/packages/angular/src/lib/threads.ts
@@ -60,18 +60,6 @@ function toInputSignal<T extends StaticSignalValue>(
   return computed(() => value);
 }
 
-function sameThreadEndpoints(
-  left: ThreadEndpointRuntimeInfo | undefined,
-  right: ThreadEndpointRuntimeInfo | undefined,
-): boolean {
-  return (
-    left?.list === right?.list &&
-    left?.inspect === right?.inspect &&
-    left?.mutations === right?.mutations &&
-    left?.realtimeMetadata === right?.realtimeMetadata
-  );
-}
-
 function toPublicThread({
   id,
   agentId,
@@ -143,6 +131,7 @@ export function injectThreads(input: InjectThreadsInput): InjectThreadsResult {
     resolvedIncludeArchived: boolean | undefined,
     resolvedLimit: number | undefined,
     threadEndpoints: ThreadEndpointRuntimeInfo | undefined,
+    runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus,
   ): ɵThreadRuntimeContext => {
     if (
       lastContext &&
@@ -151,9 +140,14 @@ export function injectThreads(input: InjectThreadsInput): InjectThreadsResult {
       lastContext.headers === headers &&
       lastContext.wsUrl === wsUrl &&
       lastContext.includeArchived === resolvedIncludeArchived &&
-      lastContext.limit === resolvedLimit &&
-      sameThreadEndpoints(lastContext.threadEndpoints, threadEndpoints)
+      lastContext.limit === resolvedLimit
     ) {
+      // Keep Angular context identity tied to the documented stable keys.
+      // Capability/status fields are live availability inputs consumed by
+      // the shared core; updating them in place lets core surface errors or
+      // reject mutations without an Angular-driven list reset/refetch.
+      lastContext.threadEndpoints = threadEndpoints;
+      lastContext.runtimeConnectionStatus = runtimeConnectionStatus;
       return lastContext;
     }
 
@@ -165,6 +159,7 @@ export function injectThreads(input: InjectThreadsInput): InjectThreadsResult {
       includeArchived: resolvedIncludeArchived,
       limit: resolvedLimit,
       threadEndpoints,
+      runtimeConnectionStatus,
     };
     return lastContext;
   };
@@ -181,21 +176,27 @@ export function injectThreads(input: InjectThreadsInput): InjectThreadsResult {
     if (
       runtimeUrl &&
       runtimeConnectionStatus !==
-        CopilotKitCoreRuntimeConnectionStatus.Connected
+        CopilotKitCoreRuntimeConnectionStatus.Connected &&
+      runtimeConnectionStatus !== CopilotKitCoreRuntimeConnectionStatus.Error
     ) {
       store.setContext(null);
       return;
     }
 
+    const isRuntimeConnected =
+      runtimeConnectionStatus ===
+      CopilotKitCoreRuntimeConnectionStatus.Connected;
+
     store.setContext(
       resolveContext(
         resolvedAgentId,
-        runtimeUrl,
+        isRuntimeConnected ? runtimeUrl : undefined,
         copilotKit.headers() ?? EMPTY_HEADERS,
-        copilotKit.intelligence()?.wsUrl,
+        isRuntimeConnected ? copilotKit.intelligence()?.wsUrl : undefined,
         includeArchived(),
         limit(),
         copilotKit.threadEndpoints(),
+        runtimeConnectionStatus,
       ),
     );
   });

--- a/packages/angular/src/lib/threads.ts
+++ b/packages/angular/src/lib/threads.ts
@@ -43,6 +43,7 @@ export interface InjectThreadsResult {
   fetchMoreThreads: () => void;
   renameThread: (threadId: string, name: string) => Promise<void>;
   archiveThread: (threadId: string) => Promise<void>;
+  unarchiveThread: (threadId: string) => Promise<void>;
   deleteThread: (threadId: string) => Promise<void>;
 }
 
@@ -104,6 +105,7 @@ export function injectThreads(input: InjectThreadsInput): InjectThreadsResult {
   const includeArchived = toInputSignal(input.includeArchived);
   const limit = toInputSignal(input.limit);
   const store = ɵcreateThreadStore({ fetch: globalThis.fetch });
+  const hasDispatchedContext = signal(false);
 
   store.start();
   destroyRef.onDestroy(() => {
@@ -112,7 +114,16 @@ export function injectThreads(input: InjectThreadsInput): InjectThreadsResult {
 
   const coreThreads = bindSelector(store, ɵselectThreads, destroyRef);
   const threads = computed(() => coreThreads().map(toPublicThread));
-  const isLoading = bindSelector(store, ɵselectThreadsIsLoading, destroyRef);
+  const storeIsLoading = bindSelector(
+    store,
+    ɵselectThreadsIsLoading,
+    destroyRef,
+  );
+  const isLoading = computed(
+    () =>
+      (!!agentId() && !!copilotKit.runtimeUrl() && !hasDispatchedContext()) ||
+      storeIsLoading(),
+  );
   const error = bindSelector(store, ɵselectThreadsError, destroyRef);
   const hasMoreThreads = bindSelector(store, ɵselectHasNextPage, destroyRef);
   const isFetchingMoreThreads = bindSelector(
@@ -168,6 +179,7 @@ export function injectThreads(input: InjectThreadsInput): InjectThreadsResult {
     const resolvedAgentId = agentId();
     if (!resolvedAgentId) {
       store.setContext(null);
+      hasDispatchedContext.set(false);
       return;
     }
 
@@ -179,7 +191,6 @@ export function injectThreads(input: InjectThreadsInput): InjectThreadsResult {
         CopilotKitCoreRuntimeConnectionStatus.Connected &&
       runtimeConnectionStatus !== CopilotKitCoreRuntimeConnectionStatus.Error
     ) {
-      store.setContext(null);
       return;
     }
 
@@ -187,18 +198,18 @@ export function injectThreads(input: InjectThreadsInput): InjectThreadsResult {
       runtimeConnectionStatus ===
       CopilotKitCoreRuntimeConnectionStatus.Connected;
 
-    store.setContext(
-      resolveContext(
-        resolvedAgentId,
-        isRuntimeConnected ? runtimeUrl : undefined,
-        copilotKit.headers() ?? EMPTY_HEADERS,
-        isRuntimeConnected ? copilotKit.intelligence()?.wsUrl : undefined,
-        includeArchived(),
-        limit(),
-        copilotKit.threadEndpoints(),
-        runtimeConnectionStatus,
-      ),
+    const context = resolveContext(
+      resolvedAgentId,
+      isRuntimeConnected ? runtimeUrl : undefined,
+      copilotKit.headers() ?? EMPTY_HEADERS,
+      isRuntimeConnected ? copilotKit.intelligence()?.wsUrl : undefined,
+      includeArchived(),
+      limit(),
+      copilotKit.threadEndpoints(),
+      runtimeConnectionStatus,
     );
+    store.setContext(context);
+    hasDispatchedContext.set(true);
   });
 
   effect((onCleanup) => {
@@ -225,6 +236,7 @@ export function injectThreads(input: InjectThreadsInput): InjectThreadsResult {
     renameThread: (threadId: string, name: string) =>
       store.renameThread(threadId, name),
     archiveThread: (threadId: string) => store.archiveThread(threadId),
+    unarchiveThread: (threadId: string) => store.unarchiveThread(threadId),
     deleteThread: (threadId: string) => store.deleteThread(threadId),
   };
 }

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -5,6 +5,7 @@ export * from "./lib/render-tool-calls";
 export * from "./lib/activity-renderer";
 export * from "./lib/open-generative-ui";
 export * from "./lib/agent";
+export * from "./lib/threads";
 export * from "./lib/chat-config";
 export * from "./lib/chat-state";
 export * from "./lib/transcription";

--- a/packages/core/src/__tests__/threads-shared-core.test.ts
+++ b/packages/core/src/__tests__/threads-shared-core.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { CopilotKitCoreRuntimeConnectionStatus } from "../core";
 import {
   ɵcreateThreadStore,
   ɵselectThreads,
@@ -117,6 +118,74 @@ describe("shared thread store context behavior", () => {
     await flushEffects();
 
     expect(fetch.calls).toHaveLength(0);
+    expect(ɵselectThreads(store.getState())).toEqual([]);
+    expect(ɵselectThreadsError(store.getState())?.message).toBe(
+      "Thread endpoints are not available on this CopilotKit runtime",
+    );
+    store.stop();
+  });
+
+  it("surfaces missing thread endpoint capability info as an error without fetching", async () => {
+    const fetch = jsonFetch([{ threads: sampleThreads }]);
+    vi.stubGlobal("fetch", fetch);
+    const store = ɵcreateThreadStore({ fetch });
+
+    store.start();
+    store.setContext(context({ threadEndpoints: undefined }));
+    await flushEffects();
+
+    expect(fetch.calls).toHaveLength(0);
+    expect(ɵselectThreads(store.getState())).toEqual([]);
+    expect(ɵselectThreadsError(store.getState())?.message).toBe(
+      "Thread endpoints are not available on this CopilotKit runtime",
+    );
+    store.stop();
+  });
+
+  it("surfaces runtime info failures as an error without fetching", async () => {
+    const fetch = jsonFetch([{ threads: sampleThreads }]);
+    vi.stubGlobal("fetch", fetch);
+    const store = ɵcreateThreadStore({ fetch });
+
+    store.start();
+    store.setContext(
+      context({
+        runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Error,
+      }),
+    );
+    await flushEffects();
+
+    expect(fetch.calls).toHaveLength(0);
+    expect(ɵselectThreads(store.getState())).toEqual([]);
+    expect(ɵselectThreadsError(store.getState())?.message).toBe(
+      "CopilotKit runtime info is unavailable",
+    );
+    store.stop();
+  });
+
+  it("revalidates list capability changes without requiring a new context reference", async () => {
+    const fetch = jsonFetch([{ threads: sampleThreads }]);
+    vi.stubGlobal("fetch", fetch);
+    const store = ɵcreateThreadStore({ fetch });
+    const stableContext = context();
+
+    store.start();
+    store.setContext(stableContext);
+    await flushEffects();
+
+    expect(fetch.calls).toHaveLength(1);
+    expect(ɵselectThreads(store.getState())).toHaveLength(1);
+
+    stableContext.threadEndpoints = {
+      list: false,
+      inspect: true,
+      mutations: true,
+      realtimeMetadata: true,
+    };
+    store.setContext(stableContext);
+    await flushEffects();
+
+    expect(fetch.calls).toHaveLength(1);
     expect(ɵselectThreads(store.getState())).toEqual([]);
     expect(ɵselectThreadsError(store.getState())?.message).toBe(
       "Thread endpoints are not available on this CopilotKit runtime",

--- a/packages/core/src/__tests__/threads-shared-core.test.ts
+++ b/packages/core/src/__tests__/threads-shared-core.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ɵcreateThreadStore,
+  ɵselectThreads,
+  ɵselectThreadsError,
+} from "../threads";
+import type { ɵThread, ɵThreadRuntimeContext } from "../threads";
+
+interface FetchCall {
+  input: RequestInfo | URL;
+  init?: RequestInit;
+}
+
+type JsonFetch = typeof fetch & {
+  calls: FetchCall[];
+};
+
+const threadEndpoints = {
+  list: true,
+  inspect: true,
+  mutations: true,
+  realtimeMetadata: true,
+};
+
+const sampleThreads: ɵThread[] = [
+  {
+    id: "thread-1",
+    organizationId: "org-1",
+    agentId: "agent-1",
+    createdById: "user-1",
+    name: "Thread One",
+    archived: false,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+];
+
+function jsonFetch(responses: unknown[], status = 200): JsonFetch {
+  const calls: FetchCall[] = [];
+  let index = 0;
+  const fetchImpl = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    calls.push({ input, init });
+    const body = responses[Math.min(index, responses.length - 1)] ?? {};
+    index += 1;
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  return Object.assign(fetchImpl, { calls });
+}
+
+async function flushEffects(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function context(
+  overrides: Partial<ɵThreadRuntimeContext> = {},
+): ɵThreadRuntimeContext {
+  return {
+    runtimeUrl: "https://runtime.example.com",
+    headers: {},
+    agentId: "agent-1",
+    threadEndpoints,
+    ...overrides,
+  };
+}
+
+describe("shared thread store context behavior", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not reset or refetch when setContext receives the same context reference", async () => {
+    const fetch = jsonFetch([{ threads: sampleThreads }]);
+    vi.stubGlobal("fetch", fetch);
+    const store = ɵcreateThreadStore({ fetch });
+    const stableContext = context();
+
+    store.start();
+    store.setContext(stableContext);
+    await flushEffects();
+
+    expect(fetch.calls).toHaveLength(1);
+    expect(ɵselectThreads(store.getState())).toHaveLength(1);
+
+    store.setContext(stableContext);
+    await flushEffects();
+
+    expect(fetch.calls).toHaveLength(1);
+    expect(ɵselectThreads(store.getState())).toHaveLength(1);
+    store.stop();
+  });
+
+  it("surfaces unavailable thread list endpoints as an error without fetching", async () => {
+    const fetch = jsonFetch([{ threads: sampleThreads }]);
+    vi.stubGlobal("fetch", fetch);
+    const store = ɵcreateThreadStore({ fetch });
+
+    store.start();
+    store.setContext(
+      context({
+        threadEndpoints: {
+          list: false,
+          inspect: false,
+          mutations: false,
+          realtimeMetadata: false,
+        },
+      }),
+    );
+    await flushEffects();
+
+    expect(fetch.calls).toHaveLength(0);
+    expect(ɵselectThreads(store.getState())).toEqual([]);
+    expect(ɵselectThreadsError(store.getState())?.message).toBe(
+      "Thread endpoints are not available on this CopilotKit runtime",
+    );
+    store.stop();
+  });
+
+  it("rejects mutations in core when the runtime reports mutations are unsupported", async () => {
+    const fetch = jsonFetch([{ threads: sampleThreads }]);
+    vi.stubGlobal("fetch", fetch);
+    const store = ɵcreateThreadStore({ fetch });
+
+    store.start();
+    store.setContext(
+      context({
+        threadEndpoints: {
+          list: true,
+          inspect: true,
+          mutations: false,
+          realtimeMetadata: false,
+        },
+      }),
+    );
+    await flushEffects();
+    fetch.calls.splice(0);
+
+    await expect(store.renameThread("thread-1", "Renamed")).rejects.toThrow(
+      "Thread mutations are not available on this CopilotKit runtime",
+    );
+
+    expect(fetch.calls).toHaveLength(0);
+    expect(ɵselectThreadsError(store.getState())?.message).toBe(
+      "Thread mutations are not available on this CopilotKit runtime",
+    );
+    store.stop();
+  });
+});

--- a/packages/core/src/__tests__/threads.test.ts
+++ b/packages/core/src/__tests__/threads.test.ts
@@ -108,6 +108,14 @@ function getChannel(): MockChannel {
   return channel;
 }
 
+function getSocket(): MockSocket {
+  const socket = phoenix.sockets[0];
+  if (!socket) {
+    throw new Error("expected a phoenix socket to exist");
+  }
+  return socket;
+}
+
 function getFetchCall(fetchMock: Mock, index: number) {
   const call = fetchMock.mock.calls[index];
   if (!call) {
@@ -259,6 +267,82 @@ describe("thread store", () => {
       id: "thread-1",
       name: "Renamed Thread",
     });
+  });
+
+  it("tears down realtime when capability is withdrawn on the same context reference", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          threads: sampleThreads,
+          joinCode: "jc-1",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          joinToken: "jt-1",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          threads: sampleThreads,
+          joinCode: "jc-2",
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const store = ɵcreateThreadStore(createEnvironment(fetchMock));
+    const stableContext = context();
+    stores.push(store);
+    store.start();
+    store.setContext(stableContext);
+
+    await flushEffects();
+
+    const socket = getSocket();
+    const channel = getChannel();
+    expect(socket.disconnected).toBe(false);
+    expect(channel.left).toBe(false);
+
+    stableContext.threadEndpoints = {
+      list: true,
+      inspect: true,
+      mutations: true,
+      realtimeMetadata: false,
+    };
+    store.setContext(stableContext);
+
+    await flushEffects();
+
+    expect(channel.left).toBe(true);
+    expect(socket.disconnected).toBe(true);
+
+    channel.serverPush("thread_metadata", {
+      operation: "renamed",
+      threadId: "thread-1",
+      userId: "user-1",
+      organizationId: "org-1",
+      occurredAt: "2026-01-03T00:00:00Z",
+      thread: {
+        ...sampleThreads[0],
+        name: "Should Not Apply",
+        updatedAt: "2026-01-03T00:00:00Z",
+      },
+    });
+
+    await flushEffects();
+
+    const thread = ɵselectThreads(store.getState()).find(
+      (item) => item.id === "thread-1",
+    );
+    expect(thread).toMatchObject({
+      id: "thread-1",
+      name: "Older Thread",
+    });
+    expect(phoenix.sockets).toHaveLength(1);
   });
 
   it("applies realtime events without client-side user filtering", async () => {

--- a/packages/core/src/__tests__/threads.test.ts
+++ b/packages/core/src/__tests__/threads.test.ts
@@ -2,6 +2,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
 import type { MockChannel } from "./test-utils";
 import { MockSocket } from "./test-utils";
+import {
+  ɵcreateThreadStore,
+  ɵselectHasNextPage,
+  ɵselectIsFetchingNextPage,
+  ɵselectThreads,
+  ɵselectThreadsError,
+  ɵselectThreadsIsLoading,
+} from "../threads";
+import type {
+  ɵThread,
+  ɵThreadEnvironment,
+  ɵThreadRuntimeContext,
+} from "../threads";
 
 const phoenix = vi.hoisted(() => ({
   sockets: [] as MockSocket[],
@@ -9,23 +22,14 @@ const phoenix = vi.hoisted(() => ({
 
 vi.mock("phoenix", () => ({
   Socket: class extends MockSocket {
-    constructor(url = "", opts: Record<string, any> = {}) {
+    constructor(url = "", opts: Record<string, unknown> = {}) {
       super(url, opts);
       phoenix.sockets.push(this);
     }
   },
 }));
 
-const {
-  ɵcreateThreadStore,
-  ɵselectThreads,
-  ɵselectThreadsError,
-  ɵselectThreadsIsLoading,
-  ɵselectHasNextPage,
-  ɵselectIsFetchingNextPage,
-} = await import("../threads");
-
-type ThreadRecord = import("../threads").ɵThread;
+type ThreadRecord = ɵThread;
 
 const flushEffects = async (): Promise<void> => {
   await Promise.resolve();
@@ -58,9 +62,41 @@ const sampleThreads: ThreadRecord[] = [
   },
 ];
 
-function createEnvironment(fetchImpl: Mock) {
+const supportedThreadEndpoints = {
+  list: true,
+  inspect: true,
+  mutations: true,
+  realtimeMetadata: true,
+};
+
+function createEnvironment(fetchImpl: Mock): ɵThreadEnvironment {
   return {
-    fetch: fetchImpl as unknown as typeof fetch,
+    fetch: async (input, init) => {
+      const response = await fetchImpl(input, init);
+      if (response instanceof Response) {
+        return response;
+      }
+
+      const body =
+        typeof response.json === "function" ? await response.json() : {};
+      return new Response(JSON.stringify(body), {
+        status: response.ok ? 200 : (response.status ?? 500),
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  };
+}
+
+function context(
+  overrides: Partial<ɵThreadRuntimeContext> = {},
+): ɵThreadRuntimeContext {
+  return {
+    runtimeUrl: "https://runtime.example.com",
+    headers: {},
+    wsUrl: "ws://localhost:4000/client",
+    agentId: "agent-1",
+    threadEndpoints: supportedThreadEndpoints,
+    ...overrides,
   };
 }
 
@@ -115,12 +151,11 @@ describe("thread store", () => {
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
     stores.push(store);
     store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: { Authorization: "Bearer token" },
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-1",
-    });
+    store.setContext(
+      context({
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
 
     await flushEffects();
 
@@ -161,12 +196,7 @@ describe("thread store", () => {
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
     stores.push(store);
     store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: {},
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-1",
-    });
+    store.setContext(context());
 
     await flushEffects();
 
@@ -214,12 +244,7 @@ describe("thread store", () => {
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
     stores.push(store);
     store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: {},
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-1",
-    });
+    store.setContext(context());
 
     await flushEffects();
 
@@ -272,20 +297,14 @@ describe("thread store", () => {
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
     stores.push(store);
     store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: {},
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-1",
-    });
+    store.setContext(context());
     await flushEffects();
 
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: {},
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-2",
-    });
+    store.setContext(
+      context({
+        agentId: "agent-2",
+      }),
+    );
 
     resolveFirstFetch({
       ok: true,
@@ -330,12 +349,11 @@ describe("thread store", () => {
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
     stores.push(store);
     store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: { Authorization: "Bearer token" },
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-1",
-    });
+    store.setContext(
+      context({
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
 
     await flushEffects();
 
@@ -392,12 +410,11 @@ describe("thread store", () => {
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
     stores.push(store);
     store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: { Authorization: "Bearer token" },
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-1",
-    });
+    store.setContext(
+      context({
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
 
     await flushEffects();
 
@@ -424,12 +441,7 @@ describe("thread store", () => {
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
     stores.push(store);
     store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: {},
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-1",
-    });
+    store.setContext(context());
 
     await flushEffects();
 
@@ -452,13 +464,11 @@ describe("thread store", () => {
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
     stores.push(store);
     store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: {},
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-1",
-      includeArchived: true,
-    });
+    store.setContext(
+      context({
+        includeArchived: true,
+      }),
+    );
 
     await flushEffects();
 
@@ -484,13 +494,11 @@ describe("thread store", () => {
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
     stores.push(store);
     store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: {},
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-1",
-      limit: 10,
-    });
+    store.setContext(
+      context({
+        limit: 10,
+      }),
+    );
 
     await flushEffects();
 
@@ -537,13 +545,11 @@ describe("thread store", () => {
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
     stores.push(store);
     store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: {},
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-1",
-      limit: 2,
-    });
+    store.setContext(
+      context({
+        limit: 2,
+      }),
+    );
 
     await flushEffects();
 
@@ -578,12 +584,7 @@ describe("thread store", () => {
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
     stores.push(store);
     store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: {},
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-1",
-    });
+    store.setContext(context());
 
     await flushEffects();
     expect(ɵselectThreads(store.getState())).toHaveLength(2);
@@ -620,13 +621,11 @@ describe("thread store", () => {
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
     stores.push(store);
     store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: {},
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-1",
-      includeArchived: true,
-    });
+    store.setContext(
+      context({
+        includeArchived: true,
+      }),
+    );
 
     await flushEffects();
     expect(ɵselectThreads(store.getState())).toHaveLength(2);
@@ -709,13 +708,11 @@ describe("thread store", () => {
     const store = ɵcreateThreadStore(createEnvironment(fetchMock));
     stores.push(store);
     store.start();
-    store.setContext({
-      runtimeUrl: "https://runtime.example.com",
-      headers: {},
-      wsUrl: "ws://localhost:4000/client",
-      agentId: "agent-1",
-      includeArchived: true,
-    });
+    store.setContext(
+      context({
+        includeArchived: true,
+      }),
+    );
 
     await flushEffects();
 

--- a/packages/core/src/__tests__/threads.test.ts
+++ b/packages/core/src/__tests__/threads.test.ts
@@ -175,6 +175,44 @@ describe("thread store", () => {
     expect(getChannel().topic).toBe("user_meta:jc-1");
   });
 
+  it("lists threads without realtime setup when realtime metadata is unsupported", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        threads: [sampleThreads[0], sampleThreads[1]],
+        joinCode: "jc-1",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const store = ɵcreateThreadStore(createEnvironment(fetchMock));
+    stores.push(store);
+    store.start();
+    store.setContext(
+      context({
+        threadEndpoints: {
+          list: true,
+          inspect: true,
+          mutations: true,
+          realtimeMetadata: false,
+        },
+      }),
+    );
+
+    await flushEffects();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://runtime.example.com/threads?agentId=agent-1",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(ɵselectThreads(store.getState()).map((thread) => thread.id)).toEqual(
+      ["thread-2", "thread-1"],
+    );
+    expect(ɵselectThreadsError(store.getState())).toBeNull();
+    expect(phoenix.sockets).toHaveLength(0);
+  });
+
   it("upserts realtime thread metadata without refetching", async () => {
     const fetchMock = vi
       .fn()

--- a/packages/core/src/threads.ts
+++ b/packages/core/src/threads.ts
@@ -297,7 +297,11 @@ function getThreadListAvailabilityKey(
   return [
     context.runtimeConnectionStatus ?? "",
     context.runtimeUrl ?? "",
+    context.wsUrl ?? "",
     context.threadEndpoints?.list === true ? "list:true" : "list:unavailable",
+    context.threadEndpoints?.realtimeMetadata === true
+      ? "realtime:true"
+      : "realtime:unavailable",
   ].join("|");
 }
 
@@ -726,6 +730,7 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
               actions$.pipe(
                 ofType(
                   threadAdapterEvents.contextChanged,
+                  threadAdapterEvents.contextAvailabilityChanged,
                   threadAdapterEvents.stopped,
                 ),
               ),
@@ -778,6 +783,7 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
               actions$.pipe(
                 ofType(
                   threadAdapterEvents.contextChanged,
+                  threadAdapterEvents.contextAvailabilityChanged,
                   threadAdapterEvents.stopped,
                 ),
               ),
@@ -812,6 +818,7 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
           const shutdown$ = actions$.pipe(
             ofType(
               threadAdapterEvents.contextChanged,
+              threadAdapterEvents.contextAvailabilityChanged,
               threadAdapterEvents.stopped,
             ),
           );
@@ -980,6 +987,7 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
               actions$.pipe(
                 ofType(
                   threadAdapterEvents.contextChanged,
+                  threadAdapterEvents.contextAvailabilityChanged,
                   threadAdapterEvents.stopped,
                 ),
               ),

--- a/packages/core/src/threads.ts
+++ b/packages/core/src/threads.ts
@@ -751,6 +751,7 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
           return (
             action.sessionId === state.sessionId &&
             !state.metadataCredentialsRequested &&
+            state.context?.threadEndpoints?.realtimeMetadata === true &&
             Boolean(state.context?.wsUrl) &&
             Boolean(state.metadataJoinCode)
           );

--- a/packages/core/src/threads.ts
+++ b/packages/core/src/threads.ts
@@ -37,6 +37,7 @@ import {
   ɵobservePhoenixSocketSignals$,
 } from "./utils/phoenix-observable";
 import type { ɵPhoenixChannelSession } from "./utils/phoenix-observable";
+import { CopilotKitCoreRuntimeConnectionStatus } from "./core";
 
 const THREADS_CHANNEL_EVENT = "thread_metadata";
 const THREAD_SUBSCRIBE_PATH = "/threads/subscribe";
@@ -63,6 +64,7 @@ interface ThreadRuntimeContext {
   includeArchived?: boolean;
   limit?: number;
   threadEndpoints?: ThreadEndpointRuntimeInfo;
+  runtimeConnectionStatus?: CopilotKitCoreRuntimeConnectionStatus;
 }
 
 type ThreadMetadataEvent =
@@ -120,6 +122,7 @@ interface ThreadState {
   metadataCredentialsRequested: boolean;
   metadataJoinCode: string | null;
   nextCursor: string | null;
+  contextAvailabilityKey: string | null;
 }
 
 const initialThreadState: ThreadState = {
@@ -132,9 +135,12 @@ const initialThreadState: ThreadState = {
   metadataCredentialsRequested: false,
   metadataJoinCode: null,
   nextCursor: null,
+  contextAvailabilityKey: null,
 };
 
 const RUNTIME_URL_NOT_CONFIGURED_MESSAGE = "Runtime URL is not configured";
+const RUNTIME_INFO_UNAVAILABLE_MESSAGE =
+  "CopilotKit runtime info is unavailable";
 const THREAD_ENDPOINTS_UNAVAILABLE_MESSAGE =
   "Thread endpoints are not available on this CopilotKit runtime";
 const THREAD_MUTATIONS_UNAVAILABLE_MESSAGE =
@@ -145,11 +151,18 @@ type ThreadFetchContext = ThreadRuntimeContext & { runtimeUrl: string };
 function getThreadListContextError(
   context: ThreadRuntimeContext,
 ): Error | null {
+  if (
+    context.runtimeConnectionStatus ===
+    CopilotKitCoreRuntimeConnectionStatus.Error
+  ) {
+    return new Error(RUNTIME_INFO_UNAVAILABLE_MESSAGE);
+  }
+
   if (!context.runtimeUrl) {
     return new Error(RUNTIME_URL_NOT_CONFIGURED_MESSAGE);
   }
 
-  if (context.threadEndpoints?.list === false) {
+  if (context.threadEndpoints?.list !== true) {
     return new Error(THREAD_ENDPOINTS_UNAVAILABLE_MESSAGE);
   }
 
@@ -159,11 +172,18 @@ function getThreadListContextError(
 function getThreadMutationContextError(
   context: ThreadRuntimeContext | null,
 ): Error | null {
+  if (
+    context?.runtimeConnectionStatus ===
+    CopilotKitCoreRuntimeConnectionStatus.Error
+  ) {
+    return new Error(RUNTIME_INFO_UNAVAILABLE_MESSAGE);
+  }
+
   if (!context?.runtimeUrl) {
     return new Error(RUNTIME_URL_NOT_CONFIGURED_MESSAGE);
   }
 
-  if (context.threadEndpoints?.mutations === false) {
+  if (context.threadEndpoints?.mutations !== true) {
     return new Error(THREAD_MUTATIONS_UNAVAILABLE_MESSAGE);
   }
 
@@ -190,6 +210,7 @@ const threadAdapterEvents = createActionGroup("Thread Adapter", {
   started: empty(),
   stopped: empty(),
   contextChanged: props<{ context: ThreadRuntimeContext | null }>(),
+  contextAvailabilityChanged: props<{ context: ThreadRuntimeContext }>(),
   fetchNextPageRequested: empty(),
   renameRequested: props<{
     requestId: string;
@@ -266,24 +287,56 @@ function upsertThread(
   return sortThreadsByRecency(next);
 }
 
+function getThreadListAvailabilityKey(
+  context: ThreadRuntimeContext | null,
+): string | null {
+  if (!context) {
+    return null;
+  }
+
+  return [
+    context.runtimeConnectionStatus ?? "",
+    context.runtimeUrl ?? "",
+    context.threadEndpoints?.list === true ? "list:true" : "list:unavailable",
+  ].join("|");
+}
+
+function resetThreadStateForContext(
+  state: ThreadState,
+  context: ThreadRuntimeContext | null,
+): ThreadState {
+  const contextError = context ? getThreadListContextError(context) : null;
+
+  return {
+    ...state,
+    context,
+    contextAvailabilityKey: getThreadListAvailabilityKey(context),
+    sessionId: state.sessionId + 1,
+    threads: [],
+    isLoading: Boolean(context && !contextError),
+    isFetchingNextPage: false,
+    error: contextError,
+    metadataCredentialsRequested: false,
+    metadataJoinCode: null,
+    nextCursor: null,
+  };
+}
+
 const threadReducer = createReducer(
   initialThreadState,
-  on(threadAdapterEvents.contextChanged, (state: ThreadState, { context }) => {
-    const contextError = context ? getThreadListContextError(context) : null;
+  on(threadAdapterEvents.contextChanged, (state: ThreadState, { context }) =>
+    resetThreadStateForContext(state, context),
+  ),
+  on(
+    threadAdapterEvents.contextAvailabilityChanged,
+    (state: ThreadState, { context }) => {
+      if (state.context !== context) {
+        return state;
+      }
 
-    return {
-      ...state,
-      context,
-      sessionId: state.sessionId + 1,
-      threads: [],
-      isLoading: Boolean(context && !contextError),
-      isFetchingNextPage: false,
-      error: contextError,
-      metadataCredentialsRequested: false,
-      metadataJoinCode: null,
-      nextCursor: null,
-    };
-  }),
+      return resetThreadStateForContext(state, context);
+    },
+  ),
   on(threadAdapterEvents.stopped, (state: ThreadState) => ({
     ...state,
     threads: [],
@@ -293,6 +346,7 @@ const threadReducer = createReducer(
     metadataCredentialsRequested: false,
     metadataJoinCode: null,
     nextCursor: null,
+    contextAvailabilityKey: null,
   })),
   on(threadRestEvents.listRequested, (state: ThreadState, { sessionId }) => {
     if (sessionId !== state.sessionId || !isThreadFetchContext(state.context)) {
@@ -646,7 +700,10 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
       state$: Observable<ThreadState>,
     ): Observable<ReturnType<typeof threadRestEvents.listRequested>> =>
       actions$.pipe(
-        ofType(threadAdapterEvents.contextChanged),
+        ofType(
+          threadAdapterEvents.contextChanged,
+          threadAdapterEvents.contextAvailabilityChanged,
+        ),
         withLatestFrom(state$),
         filter(([, state]) => isThreadFetchContext(state.context)),
         map(([, state]) =>
@@ -1073,6 +1130,13 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
     },
     setContext(context: ThreadRuntimeContext | null): void {
       if (store.getState().context === context) {
+        const state = store.getState();
+        const nextAvailabilityKey = getThreadListAvailabilityKey(context);
+        if (context && state.contextAvailabilityKey !== nextAvailabilityKey) {
+          store.dispatch(
+            threadAdapterEvents.contextAvailabilityChanged({ context }),
+          );
+        }
         return;
       }
       store.dispatch(threadAdapterEvents.contextChanged({ context }));

--- a/packages/core/src/threads.ts
+++ b/packages/core/src/threads.ts
@@ -1,4 +1,5 @@
 import { phoenixExponentialBackoff } from "@copilotkit/shared";
+import type { ThreadEndpointRuntimeInfo } from "@copilotkit/shared";
 import type { Observable } from "rxjs";
 import { defer, firstValueFrom, merge, of } from "rxjs";
 import { fromFetch } from "rxjs/fetch";
@@ -55,12 +56,13 @@ interface ThreadRecord {
 }
 
 interface ThreadRuntimeContext {
-  runtimeUrl: string;
+  runtimeUrl?: string;
   headers: Record<string, string>;
   wsUrl?: string;
   agentId: string;
   includeArchived?: boolean;
   limit?: number;
+  threadEndpoints?: ThreadEndpointRuntimeInfo;
 }
 
 type ThreadMetadataEvent =
@@ -131,6 +133,58 @@ const initialThreadState: ThreadState = {
   metadataJoinCode: null,
   nextCursor: null,
 };
+
+const RUNTIME_URL_NOT_CONFIGURED_MESSAGE = "Runtime URL is not configured";
+const THREAD_ENDPOINTS_UNAVAILABLE_MESSAGE =
+  "Thread endpoints are not available on this CopilotKit runtime";
+const THREAD_MUTATIONS_UNAVAILABLE_MESSAGE =
+  "Thread mutations are not available on this CopilotKit runtime";
+
+type ThreadFetchContext = ThreadRuntimeContext & { runtimeUrl: string };
+
+function getThreadListContextError(
+  context: ThreadRuntimeContext,
+): Error | null {
+  if (!context.runtimeUrl) {
+    return new Error(RUNTIME_URL_NOT_CONFIGURED_MESSAGE);
+  }
+
+  if (context.threadEndpoints?.list === false) {
+    return new Error(THREAD_ENDPOINTS_UNAVAILABLE_MESSAGE);
+  }
+
+  return null;
+}
+
+function getThreadMutationContextError(
+  context: ThreadRuntimeContext | null,
+): Error | null {
+  if (!context?.runtimeUrl) {
+    return new Error(RUNTIME_URL_NOT_CONFIGURED_MESSAGE);
+  }
+
+  if (context.threadEndpoints?.mutations === false) {
+    return new Error(THREAD_MUTATIONS_UNAVAILABLE_MESSAGE);
+  }
+
+  return null;
+}
+
+function isThreadFetchContext(
+  context: ThreadRuntimeContext | null,
+): context is ThreadFetchContext {
+  if (!context) {
+    return false;
+  }
+
+  return getThreadListContextError(context) === null;
+}
+
+function isThreadMutationContext(
+  context: ThreadRuntimeContext | null,
+): context is ThreadFetchContext {
+  return getThreadMutationContextError(context) === null;
+}
 
 const threadAdapterEvents = createActionGroup("Thread Adapter", {
   started: empty(),
@@ -214,18 +268,22 @@ function upsertThread(
 
 const threadReducer = createReducer(
   initialThreadState,
-  on(threadAdapterEvents.contextChanged, (state: ThreadState, { context }) => ({
-    ...state,
-    context,
-    sessionId: state.sessionId + 1,
-    threads: [],
-    isLoading: Boolean(context),
-    isFetchingNextPage: false,
-    error: null,
-    metadataCredentialsRequested: false,
-    metadataJoinCode: null,
-    nextCursor: null,
-  })),
+  on(threadAdapterEvents.contextChanged, (state: ThreadState, { context }) => {
+    const contextError = context ? getThreadListContextError(context) : null;
+
+    return {
+      ...state,
+      context,
+      sessionId: state.sessionId + 1,
+      threads: [],
+      isLoading: Boolean(context && !contextError),
+      isFetchingNextPage: false,
+      error: contextError,
+      metadataCredentialsRequested: false,
+      metadataJoinCode: null,
+      nextCursor: null,
+    };
+  }),
   on(threadAdapterEvents.stopped, (state: ThreadState) => ({
     ...state,
     threads: [],
@@ -237,7 +295,7 @@ const threadReducer = createReducer(
     nextCursor: null,
   })),
   on(threadRestEvents.listRequested, (state: ThreadState, { sessionId }) => {
-    if (sessionId !== state.sessionId || !state.context) {
+    if (sessionId !== state.sessionId || !isThreadFetchContext(state.context)) {
       return state;
     }
 
@@ -426,7 +484,7 @@ function threadFromFetch<T>(
 
 function createThreadFetchObservable(
   environment: ThreadEnvironment,
-  context: ThreadRuntimeContext,
+  context: ThreadFetchContext,
   sessionId: number,
 ): Observable<
   | ReturnType<typeof threadRestEvents.listSucceeded>
@@ -483,7 +541,7 @@ function createThreadFetchObservable(
 
 function createThreadMetadataCredentialsObservable(
   environment: ThreadEnvironment,
-  context: ThreadRuntimeContext,
+  context: ThreadFetchContext,
   sessionId: number,
 ): Observable<
   | ReturnType<typeof threadRestEvents.metadataCredentialsSucceeded>
@@ -538,7 +596,7 @@ function createThreadMetadataCredentialsObservable(
 
 function createThreadMutationObservable(
   environment: ThreadEnvironment,
-  context: ThreadRuntimeContext,
+  context: ThreadFetchContext,
   request: MutationRequest,
 ): Observable<ReturnType<typeof threadRestEvents.mutationFinished>> {
   return defer(() => {
@@ -590,7 +648,7 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
       actions$.pipe(
         ofType(threadAdapterEvents.contextChanged),
         withLatestFrom(state$),
-        filter(([, state]) => Boolean(state.context)),
+        filter(([, state]) => isThreadFetchContext(state.context)),
         map(([, state]) =>
           threadRestEvents.listRequested({ sessionId: state.sessionId }),
         ),
@@ -604,9 +662,7 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
         switchMap((action) =>
           state$.pipe(
             map((state) => state.context),
-            filter((context): context is ThreadRuntimeContext =>
-              Boolean(context),
-            ),
+            filter(isThreadFetchContext),
             take(1),
             map((context) => ({ action, context })),
             takeUntil(
@@ -657,9 +713,7 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
         switchMap((action) =>
           state$.pipe(
             map((state) => state.context),
-            filter((context): context is ThreadRuntimeContext =>
-              Boolean(context),
-            ),
+            filter(isThreadFetchContext),
             take(1),
             map((context) => ({ action, context })),
             takeUntil(
@@ -813,10 +867,11 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
         ofType(threadAdapterEvents.fetchNextPageRequested),
         withLatestFrom(state$),
         filter(
-          ([, state]) => Boolean(state.context) && Boolean(state.nextCursor),
+          ([, state]) =>
+            isThreadFetchContext(state.context) && Boolean(state.nextCursor),
         ),
         switchMap(([, state]) => {
-          const context = state.context as ThreadRuntimeContext;
+          const context = state.context as ThreadFetchContext;
           const params: Record<string, string> = {
             agentId: context.agentId,
             cursor: state.nextCursor!,
@@ -888,14 +943,17 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
         withLatestFrom(state$),
         mergeMap(([action, state]) => {
           const context = state.context;
-          if (!context?.runtimeUrl) {
+          if (!isThreadMutationContext(context)) {
+            const contextError = getThreadMutationContextError(context);
             const requestId = action.requestId;
             return of(
               threadRestEvents.mutationFinished({
                 outcome: {
                   requestId,
                   ok: false,
-                  error: new Error("Runtime URL is not configured"),
+                  error:
+                    contextError ??
+                    new Error(THREAD_MUTATIONS_UNAVAILABLE_MESSAGE),
                 },
               }),
             );
@@ -1014,6 +1072,9 @@ function createThreadStore(environment: ThreadEnvironment): ThreadStore {
       store.stop();
     },
     setContext(context: ThreadRuntimeContext | null): void {
+      if (store.getState().context === context) {
+        return;
+      }
       store.dispatch(threadAdapterEvents.contextChanged({ context }));
     },
     refresh(): void {

--- a/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
@@ -248,6 +248,12 @@ function jsonResponse(body: unknown, status = 200) {
   });
 }
 
+function threadListFetchCalls() {
+  return fetchMock.mock.calls.filter(
+    ([url]) => typeof url === "string" && url.includes("/threads?"),
+  );
+}
+
 const defaultInput = { agentId: "agent-1" };
 
 const sampleThreads = [
@@ -943,6 +949,53 @@ describe("useThreads", () => {
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
     });
+  });
+
+  it("does not refetch threads when headers are reallocated with the same contents", async () => {
+    const threadEndpointsWithoutRealtime = {
+      ...supportedThreadEndpoints,
+      realtimeMetadata: false,
+    };
+    let currentCopilotKit = createMockCopilotKit({
+      headers: {
+        Authorization: "Bearer test-token",
+        "X-CSRF": "1",
+      },
+      threadEndpoints: threadEndpointsWithoutRealtime,
+      intelligence: undefined,
+    });
+    mockUseCopilotKit.mockImplementation(() => ({
+      copilotkit: currentCopilotKit,
+    }));
+    fetchMock.mockReturnValue(jsonResponse({ threads: sampleThreads }));
+
+    const { result, rerender } = renderHook(() => useThreads(defaultInput));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(threadListFetchCalls()).toHaveLength(1);
+
+    currentCopilotKit = createMockCopilotKit({
+      headers: {
+        "X-CSRF": "1",
+        Authorization: "Bearer test-token",
+      },
+      threadEndpoints: threadEndpointsWithoutRealtime,
+      intelligence: undefined,
+    });
+    rerender();
+
+    await act(async () => {
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(threadListFetchCalls()).toHaveLength(1);
+    expect(result.current.threads.map((thread) => thread.id)).toEqual([
+      "t-2",
+      "t-1",
+    ]);
   });
 
   it("clears stale threads when list identity changes during a transient reconnect", async () => {

--- a/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
@@ -216,19 +216,26 @@ const supportedThreadEndpoints = {
   realtimeMetadata: true,
 };
 
+function createMockCopilotKit(
+  overrides: Partial<MockCopilotKitForThreads> = {},
+): MockCopilotKitForThreads {
+  return {
+    runtimeUrl: "http://localhost:4000",
+    runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Connected,
+    headers: { Authorization: "Bearer test-token" },
+    threadEndpoints: supportedThreadEndpoints,
+    intelligence: {
+      wsUrl: "ws://localhost:4000/client",
+    },
+    registerThreadStore: vi.fn(),
+    unregisterThreadStore: vi.fn(),
+    ...overrides,
+  };
+}
+
 function setupCopilotKit(runtimeUrl = "http://localhost:4000") {
   mockUseCopilotKit.mockReturnValue({
-    copilotkit: {
-      runtimeUrl,
-      runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Connected,
-      headers: { Authorization: "Bearer test-token" },
-      threadEndpoints: supportedThreadEndpoints,
-      intelligence: {
-        wsUrl: "ws://localhost:4000/client",
-      },
-      registerThreadStore: vi.fn(),
-      unregisterThreadStore: vi.fn(),
-    },
+    copilotkit: createMockCopilotKit({ runtimeUrl }),
   });
 }
 
@@ -936,5 +943,90 @@ describe("useThreads", () => {
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
     });
+  });
+
+  it("clears stale threads when list identity changes during a transient reconnect", async () => {
+    const agentTwoThreads = [
+      {
+        ...sampleThreads[0],
+        id: "t-agent-2",
+        agentId: "agent-2",
+        name: "Agent Two Thread",
+        updatedAt: "2026-02-01T00:00:00Z",
+      },
+    ];
+    let currentCopilotKit = createMockCopilotKit({
+      threadEndpoints: {
+        list: true,
+        inspect: true,
+        mutations: true,
+        realtimeMetadata: false,
+      },
+      intelligence: undefined,
+    });
+    mockUseCopilotKit.mockImplementation(() => ({
+      copilotkit: currentCopilotKit,
+    }));
+    fetchMock
+      .mockReturnValueOnce(jsonResponse({ threads: sampleThreads }))
+      .mockReturnValueOnce(jsonResponse({ threads: agentTwoThreads }));
+
+    const { result, rerender } = renderHook(
+      ({ agentId }: { agentId: string }) => useThreads({ agentId }),
+      { initialProps: { agentId: "agent-1" } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.threads.map((thread) => thread.agentId)).toEqual([
+      "agent-1",
+      "agent-1",
+    ]);
+    fetchMock.mockClear();
+
+    currentCopilotKit = createMockCopilotKit({
+      runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Connecting,
+      threadEndpoints: {
+        list: true,
+        inspect: true,
+        mutations: true,
+        realtimeMetadata: false,
+      },
+      intelligence: undefined,
+    });
+    rerender({ agentId: "agent-2" });
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.threads).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+
+    currentCopilotKit = createMockCopilotKit({
+      threadEndpoints: {
+        list: true,
+        inspect: true,
+        mutations: true,
+        realtimeMetadata: false,
+      },
+      intelligence: undefined,
+    });
+    rerender({ agentId: "agent-2" });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/threads?agentId=agent-2"),
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(result.current.threads.map((thread) => thread.id)).toEqual([
+      "t-agent-2",
+    ]);
   });
 });

--- a/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-threads.test.tsx
@@ -1,25 +1,36 @@
 import React from "react";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
-import { useCopilotKit } from "../../context";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useThreads } from "../use-threads";
 import {
   CopilotKitCoreRuntimeConnectionStatus,
   ɵMAX_SOCKET_RETRIES,
 } from "@copilotkit/core";
+import type { ThreadEndpointRuntimeInfo, ɵThreadStore } from "@copilotkit/core";
 
-vi.mock("../../context", () => ({
-  useCopilotKit: vi.fn(),
+interface MockCopilotKitForThreads {
+  runtimeUrl: string | undefined;
+  runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus;
+  headers: Record<string, string>;
+  threadEndpoints: ThreadEndpointRuntimeInfo | undefined;
+  intelligence: { wsUrl: string } | undefined;
+  registerThreadStore: (agentId: string, store: ɵThreadStore) => void;
+  unregisterThreadStore: (agentId: string) => void;
+}
+
+interface MockCopilotKitContextValue {
+  copilotkit: MockCopilotKitForThreads;
+}
+
+const mockedContext = vi.hoisted(() => ({
+  useCopilotKit: vi.fn<() => MockCopilotKitContextValue>(),
 }));
 
-const mockUseCopilotKit = useCopilotKit as ReturnType<typeof vi.fn>;
+vi.mock("../../context", () => ({
+  useCopilotKit: mockedContext.useCopilotKit,
+}));
+
+const mockUseCopilotKit = mockedContext.useCopilotKit;
 
 // Shape of the mock socket exposed via the hoisted `phoenix.sockets`
 // array. Defined as a named type so test-side assertions can drop the
@@ -255,12 +266,6 @@ const sampleThreads = [
   },
 ];
 
-let useThreads: typeof import("../use-threads").useThreads;
-
-beforeAll(async () => {
-  ({ useThreads } = await import("../use-threads"));
-});
-
 describe("useThreads", () => {
   beforeEach(() => {
     phoenix.sockets.splice(0);
@@ -337,6 +342,32 @@ describe("useThreads", () => {
     expect(result.current.error?.message).toBe("Runtime URL is not configured");
   });
 
+  it("does not fetch and surfaces an error when runtime info fails for a configured runtime URL", async () => {
+    mockUseCopilotKit.mockReturnValue({
+      copilotkit: {
+        runtimeUrl: "http://localhost:4000",
+        runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Error,
+        headers: { Authorization: "Bearer test-token" },
+        threadEndpoints: undefined,
+        intelligence: undefined,
+        registerThreadStore: vi.fn(),
+        unregisterThreadStore: vi.fn(),
+      },
+    });
+
+    const { result } = renderHook(() => useThreads(defaultInput));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.threads).toEqual([]);
+    expect(result.current.error?.message).toBe(
+      "CopilotKit runtime info is unavailable",
+    );
+  });
+
   it("does not fetch when the runtime does not advertise thread endpoints", async () => {
     mockUseCopilotKit.mockReturnValue({
       copilotkit: {
@@ -369,7 +400,7 @@ describe("useThreads", () => {
     );
   });
 
-  it("uses legacy thread behavior when connected runtime omits thread endpoint info", async () => {
+  it("does not fetch when connected runtime omits thread endpoint capability info", async () => {
     mockUseCopilotKit.mockReturnValue({
       copilotkit: {
         runtimeUrl: "http://localhost:4000",
@@ -382,7 +413,6 @@ describe("useThreads", () => {
         unregisterThreadStore: vi.fn(),
       },
     });
-    fetchMock.mockReturnValueOnce(jsonResponse({ threads: sampleThreads }));
 
     const { result } = renderHook(() => useThreads(defaultInput));
 
@@ -390,15 +420,11 @@ describe("useThreads", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining("/threads?agentId=agent-1"),
-      expect.objectContaining({ method: "GET" }),
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.threads).toEqual([]);
+    expect(result.current.error?.message).toBe(
+      "Thread endpoints are not available on this CopilotKit runtime",
     );
-    expect(result.current.threads.map((thread) => thread.id)).toEqual([
-      "t-2",
-      "t-1",
-    ]);
-    expect(result.current.error).toBeNull();
   });
 
   it("rejects mutations locally when the runtime reports mutations are unsupported", async () => {

--- a/packages/react-core/src/v2/hooks/use-threads.tsx
+++ b/packages/react-core/src/v2/hooks/use-threads.tsx
@@ -134,6 +134,8 @@ function useThreadStoreSelector<T>(
   );
 }
 
+const EMPTY_HEADERS: Record<string, string> = {};
+
 /**
  * React hook for listing and managing Intelligence platform threads.
  *
@@ -192,9 +194,17 @@ export function useThreads({
   const threads: Thread[] = useMemo(
     () =>
       coreThreads.map(
-        ({ id, agentId, name, archived, createdAt, updatedAt, lastRunAt }) => ({
+        ({
           id,
-          agentId,
+          agentId: threadAgentId,
+          name,
+          archived,
+          createdAt,
+          updatedAt,
+          lastRunAt,
+        }) => ({
+          id,
+          agentId: threadAgentId,
           name,
           archived,
           createdAt,
@@ -211,47 +221,17 @@ export function useThreads({
     store,
     ɵselectIsFetchingNextPage,
   );
-  const headersKey = useMemo(() => {
-    return JSON.stringify(
-      Object.entries(copilotkit.headers ?? {}).sort(([left], [right]) =>
-        left.localeCompare(right),
-      ),
-    );
-  }, [copilotkit.headers]);
+  const headers = copilotkit.headers ?? EMPTY_HEADERS;
   const runtimeStatus = copilotkit.runtimeConnectionStatus;
-  const threadListEndpointSupported =
-    copilotkit.threadEndpoints?.list !== false;
-  const threadMutationsSupported =
-    copilotkit.threadEndpoints?.mutations !== false;
-  const threadEndpointsUnavailable =
-    !!copilotkit.runtimeUrl &&
-    runtimeStatus === CopilotKitCoreRuntimeConnectionStatus.Connected &&
-    !threadListEndpointSupported;
-  const runtimeError = useMemo(() => {
-    if (copilotkit.runtimeUrl) {
-      return null;
-    }
-
-    return new Error("Runtime URL is not configured");
-  }, [copilotkit.runtimeUrl]);
-  const threadEndpointsError = useMemo(() => {
-    if (!threadEndpointsUnavailable) {
-      return null;
-    }
-
-    return new Error(
-      "Thread endpoints are not available on this CopilotKit runtime",
-    );
-  }, [threadEndpointsUnavailable]);
-  const threadMutationsError = useMemo(() => {
-    if (threadMutationsSupported) {
-      return null;
-    }
-
-    return new Error(
-      "Thread mutations are not available on this CopilotKit runtime",
-    );
-  }, [threadMutationsSupported]);
+  const threadEndpoints = useMemo(
+    () => copilotkit.threadEndpoints,
+    [
+      copilotkit.threadEndpoints?.list,
+      copilotkit.threadEndpoints?.inspect,
+      copilotkit.threadEndpoints?.mutations,
+      copilotkit.threadEndpoints?.realtimeMetadata,
+    ],
+  );
 
   // Tracks whether we've dispatched the first real context to the store.
   // The store itself starts with `isLoading: false`, so before we dispatch
@@ -261,16 +241,10 @@ export function useThreads({
   // the first fetch is in flight (at which point the store's own
   // isLoading takes over).
   const [hasDispatchedContext, setHasDispatchedContext] = useState(false);
-  const preConnectLoading =
-    !!copilotkit.runtimeUrl &&
-    !threadEndpointsUnavailable &&
-    !hasDispatchedContext;
+  const preConnectLoading = !!copilotkit.runtimeUrl && !hasDispatchedContext;
 
-  const isLoading =
-    runtimeError || threadEndpointsError
-      ? false
-      : preConnectLoading || storeIsLoading;
-  const error = runtimeError ?? threadEndpointsError ?? storeError;
+  const isLoading = preConnectLoading || storeIsLoading;
+  const error = storeError;
 
   useEffect(() => {
     store.start();
@@ -285,7 +259,8 @@ export function useThreads({
   // second list fetch (and a `/threads/subscribe`) once the flag lands.
   // Waiting lets the hook issue just one `/threads?…` + one `/threads/subscribe`.
   //
-  // When `runtimeUrl` is absent we dispatch `null` to clear the store. For
+  // When `runtimeUrl` is absent we dispatch a context so the shared store can
+  // expose a visible configuration error. For
   // transient states (Disconnected/Connecting/Error with a URL still set) we
   // leave the previously-dispatched context in place — any in-flight
   // realtime subscription or cached thread list stays usable while the
@@ -299,8 +274,18 @@ export function useThreads({
 
   useEffect(() => {
     if (!copilotkit.runtimeUrl) {
-      store.setContext(null);
-      setHasDispatchedContext(false);
+      const context: ɵThreadRuntimeContext = {
+        runtimeUrl: undefined,
+        headers,
+        wsUrl: copilotkit.intelligence?.wsUrl,
+        agentId,
+        includeArchived,
+        limit,
+        threadEndpoints,
+      };
+
+      store.setContext(context);
+      setHasDispatchedContext(true);
       return;
     }
 
@@ -310,19 +295,14 @@ export function useThreads({
       return;
     }
 
-    if (!threadListEndpointSupported) {
-      store.setContext(null);
-      setHasDispatchedContext(false);
-      return;
-    }
-
     const context: ɵThreadRuntimeContext = {
       runtimeUrl: copilotkit.runtimeUrl,
-      headers: { ...copilotkit.headers },
+      headers,
       wsUrl: copilotkit.intelligence?.wsUrl,
       agentId,
       includeArchived,
       limit,
+      threadEndpoints,
     };
 
     store.setContext(context);
@@ -331,49 +311,33 @@ export function useThreads({
     store,
     copilotkit.runtimeUrl,
     runtimeStatus,
-    headersKey,
+    headers,
     copilotkit.intelligence?.wsUrl,
-    threadListEndpointSupported,
+    threadEndpoints,
     agentId,
     includeArchived,
     limit,
   ]);
 
-  const guardMutation = useCallback(
-    <TArgs extends unknown[]>(
-      mutation: (...args: TArgs) => Promise<void>,
-    ): ((...args: TArgs) => Promise<void>) => {
-      return (...args: TArgs) => {
-        if (threadMutationsError) {
-          return Promise.reject(threadMutationsError);
-        }
-        return mutation(...args);
-      };
-    },
-    [threadMutationsError],
-  );
-
   const renameThread = useMemo(
-    () =>
-      guardMutation((threadId: string, name: string) =>
-        store.renameThread(threadId, name),
-      ),
-    [store, guardMutation],
+    () => (threadId: string, name: string) =>
+      store.renameThread(threadId, name),
+    [store],
   );
 
   const archiveThread = useMemo(
-    () => guardMutation((threadId: string) => store.archiveThread(threadId)),
-    [store, guardMutation],
+    () => (threadId: string) => store.archiveThread(threadId),
+    [store],
   );
 
   const unarchiveThread = useMemo(
-    () => guardMutation((threadId: string) => store.unarchiveThread(threadId)),
-    [store, guardMutation],
+    () => (threadId: string) => store.unarchiveThread(threadId),
+    [store],
   );
 
   const deleteThread = useMemo(
-    () => guardMutation((threadId: string) => store.deleteThread(threadId)),
-    [store, guardMutation],
+    () => (threadId: string) => store.deleteThread(threadId),
+    [store],
   );
 
   const fetchMoreThreads = useCallback(() => store.fetchNextPage(), [store]);

--- a/packages/react-core/src/v2/hooks/use-threads.tsx
+++ b/packages/react-core/src/v2/hooks/use-threads.tsx
@@ -137,6 +137,22 @@ function useThreadStoreSelector<T>(
 
 const EMPTY_HEADERS: Record<string, string> = {};
 
+function getSortedHeaderEntries(
+  headers: Record<string, string>,
+): Array<[string, string]> {
+  return Object.entries(headers).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+}
+
+function getHeadersKey(headers: Record<string, string>): string {
+  return JSON.stringify(getSortedHeaderEntries(headers));
+}
+
+function createStableHeaders(headers: Record<string, string>) {
+  return Object.fromEntries(getSortedHeaderEntries(headers));
+}
+
 function getThreadListIdentity({
   runtimeUrl,
   headers,
@@ -150,13 +166,9 @@ function getThreadListIdentity({
   includeArchived?: boolean;
   limit?: number;
 }): string {
-  const headerEntries = Object.entries(headers).sort(([left], [right]) =>
-    left.localeCompare(right),
-  );
-
   return JSON.stringify({
     runtimeUrl: runtimeUrl ?? null,
-    headers: headerEntries,
+    headers: getSortedHeaderEntries(headers),
     agentId,
     includeArchived: includeArchived === true,
     limit: limit ?? null,
@@ -248,7 +260,21 @@ export function useThreads({
     store,
     ɵselectIsFetchingNextPage,
   );
-  const headers = copilotkit.headers ?? EMPTY_HEADERS;
+  const rawHeaders = copilotkit.headers ?? EMPTY_HEADERS;
+  const headersKey = useMemo(() => getHeadersKey(rawHeaders), [rawHeaders]);
+  const stableHeadersRef = useRef<{
+    key: string;
+    headers: Record<string, string>;
+  } | null>(null);
+  let stableHeaders = stableHeadersRef.current;
+  if (stableHeaders === null || stableHeaders.key !== headersKey) {
+    stableHeaders = {
+      key: headersKey,
+      headers: createStableHeaders(rawHeaders),
+    };
+    stableHeadersRef.current = stableHeaders;
+  }
+  const headers = stableHeaders.headers;
   const runtimeStatus = copilotkit.runtimeConnectionStatus;
   const threadEndpoints = useMemo(
     () => copilotkit.threadEndpoints,

--- a/packages/react-core/src/v2/hooks/use-threads.tsx
+++ b/packages/react-core/src/v2/hooks/use-threads.tsx
@@ -13,6 +13,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   useSyncExternalStore,
 } from "react";
@@ -136,6 +137,32 @@ function useThreadStoreSelector<T>(
 
 const EMPTY_HEADERS: Record<string, string> = {};
 
+function getThreadListIdentity({
+  runtimeUrl,
+  headers,
+  agentId,
+  includeArchived,
+  limit,
+}: {
+  runtimeUrl?: string;
+  headers: Record<string, string>;
+  agentId: string;
+  includeArchived?: boolean;
+  limit?: number;
+}): string {
+  const headerEntries = Object.entries(headers).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+
+  return JSON.stringify({
+    runtimeUrl: runtimeUrl ?? null,
+    headers: headerEntries,
+    agentId,
+    includeArchived: includeArchived === true,
+    limit: limit ?? null,
+  });
+}
+
 /**
  * React hook for listing and managing Intelligence platform threads.
  *
@@ -241,7 +268,13 @@ export function useThreads({
   // the first fetch is in flight (at which point the store's own
   // isLoading takes over).
   const [hasDispatchedContext, setHasDispatchedContext] = useState(false);
+  const hasDispatchedContextRef = useRef(false);
+  const lastDispatchedListIdentityRef = useRef<string | null>(null);
   const preConnectLoading = !!copilotkit.runtimeUrl && !hasDispatchedContext;
+  const markHasDispatchedContext = useCallback((value: boolean) => {
+    hasDispatchedContextRef.current = value;
+    setHasDispatchedContext(value);
+  }, []);
 
   const isLoading = preConnectLoading || storeIsLoading;
   const error = storeError;
@@ -273,6 +306,14 @@ export function useThreads({
   }, [copilotkit, agentId, store]);
 
   useEffect(() => {
+    const listIdentity = getThreadListIdentity({
+      runtimeUrl: copilotkit.runtimeUrl,
+      headers,
+      agentId,
+      includeArchived,
+      limit,
+    });
+
     if (!copilotkit.runtimeUrl) {
       const context: ɵThreadRuntimeContext = {
         runtimeUrl: undefined,
@@ -285,7 +326,8 @@ export function useThreads({
       };
 
       store.setContext(context);
-      setHasDispatchedContext(true);
+      lastDispatchedListIdentityRef.current = listIdentity;
+      markHasDispatchedContext(true);
       return;
     }
 
@@ -302,13 +344,22 @@ export function useThreads({
       };
 
       store.setContext(context);
-      setHasDispatchedContext(true);
+      lastDispatchedListIdentityRef.current = listIdentity;
+      markHasDispatchedContext(true);
       return;
     }
 
     // Wait for /info to land so we can include `wsUrl` in the initial
     // context and avoid a redundant second list fetch.
     if (runtimeStatus !== CopilotKitCoreRuntimeConnectionStatus.Connected) {
+      if (
+        hasDispatchedContextRef.current &&
+        lastDispatchedListIdentityRef.current !== listIdentity
+      ) {
+        store.setContext(null);
+        lastDispatchedListIdentityRef.current = null;
+        markHasDispatchedContext(false);
+      }
       return;
     }
 
@@ -324,7 +375,8 @@ export function useThreads({
     };
 
     store.setContext(context);
-    setHasDispatchedContext(true);
+    lastDispatchedListIdentityRef.current = listIdentity;
+    markHasDispatchedContext(true);
   }, [
     store,
     copilotkit.runtimeUrl,
@@ -335,6 +387,7 @@ export function useThreads({
     agentId,
     includeArchived,
     limit,
+    markHasDispatchedContext,
   ]);
 
   const renameThread = useMemo(

--- a/packages/react-core/src/v2/hooks/use-threads.tsx
+++ b/packages/react-core/src/v2/hooks/use-threads.tsx
@@ -289,6 +289,23 @@ export function useThreads({
       return;
     }
 
+    if (runtimeStatus === CopilotKitCoreRuntimeConnectionStatus.Error) {
+      const context: ɵThreadRuntimeContext = {
+        runtimeUrl: undefined,
+        headers,
+        wsUrl: undefined,
+        agentId,
+        includeArchived,
+        limit,
+        threadEndpoints,
+        runtimeConnectionStatus: runtimeStatus,
+      };
+
+      store.setContext(context);
+      setHasDispatchedContext(true);
+      return;
+    }
+
     // Wait for /info to land so we can include `wsUrl` in the initial
     // context and avoid a redundant second list fetch.
     if (runtimeStatus !== CopilotKitCoreRuntimeConnectionStatus.Connected) {
@@ -303,6 +320,7 @@ export function useThreads({
       includeArchived,
       limit,
       threadEndpoints,
+      runtimeConnectionStatus: runtimeStatus,
     };
 
     store.setContext(context);

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -14,6 +14,7 @@ type InspectorInternals = {
   agentMessages: Map<string, Array<{ contentText?: string }>>;
   agentStates: Map<string, unknown>;
   cachedTools: Array<{ name: string }>;
+  _threads: Array<{ id: string }>;
 };
 
 type InspectorContextInternals = {
@@ -774,8 +775,8 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     });
   });
 
-  it("does not fetch with stale capabilities while runtime reconnects", async () => {
-    const { agent } = createMockAgent("alpha");
+  it("does not fetch or repopulate stale threads while runtime reconnects", async () => {
+    const { agent, controller } = createMockAgent("alpha");
     const harness = createHeaderMockCore(
       { alpha: agent },
       { Authorization: "Bearer abc" },
@@ -802,6 +803,14 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     await Promise.resolve();
 
     expect(threadListCalls()).toHaveLength(0);
+
+    controller.emit("onRunFinishedEvent", { event: { id: "run-1" } });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(threadListCalls()).toHaveLength(0);
+    expect(getInternals(inspector)._threads).toEqual([]);
 
     harness.core.threadEndpoints = {
       list: true,

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -619,6 +619,9 @@ type HeaderMockCore = {
   runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus;
   runtimeUrl: string;
   headers: Record<string, string>;
+  intelligence?: {
+    wsUrl?: string;
+  };
   threadEndpoints: {
     list: boolean;
     inspect: boolean;
@@ -646,6 +649,7 @@ function createHeaderMockCore(
     runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Connected,
     runtimeUrl: "http://localhost/api",
     headers,
+    intelligence: { wsUrl: "ws://localhost/api/client" },
     threadEndpoints: {
       list: true,
       inspect: true,
@@ -678,6 +682,17 @@ function createHeaderMockCore(
       core.headers = nextHeaders;
       subscribers.forEach((s) =>
         s.onHeadersChanged?.({ copilotkit: asCore(), headers: nextHeaders }),
+      );
+    },
+    emitRuntimeConnectionStatusChanged(
+      status: CopilotKitCoreRuntimeConnectionStatus,
+    ) {
+      core.runtimeConnectionStatus = status;
+      subscribers.forEach((s) =>
+        s.onRuntimeConnectionStatusChanged?.({
+          copilotkit: asCore(),
+          status,
+        }),
       );
     },
   };
@@ -756,6 +771,60 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
 
     expect(headersOf(threadListCalls().at(-1)!)).toMatchObject({
       "X-CSRF": "2",
+    });
+  });
+
+  it("does not fetch with stale capabilities while runtime reconnects", async () => {
+    const { agent } = createMockAgent("alpha");
+    const harness = createHeaderMockCore(
+      { alpha: agent },
+      { Authorization: "Bearer abc" },
+    );
+
+    const inspector = new WebInspectorElement();
+    document.body.appendChild(inspector);
+    inspector.core = harness.core as unknown as WebInspectorElement["core"];
+    harness.emitAgentsChanged();
+
+    await vi.waitFor(() => {
+      expect(threadListCalls().length).toBeGreaterThan(0);
+    });
+
+    fetchMock.mockClear();
+
+    harness.core.runtimeUrl = "http://localhost/new-runtime";
+    harness.core.intelligence = undefined;
+    harness.emitRuntimeConnectionStatusChanged(
+      CopilotKitCoreRuntimeConnectionStatus.Connecting,
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(threadListCalls()).toHaveLength(0);
+
+    harness.core.threadEndpoints = {
+      list: true,
+      inspect: true,
+      mutations: true,
+      realtimeMetadata: false,
+    };
+    harness.core.intelligence = {
+      wsUrl: "ws://localhost/new-runtime/client",
+    };
+    harness.emitRuntimeConnectionStatusChanged(
+      CopilotKitCoreRuntimeConnectionStatus.Connected,
+    );
+
+    await vi.waitFor(() => {
+      expect(threadListCalls().length).toBeGreaterThan(0);
+    });
+
+    expect(String(threadListCalls()[0]![0])).toContain(
+      "http://localhost/new-runtime/threads?",
+    );
+    expect(headersOf(threadListCalls()[0]!)).toMatchObject({
+      Authorization: "Bearer abc",
     });
   });
 });

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -15,6 +15,8 @@ type InspectorInternals = {
   agentStates: Map<string, unknown>;
   cachedTools: Array<{ name: string }>;
   _threads: Array<{ id: string }>;
+  selectedMenu: string;
+  selectedThreadId: string | null;
 };
 
 type InspectorContextInternals = {
@@ -709,6 +711,10 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     fetchMock.mock.calls.filter((call) =>
       String(call[0]).includes("/threads?"),
     );
+  const threadDetailsCalls = () =>
+    fetchMock.mock.calls.filter((call) =>
+      String(call[0]).includes("/threads/thread-1/"),
+    );
 
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -835,5 +841,78 @@ describe("WebInspectorElement owned thread store headers (#5581)", () => {
     expect(headersOf(threadListCalls()[0]!)).toMatchObject({
       Authorization: "Bearer abc",
     });
+  });
+
+  it("clears selected thread and does not render details when reconnect clears threads", async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/threads?")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              threads: [
+                {
+                  id: "thread-1",
+                  organizationId: "org-1",
+                  agentId: "alpha",
+                  createdById: "user-1",
+                  name: "Selected thread",
+                  archived: false,
+                  createdAt: "2026-06-24T12:00:00.000Z",
+                  updatedAt: "2026-06-24T12:00:00.000Z",
+                },
+              ],
+            }),
+        });
+      }
+
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ messages: [] }),
+      });
+    });
+
+    const { agent } = createMockAgent("alpha");
+    const harness = createHeaderMockCore(
+      { alpha: agent },
+      { Authorization: "Bearer abc" },
+    );
+
+    const inspector = new WebInspectorElement();
+    document.body.appendChild(inspector);
+    inspector.core = harness.core as unknown as WebInspectorElement["core"];
+    harness.emitAgentsChanged();
+
+    const internals = getInternals(inspector);
+    await vi.waitFor(() => {
+      expect(internals._threads).toHaveLength(1);
+      expect(internals.selectedThreadId).toBe("thread-1");
+    });
+
+    fetchMock.mockClear();
+
+    harness.core.runtimeUrl = "http://localhost/new-runtime";
+    harness.core.intelligence = undefined;
+    harness.emitRuntimeConnectionStatusChanged(
+      CopilotKitCoreRuntimeConnectionStatus.Connecting,
+    );
+
+    await inspector.updateComplete;
+
+    expect(internals._threads).toEqual([]);
+    expect(internals.selectedThreadId).toBeNull();
+
+    internals.selectedMenu = "threads";
+    inspector.requestUpdate();
+    await inspector.updateComplete;
+    await Promise.resolve();
+
+    expect(
+      inspector.shadowRoot?.querySelector("cpk-thread-details"),
+    ).toBeNull();
+    expect(threadDetailsCalls()).toHaveLength(0);
   });
 });

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -92,6 +92,15 @@ const DOCKED_LEFT_WIDTH = 500; // Sensible width for left dock with collapsed si
 const MAX_AGENT_EVENTS = 200;
 const MAX_TOTAL_EVENTS = 500;
 
+function shouldUpdateOwnedThreadStoreContext(
+  status: CopilotKitCoreRuntimeConnectionStatus | undefined,
+): boolean {
+  return (
+    status === CopilotKitCoreRuntimeConnectionStatus.Connected ||
+    status === CopilotKitCoreRuntimeConnectionStatus.Error
+  );
+}
+
 type InspectorAgentEventType =
   | "RUN_STARTED"
   | "RUN_FINISHED"
@@ -2594,7 +2603,11 @@ export class WebInspectorElement extends LitElement {
 
     const store = ɵcreateThreadStore({ fetch: globalThis.fetch });
     store.start();
-    store.setContext(this.createOwnedThreadStoreContext(agentId, core.headers));
+    if (shouldUpdateOwnedThreadStoreContext(core.runtimeConnectionStatus)) {
+      store.setContext(
+        this.createOwnedThreadStoreContext(agentId, core.headers),
+      );
+    }
     this._ownedThreadStores.set(agentId, store);
     // Subscribe directly so threads render even before the registry callback
     // fires (some published-core code paths land on the subscriber after
@@ -2623,6 +2636,9 @@ export class WebInspectorElement extends LitElement {
   ): void {
     const core = this.core;
     if (!core?.runtimeUrl) return;
+    if (!shouldUpdateOwnedThreadStoreContext(core.runtimeConnectionStatus)) {
+      return;
+    }
     for (const [agentId, store] of this._ownedThreadStores) {
       store.setContext(this.createOwnedThreadStoreContext(agentId, headers));
     }

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -2544,7 +2544,7 @@ export class WebInspectorElement extends LitElement {
     const threadsSub = store.select(ɵselectThreads).subscribe((threads) => {
       this._threadsByAgent.set(agentId, threads as ɵThread[]);
       this._threads = Array.from(this._threadsByAgent.values()).flat();
-      this.autoSelectLatestThread();
+      this.syncSelectedThreadWithThreads();
       this.requestUpdate();
     });
     const errorSub = store.select(ɵselectThreadsError).subscribe((error) => {
@@ -2569,11 +2569,14 @@ export class WebInspectorElement extends LitElement {
       this._threadsErrorByAgent.delete(agentId);
     }
     this._threads = Array.from(this._threadsByAgent.values()).flat();
-    this.autoSelectLatestThread();
+    this.syncSelectedThreadWithThreads();
   }
 
-  private autoSelectLatestThread(): void {
-    if (this._threads.length === 0) return;
+  private syncSelectedThreadWithThreads(): void {
+    if (this._threads.length === 0) {
+      this.selectedThreadId = null;
+      return;
+    }
     const stillValid =
       this.selectedThreadId != null &&
       this._threads.some((t) => t.id === this.selectedThreadId);
@@ -2591,6 +2594,7 @@ export class WebInspectorElement extends LitElement {
     this._threadsByAgent.clear();
     this._threadsErrorByAgent.clear();
     this._threads = [];
+    this.syncSelectedThreadWithThreads();
   }
 
   private ensureOwnedThreadStore(agentId: string): void {
@@ -2715,6 +2719,7 @@ export class WebInspectorElement extends LitElement {
           // Clear stale thread data immediately when the server goes away
           this._threadsByAgent.clear();
           this._threads = [];
+          this.syncSelectedThreadWithThreads();
         }
         this.requestUpdate();
       },
@@ -2749,6 +2754,7 @@ export class WebInspectorElement extends LitElement {
         this._threadsByAgent.delete(agentId);
         this._threadsErrorByAgent.delete(agentId);
         this._threads = Array.from(this._threadsByAgent.values()).flat();
+        this.syncSelectedThreadWithThreads();
         this.requestUpdate();
       },
     } satisfies CopilotKitCoreSubscriber;
@@ -5923,10 +5929,10 @@ ${argsString}</pre
         <!-- Center + right: thread details or empty state -->
         <div style="flex:1;min-width:0;overflow:hidden;display:flex;">
           ${
-            this.selectedThreadId
+            selectedThread
               ? html`<cpk-thread-details
                   style="flex:1;min-width:0;"
-                  .threadId=${this.selectedThreadId}
+                  .threadId=${selectedThread.id}
                   .thread=${selectedThread}
                   .runtimeUrl=${this._core?.runtimeUrl ?? ""}
                   .headers=${this._core?.headers ?? {}}
@@ -5934,20 +5940,13 @@ ${argsString}</pre
                     this._core?.threadEndpoints?.inspect !== false
                   }
                   .liveMessageVersion=${
-                    this.selectedThreadId
-                      ? (this.liveMessageVersion.get(this.selectedThreadId) ??
-                        0)
-                      : 0
+                    this.liveMessageVersion.get(selectedThread.id) ?? 0
                   }
-                  .agentStateInput=${
-                    selectedThread
-                      ? this.getLatestStateForAgent(selectedThread.agentId)
-                      : null
-                  }
+                  .agentStateInput=${this.getLatestStateForAgent(
+                    selectedThread.agentId,
+                  )}
                   .agentEventsInput=${
-                    selectedThread
-                      ? (this.agentEvents.get(selectedThread.agentId) ?? [])
-                      : []
+                    this.agentEvents.get(selectedThread.agentId) ?? []
                   }
                 ></cpk-thread-details>`
               : html`
@@ -6652,7 +6651,7 @@ ${prettyEvent}</pre
       if (this.selectedMenu !== "threads" && !this.core?.telemetryDisabled) {
         trackThreadsTabClicked();
       }
-      this.autoSelectLatestThread();
+      this.syncSelectedThreadWithThreads();
     }
 
     if (key === "ag-ui-events" || key === "agents") {

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -2603,11 +2603,7 @@ export class WebInspectorElement extends LitElement {
 
     const store = ɵcreateThreadStore({ fetch: globalThis.fetch });
     store.start();
-    if (shouldUpdateOwnedThreadStoreContext(core.runtimeConnectionStatus)) {
-      store.setContext(
-        this.createOwnedThreadStoreContext(agentId, core.headers),
-      );
-    }
+    store.setContext(this.getOwnedThreadStoreContext(agentId, core.headers));
     this._ownedThreadStores.set(agentId, store);
     // Subscribe directly so threads render even before the registry callback
     // fires (some published-core code paths land on the subscriber after
@@ -2631,22 +2627,37 @@ export class WebInspectorElement extends LitElement {
     };
   }
 
+  private getOwnedThreadStoreContext(
+    agentId: string,
+    headers: Readonly<Record<string, string>>,
+  ): ɵThreadRuntimeContext | null {
+    const core = this.core;
+    if (
+      !core ||
+      !shouldUpdateOwnedThreadStoreContext(core.runtimeConnectionStatus)
+    ) {
+      return null;
+    }
+    return this.createOwnedThreadStoreContext(agentId, headers);
+  }
+
   private updateOwnedThreadStoreContexts(
     headers: Readonly<Record<string, string>> = this.core?.headers ?? {},
   ): void {
-    const core = this.core;
-    if (!core?.runtimeUrl) return;
-    if (!shouldUpdateOwnedThreadStoreContext(core.runtimeConnectionStatus)) {
-      return;
-    }
     for (const [agentId, store] of this._ownedThreadStores) {
-      store.setContext(this.createOwnedThreadStoreContext(agentId, headers));
+      store.setContext(this.getOwnedThreadStoreContext(agentId, headers));
     }
   }
 
   private refreshOwnedThreadStore(agentId: string): void {
     const store = this._ownedThreadStores.get(agentId);
     if (!store) return;
+    if (
+      this.core?.runtimeConnectionStatus !==
+      CopilotKitCoreRuntimeConnectionStatus.Connected
+    ) {
+      return;
+    }
     // refresh() re-fetches without resetting threads to [] first, so the list
     // stays visible while new data loads and survives transient fetch failures.
     store.refresh();

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -19,6 +19,7 @@ import type {
   CopilotKitCoreErrorCode,
   ɵThreadStore,
   ɵThread,
+  ɵThreadRuntimeContext,
 } from "@copilotkit/core";
 import type { AbstractAgent, AgentSubscriber } from "@ag-ui/client";
 import type {
@@ -2593,18 +2594,38 @@ export class WebInspectorElement extends LitElement {
 
     const store = ɵcreateThreadStore({ fetch: globalThis.fetch });
     store.start();
-    store.setContext({
-      runtimeUrl: core.runtimeUrl,
-      headers: { ...core.headers },
-      wsUrl: core.intelligence?.wsUrl,
-      agentId,
-    });
+    store.setContext(this.createOwnedThreadStoreContext(agentId, core.headers));
     this._ownedThreadStores.set(agentId, store);
     // Subscribe directly so threads render even before the registry callback
     // fires (some published-core code paths land on the subscriber after
     // registerThreadStore returns).
     this.subscribeToThreadStore(agentId, store);
     core.registerThreadStore(agentId, store);
+  }
+
+  private createOwnedThreadStoreContext(
+    agentId: string,
+    headers: Readonly<Record<string, string>>,
+  ): ɵThreadRuntimeContext {
+    const core = this.core;
+    return {
+      runtimeUrl: core?.runtimeUrl,
+      headers: { ...headers },
+      wsUrl: core?.intelligence?.wsUrl,
+      agentId,
+      threadEndpoints: core?.threadEndpoints,
+      runtimeConnectionStatus: core?.runtimeConnectionStatus,
+    };
+  }
+
+  private updateOwnedThreadStoreContexts(
+    headers: Readonly<Record<string, string>> = this.core?.headers ?? {},
+  ): void {
+    const core = this.core;
+    if (!core?.runtimeUrl) return;
+    for (const [agentId, store] of this._ownedThreadStores) {
+      store.setContext(this.createOwnedThreadStoreContext(agentId, headers));
+    }
   }
 
   private refreshOwnedThreadStore(agentId: string): void {
@@ -2622,15 +2643,7 @@ export class WebInspectorElement extends LitElement {
   private updateOwnedThreadStoreHeaders(
     headers: Readonly<Record<string, string>>,
   ): void {
-    const core = this.core;
-    if (!core?.runtimeUrl) return;
-    for (const [agentId, store] of this._ownedThreadStores) {
-      store.setContext({
-        runtimeUrl: core.runtimeUrl,
-        headers: { ...headers },
-        agentId,
-      });
-    }
+    this.updateOwnedThreadStoreContexts(headers);
   }
 
   private removeOwnedThreadStore(agentId: string): void {
@@ -2657,6 +2670,7 @@ export class WebInspectorElement extends LitElement {
     this.coreSubscriber = {
       onRuntimeConnectionStatusChanged: ({ status }) => {
         this.runtimeStatus = status;
+        this.updateOwnedThreadStoreContexts();
         if (status === "connected") {
           if (!core.telemetryDisabled) {
             ensureTelemetryDistinctId();


### PR DESCRIPTION
## Summary

Implements the Angular `injectThreads()` design from the PDD on a fresh branch.

- Adds public `injectThreads()` exports for `@copilotkit/angular`, including Angular signal state, static/signal inputs, mutations, cleanup, reconnect handling, and `unarchiveThread` parity.
- Moves thread list capability/error/realtime handling into the shared core thread store behavior behind `ɵcreateThreadStore`.
- Keeps React `useThreads()` on the shared store while preserving its public API, including transient reconnect and stable-header behavior.
- Adds core, Angular, and React regression coverage for runtime/capability errors, realtime teardown, reconnect input changes, header stability, and mutation paths.

## Validation

- `pnpm nx run-many -t test -p @copilotkit/core @copilotkit/angular @copilotkit/react-core --skip-nx-cache`
- `pnpm nx run-many -t check-types -p @copilotkit/core @copilotkit/angular @copilotkit/react-core --skip-nx-cache`
- `pnpm nx run @copilotkit/angular:build --skip-nx-cache`
- Delegated pre-push gate:
  - `pnpm exec oxfmt --check <touched files>`
  - `pnpm lint` (0 errors; existing warnings only)
  - `pnpm nx run-many -t check-types -p @copilotkit/core @copilotkit/angular @copilotkit/react-core --skip-nx-cache`
  - `pnpm nx run-many -t test -p @copilotkit/core @copilotkit/angular @copilotkit/react-core --skip-nx-cache`
  - `pnpm nx run-many -t build -p @copilotkit/core @copilotkit/angular @copilotkit/react-core --skip-nx-cache`
  - `git diff --check`

## Notes

Opened as draft per repo workflow. Review confirmations found no remaining spec compliance or code quality issues.
