### PR TITLE
fix(bot-slack): native setStatus thinking indicator instead of hourglass

### DIFF
--- a/packages/bot-slack/README.md
+++ b/packages/bot-slack/README.md
@@ -136,6 +136,18 @@ The row is attached at `chat.stopStream` (the only streaming call that accepts
 `blocks`), so it appears on the native path only — the legacy `chat.update`
 fallback omits it.
 
+### Native "is thinking…" status (everywhere)
+
+While the agent runs, the bot shows Slack's **native** loading status
+(`assistant.threads.setStatus`: "is thinking…") on every thread-anchored reply —
+channel @-mentions, threads it owns, DMs, and the assistant pane. Slack now
+accepts this method with the ordinary **`chat:write`** scope (no `assistant:write`
+needed just for the loading state), so it works for channel-based apps too. The
+status auto-clears when the reply streams in. Tool progress is surfaced per
+surface: the pane uses live composer status ("is using \`tool\`…"); elsewhere it
+uses the native `task_update` timeline (or `:wrench:` rows on older workspaces).
+Set `assistant: false` to opt out of the status (and pane) entirely.
+
 ### Assistant pane (agent-native, default-on)
 
 When the Slack app has the **Agents & AI Apps** toggle (an `assistant_view`
@@ -144,9 +156,8 @@ the adapter activates Slack's assistant pane with **zero config**:
 
 - Opening the pane posts a greeting + tappable prompt chips, and each pane
   conversation is its own thread (replies stay in-thread).
-- While the agent runs, native composer status is shown
-  (`assistant.threads.setStatus`: "is thinking…", "is using \`tool\`…") instead
-  of placeholder/`:wrench:` messages.
+- While the agent runs, native composer status is shown (see above), with
+  "is using \`tool\`…" per tool call.
 - The pane thread is auto-titled from the first message.
 
 Customize via the `assistant` option, or set `assistant: false` to disable pane
@@ -261,7 +272,7 @@ features your app uses:
 | `chat:write`       | Posting messages, streaming, ephemeral messages (`chat.postEphemeral`), and opening modals (`views.open`) — all share this single scope. |
 | `reactions:read`   | Reading reactions; subscribe to `reaction_added` / `reaction_removed` events in the app manifest to receive them.                        |
 | `reactions:write`  | Adding or removing reactions via `reactions.add` / `reactions.remove`.                                                                   |
-| `assistant:write`  | Native streaming task chunks and assistant-pane status updates.                                                                          |
+| `assistant:write`  | Native streaming `task_update` tool-timeline chunks and the assistant pane. (The "is thinking…" status works with `chat:write` alone.)   |
 | `files:write`      | Uploading files via `thread.postFile()`.                                                                                                 |
 | `users:read`       | Resolving Slack user profiles (name, email) via `users.info`.                                                                            |
 | `users:read.email` | Resolving user email addresses.                                                                                                          |

--- a/packages/bot-slack/src/__tests__/event-renderer.test.ts
+++ b/packages/bot-slack/src/__tests__/event-renderer.test.ts
@@ -423,9 +423,13 @@ describe("createRunRenderer", () => {
   });
 });
 
