### PR TITLE
feat(examples): add OpenTag — a Slack bot starter

### DIFF
--- a/examples/opentag/.env.example
+++ b/examples/opentag/.env.example
@@ -1,0 +1,36 @@
+# OpenTag — set SLACK_*, DISCORD_*, and/or TELEGRAM_BOT_TOKEN. The bot starts an
+# adapter for each platform whose secrets are present (run one, or several at once).
+
+# ── Slack (api.slack.com/apps → your app) ───────────────────────────────
+# Set both to run on Slack; leave blank to skip Slack.
+# Bot token:  OAuth & Permissions → "Bot User OAuth Token" (xoxb-...)
+SLACK_BOT_TOKEN=xoxb-...
+# App-level token: Basic Information → App-Level Tokens → generate one with the
+# "connections:write" scope (xapp-...)
+SLACK_APP_TOKEN=xapp-...
+
+# ── Discord (discord.com/developers/applications → your app) ────────────
+# Set both to run on Discord. Bot → "Reset Token"; under Privileged Gateway
+# Intents enable BOTH Message Content and Server Members (both required). The
+# Application ID is on General Information.
+# DISCORD_BOT_TOKEN=
+# DISCORD_APP_ID=
+# Optional: a guild (server) id registers slash commands instantly during dev
+# (global commands can take up to ~1h). Omit in production.
+# DISCORD_GUILD_ID=
+
+# ── Telegram (message @BotFather → /newbot) ─────────────────────────────
+# Set to run on Telegram. Long-polling is the default ingress (no public URL or
+# webhook setup needed).
+# TELEGRAM_BOT_TOKEN=
+
+# ── Agent backend (runtime.ts) ──────────────────────────────────────────
+# The AG-UI endpoint the bot POSTs to. Defaults to the local runtime (pnpm runtime).
+AGENT_URL=http://localhost:8200/api/copilotkit/agent/opentag/run
+# Optional auth header forwarded to a deployed runtime.
+# AGENT_AUTH_HEADER=Bearer ...
+
+# Model for the BuiltInAgent. OpenAI by default; override with AGENT_MODEL (a
+# bare OpenAI id, or "openai/<id>" — the prefix is stripped). Defaults to gpt-5.5.
+# AGENT_MODEL=openai/gpt-5.5
+OPENAI_API_KEY=sk-...

--- a/examples/opentag/.env.example
+++ b/examples/opentag/.env.example
@@ -1,23 +1,12 @@
-# OpenTag — set SLACK_* and/or DISCORD_*. The bot starts an adapter for each
-# platform whose secrets are present (run one, or both at once).
+# OpenTag — a Slack bot starter. Set the two Slack tokens below plus an
+# OPENAI_API_KEY, then run the runtime + the bot (see README).
 
 # ── Slack (api.slack.com/apps → your app) ───────────────────────────────
-# Set both to run on Slack; leave blank to skip Slack.
 # Bot token:  OAuth & Permissions → "Bot User OAuth Token" (xoxb-...)
 SLACK_BOT_TOKEN=xoxb-...
 # App-level token: Basic Information → App-Level Tokens → generate one with the
 # "connections:write" scope (xapp-...)
 SLACK_APP_TOKEN=xapp-...
-
-# ── Discord (discord.com/developers/applications → your app) ────────────
-# Set both to run on Discord. Bot → "Reset Token"; under Privileged Gateway
-# Intents enable BOTH Message Content and Server Members (both required). The
-# Application ID is on General Information.
-# DISCORD_BOT_TOKEN=
-# DISCORD_APP_ID=
-# Optional: a guild (server) id registers slash commands instantly during dev
-# (global commands can take up to ~1h). Omit in production.
-# DISCORD_GUILD_ID=
 
 # ── Agent backend (runtime.ts) ──────────────────────────────────────────
 # The AG-UI endpoint the bot POSTs to. Defaults to the local runtime (pnpm runtime).

--- a/examples/opentag/.env.example
+++ b/examples/opentag/.env.example
@@ -1,5 +1,5 @@
-# OpenTag — set SLACK_*, DISCORD_*, and/or TELEGRAM_BOT_TOKEN. The bot starts an
-# adapter for each platform whose secrets are present (run one, or several at once).
+# OpenTag — set SLACK_* and/or DISCORD_*. The bot starts an adapter for each
+# platform whose secrets are present (run one, or both at once).
 
 # ── Slack (api.slack.com/apps → your app) ───────────────────────────────
 # Set both to run on Slack; leave blank to skip Slack.
@@ -18,11 +18,6 @@ SLACK_APP_TOKEN=xapp-...
 # Optional: a guild (server) id registers slash commands instantly during dev
 # (global commands can take up to ~1h). Omit in production.
 # DISCORD_GUILD_ID=
-
-# ── Telegram (message @BotFather → /newbot) ─────────────────────────────
-# Set to run on Telegram. Long-polling is the default ingress (no public URL or
-# webhook setup needed).
-# TELEGRAM_BOT_TOKEN=
 
 # ── Agent backend (runtime.ts) ──────────────────────────────────────────
 # The AG-UI endpoint the bot POSTs to. Defaults to the local runtime (pnpm runtime).

--- a/examples/opentag/.gitignore
+++ b/examples/opentag/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+.env.local

--- a/examples/opentag/README.md
+++ b/examples/opentag/README.md
@@ -1,4 +1,4 @@
-# OpenTag — a multi-platform bot starter (Slack · Discord · Telegram)
+# OpenTag — a multi-platform bot starter (Slack · Discord)
 
 The clean **"how to get started with CopilotKit bots"** starter. OpenTag is a
 thread-tagging assistant: @mention it (or run `/tag`) in a thread and it reads
@@ -8,17 +8,17 @@ the conversation, proposes a label (`bug` / `question` / `feature` / `docs` /
 It's built with [`@copilotkit/bot`](../../packages/bot) (the platform-agnostic
 bot engine), one or more platform adapters
 ([`-slack`](../../packages/bot-slack) /
-[`-discord`](../../packages/bot-discord) /
-[`-telegram`](../../packages/bot-telegram)), and
+[`-discord`](../../packages/bot-discord)), and
 [`@copilotkit/bot-ui`](../../packages/bot-ui) (a cross-platform JSX vocabulary
 for rich messages). It's the distilled sibling of
 [`examples/slack`](../slack) — the same engine and patterns, minus the kitchen
 sink (no MCP, no modals, no charts).
 
-**One app, any platform — or all at once.** `createBot` takes an array of
-adapters; `app/index.ts` includes Slack when `SLACK_*` are set, Discord when
-`DISCORD_*` are set, and Telegram when `TELEGRAM_BOT_TOKEN` is set. Everything
-in `app/` is platform-agnostic and shared verbatim.
+**One app, any platform — or both at once.** `createBot` takes an array of
+adapters; `app/index.ts` includes Slack when `SLACK_*` are set and Discord when
+`DISCORD_*` are set. Everything in `app/` is platform-agnostic and shared
+verbatim — adding another surface (e.g. Telegram) is just one more secret-gated
+adapter block.
 
 ## What it teaches
 
@@ -53,8 +53,8 @@ You need an `OPENAI_API_KEY` and the secrets for **at least one** platform.
 ## How it fits together
 
 ```
-Slack / Discord / Telegram ──@mention──▶ bot (app/) ──AG-UI──▶ runtime (runtime.ts)
-                                                                  └─ BuiltInAgent (LLM)
+Slack / Discord ──@mention──▶ bot (app/) ──AG-UI──▶ runtime (runtime.ts)
+                                                       └─ BuiltInAgent (LLM)
 ```
 
 - **`app/`** — the platform-agnostic bot: `createBot` + whichever adapters have
@@ -91,12 +91,6 @@ The manifest declares the `/tag` command, the assistant pane, and Socket Mode
   URL to add it to your server. Optionally set `DISCORD_GUILD_ID` so slash
   commands register instantly during dev.
 
-### Telegram (set `TELEGRAM_BOT_TOKEN`)
-
-- Message **@BotFather** → `/newbot` → copy the HTTP API token
-  (`TELEGRAM_BOT_TOKEN`). Long-polling is the default — no public URL needed.
-- The bot auto-registers `/tag` via `setMyCommands` on start.
-
 ## 2. Run it
 
 ```bash
@@ -107,7 +101,7 @@ pnpm --filter opentag dev       # terminal 2 — the bot
 
 ## 3. Try it
 
-@mention the bot in a thread (Slack/Discord) or DM it (Telegram), or run `/tag`:
+@mention the bot in a thread (Slack/Discord), or run `/tag`:
 
 > @OpenTag tag this thread
 
@@ -171,7 +165,7 @@ forwarded to the agent on every run as client-side tools.
 - **Change the taxonomy.** Edit the label list in the `runtime.ts` system prompt
   and the colors in `app/components/tag-card.tsx`.
 - **Add a platform.** Add another adapter to the secret-gated block in
-  `app/index.ts` (e.g. `@copilotkit/bot-whatsapp`).
+  `app/index.ts` — e.g. `@copilotkit/bot-telegram` or `@copilotkit/bot-whatsapp`.
 - **Durable buttons.** Pass a `@copilotkit/bot-store-redis` store to `createBot`
   so an Apply/Cancel click still resolves after a restart.
 

--- a/examples/opentag/README.md
+++ b/examples/opentag/README.md
@@ -1,38 +1,36 @@
-# OpenTag — a multi-platform bot starter (Slack · Discord)
+# OpenTag — a Slack bot starter
 
 The clean **"how to get started with CopilotKit bots"** starter. OpenTag is a
-thread-tagging assistant: @mention it (or run `/tag`) in a thread and it reads
-the conversation, proposes a label (`bug` / `question` / `feature` / `docs` /
-`urgent`), and — after you click **Apply** — posts the tag as a rich card.
+thread-tagging assistant for **Slack**: @mention it (or run `/tag`) in a thread
+and it reads the conversation, proposes a label (`bug` / `question` / `feature`
+/ `docs` / `urgent`), and — after you click **Apply** — posts the tag as a rich
+card.
 
 It's built with [`@copilotkit/bot`](../../packages/bot) (the platform-agnostic
-bot engine), one or more platform adapters
-([`-slack`](../../packages/bot-slack) /
-[`-discord`](../../packages/bot-discord)), and
+bot engine), the [`-slack`](../../packages/bot-slack) adapter, and
 [`@copilotkit/bot-ui`](../../packages/bot-ui) (a cross-platform JSX vocabulary
-for rich messages). It's the distilled sibling of
-[`examples/slack`](../slack) — the same engine and patterns, minus the kitchen
-sink (no MCP, no modals, no charts).
+for rich messages). It's the distilled sibling of [`examples/slack`](../slack)
+— the same engine and patterns, minus the kitchen sink (no MCP, no modals, no
+charts).
 
-**One app, any platform — or both at once.** `createBot` takes an array of
-adapters; `app/index.ts` includes Slack when `SLACK_*` are set and Discord when
-`DISCORD_*` are set. Everything in `app/` is platform-agnostic and shared
-verbatim — adding another surface (e.g. Telegram) is just one more secret-gated
-adapter block.
+The engine is platform-agnostic, so the same `app/` runs on Discord, Telegram,
+WhatsApp, or Teams by swapping one import — see
+[Run it elsewhere](#run-it-elsewhere). This starter keeps the focus on Slack so
+there's exactly one path to follow.
 
 ## What it teaches
 
 In ~250 lines of `app/`, OpenTag shows the whole shape of a CopilotKit bot:
 
-| Concept                                                                           | Where                                                   |
-| --------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| `createBot({ adapters, agent, tools, context, commands })`, secret-gated adapters | `app/index.ts`                                          |
-| The core turn loop — `bot.onMention` → `thread.runAgent()`                        | `app/index.ts`                                          |
-| A `BotTool` that grounds the agent in the real conversation                       | `app/tools/read-thread.ts`                              |
-| A generative-UI **render-tool** + JSX component                                   | `app/tools/tag-card.tsx`, `app/components/tag-card.tsx` |
-| A blocking **human-in-the-loop** gate (`thread.awaitChoice`)                      | `app/human-in-the-loop/confirm-tag.tsx`                 |
-| A slash command (`/tag`)                                                          | `app/commands/index.ts`                                 |
-| The agent backend — one `BuiltInAgent` (LLM, no MCP) over AG-UI                   | `runtime.ts`                                            |
+| Concept                                                         | Where                                                   |
+| --------------------------------------------------------------- | ------------------------------------------------------- |
+| `createBot({ adapters, agent, tools, context, commands })`      | `app/index.ts`                                          |
+| The core turn loop — `bot.onMention` → `thread.runAgent()`      | `app/index.ts`                                          |
+| A `BotTool` that grounds the agent in the real conversation     | `app/tools/read-thread.ts`                              |
+| A generative-UI **render-tool** + JSX component                 | `app/tools/tag-card.tsx`, `app/components/tag-card.tsx` |
+| A blocking **human-in-the-loop** gate (`thread.awaitChoice`)    | `app/human-in-the-loop/confirm-tag.tsx`                 |
+| A slash command (`/tag`)                                        | `app/commands/index.ts`                                 |
+| The agent backend — one `BuiltInAgent` (LLM, no MCP) over AG-UI | `runtime.ts`                                            |
 
 ## Quickstart
 
@@ -43,33 +41,25 @@ In ~250 lines of `app/`, OpenTag shows the whole shape of a CopilotKit bot:
 # from the repo root
 pnpm install
 cp examples/opentag/.env.example examples/opentag/.env
-# …fill in secrets (see below), then in two terminals:
+# …fill in OPENAI_API_KEY + your Slack tokens (see below), then in two terminals:
 pnpm --filter opentag runtime     # the agent backend on :8200
 pnpm --filter opentag dev         # the bot (tsx watch app/index.ts)
 ```
 
