### PR TITLE
fix(showcase/shell-dojo): runtime-derive preview backend URL

### DIFF
--- a/showcase/scripts/__tests__/dojo-backend-url-drift.test.ts
+++ b/showcase/scripts/__tests__/dojo-backend-url-drift.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// shell-dojo's src/lib/backend-url.ts is a VERBATIM copy of the shell's
+// (scripts cannot be imported across the two Next apps, and lifting it
+// to a shared importable package was the larger-blast-radius option).
+// The copy's only failure mode is drift — these guards make drift a CI
+// failure instead of a silent staging→prod leakage. The behavior itself
+// is covered by shell/src/lib/backend-url.test.ts; here we only assert
+// the two files (and the script-side default) stay in lockstep.
+
+const SHELL_BACKEND_URL = resolve(
+  __dirname,
+  "..",
+  "..",
+  "shell",
+  "src",
+  "lib",
+  "backend-url.ts",
+);
+const DOJO_BACKEND_URL = resolve(
+  __dirname,
+  "..",
+  "..",
+  "shell-dojo",
+  "src",
+  "lib",
+  "backend-url.ts",
+);
+const GENERATE_REGISTRY = resolve(__dirname, "..", "generate-registry.ts");
+
+function defaultPatternIn(source: string): string {
+  const match = source.match(
+    /DEFAULT_BACKEND_HOST_PATTERN\s*=\s*\n?\s*"([^"]+)"/,
+  );
+  if (!match) {
+    throw new Error("DEFAULT_BACKEND_HOST_PATTERN literal not found");
+  }
+  return match[1];
+}
+
+describe("shell-dojo backend-url drift guard", () => {
+  it("shell-dojo/backend-url.ts is byte-identical to shell/backend-url.ts", () => {
+    const shell = readFileSync(SHELL_BACKEND_URL, "utf8");
+    const dojo = readFileSync(DOJO_BACKEND_URL, "utf8");
+    // If this fails, re-copy shell/src/lib/backend-url.ts over
+    // shell-dojo/src/lib/backend-url.ts (do NOT diverge them — port any
+    // intended change to the shell first, then re-copy).
+    expect(dojo).toBe(shell);
+  });
+
+  it("the default host pattern matches between backend-url.ts and generate-registry.ts", () => {
+    // backend-url.ts (runtime consumer) and generate-registry.ts
+    // (build-time synthesizer) consume the same SHOWCASE_BACKEND_HOST_PATTERN
+    // env var and MUST agree on the unset-default, or an unset deploy
+    // would bake one host yet derive another at runtime.
+    const runtimeDefault = defaultPatternIn(
+      readFileSync(SHELL_BACKEND_URL, "utf8"),
+    );
+    const scriptDefault = defaultPatternIn(
+      readFileSync(GENERATE_REGISTRY, "utf8"),
+    );
+    expect(runtimeDefault).toBe(scriptDefault);
+    expect(runtimeDefault).toBe("showcase-{slug}-production.up.railway.app");
+  });
+});

