### PR TITLE
Isolate MAF agent instructions per request

### DIFF
--- a/showcase/integrations/ms-agent-python/src/agents/_request_scoped_instructions.py
+++ b/showcase/integrations/ms-agent-python/src/agents/_request_scoped_instructions.py
@@ -1,0 +1,67 @@
+"""Run MS Agent Framework agents with request-local instructions.
+
+Agent Framework stores the agent system prompt in ``default_options``. These
+showcase agents are mounted as FastAPI singletons, so mutating that shared
+dictionary for one request can leak instructions into another concurrent
+request. This module keeps the shared agent immutable and overlays
+``instructions`` only on the individual ``run`` call.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ag_ui.core import BaseEvent
+    from agent_framework_ag_ui import AgentFrameworkAgent
+else:
+    BaseEvent = Any
+    AgentFrameworkAgent = Any
+
+
+class _InstructionScopedAgent:
+    """Proxy an Agent while injecting request-local run options."""
+
+    def __init__(self, agent: Any, instructions: str) -> None:
+        self._agent = agent
+        self._instructions = instructions
+
+        base_options = getattr(agent, "default_options", None)
+        self.default_options = (
+            dict(base_options) if isinstance(base_options, dict) else {}
+        )
+        self.default_options["instructions"] = instructions
+
+        self.id = getattr(agent, "id", None)
+        self.name = getattr(agent, "name", None)
+        self.description = getattr(agent, "description", None)
+        self.client = getattr(agent, "client", None)
+        self.mcp_tools = getattr(agent, "mcp_tools", None)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._agent, name)
+
+    def run(self, messages: Any = None, *args: Any, **kwargs: Any) -> Any:
+        options = dict(kwargs.get("options") or {})
+        options["instructions"] = self._instructions
+        kwargs["options"] = options
+        return self._agent.run(messages, *args, **kwargs)
+
+
+async def run_with_request_instructions(
+    wrapper: AgentFrameworkAgent,
+    input_data: dict[str, Any],
+    instructions: str,
+) -> AsyncGenerator[BaseEvent, None]:
+    """Delegate to ``wrapper`` with instructions scoped to this run only."""
+    from agent_framework_ag_ui._agent_run import run_agent_stream  # type: ignore
+
+    scoped_agent = _InstructionScopedAgent(wrapper.agent, instructions)
+    async for event in run_agent_stream(
+        input_data,
+        scoped_agent,
+        wrapper.config,
+        pending_approvals=wrapper._pending_approvals,
+    ):
+        yield event

--- a/showcase/integrations/ms-agent-python/src/agents/_request_scoped_instructions.py
+++ b/showcase/integrations/ms-agent-python/src/agents/_request_scoped_instructions.py
@@ -10,6 +10,7 @@ request. This module keeps the shared agent immutable and overlays
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
+from copy import copy
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -54,14 +55,21 @@ async def run_with_request_instructions(
     input_data: dict[str, Any],
     instructions: str,
 ) -> AsyncGenerator[BaseEvent, None]:
-    """Delegate to ``wrapper`` with instructions scoped to this run only."""
-    from agent_framework_ag_ui._agent_run import run_agent_stream  # type: ignore
+    """Run a request-local agent through the adapter's public API.
 