-You need an `OPENAI_API_KEY` and the secrets for **at least one** platform.
-
 ## How it fits together
 
 ```
-Slack / Discord ──@mention──▶ bot (app/) ──AG-UI──▶ runtime (runtime.ts)
-                                                       └─ BuiltInAgent (LLM)
+Slack ──@mention──▶ bot (app/) ──AG-UI──▶ runtime (runtime.ts)
+                                            └─ BuiltInAgent (LLM)
 ```
 
-- **`app/`** — the platform-agnostic bot: `createBot` + whichever adapters have
-  secrets, the `read_thread` / `tag_card` tools, the `confirm_tag` HITL gate,
-  and the `/tag` command. **This is the directory you copy to start your own
-  bot.**
+- **`app/`** — the bot: `createBot` + the Slack adapter, the `read_thread` /
+  `tag_card` tools, the `confirm_tag` HITL gate, and the `/tag` command. **This
+  is the directory you copy to start your own bot.**
 - **`runtime.ts`** — the agent backend: a single CopilotKit `BuiltInAgent`
   (an LLM) served over AG-UI. No Python, no LangGraph, no external services.
 
-## 1. Set up a platform
-
-Set the secrets for whichever platform(s) you want — the bot starts an adapter
-for each one whose secrets are present.
-
-### Slack (set `SLACK_*`)
+## 1. Set up Slack
 
 - <https://api.slack.com/apps?new_app=1> → **From a manifest** → paste
   [`slack-app-manifest.yaml`](./slack-app-manifest.yaml).
@@ -81,27 +71,17 @@ for each one whose secrets are present.
 The manifest declares the `/tag` command, the assistant pane, and Socket Mode
 (so no public URL is needed).
 
-### Discord (set `DISCORD_*`)
-
-- <https://discord.com/developers/applications> → **New Application**.
-- **Bot** → copy the token (`DISCORD_BOT_TOKEN`); under **Privileged Gateway
-  Intents** enable **both** **Message Content** and **Server Members**.
-- **General Information** → copy the **Application ID** (`DISCORD_APP_ID`).
-- **OAuth2 → URL Generator** → scopes `bot` + `applications.commands` → open the
-  URL to add it to your server. Optionally set `DISCORD_GUILD_ID` so slash
-  commands register instantly during dev.
-
 ## 2. Run it
 
 ```bash
-cp .env.example .env       # then fill in OPENAI_API_KEY + your platform secrets
+cp .env.example .env       # then fill in OPENAI_API_KEY + your Slack tokens
 pnpm --filter opentag runtime   # terminal 1 — agent on :8200
 pnpm --filter opentag dev       # terminal 2 — the bot
 ```
 
 ## 3. Try it
 
-@mention the bot in a thread (Slack/Discord), or run `/tag`:
+@mention the bot in a Slack thread, or run `/tag`:
 
 > @OpenTag tag this thread
 
@@ -112,9 +92,8 @@ an **Apply / Cancel** card. Click **Apply** and it posts the applied tag.
 
 ### The bot (`app/index.ts`)
 
-`createBot` takes the adapters that have secrets, the bot's tools + context, and
-the `/tag` command. One `onMention` handler covers @mentions and DMs on every
-active platform:
+`createBot` takes the Slack adapter, the bot's tools + context, and the `/tag`
+command. One `onMention` handler covers @mentions and DMs:
 
 ```ts
 bot.onMention(async ({ thread, message }) => {
@@ -164,10 +143,40 @@ forwarded to the agent on every run as client-side tools.
   Linear update, a row in your DB.
 - **Change the taxonomy.** Edit the label list in the `runtime.ts` system prompt
   and the colors in `app/components/tag-card.tsx`.
-- **Add a platform.** Add another adapter to the secret-gated block in
-  `app/index.ts` — e.g. `@copilotkit/bot-telegram` or `@copilotkit/bot-whatsapp`.
 - **Durable buttons.** Pass a `@copilotkit/bot-store-redis` store to `createBot`
   so an Apply/Cancel click still resolves after a restart.
+
+## Run it elsewhere
+
+The engine is platform-agnostic — everything in `app/` is shared verbatim across
+surfaces. To run OpenTag on another platform, swap the Slack adapter in
+`app/index.ts` for another one and provide that platform's secrets:
+
+| Platform | Package                                                   |
+| -------- | --------------------------------------------------------- |
+| Discord  | [`@copilotkit/bot-discord`](../../packages/bot-discord)   |
+| Telegram | [`@copilotkit/bot-telegram`](../../packages/bot-telegram) |
+| WhatsApp | [`@copilotkit/bot-whatsapp`](../../packages/bot-whatsapp) |
+| Teams    | [`@copilotkit/bot-teams`](../../packages/bot-teams)       |
+
+```ts
+// e.g. Discord instead of Slack — the rest of app/ is unchanged
+import {
+  discord,
+  defaultDiscordTools,
+  defaultDiscordContext,
+} from "@copilotkit/bot-discord";
+
+const adapter = discord({
+  botToken: required("DISCORD_BOT_TOKEN"),
+  appId: required("DISCORD_APP_ID"),
+});
+```
+
+`createBot` also accepts **multiple** adapters at once (`adapters: [slack(...),
+discord(...)]`) to run one bot across several platforms from a single process.
+For a fuller multi-platform, MCP-backed example, see
+[`examples/slack`](../slack).
 
 ## Tests
 

--- a/examples/opentag/README.md
+++ b/examples/opentag/README.md
@@ -1,0 +1,191 @@
+# OpenTag — a multi-platform bot starter (Slack · Discord · Telegram)
+
+The clean **"how to get started with CopilotKit bots"** starter. OpenTag is a
+thread-tagging assistant: @mention it (or run `/tag`) in a thread and it reads
+the conversation, proposes a label (`bug` / `question` / `feature` / `docs` /
+`urgent`), and — after you click **Apply** — posts the tag as a rich card.
+
+It's built with [`@copilotkit/bot`](../../packages/bot) (the platform-agnostic
+bot engine), one or more platform adapters
+([`-slack`](../../packages/bot-slack) /
+[`-discord`](../../packages/bot-discord) /
+[`-telegram`](../../packages/bot-telegram)), and
+[`@copilotkit/bot-ui`](../../packages/bot-ui) (a cross-platform JSX vocabulary
+for rich messages). It's the distilled sibling of
+[`examples/slack`](../slack) — the same engine and patterns, minus the kitchen
+sink (no MCP, no modals, no charts).
+
+**One app, any platform — or all at once.** `createBot` takes an array of
+adapters; `app/index.ts` includes Slack when `SLACK_*` are set, Discord when
+`DISCORD_*` are set, and Telegram when `TELEGRAM_BOT_TOKEN` is set. Everything
+in `app/` is platform-agnostic and shared verbatim.
+
+## What it teaches
+
+In ~250 lines of `app/`, OpenTag shows the whole shape of a CopilotKit bot:
+
+| Concept                                                                           | Where                                                   |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `createBot({ adapters, agent, tools, context, commands })`, secret-gated adapters | `app/index.ts`                                          |
+| The core turn loop — `bot.onMention` → `thread.runAgent()`                        | `app/index.ts`                                          |
+| A `BotTool` that grounds the agent in the real conversation                       | `app/tools/read-thread.ts`                              |
+| A generative-UI **render-tool** + JSX component                                   | `app/tools/tag-card.tsx`, `app/components/tag-card.tsx` |
+| A blocking **human-in-the-loop** gate (`thread.awaitChoice`)                      | `app/human-in-the-loop/confirm-tag.tsx`                 |
+| A slash command (`/tag`)                                                          | `app/commands/index.ts`                                 |
+| The agent backend — one `BuiltInAgent` (LLM, no MCP) over AG-UI                   | `runtime.ts`                                            |
+
+## Quickstart
+
+> **Coming soon:** `npx copilotkit create --framework opentag` will scaffold a
+> standalone copy in one command. Until that lands, run it from the monorepo:
+
+```bash
+# from the repo root
+pnpm install
+cp examples/opentag/.env.example examples/opentag/.env
+# …fill in secrets (see below), then in two terminals:
+pnpm --filter opentag runtime     # the agent backend on :8200
+pnpm --filter opentag dev         # the bot (tsx watch app/index.ts)
+```
+
+You need an `OPENAI_API_KEY` and the secrets for **at least one** platform.
+
+## How it fits together
+
+```
+Slack / Discord / Telegram ──@mention──▶ bot (app/) ──AG-UI──▶ runtime (runtime.ts)
+                                                                  └─ BuiltInAgent (LLM)
+```
+
+- **`app/`** — the platform-agnostic bot: `createBot` + whichever adapters have
+  secrets, the `read_thread` / `tag_card` tools, the `confirm_tag` HITL gate,
+  and the `/tag` command. **This is the directory you copy to start your own
+  bot.**
+- **`runtime.ts`** — the agent backend: a single CopilotKit `BuiltInAgent`
+  (an LLM) served over AG-UI. No Python, no LangGraph, no external services.
+
+## 1. Set up a platform
+
+Set the secrets for whichever platform(s) you want — the bot starts an adapter
+for each one whose secrets are present.
+
+### Slack (set `SLACK_*`)
+
+- <https://api.slack.com/apps?new_app=1> → **From a manifest** → paste
+  [`slack-app-manifest.yaml`](./slack-app-manifest.yaml).
+- _OAuth & Permissions_ → **Install to Workspace** → copy the `xoxb-` bot token
+  (`SLACK_BOT_TOKEN`).
+- _Basic Information → App-Level Tokens_ → generate one with `connections:write`
+  → copy the `xapp-` token (`SLACK_APP_TOKEN`).
+
+The manifest declares the `/tag` command, the assistant pane, and Socket Mode
+(so no public URL is needed).
+
+### Discord (set `DISCORD_*`)
+
+- <https://discord.com/developers/applications> → **New Application**.
+- **Bot** → copy the token (`DISCORD_BOT_TOKEN`); under **Privileged Gateway
+  Intents** enable **both** **Message Content** and **Server Members**.
+- **General Information** → copy the **Application ID** (`DISCORD_APP_ID`).
+- **OAuth2 → URL Generator** → scopes `bot` + `applications.commands` → open the
+  URL to add it to your server. Optionally set `DISCORD_GUILD_ID` so slash
+  commands register instantly during dev.
+
+### Telegram (set `TELEGRAM_BOT_TOKEN`)
+
+- Message **@BotFather** → `/newbot` → copy the HTTP API token
+  (`TELEGRAM_BOT_TOKEN`). Long-polling is the default — no public URL needed.
+- The bot auto-registers `/tag` via `setMyCommands` on start.
+
+## 2. Run it
+
+```bash
+cp .env.example .env       # then fill in OPENAI_API_KEY + your platform secrets
+pnpm --filter opentag runtime   # terminal 1 — agent on :8200
+pnpm --filter opentag dev       # terminal 2 — the bot
+```
+
+## 3. Try it
+
+@mention the bot in a thread (Slack/Discord) or DM it (Telegram), or run `/tag`:
+
+> @OpenTag tag this thread
+
+OpenTag reads the thread, proposes a label with a one-line rationale, and shows
+an **Apply / Cancel** card. Click **Apply** and it posts the applied tag.
+
+## Code walkthrough
+
+### The bot (`app/index.ts`)
+
+`createBot` takes the adapters that have secrets, the bot's tools + context, and
+the `/tag` command. One `onMention` handler covers @mentions and DMs on every
+active platform:
+
+```ts
+bot.onMention(async ({ thread, message }) => {
+  await thread.runAgent({
+    context: senderContext(message.user, thread.platform),
+  });
+});
+```
+
+### The tagging flow (tools + HITL)
+
+The system prompt (`runtime.ts`) steers a strict order: **read → confirm →
+apply.**
+
+1. `read_thread` — fetches the conversation via `thread.getMessages()` so the
+   agent tags what was actually said.
+2. `confirm_tag` — posts an Apply/Cancel card and **blocks** on
+   `thread.awaitChoice(...)`, returning `{ confirmed }`. Applying a tag is a
+   write, so the agent may never skip this.
+3. `tag_card` — only after approval, renders the `<TagCard>` component to show
+   the applied tag.
+
+```tsx
+// the human-in-the-loop gate, in app/human-in-the-loop/confirm-tag.tsx
+async handler({ label, rationale }, { thread }) {
+  const choice = await thread.awaitChoice<{ confirmed?: boolean }>(
+    <ConfirmTag label={label} rationale={rationale} />,
+  );
+  return choice?.confirmed
+    ? "The user APPROVED — apply the tag now by calling tag_card."
+    : "The user DECLINED — do not apply the tag; acknowledge briefly and stop.";
+}
+```
+
+### The agent (`runtime.ts`)
+
+A single CopilotKit `BuiltInAgent` (LLM, no MCP) served over AG-UI by a
+`CopilotSseRuntime`. The default model is `openai/gpt-5.5` (override with
+`AGENT_MODEL`). The bot's tools (`read_thread`, `confirm_tag`, `tag_card`) are
+forwarded to the agent on every run as client-side tools.
+
+## Make it yours
+
+- **Apply tags for real.** Today the "apply" is visual — the seam is the
+  `tag_card` tool handler in `app/tools/tag-card.tsx` (and the approval branch
+  in `confirm-tag.tsx`). Call your own system there: a GitHub Issues label, a
+  Linear update, a row in your DB.
+- **Change the taxonomy.** Edit the label list in the `runtime.ts` system prompt
+  and the colors in `app/components/tag-card.tsx`.
+- **Add a platform.** Add another adapter to the secret-gated block in
+  `app/index.ts` (e.g. `@copilotkit/bot-whatsapp`).
+- **Durable buttons.** Pass a `@copilotkit/bot-store-redis` store to `createBot`
+  so an Apply/Cancel click still resolves after a restart.
+
+## Tests
+
+```bash
+pnpm --filter opentag test         # unit tests: read_thread, tag_card, confirm_tag
+pnpm --filter opentag check-types  # tsc --noEmit
+```
+
+## Copying this out of the monorepo
+
+This example consumes the `@copilotkit/*` packages via `workspace:*`, so it
+builds from in-repo source. To run it standalone, replace those ranges in
+`package.json` with the published versions (e.g.
+`"@copilotkit/bot-slack": "^0.1.0"`) — `workspace:*` only resolves inside this
+monorepo.

--- a/examples/opentag/app/commands/index.ts
+++ b/examples/opentag/app/commands/index.ts
@@ -5,11 +5,10 @@
  *
  * NOTE: on Slack a command only fires if it's ALSO declared in the Slack app
  * config ("Slash Commands" / manifest) with the same name — Slack won't deliver
- * an unregistered command, even over Socket Mode. Discord and Telegram register
- * their commands up front via the adapter.
+ * an unregistered command, even over Socket Mode. (Other adapters register their
+ * commands up front; the engine routes by name regardless.)
  *
- * Args arrive as free text (`ctx.text`) on Slack; `ctx.options` is for surfaces
- * with native structured args (e.g. Discord).
+ * Args arrive as free text (`ctx.text`) on Slack.
  */
 import { defineBotCommand } from "@copilotkit/bot";
 import type { BotCommand } from "@copilotkit/bot";