--- a/showcase/shell-dojo/src/app/layout.tsx
+++ b/showcase/shell-dojo/src/app/layout.tsx
@@ -42,8 +42,9 @@ export default function RootLayout({
   // Server-side: read live env at request time. `unstable_noStore()`
   // inside getRuntimeConfig opts this segment out of the static cache
   // so the inline <script> below always reflects the current Railway
-  // env vars. shell-dojo's RuntimeConfig is empty today; the
-  // injection stays for pattern symmetry across all four shells.
+  // env vars. The serialized config carries backendHostPattern, which
+  // the client reader uses to derive each integration's preview backend
+  // URL at request time (see lib/runtime-config.ts).
   const runtimeConfig = getRuntimeConfig();
   const injection = `window.__SHOWCASE_CONFIG__=${serializeRuntimeConfig(runtimeConfig)};`;
 

--- a/showcase/shell-dojo/src/app/page.tsx
+++ b/showcase/shell-dojo/src/app/page.tsx
@@ -8,6 +8,8 @@ import {
 } from "@/lib/registry";
 import type { Integration, Demo, FeatureCategory } from "@/lib/registry";
 import { CodeBlock } from "@/components/code-block";
+import { resolveBackendUrl } from "@/lib/backend-url";
+import { getRuntimeConfig } from "@/lib/runtime-config.client";
 import demoContentData from "@/data/demo-content.json";
 
 type ViewMode = "preview" | "code";
@@ -160,6 +162,18 @@ export default function DojoPage() {
   const [codeViewMode, setCodeViewMode] = useState<"core" | "all">("core");
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
+  // Client-readiness gate for the preview iframe. The registry loads
+  // synchronously (getIntegrations() above), so `integration` is
+  // populated on the very first render — including SSR and the
+  // hydration render. The runtime backend host pattern, however, only
+  // exists post-hydration (the client reader returns an
+  // `.ssr-placeholder.invalid` sentinel until window.__SHOWCASE_CONFIG__
+  // is readable). Gating previewUrl on `mounted` ensures we never render
+  // the iframe with the sentinel host — which would fire a real request
+  // at a `.invalid` domain and flash before the real URL swaps in.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
   const integration = useMemo(
     () => integrations.find((i) => i.slug === selectedSlug),
     [integrations, selectedSlug],
@@ -284,9 +298,18 @@ export default function DojoPage() {
     window.history.replaceState(null, "", `${window.location.pathname}${next}`);
   }, [integrations, selectedSlug, selectedDemoId]);
 
+  // Derive the preview backend at REQUEST time from the runtime host
+  // pattern — never the registry's `backend_url`, which is baked at
+  // Docker build and froze prod hostnames into every image (so the
+  // staging dojo iframed prod integrations). Gated on `mounted` so the
+  // SSR-phase sentinel pattern never reaches an iframe src (see the
+  // `mounted` declaration above and lib/runtime-config.client.ts).
   const previewUrl =
-    integration && selectedDemo
-      ? `${integration.backend_url}${selectedDemo.route}`
+    mounted && integration && selectedDemo
+      ? `${resolveBackendUrl(
+          integration.slug,
+          getRuntimeConfig().backendHostPattern,
+        )}${selectedDemo.route}`
       : null;
 
   return (

--- a/showcase/shell-dojo/src/lib/backend-url.ts
+++ b/showcase/shell-dojo/src/lib/backend-url.ts
@@ -1,0 +1,484 @@
+// Runtime derivation of integration backend URLs.
+//
+// The registry's `backend_url` is synthesized at Docker BUILD time by
+// scripts/generate-registry.ts, which bakes the production hostnames
+// into every image — so a staging shell iframed prod integrations.
+// These helpers derive the backend host at REQUEST time from the
+// `backendHostPattern` carried in RuntimeConfig (env var
+// SHOWCASE_BACKEND_HOST_PATTERN, default = the prod pattern), keeping
+// registry.json as the source for non-URL metadata only.
+//
+// Pattern semantics are IDENTICAL to generate-registry.ts: the pattern
+// is a bare host with `{slug}` as the only placeholder, and `https://`
+// is prepended. Keep the two in sync — they consume the same env var.
+//
+// This module is import-safe from client components, server components,
+// and middleware (pure functions, no next/* imports).
+
+// Matches an explicit URL scheme prefix (e.g. `https://`, `http://`).
+// Exported as the single source of truth — runtime-config.ts shares it
+// (this module is import-safe everywhere, so the dependency is free).
+export const SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+// Default backend host pattern — reproduces today's baked prod values
+// exactly, so a deploy with the env var unset (i.e. current prod)
+// behaves byte-identically. Lives HERE (not runtime-config.ts, which
+// re-exports it) because normalizeBackendHostPattern falls back to it
+// for degenerate values and runtime-config already imports this module
+// — defining it there would create an import cycle.
+export const DEFAULT_BACKEND_HOST_PATTERN =
+  "showcase-{slug}-production.up.railway.app";
+
+// Warn once per distinct (pattern, issue) — config is re-read every
+// request, and per-request warn spam would drown real signal.
+const patternWarnings = new Set<string>();
+
+function warnPatternOnce(key: string, message: string): void {
+  if (patternWarnings.has(key)) return;
+  patternWarnings.add(key);
+  // eslint-disable-next-line no-console
+  console.warn(`[backend-url] SHOWCASE_BACKEND_HOST_PATTERN ${message}`);
+}
+
+// FATAL once per distinct degenerate pattern value — parity with the
+// FATAL-CONFIG once-guards in runtime-config.ts (readUrl/readDocsHost).
+const patternFatals = new Set<string>();
+
+// Same dev-vs-prod branch as validateBaseUrl/readDocsHost
+// (runtime-config.ts): in production this is a FATAL-CONFIG error with
+// Railway guidance; in dev it degrades to a warn — Railway guidance is
+// useless on a laptop, and the dev contract is frictionless iteration.
+// NODE_ENV is read at CALL time (this module is import-safe everywhere;
+// Next statically inlines the literal read in client bundles).
+function fatalPatternOnce(key: string, message: string): void {
+  if (patternFatals.has(key)) return;
+  patternFatals.add(key);
+  if (process.env.NODE_ENV === "production") {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[backend-url] FATAL-CONFIG: SHOWCASE_BACKEND_HOST_PATTERN ${message} ` +
+        `Fix the SHOWCASE_BACKEND_HOST_PATTERN env var on the Railway service.`,
+    );
+  } else {
+    // eslint-disable-next-line no-console
+    console.warn(`[backend-url] SHOWCASE_BACKEND_HOST_PATTERN ${message}`);
+  }
+}
+
+/**
+ * Can the normalized pattern actually form a backend URL? Probe by
+ * substituting a registry-shaped slug and parsing the consumer's exact
+ * composition (`https://` + pattern). Catches the degenerate classes
+ * the per-issue normalizations can't fix: empty results ("https://" or
+ * "/" normalize to ""), internal whitespace, and anything else
+ * `new URL` rejects or that parses without a real host.
+ *
+ * Returns `undefined` when usable, otherwise a reason discriminant so
+ * the FATAL can be honest: a probe whose HOST is literally
+ * "http"/"https" (e.g. `https:/host` — one slash short, so SCHEME_RE
+ * never strips it) DOES parse — calling it "unparseable" would hide
+ * the actual problem (a stray scheme fragment in host position).
+ */
+function patternUsabilityProblem(
+  normalized: string,
+): "unparseable" | "stray-scheme-fragment" | undefined {
+  if (normalized.length === 0) return "unparseable";
+  try {
+    const probe = new URL(
+      `https://${normalized.replaceAll("{slug}", "probe")}`,
+    );
+    if (probe.hostname.length === 0) return "unparseable";
+    if (/^https?$/i.test(probe.hostname)) return "stray-scheme-fragment";
+    return undefined;
+  } catch {
+    return "unparseable";
+  }
+}
+
+/**
+ * Does the pattern carry a component no backend base URL may have?
+ * Detected on the LITERAL delimiter characters (see inline comments —
+ * the WHATWG getters return "" for present-but-empty components, so a
+ * probe-based check leaks bare `?`/`#`/`@`).
+ * Returns a human-readable component name for the FATAL log, or
+ * undefined when the pattern is clean. Three rejected classes (same
+ * gates validateBaseUrl has in runtime-config.ts):
+ *
+ * - userinfo credentials: a credentialed pattern yields iframe srcs
+ *   that Chromium silently blocks — the integration pane just never
+ *   loads, with zero signal;
+ * - query / fragment: consumers concatenate demo routes onto the
+ *   composed URL, so `https://host?x=1` + `/route` yields
+ *   `https://host?x=1/route` — every backend URL ships corrupted.
+ */
+function patternForbiddenComponent(normalized: string): string | undefined {
+  // Query/fragment are detected on the LITERAL characters, not the
+  // probe getters: WHATWG getters return "" for a present-but-EMPTY
+  // component (`https://host?` has search === ""), so a bare trailing
+  // `?`/`#` would slip a getter check while the raw character still
+  // ships in the pattern — and route concatenation then swallows every
+  // demo route into the query/fragment. The literal check is strictly
+  // stronger than the getter check (a non-empty search/hash implies the
+  // literal character), so the getters aren't consulted at all. Which
+  // component a literal introduces follows URL precedence: `#` starts
+  // the fragment; `?` starts a query only when no `#` precedes it.
+  const hashAt = normalized.indexOf("#");
+  const queryAt = normalized.indexOf("?");
+  if (queryAt !== -1 && (hashAt === -1 || queryAt < hashAt)) {
+    return "a query component";
+  }
+  if (hashAt !== -1) return "a fragment component";
+  // Userinfo is a literal check too: `https://@host` and
+  // `https://:@host` parse with username === "" AND password === ""
+  // (present-but-EMPTY userinfo), so the getter check let the raw
+  // `@`-bearing string ship. Any `@` in the AUTHORITY (the part before
+  // the first `/` — query/fragment are already rejected above) is a
+  // userinfo delimiter; it is never valid inside a hostname.
+  const slashAt = normalized.indexOf("/");
+  const authority = slashAt === -1 ? normalized : normalized.slice(0, slashAt);
+  if (authority.includes("@")) return "userinfo credentials";
+  return undefined;
+}
+
+/**
+ * Normalize a backend host pattern read from the environment. The
+ * pattern contract (same as scripts/generate-registry.ts) is a bare
+ * host with `{slug}` as the only placeholder — but env misconfigs are
+ * easy and were previously silent:
+ *
+ * - a scheme-bearing value would yield `https://https://…` (consumer
+ *   prepends the scheme) → strip it and warn;
+ * - a trailing slash would yield `host//route` on concat → trim and warn;
+ * - a missing `{slug}` placeholder silently sends EVERY integration to
+ *   the same host → warn (can't fix it for the operator).
+ *
+ * Warnings fire once per distinct value, not per request.
+ */
+export function normalizeBackendHostPattern(pattern: string): string {
+  let normalized = pattern;
+  if (/\s/.test(normalized)) {
+    // Whitespace was the ONE misconfig class with zero warning — a
+    // pasted ` host` yields an iframe src like `https:// host`. Trim
+    // the ends (fixable) and strip internal tab/CR/LF (the WHATWG URL
+    // parser deletes \t\r\n pre-parse, so a tab-bearing pattern would
+    // pass the usability gate while the RAW control character shipped
+    // in every iframe src — stripping matches what the parser does
+    // anyway). Internal SPACES split by position: a host-position
+    // space makes the pattern unparseable, so the usability gate below
+    // falls back to the DEFAULT (it never ships); a path-position
+    // space parses and genuinely ships broken.
+    warnPatternOnce(
+      `whitespace:${pattern}`,
+      `"${pattern}" contains whitespace — trimming the ends and stripping internal tab/CR/LF (the URL parser ignores them anyway). An internal space in the host cannot form a usable pattern (falls back to the default); a space in a path segment ships in every backend URL.`,
+    );
+    normalized = normalized.replace(/[\t\r\n]/g, "").trim();
+  }
+  // Loop the strip to convergence: a single pass left "https://https://
+  // host" with a scheme that the consumer then double-prepends. Collect
+  // every stripped scheme first so the once-guarded warn can name them
+  // ALL — warning inside the loop swallowed every name after the first.
+  const strippedSchemes: string[] = [];
+  for (
+    let scheme = SCHEME_RE.exec(normalized);
+    scheme;
+    scheme = SCHEME_RE.exec(normalized)
+  ) {
+    strippedSchemes.push(scheme[0]);
+    normalized = normalized.slice(scheme[0].length);
+  }
+  if (strippedSchemes.length > 0) {
+    warnPatternOnce(
+      `scheme:${pattern}`,
+      `"${pattern}" includes a scheme — the consumer prepends https://; stripping ${strippedSchemes
+        .map((s) => `"${s}"`)
+        .join(", ")}.`,
+    );
+  }
+  if (/\/+$/.test(normalized)) {
+    warnPatternOnce(
+      `trailing-slash:${pattern}`,
+      `"${pattern}" has a trailing slash — route concatenation would yield "//"; trimming.`,
+    );
+    normalized = normalized.replace(/\/+$/, "");
+  }
+  // Usability gate AFTER the fixable normalizations, BEFORE the
+  // advisory warns ({slug}/path) — a degenerate value ("https://", "/",
+  // whitespace) normalizes to "" or an unparseable host, and previously
+  // flowed out with NO fallback: server-side iframe srcs became
+  // "https://", and the injected "" failed the client reader's
+  // REQUIRED_CONFIG_FIELDS check, crashing every client component with
+  // a message blaming the layout injection instead of this env var.
+  //
+  // DESIGN DECISION — degenerate/forbidden patterns fail OPEN to
+  // DEFAULT_BACKEND_HOST_PATTERN, which is the PROD host pattern. On a
+  // staging deploy, a mistyped SHOWCASE_BACKEND_HOST_PATTERN therefore
+  // silently (FATAL log aside) iframes PROD integrations — the exact
+  // staging→prod leakage this module exists to prevent. The
+  // alternative (fail CLOSED: ship "" and break every integration
+  // pane) was rejected because a hard outage is worse than serving
+  // prod content with a FATAL-CONFIG log; revisit if staging/prod
+  // divergence ever becomes load-bearing for correctness.
+  const forbidden = patternForbiddenComponent(normalized);
+  if (forbidden !== undefined) {
+    fatalPatternOnce(
+      `forbidden:${forbidden}:${pattern}`,
+      `${JSON.stringify(pattern)} carries ${forbidden} — userinfo makes ` +
+        `Chromium silently block every iframe src formed from it, and a ` +
+        `query/fragment corrupts every backend URL when consumers ` +
+        `concatenate demo routes; falling back to the default pattern ` +
+        `${DEFAULT_BACKEND_HOST_PATTERN}.`,
+    );
+    return DEFAULT_BACKEND_HOST_PATTERN;
+  }
+  // Fails OPEN to the prod pattern too — see the DESIGN DECISION note
+  // above the forbidden-component gate.
+  const usabilityProblem = patternUsabilityProblem(normalized);
+  if (usabilityProblem !== undefined) {
+    fatalPatternOnce(
+      `degenerate:${pattern}`,
+      usabilityProblem === "stray-scheme-fragment"
+        ? `${JSON.stringify(pattern)} normalizes to ` +
+            `${JSON.stringify(normalized)}, whose host is literally ` +
+            `"http"/"https" — it looks like a stray scheme fragment, not ` +
+            `a backend host; falling back to the default pattern ` +
+            `${DEFAULT_BACKEND_HOST_PATTERN}.`
+        : `${JSON.stringify(pattern)} normalizes to ` +
+            `${JSON.stringify(normalized)}, which cannot form a parseable ` +
+            `backend URL; falling back to the default pattern ` +
+            `${DEFAULT_BACKEND_HOST_PATTERN}.`,
+    );
+    return DEFAULT_BACKEND_HOST_PATTERN;
+  }
+  // Canonicalize the authority for parity with the override path,
+  // which returns the parsed-normalized form (lowercase host, default
+  // port elided) — the pattern path ships this string RAW into iframe
+  // srcs, leaking uppercase hosts and an explicit :443. Hosts are
+  // case-insensitive and the consumer always prepends https://, so
+  // lowercasing the authority and stripping a trailing :443 (the https
+  // default — :80 is a REAL port under https and must survive) matches
+  // what the URL parser does to the composed URL anyway. The path part
+  // (from the first "/") is case-SENSITIVE and stays untouched; the
+  // lowercase {slug} placeholder survives lowercasing verbatim.
+  const pathAt = normalized.indexOf("/");
+  const authority = pathAt === -1 ? normalized : normalized.slice(0, pathAt);
+  const pathPart = pathAt === -1 ? "" : normalized.slice(pathAt);
+  normalized = authority.toLowerCase().replace(/:443$/, "") + pathPart;
+  if (!normalized.includes("{slug}")) {
+    warnPatternOnce(
+      `no-slug:${pattern}`,
+      `"${pattern}" lacks the {slug} placeholder — EVERY integration will resolve to the same backend host.`,
+    );
+  }
+  if (normalized.includes("/")) {
+    // The documented contract is a BARE host — an internal path segment
+    // (`host.app/base/{slug}`) violates it silently: the consumer
+    // prepends https:// and concatenates routes, so the base path lands
+    // in every backend URL. Can't fix it for the operator (the intent
+    // is ambiguous) — flag it.
+    warnPatternOnce(
+      `path:${pattern}`,
+      `"${pattern}" contains a path segment — the contract is a bare host; the path will be embedded in every backend URL.`,
+    );
+  }
+  return normalized;
+}
+
+// Registry slug contract — see scripts/generate-registry.ts manifests.
+const SLUG_RE = /^[a-z0-9-]+$/;
+
+/** Substitute `{slug}` into the host pattern and prepend `https://`. */
+export function backendUrlFromPattern(pattern: string, slug: string): string {
+  // Charset assert at the choke point: every backend URL flows through
+  // here and the slug lands in the HOST of an iframe src — a slug
+  // containing "." or "/" is host/path injection. All registry slugs
+  // match [a-z0-9-]+; anything else is a contract violation upstream
+  // (call sites resolve slugs from the registry), not data.
+  if (!SLUG_RE.test(slug)) {
+    throw new Error(
+      `[backend-url] invalid integration slug ${JSON.stringify(slug)} — ` +
+        `slugs must match ${String(SLUG_RE)} (host-injection guard).`,
+    );
+  }
+  // Function replacer: a plain string replacement is subject to `$`
+  // substitution patterns ("$&", "$'", ...), which would corrupt the
+  // host for any slug containing `$` (defense in depth behind SLUG_RE).
+  return `https://${pattern.replaceAll("{slug}", () => slug)}`;
+}
+
+// Warn once per distinct (raw value, issue) — resolveBackendUrl runs on
+// every render, so per-call warns would spam exactly like the pattern
+// warnings the patternWarnings set above exists to prevent.
+const localBackendsWarnings = new Set<string>();
+
+function warnLocalBackendsOnce(key: string, message: string): void {
+  if (localBackendsWarnings.has(key)) return;
+  localBackendsWarnings.add(key);
+  // eslint-disable-next-line no-console
+  console.warn(`[backend-url] NEXT_PUBLIC_LOCAL_BACKENDS ${message}`);
+}
+
+// Shared frozen empty map for the unset path — a fresh mutable {} per
+// call would dodge the freeze guarantee below.
+const NO_LOCAL_BACKENDS: Record<string, string> = Object.freeze({});
+
+// Memoized on the raw string: the env value is baked at build time and
+// effectively constant, so re-running JSON.parse on every render is
+// pure waste.
+let lastLocalBackendsRaw: string | undefined;
+let lastLocalBackends: Record<string, string> = NO_LOCAL_BACKENDS;
+
+/**
+ * Parse the NEXT_PUBLIC_LOCAL_BACKENDS map (baked at build from
+ * shared/local-ports.json — local-dev only, empty in deployed images).
+ * Tolerant of unset/empty/corrupt values: local dev convenience must
+ * never break rendering. The parse is memoized on the raw string and
+ * warnings fire once per distinct (value, issue), not per call.
+ *
+ * The returned object is FROZEN: the memo is shared across every
+ * caller, so a consumer mutating its "own" map would change the
+ * local-backend overrides process-wide.
+ */
+export function parseLocalBackends(
+  raw: string | undefined,
+): Record<string, string> {
+  if (!raw) return NO_LOCAL_BACKENDS;
+  if (raw !== lastLocalBackendsRaw) {
+    // Compute FIRST, then commit key and value together: committing
+    // the key before the value meant a throw mid-compute (console.warn
+    // is a foreign call — a logging shim CAN throw) left the memo
+    // poisoned, and the next call with the same raw returned the
+    // PREVIOUS raw's value.
+    const backends = Object.freeze(parseLocalBackendsUncached(raw));
+    lastLocalBackendsRaw = raw;
+    lastLocalBackends = backends;
+  }
+  return lastLocalBackends;
+}
+
+function parseLocalBackendsUncached(raw: string): Record<string, string> {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      // Validate values instead of an unchecked `as Record<string,
+      // string>` flow-through — a non-string value would otherwise
+      // surface much later as a garbage iframe src.
+      //
+      // Null-prototype accumulator: on a plain `{}`, assigning a
+      // "__proto__" key hits the Object.prototype setter and is a
+      // silent no-op — the entry would vanish with no warning (every
+      // other rejected entry warns). With no prototype it lands as an
+      // ordinary own data property.
+      const backends: Record<string, string> = Object.create(null);
+      for (const [slug, url] of Object.entries(parsed)) {
+        if (typeof url === "string") {
+          backends[slug] = url;
+        } else {
+          warnLocalBackendsOnce(
+            `non-string:${slug}:${raw}`,
+            `value for "${slug}" is not a string — skipping it.`,
+          );
+        }
+      }
+      return backends;
+    }
+    warnLocalBackendsOnce(
+      `non-object:${raw}`,
+      "is not a JSON object — ignoring it.",
+    );
+  } catch {
+    // Treat unparseable as unset (local-dev convenience must never
+    // break rendering) — but say so, instead of silently eating it.
+    warnLocalBackendsOnce(
+      `invalid-json:${raw}`,
+      "is not valid JSON — ignoring it.",
+    );
+  }
+  return {};
+}
+
+/**
+ * Resolve an integration's backend base URL: a local-dev override from
+ * NEXT_PUBLIC_LOCAL_BACKENDS wins (preserving the pre-existing
+ * `SHOWCASE_LOCAL=1` behavior), otherwise derive from the runtime host
+ * pattern.
+ */
+export function resolveBackendUrl(slug: string, pattern: string): string {
+  // ASSUMPTION: the server must never SET NEXT_PUBLIC_LOCAL_BACKENDS at
+  // runtime post-build — the client bundle bakes the build-time value,
+  // so a live server-side value would silently diverge from what client
+  // components resolve.
+  const local = parseLocalBackends(process.env.NEXT_PUBLIC_LOCAL_BACKENDS);
+  const rawOverride = local[slug];
+  if (rawOverride !== undefined) {
+    // Trim before validating — the same paste-artifact tolerance the
+    // pattern path applies (normalizeBackendHostPattern trims the
+    // ends): a leading-space override otherwise fails the SCHEME_RE
+    // anchor even though the URL parser accepts the value.
+    const override = rawOverride.trim();
+    // Length-aware: an empty/whitespace-only override (e.g.
+    // `{"mastra": ""}`) is not a usable URL — `??` would accept it and
+    // yield an empty base. The emptiness check lives INSIDE the
+    // override block so it warns like every other bad override:
+    // skipping it in the outer condition ignored the dead override
+    // with zero signal.
+    if (override.length === 0) {
+      warnLocalBackendsOnce(
+        `bad-override:${slug}:empty`,
+        `override for "${slug}" is empty (or whitespace-only) — ignoring it.`,
+      );
+      return backendUrlFromPattern(pattern, slug);
+    }
+    // The override lands verbatim in an iframe src — require a
+    // scheme-bearing, parseable URL (`localhost:4111` without a scheme
+    // parses as scheme "localhost:"!) whose protocol is http(s):
+    // `javascript://...` and `ftp://...` are scheme-bearing AND
+    // parseable, but have no business in an iframe src. Userinfo,
+    // query, and fragment components are rejected too (same gates the
+    // pattern path has): Chromium silently blocks credentialed iframe
+    // srcs, and a query/fragment corrupts every composed URL when
+    // consumers concatenate demo routes. Warn and fall back otherwise.
+    const parsed = parseUrl(override);
+    if (
+      parsed !== undefined &&
+      SCHEME_RE.test(override) &&
+      /^https?:$/i.test(parsed.protocol) &&
+      parsed.username === "" &&
+      parsed.password === "" &&
+      parsed.search === "" &&
+      parsed.hash === ""
+    ) {
+      // Return the parsed-normalized form (origin + path), not the raw
+      // string: the parse already happened, and the raw form leaks
+      // un-normalized values (uppercase hosts, explicit default ports)
+      // into iframe srcs. The trailing-slash trim matches the
+      // normalization the pattern path guarantees
+      // (normalizeBackendHostPattern) — an override skipping it yields
+      // `host//route` when consumers concatenate demo routes. Query,
+      // fragment, and userinfo are empty here (gated above), so
+      // origin + pathname IS the whole URL.
+      return (parsed.origin + parsed.pathname).replace(/\/+$/, "");
+    }
+    // Name the actual requirements instead of "not parseable":
+    // `http:localhost:4111` IS parseable (special schemes tolerate
+    // missing slashes), but it fails the explicit `scheme://`
+    // requirement — a "not parseable" claim sends the developer
+    // chasing a parse problem that doesn't exist.
+    warnLocalBackendsOnce(
+      `bad-override:${slug}:${override}`,
+      `override for "${slug}" (${JSON.stringify(override)}) must be an ` +
+        `http(s) URL with an explicit "scheme://" and no userinfo, query, ` +
+        `or fragment — ignoring it.`,
+    );
+  }
+  return backendUrlFromPattern(pattern, slug);
+}
+
+function parseUrl(value: string): URL | undefined {
+  // URL.canParse needs Node 18.17+/modern browsers — try/catch keeps
+  // this safe on every runtime the shell targets.
+  try {
+    return new URL(value);
+  } catch {
+    return undefined;
+  }
+}

--- a/showcase/shell-dojo/src/lib/runtime-config.client.ts
+++ b/showcase/shell-dojo/src/lib/runtime-config.client.ts
@@ -3,11 +3,6 @@
 // inline <script> tag BEFORE React hydrates (see app/layout.tsx). This
 // is the ONLY public API for these URLs in client code — never read
 // process.env.NEXT_PUBLIC_* directly (an ESLint rule enforces this).
-//
-// shell-dojo's `RuntimeConfig` is intentionally empty today (no URL
-// consumers); the module exists to keep the pattern symmetric across
-// shells. When a URL is added on the server side, this reader picks it
-// up via the shared interface.
 
 import type { RuntimeConfig } from "./runtime-config";
 
@@ -24,30 +19,34 @@ declare global {
  * components in the Next.js App Router are server-side rendered on the
  * initial request (that's how the HTML is streamed before hydration),
  * which means their function bodies execute on the server too. We can't
- * throw here without breaking SSR — instead we return a placeholder, and
- * post-hydration the next render reads the real values out of
- * window.__SHOWCASE_CONFIG__. Server components that need the live env
- * values MUST import getRuntimeConfig from runtime-config.ts (the server
- * variant), not this file.
+ * throw here without breaking SSR — instead we return a placeholder.
  *
- * shell-dojo's RuntimeConfig is currently `{}` — the placeholder is the
- * empty object that matches the interface.
+ * The {slug} placeholder is preserved so an SSR-phase substitution still
+ * yields a parseable, RFC-2606-unresolvable host (`.invalid`). No iframe
+ * ever renders from this: the page gates its preview iframe on a
+ * client-mounted flag, so backendHostPattern is only ever read after
+ * hydration when window.__SHOWCASE_CONFIG__ carries the real value.
+ * Server components that need the live env values MUST import
+ * getRuntimeConfig from runtime-config.ts (the server variant).
  */
-const SSR_PLACEHOLDER: RuntimeConfig = {};
+const SSR_PLACEHOLDER: Readonly<RuntimeConfig> = Object.freeze({
+  backendHostPattern: "showcase-{slug}.ssr-placeholder.invalid",
+});
 
 /**
  * Returns the runtime config injected by the root server layout.
  *
- * During SSR (no window) returns a sentinel placeholder; client code
- * re-reads after hydration and gets the real values. If the inline
- * <script> never runs (a route bypassed the layout, or injection ran
- * with empty inputs), the post-hydration read throws — surfacing the
- * wiring bug loudly rather than silently rendering empty URLs.
+ * During SSR (no window) returns a sentinel placeholder; the inline
+ * <script> runs before hydration, so every client render — including
+ * the hydration render — sees the real values. If the inline <script>
+ * never ran (a route bypassed the layout) or injected an
+ * empty/incomplete object, this read throws — surfacing the wiring bug
+ * loudly rather than silently rendering empty URLs.
  */
-export function getRuntimeConfig(): RuntimeConfig {
+export function getRuntimeConfig(): Readonly<RuntimeConfig> {
   if (typeof window === "undefined") {
     // SSR phase — "use client" component bodies execute here too.
-    // Return placeholder; hydration will re-render with real values.
+    // Return placeholder; the hydration render reads the real values.
     return SSR_PLACEHOLDER;
   }
   const cfg = window.__SHOWCASE_CONFIG__;
@@ -61,5 +60,21 @@ export function getRuntimeConfig(): RuntimeConfig {
         "The root layout must inject runtime config before client mount.",
     );
   }
-  return cfg;
+  // Field validation: an injection that ran with empty inputs (layout
+  // wired to a broken server read) yields an object that is truthy but
+  // useless — fail loud instead of resolving every preview iframe
+  // against an empty pattern. The typeof check also catches a layout
+  // bug injecting a non-string, which would otherwise explode far from
+  // the cause inside backendUrlFromPattern's replaceAll.
+  const value = cfg.backendHostPattern;
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(
+      `[runtime-config.client] window.__SHOWCASE_CONFIG__ is incomplete: ` +
+        `field "backendHostPattern" is ${
+          typeof value === "string" ? "empty" : `of type ${typeof value}`
+        }. The root layout injection ran with broken inputs — check the ` +
+        `server-side runtime config.`,
+    );
+  }
+  return Object.freeze(cfg);
 }

--- a/showcase/shell-dojo/src/lib/runtime-config.ts
+++ b/showcase/shell-dojo/src/lib/runtime-config.ts
@@ -12,35 +12,79 @@
 // This module MUST NOT be imported from client components. The matching
 // client-side reader lives in runtime-config.client.ts and reads from
 // window.__SHOWCASE_CONFIG__ which the root layout injects.
-//
-// shell-dojo today has no URL consumers (zero process.env.NEXT_PUBLIC_*
-// reads in this shell). The `RuntimeConfig` interface is intentionally
-// an empty object literal — it exists to keep the runtime-config /
-// layout-injection pattern symmetric across the shells. Adding a URL
-// later means adding a field here, reading it from process.env via
-// `readUrl`, and the client-side reader picks it up automatically
-// through the shared interface.
 
 import { unstable_noStore as noStore } from "next/cache";
+import {
+  DEFAULT_BACKEND_HOST_PATTERN,
+  normalizeBackendHostPattern,
+} from "./backend-url";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface RuntimeConfig {}
+export interface RuntimeConfig {
+  /**
+   * Backend host pattern — `{slug}` is the only placeholder. Used to
+   * derive each integration's preview-iframe backend URL at request
+   * time instead of trusting the registry's `backend_url`, which is
+   * baked at Docker build (freezing prod hostnames into every image, so
+   * the staging dojo iframed prod integrations). Same semantics as
+   * SHOWCASE_BACKEND_HOST_PATTERN in scripts/generate-registry.ts and
+   * the shell's runtime config: host only, `https://` is prepended by
+   * the consumer (see lib/backend-url.ts).
+   */
+  backendHostPattern: string;
+}
 
 /**
- * Resolve the runtime config for shell-dojo. Called once per request
- * by the root layout. Currently returns an empty object since
- * shell-dojo has no URL-dependent consumers; the module exists to keep
- * the pattern symmetric across shells (see shell-dashboard's
- * runtime-config.ts for the full template).
+ * Resolve the runtime config for shell-dojo. Called once per request by
+ * the root layout, which injects the result into
+ * window.__SHOWCASE_CONFIG__ for the client reader.
  *
  * `opts.noStore` (default `true`) controls whether to call
- * `unstable_noStore()`. The Node.js server runtime needs the opt-out
- * so Next.js does not statically prerender callers and freeze any
- * future URL values into the build artifact.
+ * `unstable_noStore()`. The Node.js server runtime needs the opt-out so
+ * Next.js does not statically prerender callers and freeze the URL
+ * values into the build artifact.
  */
 export function getRuntimeConfig(
   opts: { noStore?: boolean } = {},
 ): RuntimeConfig {
   if (opts.noStore !== false) noStore();
-  return {};
+
+  // backendHostPattern is a host *pattern*, not a URL — `{slug}` must
+  // survive untouched. It IS normalized against common env misconfigs
+  // (leading scheme, trailing slash, missing `{slug}`) with warn-once
+  // guards — see normalizeBackendHostPattern in lib/backend-url.ts. An
+  // unset var defaults to the prod pattern, so a deploy with the var
+  // unset behaves byte-identically to the build-baked prod values.
+  const backendHostPattern = normalizeBackendHostPattern(
+    readEnvPair("SHOWCASE_BACKEND_HOST_PATTERN") ??
+      DEFAULT_BACKEND_HOST_PATTERN,
+  );
+
+  return { backendHostPattern };
+}
+
+// Env-name tolerance: deploy configs in the wild use either the bare
+// name (e.g. `SHOWCASE_BACKEND_HOST_PATTERN`) or the `NEXT_PUBLIC_*`-
+// prefixed name. We accept either — the primary (passed-in) name wins,
+// with transparent fallback to the alternate so a Railway service
+// variable set under the "wrong" name still works without redeploy.
+// Same semantics as the shell's runtime-config readEnvPair.
+function altEnvName(envKey: string): string {
+  return envKey.startsWith("NEXT_PUBLIC_")
+    ? envKey.slice("NEXT_PUBLIC_".length)
+    : `NEXT_PUBLIC_${envKey}`;
+}
+
+// Length-aware env coalesce: a deliberately-empty primary (an operator
+// clearing the var on a Railway service) must NOT mask a populated
+// alternate. Treat empty-string as "unset" and fall through to the
+// alternate. Values are .trim()ed — whitespace paste artifacts would
+// otherwise survive into the pattern; a whitespace-only value counts as
+// unset. The dynamic `process.env[key]` reads assume a self-hosted Node
+// runtime (next start / Docker).
+function readEnvPair(envKey: string): string | undefined {
+  const primary = process.env[envKey]?.trim();
+  if (primary && primary.length > 0) return primary;
+  const alt = process.env[altEnvName(envKey)]?.trim();
+  if (alt && alt.length > 0) return alt;
+  return undefined;
 }


### PR DESCRIPTION
## Problem

The CopilotKit Interactive Dojo (`showcase/shell-dojo`) built its preview-iframe `src` from `integration.backend_url`, which `scripts/generate-registry.ts` synthesizes into `registry.json` at **Docker build time** (default `showcase-{slug}-production.up.railway.app`). The value is therefore frozen into every image regardless of environment — so the **staging dojo iframed production integration backends**.

## Root cause

The shell (`showcase/shell`) already solved this in SU-13 (commit `febd8bc9`, 2026-06-11): it derives each integration's backend host at **request time** from `SHOWCASE_BACKEND_HOST_PATTERN` via `lib/backend-url.ts`, keeping `registry.json` as the source for non-URL metadata only. That fix was scoped to `shell` and **never ported to `shell-dojo`** — `shell-dojo`'s `RuntimeConfig` was still empty and `page.tsx` read the build-baked `backend_url`.

## Fix

Port the `backendHostPattern` slice of SU-13 to `shell-dojo` (nothing else from SU-13 — the dojo has no docs-redirect middleware, posthog, or baseUrl consumers):

- **`lib/backend-url.ts`** — verbatim copy of shell's (`resolveBackendUrl` + the `NEXT_PUBLIC_LOCAL_BACKENDS` local-dev override). The two apps are separate build roots with different package managers (shell is a pnpm workspace member; shell-dojo is a standalone `npm ci` Next app, same as shell-dashboard), so neither can import the other's `src`, and there is no shared importable package — the same reason `generate-registry.ts` already keeps its own copy. A drift-guard test keeps the copy byte-identical and pins the default pattern across `backend-url.ts` and `generate-registry.ts`.
- **`lib/runtime-config.ts`** — adds `backendHostPattern`, read from `SHOWCASE_BACKEND_HOST_PATTERN` at request time (with the `NEXT_PUBLIC_`-prefixed/trim fallback semantics shared with shell). Unset → the prod default, so an unset deploy is byte-identical to today.
- **`lib/runtime-config.client.ts`** — carries the SSR sentinel `showcase-{slug}.ssr-placeholder.invalid` + a required-field check.
- **`app/page.tsx`** — `previewUrl` now derives via `resolveBackendUrl(...)` at request time, **gated on a `mounted` flag** so the SSR-phase sentinel host never reaches an iframe `src`. shell-dojo loads its registry synchronously (`getIntegrations()` in a `useMemo`, `viewMode` defaults to `"preview"`), so unlike the shell it has no client-`useEffect` data guard to defer the read past hydration — without the gate, the iframe would render on first paint with the `.invalid` sentinel host (a request to a dead domain + a flash before the real URL swaps in).
- **`app/layout.tsx`** — comment-only; the existing generic `JSON.stringify(config)` injection already carries the new field into `window.__SHOWCASE_CONFIG__`.

## Ops

`SHOWCASE_BACKEND_HOST_PATTERN=showcase-{slug}-staging.up.railway.app` is already set on the **staging dojo** Railway service (verified the staging hostname convention against a live staging integration's `RAILWAY_PUBLIC_DOMAIN`). **Production is intentionally left unset** = the prod default pattern, so prod behavior is unchanged. The var is runtime-only (images build in CI, not on Railway), so it was inert until this lands — merging this is what flips staging off prod backends.

## Testing

- New drift-guard test (in `scripts`): `backend-url.ts` byte-identical to shell's + default-pattern parity with `generate-registry.ts` — 2/2 pass.
- Full affected vitest run: 2110/2110 pass.
- Standalone shell-dojo Next build (`npm ci --ignore-scripts && npm run build`) compiled + type-checked successfully.
- oxfmt clean; oxlint 0 errors.

## Notes for reviewers

- **shell-dojo is not in the pnpm workspace**, so `nx affected` does not cover it — CI builds it via its own npm/Docker path. Verify locally with `cd showcase/shell-dojo && npm ci && npm run build`.
- The `iframe-missing-sandbox` oxlint **warning** at `page.tsx` pre-dates this change (the iframe does carry a `sandbox` attr; oxlint can't see it through the variable) and is outside the diff's intent — left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