-    scoped_agent = _InstructionScopedAgent(wrapper.agent, instructions)
-    async for event in run_agent_stream(
-        input_data,
-        scoped_agent,
-        wrapper.config,
-        pending_approvals=wrapper._pending_approvals,
-    ):
+    ``AgentFrameworkAgent`` changed its public entry point from ``run_agent``
+    to ``run`` during its beta period. A shallow wrapper clone preserves its
+    configuration and internal state while substituting only the agent for this
+    invocation; the shared singleton remains untouched.
+    """
+    scoped_wrapper = copy(wrapper)
+    scoped_wrapper.agent = _InstructionScopedAgent(wrapper.agent, instructions)
+
+    run = getattr(scoped_wrapper, "run", None) or getattr(
+        scoped_wrapper, "run_agent", None
+    )
+    if run is None:
+        raise TypeError("AgentFrameworkAgent exposes neither run nor run_agent")
+
+    async for event in run(input_data):
         yield event

--- a/showcase/integrations/ms-agent-python/src/agents/agent_config_agent.py
+++ b/showcase/integrations/ms-agent-python/src/agents/agent_config_agent.py
@@ -7,8 +7,8 @@ per turn.
 The CopilotKit provider's ``properties`` prop is wired through the runtime as
 ``forwardedProps`` on each AG-UI run. Because Microsoft Agent Framework agents
 store their system prompt in ``default_options["instructions"]``, we subclass
-``AgentFrameworkAgent`` and intercept ``run`` to swap in a freshly-built
-instruction string for the duration of each invocation.
+``AgentFrameworkAgent`` and intercept ``run`` to pass a freshly-built
+instruction string as request-local run options.
 
 Invalid or missing values fall back to the corresponding ``DEFAULT_*``
 constant -- this function never raises so the demo can't deadlock on a bad
@@ -24,6 +24,7 @@ from typing import Any, Literal
 from ag_ui.core import BaseEvent
 from agent_framework import Agent, BaseChatClient
 from agent_framework_ag_ui import AgentFrameworkAgent
+from agents._request_scoped_instructions import run_with_request_instructions
 
 Tone = Literal["professional", "casual", "enthusiastic"]
 Expertise = Literal["beginner", "intermediate", "expert"]
@@ -99,8 +100,8 @@ class AgentConfigFrameworkAgent(AgentFrameworkAgent):
     """AgentFrameworkAgent that rebuilds its system prompt per request.
 
     Overrides ``run`` to read ``forwardedProps`` from the AG-UI input
-    and temporarily replace the wrapped agent's ``instructions`` option before
-    delegating to the standard orchestrator chain.
+    and pass it as request-local ``instructions`` before delegating to the
+    standard orchestrator chain. The wrapped singleton agent is never mutated.
     """
 
     async def run(  # type: ignore[override]
@@ -112,22 +113,10 @@ class AgentConfigFrameworkAgent(AgentFrameworkAgent):
             props["tone"], props["expertise"], props["response_length"]
         )
 
-        options = getattr(self.agent, "default_options", None)
-        if not isinstance(options, dict):
-            async for event in super().run(input_data):
-                yield event
-            return
-
-        previous_instructions = options.get("instructions")
-        options["instructions"] = system_prompt
-        try:
-            async for event in super().run(input_data):
-                yield event
-        finally:
-            if previous_instructions is None:
-                options.pop("instructions", None)
-            else:
-                options["instructions"] = previous_instructions
+        async for event in run_with_request_instructions(
+            self, input_data, system_prompt
+        ):
+            yield event
 
 
 def create_agent_config_agent(chat_client: BaseChatClient) -> AgentConfigFrameworkAgent:

--- a/showcase/integrations/ms-agent-python/src/agents/agent_config_agent.py
+++ b/showcase/integrations/ms-agent-python/src/agents/agent_config_agent.py
@@ -18,7 +18,6 @@ payload.
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
-from textwrap import dedent
 from typing import Any, Literal
 
 from ag_ui.core import BaseEvent
@@ -122,21 +121,13 @@ class AgentConfigFrameworkAgent(AgentFrameworkAgent):
 def create_agent_config_agent(chat_client: BaseChatClient) -> AgentConfigFrameworkAgent:
     """Instantiate the Agent Config demo agent.
 
