### PR TITLE
fix(showcase): promote strands-typescript to production (dual-env SSOT)

### DIFF
--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -72,6 +72,7 @@ on:
           - starter-pydantic-ai
           - starter-strands-python
           - strands
+          - strands-typescript
           - webhooks
         # <<< END GENERATED service options
       digest:

--- a/showcase/scripts/__tests__/fixtures/railway-envs.golden.json
+++ b/showcase/scripts/__tests__/fixtures/railway-envs.golden.json
@@ -425,6 +425,13 @@
     }
   },
   "showcase-strands-typescript": {
+    "prod": {
+      "instanceId": "8a50728e-6119-43c4-b59c-d9535b6717a4",
+      "domain": "showcase-strands-typescript-production.up.railway.app",
+      "probe": true,
+      "driver": "agent",
+      "repoName": "showcase-strands-typescript"
+    },
     "staging": {
       "instanceId": "3f917b9f-c3f0-4d8b-96ca-7f455e06b5ba",
       "domain": "showcase-strands-typescript-staging.up.railway.app",

--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -22,21 +22,17 @@ import type { ServiceEntry } from "../railway-envs";
 describe("ServiceEntry gateIgnore field", () => {
   it("is optional on the type and defaults to falsy when unset", () => {
     // Every real SSOT entry has gateIgnore unset (undefined / falsy),
-    // EXCEPT two deliberately gateIgnore:true entries:
+    // EXCEPT one deliberately gateIgnore:true entry:
     //   - the staging-only `harness-workers` pool-fleet worker (no public
     //     domain, does not fit the symmetric dual-env shape the gate
-    //     validates);
-    //   - the staging-only `showcase-strands-typescript` integration (prod
-    //     not yet provisioned, so it omits the prod env and is gate-ignored
-    //     until promoted dual-env).
-    // See their SSOT entries in railway-envs.ts for the rationale.
-    // S2: the 12 starter-<slug> services are NO LONGER gate-ignored — they
-    // are fully gate-managed (gateValidated, no gateIgnore), so they fall
-    // into the default-falsy branch below exactly like every showcase-* agent.
-    const GATE_IGNORED = new Set([
-      "harness-workers",
-      "showcase-strands-typescript",
-    ]);
+    //     validates).
+    // See its SSOT entry in railway-envs.ts for the rationale.
+    // `showcase-strands-typescript` is now provisioned dual-env
+    // (gateValidated:true, no gateIgnore), so it falls into the default-falsy
+    // branch below. S2: the 12 starter-<slug> services are likewise NO LONGER
+    // gate-ignored — they are fully gate-managed (gateValidated, no
+    // gateIgnore), exactly like every showcase-* agent.
+    const GATE_IGNORED = new Set(["harness-workers"]);
     const isGateIgnored = (name: string): boolean => GATE_IGNORED.has(name);
     for (const [name, entry] of Object.entries(SERVICES)) {
       const gi = (entry as ServiceEntry).gateIgnore;
@@ -268,16 +264,13 @@ describe("WS-C: all gate-managed services gateValidated, with correct overrides"
   });
 
   it("marks every gate-managed service gateValidated (no Phase-2 holdouts)", () => {
-    // Intentional gateValidated:false entries (both gateIgnore:true): the
-    // staging-only `harness-workers` (no public domain) and the staging-only
-    // `showcase-strands-typescript` (prod not yet provisioned). S2 brought
-    // the 12 starter-<slug> services UNDER the gate (gateValidated:true), so
-    // they are no longer holdouts — every OTHER service, starters included,
+    // Intentional gateValidated:false entry (gateIgnore:true): the
+    // staging-only `harness-workers` (no public domain). S2 brought the 12
+    // starter-<slug> services UNDER the gate (gateValidated:true), so they
+    // are no longer holdouts; `showcase-strands-typescript` is now provisioned
+    // in prod and gateValidated too — every OTHER service, starters included,
     // must be gateValidated:true.
-    const GATE_IGNORED = new Set([
-      "harness-workers",
-      "showcase-strands-typescript",
-    ]);
+    const GATE_IGNORED = new Set(["harness-workers"]);
     const isGateIgnored = (name: string): boolean => GATE_IGNORED.has(name);
     const unvalidated = Object.entries(SERVICES)
       .filter(([name, entry]) => !entry.gateValidated && !isGateIgnored(name))
@@ -298,17 +291,18 @@ describe("WS-C: all gate-managed services gateValidated, with correct overrides"
     });
   }
 
-  it("findMissingServices treats all 39 gateValidated services as targets (27 showcase/infra + 12 starters)", () => {
+  it("findMissingServices treats all 40 gateValidated services as targets (28 showcase/infra + 12 starters)", () => {
     // With nothing "present", every gateValidated service should appear in
     // the missing set. After S2 brought the 12 starter-<slug> services under
-    // the gate (gateValidated:true, dual-env), that means all 39 — the 27
+    // the gate (gateValidated:true, dual-env), and showcase-strands-typescript
+    // was provisioned in prod (gateValidated:true), that means all 40 — the 28
     // showcase/infra gateValidated services plus the 12 starters. (The
     // gateIgnore entry harness-workers is NOT gateValidated and so is not
     // required here.)
     const missingProd = findMissingServices("prod", new Set<string>());
     const missingStaging = findMissingServices("staging", new Set<string>());
-    expect(missingProd).toHaveLength(39);
-    expect(missingStaging).toHaveLength(39);
+    expect(missingProd).toHaveLength(40);
+    expect(missingStaging).toHaveLength(40);
     // The 12 starters are now demanded in BOTH envs.
     expect(missingProd).toContain("starter-adk");
     expect(missingStaging).toContain("starter-mastra");

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -778,18 +778,18 @@
     {
       "name": "showcase-strands-typescript",
       "serviceId": "d6f47c8c-a0a1-4dbe-991c-50f8463fd68d",
-      "prodInstanceId": "d6f47c8c-a0a1-4dbe-991c-50f8463fd68d",
+      "prodInstanceId": "8a50728e-6119-43c4-b59c-d9535b6717a4",
       "stagingInstanceId": "3f917b9f-c3f0-4d8b-96ca-7f455e06b5ba",
       "ciBuilt": true,
-      "gateValidated": false,
+      "gateValidated": true,
       "dispatchName": "strands-typescript",
       "domains": {
         "staging": "showcase-strands-typescript-staging.up.railway.app",
-        "prod": "showcase-strands-typescript-staging.up.railway.app"
+        "prod": "showcase-strands-typescript-production.up.railway.app"
       },
       "probe": {
         "staging": true,
-        "prod": false,
+        "prod": true,
         "driver": "agent"
       },
       "promoteTier": 2,
@@ -801,6 +801,7 @@
         }
       ],
       "healthcheckPath": {
+        "prod": "/api/health",
         "staging": "/api/health"
       }
     },
@@ -1300,6 +1301,10 @@
         "tier": 2
       },
       {
+        "name": "showcase-strands-typescript",
+        "tier": 2
+      },
+      {
         "name": "starter-adk",
         "tier": 2
       },
@@ -1351,10 +1356,6 @@
     "skipped": [
       {
         "name": "harness-workers",
-        "reason": "no \"prod\" environment in the SSOT — cannot be promoted (it exists in: staging)."
-      },
-      {
-        "name": "showcase-strands-typescript",
         "reason": "no \"prod\" environment in the SSOT — cannot be promoted (it exists in: staging)."
       }
     ]

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -1150,23 +1150,16 @@ export const SERVICES: Record<
       },
     },
   },
-  // STAGING-ONLY (for now). The TypeScript sibling of `showcase-strands`
-  // ships to staging first; its prod instance is intentionally NOT yet
-  // provisioned. Under the env-map schema the entry declares only `staging`
-  // (no prod key, no placeholder ID). gateIgnore skips BOTH image-ref-gate
-  // directions so a prod-less, not-yet-pinned service does not trip
-  // findMissingServices / findUntrackedServices; gateValidated is therefore
-  // false. ciBuilt:true keeps it in the staging redeploy scope so a
-  // main-merge build of its image bounces the staging instance. When prod is
-  // later provisioned + promoted via showcase_promote.yml, convert this to
-  // the dual-env `showcase-strands` shape: add a `prod` env entry with its
-  // real serviceInstance ID, flip gateValidated:true, drop gateIgnore, and
-  // remove the legacyJsonCompat prod-domain placeholder below.
+  // The TypeScript sibling of `showcase-strands`. Now provisioned in BOTH
+  // staging and prod (dual-env `showcase-strands` shape): the prod
+  // serviceInstance was created + deployed + health-verified, so the entry
+  // declares a real `prod` env, gateValidated:true (verify-railway-image-refs
+  // validates both drift directions), gateIgnore dropped, and the
+  // legacyJsonCompat prod-domain placeholder removed.
   "showcase-strands-typescript": {
     serviceId: "d6f47c8c-a0a1-4dbe-991c-50f8463fd68d",
     ciBuilt: true,
-    gateValidated: false,
-    gateIgnore: true,
+    gateValidated: true,
     dispatchName: "strands-typescript",
     probeDriver: "agent",
     // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic
@@ -1176,22 +1169,17 @@ export const SERVICES: Record<
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
     environments: {
+      prod: {
+        instanceId: "8a50728e-6119-43c4-b59c-d9535b6717a4",
+        healthcheckPath: "/api/health",
+        domain: "showcase-strands-typescript-production.up.railway.app",
+        probe: true,
+      },
       staging: {
         instanceId: "3f917b9f-c3f0-4d8b-96ca-7f455e06b5ba",
         healthcheckPath: "/api/health",
         domain: "showcase-strands-typescript-staging.up.railway.app",
         probe: true,
-      },
-    },
-    // Ruby/jq JSON-shape compat (see ServiceEntry.legacyJsonCompat). The
-    // emitter fills the absent prod env's prodInstanceId from serviceId and
-    // the missing prod domain from this borrowed staging host so the
-    // generated JSON keeps its legacy {prod,staging} shape. Neither is read
-    // by any TS accessor (no prod env => never dereferenced; probe.prod is
-    // emitted false).
-    legacyJsonCompat: {
-      domains: {
-        prod: "showcase-strands-typescript-staging.up.railway.app",
       },
     },
   },

--- a/showcase/scripts/redeploy-env.test.ts
+++ b/showcase/scripts/redeploy-env.test.ts
@@ -68,17 +68,17 @@ describe("runRedeploy", () => {
     });
 
     expect(result.exitCode).toBe(0);
-    // 39 CI-built (27 showcase/infra incl. the staging-only
-    // showcase-strands-typescript, + 12 starters) + harness-workers
-    // (imageOf consumer of showcase-harness) = 40. All 39 declare staging,
-    // so the env-aware default scope keeps every one of them.
+    // 39 CI-built (27 showcase/infra incl. showcase-strands-typescript,
+    // now dual-env, + 12 starters) + harness-workers (imageOf consumer of
+    // showcase-harness) = 40. All 39 declare staging, so the env-aware
+    // default scope keeps every one of them.
     expect(result.attempted).toBe(40);
     expect(result.succeeded).toBe(40);
     expect(redeploy).toHaveBeenCalledTimes(40);
     // pocketbase is now CI-built, so it IS in the default redeploy scope.
     expect(seenNames).toContain("pocketbase");
-    // The staging-only TypeScript Strands integration declares staging, so
-    // it IS in the staging default scope (but NOT prod — see below).
+    // The TypeScript Strands integration declares staging, so it IS in the
+    // staging default scope (and now prod too — see below).
     expect(seenNames).toContain("showcase-strands-typescript");
     // S2: starters are CI-built, so they JOIN the default redeploy scope.
     expect(seenNames).toContain("starter-adk");
@@ -142,14 +142,14 @@ describe("runRedeploy", () => {
     ]);
   });
 
-  it("default prod scope excludes staging-only services (harness-workers + showcase-strands-typescript)", async () => {
+  it("default prod scope excludes staging-only services (harness-workers) but includes dual-env showcase-strands-typescript", async () => {
     // The default scope is env-aware: a service with no prod env never joins
     // the prod scope. harness-workers (imageOf consumer, staging-only) is
-    // excluded by the env-aware imageOf expansion; showcase-strands-typescript
-    // (ciBuilt, staging-only — prod not yet provisioned) is excluded by the
-    // env-aware base-scope filter. The prod default = the 38 CI-built services
-    // that declare prod (26 showcase/infra + 12 starters), neither staging-only
-    // service.
+    // excluded by the env-aware imageOf expansion. showcase-strands-typescript
+    // is now provisioned dual-env, so it DOES join the prod default scope. The
+    // prod default = the 39 CI-built services that declare prod (27
+    // showcase/infra incl. showcase-strands-typescript + 12 starters); only
+    // staging-only harness-workers is excluded.
     const seenNames: string[] = [];
     const redeploy = vi.fn(async (serviceId: string) => {
       const name = Object.entries(SERVICES).find(
@@ -163,9 +163,10 @@ describe("runRedeploy", () => {
       redeploy,
       appendSummary,
     });
-    expect(result.attempted).toBe(38);
+    expect(result.attempted).toBe(39);
     expect(seenNames).not.toContain("harness-workers");
-    expect(seenNames).not.toContain("showcase-strands-typescript");
+    // showcase-strands-typescript is now dual-env, so it joins the prod scope.
+    expect(seenNames).toContain("showcase-strands-typescript");
     // S2: starters ARE in the default prod scope (CI-built, dual-env).
     expect(seenNames).toContain("starter-adk");
   });


### PR DESCRIPTION
## What

The `showcase-strands-typescript` integration was **staging-only** — it had no production Railway serviceInstance. As a result the prod D6 dashboard column was a uniform **false-red**: every cell reported `errorClass=goto-error` with `backendUrl=""`, because the harness had no prod health record to hand the probe, so Playwright navigated a bare relative path (`page.goto("/demos/…")`) and Chromium rejected it as an invalid URL.

This brings the service into production so the prod D6 column mirrors **staging's actual pattern** (the false goto-error reds disappear; whatever staging genuinely passes, prod passes). Fixing staging's ~7 genuinely-broken feature cells is **out of scope**.

## Infra provisioned (production)

- **prod serviceInstance** `8a50728e-6119-43c4-b59c-d9535b6717a4` created (via `environmentStageChanges` + `environmentPatchCommitStaged`, mirroring the peer prod TS service `showcase-claude-sdk-typescript`).
- **domain** `showcase-strands-typescript-production.up.railway.app`, **healthcheck** `/api/health`, image **pinned** to the GHCR `@sha256` digest, `restartPolicyType` `ON_FAILURE`, auto-updates `minor`.
- **app vars** mirror staging's set with `OPENAI_BASE_URL` repointed at prod aimock (`https://showcase-aimock-production.up.railway.app/v1`). No real prod secret needed: the agent routes 100% to aimock and staging's `OPENAI_API_KEY` is the `sk-aim…` aimock placeholder — so nothing secret was sourced.
- deployment **SUCCESS**.

## SSOT / code changes

- `railway-envs.ts` — convert the `showcase-strands-typescript` block to the dual-env `showcase-strands` shape: add the `prod` env entry with the real instanceId, `gateValidated:true`, drop `gateIgnore`, remove the `legacyJsonCompat` prod-domain placeholder, update the leading comment.
- `railway-envs.generated.json` — regenerated (real prod instanceId/domain, `probe.prod:true`, prod healthcheck; service moves into the promote closure, tier 2).
- `railway-envs.golden.json` — regenerated to include the new prod `(service, env)` pair (intentional behavior change, not a refactor regression).
- `showcase_promote.yml` — promote dropdown regenerated to list `strands-typescript`.
- `verify-railway-image-refs.test.ts` / `redeploy-env.test.ts` — update the gateValidated/scope counts (39→40 gate targets; prod default scope 38→39) and the now-stale "staging-only" comments.

## RED → GREEN proof (live prod)

| Check | RED (before) | GREEN (after) |
|---|---|---|
| prod `/api/health` | **404** (staging 200) | **200** `{"status":"ok","integration":"strands-typescript"}` |
| prod PocketBase `health:strands-typescript` | **totalItems:0** | **present** — `status:200`, `url=…-production…/api/health` |
| `d6:strands-typescript/agentic-chat` | `errorClass=goto-error`, `backendUrl=""` | _flips on next D6 tick_ (staging: fail_count:0, 3 turns) |
| `d6:strands-typescript/prebuilt-popup` | `errorClass=goto-error`, `backendUrl=""` | _flips on next D6 tick_ (staging: fail_count:0) |
| `d6:strands-typescript/chat-css` | `errorClass=goto-error`, `backendUrl=""` | _flips on next D6 tick_ (staging: fail_count:0) |

`verify-railway-image-refs.ts` now reports **✓ 80 env-scoped instances verified**. The D6 cell flip lands on the prod harness's next hourly `d6-all-pills-e2e` tick (the harness already discovered the new prod health record); this comment will be updated with the post-flip payloads.

## Quality gates

`scripts` vitest: **2110 passing**. `emit --check`, `sync-promote-service-options --check`, `verify-railway-image-refs.ts`: all clean. oxlint: 0. tsc: changed files clean (one pre-existing unrelated error in `generate-search-index.ts` on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
