### PR TITLE
feat(skills): skill-lift eval for copilotkit-setup (with/without comparison)

### DIFF
--- a/.github/config-allowlist.txt
+++ b/.github/config-allowlist.txt
@@ -117,3 +117,5 @@ showcase/shell-dashboard/next.config.ts
 showcase/shell-docs/next.config.ts
 showcase/shell-dojo/next.config.ts
 showcase/shell/next.config.ts
+skill-evals/copilotkit-setup/workspace/vite-react/src/vite-env.d.ts
+skill-evals/copilotkit-setup/workspace/vite-react/vite.config.ts

--- a/.github/workflows/skill_eval-lift.yml
+++ b/.github/workflows/skill_eval-lift.yml
@@ -1,0 +1,95 @@
+name: skill / eval-lift
+
+# Skill-lift eval for copilotkit-setup: runs the with/without comparison
+# (skill-evals/copilotkit-setup) and posts the lift table to the run's Step
+# Summary. Three triggers:
+#   - schedule: daily trend line (trials=3).
+#   - pull_request: a merge-blocking smoke run, but ONLY on PRs that touch the
+#     eval or the skill it measures (path-filtered) — it is not a token tax on
+#     every unrelated PR. Runs trials=1 (cheap: it validates the harness + agent
+#     complete + the project builds, not statistical lift).
+#   - workflow_dispatch: ad-hoc, with a trials override.
+# Each run spins Docker containers and burns agent tokens, hence the path filter.
+on:
+  schedule:
+    # Daily at 14:00 UTC (07:00 PT / 10:00 ET) — matches the low-traffic window
+    # used by the other daily crons in this repo.
+    - cron: "0 14 * * *"
+  pull_request:
+    paths:
+      - "skill-evals/**"
+      - "skills/copilotkit-setup/**"
+      - ".github/workflows/skill_eval-lift.yml"
+  workflow_dispatch:
+    inputs:
+      trials:
+        description: "Trials per arm (with + without)"
+        required: false
+        default: "3"
+        type: string
+
+# Least-privilege: the eval only reads the repo and writes its Step Summary.
+permissions:
+  contents: read
+
+# Per-ref: a new push to a PR cancels its in-flight run; the daily cron (on the
+# default ref) never overlaps itself.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lift:
+    name: "copilotkit-setup lift"
+    # GitHub-hosted runner: Docker Engine is preinstalled, which the eval drives
+    # via the docker CLI to build its image and run each trial in a container.
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        # Omit `version:` so pnpm/action-setup inherits from the repo's
+        # `packageManager` field in package.json (via corepack).
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20.x
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store-path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store-path }}
+          key: ${{ runner.os }}-pnpm-store-20-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-20-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run skill-lift eval
+        # Trials by trigger: dispatch input if given, else 1 on a PR smoke run,
+        # else 3 (schedule). Passed via env, not inline ${{ }} in the run script,
+        # to avoid template injection.
+        #
+        # Agent auth: run.ts prefers CLAUDE_CODE_OAUTH_TOKEN (a subscription seat,
+        # no per-call Console credits) and falls back to ANTHROPIC_API_KEY (a
+        # Console key, which draws on the org's prepaid credit balance). Both are
+        # wired; if the OAuth secret is unset it renders empty and run.ts ignores
+        # it. The judge always uses OPENAI_API_KEY (an OAuth token can't drive the
+        # judge API).
+        env:
+          TRIALS: ${{ github.event.inputs.trials || (github.event_name == 'pull_request' && '1' || '3') }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: pnpm eval:skill:setup --trials="$TRIALS"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "sync:plugin-skills": "tsx scripts/sync-plugin-skills.ts",
     "parity:sync": "tsx examples/integrations/_parity/sync.ts",
     "parity:verify": "tsx examples/integrations/_parity/verify.ts",
-    "parity:check": "tsx examples/integrations/_parity/verify.ts --no-color"
+    "parity:check": "tsx examples/integrations/_parity/verify.ts --no-color",
+    "eval:skill:setup": "tsx skill-evals/copilotkit-setup/lift/run.ts"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",

--- a/skill-evals/README.md
+++ b/skill-evals/README.md
@@ -1,0 +1,196 @@
+# Skill evals
+
+Automated evaluations for the skills under `skills/`. Each skill that has an eval
+gets its own directory here: `skill-evals/<skill-name>/`. Config, fixtures, the
+grader, and the rubric live here, **not** inside `skills/<name>/`, because
+`npx copilotkit skills install` copies entire skill directories into user
+projects — harness files must never ship to users.
+
+The harness is self-contained: a small TypeScript runner driving the `docker` CLI
+and real Claude Code (`claude -p`). There is no third-party eval framework.
+
+## What an eval measures: skill _lift_
+
+A capable agent usually reaches a correct answer eventually, with or without the
+skill. So absolute "did it end correct" mostly measures the _agent_, not the
+_skill_. What we actually want is **lift**: does the skill get the agent there
+_leaner_ — fewer turns, fewer tokens, less wall-clock, lower cost — at equal
+success, and does it reach the canonical surface more directly?
+
+That makes the real experiment **comparative**: run the same task twice, once with
+the skill mounted and once without, and diff the results.
+
+- **Headline — efficiency lift.** Δ in `num_turns`, `usage` tokens, `duration_ms`,
+  and `total_cost_usd` between the with-skill and without-skill arms. These are
+  **real** values read off `claude -p --output-format stream-json`'s result event,
+  not estimates.
+- **Gate — correctness.** The project must actually build / type-check. The
+  deterministic grader _runs the project_ (`graders/check.ts`), it does not grep
+  for API names as the gate: a capable agent reaches the right APIs either way, so
+  grepping measures the agent.
+- **Judge — did the skill help (optional).** When a judge key is present, an LLM
+  reads the agent's stream-json transcript and scores how _directly_ it reached the
+  canonical v2 surface (`rubric.md`). Trial-and-error success scores lower on
+  directness — the "did the skill actually help" contrast.
+
+## How with/without works
+
+The single difference between the two arms is whether the skill directory exists
+at `/workspace/.claude/skills/copilotkit-setup` inside the container — the path
+Claude Code discovers project skills from in headless mode. The WITH arm
+`docker cp`s the skill in; the WITHOUT arm does not. No flags, no hacks, no second
+image.
+
+## Layout of a skill eval
+
+```
+skill-evals/<skill>/
+  Dockerfile          # node:20-slim + claude-code + tsx; bakes the fixture at /workspace
+  instruction.md      # the task handed to the agent (baked at /eval-tools)
+  workspace/<name>/   # the STARTING fixture the agent is dropped into
+  graders/check.ts    # deterministic correctness grader (TypeScript, run via tsx)
+  rubric.md           # optional trace-judge rubric
+  lift/run.ts         # runs the with/without comparison and reports lift
+  results/            # gitignored run outputs (ephemeral today; see "Tracking")
+```
+
+## The grader contract
+
+`graders/check.ts` prints a single JSON object to stdout:
+
+```json
+{
+  "score": 0.0,
+  "details": "human-readable summary",
+  "checks": [{ "name": "type-check: (root)", "passed": true, "message": "..." }]
+}
+```
+
+`score` is in `[0, 1]`. It runs in the post-agent container via
+`tsx /eval-tools/check.ts` (outside `/workspace`, so it is never graded as the
+agent's own output). The WITH-skill arm mounts the skill into
+`/workspace/.claude/skills`, so every source scan excludes `.claude` / `.agents` /
+`node_modules` or a no-op agent would score points off the skill's own examples.
+
+## The lift results contract
+
+`lift/run.ts` writes one JSON file per run into `results/` shaped like:
+
+```json
+{
+  "timestamp": "ISO-8601",
+  "skill": "copilotkit-setup",
+  "trials": 5,
+  "rubricRan": false,
+  "withSkill": {
+    "passRate": 0.0,
+    "meanReward": 0.0,
+    "medianDurationMs": 0,
+    "medianTurns": 0,
+    "medianTokens": 0,
+    "medianCostUsd": 0.0
+  },
+  "withoutSkill": {
+    "passRate": 0.0,
+    "meanReward": 0.0,
+    "medianDurationMs": 0,
+    "medianTurns": 0,
+    "medianTokens": 0,
+    "medianCostUsd": 0.0
+  },
+  "lift": {
+    "passRate": 0.0,
+    "durationMs": 0,
+    "turns": 0,
+    "tokens": 0,
+    "costUsd": 0.0
+  }
+}
+```
+
+`lift.*` is `withSkill - withoutSkill` (so a _negative_ `durationMs` / `turns` /
+`tokens` / `costUsd` lift is good — the skill made the agent leaner; a _positive_
+`passRate` lift is good). The script also prints a human-readable table.
+
+## Running
+
+```bash
+pnpm eval:skill:setup                 # full with/without lift comparison (needs Docker)
+pnpm eval:skill:setup --trials=3      # fewer trials per arm (default 5)
+pnpm eval:skill:setup --concurrency=2 # fewer containers/agent sessions at once (default 4)
+```
+
+Trials run in a bounded-concurrency pool (each is an independent container), so
+the wall-clock is roughly the slowest wave, not the sum of all trials. Lower
+`--concurrency` (or `SKILL_EVAL_CONCURRENCY`) if you hit the agent's API rate
+limit on a subscription token or run low on RAM.
+
+Auth — put a `.env` next to the eval (gitignored):
+
+- **Agent (required).** `CLAUDE_CODE_OAUTH_TOKEN` (subscription, key-free) or
+  `ANTHROPIC_API_KEY` (Console). Either runs Claude Code.
+- **Judge (optional).** `OPENAI_API_KEY` (preferred when set) or
+  `ANTHROPIC_API_KEY`. Absent → the run is deterministic-only and the trace judge
+  is skipped. Defaults: OpenAI → `gpt-5.5`, Anthropic → `claude-haiku-4-5`. Override
+  with `OPENAI_MODEL` / `ANTHROPIC_GRADER_MODEL`, or force a provider with
+  `JUDGE_PROVIDER=openai|anthropic`. An OAuth subscription
+  token alone **cannot** drive the judge (it can't call the messages/completions
+  API), which is why the judge is optional.
+
+> **Capture the OAuth token carefully.** `claude setup-token` is an interactive
+> TUI. Run it on its own, then **copy the printed `sk-ant-oat...` value** into the
+> `.env`. Do **NOT** do `CLAUDE_CODE_OAUTH_TOKEN=$(claude setup-token)` — command
+> substitution captures the TUI's escape codes instead of the token, producing an
+> opaque in-container `API Error 400`. (`lift/run.ts` preflights the token shape
+> and rejects this, but it is still the easiest way to footgun it.)
+>
+> ```bash
+> claude setup-token   # complete the browser flow, copy the sk-ant-oat... value
+> echo 'CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat...' > skill-evals/copilotkit-setup/.env
+> # optional judge:
+> echo 'OPENAI_API_KEY=sk-...' >> skill-evals/copilotkit-setup/.env
+> ```
+
+## Scheduled runs (CI)
+
+A GitHub Actions workflow runs the with/without comparison and posts the lift
+table to the run's **Step Summary**, so you can skim the trend from the Actions
+tab without downloading anything. See `.github/workflows/skill_eval-lift.yml`.
+
+- **When.** Three triggers: a daily cron `0 14 * * *` (trials=3) for the trend
+  line; a **pull_request** smoke run (trials=1) that fires **only** on PRs which
+  touch `skill-evals/**`, `skills/copilotkit-setup/**`, or the workflow itself —
+  it is a merge-blocking check for eval-relevant PRs, not a token tax on every
+  PR; and `workflow_dispatch` for ad-hoc runs. Each run spins Docker containers
+  and burns agent tokens, which is why the PR trigger is path-filtered.
+- **Trials.** `--trials=3` on the daily run (6 agent sessions/arm-pair) balances
+  noise vs. cost; PR smoke runs use `--trials=1` (validates the harness + agent
+  completion + build, not statistical lift); the manual-dispatch form takes a
+  `trials` input to override.
+- **Auth.** The agent prefers the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (a
+  subscription seat, no per-call Console credits) and falls back to
+  `ANTHROPIC_API_KEY` (a Console key, which draws on the org's prepaid credit
+  balance — a depleted balance surfaces as `400: Credit balance is too low`). The
+  judge uses `OPENAI_API_KEY` (an OAuth token cannot drive the judge API). If the
+  OAuth secret ever expires, rotate it with a fresh `claude setup-token` value
+  (see the footgun note below on capturing it cleanly).
+- **Output.** When `GITHUB_STEP_SUMMARY` is set, `lift/run.ts` appends a markdown
+  lift table there (same numbers as the terminal table). Scheduled Step Summaries
+  live as long as the run's logs are retained.
+- **Trying it before merge.** Scheduled workflows only fire from the default
+  branch. To exercise the workflow on a feature branch, dispatch it explicitly:
+  `gh workflow run skill_eval-lift.yml --ref <branch>`.
+
+## Tracking (today vs. later)
+
+Beyond the daily Step Summary, per-run JSON still lands in `results/` (gitignored,
+ephemeral). The results JSON shape above is deliberately stable so that "flip to
+committed history" (commit `results/` for a `git log` trend line), artifact
+upload, or a regression Slack ping are additive, not rewrites.
+
+## Adding a second skill eval
+
+The grader, Dockerfile, and runner are deliberately self-contained for the first
+skill. When a second eval lands, factor the shared pieces (the `docker` driver in
+`run.ts`, the grader contract) into a small `skill-evals/_harness/` — do not
+pre-abstract from one example.

--- a/skill-evals/copilotkit-setup/Dockerfile
+++ b/skill-evals/copilotkit-setup/Dockerfile
@@ -1,0 +1,30 @@
+# Eval container for the copilotkit-setup skill-lift harness (see lift/run.ts).
+#
+# One image, built once, run as N fresh containers per arm. The fixture is baked
+# at /workspace so every container starts from a pristine copy. The skill is NOT
+# baked in here — lift/run.ts `docker cp`s it into /workspace/.claude/skills for
+# the WITH-skill arm only. That single difference (skill dir present vs absent) IS
+# the entire with/without mechanism — no hacks, no second image.
+#
+# The grader and the task instruction live under /eval-tools (OUTSIDE /workspace)
+# so the agent never sees them and a source scan can never pick them up.
+FROM node:20-slim
+
+# git: some installs / tooling expect it. The agent CLI is Claude Code. tsx runs
+# the TypeScript grader (graders/check.ts) — the same runner the host harness uses.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git ca-certificates \
+  && rm -rf /var/lib/apt/lists/* \
+  && npm install -g @anthropic-ai/claude-code tsx
+
+WORKDIR /workspace
+
+# Bake the starting fixture and pre-install its base deps so the per-trial
+# type-check gate does not pay a cold install for react/vite every time. The
+# agent adds @copilotkit/* (and express/hono) on top; that install is incremental.
+COPY workspace/vite-react/ /workspace/
+RUN npm install
+
+# Grader + instruction live outside the workspace the agent works in.
+COPY graders/check.ts /eval-tools/check.ts
+COPY instruction.md /eval-tools/instruction.md

--- a/skill-evals/copilotkit-setup/graders/check.ts
+++ b/skill-evals/copilotkit-setup/graders/check.ts
@@ -1,0 +1,293 @@
+/**
+ * Deterministic correctness grader for the copilotkit-setup skill eval.
+ *
+ * CONTRACT: prints a single JSON object to stdout:
+ *   {"score": 0-1, "details": "...", "checks": [{"name","passed","message"}, ...]}
+ *
+ * Runs in the post-agent container (node:20-slim) via `tsx /eval-tools/check.ts`,
+ * grading /workspace. TypeScript on purpose — it shares the same `tsx` runner the
+ * host harness (lift/run.ts) uses, so the whole eval is one language with no
+ * jq/awk/bc shelling. Score math is plain JS; JSON is native.
+ *
+ * WHAT THIS GRADES: the agent was asked to add CopilotKit to an existing
+ * Vite+React app at /workspace — frontend @copilotkit/react-core, a backend
+ * (Express/Hono) running a CopilotRuntime + BuiltInAgent via @copilotkit/runtime,
+ * the <CopilotKit> provider, a CopilotSidebar (or other chat UI), and the
+ * stylesheet import. The backend may live at root or in a subdir (e.g. server/).
+ *
+ * THE GATE: this grader actually TYPE-CHECKS the project — it does not merely
+ * grep for API names. A project that does not type-check is not a working setup.
+ * For every project dir with a package.json (the root vite app + any backend
+ * subdir) we run a type-check (the dir's own `typecheck` npm script if defined,
+ * else `npx tsc --noEmit -p <dir>`). Type-check is THE dominant signal.
+ *
+ * SCORING:
+ *   total = 0.60 * GATE + 0.40 * STRINGS
+ *   - GATE    = fraction of discovered project dirs whose type-check exits 0.
+ *               If no project dir is found, GATE = 0.
+ *   - STRINGS = fraction of the 7 source/string checks that pass.
+ *   A non-compiling project drives GATE toward 0, capping the score well below
+ *   the 0.8 threshold (max ~0.40) even if every string is present.
+ *
+ * GRADER-POISONING GUARD: the WITH-skill arm copies the skill (incl. its
+ * assets/*.tsx example code) into /workspace/.claude/skills. EVERY source scan
+ * and package.json find MUST exclude that dir (and .agents, node_modules) or a
+ * no-op agent scores points off the skill's own examples.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import type { Dirent } from "node:fs";
+import path from "node:path";
+
+const WORKSPACE = process.env.WORKSPACE || "/workspace";
+
+// Directories that are never the agent's own work: dependency trees, VCS, build
+// output, and the mounted-skill copies. Excluded from BOTH dir discovery and
+// source scans.
+const EXCLUDE_DIRS = new Set([
+  "node_modules",
+  ".git",
+  ".agents",
+  ".claude",
+  "dist",
+  "build",
+]);
+
+const SOURCE_EXTS = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mts",
+  ".cts",
+  ".mjs",
+  ".cjs",
+]);
+
+interface Check {
+  name: string;
+  passed: boolean;
+  message: string;
+}
+
+const checks: Check[] = [];
+let stringPass = 0;
+let stringTotal = 0;
+
+/** Record a check that does NOT count toward the string fraction (e.g. the gate). */
+function addCheck(name: string, passed: boolean, message: string): void {
+  checks.push({ name, passed, message });
+}
+
+/** Record one of the 7 weighted string checks. */
+function addStringCheck(name: string, passed: boolean, message: string): void {
+  stringTotal++;
+  if (passed) stringPass++;
+  checks.push({ name, passed, message });
+}
+
+function truncate(s: string, n = 400): string {
+  return s.length > n ? `${s.slice(0, n)}…(truncated)` : s;
+}
+
+/** Walk WORKSPACE, applying `visit(absPath)` to every file, skipping EXCLUDE_DIRS. */
+function walk(dir: string, visit: (file: string) => void): void {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (EXCLUDE_DIRS.has(entry.name)) continue;
+      walk(path.join(dir, entry.name), visit);
+    } else if (entry.isFile()) {
+      visit(path.join(dir, entry.name));
+    }
+  }
+}
+
+// --- gather: package.json dirs, dependency names, source file contents --------
+
+const pkgFiles: string[] = [];
+const depNames = new Set<string>();
+const sourceFiles: string[] = [];
+
+walk(WORKSPACE, (file) => {
+  const base = path.basename(file);
+  if (base === "package.json") {
+    pkgFiles.push(file);
+    try {
+      const pkg = JSON.parse(readFileSync(file, "utf8"));
+      for (const field of [
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+      ]) {
+        for (const name of Object.keys(pkg[field] || {})) depNames.add(name);
+      }
+    } catch {
+      /* malformed package.json — ignore for dep scan, gate still type-checks it */
+    }
+    return;
+  }
+  if (SOURCE_EXTS.has(path.extname(file))) sourceFiles.push(file);
+});
+
+/** True if ANY source file matches `re`. */
+function srcMatch(re: RegExp): boolean {
+  return sourceFiles.some((f) => {
+    try {
+      return re.test(readFileSync(f, "utf8"));
+    } catch {
+      return false;
+    }
+  });
+}
+
+// --- 1. THE GATE: type-check every project dir --------------------------------
+
+let gateTotal = 0;
+let gatePass = 0;
+
+if (pkgFiles.length === 0) {
+  addCheck(
+    "type-check (gate)",
+    false,
+    "No package.json found in workspace — cannot type-check any project.",
+  );
+} else {
+  for (const pkgFile of pkgFiles) {
+    const dir = path.dirname(pkgFile);
+    gateTotal++;
+
+    // The agent should have installed deps; a backend subdir may be uninstalled.
+    if (!existsSync(path.join(dir, "node_modules"))) {
+      try {
+        execFileSync("npm", ["install"], { cwd: dir, stdio: "ignore" });
+      } catch {
+        /* install failure surfaces as a type-check failure below */
+      }
+    }
+
+    let hasTypecheckScript = false;
+    try {
+      const pkg = JSON.parse(readFileSync(pkgFile, "utf8"));
+      hasTypecheckScript = Boolean(pkg.scripts && pkg.scripts.typecheck);
+    } catch {
+      /* handled by gate failure */
+    }
+
+    const rel = path.relative(WORKSPACE, dir) || "(root)";
+    try {
+      if (hasTypecheckScript) {
+        execFileSync("npm", ["run", "typecheck"], { cwd: dir, stdio: "pipe" });
+      } else {
+        execFileSync("npx", ["--yes", "tsc", "--noEmit", "-p", dir], {
+          cwd: dir,
+          stdio: "pipe",
+        });
+      }
+      gatePass++;
+      addCheck(`type-check: ${rel}`, true, "Type-check passed.");
+    } catch (err) {
+      const e = err as { stdout?: Buffer | string; stderr?: Buffer | string };
+      const out = `${e.stdout || ""}${e.stderr || ""}`.toString();
+      addCheck(
+        `type-check: ${rel}`,
+        false,
+        `Type-check FAILED: ${truncate(out.slice(-600))}`,
+      );
+    }
+  }
+}
+
+// --- 2-3. Packages present ----------------------------------------------------
+
+addStringCheck(
+  "frontend package (@copilotkit/react-core)",
+  depNames.has("@copilotkit/react-core"),
+  depNames.has("@copilotkit/react-core")
+    ? "Found in a package.json dependency list."
+    : "@copilotkit/react-core not found in any package.json.",
+);
+
+addStringCheck(
+  "runtime package (@copilotkit/runtime)",
+  depNames.has("@copilotkit/runtime"),
+  depNames.has("@copilotkit/runtime")
+    ? "Found in a package.json dependency list."
+    : "@copilotkit/runtime not found in any package.json.",
+);
+
+// --- 4. Canonical handler factory (deprecated createCopilotEndpoint* excluded) -
+
+const hasHandler = srcMatch(/createCopilot(Express|Hono)Handler/);
+addStringCheck(
+  "canonical handler factory",
+  hasHandler,
+  hasHandler
+    ? "createCopilotExpressHandler or createCopilotHonoHandler present in source."
+    : "Neither createCopilotExpressHandler nor createCopilotHonoHandler found (deprecated createCopilotEndpoint* does not count).",
+);
+
+// --- 5. BuiltInAgent configured ----------------------------------------------
+
+const hasBuiltIn = srcMatch(/BuiltInAgent/);
+addStringCheck(
+  "BuiltInAgent configured",
+  hasBuiltIn,
+  hasBuiltIn
+    ? "BuiltInAgent present in source."
+    : "BuiltInAgent not found in source.",
+);
+
+// --- 6. Provider <CopilotKit> from react-core/v2 -----------------------------
+// <CopilotKit ...> element (regex excludes the legacy <CopilotKitProvider>) AND
+// imported from @copilotkit/react-core/v2.
+
+const providerElem = srcMatch(/<CopilotKit([^A-Za-z]|$)/);
+const providerImport = srcMatch(/@copilotkit\/react-core\/v2/);
+addStringCheck(
+  "provider <CopilotKit> from react-core/v2",
+  providerElem && providerImport,
+  providerElem && providerImport
+    ? "<CopilotKit> element and @copilotkit/react-core/v2 import both present."
+    : `Need <CopilotKit> element (not <CopilotKitProvider>) AND @copilotkit/react-core/v2 import. element=${providerElem} import=${providerImport}`,
+);
+
+// --- 7. Chat UI component -----------------------------------------------------
+
+const hasChat = srcMatch(/CopilotSidebar|CopilotChat|CopilotPopup/);
+addStringCheck(
+  "chat UI component",
+  hasChat,
+  hasChat
+    ? "CopilotSidebar / CopilotChat / CopilotPopup present in source."
+    : "No CopilotSidebar / CopilotChat / CopilotPopup found in source.",
+);
+
+// --- 8. Stylesheet imported ---------------------------------------------------
+
+const hasStyles = srcMatch(/@copilotkit\/react-core\/v2\/styles\.css/);
+addStringCheck(
+  "stylesheet imported",
+  hasStyles,
+  hasStyles
+    ? "@copilotkit/react-core/v2/styles.css import present."
+    : "@copilotkit/react-core/v2/styles.css import not found.",
+);
+
+// --- Score --------------------------------------------------------------------
+
+const gate = gateTotal > 0 ? gatePass / gateTotal : 0;
+const strings = stringTotal > 0 ? stringPass / stringTotal : 0;
+const score = Number((0.6 * gate + 0.4 * strings).toFixed(4));
+
+const details =
+  `Type-check gate: ${gatePass}/${gateTotal} project dir(s) passed (weight 0.60). ` +
+  `String checks: ${stringPass}/${stringTotal} passed (weight 0.40). Score=${score}.`;
+
+process.stdout.write(`${JSON.stringify({ score, details, checks })}\n`);