-    The base MS Agent Framework ``Agent`` carries only a neutral fallback
-    instruction. The real behavioural steering happens in the per-request
-    instruction string applied by ``AgentConfigFrameworkAgent.run``.
+    The base MS Agent Framework ``Agent`` is intentionally instruction-less.
+    The complete instruction is applied once per request by
+    ``AgentConfigFrameworkAgent.run``.
     """
     base_agent = Agent(
         client=chat_client,
         name="agent_config",
-        instructions=dedent(
-            """
-            You are a helpful assistant. Follow the tone, expertise level, and
-            response-length directives provided in the system message for each
-            turn. If no directive is provided, use professional / intermediate
-            / concise defaults.
-            """.strip()
-        ),
         tools=[],
     )
 

--- a/showcase/integrations/ms-agent-python/src/agents/readonly_state_agent_context.py
+++ b/showcase/integrations/ms-agent-python/src/agents/readonly_state_agent_context.py
@@ -18,6 +18,7 @@ from typing import Any
 from ag_ui.core import BaseEvent
 from agent_framework import Agent, BaseChatClient
 from agent_framework_ag_ui import AgentFrameworkAgent
+from agents._request_scoped_instructions import run_with_request_instructions
 
 
 SYSTEM_PROMPT = dedent(
@@ -62,8 +63,9 @@ class ReadonlyContextFrameworkAgent(AgentFrameworkAgent):
 
     LangGraph gets this behavior from CopilotKitMiddleware. The MS Agent
     adapter receives the AG-UI `context` entries in `input_data`, so this
-    shim appends them to the wrapped agent's instruction string before
-    delegating to the standard Agent Framework runner.
+    shim appends them to request-local instructions before delegating to the
+    standard Agent Framework runner. The wrapped singleton agent is never
+    mutated.
     """
 
     async def run(  # type: ignore[override]
@@ -76,22 +78,10 @@ class ReadonlyContextFrameworkAgent(AgentFrameworkAgent):
                 yield event
             return
 
-        options = getattr(self.agent, "default_options", None)
-        if not isinstance(options, dict):
-            async for event in super().run(input_data):
-                yield event
-            return
-
-        previous_instructions = options.get("instructions")
-        options["instructions"] = f"{SYSTEM_PROMPT}\n\n{context_prompt}"
-        try:
-            async for event in super().run(input_data):
-                yield event
-        finally:
-            if previous_instructions is None:
-                options.pop("instructions", None)
-            else:
-                options["instructions"] = previous_instructions
+        async for event in run_with_request_instructions(
+            self, input_data, f"{SYSTEM_PROMPT}\n\n{context_prompt}"
+        ):
+            yield event
 
 
 def create_readonly_state_agent_context(

--- a/showcase/integrations/ms-agent-python/src/agents/readonly_state_agent_context.py
+++ b/showcase/integrations/ms-agent-python/src/agents/readonly_state_agent_context.py
@@ -73,14 +73,11 @@ class ReadonlyContextFrameworkAgent(AgentFrameworkAgent):
         input_data: dict[str, Any],
     ) -> AsyncGenerator[BaseEvent, None]:
         context_prompt = build_context_system_message(input_data.get("context"))
-        if not context_prompt:
-            async for event in super().run(input_data):
-                yield event
-            return
+        instructions = SYSTEM_PROMPT
+        if context_prompt:
+            instructions = f"{SYSTEM_PROMPT}\n\n{context_prompt}"
 
-        async for event in run_with_request_instructions(
-            self, input_data, f"{SYSTEM_PROMPT}\n\n{context_prompt}"
-        ):
+        async for event in run_with_request_instructions(self, input_data, instructions):
             yield event
 
 
@@ -91,7 +88,6 @@ def create_readonly_state_agent_context(
     base_agent = Agent(
         client=chat_client,
         name="readonly_state_agent_context",
-        instructions=SYSTEM_PROMPT,
         tools=[],
     )
 

--- a/showcase/integrations/ms-agent-python/tests/python/test_request_scoped_instructions.py
+++ b/showcase/integrations/ms-agent-python/tests/python/test_request_scoped_instructions.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+
+from agents._request_scoped_instructions import _InstructionScopedAgent
+
+
+class _StubAgent:
+    def __init__(self) -> None:
+        self.default_options = {
+            "instructions": "<fallback>",
+            "metadata": {"shared": True},
+        }
+        self.calls: list[dict] = []
+
+    async def run(self, messages=None, **kwargs):
+        await asyncio.sleep(kwargs.pop("delay"))
+        self.calls.append(kwargs["options"])
+        return kwargs["options"]["instructions"]
+
+
+def test_request_scoped_instructions_do_not_mutate_shared_defaults():
+    async def run() -> tuple[str, str, dict]:
+        shared_agent = _StubAgent()
+        first = _InstructionScopedAgent(shared_agent, "<first>")
+        second = _InstructionScopedAgent(shared_agent, "<second>")
+
+        first_result, second_result = await asyncio.gather(
+            first.run(options={"store": True}, delay=0.02),
+            second.run(options={"metadata": {"request": 2}}, delay=0.01),
+        )
+
+        return first_result, second_result, shared_agent.default_options
+
+    first_result, second_result, default_options = asyncio.run(run())
+
+    assert first_result == "<first>"
+    assert second_result == "<second>"
+    assert default_options == {
+        "instructions": "<fallback>",
+        "metadata": {"shared": True},
+    }

--- a/showcase/integrations/ms-agent-python/tests/python/test_request_scoped_instructions.py
+++ b/showcase/integrations/ms-agent-python/tests/python/test_request_scoped_instructions.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import sys
+import types
 
-from agents._request_scoped_instructions import _InstructionScopedAgent
+from agents._request_scoped_instructions import (
+    _InstructionScopedAgent,
+    run_with_request_instructions,
+)
 
 
 class _StubAgent:
@@ -20,7 +25,7 @@ class _StubAgent:
 
 
 def test_request_scoped_instructions_do_not_mutate_shared_defaults():
-    async def run() -> tuple[str, str, dict]:
+    async def run() -> tuple[str, str, dict, list[dict]]:
         shared_agent = _StubAgent()
         first = _InstructionScopedAgent(shared_agent, "<first>")
         second = _InstructionScopedAgent(shared_agent, "<second>")
@@ -30,9 +35,14 @@ def test_request_scoped_instructions_do_not_mutate_shared_defaults():
             second.run(options={"metadata": {"request": 2}}, delay=0.01),
         )
 
-        return first_result, second_result, shared_agent.default_options
+        return (
+            first_result,
+            second_result,
+            shared_agent.default_options,
+            shared_agent.calls,
+        )
 
-    first_result, second_result, default_options = asyncio.run(run())
+    first_result, second_result, default_options, calls = asyncio.run(run())
 
     assert first_result == "<first>"
     assert second_result == "<second>"
@@ -40,3 +50,114 @@ def test_request_scoped_instructions_do_not_mutate_shared_defaults():
         "instructions": "<fallback>",
         "metadata": {"shared": True},
     }
