### PR TITLE
fix: add configurable Slack response routing

### DIFF
--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -80,6 +80,11 @@ const bot = createBot({
     slack({
       botToken: process.env.SLACK_BOT_TOKEN!,
       appToken: process.env.SLACK_APP_TOKEN!,
+      respondTo: {
+        directMessages: true,
+        appMentions: { reply: "thread" },
+        threadReplies: "mentionsOnly",
+      },
     }),
   ],
   // One AG-UI agent per conversation, pointed at the runtime.
@@ -96,7 +101,7 @@ const bot = createBot({
   context: [...defaultSlackContext, ...appContext],
 });
 
-// One handler covers @-mentions, replies in threads the bot owns, and DMs.
+// One handler covers explicit @-mentions and normal DMs.
 // senderContext names the requesting user so the agent acts "as" them.
 bot.onMention(async ({ thread, message }) => {
   await thread.runAgent({ context: senderContext(message.user) });
@@ -104,6 +109,11 @@ bot.onMention(async ({ thread, message }) => {
 
 await bot.start();
 ```
+
+The runnable Slack example keeps DMs and the assistant pane conversational, but
+channel/private-channel threads require `@Kite` on each follow-up by default.
+Set `respondTo.threadReplies: "afterBotReply"` to restore legacy behavior where
+plain replies in a thread can continue after the bot has posted there.
 
 ### Tools (`app/tools/index.ts`)
 
@@ -251,6 +261,10 @@ several from one process).
   bot token (`SLACK_BOT_TOKEN`).
 - _Basic Information → App-Level Tokens_ → generate one with
   `connections:write` → copy the `xapp-` app token (`SLACK_APP_TOKEN`).
+- The manifest is tuned for mention-only channel threads. If you enable
+  `respondTo.threadReplies: "afterBotReply"`, also subscribe to
+  `message.channels` and `message.groups` so Slack delivers plain thread
+  replies.
 
 ### 1b. Discord app (set `DISCORD_*` to enable Discord)
 
@@ -321,8 +335,9 @@ pnpm --filter slack-example dev       # tsx watch app/index.ts
 
 ### 6. Try it
 
-@mention the bot in a channel (Slack/Discord) or DM it / @mention it in a group
-(Telegram):
+@mention the bot in a channel (Slack/Discord) or DM it / @mention it in a
+group (Telegram). In Slack channel threads, mention Kite again for each
+follow-up unless you enabled legacy thread continuation:
 
 > @CopilotKit Triage what are the open CPK issues this cycle?
 

--- a/examples/slack/app/index.ts
+++ b/examples/slack/app/index.ts
@@ -85,6 +85,14 @@ async function main() {
         // `:wrench:` rows, or pane "is using `tool`…" status). Tools still run;
         // only the display is hidden.
         showToolStatus: false,
+        // Kite keeps DMs conversational and responds to explicit app mentions
+        // in channels/threads. Plain channel thread replies stay quiet unless
+        // they mention Kite again.
+        respondTo: {
+          directMessages: true,
+          appMentions: { reply: "thread" },
+          threadReplies: "mentionsOnly",
+        },
         // Assistant-pane behavior is ON by default; this just customizes it.
         // The greeting + chips show when a user opens the pane (matching the
         // app manifest's `assistant_view`); native streaming + status need no
@@ -203,9 +211,9 @@ async function main() {
   });
 
   // The turn handler. Each adapter pre-filters ingress to the turns this bot
-  // should answer — @-mentions, replies in threads it owns, and DMs (and every
-  // WhatsApp message). createBot is mention-preferred: a single handler covers
-  // all of them across every active platform. `senderContext` names the
+  // should answer — DMs, explicit mentions, and every WhatsApp message.
+  // createBot is mention-preferred: a single handler covers them across every
+  // active platform. `senderContext` names the
   // requesting user per `thread.platform`, so the label is correct on whichever
   // surface the turn arrived from. (The feature demos below add their own
   // handlers — onReaction, onModalSubmit, onThreadStarted.) Wrap the turn so a

--- a/examples/slack/slack-app-manifest.json
+++ b/examples/slack/slack-app-manifest.json
@@ -91,8 +91,6 @@
         "app_mention",
         "assistant_thread_started",
         "assistant_thread_context_changed",
-        "message.channels",
-        "message.groups",
         "message.im",
         "message.mpim",
         "reaction_added",

--- a/examples/slack/slack-app-manifest.yaml
+++ b/examples/slack/slack-app-manifest.yaml
@@ -79,10 +79,10 @@ settings:
       - app_mention
       - assistant_thread_started # user opened the assistant pane
       - assistant_thread_context_changed # the channel/context the user is viewing
-      - message.channels # messages in public channels the bot is in
-      - message.groups # messages in private channels the bot is in
       - message.im # DMs to the bot + assistant-pane messages
       - message.mpim # messages in group DMs the bot is in
+      # Add message.channels/message.groups only when using
+      # respondTo.threadReplies: "afterBotReply" for legacy plain thread continuation.
       - reaction_added # required for the emoji-triage demo (bot.onReaction)
       - reaction_removed # required for the emoji-triage demo (bot.onReaction)
   interactivity:

--- a/packages/bot-discord/README.md
+++ b/packages/bot-discord/README.md
@@ -53,9 +53,8 @@ await bot.start();
 
 `discord(opts)` returns a `DiscordAdapter`. The adapter connects via the
 Discord Gateway (WebSocket) — no public URL required. The listener pre-filters
-ingress to the turns the bot should answer (@-mentions in guild channels,
-replies in threads it owns, and DMs), so a single `onMention` handler covers
-most use cases.
+ingress to the turns the bot should answer (@-mentions in guild channels and
+DMs), so a single `onMention` handler covers most use cases.
 
 ### Required env
 

--- a/packages/bot-slack/README.md
+++ b/packages/bot-slack/README.md
@@ -44,9 +44,9 @@ await bot.start();
 `slack(opts)` returns a `SlackAdapter`. By default it runs in **Socket Mode**
 (`socketMode: true`) — outbound WebSocket only, no public URL needed. HTTP
 mode (`socketMode: false`) needs `signingSecret` and a `port`. The Slack
-listener pre-filters ingress to the turns the bot should answer (@-mentions,
-replies in threads it owns, DMs), so a single `onMention` handler usually
-covers everything.
+listener pre-filters ingress to the turns the bot should answer. By default,
+DMs are conversational, app mentions respond in-thread, and plain replies in
+channel/private-channel threads require another app mention.
 
 ### Required env
 
@@ -54,6 +54,47 @@ covers everything.
 | ----------------- | ------- | -------------------------------- |
 | `SLACK_BOT_TOKEN` | `xoxb-` | Bot token for the Web API.       |
 | `SLACK_APP_TOKEN` | `xapp-` | App-level token for Socket Mode. |
+
+## Response routing
+
+Use `respondTo` to choose which Slack message events become `onMention` turns:
+
+| Surface                                 | Default behavior        | Option                                                |
+| --------------------------------------- | ----------------------- | ----------------------------------------------------- |
+| Direct messages (`message.im`)          | Respond                 | `respondTo.directMessages`                            |
+| App mentions (`app_mention`)            | Respond in-thread       | `respondTo.appMentions` / `appMentions.reply`         |
+| Plain channel/private-channel replies   | Ignore unless mentioned | `respondTo.threadReplies: "afterBotReply"` for legacy |
+| Assistant pane                          | Separate default-on API | `assistant`; not controlled by `respondTo`            |
+| Slash commands, reactions, interactions | Explicit trigger paths  | Not controlled by `respondTo`                         |
+
+```ts
+// Default routing made explicit.
+slack({
+  botToken,
+  appToken,
+  respondTo: {
+    directMessages: true,
+    appMentions: { reply: "thread" },
+    threadReplies: "mentionsOnly",
+  },
+});
+```
+
+```ts
+// Legacy owned-thread continuation.
+slack({
+  botToken,
+  appToken,
+  respondTo: {
+    threadReplies: "afterBotReply",
+  },
+});
+```
+
+For the default mention-only thread behavior, subscribe to `app_mention` and
+`message.im` events. Add `message.channels` and `message.groups` only when you
+enable `respondTo.threadReplies: "afterBotReply"` and want Slack to deliver
+plain channel/private-channel thread replies.
 
 ## What it provides
 
@@ -289,7 +330,8 @@ features your app uses:
 
 ## Exports
 
-`slack`, `SlackAdapter`, `SlackAdapterOptions`, `SlackAssistantOptions`;
+`slack`, `SlackAdapter`, `SlackAdapterOptions`, `SlackAssistantOptions`,
+`SlackRespondToOptions`;
 `createRunRenderer`; `decodeInteraction`, `conversationKeyOf`; `renderBlockKit`,
 `renderSlackMessage`, `SLACK_LIMITS`; `defaultSlackTools`,
 `lookupSlackUserTool`, `defaultSlackContext` (+ the individual context

--- a/packages/bot-slack/src/__tests__/slack-listener.test.ts
+++ b/packages/bot-slack/src/__tests__/slack-listener.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi } from "vitest";
 import { attachSlackListener } from "../slack-listener.js";
 import type { SlackCommand } from "../slack-listener.js";
 import type { SlackConversationStore } from "../conversation-store.js";
-import type { IncomingTurn } from "../types.js";
-import { DM_SCOPE } from "../types.js";
+import type { IncomingTurn, ResolvedSlackRespondToOptions } from "../types.js";
+import { DM_SCOPE, resolveSlackRespondToOptions } from "../types.js";
 
 const BOT_USER_ID = "UBOT0001";
 
@@ -69,6 +69,7 @@ function fakeStore(
 function setup(opts?: {
   ownedThreads?: Array<{ channelId: string; threadTs: string }>;
   assistantThreads?: Array<{ channel: string; threadTs: string }>;
+  respondTo?: ResolvedSlackRespondToOptions;
 }) {
   const store = fakeStore(
     (opts?.ownedThreads ?? []).map((t) => ({
@@ -92,6 +93,7 @@ function setup(opts?: {
     app: fake.app,
     store,
     botUserId: BOT_USER_ID,
+    respondTo: opts?.respondTo,
     onTurn,
     onCommand,
     isAssistantThread: opts?.assistantThreads
@@ -102,6 +104,21 @@ function setup(opts?: {
 }
 
 describe("slack-listener", () => {
+  it("resolves partial respondTo config against Slack routing defaults", () => {
+    expect(resolveSlackRespondToOptions()).toEqual({
+      directMessages: true,
+      appMentions: { reply: "thread" },
+      threadReplies: "mentionsOnly",
+    });
+    expect(
+      resolveSlackRespondToOptions({ threadReplies: "afterBotReply" }),
+    ).toEqual({
+      directMessages: true,
+      appMentions: { reply: "thread" },
+      threadReplies: "afterBotReply",
+    });
+  });
+
   it("turns an @mention into a turn with the right reply target", async () => {
     const f = setup();
     await f.fireMention({
@@ -116,6 +133,46 @@ describe("slack-listener", () => {
       replyTarget: { channel: "C1", threadTs: "100.0" },
       userText: "hello there",
     });
+  });
+
+  it("ignores @mentions when appMentions is disabled", async () => {
+    const f = setup({
+      respondTo: {
+        directMessages: true,
+        appMentions: false,
+        threadReplies: "mentionsOnly",
+      },
+    });
+    await f.fireMention({
+      type: "app_mention",
+      channel: "C1",
+      ts: "100.0",
+      text: `<@${BOT_USER_ID}> hello there`,
+    });
+    expect(f.turns).toHaveLength(0);
+  });
+
+  it("can reply to @mentions in-channel instead of in-thread", async () => {
+    const f = setup({
+      respondTo: {
+        directMessages: true,
+        appMentions: { reply: "channel" },
+        threadReplies: "mentionsOnly",
+      },
+    });
+    await f.fireMention({
+      type: "app_mention",
+      channel: "C1",
+      ts: "100.0",
+      text: `<@${BOT_USER_ID}> hello there`,
+    });
+    expect(f.turns).toHaveLength(1);
+    expect(f.turns[0]).toMatchObject({
+      conversation: { channelId: "C1", scope: "100.0" },
+      replyTarget: { channel: "C1" },
+      userText: "hello there",
+    });
+    expect(f.turns[0]!.replyTarget.threadTs).toBeUndefined();
   });
 
   it("threads a follow-up @mention into the existing thread", async () => {
@@ -160,6 +217,25 @@ describe("slack-listener", () => {
       userText: "hi bot",
     });
     expect(f.turns[0]!.replyTarget.threadTs).toBeUndefined();
+  });
+
+  it("ignores DM messages when directMessages is disabled", async () => {
+    const f = setup({
+      respondTo: {
+        directMessages: false,
+        appMentions: { reply: "thread" },
+        threadReplies: "mentionsOnly",
+      },
+    });
+    await f.fireMessage({
+      type: "message",
+      channel: "D1",
+      channel_type: "im",
+      user: "UATAI001",
+      ts: "300.0",
+      text: "hi bot",
+    });
+    expect(f.turns).toHaveLength(0);
   });
 
   it("skips a pane message (assistant thread) — owned by the Assistant middleware", async () => {
@@ -218,8 +294,28 @@ describe("slack-listener", () => {
     expect(f.turns[0]!.replyTarget.threadTs).toBeUndefined();
   });
 
-  it("continues a tracked thread on a plain reply (no @mention)", async () => {
+  it("ignores a tracked thread plain reply by default", async () => {
     const f = setup({ ownedThreads: [{ channelId: "C1", threadTs: "100.0" }] });
+    await f.fireMessage({
+      type: "message",
+      channel: "C1",
+      user: "UATAI001",
+      ts: "400.0",
+      thread_ts: "100.0",
+      text: "carry on",
+    });
+    expect(f.turns).toHaveLength(0);
+  });
+
+  it("continues a tracked thread on a plain reply when configured for legacy behavior", async () => {
+    const f = setup({
+      ownedThreads: [{ channelId: "C1", threadTs: "100.0" }],
+      respondTo: {
+        directMessages: true,
+        appMentions: { reply: "thread" },
+        threadReplies: "afterBotReply",
+      },
+    });
     await f.fireMessage({
       type: "message",
       channel: "C1",
@@ -340,9 +436,31 @@ describe("slack-listener", () => {
       });
     }
 
-    it("processes a file_share upload in an owned thread (even with empty text)", async () => {
+    it("ignores a file_share upload in an owned thread by default", async () => {
       const f = setup({
         ownedThreads: [{ channelId: "C1", threadTs: "100.0" }],
+      });
+      await f.fireMessage({
+        type: "message",
+        subtype: "file_share",
+        channel: "C1",
+        user: "UATAI001",
+        ts: "999.0",
+        thread_ts: "100.0",
+        text: "",
+        files: [{ id: "F1", name: "data.csv", mimetype: "text/csv" }],
+      });
+      expect(f.turns).toHaveLength(0);
+    });
+
+    it("processes a file_share upload in an owned thread when legacy continuation is enabled", async () => {
+      const f = setup({
+        ownedThreads: [{ channelId: "C1", threadTs: "100.0" }],
+        respondTo: {
+          directMessages: true,
+          appMentions: { reply: "thread" },
+          threadReplies: "afterBotReply",
+        },
       });
       await f.fireMessage({
         type: "message",
@@ -490,7 +608,14 @@ describe("slack-listener", () => {
   });
 
   it("F-user-token: thread reply with both user and bot_id (xoxp- post) is treated as real user message", async () => {
-    const f = setup({ ownedThreads: [{ channelId: "C1", threadTs: "100.0" }] });
+    const f = setup({
+      ownedThreads: [{ channelId: "C1", threadTs: "100.0" }],
+      respondTo: {
+        directMessages: true,
+        appMentions: { reply: "thread" },
+        threadReplies: "afterBotReply",
+      },
+    });
     await f.fireMessage({
       type: "message",
       channel: "C1",

--- a/packages/bot-slack/src/adapter.ts
+++ b/packages/bot-slack/src/adapter.ts
@@ -50,12 +50,13 @@ import { attachAssistant } from "./assistant.js";
 import type { AssistantHandle } from "./assistant.js";
 import { autoCloseOpenMarkdown } from "./auto-close-streaming.js";
 import { markdownToMrkdwn } from "./markdown-to-mrkdwn.js";
-import { DM_SCOPE } from "./types.js";
+import { DM_SCOPE, resolveSlackRespondToOptions } from "./types.js";
 import type {
   ConversationKey,
   ReplyTarget,
   SlackAssistantOptions,
   SlackFeedbackOptions,
+  SlackRespondToOptions,
 } from "./types.js";
 
 export interface SlackAdapterOptions {
@@ -82,6 +83,12 @@ export interface SlackAdapterOptions {
    * disable pane handling entirely.
    */
   assistant?: SlackAssistantOptions | false;
+  /**
+   * Controls which Slack message surfaces become bot turns. Defaults: DMs
+   * respond, app mentions respond in-thread, and plain channel thread replies
+   * require another app mention.
+   */
+  respondTo?: SlackRespondToOptions;
   /**
    * Reply-stream transport. "native" (default): `chat.startStream` wherever the
    * reply target is a thread; flat DMs and workspaces where the streaming API
@@ -190,6 +197,7 @@ export class SlackAdapter implements PlatformAdapter {
       app: this.app,
       store: this.store,
       botUserId: this.botUserId,
+      respondTo: resolveSlackRespondToOptions(this.opts.respondTo),
       isAssistantThread: this.assistantHandle?.isAssistantThread,
       onTurn: async (turn) => {
         await sink.onTurn({

--- a/packages/bot-slack/src/index.ts
+++ b/packages/bot-slack/src/index.ts
@@ -4,12 +4,21 @@ export type { AgentSession } from "./conversation-store.js";
 export type {
   ConversationKey,
   IncomingTurn,
+  ResolvedSlackRespondToOptions,
   ReplyTarget,
   SlackAssistantOptions,
+  SlackAppMentionOptions,
   SlackFeedback,
   SlackFeedbackOptions,
+  SlackMentionReplyMode,
+  SlackRespondToOptions,
+  SlackThreadReplyMode,
 } from "./types.js";
-export { DM_SCOPE } from "./types.js";
+export {
+  DEFAULT_SLACK_RESPOND_TO_OPTIONS,
+  DM_SCOPE,
+  resolveSlackRespondToOptions,
+} from "./types.js";
 
 export { MessageStream } from "./message-stream.js";
 export type { MessageStreamConfig } from "./message-stream.js";

--- a/packages/bot-slack/src/slack-listener.ts
+++ b/packages/bot-slack/src/slack-listener.ts
@@ -1,8 +1,8 @@
 import type { App } from "@slack/bolt";
 import type { WebClient } from "@slack/web-api";
 import type { SlackConversationStore } from "./conversation-store.js";
-import type { IncomingTurn } from "./types.js";
-import { DM_SCOPE } from "./types.js";
+import type { IncomingTurn, ResolvedSlackRespondToOptions } from "./types.js";
+import { DEFAULT_SLACK_RESPOND_TO_OPTIONS, DM_SCOPE } from "./types.js";
 
 /**
  * Handler the listener calls when a Slack event maps to a usable turn.
@@ -44,6 +44,8 @@ export interface ListenerConfig {
   store: SlackConversationStore;
   /** Bot user id, used to filter out our own messages (loop guard). */
   botUserId: string | undefined;
+  /** Resolved response-routing policy for Slack ingress. */
+  respondTo?: ResolvedSlackRespondToOptions;
   /** Where each accepted turn is dispatched. */
   onTurn: TurnHandler;
   /** Where each slash command is dispatched. */
@@ -90,9 +92,9 @@ function deriveEventId(
  * stream of cleanly-normalised turns regardless of which Slack event fired.
  *
  * Triggers:
- *   1. @mention in a channel        →  start (or continue) the thread it lives in.
- *   2. Plain reply in a tracked thread → continue that thread.
- *   3. DM to the bot                →  reply flat in the DM.
+ *   1. @mention in a channel/thread → start or continue a conversation.
+ *   2. DM to the bot                → reply flat in the DM.
+ *   3. Plain reply in a tracked thread when explicitly configured.
  *
  * Filters out:
  *   - `subtype` events (edits, joins, channel_renames, …)
@@ -103,6 +105,7 @@ function deriveEventId(
  */
 export function attachSlackListener(config: ListenerConfig): void {
   const { app, store, onTurn, onCommand } = config;
+  const respondTo = config.respondTo ?? DEFAULT_SLACK_RESPOND_TO_OPTIONS;
 
   // ── Slash commands ──────────────────────────────────────────────────
   // Forward EVERY registered slash command to the engine, which routes it
@@ -137,6 +140,8 @@ export function attachSlackListener(config: ListenerConfig): void {
   });
 
   app.event("app_mention", async ({ event, body, client }) => {
+    if (respondTo.appMentions === false) return;
+
     const threadTs = event.thread_ts ?? event.ts;
     const userText = stripMentions(event.text ?? "");
     const hasFiles =
@@ -148,7 +153,10 @@ export function attachSlackListener(config: ListenerConfig): void {
     await onTurn(
       {
         conversation: { channelId: event.channel, scope: threadTs },
-        replyTarget: { channel: event.channel, threadTs },
+        replyTarget:
+          respondTo.appMentions.reply === "thread"
+            ? { channel: event.channel, threadTs }
+            : { channel: event.channel },
         userText,
         senderUserId: event.user,
         eventId: deriveEventId(
@@ -182,6 +190,8 @@ export function attachSlackListener(config: ListenerConfig): void {
     )
       return;
 
+    if (!respondTo.directMessages) return;
+
     if (isDM) {
       await onTurn(
         {
@@ -200,6 +210,8 @@ export function attachSlackListener(config: ListenerConfig): void {
 
     // app_mention runs separately for these; skip the duplicate.
     if (config.botUserId && text.includes(`<@${config.botUserId}>`)) return;
+
+    if (respondTo.threadReplies === "mentionsOnly") return;
 
     // Only continue threads we already own. `has` consults Slack itself,
     // so a restarted bridge naturally recognises threads it replied to

--- a/packages/bot-slack/src/types.ts
+++ b/packages/bot-slack/src/types.ts
@@ -72,6 +72,66 @@ export interface SlackFeedbackOptions {
   negativeLabel?: string;
 }
 
+export type SlackMentionReplyMode = "thread" | "channel";
+
+export type SlackThreadReplyMode = "mentionsOnly" | "afterBotReply";
+
+export interface SlackAppMentionOptions {
+  /**
+   * Where an app mention should reply. "thread" keeps channel noise down and is
+   * the default; "channel" posts a top-level channel reply.
+   */
+  reply?: SlackMentionReplyMode;
+}
+
+export interface SlackRespondToOptions {
+  /** Respond to normal Slack DMs (`message.im`). Default true. */
+  directMessages?: boolean;
+  /**
+   * Respond to Slack `app_mention` events in channels/private channels. Pass
+   * false to ignore app mentions entirely. Default: `{ reply: "thread" }`.
+   */
+  appMentions?: false | SlackAppMentionOptions;
+  /**
+   * How to handle plain, non-mention replies in channel/private-channel threads.
+   * "mentionsOnly" requires every thread turn to explicitly @mention the bot.
+   * "afterBotReply" preserves the legacy behavior: once the bot has replied in a
+   * thread, future plain replies in that thread can trigger new turns.
+   */
+  threadReplies?: SlackThreadReplyMode;
+}
+
+export interface ResolvedSlackRespondToOptions {
+  directMessages: boolean;
+  appMentions: false | { reply: SlackMentionReplyMode };
+  threadReplies: SlackThreadReplyMode;
+}
+
+export const DEFAULT_SLACK_RESPOND_TO_OPTIONS: ResolvedSlackRespondToOptions = {
+  directMessages: true,
+  appMentions: { reply: "thread" },
+  threadReplies: "mentionsOnly",
+};
+
+export function resolveSlackRespondToOptions(
+  respondTo?: SlackRespondToOptions,
+): ResolvedSlackRespondToOptions {
+  return {
+    directMessages:
+      respondTo?.directMessages ??
+      DEFAULT_SLACK_RESPOND_TO_OPTIONS.directMessages,
+    appMentions:
+      respondTo?.appMentions === false
+        ? false
+        : {
+            reply: respondTo?.appMentions?.reply ?? "thread",
+          },
+    threadReplies:
+      respondTo?.threadReplies ??
+      DEFAULT_SLACK_RESPOND_TO_OPTIONS.threadReplies,
+  };
+}
+
 /**
  * Stable key identifying one ongoing conversation with the bot.
  *


### PR DESCRIPTION
## Summary

- Add Slack `respondTo` routing options with mention-only channel thread replies by default.
- Keep DMs and assistant pane conversational while allowing legacy owned-thread continuation by config.
- Update the Slack example config, manifests, docs, and Discord README trigger wording.

## Why

Slack bots should stay quiet in channel threads unless explicitly mentioned or configured for continuation. This makes Kite-style bots less noisy by default while preserving the old behavior for teams that want it.

## How

- Resolve `respondTo` once in `SlackAdapter.start()` and pass the resolved policy into the Slack listener.
- Gate `app_mention`, `message.im`, and non-DM thread replies against that policy.
- Add listener coverage for defaults, disabled routes, in-channel mention replies, and legacy thread continuation.

## Test Plan

- `pnpm exec nx run @copilotkit/bot-slack:test -- src/__tests__/slack-listener.test.ts`
- `pnpm exec nx run @copilotkit/bot-slack:test`
- `pnpm exec nx run @copilotkit/bot-slack:check-types`
- `pnpm exec nx run slack-example:test`
- `pnpm exec nx run slack-example:check-types`
- targeted `pnpm exec oxfmt --check ...`
- targeted `git diff --check ...`