--- a/skill-evals/copilotkit-setup/instruction.md
+++ b/skill-evals/copilotkit-setup/instruction.md
@@ -1,0 +1,1 @@
+Add CopilotKit to this existing Vite+React project with a chat sidebar and a BuiltInAgent backend.

--- a/skill-evals/copilotkit-setup/lift/run.ts
+++ b/skill-evals/copilotkit-setup/lift/run.ts
@@ -1,0 +1,1037 @@
+#!/usr/bin/env node
+/**
+ * Skill-lift comparison harness for the copilotkit-setup skill.
+ *
+ * WHAT THIS DOES
+ *   Runs the same task in N trials per arm, each in its own fresh container:
+ *     1. WITH the skill mounted at /workspace/.claude/skills/copilotkit-setup
+ *     2. WITHOUT it (the dir is simply absent)
+ *   then diffs the two arms. The agent is real Claude Code (`claude -p`), invoked
+ *   with --output-format stream-json so we read REAL efficiency signal off the
+ *   result event — num_turns, usage tokens, duration_ms, total_cost_usd — instead
+ *   of estimates. The with/without difference is literally "is the skill dir
+ *   present", a `docker cp` toggle, not a hack.
+ *
+ *   Trials run in a bounded-concurrency pool (--concurrency, default 4): each is
+ *   independent, so several containers run at once and the wall-clock collapses
+ *   from sum-of-trials to roughly slowest-wave. Lower concurrency if you hit the
+ *   agent's API rate limit or run low on RAM.
+ *
+ *   lift.* = withSkill - withoutSkill, so:
+ *     - NEGATIVE turns / tokens / durationMs / costUsd is GOOD (skill = leaner);
+ *     - POSITIVE passRate is GOOD (skill = more correct).
+ *
+ * SCORING (per trial)
+ *   - GATE (always): graders/check.ts builds / type-checks the agent's output in
+ *     the container and returns a deterministic [0,1] score. This is THE score.
+ *   - JUDGE (optional): when an OpenAI or Anthropic key is present, an LLM reads
+ *     the agent's stream-json transcript and scores "how directly did it reach the
+ *     canonical v2 surface" against rubric.md. Folded in at gate 0.60 / judge 0.40.
+ *     Absent key -> deterministic-only (rubricRan:false), and the run stays
+ *     key-free on a `claude setup-token` subscription.
+ *
+ * AUTH
+ *   - Agent (Claude Code): CLAUDE_CODE_OAUTH_TOKEN (subscription) or
+ *     ANTHROPIC_API_KEY (Console). Either runs the agent.
+ *   - Judge: OPENAI_API_KEY (preferred when set) or ANTHROPIC_API_KEY. OAuth
+ *     subscription tokens cannot drive the judge — that is why the judge is
+ *     optional and auto-skipped on an OAuth-only setup.
+ *   Keys come from the environment or a .env next to this eval's eval-dir root.
+ *
+ * PREREQS: Docker installed and its daemon reachable.
+ */
+
+import { spawn, spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// .../skill-evals/copilotkit-setup/lift/run.ts -> eval dir is the parent of lift/.
+const EVAL_DIR = path.resolve(__dirname, "..");
+const RESULTS_DIR = path.join(EVAL_DIR, "results");
+const SKILL_NAME = "copilotkit-setup";
+const SKILL_DIR = path.resolve(EVAL_DIR, "../../skills", SKILL_NAME);
+const IMAGE = "copilotkit-setup-eval";
+const CONTAINER_SKILL_DIR = `/workspace/.claude/skills/${SKILL_NAME}`;
+
+const AGENT_TIMEOUT_MS = 15 * 60 * 1000; // 900s, matches the old task timeout.
+const GATE_TIMEOUT_MS = 5 * 60 * 1000;
+
+// --- output styling -----------------------------------------------------------
+// Color only on a real TTY (and honor NO_COLOR), so piping to a log file or CI
+// stays clean plain text instead of ANSI escape soup.
+const USE_COLOR =
+  Boolean(process.stdout.isTTY) && process.env.NO_COLOR === undefined;
+const paint =
+  (code: string) =>
+  (s: string | number): string =>
+    USE_COLOR ? `\x1b[${code}m${s}\x1b[0m` : String(s);
+const clr = {
+  bold: paint("1"),
+  dim: paint("2"),
+  red: paint("31"),
+  green: paint("32"),
+  yellow: paint("33"),
+  cyan: paint("36"),
+};
+
+type ArmLabel = "WITH-skill" | "WITHOUT-skill";
+
+interface Trial {
+  ok: boolean; // did the agent run to a successful result event
+  gateScore: number;
+  judgeScore: number | null;
+  reward: number;
+  durationMs: number;
+  numTurns: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  costUsd: number;
+  error?: string;
+}
+
+interface ArmSummary {
+  passRate: number;
+  meanReward: number;
+  medianDurationMs: number;
+  medianTurns: number;
+  medianTokens: number;
+  medianCostUsd: number;
+}
+
+/** Print a clear, actionable message and exit non-zero. */
+function die(message: string): never {
+  console.error(`\n[lift] ERROR: ${message}\n`);
+  process.exit(1);
+}
+
+/** Resolve trial count: --trials=N flag > SKILL_EVAL_TRIALS env > default 5. */
+function resolveTrials(): number {
+  const flag = process.argv.slice(2).find((a) => a.startsWith("--trials="));
+  const raw = flag ? flag.split("=")[1] : process.env.SKILL_EVAL_TRIALS;
+  if (raw === undefined) return 5;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n < 1) {
+    die(`invalid trial count "${raw}" (must be a positive integer)`);
+  }
+  return n;
+}
+
+/**
+ * Resolve max concurrent trials: --concurrency=N > SKILL_EVAL_CONCURRENCY > 4.
+ * Trials are independent, so this is purely a throttle on simultaneous
+ * containers + simultaneous agent API sessions. Lower it (e.g. =2) if you hit
+ * the agent's rate limit on a subscription token or run low on RAM; raise it on
+ * a beefy host with generous limits.
+ */
+function resolveConcurrency(): number {
+  const flag = process.argv
+    .slice(2)
+    .find((a) => a.startsWith("--concurrency="));
+  const raw = flag ? flag.split("=")[1] : process.env.SKILL_EVAL_CONCURRENCY;
+  if (raw === undefined) return 4;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n < 1) {
+    die(`invalid concurrency "${raw}" (must be a positive integer)`);
+  }
+  return n;
+}
+
+/** Read a .env file into a flat key/value map (best effort, KEY=VALUE lines). */
+function readEnvFile(file: string): Record<string, string> {
+  if (!existsSync(file)) return {};
+  const out: Record<string, string> = {};
+  for (const line of readFileSync(file, "utf8").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/** Verify Docker is installed and its daemon is reachable. */
+function preflightDocker(): void {
+  const probe = spawnSync("docker", ["info"], { stdio: "ignore" });
+  if (probe.error && (probe.error as NodeJS.ErrnoException).code === "ENOENT") {
+    die(
+      "Docker is not installed (the `docker` command was not found). Each trial " +
+        "runs in a container. Install Docker Desktop / Engine and try again.",
+    );
+  }
+  if (probe.status !== 0) {
+    die(
+      "Docker is installed but the daemon is not reachable (`docker info` failed). " +
+        "Start Docker and try again.",
+    );
+  }
+}
+
+interface JudgeConfig {
+  provider: "openai" | "anthropic";
+  key: string;
+  model: string;
+}
+
+interface Auth {
+  /** Env pairs to forward to the in-container agent (the key it authenticates with). */
+  agentEnv: Record<string, string>;
+  /** Judge config, or null when no judge-capable key is present. */
+  judge: JudgeConfig | null;
+}
+
+/**
+ * Resolve agent + judge auth from env and the eval-dir .env. Fail loud if no
+ * agent key is present. The judge is optional.
+ */
+function preflightAuth(): Auth {
+  const fileEnv = readEnvFile(path.join(EVAL_DIR, ".env"));
+  const val = (k: string) => (process.env[k] || fileEnv[k] || "").trim();
+
+  // Reject tokens polluted by $(claude setup-token) — control chars / whitespace —
+  // before a 15-minute run dies on an opaque in-container "API Error 400".
+  const malformed = (name: string, prefix: string): string | null => {
+    const v = val(name);
+    if (!v) return null;
+    if (
+      /\s/.test(v) ||
+      v.split("").some((c) => c.charCodeAt(0) < 32 || c.charCodeAt(0) === 127)
+    ) {
+      return `${name} contains whitespace or control characters`;
+    }
+    if (!v.startsWith(prefix)) return `${name} does not start with "${prefix}"`;
+    return null;
+  };
+  const badToken =
+    malformed("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat") ||
+    malformed("ANTHROPIC_API_KEY", "sk-ant-");
+  if (badToken) {
+    die(
+      `${badToken}. If you ran \`claude setup-token\`, copy ONLY the printed ` +
+        `sk-ant-oat... value into the .env next to ${EVAL_DIR}/eval — do NOT ` +
+        "capture it with $(claude setup-token), which slurps the TUI's escape codes.",
+    );
+  }
+
+  const oauth = val("CLAUDE_CODE_OAUTH_TOKEN");
+  const anthropic = val("ANTHROPIC_API_KEY");
+  const openai = val("OPENAI_API_KEY");
+
+  // Agent: prefer the OAuth subscription token, fall back to a Console key.
+  const agentEnv: Record<string, string> = {};
+  if (oauth) agentEnv.CLAUDE_CODE_OAUTH_TOKEN = oauth;
+  else if (anthropic) agentEnv.ANTHROPIC_API_KEY = anthropic;
+  else {
+    die(
+      "No agent LLM key found. Set CLAUDE_CODE_OAUTH_TOKEN (from `claude " +
+        "setup-token`, subscription) or ANTHROPIC_API_KEY (Console) in the " +
+        `environment or in a .env next to ${EVAL_DIR}/eval.`,
+    );
+  }
+
+  // Judge: JUDGE_PROVIDER forces a provider; otherwise prefer OpenAI when its key
+  // is present (the user asked for OpenAI support), else fall back to Anthropic.
+  const forced = val("JUDGE_PROVIDER").toLowerCase();
+  let judge: JudgeConfig | null = null;
+  const useOpenai =
+    openai && (forced === "openai" || (!forced && Boolean(openai)));
+  const useAnthropic = anthropic && (forced === "anthropic" || !forced);
+  if (useOpenai) {
+    judge = {
+      provider: "openai",
+      key: openai,
+      model: val("OPENAI_MODEL") || "gpt-5.5",
+    };
+  } else if (useAnthropic) {
+    judge = {
+      provider: "anthropic",
+      key: anthropic,
+      model: val("ANTHROPIC_GRADER_MODEL") || "claude-haiku-4-5-20251001",
+    };
+  }
+
+  return { agentEnv, judge };
+}
+
+/**
+ * Build the eval image once. Quiet on success (`-q` collapses the ~200-line
+ * apt/npm build log to nothing); on failure the captured output is printed so
+ * the error is still actionable.
+ */
+function buildImage(): void {
+  if (!existsSync(SKILL_DIR)) {
+    die(`skill under test not found at ${SKILL_DIR}.`);
+  }
+  process.stdout.write(` ${clr.dim("Building eval image…")} `);
+  const t0 = Date.now();
+  const res = spawnSync(
+    "docker",
+    [
+      "build",
+      "-q",
+      "-t",
+      IMAGE,
+      "-f",
+      path.join(EVAL_DIR, "Dockerfile"),
+      EVAL_DIR,
+    ],
+    { encoding: "utf8" },
+  );
+  if (res.status !== 0) {
+    process.stdout.write("\n");
+    console.error(`${res.stdout || ""}${res.stderr || ""}`);
+    die("docker build failed (see output above).");
+  }
+  console.log(
+    `${clr.green("done")} ${clr.dim(`(${Math.round((Date.now() - t0) / 1000)}s)`)}`,
+  );
+}
+
+interface DockerResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+/**
+ * Run a docker subcommand ASYNCHRONOUSLY, capturing stdout/stderr. Async (not
+ * spawnSync) is what makes parallel trials possible: spawnSync blocks the single
+ * Node thread, so N "concurrent" trials would still serialize. With async spawn,
+ * the concurrency pool can have several containers in flight at once.
+ */
+function docker(
+  args: string[],
+  opts: { timeoutMs?: number; env?: Record<string, string> } = {},
+): Promise<DockerResult> {
+  return new Promise((resolve) => {
+    const child = spawn("docker", args, {
+      env: opts.env ? { ...process.env, ...opts.env } : process.env,
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timer = opts.timeoutMs
+      ? setTimeout(() => {
+          timedOut = true;
+          child.kill("SIGTERM");
+        }, opts.timeoutMs)
+      : null;
+    child.stdout.on("data", (d) => {
+      stdout += d.toString();
+    });
+    child.stderr.on("data", (d) => {
+      stderr += d.toString();
+    });
+    child.on("error", (err) => {
+      if (timer) clearTimeout(timer);
+      resolve({ status: 1, stdout, stderr: `${stderr}${err}`, timedOut });
+    });
+    child.on("close", (code) => {
+      if (timer) clearTimeout(timer);
+      resolve({ status: code, stdout, stderr, timedOut });
+    });
+  });
+}
+
+interface AgentRun {
+  result: Record<string, any> | null;
+  transcript: string;
+}
+
+/** Parse stream-json (JSONL) into the final result event + a judge transcript. */
+function parseStreamJson(stdout: string): AgentRun {
+  let result: Record<string, any> | null = null;
+  const lines: string[] = [];
+  for (const raw of stdout.split("\n")) {
+    const line = raw.trim();
+    if (!line || line[0] !== "{") continue;
+    let evt: any;
+    try {
+      evt = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (evt.type === "result") {
+      result = evt;
+      continue;
+    }
+    if (evt.type === "assistant" && evt.message?.content) {
+      for (const block of evt.message.content) {
+        if (block.type === "text" && block.text?.trim()) {
+          lines.push(`ASSISTANT: ${truncate(block.text.trim(), 500)}`);
+        } else if (block.type === "tool_use") {
+          const input = JSON.stringify(block.input ?? {});
+          lines.push(`TOOL_USE ${block.name}: ${truncate(input, 400)}`);
+        }
+      }
+    } else if (evt.type === "user" && evt.message?.content) {
+      for (const block of evt.message.content) {
+        if (block.type === "tool_result") {
+          const c = block.content;
+          const text =
+            typeof c === "string"
+              ? c
+              : Array.isArray(c)
+                ? c.map((x: any) => x.text || "").join("")
+                : "";
+          lines.push(
+            `TOOL_RESULT${block.is_error ? " (error)" : ""}: ${truncate(text, 300)}`,
+          );
+        }
+      }
+    }
+  }
+  // Cap the transcript so judge token cost stays bounded on long traces.
+  const transcript = lines.join("\n").slice(0, 24000);
+  return { result, transcript };
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n)}…` : s;
+}
+
+// The task instruction (instruction.md) is one human sentence on purpose. This
+// operational guard is a HARNESS concern, not part of the task, so it is appended
+// here at invocation rather than polluting the human-readable instruction file:
+// without it a stray `npm run dev` would block a trial until AGENT_TIMEOUT_MS.
+const OPERATIONAL_GUARD =
+  "Just write the files. Do not start dev servers or leave any long-running " +
+  "processes; the result is graded from the files on disk and a build.";
+
+/** Run one trial in a fresh container. Returns its parsed agent run + gate score. */
+async function runTrial(
+  withSkill: boolean,
+  auth: Auth,
+): Promise<{ run: AgentRun; gate: { score: number } | null; stderr: string }> {
+  const created = await docker([
+    "run",
+    "-d",
+    "-w",
+    "/workspace",
+    IMAGE,
+    "sleep",
+    "infinity",
+  ]);
+  if (created.status !== 0) {
+    die(`failed to start a container: ${created.stderr.trim()}`);
+  }
+  const cid = created.stdout.trim();
+  try {
+    if (withSkill) {
+      await docker(["exec", cid, "mkdir", "-p", CONTAINER_SKILL_DIR]);
+      const cp = await docker([
+        "cp",
+        `${SKILL_DIR}/.`,
+        `${cid}:${CONTAINER_SKILL_DIR}`,
+      ]);
+      if (cp.status !== 0) {
+        die(`failed to copy the skill into the container: ${cp.stderr.trim()}`);
+      }
+    }
+
+    // Run the agent. IS_SANDBOX=1 lets --dangerously-skip-permissions run as root
+    // (the container IS the sandbox). The instruction is baked at /eval-tools; the
+    // operational guard is appended inside the same double-quoted prompt.
+    const envFlags: string[] = ["-e", "IS_SANDBOX=1"];
+    for (const [k, v] of Object.entries(auth.agentEnv)) {
+      envFlags.push("-e", `${k}=${v}`);
+    }
+    const agent = await docker(
+      [
+        "exec",
+        ...envFlags,
+        cid,
+        "bash",
+        "-lc",
+        `claude -p "$(cat /eval-tools/instruction.md)\n\n${OPERATIONAL_GUARD}" ` +
+          "--output-format stream-json --verbose --dangerously-skip-permissions",
+      ],
+      { timeoutMs: AGENT_TIMEOUT_MS },
+    );
+    const run = parseStreamJson(agent.stdout);
+    if (agent.timedOut) {
+      run.result = run.result ?? { is_error: true, subtype: "timeout" };
+    }
+
+    // Gate: build / type-check the agent's output via the TypeScript grader.
+    const graded = await docker(["exec", cid, "tsx", "/eval-tools/check.ts"], {
+      timeoutMs: GATE_TIMEOUT_MS,
+    });
+    let gate: { score: number } | null = null;
+    const m = graded.stdout.match(/\{[\s\S]*\}/);
+    if (m) {
+      try {
+        gate = JSON.parse(m[0]);
+      } catch {
+        gate = null;
+      }
+    }
+    return { run, gate, stderr: agent.stderr };
+  } finally {
+    await docker(["rm", "-f", cid]);
+  }
+}
+
+/** Score the agent's transcript against rubric.md via the configured judge. */
+async function judgeTranscript(
+  transcript: string,
+  judge: JudgeConfig,
+  rubric: string,
+): Promise<number | null> {
+  const user =
+    `${transcript}\n\n---\nScore the trace quality on [0, 1] per the rubric. ` +
+    "Respond with ONLY a single number between 0 and 1.";
+  try {
+    let text: string;
+    if (judge.provider === "openai") {
+      const res = await fetch("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${judge.key}`,
+        },
+        // No `temperature`: GPT-5-family models reject any non-default value
+        // ("temperature does not support 0"), and the default is fine for a
+        // single 0-1 directness score.
+        body: JSON.stringify({
+          model: judge.model,
+          messages: [
+            { role: "system", content: rubric },
+            { role: "user", content: user },
+          ],
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        console.warn(
+          `[lift] judge (openai) HTTP ${res.status}: ${truncate(body, 300)} — skipping this trial's judge.`,
+        );
+        return null;
+      }
+      const data: any = await res.json();
+      text = data.choices?.[0]?.message?.content ?? "";
+    } else {
+      const res = await fetch("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": judge.key,
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+          model: judge.model,
+          max_tokens: 64,
+          system: rubric,
+          messages: [{ role: "user", content: user }],
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        console.warn(
+          `[lift] judge (anthropic) HTTP ${res.status}: ${truncate(body, 300)} — skipping this trial's judge.`,
+        );
+        return null;
+      }
+      const data: any = await res.json();
+      text = data.content?.[0]?.text ?? "";
+    }
+    const match = text.match(/(?:0?\.\d+|[01](?:\.\d+)?)/);
+    if (!match) return null;
+    return Math.max(0, Math.min(1, Number.parseFloat(match[0])));
+  } catch (err) {
+    console.warn(`[lift] judge call failed: ${(err as Error).message}`);
+    return null;
+  }
+}
+
+/** Did the agent run to a clean success? */
+function agentOk(result: Record<string, any> | null): boolean {
+  return Boolean(
+    result && result.is_error !== true && result.subtype === "success",
+  );
+}
+
+function median(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  const s = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  const m = s.length % 2 === 0 ? (s[mid - 1] + s[mid]) / 2 : s[mid];
+  return m;
+}
+
+function round4(x: number): number {
+  return Math.round(x * 1e4) / 1e4;
+}
+
+/** Aggregate a flat trial list into per-arm metrics (efficiency over ok trials). */
+function summarize(trials: Trial[]): ArmSummary {
+  const ok = trials.filter((t) => t.ok);
+  const passes = trials.filter((t) => t.ok && t.reward >= 0.5).length;
+  const meanReward =
+    ok.length > 0 ? ok.reduce((s, t) => s + t.reward, 0) / ok.length : 0;
+  return {
+    passRate: trials.length > 0 ? passes / trials.length : 0,
+    meanReward: round4(meanReward),
+    medianDurationMs: Math.round(median(ok.map((t) => t.durationMs))),
+    medianTurns: round4(median(ok.map((t) => t.numTurns))),
+    medianTokens: Math.round(
+      median(ok.map((t) => t.inputTokens + t.outputTokens)),
+    ),
+    medianCostUsd: round4(median(ok.map((t) => t.costUsd))),
+  };
+}
+
+function fmtMs(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+function pct(x: number): string {
+  return `${(x * 100).toFixed(1)}%`;
+}
+/** Signed number with a real minus glyph: -1.2 -> "−1.2". */
+function signNum(x: number, dp: number, suffix = ""): string {
+  return `${x < 0 ? "−" : "+"}${Math.abs(x).toFixed(dp)}${suffix}`;
+}
+function signMoney(x: number): string {
+  return `${x < 0 ? "−" : "+"}$${Math.abs(x).toFixed(2)}`;
+}
+function signMs(ms: number): string {
+  return `${ms < 0 ? "−" : "+"}${fmtMs(Math.abs(ms))}`;
+}
+
+const BAR = "━".repeat(56);
+
+/** Wrap a string to lines of at most `width` chars, breaking on spaces. */
+function wrapText(s: string, width: number): string[] {
+  const lines: string[] = [];
+  let cur = "";
+  for (const word of s.trim().split(/\s+/)) {
+    if (cur && cur.length + 1 + word.length > width) {
+      lines.push(cur);
+      cur = word;
+    } else {
+      cur = cur ? `${cur} ${word}` : word;
+    }
+  }
+  if (cur) lines.push(cur);
+  return lines;
+}
+
+/** Title + the verbatim task + run config, printed before any work starts. */
+function printHeader(
+  task: string,
+  trials: number,
+  concurrency: number,
+  judge: JudgeConfig | null,
+): void {
+  console.log(`\n${clr.cyan(BAR)}`);
+  console.log(` ${clr.bold(`Skill-lift eval · ${SKILL_NAME}`)}`);
+  console.log(`${clr.cyan(BAR)}\n`);
+
+  console.log(` ${clr.bold("Task given to the agent")}`);
+  const wrapped = wrapText(task, 60);
+  wrapped.forEach((line, i) => {
+    const open = i === 0 ? "“" : " ";
+    const close = i === wrapped.length - 1 ? "”" : "";
+    console.log(`   ${clr.cyan(`${open}${line}${close}`)}`);
+  });
+
+  const judgeStr = judge
+    ? `${judge.provider} (${judge.model})`
+    : "off (deterministic-only)";
+  console.log(
+    `\n ${clr.dim(`${trials} trials/arm · concurrency ${concurrency} · judge: ${judgeStr}`)}`,
+  );
+}
+
+interface LiftRow {
+  label: string;
+  withVal: string;
+  withoutVal: string;
+  lift: string;
+  good: boolean;
+  negligible: boolean;
+}
+
+/** The with/without/lift rows, shared by the terminal table and the CI summary. */
+function buildLiftRows(
+  withSkill: ArmSummary,
+  withoutSkill: ArmSummary,
+  lift: Record<string, number>,
+): LiftRow[] {
+  return [
+    {
+      label: "pass rate",
+      withVal: pct(withSkill.passRate),
+      withoutVal: pct(withoutSkill.passRate),
+      lift: signNum(lift.passRate * 100, 1, "pp"),
+      good: lift.passRate > 0,
+      negligible: Math.abs(lift.passRate) < 0.001,
+    },
+    {
+      label: "mean reward",
+      withVal: withSkill.meanReward.toFixed(2),
+      withoutVal: withoutSkill.meanReward.toFixed(2),
+      lift: signNum(lift.meanReward, 2),
+      good: lift.meanReward > 0,
+      negligible: Math.abs(lift.meanReward) < 0.005,
+    },
+    {
+      label: "median cost",
+      withVal: `$${withSkill.medianCostUsd.toFixed(2)}`,
+      withoutVal: `$${withoutSkill.medianCostUsd.toFixed(2)}`,
+      lift: signMoney(lift.costUsd),
+      good: lift.costUsd < 0,
+      negligible: Math.abs(lift.costUsd) < 0.005,
+    },
+    {
+      label: "median turns",
+      withVal: String(withSkill.medianTurns),
+      withoutVal: String(withoutSkill.medianTurns),
+      lift: signNum(lift.turns, 0),
+      good: lift.turns < 0,
+      negligible: Math.abs(lift.turns) < 0.5,
+    },
+    {
+      label: "median tokens",
+      withVal: String(withSkill.medianTokens),
+      withoutVal: String(withoutSkill.medianTokens),
+      lift: signNum(lift.tokens, 0),
+      good: lift.tokens < 0,
+      negligible: Math.abs(lift.tokens) < 50,
+    },
+    {
+      label: "median duration",
+      withVal: fmtMs(withSkill.medianDurationMs),
+      withoutVal: fmtMs(withoutSkill.medianDurationMs),
+      lift: signMs(lift.durationMs),
+      good: lift.durationMs < 0,
+      negligible: Math.abs(lift.durationMs) < 2000,
+    },
+  ];
+}
+
+/** The results block: aligned with/without/lift columns + a ✔ where it helped. */
+function printTable(
+  withSkill: ArmSummary,
+  withoutSkill: ArmSummary,
+  lift: Record<string, number>,
+): void {
+  const rows = buildLiftRows(withSkill, withoutSkill, lift);
+
+  const headers = { label: "", w: "with", wo: "without", f: "lift" };
+  const lw = Math.max(headers.label.length, ...rows.map((r) => r.label.length));
+  const ww = Math.max(headers.w.length, ...rows.map((r) => r.withVal.length));
+  const ow = Math.max(
+    headers.wo.length,
+    ...rows.map((r) => r.withoutVal.length),
+  );
+  const fw = Math.max(headers.f.length, ...rows.map((r) => r.lift.length));
+
+  console.log(`\n${clr.cyan("━━ Results ")}${clr.cyan("━".repeat(45))}\n`);
+  console.log(
+    clr.dim(
+      `   ${headers.label.padEnd(lw)}   ${headers.w.padStart(ww)}   ` +
+        `${headers.wo.padStart(ow)}   ${headers.f.padStart(fw)}`,
+    ),
+  );
+  for (const r of rows) {
+    const liftCell = r.lift.padStart(fw);
+    const mark = r.negligible
+      ? clr.dim("·")
+      : r.good
+        ? clr.green("✔")
+        : clr.dim("–");
+    const liftOut = r.negligible
+      ? clr.dim(liftCell)
+      : r.good
+        ? clr.green(liftCell)
+        : liftCell;
+    console.log(
+      `   ${r.label.padEnd(lw)}   ${r.withVal.padStart(ww)}   ` +
+        `${r.withoutVal.padStart(ow)}   ${liftOut}   ${mark}`,
+    );
+  }
+  console.log(
+    `\n   ${clr.green("✔")} ${clr.dim(
+      "= skill helped. Lower turns/tokens/cost/duration is better;",
+    )}`,
+  );
+  console.log(`     ${clr.dim("higher pass rate / reward is better.")}`);
+}
+
+/** The lift cell for the CI summary: sign + a mark for helped / neutral / hurt. */
+function summaryLiftCell(r: LiftRow): string {
+  return r.negligible
+    ? `${r.lift} ·`
+    : r.good
+      ? `${r.lift} ✅`
+      : `${r.lift} ⚠️`;
+}
+
+/**
+ * When running under GitHub Actions, append a markdown lift table to the job's
+ * Step Summary so a scheduled run is readable at a glance from the Actions tab —
+ * no artifact download. No-op locally (GITHUB_STEP_SUMMARY unset). Same numbers
+ * as the terminal table, via the shared buildLiftRows().
+ */
+function writeStepSummary(
+  withSkill: ArmSummary,
+  withoutSkill: ArmSummary,
+  lift: Record<string, number>,
+  trials: number,
+  rubricRan: boolean,
+): void {
+  const file = process.env.GITHUB_STEP_SUMMARY;
+  if (!file) return;
+
+  const rows = buildLiftRows(withSkill, withoutSkill, lift);
+  const md = [
+    `## Skill-lift eval · ${SKILL_NAME}`,
+    "",
+    `${trials} trials/arm · trace judge: ${rubricRan ? "ran" : "skipped"}`,
+    "",
+    "| metric | with skill | without skill | lift |",
+    "| --- | ---: | ---: | ---: |",
+    ...rows.map(
+      (r) =>
+        `| ${r.label} | ${r.withVal} | ${r.withoutVal} | ${summaryLiftCell(r)} |`,
+    ),
+    "",
+    "✅ = skill helped. Lower turns/tokens/cost/duration is better; higher pass rate / reward is better.",
+    "",
+  ].join("\n");
+  appendFileSync(file, `${md}\n`);
+}
+
+interface TrialTask {
+  arm: ArmLabel;
+  withSkill: boolean;
+  index: number;
+}
+
+/**
+ * Bounded-concurrency map: run `worker` over every item, at most `limit` in
+ * flight at once, preserving input order in the result array. This is what
+ * parallelizes the trials — each trial is fully independent (its own fresh
+ * container, no shared state), so the only ceiling is host resources and the
+ * agent API rate limit, both bounded by `limit`.
+ */
+async function pool<I, O>(
+  items: I[],
+  limit: number,
+  worker: (item: I) => Promise<O>,
+): Promise<O[]> {
+  // Each lane writes results[task.index], so order is preserved without presizing.
+  const results: O[] = [];
+  let cursor = 0;
+  async function lane(): Promise<void> {
+    while (true) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      results[i] = await worker(items[i]);
+    }
+  }
+  const lanes = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: lanes }, () => lane()));
+  return results;
+}
+
+/** Run one trial end-to-end (container → agent → gate → judge) into a Trial. */
+async function runOneTrial(
+  task: TrialTask,
+  trials: number,
+  auth: Auth,
+  rubric: string,
+): Promise<Trial> {
+  const { run, gate, stderr } = await runTrial(task.withSkill, auth);
+  const ok = agentOk(run.result);
+  const r = run.result || {};
+  const usage = r.usage || {};
+  const gateScore = gate ? Number(gate.score) || 0 : 0;
+
+  let judgeScore: number | null = null;
+  if (ok && auth.judge) {
+    judgeScore = await judgeTranscript(run.transcript, auth.judge, rubric);
+  }
+  const reward =
+    judgeScore !== null ? 0.6 * gateScore + 0.4 * judgeScore : gateScore;
+
+  const trial: Trial = {
+    ok,
+    gateScore: round4(gateScore),
+    judgeScore: judgeScore !== null ? round4(judgeScore) : null,
+    reward: round4(reward),
+    durationMs: Number(r.duration_ms) || 0,
+    numTurns: Number(r.num_turns) || 0,
+    inputTokens: Number(usage.input_tokens) || 0,
+    outputTokens: Number(usage.output_tokens) || 0,
+    cacheReadTokens: Number(usage.cache_read_input_tokens) || 0,
+    costUsd: Number(r.total_cost_usd) || 0,
+  };
+  if (!ok) {
+    // Surface the ACTUAL failure, not just a bare status code. Claude Code puts
+    // the API error text in the result event's `result`/`error` field; anything
+    // that killed the CLI before a result event lands only in stderr. Both were
+    // being discarded, which is why a 400 read as an opaque "400" in CI.
+    const status = r.api_error_status || r.subtype;
+    const detail = String(r.result || r.error || "").trim();
+    const errTail = stderr.trim().split("\n").slice(-4).join(" | ");
+    trial.error =
+      [status, detail].filter(Boolean).join(": ") ||
+      errTail ||
+      "agent did not reach a result event";
+  }
+
+  // One standalone line per trial — trials finish out of order under concurrency,
+  // so the label carries the arm + index instead of relying on print order.
+  const label = task.arm.padEnd("WITHOUT-skill".length);
+  const id = `#${task.index + 1}`;
+  if (ok) {
+    // Color the reward by band so good/bad reads at a glance.
+    const rw = trial.reward;
+    const rewardStr =
+      rw >= 0.8
+        ? clr.green(rw.toFixed(2))
+        : rw >= 0.5
+          ? clr.yellow(rw.toFixed(2))
+          : clr.red(rw.toFixed(2));
+    const judgePart =
+      judgeScore !== null ? `  judge ${judgeScore.toFixed(2)}` : "";
+    console.log(
+      `   ${label} ${id}  ${clr.green("✔")}  reward ${rewardStr}  ` +
+        `gate ${trial.gateScore.toFixed(2)}${judgePart}  ` +
+        clr.dim(`  ${trial.numTurns} turns · ${fmtMs(trial.durationMs)}`),
+    );
+  } else {
+    console.log(
+      `   ${label} ${id}  ${clr.red("✗")}  ${clr.red(`agent failed (${trial.error})`)}`,
+    );
+  }
+  return trial;
+}
+
+async function main(): Promise<void> {
+  const trials = resolveTrials();
+  const concurrency = resolveConcurrency();
+  preflightDocker();
+  const auth = preflightAuth();
+  const rubric = readFileSync(path.join(EVAL_DIR, "rubric.md"), "utf8");
+  const instruction = readFileSync(
+    path.join(EVAL_DIR, "instruction.md"),
+    "utf8",
+  ).trim();
+
+  printHeader(instruction, trials, concurrency, auth.judge);
+  console.log("");
+  buildImage();
+
+  // Both arms are one flat pool of independent trials (WITH first, WITHOUT
+  // second). Running them together keeps every concurrency lane busy instead of
+  // draining one arm before starting the next.
+  const tasks: TrialTask[] = [
+    ...Array.from({ length: trials }, (_, index) => ({
+      arm: "WITH-skill" as const,
+      withSkill: true,
+      index,
+    })),
+    ...Array.from({ length: trials }, (_, index) => ({
+      arm: "WITHOUT-skill" as const,
+      withSkill: false,
+      index,
+    })),
+  ];
+  console.log(
+    `\n ${clr.bold("Trials")} ${clr.dim(`(running ${tasks.length}, ✔ = agent completed)`)}`,
+  );
+  const all = await pool(tasks, concurrency, (task) =>
+    runOneTrial(task, trials, auth, rubric),
+  );
+  const withArm = all.slice(0, trials);
+  const withoutArm = all.slice(trials);
+
+  // Fail loud if an entire arm's agent never ran — grading an untouched fixture
+  // would make a broken agent look like "no lift" rather than an error.
+  for (const [label, arm] of [
+    ["WITH-skill", withArm],
+    ["WITHOUT-skill", withoutArm],
+  ] as const) {
+    const failed = arm.filter((t) => !t.ok).length;
+    if (failed === arm.length) {
+      die(
+        `${label} arm: the agent failed in ALL ${arm.length} trial(s), so the eval ` +
+          `graded an untouched fixture. First error: ${arm[0]?.error}. ` +
+          "Most common cause: a malformed agent token (an in-container API Error " +
+          "usually means the auth header is garbage).",
+      );
+    }
+    if (failed > 0) {
+      console.log(
+        clr.yellow(
+          `   ! ${label}: ${failed}/${arm.length} agent failures (excluded from medians)`,
+        ),
+      );
+    }
+  }
+
+  const withSkill = summarize(withArm);
+  const withoutSkill = summarize(withoutArm);
+  const lift = {
+    passRate: round4(withSkill.passRate - withoutSkill.passRate),
+    meanReward: round4(withSkill.meanReward - withoutSkill.meanReward),
+    durationMs: withSkill.medianDurationMs - withoutSkill.medianDurationMs,
+    turns: round4(withSkill.medianTurns - withoutSkill.medianTurns),
+    tokens: withSkill.medianTokens - withoutSkill.medianTokens,
+    costUsd: round4(withSkill.medianCostUsd - withoutSkill.medianCostUsd),
+  };
+
+  const rubricRan = Boolean(auth.judge);
+  printTable(withSkill, withoutSkill, lift);
+  writeStepSummary(withSkill, withoutSkill, lift, trials, rubricRan);
+
+  const result = {
+    timestamp: new Date().toISOString(),
+    skill: SKILL_NAME,
+    trials,
+    rubricRan,
+    withSkill,
+    withoutSkill,
+    lift: {
+      passRate: lift.passRate,
+      durationMs: lift.durationMs,
+      turns: lift.turns,
+      tokens: lift.tokens,
+      costUsd: lift.costUsd,
+    },
+  };
+
+  mkdirSync(RESULTS_DIR, { recursive: true });
+  const outFile = path.join(
+    RESULTS_DIR,
+    `${result.timestamp.replace(/[:.]/g, "-")}.json`,
+  );
+  writeFileSync(outFile, `${JSON.stringify(result, null, 2)}\n`);
+  const relOut = path.relative(process.cwd(), outFile);
+  console.log(`\n ${clr.dim("Results →")} ${relOut}\n`);
+}
+
+main().catch((err) => die(err.stack || String(err)));

