### PR TITLE
docs(showcase): correct gen-ui-agent PARITY_NOTES — it is GREEN, not react-core-blocked

### DIFF
--- a/showcase/integrations/built-in-agent/PARITY_NOTES.md
+++ b/showcase/integrations/built-in-agent/PARITY_NOTES.md
@@ -148,21 +148,30 @@ layer.
 - Action: tracked in follow-up PR; bundled with the
   `a2ui-fixed-schema` renderer-host fix.
 
-### `gen-ui-agent` — RED (state never reaches frontend)
+### `gen-ui-agent` — GREEN (reclaimed; the react-core premise was stale)
 
-- D6 status: RED — `StepsPanel` stays in its placeholder "No plan yet"
-  state for the full run.
-- This PR addressed: backend `set_steps` tool emits `STATE_DELTA`
-  correctly (verified in `tanstack-factory.ts`), factory wiring is sound
-  (✓).
-- What's missing: the frontend `useAgent` / `useCoAgent` subscriber
-  receives no state update — there is a wire-up gap between AG-UI
-  `STATE_DELTA` emission and the React hook's consumer. The placeholder
-  never flips to the rendered plan.
-- Suspected fix location: `packages/react-core` (AG-UI middleware /
-  `useAgent` / `useCoAgent` state-subscription path), not the BIA
-  integration.
-- Action: tracked in follow-up PR against `packages/react-core`.
+- D6 status: GREEN — the cell passes the D6 probe end-to-end. The earlier
+  claim (a `STATE_DELTA → useAgent` state-subscription gap in
+  `@copilotkit/react-core`) was **stale and is now refuted** by local D6
+  runs (3-turn probe, all assertions passed, `1 passed`, `green`).
+- Why it works: the backend `set_steps` server-tool result is converted to
+  a `STATE_DELTA` with `[{op:"add", path:"/steps", value:steps}]` in
+  `src/lib/factory/tanstack-factory.ts` (the `set_steps` branch). `add`
+  (not `replace`) is used deliberately so the patch lands even before
+  `/steps` exists and `@ag-ui/client@0.0.57` never swallows it as
+  `OPERATION_PATH_UNRESOLVABLE`. `@ag-ui/client`'s `AbstractAgent` applies
+  the patch to `agent.state` and fires `onStateChanged`; the core
+  state-manager's `handleStateDelta` saves it and fans `onStateChanged` to
+  subscribers; `useAgent` re-renders the page off `agent.state.steps`. The
+  wire-up is complete in the published kit — no react-core change is
+  required.
+- Evidence: the three-turn probe
+  (`harness/src/probes/scripts/d5-gen-ui-agent.ts`) passes all assertions,
+  including the `agent-state-card` + `≥2 [data-testid="agent-step"]` rows.
+  The `set_steps → STATE_DELTA(add)` workaround already merged in
+  `tanstack-factory.ts` closed the gap this note originally described.
+- Action: none — fully supported and counted. The earlier "follow-up PR
+  against `packages/react-core`" item is obsolete.
 
 ### headless-complete server-tool reprompt loop — resolved via sequenceIndex gating
 


### PR DESCRIPTION
## Summary

Doc-only single-file correction to `showcase/integrations/built-in-agent/PARITY_NOTES.md`. The `gen-ui-agent` D6 cell already passes end-to-end locally, but its PARITY_NOTES entry still documented it as RED/blocked on a `STATE_DELTA → useAgent` gap in `@copilotkit/react-core`. That premise is stale and is now refuted by local D6 runs. This rewrites the entry to GREEN/reclaimed and rescopes the surrounding section header to the remaining A2UI render-layer demos.

## RED → GREEN proof (from the work log)

The "RED" here is documentary, not behavioral: the cell **passes** despite the stale RED doc.

Local RED baseline (`bin/showcase test built-in-agent:gen-ui-agent --d6 --direct --isolate`):
```
[conversation-runner] turn 3/3 — assertions passed
[conversation-runner] conversation completed successfully { turnsCompleted: 3 }
  ✓ d6:built-in-agent green (44.1s)
  1 passed (44.1s)
```

Local GREEN value-test (same command, `--repeat 3`):
```
  3 passed (130.1s)
✓ Tests passed for built-in-agent:gen-ui-agent
```
3/3 stable — not a flake. The doc correction changes no runtime behavior.

Why it works: the backend `set_steps` server-tool result is converted to a `STATE_DELTA` `[{op:"add", path:"/steps", value:steps}]` in `src/lib/factory/tanstack-factory.ts` (`add`, not `replace`, so `@ag-ui/client@0.0.57` doesn't drop it as `OPERATION_PATH_UNRESOLVABLE`). `@ag-ui/client` applies the patch and fires `onStateChanged`; the core state-manager fans it to subscribers; `useAgent` re-renders off `agent.state.steps`. Fully wired in published 1.61.1 — no react-core change needed.

## Key finding: there was NO config quarantine

`gen-ui-agent` was never in the manifest `not_supported_features`, never excluded in `shared/constraints.yaml`, and `shared/feature-registry.json` has no per-feature status field. The harness already routes it into `runnable` and grades it green. The **stale doc was the only artifact** — there was no executable quarantine to lift, so this is a pure doc correction.

## The two genuinely-RED demos are out of scope

`a2ui-fixed-schema` (React #31 crash from an unresolved `{path}` A2UI binding) and `declarative-gen-ui` (surface never paints; secondary-LLM op-shape) are real bugs, but both belong to `@copilotkit/a2ui-renderer` / showcase — **not** `@copilotkit/react-core`. They are being addressed in a separate spec and are intentionally left untouched here.

## Test plan

- [x] `oxfmt --check` on the changed file — passes (correctly formatted)
- [x] `oxlint` on the changed file — 0 warnings, 0 errors
- [x] `commitlint` on the commit message — passes (`docs(showcase):`)
- [x] D6 cell passes locally, 3/3 stable
- [ ] CI green