+
+    calls_by_instruction = {call["instructions"]: call for call in calls}
+    assert calls_by_instruction == {
+        "<first>": {"store": True, "instructions": "<first>"},
+        "<second>": {
+            "metadata": {"request": 2},
+            "instructions": "<second>",
+        },
+    }
+
+
+def test_run_with_request_instructions_scopes_concurrent_runs(monkeypatch):
+    seen_runs: list[dict] = []
+
+    async def fake_run_agent_stream(
+        input_data,
+        agent,
+        config,
+        pending_approvals=None,
+    ):
+        await asyncio.sleep(input_data["delay"])
+        result = await agent.run(
+            options=input_data["options"],
+            delay=input_data["delay"],
+        )
+        run_options = agent.calls[-1]
+        seen_runs.append(
+            {
+                "input": input_data["name"],
+                "default_instructions": agent.default_options["instructions"],
+                "run_options": run_options,
+                "config": config,
+                "pending_approvals": pending_approvals,
+            }
+        )
+        yield result
+
+    ag_ui_module = types.ModuleType("agent_framework_ag_ui")
+    ag_ui_module.__path__ = []
+    agent_run_module = types.ModuleType("agent_framework_ag_ui._agent_run")
+    agent_run_module.run_agent_stream = fake_run_agent_stream
+    monkeypatch.setitem(sys.modules, "agent_framework_ag_ui", ag_ui_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "agent_framework_ag_ui._agent_run",
+        agent_run_module,
+    )
+
+    async def run() -> tuple[list[str], list[dict], list[dict]]:
+        shared_agent = _StubAgent()
+        wrapper = types.SimpleNamespace(
+            agent=shared_agent,
+            config={"config": True},
+            _pending_approvals={"approval": "pending"},
+        )
+
+        first_events, second_events = await asyncio.gather(
+            _collect_events(
+                run_with_request_instructions(
+                    wrapper,
+                    {
+                        "name": "first",
+                        "options": {"store": True},
+                        "delay": 0.02,
+                    },
+                    "<first>",
+                )
+            ),
+            _collect_events(
+                run_with_request_instructions(
+                    wrapper,
+                    {
+                        "name": "second",
+                        "options": {"metadata": {"request": 2}},
+                        "delay": 0.01,
+                    },
+                    "<second>",
+                )
+            ),
+        )
+
+        return [*first_events, *second_events], seen_runs, shared_agent.calls
+
+    events, runs, calls = asyncio.run(run())
+
+    assert sorted(events) == ["<first>", "<second>"]
+
+    runs_by_instruction = {
+        run["default_instructions"]: run for run in runs
+    }
+    assert runs_by_instruction["<first>"]["run_options"] == {
+        "store": True,
+        "instructions": "<first>",
+    }
+    assert runs_by_instruction["<second>"]["run_options"] == {
+        "metadata": {"request": 2},
+        "instructions": "<second>",
+    }
+    assert {
+        run["default_instructions"] for run in runs
+    } == {"<first>", "<second>"}
+    assert all(run["config"] == {"config": True} for run in runs)
+    assert all(run["pending_approvals"] == {"approval": "pending"} for run in runs)
+
+    calls_by_instruction = {call["instructions"]: call for call in calls}
+    assert calls_by_instruction["<first>"]["store"] is True
+    assert calls_by_instruction["<second>"]["metadata"] == {"request": 2}
+
+
+async def _collect_events(stream):
+    return [event async for event in stream]

