### PR TITLE
fix(showcase): backfill prod harness-workers into SSOT so image rebuilds bounce it

### DIFF
--- a/showcase/scripts/__tests__/fixtures/railway-envs.golden.json
+++ b/showcase/scripts/__tests__/fixtures/railway-envs.golden.json
@@ -80,6 +80,13 @@
     }
   },
   "harness-workers": {
+    "prod": {
+      "instanceId": "7c48ee43-6df4-457b-b977-10f1f1ac1680",
+      "domain": null,
+      "probe": false,
+      "driver": "harness",
+      "repoName": "showcase-harness"
+    },
     "staging": {
       "instanceId": "362c1e37-5f40-45f2-ac7b-0e5adac565f8",
       "domain": null,

--- a/showcase/scripts/__tests__/redeploy-env.harness-worker-prod-scope.test.ts
+++ b/showcase/scripts/__tests__/redeploy-env.harness-worker-prod-scope.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { expandImageConsumers } from "../redeploy-env";
+import { SERVICES } from "../railway-envs";
+
+// Regression: the prod `harness-workers` fleet worker runs the shared
+// `showcase-harness` image (`imageOf: "harness"`) but had NO `prod` env entry
+// in the SSOT. `expandImageConsumers` is env-aware — a consumer only joins an
+// env's redeploy scope if it declares that env — so a rebuilt
+// `showcase-harness:latest` bounced the prod control-plane but SILENTLY SKIPPED
+// the prod worker, leaving it on a stale image (a 1-demo `registry.json` for
+// `ms-agent-harness-dotnet` → missing `UI` badge → `D0`). This test exercises
+// the REAL expansion against the REAL SSOT and asserts the prod worker enters
+// the prod harness redeploy scope.
+//
+// Verified prod worker identity (Railway, READ-ONLY GraphQL):
+//   serviceId  c2aa8a0b-350e-4b76-8541-3012dfac41d0
+//   prod env   b14919f4-6417-429f-848d-c6ae2201e04f
+//   instanceId 7c48ee43-6df4-457b-b977-10f1f1ac1680
+const PROD_WORKER_SERVICE_ID = "c2aa8a0b-350e-4b76-8541-3012dfac41d0";
+
+describe("harness redeploy-scope expansion (imageOf: harness) — prod worker", () => {
+  it("includes harness-workers in the PROD redeploy scope when showcase-harness rebuilds", () => {
+    // The image-rebuild scope for `showcase-harness:latest` starts at its
+    // builder SSOT key, `harness`. The redeploy script expands this with
+    // env-aware imageOf consumers before redeploying.
+    const scope = expandImageConsumers(["harness"], "prod");
+
+    // The prod worker MUST be pulled in so a rebuild bounces it off its stale
+    // image. (RED before the SSOT backfill: the worker declares only `staging`,
+    // so the env filter at redeploy-env.ts:278 drops it from the prod scope.)
+    expect(scope).toContain("harness-workers");
+
+    // And it must resolve to the real prod worker service.
+    const worker = SERVICES["harness-workers"];
+    expect(worker.serviceId).toBe(PROD_WORKER_SERVICE_ID);
+    expect(Object.hasOwn(worker.environments, "prod")).toBe(true);
+  });
+
+  it("still includes harness-workers in the STAGING redeploy scope (no regression)", () => {
+    const scope = expandImageConsumers(["harness"], "staging");
+    expect(scope).toContain("harness-workers");
+  });
+});

--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -21,18 +21,19 @@ import type { ServiceEntry } from "../railway-envs";
 
 describe("ServiceEntry gateIgnore field", () => {
   it("is optional on the type and defaults to falsy when unset", () => {
-    // Every real SSOT entry has gateIgnore unset (undefined / falsy),
-    // EXCEPT one deliberately gateIgnore:true entry:
-    //   - the staging-only `harness-workers` pool-fleet worker (no public
-    //     domain, does not fit the symmetric dual-env shape the gate
-    //     validates).
+    // Every real SSOT entry has gateIgnore unset (undefined / falsy). There is
+    // no longer ANY gateIgnore:true entry: the `harness-workers` pool-fleet
+    // worker, formerly the sole gate-ignored (staging-only) service, has been
+    // backfilled as a dual-env (prod + staging) gateValidated:true service —
+    // both env entries carry an explicit `repoName: "showcase-harness"`, so it
+    // now fits the gate's image-ref shape and the opt-out is dropped.
     // See its SSOT entry in railway-envs.ts for the rationale.
     // `showcase-strands-typescript` is now provisioned dual-env
     // (gateValidated:true, no gateIgnore), so it falls into the default-falsy
     // branch below. S2: the 12 starter-<slug> services are likewise NO LONGER
     // gate-ignored — they are fully gate-managed (gateValidated, no
     // gateIgnore), exactly like every showcase-* agent.
-    const GATE_IGNORED = new Set(["harness-workers"]);
+    const GATE_IGNORED = new Set<string>([]);
     const isGateIgnored = (name: string): boolean => GATE_IGNORED.has(name);
     for (const [name, entry] of Object.entries(SERVICES)) {
       const gi = (entry as ServiceEntry).gateIgnore;
@@ -264,13 +265,13 @@ describe("WS-C: all gate-managed services gateValidated, with correct overrides"
   });
 
   it("marks every gate-managed service gateValidated (no Phase-2 holdouts)", () => {
-    // Intentional gateValidated:false entry (gateIgnore:true): the
-    // staging-only `harness-workers` (no public domain). S2 brought the 12
-    // starter-<slug> services UNDER the gate (gateValidated:true), so they
-    // are no longer holdouts; `showcase-strands-typescript` is now provisioned
-    // in prod and gateValidated too — every OTHER service, starters included,
-    // must be gateValidated:true.
-    const GATE_IGNORED = new Set(["harness-workers"]);
+    // There is no longer ANY gateIgnore:true / gateValidated:false holdout: the
+    // `harness-workers` worker, formerly the sole exception, has been
+    // backfilled as a dual-env gateValidated:true service. S2 brought the 12
+    // starter-<slug> services UNDER the gate (gateValidated:true);
+    // `showcase-strands-typescript` is provisioned in prod and gateValidated
+    // too — so EVERY service must now be gateValidated:true.
+    const GATE_IGNORED = new Set<string>([]);
     const isGateIgnored = (name: string): boolean => GATE_IGNORED.has(name);
     const unvalidated = Object.entries(SERVICES)
       .filter(([name, entry]) => !entry.gateValidated && !isGateIgnored(name))
@@ -291,18 +292,19 @@ describe("WS-C: all gate-managed services gateValidated, with correct overrides"
     });
   }
 
-  it("findMissingServices treats all 40 gateValidated services as targets (28 showcase/infra + 12 starters)", () => {
+  it("findMissingServices treats all 41 gateValidated services as targets (29 showcase/infra + 12 starters)", () => {
     // With nothing "present", every gateValidated service should appear in
     // the missing set. After S2 brought the 12 starter-<slug> services under
-    // the gate (gateValidated:true, dual-env), and showcase-strands-typescript
-    // was provisioned in prod (gateValidated:true), that means all 40 — the 28
-    // showcase/infra gateValidated services plus the 12 starters. (The
-    // gateIgnore entry harness-workers is NOT gateValidated and so is not
-    // required here.)
+    // the gate (gateValidated:true, dual-env), showcase-strands-typescript
+    // was provisioned in prod (gateValidated:true), and the prod harness-workers
+    // backfill flipped that worker to gateValidated:true (dual-env), that means
+    // all 41 — the 29 showcase/infra gateValidated services plus the 12
+    // starters. (harness-workers is now gateValidated and dual-env, so it IS
+    // required in both envs here.)
     const missingProd = findMissingServices("prod", new Set<string>());
     const missingStaging = findMissingServices("staging", new Set<string>());
-    expect(missingProd).toHaveLength(40);
-    expect(missingStaging).toHaveLength(40);
+    expect(missingProd).toHaveLength(41);
+    expect(missingStaging).toHaveLength(41);
     // The 12 starters are now demanded in BOTH envs.
     expect(missingProd).toContain("starter-adk");
     expect(missingStaging).toContain("starter-mastra");

--- a/showcase/scripts/emit-railway-envs-json.test.ts
+++ b/showcase/scripts/emit-railway-envs-json.test.ts
@@ -120,11 +120,15 @@ describe("emit-railway-envs-json closure block", () => {
     const docs = services.find((s) => s.name === "docs");
     expect(docs?.healthcheckPath).toBeUndefined();
 
-    // harness-workers is /health in staging, OMITTED in prod (per-env
-    // asymmetry — the staging-only worker declares no prod env).
+    // harness-workers is now dual-env: /health in BOTH prod and staging (the
+    // prod worker was backfilled into the SSOT, each env declaring the shared
+    // showcase-harness probe path).
     const workers = services.find((s) => s.name === "harness-workers");
-    expect(workers?.healthcheckPath).toEqual({ staging: "/health" });
-    expect(workers?.healthcheckPath?.prod).toBeUndefined();
+    expect(workers?.healthcheckPath).toEqual({
+      prod: "/health",
+      staging: "/health",
+    });
+    expect(workers?.healthcheckPath?.prod).toBe("/health");
   });
 });
 

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -133,10 +133,10 @@
     {
       "name": "harness-workers",
       "serviceId": "c2aa8a0b-350e-4b76-8541-3012dfac41d0",
-      "prodInstanceId": "c2aa8a0b-350e-4b76-8541-3012dfac41d0",
+      "prodInstanceId": "7c48ee43-6df4-457b-b977-10f1f1ac1680",
       "stagingInstanceId": "362c1e37-5f40-45f2-ac7b-0e5adac565f8",
       "ciBuilt": false,
-      "gateValidated": false,
+      "gateValidated": true,
       "repoNameOverride": {
         "prod": "showcase-harness",
         "staging": "showcase-harness"
@@ -152,6 +152,7 @@
       },
       "promoteTier": 1,
       "healthcheckPath": {
+        "prod": "/health",
         "staging": "/health"
       }
     },
@@ -1212,6 +1213,10 @@
         "tier": 1
       },
       {
+        "name": "harness-workers",
+        "tier": 1
+      },
+      {
         "name": "docs",
         "tier": 2,
         "standalone": true
@@ -1353,11 +1358,6 @@
         "tier": 2
       }
     ],
-    "skipped": [
-      {
-        "name": "harness-workers",
-        "reason": "no \"prod\" environment in the SSOT — cannot be promoted (it exists in: staging)."
-      }
-    ]
+    "skipped": []
   }
 }

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -179,10 +179,11 @@ describe("railway-envs SSOT", () => {
     // Live-null service: undefined (do not assert).
     expect(healthcheckPathFor("docs", "prod")).toBeUndefined();
     expect(healthcheckPathFor("dashboard", "staging")).toBeUndefined();
-    // Per-env asymmetry: harness-workers staging /health, prod undefined
-    // (staging-only service — it declares no prod env).
+    // harness-workers is dual-env: /health in BOTH staging and prod (the prod
+    // worker was backfilled into the SSOT so a showcase-harness rebuild bounces
+    // it; both envs declare the shared probe path).
     expect(healthcheckPathFor("harness-workers", "staging")).toBe("/health");
-    expect(healthcheckPathFor("harness-workers", "prod")).toBeUndefined();
+    expect(healthcheckPathFor("harness-workers", "prod")).toBe("/health");
     // Unknown service / undeclared env → undefined (never throws).
     expect(healthcheckPathFor("nope", "prod")).toBeUndefined();
   });
@@ -302,14 +303,15 @@ describe("railway-envs SSOT", () => {
     );
   });
 
-  it("repoNameFor throws on a registered env the service does not declare", () => {
-    // harness-workers is staging-only and its GHCR repo everywhere is
-    // showcase-harness — echoing "harness-workers" for prod would be a
-    // silently wrong GHCR name (consistent with instanceIdFor/domainFor,
-    // which both throw on an undeclared env).
-    expect(() => repoNameFor("harness-workers", "prod")).toThrow(
-      /has no "prod" environment/,
-    );
+  it("repoNameFor resolves the per-env repoName override for a dual-env worker", () => {
+    // harness-workers is now dual-env (prod backfilled into the SSOT). Both
+    // env entries carry an explicit repoName override of "showcase-harness"
+    // (it runs the shared showcase-harness image, NOT a "harness-workers"
+    // image), so repoNameFor returns that override in BOTH envs rather than
+    // echoing the SSOT key. (The throw-on-an-undeclared-env path is covered by
+    // the prototype-key env-axis test below and the unknown-service test above.)
+    expect(repoNameFor("harness-workers", "prod")).toBe("showcase-harness");
+    expect(repoNameFor("harness-workers", "staging")).toBe("showcase-harness");
   });
 
   it("serviceForDispatchName round-trips through SSOT keys", () => {
@@ -909,38 +911,53 @@ describe("railway-envs SSOT — domains + probe", () => {
   });
 
   it("envsFor lists exactly the envs a service declares", () => {
-    // Dual-env services declare both; the staging-only worker declares one.
+    // Dual-env services declare both; harness-workers is now dual-env too
+    // (the prod worker was backfilled into the SSOT).
     expect(envsFor("aimock")).toEqual(["prod", "staging"]);
-    expect(envsFor("harness-workers")).toEqual(["staging"]);
+    expect(envsFor("harness-workers")).toEqual(["prod", "staging"]);
   });
 
-  it("harness-workers is a staging-only, domainless, probe-disabled worker", () => {
-    // The pool-fleet worker is the canonical single-env / domainless shape
-    // the env-map schema enables (the old schema forced a placeholder prod
-    // instanceId + a borrowed control-plane domain). Pin every facet:
+  it("harness-workers is a dual-env, domainless, probe-disabled worker", () => {
+    // The pool-fleet worker now runs in BOTH staging and prod: the prod worker
+    // was backfilled into the SSOT (real serviceInstance ID 7c48ee43-…) so an
+    // env-aware imageOf rebuild of showcase-harness bounces the prod worker too
+    // (it used to be staging-only, which silently skipped the prod worker on a
+    // rebuild and left it on a stale image). Pin every facet:
     const worker = SERVICES["harness-workers"];
-    // Staging-only: no prod env at all (no placeholder).
-    expect(worker.environments.prod).toBeUndefined();
+    // Dual-env: both envs declared (no placeholder — each carries a real
+    // serviceInstance ID).
+    expect(worker.environments.prod).toBeDefined();
     expect(worker.environments.staging).toBeDefined();
-    // Domainless: the staging env omits a public host entirely (it is a
-    // queue consumer, not HTTP-exposed). domainFor MUST throw rather than
-    // return a borrowed host.
+    // Domainless in BOTH envs: the worker is a queue consumer, not
+    // HTTP-exposed, so each env omits a public host entirely and domainFor
+    // MUST throw rather than return a borrowed control-plane host.
+    expect(worker.environments.prod.domain).toBeUndefined();
     expect(worker.environments.staging.domain).toBeUndefined();
+    expect(() => domainFor("harness-workers", "prod")).toThrow(
+      /malformed\/missing prod domain/,
+    );
     expect(() => domainFor("harness-workers", "staging")).toThrow(
       /malformed\/missing staging domain/,
     );
-    // Probe disabled (covered by the control-plane harness probe + the
-    // Railway-internal healthcheck).
+    // Probe disabled in both envs (covered by the control-plane harness probe +
+    // the Railway-internal healthcheck).
+    expect(probeEnabled("harness-workers", "prod")).toBe(false);
     expect(probeEnabled("harness-workers", "staging")).toBe(false);
-    // Runs the shared showcase-harness image; not separately CI-built; kept
-    // out of both gate directions via gateIgnore. The image consumption is
+    // Runs the shared showcase-harness image; not separately CI-built. As a
+    // fully-modeled dual-env service it is now gateValidated (gateIgnore is
+    // dropped — both gate directions validate it). The image consumption is
     // modeled explicitly via imageOf so a rebuilt showcase-harness:latest
-    // redeploys the worker alongside the scheduler.
+    // redeploys the worker alongside the scheduler in EVERY env it declares.
+    expect(worker.environments.prod.repoName).toBe("showcase-harness");
     expect(worker.environments.staging.repoName).toBe("showcase-harness");
     expect(worker.imageOf).toBe("harness");
     expect(worker.ciBuilt).toBe(false);
-    expect(worker.gateIgnore).toBe(true);
+    expect(worker.gateValidated).toBe(true);
+    expect(worker.gateIgnore).toBeUndefined();
     expect(worker.serviceId).toBe("c2aa8a0b-350e-4b76-8541-3012dfac41d0");
+    expect(worker.environments.prod.instanceId).toBe(
+      "7c48ee43-6df4-457b-b977-10f1f1ac1680",
+    );
     expect(worker.environments.staging.instanceId).toBe(
       "362c1e37-5f40-45f2-ac7b-0e5adac565f8",
     );
@@ -1117,28 +1134,31 @@ describe("computePromoteClosure", () => {
   it("always includes the full Tier-1 verification set even for a tier-0-only request", () => {
     const plan = computePromoteClosure(["pocketbase"]);
     const names = plan.services.map((s) => s.name);
+    // harness-workers is now prod-promotable Tier-1 (the prod worker was
+    // backfilled into the SSOT), so it joins the always-included Tier-1 set
+    // alongside harness + dashboard — no longer filtered out.
     expect(names).toEqual(
-      expect.arrayContaining(
-        ["harness", "harness-workers", "dashboard"].filter(
-          (k) => k !== "harness-workers",
-        ),
-      ),
+      expect.arrayContaining(["harness", "harness-workers", "dashboard"]),
     );
-    // harness + dashboard are prod-promotable Tier-1 and present:
+    // harness + dashboard + the dual-env worker are prod-promotable Tier-1:
     expect(names).toContain("harness");
+    expect(names).toContain("harness-workers");
     expect(names).toContain("dashboard");
   });
 
-  it("skips a prod-less member (harness-workers) with an explicit reason, never silently", () => {
+  it("promotes the dual-env worker (harness-workers) at Tier-1, never skipping it", () => {
     const plan = computePromoteClosure(["langgraph-python"]);
     const promotableNames = plan.services.map((s) => s.name);
-    // harness-workers has no `prod` env today → excluded from the promotable
-    // list...
-    expect(promotableNames).not.toContain("harness-workers");
-    // ...but recorded with an explicit reason (never silent).
+    // harness-workers now declares a `prod` env (backfilled into the SSOT) and
+    // is promoteTier:1, so it is PROMOTED alongside the harness control-plane
+    // rather than recorded skipped-with-reason.
+    expect(promotableNames).toContain("harness-workers");
+    expect(plan.services.find((s) => s.name === "harness-workers")?.tier).toBe(
+      1,
+    );
+    // ...and it is NOT in the skipped list (it is no longer prod-less).
     const skipped = plan.skipped.find((s) => s.name === "harness-workers");
-    expect(skipped).toBeDefined();
-    expect(skipped?.reason).toMatch(/prod/i);
+    expect(skipped).toBeUndefined();
   });
 
   it("throws on an unknown requested service (fail loud)", () => {

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -511,55 +511,54 @@ export const SERVICES: Record<
   // not `showcase-harness-worker`.
   "harness-workers": {
     serviceId: "c2aa8a0b-350e-4b76-8541-3012dfac41d0",
-    // Pool-fleet worker. Workers now run in BOTH staging and prod: the
-    // prod worker is live on Railway (deployed 2026-06-19, HARNESS_ROLE=worker,
-    // pool count 2). This SSOT entry, however, still only models the STAGING
-    // instance — a `prod` env entry has NOT yet been backfilled here, so the
-    // entry currently declares staging only. Under the env-map schema we
-    // simply OMIT the prod key (no placeholder ID is needed). gateIgnore
-    // skips both gate directions; ciBuilt:false because the worker has no
-    // build slot of its own — but `imageOf: "harness"` (below) puts it in the
-    // staging redeploy scope whenever the shared showcase-harness image is
-    // rebuilt. To bring the live prod worker under this SSOT, add a `prod`
-    // env entry with its real serviceInstance ID, flip gateIgnore off, and
-    // set gateValidated: true (the imageOf expansion is env-aware and will
-    // start covering prod automatically once the prod env entry exists).
+    // Pool-fleet worker. Workers run in BOTH staging and prod: the prod worker
+    // is live on Railway (deployed 2026-06-19, HARNESS_ROLE=worker, pool
+    // count 2) and is now BACKFILLED as a `prod` env entry below (real
+    // serviceInstance ID `7c48ee43-…`). ciBuilt:false because the worker has
+    // no build slot of its own — but `imageOf: "harness"` (below) puts it in
+    // the redeploy scope of BOTH envs whenever the shared showcase-harness
+    // image is rebuilt. Before this backfill the entry modeled only staging,
+    // so the env-aware `imageOf` expansion (redeploy-env.ts:278) SILENTLY
+    // SKIPPED the prod worker on a `showcase-harness:latest` rebuild — the
+    // prod worker kept its stale 2026-06-19 image (a 1-demo `registry.json`
+    // for `ms-agent-harness-dotnet` → missing `UI` badge → D0). Declaring the
+    // prod env here closes that gap: a rebuild now bounces the prod worker too.
     ciBuilt: false,
-    // gateIgnore: deliberately-untracked for the image-ref gate. As modeled
-    // here the worker is single-env (staging only) and domainless (it pulls
-    // jobs from the control-plane queue rather than serving HTTP), so it does
-    // not fit the symmetric dual-env / public-domain shape the gate validates.
-    // (The live prod worker exists on Railway but is not yet an SSOT prod env
-    // — see the entry header above.) Listing
-    // it here (with gateIgnore) is what clears the "untracked Railway
-    // service" failure — findUntrackedServices treats any SSOT entry as
-    // known — WITHOUT triggering a false "missing from prod" failure from
-    // findMissingServices (which only checks gateValidated:true entries).
-    gateValidated: false,
-    gateIgnore: true,
+    // gateValidated: true — the worker is now a modeled dual-env service, so
+    // the image-ref gate validates its `showcase-harness` image refs in both
+    // envs (findMissingServices checks gateValidated:true entries; both env
+    // entries carry an explicit `repoName: "showcase-harness"`). gateIgnore is
+    // dropped: the SSOT now fully models the live Railway service in both envs,
+    // so neither the SSOT→Railway nor the Railway→SSOT gate direction needs an
+    // opt-out.
+    gateValidated: true,
     probeDriver: "harness",
-    // Tier-1 verification fleet. This SSOT entry declares no prod env below
-    // (only the staging instance is modeled, though a prod worker is live on
-    // Railway — see the entry header), so computePromoteClosure records it as
-    // skipped-with-reason rather than promoting it; the tier survives for when
-    // the prod worker is backfilled as a `prod` env entry here.
+    // Tier-1 verification fleet. With the prod env declared below,
+    // computePromoteClosure now promotes the prod worker alongside the
+    // harness control-plane (rather than recording it skipped-with-reason).
     promoteTier: 1,
     // The worker runs the SAME `showcase-harness` GHCR image that the
     // existing `harness` (control-plane) service runs — it is NOT a
     // separately-built image. The single `showcase-harness` build slot in
     // showcase_build.yml produces the image both services consume; there is
     // no `harness-workers` build slot. Hence ciBuilt:false, with the
-    // consumption modeled explicitly via imageOf so the staging redeploy
-    // after a successful `showcase-harness` build bounces the worker too
-    // (it used to be silently skipped, leaving it on the stale image). The
-    // repoName override points at `showcase-harness` so the image-ref shape
-    // resolves correctly if the gate ever validates it.
+    // consumption modeled explicitly via imageOf so the redeploy after a
+    // successful `showcase-harness` build bounces the worker in EVERY env it
+    // declares (it used to be silently skipped in prod, leaving it on the
+    // stale image). The per-env repoName override points at `showcase-harness`
+    // so the image-ref shape resolves correctly.
     imageOf: "harness",
     //
-    // No public domain (queue worker, not HTTP-exposed) and probe disabled:
-    // verify-deploy skips probe:false services, and the schema no longer
-    // requires a domain, so we OMIT it rather than point at a borrowed host.
+    // No public domain (queue worker, not HTTP-exposed) and probe disabled in
+    // both envs: verify-deploy skips probe:false services, and the schema does
+    // not require a domain, so we OMIT it rather than point at a borrowed host.
     environments: {
+      prod: {
+        instanceId: "7c48ee43-6df4-457b-b977-10f1f1ac1680",
+        healthcheckPath: "/health",
+        probe: false,
+        repoName: "showcase-harness",
+      },
       staging: {
         instanceId: "362c1e37-5f40-45f2-ac7b-0e5adac565f8",
         healthcheckPath: "/health",
@@ -567,18 +566,17 @@ export const SERVICES: Record<
         repoName: "showcase-harness",
       },
     },
-    // Ruby/jq JSON-shape compat (see ServiceEntry.legacyJsonCompat). The
-    // emitter fills the absent prod env's prodInstanceId from serviceId and
-    // both domains from the legacy borrowed control-plane harness hosts so
-    // the generated JSON stays byte-identical. None of these are read by TS.
+    // Ruby/jq JSON-shape compat (see ServiceEntry.legacyJsonCompat). The prod
+    // env is now real, so its prodInstanceId/repoName come straight from the
+    // env map; the only remaining compat shim is the borrowed control-plane
+    // hosts for the domainless worker's `domains{}` block (probe:false in both
+    // envs, so these hosts are never dereferenced at runtime — they exist only
+    // to keep the generated JSON's `domains` shape byte-stable). Not read by TS.
     legacyJsonCompat: {
       domains: {
         prod: "showcase-harness-production.up.railway.app",
         staging: "harness-staging-2ee4.up.railway.app",
       },
-      // The absent prod env carried a placeholder repoName in the legacy
-      // JSON; restore it so repoNameOverride stays {prod, staging}.
-      repoNameOverride: { prod: "showcase-harness" },
     },
   },
   pocketbase: {

--- a/showcase/scripts/redeploy-env.test.ts
+++ b/showcase/scripts/redeploy-env.test.ts
@@ -142,14 +142,14 @@ describe("runRedeploy", () => {
     ]);
   });
 
-  it("default prod scope excludes staging-only services (harness-workers) but includes dual-env showcase-strands-typescript", async () => {
-    // The default scope is env-aware: a service with no prod env never joins
-    // the prod scope. harness-workers (imageOf consumer, staging-only) is
-    // excluded by the env-aware imageOf expansion. showcase-strands-typescript
-    // is now provisioned dual-env, so it DOES join the prod default scope. The
-    // prod default = the 39 CI-built services that declare prod (27
-    // showcase/infra incl. showcase-strands-typescript + 12 starters); only
-    // staging-only harness-workers is excluded.
+  it("default prod scope includes the dual-env worker (harness-workers) and dual-env showcase-strands-typescript", async () => {
+    // The default scope is env-aware: a service joins the prod scope when it
+    // declares a prod env. harness-workers is now dual-env (the prod worker was
+    // backfilled into the SSOT), so the env-aware imageOf expansion pulls it
+    // into the prod scope as a showcase-harness consumer. showcase-strands-typescript
+    // is also dual-env and joins. The prod default = the 40 services that
+    // declare prod (27 CI-built showcase/infra incl. showcase-strands-typescript
+    // + 12 starters + the imageOf-consumer harness-workers).
     const seenNames: string[] = [];
     const redeploy = vi.fn(async (serviceId: string) => {
       const name = Object.entries(SERVICES).find(
@@ -163,9 +163,11 @@ describe("runRedeploy", () => {
       redeploy,
       appendSummary,
     });
-    expect(result.attempted).toBe(39);
-    expect(seenNames).not.toContain("harness-workers");
-    // showcase-strands-typescript is now dual-env, so it joins the prod scope.
+    expect(result.attempted).toBe(40);
+    // harness-workers is now dual-env, so a prod redeploy of its showcase-harness
+    // image bounces the prod worker too (it used to be silently skipped).
+    expect(seenNames).toContain("harness-workers");
+    // showcase-strands-typescript is dual-env, so it joins the prod scope.
     expect(seenNames).toContain("showcase-strands-typescript");
     // S2: starters ARE in the default prod scope (CI-built, dual-env).
     expect(seenNames).toContain("starter-adk");
@@ -705,10 +707,18 @@ describe("expandImageConsumers", () => {
     ]);
   });
 
-  it("excludes consumers that do not declare the target env (prod)", () => {
-    // harness-workers is staging-only; a prod redeploy of harness must not
-    // attempt the worker.
-    expect(expandImageConsumers(["harness"], "prod")).toEqual(["harness"]);
+  it("includes a dual-env consumer (harness-workers) in the prod expansion", () => {
+    // harness-workers is now dual-env (the prod worker was backfilled into the
+    // SSOT), so a prod redeploy of its showcase-harness image MUST also bounce
+    // the prod worker — the env-aware expansion pulls it in for prod just like
+    // staging. (The env-aware EXCLUSION branch — skipping a consumer that does
+    // not declare the target env — is exercised by expandImageConsumers' own
+    // Object.hasOwn(entry.environments, env) guard; there is no longer a
+    // single-env imageOf consumer in the SSOT to demonstrate it end-to-end.)
+    expect(expandImageConsumers(["harness"], "prod")).toEqual([
+      "harness",
+      "harness-workers",
+    ]);
   });
 
   it("returns the input unchanged for services without consumers", () => {


### PR DESCRIPTION
## Root cause

Prod's `harness-workers` fleet worker runs a **stale `showcase-harness` image** because it had **no `prod` env entry** in the railway-envs SSOT.

- The worker (`serviceId c2aa8a0b-350e-4b76-8541-3012dfac41d0`, prod instance `7c48ee43-6df4-457b-b977-10f1f1ac1680`, `HARNESS_ROLE=worker`) consumes the shared `showcase-harness` image via `imageOf: "harness"`.
- `expandImageConsumers(names, env)` is **env-aware**: a consumer only enters an env's redeploy scope if it declares that env (`redeploy-env.ts:278` — `if (!Object.hasOwn(entry.environments, env)) continue;`).
- Because the worker modeled **staging only**, a rebuilt `showcase-harness:latest` bounced the prod control-plane but **silently skipped the prod worker**, which kept its stale **2026-06-19** image.
- That stale image bakes a **1-demo `registry.json`** for `ms-agent-harness-dotnet` (only `beautiful-chat`). The hourly `e2e_demos` driver runs on the worker → resolves 1 demo → writes only `e2e:ms-agent-harness-dotnet/beautiful-chat`. The other 38 feature rows never exist in prod PocketBase → `resolveD3.exists === false` → `UI` badge omitted → broken D3 rung collapses the ladder → **D0**.

(d5/d6 populate fully in prod because the D5/D6 drivers enumerate from a **compiled-in** script registry, not the `registry.json` data file — only `e2e_demos` is data-driven, which is why only `UI` was affected.)

## Fix

Backfill the live prod worker as a real `prod` env entry in `scripts/railway-envs.ts` (real serviceInstance ID `7c48ee43…`), flip `gateIgnore` off, and set `gateValidated: true`. The env-aware `imageOf` expansion now pulls the prod worker into the **prod** redeploy scope on every `showcase-harness` rebuild, so it can no longer drift onto a stale image.

Also regenerates `railway-envs.generated.json` (Ruby/jq boundary artifact) and the golden behavior-preservation fixture, and updates the two gate-count assertions (`gateValidated` services 40→41; `harness-workers` removed from the gateIgnore set).

## Local RED → GREEN proof

Failure surface: the real `expandImageConsumers("harness", "prod")` against the real SSOT must include `harness-workers`.

**RED** (prod env entry absent from SSOT — the bug):
```
 × includes harness-workers in the PROD redeploy scope when showcase-harness rebuilds
 AssertionError: expected [ 'harness' ] to include 'harness-workers'
   at __tests__/redeploy-env.harness-worker-prod-scope.test.ts:31:19
      Tests  1 failed | 1 passed (2)
```

**GREEN** (after adding the prod `harness-workers` env entry):
```
 ✓ includes harness-workers in the PROD redeploy scope when showcase-harness rebuilds
 ✓ still includes harness-workers in the STAGING redeploy scope (no regression)
      Tests  2 passed (2)
```

Full SSOT-dependent suite (golden snapshot, emit-json, image-ref gate, promote closure, verify-matrix, redeploy-env): **140 passed**.

## Note (out of scope for this PR)

This SSOT change ensures the prod worker is bounced on **future** rebuilds. The currently-live prod worker still needs a one-time redeploy/restart onto the current `showcase-harness:latest` (39-demo registry) to immediately backfill the 38 missing rows; that is an operational step, not a code change.