--- a/examples/opentag/app/commands/index.ts
+++ b/examples/opentag/app/commands/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Slash commands for OpenTag. Each is registered with the engine via
+ * `createBot({ commands })`; an adapter forwards every `/command` it receives
+ * and the engine routes by name (ignoring unregistered ones).
+ *
+ * NOTE: on Slack a command only fires if it's ALSO declared in the Slack app
+ * config ("Slash Commands" / manifest) with the same name — Slack won't deliver
+ * an unregistered command, even over Socket Mode. Discord and Telegram register
+ * their commands up front via the adapter.
+ *
+ * Args arrive as free text (`ctx.text`) on Slack; `ctx.options` is for surfaces
+ * with native structured args (e.g. Discord).
+ */
+import { defineBotCommand } from "@copilotkit/bot";
+import type { BotCommand } from "@copilotkit/bot";
+import { senderContext } from "../sender-context.js";
+
+export const appCommands: BotCommand[] = [
+  // `/tag [note]` — a mention-free entry point. Runs the agent to read the
+  // current thread and propose a tag; an optional note steers it. Slash-command
+  // args are never posted to the channel, so we inject them as the prompt.
+  defineBotCommand({
+    name: "tag",
+    description: "Read this thread and suggest a tag (no @mention needed).",
+    async handler({ thread, text, user }) {
+      const prompt = text
+        ? `Tag this conversation. Extra context from the user: ${text}`
+        : "Tag this conversation: read the thread and propose the single best label.";
+      await thread.runAgent({
+        prompt,
+        context: senderContext(user, thread.platform),
+      });
+    },
+  }),
+];

--- a/examples/opentag/app/components/index.ts
+++ b/examples/opentag/app/components/index.ts
@@ -1,0 +1,7 @@
+/**
+ * App-specific render components — agent-renderable cards authored with the
+ * `@copilotkit/bot-ui` JSX vocabulary. Each component's exported zod prop
+ * schema doubles as its render-tool input schema.
+ */
+export { TagCard, tagCardSchema } from "./tag-card.js";
+export type { TagCardProps } from "./tag-card.js";

--- a/examples/opentag/app/components/tag-card.tsx
+++ b/examples/opentag/app/components/tag-card.tsx
@@ -3,10 +3,10 @@
  * the conversation: the label as a colored header, a one-line rationale, and an
  * optional confidence / "applied by" footer.
  *
- * Authored with the `@copilotkit/bot-ui` JSX vocabulary; each adapter renders
- * the same IR natively (Block Kit on Slack, Components V2 on Discord, HTML on
- * Telegram). Its exported zod prop schema doubles as the render-tool input
- * schema (see `app/tools/tag-card.tsx`).
+ * Authored with the `@copilotkit/bot-ui` JSX vocabulary, which renders to each
+ * platform's native format (Block Kit on Slack) — so the same component works
+ * unchanged on other adapters. Its exported zod prop schema doubles as the
+ * render-tool input schema (see `app/tools/tag-card.tsx`).
  */
 import { z } from "zod";
 import { Context, Header, Message, Section } from "@copilotkit/bot-ui";

--- a/examples/opentag/app/components/tag-card.tsx
+++ b/examples/opentag/app/components/tag-card.tsx
@@ -1,0 +1,69 @@
+/**
+ * `tag_card` component — a small card that shows the tag OpenTag has applied to
+ * the conversation: the label as a colored header, a one-line rationale, and an
+ * optional confidence / "applied by" footer.
+ *
+ * Authored with the `@copilotkit/bot-ui` JSX vocabulary; each adapter renders
+ * the same IR natively (Block Kit on Slack, Components V2 on Discord, HTML on
+ * Telegram). Its exported zod prop schema doubles as the render-tool input
+ * schema (see `app/tools/tag-card.tsx`).
+ */
+import { z } from "zod";
+import { Context, Header, Message, Section } from "@copilotkit/bot-ui";
+import type { BotNode } from "@copilotkit/bot-ui";
+
+/** Accent color per well-known label; unknown labels fall back to slate. */
+function accentForLabel(label: string): string {
+  switch (label.toLowerCase()) {
+    case "bug":
+      return "#EB5757"; // red
+    case "urgent":
+      return "#E2B340"; // amber
+    case "question":
+      return "#2D9CDB"; // blue
+    case "feature":
+      return "#27AE60"; // green
+    case "docs":
+      return "#9B51E0"; // purple
+    default:
+      return "#64748B"; // slate
+  }
+}
+
+export const tagCardSchema = z.object({
+  label: z.string().describe("The applied tag, e.g. 'bug' or 'question'."),
+  rationale: z
+    .string()
+    .describe("One-line reason this label fits, grounded in the thread."),
+  confidence: z
+    .enum(["high", "medium", "low"])
+    .optional()
+    .describe("How confident you are in the label."),
+  appliedBy: z
+    .string()
+    .optional()
+    .describe("Display name of the person who approved the tag, if known."),
+});
+
+export type TagCardProps = z.infer<typeof tagCardSchema>;
+
+/** Render an applied tag as a card. */
+export function TagCard({
+  label,
+  rationale,
+  confidence,
+  appliedBy,
+}: TagCardProps): BotNode {
+  const footer: string[] = [];
+  if (confidence) footer.push(`confidence: ${confidence}`);
+  if (appliedBy) footer.push(`applied by ${appliedBy}`);
+  const footerText = footer.length ? footer.join("   ·   ") : undefined;
+
+  return (
+    <Message accent={accentForLabel(label)}>
+      <Header>{`🏷️ Tagged: ${label}`}</Header>
+      <Section>{rationale}</Section>
+      {footerText ? <Context>{footerText}</Context> : null}
+    </Message>
+  );
+}

--- a/examples/opentag/app/context/app-context.ts
+++ b/examples/opentag/app/context/app-context.ts
@@ -1,9 +1,8 @@
 /**
  * App-specific context entries — bot identity, tone, and tagging policy.
- * Platform tagging/formatting/thread-model guidance ships in each adapter's
- * default context (`defaultSlackContext` / `defaultDiscordContext` /
- * `defaultTelegramContext`) and is spread per-bot in `app/index.ts`; this file
- * holds the platform-neutral identity + policy only.
+ * Platform tagging/formatting/thread-model guidance ships in the adapter's
+ * default context (`defaultSlackContext`) and is spread in `app/index.ts`; this
+ * file holds the platform-neutral identity + policy only.
  *
  * Each entry is `{ description, value }`. The SDK forwards them as AG-UI
  * `context` on every turn; the agent backend surfaces them as a system-level

--- a/examples/opentag/app/context/app-context.ts
+++ b/examples/opentag/app/context/app-context.ts
@@ -1,0 +1,31 @@
+/**
+ * App-specific context entries — bot identity, tone, and tagging policy.
+ * Platform tagging/formatting/thread-model guidance ships in each adapter's
+ * default context (`defaultSlackContext` / `defaultDiscordContext` /
+ * `defaultTelegramContext`) and is spread per-bot in `app/index.ts`; this file
+ * holds the platform-neutral identity + policy only.
+ *
+ * Each entry is `{ description, value }`. The SDK forwards them as AG-UI
+ * `context` on every turn; the agent backend surfaces them as a system-level
+ * "App Context:" message.
+ */
+import type { ContextEntry } from "@copilotkit/bot";
+
+export const appContext: ReadonlyArray<ContextEntry> = [
+  {
+    description: "Bot identity & tone",
+    value: [
+      "You are OpenTag, a concise thread-tagging assistant. Read the room, pick",
+      "ONE clear label, and explain it in a single line. Don't pad your replies —",
+      "the tag card is the answer.",
+    ].join("\n"),
+  },
+  {
+    description: "Tagging policy",
+    value: [
+      "Always read the thread before tagging, and always go through the",
+      "confirm_tag gate before applying a tag — applying a tag is a write and",
+      "must be approved by a human. Never apply more than one tag per request.",
+    ].join("\n"),
+  },
+];

