### PR TITLE
feat(drawer): CopilotDrawer host theming, mobile launcher, action icons + thread-management/tooltip fixes

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -226,7 +226,19 @@ export function CopilotChat({
   const isConnecting =
     hasExplicitThreadId && lastConnectedThreadId !== resolvedThreadId;
 
+  // Tracks the threadId the connect effect last ran for, so it can tell a real
+  // thread SWITCH from an incidental re-render (agent identity change, etc.).
+  const previousThreadIdRef = useRef<string | null>(null);
+
+  // Latest explicitness, readable from an async connect that may resolve after
+  // the user has already switched threads (see the stale-connect guard below).
+  const hasExplicitThreadIdRef = useRef(hasExplicitThreadId);
+  hasExplicitThreadIdRef.current = hasExplicitThreadId;
+
   useEffect(() => {
+    const threadChanged = previousThreadIdRef.current !== resolvedThreadId;
+    previousThreadIdRef.current = resolvedThreadId;
+
     // Non-explicit threads skip /connect, but the first runAgent still has to
     // ship the same SDK-generated threadId that the chat UI is rendering.
     agent.threadId = resolvedThreadId;
@@ -236,7 +248,18 @@ export function CopilotChat({
     // ThreadsProvider). The backend has never seen it, so /connect would
     // always 404 — skip the call. A real thread is only created once the
     // user runs the agent for the first time.
-    if (!hasExplicitThreadId) return;
+    if (!hasExplicitThreadId) {
+      // Switching to a fresh, non-backend thread (e.g. startNewThread / the
+      // drawer's "+ New"): there are no messages to /connect for, so drop any
+      // messages carried over from the previously-viewed thread and fall back
+      // to the welcome screen. Guard on an actual threadId change so re-renders
+      // of the current thread (including its first run) never wipe an
+      // in-progress conversation.
+      if (threadChanged && agent.messages.length > 0) {
+        agent.setMessages([]);
+      }
+      return;
+    }
 
     let detached = false;
 
@@ -276,6 +299,14 @@ export function CopilotChat({
           raf(() => {
             if (!detached) setLastConnectedThreadId(resolvedThreadId);
           });
+        } else if (!hasExplicitThreadIdRef.current) {
+          // This connect was superseded (the user switched away while it was
+          // still loading). If the now-current thread is a fresh non-explicit
+          // one (e.g. the drawer's "+ New"), any snapshot this connect managed
+          // to apply is stale — clear it so the welcome screen shows instead of
+          // the abandoned thread's messages. A switch to ANOTHER explicit thread
+          // is left alone: that thread's own connect owns the message reset.
+          agentToConnect.setMessages([]);
         }
       }
     };

--- a/packages/react-core/src/v2/components/chat/CopilotDrawer.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotDrawer.tsx
@@ -193,11 +193,20 @@ export function CopilotDrawer({
   // license is configured, so it cannot by itself detect the no-license case.
   // We therefore also require a positive license-present signal from the
   // runtime-reported status. Only a "valid" or "expiring" license is treated
-  // as present; null/"none"/"unknown" (no/indeterminate license) and
-  // "expired"/"invalid" all gate the drawer to the upsell.
+  // as present; a resolved "none"/"expired"/"invalid" status gates the drawer
+  // to the upsell.
   const licensePresent = status === "valid" || status === "expiring";
   const featureLicensed = checkFeature("threads");
   const licensed = licensePresent && featureLicensed;
+
+  // The runtime reports license status asynchronously: `status` is null until
+  // the first /info response lands. Treat that pending window as "not yet
+  // unlicensed" — show the loading state, never the upsell — so a licensed
+  // drawer doesn't flash the upgrade CTA before its license resolves (and never
+  // strands the CTA on screen when the status is slow or fails to arrive). Only
+  // a RESOLVED-negative status (`none`/`expired`/`invalid`, or a present license
+  // missing the `threads` feature) surfaces the upsell.
+  const licensePending = status === null;
 
   const resolvedAgentId = agentId ?? configuration?.agentId ?? "default";
   const activeThreadId = configuration?.threadId ?? null;
@@ -477,13 +486,18 @@ export function CopilotDrawer({
   useEffect(() => {
     const el = elementRef.current;
     if (!el) return;
-    el.loading = isLoading;
+    // While the license is still resolving, force the loading state so the
+    // element shows its spinner instead of an empty/unlicensed body.
+    el.loading = isLoading || licensePending;
     // Only genuine list-load/mutation errors reach the end user. Developer/
     // config errors (missing runtime URL, runtime without thread endpoints) are
     // excluded via `listError` so they never leak into the drawer's error UI.
     el.error = listError ? listError.message : null;
     el.activeThreadId = activeThreadId;
-    el.licensed = licensed;
+    // Pending counts as licensed for rendering: `_renderBody` shows the upsell
+    // only when `licensed` is false, so keeping it true until the status
+    // resolves prevents the upsell from flashing (or sticking) mid-resolution.
+    el.licensed = licensed || licensePending;
     el.hasMore = hasMoreThreads;
     el.fetchingMore = isFetchingMoreThreads;
   }, [
@@ -491,6 +505,7 @@ export function CopilotDrawer({
     listError,
     activeThreadId,
     licensed,
+    licensePending,
     hasMoreThreads,
     isFetchingMoreThreads,
     mounted,

--- a/packages/react-core/src/v2/components/chat/CopilotModalHeader.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotModalHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
 import { cn } from "../../lib/utils";
 import {
@@ -38,6 +38,30 @@ export type CopilotModalHeaderProps = Omit<
   children?: (props: HeaderChildrenPayload) => React.ReactNode;
 };
 
+/**
+ * Reactively tracks whether the viewport is in the mobile range (≤767px) — the
+ * same breakpoint the drawer + chat coordination use. SSR-safe: starts `false`
+ * (desktop) so the server render and first client render agree, then syncs on
+ * mount and on resize.
+ */
+function useIsMobileViewport(): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return;
+    }
+    const mql = window.matchMedia("(max-width: 767px)");
+    const update = () => setIsMobile(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
+  return isMobile;
+}
+
 export function CopilotModalHeader({
   title,
   titleContent,
@@ -55,9 +79,14 @@ export function CopilotModalHeader({
   const resolvedTitle = title ?? fallbackTitle;
 
   // The thread-list launcher renders ONLY when a <CopilotDrawer> wrapper has
-  // registered with the chat configuration. Chats with no drawer get no
-  // launcher and no behavior change.
-  const drawerRegistered = configuration?.drawerRegistered ?? false;
+  // registered with the chat configuration AND the viewport is mobile. On
+  // desktop the drawer is an in-flow, persistent panel (it ignores `open`), so
+  // an "open the drawer" launcher there is a dead no-op — it only does anything
+  // for the mobile off-canvas drawer. Chats with no drawer get no launcher and
+  // no behavior change.
+  const isMobile = useIsMobileViewport();
+  const drawerRegistered =
+    (configuration?.drawerRegistered ?? false) && isMobile;
 
   const handleClose = useCallback(() => {
     configuration?.setModalOpen?.(false);

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.absentThreadConnect.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.absentThreadConnect.test.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { EMPTY, Observable } from "rxjs";
 import { z } from "zod";
 import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
@@ -179,5 +185,46 @@ describe("CopilotChat avoids /connect for locally-generated threadIds (ENT-314)"
           message.content === "Frontend tool finished for X.",
       ),
     ).toBe(true);
+  });
+
+  it("clears messages when switching to a fresh non-explicit thread ('+ New')", async () => {
+    // Switching to an existing thread replaces messages via /connect, but a
+    // fresh non-explicit thread skips /connect — so the previously-viewed
+    // thread's messages must be cleared explicitly, or "+ New" leaves the old
+    // conversation on screen instead of the welcome view.
+    const agent = new MockStepwiseAgent();
+
+    const { rerender } = render(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <CopilotChatConfigurationProvider
+          threadId="thread-A"
+          hasExplicitThreadId={false}
+        >
+          <CopilotChat welcomeScreen={false} />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    // Simulate an in-progress conversation on the current (non-explicit) thread.
+    act(() => {
+      agent.setMessages([
+        { id: "m1", role: "assistant", content: "hi" } as never,
+      ]);
+    });
+    expect(agent.messages.length).toBe(1);
+
+    // "+ New" mints a different non-explicit threadId.
+    rerender(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <CopilotChatConfigurationProvider
+          threadId="thread-B"
+          hasExplicitThreadId={false}
+        >
+          <CopilotChat welcomeScreen={false} />
+        </CopilotChatConfigurationProvider>
+      </CopilotKitProvider>,
+    );
+
+    await waitFor(() => expect(agent.messages.length).toBe(0));
   });
 });

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotDrawer.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotDrawer.test.tsx
@@ -501,6 +501,26 @@ test("licensed drawer enables the thread fetch (enabled=true)", async () => {
   expect(lastInput.enabled).toBe(true);
 });
 
+test("pending license (status null) shows loading, never the upsell", async () => {
+  // Before the runtime reports a license, `status` is null. The drawer must NOT
+  // flash (or strand) the upsell during this window: it renders as licensed
+  // (so `_renderBody` skips the upsell) with loading forced on, and holds the
+  // fetch until the status resolves.
+  licenseMock.mockReturnValue({
+    status: null,
+    license: null,
+    checkFeature: () => true,
+    getLimit: () => null,
+  });
+
+  await renderDrawer();
+
+  expect(getElement().licensed).toBe(true);
+  expect(getElement().loading).toBe(true);
+  const lastInput = useThreadsMock.mock.calls.at(-1)?.[0] as UseThreadsInput;
+  expect(lastInput.enabled).toBe(false);
+});
+
 test('projects per-row content into slot="row:{id}" when renderRow is provided', async () => {
   await renderDrawer({
     renderRow: (thread) => <span data-row={thread.id}>{thread.name}</span>,

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotModalHeader.drawerLauncher.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotModalHeader.drawerLauncher.test.tsx
@@ -1,11 +1,29 @@
 import React from "react";
 import { render, screen, fireEvent, act } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { CopilotModalHeader } from "../CopilotModalHeader";
 import {
   CopilotChatConfigurationProvider,
   useCopilotChatConfiguration,
 } from "../../../providers/CopilotChatConfigurationProvider";
+
+/**
+ * The in-header launcher is mobile-only (on desktop the drawer is a persistent
+ * in-flow panel, so an "open the drawer" launcher there would be a dead no-op).
+ * Stub matchMedia so these tests run in a deterministic viewport.
+ */
+function mockViewport(isMobile: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: isMobile,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
 
 /**
  * Registers a drawer on mount so the header launcher's presence gate is
@@ -24,6 +42,26 @@ function DrawerStateProbe() {
 }
 
 describe("CopilotModalHeader drawer launcher", () => {
+  const originalMatchMedia = window.matchMedia;
+  // Default to a mobile viewport so the launcher's presence tests below hold;
+  // the desktop case is asserted explicitly.
+  beforeEach(() => mockViewport(true));
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it("does NOT render the launcher on desktop even when a drawer is registered", () => {
+    mockViewport(false);
+    render(
+      <CopilotChatConfigurationProvider threadId="t">
+        <DrawerRegistrar />
+        <CopilotModalHeader title="Chat" />
+      </CopilotChatConfigurationProvider>,
+    );
+
+    expect(screen.queryByTestId("copilot-drawer-launcher")).toBeNull();
+  });
+
   it("does NOT render the launcher when no drawer is registered", () => {
     render(
       <CopilotChatConfigurationProvider threadId="t">

--- a/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
@@ -194,11 +194,21 @@ export const CopilotChatConfigurationProvider: React.FC<
 
   const resolvedAgentId = agentId ?? parentConfig?.agentId ?? DEFAULT_AGENT_ID;
 
-  // Whether this provider's threadId is controlled by the consumer (supplied
-  // via the `threadId` prop). Mirrors the top-level `<CopilotKit>` provider's
-  // `props.threadId` guard: when controlled, the imperative active-thread
-  // setters below must not override the prop-driven value.
-  const isThreadIdControlled = threadId !== undefined;
+  // A threadId prop is "authoritative" (caller-chosen) only when it is present
+  // AND not explicitly flagged non-explicit. The v1 `<CopilotKit>` bridge pipes
+  // an auto-minted UUID through as `threadId` with `hasExplicitThreadId={false}`
+  // to SEED the thread without claiming the caller picked it; that seed must
+  // stay overridable so imperative callers (e.g. `<CopilotDrawer>` selecting a
+  // row, or `startNewThread`) can switch threads. A bare `threadId` prop (no
+  // `hasExplicitThreadId`) is still treated as a caller choice.
+  const threadIdPropIsAuthoritative =
+    threadId !== undefined && hasExplicitThreadId !== false;
+
+  // Whether this provider's threadId is controlled by the consumer. When
+  // controlled, the imperative active-thread setters below must not override
+  // the prop-driven value. A non-authoritative seed (v1 bridge auto-mint) is
+  // NOT controlled, so imperative selection still works underneath it.
+  const isThreadIdControlled = threadIdPropIsAuthoritative;
 
   // Imperative active-thread override owned by the TOP-MOST provider (the one
   // with no parent). A non-null override takes precedence over the auto-minted
@@ -211,28 +221,38 @@ export const CopilotChatConfigurationProvider: React.FC<
   } | null>(null);
 
   const resolvedThreadId = useMemo(() => {
-    if (threadId) {
-      return threadId;
+    // An authoritative (caller-chosen) threadId prop always wins.
+    if (threadIdPropIsAuthoritative) {
+      return threadId as string;
+    }
+    // Otherwise an imperative override (a picked row or freshly-started thread)
+    // beats both a non-authoritative seed (the v1 bridge's auto-minted UUID) and
+    // the thread inherited from a parent provider.
+    if (activeThreadOverride) {
+      return activeThreadOverride.threadId;
     }
     if (parentConfig?.threadId) {
       return parentConfig.threadId;
     }
-    if (activeThreadOverride) {
-      return activeThreadOverride.threadId;
+    if (threadId) {
+      return threadId;
     }
     return randomUUID();
-  }, [threadId, parentConfig?.threadId, activeThreadOverride]);
+  }, [
+    threadIdPropIsAuthoritative,
+    threadId,
+    parentConfig?.threadId,
+    activeThreadOverride,
+  ]);
 
-  // If a caller passed `hasExplicitThreadId`, trust it verbatim (lets the v1
-  // bridge mark an auto-minted UUID as non-explicit). Otherwise: a threadId
-  // supplied as a prop here is by definition a caller choice; an imperative
-  // override carries its own explicitness.
-  const ownHasExplicitThreadId =
-    hasExplicitThreadId !== undefined
-      ? hasExplicitThreadId
-      : threadId
-        ? true
-        : (activeThreadOverride?.explicit ?? false);
+  // Explicitness of this provider's own thread, mirroring the resolution order
+  // above: an authoritative prop is a caller choice; otherwise an imperative
+  // override carries its own explicitness (a picked row is explicit, a fresh
+  // `startNewThread` is not); failing both, fall back to the (non-authoritative)
+  // prop flag, which is `false` for the v1 bridge seed.
+  const ownHasExplicitThreadId = threadIdPropIsAuthoritative
+    ? true
+    : (activeThreadOverride?.explicit ?? hasExplicitThreadId ?? false);
   const resolvedHasExplicitThreadId =
     ownHasExplicitThreadId || !!parentConfig?.hasExplicitThreadId;
 

--- a/packages/react-core/src/v2/providers/__tests__/CopilotChatConfigurationProvider.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotChatConfigurationProvider.test.tsx
@@ -758,6 +758,72 @@ describe("CopilotChatConfigurationProvider", () => {
       warn.mockRestore();
     });
 
+    it("v1 bridge seed: setActiveThreadId overrides a non-explicit threadId prop (no warn)", () => {
+      // The v1 <CopilotKit> bridge seeds `threadId` with hasExplicitThreadId=
+      // {false}. That seed must NOT count as controlled — imperative selection
+      // (<CopilotDrawer> picking a row) has to win, or thread switching is dead
+      // in every app wrapped in <CopilotKit>.
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      render(
+        <CopilotChatConfigurationProvider
+          threadId="auto-minted-seed"
+          hasExplicitThreadId={false}
+        >
+          <ThreadProbe />
+        </CopilotChatConfigurationProvider>,
+      );
+
+      expect(screen.getByTestId("probe-thread").textContent).toBe(
+        "auto-minted-seed",
+      );
+
+      act(() => {
+        fireEvent.click(screen.getByTestId("probe-select"));
+      });
+
+      expect(screen.getByTestId("probe-thread").textContent).toBe(
+        "picked-thread",
+      );
+      expect(screen.getByTestId("probe-explicit").textContent).toBe("true");
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
+    it("v1 bridge stack: a set from an uncontrolled child under a non-explicit seed parent switches the thread", () => {
+      // Mirrors the real tree: <CopilotKit> seeds a non-explicit threadId on its
+      // own provider, then the app nests an uncontrolled provider that the
+      // drawer + chat share. A set proxied up from the child must override the
+      // seed (this is exactly the langgraph-js de-fork case).
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      render(
+        <CopilotChatConfigurationProvider
+          threadId="auto-minted-seed"
+          hasExplicitThreadId={false}
+        >
+          <CopilotChatConfigurationProvider>
+            <ThreadProbe id="inner" />
+          </CopilotChatConfigurationProvider>
+        </CopilotChatConfigurationProvider>,
+      );
+
+      expect(screen.getByTestId("inner-thread").textContent).toBe(
+        "auto-minted-seed",
+      );
+
+      act(() => {
+        fireEvent.click(screen.getByTestId("inner-select"));
+      });
+
+      expect(screen.getByTestId("inner-thread").textContent).toBe(
+        "picked-thread",
+      );
+      expect(screen.getByTestId("inner-explicit").textContent).toBe("true");
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
     it("nested controlled guard: a set from inside a controlled NESTED provider no-ops + warns (uncontrolled top-most)", () => {
       // Top-most is uncontrolled; the NESTED provider pins the thread via its
       // own `threadId` prop. The guard must consult the nearest pinning

--- a/packages/web-components/src/drawer/__tests__/copilotkit-drawer.test.ts
+++ b/packages/web-components/src/drawer/__tests__/copilotkit-drawer.test.ts
@@ -136,6 +136,47 @@ test("a named row carries the full name as a data-tooltip (CPK bubble; shown whe
   teardown();
 });
 
+test("a clipped name marks BOTH the row-name and the owning row (tooltip + z-index stacking contract)", async () => {
+  const longName = "A very long thread name that gets clipped with an ellipsis";
+  const { element, q, teardown } = await setup({
+    threads: [makeThread({ id: "a", name: longName })],
+  });
+
+  const row = q("li.row") as HTMLElement;
+  const name = q('[part="row-name"]') as HTMLElement;
+  const text = name.querySelector(".row-name-text") as HTMLElement;
+
+  // jsdom has no layout, so simulate a truncated text node.
+  Object.defineProperty(text, "scrollWidth", {
+    value: 200,
+    configurable: true,
+  });
+  Object.defineProperty(text, "clientWidth", {
+    value: 100,
+    configurable: true,
+  });
+  (element as unknown as { _syncNameClipping(): void })._syncNameClipping();
+
+  // The tooltip bubble keys off `.row-name.name-clipped`; the z-index lift that
+  // frees the bubble from the row's transform stacking context keys off
+  // `.row.name-clipped`. BOTH elements must carry the flag — if it only landed
+  // on `.row-name` (the original bug), the z-lift selector never matched and the
+  // tooltip stayed trapped under later rows.
+  expect(name.classList.contains("name-clipped")).toBe(true);
+  expect(row.classList.contains("name-clipped")).toBe(true);
+
+  // And it clears on both when the name fits (no stale bubble / z-lift).
+  Object.defineProperty(text, "scrollWidth", {
+    value: 100,
+    configurable: true,
+  });
+  (element as unknown as { _syncNameClipping(): void })._syncNameClipping();
+  expect(name.classList.contains("name-clipped")).toBe(false);
+  expect(row.classList.contains("name-clipped")).toBe(false);
+
+  teardown();
+});
+
 test("a placeholder (unnamed) row has no name tooltip", async () => {
   const { q, teardown } = await setup({
     threads: [makeThread({ id: "a", name: null })],

--- a/packages/web-components/src/drawer/__tests__/copilotkit-drawer.test.ts
+++ b/packages/web-components/src/drawer/__tests__/copilotkit-drawer.test.ts
@@ -247,6 +247,26 @@ test("confirm dialog can be cancelled without emitting delete", async () => {
   teardown();
 });
 
+test("opening the confirm dialog marks the root `confirming` so row-action tooltips are suppressed", async () => {
+  const { q, element, teardown } = await setup({
+    threads: [makeThread({ id: "del", name: "Delete me" })],
+  });
+
+  const root = () => q('[part="root"]') as HTMLElement;
+  expect(root().classList.contains("confirming")).toBe(false);
+
+  (q('[part="row-delete"]') as HTMLElement).click();
+  await flush(element);
+  // While the dialog is open the clicked trash button keeps :focus-visible; the
+  // `confirming` class is what hides its lingering "Delete" tooltip via CSS.
+  expect(root().classList.contains("confirming")).toBe(true);
+
+  (q('[part="confirm-cancel"]') as HTMLElement).click();
+  await flush(element);
+  expect(root().classList.contains("confirming")).toBe(false);
+  teardown();
+});
+
 test("loading state renders while loading", async () => {
   const { element, q, teardown } = await setup({ threads: [] });
   element.loading = true;

--- a/packages/web-components/src/drawer/__tests__/copilotkit-drawer.test.ts
+++ b/packages/web-components/src/drawer/__tests__/copilotkit-drawer.test.ts
@@ -783,3 +783,90 @@ test("a safe thread id still emits its row slot for projection", async () => {
   expect(q('slot[name="row:safe-id_123"]')).not.toBeNull();
   teardown();
 });
+
+test("row actions render icons (not text) with instant tooltips", async () => {
+  const { q, teardown } = await setup({
+    threads: [makeThread({ id: "a", name: "A", archived: false })],
+  });
+
+  const archive = q('[part="row-archive"]') as HTMLElement;
+  const del = q('[part="row-delete"]') as HTMLElement;
+
+  expect(archive.querySelector("svg.row-action-icon")).not.toBeNull();
+  expect(del.querySelector("svg.row-action-icon")).not.toBeNull();
+  // tooltip carried on a data attribute (CSS instant tooltip), NOT native title
+  expect(archive.getAttribute("data-tooltip")).toBe("Archive");
+  expect(del.getAttribute("data-tooltip")).toBe("Delete");
+  expect(archive.hasAttribute("title")).toBe(false);
+  teardown();
+});
+
+test("archived rows are muted, not struck through", async () => {
+  const { q, element, teardown } = await setup({
+    threads: [makeThread({ id: "a", name: "A", archived: true })],
+  });
+  (q('[part="filter-all"]') as HTMLElement).click();
+  await flush(element);
+
+  const name = q(".row.archived .row-name") as HTMLElement;
+  expect(name).not.toBeNull();
+  expect(getComputedStyle(name).textDecorationLine).not.toContain(
+    "line-through",
+  );
+  teardown();
+});
+
+test("a refetch keeps the known list visible instead of flashing loading", async () => {
+  const { q, qa, element, teardown } = await setup({
+    threads: [makeThread({ id: "a", name: "A" })],
+  });
+
+  // loading goes true during a refetch while threads are already known
+  element.loading = true;
+  await flush(element);
+
+  expect(q('[data-testid="drawer-loading"]')).toBeNull();
+  expect(qa("li.row")).toHaveLength(1);
+  teardown();
+});
+
+test("the footer region stays hidden when nothing is slotted into it", async () => {
+  const { q, teardown } = await setup({ threads: [makeThread()] });
+
+  const footer = q('[part="footer"]') as HTMLElement;
+  expect(footer).not.toBeNull();
+  expect(footer.hasAttribute("hidden")).toBe(true);
+  teardown();
+});
+
+test("mobile renders a self-owned launcher that opens the drawer", async () => {
+  const { q, element, teardown } = await setup({
+    mobile: true,
+    threads: [makeThread()],
+  });
+  // start closed so the launcher (open-affordance) shows
+  element.open = false;
+  await flush(element);
+
+  const launcher = q('[part="launcher"]') as HTMLElement;
+  expect(launcher).not.toBeNull();
+  // icon is swappable via a named slot (CPK slot convention)
+  expect(launcher.querySelector('slot[name="launcher-icon"]')).not.toBeNull();
+
+  launcher.click();
+  await flush(element);
+  expect(element.open).toBe(true);
+  teardown();
+});
+
+test("desktop does NOT render the mobile launcher", async () => {
+  const { q, element, teardown } = await setup({
+    mobile: false,
+    threads: [makeThread()],
+  });
+  element.open = false;
+  await flush(element);
+
+  expect(q('[part="launcher"]')).toBeNull();
+  teardown();
+});

--- a/packages/web-components/src/drawer/__tests__/copilotkit-drawer.test.ts
+++ b/packages/web-components/src/drawer/__tests__/copilotkit-drawer.test.ts
@@ -122,6 +122,31 @@ test("renders a row per visible thread into the shadow root", async () => {
   teardown();
 });
 
+test("a named row carries the full name as a data-tooltip (CPK bubble; shown when clipped)", async () => {
+  const longName = "A very long thread name that gets clipped with an ellipsis";
+  const { q, teardown } = await setup({
+    threads: [makeThread({ id: "a", name: longName })],
+  });
+
+  // The full name rides on the row-name as data-tooltip (the same instant-bubble
+  // mechanism as the row actions); CSS reveals it only when `.name-clipped`.
+  const name = q('[part="row-name"]') as HTMLElement;
+  expect(name.getAttribute("data-tooltip")).toBe(longName);
+  expect(name.querySelector(".row-name-text")?.textContent).toBe(longName);
+  teardown();
+});
+
+test("a placeholder (unnamed) row has no name tooltip", async () => {
+  const { q, teardown } = await setup({
+    threads: [makeThread({ id: "a", name: null })],
+  });
+
+  const name = q('[part="row-name"]') as HTMLElement;
+  expect(name.classList.contains("placeholder")).toBe(true);
+  expect(name.hasAttribute("data-tooltip")).toBe(false);
+  teardown();
+});
+
 test("emits thread-selected with the thread id on row click", async () => {
   const { q, events, teardown } = await setup({
     threads: [makeThread({ id: "abc", name: "Pick me" })],

--- a/packages/web-components/src/drawer/copilotkit-drawer.ts
+++ b/packages/web-components/src/drawer/copilotkit-drawer.ts
@@ -282,6 +282,23 @@ export class CopilotKitDrawer extends LitElement {
     if (this._justRevealed.size > 0) {
       this._justRevealed = new Set<string>();
     }
+
+    this._syncNameClipping();
+  }
+
+  /**
+   * Marks each row whose name text is truncated with `name-clipped`, so the CSS
+   * shows the name tooltip ONLY when the full name isn't already visible (an
+   * always-on bubble over every row on hover would be noise). Measured after
+   * render because truncation depends on the laid-out width.
+   */
+  private _syncNameClipping(): void {
+    const names = this.renderRoot.querySelectorAll<HTMLElement>(".row-name");
+    names.forEach((name) => {
+      const text = name.querySelector<HTMLElement>(".row-name-text");
+      const clipped = !!text && text.scrollWidth > text.clientWidth;
+      name.classList.toggle("name-clipped", clipped);
+    });
   }
 
   // --- View-state helpers ----------------------------------------------------
@@ -610,11 +627,21 @@ export class CopilotKitDrawer extends LitElement {
       revealed: justRevealed,
     };
     const slotName = rowSlotName(thread.id);
+    // A long thread name is clipped with an ellipsis. The full name is exposed
+    // via a tooltip styled to match the row-action tooltips (an instant primary
+    // bubble, NOT the native `title`), shown only when the name is actually
+    // truncated (`name-clipped`, toggled in `_syncNameClipping`). The name text
+    // lives in an inner span that owns the ellipsis, so the outer `.row-name`
+    // can host the tooltip pseudo-element without its own `overflow: hidden`
+    // clipping it.
     const nameSpan = html`<span
       class=${classMap(nameClasses)}
       part="row-name"
+      data-tooltip=${hasName ? thread.name : nothing}
     >
-      ${hasName ? thread.name : "New thread"}
+      <span class="row-name-text"
+        >${hasName ? thread.name : "New thread"}</span
+      >
     </span>`;
 
     return html`

--- a/packages/web-components/src/drawer/copilotkit-drawer.ts
+++ b/packages/web-components/src/drawer/copilotkit-drawer.ts
@@ -36,6 +36,82 @@ function rowSlotName(id: string): string | null {
 }
 
 /**
+ * Inline row-action icons. The element is framework-agnostic Lit, so it cannot
+ * depend on a React icon library — these are the lucide `archive`,
+ * `archive-restore`, and `trash-2` glyphs inlined as SVG, drawn with
+ * `currentColor` so they inherit the button's themed color.
+ */
+const iconArchive = html`
+  <svg
+    class="row-action-icon"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <rect width="20" height="5" x="2" y="3" rx="1" />
+    <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
+    <path d="M10 12h4" />
+  </svg>
+`;
+const iconUnarchive = html`
+  <svg
+    class="row-action-icon"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <rect width="20" height="5" x="2" y="3" rx="1" />
+    <path d="M4 8v11a2 2 0 0 0 2 2h2" />
+    <path d="M20 8v11a2 2 0 0 1-2 2h-2" />
+    <path d="m9 15 3-3 3 3" />
+    <path d="M12 12v9" />
+  </svg>
+`;
+const iconDelete = html`
+  <svg
+    class="row-action-icon"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M3 6h18" />
+    <path
+      d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
+    />
+    <line x1="10" x2="10" y1="11" y2="17" />
+    <line x1="14" x2="14" y1="11" y2="17" />
+  </svg>
+`;
+const iconLauncher = html`
+  <svg
+    class="launcher-icon"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <rect width="18" height="18" x="3" y="3" rx="2" />
+    <path d="M9 3v18" />
+    <path d="m14 9 3 3-3 3" />
+  </svg>
+`;
+
+/**
  * `<copilotkit-drawer>` — a public, self-contained, controlled, framework-agnostic
  * threads drawer rendered into a shadow root.
  *
@@ -69,6 +145,7 @@ export class CopilotKitDrawer extends LitElement {
     _confirmingDeleteId: { state: true },
     _viewportIsMobile: { state: true },
     _hasMemories: { state: true },
+    _hasFooter: { state: true },
   };
 
   /** Inbound: thread records to render. The element re-orders/filters them. */
@@ -97,6 +174,7 @@ export class CopilotKitDrawer extends LitElement {
   private _confirmingDeleteId: string | null = null;
   private _viewportIsMobile = false;
   private _hasMemories = false;
+  private _hasFooter = false;
 
   private _mediaQuery: MediaQueryList | null = null;
   private readonly _onMediaChange = (event: MediaQueryListEvent) => {
@@ -353,6 +431,22 @@ export class CopilotKitDrawer extends LitElement {
 
     return html`
       ${
+        // Mobile open-affordance: when the drawer is a closed off-canvas modal,
+        // render its own floating launcher so there is always a way to open it
+        // on phones WITHOUT the host wiring a header button. Desktop (persistent
+        // sidebar) and the open state never show it.
+        this._viewportIsMobile && !this.open
+          ? html`<button
+            class="launcher"
+            part="launcher"
+            aria-label="Open threads"
+            @click=${() => this._setOpen(true)}
+          >
+            <slot name="launcher-icon">${iconLauncher}</slot>
+          </button>`
+          : nothing
+      }
+      ${
         this._isMobileModalOpen()
           ? html`<button
             class="backdrop"
@@ -428,7 +522,11 @@ export class CopilotKitDrawer extends LitElement {
     if (hasErrorMessage(this.error) && this.threads.length === 0) {
       return this._renderError();
     }
-    if (this.loading) return this._renderLoading();
+    // Full-panel loading only when there is nothing to show yet (initial fetch).
+    // A refetch (e.g. filter toggle Active<->All) keeps `loading` true while the
+    // list is already populated — keep showing the known threads rather than
+    // flashing the loading state over them.
+    if (this.loading && this.threads.length === 0) return this._renderLoading();
     return this._renderList();
   }
 
@@ -542,36 +640,39 @@ export class CopilotKitDrawer extends LitElement {
             ? html`<button
               class="row-action"
               part="row-unarchive"
+              data-tooltip="Unarchive"
               aria-label=${`Unarchive thread ${thread.name ?? "New thread"}`}
               @click=${(e: Event) => {
                 e.stopPropagation();
                 this._emit("unarchive", { threadId: thread.id });
               }}
             >
-              Unarchive
+              ${iconUnarchive}
             </button>`
             : html`<button
               class="row-action"
               part="row-archive"
+              data-tooltip="Archive"
               aria-label=${`Archive thread ${thread.name ?? "New thread"}`}
               @click=${(e: Event) => {
                 e.stopPropagation();
                 this._emit("archive", { threadId: thread.id });
               }}
             >
-              Archive
+              ${iconArchive}
             </button>`
         }
         <button
           class="row-action danger"
           part="row-delete"
+          data-tooltip="Delete"
           aria-label=${`Delete thread ${thread.name ?? "New thread"}`}
           @click=${(e: Event) => {
             e.stopPropagation();
             this._confirmingDeleteId = thread.id;
           }}
         >
-          Delete
+          ${iconDelete}
         </button>
       </li>
     `;
@@ -618,9 +719,18 @@ export class CopilotKitDrawer extends LitElement {
   }
 
   private _renderFooter() {
+    // Reserved region — hidden until a consumer projects content into the
+    // `footer` slot. Without this gate the footer's top border + padding render
+    // as an empty box at the bottom of the drawer. Mirrors `_renderMemories`.
     return html`
-      <div class="footer" part="footer">
-        <slot name="footer"></slot>
+      <div class="footer" part="footer" ?hidden=${!this._hasFooter}>
+        <slot
+          name="footer"
+          @slotchange=${(e: Event) => {
+            const slot = e.target as HTMLSlotElement;
+            this._hasFooter = slot.assignedElements().length > 0;
+          }}
+        ></slot>
       </div>
     `;
   }

--- a/packages/web-components/src/drawer/copilotkit-drawer.ts
+++ b/packages/web-components/src/drawer/copilotkit-drawer.ts
@@ -427,6 +427,9 @@ export class CopilotKitDrawer extends LitElement {
       collapsed: this.collapsed && !this._viewportIsMobile,
       mobile: this._viewportIsMobile,
       open: this.open,
+      // Suppresses row-action tooltips while the confirm dialog is open (the
+      // clicked trash button keeps :focus-visible/:hover otherwise).
+      confirming: this._confirmingDeleteId !== null,
     };
 
     return html`

--- a/packages/web-components/src/drawer/copilotkit-drawer.ts
+++ b/packages/web-components/src/drawer/copilotkit-drawer.ts
@@ -1,4 +1,5 @@
-import { LitElement, html, nothing, type PropertyValues } from "lit";
+import { LitElement, html, nothing } from "lit";
+import type { PropertyValues } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import { classMap } from "lit/directives/class-map.js";
 import { drawerStyles } from "./styles";
@@ -298,6 +299,15 @@ export class CopilotKitDrawer extends LitElement {
       const text = name.querySelector<HTMLElement>(".row-name-text");
       const clipped = !!text && text.scrollWidth > text.clientWidth;
       name.classList.toggle("name-clipped", clipped);
+      // The z-index lift in styles.ts (`.row.name-clipped:hover`) targets the
+      // `.row` stacking context — each row creates its own via `transform`, so a
+      // tooltip anchored on `.row-name` is trapped inside it and paints under
+      // later rows unless the row itself is re-floated. Stamp the flag on the
+      // owning row too so that rule matches; the tooltip bubble stays scoped to
+      // `.row-name:hover`, so hovering a row-action never surfaces it.
+      name
+        .closest<HTMLElement>(".row")
+        ?.classList.toggle("name-clipped", clipped);
     });
   }
 

--- a/packages/web-components/src/drawer/styles.ts
+++ b/packages/web-components/src/drawer/styles.ts
@@ -39,21 +39,40 @@ export const drawerStyles = css`
       var(--cpk-drawer-font-family, ui-sans-serif, system-ui, sans-serif);
     font-size: var(--cpk-drawer-font-size, 14px);
     line-height: var(--cpk-drawer-line-height, 1.4);
-    color: var(--cpk-drawer-fg, ${tok(T.fg)});
+    color: var(--cpk-drawer-fg, var(--foreground, ${tok(T.fg)}));
 
-    --_bg: var(--cpk-drawer-bg, ${tok(T.bg)});
-    --_surface: var(--cpk-drawer-surface, ${tok(T.surface)});
-    --_surface-fg: var(--cpk-drawer-surface-fg, ${tok(T["surface-fg"])});
-    --_muted: var(--cpk-drawer-muted, ${tok(T.muted)});
-    --_muted-fg: var(--cpk-drawer-muted-fg, ${tok(T["muted-fg"])});
-    --_accent: var(--cpk-drawer-accent, ${tok(T.accent)});
-    --_accent-fg: var(--cpk-drawer-accent-fg, ${tok(T["accent-fg"])});
-    --_primary: var(--cpk-drawer-primary, ${tok(T.primary)});
-    --_primary-fg: var(--cpk-drawer-primary-fg, ${tok(T["primary-fg"])});
-    --_danger: var(--cpk-drawer-danger, ${tok(T.danger)});
-    --_border: var(--cpk-drawer-border, ${tok(T.border)});
-    --_ring: var(--cpk-drawer-ring, ${tok(T.ring)});
-    --_radius: var(--cpk-drawer-radius, ${tok(T.radius)});
+    /* Three-level token resolution, highest priority first:
+       1. explicit per-token override (--cpk-drawer-*),
+       2. the host app's theme variable (--background/--card/… — the standard
+          react-core/shadcn names), so the drawer follows the host's light/dark
+          theme by inheritance (custom properties are NOT reset by all:initial),
+       3. the built-in light default derived from react-core at build time, so a
+          host with no theme still renders correctly (self-contained). */
+    --_bg: var(--cpk-drawer-bg, var(--background, ${tok(T.bg)}));
+    --_surface: var(--cpk-drawer-surface, var(--card, ${tok(T.surface)}));
+    --_surface-fg: var(
+      --cpk-drawer-surface-fg,
+      var(--card-foreground, ${tok(T["surface-fg"])})
+    );
+    --_muted: var(--cpk-drawer-muted, var(--muted, ${tok(T.muted)}));
+    --_muted-fg: var(
+      --cpk-drawer-muted-fg,
+      var(--muted-foreground, ${tok(T["muted-fg"])})
+    );
+    --_accent: var(--cpk-drawer-accent, var(--accent, ${tok(T.accent)}));
+    --_accent-fg: var(
+      --cpk-drawer-accent-fg,
+      var(--accent-foreground, ${tok(T["accent-fg"])})
+    );
+    --_primary: var(--cpk-drawer-primary, var(--primary, ${tok(T.primary)}));
+    --_primary-fg: var(
+      --cpk-drawer-primary-fg,
+      var(--primary-foreground, ${tok(T["primary-fg"])})
+    );
+    --_danger: var(--cpk-drawer-danger, var(--destructive, ${tok(T.danger)}));
+    --_border: var(--cpk-drawer-border, var(--border, ${tok(T.border)}));
+    --_ring: var(--cpk-drawer-ring, var(--ring, ${tok(T.ring)}));
+    --_radius: var(--cpk-drawer-radius, var(--radius, ${tok(T.radius)}));
     --_width: var(--cpk-drawer-width, 320px);
     --_rail-width: var(--cpk-drawer-rail-width, 56px);
   }
@@ -107,6 +126,34 @@ export const drawerStyles = css`
     cursor: pointer;
   }
 
+  /* Mobile-only floating affordance to OPEN the off-canvas drawer. Rendered by
+     the element itself so phones always have a way in with no host wiring. */
+  .launcher {
+    position: fixed;
+    z-index: 998;
+    /* Position is themeable so a host can line the launcher up with its own
+       header controls (e.g. vertically centering it on a toggle group). */
+    top: var(--cpk-drawer-launcher-top, 12px);
+    left: var(--cpk-drawer-launcher-left, 12px);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 999px;
+    border: 1px solid var(--_border);
+    background: var(--_surface);
+    color: var(--_surface-fg);
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgb(0 0 0 / 0.12);
+  }
+
+  .launcher-icon {
+    width: 18px;
+    height: 18px;
+    display: block;
+  }
+
   .header {
     display: flex;
     align-items: center;
@@ -142,7 +189,7 @@ export const drawerStyles = css`
   .list {
     flex: 1;
     overflow-y: auto;
-    padding: 8px;
+    padding: 8px 12px;
     margin: 0;
     list-style: none;
     display: flex;
@@ -179,7 +226,6 @@ export const drawerStyles = css`
   }
 
   .row.archived .row-name {
-    text-decoration: line-through;
     color: var(--_muted-fg);
   }
 
@@ -209,17 +255,59 @@ export const drawerStyles = css`
   }
 
   .row-action {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: none;
     border: 0;
     background: transparent;
     color: var(--_muted-fg);
     cursor: pointer;
     font: inherit;
-    padding: 2px 6px;
-    border-radius: 4px;
+    padding: 5px;
+    border-radius: 6px;
   }
 
-  .row-action.danger {
+  /* Instant tooltip (matches the react components' delayDuration:0). Rendered to
+     the LEFT of the action so the list's vertical overflow never clips it; the
+     native \`title\` tooltip is avoided because its show-delay is browser-fixed
+     (~1.5s) and cannot be tuned. */
+  .row-action[data-tooltip]:hover::after,
+  .row-action[data-tooltip]:focus-visible::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    right: calc(100% + 6px);
+    top: 50%;
+    transform: translateY(-50%);
+    white-space: nowrap;
+    background: var(--_surface);
+    color: var(--_surface-fg);
+    border: 1px solid var(--_border);
+    border-radius: 6px;
+    padding: 2px 7px;
+    font-size: 12px;
+    line-height: 1.4;
+    box-shadow: 0 2px 8px rgb(0 0 0 / 0.12);
+    pointer-events: none;
+    z-index: 20;
+  }
+
+  .row-action:hover,
+  .row-action:focus-visible {
+    background: var(--_muted);
+    color: inherit;
+  }
+
+  .row-action.danger:hover,
+  .row-action.danger:focus-visible {
     color: var(--_danger);
+  }
+
+  .row-action-icon {
+    width: 15px;
+    height: 15px;
+    display: block;
   }
 
   button.primary {
@@ -296,5 +384,9 @@ export const drawerStyles = css`
   .footer {
     border-top: 1px solid var(--_border);
     padding: 12px;
+  }
+
+  .footer[hidden] {
+    display: none;
   }
 `;

--- a/packages/web-components/src/drawer/styles.ts
+++ b/packages/web-components/src/drawer/styles.ts
@@ -269,28 +269,58 @@ export const drawerStyles = css`
     border-radius: 6px;
   }
 
-  /* Instant tooltip (matches the react components' delayDuration:0). Rendered to
-     the LEFT of the action so the list's vertical overflow never clips it; the
-     native \`title\` tooltip is avoided because its show-delay is browser-fixed
-     (~1.5s) and cannot be tuned. */
+  /* Instant tooltip (matches the react components' delayDuration:0) styled to
+     match the CPK standard tooltip: a solid primary-colored bubble with
+     primary-foreground text, rounded corners, no border, and a small arrow —
+     NOT a surface/bordered box (which reads as a button). Rendered to the LEFT
+     of the action so the list's vertical overflow never clips it; the native
+     \`title\` tooltip is avoided because its show-delay is browser-fixed (~1.5s)
+     and cannot be tuned. */
   .row-action[data-tooltip]:hover::after,
   .row-action[data-tooltip]:focus-visible::after {
     content: attr(data-tooltip);
     position: absolute;
-    right: calc(100% + 6px);
+    right: calc(100% + 8px);
     top: 50%;
     transform: translateY(-50%);
     white-space: nowrap;
-    background: var(--_surface);
-    color: var(--_surface-fg);
-    border: 1px solid var(--_border);
+    background: var(--_primary);
+    color: var(--_primary-fg);
     border-radius: 6px;
-    padding: 2px 7px;
+    padding: 4px 8px;
     font-size: 12px;
     line-height: 1.4;
-    box-shadow: 0 2px 8px rgb(0 0 0 / 0.12);
+    box-shadow: 0 4px 12px rgb(0 0 0 / 0.18);
     pointer-events: none;
     z-index: 20;
+  }
+
+  /* Arrow: a small rotated square at the bubble's right edge, pointing at the
+     action — same primary fill as the bubble. */
+  .row-action[data-tooltip]:hover::before,
+  .row-action[data-tooltip]:focus-visible::before {
+    content: "";
+    position: absolute;
+    right: calc(100% + 4.5px);
+    top: 50%;
+    transform: translateY(-50%) rotate(45deg);
+    width: 7px;
+    height: 7px;
+    background: var(--_primary);
+    border-radius: 1px;
+    pointer-events: none;
+    z-index: 21;
+  }
+
+  /* While the delete-confirmation dialog is open, suppress row-action tooltips:
+     the clicked trash button keeps :focus-visible (and may stay hovered), which
+     would otherwise leave its "Delete" tooltip floating over the dialog. */
+  .root.confirming .row-action[data-tooltip]:hover::after,
+  .root.confirming .row-action[data-tooltip]:focus-visible::after,
+  .root.confirming .row-action[data-tooltip]:hover::before,
+  .root.confirming .row-action[data-tooltip]:focus-visible::before {
+    content: none;
+    display: none;
   }
 
   .row-action:hover,

--- a/packages/web-components/src/drawer/styles.ts
+++ b/packages/web-components/src/drawer/styles.ts
@@ -210,6 +210,16 @@ export const drawerStyles = css`
     opacity: 0;
     transform: translateY(4px);
     animation: cpk-drawer-row-in 0.18s ease forwards;
+    /* Positioned so the hovered row can be lifted above later rows (below). */
+    position: relative;
+  }
+
+  /* The entry animation leaves each row with a (non-none) transform, making it
+     its own stacking context — which would paint the name tooltip UNDER the
+     following rows (their text bled through the bubble). Lifting the hovered
+     row's z-index re-floats its tooltip above the rows beneath it. */
+  .row.name-clipped:hover {
+    z-index: 2;
   }
 
   @keyframes cpk-drawer-row-in {
@@ -230,10 +240,53 @@ export const drawerStyles = css`
   }
 
   .row-name {
+    /* The outer name element owns NO overflow clip so it can host the name
+       tooltip pseudo-element; the inner .row-name-text does the ellipsis. */
     flex: 1;
+    min-width: 0;
+    position: relative;
+  }
+
+  .row-name-text {
+    display: block;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  /* Name tooltip: matches the row-action tooltip (instant primary bubble with
+     an arrow), shown ONLY when the name is clipped. Positioned below the name,
+     wrapping within the drawer width (a long name can't fit one line). */
+  .row-name.name-clipped[data-tooltip]:hover::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    left: 0;
+    top: calc(100% + 6px);
+    white-space: normal;
+    max-width: 240px;
+    background: var(--_primary);
+    color: var(--_primary-fg);
+    border-radius: 6px;
+    padding: 4px 8px;
+    font-size: 12px;
+    line-height: 1.4;
+    box-shadow: 0 4px 12px rgb(0 0 0 / 0.18);
+    pointer-events: none;
+    z-index: 20;
+  }
+
+  .row-name.name-clipped[data-tooltip]:hover::before {
+    content: "";
+    position: absolute;
+    left: 10px;
+    top: calc(100% + 1.5px);
+    transform: rotate(45deg);
+    width: 7px;
+    height: 7px;
+    background: var(--_primary);
+    border-radius: 1px;
+    pointer-events: none;
+    z-index: 21;
   }
 
   .row-name.placeholder {


### PR DESCRIPTION
## CopilotDrawer — SDK polish + thread-management fixes

Polish and fixes on top of the shipped `<copilotkit-drawer>` ([#5701](https://github.com/CopilotKit/CopilotKit/pull/5701)), surfaced by real de-fork pilots run against a locally-built SDK + the hosted Intelligence runtime: **langgraph-js** (rich canvas / inline `CopilotChat` / dark theme) and **mastra** (the proverbs CoAgents demo / `CopilotSidebar` / light theme / controlled→uncontrolled provider). Spans **`@copilotkit/web-components`** and **`@copilotkit/react-core`** — no example/de-fork changes here (those wait on a release that publishes web-components + a `react-core` bump that includes `CopilotDrawer`). Captured as Phase-5 acceptance requirements in the [design doc](https://app.notion.com/p/3883aa3818528190b5d1f9b6ba26dca0).

### `react-core` — thread management
- **Thread switching works under `<CopilotKit>`.** `CopilotChatConfigurationProvider` treated any `threadId` prop as controlled, so the auto-minted, non-explicit threadId that `<CopilotKit>`'s v1 bridge seeds blocked the drawer's imperative `setActiveThreadId` / `startNewThread` — thread switching and "+ New" were dead in every app wrapped in `<CopilotKit>`. A non-explicit (`hasExplicitThreadId={false}`) threadId is now overridable; a genuine caller-supplied threadId stays controlled.
- **"+ New" resets the chat.** `CopilotChat` clears messages when switching to a fresh non-explicit thread so the welcome screen shows instead of the prior thread's messages — including when a still-loading `/connect` is superseded by the switch (the aborted connect's stale snapshot is dropped instead of repopulating the view).
- **No upsell flash/stick.** `CopilotDrawer` treats a pending (`null`) license status as loading, not unlicensed, so the upgrade upsell no longer flashes (or sticks) before the runtime reports the license.
- **In-header drawer launcher is mobile-only.** `CopilotModalHeader.DrawerLauncher` toggles `drawerOpen`, which only drives the off-canvas *mobile* drawer; on desktop the drawer is a persistent in-flow panel that ignores `open`, so the launcher was a dead no-op there. It now renders only at ≤767px. On desktop the chat's own open/close (the toggle FAB + the header close, both lucide `X`) is the consistent pair.

### `web-components` — theming, launcher, icons, tooltips
- **Host-theme inheritance (incl. dark mode).** Each token now resolves `--cpk-drawer-* override → host theme var (`--background`/`--card`/`--foreground`/`--border`/…) → built-in light default`. The drawer follows the host app's light/dark theme by inheritance, instead of baking light-only values (it showed a light drawer on a dark app). Custom properties aren't reset by the `:host { all: initial }` guard, so the standalone fallback still holds.
- **Row actions are icon buttons with instant, on-brand tooltips.** Archive / Unarchive / Delete render inline lucide-style SVGs (`currentColor`). Native `title` is replaced by an instant CSS tooltip (matches the React components' Radix `delayDuration: 0`; `title`'s show-delay is browser-fixed at ~1.5s), styled to match the standard CopilotKit tooltip — a primary-colored bubble with an arrow, not a surface/bordered box — and positioned to the side so the list's scroll-overflow never clips it. The tooltip is suppressed while the delete-confirm dialog is open (the clicked trash button keeps `:focus-visible` otherwise, leaving its "Delete" tooltip floating over the dialog).
- **Clipped thread names get a tooltip.** A truncated name exposes its full text via the same instant primary-bubble tooltip as the row actions (not the native `title`), shown only when actually clipped. The name text moved to an inner span (so the outer can host the un-clipped bubble) and the hovered row is z-lifted (each row is its own stacking context from the entry-animation transform, which otherwise painted the bubble under later rows).
- **Archived rows are muted**, no longer struck through.
- **Refetch preserves the list.** A refetch (e.g. Active↔All toggle) keeps the known threads visible; the full loading state only renders on the initial empty fetch.
- **Empty `footer` region hides** (it rendered as a stray bordered box at the bottom). Driven by a `slotchange` listener, mirroring the `memories` region.
- **Self-owned mobile launcher.** When the drawer is a closed off-canvas mobile modal it renders its own floating "open threads" launcher, so it's always openable without the host wiring a header button. The icon is swappable via a `launcher-icon` **slot**, position is themeable via `--cpk-drawer-launcher-top` / `--cpk-drawer-launcher-left` (so a host can center it on its own header controls), and it exposes `part="launcher"`. The richer in-header `CopilotModalHeader.DrawerLauncher` remains an optional integration.

### Tests
- **react-core**: thread-control + non-explicit-override cases on `CopilotChatConfigurationProvider`, the "+ New" message reset on `CopilotChat`, license-pending gating on `CopilotDrawer`, and the mobile-only / desktop-hidden launcher on `CopilotModalHeader`. New regression tests verified red-green; chat + provider suites green, `tsc --noEmit` clean, build green. (The superseded-connect *race* guard is covered by live verification + its synchronous sibling test — an async-timing unit test would be flaky, which the repo treats as a bug.)
- **web-components**: element tests for the icon tooltips + confirm-dialog suppression, the clipped-name tooltip (`data-tooltip` + placeholder), archived styling, refetch-preserves-list, footer hide-when-empty, and mobile launcher render/open + desktop-absent. Drawer suite green, `tsc --noEmit` clean, build + `es-check` green under `CI=true`. (Truncation detection + tooltip stacking are layout/CSS — verified live, not in jsdom.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