--- a/showcase/integrations/ms-agent-python/tests/python/test_request_scoped_instructions.py
+++ b/showcase/integrations/ms-agent-python/tests/python/test_request_scoped_instructions.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-import sys
-import types
+
+import pytest
 
 from agents._request_scoped_instructions import (
     _InstructionScopedAgent,
@@ -61,60 +61,45 @@ def test_request_scoped_instructions_do_not_mutate_shared_defaults():
     }
 
 
-def test_run_with_request_instructions_scopes_concurrent_runs(monkeypatch):
+def test_run_with_request_instructions_scopes_concurrent_runs():
     seen_runs: list[dict] = []
+    wrapper: _PublicWrapper | None = None
 
-    async def fake_run_agent_stream(
-        input_data,
-        agent,
-        config,
-        pending_approvals=None,
-    ):
-        await asyncio.sleep(input_data["delay"])
-        result = await agent.run(
-            options=input_data["options"],
-            delay=input_data["delay"],
-        )
-        run_options = agent.calls[-1]
-        seen_runs.append(
-            {
-                "input": input_data["name"],
-                "default_instructions": agent.default_options["instructions"],
-                "run_options": run_options,
-                "config": config,
-                "pending_approvals": pending_approvals,
-            }
-        )
-        yield result
+    class _PublicWrapper:
+        def __init__(self, agent):
+            self.agent = agent
+            self.shared_state = {"approval": "pending"}
 
-    ag_ui_module = types.ModuleType("agent_framework_ag_ui")
-    ag_ui_module.__path__ = []
-    agent_run_module = types.ModuleType("agent_framework_ag_ui._agent_run")
-    agent_run_module.run_agent_stream = fake_run_agent_stream
-    monkeypatch.setitem(sys.modules, "agent_framework_ag_ui", ag_ui_module)
-    monkeypatch.setitem(
-        sys.modules,
-        "agent_framework_ag_ui._agent_run",
-        agent_run_module,
-    )
+        async def run(self, input_data):
+            assert wrapper is not None
+            assert self is not wrapper
+            assert self.shared_state is wrapper.shared_state
+            agent = self.agent
+            await asyncio.sleep(input_data["delay"])
+            result = await agent.run(
+                options=input_data["options"],
+                delay=input_data["delay"],
+            )
+            run_options = agent.calls[-1]
+            seen_runs.append(
+                {
+                    "input": input_data["name"],
+                    "default_instructions": agent.default_options["instructions"],
+                    "run_options": run_options,
+                }
+            )
+            yield result
 
     async def run() -> tuple[list[str], list[dict], list[dict]]:
         shared_agent = _StubAgent()
