### PR TITLE
fix(showcase): re-author pydantic-ai gen-ui-declarative aimock fixture (kill 503 no_fixture_match)

### DIFF
--- a/showcase/aimock/d6/pydantic-ai/gen-ui-declarative.json
+++ b/showcase/aimock/d6/pydantic-ai/gen-ui-declarative.json
@@ -1,339 +1,190 @@
 {
-  "_meta": {
-    "description": "D6 fixtures for pydantic-ai / gen-ui-declarative",
-    "sourceFile": "harness/fixtures/d5/gen-ui-declarative.json",
-    "created": "2026-05-22"
+ "_meta": {
+  "description": "D6 fixtures for pydantic-ai / gen-ui-declarative (A2UI Dynamic Schema)",
+  "_note": "Mirrors the langgraph-python canonical fixture 1:1, re-templated for pydantic-ai (src/agents/a2ui_dynamic.py). Two-stage A2UI pattern: (1) the outer agent (gpt-4.1 → /v1/responses, tools include `generate_a2ui`, header `x-aimock-context: pydantic-ai`) emits a no-arg `generate_a2ui` toolcall; (2) inside the `generate_a2ui` tool the agent fires a SECONDARY LLM (`client.chat.completions.create`, gpt-4.1 → /v1/chat/completions) with tools=[render_a2ui] and tool_choice forced on `render_a2ui` — that inner fixture (matched by `toolName: render_a2ui`) emits the flat A2UI components payload; (3) after the tool returns, the outer agent emits a one-sentence narration (matched by `toolCallId`). The inner secondary call goes through a bare `OpenAI()` client that does NOT forward the `x-aimock-context` header, so the inner fixtures match on `toolName: render_a2ui` ALONE (no `context`), exactly like langgraph-python. Inner (toolName) entries are ordered before the outer (userMessage+context) entries so the bare userMessage+context outer fixture can never hijack the inner secondary call. Pill userMessage matchers are the full prompt text from declarative-gen-ui/suggestions.ts (GEN_UI_DECLARATIVE_PILLS in d5-gen-ui-declarative.ts).",
+  "sourceFile": "harness/fixtures/d5/gen-ui-declarative.json",
+  "created": "2026-06-24"
+ },
+ "fixtures": [
+  {
+   "_comment": "pill sales-dashboard hero — inner secondary LLM (render_a2ui, tool_choice forced) emits the flat A2UI components. Matched by toolName alone (inner OpenAI() client does not forward x-aimock-context).",
+   "match": {
+    "userMessage": "Show me my sales dashboard for this quarter.",
+    "toolName": "render_a2ui"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_dash_design_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"sales-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"kpi-row\",\"charts-row\"]},{\"id\":\"kpi-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-revenue\",\"metric-new-customers\",\"metric-win-rate\",\"metric-deal-size\"]},{\"id\":\"metric-revenue\",\"component\":\"Metric\",\"label\":\"Quarterly Revenue\",\"value\":\"$4.2M\",\"trend\":\"up\",\"trendValue\":\"+12% QoQ\"},{\"id\":\"metric-new-customers\",\"component\":\"Metric\",\"label\":\"New Customers\",\"value\":\"186\",\"trend\":\"up\",\"trendValue\":\"+8%\"},{\"id\":\"metric-win-rate\",\"component\":\"Metric\",\"label\":\"Win Rate\",\"value\":\"31%\",\"trend\":\"down\",\"trendValue\":\"-2 pts\"},{\"id\":\"metric-deal-size\",\"component\":\"Metric\",\"label\":\"Avg Deal Size\",\"value\":\"$22.6k\",\"trend\":\"up\",\"trendValue\":\"+5%\"},{\"id\":\"charts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"region-pie\",\"monthly-bar\"]},{\"id\":\"region-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by Region\",\"description\":\"Quarter revenue split across North America, EMEA, APAC, and LATAM.\",\"data\":[{\"label\":\"North America\",\"value\":1900000},{\"label\":\"EMEA\",\"value\":1300000},{\"label\":\"APAC\",\"value\":720000},{\"label\":\"LATAM\",\"value\":280000}]},{\"id\":\"monthly-bar\",\"component\":\"BarChart\",\"title\":\"Monthly Revenue\",\"description\":\"Revenue trend from Jan through Jun.\",\"data\":[{\"label\":\"Jan\",\"value\":1210000},{\"label\":\"Feb\",\"value\":1340000},{\"label\":\"Mar\",\"value\":1650000},{\"label\":\"Apr\",\"value\":1380000},{\"label\":\"May\",\"value\":1420000},{\"label\":\"Jun\",\"value\":1400000}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
   },
-  "fixtures": [
-    {
-      "match": {
-        "userMessage": "KPI dashboard",
-        "hasToolResult": false,
-        "context": "pydantic-ai"
-      },
-      "response": {
-        "content": "Here is the KPI dashboard you requested.",
-        "toolCalls": [{ "name": "generate_a2ui", "arguments": {} }]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "hasToolResult": false,
-        "context": "pydantic-ai"
-      },
-      "response": {
-        "content": "Here is the pie chart by region.",
-        "toolCalls": [{ "name": "generate_a2ui", "arguments": {} }]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "hasToolResult": false,
-        "context": "pydantic-ai"
-      },
-      "response": {
-        "content": "Here is the bar chart of quarterly revenue.",
-        "toolCalls": [{ "name": "generate_a2ui", "arguments": {} }]
-      }
-    },
-    {
-      "match": {
-        "userMessage": "status report on system health",
-        "hasToolResult": false,
-        "context": "pydantic-ai"
-      },
-      "response": {
-        "content": "Here is the system health status report.",
-        "toolCalls": [{ "name": "generate_a2ui", "arguments": {} }]
-      }
-    },
-    {
-      "_comment": "sales-dashboard hero pill — outer agent emits generate_a2ui (no args). Mirrors LGP gen-ui-declarative.json sales-dashboard outer entry. Closes the staging pydantic-ai D-chat 503 (no_fixture_match) where the backend hits aimock with tools=[generate_a2ui] for this userMessage under x-aimock-context: pydantic-ai (ms-agent-dotnet already had the equivalent).",
-      "match": {
-        "userMessage": "Show me my sales dashboard for this quarter.",
-        "hasToolResult": false,
-        "context": "pydantic-ai"
-      },
-      "response": {
-        "content": "Here is your sales dashboard for this quarter.",
-        "toolCalls": [{ "name": "generate_a2ui", "arguments": {} }]
-      }
-    },
-    {
-      "_comment": "_design_a2ui_surface — KPI dashboard pill (pydantic-ai secondary tool name).",
-      "match": {
-        "userMessage": "KPI dashboard",
-        "toolName": "_design_a2ui_surface",
-        "context": "pydantic-ai"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "_design_a2ui_surface",
-            "arguments": {
-              "surfaceId": "declarative-surface",
-              "catalogId": "declarative-gen-ui-catalog",
-              "components": [
-                {
-                  "id": "root",
-                  "component": "Card",
-                  "title": "KPI dashboard",
-                  "subtitle": "Last 30 days",
-                  "child": "metrics-col"
-                },
-                {
-                  "id": "metrics-col",
-                  "component": "Column",
-                  "children": ["metric-revenue", "metric-signups", "metric-churn"],
-                  "gap": 12
-                },
-                {
-                  "id": "metric-revenue",
-                  "component": "Metric",
-                  "label": "Revenue",
-                  "value": "$1.2M",
-                  "trend": "up"
-                },
-                {
-                  "id": "metric-signups",
-                  "component": "Metric",
-                  "label": "Signups",
-                  "value": "4,820",
-                  "trend": "up"
-                },
-                {
-                  "id": "metric-churn",
-                  "component": "Metric",
-                  "label": "Churn",
-                  "value": "2.1%",
-                  "trend": "down"
-                }
-              ],
-              "data": {}
-            }
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "_design_a2ui_surface — pie-chart pill.",
-      "match": {
-        "userMessage": "pie chart of sales by region",
-        "toolName": "_design_a2ui_surface",
-        "context": "pydantic-ai"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "_design_a2ui_surface",
-            "arguments": {
-              "surfaceId": "declarative-surface",
-              "catalogId": "declarative-gen-ui-catalog",
-              "components": [
-                {
-                  "id": "root",
-                  "component": "PieChart",
-                  "title": "Sales by region",
-                  "description": "Q4 — share of total revenue",
-                  "data": [
-                    { "label": "North America", "value": 540 },
-                    { "label": "EMEA", "value": 320 },
-                    { "label": "APAC", "value": 210 },
-                    { "label": "LATAM", "value": 90 }
-                  ]
-                }
-              ],
-              "data": {}
-            }
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "_design_a2ui_surface — bar-chart pill.",
-      "match": {
-        "userMessage": "bar chart of quarterly revenue",
-        "toolName": "_design_a2ui_surface",
-        "context": "pydantic-ai"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "_design_a2ui_surface",
-            "arguments": {
-              "surfaceId": "declarative-surface",
-              "catalogId": "declarative-gen-ui-catalog",
-              "components": [
-                {
-                  "id": "root",
-                  "component": "BarChart",
-                  "title": "Quarterly revenue",
-                  "description": "FY24 — USD thousands",
-                  "data": [
-                    { "label": "Q1", "value": 820 },
-                    { "label": "Q2", "value": 940 },
-                    { "label": "Q3", "value": 1080 },
-                    { "label": "Q4", "value": 1240 }
-                  ]
-                }
-              ],
-              "data": {}
-            }
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "_design_a2ui_surface — status-report pill.",
-      "match": {
-        "userMessage": "status report on system health",
-        "toolName": "_design_a2ui_surface",
-        "context": "pydantic-ai"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "_design_a2ui_surface",
-            "arguments": {
-              "surfaceId": "declarative-surface",
-              "catalogId": "declarative-gen-ui-catalog",
-              "components": [
-                {
-                  "id": "root",
-                  "component": "Card",
-                  "title": "System health",
-                  "subtitle": "All services",
-                  "children": ["status-api", "status-db", "status-workers"]
-                },
-                {
-                  "id": "status-api",
-                  "component": "StatusBadge",
-                  "text": "API: healthy",
-                  "variant": "success"
-                },
-                {
-                  "id": "status-db",
-                  "component": "StatusBadge",
-                  "text": "Database: healthy",
-                  "variant": "success"
-                },
-                {
-                  "id": "status-workers",
-                  "component": "StatusBadge",
-                  "text": "Workers: degraded",
-                  "variant": "warning"
-                }
-              ],
-              "data": {}
-            }
-          }
-        ]
-      }
-    },
-    {
-      "_comment": "_design_a2ui_surface — sales-dashboard hero pill. Component payload mirrors LGP gen-ui-declarative.json sales-dashboard surface (KPI metrics row + revenue-by-region pie + monthly-revenue bar), adapted to the pydantic-ai _design_a2ui_surface convention.",
-      "match": {
-        "userMessage": "Show me my sales dashboard for this quarter.",
-        "toolName": "_design_a2ui_surface",
-        "context": "pydantic-ai"
-      },
-      "response": {
-        "toolCalls": [
-          {
-            "name": "_design_a2ui_surface",
-            "arguments": {
-              "surfaceId": "declarative-surface",
-              "catalogId": "declarative-gen-ui-catalog",
-              "components": [
-                {
-                  "id": "root",
-                  "component": "Column",
-                  "gap": 16,
-                  "children": ["kpi-row", "charts-row"]
-                },
-                {
-                  "id": "kpi-row",
-                  "component": "Row",
-                  "gap": 16,
-                  "children": [
-                    "metric-revenue",
-                    "metric-new-customers",
-                    "metric-win-rate",
-                    "metric-deal-size"
-                  ]
-                },
-                {
-                  "id": "metric-revenue",
-                  "component": "Metric",
-                  "label": "Quarterly Revenue",
-                  "value": "$4.2M",
-                  "trend": "up",
-                  "trendValue": "+12% QoQ"
-                },
-                {
-                  "id": "metric-new-customers",
-                  "component": "Metric",
-                  "label": "New Customers",
-                  "value": "186",
-                  "trend": "up",
-                  "trendValue": "+8%"
-                },
-                {
-                  "id": "metric-win-rate",
-                  "component": "Metric",
-                  "label": "Win Rate",
-                  "value": "31%",
-                  "trend": "down",
-                  "trendValue": "-2 pts"
-                },
-                {
-                  "id": "metric-deal-size",
-                  "component": "Metric",
-                  "label": "Avg Deal Size",
-                  "value": "$22.6k",
-                  "trend": "up",
-                  "trendValue": "+5%"
-                },
-                {
-                  "id": "charts-row",
-                  "component": "Row",
-                  "gap": 16,
-                  "children": ["region-pie", "monthly-bar"]
-                },
-                {
-                  "id": "region-pie",
-                  "component": "PieChart",
-                  "title": "Revenue by Region",
-                  "description": "Quarter revenue split across North America, EMEA, APAC, and LATAM.",
-                  "data": [
-                    { "label": "North America", "value": 1900000 },
-                    { "label": "EMEA", "value": 1300000 },
-                    { "label": "APAC", "value": 720000 },
-                    { "label": "LATAM", "value": 280000 }
-                  ]
-                },
-                {
-                  "id": "monthly-bar",
-                  "component": "BarChart",
-                  "title": "Monthly Revenue",
-                  "description": "Revenue trend from Jan through Jun.",
-                  "data": [
-                    { "label": "Jan", "value": 1210000 },
-                    { "label": "Feb", "value": 1340000 },
-                    { "label": "Mar", "value": 1650000 },
-                    { "label": "Apr", "value": 1380000 },
-                    { "label": "May", "value": 1420000 },
-                    { "label": "Jun", "value": 1400000 }
-                  ]
-                }
-              ],
-              "data": {}
-            }
-          }
-        ]
-      }
-    }
-  ]
+  {
+   "_comment": "pill sales-dashboard hero — outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "pydantic-ai",
+    "toolCallId": "call_d6_decl_dash_outer_001"
+   },
+   "response": {
+    "content": "Here's your Q2 sales dashboard."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill sales-dashboard hero — outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "Show me my sales dashboard for this quarter.",
+    "context": "pydantic-ai"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_dash_outer_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill team-performance — inner secondary LLM (render_a2ui) emits the flat A2UI components.",
+   "match": {
+    "userMessage": "How are our sales reps performing against quota?",
+    "toolName": "render_a2ui"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_team_design_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"rep-quota-performance\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"title\",\"summary\",\"content\"]},{\"id\":\"title\",\"component\":\"Text\",\"text\":\"Sales rep performance vs quota\"},{\"id\":\"summary\",\"component\":\"Text\",\"text\":\"2 of 5 reps are above quota, 1 is near plan, and 2 are below target in Q2.\"},{\"id\":\"content\",\"component\":\"Row\",\"gap\":16,\"children\":[\"table-card\",\"attainment-chart\"]},{\"id\":\"table-card\",\"component\":\"Card\",\"title\":\"Rep attainment table\",\"child\":\"rep-table\"},{\"id\":\"rep-table\",\"component\":\"DataTable\",\"columns\":[{\"key\":\"rep\",\"label\":\"Rep\"},{\"key\":\"attainment\",\"label\":\"Attainment\"},{\"key\":\"pipeline\",\"label\":\"Pipeline\"}],\"rows\":[{\"rep\":\"Dana Whitfield\",\"attainment\":\"124%\",\"pipeline\":\"Leading team; biggest account Meridian Apparel Group has 4 open opps worth $210k\"},{\"rep\":\"Marcus Lee\",\"attainment\":\"108%\",\"pipeline\":\"Above plan\"},{\"rep\":\"Priya Sharma\",\"attainment\":\"97%\",\"pipeline\":\"Near quota\"},{\"rep\":\"Tom Okafor\",\"attainment\":\"88%\",\"pipeline\":\"Below plan\"},{\"rep\":\"Elena Vasquez\",\"attainment\":\"71%\",\"pipeline\":\"Furthest from quota\"}]},{\"id\":\"attainment-chart\",\"component\":\"BarChart\",\"title\":\"Quota attainment by rep\",\"description\":\"Q2 quota attainment percentages for all sales reps.\",\"data\":[{\"label\":\"Dana Whitfield\",\"value\":124},{\"label\":\"Marcus Lee\",\"value\":108},{\"label\":\"Priya Sharma\",\"value\":97},{\"label\":\"Tom Okafor\",\"value\":88},{\"label\":\"Elena Vasquez\",\"value\":71}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill team-performance — outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "pydantic-ai",
+    "toolCallId": "call_d6_decl_team_outer_001"
+   },
+   "response": {
+    "content": "Here's how the team is tracking against quota."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill team-performance — outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "How are our sales reps performing against quota?",
+    "context": "pydantic-ai"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_team_outer_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill at-risk — inner secondary LLM (render_a2ui) emits the flat A2UI components.",
+   "match": {
+    "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
+    "toolName": "render_a2ui"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_risk_design_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"risk-dashboard\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Column\",\"gap\":16,\"children\":[\"metrics-row\",\"accounts-row\"]},{\"id\":\"metrics-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"metric-arr\",\"metric-accounts\",\"metric-biggest\"]},{\"id\":\"metric-arr\",\"component\":\"Metric\",\"label\":\"ARR at risk\",\"value\":\"$615k\",\"trend\":\"down\",\"trendValue\":\"3 accounts\"},{\"id\":\"metric-accounts\",\"component\":\"Metric\",\"label\":\"Accounts at risk\",\"value\":\"3\",\"trend\":\"neutral\",\"trendValue\":\"This quarter\"},{\"id\":\"metric-biggest\",\"component\":\"Metric\",\"label\":\"Biggest exposure\",\"value\":\"Northwind Retail\",\"trend\":\"down\",\"trendValue\":\"$340k renewal\"},{\"id\":\"accounts-row\",\"component\":\"Row\",\"gap\":16,\"children\":[\"card-northwind\",\"card-cascadia\",\"card-atlas\"]},{\"id\":\"card-northwind\",\"component\":\"Card\",\"title\":\"Northwind Retail\",\"subtitle\":\"$340k ARR at stake\",\"child\":\"northwind-content\"},{\"id\":\"northwind-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"northwind-badge\",\"northwind-text\"]},{\"id\":\"northwind-badge\",\"component\":\"StatusBadge\",\"text\":\"High severity\",\"variant\":\"error\"},{\"id\":\"northwind-text\",\"component\":\"Text\",\"text\":\"No contact in 6 weeks; next action: exec outreach this week to protect the renewal.\"},{\"id\":\"card-cascadia\",\"component\":\"Card\",\"title\":\"Cascadia Outfitters\",\"subtitle\":\"$180k ARR at stake\",\"child\":\"cascadia-content\"},{\"id\":\"cascadia-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"cascadia-badge\",\"cascadia-text\"]},{\"id\":\"cascadia-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"cascadia-text\",\"component\":\"Text\",\"text\":\"Champion left; next action: rebuild stakeholder map and secure a new sponsor.\"},{\"id\":\"card-atlas\",\"component\":\"Card\",\"title\":\"Atlas Goods\",\"subtitle\":\"$95k ARR at stake\",\"child\":\"atlas-content\"},{\"id\":\"atlas-content\",\"component\":\"Column\",\"gap\":8,\"children\":[\"atlas-badge\",\"atlas-text\"]},{\"id\":\"atlas-badge\",\"component\":\"StatusBadge\",\"text\":\"Medium severity\",\"variant\":\"warning\"},{\"id\":\"atlas-text\",\"component\":\"Text\",\"text\":\"Legal review is stalled; next action: align procurement and legal on open terms.\"}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill at-risk — outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "pydantic-ai",
+    "toolCallId": "call_d6_decl_risk_outer_001"
+   },
+   "response": {
+    "content": "Three accounts need attention this quarter."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill at-risk — outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "Are any accounts or pipeline deals at risk this quarter?",
+    "context": "pydantic-ai"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_risk_outer_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill top-account — inner secondary LLM (render_a2ui) emits the flat A2UI components.",
+   "match": {
+    "userMessage": "Pull up the details on our biggest account.",
+    "toolName": "render_a2ui"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_acct_design_001_render",
+      "name": "render_a2ui",
+      "arguments": "{\"surfaceId\":\"biggest-account-details\",\"catalogId\":\"declarative-gen-ui-catalog\",\"components\":[{\"id\":\"root\",\"component\":\"Row\",\"gap\":16,\"children\":[\"account-card\",\"revenue-pie\"]},{\"id\":\"account-card\",\"component\":\"Card\",\"title\":\"Meridian Apparel Group\",\"subtitle\":\"Biggest account\",\"child\":\"account-facts\"},{\"id\":\"account-facts\",\"component\":\"Column\",\"gap\":8,\"children\":[\"fact1\",\"fact2\",\"fact3\",\"fact4\",\"fact5\",\"fact6\",\"fact7\"]},{\"id\":\"fact1\",\"component\":\"InfoRow\",\"label\":\"Owner\",\"value\":\"Dana Whitfield\"},{\"id\":\"fact2\",\"component\":\"InfoRow\",\"label\":\"Region\",\"value\":\"North America\"},{\"id\":\"fact3\",\"component\":\"InfoRow\",\"label\":\"ARR\",\"value\":\"$612k\"},{\"id\":\"fact4\",\"component\":\"InfoRow\",\"label\":\"Renewal date\",\"value\":\"Sep 30\"},{\"id\":\"fact5\",\"component\":\"InfoRow\",\"label\":\"Last contact\",\"value\":\"3 days ago\"},{\"id\":\"fact6\",\"component\":\"InfoRow\",\"label\":\"Health\",\"value\":\"Green\"},{\"id\":\"fact7\",\"component\":\"InfoRow\",\"label\":\"Open opportunities\",\"value\":\"4 opportunities worth $210k\"},{\"id\":\"revenue-pie\",\"component\":\"PieChart\",\"title\":\"Revenue by product line\",\"description\":\"Meridian Apparel Group revenue mix across product lines.\",\"data\":[{\"label\":\"Outerwear\",\"value\":260000},{\"label\":\"Footwear\",\"value\":180000},{\"label\":\"Accessories\",\"value\":112000},{\"label\":\"Custom\",\"value\":60000}]}]}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill top-account — outer agent narration after generate_a2ui returns.",
+   "match": {
+    "context": "pydantic-ai",
+    "toolCallId": "call_d6_decl_acct_outer_001"
+   },
+   "response": {
+    "content": "Here's the rundown on Meridian Apparel Group."
+   },
+   "chunkSize": 9999
+  },
+  {
+   "_comment": "pill top-account — outer agent emits generate_a2ui (no args).",
+   "match": {
+    "userMessage": "Pull up the details on our biggest account.",
+    "context": "pydantic-ai"
+   },
+   "response": {
+    "toolCalls": [
+     {
+      "id": "call_d6_decl_acct_outer_001",
+      "name": "generate_a2ui",
+      "arguments": "{}"
+     }
+    ]
+   },
+   "chunkSize": 9999
+  }
+ ]
 }


### PR DESCRIPTION
## Summary
Corrects the `pydantic-ai` `gen-ui-declarative` aimock fixture. PR #5661 merged it mis-templated from `ms-agent-dotnet`: the inner secondary-LLM blocks gated on `_design_a2ui_surface` (ms-agent's tool) instead of pydantic-ai's actual **`render_a2ui`**, and only **1 of the 4** declarative pills was covered (the rest were dead KPI/pie/bar/status blocks that match no real pill). So the cell still 503'd.

Re-authored 1:1 from the canonical `langgraph-python` fixture: inner tool **`render_a2ui`**, all **4 pills** (sales-dashboard, rep-vs-quota, at-risk, biggest-account) as outer `generate_a2ui` + inner `render_a2ui` + tool-result triplets, `context: "pydantic-ai"`. Dead blocks removed.

## Effect (real-surface proven via `bin/showcase test pydantic-ai:declarative-gen-ui --d6 --direct`)
- `no_fixture_match` 503 count **6 → 0** — the 503 is fully gone.
- **Necessary, not sufficient:** the cell still can't paint (advances 503 → `surface-missing`) due to **separate pydantic-ai integration gaps** — missing `DataTable` renderer, `InfoRow` lacking the `declarative-info-row` testid, and the `injectA2UITool: false` A2UI delivery path. Filed as a follow-up (Slack `#` showcase alerts); out of scope here.
- No-regression: `multimodal` cell still green; fixture-only change (+187/-336, one file).

## Test plan
- [x] Real-surface red-green: `no_fixture_match` 6 → 0
- [x] Schema valid (`validateFixtures` 0 issues), no fixture shadowing (zero delta)
- [x] Inner `render_a2ui` arguments byte-identical to canonical langgraph-python
- [ ] CI green