--- a/skill-evals/copilotkit-setup/results/.gitignore
+++ b/skill-evals/copilotkit-setup/results/.gitignore
@@ -1,0 +1,3 @@
+# Ephemeral lift-run outputs. Flip to committed history later (see ../../README.md).
+*
+!.gitignore

--- a/skill-evals/copilotkit-setup/rubric.md
+++ b/skill-evals/copilotkit-setup/rubric.md
@@ -1,0 +1,109 @@
+# Trace-judge rubric — copilotkit-setup
+
+You are grading the **journey**, not the destination. A separate deterministic
+grader already builds and type-checks the final project, so it owns "did the
+files end up correct." Your job is to read the agent's **session transcript**
+(the task instruction, every command the agent ran, every file it edited, and
+the final result) and judge **how cleanly and directly the agent got there**.
+
+The task the agent was given was a single sentence, with NO spec or API hints:
+"Add CopilotKit to this existing Vite+React project with a chat sidebar and a
+BuiltInAgent backend." Everything below — which packages, which provider, which
+handler factory, the stylesheet — is knowledge the agent had to supply itself
+(from the skill, when mounted, or from memory / trial-and-error when not). That
+the instruction does NOT enumerate the surface is deliberate: it is what lets
+this judge see whether the agent already knew the canonical path.
+
+This same rubric runs on runs **with** the skill mounted and runs **without** it.
+Judge both by the same standard, so the score reflects how much the trace looks
+like the agent already knew the canonical path.
+
+## CRITICAL — what to ignore
+
+Some paths in the transcript are the mounted skill itself, **not** the agent's
+own work. When you see commands or file references under either of these, ignore
+them entirely — do not credit or penalize them:
+
+- `.claude/skills/` (the mounted skill copy, WITH-skill arm only)
+- `.agents/` (any mounted-skill copy)
+
+In particular, the skill's own example files live under `.claude/skills/`. An
+agent reading or matching those is harness noise, not evidence of either skill or
+real work. Judge only the commands and edits the agent made against the actual
+project (`/workspace` and `src/`, package.json, the runtime server file, etc.).
+
+## What "canonical" looks like (the well-steered path)
+
+A trace that moved directly to the correct CopilotKit v2 surface shows the agent
+reaching for these APIs **without trial and error**:
+
+- Frontend provider: `CopilotKit` imported from `@copilotkit/react-core/v2`
+  (the v1/v2 compat bridge), plus `CopilotSidebar` from the same `/v2` subpath.
+- Stylesheet: `@copilotkit/react-core/v2/styles.css`.
+- Runtime: `CopilotRuntime` and `BuiltInAgent` from `@copilotkit/runtime/v2`.
+- Endpoint factory: `createCopilotHonoHandler` (Hono) or
+  `createCopilotExpressHandler` from `@copilotkit/runtime/v2/express` (Express).
+- Packages: `@copilotkit/react-core` and `@copilotkit/runtime` (plus `hono` or
+  `express`).
+- For a standalone backend on its own port, the provider points at the external
+  URL with `useSingleEndpoint` matching the backend's route mode.
+
+These are **deprecated, wrong, or nonexistent** — reaching for them, then having
+to correct course, is a dead-end and should lower the score:
+
+- `createCopilotEndpoint`, `createCopilotEndpointExpress`,
+  `createCopilotEndpointSingleRoute*` (deprecated aliases).
+- `CopilotKitProvider` from `/v2` (a subset of the compat bridge — not the
+  recommended provider), or `CopilotKit` from the package root (legacy v1).
+- Packages `@copilotkit/react` or `@copilotkit/agent` (do not exist in this
+  layout); `@copilotkitnext/*` (deprecated scope).
+- Importing chat components or the stylesheet from `@copilotkit/react-ui`
+  (v2 chat ships from `react-core/v2`; `react-ui` is CSS-only in v2).
+
+## Scoring signals (in priority order)
+
+1. **Directness / few dead-ends (most important).** Did the agent go more or less
+   straight to the canonical v2 setup, or did it thrash — try things that
+   errored, backtrack, install a package then uninstall it, import a symbol that
+   does not exist and then fix it, flip the provider/endpoint mode back and
+   forth? Straight-line work scores high; visible course-correction scores lower.
+
+2. **Canonical APIs reached first.** Do the commands and edits show the canonical
+   surface listed above appearing **in the first attempt**, as if the agent knew
+   the API? Or does the trace show deprecated/nonexistent names appearing first
+   and being replaced later? First-try-canonical is the strongest "the skill
+   helped" signal.
+
+3. **Trial-and-error success counts as LOW directness.** An agent **without** the
+   skill may still reach a correct, building setup by experimenting — grepping
+   node_modules for export names, reading many package files to rediscover the
+   API, running a failing build repeatedly until it compiles, or fetching docs to
+   learn the surface. Even when the final files are correct, this is **lower**
+   directness, because the agent had to discover the answer the hard way. An
+   agent that wrote the canonical code as if it already knew it scores **higher**.
+   This contrast is the core "did the skill help" signal — do not flatten it.
+
+4. **Wasted effort.** Penalize repeated failed builds/installs, large amounts of
+   exploratory file reading to recover known facts, redundant re-installs, and
+   long detours that did not advance the setup.
+
+## Output
+
+Score the **trace quality** on `[0, 1]`:
+
+- **0.85–1.0** — Near straight-line. Canonical v2 APIs on the first attempt, no
+  meaningful backtracking, minimal wasted commands. Reads as if the agent knew
+  the path.
+- **0.55–0.85** — Mostly direct, but with some discovery cost: a little
+  exploration, one or two corrected missteps, or a couple of redundant commands.
+- **0.25–0.55** — Reached the setup largely by trial and error: multiple
+  dead-ends, deprecated/nonexistent APIs tried first, repeated failed builds, or
+  heavy exploratory reading before landing on the canonical surface.
+- **0.0–0.25** — Heavy thrash, lots of churn and backtracking, or never settled
+  on the canonical surface even if something eventually built.
+
+**Do NOT re-score final-file correctness** — that is the deterministic grader's
+job, and double-counting it would defeat the purpose of this judge. A run can
+have perfectly correct final files and still earn a low score here if it reached
+them through a long, error-strewn journey. Judge the path, then output a single
+number in `[0, 1]`.