-describe("createRunRenderer — assistant pane status mode", () => {
+describe("createRunRenderer — native status mode", () => {
   function makePaneClient() {
-    const statuses: { status: string; loading_messages?: string[] }[] = [];
+    const statuses: {
+      status: string;
+      loading_messages?: string[];
+      thread_ts?: string;
+    }[] = [];
     const posts: { text: string; ts: string }[] = [];
     const updates: { ts: string; text: string }[] = [];
     let counter = 0;
@@ -445,10 +449,15 @@ describe("createRunRenderer — assistant pane status mode", () => {
     const assistant = {
       threads: {
         setStatus: vi.fn(
-          async (args: { status: string; loading_messages?: string[] }) => {
+          async (args: {
+            status: string;
+            loading_messages?: string[];
+            thread_ts?: string;
+          }) => {
             statuses.push({
               status: args.status,
               loading_messages: args.loading_messages,
+              thread_ts: args.thread_ts,
             });
             return { ok: true };
           },
@@ -464,13 +473,18 @@ describe("createRunRenderer — assistant pane status mode", () => {
     const { subscriber: sub } = createRunRenderer({
       client: f.client,
       target: { channel: "D1", threadTs: "100.0" },
-      assistantStatus: { thinking: "is pondering…", loadingMessages: ["a"] },
+      status: {
+        threadTs: "100.0",
+        isPane: true,
+        config: { thinking: "is pondering…", loadingMessages: ["a"] },
+      },
     });
     await sub.onRunStartedEvent!({} as never);
     expect(f.posts).toHaveLength(0);
     expect(f.statuses[0]).toEqual({
       status: "is pondering…",
       loading_messages: ["a"],
+      thread_ts: "100.0",
     });
   });
 
@@ -479,7 +493,7 @@ describe("createRunRenderer — assistant pane status mode", () => {
     const { subscriber: sub } = createRunRenderer({
       client: f.client,
       target: { channel: "D1", threadTs: "100.0" },
-      assistantStatus: {},
+      status: { threadTs: "100.0", isPane: true, config: {} },
     });
     await sub.onToolCallStartEvent!({
       event: { toolCallId: "t1", toolCallName: "search" },
@@ -493,7 +507,7 @@ describe("createRunRenderer — assistant pane status mode", () => {
     const { subscriber: sub } = createRunRenderer({
       client: f.client,
       target: { channel: "D1", threadTs: "100.0" },
-      assistantStatus: {},
+      status: { threadTs: "100.0", isPane: true, config: {} },
       showToolStatus: false,
     });
     await sub.onToolCallStartEvent!({
@@ -508,7 +522,7 @@ describe("createRunRenderer — assistant pane status mode", () => {
     const { subscriber: sub } = createRunRenderer({
       client: f.client,
       target: { channel: "D1", threadTs: "100.0" },
-      assistantStatus: {},
+      status: { threadTs: "100.0", isPane: true, config: {} },
     });
     await sub.onRunStartedEvent!({} as never);
     await sub.onTextMessageStartEvent!({
@@ -527,10 +541,53 @@ describe("createRunRenderer — assistant pane status mode", () => {
     const { subscriber: sub } = createRunRenderer({
       client: f.client,
       target: { channel: "D1", threadTs: "100.0" },
-      assistantStatus: { thinking: "t" },
+      status: { threadTs: "100.0", isPane: true, config: { thinking: "t" } },
     });
     await sub.onRunStartedEvent!({} as never);
     await sub.onRunFinishedEvent!({} as never);
     expect(f.statuses.at(-1)?.status).toBe("");
+  });
+
+  // ── Non-pane: a channel @-mention / thread (isPane:false) gets the native
+  // "is thinking…" status instead of the old :hourglass: placeholder, but tool
+  // progress still flows to :wrench: rows (not composer status). ──────────────
+  it("non-pane thread: sets native status on run start (no :hourglass: placeholder)", async () => {
+    const f = makePaneClient();
+    const { subscriber: sub } = createRunRenderer({
+      client: f.client,
+      target: { channel: "C1", threadTs: "100.0" },
+      status: { threadTs: "100.0", isPane: false, config: {} },
+    });
+    await sub.onRunStartedEvent!({} as never);
+    expect(f.posts).toHaveLength(0);
+    expect(f.statuses[0]?.status).toBe("is thinking…");
+  });
+
+  it("non-pane thread: tool calls still post :wrench: rows, not composer status", async () => {
+    const f = makePaneClient();
+    const { subscriber: sub } = createRunRenderer({
+      client: f.client,
+      target: { channel: "C1", threadTs: "100.0" },
+      status: { threadTs: "100.0", isPane: false, config: {} },
+    });
+    await sub.onToolCallStartEvent!({
+      event: { toolCallId: "t1", toolCallName: "search" },
+    } as never);
+    expect(f.posts.at(-1)?.text).toContain(":wrench:");
+    expect(f.statuses.some((s) => s.status.includes("is using"))).toBe(false);
+  });
+
+  it("uses the provided threadTs anchor (e.g. a DM's inbound ts) for setStatus", async () => {
+    const f = makePaneClient();
+    const { subscriber: sub } = createRunRenderer({
+      client: f.client,
+      // Flat DM: the channel target has no threadTs, but the adapter passes the
+      // inbound message ts as the status anchor.
+      target: { channel: "D1" },
+      status: { threadTs: "999.000", isPane: false, config: {} },
+    });
+    await sub.onRunStartedEvent!({} as never);
+    expect(f.statuses[0]?.status).toBe("is thinking…");
+    expect(f.statuses[0]?.thread_ts).toBe("999.000");
   });
 });

--- a/packages/bot-slack/src/adapter.ts
+++ b/packages/bot-slack/src/adapter.ts
@@ -552,9 +552,19 @@ export class SlackAdapter implements PlatformAdapter {
     const t = target as ReplyTarget;
     const assistantOpts: SlackAssistantOptions | undefined =
       this.opts.assistant === false ? undefined : (this.opts.assistant ?? {});
-    // Pane targets drive native status (setStatus) instead of placeholder +
-    // :wrench: rows.
     const isPane = this.isPaneTarget(t);
+    // Native `setStatus` ("is thinking…") works for any thread we can anchor it
+    // to — pane, channel @-mention, tracked channel thread, or (via the carried
+    // inbound ts) a flat DM. `assistant: false` opts out everywhere.
+    const statusThreadTs = t.threadTs ?? t.statusTs;
+    const status =
+      assistantOpts && statusThreadTs
+        ? {
+            threadTs: statusThreadTs,
+            isPane,
+            config: assistantOpts.status ?? {},
+          }
+        : undefined;
     // Native streaming wherever a thread exists (and the workspace supports it).
     const useNative =
       this.opts.streaming !== "legacy" &&
@@ -565,7 +575,7 @@ export class SlackAdapter implements PlatformAdapter {
       target: t,
       interruptEventNames: this.opts.interruptEventNames,
       showToolStatus: this.opts.showToolStatus,
-      assistantStatus: isPane ? (assistantOpts?.status ?? {}) : undefined,
+      status,
       nativeStreaming: useNative
         ? {
             transport: this.nativeTransport(t, () => {}),

--- a/packages/bot-slack/src/event-renderer.ts
+++ b/packages/bot-slack/src/event-renderer.ts
@@ -81,11 +81,18 @@ export function createRunRenderer(args: {
    */
   showToolStatus?: boolean;
   /**
-   * Present only for assistant-pane targets. Drives Slack's native
-   * `assistant.threads.setStatus` ("is thinking…", "is using `tool`…")
-   * instead of posting a placeholder message and `:wrench:` rows.
+   * Present whenever the reply is anchored to a thread we can set native status
+   * on (pane, channel @-mention, channel thread, or a flat DM via its carried
+   * inbound ts). Drives Slack's native `assistant.threads.setStatus`
+   * ("is thinking…") instead of a placeholder message. `threadTs` is the thread
+   * the status attaches to; `isPane` selects how *tool* progress is surfaced
+   * (pane → composer "is using `tool`…"; non-pane → `task_update`/`:wrench:`).
    */
-  assistantStatus?: SlackAssistantOptions["status"];
+  status?: {
+    threadTs: string;
+    isPane: boolean;
+    config?: SlackAssistantOptions["status"];
+  };
   /**
    * When set, agent text replies stream via `chat.startStream` (native) using
    * this transport instead of `chat.update`. Falls back to the legacy
@@ -117,39 +124,43 @@ export function createRunRenderer(args: {
   const showToolStatus = args.showToolStatus ?? true;
   const nativeMode = args.nativeStreaming !== undefined;
 
-  // ── Assistant-pane status mode ──────────────────────────────────────
-  // In a pane thread the run lifecycle drives native status under the
-  // composer instead of placeholder/`:wrench:` messages.
-  const paneStatus = args.assistantStatus;
-  const paneMode = paneStatus !== undefined && target.threadTs !== undefined;
-  const paneToolStatus = paneStatus?.toolStatus ?? true;
+  // ── Native status mode ──────────────────────────────────────────────
+  // Whenever the reply is anchored to a thread, the run lifecycle drives
+  // Slack's native `assistant.threads.setStatus` ("is thinking…") instead of a
+  // placeholder message. `isPane` only selects how *tool* progress is shown.
+  const status = args.status;
+  const statusMode = status !== undefined;
+  const isPane = status?.isPane ?? false;
+  const paneToolStatus = status?.config?.toolStatus ?? true;
 
-  const setPaneStatus = async (status: string): Promise<void> => {
-    if (!paneMode || !target.threadTs) return;
+  const setStatus = async (text: string): Promise<void> => {
+    if (!status) return;
     try {
       await client.assistant.threads.setStatus({
         channel_id: target.channel,
-        thread_ts: target.threadTs,
-        status,
-        ...(status && paneStatus?.loadingMessages
-          ? { loading_messages: [...paneStatus.loadingMessages] }
+        thread_ts: status.threadTs,
+        status: text,
+        ...(text && status.config?.loadingMessages
+          ? { loading_messages: [...status.config.loadingMessages] }
           : {}),
       });
     } catch (err) {
       console.error("[slack-renderer] setStatus failed:", err);
     }
   };
-  /** Clear the composer status (best-effort). */
-  const clearPaneStatus = async (): Promise<void> => {
-    if (!paneMode) return;
-    await setPaneStatus("");
+  /** Clear the native status (best-effort). */
+  const clearStatus = async (): Promise<void> => {
+    if (!statusMode) return;
+    await setStatus("");
   };
   /** Whether this run has posted any visible reply yet (drives status clear). */
   let postedReply = false;
   const onFirstReply = async (): Promise<void> => {
     if (postedReply) return;
     postedReply = true;
-    await clearPaneStatus();
+    // Slack auto-clears status when the app replies; clear explicitly too so
+    // there's no lingering indicator on slow/edge paths.
+    await clearStatus();
   };
 
   // ── Legacy per-message streaming state ──────────────────────────────
@@ -203,96 +214,11 @@ export function createRunRenderer(args: {
    */
   let pendingInterrupt: CapturedInterrupt | undefined;
 
-  // ── "Thinking…" indicator ───────────────────────────────────────────
-  // Posted as soon as a run starts so there's no dead air while the agent
-  // reasons / calls MCP before its first token. The streamed text reply
-  // REUSES this message (the dots morph straight into the answer); if the
-  // first visible output is something else (a component, a HITL picker)
-  // the placeholder is removed instead. `runAgent` fires once per tool-loop
-  // iteration, so we (re)post on each RUN_STARTED and clear on each
-  // RUN_FINISHED — giving a "thinking" beat between steps.
-  let thinkingTs: string | undefined;
-  let thinkingTimer: ReturnType<typeof setInterval> | undefined;
-  let thinkingClaimed = false;
-
-  const stopThinkingTimer = () => {
-    if (thinkingTimer) {
-      clearInterval(thinkingTimer);
-      thinkingTimer = undefined;
-    }
-  };
-
-  const startThinking = async () => {
-    if (aborted || thinkingTs || thinkingClaimed) return;
-    try {
-      const posted = await client.chat.postMessage({
-        channel: target.channel,
-        thread_ts: target.threadTs,
-        text: ":hourglass_flowing_sand:  _thinking…_",
-      });
-      if (!posted.ts) return;
-      thinkingTs = posted.ts;
-      let frame = 0;
-      thinkingTimer = setInterval(() => {
-        if (thinkingClaimed || !thinkingTs) return;
-        frame = (frame + 1) % 3;
-        const dots = ".".repeat(frame + 1);
-        void client.chat
-          .update({
-            channel: target.channel,
-            ts: thinkingTs,
-            text: `:hourglass_flowing_sand:  _thinking${dots}_`,
-          })
-          .catch(() => {});
-      }, 1200);
-    } catch (err) {
-      console.error("[slack-renderer] thinking placeholder failed:", err);
-    }
-  };
-
-  // Hand the standing placeholder to the text stream so its dots become the
-  // reply. Returns the ts once; afterwards the message belongs to the stream.
-  const claimThinking = (): string | undefined => {
-    if (thinkingTs && !thinkingClaimed) {
-      thinkingClaimed = true;
-      stopThinkingTimer();
-      const ts = thinkingTs;
-      thinkingTs = undefined;
-      return ts;
-    }
-    return undefined;
-  };
-
-  // Remove the placeholder if it's still standing and wasn't claimed by text.
-  const clearThinking = async () => {
-    stopThinkingTimer();
-    const ts = thinkingTs;
-    thinkingTs = undefined;
-    if (ts && !thinkingClaimed) {
-      try {
-        await client.chat.delete({ channel: target.channel, ts });
-      } catch {
-        /* best-effort: the message may already be gone */
-      }
-    }
-  };
-
   // The shipped chat.update streamer (mrkdwn-translated). Also the automatic
-  // fallback for the native transport. Reuses the standing "thinking…" message
-  // when one exists so the dots morph straight into the reply.
+  // fallback for the native transport.
   const makeLegacyStream = (): TextStream =>
     new ChunkedMessageStream({
       postPlaceholder: async (text) => {
-        const claimed = claimThinking();
-        if (claimed) {
-          await client.chat.update({
-            channel: target.channel,
-            ts: claimed,
-            text,
-          });
-          await onFirstReply();
-          return claimed;
-        }
         const posted = await client.chat.postMessage({
           channel: target.channel,
           thread_ts: target.threadTs,
@@ -309,8 +235,7 @@ export function createRunRenderer(args: {
     });
 
   // The single native turn stream — raw markdown, no mrkdwn translation, with
-  // interleaved `task_update` chunks. Reuses the "thinking…" placeholder when
-  // present (drops it on first content).
+  // interleaved `task_update` chunks.
   const ensureTurnStream = (): NativeMessageStream => {
     if (turnStream) return turnStream;
     const ns = args.nativeStreaming!;
@@ -318,9 +243,8 @@ export function createRunRenderer(args: {
       transport: {
         startStream: async () => {
           const ts = await ns.transport.startStream();
-          // The native message owns the bubble now; drop the placeholder and
-          // clear any pane status (the reply is visible).
-          await clearThinking();
+          // The native message owns the bubble now; clear the native status
+          // (the reply is visible).
           await onFirstReply();
           return ts;
         },
@@ -373,7 +297,6 @@ export function createRunRenderer(args: {
     if (!showToolStatus) return;
     if (toolStatusTs.has(toolCallId)) return; // dedup
     try {
-      await clearThinking();
       const posted = await client.chat.postMessage({
         channel: target.channel,
         thread_ts: target.threadTs,
@@ -409,11 +332,11 @@ export function createRunRenderer(args: {
     // ── 0. Run lifecycle: thinking indicator ───────────────────────────
     async onRunStartedEvent() {
       if (aborted) return;
-      if (paneMode) {
-        // Native status under the composer instead of a placeholder message.
-        await setPaneStatus(paneStatus?.thinking || DEFAULT_THINKING_STATUS);
-      } else {
-        await startThinking();
+      // Native "is thinking…" status on the thread. `runAgent` fires once per
+      // tool-loop iteration, so we (re)set it on each RUN_STARTED — Slack also
+      // resets its 2-minute status timeout on each call.
+      if (statusMode) {
+        await setStatus(status?.config?.thinking || DEFAULT_THINKING_STATUS);
       }
     },
     async onRunFinishedEvent() {
@@ -432,12 +355,9 @@ export function createRunRenderer(args: {
         buffers.delete(id);
       }
       if (drains.length > 0) await Promise.all(drains);
-      // Tidy the per-iteration "thinking…" bubble (a streamed reply already
-      // claimed it; tool/component/HITL output or nothing leaves it standing).
-      await clearThinking();
-      // In a pane thread, a posted reply auto-clears Slack's status; clear it
-      // explicitly when the run produced no visible reply yet.
-      if (paneMode && !postedReply) await clearPaneStatus();
+      // A posted reply auto-clears Slack's status; clear it explicitly when the
+      // run produced no visible reply yet (tool/component/HITL output, or none).
+      if (statusMode && !postedReply) await clearStatus();
     },
 
     // ── 1. Text streaming ──────────────────────────────────────────────
@@ -491,9 +411,9 @@ export function createRunRenderer(args: {
       if (aborted) return;
       // Pane threads surface tool activity as live composer status, not rows.
       // Each setStatus also resets Slack's status timeout.
-      if (paneMode) {
+      if (isPane) {
         if (showToolStatus && paneToolStatus) {
-          await setPaneStatus(`is using \`${event.toolCallName}\`…`);
+          await setStatus(`is using \`${event.toolCallName}\`…`);
         }
         return;
       }
@@ -535,7 +455,7 @@ export function createRunRenderer(args: {
         (toolCallArgs ?? {}) as Record<string, unknown>,
       );
       // Pane threads use live status (set on START); no per-call rows to edit.
-      if (paneMode) return;
+      if (isPane) return;
       // Native path: complete the in-message `task_update`.
       if (nativeMode && taskChunksOk) {
         if (showToolStatus) {
@@ -577,8 +497,7 @@ export function createRunRenderer(args: {
       // Don't post a warning if we're the ones aborting the run; the
       // `_(interrupted)_` marker on the partial reply is the user-visible
       // signal in that case.
-      await clearThinking();
-      if (paneMode) await clearPaneStatus();
+      if (statusMode) await clearStatus();
       // Close any open native turn stream so the partial reply is committed.
       await finalizeTurnStream();
       if (aborted) return;
@@ -626,10 +545,9 @@ export function createRunRenderer(args: {
       // abort) see the flag and bail.
       if (aborted) return;
       aborted = true;
-      // Drop any standing "thinking…" bubble; the interrupted marker (or
-      // the next turn) is the user-visible signal now.
-      await clearThinking();
-      if (paneMode) await clearPaneStatus();
+      // Clear the native status; the interrupted marker (or the next turn) is
+      // the user-visible signal now.
+      if (statusMode) await clearStatus();
       // Native turn stream: append the interrupted marker to the partial reply
       // and finalize it.
       if (nativeMode) {

--- a/packages/bot-slack/src/slack-listener.ts
+++ b/packages/bot-slack/src/slack-listener.ts
@@ -186,7 +186,9 @@ export function attachSlackListener(config: ListenerConfig): void {
       await onTurn(
         {
           conversation: { channelId: message.channel, scope: DM_SCOPE },
-          replyTarget: { channel: message.channel },
+          // Flat DM reply (no threadTs); carry the inbound ts so the renderer
+          // can anchor the native "is thinking…" status to a thread.
+          replyTarget: { channel: message.channel, statusTs: message.ts },
           userText: text,
           senderUserId: message.user,
           eventId: deriveEventId(body, message, message.channel),

--- a/packages/bot-slack/src/types.ts
+++ b/packages/bot-slack/src/types.ts
@@ -14,6 +14,13 @@ export interface ReplyTarget {
    * native streamer can read it off the target.
    */
   recipientUserId?: string;
+  /**
+   * Inbound message ts used as the thread anchor for
+   * `assistant.threads.setStatus` in flat DMs (which have no `threadTs`).
+   * Replies still post flat; this only gives the native "is thinking…"
+   * indicator a thread to attach to.
+   */
+  statusTs?: string;
 }
 
 /**


### PR DESCRIPTION
## What

Replaces the homemade animated `:hourglass_flowing_sand:` "thinking" placeholder (a posted message whose dots cycled via `setInterval`) with Slack's **native** `assistant.threads.setStatus` "is thinking…" indicator — and generalizes it from assistant-pane-only to **every thread-anchored reply**: channel @-mentions, channel threads, DMs, and the pane.

## Why

The hourglass was an extra post-then-delete message that looked nothing like the native loading state other Slack agents show. Slack has since relaxed `assistant.threads.setStatus` to accept the ordinary **`chat:write`** scope (not just `assistant:write`), specifically so channel-based apps can show AI loading states in channels and DMs ([docs](https://docs.slack.dev/reference/methods/assistant.threads.setStatus/)). The adapter already used `setStatus` for the pane — this just extends it everywhere and deletes the placeholder.

## How

- **`event-renderer.ts`** — delete the hourglass machinery (`startThinking`/`claimThinking`/`clearThinking`/`setInterval`); generalize `setPaneStatus`/`clearPaneStatus` → `setStatus`/`clearStatus`. New `status?: { threadTs, isPane, config }` arg: `statusMode` drives the thinking indicator; `isPane` only selects tool-progress surface (pane composer status vs `task_update` timeline / `:wrench:` rows — both unchanged).
- **`adapter.ts`** — `createRunRenderer` builds `status` for any target with a thread anchor (`threadTs ?? statusTs`); `assistant: false` opts out everywhere.
- **`types.ts` / `slack-listener.ts`** — flat DMs (no `thread_ts`) carry the inbound message `ts` as the status anchor; replies still post flat.
- **README** — document the broadened status + the `chat:write` relaxation.

## Testing

- `nx run-many -t test build` for `bot-slack` — **248 tests pass**, build clean, oxlint 0 errors, oxfmt clean.
- New tests cover non-pane channel-thread status, the `:wrench:` tool path staying on non-pane, and the DM `statusTs` anchor.
- Net **−149 lines**.

> Note: the DM path anchors `setStatus` to a non-assistant DM message ts — the one piece only verifiable against the live Slack API. Channel @-mentions already carry a real `thread_ts`.