--- a/examples/opentag/app/human-in-the-loop/__tests__/confirm-tag.test.tsx
+++ b/examples/opentag/app/human-in-the-loop/__tests__/confirm-tag.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * `confirm_tag` is a blocking HITL tool: it posts the `<ConfirmTag>` card via
+ * `thread.awaitChoice` and resolves to the clicked button's value. We test the
+ * card renders Apply/Cancel actions, and that the tool turns the resolved
+ * choice into the right instruction back to the agent.
+ */
+import { describe, it, expect } from "vitest";
+import { renderToIR } from "@copilotkit/bot-ui";
+import { renderSlackMessage } from "@copilotkit/bot-slack";
+import { ConfirmTag, confirmTagTool } from "../confirm-tag.js";
+
+describe("ConfirmTag card", () => {
+  it("renders the proposed label, rationale, and Apply/Cancel actions", () => {
+    const { blocks } = renderSlackMessage(
+      renderToIR(
+        <ConfirmTag label="bug" rationale="500 on submit, reproducible" />,
+      ),
+    );
+    const json = JSON.stringify(blocks);
+    expect(json).toContain("Apply");
+    expect(json).toContain("Cancel");
+    expect(json).toContain("500 on submit, reproducible");
+  });
+});
+
+describe("confirm_tag tool", () => {
+  it("tells the agent to apply the tag when the user approves", async () => {
+    const ctx = {
+      thread: { awaitChoice: async () => ({ confirmed: true }) },
+    } as never;
+    const result = await confirmTagTool.handler(
+      { label: "bug", rationale: "500 on submit" },
+      ctx,
+    );
+    expect(result).toContain("APPROVED");
+  });
+
+  it("tells the agent to stop when the user declines", async () => {
+    const ctx = {
+      thread: { awaitChoice: async () => ({ confirmed: false }) },
+    } as never;
+    const result = await confirmTagTool.handler(
+      { label: "bug", rationale: "500 on submit" },
+      ctx,
+    );
+    expect(result).toContain("DECLINED");
+  });
+});

--- a/examples/opentag/app/human-in-the-loop/confirm-tag.tsx
+++ b/examples/opentag/app/human-in-the-loop/confirm-tag.tsx
@@ -1,0 +1,102 @@
+/**
+ * `confirm_tag` — the human-in-the-loop gate in front of applying a tag.
+ * Applying a tag is a "write", so the agent (see the system prompt in
+ * `runtime.ts`) must call `confirm_tag` first: the handler calls
+ * `await thread.awaitChoice(<ConfirmTag .../>)`, which posts this Apply/Cancel
+ * card and **blocks until the user clicks**, resolving to the clicked button's
+ * `value` (`{ confirmed: true | false }`). The agent applies the tag (via
+ * `tag_card`) only when this returns `{ confirmed: true }`.
+ *
+ * Each button also carries an `onClick` that updates the card in place to a
+ * resolved/declined state — so the card reflects the decision the moment it's
+ * clicked. This is the bot-side equivalent of React's `useHumanInTheLoop`,
+ * expressed as plain JSX over the cross-platform bot-ui vocabulary.
+ */
+import { z } from "zod";
+import {
+  Message,
+  Header,
+  Section,
+  Context,
+  Actions,
+  Button,
+} from "@copilotkit/bot-ui";
+import type { InteractionContext } from "@copilotkit/bot-ui";
+import { defineBotTool } from "@copilotkit/bot";
+
+export interface ConfirmTagProps {
+  /** The label about to be applied, e.g. 'bug'. */
+  label: string;
+  /** One-line reason the label fits. */
+  rationale: string;
+}
+
+export function ConfirmTag({ label, rationale }: ConfirmTagProps) {
+  return (
+    <Message accent="#E2B340">
+      <Header>{`🏷️ Apply tag \`${label}\`?`}</Header>
+      <Section>{rationale}</Section>
+      <Context>{"🔒  No tag is applied until you click **Apply**."}</Context>
+      <Actions>
+        <Button
+          value={{ confirmed: true }}
+          style="primary"
+          onClick={async ({ thread, message }: InteractionContext) => {
+            await thread.update(
+              message.ref,
+              <Message accent="#27AE60">
+                <Header>{`✅ Applying \`${label}\``}</Header>
+                <Context>{"✅  Approved — applying the tag."}</Context>
+              </Message>,
+            );
+          }}
+        >
+          Apply
+        </Button>
+        <Button
+          value={{ confirmed: false }}
+          style="danger"
+          onClick={async ({ thread, message }: InteractionContext) => {
+            await thread.update(
+              message.ref,
+              <Message accent="#EB5757">
+                <Header>{`🚫 Tag \`${label}\` not applied`}</Header>
+                <Context>{"🚫  Declined — no tag was applied."}</Context>
+              </Message>,
+            );
+          }}
+        >
+          Cancel
+        </Button>
+      </Actions>
+    </Message>
+  );
+}
+
+export const confirmTagSchema = z.object({
+  label: z
+    .string()
+    .describe("The single label you propose to apply, e.g. 'bug'."),
+  rationale: z
+    .string()
+    .describe(
+      "One-line reason this label fits, grounded in the thread you read.",
+    ),
+});
+
+export const confirmTagTool = defineBotTool({
+  name: "confirm_tag",
+  description:
+    "Ask the user to approve applying a tag before you apply it. Posts an " +
+    "Apply/Cancel card and BLOCKS until the user clicks; returns " +
+    "{confirmed: boolean}. You MUST call this before applying any tag.",
+  parameters: confirmTagSchema,
+  async handler({ label, rationale }, { thread }) {
+    const choice = await thread.awaitChoice<{ confirmed?: boolean }>(
+      <ConfirmTag label={label} rationale={rationale} />,
+    );
+    return choice?.confirmed
+      ? "The user APPROVED — apply the tag now by calling tag_card."
+      : "The user DECLINED — do not apply the tag; acknowledge briefly and stop.";
+  },
+});

--- a/examples/opentag/app/human-in-the-loop/index.ts
+++ b/examples/opentag/app/human-in-the-loop/index.ts
@@ -1,0 +1,2 @@
+export { ConfirmTag, confirmTagTool, confirmTagSchema } from "./confirm-tag.js";
+export type { ConfirmTagProps } from "./confirm-tag.js";

--- a/examples/opentag/app/index.ts
+++ b/examples/opentag/app/index.ts
@@ -3,14 +3,19 @@
  * `runtime.ts` holds the AG-UI agent backend (a CopilotKit `BuiltInAgent`);
  * this directory holds everything that runs on the chat-platform side.
  *
- * MULTI-PLATFORM: this single app drives Slack, Discord, and/or Telegram from
- * one process. `@copilotkit/bot`'s `createBot` accepts an array of adapters and
- * starts them all, so we include each platform's adapter only when its secrets
- * are present. Drop in `SLACK_*` for Slack, `DISCORD_*` for Discord,
- * `TELEGRAM_BOT_TOKEN` for Telegram — or any combination. Everything else in
- * `app/` (tools, the tag card, the confirm_tag HITL gate, the /tag command) is
- * platform-agnostic and shared verbatim. This is the directory you copy to
- * start your own bot.
+ * MULTI-PLATFORM: this single app drives Slack and/or Discord from one process.
+ * `@copilotkit/bot`'s `createBot` accepts an array of adapters and starts them
+ * all, so we include each platform's adapter only when its secrets are present.
+ * Drop in `SLACK_*` for Slack, `DISCORD_*` for Discord — or both. Everything
+ * else in `app/` (tools, the tag card, the confirm_tag HITL gate, the /tag
+ * command) is platform-agnostic and shared verbatim. This is the directory you
+ * copy to start your own bot.
+ *
+ * Adding another platform (Telegram, WhatsApp): the engine is platform-agnostic,
+ * so a new surface is just another secret-gated adapter block below (e.g.
+ * `@copilotkit/bot-telegram`). Telegram is left out here only until
+ * `@copilotkit/bot-telegram` is published to npm, so a standalone clone can
+ * `npm install` the whole thing.
  */
 import "dotenv/config";
 import { createBot } from "@copilotkit/bot";
@@ -26,11 +31,6 @@ import {
   defaultDiscordTools,
   defaultDiscordContext,
 } from "@copilotkit/bot-discord";
-import {
-  telegram,
-  defaultTelegramTools,
-  defaultTelegramContext,
-} from "@copilotkit/bot-telegram";
 import { appTools } from "./tools/index.js";
 import { appContext } from "./context/app-context.js";
 import { appCommands } from "./commands/index.js";
@@ -103,17 +103,10 @@ async function main() {
     context.push(...defaultDiscordContext);
   }
 
-  if (have("TELEGRAM_BOT_TOKEN")) {
-    // Telegram long-polls by default (no public URL / webhook needed).
-    adapters.push(telegram({ token: required("TELEGRAM_BOT_TOKEN") }));
-    tools.push(...defaultTelegramTools);
-    context.push(...defaultTelegramContext);
-  }
-
   if (adapters.length === 0) {
     console.error(
-      "No platform secrets found. Set SLACK_BOT_TOKEN + SLACK_APP_TOKEN, " +
-        "DISCORD_BOT_TOKEN + DISCORD_APP_ID, and/or TELEGRAM_BOT_TOKEN (see README).",
+      "No platform secrets found. Set SLACK_BOT_TOKEN + SLACK_APP_TOKEN " +
+        "and/or DISCORD_BOT_TOKEN + DISCORD_APP_ID (see README).",
     );
     process.exit(1);
   }