--- a/skill-evals/copilotkit-setup/workspace/vite-react/.gitignore
+++ b/skill-evals/copilotkit-setup/workspace/vite-react/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+package-lock.json
+*.local

--- a/skill-evals/copilotkit-setup/workspace/vite-react/index.html
+++ b/skill-evals/copilotkit-setup/workspace/vite-react/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + React + TS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/skill-evals/copilotkit-setup/workspace/vite-react/package.json
+++ b/skill-evals/copilotkit-setup/workspace/vite-react/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "vite-react-fixture",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "typecheck": "tsc --noEmit",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.3",
+    "vite": "^6.0.7"
+  }
+}

--- a/skill-evals/copilotkit-setup/workspace/vite-react/src/App.tsx
+++ b/skill-evals/copilotkit-setup/workspace/vite-react/src/App.tsx
@@ -1,0 +1,10 @@
+function App() {
+  return (
+    <main>
+      <h1>Vite + React</h1>
+      <p>Edit src/App.tsx and save to reload.</p>
+    </main>
+  );
+}
+
+export default App;

--- a/skill-evals/copilotkit-setup/workspace/vite-react/src/main.tsx
+++ b/skill-evals/copilotkit-setup/workspace/vite-react/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App.tsx";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/skill-evals/copilotkit-setup/workspace/vite-react/src/vite-env.d.ts
+++ b/skill-evals/copilotkit-setup/workspace/vite-react/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/skill-evals/copilotkit-setup/workspace/vite-react/tsconfig.json
+++ b/skill-evals/copilotkit-setup/workspace/vite-react/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/skill-evals/copilotkit-setup/workspace/vite-react/vite.config.ts
+++ b/skill-evals/copilotkit-setup/workspace/vite-react/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
Adds skill evaluation framework so CopilotKit skills don't regress and to prove a skill measurably helps an agent vs. running without it.

