### PR TITLE
fix(showcase): ship shared-state-read D6 cell for strands(+TS)

### DIFF
--- a/showcase/integrations/strands-typescript/manifest.yaml
+++ b/showcase/integrations/strands-typescript/manifest.yaml
@@ -354,6 +354,16 @@ demos:
       - src/app/demos/shared-state-read-write/preferences-card.tsx
       - src/app/demos/shared-state-read-write/notes-card.tsx
       - src/app/api/copilotkit/route.ts
+  - id: shared-state-read
+    name: "Shared State: Read-only"
+    description: "Recipe editor publishes form state via agent.setState; the agent reads the recipe context but does not mutate it (no backend tool — neutral default agent)."
+    tags:
+      - agent-state
+    route: /demos/shared-state-read
+    animated_preview_url:
+    highlight:
+      - src/app/demos/shared-state-read/page.tsx
+      - src/app/api/copilotkit/route.ts
   - id: subagents
     name: Sub-Agents
     description: Multiple agents with visible task delegation

--- a/showcase/integrations/strands/manifest.yaml
+++ b/showcase/integrations/strands/manifest.yaml
@@ -350,6 +350,16 @@ demos:
       - src/app/demos/shared-state-read-write/preferences-card.tsx
       - src/app/demos/shared-state-read-write/notes-card.tsx
       - src/app/api/copilotkit/route.ts
+  - id: shared-state-read
+    name: "Shared State: Read-only"
+    description: "Recipe editor publishes form state via agent.setState; the agent reads the recipe context but does not mutate it (no backend tool — neutral default agent)."
+    tags:
+      - agent-state
+    route: /demos/shared-state-read
+    animated_preview_url:
+    highlight:
+      - src/app/demos/shared-state-read/page.tsx
+      - src/app/api/copilotkit/route.ts
   - id: subagents
     name: Sub-Agents
     description: Multiple agents with visible task delegation


### PR DESCRIPTION
## Root cause: manifest gap makes #5673 a no-op on the fleet

PR #5673 fixed the aimock D6 fixture for the `shared-state-read` cell for the
`strands` and `strands-typescript` integrations. But that fix was a **no-op on
the deployed fleet**, because neither integration's manifest declared a `demos:`
entry for `shared-state-read`.

The fleet enumerates D6 cells **only** from manifest demos that have both an `id`
**and** a `route`:
- `showcase/harness/src/cli/targets.ts` `demosForSlug()` maps `manifest.demos` →
  ids; the d6 all-pills driver derives its feature matrix from this (an empty
  array short-circuits to a zero-cell false-green).
- `showcase/scripts/generate-registry.ts` `determineCellStatus()`: a feature
  declared in `features` but with no demo carrying a `route` → status `unshipped`.
- `showcase/harness/src/probes/discovery/railway-services.ts`: only demos with a
  string `id` + `route` are counted.

`shared-state-read` **was** declared as a `feature` in both manifests and is
**not** in `not_supported_features`, and the frontend demo (`page.tsx`,
`recipe-card.tsx`, `types.ts` — byte-identical to langgraph-python) already
exists on disk. Only the manifest `demos:` entry was missing → status
`unshipped` → the cell never ran on staging.

## The fix (mirror the gold standard)

Add the `shared-state-read` demo entry to **both** manifests, mirroring the
gold-standard `langgraph-python` entry exactly (same id, name, description, tags,
route, `animated_preview_url`, highlight files). The gold entry already uses the
integration-neutral default-agent shape (no agent file in `highlight`, just
`page.tsx` + `api/copilotkit/route.ts`), so no per-integration adjustment was
needed.

```yaml
  - id: shared-state-read
    name: "Shared State: Read-only"
    description: "Recipe editor publishes form state via agent.setState; the agent reads the recipe context but does not mutate it (no backend tool — neutral default agent)."
    tags:
      - agent-state
    route: /demos/shared-state-read
    animated_preview_url:
    highlight:
      - src/app/demos/shared-state-read/page.tsx
      - src/app/api/copilotkit/route.ts
```

No generated artifact is committed (`registry.json` / `catalog.json` /
`constraints.json` are gitignored, regenerated at build/test time). No hard-coded
count test needs updating: the cross-join total stays 920 cells (only the
**status** of 2 existing cells flips `unshipped → wired`); `generate-catalog`'s
13 tests pass.

## RED → GREEN proof (real surface, not a unit fake)

### Harness enumeration (`demosForSlug` — the exact fn the d6 driver uses)
| Integration | RED (origin/main) | GREEN (this PR) |
|---|---|---|
| strands | count=38, includes-ssr=**false** | count=39, includes-ssr=**true** |
| strands-typescript | count=38, includes-ssr=**false** | count=39, includes-ssr=**true** |

### Catalog status (`generate-registry` `determineCellStatus`)
| Integration | RED (origin/main) | GREEN (this PR) |
|---|---|---|
| langgraph-python (gold) | wired (max_depth=4) | wired (max_depth=4) |
| strands | **unshipped** (max_depth=0) | **wired** (max_depth=4) |
| strands-typescript | **unshipped** (max_depth=0) | **wired** (max_depth=4) |

### Full D6 fleet run (`bin/showcase test <slug>:shared-state-read --d6 --verbose --isolate`)
On `origin/main` these resolve `count=0` (cell absent from the run set). With this PR:

**strands:**
```
cli.runner.resolved-targets {"target":"strands:shared-state-read","level":"d6","count":1}
fleet.control-plane.catalog-enumerated {"driverKind":"e2e_d6","discovered":1,"enqueueable":1}
✓ d6:strands/shared-state-read green (0.0s)
1 passed (0.0s)
✓ Tests passed for strands:shared-state-read
```

**strands-typescript:**
```
cli.runner.resolved-targets {"target":"strands-typescript:shared-state-read","level":"d6","count":1}
fleet.control-plane.catalog-enumerated {"driverKind":"e2e_d6","discovered":1,"enqueueable":1}
1 passed (0.0s)
✓ Tests passed for strands-typescript:shared-state-read
```

Related: #5673 (the fixture fix this PR activates on the fleet).