@@ -124,7 +117,7 @@ async function main() {
     // CopilotKit `BuiltInAgent` (CopilotSseRuntime), which does NOT require a
     // UUID-format threadId, so the raw conversation thread id is fine.
     // `SanitizingHttpAgent` is a lenient superset of `HttpAgent`; one factory
-    // covers Slack, Discord, and Telegram alike.
+    // covers Slack and Discord alike.
     agent: (threadId) => {
       const a = new SanitizingHttpAgent({
         url: agentUrl,
@@ -139,9 +132,9 @@ async function main() {
     tools,
     context,
     // The `/tag` slash command. On Slack it must ALSO be declared in the app
-    // config (paste `slack-app-manifest.yaml`); Discord and Telegram register
-    // commands up front. The engine routes by name; adapters that can't take
-    // commands ignore them.
+    // config (paste `slack-app-manifest.yaml`); Discord registers commands up
+    // front. The engine routes by name; adapters that can't take commands ignore
+    // them.
     commands: appCommands,
   });
 
@@ -163,8 +156,8 @@ async function main() {
 
   // Slack-only nicety: set the assistant-pane prompt chips when a pane opens.
   // Harmless elsewhere — `onThreadStarted` only fires from adapters that emit it
-  // (Discord/Telegram have no assistant pane), and platforms without
-  // suggested-prompt support no-op.
+  // (Discord has no assistant pane), and platforms without suggested-prompt
+  // support no-op.
   bot.onThreadStarted(async ({ thread }) => {
     await thread.setSuggestedPrompts([
       { title: "Tag this thread", message: "Tag this thread" },

--- a/examples/opentag/app/index.ts
+++ b/examples/opentag/app/index.ts
@@ -3,34 +3,21 @@
  * `runtime.ts` holds the AG-UI agent backend (a CopilotKit `BuiltInAgent`);
  * this directory holds everything that runs on the chat-platform side.
  *
- * MULTI-PLATFORM: this single app drives Slack and/or Discord from one process.
- * `@copilotkit/bot`'s `createBot` accepts an array of adapters and starts them
- * all, so we include each platform's adapter only when its secrets are present.
- * Drop in `SLACK_*` for Slack, `DISCORD_*` for Discord — or both. Everything
- * else in `app/` (tools, the tag card, the confirm_tag HITL gate, the /tag
- * command) is platform-agnostic and shared verbatim. This is the directory you
- * copy to start your own bot.
- *
- * Adding another platform (Telegram, WhatsApp): the engine is platform-agnostic,
- * so a new surface is just another secret-gated adapter block below (e.g.
- * `@copilotkit/bot-telegram`). Telegram is left out here only until
- * `@copilotkit/bot-telegram` is published to npm, so a standalone clone can
- * `npm install` the whole thing.
+ * This is the directory you copy to start your own bot. It runs on Slack via
+ * `@copilotkit/bot-slack` over Socket Mode (no public URL needed). Everything in
+ * `app/` (the tools, the tag card, the confirm_tag HITL gate, the /tag command)
+ * is platform-agnostic, so moving to another surface is just swapping the
+ * adapter: `@copilotkit/bot` ships `-discord`, `-telegram`, `-whatsapp`, and
+ * `-teams` adapters with the same shape. See the README ("Run it elsewhere").
  */
 import "dotenv/config";
 import { createBot } from "@copilotkit/bot";
-import type { PlatformAdapter, BotTool, ContextEntry } from "@copilotkit/bot";
 import {
   slack,
   defaultSlackTools,
   defaultSlackContext,
   SanitizingHttpAgent,
 } from "@copilotkit/bot-slack";
-import {
-  discord,
-  defaultDiscordTools,
-  defaultDiscordContext,
-} from "@copilotkit/bot-discord";
 import { appTools } from "./tools/index.js";
 import { appContext } from "./context/app-context.js";
 import { appCommands } from "./commands/index.js";
@@ -39,15 +26,13 @@ import { senderContext } from "./sender-context.js";
 const required = (name: string): string => {
   const v = process.env[name];
   if (!v) {
-    console.error(`Missing required env var: ${name}`);
+    console.error(
+      `Missing required env var: ${name} (see README / .env.example)`,
+    );
     process.exit(1);
   }
   return v;
 };
-
-/** True only when every named env var is set and non-empty. */
-const have = (...names: string[]): boolean =>
-  names.every((n) => Boolean(process.env[n]));
 
 async function main() {
   const agentUrl = required("AGENT_URL");
@@ -55,69 +40,35 @@ async function main() {
     ? { Authorization: process.env.AGENT_AUTH_HEADER }
     : undefined;
 
-  // Build the platform list from whichever secrets are present. Each adapter
-  // contributes its own built-in tools (e.g. `lookup_*_user`) and context
-  // (tagging + formatting guidance), added only when that platform is active so
-  // the model isn't handed a different platform's conventions.
-  const adapters: PlatformAdapter[] = [];
-  const tools: BotTool[] = [...appTools];
-  const context: ContextEntry[] = [...appContext];
-
-  if (have("SLACK_BOT_TOKEN", "SLACK_APP_TOKEN")) {
-    adapters.push(
-      slack({
-        botToken: required("SLACK_BOT_TOKEN"),
-        appToken: required("SLACK_APP_TOKEN"),
-        // Keep DMs conversational and respond to explicit @mentions in
-        // channels/threads. Plain channel replies stay quiet unless they
-        // mention OpenTag again.
-        respondTo: {
-          directMessages: true,
-          appMentions: { reply: "thread" },
-          threadReplies: "mentionsOnly",
-        },
-        // Assistant pane greeting + chips (shown when a user opens the pane).
-        assistant: {
-          greeting: "Hi! Mention me in a thread and I'll suggest a tag.",
-          suggestedPrompts: [
-            { title: "Tag this thread", message: "Tag this thread" },
-          ],
-        },
-      }),
-    );
-    tools.push(...defaultSlackTools);
-    context.push(...defaultSlackContext);
-  }
-
-  if (have("DISCORD_BOT_TOKEN", "DISCORD_APP_ID")) {
-    adapters.push(
-      discord({
-        botToken: required("DISCORD_BOT_TOKEN"),
-        appId: required("DISCORD_APP_ID"),
-        // Optional: register slash commands to one guild instantly during dev
-        // (global commands can take up to ~1h to propagate). Omit in prod.
-        guildId: process.env.DISCORD_GUILD_ID,
-      }),
-    );
-    tools.push(...defaultDiscordTools);
-    context.push(...defaultDiscordContext);
-  }
-
-  if (adapters.length === 0) {
-    console.error(
-      "No platform secrets found. Set SLACK_BOT_TOKEN + SLACK_APP_TOKEN " +
-        "and/or DISCORD_BOT_TOKEN + DISCORD_APP_ID (see README).",
-    );
-    process.exit(1);
-  }
+  // The Slack adapter. It contributes its own built-in tools (`lookup_slack_user`)
+  // and context (Slack tagging + formatting guidance), which we add alongside
+  // OpenTag's own tools/context below.
+  const slackAdapter = slack({
+    botToken: required("SLACK_BOT_TOKEN"),
+    appToken: required("SLACK_APP_TOKEN"),
+    // Keep DMs conversational and respond to explicit @mentions in
+    // channels/threads. Plain channel replies stay quiet unless they mention
+    // OpenTag again.
+    respondTo: {
+      directMessages: true,
+      appMentions: { reply: "thread" },
+      threadReplies: "mentionsOnly",
+    },
+    // Assistant pane greeting + chips (shown when a user opens the pane).
+    assistant: {
+      greeting: "Hi! Mention me in a thread and I'll suggest a tag.",
+      suggestedPrompts: [
+        { title: "Tag this thread", message: "Tag this thread" },
+      ],
+    },
+  });
 
   const bot = createBot({
-    adapters,
+    adapters: [slackAdapter],
     // One AG-UI agent per conversation, pointed at the runtime. The backend is a
     // CopilotKit `BuiltInAgent` (CopilotSseRuntime), which does NOT require a
     // UUID-format threadId, so the raw conversation thread id is fine.
-    // `SanitizingHttpAgent` is a lenient superset of `HttpAgent`; one factory
-    // covers Slack and Discord alike.
+    // `SanitizingHttpAgent` is a lenient superset of `HttpAgent`.
     agent: (threadId) => {
       const a = new SanitizingHttpAgent({
         url: agentUrl,
@@ -126,21 +77,20 @@ async function main() {
       a.threadId = threadId;
       return a;
     },
-    // `appTools` adds OpenTag's tools (read_thread, confirm_tag, tag_card); the
-    // per-platform `default*Tools` add `lookup_*_user`. `default*Context` ships
-    // tagging/formatting guidance; `appContext` adds OpenTag's identity + policy.
-    tools,
-    context,
+    // `appTools` adds OpenTag's tools (read_thread, confirm_tag, tag_card);
+    // `defaultSlackTools` adds `lookup_slack_user`. `defaultSlackContext` ships
+    // Slack tagging/formatting guidance; `appContext` adds OpenTag's identity +
+    // policy.
+    tools: [...appTools, ...defaultSlackTools],
+    context: [...appContext, ...defaultSlackContext],
     // The `/tag` slash command. On Slack it must ALSO be declared in the app
-    // config (paste `slack-app-manifest.yaml`); Discord registers commands up
-    // front. The engine routes by name; adapters that can't take commands ignore
-    // them.
+    // config (paste `slack-app-manifest.yaml`); the engine routes by name.
     commands: appCommands,
   });
 
-  // One handler covers explicit @-mentions and DMs across every active platform.
-  // `senderContext` names the requesting user per `thread.platform`. Wrap the
-  // run so a failed turn is logged and surfaced instead of crashing the process.
+  // One handler covers explicit @-mentions and DMs. `senderContext` names the
+  // requesting user. Wrap the run so a failed turn is logged and surfaced
+  // instead of crashing the process.
   bot.onMention(async ({ thread, message }) => {
     try {
       await thread.runAgent({
@@ -154,10 +104,7 @@ async function main() {
     }
   });
 
-  // Slack-only nicety: set the assistant-pane prompt chips when a pane opens.
-  // Harmless elsewhere — `onThreadStarted` only fires from adapters that emit it
-  // (Discord has no assistant pane), and platforms without suggested-prompt
-  // support no-op.
+  // Set the assistant-pane prompt chips when a Slack pane opens.
   bot.onThreadStarted(async ({ thread }) => {
     await thread.setSuggestedPrompts([
       { title: "Tag this thread", message: "Tag this thread" },
@@ -165,9 +112,7 @@ async function main() {
   });
 
   await bot.start();
-  console.log(
-    `[opentag] started on: ${adapters.map((a) => a.platform).join(", ")}`,
-  );
+  console.log("[opentag] started on: slack");
 
   const shutdown = async (signal: string) => {
     console.log(`\n[opentag] received ${signal}, stopping…`);

--- a/examples/opentag/app/index.ts
+++ b/examples/opentag/app/index.ts
@@ -1,0 +1,201 @@
+/**
+ * The OpenTag bot application — user-land code, not SDK code. The companion
+ * `runtime.ts` holds the AG-UI agent backend (a CopilotKit `BuiltInAgent`);
+ * this directory holds everything that runs on the chat-platform side.
+ *
+ * MULTI-PLATFORM: this single app drives Slack, Discord, and/or Telegram from
+ * one process. `@copilotkit/bot`'s `createBot` accepts an array of adapters and
+ * starts them all, so we include each platform's adapter only when its secrets
+ * are present. Drop in `SLACK_*` for Slack, `DISCORD_*` for Discord,
+ * `TELEGRAM_BOT_TOKEN` for Telegram — or any combination. Everything else in
+ * `app/` (tools, the tag card, the confirm_tag HITL gate, the /tag command) is
+ * platform-agnostic and shared verbatim. This is the directory you copy to
+ * start your own bot.
+ */
+import "dotenv/config";
+import { createBot } from "@copilotkit/bot";
+import type { PlatformAdapter, BotTool, ContextEntry } from "@copilotkit/bot";
+import {
+  slack,
+  defaultSlackTools,
+  defaultSlackContext,
+  SanitizingHttpAgent,
+} from "@copilotkit/bot-slack";
+import {
+  discord,
+  defaultDiscordTools,
+  defaultDiscordContext,
+} from "@copilotkit/bot-discord";
+import {
+  telegram,
+  defaultTelegramTools,
+  defaultTelegramContext,
+} from "@copilotkit/bot-telegram";
+import { appTools } from "./tools/index.js";
+import { appContext } from "./context/app-context.js";
+import { appCommands } from "./commands/index.js";
+import { senderContext } from "./sender-context.js";
+
+const required = (name: string): string => {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return v;
+};
+
+/** True only when every named env var is set and non-empty. */
+const have = (...names: string[]): boolean =>
+  names.every((n) => Boolean(process.env[n]));
+
+async function main() {
+  const agentUrl = required("AGENT_URL");
+  const agentHeaders = process.env.AGENT_AUTH_HEADER
+    ? { Authorization: process.env.AGENT_AUTH_HEADER }
+    : undefined;
+
+  // Build the platform list from whichever secrets are present. Each adapter
+  // contributes its own built-in tools (e.g. `lookup_*_user`) and context
+  // (tagging + formatting guidance), added only when that platform is active so
+  // the model isn't handed a different platform's conventions.
+  const adapters: PlatformAdapter[] = [];
+  const tools: BotTool[] = [...appTools];
+  const context: ContextEntry[] = [...appContext];
+
+  if (have("SLACK_BOT_TOKEN", "SLACK_APP_TOKEN")) {
+    adapters.push(
+      slack({
+        botToken: required("SLACK_BOT_TOKEN"),
+        appToken: required("SLACK_APP_TOKEN"),
+        // Keep DMs conversational and respond to explicit @mentions in
+        // channels/threads. Plain channel replies stay quiet unless they
+        // mention OpenTag again.
+        respondTo: {
+          directMessages: true,
+          appMentions: { reply: "thread" },
+          threadReplies: "mentionsOnly",
+        },
+        // Assistant pane greeting + chips (shown when a user opens the pane).
+        assistant: {
+          greeting: "Hi! Mention me in a thread and I'll suggest a tag.",
+          suggestedPrompts: [
+            { title: "Tag this thread", message: "Tag this thread" },
+          ],
+        },
+      }),
+    );
+    tools.push(...defaultSlackTools);
+    context.push(...defaultSlackContext);
+  }
+
+  if (have("DISCORD_BOT_TOKEN", "DISCORD_APP_ID")) {
+    adapters.push(
+      discord({
+        botToken: required("DISCORD_BOT_TOKEN"),
+        appId: required("DISCORD_APP_ID"),
+        // Optional: register slash commands to one guild instantly during dev
+        // (global commands can take up to ~1h to propagate). Omit in prod.
+        guildId: process.env.DISCORD_GUILD_ID,
+      }),
+    );
+    tools.push(...defaultDiscordTools);
+    context.push(...defaultDiscordContext);
+  }
+
+  if (have("TELEGRAM_BOT_TOKEN")) {
+    // Telegram long-polls by default (no public URL / webhook needed).
+    adapters.push(telegram({ token: required("TELEGRAM_BOT_TOKEN") }));
+    tools.push(...defaultTelegramTools);
+    context.push(...defaultTelegramContext);
+  }
+
+  if (adapters.length === 0) {
+    console.error(
+      "No platform secrets found. Set SLACK_BOT_TOKEN + SLACK_APP_TOKEN, " +
+        "DISCORD_BOT_TOKEN + DISCORD_APP_ID, and/or TELEGRAM_BOT_TOKEN (see README).",
+    );
+    process.exit(1);
+  }
+
+  const bot = createBot({
+    adapters,
+    // One AG-UI agent per conversation, pointed at the runtime. The backend is a
+    // CopilotKit `BuiltInAgent` (CopilotSseRuntime), which does NOT require a
+    // UUID-format threadId, so the raw conversation thread id is fine.
+    // `SanitizingHttpAgent` is a lenient superset of `HttpAgent`; one factory
+    // covers Slack, Discord, and Telegram alike.
+    agent: (threadId) => {
+      const a = new SanitizingHttpAgent({
+        url: agentUrl,
+        headers: agentHeaders,
+      });
+      a.threadId = threadId;
+      return a;
+    },
+    // `appTools` adds OpenTag's tools (read_thread, confirm_tag, tag_card); the
+    // per-platform `default*Tools` add `lookup_*_user`. `default*Context` ships
+    // tagging/formatting guidance; `appContext` adds OpenTag's identity + policy.
+    tools,
+    context,
+    // The `/tag` slash command. On Slack it must ALSO be declared in the app
+    // config (paste `slack-app-manifest.yaml`); Discord and Telegram register
+    // commands up front. The engine routes by name; adapters that can't take
+    // commands ignore them.
+    commands: appCommands,
+  });
+
+  // One handler covers explicit @-mentions and DMs across every active platform.
+  // `senderContext` names the requesting user per `thread.platform`. Wrap the
+  // run so a failed turn is logged and surfaced instead of crashing the process.
+  bot.onMention(async ({ thread, message }) => {
+    try {
+      await thread.runAgent({
+        context: senderContext(message.user, thread.platform),
+      });
+    } catch (err) {
+      console.error("[opentag] agent run failed", err);
+      await thread
+        .post("Sorry — I hit an error handling that. Please try again.")
+        .catch(() => {});
+    }
+  });
+
+  // Slack-only nicety: set the assistant-pane prompt chips when a pane opens.
+  // Harmless elsewhere — `onThreadStarted` only fires from adapters that emit it
+  // (Discord/Telegram have no assistant pane), and platforms without
+  // suggested-prompt support no-op.
+  bot.onThreadStarted(async ({ thread }) => {
+    await thread.setSuggestedPrompts([
+      { title: "Tag this thread", message: "Tag this thread" },
+    ]);
+  });
+
+  await bot.start();
+  console.log(
+    `[opentag] started on: ${adapters.map((a) => a.platform).join(", ")}`,
+  );
+
+  const shutdown = async (signal: string) => {
+    console.log(`\n[opentag] received ${signal}, stopping…`);
+    await bot.stop();
+    process.exit(0);
+  };
+  process.on("SIGINT", () => void shutdown("SIGINT"));
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+}
+
+// Fail loud, not silent: surface stray async errors instead of letting them
+// kill the process with no log. Log and keep running — one bad turn shouldn't
+// take the bot down.
+process.on("unhandledRejection", (reason) => {
+  console.error("[opentag] unhandledRejection:", reason);
+});
+process.on("uncaughtException", (err) => {
+  console.error("[opentag] uncaughtException:", err);
+});
+
+main().catch((err) => {
+  console.error("[opentag] fatal", err);
+  process.exit(1);
+});

--- a/examples/opentag/app/sender-context.ts
+++ b/examples/opentag/app/sender-context.ts
@@ -6,8 +6,8 @@ import type { PlatformUser } from "@copilotkit/bot-ui";
  * "as" them and attribute the tag. The platform adapter resolves
  * `{ id, name?, email? }` per turn; if it's absent there's nothing to
  * attribute, so we add no entry. `platform` is the surface the turn came from
- * (`thread.platform`), so the label is correct across Slack, Discord, and
- * Telegram alike.
+ * (`thread.platform`, `"slack"` here) — kept generic so the same helper works
+ * unchanged if you swap in another adapter.
  */
 export function senderContext(
   user: PlatformUser | undefined,

--- a/examples/opentag/app/sender-context.ts
+++ b/examples/opentag/app/sender-context.ts
@@ -1,0 +1,21 @@
+import type { ContextEntry } from "@copilotkit/bot";
+import type { PlatformUser } from "@copilotkit/bot-ui";
+
+/**
+ * Build the per-turn context naming the requesting user, so the agent can act
+ * "as" them and attribute the tag. The platform adapter resolves
+ * `{ id, name?, email? }` per turn; if it's absent there's nothing to
+ * attribute, so we add no entry. `platform` is the surface the turn came from
+ * (`thread.platform`), so the label is correct across Slack, Discord, and
+ * Telegram alike.
+ */
+export function senderContext(
+  user: PlatformUser | undefined,
+  platform: string,
+): ContextEntry[] {
+  // `createBot` substitutes `{ id: "" }` for an unresolved sender (a truthy
+  // object), so guard on a usable id — not mere object presence.
+  if (!user?.id) return [];
+  const label = `${user.name ?? user.id}${user.email ? ` <${user.email}>` : ""} (${platform} id ${user.id})`;
+  return [{ description: `Requesting ${platform} user`, value: label }];
+}

--- a/examples/opentag/app/tools/__tests__/read-thread.test.ts
+++ b/examples/opentag/app/tools/__tests__/read-thread.test.ts
@@ -1,0 +1,55 @@
+/**
+ * `read_thread` maps the platform-agnostic `thread.getMessages()` result into a
+ * compact chronological transcript for the agent. We drive it with a fake
+ * `thread` that returns a couple of messages and assert the shape.
+ */
+import { describe, it, expect } from "vitest";
+import { readThreadTool } from "../read-thread.js";
+
+describe("read_thread tool", () => {
+  it("returns a compact transcript of the thread messages", async () => {
+    const messages = [
+      {
+        user: { name: "Ada" },
+        text: "the build is broken",
+        ts: "1",
+        isBot: false,
+      },
+      { user: { name: "Lin" }, text: "since when?", ts: "2", isBot: false },
+    ];
+    const ctx = {
+      thread: { getMessages: async () => messages },
+    } as never;
+
+    const result = (await readThreadTool.handler({}, ctx)) as {
+      count: number;
+      messages: { user: string; text: string; ts: string }[];
+    };
+
+    expect(result.count).toBe(2);
+    expect(result.messages[0]).toEqual({
+      user: "Ada",
+      text: "the build is broken",
+      ts: "1",
+    });
+    expect(result.messages[1]!.user).toBe("Lin");
+  });
+
+  it("falls back to 'bot'/'unknown' when the author can't be resolved", async () => {
+    const ctx = {
+      thread: {
+        getMessages: async () => [
+          { user: undefined, text: "beep", ts: "1", isBot: true },
+          { user: undefined, text: "?", ts: "2", isBot: false },
+        ],
+      },
+    } as never;
+
+    const result = (await readThreadTool.handler({}, ctx)) as {
+      messages: { user: string }[];
+    };
+
+    expect(result.messages[0]!.user).toBe("bot");
+    expect(result.messages[1]!.user).toBe("unknown");
+  });
+});

--- a/examples/opentag/app/tools/__tests__/tag-card.test.tsx
+++ b/examples/opentag/app/tools/__tests__/tag-card.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * The `tag_card` render-tool posts the finished `<TagCard>` to the thread. We
+ * drive the handler with a minimal fake `thread` whose `post` records the
+ * posted Renderable, then assert that rendering it through the shared
+ * `renderToIR` → `renderSlackMessage` path yields the expected Block Kit shape.
+ */
+import { describe, it, expect } from "vitest";
+import { renderToIR } from "@copilotkit/bot-ui";
+import { renderSlackMessage } from "@copilotkit/bot-slack";
+import { tagCardTool } from "../tag-card.js";
+
+/** A fake `thread` that records each posted Renderable. */
+function fakeThread() {
+  const posts: unknown[] = [];
+  const thread = {
+    post: async (ui: unknown) => {
+      posts.push(ui);
+      return { id: "m1" };
+    },
+  };
+  return { posts, ctx: { thread, platform: "slack" } as never };
+}
+
+describe("tag_card render-tool", () => {
+  it("posts a TagCard rendering to a label header + rationale", async () => {
+    const { posts, ctx } = fakeThread();
+    const result = await tagCardTool.handler(
+      {
+        label: "bug",
+        rationale: "Reporter hit a 500 on submit; reproducible.",
+        confidence: "high",
+      },
+      ctx,
+    );
+
+    expect(posts).toHaveLength(1);
+    expect(result).toBe("Displayed the applied tag card to the user.");
+
+    const { blocks } = renderSlackMessage(renderToIR(posts[0] as never));
+    expect(blocks[0]).toMatchObject({
+      type: "header",
+      text: { type: "plain_text", text: "🏷️ Tagged: bug" },
+    });
+    const json = JSON.stringify(blocks);
+    expect(json).toContain("Reporter hit a 500 on submit; reproducible.");
+    expect(json).toContain("confidence: high");
+  });
+});

--- a/examples/opentag/app/tools/index.ts
+++ b/examples/opentag/app/tools/index.ts
@@ -1,0 +1,24 @@
+/**
+ * App-specific frontend tools. Add new tools here and re-export them through
+ * `appTools`, then wire the array into
+ * `createBot({ tools: [...defaultSlackTools, ...appTools] })` in `app/index.ts`.
+ *
+ * Every tool is a plain `BotTool`: its handler receives the generic
+ * `BotToolContext` (`{ thread, message?, user?, signal?, platform }`) the
+ * adapter supplies at call time. Platform power (post, `thread.getMessages()`,
+ * `thread.awaitChoice()`, …) is reached via the `thread` methods, so there's no
+ * per-adapter context and no cast needed — the array assigns straight into
+ * `createBot({ tools })`.
+ */
+import { readThreadTool } from "./read-thread.js";
+import { tagCardTool } from "./tag-card.js";
+import { confirmTagTool } from "../human-in-the-loop/index.js";
+import type { BotTool } from "@copilotkit/bot";
+
+export const appTools: BotTool[] = [
+  readThreadTool,
+  confirmTagTool,
+  tagCardTool,
+];
+
+export { readThreadTool, tagCardTool, confirmTagTool };

--- a/examples/opentag/app/tools/read-thread.ts
+++ b/examples/opentag/app/tools/read-thread.ts
@@ -1,0 +1,32 @@
+/**
+ * `read_thread` — an app-side `BotTool` that hands the agent the full
+ * conversation thread it's replying in. This is what lets OpenTag tag a real
+ * conversation: the agent calls `read_thread`, gets the actual messages, and
+ * reasons about those instead of inventing content.
+ *
+ * It's a worked example of a `BotTool` that reads conversation history via the
+ * platform-agnostic `ctx.thread.getMessages()` capability — the adapter targets
+ * the current thread, so no channel/ts plumbing is needed.
+ */
+import { z } from "zod";
+import { defineBotTool } from "@copilotkit/bot";
+
+export const readThreadTool = defineBotTool({
+  name: "read_thread",
+  description:
+    "Fetch the messages in the current conversation thread so you can decide " +
+    "how to tag it. Call this before proposing a tag — never guess what was " +
+    "said. Returns the messages in chronological order with author and timestamp.",
+  parameters: z.object({}),
+  async handler(_args, { thread }) {
+    const messages = await thread.getMessages();
+    return {
+      count: messages.length,
+      messages: messages.map((m) => ({
+        user: m.user?.name ?? m.user?.handle ?? (m.isBot ? "bot" : "unknown"),
+        text: m.text,
+        ts: m.ts,
+      })),
+    };
+  },
+});

--- a/examples/opentag/app/tools/tag-card.tsx
+++ b/examples/opentag/app/tools/tag-card.tsx
@@ -1,0 +1,23 @@
+/**
+ * `tag_card` render-tool — the agent-facing wrapper that posts the finished
+ * `<TagCard>` to the thread. The agent calls it AFTER `confirm_tag` is approved,
+ * to show the tag that was applied.
+ *
+ * A render-tool is just a `BotTool` whose handler renders a JSX component and
+ * posts it: the agent calls the tool, the handler draws the card.
+ */
+import { defineBotTool } from "@copilotkit/bot";
+import { TagCard, tagCardSchema } from "../components/index.js";
+
+export const tagCardTool = defineBotTool({
+  name: "tag_card",
+  description:
+    "Show the tag you've applied as a rich card (colored header, the label, " +
+    "and a one-line rationale). Call this ONLY after confirm_tag returns " +
+    "approved — it represents the tag being applied.",
+  parameters: tagCardSchema,
+  async handler(props, { thread }) {
+    await thread.post(<TagCard {...props} />);
+    return "Displayed the applied tag card to the user.";
+  },
+});

--- a/examples/opentag/package.json
+++ b/examples/opentag/package.json
@@ -16,7 +16,6 @@
     "@copilotkit/bot": "workspace:*",
     "@copilotkit/bot-discord": "workspace:*",
     "@copilotkit/bot-slack": "workspace:*",
-    "@copilotkit/bot-telegram": "workspace:*",
     "@copilotkit/bot-ui": "workspace:*",
     "@copilotkit/runtime": "workspace:*",
     "@tanstack/ai": "^0.32.0",

--- a/examples/opentag/package.json
+++ b/examples/opentag/package.json
@@ -2,7 +2,7 @@
   "name": "opentag",
   "version": "0.0.1",
   "private": true,
-  "description": "OpenTag — a minimal multi-platform CopilotKit bot starter. A thread-tagging assistant on Slack, Discord, and/or Telegram: it reads a thread, proposes a label, and applies it after a human-in-the-loop confirm. Built on @copilotkit/bot.",
+  "description": "OpenTag — a minimal CopilotKit bot starter for Slack. A thread-tagging assistant: it reads a thread, proposes a label, and applies it after a human-in-the-loop confirm. Built on @copilotkit/bot; the same app runs on Discord/Telegram/WhatsApp/Teams by swapping the adapter.",
   "license": "MIT",
   "type": "module",
   "scripts": {
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@copilotkit/bot": "workspace:*",
-    "@copilotkit/bot-discord": "workspace:*",
     "@copilotkit/bot-slack": "workspace:*",
     "@copilotkit/bot-ui": "workspace:*",
     "@copilotkit/runtime": "workspace:*",

--- a/examples/opentag/package.json
+++ b/examples/opentag/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "opentag",
+  "version": "0.0.1",
+  "private": true,
+  "description": "OpenTag — a minimal multi-platform CopilotKit bot starter. A thread-tagging assistant on Slack, Discord, and/or Telegram: it reads a thread, proposes a label, and applies it after a human-in-the-loop confirm. Built on @copilotkit/bot.",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch app/index.ts",
+    "start": "tsx app/index.ts",
+    "runtime": "tsx runtime.ts",
+    "check-types": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@copilotkit/bot": "workspace:*",
+    "@copilotkit/bot-discord": "workspace:*",
+    "@copilotkit/bot-slack": "workspace:*",
+    "@copilotkit/bot-telegram": "workspace:*",
+    "@copilotkit/bot-ui": "workspace:*",
+    "@copilotkit/runtime": "workspace:*",
+    "@tanstack/ai": "^0.32.0",
+    "@tanstack/ai-openai": "^0.15.2",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "dotenv": "^16.4.5",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3",
+    "vitest": "^4.1.3"
+  }
+}

--- a/examples/opentag/runtime.ts
+++ b/examples/opentag/runtime.ts
@@ -25,7 +25,7 @@ import { openaiText } from "@tanstack/ai-openai";
 
 const SYSTEM_PROMPT = [
   "You are OpenTag, a thread-tagging assistant living in a team chat workspace",
-  "(Slack, Discord, or Telegram). Your job: read a conversation and apply ONE",
+  "(Slack or Discord). Your job: read a conversation and apply ONE",
   "concise label that captures what it is.",
   "",
   "Taxonomy — prefer these labels (pick the single best fit):",

--- a/examples/opentag/runtime.ts
+++ b/examples/opentag/runtime.ts
@@ -1,0 +1,103 @@
+/**
+ * Agent backend for OpenTag.
+ *
+ * A single CopilotKit `BuiltInAgent` (an LLM, no MCP) served over AG-UI by a
+ * `CopilotSseRuntime`. There is no Python, no LangGraph, no external service —
+ * just an LLM and the tagging system prompt below.
+ *
+ * The bot-side primitives (read_thread, the confirm_tag HITL gate, the tag_card
+ * component) are forwarded to the agent as client-provided tools by the bot on
+ * every run — see `app/index.ts`. This file only owns the LLM call.
+ *
+ * Exposed route (the bot's `AGENT_URL`):
+ *   POST http://localhost:8200/api/copilotkit/agent/opentag/run
+ */
+import "dotenv/config";
+import { createServer } from "node:http";
+import {
+  BuiltInAgent,
+  CopilotSseRuntime,
+  convertInputToTanStackAI,
+} from "@copilotkit/runtime/v2";
+import { createCopilotNodeListener } from "@copilotkit/runtime/v2/node";
+import { chat } from "@tanstack/ai";
+import { openaiText } from "@tanstack/ai-openai";
+
+const SYSTEM_PROMPT = [
+  "You are OpenTag, a thread-tagging assistant living in a team chat workspace",
+  "(Slack, Discord, or Telegram). Your job: read a conversation and apply ONE",
+  "concise label that captures what it is.",
+  "",
+  "Taxonomy — prefer these labels (pick the single best fit):",
+  "- bug      — something is broken or not working as intended",
+  "- question — someone is asking for help or information",
+  "- feature  — a request or idea for new functionality",
+  "- docs     — a documentation gap or request",
+  "- urgent   — time-sensitive / blocking / an incident",
+  "If none fit, choose a short lowercase label of your own (one or two words).",
+  "",
+  "How to tag — FOLLOW THIS ORDER:",
+  "1. Call read_thread FIRST to read the actual conversation — never guess what",
+  "   was said. (If the user handed you text directly via /tag, you may tag that.)",
+  "2. Decide the single best label and a ONE-LINE rationale grounded in the thread.",
+  "3. Call confirm_tag with that label + rationale. It posts an Apply/Cancel card",
+  "   and BLOCKS until the user decides. Applying a tag is a WRITE — you may NEVER",
+  "   skip this gate.",
+  "4. ONLY if confirm_tag returns approved: call tag_card with the label,",
+  "   rationale, and confidence to show the applied tag. If it returns declined,",
+  "   acknowledge briefly and stop — do NOT call tag_card.",
+  "",
+  "Keep text replies to one short line at most. The cards are the answer — never",
+  "restate a card's contents as prose.",
+].join("\n");
+
+// OpenAI by default. Override the model with AGENT_MODEL (a bare OpenAI id, or
+// "openai/<id>" — the prefix is stripped); defaults to gpt-5.5. The cast is
+// needed because AGENT_MODEL is dynamic and `openaiText` types its argument to
+// the known OpenAI model literals.
+const model = (process.env["AGENT_MODEL"] ?? "openai/gpt-5.5").replace(
+  /^openai\//,
+  "",
+) as Parameters<typeof openaiText>[0];
+
+// Factory mode: we own the LLM call (TanStack AI `chat()`); BuiltInAgent owns
+// the AG-UI run lifecycle and converts TanStack's stream into AG-UI events.
+// The bot's frontend tools (read_thread, confirm_tag, tag_card) arrive as
+// `clientTools` and are passed straight through so the model can call them and
+// the bot renders/gates them via the AG-UI client-tool round-trip.
+const agent = new BuiltInAgent({
+  type: "tanstack",
+  factory: async (ctx) => {
+    const {
+      messages,
+      systemPrompts,
+      tools: clientTools,
+    } = convertInputToTanStackAI(ctx.input);
+
+    return chat({
+      adapter: openaiText(model),
+      messages,
+      systemPrompts: [SYSTEM_PROMPT, ...systemPrompts],
+      tools: clientTools as never[],
+      // TanStack AI needs the full AbortController (not just the signal).
+      abortController: ctx.abortController,
+    });
+  },
+});
+
+const runtime = new CopilotSseRuntime({
+  agents: { opentag: agent },
+});
+
+const listener = createCopilotNodeListener({
+  runtime,
+  basePath: "/api/copilotkit",
+  cors: true,
+});
+
+const port = Number(process.env["PORT"] ?? 8200);
+createServer(listener).listen(port, () => {
+  console.log(
+    `[opentag-runtime] listening on http://localhost:${port}/api/copilotkit/agent/opentag/run`,
+  );
+});

--- a/examples/opentag/runtime.ts
+++ b/examples/opentag/runtime.ts
@@ -24,9 +24,9 @@ import { chat } from "@tanstack/ai";
 import { openaiText } from "@tanstack/ai-openai";
 
 const SYSTEM_PROMPT = [
-  "You are OpenTag, a thread-tagging assistant living in a team chat workspace",
-  "(Slack or Discord). Your job: read a conversation and apply ONE",
-  "concise label that captures what it is.",
+  "You are OpenTag, a thread-tagging assistant living in a Slack workspace.",
+  "Your job: read a conversation and apply ONE concise label that captures",
+  "what it is.",
   "",
   "Taxonomy — prefer these labels (pick the single best fit):",
   "- bug      — something is broken or not working as intended",

--- a/examples/opentag/slack-app-manifest.yaml
+++ b/examples/opentag/slack-app-manifest.yaml
@@ -1,0 +1,45 @@
+# OpenTag Slack app manifest.
+# Create your app at https://api.slack.com/apps?new_app=1 → "From a manifest" →
+# paste this. It enables Socket Mode (no public URL needed), the /tag command,
+# the assistant pane, and the scopes/events OpenTag uses.
+display_information:
+  name: OpenTag
+  description: Reads a thread and suggests a tag.
+  background_color: "#1e293b"
+features:
+  bot_user:
+    display_name: OpenTag
+    always_online: true
+  assistant_view:
+    assistant_description: I read a thread and suggest a tag.
+    suggested_prompts:
+      - title: Tag this thread
+        message: Tag this thread
+  slash_commands:
+    - command: /tag
+      description: Read this thread and suggest a tag
+      should_escape: false
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read
+      - assistant:write
+      - channels:history
+      - chat:write
+      - commands
+      - groups:history
+      - im:history
+      - im:read
+      - im:write
+      - users:read
+      - users:read.email
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+      - assistant_thread_started
+      - message.im
+  interactivity:
+    is_enabled: true
+  socket_mode_enabled: true
+  org_deploy_enabled: false

--- a/examples/opentag/tsconfig.json
+++ b/examples/opentag/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "module": "NodeNext",
+    "moduleDetection": "force",
+    "moduleResolution": "NodeNext",
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "noEmit": true,
+    "lib": ["es2022", "dom"],
+    "types": ["node"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "@copilotkit/bot-ui"
+  },
+  "include": ["app/**/*.ts", "app/**/*.tsx", "runtime.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/opentag/vitest.config.ts
+++ b/examples/opentag/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+    jsxImportSource: "@copilotkit/bot-ui",
+  },
+  test: {
+    include: ["app/**/*.test.ts", "app/**/*.test.tsx"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,52 @@ importers:
         specifier: ^4.1.3
         version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@18.19.130)(@vitest/coverage-v8@3.2.4)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@18.19.130)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  examples/opentag:
+    dependencies:
+      '@copilotkit/bot':
+        specifier: workspace:*
+        version: link:../../packages/bot
+      '@copilotkit/bot-discord':
+        specifier: workspace:*
+        version: link:../../packages/bot-discord
+      '@copilotkit/bot-slack':
+        specifier: workspace:*
+        version: link:../../packages/bot-slack
+      '@copilotkit/bot-telegram':
+        specifier: workspace:*
+        version: link:../../packages/bot-telegram
+      '@copilotkit/bot-ui':
+        specifier: workspace:*
+        version: link:../../packages/bot-ui
+      '@copilotkit/runtime':
+        specifier: workspace:*
+        version: link:../../packages/runtime
+      '@tanstack/ai':
+        specifier: ^0.32.0
+        version: 0.32.0(@opentelemetry/api@1.9.0)
+      '@tanstack/ai-openai':
+        specifier: ^0.15.2
+        version: 0.15.6(@tanstack/ai@0.32.0(@opentelemetry/api@1.9.0))(ws@8.19.0)(zod@3.25.76)
+      zod:
+        specifier: '>=3.22.3'
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.11
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.3
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0(@noble/hashes@1.8.0))(vite@7.3.2(@types/node@22.19.11)(jiti@2.7.0)(less@4.5.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+
   examples/showcases/banking:
     dependencies:
       '@copilotkit/core':
@@ -12668,6 +12714,12 @@ packages:
       '@tanstack/ai-client': ^0.18.0
       zod: '>=3.22.3'
 
+  '@tanstack/ai-openai@0.15.6':
+    resolution: {integrity: sha512-frItUmGMqHeM85zL562Zg7Au+0DBxpAL53jtBhCjIQToV5YR6Ocun4Ksid19o2fOP1cGgLYus67mVPH5lvOUIw==}
+    peerDependencies:
+      '@tanstack/ai': ^0.35.0
+      zod: '>=3.22.3'
+
   '@tanstack/ai-openai@0.8.2':
     resolution: {integrity: sha512-fnrY2nPhn+KZzBbMU84vmuaK74+SAOjs5XtsW/2eX1Ke3Gj3ItGrXDks7Gt9pDrDADjYK6ZSsgtUCm9F++OFOg==}
     peerDependencies:
@@ -12677,6 +12729,9 @@ packages:
 
   '@tanstack/ai-utils@0.2.2':
     resolution: {integrity: sha512-QZNgbhoPhh5snlMf21SuF4QNTJme4aldvBx2ppMefqfMQHBQPFDJl6TxHDNW8voIzQe42rE5U9XfoWrS0K/xFQ==}
+
+  '@tanstack/ai-utils@0.3.0':
+    resolution: {integrity: sha512-gy36dQvyd+DG2uuvZK533kEfBhK5S6eV2AGc7iBQBBTeCpzs+hMhqeJ5xAnqfZ2nyHsn6jzkzLyfabyrLU5dKA==}
 
   '@tanstack/ai@0.14.0':
     resolution: {integrity: sha512-oiyYHcWMmyVoKDf018xZMEX62BaJVhdgeeRQeRbqP3p5Nvar2UZUhKzFkUiE4L9KzklPqrtI5aYhVdAp9Z142g==}
@@ -12717,6 +12772,11 @@ packages:
     resolution: {integrity: sha512-x4iBvzDXPLtNsevteyD9KbJPBSy/IDCQ6O1E/bsNpAKUVljnCza9dcoIsooA/IfAjFofL9P6gd9PiEorrZ6TCw==}
     peerDependencies:
       '@tanstack/ai': ^0.32.0
+
+  '@tanstack/openai-base@0.9.2':
+    resolution: {integrity: sha512-wf6Yl5KDBE3ZDUlDsZuPSAgH154t/X9aNIEk9UMtzi4EiLy8UgaTAR8forqaWCZjdspp5kvM+5WTmOavStEQow==}
+    peerDependencies:
+      '@tanstack/ai': ^0.35.0
 
   '@tanstack/pacer@0.20.1':
     resolution: {integrity: sha512-ZNQ1bIL6eUXVKdic0tiImvBVkWrg/IoSK6VIacTrO3d3HAGnd70qFJNJagR/YOJIOw4EKGWnodwpYZkN1pWuVQ==}
@@ -33275,7 +33335,7 @@ snapshots:
     dependencies:
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       js-tiktoken: 1.0.21
-      openai: 6.35.0(ws@8.19.0)(zod@3.25.76)
+      openai: 6.44.0(ws@8.19.0)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - ws
@@ -38376,6 +38436,16 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
+  '@tanstack/ai-openai@0.15.6(@tanstack/ai@0.32.0(@opentelemetry/api@1.9.0))(ws@8.19.0)(zod@3.25.76)':
+    dependencies:
+      '@tanstack/ai': 0.32.0(@opentelemetry/api@1.9.0)
+      '@tanstack/ai-utils': 0.3.0
+      '@tanstack/openai-base': 0.9.2(@tanstack/ai@0.32.0(@opentelemetry/api@1.9.0))(ws@8.19.0)(zod@3.25.76)
+      openai: 6.44.0(ws@8.19.0)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - ws
+
   '@tanstack/ai-openai@0.8.2(@tanstack/ai-client@0.7.5)(@tanstack/ai@0.14.0)(ws@8.19.0)(zod@3.25.76)':
     dependencies:
       '@tanstack/ai': 0.14.0
@@ -38386,6 +38456,8 @@ snapshots:
       - ws
 
   '@tanstack/ai-utils@0.2.2': {}
+
+  '@tanstack/ai-utils@0.3.0': {}
 
   '@tanstack/ai@0.14.0':
     dependencies:
@@ -38427,6 +38499,15 @@ snapshots:
     dependencies:
       '@tanstack/ai': 0.32.0(@opentelemetry/api@1.9.0)
       '@tanstack/ai-utils': 0.2.2
+      openai: 6.44.0(ws@8.19.0)(zod@3.25.76)
+    transitivePeerDependencies:
+      - ws
+      - zod
+
+  '@tanstack/openai-base@0.9.2(@tanstack/ai@0.32.0(@opentelemetry/api@1.9.0))(ws@8.19.0)(zod@3.25.76)':
+    dependencies:
+      '@tanstack/ai': 0.32.0(@opentelemetry/api@1.9.0)
+      '@tanstack/ai-utils': 0.3.0
       openai: 6.44.0(ws@8.19.0)(zod@3.25.76)
     transitivePeerDependencies:
       - ws
@@ -43254,8 +43335,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.8
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2(jiti@2.7.0))
@@ -43274,8 +43355,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.9
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2(jiti@2.7.0))
@@ -43297,6 +43378,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@5.5.0)
+      eslint: 9.39.2(jiti@2.7.0)
+      get-tsconfig: 4.13.6
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -43312,21 +43408,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.2(jiti@2.7.0)
-      get-tsconfig: 4.13.6
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.16
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
@@ -43338,13 +43419,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -43377,7 +43458,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -43388,7 +43469,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,9 +199,6 @@ importers:
       '@copilotkit/bot-slack':
         specifier: workspace:*
         version: link:../../packages/bot-slack
-      '@copilotkit/bot-telegram':
-        specifier: workspace:*
-        version: link:../../packages/bot-telegram
       '@copilotkit/bot-ui':
         specifier: workspace:*
         version: link:../../packages/bot-ui

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,9 +193,6 @@ importers:
       '@copilotkit/bot':
         specifier: workspace:*
         version: link:../../packages/bot
-      '@copilotkit/bot-discord':
-        specifier: workspace:*
-        version: link:../../packages/bot-discord
       '@copilotkit/bot-slack':
         specifier: workspace:*
         version: link:../../packages/bot-slack

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ packages:
   - "examples/showcases/generative-ui-playground"
   - "examples/showcases/banking"
   - "examples/slack"
+  - "examples/opentag"
   - "examples/teams"
   - "!examples/v1/_legacy"
   - "showcase/scripts"


### PR DESCRIPTION
## What

Adds **OpenTag**, a minimal Slack bot starter under `examples/opentag` — the clean "how to get started with CopilotKit bots" reference. It's a thread-tagging assistant: @mention it (or run `/tag`) in a Slack thread and it reads the conversation, proposes a label (`bug` / `question` / `feature` / `docs` / `urgent`), and applies it after a human-in-the-loop confirm.

It's the distilled sibling of [`examples/slack`](../tree/main/examples/slack) — the same engine and patterns, minus the kitchen sink.

## What it demonstrates

- `createBot({ adapters, agent, tools, context, commands })` with the Slack adapter
- the core turn loop: `bot.onMention` → `thread.runAgent()`
- a grounding `BotTool` (`read_thread`)
- a generative-UI **render-tool** + `@copilotkit/bot-ui` JSX component (`tag_card` / `<TagCard>`)
- a blocking **human-in-the-loop** gate via `thread.awaitChoice` (`confirm_tag`)
- a slash command (`/tag`)
- `runtime.ts`: a single `BuiltInAgent` (LLM only, **no MCP**) over AG-UI

The agent is steered through a strict **read → confirm → apply** order. "Apply" is a visual stub with the seam documented in the README (swap in a GitHub label / Linear / DB write).

## Platform

**Slack-focused on purpose** — one platform, one path to follow. The engine is platform-agnostic, so everything in `app/` is shared verbatim across surfaces; the README's **"Run it elsewhere"** section links the other adapters (`bot-discord` / `bot-telegram` / `bot-whatsapp` / `bot-teams`) and shows the one-import swap, plus the `adapters: [slack(...), discord(...)]` multi-platform form.

## Out of scope (vs `examples/slack`)

Linear/Notion MCP, modals, chart/diagram/table rendering + Playwright, multi-platform wiring, e2e harnesses.

## Verification

- `nx run opentag:check-types` ✅
- `nx run opentag:test` ✅ (6 unit tests across 3 files)
- Live Slack run **not yet done** (needs Slack secrets + an `OPENAI_API_KEY`). Draft until that's confirmed.

## Notes

- Registered in `pnpm-workspace.yaml` (the workspace uses an explicit package list, not an `examples/*` glob).
- Deps are `workspace:*` like `examples/slack`; the README documents swapping to published ranges to run standalone.