- Runs the same task twice, with and without the skill, and diffs the two runs (difference is the skill's **lift**).
- Measures pass rate, reward (correctness + how directly it reached the right APIs), cost, turns, tokens, and duration.
- Adds the first eval, for the `copilotkit-setup` skill.
- Adds a workflow that runs it daily on a cron, and as a **merge-blocking smoke run** on PRs that touch a skill or the eval, posting the lift table to the run's Step Summary.

**Example CI run for copilotkit-setup skill** ([full run](https://github.com/CopilotKit/CopilotKit/actions/runs/28608703956)):

| metric | with skill | without skill | lift |
| --- | ---: | ---: | ---: |
| pass rate | 100.0% | 100.0% | +0.0pp |
| mean reward | 0.93 | 0.68 | +0.25 ✅ |
| median cost | $0.80 | $8.73 | −$7.94 ✅ |
| median turns | 38 | 70 | −32 ✅ |
| median tokens | 12,100 | 27,886 | −15,786 ✅ |
| median duration | 219.7s | 511.7s | −291.9s ✅ |

Running it locally: see `skill-evals/README.md`.


<details>
<summary>Local run output (<code>pnpm eval:skill:setup --trials=1</code>)</summary>

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Skill-lift eval · copilotkit-setup
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

 Task given to the agent
   “Add CopilotKit to this existing Vite+React project with a
    chat sidebar and a BuiltInAgent backend.”

 1 trials/arm · concurrency 4 · judge: openai (gpt-5.5)

 Building eval image… done (0s)

 Trials (running 2, ✔ = agent completed)
   WITH-skill    #1  ✔  reward 0.99  gate 1.00  judge 0.97    19 turns · 230.0s
   WITHOUT-skill #1  ✔  reward 0.52  gate 0.77  judge 0.15    25 turns · 433.0s

━━ Results ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

                       with   without      lift
   pass rate         100.0%    100.0%    +0.0pp   ·
   mean reward         0.99      0.52     +0.47   ✔
   median cost        $0.35     $1.34    −$0.99   ✔
   median turns          19        25        −6   ✔
   median tokens       8170     18933    −10763   ✔
   median duration   230.0s    433.0s   −203.0s   ✔

   ✔ = skill helped. Lower turns/tokens/cost/duration is better;
     higher pass rate / reward is better.

 Results → skill-evals/copilotkit-setup/results/2026-07-02T18-03-36-024Z.json
```

</details>


## When a skill regresses

**The skill runs but stops helping.** Eval passes (exit 0, green check), but the lift table flips ✅ → ⚠️ and reward drops. You read it off the PR Step Summary / daily run — it doesn't turn the check red on its own.

```
                       with   without       lift
   pass rate           0.0%    100.0%   −100.0pp   ⚠️
   mean reward         0.41      0.52      −0.11   ⚠️
   median cost        $2.05     $1.34     +$0.71   ⚠️
   median turns          44        25        +19   ⚠️
```

**The skill breaks the agent.** If every WITH-skill trial fails to complete (stale command loops to the turn cap, broken instruction, bad token), the eval exits 1 and the smoke run **blocks the PR**:

```
   WITH-skill    #1  ✗  agent failed (error_max_turns: reached the 80-turn cap without a result)

[lift] ERROR: WITH-skill arm: the agent failed in ALL 1 trial(s). First error: error_max_turns: reached the 80-turn cap without a result.
```
