### PR TITLE
fix(showcase): render post-sign-out auth rejection across showcase integrations

### DIFF
--- a/showcase/integrations/ag2/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/ag2/src/app/demos/auth/page.tsx
@@ -13,8 +13,19 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -28,6 +39,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -46,9 +62,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -70,12 +107,7 @@ export default function AuthDemoPage() {
       agent="auth-demo"
       headers={headers}
       useSingleEndpoint={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -86,7 +118,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -103,7 +135,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/agno/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/agno/src/app/demos/auth/page.tsx
@@ -13,8 +13,19 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -28,6 +39,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -46,9 +62,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -70,12 +107,7 @@ export default function AuthDemoPage() {
       agent="auth-demo"
       headers={headers}
       useSingleEndpoint={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -86,7 +118,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -103,7 +135,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/claude-sdk-python/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/demos/auth/page.tsx
@@ -13,14 +13,22 @@
 // inverts the historical unauth-first flow, which crashed the page on load
 // when `/info` returned 401 before `onError` handlers could attach.
 //
-// Error surfacing: <CopilotChat /> surfaces transport errors inconsistently
-// across states, so this page additionally captures errors via the
-// <CopilotKit onError> prop and renders a persistent error banner below the
-// chat. A local ErrorBoundary guards against any uncaught render-time error
-// from chat internals in the unauthenticated state so the page never white-
-// screens — instead, the user sees a clear in-page message.
+// Error surfacing: the post-sign-out 401 manifests as an AGENT-RUN error
+// (`agent_run_failed`), and that event is delivered to the AGENT-SCOPED
+// `<CopilotChat onError>` channel — NOT the provider-level `<CopilotKit
+// onError>`. The transport `/agent/<id>/run` POST returns 200; the auth
+// rejection rides inside the stream as an agent-run failure, so a demo that
+// listens only on `<CopilotKit onError>` never sees it and never renders the
+// banner. We therefore register the same handler on BOTH channels:
+// `<CopilotKit onError>` covers provider-level errors (e.g. the `/info`
+// handshake) and `<CopilotChat onError>` covers the agent-run rejection that
+// the sign-out path produces. The error surface is keyed off `lastError`
+// STATE and cleared on re-auth via an effect, so a rejection always renders
+// and signing back in always wipes it. A local ErrorBoundary still guards
+// against any uncaught render-time error from chat internals so the page
+// never white-screens.
 
-import { Component, useCallback, useMemo, useState } from "react";
+import { Component, useCallback, useEffect, useMemo, useState } from "react";
 import type { ErrorInfo, ReactNode } from "react";
 import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 import { useDemoAuth } from "./use-demo-auth";
@@ -94,14 +102,24 @@ export default function AuthDemoPage() {
   const auth = useDemoAuth();
   const [lastError, setLastError] = useState<string | null>(null);
 
-  // Clear any stale error when auth state flips (authenticate OR sign out).
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the error surface on auth state — the render
+  // condition below keys off `lastError` alone. Clearing the error inside
+  // the sign-out handler (the obvious-but-wrong guard) created a race: the
+  // sign-out wipes `lastError`, then the post-sign-out rejection's `onError`
+  // sets it again — but if the order ever inverts, the banner flickers or
+  // never appears. Driving the surface off `lastError` and clearing it here
+  // only on re-auth removes that ordering dependency: a rejection always
+  // renders, and signing back in always wipes it.
+  useEffect(() => {
+    if (auth.authenticated) setLastError(null);
+  }, [auth.authenticated]);
+
   const authenticate = useCallback(() => {
-    setLastError(null);
     auth.authenticate();
   }, [auth]);
 
   const signOut = useCallback(() => {
-    setLastError(null);
     auth.signOut();
   }, [auth]);
 
@@ -116,9 +134,15 @@ export default function AuthDemoPage() {
     return h;
   }, [auth.authorizationHeader]);
 
+  // Shared handler wired to BOTH the provider-level `<CopilotKit onError>`
+  // and the agent-scoped `<CopilotChat onError>` (see the file header for why
+  // both are needed). The event shape is identical across both channels:
+  // `{ error: Error; code; context }`. Some transport errors decorate the
+  // `Error` with a numeric `status`/`statusCode`; we read those defensively
+  // and fall back to matching the 401 in the message text.
   const onError = useCallback(
     (errorEvent: {
-      error?: { message?: string; status?: number; statusCode?: number };
+      error: Error & { status?: number; statusCode?: number };
       context?: { response?: { status?: number } };
     }) => {
       const err = errorEvent?.error;
@@ -163,7 +187,11 @@ export default function AuthDemoPage() {
         </header>
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
           <ChatErrorBoundary authenticated={auth.authenticated}>
-            <CopilotChat agentId="auth-demo" className="h-full" />
+            <CopilotChat
+              agentId="auth-demo"
+              className="h-full"
+              onError={onError}
+            />
           </ChatErrorBoundary>
         </div>
         {lastError && (

--- a/showcase/integrations/claude-sdk-typescript/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/claude-sdk-typescript/src/app/demos/auth/page.tsx
@@ -13,8 +13,19 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -28,6 +39,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -46,9 +62,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -70,12 +107,7 @@ export default function AuthDemoPage() {
       agent="auth-demo"
       headers={headers}
       useSingleEndpoint={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -86,7 +118,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -103,7 +135,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/crewai-crews/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/crewai-crews/src/app/demos/auth/page.tsx
@@ -13,8 +13,19 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -28,6 +39,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -46,9 +62,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -70,12 +107,7 @@ export default function AuthDemoPage() {
       agent="auth-demo"
       headers={headers}
       useSingleEndpoint={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -86,7 +118,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -103,7 +135,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/google-adk/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/google-adk/src/app/demos/auth/page.tsx
@@ -13,13 +13,21 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
-import {
-  CopilotKit,
-  CopilotChat,
-  type CopilotKitCoreErrorCode,
-} from "@copilotkit/react-core/v2";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+import type { CopilotKitCoreErrorCode } from "@copilotkit/react-core/v2";
 import { AuthBanner } from "./auth-banner";
 import { SignInCard } from "./sign-in-card";
 import { useDemoAuth } from "./use-demo-auth";
@@ -28,6 +36,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -46,9 +59,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -70,12 +104,7 @@ export default function AuthDemoPage() {
       agent="auth-demo"
       headers={headers}
       useSingleEndpoint={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -86,7 +115,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -103,7 +132,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/langgraph-fastapi/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/langgraph-fastapi/src/app/demos/auth/page.tsx
@@ -13,13 +13,21 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
-import {
-  CopilotKit,
-  CopilotChat,
-  type CopilotKitCoreErrorCode,
-} from "@copilotkit/react-core/v2";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+import type { CopilotKitCoreErrorCode } from "@copilotkit/react-core/v2";
 import { AuthBanner } from "./auth-banner";
 import { SignInCard } from "./sign-in-card";
 import { useDemoAuth } from "./use-demo-auth";
@@ -28,6 +36,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -46,9 +59,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -70,12 +104,7 @@ export default function AuthDemoPage() {
       agent="auth-demo"
       headers={headers}
       useSingleEndpoint={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -86,7 +115,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -103,7 +132,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/langgraph-python/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/langgraph-python/src/app/demos/auth/page.tsx
@@ -13,13 +13,21 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
-import {
-  CopilotKit,
-  CopilotChat,
-  type CopilotKitCoreErrorCode,
-} from "@copilotkit/react-core/v2";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+import type { CopilotKitCoreErrorCode } from "@copilotkit/react-core/v2";
 import { AuthBanner } from "./auth-banner";
 import { SignInCard } from "./sign-in-card";
 import { useDemoAuth } from "./use-demo-auth";
@@ -28,6 +36,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -46,9 +59,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -70,12 +104,7 @@ export default function AuthDemoPage() {
       agent="auth-demo"
       headers={headers}
       useSingleEndpoint={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -86,7 +115,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -103,7 +132,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/langgraph-typescript/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/demos/auth/page.tsx
@@ -13,8 +13,19 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -28,6 +39,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -46,9 +62,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -70,12 +107,7 @@ export default function AuthDemoPage() {
       agent="auth-demo"
       headers={headers}
       useSingleEndpoint={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -86,7 +118,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -103,7 +135,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/langroid/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/langroid/src/app/demos/auth/page.tsx
@@ -13,8 +13,19 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -28,6 +39,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -46,9 +62,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -70,12 +107,7 @@ export default function AuthDemoPage() {
       agent="auth-demo"
       headers={headers}
       useSingleEndpoint={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -86,7 +118,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -103,7 +135,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/llamaindex/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/llamaindex/src/app/demos/auth/page.tsx
@@ -13,8 +13,19 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -28,6 +39,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -46,9 +62,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -70,12 +107,7 @@ export default function AuthDemoPage() {
       agent="auth-demo"
       headers={headers}
       useSingleEndpoint={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -86,7 +118,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -103,7 +135,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/mastra/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/mastra/src/app/demos/auth/page.tsx
@@ -13,13 +13,21 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
-import {
-  CopilotKit,
-  CopilotChat,
-  type CopilotKitCoreErrorCode,
-} from "@copilotkit/react-core/v2";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+import type { CopilotKitCoreErrorCode } from "@copilotkit/react-core/v2";
 import { AuthBanner } from "./auth-banner";
 import { SignInCard } from "./sign-in-card";
 import { useDemoAuth } from "./use-demo-auth";
@@ -28,6 +36,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -46,9 +59,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -70,12 +104,7 @@ export default function AuthDemoPage() {
       agent="auth-demo"
       headers={headers}
       useSingleEndpoint={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -86,7 +115,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -103,7 +132,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/ms-agent-dotnet/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/ms-agent-dotnet/src/app/demos/auth/page.tsx
@@ -13,13 +13,21 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
-import {
-  CopilotKit,
-  CopilotChat,
-  type CopilotKitCoreErrorCode,
-} from "@copilotkit/react-core/v2";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+import type { CopilotKitCoreErrorCode } from "@copilotkit/react-core/v2";
 import { AuthBanner } from "./auth-banner";
 import { SignInCard } from "./sign-in-card";
 import { useDemoAuth } from "./use-demo-auth";
@@ -28,6 +36,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -46,9 +59,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -75,12 +109,7 @@ export default function AuthDemoPage() {
       // sign-in, so the post-sign-out Sign in button can sit underneath the
       // overlay in local/D5 runs even though production never shows it.
       enableInspector={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -91,7 +120,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -108,7 +137,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/ms-agent-harness-dotnet/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/ms-agent-harness-dotnet/src/app/demos/auth/page.tsx
@@ -13,8 +13,19 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 import type { CopilotKitCoreErrorCode } from "@copilotkit/react-core/v2";
 import { AuthBanner } from "./auth-banner";
@@ -25,6 +36,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -43,9 +59,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -72,12 +109,7 @@ export default function AuthDemoPage() {
       // sign-in, so the post-sign-out Sign in button can sit underneath the
       // overlay in local/D5 runs even though production never shows it.
       enableInspector={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -88,7 +120,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -105,7 +137,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/ms-agent-python/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/demos/auth/page.tsx
@@ -13,8 +13,19 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -28,6 +39,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -46,9 +62,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -70,12 +107,7 @@ export default function AuthDemoPage() {
       agent="auth-demo"
       headers={headers}
       useSingleEndpoint={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -86,7 +118,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -103,7 +135,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/pydantic-ai/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/demos/auth/page.tsx
@@ -13,8 +13,19 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -28,6 +39,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -46,9 +62,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -70,12 +107,7 @@ export default function AuthDemoPage() {
       agent="auth-demo"
       headers={headers}
       useSingleEndpoint={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -86,7 +118,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -103,7 +135,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/spring-ai/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/spring-ai/src/app/demos/auth/page.tsx
@@ -13,13 +13,21 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
-import {
-  CopilotKit,
-  CopilotChat,
-  type CopilotKitCoreErrorCode,
-} from "@copilotkit/react-core/v2";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+import type { CopilotKitCoreErrorCode } from "@copilotkit/react-core/v2";
 import { AuthBanner } from "./auth-banner";
 import { SignInCard } from "./sign-in-card";
 import { useDemoAuth } from "./use-demo-auth";
@@ -28,6 +36,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -46,9 +59,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -70,12 +104,7 @@ export default function AuthDemoPage() {
       agent="auth-demo"
       headers={headers}
       useSingleEndpoint={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -86,7 +115,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -103,7 +132,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/strands-typescript/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/strands-typescript/src/app/demos/auth/page.tsx
@@ -13,8 +13,19 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 import type { CopilotKitCoreErrorCode } from "@copilotkit/react-core/v2";
 import { AuthBanner } from "./auth-banner";
@@ -25,6 +36,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -43,9 +59,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -67,12 +104,7 @@ export default function AuthDemoPage() {
       agent="auth-demo"
       headers={headers}
       useSingleEndpoint={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -83,7 +115,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -100,7 +132,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>

--- a/showcase/integrations/strands/src/app/demos/auth/page.tsx
+++ b/showcase/integrations/strands/src/app/demos/auth/page.tsx
@@ -13,8 +13,19 @@
 // sign-out → sign-in cycle so the post-sign-out state can actually
 // demonstrate the runtime rejecting unauthenticated requests in the chat
 // surface (the whole point of the demo).
+//
+// Error surfacing: the post-sign-out 401 is captured via the AGENT-SCOPED
+// `<CopilotChat onError>` channel, NOT the provider-level `<CopilotKit
+// onError>` alone. Agent-run errors (`agent_run_failed`) are reliably
+// delivered to the chat-scoped subscription, whereas the provider-level
+// handler does not fire for them in this flow — so a demo that relies only
+// on `<CopilotKit onError>` never renders the rejection banner. We register
+// the same handler on BOTH channels: `<CopilotKit onError>` covers any
+// provider-level errors (e.g. the initial `/info` handshake) and
+// `<CopilotChat onError>` covers agent-run rejections, which is what the
+// sign-out path produces.
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   CopilotKit,
   CopilotChat,
@@ -28,6 +39,11 @@ import { DEMO_TOKEN } from "./demo-token";
 interface AuthDemoErrorState {
   message: string;
   code: CopilotKitCoreErrorCode | string;
+}
+
+interface AuthErrorEvent {
+  error?: { message?: string } | null;
+  code: CopilotKitCoreErrorCode;
 }
 
 export default function AuthDemoPage() {
@@ -46,9 +62,30 @@ export default function AuthDemoPage() {
 
   const [authError, setAuthError] = useState<AuthDemoErrorState | null>(null);
 
-  // Clear stale errors as soon as the user re-authenticates. Without this
-  // the amber error surface would persist after sign-in even though the
-  // failure is no longer relevant.
+  // Shared error handler wired to BOTH the provider-level and chat-level
+  // `onError` channels (see the file header for why both are needed).
+  const handleAuthError = useCallback((event: AuthErrorEvent) => {
+    setAuthError({
+      message:
+        (event.error?.message && event.error.message.trim()) ||
+        (event.code
+          ? `Request rejected (${event.code})`
+          : "The request was rejected."),
+      code: event.code,
+    });
+  }, []);
+
+  // Clear stale errors as soon as the user re-authenticates. This is the
+  // ONLY thing that gates the amber error surface on auth state — the render
+  // condition below keys off `authError` alone. Coupling the render to a
+  // second `!isAuthenticated` slice (the obvious-but-wrong guard) created a
+  // post-sign-out race: the rejection's `onError` fires and calls
+  // `setAuthError`, but if that commit landed in a render where the auth
+  // state hadn't yet settled to false, `authError && !isAuthenticated`
+  // evaluated false and the banner never appeared. Driving the surface off
+  // `authError` and clearing it here on re-auth removes the cross-slice
+  // ordering dependency: a rejection always renders, and signing back in
+  // always wipes it.
   useEffect(() => {
     if (isAuthenticated) setAuthError(null);
   }, [isAuthenticated]);
@@ -70,12 +107,7 @@ export default function AuthDemoPage() {
       agent="auth-demo"
       headers={headers}
       useSingleEndpoint={false}
-      onError={(event) => {
-        setAuthError({
-          message: event.error?.message ?? String(event.error),
-          code: event.code,
-        });
-      }}
+      onError={handleAuthError}
     >
       <div className="flex h-screen flex-col gap-3 p-6">
         <AuthBanner
@@ -86,7 +118,7 @@ export default function AuthDemoPage() {
         <header>
           <h1 className="text-lg font-semibold">Authentication</h1>
         </header>
-        {authError && !isAuthenticated && (
+        {authError && (
           <div
             data-testid="auth-demo-error"
             className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
@@ -103,7 +135,11 @@ export default function AuthDemoPage() {
           </div>
         )}
         <div className="flex-1 overflow-hidden rounded-md border border-neutral-200">
-          <CopilotChat agentId="auth-demo" className="h-full" />
+          <CopilotChat
+            agentId="auth-demo"
+            className="h-full"
+            onError={handleAuthError}
+          />
         </div>
       </div>
     </CopilotKit>


### PR DESCRIPTION
## What

Fixes the showcase **Authentication** demo across **19 of 20 integrations** — the feature row that was red (D4) across the board on the depth dashboard.

## Root cause

The post-sign-out rejection banner never rendered. After sign-out, the agent run is correctly rejected with a 401 (`agent_run_failed`), but that event is delivered **only on the agent-scoped `<CopilotChat onError>` channel** — never the provider-level `<CopilotKit onError>` the demos were listening on. So the auth D5/D6 probe's rejection-surface assertion failed, capping the cell at **D4** across integrations.

## Fix (per integration, one file each: `auth/page.tsx`)

- Wire a stable `handleAuthError` onto the agent-scoped `<CopilotChat onError>` (keeping the provider handler).
- Key the rejection-banner render off auth-error **state alone** with a clear-on-auth effect (removes the `&& !isAuthenticated` post-sign-out cross-slice race).
- Harden the banner's message fallback against nullish error events (no more literal "null"/"undefined").

## Scope: 19 of 20

- **built-in-agent excluded** — its auth probe already passes (renders via its `ChatErrorBoundary`, an accepted probe surface). Verified GREEN unmodified.
- **strands** initially looked green but that was an **infra-aborted probe (false-green)**; a re-probe with deps provisioned showed RED, and it was fixed + verified GREEN — hence 19, not 18.
- **claude-sdk-python** adapted to its legacy error-boundary shape (same fix, `lastError`/local `onError` naming).
- The originally-proposed harness change was **dropped** — investigation confirmed it a no-op (the "representative-gating" cause was a misdiagnosis; `auth` was already emitted for all integrations).

## Evidence

- Per-integration real-probe **red-green** (`bin/showcase test <slug>:auth --d6`, RED→GREEN).
- **Value-test**: 4/4 non-representative cells flip green **end-to-end (D5 and D6)** on the real probe.
- **CR**: converged (3 rounds, 11–15 agents/round) to zero bucket-(a); **Procedure 3** promotion audit clean.

## Follow-ups (not in this PR)

- claude-sdk-python idiomatic-shape migration (parity).
- Banner `<code>` chip conditional render + tighten the hand-rolled `AuthErrorEvent` type to the SDK `onError` type.
- `enableInspector={false}` divergence (only the 2 dotnet demos carry it).
- built-in-agent error-boundary parity.