-        wrapper = types.SimpleNamespace(
-            agent=shared_agent,
-            config={"config": True},
-            _pending_approvals={"approval": "pending"},
-        )
+        nonlocal wrapper
+        wrapper = _PublicWrapper(shared_agent)
 
         first_events, second_events = await asyncio.gather(
             _collect_events(
                 run_with_request_instructions(
                     wrapper,
-                    {
-                        "name": "first",
-                        "options": {"store": True},
-                        "delay": 0.02,
-                    },
+                    {"name": "first", "options": {"store": True}, "delay": 0.02},
                     "<first>",
                 )
             ),
@@ -136,10 +121,7 @@ def test_run_with_request_instructions_scopes_concurrent_runs(monkeypatch):
     events, runs, calls = asyncio.run(run())
 
     assert sorted(events) == ["<first>", "<second>"]
-
-    runs_by_instruction = {
-        run["default_instructions"]: run for run in runs
-    }
+    runs_by_instruction = {run["default_instructions"]: run for run in runs}
     assert runs_by_instruction["<first>"]["run_options"] == {
         "store": True,
         "instructions": "<first>",
@@ -151,12 +133,47 @@ def test_run_with_request_instructions_scopes_concurrent_runs(monkeypatch):
     assert {
         run["default_instructions"] for run in runs
     } == {"<first>", "<second>"}
-    assert all(run["config"] == {"config": True} for run in runs)
-    assert all(run["pending_approvals"] == {"approval": "pending"} for run in runs)
 
     calls_by_instruction = {call["instructions"]: call for call in calls}
     assert calls_by_instruction["<first>"]["store"] is True
     assert calls_by_instruction["<second>"]["metadata"] == {"request": 2}
+
+
+def test_run_with_request_instructions_supports_beta_public_entry_point():
+    seen: list[str] = []
+
+    class _BetaWrapper:
+        def __init__(self, agent):
+            self.agent = agent
+
+        async def run_agent(self, input_data):
+            seen.append(self.agent.default_options["instructions"])
+            yield input_data["event"]
+
+    async def run():
+        wrapper = _BetaWrapper(_StubAgent())
+        return [
+            event
+            async for event in run_with_request_instructions(
+                wrapper, {"event": "ok"}, "<beta>"
+            )
+        ]
+
+    assert asyncio.run(run()) == ["ok"]
+    assert seen == ["<beta>"]
+
+
+def test_instructionless_default_produces_one_final_instruction():
+    """Exercise Agent Framework's real merge semantics, not a local fake."""
+    agents_module = pytest.importorskip("agent_framework._agents")
+    merge_options = agents_module._merge_options
+
+    final_options = merge_options({}, {"instructions": "<request>"})
+
+    assert final_options["instructions"] == "<request>"
+    assert "<fallback>\n<request>" == merge_options(
+        {"instructions": "<fallback>"}, {"instructions": "<request>"}
+    )["instructions"]
 
 
 async def _collect_events(stream):


### PR DESCRIPTION
## Summary
Fixes #5659.

The MS Agent Framework showcase mounts several agents as FastAPI singletons. Two of those agents were temporarily mutating the singleton agent's `default_options["instructions"]` per request, which can leak one user's generated system prompt or `useAgentContext` payload into another concurrent request.

## Changes
- Added a request-scoped instruction proxy that overlays `instructions` into per-run options instead of mutating the shared agent.
- Updated the Agent Config and readonly `useAgentContext` agents to use the request-scoped path.
- Added a regression test that exercises concurrent instruction overlays and verifies shared defaults stay unchanged.

## Testing
- `python -m pytest showcase/integrations/ms-agent-python/tests/python/test_request_scoped_instructions.py`
- `python -m py_compile ...`
- `git diff --check`
